### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -5478,7 +5478,7 @@ package:
     sha256: 4cf3d4eb1aa9b348dec30105c55cd9b7d4629285735a102beb4441e38db90553
   category: main
   optional: false
-- name: pyautogen
+- name: ag2
   version: '0.9'
   manager: pip
   platform: win-64
@@ -5493,7 +5493,7 @@ package:
     python-dotenv: '*'
     termcolor: '*'
     tiktoken: '*'
-  url: https://files.pythonhosted.org/packages/fb/eb/ceb8c7d04d7d453472282ce40a833a7fe09f2e751dad53ad88f60199b5e9/pyautogen-0.9.0-py3-none-any.whl
+  url: https://files.pythonhosted.org/packages/fb/eb/ceb8c7d04d7d453472282ce40a833a7fe09f2e751dad53ad88f60199b5e9/ag2-0.9.0-py3-none-any.whl
   hash:
     sha256: 88be3538fb98fc443d05ec0f6b1e95660a1dffe10d9769067ba699fac8155a4a
   category: main

--- a/environment.yml
+++ b/environment.yml
@@ -71,7 +71,7 @@ dependencies:
     - playwright
     - pytest-playwright
     - psutil
-    - pyautogen>=0.2.0
+    - ag2>=0.2.0
     - tenacity
     - pybreaker
     - pytest-dotenv


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using AG2! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
