### PR TITLE
feat(ui): spectacular dashboard with 32-field rich layout (#352)

### DIFF
--- a/services/web_api/interface-web-argumentative/src/App.js
+++ b/services/web_api/interface-web-argumentative/src/App.js
@@ -8,6 +8,7 @@ import LogicGraph from './components/LogicGraph';
 import ValidationForm from './components/ValidationForm';
 import GovernanceDashboard from './components/governance/GovernanceDashboard';
 import DebateArena from './components/debate/DebateArena';
+import SpectacularDashboard from './components/spectacular/SpectacularDashboard';
 import { checkAPIHealth } from './services/api';
 
 function App() {
@@ -29,7 +30,8 @@ function App() {
     { id: 'validation', label: '✅ Validation', component: ValidationForm },
     { id: 'framework', label: '🏗️ Framework', component: FrameworkBuilder },
     { id: 'governance', label: '🏛️ Gouvernance', component: GovernanceDashboard },
-    { id: 'debate', label: '⚔️ Débat', component: DebateArena }
+    { id: 'debate', label: '⚔️ Débat', component: DebateArena },
+    { id: 'spectacular', label: '🌟 Spectacular', component: SpectacularDashboard }
   ];
 
   const renderActiveComponent = () => {
@@ -41,19 +43,21 @@ function App() {
     return null;
   };
 
+  // Spectacular tab works with mock data (no API required)
+  const isSpectacular = activeTab === 'spectacular';
+
   return (
     <div className="App">
       <header className="App-header">
         <div className="header-content">
           <h1>🎯 Interface d'Analyse Argumentative</h1>
           <p className="header-subtitle">
-            Analysez vos arguments, détectez les sophismes et construisez des frameworks r
-robustes
+            Analysez vos arguments, détectez les sophismes et construisez des frameworks robustes
           </p>
           <div className={`api-status ${apiStatus}`}>
             <span className="status-indicator"></span>
             API: {apiStatus === 'connected' ? '✅ Connectée' :
-                  apiStatus === 'disconnected' ? '❌ Déconnectée' : '🔄 Vérification...'} 
+                  apiStatus === 'disconnected' ? '❌ Déconnectée' : '🔄 Vérification...'}
           </div>
         </div>
       </header>
@@ -65,14 +69,15 @@ robustes
               key={tab.id}
               className={`tab-button ${activeTab === tab.id ? 'active' : ''}`}
               onClick={() => setActiveTab(tab.id)}
-              disabled={apiStatus !== 'connected'}
+              disabled={apiStatus !== 'connected' && tab.id !== 'spectacular'}
               data-testid={
                 tab.id === 'analyzer' ? 'analyzer-tab' :
                 tab.id === 'fallacies' ? 'fallacy-detector-tab' :
                 tab.id === 'reconstructor' ? 'reconstructor-tab' :
                 tab.id === 'logic-graph' ? 'logic-graph-tab' :
                 tab.id === 'validation' ? 'validation-tab' :
-                tab.id === 'framework' ? 'framework-tab' : undefined
+                tab.id === 'framework' ? 'framework-tab' :
+                tab.id === 'spectacular' ? 'spectacular-tab' : undefined
               }
             >
               {tab.label}
@@ -82,7 +87,7 @@ robustes
       </nav>
 
       <main className="main-content">
-        {apiStatus !== 'connected' ? (
+        {(apiStatus !== 'connected' && !isSpectacular) ? (
           <div className="api-error-state">
             <div className="error-icon">🚫</div>
             <h2>API Indisponible</h2>
@@ -92,7 +97,7 @@ robustes
             </p>
             <div className="error-instructions">
               <h3>Pour démarrer l'API :</h3>
-              <pre><code>cd services/web_api{'\n'}python start_api.py</code></pre>        
+              <pre><code>cd services/web_api{'\n'}python start_api.py</code></pre>
             </div>
           </div>
         ) : (

--- a/services/web_api/interface-web-argumentative/src/components/spectacular/SpectacularDashboard.css
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/SpectacularDashboard.css
@@ -1,0 +1,539 @@
+/* SpectacularDashboard.css — Rich 32-field dashboard layout */
+:root {
+  --spec-bg: #0f172a;
+  --spec-card: #1e293b;
+  --spec-card-hover: #334155;
+  --spec-border: #475569;
+  --spec-accent: #38bdf8;
+  --spec-success: #4ade80;
+  --spec-warning: #fbbf24;
+  --spec-danger: #f87171;
+  --spec-text: #e2e8f0;
+  --spec-text-dim: #94a3b8;
+  --spec-retracted: #ef4444;
+}
+
+.spec-dashboard {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 16px;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  color: var(--spec-text);
+}
+
+/* ── Header ── */
+.spec-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  padding: 16px 20px;
+  background: var(--spec-card);
+  border-radius: 10px;
+  border: 1px solid var(--spec-border);
+}
+
+.spec-header h2 {
+  margin: 0;
+  font-size: 1.4rem;
+  color: var(--spec-accent);
+}
+
+.spec-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 0.85rem;
+  color: var(--spec-text-dim);
+}
+
+.spec-meta span {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* ── Field coverage bar ── */
+.spec-coverage-bar {
+  margin-bottom: 20px;
+  padding: 12px 20px;
+  background: var(--spec-card);
+  border-radius: 8px;
+  border: 1px solid var(--spec-border);
+}
+
+.spec-coverage-label {
+  font-size: 0.85rem;
+  color: var(--spec-text-dim);
+  margin-bottom: 6px;
+  display: flex;
+  justify-content: space-between;
+}
+
+.spec-coverage-track {
+  height: 8px;
+  background: var(--spec-bg);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.spec-coverage-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--spec-accent), var(--spec-success));
+  border-radius: 4px;
+  transition: width 0.6s ease;
+}
+
+/* ── Section cards ── */
+.spec-section {
+  margin-bottom: 12px;
+  background: var(--spec-card);
+  border-radius: 8px;
+  border: 1px solid var(--spec-border);
+  overflow: hidden;
+  transition: border-color 0.2s;
+}
+
+.spec-section:hover {
+  border-color: var(--spec-accent);
+}
+
+.spec-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 16px;
+  cursor: pointer;
+  user-select: none;
+  transition: background 0.2s;
+}
+
+.spec-section-header:hover {
+  background: var(--spec-card-hover);
+}
+
+.spec-section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.spec-section-icon {
+  font-size: 1.1rem;
+}
+
+.spec-section-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.spec-badge-populated {
+  background: rgba(74, 222, 128, 0.15);
+  color: var(--spec-success);
+}
+
+.spec-badge-empty {
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--spec-danger);
+}
+
+.spec-section-chevron {
+  font-size: 0.8rem;
+  color: var(--spec-text-dim);
+  transition: transform 0.2s;
+}
+
+.spec-section-chevron.open {
+  transform: rotate(90deg);
+}
+
+.spec-section-body {
+  padding: 0 16px 16px;
+}
+
+/* ── Section content styles ── */
+.spec-field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 10px;
+}
+
+.spec-field-item {
+  padding: 8px 12px;
+  background: var(--spec-bg);
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+.spec-field-label {
+  color: var(--spec-text-dim);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 4px;
+}
+
+.spec-field-value {
+  color: var(--spec-text);
+  word-break: break-word;
+}
+
+/* ── Argument list ── */
+.spec-arg-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.spec-arg-item {
+  display: flex;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--spec-bg);
+  border-radius: 6px;
+  font-size: 0.85rem;
+}
+
+.spec-arg-id {
+  color: var(--spec-accent);
+  font-weight: 600;
+  white-space: nowrap;
+  min-width: 50px;
+}
+
+.spec-arg-text {
+  color: var(--spec-text);
+}
+
+/* ── Fallacy items ── */
+.spec-fallacy-item {
+  padding: 8px 12px;
+  background: var(--spec-bg);
+  border-radius: 6px;
+  border-left: 3px solid var(--spec-warning);
+  margin-bottom: 6px;
+}
+
+.spec-fallacy-path {
+  font-size: 0.75rem;
+  color: var(--spec-text-dim);
+  margin-bottom: 2px;
+}
+
+.spec-fallacy-type {
+  font-weight: 600;
+  color: var(--spec-warning);
+  font-size: 0.9rem;
+}
+
+.spec-fallacy-justification {
+  font-size: 0.82rem;
+  color: var(--spec-text);
+  margin-top: 2px;
+}
+
+.spec-severity-bar {
+  height: 4px;
+  background: var(--spec-bg);
+  border-radius: 2px;
+  margin-top: 4px;
+  overflow: hidden;
+}
+
+.spec-severity-fill {
+  height: 100%;
+  border-radius: 2px;
+}
+
+/* ── JTMS belief tree ── */
+.spec-belief-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.spec-belief-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  font-size: 0.82rem;
+  border-radius: 4px;
+}
+
+.spec-belief-status {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.spec-belief-status.valid {
+  background: var(--spec-success);
+}
+
+.spec-belief-status.retracted {
+  background: var(--spec-retracted);
+}
+
+.spec-belief-name {
+  color: var(--spec-text);
+}
+
+.spec-belief-name.retracted {
+  text-decoration: line-through;
+  color: var(--spec-retracted);
+}
+
+.spec-retraction-chain {
+  padding: 8px 12px;
+  background: rgba(239, 68, 68, 0.1);
+  border-radius: 6px;
+  border-left: 3px solid var(--spec-retracted);
+  margin-top: 8px;
+}
+
+.spec-retraction-trigger {
+  font-weight: 600;
+  color: var(--spec-retracted);
+  font-size: 0.85rem;
+}
+
+.spec-retraction-cascade {
+  font-size: 0.82rem;
+  color: var(--spec-text-dim);
+  margin-top: 2px;
+  padding-left: 12px;
+}
+
+/* ── Dung framework ── */
+.spec-dung-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 10px;
+}
+
+.spec-dung-ext {
+  padding: 8px 12px;
+  background: var(--spec-bg);
+  border-radius: 6px;
+}
+
+.spec-dung-ext-label {
+  font-size: 0.75rem;
+  color: var(--spec-text-dim);
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.spec-dung-ext-args {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.spec-dung-arg-chip {
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+/* ── Quality radar ── */
+.spec-quality-card {
+  padding: 10px 14px;
+  background: var(--spec-bg);
+  border-radius: 6px;
+  margin-bottom: 8px;
+}
+
+.spec-quality-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.spec-quality-arg {
+  font-weight: 600;
+  color: var(--spec-accent);
+  font-size: 0.9rem;
+}
+
+.spec-quality-overall {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.spec-quality-scores {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.spec-quality-virtue {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.78rem;
+}
+
+.spec-quality-virtue-label {
+  color: var(--spec-text-dim);
+}
+
+.spec-quality-virtue-value {
+  font-weight: 500;
+}
+
+.spec-quality-assessment {
+  font-size: 0.82rem;
+  color: var(--spec-text-dim);
+  font-style: italic;
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--spec-border);
+}
+
+/* ── Counter-argument items ── */
+.spec-ca-item {
+  padding: 8px 12px;
+  background: var(--spec-bg);
+  border-radius: 6px;
+  border-left: 3px solid var(--spec-accent);
+  margin-bottom: 6px;
+}
+
+.spec-ca-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.spec-ca-strategy {
+  font-size: 0.75rem;
+  padding: 2px 6px;
+  border-radius: 8px;
+  background: rgba(56, 189, 248, 0.15);
+  color: var(--spec-accent);
+}
+
+.spec-ca-content {
+  font-size: 0.85rem;
+  color: var(--spec-text);
+}
+
+/* ── Narrative section ── */
+.spec-narrative {
+  padding: 12px 16px;
+  background: var(--spec-bg);
+  border-radius: 8px;
+  border-left: 4px solid var(--spec-accent);
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: var(--spec-text);
+}
+
+/* ── Workflow phases ── */
+.spec-phase-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.spec-phase-chip {
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 0.78rem;
+  background: rgba(74, 222, 128, 0.15);
+  color: var(--spec-success);
+}
+
+/* ── Conclusion ── */
+.spec-conclusion {
+  padding: 12px 16px;
+  background: rgba(56, 189, 248, 0.08);
+  border-radius: 8px;
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+/* ── ATMS context ── */
+.spec-atms-context {
+  padding: 8px 12px;
+  background: var(--spec-bg);
+  border-radius: 6px;
+  margin-bottom: 6px;
+}
+
+.spec-atms-hypothesis {
+  font-weight: 600;
+  color: var(--spec-accent);
+  font-size: 0.9rem;
+  margin-bottom: 4px;
+}
+
+.spec-atms-status {
+  font-size: 0.78rem;
+  padding: 2px 6px;
+  border-radius: 8px;
+  display: inline-block;
+  margin-bottom: 4px;
+}
+
+.spec-atms-status.consistent {
+  background: rgba(74, 222, 128, 0.15);
+  color: var(--spec-success);
+}
+
+.spec-atms-status.mostly_consistent {
+  background: rgba(251, 191, 36, 0.15);
+  color: var(--spec-warning);
+}
+
+.spec-atms-status.conflicting {
+  background: rgba(248, 113, 113, 0.15);
+  color: var(--spec-danger);
+}
+
+/* ── Mock badge ── */
+.spec-mock-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: rgba(251, 191, 36, 0.2);
+  color: var(--spec-warning);
+  margin-left: 8px;
+}
+
+/* ── Responsive ── */
+@media (max-width: 768px) {
+  .spec-dashboard {
+    padding: 8px;
+  }
+
+  .spec-header {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .spec-field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .spec-dung-summary {
+    grid-template-columns: 1fr;
+  }
+}

--- a/services/web_api/interface-web-argumentative/src/components/spectacular/SpectacularDashboard.js
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/SpectacularDashboard.js
@@ -1,0 +1,555 @@
+import React, { useState } from 'react';
+import './SpectacularDashboard.css';
+import { MOCK_SPECTACULAR_STATE, getFieldCounts } from '../../services/spectacularMockData';
+
+const SECTION_ICONS = {
+  'Extraction': '📝',
+  'Formal Logic': '🔬',
+  'Fallacies': '⚠️',
+  'JTMS': '🔗',
+  'ATMS': '🔀',
+  'Dung': '🏗️',
+  'ASPIC': '📐',
+  'Counter-Arguments': '⚔️',
+  'Debate': '🗣️',
+  'Governance': '🏛️',
+  'Quality': '📊',
+  'Narrative': '📖',
+  'Tweety Advanced': '🧮',
+  'Workflow': '⚙️',
+};
+
+function CollapsibleSection({ title, icon, badge, children, defaultOpen = false }) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="spec-section">
+      <div className="spec-section-header" onClick={() => setOpen(!open)} data-testid={`section-${title}`}>
+        <div className="spec-section-title">
+          <span className="spec-section-icon">{icon}</span>
+          {title}
+          <span className={`spec-section-badge ${badge.populated > 0 ? 'spec-badge-populated' : 'spec-badge-empty'}`}>
+            {badge.populated}/{badge.total}
+          </span>
+        </div>
+        <span className={`spec-section-chevron ${open ? 'open' : ''}`}>▶</span>
+      </div>
+      {open && <div className="spec-section-body">{children}</div>}
+    </div>
+  );
+}
+
+function ExtractionSection({ state }) {
+  const argCount = Object.keys(state.identified_arguments || {}).length;
+  const extCount = (state.extracts || []).length;
+  return (
+    <>
+      <div className="spec-field-grid">
+        <div className="spec-field-item">
+          <div className="spec-field-label">Source Text</div>
+          <div className="spec-field-value">{state.raw_text}</div>
+        </div>
+        <div className="spec-field-item">
+          <div className="spec-field-label">Text Length</div>
+          <div className="spec-field-value">{state.raw_text_length} chars</div>
+        </div>
+        <div className="spec-field-item">
+          <div className="spec-field-label">Arguments</div>
+          <div className="spec-field-value">{argCount} identified</div>
+        </div>
+        <div className="spec-field-item">
+          <div className="spec-field-label">Fact Extracts</div>
+          <div className="spec-field-value">{extCount} extracted</div>
+        </div>
+      </div>
+      {argCount > 0 && (
+        <div style={{ marginTop: 10 }}>
+          <div className="spec-field-label" style={{ marginBottom: 4 }}>Identified Arguments</div>
+          <div className="spec-arg-list">
+            {Object.entries(state.identified_arguments).map(([id, text]) => (
+              <div key={id} className="spec-arg-item">
+                <span className="spec-arg-id">{id}</span>
+                <span className="spec-arg-text">{text}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {extCount > 0 && (
+        <div style={{ marginTop: 10 }}>
+          <div className="spec-field-label" style={{ marginBottom: 4 }}>Extracts</div>
+          <div className="spec-arg-list">
+            {(state.extracts || []).map((ext) => (
+              <div key={ext.id} className="spec-arg-item">
+                <span className="spec-arg-id" style={{ color: ext.type === 'fact' ? '#4ade80' : ext.type === 'statistic' ? '#38bdf8' : '#fbbf24' }}>
+                  [{ext.type}]
+                </span>
+                <span className="spec-arg-text">{ext.text}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+function FormalLogicSection({ state }) {
+  return (
+    <>
+      <div className="spec-field-grid">
+        {(state.belief_sets && Object.keys(state.belief_sets).length > 0) &&
+          Object.entries(state.belief_sets).map(([id, bs]) => (
+            <div key={id} className="spec-field-item">
+              <div className="spec-field-label">{bs.logic_type} Belief Set</div>
+              <div className="spec-field-value" style={{ whiteSpace: 'pre-wrap', fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                {bs.content}
+              </div>
+            </div>
+          ))}
+      </div>
+      {(state.fol_analysis_results || []).length > 0 && (
+        <div style={{ marginTop: 10 }}>
+          <div className="spec-field-label" style={{ marginBottom: 4 }}>FOL Formulas ({state.fol_analysis_results.length})</div>
+          <div className="spec-arg-list">
+            {state.fol_analysis_results.map((r) => (
+              <div key={r.id} className="spec-arg-item">
+                <span className="spec-arg-id" style={{ color: r.status === 'verified' ? '#4ade80' : '#f87171' }}>
+                  {r.status}
+                </span>
+                <span className="spec-arg-text" style={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>{r.formula}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {(state.nl_to_logic_translations || []).length > 0 && (
+        <div style={{ marginTop: 10 }}>
+          <div className="spec-field-label" style={{ marginBottom: 4 }}>NL → Logic Translations ({state.nl_to_logic_translations.length})</div>
+          <div className="spec-arg-list">
+            {state.nl_to_logic_translations.map((t) => (
+              <div key={t.id} className="spec-arg-item">
+                <span className="spec-arg-id">{t.natural}</span>
+                <span className="spec-arg-text" style={{ fontFamily: 'monospace', fontSize: '0.8rem' }}>
+                  → {t.formal} <span style={{ color: 'var(--spec-text-dim)' }}>({(t.confidence * 100).toFixed(0)}%)</span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {(state.query_log || []).length > 0 && (
+        <div style={{ marginTop: 10 }}>
+          <div className="spec-field-label" style={{ marginBottom: 4 }}>Query Log ({state.query_log.length})</div>
+          <div className="spec-arg-list">
+            {state.query_log.map((q) => (
+              <div key={q.log_id} className="spec-arg-item">
+                <span className="spec-arg-id" style={{ color: '#38bdf8' }}>{q.raw_result}</span>
+                <span className="spec-arg-text">{q.interpreted_result}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {(state.formal_synthesis_reports || []).length > 0 && (
+        <div style={{ marginTop: 10 }}>
+          <div className="spec-field-label" style={{ marginBottom: 4 }}>Formal Synthesis</div>
+          {state.formal_synthesis_reports.map((r) => (
+            <div key={r.id} className="spec-conclusion">
+              <strong>{r.title}</strong> (coherence: {(r.coherence_score * 100).toFixed(0)}%)
+              <br />{r.summary}
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+function FallaciesSection({ state }) {
+  const fallacies = Object.entries(state.identified_fallacies || {});
+  return (
+    <>
+      {fallacies.map(([id, f]) => (
+        <div key={id} className="spec-fallacy-item">
+          <div className="spec-fallacy-path">{f.taxonomy_path}</div>
+          <div className="spec-fallacy-type">{f.type} → {f.target_argument_id}</div>
+          <div className="spec-fallacy-justification">{f.justification}</div>
+          <div className="spec-severity-bar">
+            <div
+              className="spec-severity-fill"
+              style={{
+                width: `${f.severity * 100}%`,
+                background: f.severity > 0.6 ? 'var(--spec-danger)' : f.severity > 0.4 ? 'var(--spec-warning)' : 'var(--spec-success)',
+              }}
+            />
+          </div>
+        </div>
+      ))}
+      {(state.neural_fallacy_scores || []).length > 0 && (
+        <div style={{ marginTop: 8 }}>
+          <div className="spec-field-label" style={{ marginBottom: 4 }}>Neural Detection (CamemBERT)</div>
+          {state.neural_fallacy_scores.map((s, i) => (
+            <div key={i} className="spec-arg-item">
+              <span className="spec-arg-id" style={{ color: '#fbbf24' }}>{(s.score * 100).toFixed(0)}%</span>
+              <span className="spec-arg-text">[{s.family}] {s.text_segment}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+function JtmsSection({ state }) {
+  const beliefs = Object.entries(state.jtms_beliefs || {});
+  const chains = state.jtms_retraction_chain || [];
+  return (
+    <>
+      <div className="spec-belief-list">
+        {beliefs.map(([id, b]) => (
+          <div key={id} className="spec-belief-item">
+            <span className={`spec-belief-status ${b.status === 'VALID' ? 'valid' : 'retracted'}`} />
+            <span className={`spec-belief-name ${b.status === 'RETRACTED' ? 'retracted' : ''}`}>
+              {b.name}
+            </span>
+            <span style={{ color: 'var(--spec-text-dim)', fontSize: '0.75rem', marginLeft: 'auto' }}>
+              {b.justification}
+            </span>
+          </div>
+        ))}
+      </div>
+      {chains.length > 0 && (
+        <div style={{ marginTop: 10 }}>
+          <div className="spec-field-label" style={{ marginBottom: 4 }}>Retraction Cascades</div>
+          {chains.map((chain, i) => (
+            <div key={i} className="spec-retraction-chain">
+              <div className="spec-retraction-trigger">Trigger: {chain.trigger}</div>
+              <div className="spec-retraction-cascade">
+                {chain.retracted.map((r, j) => (
+                  <div key={j} style={{ paddingLeft: (j + 1) * 12 }}>
+                    ↳ {r}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}
+
+function AtmsSection({ state }) {
+  const contexts = state.atms_contexts || [];
+  return (
+    <>
+      {contexts.map((ctx) => (
+        <div key={ctx.id} className="spec-atms-context">
+          <div className="spec-atms-hypothesis">{ctx.id}: {ctx.hypothesis}</div>
+          <span className={`spec-atms-status ${ctx.status}`}>
+            {ctx.status}
+          </span>
+          <div className="spec-field-grid" style={{ marginTop: 6 }}>
+            <div className="spec-field-item">
+              <div className="spec-field-label">Coherent ({ctx.beliefs_coherent.length})</div>
+              <div className="spec-field-value" style={{ fontSize: '0.78rem', color: 'var(--spec-success)' }}>
+                {ctx.beliefs_coherent.slice(0, 5).join(', ')}{ctx.beliefs_coherent.length > 5 ? '...' : ''}
+              </div>
+            </div>
+            <div className="spec-field-item">
+              <div className="spec-field-label">Incoherent ({ctx.beliefs_incoherent.length})</div>
+              <div className="spec-field-value" style={{ fontSize: '0.78rem', color: 'var(--spec-danger)' }}>
+                {ctx.beliefs_incoherent.length > 0 ? ctx.beliefs_incoherent.slice(0, 5).join(', ') : 'None'}
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function DungSection({ state }) {
+  const frameworks = Object.entries(state.dung_frameworks || {});
+  return (
+    <>
+      {frameworks.map(([id, fw]) => (
+        <div key={id}>
+          <div className="spec-field-item" style={{ marginBottom: 8 }}>
+            <div className="spec-field-label">Arguments ({fw.arguments.length}) & Attacks ({fw.attacks.length})</div>
+          </div>
+          {fw.extensions && (
+            <div className="spec-dung-summary">
+              {['grounded', 'preferred', 'stable'].map((extType) => {
+                const ext = fw.extensions[extType];
+                if (!ext) return null;
+                const items = Array.isArray(ext[0]) ? ext : [ext];
+                return (
+                  <div key={extType} className="spec-dung-ext">
+                    <div className="spec-dung-ext-label">{extType}</div>
+                    {items.map((e, i) => (
+                      <div key={i} className="spec-dung-ext-args">
+                        {e.map((arg) => (
+                          <span key={arg} className="spec-dung-arg-chip" style={{
+                            background: extType === 'grounded' ? 'rgba(74,222,128,0.2)' :
+                              extType === 'preferred' ? 'rgba(56,189,248,0.2)' : 'rgba(251,191,36,0.2)',
+                            color: extType === 'grounded' ? '#4ade80' :
+                              extType === 'preferred' ? '#38bdf8' : '#fbbf24',
+                          }}>
+                            {arg}
+                          </span>
+                        ))}
+                      </div>
+                    ))}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      ))}
+    </>
+  );
+}
+
+function CounterArgumentsSection({ state }) {
+  const cas = state.counter_arguments || [];
+  return (
+    <>
+      {cas.map((ca) => (
+        <div key={ca.id} className="spec-ca-item">
+          <div className="spec-ca-header">
+            <span style={{ color: 'var(--spec-accent)', fontSize: '0.85rem', fontWeight: 600 }}>
+              {ca.id} vs {ca.original_argument}
+            </span>
+            <span className="spec-ca-strategy">{ca.strategy}</span>
+          </div>
+          <div className="spec-ca-content">{ca.counter_content}</div>
+          <div style={{ fontSize: '0.75rem', color: 'var(--spec-text-dim)', marginTop: 2 }}>
+            Score: {(ca.score * 100).toFixed(0)}%
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function QualitySection({ state }) {
+  const scores = state.argument_quality_scores || {};
+  const virtueColors = (v) => v >= 0.8 ? '#4ade80' : v >= 0.6 ? '#fbbf24' : '#f87171';
+  return (
+    <>
+      {Object.entries(scores).map(([argId, data]) => (
+        <div key={argId} className="spec-quality-card">
+          <div className="spec-quality-header">
+            <span className="spec-quality-arg">{argId}</span>
+            <span className="spec-quality-overall" style={{ color: virtueColors(data.overall) }}>
+              {(data.overall * 100).toFixed(0)}%
+            </span>
+          </div>
+          <div className="spec-quality-scores">
+            {Object.entries(data.scores || {}).map(([virtue, val]) => (
+              <span key={virtue} className="spec-quality-virtue">
+                <span className="spec-quality-virtue-label">{virtue}:</span>
+                <span className="spec-quality-virtue-value" style={{ color: virtueColors(val) }}>
+                  {(val * 100).toFixed(0)}%
+                </span>
+              </span>
+            ))}
+          </div>
+          {data.llm_assessment && (
+            <div className="spec-quality-assessment">{data.llm_assessment}</div>
+          )}
+        </div>
+      ))}
+    </>
+  );
+}
+
+function DebateSection({ state }) {
+  const debates = state.debate_transcripts || [];
+  return (
+    <>
+      {debates.map((d) => (
+        <div key={d.id} className="spec-field-item">
+          <div className="spec-field-label" style={{ marginBottom: 4 }}>
+            {d.topic} — Outcome: <strong>{d.outcome}</strong>
+          </div>
+          <div className="spec-arg-list">
+            {d.rounds.map((r) => (
+              <div key={r.round} className="spec-arg-item">
+                <span className="spec-arg-id">R{r.round}</span>
+                <span className="spec-arg-text">
+                  [{r.argument.type}] {r.argument.text}
+                  <span style={{ color: 'var(--spec-text-dim)', fontSize: '0.75rem', marginLeft: 8 }}>
+                    (score: {r.argument.score})
+                  </span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function GovernanceSection({ state }) {
+  const decisions = state.governance_decisions || [];
+  return (
+    <>
+      {decisions.map((d) => (
+        <div key={d.id} className="spec-field-item" style={{ marginBottom: 8 }}>
+          <div className="spec-field-label">{d.proposal}</div>
+          <div className="spec-field-value">
+            <span style={{ color: d.result === 'adopted' ? '#4ade80' : '#f87171' }}>{d.result}</span>
+            {' '}via {d.voting_method} — Pro: {d.votes.pro}, Con: {d.votes.con}, Abstain: {d.votes.abstain}
+            <span style={{ color: 'var(--spec-text-dim)', marginLeft: 8 }}>
+              Consensus: {(d.consensus_score * 100).toFixed(0)}%
+            </span>
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}
+
+function NarrativeSection({ state }) {
+  return <div className="spec-narrative">{state.narrative}</div>;
+}
+
+function TweetyAdvancedSection({ state }) {
+  const fields = [
+    { key: 'ranking_results', label: 'Rankings' },
+    { key: 'belief_revision_results', label: 'Belief Revisions' },
+    { key: 'dialogue_results', label: 'Dialogues' },
+    { key: 'probabilistic_results', label: 'Probabilistic' },
+    { key: 'bipolar_results', label: 'Bipolar' },
+  ];
+  return (
+    <div className="spec-field-grid">
+      {fields.map(({ key, label }) => {
+        const items = state[key] || [];
+        return items.length > 0 ? (
+          <div key={key} className="spec-field-item">
+            <div className="spec-field-label">{label}</div>
+            <div className="spec-field-value">
+              {items.map((item, i) => (
+                <div key={i} style={{ fontSize: '0.8rem', marginBottom: 2 }}>
+                  {item.interpretation || item.result || JSON.stringify(item).slice(0, 80)}
+                </div>
+              ))}
+            </div>
+          </div>
+        ) : null;
+      })}
+      {(state.aspic_results || []).length > 0 && (
+        <div className="spec-field-item">
+          <div className="spec-field-label">ASPIC Results</div>
+          <div className="spec-field-value">
+            {state.aspic_results.map((r) => (
+              <div key={r.id} style={{ fontSize: '0.8rem', marginBottom: 2 }}>
+                {r.conclusion} ({r.defeat_status})
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function WorkflowSection({ state }) {
+  const wr = state.workflow_results || {};
+  const conclusion = state.final_conclusion;
+  return (
+    <>
+      {wr.phase_details && (
+        <div style={{ marginBottom: 10 }}>
+          <div className="spec-field-label" style={{ marginBottom: 4 }}>
+            Phases ({wr.completed_phases}/{wr.total_phases})
+          </div>
+          <div className="spec-phase-list">
+            {wr.phase_details.map((p) => (
+              <span key={p.name} className="spec-phase-chip">
+                {p.name} ({p.duration_s}s)
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+      {conclusion && (
+        <div className="spec-conclusion">
+          <div className="spec-field-label" style={{ marginBottom: 4 }}>Final Conclusion</div>
+          {conclusion}
+        </div>
+      )}
+    </>
+  );
+}
+
+const SECTION_RENDERERS = {
+  'Extraction': ExtractionSection,
+  'Formal Logic': FormalLogicSection,
+  'Fallacies': FallaciesSection,
+  'JTMS': JtmsSection,
+  'ATMS': AtmsSection,
+  'Dung': DungSection,
+  'Counter-Arguments': CounterArgumentsSection,
+  'Quality': QualitySection,
+  'Debate': DebateSection,
+  'Governance': GovernanceSection,
+  'Narrative': NarrativeSection,
+  'Tweety Advanced': TweetyAdvancedSection,
+  'Workflow': WorkflowSection,
+};
+
+const DEFAULTS_OPEN = ['Extraction', 'Narrative', 'Quality'];
+
+export default function SpectacularDashboard() {
+  const state = MOCK_SPECTACULAR_STATE;
+  const counts = getFieldCounts(state);
+  const coveragePct = ((counts.populated / counts.total) * 100).toFixed(0);
+
+  return (
+    <div className="spec-dashboard">
+      <div className="spec-header">
+        <div>
+          <h2>Spectacular Analysis Dashboard</h2>
+          <span className="spec-mock-badge">MOCK DATA — Track 1 pending</span>
+        </div>
+        <div className="spec-meta">
+          <span>Document: {state.document_id}</span>
+          <span>Workflow: {state.workflow}</span>
+          <span>Duration: {state.duration_seconds}s</span>
+          <span>Phases: {state.phases_completed}/{state.phases_total}</span>
+        </div>
+      </div>
+
+      <div className="spec-coverage-bar">
+        <div className="spec-coverage-label">
+          <span>Field Coverage</span>
+          <span>{counts.populated}/{counts.total} fields populated ({coveragePct}%)</span>
+        </div>
+        <div className="spec-coverage-track">
+          <div className="spec-coverage-fill" style={{ width: `${coveragePct}%` }} />
+        </div>
+      </div>
+
+      {Object.entries(SECTION_RENDERERS).map(([title, Renderer]) => {
+        const badge = counts.by_section[title] || { populated: 0, total: 0 };
+        return (
+          <CollapsibleSection
+            key={title}
+            title={title}
+            icon={SECTION_ICONS[title]}
+            badge={badge}
+            defaultOpen={DEFAULTS_OPEN.includes(title)}
+          >
+            <Renderer state={state} />
+          </CollapsibleSection>
+        );
+      })}
+    </div>
+  );
+}

--- a/services/web_api/interface-web-argumentative/src/components/spectacular/SpectacularDashboard.test.js
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/SpectacularDashboard.test.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SpectacularDashboard from './SpectacularDashboard';
+
+describe('SpectacularDashboard', () => {
+  test('renders dashboard header with mock badge', () => {
+    render(<SpectacularDashboard />);
+    expect(screen.getByText('Spectacular Analysis Dashboard')).toBeInTheDocument();
+    expect(screen.getByText(/MOCK DATA/)).toBeInTheDocument();
+  });
+
+  test('displays field coverage bar', () => {
+    render(<SpectacularDashboard />);
+    expect(screen.getByText(/fields populated/)).toBeInTheDocument();
+  });
+
+  test('shows all 13 sections', () => {
+    render(<SpectacularDashboard />);
+    const sections = [
+      'Extraction', 'Formal Logic', 'Fallacies', 'JTMS', 'ATMS', 'Dung',
+      'Counter-Arguments', 'Quality', 'Debate', 'Governance', 'Narrative',
+      'Tweety Advanced', 'Workflow',
+    ];
+    sections.forEach((name) => {
+      // Section titles appear inside headers with icons
+      const header = screen.getByTestId(`section-${name}`);
+      expect(header).toBeInTheDocument();
+    });
+  });
+
+  test('default open sections show content', () => {
+    render(<SpectacularDashboard />);
+    // Narrative section should be open by default
+    expect(screen.getByText(/analyse du document doc_A/)).toBeInTheDocument();
+  });
+
+  test('collapsible sections toggle on click', () => {
+    render(<SpectacularDashboard />);
+    // Fallacies is closed by default
+    const fallaciesHeader = screen.getByTestId('section-Fallacies');
+    expect(screen.queryByText(/Tu Quoque/)).not.toBeInTheDocument();
+
+    // Click to open
+    fireEvent.click(fallaciesHeader);
+    expect(screen.getByText(/Tu Quoque/)).toBeInTheDocument();
+  });
+
+  test('displays document metadata', () => {
+    render(<SpectacularDashboard />);
+    expect(screen.getByText(/Document: doc_A/)).toBeInTheDocument();
+    expect(screen.getByText(/Workflow: standard/)).toBeInTheDocument();
+  });
+
+  test('shows argument quality scores', () => {
+    render(<SpectacularDashboard />);
+    // Quality section is open by default — check for LLM assessment text
+    expect(screen.getByText(/Le taux de 15% est précis/)).toBeInTheDocument();
+  });
+
+  test('shows JTMS beliefs when section opened', () => {
+    render(<SpectacularDashboard />);
+    fireEvent.click(screen.getByTestId('section-JTMS'));
+    // Belief names from mock data use 'arg_1_valid' etc.
+    expect(screen.getByText('arg_1_valid')).toBeInTheDocument();
+    // Retracted belief
+    const retracted = screen.getByText('arg_9_retracted');
+    expect(retracted).toBeInTheDocument();
+  });
+
+  test('shows Dung extensions when section opened', () => {
+    render(<SpectacularDashboard />);
+    fireEvent.click(screen.getByTestId('section-Dung'));
+    // Extension labels
+    expect(screen.getByText('grounded')).toBeInTheDocument();
+    expect(screen.getByText('preferred')).toBeInTheDocument();
+    expect(screen.getByText('stable')).toBeInTheDocument();
+  });
+
+  test('shows counter-arguments when section opened', () => {
+    render(<SpectacularDashboard />);
+    fireEvent.click(screen.getByTestId('section-Counter-Arguments'));
+    // Check for strategy badges
+    const strategies = screen.getAllByText(/counter-example/);
+    expect(strategies.length).toBeGreaterThan(0);
+    expect(screen.getByText(/distinction/)).toBeInTheDocument();
+  });
+
+  test('shows ATMS contexts when section opened', () => {
+    render(<SpectacularDashboard />);
+    fireEvent.click(screen.getByTestId('section-ATMS'));
+    expect(screen.getByText(/Programme efficace/)).toBeInTheDocument();
+    expect(screen.getByText(/Programme coûteux/)).toBeInTheDocument();
+    expect(screen.getByText(/Résultats contestés/)).toBeInTheDocument();
+  });
+});

--- a/services/web_api/interface-web-argumentative/src/services/spectacularMockData.js
+++ b/services/web_api/interface-web-argumentative/src/services/spectacularMockData.js
@@ -1,0 +1,373 @@
+/**
+ * Mock data for the Spectacular Dashboard (32 fields).
+ * Matches UnifiedAnalysisState from argumentation_analysis/core/shared_state.py.
+ * Used for development before Track 1 delivers real data.
+ */
+
+export const MOCK_SPECTACULAR_STATE = {
+  // ── Metadata ──
+  document_id: 'doc_A',
+  workflow: 'standard',
+  duration_seconds: 478.8,
+  phases_completed: 13,
+  phases_total: 13,
+  timestamp: '2026-04-24T10:30:00Z',
+
+  // ── Section 1: Extraction ──
+  raw_text: '[Extrait du discours source — texte complet masqué pour la démo]',
+  raw_text_length: 4231,
+  identified_arguments: {
+    arg_1: 'Le programme éducatif a permis d\'augmenter le taux de réussite de 15%.',
+    arg_2: 'Les enseignants rapportent une meilleure implication des élèves.',
+    arg_3: 'Le coût du programme est inférieur aux alternatives existantes.',
+    arg_4: 'Des études indépendantes confirment ces résultats dans 3 pays.',
+    arg_5: 'Le modèle est transposable à d\'autres niveaux scolaires.',
+    arg_6: 'Les résultats à long terme montrent un impact durable sur 5 ans.',
+    arg_7: 'Les parents sont satisfaits du programme à 87%.',
+    arg_8: 'Le programme réduit les inégalités entre zones urbaines et rurales.',
+    arg_9: 'Les critiques portent sur le manque de données comparatives.',
+    arg_10: 'L\'investissement initial est rentabilisé en 2 ans.',
+    arg_11: 'Le programme est conforme aux normes européennes.',
+  },
+  extracts: [
+    { id: 'ext_1', type: 'fact', text: 'Taux de réussite +15% sur cohorte 2023-2025', source: 'rapport_interne_v3.pdf' },
+    { id: 'ext_2', type: 'statistic', text: '87% satisfaction parentale (enquête N=1200)', source: 'enquete_satisfaction.xlsx' },
+    { id: 'ext_3', type: 'claim', text: 'Impact durable démontré sur 5 cohortes', source: 'etude_longitudinale.pdf' },
+    { id: 'ext_4', type: 'fact', text: 'Coût 30% inférieur à Alternative-B', source: 'audit_couts.pdf' },
+    { id: 'ext_5', type: 'testimony', text: 'Enseignant: "Les élèves sont plus engagés"', source: 'entretiens_qualitatifs.docx' },
+    { id: 'ext_6', type: 'statistic', text: 'Réduction inégalités urbain/rural: -22%', source: 'rapport_interne_v3.pdf' },
+    { id: 'ext_7', type: 'claim', text: 'Transposable à primaire et secondaire', source: 'etude_transposabilite.pdf' },
+    { id: 'ext_8', type: 'fact', text: 'ROI atteint en 24 mois (seuil: 36)', source: 'audit_couts.pdf' },
+    { id: 'ext_9', type: 'fact', text: '3 pays pilotes: BE, CH, PT', source: 'rapport_europeen.pdf' },
+    { id: 'ext_10', type: 'claim', text: 'Conforme normes EU-EDUC-2024', source: 'certificat_conformite.pdf' },
+    { id: 'ext_11', type: 'statistic', text: 'Cohorte 2024: 95.2% de validation', source: 'resultats_2024.xlsx' },
+    { id: 'ext_12', type: 'fact', text: '250 établissements adoptés en 2025', source: 'rapport_deploiement.pdf' },
+    { id: 'ext_13', type: 'claim', text: 'Meilleur score PISA dans les zones adoptantes', source: 'etude_comparative_pisa.pdf' },
+    { id: 'ext_14', type: 'testimony', text: 'Inspecteur: "Modèle exemplaire de pédagogie active"', source: 'rapport_inspection.pdf' },
+    { id: 'ext_15', type: 'fact', text: 'Budget initial: 2.3M€, budget courant: 1.8M€/an', source: 'audit_couts.pdf' },
+  ],
+
+  // ── Section 2: Formal Logic ──
+  belief_sets: {
+    bs_fol: { logic_type: 'FOL', content: '∀x (Program(x) → Successful(x))\n∃t (Teacher(t) ∧ Reports(t, improvement))' },
+    bs_prop: { logic_type: 'Propositional', content: 'P → Q\nQ → R\n∴ P → R' },
+    bs_modal: { logic_type: 'Modal', content: '□(Program → Success)\n◇(Criticism → Revision)' },
+  },
+  query_log: [
+    { log_id: 'ql_1', belief_set_id: 'bs_fol', query: 'Program(x) ∧ Successful(x)', raw_result: 'SATISFIABLE', interpreted_result: 'Le programme est associé au succès' },
+    { log_id: 'ql_2', belief_set_id: 'bs_prop', query: 'P → R', raw_result: 'VALID', interpreted_result: 'La chaîne d\'implication est valide' },
+    { log_id: 'ql_3', belief_set_id: 'bs_modal', query: '◇Criticism', raw_result: 'TRUE_IN_S5', interpreted_result: 'La critique est possible' },
+    { log_id: 'ql_4', belief_set_id: 'bs_fol', query: '∀x (Cost(x) < Threshold(x))', raw_result: 'SATISFIABLE', interpreted_result: 'Les coûts sont sous le seuil' },
+  ],
+  fol_analysis_results: [
+    { id: 'fol_1', formula: '∀x (Program(x) → Successful(x))', status: 'verified', sort: 'Program', constants: ['prog_edu_2024'], interpretation: 'Tout programme de ce type conduit au succès' },
+    { id: 'fol_2', formula: '∃x (Teacher(x) ∧ Engaged(x))', status: 'verified', sort: 'Teacher', constants: ['teacher_sample'], interpretation: 'Au moins un enseignant est engagé' },
+    { id: 'fol_3', formula: 'Cost(prog) < Cost(alternative)', status: 'verified', sort: 'Cost', constants: ['prog_edu_2024', 'alternative_b'], interpretation: 'Coût du programme inférieur' },
+    { id: 'fol_4', formula: '∀x (Adopt(x) → Satisfies(x, norm_eu))', status: 'verified', sort: 'Norm', constants: ['norm_eu_2024'], interpretation: 'Conformité aux normes européennes' },
+    { id: 'fol_5', formula: 'ROI(prog) ∈ [18, 24] months', status: 'verified', sort: 'Finance', constants: ['roi_period'], interpretation: 'ROI atteint entre 18-24 mois' },
+    { id: 'fol_6', formula: '∀x (Zone(x, rural) → Benefit(x))', status: 'verified', sort: 'Zone', constants: ['zone_rural'], interpretation: 'Les zones rurales bénéficient' },
+  ],
+  propositional_analysis_results: [
+    { id: 'prop_1', formula: 'P ∧ Q → R', status: 'tautology', variables: { P: 'program_exists', Q: 'funding_ok', R: 'success' } },
+  ],
+  modal_analysis_results: [
+    { id: 'modal_1', formula: '□(Implementation → Results)', status: 'necessary', modality: 'S5' },
+  ],
+  nl_to_logic_translations: [
+    { id: 'nl_1', natural: 'Le programme fonctionne', formal: 'Successful(prog_edu_2024)', confidence: 0.92 },
+    { id: 'nl_2', natural: 'Les enseignants sont satisfaits', formal: 'Satisfied(teacher_sample)', confidence: 0.87 },
+    { id: 'nl_3', natural: 'Le coût est raisonnable', formal: 'Cost(prog) < Threshold', confidence: 0.78 },
+    { id: 'nl_4', natural: 'Les résultats sont durables', formal: 'Durable(results, 5_years)', confidence: 0.85 },
+    { id: 'nl_5', natural: 'Le modèle est transposable', formal: '∃x (Transposable(prog, x))', confidence: 0.72 },
+    { id: 'nl_6', natural: 'Les parents approuvent', formal: 'Approve(parents, prog)', confidence: 0.91 },
+  ],
+  formal_synthesis_reports: [
+    { id: 'synth_1', title: 'Synthèse formelle globale', summary: '6 formules FOL vérifiées, 1 tautologie propositionnelle, 1 nécessité modale. Aucune contradiction détectée.', coherence_score: 0.94 },
+  ],
+
+  // ── Section 3: Fallacies (3-tier) ──
+  identified_fallacies: {
+    fall_1: {
+      type: 'Ad Hominem',
+      family: 'Relevance',
+      tier1: 'Ad Hominem',
+      tier2: 'Personal Attack',
+      tier3: 'Tu Quoque',
+      justification: 'L\'auteur est critiqué sur sa moralité plutôt que sur ses arguments.',
+      target_argument_id: 'arg_9',
+      taxonomy_path: 'Relevance > Ad Hominem > Personal Attack > Tu Quoque',
+      severity: 0.7,
+    },
+    fall_2: {
+      type: 'Homme de paille',
+      family: 'Relevance',
+      tier1: 'Straw Man',
+      tier2: 'Distortion',
+      tier3: 'Exaggeration',
+      justification: 'L\'argument opposé est simplifié à l\'extrême avant d\'être réfuté.',
+      target_argument_id: 'arg_3',
+      taxonomy_path: 'Relevance > Straw Man > Distortion > Exaggeration',
+      severity: 0.5,
+    },
+    fall_3: {
+      type: 'Argument tonal',
+      family: 'Emotion',
+      tier1: 'Appeal to Emotion',
+      tier2: 'Tonal Argument',
+      tier3: 'Enthusiasm',
+      justification: 'Le ton enthousiaste remplace la justification factuelle.',
+      target_argument_id: 'arg_5',
+      taxonomy_path: 'Emotion > Appeal to Emotion > Tonal Argument > Enthusiasm',
+      severity: 0.3,
+    },
+  },
+  neural_fallacy_scores: [
+    { text_segment: 'Ce critique a été condamné pour fraude', family: 'ad_hominem', score: 0.87, model: 'CamemBERT-fallacy-v2' },
+    { text_segment: 'Ils veulent détruire tout le système', family: 'straw_man', score: 0.72, model: 'CamemBERT-fallacy-v2' },
+  ],
+
+  // ── Section 4: JTMS ──
+  jtms_beliefs: {
+    b_arg_1: { name: 'arg_1_valid', status: 'VALID', justification: 'extracted_from_source', dependencies: [] },
+    b_arg_2: { name: 'arg_2_valid', status: 'VALID', justification: 'teacher_testimony', dependencies: ['b_arg_1'] },
+    b_arg_3: { name: 'arg_3_valid', status: 'VALID', justification: 'cost_audit', dependencies: [] },
+    b_fall_1: { name: 'fall_1_detected', status: 'VALID', justification: 'fallacy_detector_ad_hominem', dependencies: ['b_arg_9'] },
+    b_arg_9: { name: 'arg_9_contested', status: 'VALID', justification: 'critical_review', dependencies: [] },
+    b_defeat_1: { name: 'defeat_fall_1_to_arg_9', status: 'VALID', justification: 'fallacy_undermines_credibility', dependencies: ['b_fall_1', 'b_arg_9'] },
+    b_retract_1: { name: 'arg_9_retracted', status: 'RETRACTED', justification: 'cascade_from_fall_1', dependencies: ['b_defeat_1'] },
+    b_arg_4: { name: 'arg_4_valid', status: 'VALID', justification: 'independent_studies', dependencies: [] },
+    b_arg_5: { name: 'arg_5_valid', status: 'VALID', justification: 'transposition_study', dependencies: [] },
+    b_arg_6: { name: 'arg_6_valid', status: 'VALID', justification: 'longitudinal_data', dependencies: ['b_arg_1'] },
+    b_arg_7: { name: 'arg_7_valid', status: 'VALID', justification: 'parent_survey', dependencies: [] },
+    b_arg_8: { name: 'arg_8_valid', status: 'VALID', justification: 'inequality_report', dependencies: ['b_arg_1'] },
+    b_arg_10: { name: 'arg_10_valid', status: 'VALID', justification: 'roi_analysis', dependencies: ['b_arg_3'] },
+    b_arg_11: { name: 'arg_11_valid', status: 'VALID', justification: 'compliance_check', dependencies: [] },
+    b_fall_2: { name: 'fall_2_detected', status: 'VALID', justification: 'fallacy_detector_straw_man', dependencies: ['b_arg_3'] },
+    b_defeat_2: { name: 'defeat_fall_2_to_arg_3', status: 'VALID', justification: 'straw_man_undermines', dependencies: ['b_fall_2', 'b_arg_3'] },
+    b_fall_3: { name: 'fall_3_detected', status: 'VALID', justification: 'fallacy_detector_tonal', dependencies: ['b_arg_5'] },
+    b_defeat_3: { name: 'defeat_fall_3_to_arg_5', status: 'VALID', justification: 'tonal_fallacy_flagged', dependencies: ['b_fall_3', 'b_arg_5'] },
+    b_cascade_1: { name: 'cascade_retract_dependent_5', status: 'RETRACTED', justification: 'retraction_cascade_from_fall_3', dependencies: ['b_defeat_3'] },
+    b_cascade_2: { name: 'cascade_retract_dependent_6', status: 'RETRACTED', justification: 'retraction_cascade_from_5', dependencies: ['b_cascade_1'] },
+    b_cascade_3: { name: 'cascade_retract_dependent_8', status: 'RETRACTED', justification: 'retraction_cascade_from_1', dependencies: ['b_cascade_1'] },
+    b_reinforce_1: { name: 'reinforce_arg_4', status: 'VALID', justification: 'independent_validation', dependencies: ['b_arg_4'] },
+    b_reinforce_2: { name: 'reinforce_arg_11', status: 'VALID', justification: 'norm_compliance', dependencies: ['b_arg_11'] },
+    b_reinforce_3: { name: 'reinforce_overall', status: 'VALID', justification: 'majority_args_valid', dependencies: ['b_reinforce_1', 'b_reinforce_2'] },
+  },
+  jtms_retraction_chain: [
+    { trigger: 'fall_3 (Tonal)', retracted: ['b_cascade_1 (arg_5)', 'b_cascade_2 (arg_6)', 'b_cascade_3 (arg_8)'], depth: 3 },
+    { trigger: 'fall_1 (Ad Hominem)', retracted: ['b_retract_1 (arg_9)'], depth: 1 },
+  ],
+
+  // ── Section 5: ATMS ──
+  atms_contexts: [
+    {
+      id: 'ctx_A',
+      hypothesis: 'Programme efficace',
+      beliefs_coherent: ['b_arg_1', 'b_arg_2', 'b_arg_3', 'b_arg_4', 'b_arg_6', 'b_arg_7', 'b_arg_8', 'b_arg_10', 'b_arg_11'],
+      beliefs_incoherent: ['b_retract_1', 'b_cascade_1', 'b_cascade_2', 'b_cascade_3'],
+      status: 'mostly_consistent',
+    },
+    {
+      id: 'ctx_B',
+      hypothesis: 'Programme coûteux',
+      beliefs_coherent: ['b_arg_3', 'b_arg_10'],
+      beliefs_incoherent: [],
+      status: 'consistent',
+    },
+    {
+      id: 'ctx_C',
+      hypothesis: 'Résultats contestés',
+      beliefs_coherent: ['b_fall_1', 'b_fall_2', 'b_fall_3', 'b_defeat_1', 'b_defeat_2', 'b_defeat_3', 'b_retract_1', 'b_cascade_1', 'b_cascade_2', 'b_cascade_3'],
+      beliefs_incoherent: ['b_arg_1', 'b_arg_2', 'b_arg_4'],
+      status: 'conflicting',
+    },
+    {
+      id: 'ctx_D',
+      hypothesis: 'Modèle transposable',
+      beliefs_coherent: ['b_arg_4', 'b_arg_5', 'b_arg_11', 'b_reinforce_1', 'b_reinforce_2', 'b_reinforce_3'],
+      beliefs_incoherent: [],
+      status: 'consistent',
+    },
+  ],
+
+  // ── Section 6: Dung ──
+  dung_frameworks: {
+    framework_1: {
+      arguments: ['a1', 'a2', 'a3', 'a4', 'a5', 'a6', 'a7', 'a8'],
+      attacks: [
+        { from: 'a5', to: 'a1' },
+        { from: 'a2', to: 'a3' },
+        { from: 'a7', to: 'a4' },
+        { from: 'a8', to: 'a6' },
+      ],
+      extensions: {
+        grounded: ['a1', 'a3', 'a4', 'a6'],
+        preferred: [['a1', 'a3', 'a4', 'a6'], ['a2', 'a4', 'a5', 'a6']],
+        stable: [['a1', 'a3', 'a4', 'a6']],
+      },
+    },
+  },
+
+  // ── Section 7: ASPIC ──
+  aspic_results: [
+    {
+      id: 'aspic_1',
+      type: 'structured_argument',
+      premises: ['Program(X)', 'Evaluated(X, positive)'],
+      conclusion: 'Successful(X)',
+      rules_applied: ['rule_effectiveness'],
+      defeat_status: 'undefeated',
+    },
+  ],
+
+  // ── Section 8: Counter-Arguments ──
+  counter_arguments: [
+    { id: 'ca_1', original_argument: 'arg_1', counter_content: 'Le taux de +15% est calculé sur un échantillon biaisé (volontaires uniquement).', strategy: 'counter-example', score: 0.82 },
+    { id: 'ca_2', original_argument: 'arg_5', counter_content: 'La transposabilité n\'est démontrée que dans des contextes similaires, pas dans des systèmes éducatifs fondamentalement différents.', strategy: 'distinction', score: 0.75 },
+    { id: 'ca_3', original_argument: 'arg_3', counter_content: 'Si le coût direct est inférieur, les coûts indirects (formation, infrastructure) dépassent les alternatives.', strategy: 'reductio_ad_absurdum', score: 0.68 },
+    { id: 'ca_4', original_argument: 'arg_7', counter_content: 'La satisfaction à 87% reflète un biais de sélection: les parents insatisfaits ont quitté le programme.', strategy: 'counter-example', score: 0.71 },
+    { id: 'ca_5', original_argument: 'arg_10', counter_content: 'Le ROI de 24 mois ne tient pas compte des coûts récurrents de maintenance.', strategy: 'reformulation', score: 0.65 },
+  ],
+
+  // ── Section 9: Debate ──
+  debate_transcripts: [
+    {
+      id: 'debate_1',
+      topic: 'Faut-il généraliser le programme éducatif ?',
+      agents: [
+        { id: 'agent_prop', name: 'Socrate', stance: 'pro' },
+        { id: 'agent_opp', name: 'Devil\'s Advocate', stance: 'con' },
+      ],
+      rounds: [
+        { round: 1, argument: { id: 'd_arg_1', text: 'Les résultats sont positifs et reproductibles.', type: 'claim', agent: 'agent_prop', score: 0.85 } },
+        { round: 2, argument: { id: 'd_arg_2', text: 'Les résultats sont limités à des contextes favorables.', type: 'attack', agent: 'agent_opp', score: 0.72 } },
+        { round: 3, argument: { id: 'd_arg_3', text: 'Les 3 pays pilotes incluent des contextes variés.', type: 'rebuttal', agent: 'agent_prop', score: 0.78 } },
+      ],
+      outcome: 'balanced',
+    },
+  ],
+
+  // ── Section 10: Governance ──
+  governance_decisions: [
+    {
+      id: 'gov_1',
+      proposal: 'Déploiement national du programme',
+      voting_method: 'Borda',
+      votes: { pro: 7, con: 3, abstain: 1 },
+      result: 'adopted',
+      consensus_score: 0.72,
+    },
+    {
+      id: 'gov_2',
+      proposal: 'Augmentation budget de 50%',
+      voting_method: 'Majorité simple',
+      votes: { pro: 5, con: 4, abstain: 2 },
+      result: 'adopted',
+      consensus_score: 0.55,
+    },
+  ],
+
+  // ── Section 11: Quality ──
+  argument_quality_scores: {
+    arg_1: { scores: { clarity: 0.92, coherence: 0.88, relevance: 0.95, sufficiency: 0.78, acceptability: 0.90, effectiveness: 0.85, completeness: 0.82, organization: 0.87, cogency: 0.84 }, overall: 0.87, llm_assessment: 'Argument bien structuré avec données chiffrées. Le taux de 15% est précis mais mérite une source.' },
+    arg_3: { scores: { clarity: 0.85, coherence: 0.90, relevance: 0.88, sufficiency: 0.70, acceptability: 0.82, effectiveness: 0.78, completeness: 0.75, organization: 0.85, cogency: 0.80 }, overall: 0.81, llm_assessment: 'Comparaison de coûts pertinente. Manque de détail sur les coûts indirects.' },
+    arg_9: { scores: { clarity: 0.65, coherence: 0.60, relevance: 0.72, sufficiency: 0.45, acceptability: 0.55, effectiveness: 0.50, completeness: 0.40, organization: 0.68, cogency: 0.52 }, overall: 0.56, llm_assessment: 'Critique vague sans données comparatives. Affirmation non étayée.' },
+  },
+
+  // ── Section 12: Narrative Synthesis ──
+  narrative: "L'analyse du document doc_A révèle un plaidoyer structuré en faveur du programme éducatif, appuyé par 11 arguments dont 8 sont formellement validés. L'extraction factuelle produit 15 claims sourcés, tandis que l'analyse FOL confirme 6 formules dont ∀x(Program(x)→Successful(x)). Le JTMS identifie 3 chaînes de rétraction déclenchées par 3 sophismes (Ad Hominem, Homme de paille, Argument tonal), affectant les arguments 5, 6, 8 et 9. Le framework de Dung produit une extension stable de 4 arguments. La qualité moyenne des arguments est de 7.5/10, avec une faiblesse notable sur l'argument 9 (critique non étayée). Le débat contradictoire conclut à un équilibre entre arguments pro et con. Le vote de gouvernance recommande le déploiement (Borda, consensus 72%).",
+
+  // ── Section 13: Tweety Advanced ──
+  ranking_results: [
+    { id: 'rank_1', method: 'TweetyRanking', result: '[a1, a4, a6, a3, a8, a2, a7, a5]', interpretation: 'a1 est l\'argument le plus accepté' },
+  ],
+  belief_revision_results: [
+    { id: 'br_1', operation: 'contract', formula: 'arg_9_valid', result: 'Consistent after contraction', beliefs_removed: 1 },
+  ],
+  dialogue_results: [
+    { id: 'dlg_1', type: 'persuasion', moves: 5, outcome: 'Proponent wins on arg_1' },
+  ],
+  probabilistic_results: [
+    { id: 'prob_1', query: 'P(Successful|Evidence)', result: 0.87, interpretation: 'Probabilité élevée de succès au vu des preuves' },
+  ],
+  bipolar_results: [
+    { id: 'bip_1', supports: [{ from: 'a4', to: 'a1' }], attacks: [{ from: 'a5', to: 'a1' }], result: 'Support l\'emporte sur attack pour a1' },
+  ],
+
+  // ── Section 14: Workflow Metadata ──
+  analysis_tasks: { task_1: 'Extraction', task_2: 'Formal Analysis', task_3: 'Fallacy Detection', task_4: 'JTMS', task_5: 'Dung', task_6: 'Quality', task_7: 'Counter-Arguments', task_8: 'Debate', task_9: 'Governance', task_10: 'Synthesis' },
+  answers: {
+    task_1: { author_agent: 'ExtractAgent', answer_text: '15 extracts identifiés', confidence: 0.90 },
+    task_3: { author_agent: 'FallacyDetector', answer_text: '3 sophismes détectés', confidence: 0.85 },
+  },
+  final_conclusion: 'Le programme éducatif est globalement bénéfique (8/11 arguments valides, 87% quality), malgré 3 sophismes identifiés qui affectent marginalement la crédibilité. Déploiement recommandé avec suivi des coûts indirects.',
+  errors: [],
+
+  // ── Workflow execution results ──
+  workflow_results: {
+    workflow_name: 'standard',
+    total_phases: 13,
+    completed_phases: 13,
+    phase_details: [
+      { name: 'extract_facts', duration_s: 12.3, status: 'completed' },
+      { name: 'identify_arguments', duration_s: 45.1, status: 'completed' },
+      { name: 'detect_fallacies', duration_s: 38.7, status: 'completed' },
+      { name: 'evaluate_quality', duration_s: 22.5, status: 'completed' },
+      { name: 'generate_counter_arguments', duration_s: 55.2, status: 'completed' },
+      { name: 'build_jtms', duration_s: 18.4, status: 'completed' },
+      { name: 'compute_dung', duration_s: 15.8, status: 'completed' },
+      { name: 'run_aspic', duration_s: 12.1, status: 'completed' },
+      { name: 'translate_nl_to_logic', duration_s: 35.6, status: 'completed' },
+      { name: 'run_governance', duration_s: 8.3, status: 'completed' },
+      { name: 'run_debate', duration_s: 62.1, status: 'completed' },
+      { name: 'synthesize', duration_s: 25.4, status: 'completed' },
+      { name: 'narrative', duration_s: 10.2, status: 'completed' },
+    ],
+  },
+};
+
+/**
+ * Counts how many of the 32 fields are populated (non-empty).
+ */
+export const getFieldCounts = (state) => {
+  const counts = {
+    populated: 0,
+    total: 32,
+    by_section: {},
+  };
+
+  const fieldsBySection = {
+    'Extraction': ['raw_text', 'identified_arguments', 'extracts'],
+    'Formal Logic': ['belief_sets', 'query_log', 'fol_analysis_results', 'propositional_analysis_results', 'modal_analysis_results', 'nl_to_logic_translations', 'formal_synthesis_reports'],
+    'Fallacies': ['identified_fallacies', 'neural_fallacy_scores'],
+    'JTMS': ['jtms_beliefs', 'jtms_retraction_chain'],
+    'ATMS': ['atms_contexts'],
+    'Dung': ['dung_frameworks'],
+    'ASPIC': ['aspic_results'],
+    'Counter-Arguments': ['counter_arguments'],
+    'Debate': ['debate_transcripts'],
+    'Governance': ['governance_decisions'],
+    'Quality': ['argument_quality_scores'],
+    'Narrative': ['narrative'],
+    'Tweety Advanced': ['ranking_results', 'belief_revision_results', 'dialogue_results', 'probabilistic_results', 'bipolar_results'],
+    'Workflow': ['analysis_tasks', 'answers', 'final_conclusion', 'workflow_results'],
+  };
+
+  for (const [section, fields] of Object.entries(fieldsBySection)) {
+    let sectionPopulated = 0;
+    for (const f of fields) {
+      const val = state[f];
+      const populated = val !== undefined && val !== null && val !== '' &&
+        (typeof val !== 'object' || Object.keys(val).length > 0 || Array.isArray(val) ? val.length > 0 : false);
+      if (populated) {
+        sectionPopulated++;
+        counts.populated++;
+      }
+    }
+    counts.by_section[section] = { populated: sectionPopulated, total: fields.length };
+  }
+
+  return counts;
+};
+
+export default MOCK_SPECTACULAR_STATE;


### PR DESCRIPTION
## Summary
- Add `SpectacularDashboard` React component with 13 collapsible sections covering all 32 fields of `UnifiedAnalysisState`
- Mock data fixture (`spectacularMockData.js`) for development before Track 1 delivers real data
- Works without API connection (dedicated tab enabled even when API is disconnected)
- 11 unit tests covering section rendering, toggle behavior, and content display

## Sections implemented
| Section | Fields |
|---------|--------|
| Extraction | raw_text, identified_arguments, extracts |
| Formal Logic | belief_sets, query_log, FOL/propositional/modal results, NL→logic translations, synthesis |
| Fallacies | identified_fallacies (3-tier taxonomy), neural_fallacy_scores |
| JTMS | jtms_beliefs (status indicators), jtms_retraction_chain (cascades) |
| ATMS | atms_contexts (coherent/incoherent beliefs per hypothesis) |
| Dung | dung_frameworks (grounded/preferred/stable extensions) |
| ASPIC | aspic_results |
| Counter-Arguments | counter_arguments (strategy, score) |
| Debate | debate_transcripts (rounds, outcome) |
| Governance | governance_decisions (votes, consensus) |
| Quality | argument_quality_scores (9 virtues, LLM assessment) |
| Narrative | narrative synthesis paragraph |
| Tweety Advanced | ranking, belief_revision, dialogue, probabilistic, bipolar |
| Workflow | workflow_results, final_conclusion |

Closes #352

## Test plan
- [x] React build compiles without errors
- [x] 11 unit tests pass (`npx react-scripts test`)
- [ ] Visual verification in browser (start dev server, click Spectacular tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)