### PR TITLE
feat(web-ui): ATMS context selector (#355)

### DIFF
--- a/services/web_api/interface-web-argumentative/src/components/spectacular/AtmsContextView.css
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/AtmsContextView.css
@@ -1,0 +1,180 @@
+/* AtmsContextView.css — ATMS context selector */
+
+.atms-container {
+  background: #0f172a;
+  border-radius: 8px;
+  border: 1px solid #475569;
+  padding: 16px;
+  color: #e2e8f0;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+.atms-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.atms-header h3 {
+  margin: 0;
+  color: #38bdf8;
+  font-size: 1.1rem;
+}
+
+.atms-context-count {
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+/* Dropdown */
+.atms-selector {
+  margin-bottom: 12px;
+}
+
+.atms-dropdown {
+  width: 100%;
+  padding: 8px 12px;
+  border-radius: 6px;
+  border: 1px solid #475569;
+  background: #1e293b;
+  color: #e2e8f0;
+  font-size: 0.85rem;
+  cursor: pointer;
+}
+
+.atms-dropdown:focus {
+  outline: none;
+  border-color: #38bdf8;
+}
+
+/* Context detail */
+.atms-context-detail {
+  background: #1e293b;
+  border-radius: 6px;
+  padding: 12px;
+}
+
+/* Consistency badge */
+.atms-consistency-badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  margin-bottom: 10px;
+}
+
+.atms-consistent {
+  background: rgba(74, 222, 128, 0.15);
+  color: #4ade80;
+  border: 1px solid rgba(74, 222, 128, 0.3);
+}
+
+.atms-inconsistent {
+  background: rgba(248, 113, 113, 0.15);
+  color: #f87171;
+  border: 1px solid rgba(248, 113, 113, 0.3);
+}
+
+/* Hypotheses */
+.atms-hypotheses {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.atms-section-label {
+  font-size: 0.78rem;
+  color: #94a3b8;
+}
+
+.atms-hypothesis-chip {
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 0.72rem;
+  background: rgba(56, 189, 248, 0.12);
+  color: #38bdf8;
+}
+
+/* Conflict */
+.atms-conflict {
+  padding: 8px 12px;
+  background: rgba(248, 113, 113, 0.08);
+  border: 1px solid rgba(248, 113, 113, 0.2);
+  border-radius: 6px;
+  font-size: 0.82rem;
+  color: #f87171;
+  margin-bottom: 10px;
+}
+
+.atms-conflict-icon {
+  margin-right: 6px;
+}
+
+/* Beliefs table */
+.atms-beliefs-table {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.atms-beliefs-header {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 8px;
+  font-size: 0.72rem;
+  color: #64748b;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.atms-belief-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 8px;
+  border-radius: 4px;
+}
+
+.atms-belief-row:hover {
+  background: rgba(56, 189, 248, 0.05);
+}
+
+.atms-belief-label {
+  font-size: 0.85rem;
+}
+
+/* Status badges */
+.atms-status-badge {
+  padding: 2px 8px;
+  border-radius: 8px;
+  font-size: 0.7rem;
+  font-weight: 600;
+}
+
+.atms-status-in {
+  background: rgba(74, 222, 128, 0.15);
+  color: #4ade80;
+}
+
+.atms-status-out {
+  background: rgba(248, 113, 113, 0.15);
+  color: #f87171;
+}
+
+.atms-status-undecided {
+  background: rgba(148, 163, 184, 0.15);
+  color: #94a3b8;
+}
+
+/* Empty state */
+.atms-empty {
+  padding: 24px;
+  text-align: center;
+  color: #64748b;
+  font-style: italic;
+}

--- a/services/web_api/interface-web-argumentative/src/components/spectacular/AtmsContextView.js
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/AtmsContextView.js
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+import './AtmsContextView.css';
+
+/**
+ * Mock fixture for standalone development.
+ */
+export const MOCK_ATMS_DATA = {
+  hypotheses: ['H1_efficient', 'H2_reliable', 'H3_cost', 'H4_biased'],
+  contexts: {
+    'H1,H2': {
+      id: 'ctx_1',
+      label: 'H1 + H2',
+      hypotheses: ['H1_efficient', 'H2_reliable'],
+      consistent: true,
+      beliefs: {
+        arg_efficient: { status: 'in', label: 'Le programme est efficace' },
+        arg_reliable: { status: 'in', label: 'Les données sont fiables' },
+        arg_cost: { status: 'out', label: 'Le coût est justifié' },
+        arg_biased: { status: 'undecided', label: 'Biais détectés' },
+      },
+    },
+    'H1,H3': {
+      id: 'ctx_2',
+      label: 'H1 + H3',
+      hypotheses: ['H1_efficient', 'H3_cost'],
+      consistent: true,
+      beliefs: {
+        arg_efficient: { status: 'in', label: 'Le programme est efficace' },
+        arg_reliable: { status: 'undecided', label: 'Les données sont fiables' },
+        arg_cost: { status: 'in', label: 'Le coût est justifié' },
+        arg_biased: { status: 'out', label: 'Biais détectés' },
+      },
+    },
+    'H2,H4': {
+      id: 'ctx_3',
+      label: 'H2 + H4',
+      hypotheses: ['H2_reliable', 'H4_biased'],
+      consistent: false,
+      conflict: 'H2_reliable contradicts H4_biased',
+      beliefs: {
+        arg_efficient: { status: 'undecided', label: 'Le programme est efficace' },
+        arg_reliable: { status: 'in', label: 'Les données sont fiables' },
+        arg_cost: { status: 'out', label: 'Le coût est justifié' },
+        arg_biased: { status: 'in', label: 'Biais détectés' },
+      },
+    },
+    'H3,H4': {
+      id: 'ctx_4',
+      label: 'H3 + H4',
+      hypotheses: ['H3_cost', 'H4_biased'],
+      consistent: true,
+      beliefs: {
+        arg_efficient: { status: 'out', label: 'Le programme est efficace' },
+        arg_reliable: { status: 'undecided', label: 'Les données sont fiables' },
+        arg_cost: { status: 'in', label: 'Le coût est justifié' },
+        arg_biased: { status: 'in', label: 'Biais détectés' },
+      },
+    },
+  },
+};
+
+const STATUS_LABELS = {
+  in: { label: 'IN', className: 'atms-status-in' },
+  out: { label: 'OUT', className: 'atms-status-out' },
+  undecided: { label: 'UNDECIDED', className: 'atms-status-undecided' },
+};
+
+/**
+ * AtmsContextView — Context selector for ATMS hypothesis analysis.
+ */
+export default function AtmsContextView({ data = MOCK_ATMS_DATA }) {
+  const [activeContext, setActiveContext] = useState(null);
+  const contextKeys = Object.keys(data.contexts || {});
+
+  const selectedCtx = activeContext ? data.contexts[activeContext] : null;
+
+  return (
+    <div className="atms-container" data-testid="atms-context-view">
+      <div className="atms-header">
+        <h3>ATMS Context Explorer</h3>
+        <div className="atms-context-count">
+          {contextKeys.length} contexts
+        </div>
+      </div>
+
+      <div className="atms-selector">
+        <select
+          className="atms-dropdown"
+          value={activeContext || ''}
+          onChange={(e) => setActiveContext(e.target.value || null)}
+          data-testid="atms-context-dropdown"
+        >
+          <option value="">Select a context...</option>
+          {contextKeys.map((key) => {
+            const ctx = data.contexts[key];
+            return (
+              <option key={key} value={key}>
+                {ctx.label || key} {!ctx.consistent && '⚠'}
+              </option>
+            );
+          })}
+        </select>
+      </div>
+
+      {selectedCtx && (
+        <div className="atms-context-detail" data-testid="atms-context-detail">
+          <div className={`atms-consistency-badge ${selectedCtx.consistent ? 'atms-consistent' : 'atms-inconsistent'}`}>
+            {selectedCtx.consistent ? 'Consistent' : 'Inconsistent'}
+          </div>
+
+          <div className="atms-hypotheses">
+            <span className="atms-section-label">Hypotheses:</span>
+            {selectedCtx.hypotheses.map((h) => (
+              <span key={h} className="atms-hypothesis-chip">{h}</span>
+            ))}
+          </div>
+
+          {selectedCtx.conflict && (
+            <div className="atms-conflict" data-testid="atms-conflict">
+              <span className="atms-conflict-icon">⚠</span>
+              Conflict: {selectedCtx.conflict}
+            </div>
+          )}
+
+          <div className="atms-beliefs-table">
+            <div className="atms-beliefs-header">
+              <span>Belief</span>
+              <span>Status</span>
+            </div>
+            {Object.entries(selectedCtx.beliefs || {}).map(([id, belief]) => {
+              const statusInfo = STATUS_LABELS[belief.status] || STATUS_LABELS.undecided;
+              return (
+                <div key={id} className="atms-belief-row" data-testid={`atms-belief-${id}`}>
+                  <span className="atms-belief-label">{belief.label || id}</span>
+                  <span className={`atms-status-badge ${statusInfo.className}`}>
+                    {statusInfo.label}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {!selectedCtx && (
+        <div className="atms-empty" data-testid="atms-empty">
+          Select a context to view belief status under different hypotheses.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/services/web_api/interface-web-argumentative/src/components/spectacular/AtmsContextView.test.js
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/AtmsContextView.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AtmsContextView, { MOCK_ATMS_DATA } from './AtmsContextView';
+
+describe('AtmsContextView', () => {
+  test('renders header with title', () => {
+    render(<AtmsContextView />);
+    expect(screen.getByText('ATMS Context Explorer')).toBeInTheDocument();
+  });
+
+  test('renders context count', () => {
+    render(<AtmsContextView />);
+    expect(screen.getByText('4 contexts')).toBeInTheDocument();
+  });
+
+  test('renders dropdown with context options', () => {
+    render(<AtmsContextView />);
+    const dropdown = screen.getByTestId('atms-context-dropdown');
+    expect(dropdown).toBeInTheDocument();
+    expect(screen.getByText('Select a context...')).toBeInTheDocument();
+  });
+
+  test('shows empty state when no context selected', () => {
+    render(<AtmsContextView />);
+    expect(screen.getByTestId('atms-empty')).toBeInTheDocument();
+  });
+
+  test('selecting a context shows detail panel', () => {
+    render(<AtmsContextView />);
+    const dropdown = screen.getByTestId('atms-context-dropdown');
+    fireEvent.change(dropdown, { target: { value: 'H1,H2' } });
+    expect(screen.getByTestId('atms-context-detail')).toBeInTheDocument();
+    expect(screen.getByText('Consistent')).toBeInTheDocument();
+  });
+
+  test('selecting inconsistent context shows conflict', () => {
+    render(<AtmsContextView />);
+    const dropdown = screen.getByTestId('atms-context-dropdown');
+    fireEvent.change(dropdown, { target: { value: 'H2,H4' } });
+    expect(screen.getByText('Inconsistent')).toBeInTheDocument();
+    expect(screen.getByTestId('atms-conflict')).toBeInTheDocument();
+  });
+
+  test('context shows beliefs with status badges', () => {
+    render(<AtmsContextView />);
+    const dropdown = screen.getByTestId('atms-context-dropdown');
+    fireEvent.change(dropdown, { target: { value: 'H1,H2' } });
+    expect(screen.getByText('Le programme est efficace')).toBeInTheDocument();
+    expect(screen.getAllByText('IN').length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByText('OUT')).toBeInTheDocument();
+  });
+
+  test('switching contexts updates beliefs', () => {
+    render(<AtmsContextView />);
+    const dropdown = screen.getByTestId('atms-context-dropdown');
+
+    fireEvent.change(dropdown, { target: { value: 'H1,H2' } });
+    expect(screen.getByText('Consistent')).toBeInTheDocument();
+
+    fireEvent.change(dropdown, { target: { value: 'H2,H4' } });
+    expect(screen.getByText('Inconsistent')).toBeInTheDocument();
+  });
+
+  test('exports mock data with correct structure', () => {
+    expect(MOCK_ATMS_DATA.hypotheses).toBeDefined();
+    expect(MOCK_ATMS_DATA.contexts).toBeDefined();
+    expect(Object.keys(MOCK_ATMS_DATA.contexts).length).toBe(4);
+    expect(MOCK_ATMS_DATA.contexts['H2,H4'].consistent).toBe(false);
+  });
+
+  test('accepts custom data with no contexts', () => {
+    const emptyData = { hypotheses: [], contexts: {} };
+    render(<AtmsContextView data={emptyData} />);
+    expect(screen.getByText('0 contexts')).toBeInTheDocument();
+  });
+
+  test('hypothesis chips are displayed', () => {
+    render(<AtmsContextView />);
+    const dropdown = screen.getByTestId('atms-context-dropdown');
+    fireEvent.change(dropdown, { target: { value: 'H1,H3' } });
+    expect(screen.getByText('H1_efficient')).toBeInTheDocument();
+    expect(screen.getByText('H3_cost')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Dropdown to select ATMS hypothesis combinations (contexts)
- Consistent/inconsistent badge with conflict indicator
- Belief status table (IN/OUT/UNDECIDED) per selected context
- Hypothesis chips showing active assumptions
- 11 unit tests (all passing), mock fixture with 4 contexts

## Test plan
- [x] `npx react-scripts test --watchAll=false --ci` — 11/11 pass
- [x] `npx react-scripts build` — compiles successfully
- [ ] Visual verification (dropdown, context switching, status badges)

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)