### PR TITLE
fix(evaluation): fix 3 post-review bugs (max_docs, state_writers, enumerate)

### DIFF
--- a/argumentation_analysis/evaluation/capability_eval.py
+++ b/argumentation_analysis/evaluation/capability_eval.py
@@ -325,7 +325,15 @@ async def run_single_cell(
     state = UnifiedAnalysisState(initial_text=document_text)
 
     try:
-        results = await executor.execute(workflow, document_text, state=state)
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            CAPABILITY_STATE_WRITERS,
+        )
+        results = await executor.execute(
+            workflow,
+            document_text,
+            state=state,
+            state_writers=CAPABILITY_STATE_WRITERS,
+        )
     except Exception as e:
         logger.error(f"Workflow execution failed for {config.name}/{document_name}: {e}")
         results = {}
@@ -658,10 +666,9 @@ async def main_async(args: argparse.Namespace) -> int:
     total = len(configs) * len(documents)
     logger.info(f"Running {total} cells ({len(configs)} configs × {len(documents)} docs)...")
 
-    for doc in documents:
+    for doc_idx, doc in enumerate(documents):
         doc_text = doc.get("text", "")
-        doc_name = doc.get("id", f"doc_{documents.index(doc)}")
-        doc_idx = documents.index(doc)
+        doc_name = doc.get("id", f"doc_{doc_idx}")
 
         if not doc_text:
             logger.warning(f"Empty text for {doc_name}, skipping")

--- a/argumentation_analysis/evaluation/run_llm_judge.py
+++ b/argumentation_analysis/evaluation/run_llm_judge.py
@@ -157,9 +157,9 @@ async def run_judge_on_results(
         if max_docs is not None:
             doc_key = doc_name
             if doc_key not in seen_docs:
+                if len(seen_docs) >= max_docs:
+                    continue
                 seen_docs.add(doc_key)
-            if len(seen_docs) > max_docs and doc_key not in seen_docs:
-                continue
 
         state_snapshot = entry.get("state_snapshot", {})
         raw_text = state_snapshot.get("raw_text", "")


### PR DESCRIPTION
## Summary

Fixes 3 bugs identified during review of PRs #127 and #128.

- **`run_llm_judge.py`**: `max_docs` filtering was a no-op — `doc_key` was added to `seen_docs` before the exclusion check, making the `continue` branch unreachable. Fixed to check size first, then add.
- **`capability_eval.py`**: `executor.execute()` was called without `state_writers=CAPABILITY_STATE_WRITERS` — state object stayed empty, making LLM judge scores meaningless (it was scoring an empty snapshot). Fixed by importing and passing the writers.
- **`capability_eval.py`**: `documents.index(doc)` called twice per loop iteration (O(n) each) — replaced loop with `enumerate(documents)`.

## Test plan

- [x] 63 unit tests pass (`test_run_llm_judge.py` × 25 + `test_capability_eval.py` × 38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)