### PR TITLE
feat(orchestration): replace fake AgentGroupChat with SK native (#212)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_executor.py
+++ b/argumentation_analysis/orchestration/conversational_executor.py
@@ -260,10 +260,12 @@ class GroupChatTurnStrategy(TurnStrategy):
         agents: List[Any],
         selection_strategy: Optional[Any] = None,
         termination_strategy: Optional[Any] = None,
+        maximum_iterations: int = 25,
     ):
         self._agents = agents
         self._selection = selection_strategy
         self._termination = termination_strategy
+        self._maximum_iterations = maximum_iterations
 
     # ------------------------------------------------------------------
     # Strategy adapters: project base.py → SK native
@@ -304,8 +306,7 @@ class GroupChatTurnStrategy(TurnStrategy):
         except Exception:
             return strategy
 
-    @staticmethod
-    def _wrap_termination_strategy(strategy: Any) -> Any:
+    def _wrap_termination_strategy(self, strategy: Any) -> Any:
         """Wrap a base.py TerminationStrategy as an SK-native one if needed."""
         if strategy is None:
             return None
@@ -334,7 +335,7 @@ class GroupChatTurnStrategy(TurnStrategy):
                 async def should_terminate(self, agent: Any, history: list) -> bool:
                     return await self._inner.should_terminate(agent, history)
 
-            return _Adapter(inner=strategy, maximum_iterations=100)
+            return _Adapter(inner=strategy, maximum_iterations=self._maximum_iterations)
         except Exception:
             return strategy
 
@@ -409,7 +410,7 @@ class GroupChatTurnStrategy(TurnStrategy):
             # Seed the chat history with the user input so agents have
             # something to respond to.
             if input_data is not None:
-                chat.add_chat_message(
+                await chat.add_chat_message(
                     ChatMessageContent(
                         role=AuthorRole.USER,
                         content=str(input_data),

--- a/tests/unit/argumentation_analysis/orchestration/test_groupchat_turn_strategy.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_groupchat_turn_strategy.py
@@ -38,7 +38,8 @@ class TestStrategyAdapters:
         assert GroupChatTurnStrategy._wrap_selection_strategy(None) is None
 
     def test_wrap_none_termination_returns_none(self):
-        assert GroupChatTurnStrategy._wrap_termination_strategy(None) is None
+        strategy = GroupChatTurnStrategy(agents=[])
+        assert strategy._wrap_termination_strategy(None) is None
 
     def test_wrap_sk_native_selection_passes_through(self):
         """If already an SK strategy, return as-is."""
@@ -61,7 +62,8 @@ class TestStrategyAdapters:
             )
 
             sk_strategy = DefaultTerminationStrategy(maximum_iterations=5)
-            result = GroupChatTurnStrategy._wrap_termination_strategy(sk_strategy)
+            strategy = GroupChatTurnStrategy(agents=[])
+            result = strategy._wrap_termination_strategy(sk_strategy)
             assert result is sk_strategy
         except ImportError:
             pytest.skip("SK not available")
@@ -104,7 +106,8 @@ class TestStrategyAdapters:
                 return len(history) > 5
 
         strategy = DummyTermination()
-        result = GroupChatTurnStrategy._wrap_termination_strategy(strategy)
+        gcs = GroupChatTurnStrategy(agents=[])
+        result = gcs._wrap_termination_strategy(strategy)
         assert isinstance(result, SKTerminationStrategy)
 
 
@@ -285,3 +288,55 @@ class TestIntegrationWithSK:
         assert len(result.phase_results) >= 2
         assert result.needs_refinement is False
         assert result.duration_seconds >= 0
+
+    def test_maximum_iterations_parameter(self):
+        """maximum_iterations should be configurable, not hardcoded."""
+        strategy = GroupChatTurnStrategy(agents=[], maximum_iterations=42)
+        assert strategy._maximum_iterations == 42
+
+    def test_default_maximum_iterations(self):
+        """Default maximum_iterations should be 25."""
+        strategy = GroupChatTurnStrategy(agents=[])
+        assert strategy._maximum_iterations == 25
+
+    @pytest.mark.asyncio
+    async def test_await_add_chat_message(self):
+        """Verify add_chat_message is awaited (regression test for #219 review)."""
+        strategy = GroupChatTurnStrategy(agents=[MagicMock(), MagicMock()])
+
+        # We can't run a real SK AgentGroupChat without an LLM, but we can
+        # verify the code path calls await on add_chat_message by checking
+        # it doesn't produce a RuntimeWarning about unawaited coroutines.
+        try:
+            from semantic_kernel.agents.group_chat.agent_group_chat import (
+                AgentGroupChat,
+            )
+        except ImportError:
+            pytest.skip("SK AgentGroupChat not available")
+
+        import warnings
+
+        # Patch AgentGroupChat to track the call without needing a real LLM
+        mock_chat = AsyncMock()
+        mock_chat.add_chat_message = AsyncMock()
+
+        async def empty_invoke():
+            return
+            yield  # make it an async generator
+
+        mock_chat.invoke = empty_invoke
+
+        with patch(
+            "semantic_kernel.agents.group_chat.agent_group_chat.AgentGroupChat",
+            return_value=mock_chat,
+        ):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                result = await strategy._run_sk_native("test input", {"turn_number": 1})
+                # Check no RuntimeWarning about unawaited coroutine
+                coroutine_warnings = [
+                    x for x in w if "coroutine" in str(x.message).lower()
+                ]
+                assert (
+                    len(coroutine_warnings) == 0
+                ), f"Unawaited coroutine warnings detected: {coroutine_warnings}"


### PR DESCRIPTION
## Summary
- `GroupChatTurnStrategy` now uses the **real Semantic Kernel `AgentGroupChat`** (async generator API) instead of the sequential compatibility shim
- Automatic fallback to `cluedo_extended_orchestrator.AgentGroupChat` if SK import fails
- Strategy adapters bridge `base.py` `SelectionStrategy`/`TerminationStrategy` to SK-native equivalents
- Seeds chat history with user input via `add_chat_message()` before invoking agents

## Key changes
- `conversational_executor.py` — Rewrote `GroupChatTurnStrategy.execute_turn()` with `_run_sk_native()` (primary) and `_run_fallback()` (compatibility). Added `_wrap_selection_strategy()` and `_wrap_termination_strategy()` adapter methods.
- `test_groupchat_turn_strategy.py` — 17 tests covering: strategy adapters (6), SK native execution (3), fallback execution (2), message conversion (5), integration (1)

## Acceptance criteria (from #212)
- [x] `GroupChatTurnStrategy.execute_turn()` produces a `TurnResult` with messages from MULTIPLE agents (not just the first)
- [x] SK native `AgentGroupChat` used when available
- [x] Fallback preserved for environments without SK

## Test plan
- [x] 17/17 new tests pass
- [x] Black formatted

Closes #212
Part of Epic #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)