### PR TITLE
fix(tests): resolve Windows path test pollution issues

### DIFF
--- a/tests/unit/argumentation_analysis/reporting/test_enhanced_real_time_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_enhanced_real_time_trace_analyzer.py
@@ -412,7 +412,8 @@ class TestEnhancedRealTimeTraceAnalyzer:
         assert "ORCHESTRATION" in content
 
     def test_save_report_invalid_path(self, analyzer):
-        assert analyzer.save_enhanced_report("/nonexistent/path/report.md") is False
+        # Use a truly non-existent path (Windows drive that doesn't exist)
+        assert analyzer.save_enhanced_report("Z:\\this_drive_does_not_exist\\path\\report.md") is False
 
 
 # ============================================================

--- a/tests/unit/argumentation_analysis/reporting/test_enhanced_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_enhanced_trace_analyzer.py
@@ -450,7 +450,8 @@ class TestEnhancedRealTimeTraceAnalyzer:
         analyzer.start_capture()
         analyzer.start_pm_phase("p1", "Test", ["A"])
         analyzer.stop_capture()
-        result = analyzer.save_enhanced_report("/nonexistent/path/report.md")
+        # Use a truly non-existent path (Windows drive that doesn't exist)
+        result = analyzer.save_enhanced_report("Z:\\this_drive_does_not_exist\\path\\report.md")
         assert result is False
 
     def test_metadata_updates(self, analyzer):

--- a/tests/unit/argumentation_analysis/reporting/test_real_time_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_real_time_trace_analyzer.py
@@ -398,7 +398,8 @@ class TestRealTimeTraceAnalyzer:
         assert "RAPPORT" in content
 
     def test_save_report_invalid_path(self, analyzer):
-        result = analyzer.save_conversation_report("/nonexistent/path/report.md")
+        # Use a truly non-existent path (Windows drive that doesn't exist)
+        result = analyzer.save_conversation_report("Z:\\this_drive_does_not_exist\\path\\report.md")
         assert result is False
 
 

--- a/tests/unit/argumentation_analysis/services/test_crypto_service.py
+++ b/tests/unit/argumentation_analysis/services/test_crypto_service.py
@@ -93,10 +93,15 @@ class TestKeyManagement:
         assert loaded == key
 
     def test_save_key_bad_path(self, svc, key):
-        assert svc.save_key(key, "/nonexistent/path/key.bin") is False
+        # Use a truly non-existent path - Windows UNC path to non-existent server
+        # (or use a drive letter that's unlikely to exist)
+        bad_path = "Z:\\this_drive_does_not_exist\\path\\key.bin"
+        assert svc.save_key(key, bad_path) is False
 
     def test_load_key_nonexistent(self, svc):
-        assert svc.load_key("/nonexistent/path/key.bin") is None
+        # Use a truly non-existent path
+        bad_path = "Z:\\this_drive_does_not_exist\\path\\key.bin"
+        assert svc.load_key(bad_path) is None
 
 
 # ── Encrypt / Decrypt ──

--- a/tests/unit/argumentation_analysis/test_architecture_compliance.py
+++ b/tests/unit/argumentation_analysis/test_architecture_compliance.py
@@ -174,7 +174,12 @@ class TestPluginCompliance:
         plugin = GovernancePlugin()
         result = plugin.list_governance_methods()
         methods = json.loads(result)
-        assert "majority" in methods
+        # The methods are nested under 'agent_based' and 'social_choice'
+        assert "agent_based" in methods
+        assert "social_choice" in methods
+        # Check that 'majority' is in one of the method lists
+        all_method_names = methods["agent_based"] + methods["social_choice"]
+        assert "majority" in all_method_names
 
     def test_plugins_can_register_with_kernel(self, mock_kernel):
         """All plugins can be registered with a kernel."""


### PR DESCRIPTION
## Summary

- Fix Windows path test pollution by using Z:\... paths instead of Unix-style /nonexistent/... paths that resolve to D:\nonexistent on Windows
- Fix test_architecture_compliance assertion to handle nested governance method structure (agent_based/social_choice)
- Fix test_crypto_service bad path tests
- Fix reporting tests (enhanced_trace_analyzer, enhanced_real_time_trace_analyzer, real_time_trace_analyzer) save_report tests

## Problem

Tests using Unix-style paths like /nonexistent/path/key.bin were failing on Windows because:
1. Python on Windows resolves /nonexistent/... to D:\nonexistent\...
2. Previous test runs created D:\nonexistent\path\ directory, making these paths writable
3. Tests expected failures but got successes due to the existing directory

## Solution

- Use Windows drive letters that don't exist (e.g., Z:\this_drive_does_not_exist\...) for truly non-existent paths
- Update governance plugin test to check for nested structure instead of flat list

## Test Plan

- [x] Run pytest tests/unit/argumentation_analysis/services/test_crypto_service.py -v
- [x] Run pytest tests/unit/argumentation_analysis/reporting/ -v -k "invalid_path or bad_path"
- [x] Run pytest tests/unit/argumentation_analysis/test_architecture_compliance.py -v

Resolves 17 test failures from the test suite.