### PR TITLE
feat(fallacy): add CamemBERT Tier 2.5 to standard workflow (#208-J)

### DIFF
--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -3444,10 +3444,16 @@ def build_light_workflow() -> WorkflowDefinition:
 
 
 def build_standard_workflow() -> WorkflowDefinition:
-    """Standard 5-phase workflow with fact extraction and quality-gated counter-arguments."""
+    """Standard workflow with fact extraction, fallacy detection, and quality-gated counter-arguments."""
     return (
         WorkflowBuilder("standard_analysis")
         .add_phase("extract", capability="fact_extraction")
+        .add_phase(
+            "neural_fallacy",
+            capability="neural_fallacy_detection",
+            depends_on=["extract"],
+            optional=True,
+        )
         .add_phase("quality", capability="argument_quality", depends_on=["extract"])
         .add_phase(
             "counter",


### PR DESCRIPTION
## Summary
- CamemBERT fallacy detector (PR #206, merged) was only wired in `neural_symbolic` workflow
- Now added as **optional phase** in `standard` workflow (after extract, before quality)
- Gracefully skipped when model not installed

## Test plan
- [x] Standard workflow includes `neural_fallacy` phase
- [x] Phase is optional (no failure if model absent)
- [x] Existing workflow behavior unchanged

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)