### PR TITLE
style: apply black formatting to canonical directories (#107)

### DIFF
--- a/argumentation_analysis/agents/agent_factory.py
+++ b/argumentation_analysis/agents/agent_factory.py
@@ -47,9 +47,11 @@ class AgentFactory:
     def _create_informal_fallacy_agent(self, **kwargs) -> InformalFallacyAgent:
         """Create an informal fallacy analysis agent."""
         from .concrete_agents.informal_fallacy_agent import InformalFallacyAgent
+
         return InformalFallacyAgent(self.config, **kwargs)
 
     def _create_project_manager_agent(self, **kwargs) -> ProjectManagerAgent:
         """Create a project management agent."""
         from .concrete_agents.project_manager_agent import ProjectManagerAgent
+
         return ProjectManagerAgent(self.config, **kwargs)

--- a/argumentation_analysis/agents/core/debate/debate_agent.py
+++ b/argumentation_analysis/agents/core/debate/debate_agent.py
@@ -64,16 +64,18 @@ class DebatePlugin:
             phase=DebatePhase.MAIN_ARGUMENTS,
         )
         metrics = self.analyzer.analyze_argument(arg, [])
-        return json.dumps({
-            "logical_coherence": metrics.logical_coherence,
-            "evidence_quality": metrics.evidence_quality,
-            "relevance_score": metrics.relevance_score,
-            "persuasiveness": metrics.persuasiveness,
-            "emotional_appeal": metrics.emotional_appeal,
-            "fact_check_score": metrics.fact_check_score,
-            "novelty_score": metrics.novelty_score,
-            "readability_score": metrics.readability_score,
-        })
+        return json.dumps(
+            {
+                "logical_coherence": metrics.logical_coherence,
+                "evidence_quality": metrics.evidence_quality,
+                "relevance_score": metrics.relevance_score,
+                "persuasiveness": metrics.persuasiveness,
+                "emotional_appeal": metrics.emotional_appeal,
+                "fact_check_score": metrics.fact_check_score,
+                "novelty_score": metrics.novelty_score,
+                "readability_score": metrics.readability_score,
+            }
+        )
 
     @kernel_function(
         name="analyze_logical_structure",
@@ -144,9 +146,7 @@ class DebateAgent(BaseAgent):
     _position: str = PrivateAttr(default="for")
     _memory: List = PrivateAttr(default_factory=list)
     _strategy: str = PrivateAttr(default="balanced")
-    _performance_history: Dict = PrivateAttr(
-        default_factory=lambda: defaultdict(list)
-    )
+    _performance_history: Dict = PrivateAttr(default_factory=lambda: defaultdict(list))
     _opponent_analysis: Dict = PrivateAttr(default_factory=dict)
 
     def __init__(
@@ -369,8 +369,7 @@ class DebateAgent(BaseAgent):
         if debate_state.current_turn < 3:
             self._strategy = "balanced"
         elif any(
-            a["avg_persuasiveness"] > 0.7
-            for a in self._opponent_analysis.values()
+            a["avg_persuasiveness"] > 0.7 for a in self._opponent_analysis.values()
         ):
             self._strategy = "aggressive"
         elif debate_state.phase == DebatePhase.REBUTTALS:
@@ -381,15 +380,15 @@ class DebateAgent(BaseAgent):
     def _identify_style(self, arguments: List[EnhancedArgument]) -> str:
         if not arguments:
             return "unknown"
-        avg_emotional = sum(
-            a.metrics.emotional_appeal for a in arguments
-        ) / len(arguments)
-        avg_evidence = sum(
-            a.metrics.evidence_quality for a in arguments
-        ) / len(arguments)
-        avg_logical = sum(
-            a.metrics.logical_coherence for a in arguments
-        ) / len(arguments)
+        avg_emotional = sum(a.metrics.emotional_appeal for a in arguments) / len(
+            arguments
+        )
+        avg_evidence = sum(a.metrics.evidence_quality for a in arguments) / len(
+            arguments
+        )
+        avg_logical = sum(a.metrics.logical_coherence for a in arguments) / len(
+            arguments
+        )
         if avg_emotional > max(avg_evidence, avg_logical):
             return "emotional"
         elif avg_evidence > avg_logical:
@@ -400,24 +399,18 @@ class DebateAgent(BaseAgent):
         if not arguments:
             return "unknown"
         avg = {
-            "logical_coherence": sum(
-                a.metrics.logical_coherence for a in arguments
-            ) / len(arguments),
-            "evidence_quality": sum(
-                a.metrics.evidence_quality for a in arguments
-            ) / len(arguments),
-            "fact_check_score": sum(
-                a.metrics.fact_check_score for a in arguments
-            ) / len(arguments),
-            "novelty_score": sum(
-                a.metrics.novelty_score for a in arguments
-            ) / len(arguments),
+            "logical_coherence": sum(a.metrics.logical_coherence for a in arguments)
+            / len(arguments),
+            "evidence_quality": sum(a.metrics.evidence_quality for a in arguments)
+            / len(arguments),
+            "fact_check_score": sum(a.metrics.fact_check_score for a in arguments)
+            / len(arguments),
+            "novelty_score": sum(a.metrics.novelty_score for a in arguments)
+            / len(arguments),
         }
         return min(avg, key=avg.get)
 
-    def _build_enhanced_context(
-        self, debate_state: DebateState
-    ) -> Dict[str, Any]:
+    def _build_enhanced_context(self, debate_state: DebateState) -> Dict[str, Any]:
         recent_args = debate_state.arguments[-5:]
         return {
             "recent_arguments": [
@@ -441,12 +434,9 @@ class DebateAgent(BaseAgent):
                 "Provide a well-rounded argument balancing logic, "
                 "evidence, and appeal."
             ),
-            "aggressive": (
-                "Create a strong, direct argument challenging opponents."
-            ),
+            "aggressive": ("Create a strong, direct argument challenging opponents."),
             "defensive": (
-                "Focus on defending your position while addressing "
-                "counterarguments."
+                "Focus on defending your position while addressing " "counterarguments."
             ),
             "evidence_heavy": (
                 "Emphasize concrete evidence, data, and factual support."
@@ -454,15 +444,9 @@ class DebateAgent(BaseAgent):
         }
         phase_instructions = {
             "opening": "Make a compelling opening statement.",
-            "main_arguments": (
-                "Present your strongest arguments with evidence."
-            ),
-            "rebuttals": (
-                "Directly address and refute opposing arguments."
-            ),
-            "closing": (
-                "Summarize your position with a final persuasive appeal."
-            ),
+            "main_arguments": ("Present your strongest arguments with evidence."),
+            "rebuttals": ("Directly address and refute opposing arguments."),
+            "closing": ("Summarize your position with a final persuasive appeal."),
         }
         recent = "\n".join(context.get("recent_arguments", []))
         return (
@@ -487,10 +471,7 @@ class DebateAgent(BaseAgent):
             sentence = sentence.strip()
             if not sentence:
                 continue
-            if any(
-                c in sentence.lower()
-                for c in ["therefore", "thus", "hence"]
-            ):
+            if any(c in sentence.lower() for c in ["therefore", "thus", "hence"]):
                 structure["conclusion"] = sentence
             elif any(
                 e in sentence.lower()
@@ -602,9 +583,7 @@ class EnhancedDebateModerator:
             for i in range(turns):
                 agent = agents[i % len(agents)]
                 arg_type = arg_types[i % len(arg_types)]
-                argument = await agent.generate_argument(
-                    debate_state, arg_type
-                )
+                argument = await agent.generate_argument(debate_state, arg_type)
                 debate_state.arguments.append(argument)
                 audience_score = self._simulate_audience_reaction(argument)
                 debate_state.audience_votes[agent.name] += audience_score
@@ -613,9 +592,7 @@ class EnhancedDebateModerator:
         self._conclude_debate(debate_state, agents)
         return debate_state
 
-    def _simulate_audience_reaction(
-        self, argument: EnhancedArgument
-    ) -> int:
+    def _simulate_audience_reaction(self, argument: EnhancedArgument) -> int:
         base_score = int(argument.metrics.persuasiveness * 10)
         if argument.metrics.evidence_quality > 0.7:
             base_score += 3
@@ -651,9 +628,7 @@ class EnhancedDebateModerator:
         }
         for agent in agents:
             agent_args = [
-                arg
-                for arg in debate_state.arguments
-                if arg.agent_name == agent.name
+                arg for arg in debate_state.arguments if arg.agent_name == agent.name
             ]
             if not agent_args:
                 continue
@@ -663,16 +638,10 @@ class EnhancedDebateModerator:
 
             scores["logic"][agent.name] = sum(logic) / len(logic)
             scores["evidence"][agent.name] = sum(evidence) / len(evidence)
-            scores["persuasiveness"][agent.name] = (
-                sum(persuasion) / len(persuasion)
-            )
+            scores["persuasiveness"][agent.name] = sum(persuasion) / len(persuasion)
 
             try:
-                variance = (
-                    statistics.variance(persuasion)
-                    if len(persuasion) > 1
-                    else 0
-                )
+                variance = statistics.variance(persuasion) if len(persuasion) > 1 else 0
                 scores["consistency"][agent.name] = max(0, 1 - variance)
             except Exception:
                 scores["consistency"][agent.name] = 0.5
@@ -702,9 +671,7 @@ class EnhancedDebateModerator:
     ):
         for agent in agents:
             agent_args = [
-                arg
-                for arg in debate_state.arguments
-                if arg.agent_name == agent.name
+                arg for arg in debate_state.arguments if arg.agent_name == agent.name
             ]
             if agent_args:
                 debate_state.performance_metrics[agent.name] = {

--- a/argumentation_analysis/agents/core/governance/__init__.py
+++ b/argumentation_analysis/agents/core/governance/__init__.py
@@ -35,9 +35,7 @@ def register_with_capability_registry(registry):
     """Register governance capabilities with the Lego registry."""
     registry.register_plugin(
         name="governance",
-        plugin_class=type(
-            "GovernanceMethods", (), {"methods": GOVERNANCE_METHODS}
-        ),
+        plugin_class=type("GovernanceMethods", (), {"methods": GOVERNANCE_METHODS}),
         capabilities=[
             "collective_decision_making",
             "voting_methods",

--- a/argumentation_analysis/agents/core/governance/social_choice.py
+++ b/argumentation_analysis/agents/core/governance/social_choice.py
@@ -167,9 +167,13 @@ def kemeny_young(
         for b in options:
             if a != b:
                 count = sum(
-                    1 for ballot in ballots
-                    if (a in ballot and b in ballot
-                        and ballot.index(a) < ballot.index(b))
+                    1
+                    for ballot in ballots
+                    if (
+                        a in ballot
+                        and b in ballot
+                        and ballot.index(a) < ballot.index(b)
+                    )
                 )
                 pairwise[(a, b)] = count
 
@@ -210,7 +214,7 @@ def schulze(
         for i, a in enumerate(ballot):
             if a not in idx:
                 continue
-            for b in ballot[i + 1:]:
+            for b in ballot[i + 1 :]:
                 if b not in idx:
                     continue
                 d[idx[a]][idx[b]] += 1
@@ -241,8 +245,7 @@ def schulze(
 
     winner = max(scores, key=scores.get) if scores else None
     paths = {
-        options[i]: {options[j]: p[i][j] for j in range(n) if i != j}
-        for i in range(n)
+        options[i]: {options[j]: p[i][j] for j in range(n) if i != j} for i in range(n)
     }
     return winner, paths
 
@@ -261,14 +264,14 @@ def condorcet_winner(
             if candidate == other:
                 continue
             wins = sum(
-                1 for b in ballots
-                if candidate in b and other in b
-                and b.index(candidate) < b.index(other)
+                1
+                for b in ballots
+                if candidate in b and other in b and b.index(candidate) < b.index(other)
             )
             losses = sum(
-                1 for b in ballots
-                if candidate in b and other in b
-                and b.index(other) < b.index(candidate)
+                1
+                for b in ballots
+                if candidate in b and other in b and b.index(other) < b.index(candidate)
             )
             if wins <= losses:
                 beats_all = False
@@ -288,7 +291,7 @@ def pairwise_matrix(
         for i, a in enumerate(ballot):
             if a not in matrix:
                 continue
-            for b in ballot[i + 1:]:
+            for b in ballot[i + 1 :]:
                 if b in matrix.get(a, {}):
                     matrix[a][b] += 1
     return matrix

--- a/argumentation_analysis/agents/core/logic/__init__.py
+++ b/argumentation_analysis/agents/core/logic/__init__.py
@@ -39,12 +39,15 @@ __all__ = [
     "CLHandler",
 ]
 
+
 # Lazy imports for handlers requiring JVM (avoid import errors when JVM not started)
 def __getattr__(name):
     if name == "DLHandler":
         from .dl_handler import DLHandler
+
         return DLHandler
     if name == "CLHandler":
         from .cl_handler import CLHandler
+
         return CLHandler
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/argumentation_analysis/agents/core/logic/aba_handler.py
+++ b/argumentation_analysis/agents/core/logic/aba_handler.py
@@ -33,19 +33,25 @@ class ABAHandler:
             raise RuntimeError("ABAHandler instantiated before JVM is ready.")
         self.AbaTheory = jpype.JClass("org.tweetyproject.arg.aba.syntax.AbaTheory")
         self.Assumption = jpype.JClass("org.tweetyproject.arg.aba.syntax.Assumption")
-        self.InferenceRule = jpype.JClass("org.tweetyproject.arg.aba.syntax.InferenceRule")
+        self.InferenceRule = jpype.JClass(
+            "org.tweetyproject.arg.aba.syntax.InferenceRule"
+        )
         self.Negation = jpype.JClass("org.tweetyproject.arg.aba.syntax.Negation")
         self.AbaParser = jpype.JClass("org.tweetyproject.arg.aba.parser.AbaParser")
         # PL formula classes for ABA over propositional logic
         self.PlFormula = jpype.JClass("org.tweetyproject.logics.pl.syntax.PlFormula")
-        self.Proposition = jpype.JClass("org.tweetyproject.logics.pl.syntax.Proposition")
+        self.Proposition = jpype.JClass(
+            "org.tweetyproject.logics.pl.syntax.Proposition"
+        )
         self.PlParser = jpype.JClass("org.tweetyproject.logics.pl.parser.PlParser")
         self._reasoner_cache = {}
 
     def _get_reasoner(self, semantics: str):
         if semantics not in self._reasoner_cache:
             if semantics not in self.REASONERS:
-                raise ValueError(f"Unknown ABA semantics: {semantics}. Available: {list(self.REASONERS.keys())}")
+                raise ValueError(
+                    f"Unknown ABA semantics: {semantics}. Available: {list(self.REASONERS.keys())}"
+                )
             cls = jpype.JClass(self.REASONERS[semantics])
             self._reasoner_cache[semantics] = cls()
         return self._reasoner_cache[semantics]
@@ -121,7 +127,9 @@ class ABAHandler:
             logger.error(f"Java exception in ABA analysis: {e}")
             raise RuntimeError(f"ABA analysis failed: {e}") from e
 
-    def parse_aba_file(self, file_path: str, semantics: str = "preferred") -> Dict[str, Any]:
+    def parse_aba_file(
+        self, file_path: str, semantics: str = "preferred"
+    ) -> Dict[str, Any]:
         """Parse an ABA framework from a file and analyze it.
 
         Args:

--- a/argumentation_analysis/agents/core/logic/adf_handler.py
+++ b/argumentation_analysis/agents/core/logic/adf_handler.py
@@ -125,7 +125,9 @@ class ADFHandler:
             logger.error(f"Java exception in ADF analysis: {e}")
             raise RuntimeError(f"ADF analysis failed: {e}") from e
 
-    def parse_adf_file(self, file_path: str, semantics: str = "grounded") -> Dict[str, Any]:
+    def parse_adf_file(
+        self, file_path: str, semantics: str = "grounded"
+    ) -> Dict[str, Any]:
         """Parse an ADF from a KppADF format file and analyze it.
 
         Args:

--- a/argumentation_analysis/agents/core/logic/af_handler.py
+++ b/argumentation_analysis/agents/core/logic/af_handler.py
@@ -82,9 +82,7 @@ class AFHandler:
 
         return self._reasoner_cache[semantics_key]
 
-    def _build_framework(
-        self, arguments: List[str], attacks: List[List[str]]
-    ) -> tuple:
+    def _build_framework(self, arguments: List[str], attacks: List[List[str]]) -> tuple:
         """
         Builds a DungTheory from argument names and attack pairs.
         Returns (dung_theory, arg_map).

--- a/argumentation_analysis/agents/core/logic/aspic_handler.py
+++ b/argumentation_analysis/agents/core/logic/aspic_handler.py
@@ -41,12 +41,16 @@ class ASPICHandler:
             "org.tweetyproject.arg.aspic.ruleformulagenerator.PlFormulaGenerator"
         )
         self.PlParser = jpype.JClass("org.tweetyproject.logics.pl.parser.PlParser")
-        self.Proposition = jpype.JClass("org.tweetyproject.logics.pl.syntax.Proposition")
+        self.Proposition = jpype.JClass(
+            "org.tweetyproject.logics.pl.syntax.Proposition"
+        )
         # Dung reasoners for the generated AF
         self.SimplePreferredReasoner = jpype.JClass(
             "org.tweetyproject.arg.dung.reasoner.SimplePreferredReasoner"
         )
-        self.AspicParser = jpype.JClass("org.tweetyproject.arg.aspic.parser.AspicParser")
+        self.AspicParser = jpype.JClass(
+            "org.tweetyproject.arg.aspic.parser.AspicParser"
+        )
 
     def analyze_aspic_framework(
         self,

--- a/argumentation_analysis/agents/core/logic/belief_revision_handler.py
+++ b/argumentation_analysis/agents/core/logic/belief_revision_handler.py
@@ -21,12 +21,18 @@ class BeliefRevisionHandler:
 
     def __init__(self, initializer_instance=None):
         if initializer_instance and not initializer_instance.is_jvm_ready():
-            raise RuntimeError("BeliefRevisionHandler instantiated before JVM is ready.")
+            raise RuntimeError(
+                "BeliefRevisionHandler instantiated before JVM is ready."
+            )
         # PL classes
-        self.PlBeliefSet = jpype.JClass("org.tweetyproject.logics.pl.syntax.PlBeliefSet")
+        self.PlBeliefSet = jpype.JClass(
+            "org.tweetyproject.logics.pl.syntax.PlBeliefSet"
+        )
         self.PlParser = jpype.JClass("org.tweetyproject.logics.pl.parser.PlParser")
         self.PlFormula = jpype.JClass("org.tweetyproject.logics.pl.syntax.PlFormula")
-        self.Proposition = jpype.JClass("org.tweetyproject.logics.pl.syntax.Proposition")
+        self.Proposition = jpype.JClass(
+            "org.tweetyproject.logics.pl.syntax.Proposition"
+        )
         self.PlNegation = jpype.JClass("org.tweetyproject.logics.pl.syntax.Negation")
         # Revision operators
         self.DalalRevision = jpype.JClass(

--- a/argumentation_analysis/agents/core/logic/bipolar_handler.py
+++ b/argumentation_analysis/agents/core/logic/bipolar_handler.py
@@ -27,8 +27,12 @@ class BipolarHandler:
             "org.tweetyproject.arg.bipolar.syntax.EvidentialArgumentationFramework"
         )
         self.BArgument = jpype.JClass("org.tweetyproject.arg.bipolar.syntax.BArgument")
-        self.BinaryAttack = jpype.JClass("org.tweetyproject.arg.bipolar.syntax.BinaryAttack")
-        self.BinarySupport = jpype.JClass("org.tweetyproject.arg.bipolar.syntax.BinarySupport")
+        self.BinaryAttack = jpype.JClass(
+            "org.tweetyproject.arg.bipolar.syntax.BinaryAttack"
+        )
+        self.BinarySupport = jpype.JClass(
+            "org.tweetyproject.arg.bipolar.syntax.BinarySupport"
+        )
 
     def analyze_bipolar_framework(
         self,

--- a/argumentation_analysis/agents/core/logic/cl_handler.py
+++ b/argumentation_analysis/agents/core/logic/cl_handler.py
@@ -42,9 +42,7 @@ class CLHandler:
             self._Conditional = jpype.JClass(f"{cl_pkg}.Conditional")
             self._ClBeliefSet = jpype.JClass(f"{cl_pkg}.ClBeliefSet")
 
-            self._ClParser = jpype.JClass(
-                "org.tweetyproject.logics.cl.parser.ClParser"
-            )
+            self._ClParser = jpype.JClass("org.tweetyproject.logics.cl.parser.ClParser")
             self._SimpleCReasoner = jpype.JClass(
                 "org.tweetyproject.logics.cl.reasoner.SimpleCReasoner"
             )
@@ -163,7 +161,9 @@ class CLHandler:
 
     # ── Reasoning ────────────────────────────────────────────────────
 
-    def query(self, kb, conclusion_str: str, premise_str: Optional[str] = None) -> Tuple[bool, str]:
+    def query(
+        self, kb, conclusion_str: str, premise_str: Optional[str] = None
+    ) -> Tuple[bool, str]:
         """Query a conditional from the knowledge base.
 
         Args:
@@ -185,7 +185,9 @@ class CLHandler:
 
             result = reasoner.query(kb, cond)
             entailed = bool(result)
-            query_repr = f"({conclusion_str} | {premise_str})" if premise_str else conclusion_str
+            query_repr = (
+                f"({conclusion_str} | {premise_str})" if premise_str else conclusion_str
+            )
             msg = f"CL query {query_repr}: {'ACCEPTED' if entailed else 'REJECTED'}"
             return entailed, msg
         except jpype.JException as e:

--- a/argumentation_analysis/agents/core/logic/delp_handler.py
+++ b/argumentation_analysis/agents/core/logic/delp_handler.py
@@ -45,9 +45,7 @@ class DeLPHandler:
         self._DelpAnswer = jpype.JClass(f"{pkg}.semantics.DelpAnswer")
 
         # FOL classes for queries
-        self._FolParser = jpype.JClass(
-            "org.tweetyproject.logics.fol.parser.FolParser"
-        )
+        self._FolParser = jpype.JClass("org.tweetyproject.logics.fol.parser.FolParser")
 
         logger.info("DeLP classes loaded successfully.")
 
@@ -140,11 +138,13 @@ class DeLPHandler:
             if queries:
                 for q in queries:
                     answer, msg = self.query(program, q, criterion)
-                    results.append({
-                        "query": q,
-                        "answer": answer,
-                        "message": msg,
-                    })
+                    results.append(
+                        {
+                            "query": q,
+                            "answer": answer,
+                            "message": msg,
+                        }
+                    )
 
             return {
                 "program": program_text,

--- a/argumentation_analysis/agents/core/logic/dialogue_handler.py
+++ b/argumentation_analysis/agents/core/logic/dialogue_handler.py
@@ -89,24 +89,28 @@ class DialogueHandler:
             # Build dialogue trace
             trace = []
             # Round 1: Proponent asserts topic
-            trace.append({
-                "round": 1,
-                "speaker": "proponent",
-                "action": "assert",
-                "argument": topic,
-            })
+            trace.append(
+                {
+                    "round": 1,
+                    "speaker": "proponent",
+                    "action": "assert",
+                    "argument": topic,
+                }
+            )
 
             # Simulate opponent responses
             round_num = 2
             for atk in opponent_attacks:
                 if atk[1] == topic or atk[1] in [a[0] for a in proponent_attacks]:
-                    trace.append({
-                        "round": round_num,
-                        "speaker": "opponent",
-                        "action": "attack",
-                        "argument": atk[0],
-                        "target": atk[1],
-                    })
+                    trace.append(
+                        {
+                            "round": round_num,
+                            "speaker": "opponent",
+                            "action": "attack",
+                            "argument": atk[0],
+                            "target": atk[1],
+                        }
+                    )
                     round_num += 1
                     if round_num > max_rounds:
                         break
@@ -115,13 +119,15 @@ class DialogueHandler:
             for atk in proponent_attacks:
                 for opp_atk in opponent_attacks:
                     if atk[1] == opp_atk[0]:
-                        trace.append({
-                            "round": round_num,
-                            "speaker": "proponent",
-                            "action": "defend",
-                            "argument": atk[0],
-                            "target": atk[1],
-                        })
+                        trace.append(
+                            {
+                                "round": round_num,
+                                "speaker": "proponent",
+                                "action": "defend",
+                                "argument": atk[0],
+                                "target": atk[1],
+                            }
+                        )
                         round_num += 1
                         if round_num > max_rounds:
                             break

--- a/argumentation_analysis/agents/core/logic/dl_handler.py
+++ b/argumentation_analysis/agents/core/logic/dl_handler.py
@@ -44,7 +44,9 @@ class DLHandler:
             self._Complement = jpype.JClass(f"{dl_pkg}.Complement")
             self._Union = jpype.JClass(f"{dl_pkg}.Union")
             self._Intersection = jpype.JClass(f"{dl_pkg}.Intersection")
-            self._ExistentialRestriction = jpype.JClass(f"{dl_pkg}.ExistentialRestriction")
+            self._ExistentialRestriction = jpype.JClass(
+                f"{dl_pkg}.ExistentialRestriction"
+            )
             self._UniversalRestriction = jpype.JClass(f"{dl_pkg}.UniversalRestriction")
             self._EquivalenceAxiom = jpype.JClass(f"{dl_pkg}.EquivalenceAxiom")
             self._ConceptAssertion = jpype.JClass(f"{dl_pkg}.ConceptAssertion")
@@ -52,9 +54,7 @@ class DLHandler:
             self._DlBeliefSet = jpype.JClass(f"{dl_pkg}.DlBeliefSet")
             self._DlSignature = jpype.JClass(f"{dl_pkg}.DlSignature")
 
-            self._DlParser = jpype.JClass(
-                "org.tweetyproject.logics.dl.parser.DlParser"
-            )
+            self._DlParser = jpype.JClass("org.tweetyproject.logics.dl.parser.DlParser")
             self._NaiveDlReasoner = jpype.JClass(
                 "org.tweetyproject.logics.dl.reasoner.NaiveDlReasoner"
             )

--- a/argumentation_analysis/agents/core/logic/eaf_handler.py
+++ b/argumentation_analysis/agents/core/logic/eaf_handler.py
@@ -40,15 +40,13 @@ class EAFHandler:
     def _load_classes(self):
         """Load required Java classes."""
         pkg = "org.tweetyproject.arg.eaf"
-        self._EpistemicAF = jpype.JClass(f"{pkg}.syntax.EpistemicArgumentationFramework")
+        self._EpistemicAF = jpype.JClass(
+            f"{pkg}.syntax.EpistemicArgumentationFramework"
+        )
 
         # Dung classes shared
-        self._Argument = jpype.JClass(
-            "org.tweetyproject.arg.dung.syntax.Argument"
-        )
-        self._Attack = jpype.JClass(
-            "org.tweetyproject.arg.dung.syntax.Attack"
-        )
+        self._Argument = jpype.JClass("org.tweetyproject.arg.dung.syntax.Argument")
+        self._Attack = jpype.JClass("org.tweetyproject.arg.dung.syntax.Attack")
 
         # Load reasoners
         self._reasoners = {}
@@ -68,9 +66,7 @@ class EAFHandler:
             self._AgreementReasoner = None
             logger.debug("EAFAgreementReasoner not available.")
 
-        logger.info(
-            f"EAF classes loaded. Reasoners: {list(self._reasoners.keys())}"
-        )
+        logger.info(f"EAF classes loaded. Reasoners: {list(self._reasoners.keys())}")
 
     def analyze_epistemic_framework(
         self,

--- a/argumentation_analysis/agents/core/logic/fol_handler.py
+++ b/argumentation_analysis/agents/core/logic/fol_handler.py
@@ -356,9 +356,7 @@ class FOLHandler:
             logger.error(
                 f"Error during EProver FOL consistency check: {e}", exc_info=True
             )
-            raise RuntimeError(
-                f"EProver consistency check failed: {e}"
-            ) from e
+            raise RuntimeError(f"EProver consistency check failed: {e}") from e
 
     def fol_query(self, belief_set, query_formula_str: str) -> bool:
         """
@@ -439,7 +437,9 @@ class FOLHandler:
             )
             reasoner = EFOLReasoner()
             entails = reasoner.query(belief_set, query_formula)
-            logger.info(f"EProver query: KB entails '{query_formula_str}'? {bool(entails)}")
+            logger.info(
+                f"EProver query: KB entails '{query_formula_str}'? {bool(entails)}"
+            )
             return bool(entails)
         except Exception as e:
             logger.error(f"Error during EProver FOL query: {e}", exc_info=True)

--- a/argumentation_analysis/agents/core/logic/logic_factory.py
+++ b/argumentation_analysis/agents/core/logic/logic_factory.py
@@ -122,8 +122,10 @@ class LogicAgentFactory:
 
     # Handler-only types (no full agent, but handler available via TweetyBridge)
     _handler_types: List[str] = [
-        "description_logic", "dl",
-        "conditional_logic", "cl",
+        "description_logic",
+        "dl",
+        "conditional_logic",
+        "cl",
         "sat",
     ]
 

--- a/argumentation_analysis/agents/core/logic/modal_handler.py
+++ b/argumentation_analysis/agents/core/logic/modal_handler.py
@@ -44,9 +44,7 @@ class ModalHandler:
                 logger.info("SPASSMlReasoner loaded successfully.")
             except Exception as e:
                 logger.warning(f"Failed to load SPASSMlReasoner: {e}")
-                raise RuntimeError(
-                    f"SPASS reasoner not available: {e}"
-                ) from e
+                raise RuntimeError(f"SPASS reasoner not available: {e}") from e
         return self._spass_reasoner
 
     def _get_active_reasoner(self):
@@ -81,7 +79,11 @@ class ModalHandler:
         Uses the configured reasoner (SimpleMlReasoner or SPASSMlReasoner).
         """
         reasoner = self._get_active_reasoner()
-        reasoner_name = type(reasoner).__name__ if hasattr(reasoner, '__class__') else settings.modal_solver.value
+        reasoner_name = (
+            type(reasoner).__name__
+            if hasattr(reasoner, "__class__")
+            else settings.modal_solver.value
+        )
         logger.debug(f"Executing modal query '{query_string}' with {reasoner_name}")
         try:
             StringReader = jpype.JClass("java.io.StringReader")
@@ -99,13 +101,9 @@ class ModalHandler:
             result = reasoner.query(belief_set, query_formula)
 
             if bool(result):
-                return (
-                    f"Tweety Result ({reasoner_name}): Modal Query '{query_string}' is ACCEPTED (True)."
-                )
+                return f"Tweety Result ({reasoner_name}): Modal Query '{query_string}' is ACCEPTED (True)."
             else:
-                return (
-                    f"Tweety Result ({reasoner_name}): Modal Query '{query_string}' is REJECTED (False)."
-                )
+                return f"Tweety Result ({reasoner_name}): Modal Query '{query_string}' is REJECTED (False)."
 
         except jpype.JException as e:
             error_msg = f"Error executing modal query: {e.getMessage()}"
@@ -124,7 +122,9 @@ class ModalHandler:
         Uses the configured reasoner (SimpleMlReasoner or SPASSMlReasoner).
         """
         reasoner = self._get_active_reasoner()
-        logger.debug(f"Checking modal KB consistency with {settings.modal_solver.value}.")
+        logger.debug(
+            f"Checking modal KB consistency with {settings.modal_solver.value}."
+        )
         try:
             StringReader = jpype.JClass("java.io.StringReader")
             belief_set_reader = StringReader(belief_set_content)

--- a/argumentation_analysis/agents/core/logic/pl_handler.py
+++ b/argumentation_analysis/agents/core/logic/pl_handler.py
@@ -312,12 +312,11 @@ class PLHandler:
         """Lazy-load the SAT handler for PySAT-based solving."""
         if not hasattr(self, "_sat_handler") or self._sat_handler is None:
             from .sat_handler import SATHandler
+
             self._sat_handler = SATHandler(default_solver=settings.pysat_solver)
         return self._sat_handler
 
-    def pl_check_consistency_sat(
-        self, knowledge_base_str: str
-    ) -> bool:
+    def pl_check_consistency_sat(self, knowledge_base_str: str) -> bool:
         """Check PL consistency using PySAT instead of Tweety."""
         formula_strings = [
             f.strip().rstrip("%")
@@ -329,13 +328,13 @@ class PLHandler:
         # Normalize formulas for SAT handler
         normalized = [self._normalize_formula(f) for f in formula_strings]
         handler = self._get_sat_handler()
-        is_consistent, msg = handler.check_consistency(normalized, settings.pysat_solver)
+        is_consistent, msg = handler.check_consistency(
+            normalized, settings.pysat_solver
+        )
         logger.info(f"PySAT consistency check: {msg}")
         return is_consistent
 
-    def pl_query_sat(
-        self, knowledge_base_str: str, query_formula_str: str
-    ) -> bool:
+    def pl_query_sat(self, knowledge_base_str: str, query_formula_str: str) -> bool:
         """Check PL entailment using PySAT instead of Tweety."""
         formula_strings = [
             f.strip().rstrip("%")
@@ -343,6 +342,8 @@ class PLHandler:
             if f.strip() and f.strip() != "```"
         ]
         normalized_kb = [self._normalize_formula(f) for f in formula_strings]
-        normalized_query = self._normalize_formula(query_formula_str.rstrip("%").strip())
+        normalized_query = self._normalize_formula(
+            query_formula_str.rstrip("%").strip()
+        )
         handler = self._get_sat_handler()
         return handler.query(normalized_kb, normalized_query, settings.pysat_solver)

--- a/argumentation_analysis/agents/core/logic/probabilistic_handler.py
+++ b/argumentation_analysis/agents/core/logic/probabilistic_handler.py
@@ -20,7 +20,9 @@ class ProbabilisticHandler:
         self.DungTheory = jpype.JClass("org.tweetyproject.arg.dung.syntax.DungTheory")
         self.Argument = jpype.JClass("org.tweetyproject.arg.dung.syntax.Argument")
         self.Attack = jpype.JClass("org.tweetyproject.arg.dung.syntax.Attack")
-        self.Probability = jpype.JClass("org.tweetyproject.math.probability.Probability")
+        self.Probability = jpype.JClass(
+            "org.tweetyproject.math.probability.Probability"
+        )
         self.SubgraphProbReasoner = jpype.JClass(
             "org.tweetyproject.arg.prob.reasoner.ProbabilisticReasoner"
         )
@@ -88,7 +90,9 @@ class ProbabilisticHandler:
         Limited to small frameworks (<15 arguments) for efficiency.
         """
         if len(arguments) > 15:
-            logger.warning("Framework too large for exact probabilistic computation, using approximation")
+            logger.warning(
+                "Framework too large for exact probabilistic computation, using approximation"
+            )
             return {arg: probabilities.get(arg, 1.0) for arg in arguments}
 
         from itertools import combinations
@@ -111,7 +115,7 @@ class ProbabilisticHandler:
                     if arg in subset_set:
                         prob *= p
                     else:
-                        prob *= (1.0 - p)
+                        prob *= 1.0 - p
 
                 if prob < 1e-10:
                     continue
@@ -130,7 +134,9 @@ class ProbabilisticHandler:
                 # Compute grounded extension
                 reasoner = GroundedReasoner()
                 grounded = reasoner.getModel(sub_theory)
-                grounded_args = {str(a.getName()) for a in grounded} if grounded else set()
+                grounded_args = (
+                    {str(a.getName()) for a in grounded} if grounded else set()
+                )
 
                 for arg in grounded_args:
                     if arg in acceptance:

--- a/argumentation_analysis/agents/core/logic/qbf_handler.py
+++ b/argumentation_analysis/agents/core/logic/qbf_handler.py
@@ -41,9 +41,7 @@ class QBFHandler:
         self._ForallQuantifiedFormula = jpype.JClass(
             f"{qbf_pkg}.syntax.ForallQuantifiedFormula"
         )
-        self._NaiveQbfReasoner = jpype.JClass(
-            f"{qbf_pkg}.reasoner.NaiveQbfReasoner"
-        )
+        self._NaiveQbfReasoner = jpype.JClass(f"{qbf_pkg}.reasoner.NaiveQbfReasoner")
 
         # PL classes for building formulas
         pl_pkg = "org.tweetyproject.logics.pl.syntax"

--- a/argumentation_analysis/agents/core/logic/ranking_handler.py
+++ b/argumentation_analysis/agents/core/logic/ranking_handler.py
@@ -41,7 +41,9 @@ class RankingHandler:
     def _get_reasoner(self, name: str):
         if name not in self._reasoner_cache:
             if name not in self.REASONERS:
-                raise ValueError(f"Unknown ranking reasoner: {name}. Available: {list(self.REASONERS.keys())}")
+                raise ValueError(
+                    f"Unknown ranking reasoner: {name}. Available: {list(self.REASONERS.keys())}"
+                )
             cls = jpype.JClass(self.REASONERS[name])
             self._reasoner_cache[name] = cls()
         return self._reasoner_cache[name]

--- a/argumentation_analysis/agents/core/logic/sat_handler.py
+++ b/argumentation_analysis/agents/core/logic/sat_handler.py
@@ -20,7 +20,17 @@ except ImportError:
     PYSAT_AVAILABLE = False
 
 try:
-    from z3 import Bool, Not, Or, Implies, Solver as Z3Solver, sat, unsat, is_false, Z3_get_ast_id
+    from z3 import (
+        Bool,
+        Not,
+        Or,
+        Implies,
+        Solver as Z3Solver,
+        sat,
+        unsat,
+        is_false,
+        Z3_get_ast_id,
+    )
 
     Z3_AVAILABLE = True
 except ImportError:
@@ -46,9 +56,7 @@ class SATHandler:
 
     def __init__(self, default_solver: str = "cadical195"):
         if not PYSAT_AVAILABLE:
-            raise RuntimeError(
-                "PySAT is not installed. Run: pip install python-sat"
-            )
+            raise RuntimeError("PySAT is not installed. Run: pip install python-sat")
         self._default_solver = default_solver
         self._var_map: Dict[str, int] = {}
         self._next_var = 1
@@ -130,12 +138,14 @@ class SATHandler:
                 # Encoded as: (aux => (left => right)) & (aux => (right => left)) &
                 #              ((left => right) & (right => left) => aux)
                 # Simplified CNF:
-                clauses.extend([
-                    [-aux, -left, right],
-                    [-aux, left, -right],
-                    [aux, left, right],
-                    [aux, -left, -right],
-                ])
+                clauses.extend(
+                    [
+                        [-aux, -left, right],
+                        [-aux, left, -right],
+                        [aux, left, right],
+                        [aux, -left, -right],
+                    ]
+                )
                 left = aux
             return left
 
@@ -146,11 +156,13 @@ class SATHandler:
                 right = parse_or()
                 aux = self._new_aux_var()
                 # aux <=> (left => right) i.e. aux <=> (!left | right)
-                clauses.extend([
-                    [-aux, -left, right],
-                    [aux, left],
-                    [aux, -right],
-                ])
+                clauses.extend(
+                    [
+                        [-aux, -left, right],
+                        [aux, left],
+                        [aux, -right],
+                    ]
+                )
                 left = aux
             return left
 

--- a/argumentation_analysis/agents/core/logic/setaf_handler.py
+++ b/argumentation_analysis/agents/core/logic/setaf_handler.py
@@ -51,9 +51,7 @@ class SetAFHandler:
         self._SetAttack = jpype.JClass(f"{pkg}.syntax.SetAttack")
 
         # Dung Argument is shared
-        self._Argument = jpype.JClass(
-            "org.tweetyproject.arg.dung.syntax.Argument"
-        )
+        self._Argument = jpype.JClass("org.tweetyproject.arg.dung.syntax.Argument")
 
         # Load reasoners
         self._reasoners = {}

--- a/argumentation_analysis/agents/core/logic/social_handler.py
+++ b/argumentation_analysis/agents/core/logic/social_handler.py
@@ -42,12 +42,8 @@ class SocialHandler:
         self._IssReasoner = jpype.JClass(f"{pkg}.reasoner.IssReasoner")
 
         # Dung classes
-        self._Argument = jpype.JClass(
-            "org.tweetyproject.arg.dung.syntax.Argument"
-        )
-        self._Attack = jpype.JClass(
-            "org.tweetyproject.arg.dung.syntax.Attack"
-        )
+        self._Argument = jpype.JClass("org.tweetyproject.arg.dung.syntax.Argument")
+        self._Attack = jpype.JClass("org.tweetyproject.arg.dung.syntax.Attack")
 
         logger.info("Social AF classes loaded successfully.")
 
@@ -115,13 +111,13 @@ class SocialHandler:
                 "attacks": attacks,
                 "votes": votes or {},
                 "scores": scores,
-                "ranking": [{"argument": name, "score": score} for name, score in ranking],
+                "ranking": [
+                    {"argument": name, "score": score} for name, score in ranking
+                ],
                 "statistics": {
                     "arguments_count": len(arguments),
                     "attacks_count": len(attacks),
-                    "voters": sum(
-                        (p + n) for p, n in (votes or {}).values()
-                    ),
+                    "voters": sum((p + n) for p, n in (votes or {}).values()),
                     "handler": "SocialHandler",
                 },
             }

--- a/argumentation_analysis/agents/core/logic/weighted_handler.py
+++ b/argumentation_analysis/agents/core/logic/weighted_handler.py
@@ -44,12 +44,8 @@ class WeightedHandler:
         self._WeightedAF = jpype.JClass(f"{pkg}.syntax.WeightedArgumentationFramework")
 
         # Dung classes shared across AF variants
-        self._Argument = jpype.JClass(
-            "org.tweetyproject.arg.dung.syntax.Argument"
-        )
-        self._Attack = jpype.JClass(
-            "org.tweetyproject.arg.dung.syntax.Attack"
-        )
+        self._Argument = jpype.JClass("org.tweetyproject.arg.dung.syntax.Argument")
+        self._Attack = jpype.JClass("org.tweetyproject.arg.dung.syntax.Attack")
 
         # Load reasoners
         self._reasoners = {}
@@ -123,8 +119,7 @@ class WeightedHandler:
                 "semantics": semantics,
                 "arguments": sorted(arguments),
                 "attacks": [
-                    {"source": s, "target": t, "weight": w}
-                    for s, t, w in attacks
+                    {"source": s, "target": t, "weight": w} for s, t, w in attacks
                 ],
                 "extensions": extensions,
                 "extensions_count": len(extensions),

--- a/argumentation_analysis/agents/plugins/project_management_plugin.py
+++ b/argumentation_analysis/agents/plugins/project_management_plugin.py
@@ -3,16 +3,21 @@ from typing import List
 from pydantic import BaseModel, Field
 from semantic_kernel.functions.kernel_function_decorator import kernel_function
 
+
 class AnalysisReport(BaseModel):
     """Modèle de données pour le rapport final d'analyse."""
 
     final_summary: str = Field(..., description="Un résumé de l'analyse effectuée.")
     # Ce modèle sera enrichi dans les futurs WO pour agréger les résultats.
 
+
 class ProjectPlan(BaseModel):
     """Modèle de données pour un plan de projet structuré."""
-    
-    tasks: List[str] = Field(..., description="La liste des tâches à effectuer pour le projet.")
+
+    tasks: List[str] = Field(
+        ..., description="La liste des tâches à effectuer pour le projet."
+    )
+
 
 class ProjectManagementPlugin:
     """Plugin pour exposer les outils de gestion de projet au Kernel."""

--- a/argumentation_analysis/agents/runners/run_complete_test_and_analysis.py
+++ b/argumentation_analysis/agents/runners/run_complete_test_and_analysis.py
@@ -43,7 +43,6 @@ logging.basicConfig(
 logger = logging.getLogger("RunCompleteTestAndAnalysis")
 
 
-
 async def run_orchestration_test() -> Optional[str]:
     """
     Lance le script de test d'orchestration et récupère le chemin du fichier de trace.

--- a/argumentation_analysis/core/jvm_setup.py
+++ b/argumentation_analysis/core/jvm_setup.py
@@ -56,7 +56,9 @@ try:
     PROJ_ROOT = get_project_root_robust()
     LIBS_DIR = PROJ_ROOT / settings.jvm.tweety_libs_dir
     TWEETY_VERSION = settings.jvm.tweety_version
-    TWEETY_JAR_FILENAME = f"org.tweetyproject.tweety-full-{TWEETY_VERSION}-with-dependencies.jar"
+    TWEETY_JAR_FILENAME = (
+        f"org.tweetyproject.tweety-full-{TWEETY_VERSION}-with-dependencies.jar"
+    )
     MIN_JAVA_VERSION = settings.jvm.min_java_version
     JDK_VERSION = settings.jvm.jdk_version
     JDK_BUILD = settings.jvm.jdk_build
@@ -203,9 +205,7 @@ def download_tweety_jars(
     return success
 
 
-def download_clingo(
-    version: str = None, target_dir: Optional[Path] = None
-) -> bool:
+def download_clingo(version: str = None, target_dir: Optional[Path] = None) -> bool:
     """
     Download Clingo ASP solver binary for the current platform.
     Inspired by CoursIA download_tweety_tools.py.
@@ -239,7 +239,9 @@ def download_clingo(
         archive_url = f"{base_url}/{archive_name}"
         archive_path = clingo_dir / archive_name
 
-        success, _ = download_file(archive_url, archive_path, description=f"Clingo {version}")
+        success, _ = download_file(
+            archive_url, archive_path, description=f"Clingo {version}"
+        )
         if not success:
             logger.error(f"Failed to download Clingo from {archive_url}")
             return False
@@ -265,11 +267,14 @@ def download_clingo(
 
     elif platform.system() == "Linux":
         import tarfile
+
         archive_name = f"clingo-{version}-linux-x86_64.tar.gz"
         archive_url = f"{base_url}/{archive_name}"
         archive_path = clingo_dir / archive_name
 
-        success, _ = download_file(archive_url, archive_path, description=f"Clingo {version}")
+        success, _ = download_file(
+            archive_url, archive_path, description=f"Clingo {version}"
+        )
         if not success:
             return False
 
@@ -291,7 +296,9 @@ def download_clingo(
             logger.error(f"Error extracting Clingo: {e}")
             return False
     else:
-        logger.warning(f"Automatic Clingo download not available for {platform.system()}")
+        logger.warning(
+            f"Automatic Clingo download not available for {platform.system()}"
+        )
         return False
 
 
@@ -321,7 +328,9 @@ def download_native_sat_libs(target_dir: Optional[Path] = None) -> bool:
         url = base_url + github_path
         success, _ = download_file(url, dest, description=lib_name)
         if not success:
-            logger.warning(f"Failed to download {lib_name} — not critical if embedded in JAR")
+            logger.warning(
+                f"Failed to download {lib_name} — not critical if embedded in JAR"
+            )
             all_ok = False
     return all_ok
 
@@ -345,24 +354,32 @@ def download_external_tools() -> Dict[str, bool]:
     results["native_sat"] = download_native_sat_libs()
 
     # 4. EProver — check presence only (manual install, already committed)
-    eprover_path = EXT_TOOLS_DIR / "EProver" / (
-        "eprover.exe" if platform.system() == "Windows" else "eprover"
+    eprover_path = (
+        EXT_TOOLS_DIR
+        / "EProver"
+        / ("eprover.exe" if platform.system() == "Windows" else "eprover")
     )
     results["eprover"] = eprover_path.exists()
     if results["eprover"]:
         logger.info(f"EProver found: {eprover_path}")
     else:
-        logger.warning(f"EProver not found at {eprover_path} — install manually from https://eprover.org/")
+        logger.warning(
+            f"EProver not found at {eprover_path} — install manually from https://eprover.org/"
+        )
 
     # 5. SPASS — check presence only (manual install on Windows)
-    spass_path = EXT_TOOLS_DIR / "spass" / (
-        "SPASS.exe" if platform.system() == "Windows" else "SPASS"
+    spass_path = (
+        EXT_TOOLS_DIR
+        / "spass"
+        / ("SPASS.exe" if platform.system() == "Windows" else "SPASS")
     )
     results["spass"] = spass_path.exists()
     if results["spass"]:
         logger.info(f"SPASS found: {spass_path}")
     else:
-        logger.warning(f"SPASS not found at {spass_path} — install manually from https://www.spass-prover.org/")
+        logger.warning(
+            f"SPASS not found at {spass_path} — install manually from https://www.spass-prover.org/"
+        )
 
     # Summary
     ok = [k for k, v in results.items() if v]

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -611,7 +611,9 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "trace": trace,
         }
         self.dialogue_results.append(entry)
-        state_logger.info(f"Dialogue result added: {dl_id} (topic: {topic[:50]}, outcome: {outcome})")
+        state_logger.info(
+            f"Dialogue result added: {dl_id} (topic: {topic[:50]}, outcome: {outcome})"
+        )
         return dl_id
 
     def add_probabilistic_result(
@@ -625,7 +627,9 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "acceptance_probabilities": acceptance_probs,
         }
         self.probabilistic_results.append(entry)
-        state_logger.info(f"Probabilistic result added: {pr_id} ({len(arguments)} args)")
+        state_logger.info(
+            f"Probabilistic result added: {pr_id} ({len(arguments)} args)"
+        )
         return pr_id
 
     def add_bipolar_result(
@@ -644,7 +648,10 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         return bp_id
 
     def add_fol_analysis_result(
-        self, formulas: List[str], consistent: bool, inferences: List[str],
+        self,
+        formulas: List[str],
+        consistent: bool,
+        inferences: List[str],
         confidence: float = 0.0,
     ) -> str:
         """Add a first-order logic analysis result."""
@@ -661,7 +668,10 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         return fol_id
 
     def add_propositional_analysis_result(
-        self, formulas: List[str], satisfiable: bool, model: Optional[Dict[str, bool]] = None,
+        self,
+        formulas: List[str],
+        satisfiable: bool,
+        model: Optional[Dict[str, bool]] = None,
     ) -> str:
         """Add a propositional logic analysis result."""
         pl_id = self._generate_id("pl", self.propositional_analysis_results)
@@ -676,7 +686,10 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         return pl_id
 
     def add_modal_analysis_result(
-        self, formulas: List[str], valid: bool, modalities: List[str],
+        self,
+        formulas: List[str],
+        valid: bool,
+        modalities: List[str],
     ) -> str:
         """Add a modal logic analysis result."""
         ml_id = self._generate_id("modal", self.modal_analysis_results)
@@ -691,7 +704,10 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         return ml_id
 
     def add_formal_synthesis_report(
-        self, summary: str, phase_results: Dict[str, Any], overall_validity: float,
+        self,
+        summary: str,
+        phase_results: Dict[str, Any],
+        overall_validity: float,
     ) -> str:
         """Add a formal synthesis report aggregating all logic analyses."""
         fs_id = self._generate_id("fsyn", self.formal_synthesis_reports)
@@ -702,7 +718,9 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "overall_validity": overall_validity,
         }
         self.formal_synthesis_reports.append(entry)
-        state_logger.info(f"Formal synthesis added: {fs_id} (validity={overall_validity:.2f})")
+        state_logger.info(
+            f"Formal synthesis added: {fs_id} (validity={overall_validity:.2f})"
+        )
         return fs_id
 
     def set_workflow_results(self, workflow_name: str, results: Dict[str, Any]) -> None:
@@ -732,7 +750,9 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
                     "probabilistic_result_count": len(self.probabilistic_results),
                     "bipolar_result_count": len(self.bipolar_results),
                     "fol_analysis_count": len(self.fol_analysis_results),
-                    "propositional_analysis_count": len(self.propositional_analysis_results),
+                    "propositional_analysis_count": len(
+                        self.propositional_analysis_results
+                    ),
                     "modal_analysis_count": len(self.modal_analysis_results),
                     "formal_synthesis_count": len(self.formal_synthesis_reports),
                     "workflow_results_count": len(self.workflow_results),

--- a/argumentation_analysis/evaluation/__init__.py
+++ b/argumentation_analysis/evaluation/__init__.py
@@ -9,7 +9,10 @@ Provides:
 """
 
 from argumentation_analysis.evaluation.model_registry import ModelRegistry, ModelConfig
-from argumentation_analysis.evaluation.benchmark_runner import BenchmarkRunner, BenchmarkResult
+from argumentation_analysis.evaluation.benchmark_runner import (
+    BenchmarkRunner,
+    BenchmarkResult,
+)
 from argumentation_analysis.evaluation.result_collector import ResultCollector
 from argumentation_analysis.evaluation.judge import LLMJudge
 

--- a/argumentation_analysis/evaluation/benchmark_runner.py
+++ b/argumentation_analysis/evaluation/benchmark_runner.py
@@ -39,13 +39,16 @@ class BenchmarkResult:
     def __post_init__(self):
         if not self.timestamp:
             from datetime import datetime
+
             self.timestamp = datetime.now().isoformat()
 
 
 class BenchmarkRunner:
     """Execute benchmark cells (workflow × model × document)."""
 
-    def __init__(self, model_registry: ModelRegistry, dataset_path: Optional[str] = None):
+    def __init__(
+        self, model_registry: ModelRegistry, dataset_path: Optional[str] = None
+    ):
         self.model_registry = model_registry
         self._dataset: Optional[List[Dict[str, Any]]] = None
         self._dataset_path = dataset_path
@@ -58,7 +61,9 @@ class BenchmarkRunner:
         logger.info(f"Loaded {len(self._dataset)} documents from {path}")
         return self._dataset
 
-    def load_dataset_encrypted(self, path: str, passphrase: str) -> List[Dict[str, Any]]:
+    def load_dataset_encrypted(
+        self, path: str, passphrase: str
+    ) -> List[Dict[str, Any]]:
         """Load the encrypted dataset (Fernet + gzip)."""
         from argumentation_analysis.core.utils.crypto_utils import (
             derive_encryption_key,
@@ -172,9 +177,19 @@ class BenchmarkRunner:
             serializable_phases = {}
             for pname, presult in phases.items():
                 serializable_phases[pname] = {
-                    "status": presult.status.value if hasattr(presult.status, "value") else str(presult.status),
-                    "capability": presult.capability if hasattr(presult, "capability") else None,
-                    "has_output": presult.output is not None if hasattr(presult, "output") else False,
+                    "status": (
+                        presult.status.value
+                        if hasattr(presult.status, "value")
+                        else str(presult.status)
+                    ),
+                    "capability": (
+                        presult.capability if hasattr(presult, "capability") else None
+                    ),
+                    "has_output": (
+                        presult.output is not None
+                        if hasattr(presult, "output")
+                        else False
+                    ),
                 }
 
             return BenchmarkResult(

--- a/argumentation_analysis/evaluation/fallacy_benchmark.py
+++ b/argumentation_analysis/evaluation/fallacy_benchmark.py
@@ -362,7 +362,10 @@ class FallacyBenchmarkRunner:
                 "navigation_trace": best.get("navigation_trace", []),
                 "exploration_method": result.get("exploration_method", ""),
             }
-        return {"error": "No fallacy detected", "exploration_method": result.get("exploration_method", "")}
+        return {
+            "error": "No fallacy detected",
+            "exploration_method": result.get("exploration_method", ""),
+        }
 
     def _parse_json(self, raw: str) -> Dict[str, Any]:
         """Parse JSON from LLM response."""
@@ -439,7 +442,11 @@ class FallacyBenchmarkRunner:
         )
 
     async def _run_single(
-        self, case: dict, mode: str, runner, semaphore: asyncio.Semaphore,
+        self,
+        case: dict,
+        mode: str,
+        runner,
+        semaphore: asyncio.Semaphore,
     ) -> DetectionResult:
         """Run a single case+mode with concurrency control."""
         async with semaphore:
@@ -508,9 +515,7 @@ class FallacyBenchmarkRunner:
             for case in cases:
                 for mode in modes:
                     runner = mode_runners[mode]
-                    detection = await self._run_single(
-                        case, mode, runner, semaphore
-                    )
+                    detection = await self._run_single(case, mode, runner, semaphore)
                     report.results.append(detection)
 
         report.compute_scores()

--- a/argumentation_analysis/evaluation/judge.py
+++ b/argumentation_analysis/evaluation/judge.py
@@ -142,8 +142,12 @@ class LLMJudge:
         except Exception as e:
             logger.error(f"Judge evaluation failed: {e}")
             return JudgeScore(
-                completeness=0, accuracy=0, depth=0, coherence=0,
-                actionability=0, overall=0,
+                completeness=0,
+                accuracy=0,
+                depth=0,
+                coherence=0,
+                actionability=0,
+                overall=0,
                 reasoning=f"Evaluation failed: {e}",
                 judge_model=self.model_name,
             )
@@ -186,7 +190,9 @@ class LLMJudge:
             elif isinstance(obj, list):
                 if len(obj) > MAX_LIST_ITEMS:
                     shown = [_trim(item, depth + 1) for item in obj[:MAX_LIST_ITEMS]]
-                    return shown + [f"... and {len(obj) - MAX_LIST_ITEMS} more (total: {len(obj)})"]
+                    return shown + [
+                        f"... and {len(obj) - MAX_LIST_ITEMS} more (total: {len(obj)})"
+                    ]
                 return [_trim(item, depth + 1) for item in obj]
             elif isinstance(obj, str) and len(obj) > MAX_VALUE_LEN:
                 return obj[:MAX_VALUE_LEN] + f"... ({len(obj)} chars)"

--- a/argumentation_analysis/evaluation/model_registry.py
+++ b/argumentation_analysis/evaluation/model_registry.py
@@ -43,7 +43,9 @@ class ModelRegistry:
 
     def get(self, name: str) -> ModelConfig:
         if name not in self._models:
-            raise KeyError(f"Model '{name}' not registered. Available: {list(self._models.keys())}")
+            raise KeyError(
+                f"Model '{name}' not registered. Available: {list(self._models.keys())}"
+            )
         return self._models[name]
 
     def list_models(self) -> Dict[str, ModelConfig]:
@@ -86,12 +88,15 @@ class ModelRegistry:
         model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
         base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
         if api_key:
-            registry.register("default", ModelConfig(
-                model_id=model_id,
-                base_url=base_url,
-                api_key=api_key,
-                display_name=f"Default ({model_id})",
-            ))
+            registry.register(
+                "default",
+                ModelConfig(
+                    model_id=model_id,
+                    base_url=base_url,
+                    api_key=api_key,
+                    display_name=f"Default ({model_id})",
+                ),
+            )
 
         # Numbered endpoints (2, 3, 4, ...)
         for i in range(2, 10):
@@ -99,22 +104,28 @@ class ModelRegistry:
             url = os.environ.get(f"OPENAI_BASE_URL_{i}", "")
             name = os.environ.get(f"OPENAI_ENDPOINT_NAME_{i}", f"endpoint-{i}")
             if key and url:
-                registry.register(f"endpoint-{i}", ModelConfig(
-                    model_id=name,
-                    base_url=url,
-                    api_key=key,
-                    display_name=name,
-                ))
+                registry.register(
+                    f"endpoint-{i}",
+                    ModelConfig(
+                        model_id=name,
+                        base_url=url,
+                        api_key=key,
+                        display_name=name,
+                    ),
+                )
 
         # OpenRouter
         or_key = os.environ.get("OPENROUTER_API_KEY", "")
         or_url = os.environ.get("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1")
         if or_key:
-            registry.register("openrouter", ModelConfig(
-                model_id="anthropic/claude-sonnet-4-6",
-                base_url=or_url,
-                api_key=or_key,
-                display_name="OpenRouter (Claude Sonnet)",
-            ))
+            registry.register(
+                "openrouter",
+                ModelConfig(
+                    model_id="anthropic/claude-sonnet-4-6",
+                    base_url=or_url,
+                    api_key=or_key,
+                    display_name="OpenRouter (Claude Sonnet)",
+                ),
+            )
 
         return registry

--- a/argumentation_analysis/evaluation/result_collector.py
+++ b/argumentation_analysis/evaluation/result_collector.py
@@ -31,7 +31,9 @@ class ResultCollector:
         """Append a single result to the JSONL file."""
         with open(self._results_file, "a", encoding="utf-8") as f:
             f.write(json.dumps(asdict(result), ensure_ascii=False) + "\n")
-        logger.debug(f"Saved result: {result.workflow_name}/{result.model_name}/{result.document_name}")
+        logger.debug(
+            f"Saved result: {result.workflow_name}/{result.model_name}/{result.document_name}"
+        )
 
     def save_batch(self, results: List[BenchmarkResult]) -> None:
         """Append multiple results."""
@@ -95,8 +97,12 @@ class ResultCollector:
             model_stats[model] = {
                 "total": len(results),
                 "success": len(ok),
-                "avg_duration": sum(r["duration_seconds"] for r in ok) / len(ok) if ok else 0,
-                "avg_phases_completed": sum(r["phases_completed"] for r in ok) / len(ok) if ok else 0,
+                "avg_duration": (
+                    sum(r["duration_seconds"] for r in ok) / len(ok) if ok else 0
+                ),
+                "avg_phases_completed": (
+                    sum(r["phases_completed"] for r in ok) / len(ok) if ok else 0
+                ),
             }
 
         workflow_stats = {}
@@ -105,7 +111,9 @@ class ResultCollector:
             workflow_stats[wf] = {
                 "total": len(results),
                 "success": len(ok),
-                "avg_duration": sum(r["duration_seconds"] for r in ok) / len(ok) if ok else 0,
+                "avg_duration": (
+                    sum(r["duration_seconds"] for r in ok) / len(ok) if ok else 0
+                ),
             }
 
         return {
@@ -129,9 +137,18 @@ class ResultCollector:
             return output
 
         fields = [
-            "timestamp", "workflow_name", "model_name", "document_index",
-            "document_name", "success", "duration_seconds", "phases_completed",
-            "phases_total", "phases_failed", "phases_skipped", "error",
+            "timestamp",
+            "workflow_name",
+            "model_name",
+            "document_index",
+            "document_name",
+            "success",
+            "duration_seconds",
+            "phases_completed",
+            "phases_total",
+            "phases_failed",
+            "phases_skipped",
+            "error",
         ]
 
         with open(output, "w", newline="", encoding="utf-8") as f:

--- a/argumentation_analysis/evaluation/run_baseline_benchmark.py
+++ b/argumentation_analysis/evaluation/run_baseline_benchmark.py
@@ -127,7 +127,11 @@ async def run_baseline_benchmark(
 
         # Judge first successful result from each workflow
         for workflow in workflows:
-            wf_results = [r for r in collector.query(workflow_name=workflow) if r.get("success", False)]
+            wf_results = [
+                r
+                for r in collector.query(workflow_name=workflow)
+                if r.get("success", False)
+            ]
             if wf_results:
                 sample = wf_results[0]
                 doc_idx = sample["document_index"]
@@ -141,20 +145,24 @@ async def run_baseline_benchmark(
                         analysis_results=sample.get("state_snapshot", {}),
                         model_registry=model_registry,
                     )
-                    judge_results.append({
-                        "workflow": workflow,
-                        "document_index": doc_idx,
-                        "document_id": documents[doc_idx].get("id", f"doc_{doc_idx}"),
-                        "score": {
-                            "completeness": score.completeness,
-                            "accuracy": score.accuracy,
-                            "depth": score.depth,
-                            "coherence": score.coherence,
-                            "actionability": score.actionability,
-                            "overall": score.overall,
-                        },
-                        "reasoning": score.reasoning,
-                    })
+                    judge_results.append(
+                        {
+                            "workflow": workflow,
+                            "document_index": doc_idx,
+                            "document_id": documents[doc_idx].get(
+                                "id", f"doc_{doc_idx}"
+                            ),
+                            "score": {
+                                "completeness": score.completeness,
+                                "accuracy": score.accuracy,
+                                "depth": score.depth,
+                                "coherence": score.coherence,
+                                "actionability": score.actionability,
+                                "overall": score.overall,
+                            },
+                            "reasoning": score.reasoning,
+                        }
+                    )
                     logger.info(f"    Score global: {score.overall}/5")
                 except Exception as e:
                     logger.error(f"    Erreur de jugement: {e}")
@@ -215,13 +223,15 @@ def main():
     )
 
     # Run benchmark
-    asyncio.run(run_baseline_benchmark(
-        corpus_path=args.corpus,
-        output_dir=args.output,
-        workflows=args.workflows,
-        max_docs=args.max_docs,
-        skip_judge=args.skip_judge,
-    ))
+    asyncio.run(
+        run_baseline_benchmark(
+            corpus_path=args.corpus,
+            output_dir=args.output,
+            workflows=args.workflows,
+            max_docs=args.max_docs,
+            skip_judge=args.skip_judge,
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/argumentation_analysis/evaluation/run_synergy_analysis.py
+++ b/argumentation_analysis/evaluation/run_synergy_analysis.py
@@ -15,7 +15,9 @@ logger = logging.getLogger("evaluation.synergy_runner")
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Synergy Analysis - Optimal Workflow Configuration")
+    parser = argparse.ArgumentParser(
+        description="Synergy Analysis - Optimal Workflow Configuration"
+    )
     parser.add_argument(
         "--results-dir",
         default="argumentation_analysis/evaluation/results",

--- a/argumentation_analysis/evaluation/synergy_analyzer.py
+++ b/argumentation_analysis/evaluation/synergy_analyzer.py
@@ -23,7 +23,17 @@ logger = logging.getLogger("evaluation.synergy_analyzer")
 WORKFLOW_PHASES = {
     "light": ["extract", "quality", "counter"],
     "standard": ["extract", "quality", "counter", "jtms", "governance", "debate"],
-    "full": ["transcribe", "extract", "quality", "neural_fallacy", "counter", "jtms", "governance", "debate", "index"],
+    "full": [
+        "transcribe",
+        "extract",
+        "quality",
+        "neural_fallacy",
+        "counter",
+        "jtms",
+        "governance",
+        "debate",
+        "index",
+    ],
 }
 
 # Document difficulty levels
@@ -51,6 +61,7 @@ FALLACY_CATEGORIES = [
 @dataclass
 class WorkflowMetrics:
     """Performance metrics for a workflow."""
+
     workflow_name: str
     total_runs: int = 0
     success_rate: float = 0.0
@@ -65,6 +76,7 @@ class WorkflowMetrics:
 @dataclass
 class SynergyRecommendation:
     """Recommendation for optimal workflow configuration."""
+
     use_case: str
     recommended_workflow: str
     confidence: float  # 0.0 - 1.0
@@ -77,7 +89,10 @@ class SynergyAnalyzer:
     """Analyze workflow and agent combination performance from benchmark results."""
 
     def __init__(self, results_dir: Optional[Path] = None):
-        from argumentation_analysis.evaluation.result_collector import ResultCollector, DEFAULT_RESULTS_DIR
+        from argumentation_analysis.evaluation.result_collector import (
+            ResultCollector,
+            DEFAULT_RESULTS_DIR,
+        )
 
         self.results_dir = results_dir or DEFAULT_RESULTS_DIR
         self.collector = ResultCollector(self.results_dir)
@@ -111,10 +126,18 @@ class SynergyAnalyzer:
             return {"difficulty": "unknown", "expected_fallacies": []}
 
         return {
-            "id": corpus["documents"][document_index].get("id", f"doc_{document_index}"),
-            "difficulty": corpus["documents"][document_index].get("difficulty", "unknown"),
-            "expected_fallacies": corpus["documents"][document_index].get("expected_fallacies", []),
-            "expected_quality_score_range": corpus["documents"][document_index].get("expected_quality_score_range", [0, 10]),
+            "id": corpus["documents"][document_index].get(
+                "id", f"doc_{document_index}"
+            ),
+            "difficulty": corpus["documents"][document_index].get(
+                "difficulty", "unknown"
+            ),
+            "expected_fallacies": corpus["documents"][document_index].get(
+                "expected_fallacies", []
+            ),
+            "expected_quality_score_range": corpus["documents"][document_index].get(
+                "expected_quality_score_range", [0, 10]
+            ),
         }
 
     def analyze_workflow_performance(self) -> Dict[str, WorkflowMetrics]:
@@ -138,9 +161,21 @@ class SynergyAnalyzer:
                 workflow_name=workflow,
                 total_runs=len(wf_results),
                 success_rate=len(successful) / len(wf_results) if wf_results else 0.0,
-                avg_duration=np.mean([r["duration_seconds"] for r in successful]) if successful else 0.0,
-                avg_phases_completed=np.mean([r["phases_completed"] for r in successful]) if successful else 0.0,
-                avg_phases_total=np.mean([r["phases_total"] for r in successful]) if successful else 0.0,
+                avg_duration=(
+                    np.mean([r["duration_seconds"] for r in successful])
+                    if successful
+                    else 0.0
+                ),
+                avg_phases_completed=(
+                    np.mean([r["phases_completed"] for r in successful])
+                    if successful
+                    else 0.0
+                ),
+                avg_phases_total=(
+                    np.mean([r["phases_total"] for r in successful])
+                    if successful
+                    else 0.0
+                ),
             )
             workflow_metric.completion_ratio = (
                 workflow_metric.avg_phases_completed / workflow_metric.avg_phases_total
@@ -151,15 +186,21 @@ class SynergyAnalyzer:
             # By difficulty
             for difficulty in DIFFICULTY_LEVELS:
                 diff_results = [
-                    r for r in wf_results
-                    if self.get_document_metadata(r["document_index"])["difficulty"] == difficulty
+                    r
+                    for r in wf_results
+                    if self.get_document_metadata(r["document_index"])["difficulty"]
+                    == difficulty
                 ]
                 diff_successful = [r for r in diff_results if r["success"]]
                 if diff_results:
                     workflow_metric.by_difficulty[difficulty] = {
                         "count": len(diff_results),
                         "success_rate": len(diff_successful) / len(diff_results),
-                        "avg_duration": np.mean([r["duration_seconds"] for r in diff_successful]) if diff_successful else 0.0,
+                        "avg_duration": (
+                            np.mean([r["duration_seconds"] for r in diff_successful])
+                            if diff_successful
+                            else 0.0
+                        ),
                     }
 
             metrics[workflow] = workflow_metric
@@ -220,10 +261,16 @@ class SynergyAnalyzer:
         all_completion_ratios = [m.completion_ratio for m in metrics.values()]
 
         comparison["summary"] = {
-            "avg_success_rate": float(np.mean(all_success_rates)) if all_success_rates else 0.0,
-            "std_success_rate": float(np.std(all_success_rates)) if all_success_rates else 0.0,
+            "avg_success_rate": (
+                float(np.mean(all_success_rates)) if all_success_rates else 0.0
+            ),
+            "std_success_rate": (
+                float(np.std(all_success_rates)) if all_success_rates else 0.0
+            ),
             "avg_duration": float(np.mean(all_durations)) if all_durations else 0.0,
-            "avg_completion_ratio": float(np.mean(all_completion_ratios)) if all_completion_ratios else 0.0,
+            "avg_completion_ratio": (
+                float(np.mean(all_completion_ratios)) if all_completion_ratios else 0.0
+            ),
             "total_workflows_analyzed": len(metrics),
         }
 
@@ -244,28 +291,41 @@ class SynergyAnalyzer:
             default=None,
         )
         if fastest:
-            recommendations.append(SynergyRecommendation(
-                use_case="quick_assessment",
-                recommended_workflow=fastest[0],
-                confidence=0.9 if fastest[1].success_rate > 0.8 else 0.7,
-                reasoning=f"Fastest workflow with {fastest[1].avg_duration:.1f}s average duration and {fastest[1].success_rate*100:.1f}% success rate",
-                alternative_workflows=[k for k in metrics.keys() if k != fastest[0]],
-                expected_metrics={"avg_duration": fastest[1].avg_duration, "success_rate": fastest[1].success_rate},
-            ))
+            recommendations.append(
+                SynergyRecommendation(
+                    use_case="quick_assessment",
+                    recommended_workflow=fastest[0],
+                    confidence=0.9 if fastest[1].success_rate > 0.8 else 0.7,
+                    reasoning=f"Fastest workflow with {fastest[1].avg_duration:.1f}s average duration and {fastest[1].success_rate*100:.1f}% success rate",
+                    alternative_workflows=[
+                        k for k in metrics.keys() if k != fastest[0]
+                    ],
+                    expected_metrics={
+                        "avg_duration": fastest[1].avg_duration,
+                        "success_rate": fastest[1].success_rate,
+                    },
+                )
+            )
 
         # 2. High accuracy recommendation (for thorough analysis)
-        most_accurate = max(metrics.items(), key=lambda x: x[1].completion_ratio * x[1].success_rate)
-        recommendations.append(SynergyRecommendation(
-            use_case="thorough_analysis",
-            recommended_workflow=most_accurate[0],
-            confidence=0.85,
-            reasoning=f"Highest completion ratio ({most_accurate[1].completion_ratio:.2f}) with good success rate ({most_accurate[1].success_rate*100:.1f}%)",
-            alternative_workflows=[k for k in metrics.keys() if k != most_accurate[0]],
-            expected_metrics={
-                "completion_ratio": most_accurate[1].completion_ratio,
-                "success_rate": most_accurate[1].success_rate,
-            },
-        ))
+        most_accurate = max(
+            metrics.items(), key=lambda x: x[1].completion_ratio * x[1].success_rate
+        )
+        recommendations.append(
+            SynergyRecommendation(
+                use_case="thorough_analysis",
+                recommended_workflow=most_accurate[0],
+                confidence=0.85,
+                reasoning=f"Highest completion ratio ({most_accurate[1].completion_ratio:.2f}) with good success rate ({most_accurate[1].success_rate*100:.1f}%)",
+                alternative_workflows=[
+                    k for k in metrics.keys() if k != most_accurate[0]
+                ],
+                expected_metrics={
+                    "completion_ratio": most_accurate[1].completion_ratio,
+                    "success_rate": most_accurate[1].success_rate,
+                },
+            )
+        )
 
         # 3. Easy documents recommendation
         easy_performance = {}
@@ -276,14 +336,18 @@ class SynergyAnalyzer:
 
         if easy_performance:
             best_for_easy = max(easy_performance.items(), key=lambda x: x[1])
-            recommendations.append(SynergyRecommendation(
-                use_case="easy_documents",
-                recommended_workflow=best_for_easy[0],
-                confidence=0.8,
-                reasoning=f"Best performance on easy documents ({best_for_easy[1]*100:.1f}% success rate)",
-                alternative_workflows=[k for k in easy_performance.keys() if k != best_for_easy[0]],
-                expected_metrics={"easy_success_rate": best_for_easy[1]},
-            ))
+            recommendations.append(
+                SynergyRecommendation(
+                    use_case="easy_documents",
+                    recommended_workflow=best_for_easy[0],
+                    confidence=0.8,
+                    reasoning=f"Best performance on easy documents ({best_for_easy[1]*100:.1f}% success rate)",
+                    alternative_workflows=[
+                        k for k in easy_performance.keys() if k != best_for_easy[0]
+                    ],
+                    expected_metrics={"easy_success_rate": best_for_easy[1]},
+                )
+            )
 
         # 4. Hard documents recommendation
         hard_performance = {}
@@ -294,14 +358,18 @@ class SynergyAnalyzer:
 
         if hard_performance:
             best_for_hard = max(hard_performance.items(), key=lambda x: x[1])
-            recommendations.append(SynergyRecommendation(
-                use_case="complex_documents",
-                recommended_workflow=best_for_hard[0],
-                confidence=0.75,
-                reasoning=f"Best performance on hard/complex documents ({best_for_hard[1]*100:.1f}% success rate)",
-                alternative_workflows=[k for k in hard_performance.keys() if k != best_for_hard[0]],
-                expected_metrics={"hard_success_rate": best_for_hard[1]},
-            ))
+            recommendations.append(
+                SynergyRecommendation(
+                    use_case="complex_documents",
+                    recommended_workflow=best_for_hard[0],
+                    confidence=0.75,
+                    reasoning=f"Best performance on hard/complex documents ({best_for_hard[1]*100:.1f}% success rate)",
+                    alternative_workflows=[
+                        k for k in hard_performance.keys() if k != best_for_hard[0]
+                    ],
+                    expected_metrics={"hard_success_rate": best_for_hard[1]},
+                )
+            )
 
         return recommendations
 
@@ -355,38 +423,48 @@ class SynergyAnalyzer:
 
         if "summary" in comparison:
             summary = comparison["summary"]
-            lines.extend([
-                f"- **Total Workflows Analyzed**: {summary.get('total_workflows_analyzed', 0)}",
-                f"- **Average Success Rate**: {summary.get('avg_success_rate', 0)*100:.1f}%",
-                f"- **Average Duration**: {summary.get('avg_duration', 0):.1f}s",
-                f"- **Average Completion Ratio**: {summary.get('avg_completion_ratio', 0)*100:.1f}%",
-                "",
-            ])
+            lines.extend(
+                [
+                    f"- **Total Workflows Analyzed**: {summary.get('total_workflows_analyzed', 0)}",
+                    f"- **Average Success Rate**: {summary.get('avg_success_rate', 0)*100:.1f}%",
+                    f"- **Average Duration**: {summary.get('avg_duration', 0):.1f}s",
+                    f"- **Average Completion Ratio**: {summary.get('avg_completion_ratio', 0)*100:.1f}%",
+                    "",
+                ]
+            )
 
         if "best_by_success_rate" in comparison and comparison["best_by_success_rate"]:
             best = comparison["best_by_success_rate"]
-            lines.extend([
-                f"**Best Success Rate**: {best['workflow']} ({best['rate']*100:.1f}%)",
-            ])
+            lines.extend(
+                [
+                    f"**Best Success Rate**: {best['workflow']} ({best['rate']*100:.1f}%)",
+                ]
+            )
         if "best_by_speed" in comparison and comparison["best_by_speed"]:
             best = comparison["best_by_speed"]
-            lines.extend([
-                f"**Fastest Workflow**: {best['workflow']} ({best['avg_duration']:.1f}s)",
-            ])
+            lines.extend(
+                [
+                    f"**Fastest Workflow**: {best['workflow']} ({best['avg_duration']:.1f}s)",
+                ]
+            )
         if "best_by_completion" in comparison and comparison["best_by_completion"]:
             best = comparison["best_by_completion"]
-            lines.extend([
-                f"**Best Completion**: {best['workflow']} ({best['ratio']*100:.1f}%)",
-            ])
+            lines.extend(
+                [
+                    f"**Best Completion**: {best['workflow']} ({best['ratio']*100:.1f}%)",
+                ]
+            )
         lines.append("")
 
         # Workflow comparison table
-        lines.extend([
-            "## Workflow Comparison",
-            "",
-            "| Workflow | Success Rate | Avg Duration | Completion Ratio | Total Runs |",
-            "|----------|--------------|--------------|------------------|------------|",
-        ])
+        lines.extend(
+            [
+                "## Workflow Comparison",
+                "",
+                "| Workflow | Success Rate | Avg Duration | Completion Ratio | Total Runs |",
+                "|----------|--------------|--------------|------------------|------------|",
+            ]
+        )
 
         if "workflows" in comparison:
             for workflow, data in comparison["workflows"].items():
@@ -399,54 +477,62 @@ class SynergyAnalyzer:
         lines.append("")
 
         # Recommendations
-        lines.extend([
-            "## Recommendations",
-            "",
-        ])
+        lines.extend(
+            [
+                "## Recommendations",
+                "",
+            ]
+        )
 
         for rec in recommendations:
-            lines.extend([
-                f"### {rec.use_case.replace('_', ' ').title()}",
-                "",
-                f"**Recommended**: `{rec.recommended_workflow}`",
-                f"**Confidence**: {rec.confidence*100:.0f}%",
-                "",
-                f"{rec.reasoning}",
-                "",
-            ])
+            lines.extend(
+                [
+                    f"### {rec.use_case.replace('_', ' ').title()}",
+                    "",
+                    f"**Recommended**: `{rec.recommended_workflow}`",
+                    f"**Confidence**: {rec.confidence*100:.0f}%",
+                    "",
+                    f"{rec.reasoning}",
+                    "",
+                ]
+            )
             if rec.alternative_workflows:
-                lines.append(f"**Alternatives**: {', '.join(f'`{w}`' for w in rec.alternative_workflows)}")
+                lines.append(
+                    f"**Alternatives**: {', '.join(f'`{w}`' for w in rec.alternative_workflows)}"
+                )
                 lines.append("")
 
         # Workflow phases
-        lines.extend([
-            "## Workflow Phases",
-            "",
-            "### Light",
-            "1. extract (fact extraction)",
-            "2. quality (argument quality)",
-            "3. counter (counter-argument generation)",
-            "",
-            "### Standard",
-            "1. extract (fact extraction)",
-            "2. quality (argument quality)",
-            "3. counter (counter-argument generation)",
-            "4. jtms (belief maintenance, optional)",
-            "5. governance (governance simulation, optional)",
-            "6. debate (adversarial debate, optional)",
-            "",
-            "### Full",
-            "1. transcribe (speech transcription, optional)",
-            "2. extract (fact extraction)",
-            "3. quality (argument quality)",
-            "4. neural_fallacy (neural fallacy detection, optional)",
-            "5. counter (counter-argument generation)",
-            "6. jtms (belief maintenance, optional)",
-            "7. governance (governance simulation, optional)",
-            "8. debate (adversarial debate, optional)",
-            "9. index (semantic indexing, optional)",
-            "",
-        ])
+        lines.extend(
+            [
+                "## Workflow Phases",
+                "",
+                "### Light",
+                "1. extract (fact extraction)",
+                "2. quality (argument quality)",
+                "3. counter (counter-argument generation)",
+                "",
+                "### Standard",
+                "1. extract (fact extraction)",
+                "2. quality (argument quality)",
+                "3. counter (counter-argument generation)",
+                "4. jtms (belief maintenance, optional)",
+                "5. governance (governance simulation, optional)",
+                "6. debate (adversarial debate, optional)",
+                "",
+                "### Full",
+                "1. transcribe (speech transcription, optional)",
+                "2. extract (fact extraction)",
+                "3. quality (argument quality)",
+                "4. neural_fallacy (neural fallacy detection, optional)",
+                "5. counter (counter-argument generation)",
+                "6. jtms (belief maintenance, optional)",
+                "7. governance (governance simulation, optional)",
+                "8. debate (adversarial debate, optional)",
+                "9. index (semantic indexing, optional)",
+                "",
+            ]
+        )
 
         with open(output, "w", encoding="utf-8") as f:
             f.write("\n".join(lines))

--- a/argumentation_analysis/orchestration/cluedo_orchestrator.py
+++ b/argumentation_analysis/orchestration/cluedo_orchestrator.py
@@ -329,9 +329,9 @@ class CluedoOrchestrator:
         # Métriques de performance
         performance_metrics = {
             "efficiency": {
-                "turns_per_minute": len(history) / (execution_time / 60)
-                if execution_time > 0
-                else 0,
+                "turns_per_minute": (
+                    len(history) / (execution_time / 60) if execution_time > 0 else 0
+                ),
             },
             "agent_balance": self._calculate_agent_balance(history),
         }
@@ -420,7 +420,7 @@ async def run_cluedo_game(
         "It is maintained for backward compatibility only. "
         "Please use new agent group chat architecture for new implementations.",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
 
     orchestrator = CluedoOrchestrator(

--- a/argumentation_analysis/orchestration/conversation_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversation_orchestrator.py
@@ -188,7 +188,7 @@ class AnalysisState:
             "consistency_score": round(self.consistency_score, 2),
             "phase": self.phase,
             "completed": self.completed,
-            "processing_time": round(self.processing_time,3),
+            "processing_time": round(self.processing_time, 3),
         }
 
     def to_rhetorical_state(self) -> "RhetoricalAnalysisState":
@@ -554,6 +554,7 @@ class ConversationOrchestrator:
             from argumentation_analysis.agents.core.informal.informal_agent import (
                 InformalAnalysisAgent,
             )
+
             informal = InformalAnalysisAgent(
                 kernel=self.kernel,
                 agent_name="InformalAnalysisAgent",
@@ -568,6 +569,7 @@ class ConversationOrchestrator:
             from argumentation_analysis.agents.core.synthesis.synthesis_agent import (
                 SynthesisAgent as RealSynthesisAgent,
             )
+
             synth = RealSynthesisAgent(
                 kernel=self.kernel,
                 agent_name="SynthesisAgent",
@@ -578,9 +580,7 @@ class ConversationOrchestrator:
             self.logger.warning(f"Cannot create real SynthesisAgent: {e}")
 
         if not self._real_agents:
-            self.logger.error(
-                "No real agents could be created. Falling back to demo."
-            )
+            self.logger.error("No real agents could be created. Falling back to demo.")
             self.mode = "demo"
             self._setup_simulated_agents()
 
@@ -637,9 +637,7 @@ class ConversationOrchestrator:
             if hasattr(agent, "analyze_text"):
                 return await agent.analyze_text(text)
             else:
-                raise AttributeError(
-                    "FOLLogicAgent has no suitable analysis method"
-                )
+                raise AttributeError("FOLLogicAgent has no suitable analysis method")
         elif agent_key == "synthesis":
             report = await agent.synthesize_analysis(text)
             if hasattr(report, "model_dump"):
@@ -858,9 +856,9 @@ class ConversationOrchestrator:
             "Please use `analysis_runner` for new implementations. "
             "This class is maintained for backward compatibility only.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
-        
+
         return self.generate_report()
 
     def generate_report(self) -> str:

--- a/argumentation_analysis/orchestration/conversational_executor.py
+++ b/argumentation_analysis/orchestration/conversational_executor.py
@@ -93,9 +93,7 @@ class ConversationalPipeline:
                     "summary": f"Failed at round {round_num}: {e}",
                 }
 
-            rounds.append(
-                {"round_number": round_num, "turn_result": turn_result}
-            )
+            rounds.append({"round_number": round_num, "turn_result": turn_result})
 
             logger.info(
                 f"Round {round_num}: confidence={turn_result.confidence:.2f}, "
@@ -107,9 +105,7 @@ class ConversationalPipeline:
                 prev_result, turn_result
             ):
                 logger.info(f"Converged at round {round_num}")
-                return self._build_result(
-                    "converged", rounds, turn_result, start_time
-                )
+                return self._build_result("converged", rounds, turn_result, start_time)
 
             # Check confidence threshold
             if turn_result.confidence >= self._config.confidence_threshold:
@@ -145,9 +141,7 @@ class ConversationalPipeline:
             }
         return ctx
 
-    def _has_converged(
-        self, prev_result: TurnResult, curr_result: TurnResult
-    ) -> bool:
+    def _has_converged(self, prev_result: TurnResult, curr_result: TurnResult) -> bool:
         """Check convergence between two turns."""
         if self._config.convergence_fn is not None:
             try:
@@ -172,9 +166,7 @@ class ConversationalPipeline:
             "summary": self._generate_summary(status, rounds),
         }
 
-    def _generate_summary(
-        self, status: str, rounds: List[Dict[str, Any]]
-    ) -> str:
+    def _generate_summary(self, status: str, rounds: List[Dict[str, Any]]) -> str:
         """Generate text summary of the conversation."""
         lines = [f"Conversation: {len(rounds)} round(s), status={status}"]
         for r in rounds:
@@ -282,9 +274,7 @@ class GroupChatTurnStrategy(TurnStrategy):
                 AgentGroupChat,
             )
         except ImportError:
-            logger.warning(
-                "AgentGroupChat not available — returning empty turn"
-            )
+            logger.warning("AgentGroupChat not available — returning empty turn")
             return TurnResult(
                 turn_number=context.get("turn_number", 1),
                 phase_results={},
@@ -300,9 +290,7 @@ class GroupChatTurnStrategy(TurnStrategy):
         )
 
         # Run the group chat
-        raw_results = await chat.invoke(
-            str(input_data) if input_data else None
-        )
+        raw_results = await chat.invoke(str(input_data) if input_data else None)
 
         duration = time.time() - start
 
@@ -320,9 +308,7 @@ class GroupChatTurnStrategy(TurnStrategy):
             duration_seconds=duration,
         )
 
-    def _messages_to_phase_results(
-        self, messages: Any
-    ) -> Dict[str, PhaseResult]:
+    def _messages_to_phase_results(self, messages: Any) -> Dict[str, PhaseResult]:
         """Convert AgentGroupChat messages to PhaseResult dict."""
         results: Dict[str, PhaseResult] = {}
         if not messages or not isinstance(messages, list):
@@ -376,9 +362,7 @@ def _extract_questions(phase_results: Dict[str, PhaseResult]) -> List[str]:
     """Extract user questions from phase outputs."""
     questions: List[str] = []
     for result in phase_results.values():
-        if result.status == PhaseStatus.COMPLETED and isinstance(
-            result.output, dict
-        ):
+        if result.status == PhaseStatus.COMPLETED and isinstance(result.output, dict):
             q = result.output.get("user_question")
             if q and isinstance(q, str):
                 questions.append(q)

--- a/argumentation_analysis/orchestration/enhanced_pm_analysis_runner.py
+++ b/argumentation_analysis/orchestration/enhanced_pm_analysis_runner.py
@@ -16,6 +16,7 @@ Ce module intègre :
 # ===== AUTO-ACTIVATION ENVIRONNEMENT =====
 import argumentation_analysis.core.environment  # Auto-activation environnement intelligent
 import warnings
+
 # =========================================
 import sys
 import os
@@ -36,21 +37,32 @@ if project_root not in sys.path:
 # Imports Semantic Kernel
 import semantic_kernel as sk
 from semantic_kernel.contents import ChatMessageContent
+
 # from semantic_kernel.contents import AuthorRole
 # from semantic_kernel.agents import AgentGroupChat, ChatCompletionAgent, Agent # Supprimé car le module n'existe plus
 from semantic_kernel.exceptions import AgentChatException
-from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion, AzureChatCompletion
+from semantic_kernel.connectors.ai.open_ai import (
+    OpenAIChatCompletion,
+    AzureChatCompletion,
+)
 from semantic_kernel.functions.kernel_arguments import KernelArguments
 
 # Imports système existant
 from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
 from argumentation_analysis.core.state_manager_plugin import StateManagerPlugin
-from argumentation_analysis.core.strategies import SimpleTerminationStrategy, BalancedParticipationStrategy
+from argumentation_analysis.core.strategies import (
+    SimpleTerminationStrategy,
+    BalancedParticipationStrategy,
+)
 
 # Imports agents
 from argumentation_analysis.agents.core.pm.pm_agent import ProjectManagerAgent
-from argumentation_analysis.agents.core.informal.informal_agent import InformalAnalysisAgent
-from argumentation_analysis.agents.core.logic.propositional_logic_agent import PropositionalLogicAgent
+from argumentation_analysis.agents.core.informal.informal_agent import (
+    InformalAnalysisAgent,
+)
+from argumentation_analysis.agents.core.logic.propositional_logic_agent import (
+    PropositionalLogicAgent,
+)
 from argumentation_analysis.agents.core.logic.modal_logic_agent import ModalLogicAgent
 from argumentation_analysis.agents.core.extract.extract_agent import ExtractAgent
 
@@ -63,13 +75,15 @@ from argumentation_analysis.reporting.enhanced_real_time_trace_analyzer import (
     capture_shared_state,
     get_enhanced_pm_report,
     save_enhanced_pm_report,
-    enhanced_tool_call_tracer
+    enhanced_tool_call_tracer,
 )
 
 logger = logging.getLogger("EnhancedPMOrchestration")
 if not logger.handlers and not logger.propagate:
     handler = logging.StreamHandler()
-    formatter = logging.Formatter('%(asctime)s [%(levelname)s] [%(name)s] %(message)s', datefmt='%H:%M:%S')
+    formatter = logging.Formatter(
+        "%(asctime)s [%(levelname)s] [%(name)s] %(message)s", datefmt="%H:%M:%S"
+    )
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)
@@ -80,7 +94,7 @@ class EnhancedProjectManagerOrchestrator:
     Orchestrateur Project Manager amélioré avec gestion d'état partagé,
     orchestration multi-tours et format de conversation élégant.
     """
-    
+
     def __init__(self, llm_service: Union[OpenAIChatCompletion, AzureChatCompletion]):
         """Initialise l'orchestrateur PM amélioré."""
         warnings.warn(
@@ -88,162 +102,179 @@ class EnhancedProjectManagerOrchestrator:
             "It is maintained for backward compatibility only. "
             "Please use the new agent group chat architecture for new implementations.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         self.llm_service = llm_service
         self.shared_state: Optional[RhetoricalAnalysisState] = None
         self.kernel: Optional[sk.Kernel] = None
         self.group_chat: Optional[AgentGroupChat] = None
         self.state_manager_plugin: Optional[StateManagerPlugin] = None
-        
+
         # Orchestration multi-tours
         self.orchestration_phases = []
         self.current_phase = None
         self.tour_counter = 0
         self.phase_counter = 0
-        
+
         # Agents pour l'orchestration
         self.agents = {}
         self.agent_list = []
-        
+
         # Métadonnées PM
         self.pm_metadata = {
             "orchestration_type": "Enhanced Multi-Turn PM",
             "state_management": True,
             "conversation_format": "Enhanced Markdown",
-            "agents_coordination": "Formal/Informal Balance"
+            "agents_coordination": "Formal/Informal Balance",
         }
-    
+
     async def setup_enhanced_orchestration(self, texte_a_analyser: str) -> bool:
         """Configure l'orchestration PM améliorée."""
         logger.info("[CONFIG] Configuration de l'orchestration PM améliorée...")
-        
+
         try:
             # 1. Création de l'état partagé
             self.shared_state = RhetoricalAnalysisState(initial_text=texte_a_analyser)
             self.state_manager_plugin = StateManagerPlugin(self.shared_state)
-            
+
             # 2. Configuration du kernel
             self.kernel = sk.Kernel()
             self.kernel.add_service(self.llm_service)
-            self.kernel.add_plugin(self.state_manager_plugin, plugin_name="StateManager")
-            
+            self.kernel.add_plugin(
+                self.state_manager_plugin, plugin_name="StateManager"
+            )
+
             # 3. Configuration des agents avec instrumentation de trace
             await self._setup_enhanced_agents()
-            
+
             # 4. Configuration des stratégies
             self._setup_enhanced_strategies()
-            
+
             # 5. Démarrage de la capture de trace
             start_enhanced_pm_capture()
-            
+
             logger.info("✅ Orchestration PM améliorée configurée avec succès")
             return True
-            
+
         except Exception as e:
-            logger.error(f"[ERROR] Erreur configuration orchestration PM: {e}", exc_info=True)
+            logger.error(
+                f"[ERROR] Erreur configuration orchestration PM: {e}", exc_info=True
+            )
             return False
-    
+
     async def _setup_enhanced_agents(self):
         """Configure les agents avec instrumentation de trace améliorée."""
         logger.info("[SETUP] Configuration des agents avec instrumentation...")
-        
+
         llm_service_id = self.llm_service.service_id
-        prompt_exec_settings = self.kernel.get_prompt_execution_settings_from_service_id(llm_service_id)
-        prompt_exec_settings.function_choice_behavior = FunctionChoiceBehavior.Auto(
-            auto_invoke_kernel_functions=True, 
-            max_auto_invoke_attempts=5
+        prompt_exec_settings = (
+            self.kernel.get_prompt_execution_settings_from_service_id(llm_service_id)
         )
-        
+        prompt_exec_settings.function_choice_behavior = FunctionChoiceBehavior.Auto(
+            auto_invoke_kernel_functions=True, max_auto_invoke_attempts=5
+        )
+
         # Configuration Project Manager
-        pm_agent_refactored = ProjectManagerAgent(kernel=self.kernel, agent_name="EnhancedProjectManagerAgent")
+        pm_agent_refactored = ProjectManagerAgent(
+            kernel=self.kernel, agent_name="EnhancedProjectManagerAgent"
+        )
         pm_agent_refactored.setup_agent_components(llm_service_id=llm_service_id)
-        
-        pm_agent = pm_agent_refactored # Remplacement temporaire
+
+        pm_agent = pm_agent_refactored  # Remplacement temporaire
         self.agents["ProjectManager"] = pm_agent
-        
+
         # Configuration Informal Agent
-        informal_agent_refactored = InformalAnalysisAgent(kernel=self.kernel, agent_name="EnhancedInformalAgent")
+        informal_agent_refactored = InformalAnalysisAgent(
+            kernel=self.kernel, agent_name="EnhancedInformalAgent"
+        )
         informal_agent_refactored.setup_agent_components(llm_service_id=llm_service_id)
-        
-        informal_agent = informal_agent_refactored # Remplacement temporaire
+
+        informal_agent = informal_agent_refactored  # Remplacement temporaire
         self.agents["InformalAnalysis"] = informal_agent
-        
+
         # Configuration Modal Logic Agent
-        modal_agent_refactored = ModalLogicAgent(kernel=self.kernel, agent_name="EnhancedModalLogicAgent")
+        modal_agent_refactored = ModalLogicAgent(
+            kernel=self.kernel, agent_name="EnhancedModalLogicAgent"
+        )
         modal_agent_refactored.setup_agent_components(llm_service_id=llm_service_id)
-        
-        modal_agent = modal_agent_refactored # Remplacement temporaire
+
+        modal_agent = modal_agent_refactored  # Remplacement temporaire
         self.agents["ModalLogic"] = modal_agent
-        
+
         # Configuration Extract Agent
-        extract_agent_refactored = ExtractAgent(kernel=self.kernel, agent_name="EnhancedExtractAgent")
+        extract_agent_refactored = ExtractAgent(
+            kernel=self.kernel, agent_name="EnhancedExtractAgent"
+        )
         extract_agent_refactored.setup_agent_components(llm_service_id=llm_service_id)
-        
-        extract_agent = extract_agent_refactored # Remplacement temporaire
+
+        extract_agent = extract_agent_refactored  # Remplacement temporaire
         self.agents["Extract"] = extract_agent
-        
+
         self.agent_list = list(self.agents.values())
         logger.info(f"✅ {len(self.agents)} agents configurés avec instrumentation")
-    
+
     def _setup_enhanced_strategies(self):
         """Configure les stratégies d'orchestration améliorées."""
         logger.info("📋 Configuration des stratégies d'orchestration...")
-        
+
         # Stratégie de terminaison étendue pour multi-tours
-        termination_strategy = SimpleTerminationStrategy(self.shared_state, max_steps=20)
-        
+        termination_strategy = SimpleTerminationStrategy(
+            self.shared_state, max_steps=20
+        )
+
         # Stratégie de sélection avec balance formal/informal
         selection_strategy = BalancedParticipationStrategy(
             agents=self.agent_list,
             state=self.shared_state,
-            default_agent_name="ProjectManagerAgent"
+            default_agent_name="ProjectManagerAgent",
         )
-        
+
         # Création du groupe de chat
         # self.group_chat = AgentGroupChat(
         #     agents=self.agent_list,
         #     selection_strategy=selection_strategy,
         #     termination_strategy=termination_strategy
         # )
-        
+
         logger.info("✅ Stratégies d'orchestration configurées")
-    
-    async def run_enhanced_pm_orchestration(self, texte_a_analyser: str) -> Dict[str, Any]:
+
+    async def run_enhanced_pm_orchestration(
+        self, texte_a_analyser: str
+    ) -> Dict[str, Any]:
         """Lance l'orchestration PM améliorée avec gestion d'état multi-tours."""
         run_start_time = time.time()
         run_id = random.randint(10000, 99999)
-        
+
         logger.info(f"[START] Démarrage orchestration PM améliorée (Run_{run_id})")
-        
+
         # Configuration de l'orchestration
         setup_success = await self.setup_enhanced_orchestration(texte_a_analyser)
         if not setup_success:
             return {"success": False, "error": "Échec configuration orchestration"}
-        
+
         try:
             # Phase 1: Initialisation et analyse informelle
             await self._run_phase_1_informal_analysis()
-            
+
             # Phase 2: Analyse formelle modal logic
             await self._run_phase_2_formal_analysis()
-            
+
             # Phase 3: Synthèse et coordination PM
             await self._run_phase_3_synthesis_coordination()
-            
+
             # Finalisation
             stop_enhanced_pm_capture()
-            
+
             # Génération du rapport final
             enhanced_report = get_enhanced_pm_report()
-            
+
             # Sauvegarde
             timestamp = time.strftime("%Y%m%d_%H%M%S")
             report_path = f"./logs/enhanced_pm_orchestration_demo_{timestamp}.md"
             save_success = save_enhanced_pm_report(report_path)
-            
+
             total_duration = time.time() - run_start_time
-            
+
             result = {
                 "success": True,
                 "run_id": run_id,
@@ -253,32 +284,34 @@ class EnhancedProjectManagerOrchestrator:
                 "tool_calls": enhanced_global_trace_analyzer.total_tool_calls,
                 "report_path": report_path if save_success else None,
                 "enhanced_report": enhanced_report,
-                "pm_metadata": self.pm_metadata
+                "pm_metadata": self.pm_metadata,
             }
-            
-            logger.info(f"✅ Orchestration PM terminée avec succès ({total_duration:.2f}s)")
+
+            logger.info(
+                f"✅ Orchestration PM terminée avec succès ({total_duration:.2f}s)"
+            )
             return result
-            
+
         except Exception as e:
             logger.error(f"[ERROR] Erreur orchestration PM: {e}", exc_info=True)
             stop_enhanced_pm_capture()
             # Assurer que l'on retourne une structure JSON valide même en cas d'erreur
             return {"success": False, "error": str(e), "analysis": {}}
-    
+
     async def _run_phase_1_informal_analysis(self):
         """Phase 1: Analyse informelle coordonnée par PM."""
         self.phase_counter += 1
         phase_id = f"phase_{self.phase_counter}"
-        
+
         logger.info("[CONFIG] Phase 1: Analyse informelle coordonnée")
-        
+
         # Démarrage de la phase
         start_pm_orchestration_phase(
             phase_id=phase_id,
-            phase_name="Analyse Informelle Coordonnée", 
-            assigned_agents=["ProjectManagerAgent", "InformalAnalysisAgent"]
+            phase_name="Analyse Informelle Coordonnée",
+            assigned_agents=["ProjectManagerAgent", "InformalAnalysisAgent"],
         )
-        
+
         # Capture de l'état initial
         self.tour_counter += 1
         capture_shared_state(
@@ -290,15 +323,15 @@ class EnhancedProjectManagerOrchestrator:
                 "agents_active": ["ProjectManagerAgent", "InformalAnalysisAgent"],
                 "tasks_defined": len(self.shared_state.analysis_tasks),
                 "arguments_identified": len(self.shared_state.identified_arguments),
-                "fallacies_detected": len(self.shared_state.identified_fallacies)
+                "fallacies_detected": len(self.shared_state.identified_fallacies),
             },
             metadata={
                 "phase_type": "initialization",
                 "coordination": "pm_directed",
-                "state_management": "active"
-            }
+                "state_management": "active",
+            },
         )
-        
+
         # Message initial pour PM
         initial_prompt = f"""Bonjour équipe d'analyse. Je suis le Project Manager de cette orchestration multi-tours.
 
@@ -314,16 +347,18 @@ MISSION PHASE 1 - ANALYSE INFORMELLE:
 4. Gérer l'état partagé entre agents
 
 ProjectManagerAgent, veuillez définir les tâches d'analyse et coordonner l'équipe."""
-        
+
         logger.info(f"💬 Tour {self.tour_counter}: Prompt initial PM")
-        
+
         # Ajout à l'historique
-        if hasattr(self.group_chat, 'history') and hasattr(self.group_chat.history, 'add_user_message'):
+        if hasattr(self.group_chat, "history") and hasattr(
+            self.group_chat.history, "add_user_message"
+        ):
             self.group_chat.history.add_user_message(initial_prompt)
-        
+
         # Exécution de la phase avec capture
         await self._execute_conversation_phase(phase_id, max_turns=8)
-        
+
         # Capture de l'état final de phase
         capture_shared_state(
             phase_id=phase_id,
@@ -334,31 +369,35 @@ ProjectManagerAgent, veuillez définir les tâches d'analyse et coordonner l'éq
                 "tasks_defined": len(self.shared_state.analysis_tasks),
                 "arguments_identified": len(self.shared_state.identified_arguments),
                 "fallacies_detected": len(self.shared_state.identified_fallacies),
-                "readiness_for_formal": True
+                "readiness_for_formal": True,
             },
             metadata={
                 "phase_completion": "success",
                 "next_phase": "formal_analysis",
-                "coordination_quality": "high"
-            }
+                "coordination_quality": "high",
+            },
         )
-        
+
         logger.info("✅ Phase 1 terminée: Base informelle établie")
-    
+
     async def _run_phase_2_formal_analysis(self):
         """Phase 2: Analyse formelle avec modal logic."""
         self.phase_counter += 1
         phase_id = f"phase_{self.phase_counter}"
-        
+
         logger.info("[CONFIG] Phase 2: Analyse formelle modal logic")
-        
+
         # Démarrage de la phase
         start_pm_orchestration_phase(
             phase_id=phase_id,
             phase_name="Analyse Formelle Modal Logic",
-            assigned_agents=["ProjectManagerAgent", "ModalLogicAgent", "InformalAnalysisAgent"]
+            assigned_agents=[
+                "ProjectManagerAgent",
+                "ModalLogicAgent",
+                "InformalAnalysisAgent",
+            ],
         )
-        
+
         # Message de transition PM
         transition_prompt = f"""TRANSITION VERS PHASE 2 - ANALYSE FORMELLE
 
@@ -374,7 +413,7 @@ MISSION PHASE 2:
 4. Coordination état partagé entre analyse informelle et formelle
 
 ModalLogicAgent, veuillez commencer la formalisation en vous basant sur l'état partagé actuel."""
-        
+
         # Capture état de transition
         self.tour_counter += 1
         capture_shared_state(
@@ -386,22 +425,24 @@ ModalLogicAgent, veuillez commencer la formalisation en vous basant sur l'état 
                 "belief_sets": len(self.shared_state.belief_sets),
                 "queries_logged": len(self.shared_state.query_log),
                 "formal_readiness": True,
-                "informal_base_established": True
+                "informal_base_established": True,
             },
             metadata={
                 "transition": "informal_to_formal",
                 "coordination_mode": "state_shared",
-                "agents_cooperation": "high"
-            }
+                "agents_cooperation": "high",
+            },
         )
-        
+
         # Ajout du message de transition
-        if hasattr(self.group_chat, 'history') and hasattr(self.group_chat.history, 'add_user_message'):
+        if hasattr(self.group_chat, "history") and hasattr(
+            self.group_chat.history, "add_user_message"
+        ):
             self.group_chat.history.add_user_message(transition_prompt)
-        
+
         # Exécution de la phase formelle
         await self._execute_conversation_phase(phase_id, max_turns=10)
-        
+
         # Capture état final phase 2
         capture_shared_state(
             phase_id=phase_id,
@@ -412,31 +453,36 @@ ModalLogicAgent, veuillez commencer la formalisation en vous basant sur l'état 
                 "belief_sets": len(self.shared_state.belief_sets),
                 "queries_executed": len(self.shared_state.query_log),
                 "formal_consistency": True,
-                "modal_analysis_complete": True
+                "modal_analysis_complete": True,
             },
             metadata={
                 "formal_verification": "completed",
                 "logical_consistency": "verified",
-                "next_phase": "synthesis"
-            }
+                "next_phase": "synthesis",
+            },
         )
-        
+
         logger.info("✅ Phase 2 terminée: Analyse formelle complète")
-    
+
     async def _run_phase_3_synthesis_coordination(self):
         """Phase 3: Synthèse finale coordonnée par PM."""
         self.phase_counter += 1
         phase_id = f"phase_{self.phase_counter}"
-        
+
         logger.info("[CONFIG] Phase 3: Synthèse finale et coordination")
-        
+
         # Démarrage de la phase
         start_pm_orchestration_phase(
             phase_id=phase_id,
             phase_name="Synthèse Finale et Coordination PM",
-            assigned_agents=["ProjectManagerAgent", "InformalAnalysisAgent", "ModalLogicAgent", "ExtractAgent"]
+            assigned_agents=[
+                "ProjectManagerAgent",
+                "InformalAnalysisAgent",
+                "ModalLogicAgent",
+                "ExtractAgent",
+            ],
         )
-        
+
         # Message de synthèse finale
         synthesis_prompt = f"""PHASE 3 FINALE - SYNTHÈSE ET COORDINATION
 
@@ -452,7 +498,7 @@ MISSION FINALE:
 4. Archivage et structuration des résultats
 
 ProjectManagerAgent, veuillez coordonner la synthèse finale en intégrant tous les résultats de l'état partagé."""
-        
+
         # Capture état de synthèse
         self.tour_counter += 1
         capture_shared_state(
@@ -465,22 +511,24 @@ ProjectManagerAgent, veuillez coordonner la synthèse finale en intégrant tous 
                 "total_answers": len(self.shared_state.answers),
                 "informal_complete": True,
                 "formal_complete": True,
-                "synthesis_readiness": True
+                "synthesis_readiness": True,
             },
             metadata={
                 "final_coordination": "active",
                 "synthesis_mode": "comprehensive",
-                "pm_orchestration": "complete"
-            }
+                "pm_orchestration": "complete",
+            },
         )
-        
+
         # Ajout du message de synthèse
-        if hasattr(self.group_chat, 'history') and hasattr(self.group_chat.history, 'add_user_message'):
+        if hasattr(self.group_chat, "history") and hasattr(
+            self.group_chat.history, "add_user_message"
+        ):
             self.group_chat.history.add_user_message(synthesis_prompt)
-        
+
         # Exécution finale
         await self._execute_conversation_phase(phase_id, max_turns=6)
-        
+
         # Capture état final complet
         capture_shared_state(
             phase_id=phase_id,
@@ -489,74 +537,87 @@ ProjectManagerAgent, veuillez coordonner la synthèse finale en intégrant tous 
             state_variables={
                 "phase": "orchestration_complete",
                 "final_conclusion": self.shared_state.final_conclusion is not None,
-                "all_tasks_completed": len(self.shared_state.answers) >= len(self.shared_state.analysis_tasks),
+                "all_tasks_completed": len(self.shared_state.answers)
+                >= len(self.shared_state.analysis_tasks),
                 "orchestration_success": True,
-                "pm_coordination_quality": "excellent"
+                "pm_coordination_quality": "excellent",
             },
             metadata={
                 "orchestration_status": "fully_complete",
                 "pm_effectiveness": "high",
                 "multi_turn_success": True,
-                "state_management_quality": "excellent"
-            }
+                "state_management_quality": "excellent",
+            },
         )
-        
+
         logger.info("✅ Phase 3 terminée: Orchestration PM complète")
-    
+
     async def _execute_conversation_phase(self, phase_id: str, max_turns: int):
         """Exécute une phase de conversation avec une boucle manuelle simple."""
-        logger.info(f"🔄 Exécution phase {phase_id} (max {max_turns} tours) avec boucle manuelle")
+        logger.info(
+            f"🔄 Exécution phase {phase_id} (max {max_turns} tours) avec boucle manuelle"
+        )
 
         # Utiliser l'historique de chat de l'orchestrateur s'il existe
-        if not hasattr(self, 'chat_history'):
+        if not hasattr(self, "chat_history"):
             from semantic_kernel.contents.chat_history import ChatHistory
+
             self.chat_history = ChatHistory()
 
         pm_agent = self.agents.get("ProjectManager")
         if not pm_agent:
-            logger.error("ProjectManagerAgent non trouvé. Impossible d'exécuter la phase de conversation.")
+            logger.error(
+                "ProjectManagerAgent non trouvé. Impossible d'exécuter la phase de conversation."
+            )
             return
 
         for i in range(max_turns):
             logger.info(f"--- Tour de conversation {i+1}/{max_turns} ---")
-            
+
             # Pour cette version de débogage, seul le PM est appelé
             arguments = KernelArguments(chat_history=self.chat_history)
             try:
                 result_stream = pm_agent.invoke_stream(self.kernel, arguments=arguments)
-                
+
                 response_messages = [message async for message in result_stream]
                 if not response_messages:
-                    logger.warning(f"L'agent {pm_agent.name} n'a retourné aucune réponse.")
+                    logger.warning(
+                        f"L'agent {pm_agent.name} n'a retourné aucune réponse."
+                    )
                     break
-                
+
                 for message_list in response_messages:
                     for msg_content in message_list:
                         self.chat_history.add_message(message=msg_content)
-                        logger.info(f"Réponse de {pm_agent.name} ajoutée à l'historique.")
+                        logger.info(
+                            f"Réponse de {pm_agent.name} ajoutée à l'historique."
+                        )
 
                 # On arrête après un tour pour ce débug
                 break
 
             except Exception as e:
-                logger.error(f"Erreur lors de l'invocation de {pm_agent.name}: {e}", exc_info=True)
+                logger.error(
+                    f"Erreur lors de l'invocation de {pm_agent.name}: {e}",
+                    exc_info=True,
+                )
                 break
-        
+
         logger.info(f"✅ Phase {phase_id} exécutée.")
-    
+
     def _capture_tool_call_from_message(self, tool_call, agent_name: str):
         """Capture un tool call depuis un message SK."""
         try:
             # Extraction des informations du tool call
             tool_name = "unknown_tool"
             arguments = {}
-            
-            if hasattr(tool_call, 'function') and tool_call.function:
-                if hasattr(tool_call.function, 'name'):
+
+            if hasattr(tool_call, "function") and tool_call.function:
+                if hasattr(tool_call.function, "name"):
                     tool_name = tool_call.function.name
-                if hasattr(tool_call.function, 'arguments'):
+                if hasattr(tool_call.function, "arguments"):
                     arguments = tool_call.function.arguments or {}
-            
+
             # Enregistrement avec trace améliorée
             enhanced_global_trace_analyzer.record_enhanced_tool_call(
                 agent_name=agent_name,
@@ -564,17 +625,16 @@ ProjectManagerAgent, veuillez coordonner la synthèse finale en intégrant tous 
                 arguments=arguments,
                 result="Tool call captured from message",
                 execution_time_ms=0.0,  # Non mesurable depuis message
-                success=True
+                success=True,
             )
-            
+
         except Exception as e:
             logger.error(f"Erreur capture tool call: {e}")
 
 
 # Fonction principale d'exécution
 async def run_enhanced_pm_orchestration_demo(
-    texte_a_analyser: str,
-    llm_service: Union[OpenAIChatCompletion, AzureChatCompletion]
+    texte_a_analyser: str, llm_service: Union[OpenAIChatCompletion, AzureChatCompletion]
 ) -> Dict[str, Any]:
     """
     Lance une démo complète d'orchestration PM avec gestion d'état partagé
@@ -585,31 +645,31 @@ async def run_enhanced_pm_orchestration_demo(
         "It is maintained for backward compatibility only. "
         "Please use the new agent group chat architecture for new implementations.",
         DeprecationWarning,
-        stacklevel=2
+        stacklevel=2,
     )
     logger.info("[DEMO] DEMARRAGE DEMO PROJECT MANAGER ENHANCED")
     logger.info("=" * 60)
-    
+
     try:
         # Création de l'orchestrateur
         orchestrator = EnhancedProjectManagerOrchestrator(llm_service)
-        
+
         # Lancement de l'orchestration
         result = await orchestrator.run_enhanced_pm_orchestration(texte_a_analyser)
-        
+
         if result["success"]:
             logger.info("[SUCCESS] DÉMO PM TERMINÉE AVEC SUCCÈS")
             logger.info(f"   Phases complétées: {result['phases_completed']}")
             logger.info(f"   Snapshots d'état: {result['state_snapshots']}")
             logger.info(f"   Appels d'outils: {result['tool_calls']}")
             logger.info(f"   Durée totale: {result['total_duration_ms']:.1f}ms")
-            if result.get('report_path'):
+            if result.get("report_path"):
                 logger.info(f"   Rapport sauvegardé: {result['report_path']}")
         else:
             logger.error(f"[ERROR] ÉCHEC DÉMO PM: {result.get('error')}")
-        
+
         return result
-        
+
     except Exception as e:
         logger.error(f"[ERROR] Erreur critique démo PM: {e}", exc_info=True)
         return {"success": False, "error": str(e)}
@@ -618,21 +678,22 @@ async def run_enhanced_pm_orchestration_demo(
 # Classe wrapper pour compatibilité
 class EnhancedPMAnalysisRunner:
     """Wrapper pour intégration facile du PM amélioré."""
-    
+
     def __init__(self):
         warnings.warn(
             "`EnhancedPMAnalysisRunner` is deprecated and will be removed in a future version. "
             "It is maintained for backward compatibility only. "
             "Please use the new agent group chat architecture for new implementations.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         self.logger = logging.getLogger("EnhancedPMRunner")
-    
+
     async def run_enhanced_analysis(self, text_content: str, llm_service=None):
         """Lance une analyse avec orchestration PM améliorée."""
         if llm_service is None:
             from argumentation_analysis.core.llm_service import create_llm_service
+
             llm_service = create_llm_service()
-        
+
         return await run_enhanced_pm_orchestration_demo(text_content, llm_service)

--- a/argumentation_analysis/orchestration/hierarchical/hierarchy_bridge.py
+++ b/argumentation_analysis/orchestration/hierarchical/hierarchy_bridge.py
@@ -64,9 +64,7 @@ class RegistryBackedOperationalRegistry:
 
     # --- Discovery ---
 
-    def find_for_capability(
-        self, capability: str
-    ) -> Optional[ComponentRegistration]:
+    def find_for_capability(self, capability: str) -> Optional[ComponentRegistration]:
         """Find the best component providing a capability.
 
         Returns the first registered provider (any type) or None.
@@ -74,9 +72,7 @@ class RegistryBackedOperationalRegistry:
         providers = self._registry.find_for_capability(capability)
         return providers[0] if providers else None
 
-    def find_all_for_capability(
-        self, capability: str
-    ) -> List[ComponentRegistration]:
+    def find_all_for_capability(self, capability: str) -> List[ComponentRegistration]:
         """Find all components providing a capability."""
         return self._registry.find_for_capability(capability)
 
@@ -220,9 +216,7 @@ def objectives_to_workflow(
         priority = objective.get("priority", "medium")
 
         # Find matching capabilities from description keywords
-        matched_capabilities = _match_capabilities(
-            description, capability_registry
-        )
+        matched_capabilities = _match_capabilities(description, capability_registry)
 
         if not matched_capabilities:
             logger.warning(
@@ -392,9 +386,7 @@ def _extract_questions(phase_results: Dict[str, PhaseResult]) -> List[str]:
     """Extract user questions from phase outputs."""
     questions: List[str] = []
     for result in phase_results.values():
-        if result.status == PhaseStatus.COMPLETED and isinstance(
-            result.output, dict
-        ):
+        if result.status == PhaseStatus.COMPLETED and isinstance(result.output, dict):
             q = result.output.get("user_question")
             if q and isinstance(q, str):
                 questions.append(q)

--- a/argumentation_analysis/orchestration/logique_complexe_orchestrator.py
+++ b/argumentation_analysis/orchestration/logique_complexe_orchestrator.py
@@ -90,7 +90,7 @@ class LogiqueComplexeOrchestrator:
             "It is maintained for backward compatibility only. "
             "Please use the new agent group chat architecture for new implementations.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         self._logger = logging.getLogger(self.__class__.__name__)
         self.kernel = kernel

--- a/argumentation_analysis/orchestration/real_llm_orchestrator.py
+++ b/argumentation_analysis/orchestration/real_llm_orchestrator.py
@@ -82,7 +82,7 @@ class RealLLMOrchestrator:
             "It is maintained for backward compatibility only. "
             "Please use the new agent group chat architecture for new implementations.",
             DeprecationWarning,
-            stacklevel=2
+            stacklevel=2,
         )
         self.config = config or self._default_config()
         self.logger = logging.getLogger(__name__)

--- a/argumentation_analysis/orchestration/router.py
+++ b/argumentation_analysis/orchestration/router.py
@@ -73,9 +73,7 @@ CAPABILITY_DESCRIPTIONS: Dict[str, str] = {
     "semantic_indexing": (
         "Semantic argument search and indexing for large document collections"
     ),
-    "speech_transcription": (
-        "Speech-to-text transcription of audio content"
-    ),
+    "speech_transcription": ("Speech-to-text transcription of audio content"),
 }
 
 ROUTING_SYSTEM_PROMPT = """\
@@ -178,9 +176,7 @@ class TextAnalysisRouter:
                 result = await self._route_with_llm(text, available)
                 return self._build_workflow(result)
             except Exception as e:
-                logger.warning(
-                    "LLM routing failed, falling back to heuristics: %s", e
-                )
+                logger.warning("LLM routing failed, falling back to heuristics: %s", e)
 
         # Tier 2: Heuristic fallback
         result = self._route_with_heuristics(text, available)
@@ -249,9 +245,7 @@ class TextAnalysisRouter:
             cap_lines.append(f"- {cap}: {desc}")
         cap_list_str = "\n".join(cap_lines)
 
-        system_prompt = ROUTING_SYSTEM_PROMPT.format(
-            capability_list=cap_list_str
-        )
+        system_prompt = ROUTING_SYSTEM_PROMPT.format(capability_list=cap_list_str)
         user_prompt = f"Text to analyze:\n\n{text[:LLM_TEXT_LIMIT]}"
 
         response = await client.chat.completions.create(
@@ -309,8 +303,15 @@ class TextAnalysisRouter:
 
         # Fallacy detection — prefer hierarchical for depth, neural for speed
         fallacy_keywords = {
-            "sophisme", "fallac", "raisonnement", "logique", "argument",
-            "erreur", "manipulation", "rhétorique", "ad hominem",
+            "sophisme",
+            "fallac",
+            "raisonnement",
+            "logique",
+            "argument",
+            "erreur",
+            "manipulation",
+            "rhétorique",
+            "ad hominem",
         }
         french_chars = set("àâäéèêëïîôùûüçœæ")
         has_french = any(c in french_chars for c in text_lower)
@@ -325,9 +326,17 @@ class TextAnalysisRouter:
 
         # Governance keywords
         gov_keywords = {
-            "vote", "décision", "consensus", "majorité", "élection",
-            "délibération", "scrutin", "suffrage", "proposition",
-            "assemblée", "démocratie",
+            "vote",
+            "décision",
+            "consensus",
+            "majorité",
+            "élection",
+            "délibération",
+            "scrutin",
+            "suffrage",
+            "proposition",
+            "assemblée",
+            "démocratie",
         }
         if any(kw in text_lower for kw in gov_keywords):
             if "governance_simulation" in available_caps:
@@ -335,9 +344,17 @@ class TextAnalysisRouter:
 
         # Debate/opposition patterns
         debate_markers = {
-            "en revanche", "au contraire", "cependant", "néanmoins",
-            "toutefois", "d'un côté", "de l'autre", "s'oppose",
-            "contestant", "réfute", "objecte",
+            "en revanche",
+            "au contraire",
+            "cependant",
+            "néanmoins",
+            "toutefois",
+            "d'un côté",
+            "de l'autre",
+            "s'oppose",
+            "contestant",
+            "réfute",
+            "objecte",
         }
         if any(m in text_lower for m in debate_markers):
             if "adversarial_debate" in available_caps:

--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -74,21 +74,27 @@ async def _invoke_counter_argument(input_text: str, context: Dict[str, Any]) -> 
             # Use extracted arguments from upstream phase if available
             extract_output = context.get("phase_extract_output", {})
             arguments = extract_output.get("arguments", [])
-            args_context = ("\n".join(f"- {a}" for a in arguments)
-                           if arguments else input_text[:1500])
+            args_context = (
+                "\n".join(f"- {a}" for a in arguments)
+                if arguments
+                else input_text[:1500]
+            )
 
             response = await client.chat.completions.create(
                 model=model_id,
                 messages=[
-                    {"role": "system", "content": (
-                        "You are an expert in argumentation and counter-argument generation. "
-                        "Generate a strong counter-argument using one of: reductio ad absurdum, "
-                        "counter-example, distinction, reformulation, or concession+pivot. "
-                        "Respond with ONLY a JSON object:\n"
-                        '{"counter_argument": "text", "strategy_used": "name", '
-                        '"target_argument": "which argument", "strength": "weak|moderate|strong", '
-                        '"reasoning": "why this works"}'
-                    )},
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are an expert in argumentation and counter-argument generation. "
+                            "Generate a strong counter-argument using one of: reductio ad absurdum, "
+                            "counter-example, distinction, reformulation, or concession+pivot. "
+                            "Respond with ONLY a JSON object:\n"
+                            '{"counter_argument": "text", "strategy_used": "name", '
+                            '"target_argument": "which argument", "strength": "weak|moderate|strong", '
+                            '"reasoning": "why this works"}'
+                        ),
+                    },
                     {"role": "user", "content": args_context},
                 ],
             )
@@ -137,23 +143,29 @@ async def _invoke_debate_analysis(input_text: str, context: Dict[str, Any]) -> D
             # Use extracted arguments from upstream
             extract_output = context.get("phase_extract_output", {})
             arguments = extract_output.get("arguments", [])
-            args_text = ("\n".join(f"- {a}" for a in arguments)
-                         if arguments else input_text[:1500])
+            args_text = (
+                "\n".join(f"- {a}" for a in arguments)
+                if arguments
+                else input_text[:1500]
+            )
 
             response = await client.chat.completions.create(
                 model=model_id,
                 messages=[
-                    {"role": "system", "content": (
-                        "You are a debate judge. Analyze the arguments presented, "
-                        "identify the strongest and weakest positions, and assess "
-                        "the overall quality of the argumentation. "
-                        "Respond with ONLY a JSON object:\n"
-                        '{"strongest_argument": "text", "weakest_argument": "text", '
-                        '"winner": "which side/position wins", '
-                        '"debate_quality": 1-5, '
-                        '"key_exchanges": [{"point": "text", "rebuttal": "text"}], '
-                        '"reasoning": "brief assessment"}'
-                    )},
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a debate judge. Analyze the arguments presented, "
+                            "identify the strongest and weakest positions, and assess "
+                            "the overall quality of the argumentation. "
+                            "Respond with ONLY a JSON object:\n"
+                            '{"strongest_argument": "text", "weakest_argument": "text", '
+                            '"winner": "which side/position wins", '
+                            '"debate_quality": 1-5, '
+                            '"key_exchanges": [{"point": "text", "rebuttal": "text"}], '
+                            '"reasoning": "brief assessment"}'
+                        ),
+                    },
                     {"role": "user", "content": args_text},
                 ],
             )
@@ -229,8 +241,7 @@ async def _invoke_governance(input_text: str, context: Dict[str, Any]) -> Dict:
             context_parts = []
             if arguments:
                 context_parts.append(
-                    "Arguments identified:\n"
-                    + "\n".join(f"- {a}" for a in arguments)
+                    "Arguments identified:\n" + "\n".join(f"- {a}" for a in arguments)
                 )
             if debate_output.get("llm_debate_assessment"):
                 da = debate_output["llm_debate_assessment"]
@@ -247,35 +258,34 @@ async def _invoke_governance(input_text: str, context: Dict[str, Any]) -> Dict:
             if conflicts:
                 context_parts.append(
                     f"Conflicts detected: {len(conflicts)} between "
-                    + ", ".join(
-                        " vs ".join(c.get("agents", []))
-                        for c in conflicts[:3]
-                    )
+                    + ", ".join(" vs ".join(c.get("agents", [])) for c in conflicts[:3])
                 )
 
             deliberation_input = (
-                "\n\n".join(context_parts) if context_parts
-                else input_text[:2000]
+                "\n\n".join(context_parts) if context_parts else input_text[:2000]
             )
 
             response = await client.chat.completions.create(
                 model=model_id,
                 messages=[
-                    {"role": "system", "content": (
-                        "You are a governance and collective decision-making analyst. "
-                        "Analyze the arguments, conflicts, and positions presented. "
-                        "Assess which voting/decision method would be most appropriate, "
-                        "evaluate consensus potential, and recommend a governance approach. "
-                        "Available methods: " + ", ".join(available_methods) + ". "
-                        "Respond with ONLY a JSON object:\n"
-                        '{"recommended_method": "method_name", '
-                        '"consensus_potential": 0.0-1.0, '
-                        '"fairness_assessment": "brief text", '
-                        '"conflict_severity": "low|medium|high", '
-                        '"stakeholder_analysis": [{"agent": "name", "position": "summary", "influence": 0.0-1.0}], '
-                        '"recommended_resolution": "collaborative|competitive|compromise", '
-                        '"governance_reasoning": "brief explanation of recommendation"}'
-                    )},
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are a governance and collective decision-making analyst. "
+                            "Analyze the arguments, conflicts, and positions presented. "
+                            "Assess which voting/decision method would be most appropriate, "
+                            "evaluate consensus potential, and recommend a governance approach. "
+                            "Available methods: " + ", ".join(available_methods) + ". "
+                            "Respond with ONLY a JSON object:\n"
+                            '{"recommended_method": "method_name", '
+                            '"consensus_potential": 0.0-1.0, '
+                            '"fairness_assessment": "brief text", '
+                            '"conflict_severity": "low|medium|high", '
+                            '"stakeholder_analysis": [{"agent": "name", "position": "summary", "influence": 0.0-1.0}], '
+                            '"recommended_resolution": "collaborative|competitive|compromise", '
+                            '"governance_reasoning": "brief explanation of recommendation"}'
+                        ),
+                    },
                     {"role": "user", "content": deliberation_input},
                 ],
             )
@@ -367,6 +377,7 @@ async def _invoke_speech_transcription(
 async def _invoke_ranking(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke ranking semantics handler."""
     from argumentation_analysis.agents.core.logic.ranking_handler import RankingHandler
+
     handler = RankingHandler()
     args = context.get("arguments", ["a", "b", "c"])
     attacks = context.get("attacks", [])
@@ -377,6 +388,7 @@ async def _invoke_ranking(input_text: str, context: Dict[str, Any]) -> Dict:
 async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke bipolar argumentation handler."""
     from argumentation_analysis.agents.core.logic.bipolar_handler import BipolarHandler
+
     handler = BipolarHandler()
     args = context.get("arguments", [])
     attacks = context.get("attacks", [])
@@ -390,6 +402,7 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict:
 async def _invoke_aba(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke ABA handler."""
     from argumentation_analysis.agents.core.logic.aba_handler import ABAHandler
+
     handler = ABAHandler()
     assumptions = context.get("assumptions", [])
     rules = context.get("rules", [])
@@ -403,26 +416,35 @@ async def _invoke_aba(input_text: str, context: Dict[str, Any]) -> Dict:
 async def _invoke_adf(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke ADF handler."""
     from argumentation_analysis.agents.core.logic.adf_handler import ADFHandler
+
     handler = ADFHandler()
     statements = context.get("statements", [])
     conditions = context.get("acceptance_conditions", {})
     semantics = context.get("semantics", "grounded")
-    return await asyncio.to_thread(handler.analyze_adf, statements, conditions, semantics)
+    return await asyncio.to_thread(
+        handler.analyze_adf, statements, conditions, semantics
+    )
 
 
 async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke ASPIC+ handler."""
     from argumentation_analysis.agents.core.logic.aspic_handler import ASPICHandler
+
     handler = ASPICHandler()
     strict = context.get("strict_rules", [])
     defeasible = context.get("defeasible_rules", [])
     axioms = context.get("axioms")
-    return await asyncio.to_thread(handler.analyze_aspic_framework, strict, defeasible, axioms)
+    return await asyncio.to_thread(
+        handler.analyze_aspic_framework, strict, defeasible, axioms
+    )
 
 
 async def _invoke_belief_revision(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke belief revision handler."""
-    from argumentation_analysis.agents.core.logic.belief_revision_handler import BeliefRevisionHandler
+    from argumentation_analysis.agents.core.logic.belief_revision_handler import (
+        BeliefRevisionHandler,
+    )
+
     handler = BeliefRevisionHandler()
     beliefs = context.get("belief_set", [input_text])
     new_belief = context.get("new_belief", input_text)
@@ -432,7 +454,10 @@ async def _invoke_belief_revision(input_text: str, context: Dict[str, Any]) -> D
 
 async def _invoke_probabilistic(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke probabilistic argumentation handler."""
-    from argumentation_analysis.agents.core.logic.probabilistic_handler import ProbabilisticHandler
+    from argumentation_analysis.agents.core.logic.probabilistic_handler import (
+        ProbabilisticHandler,
+    )
+
     handler = ProbabilisticHandler()
     args = context.get("arguments", [])
     attacks = context.get("attacks", [])
@@ -444,7 +469,10 @@ async def _invoke_probabilistic(input_text: str, context: Dict[str, Any]) -> Dic
 
 async def _invoke_dialogue(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke dialogue protocol handler."""
-    from argumentation_analysis.agents.core.logic.dialogue_handler import DialogueHandler
+    from argumentation_analysis.agents.core.logic.dialogue_handler import (
+        DialogueHandler,
+    )
+
     handler = DialogueHandler()
     pro_args = context.get("proponent_args", [])
     pro_attacks = context.get("proponent_attacks", [])
@@ -459,7 +487,10 @@ async def _invoke_dialogue(input_text: str, context: Dict[str, Any]) -> Dict:
 async def _invoke_dl(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke Description Logic handler (#86)."""
     from argumentation_analysis.agents.core.logic.dl_handler import DLHandler
-    from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+    from argumentation_analysis.agents.core.logic.tweety_initializer import (
+        TweetyInitializer,
+    )
+
     initializer = TweetyInitializer()
     handler = DLHandler(initializer)
     tbox = context.get("tbox", [])
@@ -481,7 +512,10 @@ async def _invoke_dl(input_text: str, context: Dict[str, Any]) -> Dict:
 async def _invoke_cl(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke Conditional Logic handler (#86)."""
     from argumentation_analysis.agents.core.logic.cl_handler import CLHandler
-    from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+    from argumentation_analysis.agents.core.logic.tweety_initializer import (
+        TweetyInitializer,
+    )
+
     initializer = TweetyInitializer()
     handler = CLHandler(initializer)
     conditionals = context.get("conditionals", [])
@@ -505,6 +539,7 @@ async def _invoke_cl(input_text: str, context: Dict[str, Any]) -> Dict:
 async def _invoke_sat(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke SAT solver handler (#86)."""
     from argumentation_analysis.agents.core.logic.sat_handler import SATHandler
+
     handler = SATHandler(context.get("solver", "cadical195"))
     formulas = context.get("formulas", [input_text] if input_text else [])
     mode = context.get("sat_mode", "solve")  # solve, maxsat, mus
@@ -530,7 +565,10 @@ async def _invoke_sat(input_text: str, context: Dict[str, Any]) -> Dict:
 async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke Set Argumentation Framework handler (#87)."""
     from argumentation_analysis.agents.core.logic.setaf_handler import SetAFHandler
-    from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+    from argumentation_analysis.agents.core.logic.tweety_initializer import (
+        TweetyInitializer,
+    )
+
     initializer = TweetyInitializer()
     handler = SetAFHandler(initializer)
     args = context.get("arguments", [])
@@ -541,8 +579,13 @@ async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict:
 
 async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke Weighted AF handler (#87)."""
-    from argumentation_analysis.agents.core.logic.weighted_handler import WeightedHandler
-    from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+    from argumentation_analysis.agents.core.logic.weighted_handler import (
+        WeightedHandler,
+    )
+    from argumentation_analysis.agents.core.logic.tweety_initializer import (
+        TweetyInitializer,
+    )
+
     initializer = TweetyInitializer()
     handler = WeightedHandler(initializer)
     args = context.get("arguments", [])
@@ -556,7 +599,10 @@ async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict:
 async def _invoke_social(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke Social AF handler (#87)."""
     from argumentation_analysis.agents.core.logic.social_handler import SocialHandler
-    from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+    from argumentation_analysis.agents.core.logic.tweety_initializer import (
+        TweetyInitializer,
+    )
+
     initializer = TweetyInitializer()
     handler = SocialHandler(initializer)
     args = context.get("arguments", [])
@@ -576,7 +622,10 @@ async def _invoke_social(input_text: str, context: Dict[str, Any]) -> Dict:
 async def _invoke_eaf(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke Epistemic AF handler (#88)."""
     from argumentation_analysis.agents.core.logic.eaf_handler import EAFHandler
-    from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+    from argumentation_analysis.agents.core.logic.tweety_initializer import (
+        TweetyInitializer,
+    )
+
     initializer = TweetyInitializer()
     handler = EAFHandler(initializer)
     args = context.get("arguments", [])
@@ -591,19 +640,27 @@ async def _invoke_eaf(input_text: str, context: Dict[str, Any]) -> Dict:
 async def _invoke_delp(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke DeLP handler (#89)."""
     from argumentation_analysis.agents.core.logic.delp_handler import DeLPHandler
-    from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+    from argumentation_analysis.agents.core.logic.tweety_initializer import (
+        TweetyInitializer,
+    )
+
     initializer = TweetyInitializer()
     handler = DeLPHandler(initializer)
     program_text = context.get("program", input_text)
     queries = context.get("queries", [])
     criterion = context.get("criterion", "generalized_specificity")
-    return await asyncio.to_thread(handler.analyze_delp, program_text, queries, criterion)
+    return await asyncio.to_thread(
+        handler.analyze_delp, program_text, queries, criterion
+    )
 
 
 async def _invoke_qbf(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke QBF handler (#90)."""
     from argumentation_analysis.agents.core.logic.qbf_handler import QBFHandler
-    from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+    from argumentation_analysis.agents.core.logic.tweety_initializer import (
+        TweetyInitializer,
+    )
+
     initializer = TweetyInitializer()
     handler = QBFHandler(initializer)
     quantifiers = context.get("quantifiers", [])
@@ -676,9 +733,7 @@ async def _invoke_hierarchical_fallacy(
         return result
 
     except Exception as e:
-        logger.warning(
-            "Hierarchical fallacy detection failed, returning empty: %s", e
-        )
+        logger.warning("Hierarchical fallacy detection failed, returning empty: %s", e)
         return {
             "fallacies": [],
             "exploration_method": "error",
@@ -708,15 +763,18 @@ async def _invoke_fact_extraction(input_text: str, context: Dict[str, Any]) -> D
             response = await client.chat.completions.create(
                 model=model_id,
                 messages=[
-                    {"role": "system", "content": (
-                        "You are an expert argument analyst. Extract the key arguments, "
-                        "claims, and rhetorical strategies from the text. "
-                        "Respond with ONLY a JSON object:\n"
-                        '{"arguments": ["arg1", "arg2", ...], '
-                        '"claims": ["claim1", "claim2", ...], '
-                        '"fallacies": [{"type": "name", "justification": "why"}], '
-                        '"summary": "brief analysis summary"}'
-                    )},
+                    {
+                        "role": "system",
+                        "content": (
+                            "You are an expert argument analyst. Extract the key arguments, "
+                            "claims, and rhetorical strategies from the text. "
+                            "Respond with ONLY a JSON object:\n"
+                            '{"arguments": ["arg1", "arg2", ...], '
+                            '"claims": ["claim1", "claim2", ...], '
+                            '"fallacies": [{"type": "name", "justification": "why"}], '
+                            '"summary": "brief analysis summary"}'
+                        ),
+                    },
                     {"role": "user", "content": input_text[:3000]},
                 ],
             )
@@ -745,7 +803,7 @@ async def _invoke_fact_extraction(input_text: str, context: Dict[str, Any]) -> D
         logger.warning(f"LLM fact extraction failed, falling back to heuristic: {e}")
 
     # Heuristic fallback
-    sentences = re.split(r'(?<=[.!?])\s+', input_text.strip())
+    sentences = re.split(r"(?<=[.!?])\s+", input_text.strip())
     claims = [s.strip() for s in sentences if len(s.strip()) > 20]
     return {
         "arguments": [],
@@ -763,6 +821,7 @@ async def _invoke_propositional_logic(input_text: str, context: Dict[str, Any]) 
     """Invoke propositional logic analysis via TweetyBridge (JVM required)."""
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
         bridge = TweetyBridge()
         formulas = context.get("formulas", [input_text])
         if not isinstance(formulas, list):
@@ -779,13 +838,19 @@ async def _invoke_propositional_logic(input_text: str, context: Dict[str, Any]) 
             "logic_type": "propositional",
         }
     except Exception as e:
-        return {"error": str(e), "formulas": [], "satisfiable": False, "logic_type": "propositional"}
+        return {
+            "error": str(e),
+            "formulas": [],
+            "satisfiable": False,
+            "logic_type": "propositional",
+        }
 
 
 async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke first-order logic analysis via TweetyBridge (JVM required)."""
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
         bridge = TweetyBridge()
         formulas = context.get("formulas", [input_text])
         if not isinstance(formulas, list):
@@ -803,13 +868,20 @@ async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dic
             "logic_type": "first_order",
         }
     except Exception as e:
-        return {"error": str(e), "formulas": [], "consistent": False, "inferences": [], "confidence": 0.0}
+        return {
+            "error": str(e),
+            "formulas": [],
+            "consistent": False,
+            "inferences": [],
+            "confidence": 0.0,
+        }
 
 
 async def _invoke_modal_logic(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke modal logic analysis via TweetyBridge (JVM required)."""
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
         bridge = TweetyBridge()
         formulas = context.get("formulas", [input_text])
         if not isinstance(formulas, list):
@@ -836,6 +908,7 @@ async def _invoke_dung_extensions(input_text: str, context: Dict[str, Any]) -> D
     try:
         from argumentation_analysis.agents.core.logic.af_handler import AFHandler
         from argumentation_analysis.core.jvm_setup import TweetyInitializer
+
         initializer = TweetyInitializer()
         handler = AFHandler(initializer)
         arguments = context.get("arguments", [])
@@ -863,8 +936,12 @@ async def _invoke_formal_synthesis(input_text: str, context: Dict[str, Any]) -> 
     overall_scores = []
 
     for key, val in context.items():
-        if key.startswith("phase_") and key.endswith("_output") and isinstance(val, dict):
-            phase_name = key[len("phase_"):-len("_output")]
+        if (
+            key.startswith("phase_")
+            and key.endswith("_output")
+            and isinstance(val, dict)
+        ):
+            phase_name = key[len("phase_") : -len("_output")]
             phase_results[phase_name] = val
             if "consistent" in val:
                 overall_scores.append(1.0 if val["consistent"] else 0.0)
@@ -873,7 +950,9 @@ async def _invoke_formal_synthesis(input_text: str, context: Dict[str, Any]) -> 
             if "valid" in val:
                 overall_scores.append(1.0 if val["valid"] else 0.0)
 
-    overall_validity = sum(overall_scores) / len(overall_scores) if overall_scores else 0.5
+    overall_validity = (
+        sum(overall_scores) / len(overall_scores) if overall_scores else 0.5
+    )
     summary_parts = []
     for name, res in phase_results.items():
         if "error" in res:
@@ -883,11 +962,20 @@ async def _invoke_formal_synthesis(input_text: str, context: Dict[str, Any]) -> 
         elif "satisfiable" in res:
             summary_parts.append(f"{name}: satisfiable={res['satisfiable']}")
         elif "extensions" in res:
-            ext_count = sum(len(v) if isinstance(v, list) else 0 for v in res["extensions"].values()) if isinstance(res.get("extensions"), dict) else 0
+            ext_count = (
+                sum(
+                    len(v) if isinstance(v, list) else 0
+                    for v in res["extensions"].values()
+                )
+                if isinstance(res.get("extensions"), dict)
+                else 0
+            )
             summary_parts.append(f"{name}: {ext_count} extensions")
 
     return {
-        "summary": "; ".join(summary_parts) if summary_parts else "No formal results collected",
+        "summary": (
+            "; ".join(summary_parts) if summary_parts else "No formal results collected"
+        ),
         "phase_results": phase_results,
         "overall_validity": overall_validity,
         "phase_count": len(phase_results),
@@ -952,7 +1040,9 @@ def _write_jtms_to_state(output, state, ctx) -> None:
     if not isinstance(beliefs, dict):
         return
     for name, valid_str in beliefs.items():
-        valid = True if valid_str == "True" else (False if valid_str == "False" else None)
+        valid = (
+            True if valid_str == "True" else (False if valid_str == "False" else None)
+        )
         state.add_jtms_belief(str(name), valid, justifications=[])
 
 
@@ -970,10 +1060,12 @@ def _write_debate_to_state(output, state, ctx) -> None:
         if isinstance(key_exchanges, list):
             for ex in key_exchanges:
                 if isinstance(ex, dict):
-                    exchanges.append({
-                        "point": str(ex.get("point", "")),
-                        "rebuttal": str(ex.get("rebuttal", "")),
-                    })
+                    exchanges.append(
+                        {
+                            "point": str(ex.get("point", "")),
+                            "rebuttal": str(ex.get("rebuttal", "")),
+                        }
+                    )
     state.add_debate_transcript(
         topic=topic,
         exchanges=exchanges,
@@ -1012,7 +1104,9 @@ def _write_governance_to_state(output, state, ctx) -> None:
     if not scores and not has_conflicts and not has_llm:
         return
 
-    recommended = output.get("recommended_method") or llm_gov.get("recommended_method", "majority")
+    recommended = output.get("recommended_method") or llm_gov.get(
+        "recommended_method", "majority"
+    )
 
     # Determine winner from LLM assessment or conflict resolution
     winner = "N/A"
@@ -1281,7 +1375,9 @@ def _write_fol_to_state(output, state, ctx) -> None:
         inferences = []
     if not isinstance(confidence, (int, float)):
         confidence = 0.0
-    state.add_fol_analysis_result(formulas, bool(consistent), inferences, float(confidence))
+    state.add_fol_analysis_result(
+        formulas, bool(consistent), inferences, float(confidence)
+    )
 
 
 def _write_modal_to_state(output, state, ctx) -> None:
@@ -1718,6 +1814,7 @@ def setup_registry(
     # --- TweetyLogicPlugin: SK wrapper for all handlers (#91) ---
     try:
         from argumentation_analysis.plugins.tweety_logic_plugin import TweetyLogicPlugin
+
         registry.register_plugin(
             name="tweety_logic_plugin",
             plugin_class=TweetyLogicPlugin,
@@ -1735,21 +1832,49 @@ def setup_registry(
 
     # --- Logic agent capabilities (#71 Formal Verification) ---
     logic_capabilities = [
-        ("fact_extraction_service", ["fact_extraction"],
-         "Heuristic claim extraction from text", _invoke_fact_extraction),
-        ("propositional_logic_service", ["propositional_logic"],
-         "Propositional logic analysis via Tweety", _invoke_propositional_logic),
-        ("fol_reasoning_service", ["fol_reasoning"],
-         "First-order logic analysis via Tweety", _invoke_fol_reasoning),
-        ("modal_logic_service", ["modal_logic"],
-         "Modal logic analysis via Tweety", _invoke_modal_logic),
-        ("dung_extensions_service", ["dung_extensions"],
-         "Dung AF extension computation via AFHandler", _invoke_dung_extensions),
-        ("formal_synthesis_service", ["formal_synthesis"],
-         "Aggregate formal analysis into unified report", _invoke_formal_synthesis),
+        (
+            "fact_extraction_service",
+            ["fact_extraction"],
+            "Heuristic claim extraction from text",
+            _invoke_fact_extraction,
+        ),
+        (
+            "propositional_logic_service",
+            ["propositional_logic"],
+            "Propositional logic analysis via Tweety",
+            _invoke_propositional_logic,
+        ),
+        (
+            "fol_reasoning_service",
+            ["fol_reasoning"],
+            "First-order logic analysis via Tweety",
+            _invoke_fol_reasoning,
+        ),
+        (
+            "modal_logic_service",
+            ["modal_logic"],
+            "Modal logic analysis via Tweety",
+            _invoke_modal_logic,
+        ),
+        (
+            "dung_extensions_service",
+            ["dung_extensions"],
+            "Dung AF extension computation via AFHandler",
+            _invoke_dung_extensions,
+        ),
+        (
+            "formal_synthesis_service",
+            ["formal_synthesis"],
+            "Aggregate formal analysis into unified report",
+            _invoke_formal_synthesis,
+        ),
         # SAT handler — no JVM dependency, uses PySAT+Z3 (#86)
-        ("sat_handler", ["sat_solving"],
-         "SAT/MaxSAT/MUS solver (PySAT + Z3)", _invoke_sat),
+        (
+            "sat_handler",
+            ["sat_solving"],
+            "SAT/MaxSAT/MUS solver (PySAT + Z3)",
+            _invoke_sat,
+        ),
     ]
     for name, caps, desc, invoke_fn in logic_capabilities:
         try:
@@ -1777,41 +1902,105 @@ def setup_registry(
 def _declare_tweety_slots(registry: CapabilityRegistry) -> None:
     """Register Tweety handler capabilities (Track A #55-#62, #85-#86)."""
     tweety_handlers = [
-        ("ranking_semantics_handler", ["ranking_semantics"],
-         "Qualitative argument ranking (Categoriser, Burden)", _invoke_ranking),
-        ("bipolar_handler", ["bipolar_argumentation"],
-         "Bipolar argumentation (support + attack)", _invoke_bipolar),
-        ("aba_handler", ["aba_reasoning"],
-         "Assumption-Based Argumentation", _invoke_aba),
-        ("adf_handler", ["adf_reasoning"],
-         "Abstract Dialectical Frameworks", _invoke_adf),
-        ("aspic_handler", ["aspic_plus_reasoning"],
-         "ASPIC+ structured argumentation", _invoke_aspic),
-        ("belief_revision_handler", ["belief_revision"],
-         "Belief dynamics and revision operators", _invoke_belief_revision),
-        ("probabilistic_handler", ["probabilistic_argumentation"],
-         "Probabilistic argument acceptance", _invoke_probabilistic),
-        ("dialogue_handler", ["dialogue_protocols"],
-         "Agent dialogue and negotiation protocols", _invoke_dialogue),
+        (
+            "ranking_semantics_handler",
+            ["ranking_semantics"],
+            "Qualitative argument ranking (Categoriser, Burden)",
+            _invoke_ranking,
+        ),
+        (
+            "bipolar_handler",
+            ["bipolar_argumentation"],
+            "Bipolar argumentation (support + attack)",
+            _invoke_bipolar,
+        ),
+        (
+            "aba_handler",
+            ["aba_reasoning"],
+            "Assumption-Based Argumentation",
+            _invoke_aba,
+        ),
+        (
+            "adf_handler",
+            ["adf_reasoning"],
+            "Abstract Dialectical Frameworks",
+            _invoke_adf,
+        ),
+        (
+            "aspic_handler",
+            ["aspic_plus_reasoning"],
+            "ASPIC+ structured argumentation",
+            _invoke_aspic,
+        ),
+        (
+            "belief_revision_handler",
+            ["belief_revision"],
+            "Belief dynamics and revision operators",
+            _invoke_belief_revision,
+        ),
+        (
+            "probabilistic_handler",
+            ["probabilistic_argumentation"],
+            "Probabilistic argument acceptance",
+            _invoke_probabilistic,
+        ),
+        (
+            "dialogue_handler",
+            ["dialogue_protocols"],
+            "Agent dialogue and negotiation protocols",
+            _invoke_dialogue,
+        ),
         # New handlers (#86)
-        ("dl_handler", ["description_logic"],
-         "ALC Description Logic (TBox/ABox reasoning)", _invoke_dl),
-        ("cl_handler", ["conditional_logic"],
-         "Conditional Logic (System Z, non-monotonic)", _invoke_cl),
+        (
+            "dl_handler",
+            ["description_logic"],
+            "ALC Description Logic (TBox/ABox reasoning)",
+            _invoke_dl,
+        ),
+        (
+            "cl_handler",
+            ["conditional_logic"],
+            "Conditional Logic (System Z, non-monotonic)",
+            _invoke_cl,
+        ),
         # AF variants (#87)
-        ("setaf_handler", ["setaf_reasoning"],
-         "Set Argumentation Frameworks (collective attacks)", _invoke_setaf),
-        ("weighted_handler", ["weighted_argumentation"],
-         "Weighted Argumentation Frameworks (attack weights)", _invoke_weighted),
-        ("social_handler", ["social_argumentation"],
-         "Social Abstract Argumentation (voting + attacks)", _invoke_social),
+        (
+            "setaf_handler",
+            ["setaf_reasoning"],
+            "Set Argumentation Frameworks (collective attacks)",
+            _invoke_setaf,
+        ),
+        (
+            "weighted_handler",
+            ["weighted_argumentation"],
+            "Weighted Argumentation Frameworks (attack weights)",
+            _invoke_weighted,
+        ),
+        (
+            "social_handler",
+            ["social_argumentation"],
+            "Social Abstract Argumentation (voting + attacks)",
+            _invoke_social,
+        ),
         # New handlers (#88, #89, #90)
-        ("eaf_handler", ["epistemic_argumentation"],
-         "Epistemic AF (belief-aware multi-agent argumentation)", _invoke_eaf),
-        ("delp_handler", ["defeasible_logic"],
-         "Defeasible Logic Programming (dialectical trees)", _invoke_delp),
-        ("qbf_handler", ["qbf_reasoning"],
-         "Quantified Boolean Formulas (∀/∃ over PL)", _invoke_qbf),
+        (
+            "eaf_handler",
+            ["epistemic_argumentation"],
+            "Epistemic AF (belief-aware multi-agent argumentation)",
+            _invoke_eaf,
+        ),
+        (
+            "delp_handler",
+            ["defeasible_logic"],
+            "Defeasible Logic Programming (dialectical trees)",
+            _invoke_delp,
+        ),
+        (
+            "qbf_handler",
+            ["qbf_reasoning"],
+            "Quantified Boolean Formulas (∀/∃ over PL)",
+            _invoke_qbf,
+        ),
     ]
     for name, caps, desc, invoke_fn in tweety_handlers:
         try:
@@ -2124,7 +2313,9 @@ def get_workflow_catalog() -> Dict[str, WorkflowDefinition]:
                 build_formal_verification_workflow,
             )
 
-            WORKFLOW_CATALOG["formal_verification"] = build_formal_verification_workflow()
+            WORKFLOW_CATALOG["formal_verification"] = (
+                build_formal_verification_workflow()
+            )
         except Exception as e:
             logger.warning(f"Formal verification workflow not registered: {e}")
     return WORKFLOW_CATALOG
@@ -2173,7 +2364,9 @@ async def run_unified_analysis(
 
             state = UnifiedAnalysisState(text)
         except ImportError:
-            logger.warning("Could not import UnifiedAnalysisState; state tracking disabled")
+            logger.warning(
+                "Could not import UnifiedAnalysisState; state tracking disabled"
+            )
             state = None
 
     if custom_workflow is not None:

--- a/argumentation_analysis/orchestration/workflow_dsl.py
+++ b/argumentation_analysis/orchestration/workflow_dsl.py
@@ -364,8 +364,7 @@ class WorkflowExecutor:
                                 error="Condition not met",
                             )
                             logger.info(
-                                f"Phase '{phase_name}' skipped — "
-                                f"condition not met"
+                                f"Phase '{phase_name}' skipped — " f"condition not met"
                             )
                             continue
                     except Exception as cond_err:
@@ -425,7 +424,10 @@ class WorkflowExecutor:
                         if phase.loop_config is not None:
                             # Iterative execution
                             output = await self._execute_loop(
-                                phase, provider, phase_input, ctx,
+                                phase,
+                                provider,
+                                phase_input,
+                                ctx,
                                 phase.loop_config,
                             )
                         elif phase.timeout_seconds:
@@ -512,9 +514,7 @@ class WorkflowExecutor:
                         "completed": completed,
                         "failed": failed,
                         "skipped": skipped,
-                        "phases": {
-                            name: r.status.value for name, r in results.items()
-                        },
+                        "phases": {name: r.status.value for name, r in results.items()},
                     },
                 )
             except Exception as sw_err:

--- a/argumentation_analysis/plugins/belief_revision_plugin.py
+++ b/argumentation_analysis/plugins/belief_revision_plugin.py
@@ -23,7 +23,9 @@ class BeliefRevisionPlugin:
     )
     def revise_beliefs(self, revision_json: str) -> str:
         """Revise belief set and return updated beliefs."""
-        from argumentation_analysis.agents.core.logic.belief_revision_handler import BeliefRevisionHandler
+        from argumentation_analysis.agents.core.logic.belief_revision_handler import (
+            BeliefRevisionHandler,
+        )
 
         data = json.loads(revision_json)
         handler = BeliefRevisionHandler()
@@ -42,7 +44,9 @@ class BeliefRevisionPlugin:
     )
     def contract_beliefs(self, contraction_json: str) -> str:
         """Contract belief set and return reduced beliefs."""
-        from argumentation_analysis.agents.core.logic.belief_revision_handler import BeliefRevisionHandler
+        from argumentation_analysis.agents.core.logic.belief_revision_handler import (
+            BeliefRevisionHandler,
+        )
 
         data = json.loads(contraction_json)
         handler = BeliefRevisionHandler()

--- a/argumentation_analysis/plugins/exploration_plugin.py
+++ b/argumentation_analysis/plugins/exploration_plugin.py
@@ -6,6 +6,7 @@ by calling these functions — it cannot respond freely.
 
 Recovered from commit d2fdd930 and enhanced with structured output.
 """
+
 import json
 import logging
 from typing import Annotated, Optional
@@ -85,7 +86,9 @@ class ExplorationPlugin:
     def confirm_fallacy(
         self,
         node_pk: Annotated[str, "The PK of the confirmed fallacy node"],
-        confidence: Annotated[str, "Confidence level: 'high', 'medium', or 'low'"] = "medium",
+        confidence: Annotated[
+            str, "Confidence level: 'high', 'medium', or 'low'"
+        ] = "medium",
         justification: Annotated[str, "Why this fallacy matches the text"] = "",
     ) -> Annotated[str, "Confirmation result"]:
         """Confirm a fallacy identification with justification."""
@@ -120,6 +123,4 @@ class ExplorationPlugin:
         reason: Annotated[str, "Why no fallacy was found in this branch"],
     ) -> Annotated[str, "Conclusion recorded"]:
         """Conclude that no fallacy was found in this branch."""
-        return json.dumps(
-            {"confirmed": False, "reason": reason}, ensure_ascii=False
-        )
+        return json.dumps({"confirmed": False, "reason": reason}, ensure_ascii=False)

--- a/argumentation_analysis/plugins/fallacy_workflow_plugin.py
+++ b/argumentation_analysis/plugins/fallacy_workflow_plugin.py
@@ -9,6 +9,7 @@ Rebuilt from commit d2fdd930 with improvements:
 
 See docs/reports/issue_84_git_archaeology.md for architectural history.
 """
+
 import asyncio
 import csv
 import json
@@ -186,7 +187,9 @@ class FallacyWorkflowPlugin:
 
             # Feed result back to history
             history.add_message(
-                FunctionResultContent(id=item.id, result=result_str).to_chat_message_content()
+                FunctionResultContent(
+                    id=item.id, result=result_str
+                ).to_chat_message_content()
             )
 
             # Parse result for caller
@@ -251,7 +254,9 @@ class FallacyWorkflowPlugin:
             parent_desc = current_node.get(f"desc_{self.language}", "")
             parent_example = current_node.get(f"example_{self.language}", "")
 
-            options_text = f"\n--- OPTIONS at depth {current_node.get('depth', '?')} ---\n"
+            options_text = (
+                f"\n--- OPTIONS at depth {current_node.get('depth', '?')} ---\n"
+            )
             options_text += (
                 f"CONFIRM THIS LEVEL: {parent_name} (ID: {current_pk})\n"
                 f"  Description: {parent_desc}\n"
@@ -272,7 +277,7 @@ class FallacyWorkflowPlugin:
                     options_text += f"    Example: {cexample}\n"
 
             prompt = (
-                f"Text to analyze: \"{argument_text[:500]}\"\n\n"
+                f'Text to analyze: "{argument_text[:500]}"\n\n'
                 f"You are navigating the fallacy taxonomy. Current position: {parent_name}\n"
                 f"{options_text}\n"
                 "Choose ONE action:\n"
@@ -325,7 +330,9 @@ class FallacyWorkflowPlugin:
                 if func_name == "confirm_fallacy" and result.get("confirmed"):
                     confirmed_pk = result.get("pk", "")
                     confirmed_node = self.taxonomy_navigator.get_node(confirmed_pk)
-                    confirmed_depth = int(confirmed_node.get("depth", 0)) if confirmed_node else 0
+                    confirmed_depth = (
+                        int(confirmed_node.get("depth", 0)) if confirmed_node else 0
+                    )
 
                     # Reject too-shallow confirmations — force deeper exploration
                     if confirmed_depth < self.MIN_CONFIRM_DEPTH and children:
@@ -405,9 +412,7 @@ class FallacyWorkflowPlugin:
             self.logger.addHandler(file_handler)
 
         try:
-            self.logger.info(
-                f"--- Fallacy Analysis for: '{argument_text[:80]}...' ---"
-            )
+            self.logger.info(f"--- Fallacy Analysis for: '{argument_text[:80]}...' ---")
 
             # Direct one-shot mode if requested
             if use_one_shot:
@@ -418,7 +423,7 @@ class FallacyWorkflowPlugin:
             root_presentation = self._build_root_presentation()
 
             selection_prompt = (
-                f"Text to analyze: \"{argument_text[:800]}\"\n\n"
+                f'Text to analyze: "{argument_text[:800]}"\n\n'
                 f"Below are the ROOT CATEGORIES of the fallacy taxonomy:\n"
                 f"{root_presentation}\n\n"
                 "Select up to 3 candidate branches by calling explore_branch(node_pk='<ID>') "

--- a/argumentation_analysis/plugins/french_fallacy_plugin.py
+++ b/argumentation_analysis/plugins/french_fallacy_plugin.py
@@ -43,16 +43,16 @@ class FrenchFallacyPlugin:
 
     @kernel_function(
         name="get_available_tiers",
-        description=(
-            "List available detection tiers (symbolic, nli, llm)."
-        ),
+        description=("List available detection tiers (symbolic, nli, llm)."),
     )
     def get_available_tiers(self) -> str:
         """Return available detection tiers as JSON."""
-        return json.dumps({
-            "available_tiers": self.adapter.get_available_tiers(),
-            "is_available": self.adapter.is_available(),
-        })
+        return json.dumps(
+            {
+                "available_tiers": self.adapter.get_available_tiers(),
+                "is_available": self.adapter.is_available(),
+            }
+        )
 
     @kernel_function(
         name="list_fallacy_types",

--- a/argumentation_analysis/plugins/governance_plugin.py
+++ b/argumentation_analysis/plugins/governance_plugin.py
@@ -155,7 +155,9 @@ class GovernancePlugin:
         data = json.loads(input_json)
         winner = condorcet_winner(data["ballots"], data["options"])
         matrix = pairwise_matrix(data["ballots"], data["options"])
-        return json.dumps({
-            "condorcet_winner": winner,
-            "pairwise_matrix": matrix,
-        })
+        return json.dumps(
+            {
+                "condorcet_winner": winner,
+                "pairwise_matrix": matrix,
+            }
+        )

--- a/argumentation_analysis/plugins/identification_models.py
+++ b/argumentation_analysis/plugins/identification_models.py
@@ -1,4 +1,5 @@
 """Pydantic models for structured fallacy identification output."""
+
 from typing import List, Optional
 from pydantic import BaseModel, Field
 

--- a/argumentation_analysis/plugins/quality_scoring_plugin.py
+++ b/argumentation_analysis/plugins/quality_scoring_plugin.py
@@ -44,17 +44,17 @@ class QualityScoringPlugin:
 
     @kernel_function(
         name="get_quality_score",
-        description=(
-            "Get the overall quality score (0-9) for an argument text."
-        ),
+        description=("Get the overall quality score (0-9) for an argument text."),
     )
     def get_quality_score(self, text: str) -> str:
         """Return just the overall quality score as JSON."""
         result = self.evaluator.evaluate(text)
-        return json.dumps({
-            "note_finale": result["note_finale"],
-            "note_moyenne": result["note_moyenne"],
-        })
+        return json.dumps(
+            {
+                "note_finale": result["note_finale"],
+                "note_moyenne": result["note_moyenne"],
+            }
+        )
 
     @kernel_function(
         name="list_virtues",

--- a/argumentation_analysis/plugins/ranking_plugin.py
+++ b/argumentation_analysis/plugins/ranking_plugin.py
@@ -23,7 +23,9 @@ class RankingPlugin:
     )
     def rank_arguments(self, arguments_json: str) -> str:
         """Rank arguments and return ordered comparisons."""
-        from argumentation_analysis.agents.core.logic.ranking_handler import RankingHandler
+        from argumentation_analysis.agents.core.logic.ranking_handler import (
+            RankingHandler,
+        )
 
         data = json.loads(arguments_json)
         handler = RankingHandler()
@@ -40,6 +42,8 @@ class RankingPlugin:
     )
     def list_ranking_methods(self) -> str:
         """Return available ranking method names."""
-        from argumentation_analysis.agents.core.logic.ranking_handler import RankingHandler
+        from argumentation_analysis.agents.core.logic.ranking_handler import (
+            RankingHandler,
+        )
 
         return json.dumps(list(RankingHandler.REASONERS.keys()), ensure_ascii=False)

--- a/argumentation_analysis/plugins/tweety_logic_plugin.py
+++ b/argumentation_analysis/plugins/tweety_logic_plugin.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 _JVM_AVAILABLE = False
 try:
     import jpype
+
     _JVM_AVAILABLE = jpype.isJVMStarted()
 except ImportError:
     pass
@@ -48,6 +49,7 @@ def _check_jvm() -> bool:
         return True
     try:
         import jpype as jp
+
         if jp.isJVMStarted():
             _JVM_AVAILABLE = True
             return True
@@ -58,13 +60,17 @@ def _check_jvm() -> bool:
 
 def _jvm_required(func):
     """Decorator that checks JVM availability before calling handler."""
+
     def wrapper(self, *args, **kwargs):
         if not _check_jvm():
-            return json.dumps({
-                "error": "JVM not available",
-                "message": "Tweety requires JVM. Start it via jvm_setup.initialize_jvm().",
-            })
+            return json.dumps(
+                {
+                    "error": "JVM not available",
+                    "message": "Tweety requires JVM. Start it via jvm_setup.initialize_jvm().",
+                }
+            )
         return func(self, *args, **kwargs)
+
     wrapper.__name__ = func.__name__
     wrapper.__doc__ = func.__doc__
     return wrapper
@@ -96,6 +102,7 @@ class TweetyLogicPlugin:
     def analyze_dung_framework(self, input: str) -> str:
         params = _parse_json_or_default(input, {"arguments": [], "attacks": []})
         from argumentation_analysis.agents.core.logic.af_handler import AFHandler
+
         handler = AFHandler()
         args = params.get("arguments", [])
         attacks = params.get("attacks", [])
@@ -117,6 +124,7 @@ class TweetyLogicPlugin:
     def check_propositional_consistency(self, input: str) -> str:
         params = _parse_json_or_default(input, {"formulas": [input]})
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
         bridge = TweetyBridge()
         formulas = params.get("formulas", [input])
         kb_str = "\n".join(formulas)
@@ -137,6 +145,7 @@ class TweetyLogicPlugin:
     def check_fol_consistency(self, input: str) -> str:
         params = _parse_json_or_default(input, {"formulas": [input]})
         from argumentation_analysis.agents.core.logic.fol_handler import FOLHandler
+
         handler = FOLHandler()
         formulas = params.get("formulas", [input])
         result = handler.check_consistency(formulas)
@@ -156,6 +165,7 @@ class TweetyLogicPlugin:
     def check_modal_satisfiability(self, input: str) -> str:
         params = _parse_json_or_default(input, {"formula": input})
         from argumentation_analysis.agents.core.logic.modal_handler import ModalHandler
+
         handler = ModalHandler()
         formula = params.get("formula", input)
         logic_type = params.get("logic_type", "S5")
@@ -176,7 +186,10 @@ class TweetyLogicPlugin:
     @_jvm_required
     def rank_arguments(self, input: str) -> str:
         params = _parse_json_or_default(input, {})
-        from argumentation_analysis.agents.core.logic.ranking_handler import RankingHandler
+        from argumentation_analysis.agents.core.logic.ranking_handler import (
+            RankingHandler,
+        )
+
         handler = RankingHandler()
         args = params.get("arguments", [])
         attacks = params.get("attacks", [])
@@ -198,7 +211,10 @@ class TweetyLogicPlugin:
     @_jvm_required
     def analyze_bipolar_framework(self, input: str) -> str:
         params = _parse_json_or_default(input, {})
-        from argumentation_analysis.agents.core.logic.bipolar_handler import BipolarHandler
+        from argumentation_analysis.agents.core.logic.bipolar_handler import (
+            BipolarHandler,
+        )
+
         handler = BipolarHandler()
         result = handler.analyze_bipolar_framework(
             params.get("arguments", []),
@@ -223,6 +239,7 @@ class TweetyLogicPlugin:
     def analyze_aba(self, input: str) -> str:
         params = _parse_json_or_default(input, {})
         from argumentation_analysis.agents.core.logic.aba_handler import ABAHandler
+
         handler = ABAHandler()
         result = handler.analyze_aba_framework(
             params.get("assumptions", []),
@@ -247,6 +264,7 @@ class TweetyLogicPlugin:
     def analyze_adf(self, input: str) -> str:
         params = _parse_json_or_default(input, {})
         from argumentation_analysis.agents.core.logic.adf_handler import ADFHandler
+
         handler = ADFHandler()
         result = handler.analyze_adf(
             params.get("statements", []),
@@ -269,6 +287,7 @@ class TweetyLogicPlugin:
     def analyze_aspic(self, input: str) -> str:
         params = _parse_json_or_default(input, {})
         from argumentation_analysis.agents.core.logic.aspic_handler import ASPICHandler
+
         handler = ASPICHandler()
         result = handler.analyze_aspic_framework(
             params.get("strict_rules", []),
@@ -290,7 +309,10 @@ class TweetyLogicPlugin:
     @_jvm_required
     def revise_beliefs(self, input: str) -> str:
         params = _parse_json_or_default(input, {"belief_set": [], "new_belief": input})
-        from argumentation_analysis.agents.core.logic.belief_revision_handler import BeliefRevisionHandler
+        from argumentation_analysis.agents.core.logic.belief_revision_handler import (
+            BeliefRevisionHandler,
+        )
+
         handler = BeliefRevisionHandler()
         result = handler.revise(
             params.get("belief_set", []),
@@ -313,7 +335,10 @@ class TweetyLogicPlugin:
     @_jvm_required
     def analyze_probabilistic(self, input: str) -> str:
         params = _parse_json_or_default(input, {})
-        from argumentation_analysis.agents.core.logic.probabilistic_handler import ProbabilisticHandler
+        from argumentation_analysis.agents.core.logic.probabilistic_handler import (
+            ProbabilisticHandler,
+        )
+
         handler = ProbabilisticHandler()
         result = handler.analyze_probabilistic_framework(
             params.get("arguments", []),
@@ -336,7 +361,10 @@ class TweetyLogicPlugin:
     @_jvm_required
     def execute_dialogue(self, input: str) -> str:
         params = _parse_json_or_default(input, {"topic": input})
-        from argumentation_analysis.agents.core.logic.dialogue_handler import DialogueHandler
+        from argumentation_analysis.agents.core.logic.dialogue_handler import (
+            DialogueHandler,
+        )
+
         handler = DialogueHandler()
         result = handler.execute_dialogue(
             params.get("proponent_args", []),
@@ -363,7 +391,10 @@ class TweetyLogicPlugin:
     def check_dl_consistency(self, input: str) -> str:
         params = _parse_json_or_default(input, {})
         from argumentation_analysis.agents.core.logic.dl_handler import DLHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
+
         initializer = TweetyInitializer()
         handler = DLHandler(initializer)
         kb = handler.create_knowledge_base(
@@ -389,7 +420,10 @@ class TweetyLogicPlugin:
     def query_conditional_logic(self, input: str) -> str:
         params = _parse_json_or_default(input, {})
         from argumentation_analysis.agents.core.logic.cl_handler import CLHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
+
         initializer = TweetyInitializer()
         handler = CLHandler(initializer)
         kb = handler.create_knowledge_base(
@@ -397,7 +431,9 @@ class TweetyLogicPlugin:
         )
         query_conclusion = params.get("query_conclusion")
         if query_conclusion:
-            entailed, msg = handler.query(kb, query_conclusion, params.get("query_premise"))
+            entailed, msg = handler.query(
+                kb, query_conclusion, params.get("query_premise")
+            )
         else:
             entailed, msg = True, "KB constructed, no query specified."
         return json.dumps({"entailed": entailed, "message": msg})
@@ -425,15 +461,20 @@ class TweetyLogicPlugin:
         if mode == "mus":
             try:
                 mus = handler.find_mus(formulas)
-                return json.dumps({"mode": "mus", "mus_count": len(mus), "subsets": mus})
+                return json.dumps(
+                    {"mode": "mus", "mus_count": len(mus), "subsets": mus}
+                )
             except RuntimeError as e:
                 return json.dumps({"error": str(e)})
         is_sat, model, stats = handler.solve_formulas(formulas)
-        return json.dumps({
-            "satisfiable": is_sat,
-            "model": model,
-            "statistics": stats,
-        }, default=str)
+        return json.dumps(
+            {
+                "satisfiable": is_sat,
+                "model": model,
+                "statistics": stats,
+            },
+            default=str,
+        )
 
     @kernel_function(
         name="analyze_setaf",
@@ -443,7 +484,10 @@ class TweetyLogicPlugin:
     def analyze_setaf(self, input: str) -> str:
         params = _parse_json_or_default(input, {"arguments": [], "set_attacks": []})
         from argumentation_analysis.agents.core.logic.setaf_handler import SetAFHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
+
         initializer = TweetyInitializer()
         handler = SetAFHandler(initializer)
         result = handler.analyze_setaf(
@@ -459,9 +503,16 @@ class TweetyLogicPlugin:
     )
     @_jvm_required
     def analyze_weighted_framework(self, input: str) -> str:
-        params = _parse_json_or_default(input, {"arguments": [], "weighted_attacks": []})
-        from argumentation_analysis.agents.core.logic.weighted_handler import WeightedHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+        params = _parse_json_or_default(
+            input, {"arguments": [], "weighted_attacks": []}
+        )
+        from argumentation_analysis.agents.core.logic.weighted_handler import (
+            WeightedHandler,
+        )
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
+
         initializer = TweetyInitializer()
         handler = WeightedHandler(initializer)
         result = handler.analyze_weighted_framework(
@@ -478,13 +529,20 @@ class TweetyLogicPlugin:
     @_jvm_required
     def analyze_social_framework(self, input: str) -> str:
         params = _parse_json_or_default(input, {"arguments": [], "attacks": []})
-        from argumentation_analysis.agents.core.logic.social_handler import SocialHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+        from argumentation_analysis.agents.core.logic.social_handler import (
+            SocialHandler,
+        )
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
+
         initializer = TweetyInitializer()
         handler = SocialHandler(initializer)
         votes = params.get("votes", {})
         if votes:
-            votes = {k: tuple(v) if isinstance(v, list) else v for k, v in votes.items()}
+            votes = {
+                k: tuple(v) if isinstance(v, list) else v for k, v in votes.items()
+            }
         result = handler.analyze_social_framework(
             arguments=params.get("arguments", []),
             attacks=params.get("attacks", []),
@@ -500,7 +558,10 @@ class TweetyLogicPlugin:
     def analyze_epistemic_framework(self, input: str) -> str:
         params = _parse_json_or_default(input, {"arguments": [], "attacks": []})
         from argumentation_analysis.agents.core.logic.eaf_handler import EAFHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
+
         initializer = TweetyInitializer()
         handler = EAFHandler(initializer)
         result = handler.analyze_epistemic_framework(
@@ -519,7 +580,10 @@ class TweetyLogicPlugin:
     def analyze_delp(self, input: str) -> str:
         params = _parse_json_or_default(input, {"program": input})
         from argumentation_analysis.agents.core.logic.delp_handler import DeLPHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
+
         initializer = TweetyInitializer()
         handler = DeLPHandler(initializer)
         result = handler.analyze_delp(
@@ -537,7 +601,10 @@ class TweetyLogicPlugin:
     def check_qbf(self, input: str) -> str:
         params = _parse_json_or_default(input, {"formula": input, "quantifiers": []})
         from argumentation_analysis.agents.core.logic.qbf_handler import QBFHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
+
         initializer = TweetyInitializer()
         handler = QBFHandler(initializer)
         result = handler.analyze_qbf(

--- a/argumentation_analysis/services/mcp_server/main.py
+++ b/argumentation_analysis/services/mcp_server/main.py
@@ -589,12 +589,8 @@ class MCPService:
             "list_workflows": {
                 "description": "Liste les workflows d'analyse disponibles"
             },
-            "run_workflow": {
-                "description": "Exécute un workflow d'analyse nommé"
-            },
-            "get_workflow_details": {
-                "description": "Détails d'un workflow spécifique"
-            },
+            "run_workflow": {"description": "Exécute un workflow d'analyse nommé"},
+            "get_workflow_details": {"description": "Détails d'un workflow spécifique"},
             "start_conversation": {
                 "description": "Démarre une conversation d'analyse multi-tour"
             },
@@ -607,9 +603,7 @@ class MCPService:
             "list_capabilities": {
                 "description": "Liste les capacités enregistrées et leurs fournisseurs"
             },
-            "invoke_capability": {
-                "description": "Invoque une capacité par nom"
-            },
+            "invoke_capability": {"description": "Invoque une capacité par nom"},
             "get_registry_summary": {
                 "description": "Résumé détaillé du registre de capacités"
             },

--- a/argumentation_analysis/services/mcp_server/session_manager.py
+++ b/argumentation_analysis/services/mcp_server/session_manager.py
@@ -43,7 +43,9 @@ class SessionManager:
         if len(self._sessions) >= self._max_sessions:
             oldest = min(self._sessions.values(), key=lambda s: s.last_accessed)
             del self._sessions[oldest.session_id]
-            logger.info("Evicted oldest session %s (max sessions reached)", oldest.session_id)
+            logger.info(
+                "Evicted oldest session %s (max sessions reached)", oldest.session_id
+            )
 
         session_id = str(uuid.uuid4())
         now = time.time()

--- a/argumentation_analysis/services/mcp_server/tools/_serialization.py
+++ b/argumentation_analysis/services/mcp_server/tools/_serialization.py
@@ -17,7 +17,5 @@ def safe_serialize(obj: Any) -> Any:
     if isinstance(obj, Enum):
         return obj.value
     if hasattr(obj, "__dataclass_fields__"):
-        return {
-            k: safe_serialize(getattr(obj, k)) for k in obj.__dataclass_fields__
-        }
+        return {k: safe_serialize(getattr(obj, k)) for k in obj.__dataclass_fields__}
     return str(obj)

--- a/argumentation_analysis/services/mcp_server/tools/capability_tools.py
+++ b/argumentation_analysis/services/mcp_server/tools/capability_tools.py
@@ -27,9 +27,7 @@ def register_capability_tools(mcp: Any, get_registry: Any) -> None:
             summary = registry.summary()
             return {
                 "capabilities": safe_serialize(caps),
-                "unfilled_slots": {
-                    name: s.description for name, s in slots.items()
-                },
+                "unfilled_slots": {name: s.description for name, s in slots.items()},
                 "summary": safe_serialize(summary),
             }
         except Exception as e:

--- a/argumentation_analysis/services/mcp_server/tools/conversation_tools.py
+++ b/argumentation_analysis/services/mcp_server/tools/conversation_tools.py
@@ -45,9 +45,7 @@ def register_conversation_tools(
             )
 
             # Run first round
-            round_result = await _execute_round(
-                get_registry, session, round_number=1
-            )
+            round_result = await _execute_round(get_registry, session, round_number=1)
             sm.update_session(session.session_id, round_result)
 
             return {

--- a/argumentation_analysis/services/mcp_server/tools/specialized_tools.py
+++ b/argumentation_analysis/services/mcp_server/tools/specialized_tools.py
@@ -55,9 +55,7 @@ def register_specialized_tools(mcp: Any, get_registry: Any) -> None:
         Args:
             text: The argumentative text to evaluate.
         """
-        return await _invoke_by_capability(
-            "argument_quality", text, "evaluate_quality"
-        )
+        return await _invoke_by_capability("argument_quality", text, "evaluate_quality")
 
     @mcp.tool()
     async def generate_counter_argument(text: str) -> Dict[str, Any]:

--- a/argumentation_analysis/services/websocket_manager.py
+++ b/argumentation_analysis/services/websocket_manager.py
@@ -36,7 +36,9 @@ class AnalysisWebSocketManager:
             if session_id not in self._connections:
                 self._connections[session_id] = set()
             self._connections[session_id].add(websocket)
-        logger.info(f"WS connected: session={session_id}, total={len(self._connections.get(session_id, set()))}")
+        logger.info(
+            f"WS connected: session={session_id}, total={len(self._connections.get(session_id, set()))}"
+        )
 
     async def disconnect(self, session_id: str, websocket: WebSocket):
         """Remove a WebSocket from a session."""
@@ -88,14 +90,17 @@ class AnalysisWebSocketManager:
         total_phases: int = 0,
     ):
         """Broadcast a workflow phase completion event."""
-        await self._send_to_session(session_id, {
-            "type": "phase_result",
-            "phase": phase_name,
-            "phase_index": phase_index,
-            "total_phases": total_phases,
-            "result": _safe_serialize(result),
-            "timestamp": time.time(),
-        })
+        await self._send_to_session(
+            session_id,
+            {
+                "type": "phase_result",
+                "phase": phase_name,
+                "phase_index": phase_index,
+                "total_phases": total_phases,
+                "result": _safe_serialize(result),
+                "timestamp": time.time(),
+            },
+        )
 
     async def broadcast_debate_turn(
         self,
@@ -107,15 +112,18 @@ class AnalysisWebSocketManager:
         argument_type: str = "claim",
     ):
         """Broadcast a debate turn event."""
-        await self._send_to_session(session_id, {
-            "type": "debate_turn",
-            "agent": agent,
-            "argument": argument,
-            "argument_type": argument_type,
-            "scores": scores or {},
-            "round": round_num,
-            "timestamp": time.time(),
-        })
+        await self._send_to_session(
+            session_id,
+            {
+                "type": "debate_turn",
+                "agent": agent,
+                "argument": argument,
+                "argument_type": argument_type,
+                "scores": scores or {},
+                "round": round_num,
+                "timestamp": time.time(),
+            },
+        )
 
     async def broadcast_vote_update(
         self,
@@ -126,14 +134,17 @@ class AnalysisWebSocketManager:
         vote_counts: Optional[Dict[str, int]] = None,
     ):
         """Broadcast a vote update event."""
-        await self._send_to_session(session_id, {
-            "type": "vote_update",
-            "proposal_id": proposal_id,
-            "voter_id": voter_id,
-            "position": position,
-            "vote_counts": vote_counts or {},
-            "timestamp": time.time(),
-        })
+        await self._send_to_session(
+            session_id,
+            {
+                "type": "vote_update",
+                "proposal_id": proposal_id,
+                "voter_id": voter_id,
+                "position": position,
+                "vote_counts": vote_counts or {},
+                "timestamp": time.time(),
+            },
+        )
 
     async def broadcast_jtms_update(
         self,
@@ -144,31 +155,40 @@ class AnalysisWebSocketManager:
         justification: Optional[str] = None,
     ):
         """Broadcast a JTMS belief status change event."""
-        await self._send_to_session(session_id, {
-            "type": "jtms_update",
-            "belief": belief_name,
-            "old_status": old_status,
-            "new_status": new_status,
-            "justification": justification,
-            "timestamp": time.time(),
-        })
+        await self._send_to_session(
+            session_id,
+            {
+                "type": "jtms_update",
+                "belief": belief_name,
+                "old_status": old_status,
+                "new_status": new_status,
+                "justification": justification,
+                "timestamp": time.time(),
+            },
+        )
 
     async def broadcast_status(self, session_id: str, status: str, detail: str = ""):
         """Broadcast a generic status message."""
-        await self._send_to_session(session_id, {
-            "type": "status",
-            "status": status,
-            "detail": detail,
-            "timestamp": time.time(),
-        })
+        await self._send_to_session(
+            session_id,
+            {
+                "type": "status",
+                "status": status,
+                "detail": detail,
+                "timestamp": time.time(),
+            },
+        )
 
     async def broadcast_error(self, session_id: str, error: str):
         """Broadcast an error message."""
-        await self._send_to_session(session_id, {
-            "type": "error",
-            "error": error,
-            "timestamp": time.time(),
-        })
+        await self._send_to_session(
+            session_id,
+            {
+                "type": "error",
+                "error": error,
+                "timestamp": time.time(),
+            },
+        )
 
 
 def _safe_serialize(obj: Any) -> Any:
@@ -185,7 +205,11 @@ def _safe_serialize(obj: Any) -> Any:
         except Exception:
             pass
     if hasattr(obj, "__dict__"):
-        return {k: _safe_serialize(v) for k, v in obj.__dict__.items() if not k.startswith("_")}
+        return {
+            k: _safe_serialize(v)
+            for k, v in obj.__dict__.items()
+            if not k.startswith("_")
+        }
     return str(obj)
 
 

--- a/argumentation_analysis/workflows/formal_verification.py
+++ b/argumentation_analysis/workflows/formal_verification.py
@@ -27,7 +27,6 @@ from argumentation_analysis.orchestration.workflow_dsl import (
     WorkflowDefinition,
 )
 
-
 DEFAULT_INCONSISTENCY_THRESHOLD = 0.5
 
 
@@ -166,10 +165,16 @@ def build_formal_verification_workflow() -> WorkflowDefinition:
             "formal_synthesis",
             capability="formal_synthesis",
             depends_on=[
-                "ranking", "aspic_analysis", "belief_revision",
-                "adf_analysis", "bipolar_analysis", "setaf_analysis",
-                "dl_analysis", "cl_analysis",
-                "delp_analysis", "qbf_analysis",
+                "ranking",
+                "aspic_analysis",
+                "belief_revision",
+                "adf_analysis",
+                "bipolar_analysis",
+                "setaf_analysis",
+                "dl_analysis",
+                "cl_analysis",
+                "delp_analysis",
+                "qbf_analysis",
             ],
         )
         .set_metadata("domain", "formal_verification")
@@ -181,7 +186,9 @@ def build_formal_verification_workflow() -> WorkflowDefinition:
 
 async def run_formal_verification(text: str, **kwargs) -> Dict[str, Any]:
     """Convenience wrapper for running the formal verification workflow."""
-    from argumentation_analysis.orchestration.unified_pipeline import run_unified_analysis
+    from argumentation_analysis.orchestration.unified_pipeline import (
+        run_unified_analysis,
+    )
 
     return await run_unified_analysis(
         text, workflow_name="formal_verification", **kwargs

--- a/tests/agents/factories/test_agent_factory.py
+++ b/tests/agents/factories/test_agent_factory.py
@@ -62,7 +62,9 @@ class TestFactoryInit:
 class TestCreateAgentDispatch:
     """Tests for create_agent() routing to correct classes."""
 
-    @patch("argumentation_analysis.agents.factory.AgentFactory.create_informal_fallacy_agent")
+    @patch(
+        "argumentation_analysis.agents.factory.AgentFactory.create_informal_fallacy_agent"
+    )
     def test_dispatch_informal_fallacy(self, mock_create, factory):
         """AgentType.INFORMAL_FALLACY delegates to create_informal_fallacy_agent."""
         mock_agent = MagicMock()
@@ -288,12 +290,16 @@ class TestCreatePhase4Agents:
         mock_agent = MagicMock()
         MockCA.return_value = mock_agent
 
-        with patch.object(factory, "_create_agent", return_value=mock_agent) as mock_create:
+        with patch.object(
+            factory, "_create_agent", return_value=mock_agent
+        ) as mock_create:
             result = factory.create_counter_argument_agent()
             mock_create.assert_called_once()
             call_kwargs = mock_create.call_args
-            assert call_kwargs[1].get("agent_name") == "CounterArgumentAgent" or \
-                   call_kwargs.kwargs.get("agent_name") == "CounterArgumentAgent"
+            assert (
+                call_kwargs[1].get("agent_name") == "CounterArgumentAgent"
+                or call_kwargs.kwargs.get("agent_name") == "CounterArgumentAgent"
+            )
 
     @patch(
         "argumentation_analysis.agents.core.counter_argument.counter_agent.CounterArgumentAgent"
@@ -302,19 +308,21 @@ class TestCreatePhase4Agents:
         mock_agent = MagicMock()
         MockCA.return_value = mock_agent
 
-        with patch.object(factory, "_create_agent", return_value=mock_agent) as mock_create:
+        with patch.object(
+            factory, "_create_agent", return_value=mock_agent
+        ) as mock_create:
             factory.create_counter_argument_agent(agent_name="MyCA")
             call_kwargs = mock_create.call_args
             assert "MyCA" in str(call_kwargs)
 
-    @patch(
-        "argumentation_analysis.agents.core.debate.debate_agent.DebateAgent"
-    )
+    @patch("argumentation_analysis.agents.core.debate.debate_agent.DebateAgent")
     def test_create_debate_defaults(self, MockDebate, factory):
         mock_agent = MagicMock()
         MockDebate.return_value = mock_agent
 
-        with patch.object(factory, "_create_agent", return_value=mock_agent) as mock_create:
+        with patch.object(
+            factory, "_create_agent", return_value=mock_agent
+        ) as mock_create:
             result = factory.create_debate_agent()
             mock_create.assert_called_once()
             call_kwargs = mock_create.call_args
@@ -322,14 +330,14 @@ class TestCreatePhase4Agents:
             assert "The Scholar" in str(call_kwargs)
             assert result is mock_agent
 
-    @patch(
-        "argumentation_analysis.agents.core.debate.debate_agent.DebateAgent"
-    )
+    @patch("argumentation_analysis.agents.core.debate.debate_agent.DebateAgent")
     def test_create_debate_custom_params(self, MockDebate, factory):
         mock_agent = MagicMock()
         MockDebate.return_value = mock_agent
 
-        with patch.object(factory, "_create_agent", return_value=mock_agent) as mock_create:
+        with patch.object(
+            factory, "_create_agent", return_value=mock_agent
+        ) as mock_create:
             factory.create_debate_agent(
                 agent_name="CustomDebater",
                 personality="The Diplomat",

--- a/tests/integration/jpype_tweety/workers/worker_advanced_reasoning.py
+++ b/tests/integration/jpype_tweety/workers/worker_advanced_reasoning.py
@@ -42,8 +42,8 @@ def setup_jvm():
 
     project_root = get_project_root_from_env()
     libs_dir = project_root / "libs" / "tweety"
-    full_jar_path = (
-        next(libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None)
+    full_jar_path = next(
+        libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None
     )
     if not full_jar_path or not full_jar_path.exists():
         raise FileNotFoundError(

--- a/tests/integration/jpype_tweety/workers/worker_argumentation_syntax.py
+++ b/tests/integration/jpype_tweety/workers/worker_argumentation_syntax.py
@@ -31,8 +31,8 @@ def setup_jvm():
 
     project_root = get_project_root_from_env()
     libs_dir = project_root / "libs" / "tweety"
-    full_jar_path = (
-        next(libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None)
+    full_jar_path = next(
+        libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None
     )
     if not full_jar_path or not full_jar_path.exists():
         raise FileNotFoundError(

--- a/tests/integration/jpype_tweety/workers/worker_dialogical_argumentation.py
+++ b/tests/integration/jpype_tweety/workers/worker_dialogical_argumentation.py
@@ -31,8 +31,8 @@ def setup_jvm():
 
     project_root = get_project_root_from_env()
     libs_dir = project_root / "libs" / "tweety"
-    full_jar_path = (
-        next(libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None)
+    full_jar_path = next(
+        libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None
     )
     if not full_jar_path or not full_jar_path.exists():
         raise FileNotFoundError(

--- a/tests/integration/jpype_tweety/workers/worker_jvm_stability.py
+++ b/tests/integration/jpype_tweety/workers/worker_jvm_stability.py
@@ -41,8 +41,8 @@ def test_jvm_stability_logic():
             f"Le répertoire des bibliothèques Tweety n'existe pas : {libs_dir}"
         )
 
-    full_jar_path = (
-        next(libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None)
+    full_jar_path = next(
+        libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None
     )
     if not full_jar_path or not full_jar_path.exists():
         raise FileNotFoundError(

--- a/tests/integration/jpype_tweety/workers/worker_logic_operations.py
+++ b/tests/integration/jpype_tweety/workers/worker_logic_operations.py
@@ -31,8 +31,8 @@ def setup_jvm():
 
     project_root = get_project_root_from_env()
     libs_dir = project_root / "libs" / "tweety"
-    full_jar_path = (
-        next(libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None)
+    full_jar_path = next(
+        libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None
     )
     if not full_jar_path or not full_jar_path.exists():
         raise FileNotFoundError(

--- a/tests/integration/jpype_tweety/workers/worker_minimal_jvm_startup.py
+++ b/tests/integration/jpype_tweety/workers/worker_minimal_jvm_startup.py
@@ -41,8 +41,8 @@ def test_minimal_startup_logic():
     # Pour un test de démarrage minimal, le classpath peut être vide ou pointer
     # vers un JAR connu et non corrompu si on veut tester le chargement.
     # Pour rester minimal, on utilise que le JAR 'tweety-full'.
-    full_jar_path = (
-        next(libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None)
+    full_jar_path = next(
+        libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None
     )
     if not full_jar_path or not full_jar_path.exists():
         # On ne peut pas continuer sans le jar.

--- a/tests/integration/jpype_tweety/workers/worker_qbf.py
+++ b/tests/integration/jpype_tweety/workers/worker_qbf.py
@@ -31,8 +31,8 @@ def setup_jvm():
 
     project_root = get_project_root_from_env()
     libs_dir = project_root / "libs" / "tweety"
-    full_jar_path = (
-        next(libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None)
+    full_jar_path = next(
+        libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None
     )
     if not full_jar_path or not full_jar_path.exists():
         raise FileNotFoundError(

--- a/tests/integration/jpype_tweety/workers/worker_theory_operations.py
+++ b/tests/integration/jpype_tweety/workers/worker_theory_operations.py
@@ -31,8 +31,8 @@ def setup_jvm():
 
     project_root = get_project_root_from_env()
     libs_dir = project_root / "libs" / "tweety"
-    full_jar_path = (
-        next(libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None)
+    full_jar_path = next(
+        libs_dir.glob("org.tweetyproject.tweety-full-*-with-dependencies.jar"), None
     )
     if not full_jar_path or not full_jar_path.exists():
         raise FileNotFoundError(

--- a/tests/integration/test_authentic_components.py
+++ b/tests/integration/test_authentic_components.py
@@ -138,7 +138,11 @@ class TestAuthenticTweetyIntegration:
     def test_real_tweety_jar_availability(self):
         """Test de disponibilité du JAR Tweety authentique."""
         # Chemins possibles pour le JAR Tweety
-        possible_jar_paths = list(PROJECT_ROOT.glob("libs/tweety/org.tweetyproject.tweety-full-*-with-dependencies.jar")) + [
+        possible_jar_paths = list(
+            PROJECT_ROOT.glob(
+                "libs/tweety/org.tweetyproject.tweety-full-*-with-dependencies.jar"
+            )
+        ) + [
             PROJECT_ROOT / "libs/tweety-full.jar",
             PROJECT_ROOT / "libs/tweety.jar",
         ]

--- a/tests/integration/test_authentic_components_integration.py
+++ b/tests/integration/test_authentic_components_integration.py
@@ -114,7 +114,11 @@ class TestRealTweetyIntegration:
             pytest.skip("jpype not available")
 
         # Vérifier l'existence du JAR Tweety
-        tweety_jar_globs = list(Path(".").glob("libs/tweety/org.tweetyproject.tweety-full-*-with-dependencies.jar"))
+        tweety_jar_globs = list(
+            Path(".").glob(
+                "libs/tweety/org.tweetyproject.tweety-full-*-with-dependencies.jar"
+            )
+        )
         tweety_jar_paths = [str(p) for p in tweety_jar_globs] + [
             "libs/tweety.jar",
             "services/tweety/tweety.jar",
@@ -199,7 +203,11 @@ class TestRealTweetyIntegration:
                 return False
         except ImportError:
             return False
-        jar_globs = list(Path(".").glob("libs/tweety/org.tweetyproject.tweety-full-*-with-dependencies.jar"))
+        jar_globs = list(
+            Path(".").glob(
+                "libs/tweety/org.tweetyproject.tweety-full-*-with-dependencies.jar"
+            )
+        )
         jar_paths = [str(p) for p in jar_globs] + [
             "libs/tweety.jar",
             "services/tweety/tweety.jar",

--- a/tests/minimal_jpype_tweety_tests/test_list_models.py
+++ b/tests/minimal_jpype_tweety_tests/test_list_models.py
@@ -15,7 +15,12 @@ all_jars_in_libs = [
     os.path.join(LIBS_DIR, f) for f in os.listdir(LIBS_DIR) if f.endswith(".jar")
 ]
 _with_deps = [j for j in all_jars_in_libs if "with-dependencies" in os.path.basename(j)]
-_simple = [j for j in all_jars_in_libs if "tweety-full" in os.path.basename(j) and "with-dependencies" not in os.path.basename(j)]
+_simple = [
+    j
+    for j in all_jars_in_libs
+    if "tweety-full" in os.path.basename(j)
+    and "with-dependencies" not in os.path.basename(j)
+]
 TWEETY_JARS = _with_deps if _with_deps else _simple if _simple else all_jars_in_libs
 
 print(f"Dynamically included JARS for test_list_models: {TWEETY_JARS}")

--- a/tests/minimal_jpype_tweety_tests/test_load_theory.py
+++ b/tests/minimal_jpype_tweety_tests/test_load_theory.py
@@ -13,7 +13,12 @@ all_jars_in_libs = [
     os.path.join(LIBS_DIR, f) for f in os.listdir(LIBS_DIR) if f.endswith(".jar")
 ]
 _with_deps = [j for j in all_jars_in_libs if "with-dependencies" in os.path.basename(j)]
-_simple = [j for j in all_jars_in_libs if "tweety-full" in os.path.basename(j) and "with-dependencies" not in os.path.basename(j)]
+_simple = [
+    j
+    for j in all_jars_in_libs
+    if "tweety-full" in os.path.basename(j)
+    and "with-dependencies" not in os.path.basename(j)
+]
 TWEETY_JARS = _with_deps if _with_deps else _simple if _simple else all_jars_in_libs
 
 print(f"Dynamically included JARS for test_load_theory: {TWEETY_JARS}")

--- a/tests/minimal_jpype_tweety_tests/test_reasoner_query.py
+++ b/tests/minimal_jpype_tweety_tests/test_reasoner_query.py
@@ -12,12 +12,18 @@ NATIVE_LIBS_DIR = os.path.join(LIBS_DIR, "native")
 
 # Inclure tous les JARs du répertoire libs, en préférant le JAR with-dependencies
 import glob as _glob
+
 all_jars_in_libs = [
     os.path.join(LIBS_DIR, f) for f in os.listdir(LIBS_DIR) if f.endswith(".jar")
 ]
 # Prefer the uber-JAR (with-dependencies), exclude the simple one if both exist
 _with_deps = [j for j in all_jars_in_libs if "with-dependencies" in os.path.basename(j)]
-_simple = [j for j in all_jars_in_libs if "tweety-full" in os.path.basename(j) and "with-dependencies" not in os.path.basename(j)]
+_simple = [
+    j
+    for j in all_jars_in_libs
+    if "tweety-full" in os.path.basename(j)
+    and "with-dependencies" not in os.path.basename(j)
+]
 TWEETY_JARS = _with_deps if _with_deps else _simple if _simple else all_jars_in_libs
 
 print(f"Dynamically included JARS for test_reasoner_query: {TWEETY_JARS}")

--- a/tests/performance/test_integration_benchmarks.py
+++ b/tests/performance/test_integration_benchmarks.py
@@ -31,6 +31,7 @@ pytestmark = pytest.mark.performance
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def timed(func, *args, **kwargs):
     """Run func and return (result, elapsed_seconds)."""
     gc.collect()
@@ -61,6 +62,7 @@ SAMPLE_ARGUMENT_FR_3 = (
 # ===========================================================================
 # 1. CapabilityRegistry Benchmarks
 # ===========================================================================
+
 
 class TestRegistryPerformance:
     """Benchmark CapabilityRegistry registration and lookup speed."""
@@ -96,7 +98,9 @@ class TestRegistryPerformance:
 
         avg_ms = (sum(times) / len(times)) * 1000 if times else 0
         max_ms = max(times) * 1000 if times else 0
-        print(f"\n  Capability lookups ({len(times)}): avg={avg_ms:.2f}ms, max={max_ms:.2f}ms")
+        print(
+            f"\n  Capability lookups ({len(times)}): avg={avg_ms:.2f}ms, max={max_ms:.2f}ms"
+        )
         assert max_ms < 50, f"Max lookup took {max_ms:.2f}ms (limit: 50ms)"
 
     def test_registry_capabilities_count(self):
@@ -106,19 +110,25 @@ class TestRegistryPerformance:
         registry = setup_registry(include_optional=True)
         caps = registry.get_all_capabilities()
         print(f"\n  Registered capabilities: {len(caps)}")
-        assert len(caps) >= 15, f"Only {len(caps)} capabilities registered (expected >= 15)"
+        assert (
+            len(caps) >= 15
+        ), f"Only {len(caps)} capabilities registered (expected >= 15)"
 
 
 # ===========================================================================
 # 2. QualityScoringPlugin Benchmarks
 # ===========================================================================
 
+
 class TestQualityScoringPerformance:
     """Benchmark argument quality evaluation."""
 
     @pytest.fixture
     def plugin(self):
-        from argumentation_analysis.plugins.quality_scoring_plugin import QualityScoringPlugin
+        from argumentation_analysis.plugins.quality_scoring_plugin import (
+            QualityScoringPlugin,
+        )
+
         return QualityScoringPlugin()
 
     def test_evaluate_argument_quality_time(self, plugin):
@@ -135,7 +145,11 @@ class TestQualityScoringPerformance:
 
     def test_batch_evaluation_scalability(self, plugin):
         """10 sequential evaluations should show linear scaling."""
-        texts = [SAMPLE_ARGUMENT_FR, SAMPLE_ARGUMENT_FR_2, SAMPLE_ARGUMENT_FR_3] * 4  # 12 texts
+        texts = [
+            SAMPLE_ARGUMENT_FR,
+            SAMPLE_ARGUMENT_FR_2,
+            SAMPLE_ARGUMENT_FR_3,
+        ] * 4  # 12 texts
 
         gc.collect()
         start = time.perf_counter()
@@ -159,12 +173,14 @@ class TestQualityScoringPerformance:
 # 3. GovernancePlugin Benchmarks
 # ===========================================================================
 
+
 class TestGovernancePerformance:
     """Benchmark governance voting and conflict detection."""
 
     @pytest.fixture
     def plugin(self):
         from argumentation_analysis.plugins.governance_plugin import GovernancePlugin
+
         return GovernancePlugin()
 
     def _make_positions(self, n_agents):
@@ -180,7 +196,9 @@ class TestGovernancePerformance:
         """Listing methods should be near-instant."""
         _, elapsed = timed(plugin.list_governance_methods)
         result = json.loads(plugin.list_governance_methods())
-        print(f"\n  list_governance_methods: {elapsed * 1000:.2f}ms, {len(result)} methods")
+        print(
+            f"\n  list_governance_methods: {elapsed * 1000:.2f}ms, {len(result)} methods"
+        )
         assert elapsed < 0.01
 
     def test_conflict_detection_5_agents(self, plugin):
@@ -205,7 +223,9 @@ class TestGovernancePerformance:
             _, elapsed = timed(plugin.detect_conflicts_fn, positions)
             times[n] = elapsed * 1000
 
-        print(f"\n  Scalability: " + ", ".join(f"{n}={t:.1f}ms" for n, t in times.items()))
+        print(
+            f"\n  Scalability: " + ", ".join(f"{n}={t:.1f}ms" for n, t in times.items())
+        )
         # 50-agent time should be < 20x the 5-agent time (sub-quadratic)
         if times[5] > 0:
             ratio = times[50] / times[5]
@@ -217,12 +237,16 @@ class TestGovernancePerformance:
 # 4. CounterArgumentPlugin Benchmarks
 # ===========================================================================
 
+
 class TestCounterArgumentPerformance:
     """Benchmark counter-argument generation pipeline."""
 
     @pytest.fixture
     def plugin(self):
-        from argumentation_analysis.agents.core.counter_argument import CounterArgumentPlugin
+        from argumentation_analysis.agents.core.counter_argument import (
+            CounterArgumentPlugin,
+        )
+
         return CounterArgumentPlugin()
 
     def test_parse_argument_time(self, plugin):
@@ -260,12 +284,14 @@ class TestCounterArgumentPerformance:
 # 5. DebatePlugin Benchmarks
 # ===========================================================================
 
+
 class TestDebatePerformance:
     """Benchmark debate analysis operations."""
 
     @pytest.fixture
     def plugin(self):
         from argumentation_analysis.agents.core.debate.debate_agent import DebatePlugin
+
         return DebatePlugin()
 
     def test_analyze_argument_quality_time(self, plugin):
@@ -292,7 +318,9 @@ class TestDebatePerformance:
         total = time.perf_counter() - start
 
         avg_ms = (total / 10) * 1000
-        print(f"\n  Batch (10 args, quality+structure): total={total:.3f}s, avg={avg_ms:.1f}ms/arg")
+        print(
+            f"\n  Batch (10 args, quality+structure): total={total:.3f}s, avg={avg_ms:.1f}ms/arg"
+        )
         assert total < 2.0
 
 
@@ -300,12 +328,15 @@ class TestDebatePerformance:
 # 6. UnifiedPipeline Workflow Benchmarks
 # ===========================================================================
 
+
 class TestPipelinePerformance:
     """Benchmark unified pipeline workflow construction."""
 
     def test_build_light_workflow_time(self):
         """Light workflow should build in under 100ms."""
-        from argumentation_analysis.orchestration.unified_pipeline import build_light_workflow
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            build_light_workflow,
+        )
 
         _, elapsed = timed(build_light_workflow)
         print(f"\n  build_light_workflow: {elapsed * 1000:.1f}ms")
@@ -313,7 +344,9 @@ class TestPipelinePerformance:
 
     def test_build_standard_workflow_time(self):
         """Standard workflow should build in under 200ms."""
-        from argumentation_analysis.orchestration.unified_pipeline import build_standard_workflow
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            build_standard_workflow,
+        )
 
         _, elapsed = timed(build_standard_workflow)
         print(f"\n  build_standard_workflow: {elapsed * 1000:.1f}ms")
@@ -321,7 +354,9 @@ class TestPipelinePerformance:
 
     def test_build_full_workflow_time(self):
         """Full workflow should build in under 500ms."""
-        from argumentation_analysis.orchestration.unified_pipeline import build_full_workflow
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            build_full_workflow,
+        )
 
         _, elapsed = timed(build_full_workflow)
         print(f"\n  build_full_workflow: {elapsed * 1000:.1f}ms")

--- a/tests/unit/api/test_mobile_endpoints.py
+++ b/tests/unit/api/test_mobile_endpoints.py
@@ -8,6 +8,7 @@ Validates:
 - Input validation (text too short)
 - Graceful error handling when pipeline unavailable
 """
+
 import pytest
 from unittest.mock import patch, AsyncMock
 from fastapi.testclient import TestClient
@@ -27,7 +28,9 @@ class TestMobileAnalyze:
     def test_analyze_returns_200(self, client):
         resp = client.post(
             "/api/mobile/analyze",
-            json={"text": "All men are mortal. Socrates is a man. Therefore Socrates is mortal."},
+            json={
+                "text": "All men are mortal. Socrates is a man. Therefore Socrates is mortal."
+            },
         )
         assert resp.status_code == 200
         data = resp.json()
@@ -68,8 +71,10 @@ class TestMobileAnalyze:
         assert resp.status_code == 200
         data = resp.json()
         assert data["overall_quality"] == 0.0
-        assert any("error" in arg["id"].lower() or "unavailable" in arg["text"].lower()
-                    for arg in data["arguments"])
+        assert any(
+            "error" in arg["id"].lower() or "unavailable" in arg["text"].lower()
+            for arg in data["arguments"]
+        )
 
 
 # ──── Fallacies Endpoint ────
@@ -125,7 +130,9 @@ class TestMobileValidate:
     def test_validate_returns_200(self, client):
         resp = client.post(
             "/api/mobile/validate",
-            json={"text": "If it rains then the road is wet. It rains. Therefore the road is wet."},
+            json={
+                "text": "If it rains then the road is wet. It rains. Therefore the road is wet."
+            },
         )
         assert resp.status_code == 200
         data = resp.json()

--- a/tests/unit/api/test_proposal_api.py
+++ b/tests/unit/api/test_proposal_api.py
@@ -8,6 +8,7 @@ Validates:
 - Custom workflow endpoint
 - Error handling (404, 409)
 """
+
 import pytest
 from unittest.mock import patch, AsyncMock, MagicMock
 from fastapi.testclient import TestClient
@@ -101,7 +102,10 @@ class TestProposalListing:
         for i in range(5):
             client.post(
                 "/api/propose",
-                json={"text": f"Proposal number {i} text content", "author": f"user{i}"},
+                json={
+                    "text": f"Proposal number {i} text content",
+                    "author": f"user{i}",
+                },
             )
         resp = client.get("/api/proposals?limit=2&offset=0")
         assert len(resp.json()) == 2
@@ -222,7 +226,9 @@ class TestDeliberation:
         from api.proposal_models import ProposalCreate
 
         p = store.create_proposal(
-            ProposalCreate(text="Check deliberation status endpoint test", author="alice")
+            ProposalCreate(
+                text="Check deliberation status endpoint test", author="alice"
+            )
         )
         delib = store.create_deliberation(p.id, "light")
 

--- a/tests/unit/api/test_websocket_routes.py
+++ b/tests/unit/api/test_websocket_routes.py
@@ -5,6 +5,7 @@ Validates:
 - Ping/pong keepalive
 - Clean disconnect handling
 """
+
 import pytest
 from starlette.testclient import TestClient
 

--- a/tests/unit/argumentation_analysis/agents/core/abc/test_agent_bases.py
+++ b/tests/unit/argumentation_analysis/agents/core/abc/test_agent_bases.py
@@ -10,12 +10,13 @@ from unittest.mock import MagicMock, patch, AsyncMock, Mock
 import pytest
 
 from semantic_kernel import Kernel
-from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
+from semantic_kernel.connectors.ai.chat_completion_client_base import (
+    ChatCompletionClientBase,
+)
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
 
 from argumentation_analysis.agents.core.abc.agent_bases import BaseAgent, BaseLogicAgent
-
 
 # =====================================================================
 # BaseAgent Tests
@@ -244,7 +245,9 @@ class TestBaseLogicAgent:
             def generate_queries(self, text, belief_set, context=None):
                 pass
 
-            def interpret_results(self, text, belief_set, queries, results, context=None):
+            def interpret_results(
+                self, text, belief_set, queries, results, context=None
+            ):
                 pass
 
             def validate_formula(self, formula):
@@ -256,7 +259,9 @@ class TestBaseLogicAgent:
             def _create_belief_set_from_data(self, belief_set_data):
                 pass
 
-        agent = ConcreteLogicAgent(kernel, "LogicAgent", "PL", description="Logic Agent")
+        agent = ConcreteLogicAgent(
+            kernel, "LogicAgent", "PL", description="Logic Agent"
+        )
 
         assert agent.id == "LogicAgent"
         assert agent.description == "Logic Agent"
@@ -288,7 +293,9 @@ class TestBaseLogicAgent:
             def generate_queries(self, text, belief_set, context=None):
                 pass
 
-            def interpret_results(self, text, belief_set, queries, results, context=None):
+            def interpret_results(
+                self, text, belief_set, queries, results, context=None
+            ):
                 pass
 
             def validate_formula(self, formula):
@@ -326,7 +333,9 @@ class TestBaseLogicAgent:
             def generate_queries(self, text, belief_set, context=None):
                 pass
 
-            def interpret_results(self, text, belief_set, queries, results, context=None):
+            def interpret_results(
+                self, text, belief_set, queries, results, context=None
+            ):
                 pass
 
             def validate_formula(self, formula):
@@ -365,7 +374,9 @@ class TestBaseLogicAgent:
             def generate_queries(self, text, belief_set, context=None):
                 pass
 
-            def interpret_results(self, text, belief_set, queries, results, context=None):
+            def interpret_results(
+                self, text, belief_set, queries, results, context=None
+            ):
                 pass
 
             def validate_formula(self, formula):
@@ -407,7 +418,9 @@ class TestBaseLogicAgent:
             def generate_queries(self, text, belief_set, context=None):
                 pass
 
-            def interpret_results(self, text, belief_set, queries, results, context=None):
+            def interpret_results(
+                self, text, belief_set, queries, results, context=None
+            ):
                 pass
 
             def validate_formula(self, formula):
@@ -512,7 +525,7 @@ class TestAgentBasesIntegration:
                     "reasoning": True,
                     "analysis": True,
                     "synthesis": True,
-                    "supported_logics": ["propositional", "first_order"]
+                    "supported_logics": ["propositional", "first_order"],
                 }
 
         agent = CapabilitiesAgent(kernel, "Caps")
@@ -538,7 +551,9 @@ class TestAgentBasesIntegration:
             def get_agent_capabilities(self):
                 return {"version": "1.0", "features": ["test"]}
 
-        agent = InfoAgent(kernel, "InfoAgent", system_prompt="Test prompt", llm_service_id="custom")
+        agent = InfoAgent(
+            kernel, "InfoAgent", system_prompt="Test prompt", llm_service_id="custom"
+        )
         info = agent.get_agent_info()
 
         assert info["name"] == "InfoAgent"

--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument.py
@@ -13,7 +13,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from semantic_kernel import Kernel
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 
-
 # ── Fixtures ─────────────────────────────────────────────────────
 
 

--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument_definitions.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument_definitions.py
@@ -13,8 +13,8 @@ from argumentation_analysis.agents.core.counter_argument.definitions import (
     ValidationResult,
 )
 
-
 # ── Enums ──
+
 
 class TestCounterArgumentType:
     def test_has_five_types(self):
@@ -22,8 +22,11 @@ class TestCounterArgumentType:
 
     def test_values(self):
         expected = {
-            "direct_refutation", "counter_example", "alternative_explanation",
-            "premise_challenge", "reductio_ad_absurdum",
+            "direct_refutation",
+            "counter_example",
+            "alternative_explanation",
+            "premise_challenge",
+            "reductio_ad_absurdum",
         }
         assert {t.value for t in CounterArgumentType} == expected
 
@@ -44,13 +47,17 @@ class TestRhetoricalStrategy:
 
     def test_values(self):
         expected = {
-            "socratic_questioning", "reductio_ad_absurdum",
-            "analogical_counter", "authority_appeal", "statistical_evidence",
+            "socratic_questioning",
+            "reductio_ad_absurdum",
+            "analogical_counter",
+            "authority_appeal",
+            "statistical_evidence",
         }
         assert {s.value for s in RhetoricalStrategy} == expected
 
 
 # ── Argument ──
+
 
 class TestArgument:
     def test_init(self):
@@ -69,13 +76,17 @@ class TestArgument:
 
     def test_minimal(self):
         arg = Argument(
-            content="X", premises=[], conclusion="Y",
-            argument_type="inductive", confidence=0.5,
+            content="X",
+            premises=[],
+            conclusion="Y",
+            argument_type="inductive",
+            confidence=0.5,
         )
         assert arg.premises == []
 
 
 # ── Vulnerability ──
+
 
 class TestVulnerability:
     def test_init(self):
@@ -93,6 +104,7 @@ class TestVulnerability:
 
 
 # ── CounterArgument ──
+
 
 class TestCounterArgument:
     @pytest.fixture
@@ -138,6 +150,7 @@ class TestCounterArgument:
 
 # ── EvaluationResult ──
 
+
 class TestEvaluationResult:
     def test_init(self):
         ev = EvaluationResult(
@@ -154,14 +167,19 @@ class TestEvaluationResult:
 
     def test_with_recommendations(self):
         ev = EvaluationResult(
-            relevance=0.5, logical_strength=0.3, persuasiveness=0.4,
-            originality=0.2, clarity=0.6, overall_score=0.4,
+            relevance=0.5,
+            logical_strength=0.3,
+            persuasiveness=0.4,
+            originality=0.2,
+            clarity=0.6,
+            overall_score=0.4,
             recommendations=["Add evidence", "Improve logic"],
         )
         assert len(ev.recommendations) == 2
 
 
 # ── ValidationResult ──
+
 
 class TestValidationResult:
     def test_valid_attack(self):

--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument_evaluator.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument_evaluator.py
@@ -47,6 +47,7 @@ def counter_argument(original_argument):
 
 # ── Init ──
 
+
 class TestEvaluatorInit:
     def test_criteria_weights(self, evaluator):
         assert evaluator.evaluation_criteria["relevance"] == 0.25
@@ -70,8 +71,11 @@ class TestEvaluatorInit:
 
 # ── evaluate (full pipeline) ──
 
+
 class TestEvaluate:
-    def test_returns_evaluation_result(self, evaluator, original_argument, counter_argument):
+    def test_returns_evaluation_result(
+        self, evaluator, original_argument, counter_argument
+    ):
         result = evaluator.evaluate(original_argument, counter_argument)
         assert isinstance(result, EvaluationResult)
 
@@ -79,7 +83,9 @@ class TestEvaluate:
         result = evaluator.evaluate(original_argument, counter_argument)
         assert 0.0 <= result.overall_score <= 1.0
 
-    def test_all_criteria_populated(self, evaluator, original_argument, counter_argument):
+    def test_all_criteria_populated(
+        self, evaluator, original_argument, counter_argument
+    ):
         result = evaluator.evaluate(original_argument, counter_argument)
         assert 0.0 <= result.relevance <= 1.0
         assert 0.0 <= result.logical_strength <= 1.0
@@ -91,7 +97,9 @@ class TestEvaluate:
         result = evaluator.evaluate(original_argument, counter_argument)
         assert isinstance(result.recommendations, list)
 
-    def test_overall_is_weighted_sum(self, evaluator, original_argument, counter_argument):
+    def test_overall_is_weighted_sum(
+        self, evaluator, original_argument, counter_argument
+    ):
         result = evaluator.evaluate(original_argument, counter_argument)
         expected = (
             result.relevance * 0.25
@@ -104,6 +112,7 @@ class TestEvaluate:
 
 
 # ── _evaluate_relevance ──
+
 
 class TestEvaluateRelevance:
     def test_high_keyword_overlap(self, evaluator, original_argument):
@@ -192,6 +201,7 @@ class TestEvaluateRelevance:
 
 
 # ── _evaluate_logical_strength ──
+
 
 class TestEvaluateLogicalStrength:
     def test_direct_refutation_base(self, evaluator, original_argument):
@@ -299,6 +309,7 @@ class TestEvaluateLogicalStrength:
 
 # ── _evaluate_persuasiveness ──
 
+
 class TestEvaluatePersuasiveness:
     def test_with_persuasive_elements(self, evaluator, original_argument):
         ca = CounterArgument(
@@ -367,6 +378,7 @@ class TestEvaluatePersuasiveness:
 
 
 # ── _evaluate_originality ──
+
 
 class TestEvaluateOriginality:
     def test_base_originality(self, evaluator, original_argument):
@@ -446,6 +458,7 @@ class TestEvaluateOriginality:
 
 # ── _evaluate_clarity ──
 
+
 class TestEvaluateClarity:
     def test_short_sentences_clear(self, evaluator, original_argument):
         ca = CounterArgument(
@@ -523,44 +536,59 @@ class TestEvaluateClarity:
 
 # ── _generate_recommendations ──
 
+
 class TestGenerateRecommendations:
-    def test_low_relevance_recommendation(self, evaluator, original_argument, counter_argument):
+    def test_low_relevance_recommendation(
+        self, evaluator, original_argument, counter_argument
+    ):
         recs = evaluator._generate_recommendations(
             original_argument, counter_argument, 0.3, 0.8, 0.8, 0.8, 0.8
         )
         assert any("relevance" in r.lower() for r in recs)
 
-    def test_low_logic_recommendation(self, evaluator, original_argument, counter_argument):
+    def test_low_logic_recommendation(
+        self, evaluator, original_argument, counter_argument
+    ):
         recs = evaluator._generate_recommendations(
             original_argument, counter_argument, 0.8, 0.3, 0.8, 0.8, 0.8
         )
         assert any("logical" in r.lower() for r in recs)
 
-    def test_low_persuasion_recommendation(self, evaluator, original_argument, counter_argument):
+    def test_low_persuasion_recommendation(
+        self, evaluator, original_argument, counter_argument
+    ):
         recs = evaluator._generate_recommendations(
             original_argument, counter_argument, 0.8, 0.8, 0.3, 0.8, 0.8
         )
         assert any("persuasive" in r.lower() for r in recs)
 
-    def test_low_originality_recommendation(self, evaluator, original_argument, counter_argument):
+    def test_low_originality_recommendation(
+        self, evaluator, original_argument, counter_argument
+    ):
         recs = evaluator._generate_recommendations(
             original_argument, counter_argument, 0.8, 0.8, 0.8, 0.3, 0.8
         )
         assert any("original" in r.lower() for r in recs)
 
-    def test_low_clarity_recommendation(self, evaluator, original_argument, counter_argument):
+    def test_low_clarity_recommendation(
+        self, evaluator, original_argument, counter_argument
+    ):
         recs = evaluator._generate_recommendations(
             original_argument, counter_argument, 0.8, 0.8, 0.8, 0.8, 0.3
         )
         assert any("simplif" in r.lower() for r in recs)
 
-    def test_all_good_recommendation(self, evaluator, original_argument, counter_argument):
+    def test_all_good_recommendation(
+        self, evaluator, original_argument, counter_argument
+    ):
         recs = evaluator._generate_recommendations(
             original_argument, counter_argument, 0.8, 0.8, 0.8, 0.8, 0.8
         )
         assert any("good quality" in r.lower() for r in recs)
 
-    def test_multiple_low_multiple_recs(self, evaluator, original_argument, counter_argument):
+    def test_multiple_low_multiple_recs(
+        self, evaluator, original_argument, counter_argument
+    ):
         recs = evaluator._generate_recommendations(
             original_argument, counter_argument, 0.3, 0.3, 0.3, 0.3, 0.3
         )
@@ -568,6 +596,7 @@ class TestGenerateRecommendations:
 
 
 # ── Helper methods ──
+
 
 class TestHelperMethods:
     def test_extract_keywords(self, evaluator):
@@ -599,7 +628,9 @@ class TestHelperMethods:
         assert c < 0.3
 
     def test_vocabulary_complexity_complex(self, evaluator):
-        c = evaluator._vocabulary_complexity("L'épistémologie et l'ontologie du paradigme herméneutique.")
+        c = evaluator._vocabulary_complexity(
+            "L'épistémologie et l'ontologie du paradigme herméneutique."
+        )
         assert c > 0.0
 
     def test_vocabulary_complexity_empty(self, evaluator):

--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument_parser.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument_parser.py
@@ -15,8 +15,8 @@ from argumentation_analysis.agents.core.counter_argument.definitions import (
     CounterArgumentType,
 )
 
-
 # ── ArgumentParser init ──
+
 
 class TestArgumentParserInit:
     def test_has_premise_markers(self):
@@ -42,6 +42,7 @@ class TestArgumentParserInit:
 
 # ── parse_argument ──
 
+
 class TestParseArgument:
     @pytest.fixture
     def parser(self):
@@ -60,7 +61,10 @@ class TestParseArgument:
     def test_extracts_conclusion_with_marker(self, parser):
         text = "Il pleut. Donc il faut un parapluie."
         result = parser.parse_argument(text)
-        assert "donc" in result.conclusion.lower() or "parapluie" in result.conclusion.lower()
+        assert (
+            "donc" in result.conclusion.lower()
+            or "parapluie" in result.conclusion.lower()
+        )
 
     def test_single_sentence(self, parser):
         text = "Le ciel est bleu."
@@ -79,6 +83,7 @@ class TestParseArgument:
 
 
 # ── _extract_premises ──
+
 
 class TestExtractPremises:
     @pytest.fixture
@@ -113,6 +118,7 @@ class TestExtractPremises:
 
 # ── _extract_conclusion ──
 
+
 class TestExtractConclusion:
     @pytest.fixture
     def parser(self):
@@ -144,28 +150,46 @@ class TestExtractConclusion:
 
 # ── _determine_argument_type ──
 
+
 class TestDetermineArgumentType:
     @pytest.fixture
     def parser(self):
         return ArgumentParser()
 
     def test_deductive_tous(self, parser):
-        assert parser._determine_argument_type("Tous les hommes sont mortels.") == "deductive"
+        assert (
+            parser._determine_argument_type("Tous les hommes sont mortels.")
+            == "deductive"
+        )
 
     def test_deductive_chaque(self, parser):
-        assert parser._determine_argument_type("Chaque étudiant doit réussir.") == "deductive"
+        assert (
+            parser._determine_argument_type("Chaque étudiant doit réussir.")
+            == "deductive"
+        )
 
     def test_inductive_generalement(self, parser):
-        assert parser._determine_argument_type("Généralement, il fait beau en été.") == "inductive"
+        assert (
+            parser._determine_argument_type("Généralement, il fait beau en été.")
+            == "inductive"
+        )
 
     def test_inductive_souvent(self, parser):
-        assert parser._determine_argument_type("Il est souvent en retard.") == "inductive"
+        assert (
+            parser._determine_argument_type("Il est souvent en retard.") == "inductive"
+        )
 
     def test_abductive_meilleure_explication(self, parser):
-        assert parser._determine_argument_type("La meilleure explication est...") == "abductive"
+        assert (
+            parser._determine_argument_type("La meilleure explication est...")
+            == "abductive"
+        )
 
     def test_abductive_probablement(self, parser):
-        assert parser._determine_argument_type("C'est probablement la cause.") == "abductive"
+        assert (
+            parser._determine_argument_type("C'est probablement la cause.")
+            == "abductive"
+        )
 
     def test_si_alors_deductive(self, parser):
         assert parser._determine_argument_type("Si A alors B.") == "deductive"
@@ -174,13 +198,19 @@ class TestDetermineArgumentType:
         assert parser._determine_argument_type("Le ciel.") == "inductive"
 
     def test_secondary_inductive_exemple(self, parser):
-        assert parser._determine_argument_type("Par exemple, on observe que...") == "inductive"
+        assert (
+            parser._determine_argument_type("Par exemple, on observe que...")
+            == "inductive"
+        )
 
     def test_secondary_abductive_explication(self, parser):
-        assert parser._determine_argument_type("L'explication est simple.") == "abductive"
+        assert (
+            parser._determine_argument_type("L'explication est simple.") == "abductive"
+        )
 
 
 # ── _calculate_confidence ──
+
 
 class TestCalculateConfidence:
     @pytest.fixture
@@ -209,13 +239,13 @@ class TestCalculateConfidence:
 
     def test_max_is_1(self, parser):
         c = parser._calculate_confidence(
-            ["parce que premise", "car another"],
-            "donc conclusion"
+            ["parce que premise", "car another"], "donc conclusion"
         )
         assert c <= 1.0
 
 
 # ── _split_into_sentences ──
+
 
 class TestSplitIntoSentences:
     @pytest.fixture
@@ -243,6 +273,7 @@ class TestSplitIntoSentences:
 
 
 # ── _fix_identical_premise_conclusion ──
+
 
 class TestFixIdenticalPremiseConclusion:
     @pytest.fixture
@@ -278,6 +309,7 @@ class TestFixIdenticalPremiseConclusion:
 
 
 # ── VulnerabilityAnalyzer ──
+
 
 class TestVulnerabilityAnalyzer:
     @pytest.fixture
@@ -427,6 +459,7 @@ class TestVulnerabilityAnalyzer:
 
 # ── identify_vulnerabilities via ArgumentParser ──
 
+
 class TestIdentifyVulnerabilities:
     def test_sorted_by_score(self):
         parser = ArgumentParser()
@@ -444,13 +477,14 @@ class TestIdentifyVulnerabilities:
 
 # ── parse_llm_response ──
 
+
 class TestParseLlmResponse:
     def test_valid_json(self):
         result = parse_llm_response('{"key": "value"}')
         assert result == {"key": "value"}
 
     def test_json_list(self):
-        result = parse_llm_response('[1, 2, 3]')
+        result = parse_llm_response("[1, 2, 3]")
         assert result == [1, 2, 3]
 
     def test_invalid_json_structured(self):
@@ -459,11 +493,12 @@ class TestParseLlmResponse:
         assert result["other"] == "data"
 
     def test_empty_json_object(self):
-        result = parse_llm_response('{}')
+        result = parse_llm_response("{}")
         assert result == {}
 
 
 # ── parse_structured_text ──
+
 
 class TestParseStructuredText:
     def test_single_kv(self):
@@ -502,6 +537,7 @@ class TestParseStructuredText:
 
 
 # ── _extract_key_words (VulnerabilityAnalyzer) ──
+
 
 class TestExtractKeyWords:
     def test_removes_stop_words(self):

--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_evaluator.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_evaluator.py
@@ -55,6 +55,7 @@ def _make_counter(**overrides):
 # Initialization
 # ============================================================
 
+
 class TestInit:
     def test_creates_instance(self, evaluator):
         assert isinstance(evaluator, CounterArgumentEvaluator)
@@ -83,6 +84,7 @@ class TestInit:
 # evaluate (integration)
 # ============================================================
 
+
 class TestEvaluate:
     def test_returns_evaluation_result(self, evaluator):
         arg = _make_argument()
@@ -94,7 +96,14 @@ class TestEvaluate:
         arg = _make_argument()
         counter = _make_counter()
         result = evaluator.evaluate(arg, counter)
-        for field in ["relevance", "logical_strength", "persuasiveness", "originality", "clarity", "overall_score"]:
+        for field in [
+            "relevance",
+            "logical_strength",
+            "persuasiveness",
+            "originality",
+            "clarity",
+            "overall_score",
+        ]:
             score = getattr(result, field)
             assert 0.0 <= score <= 1.0, f"{field} = {score} out of range"
 
@@ -122,6 +131,7 @@ class TestEvaluate:
 # _evaluate_relevance
 # ============================================================
 
+
 class TestEvaluateRelevance:
     def test_high_overlap_gives_relevance(self, evaluator):
         arg = _make_argument(content="Les chats domestiques sont populaires")
@@ -133,19 +143,13 @@ class TestEvaluateRelevance:
 
     def test_no_overlap_low_relevance(self, evaluator):
         arg = _make_argument(content="Les oiseaux migrateurs")
-        counter = _make_counter(
-            counter_content="La philosophie analytique"
-        )
+        counter = _make_counter(counter_content="La philosophie analytique")
         score = evaluator._evaluate_relevance(arg, counter)
         assert score < 0.5
 
     def test_argument_mention_bonus(self, evaluator):
-        counter_with = _make_counter(
-            counter_content="Cet argument est faux"
-        )
-        counter_without = _make_counter(
-            counter_content="Cette affirmation est fausse"
-        )
+        counter_with = _make_counter(counter_content="Cet argument est faux")
+        counter_without = _make_counter(counter_content="Cette affirmation est fausse")
         arg = _make_argument()
         score_with = evaluator._evaluate_relevance(arg, counter_with)
         score_without = evaluator._evaluate_relevance(arg, counter_without)
@@ -173,6 +177,7 @@ class TestEvaluateRelevance:
 # _evaluate_logical_strength
 # ============================================================
 
+
 class TestEvaluateLogicalStrength:
     def test_direct_refutation_base(self, evaluator):
         counter = _make_counter(counter_type=CounterArgumentType.DIRECT_REFUTATION)
@@ -183,9 +188,7 @@ class TestEvaluateLogicalStrength:
         counter_with = _make_counter(
             counter_content="Cela est faux car les données montrent le contraire"
         )
-        counter_without = _make_counter(
-            counter_content="Cela est faux"
-        )
+        counter_without = _make_counter(counter_content="Cela est faux")
         score_with = evaluator._evaluate_logical_strength(counter_with)
         score_without = evaluator._evaluate_logical_strength(counter_without)
         assert score_with >= score_without
@@ -219,7 +222,7 @@ class TestEvaluateLogicalStrength:
         counter = _make_counter(
             counter_type=CounterArgumentType.COUNTER_EXAMPLE,
             strength=ArgumentStrength.DECISIVE,
-            counter_content="Car les preuves et exemples sont clairs, donc par conséquent c'est faux"
+            counter_content="Car les preuves et exemples sont clairs, donc par conséquent c'est faux",
         )
         score = evaluator._evaluate_logical_strength(counter)
         assert score <= 1.0
@@ -228,6 +231,7 @@ class TestEvaluateLogicalStrength:
 # ============================================================
 # _evaluate_persuasiveness
 # ============================================================
+
 
 class TestEvaluatePersuasiveness:
     def test_persuasive_elements_boost(self, evaluator):
@@ -254,7 +258,8 @@ class TestEvaluatePersuasiveness:
 
     def test_max_is_one(self, evaluator):
         counter = _make_counter(
-            counter_content="Les données clairement certainement prouvent avec des statistiques " * 5,
+            counter_content="Les données clairement certainement prouvent avec des statistiques "
+            * 5,
             rhetorical_strategy="statistical_evidence",
         )
         score = evaluator._evaluate_persuasiveness(counter)
@@ -264,6 +269,7 @@ class TestEvaluatePersuasiveness:
 # ============================================================
 # _evaluate_originality
 # ============================================================
+
 
 class TestEvaluateOriginality:
     def test_base_originality(self, evaluator):
@@ -293,7 +299,7 @@ class TestEvaluateOriginality:
         counter = _make_counter(
             counter_type=CounterArgumentType.DIRECT_REFUTATION,
             rhetorical_strategy="socratic",
-            counter_content="Une perspective nouvelle"
+            counter_content="Une perspective nouvelle",
         )
         score = evaluator._evaluate_originality(counter)
         assert score > 0.5
@@ -303,11 +309,10 @@ class TestEvaluateOriginality:
 # _evaluate_clarity
 # ============================================================
 
+
 class TestEvaluateClarity:
     def test_short_sentences_good(self, evaluator):
-        counter = _make_counter(
-            counter_content="C'est faux. Les preuves sont claires."
-        )
+        counter = _make_counter(counter_content="C'est faux. Les preuves sont claires.")
         score = evaluator._evaluate_clarity(counter)
         assert score > 0.0
 
@@ -346,28 +351,53 @@ class TestEvaluateClarity:
 # _generate_recommendations
 # ============================================================
 
+
 class TestGenerateRecommendations:
     def test_low_relevance_recommendation(self, evaluator):
         recs = evaluator._generate_recommendations(
-            _make_argument(), _make_counter(), 0.3, 0.8, 0.8, 0.8, 0.8,
+            _make_argument(),
+            _make_counter(),
+            0.3,
+            0.8,
+            0.8,
+            0.8,
+            0.8,
         )
         assert any("relevance" in r.lower() for r in recs)
 
     def test_low_logic_recommendation(self, evaluator):
         recs = evaluator._generate_recommendations(
-            _make_argument(), _make_counter(), 0.8, 0.3, 0.8, 0.8, 0.8,
+            _make_argument(),
+            _make_counter(),
+            0.8,
+            0.3,
+            0.8,
+            0.8,
+            0.8,
         )
         assert any("logical" in r.lower() for r in recs)
 
     def test_all_good_recommendation(self, evaluator):
         recs = evaluator._generate_recommendations(
-            _make_argument(), _make_counter(), 0.8, 0.8, 0.8, 0.8, 0.8,
+            _make_argument(),
+            _make_counter(),
+            0.8,
+            0.8,
+            0.8,
+            0.8,
+            0.8,
         )
         assert any("good quality" in r.lower() for r in recs)
 
     def test_returns_list(self, evaluator):
         recs = evaluator._generate_recommendations(
-            _make_argument(), _make_counter(), 0.5, 0.5, 0.5, 0.5, 0.5,
+            _make_argument(),
+            _make_counter(),
+            0.5,
+            0.5,
+            0.5,
+            0.5,
+            0.5,
         )
         assert isinstance(recs, list)
 
@@ -375,6 +405,7 @@ class TestGenerateRecommendations:
 # ============================================================
 # Helper methods
 # ============================================================
+
 
 class TestHelperMethods:
     def test_extract_keywords_removes_stops(self, evaluator):
@@ -406,7 +437,9 @@ class TestHelperMethods:
         assert score < 0.3
 
     def test_vocabulary_complexity_complex(self, evaluator):
-        score = evaluator._vocabulary_complexity("paradigme ontologie épistémologie herméneutique")
+        score = evaluator._vocabulary_complexity(
+            "paradigme ontologie épistémologie herméneutique"
+        )
         assert score > 0.3
 
     def test_vocabulary_complexity_empty(self, evaluator):

--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_evaluator_extended.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_evaluator_extended.py
@@ -19,7 +19,9 @@ def evaluator():
     return CounterArgumentEvaluator()
 
 
-def _make_argument(content="Le climat change", premises=None, conclusion="Donc il faut agir"):
+def _make_argument(
+    content="Le climat change", premises=None, conclusion="Donc il faut agir"
+):
     return Argument(
         content=content,
         premises=premises or ["Le climat change"],
@@ -50,16 +52,26 @@ def _make_counter(
 
 # ── _evaluate_relevance ──
 
+
 class TestEvaluateRelevance:
     def test_high_keyword_overlap(self, evaluator):
-        orig = _make_argument(content="Le climat change rapidement", premises=["Le climat change"])
-        counter = _make_counter(original=orig, counter_content="Le climat ne change pas rapidement selon les données")
+        orig = _make_argument(
+            content="Le climat change rapidement", premises=["Le climat change"]
+        )
+        counter = _make_counter(
+            original=orig,
+            counter_content="Le climat ne change pas rapidement selon les données",
+        )
         score = evaluator._evaluate_relevance(orig, counter)
         assert score > 0.0
 
     def test_no_overlap(self, evaluator):
-        orig = _make_argument(content="Les chats sont mignons", premises=["Les chats sont mignons"])
-        counter = _make_counter(original=orig, counter_content="La physique quantique démontre autre chose")
+        orig = _make_argument(
+            content="Les chats sont mignons", premises=["Les chats sont mignons"]
+        )
+        counter = _make_counter(
+            original=orig, counter_content="La physique quantique démontre autre chose"
+        )
         score = evaluator._evaluate_relevance(orig, counter)
         assert score < 0.5
 
@@ -93,7 +105,9 @@ class TestEvaluateRelevance:
 
     def test_mentions_argument_bonus(self, evaluator):
         orig = _make_argument()
-        counter = _make_counter(original=orig, counter_content="Cet argument est incorrect")
+        counter = _make_counter(
+            original=orig, counter_content="Cet argument est incorrect"
+        )
         score_with = evaluator._evaluate_relevance(orig, counter)
         counter2 = _make_counter(original=orig, counter_content="C'est incorrect")
         score_without = evaluator._evaluate_relevance(orig, counter2)
@@ -147,25 +161,38 @@ class TestEvaluateRelevance:
 
 # ── _evaluate_logical_strength ──
 
+
 class TestEvaluateLogicalStrength:
     def test_type_strength_direct_refutation(self, evaluator):
-        counter = _make_counter(counter_type=CounterArgumentType.DIRECT_REFUTATION, counter_content="Non")
+        counter = _make_counter(
+            counter_type=CounterArgumentType.DIRECT_REFUTATION, counter_content="Non"
+        )
         score = evaluator._evaluate_logical_strength(counter)
         assert score >= 0.5
 
     def test_type_strength_counter_example(self, evaluator):
-        counter = _make_counter(counter_type=CounterArgumentType.COUNTER_EXAMPLE, counter_content="Exemple contraire")
+        counter = _make_counter(
+            counter_type=CounterArgumentType.COUNTER_EXAMPLE,
+            counter_content="Exemple contraire",
+        )
         score = evaluator._evaluate_logical_strength(counter)
         assert score >= 0.5
 
     def test_type_strength_reductio(self, evaluator):
-        counter = _make_counter(counter_type=CounterArgumentType.REDUCTIO_AD_ABSURDUM, counter_content="Absurde")
+        counter = _make_counter(
+            counter_type=CounterArgumentType.REDUCTIO_AD_ABSURDUM,
+            counter_content="Absurde",
+        )
         score = evaluator._evaluate_logical_strength(counter)
         assert score >= 0.5
 
     def test_logical_markers_boost(self, evaluator):
-        counter_with = _make_counter(counter_content="Car ceci est faux, donc la conclusion est invalide")
-        counter_without = _make_counter(counter_content="Ceci est faux, la conclusion est invalide")
+        counter_with = _make_counter(
+            counter_content="Car ceci est faux, donc la conclusion est invalide"
+        )
+        counter_without = _make_counter(
+            counter_content="Ceci est faux, la conclusion est invalide"
+        )
         s1 = evaluator._evaluate_logical_strength(counter_with)
         s2 = evaluator._evaluate_logical_strength(counter_without)
         assert s1 >= s2
@@ -179,26 +206,38 @@ class TestEvaluateLogicalStrength:
         assert score >= 0.5
 
     def test_evidence_bonus(self, evaluator):
-        counter = _make_counter(counter_content="Une étude prouve le contraire avec des exemples")
+        counter = _make_counter(
+            counter_content="Une étude prouve le contraire avec des exemples"
+        )
         score = evaluator._evaluate_logical_strength(counter)
         assert score > 0.5
 
     def test_fallacy_penalty(self, evaluator):
-        counter_clean = _make_counter(counter_content="Les données montrent le contraire")
-        counter_fallacy = _make_counter(counter_content="C'est un ad hominem et un faux dilemme")
+        counter_clean = _make_counter(
+            counter_content="Les données montrent le contraire"
+        )
+        counter_fallacy = _make_counter(
+            counter_content="C'est un ad hominem et un faux dilemme"
+        )
         s1 = evaluator._evaluate_logical_strength(counter_clean)
         s2 = evaluator._evaluate_logical_strength(counter_fallacy)
         assert s1 >= s2
 
     def test_strength_adjustment_strong(self, evaluator):
-        counter_strong = _make_counter(strength=ArgumentStrength.STRONG, counter_content="Test")
-        counter_weak = _make_counter(strength=ArgumentStrength.WEAK, counter_content="Test")
+        counter_strong = _make_counter(
+            strength=ArgumentStrength.STRONG, counter_content="Test"
+        )
+        counter_weak = _make_counter(
+            strength=ArgumentStrength.WEAK, counter_content="Test"
+        )
         s1 = evaluator._evaluate_logical_strength(counter_strong)
         s2 = evaluator._evaluate_logical_strength(counter_weak)
         assert s1 > s2
 
     def test_strength_decisive_bonus(self, evaluator):
-        counter = _make_counter(strength=ArgumentStrength.DECISIVE, counter_content="Car c'est prouvé")
+        counter = _make_counter(
+            strength=ArgumentStrength.DECISIVE, counter_content="Car c'est prouvé"
+        )
         score = evaluator._evaluate_logical_strength(counter)
         assert score >= 0.7
 
@@ -213,6 +252,7 @@ class TestEvaluateLogicalStrength:
 
 
 # ── _evaluate_persuasiveness ──
+
 
 class TestEvaluatePersuasiveness:
     def test_persuasive_elements_boost(self, evaluator):
@@ -263,7 +303,8 @@ class TestEvaluatePersuasiveness:
 
     def test_capped_at_one(self, evaluator):
         counter = _make_counter(
-            counter_content="Clairement une étude montre des preuves et données statistiques évidentes " * 5,
+            counter_content="Clairement une étude montre des preuves et données statistiques évidentes "
+            * 5,
             rhetorical_strategy="socratic_questioning",
         )
         score = evaluator._evaluate_persuasiveness(counter)
@@ -272,9 +313,12 @@ class TestEvaluatePersuasiveness:
 
 # ── _evaluate_originality ──
 
+
 class TestEvaluateOriginality:
     def test_base_originality(self, evaluator):
-        counter = _make_counter(counter_content="Un point de vue différent sur la question climatique")
+        counter = _make_counter(
+            counter_content="Un point de vue différent sur la question climatique"
+        )
         score = evaluator._evaluate_originality(counter)
         assert 0.1 <= score <= 1.0
 
@@ -332,6 +376,7 @@ class TestEvaluateOriginality:
 
 # ── _evaluate_clarity ──
 
+
 class TestEvaluateClarity:
     def test_short_sentences_high_clarity(self, evaluator):
         counter = _make_counter(
@@ -362,14 +407,20 @@ class TestEvaluateClarity:
         assert score > 0.0
 
     def test_ambiguity_penalty(self, evaluator):
-        counter_clear = _make_counter(counter_content="Les données montrent le contraire.")
-        counter_ambig = _make_counter(counter_content="Peut-être possiblement il se pourrait que les données montrent le contraire.")
+        counter_clear = _make_counter(
+            counter_content="Les données montrent le contraire."
+        )
+        counter_ambig = _make_counter(
+            counter_content="Peut-être possiblement il se pourrait que les données montrent le contraire."
+        )
         s1 = evaluator._evaluate_clarity(counter_clear)
         s2 = evaluator._evaluate_clarity(counter_ambig)
         assert s1 >= s2
 
     def test_vocabulary_complexity_impact(self, evaluator):
-        counter_simple = _make_counter(counter_content="Les données montrent le contraire clairement.")
+        counter_simple = _make_counter(
+            counter_content="Les données montrent le contraire clairement."
+        )
         counter_complex = _make_counter(
             counter_content="Le paradigme épistémologie herméneutique heuristique dialectique syllogisme ontologie axiomatique."
         )
@@ -379,7 +430,8 @@ class TestEvaluateClarity:
 
     def test_floor_at_01(self, evaluator):
         counter = _make_counter(
-            counter_content="Peut-être possiblement il se pourrait que plus ou moins " * 3
+            counter_content="Peut-être possiblement il se pourrait que plus ou moins "
+            * 3
         )
         score = evaluator._evaluate_clarity(counter)
         assert score >= 0.1
@@ -387,51 +439,67 @@ class TestEvaluateClarity:
 
 # ── _generate_recommendations ──
 
+
 class TestGenerateRecommendations:
     def test_low_relevance(self, evaluator):
         orig = _make_argument()
         counter = _make_counter(original=orig)
-        recs = evaluator._generate_recommendations(orig, counter, 0.3, 0.7, 0.7, 0.7, 0.7)
+        recs = evaluator._generate_recommendations(
+            orig, counter, 0.3, 0.7, 0.7, 0.7, 0.7
+        )
         assert any("relevance" in r.lower() for r in recs)
 
     def test_low_logic(self, evaluator):
         orig = _make_argument()
         counter = _make_counter(original=orig)
-        recs = evaluator._generate_recommendations(orig, counter, 0.7, 0.3, 0.7, 0.7, 0.7)
+        recs = evaluator._generate_recommendations(
+            orig, counter, 0.7, 0.3, 0.7, 0.7, 0.7
+        )
         assert any("logical" in r.lower() for r in recs)
 
     def test_low_persuasion(self, evaluator):
         orig = _make_argument()
         counter = _make_counter(original=orig)
-        recs = evaluator._generate_recommendations(orig, counter, 0.7, 0.7, 0.3, 0.7, 0.7)
+        recs = evaluator._generate_recommendations(
+            orig, counter, 0.7, 0.7, 0.3, 0.7, 0.7
+        )
         assert any("persuasive" in r.lower() for r in recs)
 
     def test_low_originality(self, evaluator):
         orig = _make_argument()
         counter = _make_counter(original=orig)
-        recs = evaluator._generate_recommendations(orig, counter, 0.7, 0.7, 0.7, 0.3, 0.7)
+        recs = evaluator._generate_recommendations(
+            orig, counter, 0.7, 0.7, 0.7, 0.3, 0.7
+        )
         assert any("original" in r.lower() for r in recs)
 
     def test_low_clarity(self, evaluator):
         orig = _make_argument()
         counter = _make_counter(original=orig)
-        recs = evaluator._generate_recommendations(orig, counter, 0.7, 0.7, 0.7, 0.7, 0.3)
+        recs = evaluator._generate_recommendations(
+            orig, counter, 0.7, 0.7, 0.7, 0.7, 0.3
+        )
         assert any("simplif" in r.lower() for r in recs)
 
     def test_all_good(self, evaluator):
         orig = _make_argument()
         counter = _make_counter(original=orig)
-        recs = evaluator._generate_recommendations(orig, counter, 0.8, 0.8, 0.8, 0.8, 0.8)
+        recs = evaluator._generate_recommendations(
+            orig, counter, 0.8, 0.8, 0.8, 0.8, 0.8
+        )
         assert any("good quality" in r.lower() for r in recs)
 
     def test_multiple_low_scores(self, evaluator):
         orig = _make_argument()
         counter = _make_counter(original=orig)
-        recs = evaluator._generate_recommendations(orig, counter, 0.3, 0.3, 0.3, 0.3, 0.3)
+        recs = evaluator._generate_recommendations(
+            orig, counter, 0.3, 0.3, 0.3, 0.3, 0.3
+        )
         assert len(recs) >= 5
 
 
 # ── Helper methods ──
+
 
 class TestHelperMethods:
     def test_extract_keywords_stopwords_removed(self, evaluator):
@@ -467,7 +535,9 @@ class TestHelperMethods:
         assert avg == 3.0
 
     def test_has_structure_true(self, evaluator):
-        assert evaluator._has_structure("Premièrement c'est vrai. Ensuite c'est confirmé.")
+        assert evaluator._has_structure(
+            "Premièrement c'est vrai. Ensuite c'est confirmé."
+        )
 
     def test_has_structure_false(self, evaluator):
         assert not evaluator._has_structure("Le chat dort tranquillement")
@@ -477,7 +547,9 @@ class TestHelperMethods:
         assert score < 0.3
 
     def test_vocabulary_complexity_complex(self, evaluator):
-        score = evaluator._vocabulary_complexity("Le paradigme épistémologie herméneutique ontologie")
+        score = evaluator._vocabulary_complexity(
+            "Le paradigme épistémologie herméneutique ontologie"
+        )
         assert score > 0.0
 
     def test_vocabulary_complexity_empty(self, evaluator):
@@ -490,6 +562,7 @@ class TestHelperMethods:
 
 
 # ── Full evaluate pipeline ──
+
 
 class TestFullEvaluate:
     def test_evaluate_pipeline(self, evaluator):

--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_parser.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_parser.py
@@ -33,6 +33,7 @@ def analyzer():
 # ArgumentParser — initialization
 # ============================================================
 
+
 class TestParserInit:
     def test_creates_instance(self, parser):
         assert isinstance(parser, ArgumentParser)
@@ -59,6 +60,7 @@ class TestParserInit:
 # ============================================================
 # ArgumentParser — parse_argument
 # ============================================================
+
 
 class TestParseArgument:
     def test_returns_argument(self, parser):
@@ -100,6 +102,7 @@ class TestParseArgument:
 # ArgumentParser — _extract_premises
 # ============================================================
 
+
 class TestExtractPremises:
     def test_with_premise_marker(self, parser):
         premises = parser._extract_premises("X car Y.")
@@ -119,9 +122,7 @@ class TestExtractPremises:
         assert "Une seule phrase" in premises[0]
 
     def test_parce_que_marker(self, parser):
-        premises = parser._extract_premises(
-            "Le sol est mouillé parce que il a plu"
-        )
+        premises = parser._extract_premises("Le sol est mouillé parce que il a plu")
         assert len(premises) >= 1
 
     def test_etant_donne_marker(self, parser):
@@ -134,6 +135,7 @@ class TestExtractPremises:
 # ============================================================
 # ArgumentParser — _extract_conclusion
 # ============================================================
+
 
 class TestExtractConclusion:
     def test_with_conclusion_marker(self, parser):
@@ -158,9 +160,7 @@ class TestExtractConclusion:
         assert "Une seule phrase" in conclusion
 
     def test_par_consequent(self, parser):
-        conclusion = parser._extract_conclusion(
-            "Il fait beau. Par conséquent on sort."
-        )
+        conclusion = parser._extract_conclusion("Il fait beau. Par conséquent on sort.")
         assert "conséquent" in conclusion.lower() or "sort" in conclusion.lower()
 
 
@@ -168,36 +168,56 @@ class TestExtractConclusion:
 # ArgumentParser — _determine_argument_type
 # ============================================================
 
+
 class TestDetermineArgumentType:
     def test_deductive_tous(self, parser):
-        assert parser._determine_argument_type("Tous les hommes sont mortels") == "deductive"
+        assert (
+            parser._determine_argument_type("Tous les hommes sont mortels")
+            == "deductive"
+        )
 
     def test_deductive_chaque(self, parser):
-        assert parser._determine_argument_type("Chaque élève doit réussir") == "deductive"
+        assert (
+            parser._determine_argument_type("Chaque élève doit réussir") == "deductive"
+        )
 
     def test_deductive_toujours(self, parser):
         assert parser._determine_argument_type("Il est toujours vrai") == "deductive"
 
     def test_deductive_necessairement(self, parser):
-        assert parser._determine_argument_type("Cela est nécessairement vrai") == "deductive"
+        assert (
+            parser._determine_argument_type("Cela est nécessairement vrai")
+            == "deductive"
+        )
 
     def test_inductive_generalement(self, parser):
-        assert parser._determine_argument_type("Généralement les gens préfèrent") == "inductive"
+        assert (
+            parser._determine_argument_type("Généralement les gens préfèrent")
+            == "inductive"
+        )
 
     def test_inductive_souvent(self, parser):
         assert parser._determine_argument_type("C'est souvent le cas") == "inductive"
 
     def test_inductive_la_plupart(self, parser):
-        assert parser._determine_argument_type("La plupart des gens sont d'accord") == "inductive"
+        assert (
+            parser._determine_argument_type("La plupart des gens sont d'accord")
+            == "inductive"
+        )
 
     def test_abductive_meilleure_explication(self, parser):
-        assert parser._determine_argument_type("La meilleure explication est") == "abductive"
+        assert (
+            parser._determine_argument_type("La meilleure explication est")
+            == "abductive"
+        )
 
     def test_abductive_probablement(self, parser):
         assert parser._determine_argument_type("C'est probablement vrai") == "abductive"
 
     def test_abductive_cause(self, parser):
-        assert parser._determine_argument_type("La cause de cet événement") == "abductive"
+        assert (
+            parser._determine_argument_type("La cause de cet événement") == "abductive"
+        )
 
     def test_abductive_explique(self, parser):
         assert parser._determine_argument_type("Cela explique pourquoi") == "abductive"
@@ -210,7 +230,10 @@ class TestDetermineArgumentType:
         assert parser._determine_argument_type("Le ciel est bleu") == "inductive"
 
     def test_inductive_statistiques(self, parser):
-        assert parser._determine_argument_type("Les statistiques montrent que") == "inductive"
+        assert (
+            parser._determine_argument_type("Les statistiques montrent que")
+            == "inductive"
+        )
 
     def test_inductive_exemple(self, parser):
         assert parser._determine_argument_type("Par exemple ceci prouve") == "inductive"
@@ -219,6 +242,7 @@ class TestDetermineArgumentType:
 # ============================================================
 # ArgumentParser — _calculate_confidence
 # ============================================================
+
 
 class TestCalculateConfidence:
     def test_base_confidence(self, parser):
@@ -239,27 +263,22 @@ class TestCalculateConfidence:
         assert confidence >= 0.89  # 0.5 + 0.2 + 0.2 (float precision)
 
     def test_premise_marker_bonus(self, parser):
-        confidence = parser._calculate_confidence(
-            ["car il pleut"], "conclusion"
-        )
+        confidence = parser._calculate_confidence(["car il pleut"], "conclusion")
         assert confidence >= 0.99  # 0.5 + 0.2 + 0.2 + 0.1 (float precision)
 
     def test_conclusion_marker_bonus(self, parser):
-        confidence = parser._calculate_confidence(
-            ["prémisse"], "donc il fait beau"
-        )
+        confidence = parser._calculate_confidence(["prémisse"], "donc il fait beau")
         assert confidence >= 0.99  # 0.5 + 0.2 + 0.2 + 0.1 (float precision)
 
     def test_max_is_one(self, parser):
-        confidence = parser._calculate_confidence(
-            ["car il pleut"], "donc il fait beau"
-        )
+        confidence = parser._calculate_confidence(["car il pleut"], "donc il fait beau")
         assert confidence == 1.0
 
 
 # ============================================================
 # ArgumentParser — _split_into_sentences
 # ============================================================
+
 
 class TestSplitIntoSentences:
     def test_period_split(self, parser):
@@ -287,6 +306,7 @@ class TestSplitIntoSentences:
 # ArgumentParser — _fix_identical_premise_conclusion
 # ============================================================
 
+
 class TestFixIdenticalPremiseConclusion:
     def test_no_fix_needed_different(self, parser):
         premises, conclusion = parser._fix_identical_premise_conclusion(
@@ -296,16 +316,12 @@ class TestFixIdenticalPremiseConclusion:
         assert conclusion == "B"
 
     def test_no_fix_empty_premises(self, parser):
-        premises, conclusion = parser._fix_identical_premise_conclusion(
-            [], "B", "B"
-        )
+        premises, conclusion = parser._fix_identical_premise_conclusion([], "B", "B")
         assert premises == []
         assert conclusion == "B"
 
     def test_no_fix_empty_conclusion(self, parser):
-        premises, conclusion = parser._fix_identical_premise_conclusion(
-            ["A"], "", "A"
-        )
+        premises, conclusion = parser._fix_identical_premise_conclusion(["A"], "", "A")
         assert premises == ["A"]
         assert conclusion == ""
 
@@ -336,6 +352,7 @@ class TestFixIdenticalPremiseConclusion:
 # ArgumentParser — identify_vulnerabilities
 # ============================================================
 
+
 class TestIdentifyVulnerabilities:
     def test_returns_list(self, parser):
         arg = Argument(
@@ -365,6 +382,7 @@ class TestIdentifyVulnerabilities:
 # VulnerabilityAnalyzer — initialization
 # ============================================================
 
+
 class TestVulnerabilityAnalyzerInit:
     def test_creates_instance(self, analyzer):
         assert isinstance(analyzer, VulnerabilityAnalyzer)
@@ -386,6 +404,7 @@ class TestVulnerabilityAnalyzerInit:
 # ============================================================
 # VulnerabilityAnalyzer — _analyze_text
 # ============================================================
+
 
 class TestAnalyzeText:
     def test_generalisation_tous(self, analyzer):
@@ -438,11 +457,15 @@ class TestAnalyzeText:
 # VulnerabilityAnalyzer — _analyze_structure
 # ============================================================
 
+
 class TestAnalyzeStructure:
     def test_no_premises(self, analyzer):
         arg = Argument(
-            content="test", premises=[], conclusion="conclusion",
-            argument_type="inductive", confidence=0.5,
+            content="test",
+            premises=[],
+            conclusion="conclusion",
+            argument_type="inductive",
+            confidence=0.5,
         )
         vuln = analyzer._analyze_structure(arg)
         assert vuln is not None
@@ -478,6 +501,7 @@ class TestAnalyzeStructure:
 # VulnerabilityAnalyzer — _check_coherence
 # ============================================================
 
+
 class TestCheckCoherence:
     def test_shared_keywords_coherent(self, analyzer):
         arg = Argument(
@@ -503,6 +527,7 @@ class TestCheckCoherence:
 # ============================================================
 # VulnerabilityAnalyzer — _extract_key_words
 # ============================================================
+
 
 class TestExtractKeyWords:
     def test_removes_stop_words(self, analyzer):
@@ -532,6 +557,7 @@ class TestExtractKeyWords:
 # VulnerabilityAnalyzer — analyze_vulnerabilities (integration)
 # ============================================================
 
+
 class TestAnalyzeVulnerabilities:
     def test_premise_vulnerability_tagged(self, analyzer):
         arg = Argument(
@@ -560,8 +586,11 @@ class TestAnalyzeVulnerabilities:
 
     def test_structure_vulnerability_no_premises(self, analyzer):
         arg = Argument(
-            content="test", premises=[], conclusion="conclusion",
-            argument_type="inductive", confidence=0.5,
+            content="test",
+            premises=[],
+            conclusion="conclusion",
+            argument_type="inductive",
+            confidence=0.5,
         )
         vulns = analyzer.analyze_vulnerabilities(arg)
         structure_vulns = [v for v in vulns if v.target == "structure"]
@@ -583,6 +612,7 @@ class TestAnalyzeVulnerabilities:
 # ============================================================
 # parse_llm_response
 # ============================================================
+
 
 class TestParseLlmResponse:
     def test_valid_json(self):
@@ -608,6 +638,7 @@ class TestParseLlmResponse:
 # parse_structured_text
 # ============================================================
 
+
 class TestParseStructuredText:
     def test_simple_key_value(self):
         result = parse_structured_text("name: Alice\nage: 30")
@@ -615,7 +646,9 @@ class TestParseStructuredText:
         assert result["age"] == "30"
 
     def test_multiline_value(self):
-        result = parse_structured_text("description: first line\nsecond line\nother: value")
+        result = parse_structured_text(
+            "description: first line\nsecond line\nother: value"
+        )
         assert "first line" in result["description"]
         assert "second line" in result["description"]
         assert result["other"] == "value"

--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_strategies.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_strategies.py
@@ -38,6 +38,7 @@ def _make_argument(**overrides):
 # Initialization
 # ============================================================
 
+
 class TestInit:
     def test_creates_instance(self, strategies):
         assert isinstance(strategies, RhetoricalStrategies)
@@ -59,6 +60,7 @@ class TestInit:
 # ============================================================
 # get_strategy_prompt
 # ============================================================
+
 
 class TestGetStrategyPrompt:
     def test_socratic(self, strategies):
@@ -90,11 +92,13 @@ class TestGetStrategyPrompt:
 # apply_strategy
 # ============================================================
 
+
 class TestApplyStrategy:
     def test_socratic_returns_string(self, strategies):
         arg = _make_argument()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.SOCRATIC_QUESTIONING, arg,
+            RhetoricalStrategy.SOCRATIC_QUESTIONING,
+            arg,
             CounterArgumentType.PREMISE_CHALLENGE,
         )
         assert isinstance(result, str)
@@ -103,7 +107,8 @@ class TestApplyStrategy:
     def test_reductio_returns_string(self, strategies):
         arg = _make_argument()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.REDUCTIO_AD_ABSURDUM, arg,
+            RhetoricalStrategy.REDUCTIO_AD_ABSURDUM,
+            arg,
             CounterArgumentType.DIRECT_REFUTATION,
         )
         assert isinstance(result, str)
@@ -111,7 +116,8 @@ class TestApplyStrategy:
     def test_analogical_returns_string(self, strategies):
         arg = _make_argument()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.ANALOGICAL_COUNTER, arg,
+            RhetoricalStrategy.ANALOGICAL_COUNTER,
+            arg,
             CounterArgumentType.COUNTER_EXAMPLE,
         )
         assert isinstance(result, str)
@@ -119,7 +125,8 @@ class TestApplyStrategy:
     def test_authority_returns_string(self, strategies):
         arg = _make_argument()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.AUTHORITY_APPEAL, arg,
+            RhetoricalStrategy.AUTHORITY_APPEAL,
+            arg,
             CounterArgumentType.DIRECT_REFUTATION,
         )
         assert isinstance(result, str)
@@ -127,7 +134,8 @@ class TestApplyStrategy:
     def test_statistical_returns_string(self, strategies):
         arg = _make_argument()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.STATISTICAL_EVIDENCE, arg,
+            RhetoricalStrategy.STATISTICAL_EVIDENCE,
+            arg,
             CounterArgumentType.DIRECT_REFUTATION,
         )
         assert isinstance(result, str)
@@ -135,7 +143,9 @@ class TestApplyStrategy:
     def test_unknown_uses_fallback(self, strategies):
         arg = _make_argument()
         result = strategies.apply_strategy(
-            "unknown", arg, CounterArgumentType.DIRECT_REFUTATION,
+            "unknown",
+            arg,
+            CounterArgumentType.DIRECT_REFUTATION,
         )
         assert isinstance(result, str)
 
@@ -143,6 +153,7 @@ class TestApplyStrategy:
 # ============================================================
 # suggest_strategy
 # ============================================================
+
 
 class TestSuggestStrategy:
     def test_statistical_content(self, strategies):
@@ -182,10 +193,13 @@ class TestSuggestStrategy:
 # get_best_strategy
 # ============================================================
 
+
 class TestGetBestStrategy:
     def test_direct_refutation(self, strategies):
         arg = _make_argument()
-        result = strategies.get_best_strategy(arg, CounterArgumentType.DIRECT_REFUTATION)
+        result = strategies.get_best_strategy(
+            arg, CounterArgumentType.DIRECT_REFUTATION
+        )
         assert result == RhetoricalStrategy.STATISTICAL_EVIDENCE
 
     def test_counter_example(self, strategies):
@@ -195,23 +209,30 @@ class TestGetBestStrategy:
 
     def test_alternative_explanation(self, strategies):
         arg = _make_argument()
-        result = strategies.get_best_strategy(arg, CounterArgumentType.ALTERNATIVE_EXPLANATION)
+        result = strategies.get_best_strategy(
+            arg, CounterArgumentType.ALTERNATIVE_EXPLANATION
+        )
         assert result == RhetoricalStrategy.ANALOGICAL_COUNTER
 
     def test_premise_challenge(self, strategies):
         arg = _make_argument()
-        result = strategies.get_best_strategy(arg, CounterArgumentType.PREMISE_CHALLENGE)
+        result = strategies.get_best_strategy(
+            arg, CounterArgumentType.PREMISE_CHALLENGE
+        )
         assert result == RhetoricalStrategy.SOCRATIC_QUESTIONING
 
     def test_reductio(self, strategies):
         arg = _make_argument()
-        result = strategies.get_best_strategy(arg, CounterArgumentType.REDUCTIO_AD_ABSURDUM)
+        result = strategies.get_best_strategy(
+            arg, CounterArgumentType.REDUCTIO_AD_ABSURDUM
+        )
         assert result == RhetoricalStrategy.REDUCTIO_AD_ABSURDUM
 
 
 # ============================================================
 # Strategy implementations
 # ============================================================
+
 
 class TestSocraticQuestioning:
     def test_no_premises(self, strategies):
@@ -345,6 +366,7 @@ class TestStatisticalEvidence:
 # ============================================================
 # Helper generators
 # ============================================================
+
 
 class TestHelperGenerators:
     def test_absurd_consequence_toujours(self, strategies):

--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_strategies_extended.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_strategies_extended.py
@@ -30,6 +30,7 @@ def _make_arg(content="Un argument", premises=None, conclusion="Donc c'est vrai"
 
 # ── get_strategy_prompt ──
 
+
 class TestGetStrategyPrompt:
     def test_socratic(self, strategies):
         prompt = strategies.get_strategy_prompt(RhetoricalStrategy.SOCRATIC_QUESTIONING)
@@ -54,21 +55,36 @@ class TestGetStrategyPrompt:
 
 # ── suggest_strategy ──
 
+
 class TestSuggestStrategy:
     def test_deductive_returns_reductio(self, strategies):
-        assert strategies.suggest_strategy("deductive", "simple") == RhetoricalStrategy.REDUCTIO_AD_ABSURDUM
+        assert (
+            strategies.suggest_strategy("deductive", "simple")
+            == RhetoricalStrategy.REDUCTIO_AD_ABSURDUM
+        )
 
     def test_inductive_returns_authority(self, strategies):
-        assert strategies.suggest_strategy("inductive", "simple") == RhetoricalStrategy.AUTHORITY_APPEAL
+        assert (
+            strategies.suggest_strategy("inductive", "simple")
+            == RhetoricalStrategy.AUTHORITY_APPEAL
+        )
 
     def test_abductive_returns_analogical(self, strategies):
-        assert strategies.suggest_strategy("abductive", "simple") == RhetoricalStrategy.ANALOGICAL_COUNTER
+        assert (
+            strategies.suggest_strategy("abductive", "simple")
+            == RhetoricalStrategy.ANALOGICAL_COUNTER
+        )
 
     def test_unknown_type_returns_socratic(self, strategies):
-        assert strategies.suggest_strategy("unknown", "simple") == RhetoricalStrategy.SOCRATIC_QUESTIONING
+        assert (
+            strategies.suggest_strategy("unknown", "simple")
+            == RhetoricalStrategy.SOCRATIC_QUESTIONING
+        )
 
     def test_statistical_content_overrides_type(self, strategies):
-        result = strategies.suggest_strategy("deductive", "Les statistiques montrent que")
+        result = strategies.suggest_strategy(
+            "deductive", "Les statistiques montrent que"
+        )
         assert result == RhetoricalStrategy.STATISTICAL_EVIDENCE
 
     def test_donnees_content_overrides_type(self, strategies):
@@ -76,7 +92,9 @@ class TestSuggestStrategy:
         assert result == RhetoricalStrategy.STATISTICAL_EVIDENCE
 
     def test_universal_content_overrides_type(self, strategies):
-        result = strategies.suggest_strategy("deductive", "Tous les humains sont mortels")
+        result = strategies.suggest_strategy(
+            "deductive", "Tous les humains sont mortels"
+        )
         assert result == RhetoricalStrategy.ANALOGICAL_COUNTER
 
     def test_chaque_content_overrides_type(self, strategies):
@@ -85,16 +103,21 @@ class TestSuggestStrategy:
 
     def test_statistique_checked_before_tous(self, strategies):
         # "statistique" check comes first
-        result = strategies.suggest_strategy("deductive", "Tous les statistiques montrent")
+        result = strategies.suggest_strategy(
+            "deductive", "Tous les statistiques montrent"
+        )
         assert result == RhetoricalStrategy.STATISTICAL_EVIDENCE
 
 
 # ── get_best_strategy ──
 
+
 class TestGetBestStrategy:
     def test_direct_refutation(self, strategies):
         arg = _make_arg()
-        result = strategies.get_best_strategy(arg, CounterArgumentType.DIRECT_REFUTATION)
+        result = strategies.get_best_strategy(
+            arg, CounterArgumentType.DIRECT_REFUTATION
+        )
         assert result == RhetoricalStrategy.STATISTICAL_EVIDENCE
 
     def test_counter_example(self, strategies):
@@ -104,21 +127,28 @@ class TestGetBestStrategy:
 
     def test_alternative_explanation(self, strategies):
         arg = _make_arg()
-        result = strategies.get_best_strategy(arg, CounterArgumentType.ALTERNATIVE_EXPLANATION)
+        result = strategies.get_best_strategy(
+            arg, CounterArgumentType.ALTERNATIVE_EXPLANATION
+        )
         assert result == RhetoricalStrategy.ANALOGICAL_COUNTER
 
     def test_premise_challenge(self, strategies):
         arg = _make_arg()
-        result = strategies.get_best_strategy(arg, CounterArgumentType.PREMISE_CHALLENGE)
+        result = strategies.get_best_strategy(
+            arg, CounterArgumentType.PREMISE_CHALLENGE
+        )
         assert result == RhetoricalStrategy.SOCRATIC_QUESTIONING
 
     def test_reductio(self, strategies):
         arg = _make_arg()
-        result = strategies.get_best_strategy(arg, CounterArgumentType.REDUCTIO_AD_ABSURDUM)
+        result = strategies.get_best_strategy(
+            arg, CounterArgumentType.REDUCTIO_AD_ABSURDUM
+        )
         assert result == RhetoricalStrategy.REDUCTIO_AD_ABSURDUM
 
 
 # ── apply_strategy: Socratic ──
+
 
 class TestApplySocratic:
     def test_no_premises(self, strategies):
@@ -130,147 +160,188 @@ class TestApplySocratic:
             confidence=0.7,
         )
         result = strategies.apply_strategy(
-            RhetoricalStrategy.SOCRATIC_QUESTIONING, arg, CounterArgumentType.PREMISE_CHALLENGE
+            RhetoricalStrategy.SOCRATIC_QUESTIONING,
+            arg,
+            CounterArgumentType.PREMISE_CHALLENGE,
         )
         assert "evidence" in result.lower() or "What" in result
 
     def test_premise_challenge_with_generalization(self, strategies):
         arg = _make_arg(premises=["Tous les oiseaux volent"])
         result = strategies.apply_strategy(
-            RhetoricalStrategy.SOCRATIC_QUESTIONING, arg, CounterArgumentType.PREMISE_CHALLENGE
+            RhetoricalStrategy.SOCRATIC_QUESTIONING,
+            arg,
+            CounterArgumentType.PREMISE_CHALLENGE,
         )
         assert "exception" in result.lower() or "certain" in result.lower()
 
     def test_premise_challenge_without_generalization(self, strategies):
         arg = _make_arg(premises=["Le ciel est bleu"])
         result = strategies.apply_strategy(
-            RhetoricalStrategy.SOCRATIC_QUESTIONING, arg, CounterArgumentType.PREMISE_CHALLENGE
+            RhetoricalStrategy.SOCRATIC_QUESTIONING,
+            arg,
+            CounterArgumentType.PREMISE_CHALLENGE,
         )
         assert "basis" in result.lower() or "question" in result.lower()
 
     def test_direct_refutation(self, strategies):
         arg = _make_arg(conclusion="La terre est plate")
         result = strategies.apply_strategy(
-            RhetoricalStrategy.SOCRATIC_QUESTIONING, arg, CounterArgumentType.DIRECT_REFUTATION
+            RhetoricalStrategy.SOCRATIC_QUESTIONING,
+            arg,
+            CounterArgumentType.DIRECT_REFUTATION,
         )
         assert "reconcile" in result.lower() or "conclusion" in result.lower()
 
     def test_default_counter_type(self, strategies):
         arg = _make_arg()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.SOCRATIC_QUESTIONING, arg, CounterArgumentType.ALTERNATIVE_EXPLANATION
+            RhetoricalStrategy.SOCRATIC_QUESTIONING,
+            arg,
+            CounterArgumentType.ALTERNATIVE_EXPLANATION,
         )
         assert "inevitable" in result.lower() or "perspective" in result.lower()
 
 
 # ── apply_strategy: Reductio ad Absurdum ──
 
+
 class TestApplyReductio:
     def test_toujours_in_conclusion(self, strategies):
         arg = _make_arg(conclusion="On doit toujours faire cela")
         result = strategies.apply_strategy(
-            RhetoricalStrategy.REDUCTIO_AD_ABSURDUM, arg, CounterArgumentType.REDUCTIO_AD_ABSURDUM
+            RhetoricalStrategy.REDUCTIO_AD_ABSURDUM,
+            arg,
+            CounterArgumentType.REDUCTIO_AD_ABSURDUM,
         )
         assert "absurd" in result.lower()
 
     def test_tous_in_conclusion(self, strategies):
         arg = _make_arg(conclusion="Tous les gens pensent ainsi")
         result = strategies.apply_strategy(
-            RhetoricalStrategy.REDUCTIO_AD_ABSURDUM, arg, CounterArgumentType.REDUCTIO_AD_ABSURDUM
+            RhetoricalStrategy.REDUCTIO_AD_ABSURDUM,
+            arg,
+            CounterArgumentType.REDUCTIO_AD_ABSURDUM,
         )
         assert "absurd" in result.lower()
 
     def test_doit_in_conclusion(self, strategies):
         arg = _make_arg(conclusion="On doit nécessairement accepter")
         result = strategies.apply_strategy(
-            RhetoricalStrategy.REDUCTIO_AD_ABSURDUM, arg, CounterArgumentType.REDUCTIO_AD_ABSURDUM
+            RhetoricalStrategy.REDUCTIO_AD_ABSURDUM,
+            arg,
+            CounterArgumentType.REDUCTIO_AD_ABSURDUM,
         )
         assert "obligation" in result.lower() or "universal" in result.lower()
 
     def test_default_conclusion(self, strategies):
         arg = _make_arg(conclusion="Le soleil est chaud")
         result = strategies.apply_strategy(
-            RhetoricalStrategy.REDUCTIO_AD_ABSURDUM, arg, CounterArgumentType.REDUCTIO_AD_ABSURDUM
+            RhetoricalStrategy.REDUCTIO_AD_ABSURDUM,
+            arg,
+            CounterArgumentType.REDUCTIO_AD_ABSURDUM,
         )
         assert "extreme" in result.lower() or "limits" in result.lower()
 
 
 # ── apply_strategy: Analogical Counter ──
 
+
 class TestApplyAnalogical:
     def test_counter_example(self, strategies):
         arg = _make_arg()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.ANALOGICAL_COUNTER, arg, CounterArgumentType.COUNTER_EXAMPLE
+            RhetoricalStrategy.ANALOGICAL_COUNTER,
+            arg,
+            CounterArgumentType.COUNTER_EXAMPLE,
         )
         assert "similar" in result.lower() or "same reasoning" in result.lower()
 
     def test_alternative_explanation(self, strategies):
         arg = _make_arg()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.ANALOGICAL_COUNTER, arg, CounterArgumentType.ALTERNATIVE_EXPLANATION
+            RhetoricalStrategy.ANALOGICAL_COUNTER,
+            arg,
+            CounterArgumentType.ALTERNATIVE_EXPLANATION,
         )
         assert "analogous" in result.lower() or "alternative" in result.lower()
 
     def test_default_type(self, strategies):
         arg = _make_arg()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.ANALOGICAL_COUNTER, arg, CounterArgumentType.DIRECT_REFUTATION
+            RhetoricalStrategy.ANALOGICAL_COUNTER,
+            arg,
+            CounterArgumentType.DIRECT_REFUTATION,
         )
         assert "like saying" in result.lower() or "limits" in result.lower()
 
 
 # ── apply_strategy: Authority Appeal ──
 
+
 class TestApplyAuthority:
     def test_direct_refutation(self, strategies):
         arg = _make_arg()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.AUTHORITY_APPEAL, arg, CounterArgumentType.DIRECT_REFUTATION
+            RhetoricalStrategy.AUTHORITY_APPEAL,
+            arg,
+            CounterArgumentType.DIRECT_REFUTATION,
         )
         assert "expert" in result.lower() or "incorrect" in result.lower()
 
     def test_premise_challenge(self, strategies):
         arg = _make_arg()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.AUTHORITY_APPEAL, arg, CounterArgumentType.PREMISE_CHALLENGE
+            RhetoricalStrategy.AUTHORITY_APPEAL,
+            arg,
+            CounterArgumentType.PREMISE_CHALLENGE,
         )
         assert "research" in result.lower() or "specialist" in result.lower()
 
     def test_default_type(self, strategies):
         arg = _make_arg()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.AUTHORITY_APPEAL, arg, CounterArgumentType.ALTERNATIVE_EXPLANATION
+            RhetoricalStrategy.AUTHORITY_APPEAL,
+            arg,
+            CounterArgumentType.ALTERNATIVE_EXPLANATION,
         )
         assert "consensus" in result.lower() or "studies" in result.lower()
 
 
 # ── apply_strategy: Statistical Evidence ──
 
+
 class TestApplyStatistical:
     def test_direct_refutation(self, strategies):
         arg = _make_arg()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.STATISTICAL_EVIDENCE, arg, CounterArgumentType.DIRECT_REFUTATION
+            RhetoricalStrategy.STATISTICAL_EVIDENCE,
+            arg,
+            CounterArgumentType.DIRECT_REFUTATION,
         )
         assert "15%" in result or "contradict" in result.lower()
 
     def test_premise_challenge(self, strategies):
         arg = _make_arg()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.STATISTICAL_EVIDENCE, arg, CounterArgumentType.PREMISE_CHALLENGE
+            RhetoricalStrategy.STATISTICAL_EVIDENCE,
+            arg,
+            CounterArgumentType.PREMISE_CHALLENGE,
         )
         assert "data" in result.lower() or "empirical" in result.lower()
 
     def test_default_type(self, strategies):
         arg = _make_arg()
         result = strategies.apply_strategy(
-            RhetoricalStrategy.STATISTICAL_EVIDENCE, arg, CounterArgumentType.ALTERNATIVE_EXPLANATION
+            RhetoricalStrategy.STATISTICAL_EVIDENCE,
+            arg,
+            CounterArgumentType.ALTERNATIVE_EXPLANATION,
         )
         assert "numbers" in result.lower() or "15%" in result
 
 
 # ── Helper generators ──
+
 
 class TestHelperGenerators:
     def test_absurd_consequence_toujours(self, strategies):
@@ -330,36 +401,49 @@ class TestHelperGenerators:
 
     def test_fallback_direct_refutation(self, strategies):
         arg = _make_arg()
-        result = strategies._fallback_counter_argument(arg, CounterArgumentType.DIRECT_REFUTATION)
+        result = strategies._fallback_counter_argument(
+            arg, CounterArgumentType.DIRECT_REFUTATION
+        )
         assert "incorrect" in result.lower()
 
     def test_fallback_counter_example(self, strategies):
         arg = _make_arg()
-        result = strategies._fallback_counter_argument(arg, CounterArgumentType.COUNTER_EXAMPLE)
+        result = strategies._fallback_counter_argument(
+            arg, CounterArgumentType.COUNTER_EXAMPLE
+        )
         assert "cases" in result.lower() or "contradict" in result.lower()
 
     def test_fallback_premise_challenge(self, strategies):
         arg = _make_arg(premises=["La terre est ronde"])
-        result = strategies._fallback_counter_argument(arg, CounterArgumentType.PREMISE_CHALLENGE)
+        result = strategies._fallback_counter_argument(
+            arg, CounterArgumentType.PREMISE_CHALLENGE
+        )
         assert "premise" in result.lower() or "La terre" in result
 
     def test_fallback_premise_challenge_no_premises(self, strategies):
         arg = _make_arg(premises=[])
-        result = strategies._fallback_counter_argument(arg, CounterArgumentType.PREMISE_CHALLENGE)
+        result = strategies._fallback_counter_argument(
+            arg, CounterArgumentType.PREMISE_CHALLENGE
+        )
         assert "main" in result.lower() or "premise" in result.lower()
 
     def test_fallback_alternative(self, strategies):
         arg = _make_arg()
-        result = strategies._fallback_counter_argument(arg, CounterArgumentType.ALTERNATIVE_EXPLANATION)
+        result = strategies._fallback_counter_argument(
+            arg, CounterArgumentType.ALTERNATIVE_EXPLANATION
+        )
         assert "alternative" in result.lower()
 
     def test_fallback_reductio(self, strategies):
         arg = _make_arg()
-        result = strategies._fallback_counter_argument(arg, CounterArgumentType.REDUCTIO_AD_ABSURDUM)
+        result = strategies._fallback_counter_argument(
+            arg, CounterArgumentType.REDUCTIO_AD_ABSURDUM
+        )
         assert "absurd" in result.lower()
 
 
 # ── apply_strategy fallback ──
+
 
 class TestApplyStrategyFallback:
     def test_unknown_strategy_uses_fallback(self, strategies):
@@ -368,12 +452,15 @@ class TestApplyStrategyFallback:
         # Remove a strategy entry to force fallback
         strategies.strategies.pop(RhetoricalStrategy.SOCRATIC_QUESTIONING, None)
         result = strategies.apply_strategy(
-            RhetoricalStrategy.SOCRATIC_QUESTIONING, arg, CounterArgumentType.DIRECT_REFUTATION
+            RhetoricalStrategy.SOCRATIC_QUESTIONING,
+            arg,
+            CounterArgumentType.DIRECT_REFUTATION,
         )
         assert len(result) > 10
 
 
 # ── init ──
+
 
 class TestInit:
     def test_all_strategies_registered(self, strategies):

--- a/tests/unit/argumentation_analysis/agents/core/debate/test_debate.py
+++ b/tests/unit/argumentation_analysis/agents/core/debate/test_debate.py
@@ -22,7 +22,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from semantic_kernel import Kernel
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -32,9 +31,7 @@ from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 def mock_kernel():
     """Create a Kernel with a mock OpenAI service for testing."""
     kernel = Kernel()
-    service = OpenAIChatCompletion(
-        service_id="default", api_key="test-key"
-    )
+    service = OpenAIChatCompletion(service_id="default", api_key="test-key")
     kernel.add_service(service)
     return kernel
 
@@ -265,9 +262,7 @@ class TestDebatePlugin:
         )
 
         plugin = DebatePlugin()
-        result = plugin.suggest_debate_strategy(
-            phase="opening", turn_number="1"
-        )
+        result = plugin.suggest_debate_strategy(phase="opening", turn_number="1")
         data = json.loads(result)
         assert data["strategy"] == "balanced"
 
@@ -615,15 +610,9 @@ class TestWaltonKrabbeProtocols:
         prop = Proposition(content="Test")
         history = [
             DialogueMove(speaker="a", act=SpeechAct.CLAIM, content=prop),
-            DialogueMove(
-                speaker="b", act=SpeechAct.UNDERSTAND, content=prop
-            ),
-            DialogueMove(
-                speaker="a", act=SpeechAct.UNDERSTAND, content=prop
-            ),
-            DialogueMove(
-                speaker="b", act=SpeechAct.UNDERSTAND, content=prop
-            ),
+            DialogueMove(speaker="b", act=SpeechAct.UNDERSTAND, content=prop),
+            DialogueMove(speaker="a", act=SpeechAct.UNDERSTAND, content=prop),
+            DialogueMove(speaker="b", act=SpeechAct.UNDERSTAND, content=prop),
         ]
         assert protocol.is_terminal_state(history)
 
@@ -771,9 +760,7 @@ class TestKnowledgeBase:
         kb = KnowledgeBase()
         target = Proposition(content="It is sunny")
         neg = Proposition(content="\u00acIt is sunny")
-        arg = FormalArgument(
-            premises=[Proposition(content="Clouds")], conclusion=neg
-        )
+        arg = FormalArgument(premises=[Proposition(content="Clouds")], conclusion=neg)
         kb.add_argument(arg)
 
         attackers = kb.find_attacking_arguments(target)
@@ -824,9 +811,7 @@ class TestDebateAgent:
 
         self.AgentClass = DebateAgent
         self.kernel = Kernel()
-        service = OpenAIChatCompletion(
-            service_id="default", api_key="test-key"
-        )
+        service = OpenAIChatCompletion(service_id="default", api_key="test-key")
         self.kernel.add_service(service)
 
     def _create_agent(self, **kwargs):
@@ -870,9 +855,7 @@ class TestDebateAgent:
             new_callable=AsyncMock,
             side_effect=RuntimeError("LLM unavailable"),
         ):
-            arg = await agent.generate_argument(
-                state, ArgumentType.OPENING_STATEMENT
-            )
+            arg = await agent.generate_argument(state, ArgumentType.OPENING_STATEMENT)
 
         assert arg.agent_name == "Test"
         assert arg.content != ""
@@ -899,8 +882,7 @@ class TestDebateAgent:
         )
 
         mock_response = (
-            "Renewable energy is the future because studies show "
-            "declining costs."
+            "Renewable energy is the future because studies show " "declining costs."
         )
         with patch.object(
             agent,
@@ -908,9 +890,7 @@ class TestDebateAgent:
             new_callable=AsyncMock,
             return_value=mock_response,
         ):
-            arg = await agent.generate_argument(
-                state, ArgumentType.EVIDENCE
-            )
+            arg = await agent.generate_argument(state, ArgumentType.EVIDENCE)
 
         assert "Renewable" in arg.content or "energy" in arg.content
 
@@ -983,9 +963,7 @@ class TestDebateModerator:
     def setup_method(self):
         """Set up kernel for agent creation."""
         self.kernel = Kernel()
-        service = OpenAIChatCompletion(
-            service_id="default", api_key="test-key"
-        )
+        service = OpenAIChatCompletion(service_id="default", api_key="test-key")
         self.kernel.add_service(service)
 
     def test_moderator_creation(self):

--- a/tests/unit/argumentation_analysis/agents/core/debate/test_debate_definitions.py
+++ b/tests/unit/argumentation_analysis/agents/core/debate/test_debate_definitions.py
@@ -14,8 +14,8 @@ from argumentation_analysis.agents.core.debate.debate_definitions import (
     AGENT_PERSONALITIES,
 )
 
-
 # ── Enums ──
+
 
 class TestArgumentType:
     def test_all_values(self):
@@ -43,6 +43,7 @@ class TestDebatePhase:
 
 
 # ── ArgumentMetrics ──
+
 
 class TestArgumentMetrics:
     def test_defaults_all_zero(self):
@@ -74,6 +75,7 @@ class TestArgumentMetrics:
 
 
 # ── EnhancedArgument ──
+
 
 class TestEnhancedArgument:
     @pytest.fixture
@@ -190,6 +192,7 @@ class TestEnhancedArgument:
 
 # ── DebateState ──
 
+
 class TestDebateState:
     @pytest.fixture
     def basic_state(self):
@@ -290,6 +293,7 @@ class TestDebateState:
 
 # ── AGENT_PERSONALITIES ──
 
+
 class TestAgentPersonalities:
     def test_eight_personalities(self):
         assert len(AGENT_PERSONALITIES) == 8
@@ -308,23 +312,28 @@ class TestAgentPersonalities:
         valid_metrics = {f.name for f in ArgumentMetrics.__dataclass_fields__.values()}
         for name, personality in AGENT_PERSONALITIES.items():
             for strength in personality["strengths"]:
-                assert strength in valid_metrics, (
-                    f"{name} has invalid strength '{strength}'"
-                )
+                assert (
+                    strength in valid_metrics
+                ), f"{name} has invalid strength '{strength}'"
 
     def test_weaknesses_are_valid_metric_names(self):
         valid_metrics = {f.name for f in ArgumentMetrics.__dataclass_fields__.values()}
         for name, personality in AGENT_PERSONALITIES.items():
             for weakness in personality["weaknesses"]:
-                assert weakness in valid_metrics, (
-                    f"{name} has invalid weakness '{weakness}'"
-                )
+                assert (
+                    weakness in valid_metrics
+                ), f"{name} has invalid weakness '{weakness}'"
 
     def test_known_personalities(self):
         expected = [
-            "The Scholar", "The Pragmatist", "The Devil's Advocate",
-            "The Idealist", "The Skeptic", "The Populist",
-            "The Economist", "The Philosopher",
+            "The Scholar",
+            "The Pragmatist",
+            "The Devil's Advocate",
+            "The Idealist",
+            "The Skeptic",
+            "The Populist",
+            "The Economist",
+            "The Philosopher",
         ]
         for name in expected:
             assert name in AGENT_PERSONALITIES

--- a/tests/unit/argumentation_analysis/agents/core/debate/test_debate_scoring.py
+++ b/tests/unit/argumentation_analysis/agents/core/debate/test_debate_scoring.py
@@ -29,6 +29,7 @@ def _make_arg(content, agent="Alice", position="for"):
 
 # ── Init ──
 
+
 class TestAnalyzerInit:
     def test_indicators_loaded(self, analyzer):
         assert len(analyzer.logical_indicators) > 0
@@ -43,6 +44,7 @@ class TestAnalyzerInit:
 
 
 # ── Logical Coherence ──
+
 
 class TestLogicalCoherence:
     def test_baseline(self, analyzer):
@@ -72,13 +74,16 @@ class TestLogicalCoherence:
 
 # ── Evidence Quality ──
 
+
 class TestEvidenceQuality:
     def test_baseline(self, analyzer):
         score = analyzer._assess_evidence_quality("Simple opinion.")
         assert 0.2 <= score <= 0.4  # baseline ~0.3
 
     def test_with_citations(self, analyzer):
-        text = "Studies show that 85% of participants improved. According to the journal."
+        text = (
+            "Studies show that 85% of participants improved. According to the journal."
+        )
         score = analyzer._assess_evidence_quality(text)
         assert score > 0.5
 
@@ -99,6 +104,7 @@ class TestEvidenceQuality:
 
 
 # ── Relevance ──
+
 
 class TestRelevance:
     def test_no_context(self, analyzer):
@@ -129,6 +135,7 @@ class TestRelevance:
 
 # ── Emotional Appeal ──
 
+
 class TestEmotionalAppeal:
     def test_neutral(self, analyzer):
         score = analyzer._assess_emotional_appeal("The data is clear.")
@@ -157,6 +164,7 @@ class TestEmotionalAppeal:
 
 # ── Readability ──
 
+
 class TestReadability:
     def test_short_sentences(self, analyzer):
         text = "Short sentence. Another one. Easy to read."
@@ -176,6 +184,7 @@ class TestReadability:
 
 # ── Fact Check ──
 
+
 class TestFactCheck:
     def test_hedging_language(self, analyzer):
         text = "This might possibly be true. It could likely happen."
@@ -194,6 +203,7 @@ class TestFactCheck:
 
 
 # ── Novelty ──
+
 
 class TestNovelty:
     def test_no_context(self, analyzer):
@@ -223,6 +233,7 @@ class TestNovelty:
 
 # ── Full Analysis ──
 
+
 class TestAnalyzeArgument:
     def test_returns_metrics(self, analyzer):
         arg = _make_arg("Because of the evidence, therefore the conclusion follows.")
@@ -242,7 +253,9 @@ class TestAnalyzeArgument:
         assert 0 <= metrics.persuasiveness <= 1.0
 
     def test_persuasiveness_is_weighted_combo(self, analyzer):
-        arg = _make_arg("Because studies show evidence, therefore the conclusion follows.")
+        arg = _make_arg(
+            "Because studies show evidence, therefore the conclusion follows."
+        )
         metrics = analyzer.analyze_argument(arg, [])
         expected = min(
             metrics.logical_coherence * 0.25

--- a/tests/unit/argumentation_analysis/agents/core/debate/test_protocols.py
+++ b/tests/unit/argumentation_analysis/agents/core/debate/test_protocols.py
@@ -12,8 +12,8 @@ from argumentation_analysis.agents.core.debate.protocols import (
     PersuasionProtocol,
 )
 
-
 # ── Enums ──
+
 
 class TestDialogueType:
     def test_has_six_types(self):
@@ -21,8 +21,12 @@ class TestDialogueType:
 
     def test_values(self):
         expected = {
-            "information_seeking", "inquiry", "persuasion",
-            "negotiation", "deliberation", "eristic",
+            "information_seeking",
+            "inquiry",
+            "persuasion",
+            "negotiation",
+            "deliberation",
+            "eristic",
         }
         assert {t.value for t in DialogueType} == expected
 
@@ -33,13 +37,21 @@ class TestSpeechAct:
 
     def test_values(self):
         expected = {
-            "claim", "question", "challenge", "argue", "concede",
-            "retract", "support", "refute", "understand",
+            "claim",
+            "question",
+            "challenge",
+            "argue",
+            "concede",
+            "retract",
+            "support",
+            "refute",
+            "understand",
         }
         assert {a.value for a in SpeechAct} == expected
 
 
 # ── Proposition ──
+
 
 class TestProposition:
     def test_init(self):
@@ -88,6 +100,7 @@ class TestProposition:
 
 # ── FormalArgument ──
 
+
 class TestFormalArgument:
     def test_init(self):
         p1 = Proposition(content="P1")
@@ -122,6 +135,7 @@ class TestFormalArgument:
 
 # ── DialogueMove ──
 
+
 class TestDialogueMove:
     def test_init(self):
         p = Proposition(content="test")
@@ -133,18 +147,14 @@ class TestDialogueMove:
         assert move.id != ""  # auto UUID
 
     def test_str(self):
-        move = DialogueMove(
-            speaker="Bob", act=SpeechAct.QUESTION, content="Why?"
-        )
+        move = DialogueMove(speaker="Bob", act=SpeechAct.QUESTION, content="Why?")
         s = str(move)
         assert "Bob" in s
         assert "question" in s
         assert "Why?" in s
 
     def test_custom_id(self):
-        move = DialogueMove(
-            speaker="A", act=SpeechAct.CLAIM, content="X", id="move-1"
-        )
+        move = DialogueMove(speaker="A", act=SpeechAct.CLAIM, content="X", id="move-1")
         assert move.id == "move-1"
 
     def test_with_target(self):
@@ -155,6 +165,7 @@ class TestDialogueMove:
 
 
 # ── InquiryProtocol ──
+
 
 class TestInquiryProtocol:
     @pytest.fixture
@@ -198,9 +209,7 @@ class TestInquiryProtocol:
 
     def test_termination_max_moves(self, protocol):
         """More than 25 moves → terminal."""
-        moves = [
-            DialogueMove("A", SpeechAct.CLAIM, f"arg{i}") for i in range(26)
-        ]
+        moves = [DialogueMove("A", SpeechAct.CLAIM, f"arg{i}") for i in range(26)]
         assert protocol.is_terminal_state(moves)
 
     def test_not_terminal_few_moves(self, protocol):
@@ -236,6 +245,7 @@ class TestInquiryProtocol:
 
 # ── PersuasionProtocol ──
 
+
 class TestPersuasionProtocol:
     @pytest.fixture
     def protocol(self):
@@ -266,9 +276,7 @@ class TestPersuasionProtocol:
 
     def test_termination_max_moves(self, protocol):
         """More than 30 moves → terminal."""
-        moves = [
-            DialogueMove("A", SpeechAct.CLAIM, f"arg{i}") for i in range(31)
-        ]
+        moves = [DialogueMove("A", SpeechAct.CLAIM, f"arg{i}") for i in range(31)]
         assert protocol.is_terminal_state(moves)
 
     def test_termination_double_retract(self, protocol):

--- a/tests/unit/argumentation_analysis/agents/core/governance/test_conflict_resolution.py
+++ b/tests/unit/argumentation_analysis/agents/core/governance/test_conflict_resolution.py
@@ -11,8 +11,8 @@ from argumentation_analysis.agents.core.governance.conflict_resolution import (
     compromise_mediation,
 )
 
-
 # ── detect_conflicts ──
+
 
 class TestDetectConflicts:
     def test_no_conflicts_same_positions(self):
@@ -66,6 +66,7 @@ class TestDetectConflicts:
 
 # ── resolve_conflict ──
 
+
 class TestResolveConflict:
     @pytest.fixture
     def conflict(self):
@@ -103,6 +104,7 @@ class TestResolveConflict:
 
 # ── Individual mediation functions ──
 
+
 class TestMediationStrategies:
     @pytest.fixture
     def conflict(self):
@@ -127,12 +129,20 @@ class TestMediationStrategies:
         assert "middle ground" in result["details"]
 
     def test_all_results_have_agents(self, conflict):
-        for fn in [collaborative_mediation, competitive_mediation, compromise_mediation]:
+        for fn in [
+            collaborative_mediation,
+            competitive_mediation,
+            compromise_mediation,
+        ]:
             result = fn(conflict)
             assert result["agents"] == ["X", "Y"]
 
     def test_all_results_have_details(self, conflict):
-        for fn in [collaborative_mediation, competitive_mediation, compromise_mediation]:
+        for fn in [
+            collaborative_mediation,
+            competitive_mediation,
+            compromise_mediation,
+        ]:
             result = fn(conflict)
             assert isinstance(result["details"], str)
             assert len(result["details"]) > 0
@@ -145,6 +155,7 @@ class TestMediationStrategies:
 
 
 # ── Integration ──
+
 
 class TestConflictResolutionIntegration:
     def test_detect_then_resolve(self):

--- a/tests/unit/argumentation_analysis/agents/core/governance/test_governance_methods.py
+++ b/tests/unit/argumentation_analysis/agents/core/governance/test_governance_methods.py
@@ -29,13 +29,21 @@ def make_agent(decision=None, preferences=None, personality="default"):
 
 # ── GOVERNANCE_METHODS registry ──
 
+
 class TestGovernanceMethodsRegistry:
     def test_has_seven_methods(self):
         assert len(GOVERNANCE_METHODS) == 7
 
     def test_keys(self):
-        expected = {"majority", "plurality", "borda", "condorcet",
-                    "quadratic", "byzantine", "raft"}
+        expected = {
+            "majority",
+            "plurality",
+            "borda",
+            "condorcet",
+            "quadratic",
+            "byzantine",
+            "raft",
+        }
         assert set(GOVERNANCE_METHODS.keys()) == expected
 
     def test_all_callable(self):
@@ -44,6 +52,7 @@ class TestGovernanceMethodsRegistry:
 
 
 # ── majority_voting ──
+
 
 class TestMajorityVoting:
     def test_unanimous(self):
@@ -65,6 +74,7 @@ class TestMajorityVoting:
 
 # ── plurality_voting ──
 
+
 class TestPluralityVoting:
     def test_same_as_majority(self):
         agents = [make_agent("A"), make_agent("B"), make_agent("A")]
@@ -72,6 +82,7 @@ class TestPluralityVoting:
 
 
 # ── borda_count ──
+
 
 class TestBordaCount:
     def test_unanimous_preference(self):
@@ -107,6 +118,7 @@ class TestBordaCount:
 
 # ── condorcet_method ──
 
+
 class TestCondorcetMethod:
     def test_condorcet_winner_exists(self):
         # A beats B (2-1), A beats C (2-1)
@@ -136,6 +148,7 @@ class TestCondorcetMethod:
 
 
 # ── quadratic_voting ──
+
 
 class TestQuadraticVoting:
     def test_default_budget(self):
@@ -171,6 +184,7 @@ class TestQuadraticVoting:
 
 # ── byzantine_consensus ──
 
+
 class TestByzantineConsensus:
     def test_no_byzantine(self):
         agents = [make_agent("A"), make_agent("A"), make_agent("A")]
@@ -198,6 +212,7 @@ class TestByzantineConsensus:
 
 
 # ── raft_consensus ──
+
 
 class TestRaftConsensus:
     def test_proposal_accepted(self):

--- a/tests/unit/argumentation_analysis/agents/core/governance/test_governance_metrics.py
+++ b/tests/unit/argumentation_analysis/agents/core/governance/test_governance_metrics.py
@@ -16,8 +16,8 @@ from argumentation_analysis.agents.core.governance.metrics import (
     validate_scenario,
 )
 
-
 # ── consensus_rate ──
+
 
 class TestConsensusRate:
     def test_unanimous(self):
@@ -42,6 +42,7 @@ class TestConsensusRate:
 
 
 # ── gini ──
+
 
 class TestGini:
     def test_perfect_equality(self):
@@ -70,6 +71,7 @@ class TestGini:
 
 # ── fairness_index ──
 
+
 class TestFairnessIndex:
     def test_equal_satisfaction(self):
         r = {"satisfaction": [0.8, 0.8, 0.8]}
@@ -89,6 +91,7 @@ class TestFairnessIndex:
 
 
 # ── efficiency ──
+
 
 class TestEfficiency:
     def test_one_round(self):
@@ -114,6 +117,7 @@ class TestEfficiency:
 
 # ── satisfaction ──
 
+
 class TestSatisfaction:
     def test_mean(self):
         r = {"satisfaction": [0.5, 0.7, 0.9]}
@@ -128,6 +132,7 @@ class TestSatisfaction:
 
 
 # ── stability ──
+
 
 class TestStability:
     def test_all_same_winner(self):
@@ -147,6 +152,7 @@ class TestStability:
 
 # ── per_agent_satisfaction ──
 
+
 class TestPerAgentSatisfaction:
     def test_normal(self):
         r = {
@@ -162,6 +168,7 @@ class TestPerAgentSatisfaction:
 
 
 # ── summarize_results ──
+
 
 class TestSummarizeResults:
     def test_single_run(self):
@@ -181,12 +188,16 @@ class TestSummarizeResults:
     def test_batch_runs(self):
         runs = [
             {
-                "votes": ["A", "A"], "winner": "A",
-                "satisfaction": [0.9, 0.9], "rounds": 1,
+                "votes": ["A", "A"],
+                "winner": "A",
+                "satisfaction": [0.9, 0.9],
+                "rounds": 1,
             },
             {
-                "votes": ["A", "B"], "winner": "A",
-                "satisfaction": [0.8, 0.6], "rounds": 2,
+                "votes": ["A", "B"],
+                "winner": "A",
+                "satisfaction": [0.8, 0.6],
+                "rounds": 2,
             },
         ]
         summary = summarize_results(runs)
@@ -196,6 +207,7 @@ class TestSummarizeResults:
 
 
 # ── validate_scenario ──
+
 
 class TestValidateScenario:
     def test_valid(self):

--- a/tests/unit/argumentation_analysis/agents/core/governance/test_governance_simulation.py
+++ b/tests/unit/argumentation_analysis/agents/core/governance/test_governance_simulation.py
@@ -13,11 +13,15 @@ from argumentation_analysis.agents.core.governance.simulation import (
 )
 
 
-def make_sim_agent(name, decision=None, preferences=None, personality="default", trust=None):
+def make_sim_agent(
+    name, decision=None, preferences=None, personality="default", trust=None
+):
     """Create a mock agent for simulation tests."""
     agent = MagicMock()
     agent.name = name
-    agent.decide = MagicMock(return_value=decision or (preferences[0] if preferences else "A"))
+    agent.decide = MagicMock(
+        return_value=decision or (preferences[0] if preferences else "A")
+    )
     agent.preferences = preferences or ["A", "B"]
     agent.personality = personality
     agent.trust = trust or {}
@@ -27,6 +31,7 @@ def make_sim_agent(name, decision=None, preferences=None, personality="default",
 
 
 # ── shapley_value ──
+
 
 class TestShapleyValue:
     def test_empty_coalition(self):
@@ -58,7 +63,9 @@ class TestShapleyValue:
     def test_values_sum_to_grand_coalition(self):
         agents = [make_sim_agent(n) for n in ["X", "Y"]]
         # Shapley values sum to v(N) - v(empty) = 3.0 - 0.0 = 3.0
-        payoff = lambda names: 3.0 if len(names) == 2 else (1.0 if len(names) == 1 else 0.0)
+        payoff = lambda names: (
+            3.0 if len(names) == 2 else (1.0 if len(names) == 1 else 0.0)
+        )
         result = shapley_value(agents, agents, payoff)
         total = sum(result.values())
         # v(N) - v(∅) = 3.0 - 0.0, but each agent's marginal is relative
@@ -68,6 +75,7 @@ class TestShapleyValue:
 
 
 # ── get_neighbors ──
+
 
 class TestGetNeighbors:
     def test_fully_connected(self):
@@ -98,6 +106,7 @@ class TestGetNeighbors:
 
 # ── distributed_gossip_consensus ──
 
+
 class TestDistributedGossipConsensus:
     def test_all_agree(self):
         agents = [make_sim_agent(n, decision="X") for n in ["A", "B", "C"]]
@@ -112,7 +121,9 @@ class TestDistributedGossipConsensus:
             make_sim_agent("C", decision="Y"),
         ]
         adjacency = [[0, 1, 1], [1, 0, 1], [1, 1, 0]]
-        winner, votes = distributed_gossip_consensus(agents, ["X", "Y"], adjacency, rounds=5)
+        winner, votes = distributed_gossip_consensus(
+            agents, ["X", "Y"], adjacency, rounds=5
+        )
         assert winner == "X"
 
     def test_returns_votes_dict(self):
@@ -129,6 +140,7 @@ class TestDistributedGossipConsensus:
 
 
 # ── simulate_governance ──
+
 
 class TestSimulateGovernance:
     def test_with_adjacency_networked(self):

--- a/tests/unit/argumentation_analysis/agents/core/governance/test_social_choice.py
+++ b/tests/unit/argumentation_analysis/agents/core/governance/test_social_choice.py
@@ -10,6 +10,7 @@ Validates:
 - Pairwise matrix construction
 - GovernancePlugin social choice integration
 """
+
 import json
 import pytest
 
@@ -23,7 +24,6 @@ from argumentation_analysis.agents.core.governance.social_choice import (
     pairwise_matrix,
     SOCIAL_CHOICE_METHODS,
 )
-
 
 # ──── Test Data ────
 
@@ -272,6 +272,7 @@ class TestGovernancePluginSocialChoice:
     @pytest.fixture
     def plugin(self):
         from argumentation_analysis.plugins.governance_plugin import GovernancePlugin
+
         return GovernancePlugin()
 
     def test_list_methods_includes_social_choice(self, plugin):

--- a/tests/unit/argumentation_analysis/agents/core/informal/test_informal_agent_adapter.py
+++ b/tests/unit/argumentation_analysis/agents/core/informal/test_informal_agent_adapter.py
@@ -8,7 +8,6 @@ import pytest
 from unittest.mock import MagicMock, patch
 from datetime import datetime
 
-
 # Patch the SK import so that InformalAnalysisAgent doesn't try to use SK
 with patch(
     "argumentation_analysis.agents.core.informal.informal_agent_adapter.InformalAnalysisAgent",
@@ -22,6 +21,7 @@ with patch(
 # ============================================================
 # Initialization
 # ============================================================
+
 
 class TestInformalAgentInit:
     def test_default_init(self):
@@ -70,6 +70,7 @@ class TestInformalAgentInit:
 # get_available_tools
 # ============================================================
 
+
 class TestGetAvailableTools:
     def test_empty_tools(self):
         agent = InformalAgent()
@@ -89,6 +90,7 @@ class TestGetAvailableTools:
 # ============================================================
 # get_agent_capabilities
 # ============================================================
+
 
 class TestGetAgentCapabilities:
     def test_no_tools_all_false(self):
@@ -135,6 +137,7 @@ class TestGetAgentCapabilities:
 # ============================================================
 # _categorize_fallacies (pure logic)
 # ============================================================
+
 
 class TestCategorizeFallacies:
     def test_empty_list(self):
@@ -221,7 +224,14 @@ class TestCategorizeFallacies:
     def test_all_six_categories_present(self):
         agent = InformalAgent()
         result = agent._categorize_fallacies([])
-        expected = {"RELEVANCE", "INDUCTION", "CAUSALITE", "AMBIGUITE", "PRESUPPOSITION", "AUTRES"}
+        expected = {
+            "RELEVANCE",
+            "INDUCTION",
+            "CAUSALITE",
+            "AMBIGUITE",
+            "PRESUPPOSITION",
+            "AUTRES",
+        }
         assert set(result.keys()) == expected
 
     def test_case_normalization(self):
@@ -235,6 +245,7 @@ class TestCategorizeFallacies:
 # ============================================================
 # analyze_text (degraded mode — no SK agent)
 # ============================================================
+
 
 class TestAnalyzeText:
     def test_basic_result_structure(self):
@@ -250,7 +261,9 @@ class TestAnalyzeText:
 
     def test_with_fallacy_detector_detect_method(self):
         detector = MagicMock()
-        detector.detect.return_value = [{"fallacy_type": "ad_hominem", "confidence": 0.9}]
+        detector.detect.return_value = [
+            {"fallacy_type": "ad_hominem", "confidence": 0.9}
+        ]
         agent = InformalAgent(tools={"fallacy_detector": detector})
         result = agent.analyze_text("Tu as tort car tu es bête")
         assert len(result["fallacies"]) == 1
@@ -286,6 +299,7 @@ class TestAnalyzeText:
 # perform_complete_analysis
 # ============================================================
 
+
 class TestPerformCompleteAnalysis:
     def test_basic_structure(self):
         agent = InformalAgent()
@@ -302,9 +316,7 @@ class TestPerformCompleteAnalysis:
     def test_with_contextual_analyzer(self):
         ctx_analyzer = MagicMock()
         ctx_analyzer.analyze_context.return_value = {"context_type": "political"}
-        agent = InformalAgent(
-            tools={"contextual_analyzer": ctx_analyzer}
-        )
+        agent = InformalAgent(tools={"contextual_analyzer": ctx_analyzer})
         result = agent.perform_complete_analysis("text", context="debate")
         assert result["contextual_analysis"] == {"context_type": "political"}
 
@@ -340,6 +352,7 @@ class TestPerformCompleteAnalysis:
 # ============================================================
 # _get_timestamp
 # ============================================================
+
 
 class TestGetTimestamp:
     def test_returns_string(self):

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_af_handler_extended.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_af_handler_extended.py
@@ -8,6 +8,7 @@ Validates:
 - Error handling (invalid semantics, unavailable reasoner)
 - Framework building and extension conversion
 """
+
 import pytest
 from unittest.mock import patch, MagicMock, PropertyMock
 
@@ -15,7 +16,9 @@ from argumentation_analysis.agents.core.logic.af_handler import (
     AFHandler,
     SEMANTICS_REASONERS,
 )
-from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+from argumentation_analysis.agents.core.logic.tweety_initializer import (
+    TweetyInitializer,
+)
 
 
 @pytest.fixture
@@ -68,8 +71,17 @@ class TestSupportedSemantics:
 
     def test_supported_semantics_list(self):
         expected = [
-            "preferred", "grounded", "stable", "complete", "admissible",
-            "conflict_free", "semi_stable", "stage", "cf2", "ideal", "naive",
+            "preferred",
+            "grounded",
+            "stable",
+            "complete",
+            "admissible",
+            "conflict_free",
+            "semi_stable",
+            "stage",
+            "cf2",
+            "ideal",
+            "naive",
         ]
         assert AFHandler.supported_semantics() == expected
 

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_belief_set.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_belief_set.py
@@ -10,8 +10,8 @@ from argumentation_analysis.agents.core.logic.belief_set import (
     ModalBeliefSet,
 )
 
-
 # ── PropositionalBeliefSet ──
+
 
 class TestPropositionalBeliefSet:
     def test_init(self):
@@ -39,6 +39,7 @@ class TestPropositionalBeliefSet:
 
 # ── FirstOrderBeliefSet ──
 
+
 class TestFirstOrderBeliefSet:
     def test_init(self):
         bs = FirstOrderBeliefSet("forall(X, p(X))")
@@ -61,6 +62,7 @@ class TestFirstOrderBeliefSet:
 
 # ── ModalBeliefSet ──
 
+
 class TestModalBeliefSet:
     def test_init(self):
         bs = ModalBeliefSet("[]p => <>q")
@@ -75,6 +77,7 @@ class TestModalBeliefSet:
 
 
 # ── BeliefSet.is_empty ──
+
 
 class TestIsEmpty:
     def test_none_content(self):
@@ -107,6 +110,7 @@ class TestIsEmpty:
 
 
 # ── BeliefSet.from_dict ──
+
 
 class TestFromDict:
     def test_propositional(self):
@@ -157,6 +161,7 @@ class TestFromDict:
 
 # ── Abstract class ──
 
+
 class TestAbstractBeliefSet:
     def test_cannot_instantiate_directly(self):
         with pytest.raises(TypeError):
@@ -164,4 +169,5 @@ class TestAbstractBeliefSet:
 
     def test_is_abstract(self):
         import inspect
+
         assert inspect.isabstract(BeliefSet)

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_cl_handler.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_cl_handler.py
@@ -11,11 +11,14 @@ Validates:
 - ZReasoner (System Z) lazy loading
 - Error handling (JVM not ready, class not found, JException)
 """
+
 import pytest
 from unittest.mock import patch, MagicMock
 
 from argumentation_analysis.agents.core.logic.cl_handler import CLHandler
-from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+from argumentation_analysis.agents.core.logic.tweety_initializer import (
+    TweetyInitializer,
+)
 
 
 @pytest.fixture
@@ -38,9 +41,11 @@ def mock_jpype():
             return cls
 
         m.JClass.side_effect = jclass_side_effect
+
         class MockJException(Exception):
             def getMessage(self):
                 return str(self)
+
         m.JException = MockJException
         m.JString = str
 
@@ -178,17 +183,13 @@ class TestKBConstruction:
 
     def test_conditional_with_premise(self, mock_initializer, mock_jpype):
         handler = CLHandler(mock_initializer)
-        kb = handler.create_knowledge_base(
-            conditionals=[("flies", "bird")]
-        )
+        kb = handler.create_knowledge_base(conditionals=[("flies", "bird")])
         assert kb.add.call_count == 1
         handler._Conditional.assert_called_once()
 
     def test_unconditional_fact(self, mock_initializer, mock_jpype):
         handler = CLHandler(mock_initializer)
-        kb = handler.create_knowledge_base(
-            conditionals=[("bird", None)]
-        )
+        kb = handler.create_knowledge_base(conditionals=[("bird", None)])
         assert kb.add.call_count == 1
 
     def test_multiple_conditionals(self, mock_initializer, mock_jpype):
@@ -204,9 +205,7 @@ class TestKBConstruction:
 
     def test_negated_conclusion(self, mock_initializer, mock_jpype):
         handler = CLHandler(mock_initializer)
-        kb = handler.create_knowledge_base(
-            conditionals=[("!flies", "penguin")]
-        )
+        kb = handler.create_knowledge_base(conditionals=[("!flies", "penguin")])
         handler._Negation.assert_called_once()
 
 

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_dl_handler.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_dl_handler.py
@@ -9,11 +9,14 @@ Validates:
 - String-based parse_and_query
 - Error handling (JVM not ready, class not found, JException)
 """
+
 import pytest
 from unittest.mock import patch, MagicMock
 
 from argumentation_analysis.agents.core.logic.dl_handler import DLHandler
-from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+from argumentation_analysis.agents.core.logic.tweety_initializer import (
+    TweetyInitializer,
+)
 
 
 @pytest.fixture
@@ -37,10 +40,12 @@ def mock_jpype():
             return cls
 
         m.JClass.side_effect = jclass_side_effect
+
         # Use a specific class so ValueError isn't caught by JException handler
         class MockJException(Exception):
             def getMessage(self):
                 return str(self)
+
         m.JException = MockJException
         m.JString = str
 
@@ -178,9 +183,7 @@ class TestKBConstruction:
 
     def test_abox_role_assertions(self, mock_initializer, mock_jpype):
         handler = DLHandler(mock_initializer)
-        kb = handler.create_knowledge_base(
-            abox_roles=[("john", "hasChild", "mary")]
-        )
+        kb = handler.create_knowledge_base(abox_roles=[("john", "hasChild", "mary")])
         assert kb.add.call_count == 1
         assert handler._RoleAssertion.call_count == 1
 
@@ -284,7 +287,9 @@ class TestSubsumptionQuery:
     def test_subsumption_holds(self, mock_initializer, mock_jpype):
         handler = DLHandler(mock_initializer)
         mock_reasoner = MagicMock()
-        mock_reasoner.query.return_value = False  # C ⊓ ¬D not entailed → subsumption holds
+        mock_reasoner.query.return_value = (
+            False  # C ⊓ ¬D not entailed → subsumption holds
+        )
         handler._NaiveDlReasoner.return_value = mock_reasoner
 
         kb = MagicMock()

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
@@ -6,6 +6,7 @@ Validates:
 - Config enum extensions
 - Reasoner lazy-loading and fallback
 """
+
 import pytest
 import importlib
 from unittest.mock import patch, MagicMock, PropertyMock
@@ -21,7 +22,6 @@ from argumentation_analysis.agents.core.logic.modal_handler import ModalHandler
 from argumentation_analysis.agents.core.logic.tweety_initializer import (
     TweetyInitializer,
 )
-
 
 # ──── Config Tests ────
 
@@ -54,10 +54,13 @@ class TestSolverChoiceEnum:
         assert s.modal_solver == ModalSolverChoice.TWEETY
 
     def test_settings_env_override(self):
-        with patch.dict("os.environ", {
-            "ARG_ANALYSIS_SOLVER": "eprover",
-            "ARG_ANALYSIS_MODAL_SOLVER": "spass",
-        }):
+        with patch.dict(
+            "os.environ",
+            {
+                "ARG_ANALYSIS_SOLVER": "eprover",
+                "ARG_ANALYSIS_MODAL_SOLVER": "spass",
+            },
+        ):
             s = ArgAnalysisSettings()
             assert s.solver == SolverChoice.EPROVER
             assert s.modal_solver == ModalSolverChoice.SPASS
@@ -98,12 +101,17 @@ class TestFOLHandlerEProverDispatch:
             mock_prover9.assert_not_called()
             assert result is True
 
-    @pytest.mark.parametrize("solver,expected_method", [
-        ("tweety", "_fol_query_with_tweety"),
-        ("prover9", "_fol_query_with_prover9"),
-        ("eprover", "_fol_query_with_eprover"),
-    ])
-    def test_fol_query_dispatch_all_solvers(self, solver, expected_method, mock_belief_set):
+    @pytest.mark.parametrize(
+        "solver,expected_method",
+        [
+            ("tweety", "_fol_query_with_tweety"),
+            ("prover9", "_fol_query_with_prover9"),
+            ("eprover", "_fol_query_with_eprover"),
+        ],
+    )
+    def test_fol_query_dispatch_all_solvers(
+        self, solver, expected_method, mock_belief_set
+    ):
         with patch.object(
             FOLHandler, expected_method, return_value=True
         ) as mock_method, patch(
@@ -157,15 +165,18 @@ class TestFOLHandlerEProverDispatch:
             mock_tweety.assert_not_called()
             mock_prover9.assert_not_called()
 
-    @pytest.mark.parametrize("solver,expected_method", [
-        ("tweety", "_fol_check_consistency_with_tweety"),
-        ("prover9", "_fol_check_consistency_with_prover9"),
-        ("eprover", "_fol_check_consistency_with_eprover"),
-    ])
-    async def test_consistency_dispatch_all_solvers(self, solver, expected_method, mock_belief_set):
-        with patch.object(
-            FOLHandler, expected_method
-        ) as mock_method, patch(
+    @pytest.mark.parametrize(
+        "solver,expected_method",
+        [
+            ("tweety", "_fol_check_consistency_with_tweety"),
+            ("prover9", "_fol_check_consistency_with_prover9"),
+            ("eprover", "_fol_check_consistency_with_eprover"),
+        ],
+    )
+    async def test_consistency_dispatch_all_solvers(
+        self, solver, expected_method, mock_belief_set
+    ):
+        with patch.object(FOLHandler, expected_method) as mock_method, patch(
             "argumentation_analysis.agents.core.logic.fol_handler.settings"
         ) as mock_settings:
             mock_settings.solver = SolverChoice(solver)

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_sat_handler.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_sat_handler.py
@@ -11,6 +11,7 @@ Validates:
 - Solver benchmarking
 - PLHandler SAT dispatch methods
 """
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -54,10 +55,13 @@ class TestPLSolverChoiceEnum:
         assert s.pysat_solver == "cadical195"
 
     def test_settings_env_override(self):
-        with patch.dict("os.environ", {
-            "ARG_ANALYSIS_PL_SOLVER": "pysat",
-            "ARG_ANALYSIS_PYSAT_SOLVER": "glucose42",
-        }):
+        with patch.dict(
+            "os.environ",
+            {
+                "ARG_ANALYSIS_PL_SOLVER": "pysat",
+                "ARG_ANALYSIS_PYSAT_SOLVER": "glucose42",
+            },
+        ):
             s = ArgAnalysisSettings()
             assert s.pl_solver == PLSolverChoice.PYSAT
             assert s.pysat_solver == "glucose42"
@@ -389,8 +393,8 @@ class TestMaxSAT:
         handler = SATHandler()
         hard = [[1, 2]]  # x1 OR x2 must hold
         soft = [
-            ([1], 3),    # prefer x1=True (weight 3)
-            ([-1], 1),   # prefer x1=False (weight 1)
+            ([1], 3),  # prefer x1=True (weight 3)
+            ([-1], 1),  # prefer x1=False (weight 1)
         ]
         model, cost = handler.solve_maxsat(hard, soft)
         assert model is not None
@@ -484,6 +488,7 @@ class TestPLHandlerSATDispatch:
             mock_init.get_pl_parser.return_value = MagicMock()
 
             from argumentation_analysis.agents.core.logic.pl_handler import PLHandler
+
             handler = PLHandler(mock_init)
             return handler
 

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py
@@ -8,7 +8,6 @@ import pytest
 from unittest.mock import MagicMock, patch, PropertyMock
 import sys
 
-
 # --- Mock JPype setup ---
 # Handlers import jpype at module level, so we mock it before importing.
 
@@ -48,6 +47,7 @@ class TestRankingHandler:
             # Force reimport
             from importlib import reload
             import argumentation_analysis.agents.core.logic.ranking_handler as mod
+
             reload(mod)
 
             handler = mod.RankingHandler()
@@ -91,8 +91,15 @@ class TestRankingHandler:
 
     def test_available_reasoners(self):
         handler, _, _ = self._make_handler()
-        expected = {"categorizer", "burden", "discussion", "counting", "tuples",
-                    "strategy", "propagation"}
+        expected = {
+            "categorizer",
+            "burden",
+            "discussion",
+            "counting",
+            "tuples",
+            "strategy",
+            "propagation",
+        }
         assert set(handler.REASONERS.keys()) == expected
 
 
@@ -109,12 +116,16 @@ class TestBipolarHandler:
         with patch.dict(sys.modules, {"jpype": mock_jpype}):
             from importlib import reload
             import argumentation_analysis.agents.core.logic.bipolar_handler as mod
+
             reload(mod)
             return mod.BipolarHandler(), mock_jpype, registry
 
     def test_init_loads_bipolar_classes(self):
         handler, _, registry = self._make_handler()
-        assert "org.tweetyproject.arg.bipolar.syntax.NecessityArgumentationFramework" in registry
+        assert (
+            "org.tweetyproject.arg.bipolar.syntax.NecessityArgumentationFramework"
+            in registry
+        )
         assert "org.tweetyproject.arg.bipolar.syntax.BArgument" in registry
 
     def test_analyze_necessity_framework(self):
@@ -155,6 +166,7 @@ class TestABAHandler:
         with patch.dict(sys.modules, {"jpype": mock_jpype}):
             from importlib import reload
             import argumentation_analysis.agents.core.logic.aba_handler as mod
+
             reload(mod)
             return mod.ABAHandler(), mock_jpype, registry
 
@@ -206,12 +218,16 @@ class TestADFHandler:
         with patch.dict(sys.modules, {"jpype": mock_jpype}):
             from importlib import reload
             import argumentation_analysis.agents.core.logic.adf_handler as mod
+
             reload(mod)
             return mod.ADFHandler(), mock_jpype, registry
 
     def test_init_loads_adf_classes(self):
         handler, _, registry = self._make_handler()
-        assert "org.tweetyproject.arg.adf.syntax.adf.GraphAbstractDialecticalFramework" in registry
+        assert (
+            "org.tweetyproject.arg.adf.syntax.adf.GraphAbstractDialecticalFramework"
+            in registry
+        )
         assert "org.tweetyproject.arg.adf.syntax.Argument" in registry
 
     def test_analyze_adf_basic(self):
@@ -242,8 +258,15 @@ class TestADFHandler:
 
     def test_available_semantics(self):
         handler, _, _ = self._make_handler()
-        expected = {"grounded", "complete", "preferred", "admissible",
-                    "model", "naive", "conflict_free"}
+        expected = {
+            "grounded",
+            "complete",
+            "preferred",
+            "admissible",
+            "model",
+            "naive",
+            "conflict_free",
+        }
         assert set(handler.REASONERS.keys()) == expected
 
 
@@ -260,6 +283,7 @@ class TestASPICHandler:
         with patch.dict(sys.modules, {"jpype": mock_jpype}):
             from importlib import reload
             import argumentation_analysis.agents.core.logic.aspic_handler as mod
+
             reload(mod)
             return mod.ASPICHandler(), mock_jpype, registry
 
@@ -316,6 +340,7 @@ class TestBeliefRevisionHandler:
         with patch.dict(sys.modules, {"jpype": mock_jpype}):
             from importlib import reload
             import argumentation_analysis.agents.core.logic.belief_revision_handler as mod
+
             reload(mod)
             return mod.BeliefRevisionHandler(), mock_jpype, registry
 
@@ -323,13 +348,20 @@ class TestBeliefRevisionHandler:
         handler, _, registry = self._make_handler()
         assert "org.tweetyproject.logics.pl.syntax.PlBeliefSet" in registry
         assert "org.tweetyproject.beliefdynamics.revops.DalalRevision" in registry
-        assert "org.tweetyproject.beliefdynamics.kernels.KernelContractionOperator" in registry
+        assert (
+            "org.tweetyproject.beliefdynamics.kernels.KernelContractionOperator"
+            in registry
+        )
 
     def test_revise_dalal(self):
         handler, _, registry = self._make_handler()
         # Mock revision operator
         mock_revised = MagicMock()
-        mock_revised.__iter__ = MagicMock(return_value=iter([MagicMock(__str__=lambda s: "a"), MagicMock(__str__=lambda s: "b")]))
+        mock_revised.__iter__ = MagicMock(
+            return_value=iter(
+                [MagicMock(__str__=lambda s: "a"), MagicMock(__str__=lambda s: "b")]
+            )
+        )
 
         dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
         if dalal:
@@ -386,6 +418,7 @@ class TestProbabilisticHandler:
         with patch.dict(sys.modules, {"jpype": mock_jpype}):
             from importlib import reload
             import argumentation_analysis.agents.core.logic.probabilistic_handler as mod
+
             reload(mod)
             return mod.ProbabilisticHandler(), mock_jpype, registry
 
@@ -428,6 +461,7 @@ class TestDialogueHandler:
         with patch.dict(sys.modules, {"jpype": mock_jpype}):
             from importlib import reload
             import argumentation_analysis.agents.core.logic.dialogue_handler as mod
+
             reload(mod)
             return mod.DialogueHandler(), mock_jpype, registry
 
@@ -495,7 +529,9 @@ class TestTrackARegistration:
     def test_tweety_slots_registered_as_services(self):
         """Verify _declare_tweety_slots registers services, not just slots."""
         from unittest.mock import MagicMock
-        from argumentation_analysis.orchestration.unified_pipeline import _declare_tweety_slots
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _declare_tweety_slots,
+        )
 
         mock_registry = MagicMock()
         _declare_tweety_slots(mock_registry)
@@ -511,18 +547,30 @@ class TestTrackARegistration:
                 registered_caps.add(cap)
 
         expected_caps = {
-            "ranking_semantics", "bipolar_argumentation", "aba_reasoning",
-            "adf_reasoning", "aspic_plus_reasoning", "belief_revision",
-            "probabilistic_argumentation", "dialogue_protocols",
-            "description_logic", "conditional_logic",
-            "setaf_reasoning", "weighted_argumentation", "social_argumentation",
-            "epistemic_argumentation", "defeasible_logic", "qbf_reasoning",
+            "ranking_semantics",
+            "bipolar_argumentation",
+            "aba_reasoning",
+            "adf_reasoning",
+            "aspic_plus_reasoning",
+            "belief_revision",
+            "probabilistic_argumentation",
+            "dialogue_protocols",
+            "description_logic",
+            "conditional_logic",
+            "setaf_reasoning",
+            "weighted_argumentation",
+            "social_argumentation",
+            "epistemic_argumentation",
+            "defeasible_logic",
+            "qbf_reasoning",
         }
         assert registered_caps == expected_caps
 
     def test_tweety_slots_have_invoke_functions(self):
         """Each registered handler has an invoke callable."""
-        from argumentation_analysis.orchestration.unified_pipeline import _declare_tweety_slots
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _declare_tweety_slots,
+        )
 
         mock_registry = MagicMock()
         _declare_tweety_slots(mock_registry)
@@ -546,9 +594,14 @@ class TestTweetyBridgeTrackA:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
 
         expected_properties = [
-            "ranking_handler", "bipolar_handler", "aba_handler",
-            "adf_handler", "aspic_handler", "belief_revision_handler",
-            "probabilistic_handler", "dialogue_handler",
+            "ranking_handler",
+            "bipolar_handler",
+            "aba_handler",
+            "adf_handler",
+            "aspic_handler",
+            "belief_revision_handler",
+            "probabilistic_handler",
+            "dialogue_handler",
         ]
         for prop_name in expected_properties:
             assert hasattr(TweetyBridge, prop_name), f"Missing property: {prop_name}"

--- a/tests/unit/argumentation_analysis/agents/core/oracle/test_permissions.py
+++ b/tests/unit/argumentation_analysis/agents/core/oracle/test_permissions.py
@@ -18,8 +18,8 @@ from argumentation_analysis.agents.core.oracle.permissions import (
     get_default_cluedo_permissions,
 )
 
-
 # ── Enums ──
+
 
 class TestQueryType:
     def test_has_twelve_types(self):
@@ -42,6 +42,7 @@ class TestRevealPolicy:
 
 
 # ── PermissionRule ──
+
 
 class TestPermissionRule:
     def test_defaults(self):
@@ -83,6 +84,7 @@ class TestPermissionRule:
 
 # ── QueryResult ──
 
+
 class TestQueryResult:
     def test_success(self):
         r = QueryResult(success=True, data={"key": "val"}, message="OK")
@@ -94,6 +96,7 @@ class TestQueryResult:
 
 
 # ── ValidationResult ──
+
 
 class TestValidationResult:
     def test_can_refute(self):
@@ -111,6 +114,7 @@ class TestValidationResult:
 
 
 # ── OracleResponse ──
+
 
 class TestOracleResponse:
     def test_authorized(self):
@@ -142,6 +146,7 @@ class TestOracleResponse:
 
 
 # ── PermissionManager ──
+
 
 class TestPermissionManager:
     @pytest.fixture
@@ -246,6 +251,7 @@ class TestPermissionManager:
 
 # ── Cluedo Integrity ──
 
+
 class TestCluedoIntegrity:
     def test_forbidden_method(self):
         with pytest.raises(CluedoIntegrityError, match="INTÉGRITÉ CLUEDO"):
@@ -300,6 +306,7 @@ class TestDefaultCluedoPermissions:
 
 
 # ── Exceptions ──
+
 
 class TestExceptions:
     def test_permission_denied_error(self):

--- a/tests/unit/argumentation_analysis/agents/core/pm/test_pm_agent.py
+++ b/tests/unit/argumentation_analysis/agents/core/pm/test_pm_agent.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from semantic_kernel import Kernel
-from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
+from semantic_kernel.connectors.ai.chat_completion_client_base import (
+    ChatCompletionClientBase,
+)
 from semantic_kernel.functions import KernelArguments
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
@@ -294,7 +296,10 @@ class TestProjectManagerAgentInvocation:
 
         # Patch at CLASS level to bypass Pydantic V2 instance-level restrictions
         with patch.object(
-            ProjectManagerAgent, "invoke_single", new_callable=AsyncMock, return_value=[mock_response]
+            ProjectManagerAgent,
+            "invoke_single",
+            new_callable=AsyncMock,
+            return_value=[mock_response],
         ):
             messages = [ChatMessageContent(role=AuthorRole.USER, content="Test")]
             result = await agent.invoke_single(messages)
@@ -321,7 +326,9 @@ class TestProjectManagerAgentInvocation:
         async for item in stream:
             results.append(item)
 
-        assert len(results) == 1  # invoke_stream wraps invoke in a single-item generator
+        assert (
+            len(results) == 1
+        )  # invoke_stream wraps invoke in a single-item generator
 
 
 # =====================================================================

--- a/tests/unit/argumentation_analysis/agents/core/pm/test_sherlock_enquete_agent.py
+++ b/tests/unit/argumentation_analysis/agents/core/pm/test_sherlock_enquete_agent.py
@@ -8,7 +8,9 @@ from unittest.mock import AsyncMock, MagicMock, Mock
 import pytest
 
 from semantic_kernel import Kernel
-from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
+from semantic_kernel.connectors.ai.chat_completion_client_base import (
+    ChatCompletionClientBase,
+)
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 from semantic_kernel.contents.utils.author_role import AuthorRole
 from semantic_kernel.contents.chat_history import ChatHistory
@@ -67,7 +69,7 @@ class TestSherlockTools:
 
         mock_response = MagicMock()
         # Remove value attribute to test fallback
-        if hasattr(mock_response, 'value'):
+        if hasattr(mock_response, "value"):
             del mock_response.value
         # Mock __str__ to return string when value attribute is missing
         mock_response.__str__ = MagicMock(return_value="Direct string response")
@@ -155,11 +157,13 @@ class TestSherlockTools:
         kernel = MagicMock(spec=Kernel)
         tools = SherlockTools(kernel)
 
-        elements = json.dumps({
-            "suspects": ["Mustard", "Scarlet"],
-            "armes": ["Knife", "Revolver"],
-            "lieux": ["Kitchen", "Library"]
-        })
+        elements = json.dumps(
+            {
+                "suspects": ["Mustard", "Scarlet"],
+                "armes": ["Knife", "Revolver"],
+                "lieux": ["Kitchen", "Library"],
+            }
+        )
         result = await tools.instant_deduction(elements)
 
         deduction = json.loads(result)
@@ -178,7 +182,11 @@ class TestSherlockTools:
         deduction = json.loads(result)
         assert "suspect" in deduction
         # Should use default elements
-        assert deduction["suspect"] in ["Colonel Moutarde", "Mme Leblanc", "Mme Pervenche"]
+        assert deduction["suspect"] in [
+            "Colonel Moutarde",
+            "Mme Leblanc",
+            "Mme Pervenche",
+        ]
 
     @pytest.mark.asyncio
     async def test_instant_deduction_logic(self):
@@ -189,7 +197,7 @@ class TestSherlockTools:
         elements = {
             "suspects": ["A", "B", "C"],
             "armes": ["W1", "W2", "W3", "W4"],
-            "lieux": ["L1"]
+            "lieux": ["L1"],
         }
         result = await tools.instant_deduction(json.dumps(elements))
         deduction = json.loads(result)
@@ -354,7 +362,9 @@ class TestSherlockEnqueteAgentMethods:
             name="Sherlock",
         )
         # Use object.__setattr__ to bypass Pydantic V2 validation
-        object.__setattr__(agent, "invoke_single", AsyncMock(return_value=mock_response))
+        object.__setattr__(
+            agent, "invoke_single", AsyncMock(return_value=mock_response)
+        )
 
         result = await agent.invoke("Analyze the evidence")
         assert isinstance(result, list)
@@ -376,7 +386,9 @@ class TestSherlockEnqueteAgentMethods:
             name="Sherlock",
         )
         # Use object.__setattr__ to bypass Pydantic V2 validation
-        object.__setattr__(agent, "invoke_single", AsyncMock(return_value=mock_response))
+        object.__setattr__(
+            agent, "invoke_single", AsyncMock(return_value=mock_response)
+        )
 
         messages = [
             ChatMessageContent(role=AuthorRole.USER, content="First message"),
@@ -467,7 +479,9 @@ class TestSherlockEnqueteAgentMethods:
         messages = [ChatMessageContent(role=AuthorRole.USER, content="Test")]
         result = await agent.invoke_single(messages)
 
-        assert "erreur interne m'emp\u00eache de r\u00e9pondre" in result.content.lower()
+        assert (
+            "erreur interne m'emp\u00eache de r\u00e9pondre" in result.content.lower()
+        )
 
     @pytest.mark.asyncio
     async def test_get_response_with_async_generator(self):
@@ -548,7 +562,9 @@ class TestSherlockEnqueteAgentIntegration:
             name="Sherlock",
         )
         # Use object.__setattr__ to bypass Pydantic V2 validation
-        object.__setattr__(agent, "invoke_single", AsyncMock(return_value=mock_response))
+        object.__setattr__(
+            agent, "invoke_single", AsyncMock(return_value=mock_response)
+        )
 
         result = await agent.invoke("Examine the crime scene")
         assert len(result) == 1

--- a/tests/unit/argumentation_analysis/agents/core/synthesis/test_synthesis_agent.py
+++ b/tests/unit/argumentation_analysis/agents/core/synthesis/test_synthesis_agent.py
@@ -7,7 +7,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from semantic_kernel import Kernel
-from semantic_kernel.connectors.ai.chat_completion_client_base import ChatCompletionClientBase
+from semantic_kernel.connectors.ai.chat_completion_client_base import (
+    ChatCompletionClientBase,
+)
 
 from argumentation_analysis.agents.core.synthesis.synthesis_agent import SynthesisAgent
 from argumentation_analysis.agents.core.synthesis.data_models import (
@@ -137,9 +139,14 @@ class TestSynthesisAgentOrchestration:
         async def mock_error_analysis(text):
             raise RuntimeError("Analysis failed")
 
-        with patch.object(agent, "_run_formal_analysis", side_effect=mock_error_analysis), \
-             patch.object(agent, "_run_informal_analysis", side_effect=mock_error_analysis):
-            logic_result, informal_result = await agent.orchestrate_analysis("Test text")
+        with patch.object(
+            agent, "_run_formal_analysis", side_effect=mock_error_analysis
+        ), patch.object(
+            agent, "_run_informal_analysis", side_effect=mock_error_analysis
+        ):
+            logic_result, informal_result = await agent.orchestrate_analysis(
+                "Test text"
+            )
 
         # Should return empty results
         assert isinstance(logic_result, LogicAnalysisResult)
@@ -219,11 +226,19 @@ class TestSynthesisAgentReportGeneration:
 
         markdown = await agent.generate_report(report)
 
-        assert "# RAPPORT DE SYNTHESE UNIFIE" in markdown or "# RAPPORT DE SYNTH\u00c8SE UNIFI\u00c9" in markdown
+        assert (
+            "# RAPPORT DE SYNTHESE UNIFIE" in markdown
+            or "# RAPPORT DE SYNTH\u00c8SE UNIFI\u00c9" in markdown
+        )
         assert "## TEXTE ORIGINAL ANALYS" in markdown
-        assert "## R\u00c9SUM\u00c9 EX\u00c9CUTIF" in markdown or "RESUME EXECUTIF" in markdown
+        assert (
+            "## R\u00c9SUM\u00c9 EX\u00c9CUTIF" in markdown
+            or "RESUME EXECUTIF" in markdown
+        )
         assert "## STATISTIQUES" in markdown
-        assert "## \u00c9VALUATION GLOBALE" in markdown or "EVALUATION GLOBALE" in markdown
+        assert (
+            "## \u00c9VALUATION GLOBALE" in markdown or "EVALUATION GLOBALE" in markdown
+        )
 
     @pytest.mark.asyncio
     async def test_generate_report_includes_contradictions(self):
@@ -293,9 +308,7 @@ class TestSynthesisAgentHelperMethods:
         agent = SynthesisAgent(kernel)
 
         logic = LogicAnalysisResult(logical_validity=True)
-        informal = InformalAnalysisResult(
-            fallacies_detected=[{"type": "straw_man"}]
-        )
+        informal = InformalAnalysisResult(fallacies_detected=[{"type": "straw_man"}])
 
         validity = agent._assess_overall_validity(logic, informal)
         assert validity is False
@@ -359,9 +372,7 @@ class TestSynthesisAgentHelperMethods:
         agent = SynthesisAgent(kernel)
 
         logic = LogicAnalysisResult(logical_validity=True)
-        informal = InformalAnalysisResult(
-            fallacies_detected=[{"type": "ad_hominem"}]
-        )
+        informal = InformalAnalysisResult(fallacies_detected=[{"type": "ad_hominem"}])
 
         contradictions = agent._identify_basic_contradictions(logic, informal)
         assert len(contradictions) > 0
@@ -441,7 +452,9 @@ class TestSynthesisAgentAbstractMethods:
         agent = SynthesisAgent(kernel)
 
         # Mock the internal methods
-        with patch.object(agent, "_simple_synthesis", new_callable=AsyncMock) as mock_synthesis:
+        with patch.object(
+            agent, "_simple_synthesis", new_callable=AsyncMock
+        ) as mock_synthesis:
             mock_report = UnifiedReport(
                 original_text="Test",
                 logic_analysis=LogicAnalysisResult(),
@@ -468,8 +481,17 @@ class TestSynthesisAgentAbstractMethods:
         )
 
         # Patch at CLASS level to bypass Pydantic V2 validation on instance setattr
-        with patch.object(SynthesisAgent, "invoke_single", new_callable=AsyncMock, return_value=mock_report), \
-             patch.object(SynthesisAgent, "generate_report", new_callable=AsyncMock, return_value="# Report"):
+        with patch.object(
+            SynthesisAgent,
+            "invoke_single",
+            new_callable=AsyncMock,
+            return_value=mock_report,
+        ), patch.object(
+            SynthesisAgent,
+            "generate_report",
+            new_callable=AsyncMock,
+            return_value="# Report",
+        ):
             result = await agent.get_response("Test text")
 
         assert "# Report" in result

--- a/tests/unit/argumentation_analysis/agents/core/synthesis/test_synthesis_data_models.py
+++ b/tests/unit/argumentation_analysis/agents/core/synthesis/test_synthesis_data_models.py
@@ -12,7 +12,6 @@ from argumentation_analysis.agents.core.synthesis.data_models import (
     UnifiedReport,
 )
 
-
 # =====================================================================
 # LogicAnalysisResult Tests
 # =====================================================================

--- a/tests/unit/argumentation_analysis/agents/test_watson_jtms.py
+++ b/tests/unit/argumentation_analysis/agents/test_watson_jtms.py
@@ -44,13 +44,18 @@ from argumentation_analysis.agents.watson_jtms.models import (
 
 from argumentation_analysis.agents.watson_jtms.consistency import ConsistencyChecker
 
-
 # ============================================================================
 # Helpers: mock factories
 # ============================================================================
 
-def _make_belief(confidence=0.5, valid=True, non_monotonic=False,
-                 justifications=None, agent_source="test"):
+
+def _make_belief(
+    confidence=0.5,
+    valid=True,
+    non_monotonic=False,
+    justifications=None,
+    agent_source="test",
+):
     """Create a mock belief object with common attributes."""
     b = MagicMock()
     b.confidence = confidence
@@ -69,8 +74,7 @@ def _make_justification(in_list=None, out_list=None):
     return j
 
 
-def _make_jtms_session(extended_beliefs=None, jtms_beliefs=None,
-                       has_update_nm=False):
+def _make_jtms_session(extended_beliefs=None, jtms_beliefs=None, has_update_nm=False):
     """Create a mock JTMS session."""
     session = MagicMock()
     session.extended_beliefs = extended_beliefs or {}
@@ -86,6 +90,7 @@ def _make_jtms_session(extended_beliefs=None, jtms_beliefs=None,
 # ============================================================================
 # MODELS TESTS
 # ============================================================================
+
 
 class TestValidationResult:
     """Tests for models.ValidationResult dataclass."""
@@ -117,7 +122,10 @@ class TestValidationResult:
 
     def test_with_issues_and_suggestions(self):
         vr = ValidationResult(
-            "B1", False, 0.2, "m",
+            "B1",
+            False,
+            0.2,
+            "m",
             issues_found=["circular"],
             suggestions=["add evidence"],
             formal_proof="QED",
@@ -150,8 +158,9 @@ class TestConflictResolution:
         assert isinstance(cr.timestamp, datetime)
 
     def test_chosen_belief_none(self):
-        cr = ConflictResolution("c1", ["A", "B"], "manual_review_needed",
-                                None, "equal", 0.3)
+        cr = ConflictResolution(
+            "c1", ["A", "B"], "manual_review_needed", None, "equal", 0.3
+        )
         assert cr.chosen_belief is None
 
     def test_field_count(self):
@@ -161,6 +170,7 @@ class TestConflictResolution:
 # ============================================================================
 # UTILS TESTS: _extract_logical_structure
 # ============================================================================
+
 
 class TestExtractLogicalStructure:
 
@@ -211,6 +221,7 @@ class TestExtractLogicalStructure:
 # UTILS TESTS: _analyze_hypothesis_consistency (async)
 # ============================================================================
 
+
 class TestAnalyzeHypothesisConsistency:
 
     async def test_empty_beliefs_consistent(self):
@@ -221,11 +232,7 @@ class TestAnalyzeHypothesisConsistency:
         assert result["conflicts"] == []
 
     async def test_supportive_belief_high_similarity(self):
-        sherlock = {
-            "beliefs": {
-                "b1": {"context": {"description": "matching text"}}
-            }
-        }
+        sherlock = {"beliefs": {"b1": {"context": {"description": "matching text"}}}}
         result = await _analyze_hypothesis_consistency(
             {"hypothesis": "matching text"}, sherlock, lambda a, b: 0.8
         )
@@ -234,11 +241,7 @@ class TestAnalyzeHypothesisConsistency:
         assert result["consistent"] is True
 
     async def test_contradictory_belief_negative_similarity(self):
-        sherlock = {
-            "beliefs": {
-                "b1": {"context": {"description": "opposite"}}
-            }
-        }
+        sherlock = {"beliefs": {"b1": {"context": {"description": "opposite"}}}}
         result = await _analyze_hypothesis_consistency(
             {"hypothesis": "something"}, sherlock, lambda a, b: -0.5
         )
@@ -246,11 +249,7 @@ class TestAnalyzeHypothesisConsistency:
         assert result["consistent"] is False
 
     async def test_neutral_similarity_no_match(self):
-        sherlock = {
-            "beliefs": {
-                "b1": {"context": {"description": "neutral"}}
-            }
-        }
+        sherlock = {"beliefs": {"b1": {"context": {"description": "neutral"}}}}
         result = await _analyze_hypothesis_consistency(
             {"hypothesis": "something"}, sherlock, lambda a, b: 0.3
         )
@@ -280,8 +279,7 @@ class TestAnalyzeHypothesisConsistency:
 
     async def test_missing_hypothesis_key(self):
         result = await _analyze_hypothesis_consistency(
-            {}, {"beliefs": {"b1": {"context": {"description": "x"}}}},
-            lambda a, b: 0.0
+            {}, {"beliefs": {"b1": {"context": {"description": "x"}}}}, lambda a, b: 0.0
         )
         assert result["consistent"] is True
 
@@ -295,6 +293,7 @@ class TestAnalyzeHypothesisConsistency:
 # ============================================================================
 # UTILS TESTS: _analyze_hypothesis_strengths_weaknesses
 # ============================================================================
+
 
 class TestAnalyzeHypothesisStrengthsWeaknesses:
 
@@ -335,6 +334,7 @@ class TestAnalyzeHypothesisStrengthsWeaknesses:
 # ============================================================================
 # UTILS TESTS: _calculate_overall_assessment
 # ============================================================================
+
 
 class TestCalculateOverallAssessment:
 
@@ -390,6 +390,7 @@ class TestCalculateOverallAssessment:
 # UTILS TESTS: _analyze_justification_gaps (async)
 # ============================================================================
 
+
 class TestAnalyzeJustificationGaps:
 
     async def test_belief_not_found(self):
@@ -426,6 +427,7 @@ class TestAnalyzeJustificationGaps:
 # UTILS TESTS: _generate_contextual_alternatives (async)
 # ============================================================================
 
+
 class TestGenerateContextualAlternatives:
 
     async def test_investigation_context(self):
@@ -437,9 +439,7 @@ class TestGenerateContextualAlternatives:
         assert alts[0]["priority"] == "medium"
 
     async def test_unknown_context_empty(self):
-        alts = await _generate_contextual_alternatives(
-            "belief", {"type": "unknown"}
-        )
+        alts = await _generate_contextual_alternatives("belief", {"type": "unknown"})
         assert alts == []
 
     async def test_no_type_key(self):
@@ -447,15 +447,14 @@ class TestGenerateContextualAlternatives:
         assert alts == []
 
     async def test_other_context_type(self):
-        alts = await _generate_contextual_alternatives(
-            "belief", {"type": "debate"}
-        )
+        alts = await _generate_contextual_alternatives("belief", {"type": "debate"})
         assert alts == []
 
 
 # ============================================================================
 # UTILS TESTS: _suggest_belief_strengthening
 # ============================================================================
+
 
 class TestSuggestBeliefStrengthening:
 
@@ -490,6 +489,7 @@ class TestSuggestBeliefStrengthening:
 # UTILS TESTS: _generate_contradictory_tests
 # ============================================================================
 
+
 class TestGenerateContradictoryTests:
 
     def test_always_returns_one(self):
@@ -513,6 +513,7 @@ class TestGenerateContradictoryTests:
 # ============================================================================
 # UTILS TESTS: _resolve_single_conflict (async)
 # ============================================================================
+
 
 class TestResolveSingleConflict:
 
@@ -549,9 +550,7 @@ class TestResolveSingleConflict:
 
     async def test_missing_beliefs_error(self):
         conflict = {"beliefs": ["A", "B"]}
-        result = await _resolve_single_conflict(
-            conflict, 0, {}, ConflictResolution
-        )
+        result = await _resolve_single_conflict(conflict, 0, {}, ConflictResolution)
         assert result.resolution_strategy == "error"
         assert result.chosen_belief is None
 
@@ -565,38 +564,32 @@ class TestResolveSingleConflict:
 
     async def test_complex_conflict_three_beliefs(self):
         conflict = {"beliefs": ["A", "B", "C"]}
-        result = await _resolve_single_conflict(
-            conflict, 0, {}, ConflictResolution
-        )
+        result = await _resolve_single_conflict(conflict, 0, {}, ConflictResolution)
         assert result.resolution_strategy == "complex_conflict"
         assert "3" in result.reasoning
 
     async def test_single_belief_complex(self):
         conflict = {"beliefs": ["A"]}
-        result = await _resolve_single_conflict(
-            conflict, 0, {}, ConflictResolution
-        )
+        result = await _resolve_single_conflict(conflict, 0, {}, ConflictResolution)
         assert result.resolution_strategy == "complex_conflict"
 
     async def test_conflict_id_format(self):
         conflict = {"beliefs": ["A", "B"]}
         result = await _resolve_single_conflict(
-            conflict, 5, {"A": _make_belief(), "B": _make_belief()},
-            ConflictResolution
+            conflict, 5, {"A": _make_belief(), "B": _make_belief()}, ConflictResolution
         )
         assert result.conflict_id.startswith("conflict_5_")
 
     async def test_empty_beliefs_list(self):
         conflict = {"beliefs": []}
-        result = await _resolve_single_conflict(
-            conflict, 0, {}, ConflictResolution
-        )
+        result = await _resolve_single_conflict(conflict, 0, {}, ConflictResolution)
         assert result.resolution_strategy == "complex_conflict"
 
 
 # ============================================================================
 # UTILS TESTS: _apply_conflict_resolutions (async)
 # ============================================================================
+
 
 class TestApplyConflictResolutions:
 
@@ -652,6 +645,7 @@ class TestApplyConflictResolutions:
 # UTILS TESTS: _analyze_logical_soundness (async)
 # ============================================================================
 
+
 class TestAnalyzeLogicalSoundness:
 
     async def test_no_beliefs_sound(self):
@@ -691,13 +685,12 @@ class TestAnalyzeLogicalSoundness:
 # UTILS TESTS: _generate_validation_recommendations
 # ============================================================================
 
+
 class TestGenerateValidationRecommendations:
 
     def test_with_conflicts(self):
         report = {
-            "consistency_analysis": {
-                "conflicts_detected": [{"type": "direct"}]
-            },
+            "consistency_analysis": {"conflicts_detected": [{"type": "direct"}]},
             "beliefs_validated": {},
         }
         recs = _generate_validation_recommendations(report)
@@ -727,9 +720,7 @@ class TestGenerateValidationRecommendations:
 
     def test_both_issues(self):
         report = {
-            "consistency_analysis": {
-                "conflicts_detected": [{"x": 1}]
-            },
+            "consistency_analysis": {"conflicts_detected": [{"x": 1}]},
             "beliefs_validated": {
                 "A": {"provable": False},
             },
@@ -739,9 +730,7 @@ class TestGenerateValidationRecommendations:
 
     def test_conflict_count_in_description(self):
         report = {
-            "consistency_analysis": {
-                "conflicts_detected": [{"x": 1}, {"y": 2}]
-            },
+            "consistency_analysis": {"conflicts_detected": [{"x": 1}, {"y": 2}]},
             "beliefs_validated": {},
         }
         recs = _generate_validation_recommendations(report)
@@ -751,6 +740,7 @@ class TestGenerateValidationRecommendations:
 # ============================================================================
 # UTILS TESTS: _assess_overall_validity
 # ============================================================================
+
 
 class TestAssessOverallValidity:
 
@@ -830,6 +820,7 @@ class TestAssessOverallValidity:
 # UTILS TESTS: _build_logical_chains
 # ============================================================================
 
+
 class TestBuildLogicalChains:
 
     def test_empty_beliefs(self):
@@ -861,63 +852,79 @@ class TestBuildLogicalChains:
 # UTILS TESTS: _generate_final_assessment
 # ============================================================================
 
+
 class TestGenerateFinalAssessment:
 
     def test_excellent(self):
-        result = _generate_final_assessment({
-            "high_confidence_conclusions": ["a", "b", "c", "d"],
-            "validated_beliefs": ["a", "b", "c", "d"],
-        })
+        result = _generate_final_assessment(
+            {
+                "high_confidence_conclusions": ["a", "b", "c", "d"],
+                "validated_beliefs": ["a", "b", "c", "d"],
+            }
+        )
         assert result["assessment_level"] == "excellent"
         assert result["quality_score"] == 1.0
 
     def test_good(self):
-        result = _generate_final_assessment({
-            "high_confidence_conclusions": ["a", "b"],
-            "validated_beliefs": ["a", "b", "c"],
-        })
+        result = _generate_final_assessment(
+            {
+                "high_confidence_conclusions": ["a", "b"],
+                "validated_beliefs": ["a", "b", "c"],
+            }
+        )
         assert result["assessment_level"] == "good"
 
     def test_acceptable(self):
-        result = _generate_final_assessment({
-            "high_confidence_conclusions": ["a"],
-            "validated_beliefs": ["a", "b", "c"],
-        })
+        result = _generate_final_assessment(
+            {
+                "high_confidence_conclusions": ["a"],
+                "validated_beliefs": ["a", "b", "c"],
+            }
+        )
         assert result["assessment_level"] == "acceptable"
 
     def test_poor(self):
-        result = _generate_final_assessment({
-            "high_confidence_conclusions": [],
-            "validated_beliefs": ["a", "b", "c"],
-        })
+        result = _generate_final_assessment(
+            {
+                "high_confidence_conclusions": [],
+                "validated_beliefs": ["a", "b", "c"],
+            }
+        )
         assert result["assessment_level"] == "poor"
 
     def test_empty_validated(self):
-        result = _generate_final_assessment({
-            "high_confidence_conclusions": [],
-            "validated_beliefs": [],
-        })
+        result = _generate_final_assessment(
+            {
+                "high_confidence_conclusions": [],
+                "validated_beliefs": [],
+            }
+        )
         assert result["quality_score"] == 0.0
         assert result["assessment_level"] == "poor"
 
     def test_total_conclusions(self):
-        result = _generate_final_assessment({
-            "high_confidence_conclusions": ["a"],
-            "validated_beliefs": ["a", "b"],
-        })
+        result = _generate_final_assessment(
+            {
+                "high_confidence_conclusions": ["a"],
+                "validated_beliefs": ["a", "b"],
+            }
+        )
         assert result["total_conclusions"] == 2
 
     def test_synthesis_quality_fixed(self):
-        result = _generate_final_assessment({
-            "high_confidence_conclusions": [],
-            "validated_beliefs": [],
-        })
+        result = _generate_final_assessment(
+            {
+                "high_confidence_conclusions": [],
+                "validated_beliefs": [],
+            }
+        )
         assert result["synthesis_quality"] == "rigorous_formal_analysis"
 
 
 # ============================================================================
 # UTILS TESTS: _validate_logical_step
 # ============================================================================
+
 
 class TestValidateLogicalStep:
 
@@ -941,6 +948,7 @@ class TestValidateLogicalStep:
 # ============================================================================
 # UTILS TESTS: _calculate_text_similarity
 # ============================================================================
+
 
 class TestCalculateTextSimilarity:
 
@@ -996,6 +1004,7 @@ class TestCalculateTextSimilarity:
 # CONSISTENCY CHECKER TESTS
 # ============================================================================
 
+
 class TestConsistencyCheckerInit:
 
     def test_init(self):
@@ -1030,18 +1039,14 @@ class TestCheckGlobalConsistency:
     def test_no_contradiction_only_positive(self):
         b1 = _make_belief(valid=True)
         b2 = _make_belief(valid=True)
-        session = _make_jtms_session(
-            extended_beliefs={"A": b1, "B": b2}
-        )
+        session = _make_jtms_session(extended_beliefs={"A": b1, "B": b2})
         checker = ConsistencyChecker(session)
         report = checker.check_global_consistency()
         assert report["is_consistent"] is True
 
     def test_not_prefix_without_positive(self):
         b = _make_belief(valid=True)
-        session = _make_jtms_session(
-            extended_beliefs={"not_X": b}
-        )
+        session = _make_jtms_session(extended_beliefs={"not_X": b})
         checker = ConsistencyChecker(session)
         report = checker.check_global_consistency()
         # not_X exists but X doesn't => no contradiction
@@ -1050,9 +1055,7 @@ class TestCheckGlobalConsistency:
     def test_both_invalid_no_conflict(self):
         b_pos = _make_belief(valid=False)
         b_neg = _make_belief(valid=False)
-        session = _make_jtms_session(
-            extended_beliefs={"A": b_pos, "not_A": b_neg}
-        )
+        session = _make_jtms_session(extended_beliefs={"A": b_pos, "not_A": b_neg})
         checker = ConsistencyChecker(session)
         report = checker.check_global_consistency()
         assert len(report["conflicts_detected"]) == 0
@@ -1061,8 +1064,7 @@ class TestCheckGlobalConsistency:
         b = _make_belief(non_monotonic=True, valid=True)
         jtms_beliefs = {"loopy": MagicMock(non_monotonic=True)}
         session = _make_jtms_session(
-            extended_beliefs={"loopy": b},
-            jtms_beliefs=jtms_beliefs
+            extended_beliefs={"loopy": b}, jtms_beliefs=jtms_beliefs
         )
         checker = ConsistencyChecker(session)
         report = checker.check_global_consistency()
@@ -1071,9 +1073,7 @@ class TestCheckGlobalConsistency:
     def test_confidence_score_decreases_with_issues(self):
         b_pos = _make_belief(valid=True, confidence=0.8)
         b_neg = _make_belief(valid=True, confidence=0.6)
-        session = _make_jtms_session(
-            extended_beliefs={"X": b_pos, "not_X": b_neg}
-        )
+        session = _make_jtms_session(extended_beliefs={"X": b_pos, "not_X": b_neg})
         checker = ConsistencyChecker(session)
         report = checker.check_global_consistency()
         assert report["confidence_score"] < 1.0
@@ -1130,9 +1130,7 @@ class TestDetectDirectContradictions:
     def test_pair_only_counted_once(self):
         b_pos = _make_belief(valid=True)
         b_neg = _make_belief(valid=True)
-        session = _make_jtms_session(
-            extended_beliefs={"A": b_pos, "not_A": b_neg}
-        )
+        session = _make_jtms_session(extended_beliefs={"A": b_pos, "not_A": b_neg})
         checker = ConsistencyChecker(session)
         conflicts = checker._detect_direct_contradictions()
         # Should be exactly 1, not duplicated
@@ -1141,9 +1139,7 @@ class TestDetectDirectContradictions:
     def test_agent_source_in_conflict(self):
         b_pos = _make_belief(valid=True, agent_source="sherlock")
         b_neg = _make_belief(valid=True, agent_source="watson")
-        session = _make_jtms_session(
-            extended_beliefs={"B": b_pos, "not_B": b_neg}
-        )
+        session = _make_jtms_session(extended_beliefs={"B": b_pos, "not_B": b_neg})
         checker = ConsistencyChecker(session)
         conflicts = checker._detect_direct_contradictions()
         assert conflicts[0]["agents"] == ["sherlock", "watson"]
@@ -1152,6 +1148,7 @@ class TestDetectDirectContradictions:
 # ============================================================================
 # CONSISTENCY CHECKER: resolve_conflicts (delegation to utils)
 # ============================================================================
+
 
 class TestConsistencyCheckerResolveConflicts:
     """ConsistencyChecker.resolve_conflicts is not defined in consistency.py,
@@ -1173,24 +1170,21 @@ class TestConsistencyCheckerResolveConflicts:
 # Additional edge case tests
 # ============================================================================
 
+
 class TestEdgeCases:
 
     def test_text_similarity_est_nest_pas_no_match(self):
         # "n'est pas" is split into ["n'est", "pas"] by str.split(),
         # so the multi-word contradiction key ("est", "n'est pas") won't match.
         # The function uses word-level Jaccard instead.
-        sim = _calculate_text_similarity(
-            "il est coupable", "il n'est pas coupable"
-        )
+        sim = _calculate_text_similarity("il est coupable", "il n'est pas coupable")
         assert sim > 0  # partial word overlap, no contradiction detected
 
     def test_text_similarity_peut_ne_peut_pas_no_match(self):
         # Same issue: "ne peut pas" becomes ["ne", "peut", "pas"]
         # "peut" appears in both sets so Jaccard > 0, but multi-word
         # contradiction key doesn't trigger.
-        sim = _calculate_text_similarity(
-            "il peut partir", "il ne peut pas partir"
-        )
+        sim = _calculate_text_similarity("il peut partir", "il ne peut pas partir")
         assert sim > 0
 
     def test_extract_logical_structure_mixed_case_ou(self):
@@ -1239,10 +1233,12 @@ class TestEdgeCases:
         assert chains[0]["premises"] == ["premise_str"]
 
     def test_generate_final_assessment_high_confidence_ratio(self):
-        result = _generate_final_assessment({
-            "high_confidence_conclusions": ["a"],
-            "validated_beliefs": ["a", "b"],
-        })
+        result = _generate_final_assessment(
+            {
+                "high_confidence_conclusions": ["a"],
+                "validated_beliefs": ["a", "b"],
+            }
+        )
         assert result["high_confidence_ratio"] == result["quality_score"]
 
     async def test_apply_resolution_chosen_but_wrong_strategy(self):

--- a/tests/unit/argumentation_analysis/agents/test_watson_jtms_models.py
+++ b/tests/unit/argumentation_analysis/agents/test_watson_jtms_models.py
@@ -15,7 +15,6 @@ from argumentation_analysis.agents.watson_jtms.models import (
 )
 from argumentation_analysis.agents.watson_jtms.validation import FormalValidator
 
-
 # =============================================================================
 # ValidationResult tests
 # =============================================================================
@@ -175,8 +174,13 @@ class TestFormalValidator:
     def test_construct_formal_proof(self):
         validator = self._make_validator()
         steps = [
-            {"valid": True, "logical_structure": "modus_ponens",
-             "premises_valid": True, "negatives_invalid": True, "confidence": 0.8},
+            {
+                "valid": True,
+                "logical_structure": "modus_ponens",
+                "premises_valid": True,
+                "negatives_invalid": True,
+                "confidence": 0.8,
+            },
             {"valid": False, "logical_structure": "unknown"},
         ]
         proof = validator._construct_formal_proof("belief_x", steps)

--- a/tests/unit/argumentation_analysis/agents/test_watson_jtms_utils.py
+++ b/tests/unit/argumentation_analysis/agents/test_watson_jtms_utils.py
@@ -29,7 +29,6 @@ from argumentation_analysis.agents.watson_jtms.utils import (
     _analyze_hypothesis_consistency,
 )
 
-
 # =============================================================================
 # _extract_logical_structure
 # =============================================================================
@@ -42,7 +41,9 @@ class TestExtractLogicalStructure:
         assert "implication" in result["logical_operators"]
 
     def test_conjunctive(self):
-        result = _extract_logical_structure("Le soleil brille et la température est élevée")
+        result = _extract_logical_structure(
+            "Le soleil brille et la température est élevée"
+        )
         assert result["type"] == "conjunctive"
 
     def test_disjunctive(self):
@@ -73,17 +74,21 @@ class TestAnalyzeHypothesisStrengthsWeaknesses:
         assert "Confiance insuffisante" in result["weaknesses"]
 
     def test_multiple_evidence_strength(self):
-        result = _analyze_hypothesis_strengths_weaknesses({
-            "confidence": 0.5,
-            "supporting_evidence": ["e1", "e2", "e3"],
-        })
+        result = _analyze_hypothesis_strengths_weaknesses(
+            {
+                "confidence": 0.5,
+                "supporting_evidence": ["e1", "e2", "e3"],
+            }
+        )
         assert "Multiples évidences de support" in result["strengths"]
 
     def test_no_evidence_critical(self):
-        result = _analyze_hypothesis_strengths_weaknesses({
-            "confidence": 0.3,
-            "supporting_evidence": [],
-        })
+        result = _analyze_hypothesis_strengths_weaknesses(
+            {
+                "confidence": 0.3,
+                "supporting_evidence": [],
+            }
+        )
         assert "Aucune évidence de support" in result["critical_issues"]
 
     def test_default_values(self):
@@ -194,25 +199,31 @@ class TestGenerateContradictoryTests:
 
 class TestGenerateFinalAssessment:
     def test_excellent(self):
-        result = _generate_final_assessment({
-            "high_confidence_conclusions": ["a", "b", "c"],
-            "validated_beliefs": ["a", "b", "c"],
-        })
+        result = _generate_final_assessment(
+            {
+                "high_confidence_conclusions": ["a", "b", "c"],
+                "validated_beliefs": ["a", "b", "c"],
+            }
+        )
         assert result["assessment_level"] == "excellent"
         assert result["quality_score"] == 1.0
 
     def test_poor(self):
-        result = _generate_final_assessment({
-            "high_confidence_conclusions": [],
-            "validated_beliefs": ["a", "b", "c", "d"],
-        })
+        result = _generate_final_assessment(
+            {
+                "high_confidence_conclusions": [],
+                "validated_beliefs": ["a", "b", "c", "d"],
+            }
+        )
         assert result["assessment_level"] == "poor"
 
     def test_empty(self):
-        result = _generate_final_assessment({
-            "high_confidence_conclusions": [],
-            "validated_beliefs": [],
-        })
+        result = _generate_final_assessment(
+            {
+                "high_confidence_conclusions": [],
+                "validated_beliefs": [],
+            }
+        )
         assert result["quality_score"] == 0.0
 
 

--- a/tests/unit/argumentation_analysis/agents/tools/analysis/new/test_argument_coherence_evaluator.py
+++ b/tests/unit/argumentation_analysis/agents/tools/analysis/new/test_argument_coherence_evaluator.py
@@ -32,6 +32,7 @@ SAMPLE_ARGS = [
 # Initialization
 # ============================================================
 
+
 class TestInit:
     def test_creates_instance(self, evaluator):
         assert isinstance(evaluator, ArgumentCoherenceEvaluator)
@@ -59,6 +60,7 @@ class TestInit:
 # ============================================================
 # evaluate_coherence (integration)
 # ============================================================
+
 
 class TestEvaluateCoherence:
     def test_returns_dict(self, evaluator):
@@ -106,6 +108,7 @@ class TestEvaluateCoherence:
 # ============================================================
 # Individual coherence evaluations (simulated)
 # ============================================================
+
 
 class TestIndividualEvaluations:
     def test_logical_coherence_structure(self, evaluator):
@@ -159,6 +162,7 @@ class TestIndividualEvaluations:
 # ============================================================
 # _calculate_overall_coherence
 # ============================================================
+
 
 class TestCalculateOverallCoherence:
     def test_returns_score_and_level(self, evaluator):
@@ -224,6 +228,7 @@ class TestCalculateOverallCoherence:
 # _generate_recommendations
 # ============================================================
 
+
 class TestGenerateRecommendations:
     def test_returns_list(self, evaluator):
         evals = {k: {"score": 0.7} for k in evaluator.coherence_types}
@@ -256,7 +261,9 @@ class TestGenerateRecommendations:
         evals = {k: {"score": 0.7} for k in evaluator.coherence_types}
         overall = {"level": "Bon", "weaknesses": []}
         recs = evaluator._generate_recommendations(["arg1", "arg2"], evals, overall)
-        assert any("davantage" in r.lower() or "supplémentaires" in r.lower() for r in recs)
+        assert any(
+            "davantage" in r.lower() or "supplémentaires" in r.lower() for r in recs
+        )
 
     def test_many_arguments_recommendation(self, evaluator):
         evals = {k: {"score": 0.7} for k in evaluator.coherence_types}

--- a/tests/unit/argumentation_analysis/agents/tools/analysis/new/test_contextual_fallacy_detector.py
+++ b/tests/unit/argumentation_analysis/agents/tools/analysis/new/test_contextual_fallacy_detector.py
@@ -22,6 +22,7 @@ def detector():
 # Initialization
 # ============================================================
 
+
 class TestInit:
     def test_creates_instance(self, detector):
         assert isinstance(detector, ContextualFallacyDetector)
@@ -41,6 +42,7 @@ class TestInit:
 # ============================================================
 # _define_contextual_factors
 # ============================================================
+
 
 class TestDefineContextualFactors:
     def test_has_domain(self, detector):
@@ -77,6 +79,7 @@ class TestDefineContextualFactors:
 # _define_contextual_fallacies
 # ============================================================
 
+
 class TestDefineContextualFallacies:
     def test_has_appel_autorite(self, detector):
         assert "appel_inapproprié_autorité" in detector.contextual_fallacies
@@ -99,14 +102,15 @@ class TestDefineContextualFallacies:
             for factor, rules in fallacy.get("contextual_rules", {}).items():
                 for value, rule in rules.items():
                     severity = rule.get("severity", 0.5)
-                    assert 0.0 <= severity <= 1.0, (
-                        f"Severity {severity} out of range for {name}/{factor}/{value}"
-                    )
+                    assert (
+                        0.0 <= severity <= 1.0
+                    ), f"Severity {severity} out of range for {name}/{factor}/{value}"
 
 
 # ============================================================
 # _infer_contextual_factors
 # ============================================================
+
 
 class TestInferContextualFactors:
     def test_scientific_domain(self, detector):
@@ -194,6 +198,7 @@ class TestInferContextualFactors:
 # _calculate_contextual_severity
 # ============================================================
 
+
 class TestCalculateContextualSeverity:
     def test_unknown_fallacy_returns_base(self, detector):
         severity = detector._calculate_contextual_severity(
@@ -222,7 +227,13 @@ class TestCalculateContextualSeverity:
 
     def test_severity_in_valid_range(self, detector):
         for fallacy_name in detector.contextual_fallacies:
-            for domain in ["scientifique", "politique", "juridique", "médical", "commercial"]:
+            for domain in [
+                "scientifique",
+                "politique",
+                "juridique",
+                "médical",
+                "commercial",
+            ]:
                 severity = detector._calculate_contextual_severity(
                     fallacy_name, {"domain": domain}
                 )
@@ -232,6 +243,7 @@ class TestCalculateContextualSeverity:
 # ============================================================
 # detect_contextual_fallacies
 # ============================================================
+
 
 class TestDetectContextualFallacies:
     def test_returns_dict(self, detector):
@@ -273,7 +285,8 @@ class TestDetectContextualFallacies:
     def test_explicit_contextual_factors(self, detector):
         explicit_factors = {"domain": "juridique", "audience": "expert"}
         result = detector.detect_contextual_fallacies(
-            "un argument", "un contexte",
+            "un argument",
+            "un contexte",
             contextual_factors=explicit_factors,
         )
         assert result["contextual_factors"] == explicit_factors
@@ -303,6 +316,7 @@ class TestDetectContextualFallacies:
 # detect_multiple_contextual_fallacies
 # ============================================================
 
+
 class TestDetectMultipleContextualFallacies:
     def test_returns_dict(self, detector):
         result = detector.detect_multiple_contextual_fallacies(
@@ -311,9 +325,7 @@ class TestDetectMultipleContextualFallacies:
         assert isinstance(result, dict)
 
     def test_result_has_required_keys(self, detector):
-        result = detector.detect_multiple_contextual_fallacies(
-            ["arg1"], "contexte"
-        )
+        result = detector.detect_multiple_contextual_fallacies(["arg1"], "contexte")
         assert "argument_count" in result
         assert "argument_results" in result
         assert "analysis_timestamp" in result
@@ -326,9 +338,7 @@ class TestDetectMultipleContextualFallacies:
         assert len(result["argument_results"]) == 3
 
     def test_each_result_has_index(self, detector):
-        result = detector.detect_multiple_contextual_fallacies(
-            ["a", "b"], "contexte"
-        )
+        result = detector.detect_multiple_contextual_fallacies(["a", "b"], "contexte")
         for i, arg_result in enumerate(result["argument_results"]):
             assert arg_result["argument_index"] == i
 
@@ -347,6 +357,8 @@ class TestDetectMultipleContextualFallacies:
     def test_explicit_factors_passed_through(self, detector):
         factors = {"domain": "médical", "audience": "expert"}
         result = detector.detect_multiple_contextual_fallacies(
-            ["arg"], "ctx", contextual_factors=factors,
+            ["arg"],
+            "ctx",
+            contextual_factors=factors,
         )
         assert result["contextual_factors"] == factors

--- a/tests/unit/argumentation_analysis/agents/tools/analysis/test_fallacy_severity_evaluator.py
+++ b/tests/unit/argumentation_analysis/agents/tools/analysis/test_fallacy_severity_evaluator.py
@@ -11,10 +11,10 @@ from argumentation_analysis.agents.tools.analysis.fallacy_severity_evaluator imp
     FallacySeverityEvaluator,
 )
 
-
 # ============================================================
 # _load_severity_config
 # ============================================================
+
 
 class TestLoadSeverityConfig:
     def test_returns_dict(self):
@@ -30,7 +30,11 @@ class TestLoadSeverityConfig:
         config = _load_severity_config()
         assert "context_modifiers" in config
         assert set(config["context_modifiers"].keys()) == {
-            "politique", "scientifique", "commercial", "juridique", "académique"
+            "politique",
+            "scientifique",
+            "commercial",
+            "juridique",
+            "académique",
         }
 
     def test_base_severity_values_in_range(self):
@@ -48,6 +52,7 @@ class TestLoadSeverityConfig:
 # ============================================================
 # FallacySeverityEvaluator.__init__
 # ============================================================
+
 
 class TestEvaluatorInit:
     def test_creates_instance(self):
@@ -67,6 +72,7 @@ class TestEvaluatorInit:
 # _determine_context_type
 # ============================================================
 
+
 class TestDetermineContextType:
     @pytest.fixture
     def evaluator(self):
@@ -79,10 +85,14 @@ class TestDetermineContextType:
         assert evaluator._determine_context_type("campagne d'élection") == "politique"
 
     def test_scientifique(self, evaluator):
-        assert evaluator._determine_context_type("article scientifique") == "scientifique"
+        assert (
+            evaluator._determine_context_type("article scientifique") == "scientifique"
+        )
 
     def test_scientifique_recherche(self, evaluator):
-        assert evaluator._determine_context_type("résultat de recherche") == "scientifique"
+        assert (
+            evaluator._determine_context_type("résultat de recherche") == "scientifique"
+        )
 
     def test_commercial(self, evaluator):
         assert evaluator._determine_context_type("publicité télévisée") == "commercial"
@@ -107,6 +117,7 @@ class TestDetermineContextType:
 # _calculate_visibility
 # ============================================================
 
+
 class TestCalculateVisibility:
     @pytest.fixture
     def evaluator(self):
@@ -115,15 +126,14 @@ class TestCalculateVisibility:
     def test_known_fallacy_with_keywords(self, evaluator):
         score = evaluator._calculate_visibility(
             "Appel à l'autorité",
-            "Les experts sont unanimes que cette étude prouve tout."
+            "Les experts sont unanimes que cette étude prouve tout.",
         )
         assert 0.0 <= score <= 1.0
         assert score > 0.0  # Should find keywords
 
     def test_known_fallacy_no_keywords(self, evaluator):
         score = evaluator._calculate_visibility(
-            "Appel à l'autorité",
-            "Le ciel est bleu."
+            "Appel à l'autorité", "Le ciel est bleu."
         )
         assert score == 0.0
 
@@ -134,7 +144,7 @@ class TestCalculateVisibility:
     def test_all_keywords_max_score(self, evaluator):
         score = evaluator._calculate_visibility(
             "Faux dilemme",
-            "soit on choisit ou bien l'alternative unique, uniquement ce choix"
+            "soit on choisit ou bien l'alternative unique, uniquement ce choix",
         )
         assert score == 1.0
 
@@ -142,6 +152,7 @@ class TestCalculateVisibility:
 # ============================================================
 # _calculate_impact
 # ============================================================
+
 
 class TestCalculateImpact:
     @pytest.fixture
@@ -169,6 +180,7 @@ class TestCalculateImpact:
 # ============================================================
 # _determine_severity_level
 # ============================================================
+
 
 class TestDetermineSeverityLevel:
     @pytest.fixture
@@ -199,6 +211,7 @@ class TestDetermineSeverityLevel:
 # _generate_explanation
 # ============================================================
 
+
 class TestGenerateExplanation:
     @pytest.fixture
     def evaluator(self):
@@ -222,6 +235,7 @@ class TestGenerateExplanation:
 # evaluate_severity (integration)
 # ============================================================
 
+
 class TestEvaluateSeverity:
     @pytest.fixture
     def evaluator(self):
@@ -229,14 +243,18 @@ class TestEvaluateSeverity:
 
     def test_returns_dict_with_expected_keys(self, evaluator):
         result = evaluator.evaluate_severity(
-            "Appel à l'autorité",
-            "Les experts sont unanimes.",
-            "discours politique"
+            "Appel à l'autorité", "Les experts sont unanimes.", "discours politique"
         )
         expected_keys = {
-            "fallacy_type", "context_type", "base_score", "context_modifier",
-            "visibility_score", "impact_score", "final_score",
-            "severity_level", "explanation"
+            "fallacy_type",
+            "context_type",
+            "base_score",
+            "context_modifier",
+            "visibility_score",
+            "impact_score",
+            "final_score",
+            "severity_level",
+            "explanation",
         }
         assert expected_keys == set(result.keys())
 
@@ -248,16 +266,12 @@ class TestEvaluateSeverity:
 
     def test_context_modifier_applied(self, evaluator):
         result = evaluator.evaluate_severity(
-            "Appel à l'émotion",
-            "Pensez aux enfants !",
-            "discours politique"
+            "Appel à l'émotion", "Pensez aux enfants !", "discours politique"
         )
         assert result["context_modifier"] == 0.3  # politique -> Appel à l'émotion = 0.3
 
     def test_unknown_fallacy_uses_default_base(self, evaluator):
-        result = evaluator.evaluate_severity(
-            "Sophisme inexistant", "arg", "général"
-        )
+        result = evaluator.evaluate_severity("Sophisme inexistant", "arg", "général")
         assert result["base_score"] == 0.5
 
     def test_general_context_no_modifier(self, evaluator):
@@ -286,6 +300,7 @@ class TestEvaluateSeverity:
 # rank_fallacies
 # ============================================================
 
+
 class TestRankFallacies:
     @pytest.fixture
     def evaluator(self):
@@ -293,8 +308,16 @@ class TestRankFallacies:
 
     def test_sorts_by_severity_descending(self, evaluator):
         fallacies = [
-            {"fallacy_type": "Appel à la tradition", "argument": "C'est la tradition.", "context": "général"},
-            {"fallacy_type": "Ad hominem", "argument": "Tu es un menteur.", "context": "politique"},
+            {
+                "fallacy_type": "Appel à la tradition",
+                "argument": "C'est la tradition.",
+                "context": "général",
+            },
+            {
+                "fallacy_type": "Ad hominem",
+                "argument": "Tu es un menteur.",
+                "context": "politique",
+            },
         ]
         ranked = evaluator.rank_fallacies(fallacies)
         assert ranked[0]["severity"] >= ranked[1]["severity"]
@@ -329,6 +352,7 @@ class TestRankFallacies:
 # evaluate_impact
 # ============================================================
 
+
 class TestEvaluateImpact:
     @pytest.fixture
     def evaluator(self):
@@ -339,21 +363,24 @@ class TestEvaluateImpact:
             "Faux dilemme", "Soit A, soit B.", "juridique"
         )
         expected_keys = {
-            "fallacy_type", "severity", "severity_level",
-            "explanation", "impact_on_validity", "correction_suggestions"
+            "fallacy_type",
+            "severity",
+            "severity_level",
+            "explanation",
+            "impact_on_validity",
+            "correction_suggestions",
         }
         assert expected_keys == set(result.keys())
 
     def test_correction_suggestions_not_empty(self, evaluator):
-        result = evaluator.evaluate_impact(
-            "Ad hominem", "Tu es nul.", "politique"
-        )
+        result = evaluator.evaluate_impact("Ad hominem", "Tu es nul.", "politique")
         assert len(result["correction_suggestions"]) > 0
 
 
 # ============================================================
 # _calculate_validity_impact
 # ============================================================
+
 
 class TestCalculateValidityImpact:
     @pytest.fixture
@@ -377,6 +404,7 @@ class TestCalculateValidityImpact:
 # _generate_correction_suggestions
 # ============================================================
 
+
 class TestGenerateCorrectionSuggestions:
     @pytest.fixture
     def evaluator(self):
@@ -390,9 +418,7 @@ class TestGenerateCorrectionSuggestions:
         assert any("preuves" in s for s in suggestions)
 
     def test_unknown_fallacy_generic_suggestions(self, evaluator):
-        suggestions = evaluator._generate_correction_suggestions(
-            "Inconnu XYZ", "arg"
-        )
+        suggestions = evaluator._generate_correction_suggestions("Inconnu XYZ", "arg")
         assert len(suggestions) == 3
         assert any("preuves objectives" in s for s in suggestions)
 

--- a/tests/unit/argumentation_analysis/agents/tools/analysis/test_rhetorical_result_visualizer.py
+++ b/tests/unit/argumentation_analysis/agents/tools/analysis/test_rhetorical_result_visualizer.py
@@ -51,6 +51,7 @@ def empty_state():
 # __init__
 # ============================================================
 
+
 class TestInit:
     def test_creates_instance(self, viz):
         assert viz is not None
@@ -60,6 +61,7 @@ class TestInit:
 # ============================================================
 # generate_argument_graph
 # ============================================================
+
 
 class TestGenerateArgumentGraph:
     def test_empty_state(self, viz, empty_state):
@@ -137,6 +139,7 @@ class TestGenerateArgumentGraph:
 # generate_fallacy_distribution
 # ============================================================
 
+
 class TestGenerateFallacyDistribution:
     def test_empty_state(self, viz, empty_state):
         dist = viz.generate_fallacy_distribution(empty_state)
@@ -183,6 +186,7 @@ class TestGenerateFallacyDistribution:
 # generate_argument_quality_heatmap
 # ============================================================
 
+
 class TestGenerateHeatmap:
     def test_empty_state(self, viz, empty_state):
         hm = viz.generate_argument_quality_heatmap(empty_state)
@@ -208,8 +212,7 @@ class TestGenerateHeatmap:
         state = {
             "identified_arguments": {"arg_1": "Argument"},
             "identified_fallacies": {
-                f"f{i}": {"type": "X", "target_argument_id": "arg_1"}
-                for i in range(10)
+                f"f{i}": {"type": "X", "target_argument_id": "arg_1"} for i in range(10)
             },
         }
         hm = viz.generate_argument_quality_heatmap(state)
@@ -229,6 +232,7 @@ class TestGenerateHeatmap:
 # ============================================================
 # generate_all_visualizations
 # ============================================================
+
 
 class TestGenerateAllVisualizations:
     def test_keys_present(self, viz, sample_state):
@@ -250,6 +254,7 @@ class TestGenerateAllVisualizations:
 # ============================================================
 # generate_html_report
 # ============================================================
+
 
 class TestGenerateHtmlReport:
     def test_html_structure(self, viz, sample_state):

--- a/tests/unit/argumentation_analysis/agents/tools/support/test_shared_services.py
+++ b/tests/unit/argumentation_analysis/agents/tools/support/test_shared_services.py
@@ -12,10 +12,10 @@ from argumentation_analysis.agents.tools.support.shared_services import (
     ConfigManager,
 )
 
-
 # ============================================================
 # get_configured_logger
 # ============================================================
+
 
 class TestGetConfiguredLogger:
     def test_returns_logger(self):
@@ -41,6 +41,7 @@ class TestGetConfiguredLogger:
 # ============================================================
 # ServiceRegistry
 # ============================================================
+
 
 class TestServiceRegistry:
     def setup_method(self):
@@ -90,6 +91,7 @@ class TestServiceRegistry:
 # ============================================================
 # ConfigManager
 # ============================================================
+
 
 class TestConfigManager:
     def setup_method(self):

--- a/tests/unit/argumentation_analysis/agents/tools/test_analysis_tools.py
+++ b/tests/unit/argumentation_analysis/agents/tools/test_analysis_tools.py
@@ -11,7 +11,6 @@ import pytest
 from unittest.mock import patch, MagicMock, PropertyMock
 from datetime import datetime
 
-
 # ---------------------------------------------------------------------------
 # 1. ContextualFallacyDetector tests
 # ---------------------------------------------------------------------------
@@ -85,19 +84,27 @@ class TestContextualFallacyDetector:
         assert factors["domain"] == "scientifique"
 
     def test_infer_domain_politique(self, detector):
-        factors = detector._infer_contextual_factors("un discours politique au parlement")
+        factors = detector._infer_contextual_factors(
+            "un discours politique au parlement"
+        )
         assert factors["domain"] == "politique"
 
     def test_infer_domain_juridique(self, detector):
-        factors = detector._infer_contextual_factors("une affaire juridique au tribunal")
+        factors = detector._infer_contextual_factors(
+            "une affaire juridique au tribunal"
+        )
         assert factors["domain"] == "juridique"
 
     def test_infer_domain_medical(self, detector):
-        factors = detector._infer_contextual_factors("un contexte médical de santé publique")
+        factors = detector._infer_contextual_factors(
+            "un contexte médical de santé publique"
+        )
         assert factors["domain"] == "médical"
 
     def test_infer_domain_commercial(self, detector):
-        factors = detector._infer_contextual_factors("une campagne de marketing commercial")
+        factors = detector._infer_contextual_factors(
+            "une campagne de marketing commercial"
+        )
         assert factors["domain"] == "commercial"
 
     def test_infer_domain_default_general(self, detector):
@@ -109,7 +116,9 @@ class TestContextualFallacyDetector:
         assert factors["audience"] == "expert"
 
     def test_infer_audience_academique(self, detector):
-        factors = detector._infer_contextual_factors("un contexte académique universitaire")
+        factors = detector._infer_contextual_factors(
+            "un contexte académique universitaire"
+        )
         assert factors["audience"] == "académique"
 
     def test_infer_audience_default_generaliste(self, detector):
@@ -125,7 +134,9 @@ class TestContextualFallacyDetector:
         assert factors["medium"] == "général"
 
     def test_infer_purpose_informer(self, detector):
-        factors = detector._infer_contextual_factors("un texte pour informer le lecteur")
+        factors = detector._infer_contextual_factors(
+            "un texte pour informer le lecteur"
+        )
         assert factors["purpose"] == "informer"
 
     def test_infer_purpose_default(self, detector):
@@ -294,9 +305,7 @@ class TestContextualFallacyDetector:
     def test_multiple_arguments_updates_detection_history(self, detector):
         """detect_multiple should append to detection_history."""
         assert len(detector.detection_history) == 0
-        detector.detect_multiple_contextual_fallacies(
-            ["Arg 1"], "contexte de science"
-        )
+        detector.detect_multiple_contextual_fallacies(["Arg 1"], "contexte de science")
         assert len(detector.detection_history) == 1
         entry = detector.detection_history[0]
         assert entry["type"] == "multiple_contextual_fallacy_detection"
@@ -323,9 +332,7 @@ class TestContextualFallacyDetector:
         assert len(second_fallacies) == 0
 
     def test_multiple_returns_argument_count(self, detector):
-        results = detector.detect_multiple_contextual_fallacies(
-            ["a", "b", "c"], "ctx"
-        )
+        results = detector.detect_multiple_contextual_fallacies(["a", "b", "c"], "ctx")
         assert results["argument_count"] == 3
 
 
@@ -418,7 +425,10 @@ class TestRhetoricalResultVisualizer:
         state = {
             "identified_arguments": {"arg_1": "Some text"},
             "identified_fallacies": {
-                "fallacy_1": {"type": "Red herring", "target_argument_id": "arg_missing"},
+                "fallacy_1": {
+                    "type": "Red herring",
+                    "target_argument_id": "arg_missing",
+                },
             },
         }
         graph = visualizer.generate_argument_graph(state)
@@ -486,8 +496,7 @@ class TestRhetoricalResultVisualizer:
         state = {
             "identified_arguments": {"arg_1": "Text"},
             "identified_fallacies": {
-                f"f{i}": {"type": "X", "target_argument_id": "arg_1"}
-                for i in range(6)
+                f"f{i}": {"type": "X", "target_argument_id": "arg_1"} for i in range(6)
             },
         }
         hm = visualizer.generate_argument_quality_heatmap(state)
@@ -574,12 +583,19 @@ class TestArgumentCoherenceEvaluator:
             from argumentation_analysis.agents.tools.analysis.new.argument_coherence_evaluator import (
                 ArgumentCoherenceEvaluator,
             )
+
             return ArgumentCoherenceEvaluator()
 
     def test_init_creates_coherence_types(self, evaluator):
         """Evaluator should have 5 coherence type definitions."""
         assert len(evaluator.coherence_types) == 5
-        expected = {"logique", "thématique", "structurelle", "rhétorique", "épistémique"}
+        expected = {
+            "logique",
+            "thématique",
+            "structurelle",
+            "rhétorique",
+            "épistémique",
+        }
         assert set(evaluator.coherence_types.keys()) == expected
 
     def test_coherence_types_importances_sum_to_one(self, evaluator):
@@ -602,7 +618,13 @@ class TestArgumentCoherenceEvaluator:
         """coherence_evaluations should contain all 5 dimensions."""
         result = evaluator.evaluate_coherence(["A", "B"])
         evals = result["coherence_evaluations"]
-        expected = {"logique", "thématique", "structurelle", "rhétorique", "épistémique"}
+        expected = {
+            "logique",
+            "thématique",
+            "structurelle",
+            "rhétorique",
+            "épistémique",
+        }
         assert set(evals.keys()) == expected
 
     def test_evaluate_coherence_each_dimension_has_score(self, evaluator):
@@ -684,6 +706,7 @@ class TestFactClaimDataStructures:
             from argumentation_analysis.agents.tools.analysis.fact_claim_extractor import (
                 ClaimType,
             )
+
             assert len(ClaimType) == 10
 
     def test_claim_type_values(self):
@@ -693,10 +716,18 @@ class TestFactClaimDataStructures:
             from argumentation_analysis.agents.tools.analysis.fact_claim_extractor import (
                 ClaimType,
             )
+
             expected = {
-                "statistical", "historical", "scientific", "geographical",
-                "biographical", "numerical", "temporal", "causal",
-                "definitional", "quote",
+                "statistical",
+                "historical",
+                "scientific",
+                "geographical",
+                "biographical",
+                "numerical",
+                "temporal",
+                "causal",
+                "definitional",
+                "quote",
             }
             actual = {ct.value for ct in ClaimType}
             assert actual == expected
@@ -708,6 +739,7 @@ class TestFactClaimDataStructures:
             from argumentation_analysis.agents.tools.analysis.fact_claim_extractor import (
                 ClaimVerifiability,
             )
+
             assert len(ClaimVerifiability) == 5
 
     def test_claim_verifiability_values(self):
@@ -717,9 +749,13 @@ class TestFactClaimDataStructures:
             from argumentation_analysis.agents.tools.analysis.fact_claim_extractor import (
                 ClaimVerifiability,
             )
+
             expected = {
-                "highly_verifiable", "moderately_verifiable",
-                "partially_verifiable", "subjective", "opinion",
+                "highly_verifiable",
+                "moderately_verifiable",
+                "partially_verifiable",
+                "subjective",
+                "opinion",
             }
             actual = {cv.value for cv in ClaimVerifiability}
             assert actual == expected
@@ -729,8 +765,11 @@ class TestFactClaimDataStructures:
         mock_spacy = MagicMock()
         with patch.dict("sys.modules", {"spacy": mock_spacy}):
             from argumentation_analysis.agents.tools.analysis.fact_claim_extractor import (
-                FactualClaim, ClaimType, ClaimVerifiability,
+                FactualClaim,
+                ClaimType,
+                ClaimVerifiability,
             )
+
             claim = FactualClaim(
                 claim_text="50% of people agree",
                 claim_type=ClaimType.STATISTICAL,
@@ -755,8 +794,11 @@ class TestFactClaimDataStructures:
         mock_spacy = MagicMock()
         with patch.dict("sys.modules", {"spacy": mock_spacy}):
             from argumentation_analysis.agents.tools.analysis.fact_claim_extractor import (
-                FactualClaim, ClaimType, ClaimVerifiability,
+                FactualClaim,
+                ClaimType,
+                ClaimVerifiability,
             )
+
             claim = FactualClaim(
                 claim_text="In 1969, man landed on the moon.",
                 claim_type=ClaimType.HISTORICAL,
@@ -788,8 +830,11 @@ class TestFactClaimDataStructures:
         mock_spacy = MagicMock()
         with patch.dict("sys.modules", {"spacy": mock_spacy}):
             from argumentation_analysis.agents.tools.analysis.fact_claim_extractor import (
-                FactualClaim, ClaimType, ClaimVerifiability,
+                FactualClaim,
+                ClaimType,
+                ClaimVerifiability,
             )
+
             claim = FactualClaim(
                 claim_text="test",
                 claim_type=ClaimType.CAUSAL,
@@ -807,9 +852,18 @@ class TestFactClaimDataStructures:
             )
             d = claim.to_dict()
             expected_keys = {
-                "claim_text", "claim_type", "verifiability", "confidence",
-                "context", "start_pos", "end_pos", "entities", "keywords",
-                "temporal_references", "numerical_values", "sources_mentioned",
+                "claim_text",
+                "claim_type",
+                "verifiability",
+                "confidence",
+                "context",
+                "start_pos",
+                "end_pos",
+                "entities",
+                "keywords",
+                "temporal_references",
+                "numerical_values",
+                "sources_mentioned",
                 "extraction_method",
             }
             assert set(d.keys()) == expected_keys

--- a/tests/unit/argumentation_analysis/agents/tools/test_fallacy_analyzers.py
+++ b/tests/unit/argumentation_analysis/agents/tools/test_fallacy_analyzers.py
@@ -12,10 +12,10 @@ Issue: #36 (test coverage)
 import pytest
 from unittest.mock import patch, MagicMock
 
-
 # ---------------------------------------------------------------------------
 # Fixtures to isolate singleton state between tests
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(autouse=True)
 def _reset_singletons():
@@ -24,6 +24,7 @@ def _reset_singletons():
         ServiceRegistry,
         ConfigManager,
     )
+
     old_services = ServiceRegistry._services.copy()
     old_configs = ConfigManager._configs.copy()
     yield
@@ -44,6 +45,7 @@ class TestFallacySeverityEvaluator:
         from argumentation_analysis.agents.tools.analysis.fallacy_severity_evaluator import (
             FallacySeverityEvaluator,
         )
+
         return FallacySeverityEvaluator()
 
     # --- _determine_severity_level ---
@@ -72,10 +74,15 @@ class TestFallacySeverityEvaluator:
 
     def test_context_type_politique(self, evaluator):
         assert evaluator._determine_context_type("discours politique") == "politique"
-        assert evaluator._determine_context_type("élection présidentielle") == "politique"
+        assert (
+            evaluator._determine_context_type("élection présidentielle") == "politique"
+        )
 
     def test_context_type_scientifique(self, evaluator):
-        assert evaluator._determine_context_type("recherche scientifique") == "scientifique"
+        assert (
+            evaluator._determine_context_type("recherche scientifique")
+            == "scientifique"
+        )
         assert evaluator._determine_context_type("étude clinique") == "scientifique"
 
     def test_context_type_commercial(self, evaluator):
@@ -98,39 +105,29 @@ class TestFallacySeverityEvaluator:
     def test_visibility_known_type_with_keywords(self, evaluator):
         score = evaluator._calculate_visibility(
             "Appel à l'autorité",
-            "Les experts unanimes affirment que cette étude scientifique prouve tout."
+            "Les experts unanimes affirment que cette étude scientifique prouve tout.",
         )
         assert 0.0 < score <= 1.0
 
     def test_visibility_known_type_no_keywords(self, evaluator):
         score = evaluator._calculate_visibility(
-            "Appel à l'autorité",
-            "Le chat dort sur le canapé."
+            "Appel à l'autorité", "Le chat dort sur le canapé."
         )
         assert score == 0.0
 
     def test_visibility_unknown_type(self, evaluator):
-        score = evaluator._calculate_visibility(
-            "Type Inconnu",
-            "N'importe quel texte."
-        )
+        score = evaluator._calculate_visibility("Type Inconnu", "N'importe quel texte.")
         assert score == 0.5  # default for unknown types
 
     # --- _calculate_impact ---
 
     def test_impact_known_type(self, evaluator):
-        score = evaluator._calculate_impact(
-            "Ad hominem",
-            "Texte court."
-        )
+        score = evaluator._calculate_impact("Ad hominem", "Texte court.")
         assert score > 0.0
         assert score <= 1.0
 
     def test_impact_unknown_type(self, evaluator):
-        score = evaluator._calculate_impact(
-            "Type Inconnu",
-            "Un argument quelconque."
-        )
+        score = evaluator._calculate_impact("Type Inconnu", "Un argument quelconque.")
         assert score == 0.5
 
     def test_impact_long_argument_reduces_modifier(self, evaluator):
@@ -142,8 +139,15 @@ class TestFallacySeverityEvaluator:
     # --- _generate_explanation ---
 
     def test_generate_explanation_all_levels(self, evaluator):
-        for score, level_kw in [(0.1, "limité"), (0.4, "modéré"), (0.7, "important"), (0.9, "critique")]:
-            explanation = evaluator._generate_explanation("Ad hominem", "politique", score)
+        for score, level_kw in [
+            (0.1, "limité"),
+            (0.4, "modéré"),
+            (0.7, "important"),
+            (0.9, "critique"),
+        ]:
+            explanation = evaluator._generate_explanation(
+                "Ad hominem", "politique", score
+            )
             assert isinstance(explanation, str)
             assert len(explanation) > 10
 
@@ -187,7 +191,7 @@ class TestFallacySeverityEvaluator:
         result = evaluator.evaluate_severity(
             "Appel à l'autorité",
             "Les experts unanimes confirment cette recherche scientifique.",
-            "discours commercial"
+            "discours commercial",
         )
         assert "fallacy_type" in result
         assert "context_type" in result
@@ -218,7 +222,7 @@ class TestFallacySeverityEvaluator:
         result = evaluator.evaluate_severity(
             "Ad hominem",
             "personne caractère intégrité moralité crédibilité",
-            "politique"
+            "politique",
         )
         assert result["final_score"] <= 1.0
 
@@ -247,7 +251,7 @@ class TestFallacySeverityEvaluator:
             {
                 "fallacy_type": "Appel à l'autorité",
                 "argument": "Les experts disent que...",
-                "context": "scientifique"
+                "context": "scientifique",
             }
         ]
         ranked = evaluator.rank_fallacies(fallacies)
@@ -261,9 +265,7 @@ class TestFallacySeverityEvaluator:
 
     def test_evaluate_impact_returns_complete_result(self, evaluator):
         result = evaluator.evaluate_impact(
-            "Faux dilemme",
-            "Soit vous acceptez, soit vous perdez tout.",
-            "commercial"
+            "Faux dilemme", "Soit vous acceptez, soit vous perdez tout.", "commercial"
         )
         assert "fallacy_type" in result
         assert "severity" in result
@@ -287,6 +289,7 @@ class TestContextualFallacyAnalyzer:
         from argumentation_analysis.agents.tools.analysis.contextual_fallacy_analyzer import (
             ContextualFallacyAnalyzer,
         )
+
         return ContextualFallacyAnalyzer()
 
     # --- _determine_context_type ---
@@ -347,9 +350,7 @@ class TestContextualFallacyAnalyzer:
         assert "Pente glissante" in types
 
     def test_identify_no_fallacies_clean_text(self, analyzer):
-        fallacies = analyzer._identify_potential_fallacies(
-            "Le chat dort paisiblement."
-        )
+        fallacies = analyzer._identify_potential_fallacies("Le chat dort paisiblement.")
         assert len(fallacies) == 0
 
     def test_identify_multiple_fallacies(self, analyzer):
@@ -360,9 +361,7 @@ class TestContextualFallacyAnalyzer:
         assert len(types) >= 2
 
     def test_fallacy_has_expected_fields(self, analyzer):
-        fallacies = analyzer._identify_potential_fallacies(
-            "Les experts sont unanimes."
-        )
+        fallacies = analyzer._identify_potential_fallacies("Les experts sont unanimes.")
         assert len(fallacies) > 0
         f = fallacies[0]
         assert "fallacy_type" in f
@@ -390,7 +389,9 @@ class TestContextualFallacyAnalyzer:
         ]
         filtered = analyzer._filter_by_context(fallacies, "politique")
         ad_hominem = [f for f in filtered if f["fallacy_type"] == "Ad hominem"][0]
-        tradition = [f for f in filtered if f["fallacy_type"] == "Appel à la tradition"][0]
+        tradition = [
+            f for f in filtered if f["fallacy_type"] == "Appel à la tradition"
+        ][0]
         # Ad hominem is relevant in political context
         assert ad_hominem["confidence"] == 0.8
         assert ad_hominem["contextual_relevance"] == "Élevée"
@@ -417,7 +418,7 @@ class TestContextualFallacyAnalyzer:
         with patch.object(analyzer, "_get_taxonomy_df", return_value=MagicMock()):
             result = analyzer.analyze_context(
                 "Les experts unanimes disent que tout le monde est d'accord.",
-                "politique"
+                "politique",
             )
             assert "context_type" in result
             assert "potential_fallacies_count" in result
@@ -430,8 +431,7 @@ class TestContextualFallacyAnalyzer:
     def test_identify_contextual_fallacies_filters_by_confidence(self, analyzer):
         with patch.object(analyzer, "_get_taxonomy_df", return_value=MagicMock()):
             fallacies = analyzer.identify_contextual_fallacies(
-                "Les experts unanimes affirment que c'est vrai.",
-                "général"
+                "Les experts unanimes affirment que c'est vrai.", "général"
             )
             # All returned fallacies should have confidence >= 0.5
             for f in fallacies:
@@ -440,8 +440,7 @@ class TestContextualFallacyAnalyzer:
     def test_identify_contextual_fallacies_empty_text(self, analyzer):
         with patch.object(analyzer, "_get_taxonomy_df", return_value=MagicMock()):
             fallacies = analyzer.identify_contextual_fallacies(
-                "Le chat dort.",
-                "général"
+                "Le chat dort.", "général"
             )
             assert isinstance(fallacies, list)
 
@@ -463,9 +462,7 @@ class TestContextualFallacyAnalyzer:
         assert "Aucun exemple" in examples[0]
 
     def test_examples_unknown_type(self, analyzer):
-        examples = analyzer.get_contextual_fallacy_examples(
-            "Type Inconnu", "politique"
-        )
+        examples = analyzer.get_contextual_fallacy_examples("Type Inconnu", "politique")
         assert isinstance(examples, list)
         assert "Aucun exemple" in examples[0]
 
@@ -502,6 +499,7 @@ class TestComplexFallacyAnalyzer:
         from argumentation_analysis.agents.tools.analysis.fallacy_severity_evaluator import (
             FallacySeverityEvaluator,
         )
+
         # Pre-populate ServiceRegistry with mocks
         ServiceRegistry._services[ContextualFallacyAnalyzer] = mock_contextual
         ServiceRegistry._services[FallacySeverityEvaluator] = mock_severity
@@ -509,6 +507,7 @@ class TestComplexFallacyAnalyzer:
         from argumentation_analysis.agents.tools.analysis.complex_fallacy_analyzer import (
             ComplexFallacyAnalyzer,
         )
+
         return ComplexFallacyAnalyzer()
 
     # --- _detect_contradictions ---
@@ -547,19 +546,23 @@ class TestComplexFallacyAnalyzer:
         assert circles == []
 
     def test_circular_arguments_no_keywords(self, analyzer):
-        circles = analyzer._detect_circular_arguments([
-            "Le chat dort.",
-            "Le chien mange.",
-            "L'oiseau chante.",
-        ])
+        circles = analyzer._detect_circular_arguments(
+            [
+                "Le chat dort.",
+                "Le chien mange.",
+                "L'oiseau chante.",
+            ]
+        )
         assert circles == []
 
     def test_circular_arguments_detected_with_keywords(self, analyzer):
-        circles = analyzer._detect_circular_arguments([
-            "A est vrai, donc B est vrai.",
-            "B est vrai, donc C est vrai.",
-            "C est vrai, donc A est vrai.",
-        ])
+        circles = analyzer._detect_circular_arguments(
+            [
+                "A est vrai, donc B est vrai.",
+                "B est vrai, donc C est vrai.",
+                "C est vrai, donc A est vrai.",
+            ]
+        )
         assert len(circles) > 0
         for circle in circles:
             assert len(circle["involved_arguments"]) == 3
@@ -579,7 +582,9 @@ class TestComplexFallacyAnalyzer:
         result = analyzer.identify_combined_fallacies("Un texte.")
         assert result == []
 
-    def test_combined_matching_combination(self, analyzer, mock_contextual, mock_severity):
+    def test_combined_matching_combination(
+        self, analyzer, mock_contextual, mock_severity
+    ):
         """When both components of a known combination are present, it's detected."""
         mock_contextual.identify_contextual_fallacies.return_value = [
             {"fallacy_type": "Appel à l'autorité", "confidence": 0.6},
@@ -594,7 +599,9 @@ class TestComplexFallacyAnalyzer:
         assert result[0]["severity"] <= 1.0
         assert "component_fallacies" in result[0]
 
-    def test_combined_severity_capped_at_1(self, analyzer, mock_contextual, mock_severity):
+    def test_combined_severity_capped_at_1(
+        self, analyzer, mock_contextual, mock_severity
+    ):
         mock_contextual.identify_contextual_fallacies.return_value = [
             {"fallacy_type": "Ad hominem", "confidence": 0.95},
             {"fallacy_type": "Généralisation hâtive", "confidence": 0.95},
@@ -678,8 +685,14 @@ class TestComplexFallacyAnalyzer:
     def test_escalation_detected(self, analyzer):
         # Escalation order: Appel à la tradition < Appel à la popularité < Ad hominem
         paragraphs = [
-            {"paragraph_index": 0, "fallacies": [{"fallacy_type": "Appel à la tradition"}]},
-            {"paragraph_index": 1, "fallacies": [{"fallacy_type": "Appel à la popularité"}]},
+            {
+                "paragraph_index": 0,
+                "fallacies": [{"fallacy_type": "Appel à la tradition"}],
+            },
+            {
+                "paragraph_index": 1,
+                "fallacies": [{"fallacy_type": "Appel à la popularité"}],
+            },
             {"paragraph_index": 2, "fallacies": [{"fallacy_type": "Ad hominem"}]},
         ]
         result = analyzer._detect_escalation_patterns(paragraphs)
@@ -693,8 +706,14 @@ class TestComplexFallacyAnalyzer:
         # Reverse order should not be detected as escalation
         paragraphs = [
             {"paragraph_index": 0, "fallacies": [{"fallacy_type": "Ad hominem"}]},
-            {"paragraph_index": 1, "fallacies": [{"fallacy_type": "Appel à la popularité"}]},
-            {"paragraph_index": 2, "fallacies": [{"fallacy_type": "Appel à la tradition"}]},
+            {
+                "paragraph_index": 1,
+                "fallacies": [{"fallacy_type": "Appel à la popularité"}],
+            },
+            {
+                "paragraph_index": 2,
+                "fallacies": [{"fallacy_type": "Appel à la tradition"}],
+            },
         ]
         result = analyzer._detect_escalation_patterns(paragraphs)
         assert result == []
@@ -724,6 +743,7 @@ class TestComplexFallacyAnalyzer:
     def test_fallacy_patterns_returns_pattern_dicts(self, analyzer, mock_contextual):
         # Simulate alternation pattern detection
         call_count = [0]
+
         def side_effect(argument, context):
             call_count[0] += 1
             if call_count[0] % 2 == 1:
@@ -750,7 +770,9 @@ class TestSharedServices:
     """Tests for the shared_services infrastructure used by analyzers."""
 
     def test_service_registry_creates_singleton(self):
-        from argumentation_analysis.agents.tools.support.shared_services import ServiceRegistry
+        from argumentation_analysis.agents.tools.support.shared_services import (
+            ServiceRegistry,
+        )
 
         class DummyService:
             pass
@@ -760,9 +782,12 @@ class TestSharedServices:
         assert instance1 is instance2
 
     def test_config_manager_caches_config(self):
-        from argumentation_analysis.agents.tools.support.shared_services import ConfigManager
+        from argumentation_analysis.agents.tools.support.shared_services import (
+            ConfigManager,
+        )
 
         call_count = [0]
+
         def loader():
             call_count[0] += 1
             return {"key": "value"}
@@ -773,9 +798,12 @@ class TestSharedServices:
         assert call_count[0] == 1  # only called once
 
     def test_config_manager_force_reload(self):
-        from argumentation_analysis.agents.tools.support.shared_services import ConfigManager
+        from argumentation_analysis.agents.tools.support.shared_services import (
+            ConfigManager,
+        )
 
         call_count = [0]
+
         def loader():
             call_count[0] += 1
             return {"version": call_count[0]}
@@ -786,7 +814,9 @@ class TestSharedServices:
         assert result["version"] == 2
 
     def test_get_configured_logger(self):
-        from argumentation_analysis.agents.tools.support.shared_services import get_configured_logger
+        from argumentation_analysis.agents.tools.support.shared_services import (
+            get_configured_logger,
+        )
         import logging
 
         logger = get_configured_logger("TestLogger")

--- a/tests/unit/argumentation_analysis/agents/utils/test_taxonomy_navigator.py
+++ b/tests/unit/argumentation_analysis/agents/utils/test_taxonomy_navigator.py
@@ -8,22 +8,71 @@ import pytest
 import json
 from argumentation_analysis.agents.utils.taxonomy_navigator import TaxonomyNavigator
 
-
 # ============================================================
 # Fixtures
 # ============================================================
+
 
 @pytest.fixture
 def sample_taxonomy_data():
     """A small taxonomy tree for testing."""
     return [
-        {"PK": "1", "path": "1", "depth": "1", "nom_vulgarisé": "Logique", "text_fr": "Logique", "desc_fr": "La logique formelle"},
-        {"PK": "1.1", "path": "1.1", "depth": "2", "nom_vulgarisé": "Déduction", "text_fr": "Déduction", "desc_fr": "Raisonnement déductif"},
-        {"PK": "1.2", "path": "1.2", "depth": "2", "nom_vulgarisé": "Induction", "text_fr": "Induction", "desc_fr": "Raisonnement inductif"},
-        {"PK": "1.1.1", "path": "1.1.1", "depth": "3", "nom_vulgarisé": "Modus Ponens", "text_fr": "Modus Ponens", "desc_fr": "Si P alors Q"},
-        {"PK": "1.1.2", "path": "1.1.2", "depth": "3", "nom_vulgarisé": "Modus Tollens", "text_fr": "Modus Tollens", "desc_fr": "Si P alors Q, non Q"},
-        {"PK": "2", "path": "2", "depth": "1", "nom_vulgarisé": "Rhétorique", "text_fr": "Rhétorique", "desc_fr": "L'art de la persuasion"},
-        {"PK": "2.1", "path": "2.1", "depth": "2", "nom_vulgarisé": "Ethos", "text_fr": "Ethos", "desc_fr": "Appel à la crédibilité"},
+        {
+            "PK": "1",
+            "path": "1",
+            "depth": "1",
+            "nom_vulgarisé": "Logique",
+            "text_fr": "Logique",
+            "desc_fr": "La logique formelle",
+        },
+        {
+            "PK": "1.1",
+            "path": "1.1",
+            "depth": "2",
+            "nom_vulgarisé": "Déduction",
+            "text_fr": "Déduction",
+            "desc_fr": "Raisonnement déductif",
+        },
+        {
+            "PK": "1.2",
+            "path": "1.2",
+            "depth": "2",
+            "nom_vulgarisé": "Induction",
+            "text_fr": "Induction",
+            "desc_fr": "Raisonnement inductif",
+        },
+        {
+            "PK": "1.1.1",
+            "path": "1.1.1",
+            "depth": "3",
+            "nom_vulgarisé": "Modus Ponens",
+            "text_fr": "Modus Ponens",
+            "desc_fr": "Si P alors Q",
+        },
+        {
+            "PK": "1.1.2",
+            "path": "1.1.2",
+            "depth": "3",
+            "nom_vulgarisé": "Modus Tollens",
+            "text_fr": "Modus Tollens",
+            "desc_fr": "Si P alors Q, non Q",
+        },
+        {
+            "PK": "2",
+            "path": "2",
+            "depth": "1",
+            "nom_vulgarisé": "Rhétorique",
+            "text_fr": "Rhétorique",
+            "desc_fr": "L'art de la persuasion",
+        },
+        {
+            "PK": "2.1",
+            "path": "2.1",
+            "depth": "2",
+            "nom_vulgarisé": "Ethos",
+            "text_fr": "Ethos",
+            "desc_fr": "Appel à la crédibilité",
+        },
     ]
 
 
@@ -45,6 +94,7 @@ def none_navigator():
 # ============================================================
 # Initialization
 # ============================================================
+
 
 class TestTaxonomyNavigatorInit:
     def test_init_with_data(self, navigator, sample_taxonomy_data):
@@ -84,6 +134,7 @@ class TestTaxonomyNavigatorInit:
 # get_node
 # ============================================================
 
+
 class TestGetNode:
     def test_existing_node(self, navigator):
         node = navigator.get_node("1")
@@ -107,6 +158,7 @@ class TestGetNode:
 # get_node_by_path
 # ============================================================
 
+
 class TestGetNodeByPath:
     def test_existing_path(self, navigator):
         node = navigator.get_node_by_path("1.1")
@@ -125,6 +177,7 @@ class TestGetNodeByPath:
 # ============================================================
 # get_root_nodes
 # ============================================================
+
 
 class TestGetRootNodes:
     def test_root_nodes(self, navigator):
@@ -150,6 +203,7 @@ class TestGetRootNodes:
 # ============================================================
 # get_children
 # ============================================================
+
 
 class TestGetChildren:
     def test_children_of_root(self, navigator):
@@ -181,6 +235,7 @@ class TestGetChildren:
 # get_parent
 # ============================================================
 
+
 class TestGetParent:
     def test_parent_of_child(self, navigator):
         parent = navigator.get_parent("1.1")
@@ -203,6 +258,7 @@ class TestGetParent:
 # is_leaf
 # ============================================================
 
+
 class TestIsLeaf:
     def test_leaf_node(self, navigator):
         assert navigator.is_leaf("1.1.1") is True
@@ -222,6 +278,7 @@ class TestIsLeaf:
 # ============================================================
 # get_branch_as_str
 # ============================================================
+
 
 class TestGetBranchAsStr:
     def test_branch_with_children(self, navigator):
@@ -255,6 +312,7 @@ class TestGetBranchAsStr:
 # get_taxonomy_preview
 # ============================================================
 
+
 class TestGetTaxonomyPreview:
     def test_preview_depth_1(self, navigator):
         preview = navigator.get_taxonomy_preview(depth=1)
@@ -286,12 +344,15 @@ class TestGetTaxonomyPreview:
         assert "ID:" not in preview
 
     def test_preview_empty(self, empty_navigator):
-        assert empty_navigator.get_taxonomy_preview() == "Taxonomy data is not available."
+        assert (
+            empty_navigator.get_taxonomy_preview() == "Taxonomy data is not available."
+        )
 
 
 # ============================================================
 # get_taxonomy_as_json
 # ============================================================
+
 
 class TestGetTaxonomyAsJson:
     def test_json_output(self, navigator, sample_taxonomy_data):

--- a/tests/unit/argumentation_analysis/analytics/test_effectiveness_analyzer.py
+++ b/tests/unit/argumentation_analysis/analytics/test_effectiveness_analyzer.py
@@ -73,7 +73,9 @@ class TestAnalyzeAgentEffectiveness:
 
     def test_fallback_to_source_name(self):
         """Uses source_name when agent_name is missing."""
-        corpus = [{"source_name": "FallbackAgent", "fallacies": [], "confidence_score": 0.5}]
+        corpus = [
+            {"source_name": "FallbackAgent", "fallacies": [], "confidence_score": 0.5}
+        ]
         result = analyze_agent_effectiveness(corpus)
         assert "FallbackAgent" in result["agents_evaluated"]
 
@@ -135,7 +137,9 @@ class TestAnalyzeAgentEffectiveness:
             }
         ]
         result = analyze_agent_effectiveness(corpus)
-        assert result["fallacy_detection_by_agent"]["BadConf"]["average_confidence"] == 0.0
+        assert (
+            result["fallacy_detection_by_agent"]["BadConf"]["average_confidence"] == 0.0
+        )
 
     def test_multiple_results_same_agent(self):
         """Multiple results for same agent are aggregated."""

--- a/tests/unit/argumentation_analysis/api/test_jtms_models.py
+++ b/tests/unit/argumentation_analysis/api/test_jtms_models.py
@@ -39,8 +39,8 @@ from argumentation_analysis.api.jtms_models import (
     PluginStatusResponse,
 )
 
-
 # ── BeliefInfo ──
+
 
 class TestBeliefInfo:
     def test_required_fields(self):
@@ -56,8 +56,11 @@ class TestBeliefInfo:
 
     def test_all_fields(self):
         b = BeliefInfo(
-            name="B", valid=True, non_monotonic=True,
-            justifications_count=3, implications_count=2,
+            name="B",
+            valid=True,
+            non_monotonic=True,
+            justifications_count=3,
+            implications_count=2,
         )
         assert b.valid is True
         assert b.non_monotonic is True
@@ -70,6 +73,7 @@ class TestBeliefInfo:
 
 # ── JustificationInfo ──
 
+
 class TestJustificationInfo:
     def test_required_conclusion(self):
         j = JustificationInfo(conclusion="C")
@@ -80,14 +84,17 @@ class TestJustificationInfo:
 
     def test_all_fields(self):
         j = JustificationInfo(
-            in_beliefs=["A", "B"], out_beliefs=["D"],
-            conclusion="C", is_valid=True,
+            in_beliefs=["A", "B"],
+            out_beliefs=["D"],
+            conclusion="C",
+            is_valid=True,
         )
         assert len(j.in_beliefs) == 2
         assert j.is_valid is True
 
 
 # ── CreateBeliefRequest ──
+
 
 class TestCreateBeliefRequest:
     def test_required_name(self):
@@ -103,8 +110,11 @@ class TestCreateBeliefRequest:
 
     def test_custom(self):
         r = CreateBeliefRequest(
-            belief_name="Y", initial_value="true",
-            session_id="s1", instance_id="i1", agent_id="agent1",
+            belief_name="Y",
+            initial_value="true",
+            session_id="s1",
+            instance_id="i1",
+            agent_id="agent1",
         )
         assert r.initial_value == "true"
         assert r.session_id == "s1"
@@ -116,6 +126,7 @@ class TestCreateBeliefRequest:
 
 # ── AddJustificationRequest ──
 
+
 class TestAddJustificationRequest:
     def test_minimal(self):
         r = AddJustificationRequest(conclusion="C")
@@ -125,13 +136,17 @@ class TestAddJustificationRequest:
 
     def test_full(self):
         r = AddJustificationRequest(
-            in_beliefs=["A"], out_beliefs=["B"], conclusion="C",
-            session_id="s1", agent_id="ag",
+            in_beliefs=["A"],
+            out_beliefs=["B"],
+            conclusion="C",
+            session_id="s1",
+            agent_id="ag",
         )
         assert r.in_beliefs == ["A"]
 
 
 # ── SetBeliefValidityRequest ──
+
 
 class TestSetBeliefValidityRequest:
     def test_required(self):
@@ -146,6 +161,7 @@ class TestSetBeliefValidityRequest:
 
 # ── QueryBeliefsRequest ──
 
+
 class TestQueryBeliefsRequest:
     def test_defaults(self):
         r = QueryBeliefsRequest()
@@ -155,6 +171,7 @@ class TestQueryBeliefsRequest:
 
 # ── ExplainBeliefRequest ──
 
+
 class TestExplainBeliefRequest:
     def test_required(self):
         r = ExplainBeliefRequest(belief_name="X")
@@ -162,6 +179,7 @@ class TestExplainBeliefRequest:
 
 
 # ── GetJTMSStateRequest ──
+
 
 class TestGetJTMSStateRequest:
     def test_defaults(self):
@@ -171,6 +189,7 @@ class TestGetJTMSStateRequest:
 
 
 # ── Session Requests ──
+
 
 class TestSessionRequests:
     def test_create_session(self):
@@ -189,19 +208,20 @@ class TestSessionRequests:
         assert r.checkpoint_id == "c1"
 
     def test_update_metadata(self):
-        r = UpdateSessionMetadataRequest(
-            session_id="s1", metadata={"key": "value"}
-        )
+        r = UpdateSessionMetadataRequest(session_id="s1", metadata={"key": "value"})
         assert r.metadata["key"] == "value"
 
 
 # ── JTMSResponse ──
 
+
 class TestJTMSResponse:
     def test_base_response(self):
         r = JTMSResponse(
-            status="success", operation="create_belief",
-            agent_id="a1", timestamp="2026-01-01",
+            status="success",
+            operation="create_belief",
+            agent_id="a1",
+            timestamp="2026-01-01",
         )
         assert r.status == "success"
         assert r.session_id is None
@@ -209,25 +229,34 @@ class TestJTMSResponse:
     def test_create_belief_response(self):
         belief = BeliefInfo(name="A", valid=True)
         r = CreateBeliefResponse(
-            status="success", operation="create_belief",
-            agent_id="a1", timestamp="2026-01-01", belief=belief,
+            status="success",
+            operation="create_belief",
+            agent_id="a1",
+            timestamp="2026-01-01",
+            belief=belief,
         )
         assert r.belief.name == "A"
 
     def test_add_justification_response(self):
         j = JustificationInfo(conclusion="C")
         r = AddJustificationResponse(
-            status="success", operation="add_justification",
-            agent_id="a1", timestamp="2026-01-01",
-            justification=j, conclusion_status=True,
+            status="success",
+            operation="add_justification",
+            agent_id="a1",
+            timestamp="2026-01-01",
+            justification=j,
+            conclusion_status=True,
         )
         assert r.conclusion_status is True
 
     def test_explain_belief_response(self):
         r = ExplainBeliefResponse(
-            status="success", operation="explain",
-            agent_id="a1", timestamp="2026-01-01",
-            belief_name="X", current_status=True,
+            status="success",
+            operation="explain",
+            agent_id="a1",
+            timestamp="2026-01-01",
+            belief_name="X",
+            current_status=True,
             explanation_text="Supported by A",
         )
         assert r.belief_name == "X"
@@ -235,9 +264,12 @@ class TestJTMSResponse:
 
     def test_query_beliefs_response(self):
         r = QueryBeliefsResponse(
-            status="success", operation="query",
-            agent_id="a1", timestamp="2026-01-01",
-            total_beliefs=5, filtered_count=3,
+            status="success",
+            operation="query",
+            agent_id="a1",
+            timestamp="2026-01-01",
+            total_beliefs=5,
+            filtered_count=3,
             beliefs=[BeliefInfo(name="A"), BeliefInfo(name="B")],
         )
         assert r.total_beliefs == 5
@@ -245,6 +277,7 @@ class TestJTMSResponse:
 
 
 # ── JTMSStatistics ──
+
 
 class TestJTMSStatistics:
     def test_defaults(self):
@@ -256,8 +289,11 @@ class TestJTMSStatistics:
 
     def test_custom(self):
         s = JTMSStatistics(
-            total_beliefs=10, valid_beliefs=5, invalid_beliefs=2,
-            unknown_beliefs=3, non_monotonic_beliefs=1,
+            total_beliefs=10,
+            valid_beliefs=5,
+            invalid_beliefs=2,
+            unknown_beliefs=3,
+            non_monotonic_beliefs=1,
             total_justifications=7,
         )
         assert s.total_beliefs == 10
@@ -266,11 +302,15 @@ class TestJTMSStatistics:
 
 # ── SessionInfo ──
 
+
 class TestSessionInfo:
     def test_all_fields(self):
         s = SessionInfo(
-            session_id="s1", agent_id="a1", session_name="Test Session",
-            created_at="2026-01-01", last_accessed="2026-01-02",
+            session_id="s1",
+            agent_id="a1",
+            session_name="Test Session",
+            created_at="2026-01-01",
+            last_accessed="2026-01-02",
             checkpoint_count=3,
         )
         assert s.session_id == "s1"
@@ -279,11 +319,14 @@ class TestSessionInfo:
 
 # ── GetJTMSStateResponse ──
 
+
 class TestGetJTMSStateResponse:
     def test_minimal(self):
         r = GetJTMSStateResponse(
-            status="success", operation="get_state",
-            agent_id="a1", timestamp="2026-01-01",
+            status="success",
+            operation="get_state",
+            agent_id="a1",
+            timestamp="2026-01-01",
         )
         assert r.beliefs == {}
         assert r.justifications_graph is None
@@ -292,8 +335,10 @@ class TestGetJTMSStateResponse:
     def test_with_stats(self):
         stats = JTMSStatistics(total_beliefs=5)
         r = GetJTMSStateResponse(
-            status="success", operation="get_state",
-            agent_id="a1", timestamp="2026-01-01",
+            status="success",
+            operation="get_state",
+            agent_id="a1",
+            timestamp="2026-01-01",
             statistics=stats,
         )
         assert r.statistics.total_beliefs == 5
@@ -301,12 +346,17 @@ class TestGetJTMSStateResponse:
 
 # ── SetBeliefValidityResponse ──
 
+
 class TestSetBeliefValidityResponse:
     def test_all_fields(self):
         r = SetBeliefValidityResponse(
-            status="success", operation="set_validity",
-            agent_id="a1", timestamp="2026-01-01",
-            belief_name="A", old_value=None, new_value=True,
+            status="success",
+            operation="set_validity",
+            agent_id="a1",
+            timestamp="2026-01-01",
+            belief_name="A",
+            old_value=None,
+            new_value=True,
             propagation_occurred=True,
         )
         assert r.belief_name == "A"
@@ -316,11 +366,14 @@ class TestSetBeliefValidityResponse:
 
 # ── Session Responses ──
 
+
 class TestSessionResponses:
     def test_create_session_response(self):
         r = CreateSessionResponse(
-            session_id="s1", agent_id="a1",
-            session_name="Test", created_at="2026-01-01",
+            session_id="s1",
+            agent_id="a1",
+            session_name="Test",
+            created_at="2026-01-01",
         )
         assert r.status == "success"
 
@@ -331,22 +384,27 @@ class TestSessionResponses:
 
     def test_checkpoint_info(self):
         c = CheckpointInfo(
-            checkpoint_id="c1", session_id="s1",
-            created_at="2026-01-01", description="Before change",
+            checkpoint_id="c1",
+            session_id="s1",
+            created_at="2026-01-01",
+            description="Before change",
         )
         assert c.auto_generated is False
         assert c.session_version == 1
 
     def test_create_checkpoint_response(self):
         r = CreateCheckpointResponse(
-            checkpoint_id="c1", session_id="s1",
-            description="Test", created_at="2026-01-01",
+            checkpoint_id="c1",
+            session_id="s1",
+            description="Test",
+            created_at="2026-01-01",
         )
         assert r.status == "success"
 
     def test_restore_checkpoint_response(self):
         r = RestoreCheckpointResponse(
-            session_id="s1", checkpoint_id="c1",
+            session_id="s1",
+            checkpoint_id="c1",
             restored_at="2026-01-01",
         )
         assert r.instances_restored == 0
@@ -354,10 +412,12 @@ class TestSessionResponses:
 
 # ── JTMSError ──
 
+
 class TestJTMSError:
     def test_required(self):
         e = JTMSError(
-            error_type="validation", error_message="Invalid input",
+            error_type="validation",
+            error_message="Invalid input",
             timestamp="2026-01-01",
         )
         assert e.error_type == "validation"
@@ -365,15 +425,18 @@ class TestJTMSError:
 
     def test_with_details(self):
         e = JTMSError(
-            error_type="not_found", error_message="Belief not found",
+            error_type="not_found",
+            error_message="Belief not found",
             error_details={"belief_name": "X"},
-            operation="explain", session_id="s1",
+            operation="explain",
+            session_id="s1",
             timestamp="2026-01-01",
         )
         assert e.error_details["belief_name"] == "X"
 
 
 # ── Import/Export ──
+
 
 class TestImportExport:
     def test_export_request_defaults(self):
@@ -383,27 +446,34 @@ class TestImportExport:
 
     def test_import_request(self):
         r = ImportJTMSRequest(
-            session_id="s1", state_data='{"beliefs": []}',
+            session_id="s1",
+            state_data='{"beliefs": []}',
         )
         assert r.format == "json"
 
     def test_export_response(self):
         r = ExportJTMSResponse(
-            instance_id="i1", format="json",
-            exported_data='{}', export_timestamp="2026-01-01",
+            instance_id="i1",
+            format="json",
+            exported_data="{}",
+            export_timestamp="2026-01-01",
         )
         assert r.status == "success"
 
     def test_import_response(self):
         r = ImportJTMSResponse(
-            session_id="s1", new_instance_id="i2",
-            format="json", beliefs_imported=5,
-            justifications_imported=3, import_timestamp="2026-01-01",
+            session_id="s1",
+            new_instance_id="i2",
+            format="json",
+            beliefs_imported=5,
+            justifications_imported=3,
+            import_timestamp="2026-01-01",
         )
         assert r.beliefs_imported == 5
 
 
 # ── PluginStatusResponse ──
+
 
 class TestPluginStatusResponse:
     def test_all_fields(self):
@@ -411,7 +481,13 @@ class TestPluginStatusResponse:
             plugin_name="JTMSPlugin",
             semantic_kernel_available=True,
             functions_count=5,
-            functions=["create_belief", "add_justification", "query", "explain", "export"],
+            functions=[
+                "create_belief",
+                "add_justification",
+                "query",
+                "explain",
+                "export",
+            ],
             jtms_service_active=True,
             session_manager_active=True,
         )
@@ -422,6 +498,7 @@ class TestPluginStatusResponse:
 
 # ── Serialization ──
 
+
 class TestSerialization:
     def test_belief_info_dict(self):
         b = BeliefInfo(name="A", valid=True)
@@ -431,8 +508,10 @@ class TestSerialization:
 
     def test_response_json(self):
         r = JTMSResponse(
-            status="success", operation="test",
-            agent_id="a1", timestamp="2026-01-01",
+            status="success",
+            operation="test",
+            agent_id="a1",
+            timestamp="2026-01-01",
         )
         j = r.model_dump_json()
         assert "success" in j

--- a/tests/unit/argumentation_analysis/config/test_settings.py
+++ b/tests/unit/argumentation_analysis/config/test_settings.py
@@ -22,10 +22,10 @@ from argumentation_analysis.config.settings import (
     settings,
 )
 
-
 # ============================================================
 # Module-level singleton
 # ============================================================
+
 
 class TestModuleSingleton:
     def test_settings_is_app_settings_instance(self):
@@ -45,6 +45,7 @@ class TestModuleSingleton:
 # ============================================================
 # OpenAISettings
 # ============================================================
+
 
 class TestOpenAISettings:
     def test_default_chat_model(self):
@@ -73,6 +74,7 @@ class TestOpenAISettings:
 # AzureOpenAISettings
 # ============================================================
 
+
 class TestAzureOpenAISettings:
     def test_api_key_optional(self):
         s = AzureOpenAISettings()
@@ -96,6 +98,7 @@ class TestAzureOpenAISettings:
 # TikaSettings
 # ============================================================
 
+
 class TestTikaSettings:
     def test_timeout_is_int(self):
         s = TikaSettings()
@@ -113,6 +116,7 @@ class TestTikaSettings:
 # JinaSettings
 # ============================================================
 
+
 class TestJinaSettings:
     def test_reader_prefix_default(self):
         s = JinaSettings()
@@ -122,6 +126,7 @@ class TestJinaSettings:
 # ============================================================
 # NetworkSettings
 # ============================================================
+
 
 class TestNetworkSettings:
     def test_breaker_defaults(self):
@@ -145,6 +150,7 @@ class TestNetworkSettings:
 # UISettings
 # ============================================================
 
+
 class TestUISettings:
     def test_temp_download_dir_default(self):
         s = UISettings()
@@ -165,6 +171,7 @@ class TestUISettings:
 # ============================================================
 # ServiceManagerSettings
 # ============================================================
+
 
 class TestServiceManagerSettings:
     def test_defaults(self):
@@ -203,6 +210,7 @@ class TestServiceManagerSettings:
 # JVMSettings
 # ============================================================
 
+
 class TestJVMSettings:
     def test_java_version_defaults(self):
         s = JVMSettings()
@@ -229,6 +237,7 @@ class TestJVMSettings:
 # ============================================================
 # AppSettings — structure and defaults
 # ============================================================
+
 
 class TestAppSettings:
     def test_debug_mode_default(self):

--- a/tests/unit/argumentation_analysis/core/communication/test_adapters.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_adapters.py
@@ -15,8 +15,8 @@ from argumentation_analysis.core.communication.message import (
 from argumentation_analysis.core.communication.channel_interface import ChannelType
 from argumentation_analysis.paths import DATA_DIR
 
-
 # ── Fixtures ────────────────────────────────────────────────────────────
+
 
 @pytest.fixture
 def mock_middleware():
@@ -86,6 +86,7 @@ def make_task_result_message(sender="operational_01"):
 # ══════════════════════════════════════════════════════════════════════════
 # StrategicAdapter Tests
 # ══════════════════════════════════════════════════════════════════════════
+
 
 class TestStrategicAdapterInit:
     """Tests for StrategicAdapter.__init__."""
@@ -184,11 +185,13 @@ class TestReceiveReport:
             recipient="strategic_01",
         )
         call_count = [0]
+
         def receive_side_effect(**kwargs):
             call_count[0] += 1
             if call_count[0] == 1:
                 return non_report
             return None
+
         mock_middleware.receive_message.side_effect = receive_side_effect
         result = strategic.receive_report(timeout=0.2)
         assert result is None
@@ -205,11 +208,13 @@ class TestReceiveReport:
     def test_filter_criteria_no_match(self, strategic, mock_middleware):
         report = make_report_message()
         call_count = [0]
+
         def receive_side_effect(**kwargs):
             call_count[0] += 1
             if call_count[0] == 1:
                 return report
             return None
+
         mock_middleware.receive_message.side_effect = receive_side_effect
         result = strategic.receive_report(
             timeout=0.2,
@@ -287,6 +292,7 @@ class TestCollaborateWithStrategic:
 # ══════════════════════════════════════════════════════════════════════════
 # TacticalAdapter Tests
 # ══════════════════════════════════════════════════════════════════════════
+
 
 class TestTacticalAdapterInit:
     """Tests for TacticalAdapter.__init__."""
@@ -383,7 +389,9 @@ class TestAssignTask:
         mock_middleware.send_message.assert_called_once()
 
     def test_message_content(self, tactical, mock_middleware):
-        tactical.assign_task("detect", {"t": "x"}, "op_01", constraints={"max_time": 30})
+        tactical.assign_task(
+            "detect", {"t": "x"}, "op_01", constraints={"max_time": 30}
+        )
         sent = mock_middleware.send_message.call_args[0][0]
         assert sent.content["command_type"] == "detect"
         assert sent.content["constraints"] == {"max_time": 30}
@@ -437,11 +445,13 @@ class TestReceiveTaskResult:
             recipient="tactical_01",
         )
         call_count = [0]
+
         def receive_side_effect(**kwargs):
             call_count[0] += 1
             if call_count[0] == 1:
                 return wrong
             return None
+
         mock_middleware.receive_message.side_effect = receive_side_effect
         result = tactical.receive_task_result(timeout=0.2)
         assert result is None

--- a/tests/unit/argumentation_analysis/core/communication/test_channel_interface.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_channel_interface.py
@@ -43,6 +43,7 @@ def _make_msg(
 
 # ── ChannelType ──
 
+
 class TestChannelType:
     def test_all_values(self):
         assert ChannelType.HIERARCHICAL.value == "hierarchical"
@@ -58,6 +59,7 @@ class TestChannelType:
 
 
 # ── Exception hierarchy ──
+
 
 class TestExceptions:
     def test_channel_exception_is_exception(self):
@@ -85,6 +87,7 @@ class TestExceptions:
 
 # ── matches_filter ──
 
+
 class TestMatchesFilter:
     @pytest.fixture
     def channel(self):
@@ -108,11 +111,15 @@ class TestMatchesFilter:
 
     def test_message_type_list_match(self, channel):
         msg = _make_msg(msg_type=MessageType.EVENT)
-        assert channel.matches_filter(msg, {"message_type": ["command", "event"]}) is True
+        assert (
+            channel.matches_filter(msg, {"message_type": ["command", "event"]}) is True
+        )
 
     def test_message_type_list_no_match(self, channel):
         msg = _make_msg(msg_type=MessageType.RESPONSE)
-        assert channel.matches_filter(msg, {"message_type": ["command", "event"]}) is False
+        assert (
+            channel.matches_filter(msg, {"message_type": ["command", "event"]}) is False
+        )
 
     def test_sender_single_match(self, channel):
         msg = _make_msg(sender="sherlock")
@@ -152,7 +159,10 @@ class TestMatchesFilter:
 
     def test_sender_level_list_match(self, channel):
         msg = _make_msg(sender_level=AgentLevel.TACTICAL)
-        assert channel.matches_filter(msg, {"sender_level": ["tactical", "strategic"]}) is True
+        assert (
+            channel.matches_filter(msg, {"sender_level": ["tactical", "strategic"]})
+            is True
+        )
 
     def test_content_filter_match(self, channel):
         msg = _make_msg(content={"info_type": "result", "value": 42})
@@ -160,11 +170,15 @@ class TestMatchesFilter:
 
     def test_content_filter_no_match(self, channel):
         msg = _make_msg(content={"info_type": "status"})
-        assert channel.matches_filter(msg, {"content": {"info_type": "result"}}) is False
+        assert (
+            channel.matches_filter(msg, {"content": {"info_type": "result"}}) is False
+        )
 
     def test_content_filter_missing_key(self, channel):
         msg = _make_msg(content={"other": "val"})
-        assert channel.matches_filter(msg, {"content": {"info_type": "result"}}) is False
+        assert (
+            channel.matches_filter(msg, {"content": {"info_type": "result"}}) is False
+        )
 
     def test_multiple_criteria_all_match(self, channel):
         msg = _make_msg(
@@ -186,6 +200,7 @@ class TestMatchesFilter:
 
 
 # ── LocalChannel ──
+
 
 class TestLocalChannel:
     @pytest.fixture

--- a/tests/unit/argumentation_analysis/core/communication/test_collaboration_channel.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_collaboration_channel.py
@@ -39,6 +39,7 @@ def _make_msg(
 
 # ── CollaborationGroup ──
 
+
 class TestCollaborationGroup:
     def test_init_defaults(self):
         g = CollaborationGroup("g1")
@@ -98,7 +99,9 @@ class TestCollaborationGroup:
         assert g.get_member_count() == 3
 
     def test_get_group_info(self):
-        g = CollaborationGroup("g1", name="Team", description="Test group", members=["a"])
+        g = CollaborationGroup(
+            "g1", name="Team", description="Test group", members=["a"]
+        )
         g.add_message(_make_msg())
         info = g.get_group_info()
         assert info["id"] == "g1"
@@ -110,6 +113,7 @@ class TestCollaborationGroup:
 
 
 # ── CollaborationChannel Init ──
+
 
 class TestCollaborationChannelInit:
     def test_channel_type(self):
@@ -132,6 +136,7 @@ class TestCollaborationChannelInit:
 
 
 # ── Direct messages ──
+
 
 class TestDirectMessages:
     @pytest.fixture
@@ -181,6 +186,7 @@ class TestDirectMessages:
 
 
 # ── Group operations ──
+
 
 class TestGroupOperations:
     @pytest.fixture
@@ -265,6 +271,7 @@ class TestGroupOperations:
 
 # ── Group messaging ──
 
+
 class TestGroupMessaging:
     @pytest.fixture
     def ch(self):
@@ -308,6 +315,7 @@ class TestGroupMessaging:
 
 # ── Subscribe / Unsubscribe ──
 
+
 class TestSubscription:
     @pytest.fixture
     def ch(self):
@@ -339,6 +347,7 @@ class TestSubscription:
 
 
 # ── get_channel_info ──
+
 
 class TestGetChannelInfo:
     def test_channel_info(self):

--- a/tests/unit/argumentation_analysis/core/communication/test_data_channel.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_data_channel.py
@@ -39,6 +39,7 @@ def _make_msg(
 
 # ── DataStore ──
 
+
 class TestDataStoreInit:
     def test_init(self):
         ds = DataStore("store1")
@@ -170,6 +171,7 @@ class TestDataStoreOperations:
 
 # ── DataChannel ──
 
+
 class TestDataChannelInit:
     def test_channel_type(self):
         ch = DataChannel("d1")
@@ -190,7 +192,9 @@ class TestDataChannelInit:
         assert ch.max_inline_data_size == 10240
 
     def test_custom_config(self):
-        ch = DataChannel("d1", config={"compression_threshold": 512, "max_inline_data_size": 4096})
+        ch = DataChannel(
+            "d1", config={"compression_threshold": 512, "max_inline_data_size": 4096}
+        )
         assert ch.compression_threshold == 512
         assert ch.max_inline_data_size == 4096
 

--- a/tests/unit/argumentation_analysis/core/communication/test_hierarchical_channel.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_hierarchical_channel.py
@@ -36,6 +36,7 @@ def _make_msg(
 
 # ── Init ──
 
+
 class TestInit:
     def test_channel_type(self):
         ch = HierarchicalChannel("h1")
@@ -57,6 +58,7 @@ class TestInit:
 
 
 # ── send_message ──
+
 
 class TestSendMessage:
     @pytest.fixture
@@ -95,36 +97,29 @@ class TestSendMessage:
 
 # ── Direction tracking ──
 
+
 class TestDirectionStats:
     @pytest.fixture
     def ch(self):
         return HierarchicalChannel("h1")
 
     def test_strategic_to_tactical(self, ch):
-        msg = _make_msg(
-            sender_level=AgentLevel.STRATEGIC, recipient="tactical_agent"
-        )
+        msg = _make_msg(sender_level=AgentLevel.STRATEGIC, recipient="tactical_agent")
         ch.send_message(msg)
         assert ch.stats["by_direction"]["strategic_to_tactical"] == 1
 
     def test_tactical_to_strategic(self, ch):
-        msg = _make_msg(
-            sender_level=AgentLevel.TACTICAL, recipient="strategic_agent"
-        )
+        msg = _make_msg(sender_level=AgentLevel.TACTICAL, recipient="strategic_agent")
         ch.send_message(msg)
         assert ch.stats["by_direction"]["tactical_to_strategic"] == 1
 
     def test_tactical_to_operational(self, ch):
-        msg = _make_msg(
-            sender_level=AgentLevel.TACTICAL, recipient="operational_agent"
-        )
+        msg = _make_msg(sender_level=AgentLevel.TACTICAL, recipient="operational_agent")
         ch.send_message(msg)
         assert ch.stats["by_direction"]["tactical_to_operational"] == 1
 
     def test_operational_to_tactical(self, ch):
-        msg = _make_msg(
-            sender_level=AgentLevel.OPERATIONAL, recipient="tactical_agent"
-        )
+        msg = _make_msg(sender_level=AgentLevel.OPERATIONAL, recipient="tactical_agent")
         ch.send_message(msg)
         assert ch.stats["by_direction"]["operational_to_tactical"] == 1
 
@@ -137,6 +132,7 @@ class TestDirectionStats:
 
 
 # ── receive_message ──
+
 
 class TestReceiveMessage:
     @pytest.fixture
@@ -177,6 +173,7 @@ class TestReceiveMessage:
 
 
 # ── subscribe / unsubscribe ──
+
 
 class TestSubscribe:
     @pytest.fixture
@@ -231,6 +228,7 @@ class TestSubscribe:
 
 # ── get_pending_messages ──
 
+
 class TestGetPendingMessages:
     @pytest.fixture
     def ch(self):
@@ -262,6 +260,7 @@ class TestGetPendingMessages:
 
 # ── clear_queue ──
 
+
 class TestClearQueue:
     @pytest.fixture
     def ch(self):
@@ -284,6 +283,7 @@ class TestClearQueue:
 
 
 # ── get_channel_info ──
+
 
 class TestGetChannelInfo:
     def test_channel_info(self):

--- a/tests/unit/argumentation_analysis/core/communication/test_message.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_message.py
@@ -15,8 +15,8 @@ from argumentation_analysis.core.communication.message import (
     EventMessage,
 )
 
-
 # ── Enums ──
+
 
 class TestMessageType:
     def test_all_values(self):
@@ -56,6 +56,7 @@ class TestAgentLevel:
 
 
 # ── Message ──
+
 
 class TestMessage:
     @pytest.fixture
@@ -136,26 +137,66 @@ class TestMessage:
 
     def test_eq_different_id(self):
         ts = datetime(2026, 1, 1)
-        m1 = Message(MessageType.COMMAND, "a", AgentLevel.SYSTEM, {}, message_id="id1", timestamp=ts)
-        m2 = Message(MessageType.COMMAND, "a", AgentLevel.SYSTEM, {}, message_id="id2", timestamp=ts)
+        m1 = Message(
+            MessageType.COMMAND,
+            "a",
+            AgentLevel.SYSTEM,
+            {},
+            message_id="id1",
+            timestamp=ts,
+        )
+        m2 = Message(
+            MessageType.COMMAND,
+            "a",
+            AgentLevel.SYSTEM,
+            {},
+            message_id="id2",
+            timestamp=ts,
+        )
         assert m1 != m2
 
     # -- Ordering --
     def test_lt_higher_priority_first(self):
         ts = datetime(2026, 1, 1)
-        m_high = Message(MessageType.COMMAND, "a", AgentLevel.SYSTEM, {},
-                         priority=MessagePriority.HIGH, message_id="h", timestamp=ts)
-        m_low = Message(MessageType.COMMAND, "a", AgentLevel.SYSTEM, {},
-                        priority=MessagePriority.LOW, message_id="l", timestamp=ts)
+        m_high = Message(
+            MessageType.COMMAND,
+            "a",
+            AgentLevel.SYSTEM,
+            {},
+            priority=MessagePriority.HIGH,
+            message_id="h",
+            timestamp=ts,
+        )
+        m_low = Message(
+            MessageType.COMMAND,
+            "a",
+            AgentLevel.SYSTEM,
+            {},
+            priority=MessagePriority.LOW,
+            message_id="l",
+            timestamp=ts,
+        )
         assert m_high < m_low  # Higher priority is "less" (comes first)
 
     def test_lt_same_priority_older_first(self):
-        m_old = Message(MessageType.COMMAND, "a", AgentLevel.SYSTEM, {},
-                        priority=MessagePriority.NORMAL, message_id="o",
-                        timestamp=datetime(2026, 1, 1))
-        m_new = Message(MessageType.COMMAND, "a", AgentLevel.SYSTEM, {},
-                        priority=MessagePriority.NORMAL, message_id="n",
-                        timestamp=datetime(2026, 1, 2))
+        m_old = Message(
+            MessageType.COMMAND,
+            "a",
+            AgentLevel.SYSTEM,
+            {},
+            priority=MessagePriority.NORMAL,
+            message_id="o",
+            timestamp=datetime(2026, 1, 1),
+        )
+        m_new = Message(
+            MessageType.COMMAND,
+            "a",
+            AgentLevel.SYSTEM,
+            {},
+            priority=MessagePriority.NORMAL,
+            message_id="n",
+            timestamp=datetime(2026, 1, 2),
+        )
         assert m_old < m_new  # Older timestamp comes first
 
     def test_lt_not_message(self, basic_msg):
@@ -185,21 +226,30 @@ class TestMessage:
     # -- is_response_to --
     def test_is_response_to_true(self):
         msg = Message(
-            MessageType.RESPONSE, "b", AgentLevel.OPERATIONAL, {},
+            MessageType.RESPONSE,
+            "b",
+            AgentLevel.OPERATIONAL,
+            {},
             metadata={"reply_to": "req-123"},
         )
         assert msg.is_response_to("req-123") is True
 
     def test_is_response_to_wrong_id(self):
         msg = Message(
-            MessageType.RESPONSE, "b", AgentLevel.OPERATIONAL, {},
+            MessageType.RESPONSE,
+            "b",
+            AgentLevel.OPERATIONAL,
+            {},
             metadata={"reply_to": "req-123"},
         )
         assert msg.is_response_to("req-456") is False
 
     def test_is_response_to_not_response_type(self):
         msg = Message(
-            MessageType.COMMAND, "b", AgentLevel.OPERATIONAL, {},
+            MessageType.COMMAND,
+            "b",
+            AgentLevel.OPERATIONAL,
+            {},
             metadata={"reply_to": "req-123"},
         )
         assert msg.is_response_to("req-123") is False
@@ -207,7 +257,10 @@ class TestMessage:
     # -- requires_acknowledgement --
     def test_requires_ack_true(self):
         msg = Message(
-            MessageType.COMMAND, "a", AgentLevel.STRATEGIC, {},
+            MessageType.COMMAND,
+            "a",
+            AgentLevel.STRATEGIC,
+            {},
             metadata={"requires_ack": True},
         )
         assert msg.requires_acknowledgement() is True
@@ -249,6 +302,7 @@ class TestMessage:
 
 
 # ── CommandMessage ──
+
 
 class TestCommandMessage:
     def test_basic(self):
@@ -299,6 +353,7 @@ class TestCommandMessage:
 
 # ── InformationMessage ──
 
+
 class TestInformationMessage:
     def test_basic(self):
         msg = InformationMessage(
@@ -332,6 +387,7 @@ class TestInformationMessage:
 
 
 # ── RequestMessage ──
+
 
 class TestRequestMessage:
     def test_basic(self):
@@ -386,6 +442,7 @@ class TestRequestMessage:
 
 # ── EventMessage ──
 
+
 class TestEventMessage:
     def test_basic(self):
         msg = EventMessage(
@@ -424,16 +481,38 @@ class TestEventMessage:
 
 # ── Message sorting ──
 
+
 class TestMessageSorting:
     def test_sort_by_priority(self):
         ts = datetime(2026, 1, 1)
         msgs = [
-            Message(MessageType.COMMAND, "a", AgentLevel.SYSTEM, {},
-                    priority=MessagePriority.LOW, message_id="low", timestamp=ts),
-            Message(MessageType.COMMAND, "a", AgentLevel.SYSTEM, {},
-                    priority=MessagePriority.CRITICAL, message_id="crit", timestamp=ts),
-            Message(MessageType.COMMAND, "a", AgentLevel.SYSTEM, {},
-                    priority=MessagePriority.NORMAL, message_id="norm", timestamp=ts),
+            Message(
+                MessageType.COMMAND,
+                "a",
+                AgentLevel.SYSTEM,
+                {},
+                priority=MessagePriority.LOW,
+                message_id="low",
+                timestamp=ts,
+            ),
+            Message(
+                MessageType.COMMAND,
+                "a",
+                AgentLevel.SYSTEM,
+                {},
+                priority=MessagePriority.CRITICAL,
+                message_id="crit",
+                timestamp=ts,
+            ),
+            Message(
+                MessageType.COMMAND,
+                "a",
+                AgentLevel.SYSTEM,
+                {},
+                priority=MessagePriority.NORMAL,
+                message_id="norm",
+                timestamp=ts,
+            ),
         ]
         sorted_msgs = sorted(msgs)
         assert sorted_msgs[0].id == "crit"
@@ -442,12 +521,24 @@ class TestMessageSorting:
 
     def test_sort_same_priority_by_timestamp(self):
         msgs = [
-            Message(MessageType.COMMAND, "a", AgentLevel.SYSTEM, {},
-                    priority=MessagePriority.NORMAL, message_id="new",
-                    timestamp=datetime(2026, 1, 2)),
-            Message(MessageType.COMMAND, "a", AgentLevel.SYSTEM, {},
-                    priority=MessagePriority.NORMAL, message_id="old",
-                    timestamp=datetime(2026, 1, 1)),
+            Message(
+                MessageType.COMMAND,
+                "a",
+                AgentLevel.SYSTEM,
+                {},
+                priority=MessagePriority.NORMAL,
+                message_id="new",
+                timestamp=datetime(2026, 1, 2),
+            ),
+            Message(
+                MessageType.COMMAND,
+                "a",
+                AgentLevel.SYSTEM,
+                {},
+                priority=MessagePriority.NORMAL,
+                message_id="old",
+                timestamp=datetime(2026, 1, 1),
+            ),
         ]
         sorted_msgs = sorted(msgs)
         assert sorted_msgs[0].id == "old"

--- a/tests/unit/argumentation_analysis/core/communication/test_middleware.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_middleware.py
@@ -43,6 +43,7 @@ def middleware():
 
 # ── Init ──
 
+
 class TestInit:
     def test_default_config(self, middleware):
         assert middleware.config == {}
@@ -65,6 +66,7 @@ class TestInit:
 
 
 # ── Channel registration ──
+
 
 class TestChannelRegistration:
     def test_register_channel(self, middleware):
@@ -91,6 +93,7 @@ class TestChannelRegistration:
 
 # ── Handler registration ──
 
+
 class TestHandlerRegistration:
     def test_register_message_handler(self, middleware):
         handler = MagicMock()
@@ -110,6 +113,7 @@ class TestHandlerRegistration:
 
 
 # ── determine_channel ──
+
 
 class TestDetermineChannel:
     def test_explicit_channel(self, middleware):
@@ -177,6 +181,7 @@ class TestDetermineChannel:
 
 # ── send_message ──
 
+
 class TestSendMessage:
     def test_send_success(self, middleware):
         channel = MagicMock()
@@ -227,6 +232,7 @@ class TestSendMessage:
 
 # ── get_statistics ──
 
+
 class TestGetStatistics:
     def test_returns_copy(self, middleware):
         stats = middleware.get_statistics()
@@ -235,6 +241,7 @@ class TestGetStatistics:
 
 
 # ── get_channel_info ──
+
 
 class TestGetChannelInfo:
     def test_existing_channel(self, middleware):
@@ -251,6 +258,7 @@ class TestGetChannelInfo:
 
 
 # ── _handle_message ──
+
 
 class TestHandleMessage:
     def test_calls_type_handler(self, middleware):
@@ -292,6 +300,7 @@ class TestHandleMessage:
 
 
 # ── shutdown ──
+
 
 class TestShutdown:
     def test_shutdown_with_protocols(self, middleware):

--- a/tests/unit/argumentation_analysis/core/communication/test_pub_sub.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_pub_sub.py
@@ -38,6 +38,7 @@ def _make_msg(
 
 # ── Topic ──
 
+
 class TestTopicInit:
     def test_defaults(self):
         t = Topic("t1")
@@ -119,13 +120,17 @@ class TestTopicPublish:
 
     def test_publish_with_filter_match(self, topic):
         cb = MagicMock()
-        topic.add_subscriber("agent_1", callback=cb, filter_criteria={"sender": "agent_1"})
+        topic.add_subscriber(
+            "agent_1", callback=cb, filter_criteria={"sender": "agent_1"}
+        )
         topic.publish_message(_make_msg(sender="agent_1"))
         cb.assert_called_once()
 
     def test_publish_with_filter_no_match(self, topic):
         cb = MagicMock()
-        topic.add_subscriber("agent_1", callback=cb, filter_criteria={"sender": "other"})
+        topic.add_subscriber(
+            "agent_1", callback=cb, filter_criteria={"sender": "other"}
+        )
         topic.publish_message(_make_msg(sender="agent_1"))
         cb.assert_not_called()
 
@@ -150,49 +155,74 @@ class TestTopicFilter:
         assert topic._matches_filter(_make_msg(), {}) is True
 
     def test_sender_filter_match(self, topic):
-        assert topic._matches_filter(
-            _make_msg(sender="alice"), {"sender": "alice"}
-        ) is True
+        assert (
+            topic._matches_filter(_make_msg(sender="alice"), {"sender": "alice"})
+            is True
+        )
 
     def test_sender_filter_no_match(self, topic):
-        assert topic._matches_filter(
-            _make_msg(sender="alice"), {"sender": "bob"}
-        ) is False
+        assert (
+            topic._matches_filter(_make_msg(sender="alice"), {"sender": "bob"}) is False
+        )
 
     def test_sender_filter_list_match(self, topic):
-        assert topic._matches_filter(
-            _make_msg(sender="alice"), {"sender": ["alice", "bob"]}
-        ) is True
+        assert (
+            topic._matches_filter(
+                _make_msg(sender="alice"), {"sender": ["alice", "bob"]}
+            )
+            is True
+        )
 
     def test_sender_filter_list_no_match(self, topic):
-        assert topic._matches_filter(
-            _make_msg(sender="charlie"), {"sender": ["alice", "bob"]}
-        ) is False
+        assert (
+            topic._matches_filter(
+                _make_msg(sender="charlie"), {"sender": ["alice", "bob"]}
+            )
+            is False
+        )
 
     def test_priority_filter_match(self, topic):
-        assert topic._matches_filter(
-            _make_msg(priority=MessagePriority.HIGH), {"priority": "high"}
-        ) is True
+        assert (
+            topic._matches_filter(
+                _make_msg(priority=MessagePriority.HIGH), {"priority": "high"}
+            )
+            is True
+        )
 
     def test_priority_filter_no_match(self, topic):
-        assert topic._matches_filter(
-            _make_msg(priority=MessagePriority.LOW), {"priority": "high"}
-        ) is False
+        assert (
+            topic._matches_filter(
+                _make_msg(priority=MessagePriority.LOW), {"priority": "high"}
+            )
+            is False
+        )
 
     def test_priority_filter_list(self, topic):
-        assert topic._matches_filter(
-            _make_msg(priority=MessagePriority.CRITICAL), {"priority": ["high", "critical"]}
-        ) is True
+        assert (
+            topic._matches_filter(
+                _make_msg(priority=MessagePriority.CRITICAL),
+                {"priority": ["high", "critical"]},
+            )
+            is True
+        )
 
     def test_sender_level_filter_match(self, topic):
-        assert topic._matches_filter(
-            _make_msg(sender_level=AgentLevel.STRATEGIC), {"sender_level": "strategic"}
-        ) is True
+        assert (
+            topic._matches_filter(
+                _make_msg(sender_level=AgentLevel.STRATEGIC),
+                {"sender_level": "strategic"},
+            )
+            is True
+        )
 
     def test_sender_level_filter_no_match(self, topic):
-        assert topic._matches_filter(
-            _make_msg(sender_level=AgentLevel.TACTICAL), {"sender_level": "strategic"}
-        ) is False
+        assert (
+            topic._matches_filter(
+                _make_msg(sender_level=AgentLevel.TACTICAL),
+                {"sender_level": "strategic"},
+            )
+            is False
+        )
 
     def test_content_filter_match(self, topic):
         msg = _make_msg(content={"info_type": "result", "value": 42})
@@ -208,9 +238,10 @@ class TestTopicFilter:
 
     def test_content_filter_list_value(self, topic):
         msg = _make_msg(content={"info_type": "result"})
-        assert topic._matches_filter(
-            msg, {"content": {"info_type": ["result", "status"]}}
-        ) is True
+        assert (
+            topic._matches_filter(msg, {"content": {"info_type": ["result", "status"]}})
+            is True
+        )
 
 
 class TestTopicRecentMessages:
@@ -262,6 +293,7 @@ class TestTopicInfo:
 
 
 # ── PublishSubscribeProtocol ──
+
 
 class TestProtocolInit:
     def test_init(self):
@@ -331,7 +363,9 @@ class TestProtocolPublish:
         mw = MagicMock()
         proto = PublishSubscribeProtocol(mw)
         proto.subscribe("t1", "agent_1")
-        recipients = proto.publish("t1", "sender", AgentLevel.OPERATIONAL, {"data": "test"})
+        recipients = proto.publish(
+            "t1", "sender", AgentLevel.OPERATIONAL, {"data": "test"}
+        )
         assert "agent_1" in recipients
         proto.shutdown()
 

--- a/tests/unit/argumentation_analysis/core/communication/test_request_response.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_request_response.py
@@ -18,8 +18,8 @@ from argumentation_analysis.core.communication.message import (
     AgentLevel,
 )
 
-
 # ── Fixtures ────────────────────────────────────────────────────────────
+
 
 @pytest.fixture
 def mock_middleware():
@@ -52,6 +52,7 @@ def make_response(reply_to, conversation_id=None):
 
 # ── __init__ ────────────────────────────────────────────────────────────
 
+
 class TestRequestResponseInit:
     """Tests for RequestResponseProtocol.__init__."""
 
@@ -79,6 +80,7 @@ class TestRequestResponseInit:
 
 
 # ── handle_response ─────────────────────────────────────────────────────
+
 
 class TestHandleResponse:
     """Tests for handle_response()."""
@@ -160,6 +162,7 @@ class TestHandleResponse:
 
 # ── _handle_timeout ─────────────────────────────────────────────────────
 
+
 class TestHandleTimeout:
     """Tests for _handle_timeout()."""
 
@@ -223,6 +226,7 @@ class TestHandleTimeout:
 
 
 # ── send_request_async_callback ─────────────────────────────────────────
+
 
 class TestSendRequestAsyncCallback:
     """Tests for send_request_async_callback()."""
@@ -314,11 +318,13 @@ class TestSendRequestAsyncCallback:
 
 # ── send_request (synchronous, with fast response) ──────────────────────
 
+
 class TestSendRequest:
     """Tests for send_request() — synchronous version."""
 
     def test_sends_and_receives_response(self, protocol, mock_middleware):
         """Simulate middleware instantly responding."""
+
         def side_effect(msg):
             # Simulate instant response via handle_response
             response = make_response(msg.id)
@@ -351,6 +357,7 @@ class TestSendRequest:
 
     def test_early_response_found(self, protocol, mock_middleware):
         """Pre-store an early response before sending the request."""
+
         # We can't predict the request ID, so test via handle_response flow
         def side_effect(msg):
             response = make_response(msg.id)
@@ -370,6 +377,7 @@ class TestSendRequest:
 
 
 # ── send_request_async ──────────────────────────────────────────────────
+
 
 class TestSendRequestAsync:
     """Tests for send_request_async()."""
@@ -403,6 +411,7 @@ class TestSendRequestAsync:
 
 # ── shutdown ────────────────────────────────────────────────────────────
 
+
 class TestShutdown:
     """Tests for shutdown()."""
 
@@ -422,8 +431,14 @@ class TestShutdown:
         assert protocol.pending_requests == {}
 
     def test_clears_early_responses(self, protocol):
-        protocol.early_responses["e1"] = {"response": MagicMock(), "timestamp": datetime.now()}
-        protocol.early_responses_by_conversation["c1"] = {"response": MagicMock(), "timestamp": datetime.now()}
+        protocol.early_responses["e1"] = {
+            "response": MagicMock(),
+            "timestamp": datetime.now(),
+        }
+        protocol.early_responses_by_conversation["c1"] = {
+            "response": MagicMock(),
+            "timestamp": datetime.now(),
+        }
         protocol.shutdown()
         assert protocol.early_responses == {}
         assert protocol.early_responses_by_conversation == {}
@@ -461,6 +476,7 @@ class TestShutdown:
 
 
 # ── RequestTimeoutError ─────────────────────────────────────────────────
+
 
 class TestRequestTimeoutError:
     """Tests for RequestTimeoutError exception."""

--- a/tests/unit/argumentation_analysis/core/test_argumentation_analyzer.py
+++ b/tests/unit/argumentation_analysis/core/test_argumentation_analyzer.py
@@ -8,7 +8,6 @@ import sys
 import pytest
 from unittest.mock import MagicMock
 
-
 # The module imports UnifiedTextAnalysisPipeline from pipelines.unified_text_analysis
 # which has a deep import chain (bootstrap.get_fallacy_detector, etc.).
 # We inject mocks into sys.modules BEFORE importing the analyzer module.
@@ -26,15 +25,19 @@ _mock_analysis_service_mod.AnalysisService = MagicMock(
 )
 
 # Save originals if they exist
-_orig_pipeline = sys.modules.get("argumentation_analysis.pipelines.unified_text_analysis")
+_orig_pipeline = sys.modules.get(
+    "argumentation_analysis.pipelines.unified_text_analysis"
+)
 _orig_service = sys.modules.get(
     "argumentation_analysis.services.web_api.services.analysis_service"
 )
 
-sys.modules["argumentation_analysis.pipelines.unified_text_analysis"] = _mock_pipeline_mod
-sys.modules[
-    "argumentation_analysis.services.web_api.services.analysis_service"
-] = _mock_analysis_service_mod
+sys.modules["argumentation_analysis.pipelines.unified_text_analysis"] = (
+    _mock_pipeline_mod
+)
+sys.modules["argumentation_analysis.services.web_api.services.analysis_service"] = (
+    _mock_analysis_service_mod
+)
 
 from argumentation_analysis.core.argumentation_analyzer import (
     ArgumentationAnalyzer,
@@ -43,14 +46,16 @@ from argumentation_analysis.core.argumentation_analyzer import (
 
 # Restore originals (or remove mocks) so other tests aren't affected
 if _orig_pipeline is not None:
-    sys.modules["argumentation_analysis.pipelines.unified_text_analysis"] = _orig_pipeline
+    sys.modules["argumentation_analysis.pipelines.unified_text_analysis"] = (
+        _orig_pipeline
+    )
 else:
     sys.modules.pop("argumentation_analysis.pipelines.unified_text_analysis", None)
 
 if _orig_service is not None:
-    sys.modules[
-        "argumentation_analysis.services.web_api.services.analysis_service"
-    ] = _orig_service
+    sys.modules["argumentation_analysis.services.web_api.services.analysis_service"] = (
+        _orig_service
+    )
 else:
     sys.modules.pop(
         "argumentation_analysis.services.web_api.services.analysis_service", None
@@ -60,6 +65,7 @@ else:
 # ============================================================
 # Initialization (degraded mode)
 # ============================================================
+
 
 class TestInit:
     def test_default_init_degraded(self):
@@ -83,6 +89,7 @@ class TestInit:
 # ============================================================
 # _basic_analysis (pure logic)
 # ============================================================
+
 
 class TestBasicAnalysis:
     def test_text_length(self):
@@ -114,7 +121,10 @@ class TestBasicAnalysis:
         analyzer = ArgumentationAnalyzer()
         result = analyzer._basic_analysis("text")
         assert "message" in result
-        assert "basique" in result["message"].lower() or "basic" in result["message"].lower()
+        assert (
+            "basique" in result["message"].lower()
+            or "basic" in result["message"].lower()
+        )
 
     def test_empty_text(self):
         analyzer = ArgumentationAnalyzer()
@@ -132,6 +142,7 @@ class TestBasicAnalysis:
 # ============================================================
 # analyze_text
 # ============================================================
+
 
 class TestAnalyzeText:
     def test_empty_text_returns_error(self):
@@ -205,6 +216,7 @@ class TestAnalyzeText:
 # get_available_features
 # ============================================================
 
+
 class TestGetAvailableFeatures:
     def test_degraded_mode_only_basic(self):
         analyzer = ArgumentationAnalyzer()
@@ -233,12 +245,17 @@ class TestGetAvailableFeatures:
         analyzer.analysis_service = MagicMock()
         features = analyzer.get_available_features()
         assert len(features) == 3
-        assert set(features) == {"unified_pipeline", "analysis_service", "basic_analysis"}
+        assert set(features) == {
+            "unified_pipeline",
+            "analysis_service",
+            "basic_analysis",
+        }
 
 
 # ============================================================
 # validate_configuration
 # ============================================================
+
 
 class TestValidateConfiguration:
     def test_degraded_mode_partial(self):
@@ -280,6 +297,7 @@ class TestValidateConfiguration:
 # ============================================================
 # create_analysis_state
 # ============================================================
+
 
 class TestCreateAnalysisState:
     def test_raises_without_initial_text(self):

--- a/tests/unit/argumentation_analysis/core/test_bootstrap.py
+++ b/tests/unit/argumentation_analysis/core/test_bootstrap.py
@@ -20,7 +20,6 @@ from argumentation_analysis.core.bootstrap import (
     _load_tweety_classes,
 )
 
-
 # ===========================================================================
 # ProjectContext Tests
 # ===========================================================================
@@ -288,9 +287,7 @@ class TestInitializeProjectEnvironment:
         with patch(
             "argumentation_analysis.core.bootstrap.initialize_jvm_func",
             mock_init_jvm,
-        ), patch(
-            "argumentation_analysis.core.bootstrap._load_tweety_classes"
-        ), patch(
+        ), patch("argumentation_analysis.core.bootstrap._load_tweety_classes"), patch(
             "argumentation_analysis.core.bootstrap.CryptoService_class", None
         ), patch(
             "argumentation_analysis.core.bootstrap.DefinitionService_class", None

--- a/tests/unit/argumentation_analysis/core/test_cluedo_oracle_state_extended.py
+++ b/tests/unit/argumentation_analysis/core/test_cluedo_oracle_state_extended.py
@@ -29,7 +29,6 @@ from argumentation_analysis.agents.core.oracle.permissions import (
     QueryResult,
 )
 
-
 # ═════════════════════════════════════════════════════════════════════════════
 # SHARED FIXTURES
 # ═════════════════════════════════════════════════════════════════════════════
@@ -313,6 +312,7 @@ class TestCluedoOracleStateInit:
     def test_init_workflow_id_generated_as_uuid(self, cluedo_elements):
         state, _ = _make_oracle_state(cluedo_elements)
         import uuid
+
         # Should parse without raising
         parsed = uuid.UUID(state.workflow_id)
         assert str(parsed) == state.workflow_id
@@ -356,14 +356,13 @@ class TestCluedoOracleStateCardDistribution:
         state, _ = _make_oracle_state(cluedo_elements)
         solution = state.solution_secrete_cluedo
         solution_values = set(solution.values())
-        all_distributed = (
-            state.cartes_distribuees.get("Moriarty", [])
-            + state.cartes_distribuees.get("AutresJoueurs", [])
-        )
+        all_distributed = state.cartes_distribuees.get(
+            "Moriarty", []
+        ) + state.cartes_distribuees.get("AutresJoueurs", [])
         for card in all_distributed:
-            assert card not in solution_values, (
-                f"Solution card '{card}' should not be in distribution"
-            )
+            assert (
+                card not in solution_values
+            ), f"Solution card '{card}' should not be in distribution"
 
     def test_distribute_cards_moriarty_gets_approx_third(self, cluedo_elements):
         state, _ = _make_oracle_state(cluedo_elements)
@@ -486,9 +485,7 @@ class TestCluedoOracleStatePermissions:
 
     def test_agent_can_query_oracle_wrong_type_denied(self, oracle_state):
         """Watson cannot use ADMIN_COMMAND."""
-        result = oracle_state._agent_can_query_oracle(
-            "Watson", QueryType.ADMIN_COMMAND
-        )
+        result = oracle_state._agent_can_query_oracle("Watson", QueryType.ADMIN_COMMAND)
         assert result is False
 
     def test_moriarty_has_is_oracle_flag(self, oracle_state):
@@ -515,7 +512,10 @@ class TestCluedoOracleStateQueryOracle:
             query_params={},
         )
         assert response.authorized is False
-        assert "invalide" in response.message.lower() or "invalid" in response.message.lower()
+        assert (
+            "invalide" in response.message.lower()
+            or "invalid" in response.message.lower()
+        )
 
     async def test_query_oracle_permission_denied_returns_unauthorized(
         self, oracle_state_with_dataset
@@ -550,13 +550,9 @@ class TestCluedoOracleStateQueryOracle:
         assert isinstance(response, OracleResponse)
         assert response.authorized is True
 
-    async def test_query_oracle_increments_counters(
-        self, oracle_state_with_dataset
-    ):
+    async def test_query_oracle_increments_counters(self, oracle_state_with_dataset):
         state, mock_dataset = oracle_state_with_dataset
-        mock_result = QueryResult(
-            success=True, data={}, message="OK", metadata={}
-        )
+        mock_result = QueryResult(success=True, data={}, message="OK", metadata={})
         mock_dataset.process_query = AsyncMock(return_value=mock_result)
 
         initial_count = state.oracle_queries_count
@@ -587,7 +583,9 @@ class TestCluedoOracleStateQueryOracle:
             query_params={},
         )
         assert response.authorized is False
-        assert "erreur" in response.message.lower() or "error" in response.message.lower()
+        assert (
+            "erreur" in response.message.lower() or "error" in response.message.lower()
+        )
 
 
 class TestCluedoOracleStateRecordAgentTurn:

--- a/tests/unit/argumentation_analysis/core/test_enquete_states.py
+++ b/tests/unit/argumentation_analysis/core/test_enquete_states.py
@@ -9,8 +9,8 @@ from argumentation_analysis.core.enquete_states import (
     EnqueteCluedoState,
 )
 
-
 # ── BaseWorkflowState ──
+
 
 class TestBaseWorkflowState:
     @pytest.fixture
@@ -118,6 +118,7 @@ class TestBaseWorkflowState:
 
 
 # ── EnquetePoliciereState ──
+
 
 class TestEnquetePoliciereState:
     @pytest.fixture
@@ -266,6 +267,7 @@ class TestEnquetePoliciereState:
 
 # ── EnqueteCluedoState ──
 
+
 class TestEnqueteCluedoState:
     @pytest.fixture
     def elements(self):
@@ -296,9 +298,7 @@ class TestEnqueteCluedoState:
         assert state.final_solution is None
 
     def test_init_auto_solution(self, elements):
-        state = EnqueteCluedoState(
-            "Auto Game", elements, "Murder case", {}
-        )
+        state = EnqueteCluedoState("Auto Game", elements, "Murder case", {})
         sol = state.solution_secrete_cluedo
         assert sol["suspect"] in elements["suspects"]
         assert sol["arme"] in elements["armes"]
@@ -307,7 +307,10 @@ class TestEnqueteCluedoState:
     def test_init_no_solution_no_auto_raises(self, elements):
         with pytest.raises(ValueError):
             EnqueteCluedoState(
-                "Game", elements, "desc", {},
+                "Game",
+                elements,
+                "desc",
+                {},
                 solution_secrete_cluedo=None,
                 auto_generate_solution=False,
             )
@@ -348,7 +351,9 @@ class TestEnqueteCluedoState:
         assert "Not(Coupable(" in content
 
     def test_propose_final_solution(self, state):
-        state.propose_final_solution({"suspect": "Miss Scarlet", "arme": "Knife", "lieu": "Library"})
+        state.propose_final_solution(
+            {"suspect": "Miss Scarlet", "arme": "Knife", "lieu": "Library"}
+        )
         assert state.is_solution_proposed is True
         assert state.final_solution["suspect"] == "Miss Scarlet"
 

--- a/tests/unit/argumentation_analysis/core/test_environment.py
+++ b/tests/unit/argumentation_analysis/core/test_environment.py
@@ -37,6 +37,7 @@ class TestEnsureEnv:
             if not patched.get("E2E_TESTING_MODE"):
                 os.environ.pop("E2E_TESTING_MODE", None)
             from argumentation_analysis.core.environment import ensure_env
+
             return ensure_env(**kwargs)
 
     # --- E2E testing mode bypass ---
@@ -44,6 +45,7 @@ class TestEnsureEnv:
     def test_e2e_mode_skips_conda_check(self):
         """When E2E_TESTING_MODE=1, ensure_env returns True without checking conda."""
         from argumentation_analysis.core.environment import ensure_env
+
         with patch.dict(os.environ, {"E2E_TESTING_MODE": "1"}):
             result = ensure_env(silent=True, load_dotenv=False)
             assert result is True
@@ -51,7 +53,10 @@ class TestEnsureEnv:
     def test_e2e_mode_skips_even_wrong_env(self):
         """E2E mode bypasses conda check even with wrong env."""
         from argumentation_analysis.core.environment import ensure_env
-        with patch.dict(os.environ, {"E2E_TESTING_MODE": "1", "CONDA_DEFAULT_ENV": "wrong"}):
+
+        with patch.dict(
+            os.environ, {"E2E_TESTING_MODE": "1", "CONDA_DEFAULT_ENV": "wrong"}
+        ):
             result = ensure_env(env_name="projet-is", silent=True, load_dotenv=False)
             assert result is True
 
@@ -61,7 +66,9 @@ class TestEnsureEnv:
         """When CONDA_DEFAULT_ENV matches expected, returns True."""
         result = self._call_ensure_env(
             {"CONDA_DEFAULT_ENV": "projet-is"},
-            env_name="projet-is", silent=True, load_dotenv=False
+            env_name="projet-is",
+            silent=True,
+            load_dotenv=False,
         )
         assert result is True
 
@@ -69,7 +76,9 @@ class TestEnsureEnv:
         """When CONDA_DEFAULT_ENV matches explicitly-given env name, returns True."""
         result = self._call_ensure_env(
             {"CONDA_DEFAULT_ENV": "projet-is-roo-new"},
-            env_name="projet-is-roo-new", silent=True, load_dotenv=False
+            env_name="projet-is-roo-new",
+            silent=True,
+            load_dotenv=False,
         )
         assert result is True
 
@@ -79,7 +88,9 @@ class TestEnsureEnv:
         """When expected is 'projet-is-roo' and active is 'projet-is', it's accepted."""
         result = self._call_ensure_env(
             {"CONDA_DEFAULT_ENV": "projet-is"},
-            env_name="projet-is-roo", silent=True, load_dotenv=False
+            env_name="projet-is-roo",
+            silent=True,
+            load_dotenv=False,
         )
         assert result is True
 
@@ -90,17 +101,23 @@ class TestEnsureEnv:
         with pytest.raises(RuntimeError, match="MAUVAIS ENVIRONNEMENT CONDA"):
             self._call_ensure_env(
                 {"CONDA_DEFAULT_ENV": "wrong-env"},
-                env_name="projet-is", silent=True, load_dotenv=False
+                env_name="projet-is",
+                silent=True,
+                load_dotenv=False,
             )
 
     def test_missing_conda_env_raises(self):
         """When CONDA_DEFAULT_ENV is not set, raises RuntimeError."""
         with pytest.raises(RuntimeError, match="MAUVAIS ENVIRONNEMENT CONDA"):
             # Use a clean env without CONDA_DEFAULT_ENV
-            env_copy = {k: v for k, v in os.environ.items()
-                        if k not in ("CONDA_DEFAULT_ENV", "E2E_TESTING_MODE")}
+            env_copy = {
+                k: v
+                for k, v in os.environ.items()
+                if k not in ("CONDA_DEFAULT_ENV", "E2E_TESTING_MODE")
+            }
             with patch.dict(os.environ, env_copy, clear=True):
                 from argumentation_analysis.core.environment import ensure_env
+
                 ensure_env(env_name="projet-is", silent=True, load_dotenv=False)
 
     # --- Error message content ---
@@ -109,7 +126,9 @@ class TestEnsureEnv:
         with pytest.raises(RuntimeError) as exc_info:
             self._call_ensure_env(
                 {"CONDA_DEFAULT_ENV": "wrong"},
-                env_name="my-expected-env", silent=True, load_dotenv=False
+                env_name="my-expected-env",
+                silent=True,
+                load_dotenv=False,
             )
         assert "my-expected-env" in str(exc_info.value)
         assert "wrong" in str(exc_info.value)
@@ -118,7 +137,9 @@ class TestEnsureEnv:
         with pytest.raises(RuntimeError) as exc_info:
             self._call_ensure_env(
                 {"CONDA_DEFAULT_ENV": "bad"},
-                env_name="good", silent=True, load_dotenv=False
+                env_name="good",
+                silent=True,
+                load_dotenv=False,
             )
         assert "conda activate" in str(exc_info.value)
 
@@ -128,16 +149,22 @@ class TestEnsureEnv:
         """When load_dotenv=False, EnvironmentManager is not called."""
         result = self._call_ensure_env(
             {"CONDA_DEFAULT_ENV": "projet-is"},
-            env_name="projet-is", silent=True, load_dotenv=False
+            env_name="projet-is",
+            silent=True,
+            load_dotenv=False,
         )
         assert result is True
 
     def test_load_dotenv_handles_import_error(self):
         """When EnvironmentManager can't be imported, ensure_env continues gracefully."""
-        with patch.dict(sys.modules, {"project_core.managers.environment_manager": None}):
+        with patch.dict(
+            sys.modules, {"project_core.managers.environment_manager": None}
+        ):
             result = self._call_ensure_env(
                 {"CONDA_DEFAULT_ENV": "projet-is"},
-                env_name="projet-is", silent=True, load_dotenv=True
+                env_name="projet-is",
+                silent=True,
+                load_dotenv=True,
             )
             assert result is True
 
@@ -147,6 +174,7 @@ class TestHelperFunctions:
 
     def test_get_one_liner_returns_string(self):
         from argumentation_analysis.core.environment import get_one_liner
+
         result = get_one_liner()
         assert isinstance(result, str)
         assert len(result) > 50
@@ -154,6 +182,7 @@ class TestHelperFunctions:
 
     def test_get_simple_import_returns_string(self):
         from argumentation_analysis.core.environment import get_simple_import
+
         result = get_simple_import()
         assert isinstance(result, str)
         assert "argumentation_analysis.core.environment" in result

--- a/tests/unit/argumentation_analysis/core/test_io_manager.py
+++ b/tests/unit/argumentation_analysis/core/test_io_manager.py
@@ -16,7 +16,6 @@ from argumentation_analysis.core.io_manager import (
     save_extract_definitions,
 )
 
-
 # ============================================================
 # Helpers
 # ============================================================
@@ -51,6 +50,7 @@ def _make_encrypted_payload(definitions):
 # ============================================================
 # load_extract_definitions
 # ============================================================
+
 
 class TestLoadExtractDefinitions:
     """Tests for load_extract_definitions."""
@@ -186,6 +186,7 @@ class TestLoadExtractDefinitions:
 # save_extract_definitions
 # ============================================================
 
+
 class TestSaveExtractDefinitions:
     """Tests for save_extract_definitions."""
 
@@ -278,8 +279,11 @@ class TestSaveExtractDefinitions:
             return_value=b"data",
         ):
             result = save_extract_definitions(
-                [definition], config_file, "key",
-                embed_full_text=True, text_retriever=retriever
+                [definition],
+                config_file,
+                "key",
+                embed_full_text=True,
+                text_retriever=retriever,
             )
             assert result is True
             retriever.assert_called_once()
@@ -295,8 +299,11 @@ class TestSaveExtractDefinitions:
             return_value=b"data",
         ):
             result = save_extract_definitions(
-                [definition], config_file, "key",
-                embed_full_text=True, text_retriever=retriever
+                [definition],
+                config_file,
+                "key",
+                embed_full_text=True,
+                text_retriever=retriever,
             )
             assert result is True
 
@@ -311,8 +318,11 @@ class TestSaveExtractDefinitions:
             return_value=b"data",
         ):
             result = save_extract_definitions(
-                [definition], config_file, "key",
-                embed_full_text=True, text_retriever=retriever
+                [definition],
+                config_file,
+                "key",
+                embed_full_text=True,
+                text_retriever=retriever,
             )
             assert result is True
 
@@ -327,8 +337,11 @@ class TestSaveExtractDefinitions:
             return_value=b"data",
         ):
             result = save_extract_definitions(
-                [definition], config_file, "key",
-                embed_full_text=True, text_retriever=retriever
+                [definition],
+                config_file,
+                "key",
+                embed_full_text=True,
+                text_retriever=retriever,
             )
             assert result is True
 
@@ -374,8 +387,11 @@ class TestSaveExtractDefinitions:
             side_effect=capture_encrypt,
         ):
             save_extract_definitions(
-                [definition], config_file, "key",
-                embed_full_text=True, text_retriever=retriever
+                [definition],
+                config_file,
+                "key",
+                embed_full_text=True,
+                text_retriever=retriever,
             )
             retriever.assert_not_called()
             assert saved_data["definitions"][0]["full_text"] == "Existing full text"

--- a/tests/unit/argumentation_analysis/core/test_llm_service_extended.py
+++ b/tests/unit/argumentation_analysis/core/test_llm_service_extended.py
@@ -16,6 +16,7 @@ class TestCreateLlmServiceMocking:
 
     def _import_create(self):
         from argumentation_analysis.core.llm_service import create_llm_service
+
         return create_llm_service
 
     def test_force_mock_returns_mock_service(self):
@@ -35,13 +36,20 @@ class TestCreateLlmServiceMocking:
     def test_force_authentic_overrides_test_env(self):
         """force_authentic=True bypasses mock even in test env."""
         create = self._import_create()
-        with patch.dict(os.environ, {
-            "PYTEST_CURRENT_TEST": "test_file::test_fn",
-            "OPENAI_API_KEY": "sk-test-fake-key",
-            "OPENAI_CHAT_MODEL_ID": "gpt-5-mini",
-        }):
-            with patch("argumentation_analysis.core.llm_service.AsyncOpenAI") as mock_client:
-                with patch("argumentation_analysis.core.llm_service.OpenAIChatCompletion") as mock_oai:
+        with patch.dict(
+            os.environ,
+            {
+                "PYTEST_CURRENT_TEST": "test_file::test_fn",
+                "OPENAI_API_KEY": "sk-test-fake-key",
+                "OPENAI_CHAT_MODEL_ID": "gpt-5-mini",
+            },
+        ):
+            with patch(
+                "argumentation_analysis.core.llm_service.AsyncOpenAI"
+            ) as mock_client:
+                with patch(
+                    "argumentation_analysis.core.llm_service.OpenAIChatCompletion"
+                ) as mock_oai:
                     mock_oai.return_value = MagicMock()
                     service = create("svc", force_authentic=True)
         assert service is not None
@@ -64,13 +72,18 @@ class TestCreateLlmServiceModelSubstitution:
         """gpt-4-32k is automatically replaced by gpt-5-mini."""
         from argumentation_analysis.core.llm_service import create_llm_service
 
-        with patch.dict(os.environ, {
-            "OPENAI_API_KEY": "sk-test",
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "sk-test",
+            },
+        ):
             # Remove PYTEST_CURRENT_TEST to avoid mock path
             os.environ.pop("PYTEST_CURRENT_TEST", None)
             with patch("argumentation_analysis.core.llm_service.AsyncOpenAI"):
-                with patch("argumentation_analysis.core.llm_service.OpenAIChatCompletion") as mock_oai:
+                with patch(
+                    "argumentation_analysis.core.llm_service.OpenAIChatCompletion"
+                ) as mock_oai:
                     mock_oai.return_value = MagicMock()
                     create_llm_service(
                         "svc",
@@ -85,13 +98,18 @@ class TestCreateLlmServiceModelSubstitution:
         """When model_id is None, reads from OPENAI_CHAT_MODEL_ID."""
         from argumentation_analysis.core.llm_service import create_llm_service
 
-        with patch.dict(os.environ, {
-            "OPENAI_API_KEY": "sk-test",
-            "OPENAI_CHAT_MODEL_ID": "custom-model",
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "sk-test",
+                "OPENAI_CHAT_MODEL_ID": "custom-model",
+            },
+        ):
             os.environ.pop("PYTEST_CURRENT_TEST", None)
             with patch("argumentation_analysis.core.llm_service.AsyncOpenAI"):
-                with patch("argumentation_analysis.core.llm_service.OpenAIChatCompletion") as mock_oai:
+                with patch(
+                    "argumentation_analysis.core.llm_service.OpenAIChatCompletion"
+                ) as mock_oai:
                     mock_oai.return_value = MagicMock()
                     create_llm_service("svc", force_authentic=True)
             call_kwargs = mock_oai.call_args
@@ -121,12 +139,17 @@ class TestCreateLlmServiceAzure:
         """Azure path with endpoint creates AzureChatCompletion."""
         from argumentation_analysis.core.llm_service import create_llm_service
 
-        with patch.dict(os.environ, {
-            "OPENAI_API_KEY": "sk-test",
-            "AZURE_OPENAI_ENDPOINT": "https://my-resource.openai.azure.com",
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "sk-test",
+                "AZURE_OPENAI_ENDPOINT": "https://my-resource.openai.azure.com",
+            },
+        ):
             os.environ.pop("PYTEST_CURRENT_TEST", None)
-            with patch("argumentation_analysis.core.llm_service.AzureChatCompletion") as mock_azure:
+            with patch(
+                "argumentation_analysis.core.llm_service.AzureChatCompletion"
+            ) as mock_azure:
                 mock_azure.return_value = MagicMock()
                 service = create_llm_service(
                     "svc",
@@ -173,13 +196,20 @@ class TestCreateLlmServiceErrors:
         """OPENAI_ORG_ID is forwarded to AsyncOpenAI."""
         from argumentation_analysis.core.llm_service import create_llm_service
 
-        with patch.dict(os.environ, {
-            "OPENAI_API_KEY": "sk-test",
-            "OPENAI_ORG_ID": "org-12345",
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "sk-test",
+                "OPENAI_ORG_ID": "org-12345",
+            },
+        ):
             os.environ.pop("PYTEST_CURRENT_TEST", None)
-            with patch("argumentation_analysis.core.llm_service.AsyncOpenAI") as mock_client:
-                with patch("argumentation_analysis.core.llm_service.OpenAIChatCompletion") as mock_oai:
+            with patch(
+                "argumentation_analysis.core.llm_service.AsyncOpenAI"
+            ) as mock_client:
+                with patch(
+                    "argumentation_analysis.core.llm_service.OpenAIChatCompletion"
+                ) as mock_oai:
                     mock_oai.return_value = MagicMock()
                     create_llm_service("svc", model_id="m", force_authentic=True)
             call_kwargs = mock_client.call_args[1]

--- a/tests/unit/argumentation_analysis/core/test_logique_complexe_states.py
+++ b/tests/unit/argumentation_analysis/core/test_logique_complexe_states.py
@@ -8,8 +8,8 @@ from argumentation_analysis.core.logique_complexe_states import (
     LogiqueBridgeState,
 )
 
-
 # ── EinsteinsRiddleState ──
+
 
 class TestEinsteinsRiddleStateInit:
     def test_init_defaults(self):
@@ -59,7 +59,12 @@ class TestEinsteinsRiddleConstraints:
         assert any("Norvégien" in c for c in contraintes)
 
     def test_ajouter_clause_nouvelle(self, state):
-        assert state.ajouter_clause_logique("forall(X, couleur(X, rouge) => nation(X, anglais))") is True
+        assert (
+            state.ajouter_clause_logique(
+                "forall(X, couleur(X, rouge) => nation(X, anglais))"
+            )
+            is True
+        )
         assert len(state.clauses_logiques) == 1
         assert len(state.deductions_watson) == 1
 
@@ -156,7 +161,15 @@ class TestEinsteinsRiddleSolution:
             state.ajouter_clause_logique(f"clause_{i}")
         for i in range(5):
             state.executer_requete_logique(f"query_{i}")
-        wrong = {1: {"couleur": "X", "nationalite": "X", "animal": "X", "boisson": "X", "metier": "X"}}
+        wrong = {
+            1: {
+                "couleur": "X",
+                "nationalite": "X",
+                "animal": "X",
+                "boisson": "X",
+                "metier": "X",
+            }
+        }
         result = state.proposer_solution_complexe(wrong)
         assert result["acceptee"] is False
         assert "incorrecte" in result["raison"].lower()
@@ -168,6 +181,7 @@ class TestEinsteinsRiddleSolution:
 
 
 # ── LogiqueBridgeState ──
+
 
 class TestLogiqueBridgeStateInit:
     def test_init(self):

--- a/tests/unit/argumentation_analysis/core/test_prover9_runner.py
+++ b/tests/unit/argumentation_analysis/core/test_prover9_runner.py
@@ -12,10 +12,10 @@ from unittest.mock import patch, MagicMock, ANY
 
 from argumentation_analysis.core.prover9_runner import run_prover9, PROVER9_EXECUTABLE
 
-
 # ============================================================
 # run_prover9
 # ============================================================
+
 
 class TestRunProver9:
     """Tests for the run_prover9 function."""
@@ -72,9 +72,13 @@ class TestRunProver9:
 
     @patch("argumentation_analysis.core.prover9_runner.subprocess.run")
     @patch("argumentation_analysis.core.prover9_runner.PROVER9_EXECUTABLE")
-    @patch("argumentation_analysis.core.prover9_runner.os.path.exists", return_value=True)
+    @patch(
+        "argumentation_analysis.core.prover9_runner.os.path.exists", return_value=True
+    )
     @patch("argumentation_analysis.core.prover9_runner.os.remove")
-    def test_temp_file_cleaned_up_on_success(self, mock_remove, mock_exists, mock_executable, mock_run):
+    def test_temp_file_cleaned_up_on_success(
+        self, mock_remove, mock_exists, mock_executable, mock_run
+    ):
         mock_executable.is_file.return_value = True
         mock_run.return_value = MagicMock(stdout="ok", returncode=0)
 
@@ -83,9 +87,13 @@ class TestRunProver9:
 
     @patch("argumentation_analysis.core.prover9_runner.subprocess.run")
     @patch("argumentation_analysis.core.prover9_runner.PROVER9_EXECUTABLE")
-    @patch("argumentation_analysis.core.prover9_runner.os.path.exists", return_value=True)
+    @patch(
+        "argumentation_analysis.core.prover9_runner.os.path.exists", return_value=True
+    )
     @patch("argumentation_analysis.core.prover9_runner.os.remove")
-    def test_temp_file_cleaned_up_on_error(self, mock_remove, mock_exists, mock_executable, mock_run):
+    def test_temp_file_cleaned_up_on_error(
+        self, mock_remove, mock_exists, mock_executable, mock_run
+    ):
         mock_executable.is_file.return_value = True
         mock_run.side_effect = subprocess.CalledProcessError(
             returncode=1, cmd="prover9", output="", stderr="error"

--- a/tests/unit/argumentation_analysis/core/test_pyo3_singleton.py
+++ b/tests/unit/argumentation_analysis/core/test_pyo3_singleton.py
@@ -26,6 +26,7 @@ def reset_globals():
 
 # ── initialize_pyo3 ──
 
+
 class TestInitializePyo3:
     def test_first_init_returns_true(self):
         assert initialize_pyo3() is True
@@ -43,12 +44,14 @@ class TestInitializePyo3:
 
 # ── get_pyo3_module ──
 
+
 class TestGetPyo3Module:
     def test_loads_real_module(self):
         """Load a standard library module to test the flow."""
         mod = get_pyo3_module("json")
         assert mod is not None
         import json
+
         assert mod is json
 
     def test_caches_loaded_module(self):
@@ -98,6 +101,7 @@ class TestGetPyo3Module:
 
 # ── unload_pyo3_module ──
 
+
 class TestUnloadPyo3Module:
     def test_unload_loaded_module(self):
         get_pyo3_module("json")
@@ -126,6 +130,7 @@ class TestUnloadPyo3Module:
 
 
 # ── reset_pyo3_environment ──
+
 
 class TestResetPyo3Environment:
     def test_resets_everything(self):

--- a/tests/unit/argumentation_analysis/core/test_source_management_extended.py
+++ b/tests/unit/argumentation_analysis/core/test_source_management_extended.py
@@ -40,10 +40,10 @@ from argumentation_analysis.models.extract_definition import (
     SourceDefinition,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_extract_definitions(
     source_name: str = "Test Source",
@@ -97,6 +97,7 @@ def _make_extract_definitions_no_full_text(
 # ===========================================================================
 # UnifiedSourceConfig
 # ===========================================================================
+
 
 class TestUnifiedSourceConfigConversion:
     """Tests for UnifiedSourceConfig.from_legacy_config and to_legacy_config."""
@@ -192,7 +193,9 @@ class TestUnifiedSourceConfigConversion:
             anonymize_logs=True,
             auto_cleanup=False,
         )
-        roundtripped = UnifiedSourceConfig.from_legacy_config(original).to_legacy_config()
+        roundtripped = UnifiedSourceConfig.from_legacy_config(
+            original
+        ).to_legacy_config()
 
         assert roundtripped.source_type == original.source_type
         assert roundtripped.passphrase == original.passphrase
@@ -203,6 +206,7 @@ class TestUnifiedSourceConfigConversion:
 # ===========================================================================
 # UnifiedSourceManager._get_passphrase
 # ===========================================================================
+
 
 class TestGetPassphrase:
     """Tests for UnifiedSourceManager._get_passphrase."""
@@ -312,6 +316,7 @@ class TestGetPassphrase:
 # ===========================================================================
 # UnifiedSourceManager._load_enc_file_sources
 # ===========================================================================
+
 
 class TestLoadEncFileSources:
     """Tests for _load_enc_file_sources."""
@@ -474,6 +479,7 @@ class TestLoadEncFileSources:
 # UnifiedSourceManager._load_text_file_sources
 # ===========================================================================
 
+
 class TestLoadTextFileSources:
     """Tests for _load_text_file_sources."""
 
@@ -568,6 +574,7 @@ class TestLoadTextFileSources:
 # UnifiedSourceManager._load_free_text_sources
 # ===========================================================================
 
+
 class TestLoadFreeTextSources:
     """Tests for _load_free_text_sources."""
 
@@ -626,6 +633,7 @@ class TestLoadFreeTextSources:
 # ===========================================================================
 # UnifiedSourceManager.load_sources (routing)
 # ===========================================================================
+
 
 class TestLoadSourcesRouting:
     """Tests for load_sources routing to the correct handler."""
@@ -686,6 +694,7 @@ class TestLoadSourcesRouting:
 # ===========================================================================
 # UnifiedSourceManager.select_text_for_analysis (new types)
 # ===========================================================================
+
 
 class TestSelectTextNewTypes:
     """Tests for select_text_for_analysis with non-simple/complex source types."""
@@ -759,6 +768,7 @@ class TestSelectTextNewTypes:
 # UnifiedSourceManager._setup_logging (anonymize filter)
 # ===========================================================================
 
+
 class TestSetupLogging:
     """Tests for _setup_logging and the AnonymizeFilter.
 
@@ -776,7 +786,9 @@ class TestSetupLogging:
 
     def test_anonymize_filter_on_complex(self):
         """Complex type with anonymize_logs=True adds an AnonymizeFilter."""
-        self._clear_logger_filters("argumentation_analysis.core.source_management.complex")
+        self._clear_logger_filters(
+            "argumentation_analysis.core.source_management.complex"
+        )
         config = UnifiedSourceConfig(
             source_type=UnifiedSourceType.COMPLEX,
             passphrase="pw",
@@ -788,7 +800,9 @@ class TestSetupLogging:
 
     def test_anonymize_filter_on_enc_file(self):
         """ENC_FILE type with anonymize_logs=True adds an AnonymizeFilter."""
-        self._clear_logger_filters("argumentation_analysis.core.source_management.enc_file")
+        self._clear_logger_filters(
+            "argumentation_analysis.core.source_management.enc_file"
+        )
         config = UnifiedSourceConfig(
             source_type=UnifiedSourceType.ENC_FILE,
             anonymize_logs=True,
@@ -799,7 +813,9 @@ class TestSetupLogging:
 
     def test_no_anonymize_filter_on_simple(self):
         """SIMPLE type does not add an AnonymizeFilter even with anonymize_logs=True."""
-        self._clear_logger_filters("argumentation_analysis.core.source_management.simple")
+        self._clear_logger_filters(
+            "argumentation_analysis.core.source_management.simple"
+        )
         config = UnifiedSourceConfig(
             source_type=UnifiedSourceType.SIMPLE,
             anonymize_logs=True,
@@ -810,7 +826,9 @@ class TestSetupLogging:
 
     def test_no_anonymize_filter_when_disabled(self):
         """COMPLEX type with anonymize_logs=False does not add filter."""
-        self._clear_logger_filters("argumentation_analysis.core.source_management.complex")
+        self._clear_logger_filters(
+            "argumentation_analysis.core.source_management.complex"
+        )
         config = UnifiedSourceConfig(
             source_type=UnifiedSourceType.COMPLEX,
             passphrase="pw",
@@ -822,7 +840,9 @@ class TestSetupLogging:
 
     def test_anonymize_filter_replaces_sensitive_names(self):
         """AnonymizeFilter replaces known sensitive patterns in log messages."""
-        self._clear_logger_filters("argumentation_analysis.core.source_management.enc_file")
+        self._clear_logger_filters(
+            "argumentation_analysis.core.source_management.enc_file"
+        )
         config = UnifiedSourceConfig(
             source_type=UnifiedSourceType.ENC_FILE,
             anonymize_logs=True,
@@ -831,9 +851,13 @@ class TestSetupLogging:
 
         # Create a log record with a sensitive name
         record = logging.LogRecord(
-            name="test", level=logging.INFO,
-            pathname="", lineno=0, msg="Discours de Hitler et Macron",
-            args=(), exc_info=None,
+            name="test",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="Discours de Hitler et Macron",
+            args=(),
+            exc_info=None,
         )
         # Apply filters
         for f in manager.logger.filters:
@@ -847,6 +871,7 @@ class TestSetupLogging:
 # ===========================================================================
 # UnifiedSourceManager.list_available_sources
 # ===========================================================================
+
 
 class TestListAvailableSources:
     """Tests for list_available_sources.
@@ -884,12 +909,16 @@ class TestListAvailableSources:
         sources = manager.list_available_sources()
 
         assert len(sources["simple"]) == 1
-        assert "monstration" in sources["simple"][0].lower() or "test" in sources["simple"][0].lower()
+        assert (
+            "monstration" in sources["simple"][0].lower()
+            or "test" in sources["simple"][0].lower()
+        )
 
 
 # ===========================================================================
 # create_unified_source_manager factory
 # ===========================================================================
+
 
 class TestCreateUnifiedSourceManager:
     """Tests for the create_unified_source_manager factory function."""
@@ -956,9 +985,7 @@ class TestCreateUnifiedSourceManager:
 
     def test_forwards_source_index(self):
         """Factory forwards source_index to config."""
-        manager = create_unified_source_manager(
-            source_type="complex", source_index=3
-        )
+        manager = create_unified_source_manager(source_type="complex", source_index=3)
         assert manager.config.source_index == 3
 
     def test_defaults(self):
@@ -974,6 +1001,7 @@ class TestCreateUnifiedSourceManager:
 # ===========================================================================
 # InteractiveSourceSelector.load_source_batch
 # ===========================================================================
+
 
 class TestInteractiveSourceSelectorBatch:
     """Tests for InteractiveSourceSelector.load_source_batch (non-interactive)."""
@@ -1017,7 +1045,8 @@ class TestInteractiveSourceSelectorBatch:
     def test_batch_simple_delegates_to_legacy(self, mocker):
         """Batch load for simple type uses the legacy manager path."""
         mock_legacy_load = mocker.patch.object(
-            MagicMock(), "load_sources",
+            MagicMock(),
+            "load_sources",
             return_value=(_make_extract_definitions(), "ok"),
         )
         selector = InteractiveSourceSelector()
@@ -1032,6 +1061,7 @@ class TestInteractiveSourceSelectorBatch:
 # ===========================================================================
 # Integration: full workflow with new source types
 # ===========================================================================
+
 
 class TestFullWorkflowNewTypes:
     """Integration-style tests for the full workflow with new source types."""

--- a/tests/unit/argumentation_analysis/evaluation/test_benchmark_runner_advanced.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_benchmark_runner_advanced.py
@@ -15,7 +15,10 @@ import pytest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from argumentation_analysis.evaluation.benchmark_runner import BenchmarkRunner, BenchmarkResult
+from argumentation_analysis.evaluation.benchmark_runner import (
+    BenchmarkRunner,
+    BenchmarkResult,
+)
 
 
 @pytest.mark.unit
@@ -320,11 +323,15 @@ class TestRunCell:
         runner.load_dataset_unencrypted(str(dataset_path))
 
         # Mock the run_unified_analysis function
-        with patch("argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis") as mock_run:
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis"
+        ) as mock_run:
             mock_run.return_value = {
                 "phases": {},
                 "summary": {"completed": 1, "total": 1, "failed": 0, "skipped": 0},
-                "unified_state": MagicMock(get_state_snapshot=MagicMock(return_value={"test": "data"})),
+                "unified_state": MagicMock(
+                    get_state_snapshot=MagicMock(return_value={"test": "data"})
+                ),
             }
 
             result = await runner.run_cell(
@@ -343,9 +350,7 @@ class TestRunCell:
     async def test_run_cell_timeout(self, tmp_path):
         """Test that timeout is handled correctly."""
         dataset = {
-            "documents": [
-                {"id": "doc1", "name": "Test", "full_text": "Test text."}
-            ]
+            "documents": [{"id": "doc1", "name": "Test", "full_text": "Test text."}]
         }
 
         dataset_path = tmp_path / "dataset.json"
@@ -365,7 +370,10 @@ class TestRunCell:
             await asyncio.sleep(5)
             return {}
 
-        with patch("argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis", side_effect=slow_analysis):
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            side_effect=slow_analysis,
+        ):
             result = await runner.run_cell(
                 workflow_name="light",
                 model_name="default",
@@ -380,11 +388,7 @@ class TestRunCell:
     @pytest.mark.asyncio
     async def test_run_cell_empty_document(self, tmp_path):
         """Test handling of empty document."""
-        dataset = {
-            "documents": [
-                {"id": "doc1", "name": "Empty Doc", "full_text": ""}
-            ]
-        }
+        dataset = {"documents": [{"id": "doc1", "name": "Empty Doc", "full_text": ""}]}
 
         dataset_path = tmp_path / "dataset.json"
         with open(dataset_path, "w", encoding="utf-8") as f:
@@ -410,9 +414,7 @@ class TestRunCell:
         long_text = "A" * 10000
 
         dataset = {
-            "documents": [
-                {"id": "doc1", "name": "Long Doc", "full_text": long_text}
-            ]
+            "documents": [{"id": "doc1", "name": "Long Doc", "full_text": long_text}]
         }
 
         dataset_path = tmp_path / "dataset.json"
@@ -433,7 +435,10 @@ class TestRunCell:
             captured_text.append(text)
             return asyncio.sleep(0)
 
-        with patch("argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis", side_effect=capture_run):
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            side_effect=capture_run,
+        ):
             await runner.run_cell(
                 workflow_name="light",
                 model_name="default",
@@ -491,7 +496,8 @@ class TestPhaseSerialization:
         serializable = {
             "status": mock_phase.status,
             "capability": getattr(mock_phase, "capability", None),
-            "has_output": hasattr(mock_phase, "output") and mock_phase.output is not None,
+            "has_output": hasattr(mock_phase, "output")
+            and mock_phase.output is not None,
         }
 
         assert serializable["status"] == "completed"

--- a/tests/unit/argumentation_analysis/evaluation/test_cli_runners.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_cli_runners.py
@@ -29,8 +29,13 @@ class TestBaselineBenchmarkArgparse:
     def test_default_arguments(self):
         """Test that default arguments are correctly configured."""
         parser = argparse.ArgumentParser(description="Baseline Capability Benchmark")
-        parser.add_argument("--corpus", default="argumentation_analysis/evaluation/corpus/baseline_corpus_v1.json")
-        parser.add_argument("--output", default="argumentation_analysis/evaluation/results/baseline")
+        parser.add_argument(
+            "--corpus",
+            default="argumentation_analysis/evaluation/corpus/baseline_corpus_v1.json",
+        )
+        parser.add_argument(
+            "--output", default="argumentation_analysis/evaluation/results/baseline"
+        )
         parser.add_argument("--workflows", nargs="+", default=["light", "standard"])
         parser.add_argument("--max-docs", type=int, default=0)
         parser.add_argument("--skip-judge", action="store_true")
@@ -38,7 +43,10 @@ class TestBaselineBenchmarkArgparse:
 
         # Test with no arguments (use defaults)
         args = parser.parse_args([])
-        assert args.corpus == "argumentation_analysis/evaluation/corpus/baseline_corpus_v1.json"
+        assert (
+            args.corpus
+            == "argumentation_analysis/evaluation/corpus/baseline_corpus_v1.json"
+        )
         assert args.output == "argumentation_analysis/evaluation/results/baseline"
         assert args.workflows == ["light", "standard"]
         assert args.max_docs == 0
@@ -55,14 +63,21 @@ class TestBaselineBenchmarkArgparse:
         parser.add_argument("--skip-judge", action="store_true")
         parser.add_argument("--verbose", action="store_true")
 
-        args = parser.parse_args([
-            "--corpus", "custom_corpus.json",
-            "--output", "custom_output",
-            "--workflows", "light", "full",
-            "--max-docs", "10",
-            "--skip-judge",
-            "--verbose"
-        ])
+        args = parser.parse_args(
+            [
+                "--corpus",
+                "custom_corpus.json",
+                "--output",
+                "custom_output",
+                "--workflows",
+                "light",
+                "full",
+                "--max-docs",
+                "10",
+                "--skip-judge",
+                "--verbose",
+            ]
+        )
         assert args.corpus == "custom_corpus.json"
         assert args.output == "custom_output"
         assert args.workflows == ["light", "full"]
@@ -77,10 +92,16 @@ class TestSynergyAnalysisArgparse:
 
     def test_default_arguments(self):
         """Test that default arguments are correctly configured."""
-        parser = argparse.ArgumentParser(description="Synergy Analysis - Optimal Workflow Configuration")
-        parser.add_argument("--results-dir", default="argumentation_analysis/evaluation/results")
+        parser = argparse.ArgumentParser(
+            description="Synergy Analysis - Optimal Workflow Configuration"
+        )
+        parser.add_argument(
+            "--results-dir", default="argumentation_analysis/evaluation/results"
+        )
         parser.add_argument("--output", default=None)
-        parser.add_argument("--format", choices=["json", "markdown", "both"], default="both")
+        parser.add_argument(
+            "--format", choices=["json", "markdown", "both"], default="both"
+        )
         parser.add_argument("--verbose", action="store_true")
 
         args = parser.parse_args([])
@@ -91,18 +112,27 @@ class TestSynergyAnalysisArgparse:
 
     def test_custom_arguments(self):
         """Test that custom arguments are correctly parsed."""
-        parser = argparse.ArgumentParser(description="Synergy Analysis - Optimal Workflow Configuration")
+        parser = argparse.ArgumentParser(
+            description="Synergy Analysis - Optimal Workflow Configuration"
+        )
         parser.add_argument("--results-dir", default="default_results")
         parser.add_argument("--output", default=None)
-        parser.add_argument("--format", choices=["json", "markdown", "both"], default="both")
+        parser.add_argument(
+            "--format", choices=["json", "markdown", "both"], default="both"
+        )
         parser.add_argument("--verbose", action="store_true")
 
-        args = parser.parse_args([
-            "--results-dir", "custom_results",
-            "--output", "custom_report.md",
-            "--format", "markdown",
-            "--verbose"
-        ])
+        args = parser.parse_args(
+            [
+                "--results-dir",
+                "custom_results",
+                "--output",
+                "custom_report.md",
+                "--format",
+                "markdown",
+                "--verbose",
+            ]
+        )
         assert args.results_dir == "custom_results"
         assert args.output == "custom_report.md"
         assert args.format == "markdown"
@@ -110,8 +140,12 @@ class TestSynergyAnalysisArgparse:
 
     def test_invalid_format(self):
         """Test that invalid format is rejected."""
-        parser = argparse.ArgumentParser(description="Synergy Analysis - Optimal Workflow Configuration")
-        parser.add_argument("--format", choices=["json", "markdown", "both"], default="both")
+        parser = argparse.ArgumentParser(
+            description="Synergy Analysis - Optimal Workflow Configuration"
+        )
+        parser.add_argument(
+            "--format", choices=["json", "markdown", "both"], default="both"
+        )
 
         with pytest.raises(SystemExit):
             parser.parse_args(["--format", "invalid"])
@@ -128,17 +162,18 @@ class TestDirectoryCreation:
         assert not output_dir.exists()
 
         # Mock the benchmark components
-        with patch("argumentation_analysis.evaluation.run_baseline_benchmark.ModelRegistry") as mock_registry, \
-             patch("argumentation_analysis.evaluation.run_baseline_benchmark.BenchmarkRunner") as mock_runner:
+        with patch(
+            "argumentation_analysis.evaluation.run_baseline_benchmark.ModelRegistry"
+        ) as mock_registry, patch(
+            "argumentation_analysis.evaluation.run_baseline_benchmark.BenchmarkRunner"
+        ) as mock_runner:
 
             mock_instance = MagicMock()
             mock_runner.return_value = mock_instance
             mock_instance._dataset = []
-            mock_instance.run_cell = AsyncMock(return_value=MagicMock(
-                success=True,
-                duration_seconds=1.0,
-                error=None
-            ))
+            mock_instance.run_cell = AsyncMock(
+                return_value=MagicMock(success=True, duration_seconds=1.0, error=None)
+            )
 
             # Create a minimal corpus file
             corpus_path = tmp_path / "test_corpus.json"
@@ -194,7 +229,7 @@ class TestReportGeneration:
             "workflows": {
                 "light": {"total": 5, "successful": 4, "failed": 1},
                 "standard": {"total": 5, "successful": 4, "failed": 1},
-            }
+            },
         }
 
         summary_path = output_dir / "benchmark_summary.json"
@@ -234,7 +269,7 @@ class TestReportGeneration:
                     phases_failed=0,
                     phases_skipped=0,
                     error=None,
-                    state_snapshot={}
+                    state_snapshot={},
                 )
                 collector.save(result)
 

--- a/tests/unit/argumentation_analysis/evaluation/test_evaluation_module.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_evaluation_module.py
@@ -12,10 +12,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from argumentation_analysis.evaluation.model_registry import ModelConfig, ModelRegistry
-from argumentation_analysis.evaluation.benchmark_runner import BenchmarkResult, BenchmarkRunner
+from argumentation_analysis.evaluation.benchmark_runner import (
+    BenchmarkResult,
+    BenchmarkRunner,
+)
 from argumentation_analysis.evaluation.result_collector import ResultCollector
 from argumentation_analysis.evaluation.judge import LLMJudge, JudgeScore
-
 
 # =====================================================================
 # ModelConfig Tests
@@ -24,16 +26,24 @@ from argumentation_analysis.evaluation.judge import LLMJudge, JudgeScore
 
 class TestModelConfig:
     def test_basic_creation(self):
-        mc = ModelConfig(model_id="gpt-5-mini", base_url="https://api.openai.com/v1", api_key="sk-test")
+        mc = ModelConfig(
+            model_id="gpt-5-mini",
+            base_url="https://api.openai.com/v1",
+            api_key="sk-test",
+        )
         assert mc.model_id == "gpt-5-mini"
         assert mc.display_name == "gpt-5-mini"
 
     def test_custom_display_name(self):
-        mc = ModelConfig(model_id="x", base_url="y", api_key="z", display_name="My Model")
+        mc = ModelConfig(
+            model_id="x", base_url="y", api_key="z", display_name="My Model"
+        )
         assert mc.display_name == "My Model"
 
     def test_thinking_model_flag(self):
-        mc = ModelConfig(model_id="qwen", base_url="u", api_key="k", is_thinking_model=True)
+        mc = ModelConfig(
+            model_id="qwen", base_url="u", api_key="k", is_thinking_model=True
+        )
         assert mc.is_thinking_model is True
 
 
@@ -80,11 +90,15 @@ class TestModelRegistry:
         assert os.environ.get("OPENAI_API_KEY") == original_key
 
     def test_from_env(self):
-        with patch.dict(os.environ, {
-            "OPENAI_API_KEY": "test-key",
-            "OPENAI_CHAT_MODEL_ID": "gpt-test",
-            "OPENAI_BASE_URL": "https://test.api/v1",
-        }, clear=False):
+        with patch.dict(
+            os.environ,
+            {
+                "OPENAI_API_KEY": "test-key",
+                "OPENAI_CHAT_MODEL_ID": "gpt-test",
+                "OPENAI_BASE_URL": "https://test.api/v1",
+            },
+            clear=False,
+        ):
             reg = ModelRegistry.from_env()
             assert "default" in reg.list_models()
 
@@ -113,9 +127,16 @@ class TestBenchmarkResult:
 
     def test_serializable(self):
         r = BenchmarkResult(
-            workflow_name="test", model_name="m", document_index=0,
-            document_name="d", success=True, duration_seconds=0.5,
-            phases_completed=1, phases_total=1, phases_failed=0, phases_skipped=0,
+            workflow_name="test",
+            model_name="m",
+            document_index=0,
+            document_name="d",
+            success=True,
+            duration_seconds=0.5,
+            phases_completed=1,
+            phases_total=1,
+            phases_failed=0,
+            phases_skipped=0,
         )
         data = asdict(r)
         json_str = json.dumps(data)
@@ -133,7 +154,11 @@ class TestBenchmarkRunner:
         reg.register("mock", ModelConfig("mock-model", "http://mock/v1", "mock-key"))
         runner = BenchmarkRunner(reg)
         runner._dataset = [
-            {"source_name": "Test Doc", "full_text": "This is a test argument about policy.", "extracts": []},
+            {
+                "source_name": "Test Doc",
+                "full_text": "This is a test argument about policy.",
+                "extracts": [],
+            },
             {"source_name": "Empty Doc", "full_text": None, "extracts": []},
         ]
         return runner
@@ -167,7 +192,13 @@ class TestBenchmarkRunner:
     async def test_run_cell_success(self):
         runner = self._make_runner_with_dataset()
         mock_result = {
-            "phases": {"p1": MagicMock(status=MagicMock(value="completed"), capability="test", output={"data": 1})},
+            "phases": {
+                "p1": MagicMock(
+                    status=MagicMock(value="completed"),
+                    capability="test",
+                    output={"data": 1},
+                )
+            },
             "summary": {"completed": 1, "total": 1, "failed": 0, "skipped": 0},
             "unified_state": None,
         }
@@ -186,6 +217,7 @@ class TestBenchmarkRunner:
 
         async def slow(*a, **kw):
             import asyncio
+
             await asyncio.sleep(10)
 
         with patch(
@@ -217,9 +249,16 @@ class TestBenchmarkRunner:
 class TestResultCollector:
     def _make_result(self, wf="light", model="test", idx=0, success=True):
         return BenchmarkResult(
-            workflow_name=wf, model_name=model, document_index=idx,
-            document_name=f"doc_{idx}", success=success, duration_seconds=1.0,
-            phases_completed=2, phases_total=3, phases_failed=0, phases_skipped=1,
+            workflow_name=wf,
+            model_name=model,
+            document_index=idx,
+            document_name=f"doc_{idx}",
+            success=success,
+            duration_seconds=1.0,
+            phases_completed=2,
+            phases_total=3,
+            phases_failed=0,
+            phases_skipped=1,
         )
 
     def test_save_and_load(self, tmp_path):
@@ -405,6 +444,7 @@ class TestBaselineCorpus:
     def test_corpus_loads_valid_json(self):
         """Verify the corpus file is valid JSON."""
         import json
+
         with open(self.corpus_path, "r", encoding="utf-8") as f:
             # Strip BOM if present before parsing
             content = f.read()
@@ -416,6 +456,7 @@ class TestBaselineCorpus:
     def test_corpus_has_required_metadata(self):
         """Verify the corpus has all required metadata fields."""
         import json
+
         with open(self.corpus_path, "r", encoding="utf-8") as f:
             content = f.read()
             if content.startswith("\ufeff"):
@@ -432,6 +473,7 @@ class TestBaselineCorpus:
     def test_corpus_metadata_valid(self):
         """Verify corpus metadata contains expected values."""
         import json
+
         with open(self.corpus_path, "r", encoding="utf-8") as f:
             content = f.read()
             if content.startswith("\ufeff"):
@@ -446,6 +488,7 @@ class TestBaselineCorpus:
     def test_corpus_documents_structure(self):
         """Verify each document has the required structure."""
         import json
+
         with open(self.corpus_path, "r", encoding="utf-8") as f:
             content = f.read()
             if content.startswith("\ufeff"):
@@ -469,6 +512,7 @@ class TestBaselineCorpus:
     def test_corpus_document_ids_unique(self):
         """Verify all document IDs are unique."""
         import json
+
         with open(self.corpus_path, "r", encoding="utf-8") as f:
             content = f.read()
             if content.startswith("\ufeff"):
@@ -481,6 +525,7 @@ class TestBaselineCorpus:
     def test_corpus_difficulty_distribution(self):
         """Verify the corpus has documents from all difficulty levels."""
         import json
+
         with open(self.corpus_path, "r", encoding="utf-8") as f:
             content = f.read()
             if content.startswith("\ufeff"):
@@ -500,6 +545,7 @@ class TestBaselineCorpus:
     def test_corpus_fallacy_coverage(self):
         """Verify the corpus covers the expected fallacies."""
         import json
+
         with open(self.corpus_path, "r", encoding="utf-8") as f:
             content = f.read()
             if content.startswith("\ufeff"):
@@ -511,14 +557,14 @@ class TestBaselineCorpus:
 
         # Verify at least some documents have expected fallacies
         docs_with_fallacies = [
-            doc for doc in corpus["documents"]
-            if doc["expected_fallacies"]
+            doc for doc in corpus["documents"] if doc["expected_fallacies"]
         ]
         assert len(docs_with_fallacies) >= 8
 
     def test_corpus_text_not_empty(self):
         """Verify all documents have non-empty text."""
         import json
+
         with open(self.corpus_path, "r", encoding="utf-8") as f:
             content = f.read()
             if content.startswith("\ufeff"):
@@ -531,6 +577,7 @@ class TestBaselineCorpus:
     def test_corpus_sample_document_content(self):
         """Verify a sample document has expected content."""
         import json
+
         with open(self.corpus_path, "r", encoding="utf-8") as f:
             content = f.read()
             if content.startswith("\ufeff"):
@@ -538,14 +585,18 @@ class TestBaselineCorpus:
             corpus = json.loads(content)
 
         # Find corpus_001 (simple political argument, no fallacies)
-        doc_001 = next((d for d in corpus["documents"] if d["id"] == "corpus_001"), None)
+        doc_001 = next(
+            (d for d in corpus["documents"] if d["id"] == "corpus_001"), None
+        )
         assert doc_001 is not None
         assert doc_001["difficulty"] == "easy"
         assert len(doc_001["expected_fallacies"]) == 0
         assert "Monsieur le Président" in doc_001["text"]
 
         # Find corpus_002 (ad hominem, guilt by association)
-        doc_002 = next((d for d in corpus["documents"] if d["id"] == "corpus_002"), None)
+        doc_002 = next(
+            (d for d in corpus["documents"] if d["id"] == "corpus_002"), None
+        )
         assert doc_002 is not None
         assert doc_002["difficulty"] == "medium"
         assert "ad_hominem" in doc_002["expected_fallacies"]
@@ -611,31 +662,35 @@ class TestSynergyAnalyzer:
 
         # Create sample results
         collector = ResultCollector(tmp_path)
-        collector.save(BenchmarkResult(
-            workflow_name="light",
-            model_name="test",
-            document_index=0,
-            document_name="corpus_001",
-            success=True,
-            duration_seconds=1.5,
-            phases_completed=3,
-            phases_total=3,
-            phases_failed=0,
-            phases_skipped=0,
-        ))
-        collector.save(BenchmarkResult(
-            workflow_name="light",
-            model_name="test",
-            document_index=1,
-            document_name="corpus_002",
-            success=False,
-            duration_seconds=0.5,
-            phases_completed=1,
-            phases_total=3,
-            phases_failed=1,
-            phases_skipped=0,
-            error="Test error",
-        ))
+        collector.save(
+            BenchmarkResult(
+                workflow_name="light",
+                model_name="test",
+                document_index=0,
+                document_name="corpus_001",
+                success=True,
+                duration_seconds=1.5,
+                phases_completed=3,
+                phases_total=3,
+                phases_failed=0,
+                phases_skipped=0,
+            )
+        )
+        collector.save(
+            BenchmarkResult(
+                workflow_name="light",
+                model_name="test",
+                document_index=1,
+                document_name="corpus_002",
+                success=False,
+                duration_seconds=0.5,
+                phases_completed=1,
+                phases_total=3,
+                phases_failed=1,
+                phases_skipped=0,
+                error="Test error",
+            )
+        )
 
         analyzer = SynergyAnalyzer(tmp_path)
         metrics = analyzer.analyze_workflow_performance()
@@ -653,18 +708,20 @@ class TestSynergyAnalyzer:
         from argumentation_analysis.evaluation.benchmark_runner import BenchmarkResult
 
         collector = ResultCollector(tmp_path)
-        collector.save(BenchmarkResult(
-            workflow_name="light",
-            model_name="test",
-            document_index=0,
-            document_name="corpus_001",
-            success=True,
-            duration_seconds=1.0,
-            phases_completed=3,
-            phases_total=3,
-            phases_failed=0,
-            phases_skipped=0,
-        ))
+        collector.save(
+            BenchmarkResult(
+                workflow_name="light",
+                model_name="test",
+                document_index=0,
+                document_name="corpus_001",
+                success=True,
+                duration_seconds=1.0,
+                phases_completed=3,
+                phases_total=3,
+                phases_failed=0,
+                phases_skipped=0,
+            )
+        )
 
         analyzer = SynergyAnalyzer(tmp_path)
         comparison = analyzer.compare_workflows()
@@ -694,31 +751,35 @@ class TestSynergyAnalyzer:
         # Create results for multiple workflows
         collector = ResultCollector(tmp_path)
         for idx in range(3):
-            collector.save(BenchmarkResult(
-                workflow_name="light",
-                model_name="test",
-                document_index=idx,
-                document_name=f"corpus_00{idx+1}",
-                success=True,
-                duration_seconds=1.0,
-                phases_completed=3,
-                phases_total=3,
-                phases_failed=0,
-                phases_skipped=0,
-            ))
+            collector.save(
+                BenchmarkResult(
+                    workflow_name="light",
+                    model_name="test",
+                    document_index=idx,
+                    document_name=f"corpus_00{idx+1}",
+                    success=True,
+                    duration_seconds=1.0,
+                    phases_completed=3,
+                    phases_total=3,
+                    phases_failed=0,
+                    phases_skipped=0,
+                )
+            )
         for idx in range(3):
-            collector.save(BenchmarkResult(
-                workflow_name="standard",
-                model_name="test",
-                document_index=idx,
-                document_name=f"corpus_00{idx+1}",
-                success=True,
-                duration_seconds=2.5,
-                phases_completed=5,
-                phases_total=6,
-                phases_failed=0,
-                phases_skipped=1,
-            ))
+            collector.save(
+                BenchmarkResult(
+                    workflow_name="standard",
+                    model_name="test",
+                    document_index=idx,
+                    document_name=f"corpus_00{idx+1}",
+                    success=True,
+                    duration_seconds=2.5,
+                    phases_completed=5,
+                    phases_total=6,
+                    phases_failed=0,
+                    phases_skipped=1,
+                )
+            )
 
         analyzer = SynergyAnalyzer(tmp_path)
         recommendations = analyzer.generate_recommendations()
@@ -741,18 +802,20 @@ class TestSynergyAnalyzer:
 
         # Add sample data
         collector = ResultCollector(tmp_path)
-        collector.save(BenchmarkResult(
-            workflow_name="light",
-            model_name="test",
-            document_index=0,
-            document_name="corpus_001",
-            success=True,
-            duration_seconds=1.0,
-            phases_completed=3,
-            phases_total=3,
-            phases_failed=0,
-            phases_skipped=0,
-        ))
+        collector.save(
+            BenchmarkResult(
+                workflow_name="light",
+                model_name="test",
+                document_index=0,
+                document_name="corpus_001",
+                success=True,
+                duration_seconds=1.0,
+                phases_completed=3,
+                phases_total=3,
+                phases_failed=0,
+                phases_skipped=0,
+            )
+        )
 
         analyzer = SynergyAnalyzer(tmp_path)
         report_path = analyzer.generate_report()
@@ -773,18 +836,20 @@ class TestSynergyAnalyzer:
 
         # Add sample data
         collector = ResultCollector(tmp_path)
-        collector.save(BenchmarkResult(
-            workflow_name="light",
-            model_name="test",
-            document_index=0,
-            document_name="corpus_001",
-            success=True,
-            duration_seconds=1.0,
-            phases_completed=3,
-            phases_total=3,
-            phases_failed=0,
-            phases_skipped=0,
-        ))
+        collector.save(
+            BenchmarkResult(
+                workflow_name="light",
+                model_name="test",
+                document_index=0,
+                document_name="corpus_001",
+                success=True,
+                duration_seconds=1.0,
+                phases_completed=3,
+                phases_total=3,
+                phases_failed=0,
+                phases_skipped=0,
+            )
+        )
 
         analyzer = SynergyAnalyzer(tmp_path)
         report_path = analyzer.export_markdown_report()

--- a/tests/unit/argumentation_analysis/evaluation/test_fallacy_benchmark.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_fallacy_benchmark.py
@@ -263,7 +263,7 @@ class TestBenchmarkReport:
         assert len(report.mode_scores) == 3
         for mode in ["free", "one_shot", "constrained"]:
             assert mode in report.mode_scores
-            assert report.mode_scores[mode]["exact_pk_accuracy"] == pytest.approx(1/3)
+            assert report.mode_scores[mode]["exact_pk_accuracy"] == pytest.approx(1 / 3)
 
 
 @pytest.mark.unit
@@ -360,7 +360,9 @@ class TestFamilyLookup:
     def test_get_family_for_unknown_pk(self, tmp_path):
         """Test getting family for non-existent PK."""
         taxonomy_path = tmp_path / "taxonomy.csv"
-        taxonomy_path.write_text("PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8")
+        taxonomy_path.write_text(
+            "PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8"
+        )
 
         runner = FallacyBenchmarkRunner(taxonomy_path=str(taxonomy_path))
 
@@ -385,12 +387,12 @@ class TestJSONParsing:
     def test_parse_json_markdown_block(self):
         """Test parsing JSON from markdown code block."""
         runner = FallacyBenchmarkRunner()
-        raw = '''```json
+        raw = """```json
 {
   "fallacy_name_fr": "Appel à l'ignorance",
   "confidence": 0.9
 }
-```'''
+```"""
 
         result = runner._parse_json(raw)
 
@@ -400,9 +402,9 @@ class TestJSONParsing:
     def test_parse_json_without_language(self):
         """Test parsing JSON from markdown without language specifier."""
         runner = FallacyBenchmarkRunner()
-        raw = '''```
+        raw = """```
 {"taxonomy_pk": "4", "confidence": 1.0}
-```'''
+```"""
 
         result = runner._parse_json(raw)
 
@@ -411,11 +413,11 @@ class TestJSONParsing:
     def test_parse_json_with_text_before(self):
         """Test parsing JSON when there's text before."""
         runner = FallacyBenchmarkRunner()
-        raw = '''Here is my analysis:
+        raw = """Here is my analysis:
 
 {"fallacy_name_fr": "Test", "confidence": 0.5}
 
-Hope this helps.'''
+Hope this helps."""
 
         result = runner._parse_json(raw)
 
@@ -448,24 +450,21 @@ class TestNameSimilarity:
     def test_identical_names(self):
         """Test similarity with identical names."""
         sim = FallacyBenchmarkRunner._name_similarity(
-            "Appel à l'ignorance",
-            "Appel à l'ignorance"
+            "Appel à l'ignorance", "Appel à l'ignorance"
         )
         assert sim == 1.0
 
     def test_completely_different_names(self):
         """Test similarity with completely different names."""
         sim = FallacyBenchmarkRunner._name_similarity(
-            "Appel à l'ignorance",
-            "Rationalisation"
+            "Appel à l'ignorance", "Rationalisation"
         )
         assert sim == 0.0
 
     def test_partial_overlap(self):
         """Test similarity with partial word overlap."""
         sim = FallacyBenchmarkRunner._name_similarity(
-            "Appel à l'ignorance",
-            "Appel à l'autorité"
+            "Appel à l'ignorance", "Appel à l'autorité"
         )
         # Words: {appel, à, l'ignorance} ∩ {appel, à, l'autorité} = {appel, à}
         # Union: {appel, à, l'ignorance, l'autorité}
@@ -476,8 +475,7 @@ class TestNameSimilarity:
     def test_case_insensitive(self):
         """Test that comparison is case-insensitive."""
         sim = FallacyBenchmarkRunner._name_similarity(
-            "Appel à l'ignorance",
-            "APPEL À L'IGNORANCE"
+            "Appel à l'ignorance", "APPEL À L'IGNORANCE"
         )
         assert sim == 1.0
 
@@ -574,15 +572,16 @@ class TestResultScoring:
         scored = runner._score_result(case, "constrained", result, 1.0)
 
         assert scored.exact_pk_match is False
-        assert scored.family_match is False  # Different families (Insuffisance vs Influence)
+        assert (
+            scored.family_match is False
+        )  # Different families (Insuffisance vs Influence)
         assert scored.name_similarity < 0.5
 
     def test_depth_reached(self, tmp_path):
         """Test depth reached calculation."""
         taxonomy_path = tmp_path / "taxonomy.csv"
         taxonomy_path.write_text(
-            "PK,nom_vulgarisé,text_fr,depth,path\n"
-            "4,Test,Test,4,1.2.4\n",
+            "PK,nom_vulgarisé,text_fr,depth,path\n" "4,Test,Test,4,1.2.4\n",
             encoding="utf-8",
         )
 
@@ -598,7 +597,9 @@ class TestResultScoring:
     def test_confidence_extraction(self, tmp_path):
         """Test confidence value extraction."""
         taxonomy_path = tmp_path / "taxonomy.csv"
-        taxonomy_path.write_text("PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8")
+        taxonomy_path.write_text(
+            "PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8"
+        )
 
         runner = FallacyBenchmarkRunner(taxonomy_path=str(taxonomy_path))
 
@@ -612,7 +613,9 @@ class TestResultScoring:
     def test_error_handling(self, tmp_path):
         """Test scoring with error result."""
         taxonomy_path = tmp_path / "taxonomy.csv"
-        taxonomy_path.write_text("PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8")
+        taxonomy_path.write_text(
+            "PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8"
+        )
 
         runner = FallacyBenchmarkRunner(taxonomy_path=str(taxonomy_path))
 
@@ -633,7 +636,9 @@ class TestModeRunners:
     async def test_mode_a_free(self, tmp_path):
         """Test Mode A: Free LLM detection."""
         taxonomy_path = tmp_path / "taxonomy.csv"
-        taxonomy_path.write_text("PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8")
+        taxonomy_path.write_text(
+            "PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8"
+        )
 
         runner = FallacyBenchmarkRunner(taxonomy_path=str(taxonomy_path))
 
@@ -642,7 +647,13 @@ class TestModeRunners:
             mock_instance = MagicMock()
             mock_instance.chat.completions.create = AsyncMock(
                 return_value=MagicMock(
-                    choices=[MagicMock(message=MagicMock(content='{"fallacy_name_fr": "Test", "confidence": 0.8}'))]
+                    choices=[
+                        MagicMock(
+                            message=MagicMock(
+                                content='{"fallacy_name_fr": "Test", "confidence": 0.8}'
+                            )
+                        )
+                    ]
                 )
             )
             mock_client.return_value = mock_instance
@@ -657,8 +668,7 @@ class TestModeRunners:
         """Test Mode B: One-shot with taxonomy."""
         taxonomy_path = tmp_path / "taxonomy.csv"
         taxonomy_path.write_text(
-            "PK,nom_vulgarisé,text_fr,depth,path\n"
-            "4,Test,Test,4,1.2.4\n",
+            "PK,nom_vulgarisé,text_fr,depth,path\n" "4,Test,Test,4,1.2.4\n",
             encoding="utf-8",
         )
 
@@ -668,7 +678,13 @@ class TestModeRunners:
             mock_instance = MagicMock()
             mock_instance.chat.completions.create = AsyncMock(
                 return_value=MagicMock(
-                    choices=[MagicMock(message=MagicMock(content='{"taxonomy_pk": "4", "fallacy_name_fr": "Test"}'))]
+                    choices=[
+                        MagicMock(
+                            message=MagicMock(
+                                content='{"taxonomy_pk": "4", "fallacy_name_fr": "Test"}'
+                            )
+                        )
+                    ]
                 )
             )
             mock_client.return_value = mock_instance
@@ -684,8 +700,7 @@ class TestModeRunners:
         """Test Mode C: Constrained workflow (requires API)."""
         taxonomy_path = tmp_path / "taxonomy.csv"
         taxonomy_path.write_text(
-            "PK,nom_vulgarisé,text_fr,depth,path\n"
-            "4,Test,Test,4,1.2.4\n",
+            "PK,nom_vulgarisé,text_fr,depth,path\n" "4,Test,Test,4,1.2.4\n",
             encoding="utf-8",
         )
 
@@ -718,11 +733,20 @@ class TestBenchmarkExecution:
 
         # Mock all three mode runners
         async def mock_mode(text):
-            return {"taxonomy_pk": "4", "fallacy_name_fr": "Test", "confidence": 0.8, "justification": "OK"}
+            return {
+                "taxonomy_pk": "4",
+                "fallacy_name_fr": "Test",
+                "confidence": 0.8,
+                "justification": "OK",
+            }
 
-        with patch.object(runner, "run_mode_a_free", side_effect=mock_mode), \
-             patch.object(runner, "run_mode_b_one_shot", side_effect=mock_mode), \
-             patch.object(runner, "run_mode_c_constrained", side_effect=mock_mode):
+        with patch.object(
+            runner, "run_mode_a_free", side_effect=mock_mode
+        ), patch.object(
+            runner, "run_mode_b_one_shot", side_effect=mock_mode
+        ), patch.object(
+            runner, "run_mode_c_constrained", side_effect=mock_mode
+        ):
 
             # Run single case
             report = await runner.run_benchmark(
@@ -739,7 +763,9 @@ class TestBenchmarkExecution:
     async def test_run_benchmark_parallel(self, tmp_path):
         """Test parallel benchmark execution."""
         taxonomy_path = tmp_path / "taxonomy.csv"
-        taxonomy_path.write_text("PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8")
+        taxonomy_path.write_text(
+            "PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8"
+        )
 
         runner = FallacyBenchmarkRunner(taxonomy_path=str(taxonomy_path))
 
@@ -747,9 +773,13 @@ class TestBenchmarkExecution:
             await asyncio.sleep(0.01)  # Simulate work
             return {"taxonomy_pk": "4", "confidence": 0.8}
 
-        with patch.object(runner, "run_mode_a_free", side_effect=mock_mode), \
-             patch.object(runner, "run_mode_b_one_shot", side_effect=mock_mode), \
-             patch.object(runner, "run_mode_c_constrained", side_effect=mock_mode):
+        with patch.object(
+            runner, "run_mode_a_free", side_effect=mock_mode
+        ), patch.object(
+            runner, "run_mode_b_one_shot", side_effect=mock_mode
+        ), patch.object(
+            runner, "run_mode_c_constrained", side_effect=mock_mode
+        ):
 
             report = await runner.run_benchmark(
                 cases=[BENCHMARK_CASES[0], BENCHMARK_CASES[1]],
@@ -764,7 +794,9 @@ class TestBenchmarkExecution:
     async def test_run_benchmark_with_errors(self, tmp_path):
         """Test benchmark with error handling."""
         taxonomy_path = tmp_path / "taxonomy.csv"
-        taxonomy_path.write_text("PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8")
+        taxonomy_path.write_text(
+            "PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8"
+        )
 
         runner = FallacyBenchmarkRunner(taxonomy_path=str(taxonomy_path))
 
@@ -774,8 +806,9 @@ class TestBenchmarkExecution:
         async def working_mode(text):
             return {"taxonomy_pk": "4", "confidence": 0.9}
 
-        with patch.object(runner, "run_mode_a_free", side_effect=failing_mode), \
-             patch.object(runner, "run_mode_b_one_shot", side_effect=working_mode):
+        with patch.object(
+            runner, "run_mode_a_free", side_effect=failing_mode
+        ), patch.object(runner, "run_mode_b_one_shot", side_effect=working_mode):
 
             report = await runner.run_benchmark(
                 cases=[BENCHMARK_CASES[0]],
@@ -789,7 +822,9 @@ class TestBenchmarkExecution:
             assert free_result.error == "Simulated error"
 
             # one_shot mode should succeed
-            one_shot_result = next((r for r in report.results if r.mode == "one_shot"), None)
+            one_shot_result = next(
+                (r for r in report.results if r.mode == "one_shot"), None
+            )
             assert one_shot_result is not None
             assert one_shot_result.error == ""
 
@@ -797,16 +832,22 @@ class TestBenchmarkExecution:
     async def test_run_benchmark_default_params(self, tmp_path):
         """Test benchmark with default parameters."""
         taxonomy_path = tmp_path / "taxonomy.csv"
-        taxonomy_path.write_text("PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8")
+        taxonomy_path.write_text(
+            "PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8"
+        )
 
         runner = FallacyBenchmarkRunner(taxonomy_path=str(taxonomy_path))
 
         async def mock_mode(text):
             return {"taxonomy_pk": "4"}
 
-        with patch.object(runner, "run_mode_a_free", side_effect=mock_mode), \
-             patch.object(runner, "run_mode_b_one_shot", side_effect=mock_mode), \
-             patch.object(runner, "run_mode_c_constrained", side_effect=mock_mode):
+        with patch.object(
+            runner, "run_mode_a_free", side_effect=mock_mode
+        ), patch.object(
+            runner, "run_mode_b_one_shot", side_effect=mock_mode
+        ), patch.object(
+            runner, "run_mode_c_constrained", side_effect=mock_mode
+        ):
 
             # Use default cases and modes
             report = await runner.run_benchmark(concurrency=1)
@@ -841,7 +882,9 @@ class TestReportGeneration:
         report.summary = "# Test Report\n"
 
         taxonomy_path = tmp_path / "taxonomy.csv"
-        taxonomy_path.write_text("PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8")
+        taxonomy_path.write_text(
+            "PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8"
+        )
 
         runner = FallacyBenchmarkRunner(taxonomy_path=str(taxonomy_path))
 
@@ -862,16 +905,22 @@ class TestReportGeneration:
     async def test_summary_generation(self, tmp_path):
         """Test that summary is correctly generated."""
         taxonomy_path = tmp_path / "taxonomy.csv"
-        taxonomy_path.write_text("PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8")
+        taxonomy_path.write_text(
+            "PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8"
+        )
 
         runner = FallacyBenchmarkRunner(taxonomy_path=str(taxonomy_path))
 
         async def mock_mode(text):
             return {"taxonomy_pk": "4", "fallacy_name_fr": "Test", "confidence": 0.8}
 
-        with patch.object(runner, "run_mode_a_free", side_effect=mock_mode), \
-             patch.object(runner, "run_mode_b_one_shot", side_effect=mock_mode), \
-             patch.object(runner, "run_mode_c_constrained", side_effect=mock_mode):
+        with patch.object(
+            runner, "run_mode_a_free", side_effect=mock_mode
+        ), patch.object(
+            runner, "run_mode_b_one_shot", side_effect=mock_mode
+        ), patch.object(
+            runner, "run_mode_c_constrained", side_effect=mock_mode
+        ):
 
             report = await runner.run_benchmark(
                 cases=[BENCHMARK_CASES[0]],
@@ -893,7 +942,9 @@ class TestConcurrencyControl:
     async def test_semaphore_limits_concurrency(self, tmp_path):
         """Test that semaphore limits concurrent executions."""
         taxonomy_path = tmp_path / "taxonomy.csv"
-        taxonomy_path.write_text("PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8")
+        taxonomy_path.write_text(
+            "PK,nom_vulgarisé,text_fr,depth,path\n", encoding="utf-8"
+        )
 
         runner = FallacyBenchmarkRunner(taxonomy_path=str(taxonomy_path))
 
@@ -908,9 +959,13 @@ class TestConcurrencyControl:
             concurrent_count -= 1
             return {"taxonomy_pk": "4"}
 
-        with patch.object(runner, "run_mode_a_free", side_effect=counting_mode), \
-             patch.object(runner, "run_mode_b_one_shot", side_effect=counting_mode), \
-             patch.object(runner, "run_mode_c_constrained", side_effect=counting_mode):
+        with patch.object(
+            runner, "run_mode_a_free", side_effect=counting_mode
+        ), patch.object(
+            runner, "run_mode_b_one_shot", side_effect=counting_mode
+        ), patch.object(
+            runner, "run_mode_c_constrained", side_effect=counting_mode
+        ):
 
             # Run 6 tasks with concurrency limit of 2
             await runner.run_benchmark(
@@ -948,9 +1003,13 @@ class TestBenchmarkIntegration:
                 "justification": "Mock detection",
             }
 
-        with patch.object(runner, "run_mode_a_free", side_effect=mock_mode), \
-             patch.object(runner, "run_mode_b_one_shot", side_effect=mock_mode), \
-             patch.object(runner, "run_mode_c_constrained", side_effect=mock_mode):
+        with patch.object(
+            runner, "run_mode_a_free", side_effect=mock_mode
+        ), patch.object(
+            runner, "run_mode_b_one_shot", side_effect=mock_mode
+        ), patch.object(
+            runner, "run_mode_c_constrained", side_effect=mock_mode
+        ):
 
             # Run benchmark
             report = await runner.run_benchmark(

--- a/tests/unit/argumentation_analysis/evaluation/test_judge_advanced.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_judge_advanced.py
@@ -78,7 +78,7 @@ class TestJSONParsing:
     def test_parse_json_markdown_block(self):
         """Test parsing JSON from markdown code block."""
         judge = LLMJudge()
-        raw = '''```json
+        raw = """```json
 {
   "completeness": 4,
   "accuracy": 4,
@@ -88,7 +88,7 @@ class TestJSONParsing:
   "overall": 4,
   "reasoning": "Good analysis"
 }
-```'''
+```"""
 
         parsed = judge._parse_json_response(raw)
 
@@ -98,12 +98,12 @@ class TestJSONParsing:
     def test_parse_json_markdown_no_language(self):
         """Test parsing JSON from markdown without language specifier."""
         judge = LLMJudge()
-        raw = '''```
+        raw = """```
 {
   "completeness": 5,
   "overall": 5
 }
-```'''
+```"""
 
         parsed = judge._parse_json_response(raw)
 
@@ -113,11 +113,11 @@ class TestJSONParsing:
     def test_parse_json_with_text_before(self):
         """Test parsing JSON when there's text before the JSON."""
         judge = LLMJudge()
-        raw = '''Here's my evaluation:
+        raw = """Here's my evaluation:
 
 {"completeness": 4, "overall": 4, "reasoning": "Test"}
 
-Hope this helps!'''
+Hope this helps!"""
 
         parsed = judge._parse_json_response(raw)
 
@@ -136,10 +136,10 @@ Hope this helps!'''
     def test_parse_malformed_json_fallback(self):
         """Test fallback extraction of JSON from malformed response."""
         judge = LLMJudge()
-        raw = '''The scores are:
+        raw = """The scores are:
 completeness: 4
 accuracy: 3
-{"completeness": 4, "overall": 4}'''
+{"completeness": 4, "overall": 4}"""
 
         parsed = judge._parse_json_response(raw)
 
@@ -258,8 +258,12 @@ class TestLargeResultProcessing:
 
         # Create a large result set
         large_results = {
-            "arguments": [{"id": f"arg_{i}", "text": "Argument text"} for i in range(100)],
-            "fallacies": [{"name": f"fallacy_{i}", "confidence": 0.5} for i in range(50)],
+            "arguments": [
+                {"id": f"arg_{i}", "text": "Argument text"} for i in range(100)
+            ],
+            "fallacies": [
+                {"name": f"fallacy_{i}", "confidence": 0.5} for i in range(50)
+            ],
             "raw_text": "A" * 10000,
         }
 
@@ -275,9 +279,7 @@ class TestLargeResultProcessing:
         judge = LLMJudge()
 
         # Create results that would exceed the limit
-        large_results = {
-            "data": ["item_" + str(i) for i in range(1000)]
-        }
+        large_results = {"data": ["item_" + str(i) for i in range(1000)]}
 
         prepared = judge._prepare_results_for_judge(large_results)
         results_str = json.dumps(prepared, indent=2, ensure_ascii=False, default=str)
@@ -336,7 +338,9 @@ class TestEvaluateMethod:
         # Mock OpenAI client with delay
         async def slow_completion(*args, **kwargs):
             await asyncio.sleep(5)
-            return MagicMock(choices=[MagicMock(message=MagicMock(content='{"overall": 4}') )])
+            return MagicMock(
+                choices=[MagicMock(message=MagicMock(content='{"overall": 4}'))]
+            )
 
         with patch("openai.AsyncOpenAI") as mock_client:
             mock_instance = MagicMock()

--- a/tests/unit/argumentation_analysis/evaluation/test_result_collector_advanced.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_result_collector_advanced.py
@@ -209,7 +209,7 @@ class TestUnicodeHandling:
             state_snapshot={
                 "status": "✅ Success",
                 "flags": ["🔍 Analysis", "📊 Results", "⚠️ Warning"],
-                "metrics": {"quality": "🌟 Excellent"}
+                "metrics": {"quality": "🌟 Excellent"},
             },
         )
         collector.save(result)
@@ -524,9 +524,7 @@ class TestQueryFiltering:
 
         # Query with combined filters
         results = collector.query(
-            workflow_name="light",
-            model_name="gpt-4",
-            success_only=True
+            workflow_name="light", model_name="gpt-4", success_only=True
         )
         assert len(results) == 1  # Only one result matches all criteria
         assert results[0]["workflow_name"] == "light"

--- a/tests/unit/argumentation_analysis/evaluation/test_synergy_analyzer_advanced.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_synergy_analyzer_advanced.py
@@ -91,7 +91,9 @@ class TestWorkflowMetrics:
                     document_index=i,
                     document_name=f"{workflow}_doc{i}.txt",
                     success=True,
-                    duration_seconds=workflow_durations[workflow],  # Different durations per workflow
+                    duration_seconds=workflow_durations[
+                        workflow
+                    ],  # Different durations per workflow
                     phases_completed=len(WORKFLOW_PHASES[workflow]),
                     phases_total=len(WORKFLOW_PHASES[workflow]),
                     phases_failed=0,
@@ -292,7 +294,9 @@ class TestRecommendations:
         recommendations = analyzer.generate_recommendations()
 
         # Should have at least quick_assessment recommendation
-        quick_rec = next((r for r in recommendations if r.use_case == "quick_assessment"), None)
+        quick_rec = next(
+            (r for r in recommendations if r.use_case == "quick_assessment"), None
+        )
         assert quick_rec is not None
         assert quick_rec.recommended_workflow == "light"
         assert quick_rec.confidence > 0
@@ -345,7 +349,9 @@ class TestRecommendations:
         recommendations = analyzer.generate_recommendations()
 
         # Should have thorough_analysis recommendation
-        thorough_rec = next((r for r in recommendations if r.use_case == "thorough_analysis"), None)
+        thorough_rec = next(
+            (r for r in recommendations if r.use_case == "thorough_analysis"), None
+        )
         assert thorough_rec is not None
         assert thorough_rec.recommended_workflow == "standard"
         assert "completion" in thorough_rec.reasoning.lower()

--- a/tests/unit/argumentation_analysis/models/test_agent_communication_model.py
+++ b/tests/unit/argumentation_analysis/models/test_agent_communication_model.py
@@ -21,7 +21,6 @@ from argumentation_analysis.models.agent_communication_model import (
     create_sync_request_message,
 )
 
-
 # ── Enums ──
 
 
@@ -92,8 +91,8 @@ class TestMessageMetadata:
 
     def test_increment_retry(self):
         m = self._make_metadata(max_retries=2)
-        assert m.increment_retry() is True   # retry_count = 1
-        assert m.increment_retry() is True   # retry_count = 2
+        assert m.increment_retry() is True  # retry_count = 1
+        assert m.increment_retry() is True  # retry_count = 2
         assert m.increment_retry() is False  # retry_count = 3 > max_retries=2
 
     def test_is_expired_no_timeout(self):
@@ -333,7 +332,9 @@ class TestCommunicationProtocol:
 
     def test_can_send_unsupported_type(self, protocol):
         protocol.add_agent("sherlock")
-        ok, reason = protocol.can_send_message("sherlock", MessageType.ERROR_NOTIFICATION)
+        ok, reason = protocol.can_send_message(
+            "sherlock", MessageType.ERROR_NOTIFICATION
+        )
         assert ok is False
         assert "non supporté" in reason
 
@@ -347,8 +348,10 @@ class TestCommunicationProtocol:
     def test_validate_message_valid(self, protocol):
         protocol.add_agent("sherlock")
         metadata = MessageMetadata(
-            message_id="", timestamp=datetime.now(),
-            sender_id="sherlock", receiver_id="watson",
+            message_id="",
+            timestamp=datetime.now(),
+            sender_id="sherlock",
+            receiver_id="watson",
             message_type=MessageType.BELIEF_SHARE,
             priority=MessagePriority.NORMAL,
         )
@@ -362,8 +365,10 @@ class TestCommunicationProtocol:
 
     def test_validate_message_non_participant(self, protocol):
         metadata = MessageMetadata(
-            message_id="", timestamp=datetime.now(),
-            sender_id="unknown", receiver_id="watson",
+            message_id="",
+            timestamp=datetime.now(),
+            sender_id="unknown",
+            receiver_id="watson",
             message_type=MessageType.BELIEF_SHARE,
             priority=MessagePriority.NORMAL,
         )
@@ -577,7 +582,11 @@ class TestIntegration:
 
         # Create validation request
         msg = create_validation_request_message(
-            "sherlock", "watson", "b1", {"strict": True}, "session1",
+            "sherlock",
+            "watson",
+            "b1",
+            {"strict": True},
+            "session1",
         )
 
         # Validate message

--- a/tests/unit/argumentation_analysis/models/test_extended_belief_model.py
+++ b/tests/unit/argumentation_analysis/models/test_extended_belief_model.py
@@ -16,18 +16,24 @@ from argumentation_analysis.models.extended_belief_model import (
     ExtendedBeliefModel,
 )
 
-
 # ============================================================
 # BeliefType enum
 # ============================================================
+
 
 class TestBeliefType:
     """Tests for the BeliefType enum."""
 
     def test_all_values(self):
         expected = {
-            "fact", "hypothesis", "evidence", "deduction",
-            "assumption", "constraint", "validation", "critique",
+            "fact",
+            "hypothesis",
+            "evidence",
+            "deduction",
+            "assumption",
+            "constraint",
+            "validation",
+            "critique",
         }
         assert {bt.value for bt in BeliefType} == expected
 
@@ -46,6 +52,7 @@ class TestBeliefType:
 # ============================================================
 # ConfidenceLevel enum
 # ============================================================
+
 
 class TestConfidenceLevel:
     """Tests for the ConfidenceLevel enum."""
@@ -94,11 +101,18 @@ class TestConfidenceLevel:
 # EvidenceQuality enum
 # ============================================================
 
+
 class TestEvidenceQuality:
     """Tests for the EvidenceQuality enum."""
 
     def test_all_values(self):
-        expected = {"unreliable", "circumstantial", "corroborated", "verified", "proven"}
+        expected = {
+            "unreliable",
+            "circumstantial",
+            "corroborated",
+            "verified",
+            "proven",
+        }
         assert {eq.value for eq in EvidenceQuality} == expected
 
     def test_from_value(self):
@@ -111,6 +125,7 @@ class TestEvidenceQuality:
 # ============================================================
 # ModificationHistory
 # ============================================================
+
 
 class TestModificationHistory:
     """Tests for the ModificationHistory dataclass."""
@@ -195,6 +210,7 @@ class TestModificationHistory:
 # ============================================================
 # BeliefMetadata
 # ============================================================
+
 
 class TestBeliefMetadata:
     """Tests for the BeliefMetadata dataclass."""
@@ -340,6 +356,7 @@ class TestBeliefMetadata:
 # ExtendedBeliefModel
 # ============================================================
 
+
 class TestExtendedBeliefModel:
     """Tests for the ExtendedBeliefModel dataclass."""
 
@@ -381,7 +398,9 @@ class TestExtendedBeliefModel:
         assert default_belief.metadata is not None
         assert default_belief.metadata.belief_type is BeliefType.FACT
         assert default_belief.metadata.source_agent == "unknown"
-        assert default_belief.metadata.evidence_quality is EvidenceQuality.CIRCUMSTANTIAL
+        assert (
+            default_belief.metadata.evidence_quality is EvidenceQuality.CIRCUMSTANTIAL
+        )
 
     def test_creation_records_history(self, default_belief):
         assert len(default_belief.modification_history) >= 1
@@ -404,7 +423,11 @@ class TestExtendedBeliefModel:
         assert sample_belief.confidence == 0.9
         assert sample_belief.metadata.confidence_level is ConfidenceLevel.VERY_HIGH
         # History should have creation + update
-        updates = [m for m in sample_belief.modification_history if m.modification_type == "updated"]
+        updates = [
+            m
+            for m in sample_belief.modification_history
+            if m.modification_type == "updated"
+        ]
         assert len(updates) == 1
         assert updates[0].previous_confidence == 0.75
         assert updates[0].new_confidence == 0.9
@@ -499,7 +522,10 @@ class TestExtendedBeliefModel:
         assert summary["total_modifications"] >= 2
         assert "created" in summary["modification_types"]
         assert "updated" in summary["modification_types"]
-        assert "watson" in summary["involved_agents"] or "unknown" in summary["involved_agents"]
+        assert (
+            "watson" in summary["involved_agents"]
+            or "unknown" in summary["involved_agents"]
+        )
 
     def test_is_consistent_with_no_conflict(self, sample_belief, default_belief):
         report = sample_belief.is_consistent_with(default_belief)
@@ -510,7 +536,10 @@ class TestExtendedBeliefModel:
             belief_id="b1", belief_name="guilty", content="Guilty", confidence=0.8
         )
         b2 = ExtendedBeliefModel(
-            belief_id="b2", belief_name="not_guilty", content="Not guilty", confidence=0.8
+            belief_id="b2",
+            belief_name="not_guilty",
+            content="Not guilty",
+            confidence=0.8,
         )
         report = b1.is_consistent_with(b2)
         assert report["is_consistent"] is False
@@ -518,7 +547,10 @@ class TestExtendedBeliefModel:
 
     def test_is_consistent_with_direct_contradiction_reversed(self):
         b1 = ExtendedBeliefModel(
-            belief_id="b1", belief_name="not_guilty", content="Not guilty", confidence=0.8
+            belief_id="b1",
+            belief_name="not_guilty",
+            content="Not guilty",
+            confidence=0.8,
         )
         b2 = ExtendedBeliefModel(
             belief_id="b2", belief_name="guilty", content="Guilty", confidence=0.8

--- a/tests/unit/argumentation_analysis/models/test_investigation_session_model.py
+++ b/tests/unit/argumentation_analysis/models/test_investigation_session_model.py
@@ -14,8 +14,8 @@ from argumentation_analysis.models.investigation_session_model import (
     InvestigationSessionModel,
 )
 
-
 # ── Enums ──
+
 
 class TestEnums:
     def test_session_status_values(self):
@@ -34,6 +34,7 @@ class TestEnums:
 
 
 # ── SessionCheckpoint ──
+
 
 class TestSessionCheckpoint:
     def test_auto_id_generation(self):
@@ -96,6 +97,7 @@ class TestSessionCheckpoint:
 
 # ── SessionSummary ──
 
+
 class TestSessionSummary:
     @pytest.fixture
     def summary(self):
@@ -152,6 +154,7 @@ class TestSessionSummary:
 
 
 # ── InvestigationSessionModel ──
+
 
 class TestInvestigationSessionModel:
     @pytest.fixture
@@ -259,7 +262,9 @@ class TestInvestigationSessionModel:
 
     # -- Beliefs --
     def test_add_session_belief(self, session):
-        assert session.add_session_belief("b1", {"content": "suspect"}, "sherlock") is True
+        assert (
+            session.add_session_belief("b1", {"content": "suspect"}, "sherlock") is True
+        )
         assert "b1" in session.session_beliefs
         assert session.session_statistics["beliefs_created"] == 1
 
@@ -286,7 +291,10 @@ class TestInvestigationSessionModel:
 
     # -- Hypotheses --
     def test_add_hypothesis(self, session):
-        assert session.add_hypothesis("h1", {"text": "Colonel Mustard"}, "sherlock") is True
+        assert (
+            session.add_hypothesis("h1", {"text": "Colonel Mustard"}, "sherlock")
+            is True
+        )
         assert "h1" in session.hypotheses_under_test
         assert session.session_statistics["hypotheses_formulated"] == 1
 
@@ -384,10 +392,12 @@ class TestInvestigationSessionModel:
 
     def test_update_consistency_with_conflicts(self, session):
         session.start_phase("test")
-        session.update_consistency_state({
-            "is_consistent": False,
-            "conflicts": ["c1", "c2"],
-        })
+        session.update_consistency_state(
+            {
+                "is_consistent": False,
+                "conflicts": ["c1", "c2"],
+            }
+        )
         assert session.session_statistics["conflicts_detected"] == 2
 
     # -- Metrics --
@@ -433,6 +443,7 @@ class TestInvestigationSessionModel:
 
 # ── Integration ──
 
+
 class TestInvestigationIntegration:
     def test_full_investigation_lifecycle(self):
         """Full Cluedo investigation: register, start, evidence, hypotheses, validate, complete."""
@@ -463,7 +474,9 @@ class TestInvestigationIntegration:
         session.end_phase()
 
         # Link evidence
-        session.link_evidence_to_hypothesis("fingerprint_kitchen", "h_mustard", "supports")
+        session.link_evidence_to_hypothesis(
+            "fingerprint_kitchen", "h_mustard", "supports"
+        )
         session.link_evidence_to_hypothesis("weapon_rope", "h_plum", "contradicts")
 
         # Validation phase
@@ -473,10 +486,12 @@ class TestInvestigationIntegration:
         session.end_phase()
 
         # Complete
-        summary = session.complete_session({
-            "solution": "Colonel Mustard in the Kitchen with the Rope",
-            "confidence": 0.95,
-        })
+        summary = session.complete_session(
+            {
+                "solution": "Colonel Mustard in the Kitchen with the Rope",
+                "confidence": 0.95,
+            }
+        )
 
         assert summary.status == SessionStatus.COMPLETED
         assert summary.confidence_score == 0.95

--- a/tests/unit/argumentation_analysis/nlp/test_embedding_utils.py
+++ b/tests/unit/argumentation_analysis/nlp/test_embedding_utils.py
@@ -206,7 +206,9 @@ def test_save_embeddings_data_success(tmp_path, sample_embeddings_data):
         # ou utiliser un mock plus sophistiqué pour json.dump.
         # Ici, on vérifie au moins que le fichier a été ouvert en écriture.
         # Pour une vérification plus poussée de json.dump:
-        with patch("argumentation_analysis.nlp.embedding_utils.json.dump") as mock_json_dump:
+        with patch(
+            "argumentation_analysis.nlp.embedding_utils.json.dump"
+        ) as mock_json_dump:
             save_embeddings_data(
                 sample_embeddings_data, output_file
             )  # Appeler à nouveau avec le mock json.dump
@@ -223,7 +225,8 @@ def test_save_embeddings_data_io_error(tmp_path, sample_embeddings_data, caplog)
     output_file = tmp_path / "embeddings_io_error.json"
 
     with patch(MKDIR_PATH), patch(OPEN_BUILTIN_PATH, mock_open()), patch(
-        "argumentation_analysis.nlp.embedding_utils.json.dump", side_effect=IOError("Test IOError")
+        "argumentation_analysis.nlp.embedding_utils.json.dump",
+        side_effect=IOError("Test IOError"),
     ):
         success = save_embeddings_data(sample_embeddings_data, output_file)
 
@@ -237,7 +240,8 @@ def test_save_embeddings_data_other_exception(tmp_path, sample_embeddings_data, 
     output_file = tmp_path / "embeddings_other_error.json"
 
     with patch(MKDIR_PATH), patch(OPEN_BUILTIN_PATH, mock_open()), patch(
-        "argumentation_analysis.nlp.embedding_utils.json.dump", side_effect=Exception("Test Generic Exception")
+        "argumentation_analysis.nlp.embedding_utils.json.dump",
+        side_effect=Exception("Test Generic Exception"),
     ):
         success = save_embeddings_data(sample_embeddings_data, output_file)
 

--- a/tests/unit/argumentation_analysis/orchestration/hierarchical/operational/test_operational_state.py
+++ b/tests/unit/argumentation_analysis/orchestration/hierarchical/operational/test_operational_state.py
@@ -28,6 +28,7 @@ def _make_task(task_id="t1", **extra):
 # Initialization
 # ============================================================
 
+
 class TestInit:
     def test_creates_instance(self, state):
         assert isinstance(state, OperationalState)
@@ -58,6 +59,7 @@ class TestInit:
 # ============================================================
 # add_task
 # ============================================================
+
 
 class TestAddTask:
     def test_adds_task(self, state):
@@ -93,6 +95,7 @@ class TestAddTask:
 # update_task_status
 # ============================================================
 
+
 class TestUpdateTaskStatus:
     def test_updates_status(self, state):
         state.add_task(_make_task("t1"))
@@ -120,6 +123,7 @@ class TestUpdateTaskStatus:
 # get_task
 # ============================================================
 
+
 class TestGetTask:
     def test_existing_task(self, state):
         state.add_task(_make_task("t1"))
@@ -134,6 +138,7 @@ class TestGetTask:
 # ============================================================
 # Text extracts
 # ============================================================
+
 
 class TestTextExtracts:
     def test_add_extract(self, state):
@@ -150,6 +155,7 @@ class TestTextExtracts:
 # ============================================================
 # Analysis results
 # ============================================================
+
 
 class TestAnalysisResults:
     def test_add_known_type(self, state):
@@ -179,6 +185,7 @@ class TestAnalysisResults:
 # Issues
 # ============================================================
 
+
 class TestIssues:
     def test_add_issue(self, state):
         issue_id = state.add_issue({"severity": "high"})
@@ -201,6 +208,7 @@ class TestIssues:
 # ============================================================
 # Metrics
 # ============================================================
+
 
 class TestMetrics:
     def test_update_execution_time(self, state):
@@ -227,6 +235,7 @@ class TestMetrics:
 # Action log
 # ============================================================
 
+
 class TestActionLog:
     def test_log_action(self, state):
         state.log_action("started", {"task": "t1"})
@@ -241,6 +250,7 @@ class TestActionLog:
 # ============================================================
 # Query methods
 # ============================================================
+
 
 class TestQueries:
     def test_get_task_results(self, state):
@@ -299,6 +309,7 @@ class TestQueries:
 # clear
 # ============================================================
 
+
 class TestClear:
     def test_resets_tasks(self, state):
         state.add_task(_make_task("t1"))
@@ -320,6 +331,7 @@ class TestClear:
 # find_operational_task_by_tactical_id
 # ============================================================
 
+
 class TestFindByTacticalId:
     def test_finds_task(self, state):
         state.add_task(_make_task("op1", tactical_task_id="tac1"))
@@ -340,6 +352,7 @@ class TestFindByTacticalId:
 # ============================================================
 # Result futures
 # ============================================================
+
 
 class TestResultFutures:
     def test_add_and_get_future(self, state):

--- a/tests/unit/argumentation_analysis/orchestration/hierarchical/strategic/test_allocator.py
+++ b/tests/unit/argumentation_analysis/orchestration/hierarchical/strategic/test_allocator.py
@@ -15,10 +15,10 @@ from argumentation_analysis.orchestration.hierarchical.strategic.state import (
     StrategicState,
 )
 
-
 # ============================================================
 # Fixtures
 # ============================================================
+
 
 @pytest.fixture
 def allocator():
@@ -71,6 +71,7 @@ def allocated_allocator(allocator, sample_plan):
 # __init__
 # ============================================================
 
+
 class TestResourceAllocatorInit:
     def test_default_state_created(self, allocator):
         assert isinstance(allocator.state, StrategicState)
@@ -99,6 +100,7 @@ class TestResourceAllocatorInit:
 # ============================================================
 # allocate_initial_resources
 # ============================================================
+
 
 class TestAllocateInitialResources:
     def test_returns_dict(self, allocator, sample_plan):
@@ -140,6 +142,7 @@ class TestAllocateInitialResources:
 # _analyze_resource_needs
 # ============================================================
 
+
 class TestAnalyzeResourceNeeds:
     def test_returns_dict_per_phase(self, allocator):
         phases = [
@@ -151,7 +154,9 @@ class TestAnalyzeResourceNeeds:
         assert "p2" in result
 
     def test_identification_keywords_boost_scores(self, allocator):
-        phases = [{"id": "p1", "description": "Identification des éléments clés et arguments"}]
+        phases = [
+            {"id": "p1", "description": "Identification des éléments clés et arguments"}
+        ]
         result = allocator._analyze_resource_needs(phases)
         assert result["p1"]["argument_identification"] > 0
         assert result["p1"]["text_extraction"] > 0
@@ -174,25 +179,70 @@ class TestAnalyzeResourceNeeds:
         assert result["p1"]["argument_visualization"] > 0
 
     def test_short_duration_reduces_scores(self, allocator):
-        phases_short = [{"id": "p1", "description": "Identification des éléments clés", "estimated_duration": "short"}]
-        phases_medium = [{"id": "p1", "description": "Identification des éléments clés", "estimated_duration": "medium"}]
+        phases_short = [
+            {
+                "id": "p1",
+                "description": "Identification des éléments clés",
+                "estimated_duration": "short",
+            }
+        ]
+        phases_medium = [
+            {
+                "id": "p1",
+                "description": "Identification des éléments clés",
+                "estimated_duration": "medium",
+            }
+        ]
         short_result = allocator._analyze_resource_needs(phases_short)
         medium_result = allocator._analyze_resource_needs(phases_medium)
-        assert short_result["p1"]["argument_identification"] < medium_result["p1"]["argument_identification"]
+        assert (
+            short_result["p1"]["argument_identification"]
+            < medium_result["p1"]["argument_identification"]
+        )
 
     def test_long_duration_increases_scores(self, allocator):
-        phases_long = [{"id": "p1", "description": "Identification des éléments clés", "estimated_duration": "long"}]
-        phases_medium = [{"id": "p1", "description": "Identification des éléments clés", "estimated_duration": "medium"}]
+        phases_long = [
+            {
+                "id": "p1",
+                "description": "Identification des éléments clés",
+                "estimated_duration": "long",
+            }
+        ]
+        phases_medium = [
+            {
+                "id": "p1",
+                "description": "Identification des éléments clés",
+                "estimated_duration": "medium",
+            }
+        ]
         long_result = allocator._analyze_resource_needs(phases_long)
         medium_result = allocator._analyze_resource_needs(phases_medium)
-        assert long_result["p1"]["argument_identification"] > medium_result["p1"]["argument_identification"]
+        assert (
+            long_result["p1"]["argument_identification"]
+            > medium_result["p1"]["argument_identification"]
+        )
 
     def test_unknown_duration_defaults_to_medium(self, allocator):
-        phases_unknown = [{"id": "p1", "description": "Identification des éléments clés", "estimated_duration": "unknown"}]
-        phases_medium = [{"id": "p1", "description": "Identification des éléments clés", "estimated_duration": "medium"}]
+        phases_unknown = [
+            {
+                "id": "p1",
+                "description": "Identification des éléments clés",
+                "estimated_duration": "unknown",
+            }
+        ]
+        phases_medium = [
+            {
+                "id": "p1",
+                "description": "Identification des éléments clés",
+                "estimated_duration": "medium",
+            }
+        ]
         unknown_result = allocator._analyze_resource_needs(phases_unknown)
         medium_result = allocator._analyze_resource_needs(phases_medium)
-        assert unknown_result["p1"]["argument_identification"] == medium_result["p1"]["argument_identification"]
+        assert (
+            unknown_result["p1"]["argument_identification"]
+            == medium_result["p1"]["argument_identification"]
+        )
 
     def test_unmatched_description_all_zero(self, allocator):
         phases = [{"id": "p1", "description": "generic task with no keywords"}]
@@ -203,6 +253,7 @@ class TestAnalyzeResourceNeeds:
 # ============================================================
 # _determine_agent_assignments
 # ============================================================
+
 
 class TestDetermineAgentAssignments:
     def test_relevant_agents_assigned(self, allocator):
@@ -232,6 +283,7 @@ class TestDetermineAgentAssignments:
 # ============================================================
 # _define_agent_priorities
 # ============================================================
+
 
 class TestDefineAgentPriorities:
     def test_unassigned_agents_get_low(self, allocator):
@@ -273,6 +325,7 @@ class TestDefineAgentPriorities:
 # _allocate_computational_budget
 # ============================================================
 
+
 class TestAllocateComputationalBudget:
     def test_budget_sums_to_one(self, allocator):
         assignments = {
@@ -312,6 +365,7 @@ class TestAllocateComputationalBudget:
 # adjust_allocation
 # ============================================================
 
+
 class TestAdjustAllocation:
     def test_bottleneck_increases_priority(self, allocated_allocator):
         alloc = allocated_allocator
@@ -330,7 +384,9 @@ class TestAdjustAllocation:
         alloc = allocated_allocator
         agents = list(alloc.state.resource_allocation["computational_budget"].keys())
         target_agent = agents[0]
-        original_budget = alloc.state.resource_allocation["computational_budget"][target_agent]
+        original_budget = alloc.state.resource_allocation["computational_budget"][
+            target_agent
+        ]
 
         feedback = {
             "bottlenecks": [],
@@ -369,6 +425,7 @@ class TestAdjustAllocation:
 # ============================================================
 # optimize_resource_utilization
 # ============================================================
+
 
 class TestOptimizeResourceUtilization:
     def test_adjusts_budget_based_on_efficiency(self, allocated_allocator):
@@ -413,12 +470,24 @@ class TestOptimizeResourceUtilization:
 
         metrics = {
             "agent_efficiency": {
-                agents[0]: {"processing_speed": 1.0, "accuracy": 1.0, "resource_usage": 0.0},
-                agents[1]: {"processing_speed": 0.1, "accuracy": 0.1, "resource_usage": 0.9},
+                agents[0]: {
+                    "processing_speed": 1.0,
+                    "accuracy": 1.0,
+                    "resource_usage": 0.0,
+                },
+                agents[1]: {
+                    "processing_speed": 0.1,
+                    "accuracy": 0.1,
+                    "resource_usage": 0.9,
+                },
             },
         }
-        before_0 = alloc.state.resource_allocation["computational_budget"].get(agents[0], 0)
-        before_1 = alloc.state.resource_allocation["computational_budget"].get(agents[1], 0)
+        before_0 = alloc.state.resource_allocation["computational_budget"].get(
+            agents[0], 0
+        )
+        before_1 = alloc.state.resource_allocation["computational_budget"].get(
+            agents[1], 0
+        )
         result = alloc.optimize_resource_utilization(metrics)
         # After optimization, the more efficient agent should move toward more budget
         # (progressive 50% movement toward ideal)
@@ -428,6 +497,7 @@ class TestOptimizeResourceUtilization:
 # ============================================================
 # get_resource_allocation_snapshot
 # ============================================================
+
 
 class TestGetResourceAllocationSnapshot:
     def test_returns_dict(self, allocated_allocator):

--- a/tests/unit/argumentation_analysis/orchestration/hierarchical/tactical/test_monitor.py
+++ b/tests/unit/argumentation_analysis/orchestration/hierarchical/tactical/test_monitor.py
@@ -8,8 +8,12 @@ progress reports, critical issues, corrective actions, coherence evaluation.
 import pytest
 from datetime import datetime, timedelta
 
-from argumentation_analysis.orchestration.hierarchical.tactical.state import TacticalState
-from argumentation_analysis.orchestration.hierarchical.tactical.monitor import ProgressMonitor
+from argumentation_analysis.orchestration.hierarchical.tactical.state import (
+    TacticalState,
+)
+from argumentation_analysis.orchestration.hierarchical.tactical.monitor import (
+    ProgressMonitor,
+)
 
 
 @pytest.fixture
@@ -32,6 +36,7 @@ def _make_task(task_id, obj_id="obj1", **extra):
 # Initialization
 # ============================================================
 
+
 class TestInit:
     def test_creates_instance(self, monitor):
         assert isinstance(monitor, ProgressMonitor)
@@ -52,6 +57,7 @@ class TestInit:
 # ============================================================
 # update_task_progress
 # ============================================================
+
 
 class TestUpdateTaskProgress:
     def test_update_existing_task(self, monitor, state):
@@ -79,6 +85,7 @@ class TestUpdateTaskProgress:
 # ============================================================
 # _check_task_anomalies
 # ============================================================
+
 
 class TestCheckAnomalies:
     def test_stagnation_detected(self, monitor, state):
@@ -123,6 +130,7 @@ class TestCheckAnomalies:
 # generate_progress_report
 # ============================================================
 
+
 class TestGenerateProgressReport:
     def test_empty_state(self, monitor):
         report = monitor.generate_progress_report()
@@ -161,7 +169,9 @@ class TestGenerateProgressReport:
         assert report["progress_by_objective"]["obj1"]["completed_tasks"] == 1
 
     def test_issues_include_conflicts(self, monitor, state):
-        state.add_conflict({"id": "c1", "description": "test conflict", "severity": "high"})
+        state.add_conflict(
+            {"id": "c1", "description": "test conflict", "severity": "high"}
+        )
         report = monitor.generate_progress_report()
         conflict_issues = [i for i in report["issues"] if i["type"] == "conflict"]
         assert len(conflict_issues) == 1
@@ -194,6 +204,7 @@ class TestGenerateProgressReport:
 # ============================================================
 # detect_critical_issues
 # ============================================================
+
 
 class TestDetectCriticalIssues:
     def test_no_issues(self, monitor):
@@ -230,7 +241,10 @@ class TestDetectCriticalIssues:
     def test_delayed_task_with_start_time(self, monitor, state):
         # Task started 2 hours ago with 1 hour estimated, progress at 10%
         past = (datetime.now() - timedelta(hours=2)).isoformat()
-        state.add_task(_make_task("t1", start_time=past, estimated_duration=3600), status="in_progress")
+        state.add_task(
+            _make_task("t1", start_time=past, estimated_duration=3600),
+            status="in_progress",
+        )
         state.task_progress["t1"] = 0.1
         issues = monitor.detect_critical_issues()
         delayed = [i for i in issues if i["type"] == "delayed_task"]
@@ -240,6 +254,7 @@ class TestDetectCriticalIssues:
 # ============================================================
 # suggest_corrective_actions
 # ============================================================
+
 
 class TestSuggestCorrectiveActions:
     def test_no_issues(self, monitor):
@@ -284,39 +299,57 @@ class TestSuggestCorrectiveActions:
 # _evaluate_overall_coherence
 # ============================================================
 
+
 class TestEvaluateCoherence:
     def test_high_coherence(self, monitor):
         result = monitor._evaluate_overall_coherence(
-            {"coherence_score": 0.9}, {"coherence_score": 0.9}, {"coherence_score": 0.9}, []
+            {"coherence_score": 0.9},
+            {"coherence_score": 0.9},
+            {"coherence_score": 0.9},
+            [],
         )
         assert result["overall_score"] >= 0.8
         assert result["coherence_level"] == "Élevé"
 
     def test_moderate_coherence(self, monitor):
         result = monitor._evaluate_overall_coherence(
-            {"coherence_score": 0.7}, {"coherence_score": 0.7}, {"coherence_score": 0.7}, []
+            {"coherence_score": 0.7},
+            {"coherence_score": 0.7},
+            {"coherence_score": 0.7},
+            [],
         )
         assert result["coherence_level"] == "Modéré"
 
     def test_low_coherence(self, monitor):
         result = monitor._evaluate_overall_coherence(
-            {"coherence_score": 0.4}, {"coherence_score": 0.4}, {"coherence_score": 0.5}, []
+            {"coherence_score": 0.4},
+            {"coherence_score": 0.4},
+            {"coherence_score": 0.5},
+            [],
         )
         assert result["coherence_level"] == "Faible"
 
     def test_very_low_coherence(self, monitor):
         result = monitor._evaluate_overall_coherence(
-            {"coherence_score": 0.1}, {"coherence_score": 0.1}, {"coherence_score": 0.1}, []
+            {"coherence_score": 0.1},
+            {"coherence_score": 0.1},
+            {"coherence_score": 0.1},
+            [],
         )
         assert result["coherence_level"] == "Très faible"
 
     def test_contradiction_penalty(self, monitor):
         no_contradiction = monitor._evaluate_overall_coherence(
-            {"coherence_score": 0.9}, {"coherence_score": 0.9}, {"coherence_score": 0.9}, []
+            {"coherence_score": 0.9},
+            {"coherence_score": 0.9},
+            {"coherence_score": 0.9},
+            [],
         )
         with_contradiction = monitor._evaluate_overall_coherence(
-            {"coherence_score": 0.9}, {"coherence_score": 0.9}, {"coherence_score": 0.9},
-            [{"severity": "high"}]
+            {"coherence_score": 0.9},
+            {"coherence_score": 0.9},
+            {"coherence_score": 0.9},
+            [{"severity": "high"}],
         )
         assert with_contradiction["overall_score"] < no_contradiction["overall_score"]
         assert with_contradiction["contradiction_penalty"] > 0
@@ -324,14 +357,19 @@ class TestEvaluateCoherence:
     def test_max_penalty_capped(self, monitor):
         many_contradictions = [{"severity": "critical"}] * 10
         result = monitor._evaluate_overall_coherence(
-            {"coherence_score": 1.0}, {"coherence_score": 1.0}, {"coherence_score": 1.0},
-            many_contradictions
+            {"coherence_score": 1.0},
+            {"coherence_score": 1.0},
+            {"coherence_score": 1.0},
+            many_contradictions,
         )
         assert result["contradiction_penalty"] == 0.5  # Capped at 0.5
 
     def test_result_structure(self, monitor):
         result = monitor._evaluate_overall_coherence(
-            {"coherence_score": 0.5}, {"coherence_score": 0.6}, {"coherence_score": 0.7}, []
+            {"coherence_score": 0.5},
+            {"coherence_score": 0.6},
+            {"coherence_score": 0.7},
+            [],
         )
         assert "overall_score" in result
         assert "coherence_level" in result
@@ -343,13 +381,19 @@ class TestEvaluateCoherence:
 
     def test_weights_correct(self, monitor):
         result = monitor._evaluate_overall_coherence(
-            {"coherence_score": 1.0}, {"coherence_score": 0.0}, {"coherence_score": 0.0}, []
+            {"coherence_score": 1.0},
+            {"coherence_score": 0.0},
+            {"coherence_score": 0.0},
+            [],
         )
         # Only structure contributes: 1.0 * 0.3 = 0.3
         assert abs(result["overall_score"] - 0.3) < 0.01
 
     def test_zero_scores(self, monitor):
         result = monitor._evaluate_overall_coherence(
-            {"coherence_score": 0.0}, {"coherence_score": 0.0}, {"coherence_score": 0.0}, []
+            {"coherence_score": 0.0},
+            {"coherence_score": 0.0},
+            {"coherence_score": 0.0},
+            [],
         )
         assert result["overall_score"] == 0.0

--- a/tests/unit/argumentation_analysis/orchestration/hierarchical/tactical/test_resolver.py
+++ b/tests/unit/argumentation_analysis/orchestration/hierarchical/tactical/test_resolver.py
@@ -7,8 +7,12 @@ contradiction/overlap/fallacy/formal checking, escalation.
 
 import pytest
 
-from argumentation_analysis.orchestration.hierarchical.tactical.state import TacticalState
-from argumentation_analysis.orchestration.hierarchical.tactical.resolver import ConflictResolver
+from argumentation_analysis.orchestration.hierarchical.tactical.state import (
+    TacticalState,
+)
+from argumentation_analysis.orchestration.hierarchical.tactical.resolver import (
+    ConflictResolver,
+)
 
 
 @pytest.fixture
@@ -28,6 +32,7 @@ def _make_task(task_id, obj_id="obj1"):
 # ============================================================
 # Initialization
 # ============================================================
+
 
 class TestInit:
     def test_creates_instance(self, resolver):
@@ -51,6 +56,7 @@ class TestInit:
 # _are_arguments_contradictory
 # ============================================================
 
+
 class TestAreArgumentsContradictory:
     def test_contradictory_est_nest_pas(self, resolver):
         arg1 = {"conclusion": "La terre est ronde"}
@@ -73,12 +79,15 @@ class TestAreArgumentsContradictory:
         assert resolver._are_arguments_contradictory(arg1, arg2) is False
 
     def test_no_conclusion_field(self, resolver):
-        assert resolver._are_arguments_contradictory({"text": "a"}, {"text": "b"}) is False
+        assert (
+            resolver._are_arguments_contradictory({"text": "a"}, {"text": "b"}) is False
+        )
 
 
 # ============================================================
 # _are_arguments_overlapping
 # ============================================================
+
 
 class TestAreArgumentsOverlapping:
     def test_same_subject(self, resolver):
@@ -104,6 +113,7 @@ class TestAreArgumentsOverlapping:
 # _are_fallacies_contradictory
 # ============================================================
 
+
 class TestAreFallaciesContradictory:
     def test_same_segment_different_type(self, resolver):
         f1 = {"segment": "les experts disent", "type": "appel_autorité"}
@@ -127,6 +137,7 @@ class TestAreFallaciesContradictory:
 # ============================================================
 # _are_formal_analyses_contradictory
 # ============================================================
+
 
 class TestAreFormalAnalysesContradictory:
     def test_same_arg_opposite_validity(self, resolver):
@@ -152,64 +163,67 @@ class TestAreFormalAnalysesContradictory:
 # detect_conflicts
 # ============================================================
 
+
 class TestDetectConflicts:
     def test_no_existing_results(self, resolver):
-        conflicts = resolver.detect_conflicts({"identified_arguments": [{"conclusion": "A"}]})
+        conflicts = resolver.detect_conflicts(
+            {"identified_arguments": [{"conclusion": "A"}]}
+        )
         assert isinstance(conflicts, list)
         assert len(conflicts) == 0  # No existing results to compare against
 
     def test_detects_argument_contradiction(self, resolver, state):
         # Set up existing results
         state.add_task(_make_task("t1", "obj1"))
-        state.add_intermediate_result("t1", {
-            "identified_arguments": [{"conclusion": "La terre est ronde"}]
-        })
+        state.add_intermediate_result(
+            "t1", {"identified_arguments": [{"conclusion": "La terre est ronde"}]}
+        )
         # Detect conflicts with contradictory argument
-        conflicts = resolver.detect_conflicts({
-            "identified_arguments": [{"conclusion": "La terre n'est pas ronde"}]
-        })
+        conflicts = resolver.detect_conflicts(
+            {"identified_arguments": [{"conclusion": "La terre n'est pas ronde"}]}
+        )
         assert len(conflicts) >= 1
         assert conflicts[0]["type"] == "contradiction"
 
     def test_detects_argument_overlap(self, resolver, state):
         state.add_task(_make_task("t1", "obj1"))
-        state.add_intermediate_result("t1", {
-            "identified_arguments": [{"subject": "climat"}]
-        })
-        conflicts = resolver.detect_conflicts({
-            "identified_arguments": [{"subject": "climat"}]
-        })
+        state.add_intermediate_result(
+            "t1", {"identified_arguments": [{"subject": "climat"}]}
+        )
+        conflicts = resolver.detect_conflicts(
+            {"identified_arguments": [{"subject": "climat"}]}
+        )
         assert len(conflicts) >= 1
         assert conflicts[0]["type"] == "overlap"
 
     def test_detects_fallacy_contradiction(self, resolver, state):
         state.add_task(_make_task("t1", "obj1"))
-        state.add_intermediate_result("t1", {
-            "identified_fallacies": [{"segment": "test", "type": "type_a"}]
-        })
-        conflicts = resolver.detect_conflicts({
-            "identified_fallacies": [{"segment": "test", "type": "type_b"}]
-        })
+        state.add_intermediate_result(
+            "t1", {"identified_fallacies": [{"segment": "test", "type": "type_a"}]}
+        )
+        conflicts = resolver.detect_conflicts(
+            {"identified_fallacies": [{"segment": "test", "type": "type_b"}]}
+        )
         assert len(conflicts) >= 1
 
     def test_detects_formal_contradiction(self, resolver, state):
         state.add_task(_make_task("t1", "obj1"))
-        state.add_intermediate_result("t1", {
-            "formal_analyses": [{"argument_id": "arg1", "is_valid": True}]
-        })
-        conflicts = resolver.detect_conflicts({
-            "formal_analyses": [{"argument_id": "arg1", "is_valid": False}]
-        })
+        state.add_intermediate_result(
+            "t1", {"formal_analyses": [{"argument_id": "arg1", "is_valid": True}]}
+        )
+        conflicts = resolver.detect_conflicts(
+            {"formal_analyses": [{"argument_id": "arg1", "is_valid": False}]}
+        )
         assert len(conflicts) >= 1
 
     def test_conflicts_added_to_state(self, resolver, state):
         state.add_task(_make_task("t1", "obj1"))
-        state.add_intermediate_result("t1", {
-            "identified_arguments": [{"conclusion": "c'est vrai"}]
-        })
-        resolver.detect_conflicts({
-            "identified_arguments": [{"conclusion": "c'est faux"}]
-        })
+        state.add_intermediate_result(
+            "t1", {"identified_arguments": [{"conclusion": "c'est vrai"}]}
+        )
+        resolver.detect_conflicts(
+            {"identified_arguments": [{"conclusion": "c'est faux"}]}
+        )
         assert len(state.identified_conflicts) >= 1
 
     def test_empty_results(self, resolver):
@@ -225,48 +239,74 @@ class TestDetectConflicts:
 # resolve_conflict
 # ============================================================
 
+
 class TestResolveConflict:
     def test_nonexistent_conflict(self, resolver):
         result = resolver.resolve_conflict("nonexistent")
         assert result["status"] == "error"
 
     def test_already_resolved(self, resolver, state):
-        state.add_conflict({"id": "c1", "type": "contradiction", "resolved": True, "resolution": {"method": "test"}})
+        state.add_conflict(
+            {
+                "id": "c1",
+                "type": "contradiction",
+                "resolved": True,
+                "resolution": {"method": "test"},
+            }
+        )
         result = resolver.resolve_conflict("c1")
         assert result["status"] == "already_resolved"
 
     def test_resolve_contradiction_with_args(self, resolver, state):
-        state.add_conflict({
-            "id": "c1", "type": "contradiction", "severity": "medium",
-            "details": {
-                "argument1": {"conclusion": "A", "confidence": 0.8},
-                "argument2": {"conclusion": "B", "confidence": 0.3},
+        state.add_conflict(
+            {
+                "id": "c1",
+                "type": "contradiction",
+                "severity": "medium",
+                "details": {
+                    "argument1": {"conclusion": "A", "confidence": 0.8},
+                    "argument2": {"conclusion": "B", "confidence": 0.3},
+                },
             }
-        })
+        )
         result = resolver.resolve_conflict("c1")
         assert result["status"] == "success"
         assert result["resolution"]["method"] == "confidence_based"
 
     def test_resolve_contradiction_with_fallacies(self, resolver, state):
-        state.add_conflict({
-            "id": "c1", "type": "contradiction",
-            "details": {
-                "fallacy1": {"type": "a", "confidence": 0.9},
-                "fallacy2": {"type": "b", "confidence": 0.4},
+        state.add_conflict(
+            {
+                "id": "c1",
+                "type": "contradiction",
+                "details": {
+                    "fallacy1": {"type": "a", "confidence": 0.9},
+                    "fallacy2": {"type": "b", "confidence": 0.4},
+                },
             }
-        })
+        )
         result = resolver.resolve_conflict("c1")
         assert result["status"] == "success"
         assert result["resolution"]["method"] == "confidence_based"
 
     def test_resolve_contradiction_with_analyses(self, resolver, state):
-        state.add_conflict({
-            "id": "c1", "type": "contradiction",
-            "details": {
-                "analysis1": {"argument_id": "a1", "is_valid": True, "confidence": 0.7},
-                "analysis2": {"argument_id": "a1", "is_valid": False, "confidence": 0.6},
+        state.add_conflict(
+            {
+                "id": "c1",
+                "type": "contradiction",
+                "details": {
+                    "analysis1": {
+                        "argument_id": "a1",
+                        "is_valid": True,
+                        "confidence": 0.7,
+                    },
+                    "analysis2": {
+                        "argument_id": "a1",
+                        "is_valid": False,
+                        "confidence": 0.6,
+                    },
+                },
             }
-        })
+        )
         result = resolver.resolve_conflict("c1")
         assert result["status"] == "success"
 
@@ -277,13 +317,28 @@ class TestResolveConflict:
         assert result["resolution"]["method"] == "default"
 
     def test_resolve_overlap(self, resolver, state):
-        state.add_conflict({
-            "id": "c1", "type": "overlap",
-            "details": {
-                "argument1": {"id": "a1", "subject": "X", "premises": ["p1"], "conclusion": "C", "confidence": 0.8},
-                "argument2": {"id": "a2", "subject": "X", "premises": ["p2"], "conclusion": "D", "confidence": 0.6},
+        state.add_conflict(
+            {
+                "id": "c1",
+                "type": "overlap",
+                "details": {
+                    "argument1": {
+                        "id": "a1",
+                        "subject": "X",
+                        "premises": ["p1"],
+                        "conclusion": "C",
+                        "confidence": 0.8,
+                    },
+                    "argument2": {
+                        "id": "a2",
+                        "subject": "X",
+                        "premises": ["p2"],
+                        "conclusion": "D",
+                        "confidence": 0.6,
+                    },
+                },
             }
-        })
+        )
         result = resolver.resolve_conflict("c1")
         assert result["status"] == "success"
         assert result["resolution"]["method"] == "merge"
@@ -308,6 +363,7 @@ class TestResolveConflict:
 # escalate_unresolved_conflicts
 # ============================================================
 
+
 class TestEscalateUnresolved:
     def test_no_conflicts(self, resolver):
         result = resolver.escalate_unresolved_conflicts()
@@ -321,19 +377,37 @@ class TestEscalateUnresolved:
         assert result[0]["resolution_attempt"] is None
 
     def test_resolved_not_escalated(self, resolver, state):
-        state.add_conflict({"id": "c1", "type": "contradiction", "resolved": True, "resolution": {"method": "confidence_based"}})
+        state.add_conflict(
+            {
+                "id": "c1",
+                "type": "contradiction",
+                "resolved": True,
+                "resolution": {"method": "confidence_based"},
+            }
+        )
         result = resolver.escalate_unresolved_conflicts()
         assert len(result) == 0
 
     def test_default_resolution_escalated(self, resolver, state):
-        state.add_conflict({"id": "c1", "type": "contradiction", "resolved": True, "resolution": {"method": "default"}})
+        state.add_conflict(
+            {
+                "id": "c1",
+                "type": "contradiction",
+                "resolved": True,
+                "resolution": {"method": "default"},
+            }
+        )
         result = resolver.escalate_unresolved_conflicts()
         assert len(result) == 1
 
     def test_mixed_conflicts(self, resolver, state):
-        state.add_conflict({"id": "c1", "resolved": True, "resolution": {"method": "confidence_based"}})
+        state.add_conflict(
+            {"id": "c1", "resolved": True, "resolution": {"method": "confidence_based"}}
+        )
         state.add_conflict({"id": "c2", "type": "overlap"})
-        state.add_conflict({"id": "c3", "resolved": True, "resolution": {"method": "default"}})
+        state.add_conflict(
+            {"id": "c3", "resolved": True, "resolution": {"method": "default"}}
+        )
         result = resolver.escalate_unresolved_conflicts()
         # c2 (unresolved) and c3 (default resolution) should be escalated
         assert len(result) == 2

--- a/tests/unit/argumentation_analysis/orchestration/hierarchical/tactical/test_state.py
+++ b/tests/unit/argumentation_analysis/orchestration/hierarchical/tactical/test_state.py
@@ -19,12 +19,17 @@ def state():
 
 
 def _make_task(task_id, objective_id="obj1"):
-    return {"id": task_id, "description": f"Task {task_id}", "objective_id": objective_id}
+    return {
+        "id": task_id,
+        "description": f"Task {task_id}",
+        "objective_id": objective_id,
+    }
 
 
 # ============================================================
 # Initialization
 # ============================================================
+
 
 class TestInit:
     def test_creates_instance(self, state):
@@ -34,7 +39,12 @@ class TestInit:
         assert state.assigned_objectives == []
 
     def test_task_statuses(self, state):
-        assert set(state.tasks.keys()) == {"pending", "in_progress", "completed", "failed"}
+        assert set(state.tasks.keys()) == {
+            "pending",
+            "in_progress",
+            "completed",
+            "failed",
+        }
         for v in state.tasks.values():
             assert v == []
 
@@ -52,9 +62,12 @@ class TestInit:
 
     def test_rhetorical_analysis_results_keys(self, state):
         expected = {
-            "complex_fallacy_analyses", "contextual_fallacy_analyses",
-            "fallacy_severity_evaluations", "argument_structure_visualizations",
-            "argument_coherence_evaluations", "semantic_argument_analyses",
+            "complex_fallacy_analyses",
+            "contextual_fallacy_analyses",
+            "fallacy_severity_evaluations",
+            "argument_structure_visualizations",
+            "argument_coherence_evaluations",
+            "semantic_argument_analyses",
             "contextual_fallacy_detections",
         }
         assert set(state.rhetorical_analysis_results.keys()) == expected
@@ -75,9 +88,12 @@ class TestInit:
 # add_assigned_objective
 # ============================================================
 
+
 class TestAddObjective:
     def test_add_one(self, state):
-        state.add_assigned_objective({"id": "o1", "description": "test", "priority": "high"})
+        state.add_assigned_objective(
+            {"id": "o1", "description": "test", "priority": "high"}
+        )
         assert len(state.assigned_objectives) == 1
 
     def test_add_multiple(self, state):
@@ -89,6 +105,7 @@ class TestAddObjective:
 # ============================================================
 # add_task / update_task_status
 # ============================================================
+
 
 class TestTaskLifecycle:
     def test_add_pending(self, state):
@@ -127,6 +144,7 @@ class TestTaskLifecycle:
 # assign_task
 # ============================================================
 
+
 class TestAssignTask:
     def test_assign_existing_task(self, state):
         state.add_task(_make_task("t1"))
@@ -146,6 +164,7 @@ class TestAssignTask:
 # ============================================================
 # add_task_dependency
 # ============================================================
+
 
 class TestTaskDependency:
     def test_add_dependency(self, state):
@@ -182,6 +201,7 @@ class TestTaskDependency:
 # ============================================================
 # update_task_progress
 # ============================================================
+
 
 class TestTaskProgress:
     def test_update_progress(self, state):
@@ -221,6 +241,7 @@ class TestTaskProgress:
 # Intermediate Results
 # ============================================================
 
+
 class TestIntermediateResults:
     def test_add_result(self, state):
         state.add_task(_make_task("t1"))
@@ -235,22 +256,34 @@ class TestIntermediateResults:
 # Rhetorical Analysis Results
 # ============================================================
 
+
 class TestRhetoricalResults:
     def test_add_valid_type(self, state):
         state.add_task(_make_task("t1"))
-        result = state.add_rhetorical_analysis_result("t1", "complex_fallacy_analyses", {"data": 1})
+        result = state.add_rhetorical_analysis_result(
+            "t1", "complex_fallacy_analyses", {"data": 1}
+        )
         assert result is True
 
     def test_add_invalid_type(self, state):
         state.add_task(_make_task("t1"))
-        assert state.add_rhetorical_analysis_result("t1", "nonexistent_type", {}) is False
+        assert (
+            state.add_rhetorical_analysis_result("t1", "nonexistent_type", {}) is False
+        )
 
     def test_add_nonexistent_task(self, state):
-        assert state.add_rhetorical_analysis_result("nonexistent", "complex_fallacy_analyses", {}) is False
+        assert (
+            state.add_rhetorical_analysis_result(
+                "nonexistent", "complex_fallacy_analyses", {}
+            )
+            is False
+        )
 
     def test_get_result_by_type_and_task(self, state):
         state.add_task(_make_task("t1"))
-        state.add_rhetorical_analysis_result("t1", "complex_fallacy_analyses", {"v": 42})
+        state.add_rhetorical_analysis_result(
+            "t1", "complex_fallacy_analyses", {"v": 42}
+        )
         result = state.get_rhetorical_analysis_result("complex_fallacy_analyses", "t1")
         assert result == {"v": 42}
 
@@ -268,6 +301,7 @@ class TestRhetoricalResults:
 # ============================================================
 # Conflicts
 # ============================================================
+
 
 class TestConflicts:
     def test_add_conflict(self, state):
@@ -298,6 +332,7 @@ class TestConflicts:
 # Agent utilization & action log
 # ============================================================
 
+
 class TestAgentUtilization:
     def test_set_utilization(self, state):
         state.update_agent_utilization("a1", 0.75)
@@ -315,6 +350,7 @@ class TestAgentUtilization:
 # ============================================================
 # Queries
 # ============================================================
+
 
 class TestQueries:
     def test_get_pending_tasks(self, state):
@@ -364,6 +400,7 @@ class TestQueries:
 # Snapshots and summaries
 # ============================================================
 
+
 class TestSnapshots:
     def test_get_snapshot_structure(self, state):
         snap = state.get_snapshot()
@@ -404,6 +441,7 @@ class TestSnapshots:
 # JSON serialization
 # ============================================================
 
+
 class TestSerialization:
     def test_to_json_is_valid(self, state):
         state.add_task(_make_task("t1"))
@@ -429,7 +467,16 @@ class TestSerialization:
         assert len(restored.identified_conflicts) == 1
 
     def test_from_json_partial(self):
-        partial = json.dumps({"tasks": {"pending": [{"id": "t1"}], "in_progress": [], "completed": [], "failed": []}})
+        partial = json.dumps(
+            {
+                "tasks": {
+                    "pending": [{"id": "t1"}],
+                    "in_progress": [],
+                    "completed": [],
+                    "failed": [],
+                }
+            }
+        )
         restored = TacticalState.from_json(partial)
         assert len(restored.tasks["pending"]) == 1
 
@@ -445,6 +492,7 @@ class TestSerialization:
 # ============================================================
 # Completion rate edge cases
 # ============================================================
+
 
 class TestCompletionRate:
     def test_zero_tasks(self, state):

--- a/tests/unit/argumentation_analysis/orchestration/test_cluedo_components.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_cluedo_components.py
@@ -14,10 +14,10 @@ import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 from datetime import datetime, timedelta
 
-
 # ============================================================================
 # TestCluedoInvestigatorPlugin
 # ============================================================================
+
 
 class TestCluedoInvestigatorPlugin:
     """Tests for CluedoInvestigatorPlugin (cluedo_plugins.py)."""
@@ -26,6 +26,7 @@ class TestCluedoInvestigatorPlugin:
         from argumentation_analysis.orchestration.cluedo_components.cluedo_plugins import (
             CluedoInvestigatorPlugin,
         )
+
         if handler is None:
             handler = MagicMock()
             handler.force_moriarty_oracle_revelation = AsyncMock()
@@ -71,7 +72,9 @@ class TestCluedoInvestigatorPlugin:
 
     async def test_make_suggestion_exception_handled(self):
         plugin, handler = self._make_plugin()
-        handler.force_moriarty_oracle_revelation.side_effect = RuntimeError("Network error")
+        handler.force_moriarty_oracle_revelation.side_effect = RuntimeError(
+            "Network error"
+        )
         result = await plugin.make_suggestion(
             suspect="Rose", arme="Poignard", lieu="Cuisine"
         )
@@ -82,6 +85,7 @@ class TestCluedoInvestigatorPlugin:
 # TestDialogueAnalyzer
 # ============================================================================
 
+
 class TestDialogueAnalyzer:
     """Tests for DialogueAnalyzer (dialogue_analyzer.py)."""
 
@@ -89,6 +93,7 @@ class TestDialogueAnalyzer:
         from argumentation_analysis.orchestration.cluedo_components.dialogue_analyzer import (
             DialogueAnalyzer,
         )
+
         oracle_state = MagicMock()
         oracle_state.record_contextual_reference = MagicMock()
         oracle_state.record_emotional_reaction = MagicMock()
@@ -104,9 +109,14 @@ class TestDialogueAnalyzer:
 
     def test_detect_suggestion(self):
         analyzer, _ = self._make_analyzer()
-        assert analyzer.detect_message_type("Je suggère Colonel Moutarde") == "suggestion"
+        assert (
+            analyzer.detect_message_type("Je suggère Colonel Moutarde") == "suggestion"
+        )
         assert analyzer.detect_message_type("Le suspect est Rose") == "suggestion"
-        assert analyzer.detect_message_type("L'arme utilisée est le poignard") == "suggestion"
+        assert (
+            analyzer.detect_message_type("L'arme utilisée est le poignard")
+            == "suggestion"
+        )
 
     def test_detect_analysis(self):
         analyzer, _ = self._make_analyzer()
@@ -207,19 +217,19 @@ class TestDialogueAnalyzer:
     def test_emotional_reaction_fallback_to_role(self):
         """When author_name is missing on trigger msg, falls back to role attribute."""
         analyzer, _ = self._make_analyzer()
+
         # history[-2] is the trigger; give it no author_name so getattr falls back to role
         class _MinimalMsg:
             def __init__(self, role, content):
                 self.role = role
                 self.content = content
+
         trigger_msg = _MinimalMsg(role="assistant", content="Some message")
         current_msg = MagicMock()
         current_msg.author_name = "Watson"
         current_msg.content = "brillant!"
         history = [trigger_msg, current_msg]
-        reactions = analyzer._detect_emotional_reactions(
-            "Watson", "brillant!", history
-        )
+        reactions = analyzer._detect_emotional_reactions("Watson", "brillant!", history)
         assert len(reactions) == 1
         assert reactions[0]["trigger_agent"] == "assistant"
 
@@ -228,6 +238,7 @@ class TestDialogueAnalyzer:
 # TestEnhancedLogicHandler
 # ============================================================================
 
+
 class TestEnhancedLogicHandler:
     """Tests for EnhancedLogicHandler (enhanced_logic.py)."""
 
@@ -235,6 +246,7 @@ class TestEnhancedLogicHandler:
         from argumentation_analysis.orchestration.cluedo_components.enhanced_logic import (
             EnhancedLogicHandler,
         )
+
         return EnhancedLogicHandler(oracle_state=oracle_state, oracle_strategy=strategy)
 
     # -- analyze_suggestion_quality --
@@ -257,7 +269,9 @@ class TestEnhancedLogicHandler:
 
     def test_suggestion_trivial_keyword(self):
         handler = self._make_handler()
-        result = handler.analyze_suggestion_quality("Je ne sais pas qui c'est, c'est difficile")
+        result = handler.analyze_suggestion_quality(
+            "Je ne sais pas qui c'est, c'est difficile"
+        )
         assert result["is_trivial"] is True
         assert "trivial_keyword_detected" in result["reason"]
 
@@ -289,7 +303,9 @@ class TestEnhancedLogicHandler:
         state = MagicMock()
         state.get_moriarty_cards.return_value = ["Chandelier", "Salon"]
         state.add_revelation = MagicMock()
-        handler = self._make_handler(oracle_state=state, strategy="enhanced_auto_reveal")
+        handler = self._make_handler(
+            oracle_state=state, strategy="enhanced_auto_reveal"
+        )
         result = handler.trigger_auto_revelation("stalled", "test context")
         assert result["success"] is True
         assert result["revealed_card"] == "Chandelier"
@@ -312,9 +328,7 @@ class TestEnhancedLogicHandler:
 
     def test_state_transition_invalid_target(self):
         handler = self._make_handler()
-        result = handler.handle_enhanced_state_transition(
-            "idle", "invalid_state", {}
-        )
+        result = handler.handle_enhanced_state_transition("idle", "invalid_state", {})
         assert result["success"] is False
         assert result["new_state"] == "idle"  # stays at current
         assert "Invalid target state" in result["error"]
@@ -336,7 +350,9 @@ class TestEnhancedLogicHandler:
 
     async def test_optimized_turn_sherlock(self):
         handler = self._make_handler()
-        result = await handler.execute_optimized_agent_turn("Sherlock", 1, "enhanced_cluedo")
+        result = await handler.execute_optimized_agent_turn(
+            "Sherlock", 1, "enhanced_cluedo"
+        )
         assert result["role"] == "investigator"
         assert result["success"] is True
         assert result["performance"]["context_awareness"] == 0.75
@@ -350,7 +366,9 @@ class TestEnhancedLogicHandler:
 
     async def test_optimized_turn_moriarty(self):
         handler = self._make_handler()
-        result = await handler.execute_optimized_agent_turn("Moriarty", 0, "enhanced_cluedo")
+        result = await handler.execute_optimized_agent_turn(
+            "Moriarty", 0, "enhanced_cluedo"
+        )
         assert result["role"] == "oracle_revealer"
 
     async def test_optimized_turn_unknown_agent(self):
@@ -369,6 +387,7 @@ class TestEnhancedLogicHandler:
 # TestToolCallLoggingHandler
 # ============================================================================
 
+
 class TestToolCallLoggingHandler:
     """Tests for ToolCallLoggingHandler (logging_handler.py)."""
 
@@ -376,6 +395,7 @@ class TestToolCallLoggingHandler:
         from argumentation_analysis.orchestration.cluedo_components.logging_handler import (
             ToolCallLoggingHandler,
         )
+
         return ToolCallLoggingHandler()
 
     def test_construction(self):
@@ -440,6 +460,7 @@ class TestToolCallLoggingHandler:
 # ============================================================================
 # TestMetricsCollector
 # ============================================================================
+
 
 class TestMetricsCollector:
     """Tests for MetricsCollector (metrics_collector.py)."""
@@ -626,6 +647,7 @@ class TestMetricsCollector:
 # TestSuggestionHandler
 # ============================================================================
 
+
 class TestSuggestionHandler:
     """Tests for SuggestionHandler (suggestion_handler.py)."""
 
@@ -633,6 +655,7 @@ class TestSuggestionHandler:
         from argumentation_analysis.orchestration.cluedo_components.suggestion_handler import (
             SuggestionHandler,
         )
+
         if moriarty is None:
             moriarty = MagicMock()
             moriarty.validate_suggestion_cluedo = AsyncMock()

--- a/tests/unit/argumentation_analysis/orchestration/test_cluedo_extended_orchestrator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_cluedo_extended_orchestrator.py
@@ -8,29 +8,38 @@ from datetime import datetime
 
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 
-
 # ============================================================================
 # AgentGroupChat Tests
 # ============================================================================
+
 
 class TestAgentGroupChatInit:
     """Tests for AgentGroupChat initialization."""
 
     def test_init_default_empty_agents(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import AgentGroupChat
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            AgentGroupChat,
+        )
+
         chat = AgentGroupChat()
         assert chat.agents == []
         assert chat.selection_strategy is None
         assert chat.termination_strategy is None
 
     def test_init_with_agents(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import AgentGroupChat
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            AgentGroupChat,
+        )
+
         agents = [MagicMock(), MagicMock()]
         chat = AgentGroupChat(agents=agents)
         assert len(chat.agents) == 2
 
     def test_init_with_strategies(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import AgentGroupChat
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            AgentGroupChat,
+        )
+
         sel = MagicMock()
         term = MagicMock()
         chat = AgentGroupChat(
@@ -42,7 +51,10 @@ class TestAgentGroupChatInit:
         assert chat.termination_strategy is term
 
     def test_init_none_agents_becomes_empty_list(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import AgentGroupChat
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            AgentGroupChat,
+        )
+
         chat = AgentGroupChat(agents=None)
         assert chat.agents == []
 
@@ -51,13 +63,19 @@ class TestAgentGroupChatInvoke:
     """Tests for AgentGroupChat.invoke()."""
 
     async def test_invoke_empty_agents_returns_empty_list(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import AgentGroupChat
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            AgentGroupChat,
+        )
+
         chat = AgentGroupChat(agents=[])
         result = await chat.invoke("hello")
         assert result == []
 
     async def test_invoke_with_callable_agent(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import AgentGroupChat
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            AgentGroupChat,
+        )
+
         agent = MagicMock()
         agent.invoke.return_value = "response1"
         chat = AgentGroupChat(agents=[agent])
@@ -65,7 +83,10 @@ class TestAgentGroupChatInvoke:
         assert "response1" in result
 
     async def test_invoke_with_async_agent(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import AgentGroupChat
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            AgentGroupChat,
+        )
+
         agent = MagicMock()
         agent.invoke = AsyncMock(return_value="async_response")
         chat = AgentGroupChat(agents=[agent])
@@ -73,7 +94,10 @@ class TestAgentGroupChatInvoke:
         assert "async_response" in result
 
     async def test_invoke_agent_without_invoke_method(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import AgentGroupChat
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            AgentGroupChat,
+        )
+
         agent = MagicMock(spec=[])  # No invoke method
         chat = AgentGroupChat(agents=[agent])
         result = await chat.invoke("hello")
@@ -82,7 +106,10 @@ class TestAgentGroupChatInvoke:
         assert "AgentGroupChat" in result[0]
 
     async def test_invoke_agent_raises_exception(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import AgentGroupChat
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            AgentGroupChat,
+        )
+
         agent = MagicMock()
         agent.invoke.side_effect = RuntimeError("Agent error")
         chat = AgentGroupChat(agents=[agent])
@@ -92,7 +119,10 @@ class TestAgentGroupChatInvoke:
         assert "AgentGroupChat" in result[0]
 
     async def test_invoke_multiple_agents(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import AgentGroupChat
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            AgentGroupChat,
+        )
+
         agent1 = MagicMock()
         agent1.invoke.return_value = "resp1"
         agent2 = MagicMock()
@@ -102,7 +132,10 @@ class TestAgentGroupChatInvoke:
         assert len(result) == 2
 
     async def test_invoke_none_input(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import AgentGroupChat
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            AgentGroupChat,
+        )
+
         agent = MagicMock()
         agent.invoke.return_value = "response"
         chat = AgentGroupChat(agents=[agent])
@@ -114,11 +147,15 @@ class TestAgentGroupChatInvoke:
 # CluedoExtendedOrchestrator Tests
 # ============================================================================
 
+
 class TestCluedoExtendedOrchestratorInit:
     """Tests for CluedoExtendedOrchestrator initialization."""
 
     def test_init_default_values(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         kernel = MagicMock()
         settings = MagicMock()
         orch = CluedoExtendedOrchestrator(kernel=kernel, settings=settings)
@@ -134,7 +171,10 @@ class TestCluedoExtendedOrchestratorInit:
         assert orch.moriarty_agent is None
 
     def test_init_custom_values(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         kernel = MagicMock()
         settings = MagicMock()
         orch = CluedoExtendedOrchestrator(
@@ -151,7 +191,10 @@ class TestCluedoExtendedOrchestratorInit:
         assert orch.adaptive_selection is True
 
     def test_init_execution_metrics_empty(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         kernel = MagicMock()
         settings = MagicMock()
         orch = CluedoExtendedOrchestrator(kernel=kernel, settings=settings)
@@ -164,7 +207,10 @@ class TestCluedoExtendedOrchestratorConsolidate:
     """Tests for consolidate_agent_response()."""
 
     def _make_orchestrator(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         return CluedoExtendedOrchestrator(kernel=MagicMock(), settings=MagicMock())
 
     def test_consolidate_string_response(self):
@@ -212,12 +258,17 @@ class TestCluedoExtendedOrchestratorDetectMessageType:
     """Tests for _detect_message_type()."""
 
     def _make_orchestrator(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         return CluedoExtendedOrchestrator(kernel=MagicMock(), settings=MagicMock())
 
     def test_detect_revelation(self):
         orch = self._make_orchestrator()
-        assert orch._detect_message_type("Je révèle la carte du Colonel") == "revelation"
+        assert (
+            orch._detect_message_type("Je révèle la carte du Colonel") == "revelation"
+        )
 
     def test_detect_revelation_carte(self):
         orch = self._make_orchestrator()
@@ -225,11 +276,17 @@ class TestCluedoExtendedOrchestratorDetectMessageType:
 
     def test_detect_suggestion(self):
         orch = self._make_orchestrator()
-        assert orch._detect_message_type("Je suggère que le suspect est...") == "suggestion"
+        assert (
+            orch._detect_message_type("Je suggère que le suspect est...")
+            == "suggestion"
+        )
 
     def test_detect_suggestion_propose(self):
         orch = self._make_orchestrator()
-        assert orch._detect_message_type("Je propose une hypothèse avec l'arme") == "suggestion"
+        assert (
+            orch._detect_message_type("Je propose une hypothèse avec l'arme")
+            == "suggestion"
+        )
 
     def test_detect_analysis(self):
         orch = self._make_orchestrator()
@@ -237,7 +294,10 @@ class TestCluedoExtendedOrchestratorDetectMessageType:
 
     def test_detect_analysis_deduction(self):
         orch = self._make_orchestrator()
-        assert orch._detect_message_type("Ma déduction logique est la suivante") == "analysis"
+        assert (
+            orch._detect_message_type("Ma déduction logique est la suivante")
+            == "analysis"
+        )
 
     def test_detect_analysis_donc(self):
         orch = self._make_orchestrator()
@@ -249,7 +309,9 @@ class TestCluedoExtendedOrchestratorDetectMessageType:
 
     def test_detect_reaction_aha(self):
         orch = self._make_orchestrator()
-        assert orch._detect_message_type("Aha! Exactement ce que je pensais") == "reaction"
+        assert (
+            orch._detect_message_type("Aha! Exactement ce que je pensais") == "reaction"
+        )
 
     def test_detect_generic_message(self):
         orch = self._make_orchestrator()
@@ -268,7 +330,10 @@ class TestCluedoExtendedOrchestratorExtractSuggestion:
     """Tests for _extract_cluedo_suggestion()."""
 
     def _make_orchestrator(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         return CluedoExtendedOrchestrator(kernel=MagicMock(), settings=MagicMock())
 
     def test_no_suggestion_keywords(self):
@@ -341,8 +406,13 @@ class TestCluedoExtendedOrchestratorExtractSuggestion:
 class TestCluedoExtendedOrchestratorEvaluateSolution:
     """Tests for _evaluate_solution_success()."""
 
-    def _make_orchestrator_with_state(self, proposed=None, correct=None, is_proposed=False):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+    def _make_orchestrator_with_state(
+        self, proposed=None, correct=None, is_proposed=False
+    ):
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         orch = CluedoExtendedOrchestrator(kernel=MagicMock(), settings=MagicMock())
         orch.oracle_state = MagicMock()
         orch.oracle_state.is_solution_proposed = is_proposed
@@ -393,7 +463,10 @@ class TestCluedoExtendedOrchestratorPerformanceMetrics:
     """Tests for _calculate_performance_metrics()."""
 
     def _make_orchestrator(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         return CluedoExtendedOrchestrator(kernel=MagicMock(), settings=MagicMock())
 
     def test_performance_metrics_basic(self):
@@ -446,7 +519,10 @@ class TestCluedoExtendedOrchestratorDetectEmotionalReactions:
     """Tests for _detect_emotional_reactions()."""
 
     def _make_orchestrator(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         return CluedoExtendedOrchestrator(kernel=MagicMock(), settings=MagicMock())
 
     def test_returns_empty_list(self):
@@ -459,13 +535,19 @@ class TestCluedoExtendedOrchestratorExecuteWorkflow:
     """Tests for execute_workflow() error handling."""
 
     async def test_execute_without_setup_raises(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         orch = CluedoExtendedOrchestrator(kernel=MagicMock(), settings=MagicMock())
         with pytest.raises(ValueError, match="Workflow non configuré"):
             await orch.execute_workflow()
 
     async def test_execute_sets_start_time(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         orch = CluedoExtendedOrchestrator(kernel=MagicMock(), settings=MagicMock())
         orch.orchestration = MagicMock()
         orch.oracle_state = MagicMock()
@@ -497,7 +579,10 @@ class TestAnalyzeContextualElements:
     """Tests for _analyze_contextual_elements()."""
 
     def _make_orchestrator_with_state(self):
-        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import CluedoExtendedOrchestrator
+        from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+            CluedoExtendedOrchestrator,
+        )
+
         orch = CluedoExtendedOrchestrator(kernel=MagicMock(), settings=MagicMock())
         orch.oracle_state = MagicMock()
         return orch
@@ -505,7 +590,9 @@ class TestAnalyzeContextualElements:
     def test_detects_suite_a_reference(self):
         orch = self._make_orchestrator_with_state()
         history = [MagicMock(), MagicMock()]
-        orch._analyze_contextual_elements("Sherlock", "Suite à votre remarque...", history)
+        orch._analyze_contextual_elements(
+            "Sherlock", "Suite à votre remarque...", history
+        )
         orch.oracle_state.record_contextual_reference.assert_called_once()
         call_args = orch.oracle_state.record_contextual_reference.call_args
         assert call_args.kwargs["reference_type"] == "building_on"

--- a/tests/unit/argumentation_analysis/orchestration/test_cluedo_strategies.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_cluedo_strategies.py
@@ -10,10 +10,10 @@ Covers:
 import pytest
 from unittest.mock import MagicMock, AsyncMock, PropertyMock
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_mock_agent(name: str, has_context_enhanced=False):
     """Create a minimal mock Agent with a .name attribute."""
@@ -36,7 +36,9 @@ def _make_oracle_state(**overrides):
     state.is_solution_proposed = overrides.get("is_solution_proposed", False)
     state.final_solution = overrides.get("final_solution", None)
     state.get_solution_secrete = MagicMock(
-        return_value=overrides.get("secret", {"suspect": "Moutarde", "arme": "Chandelier", "lieu": "Salon"})
+        return_value=overrides.get(
+            "secret", {"suspect": "Moutarde", "arme": "Chandelier", "lieu": "Salon"}
+        )
     )
     state.is_game_solvable_by_elimination = MagicMock(
         return_value=overrides.get("solvable_by_elimination", False)
@@ -51,6 +53,7 @@ def _make_oracle_state(**overrides):
 # CyclicSelectionStrategy
 # ============================================================================
 
+
 class TestCyclicSelectionStrategy:
     """Tests for CyclicSelectionStrategy."""
 
@@ -58,6 +61,7 @@ class TestCyclicSelectionStrategy:
         from argumentation_analysis.orchestration.cluedo_components.strategies import (
             CyclicSelectionStrategy,
         )
+
         if agents is None:
             agents = _make_agents()
         return CyclicSelectionStrategy(
@@ -171,7 +175,10 @@ class TestCyclicSelectionStrategy:
         selected = await strategy.next(agents, [])
         # get_contextual_prompt_addition called but returned "", so no _current_context set
         state.get_contextual_prompt_addition.assert_called_once_with("Sherlock")
-        assert not hasattr(selected, "_current_context") or getattr(selected, "_current_context", None) != ""
+        assert (
+            not hasattr(selected, "_current_context")
+            or getattr(selected, "_current_context", None) != ""
+        )
 
     # -- next() with adaptive selection --
 
@@ -190,6 +197,7 @@ class TestCyclicSelectionStrategy:
         from argumentation_analysis.orchestration.cluedo_components.strategies import (
             CyclicSelectionStrategy,
         )
+
         agents = _make_agents()
         strategy = self._make_strategy(agents=agents)
         default = agents[0]
@@ -230,6 +238,7 @@ class TestCyclicSelectionStrategy:
 # OracleTerminationStrategy
 # ============================================================================
 
+
 class TestOracleTerminationStrategy:
     """Tests for OracleTerminationStrategy."""
 
@@ -237,6 +246,7 @@ class TestOracleTerminationStrategy:
         from argumentation_analysis.orchestration.cluedo_components.strategies import (
             OracleTerminationStrategy,
         )
+
         return OracleTerminationStrategy(
             max_turns=max_turns,
             max_cycles=max_cycles,
@@ -336,7 +346,9 @@ class TestOracleTerminationStrategy:
             final_solution=wrong,
             secret=secret,
         )
-        strategy = self._make_strategy(max_turns=100, max_cycles=100, oracle_state=state)
+        strategy = self._make_strategy(
+            max_turns=100, max_cycles=100, oracle_state=state
+        )
         agent = _make_mock_agent("Watson")
 
         result = await strategy.should_terminate(agent, [])
@@ -345,7 +357,9 @@ class TestOracleTerminationStrategy:
 
     async def test_does_not_terminate_when_solution_not_proposed(self):
         state = _make_oracle_state(is_solution_proposed=False)
-        strategy = self._make_strategy(max_turns=100, max_cycles=100, oracle_state=state)
+        strategy = self._make_strategy(
+            max_turns=100, max_cycles=100, oracle_state=state
+        )
         agent = _make_mock_agent("Watson")
 
         result = await strategy.should_terminate(agent, [])
@@ -355,7 +369,9 @@ class TestOracleTerminationStrategy:
 
     async def test_terminates_when_elimination_complete(self):
         state = _make_oracle_state(solvable_by_elimination=True)
-        strategy = self._make_strategy(max_turns=100, max_cycles=100, oracle_state=state)
+        strategy = self._make_strategy(
+            max_turns=100, max_cycles=100, oracle_state=state
+        )
         agent = _make_mock_agent("Watson")
 
         result = await strategy.should_terminate(agent, [])
@@ -363,7 +379,9 @@ class TestOracleTerminationStrategy:
 
     async def test_does_not_terminate_when_elimination_incomplete(self):
         state = _make_oracle_state(solvable_by_elimination=False)
-        strategy = self._make_strategy(max_turns=100, max_cycles=100, oracle_state=state)
+        strategy = self._make_strategy(
+            max_turns=100, max_cycles=100, oracle_state=state
+        )
         agent = _make_mock_agent("Watson")
 
         result = await strategy.should_terminate(agent, [])
@@ -390,14 +408,18 @@ class TestOracleTerminationStrategy:
 
     def test_check_solution_correct(self):
         secret = {"suspect": "X", "arme": "Y", "lieu": "Z"}
-        state = _make_oracle_state(is_solution_proposed=True, final_solution=secret, secret=secret)
+        state = _make_oracle_state(
+            is_solution_proposed=True, final_solution=secret, secret=secret
+        )
         strategy = self._make_strategy(oracle_state=state)
         assert strategy._check_solution_found() is True
 
     def test_check_solution_incorrect(self):
         secret = {"suspect": "X", "arme": "Y", "lieu": "Z"}
         wrong = {"suspect": "A", "arme": "B", "lieu": "C"}
-        state = _make_oracle_state(is_solution_proposed=True, final_solution=wrong, secret=secret)
+        state = _make_oracle_state(
+            is_solution_proposed=True, final_solution=wrong, secret=secret
+        )
         strategy = self._make_strategy(oracle_state=state)
         assert strategy._check_solution_found() is False
 
@@ -457,7 +479,9 @@ class TestOracleTerminationStrategy:
             final_solution=secret,
             secret=secret,
         )
-        strategy = self._make_strategy(max_turns=100, max_cycles=100, oracle_state=state)
+        strategy = self._make_strategy(
+            max_turns=100, max_cycles=100, oracle_state=state
+        )
         agent = _make_mock_agent("Watson")
 
         result = await strategy.should_terminate(agent, [])
@@ -467,7 +491,9 @@ class TestOracleTerminationStrategy:
     async def test_termination_priority_elimination_before_timeout(self):
         """Elimination complete should terminate before hitting timeout."""
         state = _make_oracle_state(solvable_by_elimination=True)
-        strategy = self._make_strategy(max_turns=100, max_cycles=100, oracle_state=state)
+        strategy = self._make_strategy(
+            max_turns=100, max_cycles=100, oracle_state=state
+        )
         agent = _make_mock_agent("Watson")
 
         result = await strategy.should_terminate(agent, [])
@@ -482,7 +508,7 @@ class TestOracleTerminationStrategy:
         moriarty = _make_mock_agent("Moriarty")
 
         await strategy.should_terminate(sherlock, [])  # cycle 1, turn 1
-        await strategy.should_terminate(watson, [])    # turn 2
+        await strategy.should_terminate(watson, [])  # turn 2
         await strategy.should_terminate(moriarty, [])  # turn 3
         await strategy.should_terminate(sherlock, [])  # cycle 2, turn 4
 

--- a/tests/unit/argumentation_analysis/orchestration/test_conversation_orchestrator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversation_orchestrator.py
@@ -16,11 +16,11 @@ from argumentation_analysis.orchestration.conversation_orchestrator import (
     run_mode_enhanced,
 )
 
-
 SAMPLE_TEXT = "Les mesures fermes sont nécessaires pour maintenir l'ordre et la stabilité du pays."
 
 
 # ── ConversationLogger ──
+
 
 class TestConversationLogger:
     def test_micro_mode_limits(self):
@@ -96,6 +96,7 @@ class TestConversationLogger:
 
 # ── AnalysisState ──
 
+
 class TestAnalysisState:
     def test_initial_state(self):
         state = AnalysisState()
@@ -113,7 +114,9 @@ class TestAnalysisState:
 
     def test_update_from_modal(self):
         state = AnalysisState()
-        state.update_from_modal({"propositions_count": 5, "consistency": 0.9, "logical_score": 0.7})
+        state.update_from_modal(
+            {"propositions_count": 5, "consistency": 0.9, "logical_score": 0.7}
+        )
         assert state.propositions_found == 5
         assert state.consistency_score == 0.9
         assert state.score == pytest.approx(0.21)  # 0.7 * 0.3
@@ -138,6 +141,7 @@ class TestAnalysisState:
         state.completed = True
         rs = state.to_rhetorical_state()
         from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+
         assert isinstance(rs, RhetoricalAnalysisState)
         assert rs.final_conclusion is not None
 
@@ -145,6 +149,7 @@ class TestAnalysisState:
         state = AnalysisState()
         rs = state.to_rhetorical_state()
         from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+
         assert isinstance(rs, RhetoricalAnalysisState)
         assert rs.final_conclusion is None
 
@@ -156,12 +161,15 @@ class TestAnalysisState:
     def test_cumulative_scoring(self):
         state = AnalysisState()
         state.update_from_informal({"fallacies_count": 2, "sophistication_score": 1.0})
-        state.update_from_modal({"propositions_count": 3, "consistency": 0.8, "logical_score": 1.0})
+        state.update_from_modal(
+            {"propositions_count": 3, "consistency": 0.8, "logical_score": 1.0}
+        )
         state.update_from_synthesis({"unified_score": 1.0})
         assert state.score == pytest.approx(1.0)  # 0.4 + 0.3 + 0.3
 
 
 # ── SimulatedAgent ──
+
 
 class TestSimulatedAgent:
     def test_informal_agent(self):
@@ -200,6 +208,7 @@ class TestSimulatedAgent:
 
 
 # ── ConversationOrchestrator ──
+
 
 class TestConversationOrchestrator:
     def test_micro_mode_setup(self):
@@ -263,12 +272,15 @@ class TestConversationOrchestrator:
     @patch("builtins.print")
     def test_agent_error_handled(self, mock_print):
         orch = ConversationOrchestrator(mode="demo")
+
         # Replace first agent with one that raises
         class FailingAgent:
             name = "FailAgent"
             agent_type = "informal"
+
             def analyze(self, text, cl, state):
                 raise RuntimeError("Agent failure")
+
         orch.agents[0] = FailingAgent()
         # Should not raise — errors are caught
         report = orch.run_orchestration(SAMPLE_TEXT)
@@ -282,6 +294,7 @@ class TestConversationOrchestrator:
 
 
 # ── Factory and mode functions ──
+
 
 class TestFactoryAndModes:
     def test_create_conversation_orchestrator(self):

--- a/tests/unit/argumentation_analysis/orchestration/test_conversation_orchestrator_real.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversation_orchestrator_real.py
@@ -16,7 +16,6 @@ from argumentation_analysis.orchestration.conversation_orchestrator import (
     create_conversation_orchestrator,
 )
 
-
 # ============================================================
 # Real mode setup & fallback
 # ============================================================
@@ -83,12 +82,15 @@ class TestResultAdaptation:
         return ConversationOrchestrator(mode="demo")
 
     def test_adapt_informal_result(self, orch):
-        result = orch._adapt_real_result("informal", {
-            "fallacies": [
-                {"fallacy_type": "ad_hominem", "confidence": 0.9},
-                {"fallacy_type": "false_cause", "confidence": 0.7},
-            ],
-        })
+        result = orch._adapt_real_result(
+            "informal",
+            {
+                "fallacies": [
+                    {"fallacy_type": "ad_hominem", "confidence": 0.9},
+                    {"fallacy_type": "false_cause", "confidence": 0.7},
+                ],
+            },
+        )
         assert result["fallacies_count"] == 2
         assert result["sophistication_score"] > 0
         assert "ad_hominem" in result["main_issues"]
@@ -99,21 +101,27 @@ class TestResultAdaptation:
         assert result["sophistication_score"] == 0.3  # baseline
 
     def test_adapt_fol_result(self, orch):
-        result = orch._adapt_real_result("fol_logic", {
-            "formulas": ["forall X: (P(X) => Q(X))"],
-            "consistency_check": True,
-            "confidence_score": 0.8,
-        })
+        result = orch._adapt_real_result(
+            "fol_logic",
+            {
+                "formulas": ["forall X: (P(X) => Q(X))"],
+                "consistency_check": True,
+                "confidence_score": 0.8,
+            },
+        )
         assert result["formulas_count"] == 1
         assert result["logical_score"] == 0.8
         assert result["consistency"] == 1.0
 
     def test_adapt_synthesis_result(self, orch):
-        result = orch._adapt_real_result("synthesis", {
-            "confidence_level": 0.65,
-            "overall_validity": True,
-            "executive_summary": "Good argument",
-        })
+        result = orch._adapt_real_result(
+            "synthesis",
+            {
+                "confidence_level": 0.65,
+                "overall_validity": True,
+                "executive_summary": "Good argument",
+            },
+        )
         assert result["unified_score"] == 0.65
         assert result["recommendation"] == "Good argument"
 
@@ -144,12 +152,14 @@ class TestRealModeExecution:
     def mock_informal(self):
         agent = AsyncMock()
         agent.name = "InformalAnalysisAgent"
-        agent.perform_complete_analysis = AsyncMock(return_value={
-            "fallacies": [
-                {"fallacy_type": "ad_hominem", "confidence": 0.9},
-            ],
-            "categories": {"RELEVANCE": ["ad_hominem"]},
-        })
+        agent.perform_complete_analysis = AsyncMock(
+            return_value={
+                "fallacies": [
+                    {"fallacy_type": "ad_hominem", "confidence": 0.9},
+                ],
+                "categories": {"RELEVANCE": ["ad_hominem"]},
+            }
+        )
         return agent
 
     @pytest.fixture

--- a/tests/unit/argumentation_analysis/orchestration/test_conversational_executor.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversational_executor.py
@@ -38,7 +38,6 @@ from argumentation_analysis.orchestration.workflow_dsl import (
     WorkflowExecutor,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -201,7 +200,9 @@ class TestConversationConfig:
         assert cfg.convergence_fn is fn
 
     def test_convergence_fn_callable(self):
-        cfg = ConversationConfig(convergence_fn=lambda p, c: p.confidence == c.confidence)
+        cfg = ConversationConfig(
+            convergence_fn=lambda p, c: p.confidence == c.confidence
+        )
         tr1 = TurnResult(1, {}, 0.5, False)
         tr2 = TurnResult(2, {}, 0.5, False)
         assert cfg.convergence_fn(tr1, tr2) is True
@@ -217,9 +218,11 @@ class TestConversationalPipeline:
 
     async def test_single_round_high_confidence(self):
         """Single round with high confidence exits immediately."""
-        strategy = MockTurnStrategy([
-            TurnResult(1, {"p1": make_phase_result("p1")}, 0.9, False),
-        ])
+        strategy = MockTurnStrategy(
+            [
+                TurnResult(1, {"p1": make_phase_result("p1")}, 0.9, False),
+            ]
+        )
         pipeline = ConversationalPipeline(
             strategy, ConversationConfig(max_rounds=5, confidence_threshold=0.8)
         )
@@ -230,11 +233,13 @@ class TestConversationalPipeline:
 
     async def test_multi_round_reaches_max(self):
         """Low confidence rounds hit max_rounds."""
-        strategy = MockTurnStrategy([
-            TurnResult(1, {"p1": make_phase_result("p1")}, 0.3, True),
-            TurnResult(2, {"p1": make_phase_result("p1")}, 0.4, True),
-            TurnResult(3, {"p1": make_phase_result("p1")}, 0.5, True),
-        ])
+        strategy = MockTurnStrategy(
+            [
+                TurnResult(1, {"p1": make_phase_result("p1")}, 0.3, True),
+                TurnResult(2, {"p1": make_phase_result("p1")}, 0.4, True),
+                TurnResult(3, {"p1": make_phase_result("p1")}, 0.5, True),
+            ]
+        )
         pipeline = ConversationalPipeline(
             strategy, ConversationConfig(max_rounds=3, confidence_threshold=0.8)
         )
@@ -244,10 +249,12 @@ class TestConversationalPipeline:
 
     async def test_convergence_stops_early(self):
         """Custom convergence function stops execution."""
-        strategy = MockTurnStrategy([
-            TurnResult(1, {"p1": make_phase_result("p1")}, 0.5, True),
-            TurnResult(2, {"p1": make_phase_result("p1")}, 0.5, True),
-        ])
+        strategy = MockTurnStrategy(
+            [
+                TurnResult(1, {"p1": make_phase_result("p1")}, 0.5, True),
+                TurnResult(2, {"p1": make_phase_result("p1")}, 0.5, True),
+            ]
+        )
         pipeline = ConversationalPipeline(
             strategy,
             ConversationConfig(
@@ -262,14 +269,14 @@ class TestConversationalPipeline:
 
     async def test_context_carries_turn_number(self):
         """Each round receives incrementing turn_number in context."""
-        strategy = MockTurnStrategy([
-            TurnResult(1, {}, 0.3, True),
-            TurnResult(2, {}, 0.3, True),
-            TurnResult(3, {}, 0.9, False),
-        ])
-        pipeline = ConversationalPipeline(
-            strategy, ConversationConfig(max_rounds=3)
+        strategy = MockTurnStrategy(
+            [
+                TurnResult(1, {}, 0.3, True),
+                TurnResult(2, {}, 0.3, True),
+                TurnResult(3, {}, 0.9, False),
+            ]
         )
+        pipeline = ConversationalPipeline(strategy, ConversationConfig(max_rounds=3))
         await pipeline.execute("test")
         assert strategy.contexts_received[0]["turn_number"] == 1
         assert strategy.contexts_received[1]["turn_number"] == 2
@@ -277,13 +284,17 @@ class TestConversationalPipeline:
 
     async def test_previous_outputs_in_context(self):
         """Subsequent rounds get previous_outputs from prior turn."""
-        strategy = MockTurnStrategy([
-            TurnResult(1, {"p1": make_phase_result("p1", output={"score": 5})}, 0.3, True),
-            TurnResult(2, {"p1": make_phase_result("p1", output={"score": 8})}, 0.9, False),
-        ])
-        pipeline = ConversationalPipeline(
-            strategy, ConversationConfig(max_rounds=3)
+        strategy = MockTurnStrategy(
+            [
+                TurnResult(
+                    1, {"p1": make_phase_result("p1", output={"score": 5})}, 0.3, True
+                ),
+                TurnResult(
+                    2, {"p1": make_phase_result("p1", output={"score": 8})}, 0.9, False
+                ),
+            ]
         )
+        pipeline = ConversationalPipeline(strategy, ConversationConfig(max_rounds=3))
         await pipeline.execute("test")
         # First round: no previous
         assert strategy.contexts_received[0].get("previous_outputs") is None
@@ -293,28 +304,27 @@ class TestConversationalPipeline:
     async def test_failed_round(self):
         """Strategy exception produces failed status."""
         strategy = FailingTurnStrategy(fail_on=1)
-        pipeline = ConversationalPipeline(
-            strategy, ConversationConfig(max_rounds=3)
-        )
+        pipeline = ConversationalPipeline(strategy, ConversationConfig(max_rounds=3))
         result = await pipeline.execute("test")
         assert result["status"] == "failed"
         assert "Strategy failed" in result["summary"]
 
     async def test_convergence_fn_exception_continues(self):
         """Convergence function error doesn't crash — continues looping."""
+
         def bad_convergence(prev, curr):
             raise ValueError("convergence boom")
 
-        strategy = MockTurnStrategy([
-            TurnResult(1, {}, 0.3, True),
-            TurnResult(2, {}, 0.3, True),
-            TurnResult(3, {}, 0.9, False),
-        ])
+        strategy = MockTurnStrategy(
+            [
+                TurnResult(1, {}, 0.3, True),
+                TurnResult(2, {}, 0.3, True),
+                TurnResult(3, {}, 0.9, False),
+            ]
+        )
         pipeline = ConversationalPipeline(
             strategy,
-            ConversationConfig(
-                max_rounds=3, convergence_fn=bad_convergence
-            ),
+            ConversationConfig(max_rounds=3, convergence_fn=bad_convergence),
         )
         result = await pipeline.execute("test")
         # Convergence fn always fails → reaches round 3 where confidence hits threshold
@@ -322,9 +332,11 @@ class TestConversationalPipeline:
 
     async def test_result_dict_structure(self):
         """Verify complete result dict structure."""
-        strategy = MockTurnStrategy([
-            TurnResult(1, {"p1": make_phase_result("p1")}, 0.9, False),
-        ])
+        strategy = MockTurnStrategy(
+            [
+                TurnResult(1, {"p1": make_phase_result("p1")}, 0.9, False),
+            ]
+        )
         pipeline = ConversationalPipeline(strategy)
         result = await pipeline.execute("test")
         assert "status" in result
@@ -546,7 +558,9 @@ class TestConfidenceExtraction:
 
     def test_handles_failed_phases(self):
         results = {
-            "p1": make_phase_result("p1", PhaseStatus.FAILED, output={"confidence": 0.9}),
+            "p1": make_phase_result(
+                "p1", PhaseStatus.FAILED, output={"confidence": 0.9}
+            ),
         }
         assert _extract_confidence(results) == 0.5  # failed phases ignored
 
@@ -561,7 +575,9 @@ class TestQuestionExtraction:
 
     def test_extracts_questions(self):
         results = {
-            "p1": make_phase_result("p1", output={"user_question": "What do you mean?"}),
+            "p1": make_phase_result(
+                "p1", output={"user_question": "What do you mean?"}
+            ),
         }
         questions = _extract_questions(results)
         assert questions == ["What do you mean?"]
@@ -588,23 +604,25 @@ class TestSummary:
     """Tests for summary generation."""
 
     async def test_summary_format(self):
-        strategy = MockTurnStrategy([
-            TurnResult(1, {"p1": make_phase_result("p1")}, 0.9, False),
-        ])
+        strategy = MockTurnStrategy(
+            [
+                TurnResult(1, {"p1": make_phase_result("p1")}, 0.9, False),
+            ]
+        )
         pipeline = ConversationalPipeline(strategy)
         result = await pipeline.execute("test")
         assert "1 round(s)" in result["summary"]
         assert "high_confidence" in result["summary"]
 
     async def test_multi_round_summary(self):
-        strategy = MockTurnStrategy([
-            TurnResult(1, {}, 0.3, True),
-            TurnResult(2, {}, 0.4, True),
-            TurnResult(3, {}, 0.9, False),
-        ])
-        pipeline = ConversationalPipeline(
-            strategy, ConversationConfig(max_rounds=3)
+        strategy = MockTurnStrategy(
+            [
+                TurnResult(1, {}, 0.3, True),
+                TurnResult(2, {}, 0.4, True),
+                TurnResult(3, {}, 0.9, False),
+            ]
         )
+        pipeline = ConversationalPipeline(strategy, ConversationConfig(max_rounds=3))
         result = await pipeline.execute("test")
         assert "3 round(s)" in result["summary"]
 
@@ -647,9 +665,11 @@ class TestEdgeCases:
 
     async def test_pipeline_with_base_context(self):
         """Base context is merged into each round's context."""
-        strategy = MockTurnStrategy([
-            TurnResult(1, {}, 0.9, False),
-        ])
+        strategy = MockTurnStrategy(
+            [
+                TurnResult(1, {}, 0.9, False),
+            ]
+        )
         pipeline = ConversationalPipeline(strategy)
         await pipeline.execute("test", context={"custom_key": "custom_value"})
         assert strategy.contexts_received[0]["custom_key"] == "custom_value"

--- a/tests/unit/argumentation_analysis/orchestration/test_cross_loops.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_cross_loops.py
@@ -29,7 +29,6 @@ from argumentation_analysis.orchestration.workflow_dsl import (
     WorkflowPhase,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -223,9 +222,7 @@ class TestLoopExecution:
         assert results["p1"].output == {"s": 3}
 
     async def test_convergence_stops_early(self):
-        invoke_fn = AsyncMock(
-            side_effect=[{"s": 1}, {"s": 5}, {"s": 5}]
-        )
+        invoke_fn = AsyncMock(side_effect=[{"s": 1}, {"s": 5}, {"s": 5}])
         registry = make_registry(("cap_a", "prov_a", invoke_fn))
         wf = (
             WorkflowBuilder("loop_conv")
@@ -382,9 +379,7 @@ class TestWorkflowBuilderExtensions:
         conv = lambda p, c: p == c
         wf = (
             WorkflowBuilder("b2")
-            .add_loop(
-                "p1", capability="cap_a", max_iterations=5, convergence_fn=conv
-            )
+            .add_loop("p1", capability="cap_a", max_iterations=5, convergence_fn=conv)
             .build()
         )
         assert wf.phases[0].loop_config is not None

--- a/tests/unit/argumentation_analysis/orchestration/test_engine_config_strategy.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_engine_config_strategy.py
@@ -6,37 +6,43 @@ import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 from dataclasses import asdict
 
-
 # ============================================================================
 # OrchestrationMode Enum Tests
 # ============================================================================
+
 
 class TestOrchestrationMode:
     """Tests for OrchestrationMode enum."""
 
     def test_pipeline_mode(self):
         from argumentation_analysis.orchestration.engine.config import OrchestrationMode
+
         assert OrchestrationMode.PIPELINE.value == "pipeline"
 
     def test_real_mode(self):
         from argumentation_analysis.orchestration.engine.config import OrchestrationMode
+
         assert OrchestrationMode.REAL.value == "real"
 
     def test_auto_select_mode(self):
         from argumentation_analysis.orchestration.engine.config import OrchestrationMode
+
         assert OrchestrationMode.AUTO_SELECT.value == "auto_select"
 
     def test_all_modes_have_unique_values(self):
         from argumentation_analysis.orchestration.engine.config import OrchestrationMode
+
         values = [m.value for m in OrchestrationMode]
         assert len(values) == len(set(values))
 
     def test_mode_count(self):
         from argumentation_analysis.orchestration.engine.config import OrchestrationMode
+
         assert len(OrchestrationMode) == 11
 
     def test_cluedo_investigation_mode(self):
         from argumentation_analysis.orchestration.engine.config import OrchestrationMode
+
         assert OrchestrationMode.CLUEDO_INVESTIGATION.value == "cluedo_investigation"
 
 
@@ -44,28 +50,34 @@ class TestOrchestrationMode:
 # AnalysisType Enum Tests
 # ============================================================================
 
+
 class TestAnalysisType:
     """Tests for AnalysisType enum."""
 
     def test_comprehensive_type(self):
         from argumentation_analysis.orchestration.engine.config import AnalysisType
+
         assert AnalysisType.COMPREHENSIVE.value == "comprehensive"
 
     def test_logical_type(self):
         from argumentation_analysis.orchestration.engine.config import AnalysisType
+
         assert AnalysisType.LOGICAL.value == "logical"
 
     def test_investigative_type(self):
         from argumentation_analysis.orchestration.engine.config import AnalysisType
+
         assert AnalysisType.INVESTIGATIVE.value == "investigative"
 
     def test_all_types_have_unique_values(self):
         from argumentation_analysis.orchestration.engine.config import AnalysisType
+
         values = [t.value for t in AnalysisType]
         assert len(values) == len(set(values))
 
     def test_type_count(self):
         from argumentation_analysis.orchestration.engine.config import AnalysisType
+
         assert len(AnalysisType) == 8
 
 
@@ -73,13 +85,17 @@ class TestAnalysisType:
 # OrchestrationConfig Dataclass Tests
 # ============================================================================
 
+
 class TestOrchestrationConfig:
     """Tests for OrchestrationConfig dataclass."""
 
     def test_default_values(self):
         from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, OrchestrationMode, AnalysisType
+            OrchestrationConfig,
+            OrchestrationMode,
+            AnalysisType,
         )
+
         config = OrchestrationConfig()
         assert config.analysis_modes == ["informal", "formal"]
         assert config.orchestration_mode == OrchestrationMode.PIPELINE
@@ -93,8 +109,11 @@ class TestOrchestrationConfig:
 
     def test_custom_values(self):
         from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, OrchestrationMode, AnalysisType
+            OrchestrationConfig,
+            OrchestrationMode,
+            AnalysisType,
         )
+
         config = OrchestrationConfig(
             orchestration_mode=OrchestrationMode.REAL,
             analysis_type=AnalysisType.LOGICAL,
@@ -108,47 +127,69 @@ class TestOrchestrationConfig:
 
     def test_string_mode_conversion(self):
         from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, OrchestrationMode
+            OrchestrationConfig,
+            OrchestrationMode,
         )
+
         config = OrchestrationConfig(orchestration_mode="pipeline")
         assert config.orchestration_mode == OrchestrationMode.PIPELINE
 
     def test_string_analysis_type_conversion(self):
         from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, AnalysisType
+            OrchestrationConfig,
+            AnalysisType,
         )
+
         config = OrchestrationConfig(analysis_type="logical")
         assert config.analysis_type == AnalysisType.LOGICAL
 
     def test_invalid_string_mode_stays_string(self):
-        from argumentation_analysis.orchestration.engine.config import OrchestrationConfig
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+        )
+
         config = OrchestrationConfig(orchestration_mode="unknown_mode")
         assert config.orchestration_mode == "unknown_mode"
 
     def test_invalid_string_analysis_type_stays_string(self):
-        from argumentation_analysis.orchestration.engine.config import OrchestrationConfig
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+        )
+
         config = OrchestrationConfig(analysis_type="unknown_type")
         assert config.analysis_type == "unknown_type"
 
     def test_default_analysis_modes(self):
-        from argumentation_analysis.orchestration.engine.config import OrchestrationConfig
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+        )
+
         config = OrchestrationConfig()
         assert "informal" in config.analysis_modes
         assert "formal" in config.analysis_modes
 
     def test_default_priority_order(self):
-        from argumentation_analysis.orchestration.engine.config import OrchestrationConfig
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+        )
+
         config = OrchestrationConfig()
         assert "cluedo_investigation" in config.specialized_orchestrator_priority_order
         assert "logic_complex" in config.specialized_orchestrator_priority_order
 
     def test_default_communication_config_empty(self):
-        from argumentation_analysis.orchestration.engine.config import OrchestrationConfig
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+        )
+
         config = OrchestrationConfig()
         assert config.communication_middleware_config == {}
 
     def test_save_trace_default_enabled(self):
-        from argumentation_analysis.orchestration.engine.config import OrchestrationConfig
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+        )
+
         config = OrchestrationConfig()
         assert config.save_orchestration_trace_enabled is True
 
@@ -157,36 +198,58 @@ class TestOrchestrationConfig:
 # OrchestrationStrategy Enum Tests
 # ============================================================================
 
+
 class TestOrchestrationStrategy:
     """Tests for OrchestrationStrategy enum."""
 
     def test_hierarchical_full(self):
-        from argumentation_analysis.orchestration.engine.strategy import OrchestrationStrategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            OrchestrationStrategy,
+        )
+
         assert OrchestrationStrategy.HIERARCHICAL_FULL.value == "hierarchical_full"
 
     def test_fallback(self):
-        from argumentation_analysis.orchestration.engine.strategy import OrchestrationStrategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            OrchestrationStrategy,
+        )
+
         assert OrchestrationStrategy.FALLBACK.value == "fallback"
 
     def test_service_manager(self):
-        from argumentation_analysis.orchestration.engine.strategy import OrchestrationStrategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            OrchestrationStrategy,
+        )
+
         assert OrchestrationStrategy.SERVICE_MANAGER.value == "service_manager"
 
     def test_manual_selection(self):
-        from argumentation_analysis.orchestration.engine.strategy import OrchestrationStrategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            OrchestrationStrategy,
+        )
+
         assert OrchestrationStrategy.MANUAL_SELECTION.value == "manual_selection"
 
     def test_complex_pipeline(self):
-        from argumentation_analysis.orchestration.engine.strategy import OrchestrationStrategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            OrchestrationStrategy,
+        )
+
         assert OrchestrationStrategy.COMPLEX_PIPELINE.value == "complex_pipeline"
 
     def test_all_strategies_unique(self):
-        from argumentation_analysis.orchestration.engine.strategy import OrchestrationStrategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            OrchestrationStrategy,
+        )
+
         values = [s.value for s in OrchestrationStrategy]
         assert len(values) == len(set(values))
 
     def test_strategy_count(self):
-        from argumentation_analysis.orchestration.engine.strategy import OrchestrationStrategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            OrchestrationStrategy,
+        )
+
         assert len(OrchestrationStrategy) == 10
 
 
@@ -194,59 +257,90 @@ class TestOrchestrationStrategy:
 # _analyze_text_features_for_strategy Tests
 # ============================================================================
 
+
 class TestAnalyzeTextFeatures:
     """Tests for _analyze_text_features_for_strategy()."""
 
     async def test_basic_features(self):
-        from argumentation_analysis.orchestration.engine.strategy import _analyze_text_features_for_strategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            _analyze_text_features_for_strategy,
+        )
+
         features = await _analyze_text_features_for_strategy("Hello world.")
         assert features["length"] == 12
         assert features["word_count"] == 2
         assert features["sentence_count"] == 1
 
     async def test_has_questions(self):
-        from argumentation_analysis.orchestration.engine.strategy import _analyze_text_features_for_strategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            _analyze_text_features_for_strategy,
+        )
+
         features = await _analyze_text_features_for_strategy("Is this a question?")
         assert features["has_questions"] is True
 
     async def test_no_questions(self):
-        from argumentation_analysis.orchestration.engine.strategy import _analyze_text_features_for_strategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            _analyze_text_features_for_strategy,
+        )
+
         features = await _analyze_text_features_for_strategy("No question here.")
         assert features["has_questions"] is False
 
     async def test_logical_connectors(self):
-        from argumentation_analysis.orchestration.engine.strategy import _analyze_text_features_for_strategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            _analyze_text_features_for_strategy,
+        )
+
         features = await _analyze_text_features_for_strategy("Donc on peut conclure.")
         assert features["has_logical_connectors"] is True
 
     async def test_no_logical_connectors(self):
-        from argumentation_analysis.orchestration.engine.strategy import _analyze_text_features_for_strategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            _analyze_text_features_for_strategy,
+        )
+
         features = await _analyze_text_features_for_strategy("Simple sentence.")
         assert features["has_logical_connectors"] is False
 
     async def test_debate_markers(self):
-        from argumentation_analysis.orchestration.engine.strategy import _analyze_text_features_for_strategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            _analyze_text_features_for_strategy,
+        )
+
         features = await _analyze_text_features_for_strategy("Mon argument principal.")
         assert features["has_debate_markers"] is True
 
     async def test_no_debate_markers(self):
-        from argumentation_analysis.orchestration.engine.strategy import _analyze_text_features_for_strategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            _analyze_text_features_for_strategy,
+        )
+
         features = await _analyze_text_features_for_strategy("Simple text.")
         assert features["has_debate_markers"] is False
 
     async def test_complexity_score_caps_at_5(self):
-        from argumentation_analysis.orchestration.engine.strategy import _analyze_text_features_for_strategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            _analyze_text_features_for_strategy,
+        )
+
         long_text = "a" * 5000
         features = await _analyze_text_features_for_strategy(long_text)
         assert features["complexity_score"] == 5.0
 
     async def test_complexity_score_short_text(self):
-        from argumentation_analysis.orchestration.engine.strategy import _analyze_text_features_for_strategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            _analyze_text_features_for_strategy,
+        )
+
         features = await _analyze_text_features_for_strategy("Hi.")
         assert features["complexity_score"] < 1.0
 
     async def test_empty_text(self):
-        from argumentation_analysis.orchestration.engine.strategy import _analyze_text_features_for_strategy
+        from argumentation_analysis.orchestration.engine.strategy import (
+            _analyze_text_features_for_strategy,
+        )
+
         features = await _analyze_text_features_for_strategy("")
         assert features["length"] == 0
         assert features["word_count"] == 0  # "".split() returns []
@@ -257,23 +351,40 @@ class TestAnalyzeTextFeatures:
 # select_strategy Tests
 # ============================================================================
 
+
 class TestSelectStrategy:
     """Tests for select_strategy()."""
 
     async def test_manual_mode_returns_manual_selection(self):
-        from argumentation_analysis.orchestration.engine.strategy import select_strategy, OrchestrationStrategy
-        from argumentation_analysis.orchestration.engine.config import OrchestrationConfig
+        from argumentation_analysis.orchestration.engine.strategy import (
+            select_strategy,
+            OrchestrationStrategy,
+        )
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+        )
+
         config = OrchestrationConfig()
-        with patch("argumentation_analysis.orchestration.engine.strategy.UnifiedConfig") as MockConfig:
+        with patch(
+            "argumentation_analysis.orchestration.engine.strategy.UnifiedConfig"
+        ) as MockConfig:
             MockConfig.return_value.manual_mode = True
             result = await select_strategy(config, "test text")
             assert result == OrchestrationStrategy.MANUAL_SELECTION
 
     async def test_force_strategy_from_custom_config(self):
-        from argumentation_analysis.orchestration.engine.strategy import select_strategy, OrchestrationStrategy
-        from argumentation_analysis.orchestration.engine.config import OrchestrationConfig
+        from argumentation_analysis.orchestration.engine.strategy import (
+            select_strategy,
+            OrchestrationStrategy,
+        )
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+        )
+
         config = OrchestrationConfig()
-        with patch("argumentation_analysis.orchestration.engine.strategy.UnifiedConfig") as MockConfig:
+        with patch(
+            "argumentation_analysis.orchestration.engine.strategy.UnifiedConfig"
+        ) as MockConfig:
             MockConfig.return_value.manual_mode = False
             result = await select_strategy(
                 config, "test", custom_config={"force_strategy": "fallback"}
@@ -281,15 +392,22 @@ class TestSelectStrategy:
             assert result == OrchestrationStrategy.FALLBACK
 
     async def test_force_invalid_strategy_falls_through(self):
-        from argumentation_analysis.orchestration.engine.strategy import select_strategy, OrchestrationStrategy
-        from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, OrchestrationMode
+        from argumentation_analysis.orchestration.engine.strategy import (
+            select_strategy,
+            OrchestrationStrategy,
         )
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+            OrchestrationMode,
+        )
+
         config = OrchestrationConfig(
             orchestration_mode=OrchestrationMode.AUTO_SELECT,
             auto_select_orchestrator_enabled=False,
         )
-        with patch("argumentation_analysis.orchestration.engine.strategy.UnifiedConfig") as MockConfig:
+        with patch(
+            "argumentation_analysis.orchestration.engine.strategy.UnifiedConfig"
+        ) as MockConfig:
             MockConfig.return_value.manual_mode = False
             result = await select_strategy(
                 config, "test", custom_config={"force_strategy": "nonexistent"}
@@ -298,10 +416,18 @@ class TestSelectStrategy:
             assert result == OrchestrationStrategy.HIERARCHICAL_FULL
 
     async def test_monitoring_source_returns_operational(self):
-        from argumentation_analysis.orchestration.engine.strategy import select_strategy, OrchestrationStrategy
-        from argumentation_analysis.orchestration.engine.config import OrchestrationConfig
+        from argumentation_analysis.orchestration.engine.strategy import (
+            select_strategy,
+            OrchestrationStrategy,
+        )
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+        )
+
         config = OrchestrationConfig()
-        with patch("argumentation_analysis.orchestration.engine.strategy.UnifiedConfig") as MockConfig:
+        with patch(
+            "argumentation_analysis.orchestration.engine.strategy.UnifiedConfig"
+        ) as MockConfig:
             MockConfig.return_value.manual_mode = False
             result = await select_strategy(
                 config, "test", source_info={"type": "monitoring"}
@@ -309,80 +435,123 @@ class TestSelectStrategy:
             assert result == OrchestrationStrategy.OPERATIONAL_DIRECT
 
     async def test_manual_mode_hierarchical(self):
-        from argumentation_analysis.orchestration.engine.strategy import select_strategy, OrchestrationStrategy
-        from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, OrchestrationMode
+        from argumentation_analysis.orchestration.engine.strategy import (
+            select_strategy,
+            OrchestrationStrategy,
         )
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+            OrchestrationMode,
+        )
+
         config = OrchestrationConfig(
             orchestration_mode=OrchestrationMode.HIERARCHICAL_FULL
         )
-        with patch("argumentation_analysis.orchestration.engine.strategy.UnifiedConfig") as MockConfig:
+        with patch(
+            "argumentation_analysis.orchestration.engine.strategy.UnifiedConfig"
+        ) as MockConfig:
             MockConfig.return_value.manual_mode = False
             result = await select_strategy(config, "test")
             assert result == OrchestrationStrategy.HIERARCHICAL_FULL
 
     async def test_manual_mode_cluedo_maps_to_specialized(self):
-        from argumentation_analysis.orchestration.engine.strategy import select_strategy, OrchestrationStrategy
-        from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, OrchestrationMode
+        from argumentation_analysis.orchestration.engine.strategy import (
+            select_strategy,
+            OrchestrationStrategy,
         )
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+            OrchestrationMode,
+        )
+
         config = OrchestrationConfig(
             orchestration_mode=OrchestrationMode.CLUEDO_INVESTIGATION
         )
-        with patch("argumentation_analysis.orchestration.engine.strategy.UnifiedConfig") as MockConfig:
+        with patch(
+            "argumentation_analysis.orchestration.engine.strategy.UnifiedConfig"
+        ) as MockConfig:
             MockConfig.return_value.manual_mode = False
             result = await select_strategy(config, "test")
             assert result == OrchestrationStrategy.SPECIALIZED_DIRECT
 
     async def test_auto_select_disabled_returns_hierarchical(self):
-        from argumentation_analysis.orchestration.engine.strategy import select_strategy, OrchestrationStrategy
-        from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, OrchestrationMode
+        from argumentation_analysis.orchestration.engine.strategy import (
+            select_strategy,
+            OrchestrationStrategy,
         )
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+            OrchestrationMode,
+        )
+
         config = OrchestrationConfig(
             orchestration_mode=OrchestrationMode.AUTO_SELECT,
             auto_select_orchestrator_enabled=False,
         )
-        with patch("argumentation_analysis.orchestration.engine.strategy.UnifiedConfig") as MockConfig:
+        with patch(
+            "argumentation_analysis.orchestration.engine.strategy.UnifiedConfig"
+        ) as MockConfig:
             MockConfig.return_value.manual_mode = False
             result = await select_strategy(config, "test")
             assert result == OrchestrationStrategy.HIERARCHICAL_FULL
 
     async def test_auto_select_investigative(self):
-        from argumentation_analysis.orchestration.engine.strategy import select_strategy, OrchestrationStrategy
-        from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, OrchestrationMode, AnalysisType
+        from argumentation_analysis.orchestration.engine.strategy import (
+            select_strategy,
+            OrchestrationStrategy,
         )
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+            OrchestrationMode,
+            AnalysisType,
+        )
+
         config = OrchestrationConfig(
             orchestration_mode=OrchestrationMode.AUTO_SELECT,
             analysis_type=AnalysisType.INVESTIGATIVE,
             auto_select_orchestrator_enabled=True,
         )
-        with patch("argumentation_analysis.orchestration.engine.strategy.UnifiedConfig") as MockConfig:
+        with patch(
+            "argumentation_analysis.orchestration.engine.strategy.UnifiedConfig"
+        ) as MockConfig:
             MockConfig.return_value.manual_mode = False
             result = await select_strategy(config, "test")
             assert result == OrchestrationStrategy.SPECIALIZED_DIRECT
 
     async def test_auto_select_logical(self):
-        from argumentation_analysis.orchestration.engine.strategy import select_strategy, OrchestrationStrategy
-        from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, OrchestrationMode, AnalysisType
+        from argumentation_analysis.orchestration.engine.strategy import (
+            select_strategy,
+            OrchestrationStrategy,
         )
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+            OrchestrationMode,
+            AnalysisType,
+        )
+
         config = OrchestrationConfig(
             orchestration_mode=OrchestrationMode.AUTO_SELECT,
             analysis_type=AnalysisType.LOGICAL,
             auto_select_orchestrator_enabled=True,
         )
-        with patch("argumentation_analysis.orchestration.engine.strategy.UnifiedConfig") as MockConfig:
+        with patch(
+            "argumentation_analysis.orchestration.engine.strategy.UnifiedConfig"
+        ) as MockConfig:
             MockConfig.return_value.manual_mode = False
             result = await select_strategy(config, "test")
             assert result == OrchestrationStrategy.SPECIALIZED_DIRECT
 
     async def test_auto_select_long_text_hierarchical(self):
-        from argumentation_analysis.orchestration.engine.strategy import select_strategy, OrchestrationStrategy
-        from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, OrchestrationMode, AnalysisType
+        from argumentation_analysis.orchestration.engine.strategy import (
+            select_strategy,
+            OrchestrationStrategy,
         )
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+            OrchestrationMode,
+            AnalysisType,
+        )
+
         config = OrchestrationConfig(
             orchestration_mode=OrchestrationMode.AUTO_SELECT,
             analysis_type=AnalysisType.COMPREHENSIVE,
@@ -390,23 +559,33 @@ class TestSelectStrategy:
             enable_hierarchical_orchestration=True,
         )
         long_text = "a " * 600  # > 1000 chars
-        with patch("argumentation_analysis.orchestration.engine.strategy.UnifiedConfig") as MockConfig:
+        with patch(
+            "argumentation_analysis.orchestration.engine.strategy.UnifiedConfig"
+        ) as MockConfig:
             MockConfig.return_value.manual_mode = False
             result = await select_strategy(config, long_text)
             assert result == OrchestrationStrategy.HIERARCHICAL_FULL
 
     async def test_auto_select_default_complex_pipeline(self):
-        from argumentation_analysis.orchestration.engine.strategy import select_strategy, OrchestrationStrategy
-        from argumentation_analysis.orchestration.engine.config import (
-            OrchestrationConfig, OrchestrationMode, AnalysisType
+        from argumentation_analysis.orchestration.engine.strategy import (
+            select_strategy,
+            OrchestrationStrategy,
         )
+        from argumentation_analysis.orchestration.engine.config import (
+            OrchestrationConfig,
+            OrchestrationMode,
+            AnalysisType,
+        )
+
         config = OrchestrationConfig(
             orchestration_mode=OrchestrationMode.AUTO_SELECT,
             analysis_type=AnalysisType.COMPREHENSIVE,
             auto_select_orchestrator_enabled=True,
             enable_hierarchical_orchestration=False,
         )
-        with patch("argumentation_analysis.orchestration.engine.strategy.UnifiedConfig") as MockConfig:
+        with patch(
+            "argumentation_analysis.orchestration.engine.strategy.UnifiedConfig"
+        ) as MockConfig:
             MockConfig.return_value.manual_mode = False
             result = await select_strategy(config, "short text")
             assert result == OrchestrationStrategy.COMPLEX_PIPELINE
@@ -416,6 +595,7 @@ class TestSelectStrategy:
 # EnqueteStateManagerPlugin Tests
 # ============================================================================
 
+
 class TestEnqueteStateManagerPluginInit:
     """Tests for EnqueteStateManagerPlugin initialization."""
 
@@ -423,6 +603,7 @@ class TestEnqueteStateManagerPluginInit:
         from argumentation_analysis.orchestration.plugins.enquete_state_manager_plugin import (
             EnqueteStateManagerPlugin,
         )
+
         mock_state = MagicMock()
         plugin = EnqueteStateManagerPlugin(state=mock_state)
         assert plugin._state is mock_state
@@ -431,6 +612,7 @@ class TestEnqueteStateManagerPluginInit:
         from argumentation_analysis.orchestration.plugins.enquete_state_manager_plugin import (
             EnqueteStateManagerPlugin,
         )
+
         mock_state = MagicMock()
         plugin = EnqueteStateManagerPlugin(state=mock_state)
         assert plugin._logger is not None
@@ -443,12 +625,17 @@ class TestEnqueteStateManagerPluginTasks:
         from argumentation_analysis.orchestration.plugins.enquete_state_manager_plugin import (
             EnqueteStateManagerPlugin,
         )
+
         mock_state = MagicMock()
         return EnqueteStateManagerPlugin(state=mock_state), mock_state
 
     def test_add_task_success(self):
         plugin, state = self._make_plugin()
-        state.add_task.return_value = {"id": "t1", "description": "Test", "assignee": "Agent"}
+        state.add_task.return_value = {
+            "id": "t1",
+            "description": "Test",
+            "assignee": "Agent",
+        }
         result = json.loads(plugin.add_task("Test task", "Agent"))
         assert result["id"] == "t1"
 
@@ -490,6 +677,7 @@ class TestEnqueteStateManagerPluginDesignation:
         from argumentation_analysis.orchestration.plugins.enquete_state_manager_plugin import (
             EnqueteStateManagerPlugin,
         )
+
         mock_state = MagicMock()
         return EnqueteStateManagerPlugin(state=mock_state), mock_state
 
@@ -520,6 +708,7 @@ class TestEnqueteStateManagerPluginCaseDescription:
             EnqueteStateManagerPlugin,
         )
         from argumentation_analysis.core.enquete_states import EnquetePoliciereState
+
         mock_state = MagicMock(spec=EnquetePoliciereState)
         return EnqueteStateManagerPlugin(state=mock_state), mock_state
 
@@ -528,6 +717,7 @@ class TestEnqueteStateManagerPluginCaseDescription:
             EnqueteStateManagerPlugin,
         )
         from argumentation_analysis.core.enquete_states import BaseWorkflowState
+
         mock_state = MagicMock(spec=BaseWorkflowState)
         return EnqueteStateManagerPlugin(state=mock_state), mock_state
 
@@ -562,13 +752,19 @@ class TestEnqueteStateManagerPluginElements:
             EnqueteStateManagerPlugin,
         )
         from argumentation_analysis.core.enquete_states import EnquetePoliciereState
+
         mock_state = MagicMock(spec=EnquetePoliciereState)
         return EnqueteStateManagerPlugin(state=mock_state), mock_state
 
     def test_add_identified_element(self):
         plugin, state = self._make_plugin()
-        state.add_identified_element.return_value = {"type": "evidence", "description": "Knife"}
-        result = json.loads(plugin.add_identified_element("evidence", "Knife", "Crime scene"))
+        state.add_identified_element.return_value = {
+            "type": "evidence",
+            "description": "Knife",
+        }
+        result = json.loads(
+            plugin.add_identified_element("evidence", "Knife", "Crime scene")
+        )
         assert result["type"] == "evidence"
 
     def test_get_identified_elements(self):
@@ -586,6 +782,7 @@ class TestEnqueteStateManagerPluginBeliefSets:
             EnqueteStateManagerPlugin,
         )
         from argumentation_analysis.core.enquete_states import EnquetePoliciereState
+
         mock_state = MagicMock(spec=EnquetePoliciereState)
         return EnqueteStateManagerPlugin(state=mock_state), mock_state
 

--- a/tests/unit/argumentation_analysis/orchestration/test_fact_checking_orchestrator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_fact_checking_orchestrator.py
@@ -14,7 +14,6 @@ from unittest.mock import MagicMock, AsyncMock, patch
 from datetime import datetime
 from enum import Enum
 
-
 # ---------------------------------------------------------------------------
 # We import the real AnalysisDepth enum so tests stay close to production.
 # Everything else that touches external services is mocked.
@@ -22,7 +21,6 @@ from enum import Enum
 from argumentation_analysis.agents.tools.analysis.fallacy_family_analyzer import (
     AnalysisDepth,
 )
-
 
 # ---------------------------------------------------------------------------
 # Module path constant for patching
@@ -34,11 +32,14 @@ MOD = "argumentation_analysis.orchestration.fact_checking_orchestrator"
 # Helpers to build mock objects used across many tests
 # ---------------------------------------------------------------------------
 
+
 def _make_mock_comprehensive_result(**overrides):
     """Return a MagicMock that behaves like ComprehensiveAnalysisResult."""
     result = MagicMock()
     result.text_analyzed = overrides.get("text_analyzed", "sample text")
-    result.analysis_timestamp = overrides.get("analysis_timestamp", datetime(2026, 1, 1))
+    result.analysis_timestamp = overrides.get(
+        "analysis_timestamp", datetime(2026, 1, 1)
+    )
     result.analysis_depth = overrides.get("analysis_depth", AnalysisDepth.STANDARD)
     result.family_results = overrides.get("family_results", {})
     result.factual_claims = overrides.get("factual_claims", [])
@@ -79,10 +80,12 @@ def _build_plugin_registry():
 # Fixtures
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True)
 def _reset_singleton():
     """Reset the module-level singleton before each test."""
     import argumentation_analysis.orchestration.fact_checking_orchestrator as mod
+
     mod._global_fact_checking_orchestrator = None
     yield
     mod._global_fact_checking_orchestrator = None
@@ -105,12 +108,14 @@ def mock_family_analyzer():
 @pytest.fixture
 def orchestrator(plugin_registry, mock_family_analyzer):
     """Build a fully-mocked FactCheckingOrchestrator."""
-    with patch(f"{MOD}.get_family_analyzer", return_value=mock_family_analyzer), \
-         patch(f"{MOD}.FactClaimExtractor") as mock_extractor_cls:
+    with patch(f"{MOD}.get_family_analyzer", return_value=mock_family_analyzer), patch(
+        f"{MOD}.FactClaimExtractor"
+    ) as mock_extractor_cls:
         mock_extractor_cls.return_value = MagicMock()
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingOrchestrator,
         )
+
         orch = FactCheckingOrchestrator(
             plugin_registry=plugin_registry,
             api_config={"key": "value"},
@@ -132,6 +137,7 @@ class TestFactCheckingRequest:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingRequest,
         )
+
         req = FactCheckingRequest(text="Hello world")
         assert req.text == "Hello world"
         assert req.analysis_depth == AnalysisDepth.STANDARD
@@ -145,6 +151,7 @@ class TestFactCheckingRequest:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingRequest,
         )
+
         req = FactCheckingRequest(
             text="Test",
             analysis_depth=AnalysisDepth.EXPERT,
@@ -165,6 +172,7 @@ class TestFactCheckingRequest:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingRequest,
         )
+
         for depth in AnalysisDepth:
             req = FactCheckingRequest(text="t", analysis_depth=depth)
             assert req.analysis_depth is depth
@@ -182,6 +190,7 @@ class TestFactCheckingResponse:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingResponse,
         )
+
         comp = _make_mock_comprehensive_result()
         ts = datetime(2026, 3, 1, 12, 0, 0)
         resp = FactCheckingResponse(
@@ -201,6 +210,7 @@ class TestFactCheckingResponse:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingResponse,
         )
+
         comp = _make_mock_comprehensive_result()
         ts = datetime(2026, 3, 1, 12, 0, 0)
         resp = FactCheckingResponse(
@@ -222,6 +232,7 @@ class TestFactCheckingResponse:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingResponse,
         )
+
         long_text = "A" * 300
         comp = _make_mock_comprehensive_result()
         resp = FactCheckingResponse(
@@ -240,6 +251,7 @@ class TestFactCheckingResponse:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingResponse,
         )
+
         comp = _make_mock_comprehensive_result()
         resp = FactCheckingResponse(
             request_id="req-err",
@@ -264,12 +276,14 @@ class TestOrchestratorInit:
     """Tests for FactCheckingOrchestrator initialization."""
 
     def test_init_with_plugin_registry(self, plugin_registry):
-        with patch(f"{MOD}.get_family_analyzer") as mock_gfa, \
-             patch(f"{MOD}.FactClaimExtractor"):
+        with patch(f"{MOD}.get_family_analyzer") as mock_gfa, patch(
+            f"{MOD}.FactClaimExtractor"
+        ):
             mock_gfa.return_value = MagicMock()
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 FactCheckingOrchestrator,
             )
+
             orch = FactCheckingOrchestrator(plugin_registry=plugin_registry)
 
         assert orch.taxonomy_plugin is plugin_registry["taxonomy_explorer"]
@@ -280,14 +294,16 @@ class TestOrchestratorInit:
     def test_init_without_registry_uses_singletons(self):
         mock_tm = MagicMock()
         mock_vs = MagicMock()
-        with patch(f"{MOD}.get_taxonomy_manager", return_value=mock_tm), \
-             patch(f"{MOD}.get_verification_service", return_value=mock_vs), \
-             patch(f"{MOD}.get_family_analyzer") as mock_gfa, \
-             patch(f"{MOD}.FactClaimExtractor"):
+        with patch(f"{MOD}.get_taxonomy_manager", return_value=mock_tm), patch(
+            f"{MOD}.get_verification_service", return_value=mock_vs
+        ), patch(f"{MOD}.get_family_analyzer") as mock_gfa, patch(
+            f"{MOD}.FactClaimExtractor"
+        ):
             mock_gfa.return_value = MagicMock()
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 FactCheckingOrchestrator,
             )
+
             orch = FactCheckingOrchestrator()
 
         assert orch.taxonomy_plugin is mock_tm
@@ -299,6 +315,7 @@ class TestOrchestratorInit:
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 FactCheckingOrchestrator,
             )
+
             with pytest.raises(ValueError, match="taxonomy_explorer"):
                 FactCheckingOrchestrator(plugin_registry=registry)
 
@@ -308,26 +325,31 @@ class TestOrchestratorInit:
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 FactCheckingOrchestrator,
             )
+
             with pytest.raises(ValueError, match="external_verification"):
                 FactCheckingOrchestrator(plugin_registry=registry)
 
     def test_init_api_config_defaults_to_empty_dict(self, plugin_registry):
-        with patch(f"{MOD}.get_family_analyzer") as mock_gfa, \
-             patch(f"{MOD}.FactClaimExtractor"):
+        with patch(f"{MOD}.get_family_analyzer") as mock_gfa, patch(
+            f"{MOD}.FactClaimExtractor"
+        ):
             mock_gfa.return_value = MagicMock()
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 FactCheckingOrchestrator,
             )
+
             orch = FactCheckingOrchestrator(plugin_registry=plugin_registry)
         assert orch.api_config == {}
 
     def test_backward_compat_aliases(self, plugin_registry):
-        with patch(f"{MOD}.get_family_analyzer") as mock_gfa, \
-             patch(f"{MOD}.FactClaimExtractor"):
+        with patch(f"{MOD}.get_family_analyzer") as mock_gfa, patch(
+            f"{MOD}.FactClaimExtractor"
+        ):
             mock_gfa.return_value = MagicMock()
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 FactCheckingOrchestrator,
             )
+
             orch = FactCheckingOrchestrator(plugin_registry=plugin_registry)
         assert orch.taxonomy_manager is orch.taxonomy_plugin
         assert orch.verification_service is orch.verification_plugin
@@ -345,6 +367,7 @@ class TestAnalyzeWithFactChecking:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingRequest,
         )
+
         req = FactCheckingRequest(text="Test text for analysis")
         resp = await orchestrator.analyze_with_fact_checking(req)
 
@@ -358,6 +381,7 @@ class TestAnalyzeWithFactChecking:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingRequest,
         )
+
         assert orchestrator.analysis_count == 0
         req = FactCheckingRequest(text="Test")
         await orchestrator.analyze_with_fact_checking(req)
@@ -369,6 +393,7 @@ class TestAnalyzeWithFactChecking:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingRequest,
         )
+
         mock_family_analyzer.analyze_comprehensive.side_effect = RuntimeError("boom")
         req = FactCheckingRequest(text="Test")
         resp = await orchestrator.analyze_with_fact_checking(req)
@@ -383,6 +408,7 @@ class TestAnalyzeWithFactChecking:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingRequest,
         )
+
         mock_family_analyzer.analyze_comprehensive.side_effect = ValueError("bad input")
         req = FactCheckingRequest(text="Test", analysis_depth=AnalysisDepth.BASIC)
 
@@ -398,6 +424,7 @@ class TestAnalyzeWithFactChecking:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingRequest,
         )
+
         req = FactCheckingRequest(text="Test")
         resp = await orchestrator.analyze_with_fact_checking(req)
         # Should be a valid UUID
@@ -421,7 +448,9 @@ class TestQuickFactCheck:
             return_value=[mock_verif]
         )
 
-        result = await orchestrator.quick_fact_check("Some text with facts", max_claims=3)
+        result = await orchestrator.quick_fact_check(
+            "Some text with facts", max_claims=3
+        )
 
         assert result["status"] == "completed"
         assert result["claims_count"] == 1
@@ -438,7 +467,9 @@ class TestQuickFactCheck:
         assert "message" in result
 
     async def test_error_handling(self, orchestrator):
-        orchestrator.fact_extractor.extract_factual_claims.side_effect = Exception("fail")
+        orchestrator.fact_extractor.extract_factual_claims.side_effect = Exception(
+            "fail"
+        )
 
         result = await orchestrator.quick_fact_check("Some text")
 
@@ -594,7 +625,9 @@ class TestBatchAnalyze:
         # Each text triggers one call
         assert mock_family_analyzer.analyze_comprehensive.await_count == 3
 
-    async def test_handles_exceptions_in_batch(self, orchestrator, mock_family_analyzer):
+    async def test_handles_exceptions_in_batch(
+        self, orchestrator, mock_family_analyzer
+    ):
         call_count = 0
 
         async def side_effect(**kwargs):
@@ -649,9 +682,8 @@ class TestPerformanceMetrics:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingRequest,
         )
-        await orchestrator.analyze_with_fact_checking(
-            FactCheckingRequest(text="Test")
-        )
+
+        await orchestrator.analyze_with_fact_checking(FactCheckingRequest(text="Test"))
         metrics = orchestrator.get_performance_metrics()
         assert metrics["total_analyses"] == 1
         assert metrics["total_processing_time"] >= 0  # may be 0.0 on fast machines
@@ -665,6 +697,7 @@ class TestPerformanceMetrics:
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingRequest,
         )
+
         mock_family_analyzer.analyze_comprehensive.side_effect = Exception("err")
 
         with patch(f"{MOD}.ComprehensiveAnalysisResult") as mock_car:
@@ -679,11 +712,14 @@ class TestPerformanceMetrics:
         assert metrics["total_analyses"] == 0
         assert metrics["error_rate"] == 0.0
 
-    async def test_metrics_mixed_success_and_error(self, orchestrator, mock_family_analyzer):
+    async def test_metrics_mixed_success_and_error(
+        self, orchestrator, mock_family_analyzer
+    ):
         """After one success + one error, error_rate = 1/1 = 1.0 (only successes counted)."""
         from argumentation_analysis.orchestration.fact_checking_orchestrator import (
             FactCheckingRequest,
         )
+
         # First call succeeds
         await orchestrator.analyze_with_fact_checking(FactCheckingRequest(text="ok"))
 
@@ -691,7 +727,9 @@ class TestPerformanceMetrics:
         mock_family_analyzer.analyze_comprehensive.side_effect = Exception("err")
         with patch(f"{MOD}.ComprehensiveAnalysisResult") as mock_car:
             mock_car.return_value = _make_mock_comprehensive_result()
-            await orchestrator.analyze_with_fact_checking(FactCheckingRequest(text="fail"))
+            await orchestrator.analyze_with_fact_checking(
+                FactCheckingRequest(text="fail")
+            )
 
         metrics = orchestrator.get_performance_metrics()
         assert metrics["total_analyses"] == 1
@@ -720,7 +758,9 @@ class TestHealthCheck:
         assert health["components"]["family_analyzer"]["status"] == "ok"
 
     async def test_extractor_error(self, orchestrator):
-        orchestrator.fact_extractor.extract_factual_claims.side_effect = Exception("broken")
+        orchestrator.fact_extractor.extract_factual_claims.side_effect = Exception(
+            "broken"
+        )
         orchestrator.taxonomy_manager.detect_fallacies_with_families.return_value = []
 
         health = await orchestrator.health_check()
@@ -730,7 +770,9 @@ class TestHealthCheck:
 
     async def test_taxonomy_fallback_to_plugin(self, orchestrator, plugin_registry):
         # Sync service call fails -> falls back to async plugin
-        orchestrator.taxonomy_manager.detect_fallacies_with_families.side_effect = Exception("sync fail")
+        orchestrator.taxonomy_manager.detect_fallacies_with_families.side_effect = (
+            Exception("sync fail")
+        )
         plugin_registry["taxonomy_explorer"].detect_and_classify = AsyncMock(
             return_value=[MagicMock()]
         )
@@ -783,6 +825,7 @@ class TestModuleLevelFunctions:
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 get_taxonomy_manager,
             )
+
             result = get_taxonomy_manager()
             assert result == "tm_instance"
 
@@ -794,20 +837,23 @@ class TestModuleLevelFunctions:
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 get_verification_service,
             )
+
             result = get_verification_service()
             assert result == "vs_instance"
 
     def test_singleton_factory_creates_once(self):
         mock_tm = MagicMock()
         mock_vs = MagicMock()
-        with patch(f"{MOD}.get_taxonomy_manager", return_value=mock_tm), \
-             patch(f"{MOD}.get_verification_service", return_value=mock_vs), \
-             patch(f"{MOD}.get_family_analyzer") as mock_gfa, \
-             patch(f"{MOD}.FactClaimExtractor"):
+        with patch(f"{MOD}.get_taxonomy_manager", return_value=mock_tm), patch(
+            f"{MOD}.get_verification_service", return_value=mock_vs
+        ), patch(f"{MOD}.get_family_analyzer") as mock_gfa, patch(
+            f"{MOD}.FactClaimExtractor"
+        ):
             mock_gfa.return_value = MagicMock()
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 get_fact_checking_orchestrator,
             )
+
             orch1 = get_fact_checking_orchestrator(api_config={"k": "v"})
             orch2 = get_fact_checking_orchestrator()
             assert orch1 is orch2
@@ -822,6 +868,7 @@ class TestModuleLevelFunctions:
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 quick_analyze_text,
             )
+
             result = await quick_analyze_text("Hello", api_config={"k": "v"})
 
         assert result == {"result": "ok"}
@@ -835,6 +882,7 @@ class TestModuleLevelFunctions:
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 quick_fact_check_only,
             )
+
             result = await quick_fact_check_only("text", api_config={"k": "v"})
 
         assert result == {"status": "no_claims"}
@@ -849,6 +897,7 @@ class TestModuleLevelFunctions:
             from argumentation_analysis.orchestration.fact_checking_orchestrator import (
                 quick_fallacy_analysis_only,
             )
+
             result = await quick_fallacy_analysis_only("text")
 
         assert result == {"status": "completed"}

--- a/tests/unit/argumentation_analysis/orchestration/test_group_chat.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_group_chat.py
@@ -7,8 +7,8 @@ from datetime import datetime
 
 from argumentation_analysis.orchestration.group_chat import GroupChatOrchestration
 
-
 # ── Fixtures ────────────────────────────────────────────────────────────
+
 
 @pytest.fixture
 def orchestration():
@@ -37,6 +37,7 @@ def active_session(orchestration, mock_agents):
 
 # ── __init__ ────────────────────────────────────────────────────────────
 
+
 class TestGroupChatInit:
     """Tests for GroupChatOrchestration.__init__."""
 
@@ -56,6 +57,7 @@ class TestGroupChatInit:
 
 
 # ── initialize_session ──────────────────────────────────────────────────
+
 
 class TestInitializeSession:
     """Tests for initialize_session()."""
@@ -94,6 +96,7 @@ class TestInitializeSession:
 
 # ── add_message ─────────────────────────────────────────────────────────
 
+
 class TestAddMessage:
     """Tests for add_message()."""
 
@@ -130,6 +133,7 @@ class TestAddMessage:
 
 # ── get_conversation_summary ────────────────────────────────────────────
 
+
 class TestGetConversationSummary:
     """Tests for get_conversation_summary()."""
 
@@ -159,6 +163,7 @@ class TestGetConversationSummary:
 
 # ── _get_agent_type ─────────────────────────────────────────────────────
 
+
 class TestGetAgentType:
     """Tests for _get_agent_type()."""
 
@@ -183,6 +188,7 @@ class TestGetAgentType:
 
 
 # ── coordinate_analysis ─────────────────────────────────────────────────
+
 
 class TestCoordinateAnalysis:
     """Tests for coordinate_analysis()."""
@@ -231,6 +237,7 @@ class TestCoordinateAnalysis:
 
 # ── _consolidate_results ────────────────────────────────────────────────
 
+
 class TestConsolidateResults:
     """Tests for _consolidate_results()."""
 
@@ -270,6 +277,7 @@ class TestConsolidateResults:
 
 # ── get_agent_status ────────────────────────────────────────────────────
 
+
 class TestGetAgentStatus:
     """Tests for get_agent_status()."""
 
@@ -301,6 +309,7 @@ class TestGetAgentStatus:
 
 
 # ── cleanup_session ─────────────────────────────────────────────────────
+
 
 class TestCleanupSession:
     """Tests for cleanup_session()."""
@@ -336,12 +345,15 @@ class TestCleanupSession:
 
     def test_cleanup_async_error_handled(self, active_session):
         active_session.async_manager = MagicMock()
-        active_session.async_manager.cleanup_completed_tasks.side_effect = RuntimeError("boom")
+        active_session.async_manager.cleanup_completed_tasks.side_effect = RuntimeError(
+            "boom"
+        )
         # Should not raise
         assert active_session.cleanup_session() is True
 
 
 # ── _analyze_with_agent ─────────────────────────────────────────────────
+
 
 class TestAnalyzeWithAgent:
     """Tests for _analyze_with_agent()."""
@@ -365,7 +377,10 @@ class TestAnalyzeWithAgent:
         async_agent.analyze_text = MagicMock()
         # Make it look async
         import asyncio
-        async def fake_analyze(t): pass
+
+        async def fake_analyze(t):
+            pass
+
         async_agent.analyze_text = fake_analyze
         active_session.active_agents["async_agent"] = async_agent
 
@@ -388,6 +403,7 @@ class TestAnalyzeWithAgent:
 
 
 # ── coordinate_analysis_async ───────────────────────────────────────────
+
 
 class TestCoordinateAnalysisAsync:
     """Tests for coordinate_analysis_async()."""
@@ -432,7 +448,9 @@ class TestCoordinateAnalysisAsync:
         active_session.async_manager.run_multiple_hybrid.return_value = [
             {"agent_id": "informal_agent", "confidence": 0.9, "findings": []},
         ]
-        with patch.object(active_session, "_consolidate_results_robust", side_effect=Exception("boom")):
+        with patch.object(
+            active_session, "_consolidate_results_robust", side_effect=Exception("boom")
+        ):
             result = active_session.coordinate_analysis_async("txt", ["informal_agent"])
             assert "error" in result["consolidated_analysis"]
 
@@ -457,6 +475,7 @@ class TestCoordinateAnalysisAsync:
 
 # ── _consolidate_results_robust ─────────────────────────────────────────
 
+
 class TestConsolidateResultsRobust:
     """Tests for _consolidate_results_robust()."""
 
@@ -468,7 +487,11 @@ class TestConsolidateResultsRobust:
 
     def test_separates_valid_and_error(self, orchestration):
         results = {
-            "good_agent": {"confidence": 0.9, "findings": ["f1"], "analysis_type": "general_analysis"},
+            "good_agent": {
+                "confidence": 0.9,
+                "findings": ["f1"],
+                "analysis_type": "general_analysis",
+            },
             "bad_agent": {"confidence": 0.0, "findings": [], "error": "timeout"},
         }
         consolidated = orchestration._consolidate_results_robust(results)
@@ -477,8 +500,16 @@ class TestConsolidateResultsRobust:
 
     def test_average_confidence_from_valid_only(self, orchestration):
         results = {
-            "a1": {"confidence": 0.8, "findings": [], "analysis_type": "general_analysis"},
-            "a2": {"confidence": 0.6, "findings": [], "analysis_type": "general_analysis"},
+            "a1": {
+                "confidence": 0.8,
+                "findings": [],
+                "analysis_type": "general_analysis",
+            },
+            "a2": {
+                "confidence": 0.6,
+                "findings": [],
+                "analysis_type": "general_analysis",
+            },
             "bad": {"confidence": 0.0, "findings": [], "error": "err"},
         }
         consolidated = orchestration._consolidate_results_robust(results)
@@ -486,8 +517,16 @@ class TestConsolidateResultsRobust:
 
     def test_weighted_confidence(self, orchestration):
         results = {
-            "logic": {"confidence": 1.0, "findings": [], "analysis_type": "formal_logic"},
-            "extract": {"confidence": 1.0, "findings": [], "analysis_type": "extraction"},
+            "logic": {
+                "confidence": 1.0,
+                "findings": [],
+                "analysis_type": "formal_logic",
+            },
+            "extract": {
+                "confidence": 1.0,
+                "findings": [],
+                "analysis_type": "extraction",
+            },
         }
         consolidated = orchestration._consolidate_results_robust(results)
         # formal_logic weight=1.2, extraction weight=0.8
@@ -496,8 +535,16 @@ class TestConsolidateResultsRobust:
 
     def test_weighted_confidence_different_scores(self, orchestration):
         results = {
-            "logic": {"confidence": 0.5, "findings": [], "analysis_type": "formal_logic"},
-            "informal": {"confidence": 0.5, "findings": [], "analysis_type": "informal_analysis"},
+            "logic": {
+                "confidence": 0.5,
+                "findings": [],
+                "analysis_type": "formal_logic",
+            },
+            "informal": {
+                "confidence": 0.5,
+                "findings": [],
+                "analysis_type": "informal_analysis",
+            },
         }
         consolidated = orchestration._consolidate_results_robust(results)
         # weights: formal_logic=1.2, informal_analysis=1.0
@@ -506,12 +553,23 @@ class TestConsolidateResultsRobust:
 
     def test_key_findings_sorted_by_confidence(self, orchestration):
         results = {
-            "low": {"confidence": 0.3, "findings": ["low_finding"], "analysis_type": "general_analysis"},
-            "high": {"confidence": 0.9, "findings": ["high_finding"], "analysis_type": "general_analysis"},
+            "low": {
+                "confidence": 0.3,
+                "findings": ["low_finding"],
+                "analysis_type": "general_analysis",
+            },
+            "high": {
+                "confidence": 0.9,
+                "findings": ["high_finding"],
+                "analysis_type": "general_analysis",
+            },
         }
         consolidated = orchestration._consolidate_results_robust(results)
         if len(consolidated["key_findings"]) >= 2:
-            assert consolidated["key_findings"][0]["confidence"] >= consolidated["key_findings"][1]["confidence"]
+            assert (
+                consolidated["key_findings"][0]["confidence"]
+                >= consolidated["key_findings"][1]["confidence"]
+            )
 
     def test_key_findings_capped_at_10(self, orchestration):
         results = {}
@@ -537,7 +595,11 @@ class TestConsolidateResultsRobust:
 
     def test_no_errors_empty_summary(self, orchestration):
         results = {
-            "a1": {"confidence": 0.9, "findings": ["f"], "analysis_type": "general_analysis"},
+            "a1": {
+                "confidence": 0.9,
+                "findings": ["f"],
+                "analysis_type": "general_analysis",
+            },
         }
         consolidated = orchestration._consolidate_results_robust(results)
         assert consolidated["error_summary"] == []
@@ -553,8 +615,16 @@ class TestConsolidateResultsRobust:
     def test_consensus_detection(self, orchestration):
         # Two agents with similar first-3-word findings
         results = {
-            "a1": {"confidence": 0.9, "findings": ["argument is valid here"], "analysis_type": "general_analysis"},
-            "a2": {"confidence": 0.8, "findings": ["argument is strong here"], "analysis_type": "general_analysis"},
+            "a1": {
+                "confidence": 0.9,
+                "findings": ["argument is valid here"],
+                "analysis_type": "general_analysis",
+            },
+            "a2": {
+                "confidence": 0.8,
+                "findings": ["argument is strong here"],
+                "analysis_type": "general_analysis",
+            },
         }
         consolidated = orchestration._consolidate_results_robust(results)
         # "argument is valid" vs "argument is strong" share "argument" and "is" = 2 matches
@@ -564,6 +634,7 @@ class TestConsolidateResultsRobust:
 
 
 # ── get_service_health ──────────────────────────────────────────────────
+
 
 class TestGetServiceHealth:
     """Tests for get_service_health()."""
@@ -614,7 +685,9 @@ class TestGetServiceHealth:
 
     def test_error_in_health_check(self, orchestration):
         orchestration.async_manager = MagicMock()
-        orchestration.async_manager.get_performance_stats.side_effect = Exception("bad stats")
+        orchestration.async_manager.get_performance_stats.side_effect = Exception(
+            "bad stats"
+        )
         # Need at least one agent for get_service_health to reach stats
         orchestration.initialize_session("s", {"a": MagicMock()})
         health = orchestration.get_service_health()
@@ -629,6 +702,7 @@ class TestGetServiceHealth:
 
 
 # ── Integration scenarios ───────────────────────────────────────────────
+
 
 class TestGroupChatScenarios:
     """End-to-end scenarios combining multiple methods."""

--- a/tests/unit/argumentation_analysis/orchestration/test_hierarchy_bridge.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_hierarchy_bridge.py
@@ -41,7 +41,6 @@ from argumentation_analysis.orchestration.hierarchical.hierarchy_bridge import (
     _extract_questions,
 )
 
-
 # ---------------------------------------------------------------------------
 # Test helpers
 # ---------------------------------------------------------------------------
@@ -380,9 +379,7 @@ class TestHierarchicalTurnStrategy:
 
     @pytest.mark.asyncio
     async def test_basic_execution(self):
-        invoke_fn = AsyncMock(
-            return_value={"confidence": 0.9, "analysis": "done"}
-        )
+        invoke_fn = AsyncMock(return_value={"confidence": 0.9, "analysis": "done"})
         registry = make_registry(
             make_component("extract", ["fact_extraction"], invoke=invoke_fn),
         )
@@ -419,8 +416,7 @@ class TestHierarchicalTurnStrategy:
 
         assert result.needs_refinement is True
         assert any(
-            r.status == PhaseStatus.FAILED
-            for r in result.phase_results.values()
+            r.status == PhaseStatus.FAILED for r in result.phase_results.values()
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/argumentation_analysis/orchestration/test_logique_complexe_plugin.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_logique_complexe_plugin.py
@@ -27,13 +27,17 @@ def mock_state():
 
 @pytest.fixture
 def plugin(mock_state):
-    from argumentation_analysis.orchestration.plugins.logique_complexe_plugin import LogiqueComplexePlugin
+    from argumentation_analysis.orchestration.plugins.logique_complexe_plugin import (
+        LogiqueComplexePlugin,
+    )
+
     return LogiqueComplexePlugin(state_instance=mock_state)
 
 
 # ============================================================================
 # Init Tests
 # ============================================================================
+
 
 class TestLogiqueComplexePluginInit:
 
@@ -50,6 +54,7 @@ class TestLogiqueComplexePluginInit:
 # ============================================================================
 # get_enigme_description Tests
 # ============================================================================
+
 
 class TestGetEnigmeDescription:
 
@@ -76,6 +81,7 @@ class TestGetEnigmeDescription:
 # get_contraintes_logiques Tests
 # ============================================================================
 
+
 class TestGetContraintesLogiques:
 
     def test_returns_string(self, plugin, mock_state):
@@ -98,6 +104,7 @@ class TestGetContraintesLogiques:
 # formuler_clause_logique Tests
 # ============================================================================
 
+
 class TestFormulerClauseLogique:
 
     def test_clause_too_short(self, plugin):
@@ -110,7 +117,7 @@ class TestFormulerClauseLogique:
         mock_state.verifier_progression_logique.return_value = {"clauses_formulees": 1}
         result = plugin.formuler_clause_logique(
             "∀x (Maison(x) ∧ Couleur(x,Rouge) → Nationalité(x,Anglais))",
-            justification="Constraint 1"
+            justification="Constraint 1",
         )
         assert "ajoutée avec succès" in result
         assert "Constraint 1" in result
@@ -134,6 +141,7 @@ class TestFormulerClauseLogique:
 # ============================================================================
 # executer_requete_tweety Tests
 # ============================================================================
+
 
 class TestExecuterRequeteTweety:
 
@@ -162,6 +170,7 @@ class TestExecuterRequeteTweety:
 # verifier_deduction_partielle Tests
 # ============================================================================
 
+
 class TestVerifierDeductionPartielle:
 
     def test_invalid_position(self, plugin, mock_state):
@@ -185,7 +194,11 @@ class TestVerifierDeductionPartielle:
 
     def test_partial_deduction(self, plugin, mock_state):
         result = plugin.verifier_deduction_partielle(
-            1, {"couleur": "Jaune", "nationalité": "Anglais"}  # couleur correct, nat wrong
+            1,
+            {
+                "couleur": "Jaune",
+                "nationalité": "Anglais",
+            },  # couleur correct, nat wrong
         )
         assert "1/2" in result
 
@@ -198,6 +211,7 @@ class TestVerifierDeductionPartielle:
 # ============================================================================
 # proposer_solution_complete Tests
 # ============================================================================
+
 
 class TestProposerSolutionComplete:
 
@@ -241,6 +255,7 @@ class TestProposerSolutionComplete:
 # obtenir_progression_logique Tests
 # ============================================================================
 
+
 class TestObtenirProgressionLogique:
 
     def test_returns_string(self, plugin, mock_state):
@@ -253,6 +268,7 @@ class TestObtenirProgressionLogique:
 # ============================================================================
 # generer_indice_complexe Tests
 # ============================================================================
+
 
 class TestGenererIndiceComplexe:
 
@@ -273,6 +289,7 @@ class TestGenererIndiceComplexe:
 # valider_syntaxe_tweety Tests
 # ============================================================================
 
+
 class TestValiderSyntaxeTweety:
 
     def test_valid_clause(self, plugin):
@@ -282,7 +299,9 @@ class TestValiderSyntaxeTweety:
         assert "valide" in result
 
     def test_missing_operators(self, plugin):
-        result = plugin.valider_syntaxe_tweety("Maison(x) has Couleur Rouge for the test")
+        result = plugin.valider_syntaxe_tweety(
+            "Maison(x) has Couleur Rouge for the test"
+        )
         assert "invalide" in result
         assert "opérateurs" in result
 
@@ -301,7 +320,5 @@ class TestValiderSyntaxeTweety:
         assert "invalide" in result
 
     def test_valid_with_exists(self, plugin):
-        result = plugin.valider_syntaxe_tweety(
-            "∃x (Position(x,3) ∧ Boisson(x,Lait))"
-        )
+        result = plugin.valider_syntaxe_tweety("∃x (Position(x,3) ∧ Boisson(x,Lait))")
         assert "valide" in result

--- a/tests/unit/argumentation_analysis/orchestration/test_main_orchestrator_engine.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_main_orchestrator_engine.py
@@ -10,8 +10,8 @@ from argumentation_analysis.orchestration.engine.main_orchestrator import (
 from argumentation_analysis.orchestration.engine.strategy import OrchestrationStrategy
 from argumentation_analysis.orchestration.engine.config import OrchestrationConfig
 
-
 # ── Fixtures ────────────────────────────────────────────────────────────
+
 
 @pytest.fixture
 def mock_kernel():
@@ -60,7 +60,9 @@ def orchestrator(mock_config, mock_kernel):
 
 
 @pytest.fixture
-def full_orchestrator(mock_config, mock_kernel, mock_strategic, mock_tactical, mock_operational):
+def full_orchestrator(
+    mock_config, mock_kernel, mock_strategic, mock_tactical, mock_operational
+):
     """MainOrchestrator with all managers configured."""
     with patch(
         "argumentation_analysis.orchestration.engine.main_orchestrator.DirectOperationalExecutor",
@@ -87,6 +89,7 @@ def full_orchestrator(mock_config, mock_kernel, mock_strategic, mock_tactical, m
 
 # ── __init__ ────────────────────────────────────────────────────────────
 
+
 class TestMainOrchestratorInit:
     """Tests for MainOrchestrator.__init__."""
 
@@ -101,7 +104,9 @@ class TestMainOrchestratorInit:
         assert orchestrator.tactical_coordinator is None
         assert orchestrator.operational_manager is None
 
-    def test_managers_stored(self, full_orchestrator, mock_strategic, mock_tactical, mock_operational):
+    def test_managers_stored(
+        self, full_orchestrator, mock_strategic, mock_tactical, mock_operational
+    ):
         assert full_orchestrator.strategic_manager is mock_strategic
         assert full_orchestrator.tactical_coordinator is mock_tactical
         assert full_orchestrator.operational_manager is mock_operational
@@ -112,35 +117,47 @@ class TestMainOrchestratorInit:
 
 # ── run_analysis ────────────────────────────────────────────────────────
 
+
 class TestRunAnalysis:
     """Tests for run_analysis() strategy dispatch."""
 
-    @pytest.mark.parametrize("strategy,method_name", [
-        (OrchestrationStrategy.HIERARCHICAL_FULL, "_execute_hierarchical_full"),
-        (OrchestrationStrategy.STRATEGIC_ONLY, "_execute_strategic_only"),
-        (OrchestrationStrategy.TACTICAL_COORDINATION, "_execute_tactical_coordination"),
-        (OrchestrationStrategy.OPERATIONAL_DIRECT, "_execute_operational_direct"),
-        (OrchestrationStrategy.SPECIALIZED_DIRECT, "_execute_specialized_direct"),
-        (OrchestrationStrategy.HYBRID, "_execute_hybrid"),
-        (OrchestrationStrategy.SERVICE_MANAGER, "_execute_service_manager"),
-        (OrchestrationStrategy.FALLBACK, "_execute_fallback"),
-        (OrchestrationStrategy.COMPLEX_PIPELINE, "_execute_complex_pipeline"),
-        (OrchestrationStrategy.MANUAL_SELECTION, "_execute_manual_selection"),
-    ])
-    async def test_dispatches_to_correct_method(self, orchestrator, strategy, method_name):
+    @pytest.mark.parametrize(
+        "strategy,method_name",
+        [
+            (OrchestrationStrategy.HIERARCHICAL_FULL, "_execute_hierarchical_full"),
+            (OrchestrationStrategy.STRATEGIC_ONLY, "_execute_strategic_only"),
+            (
+                OrchestrationStrategy.TACTICAL_COORDINATION,
+                "_execute_tactical_coordination",
+            ),
+            (OrchestrationStrategy.OPERATIONAL_DIRECT, "_execute_operational_direct"),
+            (OrchestrationStrategy.SPECIALIZED_DIRECT, "_execute_specialized_direct"),
+            (OrchestrationStrategy.HYBRID, "_execute_hybrid"),
+            (OrchestrationStrategy.SERVICE_MANAGER, "_execute_service_manager"),
+            (OrchestrationStrategy.FALLBACK, "_execute_fallback"),
+            (OrchestrationStrategy.COMPLEX_PIPELINE, "_execute_complex_pipeline"),
+            (OrchestrationStrategy.MANUAL_SELECTION, "_execute_manual_selection"),
+        ],
+    )
+    async def test_dispatches_to_correct_method(
+        self, orchestrator, strategy, method_name
+    ):
         expected = {"status": "success", "test": True}
         with patch(
             "argumentation_analysis.orchestration.engine.main_orchestrator.select_strategy",
             new_callable=AsyncMock,
             return_value=strategy,
         ):
-            with patch.object(orchestrator, method_name, new_callable=AsyncMock, return_value=expected) as mock_method:
+            with patch.object(
+                orchestrator, method_name, new_callable=AsyncMock, return_value=expected
+            ) as mock_method:
                 result = await orchestrator.run_analysis("sample text")
                 mock_method.assert_called_once_with("sample text")
                 assert result == expected
 
 
 # ── _execute_fallback ───────────────────────────────────────────────────
+
 
 class TestExecuteFallback:
     """Tests for _execute_fallback()."""
@@ -163,6 +180,7 @@ class TestExecuteFallback:
 
 # ── _execute_complex_pipeline ───────────────────────────────────────────
 
+
 class TestExecuteComplexPipeline:
     """Tests for _execute_complex_pipeline()."""
 
@@ -174,6 +192,7 @@ class TestExecuteComplexPipeline:
 
 # ── _execute_manual_selection ───────────────────────────────────────────
 
+
 class TestExecuteManualSelection:
     """Tests for _execute_manual_selection()."""
 
@@ -184,6 +203,7 @@ class TestExecuteManualSelection:
 
 
 # ── _synthesize_hierarchical_results ────────────────────────────────────
+
 
 class TestSynthesizeHierarchicalResults:
     """Tests for _synthesize_hierarchical_results()."""
@@ -215,7 +235,9 @@ class TestSynthesizeHierarchicalResults:
 
     async def test_overall_score_average(self, orchestrator):
         results = {
-            "strategic_analysis": {"objectives": ["o1", "o2", "o3", "o4"]},  # alignment=1.0
+            "strategic_analysis": {
+                "objectives": ["o1", "o2", "o3", "o4"]
+            },  # alignment=1.0
             "tactical_coordination": {"tasks_created": 10},  # efficiency=1.0
             "operational_results": {"summary": {"success_rate": 1.0}},  # success=1.0
         }
@@ -256,6 +278,7 @@ class TestSynthesizeHierarchicalResults:
 
 # ── _execute_operational_tasks ──────────────────────────────────────────
 
+
 class TestExecuteOperationalTasks:
     """Tests for _execute_operational_tasks()."""
 
@@ -266,13 +289,15 @@ class TestExecuteOperationalTasks:
         assert result["tasks_executed"] == 0
 
     async def test_delegates_to_executor(self, full_orchestrator):
-        result = await full_orchestrator._execute_operational_tasks("text", {"tasks": []})
+        result = await full_orchestrator._execute_operational_tasks(
+            "text", {"tasks": []}
+        )
         full_orchestrator.direct_operational_executor.execute_operational_pipeline.assert_called_once()
         assert result["status"] == "success"
 
     async def test_executor_exception(self, full_orchestrator):
-        full_orchestrator.direct_operational_executor.execute_operational_pipeline = AsyncMock(
-            side_effect=RuntimeError("executor crashed")
+        full_orchestrator.direct_operational_executor.execute_operational_pipeline = (
+            AsyncMock(side_effect=RuntimeError("executor crashed"))
         )
         result = await full_orchestrator._execute_operational_tasks("text", {})
         assert result["status"] == "error"
@@ -280,6 +305,7 @@ class TestExecuteOperationalTasks:
 
 
 # ── _execute_hierarchical_full ──────────────────────────────────────────
+
 
 class TestExecuteHierarchicalFull:
     """Tests for _execute_hierarchical_full()."""
@@ -313,6 +339,7 @@ class TestExecuteHierarchicalFull:
 
 # ── _execute_strategic_only ─────────────────────────────────────────────
 
+
 class TestExecuteStrategicOnly:
     """Tests for _execute_strategic_only()."""
 
@@ -337,6 +364,7 @@ class TestExecuteStrategicOnly:
 
 
 # ── _execute_tactical_coordination ──────────────────────────────────────
+
 
 class TestExecuteTacticalCoordination:
     """Tests for _execute_tactical_coordination()."""
@@ -367,6 +395,7 @@ class TestExecuteTacticalCoordination:
 
 # ── _execute_operational_direct ─────────────────────────────────────────
 
+
 class TestExecuteOperationalDirect:
     """Tests for _execute_operational_direct()."""
 
@@ -386,6 +415,7 @@ class TestExecuteOperationalDirect:
 
 
 # ── _execute_service_manager ────────────────────────────────────────────
+
 
 class TestExecuteServiceManager:
     """Tests for _execute_service_manager()."""
@@ -414,35 +444,61 @@ class TestExecuteServiceManager:
 
 # ── _execute_hybrid ─────────────────────────────────────────────────────
 
+
 class TestExecuteHybrid:
     """Tests for _execute_hybrid()."""
 
     async def test_both_succeed(self, orchestrator):
-        with patch.object(orchestrator, "_execute_tactical_coordination", new_callable=AsyncMock,
-                          return_value={"status": "success"}):
-            with patch.object(orchestrator, "_execute_specialized_direct", new_callable=AsyncMock,
-                              return_value={"status": "success"}):
+        with patch.object(
+            orchestrator,
+            "_execute_tactical_coordination",
+            new_callable=AsyncMock,
+            return_value={"status": "success"},
+        ):
+            with patch.object(
+                orchestrator,
+                "_execute_specialized_direct",
+                new_callable=AsyncMock,
+                return_value={"status": "success"},
+            ):
                 result = await orchestrator._execute_hybrid("text")
                 assert result["status"] == "success"
 
     async def test_one_fails_partial(self, orchestrator):
-        with patch.object(orchestrator, "_execute_tactical_coordination", new_callable=AsyncMock,
-                          return_value={"status": "error", "error_message": "fail"}):
-            with patch.object(orchestrator, "_execute_specialized_direct", new_callable=AsyncMock,
-                              return_value={"status": "success"}):
+        with patch.object(
+            orchestrator,
+            "_execute_tactical_coordination",
+            new_callable=AsyncMock,
+            return_value={"status": "error", "error_message": "fail"},
+        ):
+            with patch.object(
+                orchestrator,
+                "_execute_specialized_direct",
+                new_callable=AsyncMock,
+                return_value={"status": "success"},
+            ):
                 result = await orchestrator._execute_hybrid("text")
                 assert result["status"] == "partial_failure"
 
     async def test_both_fail(self, orchestrator):
-        with patch.object(orchestrator, "_execute_tactical_coordination", new_callable=AsyncMock,
-                          return_value={"status": "error", "error_message": "f1"}):
-            with patch.object(orchestrator, "_execute_specialized_direct", new_callable=AsyncMock,
-                              return_value={"status": "error", "error_message": "f2"}):
+        with patch.object(
+            orchestrator,
+            "_execute_tactical_coordination",
+            new_callable=AsyncMock,
+            return_value={"status": "error", "error_message": "f1"},
+        ):
+            with patch.object(
+                orchestrator,
+                "_execute_specialized_direct",
+                new_callable=AsyncMock,
+                return_value={"status": "error", "error_message": "f2"},
+            ):
                 result = await orchestrator._execute_hybrid("text")
                 assert result["status"] == "error"
 
 
 # ── _select_specialized_orchestrator ────────────────────────────────────
+
 
 class TestSelectSpecializedOrchestrator:
     """Tests for _select_specialized_orchestrator()."""
@@ -462,10 +518,19 @@ class TestSelectSpecializedOrchestrator:
 
     async def test_filters_by_analysis_type(self, orchestrator):
         from argumentation_analysis.core.enums import AnalysisType
+
         orchestrator.config.analysis_type_enum = AnalysisType.LOGICAL
         orchestrator.specialized_orchestrators_map = {
-            "logic": {"priority": 2, "orchestrator": MagicMock(), "types": [AnalysisType.LOGICAL]},
-            "other": {"priority": 1, "orchestrator": MagicMock(), "types": [AnalysisType.RHETORICAL]},
+            "logic": {
+                "priority": 2,
+                "orchestrator": MagicMock(),
+                "types": [AnalysisType.LOGICAL],
+            },
+            "other": {
+                "priority": 1,
+                "orchestrator": MagicMock(),
+                "types": [AnalysisType.RHETORICAL],
+            },
         }
         name, data = await orchestrator._select_specialized_orchestrator()
         assert name == "logic"
@@ -473,28 +538,43 @@ class TestSelectSpecializedOrchestrator:
 
 # ── _execute_specialized_direct ─────────────────────────────────────────
 
+
 class TestExecuteSpecializedDirect:
     """Tests for _execute_specialized_direct()."""
 
     async def test_no_orchestrator_selected(self, orchestrator):
-        with patch.object(orchestrator, "_select_specialized_orchestrator", new_callable=AsyncMock, return_value=None):
+        with patch.object(
+            orchestrator,
+            "_select_specialized_orchestrator",
+            new_callable=AsyncMock,
+            return_value=None,
+        ):
             result = await orchestrator._execute_specialized_direct("text")
             assert result["status"] == "no_orchestrator_selected"
 
     async def test_missing_orchestrator_instance(self, orchestrator):
-        with patch.object(orchestrator, "_select_specialized_orchestrator", new_callable=AsyncMock,
-                          return_value=("test", {"orchestrator": None, "priority": 1})):
+        with patch.object(
+            orchestrator,
+            "_select_specialized_orchestrator",
+            new_callable=AsyncMock,
+            return_value=("test", {"orchestrator": None, "priority": 1}),
+        ):
             result = await orchestrator._execute_specialized_direct("text")
             assert result["status"] == "error"
 
     async def test_exception_handled(self, orchestrator):
-        with patch.object(orchestrator, "_select_specialized_orchestrator", new_callable=AsyncMock,
-                          side_effect=RuntimeError("boom")):
+        with patch.object(
+            orchestrator,
+            "_select_specialized_orchestrator",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("boom"),
+        ):
             result = await orchestrator._execute_specialized_direct("text")
             assert result["status"] == "error"
 
 
 # ── _run_logic_complex_analysis ─────────────────────────────────────────
+
 
 class TestRunLogicComplexAnalysis:
     """Tests for _run_logic_complex_analysis()."""
@@ -502,19 +582,28 @@ class TestRunLogicComplexAnalysis:
     async def test_no_method(self, orchestrator):
         mock_orch = MagicMock(spec=[])
         # LogiqueComplexeOrchestrator might not be available
-        with patch("argumentation_analysis.orchestration.engine.main_orchestrator.LogiqueComplexeOrchestrator", None):
+        with patch(
+            "argumentation_analysis.orchestration.engine.main_orchestrator.LogiqueComplexeOrchestrator",
+            None,
+        ):
             result = await orchestrator._run_logic_complex_analysis("text", mock_orch)
             assert result["status"] == "limited"
 
     async def test_exception(self, orchestrator):
         mock_orch = MagicMock()
-        mock_orch.analyze_complex_logic = AsyncMock(side_effect=Exception("logic error"))
-        with patch("argumentation_analysis.orchestration.engine.main_orchestrator.LogiqueComplexeOrchestrator", type(mock_orch)):
+        mock_orch.analyze_complex_logic = AsyncMock(
+            side_effect=Exception("logic error")
+        )
+        with patch(
+            "argumentation_analysis.orchestration.engine.main_orchestrator.LogiqueComplexeOrchestrator",
+            type(mock_orch),
+        ):
             result = await orchestrator._run_logic_complex_analysis("text", mock_orch)
             assert result["status"] == "error"
 
 
 # ── Integration scenarios ───────────────────────────────────────────────
+
 
 class TestMainOrchestratorScenarios:
     """Integration scenarios."""

--- a/tests/unit/argumentation_analysis/orchestration/test_orchestration_strategies.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_orchestration_strategies.py
@@ -22,16 +22,18 @@ from argumentation_analysis.orchestration.strategies import (
     OracleTerminationStrategy,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers: concrete Agent subclass (Agent is abstract)
 # ---------------------------------------------------------------------------
+
 
 class ConcreteAgent(Agent):
     """Minimal concrete Agent for testing purposes."""
 
     async def invoke(self, history: List[ChatMessageContent]) -> ChatMessageContent:
-        return ChatMessageContent(role="assistant", content=f"Response from {self.name}")
+        return ChatMessageContent(
+            role="assistant", content=f"Response from {self.name}"
+        )
 
 
 def _make_agents(*names: str) -> List[ConcreteAgent]:
@@ -58,6 +60,7 @@ def _make_oracle_state(
 # ===========================================================================
 # Tests for base classes
 # ===========================================================================
+
 
 class TestBaseAgent:
     """Tests for the abstract Agent base class."""
@@ -109,6 +112,7 @@ class TestBaseTerminationStrategy:
 # ===========================================================================
 # Tests for CyclicSelectionStrategy
 # ===========================================================================
+
 
 class TestCyclicSelectionStrategyInit:
     """Tests for CyclicSelectionStrategy initialization."""
@@ -186,8 +190,12 @@ class TestCyclicSelectionStrategyNext:
             names.append(selected.name)
 
         assert names == [
-            "Sherlock", "Watson", "Moriarty",
-            "Sherlock", "Watson", "Moriarty",
+            "Sherlock",
+            "Watson",
+            "Moriarty",
+            "Sherlock",
+            "Watson",
+            "Moriarty",
         ]
 
     async def test_cyclic_order_two_agents(self):
@@ -301,7 +309,9 @@ class TestCyclicSelectionStrategyContextInjection:
     async def test_context_injected_when_oracle_state_and_attr_present(self):
         """Context is injected into agent when oracle_state and _context_enhanced_prompt attr exist."""
         mock_state = _make_oracle_state()
-        mock_state.get_contextual_prompt_addition = Mock(return_value="Extra context info")
+        mock_state.get_contextual_prompt_addition = Mock(
+            return_value="Extra context info"
+        )
 
         agents = _make_agents("Sherlock", "Watson")
         # Add the attribute that triggers context injection
@@ -397,6 +407,7 @@ class TestCyclicSelectionStrategyReset:
 # ===========================================================================
 # Tests for OracleTerminationStrategy
 # ===========================================================================
+
 
 class TestOracleTerminationStrategyInit:
     """Tests for OracleTerminationStrategy initialization."""
@@ -514,7 +525,11 @@ class TestOracleTerminationStrategyShouldTerminate:
 
     async def test_terminates_when_solution_found(self):
         """should_terminate() returns True when oracle_state has a correct proposed solution."""
-        solution = {"suspect": "Colonel Mustard", "weapon": "Candlestick", "room": "Library"}
+        solution = {
+            "suspect": "Colonel Mustard",
+            "weapon": "Candlestick",
+            "room": "Library",
+        }
         mock_state = _make_oracle_state(
             is_solution_proposed=True,
             final_solution=solution,
@@ -529,7 +544,11 @@ class TestOracleTerminationStrategyShouldTerminate:
 
     async def test_does_not_terminate_on_wrong_solution(self):
         """should_terminate() returns False when proposed solution does not match secret."""
-        proposed = {"suspect": "Colonel Mustard", "weapon": "Candlestick", "room": "Library"}
+        proposed = {
+            "suspect": "Colonel Mustard",
+            "weapon": "Candlestick",
+            "room": "Library",
+        }
         secret = {"suspect": "Miss Scarlet", "weapon": "Rope", "room": "Kitchen"}
         mock_state = _make_oracle_state(
             is_solution_proposed=True,
@@ -740,7 +759,12 @@ class TestOracleTerminationStrategySummary:
         strategy = OracleTerminationStrategy()
         summary = strategy.get_termination_summary()
         expected_keys = {
-            "turn_count", "cycle_count", "max_turns", "max_cycles",
-            "is_solution_found", "solution_proposed", "elimination_possible",
+            "turn_count",
+            "cycle_count",
+            "max_turns",
+            "max_cycles",
+            "is_solution_found",
+            "solution_proposed",
+            "elimination_possible",
         }
         assert set(summary.keys()) == expected_keys

--- a/tests/unit/argumentation_analysis/orchestration/test_real_llm_orchestrator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_real_llm_orchestrator.py
@@ -19,10 +19,10 @@ from unittest.mock import patch, MagicMock, AsyncMock
 from dataclasses import asdict
 from datetime import datetime
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def orchestrator():
@@ -48,7 +48,9 @@ def initialized_orchestrator(orchestrator):
     orchestrator.pragmatic_analyzer = orchestrator._create_basic_pragmatic_analyzer()
     orchestrator.entity_extractor = orchestrator._create_basic_entity_extractor()
     orchestrator.relation_extractor = orchestrator._create_basic_relation_extractor()
-    orchestrator.consistency_validator = orchestrator._create_basic_consistency_validator()
+    orchestrator.consistency_validator = (
+        orchestrator._create_basic_consistency_validator()
+    )
     orchestrator.coherence_validator = orchestrator._create_basic_coherence_validator()
     return orchestrator
 
@@ -256,7 +258,9 @@ class TestMetricsAndCache:
 
         r1 = LLMAnalysisRequest(text="Hello", analysis_type="syntactic")
         r2 = LLMAnalysisRequest(text="World", analysis_type="syntactic")
-        assert orchestrator._generate_cache_key(r1) != orchestrator._generate_cache_key(r2)
+        assert orchestrator._generate_cache_key(r1) != orchestrator._generate_cache_key(
+            r2
+        )
 
     def test_cache_roundtrip(self, orchestrator, request_obj):
         from argumentation_analysis.orchestration.real_llm_orchestrator import (
@@ -424,7 +428,9 @@ class TestAnalyzeText:
             LLMAnalysisRequest,
         )
 
-        req = LLMAnalysisRequest(text="A implies B.", analysis_type="relation_extraction")
+        req = LLMAnalysisRequest(
+            text="A implies B.", analysis_type="relation_extraction"
+        )
         result = await initialized_orchestrator.analyze_text(req)
         assert result.result["success"] is True
 
@@ -433,7 +439,9 @@ class TestAnalyzeText:
             LLMAnalysisRequest,
         )
 
-        req = LLMAnalysisRequest(text="Statement.", analysis_type="consistency_validation")
+        req = LLMAnalysisRequest(
+            text="Statement.", analysis_type="consistency_validation"
+        )
         result = await initialized_orchestrator.analyze_text(req)
         assert result.result["success"] is True
 
@@ -451,7 +459,9 @@ class TestAnalyzeText:
             LLMAnalysisRequest,
         )
 
-        req = LLMAnalysisRequest(text="Full analysis.", analysis_type="unified_analysis")
+        req = LLMAnalysisRequest(
+            text="Full analysis.", analysis_type="unified_analysis"
+        )
         result = await initialized_orchestrator.analyze_text(req)
         assert result.result["success"] is True
         assert "results" in result.result
@@ -492,13 +502,27 @@ class TestAnalyzeText:
         async def mock_init():
             orchestrator.is_initialized = True
             orchestrator.unified_analyzer = orchestrator._create_unified_analyzer()
-            orchestrator.syntactic_analyzer = orchestrator._create_basic_syntactic_analyzer()
-            orchestrator.semantic_analyzer = orchestrator._create_basic_semantic_analyzer()
-            orchestrator.pragmatic_analyzer = orchestrator._create_basic_pragmatic_analyzer()
-            orchestrator.entity_extractor = orchestrator._create_basic_entity_extractor()
-            orchestrator.relation_extractor = orchestrator._create_basic_relation_extractor()
-            orchestrator.consistency_validator = orchestrator._create_basic_consistency_validator()
-            orchestrator.coherence_validator = orchestrator._create_basic_coherence_validator()
+            orchestrator.syntactic_analyzer = (
+                orchestrator._create_basic_syntactic_analyzer()
+            )
+            orchestrator.semantic_analyzer = (
+                orchestrator._create_basic_semantic_analyzer()
+            )
+            orchestrator.pragmatic_analyzer = (
+                orchestrator._create_basic_pragmatic_analyzer()
+            )
+            orchestrator.entity_extractor = (
+                orchestrator._create_basic_entity_extractor()
+            )
+            orchestrator.relation_extractor = (
+                orchestrator._create_basic_relation_extractor()
+            )
+            orchestrator.consistency_validator = (
+                orchestrator._create_basic_consistency_validator()
+            )
+            orchestrator.coherence_validator = (
+                orchestrator._create_basic_coherence_validator()
+            )
             return True
 
         orchestrator.initialize = mock_init
@@ -639,7 +663,9 @@ class TestOrchestrateAnalysis:
 
         async def mock_init():
             orchestrator.is_initialized = True
-            orchestrator.semantic_analyzer = orchestrator._create_basic_semantic_analyzer()
+            orchestrator.semantic_analyzer = (
+                orchestrator._create_basic_semantic_analyzer()
+            )
             return True
 
         orchestrator.initialize = mock_init
@@ -659,7 +685,9 @@ class TestErrorHandling:
         """When an analyzer raises, analyze_text returns error result, not exception."""
         # Make syntactic analyzer raise
         initialized_orchestrator.syntactic_analyzer = MagicMock()
-        initialized_orchestrator.syntactic_analyzer.analyze.side_effect = RuntimeError("boom")
+        initialized_orchestrator.syntactic_analyzer.analyze.side_effect = RuntimeError(
+            "boom"
+        )
 
         from argumentation_analysis.orchestration.real_llm_orchestrator import (
             LLMAnalysisRequest,
@@ -673,7 +701,9 @@ class TestErrorHandling:
 
     async def test_failed_analysis_has_request_id(self, initialized_orchestrator):
         initialized_orchestrator.syntactic_analyzer = MagicMock()
-        initialized_orchestrator.syntactic_analyzer.analyze.side_effect = ValueError("err")
+        initialized_orchestrator.syntactic_analyzer.analyze.side_effect = ValueError(
+            "err"
+        )
 
         from argumentation_analysis.orchestration.real_llm_orchestrator import (
             LLMAnalysisRequest,
@@ -695,7 +725,9 @@ class TestLogicalAnalysis:
 
     async def test_logical_without_proper_agent(self, initialized_orchestrator):
         """When logical_analyzer is not PropositionalLogicAgent, returns error."""
-        initialized_orchestrator.logical_analyzer = MagicMock()  # Not a PropositionalLogicAgent
+        initialized_orchestrator.logical_analyzer = (
+            MagicMock()
+        )  # Not a PropositionalLogicAgent
 
         result = await initialized_orchestrator._analyze_logical("Test", {}, {})
         assert result["success"] is False

--- a/tests/unit/argumentation_analysis/orchestration/test_router.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_router.py
@@ -20,7 +20,6 @@ from argumentation_analysis.orchestration.router import (
 )
 from argumentation_analysis.orchestration.workflow_dsl import WorkflowDefinition
 
-
 # ============================================================
 # Helpers
 # ============================================================
@@ -55,15 +54,19 @@ class TestLLMRouting:
     async def test_llm_returns_valid_json(self):
         """LLM returns valid JSON → correct capabilities selected."""
         router = _make_router()
-        llm_response = json.dumps({
-            "capabilities": ["argument_quality", "counter_argument_generation"],
-            "workflow_complexity": "standard",
-        })
+        llm_response = json.dumps(
+            {
+                "capabilities": ["argument_quality", "counter_argument_generation"],
+                "workflow_complexity": "standard",
+            }
+        )
         mock_response = _mock_openai_response(llm_response)
 
         with patch("openai.AsyncOpenAI") as MockClient:
             client_instance = AsyncMock()
-            client_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+            client_instance.chat.completions.create = AsyncMock(
+                return_value=mock_response
+            )
             MockClient.return_value = client_instance
 
             workflow = await router.analyze_and_route_async("Test text for analysis.")
@@ -77,15 +80,19 @@ class TestLLMRouting:
     async def test_llm_unknown_capabilities_filtered(self):
         """LLM returns unknown capabilities → filtered out."""
         router = _make_router()
-        llm_response = json.dumps({
-            "capabilities": ["argument_quality", "unknown_cap", "magic_analysis"],
-            "workflow_complexity": "light",
-        })
+        llm_response = json.dumps(
+            {
+                "capabilities": ["argument_quality", "unknown_cap", "magic_analysis"],
+                "workflow_complexity": "light",
+            }
+        )
         mock_response = _mock_openai_response(llm_response)
 
         with patch("openai.AsyncOpenAI") as MockClient:
             client_instance = AsyncMock()
-            client_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+            client_instance.chat.completions.create = AsyncMock(
+                return_value=mock_response
+            )
             MockClient.return_value = client_instance
 
             workflow = await router.analyze_and_route_async("Test text.")
@@ -99,15 +106,19 @@ class TestLLMRouting:
     async def test_llm_empty_capabilities_gives_quality_only(self):
         """LLM returns empty list → quality-only workflow."""
         router = _make_router()
-        llm_response = json.dumps({
-            "capabilities": [],
-            "workflow_complexity": "light",
-        })
+        llm_response = json.dumps(
+            {
+                "capabilities": [],
+                "workflow_complexity": "light",
+            }
+        )
         mock_response = _mock_openai_response(llm_response)
 
         with patch("openai.AsyncOpenAI") as MockClient:
             client_instance = AsyncMock()
-            client_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+            client_instance.chat.completions.create = AsyncMock(
+                return_value=mock_response
+            )
             MockClient.return_value = client_instance
 
             workflow = await router.analyze_and_route_async("Short text.")
@@ -124,7 +135,9 @@ class TestLLMRouting:
 
         with patch("openai.AsyncOpenAI") as MockClient:
             client_instance = AsyncMock()
-            client_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+            client_instance.chat.completions.create = AsyncMock(
+                return_value=mock_response
+            )
             MockClient.return_value = client_instance
 
             workflow = await router.analyze_and_route_async("Test text for analysis.")
@@ -156,15 +169,19 @@ class TestLLMRouting:
     async def test_llm_routing_method_is_llm(self):
         """LLM routing sets routing_method='llm' in RoutingResult."""
         router = _make_router()
-        llm_response = json.dumps({
-            "capabilities": ["argument_quality", "adversarial_debate"],
-            "workflow_complexity": "standard",
-        })
+        llm_response = json.dumps(
+            {
+                "capabilities": ["argument_quality", "adversarial_debate"],
+                "workflow_complexity": "standard",
+            }
+        )
         mock_response = _mock_openai_response(llm_response)
 
         with patch("openai.AsyncOpenAI") as MockClient:
             client_instance = AsyncMock()
-            client_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+            client_instance.chat.completions.create = AsyncMock(
+                return_value=mock_response
+            )
             MockClient.return_value = client_instance
 
             result = await router._route_with_llm("Test text.", KNOWN_CAPABILITIES)
@@ -177,10 +194,12 @@ class TestLLMRouting:
         """Text is truncated to LLM_TEXT_LIMIT chars for the LLM call."""
         router = _make_router()
         long_text = "A" * 5000
-        llm_response = json.dumps({
-            "capabilities": ["argument_quality"],
-            "workflow_complexity": "full",
-        })
+        llm_response = json.dumps(
+            {
+                "capabilities": ["argument_quality"],
+                "workflow_complexity": "full",
+            }
+        )
         mock_response = _mock_openai_response(llm_response)
         captured_messages = []
 
@@ -190,7 +209,9 @@ class TestLLMRouting:
 
         with patch("openai.AsyncOpenAI") as MockClient:
             client_instance = AsyncMock()
-            client_instance.chat.completions.create = AsyncMock(side_effect=capture_create)
+            client_instance.chat.completions.create = AsyncMock(
+                side_effect=capture_create
+            )
             MockClient.return_value = client_instance
 
             await router.analyze_and_route_async(long_text)
@@ -215,7 +236,9 @@ class TestLLMRouting:
 
         with patch("openai.AsyncOpenAI") as MockClient:
             client_instance = AsyncMock()
-            client_instance.chat.completions.create = AsyncMock(return_value=mock_response)
+            client_instance.chat.completions.create = AsyncMock(
+                return_value=mock_response
+            )
             MockClient.return_value = client_instance
 
             workflow = await router.analyze_and_route_async("Test text.")
@@ -455,10 +478,12 @@ class TestRouterIntegration:
         registry = setup_registry(include_optional=False)
 
         # Mock the LLM call in the router
-        llm_response = json.dumps({
-            "capabilities": ["argument_quality", "counter_argument_generation"],
-            "workflow_complexity": "light",
-        })
+        llm_response = json.dumps(
+            {
+                "capabilities": ["argument_quality", "counter_argument_generation"],
+                "workflow_complexity": "light",
+            }
+        )
         mock_response = _mock_openai_response(llm_response)
 
         with patch("openai.AsyncOpenAI") as MockClient:

--- a/tests/unit/argumentation_analysis/orchestration/test_service_manager.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_service_manager.py
@@ -33,7 +33,6 @@ from unittest.mock import patch, MagicMock, AsyncMock, PropertyMock
 from datetime import datetime, timedelta
 from pathlib import Path
 
-
 # ========================================================================
 # Module-level patch path prefix
 # ========================================================================
@@ -52,6 +51,7 @@ class TestServiceManagerState:
         from argumentation_analysis.orchestration.service_manager import (
             ServiceManagerState,
         )
+
         return ServiceManagerState()
 
     def test_init_creates_session_id(self):
@@ -113,12 +113,14 @@ class TestServiceManagerError:
         from argumentation_analysis.orchestration.service_manager import (
             ServiceManagerError,
         )
+
         assert issubclass(ServiceManagerError, Exception)
 
     def test_can_be_raised_and_caught(self):
         from argumentation_analysis.orchestration.service_manager import (
             ServiceManagerError,
         )
+
         with pytest.raises(ServiceManagerError, match="test message"):
             raise ServiceManagerError("test message")
 
@@ -126,6 +128,7 @@ class TestServiceManagerError:
         from argumentation_analysis.orchestration.service_manager import (
             ServiceManagerError,
         )
+
         err = ServiceManagerError("specific error detail")
         assert str(err) == "specific error detail"
 
@@ -143,6 +146,7 @@ class TestOrchestrationServiceManagerInit:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         return OrchestrationServiceManager(enable_logging=False)
 
     # --- __init__ ---
@@ -177,6 +181,7 @@ class TestOrchestrationServiceManagerInit:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         mgr = OrchestrationServiceManager(
             enable_logging=False, taxonomy_file_path="/some/path.csv"
         )
@@ -196,6 +201,7 @@ class TestOrchestrationServiceManagerInit:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         # Should not raise
         mgr = OrchestrationServiceManager(enable_logging=True, log_level=40)
         assert mgr.logger is not None
@@ -265,6 +271,7 @@ class TestUnifiedState:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         return OrchestrationServiceManager(enable_logging=False)
 
     def test_unified_state_initially_none(self, manager):
@@ -309,6 +316,7 @@ class TestInitialize:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         return OrchestrationServiceManager(enable_logging=False)
 
     async def test_initialize_already_initialized(self, manager):
@@ -342,9 +350,11 @@ class TestInitialize:
 
         mock_context = MagicMock()
 
-        with patch(f"{SM_MODULE}.initialize_project_environment", return_value=mock_context), \
-             patch(f"{SM_MODULE}.settings", mock_settings), \
-             patch(f"{SM_MODULE}.sk") as mock_sk:
+        with patch(
+            f"{SM_MODULE}.initialize_project_environment", return_value=mock_context
+        ), patch(f"{SM_MODULE}.settings", mock_settings), patch(
+            f"{SM_MODULE}.sk"
+        ) as mock_sk:
             mock_sk.Kernel.return_value = MagicMock()
             result = await manager.initialize()
             assert result is True
@@ -364,10 +374,13 @@ class TestInitialize:
         mock_kernel.get_service.return_value = MagicMock()
         mock_llm_service = MagicMock()
 
-        with patch(f"{SM_MODULE}.initialize_project_environment", return_value=mock_context), \
-             patch(f"{SM_MODULE}.settings", mock_settings), \
-             patch(f"{SM_MODULE}.sk") as mock_sk, \
-             patch(f"{SM_MODULE}.create_llm_service", return_value=mock_llm_service):
+        with patch(
+            f"{SM_MODULE}.initialize_project_environment", return_value=mock_context
+        ), patch(f"{SM_MODULE}.settings", mock_settings), patch(
+            f"{SM_MODULE}.sk"
+        ) as mock_sk, patch(
+            f"{SM_MODULE}.create_llm_service", return_value=mock_llm_service
+        ):
             mock_sk.Kernel.return_value = mock_kernel
             result = await manager.initialize()
             assert result is True
@@ -387,10 +400,13 @@ class TestInitialize:
         mock_kernel = MagicMock()
         mock_kernel.get_service.side_effect = Exception("no service")
 
-        with patch(f"{SM_MODULE}.initialize_project_environment", return_value=mock_context), \
-             patch(f"{SM_MODULE}.settings", mock_settings), \
-             patch(f"{SM_MODULE}.sk") as mock_sk, \
-             patch(f"{SM_MODULE}.create_llm_service", side_effect=RuntimeError("LLM fail")):
+        with patch(
+            f"{SM_MODULE}.initialize_project_environment", return_value=mock_context
+        ), patch(f"{SM_MODULE}.settings", mock_settings), patch(
+            f"{SM_MODULE}.sk"
+        ) as mock_sk, patch(
+            f"{SM_MODULE}.create_llm_service", side_effect=RuntimeError("LLM fail")
+        ):
             mock_sk.Kernel.return_value = mock_kernel
             result = await manager.initialize()
             # Still succeeds (error is logged but not fatal)
@@ -407,10 +423,13 @@ class TestInitialize:
 
         mock_context = MagicMock()
 
-        with patch(f"{SM_MODULE}.initialize_project_environment", return_value=mock_context), \
-             patch(f"{SM_MODULE}.settings", mock_settings), \
-             patch(f"{SM_MODULE}.sk") as mock_sk, \
-             patch.object(manager, "initialize_middleware", new_callable=AsyncMock) as mock_mw:
+        with patch(
+            f"{SM_MODULE}.initialize_project_environment", return_value=mock_context
+        ), patch(f"{SM_MODULE}.settings", mock_settings), patch(
+            f"{SM_MODULE}.sk"
+        ) as mock_sk, patch.object(
+            manager, "initialize_middleware", new_callable=AsyncMock
+        ) as mock_mw:
             mock_sk.Kernel.return_value = MagicMock()
             result = await manager.initialize()
             assert result is True
@@ -427,10 +446,13 @@ class TestInitialize:
 
         mock_context = MagicMock()
 
-        with patch(f"{SM_MODULE}.initialize_project_environment", return_value=mock_context), \
-             patch(f"{SM_MODULE}.settings", mock_settings), \
-             patch(f"{SM_MODULE}.sk") as mock_sk, \
-             patch.object(manager, "_initialize_hierarchical_managers", new_callable=AsyncMock) as mock_hm:
+        with patch(
+            f"{SM_MODULE}.initialize_project_environment", return_value=mock_context
+        ), patch(f"{SM_MODULE}.settings", mock_settings), patch(
+            f"{SM_MODULE}.sk"
+        ) as mock_sk, patch.object(
+            manager, "_initialize_hierarchical_managers", new_callable=AsyncMock
+        ) as mock_hm:
             mock_sk.Kernel.return_value = MagicMock()
             result = await manager.initialize()
             assert result is True
@@ -450,6 +472,7 @@ class TestInitializeMiddleware:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         return OrchestrationServiceManager(enable_logging=False)
 
     async def test_middleware_already_initialized(self, manager):
@@ -478,9 +501,9 @@ class TestInitializeMiddleware:
         mock_hc_instance = MagicMock()
         mock_hc_class.return_value = mock_hc_instance
 
-        with patch(f"{SM_MODULE}.settings", mock_settings), \
-             patch(f"{SM_MODULE}.MessageMiddleware", mock_mw_class), \
-             patch(f"{SM_MODULE}.HierarchicalChannel", mock_hc_class):
+        with patch(f"{SM_MODULE}.settings", mock_settings), patch(
+            f"{SM_MODULE}.MessageMiddleware", mock_mw_class
+        ), patch(f"{SM_MODULE}.HierarchicalChannel", mock_hc_class):
             await manager.initialize_middleware()
             assert manager.middleware is mock_mw_instance
             mock_mw_instance.register_channel.assert_called_once_with(mock_hc_instance)
@@ -493,9 +516,9 @@ class TestInitializeMiddleware:
         mock_mw_instance = MagicMock()
         mock_mw_class.return_value = mock_mw_instance
 
-        with patch(f"{SM_MODULE}.settings", mock_settings), \
-             patch(f"{SM_MODULE}.MessageMiddleware", mock_mw_class), \
-             patch(f"{SM_MODULE}.HierarchicalChannel", None):
+        with patch(f"{SM_MODULE}.settings", mock_settings), patch(
+            f"{SM_MODULE}.MessageMiddleware", mock_mw_class
+        ), patch(f"{SM_MODULE}.HierarchicalChannel", None):
             await manager.initialize_middleware()
             assert manager.middleware is mock_mw_instance
             # No channel registered since HierarchicalChannel is None
@@ -513,9 +536,9 @@ class TestInitializeMiddleware:
 
         mock_hc_class = MagicMock()
 
-        with patch(f"{SM_MODULE}.settings", mock_settings), \
-             patch(f"{SM_MODULE}.MessageMiddleware", mock_mw_class), \
-             patch(f"{SM_MODULE}.HierarchicalChannel", mock_hc_class):
+        with patch(f"{SM_MODULE}.settings", mock_settings), patch(
+            f"{SM_MODULE}.MessageMiddleware", mock_mw_class
+        ), patch(f"{SM_MODULE}.HierarchicalChannel", mock_hc_class):
             # Should not raise, error is logged
             await manager.initialize_middleware()
             assert manager.middleware is mock_mw_instance
@@ -534,6 +557,7 @@ class TestInitializeHierarchicalManagers:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         return OrchestrationServiceManager(enable_logging=False)
 
     async def test_no_middleware_skips(self, manager):
@@ -553,9 +577,9 @@ class TestInitializeHierarchicalManagers:
         mock_tactical = MagicMock()
         mock_operational = MagicMock()
 
-        with patch(f"{SM_MODULE}.StrategicManager", mock_strategic), \
-             patch(f"{SM_MODULE}.TacticalManager", mock_tactical), \
-             patch(f"{SM_MODULE}.OperationalManager", mock_operational):
+        with patch(f"{SM_MODULE}.StrategicManager", mock_strategic), patch(
+            f"{SM_MODULE}.TacticalManager", mock_tactical
+        ), patch(f"{SM_MODULE}.OperationalManager", mock_operational):
             await manager._initialize_hierarchical_managers()
             assert manager.strategic_manager is not None
             assert manager.tactical_manager is not None
@@ -564,7 +588,9 @@ class TestInitializeHierarchicalManagers:
     async def test_exception_resets_managers_to_none(self, manager):
         manager.middleware = MagicMock()
 
-        with patch(f"{SM_MODULE}.StrategicManager", side_effect=RuntimeError("init fail")):
+        with patch(
+            f"{SM_MODULE}.StrategicManager", side_effect=RuntimeError("init fail")
+        ):
             await manager._initialize_hierarchical_managers()
             assert manager.strategic_manager is None
             assert manager.tactical_manager is None
@@ -573,9 +599,9 @@ class TestInitializeHierarchicalManagers:
     async def test_managers_none_when_classes_none(self, manager):
         manager.middleware = MagicMock()
 
-        with patch(f"{SM_MODULE}.StrategicManager", None), \
-             patch(f"{SM_MODULE}.TacticalManager", None), \
-             patch(f"{SM_MODULE}.OperationalManager", None):
+        with patch(f"{SM_MODULE}.StrategicManager", None), patch(
+            f"{SM_MODULE}.TacticalManager", None
+        ), patch(f"{SM_MODULE}.OperationalManager", None):
             await manager._initialize_hierarchical_managers()
             assert manager.strategic_manager is None
             assert manager.tactical_manager is None
@@ -595,6 +621,7 @@ class TestInitializeSpecializedOrchestrators:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         mgr = OrchestrationServiceManager(enable_logging=False)
         mgr.kernel = MagicMock()
         return mgr
@@ -603,10 +630,11 @@ class TestInitializeSpecializedOrchestrators:
         mock_cluedo = MagicMock()
         mock_conversation = MagicMock()
 
-        with patch(f"{SM_MODULE}.CluedoOrchestrator", mock_cluedo), \
-             patch(f"{SM_MODULE}.ConversationOrchestrator", mock_conversation), \
-             patch(f"{SM_MODULE}.RealLLMOrchestrator", None), \
-             patch(f"{SM_MODULE}.FactCheckingOrchestrator", None):
+        with patch(f"{SM_MODULE}.CluedoOrchestrator", mock_cluedo), patch(
+            f"{SM_MODULE}.ConversationOrchestrator", mock_conversation
+        ), patch(f"{SM_MODULE}.RealLLMOrchestrator", None), patch(
+            f"{SM_MODULE}.FactCheckingOrchestrator", None
+        ):
             await manager._initialize_specialized_orchestrators()
             assert manager.cluedo_orchestrator is not None
             assert manager.conversation_orchestrator is not None
@@ -617,10 +645,11 @@ class TestInitializeSpecializedOrchestrators:
                 await manager._initialize_specialized_orchestrators()
 
     async def test_all_none_when_classes_none(self, manager):
-        with patch(f"{SM_MODULE}.CluedoOrchestrator", None), \
-             patch(f"{SM_MODULE}.ConversationOrchestrator", None), \
-             patch(f"{SM_MODULE}.RealLLMOrchestrator", None), \
-             patch(f"{SM_MODULE}.FactCheckingOrchestrator", None):
+        with patch(f"{SM_MODULE}.CluedoOrchestrator", None), patch(
+            f"{SM_MODULE}.ConversationOrchestrator", None
+        ), patch(f"{SM_MODULE}.RealLLMOrchestrator", None), patch(
+            f"{SM_MODULE}.FactCheckingOrchestrator", None
+        ):
             await manager._initialize_specialized_orchestrators()
             assert manager.cluedo_orchestrator is None
             assert manager.conversation_orchestrator is None
@@ -641,6 +670,7 @@ class TestAnalyzeText:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         mgr = OrchestrationServiceManager(enable_logging=False)
         mgr._initialized = True
         return mgr
@@ -650,6 +680,7 @@ class TestAnalyzeText:
             OrchestrationServiceManager,
             ServiceManagerError,
         )
+
         mgr = OrchestrationServiceManager(enable_logging=False)
         with pytest.raises(ServiceManagerError, match="non initialisé"):
             await mgr.analyze_text("Test text")
@@ -658,6 +689,7 @@ class TestAnalyzeText:
         from argumentation_analysis.orchestration.service_manager import (
             ServiceManagerError,
         )
+
         with pytest.raises(ServiceManagerError, match="vide"):
             await manager.analyze_text("")
 
@@ -665,6 +697,7 @@ class TestAnalyzeText:
         from argumentation_analysis.orchestration.service_manager import (
             ServiceManagerError,
         )
+
         with pytest.raises(ServiceManagerError, match="vide"):
             await manager.analyze_text("   \t\n  ")
 
@@ -675,9 +708,16 @@ class TestAnalyzeText:
         mock_settings = MagicMock()
         mock_settings.service_manager.save_results = False
 
-        with patch.object(manager, "_select_orchestrator", return_value=mock_orch), \
-             patch.object(manager, "_run_specialized_analysis", new_callable=AsyncMock, return_value={"result": "ok"}), \
-             patch(f"{SM_MODULE}.settings", mock_settings):
+        with patch.object(
+            manager, "_select_orchestrator", return_value=mock_orch
+        ), patch.object(
+            manager,
+            "_run_specialized_analysis",
+            new_callable=AsyncMock,
+            return_value={"result": "ok"},
+        ), patch(
+            f"{SM_MODULE}.settings", mock_settings
+        ):
             result = await manager.analyze_text("Analyze this text")
             assert result["status"] == "completed"
             assert result["results"]["specialized"] == {"result": "ok"}
@@ -686,10 +726,19 @@ class TestAnalyzeText:
         mock_settings = MagicMock()
         mock_settings.service_manager.save_results = False
 
-        with patch.object(manager, "_select_orchestrator", return_value=None), \
-             patch.object(manager, "_run_hierarchical_analysis", new_callable=AsyncMock, return_value={"level": "hierarchical"}), \
-             patch(f"{SM_MODULE}.settings", mock_settings):
-            result = await manager.analyze_text("Analyze this text", analysis_type="unknown_type")
+        with patch.object(
+            manager, "_select_orchestrator", return_value=None
+        ), patch.object(
+            manager,
+            "_run_hierarchical_analysis",
+            new_callable=AsyncMock,
+            return_value={"level": "hierarchical"},
+        ), patch(
+            f"{SM_MODULE}.settings", mock_settings
+        ):
+            result = await manager.analyze_text(
+                "Analyze this text", analysis_type="unknown_type"
+            )
             assert result["status"] == "completed"
             assert result["results"]["hierarchical"] == {"level": "hierarchical"}
 
@@ -697,8 +746,9 @@ class TestAnalyzeText:
         mock_settings = MagicMock()
         mock_settings.service_manager.save_results = False
 
-        with patch.object(manager, "_select_orchestrator", side_effect=RuntimeError("select error")), \
-             patch(f"{SM_MODULE}.settings", mock_settings):
+        with patch.object(
+            manager, "_select_orchestrator", side_effect=RuntimeError("select error")
+        ), patch(f"{SM_MODULE}.settings", mock_settings):
             result = await manager.analyze_text("Some text")
             assert result["status"] == "failed"
             assert "error" in result
@@ -707,10 +757,18 @@ class TestAnalyzeText:
         mock_settings = MagicMock()
         mock_settings.service_manager.save_results = True
 
-        with patch.object(manager, "_select_orchestrator", return_value=None), \
-             patch.object(manager, "_run_hierarchical_analysis", new_callable=AsyncMock, return_value={}), \
-             patch.object(manager, "_save_results", new_callable=AsyncMock) as mock_save, \
-             patch(f"{SM_MODULE}.settings", mock_settings):
+        with patch.object(
+            manager, "_select_orchestrator", return_value=None
+        ), patch.object(
+            manager,
+            "_run_hierarchical_analysis",
+            new_callable=AsyncMock,
+            return_value={},
+        ), patch.object(
+            manager, "_save_results", new_callable=AsyncMock
+        ) as mock_save, patch(
+            f"{SM_MODULE}.settings", mock_settings
+        ):
             await manager.analyze_text("Text to analyze")
             mock_save.assert_awaited_once()
 
@@ -718,9 +776,16 @@ class TestAnalyzeText:
         mock_settings = MagicMock()
         mock_settings.service_manager.save_results = False
 
-        with patch.object(manager, "_select_orchestrator", return_value=None), \
-             patch.object(manager, "_run_hierarchical_analysis", new_callable=AsyncMock, return_value={}), \
-             patch(f"{SM_MODULE}.settings", mock_settings):
+        with patch.object(
+            manager, "_select_orchestrator", return_value=None
+        ), patch.object(
+            manager,
+            "_run_hierarchical_analysis",
+            new_callable=AsyncMock,
+            return_value={},
+        ), patch(
+            f"{SM_MODULE}.settings", mock_settings
+        ):
             result = await manager.analyze_text("Test text")
             assert "analysis_id" in result
             # Should be a valid UUID
@@ -740,6 +805,7 @@ class TestSelectOrchestrator:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         mgr = OrchestrationServiceManager(enable_logging=False)
         mgr.cluedo_orchestrator = MagicMock(name="cluedo")
         mgr.conversation_orchestrator = MagicMock(name="conversation")
@@ -754,25 +820,42 @@ class TestSelectOrchestrator:
         assert manager._select_orchestrator("detective") is manager.cluedo_orchestrator
 
     def test_conversation_type(self, manager):
-        assert manager._select_orchestrator("conversation") is manager.conversation_orchestrator
+        assert (
+            manager._select_orchestrator("conversation")
+            is manager.conversation_orchestrator
+        )
 
     def test_dialogue_type(self, manager):
-        assert manager._select_orchestrator("dialogue") is manager.conversation_orchestrator
+        assert (
+            manager._select_orchestrator("dialogue")
+            is manager.conversation_orchestrator
+        )
 
     def test_llm_type(self, manager):
         assert manager._select_orchestrator("llm") is manager.llm_orchestrator
 
     def test_language_model_type(self, manager):
-        assert manager._select_orchestrator("language_model") is manager.llm_orchestrator
+        assert (
+            manager._select_orchestrator("language_model") is manager.llm_orchestrator
+        )
 
     def test_fact_checking_type(self, manager):
-        assert manager._select_orchestrator("fact_checking") is manager.fact_checking_orchestrator
+        assert (
+            manager._select_orchestrator("fact_checking")
+            is manager.fact_checking_orchestrator
+        )
 
     def test_comprehensive_type(self, manager):
-        assert manager._select_orchestrator("comprehensive") is manager.fact_checking_orchestrator
+        assert (
+            manager._select_orchestrator("comprehensive")
+            is manager.fact_checking_orchestrator
+        )
 
     def test_rhetorical_type(self, manager):
-        assert manager._select_orchestrator("rhetorical") is manager.fact_checking_orchestrator
+        assert (
+            manager._select_orchestrator("rhetorical")
+            is manager.fact_checking_orchestrator
+        )
 
     def test_logical_type(self, manager):
         assert manager._select_orchestrator("logical") is manager.llm_orchestrator
@@ -791,7 +874,9 @@ class TestSelectOrchestrator:
 
     def test_unified_analysis_defaults_to_llm(self, manager):
         # "unified_analysis" is not in the map, so defaults to llm_orchestrator
-        assert manager._select_orchestrator("unified_analysis") is manager.llm_orchestrator
+        assert (
+            manager._select_orchestrator("unified_analysis") is manager.llm_orchestrator
+        )
 
 
 # ========================================================================
@@ -807,6 +892,7 @@ class TestRunSpecializedAnalysis:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         return OrchestrationServiceManager(enable_logging=False)
 
     async def test_fact_checking_interface(self, manager):
@@ -827,14 +913,18 @@ class TestRunSpecializedAnalysis:
         # which resolves to `argumentation_analysis.orchestration.fact_checking_orchestrator`.
         # We mock the module in sys.modules so the import picks up our mocks.
         import sys
+
         mock_fc_module = MagicMock()
         mock_fc_module.FactCheckingRequest = MagicMock(return_value=MagicMock())
         mock_fc_module.AnalysisDepth = MagicMock()
         mock_fc_module.AnalysisDepth.STANDARD = "standard"
 
-        with patch.dict(sys.modules, {
-            "argumentation_analysis.orchestration.fact_checking_orchestrator": mock_fc_module
-        }):
+        with patch.dict(
+            sys.modules,
+            {
+                "argumentation_analysis.orchestration.fact_checking_orchestrator": mock_fc_module
+            },
+        ):
             result = await manager._run_specialized_analysis(
                 mock_orch, "test text", "fact_checking", None
             )
@@ -859,12 +949,16 @@ class TestRunSpecializedAnalysis:
         mock_orch.analyze_text = AsyncMock(return_value=mock_result)
 
         import sys
+
         mock_llm_module = MagicMock()
         mock_llm_module.LLMAnalysisRequest = MagicMock()
 
-        with patch.dict(sys.modules, {
-            "argumentation_analysis.orchestration.real_llm_orchestrator": mock_llm_module
-        }):
+        with patch.dict(
+            sys.modules,
+            {
+                "argumentation_analysis.orchestration.real_llm_orchestrator": mock_llm_module
+            },
+        ):
             result = await manager._run_specialized_analysis(
                 mock_orch, "test text", "llm", {"context": "test"}
             )
@@ -921,6 +1015,7 @@ class TestRunHierarchicalAnalysis:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         return OrchestrationServiceManager(enable_logging=False)
 
     async def test_no_managers_returns_empty(self, manager):
@@ -931,9 +1026,10 @@ class TestRunHierarchicalAnalysis:
         manager.strategic_manager = MagicMock()
 
         with patch.object(
-            manager, "_run_strategic_analysis",
+            manager,
+            "_run_strategic_analysis",
             new_callable=AsyncMock,
-            return_value={"level": "strategic", "status": "ok"}
+            return_value={"level": "strategic", "status": "ok"},
         ):
             result = await manager._run_hierarchical_analysis("text", "type", None)
             assert "strategic" in result
@@ -942,9 +1038,10 @@ class TestRunHierarchicalAnalysis:
         manager.tactical_manager = MagicMock()
 
         with patch.object(
-            manager, "_run_tactical_analysis",
+            manager,
+            "_run_tactical_analysis",
             new_callable=AsyncMock,
-            return_value={"level": "tactical", "status": "ok"}
+            return_value={"level": "tactical", "status": "ok"},
         ):
             result = await manager._run_hierarchical_analysis("text", "type", None)
             assert "tactical" in result
@@ -953,9 +1050,10 @@ class TestRunHierarchicalAnalysis:
         manager.operational_manager = MagicMock()
 
         with patch.object(
-            manager, "_run_operational_analysis",
+            manager,
+            "_run_operational_analysis",
             new_callable=AsyncMock,
-            return_value={"level": "operational", "status": "ok"}
+            return_value={"level": "operational", "status": "ok"},
         ):
             result = await manager._run_hierarchical_analysis("text", "type", None)
             assert "operational" in result
@@ -964,9 +1062,10 @@ class TestRunHierarchicalAnalysis:
         manager.strategic_manager = MagicMock()
 
         with patch.object(
-            manager, "_run_strategic_analysis",
+            manager,
+            "_run_strategic_analysis",
             new_callable=AsyncMock,
-            side_effect=RuntimeError("strategic fail")
+            side_effect=RuntimeError("strategic fail"),
         ):
             result = await manager._run_hierarchical_analysis("text", "type", None)
             assert result["strategic"]["error"] == "strategic fail"
@@ -985,6 +1084,7 @@ class TestGetStatusAndHealthCheck:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         return OrchestrationServiceManager(enable_logging=False)
 
     async def test_get_status_not_initialized(self, manager):
@@ -1031,6 +1131,7 @@ class TestShutdown:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         return OrchestrationServiceManager(enable_logging=False)
 
     async def test_shutdown_sets_flag(self, manager):
@@ -1066,8 +1167,15 @@ class TestShutdown:
     async def test_shutdown_with_multiple_components(self, manager):
         """Shutdown calls shutdown on all components that have it."""
         components = {}
-        for name in ["cluedo_orchestrator", "conversation_orchestrator", "llm_orchestrator",
-                      "strategic_manager", "tactical_manager", "operational_manager", "middleware"]:
+        for name in [
+            "cluedo_orchestrator",
+            "conversation_orchestrator",
+            "llm_orchestrator",
+            "strategic_manager",
+            "tactical_manager",
+            "operational_manager",
+            "middleware",
+        ]:
             mock = MagicMock()
             mock.shutdown = MagicMock(return_value=None)
             components[name] = mock
@@ -1103,6 +1211,7 @@ class TestSaveResults:
         from argumentation_analysis.orchestration.service_manager import (
             OrchestrationServiceManager,
         )
+
         return OrchestrationServiceManager(enable_logging=False)
 
     async def test_save_results_creates_file(self, manager, tmp_path):
@@ -1123,7 +1232,9 @@ class TestSaveResults:
 
     async def test_save_results_error_does_not_crash(self, manager):
         mock_settings = MagicMock()
-        mock_settings.service_manager.results_dir = Path("/nonexistent/path/that/wont/work")
+        mock_settings.service_manager.results_dir = Path(
+            "/nonexistent/path/that/wont/work"
+        )
 
         results = {"analysis_id": "bad-id", "data": "test"}
 
@@ -1148,10 +1259,13 @@ class TestCreateServiceManager:
         mock_instance = MagicMock(spec=OrchestrationServiceManager)
         mock_instance.initialize = AsyncMock()
 
-        with patch(f"{SM_MODULE}.OrchestrationServiceManager", return_value=mock_instance):
+        with patch(
+            f"{SM_MODULE}.OrchestrationServiceManager", return_value=mock_instance
+        ):
             from argumentation_analysis.orchestration.service_manager import (
                 create_service_manager,
             )
+
             result = await create_service_manager()
             assert result is mock_instance
             mock_instance.initialize.assert_awaited_once()
@@ -1174,7 +1288,9 @@ class TestServiceManagerAlias:
             instance = ServiceManager(enable_logging=False)
             assert len(w) >= 1
             assert issubclass(w[-1].category, DeprecationWarning)
-            assert "déprécié" in str(w[-1].message).lower() or "ServiceManager" in str(w[-1].message)
+            assert "déprécié" in str(w[-1].message).lower() or "ServiceManager" in str(
+                w[-1].message
+            )
 
     def test_deprecated_alias_returns_orchestration_manager(self):
         import warnings
@@ -1202,6 +1318,7 @@ class TestGetDefaultServiceManager:
             get_default_service_manager,
             OrchestrationServiceManager,
         )
+
         mgr = get_default_service_manager()
         assert isinstance(mgr, OrchestrationServiceManager)
         assert mgr._initialized is False

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -659,12 +659,16 @@ class TestInvokeCallables:
 
         mock_plugin = MagicMock()
         mock_plugin.parse_argument.return_value = '{"premise": "X", "conclusion": "Y"}'
-        mock_plugin.suggest_strategy.return_value = '{"strategy_name": "reductio", "confidence": 0.9}'
+        mock_plugin.suggest_strategy.return_value = (
+            '{"strategy_name": "reductio", "confidence": 0.9}'
+        )
         with patch(
             "argumentation_analysis.agents.core.counter_argument.counter_agent.CounterArgumentPlugin",
             return_value=mock_plugin,
         ):
-            result = await _invoke_counter_argument("Test", {"phase_quality_output": {"score": 5}})
+            result = await _invoke_counter_argument(
+                "Test", {"phase_quality_output": {"score": 5}}
+            )
         assert result["parsed_argument"]["premise"] == "X"
         assert result["suggested_strategy"]["strategy_name"] == "reductio"
         assert result["quality_context"] == {"score": 5}
@@ -692,7 +696,9 @@ class TestInvokeCallables:
         )
 
         mock_plugin = MagicMock()
-        mock_plugin.analyze_argument_quality.return_value = '{"score": 7, "winner": "pro"}'
+        mock_plugin.analyze_argument_quality.return_value = (
+            '{"score": 7, "winner": "pro"}'
+        )
         with patch(
             "argumentation_analysis.agents.core.debate.debate_agent.DebatePlugin",
             return_value=mock_plugin,
@@ -709,7 +715,7 @@ class TestInvokeCallables:
 
         mock_plugin = MagicMock()
         mock_plugin.list_governance_methods.return_value = '["majority", "borda"]'
-        mock_plugin.detect_conflicts_fn.return_value = '[]'
+        mock_plugin.detect_conflicts_fn.return_value = "[]"
         with patch(
             "argumentation_analysis.plugins.governance_plugin.GovernancePlugin",
             return_value=mock_plugin,
@@ -819,7 +825,9 @@ class TestInvokeCallables:
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             return_value=mock_bridge,
         ):
-            result = await _invoke_propositional_logic("p", {"formulas": "single_formula"})
+            result = await _invoke_propositional_logic(
+                "p", {"formulas": "single_formula"}
+            )
         assert result["formulas"] == ["single_formula"]
         assert result["satisfiable"] is False
 
@@ -947,17 +955,22 @@ class TestInvokeCallables:
         )
 
         mock_handler = MagicMock()
-        mock_handler.analyze_dung_framework.return_value = {"extensions": {"preferred": []}}
+        mock_handler.analyze_dung_framework.return_value = {
+            "extensions": {"preferred": []}
+        }
 
         # Patch at the module level where the import happens inside the function
-        with patch.dict("sys.modules", {
-            "argumentation_analysis.agents.core.logic.af_handler": MagicMock(
-                AFHandler=MagicMock(return_value=mock_handler)
-            ),
-            "argumentation_analysis.core.jvm_setup": MagicMock(
-                TweetyInitializer=MagicMock()
-            ),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "argumentation_analysis.agents.core.logic.af_handler": MagicMock(
+                    AFHandler=MagicMock(return_value=mock_handler)
+                ),
+                "argumentation_analysis.core.jvm_setup": MagicMock(
+                    TweetyInitializer=MagicMock()
+                ),
+            },
+        ):
             result = await _invoke_dung_extensions("text", {})
         # Should have called with default arg_0, arg_1, arg_2
         call_args = mock_handler.analyze_dung_framework.call_args
@@ -1010,7 +1023,9 @@ class TestInvokeCallables:
         )
 
         ctx = {
-            "phase_dung_output": {"extensions": {"preferred": [["a"], ["b"]], "grounded": [["a"]]}},
+            "phase_dung_output": {
+                "extensions": {"preferred": [["a"], ["b"]], "grounded": [["a"]]}
+            },
         }
         result = await _invoke_formal_synthesis("text", ctx)
         assert "extensions" in result["summary"]
@@ -1026,6 +1041,7 @@ class TestStateWriters:
 
     def _make_state(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         return UnifiedAnalysisState("Test text")
 
     def test_write_quality_to_state(self):
@@ -1035,7 +1051,12 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        output = {"note_finale": 7.5, "clarity": 8.0, "relevance": 6.0, "non_numeric": "skip"}
+        output = {
+            "note_finale": 7.5,
+            "clarity": 8.0,
+            "relevance": 6.0,
+            "non_numeric": "skip",
+        }
         _write_quality_to_state(output, state, {})
         assert "arg_input" in state.argument_quality_scores
         assert state.argument_quality_scores["arg_input"]["overall"] == 7.5
@@ -1110,7 +1131,9 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        output = {"beliefs": {"claim_0": "True", "claim_1": "False", "claim_2": "maybe"}}
+        output = {
+            "beliefs": {"claim_0": "True", "claim_1": "False", "claim_2": "maybe"}
+        }
         _write_jtms_to_state(output, state, {})
         assert len(state.jtms_beliefs) == 3
 
@@ -1188,7 +1211,11 @@ class TestStateWriters:
         state = self._make_state()
         output = {
             "detections": [
-                {"text": "attack the person", "label": "ad_hominem", "confidence": 0.92},
+                {
+                    "text": "attack the person",
+                    "label": "ad_hominem",
+                    "confidence": 0.92,
+                },
                 {"text": "straw man", "label": "straw_man", "confidence": 0.78},
             ]
         }
@@ -1222,7 +1249,9 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        output = {"results": [{"id": "doc1", "score": 0.95, "snippet": "relevant text"}]}
+        output = {
+            "results": [{"id": "doc1", "score": 0.95, "snippet": "relevant text"}]
+        }
         _write_semantic_index_to_state(output, state, {"input_data": "query"})
         assert len(state.semantic_index_refs) == 1
 
@@ -1269,7 +1298,13 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        output = {"claims": ["Claim one about something", "  ", "Claim two about another thing"]}
+        output = {
+            "claims": [
+                "Claim one about something",
+                "  ",
+                "Claim two about another thing",
+            ]
+        }
         _write_fact_extraction_to_state(output, state, {})
         # Only non-empty stripped strings are added
         assert len(state.extracts) == 2
@@ -1351,7 +1386,9 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        _write_modal_to_state({"formulas": 42, "valid": True, "modalities": "not list"}, state, {})
+        _write_modal_to_state(
+            {"formulas": 42, "valid": True, "modalities": "not list"}, state, {}
+        )
 
     def test_write_dung_extensions_to_state(self):
         """_write_dung_extensions_to_state writes Dung framework results."""
@@ -1401,7 +1438,11 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        output = {"summary": 42, "phase_results": "not dict", "overall_validity": "high"}
+        output = {
+            "summary": 42,
+            "phase_results": "not dict",
+            "overall_validity": "high",
+        }
         _write_formal_synthesis_to_state(output, state, {})
 
     def test_write_ranking_to_state(self):
@@ -1411,7 +1452,11 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        output = {"method": "categorizer", "arguments": ["a", "b"], "comparisons": [{"a": 1, "b": 2}]}
+        output = {
+            "method": "categorizer",
+            "arguments": ["a", "b"],
+            "comparisons": [{"a": 1, "b": 2}],
+        }
         _write_ranking_to_state(output, state, {})
 
     def test_write_ranking_to_state_bad_types(self):
@@ -1421,7 +1466,9 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        _write_ranking_to_state({"method": "x", "arguments": "bad", "comparisons": "bad"}, state, {})
+        _write_ranking_to_state(
+            {"method": "x", "arguments": "bad", "comparisons": "bad"}, state, {}
+        )
 
     def test_write_aspic_to_state(self):
         """_write_aspic_to_state writes ASPIC+ result."""
@@ -1430,7 +1477,11 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        output = {"reasoner_type": "simple", "extensions": [["a"]], "statistics": {"count": 1}}
+        output = {
+            "reasoner_type": "simple",
+            "extensions": [["a"]],
+            "statistics": {"count": 1},
+        }
         _write_aspic_to_state(output, state, {})
 
     def test_write_aspic_to_state_bad_types(self):
@@ -1459,7 +1510,9 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        _write_belief_revision_to_state({"original": "bad", "revised": "bad"}, state, {})
+        _write_belief_revision_to_state(
+            {"original": "bad", "revised": "bad"}, state, {}
+        )
 
     def test_write_dialogue_to_state(self):
         """_write_dialogue_to_state writes dialogue result."""
@@ -1468,7 +1521,11 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        output = {"topic": "AI", "outcome": "agreement", "dialogue_trace": [{"move": "claim"}]}
+        output = {
+            "topic": "AI",
+            "outcome": "agreement",
+            "dialogue_trace": [{"move": "claim"}],
+        }
         _write_dialogue_to_state(output, state, {})
 
     def test_write_dialogue_to_state_bad_trace(self):
@@ -1497,7 +1554,9 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        _write_probabilistic_to_state({"arguments": "bad", "acceptance_probabilities": "bad"}, state, {})
+        _write_probabilistic_to_state(
+            {"arguments": "bad", "acceptance_probabilities": "bad"}, state, {}
+        )
 
     def test_write_bipolar_to_state(self):
         """_write_bipolar_to_state writes bipolar result."""
@@ -1506,7 +1565,11 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        output = {"framework_type": "necessity", "arguments": ["a"], "supports": [["a", "b"]]}
+        output = {
+            "framework_type": "necessity",
+            "arguments": ["a"],
+            "supports": [["a", "b"]],
+        }
         _write_bipolar_to_state(output, state, {})
 
     def test_write_bipolar_to_state_bad_types(self):
@@ -1525,7 +1588,11 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        output = {"assumptions": ["a", "b"], "extensions": [["a"]], "semantics": "preferred"}
+        output = {
+            "assumptions": ["a", "b"],
+            "extensions": [["a"]],
+            "semantics": "preferred",
+        }
         _write_aba_to_state(output, state, {})
         assert len(state.dung_frameworks) == 1
 
@@ -1546,7 +1613,11 @@ class TestStateWriters:
         )
 
         state = self._make_state()
-        output = {"statements": ["s1"], "models": [{"s1": True}], "semantics": "grounded"}
+        output = {
+            "statements": ["s1"],
+            "models": [{"s1": True}],
+            "semantics": "grounded",
+        }
         _write_adf_to_state(output, state, {})
         assert len(state.dung_frameworks) == 1
 
@@ -1678,7 +1749,10 @@ class TestAdditionalWorkflows:
 
         wf = build_quality_gated_counter_workflow()
         counter_phase = wf.get_phase("counter")
-        assert counter_phase.condition({"phase_quality_output": {"note_finale": 5.0}}) is True
+        assert (
+            counter_phase.condition({"phase_quality_output": {"note_finale": 5.0}})
+            is True
+        )
 
     def test_quality_gate_function_blocks_when_low_score(self):
         """Quality gate function returns False when score <= 3.0."""
@@ -1688,7 +1762,10 @@ class TestAdditionalWorkflows:
 
         wf = build_quality_gated_counter_workflow()
         counter_phase = wf.get_phase("counter")
-        assert counter_phase.condition({"phase_quality_output": {"note_finale": 2.0}}) is False
+        assert (
+            counter_phase.condition({"phase_quality_output": {"note_finale": 2.0}})
+            is False
+        )
 
     def test_quality_gate_function_non_dict_output(self):
         """Quality gate function returns True for non-dict quality output."""
@@ -2076,8 +2153,9 @@ class TestHierarchicalFallacyWorkflow:
             _invoke_hierarchical_fallacy,
         )
 
-        with patch("os.path.isfile", return_value=True), \
-             patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+        with patch("os.path.isfile", return_value=True), patch.dict(
+            "os.environ", {"OPENAI_API_KEY": ""}, clear=False
+        ):
             result = await _invoke_hierarchical_fallacy("text", {})
         assert result["exploration_method"] == "error"
         assert result["fallacies"] == []
@@ -2123,8 +2201,9 @@ class TestHierarchicalFallacyWorkflow:
         mock_llm_service = MagicMock()
         mock_kernel_cls = MagicMock()
 
-        with patch("os.path.isfile", return_value=True), \
-             patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}, clear=False):
+        with patch("os.path.isfile", return_value=True), patch.dict(
+            "os.environ", {"OPENAI_API_KEY": "test-key"}, clear=False
+        ):
             # Mock at the source modules that the function imports from
             import argumentation_analysis.plugins.fallacy_workflow_plugin as fwp_mod
             import semantic_kernel.connectors.ai.open_ai as sk_oai
@@ -2140,9 +2219,7 @@ class TestHierarchicalFallacyWorkflow:
             sk_kernel.Kernel = mock_kernel_cls
             openai_mod.AsyncOpenAI = MagicMock()
             try:
-                result = await _invoke_hierarchical_fallacy(
-                    "some argument text", {}
-                )
+                result = await _invoke_hierarchical_fallacy("some argument text", {})
             finally:
                 fwp_mod.FallacyWorkflowPlugin = orig_plugin
                 sk_oai.OpenAIChatCompletion = orig_oai

--- a/tests/unit/argumentation_analysis/orchestration/test_workflow_executor_invoke.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_workflow_executor_invoke.py
@@ -19,7 +19,6 @@ from argumentation_analysis.orchestration.workflow_dsl import (
     PhaseStatus,
 )
 
-
 # ============================================================
 # Basic invoke callable dispatch
 # ============================================================
@@ -43,7 +42,9 @@ class TestInvokeCallableDispatch:
             invoke=fake_invoke,
         )
 
-        workflow = WorkflowBuilder("test").add_phase("p1", capability="test_cap").build()
+        workflow = (
+            WorkflowBuilder("test").add_phase("p1", capability="test_cap").build()
+        )
         executor = WorkflowExecutor(registry)
         results = await executor.execute(workflow, "hello world")
 
@@ -170,9 +171,7 @@ class TestInvokeErrorHandling:
             invoke=bad_invoke,
         )
 
-        workflow = (
-            WorkflowBuilder("test").add_phase("p1", capability="bad_cap").build()
-        )
+        workflow = WorkflowBuilder("test").add_phase("p1", capability="bad_cap").build()
         executor = WorkflowExecutor(registry)
         results = await executor.execute(workflow, "test")
 
@@ -195,7 +194,9 @@ class TestContextChaining:
 
         async def phase_b_invoke(text, ctx):
             upstream = ctx.get("phase_a_output", {})
-            score = upstream.get("quality_score", 0) if isinstance(upstream, dict) else 0
+            score = (
+                upstream.get("quality_score", 0) if isinstance(upstream, dict) else 0
+            )
             return {"counter_based_on": score}
 
         registry = CapabilityRegistry()
@@ -366,10 +367,16 @@ class TestMultiPhaseWorkflow:
 
         registry = CapabilityRegistry()
         registry.register(
-            "extractor", ComponentType.AGENT, capabilities=["extract"], invoke=extract_invoke
+            "extractor",
+            ComponentType.AGENT,
+            capabilities=["extract"],
+            invoke=extract_invoke,
         )
         registry.register(
-            "analyzer", ComponentType.AGENT, capabilities=["analyze"], invoke=analyze_invoke
+            "analyzer",
+            ComponentType.AGENT,
+            capabilities=["analyze"],
+            invoke=analyze_invoke,
         )
         registry.register(
             "synthesizer",
@@ -392,7 +399,9 @@ class TestMultiPhaseWorkflow:
         assert results["analyze"].status == PhaseStatus.COMPLETED
         assert results["synthesize"].status == PhaseStatus.COMPLETED
         assert results["extract"].output["claims"][0] == "Claim one"
-        assert results["analyze"].output["claim_count"] >= 3  # 3 claims + possible empty trailing
+        assert (
+            results["analyze"].output["claim_count"] >= 3
+        )  # 3 claims + possible empty trailing
 
     @pytest.mark.asyncio
     async def test_mixed_invoke_and_none(self):
@@ -445,7 +454,8 @@ class TestRealComponentIntegration:
         )
         executor = WorkflowExecutor(registry)
         results = await executor.execute(
-            workflow, "Les vaccins sont efficaces car les études scientifiques le montrent."
+            workflow,
+            "Les vaccins sont efficaces car les études scientifiques le montrent.",
         )
 
         assert results["quality"].status == PhaseStatus.COMPLETED
@@ -488,7 +498,8 @@ class TestRealComponentIntegration:
         workflow = build_light_workflow()
         executor = WorkflowExecutor(registry)
         results = await executor.execute(
-            workflow, "La peine de mort devrait être abolie car elle ne dissuade pas le crime."
+            workflow,
+            "La peine de mort devrait être abolie car elle ne dissuade pas le crime.",
         )
 
         assert results["quality"].status == PhaseStatus.COMPLETED

--- a/tests/unit/argumentation_analysis/orchestration/test_workflow_state_integration.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_workflow_state_integration.py
@@ -21,7 +21,6 @@ from argumentation_analysis.orchestration.workflow_dsl import (
     PhaseStatus,
 )
 
-
 # ============================================================
 # State injection into context
 # ============================================================
@@ -94,8 +93,12 @@ class TestStateInjection:
             state.add_quality_score("arg_1", {"clarity": 0.9}, 0.9)
 
         registry = CapabilityRegistry()
-        registry.register("a", ComponentType.AGENT, capabilities=["cap_a"], invoke=phase_a)
-        registry.register("b", ComponentType.AGENT, capabilities=["cap_b"], invoke=phase_b)
+        registry.register(
+            "a", ComponentType.AGENT, capabilities=["cap_a"], invoke=phase_a
+        )
+        registry.register(
+            "b", ComponentType.AGENT, capabilities=["cap_b"], invoke=phase_b
+        )
 
         workflow = (
             WorkflowBuilder("chain")
@@ -139,7 +142,10 @@ class TestStateWriters:
         state = UnifiedAnalysisState("test")
         output = {
             "parsed_argument": {"premise": "All cats are animals"},
-            "suggested_strategy": {"strategy_name": "counter_example", "confidence": 0.8},
+            "suggested_strategy": {
+                "strategy_name": "counter_example",
+                "confidence": 0.8,
+            },
         }
         ctx = {"input_data": "test"}
         _write_counter_argument_to_state(output, state, ctx)
@@ -267,7 +273,9 @@ class TestWorkflowExecutorWithState:
             writer_calls.append(output)
 
         registry = CapabilityRegistry()
-        registry.register("c", ComponentType.AGENT, capabilities=["cap"], invoke=fake_invoke)
+        registry.register(
+            "c", ComponentType.AGENT, capabilities=["cap"], invoke=fake_invoke
+        )
 
         workflow = WorkflowBuilder("test").add_phase("p1", capability="cap").build()
         state = UnifiedAnalysisState("test")
@@ -317,7 +325,9 @@ class TestWorkflowExecutorWithState:
             raise ValueError("writer exploded")
 
         registry = CapabilityRegistry()
-        registry.register("c", ComponentType.AGENT, capabilities=["cap"], invoke=ok_invoke)
+        registry.register(
+            "c", ComponentType.AGENT, capabilities=["cap"], invoke=ok_invoke
+        )
 
         workflow = WorkflowBuilder("test").add_phase("p1", capability="cap").build()
         state = UnifiedAnalysisState("test")
@@ -337,7 +347,9 @@ class TestWorkflowExecutorWithState:
             return {"ok": True}
 
         registry = CapabilityRegistry()
-        registry.register("c", ComponentType.AGENT, capabilities=["cap"], invoke=ok_invoke)
+        registry.register(
+            "c", ComponentType.AGENT, capabilities=["cap"], invoke=ok_invoke
+        )
 
         workflow = WorkflowBuilder("wf").add_phase("p1", capability="cap").build()
         state = UnifiedAnalysisState("test")

--- a/tests/unit/argumentation_analysis/pipelines/test_unified_pipelines.py
+++ b/tests/unit/argumentation_analysis/pipelines/test_unified_pipelines.py
@@ -25,12 +25,12 @@ import warnings
 from types import SimpleNamespace, ModuleType
 from unittest.mock import MagicMock, AsyncMock, patch, mock_open
 
-
 # ============================================================================
 # IMPORT WORKAROUND: unified_text_analysis.py fails to import because
 # `from argumentation_analysis.core.bootstrap import get_fallacy_detector` does
 # not exist as a module-level name. We must patch it BEFORE importing the module.
 # ============================================================================
+
 
 def _ensure_uta_importable():
     """Ensure unified_text_analysis and orchestration subpackages can be imported.
@@ -40,10 +40,12 @@ def _ensure_uta_importable():
     """
     try:
         from argumentation_analysis.core import bootstrap as _bootstrap_mod
-        if not hasattr(_bootstrap_mod, 'get_fallacy_detector'):
+
+        if not hasattr(_bootstrap_mod, "get_fallacy_detector"):
             _bootstrap_mod.get_fallacy_detector = MagicMock(return_value=MagicMock())
     except ImportError:
         pass
+
 
 _ensure_uta_importable()
 
@@ -55,6 +57,7 @@ try:
         run_unified_text_analysis_pipeline,
         create_unified_config_from_legacy,
     )
+
     UTA_AVAILABLE = True
 except ImportError:
     UTA_AVAILABLE = False
@@ -67,6 +70,7 @@ try:
     from argumentation_analysis.pipelines.orchestration.config.base_config import (
         ExtendedOrchestrationConfig,
     )
+
     ORCH_CONFIG_AVAILABLE = True
 except ImportError:
     ORCH_CONFIG_AVAILABLE = False
@@ -75,6 +79,7 @@ try:
     from argumentation_analysis.pipelines.orchestration.core.communication import (
         initialize_communication_middleware,
     )
+
     COMM_AVAILABLE = True
 except ImportError:
     COMM_AVAILABLE = False
@@ -92,6 +97,7 @@ try:
         get_communication_log,
         save_orchestration_trace,
     )
+
     ANALYSIS_AVAILABLE = True
 except ImportError:
     ANALYSIS_AVAILABLE = False
@@ -113,18 +119,22 @@ class TestPipelineMode:
 
     def test_pipeline_mode_original(self):
         from argumentation_analysis.pipelines.unified_pipeline import PipelineMode
+
         assert PipelineMode.ORIGINAL == "original"
 
     def test_pipeline_mode_orchestration(self):
         from argumentation_analysis.pipelines.unified_pipeline import PipelineMode
+
         assert PipelineMode.ORCHESTRATION == "orchestration"
 
     def test_pipeline_mode_auto(self):
         from argumentation_analysis.pipelines.unified_pipeline import PipelineMode
+
         assert PipelineMode.AUTO == "auto"
 
     def test_pipeline_mode_hybrid(self):
         from argumentation_analysis.pipelines.unified_pipeline import PipelineMode
+
         assert PipelineMode.HYBRID == "hybrid"
 
 
@@ -134,32 +144,47 @@ class TestDetectBestPipelineMode:
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     def test_detect_orchestration_when_enabled_and_available(self):
-        from argumentation_analysis.pipelines.unified_pipeline import _detect_best_pipeline_mode
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _detect_best_pipeline_mode,
+        )
+
         assert _detect_best_pipeline_mode(enable_orchestration=True) == "orchestration"
 
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", False)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     def test_detect_original_when_orchestration_unavailable(self):
-        from argumentation_analysis.pipelines.unified_pipeline import _detect_best_pipeline_mode
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _detect_best_pipeline_mode,
+        )
+
         assert _detect_best_pipeline_mode(enable_orchestration=True) == "original"
 
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     def test_detect_original_when_orchestration_disabled(self):
-        from argumentation_analysis.pipelines.unified_pipeline import _detect_best_pipeline_mode
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _detect_best_pipeline_mode,
+        )
+
         assert _detect_best_pipeline_mode(enable_orchestration=False) == "original"
 
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", False)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", False)
     def test_detect_raises_when_nothing_available(self):
-        from argumentation_analysis.pipelines.unified_pipeline import _detect_best_pipeline_mode
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _detect_best_pipeline_mode,
+        )
+
         with pytest.raises(RuntimeError, match="Aucun pipeline disponible"):
             _detect_best_pipeline_mode(enable_orchestration=True)
 
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", False)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", False)
     def test_detect_raises_when_disabled_and_original_unavailable(self):
-        from argumentation_analysis.pipelines.unified_pipeline import _detect_best_pipeline_mode
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _detect_best_pipeline_mode,
+        )
+
         with pytest.raises(RuntimeError):
             _detect_best_pipeline_mode(enable_orchestration=False)
 
@@ -168,57 +193,114 @@ class TestMapAnalysisTypeToLegacyMode:
     """Tests for _map_analysis_type_to_legacy_mode."""
 
     def _call(self, val):
-        from argumentation_analysis.pipelines.unified_pipeline import _map_analysis_type_to_legacy_mode
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _map_analysis_type_to_legacy_mode,
+        )
+
         return _map_analysis_type_to_legacy_mode(val)
 
-    def test_comprehensive(self): assert self._call("comprehensive") == "unified"
-    def test_rhetorical(self): assert self._call("rhetorical") == "informal"
-    def test_logical(self): assert self._call("logical") == "formal"
-    def test_investigative(self): assert self._call("investigative") == "unified"
-    def test_fallacy_focused(self): assert self._call("fallacy_focused") == "informal"
-    def test_argument_structure(self): assert self._call("argument_structure") == "formal"
-    def test_debate_analysis(self): assert self._call("debate_analysis") == "unified"
-    def test_custom(self): assert self._call("custom") == "unified"
-    def test_unknown(self): assert self._call("xyz") == "unified"
+    def test_comprehensive(self):
+        assert self._call("comprehensive") == "unified"
+
+    def test_rhetorical(self):
+        assert self._call("rhetorical") == "informal"
+
+    def test_logical(self):
+        assert self._call("logical") == "formal"
+
+    def test_investigative(self):
+        assert self._call("investigative") == "unified"
+
+    def test_fallacy_focused(self):
+        assert self._call("fallacy_focused") == "informal"
+
+    def test_argument_structure(self):
+        assert self._call("argument_structure") == "formal"
+
+    def test_debate_analysis(self):
+        assert self._call("debate_analysis") == "unified"
+
+    def test_custom(self):
+        assert self._call("custom") == "unified"
+
+    def test_unknown(self):
+        assert self._call("xyz") == "unified"
 
 
 class TestGenerateUnifiedRecommendations:
     """Tests for _generate_unified_recommendations."""
 
     def _call(self, results):
-        from argumentation_analysis.pipelines.unified_pipeline import _generate_unified_recommendations
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _generate_unified_recommendations,
+        )
+
         return _generate_unified_recommendations(results)
 
     def test_orchestration_with_specialized(self):
-        recs = self._call({"metadata": {"pipeline_mode": "orchestration"}, "specialized_orchestration": {"orchestrator_used": "CluedoOrchestrator"}, "execution_time": 5})
+        recs = self._call(
+            {
+                "metadata": {"pipeline_mode": "orchestration"},
+                "specialized_orchestration": {
+                    "orchestrator_used": "CluedoOrchestrator"
+                },
+                "execution_time": 5,
+            }
+        )
         assert any("CluedoOrchestrator" in r for r in recs)
 
     def test_orchestration_with_strategic(self):
-        recs = self._call({"metadata": {"pipeline_mode": "orchestration"}, "strategic_analysis": {}, "execution_time": 5})
+        recs = self._call(
+            {
+                "metadata": {"pipeline_mode": "orchestration"},
+                "strategic_analysis": {},
+                "execution_time": 5,
+            }
+        )
         assert any("hiérarchique" in r.lower() for r in recs)
 
     def test_hybrid_mode(self):
-        recs = self._call({"metadata": {"pipeline_mode": "hybrid"}, "execution_time": 5})
+        recs = self._call(
+            {"metadata": {"pipeline_mode": "hybrid"}, "execution_time": 5}
+        )
         assert any("hybride" in r.lower() for r in recs)
 
     def test_high_exec_time(self):
-        recs = self._call({"metadata": {"pipeline_mode": "original"}, "execution_time": 15})
+        recs = self._call(
+            {"metadata": {"pipeline_mode": "original"}, "execution_time": 15}
+        )
         assert any("élevé" in r.lower() for r in recs)
 
     def test_fast_exec_time(self):
-        recs = self._call({"metadata": {"pipeline_mode": "original"}, "execution_time": 0.5})
+        recs = self._call(
+            {"metadata": {"pipeline_mode": "original"}, "execution_time": 0.5}
+        )
         assert any("rapide" in r.lower() for r in recs)
 
     def test_error_status(self):
-        recs = self._call({"metadata": {"pipeline_mode": "original"}, "status": "error", "execution_time": 5})
+        recs = self._call(
+            {
+                "metadata": {"pipeline_mode": "original"},
+                "status": "error",
+                "execution_time": 5,
+            }
+        )
         assert any("erreur" in r.lower() for r in recs)
 
     def test_fallback_used(self):
-        recs = self._call({"metadata": {"pipeline_mode": "original"}, "fallback_used": True, "execution_time": 5})
+        recs = self._call(
+            {
+                "metadata": {"pipeline_mode": "original"},
+                "fallback_used": True,
+                "execution_time": 5,
+            }
+        )
         assert any("fallback" in r.lower() for r in recs)
 
     def test_default(self):
-        recs = self._call({"metadata": {"pipeline_mode": "original"}, "execution_time": 5})
+        recs = self._call(
+            {"metadata": {"pipeline_mode": "original"}, "execution_time": 5}
+        )
         assert any("succès" in r.lower() for r in recs)
 
 
@@ -226,14 +308,29 @@ class TestSynthesizeHybridResults:
     """Tests for _synthesize_hybrid_results."""
 
     def _call(self, results):
-        from argumentation_analysis.pipelines.unified_pipeline import _synthesize_hybrid_results
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _synthesize_hybrid_results,
+        )
+
         return _synthesize_hybrid_results(results)
 
     def test_merges_without_duplicates(self):
-        r = self._call({"pipeline_results": {
-            "orchestration": {"informal_analysis": {"fallacies": [{"type": "A"}, {"type": "B"}]}},
-            "original": {"informal_analysis": {"fallacies": [{"type": "B"}, {"type": "C"}]}},
-        }})
+        r = self._call(
+            {
+                "pipeline_results": {
+                    "orchestration": {
+                        "informal_analysis": {
+                            "fallacies": [{"type": "A"}, {"type": "B"}]
+                        }
+                    },
+                    "original": {
+                        "informal_analysis": {
+                            "fallacies": [{"type": "B"}, {"type": "C"}]
+                        }
+                    },
+                }
+            }
+        )
         types = [f["type"] for f in r["informal_analysis"]["fallacies"]]
         assert sorted(types) == ["A", "B", "C"]
 
@@ -246,10 +343,16 @@ class TestSynthesizeHybridResults:
         assert "pipeline_results" in r
 
     def test_summary_counts(self):
-        r = self._call({"pipeline_results": {
-            "orchestration": {"informal_analysis": {"fallacies": [{"type": "X"}]}},
-            "original": {"informal_analysis": {"fallacies": [{"type": "Y"}]}},
-        }})
+        r = self._call(
+            {
+                "pipeline_results": {
+                    "orchestration": {
+                        "informal_analysis": {"fallacies": [{"type": "X"}]}
+                    },
+                    "original": {"informal_analysis": {"fallacies": [{"type": "Y"}]}},
+                }
+            }
+        )
         s = r["informal_analysis"]["summary"]
         assert s["total_fallacies"] == 2
         assert s["source"] == "hybrid_synthesis"
@@ -262,6 +365,7 @@ class TestAnalyzeText:
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", False)
     async def test_empty_text_raises(self):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
+
         with pytest.raises(ValueError, match="Texte vide"):
             await analyze_text("", mode="original")
 
@@ -269,6 +373,7 @@ class TestAnalyzeText:
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", False)
     async def test_whitespace_text_raises(self):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
+
         with pytest.raises(ValueError):
             await analyze_text("   ", mode="original")
 
@@ -278,7 +383,15 @@ class TestAnalyzeText:
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_orchestration_mode(self, mock_run, mock_recs):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
-        mock_run.return_value = {"metadata": {"pipeline_mode": "orchestration"}, "pipeline_results": {}, "comparison": {}, "recommendations": [], "execution_time": 0, "status": "in_progress"}
+
+        mock_run.return_value = {
+            "metadata": {"pipeline_mode": "orchestration"},
+            "pipeline_results": {},
+            "comparison": {},
+            "recommendations": [],
+            "execution_time": 0,
+            "status": "in_progress",
+        }
         r = await analyze_text("Text", mode="orchestration")
         mock_run.assert_called_once()
 
@@ -288,7 +401,15 @@ class TestAnalyzeText:
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_original_mode(self, mock_run, mock_recs):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
-        mock_run.return_value = {"metadata": {"pipeline_mode": "original"}, "pipeline_results": {}, "comparison": {}, "recommendations": [], "execution_time": 0, "status": "in_progress"}
+
+        mock_run.return_value = {
+            "metadata": {"pipeline_mode": "original"},
+            "pipeline_results": {},
+            "comparison": {},
+            "recommendations": [],
+            "execution_time": 0,
+            "status": "in_progress",
+        }
         await analyze_text("Text", mode="original")
         mock_run.assert_called_once()
 
@@ -298,7 +419,15 @@ class TestAnalyzeText:
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_hybrid_mode(self, mock_run, mock_recs):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
-        mock_run.return_value = {"metadata": {"pipeline_mode": "hybrid"}, "pipeline_results": {}, "comparison": {}, "recommendations": [], "execution_time": 0, "status": "in_progress"}
+
+        mock_run.return_value = {
+            "metadata": {"pipeline_mode": "hybrid"},
+            "pipeline_results": {},
+            "comparison": {},
+            "recommendations": [],
+            "execution_time": 0,
+            "status": "in_progress",
+        }
         await analyze_text("Text", mode="hybrid")
         mock_run.assert_called_once()
 
@@ -309,7 +438,15 @@ class TestAnalyzeText:
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_auto_mode(self, mock_detect, mock_run, mock_recs):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
-        mock_run.return_value = {"metadata": {"pipeline_mode": "orchestration"}, "pipeline_results": {}, "comparison": {}, "recommendations": [], "execution_time": 0, "status": "in_progress"}
+
+        mock_run.return_value = {
+            "metadata": {"pipeline_mode": "orchestration"},
+            "pipeline_results": {},
+            "comparison": {},
+            "recommendations": [],
+            "execution_time": 0,
+            "status": "in_progress",
+        }
         await analyze_text("Text", mode="auto")
         mock_detect.assert_called_once()
 
@@ -319,7 +456,15 @@ class TestAnalyzeText:
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_unknown_mode_orchestration_fallback(self, mock_run, mock_recs):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
-        mock_run.return_value = {"metadata": {"pipeline_mode": "x"}, "pipeline_results": {}, "comparison": {}, "recommendations": [], "execution_time": 0, "status": "in_progress"}
+
+        mock_run.return_value = {
+            "metadata": {"pipeline_mode": "x"},
+            "pipeline_results": {},
+            "comparison": {},
+            "recommendations": [],
+            "execution_time": 0,
+            "status": "in_progress",
+        }
         await analyze_text("Text", mode="unknown_mode")
         mock_run.assert_called_once()
 
@@ -329,7 +474,15 @@ class TestAnalyzeText:
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_unknown_mode_original_fallback(self, mock_run, mock_recs):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
-        mock_run.return_value = {"metadata": {"pipeline_mode": "x"}, "pipeline_results": {}, "comparison": {}, "recommendations": [], "execution_time": 0, "status": "in_progress"}
+
+        mock_run.return_value = {
+            "metadata": {"pipeline_mode": "x"},
+            "pipeline_results": {},
+            "comparison": {},
+            "recommendations": [],
+            "execution_time": 0,
+            "status": "in_progress",
+        }
         await analyze_text("Text", mode="unknown_mode")
         mock_run.assert_called_once()
 
@@ -337,37 +490,67 @@ class TestAnalyzeText:
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", False)
     async def test_unknown_mode_no_pipeline_error(self):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
+
         r = await analyze_text("Text", mode="unknown_mode")
         assert r["status"] == "error"
 
     @patch(f"{MODULE}._generate_unified_recommendations", return_value=["OK"])
     @patch(f"{MODULE}._run_original_pipeline", new_callable=AsyncMock)
-    @patch(f"{MODULE}._run_orchestration_pipeline", new_callable=AsyncMock, side_effect=RuntimeError("Boom"))
+    @patch(
+        f"{MODULE}._run_orchestration_pipeline",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("Boom"),
+    )
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_fallback_on_error(self, mock_orch, mock_orig, mock_recs):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
-        mock_orig.return_value = {"metadata": {"pipeline_mode": "original"}, "pipeline_results": {"original": {"data": 1}}, "comparison": {}, "recommendations": [], "execution_time": 0, "status": "in_progress"}
+
+        mock_orig.return_value = {
+            "metadata": {"pipeline_mode": "original"},
+            "pipeline_results": {"original": {"data": 1}},
+            "comparison": {},
+            "recommendations": [],
+            "execution_time": 0,
+            "status": "in_progress",
+        }
         r = await analyze_text("Text", mode="orchestration")
         assert r["status"] == "partial_success"
         assert r.get("fallback_used") is True
 
-    @patch(f"{MODULE}._run_orchestration_pipeline", new_callable=AsyncMock, side_effect=RuntimeError("Boom"))
+    @patch(
+        f"{MODULE}._run_orchestration_pipeline",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("Boom"),
+    )
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", False)
     async def test_no_fallback_when_unavailable(self, mock_orch):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
+
         r = await analyze_text("Text", mode="orchestration")
         assert r["status"] == "error"
 
     @patch(f"{MODULE}._generate_unified_recommendations", return_value=["OK"])
-    @patch(f"{MODULE}._compare_pipelines", new_callable=AsyncMock, return_value={"approaches_tested": []})
+    @patch(
+        f"{MODULE}._compare_pipelines",
+        new_callable=AsyncMock,
+        return_value={"approaches_tested": []},
+    )
     @patch(f"{MODULE}._run_orchestration_pipeline", new_callable=AsyncMock)
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_comparison_called(self, mock_run, mock_compare, mock_recs):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
-        mock_run.return_value = {"metadata": {"pipeline_mode": "orchestration"}, "pipeline_results": {}, "comparison": {}, "recommendations": [], "execution_time": 0, "status": "in_progress"}
+
+        mock_run.return_value = {
+            "metadata": {"pipeline_mode": "orchestration"},
+            "pipeline_results": {},
+            "comparison": {},
+            "recommendations": [],
+            "execution_time": 0,
+            "status": "in_progress",
+        }
         await analyze_text("Text", mode="orchestration", enable_comparison=True)
         mock_compare.assert_called_once()
 
@@ -377,7 +560,15 @@ class TestAnalyzeText:
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_success_status(self, mock_run, mock_recs):
         from argumentation_analysis.pipelines.unified_pipeline import analyze_text
-        mock_run.return_value = {"metadata": {"pipeline_mode": "orchestration"}, "pipeline_results": {}, "comparison": {}, "recommendations": [], "execution_time": 0, "status": "in_progress"}
+
+        mock_run.return_value = {
+            "metadata": {"pipeline_mode": "orchestration"},
+            "pipeline_results": {},
+            "comparison": {},
+            "recommendations": [],
+            "execution_time": 0,
+            "status": "in_progress",
+        }
         r = await analyze_text("Hello", mode="orchestration")
         assert r["status"] == "success"
         assert r["execution_time"] >= 0
@@ -388,55 +579,113 @@ class TestRunOrchestrationPipeline:
 
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", False)
     async def test_raises_when_unavailable(self):
-        from argumentation_analysis.pipelines.unified_pipeline import _run_orchestration_pipeline
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _run_orchestration_pipeline,
+        )
+
         with pytest.raises(RuntimeError, match="non disponibles"):
             await _run_orchestration_pipeline("t", "c", "a", False, None, {})
 
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     async def test_selects_cluedo_for_mode(self):
         import argumentation_analysis.pipelines.unified_pipeline as mod
-        mi = MagicMock(); mi.__class__.__name__ = "CluedoOrchestrator"
+
+        mi = MagicMock()
+        mi.__class__.__name__ = "CluedoOrchestrator"
         mi.orchestrate_investigation_analysis = AsyncMock(return_value={"r": 1})
-        with patch.object(mod, "create_llm_service", return_value=MagicMock(), create=True), \
-             patch.object(mod, "CluedoOrchestrator", MagicMock(return_value=mi), create=True):
-            r = await mod._run_orchestration_pipeline("text", "c", "cluedo", False, None, {"pipeline_results": {}})
+        with patch.object(
+            mod, "create_llm_service", return_value=MagicMock(), create=True
+        ), patch.object(
+            mod, "CluedoOrchestrator", MagicMock(return_value=mi), create=True
+        ):
+            r = await mod._run_orchestration_pipeline(
+                "text", "c", "cluedo", False, None, {"pipeline_results": {}}
+            )
             assert "orchestration" in r["pipeline_results"]
 
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     async def test_selects_cluedo_for_keyword(self):
         import argumentation_analysis.pipelines.unified_pipeline as mod
-        mi = MagicMock(); mi.__class__.__name__ = "CluedoOrchestrator"
+
+        mi = MagicMock()
+        mi.__class__.__name__ = "CluedoOrchestrator"
         mi.orchestrate_investigation_analysis = AsyncMock(return_value={"r": 1})
-        with patch.object(mod, "create_llm_service", return_value=MagicMock(), create=True), \
-             patch.object(mod, "CluedoOrchestrator", MagicMock(return_value=mi), create=True):
-            await mod._run_orchestration_pipeline("Le témoin de l'enquête", "c", "auto_select", False, None, {"pipeline_results": {}})
+        with patch.object(
+            mod, "create_llm_service", return_value=MagicMock(), create=True
+        ), patch.object(
+            mod, "CluedoOrchestrator", MagicMock(return_value=mi), create=True
+        ):
+            await mod._run_orchestration_pipeline(
+                "Le témoin de l'enquête",
+                "c",
+                "auto_select",
+                False,
+                None,
+                {"pipeline_results": {}},
+            )
 
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     async def test_selects_conversation_for_colon(self):
         import argumentation_analysis.pipelines.unified_pipeline as mod
-        mi = MagicMock(); mi.__class__.__name__ = "ConversationOrchestrator"
+
+        mi = MagicMock()
+        mi.__class__.__name__ = "ConversationOrchestrator"
         mi.orchestrate_dialogue_analysis = AsyncMock(return_value={"r": 1})
-        with patch.object(mod, "create_llm_service", return_value=MagicMock(), create=True), \
-             patch.object(mod, "ConversationOrchestrator", MagicMock(return_value=mi), create=True):
-            await mod._run_orchestration_pipeline("Speaker: Hello", "c", "auto_select", False, None, {"pipeline_results": {}})
+        with patch.object(
+            mod, "create_llm_service", return_value=MagicMock(), create=True
+        ), patch.object(
+            mod, "ConversationOrchestrator", MagicMock(return_value=mi), create=True
+        ):
+            await mod._run_orchestration_pipeline(
+                "Speaker: Hello",
+                "c",
+                "auto_select",
+                False,
+                None,
+                {"pipeline_results": {}},
+            )
 
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     async def test_selects_logique_for_keyword(self):
         import argumentation_analysis.pipelines.unified_pipeline as mod
-        mi = MagicMock(); mi.__class__.__name__ = "LogiqueComplexeOrchestrator"
+
+        mi = MagicMock()
+        mi.__class__.__name__ = "LogiqueComplexeOrchestrator"
         mi.orchestrate_complex_logical_analysis = AsyncMock(return_value={"r": 1})
-        with patch.object(mod, "create_llm_service", return_value=MagicMock(), create=True), \
-             patch.object(mod, "LogiqueComplexeOrchestrator", MagicMock(return_value=mi), create=True):
-            await mod._run_orchestration_pipeline("tous les hommes sont mortels", "c", "auto_select", False, None, {"pipeline_results": {}})
+        with patch.object(
+            mod, "create_llm_service", return_value=MagicMock(), create=True
+        ), patch.object(
+            mod, "LogiqueComplexeOrchestrator", MagicMock(return_value=mi), create=True
+        ):
+            await mod._run_orchestration_pipeline(
+                "tous les hommes sont mortels",
+                "c",
+                "auto_select",
+                False,
+                None,
+                {"pipeline_results": {}},
+            )
 
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     async def test_selects_real_llm_fallback(self):
         import argumentation_analysis.pipelines.unified_pipeline as mod
-        mi = MagicMock(); mi.__class__.__name__ = "RealLLMOrchestrator"
+
+        mi = MagicMock()
+        mi.__class__.__name__ = "RealLLMOrchestrator"
         mi.orchestrate_multi_llm_analysis = AsyncMock(return_value={"r": 1})
-        with patch.object(mod, "create_llm_service", return_value=MagicMock(), create=True), \
-             patch.object(mod, "RealLLMOrchestrator", MagicMock(return_value=mi), create=True):
-            r = await mod._run_orchestration_pipeline("Generic text", "c", "auto_select", False, None, {"pipeline_results": {}})
+        with patch.object(
+            mod, "create_llm_service", return_value=MagicMock(), create=True
+        ), patch.object(
+            mod, "RealLLMOrchestrator", MagicMock(return_value=mi), create=True
+        ):
+            r = await mod._run_orchestration_pipeline(
+                "Generic text",
+                "c",
+                "auto_select",
+                False,
+                None,
+                {"pipeline_results": {}},
+            )
             assert "specialized_orchestration" in r
 
 
@@ -445,53 +694,101 @@ class TestRunOriginalPipeline:
 
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", False)
     async def test_raises_when_unavailable(self):
-        from argumentation_analysis.pipelines.unified_pipeline import _run_original_pipeline
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _run_original_pipeline,
+        )
+
         with pytest.raises(RuntimeError, match="non disponible"):
             await _run_original_pipeline("t", "c", False, None, {})
 
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_calls_pipeline(self):
         import argumentation_analysis.pipelines.unified_pipeline as mod
-        mock_run = AsyncMock(return_value={"informal_analysis": {"f": []}, "formal_analysis": {}})
-        with patch.object(mod, "create_unified_config_from_legacy", return_value=MagicMock(), create=True), \
-             patch.object(mod, "run_unified_text_analysis_pipeline", mock_run, create=True):
-            r = await mod._run_original_pipeline("t", "comprehensive", False, None, {"pipeline_results": {}})
+
+        mock_run = AsyncMock(
+            return_value={"informal_analysis": {"f": []}, "formal_analysis": {}}
+        )
+        with patch.object(
+            mod,
+            "create_unified_config_from_legacy",
+            return_value=MagicMock(),
+            create=True,
+        ), patch.object(
+            mod, "run_unified_text_analysis_pipeline", mock_run, create=True
+        ):
+            r = await mod._run_original_pipeline(
+                "t", "comprehensive", False, None, {"pipeline_results": {}}
+            )
             assert "original" in r["pipeline_results"]
 
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_copies_fields(self):
         import argumentation_analysis.pipelines.unified_pipeline as mod
-        mock_run = AsyncMock(return_value={"informal_analysis": {"d": 1}, "formal_analysis": {"l": 1}, "unified_analysis": {"s": 1}})
-        with patch.object(mod, "create_unified_config_from_legacy", return_value=MagicMock(), create=True), \
-             patch.object(mod, "run_unified_text_analysis_pipeline", mock_run, create=True):
-            r = await mod._run_original_pipeline("t", "c", False, None, {"pipeline_results": {}})
+
+        mock_run = AsyncMock(
+            return_value={
+                "informal_analysis": {"d": 1},
+                "formal_analysis": {"l": 1},
+                "unified_analysis": {"s": 1},
+            }
+        )
+        with patch.object(
+            mod,
+            "create_unified_config_from_legacy",
+            return_value=MagicMock(),
+            create=True,
+        ), patch.object(
+            mod, "run_unified_text_analysis_pipeline", mock_run, create=True
+        ):
+            r = await mod._run_original_pipeline(
+                "t", "c", False, None, {"pipeline_results": {}}
+            )
             assert r["informal_analysis"] == {"d": 1}
 
 
 class TestRunHybridPipeline:
     @patch(f"{MODULE}._synthesize_hybrid_results", side_effect=lambda r: r)
-    @patch(f"{MODULE}._run_original_pipeline", new_callable=AsyncMock, return_value={"pipeline_results": {}})
-    @patch(f"{MODULE}._run_orchestration_pipeline", new_callable=AsyncMock, return_value={"pipeline_results": {}})
+    @patch(
+        f"{MODULE}._run_original_pipeline",
+        new_callable=AsyncMock,
+        return_value={"pipeline_results": {}},
+    )
+    @patch(
+        f"{MODULE}._run_orchestration_pipeline",
+        new_callable=AsyncMock,
+        return_value={"pipeline_results": {}},
+    )
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     async def test_runs_both(self, mock_o, mock_p, mock_s):
-        from argumentation_analysis.pipelines.unified_pipeline import _run_hybrid_pipeline
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _run_hybrid_pipeline,
+        )
+
         await _run_hybrid_pipeline("t", "c", "a", False, None, {"pipeline_results": {}})
         mock_o.assert_called_once()
         mock_p.assert_called_once()
 
     @patch(f"{MODULE}._synthesize_hybrid_results", side_effect=lambda r: r)
-    @patch(f"{MODULE}._run_orchestration_pipeline", new_callable=AsyncMock, side_effect=RuntimeError("F"))
+    @patch(
+        f"{MODULE}._run_orchestration_pipeline",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("F"),
+    )
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", False)
     async def test_tolerates_failure(self, mock_o, mock_s):
-        from argumentation_analysis.pipelines.unified_pipeline import _run_hybrid_pipeline
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            _run_hybrid_pipeline,
+        )
+
         await _run_hybrid_pipeline("t", "c", "a", False, None, {"pipeline_results": {}})
 
 
 class TestComparePipelines:
     async def test_returns_structure(self):
         from argumentation_analysis.pipelines.unified_pipeline import _compare_pipelines
+
         r = await _compare_pipelines("t", "c", False)
         assert "comparison_timestamp" in r
         assert "approaches_tested" in r
@@ -501,36 +798,61 @@ class TestGetAvailableFeatures:
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     def test_all_available(self):
-        from argumentation_analysis.pipelines.unified_pipeline import get_available_features
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            get_available_features,
+        )
+
         f = get_available_features()
-        assert f["original_pipeline"] is True and f["orchestration_pipeline"] is True and f["hybrid_mode"] is True
+        assert (
+            f["original_pipeline"] is True
+            and f["orchestration_pipeline"] is True
+            and f["hybrid_mode"] is True
+        )
 
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", False)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", False)
     def test_none_available(self):
-        from argumentation_analysis.pipelines.unified_pipeline import get_available_features
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            get_available_features,
+        )
+
         f = get_available_features()
         assert f["original_pipeline"] is False and f["hybrid_mode"] is False
 
 
 class TestCompatibilityFunctions:
-    @patch(f"{MODULE}.analyze_text", new_callable=AsyncMock, return_value={"status": "ok"})
+    @patch(
+        f"{MODULE}.analyze_text", new_callable=AsyncMock, return_value={"status": "ok"}
+    )
     async def test_run_analysis(self, mock_at):
         from argumentation_analysis.pipelines.unified_pipeline import run_analysis
+
         r = await run_analysis("Hello")
         mock_at.assert_called_once_with("Hello")
 
-    @patch(f"{MODULE}.analyze_text", new_callable=AsyncMock, return_value={"status": "ok"})
+    @patch(
+        f"{MODULE}.analyze_text", new_callable=AsyncMock, return_value={"status": "ok"}
+    )
     async def test_enhanced_hierarchical(self, mock_at):
-        from argumentation_analysis.pipelines.unified_pipeline import run_enhanced_analysis
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            run_enhanced_analysis,
+        )
+
         await run_enhanced_analysis("Hello", enable_hierarchical=True)
         _, kw = mock_at.call_args
         assert kw.get("mode") == "orchestration"
 
-    @patch(f"{MODULE}.analyze_text", new_callable=AsyncMock, return_value={"status": "ok"})
+    @patch(
+        f"{MODULE}.analyze_text", new_callable=AsyncMock, return_value={"status": "ok"}
+    )
     async def test_enhanced_no_flags(self, mock_at):
-        from argumentation_analysis.pipelines.unified_pipeline import run_enhanced_analysis
-        await run_enhanced_analysis("Hello", enable_hierarchical=False, enable_specialized=False)
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            run_enhanced_analysis,
+        )
+
+        await run_enhanced_analysis(
+            "Hello", enable_hierarchical=False, enable_specialized=False
+        )
         _, kw = mock_at.call_args
         assert kw.get("mode") == "original"
 
@@ -539,6 +861,7 @@ class TestMigrationMessage:
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     def test_sets_flag(self):
         import argumentation_analysis.pipelines.unified_pipeline as mod
+
         mod._MIGRATION_MESSAGE_SHOWN = False
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
@@ -548,6 +871,7 @@ class TestMigrationMessage:
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     def test_no_double_warn(self):
         import argumentation_analysis.pipelines.unified_pipeline as mod
+
         mod._MIGRATION_MESSAGE_SHOWN = True
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
@@ -557,6 +881,7 @@ class TestMigrationMessage:
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", False)
     def test_no_warn_when_unavailable(self):
         import argumentation_analysis.pipelines.unified_pipeline as mod
+
         mod._MIGRATION_MESSAGE_SHOWN = False
         mod._show_migration_message()
         assert mod._MIGRATION_MESSAGE_SHOWN is False
@@ -566,7 +891,10 @@ class TestPrintFeatureStatus:
     @patch(f"{MODULE}.ORCHESTRATION_PIPELINE_AVAILABLE", True)
     @patch(f"{MODULE}.ORIGINAL_PIPELINE_AVAILABLE", True)
     def test_does_not_crash(self):
-        from argumentation_analysis.pipelines.unified_pipeline import print_feature_status
+        from argumentation_analysis.pipelines.unified_pipeline import (
+            print_feature_status,
+        )
+
         print_feature_status()
 
 
@@ -574,7 +902,11 @@ class TestPrintFeatureStatus:
 # SECTION 2: unified_text_analysis.py tests
 # ============================================================================
 
-@pytest.mark.skipif(not UTA_AVAILABLE, reason="unified_text_analysis import failed (missing get_fallacy_detector)")
+
+@pytest.mark.skipif(
+    not UTA_AVAILABLE,
+    reason="unified_text_analysis import failed (missing get_fallacy_detector)",
+)
 class TestUnifiedAnalysisConfig:
     def test_default(self):
         c = UnifiedAnalysisConfig()
@@ -600,16 +932,25 @@ class TestUnifiedAnalysisConfig:
 
     def test_conversation_logging(self):
         assert UnifiedAnalysisConfig().enable_conversation_logging is True
-        assert UnifiedAnalysisConfig(enable_conversation_logging=False).enable_conversation_logging is False
+        assert (
+            UnifiedAnalysisConfig(
+                enable_conversation_logging=False
+            ).enable_conversation_logging
+            is False
+        )
 
 
 @pytest.mark.skipif(not UTA_AVAILABLE, reason="unified_text_analysis import failed")
 class TestCreateConfigFromLegacy:
     def test_formal(self):
-        assert create_unified_config_from_legacy(mode="formal").analysis_modes == ["formal"]
+        assert create_unified_config_from_legacy(mode="formal").analysis_modes == [
+            "formal"
+        ]
 
     def test_informal(self):
-        assert create_unified_config_from_legacy(mode="informal").analysis_modes == ["informal"]
+        assert create_unified_config_from_legacy(mode="informal").analysis_modes == [
+            "informal"
+        ]
 
     def test_unified(self):
         c = create_unified_config_from_legacy(mode="unified")
@@ -619,10 +960,14 @@ class TestCreateConfigFromLegacy:
         assert len(create_unified_config_from_legacy(mode="all").analysis_modes) == 3
 
     def test_unknown(self):
-        assert create_unified_config_from_legacy(mode="xyz").analysis_modes == ["informal"]
+        assert create_unified_config_from_legacy(mode="xyz").analysis_modes == [
+            "informal"
+        ]
 
     def test_kwargs(self):
-        c = create_unified_config_from_legacy(mode="formal", use_mocks=True, logic_type="modal")
+        c = create_unified_config_from_legacy(
+            mode="formal", use_mocks=True, logic_type="modal"
+        )
         assert c.use_mocks is True and c.logic_type == "modal"
 
 
@@ -637,70 +982,136 @@ class TestUnifiedTextAnalysisPipeline:
 
     def test_severity_distribution(self):
         p = self._make()
-        d = p._calculate_severity_distribution([{"severity": "Faible"}, {"severity": "Moyen"}, {"severity": "Moyen"}, {"severity": "Critique"}, {"severity": "X"}])
-        assert d["Faible"] == 1 and d["Moyen"] == 2 and d["Critique"] == 1 and d["Élevé"] == 0
+        d = p._calculate_severity_distribution(
+            [
+                {"severity": "Faible"},
+                {"severity": "Moyen"},
+                {"severity": "Moyen"},
+                {"severity": "Critique"},
+                {"severity": "X"},
+            ]
+        )
+        assert (
+            d["Faible"] == 1
+            and d["Moyen"] == 2
+            and d["Critique"] == 1
+            and d["Élevé"] == 0
+        )
 
     def test_severity_empty(self):
-        assert all(v == 0 for v in self._make()._calculate_severity_distribution([]).values())
+        assert all(
+            v == 0 for v in self._make()._calculate_severity_distribution([]).values()
+        )
 
     def test_recs_many_fallacies(self):
-        r = self._make()._generate_recommendations({"informal_analysis": {"fallacies": [{"severity": "M"}]*5}, "formal_analysis": {}, "orchestration_analysis": {}})
+        r = self._make()._generate_recommendations(
+            {
+                "informal_analysis": {"fallacies": [{"severity": "M"}] * 5},
+                "formal_analysis": {},
+                "orchestration_analysis": {},
+            }
+        )
         assert any("révision" in x.lower() for x in r)
 
     def test_recs_critical(self):
-        r = self._make()._generate_recommendations({"informal_analysis": {"fallacies": [{"severity": "Critique"}]}, "formal_analysis": {}, "orchestration_analysis": {}})
+        r = self._make()._generate_recommendations(
+            {
+                "informal_analysis": {"fallacies": [{"severity": "Critique"}]},
+                "formal_analysis": {},
+                "orchestration_analysis": {},
+            }
+        )
         assert any("critique" in x.lower() for x in r)
 
     def test_recs_inconsistency(self):
-        r = self._make()._generate_recommendations({"informal_analysis": {"fallacies": []}, "formal_analysis": {"consistency_check": False}, "orchestration_analysis": {}})
+        r = self._make()._generate_recommendations(
+            {
+                "informal_analysis": {"fallacies": []},
+                "formal_analysis": {"consistency_check": False},
+                "orchestration_analysis": {},
+            }
+        )
         assert any("incohérence" in x.lower() for x in r)
 
     def test_recs_orch_success(self):
-        r = self._make()._generate_recommendations({"informal_analysis": {"fallacies": []}, "formal_analysis": {}, "orchestration_analysis": {"status": "success"}})
+        r = self._make()._generate_recommendations(
+            {
+                "informal_analysis": {"fallacies": []},
+                "formal_analysis": {},
+                "orchestration_analysis": {"status": "success"},
+            }
+        )
         assert any("orchestrée" in x.lower() for x in r)
 
     def test_recs_default(self):
-        r = self._make()._generate_recommendations({"informal_analysis": {"fallacies": []}, "formal_analysis": {}, "orchestration_analysis": {}})
+        r = self._make()._generate_recommendations(
+            {
+                "informal_analysis": {"fallacies": []},
+                "formal_analysis": {},
+                "orchestration_analysis": {},
+            }
+        )
         assert len(r) >= 1
 
     def test_conv_log_none(self):
-        p = self._make(); p.conversation_logger = None
+        p = self._make()
+        p.conversation_logger = None
         assert p.get_conversation_log() == {}
 
     def test_conv_log_present(self):
         p = self._make()
-        p.conversation_logger = MagicMock(messages=[{"m": 1}], tool_calls=[], state_snapshots=[])
+        p.conversation_logger = MagicMock(
+            messages=[{"m": 1}], tool_calls=[], state_snapshots=[]
+        )
         assert len(p.get_conversation_log()["messages"]) == 1
 
     async def test_informal_no_plugin(self):
-        p = self._make(); p.analysis_tools = {}
+        p = self._make()
+        p.analysis_tools = {}
         r = await p._perform_informal_analysis("t")
         assert "error" in str(r).lower()
 
     async def test_informal_with_plugin(self):
         p = self._make()
         mp = MagicMock()
-        mp.analyze_text.return_value = {"fallacy_analysis": {"fallacy_types_distribution": {"AH": 2}, "total_fallacies": 2, "overall_severity": 0.5, "severity_level": "M"}}
+        mp.analyze_text.return_value = {
+            "fallacy_analysis": {
+                "fallacy_types_distribution": {"AH": 2},
+                "total_fallacies": 2,
+                "overall_severity": 0.5,
+                "severity_level": "M",
+            }
+        }
         p.analysis_tools = {"analysis_plugin": mp}
         r = await p._perform_informal_analysis("t")
         assert "fallacies" in r
 
     async def test_formal_no_jvm(self):
-        p = self._make(); p.jvm_ready = False; p.llm_service = MagicMock()
+        p = self._make()
+        p.jvm_ready = False
+        p.llm_service = MagicMock()
         assert (await p._perform_formal_analysis("t"))["status"] == "Skipped"
 
     async def test_formal_no_llm(self):
-        p = self._make(); p.jvm_ready = True; p.llm_service = None
+        p = self._make()
+        p.jvm_ready = True
+        p.llm_service = None
         assert (await p._perform_formal_analysis("t"))["status"] == "Skipped"
 
     async def test_unified_no_agent(self):
-        p = self._make(); p.analysis_tools = {}
+        p = self._make()
+        p.analysis_tools = {}
         assert (await p._perform_unified_analysis("t"))["status"] == "Skipped"
 
     async def test_unified_with_agent(self):
         p = self._make()
         ma = AsyncMock()
-        mr = MagicMock(executive_summary="S", recommendations=["r"], overall_validity=0.8, confidence_level=0.9)
+        mr = MagicMock(
+            executive_summary="S",
+            recommendations=["r"],
+            overall_validity=0.8,
+            confidence_level=0.9,
+        )
         ma.synthesize_analysis.return_value = mr
         p.analysis_tools = {"synthesis_agent": ma}
         r = await p._perform_unified_analysis("t")
@@ -708,59 +1119,79 @@ class TestUnifiedTextAnalysisPipeline:
 
     async def test_unified_returns_none(self):
         p = self._make()
-        ma = AsyncMock(); ma.synthesize_analysis.return_value = None
+        ma = AsyncMock()
+        ma.synthesize_analysis.return_value = None
         p.analysis_tools = {"synthesis_agent": ma}
         assert (await p._perform_unified_analysis("t"))["status"] == "Failed"
 
     async def test_unified_raises(self):
         p = self._make()
-        ma = AsyncMock(); ma.synthesize_analysis.side_effect = RuntimeError("E")
+        ma = AsyncMock()
+        ma.synthesize_analysis.side_effect = RuntimeError("E")
         p.analysis_tools = {"synthesis_agent": ma}
         assert (await p._perform_unified_analysis("t"))["status"] == "Error"
 
     async def test_orch_no_orchestrator(self):
-        p = self._make(); p.orchestrator = None
+        p = self._make()
+        p.orchestrator = None
         assert (await p._perform_orchestration_analysis("t"))["status"] == "Skipped"
 
     async def test_orch_comprehensive(self):
         p = self._make(orchestration_mode="real")
-        mo = AsyncMock(); mo.analyze_text_comprehensive = AsyncMock(return_value={"agents_used": ["a"], "conversation_summary": {}, "results": {}})
+        mo = AsyncMock()
+        mo.analyze_text_comprehensive = AsyncMock(
+            return_value={
+                "agents_used": ["a"],
+                "conversation_summary": {},
+                "results": {},
+            }
+        )
         p.orchestrator = mo
         assert (await p._perform_orchestration_analysis("t"))["status"] == "success"
 
     async def test_orch_conversation(self):
         p = self._make(orchestration_mode="conversation")
-        mo = MagicMock(spec=[]); mo.run_conversation = AsyncMock(return_value={})
+        mo = MagicMock(spec=[])
+        mo.run_conversation = AsyncMock(return_value={})
         p.orchestrator = mo
         assert (await p._perform_orchestration_analysis("t"))["status"] == "success"
 
     async def test_orch_unknown_method(self):
-        p = self._make(); p.orchestrator = MagicMock(spec=[])
+        p = self._make()
+        p.orchestrator = MagicMock(spec=[])
         assert (await p._perform_orchestration_analysis("t"))["status"] == "Failed"
 
     async def test_orch_error(self):
         p = self._make(orchestration_mode="real")
-        mo = AsyncMock(); mo.analyze_text_comprehensive = AsyncMock(side_effect=RuntimeError("E"))
+        mo = AsyncMock()
+        mo.analyze_text_comprehensive = AsyncMock(side_effect=RuntimeError("E"))
         p.orchestrator = mo
         assert (await p._perform_orchestration_analysis("t"))["status"] == "Error"
 
     async def test_analyze_unified_runs(self):
         p = self._make(analysis_modes=["informal"])
-        p.orchestrator = None; p.conversation_logger = None
-        p._perform_informal_analysis = AsyncMock(return_value={"status": "Success", "fallacies": [], "summary": {}})
+        p.orchestrator = None
+        p.conversation_logger = None
+        p._perform_informal_analysis = AsyncMock(
+            return_value={"status": "Success", "fallacies": [], "summary": {}}
+        )
         p._generate_recommendations = MagicMock(return_value=["r"])
         r = await p.analyze_text_unified("t")
         assert r["informal_analysis"]["status"] == "Success"
 
     async def test_analyze_unified_error(self):
         p = self._make(analysis_modes=["informal"])
-        p.orchestrator = None; p.conversation_logger = None
+        p.orchestrator = None
+        p.conversation_logger = None
         p._perform_informal_analysis = AsyncMock(side_effect=RuntimeError("F"))
         assert "error" in await p.analyze_text_unified("t")
 
     async def test_informal_orchestrated_no_orch(self):
-        p = self._make(); p.orchestrator = None
-        p._perform_informal_analysis = AsyncMock(return_value={"status": "S", "fallacies": [], "summary": {}})
+        p = self._make()
+        p.orchestrator = None
+        p._perform_informal_analysis = AsyncMock(
+            return_value={"status": "S", "fallacies": [], "summary": {}}
+        )
         await p._perform_informal_analysis_orchestrated("t")
         p._perform_informal_analysis.assert_called_once()
 
@@ -769,14 +1200,18 @@ class TestUnifiedTextAnalysisPipeline:
 class TestRunPipelineFunction:
     @patch(f"{UTA_MODULE}.UnifiedTextAnalysisPipeline")
     async def test_default_config(self, mock_cls):
-        mi = AsyncMock(); mi.initialize.return_value = True; mi.analyze_text_unified.return_value = {"d": 1}
+        mi = AsyncMock()
+        mi.initialize.return_value = True
+        mi.analyze_text_unified.return_value = {"d": 1}
         mock_cls.return_value = mi
         r = await run_unified_text_analysis_pipeline("t")
         assert r["status"] == "success"
 
     @patch(f"{UTA_MODULE}.UnifiedTextAnalysisPipeline")
     async def test_init_fail(self, mock_cls):
-        mi = AsyncMock(); mi.initialize.return_value = False; mock_cls.return_value = mi
+        mi = AsyncMock()
+        mi.initialize.return_value = False
+        mock_cls.return_value = mi
         assert (await run_unified_text_analysis_pipeline("t"))["status"] == "failed"
 
     @patch(f"{UTA_MODULE}.UnifiedTextAnalysisPipeline", side_effect=RuntimeError("E"))
@@ -791,58 +1226,104 @@ class TestRunPipelineFunction:
 # SECTION 3: orchestration/config/enums.py tests
 # ============================================================================
 
-@pytest.mark.skipif(not ORCH_CONFIG_AVAILABLE, reason="orchestration config import failed")
+
+@pytest.mark.skipif(
+    not ORCH_CONFIG_AVAILABLE, reason="orchestration config import failed"
+)
 class TestOrchestrationModeEnum:
-    def test_pipeline(self): assert OrchestrationMode.PIPELINE.value == "pipeline"
-    def test_real(self): assert OrchestrationMode.REAL.value == "real"
-    def test_auto(self): assert OrchestrationMode.AUTO_SELECT.value == "auto_select"
+    def test_pipeline(self):
+        assert OrchestrationMode.PIPELINE.value == "pipeline"
+
+    def test_real(self):
+        assert OrchestrationMode.REAL.value == "real"
+
+    def test_auto(self):
+        assert OrchestrationMode.AUTO_SELECT.value == "auto_select"
+
     def test_all_strings(self):
-        for m in OrchestrationMode: assert isinstance(m.value, str)
-    def test_count(self): assert len(OrchestrationMode) == 11
+        for m in OrchestrationMode:
+            assert isinstance(m.value, str)
+
+    def test_count(self):
+        assert len(OrchestrationMode) == 11
 
 
-@pytest.mark.skipif(not ORCH_CONFIG_AVAILABLE, reason="orchestration config import failed")
+@pytest.mark.skipif(
+    not ORCH_CONFIG_AVAILABLE, reason="orchestration config import failed"
+)
 class TestAnalysisTypeEnum:
-    def test_comprehensive(self): assert AnalysisType.COMPREHENSIVE.value == "comprehensive"
-    def test_custom(self): assert AnalysisType.CUSTOM.value == "custom"
+    def test_comprehensive(self):
+        assert AnalysisType.COMPREHENSIVE.value == "comprehensive"
+
+    def test_custom(self):
+        assert AnalysisType.CUSTOM.value == "custom"
+
     def test_all_strings(self):
-        for m in AnalysisType: assert isinstance(m.value, str)
-    def test_count(self): assert len(AnalysisType) == 8
+        for m in AnalysisType:
+            assert isinstance(m.value, str)
+
+    def test_count(self):
+        assert len(AnalysisType) == 8
 
 
 # ============================================================================
 # SECTION 4: orchestration/config/base_config.py tests
 # ============================================================================
 
-@pytest.mark.skipif(not ORCH_CONFIG_AVAILABLE, reason="orchestration config import failed")
+
+@pytest.mark.skipif(
+    not ORCH_CONFIG_AVAILABLE, reason="orchestration config import failed"
+)
 class TestExtendedOrchestrationConfig:
     def test_default(self):
         c = ExtendedOrchestrationConfig()
-        assert c.enable_hierarchical is True and c.max_concurrent_analyses == 10 and c.analysis_timeout == 300
+        assert (
+            c.enable_hierarchical is True
+            and c.max_concurrent_analyses == 10
+            and c.analysis_timeout == 300
+        )
 
     def test_inherits(self):
         assert isinstance(ExtendedOrchestrationConfig(), UnifiedAnalysisConfig)
 
     def test_custom(self):
-        c = ExtendedOrchestrationConfig(enable_hierarchical=False, max_concurrent_analyses=5, use_mocks=True)
-        assert c.enable_hierarchical is False and c.max_concurrent_analyses == 5 and c.use_mocks is True
+        c = ExtendedOrchestrationConfig(
+            enable_hierarchical=False, max_concurrent_analyses=5, use_mocks=True
+        )
+        assert (
+            c.enable_hierarchical is False
+            and c.max_concurrent_analyses == 5
+            and c.use_mocks is True
+        )
 
     def test_mode_from_string(self):
-        assert ExtendedOrchestrationConfig(orchestration_mode="real").orchestration_mode_enum == OrchestrationMode.REAL
+        assert (
+            ExtendedOrchestrationConfig(
+                orchestration_mode="real"
+            ).orchestration_mode_enum
+            == OrchestrationMode.REAL
+        )
 
     def test_mode_from_enum(self):
-        c = ExtendedOrchestrationConfig(orchestration_mode=OrchestrationMode.CONVERSATION)
+        c = ExtendedOrchestrationConfig(
+            orchestration_mode=OrchestrationMode.CONVERSATION
+        )
         assert c.orchestration_mode == "conversation"
 
     def test_analysis_type_from_string(self):
-        assert ExtendedOrchestrationConfig(analysis_type="rhetorical").analysis_type == AnalysisType.RHETORICAL
+        assert (
+            ExtendedOrchestrationConfig(analysis_type="rhetorical").analysis_type
+            == AnalysisType.RHETORICAL
+        )
 
     def test_default_priority(self):
         c = ExtendedOrchestrationConfig()
         assert len(c.specialized_orchestrator_priority) == 4
 
     def test_custom_priority(self):
-        assert ExtendedOrchestrationConfig(specialized_orchestrator_priority=["a"]).specialized_orchestrator_priority == ["a"]
+        assert ExtendedOrchestrationConfig(
+            specialized_orchestrator_priority=["a"]
+        ).specialized_orchestrator_priority == ["a"]
 
     def test_middleware_default(self):
         assert ExtendedOrchestrationConfig().middleware_config == {}
@@ -855,6 +1336,7 @@ class TestExtendedOrchestrationConfig:
 # SECTION 5: orchestration/core/communication.py tests
 # ============================================================================
 
+
 @pytest.mark.skipif(not COMM_AVAILABLE, reason="communication import failed")
 class TestInitializeCommunicationMiddleware:
     @patch(f"{COMM_MODULE}.MessageMiddleware", None)
@@ -863,13 +1345,16 @@ class TestInitializeCommunicationMiddleware:
 
     @patch(f"{COMM_MODULE}.MessageMiddleware")
     def test_from_service_manager(self, mock_cls):
-        sm = MagicMock(); sm.middleware = MagicMock()
+        sm = MagicMock()
+        sm.middleware = MagicMock()
         assert initialize_communication_middleware(service_manager=sm) is sm.middleware
 
     @patch(f"{COMM_MODULE}.MessageMiddleware")
     def test_creates_new(self, mock_cls):
         mock_cls.return_value = MagicMock()
-        assert initialize_communication_middleware(enable_communication=True) is not None
+        assert (
+            initialize_communication_middleware(enable_communication=True) is not None
+        )
         mock_cls.assert_called_once()
 
     @patch(f"{COMM_MODULE}.MessageMiddleware")
@@ -878,8 +1363,11 @@ class TestInitializeCommunicationMiddleware:
 
     @patch(f"{COMM_MODULE}.MessageMiddleware")
     def test_prefers_sm(self, mock_cls):
-        sm = MagicMock(); sm.middleware = MagicMock()
-        r = initialize_communication_middleware(service_manager=sm, enable_communication=True)
+        sm = MagicMock()
+        sm.middleware = MagicMock()
+        r = initialize_communication_middleware(
+            service_manager=sm, enable_communication=True
+        )
         assert r is sm.middleware
         mock_cls.assert_not_called()
 
@@ -888,32 +1376,61 @@ class TestInitializeCommunicationMiddleware:
 # SECTION 6: orchestration/analysis/post_processors.py tests
 # ============================================================================
 
+
 @pytest.mark.skipif(not ANALYSIS_AVAILABLE, reason="analysis import failed")
 class TestPostProcessResults:
     async def test_high_score(self):
-        p = MagicMock(); p.middleware = None
-        r = await post_process_orchestration_results(p, {"hierarchical_coordination": {"overall_score": 0.9}, "specialized_orchestration": {"results": {"status": "completed"}, "orchestrator_used": "T"}})
+        p = MagicMock()
+        p.middleware = None
+        r = await post_process_orchestration_results(
+            p,
+            {
+                "hierarchical_coordination": {"overall_score": 0.9},
+                "specialized_orchestration": {
+                    "results": {"status": "completed"},
+                    "orchestrator_used": "T",
+                },
+            },
+        )
         assert any("performante" in x.lower() for x in r["recommendations"])
 
     async def test_specialized(self):
-        p = MagicMock(); p.middleware = None
-        r = await post_process_orchestration_results(p, {"hierarchical_coordination": {"overall_score": 0.5}, "specialized_orchestration": {"results": {"status": "completed"}, "orchestrator_used": "TestO"}})
+        p = MagicMock()
+        p.middleware = None
+        r = await post_process_orchestration_results(
+            p,
+            {
+                "hierarchical_coordination": {"overall_score": 0.5},
+                "specialized_orchestration": {
+                    "results": {"status": "completed"},
+                    "orchestrator_used": "TestO",
+                },
+            },
+        )
         assert any("TestO" in x for x in r["recommendations"])
 
     async def test_default(self):
-        p = MagicMock(); p.middleware = None
-        r = await post_process_orchestration_results(p, {"hierarchical_coordination": {}, "specialized_orchestration": {}})
+        p = MagicMock()
+        p.middleware = None
+        r = await post_process_orchestration_results(
+            p, {"hierarchical_coordination": {}, "specialized_orchestration": {}}
+        )
         assert len(r["recommendations"]) >= 1
 
     async def test_comm_log(self):
-        p = MagicMock(); p.middleware = MagicMock(); p._get_communication_log.return_value = [{"m": 1}]
-        r = await post_process_orchestration_results(p, {"hierarchical_coordination": {}, "specialized_orchestration": {}})
+        p = MagicMock()
+        p.middleware = MagicMock()
+        p._get_communication_log.return_value = [{"m": 1}]
+        r = await post_process_orchestration_results(
+            p, {"hierarchical_coordination": {}, "specialized_orchestration": {}}
+        )
         assert "communication_log" in r
 
 
 # ============================================================================
 # SECTION 7: orchestration/analysis/processors.py tests
 # ============================================================================
+
 
 @pytest.mark.skipif(not ANALYSIS_AVAILABLE, reason="analysis import failed")
 class TestExecuteOperationalTasks:
@@ -941,11 +1458,25 @@ class TestExecuteOperationalTasks:
 @pytest.mark.skipif(not ANALYSIS_AVAILABLE, reason="analysis import failed")
 class TestSynthesizeHierarchical:
     async def test_high(self):
-        r = await synthesize_hierarchical_results(MagicMock(), {"strategic_analysis": {"objectives": list("abcd")}, "tactical_coordination": {"tasks_created": 10}, "operational_results": {"summary": {"success_rate": 1.0}}})
+        r = await synthesize_hierarchical_results(
+            MagicMock(),
+            {
+                "strategic_analysis": {"objectives": list("abcd")},
+                "tactical_coordination": {"tasks_created": 10},
+                "operational_results": {"summary": {"success_rate": 1.0}},
+            },
+        )
         assert r["coordination_effectiveness"] > 0.8
 
     async def test_low(self):
-        r = await synthesize_hierarchical_results(MagicMock(), {"strategic_analysis": {"objectives": []}, "tactical_coordination": {"tasks_created": 0}, "operational_results": {"summary": {"success_rate": 0.0}}})
+        r = await synthesize_hierarchical_results(
+            MagicMock(),
+            {
+                "strategic_analysis": {"objectives": []},
+                "tactical_coordination": {"tasks_created": 0},
+                "operational_results": {"summary": {"success_rate": 0.0}},
+            },
+        )
         assert r["coordination_effectiveness"] == 0.0
 
     async def test_empty(self):
@@ -957,20 +1488,30 @@ class TestSynthesizeHierarchical:
 # SECTION 8: orchestration/analysis/traces.py tests
 # ============================================================================
 
+
 @pytest.mark.skipif(not ANALYSIS_AVAILABLE, reason="analysis import failed")
 class TestTraceOrchestration:
     def test_appends(self):
-        p = MagicMock(); p.config.save_orchestration_trace = True; p.orchestration_trace = []
+        p = MagicMock()
+        p.config.save_orchestration_trace = True
+        p.orchestration_trace = []
         trace_orchestration(p, "evt", {"k": "v"})
-        assert len(p.orchestration_trace) == 1 and p.orchestration_trace[0]["event_type"] == "evt"
+        assert (
+            len(p.orchestration_trace) == 1
+            and p.orchestration_trace[0]["event_type"] == "evt"
+        )
 
     def test_disabled(self):
-        p = MagicMock(); p.config.save_orchestration_trace = False; p.orchestration_trace = []
+        p = MagicMock()
+        p.config.save_orchestration_trace = False
+        p.orchestration_trace = []
         trace_orchestration(p, "evt", {})
         assert len(p.orchestration_trace) == 0
 
     def test_data_preserved(self):
-        p = MagicMock(); p.config.save_orchestration_trace = True; p.orchestration_trace = []
+        p = MagicMock()
+        p.config.save_orchestration_trace = True
+        p.orchestration_trace = []
         trace_orchestration(p, "a", {"x": 1})
         assert p.orchestration_trace[0]["data"] == {"x": 1}
 
@@ -978,15 +1519,18 @@ class TestTraceOrchestration:
 @pytest.mark.skipif(not ANALYSIS_AVAILABLE, reason="analysis import failed")
 class TestGetCommunicationLogFunc:
     def test_from_middleware(self):
-        p = MagicMock(); p.middleware.get_message_history.return_value = [{"m": 1}]
+        p = MagicMock()
+        p.middleware.get_message_history.return_value = [{"m": 1}]
         assert len(get_communication_log(p)) == 1
 
     def test_no_middleware(self):
-        p = MagicMock(); p.middleware = None
+        p = MagicMock()
+        p.middleware = None
         assert get_communication_log(p) == []
 
     def test_error(self):
-        p = MagicMock(); p.middleware.get_message_history.side_effect = RuntimeError("F")
+        p = MagicMock()
+        p.middleware.get_message_history.side_effect = RuntimeError("F")
         assert get_communication_log(p) == []
 
 
@@ -998,10 +1542,13 @@ class TestSaveTrace:
         p = MagicMock()
         p.config.orchestration_mode_enum = OrchestrationMode.PIPELINE
         p.config.analysis_type = AnalysisType.COMPREHENSIVE
-        p.config.enable_hierarchical = True; p.config.enable_specialized_orchestrators = True
+        p.config.enable_hierarchical = True
+        p.config.enable_specialized_orchestrators = True
         p.orchestration_trace = []
         with patch("builtins.open", mock_open()) as mf:
-            await save_orchestration_trace(p, "id", {"status": "ok", "execution_time": 1, "recommendations": []})
+            await save_orchestration_trace(
+                p, "id", {"status": "ok", "execution_time": 1, "recommendations": []}
+            )
             mf.assert_called_once()
 
     @patch("argumentation_analysis.pipelines.orchestration.analysis.traces.RESULTS_DIR")

--- a/tests/unit/argumentation_analysis/plugins/analysis_tools/logic/test_enhanced_contextual_fallacy_analyzer.py
+++ b/tests/unit/argumentation_analysis/plugins/analysis_tools/logic/test_enhanced_contextual_fallacy_analyzer.py
@@ -45,6 +45,7 @@ def analyzer(mock_detector):
 # __init__
 # ============================================================
 
+
 class TestInit:
     def test_creates_instance(self, analyzer):
         assert isinstance(analyzer, EnhancedContextualFallacyAnalyzer)
@@ -67,6 +68,7 @@ class TestInit:
 # _determine_context_type
 # ============================================================
 
+
 class TestDetermineContextType:
     def test_political(self, analyzer):
         assert analyzer._determine_context_type("discours politique") == "politique"
@@ -75,10 +77,14 @@ class TestDetermineContextType:
         assert analyzer._determine_context_type("campagne élection") == "politique"
 
     def test_scientific(self, analyzer):
-        assert analyzer._determine_context_type("article scientifique") == "scientifique"
+        assert (
+            analyzer._determine_context_type("article scientifique") == "scientifique"
+        )
 
     def test_research(self, analyzer):
-        assert analyzer._determine_context_type("recherche académique") == "scientifique"
+        assert (
+            analyzer._determine_context_type("recherche académique") == "scientifique"
+        )
 
     def test_commercial(self, analyzer):
         assert analyzer._determine_context_type("publicité commercial") == "commercial"
@@ -100,51 +106,65 @@ class TestDetermineContextType:
 # _are_complementary_fallacies
 # ============================================================
 
+
 class TestAreComplementaryFallacies:
     def test_authority_and_popularity(self, analyzer):
-        assert analyzer._are_complementary_fallacies(
-            "Appel à l'autorité", "Appel à la popularité"
-        ) is True
+        assert (
+            analyzer._are_complementary_fallacies(
+                "Appel à l'autorité", "Appel à la popularité"
+            )
+            is True
+        )
 
     def test_popularity_and_authority_reversed(self, analyzer):
-        assert analyzer._are_complementary_fallacies(
-            "Appel à la popularité", "Appel à l'autorité"
-        ) is True
+        assert (
+            analyzer._are_complementary_fallacies(
+                "Appel à la popularité", "Appel à l'autorité"
+            )
+            is True
+        )
 
     def test_dilemma_and_emotion(self, analyzer):
-        assert analyzer._are_complementary_fallacies(
-            "Faux dilemme", "Appel à l'émotion"
-        ) is True
+        assert (
+            analyzer._are_complementary_fallacies("Faux dilemme", "Appel à l'émotion")
+            is True
+        )
 
     def test_slippery_slope_and_fear(self, analyzer):
-        assert analyzer._are_complementary_fallacies(
-            "Pente glissante", "Appel à la peur"
-        ) is True
+        assert (
+            analyzer._are_complementary_fallacies("Pente glissante", "Appel à la peur")
+            is True
+        )
 
     def test_strawman_and_ad_hominem(self, analyzer):
-        assert analyzer._are_complementary_fallacies(
-            "Homme de paille", "Ad hominem"
-        ) is True
+        assert (
+            analyzer._are_complementary_fallacies("Homme de paille", "Ad hominem")
+            is True
+        )
 
     def test_tradition_and_authority(self, analyzer):
-        assert analyzer._are_complementary_fallacies(
-            "Appel à la tradition", "Appel à l'autorité"
-        ) is True
+        assert (
+            analyzer._are_complementary_fallacies(
+                "Appel à la tradition", "Appel à l'autorité"
+            )
+            is True
+        )
 
     def test_non_complementary(self, analyzer):
-        assert analyzer._are_complementary_fallacies(
-            "Ad hominem", "Faux dilemme"
-        ) is False
+        assert (
+            analyzer._are_complementary_fallacies("Ad hominem", "Faux dilemme") is False
+        )
 
     def test_same_type_not_complementary(self, analyzer):
-        assert analyzer._are_complementary_fallacies(
-            "Ad hominem", "Ad hominem"
-        ) is False
+        assert (
+            analyzer._are_complementary_fallacies("Ad hominem", "Ad hominem") is False
+        )
 
 
 # ============================================================
 # _analyze_context_deeply (without NLP models)
 # ============================================================
+
 
 class TestAnalyzeContextDeeply:
     def test_returns_expected_keys(self, analyzer):
@@ -173,6 +193,7 @@ class TestAnalyzeContextDeeply:
 # ============================================================
 # _analyze_fallacy_relations
 # ============================================================
+
 
 class TestAnalyzeFallacyRelations:
     def test_empty_list(self, analyzer):
@@ -212,12 +233,18 @@ class TestAnalyzeFallacyRelations:
 # _filter_by_context_semantic
 # ============================================================
 
+
 class TestFilterByContextSemantic:
     def test_general_context_returns_all(self, analyzer):
         fallacies = [
             {"fallacy_type": "Ad hominem", "confidence": 0.5, "context_text": "x"},
         ]
-        ctx = {"context_type": "général", "context_subtypes": [], "audience_characteristics": [], "formality_level": "moyen"}
+        ctx = {
+            "context_type": "général",
+            "context_subtypes": [],
+            "audience_characteristics": [],
+            "formality_level": "moyen",
+        }
         result = analyzer._filter_by_context_semantic(fallacies, ctx)
         assert len(result) == len(fallacies)
 
@@ -239,7 +266,11 @@ class TestFilterByContextSemantic:
 
     def test_irrelevant_fallacy_low_relevance(self, analyzer):
         fallacies = [
-            {"fallacy_type": "Post hoc ergo propter hoc", "confidence": 0.5, "context_text": "x"},
+            {
+                "fallacy_type": "Post hoc ergo propter hoc",
+                "confidence": 0.5,
+                "context_text": "x",
+            },
         ]
         ctx = {
             "context_type": "politique",
@@ -253,7 +284,11 @@ class TestFilterByContextSemantic:
 
     def test_subtype_adjustments(self, analyzer):
         fallacies = [
-            {"fallacy_type": "Appel à l'émotion", "confidence": 0.5, "context_text": "x"},
+            {
+                "fallacy_type": "Appel à l'émotion",
+                "confidence": 0.5,
+                "context_text": "x",
+            },
         ]
         ctx = {
             "context_type": "politique",
@@ -267,7 +302,11 @@ class TestFilterByContextSemantic:
 
     def test_audience_adjustments(self, analyzer):
         fallacies = [
-            {"fallacy_type": "Appel à l'autorité", "confidence": 0.5, "context_text": "x"},
+            {
+                "fallacy_type": "Appel à l'autorité",
+                "confidence": 0.5,
+                "context_text": "x",
+            },
         ]
         ctx = {
             "context_type": "académique",
@@ -281,7 +320,11 @@ class TestFilterByContextSemantic:
 
     def test_sorted_by_confidence_desc(self, analyzer):
         fallacies = [
-            {"fallacy_type": "Post hoc ergo propter hoc", "confidence": 0.9, "context_text": "x"},
+            {
+                "fallacy_type": "Post hoc ergo propter hoc",
+                "confidence": 0.9,
+                "context_text": "x",
+            },
             {"fallacy_type": "Ad hominem", "confidence": 0.3, "context_text": "y"},
         ]
         ctx = {
@@ -298,6 +341,7 @@ class TestFilterByContextSemantic:
 # analyze_context
 # ============================================================
 
+
 class TestAnalyzeContext:
     def test_returns_expected_keys(self, analyzer, mock_detector):
         mock_detector.detect_fallacies.return_value = []
@@ -311,7 +355,12 @@ class TestAnalyzeContext:
 
     def test_with_detected_fallacies(self, analyzer, mock_detector):
         mock_detector.detect_fallacies.return_value = [
-            {"fallacy_type": "Ad hominem", "keyword": "x", "context_text": "attack", "confidence": 0.7},
+            {
+                "fallacy_type": "Ad hominem",
+                "keyword": "x",
+                "context_text": "attack",
+                "confidence": 0.7,
+            },
         ]
         result = analyzer.analyze_context("He attacked the person", "politique")
         assert result["potential_fallacies_count"] >= 1
@@ -319,7 +368,12 @@ class TestAnalyzeContext:
 
     def test_stores_last_analysis_fallacies(self, analyzer, mock_detector):
         mock_detector.detect_fallacies.return_value = [
-            {"fallacy_type": "Ad hominem", "keyword": "x", "context_text": "t", "confidence": 0.5},
+            {
+                "fallacy_type": "Ad hominem",
+                "keyword": "x",
+                "context_text": "t",
+                "confidence": 0.5,
+            },
         ]
         analyzer.analyze_context("text", "politique")
         assert len(analyzer.last_analysis_fallacies) >= 1
@@ -329,10 +383,16 @@ class TestAnalyzeContext:
 # provide_feedback
 # ============================================================
 
+
 class TestProvideFeedback:
     def test_records_feedback(self, analyzer, mock_detector):
         mock_detector.detect_fallacies.return_value = [
-            {"fallacy_type": "Ad hominem", "keyword": "x", "context_text": "t", "confidence": 0.5},
+            {
+                "fallacy_type": "Ad hominem",
+                "keyword": "x",
+                "context_text": "t",
+                "confidence": 0.5,
+            },
         ]
         analyzer.analyze_context("text", "politique")
         analyzer.provide_feedback("fallacy_0", True, "good detection")
@@ -341,23 +401,42 @@ class TestProvideFeedback:
 
     def test_positive_feedback_increases_confidence(self, analyzer, mock_detector):
         mock_detector.detect_fallacies.return_value = [
-            {"fallacy_type": "Ad hominem", "keyword": "x", "context_text": "t", "confidence": 0.5},
+            {
+                "fallacy_type": "Ad hominem",
+                "keyword": "x",
+                "context_text": "t",
+                "confidence": 0.5,
+            },
         ]
         analyzer.analyze_context("text", "politique")
         analyzer.provide_feedback("fallacy_0", True)
-        assert analyzer.learning_data["confidence_adjustments"]["Ad hominem"] == pytest.approx(0.05)
+        assert analyzer.learning_data["confidence_adjustments"][
+            "Ad hominem"
+        ] == pytest.approx(0.05)
 
     def test_negative_feedback_decreases_confidence(self, analyzer, mock_detector):
         mock_detector.detect_fallacies.return_value = [
-            {"fallacy_type": "Faux dilemme", "keyword": "x", "context_text": "t", "confidence": 0.5},
+            {
+                "fallacy_type": "Faux dilemme",
+                "keyword": "x",
+                "context_text": "t",
+                "confidence": 0.5,
+            },
         ]
         analyzer.analyze_context("text", "politique")
         analyzer.provide_feedback("fallacy_0", False)
-        assert analyzer.learning_data["confidence_adjustments"]["Faux dilemme"] == pytest.approx(-0.1)
+        assert analyzer.learning_data["confidence_adjustments"][
+            "Faux dilemme"
+        ] == pytest.approx(-0.1)
 
     def test_feedback_clamped(self, analyzer, mock_detector):
         mock_detector.detect_fallacies.return_value = [
-            {"fallacy_type": "Ad hominem", "keyword": "x", "context_text": "t", "confidence": 0.5},
+            {
+                "fallacy_type": "Ad hominem",
+                "keyword": "x",
+                "context_text": "t",
+                "confidence": 0.5,
+            },
         ]
         analyzer.analyze_context("text", "politique")
         # Push confidence down many times
@@ -374,6 +453,7 @@ class TestProvideFeedback:
 # ============================================================
 # _generate_fallacy_explanation
 # ============================================================
+
 
 class TestGenerateFallacyExplanation:
     def test_known_combination(self, analyzer):
@@ -393,6 +473,7 @@ class TestGenerateFallacyExplanation:
 # ============================================================
 # _generate_correction_suggestion
 # ============================================================
+
 
 class TestGenerateCorrectionSuggestion:
     def test_known_fallacy(self, analyzer):
@@ -418,6 +499,7 @@ class TestGenerateCorrectionSuggestion:
 # get_contextual_fallacy_examples
 # ============================================================
 
+
 class TestGetContextualFallacyExamples:
     def test_returns_list(self, analyzer):
         result = analyzer.get_contextual_fallacy_examples(
@@ -437,6 +519,7 @@ class TestGetContextualFallacyExamples:
 # identify_contextual_fallacies
 # ============================================================
 
+
 class TestIdentifyContextualFallacies:
     def test_returns_list(self, analyzer, mock_detector):
         mock_detector.detect_fallacies.return_value = []
@@ -445,7 +528,12 @@ class TestIdentifyContextualFallacies:
 
     def test_filters_by_confidence(self, analyzer, mock_detector):
         mock_detector.detect_fallacies.return_value = [
-            {"fallacy_type": "Ad hominem", "keyword": "x", "context_text": "t", "confidence": 0.1},
+            {
+                "fallacy_type": "Ad hominem",
+                "keyword": "x",
+                "context_text": "t",
+                "confidence": 0.1,
+            },
         ]
         result = analyzer.identify_contextual_fallacies("some text", "politique")
         # In political context, Ad hominem gets +0.3 -> 0.4 still below 0.5?
@@ -455,7 +543,12 @@ class TestIdentifyContextualFallacies:
 
     def test_high_confidence_passed_through(self, analyzer, mock_detector):
         mock_detector.detect_fallacies.return_value = [
-            {"fallacy_type": "Ad hominem", "keyword": "x", "context_text": "t", "confidence": 0.8},
+            {
+                "fallacy_type": "Ad hominem",
+                "keyword": "x",
+                "context_text": "t",
+                "confidence": 0.8,
+            },
         ]
         result = analyzer.identify_contextual_fallacies("some text", "politique")
         # 0.8 + 0.3 = 1.0, well above 0.5 threshold

--- a/tests/unit/argumentation_analysis/plugins/analysis_tools/logic/test_enhanced_severity_evaluator.py
+++ b/tests/unit/argumentation_analysis/plugins/analysis_tools/logic/test_enhanced_severity_evaluator.py
@@ -21,6 +21,7 @@ def evaluator():
 # __init__
 # ============================================================
 
+
 class TestInit:
     def test_creates_instance(self, evaluator):
         assert isinstance(evaluator, EnhancedFallacySeverityEvaluator)
@@ -46,6 +47,7 @@ class TestInit:
 # _determine_severity_level
 # ============================================================
 
+
 class TestDetermineSeverityLevel:
     def test_low(self, evaluator):
         assert evaluator._determine_severity_level(0.0) == "Faible"
@@ -67,6 +69,7 @@ class TestDetermineSeverityLevel:
 # ============================================================
 # _analyze_context_impact
 # ============================================================
+
 
 class TestAnalyzeContextImpact:
     def test_known_context(self, evaluator):
@@ -112,6 +115,7 @@ class TestAnalyzeContextImpact:
 # _calculate_fallacy_severity
 # ============================================================
 
+
 class TestCalculateFallacySeverity:
     def test_known_fallacy_general_context(self, evaluator):
         fallacy = {"fallacy_type": "Appel à l'autorité", "context_text": "test"}
@@ -131,8 +135,12 @@ class TestCalculateFallacySeverity:
         fallacy = {"fallacy_type": "Ad hominem", "context_text": "test"}
         ctx_general = evaluator._analyze_context_impact("général")
         ctx_science = evaluator._analyze_context_impact("scientifique")
-        sev_general = evaluator._calculate_fallacy_severity(fallacy, ctx_general)["final_severity"]
-        sev_science = evaluator._calculate_fallacy_severity(fallacy, ctx_science)["final_severity"]
+        sev_general = evaluator._calculate_fallacy_severity(fallacy, ctx_general)[
+            "final_severity"
+        ]
+        sev_science = evaluator._calculate_fallacy_severity(fallacy, ctx_science)[
+            "final_severity"
+        ]
         assert sev_science > sev_general
 
     def test_severity_clamped_to_one(self, evaluator):
@@ -152,6 +160,7 @@ class TestCalculateFallacySeverity:
 # ============================================================
 # _calculate_overall_severity
 # ============================================================
+
 
 class TestCalculateOverallSeverity:
     def test_empty_list(self, evaluator):
@@ -186,6 +195,7 @@ class TestCalculateOverallSeverity:
 # ============================================================
 # evaluate_fallacy_severity (keyword-based detection)
 # ============================================================
+
 
 class TestEvaluateFallacySeverity:
     def test_detects_authority_keyword(self, evaluator):
@@ -226,12 +236,16 @@ class TestEvaluateFallacySeverity:
         gen = evaluator.evaluate_fallacy_severity(args, "général")
         sci = evaluator.evaluate_fallacy_severity(args, "scientifique")
         if gen["fallacy_evaluations"] and sci["fallacy_evaluations"]:
-            assert sci["fallacy_evaluations"][0]["final_severity"] >= gen["fallacy_evaluations"][0]["final_severity"]
+            assert (
+                sci["fallacy_evaluations"][0]["final_severity"]
+                >= gen["fallacy_evaluations"][0]["final_severity"]
+            )
 
 
 # ============================================================
 # evaluate_fallacy_list (pre-identified fallacies)
 # ============================================================
+
 
 class TestEvaluateFallacyList:
     def test_empty_list(self, evaluator):
@@ -258,7 +272,10 @@ class TestEvaluateFallacyList:
         fallacies = [{"fallacy_type": "Appel à la peur", "context_text": "risk"}]
         gen = evaluator.evaluate_fallacy_list(fallacies, "général")
         med = evaluator.evaluate_fallacy_list(fallacies, "médical")
-        assert med["fallacy_evaluations"][0]["final_severity"] > gen["fallacy_evaluations"][0]["final_severity"]
+        assert (
+            med["fallacy_evaluations"][0]["final_severity"]
+            > gen["fallacy_evaluations"][0]["final_severity"]
+        )
 
     def test_result_structure(self, evaluator):
         result = evaluator.evaluate_fallacy_list(

--- a/tests/unit/argumentation_analysis/plugins/analysis_tools/logic/test_nlp_model_manager.py
+++ b/tests/unit/argumentation_analysis/plugins/analysis_tools/logic/test_nlp_model_manager.py
@@ -12,7 +12,9 @@ from unittest.mock import MagicMock
 
 def _get_module():
     """Get the actual nlp_model_manager MODULE (not the instance exported by __init__.py)."""
-    return sys.modules["argumentation_analysis.plugins.analysis_tools.logic.nlp_model_manager"]
+    return sys.modules[
+        "argumentation_analysis.plugins.analysis_tools.logic.nlp_model_manager"
+    ]
 
 
 # Force import so the module is in sys.modules
@@ -25,10 +27,10 @@ from argumentation_analysis.plugins.analysis_tools.logic.nlp_model_manager impor
     HAS_TRANSFORMERS,
 )
 
-
 # ============================================================
 # Singleton pattern
 # ============================================================
+
 
 class TestSingleton:
     def test_singleton_returns_same_instance(self):
@@ -44,6 +46,7 @@ class TestSingleton:
 # Constants
 # ============================================================
 
+
 class TestConstants:
     def test_model_constants_defined(self):
         assert isinstance(TEXT_CLASSIFICATION_MODEL, str)
@@ -57,6 +60,7 @@ class TestConstants:
 # ============================================================
 # get_model / are_models_loaded (without loading)
 # ============================================================
+
 
 class TestGetModelWithoutLoad:
     def test_get_model_returns_none_when_not_loaded(self):
@@ -85,6 +89,7 @@ class TestGetModelWithoutLoad:
 # ============================================================
 # load_models_sync (mocked)
 # ============================================================
+
 
 class TestLoadModelsSync:
     def test_load_without_transformers_does_nothing(self):
@@ -174,6 +179,7 @@ class TestLoadModelsSync:
 # ============================================================
 # get_model after successful load
 # ============================================================
+
 
 class TestGetModelAfterLoad:
     def test_returns_model_when_loaded(self):

--- a/tests/unit/argumentation_analysis/plugins/analysis_tools/logic/test_rhetorical_result_analyzer.py
+++ b/tests/unit/argumentation_analysis/plugins/analysis_tools/logic/test_rhetorical_result_analyzer.py
@@ -9,7 +9,6 @@ from argumentation_analysis.plugins.analysis_tools.logic.rhetorical_result_analy
     EnhancedRhetoricalResultAnalyzer,
 )
 
-
 # ── RecommendationGenerator ──
 
 
@@ -43,21 +42,27 @@ class TestRecommendationGenerator:
     def test_most_common_fallacies_emotion(self, gen):
         recs = gen.generate(
             {"overall_severity": 0.8, "most_common_fallacies": ["Appel à l'émotion"]},
-            {}, {}, "",
+            {},
+            {},
+            "",
         )
         assert any("émotionnel" in r for r in recs["fallacy_recommendations"])
 
     def test_most_common_fallacies_ad_hominem(self, gen):
         recs = gen.generate(
             {"overall_severity": 0.8, "most_common_fallacies": ["Ad hominem"]},
-            {}, {}, "",
+            {},
+            {},
+            "",
         )
         assert any("personnelles" in r for r in recs["fallacy_recommendations"])
 
     def test_most_common_fallacies_authority(self, gen):
         recs = gen.generate(
             {"overall_severity": 0.8, "most_common_fallacies": ["Appel à l'autorité"]},
-            {}, {}, "",
+            {},
+            {},
+            "",
         )
         assert any("crédibles" in r for r in recs["fallacy_recommendations"])
 
@@ -76,49 +81,70 @@ class TestRecommendationGenerator:
 
     def test_thematic_shifts_issue(self, gen):
         recs = gen.generate(
-            {}, {"main_coherence_issues": ["Thematic shifts"]}, {}, "",
+            {},
+            {"main_coherence_issues": ["Thematic shifts"]},
+            {},
+            "",
         )
         assert any("thématique" in r for r in recs["coherence_recommendations"])
 
     def test_logical_gaps_issue(self, gen):
         recs = gen.generate(
-            {}, {"main_coherence_issues": ["Logical gaps"]}, {}, "",
+            {},
+            {"main_coherence_issues": ["Logical gaps"]},
+            {},
+            "",
         )
         assert any("logiques" in r for r in recs["coherence_recommendations"])
 
     def test_multiple_themes_issue(self, gen):
         recs = gen.generate(
-            {}, {"main_coherence_issues": ["Multiple unrelated themes"]}, {}, "",
+            {},
+            {"main_coherence_issues": ["Multiple unrelated themes"]},
+            {},
+            "",
         )
         assert any("thèmes" in r for r in recs["coherence_recommendations"])
 
     # -- Persuasion recommendations --
     def test_low_persuasion(self, gen):
         recs = gen.generate({}, {}, {"persuasion_score": 0.3}, "")
-        assert any("persuasive" in r.lower() for r in recs["persuasion_recommendations"])
+        assert any(
+            "persuasive" in r.lower() for r in recs["persuasion_recommendations"]
+        )
 
     def test_low_ethos_appeal(self, gen):
         recs = gen.generate(
-            {}, {}, {"rhetorical_appeals": {"ethos": 0.2, "pathos": 0.8, "logos": 0.5}}, "",
+            {},
+            {},
+            {"rhetorical_appeals": {"ethos": 0.2, "pathos": 0.8, "logos": 0.5}},
+            "",
         )
         assert any("crédibilité" in r for r in recs["persuasion_recommendations"])
 
     def test_low_pathos_appeal(self, gen):
         recs = gen.generate(
-            {}, {}, {"rhetorical_appeals": {"ethos": 0.8, "pathos": 0.2, "logos": 0.5}}, "",
+            {},
+            {},
+            {"rhetorical_appeals": {"ethos": 0.8, "pathos": 0.2, "logos": 0.5}},
+            "",
         )
         assert any("émotionnel" in r for r in recs["persuasion_recommendations"])
 
     def test_low_logos_appeal(self, gen):
         recs = gen.generate(
-            {}, {}, {"rhetorical_appeals": {"ethos": 0.8, "pathos": 0.8, "logos": 0.1}}, "",
+            {},
+            {},
+            {"rhetorical_appeals": {"ethos": 0.8, "pathos": 0.8, "logos": 0.1}},
+            "",
         )
         assert any("logique" in r for r in recs["persuasion_recommendations"])
 
     # -- Context-specific recommendations --
     def test_politique_context(self, gen):
         recs = gen.generate(
-            {}, {},
+            {},
+            {},
             {"emotional_appeal": 0.9, "logical_appeal": 0.2},
             "politique",
         )
@@ -282,16 +308,32 @@ class TestAnalyzePersuasionEffectiveness:
 
     def test_persuasion_levels(self, analyzer):
         # Test excellent level
-        with patch.object(analyzer, "_identify_rhetorical_appeals", return_value={"ethos": 1.0, "pathos": 1.0, "logos": 1.0}):
-            with patch.object(analyzer, "_evaluate_context_appropriateness", return_value=1.0):
-                with patch.object(analyzer, "_evaluate_audience_alignment", return_value=1.0):
+        with patch.object(
+            analyzer,
+            "_identify_rhetorical_appeals",
+            return_value={"ethos": 1.0, "pathos": 1.0, "logos": 1.0},
+        ):
+            with patch.object(
+                analyzer, "_evaluate_context_appropriateness", return_value=1.0
+            ):
+                with patch.object(
+                    analyzer, "_evaluate_audience_alignment", return_value=1.0
+                ):
                     result = analyzer._analyze_persuasion_effectiveness({}, "")
                     assert result["persuasion_level"] == "Excellent"
 
     def test_low_persuasion_level(self, analyzer):
-        with patch.object(analyzer, "_identify_rhetorical_appeals", return_value={"ethos": 0.0, "pathos": 0.0, "logos": 0.0}):
-            with patch.object(analyzer, "_evaluate_context_appropriateness", return_value=0.0):
-                with patch.object(analyzer, "_evaluate_audience_alignment", return_value=0.0):
+        with patch.object(
+            analyzer,
+            "_identify_rhetorical_appeals",
+            return_value={"ethos": 0.0, "pathos": 0.0, "logos": 0.0},
+        ):
+            with patch.object(
+                analyzer, "_evaluate_context_appropriateness", return_value=0.0
+            ):
+                with patch.object(
+                    analyzer, "_evaluate_audience_alignment", return_value=0.0
+                ):
                     result = analyzer._analyze_persuasion_effectiveness({}, "")
                     assert result["persuasion_level"] == "Très faible"
 
@@ -321,9 +363,17 @@ class TestContextAppropriateness:
         score = analyzer._evaluate_context_appropriateness(appeals, "général")
         assert score <= 1.0
 
-    @pytest.mark.parametrize("context", [
-        "politique", "scientifique", "commercial", "juridique", "académique", "général",
-    ])
+    @pytest.mark.parametrize(
+        "context",
+        [
+            "politique",
+            "scientifique",
+            "commercial",
+            "juridique",
+            "académique",
+            "général",
+        ],
+    )
     def test_all_defined_contexts(self, analyzer, context):
         appeals = {"ethos": 0.5, "pathos": 0.5, "logos": 0.5}
         score = analyzer._evaluate_context_appropriateness(appeals, context)
@@ -410,61 +460,81 @@ class TestStrengthsAndWeaknesses:
 
     def test_no_fallacies_is_strength(self, analyzer):
         s, w = analyzer._identify_strengths_and_weaknesses(
-            {"total_fallacies": 0}, {}, {},
+            {"total_fallacies": 0},
+            {},
+            {},
         )
         assert any("Absence" in x for x in s)
 
     def test_moderate_fallacies_is_strength(self, analyzer):
         s, w = analyzer._identify_strengths_and_weaknesses(
-            {"total_fallacies": 3, "overall_severity": 0.3}, {}, {},
+            {"total_fallacies": 3, "overall_severity": 0.3},
+            {},
+            {},
         )
         assert any("modérée" in x for x in s)
 
     def test_severe_fallacies_is_weakness(self, analyzer):
         s, w = analyzer._identify_strengths_and_weaknesses(
-            {"total_fallacies": 5, "overall_severity": 0.8}, {}, {},
+            {"total_fallacies": 5, "overall_severity": 0.8},
+            {},
+            {},
         )
         assert any("excessive" in x for x in w)
 
     def test_high_coherence_strength(self, analyzer):
         s, w = analyzer._identify_strengths_and_weaknesses(
-            {}, {"overall_coherence": 0.8}, {},
+            {},
+            {"overall_coherence": 0.8},
+            {},
         )
         assert any("cohérence argumentative" in x for x in s)
 
     def test_low_coherence_weakness(self, analyzer):
         s, w = analyzer._identify_strengths_and_weaknesses(
-            {}, {"overall_coherence": 0.3}, {},
+            {},
+            {"overall_coherence": 0.3},
+            {},
         )
         assert any("cohérence argumentative" in x for x in w)
 
     def test_high_persuasion_strength(self, analyzer):
         s, w = analyzer._identify_strengths_and_weaknesses(
-            {}, {}, {"persuasion_score": 0.8},
+            {},
+            {},
+            {"persuasion_score": 0.8},
         )
         assert any("persuasive" in x.lower() for x in s)
 
     def test_low_persuasion_weakness(self, analyzer):
         s, w = analyzer._identify_strengths_and_weaknesses(
-            {}, {}, {"persuasion_score": 0.3},
+            {},
+            {},
+            {"persuasion_score": 0.3},
         )
         assert any("persuasive" in x.lower() for x in w)
 
     def test_strong_emotional_appeal(self, analyzer):
         s, _ = analyzer._identify_strengths_and_weaknesses(
-            {}, {}, {"emotional_appeal": 0.8},
+            {},
+            {},
+            {"emotional_appeal": 0.8},
         )
         assert any("émotionnel" in x for x in s)
 
     def test_strong_logical_appeal(self, analyzer):
         s, _ = analyzer._identify_strengths_and_weaknesses(
-            {}, {}, {"logical_appeal": 0.8},
+            {},
+            {},
+            {"logical_appeal": 0.8},
         )
         assert any("logique" in x for x in s)
 
     def test_strong_credibility_appeal(self, analyzer):
         s, _ = analyzer._identify_strengths_and_weaknesses(
-            {}, {}, {"credibility_appeal": 0.8},
+            {},
+            {},
+            {"credibility_appeal": 0.8},
         )
         assert any("crédibilité" in x for x in s)
 

--- a/tests/unit/argumentation_analysis/plugins/test_fallacy_workflow_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_fallacy_workflow_plugin.py
@@ -29,7 +29,6 @@ from argumentation_analysis.plugins.identification_models import (
 )
 from argumentation_analysis.agents.utils.taxonomy_navigator import TaxonomyNavigator
 
-
 # ---------------------------------------------------------------------------
 # Sample taxonomy data for testing
 # ---------------------------------------------------------------------------
@@ -191,7 +190,9 @@ class TestConstruction:
         assert roots[0]["PK"] == "1"
         assert roots[1]["PK"] == "10"
 
-    def test_construction_with_taxonomy_file(self, mock_kernel, mock_llm_service, tmp_path):
+    def test_construction_with_taxonomy_file(
+        self, mock_kernel, mock_llm_service, tmp_path
+    ):
         csv_file = tmp_path / "taxonomy.csv"
         csv_file.write_text(
             "PK,path,depth,name\n1,root,1,Root Fallacy\n",
@@ -455,12 +456,14 @@ class TestIdentifiedFallacyModel:
 class TestOneShotMode:
     async def test_one_shot_with_json_response(self, plugin, mock_llm_service):
         mock_response = MagicMock()
-        mock_response.__str__ = lambda self: json.dumps({
-            "fallacy_name": "Ad Hominem",
-            "taxonomy_pk": "11",
-            "explanation": "Attacks the person",
-            "confidence": 0.8,
-        })
+        mock_response.__str__ = lambda self: json.dumps(
+            {
+                "fallacy_name": "Ad Hominem",
+                "taxonomy_pk": "11",
+                "explanation": "Attacks the person",
+                "confidence": 0.8,
+            }
+        )
         mock_llm_service.get_chat_message_content.return_value = mock_response
 
         result = await plugin._run_one_shot("You are stupid so you are wrong")
@@ -476,17 +479,23 @@ class TestOneShotMode:
         result = await plugin._run_one_shot("You are wrong")
         parsed = json.loads(result)
         assert "Ad Hominem" in parsed["fallacies"][0]["fallacy_type"]
-        assert parsed["fallacies"][0]["confidence"] == 0.3  # Low confidence for plain text
+        assert (
+            parsed["fallacies"][0]["confidence"] == 0.3
+        )  # Low confidence for plain text
 
     async def test_one_shot_on_llm_error(self, plugin, mock_llm_service):
-        mock_llm_service.get_chat_message_content.side_effect = RuntimeError("API error")
+        mock_llm_service.get_chat_message_content.side_effect = RuntimeError(
+            "API error"
+        )
         result = await plugin._run_one_shot("test")
         parsed = json.loads(result)
         assert "error" in parsed
 
     async def test_use_one_shot_flag(self, plugin, mock_llm_service):
         mock_response = MagicMock()
-        mock_response.__str__ = lambda self: '{"fallacy_name": "Test", "taxonomy_pk": "1", "explanation": "test", "confidence": 0.5}'
+        mock_response.__str__ = (
+            lambda self: '{"fallacy_name": "Test", "taxonomy_pk": "1", "explanation": "test", "confidence": 0.5}'
+        )
         mock_llm_service.get_chat_message_content.return_value = mock_response
 
         result = await plugin.run_guided_analysis(
@@ -530,12 +539,12 @@ class TestIterativeDeepening:
         mock_llm_service.get_chat_message_contents.return_value = []
 
         mock_response = MagicMock()
-        mock_response.__str__ = lambda self: '{"fallacy_name": "Unknown", "taxonomy_pk": "", "explanation": "fallback", "confidence": 0.3}'
+        mock_response.__str__ = (
+            lambda self: '{"fallacy_name": "Unknown", "taxonomy_pk": "", "explanation": "fallback", "confidence": 0.3}'
+        )
         mock_llm_service.get_chat_message_content.return_value = mock_response
 
-        result = await empty_plugin.run_guided_analysis(
-            argument_text="Some text"
-        )
+        result = await empty_plugin.run_guided_analysis(argument_text="Some text")
         parsed = json.loads(result)
         assert parsed["exploration_method"] == "one_shot"
 
@@ -548,21 +557,23 @@ class TestIterativeDeepening:
         mock_llm_service.get_chat_message_contents.return_value = [msg]
 
         mock_response = MagicMock()
-        mock_response.__str__ = lambda self: '{"fallacy_name": "Fallback", "taxonomy_pk": "", "explanation": "no tools", "confidence": 0.3}'
+        mock_response.__str__ = (
+            lambda self: '{"fallacy_name": "Fallback", "taxonomy_pk": "", "explanation": "no tools", "confidence": 0.3}'
+        )
         mock_llm_service.get_chat_message_content.return_value = mock_response
 
         result = await plugin.run_guided_analysis(argument_text="text")
         parsed = json.loads(result)
         assert parsed["exploration_method"] == "one_shot"
 
-    async def test_falls_back_on_root_selection_error(
-        self, plugin, mock_llm_service
-    ):
+    async def test_falls_back_on_root_selection_error(self, plugin, mock_llm_service):
         """If root selection LLM call fails, fall back to one-shot."""
         mock_llm_service.get_chat_message_contents.side_effect = RuntimeError("fail")
 
         mock_response = MagicMock()
-        mock_response.__str__ = lambda self: '{"fallacy_name": "Fallback", "taxonomy_pk": "", "explanation": "error", "confidence": 0.2}'
+        mock_response.__str__ = (
+            lambda self: '{"fallacy_name": "Fallback", "taxonomy_pk": "", "explanation": "error", "confidence": 0.2}'
+        )
         mock_llm_service.get_chat_message_content.return_value = mock_response
 
         result = await plugin.run_guided_analysis(argument_text="text")
@@ -579,7 +590,9 @@ class TestTraceLogging:
     async def test_trace_log_file_created(self, plugin, mock_llm_service, tmp_path):
         # Use one-shot mode for simpler mock setup
         mock_response = MagicMock()
-        mock_response.__str__ = lambda self: '{"fallacy_name": "Test", "taxonomy_pk": "1", "explanation": "t", "confidence": 0.5}'
+        mock_response.__str__ = (
+            lambda self: '{"fallacy_name": "Test", "taxonomy_pk": "1", "explanation": "t", "confidence": 0.5}'
+        )
         mock_llm_service.get_chat_message_content.return_value = mock_response
 
         log_file = tmp_path / "trace.log"
@@ -592,7 +605,9 @@ class TestTraceLogging:
 
     async def test_handlers_cleaned_up(self, plugin, mock_llm_service, tmp_path):
         mock_response = MagicMock()
-        mock_response.__str__ = lambda self: '{"fallacy_name": "T", "taxonomy_pk": "", "explanation": "", "confidence": 0.5}'
+        mock_response.__str__ = (
+            lambda self: '{"fallacy_name": "T", "taxonomy_pk": "", "explanation": "", "confidence": 0.5}'
+        )
         mock_llm_service.get_chat_message_content.return_value = mock_response
 
         log_file = tmp_path / "trace.log"

--- a/tests/unit/argumentation_analysis/plugins/test_governance_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_governance_plugin.py
@@ -20,6 +20,7 @@ def plugin():
 # detect_conflicts_fn
 # ============================================================
 
+
 class TestDetectConflicts:
     def test_no_conflicts(self, plugin):
         positions = {"agent_a": "agree", "agent_b": "agree"}
@@ -52,24 +53,47 @@ class TestDetectConflicts:
 # resolve_conflict_fn
 # ============================================================
 
+
 class TestResolveConflict:
     def test_collaborative(self, plugin):
-        conflict = {"agents": ["a", "b"], "positions": {"a": "pour", "b": "contre"}, "conflict_level": "high"}
-        result = json.loads(plugin.resolve_conflict_fn(json.dumps(conflict), strategy="collaborative"))
+        conflict = {
+            "agents": ["a", "b"],
+            "positions": {"a": "pour", "b": "contre"},
+            "conflict_level": "high",
+        }
+        result = json.loads(
+            plugin.resolve_conflict_fn(json.dumps(conflict), strategy="collaborative")
+        )
         assert isinstance(result, dict)
 
     def test_competitive(self, plugin):
-        conflict = {"agents": ["a", "b"], "positions": {"a": "pour", "b": "contre"}, "conflict_level": "medium"}
-        result = json.loads(plugin.resolve_conflict_fn(json.dumps(conflict), strategy="competitive"))
+        conflict = {
+            "agents": ["a", "b"],
+            "positions": {"a": "pour", "b": "contre"},
+            "conflict_level": "medium",
+        }
+        result = json.loads(
+            plugin.resolve_conflict_fn(json.dumps(conflict), strategy="competitive")
+        )
         assert isinstance(result, dict)
 
     def test_arbitration(self, plugin):
-        conflict = {"agents": ["a", "b"], "positions": {"a": "pour", "b": "contre"}, "conflict_level": "low"}
-        result = json.loads(plugin.resolve_conflict_fn(json.dumps(conflict), strategy="arbitration"))
+        conflict = {
+            "agents": ["a", "b"],
+            "positions": {"a": "pour", "b": "contre"},
+            "conflict_level": "low",
+        }
+        result = json.loads(
+            plugin.resolve_conflict_fn(json.dumps(conflict), strategy="arbitration")
+        )
         assert isinstance(result, dict)
 
     def test_default_strategy(self, plugin):
-        conflict = {"agents": ["a", "b"], "positions": {"a": "x", "b": "y"}, "conflict_level": "low"}
+        conflict = {
+            "agents": ["a", "b"],
+            "positions": {"a": "x", "b": "y"},
+            "conflict_level": "low",
+        }
         result = json.loads(plugin.resolve_conflict_fn(json.dumps(conflict)))
         assert isinstance(result, dict)
 
@@ -77,6 +101,7 @@ class TestResolveConflict:
 # ============================================================
 # compute_consensus_metrics
 # ============================================================
+
 
 class TestComputeConsensusMetrics:
     def test_unanimous(self, plugin):
@@ -105,6 +130,7 @@ class TestComputeConsensusMetrics:
 # ============================================================
 # list_governance_methods
 # ============================================================
+
 
 class TestListGovernanceMethods:
     def test_returns_list(self, plugin):

--- a/tests/unit/argumentation_analysis/plugins/test_jtms_sk_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_jtms_sk_plugin.py
@@ -14,51 +14,63 @@ from argumentation_analysis.plugins.semantic_kernel.jtms_plugin import (
     create_jtms_plugin,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture
 def mock_jtms_service():
     """Creates a mocked JTMSService with all async methods."""
     svc = MagicMock()
     svc.create_jtms_instance = AsyncMock(return_value="inst_abc123")
-    svc.create_belief = AsyncMock(return_value={
-        "belief_name": "rain",
-        "value": True,
-        "created": True,
-    })
-    svc.add_justification = AsyncMock(return_value={
-        "justification_id": "j_001",
-        "in_beliefs": ["rain"],
-        "out_beliefs": [],
-        "conclusion": "wet_road",
-    })
-    svc.explain_belief = AsyncMock(return_value={
-        "belief_name": "rain",
-        "current_status": True,
-        "non_monotonic": False,
-        "justifications": [{"id": "j_001"}],
-        "implications_count": 1,
-    })
-    svc.query_beliefs = AsyncMock(return_value={
-        "beliefs": [{"name": "rain", "status": "valid"}],
-        "total_beliefs": 3,
-        "filtered_count": 1,
-    })
-    svc.get_jtms_state = AsyncMock(return_value={
-        "beliefs": [{"name": "rain"}, {"name": "wet_road"}],
-        "justifications_graph": {"j_001": {"in": ["rain"], "out": [], "conclusion": "wet_road"}},
-        "statistics": {
-            "total_beliefs": 2,
-            "valid_beliefs": 1,
-            "invalid_beliefs": 0,
-            "unknown_beliefs": 1,
-            "total_justifications": 1,
-            "non_monotonic_beliefs": 0,
-        },
-    })
+    svc.create_belief = AsyncMock(
+        return_value={
+            "belief_name": "rain",
+            "value": True,
+            "created": True,
+        }
+    )
+    svc.add_justification = AsyncMock(
+        return_value={
+            "justification_id": "j_001",
+            "in_beliefs": ["rain"],
+            "out_beliefs": [],
+            "conclusion": "wet_road",
+        }
+    )
+    svc.explain_belief = AsyncMock(
+        return_value={
+            "belief_name": "rain",
+            "current_status": True,
+            "non_monotonic": False,
+            "justifications": [{"id": "j_001"}],
+            "implications_count": 1,
+        }
+    )
+    svc.query_beliefs = AsyncMock(
+        return_value={
+            "beliefs": [{"name": "rain", "status": "valid"}],
+            "total_beliefs": 3,
+            "filtered_count": 1,
+        }
+    )
+    svc.get_jtms_state = AsyncMock(
+        return_value={
+            "beliefs": [{"name": "rain"}, {"name": "wet_road"}],
+            "justifications_graph": {
+                "j_001": {"in": ["rain"], "out": [], "conclusion": "wet_road"}
+            },
+            "statistics": {
+                "total_beliefs": 2,
+                "valid_beliefs": 1,
+                "invalid_beliefs": 0,
+                "unknown_beliefs": 1,
+                "total_justifications": 1,
+                "non_monotonic_beliefs": 0,
+            },
+        }
+    )
     return svc
 
 
@@ -68,14 +80,16 @@ def mock_session_manager():
     mgr = MagicMock()
     mgr.create_session = AsyncMock(return_value="session_xyz789")
     mgr.add_jtms_instance_to_session = AsyncMock()
-    mgr.get_session = AsyncMock(return_value={
-        "session_id": "session_xyz789",
-        "agent_id": "semantic_kernel",
-        "session_name": "SK_Session_semantic_kernel",
-        "created_at": "2026-01-01T00:00:00",
-        "last_accessed": "2026-01-01T00:01:00",
-        "checkpoint_count": 0,
-    })
+    mgr.get_session = AsyncMock(
+        return_value={
+            "session_id": "session_xyz789",
+            "agent_id": "semantic_kernel",
+            "session_name": "SK_Session_semantic_kernel",
+            "created_at": "2026-01-01T00:00:00",
+            "last_accessed": "2026-01-01T00:01:00",
+            "checkpoint_count": 0,
+        }
+    )
     return mgr
 
 
@@ -92,6 +106,7 @@ def plugin(mock_jtms_service, mock_session_manager):
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def parse_result(json_str: str) -> dict:
     """Parse a JSON string returned by a kernel function."""
     assert isinstance(json_str, str)
@@ -101,6 +116,7 @@ def parse_result(json_str: str) -> dict:
 # ===========================================================================
 # 1. Construction & Factory
 # ===========================================================================
+
 
 class TestConstruction:
 
@@ -139,6 +155,7 @@ class TestConstruction:
 # 2. Configuration methods
 # ===========================================================================
 
+
 class TestConfiguration:
 
     def test_set_default_session(self, plugin):
@@ -158,6 +175,7 @@ class TestConfiguration:
 # ===========================================================================
 # 3. get_plugin_status
 # ===========================================================================
+
 
 class TestGetPluginStatus:
 
@@ -180,9 +198,12 @@ class TestGetPluginStatus:
 # 4. _ensure_session_and_instance
 # ===========================================================================
 
+
 class TestEnsureSessionAndInstance:
 
-    async def test_auto_creates_session_and_instance(self, plugin, mock_session_manager, mock_jtms_service):
+    async def test_auto_creates_session_and_instance(
+        self, plugin, mock_session_manager, mock_jtms_service
+    ):
         sid, iid = await plugin._ensure_session_and_instance()
         mock_session_manager.create_session.assert_awaited_once()
         mock_jtms_service.create_jtms_instance.assert_awaited_once()
@@ -192,7 +213,9 @@ class TestEnsureSessionAndInstance:
         assert plugin.default_session_id == sid
         assert plugin.default_instance_id == iid
 
-    async def test_uses_defaults_when_set(self, plugin, mock_session_manager, mock_jtms_service):
+    async def test_uses_defaults_when_set(
+        self, plugin, mock_session_manager, mock_jtms_service
+    ):
         plugin.set_default_session("my_session")
         plugin.set_default_instance("my_instance")
         sid, iid = await plugin._ensure_session_and_instance()
@@ -201,7 +224,9 @@ class TestEnsureSessionAndInstance:
         mock_session_manager.create_session.assert_not_awaited()
         mock_jtms_service.create_jtms_instance.assert_not_awaited()
 
-    async def test_uses_explicit_params(self, plugin, mock_session_manager, mock_jtms_service):
+    async def test_uses_explicit_params(
+        self, plugin, mock_session_manager, mock_jtms_service
+    ):
         sid, iid = await plugin._ensure_session_and_instance(
             session_id="explicit_s", instance_id="explicit_i"
         )
@@ -215,7 +240,9 @@ class TestEnsureSessionAndInstance:
         with pytest.raises(ValueError, match="session"):
             await plugin._ensure_session_and_instance()
 
-    async def test_raises_when_auto_create_instance_disabled(self, plugin, mock_session_manager):
+    async def test_raises_when_auto_create_instance_disabled(
+        self, plugin, mock_session_manager
+    ):
         plugin.configure_auto_creation(auto_session=True, auto_instance=False)
         # session auto-creates fine, but instance should fail
         with pytest.raises(ValueError, match="instance"):
@@ -226,15 +253,20 @@ class TestEnsureSessionAndInstance:
 # 5. create_belief
 # ===========================================================================
 
+
 class TestCreateBelief:
 
     async def test_success_true(self, plugin, mock_jtms_service):
-        result = parse_result(await plugin.create_belief(
-            belief_name="rain", initial_value="true"
-        ))
+        result = parse_result(
+            await plugin.create_belief(belief_name="rain", initial_value="true")
+        )
         assert result["operation"] == "create_belief"
         assert result["status"] == "success"
-        assert result["belief"] == {"belief_name": "rain", "value": True, "created": True}
+        assert result["belief"] == {
+            "belief_name": "rain",
+            "value": True,
+            "created": True,
+        }
         mock_jtms_service.create_belief.assert_awaited_once_with(
             instance_id="inst_abc123",
             belief_name="rain",
@@ -242,9 +274,9 @@ class TestCreateBelief:
         )
 
     async def test_success_false(self, plugin, mock_jtms_service):
-        result = parse_result(await plugin.create_belief(
-            belief_name="sun", initial_value="false"
-        ))
+        result = parse_result(
+            await plugin.create_belief(belief_name="sun", initial_value="false")
+        )
         assert result["status"] == "success"
         mock_jtms_service.create_belief.assert_awaited_once_with(
             instance_id="inst_abc123",
@@ -253,9 +285,9 @@ class TestCreateBelief:
         )
 
     async def test_success_unknown(self, plugin, mock_jtms_service):
-        result = parse_result(await plugin.create_belief(
-            belief_name="wind", initial_value="unknown"
-        ))
+        result = parse_result(
+            await plugin.create_belief(belief_name="wind", initial_value="unknown")
+        )
         assert result["status"] == "success"
         mock_jtms_service.create_belief.assert_awaited_once_with(
             instance_id="inst_abc123",
@@ -264,11 +296,14 @@ class TestCreateBelief:
         )
 
     async def test_invalid_initial_value(self, plugin):
-        result = parse_result(await plugin.create_belief(
-            belief_name="x", initial_value="maybe"
-        ))
+        result = parse_result(
+            await plugin.create_belief(belief_name="x", initial_value="maybe")
+        )
         assert result["status"] == "error"
-        assert "invalide" in result["error"].lower() or "invalid" in result["error"].lower()
+        assert (
+            "invalide" in result["error"].lower()
+            or "invalid" in result["error"].lower()
+        )
         assert result["operation"] == "create_belief"
 
     async def test_service_error(self, plugin, mock_jtms_service):
@@ -284,9 +319,9 @@ class TestCreateBelief:
         assert "agent_id" in result
 
     async def test_custom_agent_id(self, plugin):
-        result = parse_result(await plugin.create_belief(
-            belief_name="b", agent_id="sherlock"
-        ))
+        result = parse_result(
+            await plugin.create_belief(belief_name="b", agent_id="sherlock")
+        )
         assert result["agent_id"] == "sherlock"
 
 
@@ -294,14 +329,17 @@ class TestCreateBelief:
 # 6. add_justification
 # ===========================================================================
 
+
 class TestAddJustification:
 
     async def test_success_with_comma_separated(self, plugin, mock_jtms_service):
-        result = parse_result(await plugin.add_justification(
-            in_beliefs="rain, wind",
-            out_beliefs="sun",
-            conclusion="bad_weather",
-        ))
+        result = parse_result(
+            await plugin.add_justification(
+                in_beliefs="rain, wind",
+                out_beliefs="sun",
+                conclusion="bad_weather",
+            )
+        )
         assert result["operation"] == "add_justification"
         assert result["status"] == "success"
         assert "justification" in result
@@ -314,11 +352,13 @@ class TestAddJustification:
         )
 
     async def test_empty_in_and_out_beliefs(self, plugin, mock_jtms_service):
-        result = parse_result(await plugin.add_justification(
-            in_beliefs="",
-            out_beliefs="",
-            conclusion="axiom",
-        ))
+        result = parse_result(
+            await plugin.add_justification(
+                in_beliefs="",
+                out_beliefs="",
+                conclusion="axiom",
+            )
+        )
         assert result["status"] == "success"
         mock_jtms_service.add_justification.assert_awaited_once_with(
             instance_id="inst_abc123",
@@ -328,27 +368,33 @@ class TestAddJustification:
         )
 
     async def test_empty_conclusion_error(self, plugin):
-        result = parse_result(await plugin.add_justification(
-            in_beliefs="a",
-            out_beliefs="",
-            conclusion="",
-        ))
+        result = parse_result(
+            await plugin.add_justification(
+                in_beliefs="a",
+                out_beliefs="",
+                conclusion="",
+            )
+        )
         assert result["status"] == "error"
         assert "vide" in result["error"].lower() or "empty" in result["error"].lower()
 
     async def test_whitespace_conclusion_error(self, plugin):
-        result = parse_result(await plugin.add_justification(
-            in_beliefs="a",
-            out_beliefs="",
-            conclusion="   ",
-        ))
+        result = parse_result(
+            await plugin.add_justification(
+                in_beliefs="a",
+                out_beliefs="",
+                conclusion="   ",
+            )
+        )
         assert result["status"] == "error"
 
     async def test_service_error(self, plugin, mock_jtms_service):
         mock_jtms_service.add_justification.side_effect = RuntimeError("conflict")
-        result = parse_result(await plugin.add_justification(
-            in_beliefs="a", out_beliefs="", conclusion="c"
-        ))
+        result = parse_result(
+            await plugin.add_justification(
+                in_beliefs="a", out_beliefs="", conclusion="c"
+            )
+        )
         assert result["status"] == "error"
         assert "conflict" in result["error"]
 
@@ -356,6 +402,7 @@ class TestAddJustification:
 # ===========================================================================
 # 7. explain_belief
 # ===========================================================================
+
 
 class TestExplainBelief:
 
@@ -405,16 +452,22 @@ class TestExplainBelief:
 # 8. query_beliefs
 # ===========================================================================
 
+
 class TestQueryBeliefs:
 
-    @pytest.mark.parametrize("filter_val,expected_param", [
-        ("valid", "valid"),
-        ("invalid", "invalid"),
-        ("unknown", "unknown"),
-        ("non_monotonic", "non_monotonic"),
-        ("all", None),
-    ])
-    async def test_all_filter_types(self, plugin, mock_jtms_service, filter_val, expected_param):
+    @pytest.mark.parametrize(
+        "filter_val,expected_param",
+        [
+            ("valid", "valid"),
+            ("invalid", "invalid"),
+            ("unknown", "unknown"),
+            ("non_monotonic", "non_monotonic"),
+            ("all", None),
+        ],
+    )
+    async def test_all_filter_types(
+        self, plugin, mock_jtms_service, filter_val, expected_param
+    ):
         result = parse_result(await plugin.query_beliefs(filter_status=filter_val))
         assert result["operation"] == "query_beliefs"
         assert result["status"] == "success"
@@ -436,7 +489,10 @@ class TestQueryBeliefs:
     async def test_invalid_filter_error(self, plugin):
         result = parse_result(await plugin.query_beliefs(filter_status="bogus"))
         assert result["status"] == "error"
-        assert "invalide" in result["error"].lower() or "invalid" in result["error"].lower()
+        assert (
+            "invalide" in result["error"].lower()
+            or "invalid" in result["error"].lower()
+        )
 
     async def test_service_error(self, plugin, mock_jtms_service):
         mock_jtms_service.query_beliefs.side_effect = RuntimeError("timeout")
@@ -448,6 +504,7 @@ class TestQueryBeliefs:
 # ===========================================================================
 # 9. get_jtms_state
 # ===========================================================================
+
 
 class TestGetJtmsState:
 
@@ -480,15 +537,19 @@ class TestGetJtmsState:
         assert "statistics" not in result
 
     async def test_exclude_both(self, plugin, mock_jtms_service):
-        result = parse_result(await plugin.get_jtms_state(
-            include_graph="false", include_statistics="false"
-        ))
+        result = parse_result(
+            await plugin.get_jtms_state(
+                include_graph="false", include_statistics="false"
+            )
+        )
         assert "justifications_graph" not in result
         assert "statistics" not in result
         # Summary should still exist, using empty stats
         assert "natural_language_summary" in result
 
-    async def test_non_monotonic_warning_in_summary(self, plugin, mock_jtms_service, mock_session_manager):
+    async def test_non_monotonic_warning_in_summary(
+        self, plugin, mock_jtms_service, mock_session_manager
+    ):
         state = mock_jtms_service.get_jtms_state.return_value
         state["statistics"]["non_monotonic_beliefs"] = 2
         result = parse_result(await plugin.get_jtms_state())
@@ -501,7 +562,9 @@ class TestGetJtmsState:
         assert "corrupt state" in result["error"]
         assert result["operation"] == "get_jtms_state"
 
-    async def test_session_manager_error(self, plugin, mock_jtms_service, mock_session_manager):
+    async def test_session_manager_error(
+        self, plugin, mock_jtms_service, mock_session_manager
+    ):
         mock_session_manager.get_session.side_effect = KeyError("session gone")
         result = parse_result(await plugin.get_jtms_state())
         assert result["status"] == "error"

--- a/tests/unit/argumentation_analysis/plugins/test_quality_scoring_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_quality_scoring_plugin.py
@@ -22,6 +22,7 @@ def plugin():
 # __init__
 # ============================================================
 
+
 class TestInit:
     def test_creates_evaluator(self, plugin):
         assert plugin.evaluator is not None
@@ -31,13 +32,22 @@ class TestInit:
 # evaluate_argument_quality
 # ============================================================
 
+
 class TestEvaluateArgumentQuality:
     def test_returns_json(self, plugin):
-        result = json.loads(plugin.evaluate_argument_quality("Ceci est un argument clair et bien structuré."))
+        result = json.loads(
+            plugin.evaluate_argument_quality(
+                "Ceci est un argument clair et bien structuré."
+            )
+        )
         assert isinstance(result, dict)
 
     def test_has_note_finale(self, plugin):
-        result = json.loads(plugin.evaluate_argument_quality("Un argument solide avec des sources fiables."))
+        result = json.loads(
+            plugin.evaluate_argument_quality(
+                "Un argument solide avec des sources fiables."
+            )
+        )
         assert "note_finale" in result
 
     def test_has_note_moyenne(self, plugin):
@@ -57,6 +67,7 @@ class TestEvaluateArgumentQuality:
 # ============================================================
 # get_quality_score
 # ============================================================
+
 
 class TestGetQualityScore:
     def test_returns_json(self, plugin):
@@ -80,6 +91,7 @@ class TestGetQualityScore:
 # ============================================================
 # list_virtues
 # ============================================================
+
 
 class TestListVirtues:
     def test_returns_list(self, plugin):

--- a/tests/unit/argumentation_analysis/plugins/test_tweety_plugins.py
+++ b/tests/unit/argumentation_analysis/plugins/test_tweety_plugins.py
@@ -4,7 +4,6 @@ import json
 import pytest
 from unittest.mock import patch, MagicMock
 
-
 # =====================================================================
 # RankingPlugin Tests
 # =====================================================================
@@ -14,10 +13,9 @@ class TestRankingPlugin:
     """Test RankingPlugin @kernel_function methods."""
 
     def test_list_ranking_methods(self):
-        with patch(
-            "argumentation_analysis.agents.core.logic.ranking_handler.jpype"
-        ):
+        with patch("argumentation_analysis.agents.core.logic.ranking_handler.jpype"):
             from argumentation_analysis.plugins.ranking_plugin import RankingPlugin
+
             plugin = RankingPlugin()
             result = json.loads(plugin.list_ranking_methods())
             assert isinstance(result, list)
@@ -38,24 +36,30 @@ class TestRankingPlugin:
             mock_handler,
         ):
             from argumentation_analysis.plugins.ranking_plugin import RankingPlugin
+
             plugin = RankingPlugin()
-            input_json = json.dumps({
-                "arguments": ["a", "b"],
-                "attacks": [["a", "b"]],
-                "method": "categorizer",
-            })
+            input_json = json.dumps(
+                {
+                    "arguments": ["a", "b"],
+                    "attacks": [["a", "b"]],
+                    "method": "categorizer",
+                }
+            )
             result = json.loads(plugin.rank_arguments(input_json))
             assert result["method"] == "categorizer"
             assert "comparisons" in result
 
     def test_rank_arguments_default_method(self):
         mock_handler = MagicMock()
-        mock_handler.return_value.rank_arguments.return_value = {"method": "categorizer"}
+        mock_handler.return_value.rank_arguments.return_value = {
+            "method": "categorizer"
+        }
         with patch(
             "argumentation_analysis.agents.core.logic.ranking_handler.RankingHandler",
             mock_handler,
         ):
             from argumentation_analysis.plugins.ranking_plugin import RankingPlugin
+
             plugin = RankingPlugin()
             input_json = json.dumps({"arguments": ["a"], "attacks": []})
             plugin.rank_arguments(input_json)
@@ -65,6 +69,7 @@ class TestRankingPlugin:
 
     def test_rank_arguments_invalid_json(self):
         from argumentation_analysis.plugins.ranking_plugin import RankingPlugin
+
         plugin = RankingPlugin()
         with pytest.raises(json.JSONDecodeError):
             plugin.rank_arguments("not valid json")
@@ -80,6 +85,7 @@ class TestASPICPlugin:
 
     def test_list_reasoner_types(self):
         from argumentation_analysis.plugins.aspic_plugin import ASPICPlugin
+
         plugin = ASPICPlugin()
         result = json.loads(plugin.list_aspic_reasoner_types())
         assert result == ["simple", "directional"]
@@ -96,12 +102,15 @@ class TestASPICPlugin:
             mock_handler,
         ):
             from argumentation_analysis.plugins.aspic_plugin import ASPICPlugin
+
             plugin = ASPICPlugin()
-            input_json = json.dumps({
-                "strict_rules": [{"head": "c", "body": ["a", "b"]}],
-                "defeasible_rules": [],
-                "axioms": ["a", "b"],
-            })
+            input_json = json.dumps(
+                {
+                    "strict_rules": [{"head": "c", "body": ["a", "b"]}],
+                    "defeasible_rules": [],
+                    "axioms": ["a", "b"],
+                }
+            )
             result = json.loads(plugin.analyze_aspic(input_json))
             assert result["reasoner_type"] == "simple"
             assert "extensions" in result
@@ -118,17 +127,21 @@ class TestASPICPlugin:
             mock_handler,
         ):
             from argumentation_analysis.plugins.aspic_plugin import ASPICPlugin
+
             plugin = ASPICPlugin()
-            input_json = json.dumps({
-                "strict_rules": [],
-                "defeasible_rules": [{"head": "x", "body": ["y"]}],
-                "reasoner_type": "directional",
-            })
+            input_json = json.dumps(
+                {
+                    "strict_rules": [],
+                    "defeasible_rules": [{"head": "x", "body": ["y"]}],
+                    "reasoner_type": "directional",
+                }
+            )
             result = json.loads(plugin.analyze_aspic(input_json))
             assert result["reasoner_type"] == "directional"
 
     def test_analyze_aspic_invalid_json(self):
         from argumentation_analysis.plugins.aspic_plugin import ASPICPlugin
+
         plugin = ASPICPlugin()
         with pytest.raises(json.JSONDecodeError):
             plugin.analyze_aspic("{bad")
@@ -143,7 +156,10 @@ class TestBeliefRevisionPlugin:
     """Test BeliefRevisionPlugin @kernel_function methods."""
 
     def test_list_revision_methods(self):
-        from argumentation_analysis.plugins.belief_revision_plugin import BeliefRevisionPlugin
+        from argumentation_analysis.plugins.belief_revision_plugin import (
+            BeliefRevisionPlugin,
+        )
+
         plugin = BeliefRevisionPlugin()
         result = json.loads(plugin.list_revision_methods())
         assert result == ["dalal", "levi"]
@@ -161,13 +177,18 @@ class TestBeliefRevisionPlugin:
             "argumentation_analysis.agents.core.logic.belief_revision_handler.BeliefRevisionHandler",
             mock_handler,
         ):
-            from argumentation_analysis.plugins.belief_revision_plugin import BeliefRevisionPlugin
+            from argumentation_analysis.plugins.belief_revision_plugin import (
+                BeliefRevisionPlugin,
+            )
+
             plugin = BeliefRevisionPlugin()
-            input_json = json.dumps({
-                "belief_set": ["p", "q"],
-                "new_belief": "!p",
-                "method": "dalal",
-            })
+            input_json = json.dumps(
+                {
+                    "belief_set": ["p", "q"],
+                    "new_belief": "!p",
+                    "method": "dalal",
+                }
+            )
             result = json.loads(plugin.revise_beliefs(input_json))
             assert result["method"] == "dalal"
             assert "revised" in result
@@ -185,41 +206,60 @@ class TestBeliefRevisionPlugin:
             "argumentation_analysis.agents.core.logic.belief_revision_handler.BeliefRevisionHandler",
             mock_handler,
         ):
-            from argumentation_analysis.plugins.belief_revision_plugin import BeliefRevisionPlugin
+            from argumentation_analysis.plugins.belief_revision_plugin import (
+                BeliefRevisionPlugin,
+            )
+
             plugin = BeliefRevisionPlugin()
-            input_json = json.dumps({
-                "belief_set": ["p", "q"],
-                "formula_to_remove": "p",
-            })
+            input_json = json.dumps(
+                {
+                    "belief_set": ["p", "q"],
+                    "formula_to_remove": "p",
+                }
+            )
             result = json.loads(plugin.contract_beliefs(input_json))
             assert result["operation"] == "contraction"
             assert "contracted" in result
 
     def test_revise_beliefs_levi_method(self):
         mock_handler = MagicMock()
-        mock_handler.return_value.revise.return_value = {"method": "levi", "revised": ["r"]}
+        mock_handler.return_value.revise.return_value = {
+            "method": "levi",
+            "revised": ["r"],
+        }
         with patch(
             "argumentation_analysis.agents.core.logic.belief_revision_handler.BeliefRevisionHandler",
             mock_handler,
         ):
-            from argumentation_analysis.plugins.belief_revision_plugin import BeliefRevisionPlugin
+            from argumentation_analysis.plugins.belief_revision_plugin import (
+                BeliefRevisionPlugin,
+            )
+
             plugin = BeliefRevisionPlugin()
-            input_json = json.dumps({
-                "belief_set": ["p"],
-                "new_belief": "r",
-                "method": "levi",
-            })
+            input_json = json.dumps(
+                {
+                    "belief_set": ["p"],
+                    "new_belief": "r",
+                    "method": "levi",
+                }
+            )
             result = json.loads(plugin.revise_beliefs(input_json))
             assert result["method"] == "levi"
 
     def test_revise_beliefs_invalid_json(self):
-        from argumentation_analysis.plugins.belief_revision_plugin import BeliefRevisionPlugin
+        from argumentation_analysis.plugins.belief_revision_plugin import (
+            BeliefRevisionPlugin,
+        )
+
         plugin = BeliefRevisionPlugin()
         with pytest.raises(json.JSONDecodeError):
             plugin.revise_beliefs("invalid")
 
     def test_contract_beliefs_invalid_json(self):
-        from argumentation_analysis.plugins.belief_revision_plugin import BeliefRevisionPlugin
+        from argumentation_analysis.plugins.belief_revision_plugin import (
+            BeliefRevisionPlugin,
+        )
+
         plugin = BeliefRevisionPlugin()
         with pytest.raises(json.JSONDecodeError):
             plugin.contract_beliefs("invalid")
@@ -235,11 +275,15 @@ class TestToulminPlugin:
 
     def test_plugin_instantiation(self):
         from argumentation_analysis.plugins.toulmin_plugin import ToulminPlugin
+
         plugin = ToulminPlugin()
         assert hasattr(plugin, "analyze_argument")
 
     async def test_analyze_argument_not_implemented(self):
         from argumentation_analysis.plugins.toulmin_plugin import ToulminPlugin
+
         plugin = ToulminPlugin()
         with pytest.raises(NotImplementedError, match="not yet implemented"):
-            await plugin.analyze_argument("The death penalty should be abolished because it is cruel.")
+            await plugin.analyze_argument(
+                "The death penalty should be abolished because it is cruel."
+            )

--- a/tests/unit/argumentation_analysis/reporting/test_document_assembler.py
+++ b/tests/unit/argumentation_analysis/reporting/test_document_assembler.py
@@ -10,8 +10,8 @@ from argumentation_analysis.reporting.document_assembler import (
     UnifiedReportTemplate,
 )
 
-
 # ── ReportMetadata ──
+
 
 class TestReportMetadata:
     def test_required_fields(self):
@@ -51,6 +51,7 @@ class TestReportMetadata:
 
 # ── UnifiedReportTemplate Init ──
 
+
 class TestTemplateInit:
     def test_default_config(self):
         t = UnifiedReportTemplate({})
@@ -77,11 +78,14 @@ class TestTemplateInit:
 
 # ── Render Dispatch ──
 
+
 class TestRenderDispatch:
     @pytest.fixture
     def metadata(self):
         return ReportMetadata(
-            source_component="test", analysis_type="unit", generated_at=datetime(2026, 1, 1)
+            source_component="test",
+            analysis_type="unit",
+            generated_at=datetime(2026, 1, 1),
         )
 
     def test_markdown_format(self, metadata):
@@ -115,6 +119,7 @@ class TestRenderDispatch:
 
 
 # ── Markdown Rendering ──
+
 
 class TestMarkdownRendering:
     @pytest.fixture
@@ -209,11 +214,7 @@ class TestMarkdownRendering:
         assert "72" in result
 
     def test_fallacy_zero_confidence(self, template, metadata):
-        data = {
-            "informal_analysis": {
-                "fallacies": [{"type": "Test", "confidence": 0}]
-            }
-        }
+        data = {"informal_analysis": {"fallacies": [{"type": "Test", "confidence": 0}]}}
         result = template.render(data, metadata)
         assert "Non calculée" in result
 
@@ -291,6 +292,7 @@ class TestMarkdownRendering:
 
 # ── Console Rendering ──
 
+
 class TestConsoleRendering:
     @pytest.fixture
     def template(self):
@@ -299,7 +301,9 @@ class TestConsoleRendering:
     @pytest.fixture
     def metadata(self):
         return ReportMetadata(
-            source_component="system", analysis_type="analysis", generated_at=datetime.now()
+            source_component="system",
+            analysis_type="analysis",
+            generated_at=datetime.now(),
         )
 
     def test_header_bar(self, template, metadata):
@@ -351,6 +355,7 @@ class TestConsoleRendering:
 
 # ── JSON Rendering ──
 
+
 class TestJsonRendering:
     @pytest.fixture
     def template(self):
@@ -359,7 +364,9 @@ class TestJsonRendering:
     @pytest.fixture
     def metadata(self):
         return ReportMetadata(
-            source_component="test", analysis_type="test", generated_at=datetime(2026, 1, 1)
+            source_component="test",
+            analysis_type="test",
+            generated_at=datetime(2026, 1, 1),
         )
 
     def test_valid_json(self, template, metadata):
@@ -382,6 +389,7 @@ class TestJsonRendering:
 
 # ── HTML Rendering ──
 
+
 class TestHtmlRendering:
     @pytest.fixture
     def template(self):
@@ -390,7 +398,9 @@ class TestHtmlRendering:
     @pytest.fixture
     def metadata(self):
         return ReportMetadata(
-            source_component="pipeline", analysis_type="LLM", generated_at=datetime(2026, 1, 1)
+            source_component="pipeline",
+            analysis_type="LLM",
+            generated_at=datetime(2026, 1, 1),
         )
 
     def test_html_structure(self, template, metadata):
@@ -454,6 +464,7 @@ class TestHtmlRendering:
 
 # ── Helper Methods ──
 
+
 class TestHelperMethods:
     @pytest.fixture
     def template(self):
@@ -476,7 +487,11 @@ class TestHelperMethods:
     def test_extract_error_context_found(self, template):
         text = "some prefix predicate 'test' has not been declared some suffix"
         result = template._extract_error_context(text, "predicate")
-        assert "non déclaré" in result.lower() or "not declared" in result.lower() or "déclaré" in result.lower()
+        assert (
+            "non déclaré" in result.lower()
+            or "not declared" in result.lower()
+            or "déclaré" in result.lower()
+        )
 
     def test_extract_error_context_not_found(self, template):
         result = template._extract_error_context("some text", "nonexistent_xyz")
@@ -503,11 +518,24 @@ class TestHelperMethods:
         assert errors == []
 
     def test_is_generic_recommendation_true(self, template):
-        assert template._is_generic_recommendation("Analyse orchestrée complétée avec succès") is True
-        assert template._is_generic_recommendation("Examen des insights avancés recommandé pour l'avenir") is True
+        assert (
+            template._is_generic_recommendation(
+                "Analyse orchestrée complétée avec succès"
+            )
+            is True
+        )
+        assert (
+            template._is_generic_recommendation(
+                "Examen des insights avancés recommandé pour l'avenir"
+            )
+            is True
+        )
 
     def test_is_generic_recommendation_false(self, template):
-        assert template._is_generic_recommendation("Fix the modal logic conversion") is False
+        assert (
+            template._is_generic_recommendation("Fix the modal logic conversion")
+            is False
+        )
 
     def test_count_modal_failures_none(self, template):
         assert template._count_modal_failures({}) == 0
@@ -579,7 +607,10 @@ class TestHelperMethods:
             "orchestration_analysis": {
                 "conversation_log": {
                     "messages": [
-                        {"agent": "ModalLogicAgent", "message": "erreur de conversion Tweety"},
+                        {
+                            "agent": "ModalLogicAgent",
+                            "message": "erreur de conversion Tweety",
+                        },
                     ]
                 }
             }
@@ -600,6 +631,7 @@ class TestHelperMethods:
 
 # ── Orchestration Sections ──
 
+
 class TestOrchestrationRendering:
     @pytest.fixture
     def template(self):
@@ -608,7 +640,9 @@ class TestOrchestrationRendering:
     @pytest.fixture
     def metadata(self):
         return ReportMetadata(
-            source_component="test", analysis_type="test", generated_at=datetime(2026, 1, 1)
+            source_component="test",
+            analysis_type="test",
+            generated_at=datetime(2026, 1, 1),
         )
 
     def test_orchestration_results(self, template, metadata):
@@ -656,7 +690,10 @@ class TestOrchestrationRendering:
                 "status": "partial",
                 "conversation_log": {
                     "messages": [
-                        {"agent": "ModalLogicAgent", "message": "tentative de conversion 1/3 échouée"},
+                        {
+                            "agent": "ModalLogicAgent",
+                            "message": "tentative de conversion 1/3 échouée",
+                        },
                     ]
                 },
             }

--- a/tests/unit/argumentation_analysis/reporting/test_enhanced_real_time_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_enhanced_real_time_trace_analyzer.py
@@ -23,41 +23,53 @@ from argumentation_analysis.reporting.enhanced_real_time_trace_analyzer import (
     get_enhanced_pm_report,
 )
 
-
 # ============================================================
 # ConversationMessage
 # ============================================================
 
+
 class TestConversationMessage:
     def test_basic_fields(self):
-        msg = ConversationMessage(agent_name="Agent1", content="Hello", tour_number=1, phase_id="p1")
+        msg = ConversationMessage(
+            agent_name="Agent1", content="Hello", tour_number=1, phase_id="p1"
+        )
         assert msg.agent_name == "Agent1"
         assert msg.content == "Hello"
         assert msg.tour_number == 1
         assert msg.phase_id == "p1"
 
     def test_default_timestamp(self):
-        msg = ConversationMessage(agent_name="A", content="c", tour_number=1, phase_id="p")
+        msg = ConversationMessage(
+            agent_name="A", content="c", tour_number=1, phase_id="p"
+        )
         assert msg.timestamp > 0
 
     def test_default_tool_calls_count(self):
-        msg = ConversationMessage(agent_name="A", content="c", tour_number=1, phase_id="p")
+        msg = ConversationMessage(
+            agent_name="A", content="c", tour_number=1, phase_id="p"
+        )
         assert msg.tool_calls_count == 0
 
     def test_format_short_content(self):
-        msg = ConversationMessage(agent_name="Agent1", content="Short text", tour_number=2, phase_id="p1")
+        msg = ConversationMessage(
+            agent_name="Agent1", content="Short text", tour_number=2, phase_id="p1"
+        )
         output = msg.to_enhanced_format()
         assert "Agent1" in output
         assert "Tour 2" in output
         assert "Short text" in output
 
     def test_format_long_content_truncated(self):
-        msg = ConversationMessage(agent_name="A", content="x" * 600, tour_number=1, phase_id="p")
+        msg = ConversationMessage(
+            agent_name="A", content="x" * 600, tour_number=1, phase_id="p"
+        )
         output = msg.to_enhanced_format()
         assert "..." in output
 
     def test_format_with_tool_calls(self):
-        msg = ConversationMessage(agent_name="A", content="c", tour_number=1, phase_id="p", tool_calls_count=5)
+        msg = ConversationMessage(
+            agent_name="A", content="c", tour_number=1, phase_id="p", tool_calls_count=5
+        )
         output = msg.to_enhanced_format()
         assert "5 appels d'outils" in output
 
@@ -66,47 +78,83 @@ class TestConversationMessage:
 # StateSnapshot
 # ============================================================
 
+
 class TestStateSnapshot:
     def test_basic_fields(self):
-        snap = StateSnapshot(phase_id="p1", tour_number=1, agent_active="Agent1",
-                             state_variables={"key": "val"}, metadata={"m": 1})
+        snap = StateSnapshot(
+            phase_id="p1",
+            tour_number=1,
+            agent_active="Agent1",
+            state_variables={"key": "val"},
+            metadata={"m": 1},
+        )
         assert snap.phase_id == "p1"
         assert snap.agent_active == "Agent1"
         assert snap.state_variables == {"key": "val"}
 
     def test_markdown_format_numeric(self):
-        snap = StateSnapshot(phase_id="p1", tour_number=1, agent_active="A",
-                             state_variables={"count": 42}, metadata={})
+        snap = StateSnapshot(
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={"count": 42},
+            metadata={},
+        )
         output = snap.to_markdown_format()
         assert "`count`: 42" in output
 
     def test_markdown_format_string(self):
-        snap = StateSnapshot(phase_id="p1", tour_number=1, agent_active="A",
-                             state_variables={"name": "hello"}, metadata={})
+        snap = StateSnapshot(
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={"name": "hello"},
+            metadata={},
+        )
         output = snap.to_markdown_format()
         assert '"hello"' in output
 
     def test_markdown_format_long_string_truncated(self):
-        snap = StateSnapshot(phase_id="p1", tour_number=1, agent_active="A",
-                             state_variables={"text": "z" * 100}, metadata={})
+        snap = StateSnapshot(
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={"text": "z" * 100},
+            metadata={},
+        )
         output = snap.to_markdown_format()
         assert "..." in output
 
     def test_markdown_format_list(self):
-        snap = StateSnapshot(phase_id="p1", tour_number=1, agent_active="A",
-                             state_variables={"items": [1, 2, 3]}, metadata={})
+        snap = StateSnapshot(
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={"items": [1, 2, 3]},
+            metadata={},
+        )
         output = snap.to_markdown_format()
         assert "list(3)" in output
 
     def test_markdown_format_dict(self):
-        snap = StateSnapshot(phase_id="p1", tour_number=1, agent_active="A",
-                             state_variables={"config": {"a": 1}}, metadata={})
+        snap = StateSnapshot(
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={"config": {"a": 1}},
+            metadata={},
+        )
         output = snap.to_markdown_format()
         assert "dict(1)" in output
 
     def test_metadata_in_output(self):
-        snap = StateSnapshot(phase_id="p1", tour_number=3, agent_active="AgentX",
-                             state_variables={}, metadata={"key": "val"})
+        snap = StateSnapshot(
+            phase_id="p1",
+            tour_number=3,
+            agent_active="AgentX",
+            state_variables={},
+            metadata={"key": "val"},
+        )
         output = snap.to_markdown_format()
         assert "Tour**: 3" in output
         assert "AgentX" in output
@@ -116,11 +164,17 @@ class TestStateSnapshot:
 # EnhancedToolCall
 # ============================================================
 
+
 class TestEnhancedToolCall:
     def _make_call(self, **overrides):
         defaults = dict(
-            agent_name="Agent1", tool_name="search", arguments={"q": "test"},
-            result="found", timestamp=1000.0, execution_time_ms=50.0, success=True,
+            agent_name="Agent1",
+            tool_name="search",
+            arguments={"q": "test"},
+            result="found",
+            timestamp=1000.0,
+            execution_time_ms=50.0,
+            success=True,
         )
         defaults.update(overrides)
         return EnhancedToolCall(**defaults)
@@ -245,9 +299,12 @@ class TestEnhancedToolCall:
 # ProjectManagerPhase
 # ============================================================
 
+
 class TestProjectManagerPhase:
     def test_init(self):
-        phase = ProjectManagerPhase(phase_id="p1", phase_name="Analysis", assigned_agents=["A1", "A2"])
+        phase = ProjectManagerPhase(
+            phase_id="p1", phase_name="Analysis", assigned_agents=["A1", "A2"]
+        )
         assert phase.phase_id == "p1"
         assert phase.phase_name == "Analysis"
         assert phase.assigned_agents == ["A1", "A2"]
@@ -258,16 +315,26 @@ class TestProjectManagerPhase:
     def test_add_tool_call(self):
         phase = ProjectManagerPhase(phase_id="p1", phase_name="P", assigned_agents=[])
         call = EnhancedToolCall(
-            agent_name="A", tool_name="t", arguments={},
-            result=None, timestamp=0, execution_time_ms=0, success=True,
+            agent_name="A",
+            tool_name="t",
+            arguments={},
+            result=None,
+            timestamp=0,
+            execution_time_ms=0,
+            success=True,
         )
         phase.add_tool_call(call)
         assert len(phase.tool_calls) == 1
 
     def test_add_state_snapshot(self):
         phase = ProjectManagerPhase(phase_id="p1", phase_name="P", assigned_agents=[])
-        snap = StateSnapshot(phase_id="p1", tour_number=1, agent_active="A",
-                             state_variables={}, metadata={})
+        snap = StateSnapshot(
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={},
+            metadata={},
+        )
         phase.add_state_snapshot(snap)
         assert len(phase.state_snapshots) == 1
 
@@ -288,7 +355,9 @@ class TestProjectManagerPhase:
         assert phase._get_duration() > 0
 
     def test_conversation_format(self):
-        phase = ProjectManagerPhase(phase_id="p1", phase_name="Detection", assigned_agents=["Sherlock"])
+        phase = ProjectManagerPhase(
+            phase_id="p1", phase_name="Detection", assigned_agents=["Sherlock"]
+        )
         output = phase.to_enhanced_conversation_format()
         assert "Detection" in output
         assert "Sherlock" in output
@@ -297,6 +366,7 @@ class TestProjectManagerPhase:
 # ============================================================
 # EnhancedRealTimeTraceAnalyzer
 # ============================================================
+
 
 class TestEnhancedRealTimeTraceAnalyzer:
     @pytest.fixture
@@ -379,7 +449,9 @@ class TestEnhancedRealTimeTraceAnalyzer:
     def test_report_with_data(self, analyzer):
         analyzer.start_capture()
         analyzer.start_pm_phase("p1", "Detection", ["Sherlock"])
-        analyzer.record_enhanced_tool_call("Sherlock", "investigate", {"clue": "x"}, "found", 50.0)
+        analyzer.record_enhanced_tool_call(
+            "Sherlock", "investigate", {"clue": "x"}, "found", 50.0
+        )
         analyzer.capture_state_snapshot("p1", 1, "Sherlock", {"hypothesis": "butler"})
         analyzer.capture_conversation_message("Sherlock", "I found a clue", 1, "p1")
         analyzer.stop_capture()
@@ -413,12 +485,18 @@ class TestEnhancedRealTimeTraceAnalyzer:
 
     def test_save_report_invalid_path(self, analyzer):
         # Use a truly non-existent path (Windows drive that doesn't exist)
-        assert analyzer.save_enhanced_report("Z:\\this_drive_does_not_exist\\path\\report.md") is False
+        assert (
+            analyzer.save_enhanced_report(
+                "Z:\\this_drive_does_not_exist\\path\\report.md"
+            )
+            is False
+        )
 
 
 # ============================================================
 # enhanced_tool_call_tracer decorator
 # ============================================================
+
 
 class TestEnhancedToolCallTracer:
     def test_decorator_disabled(self):
@@ -451,6 +529,7 @@ class TestEnhancedToolCallTracer:
 # ============================================================
 # Module-level helpers
 # ============================================================
+
 
 class TestModuleHelpers:
     def test_start_stop_capture(self):

--- a/tests/unit/argumentation_analysis/reporting/test_enhanced_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_enhanced_trace_analyzer.py
@@ -12,8 +12,8 @@ from argumentation_analysis.reporting.enhanced_real_time_trace_analyzer import (
     EnhancedRealTimeTraceAnalyzer,
 )
 
-
 # ── ConversationMessage ──
+
 
 class TestConversationMessage:
     def test_init(self):
@@ -53,7 +53,10 @@ class TestConversationMessage:
 
     def test_to_enhanced_format_with_tool_calls(self):
         msg = ConversationMessage(
-            agent_name="A", content="c", tour_number=1, phase_id="p",
+            agent_name="A",
+            content="c",
+            tour_number=1,
+            phase_id="p",
             tool_calls_count=5,
         )
         result = msg.to_enhanced_format()
@@ -62,11 +65,15 @@ class TestConversationMessage:
 
 # ── StateSnapshot ──
 
+
 class TestStateSnapshot:
     def test_init(self):
         snap = StateSnapshot(
-            phase_id="p1", tour_number=2, agent_active="AgentB",
-            state_variables={"key": "val"}, metadata={"m": 1},
+            phase_id="p1",
+            tour_number=2,
+            agent_active="AgentB",
+            state_variables={"key": "val"},
+            metadata={"m": 1},
         )
         assert snap.phase_id == "p1"
         assert snap.tour_number == 2
@@ -75,8 +82,11 @@ class TestStateSnapshot:
 
     def test_to_markdown_int(self):
         snap = StateSnapshot(
-            phase_id="p1", tour_number=1, agent_active="A",
-            state_variables={"count": 42}, metadata={},
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={"count": 42},
+            metadata={},
         )
         result = snap.to_markdown_format()
         assert "`count`" in result
@@ -84,48 +94,66 @@ class TestStateSnapshot:
 
     def test_to_markdown_string(self):
         snap = StateSnapshot(
-            phase_id="p1", tour_number=1, agent_active="A",
-            state_variables={"name": "hello world"}, metadata={},
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={"name": "hello world"},
+            metadata={},
         )
         result = snap.to_markdown_format()
         assert '"hello world"' in result
 
     def test_to_markdown_long_string(self):
         snap = StateSnapshot(
-            phase_id="p1", tour_number=1, agent_active="A",
-            state_variables={"text": "a" * 100}, metadata={},
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={"text": "a" * 100},
+            metadata={},
         )
         result = snap.to_markdown_format()
         assert "..." in result
 
     def test_to_markdown_list(self):
         snap = StateSnapshot(
-            phase_id="p1", tour_number=1, agent_active="A",
-            state_variables={"items": [1, 2, 3]}, metadata={},
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={"items": [1, 2, 3]},
+            metadata={},
         )
         result = snap.to_markdown_format()
         assert "list(3)" in result
 
     def test_to_markdown_dict(self):
         snap = StateSnapshot(
-            phase_id="p1", tour_number=1, agent_active="A",
-            state_variables={"data": {"a": 1}}, metadata={},
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={"data": {"a": 1}},
+            metadata={},
         )
         result = snap.to_markdown_format()
         assert "dict(1)" in result
 
     def test_to_markdown_other_type(self):
         snap = StateSnapshot(
-            phase_id="p1", tour_number=1, agent_active="A",
-            state_variables={"obj": object()}, metadata={},
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={"obj": object()},
+            metadata={},
         )
         result = snap.to_markdown_format()
         assert "object" in result
 
     def test_to_markdown_metadata_section(self):
         snap = StateSnapshot(
-            phase_id="analysis", tour_number=3, agent_active="Watson",
-            state_variables={}, metadata={"key": "val"},
+            phase_id="analysis",
+            tour_number=3,
+            agent_active="Watson",
+            state_variables={},
+            metadata={"key": "val"},
         )
         result = snap.to_markdown_format()
         assert "Tour" in result and "3" in result
@@ -134,6 +162,7 @@ class TestStateSnapshot:
 
 
 # ── EnhancedToolCall ──
+
 
 class TestEnhancedToolCall:
     @pytest.fixture
@@ -162,8 +191,13 @@ class TestEnhancedToolCall:
 
     def test_to_enhanced_format_no_args(self):
         tc = EnhancedToolCall(
-            agent_name="A", tool_name="t", arguments={},
-            result=None, timestamp=0, execution_time_ms=10, success=True,
+            agent_name="A",
+            tool_name="t",
+            arguments={},
+            result=None,
+            timestamp=0,
+            execution_time_ms=10,
+            success=True,
         )
         result = tc.to_enhanced_conversation_format()
         assert "aucun argument" in result
@@ -246,6 +280,7 @@ class TestEnhancedToolCall:
 
 # ── ProjectManagerPhase ──
 
+
 class TestProjectManagerPhase:
     def test_init(self):
         phase = ProjectManagerPhase(
@@ -262,8 +297,11 @@ class TestProjectManagerPhase:
             phase_id="p1", phase_name="Test", assigned_agents=[]
         )
         snap = StateSnapshot(
-            phase_id="p1", tour_number=1, agent_active="A",
-            state_variables={}, metadata={},
+            phase_id="p1",
+            tour_number=1,
+            agent_active="A",
+            state_variables={},
+            metadata={},
         )
         phase.add_state_snapshot(snap)
         assert len(phase.state_snapshots) == 1
@@ -273,8 +311,13 @@ class TestProjectManagerPhase:
             phase_id="p1", phase_name="Test", assigned_agents=[]
         )
         tc = EnhancedToolCall(
-            agent_name="A", tool_name="t", arguments={},
-            result=None, timestamp=0, execution_time_ms=10, success=True,
+            agent_name="A",
+            tool_name="t",
+            arguments={},
+            result=None,
+            timestamp=0,
+            execution_time_ms=10,
+            success=True,
         )
         phase.add_tool_call(tc)
         assert len(phase.tool_calls) == 1
@@ -303,7 +346,8 @@ class TestProjectManagerPhase:
 
     def test_to_enhanced_format(self):
         phase = ProjectManagerPhase(
-            phase_id="p1", phase_name="Analysis Phase",
+            phase_id="p1",
+            phase_name="Analysis Phase",
             assigned_agents=["Sherlock", "Watson"],
         )
         result = phase.to_enhanced_conversation_format()
@@ -313,6 +357,7 @@ class TestProjectManagerPhase:
 
 
 # ── EnhancedRealTimeTraceAnalyzer ──
+
 
 class TestEnhancedRealTimeTraceAnalyzer:
     @pytest.fixture
@@ -392,7 +437,9 @@ class TestEnhancedRealTimeTraceAnalyzer:
     def test_record_tool_call_enabled(self, analyzer):
         analyzer.start_capture()
         analyzer.start_pm_phase("p1", "Phase 1", ["A"])
-        analyzer.record_enhanced_tool_call("A", "analyze", {"text": "t"}, "result", 50.0)
+        analyzer.record_enhanced_tool_call(
+            "A", "analyze", {"text": "t"}, "result", 50.0
+        )
         assert analyzer.total_tool_calls == 1
         assert len(analyzer.current_phase.tool_calls) == 1
 
@@ -420,7 +467,9 @@ class TestEnhancedRealTimeTraceAnalyzer:
         analyzer.start_pm_phase("p1", "Rhetoric Analysis", ["Sherlock", "Watson"])
         analyzer.capture_state_snapshot("p1", 1, "Sherlock", {"findings": 3})
         analyzer.record_enhanced_tool_call("Sherlock", "detect", {}, "found 2", 100.0)
-        analyzer.capture_conversation_message("Sherlock", "I found 2 fallacies", 1, "p1")
+        analyzer.capture_conversation_message(
+            "Sherlock", "I found 2 fallacies", 1, "p1"
+        )
         analyzer.stop_capture()
 
         report = analyzer.generate_enhanced_pm_orchestration_report()
@@ -451,7 +500,9 @@ class TestEnhancedRealTimeTraceAnalyzer:
         analyzer.start_pm_phase("p1", "Test", ["A"])
         analyzer.stop_capture()
         # Use a truly non-existent path (Windows drive that doesn't exist)
-        result = analyzer.save_enhanced_report("Z:\\this_drive_does_not_exist\\path\\report.md")
+        result = analyzer.save_enhanced_report(
+            "Z:\\this_drive_does_not_exist\\path\\report.md"
+        )
         assert result is False
 
     def test_metadata_updates(self, analyzer):
@@ -470,8 +521,11 @@ class TestEnhancedRealTimeTraceAnalyzer:
         analyzer.start_pm_phase("extraction", "Extraction Phase", ["FactExtractor"])
         analyzer.capture_state_snapshot("extraction", 1, "FactExtractor", {"facts": 0})
         analyzer.record_enhanced_tool_call(
-            "FactExtractor", "extract_facts", {"text": "sample"},
-            ["fact1", "fact2"], 200.0
+            "FactExtractor",
+            "extract_facts",
+            {"text": "sample"},
+            ["fact1", "fact2"],
+            200.0,
         )
         analyzer.capture_conversation_message(
             "FactExtractor", "Extracted 2 facts", 1, "extraction"

--- a/tests/unit/argumentation_analysis/reporting/test_real_time_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_real_time_trace_analyzer.py
@@ -20,10 +20,10 @@ from argumentation_analysis.reporting.real_time_trace_analyzer import (
     get_conversation_report,
 )
 
-
 # ============================================================
 # RealToolCall — formatting
 # ============================================================
+
 
 class TestRealToolCall:
     def _make_call(self, **overrides):
@@ -175,6 +175,7 @@ class TestRealToolCall:
 # AgentConversationBlock
 # ============================================================
 
+
 class TestAgentConversationBlock:
     def test_init(self):
         block = AgentConversationBlock(agent_name="Agent1")
@@ -185,8 +186,13 @@ class TestAgentConversationBlock:
     def test_add_tool_call(self):
         block = AgentConversationBlock(agent_name="Agent1")
         call = RealToolCall(
-            agent_name="Agent1", tool_name="t", arguments={},
-            result=None, timestamp=0, execution_time_ms=0, success=True,
+            agent_name="Agent1",
+            tool_name="t",
+            arguments={},
+            result=None,
+            timestamp=0,
+            execution_time_ms=0,
+            success=True,
         )
         block.add_tool_call(call)
         assert len(block.tool_calls) == 1
@@ -206,8 +212,13 @@ class TestAgentConversationBlock:
     def test_conversation_format_with_calls(self):
         block = AgentConversationBlock(agent_name="Agent1")
         call = RealToolCall(
-            agent_name="Agent1", tool_name="search", arguments={"q": "test"},
-            result="found", timestamp=0, execution_time_ms=10.0, success=True,
+            agent_name="Agent1",
+            tool_name="search",
+            arguments={"q": "test"},
+            result="found",
+            timestamp=0,
+            execution_time_ms=10.0,
+            success=True,
         )
         block.add_tool_call(call)
         output = block.to_conversation_format()
@@ -217,6 +228,7 @@ class TestAgentConversationBlock:
 # ============================================================
 # RealTimeTraceAnalyzer
 # ============================================================
+
 
 class TestRealTimeTraceAnalyzer:
     @pytest.fixture
@@ -262,8 +274,11 @@ class TestRealTimeTraceAnalyzer:
 
     def test_record_tool_call_disabled(self, analyzer):
         analyzer.record_tool_call(
-            agent_name="A", tool_name="t", arguments={},
-            result=None, execution_time_ms=0,
+            agent_name="A",
+            tool_name="t",
+            arguments={},
+            result=None,
+            execution_time_ms=0,
         )
         assert analyzer.total_tool_calls == 0
 
@@ -272,8 +287,11 @@ class TestRealTimeTraceAnalyzer:
         # Pre-create block to avoid nested lock (source code uses non-reentrant Lock)
         analyzer.start_agent_block("Agent1")
         analyzer.record_tool_call(
-            agent_name="Agent1", tool_name="search", arguments={"q": "test"},
-            result="found", execution_time_ms=15.0,
+            agent_name="Agent1",
+            tool_name="search",
+            arguments={"q": "test"},
+            result="found",
+            execution_time_ms=15.0,
         )
         assert analyzer.total_tool_calls == 1
         assert len(analyzer.conversation_blocks) == 1
@@ -284,14 +302,20 @@ class TestRealTimeTraceAnalyzer:
         # Pre-create blocks to avoid nested lock deadlock
         analyzer.start_agent_block("A1")
         analyzer.record_tool_call(
-            agent_name="A1", tool_name="t1", arguments={},
-            result=None, execution_time_ms=0,
+            agent_name="A1",
+            tool_name="t1",
+            arguments={},
+            result=None,
+            execution_time_ms=0,
         )
         # Switch agent — pre-create block
         analyzer.start_agent_block("A2")
         analyzer.record_tool_call(
-            agent_name="A2", tool_name="t2", arguments={},
-            result=None, execution_time_ms=0,
+            agent_name="A2",
+            tool_name="t2",
+            arguments={},
+            result=None,
+            execution_time_ms=0,
         )
         assert len(analyzer.conversation_blocks) == 2
 
@@ -299,12 +323,18 @@ class TestRealTimeTraceAnalyzer:
         analyzer.start_capture()
         analyzer.start_agent_block("A1")
         analyzer.record_tool_call(
-            agent_name="A1", tool_name="t1", arguments={},
-            result=None, execution_time_ms=0,
+            agent_name="A1",
+            tool_name="t1",
+            arguments={},
+            result=None,
+            execution_time_ms=0,
         )
         analyzer.record_tool_call(
-            agent_name="A1", tool_name="t2", arguments={},
-            result=None, execution_time_ms=0,
+            agent_name="A1",
+            tool_name="t2",
+            arguments={},
+            result=None,
+            execution_time_ms=0,
         )
         assert len(analyzer.conversation_blocks) == 1
         assert len(analyzer.conversation_blocks[0].tool_calls) == 2
@@ -313,9 +343,13 @@ class TestRealTimeTraceAnalyzer:
         analyzer.start_capture()
         analyzer.start_agent_block("A1")
         analyzer.record_tool_call(
-            agent_name="A1", tool_name="fail_tool", arguments={},
-            result=None, execution_time_ms=5.0,
-            success=False, error_message="timeout",
+            agent_name="A1",
+            tool_name="fail_tool",
+            arguments={},
+            result=None,
+            execution_time_ms=5.0,
+            success=False,
+            error_message="timeout",
         )
         call = analyzer.conversation_blocks[0].tool_calls[0]
         assert call.success is False
@@ -343,8 +377,10 @@ class TestRealTimeTraceAnalyzer:
         analyzer.start_capture()
         analyzer.start_agent_block("Sherlock")
         analyzer.record_tool_call(
-            agent_name="Sherlock", tool_name="investigate",
-            arguments={"clue": "footprint"}, result="suspect found",
+            agent_name="Sherlock",
+            tool_name="investigate",
+            arguments={"clue": "footprint"},
+            result="suspect found",
             execution_time_ms=100.0,
         )
         analyzer.stop_capture()
@@ -386,8 +422,11 @@ class TestRealTimeTraceAnalyzer:
         analyzer.start_capture()
         analyzer.start_agent_block("A")
         analyzer.record_tool_call(
-            agent_name="A", tool_name="t", arguments={},
-            result="ok", execution_time_ms=1.0,
+            agent_name="A",
+            tool_name="t",
+            arguments={},
+            result="ok",
+            execution_time_ms=1.0,
         )
         analyzer.stop_capture()
         filepath = str(tmp_path / "report.md")
@@ -399,7 +438,9 @@ class TestRealTimeTraceAnalyzer:
 
     def test_save_report_invalid_path(self, analyzer):
         # Use a truly non-existent path (Windows drive that doesn't exist)
-        result = analyzer.save_conversation_report("Z:\\this_drive_does_not_exist\\path\\report.md")
+        result = analyzer.save_conversation_report(
+            "Z:\\this_drive_does_not_exist\\path\\report.md"
+        )
         assert result is False
 
 
@@ -407,9 +448,11 @@ class TestRealTimeTraceAnalyzer:
 # tool_call_tracer decorator
 # ============================================================
 
+
 class TestToolCallTracer:
     def test_decorator_when_disabled(self):
         """When capture is disabled, function runs normally."""
+
         @tool_call_tracer("Agent", "tool")
         def my_func(x):
             return x * 2
@@ -442,6 +485,7 @@ class TestToolCallTracer:
 # ============================================================
 # Module-level functions
 # ============================================================
+
 
 class TestModuleFunctions:
     def test_start_stop_capture(self):

--- a/tests/unit/argumentation_analysis/reporting/test_section_formatter.py
+++ b/tests/unit/argumentation_analysis/reporting/test_section_formatter.py
@@ -60,6 +60,7 @@ def rich_data(basic_data):
 
 # ── __init__ ──
 
+
 class TestInit:
     def test_default_config(self):
         t = UnifiedReportTemplate({})
@@ -68,17 +69,20 @@ class TestInit:
         assert t.sections == []
 
     def test_custom_config(self):
-        t = UnifiedReportTemplate({
-            "name": "custom",
-            "format": "json",
-            "sections": ["s1"],
-            "metadata": {"key": "val"},
-        })
+        t = UnifiedReportTemplate(
+            {
+                "name": "custom",
+                "format": "json",
+                "sections": ["s1"],
+                "metadata": {"key": "val"},
+            }
+        )
         assert t.name == "custom"
         assert t.format_type == "json"
 
 
 # ── render ──
+
 
 class TestRender:
     def test_render_markdown(self, metadata, basic_data):
@@ -112,6 +116,7 @@ class TestRender:
 
 
 # ── _render_markdown ──
+
 
 class TestRenderMarkdown:
     def test_contains_title(self, metadata, basic_data):
@@ -167,7 +172,9 @@ class TestRenderMarkdown:
             "orchestration_results": {
                 "execution_plan": {
                     "strategy": "sequential",
-                    "steps": [{"agent": "FallacyAgent", "description": "Detect fallacies"}],
+                    "steps": [
+                        {"agent": "FallacyAgent", "description": "Detect fallacies"}
+                    ],
                 },
                 "agent_results": {
                     "FallacyAgent": {
@@ -190,6 +197,7 @@ class TestRenderMarkdown:
 
 
 # ── _render_console ──
+
 
 class TestRenderConsole:
     def test_compact_format(self, metadata, basic_data):
@@ -227,6 +235,7 @@ class TestRenderConsole:
 
 # ── _render_json ──
 
+
 class TestRenderJson:
     def test_valid_json(self, metadata, rich_data):
         t = UnifiedReportTemplate({"format": "json"})
@@ -244,6 +253,7 @@ class TestRenderJson:
 
 
 # ── _render_html ──
+
 
 class TestRenderHtml:
     def test_html_structure(self, metadata, basic_data):
@@ -267,6 +277,7 @@ class TestRenderHtml:
 
 
 # ── Edge Cases ──
+
 
 class TestEdgeCases:
     def test_empty_data(self, metadata):

--- a/tests/unit/argumentation_analysis/reporting/test_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_trace_analyzer.py
@@ -17,8 +17,8 @@ from argumentation_analysis.reporting.trace_analyzer import (
     InformalExploration,
 )
 
-
 # ── ExtractMetadata ──
+
 
 class TestExtractMetadata:
     def test_required_fields(self):
@@ -73,6 +73,7 @@ class TestExtractMetadata:
 
 # ── OrchestrationFlow ──
 
+
 class TestOrchestrationFlow:
     def test_basic(self):
         flow = OrchestrationFlow(
@@ -99,6 +100,7 @@ class TestOrchestrationFlow:
 
 # ── StateEvolution ──
 
+
 class TestStateEvolution:
     def test_basic(self):
         evo = StateEvolution(
@@ -122,6 +124,7 @@ class TestStateEvolution:
 
 # ── QueryResults ──
 
+
 class TestQueryResults:
     def test_basic(self):
         qr = QueryResults(
@@ -137,6 +140,7 @@ class TestQueryResults:
 
 
 # ── ToolCall ──
+
 
 class TestToolCall:
     @pytest.fixture
@@ -228,7 +232,9 @@ class TestToolCall:
         assert "keys" in result
 
     def test_format_args_total_truncation(self):
-        call = ToolCall("t", {f"key_{i}": f"value_{i}" * 10 for i in range(20)}, None, 0, 0, True)
+        call = ToolCall(
+            "t", {f"key_{i}": f"value_{i}" * 10 for i in range(20)}, None, 0, 0, True
+        )
         result = call._format_arguments_intelligently()
         # Very long args string gets truncated to 150 chars
         assert len(result) <= 153  # 150 + "..."
@@ -289,6 +295,7 @@ class TestToolCall:
 
 # ── AgentStep ──
 
+
 class TestAgentStep:
     def test_basic_init(self):
         step = AgentStep(agent_name="sherlock")
@@ -342,6 +349,7 @@ class TestAgentStep:
 
 
 # ── ConversationCapture ──
+
 
 class TestConversationCapture:
     def test_init(self):
@@ -410,6 +418,7 @@ class TestConversationCapture:
 
 # ── InformalExploration ──
 
+
 class TestInformalExploration:
     def test_basic(self):
         exp = InformalExploration(
@@ -450,6 +459,7 @@ class TestInformalExploration:
 
 
 # ── Integration: dataclass serialization ──
+
 
 class TestDataclassSerialization:
     def test_tool_call_roundtrip(self):

--- a/tests/unit/argumentation_analysis/services/test_cache_service.py
+++ b/tests/unit/argumentation_analysis/services/test_cache_service.py
@@ -19,6 +19,7 @@ def service(cache_dir):
 
 # ── Init ──
 
+
 class TestInit:
     def test_creates_dir(self, cache_dir):
         assert not cache_dir.exists()
@@ -32,6 +33,7 @@ class TestInit:
 
 
 # ── get_cache_filepath ──
+
 
 class TestGetCacheFilepath:
     def test_returns_path(self, service):
@@ -52,12 +54,14 @@ class TestGetCacheFilepath:
 
     def test_sha256_based(self, service):
         import hashlib
+
         url = "https://example.com"
         expected = hashlib.sha256(url.encode()).hexdigest() + ".txt"
         assert service.get_cache_filepath(url).name == expected
 
 
 # ── save_to_cache / load_from_cache ──
+
 
 class TestSaveAndLoad:
     def test_roundtrip(self, service):
@@ -96,6 +100,7 @@ class TestSaveAndLoad:
 
 # ── clear_cache ──
 
+
 class TestClearCache:
     def test_clear_specific_url(self, service):
         url = "https://example.com"
@@ -126,6 +131,7 @@ class TestClearCache:
 
 # ── get_cache_size ──
 
+
 class TestGetCacheSize:
     def test_empty_cache(self, service):
         count, size = service.get_cache_size()
@@ -147,6 +153,7 @@ class TestGetCacheSize:
 
 # ── get_cache_info ──
 
+
 class TestGetCacheInfo:
     def test_empty_info(self, service):
         info = service.get_cache_info()
@@ -159,6 +166,7 @@ class TestGetCacheInfo:
 
 
 # ── _format_size ──
+
 
 class TestFormatSize:
     def test_bytes(self, service):

--- a/tests/unit/argumentation_analysis/services/test_crypto_service.py
+++ b/tests/unit/argumentation_analysis/services/test_crypto_service.py
@@ -24,6 +24,7 @@ def svc_no_key():
 
 # ── Init ──
 
+
 class TestInit:
     def test_init_with_key(self, key):
         svc = CryptoService(encryption_key=key)
@@ -47,6 +48,7 @@ class TestInit:
 
 
 # ── Key management ──
+
 
 class TestKeyManagement:
     def test_set_encryption_key(self, svc_no_key, key):
@@ -106,6 +108,7 @@ class TestKeyManagement:
 
 # ── Encrypt / Decrypt ──
 
+
 class TestEncryptDecrypt:
     def test_roundtrip(self, svc):
         data = b"Hello, World!"
@@ -150,6 +153,7 @@ class TestEncryptDecrypt:
 
 
 # ── JSON encrypt/compress ──
+
 
 class TestJsonEncryptCompress:
     def test_roundtrip_dict(self, svc):

--- a/tests/unit/argumentation_analysis/services/test_fact_verification_service.py
+++ b/tests/unit/argumentation_analysis/services/test_fact_verification_service.py
@@ -17,16 +17,21 @@ from argumentation_analysis.services.fact_verification_service import (
 )
 import argumentation_analysis.services.fact_verification_service as fvs_module
 
-
 # ============================================================
 # VerificationStatus enum
 # ============================================================
 
+
 class TestVerificationStatus:
     def test_all_values(self):
         expected = {
-            "verified_true", "verified_false", "partially_true",
-            "disputed", "unverifiable", "insufficient_info", "error",
+            "verified_true",
+            "verified_false",
+            "partially_true",
+            "disputed",
+            "unverifiable",
+            "insufficient_info",
+            "error",
         }
         assert {vs.value for vs in VerificationStatus} == expected
 
@@ -46,11 +51,15 @@ class TestVerificationStatus:
 # SourceReliability enum
 # ============================================================
 
+
 class TestSourceReliability:
     def test_all_values(self):
         expected = {
-            "highly_reliable", "moderately_reliable",
-            "questionable", "unreliable", "unknown",
+            "highly_reliable",
+            "moderately_reliable",
+            "questionable",
+            "unreliable",
+            "unknown",
         }
         assert {sr.value for sr in SourceReliability} == expected
 
@@ -64,6 +73,7 @@ class TestSourceReliability:
 # ============================================================
 # VerificationResult dataclass
 # ============================================================
+
 
 class TestVerificationResult:
     @pytest.fixture
@@ -116,6 +126,7 @@ class TestVerificationResult:
 # FactVerificationService
 # ============================================================
 
+
 class TestFactVerificationService:
     def test_init_default_config(self):
         service = FactVerificationService()
@@ -130,29 +141,53 @@ class TestFactVerificationService:
     def test_source_reliability_map_contains_known_sources(self):
         service = FactVerificationService()
         assert "wikipedia.org" in service.source_reliability_map
-        assert service.source_reliability_map["wikipedia.org"] is SourceReliability.HIGHLY_RELIABLE
+        assert (
+            service.source_reliability_map["wikipedia.org"]
+            is SourceReliability.HIGHLY_RELIABLE
+        )
         assert "lemonde.fr" in service.source_reliability_map
         assert "huffingtonpost.fr" in service.source_reliability_map
-        assert service.source_reliability_map["huffingtonpost.fr"] is SourceReliability.MODERATELY_RELIABLE
+        assert (
+            service.source_reliability_map["huffingtonpost.fr"]
+            is SourceReliability.MODERATELY_RELIABLE
+        )
 
     def test_assess_source_reliability_known(self):
         service = FactVerificationService()
-        assert service._assess_source_reliability("wikipedia.org") is SourceReliability.HIGHLY_RELIABLE
-        assert service._assess_source_reliability("bbc.com") is SourceReliability.HIGHLY_RELIABLE
-        assert service._assess_source_reliability("huffingtonpost.fr") is SourceReliability.MODERATELY_RELIABLE
+        assert (
+            service._assess_source_reliability("wikipedia.org")
+            is SourceReliability.HIGHLY_RELIABLE
+        )
+        assert (
+            service._assess_source_reliability("bbc.com")
+            is SourceReliability.HIGHLY_RELIABLE
+        )
+        assert (
+            service._assess_source_reliability("huffingtonpost.fr")
+            is SourceReliability.MODERATELY_RELIABLE
+        )
 
     def test_assess_source_reliability_unknown(self):
         service = FactVerificationService()
-        assert service._assess_source_reliability("randomsite.xyz") is SourceReliability.UNKNOWN
+        assert (
+            service._assess_source_reliability("randomsite.xyz")
+            is SourceReliability.UNKNOWN
+        )
 
     def test_assess_source_reliability_case_insensitive(self):
         service = FactVerificationService()
-        assert service._assess_source_reliability("WIKIPEDIA.ORG") is SourceReliability.HIGHLY_RELIABLE
+        assert (
+            service._assess_source_reliability("WIKIPEDIA.ORG")
+            is SourceReliability.HIGHLY_RELIABLE
+        )
 
     def test_assess_source_reliability_subdomain(self):
         service = FactVerificationService()
         # "bbc.com" is in map, so "news.bbc.com" should match
-        assert service._assess_source_reliability("news.bbc.com") is SourceReliability.HIGHLY_RELIABLE
+        assert (
+            service._assess_source_reliability("news.bbc.com")
+            is SourceReliability.HIGHLY_RELIABLE
+        )
 
     @pytest.mark.asyncio
     async def test_verify_claim(self):
@@ -183,6 +218,7 @@ class TestFactVerificationService:
 # ============================================================
 # get_verification_service singleton
 # ============================================================
+
 
 class TestGetVerificationService:
     def setup_method(self):

--- a/tests/unit/argumentation_analysis/services/test_fallacy_family_definitions.py
+++ b/tests/unit/argumentation_analysis/services/test_fallacy_family_definitions.py
@@ -16,11 +16,11 @@ from argumentation_analysis.services.fallacy_family_definitions import (
 )
 from argumentation_analysis.services.fallacy_taxonomy_service import FallacyFamily
 
-
 ALL_FAMILIES = list(FallacyFamily)
 
 
 # ── FALLACY_FAMILY_SEVERITY ──
+
 
 class TestSeverityDictionary:
     def test_all_families_present(self):
@@ -32,7 +32,9 @@ class TestSeverityDictionary:
 
     def test_base_severity_range(self):
         for family, info in FALLACY_FAMILY_SEVERITY.items():
-            assert 0.0 <= info["base_severity"] <= 1.0, f"{family} base_severity out of range"
+            assert (
+                0.0 <= info["base_severity"] <= 1.0
+            ), f"{family} base_severity out of range"
 
     def test_context_multipliers_range(self):
         for family, info in FALLACY_FAMILY_SEVERITY.items():
@@ -46,7 +48,9 @@ class TestSeverityDictionary:
 
     def test_all_have_keywords_medium(self):
         for family, info in FALLACY_FAMILY_SEVERITY.items():
-            assert "keywords_medium_severity" in info, f"{family} missing medium keywords"
+            assert (
+                "keywords_medium_severity" in info
+            ), f"{family} missing medium keywords"
             assert len(info["keywords_medium_severity"]) > 0
 
     def test_all_have_keywords_low(self):
@@ -71,6 +75,7 @@ class TestSeverityDictionary:
 
 # ── FALLACY_FAMILY_KEYWORDS ──
 
+
 class TestKeywordsDictionary:
     def test_all_families_present(self):
         for family in ALL_FAMILIES:
@@ -81,15 +86,21 @@ class TestKeywordsDictionary:
 
     def test_all_have_primary(self):
         for family, kw in FALLACY_FAMILY_KEYWORDS.items():
-            assert "primary" in kw and len(kw["primary"]) > 0, f"{family} missing primary"
+            assert (
+                "primary" in kw and len(kw["primary"]) > 0
+            ), f"{family} missing primary"
 
     def test_all_have_secondary(self):
         for family, kw in FALLACY_FAMILY_KEYWORDS.items():
-            assert "secondary" in kw and len(kw["secondary"]) > 0, f"{family} missing secondary"
+            assert (
+                "secondary" in kw and len(kw["secondary"]) > 0
+            ), f"{family} missing secondary"
 
     def test_all_have_patterns(self):
         for family, kw in FALLACY_FAMILY_KEYWORDS.items():
-            assert "patterns" in kw and len(kw["patterns"]) > 0, f"{family} missing patterns"
+            assert (
+                "patterns" in kw and len(kw["patterns"]) > 0
+            ), f"{family} missing patterns"
 
     def test_patterns_are_valid_regex(self):
         for family, kw in FALLACY_FAMILY_KEYWORDS.items():
@@ -117,10 +128,13 @@ class TestKeywordsDictionary:
     def test_no_duplicate_primary_keywords_within_family(self):
         for family, kw in FALLACY_FAMILY_KEYWORDS.items():
             primary = kw["primary"]
-            assert len(primary) == len(set(primary)), f"{family} has duplicate primary keywords"
+            assert len(primary) == len(
+                set(primary)
+            ), f"{family} has duplicate primary keywords"
 
 
 # ── FALLACY_FAMILY_CONTEXTS ──
+
 
 class TestContextsDictionary:
     def test_all_families_present(self):
@@ -151,6 +165,7 @@ class TestContextsDictionary:
 
 # ── FALLACY_FAMILY_METRICS ──
 
+
 class TestMetricsDictionary:
     def test_all_families_present(self):
         for family in ALL_FAMILIES:
@@ -162,13 +177,17 @@ class TestMetricsDictionary:
     def test_all_metrics_have_description_and_weight(self):
         for family, metrics in FALLACY_FAMILY_METRICS.items():
             for metric_name, metric_info in metrics.items():
-                assert "description" in metric_info, f"{family}/{metric_name} missing description"
+                assert (
+                    "description" in metric_info
+                ), f"{family}/{metric_name} missing description"
                 assert "weight" in metric_info, f"{family}/{metric_name} missing weight"
 
     def test_weights_sum_to_one(self):
         for family, metrics in FALLACY_FAMILY_METRICS.items():
             total = sum(m["weight"] for m in metrics.values())
-            assert abs(total - 1.0) < 0.01, f"{family} weights sum to {total}, expected 1.0"
+            assert (
+                abs(total - 1.0) < 0.01
+            ), f"{family} weights sum to {total}, expected 1.0"
 
     def test_weights_positive(self):
         for family, metrics in FALLACY_FAMILY_METRICS.items():
@@ -187,6 +206,7 @@ class TestMetricsDictionary:
 
 
 # ── Helper Functions ──
+
 
 class TestGetFamilySeverityInfo:
     def test_known_family(self):

--- a/tests/unit/argumentation_analysis/services/test_fallacy_taxonomy_service.py
+++ b/tests/unit/argumentation_analysis/services/test_fallacy_taxonomy_service.py
@@ -11,8 +11,8 @@ from argumentation_analysis.services.fallacy_taxonomy_service import (
     get_taxonomy_manager,
 )
 
-
 # ── FallacyFamily Enum ──
+
 
 class TestFallacyFamily:
     def test_has_eight_families(self):
@@ -33,7 +33,9 @@ class TestFallacyFamily:
         assert actual == expected
 
     def test_by_value(self):
-        assert FallacyFamily("authority_popularity") == FallacyFamily.AUTHORITY_POPULARITY
+        assert (
+            FallacyFamily("authority_popularity") == FallacyFamily.AUTHORITY_POPULARITY
+        )
         assert FallacyFamily("emotional_appeals") == FallacyFamily.EMOTIONAL_APPEALS
 
     def test_invalid_value_raises(self):
@@ -42,6 +44,7 @@ class TestFallacyFamily:
 
 
 # ── ClassifiedFallacy ──
+
 
 class TestClassifiedFallacy:
     @pytest.fixture
@@ -77,11 +80,16 @@ class TestClassifiedFallacy:
 
     def test_to_dict_string_family(self):
         f = ClassifiedFallacy(
-            taxonomy_key=1, name="n", nom_vulgarise="nv",
+            taxonomy_key=1,
+            name="n",
+            nom_vulgarise="nv",
             family="string_family",
-            confidence=0.5, description="d",
-            severity="Moyenne", context_relevance=0.5,
-            family_pattern_score=0.5, detection_method="m",
+            confidence=0.5,
+            description="d",
+            severity="Moyenne",
+            context_relevance=0.5,
+            family_pattern_score=0.5,
+            detection_method="m",
         )
         d = f.to_dict()
         assert d["family"] == "string_family"  # no .value call
@@ -89,14 +97,22 @@ class TestClassifiedFallacy:
     def test_to_dict_all_keys(self, fallacy):
         d = fallacy.to_dict()
         expected_keys = {
-            "taxonomy_key", "name", "nom_vulgarise", "family",
-            "confidence", "description", "severity",
-            "context_relevance", "family_pattern_score", "detection_method",
+            "taxonomy_key",
+            "name",
+            "nom_vulgarise",
+            "family",
+            "confidence",
+            "description",
+            "severity",
+            "context_relevance",
+            "family_pattern_score",
+            "detection_method",
         }
         assert set(d.keys()) == expected_keys
 
 
 # ── FallacyTaxonomyManager ──
+
 
 class TestFallacyTaxonomyManager:
     @pytest.fixture
@@ -152,9 +168,11 @@ class TestFallacyTaxonomyManager:
 
 # ── get_taxonomy_manager singleton ──
 
+
 class TestGetTaxonomyManager:
     def test_returns_manager(self):
         import argumentation_analysis.services.fallacy_taxonomy_service as mod
+
         mod._global_taxonomy_manager = None
         with patch(
             "argumentation_analysis.services.fallacy_taxonomy_service.get_global_detector",
@@ -165,6 +183,7 @@ class TestGetTaxonomyManager:
 
     def test_singleton(self):
         import argumentation_analysis.services.fallacy_taxonomy_service as mod
+
         mod._global_taxonomy_manager = None
         with patch(
             "argumentation_analysis.services.fallacy_taxonomy_service.get_global_detector",

--- a/tests/unit/argumentation_analysis/services/test_flask_service_integration.py
+++ b/tests/unit/argumentation_analysis/services/test_flask_service_integration.py
@@ -8,9 +8,9 @@ import pytest
 from unittest.mock import MagicMock, patch
 from datetime import datetime
 
-
 # Patch heavy imports before importing the module
 import sys
+
 _mock_logic = MagicMock()
 _mock_group_chat = MagicMock()
 _orig_logic = sys.modules.get("argumentation_analysis.services.logic_service")
@@ -40,6 +40,7 @@ else:
 # Initialization
 # ============================================================
 
+
 class TestInit:
     def test_default_init(self):
         integrator = FlaskServiceIntegrator()
@@ -57,6 +58,7 @@ class TestInit:
 # ============================================================
 # get_health_status
 # ============================================================
+
 
 class TestGetHealthStatus:
     def test_empty_services(self):
@@ -110,6 +112,7 @@ class TestGetHealthStatus:
 # get_detailed_health_status
 # ============================================================
 
+
 class TestGetDetailedHealthStatus:
     def test_has_timestamp(self):
         integrator = FlaskServiceIntegrator()
@@ -135,6 +138,7 @@ class TestGetDetailedHealthStatus:
 # get_service_health
 # ============================================================
 
+
 class TestGetServiceHealth:
     def test_existing_service(self):
         integrator = FlaskServiceIntegrator()
@@ -157,6 +161,7 @@ class TestGetServiceHealth:
 # get_service
 # ============================================================
 
+
 class TestGetService:
     def test_existing_service(self):
         integrator = FlaskServiceIntegrator()
@@ -172,6 +177,7 @@ class TestGetService:
 # ============================================================
 # is_service_healthy
 # ============================================================
+
 
 class TestIsServiceHealthy:
     def test_healthy(self):
@@ -192,6 +198,7 @@ class TestIsServiceHealthy:
 # ============================================================
 # _register_services_to_app
 # ============================================================
+
 
 class TestRegisterServicesToApp:
     def test_no_app_raises(self):
@@ -225,6 +232,7 @@ class TestRegisterServicesToApp:
 # ============================================================
 # _perform_initial_healthcheck
 # ============================================================
+
 
 class TestPerformInitialHealthcheck:
     def test_updates_healthy_service(self):
@@ -260,6 +268,7 @@ class TestPerformInitialHealthcheck:
 # refresh_health_status
 # ============================================================
 
+
 class TestRefreshHealthStatus:
     def test_returns_health_status(self):
         integrator = FlaskServiceIntegrator()
@@ -271,6 +280,7 @@ class TestRefreshHealthStatus:
 # ============================================================
 # Module-level utilities
 # ============================================================
+
 
 class TestModuleUtilities:
     def test_service_integrator_singleton(self):

--- a/tests/unit/argumentation_analysis/services/test_jtms_service.py
+++ b/tests/unit/argumentation_analysis/services/test_jtms_service.py
@@ -22,6 +22,7 @@ async def service_with_instance(service):
 
 # ── __init__ ──
 
+
 class TestInit:
     def test_initial_state(self, service):
         assert service.instances == {}
@@ -30,6 +31,7 @@ class TestInit:
 
 
 # ── create_jtms_instance ──
+
 
 class TestCreateJTMSInstance:
     @pytest.mark.asyncio
@@ -58,6 +60,7 @@ class TestCreateJTMSInstance:
 
 
 # ── create_belief ──
+
 
 class TestCreateBelief:
     @pytest.mark.asyncio
@@ -99,6 +102,7 @@ class TestCreateBelief:
 
 
 # ── add_justification ──
+
 
 class TestAddJustification:
     @pytest.mark.asyncio
@@ -147,6 +151,7 @@ class TestAddJustification:
 
 # ── explain_belief ──
 
+
 class TestExplainBelief:
     @pytest.mark.asyncio
     async def test_explains_belief_no_justifications(self, service):
@@ -180,6 +185,7 @@ class TestExplainBelief:
 
 
 # ── query_beliefs ──
+
 
 class TestQueryBeliefs:
     @pytest.mark.asyncio
@@ -234,6 +240,7 @@ class TestQueryBeliefs:
 
 # ── get_jtms_state ──
 
+
 class TestGetJTMSState:
     @pytest.mark.asyncio
     async def test_empty_state(self, service):
@@ -274,6 +281,7 @@ class TestGetJTMSState:
 
 # ── set_belief_validity ──
 
+
 class TestSetBeliefValidity:
     @pytest.mark.asyncio
     async def test_changes_validity(self, service):
@@ -297,6 +305,7 @@ class TestSetBeliefValidity:
 
 
 # ── remove_belief ──
+
 
 class TestRemoveBelief:
     @pytest.mark.asyncio
@@ -329,6 +338,7 @@ class TestRemoveBelief:
 
 # ── export_jtms_state ──
 
+
 class TestExportJTMSState:
     @pytest.mark.asyncio
     async def test_export_json(self, service):
@@ -359,6 +369,7 @@ class TestExportJTMSState:
 
 
 # ── import_jtms_state ──
+
 
 class TestImportJTMSState:
     @pytest.mark.asyncio
@@ -402,6 +413,7 @@ class TestImportJTMSState:
 
 # ── get_instance_ids ──
 
+
 class TestGetInstanceIds:
     @pytest.mark.asyncio
     async def test_no_instances(self, service):
@@ -426,6 +438,7 @@ class TestGetInstanceIds:
 
 # ── cleanup_instance ──
 
+
 class TestCleanupInstance:
     @pytest.mark.asyncio
     async def test_cleanup_existing(self, service):
@@ -442,6 +455,7 @@ class TestCleanupInstance:
 
 
 # ── Integration ──
+
 
 class TestJTMSServiceIntegration:
     @pytest.mark.asyncio

--- a/tests/unit/argumentation_analysis/services/test_jtms_session_manager.py
+++ b/tests/unit/argumentation_analysis/services/test_jtms_session_manager.py
@@ -29,6 +29,7 @@ async def session(manager):
 
 # ── __init__ ──
 
+
 class TestInit:
     def test_bidirectional_injection(self, service, tmp_path):
         mgr = JTMSSessionManager(service, storage_path=str(tmp_path))
@@ -50,6 +51,7 @@ class TestInit:
 
 
 # ── create_session ──
+
 
 class TestCreateSession:
     @pytest.mark.asyncio
@@ -104,6 +106,7 @@ class TestCreateSession:
 
 # ── get_session ──
 
+
 class TestGetSession:
     @pytest.mark.asyncio
     async def test_get_existing_session(self, manager):
@@ -148,6 +151,7 @@ class TestGetSession:
 
 # ── list_sessions ──
 
+
 class TestListSessions:
     @pytest.mark.asyncio
     async def test_list_all(self, manager):
@@ -188,6 +192,7 @@ class TestListSessions:
 
 
 # ── create_checkpoint ──
+
 
 class TestCreateCheckpoint:
     @pytest.mark.asyncio
@@ -230,6 +235,7 @@ class TestCreateCheckpoint:
 
 
 # ── restore_checkpoint ──
+
 
 class TestRestoreCheckpoint:
     @pytest.mark.asyncio
@@ -276,6 +282,7 @@ class TestRestoreCheckpoint:
 
 
 # ── delete_session ──
+
 
 class TestDeleteSession:
     @pytest.mark.asyncio
@@ -324,6 +331,7 @@ class TestDeleteSession:
 
 # ── update_session_metadata ──
 
+
 class TestUpdateSessionMetadata:
     @pytest.mark.asyncio
     async def test_updates_metadata(self, manager):
@@ -354,6 +362,7 @@ class TestUpdateSessionMetadata:
 
 
 # ── add_jtms_instance_to_session ──
+
 
 class TestAddJTMSInstanceToSession:
     @pytest.mark.asyncio
@@ -386,6 +395,7 @@ class TestAddJTMSInstanceToSession:
 
 # ── cleanup_expired_sessions ──
 
+
 class TestCleanupExpiredSessions:
     @pytest.mark.asyncio
     async def test_no_expired(self, manager):
@@ -398,6 +408,7 @@ class TestCleanupExpiredSessions:
         sid = await manager.create_session("watson")
         # Set last_accessed to 48 hours ago
         from datetime import datetime, timedelta
+
         old_time = (datetime.now() - timedelta(hours=48)).isoformat()
         manager.sessions[sid]["last_accessed"] = old_time
         count = await manager.cleanup_expired_sessions()
@@ -408,6 +419,7 @@ class TestCleanupExpiredSessions:
     async def test_locked_sessions_not_cleaned(self, manager):
         sid = await manager.create_session("watson")
         from datetime import datetime, timedelta
+
         old_time = (datetime.now() - timedelta(hours=48)).isoformat()
         manager.sessions[sid]["last_accessed"] = old_time
         manager.sessions[sid]["status"] = "locked"
@@ -416,6 +428,7 @@ class TestCleanupExpiredSessions:
 
 
 # ── Disk persistence ──
+
 
 class TestDiskPersistence:
     @pytest.mark.asyncio
@@ -468,6 +481,7 @@ class TestDiskPersistence:
 
 
 # ── Integration ──
+
 
 class TestSessionManagerIntegration:
     @pytest.mark.asyncio

--- a/tests/unit/argumentation_analysis/services/test_logic_service.py
+++ b/tests/unit/argumentation_analysis/services/test_logic_service.py
@@ -21,6 +21,7 @@ def initialized_service(service):
 
 # ── __init__ ──
 
+
 class TestInit:
     def test_initial_state(self, service):
         assert service.active_sessions == {}
@@ -32,6 +33,7 @@ class TestInit:
 
 
 # ── initialize_logic_agents ──
+
 
 class TestInitializeLogicAgents:
     def test_default_config(self, service):
@@ -50,6 +52,7 @@ class TestInitializeLogicAgents:
 
 
 # ── analyze_text_logic ──
+
 
 class TestAnalyzeTextLogic:
     def test_propositional_analysis(self, initialized_service):
@@ -94,6 +97,7 @@ class TestAnalyzeTextLogic:
 
 # ── validate_formula ──
 
+
 class TestValidateFormula:
     def test_propositional(self, service):
         valid, msg = service.validate_formula("p => q", "propositional")
@@ -114,6 +118,7 @@ class TestValidateFormula:
 
 
 # ── execute_query ──
+
 
 class TestExecuteQuery:
     def test_propositional_query(self, service):
@@ -143,6 +148,7 @@ class TestExecuteQuery:
 
 # ── get_service_status ──
 
+
 class TestGetServiceStatus:
     def test_initial_status(self, service):
         status = service.get_service_status()
@@ -162,6 +168,7 @@ class TestGetServiceStatus:
 
 # ── clear_cache ──
 
+
 class TestClearCache:
     def test_clears_cache(self, initialized_service):
         initialized_service.analyze_text_logic("text", "propositional")
@@ -172,6 +179,7 @@ class TestClearCache:
 
 
 # ── Circuit Breaker ──
+
 
 class TestCircuitBreaker:
     def test_initially_closed(self, service):
@@ -198,6 +206,7 @@ class TestCircuitBreaker:
 
 # ── Fallback ──
 
+
 class TestFallback:
     def test_fallback_result(self, service):
         result = service._get_fallback_analysis_result("text", "propositional")
@@ -205,7 +214,9 @@ class TestFallback:
         assert result["success"] is True
 
     def test_fallback_with_error(self, service):
-        result = service._get_fallback_analysis_result("text", "propositional", "test error")
+        result = service._get_fallback_analysis_result(
+            "text", "propositional", "test error"
+        )
         assert result["error"] == "test error"
 
     def test_fallback_disabled(self, service):
@@ -223,6 +234,7 @@ class TestFallback:
 
 # ── analyze_text_logic_async ──
 
+
 class TestAnalyzeTextLogicAsync:
     def test_async_with_circuit_breaker_open(self, service):
         for _ in range(5):
@@ -238,6 +250,7 @@ class TestAnalyzeTextLogicAsync:
 
 # ── execute_multiple_queries_async ──
 
+
 class TestExecuteMultipleQueriesAsync:
     def test_multiple_queries(self, service):
         queries = [
@@ -249,6 +262,7 @@ class TestExecuteMultipleQueriesAsync:
 
 
 # ── validate_and_sanitize_input ──
+
 
 class TestValidateAndSanitizeInput:
     def test_valid_input(self, service):
@@ -272,35 +286,44 @@ class TestValidateAndSanitizeInput:
 
     def test_text_truncated(self, service):
         long_text = "A" * 20000
-        valid, text, lt = service.validate_and_sanitize_input(long_text, "propositional")
+        valid, text, lt = service.validate_and_sanitize_input(
+            long_text, "propositional"
+        )
         assert valid is True
         assert len(text) == 10000
 
     def test_text_stripped(self, service):
-        valid, text, lt = service.validate_and_sanitize_input("  hello  ", "propositional")
+        valid, text, lt = service.validate_and_sanitize_input(
+            "  hello  ", "propositional"
+        )
         assert text == "hello"
 
 
 # ── _determine_logic_type ──
 
+
 class TestDetermineLogicType:
-    @pytest.mark.parametrize("text,expected", [
-        ("forall x P(x)", "first_order"),
-        ("exists y Q(y)", "first_order"),
-        ("∀x P(x)", "first_order"),
-        ("∃y Q(y)", "first_order"),
-        ("necessarily p", "modal"),
-        ("possibly q", "modal"),
-        ("□p", "modal"),
-        ("◇q", "modal"),
-        ("simple text", "propositional"),
-    ])
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("forall x P(x)", "first_order"),
+            ("exists y Q(y)", "first_order"),
+            ("∀x P(x)", "first_order"),
+            ("∃y Q(y)", "first_order"),
+            ("necessarily p", "modal"),
+            ("possibly q", "modal"),
+            ("□p", "modal"),
+            ("◇q", "modal"),
+            ("simple text", "propositional"),
+        ],
+    )
     def test_detection(self, service, text, expected):
         result = service._determine_logic_type(text)
         assert result == expected
 
 
 # ── shutdown ──
+
 
 class TestShutdown:
     def test_shutdown_clears_state(self, initialized_service):
@@ -313,6 +336,7 @@ class TestShutdown:
 
 
 # ── Integration ──
+
 
 class TestLogicServiceIntegration:
     def test_full_workflow(self, service):

--- a/tests/unit/argumentation_analysis/services/test_mcp_server.py
+++ b/tests/unit/argumentation_analysis/services/test_mcp_server.py
@@ -15,10 +15,10 @@ from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
 
 import pytest
 
-
 # ---------------------------------------------------------------------------
 # 1. safe_serialize tests
 # ---------------------------------------------------------------------------
+
 
 class TestSafeSerialize:
     """Tests for _serialization.safe_serialize."""
@@ -27,6 +27,7 @@ class TestSafeSerialize:
         from argumentation_analysis.services.mcp_server.tools._serialization import (
             safe_serialize,
         )
+
         return safe_serialize
 
     def test_none(self):
@@ -128,6 +129,7 @@ class TestSafeSerialize:
 # 2. SessionManager tests
 # ---------------------------------------------------------------------------
 
+
 class TestSessionManager:
     """Tests for session_manager.SessionManager."""
 
@@ -135,6 +137,7 @@ class TestSessionManager:
         from argumentation_analysis.services.mcp_server.session_manager import (
             SessionManager,
         )
+
         return SessionManager(**kwargs)
 
     def test_create_session_returns_state(self):
@@ -236,6 +239,7 @@ class TestSessionManager:
         from argumentation_analysis.services.mcp_server.session_manager import (
             SessionState,
         )
+
         ss = SessionState(
             session_id="test",
             created_at=1.0,
@@ -253,6 +257,7 @@ class TestSessionManager:
 # 3. AppServices tests
 # ---------------------------------------------------------------------------
 
+
 class TestAppServices:
     """Tests for main.AppServices."""
 
@@ -261,9 +266,11 @@ class TestAppServices:
     @patch("argumentation_analysis.services.mcp_server.main.ValidationService")
     @patch("argumentation_analysis.services.mcp_server.main.AnalysisService")
     @patch("argumentation_analysis.services.mcp_server.main.LogicService")
-    def test_init_creates_services(self, mock_logic, mock_analysis,
-                                    mock_validation, mock_fallacy, mock_framework):
+    def test_init_creates_services(
+        self, mock_logic, mock_analysis, mock_validation, mock_fallacy, mock_framework
+    ):
         from argumentation_analysis.services.mcp_server.main import AppServices
+
         app = AppServices()
         mock_logic.assert_called_once()
         mock_analysis.assert_called_once()
@@ -277,8 +284,15 @@ class TestAppServices:
     @patch("argumentation_analysis.services.mcp_server.main.AnalysisService")
     @patch("argumentation_analysis.services.mcp_server.main.LogicService")
     @patch("argumentation_analysis.services.mcp_server.main.jpype")
-    def test_is_healthy_jvm_running(self, mock_jpype, mock_logic, mock_analysis,
-                                     mock_validation, mock_fallacy, mock_framework):
+    def test_is_healthy_jvm_running(
+        self,
+        mock_jpype,
+        mock_logic,
+        mock_analysis,
+        mock_validation,
+        mock_fallacy,
+        mock_framework,
+    ):
         mock_jpype.isJVMStarted.return_value = True
         mock_logic.return_value.is_healthy.return_value = {"status": "ok"}
         mock_analysis.return_value.is_healthy.return_value = {"status": "ok"}
@@ -287,6 +301,7 @@ class TestAppServices:
         mock_framework.return_value.is_healthy.return_value = {"status": "ok"}
 
         from argumentation_analysis.services.mcp_server.main import AppServices
+
         app = AppServices()
         health = app.is_healthy()
         assert health["jvm"]["running"] is True
@@ -298,13 +313,27 @@ class TestAppServices:
     @patch("argumentation_analysis.services.mcp_server.main.AnalysisService")
     @patch("argumentation_analysis.services.mcp_server.main.LogicService")
     @patch("argumentation_analysis.services.mcp_server.main.jpype")
-    def test_is_healthy_jvm_not_running(self, mock_jpype, mock_logic, mock_analysis,
-                                         mock_validation, mock_fallacy, mock_framework):
+    def test_is_healthy_jvm_not_running(
+        self,
+        mock_jpype,
+        mock_logic,
+        mock_analysis,
+        mock_validation,
+        mock_fallacy,
+        mock_framework,
+    ):
         mock_jpype.isJVMStarted.return_value = False
-        for m in [mock_logic, mock_analysis, mock_validation, mock_fallacy, mock_framework]:
+        for m in [
+            mock_logic,
+            mock_analysis,
+            mock_validation,
+            mock_fallacy,
+            mock_framework,
+        ]:
             m.return_value.is_healthy.return_value = {"status": "ok"}
 
         from argumentation_analysis.services.mcp_server.main import AppServices
+
         app = AppServices()
         health = app.is_healthy()
         assert health["jvm"]["running"] is False
@@ -315,22 +344,31 @@ class TestAppServices:
 # 4. MCPService tests — tool methods
 # ---------------------------------------------------------------------------
 
+
 def _make_mcp_service():
     """Create an MCPService with all heavy dependencies mocked."""
-    with patch("argumentation_analysis.services.mcp_server.main.FastMCP") as mock_fmcp, \
-         patch("argumentation_analysis.services.mcp_server.main.initialize_project_environment"), \
-         patch("argumentation_analysis.services.mcp_server.main.AppServices") as mock_app, \
-         patch("argumentation_analysis.services.mcp_server.main.jpype") as mock_jpype, \
-         patch.dict("sys.modules", {
-             "argumentation_analysis.services.mcp_server.tools.workflow_tools": MagicMock(),
-             "argumentation_analysis.services.mcp_server.tools.conversation_tools": MagicMock(),
-             "argumentation_analysis.services.mcp_server.tools.capability_tools": MagicMock(),
-             "argumentation_analysis.services.mcp_server.tools.specialized_tools": MagicMock(),
-         }):
+    with patch(
+        "argumentation_analysis.services.mcp_server.main.FastMCP"
+    ) as mock_fmcp, patch(
+        "argumentation_analysis.services.mcp_server.main.initialize_project_environment"
+    ), patch(
+        "argumentation_analysis.services.mcp_server.main.AppServices"
+    ) as mock_app, patch(
+        "argumentation_analysis.services.mcp_server.main.jpype"
+    ) as mock_jpype, patch.dict(
+        "sys.modules",
+        {
+            "argumentation_analysis.services.mcp_server.tools.workflow_tools": MagicMock(),
+            "argumentation_analysis.services.mcp_server.tools.conversation_tools": MagicMock(),
+            "argumentation_analysis.services.mcp_server.tools.capability_tools": MagicMock(),
+            "argumentation_analysis.services.mcp_server.tools.specialized_tools": MagicMock(),
+        },
+    ):
         mock_fmcp.return_value = MagicMock()
         mock_jpype.isJVMStarted.return_value = True
         mock_app.return_value = MagicMock()
         from argumentation_analysis.services.mcp_server.main import MCPService
+
         svc = MCPService("test_mcp")
     return svc
 
@@ -344,31 +382,48 @@ class TestMCPServiceInit:
         assert svc.services is not None
 
     def test_init_failure_raises_runtime_error(self):
-        with patch("argumentation_analysis.services.mcp_server.main.FastMCP") as mock_fmcp, \
-             patch("argumentation_analysis.services.mcp_server.main.initialize_project_environment",
-                   side_effect=Exception("init failed")):
+        with patch(
+            "argumentation_analysis.services.mcp_server.main.FastMCP"
+        ) as mock_fmcp, patch(
+            "argumentation_analysis.services.mcp_server.main.initialize_project_environment",
+            side_effect=Exception("init failed"),
+        ):
             mock_fmcp.return_value = MagicMock()
             from argumentation_analysis.services.mcp_server.main import MCPService
+
             with pytest.raises(RuntimeError, match="init failed"):
                 MCPService("failing_mcp")
 
     def test_v2_tools_failure_is_silent(self):
         """V2 tool registration failure should not crash init."""
-        with patch("argumentation_analysis.services.mcp_server.main.FastMCP") as mock_fmcp, \
-             patch("argumentation_analysis.services.mcp_server.main.initialize_project_environment"), \
-             patch("argumentation_analysis.services.mcp_server.main.AppServices"), \
-             patch("argumentation_analysis.services.mcp_server.main.jpype"):
+        with patch(
+            "argumentation_analysis.services.mcp_server.main.FastMCP"
+        ) as mock_fmcp, patch(
+            "argumentation_analysis.services.mcp_server.main.initialize_project_environment"
+        ), patch(
+            "argumentation_analysis.services.mcp_server.main.AppServices"
+        ), patch(
+            "argumentation_analysis.services.mcp_server.main.jpype"
+        ):
             mock_fmcp.return_value = MagicMock()
             # Make v2 imports fail
             import builtins
+
             original_import = builtins.__import__
+
             def failing_import(name, *args, **kwargs):
-                if "workflow_tools" in name or "conversation_tools" in name or \
-                   "capability_tools" in name or "specialized_tools" in name:
+                if (
+                    "workflow_tools" in name
+                    or "conversation_tools" in name
+                    or "capability_tools" in name
+                    or "specialized_tools" in name
+                ):
                     raise ImportError("no v2")
                 return original_import(name, *args, **kwargs)
+
             with patch("builtins.__import__", side_effect=failing_import):
                 from argumentation_analysis.services.mcp_server.main import MCPService
+
                 svc = MCPService("test_no_v2")
                 # Should not raise
                 assert svc._initialized is True
@@ -380,7 +435,9 @@ class TestMCPServiceHealthCheck:
     async def test_health_check_healthy(self):
         svc = _make_mcp_service()
         svc.services.is_healthy.return_value = {"all": "ok"}
-        with patch("argumentation_analysis.services.mcp_server.main.jpype") as mock_jpype:
+        with patch(
+            "argumentation_analysis.services.mcp_server.main.jpype"
+        ) as mock_jpype:
             mock_jpype.isJVMStarted.return_value = True
             result = await svc.health_check()
         assert result["status"] == "healthy"
@@ -389,7 +446,9 @@ class TestMCPServiceHealthCheck:
     async def test_health_check_unhealthy(self):
         svc = _make_mcp_service()
         svc.services.is_healthy.return_value = {"all": "ok"}
-        with patch("argumentation_analysis.services.mcp_server.main.jpype") as mock_jpype:
+        with patch(
+            "argumentation_analysis.services.mcp_server.main.jpype"
+        ) as mock_jpype:
             mock_jpype.isJVMStarted.return_value = False
             result = await svc.health_check()
         assert result["status"] == "unhealthy"
@@ -397,7 +456,9 @@ class TestMCPServiceHealthCheck:
     async def test_health_check_error(self):
         svc = _make_mcp_service()
         svc.services.is_healthy.side_effect = Exception("boom")
-        with patch("argumentation_analysis.services.mcp_server.main.jpype") as mock_jpype:
+        with patch(
+            "argumentation_analysis.services.mcp_server.main.jpype"
+        ) as mock_jpype:
             mock_jpype.isJVMStarted.return_value = True
             result = await svc.health_check()
         assert result["status"] == "error"
@@ -418,19 +479,24 @@ class TestMCPServiceAnalyzeText:
     async def test_analyze_text_validation_error(self):
         svc = _make_mcp_service()
         from pydantic import ValidationError
+
         # Trigger validation error via invalid severity_threshold
         # We mock the AnalysisRequest to raise
-        with patch("argumentation_analysis.services.mcp_server.main.AnalysisRequest",
-                    side_effect=ValidationError.from_exception_data(
-                        title="AnalysisRequest",
-                        line_errors=[{
-                            "type": "string_type",
-                            "loc": ("text",),
-                            "msg": "bad",
-                            "input": None,
-                            "ctx": {},
-                        }],
-                    )):
+        with patch(
+            "argumentation_analysis.services.mcp_server.main.AnalysisRequest",
+            side_effect=ValidationError.from_exception_data(
+                title="AnalysisRequest",
+                line_errors=[
+                    {
+                        "type": "string_type",
+                        "loc": ("text",),
+                        "msg": "bad",
+                        "input": None,
+                        "ctx": {},
+                    }
+                ],
+            ),
+        ):
             result = await svc.analyze_text("test")
         assert result["status_code"] == 400
 
@@ -560,9 +626,7 @@ class TestMCPServiceLogicTools:
         svc = _make_mcp_service()
         mock_result = MagicMock()
         mock_result.model_dump.return_value = {"answer": True}
-        svc.services.logic_service.execute_query = AsyncMock(
-            return_value=mock_result
-        )
+        svc.services.logic_service.execute_query = AsyncMock(return_value=mock_result)
         result = await svc.execute_logic_query("bs1", "p", "propositional")
         assert result == {"answer": True}
 
@@ -660,6 +724,7 @@ class TestMCPServiceRun:
 # 5. Tool registration module tests (workflow, capability, specialized, conversation)
 # ---------------------------------------------------------------------------
 
+
 class TestWorkflowToolsRegistration:
     """Tests for workflow_tools.register_workflow_tools."""
 
@@ -667,6 +732,7 @@ class TestWorkflowToolsRegistration:
         from argumentation_analysis.services.mcp_server.tools.workflow_tools import (
             register_workflow_tools,
         )
+
         mock_mcp = MagicMock()
         mock_mcp.tool.return_value = lambda fn: fn
         register_workflow_tools(mock_mcp, MagicMock())
@@ -680,6 +746,7 @@ class TestCapabilityToolsRegistration:
         from argumentation_analysis.services.mcp_server.tools.capability_tools import (
             register_capability_tools,
         )
+
         mock_mcp = MagicMock()
         mock_mcp.tool.return_value = lambda fn: fn
         register_capability_tools(mock_mcp, MagicMock())
@@ -693,6 +760,7 @@ class TestSpecializedToolsRegistration:
         from argumentation_analysis.services.mcp_server.tools.specialized_tools import (
             register_specialized_tools,
         )
+
         mock_mcp = MagicMock()
         mock_mcp.tool.return_value = lambda fn: fn
         register_specialized_tools(mock_mcp, MagicMock())
@@ -706,6 +774,7 @@ class TestConversationToolsRegistration:
         from argumentation_analysis.services.mcp_server.tools.conversation_tools import (
             register_conversation_tools,
         )
+
         mock_mcp = MagicMock()
         mock_mcp.tool.return_value = lambda fn: fn
         register_conversation_tools(mock_mcp, MagicMock(), MagicMock())

--- a/tests/unit/argumentation_analysis/services/test_web_api_models_and_services.py
+++ b/tests/unit/argumentation_analysis/services/test_web_api_models_and_services.py
@@ -48,7 +48,6 @@ from argumentation_analysis.services.web_api.models.response_models import (
     LogicQueryResult,
 )
 
-
 # ============================================================================
 # Request Models
 # ============================================================================
@@ -416,13 +415,19 @@ class TestResponseModels:
     def test_fallacy_detection_severity_bounds(self):
         with pytest.raises(ValidationError):
             FallacyDetection(
-                type="x", name="x", description="x",
-                severity=1.5, confidence=0.5,
+                type="x",
+                name="x",
+                description="x",
+                severity=1.5,
+                confidence=0.5,
             )
         with pytest.raises(ValidationError):
             FallacyDetection(
-                type="x", name="x", description="x",
-                severity=0.5, confidence=-0.1,
+                type="x",
+                name="x",
+                description="x",
+                severity=0.5,
+                confidence=-0.1,
             )
 
     def test_argument_structure_defaults(self):
@@ -612,6 +617,7 @@ class TestValidationService:
         from argumentation_analysis.services.web_api.services.validation_service import (
             ValidationService,
         )
+
         return ValidationService(logic_service=mock_logic_service)
 
     def test_init(self, validation_service):
@@ -625,7 +631,9 @@ class TestValidationService:
         mock_logic_service.is_healthy.return_value = True
         assert validation_service.is_healthy() is True
 
-    def test_is_healthy_logic_service_down(self, validation_service, mock_logic_service):
+    def test_is_healthy_logic_service_down(
+        self, validation_service, mock_logic_service
+    ):
         """is_healthy returns False when logic_service is unhealthy."""
         mock_logic_service.is_healthy.return_value = False
         assert validation_service.is_healthy() is False
@@ -737,7 +745,10 @@ class TestValidationService:
 
     def test_assess_clarity_normal_text(self, validation_service):
         """Normal length text should get good clarity score."""
-        assert validation_service._assess_clarity("This is a normal length sentence") == 0.8
+        assert (
+            validation_service._assess_clarity("This is a normal length sentence")
+            == 0.8
+        )
 
     def test_assess_clarity_long_text(self, validation_service):
         """Very long text should get medium clarity score."""
@@ -746,7 +757,10 @@ class TestValidationService:
 
     def test_assess_specificity_vague(self, validation_service):
         """Text with vague terms should get low specificity."""
-        assert validation_service._assess_specificity("Certains pensent souvent que") == 0.4
+        assert (
+            validation_service._assess_specificity("Certains pensent souvent que")
+            == 0.4
+        )
 
     def test_assess_specificity_precise(self, validation_service):
         """Text without vague terms should get higher specificity."""
@@ -761,7 +775,9 @@ class TestValidationService:
         assert validation_service._assess_credibility("Le ciel est bleu") == 0.6
 
     def test_contains_qualifiers_true(self, validation_service):
-        assert validation_service._contains_qualifiers("C'est probablement vrai") is True
+        assert (
+            validation_service._contains_qualifiers("C'est probablement vrai") is True
+        )
 
     def test_contains_qualifiers_false(self, validation_service):
         assert validation_service._contains_qualifiers("C'est vrai") is False
@@ -831,6 +847,7 @@ class TestFallacyService:
             from argumentation_analysis.services.web_api.services.fallacy_service import (
                 FallacyService,
             )
+
             service = FallacyService()
         return service
 
@@ -886,7 +903,10 @@ class TestFallacyService:
         )
         response = fallacy_service.detect_fallacies(request)
         assert response.success is True
-        assert response.text_analyzed == "Soit vous etes avec nous, soit vous etes contre nous"
+        assert (
+            response.text_analyzed
+            == "Soit vous etes avec nous, soit vous etes contre nous"
+        )
         # The "soit.*soit" pattern should match
         fallacy_types = [f.type for f in response.fallacies]
         assert "false_dilemma" in fallacy_types
@@ -959,26 +979,50 @@ class TestFallacyService:
     def test_severity_distribution_calculation(self, fallacy_service):
         """Severity distribution should classify into low/medium/high."""
         fallacies = [
-            FallacyDetection(type="a", name="A", description="d", severity=0.3, confidence=0.5),
-            FallacyDetection(type="b", name="B", description="d", severity=0.5, confidence=0.5),
-            FallacyDetection(type="c", name="C", description="d", severity=0.8, confidence=0.5),
+            FallacyDetection(
+                type="a", name="A", description="d", severity=0.3, confidence=0.5
+            ),
+            FallacyDetection(
+                type="b", name="B", description="d", severity=0.5, confidence=0.5
+            ),
+            FallacyDetection(
+                type="c", name="C", description="d", severity=0.8, confidence=0.5
+            ),
         ]
         dist = fallacy_service._calculate_severity_distribution(fallacies)
-        assert dist["low"] == 1      # 0.3 < 0.4
-        assert dist["medium"] == 1   # 0.4 <= 0.5 < 0.7
-        assert dist["high"] == 1     # 0.8 >= 0.7
+        assert dist["low"] == 1  # 0.3 < 0.4
+        assert dist["medium"] == 1  # 0.4 <= 0.5 < 0.7
+        assert dist["high"] == 1  # 0.8 >= 0.7
 
     def test_category_distribution_calculation(self, fallacy_service):
         """Category distribution should count by type -> category mapping."""
         fallacies = [
-            FallacyDetection(type="ad_hominem", name="AH", description="d", severity=0.5, confidence=0.5),
-            FallacyDetection(type="affirming_consequent", name="AC", description="d", severity=0.5, confidence=0.5),
-            FallacyDetection(type="unknown_type", name="U", description="d", severity=0.5, confidence=0.5),
+            FallacyDetection(
+                type="ad_hominem",
+                name="AH",
+                description="d",
+                severity=0.5,
+                confidence=0.5,
+            ),
+            FallacyDetection(
+                type="affirming_consequent",
+                name="AC",
+                description="d",
+                severity=0.5,
+                confidence=0.5,
+            ),
+            FallacyDetection(
+                type="unknown_type",
+                name="U",
+                description="d",
+                severity=0.5,
+                confidence=0.5,
+            ),
         ]
         dist = fallacy_service._calculate_category_distribution(fallacies)
         assert dist.get("informal", 0) == 1  # ad_hominem is informal
-        assert dist.get("formal", 0) == 1    # affirming_consequent is formal
-        assert dist.get("unknown", 0) == 1   # unknown_type not in patterns
+        assert dist.get("formal", 0) == 1  # affirming_consequent is formal
+        assert dist.get("unknown", 0) == 1  # unknown_type not in patterns
 
     def test_extract_context(self, fallacy_service):
         """Context extraction around a position."""
@@ -994,16 +1038,28 @@ class TestFallacyService:
     def test_filter_and_deduplicate(self, fallacy_service):
         """Duplicate fallacies (same type+location) should be removed."""
         f1 = FallacyDetection(
-            type="ad_hominem", name="AH", description="d",
-            severity=0.8, confidence=0.5, location={"start": 10, "end": 20},
+            type="ad_hominem",
+            name="AH",
+            description="d",
+            severity=0.8,
+            confidence=0.5,
+            location={"start": 10, "end": 20},
         )
         f2 = FallacyDetection(
-            type="ad_hominem", name="AH", description="d",
-            severity=0.8, confidence=0.5, location={"start": 10, "end": 25},
+            type="ad_hominem",
+            name="AH",
+            description="d",
+            severity=0.8,
+            confidence=0.5,
+            location={"start": 10, "end": 25},
         )
         f3 = FallacyDetection(
-            type="straw_man", name="SM", description="d",
-            severity=0.7, confidence=0.5, location={"start": 30, "end": 40},
+            type="straw_man",
+            name="SM",
+            description="d",
+            severity=0.7,
+            confidence=0.5,
+            location={"start": 30, "end": 40},
         )
         result = fallacy_service._filter_and_deduplicate([f1, f2, f3], None)
         # f1 and f2 have same type + start position -> deduplicated
@@ -1013,8 +1069,11 @@ class TestFallacyService:
         """Should respect max_fallacies limit."""
         fallacies = [
             FallacyDetection(
-                type=f"type_{i}", name=f"F{i}", description="d",
-                severity=0.8, confidence=0.5,
+                type=f"type_{i}",
+                name=f"F{i}",
+                description="d",
+                severity=0.8,
+                confidence=0.5,
             )
             for i in range(20)
         ]
@@ -1024,13 +1083,18 @@ class TestFallacyService:
 
     def test_pattern_matches_regex(self, fallacy_service):
         """Pattern matching should work with regex."""
-        assert fallacy_service._pattern_matches("soit.*soit", "soit ceci soit cela") is True
+        assert (
+            fallacy_service._pattern_matches("soit.*soit", "soit ceci soit cela")
+            is True
+        )
         assert fallacy_service._pattern_matches("soit.*soit", "rien du tout") is False
 
     def test_pattern_matches_fallback(self, fallacy_service):
         """Invalid regex should fall back to substring search."""
         # This pattern has unbalanced brackets, should trigger fallback
-        assert fallacy_service._pattern_matches("[invalid", "some [invalid text") is True
+        assert (
+            fallacy_service._pattern_matches("[invalid", "some [invalid text") is True
+        )
 
     def test_detect_fallacies_error_handling(self, fallacy_service):
         """If an internal error occurs, service should return success=False gracefully."""

--- a/tests/unit/argumentation_analysis/services/test_websocket_manager.py
+++ b/tests/unit/argumentation_analysis/services/test_websocket_manager.py
@@ -9,6 +9,7 @@ Validates:
 - Singleton manager
 - Safe serialization
 """
+
 import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -26,7 +27,9 @@ class FakeWebSocket:
     """Minimal fake WebSocket for testing."""
 
     def __init__(self, connected=True):
-        self.client_state = WebSocketState.CONNECTED if connected else WebSocketState.DISCONNECTED
+        self.client_state = (
+            WebSocketState.CONNECTED if connected else WebSocketState.DISCONNECTED
+        )
         self.accepted = False
         self.sent_messages = []
         self.accept = AsyncMock()
@@ -144,8 +147,12 @@ class TestBroadcastHelpers:
     async def test_debate_turn(self, manager, ws):
         await manager.connect("s1", ws)
         await manager.broadcast_debate_turn(
-            "s1", "Socrate", "The argument is...",
-            {"clarity": 8.5}, round_num=3, argument_type="rebuttal"
+            "s1",
+            "Socrate",
+            "The argument is...",
+            {"clarity": 8.5},
+            round_num=3,
+            argument_type="rebuttal",
         )
 
         msg = ws.sent_messages[0]
@@ -159,7 +166,11 @@ class TestBroadcastHelpers:
     async def test_vote_update(self, manager, ws):
         await manager.connect("s1", ws)
         await manager.broadcast_vote_update(
-            "s1", "prop-1", "voter-42", "pour", {"pour": 5, "contre": 2, "abstention": 1}
+            "s1",
+            "prop-1",
+            "voter-42",
+            "pour",
+            {"pour": 5, "contre": 2, "abstention": 1},
         )
 
         msg = ws.sent_messages[0]
@@ -219,6 +230,7 @@ class TestSafeSerialize:
         class Custom:
             def __str__(self):
                 return "custom_repr"
+
         # Non-serializable falls back to str()
         result = _safe_serialize(Custom())
         assert "custom_repr" in str(result) or isinstance(result, dict)
@@ -230,6 +242,7 @@ class TestSafeSerialize:
 class TestSingleton:
     def test_get_websocket_manager(self):
         import argumentation_analysis.services.websocket_manager as mod
+
         old = mod._manager
         mod._manager = None
         try:

--- a/tests/unit/argumentation_analysis/services/web_api/models/test_response_models.py
+++ b/tests/unit/argumentation_analysis/services/web_api/models/test_response_models.py
@@ -33,23 +33,30 @@ from argumentation_analysis.services.web_api.models.response_models import (
     SuccessResponse,
 )
 
-
 # ============================================================
 # FallacyDetection
 # ============================================================
 
+
 class TestFallacyDetection:
     def test_valid_creation(self):
         fd = FallacyDetection(
-            type="ad_hominem", name="Ad Hominem",
-            description="Attaque la personne", severity=0.8, confidence=0.9,
+            type="ad_hominem",
+            name="Ad Hominem",
+            description="Attaque la personne",
+            severity=0.8,
+            confidence=0.9,
         )
         assert fd.type == "ad_hominem"
         assert fd.severity == 0.8
 
     def test_optional_fields_default_none(self):
         fd = FallacyDetection(
-            type="t", name="n", description="d", severity=0.5, confidence=0.5,
+            type="t",
+            name="n",
+            description="d",
+            severity=0.5,
+            confidence=0.5,
         )
         assert fd.location is None
         assert fd.context is None
@@ -57,8 +64,14 @@ class TestFallacyDetection:
 
     def test_with_optional_fields(self):
         fd = FallacyDetection(
-            type="t", name="n", description="d", severity=0.5, confidence=0.5,
-            location={"start": 0, "end": 10}, context="ctx", explanation="expl",
+            type="t",
+            name="n",
+            description="d",
+            severity=0.5,
+            confidence=0.5,
+            location={"start": 0, "end": 10},
+            context="ctx",
+            explanation="expl",
         )
         assert fd.location == {"start": 0, "end": 10}
         assert fd.context == "ctx"
@@ -66,18 +79,30 @@ class TestFallacyDetection:
     def test_severity_out_of_range(self):
         with pytest.raises(ValidationError):
             FallacyDetection(
-                type="t", name="n", description="d", severity=1.5, confidence=0.5,
+                type="t",
+                name="n",
+                description="d",
+                severity=1.5,
+                confidence=0.5,
             )
 
     def test_confidence_out_of_range(self):
         with pytest.raises(ValidationError):
             FallacyDetection(
-                type="t", name="n", description="d", severity=0.5, confidence=-0.1,
+                type="t",
+                name="n",
+                description="d",
+                severity=0.5,
+                confidence=-0.1,
             )
 
     def test_severity_boundaries(self):
-        fd0 = FallacyDetection(type="t", name="n", description="d", severity=0.0, confidence=0.0)
-        fd1 = FallacyDetection(type="t", name="n", description="d", severity=1.0, confidence=1.0)
+        fd0 = FallacyDetection(
+            type="t", name="n", description="d", severity=0.0, confidence=0.0
+        )
+        fd1 = FallacyDetection(
+            type="t", name="n", description="d", severity=1.0, confidence=1.0
+        )
         assert fd0.severity == 0.0
         assert fd1.severity == 1.0
 
@@ -85,6 +110,7 @@ class TestFallacyDetection:
 # ============================================================
 # ArgumentStructure
 # ============================================================
+
 
 class TestArgumentStructure:
     def test_defaults(self):
@@ -97,8 +123,11 @@ class TestArgumentStructure:
 
     def test_custom_values(self):
         a = ArgumentStructure(
-            premises=["P1", "P2"], conclusion="C",
-            argument_type="deductive", strength=0.8, coherence=0.7,
+            premises=["P1", "P2"],
+            conclusion="C",
+            argument_type="deductive",
+            strength=0.8,
+            coherence=0.7,
         )
         assert len(a.premises) == 2
         assert a.argument_type == "deductive"
@@ -115,6 +144,7 @@ class TestArgumentStructure:
 # ============================================================
 # AnalysisResponse
 # ============================================================
+
 
 class TestAnalysisResponse:
     def test_minimal_creation(self):
@@ -135,7 +165,11 @@ class TestAnalysisResponse:
 
     def test_with_fallacies(self):
         fd = FallacyDetection(
-            type="t", name="n", description="d", severity=0.5, confidence=0.5,
+            type="t",
+            name="n",
+            description="d",
+            severity=0.5,
+            confidence=0.5,
         )
         r = AnalysisResponse(success=True, text_analyzed="X", fallacies=[fd])
         assert len(r.fallacies) == 1
@@ -152,6 +186,7 @@ class TestAnalysisResponse:
 # ============================================================
 # ValidationResult
 # ============================================================
+
 
 class TestValidationResult:
     def test_creation(self):
@@ -176,12 +211,16 @@ class TestValidationResult:
 # ValidationResponse
 # ============================================================
 
+
 class TestValidationResponse:
     def test_creation(self):
         vr = ValidationResult(is_valid=True, validity_score=0.9, soundness_score=0.8)
         resp = ValidationResponse(
-            success=True, premises=["P1"], conclusion="C",
-            argument_type="deductive", result=vr,
+            success=True,
+            premises=["P1"],
+            conclusion="C",
+            argument_type="deductive",
+            result=vr,
         )
         assert resp.success is True
         assert resp.result.is_valid is True
@@ -190,8 +229,11 @@ class TestValidationResponse:
     def test_default_processing_time(self):
         vr = ValidationResult(is_valid=True, validity_score=0.5, soundness_score=0.5)
         resp = ValidationResponse(
-            success=True, premises=[], conclusion="C",
-            argument_type="inductive", result=vr,
+            success=True,
+            premises=[],
+            conclusion="C",
+            argument_type="inductive",
+            result=vr,
         )
         assert resp.processing_time == 0.0
 
@@ -199,6 +241,7 @@ class TestValidationResponse:
 # ============================================================
 # FallacyResponse
 # ============================================================
+
 
 class TestFallacyResponse:
     def test_creation(self):
@@ -218,6 +261,7 @@ class TestFallacyResponse:
 # ArgumentNode
 # ============================================================
 
+
 class TestArgumentNode:
     def test_creation(self):
         node = ArgumentNode(id="a1", content="Argument 1")
@@ -233,9 +277,12 @@ class TestArgumentNode:
 
     def test_with_relations(self):
         node = ArgumentNode(
-            id="a1", content="X",
-            attacks=["a2"], attacked_by=["a3"],
-            supports=["a4"], supported_by=["a5"],
+            id="a1",
+            content="X",
+            attacks=["a2"],
+            attacked_by=["a3"],
+            supports=["a4"],
+            supported_by=["a5"],
         )
         assert "a2" in node.attacks
         assert "a3" in node.attacked_by
@@ -244,6 +291,7 @@ class TestArgumentNode:
 # ============================================================
 # Extension
 # ============================================================
+
 
 class TestExtension:
     def test_creation(self):
@@ -263,6 +311,7 @@ class TestExtension:
 # FrameworkVisualization
 # ============================================================
 
+
 class TestFrameworkVisualization:
     def test_defaults(self):
         fv = FrameworkVisualization()
@@ -272,7 +321,8 @@ class TestFrameworkVisualization:
 
     def test_with_data(self):
         fv = FrameworkVisualization(
-            nodes=[{"id": "a1"}], edges=[{"from": "a1", "to": "a2"}],
+            nodes=[{"id": "a1"}],
+            edges=[{"from": "a1", "to": "a2"}],
             layout={"type": "force"},
         )
         assert len(fv.nodes) == 1
@@ -282,6 +332,7 @@ class TestFrameworkVisualization:
 # ============================================================
 # FrameworkResponse
 # ============================================================
+
 
 class TestFrameworkResponse:
     def test_creation(self):
@@ -309,6 +360,7 @@ class TestFrameworkResponse:
 # ErrorResponse
 # ============================================================
 
+
 class TestErrorResponse:
     def test_creation(self):
         err = ErrorResponse(error="NotFound", message="Not found", status_code=404)
@@ -322,7 +374,9 @@ class TestErrorResponse:
 
     def test_with_details(self):
         err = ErrorResponse(
-            error="E", message="M", status_code=500,
+            error="E",
+            message="M",
+            status_code=500,
             details={"trace": "stack"},
         )
         assert err.details["trace"] == "stack"
@@ -331,6 +385,7 @@ class TestErrorResponse:
 # ============================================================
 # LogicQueryResult
 # ============================================================
+
 
 class TestLogicQueryResult:
     def test_creation(self):
@@ -348,7 +403,9 @@ class TestLogicQueryResult:
 
     def test_with_explanation(self):
         r = LogicQueryResult(
-            query="q", result=True, formatted_result="T",
+            query="q",
+            result=True,
+            formatted_result="T",
             explanation="Because...",
         )
         assert r.explanation == "Because..."
@@ -358,11 +415,14 @@ class TestLogicQueryResult:
 # LogicBeliefSet
 # ============================================================
 
+
 class TestLogicBeliefSet:
     def test_creation(self):
         bs = LogicBeliefSet(
-            id="bs1", logic_type="propositional",
-            content="p -> q, p", source_text="If p then q, p.",
+            id="bs1",
+            logic_type="propositional",
+            content="p -> q, p",
+            source_text="If p then q, p.",
         )
         assert bs.id == "bs1"
         assert bs.logic_type == "propositional"
@@ -373,11 +433,14 @@ class TestLogicBeliefSet:
 # LogicBeliefSetResponse
 # ============================================================
 
+
 class TestLogicBeliefSetResponse:
     def test_creation(self):
         bs = LogicBeliefSet(
-            id="bs1", logic_type="first_order",
-            content="forall X: P(X)", source_text="All X are P",
+            id="bs1",
+            logic_type="first_order",
+            content="forall X: P(X)",
+            source_text="All X are P",
         )
         resp = LogicBeliefSetResponse(success=True, belief_set=bs)
         assert resp.success is True
@@ -389,12 +452,15 @@ class TestLogicBeliefSetResponse:
 # LogicQueryResponse
 # ============================================================
 
+
 class TestLogicQueryResponse:
     def test_creation(self):
         qr = LogicQueryResult(query="p", result=True, formatted_result="True")
         resp = LogicQueryResponse(
-            success=True, belief_set_id="bs1",
-            logic_type="propositional", result=qr,
+            success=True,
+            belief_set_id="bs1",
+            logic_type="propositional",
+            result=qr,
         )
         assert resp.belief_set_id == "bs1"
         assert resp.processing_time == 0.0
@@ -404,17 +470,22 @@ class TestLogicQueryResponse:
 # LogicGenerateQueriesResponse
 # ============================================================
 
+
 class TestLogicGenerateQueriesResponse:
     def test_creation(self):
         resp = LogicGenerateQueriesResponse(
-            success=True, belief_set_id="bs1", logic_type="modal",
+            success=True,
+            belief_set_id="bs1",
+            logic_type="modal",
             queries=["p", "q", "p -> q"],
         )
         assert len(resp.queries) == 3
 
     def test_defaults(self):
         resp = LogicGenerateQueriesResponse(
-            success=True, belief_set_id="bs1", logic_type="modal",
+            success=True,
+            belief_set_id="bs1",
+            logic_type="modal",
         )
         assert resp.queries == []
         assert resp.processing_time == 0.0
@@ -425,18 +496,23 @@ class TestLogicGenerateQueriesResponse:
 # LogicInterpretationResponse
 # ============================================================
 
+
 class TestLogicInterpretationResponse:
     def test_creation(self):
         resp = LogicInterpretationResponse(
-            success=True, belief_set_id="bs1",
-            logic_type="propositional", interpretation="The results show...",
+            success=True,
+            belief_set_id="bs1",
+            logic_type="propositional",
+            interpretation="The results show...",
         )
         assert resp.interpretation == "The results show..."
 
     def test_defaults(self):
         resp = LogicInterpretationResponse(
-            success=True, belief_set_id="bs1",
-            logic_type="propositional", interpretation="X",
+            success=True,
+            belief_set_id="bs1",
+            logic_type="propositional",
+            interpretation="X",
         )
         assert resp.queries == []
         assert resp.results == []
@@ -448,6 +524,7 @@ class TestLogicInterpretationResponse:
 # SuccessResponse
 # ============================================================
 
+
 class TestSuccessResponse:
     def test_defaults(self):
         resp = SuccessResponse()
@@ -458,7 +535,9 @@ class TestSuccessResponse:
 
     def test_custom_values(self):
         resp = SuccessResponse(
-            message="Created", data={"id": 1}, status_code=201,
+            message="Created",
+            data={"id": 1},
+            status_code=201,
         )
         assert resp.message == "Created"
         assert resp.data == {"id": 1}

--- a/tests/unit/argumentation_analysis/services/web_api/services/test_fallacy_service.py
+++ b/tests/unit/argumentation_analysis/services/web_api/services/test_fallacy_service.py
@@ -35,6 +35,7 @@ def service():
 
 # ── Init & Health ──
 
+
 class TestInit:
     def test_initialized(self, service):
         assert service.is_initialized is True
@@ -59,12 +60,20 @@ class TestInit:
 
 # ── Pattern Matching ──
 
+
 class TestPatternMatching:
     def test_simple_substring_match(self, service):
-        assert service._pattern_matches("tout le monde", "tout le monde sait que") is True
+        assert (
+            service._pattern_matches("tout le monde", "tout le monde sait que") is True
+        )
 
     def test_regex_match(self, service):
-        assert service._pattern_matches("si.*alors.*donc.*vrai", "si A alors B donc c'est vrai") is True
+        assert (
+            service._pattern_matches(
+                "si.*alors.*donc.*vrai", "si A alors B donc c'est vrai"
+            )
+            is True
+        )
 
     def test_no_match(self, service):
         assert service._pattern_matches("xyz123", "un texte normal") is False
@@ -74,6 +83,7 @@ class TestPatternMatching:
 
 
 # ── Context Extraction ──
+
 
 class TestContextExtraction:
     def test_extract_middle(self, service):
@@ -92,33 +102,52 @@ class TestContextExtraction:
 
 # ── Severity Distribution ──
 
+
 class TestSeverityDistribution:
     def test_empty_list(self, service):
         dist = service._calculate_severity_distribution([])
         assert dist == {"low": 0, "medium": 0, "high": 0}
 
     def test_low_severity(self, service):
-        fallacies = [FallacyDetection(type="t", name="n", description="d", severity=0.3, confidence=0.5)]
+        fallacies = [
+            FallacyDetection(
+                type="t", name="n", description="d", severity=0.3, confidence=0.5
+            )
+        ]
         dist = service._calculate_severity_distribution(fallacies)
         assert dist["low"] == 1
         assert dist["medium"] == 0
         assert dist["high"] == 0
 
     def test_medium_severity(self, service):
-        fallacies = [FallacyDetection(type="t", name="n", description="d", severity=0.5, confidence=0.5)]
+        fallacies = [
+            FallacyDetection(
+                type="t", name="n", description="d", severity=0.5, confidence=0.5
+            )
+        ]
         dist = service._calculate_severity_distribution(fallacies)
         assert dist["medium"] == 1
 
     def test_high_severity(self, service):
-        fallacies = [FallacyDetection(type="t", name="n", description="d", severity=0.8, confidence=0.5)]
+        fallacies = [
+            FallacyDetection(
+                type="t", name="n", description="d", severity=0.8, confidence=0.5
+            )
+        ]
         dist = service._calculate_severity_distribution(fallacies)
         assert dist["high"] == 1
 
     def test_mixed(self, service):
         fallacies = [
-            FallacyDetection(type="t", name="n", description="d", severity=0.2, confidence=0.5),
-            FallacyDetection(type="t", name="n", description="d", severity=0.5, confidence=0.5),
-            FallacyDetection(type="t", name="n", description="d", severity=0.9, confidence=0.5),
+            FallacyDetection(
+                type="t", name="n", description="d", severity=0.2, confidence=0.5
+            ),
+            FallacyDetection(
+                type="t", name="n", description="d", severity=0.5, confidence=0.5
+            ),
+            FallacyDetection(
+                type="t", name="n", description="d", severity=0.9, confidence=0.5
+            ),
         ]
         dist = service._calculate_severity_distribution(fallacies)
         assert dist == {"low": 1, "medium": 1, "high": 1}
@@ -126,29 +155,51 @@ class TestSeverityDistribution:
 
 # ── Category Distribution ──
 
+
 class TestCategoryDistribution:
     def test_empty_list(self, service):
         dist = service._calculate_category_distribution([])
         assert dist == {}
 
     def test_known_type(self, service):
-        fallacies = [FallacyDetection(type="ad_hominem", name="n", description="d", severity=0.5, confidence=0.5)]
+        fallacies = [
+            FallacyDetection(
+                type="ad_hominem",
+                name="n",
+                description="d",
+                severity=0.5,
+                confidence=0.5,
+            )
+        ]
         dist = service._calculate_category_distribution(fallacies)
         assert dist.get("informal", 0) == 1
 
     def test_unknown_type(self, service):
-        fallacies = [FallacyDetection(type="unknown_type", name="n", description="d", severity=0.5, confidence=0.5)]
+        fallacies = [
+            FallacyDetection(
+                type="unknown_type",
+                name="n",
+                description="d",
+                severity=0.5,
+                confidence=0.5,
+            )
+        ]
         dist = service._calculate_category_distribution(fallacies)
         assert "unknown" in dist
 
 
 # ── Filter and Deduplicate ──
 
+
 class TestFilterAndDeduplicate:
     def test_severity_threshold_default(self, service):
         fallacies = [
-            FallacyDetection(type="t1", name="n", description="d", severity=0.3, confidence=0.5),
-            FallacyDetection(type="t2", name="n", description="d", severity=0.8, confidence=0.5),
+            FallacyDetection(
+                type="t1", name="n", description="d", severity=0.3, confidence=0.5
+            ),
+            FallacyDetection(
+                type="t2", name="n", description="d", severity=0.8, confidence=0.5
+            ),
         ]
         result = service._filter_and_deduplicate(fallacies, None)
         assert len(result) == 1
@@ -157,24 +208,56 @@ class TestFilterAndDeduplicate:
     def test_severity_threshold_custom(self, service):
         options = FallacyOptions(severity_threshold=0.2)
         fallacies = [
-            FallacyDetection(type="t1", name="n", description="d", severity=0.3, confidence=0.5),
-            FallacyDetection(type="t2", name="n", description="d", severity=0.8, confidence=0.5),
+            FallacyDetection(
+                type="t1", name="n", description="d", severity=0.3, confidence=0.5
+            ),
+            FallacyDetection(
+                type="t2", name="n", description="d", severity=0.8, confidence=0.5
+            ),
         ]
         result = service._filter_and_deduplicate(fallacies, options)
         assert len(result) == 2
 
     def test_deduplication_same_type_same_location(self, service):
         fallacies = [
-            FallacyDetection(type="t1", name="n", description="d", severity=0.8, confidence=0.5, location={"start": 10}),
-            FallacyDetection(type="t1", name="n", description="d", severity=0.8, confidence=0.5, location={"start": 10}),
+            FallacyDetection(
+                type="t1",
+                name="n",
+                description="d",
+                severity=0.8,
+                confidence=0.5,
+                location={"start": 10},
+            ),
+            FallacyDetection(
+                type="t1",
+                name="n",
+                description="d",
+                severity=0.8,
+                confidence=0.5,
+                location={"start": 10},
+            ),
         ]
         result = service._filter_and_deduplicate(fallacies, None)
         assert len(result) == 1
 
     def test_no_dedup_different_locations(self, service):
         fallacies = [
-            FallacyDetection(type="t1", name="n", description="d", severity=0.8, confidence=0.5, location={"start": 10}),
-            FallacyDetection(type="t1", name="n", description="d", severity=0.8, confidence=0.5, location={"start": 50}),
+            FallacyDetection(
+                type="t1",
+                name="n",
+                description="d",
+                severity=0.8,
+                confidence=0.5,
+                location={"start": 10},
+            ),
+            FallacyDetection(
+                type="t1",
+                name="n",
+                description="d",
+                severity=0.8,
+                confidence=0.5,
+                location={"start": 50},
+            ),
         ]
         result = service._filter_and_deduplicate(fallacies, None)
         assert len(result) == 2
@@ -182,7 +265,9 @@ class TestFilterAndDeduplicate:
     def test_max_fallacies_limit(self, service):
         options = FallacyOptions(max_fallacies=2, severity_threshold=0.0)
         fallacies = [
-            FallacyDetection(type=f"t{i}", name="n", description="d", severity=0.8, confidence=0.5)
+            FallacyDetection(
+                type=f"t{i}", name="n", description="d", severity=0.8, confidence=0.5
+            )
             for i in range(5)
         ]
         result = service._filter_and_deduplicate(fallacies, options)
@@ -191,8 +276,20 @@ class TestFilterAndDeduplicate:
     def test_category_filter(self, service):
         options = FallacyOptions(categories=["ad_hominem"], severity_threshold=0.0)
         fallacies = [
-            FallacyDetection(type="ad_hominem", name="n", description="d", severity=0.8, confidence=0.5),
-            FallacyDetection(type="straw_man", name="n", description="d", severity=0.8, confidence=0.5),
+            FallacyDetection(
+                type="ad_hominem",
+                name="n",
+                description="d",
+                severity=0.8,
+                confidence=0.5,
+            ),
+            FallacyDetection(
+                type="straw_man",
+                name="n",
+                description="d",
+                severity=0.8,
+                confidence=0.5,
+            ),
         ]
         result = service._filter_and_deduplicate(fallacies, options)
         assert len(result) == 1
@@ -200,6 +297,7 @@ class TestFilterAndDeduplicate:
 
 
 # ── Get Fallacy Types ──
+
 
 class TestGetFallacyTypes:
     def test_returns_dict(self, service):
@@ -223,6 +321,7 @@ class TestGetFallacyTypes:
 
 # ── Get Categories ──
 
+
 class TestGetCategories:
     def test_returns_list(self, service):
         categories = service.get_categories()
@@ -236,9 +335,12 @@ class TestGetCategories:
 
 # ── Detect Fallacies (integration) ──
 
+
 class TestDetectFallacies:
     def test_detect_false_dilemma(self, service):
-        request = FallacyRequest(text="Soit vous êtes avec nous, soit vous êtes contre nous.")
+        request = FallacyRequest(
+            text="Soit vous êtes avec nous, soit vous êtes contre nous."
+        )
         response = service.detect_fallacies(request)
         assert response.success is True
         assert response.fallacy_count > 0
@@ -257,14 +359,18 @@ class TestDetectFallacies:
         assert response.processing_time >= 0.0
 
     def test_response_has_distributions(self, service):
-        request = FallacyRequest(text="Soit ceci soit cela, c'est tout le monde qui le dit.")
+        request = FallacyRequest(
+            text="Soit ceci soit cela, c'est tout le monde qui le dit."
+        )
         response = service.detect_fallacies(request)
         assert isinstance(response.severity_distribution, dict)
         assert isinstance(response.category_distribution, dict)
 
     def test_detect_with_options(self, service):
         options = FallacyOptions(severity_threshold=0.9)
-        request = FallacyRequest(text="Soit A soit B, tout le monde le dit.", options=options)
+        request = FallacyRequest(
+            text="Soit A soit B, tout le monde le dit.", options=options
+        )
         response = service.detect_fallacies(request)
         assert response.success is True
         # High threshold should filter out low-severity matches

--- a/tests/unit/argumentation_analysis/services/web_api/services/test_validation_service.py
+++ b/tests/unit/argumentation_analysis/services/web_api/services/test_validation_service.py
@@ -26,6 +26,7 @@ def service(mock_logic_service):
 
 # ── Init & Health ──
 
+
 class TestInit:
     def test_init(self, service):
         assert service.is_initialized is True
@@ -43,6 +44,7 @@ class TestInit:
 
 # ── Clarity ──
 
+
 class TestClarity:
     def test_short_text_low_clarity(self, service):
         assert service._assess_clarity("ab") == 0.3
@@ -57,6 +59,7 @@ class TestClarity:
 
 # ── Specificity ──
 
+
 class TestSpecificity:
     def test_vague_term_lowers_specificity(self, service):
         assert service._assess_specificity("certains pensent que c'est vrai") == 0.4
@@ -66,6 +69,7 @@ class TestSpecificity:
 
 
 # ── Credibility ──
+
 
 class TestCredibility:
     def test_source_indicator_high_credibility(self, service):
@@ -77,6 +81,7 @@ class TestCredibility:
 
 # ── Qualifiers ──
 
+
 class TestQualifiers:
     def test_contains_qualifier(self, service):
         assert service._contains_qualifiers("c'est probablement vrai") is True
@@ -86,6 +91,7 @@ class TestQualifiers:
 
 
 # ── Factual Claim ──
+
 
 class TestFactualClaim:
     def test_factual(self, service):
@@ -100,6 +106,7 @@ class TestFactualClaim:
 
 # ── Conclusion Strength ──
 
+
 class TestConclusionStrength:
     def test_reasonable_conclusion(self, service):
         strength = service._assess_conclusion_strength(
@@ -109,6 +116,7 @@ class TestConclusionStrength:
 
 
 # ── Logical Connectors ──
+
 
 class TestLogicalConnectors:
     def test_has_connector(self, service):
@@ -122,6 +130,7 @@ class TestLogicalConnectors:
 
 
 # ── Premise Relevance ──
+
 
 class TestPremiseRelevance:
     def test_relevant_premises(self, service):
@@ -144,6 +153,7 @@ class TestPremiseRelevance:
 
 # ── Logical Flow ──
 
+
 class TestLogicalFlow:
     def test_good_flow(self, service):
         score = service._assess_logical_flow(
@@ -162,6 +172,7 @@ class TestLogicalFlow:
 
 # ── Completeness ──
 
+
 class TestCompleteness:
     def test_complete_argument(self, service):
         score = service._assess_completeness(
@@ -177,6 +188,7 @@ class TestCompleteness:
 
 # ── Consistency ──
 
+
 class TestConsistency:
     def test_single_premise_full_consistency(self, service):
         assert service._assess_consistency(["une prémisse"]) == 1.0
@@ -186,6 +198,7 @@ class TestConsistency:
 
 
 # ── Logical Gaps ──
+
 
 class TestLogicalGaps:
     def test_no_gaps(self, service):
@@ -214,12 +227,15 @@ class TestLogicalGaps:
 
 # ── Premise Analysis ──
 
+
 class TestPremiseAnalysis:
     def test_analyze_premises(self, service):
-        analysis = service._analyze_premises([
-            "Selon une étude, la terre est ronde",
-            "ok",
-        ])
+        analysis = service._analyze_premises(
+            [
+                "Selon une étude, la terre est ronde",
+                "ok",
+            ]
+        )
         assert len(analysis) == 2
         assert analysis[0]["index"] == 0
         assert analysis[0]["credibility_score"] == 0.8  # "étude"
@@ -228,6 +244,7 @@ class TestPremiseAnalysis:
 
 
 # ── Conclusion Analysis ──
+
 
 class TestConclusionAnalysis:
     def test_analyze_conclusion(self, service):
@@ -241,10 +258,13 @@ class TestConclusionAnalysis:
 
 # ── Logical Structure ──
 
+
 class TestLogicalStructure:
     def test_analyze_structure(self, service):
         result = service._analyze_logical_structure(
-            ["p1", "p2"], "donc c'est vrai", "deductive",
+            ["p1", "p2"],
+            "donc c'est vrai",
+            "deductive",
         )
         assert result["argument_type"] == "deductive"
         assert result["premise_count"] == 2
@@ -255,6 +275,7 @@ class TestLogicalStructure:
 
 # ── Validity Score ──
 
+
 class TestValidityScore:
     def test_no_premises_returns_zero(self, service):
         assert service._calculate_validity_score([], {}, {}) == 0.0
@@ -264,12 +285,15 @@ class TestValidityScore:
         conclusion_analysis = {"strength": 0.6}
         structure = {"premise_relevance": 0.5, "logical_flow": 0.6, "completeness": 0.5}
         score = service._calculate_validity_score(
-            premise_analysis, conclusion_analysis, structure,
+            premise_analysis,
+            conclusion_analysis,
+            structure,
         )
         assert 0.0 <= score <= 1.0
 
 
 # ── Soundness Score ──
+
 
 class TestSoundnessScore:
     def test_no_premises_returns_zero(self, service):
@@ -283,10 +307,13 @@ class TestSoundnessScore:
 
 # ── Issues ──
 
+
 class TestIdentifyIssues:
     def test_no_premises_issue(self, service):
         issues = service._identify_issues(
-            [], {"text": "conclusion", "clarity_score": 0.8}, {},
+            [],
+            {"text": "conclusion", "clarity_score": 0.8},
+            {},
         )
         assert any("prémisse" in i.lower() for i in issues)
 
@@ -294,7 +321,13 @@ class TestIdentifyIssues:
         issues = service._identify_issues(
             [{"clarity_score": 0.3, "credibility_score": 0.7}],
             {"text": "ok", "clarity_score": 0.8},
-            {"premise_relevance": 0.8, "logical_flow": 0.8, "completeness": 0.8, "consistency": 0.8, "gap_analysis": []},
+            {
+                "premise_relevance": 0.8,
+                "logical_flow": 0.8,
+                "completeness": 0.8,
+                "consistency": 0.8,
+                "gap_analysis": [],
+            },
         )
         assert any("clarté" in i for i in issues)
 
@@ -302,13 +335,19 @@ class TestIdentifyIssues:
         issues = service._identify_issues(
             [{"clarity_score": 0.9, "credibility_score": 0.9}],
             {"text": "conclusion", "clarity_score": 0.9},
-            {"premise_relevance": 0.8, "logical_flow": 0.8, "completeness": 0.8, "consistency": 0.8,
-             "gap_analysis": ["gap1"]},
+            {
+                "premise_relevance": 0.8,
+                "logical_flow": 0.8,
+                "completeness": 0.8,
+                "consistency": 0.8,
+                "gap_analysis": ["gap1"],
+            },
         )
         assert any("gap1" in i for i in issues)
 
 
 # ── Suggestions ──
+
 
 class TestSuggestions:
     def test_no_issues_positive_suggestion(self, service):
@@ -318,36 +357,43 @@ class TestSuggestions:
 
     def test_premise_clarity_suggestion(self, service):
         suggestions = service._generate_suggestions(
-            ["la prémisse manque de clarté"], {},
+            ["la prémisse manque de clarté"],
+            {},
         )
         assert any("clarté" in s for s in suggestions)
 
     def test_premise_credibility_suggestion(self, service):
         suggestions = service._generate_suggestions(
-            ["prémisse manque de crédibilité"], {},
+            ["prémisse manque de crédibilité"],
+            {},
         )
         assert any("crédibilité" in s for s in suggestions)
 
     def test_deductive_suggestion(self, service):
         suggestions = service._generate_suggestions(
-            ["un problème"], {"argument_type": "deductive"},
+            ["un problème"],
+            {"argument_type": "deductive"},
         )
         assert any("déductif" in s for s in suggestions)
 
     def test_inductive_suggestion(self, service):
         suggestions = service._generate_suggestions(
-            ["un problème"], {"argument_type": "inductive"},
+            ["un problème"],
+            {"argument_type": "inductive"},
         )
         assert any("inductif" in s for s in suggestions)
 
 
 # ── validate_argument (async) ──
 
+
 class TestValidateArgument:
     async def test_valid_argument(self, service):
         request = ValidationRequest(
-            premises=["La terre est ronde selon les données scientifiques",
-                       "Les données proviennent d'une étude approfondie"],
+            premises=[
+                "La terre est ronde selon les données scientifiques",
+                "Les données proviennent d'une étude approfondie",
+            ],
             conclusion="Donc la terre est ronde selon ces données",
         )
         response = await service.validate_argument(request)
@@ -358,12 +404,14 @@ class TestValidateArgument:
     async def test_no_premises_pydantic_rejects(self, service):
         """Pydantic model enforces min 1 premise."""
         from pydantic import ValidationError as PydanticValidationError
+
         with pytest.raises(PydanticValidationError):
             ValidationRequest(premises=[], conclusion="conclusion")
 
     async def test_empty_conclusion_pydantic_rejects(self, service):
         """Pydantic model enforces non-empty conclusion."""
         from pydantic import ValidationError as PydanticValidationError
+
         with pytest.raises(PydanticValidationError):
             ValidationRequest(premises=["premise"], conclusion="")
 

--- a/tests/unit/argumentation_analysis/test_architecture_compliance.py
+++ b/tests/unit/argumentation_analysis/test_architecture_compliance.py
@@ -18,7 +18,6 @@ from semantic_kernel import Kernel
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 from semantic_kernel.functions import kernel_function
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -28,9 +27,7 @@ from semantic_kernel.functions import kernel_function
 def mock_kernel():
     """Kernel with mock OpenAI service for agent tests."""
     kernel = Kernel()
-    service = OpenAIChatCompletion(
-        service_id="default", api_key="test-key"
-    )
+    service = OpenAIChatCompletion(service_id="default", api_key="test-key")
     kernel.add_service(service)
     return kernel
 
@@ -116,9 +113,8 @@ class TestPluginCompliance:
 
     def _has_kernel_function_attr(self, method):
         """Check if method has kernel_function metadata."""
-        return (
-            hasattr(method, "__kernel_function__")
-            or hasattr(method, "__kernel_function_name__")
+        return hasattr(method, "__kernel_function__") or hasattr(
+            method, "__kernel_function_name__"
         )
 
     def test_counter_argument_plugin_has_kernel_functions(self):
@@ -194,16 +190,10 @@ class TestPluginCompliance:
             GovernancePlugin,
         )
 
-        mock_kernel.add_plugin(
-            CounterArgumentPlugin(), plugin_name="counter_argument"
-        )
+        mock_kernel.add_plugin(CounterArgumentPlugin(), plugin_name="counter_argument")
         mock_kernel.add_plugin(DebatePlugin(), plugin_name="debate")
-        mock_kernel.add_plugin(
-            QualityScoringPlugin(), plugin_name="quality"
-        )
-        mock_kernel.add_plugin(
-            GovernancePlugin(), plugin_name="governance"
-        )
+        mock_kernel.add_plugin(QualityScoringPlugin(), plugin_name="quality")
+        mock_kernel.add_plugin(GovernancePlugin(), plugin_name="governance")
 
         assert "counter_argument" in mock_kernel.plugins
         assert "debate" in mock_kernel.plugins
@@ -299,9 +289,7 @@ class TestFactoryCompliance:
         """Factory creates CounterArgumentAgent."""
         from argumentation_analysis.agents.factory import AgentFactory
 
-        factory = AgentFactory(
-            kernel=mock_kernel, llm_service_id="default"
-        )
+        factory = AgentFactory(kernel=mock_kernel, llm_service_id="default")
         agent = factory.create_counter_argument_agent()
         assert agent.name == "CounterArgumentAgent"
 
@@ -309,9 +297,7 @@ class TestFactoryCompliance:
         """Factory creates DebateAgent with personality."""
         from argumentation_analysis.agents.factory import AgentFactory
 
-        factory = AgentFactory(
-            kernel=mock_kernel, llm_service_id="default"
-        )
+        factory = AgentFactory(kernel=mock_kernel, llm_service_id="default")
         agent = factory.create_debate_agent(
             agent_name="Alice",
             personality="Scholar",

--- a/tests/unit/argumentation_analysis/test_communication_channels.py
+++ b/tests/unit/argumentation_analysis/test_communication_channels.py
@@ -51,7 +51,6 @@ from argumentation_analysis.core.communication.pub_sub import (
     PublishSubscribeProtocol,
 )
 
-
 # ===========================================================================
 # Message Tests
 # ===========================================================================
@@ -93,20 +92,29 @@ class TestMessage:
     def test_message_priority_ordering(self):
         """Critical messages should sort before low-priority ones."""
         critical = Message(
-            MessageType.COMMAND, "a", AgentLevel.STRATEGIC, {},
+            MessageType.COMMAND,
+            "a",
+            AgentLevel.STRATEGIC,
+            {},
             priority=MessagePriority.CRITICAL,
         )
         time.sleep(0.001)  # ensure different timestamps
         low = Message(
-            MessageType.INFORMATION, "b", AgentLevel.OPERATIONAL, {},
+            MessageType.INFORMATION,
+            "b",
+            AgentLevel.OPERATIONAL,
+            {},
             priority=MessagePriority.LOW,
         )
         assert critical < low  # critical should come first in sorted order
 
     def test_message_response_creation(self):
         original = Message(
-            MessageType.REQUEST, "agent-1", AgentLevel.TACTICAL,
-            {"request_type": "help"}, recipient="agent-2",
+            MessageType.REQUEST,
+            "agent-1",
+            AgentLevel.TACTICAL,
+            {"request_type": "help"},
+            recipient="agent-2",
         )
         response = original.create_response(content={"answer": "done"})
         assert response.recipient == "agent-1"
@@ -115,8 +123,11 @@ class TestMessage:
 
     def test_message_acknowledgement(self):
         msg = Message(
-            MessageType.COMMAND, "agent-1", AgentLevel.STRATEGIC,
-            {"action": "start"}, recipient="agent-2",
+            MessageType.COMMAND,
+            "agent-1",
+            AgentLevel.STRATEGIC,
+            {"action": "start"},
+            recipient="agent-2",
         )
         ack = msg.create_acknowledgement()
         assert ack.type == MessageType.RESPONSE  # ACK is a RESPONSE type
@@ -124,8 +135,10 @@ class TestMessage:
 
     def test_command_message(self):
         cmd = CommandMessage(
-            sender="strategic-1", sender_level=AgentLevel.STRATEGIC,
-            command_type="analyze", parameters={"text_id": "t1"},
+            sender="strategic-1",
+            sender_level=AgentLevel.STRATEGIC,
+            command_type="analyze",
+            parameters={"text_id": "t1"},
             recipient="tactical-1",
         )
         assert cmd.type == MessageType.COMMAND
@@ -134,25 +147,32 @@ class TestMessage:
 
     def test_information_message(self):
         info = InformationMessage(
-            sender="tactical-1", sender_level=AgentLevel.TACTICAL,
-            info_type="status_update", data={"progress": 50},
+            sender="tactical-1",
+            sender_level=AgentLevel.TACTICAL,
+            info_type="status_update",
+            data={"progress": 50},
         )
         assert info.type == MessageType.INFORMATION
         assert info.content["info_type"] == "status_update"
 
     def test_request_message(self):
         req = RequestMessage(
-            sender="tactical-1", sender_level=AgentLevel.TACTICAL,
-            request_type="guidance", description="Need help",
-            context={"task": "analysis"}, recipient="strategic-1",
+            sender="tactical-1",
+            sender_level=AgentLevel.TACTICAL,
+            request_type="guidance",
+            description="Need help",
+            context={"task": "analysis"},
+            recipient="strategic-1",
         )
         assert req.type == MessageType.REQUEST
         assert req.content["request_type"] == "guidance"
 
     def test_event_message(self):
         evt = EventMessage(
-            sender="system", sender_level=AgentLevel.SYSTEM,
-            event_type="resource_low", description="CPU at 95%",
+            sender="system",
+            sender_level=AgentLevel.SYSTEM,
+            event_type="resource_low",
+            description="CPU at 95%",
             details={"cpu": 95},
         )
         assert evt.type == MessageType.EVENT
@@ -173,8 +193,11 @@ class TestHierarchicalChannel:
 
     def test_send_and_receive(self, channel):
         msg = Message(
-            MessageType.COMMAND, "strategic-1", AgentLevel.STRATEGIC,
-            {"action": "analyze"}, recipient="tactical-1",
+            MessageType.COMMAND,
+            "strategic-1",
+            AgentLevel.STRATEGIC,
+            {"action": "analyze"},
+            recipient="tactical-1",
         )
         assert channel.send_message(msg) is True
 
@@ -189,12 +212,20 @@ class TestHierarchicalChannel:
     def test_priority_ordering(self, channel):
         """Higher priority messages should be received first."""
         low = Message(
-            MessageType.INFORMATION, "a", AgentLevel.TACTICAL,
-            {"p": "low"}, recipient="agent-1", priority=MessagePriority.LOW,
+            MessageType.INFORMATION,
+            "a",
+            AgentLevel.TACTICAL,
+            {"p": "low"},
+            recipient="agent-1",
+            priority=MessagePriority.LOW,
         )
         high = Message(
-            MessageType.COMMAND, "a", AgentLevel.STRATEGIC,
-            {"p": "high"}, recipient="agent-1", priority=MessagePriority.HIGH,
+            MessageType.COMMAND,
+            "a",
+            AgentLevel.STRATEGIC,
+            {"p": "high"},
+            recipient="agent-1",
+            priority=MessagePriority.HIGH,
         )
         channel.send_message(low)
         channel.send_message(high)
@@ -205,8 +236,11 @@ class TestHierarchicalChannel:
     def test_get_pending_messages(self, channel):
         for i in range(5):
             msg = Message(
-                MessageType.INFORMATION, "sender", AgentLevel.TACTICAL,
-                {"i": i}, recipient="agent-1",
+                MessageType.INFORMATION,
+                "sender",
+                AgentLevel.TACTICAL,
+                {"i": i},
+                recipient="agent-1",
             )
             channel.send_message(msg)
 
@@ -219,8 +253,11 @@ class TestHierarchicalChannel:
         assert sub_id is not None
 
         msg = Message(
-            MessageType.INFORMATION, "sender", AgentLevel.TACTICAL,
-            {"data": "test"}, recipient="agent-1",
+            MessageType.INFORMATION,
+            "sender",
+            AgentLevel.TACTICAL,
+            {"data": "test"},
+            recipient="agent-1",
         )
         channel.send_message(msg)
 
@@ -240,8 +277,11 @@ class TestHierarchicalChannel:
     def test_clear_queue(self, channel):
         for i in range(3):
             msg = Message(
-                MessageType.INFORMATION, "s", AgentLevel.TACTICAL,
-                {}, recipient="agent-1",
+                MessageType.INFORMATION,
+                "s",
+                AgentLevel.TACTICAL,
+                {},
+                recipient="agent-1",
             )
             channel.send_message(msg)
 
@@ -285,8 +325,11 @@ class TestCollaborationChannel:
 
     def test_send_direct_message(self, channel):
         msg = Message(
-            MessageType.INFORMATION, "agent-1", AgentLevel.TACTICAL,
-            {"info": "hello"}, recipient="agent-2",
+            MessageType.INFORMATION,
+            "agent-1",
+            AgentLevel.TACTICAL,
+            {"info": "hello"},
+            recipient="agent-2",
         )
         assert channel.send_message(msg) is True
 
@@ -297,7 +340,9 @@ class TestCollaborationChannel:
     def test_group_messaging(self, channel):
         group_id = channel.create_group(name="Team", members=["a1", "a2", "a3"])
         msg = Message(
-            MessageType.INFORMATION, "a1", AgentLevel.TACTICAL,
+            MessageType.INFORMATION,
+            "a1",
+            AgentLevel.TACTICAL,
             {"info": "group msg"},
             metadata={"group_id": group_id},  # routing via metadata
         )
@@ -367,7 +412,9 @@ class TestDataStore:
         assert store.get_versions("d1") == []
 
     def test_data_info(self, store):
-        store.store_data("d1", {"data": "x"}, metadata={"owner": "agent-1"}, compress=False)
+        store.store_data(
+            "d1", {"data": "x"}, metadata={"owner": "agent-1"}, compress=False
+        )
         info = store.get_data_info("d1")
         assert info is not None
         assert info["metadata"]["owner"] == "agent-1"
@@ -387,8 +434,11 @@ class TestDataChannel:
 
     def test_send_message_with_data(self, channel):
         msg = Message(
-            MessageType.INFORMATION, "agent-1", AgentLevel.TACTICAL,
-            {"data_id": "d1", "info": "dataset ready"}, recipient="agent-2",
+            MessageType.INFORMATION,
+            "agent-1",
+            AgentLevel.TACTICAL,
+            {"data_id": "d1", "info": "dataset ready"},
+            recipient="agent-2",
         )
         assert channel.send_message(msg) is True
 
@@ -421,7 +471,10 @@ class TestMessageMiddleware:
 
     def test_determine_channel_command(self, middleware):
         msg = Message(
-            MessageType.COMMAND, "s", AgentLevel.STRATEGIC, {},
+            MessageType.COMMAND,
+            "s",
+            AgentLevel.STRATEGIC,
+            {},
             recipient="t",
         )
         ch_type = middleware.determine_channel(msg)
@@ -429,7 +482,10 @@ class TestMessageMiddleware:
 
     def test_determine_channel_information(self, middleware):
         msg = Message(
-            MessageType.INFORMATION, "s", AgentLevel.TACTICAL, {},
+            MessageType.INFORMATION,
+            "s",
+            AgentLevel.TACTICAL,
+            {},
             recipient="t",
         )
         ch_type = middleware.determine_channel(msg)
@@ -438,13 +494,18 @@ class TestMessageMiddleware:
 
     def test_send_and_receive_via_middleware(self, middleware):
         msg = CommandMessage(
-            "strategic-1", AgentLevel.STRATEGIC, "analyze",
-            {"text": "hello"}, "tactical-1",
+            "strategic-1",
+            AgentLevel.STRATEGIC,
+            "analyze",
+            {"text": "hello"},
+            "tactical-1",
         )
         assert middleware.send_message(msg) is True
 
         received = middleware.receive_message(
-            "tactical-1", channel_type=ChannelType.HIERARCHICAL, timeout=1.0,
+            "tactical-1",
+            channel_type=ChannelType.HIERARCHICAL,
+            timeout=1.0,
         )
         assert received is not None
         assert received.id == msg.id
@@ -455,14 +516,19 @@ class TestMessageMiddleware:
         middleware.register_message_handler(MessageType.COMMAND, handler)
 
         msg = CommandMessage(
-            "strategic-1", AgentLevel.STRATEGIC, "test",
-            {}, "tactical-1",
+            "strategic-1",
+            AgentLevel.STRATEGIC,
+            "test",
+            {},
+            "tactical-1",
         )
         middleware.send_message(msg)
 
         # Handlers are triggered on receive_message, not send_message
         middleware.receive_message(
-            "tactical-1", channel_type=ChannelType.HIERARCHICAL, timeout=1.0,
+            "tactical-1",
+            channel_type=ChannelType.HIERARCHICAL,
+            timeout=1.0,
         )
         handler.assert_called_once()
 
@@ -472,20 +538,28 @@ class TestMessageMiddleware:
         middleware.register_global_handler(handler)
 
         msg = Message(
-            MessageType.INFORMATION, "s", AgentLevel.TACTICAL, {},
+            MessageType.INFORMATION,
+            "s",
+            AgentLevel.TACTICAL,
+            {},
             recipient="r",
         )
         middleware.send_message(msg)
 
         # Trigger handlers by receiving the message
         middleware.receive_message(
-            "r", channel_type=ChannelType.HIERARCHICAL, timeout=1.0,
+            "r",
+            channel_type=ChannelType.HIERARCHICAL,
+            timeout=1.0,
         )
         handler.assert_called_once()
 
     def test_statistics(self, middleware):
         msg = Message(
-            MessageType.COMMAND, "s", AgentLevel.STRATEGIC, {},
+            MessageType.COMMAND,
+            "s",
+            AgentLevel.STRATEGIC,
+            {},
             recipient="r",
         )
         middleware.send_message(msg)
@@ -495,13 +569,17 @@ class TestMessageMiddleware:
     def test_get_pending_messages(self, middleware):
         for i in range(3):
             msg = Message(
-                MessageType.INFORMATION, "s", AgentLevel.TACTICAL,
-                {"i": i}, recipient="agent-1",
+                MessageType.INFORMATION,
+                "s",
+                AgentLevel.TACTICAL,
+                {"i": i},
+                recipient="agent-1",
             )
             middleware.send_message(msg)
 
         pending = middleware.get_pending_messages(
-            "agent-1", channel_type=ChannelType.HIERARCHICAL,
+            "agent-1",
+            channel_type=ChannelType.HIERARCHICAL,
         )
         assert len(pending) >= 1
 
@@ -531,7 +609,9 @@ class TestTopic:
         assert sub_id is not None
 
         msg = Message(
-            MessageType.PUBLICATION, "system", AgentLevel.SYSTEM,
+            MessageType.PUBLICATION,
+            "system",
+            AgentLevel.SYSTEM,
             {"event": "update"},
         )
         notified = topic.publish_message(msg)
@@ -549,7 +629,9 @@ class TestTopic:
         topic = Topic("test-topic")
         for i in range(5):
             msg = Message(
-                MessageType.PUBLICATION, "system", AgentLevel.SYSTEM,
+                MessageType.PUBLICATION,
+                "system",
+                AgentLevel.SYSTEM,
                 {"i": i},
             )
             topic.publish_message(msg)
@@ -599,7 +681,9 @@ class TestPublishSubscribeProtocol:
         protocol.subscribe("test-topic", "agent-1", callback=callback)
 
         notified = protocol.publish(
-            "test-topic", "system", AgentLevel.SYSTEM,
+            "test-topic",
+            "system",
+            AgentLevel.SYSTEM,
             content={"event": "update"},
         )
         assert len(notified) >= 1

--- a/tests/unit/argumentation_analysis/test_plugin_framework.py
+++ b/tests/unit/argumentation_analysis/test_plugin_framework.py
@@ -39,7 +39,6 @@ from argumentation_analysis.plugin_framework.benchmarking.benchmark_service impo
 )
 from argumentation_analysis.plugin_framework.agents.agent_loader import AgentLoader
 
-
 # ============================================================================
 # contracts.py — OrchestrationRequest
 # ============================================================================
@@ -118,9 +117,7 @@ class TestOrchestrationResponse:
     """Tests for OrchestrationResponse Pydantic model."""
 
     def test_success_response(self):
-        resp = OrchestrationResponse(
-            status="success", result={"output": "data"}
-        )
+        resp = OrchestrationResponse(status="success", result={"output": "data"})
         assert resp.status == "success"
         assert resp.result == {"output": "data"}
         assert resp.error_message is None
@@ -362,7 +359,9 @@ class TestBenchmarkSuiteResult:
             results=[
                 BenchmarkResult(request_id="r1", is_success=True, duration_ms=30.0),
                 BenchmarkResult(request_id="r2", is_success=True, duration_ms=50.0),
-                BenchmarkResult(request_id="r3", is_success=False, duration_ms=20.0, error="e"),
+                BenchmarkResult(
+                    request_id="r3", is_success=False, duration_ms=20.0, error="e"
+                ),
             ],
         )
         assert sr.total_runs == 3
@@ -454,11 +453,15 @@ class TestPluginLoader:
         # Make inspect.getmembers find our class
         fake_module.FakePlugin = FakePlugin
 
-        with patch("argumentation_analysis.plugin_framework.core.plugin_loader.importlib.import_module") as mock_import:
+        with patch(
+            "argumentation_analysis.plugin_framework.core.plugin_loader.importlib.import_module"
+        ) as mock_import:
             mock_import.return_value = fake_module
 
             # We need inspect.getmembers to work on our mock module
-            with patch("argumentation_analysis.plugin_framework.core.plugin_loader.inspect.getmembers") as mock_members:
+            with patch(
+                "argumentation_analysis.plugin_framework.core.plugin_loader.inspect.getmembers"
+            ) as mock_members:
                 mock_members.return_value = [("FakePlugin", FakePlugin)]
 
                 loader = PluginLoader([str(tmp_path)])
@@ -474,9 +477,13 @@ class TestPluginLoader:
 
         fake_module = MagicMock()
 
-        with patch("argumentation_analysis.plugin_framework.core.plugin_loader.importlib.import_module") as mock_import:
+        with patch(
+            "argumentation_analysis.plugin_framework.core.plugin_loader.importlib.import_module"
+        ) as mock_import:
             mock_import.return_value = fake_module
-            with patch("argumentation_analysis.plugin_framework.core.plugin_loader.inspect.getmembers") as mock_members:
+            with patch(
+                "argumentation_analysis.plugin_framework.core.plugin_loader.inspect.getmembers"
+            ) as mock_members:
                 # Return BasePlugin itself — should be filtered out
                 bp = BasePlugin
                 bp.__module__ = "src.core.plugins.standard.base_mod"
@@ -516,8 +523,12 @@ class TestPluginLoader:
         FakePlugin2.__name__ = "FakePlugin"
         FakePlugin2.__module__ = "src.core.plugins.standard.plug2"
 
-        with patch("argumentation_analysis.plugin_framework.core.plugin_loader.importlib.import_module") as mock_import:
-            with patch("argumentation_analysis.plugin_framework.core.plugin_loader.inspect.getmembers") as mock_members:
+        with patch(
+            "argumentation_analysis.plugin_framework.core.plugin_loader.importlib.import_module"
+        ) as mock_import:
+            with patch(
+                "argumentation_analysis.plugin_framework.core.plugin_loader.inspect.getmembers"
+            ) as mock_members:
                 call_count = [0]
 
                 def side_effect_import(name):
@@ -573,9 +584,7 @@ class TestOrchestrationService:
         plugin.do_thing.return_value = {"ok": True}
         svc = self._make_service(p=plugin)
 
-        req = OrchestrationRequest(
-            mode="direct_plugin_call", target="p.do_thing"
-        )
+        req = OrchestrationRequest(mode="direct_plugin_call", target="p.do_thing")
         resp = svc.handle_request(req)
 
         assert resp.status == "success"
@@ -583,9 +592,7 @@ class TestOrchestrationService:
 
     def test_workflow_execution_not_supported(self):
         svc = self._make_service()
-        req = OrchestrationRequest(
-            mode="workflow_execution", target="wf1"
-        )
+        req = OrchestrationRequest(mode="workflow_execution", target="wf1")
         resp = svc.handle_request(req)
 
         assert resp.status == "error"
@@ -593,9 +600,7 @@ class TestOrchestrationService:
 
     def test_missing_plugin_error(self):
         svc = self._make_service()
-        req = OrchestrationRequest(
-            mode="direct_plugin_call", target="nonexistent.func"
-        )
+        req = OrchestrationRequest(mode="direct_plugin_call", target="nonexistent.func")
         resp = svc.handle_request(req)
 
         assert resp.status == "error"
@@ -605,9 +610,7 @@ class TestOrchestrationService:
         plugin = MagicMock(spec=[])  # Empty spec -> no attributes
         svc = self._make_service(p=plugin)
 
-        req = OrchestrationRequest(
-            mode="direct_plugin_call", target="p.missing_func"
-        )
+        req = OrchestrationRequest(mode="direct_plugin_call", target="p.missing_func")
         resp = svc.handle_request(req)
 
         assert resp.status == "error"
@@ -615,9 +618,7 @@ class TestOrchestrationService:
 
     def test_target_without_dot_separator_error(self):
         svc = self._make_service()
-        req = OrchestrationRequest(
-            mode="direct_plugin_call", target="no_dot_here"
-        )
+        req = OrchestrationRequest(mode="direct_plugin_call", target="no_dot_here")
         resp = svc.handle_request(req)
 
         assert resp.status == "error"
@@ -625,9 +626,7 @@ class TestOrchestrationService:
 
     def test_target_with_multiple_dots_error(self):
         svc = self._make_service()
-        req = OrchestrationRequest(
-            mode="direct_plugin_call", target="a.b.c"
-        )
+        req = OrchestrationRequest(mode="direct_plugin_call", target="a.b.c")
         resp = svc.handle_request(req)
 
         assert resp.status == "error"
@@ -638,9 +637,7 @@ class TestOrchestrationService:
         plugin.crash.side_effect = RuntimeError("boom")
         svc = self._make_service(my=plugin)
 
-        req = OrchestrationRequest(
-            mode="direct_plugin_call", target="my.crash"
-        )
+        req = OrchestrationRequest(mode="direct_plugin_call", target="my.crash")
         resp = svc.handle_request(req)
 
         assert resp.status == "error"
@@ -853,10 +850,14 @@ class TestBenchmarkService:
         )
         bench = BenchmarkService(orch)
 
-        result = bench.run_suite("myplugin", "analyze", [
-            {"text": "hello"},
-            {"text": "world"},
-        ])
+        result = bench.run_suite(
+            "myplugin",
+            "analyze",
+            [
+                {"text": "hello"},
+                {"text": "world"},
+            ],
+        )
 
         assert isinstance(result, BenchmarkSuiteResult)
         assert result.plugin_name == "myplugin"
@@ -927,7 +928,8 @@ class TestBenchmarkService:
         # The custom_metrics dict itself is cleared
         # But the result's custom_metrics comes from what was recorded DURING the run
         assert all(
-            "stale" not in r.custom_metrics for r in bench.run_suite("p", "c", [{"x": 1}]).results
+            "stale" not in r.custom_metrics
+            for r in bench.run_suite("p", "c", [{"x": 1}]).results
         )
 
     def test_run_suite_request_ids_sequential(self):

--- a/tests/unit/argumentation_analysis/test_plugin_loader.py
+++ b/tests/unit/argumentation_analysis/test_plugin_loader.py
@@ -22,7 +22,6 @@ from argumentation_analysis.agents.core.exceptions import (
     CircularDependencyError,
 )
 
-
 # ===========================================================================
 # BasePlugin / LegoPlugin Tests
 # ===========================================================================
@@ -46,7 +45,9 @@ class ConcreteLegoPlugin(LegoPlugin):
     requires = ["llm_service"]
     parameters = [
         ParameterSpec("language", type="string", default="fr"),
-        ParameterSpec("threshold", type="float", required=True, description="Min confidence"),
+        ParameterSpec(
+            "threshold", type="float", required=True, description="Min confidence"
+        ),
     ]
 
     @property
@@ -269,7 +270,10 @@ class {class_name}(BasePlugin):
     def test_load_with_dependencies(self, loader, tmp_path):
         self._create_plugin_dir(tmp_path, "base_plugin", "base_mod", "BaseP")
         self._create_plugin_dir(
-            tmp_path, "dependent_plugin", "dep_mod", "DepP",
+            tmp_path,
+            "dependent_plugin",
+            "dep_mod",
+            "DepP",
             deps=["base_plugin"],
         )
 

--- a/tests/unit/argumentation_analysis/test_shared_state.py
+++ b/tests/unit/argumentation_analysis/test_shared_state.py
@@ -458,9 +458,7 @@ class TestUnifiedAnalysisStateNewMethods(unittest.TestCase):
         self.state = UnifiedAnalysisState("Test text")
 
     def test_add_neural_fallacy_score(self):
-        nf_id = self.state.add_neural_fallacy_score(
-            "you're dumb", "ad_hominem", 0.92
-        )
+        nf_id = self.state.add_neural_fallacy_score("you're dumb", "ad_hominem", 0.92)
         self.assertTrue(nf_id.startswith("nf_"))
         self.assertEqual(len(self.state.neural_fallacy_scores), 1)
         self.assertEqual(self.state.neural_fallacy_scores[0]["label"], "ad_hominem")
@@ -471,7 +469,9 @@ class TestUnifiedAnalysisStateNewMethods(unittest.TestCase):
         nf_id = self.state.add_neural_fallacy_score(
             "text", "straw_man", 0.75, detector="custom_model"
         )
-        self.assertEqual(self.state.neural_fallacy_scores[0]["detector"], "custom_model")
+        self.assertEqual(
+            self.state.neural_fallacy_scores[0]["detector"], "custom_model"
+        )
 
     def test_add_transcription_segment(self):
         ts_id = self.state.add_transcription_segment(0.0, 1.5, "Hello world", "Alice")

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_code_manipulation_utils.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_code_manipulation_utils.py
@@ -10,8 +10,8 @@ from argumentation_analysis.core.utils.code_manipulation_utils import (
     refactor_rename_function,
 )
 
-
 # ── ImportUpdater ──
+
 
 class TestImportUpdater:
     def test_init(self):
@@ -21,6 +21,7 @@ class TestImportUpdater:
 
     def test_replaces_matching_import(self):
         import ast
+
         code = "from old.module import something"
         tree = ast.parse(code)
         updater = ImportUpdater("old.module", "new.module")
@@ -31,6 +32,7 @@ class TestImportUpdater:
 
     def test_no_match_unchanged(self):
         import ast
+
         code = "from other.module import something"
         tree = ast.parse(code)
         updater = ImportUpdater("old.module", "new.module")
@@ -40,6 +42,7 @@ class TestImportUpdater:
 
     def test_multiple_imports(self):
         import ast
+
         code = "from old.mod import a\nfrom old.mod import b\nfrom keep.mod import c"
         tree = ast.parse(code)
         updater = ImportUpdater("old.mod", "new.mod")
@@ -50,6 +53,7 @@ class TestImportUpdater:
 
 
 # ── refactor_update_import ──
+
 
 class TestRefactorUpdateImport:
     def test_basic_replacement(self):
@@ -89,6 +93,7 @@ class TestRefactorUpdateImport:
 
 # ── FunctionRenamer ──
 
+
 class TestFunctionRenamer:
     def test_init(self):
         renamer = FunctionRenamer("old_fn", "new_fn")
@@ -97,6 +102,7 @@ class TestFunctionRenamer:
 
     def test_renames_matching_call(self):
         import ast
+
         code = "old_fn(x, y)"
         tree = ast.parse(code)
         renamer = FunctionRenamer("old_fn", "new_fn")
@@ -107,6 +113,7 @@ class TestFunctionRenamer:
 
     def test_no_match_unchanged(self):
         import ast
+
         code = "other_fn(x)"
         tree = ast.parse(code)
         renamer = FunctionRenamer("old_fn", "new_fn")
@@ -116,6 +123,7 @@ class TestFunctionRenamer:
 
     def test_attribute_call_not_affected(self):
         import ast
+
         code = "obj.old_fn(x)"
         tree = ast.parse(code)
         renamer = FunctionRenamer("old_fn", "new_fn")
@@ -126,6 +134,7 @@ class TestFunctionRenamer:
 
 
 # ── refactor_rename_function ──
+
 
 class TestRefactorRenameFunction:
     def test_basic_rename(self):

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_error_management.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_error_management.py
@@ -8,8 +8,8 @@ from argumentation_analysis.core.utils.error_management import (
     ErrorRecoveryManager,
 )
 
-
 # ── StateManager ──
+
 
 class TestStateManager:
     @pytest.fixture
@@ -91,6 +91,7 @@ class TestStateManager:
 
 
 # ── ErrorRecoveryManager ──
+
 
 class TestErrorRecoveryManager:
     @pytest.fixture

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_file_loaders.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_file_loaders.py
@@ -12,8 +12,8 @@ from argumentation_analysis.core.utils.file_loaders import (
     load_document_content,
 )
 
-
 # ── load_json_file ──
+
 
 class TestLoadJsonFile:
     def test_load_dict(self, tmp_path):
@@ -24,7 +24,7 @@ class TestLoadJsonFile:
 
     def test_load_list(self, tmp_path):
         f = tmp_path / "data.json"
-        f.write_text('[1, 2, 3]', encoding="utf-8")
+        f.write_text("[1, 2, 3]", encoding="utf-8")
         result = load_json_file(f)
         assert result == [1, 2, 3]
 
@@ -70,6 +70,7 @@ class TestLoadJsonFile:
 
 # ── load_extracts ──
 
+
 class TestLoadExtracts:
     def test_returns_list(self, tmp_path):
         f = tmp_path / "extracts.json"
@@ -93,6 +94,7 @@ class TestLoadExtracts:
 
 
 # ── load_text_file ──
+
 
 class TestLoadTextFile:
     def test_basic(self, tmp_path):
@@ -129,6 +131,7 @@ class TestLoadTextFile:
 
 
 # ── load_document_content ──
+
 
 class TestLoadDocumentContent:
     def test_txt_file(self, tmp_path):

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_file_savers.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_file_savers.py
@@ -11,8 +11,8 @@ from argumentation_analysis.core.utils.file_savers import (
     save_temp_extracts_json,
 )
 
-
 # ── save_json_file ──
+
 
 class TestSaveJsonFile:
     def test_save_dict(self, tmp_path):
@@ -60,6 +60,7 @@ class TestSaveJsonFile:
 
 # ── save_text_file ──
 
+
 class TestSaveTextFile:
     def test_save_basic(self, tmp_path):
         f = tmp_path / "out.txt"
@@ -99,6 +100,7 @@ class TestSaveTextFile:
 
 
 # ── save_temp_extracts_json ──
+
 
 class TestSaveTempExtractsJson:
     def test_saves_extracts(self, tmp_path, monkeypatch):

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_file_validation_utils.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_file_validation_utils.py
@@ -11,8 +11,8 @@ from argumentation_analysis.core.utils.file_validation_utils import (
     check_markdown_file_readable_and_basic_structure,
 )
 
-
 # ── check_text_file_readable_and_not_empty ──
+
 
 class TestCheckTextFile:
     def test_valid_file(self, tmp_path):
@@ -59,6 +59,7 @@ class TestCheckTextFile:
 
 # ── check_json_file_valid ──
 
+
 class TestCheckJsonFile:
     def test_valid_json_dict(self, tmp_path):
         f = tmp_path / "data.json"
@@ -69,20 +70,20 @@ class TestCheckJsonFile:
 
     def test_valid_json_list(self, tmp_path):
         f = tmp_path / "data.json"
-        f.write_text('[1, 2, 3]', encoding="utf-8")
+        f.write_text("[1, 2, 3]", encoding="utf-8")
         valid, msg = check_json_file_valid(f)
         assert valid is True
 
     def test_empty_dict(self, tmp_path):
         f = tmp_path / "data.json"
-        f.write_text('{}', encoding="utf-8")
+        f.write_text("{}", encoding="utf-8")
         valid, msg = check_json_file_valid(f)
         assert valid is False
         assert "vide" in msg
 
     def test_empty_list(self, tmp_path):
         f = tmp_path / "data.json"
-        f.write_text('[]', encoding="utf-8")
+        f.write_text("[]", encoding="utf-8")
         valid, msg = check_json_file_valid(f)
         assert valid is False
 
@@ -106,6 +107,7 @@ class TestCheckJsonFile:
 
 
 # ── check_markdown_file_readable_and_basic_structure ──
+
 
 class TestCheckMarkdownFile:
     def test_valid_markdown(self, tmp_path):

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_filesystem_utils.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_filesystem_utils.py
@@ -11,8 +11,8 @@ from argumentation_analysis.core.utils.filesystem_utils import (
     get_all_files_in_directory,
 )
 
-
 # ── ensure_directory_exists ──
+
 
 class TestEnsureDirectoryExists:
     def test_creates_new_directory(self, tmp_path):
@@ -34,6 +34,7 @@ class TestEnsureDirectoryExists:
 
 
 # ── create_gitkeep_in_directory ──
+
 
 class TestCreateGitkeepInDirectory:
     def test_creates_gitkeep(self, tmp_path):
@@ -65,6 +66,7 @@ class TestCreateGitkeepInDirectory:
 
 
 # ── check_files_existence ──
+
 
 class TestCheckFilesExistence:
     def test_all_exist(self, tmp_path):
@@ -110,6 +112,7 @@ class TestCheckFilesExistence:
 
 # ── get_all_files_in_directory ──
 
+
 class TestGetAllFilesInDirectory:
     def test_all_files(self, tmp_path):
         (tmp_path / "a.txt").write_text("a")
@@ -137,7 +140,9 @@ class TestGetAllFilesInDirectory:
         subdir.mkdir()
         (tmp_path / "root.txt").write_text("r")
         (subdir / "nested.txt").write_text("n")
-        files = get_all_files_in_directory(tmp_path, patterns=["*.txt"], recursive=False)
+        files = get_all_files_in_directory(
+            tmp_path, patterns=["*.txt"], recursive=False
+        )
         assert len(files) == 1
 
     def test_exclusions(self, tmp_path):

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_json_utils.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_json_utils.py
@@ -11,8 +11,8 @@ from argumentation_analysis.core.utils.json_utils import (
     filter_list_in_json_data,
 )
 
-
 # ── load_json_from_file ──
+
 
 class TestLoadJsonFromFile:
     def test_load_dict(self, tmp_path):
@@ -23,7 +23,7 @@ class TestLoadJsonFromFile:
 
     def test_load_list(self, tmp_path):
         f = tmp_path / "test.json"
-        f.write_text('[1, 2, 3]', encoding="utf-8")
+        f.write_text("[1, 2, 3]", encoding="utf-8")
         result = load_json_from_file(f)
         assert result == [1, 2, 3]
 
@@ -50,6 +50,7 @@ class TestLoadJsonFromFile:
 
 
 # ── save_json_to_file ──
+
 
 class TestSaveJsonToFile:
     def test_save_dict(self, tmp_path):
@@ -97,6 +98,7 @@ class TestSaveJsonToFile:
 
 
 # ── filter_list_in_json_data ──
+
 
 class TestFilterListInJsonData:
     def test_filter_root_list(self):

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_markdown_utils.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_markdown_utils.py
@@ -9,8 +9,8 @@ from argumentation_analysis.core.utils.markdown_utils import (
     convert_markdown_file_to_html,
 )
 
-
 # ── save_markdown_to_html ──
+
 
 class TestSaveMarkdownToHtml:
     def test_basic_conversion(self, tmp_path):
@@ -75,6 +75,7 @@ class TestSaveMarkdownToHtml:
 
 # ── convert_markdown_file_to_html ──
 
+
 class TestConvertMarkdownFileToHtml:
     def test_basic_conversion(self, tmp_path):
         md_file = tmp_path / "input.md"
@@ -98,7 +99,9 @@ class TestConvertMarkdownFileToHtml:
         html_file = tmp_path / "output.html"
         viz_dir = tmp_path / "viz"
         viz_dir.mkdir()
-        result = convert_markdown_file_to_html(md_file, html_file, visualization_dir=viz_dir)
+        result = convert_markdown_file_to_html(
+            md_file, html_file, visualization_dir=viz_dir
+        )
         assert result is True
 
     def test_unicode_file(self, tmp_path):

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_network_utils.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_network_utils.py
@@ -91,9 +91,9 @@ def test_download_file_http_error(mock_requests_get, tmp_path, caplog):
 
     # Après une écriture ratée, on suppose que le fichier partiel existe.
     # La logique de cleanup dans `except RequestException` sera appelée à chaque nouvelle tentative.
-    with patch("argumentation_analysis.core.utils.network_utils.os.remove") as mock_remove, patch.object(
-        Path, "exists", return_value=True
-    ):
+    with patch(
+        "argumentation_analysis.core.utils.network_utils.os.remove"
+    ) as mock_remove, patch.object(Path, "exists", return_value=True):
         with pytest.raises(tenacity.RetryError):
             download_file(url, dest_path)
 
@@ -118,7 +118,9 @@ def test_download_file_size_mismatch(mock_requests_get, tmp_path, caplog):
     # mkdir doit être patché pour éviter FileExistsError de tmp_path
     with patch("builtins.open", mock_open()), patch.object(Path, "mkdir"), patch.object(
         Path, "stat"
-    ) as mock_stat, patch("argumentation_analysis.core.utils.network_utils.os.remove") as mock_remove:
+    ) as mock_stat, patch(
+        "argumentation_analysis.core.utils.network_utils.os.remove"
+    ) as mock_remove:
         mock_stat.return_value.st_mode = stat.S_IFREG
         mock_stat.return_value.st_size = actual_size
 
@@ -173,7 +175,9 @@ def test_download_file_cleans_up_partial_on_request_exception(tmp_path, caplog):
     with patch(
         "requests.get",
         side_effect=requests.exceptions.ConnectionError("Simulated network error"),
-    ), patch("argumentation_analysis.core.utils.network_utils.os.remove") as mock_remove, patch.object(
+    ), patch(
+        "argumentation_analysis.core.utils.network_utils.os.remove"
+    ) as mock_remove, patch.object(
         Path, "exists", return_value=True
     ):
         with pytest.raises(tenacity.RetryError):
@@ -197,9 +201,9 @@ def test_download_file_cleans_up_partial_on_unexpected_exception(
         "Unexpected error during iteration"
     )
 
-    with patch("argumentation_analysis.core.utils.network_utils.os.remove") as mock_remove, patch.object(
-        Path, "exists", return_value=True
-    ):
+    with patch(
+        "argumentation_analysis.core.utils.network_utils.os.remove"
+    ) as mock_remove, patch.object(Path, "exists", return_value=True):
         with pytest.raises(ValueError, match="Unexpected error during iteration"):
             download_file(url, dest_path)
 
@@ -219,7 +223,8 @@ def test_download_file_handles_os_error_on_remove_after_exception(tmp_path, capl
     with patch(
         "requests.get", side_effect=requests.exceptions.Timeout("Simulated timeout")
     ), patch.object(Path, "exists", return_value=True), patch(
-        "argumentation_analysis.core.utils.network_utils.os.remove", side_effect=OSError("Simulated permission error on remove")
+        "argumentation_analysis.core.utils.network_utils.os.remove",
+        side_effect=OSError("Simulated permission error on remove"),
     ):
         with pytest.raises(tenacity.RetryError):
             download_file(url, dest_path)

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_path_operations.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_path_operations.py
@@ -13,8 +13,8 @@ from argumentation_analysis.core.utils.path_operations import (
     PATH_TYPE_DIRECTORY,
 )
 
-
 # ── sanitize_filename ──
+
 
 class TestSanitizeFilename:
     def test_simple_name(self):
@@ -86,6 +86,7 @@ class TestSanitizeFilename:
 
 # ── check_path_exists ──
 
+
 class TestCheckPathExists:
     def test_existing_file(self, tmp_path):
         f = tmp_path / "test.txt"
@@ -118,6 +119,7 @@ class TestCheckPathExists:
 
 
 # ── create_archive_path ──
+
 
 class TestCreateArchivePath:
     def test_basic(self, tmp_path):
@@ -160,6 +162,7 @@ class TestCreateArchivePath:
 
 
 # ── archive_file ──
+
 
 class TestArchiveFile:
     def test_archive_moves_file(self, tmp_path):

--- a/tests/unit/argumentation_analysis/utils/core_utils/test_shell_utils.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_shell_utils.py
@@ -36,9 +36,7 @@ class TestRunShellCommand:
         assert "error msg" in stderr
 
     def test_command_not_found(self):
-        code, stdout, stderr = run_shell_command(
-            ["nonexistent_command_12345"]
-        )
+        code, stdout, stderr = run_shell_command(["nonexistent_command_12345"])
         assert code == -1
 
     def test_capture_output_false(self):
@@ -57,15 +55,22 @@ class TestRunShellCommand:
         )
         assert code == 0
         # Output should contain the tmp_path
-        assert str(tmp_path).replace("\\", "/") in stdout.replace("\\", "/") or \
-               tmp_path.name in stdout
+        assert (
+            str(tmp_path).replace("\\", "/") in stdout.replace("\\", "/")
+            or tmp_path.name in stdout
+        )
 
     def test_custom_env(self):
         import os
+
         env = os.environ.copy()
         env["TEST_VAR_SHELL_UTILS"] = "custom_value"
         code, stdout, stderr = run_shell_command(
-            [sys.executable, "-c", "import os; print(os.environ.get('TEST_VAR_SHELL_UTILS', ''))"],
+            [
+                sys.executable,
+                "-c",
+                "import os; print(os.environ.get('TEST_VAR_SHELL_UTILS', ''))",
+            ],
             env=env,
         )
         assert code == 0
@@ -81,9 +86,7 @@ class TestRunShellCommand:
 
     def test_default_description_string(self):
         # Verify it doesn't crash with auto-generated description
-        code, stdout, stderr = run_shell_command(
-            [sys.executable, "-c", "pass"]
-        )
+        code, stdout, stderr = run_shell_command([sys.executable, "-c", "pass"])
         assert code == 0
 
     def test_default_description_long_command(self):
@@ -94,9 +97,7 @@ class TestRunShellCommand:
         assert code == 0
 
     def test_return_types(self):
-        code, stdout, stderr = run_shell_command(
-            [sys.executable, "-c", "pass"]
-        )
+        code, stdout, stderr = run_shell_command([sys.executable, "-c", "pass"])
         assert isinstance(code, int)
         assert isinstance(stdout, str)
         assert isinstance(stderr, str)

--- a/tests/unit/argumentation_analysis/utils/dev_tools/test_dev_tools_utilities.py
+++ b/tests/unit/argumentation_analysis/utils/dev_tools/test_dev_tools_utilities.py
@@ -11,7 +11,6 @@ import pytest
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
-
 # ============================================================================
 # project_structure_utils tests
 # ============================================================================
@@ -67,7 +66,9 @@ class TestMapPackageToModule:
     def test_custom_mapping_overrides_default(self):
         """Custom mapping overrides default mapping."""
         custom = {"argumentation_analysis.utils": "Custom Utils"}
-        result = map_package_to_module("argumentation_analysis.utils", custom_mapping=custom)
+        result = map_package_to_module(
+            "argumentation_analysis.utils", custom_mapping=custom
+        )
         assert result == "Custom Utils"
 
     def test_custom_mapping_adds_new_entry(self):
@@ -78,7 +79,9 @@ class TestMapPackageToModule:
 
     def test_custom_mapping_none_uses_defaults(self):
         """None custom_mapping uses defaults only."""
-        result = map_package_to_module("argumentation_analysis.services", custom_mapping=None)
+        result = map_package_to_module(
+            "argumentation_analysis.services", custom_mapping=None
+        )
         assert result == "Argumentation Services"
 
     def test_most_specific_partial_match_wins(self):
@@ -101,7 +104,6 @@ from argumentation_analysis.utils.dev_tools.coverage_utils import (
     create_initial_coverage_history,
     save_coverage_history,
 )
-
 
 SAMPLE_COVERAGE_XML = """<?xml version="1.0" ?>
 <coverage version="7.0" timestamp="1234567890" lines-valid="1000" lines-covered="750"

--- a/tests/unit/argumentation_analysis/utils/dev_tools/test_env_checks.py
+++ b/tests/unit/argumentation_analysis/utils/dev_tools/test_env_checks.py
@@ -17,10 +17,10 @@ from argumentation_analysis.utils.dev_tools.env_checks import (
     check_python_dependencies,
 )
 
-
 # ============================================================
 # _parse_requirement / _parse_version
 # ============================================================
+
 
 class TestParseHelpers:
     def test_parse_requirement_simple(self):
@@ -53,6 +53,7 @@ class TestParseHelpers:
 # _run_command
 # ============================================================
 
+
 class TestRunCommand:
     @patch("argumentation_analysis.utils.dev_tools.env_checks.subprocess.Popen")
     def test_success(self, mock_popen):
@@ -67,6 +68,7 @@ class TestRunCommand:
     @patch("argumentation_analysis.utils.dev_tools.env_checks.subprocess.Popen")
     def test_timeout(self, mock_popen):
         import subprocess
+
         proc = MagicMock()
         proc.communicate.side_effect = subprocess.TimeoutExpired(cmd="cmd", timeout=30)
         mock_popen.return_value = proc
@@ -92,9 +94,13 @@ class TestRunCommand:
 # check_java_environment
 # ============================================================
 
+
 class TestCheckJavaEnvironment:
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
-    @patch("argumentation_analysis.utils.dev_tools.env_checks.os.environ", {"JAVA_HOME": "/fake/java"})
+    @patch(
+        "argumentation_analysis.utils.dev_tools.env_checks.os.environ",
+        {"JAVA_HOME": "/fake/java"},
+    )
     @patch("argumentation_analysis.utils.dev_tools.env_checks._PathInternal")
     def test_java_home_valid_and_java_works(self, mock_path_cls, mock_run):
         # Setup JAVA_HOME path mock
@@ -103,11 +109,13 @@ class TestCheckJavaEnvironment:
         mock_java_exe = MagicMock()
         mock_java_exe.exists.return_value = True
         mock_java_exe.is_file.return_value = True
-        mock_home_path.__truediv__ = MagicMock(side_effect=lambda x: mock_java_exe if "java" in str(x) else MagicMock())
+        mock_home_path.__truediv__ = MagicMock(
+            side_effect=lambda x: mock_java_exe if "java" in str(x) else MagicMock()
+        )
         # Return the home path when _PathInternal is called with JAVA_HOME
         mock_path_cls.return_value = mock_home_path
         # java -version succeeds
-        mock_run.return_value = (0, "", "openjdk version \"11.0.1\"")
+        mock_run.return_value = (0, "", 'openjdk version "11.0.1"')
         result = check_java_environment()
         assert result is True
 
@@ -128,7 +136,10 @@ class TestCheckJavaEnvironment:
         assert result is False
 
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
-    @patch("argumentation_analysis.utils.dev_tools.env_checks.os.environ", {"JAVA_HOME": "/fake"})
+    @patch(
+        "argumentation_analysis.utils.dev_tools.env_checks.os.environ",
+        {"JAVA_HOME": "/fake"},
+    )
     @patch("argumentation_analysis.utils.dev_tools.env_checks._PathInternal")
     def test_java_home_not_a_dir(self, mock_path_cls, mock_run):
         mock_home_path = MagicMock()
@@ -139,7 +150,10 @@ class TestCheckJavaEnvironment:
         assert result is False
 
     @patch("argumentation_analysis.utils.dev_tools.env_checks._run_command")
-    @patch("argumentation_analysis.utils.dev_tools.env_checks.os.environ", {"JAVA_HOME": "/fake/java"})
+    @patch(
+        "argumentation_analysis.utils.dev_tools.env_checks.os.environ",
+        {"JAVA_HOME": "/fake/java"},
+    )
     @patch("argumentation_analysis.utils.dev_tools.env_checks._PathInternal")
     def test_java_version_returns_no_output(self, mock_path_cls, mock_run):
         mock_home_path = MagicMock()
@@ -159,6 +173,7 @@ class TestCheckJavaEnvironment:
 # check_python_dependencies
 # ============================================================
 
+
 class TestCheckPythonDependencies:
     def test_file_not_found(self, tmp_path):
         result = check_python_dependencies(tmp_path / "nonexistent.txt")
@@ -170,7 +185,9 @@ class TestCheckPythonDependencies:
         result = check_python_dependencies(f)
         assert result is True
 
-    @patch("argumentation_analysis.utils.dev_tools.env_checks.importlib.metadata.version")
+    @patch(
+        "argumentation_analysis.utils.dev_tools.env_checks.importlib.metadata.version"
+    )
     def test_satisfied_dependency(self, mock_version, tmp_path):
         mock_version.return_value = "2.28.0"
         f = tmp_path / "reqs.txt"
@@ -178,7 +195,9 @@ class TestCheckPythonDependencies:
         result = check_python_dependencies(f)
         assert result is True
 
-    @patch("argumentation_analysis.utils.dev_tools.env_checks.importlib.metadata.version")
+    @patch(
+        "argumentation_analysis.utils.dev_tools.env_checks.importlib.metadata.version"
+    )
     def test_unsatisfied_dependency(self, mock_version, tmp_path):
         mock_version.return_value = "1.0.0"
         f = tmp_path / "reqs.txt"
@@ -186,9 +205,12 @@ class TestCheckPythonDependencies:
         result = check_python_dependencies(f)
         assert result is False
 
-    @patch("argumentation_analysis.utils.dev_tools.env_checks.importlib.metadata.version")
+    @patch(
+        "argumentation_analysis.utils.dev_tools.env_checks.importlib.metadata.version"
+    )
     def test_missing_package(self, mock_version, tmp_path):
         import importlib.metadata
+
         mock_version.side_effect = importlib.metadata.PackageNotFoundError("nope")
         f = tmp_path / "reqs.txt"
         f.write_text("nonexistent_package_xyz\n", encoding="utf-8")
@@ -207,7 +229,9 @@ class TestCheckPythonDependencies:
         result = check_python_dependencies(f)
         assert result is True
 
-    @patch("argumentation_analysis.utils.dev_tools.env_checks.importlib.metadata.version")
+    @patch(
+        "argumentation_analysis.utils.dev_tools.env_checks.importlib.metadata.version"
+    )
     def test_no_version_specifier(self, mock_version, tmp_path):
         mock_version.return_value = "1.0.0"
         f = tmp_path / "reqs.txt"
@@ -221,13 +245,17 @@ class TestCheckPythonDependencies:
         result = check_python_dependencies(str(f))
         assert result is True
 
-    @patch("argumentation_analysis.utils.dev_tools.env_checks.importlib.metadata.version")
+    @patch(
+        "argumentation_analysis.utils.dev_tools.env_checks.importlib.metadata.version"
+    )
     def test_multiple_deps_mixed(self, mock_version, tmp_path):
         import importlib.metadata
+
         def side_effect(name):
             if name == "requests":
                 return "2.28.0"
             raise importlib.metadata.PackageNotFoundError(name)
+
         mock_version.side_effect = side_effect
         f = tmp_path / "reqs.txt"
         f.write_text("requests>=2.20\nmissing_pkg\n", encoding="utf-8")

--- a/tests/unit/argumentation_analysis/utils/dev_tools/test_import_testing_utils.py
+++ b/tests/unit/argumentation_analysis/utils/dev_tools/test_import_testing_utils.py
@@ -19,6 +19,7 @@ _test_import_alias = import_testing_utils.test_import
 # test_module_import_by_name
 # ============================================================
 
+
 class TestModuleImportByName:
     def test_existing_module(self):
         success, msg = _import_by_name("json")
@@ -54,6 +55,7 @@ class TestModuleImportByName:
 # test_module_import_by_path
 # ============================================================
 
+
 class TestModuleImportByPath:
     def test_existing_file(self, tmp_path):
         mod_file = tmp_path / "importutil_test_mod_001.py"
@@ -77,7 +79,9 @@ class TestModuleImportByPath:
     def test_with_name_override(self, tmp_path):
         mod_file = tmp_path / "importutil_custom_mod_002.py"
         mod_file.write_text("Y = 99\n", encoding="utf-8")
-        success, msg = _import_by_path(mod_file, module_name_override="importutil_custom_mod_002")
+        success, msg = _import_by_path(
+            mod_file, module_name_override="importutil_custom_mod_002"
+        )
         assert success is True
 
     def test_invalid_path_type(self):

--- a/tests/unit/argumentation_analysis/utils/dev_tools/test_refactoring_utils.py
+++ b/tests/unit/argumentation_analysis/utils/dev_tools/test_refactoring_utils.py
@@ -18,10 +18,10 @@ from argumentation_analysis.utils.dev_tools.refactoring_utils import (
     DEFAULT_PATH_PATTERNS,
 )
 
-
 # ============================================================
 # update_imports_in_file_content
 # ============================================================
+
 
 class TestUpdateImportsInFileContent:
     def test_no_changes_on_unmatched_content(self):
@@ -58,7 +58,9 @@ class TestUpdateImportsInFileContent:
         content = "from agents.core.abc import agent_bases\n"
         result, count = update_imports_in_file_content(content)
         assert count == 1
-        assert "from argumentation_analysis.agents.core.abc import agent_bases" in result
+        assert (
+            "from argumentation_analysis.agents.core.abc import agent_bases" in result
+        )
 
     def test_replaces_orchestration_import(self):
         content = "from orchestration import workflow_dsl\n"
@@ -131,6 +133,7 @@ class TestUpdateImportsInFileContent:
 # update_imports_in_file
 # ============================================================
 
+
 class TestUpdateImportsInFile:
     def test_dry_run_returns_updated_content(self, tmp_path):
         f = tmp_path / "test.py"
@@ -166,7 +169,9 @@ class TestUpdateImportsInFile:
         f = tmp_path / "test.py"
         f.write_text("from mymod import X\n", encoding="utf-8")
         patterns = [(r"from\s+mymod\s+import\s+([^\n]+)", r"from newmod import \1")]
-        count, content = update_imports_in_file(f, dry_run=True, import_patterns=patterns)
+        count, content = update_imports_in_file(
+            f, dry_run=True, import_patterns=patterns
+        )
         assert count == 1
         assert "from newmod import X" in content
 
@@ -175,15 +180,20 @@ class TestUpdateImportsInFile:
 # update_imports_in_directory
 # ============================================================
 
+
 class TestUpdateImportsInDirectory:
     def _make_tree(self, tmp_path):
         """Create a simple directory tree with Python files."""
         (tmp_path / "src").mkdir()
         (tmp_path / "src" / "a.py").write_text("from core import A\n", encoding="utf-8")
         (tmp_path / "src" / "b.py").write_text("import os\n", encoding="utf-8")
-        (tmp_path / "src" / "c.txt").write_text("from core import C\n", encoding="utf-8")
+        (tmp_path / "src" / "c.txt").write_text(
+            "from core import C\n", encoding="utf-8"
+        )
         (tmp_path / "__pycache__").mkdir()
-        (tmp_path / "__pycache__" / "d.py").write_text("from core import D\n", encoding="utf-8")
+        (tmp_path / "__pycache__" / "d.py").write_text(
+            "from core import D\n", encoding="utf-8"
+        )
         return tmp_path
 
     def test_scans_only_py_files(self, tmp_path):
@@ -217,7 +227,9 @@ class TestUpdateImportsInDirectory:
         self._make_tree(tmp_path)
         update_imports_in_directory(tmp_path, dry_run=True)
         # Original file content should be unchanged
-        assert (tmp_path / "src" / "a.py").read_text(encoding="utf-8") == "from core import A\n"
+        assert (tmp_path / "src" / "a.py").read_text(
+            encoding="utf-8"
+        ) == "from core import A\n"
 
     def test_write_mode_modifies_files(self, tmp_path):
         self._make_tree(tmp_path)
@@ -234,6 +246,7 @@ class TestUpdateImportsInDirectory:
 # ============================================================
 # update_paths_in_file_content
 # ============================================================
+
 
 class TestUpdatePathsInFileContent:
     def test_no_changes_on_unmatched(self):
@@ -329,6 +342,7 @@ class TestUpdatePathsInFileContent:
 # update_paths_in_file
 # ============================================================
 
+
 class TestUpdatePathsInFile:
     def test_dry_run(self, tmp_path):
         f = tmp_path / "test.py"
@@ -367,13 +381,18 @@ class TestUpdatePathsInFile:
 # update_paths_in_directory
 # ============================================================
 
+
 class TestUpdatePathsInDirectory:
     def _make_tree(self, tmp_path):
         (tmp_path / "src").mkdir()
-        (tmp_path / "src" / "a.py").write_text('f = "config/x.yaml"\n', encoding="utf-8")
+        (tmp_path / "src" / "a.py").write_text(
+            'f = "config/x.yaml"\n', encoding="utf-8"
+        )
         (tmp_path / "src" / "b.py").write_text("import os\n", encoding="utf-8")
         (tmp_path / "docs").mkdir()
-        (tmp_path / "docs" / "c.py").write_text('f = "config/y.yaml"\n', encoding="utf-8")
+        (tmp_path / "docs" / "c.py").write_text(
+            'f = "config/y.yaml"\n', encoding="utf-8"
+        )
         return tmp_path
 
     def test_scans_and_reports(self, tmp_path):
@@ -389,6 +408,7 @@ class TestUpdatePathsInDirectory:
         # docs/ directory files should be excluded by default
         # Check using Path parts (not substring) to avoid false positives from temp dir names
         from pathlib import Path
+
         for p in modified_paths:
             assert "docs" not in Path(p).relative_to(tmp_path).parts
 
@@ -408,12 +428,14 @@ class TestUpdatePathsInDirectory:
 # DEFAULT_IMPORT_PATTERNS validation
 # ============================================================
 
+
 class TestDefaultImportPatterns:
     def test_patterns_are_nonempty(self):
         assert len(DEFAULT_IMPORT_PATTERNS) > 0
 
     def test_all_patterns_are_valid_regex(self):
         import re
+
         for pattern, replacement in DEFAULT_IMPORT_PATTERNS:
             re.compile(pattern)  # Should not raise
 
@@ -428,12 +450,14 @@ class TestDefaultImportPatterns:
 # DEFAULT_PATH_PATTERNS validation
 # ============================================================
 
+
 class TestDefaultPathPatterns:
     def test_patterns_are_nonempty(self):
         assert len(DEFAULT_PATH_PATTERNS) > 0
 
     def test_all_patterns_are_valid_regex(self):
         import re
+
         for pattern, replacement in DEFAULT_PATH_PATTERNS:
             re.compile(pattern)  # Should not raise
 

--- a/tests/unit/argumentation_analysis/utils/dev_tools/test_reporting_utils.py
+++ b/tests/unit/argumentation_analysis/utils/dev_tools/test_reporting_utils.py
@@ -144,8 +144,16 @@ class TestGenerateCoverageEvolutionReport:
     def test_new_package_in_last_entry(self, tmp_path):
         """Package exists only in last entry (new module)."""
         data = [
-            {"timestamp": "t1", "global_line_rate": 40.0, "packages": {"pkg1": {"line_rate": 30.0}}},
-            {"timestamp": "t2", "global_line_rate": 60.0, "packages": {"pkg1": {"line_rate": 50.0}, "pkg2": {"line_rate": 70.0}}},
+            {
+                "timestamp": "t1",
+                "global_line_rate": 40.0,
+                "packages": {"pkg1": {"line_rate": 30.0}},
+            },
+            {
+                "timestamp": "t2",
+                "global_line_rate": 60.0,
+                "packages": {"pkg1": {"line_rate": 50.0}, "pkg2": {"line_rate": 70.0}},
+            },
         ]
         history = tmp_path / "history.json"
         history.write_text(json.dumps(data), encoding="utf-8")

--- a/tests/unit/argumentation_analysis/utils/extract_repair/test_fix_missing_first_letter.py
+++ b/tests/unit/argumentation_analysis/utils/extract_repair/test_fix_missing_first_letter.py
@@ -96,9 +96,7 @@ class TestFixMissingFirstLetter:
         data = [
             {
                 "source_name": "No Template",
-                "extracts": [
-                    {"extract_name": "E1", "start_marker": "Hello"}
-                ],
+                "extracts": [{"extract_name": "E1", "start_marker": "Hello"}],
             }
         ]
         f = tmp_path / "no_template.json"

--- a/tests/unit/argumentation_analysis/utils/extract_repair/test_marker_repair_report.py
+++ b/tests/unit/argumentation_analysis/utils/extract_repair/test_marker_repair_report.py
@@ -15,10 +15,10 @@ from argumentation_analysis.utils.extract_repair.marker_repair_logic import (
     VALIDATION_AGENT_INSTRUCTIONS,
 )
 
-
 # ============================================================
 # Constants
 # ============================================================
+
 
 class TestConstants:
     def test_repair_instructions_not_empty(self):
@@ -28,7 +28,10 @@ class TestConstants:
         assert len(VALIDATION_AGENT_INSTRUCTIONS) > 100
 
     def test_repair_instructions_contain_key_terms(self):
-        assert "réparation" in REPAIR_AGENT_INSTRUCTIONS or "repair" in REPAIR_AGENT_INSTRUCTIONS.lower()
+        assert (
+            "réparation" in REPAIR_AGENT_INSTRUCTIONS
+            or "repair" in REPAIR_AGENT_INSTRUCTIONS.lower()
+        )
 
     def test_validation_instructions_contain_key_terms(self):
         assert "validation" in VALIDATION_AGENT_INSTRUCTIONS
@@ -38,10 +41,16 @@ class TestConstants:
 # generate_report
 # ============================================================
 
+
 class TestGenerateReport:
     def test_generates_html_file(self, tmp_path):
         results = [
-            {"source_name": "S1", "extract_name": "E1", "status": "valid", "message": "OK"},
+            {
+                "source_name": "S1",
+                "extract_name": "E1",
+                "status": "valid",
+                "message": "OK",
+            },
         ]
         output = str(tmp_path / "report.html")
         generate_report(results, output)
@@ -49,11 +58,23 @@ class TestGenerateReport:
 
     def test_html_contains_summary(self, tmp_path):
         results = [
-            {"source_name": "S1", "extract_name": "E1", "status": "valid", "message": "OK"},
-            {"source_name": "S2", "extract_name": "E2", "status": "repaired", "message": "Fixed",
-             "old_start_marker": "ello", "new_start_marker": "Hello",
-             "old_end_marker": "end", "new_end_marker": "end",
-             "old_template_start": "H{0}"},
+            {
+                "source_name": "S1",
+                "extract_name": "E1",
+                "status": "valid",
+                "message": "OK",
+            },
+            {
+                "source_name": "S2",
+                "extract_name": "E2",
+                "status": "repaired",
+                "message": "Fixed",
+                "old_start_marker": "ello",
+                "new_start_marker": "Hello",
+                "old_end_marker": "end",
+                "new_end_marker": "end",
+                "old_template_start": "H{0}",
+            },
         ]
         output = str(tmp_path / "report.html")
         generate_report(results, output)
@@ -63,14 +84,41 @@ class TestGenerateReport:
 
     def test_status_counts(self, tmp_path):
         results = [
-            {"status": "valid", "source_name": "S", "extract_name": "E", "message": "ok"},
-            {"status": "valid", "source_name": "S", "extract_name": "E", "message": "ok"},
-            {"status": "repaired", "source_name": "S", "extract_name": "E", "message": "fixed",
-             "old_start_marker": "x", "new_start_marker": "Xx",
-             "old_end_marker": "y", "new_end_marker": "y",
-             "old_template_start": "X{0}"},
-            {"status": "rejected", "source_name": "S", "extract_name": "E", "message": "bad"},
-            {"status": "error", "source_name": "S", "extract_name": "E", "message": "err"},
+            {
+                "status": "valid",
+                "source_name": "S",
+                "extract_name": "E",
+                "message": "ok",
+            },
+            {
+                "status": "valid",
+                "source_name": "S",
+                "extract_name": "E",
+                "message": "ok",
+            },
+            {
+                "status": "repaired",
+                "source_name": "S",
+                "extract_name": "E",
+                "message": "fixed",
+                "old_start_marker": "x",
+                "new_start_marker": "Xx",
+                "old_end_marker": "y",
+                "new_end_marker": "y",
+                "old_template_start": "X{0}",
+            },
+            {
+                "status": "rejected",
+                "source_name": "S",
+                "extract_name": "E",
+                "message": "bad",
+            },
+            {
+                "status": "error",
+                "source_name": "S",
+                "extract_name": "E",
+                "message": "err",
+            },
         ]
         output = str(tmp_path / "report.html")
         generate_report(results, output)
@@ -125,7 +173,12 @@ class TestGenerateReport:
 
     def test_html_structure(self, tmp_path):
         results = [
-            {"status": "valid", "source_name": "S", "extract_name": "E", "message": "ok"},
+            {
+                "status": "valid",
+                "source_name": "S",
+                "extract_name": "E",
+                "message": "ok",
+            },
         ]
         output = str(tmp_path / "report.html")
         generate_report(results, output)
@@ -138,6 +191,7 @@ class TestGenerateReport:
 # ============================================================
 # ExtractRepairPlugin
 # ============================================================
+
 
 class TestExtractRepairPlugin:
     @pytest.fixture

--- a/tests/unit/argumentation_analysis/utils/test_async_manager.py
+++ b/tests/unit/argumentation_analysis/utils/test_async_manager.py
@@ -22,6 +22,7 @@ def mgr():
 
 # ── Init ──
 
+
 class TestAsyncManagerInit:
     def test_defaults(self):
         m = AsyncManager()
@@ -39,6 +40,7 @@ class TestAsyncManagerInit:
 
 
 # ── run_hybrid (sync functions) ──
+
 
 class TestRunHybridSync:
     def test_basic_sync_function(self, mgr):
@@ -85,6 +87,7 @@ class TestRunHybridSync:
 
 # ── run_hybrid (async functions) ──
 
+
 class TestRunHybridAsync:
     def test_async_function(self, mgr):
         async def async_add(a, b):
@@ -102,6 +105,7 @@ class TestRunHybridAsync:
 
 
 # ── run_multiple_hybrid ──
+
 
 class TestRunMultipleHybrid:
     def test_multiple_tasks(self, mgr):
@@ -132,6 +136,7 @@ class TestRunMultipleHybrid:
 
 
 # ── Task management ──
+
 
 class TestTaskManagement:
     def test_generate_task_id(self, mgr):
@@ -180,6 +185,7 @@ class TestTaskManagement:
 
 # ── Performance stats ──
 
+
 class TestPerformanceStats:
     def test_no_tasks(self, mgr):
         stats = mgr.get_performance_stats()
@@ -195,12 +201,15 @@ class TestPerformanceStats:
         assert stats["average_duration"] >= 0
 
     def test_with_error_tasks(self, mgr):
-        mgr.run_hybrid(lambda: (_ for _ in ()).throw(RuntimeError("e")), fallback_result=None)
+        mgr.run_hybrid(
+            lambda: (_ for _ in ()).throw(RuntimeError("e")), fallback_result=None
+        )
         stats = mgr.get_performance_stats()
         assert stats["error_tasks"] >= 0
 
 
 # ── Wrappers ──
+
 
 class TestWrappers:
     def test_create_async_wrapper(self, mgr):
@@ -220,6 +229,7 @@ class TestWrappers:
 
 # ── Module-level functions ──
 
+
 class TestModuleFunctions:
     def test_run_hybrid_safe(self):
         result = run_hybrid_safe(lambda: 42)
@@ -238,6 +248,7 @@ class TestModuleFunctions:
 
         wrapped = ensure_async(sync_fn)
         import asyncio
+
         assert asyncio.iscoroutinefunction(wrapped)
 
     def test_ensure_async_already_async(self):
@@ -260,10 +271,12 @@ class TestModuleFunctions:
 
         wrapped = ensure_sync(async_fn)
         import asyncio
+
         assert not asyncio.iscoroutinefunction(wrapped)
 
 
 # ── Shutdown ──
+
 
 class TestShutdown:
     def test_shutdown_clean(self):

--- a/tests/unit/argumentation_analysis/utils/test_debug_utils.py
+++ b/tests/unit/argumentation_analysis/utils/test_debug_utils.py
@@ -94,7 +94,10 @@ class TestDisplayExtractSourcesDetails:
         display_extract_sources_details(data, show_all=True, show_all_french=True)
 
     def test_non_dict_items_skipped(self):
-        data = ["not_a_dict", {"id": "s1", "source_name": "S1", "host_parts": [], "extracts": []}]
+        data = [
+            "not_a_dict",
+            {"id": "s1", "source_name": "S1", "host_parts": [], "extracts": []},
+        ]
         display_extract_sources_details(data, show_all=True)
 
     def test_source_with_full_text_preview(self):

--- a/tests/unit/argumentation_analysis/utils/test_metrics_calculator.py
+++ b/tests/unit/argumentation_analysis/utils/test_metrics_calculator.py
@@ -9,8 +9,8 @@ from argumentation_analysis.utils.metrics_calculator import (
     analyze_contextual_richness,
 )
 
-
 # ── count_fallacies ──
+
 
 class TestCountFallacies:
     def test_empty_results(self):
@@ -131,6 +131,7 @@ class TestCountFallacies:
 
 # ── extract_confidence_scores ──
 
+
 class TestExtractConfidenceScores:
     def test_empty_results(self):
         scores = extract_confidence_scores([])
@@ -139,13 +140,7 @@ class TestExtractConfidenceScores:
 
     def test_base_coherence(self):
         results = [
-            {
-                "analyses": {
-                    "argument_coherence": {
-                        "overall_coherence": {"score": 0.85}
-                    }
-                }
-            }
+            {"analyses": {"argument_coherence": {"overall_coherence": {"score": 0.85}}}}
         ]
         scores = extract_confidence_scores(results)
         assert abs(scores["base_coherence"] - 0.85) < 1e-6
@@ -168,9 +163,7 @@ class TestExtractConfidenceScores:
             {
                 "analyses": {
                     "rhetorical_results": {
-                        "coherence_analysis": {
-                            "overall_coherence": {"score": 0.9}
-                        }
+                        "coherence_analysis": {"overall_coherence": {"score": 0.9}}
                     }
                 }
             }
@@ -192,24 +185,14 @@ class TestExtractConfidenceScores:
         assert abs(scores["advanced_coherence"] - 0.75) < 1e-6
 
     def test_advanced_severity(self):
-        results = [
-            {"analyses": {"fallacy_severity": {"overall_severity": 0.3}}}
-        ]
+        results = [{"analyses": {"fallacy_severity": {"overall_severity": 0.3}}}]
         scores = extract_confidence_scores(results)
         assert abs(scores["advanced_severity"] - 0.3) < 1e-6
 
     def test_averaging_multiple(self):
         results = [
-            {
-                "analyses": {
-                    "argument_coherence": {"overall_coherence": {"score": 0.8}}
-                }
-            },
-            {
-                "analyses": {
-                    "argument_coherence": {"overall_coherence": {"score": 0.6}}
-                }
-            },
+            {"analyses": {"argument_coherence": {"overall_coherence": {"score": 0.8}}}},
+            {"analyses": {"argument_coherence": {"overall_coherence": {"score": 0.6}}}},
         ]
         scores = extract_confidence_scores(results)
         assert abs(scores["base_coherence"] - 0.7) < 1e-6
@@ -226,6 +209,7 @@ class TestExtractConfidenceScores:
 
 
 # ── analyze_contextual_richness ──
+
 
 class TestAnalyzeContextualRichness:
     def test_empty_results(self):
@@ -310,9 +294,7 @@ class TestAnalyzeContextualRichness:
         results = [
             {
                 "analyses": {
-                    "contextual_fallacies": {
-                        "contextual_factors": {"f1": "v1"}
-                    }
+                    "contextual_fallacies": {"contextual_factors": {"f1": "v1"}}
                 }
             },
             {
@@ -328,14 +310,6 @@ class TestAnalyzeContextualRichness:
         assert abs(scores["base_contextual"] - 2.0) < 1e-6
 
     def test_empty_context_analysis(self):
-        results = [
-            {
-                "analyses": {
-                    "contextual_fallacies": {
-                        "context_analysis": {}
-                    }
-                }
-            }
-        ]
+        results = [{"analyses": {"contextual_fallacies": {"context_analysis": {}}}}]
         scores = analyze_contextual_richness(results)
         assert abs(scores["advanced_contextual"] - 0.0) < 1e-6

--- a/tests/unit/argumentation_analysis/utils/test_performance_monitoring.py
+++ b/tests/unit/argumentation_analysis/utils/test_performance_monitoring.py
@@ -62,6 +62,7 @@ class TestMonitorPerformance:
 
     def test_logs_execution_even_on_exception(self):
         """The decorator should log timing even when the function fails."""
+
         @monitor_performance()
         def failing():
             raise RuntimeError("error")

--- a/tests/unit/argumentation_analysis/utils/test_system_utils.py
+++ b/tests/unit/argumentation_analysis/utils/test_system_utils.py
@@ -16,10 +16,10 @@ from argumentation_analysis.utils.system_utils import (
     check_and_install,
 )
 
-
 # ============================================================
 # ensure_directory_exists
 # ============================================================
+
 
 class TestEnsureDirectoryExists:
     def test_creates_missing_directory(self, tmp_path):
@@ -64,6 +64,7 @@ class TestEnsureDirectoryExists:
 # get_project_root
 # ============================================================
 
+
 class TestGetProjectRoot:
     def test_returns_path(self):
         root = get_project_root()
@@ -84,6 +85,7 @@ class TestGetProjectRoot:
 # is_running_in_notebook
 # ============================================================
 
+
 class TestIsRunningInNotebook:
     def test_not_in_notebook(self):
         # In pytest, ipykernel is typically not loaded
@@ -102,6 +104,7 @@ class TestIsRunningInNotebook:
 # check_and_install
 # ============================================================
 
+
 class TestCheckAndInstall:
     def test_existing_package_returns_true(self):
         # os is always available
@@ -118,7 +121,9 @@ class TestCheckAndInstall:
 
     def test_install_failure_returns_false(self):
         with patch("importlib.import_module", side_effect=ImportError):
-            with patch("subprocess.check_call", side_effect=Exception("install failed")):
+            with patch(
+                "subprocess.check_call", side_effect=Exception("install failed")
+            ):
                 result = check_and_install("fake_pkg_xyz", "fake-pkg-xyz")
                 assert result is False
 

--- a/tests/unit/argumentation_analysis/utils/test_tweety_error_analyzer.py
+++ b/tests/unit/argumentation_analysis/utils/test_tweety_error_analyzer.py
@@ -13,10 +13,10 @@ from argumentation_analysis.utils.tweety_error_analyzer import (
     create_bnf_feedback_for_error,
 )
 
-
 # ============================================================
 # Fixtures
 # ============================================================
+
 
 @pytest.fixture
 def analyzer():
@@ -26,6 +26,7 @@ def analyzer():
 # ============================================================
 # TweetyErrorFeedback dataclass
 # ============================================================
+
 
 class TestTweetyErrorFeedback:
     def test_creation(self):
@@ -41,16 +42,21 @@ class TestTweetyErrorFeedback:
 
     def test_custom_confidence(self):
         fb = TweetyErrorFeedback(
-            error_type="t", original_error="e",
-            bnf_rules=[], corrections=[], example_fix="",
+            error_type="t",
+            original_error="e",
+            bnf_rules=[],
+            corrections=[],
+            example_fix="",
             confidence=0.5,
         )
         assert fb.confidence == 0.5
 
     def test_fields_accessible(self):
         fb = TweetyErrorFeedback(
-            error_type="atom_error", original_error="atom not defined",
-            bnf_rules=["r1", "r2"], corrections=["c1"],
+            error_type="atom_error",
+            original_error="atom not defined",
+            bnf_rules=["r1", "r2"],
+            corrections=["c1"],
             example_fix="fix",
         )
         assert len(fb.bnf_rules) == 2
@@ -61,6 +67,7 @@ class TestTweetyErrorFeedback:
 # ============================================================
 # TweetyErrorAnalyzer.__init__
 # ============================================================
+
 
 class TestAnalyzerInit:
     def test_error_patterns_populated(self, analyzer):
@@ -78,12 +85,15 @@ class TestAnalyzerInit:
 
     def test_all_error_types_have_corrections(self, analyzer):
         for error_type in analyzer.error_patterns:
-            assert error_type in analyzer.corrections, f"Missing corrections for {error_type}"
+            assert (
+                error_type in analyzer.corrections
+            ), f"Missing corrections for {error_type}"
 
 
 # ============================================================
 # _detect_error_type
 # ============================================================
+
 
 class TestDetectErrorType:
     def test_declaration_error(self, analyzer):
@@ -155,6 +165,7 @@ class TestDetectErrorType:
 # analyze_error
 # ============================================================
 
+
 class TestAnalyzeError:
     def test_returns_feedback(self, analyzer):
         fb = analyzer.analyze_error("syntax error near ';'")
@@ -207,17 +218,22 @@ class TestAnalyzeError:
 # _generate_example_fix
 # ============================================================
 
+
 class TestGenerateExampleFix:
     def test_syntax_error_example(self, analyzer):
         fix = analyzer._generate_example_fix("syntax_error", "syntax error", None)
         assert "Exemple" in fix or "règle" in fix
 
     def test_atom_error_with_entity(self, analyzer):
-        fix = analyzer._generate_example_fix("atom_error", "atom 'foo' not defined", None)
+        fix = analyzer._generate_example_fix(
+            "atom_error", "atom 'foo' not defined", None
+        )
         assert "foo" in fix
 
     def test_declaration_error_with_entity(self, analyzer):
-        fix = analyzer._generate_example_fix("DECLARATION_ERROR", "predicate 'bar' not declared", None)
+        fix = analyzer._generate_example_fix(
+            "DECLARATION_ERROR", "predicate 'bar' not declared", None
+        )
         assert "bar" in fix
 
     def test_unknown_type_default(self, analyzer):
@@ -238,6 +254,7 @@ class TestGenerateExampleFix:
 # ============================================================
 # _calculate_confidence
 # ============================================================
+
 
 class TestCalculateConfidence:
     def test_declaration_error_high(self, analyzer):
@@ -275,27 +292,37 @@ class TestCalculateConfidence:
 # generate_bnf_feedback_message
 # ============================================================
 
+
 class TestGenerateBnfFeedbackMessage:
     def test_contains_error_type(self, analyzer):
         fb = TweetyErrorFeedback(
-            error_type="syntax_error", original_error="err",
-            bnf_rules=["r1"], corrections=["c1"], example_fix="fix",
+            error_type="syntax_error",
+            original_error="err",
+            bnf_rules=["r1"],
+            corrections=["c1"],
+            example_fix="fix",
         )
         msg = analyzer.generate_bnf_feedback_message(fb)
         assert "syntax_error" in msg
 
     def test_contains_attempt_number(self, analyzer):
         fb = TweetyErrorFeedback(
-            error_type="t", original_error="e",
-            bnf_rules=[], corrections=[], example_fix="",
+            error_type="t",
+            original_error="e",
+            bnf_rules=[],
+            corrections=[],
+            example_fix="",
         )
         msg = analyzer.generate_bnf_feedback_message(fb, attempt_number=3)
         assert "#3" in msg
 
     def test_contains_bnf_rules(self, analyzer):
         fb = TweetyErrorFeedback(
-            error_type="t", original_error="e",
-            bnf_rules=["rule1", "rule2"], corrections=[], example_fix="",
+            error_type="t",
+            original_error="e",
+            bnf_rules=["rule1", "rule2"],
+            corrections=[],
+            example_fix="",
         )
         msg = analyzer.generate_bnf_feedback_message(fb)
         assert "rule1" in msg
@@ -303,8 +330,11 @@ class TestGenerateBnfFeedbackMessage:
 
     def test_contains_corrections(self, analyzer):
         fb = TweetyErrorFeedback(
-            error_type="t", original_error="e",
-            bnf_rules=[], corrections=["Fix this", "Fix that"], example_fix="",
+            error_type="t",
+            original_error="e",
+            bnf_rules=[],
+            corrections=["Fix this", "Fix that"],
+            example_fix="",
         )
         msg = analyzer.generate_bnf_feedback_message(fb)
         assert "Fix this" in msg
@@ -312,16 +342,22 @@ class TestGenerateBnfFeedbackMessage:
 
     def test_contains_example_fix(self, analyzer):
         fb = TweetyErrorFeedback(
-            error_type="t", original_error="e",
-            bnf_rules=[], corrections=[], example_fix="my_example_fix_code",
+            error_type="t",
+            original_error="e",
+            bnf_rules=[],
+            corrections=[],
+            example_fix="my_example_fix_code",
         )
         msg = analyzer.generate_bnf_feedback_message(fb)
         assert "my_example_fix_code" in msg
 
     def test_contains_confidence(self, analyzer):
         fb = TweetyErrorFeedback(
-            error_type="t", original_error="e",
-            bnf_rules=[], corrections=[], example_fix="",
+            error_type="t",
+            original_error="e",
+            bnf_rules=[],
+            corrections=[],
+            example_fix="",
             confidence=0.85,
         )
         msg = analyzer.generate_bnf_feedback_message(fb)
@@ -331,6 +367,7 @@ class TestGenerateBnfFeedbackMessage:
 # ============================================================
 # analyze_tweety_error (top-level function)
 # ============================================================
+
 
 class TestAnalyzeTweetyError:
     def test_returns_string(self):
@@ -353,6 +390,7 @@ class TestAnalyzeTweetyError:
 # ============================================================
 # create_bnf_feedback_for_error (alias function)
 # ============================================================
+
 
 class TestCreateBnfFeedbackForError:
     def test_returns_string(self):

--- a/tests/unit/argumentation_analysis/workflows/test_debate_tournament.py
+++ b/tests/unit/argumentation_analysis/workflows/test_debate_tournament.py
@@ -19,7 +19,6 @@ from argumentation_analysis.core.capability_registry import (
     ComponentType,
 )
 
-
 # --- Build tests ---
 
 
@@ -84,17 +83,33 @@ class TestDebateScoreConverged:
     """Test _debate_score_converged function."""
 
     def test_stable_scores_converge(self):
-        prev = {"logical_coherence": 0.8, "evidence_quality": 0.7,
-                "relevance_score": 0.75, "persuasiveness": 0.8}
-        curr = {"logical_coherence": 0.81, "evidence_quality": 0.71,
-                "relevance_score": 0.76, "persuasiveness": 0.8}
+        prev = {
+            "logical_coherence": 0.8,
+            "evidence_quality": 0.7,
+            "relevance_score": 0.75,
+            "persuasiveness": 0.8,
+        }
+        curr = {
+            "logical_coherence": 0.81,
+            "evidence_quality": 0.71,
+            "relevance_score": 0.76,
+            "persuasiveness": 0.8,
+        }
         assert _debate_score_converged(prev, curr) is True
 
     def test_changing_scores_not_converged(self):
-        prev = {"logical_coherence": 0.5, "evidence_quality": 0.4,
-                "relevance_score": 0.3, "persuasiveness": 0.4}
-        curr = {"logical_coherence": 0.8, "evidence_quality": 0.7,
-                "relevance_score": 0.75, "persuasiveness": 0.8}
+        prev = {
+            "logical_coherence": 0.5,
+            "evidence_quality": 0.4,
+            "relevance_score": 0.3,
+            "persuasiveness": 0.4,
+        }
+        curr = {
+            "logical_coherence": 0.8,
+            "evidence_quality": 0.7,
+            "relevance_score": 0.75,
+            "persuasiveness": 0.8,
+        }
         assert _debate_score_converged(prev, curr) is False
 
     def test_non_dict_inputs(self):

--- a/tests/unit/argumentation_analysis/workflows/test_democratech.py
+++ b/tests/unit/argumentation_analysis/workflows/test_democratech.py
@@ -18,7 +18,6 @@ from argumentation_analysis.core.capability_registry import (
     ComponentType,
 )
 
-
 # --- Build tests ---
 
 
@@ -184,9 +183,7 @@ class TestDemocratechExecution:
     @pytest.mark.asyncio
     async def test_conditional_recheck_triggered(self):
         """Low consensus triggers quality recheck."""
-        low_consensus = AsyncMock(
-            return_value={"consensus": 0.3, "method": "majority"}
-        )
+        low_consensus = AsyncMock(return_value={"consensus": 0.3, "method": "majority"})
         registry = _make_registry(
             "counter_argument_generation",
             "adversarial_debate",
@@ -255,22 +252,26 @@ class TestDemocratechExecution:
         registry = CapabilityRegistry()
         quality_invoke = AsyncMock(return_value={"note_finale": 7.5})
         registry.register(
-            "quality", ComponentType.AGENT,
+            "quality",
+            ComponentType.AGENT,
             capabilities=["argument_quality"],
             invoke=quality_invoke,
         )
         registry.register(
-            "counter", ComponentType.AGENT,
+            "counter",
+            ComponentType.AGENT,
             capabilities=["counter_argument_generation"],
             invoke=capturing_invoke,
         )
         registry.register(
-            "debate", ComponentType.AGENT,
+            "debate",
+            ComponentType.AGENT,
             capabilities=["adversarial_debate"],
             invoke=AsyncMock(return_value={"debate": True}),
         )
         registry.register(
-            "governance", ComponentType.AGENT,
+            "governance",
+            ComponentType.AGENT,
             capabilities=["governance_simulation"],
             invoke=AsyncMock(return_value={"consensus": 0.9}),
         )

--- a/tests/unit/argumentation_analysis/workflows/test_fact_check_pipeline.py
+++ b/tests/unit/argumentation_analysis/workflows/test_fact_check_pipeline.py
@@ -16,7 +16,6 @@ from argumentation_analysis.core.capability_registry import (
     ComponentType,
 )
 
-
 # --- Build tests ---
 
 
@@ -157,17 +156,20 @@ class TestFactCheckExecution:
 
         registry = CapabilityRegistry()
         registry.register(
-            "quality", ComponentType.AGENT,
+            "quality",
+            ComponentType.AGENT,
             capabilities=["argument_quality"],
             invoke=AsyncMock(return_value={"note_finale": 6.5}),
         )
         registry.register(
-            "jtms", ComponentType.SERVICE,
+            "jtms",
+            ComponentType.SERVICE,
             capabilities=["belief_maintenance"],
             invoke=tracking_invoke,
         )
         registry.register(
-            "counter", ComponentType.AGENT,
+            "counter",
+            ComponentType.AGENT,
             capabilities=["counter_argument_generation"],
             invoke=counter_invoke,
         )

--- a/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
+++ b/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
@@ -27,7 +27,6 @@ from argumentation_analysis.core.capability_registry import (
     ComponentType,
 )
 
-
 # =====================================================================
 # Helper
 # =====================================================================
@@ -63,7 +62,9 @@ class TestBuildFormalVerificationWorkflow:
 
     def test_phase_count(self):
         wf = build_formal_verification_workflow()
-        assert len(wf.phases) == 17  # 10 original + 7 new optional (#85/#86/#87/#89/#90)
+        assert (
+            len(wf.phases) == 17
+        )  # 10 original + 7 new optional (#85/#86/#87/#89/#90)
 
     def test_required_capabilities(self):
         wf = build_formal_verification_workflow()
@@ -198,7 +199,9 @@ class TestFormalVerificationExecution:
         executor = WorkflowExecutor(registry)
         results = await executor.execute(wf, "Test argument for verification.")
         assert results is not None
-        completed = [name for name, r in results.items() if r.status == PhaseStatus.COMPLETED]
+        completed = [
+            name for name, r in results.items() if r.status == PhaseStatus.COMPLETED
+        ]
         # At least extraction + synthesis should complete
         assert len(completed) >= 2
 
@@ -211,8 +214,12 @@ class TestFormalVerificationExecution:
         registry = _make_registry(*caps_without_modal)
         executor = WorkflowExecutor(registry)
         results = await executor.execute(wf, "Test text.")
-        completed_names = [name for name, r in results.items() if r.status == PhaseStatus.COMPLETED]
-        skipped_names = [name for name, r in results.items() if r.status == PhaseStatus.SKIPPED]
+        completed_names = [
+            name for name, r in results.items() if r.status == PhaseStatus.COMPLETED
+        ]
+        skipped_names = [
+            name for name, r in results.items() if r.status == PhaseStatus.SKIPPED
+        ]
         assert "modal_analysis" in skipped_names
         assert "extraction" in completed_names
 
@@ -233,7 +240,10 @@ class TestRunFormalVerification:
             return_value={"status": "ok"},
         ) as mock_run:
             # Re-import to pick up the patch (lazy import in function body)
-            from argumentation_analysis.workflows.formal_verification import run_formal_verification as rfv
+            from argumentation_analysis.workflows.formal_verification import (
+                run_formal_verification as rfv,
+            )
+
             result = await rfv("Test text")
             mock_run.assert_called_once()
             assert mock_run.call_args[1]["workflow_name"] == "formal_verification"
@@ -250,7 +260,10 @@ class TestInvokeCallables:
 
     @pytest.mark.asyncio
     async def test_invoke_fact_extraction(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _invoke_fact_extraction
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fact_extraction,
+        )
+
         result = await _invoke_fact_extraction(
             "This is a long claim about logic. Another important assertion here. A third point.",
             {},
@@ -261,13 +274,19 @@ class TestInvokeCallables:
 
     @pytest.mark.asyncio
     async def test_invoke_fact_extraction_short_text(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _invoke_fact_extraction
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fact_extraction,
+        )
+
         result = await _invoke_fact_extraction("Hi.", {})
         assert result["claim_count"] == 0  # Too short
 
     @pytest.mark.asyncio
     async def test_invoke_propositional_logic_error_fallback(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _invoke_propositional_logic
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_propositional_logic,
+        )
+
         # Without JVM, should return error dict
         result = await _invoke_propositional_logic("a && b", {})
         assert "logic_type" in result
@@ -275,26 +294,38 @@ class TestInvokeCallables:
 
     @pytest.mark.asyncio
     async def test_invoke_fol_reasoning_error_fallback(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _invoke_fol_reasoning
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fol_reasoning,
+        )
+
         result = await _invoke_fol_reasoning("forall x: P(x)", {})
         assert result["logic_type"] == "first_order"
 
     @pytest.mark.asyncio
     async def test_invoke_modal_logic_error_fallback(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _invoke_modal_logic
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_modal_logic,
+        )
+
         result = await _invoke_modal_logic("[]p => p", {})
         # Should either succeed or return error dict
         assert "logic_type" in result or "formulas" in result
 
     @pytest.mark.asyncio
     async def test_invoke_dung_extensions_error_fallback(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _invoke_dung_extensions
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_dung_extensions,
+        )
+
         result = await _invoke_dung_extensions("test", {"arguments": ["a", "b"]})
         assert "semantics" in result or "error" in result
 
     @pytest.mark.asyncio
     async def test_invoke_formal_synthesis_aggregates(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _invoke_formal_synthesis
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_formal_synthesis,
+        )
+
         ctx = {
             "phase_fol_analysis_output": {"consistent": True},
             "phase_pl_analysis_output": {"satisfiable": False},
@@ -308,7 +339,10 @@ class TestInvokeCallables:
 
     @pytest.mark.asyncio
     async def test_invoke_formal_synthesis_empty_context(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _invoke_formal_synthesis
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_formal_synthesis,
+        )
+
         result = await _invoke_formal_synthesis("test", {})
         assert result["overall_validity"] == 0.5
         assert result["phase_count"] == 0
@@ -324,23 +358,33 @@ class TestStateWriters:
 
     def _make_state(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         return UnifiedAnalysisState("test text")
 
     def test_write_fact_extraction_to_state(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _write_fact_extraction_to_state
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _write_fact_extraction_to_state,
+        )
+
         state = self._make_state()
         output = {"claims": ["Claim one here", "Claim two here"]}
         _write_fact_extraction_to_state(output, state, {})
         assert len(state.extracts) == 2
 
     def test_write_fact_extraction_none(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _write_fact_extraction_to_state
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _write_fact_extraction_to_state,
+        )
+
         state = self._make_state()
         _write_fact_extraction_to_state(None, state, {})
         assert len(state.extracts) == 0
 
     def test_write_propositional_to_state(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _write_propositional_to_state
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _write_propositional_to_state,
+        )
+
         state = self._make_state()
         output = {"formulas": ["a && b"], "satisfiable": True, "model": {"a": True}}
         _write_propositional_to_state(output, state, {})
@@ -348,16 +392,27 @@ class TestStateWriters:
         assert state.propositional_analysis_results[0]["satisfiable"] is True
 
     def test_write_fol_to_state(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _write_fol_to_state
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _write_fol_to_state,
+        )
+
         state = self._make_state()
-        output = {"formulas": ["forall x: P(x)"], "consistent": True, "inferences": ["P(a)"], "confidence": 0.9}
+        output = {
+            "formulas": ["forall x: P(x)"],
+            "consistent": True,
+            "inferences": ["P(a)"],
+            "confidence": 0.9,
+        }
         _write_fol_to_state(output, state, {})
         assert len(state.fol_analysis_results) == 1
         assert state.fol_analysis_results[0]["consistent"] is True
         assert state.fol_analysis_results[0]["confidence"] == 0.9
 
     def test_write_modal_to_state(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _write_modal_to_state
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _write_modal_to_state,
+        )
+
         state = self._make_state()
         output = {"formulas": ["[]p"], "valid": True, "modalities": ["necessity"]}
         _write_modal_to_state(output, state, {})
@@ -365,7 +420,10 @@ class TestStateWriters:
         assert state.modal_analysis_results[0]["valid"] is True
 
     def test_write_dung_extensions_to_state(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _write_dung_extensions_to_state
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _write_dung_extensions_to_state,
+        )
+
         state = self._make_state()
         output = {
             "semantics": "preferred",
@@ -378,7 +436,10 @@ class TestStateWriters:
         assert fw["name"] == "verification_preferred"
 
     def test_write_formal_synthesis_to_state(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _write_formal_synthesis_to_state
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _write_formal_synthesis_to_state,
+        )
+
         state = self._make_state()
         output = {
             "summary": "All consistent",
@@ -390,7 +451,10 @@ class TestStateWriters:
         assert state.formal_synthesis_reports[0]["overall_validity"] == 0.85
 
     def test_write_formal_synthesis_none(self):
-        from argumentation_analysis.orchestration.unified_pipeline import _write_formal_synthesis_to_state
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _write_formal_synthesis_to_state,
+        )
+
         state = self._make_state()
         _write_formal_synthesis_to_state(None, state, {})
         assert len(state.formal_synthesis_reports) == 0
@@ -406,39 +470,48 @@ class TestUnifiedAnalysisStateNewFields:
 
     def test_fol_analysis_field_exists(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         state = UnifiedAnalysisState("test")
         assert hasattr(state, "fol_analysis_results")
         assert state.fol_analysis_results == []
 
     def test_propositional_analysis_field_exists(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         state = UnifiedAnalysisState("test")
         assert hasattr(state, "propositional_analysis_results")
         assert state.propositional_analysis_results == []
 
     def test_modal_analysis_field_exists(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         state = UnifiedAnalysisState("test")
         assert hasattr(state, "modal_analysis_results")
         assert state.modal_analysis_results == []
 
     def test_formal_synthesis_field_exists(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         state = UnifiedAnalysisState("test")
         assert hasattr(state, "formal_synthesis_reports")
         assert state.formal_synthesis_reports == []
 
     def test_add_fol_analysis_result(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         state = UnifiedAnalysisState("test")
         fol_id = state.add_fol_analysis_result(
-            formulas=["forall x: P(x)"], consistent=True, inferences=["P(a)"], confidence=0.9
+            formulas=["forall x: P(x)"],
+            consistent=True,
+            inferences=["P(a)"],
+            confidence=0.9,
         )
         assert fol_id.startswith("fol_")
         assert len(state.fol_analysis_results) == 1
 
     def test_add_propositional_analysis_result(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         state = UnifiedAnalysisState("test")
         pl_id = state.add_propositional_analysis_result(
             formulas=["a && b"], satisfiable=True, model={"a": True, "b": True}
@@ -448,6 +521,7 @@ class TestUnifiedAnalysisStateNewFields:
 
     def test_add_modal_analysis_result(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         state = UnifiedAnalysisState("test")
         ml_id = state.add_modal_analysis_result(
             formulas=["[]p"], valid=True, modalities=["necessity"]
@@ -457,6 +531,7 @@ class TestUnifiedAnalysisStateNewFields:
 
     def test_add_formal_synthesis_report(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         state = UnifiedAnalysisState("test")
         fs_id = state.add_formal_synthesis_report(
             summary="All consistent", phase_results={"fol": {}}, overall_validity=0.9
@@ -466,6 +541,7 @@ class TestUnifiedAnalysisStateNewFields:
 
     def test_snapshot_summarize_includes_new_fields(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         state = UnifiedAnalysisState("test")
         state.add_fol_analysis_result(["f"], True, [], 0.8)
         state.add_propositional_analysis_result(["a"], True)
@@ -477,6 +553,7 @@ class TestUnifiedAnalysisStateNewFields:
 
     def test_snapshot_full_includes_new_fields(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         state = UnifiedAnalysisState("test")
         state.add_modal_analysis_result(["[]p"], True, ["necessity"])
         snapshot = state.get_state_snapshot(summarize=False)
@@ -493,21 +570,32 @@ class TestCatalogRegistration:
     """Test that formal_verification workflow is in the catalog."""
 
     def test_formal_verification_in_catalog(self):
-        from argumentation_analysis.orchestration.unified_pipeline import get_workflow_catalog
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            get_workflow_catalog,
+        )
+
         catalog = get_workflow_catalog()
         assert "formal_verification" in catalog
 
     def test_catalog_total_count(self):
-        from argumentation_analysis.orchestration.unified_pipeline import get_workflow_catalog
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            get_workflow_catalog,
+        )
+
         catalog = get_workflow_catalog()
         # 7 built-in + 3 macro + 3 formal + 1 formal_verification = 14
         assert len(catalog) >= 14
 
     def test_formal_verification_phase_count_in_catalog(self):
-        from argumentation_analysis.orchestration.unified_pipeline import get_workflow_catalog
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            get_workflow_catalog,
+        )
+
         catalog = get_workflow_catalog()
         wf = catalog["formal_verification"]
-        assert len(wf.phases) == 17  # 10 original + 7 new optional (#85/#86/#87/#89/#90)
+        assert (
+            len(wf.phases) == 17
+        )  # 10 original + 7 new optional (#85/#86/#87/#89/#90)
 
 
 # =====================================================================
@@ -520,6 +608,7 @@ class TestLogicCapabilityRegistration:
 
     def test_logic_capabilities_registered(self):
         from argumentation_analysis.orchestration.unified_pipeline import setup_registry
+
         registry = setup_registry()
         all_caps = registry.get_all_capabilities()
         for cap in [
@@ -535,6 +624,7 @@ class TestLogicCapabilityRegistration:
 
     def test_logic_services_have_invoke(self):
         from argumentation_analysis.orchestration.unified_pipeline import setup_registry
+
         registry = setup_registry()
         for name in [
             "fact_extraction_service",

--- a/tests/unit/argumentation_analysis/workflows/test_formal_workflows.py
+++ b/tests/unit/argumentation_analysis/workflows/test_formal_workflows.py
@@ -25,7 +25,6 @@ from argumentation_analysis.core.capability_registry import (
     ComponentType,
 )
 
-
 # =====================================================================
 # Helper
 # =====================================================================
@@ -61,7 +60,9 @@ class TestBuildFormalDebateWorkflow:
 
     def test_phase_count(self):
         wf = build_formal_debate_workflow()
-        assert len(wf.phases) == 8  # 5 original + 3 optional (ABA #85, Social #87, EAF #88)
+        assert (
+            len(wf.phases) == 8
+        )  # 5 original + 3 optional (ABA #85, Social #87, EAF #88)
 
     def test_required_capabilities(self):
         wf = build_formal_debate_workflow()
@@ -93,7 +94,11 @@ class TestBuildFormalDebateWorkflow:
         wf = build_formal_debate_workflow()
         phases = wf.phases if isinstance(wf.phases, list) else list(wf.phases.values())
         optional_names = {p.name for p in phases if p.optional}
-        assert optional_names == {"aba_formalization", "social_ranking", "epistemic_analysis"}  # #85, #87, #88
+        assert optional_names == {
+            "aba_formalization",
+            "social_ranking",
+            "epistemic_analysis",
+        }  # #85, #87, #88
 
 
 class TestFormalDebateExecution:
@@ -256,7 +261,9 @@ class TestBuildArgumentStrengthWorkflow:
 
     def test_phase_count(self):
         wf = build_argument_strength_workflow()
-        assert len(wf.phases) == 6  # 4 original + 2 optional (bipolar #85, weighted #87)
+        assert (
+            len(wf.phases) == 6
+        )  # 4 original + 2 optional (bipolar #85, weighted #87)
 
     def test_required_capabilities(self):
         wf = build_argument_strength_workflow()
@@ -344,12 +351,14 @@ class TestStateWriters:
 
     def _make_state(self):
         from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
         return UnifiedAnalysisState("Test text")
 
     def test_write_ranking_to_state(self):
         from argumentation_analysis.orchestration.unified_pipeline import (
             _write_ranking_to_state,
         )
+
         state = self._make_state()
         output = {"method": "categorizer", "arguments": ["a", "b"], "comparisons": []}
         _write_ranking_to_state(output, state, {})
@@ -360,6 +369,7 @@ class TestStateWriters:
         from argumentation_analysis.orchestration.unified_pipeline import (
             _write_aspic_to_state,
         )
+
         state = self._make_state()
         output = {"reasoner_type": "simple", "extensions": [["a"]], "statistics": {}}
         _write_aspic_to_state(output, state, {})
@@ -369,6 +379,7 @@ class TestStateWriters:
         from argumentation_analysis.orchestration.unified_pipeline import (
             _write_belief_revision_to_state,
         )
+
         state = self._make_state()
         output = {"method": "dalal", "original": ["p"], "revised": ["!p"]}
         _write_belief_revision_to_state(output, state, {})
@@ -378,8 +389,13 @@ class TestStateWriters:
         from argumentation_analysis.orchestration.unified_pipeline import (
             _write_dialogue_to_state,
         )
+
         state = self._make_state()
-        output = {"topic": "AI", "outcome": "accepted", "dialogue_trace": [{"round": 1}]}
+        output = {
+            "topic": "AI",
+            "outcome": "accepted",
+            "dialogue_trace": [{"round": 1}],
+        }
         _write_dialogue_to_state(output, state, {})
         assert len(state.dialogue_results) == 1
         assert state.dialogue_results[0]["outcome"] == "accepted"
@@ -388,8 +404,12 @@ class TestStateWriters:
         from argumentation_analysis.orchestration.unified_pipeline import (
             _write_probabilistic_to_state,
         )
+
         state = self._make_state()
-        output = {"arguments": ["a", "b"], "acceptance_probabilities": {"a": 0.8, "b": 0.3}}
+        output = {
+            "arguments": ["a", "b"],
+            "acceptance_probabilities": {"a": 0.8, "b": 0.3},
+        }
         _write_probabilistic_to_state(output, state, {})
         assert len(state.probabilistic_results) == 1
 
@@ -397,6 +417,7 @@ class TestStateWriters:
         from argumentation_analysis.orchestration.unified_pipeline import (
             _write_bipolar_to_state,
         )
+
         state = self._make_state()
         output = {"framework_type": "necessity", "arguments": ["a"], "supports": []}
         _write_bipolar_to_state(output, state, {})
@@ -408,6 +429,7 @@ class TestStateWriters:
             _write_aspic_to_state,
             _write_belief_revision_to_state,
         )
+
         state = self._make_state()
         _write_ranking_to_state(None, state, {})
         _write_aspic_to_state(None, state, {})
@@ -429,6 +451,7 @@ class TestWorkflowCatalog:
         from argumentation_analysis.orchestration.unified_pipeline import (
             get_workflow_catalog,
         )
+
         catalog = get_workflow_catalog()
         assert "formal_debate" in catalog
 
@@ -436,6 +459,7 @@ class TestWorkflowCatalog:
         from argumentation_analysis.orchestration.unified_pipeline import (
             get_workflow_catalog,
         )
+
         catalog = get_workflow_catalog()
         assert "belief_dynamics" in catalog
 
@@ -443,6 +467,7 @@ class TestWorkflowCatalog:
         from argumentation_analysis.orchestration.unified_pipeline import (
             get_workflow_catalog,
         )
+
         catalog = get_workflow_catalog()
         assert "argument_strength" in catalog
 
@@ -450,6 +475,7 @@ class TestWorkflowCatalog:
         from argumentation_analysis.orchestration.unified_pipeline import (
             get_workflow_catalog,
         )
+
         catalog = get_workflow_catalog()
         # 7 core + 3 macro (Track D) + 3 formal = 13
         assert len(catalog) >= 13

--- a/tests/unit/orchestration/hierarchical/operational/test_feedback_mechanism.py
+++ b/tests/unit/orchestration/hierarchical/operational/test_feedback_mechanism.py
@@ -13,10 +13,10 @@ from argumentation_analysis.orchestration.hierarchical.operational.feedback_mech
     FeedbackManager,
 )
 
-
 # ============================================================
 # RhetoricalToolsFeedback
 # ============================================================
+
 
 class TestRhetoricalToolsFeedbackInit:
     def test_default_storage_path(self, tmp_path, monkeypatch):
@@ -37,9 +37,12 @@ class TestRhetoricalToolsFeedbackInit:
     def test_stats_structure(self, tmp_path):
         fb = RhetoricalToolsFeedback(feedback_storage_path=str(tmp_path / "fb"))
         expected_tools = {
-            "complex_fallacy_analysis", "contextual_fallacy_analysis",
-            "fallacy_severity_evaluation", "argument_structure_visualization",
-            "argument_coherence_evaluation", "semantic_argument_analysis",
+            "complex_fallacy_analysis",
+            "contextual_fallacy_analysis",
+            "fallacy_severity_evaluation",
+            "argument_structure_visualization",
+            "argument_coherence_evaluation",
+            "semantic_argument_analysis",
             "contextual_fallacy_detection",
         }
         assert set(fb.feedback_stats.keys()) == expected_tools
@@ -53,13 +56,17 @@ class TestAddFeedback:
         return RhetoricalToolsFeedback(feedback_storage_path=str(tmp_path / "fb"))
 
     def test_add_positive(self, fb):
-        result = fb.add_feedback("complex_fallacy_analysis", "r1", "positive", {"comment": "Good"})
+        result = fb.add_feedback(
+            "complex_fallacy_analysis", "r1", "positive", {"comment": "Good"}
+        )
         assert result is True
         assert len(fb.feedback_history) == 1
         assert fb.feedback_stats["complex_fallacy_analysis"]["positive"] == 1
 
     def test_add_negative(self, fb):
-        fb.add_feedback("complex_fallacy_analysis", "r1", "negative", {"comment": "Bad"})
+        fb.add_feedback(
+            "complex_fallacy_analysis", "r1", "negative", {"comment": "Bad"}
+        )
         assert fb.feedback_stats["complex_fallacy_analysis"]["negative"] == 1
 
     def test_add_neutral(self, fb):
@@ -83,7 +90,9 @@ class TestAddFeedback:
         assert fb.feedback_history[0]["id"] == "feedback-1"
 
     def test_custom_source(self, fb):
-        fb.add_feedback("complex_fallacy_analysis", "r1", "positive", {}, source="system")
+        fb.add_feedback(
+            "complex_fallacy_analysis", "r1", "positive", {}, source="system"
+        )
         assert fb.feedback_history[0]["source"] == "system"
 
     def test_multiple_feedbacks(self, fb):
@@ -150,7 +159,9 @@ class TestApplyFeedback:
 
     def test_no_feedbacks_unchanged(self, fb):
         params = {"confidence_threshold": 0.8}
-        result = fb.apply_feedback_to_tool_parameters("complex_fallacy_analysis", params)
+        result = fb.apply_feedback_to_tool_parameters(
+            "complex_fallacy_analysis", params
+        )
         assert result == params
 
     def test_positive_feedback_adjusts_threshold(self, fb):
@@ -159,7 +170,9 @@ class TestApplyFeedback:
             fb.add_feedback("complex_fallacy_analysis", f"r{i}", "positive", {})
         fb.add_feedback("complex_fallacy_analysis", "rn", "negative", {})
         params = {"confidence_threshold": 0.8}
-        result = fb.apply_feedback_to_tool_parameters("complex_fallacy_analysis", params)
+        result = fb.apply_feedback_to_tool_parameters(
+            "complex_fallacy_analysis", params
+        )
         # Positive feedback should decrease threshold slightly
         assert result["confidence_threshold"] < 0.8
 
@@ -168,27 +181,35 @@ class TestApplyFeedback:
             fb.add_feedback("complex_fallacy_analysis", f"r{i}", "negative", {})
         fb.add_feedback("complex_fallacy_analysis", "rp", "positive", {})
         params = {"confidence_threshold": 0.7}
-        result = fb.apply_feedback_to_tool_parameters("complex_fallacy_analysis", params)
+        result = fb.apply_feedback_to_tool_parameters(
+            "complex_fallacy_analysis", params
+        )
         assert result["confidence_threshold"] > 0.7
 
     def test_threshold_clamped_min(self, fb):
         for i in range(100):
             fb.add_feedback("complex_fallacy_analysis", f"r{i}", "positive", {})
         params = {"confidence_threshold": 0.51}
-        result = fb.apply_feedback_to_tool_parameters("complex_fallacy_analysis", params)
+        result = fb.apply_feedback_to_tool_parameters(
+            "complex_fallacy_analysis", params
+        )
         assert result["confidence_threshold"] >= 0.5
 
     def test_threshold_clamped_max(self, fb):
         for i in range(100):
             fb.add_feedback("complex_fallacy_analysis", f"r{i}", "negative", {})
         params = {"confidence_threshold": 0.94}
-        result = fb.apply_feedback_to_tool_parameters("complex_fallacy_analysis", params)
+        result = fb.apply_feedback_to_tool_parameters(
+            "complex_fallacy_analysis", params
+        )
         assert result["confidence_threshold"] <= 0.95
 
     def test_no_threshold_param_unchanged(self, fb):
         fb.add_feedback("complex_fallacy_analysis", "r1", "positive", {})
         params = {"other_param": 42}
-        result = fb.apply_feedback_to_tool_parameters("complex_fallacy_analysis", params)
+        result = fb.apply_feedback_to_tool_parameters(
+            "complex_fallacy_analysis", params
+        )
         assert result["other_param"] == 42
 
 
@@ -214,7 +235,10 @@ class TestGenerateReport:
         fb.add_feedback("complex_fallacy_analysis", "r1", "positive", {})
         report = fb.generate_feedback_report()
         assert "complex_fallacy_analysis" in report["tool_statistics"]
-        assert report["tool_statistics"]["complex_fallacy_analysis"]["satisfaction_rate"] == 1.0
+        assert (
+            report["tool_statistics"]["complex_fallacy_analysis"]["satisfaction_rate"]
+            == 1.0
+        )
 
     def test_report_recent_feedbacks(self, tmp_path):
         fb = RhetoricalToolsFeedback(feedback_storage_path=str(tmp_path / "fb"))
@@ -241,6 +265,7 @@ class TestPersistence:
 # FeedbackManager
 # ============================================================
 
+
 class TestFeedbackManagerInit:
     def test_default_state(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
@@ -252,7 +277,10 @@ class TestFeedbackManagerInit:
 class TestCollectFeedback:
     @pytest.fixture
     def fm(self, tmp_path):
-        from argumentation_analysis.orchestration.hierarchical.operational.state import OperationalState
+        from argumentation_analysis.orchestration.hierarchical.operational.state import (
+            OperationalState,
+        )
+
         os_state = OperationalState()
         fm = FeedbackManager(operational_state=os_state)
         fm.rhetorical_tools_feedback = RhetoricalToolsFeedback(
@@ -261,22 +289,31 @@ class TestCollectFeedback:
         return fm
 
     def test_operational_level(self, fm):
-        result = fm.collect_feedback("operational", "complex_fallacy_analysis", "r1", "positive", {})
+        result = fm.collect_feedback(
+            "operational", "complex_fallacy_analysis", "r1", "positive", {}
+        )
         assert result is True
 
     def test_unsupported_level(self, fm):
-        result = fm.collect_feedback("strategic", "complex_fallacy_analysis", "r1", "positive", {})
+        result = fm.collect_feedback(
+            "strategic", "complex_fallacy_analysis", "r1", "positive", {}
+        )
         assert result is False
 
     def test_unsupported_tool(self, fm):
-        result = fm.collect_feedback("operational", "unknown_tool", "r1", "positive", {})
+        result = fm.collect_feedback(
+            "operational", "unknown_tool", "r1", "positive", {}
+        )
         assert result is False
 
 
 class TestApplyFeedbackManager:
     @pytest.fixture
     def fm(self, tmp_path):
-        from argumentation_analysis.orchestration.hierarchical.operational.state import OperationalState
+        from argumentation_analysis.orchestration.hierarchical.operational.state import (
+            OperationalState,
+        )
+
         fm = FeedbackManager(operational_state=OperationalState())
         fm.rhetorical_tools_feedback = RhetoricalToolsFeedback(
             feedback_storage_path=str(tmp_path / "fb")
@@ -297,7 +334,10 @@ class TestApplyFeedbackManager:
 class TestGenerateReportManager:
     @pytest.fixture
     def fm(self, tmp_path):
-        from argumentation_analysis.orchestration.hierarchical.operational.state import OperationalState
+        from argumentation_analysis.orchestration.hierarchical.operational.state import (
+            OperationalState,
+        )
+
         fm = FeedbackManager(operational_state=OperationalState())
         fm.rhetorical_tools_feedback = RhetoricalToolsFeedback(
             feedback_storage_path=str(tmp_path / "fb")

--- a/tests/unit/orchestration/hierarchical/operational/test_operational_state.py
+++ b/tests/unit/orchestration/hierarchical/operational/test_operational_state.py
@@ -22,6 +22,7 @@ def state():
 # __init__
 # ============================================================
 
+
 class TestInit:
     def test_default_values(self, state):
         assert state.assigned_tasks == []
@@ -31,11 +32,18 @@ class TestInit:
 
     def test_analysis_results_structure(self, state):
         expected_keys = {
-            "identified_arguments", "identified_fallacies", "formal_analyses",
-            "extracted_data", "visualizations", "complex_fallacy_analyses",
-            "contextual_fallacy_analyses", "fallacy_severity_evaluations",
-            "argument_structure_visualizations", "argument_coherence_evaluations",
-            "semantic_argument_analyses", "contextual_fallacy_detections",
+            "identified_arguments",
+            "identified_fallacies",
+            "formal_analyses",
+            "extracted_data",
+            "visualizations",
+            "complex_fallacy_analyses",
+            "contextual_fallacy_analyses",
+            "fallacy_severity_evaluations",
+            "argument_structure_visualizations",
+            "argument_coherence_evaluations",
+            "semantic_argument_analyses",
+            "contextual_fallacy_detections",
         }
         assert expected_keys == set(state.analysis_results.keys())
 
@@ -48,6 +56,7 @@ class TestInit:
 # ============================================================
 # add_task
 # ============================================================
+
 
 class TestAddTask:
     def test_add_with_id(self, state):
@@ -73,6 +82,7 @@ class TestAddTask:
 # ============================================================
 # update_task_status
 # ============================================================
+
 
 class TestUpdateTaskStatus:
     def test_update_success(self, state):
@@ -101,6 +111,7 @@ class TestUpdateTaskStatus:
 # get_task
 # ============================================================
 
+
 class TestGetTask:
     def test_found(self, state):
         state.add_task({"id": "t1", "description": "Test"})
@@ -115,6 +126,7 @@ class TestGetTask:
 # ============================================================
 # add_text_extract
 # ============================================================
+
 
 class TestAddTextExtract:
     def test_add_success(self, state):
@@ -133,18 +145,25 @@ class TestAddTextExtract:
 # add_analysis_result
 # ============================================================
 
+
 class TestAddAnalysisResult:
     def test_known_type(self, state):
-        result_id = state.add_analysis_result("identified_fallacies", {"type": "ad_hominem"})
+        result_id = state.add_analysis_result(
+            "identified_fallacies", {"type": "ad_hominem"}
+        )
         assert len(state.analysis_results["identified_fallacies"]) == 1
         assert state.analysis_results["identified_fallacies"][0]["type"] == "ad_hominem"
 
     def test_auto_id(self, state):
-        result_id = state.add_analysis_result("identified_arguments", {"content": "test"})
+        result_id = state.add_analysis_result(
+            "identified_arguments", {"content": "test"}
+        )
         assert result_id.startswith("result-")
 
     def test_custom_id(self, state):
-        result_id = state.add_analysis_result("identified_arguments", {"id": "r1", "content": "test"})
+        result_id = state.add_analysis_result(
+            "identified_arguments", {"id": "r1", "content": "test"}
+        )
         assert result_id == "r1"
 
     def test_unknown_type_creates_category(self, state):
@@ -160,6 +179,7 @@ class TestAddAnalysisResult:
 # ============================================================
 # add_issue
 # ============================================================
+
 
 class TestAddIssue:
     def test_add_with_id(self, state):
@@ -179,6 +199,7 @@ class TestAddIssue:
 # ============================================================
 # update_metrics
 # ============================================================
+
 
 class TestUpdateMetrics:
     def test_execution_time(self, state):
@@ -205,6 +226,7 @@ class TestUpdateMetrics:
 # log_action
 # ============================================================
 
+
 class TestLogAction:
     def test_logs_entry(self, state):
         state.log_action("analyze", {"text": "sample"})
@@ -217,10 +239,15 @@ class TestLogAction:
 # get_task_results / get_task_issues / get_task_metrics
 # ============================================================
 
+
 class TestGetTaskData:
     def test_get_task_results(self, state):
-        state.add_analysis_result("identified_fallacies", {"task_id": "t1", "type": "ad_hominem"})
-        state.add_analysis_result("identified_fallacies", {"task_id": "t2", "type": "straw_man"})
+        state.add_analysis_result(
+            "identified_fallacies", {"task_id": "t1", "type": "ad_hominem"}
+        )
+        state.add_analysis_result(
+            "identified_fallacies", {"task_id": "t2", "type": "straw_man"}
+        )
         results = state.get_task_results("t1")
         assert "identified_fallacies" in results
         assert len(results["identified_fallacies"]) == 1
@@ -245,6 +272,7 @@ class TestGetTaskData:
 # ============================================================
 # Filtering methods
 # ============================================================
+
 
 class TestFilteringMethods:
     def test_get_pending_tasks(self, state):
@@ -278,6 +306,7 @@ class TestFilteringMethods:
 # clear
 # ============================================================
 
+
 class TestClear:
     def test_resets_state(self, state):
         state.add_task({"id": "t1"})
@@ -293,6 +322,7 @@ class TestClear:
 # find_operational_task_by_tactical_id
 # ============================================================
 
+
 class TestFindByTacticalId:
     def test_found(self, state):
         state.add_task({"id": "op1", "tactical_task_id": "tac1"})
@@ -307,6 +337,7 @@ class TestFindByTacticalId:
 # ============================================================
 # add_result_future / get_result_future
 # ============================================================
+
 
 class TestResultFutures:
     def test_add_and_get(self, state):

--- a/tests/unit/orchestration/hierarchical/strategic/test_resource_allocator.py
+++ b/tests/unit/orchestration/hierarchical/strategic/test_resource_allocator.py
@@ -29,6 +29,7 @@ def allocator(state):
 # __init__
 # ============================================================
 
+
 class TestInit:
     def test_default_state(self):
         a = ResourceAllocator()
@@ -56,6 +57,7 @@ class TestInit:
 # _analyze_resource_needs
 # ============================================================
 
+
 class TestAnalyzeResourceNeeds:
     def test_empty_phases(self, allocator):
         needs = allocator._analyze_resource_needs([])
@@ -68,7 +70,9 @@ class TestAnalyzeResourceNeeds:
         assert needs["p1"]["text_extraction"] > 0
 
     def test_sophisme_phase(self, allocator):
-        phases = [{"id": "p1", "description": "Détection de sophisme et analyse logique"}]
+        phases = [
+            {"id": "p1", "description": "Détection de sophisme et analyse logique"}
+        ]
         needs = allocator._analyze_resource_needs(phases)
         assert needs["p1"]["fallacy_detection"] > 0
         assert needs["p1"]["formal_logic"] > 0
@@ -80,13 +84,25 @@ class TestAnalyzeResourceNeeds:
         assert needs["p1"]["summary_generation"] > 0
 
     def test_short_duration_factor(self, allocator):
-        phases = [{"id": "p1", "description": "Identification des éléments clés", "estimated_duration": "short"}]
+        phases = [
+            {
+                "id": "p1",
+                "description": "Identification des éléments clés",
+                "estimated_duration": "short",
+            }
+        ]
         needs = allocator._analyze_resource_needs(phases)
         # Short duration uses 0.7 factor
         assert needs["p1"]["argument_identification"] == pytest.approx(0.8 * 0.7)
 
     def test_long_duration_factor(self, allocator):
-        phases = [{"id": "p1", "description": "Identification des éléments clés", "estimated_duration": "long"}]
+        phases = [
+            {
+                "id": "p1",
+                "description": "Identification des éléments clés",
+                "estimated_duration": "long",
+            }
+        ]
         needs = allocator._analyze_resource_needs(phases)
         assert needs["p1"]["argument_identification"] == pytest.approx(0.8 * 1.3)
 
@@ -109,6 +125,7 @@ class TestAnalyzeResourceNeeds:
 # ============================================================
 # _determine_agent_assignments
 # ============================================================
+
 
 class TestDetermineAgentAssignments:
     def test_empty_phases(self, allocator):
@@ -136,6 +153,7 @@ class TestDetermineAgentAssignments:
 # ============================================================
 # _define_agent_priorities
 # ============================================================
+
 
 class TestDefineAgentPriorities:
     def test_no_assignments_low_priority(self, allocator):
@@ -171,6 +189,7 @@ class TestDefineAgentPriorities:
 # _allocate_computational_budget
 # ============================================================
 
+
 class TestAllocateComputationalBudget:
     def test_budget_sums_to_one(self, allocator):
         assignments = {"a1": ["p1"], "a2": ["p1", "p2"]}
@@ -201,6 +220,7 @@ class TestAllocateComputationalBudget:
 # ============================================================
 # allocate_initial_resources
 # ============================================================
+
 
 class TestAllocateInitialResources:
     def test_basic_plan(self, allocator, state):
@@ -233,6 +253,7 @@ class TestAllocateInitialResources:
 # ============================================================
 # adjust_allocation
 # ============================================================
+
 
 class TestAdjustAllocation:
     def test_no_feedback_unchanged(self, allocator, state):
@@ -283,6 +304,7 @@ class TestAdjustAllocation:
 # optimize_resource_utilization
 # ============================================================
 
+
 class TestOptimizeResourceUtilization:
     def test_no_metrics_unchanged(self, allocator, state):
         plan = {
@@ -303,8 +325,16 @@ class TestOptimizeResourceUtilization:
         if len(agent_ids) >= 2:
             metrics = {
                 "agent_efficiency": {
-                    agent_ids[0]: {"processing_speed": 0.9, "accuracy": 0.9, "resource_usage": 0.2},
-                    agent_ids[1]: {"processing_speed": 0.1, "accuracy": 0.1, "resource_usage": 0.9},
+                    agent_ids[0]: {
+                        "processing_speed": 0.9,
+                        "accuracy": 0.9,
+                        "resource_usage": 0.2,
+                    },
+                    agent_ids[1]: {
+                        "processing_speed": 0.1,
+                        "accuracy": 0.1,
+                        "resource_usage": 0.9,
+                    },
                 }
             }
             allocator.optimize_resource_utilization(metrics)
@@ -317,6 +347,7 @@ class TestOptimizeResourceUtilization:
 # ============================================================
 # get_resource_allocation_snapshot
 # ============================================================
+
 
 class TestGetSnapshot:
     def test_snapshot_structure(self, allocator):

--- a/tests/unit/orchestration/hierarchical/strategic/test_strategic_planner.py
+++ b/tests/unit/orchestration/hierarchical/strategic/test_strategic_planner.py
@@ -18,9 +18,15 @@ from argumentation_analysis.orchestration.hierarchical.strategic.state import (
 @pytest.fixture
 def state():
     s = StrategicState()
-    s.add_global_objective({"id": "obj-1", "description": "Identifier les arguments", "priority": "high"})
-    s.add_global_objective({"id": "obj-2", "description": "Détecter les sophismes", "priority": "medium"})
-    s.add_global_objective({"id": "obj-3", "description": "Évaluer la cohérence", "priority": "low"})
+    s.add_global_objective(
+        {"id": "obj-1", "description": "Identifier les arguments", "priority": "high"}
+    )
+    s.add_global_objective(
+        {"id": "obj-2", "description": "Détecter les sophismes", "priority": "medium"}
+    )
+    s.add_global_objective(
+        {"id": "obj-3", "description": "Évaluer la cohérence", "priority": "low"}
+    )
     return s
 
 
@@ -32,6 +38,7 @@ def planner(state):
 # ============================================================
 # __init__
 # ============================================================
+
 
 class TestPlannerInit:
     def test_default_state(self):
@@ -47,34 +54,52 @@ class TestPlannerInit:
 # _assess_text_complexity
 # ============================================================
 
+
 class TestAssessTextComplexity:
     @pytest.fixture
     def planner(self):
         return StrategicPlanner()
 
     def test_low_complexity(self, planner):
-        metadata = {"length": 500, "avg_sentence_length": 10, "vocabulary_diversity": 0.3}
+        metadata = {
+            "length": 500,
+            "avg_sentence_length": 10,
+            "vocabulary_diversity": 0.3,
+        }
         assert planner._assess_text_complexity(metadata) == "low"
 
     def test_medium_complexity(self, planner):
-        metadata = {"length": 3000, "avg_sentence_length": 18, "vocabulary_diversity": 0.6}
+        metadata = {
+            "length": 3000,
+            "avg_sentence_length": 18,
+            "vocabulary_diversity": 0.6,
+        }
         assert planner._assess_text_complexity(metadata) == "medium"
 
     def test_high_complexity(self, planner):
-        metadata = {"length": 10000, "avg_sentence_length": 25, "vocabulary_diversity": 0.8}
+        metadata = {
+            "length": 10000,
+            "avg_sentence_length": 25,
+            "vocabulary_diversity": 0.8,
+        }
         assert planner._assess_text_complexity(metadata) == "high"
 
     def test_empty_metadata_defaults_low(self, planner):
         assert planner._assess_text_complexity({}) == "low"
 
     def test_boundary_medium(self, planner):
-        metadata = {"length": 2001, "avg_sentence_length": 16, "vocabulary_diversity": 0.51}
+        metadata = {
+            "length": 2001,
+            "avg_sentence_length": 16,
+            "vocabulary_diversity": 0.51,
+        }
         assert planner._assess_text_complexity(metadata) == "medium"
 
 
 # ============================================================
 # _decompose_objectives_into_phases
 # ============================================================
+
 
 class TestDecomposeObjectives:
     @pytest.fixture
@@ -125,6 +150,7 @@ class TestDecomposeObjectives:
 # _establish_phase_dependencies
 # ============================================================
 
+
 class TestEstablishDependencies:
     @pytest.fixture
     def planner(self):
@@ -146,6 +172,7 @@ class TestEstablishDependencies:
 # ============================================================
 # _define_phase_priorities
 # ============================================================
+
 
 class TestDefinePhaPriorities:
     @pytest.fixture
@@ -182,6 +209,7 @@ class TestDefinePhaPriorities:
 # ============================================================
 # _define_success_criteria
 # ============================================================
+
 
 class TestDefineSuccessCriteria:
     @pytest.fixture
@@ -222,9 +250,14 @@ class TestDefineSuccessCriteria:
 # create_analysis_plan (integration)
 # ============================================================
 
+
 class TestCreateAnalysisPlan:
     def test_creates_plan(self, planner, state):
-        metadata = {"length": 1000, "avg_sentence_length": 12, "vocabulary_diversity": 0.4}
+        metadata = {
+            "length": 1000,
+            "avg_sentence_length": 12,
+            "vocabulary_diversity": 0.4,
+        }
         plan = planner.create_analysis_plan(metadata, state.global_objectives)
         assert "phases" in plan
         assert len(plan["phases"]) >= 3
@@ -240,6 +273,7 @@ class TestCreateAnalysisPlan:
 # ============================================================
 # decompose_objective
 # ============================================================
+
 
 class TestDecomposeObjective:
     def test_identifier_arguments(self, planner, state):
@@ -263,7 +297,9 @@ class TestDecomposeObjective:
         assert subs == []
 
     def test_generic_decomposition(self, planner, state):
-        state.add_global_objective({"id": "obj-generic", "description": "Faire le café", "priority": "medium"})
+        state.add_global_objective(
+            {"id": "obj-generic", "description": "Faire le café", "priority": "medium"}
+        )
         subs = planner.decompose_objective("obj-generic")
         assert len(subs) == 2
 
@@ -271,6 +307,7 @@ class TestDecomposeObjective:
 # ============================================================
 # adjust_plan
 # ============================================================
+
 
 class TestAdjustPlan:
     def test_no_feedback_no_change(self, planner, state):
@@ -287,7 +324,7 @@ class TestAdjustPlan:
             "progress": {
                 "phase-2": {"completion_rate": 0.2, "expected_completion_rate": 0.8}
             },
-            "issues": []
+            "issues": [],
         }
         planner.adjust_plan(feedback)
         # Plan should be adjusted
@@ -297,6 +334,7 @@ class TestAdjustPlan:
 # ============================================================
 # _identify_problematic_phases
 # ============================================================
+
 
 class TestIdentifyProblematicPhases:
     @pytest.fixture
@@ -324,6 +362,7 @@ class TestIdentifyProblematicPhases:
 # _create_phase_adjustment
 # ============================================================
 
+
 class TestCreatePhaseAdjustment:
     @pytest.fixture
     def planner(self):
@@ -341,6 +380,11 @@ class TestCreatePhaseAdjustment:
         assert adj == {}
 
     def test_objective_unrealistic(self, planner):
-        problems = [{"type": "objective_unrealistic", "details": {"suggested_criteria": "50% accuracy"}}]
+        problems = [
+            {
+                "type": "objective_unrealistic",
+                "details": {"suggested_criteria": "50% accuracy"},
+            }
+        ]
         adj = planner._create_phase_adjustment("p1", problems)
         assert adj["success_criteria"] == "50% accuracy"

--- a/tests/unit/orchestration/hierarchical/strategic/test_strategic_state.py
+++ b/tests/unit/orchestration/hierarchical/strategic/test_strategic_state.py
@@ -21,6 +21,7 @@ def state():
 # __init__
 # ============================================================
 
+
 class TestInit:
     def test_default_values(self, state):
         assert state.raw_text is None
@@ -46,9 +47,12 @@ class TestInit:
 
     def test_rhetorical_summary_keys(self, state):
         expected = {
-            "complex_fallacy_summary", "contextual_fallacy_summary",
-            "fallacy_severity_summary", "argument_structure_summary",
-            "argument_coherence_summary", "semantic_argument_summary",
+            "complex_fallacy_summary",
+            "contextual_fallacy_summary",
+            "fallacy_severity_summary",
+            "argument_structure_summary",
+            "argument_coherence_summary",
+            "semantic_argument_summary",
         }
         assert set(state.rhetorical_analysis_summary.keys()) == expected
 
@@ -56,6 +60,7 @@ class TestInit:
 # ============================================================
 # set_raw_text
 # ============================================================
+
 
 class TestSetRawText:
     def test_sets_text(self, state):
@@ -72,6 +77,7 @@ class TestSetRawText:
 # add_global_objective
 # ============================================================
 
+
 class TestAddGlobalObjective:
     def test_adds_objective(self, state):
         obj = {"id": "obj-1", "description": "Test", "priority": "high"}
@@ -81,13 +87,16 @@ class TestAddGlobalObjective:
 
     def test_multiple_objectives(self, state):
         for i in range(3):
-            state.add_global_objective({"id": f"obj-{i}", "description": f"Obj {i}", "priority": "medium"})
+            state.add_global_objective(
+                {"id": f"obj-{i}", "description": f"Obj {i}", "priority": "medium"}
+            )
         assert len(state.global_objectives) == 3
 
 
 # ============================================================
 # update_strategic_plan
 # ============================================================
+
 
 class TestUpdateStrategicPlan:
     def test_update_phases(self, state):
@@ -107,6 +116,7 @@ class TestUpdateStrategicPlan:
 # update_resource_allocation
 # ============================================================
 
+
 class TestUpdateResourceAllocation:
     def test_update_agent_assignments(self, state):
         state.update_resource_allocation({"agent_assignments": {"a1": "task1"}})
@@ -123,6 +133,7 @@ class TestUpdateResourceAllocation:
 # update_global_metrics
 # ============================================================
 
+
 class TestUpdateGlobalMetrics:
     def test_update_progress(self, state):
         state.update_global_metrics({"progress": 0.5})
@@ -137,10 +148,15 @@ class TestUpdateGlobalMetrics:
 # update_rhetorical_analysis_summary
 # ============================================================
 
+
 class TestUpdateRhetoricalSummary:
     def test_update_summary(self, state):
-        state.update_rhetorical_analysis_summary({"complex_fallacy_summary": {"count": 3}})
-        assert state.rhetorical_analysis_summary["complex_fallacy_summary"]["count"] == 3
+        state.update_rhetorical_analysis_summary(
+            {"complex_fallacy_summary": {"count": 3}}
+        )
+        assert (
+            state.rhetorical_analysis_summary["complex_fallacy_summary"]["count"] == 3
+        )
 
     def test_unknown_key_ignored(self, state):
         state.update_rhetorical_analysis_summary({"nonexistent": "val"})
@@ -151,25 +167,33 @@ class TestUpdateRhetoricalSummary:
 # set_final_conclusion / log_strategic_decision
 # ============================================================
 
+
 class TestConclusionAndDecisions:
     def test_set_conclusion(self, state):
         state.set_final_conclusion("The argument is fallacious.")
         assert state.final_conclusion == "The argument is fallacious."
 
     def test_log_decision(self, state):
-        decision = {"timestamp": "2025-01-01", "description": "Increase priority", "rationale": "Too slow"}
+        decision = {
+            "timestamp": "2025-01-01",
+            "description": "Increase priority",
+            "rationale": "Too slow",
+        }
         state.log_strategic_decision(decision)
         assert len(state.strategic_decisions_log) == 1
 
     def test_multiple_decisions(self, state):
         for i in range(5):
-            state.log_strategic_decision({"timestamp": f"t{i}", "description": f"D{i}", "rationale": f"R{i}"})
+            state.log_strategic_decision(
+                {"timestamp": f"t{i}", "description": f"D{i}", "rationale": f"R{i}"}
+            )
         assert len(state.strategic_decisions_log) == 5
 
 
 # ============================================================
 # get_snapshot
 # ============================================================
+
 
 class TestGetSnapshot:
     def test_snapshot_structure(self, state):
@@ -192,7 +216,9 @@ class TestGetSnapshot:
         assert snap["raw_text_length"] == 5
 
     def test_decisions_count(self, state):
-        state.log_strategic_decision({"timestamp": "t", "description": "d", "rationale": "r"})
+        state.log_strategic_decision(
+            {"timestamp": "t", "description": "d", "rationale": "r"}
+        )
         snap = state.get_snapshot()
         assert snap["strategic_decisions_count"] == 1
 
@@ -200,6 +226,7 @@ class TestGetSnapshot:
 # ============================================================
 # to_json / from_json
 # ============================================================
+
 
 class TestSerialization:
     def test_to_json_returns_string(self, state):
@@ -210,10 +237,14 @@ class TestSerialization:
 
     def test_roundtrip(self, state):
         state.set_raw_text("Test text")
-        state.add_global_objective({"id": "obj-1", "description": "Test", "priority": "high"})
+        state.add_global_objective(
+            {"id": "obj-1", "description": "Test", "priority": "high"}
+        )
         state.update_global_metrics({"progress": 0.75})
         state.set_final_conclusion("Done")
-        state.log_strategic_decision({"timestamp": "t", "description": "d", "rationale": "r"})
+        state.log_strategic_decision(
+            {"timestamp": "t", "description": "d", "rationale": "r"}
+        )
 
         j = state.to_json()
         restored = StrategicState.from_json(j)

--- a/tests/unit/orchestration/hierarchical/tactical/test_progress_monitor.py
+++ b/tests/unit/orchestration/hierarchical/tactical/test_progress_monitor.py
@@ -20,9 +20,27 @@ from argumentation_analysis.orchestration.hierarchical.tactical.state import (
 def state():
     """Create a TacticalState with sample tasks."""
     s = TacticalState()
-    s.add_assigned_objective({"id": "obj-1", "description": "Analyze text", "priority": "high"})
-    s.add_task({"id": "t1", "description": "Task 1", "objective_id": "obj-1", "estimated_duration": 60}, "pending")
-    s.add_task({"id": "t2", "description": "Task 2", "objective_id": "obj-1", "estimated_duration": 120}, "pending")
+    s.add_assigned_objective(
+        {"id": "obj-1", "description": "Analyze text", "priority": "high"}
+    )
+    s.add_task(
+        {
+            "id": "t1",
+            "description": "Task 1",
+            "objective_id": "obj-1",
+            "estimated_duration": 60,
+        },
+        "pending",
+    )
+    s.add_task(
+        {
+            "id": "t2",
+            "description": "Task 2",
+            "objective_id": "obj-1",
+            "estimated_duration": 120,
+        },
+        "pending",
+    )
     return s
 
 
@@ -34,6 +52,7 @@ def monitor(state):
 # ============================================================
 # __init__
 # ============================================================
+
 
 class TestProgressMonitorInit:
     def test_default_state(self):
@@ -54,6 +73,7 @@ class TestProgressMonitorInit:
 # ============================================================
 # update_task_progress
 # ============================================================
+
 
 class TestUpdateTaskProgress:
     def test_success(self, monitor, state):
@@ -87,6 +107,7 @@ class TestUpdateTaskProgress:
 # _check_task_anomalies
 # ============================================================
 
+
 class TestCheckTaskAnomalies:
     def test_stagnation_detected(self, monitor, state):
         state.update_task_status("t1", "in_progress")
@@ -105,7 +126,15 @@ class TestCheckTaskAnomalies:
         assert not any(a["type"] == "regression" for a in anomalies)
 
     def test_blocked_dependency(self, monitor, state):
-        state.add_task({"id": "t3", "description": "Task 3", "objective_id": "obj-1", "estimated_duration": 60}, "in_progress")
+        state.add_task(
+            {
+                "id": "t3",
+                "description": "Task 3",
+                "objective_id": "obj-1",
+                "estimated_duration": 60,
+            },
+            "in_progress",
+        )
         state.add_task_dependency("t1", "t3")
         state.update_task_status("t3", "failed")
         anomalies = monitor._check_task_anomalies("t1", 0.0, 0.1)
@@ -124,6 +153,7 @@ class TestCheckTaskAnomalies:
 # ============================================================
 # generate_progress_report
 # ============================================================
+
 
 class TestGenerateProgressReport:
     def test_empty_state_report(self):
@@ -145,7 +175,14 @@ class TestGenerateProgressReport:
         assert any(i["type"] == "task_failure" for i in report["issues"])
 
     def test_report_with_unresolved_conflicts(self, monitor, state):
-        state.add_conflict({"id": "c1", "description": "Conflict", "involved_tasks": ["t1"], "severity": "high"})
+        state.add_conflict(
+            {
+                "id": "c1",
+                "description": "Conflict",
+                "involved_tasks": ["t1"],
+                "severity": "high",
+            }
+        )
         report = monitor.generate_progress_report()
         assert report["conflicts"]["total"] == 1
         assert report["conflicts"]["resolved"] == 0
@@ -166,7 +203,15 @@ class TestGenerateProgressReport:
         assert report["overall_progress"] > 0.0
 
     def test_blocked_task_detected(self, monitor, state):
-        state.add_task({"id": "t3", "description": "Dep", "objective_id": "obj-1", "estimated_duration": 30}, "failed")
+        state.add_task(
+            {
+                "id": "t3",
+                "description": "Dep",
+                "objective_id": "obj-1",
+                "estimated_duration": 30,
+            },
+            "failed",
+        )
         state.add_task_dependency("t1", "t3")
         report = monitor.generate_progress_report()
         assert any(i["type"] == "blocked_task" for i in report["issues"])
@@ -176,6 +221,7 @@ class TestGenerateProgressReport:
 # detect_critical_issues
 # ============================================================
 
+
 class TestDetectCriticalIssues:
     def test_no_issues_clean_state(self, monitor):
         issues = monitor.detect_critical_issues()
@@ -183,7 +229,15 @@ class TestDetectCriticalIssues:
 
     def test_blocked_task(self, monitor, state):
         state.update_task_status("t1", "in_progress")
-        state.add_task({"id": "dep", "description": "Failed dep", "objective_id": "obj-1", "estimated_duration": 30}, "failed")
+        state.add_task(
+            {
+                "id": "dep",
+                "description": "Failed dep",
+                "objective_id": "obj-1",
+                "estimated_duration": 30,
+            },
+            "failed",
+        )
         state.add_task_dependency("t1", "dep")
         issues = monitor.detect_critical_issues()
         blocked = [i for i in issues if i["type"] == "blocked_task"]
@@ -214,6 +268,7 @@ class TestDetectCriticalIssues:
 # ============================================================
 # suggest_corrective_actions
 # ============================================================
+
 
 class TestSuggestCorrectiveActions:
     def test_blocked_task_action(self, monitor):
@@ -257,6 +312,7 @@ class TestSuggestCorrectiveActions:
 # _evaluate_overall_coherence
 # ============================================================
 
+
 class TestEvaluateOverallCoherence:
     @pytest.fixture
     def monitor_fresh(self):
@@ -267,7 +323,7 @@ class TestEvaluateOverallCoherence:
             {"coherence_score": 0.9},
             {"coherence_score": 0.9},
             {"coherence_score": 0.9},
-            []
+            [],
         )
         assert result["overall_score"] == pytest.approx(0.9, abs=0.01)
         assert result["coherence_level"] == "Élevé"
@@ -277,7 +333,7 @@ class TestEvaluateOverallCoherence:
             {"coherence_score": 0.1},
             {"coherence_score": 0.1},
             {"coherence_score": 0.1},
-            []
+            [],
         )
         assert result["overall_score"] < 0.3
         assert result["coherence_level"] == "Très faible"
@@ -287,13 +343,13 @@ class TestEvaluateOverallCoherence:
             {"coherence_score": 0.8},
             {"coherence_score": 0.8},
             {"coherence_score": 0.8},
-            []
+            [],
         )
         with_contradictions = monitor_fresh._evaluate_overall_coherence(
             {"coherence_score": 0.8},
             {"coherence_score": 0.8},
             {"coherence_score": 0.8},
-            [{"severity": "critical"}, {"severity": "high"}]
+            [{"severity": "critical"}, {"severity": "high"}],
         )
         assert with_contradictions["overall_score"] < no_contradictions["overall_score"]
         assert with_contradictions["contradiction_penalty"] > 0.0
@@ -303,13 +359,16 @@ class TestEvaluateOverallCoherence:
             {"coherence_score": 1.0},
             {"coherence_score": 1.0},
             {"coherence_score": 1.0},
-            [{"severity": "critical"}] * 10  # Many contradictions
+            [{"severity": "critical"}] * 10,  # Many contradictions
         )
         assert result["contradiction_penalty"] == 0.5
 
     def test_weights_sum(self, monitor_fresh):
         result = monitor_fresh._evaluate_overall_coherence(
-            {"coherence_score": 1.0}, {"coherence_score": 1.0}, {"coherence_score": 1.0}, []
+            {"coherence_score": 1.0},
+            {"coherence_score": 1.0},
+            {"coherence_score": 1.0},
+            [],
         )
         weights = result["weights_used"]
         assert sum(weights.values()) == pytest.approx(1.0)
@@ -323,14 +382,16 @@ class TestEvaluateOverallCoherence:
             {"coherence_score": 0.7},
             {"coherence_score": 0.65},
             {"coherence_score": 0.7},
-            []
+            [],
         )
         assert result["coherence_level"] == "Modéré"
 
     def test_contradictions_count(self, monitor_fresh):
         result = monitor_fresh._evaluate_overall_coherence(
-            {"coherence_score": 0.5}, {"coherence_score": 0.5}, {"coherence_score": 0.5},
-            [{"severity": "low"}, {"severity": "medium"}]
+            {"coherence_score": 0.5},
+            {"coherence_score": 0.5},
+            {"coherence_score": 0.5},
+            [{"severity": "low"}, {"severity": "medium"}],
         )
         assert result["contradictions_count"] == 2
 
@@ -338,6 +399,7 @@ class TestEvaluateOverallCoherence:
 # ============================================================
 # _log_action
 # ============================================================
+
 
 class TestLogAction:
     def test_logs_to_state(self, monitor, state):

--- a/tests/unit/services/test_mcp_server_v2/test_capability_tools.py
+++ b/tests/unit/services/test_mcp_server_v2/test_capability_tools.py
@@ -46,9 +46,15 @@ def _make_registry(components=None, slots=None):
     registry.get_all_capabilities.return_value = caps_index
     registry.get_all_slots.return_value = slots
     registry.summary.return_value = {
-        "agents": sum(1 for c in components if c.component_type == MockComponentType.AGENT),
-        "services": sum(1 for c in components if c.component_type == MockComponentType.SERVICE),
-        "plugins": sum(1 for c in components if c.component_type == MockComponentType.PLUGIN),
+        "agents": sum(
+            1 for c in components if c.component_type == MockComponentType.AGENT
+        ),
+        "services": sum(
+            1 for c in components if c.component_type == MockComponentType.SERVICE
+        ),
+        "plugins": sum(
+            1 for c in components if c.component_type == MockComponentType.PLUGIN
+        ),
         "total_registrations": len(components),
         "slots_unfilled": len(slots),
     }
@@ -70,6 +76,7 @@ def _setup_tools():
         def wrapper(fn):
             tools[fn.__name__] = fn
             return fn
+
         return wrapper
 
     mcp_mock.tool = fake_tool
@@ -97,6 +104,7 @@ class TestListCapabilities:
         from argumentation_analysis.services.mcp_server.tools.capability_tools import (
             register_capability_tools,
         )
+
         register_capability_tools(mcp_mock, lambda: registry)
 
         result = await tools["list_capabilities"]()
@@ -112,6 +120,7 @@ class TestListCapabilities:
         from argumentation_analysis.services.mcp_server.tools.capability_tools import (
             register_capability_tools,
         )
+
         register_capability_tools(mcp_mock, lambda: registry)
 
         result = await tools["list_capabilities"]()
@@ -140,6 +149,7 @@ class TestInvokeCapability:
         from argumentation_analysis.services.mcp_server.tools.capability_tools import (
             register_capability_tools,
         )
+
         register_capability_tools(mcp_mock, lambda: registry)
 
         result = await tools["invoke_capability"](
@@ -157,6 +167,7 @@ class TestInvokeCapability:
         from argumentation_analysis.services.mcp_server.tools.capability_tools import (
             register_capability_tools,
         )
+
         register_capability_tools(mcp_mock, lambda: registry)
 
         result = await tools["invoke_capability"](
@@ -182,6 +193,7 @@ class TestInvokeCapability:
         from argumentation_analysis.services.mcp_server.tools.capability_tools import (
             register_capability_tools,
         )
+
         register_capability_tools(mcp_mock, lambda: registry)
 
         result = await tools["invoke_capability"](
@@ -208,6 +220,7 @@ class TestInvokeCapability:
         from argumentation_analysis.services.mcp_server.tools.capability_tools import (
             register_capability_tools,
         )
+
         register_capability_tools(mcp_mock, lambda: registry)
 
         ctx = {"key": "value"}
@@ -242,6 +255,7 @@ class TestGetRegistrySummary:
         from argumentation_analysis.services.mcp_server.tools.capability_tools import (
             register_capability_tools,
         )
+
         register_capability_tools(mcp_mock, lambda: registry)
 
         result = await tools["get_registry_summary"]()

--- a/tests/unit/services/test_mcp_server_v2/test_conversation_tools.py
+++ b/tests/unit/services/test_mcp_server_v2/test_conversation_tools.py
@@ -60,6 +60,7 @@ def _setup_tools():
         def wrapper(fn):
             tools[fn.__name__] = fn
             return fn
+
         return wrapper
 
     mcp_mock.tool = fake_tool
@@ -106,6 +107,7 @@ class TestStartConversation:
         from argumentation_analysis.services.mcp_server.tools.conversation_tools import (
             register_conversation_tools,
         )
+
         register_conversation_tools(mcp_mock, lambda: mock_registry, lambda: sm)
 
         patches = _make_conversation_patches(catalog, mock_strategy)
@@ -125,9 +127,7 @@ class TestStartConversation:
         mock_registry = MagicMock()
 
         catalog = {
-            "full": MockWorkflowDefinition(
-                "full", [MockWorkflowPhase("p1", "quality")]
-            )
+            "full": MockWorkflowDefinition("full", [MockWorkflowPhase("p1", "quality")])
         }
 
         mock_strategy = MagicMock()
@@ -136,6 +136,7 @@ class TestStartConversation:
         from argumentation_analysis.services.mcp_server.tools.conversation_tools import (
             register_conversation_tools,
         )
+
         register_conversation_tools(mcp_mock, lambda: mock_registry, lambda: sm)
 
         patches = _make_conversation_patches(catalog, mock_strategy)
@@ -172,13 +173,12 @@ class TestContinueConversation:
         from argumentation_analysis.services.mcp_server.tools.conversation_tools import (
             register_conversation_tools,
         )
+
         register_conversation_tools(mcp_mock, lambda: mock_registry, lambda: sm)
 
         patches = _make_conversation_patches(catalog, mock_strategy)
         with patches[0], patches[1], patches[2]:
-            result = await tools["continue_conversation"](
-                session_id=session.session_id
-            )
+            result = await tools["continue_conversation"](session_id=session.session_id)
 
         assert result["status"] == "active"
         assert result["round"] == 2
@@ -191,6 +191,7 @@ class TestContinueConversation:
         from argumentation_analysis.services.mcp_server.tools.conversation_tools import (
             register_conversation_tools,
         )
+
         register_conversation_tools(mcp_mock, lambda: MagicMock(), lambda: sm)
 
         result = await tools["continue_conversation"](session_id="nonexistent")
@@ -207,11 +208,10 @@ class TestContinueConversation:
         from argumentation_analysis.services.mcp_server.tools.conversation_tools import (
             register_conversation_tools,
         )
+
         register_conversation_tools(mcp_mock, lambda: MagicMock(), lambda: sm)
 
-        result = await tools["continue_conversation"](
-            session_id=session.session_id
-        )
+        result = await tools["continue_conversation"](session_id=session.session_id)
         assert result["status"] == "max_rounds_reached"
 
 
@@ -223,16 +223,17 @@ class TestGetConversationStatus:
         mcp_mock, tools = _setup_tools()
         sm = SessionManager()
         session = sm.create_session("Test", workflow_name="full")
-        sm.update_session(session.session_id, {"status": "completed", "confidence": 0.8})
+        sm.update_session(
+            session.session_id, {"status": "completed", "confidence": 0.8}
+        )
 
         from argumentation_analysis.services.mcp_server.tools.conversation_tools import (
             register_conversation_tools,
         )
+
         register_conversation_tools(mcp_mock, lambda: MagicMock(), lambda: sm)
 
-        result = await tools["get_conversation_status"](
-            session_id=session.session_id
-        )
+        result = await tools["get_conversation_status"](session_id=session.session_id)
         assert result["workflow"] == "full"
         assert result["rounds_completed"] == 1
 
@@ -244,6 +245,7 @@ class TestGetConversationStatus:
         from argumentation_analysis.services.mcp_server.tools.conversation_tools import (
             register_conversation_tools,
         )
+
         register_conversation_tools(mcp_mock, lambda: MagicMock(), lambda: sm)
 
         result = await tools["get_conversation_status"](session_id="missing")

--- a/tests/unit/services/test_mcp_server_v2/test_specialized_tools.py
+++ b/tests/unit/services/test_mcp_server_v2/test_specialized_tools.py
@@ -44,6 +44,7 @@ def _setup_tools():
         def wrapper(fn):
             tools[fn.__name__] = fn
             return fn
+
         return wrapper
 
     mcp_mock.tool = fake_tool
@@ -57,16 +58,21 @@ class TestEvaluateQuality:
     async def test_success(self):
         mcp_mock, tools = _setup_tools()
         invoke_fn = AsyncMock(return_value={"overall_score": 0.82, "virtues": {}})
-        registry = _make_registry([
-            MockComponentRegistration(
-                "quality", MockComponentType.AGENT,
-                ["argument_quality"], invoke=invoke_fn,
-            )
-        ])
+        registry = _make_registry(
+            [
+                MockComponentRegistration(
+                    "quality",
+                    MockComponentType.AGENT,
+                    ["argument_quality"],
+                    invoke=invoke_fn,
+                )
+            ]
+        )
 
         from argumentation_analysis.services.mcp_server.tools.specialized_tools import (
             register_specialized_tools,
         )
+
         register_specialized_tools(mcp_mock, lambda: registry)
 
         result = await tools["evaluate_quality"](text="This is a strong argument.")
@@ -81,6 +87,7 @@ class TestEvaluateQuality:
         from argumentation_analysis.services.mcp_server.tools.specialized_tools import (
             register_specialized_tools,
         )
+
         register_specialized_tools(mcp_mock, lambda: registry)
 
         result = await tools["evaluate_quality"](text="Test")
@@ -94,22 +101,33 @@ class TestGenerateCounterArgument:
     @pytest.mark.asyncio
     async def test_success(self):
         mcp_mock, tools = _setup_tools()
-        invoke_fn = AsyncMock(return_value={
-            "counter_arguments": [{"strategy": "reductio", "text": "If we accept..."}]
-        })
-        registry = _make_registry([
-            MockComponentRegistration(
-                "counter_arg", MockComponentType.AGENT,
-                ["counter_argument_generation"], invoke=invoke_fn,
-            )
-        ])
+        invoke_fn = AsyncMock(
+            return_value={
+                "counter_arguments": [
+                    {"strategy": "reductio", "text": "If we accept..."}
+                ]
+            }
+        )
+        registry = _make_registry(
+            [
+                MockComponentRegistration(
+                    "counter_arg",
+                    MockComponentType.AGENT,
+                    ["counter_argument_generation"],
+                    invoke=invoke_fn,
+                )
+            ]
+        )
 
         from argumentation_analysis.services.mcp_server.tools.specialized_tools import (
             register_specialized_tools,
         )
+
         register_specialized_tools(mcp_mock, lambda: registry)
 
-        result = await tools["generate_counter_argument"](text="Climate change is fake.")
+        result = await tools["generate_counter_argument"](
+            text="Climate change is fake."
+        )
         assert result["tool"] == "generate_counter_argument"
         assert "counter_arguments" in result["result"]
 
@@ -121,6 +139,7 @@ class TestGenerateCounterArgument:
         from argumentation_analysis.services.mcp_server.tools.specialized_tools import (
             register_specialized_tools,
         )
+
         register_specialized_tools(mcp_mock, lambda: registry)
 
         result = await tools["generate_counter_argument"](text="Test")
@@ -134,16 +153,21 @@ class TestRunDebateAnalysis:
     async def test_success(self):
         mcp_mock, tools = _setup_tools()
         invoke_fn = AsyncMock(return_value={"debate_score": 0.7})
-        registry = _make_registry([
-            MockComponentRegistration(
-                "debate", MockComponentType.AGENT,
-                ["adversarial_debate"], invoke=invoke_fn,
-            )
-        ])
+        registry = _make_registry(
+            [
+                MockComponentRegistration(
+                    "debate",
+                    MockComponentType.AGENT,
+                    ["adversarial_debate"],
+                    invoke=invoke_fn,
+                )
+            ]
+        )
 
         from argumentation_analysis.services.mcp_server.tools.specialized_tools import (
             register_specialized_tools,
         )
+
         register_specialized_tools(mcp_mock, lambda: registry)
 
         result = await tools["run_debate_analysis"](text="Should we ban AI?")
@@ -153,16 +177,21 @@ class TestRunDebateAnalysis:
     @pytest.mark.asyncio
     async def test_no_invoke(self):
         mcp_mock, tools = _setup_tools()
-        registry = _make_registry([
-            MockComponentRegistration(
-                "debate", MockComponentType.AGENT,
-                ["adversarial_debate"], invoke=None,
-            )
-        ])
+        registry = _make_registry(
+            [
+                MockComponentRegistration(
+                    "debate",
+                    MockComponentType.AGENT,
+                    ["adversarial_debate"],
+                    invoke=None,
+                )
+            ]
+        )
 
         from argumentation_analysis.services.mcp_server.tools.specialized_tools import (
             register_specialized_tools,
         )
+
         register_specialized_tools(mcp_mock, lambda: registry)
 
         result = await tools["run_debate_analysis"](text="Test")
@@ -177,19 +206,26 @@ class TestRunGovernanceAnalysis:
     async def test_success(self):
         mcp_mock, tools = _setup_tools()
         invoke_fn = AsyncMock(return_value={"consensus": 0.65, "method": "borda"})
-        registry = _make_registry([
-            MockComponentRegistration(
-                "governance", MockComponentType.AGENT,
-                ["governance_simulation"], invoke=invoke_fn,
-            )
-        ])
+        registry = _make_registry(
+            [
+                MockComponentRegistration(
+                    "governance",
+                    MockComponentType.AGENT,
+                    ["governance_simulation"],
+                    invoke=invoke_fn,
+                )
+            ]
+        )
 
         from argumentation_analysis.services.mcp_server.tools.specialized_tools import (
             register_specialized_tools,
         )
+
         register_specialized_tools(mcp_mock, lambda: registry)
 
-        result = await tools["run_governance_analysis"](text="Proposal: increase budget")
+        result = await tools["run_governance_analysis"](
+            text="Proposal: increase budget"
+        )
         assert result["tool"] == "run_governance_analysis"
         assert result["result"]["consensus"] == 0.65
 
@@ -201,6 +237,7 @@ class TestRunGovernanceAnalysis:
         from argumentation_analysis.services.mcp_server.tools.specialized_tools import (
             register_specialized_tools,
         )
+
         register_specialized_tools(mcp_mock, lambda: registry)
 
         result = await tools["run_governance_analysis"](text="Test")

--- a/tests/unit/services/test_mcp_server_v2/test_workflow_tools.py
+++ b/tests/unit/services/test_mcp_server_v2/test_workflow_tools.py
@@ -5,8 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from dataclasses import dataclass
 from enum import Enum
 
-
 # --- Helpers for building mock registries and workflows ---
+
 
 class MockPhaseStatus(Enum):
     COMPLETED = "completed"
@@ -91,6 +91,7 @@ class TestListWorkflows:
             def wrapper(fn):
                 tools_registered[fn.__name__] = fn
                 return fn
+
             return wrapper
 
         mcp_mock.tool = fake_tool
@@ -98,6 +99,7 @@ class TestListWorkflows:
         from argumentation_analysis.services.mcp_server.tools.workflow_tools import (
             register_workflow_tools,
         )
+
         register_workflow_tools(mcp_mock, lambda: MagicMock())
 
         assert "list_workflows" in tools_registered
@@ -125,6 +127,7 @@ class TestRunWorkflow:
             def wrapper(fn):
                 tools_registered[fn.__name__] = fn
                 return fn
+
             return wrapper
 
         mcp_mock.tool = fake_tool
@@ -133,12 +136,15 @@ class TestRunWorkflow:
         from argumentation_analysis.services.mcp_server.tools.workflow_tools import (
             register_workflow_tools,
         )
+
         register_workflow_tools(mcp_mock, lambda: mock_registry)
 
         mock_result = {
             "workflow_name": "standard",
             "phases": {
-                "p1": MockPhaseResult("p1", MockPhaseStatus.COMPLETED, "argument_quality"),
+                "p1": MockPhaseResult(
+                    "p1", MockPhaseStatus.COMPLETED, "argument_quality"
+                ),
             },
             "summary": {"completed": 1, "failed": 0, "skipped": 0},
             "capabilities_used": ["argument_quality"],
@@ -167,6 +173,7 @@ class TestRunWorkflow:
             def wrapper(fn):
                 tools_registered[fn.__name__] = fn
                 return fn
+
             return wrapper
 
         mcp_mock.tool = fake_tool
@@ -174,6 +181,7 @@ class TestRunWorkflow:
         from argumentation_analysis.services.mcp_server.tools.workflow_tools import (
             register_workflow_tools,
         )
+
         register_workflow_tools(mcp_mock, lambda: MagicMock())
 
         with patch(
@@ -200,6 +208,7 @@ class TestGetWorkflowDetails:
             def wrapper(fn):
                 tools_registered[fn.__name__] = fn
                 return fn
+
             return wrapper
 
         mcp_mock.tool = fake_tool
@@ -207,6 +216,7 @@ class TestGetWorkflowDetails:
         from argumentation_analysis.services.mcp_server.tools.workflow_tools import (
             register_workflow_tools,
         )
+
         register_workflow_tools(mcp_mock, lambda: MagicMock())
 
         with patch(
@@ -230,6 +240,7 @@ class TestGetWorkflowDetails:
             def wrapper(fn):
                 tools_registered[fn.__name__] = fn
                 return fn
+
             return wrapper
 
         mcp_mock.tool = fake_tool
@@ -237,6 +248,7 @@ class TestGetWorkflowDetails:
         from argumentation_analysis.services.mcp_server.tools.workflow_tools import (
             register_workflow_tools,
         )
+
         register_workflow_tools(mcp_mock, lambda: MagicMock())
 
         with patch(


### PR DESCRIPTION
## Summary
- Applied `black` formatting to `argumentation_analysis/` (67 files) and `tests/` (195 files)
- **262 files reformatted**, no logic changes — formatting only
- Created fresh from current main (avoids stale-branch issues from po-2023's original)

## Difference from po-2023's `chore/black-formatting` branch
Po-2023's branch was 15 commits behind main and would have:
- Reverted `.gitignore` cleanup (PR #104)
- Reverted `test_auto_env.py` context manager fix (commit 84d65f35)
- Deleted evaluation module files (PRs #105/#106)
- Changed CI policy (`continue-on-error` removal)

This PR is a clean re-application on current main with zero side effects.

## Test plan
- [x] `black --check argumentation_analysis/ tests/` passes (0 files to reformat)
- [x] Full suite: 9265 passed, 0 failed, 7 skipped

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)