### PR TITLE
fix(tests): increase timeout in flaky test_timeout_raises_error

### DIFF
--- a/tests/unit/argumentation_analysis/core/communication/test_request_response.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_request_response.py
@@ -352,7 +352,7 @@ class TestSendRequest:
                 recipient="b",
                 request_type="q",
                 content={},
-                timeout=0.2,
+                timeout=0.5,
                 retry_count=0,
             )
 


### PR DESCRIPTION
## Summary
- Increase `timeout` from 0.2s to 0.5s in `test_timeout_raises_error`

## Context
The test uses `threading.Event.wait(timeout=...)` to verify that a request timeout raises `RequestTimeoutError`. The 0.2s value was too tight and caused intermittent failures during full suite runs (2845 tests) on slower machines. 0.5s provides sufficient headroom while keeping the test fast.

## Test plan
- [x] Test passes in isolation
- [x] Test passes under full suite load
- [x] No behavior change to production code