### PR TITLE
feat(orchestration): spectacular workflow profile (#347)

### DIFF
--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -28,6 +28,7 @@ __all__ = [
     "build_jtms_dung_loop_workflow",
     "build_neural_symbolic_fallacy_workflow",
     "build_hierarchical_fallacy_workflow",
+    "build_spectacular_workflow",
     "WORKFLOW_CATALOG",
     "get_workflow_catalog",
     "reset_workflow_catalog",
@@ -522,6 +523,126 @@ def build_hierarchical_fallacy_workflow() -> WorkflowDefinition:
     )
 
 
+def build_spectacular_workflow() -> WorkflowDefinition:
+    """Full-chain spectacular analysis composing every available capability.
+
+    Designed to maximise UnifiedAnalysisState field coverage (target ≥28/32).
+    Phases are arranged in a DAG so formal logic, fallacy detection, and
+    quality evaluation run in parallel after extraction; downstream phases
+    (Dung, ASPIC, JTMS, ATMS, debate, governance, synthesis) aggregate
+    results from earlier stages.
+
+    DAG levels (approximate):
+        L0  extract
+        L1  quality | nl_to_logic | neural_detect | hierarchical_fallacy
+        L2  pl | fol | modal                     (from nl_to_logic)
+        L3  dung_extensions                       (from fallacy + pl)
+        L4  aspic_analysis                        (from dung)
+        L5  counter                               (from quality)
+        L6  jtms | debate                         (from counter)
+        L7  atms                                  (from jtms)
+        L8  governance | formal_synthesis         (aggregation)
+    """
+    return (
+        WorkflowBuilder("spectacular_analysis")
+        # L0 — extraction
+        .add_phase("extract", capability="fact_extraction")
+        # L1 — parallel after extraction
+        .add_phase("quality", capability="argument_quality", depends_on=["extract"])
+        .add_phase(
+            "nl_to_logic",
+            capability="nl_to_logic_translation",
+            depends_on=["extract"],
+            optional=True,
+        )
+        .add_phase(
+            "neural_detect",
+            capability="neural_fallacy_detection",
+            depends_on=["extract"],
+            optional=True,
+        )
+        .add_phase(
+            "hierarchical_fallacy",
+            capability="hierarchical_fallacy_detection",
+            depends_on=["extract"],
+            optional=True,
+        )
+        # L2 — formal logic (parallel, from nl_to_logic)
+        .add_phase(
+            "pl",
+            capability="propositional_logic",
+            depends_on=["nl_to_logic"],
+            optional=True,
+        )
+        .add_phase(
+            "fol",
+            capability="fol_reasoning",
+            depends_on=["nl_to_logic"],
+            optional=True,
+        )
+        .add_phase(
+            "modal",
+            capability="modal_logic",
+            depends_on=["nl_to_logic"],
+            optional=True,
+        )
+        # L3 — Dung extensions (from fallacy + PL results)
+        .add_phase(
+            "dung_extensions",
+            capability="dung_extensions",
+            depends_on=["hierarchical_fallacy", "pl"],
+            optional=True,
+        )
+        # L4 — ASPIC+ structured argumentation
+        .add_phase(
+            "aspic_analysis",
+            capability="aspic_plus_reasoning",
+            depends_on=["dung_extensions"],
+            optional=True,
+        )
+        # L5 — counter-argument generation
+        .add_phase(
+            "counter",
+            capability="counter_argument_generation",
+            depends_on=["quality"],
+        )
+        # L6 — JTMS belief tracking + adversarial debate (parallel)
+        .add_phase(
+            "jtms",
+            capability="belief_maintenance",
+            depends_on=["counter"],
+            optional=True,
+        )
+        .add_phase(
+            "debate",
+            capability="adversarial_debate",
+            depends_on=["counter"],
+            optional=True,
+        )
+        # L7 — ATMS multi-context (from JTMS beliefs)
+        .add_phase(
+            "atms",
+            capability="assumption_based_reasoning",
+            depends_on=["jtms"],
+            optional=True,
+        )
+        # L8 — governance + formal synthesis (terminal aggregation)
+        .add_phase(
+            "governance",
+            capability="governance_simulation",
+            depends_on=["quality"],
+            optional=True,
+        )
+        .add_phase(
+            "formal_synthesis",
+            capability="formal_synthesis",
+            depends_on=["fol", "modal", "aspic_analysis"],
+            optional=True,
+        )
+        .build()
+    )
+
+
 WORKFLOW_CATALOG: Dict[str, WorkflowDefinition] = {}
 
 
@@ -540,6 +661,7 @@ def get_workflow_catalog() -> Dict[str, WorkflowDefinition]:
             "neural_symbolic": build_neural_symbolic_fallacy_workflow(),
             "hierarchical_fallacy": build_hierarchical_fallacy_workflow(),
             "nl_to_logic": build_nl_to_logic_workflow(),
+            "spectacular": build_spectacular_workflow(),
         }
         # Collaborative multi-agent debate (#175)
         try:

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
@@ -1,0 +1,128 @@
+"""Unit tests for the spectacular workflow DAG structure.
+
+Validates that build_spectacular_workflow() produces a well-formed DAG
+with all expected phases, capabilities, and dependency chains (#347).
+"""
+
+import pytest
+
+from argumentation_analysis.orchestration.workflows import (
+    build_spectacular_workflow,
+    reset_workflow_catalog,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_catalog():
+    reset_workflow_catalog()
+    yield
+    reset_workflow_catalog()
+
+
+class TestSpectacularWorkflowDAG:
+    """Validate the spectacular workflow structure."""
+
+    def test_workflow_builds_without_error(self):
+        wf = build_spectacular_workflow()
+        assert wf is not None
+        assert wf.name == "spectacular_analysis"
+
+    def test_phase_count(self):
+        wf = build_spectacular_workflow()
+        assert len(wf.phases) == 16
+
+    def test_all_expected_phases_present(self):
+        wf = build_spectacular_workflow()
+        phase_names = {p.name for p in wf.phases}
+        expected = {
+            "extract",
+            "quality",
+            "nl_to_logic",
+            "neural_detect",
+            "hierarchical_fallacy",
+            "pl",
+            "fol",
+            "modal",
+            "dung_extensions",
+            "aspic_analysis",
+            "counter",
+            "jtms",
+            "debate",
+            "atms",
+            "governance",
+            "formal_synthesis",
+        }
+        assert expected == phase_names
+
+    def test_all_capabilities_unique(self):
+        wf = build_spectacular_workflow()
+        caps = [p.capability for p in wf.phases]
+        assert len(caps) == len(set(caps)), f"Duplicate capabilities: {caps}"
+
+    def test_dag_validates(self):
+        wf = build_spectacular_workflow()
+        errors = wf.validate()
+        assert errors == [], f"DAG validation errors: {errors}"
+
+    def test_execution_order_resolvable(self):
+        wf = build_spectacular_workflow()
+        levels = wf.get_execution_order()
+        assert len(levels) >= 2
+        all_phases = {name for level in levels for name in level}
+        assert len(all_phases) == len(wf.phases)
+
+    def test_extract_is_first_phase(self):
+        wf = build_spectacular_workflow()
+        levels = wf.get_execution_order()
+        assert "extract" in levels[0]
+        assert len(levels[0]) == 1  # extract is sole entry point
+
+    def test_formal_logic_depends_on_nl_to_logic(self):
+        wf = build_spectacular_workflow()
+        for name in ("pl", "fol", "modal"):
+            phase = wf.get_phase(name)
+            assert "nl_to_logic" in phase.depends_on
+
+    def test_dung_depends_on_fallacy_and_pl(self):
+        wf = build_spectacular_workflow()
+        phase = wf.get_phase("dung_extensions")
+        assert "hierarchical_fallacy" in phase.depends_on
+        assert "pl" in phase.depends_on
+
+    def test_atms_depends_on_jtms(self):
+        wf = build_spectacular_workflow()
+        phase = wf.get_phase("atms")
+        assert "jtms" in phase.depends_on
+
+    def test_formal_synthesis_aggregates(self):
+        wf = build_spectacular_workflow()
+        phase = wf.get_phase("formal_synthesis")
+        assert "fol" in phase.depends_on
+        assert "modal" in phase.depends_on
+        assert "aspic_analysis" in phase.depends_on
+
+    def test_catalog_includes_spectacular(self):
+        from argumentation_analysis.orchestration.workflows import get_workflow_catalog
+
+        catalog = get_workflow_catalog()
+        assert "spectacular" in catalog
+        assert catalog["spectacular"].name == "spectacular_analysis"
+
+    def test_spectacular_has_more_phases_than_standard(self):
+        from argumentation_analysis.orchestration.workflows import (
+            build_standard_workflow,
+        )
+
+        standard = build_standard_workflow()
+        spectacular = build_spectacular_workflow()
+        assert len(spectacular.phases) > len(standard.phases)
+
+    def test_spectacular_includes_modal_logic(self):
+        wf = build_spectacular_workflow()
+        caps = wf.get_required_capabilities()
+        assert "modal_logic" in caps
+
+    def test_spectacular_includes_atms(self):
+        wf = build_spectacular_workflow()
+        caps = wf.get_required_capabilities()
+        assert "assumption_based_reasoning" in caps


### PR DESCRIPTION
## Summary
- Add `build_spectacular_workflow()` — a 16-phase full-chain DAG composing the entire analysis pipeline: extraction → NL-to-logic → PL/FOL/Modal → 3-tier fallacy → Dung → ASPIC → counter-arg → JTMS → ATMS → debate → governance → formal_synthesis
- Register `spectacular` in workflow catalog (exposed via `--workflow spectacular`)
- 15 unit tests validating DAG structure, dependencies, and catalog registration

## Test plan
- [x] `test_spectacular_workflow_dag.py` — 15/15 passed
- [x] DAG validates (no circular deps)
- [x] Catalog includes spectacular
- [x] Phase count > standard (16 > 13)

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)