### PR TITLE
feat: argument-level semantic chunking with metadata (#174)

### DIFF
--- a/argumentation_analysis/services/semantic_index_service.py
+++ b/argumentation_analysis/services/semantic_index_service.py
@@ -320,3 +320,251 @@ class SemanticIndexService:
             "available": self.is_available(),
             "default_index": self._default_index,
         }
+
+    # ── Argument-level chunking (#174) ──────────────────────────────────
+
+    def index_arguments(
+        self,
+        arguments: List[Dict[str, Any]],
+        source_name: str = "pipeline",
+        quality_scores: Optional[Dict[str, Dict]] = None,
+        fallacies: Optional[List[Dict[str, Any]]] = None,
+        index: Optional[str] = None,
+    ) -> List[str]:
+        """Index individual arguments as separate vectors with metadata.
+
+        Instead of chunking by fixed token count, each argument from
+        fact_extraction is indexed as its own vector with quality and
+        fallacy metadata attached for filtered search.
+
+        Args:
+            arguments: List of argument dicts from fact_extraction
+                       (each has 'text' and optionally 'source_quote').
+            source_name: Name of the source document.
+            quality_scores: Per-argument quality scores from quality evaluator
+                           {arg_id: {scores_par_vertu: {...}, note_finale: float}}.
+            fallacies: List of detected fallacies with target_argument references.
+            index: Index to store in (defaults to service default).
+
+        Returns:
+            List of document IDs for indexed arguments.
+        """
+        quality_scores = quality_scores or {}
+        fallacies = fallacies or []
+        doc_ids = []
+
+        # Build fallacy lookup: arg_index → fallacy type
+        fallacy_by_arg: Dict[int, str] = {}
+        for f in fallacies:
+            if isinstance(f, dict):
+                target = f.get("target_argument_id", f.get("argument_index", -1))
+                ftype = f.get("type", f.get("fallacy_type", "unknown"))
+                if isinstance(target, int) and target >= 0:
+                    fallacy_by_arg[target] = str(ftype)
+                elif isinstance(target, str) and target.startswith("arg_"):
+                    try:
+                        idx = int(target.split("_")[1]) - 1
+                        fallacy_by_arg[idx] = str(ftype)
+                    except (ValueError, IndexError):
+                        pass
+
+        for i, arg in enumerate(arguments):
+            arg_text = arg.get("text", str(arg)) if isinstance(arg, dict) else str(arg)
+            if not arg_text or len(arg_text) < 5:
+                continue
+
+            arg_id = f"arg_{i+1}"
+            source_quote = (
+                arg.get("source_quote", "") if isinstance(arg, dict) else ""
+            )
+
+            # Build metadata tags
+            tags: Dict[str, str] = {
+                "chunk_type": "argument",
+                "argument_index": str(i),
+                "argument_id": arg_id,
+                "source_name": source_name,
+            }
+
+            # Add quality metadata
+            q_scores = quality_scores.get(arg_id, {})
+            if isinstance(q_scores, dict):
+                overall = q_scores.get("note_finale", 0)
+                if isinstance(overall, (int, float)):
+                    tags["quality_score"] = f"{float(overall):.2f}"
+                    # Bin into categories for filtered search
+                    if overall >= 0.7:
+                        tags["quality_level"] = "high"
+                    elif overall >= 0.4:
+                        tags["quality_level"] = "medium"
+                    else:
+                        tags["quality_level"] = "low"
+
+                virtues = q_scores.get("scores_par_vertu", {})
+                if isinstance(virtues, dict):
+                    # Store weakest virtue for targeted search
+                    weakest = min(
+                        ((k, v) for k, v in virtues.items() if isinstance(v, (int, float))),
+                        key=lambda x: x[1],
+                        default=None,
+                    )
+                    if weakest:
+                        tags["weakest_virtue"] = weakest[0]
+
+            # Add fallacy metadata
+            if i in fallacy_by_arg:
+                tags["fallacy_type"] = fallacy_by_arg[i]
+                tags["has_fallacy"] = "true"
+            else:
+                tags["has_fallacy"] = "false"
+
+            if source_quote:
+                tags["source_quote"] = source_quote[:200]
+
+            try:
+                doc_id = self.upload_document(
+                    name=f"{source_name}__{arg_id}",
+                    text=arg_text,
+                    source_type="argument",
+                    tags=tags,
+                )
+                doc_ids.append(doc_id)
+            except Exception as e:
+                logger.warning(f"Failed to index argument {arg_id}: {e}")
+
+        logger.info(
+            f"Indexed {len(doc_ids)}/{len(arguments)} arguments from '{source_name}'"
+        )
+        return doc_ids
+
+    def search_arguments(
+        self,
+        query: str,
+        index: Optional[str] = None,
+        fallacy_type: Optional[str] = None,
+        quality_level: Optional[str] = None,
+        has_fallacy: Optional[bool] = None,
+        limit: int = 5,
+    ) -> List[SearchResult]:
+        """Search indexed arguments with metadata filtering.
+
+        Args:
+            query: Semantic search query.
+            index: Index to search in.
+            fallacy_type: Filter by specific fallacy type.
+            quality_level: Filter by quality level ("high", "medium", "low").
+            has_fallacy: Filter for arguments with/without fallacies.
+            limit: Max results.
+
+        Returns:
+            List of SearchResult objects with metadata tags.
+        """
+        requests = self._get_requests()
+        payload: Dict[str, Any] = {
+            "index": index or self._default_index,
+            "query": query,
+            "limit": limit,
+        }
+
+        # Build filters
+        filters = []
+        if fallacy_type:
+            filters.append({"fallacy_type": [fallacy_type]})
+        if quality_level:
+            filters.append({"quality_level": [quality_level]})
+        if has_fallacy is not None:
+            filters.append({"has_fallacy": ["true" if has_fallacy else "false"]})
+        filters.append({"chunk_type": ["argument"]})
+
+        if filters:
+            payload["filters"] = filters
+
+        resp = requests.post(
+            f"{self._km_url}/search",
+            json=payload,
+            headers=self._headers(),
+            timeout=self._timeout,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+        results = []
+        for item in body.get("results", []):
+            for partition in item.get("partitions", []):
+                results.append(
+                    SearchResult(
+                        text=partition.get("text", ""),
+                        relevance=partition.get("relevance", 0.0),
+                        document_id=item.get("documentId", ""),
+                        source_name=item.get("sourceName", ""),
+                        tags={
+                            t.split(":", 1)[0]: t.split(":", 1)[1]
+                            for t in item.get("tags", {}).get("tags", [])
+                            if ":" in t
+                        },
+                    )
+                )
+        return results
+
+    @staticmethod
+    def chunk_by_arguments(
+        text: str,
+        fact_extraction_output: Optional[Dict[str, Any]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Split text into argument-level chunks.
+
+        Uses fact_extraction output if available, otherwise falls back
+        to sentence-level splitting with heuristic argument detection.
+
+        Args:
+            text: Raw input text.
+            fact_extraction_output: Output from fact_extraction phase
+                containing 'arguments' and 'claims' lists.
+
+        Returns:
+            List of argument dicts with 'text' and 'source_quote' fields.
+        """
+        if fact_extraction_output and isinstance(fact_extraction_output, dict):
+            arguments = fact_extraction_output.get("arguments", [])
+            claims = fact_extraction_output.get("claims", [])
+
+            chunks = []
+            for arg in arguments:
+                if isinstance(arg, dict):
+                    chunks.append({
+                        "text": arg.get("text", str(arg)),
+                        "source_quote": arg.get("source_quote", ""),
+                        "chunk_type": "argument",
+                    })
+                elif isinstance(arg, str) and len(arg) >= 10:
+                    chunks.append({
+                        "text": arg,
+                        "source_quote": "",
+                        "chunk_type": "argument",
+                    })
+
+            for claim in claims:
+                if isinstance(claim, dict):
+                    chunks.append({
+                        "text": claim.get("text", str(claim)),
+                        "source_quote": claim.get("source_quote", ""),
+                        "chunk_type": "claim",
+                    })
+                elif isinstance(claim, str) and len(claim) >= 10:
+                    chunks.append({
+                        "text": claim,
+                        "source_quote": "",
+                        "chunk_type": "claim",
+                    })
+
+            if chunks:
+                return chunks
+
+        # Fallback: sentence-level splitting
+        import re
+        sentences = re.split(r'(?<=[.!?])\s+', text)
+        return [
+            {"text": s.strip(), "source_quote": "", "chunk_type": "sentence"}
+            for s in sentences
+            if len(s.strip()) >= 15
+        ]

--- a/tests/unit/argumentation_analysis/test_semantic_index_chunking.py
+++ b/tests/unit/argumentation_analysis/test_semantic_index_chunking.py
@@ -1,0 +1,217 @@
+"""Tests for argument-level semantic chunking (#174).
+
+Tests the chunk_by_arguments, index_arguments, and search_arguments
+methods added to SemanticIndexService.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from argumentation_analysis.services.semantic_index_service import (
+    SemanticIndexService,
+    SearchResult,
+)
+
+
+class TestChunkByArguments:
+    """Test argument-level chunking from fact_extraction output."""
+
+    def test_chunks_from_extraction_output(self):
+        """Arguments from fact_extraction are chunked individually."""
+        extraction = {
+            "arguments": [
+                {"text": "The climate is changing due to CO2 emissions", "source_quote": "para 2"},
+                {"text": "Renewable energy reduces carbon footprint", "source_quote": "para 5"},
+            ],
+            "claims": [
+                {"text": "We should invest in solar power", "source_quote": "conclusion"},
+            ],
+        }
+        chunks = SemanticIndexService.chunk_by_arguments("raw text", extraction)
+        assert len(chunks) == 3
+        assert chunks[0]["chunk_type"] == "argument"
+        assert chunks[2]["chunk_type"] == "claim"
+        assert chunks[0]["source_quote"] == "para 2"
+
+    def test_chunks_from_string_arguments(self):
+        """String-format arguments are also chunked."""
+        extraction = {
+            "arguments": [
+                "First argument with enough text",
+                "Second argument also long enough",
+            ],
+            "claims": [],
+        }
+        chunks = SemanticIndexService.chunk_by_arguments("raw text", extraction)
+        assert len(chunks) == 2
+        assert chunks[0]["text"] == "First argument with enough text"
+
+    def test_fallback_sentence_splitting(self):
+        """Without extraction output, falls back to sentence splitting."""
+        text = "First sentence is here now. Second sentence follows after. Third sentence as well."
+        chunks = SemanticIndexService.chunk_by_arguments(text)
+        assert len(chunks) == 3
+        for c in chunks:
+            assert c["chunk_type"] == "sentence"
+
+    def test_filters_short_chunks_in_indexing(self):
+        """Short arguments are filtered during indexing, not chunking."""
+        service = SemanticIndexService()
+        uploaded = []
+        service.upload_document = lambda name, text, source_type="text", tags=None: (
+            uploaded.append(1) or f"doc_{len(uploaded)}"
+        )
+        doc_ids = service.index_arguments(
+            arguments=[{"text": "ok"}, {"text": "This is long enough to be a real argument"}],
+            source_name="test",
+        )
+        # Only the long argument gets indexed (short ones skipped)
+        assert len(doc_ids) == 1
+
+    def test_empty_extraction_falls_back(self):
+        """Empty extraction output triggers sentence fallback."""
+        chunks = SemanticIndexService.chunk_by_arguments(
+            "A statement worth indexing here. Another statement also follows.",
+            {"arguments": [], "claims": []},
+        )
+        assert len(chunks) == 2
+
+
+class TestIndexArguments:
+    """Test argument indexing with metadata."""
+
+    def test_index_with_quality_and_fallacy_metadata(self):
+        """Arguments indexed with quality scores and fallacy tags."""
+        service = SemanticIndexService()
+        # Mock upload_document to capture calls
+        uploaded = []
+
+        def mock_upload(name, text, source_type="text", tags=None):
+            uploaded.append({"name": name, "text": text, "tags": tags or {}})
+            return f"doc_{len(uploaded)}"
+
+        service.upload_document = mock_upload
+
+        arguments = [
+            {"text": "Climate change is caused by human activity"},
+            {"text": "The earth is flat because the horizon looks flat"},
+        ]
+        quality_scores = {
+            "arg_1": {
+                "note_finale": 0.85,
+                "scores_par_vertu": {"sources": 0.9, "pertinence": 0.8},
+            },
+            "arg_2": {
+                "note_finale": 0.25,
+                "scores_par_vertu": {"sources": 0.1, "pertinence": 0.4},
+            },
+        }
+        fallacies = [
+            {"argument_index": 1, "fallacy_type": "appeal_to_ignorance"},
+        ]
+
+        doc_ids = service.index_arguments(
+            arguments=arguments,
+            source_name="test_doc",
+            quality_scores=quality_scores,
+            fallacies=fallacies,
+        )
+        assert len(doc_ids) == 2
+        assert len(uploaded) == 2
+
+        # First argument: high quality, no fallacy
+        tags1 = uploaded[0]["tags"]
+        assert tags1["chunk_type"] == "argument"
+        assert tags1["quality_level"] == "high"
+        assert tags1["has_fallacy"] == "false"
+        assert tags1["argument_id"] == "arg_1"
+
+        # Second argument: low quality, has fallacy
+        tags2 = uploaded[1]["tags"]
+        assert tags2["quality_level"] == "low"
+        assert tags2["has_fallacy"] == "true"
+        assert tags2["fallacy_type"] == "appeal_to_ignorance"
+        assert tags2["weakest_virtue"] == "sources"
+
+    def test_index_skips_short_arguments(self):
+        """Arguments shorter than 5 chars are skipped."""
+        service = SemanticIndexService()
+        uploaded = []
+        service.upload_document = lambda **kw: uploaded.append(1) or "doc_1"
+
+        doc_ids = service.index_arguments(
+            arguments=[{"text": "ok"}, {"text": "A real argument with substance"}],
+            source_name="test",
+        )
+        assert len(doc_ids) == 1
+
+    def test_index_handles_upload_failure(self):
+        """Failed uploads are logged but don't crash."""
+        service = SemanticIndexService()
+        call_count = [0]
+
+        def failing_upload(name, text, source_type="text", tags=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise RuntimeError("Upload failed")
+            return "doc_2"
+
+        service.upload_document = failing_upload
+
+        doc_ids = service.index_arguments(
+            arguments=[
+                {"text": "First argument that will fail upload"},
+                {"text": "Second argument that will succeed"},
+            ],
+            source_name="test",
+        )
+        assert len(doc_ids) == 1  # Only second one succeeded
+
+    def test_index_with_string_fallacy_target(self):
+        """Fallacy with arg_N target format works."""
+        service = SemanticIndexService()
+        uploaded = []
+        service.upload_document = lambda name, text, source_type="text", tags=None: (
+            uploaded.append({"tags": tags or {}}) or f"doc_{len(uploaded)}"
+        )
+
+        service.index_arguments(
+            arguments=[{"text": "An argument that has a fallacy in it"}],
+            fallacies=[{"target_argument_id": "arg_1", "type": "ad_hominem"}],
+            source_name="test",
+        )
+        assert uploaded[0]["tags"]["fallacy_type"] == "ad_hominem"
+
+
+class TestSearchArguments:
+    """Test argument search with metadata filtering."""
+
+    def test_search_builds_filters(self):
+        """Search includes metadata filters in API call."""
+        service = SemanticIndexService(km_url="http://test:9001")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"results": []}
+        mock_resp.raise_for_status = MagicMock()
+
+        mock_requests = MagicMock()
+        mock_requests.post.return_value = mock_resp
+        service._requests = mock_requests
+
+        service.search_arguments(
+            query="climate change",
+            fallacy_type="ad_hominem",
+            quality_level="high",
+            has_fallacy=True,
+        )
+
+        # Verify the API call included filters
+        call_args = mock_requests.post.call_args
+        payload = call_args[1]["json"] if "json" in call_args[1] else call_args[0][1]
+        assert "filters" in payload
+        filter_keys = [list(f.keys())[0] for f in payload["filters"]]
+        assert "fallacy_type" in filter_keys
+        assert "quality_level" in filter_keys
+        assert "has_fallacy" in filter_keys
+        assert "chunk_type" in filter_keys  # Always filter by argument type


### PR DESCRIPTION
## Summary

- Adds **argument-level chunking** to `SemanticIndexService` — each argument from fact_extraction indexed as its own vector
- Attaches **quality and fallacy metadata** per argument for filtered semantic search
- Implements professor's soutenance suggestion for 2.4.1 Semantic Index

## Components

- `chunk_by_arguments()` — argument-aware chunking with sentence fallback
- `index_arguments()` — indexes arguments with quality/fallacy metadata tags
- `search_arguments()` — filtered search by fallacy_type, quality_level, has_fallacy

## Test plan

- [x] Chunking from extraction output, string args, sentence fallback
- [x] Metadata tags: quality_level, weakest_virtue, fallacy_type, has_fallacy
- [x] Upload failure handling, short argument filtering
- [x] Search filter payload construction

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)