### PR TITLE
fix(tests): correct mock scoping and environment isolation (#93)

### DIFF
--- a/tests/unit/argumentation_analysis/nlp/test_embedding_utils.py
+++ b/tests/unit/argumentation_analysis/nlp/test_embedding_utils.py
@@ -1,8 +1,3 @@
-import openai
-from semantic_kernel.contents import ChatHistory
-from semantic_kernel.core_plugins import ConversationSummaryPlugin
-from config.unified_config import UnifiedConfig
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
@@ -228,7 +223,7 @@ def test_save_embeddings_data_io_error(tmp_path, sample_embeddings_data, caplog)
     output_file = tmp_path / "embeddings_io_error.json"
 
     with patch(MKDIR_PATH), patch(OPEN_BUILTIN_PATH, mock_open()), patch(
-        "json.dump", side_effect=IOError("Test IOError")
+        "argumentation_analysis.nlp.embedding_utils.json.dump", side_effect=IOError("Test IOError")
     ):
         success = save_embeddings_data(sample_embeddings_data, output_file)
 
@@ -242,7 +237,7 @@ def test_save_embeddings_data_other_exception(tmp_path, sample_embeddings_data, 
     output_file = tmp_path / "embeddings_other_error.json"
 
     with patch(MKDIR_PATH), patch(OPEN_BUILTIN_PATH, mock_open()), patch(
-        "json.dump", side_effect=Exception("Test Generic Exception")
+        "argumentation_analysis.nlp.embedding_utils.json.dump", side_effect=Exception("Test Generic Exception")
     ):
         success = save_embeddings_data(sample_embeddings_data, output_file)
 

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_network_utils.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_network_utils.py
@@ -91,7 +91,7 @@ def test_download_file_http_error(mock_requests_get, tmp_path, caplog):
 
     # Après une écriture ratée, on suppose que le fichier partiel existe.
     # La logique de cleanup dans `except RequestException` sera appelée à chaque nouvelle tentative.
-    with patch("os.remove") as mock_remove, patch.object(
+    with patch("argumentation_analysis.core.utils.network_utils.os.remove") as mock_remove, patch.object(
         Path, "exists", return_value=True
     ):
         with pytest.raises(tenacity.RetryError):
@@ -118,7 +118,7 @@ def test_download_file_size_mismatch(mock_requests_get, tmp_path, caplog):
     # mkdir doit être patché pour éviter FileExistsError de tmp_path
     with patch("builtins.open", mock_open()), patch.object(Path, "mkdir"), patch.object(
         Path, "stat"
-    ) as mock_stat, patch("os.remove") as mock_remove:
+    ) as mock_stat, patch("argumentation_analysis.core.utils.network_utils.os.remove") as mock_remove:
         mock_stat.return_value.st_mode = stat.S_IFREG
         mock_stat.return_value.st_size = actual_size
 
@@ -173,7 +173,7 @@ def test_download_file_cleans_up_partial_on_request_exception(tmp_path, caplog):
     with patch(
         "requests.get",
         side_effect=requests.exceptions.ConnectionError("Simulated network error"),
-    ), patch("os.remove") as mock_remove, patch.object(
+    ), patch("argumentation_analysis.core.utils.network_utils.os.remove") as mock_remove, patch.object(
         Path, "exists", return_value=True
     ):
         with pytest.raises(tenacity.RetryError):
@@ -197,7 +197,7 @@ def test_download_file_cleans_up_partial_on_unexpected_exception(
         "Unexpected error during iteration"
     )
 
-    with patch("os.remove") as mock_remove, patch.object(
+    with patch("argumentation_analysis.core.utils.network_utils.os.remove") as mock_remove, patch.object(
         Path, "exists", return_value=True
     ):
         with pytest.raises(ValueError, match="Unexpected error during iteration"):

--- a/tests/unit/scripts/test_auto_env.py
+++ b/tests/unit/scripts/test_auto_env.py
@@ -46,7 +46,7 @@ class TestEnsureEnvAsGuard(unittest.TestCase):
 
     @patch.dict(
         "os.environ",
-        {"CONDA_DEFAULT_ENV": "wrong-env", "IS_PYTEST_RUNNING": "true"},
+        {"CONDA_DEFAULT_ENV": "wrong-env", "IS_PYTEST_RUNNING": "true", "E2E_TESTING_MODE": ""},
         clear=True,
     )
     def test_ensure_env_incorrect_environment_raises_error(self):
@@ -69,7 +69,7 @@ class TestEnsureEnvAsGuard(unittest.TestCase):
 
     @patch.dict(
         "os.environ",
-        {"CONDA_DEFAULT_ENV": "base", "IS_PYTEST_RUNNING": "true"},
+        {"CONDA_DEFAULT_ENV": "base", "IS_PYTEST_RUNNING": "true", "E2E_TESTING_MODE": ""},
         clear=True,
     )
     def test_ensure_env_base_environment_raises_error(self):
@@ -90,7 +90,7 @@ class TestEnsureEnvAsGuard(unittest.TestCase):
 
     @patch.dict(
         "os.environ",
-        {"CONDA_DEFAULT_ENV": "projet-is", "IS_PYTEST_RUNNING": "true"},
+        {"CONDA_DEFAULT_ENV": "projet-is", "IS_PYTEST_RUNNING": "true", "E2E_TESTING_MODE": ""},
         clear=True,
     )
     def test_ensure_env_silent_mode(self):


### PR DESCRIPTION
## Summary
- Fix environment isolation in `test_auto_env.py` by adding `E2E_TESTING_MODE=""` to patch.dict
- Remove spurious imports and fix mock target scoping in `test_embedding_utils.py`
- Fix `os.remove` mock target scoping in `test_network_utils.py`

## Root Cause
Python `mock.patch()` only affects the specified namespace. When code imports a function at module level (e.g., `import json`), patching the global name doesn't affect the module's local reference.

## Test Results
- **21 tests** in the 3 affected files: ✅ All pass
- **936 unit tests** in scripts/nlp/utils: ✅ All pass

## Test plan
- [x] Run `pytest tests/unit/scripts/test_auto_env.py` - 4 passed
- [x] Run `pytest tests/unit/argumentation_analysis/nlp/test_embedding_utils.py` - 9 passed
- [x] Run `pytest tests/unit/argumentation_analysis/utils/core_utils/test_network_utils.py` - 8 passed
- [x] Run full unit test suite - 936 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)