### PR TITLE
feat(pipeline): source_quote citations in fact extraction (#160)

### DIFF
--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -396,12 +396,18 @@ def _extract_arguments_from_context(
             if "arguments" in phase_out:
                 args = phase_out["arguments"]
                 if isinstance(args, list) and args:
-                    return [str(a) for a in args]
+                    return [
+                        a.get("text", str(a)) if isinstance(a, dict) else str(a)
+                        for a in args
+                    ]
             # Secondary: claims list (from fact_extraction heuristic fallback)
             if "claims" in phase_out:
                 claims = phase_out["claims"]
                 if isinstance(claims, list) and claims:
-                    return [str(c) for c in claims[:8]]
+                    return [
+                        c.get("text", str(c)) if isinstance(c, dict) else str(c)
+                        for c in claims[:8]
+                    ]
             # Tertiary: scores dict keyed by argument ID
             if "scores" in phase_out and isinstance(phase_out["scores"], dict):
                 return list(phase_out["scores"].keys())
@@ -1089,6 +1095,35 @@ async def _invoke_hierarchical_fallacy(
 # --- Invoke callables for logic agent capabilities (#71 Formal Verification) ---
 
 
+def _normalize_items_with_quotes(items: list) -> list:
+    """Normalize argument/claim items: accept both str and dict with source_quote."""
+    result = []
+    for item in items:
+        if isinstance(item, str):
+            result.append({"text": item, "source_quote": ""})
+        elif isinstance(item, dict):
+            result.append({
+                "text": str(item.get("text", item.get("content", ""))),
+                "source_quote": str(item.get("source_quote", "")),
+            })
+    return result
+
+
+def _normalize_fallacies_with_quotes(items: list) -> list:
+    """Normalize fallacy items to include source_quote."""
+    result = []
+    for item in items:
+        if isinstance(item, dict):
+            result.append({
+                "type": str(item.get("type", "unknown")),
+                "justification": str(item.get("justification", "")),
+                "source_quote": str(item.get("source_quote", "")),
+            })
+        elif isinstance(item, str):
+            result.append({"type": item, "justification": "", "source_quote": ""})
+    return result
+
+
 async def _invoke_fact_extraction(input_text: str, context: Dict[str, Any]) -> Dict:
     """Extract verifiable claims and arguments from text using LLM with heuristic fallback."""
     import os
@@ -1112,10 +1147,12 @@ async def _invoke_fact_extraction(input_text: str, context: Dict[str, Any]) -> D
                         "content": (
                             "You are an expert argument analyst. Extract the key arguments, "
                             "claims, and rhetorical strategies from the text. "
+                            "For each argument and claim, include the exact quote from the "
+                            "source text that supports it (verbatim, max 150 chars). "
                             "Respond with ONLY a JSON object:\n"
-                            '{"arguments": ["arg1", "arg2", ...], '
-                            '"claims": ["claim1", "claim2", ...], '
-                            '"fallacies": [{"type": "name", "justification": "why"}], '
+                            '{"arguments": [{"text": "arg description", "source_quote": "exact quote..."}], '
+                            '"claims": [{"text": "claim description", "source_quote": "exact quote..."}], '
+                            '"fallacies": [{"type": "name", "justification": "why", "source_quote": "exact quote..."}], '
                             '"summary": "brief analysis summary"}'
                         ),
                     },
@@ -1133,13 +1170,20 @@ async def _invoke_fact_extraction(input_text: str, context: Dict[str, Any]) -> D
             end = text_content.rfind("}") + 1
             if start >= 0 and end > start:
                 data = json.loads(text_content[start:end])
+                # Normalize arguments/claims: accept both str and dict formats
+                raw_args = data.get("arguments", [])
+                raw_claims = data.get("claims", [])
+                raw_fallacies = data.get("fallacies", [])
+                arguments = _normalize_items_with_quotes(raw_args)
+                claims = _normalize_items_with_quotes(raw_claims)
+                fallacies = _normalize_fallacies_with_quotes(raw_fallacies)
                 return {
-                    "arguments": data.get("arguments", []),
-                    "claims": data.get("claims", []),
-                    "fallacies": data.get("fallacies", []),
+                    "arguments": arguments,
+                    "claims": claims,
+                    "fallacies": fallacies,
                     "summary": data.get("summary", ""),
-                    "claim_count": len(data.get("claims", [])),
-                    "argument_count": len(data.get("arguments", [])),
+                    "claim_count": len(claims),
+                    "argument_count": len(arguments),
                     "source_length": len(input_text),
                     "extraction_method": "llm",
                 }
@@ -1664,26 +1708,46 @@ def _write_fact_extraction_to_state(output, state, ctx) -> None:
     """Write fact extraction results to state (populates extracts + base fields)."""
     if not output or not isinstance(output, dict):
         return
-    # Write claims to extracts
+    # Write claims to extracts (with source quotes when available)
     claims = output.get("claims", [])
     if isinstance(claims, list):
         for claim in claims:
-            if isinstance(claim, str) and claim.strip():
+            if isinstance(claim, dict):
+                text = claim.get("text", "").strip()
+                quote = claim.get("source_quote", "")
+                if text:
+                    entry = {"type": "claim", "content": text}
+                    if quote:
+                        entry["source_quote"] = quote
+                    state.extracts.append(entry)
+            elif isinstance(claim, str) and claim.strip():
                 state.extracts.append({"type": "claim", "content": claim.strip()})
     # Populate base identified_arguments from LLM extraction
     arguments = output.get("arguments", [])
     if isinstance(arguments, list):
         for arg in arguments:
-            if isinstance(arg, str) and arg.strip():
+            if isinstance(arg, dict):
+                text = arg.get("text", "").strip()
+                quote = arg.get("source_quote", "")
+                if text:
+                    arg_text = text
+                    if quote:
+                        arg_text = f"{text} [quote: \"{quote[:100]}\"]"
+                    state.add_argument(arg_text)
+            elif isinstance(arg, str) and arg.strip():
                 state.add_argument(arg.strip())
     # Populate base identified_fallacies from LLM extraction
     fallacies = output.get("fallacies", [])
     if isinstance(fallacies, list):
         for f in fallacies:
             if isinstance(f, dict):
+                justification = str(f.get("justification", ""))
+                quote = f.get("source_quote", "")
+                if quote:
+                    justification = f"{justification} [quote: \"{quote[:100]}\"]"
                 state.add_fallacy(
                     fallacy_type=str(f.get("type", "unknown")),
-                    justification=str(f.get("justification", "")),
+                    justification=justification,
                 )
     # Set summary as analysis task if present
     summary = output.get("summary", "")

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -2291,3 +2291,97 @@ class TestHierarchicalFallacyWorkflow:
         )
 
         assert "hierarchical_fallacy_detection" in CAPABILITY_STATE_WRITERS
+
+
+class TestTextualCitations:
+    """Tests for source_quote support in fact extraction (#160)."""
+
+    def test_normalize_items_with_quotes_strings(self):
+        """_normalize_items_with_quotes handles legacy string format."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _normalize_items_with_quotes,
+        )
+
+        result = _normalize_items_with_quotes(["arg1", "arg2"])
+        assert len(result) == 2
+        assert result[0] == {"text": "arg1", "source_quote": ""}
+        assert result[1] == {"text": "arg2", "source_quote": ""}
+
+    def test_normalize_items_with_quotes_dicts(self):
+        """_normalize_items_with_quotes handles new dict format with source_quote."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _normalize_items_with_quotes,
+        )
+
+        result = _normalize_items_with_quotes([
+            {"text": "argument one", "source_quote": "exact quote from text"},
+            {"text": "argument two"},
+        ])
+        assert result[0]["source_quote"] == "exact quote from text"
+        assert result[1]["source_quote"] == ""
+
+    def test_normalize_fallacies_with_quotes(self):
+        """_normalize_fallacies_with_quotes handles both formats."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _normalize_fallacies_with_quotes,
+        )
+
+        result = _normalize_fallacies_with_quotes([
+            {"type": "ad_hominem", "justification": "attacks person", "source_quote": "you fool"},
+            "bare_assertion",
+        ])
+        assert result[0]["source_quote"] == "you fool"
+        assert result[1]["type"] == "bare_assertion"
+        assert result[1]["source_quote"] == ""
+
+    def test_write_fact_extraction_with_quotes(self):
+        """_write_fact_extraction_to_state propagates source_quote to state."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _write_fact_extraction_to_state,
+        )
+
+        state = UnifiedAnalysisState("Test text")
+        output = {
+            "claims": [
+                {"text": "Earth is flat", "source_quote": "the horizon looks flat"},
+            ],
+            "arguments": [
+                {"text": "visual argument", "source_quote": "horizon looks flat"},
+            ],
+            "fallacies": [
+                {"type": "hasty_gen", "justification": "insufficient evidence", "source_quote": "horizon looks flat"},
+            ],
+        }
+        _write_fact_extraction_to_state(output, state, {})
+
+        # Claims should have source_quote in extracts
+        assert len(state.extracts) == 1
+        assert state.extracts[0]["source_quote"] == "the horizon looks flat"
+
+        # Arguments: add_argument stores a string with embedded quote
+        args = list(state.identified_arguments.values())
+        assert len(args) == 1
+        assert "[quote:" in args[0]  # string with embedded quote
+
+        # Fallacies: add_fallacy stores {"type", "justification"} with embedded quote
+        fallacies = list(state.identified_fallacies.values())
+        assert len(fallacies) == 1
+        assert "[quote:" in fallacies[0]["justification"]
+
+    def test_write_fact_extraction_legacy_strings(self):
+        """_write_fact_extraction_to_state still works with legacy string format."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _write_fact_extraction_to_state,
+        )
+
+        state = UnifiedAnalysisState("Test text")
+        output = {
+            "claims": ["claim one", "claim two"],
+            "arguments": ["arg one"],
+            "fallacies": [{"type": "ad_hominem", "justification": "attacks person"}],
+        }
+        _write_fact_extraction_to_state(output, state, {})
+
+        assert len(state.extracts) == 2
+        assert len(state.identified_arguments) == 1
+        assert len(state.identified_fallacies) == 1


### PR DESCRIPTION
## Summary

- LLM prompt now requests verbatim source quotes for each argument, claim, and fallacy
- Backward-compatible: handles both legacy string format and new dict format with `source_quote`
- Quotes are propagated to shared state (embedded in argument text and fallacy justification)
- 5 regression tests added

## Before/After

**Before**: `"arguments": ["arg1", "arg2"]`
**After**: `"arguments": [{"text": "arg1", "source_quote": "exact text from source"}]`

In state: `"visual argument [quote: \"horizon looks flat\"]"`

## Test plan

- [x] 5 unit tests passing (normalizers + state writer with/without quotes)
- [x] LLM-verified: `_invoke_fact_extraction` returns source_quote for all items
- [ ] Review by coordinator

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)