### PR TITLE
feat: NL-to-formal-logic translation pipeline with Tweety validation (#173)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -396,6 +396,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         self.propositional_analysis_results: List[Dict[str, Any]] = []
         self.modal_analysis_results: List[Dict[str, Any]] = []
         self.formal_synthesis_reports: List[Dict[str, Any]] = []
+        # NL-to-formal-logic translations (#173)
+        self.nl_to_logic_translations: List[Dict[str, Any]] = []
         # Workflow execution results
         self.workflow_results: Dict[str, Any] = {}
 
@@ -722,6 +724,32 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             f"Formal synthesis added: {fs_id} (validity={overall_validity:.2f})"
         )
         return fs_id
+
+    def add_nl_to_logic_translation(
+        self,
+        original_text: str,
+        formula: str,
+        logic_type: str,
+        is_valid: bool,
+        variables: Optional[Dict[str, str]] = None,
+        confidence: float = 0.0,
+    ) -> str:
+        """Add a NL-to-formal-logic translation result (#173)."""
+        tr_id = self._generate_id("nll", self.nl_to_logic_translations)
+        entry = {
+            "id": tr_id,
+            "original_text": original_text[:200],
+            "formula": formula,
+            "logic_type": logic_type,
+            "is_valid": is_valid,
+            "variables": variables or {},
+            "confidence": confidence,
+        }
+        self.nl_to_logic_translations.append(entry)
+        state_logger.info(
+            f"NL→logic translation added: {tr_id} ({logic_type}, valid={is_valid})"
+        )
+        return tr_id
 
     def set_workflow_results(self, workflow_name: str, results: Dict[str, Any]) -> None:
         """Store workflow execution results."""

--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -2113,6 +2113,48 @@ async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dic
         }
 
 
+async def _invoke_nl_to_logic(input_text: str, context: Dict[str, Any]) -> Dict:
+    """Translate extracted NL arguments to formal logic with validation (#173).
+
+    Uses LLM to generate propositional/FOL formulas, validates via Tweety
+    (or Python fallback), and retries on failure with error feedback.
+    Bridges the gap between informal LLM analysis and formal reasoning.
+    """
+    from argumentation_analysis.services.nl_to_logic import NLToLogicTranslator
+
+    args = _extract_arguments_from_context(input_text, context)
+    logic_type = context.get("logic_type", "propositional")
+
+    translator = NLToLogicTranslator(max_retries=3, logic_type=logic_type)
+    batch_result = await translator.translate_batch(
+        args[:6], logic_type=logic_type, check_consistency=True
+    )
+
+    translations = []
+    for t in batch_result.translations:
+        translations.append({
+            "original_text": t.original_text[:200],
+            "formula": t.formula,
+            "logic_type": t.logic_type,
+            "is_valid": t.is_valid,
+            "validation_message": t.validation_message,
+            "attempts": t.attempts,
+            "variables": t.variables,
+            "confidence": t.confidence,
+        })
+
+    valid_count = sum(1 for t in translations if t["is_valid"])
+    return {
+        "translations": translations,
+        "total": len(translations),
+        "valid_count": valid_count,
+        "overall_consistency": batch_result.overall_consistency,
+        "consistency_message": batch_result.consistency_message,
+        "method": batch_result.method,
+        "logic_type": logic_type,
+    }
+
+
 async def _invoke_modal_logic(input_text: str, context: Dict[str, Any]) -> Dict:
     """Invoke modal logic analysis via TweetyBridge (JVM required)."""
     try:
@@ -2694,6 +2736,25 @@ def _write_modal_to_state(output, state, ctx) -> None:
     state.add_modal_analysis_result(formulas, bool(valid), modalities)
 
 
+def _write_nl_to_logic_to_state(output, state, ctx) -> None:
+    """Write NL-to-formal-logic translation results to UnifiedAnalysisState (#173)."""
+    if not output or not isinstance(output, dict):
+        return
+    translations = output.get("translations", [])
+    if not isinstance(translations, list):
+        return
+    for t in translations:
+        if isinstance(t, dict) and t.get("formula"):
+            state.add_nl_to_logic_translation(
+                original_text=t.get("original_text", ""),
+                formula=t.get("formula", ""),
+                logic_type=t.get("logic_type", "propositional"),
+                is_valid=bool(t.get("is_valid", False)),
+                variables=t.get("variables", {}),
+                confidence=float(t.get("confidence", 0.0)),
+            )
+
+
 def _write_dung_extensions_to_state(output, state, ctx) -> None:
     """Write Dung extension computation results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
@@ -2897,6 +2958,7 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "defeasible_logic": _write_delp_to_state,
     "qbf_reasoning": _write_qbf_to_state,
     "collaborative_analysis": _write_collaborative_analysis_to_state,
+    "nl_to_logic_translation": _write_nl_to_logic_to_state,
 }
 
 
@@ -3185,6 +3247,13 @@ def setup_registry(
             "SAT/MaxSAT/MUS solver (PySAT + Z3)",
             _invoke_sat,
         ),
+        # NL-to-formal-logic translation (#173)
+        (
+            "nl_to_logic_service",
+            ["nl_to_logic_translation"],
+            "NL→formal logic with LLM + Tweety validation",
+            _invoke_nl_to_logic,
+        ),
     ]
     for name, caps, desc, invoke_fn in logic_capabilities:
         try:
@@ -3446,6 +3515,42 @@ def build_full_workflow() -> WorkflowDefinition:
             depends_on=["counter"],
             optional=True,
         )
+        .add_phase(
+            "nl_to_logic",
+            capability="nl_to_logic_translation",
+            depends_on=["extract"],
+            optional=True,
+        )
+        .build()
+    )
+
+
+def build_nl_to_logic_workflow() -> WorkflowDefinition:
+    """NL-to-formal-logic pipeline: extract → translate → validate → reason (#173).
+
+    Bridges informal NL analysis and formal reasoning by translating
+    extracted arguments into propositional/FOL formulas with Tweety validation.
+    """
+    return (
+        WorkflowBuilder("nl_to_logic_analysis")
+        .add_phase("extract", capability="fact_extraction")
+        .add_phase(
+            "nl_to_logic",
+            capability="nl_to_logic_translation",
+            depends_on=["extract"],
+        )
+        .add_phase(
+            "pl",
+            capability="propositional_logic",
+            depends_on=["nl_to_logic"],
+            optional=True,
+        )
+        .add_phase(
+            "fol",
+            capability="fol_reasoning",
+            depends_on=["nl_to_logic"],
+            optional=True,
+        )
         .build()
     )
 
@@ -3605,6 +3710,7 @@ def get_workflow_catalog() -> Dict[str, WorkflowDefinition]:
             "jtms_dung": build_jtms_dung_loop_workflow(),
             "neural_symbolic": build_neural_symbolic_fallacy_workflow(),
             "hierarchical_fallacy": build_hierarchical_fallacy_workflow(),
+            "nl_to_logic": build_nl_to_logic_workflow(),
         }
         # Collaborative multi-agent debate (#175)
         try:

--- a/argumentation_analysis/services/nl_to_logic.py
+++ b/argumentation_analysis/services/nl_to_logic.py
@@ -1,0 +1,594 @@
+"""
+NL-to-Formal-Logic Translation Service.
+
+Translates natural language arguments into formal logic representations
+(propositional or first-order logic) using LLM-based translation with
+Tweety validation and a retry loop for error correction.
+
+Key insight from QBF soutenance (1.1.5): LLM translation alone is unreliable.
+The solution is a translate-validate-retry loop: LLM generates the formula,
+Tweety validates its syntax/consistency, and if it fails, the error message
+is fed back to the LLM for correction.
+
+Integration: Issue #173.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# ── Operator mappings ────────────────────────────────────────────────────
+
+# Unicode → ASCII operators (Tweety only accepts ASCII)
+UNICODE_TO_ASCII = {
+    "\u2200": "forall",  # ∀
+    "\u2203": "exists",  # ∃
+    "\u2227": "&&",  # ∧
+    "\u2228": "||",  # ∨
+    "\u2192": "=>",  # →
+    "\u00ac": "!",  # ¬
+    "\u2194": "<=>",  # ↔
+    "\u22a4": "true",  # ⊤
+    "\u22a5": "false",  # ⊥
+}
+
+
+def normalize_operators(formula: str) -> str:
+    """Replace Unicode logic operators with ASCII equivalents for Tweety."""
+    result = formula
+    for uni, ascii_op in UNICODE_TO_ASCII.items():
+        result = result.replace(uni, ascii_op)
+    return result
+
+
+# ── Data classes ─────────────────────────────────────────────────────────
+
+
+@dataclass
+class TranslationResult:
+    """Result of translating a single NL argument to formal logic."""
+
+    original_text: str
+    formula: str
+    logic_type: str  # "propositional" or "fol"
+    is_valid: bool
+    validation_message: str = ""
+    attempts: int = 1
+    variables: Dict[str, str] = field(default_factory=dict)
+    confidence: float = 0.0
+
+
+@dataclass
+class TranslationBatchResult:
+    """Result of translating multiple arguments."""
+
+    translations: List[TranslationResult] = field(default_factory=list)
+    overall_consistency: Optional[bool] = None
+    consistency_message: str = ""
+    method: str = "llm"  # "llm" or "heuristic"
+
+
+# ── Prompt templates ─────────────────────────────────────────────────────
+
+PL_SYSTEM_PROMPT = (
+    "You are a formal logic expert. Translate natural language arguments "
+    "into propositional logic formulas.\n\n"
+    "Rules:\n"
+    "- Use lowercase variable names (p, q, r, rain, sunny, etc.)\n"
+    "- Operators: && (and), || (or), => (implies), ! (not), <=> (iff)\n"
+    "- Each proposition should be a simple, atomic variable name\n"
+    "- Provide a variable mapping explaining what each variable represents\n\n"
+    "Respond with ONLY a JSON object:\n"
+    '{"formula": "p && (p => q) => q", '
+    '"variables": {"p": "it is raining", "q": "the ground is wet"}, '
+    '"confidence": 0.85}'
+)
+
+PL_RETRY_PROMPT = (
+    "Your previous translation was invalid. The validator returned:\n"
+    "Error: {error}\n\n"
+    "Please fix the formula. Common issues:\n"
+    "- Missing parentheses around implications\n"
+    "- Invalid variable names (use simple alphanumeric)\n"
+    "- Unmatched parentheses\n"
+    "- Wrong operator syntax (use &&, ||, =>, !, <=>)\n\n"
+    "Original text: {original}\n"
+    "Previous (invalid) formula: {formula}\n\n"
+    "Respond with ONLY a corrected JSON object."
+)
+
+FOL_SYSTEM_PROMPT = (
+    "You are a formal logic expert. Translate natural language arguments "
+    "into first-order logic formulas using Tweety syntax.\n\n"
+    "Rules:\n"
+    "- Predicates: CamelCase (e.g., Mortal, Human, Argues)\n"
+    "- Constants: lowercase (e.g., socrates, plato)\n"
+    "- Variables: uppercase single letters (e.g., X, Y, Z)\n"
+    "- Quantifiers: forall X: (...) and exists X: (...)\n"
+    "- Operators: && (and), || (or), => (implies), ! (not), <=> (iff)\n"
+    "- Separate multiple formulas with semicolons\n\n"
+    "Respond with ONLY a JSON object:\n"
+    '{"formulas": ["forall X: (Human(X) => Mortal(X))", "Human(socrates)"], '
+    '"predicates": {"Human": "is a human being", "Mortal": "is mortal"}, '
+    '"constants": {"socrates": "the philosopher Socrates"}, '
+    '"confidence": 0.9}'
+)
+
+FOL_RETRY_PROMPT = (
+    "Your previous FOL translation was invalid. The validator returned:\n"
+    "Error: {error}\n\n"
+    "Common issues:\n"
+    "- Predicate names must be CamelCase\n"
+    "- Constants must be lowercase\n"
+    "- Quantifier syntax: forall X: (...) not ∀x.(...)\n"
+    "- Missing parentheses around quantifier scope\n\n"
+    "Original text: {original}\n"
+    "Previous (invalid) formulas: {formulas}\n\n"
+    "Respond with ONLY a corrected JSON object."
+)
+
+
+# ── Service class ────────────────────────────────────────────────────────
+
+
+class NLToLogicTranslator:
+    """Translates natural language arguments to formal logic with validation.
+
+    Uses an LLM to generate formal representations, validates them via
+    Tweety (or Python fallback), and retries on failure with the error
+    message fed back to the LLM.
+
+    Args:
+        max_retries: Maximum translation attempts per argument (default: 3).
+        logic_type: Default logic type ("propositional" or "fol").
+    """
+
+    def __init__(
+        self,
+        max_retries: int = 3,
+        logic_type: str = "propositional",
+    ):
+        self.max_retries = max_retries
+        self.logic_type = logic_type
+
+    async def translate(
+        self,
+        text: str,
+        logic_type: Optional[str] = None,
+    ) -> TranslationResult:
+        """Translate a single NL argument to formal logic.
+
+        Args:
+            text: Natural language argument text.
+            logic_type: Override default logic type.
+
+        Returns:
+            TranslationResult with formula, validity, and metadata.
+        """
+        lt = logic_type or self.logic_type
+
+        # Try LLM-based translation with retry loop
+        try:
+            return await self._translate_with_llm(text, lt)
+        except Exception as e:
+            logger.warning(f"LLM translation failed, using heuristic: {e}")
+            return self._translate_heuristic(text, lt)
+
+    async def translate_batch(
+        self,
+        arguments: List[str],
+        logic_type: Optional[str] = None,
+        check_consistency: bool = True,
+    ) -> TranslationBatchResult:
+        """Translate multiple arguments and optionally check consistency.
+
+        Args:
+            arguments: List of NL argument texts.
+            logic_type: Logic type for all translations.
+            check_consistency: Whether to check KB consistency.
+
+        Returns:
+            TranslationBatchResult with all translations and consistency info.
+        """
+        lt = logic_type or self.logic_type
+        translations = []
+
+        for arg_text in arguments[:10]:  # Cap at 10
+            if len(arg_text.strip()) < 10:
+                continue
+            result = await self.translate(arg_text, lt)
+            translations.append(result)
+
+        batch = TranslationBatchResult(translations=translations)
+
+        # Check consistency if requested and we have valid formulas
+        valid_formulas = [t.formula for t in translations if t.is_valid]
+        if check_consistency and valid_formulas:
+            is_consistent, msg = await self._check_consistency(valid_formulas, lt)
+            batch.overall_consistency = is_consistent
+            batch.consistency_message = msg
+
+        # Determine method
+        batch.method = (
+            "llm" if any(t.attempts > 0 for t in translations) else "heuristic"
+        )
+
+        return batch
+
+    # ── LLM translation with retry loop ──────────────────────────────
+
+    async def _translate_with_llm(
+        self,
+        text: str,
+        logic_type: str,
+    ) -> TranslationResult:
+        """Translate via LLM with validate-retry loop."""
+        from openai import AsyncOpenAI
+
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+        if not api_key:
+            return self._translate_heuristic(text, logic_type)
+
+        base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+        client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+        system_prompt = (
+            PL_SYSTEM_PROMPT if logic_type == "propositional" else FOL_SYSTEM_PROMPT
+        )
+        retry_template = (
+            PL_RETRY_PROMPT if logic_type == "propositional" else FOL_RETRY_PROMPT
+        )
+
+        last_error = ""
+        last_formula = ""
+        variables = {}
+        confidence = 0.0
+
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                messages = [
+                    {"role": "system", "content": system_prompt},
+                ]
+
+                if attempt == 1:
+                    messages.append({"role": "user", "content": text[:2000]})
+                else:
+                    retry_msg = retry_template.format(
+                        error=last_error,
+                        original=text[:1000],
+                        formula=last_formula,
+                        formulas=last_formula,
+                    )
+                    messages.append({"role": "user", "content": retry_msg})
+
+                response = await client.chat.completions.create(
+                    model=model_id,
+                    messages=messages,
+                )
+                raw = response.choices[0].message.content or ""
+                parsed = self._parse_llm_response(raw, logic_type)
+
+                if logic_type == "propositional":
+                    formula = parsed.get("formula", "")
+                    variables = parsed.get("variables", {})
+                    confidence = parsed.get("confidence", 0.7)
+                    last_formula = formula
+                else:
+                    formulas = parsed.get("formulas", [])
+                    formula = "; ".join(formulas) if formulas else ""
+                    variables = {
+                        **parsed.get("predicates", {}),
+                        **parsed.get("constants", {}),
+                    }
+                    confidence = parsed.get("confidence", 0.7)
+                    last_formula = formula
+
+                # Validate via Tweety or Python fallback
+                is_valid, val_msg = await self._validate_formula(formula, logic_type)
+
+                if is_valid:
+                    return TranslationResult(
+                        original_text=text,
+                        formula=formula,
+                        logic_type=logic_type,
+                        is_valid=True,
+                        validation_message=val_msg,
+                        attempts=attempt,
+                        variables=variables,
+                        confidence=confidence,
+                    )
+
+                last_error = val_msg
+                logger.info(
+                    f"Translation attempt {attempt}/{self.max_retries} invalid: {val_msg}"
+                )
+
+            except Exception as e:
+                last_error = str(e)
+                logger.warning(f"LLM call failed on attempt {attempt}: {e}")
+
+        # All retries exhausted — return last attempt as invalid
+        return TranslationResult(
+            original_text=text,
+            formula=last_formula,
+            logic_type=logic_type,
+            is_valid=False,
+            validation_message=f"Failed after {self.max_retries} attempts: {last_error}",
+            attempts=self.max_retries,
+            variables=variables,
+            confidence=0.0,
+        )
+
+    def _parse_llm_response(self, raw: str, logic_type: str) -> Dict[str, Any]:
+        """Extract JSON from LLM response, handling markdown fences."""
+        text = raw.strip()
+        if "```json" in text:
+            text = text.split("```json")[1].split("```")[0]
+        elif "```" in text:
+            text = text.split("```")[1].split("```")[0]
+
+        start = text.find("{")
+        end = text.rfind("}") + 1
+        if start >= 0 and end > start:
+            return json.loads(text[start:end])
+        return {}
+
+    # ── Validation ───────────────────────────────────────────────────
+
+    async def _validate_formula(
+        self,
+        formula: str,
+        logic_type: str,
+    ) -> Tuple[bool, str]:
+        """Validate formula via Tweety (JVM) or Python fallback."""
+        if not formula or not formula.strip():
+            return False, "Empty formula"
+
+        formula = normalize_operators(formula)
+
+        # Try Tweety validation first
+        try:
+            return await self._validate_with_tweety(formula, logic_type)
+        except Exception as e:
+            logger.debug(f"Tweety validation unavailable ({e}), using Python fallback")
+            return self._validate_with_python(formula, logic_type)
+
+    async def _validate_with_tweety(
+        self,
+        formula: str,
+        logic_type: str,
+    ) -> Tuple[bool, str]:
+        """Validate using TweetyBridge (requires JVM)."""
+        from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
+        bridge = TweetyBridge()
+
+        if logic_type == "propositional":
+            # Try to parse as PL formula
+            result = await asyncio.to_thread(
+                bridge.validate_pl_formula, formula
+            )
+            if result:
+                return True, "Valid propositional formula (Tweety)"
+            else:
+                return False, "Invalid propositional formula syntax"
+        else:
+            # FOL: try parsing each formula
+            fol_formulas = [f.strip() for f in formula.split(";") if f.strip()]
+            errors = []
+            for f in fol_formulas:
+                try:
+                    await asyncio.to_thread(
+                        bridge.fol_handler.parse_fol_formula, f
+                    )
+                except (ValueError, Exception) as e:
+                    errors.append(f"'{f}': {e}")
+            if errors:
+                return False, "; ".join(errors)
+            return True, "Valid FOL formulas (Tweety)"
+
+    def _validate_with_python(
+        self,
+        formula: str,
+        logic_type: str,
+    ) -> Tuple[bool, str]:
+        """Lightweight Python-based syntax validation (no JVM needed)."""
+        if logic_type == "propositional":
+            return self._validate_pl_python(formula)
+        else:
+            return self._validate_fol_python(formula)
+
+    def _validate_pl_python(self, formula: str) -> Tuple[bool, str]:
+        """Basic propositional logic syntax validation."""
+        # Check balanced parentheses
+        depth = 0
+        for ch in formula:
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+            if depth < 0:
+                return False, "Unmatched closing parenthesis"
+        if depth != 0:
+            return False, f"Unmatched parentheses (depth {depth})"
+
+        # Check for valid tokens
+        # Remove known operators and whitespace
+        cleaned = formula
+        for op in ["<=>", "=>", "&&", "||", "!"]:
+            cleaned = cleaned.replace(op, " ")
+        cleaned = cleaned.replace("(", " ").replace(")", " ")
+        tokens = cleaned.split()
+
+        # Each token should be a valid identifier
+        for token in tokens:
+            if not re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", token):
+                return False, f"Invalid token: '{token}'"
+
+        # Check for empty formula (just operators)
+        if not tokens:
+            return False, "Formula contains no propositions"
+
+        return True, "Valid propositional formula (Python)"
+
+    def _validate_fol_python(self, formula: str) -> Tuple[bool, str]:
+        """Basic FOL syntax validation."""
+        fol_formulas = [f.strip() for f in formula.split(";") if f.strip()]
+        if not fol_formulas:
+            return False, "No formulas found"
+
+        for f in fol_formulas:
+            # Check balanced parentheses
+            depth = 0
+            for ch in f:
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                if depth < 0:
+                    return False, f"Unmatched closing parenthesis in '{f}'"
+            if depth != 0:
+                return False, f"Unmatched parentheses in '{f}'"
+
+            # Check for predicates: at least one CamelCase word followed by (
+            if not re.search(r"[A-Z][a-zA-Z]*\(", f) and "forall" not in f and "exists" not in f:
+                return False, f"No predicates found in '{f}'"
+
+        return True, "Valid FOL formulas (Python)"
+
+    # ── Consistency checking ─────────────────────────────────────────
+
+    async def _check_consistency(
+        self,
+        formulas: List[str],
+        logic_type: str,
+    ) -> Tuple[bool, str]:
+        """Check if a set of formulas is consistent."""
+        try:
+            from argumentation_analysis.agents.core.logic.tweety_bridge import (
+                TweetyBridge,
+            )
+
+            bridge = TweetyBridge()
+            normalized = [normalize_operators(f) for f in formulas]
+            belief_set = "\n".join(normalized)
+            lt = "propositional" if logic_type == "propositional" else "first_order"
+            is_consistent, msg = await asyncio.to_thread(
+                bridge.check_consistency, belief_set, lt
+            )
+            return bool(is_consistent), msg
+        except Exception as e:
+            logger.debug(f"Tweety consistency check unavailable: {e}")
+            # Python fallback: check for obvious contradictions
+            return self._check_consistency_python(formulas, logic_type)
+
+    def _check_consistency_python(
+        self,
+        formulas: List[str],
+        logic_type: str,
+    ) -> Tuple[bool, str]:
+        """Lightweight contradiction detection (Python fallback)."""
+        positives = set()
+        negatives = set()
+        for f in formulas:
+            f = f.strip()
+            if f.startswith("!"):
+                negatives.add(f[1:].strip())
+            else:
+                # Only consider simple atoms
+                if re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", f):
+                    positives.add(f)
+
+        contradictions = positives & negatives
+        if contradictions:
+            return False, f"Contradictions found: {', '.join(contradictions)}"
+        return True, "No obvious contradictions (Python check)"
+
+    # ── Heuristic fallback ───────────────────────────────────────────
+
+    def _translate_heuristic(
+        self,
+        text: str,
+        logic_type: str,
+    ) -> TranslationResult:
+        """Simple heuristic translation when LLM is unavailable.
+
+        Extracts key terms and creates basic propositional variables.
+        """
+        # Extract simple propositions from argument markers
+        markers = [
+            "therefore", "because", "since", "thus", "hence",
+            "consequently", "so", "if", "then",
+            # French markers
+            "donc", "car", "puisque", "parce que", "si", "alors",
+        ]
+
+        sentences = re.split(r"[.!?;]", text)
+        sentences = [s.strip() for s in sentences if len(s.strip()) > 10]
+
+        if logic_type == "propositional":
+            variables = {}
+            for i, sent in enumerate(sentences[:5]):
+                var_name = f"p{i + 1}"
+                variables[var_name] = sent[:80]
+
+            if len(variables) >= 2:
+                var_names = list(variables.keys())
+                # Simple implication chain: p1 => p2 => ... => pN
+                implications = [
+                    f"{var_names[i]} => {var_names[i+1]}"
+                    for i in range(len(var_names) - 1)
+                ]
+                formula = " && ".join(
+                    [var_names[0]] + implications
+                )
+            elif variables:
+                formula = list(variables.keys())[0]
+            else:
+                formula = "p1"
+                variables = {"p1": text[:80]}
+
+            return TranslationResult(
+                original_text=text,
+                formula=formula,
+                logic_type="propositional",
+                is_valid=True,
+                validation_message="Heuristic translation (no LLM)",
+                attempts=0,
+                variables=variables,
+                confidence=0.3,
+            )
+
+        else:  # FOL
+            sentences_clean = [
+                re.sub(r"[^a-zA-Z0-9\s]", "", s).strip()
+                for s in sentences[:5]
+            ]
+            formulas = []
+            predicates = {}
+            for i, sent in enumerate(sentences_clean):
+                words = sent.split()
+                if len(words) >= 2:
+                    pred = words[0].capitalize()
+                    const = words[-1].lower()
+                    formulas.append(f"{pred}({const})")
+                    predicates[pred] = f"relates to {sent[:40]}"
+
+            formula = "; ".join(formulas) if formulas else "Stated(arg1)"
+            return TranslationResult(
+                original_text=text,
+                formula=formula,
+                logic_type="fol",
+                is_valid=True,
+                validation_message="Heuristic FOL translation (no LLM)",
+                attempts=0,
+                variables=predicates,
+                confidence=0.2,
+            )

--- a/tests/unit/argumentation_analysis/test_nl_to_logic.py
+++ b/tests/unit/argumentation_analysis/test_nl_to_logic.py
@@ -1,0 +1,404 @@
+"""
+Tests for NL-to-formal-logic translation service (#173).
+
+Tests the translate-validate-retry pipeline, heuristic fallback,
+Python validation, and pipeline integration.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+# ── Service unit tests ───────────────────────────────────────────────────
+
+
+class TestNLToLogicTranslator:
+    """Tests for NLToLogicTranslator service."""
+
+    def _make_translator(self, **kwargs):
+        from argumentation_analysis.services.nl_to_logic import NLToLogicTranslator
+
+        return NLToLogicTranslator(**kwargs)
+
+    # ── Heuristic fallback tests ─────────────────────────────────────
+
+    def test_heuristic_pl_translation(self):
+        """Heuristic produces valid PL formula from multi-sentence text."""
+        translator = self._make_translator(logic_type="propositional")
+        result = translator._translate_heuristic(
+            "Rain causes wet ground. Wet ground leads to slippery roads. "
+            "Slippery roads are dangerous for drivers.",
+            "propositional",
+        )
+        assert result.is_valid is True
+        assert result.logic_type == "propositional"
+        assert result.confidence == 0.3
+        assert "=>" in result.formula
+        assert len(result.variables) >= 2
+
+    def test_heuristic_fol_translation(self):
+        """Heuristic produces FOL predicates from text."""
+        translator = self._make_translator(logic_type="fol")
+        result = translator._translate_heuristic(
+            "Socrates is a human being. All humans are mortal creatures.",
+            "fol",
+        )
+        assert result.is_valid is True
+        assert result.logic_type == "fol"
+        assert result.confidence == 0.2
+        assert "(" in result.formula  # has predicates
+
+    def test_heuristic_single_sentence(self):
+        """Heuristic handles single sentence gracefully."""
+        translator = self._make_translator()
+        result = translator._translate_heuristic(
+            "This argument is about climate change and rising temperatures.",
+            "propositional",
+        )
+        assert result.is_valid is True
+        assert result.formula  # Non-empty
+
+    # ── Python validation tests ──────────────────────────────────────
+
+    def test_validate_pl_valid(self):
+        """Valid PL formula passes Python validation."""
+        translator = self._make_translator()
+        is_valid, msg = translator._validate_pl_python("p && (p => q)")
+        assert is_valid is True
+
+    def test_validate_pl_unmatched_parens(self):
+        """Unmatched parentheses are detected."""
+        translator = self._make_translator()
+        is_valid, msg = translator._validate_pl_python("p && (q => r")
+        assert is_valid is False
+        assert "parenthes" in msg.lower()
+
+    def test_validate_pl_invalid_token(self):
+        """Invalid tokens in PL formula are detected."""
+        translator = self._make_translator()
+        is_valid, msg = translator._validate_pl_python("p && 123abc")
+        assert is_valid is False
+        assert "Invalid token" in msg
+
+    def test_validate_pl_empty(self):
+        """Empty formula is invalid."""
+        translator = self._make_translator()
+        is_valid, msg = translator._validate_pl_python("")
+        assert is_valid is False
+
+    def test_validate_fol_valid(self):
+        """Valid FOL formula passes Python validation."""
+        translator = self._make_translator()
+        is_valid, msg = translator._validate_fol_python(
+            "forall X: (Human(X) => Mortal(X)); Human(socrates)"
+        )
+        assert is_valid is True
+
+    def test_validate_fol_no_predicates(self):
+        """FOL formula without predicates is invalid."""
+        translator = self._make_translator()
+        is_valid, msg = translator._validate_fol_python("x && y")
+        assert is_valid is False
+        assert "predicate" in msg.lower()
+
+    def test_validate_fol_unmatched_parens(self):
+        """FOL with unmatched parentheses is invalid."""
+        translator = self._make_translator()
+        is_valid, msg = translator._validate_fol_python("Human(socrates")
+        assert is_valid is False
+
+    # ── Consistency checking (Python fallback) ───────────────────────
+
+    def test_consistency_no_contradiction(self):
+        """No contradictions → consistent."""
+        translator = self._make_translator()
+        is_consistent, msg = translator._check_consistency_python(
+            ["p", "q", "r"], "propositional"
+        )
+        assert is_consistent is True
+
+    def test_consistency_with_contradiction(self):
+        """Direct contradiction detected."""
+        translator = self._make_translator()
+        is_consistent, msg = translator._check_consistency_python(
+            ["p", "!p"], "propositional"
+        )
+        assert is_consistent is False
+        assert "contradiction" in msg.lower()
+
+    # ── Operator normalization ───────────────────────────────────────
+
+    def test_normalize_operators(self):
+        """Unicode operators are replaced with ASCII."""
+        from argumentation_analysis.services.nl_to_logic import normalize_operators
+
+        result = normalize_operators("∀X: (Human(X) → Mortal(X)) ∧ ¬Dead(X)")
+        assert "forall" in result
+        assert "=>" in result
+        assert "&&" in result
+        assert "!" in result
+
+    # ── Async translate (with mock LLM) ──────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_translate_no_api_key_uses_heuristic(self):
+        """Without API key, translate falls back to heuristic."""
+        translator = self._make_translator()
+        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+            result = await translator.translate(
+                "All men are mortal. Socrates is a man. Therefore Socrates is mortal.",
+                logic_type="propositional",
+            )
+        assert result.is_valid is True
+        assert result.confidence <= 0.3  # heuristic confidence
+
+    @pytest.mark.asyncio
+    async def test_translate_with_mock_llm(self):
+        """LLM translation produces valid result when API succeeds."""
+        translator = self._make_translator()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            '{"formula": "mortal && human", '
+            '"variables": {"mortal": "all men are mortal", "human": "Socrates is human"}, '
+            '"confidence": 0.85}'
+        )
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        async def mock_validate(formula, logic_type):
+            return (True, "Valid (mocked)")
+
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}, clear=False):
+            with patch("openai.AsyncOpenAI", return_value=mock_client):
+                with patch.object(translator, "_validate_formula", mock_validate):
+                    result = await translator.translate(
+                        "All men are mortal. Socrates is a man.",
+                        logic_type="propositional",
+                    )
+
+        assert result.is_valid is True
+        assert result.formula == "mortal && human"
+        assert result.confidence == 0.85
+        assert result.attempts == 1
+
+    @pytest.mark.asyncio
+    async def test_translate_retry_on_invalid(self):
+        """LLM retries when first attempt produces invalid formula."""
+        translator = self._make_translator(max_retries=2)
+
+        # First response: invalid (unmatched parens)
+        bad_response = MagicMock()
+        bad_response.choices = [MagicMock()]
+        bad_response.choices[0].message.content = (
+            '{"formula": "p && (q", "variables": {"p": "x"}, "confidence": 0.5}'
+        )
+
+        # Second response: valid
+        good_response = MagicMock()
+        good_response.choices = [MagicMock()]
+        good_response.choices[0].message.content = (
+            '{"formula": "p && q && r", "variables": {"p": "x", "q": "y", "r": "z"}, "confidence": 0.8}'
+        )
+
+        mock_client = AsyncMock()
+        mock_client.chat.completions.create = AsyncMock(
+            side_effect=[bad_response, good_response]
+        )
+
+        # Use Python validation (not Tweety) for predictable behavior
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}, clear=False):
+            with patch("openai.AsyncOpenAI", return_value=mock_client):
+                with patch.object(
+                    translator,
+                    "_validate_formula",
+                    side_effect=[
+                        (False, "Unmatched parentheses"),  # first call: invalid
+                        (True, "Valid (mocked)"),  # second call: valid
+                    ],
+                ):
+                    result = await translator.translate(
+                        "Some argument text here that is long enough.",
+                        logic_type="propositional",
+                    )
+
+        assert result.is_valid is True
+        assert result.attempts == 2
+
+    # ── Batch translation ────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_translate_batch_heuristic(self):
+        """Batch translation works with heuristic fallback."""
+        translator = self._make_translator()
+        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+            batch = await translator.translate_batch(
+                [
+                    "Rain causes wet ground and slippery conditions.",
+                    "Climate change increases extreme weather events significantly.",
+                ],
+                logic_type="propositional",
+            )
+        assert len(batch.translations) == 2
+        assert all(t.is_valid for t in batch.translations)
+
+    @pytest.mark.asyncio
+    async def test_translate_batch_skips_short(self):
+        """Batch skips arguments shorter than 10 chars."""
+        translator = self._make_translator()
+        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+            batch = await translator.translate_batch(
+                ["short", "This is a sufficiently long argument about something."],
+                logic_type="propositional",
+            )
+        assert len(batch.translations) == 1
+
+
+# ── Pipeline integration tests ───────────────────────────────────────
+
+
+class TestNLToLogicPipelineIntegration:
+    """Tests for NL-to-logic integration in unified pipeline."""
+
+    def test_capability_registered(self):
+        """nl_to_logic_translation capability is registered in setup_registry."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            setup_registry,
+        )
+
+        registry = setup_registry(include_optional=False)
+        # Check capability exists
+        found = registry.find_agents_for_capability("nl_to_logic_translation")
+        assert found or "nl_to_logic_service" in str(
+            registry._registrations.keys()
+        )
+
+    def test_state_writer_in_dict(self):
+        """nl_to_logic_translation has a state writer."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            CAPABILITY_STATE_WRITERS,
+        )
+
+        assert "nl_to_logic_translation" in CAPABILITY_STATE_WRITERS
+
+    def test_workflow_in_catalog(self):
+        """nl_to_logic workflow appears in the catalog."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            get_workflow_catalog,
+        )
+
+        catalog = get_workflow_catalog()
+        assert "nl_to_logic" in catalog
+
+    def test_state_has_nl_to_logic_field(self):
+        """UnifiedAnalysisState has nl_to_logic_translations field."""
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+        state = UnifiedAnalysisState("test text")
+        assert hasattr(state, "nl_to_logic_translations")
+        assert isinstance(state.nl_to_logic_translations, list)
+
+    def test_state_add_translation(self):
+        """State correctly stores NL-to-logic translations."""
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+        state = UnifiedAnalysisState("test text")
+        tr_id = state.add_nl_to_logic_translation(
+            original_text="All men are mortal",
+            formula="forall X: (Man(X) => Mortal(X))",
+            logic_type="fol",
+            is_valid=True,
+            variables={"Man": "is a man", "Mortal": "is mortal"},
+            confidence=0.85,
+        )
+        assert tr_id.startswith("nll")
+        assert len(state.nl_to_logic_translations) == 1
+        assert state.nl_to_logic_translations[0]["is_valid"] is True
+
+    def test_state_writer_function(self):
+        """State writer correctly populates state from pipeline output."""
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _write_nl_to_logic_to_state,
+        )
+
+        state = UnifiedAnalysisState("test text")
+        output = {
+            "translations": [
+                {
+                    "original_text": "Rain implies wet ground",
+                    "formula": "rain => wet",
+                    "logic_type": "propositional",
+                    "is_valid": True,
+                    "variables": {"rain": "it rains", "wet": "ground is wet"},
+                    "confidence": 0.8,
+                },
+                {
+                    "original_text": "All humans are mortal",
+                    "formula": "forall X: (Human(X) => Mortal(X))",
+                    "logic_type": "fol",
+                    "is_valid": True,
+                    "variables": {},
+                    "confidence": 0.9,
+                },
+            ],
+            "total": 2,
+            "valid_count": 2,
+        }
+        _write_nl_to_logic_to_state(output, state, {})
+        assert len(state.nl_to_logic_translations) == 2
+
+    @pytest.mark.asyncio
+    async def test_invoke_nl_to_logic_heuristic(self):
+        """_invoke_nl_to_logic produces structured output."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_nl_to_logic,
+        )
+
+        context = {
+            "phase_extract_output": {
+                "arguments": [
+                    {"text": "Rain causes wet ground and dangerous conditions."},
+                    {"text": "Climate change accelerates extreme weather events globally."},
+                ],
+            },
+        }
+        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+            result = await _invoke_nl_to_logic("test input text", context)
+
+        assert "translations" in result
+        assert "valid_count" in result
+        assert "total" in result
+        assert result["total"] >= 1
+        assert result["method"] == "heuristic"
+
+
+# ── TranslationResult dataclass tests ────────────────────────────────
+
+
+class TestTranslationDataclasses:
+    """Tests for data structures."""
+
+    def test_translation_result_defaults(self):
+        from argumentation_analysis.services.nl_to_logic import TranslationResult
+
+        result = TranslationResult(
+            original_text="test",
+            formula="p => q",
+            logic_type="propositional",
+            is_valid=True,
+        )
+        assert result.attempts == 1
+        assert result.variables == {}
+        assert result.confidence == 0.0
+
+    def test_batch_result_defaults(self):
+        from argumentation_analysis.services.nl_to_logic import TranslationBatchResult
+
+        batch = TranslationBatchResult()
+        assert batch.translations == []
+        assert batch.overall_consistency is None
+        assert batch.method == "llm"


### PR DESCRIPTION
## Summary
- **New service** `argumentation_analysis/services/nl_to_logic.py`: LLM-based NL→formal logic translation with translate-validate-retry loop (max 3 attempts)
- Supports propositional logic and first-order logic (FOL), with prompt templates optimized per logic type
- Validates via Tweety (JVM) with Python fallback for syntax checking
- **Pipeline integration**: `_invoke_nl_to_logic` phase, state writer, registry registration
- **Dedicated workflow** `nl_to_logic`: extract → translate → PL/FOL reasoning
- Also added to `build_full_workflow` as optional phase

## Key design decision
Per QBF soutenance insight: LLM translation alone is unreliable. This implements a **translate-validate-retry** loop where validation errors are fed back to the LLM for self-correction.

## Test plan
- [x] 27 unit tests covering:
  - Heuristic fallback (PL + FOL)
  - Python syntax validation (parens, tokens, predicates)
  - Consistency checking (contradictions)
  - Unicode→ASCII operator normalization
  - Mock LLM translation with retry
  - Batch translation
  - Pipeline integration (registry, state writer, workflow catalog)
- [x] All tests pass locally

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)