### PR TITLE
fix(tests): remove redundant force_mock_llm fixture (#93)

### DIFF
--- a/tests/unit/argumentation_analysis/conftest.py
+++ b/tests/unit/argumentation_analysis/conftest.py
@@ -5,19 +5,6 @@ from unittest.mock import patch
 from argumentation_analysis.models.extract_result import ExtractResult
 
 
-@pytest.fixture(autouse=True)
-def force_mock_llm():
-    """
-    Fixture 'autouse' qui force l'activation du mock LLM pour tous les tests
-    dans ce répertoire et ses sous-répertoires.
-
-    Ceci assure que les tests unitaires n'effectuent jamais d'appels réels
-    au LLM, conformément aux bonnes pratiques d'isolation.
-    """
-    with patch("argumentation_analysis.config.settings.settings.use_mock_llm", True):
-        yield
-
-
 @pytest.fixture
 def extract_result_dict():
     """Dictionnaire de données pour un résultat d'extraction."""


### PR DESCRIPTION
Fixes #93. Removes the redundant force_mock_llm autouse fixture that conflicted with the root conftest check_mock_llm_is_forced, causing 14 sherlock_watson test failures via singleton pollution.