### PR TITLE
chore(tests): consolidate 9 README files into 1 + docs/guides/testing/ (#334 Track 3)

### DIFF
--- a/docs/guides/WEB_APPLICATION_GUIDE.md
+++ b/docs/guides/WEB_APPLICATION_GUIDE.md
@@ -180,7 +180,7 @@ Test-NetConnection localhost -Port 3000
 ## 📚 Documentation Supplémentaire
 
 - **[Guide Installation](../GUIDE_INSTALLATION_ETUDIANTS.md)** : Configuration initiale
-- **[Tests Fonctionnels](../tests/README_FUNCTIONAL_TESTS.md)** : Documentation des tests
+- **[Tests Fonctionnels](testing/functional_tests.md)** : Documentation des tests
 - **[API Documentation](../argumentation_analysis/services/web_api/README.md)** : Référence API détaillée
 
 ## 🤝 Contribution

--- a/docs/guides/testing/advanced_patterns.md
+++ b/docs/guides/testing/advanced_patterns.md
@@ -1,0 +1,226 @@
+# Patterns de Test Avancés pour l'Analyse d'Argumentation
+
+Ce document décrit les patterns de test avancés utilisés pour tester les différents modules du système d'analyse d'argumentation, en particulier pour les modules prioritaires identifiés.
+
+## Table des Matières
+
+1. [Introduction](#introduction)
+2. [Patterns de Test Généraux](#patterns-de-test-généraux)
+3. [Patterns Spécifiques par Module](#patterns-spécifiques-par-module)
+   - [Orchestration Hiérarchique Tactique](#orchestration-hiérarchique-tactique)
+   - [Adaptateurs Opérationnels](#adaptateurs-opérationnels)
+   - [Outils d'Analyse Améliorés](#outils-danalyse-améliorés)
+   - [Agents Informels](#agents-informels)
+   - [Outils d'Analyse de Base](#outils-danalyse-de-base)
+4. [Bonnes Pratiques](#bonnes-pratiques)
+5. [Mesure de la Couverture](#mesure-de-la-couverture)
+
+## Introduction
+
+L'augmentation de la couverture des tests est essentielle pour garantir la fiabilité et la robustesse du système d'analyse d'argumentation. Les patterns de test avancés décrits dans ce document ont été conçus pour cibler spécifiquement les modules prioritaires identifiés avec une faible couverture de tests.
+
+## Patterns de Test Généraux
+
+### Pattern de Test Complet
+
+Ce pattern vise à tester une fonctionnalité de bout en bout, en vérifiant tous les aspects de son comportement :
+
+1. **Configuration initiale** : Mise en place de l'environnement de test avec des mocks appropriés
+2. **Exécution de la fonctionnalité** : Appel de la méthode à tester avec différents paramètres
+3. **Vérification des résultats** : Assertions sur les résultats attendus
+4. **Vérification des effets secondaires** : Vérification des modifications d'état, des appels aux dépendances, etc.
+5. **Nettoyage** : Restauration de l'environnement de test à son état initial
+
+### Pattern de Test des Cas Limites
+
+Ce pattern se concentre sur les cas limites et les conditions exceptionnelles :
+
+1. **Valeurs nulles ou vides** : Tester le comportement avec des entrées nulles ou vides
+2. **Valeurs extrêmes** : Tester le comportement avec des valeurs minimales et maximales
+3. **Formats invalides** : Tester le comportement avec des entrées mal formatées
+4. **Conditions d'erreur** : Tester le comportement en cas d'erreur des dépendances
+
+### Pattern de Test des Interactions
+
+Ce pattern teste les interactions entre différents composants :
+
+1. **Mocking des dépendances** : Création de mocks pour simuler le comportement des dépendances
+2. **Vérification des appels** : Vérification que les méthodes des dépendances sont appelées correctement
+3. **Simulation des réponses** : Simulation des différentes réponses possibles des dépendances
+4. **Vérification de l'intégration** : Vérification que le composant s'intègre correctement avec ses dépendances
+
+## Patterns Spécifiques par Module
+
+### Orchestration Hiérarchique Tactique
+
+#### Pattern de Test du Coordinateur Tactique
+
+Ce pattern teste les fonctionnalités du coordinateur tactique :
+
+1. **Initialisation du coordinateur** : Vérification de l'initialisation correcte du coordinateur
+2. **Traitement des objectifs stratégiques** : Test du traitement des objectifs stratégiques et de leur décomposition en tâches
+3. **Assignation des tâches** : Vérification de l'assignation correcte des tâches aux agents opérationnels
+4. **Gestion des résultats de tâches** : Test de la gestion des résultats de tâches et de leur intégration
+5. **Génération de rapports** : Vérification de la génération correcte des rapports de statut
+6. **Application des ajustements stratégiques** : Test de l'application des ajustements stratégiques
+
+#### Pattern de Test du Moniteur Tactique
+
+Ce pattern teste les fonctionnalités du moniteur tactique :
+
+1. **Détection des problèmes critiques** : Vérification de la détection correcte des problèmes critiques
+2. **Suggestion d'actions correctives** : Test des suggestions d'actions correctives appropriées
+3. **Évaluation de la cohérence globale** : Vérification de l'évaluation correcte de la cohérence globale
+4. **Mise à jour de la progression des tâches** : Test de la mise à jour correcte de la progression des tâches
+5. **Détection des conflits** : Vérification de la détection correcte des conflits entre tâches
+
+#### Pattern de Test du Résolveur Tactique
+
+Ce pattern teste les fonctionnalités du résolveur tactique :
+
+1. **Détection des conflits** : Vérification de la détection correcte des conflits
+2. **Résolution des conflits** : Test de la résolution correcte des différents types de conflits
+3. **Application des résolutions** : Vérification de l'application correcte des résolutions
+4. **Escalade des conflits non résolus** : Test de l'escalade correcte des conflits non résolus
+5. **Vérification des arguments contradictoires** : Test de la détection correcte des arguments contradictoires
+
+### Adaptateurs Opérationnels
+
+#### Pattern de Test des Adaptateurs d'Agents
+
+Ce pattern teste les fonctionnalités des adaptateurs d'agents :
+
+1. **Initialisation de l'adaptateur** : Vérification de l'initialisation correcte de l'adaptateur
+2. **Traitement des tâches** : Test du traitement correct des tâches assignées
+3. **Communication avec les agents** : Vérification de la communication correcte avec les agents
+4. **Gestion des résultats** : Test de la gestion correcte des résultats des agents
+5. **Conversion des formats** : Vérification de la conversion correcte des formats entre les niveaux tactique et opérationnel
+
+### Outils d'Analyse Améliorés
+
+#### Pattern de Test de l'Analyseur Contextuel de Sophismes Amélioré
+
+Ce pattern teste les fonctionnalités de l'analyseur contextuel de sophismes amélioré :
+
+1. **Analyse du contexte** : Vérification de l'analyse correcte du contexte
+2. **Identification des sophismes potentiels** : Test de l'identification correcte des sophismes potentiels
+3. **Filtrage par contexte sémantique** : Vérification du filtrage correct des sophismes en fonction du contexte
+4. **Analyse des relations entre sophismes** : Test de l'analyse correcte des relations entre sophismes
+5. **Apprentissage continu** : Vérification de l'apprentissage correct à partir des feedbacks
+
+#### Pattern de Test de l'Évaluateur de Gravité des Sophismes Amélioré
+
+Ce pattern teste les fonctionnalités de l'évaluateur de gravité des sophismes amélioré :
+
+1. **Évaluation de la gravité des sophismes** : Vérification de l'évaluation correcte de la gravité des sophismes
+2. **Analyse de l'impact du contexte** : Test de l'analyse correcte de l'impact du contexte sur la gravité
+3. **Calcul de la gravité globale** : Vérification du calcul correct de la gravité globale
+4. **Détermination du niveau de gravité** : Test de la détermination correcte du niveau de gravité
+5. **Évaluation avec différents contextes** : Vérification de l'évaluation correcte avec différents contextes
+
+#### Pattern de Test de l'Analyseur de Sophismes Complexes Amélioré
+
+Ce pattern teste les fonctionnalités de l'analyseur de sophismes complexes amélioré :
+
+1. **Analyse des sophismes complexes** : Vérification de l'analyse correcte des sophismes complexes
+2. **Détection des combinaisons de sophismes** : Test de la détection correcte des combinaisons de sophismes
+3. **Analyse de la structure argumentative** : Vérification de l'analyse correcte de la structure argumentative
+4. **Détection du raisonnement circulaire** : Test de la détection correcte du raisonnement circulaire
+5. **Analyse des vulnérabilités structurelles** : Vérification de l'analyse correcte des vulnérabilités structurelles
+6. **Évaluation de la gravité des sophismes complexes** : Test de l'évaluation correcte de la gravité des sophismes complexes
+7. **Analyse des interactions entre sophismes** : Vérification de l'analyse correcte des interactions entre sophismes
+8. **Génération de rapports** : Test de la génération correcte des rapports d'analyse
+
+### Agents Informels
+
+#### Pattern de Test de la Création d'Agents Informels
+
+Ce pattern teste la création et l'initialisation des agents informels :
+
+1. **Initialisation de l'agent** : Vérification de l'initialisation correcte de l'agent
+2. **Initialisation avec différentes configurations** : Test de l'initialisation avec différentes configurations
+3. **Initialisation avec différents outils** : Vérification de l'initialisation avec différents outils
+4. **Gestion des erreurs d'initialisation** : Test de la gestion correcte des erreurs d'initialisation
+5. **Récupération des informations de l'agent** : Vérification de la récupération correcte des informations de l'agent
+
+#### Pattern de Test des Méthodes d'Analyse des Agents Informels
+
+Ce pattern teste les méthodes d'analyse des agents informels :
+
+1. **Analyse de texte** : Vérification de l'analyse correcte du texte
+2. **Analyse complète** : Test de l'analyse complète avec différents outils
+3. **Analyse et catégorisation** : Vérification de l'analyse et de la catégorisation correctes des sophismes
+4. **Extraction d'arguments** : Test de l'extraction correcte des arguments
+5. **Traitement du texte** : Vérification du traitement correct du texte
+
+#### Pattern de Test de la Gestion des Erreurs des Agents Informels
+
+Ce pattern teste la gestion des erreurs des agents informels :
+
+1. **Gestion des entrées invalides** : Vérification de la gestion correcte des entrées invalides
+2. **Gestion des erreurs des outils** : Test de la gestion correcte des erreurs des outils
+3. **Récupération après erreur** : Vérification de la récupération correcte après une erreur
+4. **Gestion des configurations invalides** : Test de la gestion correcte des configurations invalides
+5. **Gestion des outils manquants** : Vérification de la gestion correcte des outils manquants
+
+### Outils d'Analyse de Base
+
+#### Pattern de Test de l'Analyseur de Sophismes
+
+Ce pattern teste les fonctionnalités de l'analyseur de sophismes :
+
+1. **Détection des sophismes** : Vérification de la détection correcte des sophismes
+2. **Correspondance des patterns** : Test de la correspondance correcte des patterns
+3. **Calcul de la confiance** : Vérification du calcul correct de la confiance
+4. **Extraction du contexte** : Test de l'extraction correcte du contexte
+5. **Gestion des cas limites** : Vérification de la gestion correcte des cas limites
+
+#### Pattern de Test de l'Analyseur Rhétorique
+
+Ce pattern teste les fonctionnalités de l'analyseur rhétorique :
+
+1. **Analyse du ton** : Vérification de l'analyse correcte du ton
+2. **Analyse du style** : Test de l'analyse correcte du style
+3. **Identification des techniques rhétoriques** : Vérification de l'identification correcte des techniques rhétoriques
+4. **Évaluation de l'efficacité** : Test de l'évaluation correcte de l'efficacité
+5. **Analyse des figures de style** : Vérification de l'analyse correcte des figures de style
+
+## Bonnes Pratiques
+
+### Isolation des Tests
+
+Chaque test doit être isolé des autres tests, c'est-à-dire qu'il ne doit pas dépendre de l'état laissé par d'autres tests. Cela garantit que les tests peuvent être exécutés dans n'importe quel ordre et que l'échec d'un test n'affecte pas les autres tests.
+
+### Utilisation de Mocks
+
+Les mocks doivent être utilisés pour simuler le comportement des dépendances externes, afin d'isoler le composant testé et de contrôler précisément les conditions de test. Cependant, il est important de s'assurer que les mocks reflètent fidèlement le comportement des dépendances réelles.
+
+### Tests Paramétrés
+
+Les tests paramétrés doivent être utilisés pour tester un comportement avec différentes entrées, afin de maximiser la couverture avec un minimum de code. Cela permet également de s'assurer que le comportement est cohérent pour différentes entrées.
+
+### Tests de Régression
+
+Des tests de régression doivent être ajoutés pour chaque bug corrigé, afin de s'assurer que le bug ne réapparaît pas dans le futur. Ces tests doivent reproduire les conditions exactes qui ont conduit au bug.
+
+### Documentation des Tests
+
+Chaque test doit être documenté avec une description claire de ce qu'il teste et des conditions dans lesquelles il s'exécute. Cela facilite la maintenance des tests et aide les autres développeurs à comprendre leur objectif.
+
+## Mesure de la Couverture
+
+### Outils de Mesure
+
+La couverture des tests est mesurée à l'aide de l'outil `pytest-cov`, qui génère des rapports détaillés sur la couverture des tests. Ces rapports indiquent quelles lignes de code ont été exécutées par les tests et quelles lignes n'ont pas été couvertes.
+
+### Interprétation des Résultats
+
+La couverture des tests est exprimée en pourcentage de lignes de code couvertes par les tests. Cependant, il est important de noter que 100% de couverture ne garantit pas l'absence de bugs. La qualité des tests est tout aussi importante que leur quantité.
+
+### Objectifs de Couverture
+
+L'objectif est d'atteindre une couverture d'au moins 30% pour chaque module prioritaire et une couverture globale d'au moins 25%. Ces objectifs sont considérés comme un minimum acceptable pour garantir la fiabilité du système.
+
+### Amélioration Continue
+
+La couverture des tests doit être améliorée continuellement, en ajoutant de nouveaux tests pour les fonctionnalités non couvertes et en améliorant les tests existants pour couvrir plus de cas. Les rapports de couverture doivent être analysés régulièrement pour identifier les zones nécessitant plus de tests.

--- a/docs/guides/testing/best_practices.md
+++ b/docs/guides/testing/best_practices.md
@@ -1,0 +1,434 @@
+# Bonnes Pratiques pour les Tests d'Intégration et Fonctionnels
+
+Ce document présente les bonnes pratiques à suivre pour l'écriture et l'exécution des tests d'intégration et fonctionnels dans le projet d'Intelligence Symbolique.
+
+## Table des Matières
+
+1. [Principes Généraux](#principes-généraux)
+2. [Organisation des Tests](#organisation-des-tests)
+3. [Gestion des Dépendances](#gestion-des-dépendances)
+4. [Fixtures et Utilitaires](#fixtures-et-utilitaires)
+5. [Tests d'Intégration](#tests-dintégration)
+6. [Tests Fonctionnels](#tests-fonctionnels)
+7. [Exécution des Tests](#exécution-des-tests)
+8. [Résolution des Problèmes Courants](#résolution-des-problèmes-courants)
+
+## Principes Généraux
+
+### Objectifs des Tests
+
+- **Tests d'intégration** : Vérifier que les différents modules du système fonctionnent correctement ensemble.
+- **Tests fonctionnels** : Vérifier que le système répond aux exigences fonctionnelles et se comporte comme prévu du point de vue de l'utilisateur.
+
+### Bonnes Pratiques Générales
+
+1. **Isolation** : Chaque test doit être indépendant des autres tests.
+2. **Reproductibilité** : Les tests doivent être reproductibles et donner les mêmes résultats à chaque exécution.
+3. **Clarté** : Les tests doivent être clairs et faciles à comprendre.
+4. **Maintenabilité** : Les tests doivent être faciles à maintenir et à mettre à jour.
+5. **Couverture** : Les tests doivent couvrir les cas normaux, les cas limites et les cas d'erreur.
+
+## Organisation des Tests
+
+### Structure des Répertoires
+
+```
+tests/
+├── __init__.py
+├── conftest.py                    # Configuration globale pour pytest
+├── test_*.py                      # Tests unitaires
+├── integration/                   # Tests d'intégration
+│   ├── __init__.py
+│   ├── test_*_integration.py      # Tests d'intégration spécifiques
+├── functional/                    # Tests fonctionnels
+│   ├── __init__.py
+│   ├── test_*_workflow.py         # Tests de flux de travail
+├── fixtures/                      # Fixtures réutilisables
+│   ├── __init__.py
+│   ├── *_fixtures.py              # Fixtures spécifiques
+├── utils/                         # Utilitaires pour les tests
+│   ├── __init__.py
+│   ├── test_*.py                  # Utilitaires spécifiques
+├── mocks/                         # Mocks pour les dépendances
+│   ├── __init__.py
+│   ├── *_mock.py                  # Mocks spécifiques
+```
+
+### Conventions de Nommage
+
+- **Tests d'intégration** : `test_*_integration.py`
+- **Tests fonctionnels** : `test_*_workflow.py`
+- **Fixtures** : `*_fixtures.py`
+- **Utilitaires** : `test_*.py`
+- **Mocks** : `*_mock.py`
+
+### Tests Asynchrones
+
+Pour les tests nécessitant des opérations asynchrones, le projet utilise `pytest-asyncio`. Les tests asynchrones doivent être marqués avec `@pytest.mark.anyio`.
+
+Exemple :
+```python
+import pytest
+
+@pytest.mark.anyio
+async def test_ma_fonction_asynchrone():
+    # ... code du test ...
+    result = await ma_fonction_asynchrone()
+    assert result == "valeur attendue"
+```
+L'ancienne classe utilitaire `AsyncTestCase` est obsolète et a été retirée du projet.
+## Gestion des Dépendances
+
+### Approche de Résolution des Dépendances
+
+L'approche recommandée est de résoudre les problèmes de dépendances (numpy, pandas, jpype) en utilisant des versions spécifiques connues pour être compatibles avec notre environnement de test.
+
+```bash
+# Windows (PowerShell)
+.\scripts\setup\fix_dependencies.ps1
+
+# Linux/macOS
+python scripts/setup/fix_dependencies.py
+```
+
+### Vérification des Dépendances
+
+Avant d'exécuter les tests, vérifiez que les dépendances sont correctement installées :
+
+```bash
+# Windows (PowerShell)
+.\scripts\setup\test_dependencies.ps1
+
+# Linux/macOS
+python scripts/setup/test_dependencies.py
+```
+
+### Utilisation des Mocks
+
+Dans certains cas, il peut être nécessaire d'utiliser des mocks pour les dépendances problématiques. Utilisez les mocks fournis dans le répertoire `tests/mocks/` :
+
+```python
+from tests.utils.test_helpers import mocked_dependencies
+
+with mocked_dependencies():
+    # Code utilisant les dépendances mockées
+    result = my_function()
+```
+
+## Fixtures et Utilitaires
+
+### Utilisation des Fixtures
+
+Les fixtures sont des fonctions qui fournissent des données ou des objets réutilisables pour les tests. Utilisez les fixtures fournies dans le répertoire `tests/fixtures/` :
+
+```python
+import pytest
+from tests.fixtures.rhetorical_data_fixtures import example_text, example_fallacies
+
+def test_fallacy_detection(example_text, example_fallacies):
+    # Utiliser example_text et example_fallacies dans le test
+    pass
+```
+
+### Utilitaires de Test
+
+Les utilitaires de test sont des fonctions qui facilitent l'écriture et l'exécution des tests. Utilisez les utilitaires fournis dans le répertoire `tests/utils/` :
+
+```python
+from tests.utils.test_helpers import temp_file, read_json_file
+
+def test_file_processing():
+    with temp_file("Contenu de test") as file_path:
+        # Utiliser file_path dans le test
+        result = process_file(file_path)
+        assert result is not None
+```
+
+### Générateurs de Données
+
+Les générateurs de données sont des fonctions qui génèrent des données de test. Utilisez les générateurs fournis dans le répertoire `tests/utils/` :
+
+```python
+from tests.utils.test_data_generators import generate_text_with_fallacies
+
+def test_fallacy_analysis():
+    text = generate_text_with_fallacies(fallacy_types=["ad_hominem", "faux_dilemme"])
+    # Utiliser text dans le test
+    result = analyze_fallacies(text)
+    assert len(result["fallacies"]) > 0
+```
+
+## Tests d'Intégration
+
+### Patterns pour les Tests d'Intégration
+
+1. **Pattern d'Intégration de Modules** : Tester l'interaction entre deux modules adjacents.
+
+```python
+def test_module_integration():
+    # Créer les modules
+    module1 = Module1()
+    module2 = Module2()
+    
+    # Configurer l'interaction
+    module1.connect(module2)
+    
+    # Exécuter l'opération
+    result = module1.process_with_module2("input")
+    
+    # Vérifier le résultat
+    assert result == "expected output"
+```
+
+2. **Pattern d'Intégration de Composants** : Tester l'interaction entre plusieurs composants.
+
+```python
+def test_component_integration():
+    # Créer les composants
+    component1 = Component1()
+    component2 = Component2()
+    component3 = Component3()
+    
+    # Configurer l'interaction
+    system = System([component1, component2, component3])
+    
+    # Exécuter l'opération
+    result = system.process("input")
+    
+    # Vérifier le résultat
+    assert result == "expected output"
+```
+
+3. **Pattern d'Intégration de Sous-systèmes** : Tester l'interaction entre des sous-systèmes.
+
+```python
+def test_subsystem_integration():
+    # Créer les sous-systèmes
+    subsystem1 = Subsystem1()
+    subsystem2 = Subsystem2()
+    
+    # Configurer l'interaction
+    system = System(subsystem1, subsystem2)
+    
+    # Exécuter l'opération
+    result = system.process("input")
+    
+    # Vérifier le résultat
+    assert result == "expected output"
+```
+
+### Bonnes Pratiques pour les Tests d'Intégration
+
+1. **Isolation des Dépendances Externes** : Utilisez des mocks ou des stubs pour isoler les dépendances externes.
+2. **Tests Progressifs** : Commencez par tester l'intégration de petits modules, puis progressez vers des intégrations plus complexes.
+3. **Vérification des Interfaces** : Vérifiez que les interfaces entre les modules sont correctement utilisées.
+4. **Gestion des Erreurs** : Testez la gestion des erreurs entre les modules.
+5. **Nettoyage** : Assurez-vous de nettoyer les ressources après chaque test.
+
+### Comment tester un agent logique qui dépend de la JVM ?
+
+Tout test impliquant un agent logique (comme `PropositionalLogicAgent` ou d'autres agents basés sur `TweetyBridge`) nécessite que la JVM soit démarrée. Pour garantir cela de manière propre et centralisée, utilisez la fixture `jvm_session`.
+
+**Comment faire :**
+
+Ajoutez le décorateur `@pytest.mark.usefixtures("jvm_session")` au-dessus de votre classe de test.
+
+**Exemple :**
+
+```python
+import pytest
+
+# Assure que la JVM est initialisée avant l'exécution de ces tests.
+@pytest.mark.usefixtures("jvm_session")
+class TestMonAgentLogique:
+    def test_une_fonction_qui_utilise_la_jvm(self):
+        # Ce test s'exécutera avec la garantie que la JVM est prête.
+        assert True
+```
+
+Cette pratique évite les erreurs `RuntimeError: JVM not ready` et centralise la gestion du cycle de vie de la JVM pour toute la session de test.
+
+## Tests Fonctionnels
+
+### Patterns pour les Tests Fonctionnels
+
+1. **Pattern de Flux de Travail** : Tester un flux de travail complet du point de vue de l'utilisateur.
+
+```python
+def test_workflow():
+    # Configurer l'environnement
+    setup_environment()
+    
+    # Exécuter les étapes du flux de travail
+    step1_result = execute_step1("input1")
+    step2_result = execute_step2(step1_result, "input2")
+    final_result = execute_step3(step2_result)
+    
+    # Vérifier le résultat final
+    assert final_result == "expected output"
+    
+    # Nettoyer l'environnement
+    cleanup_environment()
+```
+
+2. **Pattern de Scénario** : Tester un scénario spécifique.
+
+```python
+def test_scenario():
+    # Configurer le scénario
+    setup_scenario()
+    
+    # Exécuter le scénario
+    result = execute_scenario("input")
+    
+    # Vérifier le résultat
+    assert result == "expected output"
+    
+    # Nettoyer le scénario
+    cleanup_scenario()
+```
+
+3. **Pattern de Cas d'Utilisation** : Tester un cas d'utilisation spécifique.
+
+```python
+def test_use_case():
+    # Configurer le cas d'utilisation
+    setup_use_case()
+    
+    # Exécuter le cas d'utilisation
+    result = execute_use_case("input")
+    
+    # Vérifier le résultat
+    assert result == "expected output"
+    
+    # Nettoyer le cas d'utilisation
+    cleanup_use_case()
+```
+
+### Bonnes Pratiques pour les Tests Fonctionnels
+
+1. **Tests de Bout en Bout** : Testez le système de bout en bout, du point de vue de l'utilisateur.
+2. **Scénarios Réalistes** : Utilisez des scénarios réalistes pour les tests.
+3. **Données Réalistes** : Utilisez des données réalistes pour les tests.
+4. **Vérification des Résultats** : Vérifiez que les résultats correspondent aux attentes de l'utilisateur.
+5. **Documentation** : Documentez les scénarios de test pour faciliter leur compréhension et leur maintenance.
+
+## Exécution des Tests
+
+### Exécution des Tests d'Intégration
+
+```bash
+# Exécuter tous les tests d'intégration
+pytest tests/integration/
+
+# Exécuter un test d'intégration spécifique
+pytest tests/integration/test_tactical_operational_integration.py
+```
+
+### Exécution des Tests Fonctionnels
+
+```bash
+# Exécuter tous les tests fonctionnels
+pytest tests/functional/
+
+# Exécuter un test fonctionnel spécifique
+pytest tests/functional/test_rhetorical_analysis_workflow.py
+```
+
+### Exécution avec Couverture de Code
+
+```bash
+# Exécuter les tests avec couverture de code
+pytest --cov=argumentation_analysis tests/integration/ tests/functional/
+
+# Générer un rapport HTML de couverture
+pytest --cov=argumentation_analysis --cov-report=html tests/integration/ tests/functional/
+```
+
+## Résolution des Problèmes Courants
+
+### Problèmes de Dépendances
+
+Si vous rencontrez des problèmes avec les dépendances, essayez les solutions suivantes :
+
+1. **Réinstaller les dépendances** :
+
+```bash
+# Windows (PowerShell)
+.\scripts\setup\fix_dependencies.ps1
+
+# Linux/macOS
+python scripts/setup/fix_dependencies.py
+```
+
+2. **Utiliser les mocks** :
+
+```python
+from tests.utils.test_helpers import mocked_dependencies
+
+with mocked_dependencies():
+    # Code utilisant les dépendances mockées
+    result = my_function()
+```
+
+### Problèmes d'Isolation des Tests
+
+Si les tests ne sont pas correctement isolés, essayez les solutions suivantes :
+
+1. **Utiliser des fixtures avec portée de fonction** :
+
+```python
+@pytest.fixture(scope="function")
+def my_fixture():
+    # Configurer la fixture
+    yield my_object
+    # Nettoyer la fixture
+```
+
+2. **Utiliser des répertoires temporaires** :
+
+```python
+from tests.utils.test_helpers import temp_directory
+
+def test_file_operations():
+    with temp_directory() as temp_dir:
+        # Utiliser temp_dir pour les opérations de fichier
+        pass
+```
+
+### Problèmes de Reproductibilité
+
+Si les tests ne sont pas reproductibles, essayez les solutions suivantes :
+
+1. **Fixer les graines aléatoires** :
+
+```python
+import random
+import numpy as np
+
+def test_random_operations():
+    # Fixer les graines aléatoires
+    random.seed(42)
+    np.random.seed(42)
+    
+    # Exécuter les opérations aléatoires
+    result = my_random_function()
+    
+    # Vérifier le résultat
+    assert result == "expected output"
+```
+
+2. **Utiliser des données de test fixes** :
+
+```python
+from tests.fixtures.rhetorical_data_fixtures import example_text
+
+def test_text_analysis(example_text):
+    # Utiliser example_text au lieu de générer du texte aléatoire
+    result = analyze_text(example_text)
+    assert result is not None
+```
+
+## Conclusion
+
+En suivant ces bonnes pratiques, vous pourrez écrire des tests d'intégration et fonctionnels efficaces, maintenables et reproductibles. Ces tests vous aideront à garantir la qualité et la fiabilité du système d'analyse rhétorique et de détection des sophismes.

--- a/docs/guides/testing/conditional_skips.md
+++ b/docs/guides/testing/conditional_skips.md
@@ -1,0 +1,241 @@
+# Documentation des Skips Conditionnels - Tests
+
+Ce document documente tous les tests skippés conditionnellement, leurs raisons, et les conditions de réactivation.
+
+**Dernière mise à jour** : 2025-10-16 (Phase D3.1.1-Batch2)
+
+---
+
+## 1. Tests PyTorch - Windows (2 tests)
+
+### Tests concernés
+
+1. `tests/unit/argumentation_analysis/test_baselogicagent_import_fix.py::test_service_manager_can_import_baselogicagent`
+2. `tests/unit/argumentation_analysis/test_baselogicagent_import_fix.py::TestBaseLogicAgentImportFix::test_complete_import_resolution`
+
+### Raison du skip
+
+**Problème** : PyTorch `fbgemm.dll` ne peut pas charger ses dépendances sur Windows
+
+**Erreur** : `OSError: [WinError 182] Le système d'exploitation ne peut pas exécuter %1. Error loading "...\torch\lib\fbgemm.dll" or one of its dependencies.`
+
+**Cause racine** : 
+- `fbgemm.dll` (Facebook's GEMM library) nécessite Visual C++ Redistributable
+- Les dépendances natives Windows (vcruntime140.dll, msvcp140.dll) sont manquantes ou incompatibles
+- Problème spécifique à Windows, les tests fonctionnent sous Linux
+
+### Condition du skip
+
+```python
+@pytest.mark.skipif(
+    sys.platform == "win32" and not PYTORCH_AVAILABLE,
+    reason=f"PyTorch fbgemm.dll issue on Windows - {PYTORCH_ERROR}"
+)
+```
+
+Le test est skippé si :
+- Plateforme = Windows (`win32`)
+- ET PyTorch ne peut pas être importé (OSError lors de `import torch`)
+
+### Conditions de réactivation
+
+**Option 1 : Installer Visual C++ Redistributable (recommandé)**
+1. Télécharger : https://aka.ms/vs/17/release/vc_redist.x64.exe
+2. Installer Visual C++ Redistributable 2015-2022 (x64)
+3. Redémarrer le système
+4. Vérifier : `python -c "import torch; print(torch.__version__)"`
+
+**Option 2 : Réinstaller PyTorch CPU-only**
+```bash
+pip uninstall torch torchvision torchaudio -y
+pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+```
+
+**Option 3 : Lazy import dans le code (fix définitif)**
+Modifier `plugins/AnalysisToolsPlugin/logic/contextual_fallacy_analyzer.py` pour importer PyTorch uniquement quand nécessaire avec fallback gracieux.
+
+**Option 4 : Migration Linux CI**
+Exécuter les tests sur Linux où PyTorch fonctionne nativement.
+
+### Impact
+
+- **Tests affectés** : 2 tests d'import BaseLogicAgent
+- **Fonctionnalités** : Tests de résolution des cycles d'import ServiceManager → BaseLogicAgent → PyTorch
+- **Criticité** : Moyenne (tests d'intégration, pas de perte de fonctionnalité runtime)
+
+---
+
+## 2. Tests API Configuration (3 tests)
+
+### Tests concernés
+
+1. `tests/unit/api/test_api_direct_simple.py::test_environment_setup`
+2. `tests/unit/api/test_api_direct_simple.py::test_api_startup_and_basic_functionality`
+3. `tests/unit/api/test_api_direct.py::test_api_startup_and_basic_functionality`
+
+### Raison du skip
+
+**Problème** : Tests nécessitent environnement complet avec clé API OpenAI et fichiers de configuration
+
+**Erreur(s)** :
+- `AssertionError: OPENAI_API_KEY n'a pas été chargée dans l'environnement de test`
+- `AssertionError: Fichier manquant: api/main_simple.py`
+
+**Cause racine** :
+1. Variable d'environnement `OPENAI_API_KEY` non définie ou invalide (<20 caractères)
+2. Fichiers API manquants :
+   - `api/main_simple.py`, `api/endpoints_simple.py`, `api/dependencies_simple.py` (test_api_direct_simple.py)
+   - `api/main.py`, `api/endpoints.py`, `api/dependencies.py` (test_api_direct.py)
+3. Les tests lancent un serveur FastAPI réel via subprocess et nécessitent l'infrastructure complète
+
+### Condition du skip
+
+```python
+API_ENVIRONMENT_AVAILABLE = True
+API_ENVIRONMENT_ERROR = None
+API_FILES_REQUIRED = ["api/main.py", "api/endpoints.py", "api/dependencies.py"]
+
+try:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key or len(api_key) < 20:
+        API_ENVIRONMENT_AVAILABLE = False
+        API_ENVIRONMENT_ERROR = "OPENAI_API_KEY non configurée ou invalide"
+    
+    missing_files = [f for f in API_FILES_REQUIRED if not Path(f).exists()]
+    if missing_files:
+        API_ENVIRONMENT_AVAILABLE = False
+        API_ENVIRONMENT_ERROR = f"Fichiers API manquants: {', '.join(missing_files)}"
+except Exception as e:
+    API_ENVIRONMENT_AVAILABLE = False
+    API_ENVIRONMENT_ERROR = str(e)
+
+@pytest.mark.skipif(
+    not API_ENVIRONMENT_AVAILABLE,
+    reason=f"API test environment not configured - {API_ENVIRONMENT_ERROR}"
+)
+```
+
+Le test est skippé si :
+- `OPENAI_API_KEY` absente, vide ou <20 caractères
+- OU fichiers API requis manquants
+- OU erreur lors de la vérification
+
+### Conditions de réactivation
+
+**Étape 1 : Configurer OPENAI_API_KEY**
+
+Créer/modifier le fichier `.env` à la racine du projet :
+```bash
+OPENAI_API_KEY=sk-votre-cle-api-openai-ici
+```
+
+Ou définir la variable d'environnement système :
+```bash
+# Windows
+set OPENAI_API_KEY=sk-votre-cle-api-openai-ici
+
+# Linux/Mac
+export OPENAI_API_KEY=sk-votre-cle-api-openai-ici
+```
+
+**Étape 2 : Vérifier les fichiers API**
+
+S'assurer que les fichiers suivants existent :
+- `api/main.py` ou `api/main_simple.py`
+- `api/endpoints.py` ou `api/endpoints_simple.py`
+- `api/dependencies.py` ou `api/dependencies_simple.py`
+
+Si les noms diffèrent, créer des liens symboliques ou corriger les noms attendus dans les tests.
+
+**Étape 3 : Installer les dépendances**
+
+```bash
+pip install fastapi uvicorn[standard] requests python-dotenv
+```
+
+**Étape 4 : Tester manuellement**
+
+```bash
+# Test import
+python -c "from api.main import app; print('OK')"
+
+# Test démarrage serveur
+python -m uvicorn api.main:app --host 127.0.0.1 --port 8001
+```
+
+**Étape 5 : Configurer pytest pour charger .env**
+
+Ajouter dans `tests/conftest.py` si nécessaire :
+```python
+@pytest.fixture(scope="session", autouse=True)
+def load_environment_variables():
+    """Charge .env pour tous les tests."""
+    from dotenv import load_dotenv
+    load_dotenv(override=True)
+    yield
+```
+
+### Impact
+
+- **Tests affectés** : 3 tests de validation API FastAPI avec GPT-4o-mini
+- **Fonctionnalités** : Tests d'intégration E2E de l'API de détection de sophismes
+- **Criticité** : Moyenne (tests d'intégration, l'API peut fonctionner même si tests skippés)
+
+---
+
+## 3. Statistiques Globales
+
+| Catégorie | Nombre tests | Plateforme | Dépendances | Criticité |
+|-----------|--------------|------------|-------------|-----------|
+| PyTorch Windows | 2 | Windows only | PyTorch + MSVC | Moyenne |
+| API Config | 3 | Toutes | OPENAI_API_KEY + fichiers | Moyenne |
+| **TOTAL** | **5** | - | - | - |
+
+---
+
+## 4. Workflow de Réactivation Globale
+
+### Pour développeur local
+
+1. **Installer Visual C++ Redistributable** (fix PyTorch)
+2. **Configurer .env** avec `OPENAI_API_KEY`
+3. **Vérifier structure API** (fichiers présents)
+4. **Installer dépendances** : `pip install -r requirements.txt`
+5. **Tester** : `pytest tests/unit/argumentation_analysis/test_baselogicagent_import_fix.py tests/unit/api/ -v`
+
+### Pour CI/CD
+
+**Option 1 : CI Linux (recommandé)**
+- Pas de problème fbgemm.dll sous Linux
+- Configure `OPENAI_API_KEY` via secrets GitHub
+- Tests réactivés automatiquement
+
+**Option 2 : CI Windows**
+- Installer VC++ Redistributable dans image Docker/VM
+- Configure `OPENAI_API_KEY` via secrets
+- Vérifier structure fichiers API
+
+---
+
+## 5. Historique des Modifications
+
+| Date | Version | Modification | Commit |
+|------|---------|--------------|--------|
+| 2025-10-16 | D3.1.1-Batch2 | Ajout skips PyTorch Windows (2 tests) | 8971dc6b |
+| 2025-10-16 | D3.1.1-Batch2 | Ajout skips API Config (3 tests) | 91b76418 |
+| 2025-10-16 | D3.1.1-Batch2 | Documentation initiale | (ce commit) |
+
+---
+
+## 6. Contact et Support
+
+Pour toute question ou problème de réactivation :
+1. Consulter cette documentation
+2. Vérifier les logs d'erreur pytest détaillés
+3. Tester manuellement les imports/configurations problématiques
+4. Créer une issue si le problème persiste après avoir suivi les étapes
+
+---
+
+**Document maintenu par** : Équipe Validation Tests Phase D3.1.1
+**Dernière révision** : 2025-10-16

--- a/docs/guides/testing/dependency_resolution.md
+++ b/docs/guides/testing/dependency_resolution.md
@@ -1,0 +1,158 @@
+# Résolution des Problèmes de Dépendances pour les Tests
+
+Ce document explique comment résoudre les problèmes de dépendances (numpy, pandas, jpype) pour exécuter les tests unitaires sans utiliser de mocks.
+
+## Problèmes de Dépendances Identifiés
+
+Les problèmes de dépendances suivants ont été identifiés :
+
+1. **numpy** : Erreurs d'importation et incompatibilités avec l'environnement de test
+2. **pandas** : Dépendance forte pour l'analyse de données structurées
+3. **jpype** : Erreurs d'initialisation et problèmes de compatibilité
+
+## Solution : Utilisation de Versions Spécifiques
+
+Au lieu d'utiliser des mocks pour ces dépendances, nous avons opté pour l'utilisation de versions spécifiques connues pour être compatibles avec notre environnement de test :
+
+- **numpy==1.24.3** : Cette version est compatible avec notre environnement de test et ne présente pas les erreurs d'importation observées avec d'autres versions.
+- **pandas==2.0.3** : Cette version est compatible avec numpy 1.24.3 et fonctionne correctement dans notre environnement de test.
+- **jpype1==1.4.1** : Cette version résout les erreurs d'initialisation et les problèmes de compatibilité.
+
+## Installation des Dépendances
+
+### Méthode Automatique (Recommandée)
+
+Nous avons créé des scripts pour installer automatiquement les versions compatibles des dépendances :
+
+#### Sous Windows (PowerShell)
+
+```powershell
+# Exécuter le script PowerShell
+.\scripts\setup\fix_dependencies.ps1
+```
+
+Ce script :
+1. Vérifie si Python est installé
+2. Installe les versions spécifiques de numpy, pandas et jpype1
+3. Crée un environnement virtuel pour les tests si nécessaire
+4. Installe toutes les dépendances de test dans l'environnement virtuel
+
+#### Sous Linux/macOS (Bash)
+
+```bash
+# Exécuter le script Python directement
+python scripts/setup/fix_dependencies.py
+
+# Ou créer un environnement virtuel et installer les dépendances
+python -m venv venv_test
+source venv_test/bin/activate  # Linux/macOS
+pip install -r requirements-test.txt
+```
+
+### Méthode Manuelle
+
+Si vous préférez installer les dépendances manuellement :
+
+```bash
+# Installer les versions spécifiques des dépendances problématiques
+pip install numpy==1.24.3 pandas==2.0.3 jpype1==1.4.1
+
+# Installer les autres dépendances de test
+pip install -r requirements-test.txt
+```
+
+## Exécution des Tests
+
+Une fois les dépendances installées, vous pouvez exécuter les tests comme suit :
+
+```bash
+# Activer l'environnement virtuel si vous en utilisez un
+# Windows
+.\venv_test\Scripts\activate
+# Linux/macOS
+source venv_test/bin/activate
+
+# Exécuter tous les tests
+pytest
+
+# Exécuter les tests avec la couverture de code
+pytest --cov=argumentation_analysis
+
+# Générer un rapport HTML de couverture
+pytest --cov=argumentation_analysis --cov-report=html
+```
+
+## Vérification de l'Installation des Dépendances
+
+Pour vérifier que les dépendances sont correctement installées et fonctionnelles :
+
+```python
+# Créer un fichier test_dependencies.py
+import numpy as np
+import pandas as pd
+import jpype
+
+print(f"numpy version: {np.__version__}")
+print(f"pandas version: {pd.__version__}")
+print(f"jpype version: {jpype.__version__}")
+
+# Tester numpy
+arr = np.array([1, 2, 3, 4, 5])
+print(f"numpy array: {arr}")
+print(f"numpy mean: {np.mean(arr)}")
+
+# Tester pandas
+df = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+print(f"pandas DataFrame:\n{df}")
+
+# Tester jpype (sans initialiser la JVM)
+print(f"jpype.isJVMStarted(): {jpype.isJVMStarted()}")
+
+print("Toutes les dépendances sont correctement installées et fonctionnelles.")
+```
+
+Exécutez ce script pour vérifier que les dépendances sont correctement installées :
+
+```bash
+python test_dependencies.py
+```
+
+## Problèmes Connus et Solutions
+
+### Problème : Erreur d'importation de numpy
+
+**Symptôme** : `ImportError: DLL load failed while importing _multiarray_umath: Le module spécifié est introuvable.`
+
+**Solution** : Réinstaller numpy avec la version spécifiée :
+```bash
+pip uninstall -y numpy
+pip install numpy==1.24.3
+```
+
+### Problème : Erreur d'importation de pandas
+
+**Symptôme** : `ImportError: C extension: No module named 'pandas._libs.window.aggregations' not built.`
+
+**Solution** : Réinstaller pandas avec la version spécifiée :
+```bash
+pip uninstall -y pandas
+pip install pandas==2.0.3
+```
+
+### Problème : Erreur d'initialisation de jpype
+
+**Symptôme** : `JVMNotFoundException: No JVM shared library file (jvm.dll) found.`
+
+**Solution** : 
+1. Vérifier que Java est installé et que JAVA_HOME est correctement configuré
+2. Réinstaller jpype avec la version spécifiée :
+```bash
+pip uninstall -y jpype1
+pip install jpype1==1.4.1
+```
+
+## Conclusion
+
+En utilisant des versions spécifiques des dépendances problématiques, nous pouvons exécuter les tests unitaires sans avoir recours à des mocks. Cette approche est préférable car elle permet de tester le code avec les bibliothèques réelles, ce qui garantit que les tests sont plus représentatifs du comportement en production.
+
+Si vous rencontrez des problèmes avec cette approche, n'hésitez pas à consulter les scripts de résolution des dépendances dans le répertoire `scripts/setup/` ou à contacter l'équipe de développement.

--- a/docs/guides/testing/fol_tests.md
+++ b/docs/guides/testing/fol_tests.md
@@ -1,0 +1,342 @@
+﻿# Tests pour FirstOrderLogicAgent (FOL)
+
+## 📋 Vue d'ensemble
+
+Cette suite de tests valide complètement l'agent `FirstOrderLogicAgent` qui remplace le `ModalLogicAgent` problématique. L'agent FOL génère une syntaxe FOL valide et s'intègre parfaitement avec le solveur Tweety sans erreurs de parsing.
+
+## 🎯 Objectifs de validation
+
+### **Métriques critiques**
+- ✅ **100%** des formules FOL générées valides
+- ✅ **0** erreur de parsing Tweety avec syntaxe FOL  
+- ✅ **>95%** compatibilité avec sophismes existants
+- ✅ **Temps réponse** ≤ Modal Logic précédent
+- ✅ **>90%** couverture tests pour FirstOrderLogicAgent
+
+### **Fonctionnalités validées**
+- 🔧 Génération syntaxe FOL : `∀x(P(x) → Q(x))`, `∃x(F(x) ∧ G(x))`
+- 🔧 Intégration Tweety sans erreurs de parsing
+- 🔧 Configuration dynamique via `UnifiedConfig`
+- 🔧 Utilisation dans orchestrations unifiées
+
+## 📁 Structure des tests
+
+```
+tests/
+├── unit/agents/
+│   └── test_fol_logic_agent.py           # Tests unitaires complets
+├── integration/
+│   └── test_fol_tweety_integration.py    # Tests intégration Tweety
+├── validation/
+│   └── test_fol_complete_validation.py   # Validation avec métriques
+├── migration/
+│   └── test_modal_to_fol_migration.py    # Tests migration Modal→FOL
+└── README_FOL_TESTS.md                   # Cette documentation
+```
+
+## 🧪 Tests unitaires (`test_fol_logic_agent.py`)
+
+### **Classes de test**
+
+#### `TestFOLLogicAgentInitialization`
+- ✅ `test_agent_initialization_with_fol_config()` - Création avec config FOL
+- ✅ `test_unified_config_fol_mapping()` - Mapping depuis `UnifiedConfig.logic_type='FOL'`
+- ✅ `test_agent_parameters_configuration()` - Paramètres agent (expertise, style)
+- ✅ `test_fol_configuration_validation()` - Validation configuration FOL
+
+#### `TestFOLSyntaxGeneration`
+- ✅ `test_quantifier_universal_generation()` - Tests `∀x(P(x) → Q(x))`
+- ✅ `test_quantifier_existential_generation()` - Tests `∃x(F(x) ∧ G(x))`
+- ✅ `test_complex_predicate_generation()` - Tests `∀x∀y(R(x,y) → S(y,x))`
+- ✅ `test_logical_connectors_validation()` - Tests `∧`, `∨`, `→`, `¬`, `↔`
+
+#### `TestFOLTweetyIntegration`
+- ✅ `test_tweety_integration_fol()` - Compatibilité syntaxe Tweety
+- ✅ `test_tweety_validation_formulas()` - Validation avant envoi Tweety
+- ✅ `test_tweety_error_handling_fol()` - Gestion erreurs Tweety
+- ✅ `test_tweety_results_analysis_fol()` - Analyse résultats Tweety
+
+#### `TestFOLAnalysisPipeline`
+- ✅ `test_sophism_analysis_with_fol()` - Analyse sophismes avec FOL
+- ✅ `test_fol_report_generation()` - Génération rapport avec formules FOL
+- ✅ `test_tweety_error_analyzer_integration()` - Intégration `TweetyErrorAnalyzer`
+- ✅ `test_performance_analysis()` - Tests performance
+
+### **Syntaxe FOL validée**
+
+```fol
+# Quantificateurs de base
+∀x(Human(x) → Mortal(x))
+∃x(Student(x) ∧ Intelligent(x))
+
+# Prédicats complexes  
+∀x∀y(Loves(x,y) → Cares(x,y))
+∃x∃y(Friend(x,y) ∧ Trust(x,y))
+
+# Connecteurs logiques complets
+∀x((P(x) ∧ Q(x)) → (R(x) ∨ S(x)))
+∃x(¬Bad(x) ↔ Good(x))
+```
+
+## 🔗 Tests d'intégration (`test_fol_tweety_integration.py`)
+
+### **Validation Tweety authentique**
+
+#### `TestFOLTweetyCompatibility`
+- ✅ `test_fol_formula_tweety_compatibility()` - Formules acceptées par Tweety réel
+- ✅ `test_fol_predicate_declaration_validation()` - Validation déclaration prédicats
+- ✅ `test_fol_quantifier_binding_validation()` - Validation liaison quantificateurs
+
+#### `TestRealTweetyFOLAnalysis`
+- ✅ `test_real_tweety_fol_syllogism_analysis()` - Analyse syllogisme avec Tweety réel
+- ✅ `test_real_tweety_fol_inconsistency_detection()` - Détection incohérence
+- ✅ `test_real_tweety_fol_inference_generation()` - Génération inférences
+
+#### `TestFOLErrorHandling`
+- ✅ `test_fol_predicate_declaration_error_handling()` - Gestion erreurs déclaration
+- ✅ `test_fol_syntax_error_recovery()` - Récupération erreurs syntaxe
+- ✅ `test_fol_timeout_handling()` - Gestion timeouts
+
+### **Exigences Tweety**
+- 🔧 `USE_REAL_JPYPE=true` pour tests authentiques
+- 🔧 JAR Tweety authentique requis
+- 🔧 Parsing sans erreurs validé
+- 🔧 Résultats cohérents garantis
+
+## 📊 Validation complète (`test_fol_complete_validation.py`)
+
+### **Métriques automatisées**
+
+La classe `FOLCompleteValidator` exécute une validation exhaustive :
+
+#### **Critères validés**
+- 📈 **100%** formules FOL syntaxiquement valides
+- 📈 **0** erreur parsing Tweety  
+- 📈 **>95%** compatibilité sophismes existants
+- 📈 **Performance** acceptable (< 10s moyenne)
+- 📈 **Gestion erreurs** complète et gracieuse
+
+#### **Tests d'échantillons**
+- 🔍 **Syntaxe FOL** : Quantificateurs, prédicats, connecteurs
+- 🔍 **Sophismes** : Syllogismes, sophismes classiques, contradictions
+- 🔍 **Argumentation complexe** : Philosophie, science, déontique
+- 🔍 **Cas d'erreur** : Texte vide, non-logique, caractères spéciaux
+
+### **Rapport automatique**
+```json
+{
+  "overall_success": true,
+  "metrics": {
+    "fol_syntax_validity_rate": 1.0,
+    "tweety_parsing_success_rate": 1.0,
+    "sophism_compatibility": 0.98,
+    "avg_analysis_time": 3.2,
+    "avg_confidence": 0.85
+  },
+  "recommendations": ["✅ Agent FOL prêt pour production"]
+}
+```
+
+## 🔄 Tests de migration (`test_modal_to_fol_migration.py`)
+
+### **Validation remplacement Modal Logic**
+
+#### `TestModalToFOLInterface`
+- ✅ `test_interface_compatibility()` - Interface identique
+- ✅ `test_configuration_migration_transparency()` - Migration config transparente
+- ✅ `test_result_structure_compatibility()` - Structure résultats compatible
+
+#### `TestFunctionalReplacement`
+- ✅ `test_sophism_analysis_migration()` - Migration analyse sophismes
+- ✅ `test_error_handling_improvement()` - Amélioration gestion erreurs
+
+#### `TestPerformanceComparison`
+- ✅ `test_performance_parity_or_improvement()` - Performance équivalente/meilleure
+- ✅ `test_stability_improvement()` - Stabilité améliorée
+
+### **Améliorations vs Modal Logic**
+- 🚀 **Stabilité** : Moins de crashes et erreurs
+- 🚀 **Performance** : Temps réponse équivalent ou meilleur
+- 🚀 **Compatibilité** : Même interface, meilleurs résultats
+- 🚀 **Intégration** : Fonctionne avec orchestrations existantes
+
+## 🚀 Exécution des tests
+
+### **Script d'exécution automatisé**
+```bash
+# Tous les tests
+python scripts/run_fol_tests.py --all
+
+# Tests unitaires seulement
+python scripts/run_fol_tests.py --unit-only
+
+# Tests intégration avec Tweety réel
+python scripts/run_fol_tests.py --integration --real-tweety
+
+# Validation complète avec métriques
+python scripts/run_fol_tests.py --validation
+
+# Tests migration Modal → FOL
+python scripts/run_fol_tests.py --migration
+```
+
+### **Prérequis pour tests complets**
+```bash
+# Variables d'environnement
+export USE_REAL_JPYPE=true
+export TWEETY_JAR_PATH=libs/tweety-full.jar
+export JVM_MEMORY=1024m
+export UNIFIED_LOGIC_TYPE=fol
+export UNIFIED_MOCK_LEVEL=none
+
+# Installation dépendances
+pip install pytest pytest-asyncio pytest-json-report
+```
+
+### **Tests par niveau**
+
+#### **Niveau 1 : Tests unitaires (sans Tweety)**
+```bash
+python scripts/run_fol_tests.py --unit-only
+# ✅ Validation syntaxe FOL
+# ✅ Configuration UnifiedConfig  
+# ✅ Interface agent
+# ✅ Pipeline analyse (mocked)
+```
+
+#### **Niveau 2 : Tests intégration (avec Tweety simulé)**
+```bash
+python scripts/run_fol_tests.py --integration
+# ✅ Compatibilité syntaxe (simulée)
+# ✅ Gestion erreurs
+# ✅ Performance
+```
+
+#### **Niveau 3 : Tests authentiques (Tweety réel)**
+```bash
+python scripts/run_fol_tests.py --integration --real-tweety
+# ✅ Parsing Tweety authentique
+# ✅ Analyse syllogismes réels
+# ✅ Détection incohérences réelles
+# ✅ Inférences Tweety valides
+```
+
+#### **Niveau 4 : Validation complète**
+```bash
+python scripts/run_fol_tests.py --validation --real-tweety
+# ✅ Métriques toutes validées
+# ✅ Critères 100% respectés
+# ✅ Rapport détaillé généré
+# ✅ Recommandations produites
+```
+
+## 📋 Rapport de validation
+
+### **Exemple de rapport réussi**
+```
+📋 RAPPORT VALIDATION AGENT FOL
+================================================================================
+
+🕐 Temps total: 45.67s
+🎯 Succès global: ✅ OUI
+📊 Taux réussite: 100% (4/4)
+
+📋 Résultats par suite:
+  ✅ Unit: 12.34s
+  ✅ Integration: 18.45s  
+  ✅ Validation: 8.92s
+  ✅ Migration: 5.96s
+
+📏 Conformité critères:
+  ✅ 100% formules FOL valides
+  ✅ 0 erreur parsing Tweety
+  ✅ >95% compatibilité sophismes
+  ✅ Performance acceptable
+  ✅ Gestion erreurs complète
+
+📈 Métriques clés:
+  • Syntaxe FOL valide: 100%
+  • Parsing Tweety: 100%
+  • Compatibilité sophismes: 98%
+  • Temps analyse moyen: 3.20s
+  • Confiance moyenne: 0.85
+
+💡 Recommandations:
+  • ✅ Tous les tests réussis - Agent FOL prêt pour production
+
+🎉 Agent FOL validé avec succès!
+```
+
+## 🔧 Configuration et environnement
+
+### **Configuration UnifiedConfig pour FOL**
+```python
+# Configuration authentique FOL
+config = PresetConfigs.authentic_fol()
+assert config.logic_type == LogicType.FOL
+assert config.mock_level == MockLevel.NONE
+assert config.require_real_tweety == True
+assert AgentType.FOL_LOGIC in config.agents
+
+# Utilisation en orchestration
+agent_classes = config.get_agent_classes()
+assert agent_classes["fol_logic"] == "FirstOrderLogicAgent"
+```
+
+### **Mapping automatique Modal → FOL**
+```python
+# Configuration legacy automatiquement migrée
+config = UnifiedConfig(logic_type=LogicType.FOL)
+# AgentType.LOGIC automatiquement remplacé par AgentType.FOL_LOGIC
+assert AgentType.FOL_LOGIC in config.agents
+```
+
+## 📚 Documentation technique
+
+### **Syntaxe FOL supportée**
+- **Quantificateurs** : `∀x`, `∃x`, `∀x∀y`, `∃x∃y`
+- **Prédicats** : `P(x)`, `Q(x,y)`, `R(x,y,z)`
+- **Connecteurs** : `∧` (et), `∨` (ou), `→` (implique), `¬` (non), `↔` (équivalent)
+- **Variables** : `x`, `y`, `z` (liées par quantificateurs)
+- **Constantes** : `a`, `b`, `c`, `socrate`, etc.
+
+### **Intégration Tweety**
+- **Initialisation** : `TweetyBridge.initialize_fol_reasoner()`
+- **Validation** : `check_consistency(formulas)`
+- **Inférences** : `derive_inferences(formulas)` 
+- **Modèles** : `generate_models(formulas)`
+
+### **Gestion d'erreurs**
+- **TweetyErrorAnalyzer** : Analyse erreurs avec feedback BNF
+- **Récupération gracieuse** : Aucun crash sur erreurs
+- **Logging détaillé** : Traces complètes pour debugging
+
+## 🎯 Critères de succès
+
+### **Critères obligatoires (PASS/FAIL)**
+- [ ] **100%** formules FOL syntaxiquement valides
+- [ ] **0** erreur parsing Tweety avec syntaxe FOL
+- [ ] **>95%** compatibilité avec sophismes existants
+- [ ] **Performance** ≤ Modal Logic précédent
+- [ ] **>90%** couverture tests
+- [ ] **Migration** transparente depuis Modal Logic
+
+### **Critères d'amélioration**
+- [ ] **Stabilité** améliorée (moins d'erreurs vs Modal Logic)
+- [ ] **Confiance** moyenne > 70%
+- [ ] **Gestion erreurs** gracieuse sur tous cas de test
+- [ ] **Documentation** complète et exemples
+
+## 🚦 Prochaines étapes
+
+1. **Exécution initiale** : `python scripts/run_fol_tests.py --unit-only`
+2. **Validation progressive** : Ajouter `--integration` puis `--real-tweety`
+3. **Validation finale** : `python scripts/run_fol_tests.py --all --real-tweety`
+4. **Déploiement** : Si tous critères validés
+5. **Migration production** : Remplacement Modal Logic par FOL
+
+---
+
+**✅ Agent FOL validé** = Prêt pour remplacement de Modal Logic en production  
+**⚠️ Validation partielle** = Corrections nécessaires avant déploiement  
+**❌ Validation échouée** = Retour développement requis

--- a/docs/guides/testing/functional_tests.md
+++ b/docs/guides/testing/functional_tests.md
@@ -1,0 +1,355 @@
+# Tests Fonctionnels - Playwright
+
+## Vue d'ensemble
+
+Suite de tests fonctionnels end-to-end utilisant Playwright pour valider l'intégration complète entre le frontend React et l'API backend Flask. Ces tests automatisent l'interaction utilisateur avec l'interface web et vérifient le bon fonctionnement de la chaîne complète d'analyse argumentative.
+
+## 🧪 Architecture des Tests
+
+### Framework : Playwright
+- **Navigateur** : Chromium (headless)
+- **Langage** : Python avec pytest
+- **Approche** : Tests end-to-end via automation navigateur
+- **Couverture** : Interface utilisateur + API + intégration
+
+### Structure des Tests
+```
+tests/
+├── functional/
+│   ├── test_logic_graph.py      # Tests principaux interface web
+│   ├── conftest.py              # Configuration pytest commune
+│   └── fixtures/
+│       ├── test_data.py         # Données de test
+│       └── page_objects.py      # Page Object Models
+├── README_FUNCTIONAL_TESTS.md   # Cette documentation
+└── requirements.txt             # Dépendances tests
+```
+
+## 🎯 Scénarios de Test
+
+### `test_logic_graph.py`
+
+#### Test 1: Conversion Logique de Base
+```python
+async def test_logic_graph_conversion(page):
+    """Test conversion texte → graphique logique"""
+```
+
+**Objectif :** Valider le workflow complet de conversion
+
+**Étapes :**
+1. Navigation vers `http://localhost:3000`
+2. Saisie de texte logique : `"A -> B; B -> C"`
+3. Clic sur bouton "Convertir"
+4. Attente de la réponse API
+5. Vérification affichage du graphique résultant
+
+**Validations :**
+- ✅ Interface utilisateur répond correctement
+- ✅ Requête API `/api/logic/belief-set` envoyée avec bon format
+- ✅ Réponse API contient `success: true` et `belief_set`
+- ✅ Graphique SVG affiché dans l'interface
+- ✅ Temps de traitement < 2 secondes
+
+#### Test 2: Validation des Entrées
+```python
+async def test_invalid_input_handling(page):
+    """Test gestion des entrées invalides"""
+```
+
+**Objectif :** Vérifier la robustesse de la validation
+
+**Étapes :**
+1. Saisie de texte invalide : `"invalid logic syntax"`
+2. Soumission du formulaire
+3. Vérification gestion d'erreur appropriée
+
+**Validations :**
+- ✅ Message d'erreur utilisateur affiché
+- ✅ Interface reste stable (pas de crash)
+- ✅ Possibilité de corriger et re-soumettre
+
+#### Test 3: Performance et Interaction
+```python
+async def test_user_interaction_flow(page):
+    """Test workflow interaction utilisateur complet"""
+```
+
+**Objectif :** Valider l'expérience utilisateur complète
+
+**Étapes :**
+1. Interaction avec différents éléments d'interface
+2. Tests de réactivité et feedback visuel
+3. Vérification des états de chargement
+
+**Validations :**
+- ✅ Boutons réactifs aux interactions
+- ✅ États de chargement visibles
+- ✅ Interface responsive et fluide
+
+## 🚀 Exécution des Tests
+
+### Prérequis
+1. **Backend API** lancé sur `http://localhost:5003`
+2. **Frontend React** lancé sur `http://localhost:3000`
+3. **Environnement Python** activé avec dépendances
+
+### Méthode Recommandée : Script Automatisé
+```powershell
+# Exécution complète automatisée
+.\scripts\run_all_and_test.ps1
+```
+
+**Ce script :**
+- ✅ Active l'environnement Python
+- ✅ Lance le backend API en arrière-plan
+- ✅ Lance le frontend React en arrière-plan  
+- ✅ Attend que les serveurs soient prêts
+- ✅ Exécute tous les tests Playwright
+- ✅ Nettoie les processus à la fin
+
+### Exécution Manuelle
+
+#### 1. Préparer l'Environnement
+```powershell
+# Activer l'environnement
+.\scripts\env\activate_project_env.ps1
+
+# Installer dépendances Playwright
+pip install playwright
+playwright install chromium
+```
+
+#### 2. Lancer les Services
+```powershell
+# Terminal 1: Backend API
+python -m argumentation_analysis.services.web_api.app
+
+# Terminal 2: Frontend React  
+cd services\web_api\interface-web-argumentative
+npm start
+```
+
+#### 3. Exécuter les Tests
+```powershell
+# Tous les tests fonctionnels
+pytest tests/functional/ -v
+
+# Test spécifique
+pytest tests/functional/test_logic_graph.py::test_logic_graph_conversion -v
+
+# Avec output détaillé
+pytest tests/functional/ -v -s
+```
+
+## 📊 Rapports et Résultats
+
+### Format de Sortie Pytest
+```
+tests/functional/test_logic_graph.py::test_logic_graph_conversion PASSED [33%]
+tests/functional/test_logic_graph.py::test_invalid_input_handling PASSED [66%]  
+tests/functional/test_logic_graph.py::test_user_interaction_flow PASSED [100%]
+
+=================== 3 passed in 12.45s ===================
+```
+
+### Métriques de Performance
+- **Temps d'exécution total** : ~12-15 secondes
+- **Temps par test** : 3-5 secondes
+- **Couverture** : Interface complète + API endpoints critiques
+
+### Artifacts de Debug
+En cas d'échec, Playwright génère automatiquement :
+- **Screenshots** : Captures d'écran au moment de l'erreur
+- **Videos** : Enregistrement de l'interaction complète
+- **Traces** : Timeline détaillée des actions
+
+## 🔧 Configuration Avancée
+
+### Variables d'Environnement
+```bash
+# Configuration Playwright
+PLAYWRIGHT_BROWSERS_PATH=./browsers
+PLAYWRIGHT_TIMEOUT=30000
+
+# URLs de test (si différentes)
+FRONTEND_URL=http://localhost:3000
+BACKEND_URL=http://localhost:5003
+```
+
+### Configuration Browser
+```python
+# conftest.py
+@pytest.fixture
+async def browser():
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(
+            headless=True,           # Mode sans interface
+            slow_mo=100,            # Ralentissement pour debug
+            args=['--disable-dev-shm-usage']
+        )
+        yield browser
+        await browser.close()
+```
+
+### Timeouts et Retry
+```python
+# Attente intelligente des éléments
+await page.wait_for_selector('#result-graph', timeout=5000)
+
+# Retry automatique des requêtes réseau
+await page.wait_for_response(
+    lambda response: "/api/logic/belief-set" in response.url,
+    timeout=10000
+)
+```
+
+## 🐛 Résolution de Problèmes
+
+### Erreurs Communes
+
+#### Test Timeout
+```
+TimeoutError: page.wait_for_selector: Timeout 30000ms exceeded.
+```
+
+**Causes possibles :**
+- Backend API non démarré
+- Frontend React non accessible
+- Réseau lent ou surcharge système
+
+**Solutions :**
+1. Vérifier `http://localhost:5003/api/health`
+2. Vérifier `http://localhost:3000`
+3. Augmenter les timeouts dans la configuration
+
+#### Élément Non Trouvé
+```
+Error: Element not found: #submit-button
+```
+
+**Causes possibles :**
+- Sélecteur CSS incorrect
+- Element pas encore chargé
+- Changement dans l'interface frontend
+
+**Solutions :**
+1. Vérifier les sélecteurs dans le code frontend
+2. Ajouter des attentes explicites
+3. Utiliser `page.wait_for_selector()`
+
+#### Échec de Requête API
+```
+AssertionError: Expected success=true in API response
+```
+
+**Causes possibles :**
+- API retourne une erreur
+- Format de requête incorrect
+- Service backend défaillant
+
+**Solutions :**
+1. Tester l'API manuellement avec curl/Postman
+2. Vérifier les logs du backend
+3. Valider le format JSON de la requête
+
+### Mode Debug
+
+#### Exécution avec Interface Visible
+```python
+# Modifier conftest.py temporairement
+browser = await p.chromium.launch(headless=False, slow_mo=1000)
+```
+
+#### Screenshots de Debug
+```python
+# Ajouter dans les tests
+await page.screenshot(path="debug_screenshot.png")
+await page.pause()  # Pause interactive pour debug
+```
+
+#### Logs Détaillés
+```powershell
+# Activer debug Playwright
+$env:DEBUG = "pw:api"
+pytest tests/functional/ -v -s
+```
+
+## 📈 Métriques et Monitoring
+
+### Couverture Fonctionnelle
+- ✅ **Interface utilisateur** : 100% des composants critiques
+- ✅ **API endpoints** : 100% des endpoints publics  
+- ✅ **Intégration** : 100% du workflow principal
+- ✅ **Gestion d'erreurs** : Scénarios d'erreur principaux
+
+### Performance Benchmarks
+- **Temps de réponse API** : < 1 seconde
+- **Rendu interface** : < 500ms
+- **Workflow complet** : < 3 secondes
+
+### Reliability
+- **Taux de succès** : > 95% en conditions normales
+- **Stabilité** : Tests reproductibles
+- **Isolation** : Aucune dépendance entre tests
+
+## 🔄 Intégration CI/CD
+
+### Pipeline Automatisé
+```yaml
+# Exemple GitHub Actions
+name: Functional Tests
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run functional tests
+        run: ./scripts/run_all_and_test.ps1
+```
+
+### Intégration Locale
+```powershell
+# Hook pre-commit pour validation
+# .git/hooks/pre-commit
+#!/bin/sh
+./scripts/run_all_and_test.ps1
+if [ $? -ne 0 ]; then
+    echo "Tests fonctionnels échoués - commit annulé"
+    exit 1
+fi
+```
+
+## 📚 Documentation Associée
+
+- **[Guide Application Web](../docs/WEB_APPLICATION_GUIDE.md)** : Guide utilisateur complet
+- **[API Backend](../argumentation_analysis/services/web_api/README.md)** : Documentation API
+- **[Frontend React](../services/web_api/interface-web-argumentative/README.md)** : Documentation frontend
+- **[Script d'Exécution](../scripts/run_all_and_test.ps1)** : Pipeline automatisé
+
+## 🤝 Maintenance et Évolution
+
+### Ajout de Nouveaux Tests
+1. Créer nouvelle fonction test dans `test_logic_graph.py`
+2. Suivre le pattern async/await
+3. Utiliser les fixtures communes
+4. Documenter le scénario testé
+
+### Mise à Jour des Tests
+Lors de changements d'interface :
+1. Mettre à jour les sélecteurs CSS
+2. Adapter les timeouts si nécessaire
+3. Valider que tous les tests passent
+4. Mettre à jour cette documentation
+
+---
+
+*Dernière mise à jour : 2025-06-06*  
+*Tests compatibles avec : API v1.0.0, Frontend v1.0.0*  
+*Playwright version : 1.40+*

--- a/docs/guides/testing/integration_tests.md
+++ b/docs/guides/testing/integration_tests.md
@@ -1,0 +1,375 @@
+# Tests d'Intégration pour le Projet d'Intelligence Symbolique
+
+Ce document explique comment écrire, exécuter et maintenir les tests d'intégration pour le projet d'Intelligence Symbolique.
+
+## Table des Matières
+
+1. [Introduction](#introduction)
+2. [Structure des Tests d'Intégration](#structure-des-tests-dintégration)
+3. [Modules Prioritaires](#modules-prioritaires)
+4. [Approche de Test](#approche-de-test)
+5. [Fixtures et Utilitaires](#fixtures-et-utilitaires)
+6. [Exécution des Tests](#exécution-des-tests)
+7. [Bonnes Pratiques](#bonnes-pratiques)
+8. [Exemples](#exemples)
+
+## Introduction
+
+Les tests d'intégration vérifient que les différents modules du système fonctionnent correctement ensemble. Ils sont essentiels pour s'assurer que les interactions entre les composants sont correctes et que le système dans son ensemble fonctionne comme prévu.
+
+### Objectifs des Tests d'Intégration
+
+- Vérifier l'interaction entre les modules prioritaires
+- Tester les flux de données entre les différents niveaux hiérarchiques
+- Vérifier la communication entre les agents et les outils d'analyse
+- Détecter les problèmes d'intégration qui ne sont pas visibles dans les tests unitaires
+
+## Structure des Tests d'Intégration
+
+Les tests d'intégration sont organisés dans le répertoire `tests/integration/`. Chaque fichier de test se concentre sur l'intégration entre des modules spécifiques.
+
+```
+tests/integration/
+├── __init__.py
+├── test_tactical_operational_integration.py    # Intégration entre les niveaux tactique et opérationnel
+├── test_agents_tools_integration.py            # Intégration entre les agents et les outils d'analyse
+├── test_informal_analysis_integration.py       # Intégration entre les agents informels et les outils d'analyse
+```
+
+## Modules Prioritaires
+
+Les modules prioritaires pour les tests d'intégration sont :
+
+1. **orchestration.hierarchical.tactical** (11.78%)
+2. **orchestration.hierarchical.operational.adapters** (12.44%)
+3. **agents.tools.analysis.enhanced** (12.90%)
+4. **agents.core.informal** (16.23%)
+5. **agents.tools.analysis** (16.46%)
+
+## Approche de Test
+
+### Approche de Résolution des Dépendances
+
+L'approche recommandée est de résoudre les problèmes de dépendances (numpy, pandas, jpype) en utilisant des versions spécifiques connues pour être compatibles avec notre environnement de test.
+
+```bash
+# Windows (PowerShell)
+.\scripts\setup\fix_dependencies.ps1
+
+# Linux/macOS
+python scripts/setup/fix_dependencies.py
+```
+
+### Approche avec Mocks
+
+Dans certains cas, il peut être nécessaire d'utiliser des mocks pour les dépendances problématiques. Utilisez les mocks fournis dans le répertoire `tests/mocks/` et les utilitaires dans `tests/utils/test_helpers.py`.
+
+```python
+from tests.utils.test_helpers import mocked_dependencies
+
+def test_with_mocked_dependencies():
+    with mocked_dependencies():
+        # Code utilisant les dépendances mockées
+        result = my_function()
+        assert result is not None
+```
+
+### Patterns de Test d'Intégration
+
+#### 1. Intégration Tactique-Opérationnel
+
+Ce pattern teste l'interaction entre les composants tactiques (coordinateur, moniteur, résolveur) et les adaptateurs opérationnels.
+
+```python
+def test_tactical_operational_integration():
+    # Créer les composants tactiques
+    tactical_state = TacticalState()
+    coordinator = TaskCoordinator(tactical_state=tactical_state, middleware=middleware)
+    
+    # Créer les adaptateurs opérationnels
+    extract_adapter = ExtractAgentAdapter(agent_id="extract_agent", middleware=middleware)
+    
+    # Tester l'interaction
+    task = {...}  # Définir une tâche
+    coordinator.assign_task(task, "extract_agent")
+    
+    # Vérifier que l'adaptateur a reçu la tâche
+    assert extract_adapter.has_pending_task(task["id"])
+```
+
+#### 2. Intégration Agents-Outils
+
+Ce pattern teste l'interaction entre les agents et leurs outils d'analyse.
+
+```python
+def test_agent_tools_integration():
+    # Créer les outils d'analyse
+    complex_analyzer = ComplexFallacyAnalyzer()
+    
+    # Créer l'agent avec les outils
+    agent = InformalAgent(
+        agent_id="informal_agent",
+        tools={"complex_analyzer": complex_analyzer}
+    )
+    
+    # Tester l'interaction
+    text = "Exemple de texte avec sophismes"
+    result = agent.analyze_text(text)
+    
+    # Vérifier le résultat
+    assert "fallacies" in result
+```
+
+#### 3. Intégration Informel-Analyse
+
+Ce pattern teste l'interaction entre les agents informels et les différents types d'analyse.
+
+```python
+def test_informal_analysis_integration():
+    # Créer les définitions de sophismes
+    fallacy_definitions = [...]  # Définir des sophismes
+    
+    # Créer le détecteur de sophismes
+    fallacy_detector = FallacyDetector(fallacy_definitions=fallacy_definitions)
+    
+    # Créer l'agent informel
+    agent = InformalAgent(
+        agent_id="informal_agent",
+        tools={"fallacy_detector": fallacy_detector}
+    )
+    
+    # Tester l'interaction
+    text = "Exemple de texte avec sophismes"
+    result = agent.analyze_text(text)
+    
+    # Vérifier le résultat
+    assert "fallacies" in result
+```
+
+## Fixtures et Utilitaires
+
+### Fixtures pour les Tests d'Intégration
+
+Les fixtures réutilisables pour les tests d'intégration sont définies dans le répertoire `tests/fixtures/`.
+
+```python
+import pytest
+from tests.fixtures.rhetorical_data_fixtures import example_text, example_fallacies
+from tests.fixtures.agent_fixtures import informal_agent, complex_fallacy_analyzer
+
+def test_agent_analyzer_integration(informal_agent, complex_fallacy_analyzer, example_text):
+    # Configurer l'agent avec l'analyseur
+    informal_agent.tools["complex_analyzer"] = complex_fallacy_analyzer
+    
+    # Tester l'interaction
+    result = informal_agent.analyze_text(example_text)
+    
+    # Vérifier le résultat
+    assert "fallacies" in result
+```
+
+### Utilitaires pour les Tests d'Intégration
+
+Les utilitaires pour les tests d'intégration sont définis dans le répertoire `tests/utils/`.
+
+```python
+from tests.utils.test_helpers import temp_file, read_json_file
+from tests.utils.test_data_generators import generate_text_with_fallacies
+
+def test_file_processing_integration():
+    # Générer un texte avec sophismes
+    text = generate_text_with_fallacies()
+    
+    # Créer un fichier temporaire
+    with temp_file(text) as file_path:
+        # Tester l'intégration
+        result = process_and_analyze_file(file_path)
+        
+        # Vérifier le résultat
+        assert "fallacies" in result
+```
+
+## Exécution des Tests
+
+### Exécuter Tous les Tests d'Intégration
+
+```bash
+pytest tests/integration/
+```
+
+### Exécuter un Test d'Intégration Spécifique
+
+```bash
+pytest tests/integration/test_tactical_operational_integration.py
+```
+
+### Exécuter avec Couverture de Code
+
+```bash
+pytest --cov=argumentation_analysis.orchestration.hierarchical tests/integration/
+```
+
+### Exécuter avec Verbosité
+
+```bash
+pytest -v tests/integration/
+```
+
+## Bonnes Pratiques
+
+1. **Isolation des Tests** : Chaque test doit être indépendant des autres tests.
+2. **Nettoyage des Ressources** : Assurez-vous de nettoyer les ressources après chaque test.
+3. **Tests Progressifs** : Commencez par tester l'intégration de petits modules, puis progressez vers des intégrations plus complexes.
+4. **Vérification des Interfaces** : Vérifiez que les interfaces entre les modules sont correctement utilisées.
+5. **Gestion des Erreurs** : Testez la gestion des erreurs entre les modules.
+
+Pour plus de détails sur les bonnes pratiques, consultez le fichier [BEST_PRACTICES.md](BEST_PRACTICES.md).
+
+## Exemples
+
+### Exemple 1 : Intégration Tactique-Opérationnel
+
+```python
+def test_task_assignment_and_execution():
+    """
+    Teste l'assignation d'une tâche par le coordinateur tactique
+    et son exécution par un agent opérationnel via l'adaptateur.
+    """
+    # Créer un état tactique
+    tactical_state = TacticalState()
+    
+    # Créer un middleware
+    middleware = MessageMiddleware()
+    
+    # Créer le coordinateur tactique
+    coordinator = TaskCoordinator(tactical_state=tactical_state, middleware=middleware)
+    
+    # Créer un adaptateur d'agent d'extraction
+    extract_adapter = ExtractAgentAdapter(agent_id="extract_agent", middleware=middleware)
+    
+    # Créer une tâche d'extraction
+    task = {
+        "id": "extract-task-1",
+        "description": "Extraire le texte du document",
+        "objective_id": "test-objective",
+        "estimated_duration": 3600,
+        "required_capabilities": ["text_extraction"],
+        "parameters": {
+            "document_path": "examples/exemple_sophisme.txt",
+            "output_format": "text"
+        }
+    }
+    
+    # Ajouter la tâche à l'état tactique
+    tactical_state.add_task(task)
+    
+    # Assigner la tâche
+    coordinator._assign_pending_tasks()
+    
+    # Vérifier que la tâche a été assignée
+    assert tactical_state.get_task_status(task["id"]) == "assigned"
+    
+    # Simuler l'exécution de la tâche par l'adaptateur
+    extract_result = {
+        "text": "Texte extrait du document",
+        "metadata": {
+            "source": "examples/exemple_sophisme.txt",
+            "extraction_time": "2025-05-21T23:30:00"
+        }
+    }
+    
+    # Envoyer le résultat
+    extract_adapter.send_task_result(task["id"], extract_result, "completed")
+    
+    # Vérifier que la tâche a été complétée
+    assert tactical_state.get_task_status(task["id"]) == "completed"
+```
+
+### Exemple 2 : Intégration Agents-Outils
+
+```python
+def test_fallacy_detection_and_evaluation():
+    """
+    Teste la détection et l'évaluation des sophismes par l'agent informel
+    en utilisant les outils d'analyse.
+    """
+    # Créer les outils d'analyse
+    complex_analyzer = ComplexFallacyAnalyzer()
+    contextual_analyzer = ContextualFallacyAnalyzer()
+    severity_evaluator = FallacySeverityEvaluator()
+    
+    # Créer l'agent informel avec les outils d'analyse
+    informal_agent = InformalAgent(
+        agent_id="informal_agent_test",
+        tools={
+            "complex_analyzer": complex_analyzer,
+            "contextual_analyzer": contextual_analyzer,
+            "severity_evaluator": severity_evaluator
+        }
+    )
+    
+    # Texte d'exemple
+    text = """
+    Le réchauffement climatique est un mythe car il a neigé cet hiver.
+    Soit nous réduisons drastiquement les émissions de CO2, soit la planète sera inhabitable dans 10 ans.
+    """
+    
+    # Exécuter l'analyse
+    result = informal_agent.perform_enhanced_analysis(text)
+    
+    # Vérifier le résultat
+    assert "fallacies" in result
+    assert "context_analysis" in result
+    assert "severity_evaluation" in result
+```
+
+### Exemple 3 : Intégration Informel-Analyse
+
+```python
+def test_fallacy_categorization():
+    """
+    Teste la catégorisation des sophismes détectés selon les définitions.
+    """
+    # Créer les définitions de sophismes
+    fallacy_definitions = [
+        FallacyDefinition(
+            name="généralisation_hâtive",
+            category=FallacyCategory.INDUCTION,
+            description="Généralise à partir d'un échantillon insuffisant",
+            examples=["Il a neigé, donc le réchauffement climatique est un mythe"],
+            detection_patterns=["neigé", "froid", "hiver"]
+        ),
+        FallacyDefinition(
+            name="faux_dilemme",
+            category=FallacyCategory.STRUCTURE,
+            description="Présente seulement deux options alors qu'il en existe d'autres",
+            examples=["Soit nous augmentons les impôts, soit l'économie s'effondrera"],
+            detection_patterns=["soit...soit", "ou bien...ou bien"]
+        )
+    ]
+    
+    # Créer le détecteur de sophismes
+    fallacy_detector = FallacyDetector(fallacy_definitions=fallacy_definitions)
+    
+    # Créer l'agent informel
+    informal_agent = InformalAgent(
+        agent_id="informal_agent_test",
+        tools={"fallacy_detector": fallacy_detector}
+    )
+    
+    # Texte d'exemple
+    text = """
+    Le réchauffement climatique est un mythe car il a neigé cet hiver.
+    Soit nous augmentons les impôts, soit l'économie s'effondrera.
+    """
+    
+    # Exécuter l'analyse et la catégorisation
+    result = informal_agent.analyze_and_categorize(text)
+    
+    # Vérifier le résultat
+    assert "fallacies" in result
+    assert "categories" in result
+    assert FallacyCategory.INDUCTION.name in result["categories"]
+    assert FallacyCategory.STRUCTURE.name in result["categories"]
+    assert "généralisation_hâtive" in result["categories"][FallacyCategory.INDUCTION.name]
+    assert "faux_dilemme" in result["categories"][FallacyCategory.STRUCTURE.name]

--- a/docs/guides/testing/unified_config_tests.md
+++ b/docs/guides/testing/unified_config_tests.md
@@ -1,0 +1,416 @@
+# Guide complet des tests UnifiedConfig
+
+## Vue d'ensemble
+
+Cette suite de tests valide complètement le système de configuration dynamique `UnifiedConfig` qui gère les paramètres de logique, niveaux de mock, taxonomie, et orchestration du système d'analyse rhétorique.
+
+## 🏗️ Architecture des tests
+
+### Structure des fichiers de tests
+
+```
+tests/
+├── unit/
+│   ├── config/
+│   │   └── test_unified_config.py          # Tests unitaires UnifiedConfig
+│   ├── scripts/
+│   │   └── test_configuration_cli.py       # Tests intégration CLI
+│   └── integration/
+│       └── test_unified_config_integration.py  # Tests bout-en-bout
+├── scripts/
+│   └── test_unified_config_cli.ps1         # Tests PowerShell CLI
+├── run_unified_config_tests.py             # Orchestrateur de tests
+└── README_UNIFIED_CONFIG_TESTS.md          # Cette documentation
+```
+
+### Types de tests implémentés
+
+| Type | Fichier | Description | Couverture |
+|------|---------|-------------|------------|
+| **Unitaires** | `test_unified_config.py` | Tests des classes et méthodes | >95% |
+| **CLI** | `test_configuration_cli.py` | Tests mapping CLI → Config | 100% des args |
+| **Intégration** | `test_unified_config_integration.py` | Tests pipeline complet | Bout-en-bout |
+| **PowerShell** | `test_unified_config_cli.ps1` | Tests CLI système | Réels |
+| **Performance** | Inclus dans orchestrateur | Tests vitesse/mémoire | Métriques |
+
+## 🧪 Tests unitaires détaillés
+
+### [`test_unified_config.py`](unit/config/test_unified_config.py)
+
+**Couverture :** Configuration principale, énumérations, validation
+
+#### Tests de configuration de base
+```python
+def test_default_configuration_loading()     # Valeurs par défaut
+def test_logic_type_validation()            # FOL/PL/Modal
+def test_mock_level_validation()            # NONE/PARTIAL/FULL  
+def test_taxonomy_size_validation()         # 3/1000 nœuds
+def test_orchestration_mode_validation()    # UNIFIED/CONVERSATION/etc.
+```
+
+#### Tests de validation avancée
+```python
+def test_invalid_combinations()             # Combinaisons interdites
+def test_valid_combinations()               # Combinaisons validées
+def test_configuration_persistence()        # Sérialisation/stockage
+def test_agent_normalization()             # LOGIC → FOL_LOGIC auto
+def test_authenticity_constraints()        # Contraintes authenticité
+```
+
+#### Tests des services spécialisés
+```python
+def test_service_configurations()          # Tweety/LLM/Taxonomie
+def test_get_agent_classes()              # Mapping agents → classes
+```
+
+### Combinaisons testées
+
+#### ✅ Combinaisons valides
+| Logic | Mock | Taxonomy | Orchestration | Usage |
+|-------|------|----------|---------------|-------|
+| `FOL` | `NONE` | `FULL` | `UNIFIED` | **Production optimale** |
+| `FOL` | `PARTIAL` | `MOCK` | `CONVERSATION` | **Développement** |
+| `PL` | `FULL` | `MOCK` | `CONVERSATION` | **Test rapide** |
+
+#### ❌ Combinaisons invalides
+| Logic | Mock | Reason |
+|-------|------|--------|
+| `*` | `PARTIAL/FULL` + `require_real_gpt=True` | Incohérence authenticité |
+| `*` | `enable_jvm=False` + `FOL_LOGIC agent` | Agent nécessite JVM |
+
+## 🖥️ Tests CLI
+
+### [`test_configuration_cli.py`](unit/scripts/test_configuration_cli.py)
+
+**Couverture :** Interface CLI, conversion arguments, validation
+
+#### Arguments CLI testés
+
+| Argument | Valeurs testées | Mapping |
+|----------|----------------|---------|
+| `--logic-type` | `fol`, `pl`, `propositional`, `first_order`, `modal` | → `LogicType` |
+| `--mock-level` | `none`, `partial`, `full` | → `MockLevel` |
+| `--taxonomy` | `full`, `mock` | → `TaxonomySize` |
+| `--orchestration` | `unified`, `conversation`, `real`, `custom` | → `OrchestrationType` |
+| `--agents` | `informal,fol_logic,synthesis,pm,extract` | → `List[AgentType]` |
+
+#### Tests de conversion CLI
+```python
+def test_logic_type_cli_argument()          # --logic-type mapping
+def test_mock_level_cli_argument()          # --mock-level mapping  
+def test_taxonomy_cli_argument()            # --taxonomy mapping
+def test_orchestration_mode_cli_argument()  # --orchestration mapping
+def test_agents_cli_argument()              # --agents parsing
+def test_combined_cli_arguments()           # Combinaisons multiples
+def test_invalid_cli_combinations()         # Détection erreurs CLI
+```
+
+### Exemples de commandes testées
+
+#### Configuration production
+```bash
+python scripts/main/analyze_text.py \
+  --source-type simple \
+  --logic-type fol \
+  --mock-level none \
+  --taxonomy full \
+  --orchestration unified \
+  --require-real-gpt \
+  --require-real-tweety
+```
+
+#### Configuration développement
+```bash
+python scripts/main/analyze_text.py \
+  --source-type simple \
+  --logic-type pl \
+  --mock-level partial \
+  --taxonomy mock \
+  --orchestration conversation \
+  --no-jvm
+```
+
+## 🔗 Tests d'intégration
+
+### [`test_unified_config_integration.py`](unit/integration/test_unified_config_integration.py)
+
+**Couverture :** Pipeline complet, presets, compatibilité
+
+#### Tests de presets
+```python
+def test_full_pipeline_with_authentic_fol_config()  # Preset production
+def test_development_workflow_integration()         # Preset développement
+def test_testing_configuration_isolation()          # Preset test
+```
+
+#### Tests de compatibilité
+```python  
+def test_configuration_compatibility_matrix()       # Matrice complète
+def test_invalid_configuration_combinations()       # Échecs attendus
+def test_configuration_serialization_roundtrip()    # Persistance
+def test_performance_configuration_impact()         # Impact perf
+```
+
+#### Tests de migration
+```python
+def test_configuration_migration_compatibility()    # Rétrocompatibilité
+def test_configuration_validation_comprehensive()   # Validation complète
+```
+
+## 💻 Tests PowerShell CLI
+
+### [`test_unified_config_cli.ps1`](scripts/test_unified_config_cli.ps1)
+
+**Couverture :** CLI système, intégration Windows, validation bout-en-bout
+
+#### Suites de tests PowerShell
+
+| Suite | Tests | Description |
+|-------|-------|-------------|
+| **Basic** | 5 tests | Arguments CLI de base |
+| **Advanced** | 3 tests | Combinaisons invalides + formats |
+| **Integration** | 2 tests | Variables environnement |
+| **Performance** | 1 test | Vitesse d'exécution |
+
+#### Commandes testées
+```powershell
+# Test configuration FOL authentique
+python analyze_text.py --source-type simple --logic-type fol --mock-level none
+
+# Test configuration développement  
+python analyze_text.py --source-type simple --logic-type pl --mock-level partial
+
+# Test formats de sortie
+python analyze_text.py --source-type simple --format json --output test.json
+```
+
+#### Métriques validées
+- **Temps d'exécution** : < 60s pour config rapide
+- **Codes de sortie** : 0 pour succès, != 0 pour échecs
+- **Fichiers de sortie** : Création et contenu validés
+
+## 🚀 Orchestrateur de tests
+
+### [`run_unified_config_tests.py`](run_unified_config_tests.py)
+
+**Couverture :** Automatisation complète, rapports, métriques
+
+#### Pipeline d'exécution
+1. **Validation des fichiers** → Import UnifiedConfig
+2. **Tests unitaires** → pytest avec couverture
+3. **Tests d'intégration** → Validation pipeline
+4. **Tests de performance** → Métriques vitesse/mémoire
+5. **Tests CLI** → PowerShell système
+6. **Génération rapport** → JSON + métriques
+
+#### Utilisation
+```bash
+# Exécution complète
+python tests/run_unified_config_tests.py
+
+# Mode verbeux avec couverture  
+python tests/run_unified_config_tests.py --verbose
+
+# Exécution rapide (sans PowerShell)
+python tests/run_unified_config_tests.py --fast --no-coverage
+```
+
+#### Métriques collectées
+- **Couverture de code** : >95% cible
+- **Temps d'exécution** : Par suite et total
+- **Taux de réussite** : Tests passés/échoués
+- **Performance** : Vitesse création/validation config
+
+## 📊 Métriques de validation
+
+### Objectifs de couverture
+
+| Composant | Couverture cible | Métriques |
+|-----------|------------------|-----------|
+| **UnifiedConfig classe** | >95% | Toutes méthodes |
+| **Énumérations** | 100% | Toutes valeurs |
+| **CLI mapping** | 100% | Tous arguments |
+| **Combinaisons valides** | 100% | Presets + custom |
+| **Validation d'erreurs** | 100% | Tous cas invalides |
+
+### Tests de régression
+
+#### Configuration legacy
+- ✅ Compatibilité avec anciens scripts
+- ✅ Migration transparente vers UnifiedConfig
+- ✅ Préservation des comportements existants
+
+#### Performance
+- ✅ Création config < 1s pour 100 instances
+- ✅ Validation < 0.5s pour sérialisation
+- ✅ CLI réponse < 60s pour config rapide
+
+## 🛠️ Instructions d'exécution
+
+### Prérequis
+```bash
+# Installation des dépendances de test
+pip install pytest pytest-cov
+
+# Vérification PowerShell (Windows)
+powershell -Command "Get-Host"
+```
+
+### Tests unitaires seuls
+```bash
+# Tests UnifiedConfig
+pytest tests/unit/config/test_unified_config.py -v
+
+# Tests CLI
+pytest tests/unit/scripts/test_configuration_cli.py -v
+
+# Tests intégration
+pytest tests/unit/integration/test_unified_config_integration.py -v
+```
+
+### Tests CLI PowerShell
+```bash
+# Windows PowerShell
+powershell -ExecutionPolicy Bypass -File tests/scripts/test_unified_config_cli.ps1
+
+# Tests spécifiques
+powershell -File tests/scripts/test_unified_config_cli.ps1 -TestSuite Basic
+```
+
+### Suite complète automatisée
+```bash
+# Exécution complète
+python tests/run_unified_config_tests.py
+
+# Avec options
+python tests/run_unified_config_tests.py --verbose --no-coverage
+```
+
+## 📋 Matrice de compatibilité
+
+### Configurations validées
+
+| Preset | Logic | Mock | Taxonomy | Agents | JVM | Usage |
+|--------|-------|------|----------|--------|-----|-------|
+| **authentic_fol** | FOL | NONE | FULL | informal+fol_logic+synthesis | ✓ | Production |
+| **authentic_pl** | PL | NONE | FULL | informal+fol_logic+synthesis | ✓ | Production rapide |
+| **development** | FOL | PARTIAL | MOCK | informal+fol_logic+synthesis | ✗ | Développement |
+| **testing** | PL | FULL | MOCK | informal+synthesis | ✗ | Tests auto |
+
+### Combinaisons personnalisées supportées
+
+#### Authentiques (production)
+```python
+# FOL authentique maximal
+UnifiedConfig(
+    logic_type=LogicType.FOL,
+    mock_level=MockLevel.NONE,
+    taxonomy_size=TaxonomySize.FULL,
+    require_real_gpt=True,
+    require_real_tweety=True
+)
+
+# PL authentique rapide  
+UnifiedConfig(
+    logic_type=LogicType.PL,
+    mock_level=MockLevel.NONE,
+    taxonomy_size=TaxonomySize.FULL
+)
+```
+
+#### Développement
+```python
+# Développement avec mocks
+UnifiedConfig(
+    logic_type=LogicType.FOL,
+    mock_level=MockLevel.PARTIAL,
+    taxonomy_size=TaxonomySize.MOCK,
+    enable_jvm=False,
+    require_real_gpt=False
+)
+```
+
+## 🐛 Débogage et diagnostics
+
+### Tests échoués
+
+#### Erreurs fréquentes
+1. **Import Error** : Vérifier `PYTHONPATH` et installation
+2. **Mock Incompatibility** : Vérifier `mock_level` vs `require_real_*`
+3. **JVM Error** : Vérifier agents vs `enable_jvm`
+4. **PowerShell Error** : Vérifier disponibilité et policy
+
+#### Diagnostics
+```bash
+# Test import basic
+python -c "from config.unified_config import UnifiedConfig; print('OK')"
+
+# Test CLI basic  
+python scripts/main/analyze_text.py --help
+
+# Test PowerShell
+powershell -Command "Get-ExecutionPolicy"
+```
+
+### Logs et rapports
+
+#### Structure des rapports
+```json
+{
+  "summary": {
+    "timestamp": "2025-01-07T14:30:00",
+    "tests_run": 15,
+    "tests_passed": 14,
+    "tests_failed": 1,
+    "total_duration": 45.2
+  },
+  "detailed_results": {
+    "unit_tests": {"success": true, "duration": 12.1},
+    "cli_tests": {"success": false, "error": "PowerShell timeout"}
+  }
+}
+```
+
+#### Localisation des rapports
+- **HTML Coverage** : `tests/reports/coverage_html/index.html`
+- **JSON Reports** : `tests/reports/unified_config_test_report_*.json`
+- **Test Outputs** : `tests/test_results/`
+
+## ✅ Checklist de validation
+
+### Avant commit
+- [ ] Tous les tests unitaires passent
+- [ ] Couverture >95% pour UnifiedConfig
+- [ ] Tests CLI PowerShell passent
+- [ ] Aucune régression de performance
+- [ ] Documentation à jour
+
+### Avant release
+- [ ] Suite complète passe sur environnement propre
+- [ ] Tests d'intégration bout-en-bout validés
+- [ ] Métriques de performance respectées
+- [ ] Compatibilité rétrograde confirmée
+- [ ] Rapports de test archivés
+
+---
+
+## 📞 Support et maintenance
+
+### Mise à jour des tests
+
+Lors d'ajout de nouvelles fonctionnalités à `UnifiedConfig` :
+
+1. **Ajouter tests unitaires** dans `test_unified_config.py`
+2. **Ajouter arguments CLI** dans `test_configuration_cli.py` 
+3. **Mettre à jour intégration** dans `test_unified_config_integration.py`
+4. **Tester PowerShell** si nouvel argument CLI
+5. **Mettre à jour documentation** dans ce fichier
+
+### Contact
+- **Tests techniques** : Équipe développement core
+- **Tests CLI** : Équipe interface utilisateur  
+- **Performance** : Équipe architecture
+
+---
+
+*Documentation générée automatiquement - Version 1.0*

--- a/docs/guides/testing/unit_tests.md
+++ b/docs/guides/testing/unit_tests.md
@@ -1,0 +1,119 @@
+# Tests Unitaires pour les Modules Prioritaires
+
+Ce document explique comment exécuter les tests unitaires pour les modules prioritaires identifiés avec une faible couverture de tests.
+
+## Modules Prioritaires
+
+Les modules prioritaires suivants ont été identifiés avec une faible couverture de tests :
+
+1. **orchestration.hierarchical.tactical** (11.78%)
+2. **orchestration.hierarchical.operational.adapters** (12.44%)
+3. **agents.tools.analysis.enhanced** (12.90%)
+4. **agents.core.informal** (16.23%)
+5. **agents.tools.analysis** (16.46%)
+
+## Tests Unitaires Implémentés
+
+Les tests unitaires suivants ont été implémentés pour les modules prioritaires :
+
+1. **orchestration.hierarchical.tactical**
+   - `tests/test_tactical_coordinator.py` : Tests pour le coordinateur tactique
+   - `tests/test_tactical_monitor.py` : Tests pour le moniteur tactique
+   - `tests/test_tactical_resolver.py` : Tests pour le résolveur de conflits tactique
+
+2. **orchestration.hierarchical.operational.adapters**
+   - `tests/test_extract_agent_adapter.py` : Tests pour l'adaptateur d'agent d'extraction
+
+3. **agents.tools.analysis.enhanced**
+   - `tests/test_enhanced_complex_fallacy_analyzer.py` : Tests pour l'analyseur de sophismes complexes amélioré
+
+4. **agents.core.informal**
+   - `tests/test_informal_definitions.py` : Tests pour les définitions de l'agent informel
+
+## Mocks pour les Dépendances Problématiques
+
+Les mocks suivants ont été créés pour les dépendances problématiques :
+
+1. **numpy** : `tests/mocks/numpy_mock.py`
+2. **pandas** : `tests/mocks/pandas_mock.py`
+3. **jpype** : `tests/mocks/jpype_mock.py` (déjà existant)
+
+Ces mocks sont automatiquement utilisés lors de l'exécution des tests grâce aux fixtures définies dans `tests/conftest.py`.
+
+## Exécution des Tests
+
+### Exécuter tous les tests
+
+Pour exécuter tous les tests unitaires :
+
+```bash
+pytest
+```
+
+### Exécuter les tests pour un module spécifique
+
+Pour exécuter les tests pour un module spécifique :
+
+```bash
+pytest tests/test_tactical_coordinator.py
+pytest tests/test_tactical_monitor.py
+pytest tests/test_tactical_resolver.py
+pytest tests/test_extract_agent_adapter.py
+pytest tests/test_enhanced_complex_fallacy_analyzer.py
+pytest tests/test_informal_definitions.py
+```
+
+### Exécuter les tests avec la couverture de code
+
+Pour exécuter les tests avec la génération d'un rapport de couverture :
+
+```bash
+pytest --cov=argumentation_analysis
+```
+
+Pour générer un rapport HTML détaillé :
+
+```bash
+pytest --cov=argumentation_analysis --cov-report=html
+```
+
+Le rapport HTML sera généré dans le répertoire `htmlcov/`.
+
+## Approche d'Isolation des Dépendances
+
+L'approche d'isolation des dépendances problématiques (numpy, pandas, jpype) a été mise en œuvre comme suit :
+
+1. **Création de mocks** : Des mocks ont été créés pour simuler les fonctionnalités des dépendances problématiques.
+2. **Configuration automatique** : Les mocks sont automatiquement configurés lors de l'exécution des tests grâce aux fixtures définies dans `conftest.py`.
+3. **Patching des modules** : Les modules qui utilisent les dépendances problématiques sont patchés pour utiliser les mocks.
+
+Cette approche permet d'exécuter les tests sans avoir besoin des dépendances réelles, ce qui résout les problèmes d'importation et d'incompatibilités avec l'environnement de test.
+
+## Cas de Test Implémentés
+
+Les tests unitaires implémentés couvrent les cas suivants :
+
+1. **Tests d'initialisation** : Vérification que les objets sont correctement initialisés.
+2. **Tests de fonctionnalités de base** : Vérification que les méthodes de base fonctionnent correctement.
+3. **Tests de cas limites** : Vérification du comportement dans des cas limites (entrées invalides, etc.).
+4. **Tests de conditions d'erreur** : Vérification du comportement en cas d'erreur.
+
+## Amélioration de la Couverture
+
+Ces tests unitaires devraient améliorer significativement la couverture de code des modules prioritaires. Pour continuer à améliorer la couverture, les actions suivantes peuvent être entreprises :
+
+1. **Ajouter des tests pour les autres modules** : Créer des tests unitaires pour les autres modules avec une faible couverture.
+2. **Ajouter des tests pour les cas non couverts** : Identifier les parties du code qui ne sont pas couvertes par les tests existants et ajouter des tests pour ces parties.
+3. **Ajouter des tests d'intégration** : Créer des tests d'intégration pour vérifier l'interaction entre les différents modules.
+
+## Problèmes Connus
+
+Si vous rencontrez des problèmes lors de l'exécution des tests, veuillez vérifier les points suivants :
+
+1. **Dépendances manquantes** : Assurez-vous que toutes les dépendances requises sont installées.
+2. **Mocks incomplets** : Si un test échoue en raison d'une fonctionnalité manquante dans un mock, vous devrez peut-être mettre à jour le mock correspondant.
+3. **Problèmes d'importation** : Si un test échoue en raison d'un problème d'importation, vérifiez que le module est correctement importé et que les mocks sont correctement configurés.
+
+## Conclusion
+
+Ces tests unitaires constituent une première étape importante pour améliorer la couverture de code des modules prioritaires. Ils fournissent une base solide pour continuer à améliorer la qualité du code et la fiabilité du système.

--- a/services/web_api/interface-web-argumentative/README.md
+++ b/services/web_api/interface-web-argumentative/README.md
@@ -264,7 +264,7 @@ Le serveur de développement supporte le rechargement automatique lors des modif
 
 - **[Guide Application Web](../../../docs/WEB_APPLICATION_GUIDE.md)** : Guide complet d'utilisation
 - **[API Backend](../../argumentation_analysis/services/web_api/README.md)** : Documentation API
-- **[Tests Fonctionnels](../../../tests/README_FUNCTIONAL_TESTS.md)** : Tests Playwright
+- **[Tests Fonctionnels](../../../docs/guides/testing/functional_tests.md)** : Tests Playwright
 - **[Architecture Générale](../../../docs/ARCHITECTURE.md)** : Vue d'ensemble système
 
 ## 🤝 Contribution

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,50 +1,81 @@
-# Stratégie de Gestion de la JVM dans les Tests
+# Test Suite
 
-Ce document explique comment la JVM est gérée dans notre suite de tests `pytest` pour garantir la stabilité, en particulier sous Windows où les conflits de cycle de vie de la JVM peuvent causer des crashs fatals (`Windows fatal exception: access violation`).
+Unit, integration, and functional tests for the argumentation analysis system.
 
-## Le Problème : Conflit de Cycle de Vie de la JVM
+## Running Tests
 
-Le cœur du problème réside dans le fait que `JPype` ne permet de démarrer la JVM **qu'une seule fois** par processus. Toute tentative de redémarrage ou de démarrage d'une seconde JVM dans un sous-processus qui a hérité de l'état du parent mène à un crash.
+```bash
+# Activate environment first
+conda activate projet-is-roo-new
 
-Nos tests se divisent en deux catégories principales :
+# All tests
+pytest tests/ -v
 
-1.  **Tests d'Intégration (`@pytest.mark.jvm_test`)**: Ces tests importent directement des composants qui dépendent de la JVM (ex: `TweetyBridge`). Ils nécessitent qu'une JVM soit active dans le processus `pytest` principal.
-2.  **Tests End-to-End (`@pytest.mark.e2e`)**: Ces tests valident l'application complète. Ils utilisent la fixture `e2e_servers` qui démarre le serveur backend dans un **sous-processus**. Ce serveur backend est lui-même responsable de démarrer et de gérer sa propre JVM.
+# Unit tests only
+pytest tests/unit/ -v
 
-Le conflit survient lorsqu'un test E2E est exécuté dans une session `pytest` où la JVM a déjà été démarrée pour des tests d'intégration. Le sous-processus du serveur E2E hérite d'un état invalide et crashe en tentant d'initialiser sa propre JVM.
+# Skip slow tests
+pytest tests/ -m "not slow" -v
 
-## La Solution : Isolation Stricte
+# Single test file / function
+pytest tests/unit/argumentation_analysis/test_foo.py -v
+pytest tests/unit/argumentation_analysis/test_foo.py::TestClass::test_method -v
 
-Pour résoudre ce problème, nous avons implémenté une stratégie d'isolation stricte :
+# With coverage
+pytest --cov=argumentation_analysis tests/ -v
 
-1.  **Fixture de Session `jvm_session`**:
-    *   Une fixture `jvm_session` avec `scope="session"` et `autouse=True` est définie dans `tests/conftest.py`.
-    *   Elle est responsable de démarrer la JVM **une unique fois** pour tous les tests qui en ont besoin (principalement les tests d'intégration).
+# LLM tests by cost tier
+pytest tests/ -m "llm_light" -v          # <30s, ~$0.01-0.05
+pytest tests/ -m "llm_integration" -v    # >30s, ~$0.05-0.20
+pytest tests/ -m "llm_critical" -v       # E2E, >60s, >$0.20
+```
 
-2.  **Désactivation pour les Tests E2E**:
-    *   Les tests qui utilisent la fixture `e2e_servers` **ne doivent pas** avoir de JVM active dans le processus `pytest` principal.
-    *   Pour garantir cela, tous les tests E2E doivent être marqués avec `@pytest.mark.no_jvm_session`.
-    *   Ce marqueur indique à la fixture `jvm_session` de ne pas s'exécuter pour ce test.
-    *   De plus, une assertion de sécurité a été ajoutée au début de la fixture `e2e_servers` pour vérifier que `jpype.isJVMStarted()` est `False`. Si ce n'est pas le cas, le test échoue avec un message d'erreur explicite, empêchant le crash fatal.
+Tests auto-skip when API keys are unavailable (no failures).
 
-## Comment Exécuter les Tests
+## Structure
 
-*   **Pour exécuter tous les tests sauf les E2E (recommandé pour le développement rapide)**:
-    ```bash
-    python -m pytest -m "not e2e"
-    ```
+```text
+tests/
+├── conftest.py              # Global fixtures (JVM session, env setup)
+├── unit/                    # Unit tests (no external services)
+│   └── argumentation_analysis/
+│       ├── agents/          # Agent tests
+│       ├── services/        # Service tests
+│       └── orchestration/   # Orchestration tests
+├── integration/             # Integration tests (cross-module)
+└── functional/              # E2E tests (Playwright, full workflows)
+```
 
-*   **Pour exécuter uniquement les tests E2E**:
-    Il est **crucial** d'utiliser le marqueur pour s'assurer que la JVM de session n'est pas démarrée.
-    ```bash
-    python -m pytest -m e2e
-    ```
-    (La configuration actuelle des marqueurs devrait gérer l'isolation automatiquement).
+## Key Conventions
 
-*   **Pour exécuter un fichier de test E2E spécifique**:
-    Assurez-vous que le test est marqué avec `@pytest.mark.no_jvm_session`.
-    ```bash
-    python -m pytest tests/test_mon_fichier_e2e.py
-    ```
+### Async
 
-Cette approche garantit que les deux types de tests peuvent coexister dans la même suite de tests sans provoquer d'instabilité liée à la JVM.
+`asyncio_mode = auto` in `pyproject.toml` — no need for `@pytest.mark.asyncio`.
+
+### JVM / JPype
+
+Tests requiring the JVM use `@pytest.mark.usefixtures("jvm_session")`. A session-scoped fixture starts the JVM once. Tests that must NOT have a JVM active (e.g., E2E subprocess tests) use `@pytest.mark.no_jvm_session`.
+
+### Windows DLL Load Order
+
+`conftest.py` imports torch/transformers BEFORE jpype to avoid `WinError 182`. Do not reorder.
+
+### Conditional Skips
+
+Some tests skip on Windows when PyTorch's `fbgemm.dll` fails to load, or when `OPENAI_API_KEY` is absent. See `docs/guides/testing/conditional_skips.md` for the full catalog and reactivation steps.
+
+### Test Markers
+
+50+ markers defined in `pyproject.toml` under `[tool.pytest.ini_options]`. Common ones: `slow`, `integration`, `e2e`, `api`, `real_jpype`, `playwright`, `belief_set`, `propositional`.
+
+## Detailed Guides
+
+- **Advanced patterns & module-specific patterns** — `docs/guides/testing/advanced_patterns.md`
+
+- **Integration & functional test best practices** — `docs/guides/testing/best_practices.md`
+
+- **FOL agent tests** — `docs/guides/testing/fol_tests.md`
+
+- **UnifiedConfig tests** — `docs/guides/testing/unified_config_tests.md`
+
+- **Conditional skip catalog** — `docs/guides/testing/conditional_skips.md`


### PR DESCRIPTION
## Summary
- Replace 8 separate README-like files at `tests/` root with 1 consolidated `tests/README.md`
- Move detailed guides to `docs/guides/testing/` (advanced patterns, best practices, FOL, functional, integration, unified config, unit tests, conditional skips)
- Update 2 active docs with stale links (`WEB_APPLICATION_GUIDE.md`, `interface-web-argumentative/README.md`)

## Test plan
- [x] No Python code references the moved files (grep verified)
- [x] 2 active docs with stale links updated
- [x] Historical task log references left as-is (archived records)
- [x] No behavior change — documentation-only

Part of Epic #334 (Post-Epic-317 consolidation v2), Track 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)