### PR TITLE
fix(.env): load dotenv in all pipeline entry points (#208-A)

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,15 @@
 import glob
 import logging
 from pathlib import Path
+
+# Load .env for API keys before any other imports (#208-A)
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(override=False)
+except ImportError:
+    pass
+
 from .factory import create_app
 from .endpoints import router as api_router, framework_router, informal_router
 from .proposal_endpoints import proposal_router

--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -15,6 +15,7 @@ This module ties together the Lego architecture built in Phases 0-4:
 import asyncio
 import json
 import logging
+import os
 from typing import Dict, Any, Optional, List
 
 from argumentation_analysis.core.capability_registry import (
@@ -31,6 +32,29 @@ from argumentation_analysis.orchestration.workflow_dsl import (
 )
 
 logger = logging.getLogger("UnifiedPipeline")
+
+# ── .env loading (#208-A) ────────────────────────────────────────────────
+# Ensure .env is loaded before any invoke callable reads OPENAI_API_KEY.
+# This is idempotent — calling load_dotenv() multiple times is safe.
+_dotenv_loaded = False
+
+
+def _ensure_dotenv() -> None:
+    """Load .env file if not already loaded. Idempotent, no-op if dotenv missing."""
+    global _dotenv_loaded
+    if _dotenv_loaded:
+        return
+    _dotenv_loaded = True
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(override=False)
+        if os.environ.get("OPENAI_API_KEY"):
+            logger.debug(".env loaded — OPENAI_API_KEY is set")
+        else:
+            logger.debug(".env loaded but OPENAI_API_KEY not found")
+    except ImportError:
+        pass  # python-dotenv not installed — env vars must come from elsewhere
 
 
 # --- Invoke callables for registered components ---
@@ -2984,6 +3008,8 @@ def setup_registry(
     Returns:
         Populated CapabilityRegistry instance.
     """
+    _ensure_dotenv()  # Load .env before registering LLM-dependent components (#208-A)
+
     registry = CapabilityRegistry()
     registered = []
     skipped = []
@@ -3816,6 +3842,8 @@ async def run_unified_analysis(
             - unified_state: UnifiedAnalysisState (if state tracking enabled)
             - state_snapshot: Dict snapshot of the state (if state tracking enabled)
     """
+    _ensure_dotenv()  # Load .env before any LLM calls (#208-A)
+
     if registry is None:
         registry = setup_registry()
 

--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -87,11 +87,27 @@ def list_workflows() -> None:
 async def setup_environment() -> Any:
     """Initialise l'environnement nécessaire pour l'orchestration.
 
-    Charge les variables d'environnement, initialise la JVM et crée le service LLM.
+    Charge les variables d'environnement depuis .env, initialise la JVM
+    et crée le service LLM.
 
     :return: L'instance du service LLM si la création est réussie, sinon None.
     :rtype: Any
     """
+    # Load .env BEFORE any os.environ.get() calls (#208-A)
+    try:
+        from dotenv import load_dotenv
+
+        loaded = load_dotenv(override=False)
+        if loaded:
+            logging.info(".env chargé avec succès.")
+        else:
+            logging.debug(".env non trouvé ou déjà chargé.")
+    except ImportError:
+        logging.warning(
+            "python-dotenv non installé — les variables .env ne seront pas chargées. "
+            "Installez avec: pip install python-dotenv"
+        )
+
     logging.info(
         "Initialisation de l'environnement (chargement des settings implicite)..."
     )

--- a/interface_web/app.py
+++ b/interface_web/app.py
@@ -32,6 +32,14 @@ from starlette.routing import Mount, Route
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
 
+# --- Load .env for API keys (#208-A) ---
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(override=False)
+except ImportError:
+    pass
+
 # --- Activation de l'environnement et imports du projet ---
 try:
     from scripts.core.auto_env import ensure_env


### PR DESCRIPTION
## Summary
- All LLM features were **silently disabled** because `.env` was never loaded in the pipeline entry points
- `os.environ.get("OPENAI_API_KEY")` returned `""` in every invoke callable → 0% fallacy detection, empty debates, regex-only quality scoring

## Changes
- `run_orchestration.py::setup_environment()` — `load_dotenv()` at start
- `unified_pipeline.py` — idempotent `_ensure_dotenv()` helper called from `setup_registry()` and `run_unified_analysis()`
- `interface_web/app.py` — `load_dotenv()` before app imports
- `api/main.py` — `load_dotenv()` before app imports

## Test plan
- [x] `_ensure_dotenv()` correctly loads OPENAI_API_KEY from .env
- [x] Graceful degradation when python-dotenv not installed
- [x] Idempotent (safe to call multiple times)

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)