### PR TITLE
feat(web-ui): fallacy taxonomy drill-down (#356)

### DIFF
--- a/services/web_api/interface-web-argumentative/src/components/spectacular/FallacyTaxonomy.css
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/FallacyTaxonomy.css
@@ -1,0 +1,153 @@
+/* FallacyTaxonomy.css — Interactive fallacy taxonomy drill-down */
+
+.taxonomy-container {
+  background: #0f172a;
+  border-radius: 8px;
+  border: 1px solid #475569;
+  padding: 16px;
+  color: #e2e8f0;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+.taxonomy-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.taxonomy-header h3 {
+  margin: 0;
+  color: #38bdf8;
+  font-size: 1.1rem;
+}
+
+.taxonomy-stats {
+  display: flex;
+  gap: 4px;
+  font-size: 0.82rem;
+}
+
+.taxonomy-stat {
+  color: #94a3b8;
+}
+
+.taxonomy-stat-divider {
+  color: #475569;
+}
+
+/* Filters */
+.taxonomy-filters {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.taxonomy-filter-btn {
+  padding: 4px 12px;
+  border-radius: 16px;
+  border: 1px solid #475569;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.taxonomy-filter-btn:hover {
+  background: rgba(56, 189, 248, 0.1);
+  border-color: #38bdf8;
+  color: #38bdf8;
+}
+
+.taxonomy-filter-btn.active {
+  background: rgba(56, 189, 248, 0.2);
+  border-color: #38bdf8;
+  color: #38bdf8;
+}
+
+/* Tree */
+.taxonomy-tree {
+  background: #1e293b;
+  border-radius: 6px;
+  padding: 4px 0;
+}
+
+.taxonomy-empty {
+  padding: 20px;
+  text-align: center;
+  color: #64748b;
+  font-style: italic;
+}
+
+/* Nodes */
+.taxonomy-node {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  font-size: 0.85rem;
+  transition: background 0.15s;
+}
+
+.taxonomy-node:hover {
+  background: rgba(56, 189, 248, 0.06);
+}
+
+.taxonomy-branch {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.taxonomy-expand-icon {
+  font-size: 0.65rem;
+  color: #64748b;
+  width: 14px;
+  flex-shrink: 0;
+}
+
+.taxonomy-leaf-spacer {
+  width: 14px;
+  flex-shrink: 0;
+}
+
+.taxonomy-node-name {
+  flex: 1;
+}
+
+.taxonomy-leaf .taxonomy-node-name {
+  font-weight: 400;
+  color: #cbd5e1;
+}
+
+/* Detected */
+.taxonomy-detected .taxonomy-node-name {
+  color: #fbbf24;
+}
+
+.taxonomy-detected-badge {
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  border: 1px solid;
+  color: #fbbf24;
+  background: rgba(251, 191, 36, 0.1);
+}
+
+.taxonomy-count-badge {
+  padding: 1px 6px;
+  border-radius: 8px;
+  font-size: 0.65rem;
+  background: rgba(56, 189, 248, 0.12);
+  color: #38bdf8;
+  font-weight: 500;
+}
+
+/* Severity */
+.taxonomy-severity {
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}

--- a/services/web_api/interface-web-argumentative/src/components/spectacular/FallacyTaxonomy.js
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/FallacyTaxonomy.js
@@ -1,0 +1,193 @@
+import React, { useState } from 'react';
+import './FallacyTaxonomy.css';
+
+/**
+ * Mock taxonomy tree — 8 families, each with subcategories and leaf fallacies.
+ * Represents the hierarchical drill-down structure (depth 2-3).
+ */
+export const MOCK_TAXONOMY = {
+  name: 'Fallacy Taxonomy',
+  children: [
+    {
+      name: 'Ad Hominem',
+      children: [
+        { name: 'Abusive', detected: true, path: 'Ad Hominem > Abusive', severity: 'high' },
+        { name: 'Circumstantial', detected: false, path: 'Ad Hominem > Circumstantial' },
+        { name: 'Tu Quoque', detected: true, path: 'Ad Hominem > Tu Quoque', severity: 'medium' },
+      ],
+    },
+    {
+      name: 'Appeal to Authority',
+      children: [
+        { name: 'False Authority', detected: true, path: 'Appeal to Authority > False Authority', severity: 'high' },
+        { name: 'Anonymous Authority', detected: false, path: 'Appeal to Authority > Anonymous Authority' },
+      ],
+    },
+    {
+      name: 'Straw Man',
+      children: [
+        { name: 'Misrepresentation', detected: false, path: 'Straw Man > Misrepresentation' },
+        { name: 'Exaggeration', detected: true, path: 'Straw Man > Exaggeration', severity: 'medium' },
+      ],
+    },
+    {
+      name: 'False Dilemma',
+      children: [
+        { name: 'Black-or-White', detected: false, path: 'False Dilemma > Black-or-White' },
+        { name: 'Excluded Middle', detected: false, path: 'False Dilemma > Excluded Middle' },
+      ],
+    },
+    {
+      name: 'Slippery Slope',
+      children: [
+        { name: 'Causal Chain', detected: true, path: 'Slippery Slope > Causal Chain', severity: 'low' },
+        { name: 'Fear Mongering', detected: false, path: 'Slippery Slope > Fear Mongering' },
+      ],
+    },
+    {
+      name: 'Circular Reasoning',
+      children: [
+        { name: 'Begging the Question', detected: false, path: 'Circular Reasoning > Begging the Question' },
+        { name: 'Tautology', detected: false, path: 'Circular Reasoning > Tautology' },
+      ],
+    },
+    {
+      name: 'Hasty Generalization',
+      children: [
+        { name: 'Small Sample', detected: true, path: 'Hasty Generalization > Small Sample', severity: 'medium' },
+        { name: 'Unrepresentative Sample', detected: false, path: 'Hasty Generalization > Unrepresentative Sample' },
+      ],
+    },
+    {
+      name: 'Red Herring',
+      children: [
+        { name: 'Distraction', detected: false, path: 'Red Herring > Distraction' },
+        { name: 'Topic Shift', detected: false, path: 'Red Herring > Topic Shift' },
+      ],
+    },
+  ],
+};
+
+const SEVERITY_COLORS = {
+  high: '#f87171',
+  medium: '#fbbf24',
+  low: '#4ade80',
+};
+
+function countDetected(node) {
+  if (!node.children) return node.detected ? 1 : 0;
+  return node.children.reduce((sum, child) => sum + countDetected(child), 0);
+}
+
+function countLeaves(node) {
+  if (!node.children) return 1;
+  return node.children.reduce((sum, child) => sum + countLeaves(child), 0);
+}
+
+function TaxonomyNode({ node, depth = 0 }) {
+  const [expanded, setExpanded] = useState(depth < 2);
+  const hasChildren = node.children && node.children.length > 0;
+  const isLeaf = !hasChildren;
+  const detected = node.detected;
+  const detectedCount = hasChildren ? countDetected(node) : 0;
+  const totalLeaves = hasChildren ? countLeaves(node) : 0;
+
+  return (
+    <div className="taxonomy-node-wrapper">
+      <div
+        className={`taxonomy-node ${isLeaf ? 'taxonomy-leaf' : 'taxonomy-branch'} ${detected ? 'taxonomy-detected' : ''}`}
+        style={{ paddingLeft: depth * 20 + 8 }}
+        data-testid={`taxonomy-${node.name.replace(/\s+/g, '-').toLowerCase()}`}
+        onClick={() => hasChildren && setExpanded(!expanded)}
+      >
+        {hasChildren && (
+          <span className="taxonomy-expand-icon">{expanded ? '▼' : '▶'}</span>
+        )}
+        {isLeaf && <span className="taxonomy-leaf-spacer" />}
+
+        <span className="taxonomy-node-name">
+          {node.name}
+        </span>
+
+        {hasChildren && detectedCount > 0 && (
+          <span className="taxonomy-count-badge">{detectedCount}/{totalLeaves} detected</span>
+        )}
+
+        {isLeaf && detected && (
+          <span className="taxonomy-detected-badge" style={{ borderColor: SEVERITY_COLORS[node.severity] || '#38bdf8' }}>
+            detected
+          </span>
+        )}
+
+        {isLeaf && node.severity && (
+          <span className="taxonomy-severity" style={{ color: SEVERITY_COLORS[node.severity] }}>
+            {node.severity}
+          </span>
+        )}
+      </div>
+
+      {hasChildren && expanded && (
+        <div className="taxonomy-children">
+          {node.children.map((child) => (
+            <TaxonomyNode key={child.name} node={child} depth={depth + 1} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * FallacyTaxonomy — Interactive drill-down explorer for fallacy classification taxonomy.
+ */
+export default function FallacyTaxonomy({ taxonomy = MOCK_TAXONOMY, detectedFallacies = [] }) {
+  const [filter, setFilter] = useState('all'); // 'all' | 'detected'
+
+  const detectedSet = new Set(detectedFallacies);
+
+  const filteredChildren = filter === 'detected'
+    ? (taxonomy.children || []).filter((family) => countDetected(family) > 0)
+    : taxonomy.children || [];
+
+  const totalDetected = countDetected(taxonomy);
+  const totalLeaves = countLeaves(taxonomy);
+
+  return (
+    <div className="taxonomy-container" data-testid="fallacy-taxonomy">
+      <div className="taxonomy-header">
+        <h3>Fallacy Taxonomy Explorer</h3>
+        <div className="taxonomy-stats">
+          <span className="taxonomy-stat">{totalDetected} detected</span>
+          <span className="taxonomy-stat-divider">/</span>
+          <span className="taxonomy-stat">{totalLeaves} types</span>
+        </div>
+      </div>
+
+      <div className="taxonomy-filters">
+        <button
+          className={`taxonomy-filter-btn ${filter === 'all' ? 'active' : ''}`}
+          onClick={() => setFilter('all')}
+          data-testid="filter-all"
+        >
+          All
+        </button>
+        <button
+          className={`taxonomy-filter-btn ${filter === 'detected' ? 'active' : ''}`}
+          onClick={() => setFilter('detected')}
+          data-testid="filter-detected"
+        >
+          Detected only ({totalDetected})
+        </button>
+      </div>
+
+      <div className="taxonomy-tree">
+        {filteredChildren.map((family) => (
+          <TaxonomyNode key={family.name} node={family} depth={0} />
+        ))}
+        {filteredChildren.length === 0 && (
+          <div className="taxonomy-empty">No fallacies detected.</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/services/web_api/interface-web-argumentative/src/components/spectacular/FallacyTaxonomy.test.js
+++ b/services/web_api/interface-web-argumentative/src/components/spectacular/FallacyTaxonomy.test.js
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import FallacyTaxonomy, { MOCK_TAXONOMY } from './FallacyTaxonomy';
+
+describe('FallacyTaxonomy', () => {
+  test('renders header with title', () => {
+    render(<FallacyTaxonomy />);
+    expect(screen.getByText('Fallacy Taxonomy Explorer')).toBeInTheDocument();
+  });
+
+  test('renders taxonomy stats', () => {
+    render(<FallacyTaxonomy />);
+    expect(screen.getByText(/6 detected/)).toBeInTheDocument();
+    expect(screen.getByText(/17 types/)).toBeInTheDocument();
+  });
+
+  test('renders all 8 fallacy families', () => {
+    render(<FallacyTaxonomy />);
+    expect(screen.getByTestId('taxonomy-ad-hominem')).toBeInTheDocument();
+    expect(screen.getByTestId('taxonomy-appeal-to-authority')).toBeInTheDocument();
+    expect(screen.getByTestId('taxonomy-straw-man')).toBeInTheDocument();
+    expect(screen.getByTestId('taxonomy-false-dilemma')).toBeInTheDocument();
+    expect(screen.getByTestId('taxonomy-slippery-slope')).toBeInTheDocument();
+    expect(screen.getByTestId('taxonomy-circular-reasoning')).toBeInTheDocument();
+    expect(screen.getByTestId('taxonomy-hasty-generalization')).toBeInTheDocument();
+    expect(screen.getByTestId('taxonomy-red-herring')).toBeInTheDocument();
+  });
+
+  test('leaf fallacies are visible by default (depth 2 expansion)', () => {
+    render(<FallacyTaxonomy />);
+    expect(screen.getByTestId('taxonomy-abusive')).toBeInTheDocument();
+    expect(screen.getByTestId('taxonomy-tu-quoque')).toBeInTheDocument();
+  });
+
+  test('filter buttons toggle between all and detected', () => {
+    render(<FallacyTaxonomy />);
+    const allBtn = screen.getByTestId('filter-all');
+    const detectedBtn = screen.getByTestId('filter-detected');
+    expect(allBtn.classList.contains('active')).toBe(true);
+    fireEvent.click(detectedBtn);
+    expect(detectedBtn.classList.contains('active')).toBe(true);
+  });
+
+  test('detected filter hides families with no detections', () => {
+    render(<FallacyTaxonomy />);
+    fireEvent.click(screen.getByTestId('filter-detected'));
+    expect(screen.queryByTestId('taxonomy-false-dilemma')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('taxonomy-red-herring')).not.toBeInTheDocument();
+    expect(screen.getByTestId('taxonomy-ad-hominem')).toBeInTheDocument();
+  });
+
+  test('families with detections show count badge', () => {
+    render(<FallacyTaxonomy />);
+    const adHominem = screen.getByTestId('taxonomy-ad-hominem');
+    expect(adHominem.textContent).toContain('2/3 detected');
+  });
+
+  test('detected leaf shows detected badge and severity', () => {
+    render(<FallacyTaxonomy />);
+    const abusive = screen.getByTestId('taxonomy-abusive');
+    expect(abusive.textContent).toContain('detected');
+    expect(abusive.textContent).toContain('high');
+  });
+
+  test('clicking a branch collapses it', () => {
+    render(<FallacyTaxonomy />);
+    const adHominem = screen.getByTestId('taxonomy-ad-hominem');
+    fireEvent.click(adHominem);
+    expect(screen.queryByTestId('taxonomy-abusive')).not.toBeInTheDocument();
+    fireEvent.click(adHominem);
+    expect(screen.getByTestId('taxonomy-abusive')).toBeInTheDocument();
+  });
+
+  test('exports mock taxonomy with correct structure', () => {
+    expect(MOCK_TAXONOMY.name).toBe('Fallacy Taxonomy');
+    expect(MOCK_TAXONOMY.children.length).toBe(8);
+    const detected = MOCK_TAXONOMY.children.reduce(
+      (sum, family) => sum + family.children.filter((c) => c.detected).length, 0
+    );
+    expect(detected).toBe(6);
+  });
+
+  test('accepts custom empty taxonomy', () => {
+    const empty = { name: 'Empty', children: [] };
+    render(<FallacyTaxonomy taxonomy={empty} />);
+    expect(screen.getByText('0 detected')).toBeInTheDocument();
+  });
+
+  test('clicking a leaf does not crash', () => {
+    render(<FallacyTaxonomy />);
+    const abusive = screen.getByTestId('taxonomy-abusive');
+    fireEvent.click(abusive);
+    expect(abusive).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Interactive drill-down explorer for 8 fallacy families (depth 2-3)
- All/detected filter to show only families with hits
- Severity indicators (high/medium/low) for detected fallacies
- Count badges per family showing detected/total ratio
- Collapse/expand branches, click-to-toggle
- 12 unit tests (all passing), mock taxonomy with 17 leaf types

## Test plan
- [x] `npx react-scripts test --watchAll=false --ci` — 12/12 pass
- [x] `npx react-scripts build` — compiles successfully
- [ ] Visual verification (tree drill-down, filter toggle, severity colors)

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)