### PR TITLE
feat: collaborative multi-agent debate pipeline (#175)

### DIFF
--- a/argumentation_analysis/orchestration/collaborative_debate.py
+++ b/argumentation_analysis/orchestration/collaborative_debate.py
@@ -1,0 +1,348 @@
+"""
+Collaborative multi-agent debate pipeline.
+
+Addresses #175 finding that multi-round repetition does NOT improve quality
+(single-pass 3.33 vs multi-round 3.27). Instead, quality comes from
+**inter-agent collaboration** with distinct roles:
+
+1. Extractor: Identifies claims, premises, arguments (fact_extraction)
+2. Critic (Skeptic): Challenges each argument, identifies weaknesses
+3. Validator (Scholar): Checks logic, finds supporting evidence
+4. Devil's Advocate: Generates strongest counter-arguments
+5. Synthesizer: Resolves disagreements, produces final assessment
+
+Each agent reads and responds to previous agents' outputs, creating genuine
+dialogue instead of independent parallel analysis.
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("CollaborativeDebate")
+
+
+# --- Agent role definitions ---
+
+COLLABORATIVE_ROLES = {
+    "critic": {
+        "name": "Critic (Skeptic)",
+        "system_prompt": (
+            "You are a Skeptic analyst. Your role is to critically examine arguments "
+            "and identify weaknesses, hidden assumptions, logical gaps, and potential "
+            "fallacies. Be rigorous but fair. For each argument, provide:\n"
+            "- weakness: what's wrong or missing\n"
+            "- severity: low/medium/high\n"
+            "- suggestion: how the argument could be strengthened\n"
+            "Respond with ONLY a JSON object:\n"
+            '{"critiques": [{"argument": "which", "weakness": "text", '
+            '"severity": "low|medium|high", "suggestion": "text"}], '
+            '"overall_rigor": 1-5, "reasoning": "brief assessment"}'
+        ),
+    },
+    "validator": {
+        "name": "Validator (Scholar)",
+        "system_prompt": (
+            "You are a Scholar validator. Your role is to verify arguments against "
+            "known evidence, check logical consistency, and find supporting or "
+            "contradicting evidence. You have access to the Critic's assessment. "
+            "For each argument, assess:\n"
+            "- evidence_status: supported/unsupported/mixed\n"
+            "- logical_validity: valid/invalid/partial\n"
+            "- confidence: 0.0-1.0\n"
+            "Respond with ONLY a JSON object:\n"
+            '{"validations": [{"argument": "which", "evidence_status": "status", '
+            '"logical_validity": "validity", "confidence": 0.0-1.0, '
+            '"evidence_notes": "supporting/contradicting info"}], '
+            '"overall_validity": 0.0-1.0, "reasoning": "brief assessment"}'
+        ),
+    },
+    "devils_advocate": {
+        "name": "Devil's Advocate",
+        "system_prompt": (
+            "You are a Devil's Advocate. Your role is to generate the strongest "
+            "possible counter-arguments, considering the Critic's weaknesses and "
+            "the Validator's evidence assessment. Target the most vulnerable "
+            "arguments first. Use strategies: reductio ad absurdum, counter-example, "
+            "distinction, reformulation, or concession+pivot.\n"
+            "Respond with ONLY a JSON object:\n"
+            '{"counter_arguments": [{"target": "which argument", '
+            '"strategy": "strategy name", "counter": "the counter-argument", '
+            '"strength": "weak|moderate|strong"}], '
+            '"most_vulnerable": "which argument is weakest", '
+            '"reasoning": "brief assessment"}'
+        ),
+    },
+    "synthesizer": {
+        "name": "Synthesizer",
+        "system_prompt": (
+            "You are a Synthesis moderator. You have read the outputs of the "
+            "Critic, Validator, and Devil's Advocate. Your role is to:\n"
+            "1. Resolve disagreements between agents\n"
+            "2. Identify arguments that survived all challenges\n"
+            "3. Note new insights that emerged from the debate\n"
+            "4. Produce a final quality assessment\n"
+            "Respond with ONLY a JSON object:\n"
+            '{"surviving_arguments": [{"argument": "text", "confidence": 0.0-1.0, '
+            '"survived_challenges": ["list of challenges it survived"]}], '
+            '"defeated_arguments": [{"argument": "text", "defeated_by": "who/what"}], '
+            '"new_insights": ["insight not obvious from initial analysis"], '
+            '"consensus_areas": ["where all agents agreed"], '
+            '"unresolved_disputes": ["where agents still disagree"], '
+            '"final_quality_score": 1-5, '
+            '"reasoning": "overall synthesis assessment"}'
+        ),
+    },
+}
+
+
+async def _invoke_collaborative_analysis(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Run a collaborative multi-agent analysis with 4 distinct agent roles.
+
+    Each agent reads previous agents' outputs, creating genuine inter-agent
+    dialogue. Uses the LLM to simulate each agent role sequentially.
+
+    Returns a dict with per-role outputs and final synthesis.
+    """
+    from openai import AsyncOpenAI
+
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    if not api_key:
+        return _fallback_collaborative(input_text, context)
+
+    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+    model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+    client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+    # Gather upstream context
+    extract_output = context.get("phase_extract_output", {})
+    quality_output = context.get("phase_quality_output", {})
+    arguments = (
+        extract_output.get("arguments", []) if isinstance(extract_output, dict) else []
+    )
+    claims = (
+        extract_output.get("claims", []) if isinstance(extract_output, dict) else []
+    )
+
+    # Build argument summary for agents
+    arg_lines = []
+    for i, a in enumerate(arguments[:8]):
+        text = a.get("text", str(a)) if isinstance(a, dict) else str(a)
+        arg_lines.append(f"A{i + 1}. {text}")
+    if not arg_lines:
+        for i, c in enumerate(claims[:8]):
+            text = c.get("text", str(c)) if isinstance(c, dict) else str(c)
+            arg_lines.append(f"C{i + 1}. {text}")
+    if not arg_lines:
+        # Sentence split fallback
+        sentences = [s.strip() for s in input_text.split(".") if len(s.strip()) > 15]
+        for i, s in enumerate(sentences[:6]):
+            arg_lines.append(f"S{i + 1}. {s}")
+
+    argument_text = "\n".join(arg_lines) if arg_lines else input_text[:1500]
+
+    # Quality context if available
+    quality_summary = ""
+    if isinstance(quality_output, dict):
+        per_arg = quality_output.get("per_argument_scores", {})
+        if per_arg:
+            quality_lines = []
+            for arg_id, scores in per_arg.items():
+                overall = scores.get("note_finale", 0)
+                quality_lines.append(f"  {arg_id}: {overall:.1f}/10")
+            quality_summary = "\nQuality scores:\n" + "\n".join(quality_lines)
+
+    results = {}
+    accumulated_context = f"ARGUMENTS to analyze:\n{argument_text}{quality_summary}"
+
+    # --- Phase 1: Critic ---
+    critic_output = await _run_agent_role(
+        client, model_id, "critic", accumulated_context
+    )
+    results["critic"] = critic_output
+    accumulated_context += (
+        f"\n\nCRITIC ASSESSMENT:\n{json.dumps(critic_output, default=str)[:1500]}"
+    )
+
+    # --- Phase 2: Validator ---
+    validator_output = await _run_agent_role(
+        client, model_id, "validator", accumulated_context
+    )
+    results["validator"] = validator_output
+    accumulated_context += (
+        f"\n\nVALIDATOR ASSESSMENT:\n{json.dumps(validator_output, default=str)[:1500]}"
+    )
+
+    # --- Phase 3: Devil's Advocate ---
+    da_output = await _run_agent_role(
+        client, model_id, "devils_advocate", accumulated_context
+    )
+    results["devils_advocate"] = da_output
+    accumulated_context += (
+        f"\n\nDEVIL'S ADVOCATE:\n{json.dumps(da_output, default=str)[:1500]}"
+    )
+
+    # --- Phase 4: Synthesizer ---
+    synthesis_output = await _run_agent_role(
+        client, model_id, "synthesizer", accumulated_context
+    )
+    results["synthesis"] = synthesis_output
+
+    # Build final result
+    final_score = 3.0
+    if isinstance(synthesis_output, dict):
+        final_score = float(synthesis_output.get("final_quality_score", 3.0))
+
+    new_insights = []
+    if isinstance(synthesis_output, dict):
+        new_insights = synthesis_output.get("new_insights", [])
+
+    surviving = []
+    if isinstance(synthesis_output, dict):
+        surviving = synthesis_output.get("surviving_arguments", [])
+
+    defeated = []
+    if isinstance(synthesis_output, dict):
+        defeated = synthesis_output.get("defeated_arguments", [])
+
+    return {
+        "agent_outputs": results,
+        "final_quality_score": final_score,
+        "new_insights": new_insights,
+        "surviving_arguments": surviving,
+        "defeated_arguments": defeated,
+        "agents_involved": list(COLLABORATIVE_ROLES.keys()),
+        "interaction_type": "sequential_collaborative",
+    }
+
+
+async def _run_agent_role(
+    client: Any,
+    model_id: str,
+    role: str,
+    accumulated_context: str,
+) -> Dict[str, Any]:
+    """Run a single agent role via LLM and parse JSON response."""
+    role_def = COLLABORATIVE_ROLES[role]
+    try:
+        response = await client.chat.completions.create(
+            model=model_id,
+            messages=[
+                {"role": "system", "content": role_def["system_prompt"]},
+                {"role": "user", "content": accumulated_context},
+            ],
+        )
+        raw = response.choices[0].message.content or ""
+        return _parse_json_response(raw, role)
+    except Exception as e:
+        logger.warning(f"Agent role '{role}' failed: {e}")
+        return {"error": str(e), "role": role}
+
+
+def _parse_json_response(raw: str, role: str) -> Dict[str, Any]:
+    """Parse a JSON response from an LLM, handling markdown fences."""
+    text = raw.strip()
+    if "```json" in text:
+        text = text.split("```json")[1].split("```")[0]
+    elif "```" in text:
+        text = text.split("```")[1].split("```")[0]
+    start = text.find("{")
+    end = text.rfind("}") + 1
+    if start >= 0 and end > start:
+        try:
+            return json.loads(text[start:end])
+        except json.JSONDecodeError as e:
+            logger.warning(f"JSON parse failed for {role}: {e}")
+    return {"raw_response": raw[:500], "role": role, "parse_error": True}
+
+
+def _fallback_collaborative(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+    """Fallback when no API key is available — heuristic-only analysis."""
+    extract_output = context.get("phase_extract_output", {})
+    arguments = (
+        extract_output.get("arguments", []) if isinstance(extract_output, dict) else []
+    )
+
+    surviving = []
+    for a in arguments[:6]:
+        text = a.get("text", str(a)) if isinstance(a, dict) else str(a)
+        surviving.append(
+            {"argument": text, "confidence": 0.5, "survived_challenges": []}
+        )
+
+    return {
+        "agent_outputs": {},
+        "final_quality_score": 3.0,
+        "new_insights": ["No API key available — heuristic fallback used"],
+        "surviving_arguments": surviving,
+        "defeated_arguments": [],
+        "agents_involved": [],
+        "interaction_type": "fallback_heuristic",
+    }
+
+
+def _write_collaborative_to_state(output: Any, state: Any, ctx: Dict[str, Any]) -> None:
+    """Write collaborative debate results to UnifiedAnalysisState."""
+    if not output or not isinstance(output, dict):
+        return
+
+    # Store as a debate transcript with collaborative metadata
+    exchanges = []
+    agent_outputs = output.get("agent_outputs", {})
+    for role_name, role_output in agent_outputs.items():
+        if isinstance(role_output, dict) and not role_output.get("error"):
+            exchanges.append(
+                {
+                    "agent": role_name,
+                    "assessment": json.dumps(role_output, default=str)[:500],
+                }
+            )
+
+    if hasattr(state, "add_debate_transcript"):
+        state.add_debate_transcript(
+            topic="collaborative_multi_agent_analysis",
+            exchanges=exchanges,
+            winner=None,
+        )
+
+    # Store new insights as workflow results
+    if hasattr(state, "set_workflow_results"):
+        state.set_workflow_results(
+            "collaborative_analysis",
+            {
+                "final_quality_score": output.get("final_quality_score", 0),
+                "new_insights": output.get("new_insights", []),
+                "surviving_count": len(output.get("surviving_arguments", [])),
+                "defeated_count": len(output.get("defeated_arguments", [])),
+                "agents_involved": output.get("agents_involved", []),
+            },
+        )
+
+
+def build_collaborative_analysis_workflow():
+    """Build the collaborative multi-agent analysis workflow.
+
+    Pipeline:
+        extract → quality → collaborative_analysis
+
+    The collaborative_analysis phase internally runs 4 agent roles
+    (critic, validator, devil's advocate, synthesizer) sequentially,
+    with each reading the previous agents' outputs.
+    """
+    from argumentation_analysis.orchestration.workflow_dsl import WorkflowBuilder
+
+    return (
+        WorkflowBuilder("collaborative_analysis")
+        .add_phase("extract", capability="fact_extraction", depends_on=[])
+        .add_phase("quality", capability="argument_quality", depends_on=["extract"])
+        .add_phase(
+            "collaborative",
+            capability="collaborative_analysis",
+            depends_on=["quality"],
+        )
+        .build()
+    )

--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -232,29 +232,47 @@ async def _invoke_debate_analysis(input_text: str, context: Dict[str, Any]) -> D
             raw_arguments = extract_output.get("arguments", [])
             raw_fallacies = extract_output.get("fallacies", [])
             counter_output = context.get("phase_counter_output", {})
-            raw_cas = counter_output.get("llm_counter_arguments", []) if isinstance(counter_output, dict) else []
+            raw_cas = (
+                counter_output.get("llm_counter_arguments", [])
+                if isinstance(counter_output, dict)
+                else []
+            )
 
             def _txt(item):
-                return item.get("text", str(item)) if isinstance(item, dict) else str(item)
+                return (
+                    item.get("text", str(item)) if isinstance(item, dict) else str(item)
+                )
 
             # Build structured debate material
             debate_parts = []
             if raw_arguments:
-                debate_parts.append("ARGUMENTS identified:\n" + "\n".join(
-                    f"  A{i+1}. {_txt(a)}" for i, a in enumerate(raw_arguments[:6])
-                ))
+                debate_parts.append(
+                    "ARGUMENTS identified:\n"
+                    + "\n".join(
+                        f"  A{i+1}. {_txt(a)}" for i, a in enumerate(raw_arguments[:6])
+                    )
+                )
             if raw_fallacies:
-                debate_parts.append("FALLACIES detected:\n" + "\n".join(
-                    f"  F{i+1}. {_txt(f)} — {f.get('justification', '')[:80] if isinstance(f, dict) else ''}"
-                    for i, f in enumerate(raw_fallacies[:5])
-                ))
+                debate_parts.append(
+                    "FALLACIES detected:\n"
+                    + "\n".join(
+                        f"  F{i+1}. {_txt(f)} — {f.get('justification', '')[:80] if isinstance(f, dict) else ''}"
+                        for i, f in enumerate(raw_fallacies[:5])
+                    )
+                )
             if raw_cas:
-                debate_parts.append("COUNTER-ARGUMENTS available:\n" + "\n".join(
-                    f"  CA{i+1}. [{ca.get('strategy_used', '?')}] {ca.get('counter_argument', '')[:100]}"
-                    for i, ca in enumerate(raw_cas[:5]) if isinstance(ca, dict)
-                ))
+                debate_parts.append(
+                    "COUNTER-ARGUMENTS available:\n"
+                    + "\n".join(
+                        f"  CA{i+1}. [{ca.get('strategy_used', '?')}] {ca.get('counter_argument', '')[:100]}"
+                        for i, ca in enumerate(raw_cas[:5])
+                        if isinstance(ca, dict)
+                    )
+                )
 
-            debate_material = "\n\n".join(debate_parts) if debate_parts else input_text[:1500]
+            debate_material = (
+                "\n\n".join(debate_parts) if debate_parts else input_text[:1500]
+            )
 
             response = await client.chat.completions.create(
                 model=model_id,
@@ -501,9 +519,7 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict:
 
     # Invalidate beliefs associated with detected fallacies
     for i, name in enumerate(belief_names):
-        is_undermined = any(
-            ft.lower() in name.lower() for ft in fallacy_types if ft
-        )
+        is_undermined = any(ft.lower() in name.lower() for ft in fallacy_types if ft)
         if is_undermined:
             jtms.set_belief_validity(name, False)
 
@@ -765,9 +781,7 @@ def _enrich_ranking_with_justification(
             reasons.append(f"attacks {outgoing} other argument(s)")
 
         # Check if targeted by fallacy
-        is_fallacious = any(
-            ft in arg.lower()[:30] for ft in fallacy_targets
-        )
+        is_fallacious = any(ft in arg.lower()[:30] for ft in fallacy_targets)
         if is_fallacious:
             reasons.append("targeted by detected fallacy (weakened)")
 
@@ -822,9 +836,7 @@ async def _invoke_ranking(input_text: str, context: Dict[str, Any]) -> Dict:
         )
 
         handler = RankingHandler()
-        result = await asyncio.to_thread(
-            handler.rank_arguments, args, attacks, method
-        )
+        result = await asyncio.to_thread(handler.rank_arguments, args, attacks, method)
         # Enrich Tweety result with strength justification
         if isinstance(result, dict) and "ranking" in result:
             result = _enrich_ranking_with_justification(result, args, attacks, context)
@@ -981,7 +993,9 @@ def _python_aspic_fallback(
                 for f in fallacies
                 if isinstance(f, dict)
             ]
-            reasons.append(f"undermined by fallacy: {', '.join(matching_fallacies[:2])}")
+            reasons.append(
+                f"undermined by fallacy: {', '.join(matching_fallacies[:2])}"
+            )
         if is_rebutted:
             status = "defeated" if is_undermined else "challenged"
             reasons.append("rebutted by counter-argument")
@@ -1248,37 +1262,49 @@ async def _invoke_dialogue(input_text: str, context: Dict[str, Any]) -> Dict:
             if isinstance(f, dict):
                 ftype = f.get("type", "unknown")
                 justification = f.get("justification", "")
-                fallacy_attacks.append(
-                    f"[CHALLENGE: {ftype}] {justification[:120]}"
-                )
+                fallacy_attacks.append(f"[CHALLENGE: {ftype}] {justification[:120]}")
 
         trace = []
         turn = 1
         for i, arg in enumerate(pro_args):
-            trace.append({
-                "turn": turn, "speaker": "proponent",
-                "move_type": "assert", "move": arg,
-            })
+            trace.append(
+                {
+                    "turn": turn,
+                    "speaker": "proponent",
+                    "move_type": "assert",
+                    "move": arg,
+                }
+            )
             turn += 1
             # Opponent responds with CA if available, fallacy attack, or counter-arg
             if i < len(opp_args):
-                trace.append({
-                    "turn": turn, "speaker": "opponent",
-                    "move_type": "counter", "move": opp_args[i],
-                })
+                trace.append(
+                    {
+                        "turn": turn,
+                        "speaker": "opponent",
+                        "move_type": "counter",
+                        "move": opp_args[i],
+                    }
+                )
                 turn += 1
             if i < len(fallacy_attacks):
-                trace.append({
-                    "turn": turn, "speaker": "opponent",
-                    "move_type": "challenge", "move": fallacy_attacks[i],
-                })
+                trace.append(
+                    {
+                        "turn": turn,
+                        "speaker": "opponent",
+                        "move_type": "challenge",
+                        "move": fallacy_attacks[i],
+                    }
+                )
                 turn += 1
 
         # Determine winner based on move balance
         pro_moves = sum(1 for t in trace if t["speaker"] == "proponent")
         opp_moves = sum(1 for t in trace if t["speaker"] == "opponent")
-        winner = "proponent" if pro_moves > opp_moves else (
-            "opponent" if opp_moves > pro_moves else "draw"
+        winner = (
+            "proponent"
+            if pro_moves > opp_moves
+            else ("opponent" if opp_moves > pro_moves else "draw")
         )
 
         return {
@@ -1523,7 +1549,9 @@ def _python_social_fallback(
         # Signal 1: votes (if available)
         if arg in votes:
             v = votes[arg]
-            base_score = v[0] / (v[0] + v[1]) if isinstance(v, tuple) and sum(v) > 0 else 0.5
+            base_score = (
+                v[0] / (v[0] + v[1]) if isinstance(v, tuple) and sum(v) > 0 else 0.5
+            )
         # Signal 2: quality score boost
         q = quality_scores.get(arg)
         quality_boost = 0.0
@@ -1661,7 +1689,8 @@ def _python_eaf_fallback(
             "believed": len(believed_args),
             "disbelieved": len(disbelieved_args),
             "avg_confidence": round(
-                sum(e["confidence"] for e in epistemic.values()) / max(len(epistemic), 1),
+                sum(e["confidence"] for e in epistemic.values())
+                / max(len(epistemic), 1),
                 3,
             ),
         },
@@ -2825,6 +2854,15 @@ def _write_qbf_to_state(output, state, ctx) -> None:
     )
 
 
+def _write_collaborative_analysis_to_state(output, state, ctx) -> None:
+    """Write collaborative multi-agent debate results to state (#175)."""
+    from argumentation_analysis.orchestration.collaborative_debate import (
+        _write_collaborative_to_state,
+    )
+
+    _write_collaborative_to_state(output, state, ctx)
+
+
 CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "argument_quality": _write_quality_to_state,
     "counter_argument_generation": _write_counter_argument_to_state,
@@ -2858,6 +2896,7 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "epistemic_argumentation": _write_eaf_to_state,
     "defeasible_logic": _write_delp_to_state,
     "qbf_reasoning": _write_qbf_to_state,
+    "collaborative_analysis": _write_collaborative_analysis_to_state,
 }
 
 
@@ -2893,9 +2932,9 @@ def setup_registry(
         register_counter_arg(registry)
         # Wire invoke callable (registration was created by register_counter_arg)
         if "counter_argument_agent" in registry._registrations:
-            registry._registrations["counter_argument_agent"].invoke = (
-                _invoke_counter_argument
-            )
+            registry._registrations[
+                "counter_argument_agent"
+            ].invoke = _invoke_counter_argument
         registered.append("counter_argument_agent")
     except ImportError as e:
         skipped.append(("counter_argument_agent", str(e)))
@@ -3159,6 +3198,28 @@ def setup_registry(
             registered.append(name)
         except Exception as e:
             skipped.append((name, str(e)))
+
+    # --- Collaborative multi-agent debate (#175) ---
+    try:
+        from argumentation_analysis.orchestration.collaborative_debate import (
+            _invoke_collaborative_analysis,
+        )
+
+        registry.register_service(
+            name="collaborative_debate_service",
+            service_class=type("collaborative_debate_service", (), {}),
+            capabilities=["collaborative_analysis"],
+            metadata={
+                "description": (
+                    "Multi-agent collaborative debate with 4 distinct roles "
+                    "(critic, validator, devil's advocate, synthesizer)"
+                )
+            },
+            invoke=_invoke_collaborative_analysis,
+        )
+        registered.append("collaborative_debate_service")
+    except ImportError as e:
+        skipped.append(("collaborative_debate_service", str(e)))
 
     logger.info(
         f"Registry setup complete: {len(registered)} registered, "
@@ -3545,6 +3606,15 @@ def get_workflow_catalog() -> Dict[str, WorkflowDefinition]:
             "neural_symbolic": build_neural_symbolic_fallacy_workflow(),
             "hierarchical_fallacy": build_hierarchical_fallacy_workflow(),
         }
+        # Collaborative multi-agent debate (#175)
+        try:
+            from argumentation_analysis.orchestration.collaborative_debate import (
+                build_collaborative_analysis_workflow,
+            )
+
+            WORKFLOW_CATALOG["collaborative"] = build_collaborative_analysis_workflow()
+        except Exception as e:
+            logger.warning(f"Collaborative workflow not registered: {e}")
         # Macro workflows (Track D)
         try:
             from argumentation_analysis.workflows.democratech import (
@@ -3585,9 +3655,9 @@ def get_workflow_catalog() -> Dict[str, WorkflowDefinition]:
                 build_formal_verification_workflow,
             )
 
-            WORKFLOW_CATALOG["formal_verification"] = (
-                build_formal_verification_workflow()
-            )
+            WORKFLOW_CATALOG[
+                "formal_verification"
+            ] = build_formal_verification_workflow()
         except Exception as e:
             logger.warning(f"Formal verification workflow not registered: {e}")
         # Comprehensive analysis (LLM-only, benchmark-optimized)

--- a/tests/unit/argumentation_analysis/test_collaborative_debate.py
+++ b/tests/unit/argumentation_analysis/test_collaborative_debate.py
@@ -1,0 +1,400 @@
+"""Tests for the collaborative multi-agent debate pipeline (#175).
+
+Validates:
+- Agent role definitions and prompt structure
+- JSON response parsing (clean, fenced, malformed)
+- Fallback when no API key is available
+- State writer populates debate transcripts and workflow results
+- Full collaborative invoke with mocked LLM responses
+- Workflow builder produces correct phase structure
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from argumentation_analysis.orchestration.collaborative_debate import (
+    COLLABORATIVE_ROLES,
+    _fallback_collaborative,
+    _invoke_collaborative_analysis,
+    _parse_json_response,
+    _write_collaborative_to_state,
+    build_collaborative_analysis_workflow,
+)
+
+
+# --- Role definitions ---
+
+
+class TestCollaborativeRoles:
+    def test_all_roles_defined(self):
+        expected = {"critic", "validator", "devils_advocate", "synthesizer"}
+        assert set(COLLABORATIVE_ROLES.keys()) == expected
+
+    def test_each_role_has_required_fields(self):
+        for role_name, role_def in COLLABORATIVE_ROLES.items():
+            assert "name" in role_def, f"Missing name for {role_name}"
+            assert "system_prompt" in role_def, f"Missing system_prompt for {role_name}"
+            assert (
+                len(role_def["system_prompt"]) > 50
+            ), f"System prompt too short for {role_name}"
+
+    def test_roles_request_json_output(self):
+        for role_name, role_def in COLLABORATIVE_ROLES.items():
+            assert (
+                "JSON" in role_def["system_prompt"]
+            ), f"Role {role_name} should request JSON output"
+
+
+# --- JSON parsing ---
+
+
+class TestJsonParsing:
+    def test_clean_json(self):
+        raw = '{"key": "value", "number": 42}'
+        result = _parse_json_response(raw, "test")
+        assert result == {"key": "value", "number": 42}
+
+    def test_json_with_markdown_fence(self):
+        raw = 'Some text\n```json\n{"key": "value"}\n```\nMore text'
+        result = _parse_json_response(raw, "test")
+        assert result == {"key": "value"}
+
+    def test_json_with_generic_fence(self):
+        raw = 'Text\n```\n{"result": true}\n```'
+        result = _parse_json_response(raw, "test")
+        assert result == {"result": True}
+
+    def test_json_embedded_in_text(self):
+        raw = 'Here is my analysis: {"score": 4.5, "valid": true} end.'
+        result = _parse_json_response(raw, "test")
+        assert result["score"] == 4.5
+
+    def test_malformed_json_returns_raw(self):
+        raw = "This is not JSON at all"
+        result = _parse_json_response(raw, "test_role")
+        assert result["parse_error"] is True
+        assert result["role"] == "test_role"
+        assert "This is not" in result["raw_response"]
+
+
+# --- Fallback (no API key) ---
+
+
+class TestFallbackCollaborative:
+    def test_fallback_returns_valid_structure(self):
+        context = {
+            "phase_extract_output": {
+                "arguments": [
+                    {"text": "First argument"},
+                    {"text": "Second argument"},
+                ]
+            }
+        }
+        result = _fallback_collaborative("test text", context)
+        assert result["interaction_type"] == "fallback_heuristic"
+        assert result["final_quality_score"] == 3.0
+        assert len(result["surviving_arguments"]) == 2
+        assert result["agents_involved"] == []
+
+    def test_fallback_empty_arguments(self):
+        result = _fallback_collaborative("test text", {})
+        assert result["surviving_arguments"] == []
+        assert result["interaction_type"] == "fallback_heuristic"
+
+
+# --- State writer ---
+
+
+class TestStateWriter:
+    def test_writes_debate_transcript(self):
+        state = MagicMock()
+        state.add_debate_transcript = MagicMock(return_value="debate_1")
+        state.set_workflow_results = MagicMock()
+
+        output = {
+            "agent_outputs": {
+                "critic": {"critiques": [], "overall_rigor": 3},
+                "validator": {"validations": [], "overall_validity": 0.7},
+            },
+            "final_quality_score": 4.0,
+            "new_insights": ["insight 1"],
+            "surviving_arguments": [{"argument": "A1", "confidence": 0.8}],
+            "defeated_arguments": [],
+            "agents_involved": ["critic", "validator"],
+        }
+
+        _write_collaborative_to_state(output, state, {})
+
+        state.add_debate_transcript.assert_called_once()
+        call_args = state.add_debate_transcript.call_args
+        assert call_args[1]["topic"] == "collaborative_multi_agent_analysis"
+        assert len(call_args[1]["exchanges"]) == 2
+
+        state.set_workflow_results.assert_called_once()
+        wf_args = state.set_workflow_results.call_args
+        assert wf_args[0][0] == "collaborative_analysis"
+        assert wf_args[0][1]["final_quality_score"] == 4.0
+
+    def test_handles_none_output(self):
+        state = MagicMock()
+        _write_collaborative_to_state(None, state, {})
+        state.add_debate_transcript.assert_not_called()
+
+    def test_handles_empty_dict(self):
+        state = MagicMock()
+        _write_collaborative_to_state({}, state, {})
+        # Empty dict is falsy — should not write
+        state.add_debate_transcript.assert_not_called()
+
+    def test_skips_error_outputs(self):
+        state = MagicMock()
+        state.add_debate_transcript = MagicMock(return_value="debate_1")
+        state.set_workflow_results = MagicMock()
+
+        output = {
+            "agent_outputs": {
+                "critic": {"error": "LLM timeout", "role": "critic"},
+                "validator": {"validations": [], "overall_validity": 0.5},
+            },
+            "final_quality_score": 2.0,
+            "new_insights": [],
+            "surviving_arguments": [],
+            "defeated_arguments": [],
+            "agents_involved": ["critic", "validator"],
+        }
+
+        _write_collaborative_to_state(output, state, {})
+        call_args = state.add_debate_transcript.call_args
+        # Only validator should be in exchanges (critic had error)
+        assert len(call_args[1]["exchanges"]) == 1
+
+
+# --- Full invoke with mocked LLM ---
+
+
+def _mock_llm_response(content: str):
+    """Create a mock OpenAI response."""
+    mock_choice = MagicMock()
+    mock_choice.message.content = content
+    mock_resp = MagicMock()
+    mock_resp.choices = [mock_choice]
+    return mock_resp
+
+
+CRITIC_RESPONSE = json.dumps(
+    {
+        "critiques": [
+            {
+                "argument": "A1",
+                "weakness": "Lacks empirical evidence",
+                "severity": "medium",
+                "suggestion": "Add data sources",
+            }
+        ],
+        "overall_rigor": 3,
+        "reasoning": "Arguments need more evidence",
+    }
+)
+
+VALIDATOR_RESPONSE = json.dumps(
+    {
+        "validations": [
+            {
+                "argument": "A1",
+                "evidence_status": "mixed",
+                "logical_validity": "valid",
+                "confidence": 0.6,
+                "evidence_notes": "Some support found",
+            }
+        ],
+        "overall_validity": 0.6,
+        "reasoning": "Logically sound but evidence is mixed",
+    }
+)
+
+DA_RESPONSE = json.dumps(
+    {
+        "counter_arguments": [
+            {
+                "target": "A1",
+                "strategy": "counter-example",
+                "counter": "Consider case X where this fails",
+                "strength": "moderate",
+            }
+        ],
+        "most_vulnerable": "A1",
+        "reasoning": "A1 can be challenged with real counter-examples",
+    }
+)
+
+SYNTHESIS_RESPONSE = json.dumps(
+    {
+        "surviving_arguments": [
+            {
+                "argument": "A1",
+                "confidence": 0.65,
+                "survived_challenges": ["logical validity check"],
+            }
+        ],
+        "defeated_arguments": [],
+        "new_insights": ["Evidence quality matters more than logical form"],
+        "consensus_areas": ["A1 is logically valid"],
+        "unresolved_disputes": ["empirical support level"],
+        "final_quality_score": 4,
+        "reasoning": "A1 survives but needs stronger evidence",
+    }
+)
+
+
+class TestInvokeCollaborativeAnalysis:
+    @pytest.mark.asyncio
+    async def test_full_collaborative_flow(self):
+        """Test the full 4-agent collaborative flow with mocked LLM."""
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[
+                _mock_llm_response(CRITIC_RESPONSE),
+                _mock_llm_response(VALIDATOR_RESPONSE),
+                _mock_llm_response(DA_RESPONSE),
+                _mock_llm_response(SYNTHESIS_RESPONSE),
+            ]
+        )
+
+        context = {
+            "phase_extract_output": {
+                "arguments": [
+                    {"text": "Education spending correlates with economic growth"},
+                    {"text": "Countries with higher education invest more"},
+                ]
+            },
+            "phase_quality_output": {
+                "per_argument_scores": {
+                    "arg_1": {"note_finale": 6.5},
+                    "arg_2": {"note_finale": 5.0},
+                }
+            },
+        }
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}), patch(
+            "openai.AsyncOpenAI",
+            return_value=mock_client,
+        ):
+            result = await _invoke_collaborative_analysis("test text", context)
+
+        assert result["interaction_type"] == "sequential_collaborative"
+        assert result["final_quality_score"] == 4
+        assert len(result["new_insights"]) == 1
+        assert len(result["surviving_arguments"]) == 1
+        assert len(result["agents_involved"]) == 4
+
+        # Verify all 4 LLM calls were made
+        assert mock_client.chat.completions.create.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_no_api_key_uses_fallback(self):
+        """Without API key, should use heuristic fallback."""
+        context = {"phase_extract_output": {"arguments": [{"text": "Test argument"}]}}
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+            result = await _invoke_collaborative_analysis("test text", context)
+
+        assert result["interaction_type"] == "fallback_heuristic"
+
+    @pytest.mark.asyncio
+    async def test_handles_llm_failure_gracefully(self):
+        """If one agent fails, the others should still run."""
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[
+                Exception("API timeout"),  # Critic fails
+                _mock_llm_response(VALIDATOR_RESPONSE),
+                _mock_llm_response(DA_RESPONSE),
+                _mock_llm_response(SYNTHESIS_RESPONSE),
+            ]
+        )
+
+        context = {
+            "phase_extract_output": {
+                "arguments": [{"text": "Test argument for resilience testing"}]
+            }
+        }
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}), patch(
+            "openai.AsyncOpenAI",
+            return_value=mock_client,
+        ):
+            result = await _invoke_collaborative_analysis("test text", context)
+
+        # Should still complete — critic output will have error
+        assert "critic" in result["agent_outputs"]
+        assert "error" in result["agent_outputs"]["critic"]
+        assert result["interaction_type"] == "sequential_collaborative"
+
+    @pytest.mark.asyncio
+    async def test_sentence_split_fallback(self):
+        """When no arguments in extract, should fall back to sentence splitting."""
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[
+                _mock_llm_response(CRITIC_RESPONSE),
+                _mock_llm_response(VALIDATOR_RESPONSE),
+                _mock_llm_response(DA_RESPONSE),
+                _mock_llm_response(SYNTHESIS_RESPONSE),
+            ]
+        )
+
+        context = {"phase_extract_output": {}}
+        long_text = "First sentence about policy. Second sentence about economics. Third point on education."
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}), patch(
+            "openai.AsyncOpenAI",
+            return_value=mock_client,
+        ):
+            result = await _invoke_collaborative_analysis(long_text, context)
+
+        assert result["interaction_type"] == "sequential_collaborative"
+
+
+# --- Workflow builder ---
+
+
+class TestWorkflowBuilder:
+    def test_builds_3_phase_workflow(self):
+        workflow = build_collaborative_analysis_workflow()
+        assert workflow.name == "collaborative_analysis"
+        assert len(workflow.phases) == 3
+
+    def test_phase_names_and_capabilities(self):
+        workflow = build_collaborative_analysis_workflow()
+        phase_map = {p.name: p.capability for p in workflow.phases}
+        assert phase_map["extract"] == "fact_extraction"
+        assert phase_map["quality"] == "argument_quality"
+        assert phase_map["collaborative"] == "collaborative_analysis"
+
+    def test_dependency_chain(self):
+        workflow = build_collaborative_analysis_workflow()
+        phase_map = {p.name: p for p in workflow.phases}
+        assert phase_map["extract"].depends_on == []
+        assert phase_map["quality"].depends_on == ["extract"]
+        assert phase_map["collaborative"].depends_on == ["quality"]
+
+
+# --- Integration: capability state writer in unified pipeline ---
+
+
+class TestCapabilityStateWriterRegistered:
+    def test_collaborative_analysis_in_writers(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            CAPABILITY_STATE_WRITERS,
+        )
+
+        assert "collaborative_analysis" in CAPABILITY_STATE_WRITERS
+
+    def test_collaborative_in_workflow_catalog(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            get_workflow_catalog,
+        )
+
+        catalog = get_workflow_catalog()
+        assert "collaborative" in catalog


### PR DESCRIPTION
## Summary

- **New module** `argumentation_analysis/orchestration/collaborative_debate.py` implementing a collaborative multi-agent analysis pipeline with 4 distinct roles:
  - **Critic (Skeptic)**: Identifies weaknesses, assumptions, logical gaps
  - **Validator (Scholar)**: Checks logic consistency, finds evidence
  - **Devil's Advocate**: Generates strongest counter-arguments
  - **Synthesizer**: Resolves disagreements, produces final assessment
- Each agent **reads and responds to previous agents' outputs**, creating genuine inter-agent dialogue (not parallel independent analysis)
- Registered as `collaborative_analysis` capability in unified pipeline
- Added to workflow catalog as `"collaborative"` workflow (extract → quality → collaborative)
- Fallback heuristic when no API key available
- State writer populates debate transcripts and workflow results

## Addresses #175 (and #97 finding)

Issue #97 found multi-round pipeline repetition does NOT improve quality (3.33 → 3.27 composite, 2.89x slower). This implements the recommended fix: quality improvement through **inter-agent collaboration** with distinct roles, not repetition.

## Test plan

- [x] 23 unit tests passing (role definitions, JSON parsing, fallback, state writing, full mocked LLM flow)
- [x] Black formatted
- [ ] Integration test with real LLM (requires API key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)