### PR TITLE
fix(tests): salvage test pollution fixes from stale branch

### DIFF
--- a/scripts/analyze_skips.py
+++ b/scripts/analyze_skips.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Script pour analyser les marqueurs de skip dans les tests.
+
+Identifie tous les tests qui sont potentiellement skippés et catégorise
+les raisons selon le protocole de la Mission 1 (#94).
+"""
+
+import os
+import re
+from pathlib import Path
+from collections import defaultdict
+
+# Racine du projet
+PROJECT_ROOT = Path(__file__).parent.parent
+TESTS_DIR = PROJECT_ROOT / "tests"
+
+
+def find_test_files(directory: Path) -> list[Path]:
+    """Trouve tous les fichiers de test Python."""
+    test_files = []
+    for root, dirs, files in os.walk(directory):
+        # Ignorer certains répertoires
+        dirs[:] = [d for d in dirs if d not in ['__pycache__', '.pytest_cache', 'node_modules']]
+
+        for file in files:
+            if file.startswith('test_') and file.endswith('.py'):
+                test_files.append(Path(root) / file)
+            elif file == 'conftest.py':
+                test_files.append(Path(root) / file)
+
+    return sorted(test_files)
+
+
+def extract_skip_markers(file_path: Path) -> list[dict]:
+    """Extrait les marqueurs de skip d'un fichier de test."""
+    try:
+        content = file_path.read_text(encoding='utf-8')
+    except Exception as e:
+        return []
+
+    skips = []
+
+    # Patterns pour différents types de skip
+    patterns = [
+        # @pytest.mark.skipif avec condition
+        (r'@pytest\.mark\.skipif\((.*?)\s*,\s*reason\s*=\s*["\']([^"\']+)["\']\)', 'skipif'),
+        # @pytest.mark.skip avec raison
+        (r'@pytest\.mark\.skip\((?:reason\s*=\s*)?["\']([^"\']+)["\']?\)', 'skip'),
+        # pytest.skip() dans le code
+        (r'pytest\.skip\(["\']([^"\']+)["\']\)', 'runtime_skip'),
+        # @pytest.mark.jpype_tweety
+        (r'@pytest\.mark\.jpype_tweety\b', 'jpype_tweety'),
+        # @pytest.mark.tweety
+        (r'@pytest\.mark\.tweety\b', 'tweety'),
+        # @pytest.mark.jpype
+        (r'@pytest\.mark\.jpype\b', 'jpype'),
+        # @pytest.mark.requires_api
+        (r'@pytest\.mark\.requires_api\b', 'requires_api'),
+        # @pytest.mark.slow
+        (r'@pytest\.mark\.slow\b', 'slow'),
+    ]
+
+    for pattern, marker_type in patterns:
+        for match in re.finditer(pattern, content, re.MULTILINE | re.DOTALL):
+            if marker_type in ['skip', 'skipif']:
+                reason = match.group(2) if marker_type == 'skipif' else match.group(1)
+                condition = match.group(1) if marker_type == 'skipif' else None
+                skips.append({
+                    'type': marker_type,
+                    'reason': reason,
+                    'condition': condition,
+                    'line': content[:match.start()].count('\n') + 1
+                })
+            elif marker_type == 'runtime_skip':
+                skips.append({
+                    'type': 'runtime_skip',
+                    'reason': match.group(1),
+                    'line': content[:match.start()].count('\n') + 1
+                })
+            else:
+                skips.append({
+                    'type': marker_type,
+                    'reason': f'Marker: @{marker_type}',
+                    'line': content[:match.start()].count('\n') + 1
+                })
+
+    return skips
+
+
+def categorize_skip(skip_info: dict, file_path: Path) -> str:
+    """
+    Catégorise un skip selon le protocole Mission 1:
+    - INTENTIONNEL: marker légitime (jpype, tweety, requires_api, slow)
+    - ENV_DELTA: dû à un delta d'environnement (package manquant, version)
+    - BUG: skip par erreur d'import ou condition cassée
+    """
+    reason_lower = skip_info['reason'].lower()
+    marker_type = skip_info['type']
+    rel_path = file_path.relative_to(PROJECT_ROOT)
+
+    # INTENTIONNEL - marqueurs connus
+    if marker_type in ['jpype_tweety', 'tweety', 'jpype', 'requires_api', 'slow']:
+        return 'INTENTIONNEL'
+
+    # INTENTIONNEL - raisons connues
+    intentional_keywords = [
+        'jvm non disponible', 'jvm non démarrée', 'jpype',
+        'oracle non disponible', 'gpt réel', 'openai_api_key',
+        'démo', 'setup', 'désactivé',
+    ]
+    if any(kw in reason_lower for kw in intentional_keywords):
+        return 'INTENTIONNEL'
+
+    # ENV_DELTA - package manquant ou version
+    env_keywords = [
+        'module', 'package', 'import', 'version',
+        'installé', 'disponible', 'dependencies',
+    ]
+    if any(kw in reason_lower for kw in env_keywords):
+        return 'ENV_DELTA'
+
+    # BUG - conditions cassées ou erreurs d'import
+    bug_keywords = [
+        'error', 'exception', 'failed', 'crash',
+        'timeout', 'hang', 'freeze',
+    ]
+    if any(kw in reason_lower for kw in bug_keywords):
+        return 'BUG'
+
+    # Par défaut, classer comme ENV_DELTA pour investigation
+    return 'ENV_DELTA'
+
+
+def main():
+    print("🔍 Analyse des marqueurs de skip dans les tests...\n")
+    print(f"📁 Répertoire: {TESTS_DIR}\n")
+
+    test_files = find_test_files(TESTS_DIR)
+    print(f"📝 {len(test_files)} fichiers de test trouvés\n")
+
+    all_skips = []
+    category_counts = defaultdict(int)
+    file_skips = defaultdict(list)
+
+    for file_path in test_files:
+        skips = extract_skip_markers(file_path)
+        if skips:
+            rel_path = file_path.relative_to(PROJECT_ROOT)
+            for skip in skips:
+                skip['file'] = str(rel_path)
+                category = categorize_skip(skip, file_path)
+                skip['category'] = category
+                all_skips.append(skip)
+                category_counts[category] += 1
+                file_skips[str(rel_path)].append(skip)
+
+    # Afficher le résumé par catégorie
+    print("=" * 70)
+    print("📊 RÉSUMÉ PAR CATÉGORIE")
+    print("=" * 70)
+
+    for category in ['INTENTIONNEL', 'ENV_DELTA', 'BUG']:
+        count = category_counts[category]
+        print(f"\n{category}: {count} skips")
+
+    print(f"\n{'TOTAL':<20} {len(all_skips)} skips identifiés")
+
+    # Afficher les détails par fichier
+    print("\n" + "=" * 70)
+    print("📋 DÉTAILS PAR FICHIER")
+    print("=" * 70)
+
+    for file_path, skips in sorted(file_skips.items()):
+        print(f"\n📄 {file_path} ({len(skips)} skip(s))")
+        for skip in skips:
+            print(f"   Line {skip['line']}: [{skip['category']}] {skip['type']}")
+            if skip.get('reason'):
+                print(f"      Reason: {skip['reason']}")
+
+    # Générer le tableau pour la Mission 1
+    print("\n" + "=" * 70)
+    print("📋 TABLEAU POUR MISSION 1 (#94)")
+    print("=" * 70)
+
+    print("\n| Test | Catégorie | Raison | Marker |")
+    print("|------|-----------|---------|--------|")
+
+    for skip in sorted(all_skips, key=lambda s: (s['file'], s['line'])):
+        test_name = f"{skip['file']}:{skip['line']}"
+        category = skip['category']
+        reason = skip['reason'][:50] + '...' if len(skip.get('reason', '')) > 50 else skip.get('reason', '')
+        marker = skip['type']
+        print(f"| {test_name:<50} | {category:<10} | {reason:<30} | {marker:<15} |")
+
+    print(f"\n📈 Total: {len(all_skips)} skips analysés")
+    print(f"   - INTENTIONNEL: {category_counts['INTENTIONNEL']}")
+    print(f"   - ENV_DELTA: {category_counts['ENV_DELTA']}")
+    print(f"   - BUG: {category_counts['BUG']}")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/unit/api/test_api_direct.py
+++ b/tests/unit/api/test_api_direct.py
@@ -150,9 +150,16 @@ def test_api_startup_and_basic_functionality():
             try:
                 response = requests.get(f"{api_url}/health", timeout=3)
                 if response.status_code == 200:
-                    api_ready = True
-                    print(f"✓ API prête après {wait_time}s")
-                    break
+                    # Verify the response body is valid JSON with expected content
+                    try:
+                        data = response.json()
+                        if data.get("status") == "healthy":
+                            api_ready = True
+                            print(f"✓ API prête après {wait_time}s")
+                            break
+                    except requests.exceptions.JSONDecodeError:
+                        # Response body not ready yet, continue waiting
+                        pass
             except (requests.ConnectionError, requests.Timeout):
                 pass
 

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_af_handler_extended.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_af_handler_extended.py
@@ -47,13 +47,21 @@ def mock_jpype():
 
         mock_argument_cls = MagicMock(side_effect=make_arg)
 
+        # Make Attack a proper constructor that returns a mock attack object
+        def make_attack(source, target):
+            attack = MagicMock()
+            attack.getAttacker.return_value = source
+            attack.getAttacked.return_value = target
+            return attack
+        mock_attack_cls = MagicMock(side_effect=make_attack)
+
         def jclass_side_effect(class_name):
             if "DungTheory" in class_name:
                 return MagicMock  # Constructor
             elif "Argument" in class_name and "syntax" in class_name:
                 return mock_argument_cls
             elif "Attack" in class_name:
-                return MagicMock
+                return mock_attack_cls
             elif "Extension" in class_name:
                 return mock_extension
             elif "Reasoner" in class_name:

--- a/tests/unit/argumentation_analysis/core/communication/test_request_response.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_request_response.py
@@ -344,6 +344,7 @@ class TestSendRequest:
         assert result.content["answer"] == "yes"
 
     def test_timeout_raises_error(self, protocol):
+        """Test that a timeout raises RequestTimeoutError."""
         with pytest.raises(RequestTimeoutError):
             protocol.send_request(
                 sender="a",

--- a/tests/unit/argumentation_analysis/reporting/test_enhanced_real_time_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_enhanced_real_time_trace_analyzer.py
@@ -7,6 +7,7 @@ ProjectManagerPhase, EnhancedRealTimeTraceAnalyzer, decorator, and helpers.
 
 import time
 import pytest
+from unittest.mock import patch
 
 from argumentation_analysis.reporting.enhanced_real_time_trace_analyzer import (
     ConversationMessage,
@@ -484,13 +485,10 @@ class TestEnhancedRealTimeTraceAnalyzer:
         assert "ORCHESTRATION" in content
 
     def test_save_report_invalid_path(self, analyzer):
-        # Use a truly non-existent path (Windows drive that doesn't exist)
-        assert (
-            analyzer.save_enhanced_report(
-                "Z:\\this_drive_does_not_exist\\path\\report.md"
-            )
-            is False
-        )
+        """Test que save_enhanced_report retourne False si l'écriture échoue."""
+        with patch("builtins.open", side_effect=PermissionError("Cannot write to path")):
+            result = analyzer.save_enhanced_report("/nonexistent/path/report.md")
+        assert result is False
 
 
 # ============================================================

--- a/tests/unit/argumentation_analysis/reporting/test_enhanced_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_enhanced_trace_analyzer.py
@@ -3,6 +3,7 @@
 
 import time
 import pytest
+from unittest.mock import patch
 
 from argumentation_analysis.reporting.enhanced_real_time_trace_analyzer import (
     ConversationMessage,
@@ -496,13 +497,12 @@ class TestEnhancedRealTimeTraceAnalyzer:
         assert "Test" in content
 
     def test_save_report_bad_path(self, analyzer):
+        """Test que save_enhanced_report retourne False si l'écriture échoue."""
         analyzer.start_capture()
         analyzer.start_pm_phase("p1", "Test", ["A"])
         analyzer.stop_capture()
-        # Use a truly non-existent path (Windows drive that doesn't exist)
-        result = analyzer.save_enhanced_report(
-            "Z:\\this_drive_does_not_exist\\path\\report.md"
-        )
+        with patch("builtins.open", side_effect=PermissionError("Cannot write to path")):
+            result = analyzer.save_enhanced_report("/nonexistent/path/report.md")
         assert result is False
 
     def test_metadata_updates(self, analyzer):

--- a/tests/unit/argumentation_analysis/reporting/test_real_time_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_real_time_trace_analyzer.py
@@ -437,10 +437,9 @@ class TestRealTimeTraceAnalyzer:
         assert "RAPPORT" in content
 
     def test_save_report_invalid_path(self, analyzer):
-        # Use a truly non-existent path (Windows drive that doesn't exist)
-        result = analyzer.save_conversation_report(
-            "Z:\\this_drive_does_not_exist\\path\\report.md"
-        )
+        """Test que save_conversation_report retourne False si l'écriture échoue."""
+        with patch("builtins.open", side_effect=PermissionError("Cannot write to path")):
+            result = analyzer.save_conversation_report("/nonexistent/path/report.md")
         assert result is False
 
 

--- a/tests/unit/argumentation_analysis/services/test_crypto_service.py
+++ b/tests/unit/argumentation_analysis/services/test_crypto_service.py
@@ -2,6 +2,7 @@
 """Tests for CryptoService — encryption, decryption, key management."""
 
 import pytest
+from unittest.mock import patch
 from cryptography.fernet import Fernet
 
 from argumentation_analysis.services.crypto_service import CryptoService
@@ -95,15 +96,14 @@ class TestKeyManagement:
         assert loaded == key
 
     def test_save_key_bad_path(self, svc, key):
-        # Use a truly non-existent path - Windows UNC path to non-existent server
-        # (or use a drive letter that's unlikely to exist)
-        bad_path = "Z:\\this_drive_does_not_exist\\path\\key.bin"
-        assert svc.save_key(key, bad_path) is False
+        """Test que save_key retourne False si l'écriture échoue."""
+        with patch("builtins.open", side_effect=PermissionError("Cannot write to path")):
+            assert svc.save_key(key, "/nonexistent/path/key.bin") is False
 
     def test_load_key_nonexistent(self, svc):
-        # Use a truly non-existent path
-        bad_path = "Z:\\this_drive_does_not_exist\\path\\key.bin"
-        assert svc.load_key(bad_path) is None
+        """Test que load_key retourne None si la lecture échoue."""
+        with patch("builtins.open", side_effect=FileNotFoundError("File not found")):
+            assert svc.load_key("/nonexistent/path/key.bin") is None
 
 
 # ── Encrypt / Decrypt ──

--- a/tests/unit/argumentation_analysis/test_architecture_compliance.py
+++ b/tests/unit/argumentation_analysis/test_architecture_compliance.py
@@ -170,12 +170,7 @@ class TestPluginCompliance:
         plugin = GovernancePlugin()
         result = plugin.list_governance_methods()
         methods = json.loads(result)
-        # The methods are nested under 'agent_based' and 'social_choice'
-        assert "agent_based" in methods
-        assert "social_choice" in methods
-        # Check that 'majority' is in one of the method lists
-        all_method_names = methods["agent_based"] + methods["social_choice"]
-        assert "majority" in all_method_names
+        assert "majority" in methods["agent_based"]
 
     def test_plugins_can_register_with_kernel(self, mock_kernel):
         """All plugins can be registered with a kernel."""

--- a/tests/unit/argumentation_analysis/test_strategies_real.py
+++ b/tests/unit/argumentation_analysis/test_strategies_real.py
@@ -14,8 +14,20 @@ import pytest_asyncio
 from pathlib import Path
 from typing import List
 
-# Configuration pour forcer l'utilisation du vrai JPype
-os.environ["USE_REAL_JPYPE"] = "true"
+
+# Fixture pour gérer la variable d'environnement sans polluer les autres tests
+@pytest.fixture(scope="module", autouse=True)
+def _manage_real_jpype_env():
+    """Gère la variable USE_REAL_JPYPE pour ce module uniquement."""
+    original_value = os.environ.get("USE_REAL_JPYPE")
+    os.environ["USE_REAL_JPYPE"] = "true"
+    yield
+    # Restauration après tous les tests du module
+    if original_value is None:
+        os.environ.pop("USE_REAL_JPYPE", None)
+    else:
+        os.environ["USE_REAL_JPYPE"] = original_value
+
 
 try:
     # IMPORTS CORRIGÉS avec les bons chemins

--- a/tests/unit/scripts/test_auto_env.py
+++ b/tests/unit/scripts/test_auto_env.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
 """
 Tests unitaires pour le module `environment` et sa fonction coupe-circuit `ensure_env`.
 =====================================================================================
@@ -15,38 +15,46 @@ Auteur: Intelligence Symbolique EPITA
 Date: 23/06/2025
 """
 
-import unittest
+import pytest
 import os
-import sys
-from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-# Assurer que le module à tester est dans le path
-current_dir = Path(__file__).resolve().parent.parent.parent.parent
-sys.path.insert(0, str(current_dir))
-
-# Importer la fonction à tester
 from argumentation_analysis.core.environment import ensure_env
+
+
+# Fixture pour isoler les tests de la pollution globale
+@pytest.fixture(autouse=True)
+def _isolate_from_global_pollution():
+    """Isole les tests de toute pollution d'environnement globale."""
+    # Sauvegarder l'état original
+    original_e2e = os.environ.get("E2E_TESTING_MODE")
+    original_conda = os.environ.get("CONDA_DEFAULT_ENV")
+
+    yield
+
+    # Restaurer l'état original
+    if original_e2e is None:
+        os.environ.pop("E2E_TESTING_MODE", None)
+    else:
+        os.environ["E2E_TESTING_MODE"] = original_e2e
+
+    if original_conda is None:
+        os.environ.pop("CONDA_DEFAULT_ENV", None)
+    else:
+        os.environ["CONDA_DEFAULT_ENV"] = original_conda
 
 
 def _call_ensure_env(env_vars, **kwargs):
     """Call ensure_env with fully controlled environment.
 
-    Removes E2E_TESTING_MODE and uses context manager pattern (not decorator)
-    to ensure isolation even in full test suite where conftest.py sets
-    E2E_TESTING_MODE=1 globally.
+    Uses clear=True to fully isolate from global state (conftest.py sets
+    E2E_TESTING_MODE=1 globally, which bypasses conda checks).
     """
-    patched = dict(env_vars)
-    if "E2E_TESTING_MODE" not in patched:
-        patched["E2E_TESTING_MODE"] = ""
-
-    with patch.dict(os.environ, patched, clear=False):
-        # Explicitly remove E2E bypass inside the patched context
-        os.environ.pop("E2E_TESTING_MODE", None)
+    with patch.dict(os.environ, env_vars, clear=True):
         return ensure_env(load_dotenv=False, **kwargs)
 
 
-class TestEnsureEnvAsGuard(unittest.TestCase):
+class TestEnsureEnvAsGuard:
     """
     Teste la fonction `ensure_env` en tant que garde-fou de l'environnement.
     La nouvelle version se base sur la variable d'environnement `CONDA_DEFAULT_ENV`.
@@ -62,27 +70,27 @@ class TestEnsureEnvAsGuard(unittest.TestCase):
             env_name="projet-is",
             silent=True,
         )
-        self.assertTrue(result)
+        assert result is True
 
     def test_ensure_env_incorrect_environment_raises_error(self):
         """
         Vérifie que ensure_env() lève une RuntimeError si 'CONDA_DEFAULT_ENV'
         est incorrect.
         """
-        with self.assertRaises(RuntimeError) as cm:
+        with pytest.raises(RuntimeError) as cm:
             _call_ensure_env(
                 {"CONDA_DEFAULT_ENV": "wrong-env", "IS_PYTEST_RUNNING": "true"},
                 env_name="projet-is",
                 silent=False,
             )
 
-        exception_message = str(cm.exception)
-        self.assertIn("ERREUR CRITIQUE", exception_message)
-        self.assertIn("MAUVAIS ENVIRONNEMENT CONDA ACTIF", exception_message)
-        self.assertIn("Environnement attendu   : 'projet-is'", exception_message)
-        self.assertIn(
-            "Environnement détecté (CONDA_DEFAULT_ENV) : 'wrong-env'",
-            exception_message,
+        exception_message = str(cm.value)
+        assert "ERREUR CRITIQUE" in exception_message
+        assert "MAUVAIS ENVIRONNEMENT CONDA ACTIF" in exception_message
+        assert "Environnement attendu   : 'projet-is'" in exception_message
+        assert (
+            "Environnement détecté (CONDA_DEFAULT_ENV) : 'wrong-env'"
+            in exception_message
         )
 
     def test_ensure_env_base_environment_raises_error(self):
@@ -90,27 +98,26 @@ class TestEnsureEnvAsGuard(unittest.TestCase):
         Vérifie que ensure_env() lève une RuntimeError si 'CONDA_DEFAULT_ENV'
         est défini sur 'base'.
         """
-        with self.assertRaises(RuntimeError) as cm:
+        with pytest.raises(RuntimeError) as cm:
             _call_ensure_env(
                 {"CONDA_DEFAULT_ENV": "base", "IS_PYTEST_RUNNING": "true"},
                 env_name="projet-is",
                 silent=False,
             )
 
-        exception_message = str(cm.exception)
-        self.assertIn("ERREUR CRITIQUE", exception_message)
-        self.assertIn("MAUVAIS ENVIRONNEMENT CONDA ACTIF", exception_message)
-        self.assertIn("Environnement attendu   : 'projet-is'", exception_message)
-        self.assertIn(
-            "Environnement détecté (CONDA_DEFAULT_ENV) : 'base'", exception_message
+        exception_message = str(cm.value)
+        assert "ERREUR CRITIQUE" in exception_message
+        assert "MAUVAIS ENVIRONNEMENT CONDA ACTIF" in exception_message
+        assert "Environnement attendu   : 'projet-is'" in exception_message
+        assert (
+            "Environnement détecté (CONDA_DEFAULT_ENV) : 'base'" in exception_message
         )
 
     def test_ensure_env_silent_mode(self):
         """Vérifie le mode silencieux et non silencieux."""
-        # En mode non silencieux, on s'attend à un print
         env = {"CONDA_DEFAULT_ENV": "projet-is", "IS_PYTEST_RUNNING": "true"}
-        with patch.dict(os.environ, env, clear=False):
-            os.environ.pop("E2E_TESTING_MODE", None)
+        # En mode non silencieux, on s'attend à un print
+        with patch.dict(os.environ, env, clear=True):
             with patch("builtins.print") as mock_print:
                 ensure_env(env_name="projet-is", silent=False, load_dotenv=False)
                 found_call = any(
@@ -118,18 +125,10 @@ class TestEnsureEnvAsGuard(unittest.TestCase):
                     in str(call)
                     for call in mock_print.call_args_list
                 )
-                self.assertTrue(
-                    found_call,
-                    "Le message de succès n'a pas été affiché en mode non-silencieux.",
-                )
+                assert found_call, "Le message de succès n'a pas été affiché en mode non-silencieux."
 
         # En mode silencieux, on ne s'attend pas à un print
-        with patch.dict(os.environ, env, clear=False):
-            os.environ.pop("E2E_TESTING_MODE", None)
+        with patch.dict(os.environ, env, clear=True):
             with patch("builtins.print") as mock_print:
                 ensure_env(env_name="projet-is", silent=True, load_dotenv=False)
                 mock_print.assert_not_called()
-
-
-if __name__ == "__main__":
-    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

Cherry-picks 3 test fixes from `fix/pre-existing-test-failures` (263 behind main, now stale) and resolves conflicts with current main:

- **Cross-platform path tests**: Replace `Z:\this_drive_does_not_exist` Windows drive hacks with `patch("builtins.open", side_effect=...)` in 4 test files (reporting, crypto service)
- **Architecture compliance**: Fix assertion in `test_governance_plugin_has_kernel_functions` to check `methods["agent_based"]` directly
- **Env pollution prevention**: Move module-level `os.environ["USE_REAL_JPYPE"] = "true"` into a scoped `@pytest.fixture` with teardown in `test_strategies_real.py`
- **Attack mock fix**: Fix `InvalidSpecError` in `test_af_handler_extended.py` by making Attack a proper constructor
- **pytest migration**: Convert `test_auto_env.py` from `unittest.TestCase` to pytest style with isolation fixtures to prevent pollution from `pyo3_singleton` tests
- **API readiness**: Improve `test_api_direct.py` wait loop to validate JSON body before declaring API ready

## Test plan

- [x] All 457 affected tests pass (381 + 76 batches, 0 failures)
- [x] No conflict markers remain
- [x] `patch("builtins.open")` approach verified as cross-platform replacement for Windows-specific drive path tests
- [ ] CI green

## Related

- Task: TASK-93-A (Round 93 dispatch)
- Source commits: `da2b9a56`, `6ae1226d`, `5a2a6b50` from `fix/pre-existing-test-failures`
- Related issue: #329 (test-suite health audit, Track 1 JVM skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)