### PR TITLE
feat(logic): FOL signature pre-declaration (#348)

### DIFF
--- a/argumentation_analysis/agents/core/logic/fol_logic_agent.py
+++ b/argumentation_analysis/agents/core/logic/fol_logic_agent.py
@@ -514,6 +514,69 @@ RÉPONDS EN FORMAT JSON :
         # Combine declarations + empty line + formulas (Tweety BNF: SORTSDEC DECLAR FORMULAS)
         return declarations + [""] + formulas
 
+    @staticmethod
+    def extract_fol_metadata(formulas: List[str]) -> Dict[str, Any]:
+        """Extract sorts, predicates, and constants from FOL formulas.
+
+        Parses LLM-generated formulas to build a Tweety-compatible signature
+        (sort declarations + constant assignments). This pre-declaration is
+        required by Tweety's FolParser — without it, unknown constants cause
+        parse failures (#348).
+
+        Returns:
+            Dict with keys: sorts (Dict[str, List[str]]), predicates (Dict[str, int]),
+            constants (set), signature_lines (List[str]).
+        """
+        import re
+
+        predicates: Dict[str, int] = {}  # name -> arity
+        constants: set = set()
+        variables: set = set()
+
+        for formula in formulas:
+            # Extract predicate applications: Name(arg1, arg2, ...)
+            for match in re.finditer(r"([A-Z][A-Za-z_]*)\(([^)]+)\)", formula):
+                pred_name = match.group(1)
+                args_str = match.group(2)
+                args = [a.strip() for a in args_str.split(",")]
+                arity = len(args)
+                if pred_name not in predicates or predicates[pred_name] < arity:
+                    predicates[pred_name] = arity
+                for arg in args:
+                    if arg[0].isupper():
+                        variables.add(arg)
+                    else:
+                        constants.add(arg)
+
+        # Build sort declarations from constants
+        # Default sort "thing" collects all lowercase constants
+        sorts: Dict[str, List[str]] = {"thing": sorted(constants)}
+        signature_lines = [f"thing = {{{', '.join(sorted(constants))}}}"]
+        for pred_name, arity in sorted(predicates.items()):
+            sort_args = ", ".join(["thing"] * arity)
+            signature_lines.append(f"type({pred_name}({sort_args}))")
+
+        return {
+            "sorts": sorts,
+            "predicates": predicates,
+            "constants": constants,
+            "variables": variables,
+            "signature_lines": signature_lines,
+        }
+
+    @staticmethod
+    def build_signature_prefixed_formulas(formulas: List[str]) -> List[str]:
+        """Prepend signature declarations to formulas for Tweety parsing.
+
+        Tweety's FolParser requires sort/type declarations before formulas.
+        This method extracts metadata from formulas, generates declarations,
+        and combines them into a single parseable block.
+        """
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+        if not meta["constants"] and not meta["predicates"]:
+            return formulas
+        return meta["signature_lines"] + [""] + formulas
+
     def _validate_fol_formula(self, formula: str) -> bool:
         """Validation basique syntaxe FOL (accepts both Unicode and ASCII)."""
         # Vérifications de base

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -406,6 +406,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         self.bipolar_results: List[Dict[str, Any]] = []
         # Logic agent analysis results (#71 formal verification)
         self.fol_analysis_results: List[Dict[str, Any]] = []
+        self.fol_signature: List[str] = []  # Pre-declared sorts/types (#348)
         self.propositional_analysis_results: List[Dict[str, Any]] = []
         self.modal_analysis_results: List[Dict[str, Any]] = []
         self.formal_synthesis_reports: List[Dict[str, Any]] = []

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -2987,14 +2987,20 @@ async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dic
 
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+        from argumentation_analysis.agents.core.logic.fol_logic_agent import FOLLogicAgent
 
         bridge = TweetyBridge()
-        belief_set_str = "\n".join(str(f) for f in formulas)
+        # Pre-declare signature (sorts + types) for Tweety FolParser (#348)
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+        fol_signature = meta.get("signature_lines", [])
+        belief_set_str = "\n".join(str(f) for f in fol_signature + [""] + formulas)
         is_consistent, msg = await asyncio.to_thread(
             bridge.check_consistency, belief_set_str, "first_order"
         )
         return {
             "formulas": formulas,
+            "fol_signature": fol_signature,
+            "fol_metadata": meta,
             "consistent": bool(is_consistent),
             "inferences": inferences,
             "confidence": 0.8 if is_consistent else 0.4,
@@ -3005,8 +3011,17 @@ async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dic
     except Exception:
         # Fallback: check for contradiction in generated formulas
         has_fallacious = any("Fallacious" in f for f in formulas)
+        # Still extract signature metadata even in fallback (#348)
+        fol_signature = []
+        try:
+            from argumentation_analysis.agents.core.logic.fol_logic_agent import FOLLogicAgent
+            meta = FOLLogicAgent.extract_fol_metadata(formulas)
+            fol_signature = meta.get("signature_lines", [])
+        except Exception:
+            pass
         return {
             "formulas": formulas,
+            "fol_signature": fol_signature,
             "consistent": not has_fallacious,
             "inferences": inferences,
             "confidence": 0.6 if not has_fallacious else 0.3,

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -559,6 +559,13 @@ def _write_fol_to_state(output, state, ctx) -> None:
     state.add_fol_analysis_result(
         formulas, bool(consistent), inferences, float(confidence)
     )
+    # Store FOL signature metadata (#348)
+    fol_signature = output.get("fol_signature", [])
+    if isinstance(fol_signature, list) and fol_signature:
+        if not hasattr(state, "fol_signature"):
+            state.fol_signature = fol_signature
+        else:
+            state.fol_signature = fol_signature
 
 
 def _write_modal_to_state(output, state, ctx) -> None:

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_fol_signature_predeclaration.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_fol_signature_predeclaration.py
@@ -1,0 +1,85 @@
+"""Tests for FOL signature pre-declaration (#348).
+
+Validates that extract_fol_metadata() correctly parses LLM-generated
+formulas to produce Tweety-compatible sort/type declarations.
+"""
+
+import pytest
+
+from argumentation_analysis.agents.core.logic.fol_logic_agent import FOLLogicAgent
+
+
+class TestExtractFolMetadata:
+    """Test the static extract_fol_metadata method."""
+
+    def test_empty_formulas(self):
+        meta = FOLLogicAgent.extract_fol_metadata([])
+        assert meta["predicates"] == {}
+        assert meta["constants"] == set()
+
+    def test_single_predicate(self):
+        formulas = ["Mortel(socrate)"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+        assert "Mortel" in meta["predicates"]
+        assert meta["predicates"]["Mortel"] == 1
+        assert "socrate" in meta["constants"]
+
+    def test_quantified_formula(self):
+        formulas = ["forall X: (Homme(X) => Mortel(X))"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+        assert "Homme" in meta["predicates"]
+        assert "Mortel" in meta["predicates"]
+        assert "X" in meta["variables"]
+        assert meta["predicates"]["Homme"] == 1
+        assert meta["predicates"]["Mortel"] == 1
+
+    def test_multi_arg_predicate(self):
+        formulas = ["Aime(socrate, platon)"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+        assert "Aime" in meta["predicates"]
+        assert meta["predicates"]["Aime"] == 2
+        assert "socrate" in meta["constants"]
+        assert "platon" in meta["constants"]
+
+    def test_signature_lines_format(self):
+        formulas = ["Homme(socrate)", "Mortel(socrate)"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+        lines = meta["signature_lines"]
+        assert any("thing = {" in line for line in lines)
+        assert any("type(Homme(thing))" in line for line in lines)
+        assert any("type(Mortel(thing))" in line for line in lines)
+
+    def test_mixed_formulas_produce_5_plus(self):
+        """Target: 5+ formulas should produce signature declarations for 5+ predicates."""
+        formulas = [
+            "Asserted(arg1)",
+            "Asserted(arg2)",
+            "Fallacious(arg1)",
+            "Undermines(fallacy1, arg1)",
+            "forall X: (Fallacious(X) => !FullySupported(X))",
+        ]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+        assert len(meta["predicates"]) >= 3  # Asserted, Fallacious, Undermines, FullySupported
+        assert len(meta["constants"]) >= 2  # arg1, arg2, fallacy1
+        assert len(meta["signature_lines"]) >= 3
+
+    def test_constants_collected_across_formulas(self):
+        formulas = ["P(a)", "Q(b)", "R(a, c)"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+        assert meta["constants"] == {"a", "b", "c"}
+
+
+class TestBuildSignaturePrefixedFormulas:
+    """Test the build_signature_prefixed_formulas method."""
+
+    def test_prefixes_signature(self):
+        formulas = ["Homme(socrate)", "Mortel(socrate)"]
+        result = FOLLogicAgent.build_signature_prefixed_formulas(formulas)
+        # First lines should be signature, then blank, then formulas
+        assert len(result) > len(formulas)
+        assert result[-1] == "Mortel(socrate)"
+        assert any("thing = {" in line for line in result)
+
+    def test_empty_formulas_return_empty(self):
+        result = FOLLogicAgent.build_signature_prefixed_formulas([])
+        assert result == []


### PR DESCRIPTION
## Summary
- Add `extract_fol_metadata()` static method to FOLLogicAgent — parses LLM-generated formulas to extract predicates, constants, variables, and produce Tweety-compatible sort/type declarations
- Modify `_invoke_fol_reasoning` to prepend signature declarations before sending to Tweety's FolParser
- Store `fol_signature` in UnifiedAnalysisState and state_writers
- 9 unit tests validating metadata extraction, signature generation, and prefixing

## Test plan
- [x] `test_fol_signature_predeclaration.py` — 9/9 passed
- [x] Signature lines correctly extract predicates and constants from formulas
- [x] Empty formulas handled gracefully
- [x] Mixed formulas with quantifiers, multi-arg predicates all parsed

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)