### PR TITLE
docs: port recoverable documentation from rescue branch (#253)

### DIFF
--- a/docs/debugging/mcp_server.md
+++ b/docs/debugging/mcp_server.md
@@ -1,0 +1,121 @@
+# Débogage du Serveur MCP
+
+Ce document détaille les étapes de débogage pour les problèmes liés au serveur MCP.
+
+## Analyse du blocage du serveur principal
+
+### Contexte
+
+Le serveur MCP principal (`services/mcp_server/main.py`) se bloquait silencieusement au démarrage. Le script de diagnostic `diagnose_mcp_connection.py` restait bloqué sans erreur.
+
+### Étapes de débogage
+
+1.  **Amélioration du script de diagnostic** : Le script a été modifié pour inclure un timeout global de 15 secondes. Cela a permis de transformer le blocage silencieux en une erreur de timeout explicite.
+
+2.  **Isoler le problème par la méthode "diviser pour régner"** :
+    *   Les services (`AnalysisService`, `ValidationService`, etc.) dans `services/mcp_server/main.py` ont été commentés un par un. Le blocage persistait.
+    *   L'initialisation de `AppServices` a été commentée. Le blocage persistait.
+    *   L'initialisation de `initialize_project_environment` a été commentée. Le blocage persistait.
+    *   Cela a indiqué que le problème se situait au niveau des imports, avant même l'exécution de la logique principale.
+
+3.  **Analyse des imports dans `argumentation_analysis/core/bootstrap.py`** :
+    *   Chaque import de service ou de composant complexe a été commenté un par un. Le blocage persistait à chaque étape.
+    *   Cela a suggéré que le problème n'était pas lié à un seul module, mais à une condition d'environnement plus fondamentale.
+
+4.  **Exécution directe du serveur** :
+    *   L'exécution de `python services/mcp_server/main.py` a finalement révélé la véritable erreur, qui était masquée par l'exécution en sous-processus :
+        ```
+        RuntimeError: ERREUR CRITIQUE : L'ENVIRONNEMENT 'projet-is' N'EST PAS CORRECTEMENT ACTIVÉ.
+        ```
+
+### Cause racine identifiée
+
+Le blocage n'était pas un blocage silencieux, mais un `RuntimeError` explicite causé par le script `argumentation_analysis/core/from_scripts/auto_env.py`. Ce script vérifie si l'environnement Conda `projet-is` est actif et arrête l'exécution si ce n'est pas le cas.
+
+Le script de diagnostic, en lançant `python -m services.mcp_server.main`, n'activait pas l'environnement Conda requis, ce qui provoquait le crash immédiat du sous-processus serveur.
+
+### Solution (partielle)
+
+Le script de diagnostic a été modifié pour utiliser le wrapper `activate_project_env.ps1`, qui est la méthode préconisée pour lancer des commandes dans l'environnement de projet correctement configuré.
+
+```python
+# Dans scripts/tools/debugging/diagnose_mcp_connection.py
+server_params = StdioServerParameters(
+    command="powershell.exe",
+    args=["-File", ".\\activate_project_env.ps1", "-CommandToRun", f"python -u -m {module_path}"],
+    env=env
+)
+```
+
+### Tentative de correction supplémentaire
+
+Suite aux retours, le script de diagnostic a été modifié pour importer et utiliser directement les fonctions de `scripts/test_executor.py` pour activer l'environnement Conda.
+
+```python
+# Dans scripts/tools/debugging/diagnose_mcp_connection.py
+conda_env_name = get_conda_env_name()
+env = get_conda_env_vars(conda_env_name)
+env_prefix = get_conda_env_prefix(conda_env_name)
+python_executable = os.path.join(env_prefix, "python.exe")
+
+server_params = StdioServerParameters(
+    command=python_executable,
+    args=["-u", "-m", module_path],
+    env=env
+)
+```
+
+### Problème résiduel
+
+Même avec cette correction, le serveur ne démarre toujours pas via le script de diagnostic, échouant avec une `ProcessLookupError`. Cela suggère qu'il pourrait y avoir un problème plus profond dans la manière dont l'environnement est activé ou dont le processus est géré par `mcp.client.stdio`. Cependant, la cause *initiale* du blocage a été identifiée.
+## Analyse du blocage du serveur principal (Post-Merge)
+
+### Contexte
+Après une fusion de branches, le serveur MCP principal (`services/mcp_server/main.py`) a commencé à se bloquer silencieusement au démarrage. Le script de diagnostic `diagnose_mcp_connection.py` restait bloqué sans retourner d'erreur, indiquant un problème profond lors de l'initialisation.
+
+### Étapes de débogage
+
+La cause du blocage a été identifiée en utilisant une approche systématique de "diviser pour régner" :
+
+1.  **Isolation des services applicatifs** : Les services dans la classe `AppServices` de `main.py` (`LogicService`, `AnalysisService`, etc.) ont été commentés un par un. Le blocage persistait jusqu'à ce que l'initialisation de `ValidationService` soit activée, ce qui a immédiatement provoqué le retour du blocage. Cela a permis d'isoler le problème à l'initialisation de `ValidationService` ou l'une de ses dépendances.
+
+2.  **Analyse des dépendances de `ValidationService`** : Le constructeur de `ValidationService` est simple, mais il importe `LogicService`. Une hypothèse de dépendance circulaire a été explorée mais s'est avérée incorrecte.
+
+3.  **Analyse de la pile d'initialisation** : Le problème a été tracé plus haut, dans le script `argumentation_analysis/core/bootstrap.py`, qui est responsable de l'initialisation de l'environnement global du projet, y compris la JVM.
+
+4.  **Identification de la cause racine** : En commentant sélectivement des parties du processus d'initialisation de la JVM dans `argumentation_analysis/core/jvm_setup.py`, la ligne exacte causant le blocage a été identifiée.
+
+### Cause du blocage
+
+Le blocage silencieux est causé par l'appel suivant :
+
+-   **Fichier** : `argumentation_analysis/core/jvm_setup.py`
+-   **Ligne** : 390
+-   **Code** : `jpype.startJVM(...)`
+
+Cette ligne est responsable du démarrage de la machine virtuelle Java. Un problème dans la configuration (comme un classpath incorrect, des options JVM invalides, ou un conflit de version de Java) peut amener cet appel à se bloquer indéfiniment sans lever d'exception, ce qui explique le blocage silencieux du serveur.
+
+## Solution : Démarrage Robuste et Asynchrone de la JVM
+
+Pour corriger ce point de défaillance unique, le mécanisme de démarrage de la JVM a été entièrement revu pour être asynchrone, non-bloquant et robuste.
+
+### Mécanisme d'implémentation
+
+1.  **Appel non-bloquant** : L'appel bloquant `jpype.startJVM` est maintenant exécuté dans un thread séparé en utilisant `asyncio.to_thread`. Cela empêche l'appel de bloquer la boucle d'événements principale du serveur.
+
+2.  **Timeout Strict** : L'appel est enveloppé dans un `asyncio.wait_for` avec un timeout de 30 secondes. Si le démarrage de la JVM prend plus de temps, l'attente est annulée.
+
+3.  **Exception Personnalisée** : En cas de timeout, une exception personnalisée `JVMStartupTimeoutError` est levée. Cette exception est explicite et permet d'identifier immédiatement la source du problème.
+
+4.  **Propagation des Erreurs** : La pile d'appels, depuis `jvm_setup.py` jusqu'au `lifespan` du serveur MCP dans `services/mcp_server/main.py`, a été rendue `async`. Cela garantit que toute exception, y compris `JVMStartupTimeoutError`, se propage correctement et provoque un échec de démarrage propre du serveur, avec des logs clairs, au lieu d'un blocage silencieux.
+
+### Comment diagnostiquer les problèmes de timeout de la JVM
+
+Si le serveur ne démarre pas et que les logs indiquent une `JVMStartupTimeoutError`, cela signifie que la JVM n'a pas pu démarrer en moins de 30 secondes. Les causes possibles sont :
+
+*   **Problèmes de performance** : Le système est surchargé et le démarrage de la JVM est ralenti.
+*   **Conflits de dépendances** : Un problème avec les JARs dans le classpath.
+*   **Configuration Java** : Un `JAVA_HOME` incorrect ou une version de Java incompatible.
+*   **Problèmes réseau** : Si le démarrage dépend de ressources réseau qui ne sont pas disponibles.
+
+Pour déboguer, examinez les logs juste avant le message de timeout pour des indices sur la cause du ralentissement.

--- a/docs/internal/new_test_architecture.md
+++ b/docs/internal/new_test_architecture.md
@@ -1,0 +1,53 @@
+# Nouvelle Architecture d'Exécution des Tests
+
+Ce document de conception décrit une nouvelle architecture pour l'exécution des tests, conçue pour contourner les limitations de `conda run` sous Windows sans modifier le code de production existant (`environment_manager.py`).
+
+## 1. Problématique
+
+L'utilisation de `conda run` à partir de PowerShell pour exécuter des commandes dans un environnement Conda spécifique est défaillante et provoque une erreur fatale `Fatal Python error: init_fs_encoding`. Cette erreur est due à une mauvaise construction de l'environnement d'exécution par `conda run`, qui ne parvient pas à localiser les bibliothèques internes de Python. Toutes les tentatives de correction directe ont échoué.
+
+## 2. Architecture Proposée
+
+L'architecture proposée introduit un script "pont" en Python (`scripts/test_executor.py`) qui agit comme un intermédiaire intelligent entre le script d'activation PowerShell et le gestionnaire d'environnement Python existant.
+
+### Diagramme de Flux
+
+```mermaid
+graph TD
+    A[activate_project_env.ps1] --> B{scripts/test_executor.py};
+    B --> C{Détermine l'env Conda cible};
+    C --> D{Récupère les variables d'environnement};
+    D --> E{Construit l'environnement d'exécution};
+    E --> F[Appelle environment_manager.py via subprocess];
+    F --> G[project_core/core_from_scripts/environment_manager.py];
+```
+
+### Responsabilités des Composants
+
+1.  **`activate_project_env.ps1` (Modifié)**
+    *   **Responsabilité unique :** Lancer le nouveau script `test_executor.py`.
+    *   N'essaie plus d'activer ou d'exécuter des commandes directement avec `conda run`.
+    *   **Commande d'appel :**
+        ```powershell
+        python scripts/test_executor.py --original-command "pytest -m jvm_test"
+        ```
+
+2.  **`scripts/test_executor.py` (Nouveau)**
+    *   **Chef d'orchestre :** C'est le cœur de la nouvelle architecture.
+    *   **Responsabilités :**
+        a.  **Déterminer l'environnement cible :** Lit le fichier `environment.yml` pour connaître le nom de l'environnement Conda (`e2e_test_env`).
+        b.  **Exporter les variables d'environnement :** Exécute `conda env export -n e2e_test_env` pour obtenir une liste des dépendances et potentiellement des variables d'environnement de l'environnement cible. Une autre approche pourrait être `conda run -n e2e_test_env python -c "import os; print(os.environ)"` pour capturer l'environnement.
+        c.  **Construire l'environnement d'exécution :** Parse la sortie de la commande précédente pour construire un dictionnaire `env` compatible avec `subprocess.run`. Ce dictionnaire contiendra les `PATH`, `PYTHONPATH`, et autres variables essentielles de l'environnement cible.
+        d.  **Exécuter la commande :** Appelle la fonction cible dans `project_core/core_from_scripts/environment_manager.py` en utilisant `subprocess.run`. Il passe la commande originale (`pytest...`) et le dictionnaire `env` nouvellement construit.
+
+3.  **`project_core/core_from_scripts/environment_manager.py` (Inchangé)**
+    *   **Continue son rôle :** Exécute la logique de test comme auparavant.
+    *   **Avantage :** Il reçoit un environnement d'exécution déjà configuré et correct, ignorant complètement la complexité de Conda. Il n'y a aucune régression ou modification de son comportement.
+
+## 3. Avantages de l'Approche
+
+*   **Isolation :** Le problème `conda run` est contenu et géré par le `test_executor.py`, sans impacter le reste du code.
+*   **Non-régression :** `environment_manager.py` n'est pas modifié, ce qui élimine le risque d'introduire de nouveaux bugs dans la logique métier existante.
+*   **Testabilité :** Le `test_executor.py` peut être testé unitairement de manière indépendante.
+*   **Robustesse :** La construction explicite de l'environnement d'exécution est plus fiable que de dépendre du comportement interne et bogué de `conda run`.
+*   **Clarté :** Sépare la préoccupation de la "construction de l'environnement" de celle de "l'exécution des tests".

--- a/docs/reports/merge_report_mcp_stabilization.md
+++ b/docs/reports/merge_report_mcp_stabilization.md
@@ -1,0 +1,44 @@
+# Rapports de Merge
+
+Ce document suit les fusions importantes réalisées dans le projet, en particulier celles qui ont nécessité une résolution de conflits complexe.
+
+---
+
+## Merge du 2025-07-26 : Stabilisation MCP et synchronisation `main`
+
+-   **Date :** 2025-07-26
+-   **Branches :** `origin/main` -> `main`
+-   **Commit initial (local) :** `375e424b`
+-   **Commit de merge :** `7abaf158`
+
+### Résumé des changements entrants
+
+La branche `main` distante avait accumulé de nombreuses modifications, notamment :
+-   Une refactorisation complète du script d'activation de l'environnement (`activate_project_env.ps1`) pour une gestion plus robuste de Conda.
+-   L'ajout de nombreuses dépendances de test (`pytest-asyncio`, `playwright`, etc.) dans `requirements.txt`.
+-   Une refactorisation de l'infrastructure de test dans `tests/conftest.py` pour une gestion plus fine du cycle de vie de la JVM.
+-   La centralisation de la configuration du JDK dans `argumentation_analysis/core/jvm_setup.py`.
+
+### Conflits rencontrés et logique de résolution
+
+Cinq conflits ont été détectés et résolus manuellement :
+
+1.  **`requirements.txt`**:
+    -   **Conflit :** Ajout de `mcp-client` localement vs ajout de multiples dépendances de test sur `origin/main`.
+    -   **Résolution :** Les deux ensembles d'ajouts ont été conservés car ils sont complémentaires et nécessaires.
+
+2.  **`argumentation_analysis/core/jvm_setup.py`**:
+    -   **Conflit :** Définition de constantes JDK en dur localement vs récupération depuis les `settings` sur `origin/main`.
+    -   **Résolution :** La version de `origin/main` a été choisie car elle centralise la configuration, ce qui est une meilleure pratique. Un commentaire informatif sur une configuration `jpype` obsolète a également été conservé.
+
+3.  **`services/mcp_server/main.py`**:
+    -   **Conflit :** Refactorisation majeure du serveur MCP localement (avec `lifespan` et injection de dépendances) vs l'ancienne version sur `origin/main`.
+    -   **Résolution :** La version locale (`HEAD`) a été conservée intégralement car elle représente la nouvelle architecture stable et corrigée.
+
+4.  **`tests/conftest.py`**:
+    -   **Conflit :** Deux implémentations différentes de la fixture `jvm_session` pour la gestion de la JVM pendant les tests.
+    -   **Résolution :** La version de `origin/main` a été choisie car elle était plus sophistiquée, offrant un contrôle plus fin sur le cycle de vie de la JVM avec des marqueurs d'exclusion.
+
+5.  **`activate_project_env.ps1`**:
+    -   **Conflit :** Un simple script de façade local vs un script robuste de gestion d'environnement Conda sur `origin/main`.
+    -   **Résolution :** La version de `origin/main` a été choisie car elle est beaucoup plus résiliente et gère correctement la complexité de l'environnement Conda.


### PR DESCRIPTION
## Summary
- Port 3 documentation files from `rescue/mcp-jvm-stabilization-2026-03`
- No code changes — docs only, zero conflict risk

## Analysis of rescue branch (posted on #253)
After thorough analysis of all 14 commits, **none can be cleanly cherry-picked** due to 562-commit divergence. Key findings:

### Safe to port (done in this PR)
- `docs/internal/new_test_architecture.md` — conda run workaround design
- `docs/debugging/mcp_server.md` — MCP server debugging guide
- `docs/reports/merge_report_mcp_stabilization.md` — rescue branch report

### Valuable ideas to port manually (separate PRs needed)
1. **asyncio.Lock in tweety_bridge.py** — main uses threading.Lock; async contexts would benefit
2. **JVM startup timeout** — `JVMStartupTimeoutError` class + timeout guard
3. **MCP client library** at `libs/mcp/client/` — session.py (138 lines), stdio.py, models.py
4. **bootstrap.py hardening** — 35 lines of pre-init safety checks

### Skip entirely
- Dependency pins (conflict with conda-managed env)
- Test config refactor (completely superseded)
- Import order enforcement (depends on non-existent pre_bootstrap, has variable reference bug)
- MCP server changes (target old pre-migration paths)

## Test plan
- [x] Documentation only — no code changes

Partially addresses #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)