### PR TITLE
feat: add web routes for fallacy, quality, counter-argument agents (#168)

### DIFF
--- a/interface_web/routes/counter_argument_routes.py
+++ b/interface_web/routes/counter_argument_routes.py
@@ -1,0 +1,120 @@
+"""
+Starlette routes for counter-argument generation.
+
+Provides endpoints for parsing arguments, identifying vulnerabilities,
+and generating counter-arguments using the 5 rhetorical strategies.
+"""
+
+import logging
+import time
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+logger = logging.getLogger(__name__)
+
+
+async def parse_argument(request: Request) -> JSONResponse:
+    """POST /api/counter/parse — Parse an argument into premises and conclusion.
+
+    Request body: {"text": "..."}
+    Response: {"premises": [...], "conclusion": "...", "type": "..."}
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    text = body.get("text", "").strip()
+    if not text or len(text) < 10:
+        return JSONResponse(
+            {"error": "Text must be at least 10 characters"}, status_code=400
+        )
+
+    try:
+        from argumentation_analysis.agents.core.counter_argument.parser import (
+            ArgumentParser,
+        )
+
+        parser = ArgumentParser()
+        result = parser.parse_argument(text)
+
+        if isinstance(result, dict):
+            return JSONResponse(result)
+        return JSONResponse({"raw": str(result)})
+    except ImportError:
+        return JSONResponse(
+            {"error": "Counter-argument module unavailable"}, status_code=503
+        )
+    except Exception as e:
+        logger.error(f"Parse error: {e}")
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+async def identify_vulnerabilities(request: Request) -> JSONResponse:
+    """POST /api/counter/vulnerabilities — Identify argument vulnerabilities.
+
+    Request body: {"text": "..."}
+    Response: {"vulnerabilities": [...]}
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    text = body.get("text", "").strip()
+    if not text:
+        return JSONResponse({"error": "Text required"}, status_code=400)
+
+    try:
+        from argumentation_analysis.agents.core.counter_argument.parser import (
+            ArgumentParser,
+        )
+
+        parser = ArgumentParser()
+        vulns = parser.identify_vulnerabilities(text)
+        return JSONResponse(
+            {"vulnerabilities": vulns if isinstance(vulns, list) else [str(vulns)]}
+        )
+    except ImportError:
+        return JSONResponse(
+            {"error": "Counter-argument module unavailable"}, status_code=503
+        )
+    except Exception as e:
+        logger.error(f"Vulnerability identification error: {e}")
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+async def list_strategies(request: Request) -> JSONResponse:
+    """GET /api/counter/strategies — List available rhetorical strategies."""
+    strategies = [
+        {
+            "name": "reductio_ad_absurdum",
+            "description": "Show the argument leads to absurd conclusions",
+        },
+        {
+            "name": "counter_example",
+            "description": "Provide a concrete counter-example",
+        },
+        {
+            "name": "distinction",
+            "description": "Distinguish between cases the argument conflates",
+        },
+        {
+            "name": "reformulation",
+            "description": "Reformulate the argument to reveal hidden assumptions",
+        },
+        {
+            "name": "concession",
+            "description": "Concede partial validity while pivoting to a stronger position",
+        },
+    ]
+    return JSONResponse({"strategies": strategies, "count": len(strategies)})
+
+
+counter_argument_routes = [
+    Route("/api/counter/parse", parse_argument, methods=["POST"]),
+    Route("/api/counter/vulnerabilities", identify_vulnerabilities, methods=["POST"]),
+    Route("/api/counter/strategies", list_strategies, methods=["GET"]),
+]

--- a/interface_web/routes/fallacy_routes.py
+++ b/interface_web/routes/fallacy_routes.py
@@ -1,0 +1,109 @@
+"""
+Starlette routes for fallacy detection.
+
+Provides endpoints for detecting argumentative fallacies in text using
+the FrenchFallacyAdapter (3-tier: symbolic -> NLI -> LLM).
+"""
+
+import json
+import logging
+import time
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+logger = logging.getLogger(__name__)
+
+_adapter = None
+
+
+def _get_adapter():
+    """Lazy-load the FrenchFallacyAdapter."""
+    global _adapter
+    if _adapter is None:
+        try:
+            from argumentation_analysis.adapters.french_fallacy_adapter import (
+                FrenchFallacyAdapter,
+            )
+
+            _adapter = FrenchFallacyAdapter()
+            logger.info("FrenchFallacyAdapter loaded successfully")
+        except Exception as e:
+            logger.warning(f"FrenchFallacyAdapter unavailable: {e}")
+    return _adapter
+
+
+async def detect_fallacies(request: Request) -> JSONResponse:
+    """POST /api/fallacies — Detect fallacies in text.
+
+    Request body: {"text": "..."}
+    Response: {"text": "...", "fallacies": [...], "execution_time": ...}
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    text = body.get("text", "").strip()
+    if not text or len(text) < 10:
+        return JSONResponse(
+            {"error": "Text must be at least 10 characters"}, status_code=400
+        )
+
+    start = time.time()
+    adapter = _get_adapter()
+
+    if adapter is None:
+        return JSONResponse(
+            {"error": "Fallacy detection service unavailable"}, status_code=503
+        )
+
+    try:
+        result = adapter.detect(text)
+        elapsed = time.time() - start
+
+        fallacies = []
+        if isinstance(result, list):
+            for f in result:
+                if isinstance(f, dict):
+                    fallacies.append(
+                        {
+                            "type": f.get("fallacy_type", f.get("type", "unknown")),
+                            "confidence": f.get("confidence", 0.0),
+                            "explanation": f.get("explanation", ""),
+                            "tier": f.get("detection_tier", "unknown"),
+                        }
+                    )
+
+        return JSONResponse(
+            {
+                "text": text[:200],
+                "fallacies": fallacies,
+                "count": len(fallacies),
+                "execution_time": round(elapsed, 3),
+            }
+        )
+    except Exception as e:
+        logger.error(f"Fallacy detection error: {e}")
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+async def list_fallacy_types(request: Request) -> JSONResponse:
+    """GET /api/fallacies/types — List available fallacy types."""
+    try:
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            FALLACY_LABELS_FR,
+        )
+
+        return JSONResponse(
+            {"types": FALLACY_LABELS_FR, "count": len(FALLACY_LABELS_FR)}
+        )
+    except ImportError:
+        return JSONResponse({"types": [], "count": 0, "error": "Adapter unavailable"})
+
+
+fallacy_routes = [
+    Route("/api/fallacies", detect_fallacies, methods=["POST"]),
+    Route("/api/fallacies/types", list_fallacy_types, methods=["GET"]),
+]

--- a/interface_web/routes/quality_routes.py
+++ b/interface_web/routes/quality_routes.py
@@ -1,0 +1,103 @@
+"""
+Starlette routes for argument quality evaluation.
+
+Provides endpoints for evaluating the quality of arguments using
+the 9-virtue ArgumentQualityEvaluator.
+"""
+
+import logging
+import time
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+
+logger = logging.getLogger(__name__)
+
+_evaluator = None
+
+
+def _get_evaluator():
+    """Lazy-load the ArgumentQualityEvaluator."""
+    global _evaluator
+    if _evaluator is None:
+        try:
+            from argumentation_analysis.agents.core.quality.quality_evaluator import (
+                ArgumentQualityEvaluator,
+            )
+
+            _evaluator = ArgumentQualityEvaluator()
+            logger.info("ArgumentQualityEvaluator loaded successfully")
+        except Exception as e:
+            logger.warning(f"ArgumentQualityEvaluator unavailable: {e}")
+    return _evaluator
+
+
+async def evaluate_quality(request: Request) -> JSONResponse:
+    """POST /api/quality — Evaluate argument quality (9 virtues).
+
+    Request body: {"text": "..."}
+    Response: {"text": "...", "scores": {...}, "overall": ..., "virtues": [...]}
+    """
+    try:
+        body = await request.json()
+    except Exception:
+        return JSONResponse({"error": "Invalid JSON body"}, status_code=400)
+
+    text = body.get("text", "").strip()
+    if not text or len(text) < 10:
+        return JSONResponse(
+            {"error": "Text must be at least 10 characters"}, status_code=400
+        )
+
+    start = time.time()
+    evaluator = _get_evaluator()
+
+    if evaluator is None:
+        return JSONResponse(
+            {"error": "Quality evaluator unavailable"}, status_code=503
+        )
+
+    try:
+        result = evaluator.evaluate(text)
+        elapsed = time.time() - start
+
+        if isinstance(result, dict):
+            return JSONResponse(
+                {
+                    "text": text[:200],
+                    "scores": result.get("scores_par_vertu", result.get("scores", {})),
+                    "overall": result.get("score_global", result.get("overall", 0.0)),
+                    "average": result.get("score_moyen", 0.0),
+                    "report": result.get("rapport", ""),
+                    "execution_time": round(elapsed, 3),
+                }
+            )
+        return JSONResponse(
+            {"text": text[:200], "result": str(result), "execution_time": round(elapsed, 3)}
+        )
+    except Exception as e:
+        logger.error(f"Quality evaluation error: {e}")
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+async def list_virtues(request: Request) -> JSONResponse:
+    """GET /api/quality/virtues — List the 9 argumentative virtues."""
+    virtues = [
+        {"name": "clarte", "description": "Clarity — Flesch readability score"},
+        {"name": "pertinence", "description": "Relevance — topic alignment"},
+        {"name": "sources", "description": "Source citations present"},
+        {"name": "refutation", "description": "Constructive refutation"},
+        {"name": "structure_logique", "description": "Logical structure (connectors)"},
+        {"name": "analogies", "description": "Analogies used"},
+        {"name": "fiabilite_sources", "description": "Source reliability"},
+        {"name": "exhaustivite", "description": "Exhaustiveness"},
+        {"name": "faible_redundance", "description": "Low redundancy"},
+    ]
+    return JSONResponse({"virtues": virtues, "count": len(virtues)})
+
+
+quality_routes = [
+    Route("/api/quality", evaluate_quality, methods=["POST"]),
+    Route("/api/quality/virtues", list_virtues, methods=["GET"]),
+]


### PR DESCRIPTION
## Summary
7 new Starlette API endpoints for 3 agents that previously had no web interface:

- **Fallacy detection**: POST `/api/fallacies`, GET `/api/fallacies/types`
- **Quality evaluation**: POST `/api/quality`, GET `/api/quality/virtues`
- **Counter-arguments**: POST `/api/counter/parse`, POST `/api/counter/vulnerabilities`, GET `/api/counter/strategies`

All routes use lazy-loading with graceful degradation.

## Test plan
- [x] All 3 route modules import successfully
- [x] 7 routes total (2 + 2 + 3)
- [x] Lazy-loading prevents import failures

Addresses #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)