### PR TITLE
feat(jtms): use fallacy.target_argument for smarter defeat matching

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,6 +1,6 @@
 # Known Issues — Projet Intelligence Symbolique
 
-Last updated: 2026-03-19
+Last updated: 2026-03-28
 
 ---
 
@@ -73,9 +73,26 @@ Last updated: 2026-03-19
 
 ---
 
-## Test Statistics (as of 2026-03-19)
+## Recently Resolved (2026-03-28)
+
+### Fallacy Workflow Calibration Tests (Issue #269)
+- **Identified**: 2026-03-28 | **Resolved**: 2026-03-28
+- **Cause**: Mock LLM was too simplistic — all branches confirmed same fallacy; missing `get_chat_message_content` (singular) for one-shot path
+- **Fix**: Branch-aware mock with per-branch confirmations + neutral text detection (PR #278)
+- **Status**: RESOLVED
+
+### Stale JTMS Imports (Issue #263)
+- **Identified**: 2026-03-28 | **Resolved**: 2026-03-28
+- **Cause**: 4 files imported JTMSSession/ExtendedBelief from old `agents/jtms_agent_base` instead of canonical `services/jtms/`
+- **Fix**: Migrated all 7 import sites to `argumentation_analysis.services.jtms` (PR #279)
+- **Status**: RESOLVED
+
+---
+
+## Test Statistics (as of 2026-03-28)
 
 - **Unit suite**: 9265 passed, 0 failed, 7 skipped
+- **Fallacy calibration**: 3/3 passed (branch-aware mock)
 - **Sherlock Watson validation**: 43/43 passed
 - **Black formatting**: 0 files to reformat (fully compliant)
 

--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -669,11 +669,21 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict:
         fallacy_beliefs.append(fallacy_name)
 
         # Find which argument the fallacy undermines
-        # TODO: use fallacy.target_argument for smarter matching
-        target_idx = min(i, len(arg_beliefs) - 1) if arg_beliefs else -1
+        # Use target_argument for smarter matching if available
+        target_argument = f.get("target_argument")
+        if target_argument:
+            # Find the matching argument belief by name/substring
+            target_arg = next(
+                (ab for ab in arg_beliefs
+                if target_argument.lower() in ab.lower() or ab.lower() in target_argument.lower()),
+                None,
+            )
+        else:
+            # Fallback: positional matching
+            target_idx = min(i, len(arg_beliefs) - 1) if arg_beliefs else -1
+            target_arg = arg_beliefs[target_idx] if target_idx >= 0 else None
 
-        if target_idx >= 0:
-            target_arg = arg_beliefs[target_idx]
+        if target_arg:
             # Create a DEFEAT justification: fallacy OUT-lists the argument
             defeat_name = f"defeat:{fallacy_type}→{target_arg[:30]}"[:80]
             session.add_belief(

--- a/argumentation_analysis/plugins/identification_models.py
+++ b/argumentation_analysis/plugins/identification_models.py
@@ -26,6 +26,10 @@ class IdentifiedFallacy(BaseModel):
     confidence: float = Field(
         default=0.0, ge=0.0, le=1.0, description="Confidence score (0.0 to 1.0)"
     )
+    target_argument: Optional[str] = Field(
+        default=None,
+        description="The argument or claim that this fallacy targets (for JTMS defeat matching)",
+    )
     navigation_trace: List[str] = Field(
         default_factory=list,
         description="List of taxonomy node PKs visited during iterative deepening",


### PR DESCRIPTION
## Summary
- Add optional `target_argument` field to `IdentifiedFallacy` model (stores which argument the fallacy targets)
- Update `unified_pipeline.py` defeat matching: use `target_argument` for substring-based matching when available, fall back to positional matching otherwise

## Test plan
- [x] `IdentifiedFallacy` model validates with new `target_argument` field (optional, defaults to None)
- [x] Fallback positional matching preserved for fallacies without `target_argument`
- [ ] Integration test with real LLM to verify smarter matching

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)