### PR TITLE
feat(belief-revision): add test coverage + REVISION_METHODS constant (#57)

### DIFF
--- a/argumentation_analysis/agents/core/logic/belief_revision_handler.py
+++ b/argumentation_analysis/agents/core/logic/belief_revision_handler.py
@@ -19,6 +19,8 @@ logger = logging.getLogger(__name__)
 class BeliefRevisionHandler:
     """AGM belief revision using Tweety's beliefdynamics module."""
 
+    REVISION_METHODS = {"dalal", "levi"}
+
     def __init__(self, initializer_instance=None):
         if initializer_instance and not initializer_instance.is_jvm_ready():
             raise RuntimeError(

--- a/argumentation_analysis/plugins/belief_revision_plugin.py
+++ b/argumentation_analysis/plugins/belief_revision_plugin.py
@@ -62,7 +62,11 @@ class BeliefRevisionPlugin:
     )
     def list_revision_methods(self) -> str:
         """Return available revision method names."""
+        from argumentation_analysis.agents.core.logic.belief_revision_handler import (
+            BeliefRevisionHandler,
+        )
+
         return json.dumps(
-            ["dalal", "levi"],
+            sorted(BeliefRevisionHandler.REVISION_METHODS),
             ensure_ascii=False,
         )

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py
@@ -404,6 +404,114 @@ class TestBeliefRevisionHandler:
         assert result["operation"] == "contraction"
         assert result["removed"] == "a"
 
+    def test_revise_returns_statistics(self):
+        handler, _, registry = self._make_handler()
+        mock_revised = MagicMock()
+        mock_revised.__iter__ = MagicMock(
+            return_value=iter(
+                [MagicMock(__str__=lambda s: "a"), MagicMock(__str__=lambda s: "b")]
+            )
+        )
+        dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
+        if dalal:
+            dalal.return_value.revise.return_value = mock_revised
+
+        result = handler.revise(["a"], "b", method="dalal")
+        assert "statistics" in result
+        assert result["statistics"]["original_size"] == 1
+        assert result["statistics"]["revised_size"] == 2
+
+    def test_contract_returns_statistics(self):
+        handler, _, registry = self._make_handler()
+        mock_contracted = MagicMock()
+        mock_contracted.__iter__ = MagicMock(return_value=iter([]))
+        kernel = registry.get(
+            "org.tweetyproject.beliefdynamics.kernels.KernelContractionOperator"
+        )
+        if kernel:
+            kernel.return_value.contract.return_value = mock_contracted
+
+        result = handler.contract(["a", "b", "c"], "b")
+        assert result["statistics"]["original_size"] == 3
+        assert result["statistics"]["contracted_size"] == 0
+
+    def test_revise_with_negated_formula(self):
+        handler, _, registry = self._make_handler()
+        mock_revised = MagicMock()
+        mock_revised.__iter__ = MagicMock(
+            return_value=iter([MagicMock(__str__=lambda s: "!a")])
+        )
+        dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
+        if dalal:
+            dalal.return_value.revise.return_value = mock_revised
+
+        result = handler.revise(["a"], "!a", method="dalal")
+        assert result["new_belief"] == "!a"
+
+    def test_revise_empty_belief_set(self):
+        handler, _, registry = self._make_handler()
+        mock_revised = MagicMock()
+        mock_revised.__iter__ = MagicMock(
+            return_value=iter([MagicMock(__str__=lambda s: "p")])
+        )
+        dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
+        if dalal:
+            dalal.return_value.revise.return_value = mock_revised
+
+        result = handler.revise([], "p", method="dalal")
+        assert result["statistics"]["original_size"] == 0
+        assert result["statistics"]["revised_size"] == 1
+
+    def test_contract_single_formula(self):
+        handler, _, registry = self._make_handler()
+        mock_contracted = MagicMock()
+        mock_contracted.__iter__ = MagicMock(return_value=iter([]))
+        kernel = registry.get(
+            "org.tweetyproject.beliefdynamics.kernels.KernelContractionOperator"
+        )
+        if kernel:
+            kernel.return_value.contract.return_value = mock_contracted
+
+        result = handler.contract(["x"], "x")
+        assert result["removed"] == "x"
+        assert result["statistics"]["contracted_size"] == 0
+
+    def test_revise_dalal_vs_levi_different_results(self):
+        """Both methods should work on the same input without errors."""
+        handler, _, registry = self._make_handler()
+        mock_revised_dalal = MagicMock()
+        mock_revised_dalal.__iter__ = MagicMock(
+            return_value=iter([MagicMock(__str__=lambda s: "a")])
+        )
+        dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
+        if dalal:
+            dalal.return_value.revise.return_value = mock_revised_dalal
+
+        result_d = handler.revise(["a", "b"], "c", method="dalal")
+        result_l = handler.revise(["a", "b"], "c", method="levi")
+        assert result_d["method"] == "dalal"
+        assert result_l["method"] == "levi"
+        assert result_d["original"] == result_l["original"]
+
+    def test_revised_formulas_are_sorted(self):
+        handler, _, registry = self._make_handler()
+        mock_revised = MagicMock()
+        mock_revised.__iter__ = MagicMock(
+            return_value=iter(
+                [
+                    MagicMock(__str__=lambda s: "c"),
+                    MagicMock(__str__=lambda s: "a"),
+                    MagicMock(__str__=lambda s: "b"),
+                ]
+            )
+        )
+        dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
+        if dalal:
+            dalal.return_value.revise.return_value = mock_revised
+
+        result = handler.revise(["a"], "b", method="dalal")
+        assert result["revised"] == sorted(result["revised"])
+
 
 # =====================================================================
 # Probabilistic Handler Tests (#59)


### PR DESCRIPTION
## Summary
- Add `REVISION_METHODS` class constant to `BeliefRevisionHandler` for introspection
- Update `BeliefRevisionPlugin.list_revision_methods()` to use handler constant instead of hardcoded list
- Add 7 new unit tests for `TestBeliefRevisionHandler` (11 total): statistics on revise/contract, empty belief set, negated formulas, single-formula contraction, Dalal vs Levi comparison, sorted output verification

## Test plan
- [x] `pytest tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py::TestBeliefRevisionHandler -v` → 11/11 passed
- [x] `pytest tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py -v` → 36/36 passed (no regression)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>