### PR TITLE
chore(scripts): increase benchmark timeout defaults 120s/180s → 600s

### DIFF
--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -102,7 +102,7 @@ async def run_benchmark(
     workflows: list,
     doc_indices: list,
     model_name: str,
-    timeout: float = 120.0,
+    timeout: float = 600.0,
     max_text_chars: int = 3000,
 ):
     """Run a grid of benchmark cells."""
@@ -166,7 +166,7 @@ def main():
                         help="Document indices to use")
     parser.add_argument("--model", default="default",
                         help="Model name from registry")
-    parser.add_argument("--timeout", type=float, default=120.0,
+    parser.add_argument("--timeout", type=float, default=600.0,
                         help="Timeout per cell in seconds")
     parser.add_argument("--max-text", type=int, default=3000,
                         help="Max chars of input text per cell")

--- a/scripts/run_benchmark_multimodel.py
+++ b/scripts/run_benchmark_multimodel.py
@@ -70,7 +70,7 @@ def build_registry() -> ModelRegistry:
 async def run_multimodel_comparison(
     workflows: list,
     doc_indices: list,
-    timeout: float = 180.0,
+    timeout: float = 600.0,
     max_text_chars: int = 3000,
     run_judge: bool = False,
 ) -> dict:
@@ -351,7 +351,7 @@ def main():
                         help="Workflows to compare")
     parser.add_argument("--docs", nargs="+", type=int, default=COMPARE_DOCS,
                         help="Document indices")
-    parser.add_argument("--timeout", type=float, default=180.0,
+    parser.add_argument("--timeout", type=float, default=600.0,
                         help="Timeout per cell in seconds")
     parser.add_argument("--max-text", type=int, default=3000,
                         help="Max chars of input text per cell")


### PR DESCRIPTION
## Summary
- Increase default timeout in `run_benchmark.py` from 120s to 600s
- Increase default timeout in `run_benchmark_multimodel.py` from 180s to 600s

## Context
TASK-93-C baseline runs showed standard workflow takes 478-508s per cell. The previous defaults (120s/180s) caused unnecessary timeouts, requiring manual `--timeout 600` overrides. The new 600s default provides safe headroom for standard/full workflows with LLM latency variance.

## Test plan
- [x] Existing tests unaffected (scripts-only change)
- [x] Baseline data confirms 478-508s needed for standard workflow