### PR TITLE
feat(investigation): open-domain whodunit-style argument analysis (#358)

### DIFF
--- a/argumentation_analysis/orchestration/open_domain_investigation.py
+++ b/argumentation_analysis/orchestration/open_domain_investigation.py
@@ -1,0 +1,233 @@
+"""Open-domain investigation module for Sherlock Modern (#358).
+
+Extends the investigation paradigm beyond Cluedo to general rhetorical
+analysis. Applies the whodunit-style framing:
+
+- "Who attributes responsibility for fact X?"
+- "Which thesis holds under which context/hypothesis?"
+- "Under hypothesis H1, the author claims X; under H2, claim X collapses."
+
+Works on any discourse text — no Cluedo-specific constraints.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Attribution:
+    """A responsibility attribution under a specific hypothesis."""
+
+    claim: str
+    attribution: str
+    hypothesis_id: str
+    coherent: bool
+    confidence: float = 0.0
+
+
+@dataclass
+class OpenDomainResult:
+    """Result of an open-domain investigation."""
+
+    document_id: str = ""
+    claims_analyzed: int = 0
+    attributions: List[Attribution] = field(default_factory=list)
+    hypothesis_summary: Dict[str, str] = field(default_factory=dict)
+    reasoning_trace: List[str] = field(default_factory=list)
+    conclusion: str = ""
+
+
+class OpenDomainInvestigator:
+    """Whodunit-style argument analysis on any discourse.
+
+    Uses SherlockModernOrchestrator for the heavy lifting, then
+    interprets results through the attribution lens:
+    - Who is responsible for what claim?
+    - Which hypothesis supports or undermines each claim?
+    """
+
+    def __init__(self, state: Optional[UnifiedAnalysisState] = None):
+        self.state = state
+
+    async def investigate_document(
+        self,
+        discourse: str,
+        document_id: str = "doc_A",
+        context: Optional[Dict] = None,
+    ) -> OpenDomainResult:
+        """Run open-domain whodunit investigation on a discourse.
+
+        Args:
+            discourse: Text to analyze.
+            document_id: Opaque ID for the document (privacy).
+            context: Optional context for agents.
+
+        Returns:
+            OpenDomainResult with attributions and hypothesis analysis.
+        """
+        from argumentation_analysis.orchestration.sherlock_modern_orchestrator import (
+            SherlockModernOrchestrator,
+        )
+
+        state = self.state or UnifiedAnalysisState(discourse)
+        self.state = state
+
+        # Run the Sherlock Modern investigation
+        orchestrator = SherlockModernOrchestrator(state=state)
+        inv_result = await orchestrator.investigate(discourse, context=context)
+
+        # Build attributions from investigation trace
+        claims = self._extract_claims_from_trace(inv_result.trace)
+        hypotheses = inv_result.hypotheses
+
+        attributions = self._build_attributions(claims, hypotheses)
+        hypothesis_summary = self._build_hypothesis_summary(hypotheses)
+
+        # Build conclusion
+        conclusion = self._build_conclusion(
+            document_id, claims, attributions, hypotheses
+        )
+
+        return OpenDomainResult(
+            document_id=document_id,
+            claims_analyzed=len(claims),
+            attributions=attributions,
+            hypothesis_summary=hypothesis_summary,
+            reasoning_trace=inv_result.reasoning_chain,
+            conclusion=conclusion,
+        )
+
+    def _extract_claims_from_trace(self, trace: List[Dict]) -> List[str]:
+        """Extract claim descriptions from the investigation trace."""
+        claims = []
+        for step in trace:
+            phase = step.get("phase", "")
+            findings = step.get("findings", {})
+            if phase == "extraction":
+                claims_found = findings.get("claims_found", 0)
+                args_found = findings.get("arguments_found", 0)
+                if claims_found > 0:
+                    claims.append(f"{claims_found} factual claim(s) extracted")
+                if args_found > 0:
+                    claims.append(f"{args_found} argumentative structure(s) identified")
+            elif phase == "fallacy_detection":
+                count = findings.get("fallacy_count", 0)
+                if count > 0:
+                    types = findings.get("types", [])
+                    claims.append(
+                        f"{count} inconsistency/es detected"
+                        + (f" ({', '.join(types[:3])})" if types else "")
+                    )
+            elif phase == "quality_evaluation":
+                score = findings.get("overall_score", 0)
+                n = findings.get("arguments_evaluated", 0)
+                claims.append(f"Reliability score: {score:.1f}/10 ({n} arguments)")
+        return claims
+
+    def _build_attributions(
+        self,
+        claims: List[str],
+        hypotheses: List[Dict],
+    ) -> List[Attribution]:
+        """Build responsibility attributions under each hypothesis."""
+        attributions = []
+        for hyp in hypotheses:
+            hyp_id = hyp.get("id", "unknown")
+            coherent = hyp.get("coherent", False)
+            assumptions = hyp.get("assumptions", [])
+
+            for claim in claims:
+                # Under a coherent hypothesis, the author's claim is maintained
+                # Under an incoherent one, it is undermined
+                if coherent:
+                    attr_text = f"Author's claim ({claim}) is supported under {hyp_id}"
+                    confidence = 0.7 + 0.1 * min(len(assumptions), 3)
+                else:
+                    attr_text = f"Author's claim ({claim}) is undermined under {hyp_id}"
+                    confidence = 0.3
+
+                attributions.append(
+                    Attribution(
+                        claim=claim,
+                        attribution=attr_text,
+                        hypothesis_id=hyp_id,
+                        coherent=coherent,
+                        confidence=min(confidence, 1.0),
+                    )
+                )
+        return attributions
+
+    def _build_hypothesis_summary(
+        self, hypotheses: List[Dict]
+    ) -> Dict[str, str]:
+        """Build a human-readable hypothesis summary."""
+        summary = {}
+        for hyp in hypotheses:
+            hyp_id = hyp.get("id", "unknown")
+            coherent = hyp.get("coherent", False)
+            assumptions = hyp.get("assumptions", [])
+            status = "COHERENT" if coherent else "INCOHERENT"
+            summary[hyp_id] = (
+                f"{status} — assumptions: {assumptions}"
+            )
+        return summary
+
+    def _build_conclusion(
+        self,
+        doc_id: str,
+        claims: List[str],
+        attributions: List[Attribution],
+        hypotheses: List[Dict],
+    ) -> str:
+        """Build the final whodunit conclusion."""
+        if not claims and not hypotheses:
+            return (
+                f"Document {doc_id}: insufficient data for open-domain "
+                f"investigation. Partial analysis only."
+            )
+
+        coherent_hyps = [h for h in hypotheses if h.get("coherent")]
+        incoherent_hyps = [h for h in hypotheses if not h.get("coherent")]
+
+        lines = [f"Document {doc_id} — Open-domain investigation"]
+
+        if claims:
+            lines.append(f"  Claims identified: {len(claims)}")
+        if coherent_hyps:
+            lines.append(
+                f"  Coherent hypotheses: {len(coherent_hyps)} "
+                f"({', '.join(h['id'] for h in coherent_hyps)})"
+            )
+        if incoherent_hyps:
+            lines.append(
+                f"  Incoherent hypotheses: {len(incoherent_hyps)} "
+                f"({', '.join(h['id'] for h in incoherent_hyps)})"
+            )
+
+        if attributions:
+            supported = [a for a in attributions if a.coherent]
+            undermined = [a for a in attributions if not a.coherent]
+            if supported:
+                lines.append(
+                    f"  Supported attributions: {len(supported)}"
+                )
+            if undermined:
+                lines.append(
+                    f"  Undermined attributions: {len(undermined)}"
+                )
+
+        # Attribution narrative
+        if coherent_hyps and incoherent_hyps:
+            lines.append(
+                f"  The author's argumentation holds under "
+                f"{', '.join(h['id'] for h in coherent_hyps)} "
+                f"but collapses under "
+                f"{', '.join(h['id'] for h in incoherent_hyps)}."
+            )
+
+        return "\n".join(lines)

--- a/examples/02_core_system_demos/scripts_demonstration/demo_sherlock_investigation.py
+++ b/examples/02_core_system_demos/scripts_demonstration/demo_sherlock_investigation.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Demo: Open-domain investigation via Sherlock Modern (#358).
+
+Whodunit-style argument analysis on a sample discourse. Uses opaque IDs
+for privacy compliance.
+
+Usage:
+    python examples/02_core_system_demos/scripts_demonstration/demo_sherlock_investigation.py
+"""
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path
+_project_root = Path(__file__).resolve().parents[3]
+if str(_project_root) not in sys.path:
+    sys.path.insert(0, str(_project_root))
+
+SAMPLE_DISCOURSE = (
+    "Le professeur affirme que le changement climatique est exagere par les medias. "
+    "Il cite une etude non peer-reviewee et attaque personnellement les scientifiques "
+    "du GIEC. Malgre des preuves contradictoires issues de sources independantes, "
+    "il maintient sa position avec conviction et rejette tout debat contradictoire."
+)
+
+
+async def run_demo():
+    """Run the open-domain investigation demo."""
+    from argumentation_analysis.orchestration.open_domain_investigation import (
+        OpenDomainInvestigator,
+    )
+
+    print("=" * 60)
+    print(" Sherlock Modern — Open-domain Investigation Demo")
+    print("=" * 60)
+    print(f"\nDocument: doc_A (opaque ID)")
+    print(f"Text length: {len(SAMPLE_DISCOURSE)} characters\n")
+
+    investigator = OpenDomainInvestigator()
+    result = await investigator.investigate_document(
+        discourse=SAMPLE_DISCOURSE,
+        document_id="doc_A",
+    )
+
+    # Display results
+    print("-" * 60)
+    print(" INVESTIGATION RESULTS")
+    print("-" * 60)
+    print(f"Document: {result.document_id}")
+    print(f"Claims analyzed: {result.claims_analyzed}")
+
+    print("\n Reasoning trace:")
+    for i, step in enumerate(result.reasoning_trace, 1):
+        print(f"  {i}. {step}")
+
+    if result.hypothesis_summary:
+        print("\n Hypotheses:")
+        for h_id, desc in result.hypothesis_summary.items():
+            print(f"  - {h_id}: {desc}")
+
+    if result.attributions:
+        print("\n Attributions:")
+        for attr in result.attributions:
+            status = "SUPPORTED" if attr.coherent else "UNDERMINED"
+            print(f"  [{status}] {attr.attribution} (confidence: {attr.confidence:.2f})")
+
+    print("\n Conclusion:")
+    print(f"  {result.conclusion}")
+    print("=" * 60)
+
+    return result
+
+
+if __name__ == "__main__":
+    result = asyncio.run(run_demo())
+    # Exit with 0 if investigation produced results
+    sys.exit(0 if result.claims_analyzed >= 0 else 1)

--- a/tests/unit/argumentation_analysis/test_open_domain_investigation.py
+++ b/tests/unit/argumentation_analysis/test_open_domain_investigation.py
@@ -1,0 +1,280 @@
+"""Tests for open-domain investigation (#358).
+
+Validates that the OpenDomainInvestigator:
+- Produces attributions under different hypotheses
+- Generates hypothesis summaries
+- Builds a whodunit-style conclusion
+- Works with opaque document IDs
+- Integrates with SherlockModernOrchestrator
+
+All tests mock the SherlockModernOrchestrator to avoid JVM/DLL issues.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from argumentation_analysis.orchestration.open_domain_investigation import (
+    OpenDomainInvestigator,
+    OpenDomainResult,
+    Attribution,
+)
+from argumentation_analysis.orchestration.sherlock_modern_orchestrator import (
+    InvestigationResult,
+)
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+SAMPLE_DISCOURSE = (
+    "L'auteur attribue la responsabilite du echec au gouvernement. "
+    "Il utilise des arguments ad hominem et des generalisations hatives."
+)
+
+MOCK_INVESTIGATION = InvestigationResult(
+    trace=[
+        {"step": 1, "phase": "extraction", "agent": "ExtractAgent",
+         "findings": {"claims_found": 2, "arguments_found": 1}, "conclusion": "Found 2 claims"},
+        {"step": 2, "phase": "fallacy_detection", "agent": "InformalAnalysisAgent",
+         "findings": {"fallacy_count": 2, "types": ["ad_hominem", "generalisation_hative"]},
+         "conclusion": "Detected 2 fallacies"},
+        {"step": 3, "phase": "quality_evaluation", "agent": "QualityScoringPlugin",
+         "findings": {"overall_score": 3.5, "arguments_evaluated": 2}, "conclusion": "Score 3.5/10"},
+        {"step": 4, "phase": "cross_examination", "agent": "CounterArgumentAgent",
+         "findings": {"counter_arguments": 1, "strategy": "reductio"},
+         "conclusion": "Cross-exam produced 1 counter"},
+        {"step": 5, "phase": "belief_tracking", "agent": "JTMS",
+         "findings": {"beliefs_total": 3, "beliefs_valid": 2, "beliefs_invalid": 1},
+         "conclusion": "3 beliefs, 1 retracted"},
+        {"step": 6, "phase": "hypothesis_branching", "agent": "ATMS",
+         "findings": {"hypotheses_tested": 2, "coherent": 1, "incoherent": 1},
+         "conclusion": "1 coherent, 1 incoherent"},
+        {"step": 7, "phase": "solution_synthesis", "agent": "NarrativeSynthesisPlugin",
+         "findings": {"paragraph_count": 1}, "conclusion": "Synthesis complete"},
+    ],
+    reasoning_chain=[
+        "Found 2 claims", "Detected 2 fallacies", "Score 3.5/10",
+        "Cross-exam produced 1 counter", "3 beliefs, 1 retracted",
+        "1 coherent, 1 incoherent", "Synthesis complete",
+    ],
+    agents_used=["ExtractAgent", "InformalAnalysisAgent", "QualityScoringPlugin",
+                  "CounterArgumentAgent", "JTMS", "ATMS", "NarrativeSynthesisPlugin"],
+    agent_count=7,
+    hypotheses=[
+        {"id": "h_full_trust", "coherent": True, "assumptions": ["trust_all_sources"]},
+        {"id": "h_skeptical", "coherent": False, "assumptions": ["doubt_fallacious_sources"]},
+    ],
+    solution="Investigation summary: multiple fallacies detected under full trust hypothesis.",
+)
+
+
+def _mocked_investigator():
+    """Create investigator with mocked orchestrator."""
+    inv = OpenDomainInvestigator()
+    return inv
+
+
+class TestOpenDomainInvestigator:
+    """Tests for the OpenDomainInvestigator class."""
+
+    def test_investigate_returns_result(self):
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_A"))
+            assert isinstance(result, OpenDomainResult)
+
+    def test_document_id_set(self):
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_B"))
+            assert result.document_id == "doc_B"
+
+    def test_reasoning_trace_not_empty(self):
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document(SAMPLE_DISCOURSE))
+            assert len(result.reasoning_trace) >= 1
+
+    def test_conclusion_not_empty(self):
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_A"))
+            assert isinstance(result.conclusion, str)
+            assert len(result.conclusion) > 20
+
+    def test_conclusion_mentions_document_id(self):
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_A"))
+            assert "doc_A" in result.conclusion
+
+    def test_hypothesis_summary_built(self):
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document(SAMPLE_DISCOURSE))
+            assert isinstance(result.hypothesis_summary, dict)
+            assert "h_full_trust" in result.hypothesis_summary
+            assert "h_skeptical" in result.hypothesis_summary
+
+    def test_state_stored(self):
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            _run(inv.investigate_document(SAMPLE_DISCOURSE))
+            assert inv.state is not None
+
+    def test_with_pre_existing_state(self):
+        state = UnifiedAnalysisState("pre-existing")
+        inv = OpenDomainInvestigator(state=state)
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            _run(inv.investigate_document(SAMPLE_DISCOURSE))
+            assert inv.state is state
+
+    def test_opaque_id_no_sensitive_data(self):
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_X"))
+            assert SAMPLE_DISCOURSE not in result.conclusion
+            assert SAMPLE_DISCOURSE not in str(result.attributions)
+
+    def test_attributions_differentiate_coherent(self):
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document(SAMPLE_DISCOURSE))
+            coherent_attrs = [a for a in result.attributions if a.coherent]
+            incoherent_attrs = [a for a in result.attributions if not a.coherent]
+            assert len(coherent_attrs) > 0
+            assert len(incoherent_attrs) > 0
+
+    def test_conclusion_holds_vs_collapses(self):
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_A"))
+            assert "h_full_trust" in result.conclusion
+            assert "h_skeptical" in result.conclusion
+
+    def test_empty_state_fallback(self):
+        empty_result = InvestigationResult(
+            trace=[], reasoning_chain=[], agents_used=[], agent_count=0,
+            hypotheses=[], solution="",
+        )
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=empty_result,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document("empty", "doc_C"))
+            assert "insufficient" in result.conclusion.lower() or "partial" in result.conclusion.lower()
+
+    def test_claims_analyzed_count(self):
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document(SAMPLE_DISCOURSE))
+            assert result.claims_analyzed >= 1
+
+    def test_attribution_output_format(self):
+        """Verify attribution output mentions the expected format."""
+        with patch(
+            "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
+            ".SherlockModernOrchestrator.investigate",
+            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+        ):
+            inv = _mocked_investigator()
+            result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_A"))
+            # Attributions should mention "supported" or "undermined"
+            all_text = " ".join(a.attribution for a in result.attributions)
+            assert "supported" in all_text.lower() or "undermined" in all_text.lower()
+
+
+class TestAttribution:
+    """Tests for the Attribution dataclass."""
+
+    def test_creation(self):
+        attr = Attribution(
+            claim="test claim", attribution="Author claims X",
+            hypothesis_id="h1", coherent=True, confidence=0.8,
+        )
+        assert attr.claim == "test claim"
+        assert attr.coherent is True
+        assert attr.confidence == 0.8
+
+    def test_defaults(self):
+        attr = Attribution(
+            claim="test", attribution="test",
+            hypothesis_id="h1", coherent=False,
+        )
+        assert attr.confidence == 0.0
+
+
+class TestDemoScript:
+    """Smoke test for the demo script."""
+
+    def test_demo_file_exists(self):
+        from pathlib import Path
+        demo_path = Path(
+            "examples/02_core_system_demos/scripts_demonstration"
+            "/demo_sherlock_investigation.py"
+        )
+        assert demo_path.exists()
+
+    def test_demo_has_run_function(self):
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            "demo_sherlock",
+            "examples/02_core_system_demos/scripts_demonstration"
+            "/demo_sherlock_investigation.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        assert hasattr(mod, "__file__")


### PR DESCRIPTION
## Summary
- New `OpenDomainInvestigator` class extending Sherlock Modern to general discourse analysis
- Whodunit-style framing: "Who attributes responsibility? Which thesis holds under which hypothesis?"
- Per-hypothesis attributions with coherent/incoherent status and confidence scores
- Demo script `demo_sherlock_investigation.py` with opaque IDs (privacy compliant)
- Conclusion format: "The author's argumentation holds under h_trust but collapses under h_skeptical"

## Dependencies
- Builds on #357 (PR #382 — Sherlock Modern Orchestrator)

## Test plan
- [x] 18 unit tests pass: attributions, hypothesis summaries, conclusion format, opaque IDs, empty fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)