### PR TITLE
fix(jvm): add native SAT solver dir to classpath for getResource()

### DIFF
--- a/argumentation_analysis/core/jvm_setup.py
+++ b/argumentation_analysis/core/jvm_setup.py
@@ -822,13 +822,21 @@ def initialize_jvm(force_restart=False, session_fixture_owns_jvm=False) -> bool:
         ]
         if uber_jars:
             # Sort to pick the latest version (alphabetical = version order for tweety jars)
-            classpath = [str(sorted(uber_jars)[-1].resolve())]
+            jar_entries = [str(sorted(uber_jars)[-1].resolve())]
         else:
             logger.warning("Aucun uber-jar trouvé, chargement de tous les JARs.")
-            classpath = [str(jar.resolve()) for jar in tweety_libs_dir.glob("*.jar")]
-            if not classpath:
+            jar_entries = [str(jar.resolve()) for jar in tweety_libs_dir.glob("*.jar")]
+            if not jar_entries:
                 logger.critical(f"Aucun JAR trouvé dans {tweety_libs_dir}. Arrêt.")
                 return False
+
+        # Build classpath: native dir first for JNI SAT solver getResource(), then JARs
+        classpath = []
+        native_libs_dir = PROJ_ROOT / settings.jvm.native_libs_dir
+        if native_libs_dir.exists():
+            classpath.append(str(native_libs_dir.resolve()))
+            logger.info(f"Native SAT dir prepended to classpath: {native_libs_dir.resolve()}")
+        classpath.extend(jar_entries)
 
         try:
             # Correction de la logique de détection du chemin de la JVM.


### PR DESCRIPTION
## Summary

- Prepend `libs/native/` to the Java classpath before Tweety JARs, allowing JNI SAT solvers (lingeling, minisat, picosat) to be found via `getResource()`
- Port from CoursIA `tweety_init.py` lines 164-171 pattern (validated by coordinator)

## Change Details

**File**: `argumentation_analysis/core/jvm_setup.py` (lines 819-839)
- Classpath now: `[libs/native/, tweety-full-1.29.jar]` (was: `[tweety-full-1.29.jar]`)
- Additive only — no modification to JVM lifecycle, startup order, or defense layers

## Risk Assessment

| Factor | Assessment |
|--------|-----------|
| Nature of DLLs | JNI SAT solver wrappers (Tweety). Designed to coexist with JVM. |
| Prover9-like risk | **NONE**. Prover9 was an external executable, these are standard JNI wrappers. |
| Regression risk | **LOW**. Additive change. 4 defense layers intact. |
| Load order | Unchanged. `torch/transformers` → `jpype` via `conftest.py`. |
| `-Djava.awt.headless` | Still absent. |

## Test Plan

- [x] `jvm_setup.py` imports and `get_jvm_options()` returns correct options
- [x] Classpath ordering verified: native dir first, then uber JAR
- [x] 2748 unit tests pass (1 pre-existing failure in `test_accepts_python_3_10`, unrelated)
- [ ] CI full suite (pending)
- [ ] Coordinator to validate JNI SAT solver loadability post-merge

## References

- Mini-report on RooSync workspace dashboard (2026-04-24)
- CoursIA `tweety_init.py:164-171` — reference pattern
- Issue #329 context (test-health audit)
- Relates to #78 Track #24 (Tweety JARs 1.29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)