### PR TITLE
feat: integrate CamemBERT fine-tuned fallacy detector as Tier 2.5 (#169)

### DIFF
--- a/argumentation_analysis/adapters/french_fallacy_adapter.py
+++ b/argumentation_analysis/adapters/french_fallacy_adapter.py
@@ -476,6 +476,184 @@ class NLIFallacyDetector:
             return []
 
 
+# ── Tier 2.5: CamemBERT Fine-Tuned Detection (#169) ─────────────────────
+
+# Maps CamemBERT's 13 output labels → standardized French labels
+_CAMEMBERT_LABEL_MAPPING = {
+    0: "Attaque personnelle (Ad Hominem)",
+    1: "Appel à la popularité (Ad Populum)",
+    2: "Appel à l'émotion (Appeal to Emotion)",
+    3: "Fallacy de crédibilité",
+    4: "Fallacy d'extension",
+    5: "Fallacy de logique",
+    6: "Généralisation hâtive (Hasty Generalization)",
+    7: "Fausse causalité (False Cause)",
+    8: "Faux dilemme (False Dilemma)",
+    9: "Intentionnel",
+    10: "Raisonnement circulaire (Circular Reasoning)",
+    11: "Sophisme de pertinence",
+    12: "Équivoque (Equivocation)",
+}
+
+
+class CamemBERTFallacyDetector:
+    """Fine-tuned CamemBERT for 13-category French fallacy classification.
+
+    Uses the model trained by student project 2.3.2 (Hamard) on a French
+    fallacy dataset. Gracefully degrades if the model or dependencies are
+    not available.
+
+    The model can be loaded from:
+    - A local directory (fine_tuned_camembert/)
+    - The student project directory (2.3.2-detection-sophismes/fine_tuned_camembert/)
+
+    Integration: Issue #169.
+    """
+
+    # Default model search paths (relative to project root)
+    _MODEL_SEARCH_PATHS = [
+        "fine_tuned_camembert",
+        "2.3.2-detection-sophismes/fine_tuned_camembert",
+        "models/camembert_fallacy",
+    ]
+
+    def __init__(
+        self,
+        model_path: Optional[str] = None,
+        threshold: float = 0.3,
+        max_length: int = 128,
+    ):
+        self._model_path = model_path
+        self._threshold = threshold
+        self._max_length = max_length
+        self._tokenizer = None
+        self._model = None
+        self._available = None
+
+    def _find_model_path(self) -> Optional[str]:
+        """Search for the fine-tuned model in known locations."""
+        if self._model_path:
+            p = Path(self._model_path)
+            if p.exists() and (p / "config.json").exists():
+                return str(p)
+            return None
+
+        # Search in known locations relative to project root
+        project_root = Path(__file__).resolve().parent.parent.parent
+        for rel_path in self._MODEL_SEARCH_PATHS:
+            candidate = project_root / rel_path
+            if candidate.exists() and (candidate / "config.json").exists():
+                logger.info(f"Found CamemBERT model at: {candidate}")
+                return str(candidate)
+        return None
+
+    def is_available(self) -> bool:
+        """Check if fine-tuned model exists and dependencies are installed."""
+        if self._available is not None:
+            return self._available
+
+        try:
+            import torch  # noqa: F401
+            from transformers import (  # noqa: F401
+                CamembertTokenizer,
+                CamembertForSequenceClassification,
+            )
+        except ImportError:
+            logger.debug("CamemBERT dependencies not available (torch/transformers)")
+            self._available = False
+            return False
+
+        model_path = self._find_model_path()
+        if model_path is None:
+            logger.info(
+                "CamemBERT fine-tuned model not found. "
+                "Tier 2.5 will be skipped. "
+                "To enable: place model in fine_tuned_camembert/ or "
+                "2.3.2-detection-sophismes/fine_tuned_camembert/"
+            )
+            self._available = False
+            return False
+
+        try:
+            from transformers import (
+                CamembertTokenizer,
+                CamembertForSequenceClassification,
+            )
+
+            self._tokenizer = CamembertTokenizer.from_pretrained(model_path)
+            self._model = CamembertForSequenceClassification.from_pretrained(model_path)
+            self._model.eval()
+            self._available = True
+            logger.info(f"CamemBERT fallacy detector loaded from {model_path}")
+        except Exception as e:
+            logger.warning(f"Failed to load CamemBERT model: {e}")
+            self._available = False
+
+        return self._available
+
+    def detect(self, text: str) -> List[FallacyDetection]:
+        """Classify text using fine-tuned CamemBERT.
+
+        Returns at most one detection (the highest-confidence class).
+        """
+        if not self.is_available():
+            return []
+
+        try:
+            import torch
+
+            inputs = self._tokenizer(
+                text,
+                return_tensors="pt",
+                truncation=True,
+                max_length=self._max_length,
+                padding=True,
+            )
+
+            with torch.no_grad():
+                outputs = self._model(**inputs)
+
+            logits = outputs.logits
+            probabilities = torch.softmax(logits, dim=1)
+            predicted_class_id = torch.argmax(probabilities, dim=1).item()
+            confidence = probabilities[0][predicted_class_id].item()
+
+            if confidence < self._threshold:
+                return []
+
+            fallacy_type = _CAMEMBERT_LABEL_MAPPING.get(
+                predicted_class_id, f"unknown_class_{predicted_class_id}"
+            )
+            taxonomy_pk = _TAXONOMY_LABEL_TO_PK.get(fallacy_type)
+
+            return [
+                FallacyDetection(
+                    fallacy_type=fallacy_type,
+                    confidence=round(confidence, 3),
+                    source="camembert",
+                    description=(
+                        f"CamemBERT fine-tuned classifier "
+                        f"[class={predicted_class_id}, conf={confidence:.3f}]"
+                    ),
+                    taxonomy_pk=taxonomy_pk,
+                )
+            ]
+
+        except Exception as e:
+            logger.error(f"CamemBERT detection failed: {e}")
+            return []
+
+    def get_status_details(self) -> Dict[str, Any]:
+        """Return detector status details."""
+        return {
+            "detector_type": "CamemBERTFallacyDetector",
+            "available": self.is_available(),
+            "model_path": self._find_model_path(),
+            "threshold": self._threshold,
+            "num_labels": len(_CAMEMBERT_LABEL_MAPPING),
+        }
+
+
 # ── Tier 1: LLM Zero-Shot Detection ─────────────────────────────────────
 
 
@@ -556,11 +734,18 @@ Si aucun sophisme n'est détecté, réponds: {"fallacies": []}"""
 
 
 class FrenchFallacyAdapter(AbstractFallacyDetector):
-    """3-tier French fallacy detection adapter.
+    """4-tier French fallacy detection adapter.
 
-    Combines symbolic rules, NLI zero-shot, and LLM zero-shot with
-    automatic fallback. Results are merged using an ensemble strategy
-    where symbolic matches (confidence=1.0) override neural/LLM scores.
+    Combines symbolic rules, CamemBERT fine-tuned, NLI zero-shot, and
+    LLM zero-shot with automatic fallback. Results are merged using an
+    ensemble strategy where symbolic matches (confidence=1.0) override
+    neural/LLM scores.
+
+    Tier hierarchy (fastest → most capable):
+      Tier 3:   Symbolic (spaCy Matcher, always available)
+      Tier 2.5: CamemBERT fine-tuned (13-class, offline, #169)
+      Tier 2:   NLI zero-shot (mDeBERTa, 28-class)
+      Tier 1:   LLM zero-shot (via ServiceDiscovery)
 
     Register with CapabilityRegistry:
         registry.register_service(
@@ -574,13 +759,24 @@ class FrenchFallacyAdapter(AbstractFallacyDetector):
     def __init__(
         self,
         enable_symbolic: bool = True,
+        enable_camembert: bool = True,
         enable_nli: bool = True,
         enable_llm: bool = True,
+        camembert_model_path: Optional[str] = None,
+        camembert_threshold: float = 0.3,
         nli_model: Optional[str] = None,
         nli_threshold: float = 0.5,
         service_discovery=None,
     ):
         self._symbolic = SymbolicFallacyDetector() if enable_symbolic else None
+        self._camembert = (
+            CamemBERTFallacyDetector(
+                model_path=camembert_model_path,
+                threshold=camembert_threshold,
+            )
+            if enable_camembert
+            else None
+        )
         self._nli = (
             NLIFallacyDetector(model_name=nli_model, threshold=nli_threshold)
             if enable_nli
@@ -596,7 +792,7 @@ class FrenchFallacyAdapter(AbstractFallacyDetector):
         """At least one tier must be available."""
         return any(
             t is not None and t.is_available()
-            for t in [self._symbolic, self._nli, self._llm]
+            for t in [self._symbolic, self._camembert, self._nli, self._llm]
         )
 
     def get_available_tiers(self) -> List[str]:
@@ -604,6 +800,8 @@ class FrenchFallacyAdapter(AbstractFallacyDetector):
         tiers = []
         if self._symbolic and self._symbolic.is_available():
             tiers.append("symbolic")
+        if self._camembert and self._camembert.is_available():
+            tiers.append("camembert")
         if self._nli and self._nli.is_available():
             tiers.append("nli")
         if self._llm and self._llm.is_available():
@@ -632,6 +830,13 @@ class FrenchFallacyAdapter(AbstractFallacyDetector):
             all_detections.extend(symbolic_results)
             if symbolic_results:
                 result.tiers_used.append("symbolic")
+
+        # Tier 2.5: CamemBERT fine-tuned (#169)
+        if self._camembert and self._camembert.is_available():
+            camembert_results = self._camembert.detect(text)
+            all_detections.extend(camembert_results)
+            if camembert_results:
+                result.tiers_used.append("camembert")
 
         # Tier 2: NLI zero-shot
         if self._nli and self._nli.is_available():

--- a/tests/unit/argumentation_analysis/test_camembert_integration.py
+++ b/tests/unit/argumentation_analysis/test_camembert_integration.py
@@ -1,0 +1,334 @@
+"""
+Tests for CamemBERT fine-tuned fallacy detector integration (#169).
+
+Tests the CamemBERTFallacyDetector class, its integration into
+FrenchFallacyAdapter, label mapping, and graceful degradation.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch, PropertyMock
+from pathlib import Path
+
+
+# ── CamemBERT label mapping tests ────────────────────────────────────
+
+
+class TestCamemBERTLabelMapping:
+    """Tests for the label mapping from CamemBERT's 13 classes."""
+
+    def test_all_13_labels_mapped(self):
+        """All 13 CamemBERT output classes have French label mappings."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            _CAMEMBERT_LABEL_MAPPING,
+        )
+
+        assert len(_CAMEMBERT_LABEL_MAPPING) == 13
+        for i in range(13):
+            assert i in _CAMEMBERT_LABEL_MAPPING
+            assert isinstance(_CAMEMBERT_LABEL_MAPPING[i], str)
+            assert len(_CAMEMBERT_LABEL_MAPPING[i]) > 0
+
+    def test_known_labels(self):
+        """Spot-check specific label mappings."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            _CAMEMBERT_LABEL_MAPPING,
+        )
+
+        assert _CAMEMBERT_LABEL_MAPPING[0] == "Attaque personnelle (Ad Hominem)"
+        assert _CAMEMBERT_LABEL_MAPPING[7] == "Fausse causalité (False Cause)"
+        assert _CAMEMBERT_LABEL_MAPPING[12] == "Équivoque (Equivocation)"
+
+
+# ── CamemBERTFallacyDetector unit tests ──────────────────────────────
+
+
+class TestCamemBERTFallacyDetector:
+    """Tests for CamemBERTFallacyDetector class."""
+
+    def _make_detector(self, **kwargs):
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            CamemBERTFallacyDetector,
+        )
+
+        return CamemBERTFallacyDetector(**kwargs)
+
+    def test_not_available_without_model(self):
+        """Detector reports unavailable when model not found."""
+        detector = self._make_detector(model_path="/nonexistent/path")
+        assert detector.is_available() is False
+
+    def test_not_available_without_transformers(self):
+        """Detector reports unavailable when transformers not installed."""
+        detector = self._make_detector()
+        with patch.dict("sys.modules", {"transformers": None}):
+            # Reset cached availability
+            detector._available = None
+            # Will fail on import
+            result = detector.is_available()
+            # May or may not be available depending on actual env
+            # Just test it doesn't crash
+            assert isinstance(result, bool)
+
+    def test_detect_returns_empty_when_unavailable(self):
+        """detect() returns empty list when model not available."""
+        detector = self._make_detector(model_path="/nonexistent/path")
+        results = detector.detect("Cet argument est fallacieux.")
+        assert results == []
+
+    def test_detect_with_mock_model(self):
+        """detect() returns correct FallacyDetection with mocked model."""
+        import torch
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            CamemBERTFallacyDetector,
+            FallacyDetection,
+        )
+
+        detector = CamemBERTFallacyDetector(threshold=0.3)
+
+        # Mock tokenizer and model
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {"input_ids": torch.tensor([[1, 2, 3]])}
+
+        # Create mock output with logits for class 0 (Ad Hominem) having highest score
+        mock_logits = torch.tensor([[5.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]])
+        mock_output = MagicMock()
+        mock_output.logits = mock_logits
+
+        mock_model = MagicMock()
+        mock_model.return_value = mock_output
+
+        detector._tokenizer = mock_tokenizer
+        detector._model = mock_model
+        detector._available = True
+
+        results = detector.detect("Tu es stupide donc ton argument est faux.")
+
+        assert len(results) == 1
+        assert isinstance(results[0], FallacyDetection)
+        assert results[0].fallacy_type == "Attaque personnelle (Ad Hominem)"
+        assert results[0].source == "camembert"
+        assert results[0].confidence > 0.5
+
+    def test_detect_below_threshold(self):
+        """detect() returns empty when confidence below threshold."""
+        import torch
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            CamemBERTFallacyDetector,
+        )
+
+        detector = CamemBERTFallacyDetector(threshold=0.99)
+
+        mock_tokenizer = MagicMock()
+        mock_tokenizer.return_value = {"input_ids": torch.tensor([[1, 2, 3]])}
+
+        # Uniform logits → all classes ~0.077 confidence → below 0.99
+        mock_logits = torch.tensor([[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]])
+        mock_output = MagicMock()
+        mock_output.logits = mock_logits
+
+        mock_model = MagicMock()
+        mock_model.return_value = mock_output
+
+        detector._tokenizer = mock_tokenizer
+        detector._model = mock_model
+        detector._available = True
+
+        results = detector.detect("Un texte quelconque.")
+        assert results == []
+
+    def test_model_path_search(self):
+        """_find_model_path searches in known locations."""
+        detector = self._make_detector()
+        # Without a real model, should return None
+        path = detector._find_model_path()
+        # Just verify it doesn't crash and returns str or None
+        assert path is None or isinstance(path, str)
+
+    def test_get_status_details(self):
+        """get_status_details returns structured info."""
+        detector = self._make_detector()
+        status = detector.get_status_details()
+        assert status["detector_type"] == "CamemBERTFallacyDetector"
+        assert "available" in status
+        assert "threshold" in status
+        assert status["num_labels"] == 13
+
+
+# ── FrenchFallacyAdapter integration tests ───────────────────────────
+
+
+class TestFrenchFallacyAdapterCamemBERT:
+    """Tests for CamemBERT integration into FrenchFallacyAdapter."""
+
+    def test_adapter_has_camembert_tier(self):
+        """Adapter creates CamemBERT detector by default."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            FrenchFallacyAdapter,
+            CamemBERTFallacyDetector,
+        )
+
+        adapter = FrenchFallacyAdapter(
+            enable_symbolic=False,
+            enable_nli=False,
+            enable_llm=False,
+            enable_camembert=True,
+        )
+        assert adapter._camembert is not None
+        assert isinstance(adapter._camembert, CamemBERTFallacyDetector)
+
+    def test_adapter_disables_camembert(self):
+        """Adapter skips CamemBERT when disabled."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            FrenchFallacyAdapter,
+        )
+
+        adapter = FrenchFallacyAdapter(
+            enable_symbolic=False,
+            enable_nli=False,
+            enable_llm=False,
+            enable_camembert=False,
+        )
+        assert adapter._camembert is None
+
+    def test_available_tiers_includes_camembert(self):
+        """get_available_tiers includes 'camembert' when model is available."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            FrenchFallacyAdapter,
+        )
+
+        adapter = FrenchFallacyAdapter(
+            enable_symbolic=False,
+            enable_nli=False,
+            enable_llm=False,
+            enable_camembert=True,
+        )
+        # Mock CamemBERT as available
+        adapter._camembert._available = True
+
+        tiers = adapter.get_available_tiers()
+        assert "camembert" in tiers
+
+    def test_detect_uses_camembert_tier(self):
+        """detect() invokes CamemBERT tier when available."""
+        import torch
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            FrenchFallacyAdapter,
+            FallacyDetection,
+        )
+
+        adapter = FrenchFallacyAdapter(
+            enable_symbolic=False,
+            enable_nli=False,
+            enable_llm=False,
+            enable_camembert=True,
+        )
+
+        # Mock the CamemBERT detector's detect method
+        mock_detection = FallacyDetection(
+            fallacy_type="Fausse causalité (False Cause)",
+            confidence=0.85,
+            source="camembert",
+        )
+        adapter._camembert._available = True
+        adapter._camembert.detect = MagicMock(return_value=[mock_detection])
+
+        result = adapter.detect("Le soleil brille donc il fait chaud.")
+
+        assert result["total_fallacies"] == 1
+        assert "camembert" in result["tiers_used"]
+        assert "Fausse causalité (False Cause)" in result["detected_fallacies"]
+
+    def test_graceful_degradation(self):
+        """Adapter works when CamemBERT is unavailable."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            FrenchFallacyAdapter,
+        )
+
+        adapter = FrenchFallacyAdapter(
+            enable_symbolic=False,
+            enable_nli=False,
+            enable_llm=False,
+            enable_camembert=True,
+        )
+        # CamemBERT unavailable (no model)
+        adapter._camembert._available = False
+
+        result = adapter.detect("Un texte normal.")
+        # Should still work, just no detections
+        assert isinstance(result, dict)
+        assert "tiers_used" in result
+        assert "camembert" not in result["tiers_used"]
+
+    def test_camembert_custom_path(self):
+        """Adapter passes custom model path to CamemBERT detector."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            FrenchFallacyAdapter,
+        )
+
+        adapter = FrenchFallacyAdapter(
+            enable_symbolic=False,
+            enable_nli=False,
+            enable_llm=False,
+            enable_camembert=True,
+            camembert_model_path="/custom/model/path",
+        )
+        assert adapter._camembert._model_path == "/custom/model/path"
+
+    def test_camembert_custom_threshold(self):
+        """Adapter passes custom threshold to CamemBERT detector."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            FrenchFallacyAdapter,
+        )
+
+        adapter = FrenchFallacyAdapter(
+            enable_symbolic=False,
+            enable_nli=False,
+            enable_llm=False,
+            enable_camembert=True,
+            camembert_threshold=0.7,
+        )
+        assert adapter._camembert._threshold == 0.7
+
+    def test_ensemble_camembert_with_symbolic(self):
+        """Ensemble correctly merges CamemBERT + symbolic detections."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            FrenchFallacyAdapter,
+            FallacyDetection,
+        )
+
+        adapter = FrenchFallacyAdapter(
+            enable_symbolic=True,
+            enable_nli=False,
+            enable_llm=False,
+            enable_camembert=True,
+        )
+
+        # Mock both tiers detecting same fallacy
+        symbolic_det = FallacyDetection(
+            fallacy_type="Attaque personnelle (Ad Hominem)",
+            confidence=1.0,
+            source="symbolic",
+            matched_rule="tu es ... donc",
+        )
+        camembert_det = FallacyDetection(
+            fallacy_type="Attaque personnelle (Ad Hominem)",
+            confidence=0.9,
+            source="camembert",
+        )
+
+        # Mock symbolic and camembert
+        adapter._symbolic._available = True
+        adapter._symbolic.detect = MagicMock(return_value=[symbolic_det])
+        adapter._symbolic.mine_arguments = MagicMock(return_value=None)
+        adapter._camembert._available = True
+        adapter._camembert.detect = MagicMock(return_value=[camembert_det])
+
+        result = adapter.detect("Tu es stupide donc ton argument est faux.")
+
+        assert result["total_fallacies"] == 1  # Merged, not duplicated
+        ad_hominem = result["detected_fallacies"]["Attaque personnelle (Ad Hominem)"]
+        # Symbolic (confidence=1.0) should win
+        assert ad_hominem["confidence"] == 1.0
+        # Source should be concatenated
+        assert "symbolic" in ad_hominem["source"]
+        assert "camembert" in ad_hominem["source"]


### PR DESCRIPTION
## Summary
- **New class** `CamemBERTFallacyDetector` in `french_fallacy_adapter.py`: fine-tuned CamemBERT (13-class) for offline fallacy classification
- **4-tier pipeline** (was 3): Symbolic → CamemBERT → NLI → LLM, with automatic fallback
- Auto-discovers model in `fine_tuned_camembert/` or `2.3.2-detection-sophismes/fine_tuned_camembert/`
- Graceful degradation: skips tier silently when model or dependencies are absent
- Label mapping from CamemBERT's 13 output classes to standardized French taxonomy
- Ensemble merging: symbolic (confidence=1.0) overrides neural scores

## Why Tier 2.5?
- Faster than LLM (no API call, offline-capable)
- More task-specific than NLI zero-shot (trained on fallacy data)
- Slower than symbolic rules (needs GPU/CPU inference)
- Reduces API dependency for fallacy detection

## Test plan
- [x] 17 unit tests covering:
  - Label mapping completeness and correctness
  - Detector availability checks (model present/absent, deps missing)
  - Detection with mock model (confidence, thresholds)
  - Adapter integration (enable/disable, tiers list, detect flow)
  - Graceful degradation when model unavailable
  - Ensemble merging with symbolic tier
  - Custom path and threshold configuration
- [x] All tests pass locally

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)