### PR TITLE
feat(web-ui): JTMS belief tree explorer (#354)

### DIFF
--- a/services/web_api/interface-web-argumentative/src/components/spectacular/JtmsBeliefTree.css
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/JtmsBeliefTree.css
@@ -1,0 +1,177 @@
+/* JtmsBeliefTree.css — Collapsible JTMS belief tree */
+
+.jtms-tree-container {
+  background: #0f172a;
+  border-radius: 8px;
+  border: 1px solid #475569;
+  padding: 16px;
+  color: #e2e8f0;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+.jtms-tree-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.jtms-tree-header h3 {
+  margin: 0;
+  color: #38bdf8;
+  font-size: 1.1rem;
+}
+
+.jtms-summary {
+  display: flex;
+  gap: 10px;
+  font-size: 0.78rem;
+}
+
+.jtms-summary-item {
+  padding: 2px 8px;
+  border-radius: 10px;
+}
+
+/* Summary badge colors */
+.jtms-summary-item.jtms-status-valid { background: rgba(74, 222, 128, 0.2); color: #4ade80; }
+.jtms-summary-item.jtms-status-invalid { background: rgba(248, 113, 113, 0.2); color: #f87171; }
+.jtms-summary-item.jtms-status-unknown { background: rgba(148, 163, 184, 0.2); color: #94a3b8; }
+.jtms-summary-item.jtms-status-retracted { background: rgba(251, 146, 60, 0.2); color: #fb923c; }
+
+/* Tree body */
+.jtms-tree-body {
+  background: #1e293b;
+  border-radius: 6px;
+  padding: 8px 0;
+}
+
+.jtms-empty {
+  padding: 20px;
+  text-align: center;
+  color: #64748b;
+  font-style: italic;
+}
+
+/* Belief node */
+.jtms-node {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  cursor: default;
+  transition: background 0.15s;
+  min-height: 32px;
+}
+
+.jtms-node:hover {
+  background: rgba(56, 189, 248, 0.06);
+}
+
+.jtms-node.jtms-hovered {
+  background: rgba(56, 189, 248, 0.1);
+}
+
+/* Collapse button */
+.jtms-collapse-btn {
+  background: none;
+  border: none;
+  color: #64748b;
+  cursor: pointer;
+  font-size: 0.7rem;
+  padding: 0 2px;
+  width: 16px;
+  flex-shrink: 0;
+}
+
+.jtms-collapse-btn:hover {
+  color: #38bdf8;
+}
+
+.jtms-leaf-spacer {
+  width: 16px;
+  flex-shrink: 0;
+}
+
+/* Status icons */
+.jtms-status-icon {
+  font-weight: 700;
+  font-size: 0.85rem;
+  flex-shrink: 0;
+  width: 18px;
+  text-align: center;
+}
+
+.jtms-status-icon.jtms-status-valid { color: #4ade80; }
+.jtms-status-icon.jtms-status-invalid { color: #f87171; }
+.jtms-status-icon.jtms-status-unknown { color: #94a3b8; }
+
+/* Belief label */
+.jtms-belief-label {
+  font-size: 0.85rem;
+  color: #e2e8f0;
+}
+
+.jtms-strikethrough {
+  text-decoration: line-through;
+  color: #fb923c;
+}
+
+/* Retracted node */
+.jtms-node.jtms-retracted {
+  background: rgba(251, 146, 60, 0.05);
+}
+
+/* Badges */
+.jtms-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.jtms-badge-root {
+  background: rgba(74, 222, 128, 0.15);
+  color: #4ade80;
+}
+
+.jtms-badge-retracted {
+  background: rgba(251, 146, 60, 0.15);
+  color: #fb923c;
+}
+
+.jtms-badge-source {
+  background: rgba(56, 189, 248, 0.12);
+  color: #38bdf8;
+}
+
+/* Tooltip */
+.jtms-tooltip {
+  padding: 8px 12px;
+  background: #0f172a;
+  border: 1px solid #38bdf8;
+  border-radius: 6px;
+  font-size: 0.78rem;
+  color: #e2e8f0;
+  margin-bottom: 4px;
+  pointer-events: none;
+}
+
+.jtms-tooltip-title {
+  font-weight: 600;
+  color: #38bdf8;
+  margin-bottom: 4px;
+}
+
+.jtms-tooltip-detail {
+  color: #94a3b8;
+  font-size: 0.74rem;
+  margin-top: 2px;
+}
+
+.jtms-tooltip-retraction {
+  color: #fb923c;
+}

--- a/services/web_api/interface-web-argumentative/src/components/spectacular/JtmsBeliefTree.js
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/JtmsBeliefTree.js
@@ -1,0 +1,200 @@
+import React, { useState } from 'react';
+import './JtmsBeliefTree.css';
+
+const STATUS_ICONS = {
+  valid: { icon: '✓', className: 'jtms-status-valid' },
+  invalid: { icon: '✗', className: 'jtms-status-invalid' },
+  unknown: { icon: '?', className: 'jtms-status-unknown' },
+};
+
+/**
+ * Mock fixture for standalone development.
+ */
+export const MOCK_JTMS_DATA = {
+  beliefs: {
+    root_1: { name: 'root_1', label: 'Argument principal valide', valid: true, justifications: [], source: 'ExtractAgent' },
+    root_2: { name: 'root_2', label: 'Données empiriques confirmées', valid: true, justifications: [], source: 'ExtractAgent' },
+    derived_1: { name: 'derived_1', label: 'Conclusion intermédiaire', valid: true, justifications: ['root_1', 'root_2'], source: 'LogicAgent' },
+    derived_2: { name: 'derived_2', label: 'Inférence logique A', valid: true, justifications: ['derived_1'], source: 'FOLAgent' },
+    derived_3: { name: 'derived_3', label: 'Inférence logique B', valid: true, justifications: ['derived_1'], source: 'FOLAgent' },
+    retracted_1: {
+      name: 'retracted_1', label: 'Argument par autorité', valid: null,
+      justifications: ['root_2'],
+      retracted: true, retraction_reason: 'fallacy: appeal_to_authority',
+      source: 'ExtractAgent',
+    },
+    retracted_2: {
+      name: 'retracted_2', label: 'Conclusion basée sur argument retraité',
+      valid: null, justifications: ['retracted_1'],
+      retracted: true, retraction_reason: 'cascade: retracted_1 retracted',
+      source: 'LogicAgent',
+    },
+    root_3: { name: 'root_3', label: 'Hypothèse non vérifiée', valid: null, justifications: [], source: 'InformalAgent' },
+  },
+};
+
+function getBeliefStatus(valid) {
+  if (valid === true) return 'valid';
+  if (valid === false) return 'invalid';
+  return 'unknown';
+}
+
+function BeliefNode({ belief, beliefs, childrenMap, depth = 0, hoveredId, setHoveredId }) {
+  const [collapsed, setCollapsed] = useState(false);
+  const status = getBeliefStatus(belief.valid);
+  const statusInfo = STATUS_ICONS[status];
+  const isRetracted = belief.retracted || belief.valid === null;
+  const isHovered = hoveredId === belief.name;
+
+  const childNames = (childrenMap && childrenMap[belief.name]) || [];
+  const children = childNames.map((n) => beliefs[n]).filter(Boolean);
+
+  const isRoot = !belief.justifications || belief.justifications.length === 0;
+
+  return (
+    <div className="jtms-node-wrapper">
+      <div
+        className={`jtms-node ${statusInfo.className} ${isRetracted ? 'jtms-retracted' : ''} ${isHovered ? 'jtms-hovered' : ''}`}
+        style={{ paddingLeft: depth * 24 + 12 }}
+        onMouseEnter={() => setHoveredId(belief.name)}
+        onMouseLeave={() => setHoveredId(null)}
+        data-testid={`belief-node-${belief.name}`}
+      >
+        {children.length > 0 && (
+          <button
+            className="jtms-collapse-btn"
+            onClick={() => setCollapsed(!collapsed)}
+            data-testid={`collapse-btn-${belief.name}`}
+          >
+            {collapsed ? '▶' : '▼'}
+          </button>
+        )}
+        {children.length === 0 && <span className="jtms-leaf-spacer" />}
+
+        <span className={`jtms-status-icon ${statusInfo.className}`}>
+          {statusInfo.icon}
+        </span>
+
+        <span className={`jtms-belief-label ${isRetracted ? 'jtms-strikethrough' : ''}`}>
+          {belief.label || belief.name}
+        </span>
+
+        {isRoot && <span className="jtms-badge jtms-badge-root">root</span>}
+        {isRetracted && belief.retraction_reason && (
+          <span className="jtms-badge jtms-badge-retracted">retracted</span>
+        )}
+        {belief.source && <span className="jtms-badge jtms-badge-source">{belief.source}</span>}
+      </div>
+
+      {isHovered && (
+        <div className="jtms-tooltip" style={{ marginLeft: depth * 24 + 40 }}>
+          <div className="jtms-tooltip-title">{belief.label || belief.name}</div>
+          <div className="jtms-tooltip-detail">Status: {status}</div>
+          {belief.justifications && belief.justifications.length > 0 && (
+            <div className="jtms-tooltip-detail">
+              Justifications: {belief.justifications.join(', ')}
+            </div>
+          )}
+          {isRetracted && belief.retraction_reason && (
+            <div className="jtms-tooltip-detail jtms-tooltip-retraction">
+              Reason: {belief.retraction_reason}
+            </div>
+          )}
+          {children.length > 0 && (
+            <div className="jtms-tooltip-detail">
+              Derives: {children.map((c) => c.name).join(', ')}
+            </div>
+          )}
+        </div>
+      )}
+
+      {!collapsed && children.length > 0 && (
+        <div className="jtms-children">
+          {children.map((child) => (
+            <BeliefNode
+              key={child.name}
+              belief={child}
+              beliefs={beliefs}
+              childrenMap={childrenMap}
+              depth={depth + 1}
+              hoveredId={hoveredId}
+              setHoveredId={setHoveredId}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Build a tree structure where each belief appears exactly once.
+ * A belief is a child of its first justification; if no justifications, it's a root.
+ */
+function buildTree(beliefs) {
+  const claimed = new Set();
+  const childrenMap = {};
+
+  // First pass: assign each belief to its first justification's children list
+  Object.values(beliefs).forEach((b) => {
+    if (b.justifications && b.justifications.length > 0) {
+      const parent = b.justifications[0];
+      if (!childrenMap[parent]) childrenMap[parent] = [];
+      childrenMap[parent].push(b.name);
+      claimed.add(b.name);
+    }
+  });
+
+  const roots = Object.values(beliefs)
+    .filter((b) => !claimed.has(b.name))
+    .map((b) => b.name);
+
+  return { roots, childrenMap };
+}
+
+/**
+ * JtmsBeliefTree — Collapsible tree explorer for JTMS beliefs with retraction cascades.
+ */
+export default function JtmsBeliefTree({ data = MOCK_JTMS_DATA }) {
+  const [hoveredId, setHoveredId] = useState(null);
+  const beliefs = data.beliefs || {};
+  const { roots, childrenMap } = buildTree(beliefs);
+
+  const counts = { valid: 0, invalid: 0, unknown: 0, retracted: 0 };
+  Object.values(beliefs).forEach((b) => {
+    counts[getBeliefStatus(b.valid)]++;
+    if (b.retracted) counts.retracted++;
+  });
+
+  return (
+    <div className="jtms-tree-container" data-testid="jtms-belief-tree">
+      <div className="jtms-tree-header">
+        <h3>JTMS Belief Explorer</h3>
+        <div className="jtms-summary">
+          <span className="jtms-summary-item jtms-status-valid">{counts.valid} valid</span>
+          <span className="jtms-summary-item jtms-status-invalid">{counts.invalid} invalid</span>
+          <span className="jtms-summary-item jtms-status-unknown">{counts.unknown} unknown</span>
+          {counts.retracted > 0 && (
+            <span className="jtms-summary-item jtms-status-retracted">{counts.retracted} retracted</span>
+          )}
+        </div>
+      </div>
+
+      <div className="jtms-tree-body">
+        {roots.length === 0 && (
+          <div className="jtms-empty">No beliefs to display.</div>
+        )}
+        {roots.map((name) => (
+          <BeliefNode
+            key={name}
+            belief={beliefs[name]}
+            beliefs={beliefs}
+            childrenMap={childrenMap}
+            hoveredId={hoveredId}
+            setHoveredId={setHoveredId}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/services/web_api/interface-web-argumentative/src/components/spectacular/JtmsBeliefTree.test.js
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/JtmsBeliefTree.test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import JtmsBeliefTree, { MOCK_JTMS_DATA } from './JtmsBeliefTree';
+
+describe('JtmsBeliefTree', () => {
+  test('renders header with title', () => {
+    render(<JtmsBeliefTree />);
+    expect(screen.getByText('JTMS Belief Explorer')).toBeInTheDocument();
+  });
+
+  test('renders belief summary counts', () => {
+    render(<JtmsBeliefTree />);
+    expect(screen.getByText(/5 valid/)).toBeInTheDocument();
+    expect(screen.getByText(/3 unknown/)).toBeInTheDocument();
+    expect(screen.getByText(/2 retracted/)).toBeInTheDocument();
+  });
+
+  test('renders root beliefs', () => {
+    render(<JtmsBeliefTree />);
+    expect(screen.getByTestId('belief-node-root_1')).toBeInTheDocument();
+    expect(screen.getByTestId('belief-node-root_2')).toBeInTheDocument();
+    expect(screen.getByTestId('belief-node-root_3')).toBeInTheDocument();
+  });
+
+  test('renders derived beliefs as children', () => {
+    render(<JtmsBeliefTree />);
+    expect(screen.getByTestId('belief-node-derived_1')).toBeInTheDocument();
+  });
+
+  test('retracted beliefs show strikethrough and badge', () => {
+    render(<JtmsBeliefTree />);
+    const retractedNode = screen.getByTestId('belief-node-retracted_1');
+    expect(retractedNode).toBeInTheDocument();
+    const badges = screen.getAllByText('retracted');
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('hovering a belief shows tooltip with justification', () => {
+    render(<JtmsBeliefTree />);
+    const derivedNode = screen.getByTestId('belief-node-derived_1');
+    fireEvent.mouseEnter(derivedNode);
+    expect(screen.getByText(/Justifications: root_1, root_2/)).toBeInTheDocument();
+    fireEvent.mouseLeave(derivedNode);
+  });
+
+  test('hovering retracted belief shows retraction reason', () => {
+    render(<JtmsBeliefTree />);
+    const retractedNode = screen.getByTestId('belief-node-retracted_1');
+    fireEvent.mouseEnter(retractedNode);
+    expect(screen.getByText(/appeal_to_authority/)).toBeInTheDocument();
+    fireEvent.mouseLeave(retractedNode);
+  });
+
+  test('collapse toggle hides children', () => {
+    render(<JtmsBeliefTree />);
+    const collapseBtn = screen.getByTestId('collapse-btn-derived_1');
+    fireEvent.click(collapseBtn);
+    expect(screen.queryByTestId('belief-node-derived_2')).not.toBeInTheDocument();
+    fireEvent.click(collapseBtn);
+    expect(screen.getByTestId('belief-node-derived_2')).toBeInTheDocument();
+  });
+
+  test('exports mock data with correct structure', () => {
+    expect(MOCK_JTMS_DATA.beliefs).toBeDefined();
+    expect(Object.keys(MOCK_JTMS_DATA.beliefs).length).toBe(8);
+    const retracted = Object.values(MOCK_JTMS_DATA.beliefs).filter((b) => b.retracted);
+    expect(retracted.length).toBe(2);
+  });
+
+  test('accepts custom data with empty beliefs', () => {
+    const emptyData = { beliefs: {} };
+    render(<JtmsBeliefTree data={emptyData} />);
+    expect(screen.getByText('No beliefs to display.')).toBeInTheDocument();
+  });
+
+  test('root beliefs show root badge', () => {
+    render(<JtmsBeliefTree />);
+    const rootBadges = screen.getAllByText('root');
+    expect(rootBadges.length).toBe(3); // root_1, root_2, root_3
+  });
+});


### PR DESCRIPTION
## Summary
- Collapsible tree visualization for JTMS belief hierarchies (root → derived)
- Retracted beliefs displayed with strikethrough, orange badge, and retraction reason
- Hover tooltips showing justification chain and cascade trigger
- Summary bar with valid/invalid/unknown/retracted counts
- Deduplicated tree (each belief appears once under its first parent justification)
- 11 unit tests (all passing), mock fixture with 8 beliefs including retraction cascades

## Test plan
- [x] `npx react-scripts test --watchAll=false --ci` — 11/11 pass
- [x] `npx react-scripts build` — compiles successfully
- [ ] Visual verification in browser (tree collapse, tooltips, retraction styling)

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)