### PR TITLE
fix: quality_scores key mismatch for downstream consumers (#177)

### DIFF
--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -82,6 +82,12 @@ async def _invoke_quality_evaluator(input_text: str, context: Dict[str, Any]) ->
                 # Keep top-level keys for state writer compatibility
                 "note_finale": aggregate_score,
                 "scores_par_vertu": _aggregate_virtue_scores(results),
+                # Alias for downstream context consumers (#177 key mismatch fix)
+                "quality_scores": {
+                    arg_id: r.get("note_finale", 0)
+                    for arg_id, r in results.items()
+                    if isinstance(r, dict)
+                },
             }
         # Fallback if no results
         return await asyncio.to_thread(evaluator.evaluate, input_text)


### PR DESCRIPTION
## Summary

Fixes a key name mismatch where `_invoke_quality_evaluator` outputs `per_argument_scores` but downstream phases (ranking, social, formal_synthesis) look for `quality_scores` in the context — causing quality data to be silently empty in inter-phase communication despite being correctly written to state.

## Root cause

- `_invoke_quality_evaluator` returns `{"per_argument_scores": {...}, ...}` (line 79)
- Downstream consumers at lines 734, 1515, 1589 do: `quality_output.get("quality_scores", quality_output.get("scores", {}))` 
- Neither `quality_scores` nor `scores` exists in the output → returns `{}`

## Fix

Add a `quality_scores` alias key in the return dict mapping `arg_id → note_finale`, so downstream consumers find the data they expect.

## Test plan

- [x] Syntax verification passes
- [x] State writer still works (uses `per_argument_scores`)
- [x] Downstream consumers now find `quality_scores` key

Fixes #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)