### PR TITLE
feat(dataset): enrichment workflow CLI + docs (#413)

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,18 @@ Ce processus garantit que chaque modification est non seulement testée fonction
 
 ---
 
+## Discourse Pattern Mining
+
+Quantitative analysis of discourse signatures across the encrypted corpus — fallacy spectres, Tricherie/Influence asymmetry, co-occurrence patterns, and cross-coverage with formal reasoning.
+
+- **Report**: `docs/reports/discourse_patterns.md` (generated, committed with opaque IDs only)
+- **Enrichment workflow**: `docs/security/dataset_enrichment.md` — how to add new extracts and regenerate
+- **CLI**: `python scripts/dataset/tasks.py pattern-add|pattern-rerun|pattern-report`
+
+All analyses use opaque IDs; qualitative data remains local (`.analysis_kb/`, gitignored).
+
+---
+
 ## Tests de Performance
 
 Ce projet utilise `pytest-benchmark` pour réaliser des mesures de performance statistiques et fiables.

--- a/docs/security/dataset_enrichment.md
+++ b/docs/security/dataset_enrichment.md
@@ -1,0 +1,61 @@
+# Dataset Enrichment Workflow
+
+How to add new extracts and regenerate the discourse pattern report.
+
+## Adding a new extract
+
+1. Place the plaintext **outside** the repo (e.g. `~/local-texts/foo.txt`).
+2. Run:
+   ```bash
+   python scripts/dataset/tasks.py pattern-add \
+       --source "speech_id_X" \
+       --text ~/local-texts/foo.txt \
+       --metadata "discourse_type=populist,era=2025,regime_type=democracy"
+   ```
+   The script encrypts the text and appends it to the canonical dataset,
+   then prints the opaque ID assigned to the new extract.
+3. Re-run the full analysis:
+   ```bash
+   python scripts/dataset/tasks.py pattern-rerun --skip-existing
+   ```
+   This runs the spectacular workflow on new documents (~7 min/doc).
+4. Regenerate the public report:
+   ```bash
+   python scripts/dataset/tasks.py pattern-report
+   ```
+   Output: `docs/reports/discourse_patterns.md` + SVG charts.
+5. Commit the report (**not** the plaintext, **not** `.analysis_kb/`).
+
+## Metadata schema
+
+| Field | Required | Values |
+|-------|----------|--------|
+| `discourse_type` | yes | `populist`, `technocratic`, `dictatorial`, `dialectic`, `other` |
+| `era` | yes | Decade bucket, e.g. `2020-2025` |
+| `regime_type` | no | `democracy`, `autocracy`, `mixed`, `historical` |
+| `language` | no | Default `fr` |
+
+## Privacy reminders
+
+- Plaintext stays on local disk. **Never** tracked in git.
+- Use opaque IDs in commits, PRs, and dashboards. **Never** source names.
+- `.analysis_kb/` is gitignored — do not move state dumps out of it.
+- For full policy, see `CLAUDE.md` → "Dataset Privacy Discipline".
+
+## Rotating the passphrase
+
+1. Generate a new key:
+   ```bash
+   python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+   ```
+2. Update `TEXT_CONFIG_PASSPHRASE` in `.env`.
+3. Re-encrypt the dataset with the new key (keep a backup of the old `.env` until confirmed).
+4. Verify decryption round-trip before deleting the old key.
+
+## Task reference
+
+| Task | Script | Description |
+|------|--------|-------------|
+| `pattern-add` | `add_extract.py` | Encrypt + append extract to canonical dataset |
+| `pattern-rerun` | `run_corpus_batch.py` | Run spectacular on new/selected documents |
+| `pattern-report` | `build_pattern_report.py` | Generate markdown + SVG report from signatures |

--- a/scripts/dataset/tasks.py
+++ b/scripts/dataset/tasks.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Enrichment workflow tasks for Discourse Pattern Mining (Issue #413).
+
+Standalone CLI — no external task runner required.
+
+Usage:
+    python scripts/dataset/tasks.py pattern-add --source NAME --text PATH [--metadata KEY=VAL,...]
+    python scripts/dataset/tasks.py pattern-rerun [--skip-existing]
+    python scripts/dataset/tasks.py pattern-report
+"""
+import argparse
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts" / "dataset"
+
+ADD_SCRIPT = SCRIPTS_DIR / "add_extract.py"
+BATCH_SCRIPT = SCRIPTS_DIR / "run_corpus_batch.py"
+REPORT_SCRIPT = SCRIPTS_DIR / "build_pattern_report.py"
+
+
+def _check_script(path: pathlib.Path, name: str) -> bool:
+    if not path.is_file():
+        print(f"ERROR: {name} not found at {path}", file=sys.stderr)
+        print(f"  → This script is provided by a dependent issue (C.1–C.4).", file=sys.stderr)
+        print(f"  → See docs/security/dataset_enrichment.md for the workflow.", file=sys.stderr)
+        return False
+    return True
+
+
+def cmd_pattern_add(args):
+    if not _check_script(ADD_SCRIPT, "add_extract.py"):
+        return 1
+    cmd = [sys.executable, str(ADD_SCRIPT),
+           "--source-name", args.source,
+           "--extract-text-file", args.text]
+    if args.metadata:
+        cmd.extend(["--metadata", args.metadata])
+    return subprocess.call(cmd)
+
+
+def cmd_pattern_rerun(args):
+    if not _check_script(BATCH_SCRIPT, "run_corpus_batch.py"):
+        return 1
+    cmd = [sys.executable, str(BATCH_SCRIPT),
+           "--workflow", "spectacular"]
+    if args.skip_existing:
+        cmd.append("--skip-existing")
+    return subprocess.call(cmd)
+
+
+def cmd_pattern_report(args):
+    if not _check_script(REPORT_SCRIPT, "build_pattern_report.py"):
+        return 1
+    return subprocess.call([sys.executable, str(REPORT_SCRIPT)])
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Discourse Pattern Mining — enrichment workflow tasks")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_add = sub.add_parser("pattern-add",
+                           help="Add a new extract to the encrypted dataset")
+    p_add.add_argument("--source", required=True,
+                       help="Opaque source identifier (e.g. speech_id_X)")
+    p_add.add_argument("--text", required=True,
+                       help="Path to plaintext file (stays local, not committed)")
+    p_add.add_argument("--metadata", default=None,
+                       help="Comma-separated key=val pairs "
+                            "(discourse_type=populist,era=2025)")
+
+    p_rerun = sub.add_parser("pattern-rerun",
+                             help="Re-run spectacular analysis on corpus")
+    p_rerun.add_argument("--skip-existing", action="store_true",
+                         help="Skip documents already processed")
+
+    p_report = sub.add_parser("pattern-report",
+                              help="Generate discourse pattern report + SVGs")
+
+    args = parser.parse_args()
+    dispatch = {
+        "pattern-add": cmd_pattern_add,
+        "pattern-rerun": cmd_pattern_rerun,
+        "pattern-report": cmd_pattern_report,
+    }
+    sys.exit(dispatch[args.command](args))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_enrichment_workflow.py
+++ b/tests/integration/test_enrichment_workflow.py
@@ -1,0 +1,116 @@
+"""Tests for the enrichment workflow CLI and docs (Issue #413).
+
+Validates:
+- tasks.py CLI parses commands and flags correctly
+- Graceful error when dependent scripts (C.1–C.4) are not yet available
+- Enrichment doc exists and contains key sections
+- README points to Discourse Pattern Mining
+- Privacy guard catches intentional leaks
+"""
+import pathlib
+import subprocess
+import sys
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+TASKS_CLI = REPO_ROOT / "scripts" / "dataset" / "tasks.py"
+ENRICH_DOC = REPO_ROOT / "docs" / "security" / "dataset_enrichment.md"
+README = REPO_ROOT / "README.md"
+
+
+class TestTasksCLI:
+    """Tests for scripts/dataset/tasks.py."""
+
+    def test_tasks_script_exists(self):
+        assert TASKS_CLI.is_file()
+
+    def test_pattern_add_requires_args(self):
+        result = subprocess.run(
+            [sys.executable, str(TASKS_CLI), "pattern-add"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0
+        assert "--source" in result.stderr or "--source" in result.stdout
+
+    def test_pattern_rerun_graceful_missing_script(self):
+        result = subprocess.run(
+            [sys.executable, str(TASKS_CLI), "pattern-rerun", "--skip-existing"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        assert "not found" in result.stderr.lower()
+
+    def test_pattern_report_graceful_missing_script(self):
+        result = subprocess.run(
+            [sys.executable, str(TASKS_CLI), "pattern-report"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 1
+        assert "not found" in result.stderr.lower()
+
+    def test_invalid_command_exits_error(self):
+        result = subprocess.run(
+            [sys.executable, str(TASKS_CLI), "nonexistent"],
+            capture_output=True, text=True,
+        )
+        assert result.returncode != 0
+
+
+class TestEnrichmentDoc:
+    """Tests for docs/security/dataset_enrichment.md."""
+
+    def test_doc_exists(self):
+        assert ENRICH_DOC.is_file()
+
+    def test_doc_has_metadata_schema(self):
+        content = ENRICH_DOC.read_text(encoding="utf-8")
+        assert "discourse_type" in content
+        assert "era" in content
+
+    def test_doc_has_privacy_section(self):
+        content = ENRICH_DOC.read_text(encoding="utf-8")
+        assert "opaque" in content.lower()
+        assert "privacy" in content.lower() or "Privacy" in content
+
+    def test_doc_has_task_reference(self):
+        content = ENRICH_DOC.read_text(encoding="utf-8")
+        assert "pattern-add" in content
+        assert "pattern-rerun" in content
+        assert "pattern-report" in content
+
+    def test_doc_under_80_lines(self):
+        lines = ENRICH_DOC.read_text(encoding="utf-8").splitlines()
+        assert len(lines) <= 80, f"Doc has {len(lines)} lines, exceeds 80"
+
+
+class TestReadmePointer:
+    """Tests for README Discourse Pattern Mining pointer."""
+
+    def test_readme_has_pattern_mining_section(self):
+        content = README.read_text(encoding="utf-8")
+        assert "Discourse Pattern Mining" in content
+
+    def test_readme_links_enrichment_doc(self):
+        content = README.read_text(encoding="utf-8")
+        assert "dataset_enrichment" in content
+
+    def test_readme_links_report(self):
+        content = README.read_text(encoding="utf-8")
+        assert "discourse_patterns" in content
+
+
+class TestPrivacyGuard:
+    """Privacy guard for enrichment artifacts."""
+
+    def test_enrichment_doc_no_plaintext_refs(self):
+        content = ENRICH_DOC.read_text(encoding="utf-8")
+        for forbidden in ("full_text", "raw_text", "source_name"):
+            assert forbidden not in content, f"LEAK: {forbidden} found in doc"
+
+    def test_readme_no_plaintext_refs_in_pattern_section(self):
+        content = README.read_text(encoding="utf-8")
+        idx = content.find("Discourse Pattern Mining")
+        if idx == -1:
+            return
+        section = content[idx:idx + 2000]
+        for forbidden in ("full_text", "raw_text", "source_name"):
+            assert forbidden not in section, f"LEAK: {forbidden} in README pattern section"


### PR DESCRIPTION
## Summary

- **`scripts/dataset/tasks.py`**: Standalone CLI (no invoke dependency) with `pattern-add`, `pattern-rerun`, `pattern-report` subcommands. Graceful errors when C.1–C.4 scripts are not yet available.
- **`docs/security/dataset_enrichment.md`**: ~65-line operational doc covering metadata schema, privacy reminders, passphrase rotation.
- **README**: Discourse Pattern Mining section linking report and enrichment doc.
- **15 smoke tests**: CLI parsing, doc content, README pointer, privacy guard.

## Dependency note

This is C.5 from Epic #408. The CLI targets reference scripts that will be created by C.1–C.4. Until those PRs merge, `pattern-rerun` and `pattern-report` exit with a clear error. `pattern-add` will work once C.1 provides `add_extract.py`.

## Test plan
- [x] 15/15 tests passed locally (0.95s)
- [ ] CI green (lint + automated-tests)

Closes #413

🤖 Generated with [Claude Code](https://claude.com/claude-code)