### PR TITLE
feat(synthesis): narrative synthesis agent (#351)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -413,6 +413,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         self.nl_to_logic_translations: List[Dict[str, Any]] = []
         # Workflow execution results
         self.workflow_results: Dict[str, Any] = {}
+        # Narrative synthesis (#351)
+        self.narrative_synthesis: str = ""
 
     def add_counter_argument(
         self, original_arg: str, counter_content: str, strategy: str, score: float

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -72,6 +72,7 @@ __all__ = [
     "_invoke_dung_extensions",
     "_python_dung_fallback",
     "_invoke_formal_synthesis",
+    "_invoke_narrative_synthesis",
 ]
 
 
@@ -3248,6 +3249,62 @@ async def _invoke_formal_synthesis(input_text: str, context: Dict[str, Any]) -> 
         "overall_validity": overall_validity,
         "phase_count": len(phase_results),
     }
+
+
+async def _invoke_narrative_synthesis(input_text: str, context: Dict[str, Any]) -> Dict:
+    """Invoke narrative synthesis to produce readable prose from all phase outputs (#351).
+
+    Reads state from context (populated by prior phases) and calls
+    build_narrative to generate 1-2 paragraphs weaving together quality,
+    fallacies, JTMS, ATMS, Dung, and formal logic results.
+    """
+    from argumentation_analysis.plugins.narrative_synthesis_plugin import build_narrative
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+    # Reconstruct state from context if possible
+    state = context.get("_state_object")
+    if not isinstance(state, UnifiedAnalysisState):
+        state = UnifiedAnalysisState(input_text[:200])
+        # Populate from context outputs
+        for key, value in context.items():
+            if key.startswith("phase_") and key.endswith("_output"):
+                cap = key[len("phase_") : -len("_output")]
+                writer = CAPABILITY_STATE_WRITERS.get(cap)
+                if writer and isinstance(value, dict):
+                    try:
+                        writer(value, state, context)
+                    except Exception:
+                        pass
+
+    narrative = build_narrative(state)
+
+    return {
+        "narrative": narrative,
+        "paragraph_count": narrative.count("\n\n") + 1,
+        "referenced_fields": _count_referenced_fields(state),
+    }
+
+
+def _count_referenced_fields(state) -> int:
+    """Count how many state fields have data (used as references in narrative)."""
+    count = 0
+    for field_name in [
+        "argument_quality_scores",
+        "identified_fallacies",
+        "neural_fallacy_scores",
+        "counter_arguments",
+        "jtms_beliefs",
+        "jtms_retraction_chain",
+        "atms_contexts",
+        "dung_frameworks",
+        "fol_analysis_results",
+        "propositional_analysis_results",
+        "modal_analysis_results",
+    ]:
+        val = getattr(state, field_name, None)
+        if val and (isinstance(val, (list, dict)) and len(val) > 0):
+            count += 1
+    return count
 
 
 # --- State writers: map capability → (output, state, ctx) → None ---

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -48,6 +48,7 @@ __all__ = [
     "_write_delp_to_state",
     "_write_qbf_to_state",
     "_write_collaborative_analysis_to_state",
+    "_write_narrative_synthesis_to_state",
     "CAPABILITY_STATE_WRITERS",
 ]
 
@@ -773,6 +774,15 @@ def _write_collaborative_analysis_to_state(output, state, ctx) -> None:
     _write_collaborative_to_state(output, state, ctx)
 
 
+def _write_narrative_synthesis_to_state(output, state, ctx) -> None:
+    """Write narrative synthesis results to UnifiedAnalysisState (#351)."""
+    if not output or not isinstance(output, dict):
+        return
+    narrative = output.get("narrative", "")
+    if isinstance(narrative, str) and narrative:
+        state.narrative_synthesis = narrative
+
+
 CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "argument_quality": _write_quality_to_state,
     "counter_argument_generation": _write_counter_argument_to_state,
@@ -809,4 +819,5 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "qbf_reasoning": _write_qbf_to_state,
     "collaborative_analysis": _write_collaborative_analysis_to_state,
     "nl_to_logic_translation": _write_nl_to_logic_to_state,
+    "narrative_synthesis": _write_narrative_synthesis_to_state,
 }

--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -1,0 +1,181 @@
+"""Narrative Synthesis Plugin for Spectacular Analysis Pipeline (#351).
+
+Produces 1-2 paragraphs of human-readable narrative weaving together
+results from all analysis KBs (fallacies, JTMS, ATMS, Dung, quality,
+counter-arguments). Reads from UnifiedAnalysisState and generates
+prose without LLM calls — purely template-based for reliability.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional
+
+try:
+    from semantic_kernel.functions import kernel_function
+
+    SK_AVAILABLE = True
+except ImportError:
+
+    def kernel_function(name=None, description=None):
+        def decorator(func):
+            func._sk_function_name = name or func.__name__
+            func._sk_function_description = description or func.__doc__
+            return func
+
+        return decorator
+
+    SK_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+
+def build_narrative(state: Any) -> str:
+    """Build a narrative synthesis paragraph from UnifiedAnalysisState.
+
+    Weaves together results from quality, fallacies, counter-arguments,
+    JTMS beliefs, ATMS contexts, Dung extensions, and formal logic into
+    1-2 readable paragraphs. Each referenced field is cited naturally.
+    """
+    parts: List[str] = []
+
+    # ── Quality scores ─────────────────────────────────────────────
+    quality = getattr(state, "argument_quality_scores", {})
+    if quality:
+        scores = [v.get("overall", 0) for v in quality.values() if isinstance(v, dict)]
+        if scores:
+            avg = sum(scores) / len(scores)
+            quality_desc = (
+                f"L'evaluation de la qualite argumentative couvre "
+                f"{len(quality)} argument(s), avec une note moyenne de "
+                f"{avg:.1f}/5."
+            )
+            weak = [k for k, v in quality.items() if isinstance(v, dict) and v.get("overall", 0) < 3]
+            if weak:
+                quality_desc += f" {len(weak)} argument(s) presentent des faiblesses significatives."
+            parts.append(quality_desc)
+
+    # ── Fallacies ──────────────────────────────────────────────────
+    fallacies = getattr(state, "identified_fallacies", {})
+    neural_fallacies = getattr(state, "neural_fallacy_scores", [])
+    total_fallacies = len(fallacies) + len(neural_fallacies)
+    if total_fallacies:
+        types = [v.get("type", "inconnu") for v in fallacies.values() if isinstance(v, dict)]
+        types_str = ", ".join(set(types)) if types else f"{total_fallacies} sophisme(s)"
+        fallacy_text = (
+            f"L'analyse a detecte {total_fallacies} sophisme(s) "
+            f"({types_str}), ce qui fragilise la structure argumentative."
+        )
+        parts.append(fallacy_text)
+
+    # ── Counter-arguments ──────────────────────────────────────────
+    counters = getattr(state, "counter_arguments", [])
+    if counters:
+        strategies = set()
+        for ca in counters:
+            if isinstance(ca, dict):
+                strategies.add(ca.get("strategy", "general"))
+        strat_text = ", ".join(strategies) if strategies else "plusieurs approches"
+        parts.append(
+            f"Des contre-arguments ont ete generes via {strat_text}, "
+            f"identifiant {len(counters)} point(s) de contestation."
+        )
+
+    # ── JTMS beliefs ───────────────────────────────────────────────
+    jtms_beliefs = getattr(state, "jtms_beliefs", {})
+    if jtms_beliefs:
+        valid_count = sum(1 for v in jtms_beliefs.values() if isinstance(v, dict) and v.get("valid") is True)
+        invalid_count = sum(1 for v in jtms_beliefs.values() if isinstance(v, dict) and v.get("valid") is False)
+        jtms_text = (
+            f"Le systeme JTMS maintient {len(jtms_beliefs)} croyance(s): "
+            f"{valid_count} valide(s), {invalid_count} rejetee(s)."
+        )
+        retraction_chain = getattr(state, "jtms_retraction_chain", [])
+        if retraction_chain:
+            cascade_count = sum(len(r.get("cascaded", [])) for r in retraction_chain)
+            jtms_text += (
+                f" {len(retraction_chain)} retraction(s) en cascade ont ete observee(s), "
+                f"affectant {cascade_count} croyance(s) dependante(s)."
+            )
+        parts.append(jtms_text)
+
+    # ── ATMS multi-context ─────────────────────────────────────────
+    atms_contexts = getattr(state, "atms_contexts", [])
+    if atms_contexts:
+        coherent = sum(1 for c in atms_contexts if isinstance(c, dict) and c.get("coherent"))
+        incoherent = len(atms_contexts) - coherent
+        parts.append(
+            f"L'analyse ATMS multi-contextes a teste {len(atms_contexts)} hypothese(s): "
+            f"{coherent} coherente(s), {incoherent} incoherente(s), "
+            f"illustrant la sensibilite des conclusions aux hypotheses retenues."
+        )
+
+    # ── Dung frameworks ────────────────────────────────────────────
+    dung = getattr(state, "dung_frameworks", {})
+    if dung:
+        ext_count = sum(
+            len(v.get("extensions", [])) for v in dung.values() if isinstance(v, dict)
+        )
+        if ext_count:
+            parts.append(
+                f"L'argumentation abstraite (semantiques de Dung) a identifie "
+                f"{ext_count} extension(s) parmi {len(dung)} cadre(s) d'attaque."
+            )
+
+    # ── Formal logic ───────────────────────────────────────────────
+    fol = getattr(state, "fol_analysis_results", [])
+    pl = getattr(state, "propositional_analysis_results", [])
+    modal = getattr(state, "modal_analysis_results", [])
+    formal_count = len(fol) + len(pl) + len(modal)
+    if formal_count:
+        formal_parts = []
+        if fol:
+            formal_parts.append(f"{len(fol)} en logique du premier ordre")
+        if pl:
+            formal_parts.append(f"{len(pl)} en logique propositionnelle")
+        if modal:
+            formal_parts.append(f"{len(modal)} en logique modale")
+        formal_str = ", ".join(formal_parts)
+        parts.append(
+            f"L'analyse formelle a produit {formal_count} resultat(s) ({formal_str})."
+        )
+
+    if not parts:
+        return (
+            "L'analyse n'a pas produit suffisamment de donnees pour generer "
+            "une synthese narrative. Seules des donnees partielles sont disponibles."
+        )
+
+    # ── Assemble into 1-2 paragraphs ───────────────────────────────
+    paragraph_1 = " ".join(parts[: len(parts) // 2 + 1])
+    paragraph_2 = " ".join(parts[len(parts) // 2 + 1 :]) if len(parts) > 3 else ""
+
+    if paragraph_2:
+        return f"{paragraph_1}\n\n{paragraph_2}"
+    return paragraph_1
+
+
+class NarrativeSynthesisPlugin:
+    """Semantic Kernel plugin for narrative synthesis (#351).
+
+    Produces human-readable analysis summaries by weaving together
+    outputs from all pipeline phases.
+    """
+
+    @kernel_function(
+        name="narrative_synthesis",
+        description="Generate a narrative synthesis paragraph from all "
+        "analysis results. Weaves quality scores, fallacy detection, "
+        "counter-arguments, JTMS beliefs, ATMS contexts, and formal "
+        "logic into readable prose.",
+    )
+    def synthesize(self, state_json: str = "{}") -> str:
+        """Generate narrative synthesis from state JSON."""
+        import json
+
+        try:
+            state_data = json.loads(state_json)
+        except (json.JSONDecodeError, TypeError):
+            state_data = {}
+
+        # Build a simple namespace object from dict for build_narrative
+        ns = type("State", (), state_data)()
+        return build_narrative(ns)

--- a/tests/unit/argumentation_analysis/test_narrative_synthesis.py
+++ b/tests/unit/argumentation_analysis/test_narrative_synthesis.py
@@ -1,0 +1,166 @@
+"""Tests for narrative synthesis (#351).
+
+Validates that build_narrative produces 1-2 readable paragraphs referencing
+at least 5 distinct state fields, and that the pipeline integration works.
+"""
+
+import asyncio
+import pytest
+
+from argumentation_analysis.plugins.narrative_synthesis_plugin import (
+    build_narrative,
+    NarrativeSynthesisPlugin,
+)
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.orchestration.state_writers import (
+    _write_narrative_synthesis_to_state,
+    CAPABILITY_STATE_WRITERS,
+)
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _rich_state() -> UnifiedAnalysisState:
+    """Create a state with data from multiple analysis phases."""
+    state = UnifiedAnalysisState("Test discourse for analysis.")
+
+    # Quality
+    state.add_quality_score("arg_1", {"clarte": 4.0, "coherence": 3.5}, 3.8)
+    state.add_quality_score("arg_2", {"clarte": 2.0, "pertinence": 2.5}, 2.2)
+
+    # Fallacies
+    state.add_fallacy("ad_hominem", "Attack on person", "arg_1")
+    state.add_fallacy("straw_man", "Distortion", "arg_2")
+
+    # Counter-arguments
+    state.add_counter_argument("arg_1", "Counter via reductio", "reductio", 0.7)
+
+    # JTMS
+    state.add_jtms_belief("premise_A", True, justifications=[])
+    state.add_jtms_belief("premise_B", False, justifications=["retracted"])
+    state.jtms_retraction_chain = [
+        {"trigger": "premise_B", "retracted": ["premise_B"], "cascaded": ["claim_X"], "reason": "inconsistency"}
+    ]
+
+    # ATMS
+    state.atms_contexts = [
+        {"hypothesis_id": "h_full", "coherent": False, "assumptions": ["a", "b"]},
+        {"hypothesis_id": "h_skeptical", "coherent": True, "assumptions": ["a"]},
+    ]
+
+    # Dung
+    state.dung_frameworks = {
+        "framework_1": {"extensions": [["arg_1"], ["arg_2"]], "attacks": [["arg_1", "arg_2"]]}
+    }
+
+    # Formal logic
+    state.fol_analysis_results = [{"query": "consistency", "result": "UNSAT"}]
+    state.propositional_analysis_results = [{"satisfiable": False}]
+
+    return state
+
+
+class TestBuildNarrative:
+    """Tests for build_narrative function."""
+
+    def test_produces_non_empty_string(self):
+        state = _rich_state()
+        result = build_narrative(state)
+        assert isinstance(result, str)
+        assert len(result) > 50
+
+    def test_references_quality(self):
+        state = _rich_state()
+        result = build_narrative(state)
+        assert "qualite" in result.lower() or "evaluation" in result.lower()
+
+    def test_references_fallacies(self):
+        state = _rich_state()
+        result = build_narrative(state)
+        assert "sophisme" in result.lower()
+
+    def test_references_jtms(self):
+        state = _rich_state()
+        result = build_narrative(state)
+        assert "jtms" in result.lower() or "croyance" in result.lower()
+
+    def test_references_atms(self):
+        state = _rich_state()
+        result = build_narrative(state)
+        assert "atms" in result.lower() or "hypothese" in result.lower()
+
+    def test_references_counter_arguments(self):
+        state = _rich_state()
+        result = build_narrative(state)
+        assert "contre-argument" in result.lower() or "contestat" in result.lower()
+
+    def test_at_least_5_distinct_references(self):
+        state = _rich_state()
+        result = build_narrative(state)
+        keywords = ["qualite", "sophisme", "croyance", "hypothese", "contre-argument",
+                     "dung", "logique", "jtms", "atms", "retraction", "extension"]
+        found = sum(1 for kw in keywords if kw in result.lower())
+        assert found >= 5, f"Only {found} references found in: {result[:200]}"
+
+    def test_readable_prose_not_json(self):
+        state = _rich_state()
+        result = build_narrative(state)
+        assert not result.startswith("{")
+        assert not result.startswith("[")
+        assert '{"' not in result
+        assert "': " not in result
+
+    def test_max_2_paragraphs(self):
+        state = _rich_state()
+        result = build_narrative(state)
+        paragraphs = [p for p in result.split("\n\n") if p.strip()]
+        assert len(paragraphs) <= 2
+
+    def test_empty_state_gives_fallback(self):
+        state = UnifiedAnalysisState("empty")
+        result = build_narrative(state)
+        assert isinstance(result, str)
+        assert len(result) > 0
+        assert "partielles" in result.lower()
+
+    def test_only_quality(self):
+        state = UnifiedAnalysisState("test")
+        state.add_quality_score("arg_1", {"clarte": 4}, 4.0)
+        result = build_narrative(state)
+        assert "qualite" in result.lower() or "evaluation" in result.lower()
+        assert "argument" in result.lower()
+
+
+class TestNarrativeSynthesisPlugin:
+    """Tests for the SK plugin wrapper."""
+
+    def test_plugin_synthesize(self):
+        plugin = NarrativeSynthesisPlugin()
+        import json
+        state_dict = {
+            "argument_quality_scores": {"arg_1": {"overall": 3.5}},
+            "identified_fallacies": {"f_1": {"type": "ad_hominem"}},
+        }
+        result = plugin.synthesize(json.dumps(state_dict))
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+
+class TestNarrativeStateWriter:
+    """Tests for state writer integration."""
+
+    def test_narrative_stored_in_state(self):
+        state = UnifiedAnalysisState("test")
+        output = {"narrative": "This is the synthesis paragraph.", "paragraph_count": 1}
+        _write_narrative_synthesis_to_state(output, state, {})
+        assert state.narrative_synthesis == "This is the synthesis paragraph."
+
+    def test_empty_output_no_crash(self):
+        state = UnifiedAnalysisState("test")
+        _write_narrative_synthesis_to_state(None, state, {})
+        assert state.narrative_synthesis == ""
+
+    def test_capability_registered(self):
+        assert "narrative_synthesis" in CAPABILITY_STATE_WRITERS


### PR DESCRIPTION
## Summary
- **NarrativeSynthesisPlugin**: Template-based engine producing 1-2 paragraphs of readable prose from analysis results
- **build_narrative()**: Weaves quality, fallacies, counter-arguments, JTMS, ATMS, Dung, formal logic into narrative
- **_invoke_narrative_synthesis**: Reconstructs state from context and generates narrative
- **state.narrative_synthesis**: New field storing the generated paragraph

## DoD Checklist (#351)
- [x] `state.narrative_synthesis` contains 1-2 paragraphs
- [x] Paragraph cites at least 5 distinct state fields (quality, fallacies, JTMS, ATMS, counters, Dung, formal)
- [x] Format is readable prose (not JSON dump)
- [x] `test_narrative_synthesis.py` validates presence + coherence (15 tests)
- [ ] CI green

## Test plan
- [x] `pytest tests/unit/argumentation_analysis/test_narrative_synthesis.py -v` — 15/15 passed
- [ ] Existing tests unaffected

Closes #351

🤖 Generated with [Claude Code](https://claude.com/claude-code)