### PR TITLE
fix(lint): replace bare except: with specific exception types

### DIFF
--- a/argumentation_analysis/agents/core/logic/modal_logic_agent.py
+++ b/argumentation_analysis/agents/core/logic/modal_logic_agent.py
@@ -466,7 +466,7 @@ Utilisez cette BNF pour corriger la syntaxe et réessayer automatiquement.
                     simple_repair = partial_json[:valid_end] + "}" * open_braces
                     json.loads(simple_repair)
                     return simple_repair
-                except:
+                except (json.JSONDecodeError, IndexError):
                     pass
 
         self.logger.warning("Retour du JSON partiel original.")

--- a/argumentation_analysis/api/jtms_endpoints.py
+++ b/argumentation_analysis/api/jtms_endpoints.py
@@ -482,7 +482,7 @@ async def get_jtms_state(
                     last_accessed=session_data["last_accessed"],
                     checkpoint_count=session_data.get("checkpoint_count", 0),
                 )
-            except:
+            except (KeyError, TypeError):
                 pass  # Session info optionnelle
 
         # Construire les justifications si demandées

--- a/argumentation_analysis/core/state_manager_plugin.py
+++ b/argumentation_analysis/core/state_manager_plugin.py
@@ -392,7 +392,7 @@ class StateManagerPlugin:
             if context:
                 try:
                     context_dict = json.loads(context)
-                except:
+                except (json.JSONDecodeError, TypeError):
                     context_dict = {"raw": context}
 
             # Create extended belief

--- a/argumentation_analysis/models/investigation_session_model.py
+++ b/argumentation_analysis/models/investigation_session_model.py
@@ -79,7 +79,7 @@ class SessionCheckpoint:
         try:
             data = self.to_dict()
             return len(json.dumps(data, default=str))
-        except:
+        except (TypeError, ValueError):
             return 0
 
     def to_dict(self) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- Replace 4 bare `except:` clauses with specific exception types
- Bare except silently swallows `KeyboardInterrupt`, `SystemExit`, `GeneratorExit`

## Files changed
- `agents/core/logic/modal_logic_agent.py` -> except (json.JSONDecodeError, IndexError)
- `core/state_manager_plugin.py` -> except (json.JSONDecodeError, TypeError)
- `models/investigation_session_model.py` -> except (TypeError, ValueError)
- `api/jtms_endpoints.py` -> except (KeyError, TypeError)

## Test plan
- [x] CI green (lint + tests expected)
- [ ] Verify no behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)