### PR TITLE
feat(jtms): retraction cascade rendering (#350)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -385,6 +385,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         self.argument_quality_scores: Dict[str, Dict[str, Any]] = {}
         # JTMS belief network (1.4.1)
         self.jtms_beliefs: Dict[str, Dict[str, Any]] = {}
+        # JTMS retraction cascade chains (#350)
+        self.jtms_retraction_chain: List[Dict[str, Any]] = []
         # Dung abstract argumentation frameworks (abs_arg_dung)
         self.dung_frameworks: Dict[str, Dict[str, Any]] = {}
         # Governance decisions and votes (2.1.6)

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -989,6 +989,7 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict:
 
     # ── Step 4: Fallacies → retract undermined beliefs + propagation ─
     fallacy_beliefs = []
+    session.jtms.enable_tracing()  # Track retraction cascades (#350)
     for i, f in enumerate(detected_fallacies[:6]):
         if not isinstance(f, dict):
             continue
@@ -1138,6 +1139,7 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict:
         "formal_consistency": formal_consistency,
         "session_version": session.version,
         "consistency_checks": session.consistency_checks,
+        "retraction_chain": session.jtms.get_retraction_chain(),
     }
 
 

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -171,6 +171,10 @@ def _write_jtms_to_state(output, state, ctx) -> None:
         if not isinstance(justifications, list):
             justifications = []
         state.add_jtms_belief(str(name), valid, justifications=justifications)
+    # Store retraction cascade chains (#350)
+    retraction_chain = output.get("retraction_chain", [])
+    if isinstance(retraction_chain, list):
+        state.jtms_retraction_chain = retraction_chain
 
 
 def _write_atms_to_state(output, state, ctx) -> None:

--- a/argumentation_analysis/services/jtms/jtms_core.py
+++ b/argumentation_analysis/services/jtms/jtms_core.py
@@ -93,7 +93,21 @@ class Belief:
         self._propagating = True
         try:
             for justification in self.implications:
-                justification.conclusion.compute_truth_statement()
+                conclusion = justification.conclusion
+                old_valid = conclusion.valid
+                conclusion.compute_truth_statement()
+                # Track cascade: conclusion was valid, now retracted
+                if (
+                    hasattr(self, '_jtms_ref')
+                    and self._jtms_ref is not None
+                    and self._jtms_ref._tracing_enabled
+                    and old_valid is True
+                    and conclusion.valid is not True
+                    and self._jtms_ref._retraction_trace
+                ):
+                    self._jtms_ref._retraction_trace[-1]["cascaded"].append(
+                        conclusion.name
+                    )
         finally:
             self._propagating = False
 
@@ -131,11 +145,15 @@ class JTMS:
     def __init__(self, strict: bool = False):
         self.beliefs: Dict[str, Belief] = {}
         self.strict = strict
+        self._retraction_trace: List[Dict] = []
+        self._tracing_enabled: bool = False
 
     def add_belief(self, name: str):
         """Add a new belief to the system."""
         if name not in self.beliefs:
-            self.beliefs[name] = Belief(name)
+            belief = Belief(name)
+            belief._jtms_ref = self
+            self.beliefs[name] = belief
 
     def remove_belief(self, belief_name: str):
         """Remove a belief and clean up its implications."""
@@ -153,7 +171,16 @@ class JTMS:
         """Set the truth value of a belief and propagate."""
         if belief_name not in self.beliefs:
             raise KeyError(f"Unknown belief: {belief_name}")
-        self.beliefs[belief_name].set_truth_value(validity)
+        belief = self.beliefs[belief_name]
+        old_valid = belief.valid
+        if self._tracing_enabled and old_valid is True and validity is not True:
+            self._retraction_trace.append({
+                "trigger": belief_name,
+                "retracted": [belief_name],
+                "cascaded": [],
+                "reason": f"directly set to {validity}",
+            })
+        belief.set_truth_value(validity)
 
     def add_justification(
         self,
@@ -206,6 +233,19 @@ class JTMS:
         """Print all beliefs and their truth values."""
         for b in self.beliefs.values():
             print(b)
+
+    def enable_tracing(self):
+        """Enable retraction cascade tracing."""
+        self._tracing_enabled = True
+        self._retraction_trace = []
+
+    def get_retraction_chain(self) -> List[Dict]:
+        """Return the accumulated retraction cascade trace.
+
+        Each entry is:
+            {trigger: str, retracted: [str], cascaded: [str], reason: str}
+        """
+        return list(self._retraction_trace)
 
     def explain_belief(self, belief_name: str) -> str:
         """Return a formatted explanation of a belief's justifications."""

--- a/tests/unit/argumentation_analysis/test_jtms_cascade_render.py
+++ b/tests/unit/argumentation_analysis/test_jtms_cascade_render.py
@@ -1,0 +1,214 @@
+"""Tests for JTMS retraction cascade rendering (#350).
+
+Validates that JTMS tracks cascading retractions when fallacies undermine
+beliefs, and that the cascade chain is properly stored in state.
+"""
+
+import asyncio
+import pytest
+
+from argumentation_analysis.services.jtms.jtms_core import JTMS, Belief
+from argumentation_analysis.orchestration.invoke_callables import _invoke_jtms
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.orchestration.state_writers import _write_jtms_to_state
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+class TestJTMSCoreRetractionTrace:
+    """Tests for JTMS core retraction trace."""
+
+    def test_enable_tracing(self):
+        jtms = JTMS()
+        jtms.enable_tracing()
+        assert jtms._tracing_enabled is True
+        assert jtms._retraction_trace == []
+
+    def test_retraction_recorded_when_belief_set_false(self):
+        jtms = JTMS()
+        jtms.add_belief("A")
+        jtms.set_belief_validity("A", True)
+        jtms.enable_tracing()
+        jtms.set_belief_validity("A", False)
+        chain = jtms.get_retraction_chain()
+        assert len(chain) == 1
+        assert chain[0]["trigger"] == "A"
+        assert "A" in chain[0]["retracted"]
+
+    def test_cascade_retraction_tracked(self):
+        """A → B; retract A → cascade retracts B."""
+        jtms = JTMS()
+        jtms.add_belief("A")
+        jtms.add_belief("B")
+        jtms.add_justification(["A"], [], "B")
+        jtms.set_belief_validity("A", True)
+        # B should be valid via A
+        assert jtms.beliefs["B"].valid is True
+
+        jtms.enable_tracing()
+        jtms.set_belief_validity("A", False)
+
+        chain = jtms.get_retraction_chain()
+        assert len(chain) == 1
+        assert chain[0]["trigger"] == "A"
+        assert "A" in chain[0]["retracted"]
+        assert "B" in chain[0]["cascaded"]
+
+    def test_no_trace_when_not_tracing(self):
+        jtms = JTMS()
+        jtms.add_belief("A")
+        jtms.set_belief_validity("A", True)
+        # Not enabling tracing
+        jtms.set_belief_validity("A", False)
+        chain = jtms.get_retraction_chain()
+        assert len(chain) == 0
+
+    def test_deep_cascade_three_levels(self):
+        """A → B → C; retract A → cascades to B and C."""
+        jtms = JTMS()
+        jtms.add_belief("A")
+        jtms.add_belief("B")
+        jtms.add_belief("C")
+        jtms.add_justification(["A"], [], "B")
+        jtms.add_justification(["B"], [], "C")
+        jtms.set_belief_validity("A", True)
+
+        assert jtms.beliefs["B"].valid is True
+        assert jtms.beliefs["C"].valid is True
+
+        jtms.enable_tracing()
+        jtms.set_belief_validity("A", False)
+
+        chain = jtms.get_retraction_chain()
+        assert len(chain) == 1
+        assert "B" in chain[0]["cascaded"]
+
+    def test_chain_entry_format(self):
+        """Each chain entry has the required format fields."""
+        jtms = JTMS()
+        jtms.add_belief("X")
+        jtms.set_belief_validity("X", True)
+        jtms.enable_tracing()
+        jtms.set_belief_validity("X", False)
+
+        chain = jtms.get_retraction_chain()
+        assert len(chain) == 1
+        entry = chain[0]
+        assert "trigger" in entry
+        assert "retracted" in entry
+        assert "cascaded" in entry
+        assert "reason" in entry
+        assert isinstance(entry["retracted"], list)
+        assert isinstance(entry["cascaded"], list)
+
+    def test_get_retraction_chain_returns_copy(self):
+        """get_retraction_chain returns a copy, not the internal list."""
+        jtms = JTMS()
+        jtms.add_belief("A")
+        jtms.set_belief_validity("A", True)
+        jtms.enable_tracing()
+        jtms.set_belief_validity("A", False)
+
+        chain1 = jtms.get_retraction_chain()
+        chain2 = jtms.get_retraction_chain()
+        assert chain1 == chain2
+        assert chain1 is not chain2
+
+
+class TestInvokeJtmsRetractionChain:
+    """Tests for _invoke_jtms retraction chain output."""
+
+    def test_retraction_chain_in_output(self):
+        context = {
+            "phase_extract_output": {
+                "arguments": [
+                    {"text": "First argument about X"},
+                    {"text": "Second argument about Y"},
+                    {"text": "Third argument about Z"},
+                ],
+                "claims": [{"text": "Main claim"}],
+            },
+            "phase_hierarchical_fallacy_output": {
+                "fallacies": [
+                    {"type": "ad_hominem", "target_argument": "First argument about X"},
+                ],
+            },
+        }
+        result = _run(_invoke_jtms("Some text.", context))
+        assert "retraction_chain" in result
+        assert isinstance(result["retraction_chain"], list)
+
+    def test_cascade_chain_with_fallacy(self):
+        """When a fallacy undermines an argument, it creates a retraction entry."""
+        context = {
+            "phase_extract_output": {
+                "arguments": [
+                    {"text": "Premise supporting conclusion A"},
+                    {"text": "Another premise"},
+                ],
+                "claims": [{"text": "Conclusion A follows from premises"}],
+            },
+            "phase_hierarchical_fallacy_output": {
+                "fallacies": [
+                    {
+                        "type": "straw_man",
+                        "target_argument": "Premise supporting conclusion A",
+                    },
+                ],
+            },
+        }
+        result = _run(_invoke_jtms("Text.", context))
+        chain = result["retraction_chain"]
+        # At least one retraction should have happened
+        assert len(chain) >= 1
+        # The chain entry should have proper format
+        entry = chain[0]
+        assert entry["trigger"]  # non-empty trigger
+        assert isinstance(entry["retracted"], list)
+        assert isinstance(entry["cascaded"], list)
+
+    def test_no_fallacies_empty_chain(self):
+        """Without fallacies, retraction chain is empty."""
+        context = {
+            "phase_extract_output": {
+                "arguments": [{"text": "Clean argument"}],
+                "claims": [{"text": "Clean claim"}],
+            },
+        }
+        result = _run(_invoke_jtms("Text.", context))
+        chain = result.get("retraction_chain", [])
+        assert len(chain) == 0
+
+
+class TestStateWriterRetractionChain:
+    """Tests for state_writer integration with retraction chain."""
+
+    def test_retraction_chain_stored_in_state(self):
+        state = UnifiedAnalysisState("test text")
+        output = {
+            "beliefs": {"A": {"valid": False, "justifications": []}},
+            "retraction_chain": [
+                {
+                    "trigger": "A",
+                    "retracted": ["A"],
+                    "cascaded": ["B"],
+                    "reason": "directly set to False",
+                }
+            ],
+        }
+        _write_jtms_to_state(output, state, {})
+        assert len(state.jtms_retraction_chain) == 1
+        assert state.jtms_retraction_chain[0]["trigger"] == "A"
+        assert "B" in state.jtms_retraction_chain[0]["cascaded"]
+
+    def test_empty_chain_when_no_output(self):
+        state = UnifiedAnalysisState("test text")
+        _write_jtms_to_state(None, state, {})
+        assert state.jtms_retraction_chain == []
+
+    def test_state_has_retraction_chain_field(self):
+        state = UnifiedAnalysisState("test")
+        assert hasattr(state, "jtms_retraction_chain")
+        assert isinstance(state.jtms_retraction_chain, list)


### PR DESCRIPTION
## Summary
- **JTMS core tracing**: `enable_tracing()` / `get_retraction_chain()` capture cascading retractions when beliefs are invalidated
- **Cascade tracking**: `Belief.propagate()` records which downstream beliefs lose validity via `_jtms_ref`
- **Pipeline integration**: `_invoke_jtms` enables tracing before fallacy retraction, returns `retraction_chain`
- **State field**: `state.jtms_retraction_chain` stores human-readable cascade entries

## DoD Checklist (#350)
- [x] `state.jtms_retraction_chain` contains at least 1 complete cascade chain
- [x] Format: list of dicts `{trigger: ..., retracted: [...], cascaded: [...], reason: ...}`
- [x] `test_jtms_cascade_render.py` passes with cascade scenario (13 tests)
- [ ] CI green

## Test plan
- [x] `pytest tests/unit/argumentation_analysis/test_jtms_cascade_render.py -v` — 13/13 passed
- [ ] Existing JTMS tests unaffected

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)