### PR TITLE
feat(soutenance): reveal.js slide deck for presentation (#406)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,6 +177,9 @@ tests/e2e/test-results/
 tests/unit/all_tests.txt
 tests/unit/targeted_test_list.txt
 
+# Soutenance slide deck build output
+docs/soutenance/build/
+
 # Misc generated docs
 docs/reports/ARBRE_*
 docs/reports/CLEANUP_LOG.md

--- a/docs/soutenance/slides.md
+++ b/docs/soutenance/slides.md
@@ -1,0 +1,408 @@
+---
+title: "Analyse Argumentative Multi-Agents"
+subtitle: "Intelligence Symbolique — EPITA 2025"
+author: "Equipe Projet IS"
+date: "2025"
+revealjs-url: "https://cdn.jsdelivr.net/npm/reveal.js@5"
+theme: "white"
+---
+
+# Analyse Argumentative Multi-Agents
+
+## Intelligence Symbolique — EPITA 2025
+
+Equipe Projet IS | Mai 2025
+
+---
+
+## Le Probleme
+
+- Comment analyser automatiquement la qualite d'un discours politique ?
+- Peut-on detecter les sophismes de maniere systematique ?
+- Comment formaliser un debat en logique mathematique ?
+- Est-il possible de simuler un vote democratique sur des arguments ?
+
+**Reponse** : Un systeme multi-agents combinant IA symbolique et connexionniste.
+
+---
+
+## Architecture Multi-Agents
+
+```
+Strategic  → Orchestrators (workflows complexes)
+Tactical   → Coordinators (interactions agents)
+Operational → Base agents (Sherlock, Watson, JTMS, FOL, Modal)
+```
+
+- **CapabilityRegistry** — Registre central Lego
+- **AgentFactory** — Fabrication d'agents avec wiring SK
+- **WorkflowDSL** — Workflows declaratifs en DAG
+- **17 phases** dans le pipeline spectacular
+
+---
+
+## Le Tronc Commun
+
+Fondation du professeur :
+
+- **Agents SK** heritant de `BaseAgent(ChatCompletionAgent)`
+- **Plugins** exposes via `@kernel_function`
+- **Tweety Bridge** — Raisonneur formel Java/JPype
+- **Communication** — Messagerie multi-canal hierarchique
+- **Pydantic V2** — Validation et serialisation
+
+---
+
+## Integrations Etudiants
+
+12 projets etudiens integres dans l'architecture `BaseAgent` :
+
+| Projet | Composant integre |
+|--------|------------------|
+| 1.4.1 JTMS | Systeme de maintenance de verite |
+| 2.3.2 Detection sophismes | Taxonomie 8 familles |
+| 2.3.3 Contre-argumentation | 5 strategies rhetoriques |
+| 2.3.5 Qualite argumentaire | 9 vertus d'evaluation |
+| 2.3.6 LLM local | Adaptateur endpoints locaux |
+| ... | ... |
+
+---
+
+## Pipeline Spectacular — 17 Phases
+
+```
+Extract → Quality → NL-to-Logic → Neural Detect → Hierarchical Fallacy
+    ↓
+PL → FOL → Modal → Dung → ASPIC → Counter-Args
+    ↓
+JTMS → Debate → ATMS → Governance → Formal Synthesis → Narrative Synthesis
+```
+
+17 phases | 0 echecs (sur golden fixture) | ~45s par document
+
+---
+
+## Phase 1-2 : Extraction & Qualite
+
+**Extraction** : 8 arguments identifies (5 premisses, 3 conclusions)
+
+**Qualite** : 4 dimensions par argument
+
+| Argument | Clarte | Coherence | Pertinence | Global |
+|----------|--------|-----------|------------|--------|
+| arg_p1 | 0.92 | 0.88 | 0.95 | **0.90** |
+| arg_c1 | 0.85 | 0.72 | 0.88 | **0.78** |
+
+Score moyen : 0.84 | Range : 0.74 – 0.90
+
+---
+
+## Phase 3-4 : Detection de Sophismes
+
+**Detection hybride** : neuronale + hierarchique
+
+| Sophisme | Famille | Confiance |
+|----------|---------|-----------|
+| Ad hominem | Pertinence | 87% |
+| Pente glissante | Causal | 82% |
+| Homme de paille | Distorsion | 79% |
+| Faux dilemme | Presomption | 75% |
+
+**Taxonomie** : 8 familles, 30+ types de sophismes
+
+---
+
+## Phase 5-7 : Logique Formelle
+
+**Trois systemes** pour le meme texte :
+
+- **Propositionnelle** : P1 AND P2 → C1 (3/5 valides)
+- **Premier ordre** : ∀x(Citizen(x) → HasRight(x, expression))
+  - 16 predicats dans la signature
+- **Modale S5** : □(HasRight(citizen, expression))
+  - 5 formules analysees
+
+---
+
+## Phase 8 : Cadre de Dung
+
+**Argumentation abstraite** — extensions semantiques :
+
+```
+arg_c1 ← ATTACKS ← arg_p3
+arg_c1 ← ATTACKS ← arg_c2
+```
+
+| Semantique | Taille | Arguments acceptes |
+|-------------|--------|--------------------|
+| Grounded | 6 | p1, p2, p4, p5, c2, c3 |
+| Preferred | 6-7 | + p3 (credule) |
+| Stable | 6 | p1, p2, p4, p5, c2, c3 |
+
+**Verdict** : arg_c1 rejete (grounded)
+
+---
+
+## Phase 9 : ATMS — Branchement d'Hypotheses
+
+**4 contextes de raisonnement** :
+
+| Contexte | Statut | Hypotheses |
+|----------|--------|------------|
+| Liberte absolue | **CONTRADICTOIRE** | freedom_absolute |
+| Liberte regulee | Consistent | regulation_compatible |
+| Inductif historique | **CONTRADICTOIRE** | censorship_authoritarian |
+| Deliberatif | Consistent | structured_deliberation |
+
+2 contextes contradictoires revelent les tensions internes
+
+---
+
+## Phase 10 : JTMS — Cascades de Retraction
+
+**Maintenance de verite** avec 10 croyances :
+
+```
+Cascade 1 : counter_reductio → arg_c1: IN → OUT
+  Raison : Le contre-argument reductio expose le faux dilemme
+
+Cascade 2 : counter_example → arg_p3: confiance 0.85 → 0.78
+  Raison : L'exemple allemand affaiblit le lien causal
+```
+
+Methode AGM : contraction avec minimalite
+
+---
+
+## Phase 11 : Contre-Argumentation
+
+**4 strategies** deployees :
+
+| Strategie | Cible | Force |
+|-----------|-------|-------|
+| Reductio ad absurdum | arg_c1 | 88% |
+| Contre-exemple | arg_p3 | 91% |
+| Distinction | arg_c2 | 84% |
+| Concession | arg_p4 | 79% |
+
+Le contre-exemple allemand est le plus fort (91%)
+
+---
+
+## Phase 12 : Debat — Protocole Walton-Krabbe
+
+**3 rounds** de debat structure :
+
+| Round | Proponent | Opposant | Vainqueur |
+|-------|-----------|----------|-----------|
+| 1 | arg_c1 | reductio | **Opposant** |
+| 2 | arg_p3 | contre-exemple | **Opposant** |
+| 3 | arg_c2 | distinction | Nul |
+
+Protocole : PPD (Persuasion Dialogue Protocol)
+Point tournant : round 1 reductio
+
+---
+
+## Phase 13 : Gouvernance Democratique
+
+**3 methodes de vote** unanimes :
+
+| Methode | Gagnant | Consensus |
+|---------|---------|-----------|
+| Majorite | Liberte regulee | 67% |
+| Borda | Liberte regulee | 78% |
+| Condorcet | Liberte regulee | 72% |
+
+**Verdict** : Tous les votants preferent la proposition "liberte regulee"
+
+---
+
+## Phase 14 : Synthese Narrative
+
+**Integration des 16 phases** precedentes :
+
+> "L'analyse spectaculaire de doc_A revele une structure argumentative a 8 arguments...
+> La logique propositionnelle valide 3/5 formules mais trouve le lien causal non supporte...
+> 4 sophismes detectes sur 3 familles...
+> Le Dung rejette arg_c1 en semant grounded...
+> Le JTMS demontre 2 cascades de retraction...
+> La gouvernance vote unanimement pour la liberte regulee."
+
+---
+
+## 5 Scenarios Pedagogiques
+
+| Scenario | Theme | Phases cibles |
+|----------|-------|--------------|
+| Politique | Loi logement | Extraction, sophismes, gouvernance |
+| Scientifique | Climat | Logique formelle, Dung |
+| Media | Liberte expression | Qualite, taxonomie |
+| Fact-check | Retraites | ATMS, JTMS |
+| Philosophie | Tramway | Contre-args, debat |
+
+Tous originaux — aucun extrait du corpus chiffre
+
+---
+
+## Scenario : Politique
+
+**"Loi sur le Logement Abordable"**
+
+- 7 arguments extraits
+- Ad hominem (87%) + pente glissante (82%)
+- Appel a l'autorite (expert)
+- Faux dilemme : "marche libre ou justice sociale"
+
+**Enseignement** : Comment identifier les sophismes dans un debat politique reel
+
+---
+
+## Scenario : Science
+
+**"Le changement climatique : mythe ou realite ?"**
+
+- 6 arguments extraits
+- Formalisation PL : Emissions → Rechauffement (valide)
+- FOL : ∀x(CO2(x) → Temperature(x+Δ))
+- Dung : contre-argument reductio sur l'inaction
+
+**Enseignement** : Logique formelle appliquee a la desinformation
+
+---
+
+## Scenario : Media
+
+**"La liberte d'expression a-t-elle des limites ?"**
+
+- 5 arguments extraits
+- Qualite : 0.72 a 0.88 (variance)
+- 3 familles de sophismes
+- Argument nuance (ni pour ni contre)
+
+**Enseignement** : Evaluation de la qualite argumentaire dans un editorial
+
+---
+
+## Scenario : Fact-Checking
+
+**"Les retraites seront-elles supprimees en 2027 ?"**
+
+- 4 hypotheses ATMS
+- JTMS : 2 cascades de retraction
+- Modal S5 : "necessairement faux" pour la suppression
+- Verdict : FAUX (reduction, pas suppression)
+
+**Enseignement** : Maintenance de verite appliquee au fact-checking
+
+---
+
+## Scenario : Philosophie
+
+**"Le probleme du tramway"**
+
+- 5 arguments (utilitariste, deontologique, agentivite)
+- 3 strategies de contre-argumentation
+- Debat : utilitarisme vs deontologie
+- Gouvernance : vote sur la decision morale
+
+**Enseignement** : Ethique computationnelle et dilemmes moraux
+
+---
+
+## Performance
+
+**Pipeline spectacular** (golden fixture doc_A) :
+
+| Metrique | Valeur |
+|----------|--------|
+| Phases | 17/17 completees |
+| Duree totale | ~45 secondes |
+| Arguments extraits | 8 |
+| Sophismes detectes | 4 |
+| Formules formelles | 16 |
+| Croyances JTMS | 10 |
+| Methodes de vote | 3 |
+
+---
+
+## Tests & Qualite
+
+**Strategie de test** :
+
+- **2845+ tests** passes
+- **Couverture** : 7 modules >80%
+- **Tests de regression** : 75 tests golden (spectacular)
+- **Markers** : 41 markers pytest (requires_api, slow, jpype, ...)
+- **CI** : GitHub Actions (lint + automated-tests)
+
+**Hardening en cours** (Epic A) :
+
+- Property-based tests (hypothesis)
+- LLM response caching (DiskCache)
+- mypy strict mode
+- Coverage audit
+
+---
+
+## Limitations
+
+**Honetesse sur les points faibles** :
+
+- **Tweety FOL** : Les constantes doivent etre pre-definies (pas de decouverte dynamique)
+- **Cout LLM** : ~$0.05-0.15 par analyse complete
+- **Biais de detection** : Les modeles neuronaux sont entraines sur l'anglais
+- **JTMS** : Les cascades de retraction peuvent etre incompletes sur des texts tres longs
+- **Langue** : Support optimal en anglais, partiel en francais
+- **ATMS** : Explosion combinatoire sur >10 hypotheses
+
+---
+
+## Travaux Futurs — Roadmap Democratech
+
+**Vision long terme** :
+
+1. **Discourse Pattern Mining** — Signatures quantitatives sur corpus
+2. **Enrichissement iteratif** — Cycle vertueux dataset → analyse → rapport
+3. **Mobile UI** — Interface React Native pour grand public
+4. **API publique** — Analyse argumentaire en temps reel
+5. **Collaboration** — Multi-utilisateurs avec debat en direct
+
+**Issue #78** : Roadmap complete post-integration
+
+---
+
+## Conclusion
+
+- **17 phases** d'analyse couvrant extraction → synthese
+- **Multi-agents** : Sherlock, Watson, JTMS, Dung, ATMS, governance
+- **Formel + connexionniste** : Meilleur des deux mondes
+- **Pedagogique** : 5 scenarios, notebook Jupyter, slide deck
+- **Open source** : Architecture extensible Lego
+
+**Merci ! Questions ?**
+
+---
+
+## Architecture Lego — Vue d'ensemble
+
+```
+┌─────────────────────────────────────┐
+│        CapabilityRegistry           │
+│  (agents, plugins, services)        │
+├─────────────────────────────────────┤
+│  AgentFactory → BaseAgent (SK)      │
+│  ├── Sherlock, Watson, Moriarty     │
+│  ├── FOL, Modal, Propositional      │
+│  ├── Counter-Argument, Debate       │
+│  └── Quality, Fallacy, Governance   │
+├─────────────────────────────────────┤
+│  WorkflowDSL → UnifiedPipeline      │
+│  ├── light (5 phases)               │
+│  ├── standard (10 phases)           │
+│  └── spectacular (17 phases)        │
+├─────────────────────────────────────┤
+│  Tweety Bridge (Java/JPype)         │
+│  └── 12 ranking reasoners           │
+└─────────────────────────────────────┘
+```

--- a/scripts/build_deck.py
+++ b/scripts/build_deck.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Build reveal.js HTML slide deck from markdown source.
+
+Usage:
+    python scripts/build_deck.py [--source docs/soutenance/slides.md] [--output docs/soutenance/build/slides.html]
+"""
+import argparse
+import pathlib
+import re
+
+REVEAL_TEMPLATE = """<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{title}</title>
+    <link rel="stylesheet" href="{reveal_url}/dist/reveal.css">
+    <link rel="stylesheet" href="{reveal_url}/dist/theme/{theme}.css">
+    <style>
+        .reveal h1, .reveal h2 {{ font-weight: bold; }}
+        .reveal table {{ font-size: 0.7em; border-collapse: collapse; margin: 10px auto; }}
+        .reveal th {{ background: #2c3e50; color: white; padding: 6px 12px; }}
+        .reveal td {{ border: 1px solid #ddd; padding: 4px 10px; }}
+        .reveal code {{ background: #f4f4f4; padding: 2px 6px; border-radius: 3px; font-size: 0.85em; }}
+        .reveal pre code {{ display: block; padding: 12px; overflow-x: auto; }}
+        .reveal blockquote {{ border-left: 4px solid #2c3e50; padding-left: 12px; font-style: italic; }}
+    </style>
+</head>
+<body>
+    <div class="reveal">
+        <div class="slides">
+{slides_html}
+        </div>
+    </div>
+    <script src="{reveal_url}/dist/reveal.js"></script>
+    <script>
+        Reveal.initialize({{
+            hash: true,
+            slideNumber: true,
+            transition: 'slide',
+            width: 1200,
+            height: 800
+        }});
+    </script>
+</body>
+</html>"""
+
+SLIDE_SEPARATOR = re.compile(r"\n---\n")
+
+
+def markdown_to_slides(md_content: str) -> str:
+    """Convert markdown with --- separators to reveal.js section tags."""
+    sections = SLIDE_SEPARATOR.split(md_content)
+    html_sections = []
+    for section in sections:
+        section = section.strip()
+        if not section:
+            continue
+        html_sections.append(f"            <section data-markdown>\n                <textarea data-template>\n{section}\n                </textarea>\n            </section>")
+    return "\n".join(html_sections)
+
+
+def parse_frontmatter(md_content: str):
+    """Extract YAML frontmatter from markdown."""
+    if md_content.startswith("---"):
+        parts = md_content.split("---", 2)
+        if len(parts) >= 3:
+            fm = {}
+            for line in parts[1].strip().split("\n"):
+                if ":" in line:
+                    key, val = line.split(":", 1)
+                    fm[key.strip()] = val.strip().strip('"').strip("'")
+            return fm, parts[2]
+    return {}, md_content
+
+
+def build_deck(source: pathlib.Path, output: pathlib.Path) -> pathlib.Path:
+    """Build reveal.js HTML deck from markdown source."""
+    md_content = source.read_text(encoding="utf-8")
+    fm, body = parse_frontmatter(md_content)
+
+    title = fm.get("title", "Presentation")
+    reveal_url = fm.get("revealjs-url", "https://cdn.jsdelivr.net/npm/reveal.js@5")
+    theme = fm.get("theme", "white")
+
+    slides_html = markdown_to_slides(body)
+
+    html = REVEAL_TEMPLATE.format(
+        title=title,
+        reveal_url=reveal_url,
+        theme=theme,
+        slides_html=slides_html,
+    )
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(html, encoding="utf-8")
+    return output
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build reveal.js slide deck")
+    parser.add_argument("--source", type=pathlib.Path, default=pathlib.Path("docs/soutenance/slides.md"))
+    parser.add_argument("--output", type=pathlib.Path, default=pathlib.Path("docs/soutenance/build/slides.html"))
+    args = parser.parse_args()
+    result = build_deck(args.source, args.output)
+    print(f"Built: {result}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/soutenance/test_slide_deck.py
+++ b/tests/soutenance/test_slide_deck.py
@@ -1,0 +1,133 @@
+"""Smoke tests for the soutenance slide deck (Issue #406).
+
+Validates:
+- slides.md exists and has >= 25 slides
+- build_deck.py produces valid HTML without error
+- No plaintext dataset extracts in slides
+- Build output is gitignored
+- All assets under 100KB
+"""
+import pathlib
+import re
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+SLIDES_MD = REPO_ROOT / "docs" / "soutenance" / "slides.md"
+BUILD_SCRIPT = REPO_ROOT / "scripts" / "build_deck.py"
+GITIGNORE = REPO_ROOT / ".gitignore"
+BUILD_OUTPUT_DIR = REPO_ROOT / "docs" / "soutenance" / "build"
+
+SLIDE_SEPARATOR = re.compile(r"\n---\n")
+
+SENSITIVE_FIELDS = ("source_name", "full_text", "raw_text")
+
+
+class TestSlideSource:
+    """Tests for docs/soutenance/slides.md."""
+
+    def test_slides_md_exists(self):
+        assert SLIDES_MD.is_file(), f"slides.md not found at {SLIDES_MD}"
+
+    def test_minimum_25_slides(self):
+        content = SLIDES_MD.read_text(encoding="utf-8")
+        sections = SLIDE_SEPARATOR.split(content)
+        non_empty = [s.strip() for s in sections if s.strip()]
+        assert len(non_empty) >= 25, (
+            f"Expected >= 25 slides, found {len(non_empty)}"
+        )
+
+    def test_has_frontmatter(self):
+        content = SLIDES_MD.read_text(encoding="utf-8")
+        assert content.startswith("---"), "slides.md must start with YAML frontmatter"
+        parts = content.split("---", 2)
+        assert len(parts) >= 3, "Frontmatter must be delimited by ---"
+        fm = parts[1]
+        assert "title:" in fm, "Frontmatter missing 'title'"
+        assert "theme:" in fm, "Frontmatter missing 'theme'"
+
+    def test_no_plaintext_extracts(self):
+        content = SLIDES_MD.read_text(encoding="utf-8").lower()
+        for field in SENSITIVE_FIELDS:
+            assert field not in content, (
+                f"Found sensitive field '{field}' in slides.md"
+            )
+
+    def test_opaque_ids_only(self):
+        content = SLIDES_MD.read_text(encoding="utf-8")
+        has_doc_ref = "doc_a" in content.lower() or "doc_A" in content
+        if has_doc_ref:
+            assert "source_name" not in content.lower()
+            assert "extract_sources" not in content.lower()
+
+    def test_covers_17_phases(self):
+        content = SLIDES_MD.read_text(encoding="utf-8")
+        assert "17" in content, "Slides should mention 17 phases"
+
+    def test_covers_architecture_section(self):
+        content = SLIDES_MD.read_text(encoding="utf-8").lower()
+        assert "architecture" in content, "Slides should cover architecture"
+        assert "multi-agent" in content, "Slides should mention multi-agents"
+
+    def test_covers_scenarios(self):
+        content = SLIDES_MD.read_text(encoding="utf-8").lower()
+        assert "politique" in content or "politic" in content
+        assert "scient" in content or "climat" in content
+
+    def test_file_size_under_100kb(self):
+        size = SLIDES_MD.stat().st_size
+        assert size < 100 * 1024, f"slides.md is {size} bytes, exceeds 100KB"
+
+
+class TestBuildScript:
+    """Tests for scripts/build_deck.py."""
+
+    def test_build_script_exists(self):
+        assert BUILD_SCRIPT.is_file(), f"build_deck.py not found at {BUILD_SCRIPT}"
+
+    def test_build_produces_html(self, tmp_path):
+        sys.path.insert(0, str(BUILD_SCRIPT.parent.parent / "scripts"))
+        from build_deck import build_deck
+
+        output = tmp_path / "slides.html"
+        result = build_deck(SLIDES_MD, output)
+        assert result.is_file(), "Build did not produce output file"
+
+        html = result.read_text(encoding="utf-8")
+        assert "<!DOCTYPE html>" in html, "Output is not valid HTML"
+        assert "reveal.js" in html, "Output does not reference reveal.js"
+        assert "data-markdown" in html, "Output missing data-markdown sections"
+
+    def test_build_output_sections_match_source(self, tmp_path):
+        from build_deck import build_deck, parse_frontmatter
+
+        output = tmp_path / "slides.html"
+        build_deck(SLIDES_MD, output)
+        html = output.read_text(encoding="utf-8")
+
+        section_count = html.count("<section data-markdown>")
+        md_content = SLIDES_MD.read_text(encoding="utf-8")
+        _, body = parse_frontmatter(md_content)
+        md_sections = [
+            s.strip() for s in SLIDE_SEPARATOR.split(body) if s.strip()
+        ]
+        assert section_count == len(md_sections), (
+            f"HTML has {section_count} sections but source has {len(md_sections)}"
+        )
+
+    def test_build_output_under_100kb(self, tmp_path):
+        from build_deck import build_deck
+
+        output = tmp_path / "slides.html"
+        build_deck(SLIDES_MD, output)
+        size = output.stat().st_size
+        assert size < 100 * 1024, f"Built HTML is {size} bytes, exceeds 100KB"
+
+
+class TestGitignore:
+    """Ensure build artifacts are excluded from git."""
+
+    def test_build_dir_gitignored(self):
+        gitignore = GITIGNORE.read_text(encoding="utf-8")
+        assert "docs/soutenance/build/" in gitignore or (
+            "build/" in gitignore
+        ), "docs/soutenance/build/ should be gitignored"


### PR DESCRIPTION
## Summary

- **28-slide reveal.js markdown deck** (`docs/soutenance/slides.md`) covering architecture, 17 pipeline phases, 5 pedagogical scenarios, performance metrics, testing strategy, limitations, and future roadmap
- **Build script** (`scripts/build_deck.py`) converting markdown → standalone HTML with CDN reveal.js, YAML frontmatter parsing, custom CSS
- **14 smoke tests** validating source structure, build output, section count, privacy compliance, file size, and gitignore

## Acceptance Criteria (#406)

- [x] `python scripts/build_deck.py` produces a working HTML deck
- [x] ≥25 slides (28 slides total)
- [x] slides.md committed with no plaintext extracts
- [x] All assets <100KB, build output gitignored
- [x] Smoke test suite passes (14/14)

## Test plan

- [x] `pytest tests/soutenance/test_slide_deck.py -v` — 14 passed

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)