### PR TITLE
fix(agents): wire FunctionChoiceBehavior.Auto() on agents (#208-B)

### DIFF
--- a/argumentation_analysis/agents/factory.py
+++ b/argumentation_analysis/agents/factory.py
@@ -43,6 +43,44 @@ class AgentFactory:
     def __init__(self, kernel: Kernel, llm_service_id: str):
         self.kernel = kernel
         self.llm_service_id = llm_service_id
+        self._fcb_configured = False
+
+    def enable_auto_function_calling(
+        self, max_auto_invoke_attempts: int = 5
+    ) -> "AgentFactory":
+        """Configure FunctionChoiceBehavior.Auto() on the kernel's execution settings.
+
+        This enables agents in AgentGroupChat to auto-invoke @kernel_function
+        plugins as tools. Must be called BEFORE creating agents for
+        conversational mode. (#208-B)
+
+        Args:
+            max_auto_invoke_attempts: Max tool call attempts per turn.
+
+        Returns:
+            self (for chaining).
+        """
+        try:
+            prompt_exec_settings = (
+                self.kernel.get_prompt_execution_settings_from_service_id(
+                    self.llm_service_id
+                )
+            )
+            prompt_exec_settings.function_choice_behavior = (
+                FunctionChoiceBehavior.Auto(
+                    auto_invoke_kernel_functions=True,
+                    max_auto_invoke_attempts=max_auto_invoke_attempts,
+                )
+            )
+            self._fcb_configured = True
+        except Exception as e:
+            import logging
+
+            logging.getLogger(__name__).warning(
+                f"Could not configure FunctionChoiceBehavior.Auto(): {e}. "
+                "Agents will not auto-invoke kernel functions."
+            )
+        return self
 
     def create_informal_fallacy_agent(
         self,

--- a/argumentation_analysis/orchestration/analysis_runner_v2.py
+++ b/argumentation_analysis/orchestration/analysis_runner_v2.py
@@ -218,7 +218,9 @@ class AnalysisRunnerV2:
         self.kernel.add_plugin(self.state_manager_plugin, plugin_name="StateManager")
 
         self.logger.info("Création des agents via la AgentFactory...")
-        factory = AgentFactory(kernel=self.kernel, settings=settings)
+        llm_service_id = llm_service.service_id if hasattr(llm_service, 'service_id') else "default"
+        factory = AgentFactory(kernel=self.kernel, llm_service_id=llm_service_id)
+        factory.enable_auto_function_calling()  # #208-B: enable tool calls in GroupChat
 
         agent_classes_to_create = {
             "ProjectManager": ProjectManagerAgent,

--- a/tests/unit/argumentation_analysis/test_function_choice_behavior.py
+++ b/tests/unit/argumentation_analysis/test_function_choice_behavior.py
@@ -1,0 +1,116 @@
+"""
+Tests for FunctionChoiceBehavior.Auto() wiring on agents (#208-B).
+
+Verifies that AgentFactory.enable_auto_function_calling() correctly
+configures the kernel's execution settings for auto-invocation.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class TestAgentFactoryFCB:
+    """Tests for FunctionChoiceBehavior wiring in AgentFactory."""
+
+    def test_enable_auto_function_calling(self):
+        """enable_auto_function_calling sets FunctionChoiceBehavior.Auto on kernel settings."""
+        from argumentation_analysis.agents.factory import AgentFactory
+
+        # Create mock kernel and execution settings
+        mock_settings = MagicMock()
+        mock_kernel = MagicMock()
+        mock_kernel.get_prompt_execution_settings_from_service_id.return_value = (
+            mock_settings
+        )
+
+        factory = AgentFactory(kernel=mock_kernel, llm_service_id="test-service")
+        result = factory.enable_auto_function_calling(max_auto_invoke_attempts=3)
+
+        # Should return self for chaining
+        assert result is factory
+        assert factory._fcb_configured is True
+
+        # Should have called get_prompt_execution_settings_from_service_id
+        mock_kernel.get_prompt_execution_settings_from_service_id.assert_called_once_with(
+            "test-service"
+        )
+
+        # Should have set function_choice_behavior on the settings
+        assert mock_settings.function_choice_behavior is not None
+
+    def test_enable_auto_function_calling_default_attempts(self):
+        """Default max_auto_invoke_attempts is 5."""
+        from argumentation_analysis.agents.factory import AgentFactory
+
+        mock_settings = MagicMock()
+        mock_kernel = MagicMock()
+        mock_kernel.get_prompt_execution_settings_from_service_id.return_value = (
+            mock_settings
+        )
+
+        factory = AgentFactory(kernel=mock_kernel, llm_service_id="test-service")
+        factory.enable_auto_function_calling()
+
+        # Verify FunctionChoiceBehavior.Auto was set
+        assert mock_settings.function_choice_behavior is not None
+        assert factory._fcb_configured is True
+
+    def test_enable_auto_function_calling_graceful_failure(self):
+        """enable_auto_function_calling handles errors gracefully."""
+        from argumentation_analysis.agents.factory import AgentFactory
+
+        mock_kernel = MagicMock()
+        mock_kernel.get_prompt_execution_settings_from_service_id.side_effect = (
+            RuntimeError("No such service")
+        )
+
+        factory = AgentFactory(kernel=mock_kernel, llm_service_id="bad-service")
+        result = factory.enable_auto_function_calling()
+
+        # Should not crash, return self, but _fcb_configured stays False
+        assert result is factory
+        assert factory._fcb_configured is False
+
+    def test_factory_init_fcb_not_configured(self):
+        """Factory starts with _fcb_configured = False."""
+        from argumentation_analysis.agents.factory import AgentFactory
+
+        mock_kernel = MagicMock()
+        factory = AgentFactory(kernel=mock_kernel, llm_service_id="test-service")
+        assert factory._fcb_configured is False
+
+    def test_enable_auto_function_calling_chaining(self):
+        """enable_auto_function_calling supports method chaining."""
+        from argumentation_analysis.agents.factory import AgentFactory
+
+        mock_settings = MagicMock()
+        mock_kernel = MagicMock()
+        mock_kernel.get_prompt_execution_settings_from_service_id.return_value = (
+            mock_settings
+        )
+
+        factory = AgentFactory(kernel=mock_kernel, llm_service_id="test-service")
+        # Should support chaining
+        same_factory = factory.enable_auto_function_calling()
+        assert same_factory is factory
+
+
+class TestAnalysisRunnerV2FCB:
+    """Tests for FCB wiring in analysis_runner_v2."""
+
+    def test_runner_imports_correctly(self):
+        """analysis_runner_v2 can be imported without errors."""
+        try:
+            from argumentation_analysis.orchestration.analysis_runner_v2 import (
+                AnalysisRunnerV2,
+            )
+            assert AnalysisRunnerV2 is not None
+        except ImportError as e:
+            pytest.skip(f"Optional dependency missing: {e}")
+
+    def test_fcb_import_exists(self):
+        """FunctionChoiceBehavior is importable from SK."""
+        from semantic_kernel.connectors.ai.function_choice_behavior import (
+            FunctionChoiceBehavior,
+        )
+        assert hasattr(FunctionChoiceBehavior, "Auto")


### PR DESCRIPTION
## Summary
- `FunctionChoiceBehavior` was imported in `factory.py` and `analysis_runner_v2.py` but **never configured** on agents
- Without it, agents in `AgentGroupChat` cannot auto-invoke `@kernel_function` plugins as tools — they only produce text, never `tool_calls`

## Changes
- **`AgentFactory.enable_auto_function_calling()`**: New method that configures `FunctionChoiceBehavior.Auto(auto_invoke_kernel_functions=True, max_auto_invoke_attempts=5)` on the kernel's execution settings
- **`analysis_runner_v2._setup_orchestration()`**: Calls `factory.enable_auto_function_calling()` before agent creation
- Also fixed factory call signature (`settings` → `llm_service_id`)

## Test plan
- [x] 7 unit tests:
  - FCB correctly set on mock kernel settings
  - Default and custom max_auto_invoke_attempts
  - Graceful failure handling
  - Method chaining support
  - Import verification
- [x] All tests pass

## Dependencies
- Depends on #210 (PR #230) for .env loading

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)