### PR TITLE
feat(testing): property-based tests for ATMS/JTMS invariants (#398)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -46,6 +46,7 @@ markers =
     config: Tests de configuration
     user_experience: Tests d'experience utilisateur
     crypto: Tests crypto
+    property: Property-based tests (hypothesis library)
 
 # Test discovery patterns (explicites pour clarte)
 python_files = test_*.py *_test.py

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -16,3 +16,4 @@ unidecode
 pytest-playwright
 matplotlib
 mcp
+hypothesis

--- a/tests/property/test_atms_invariants.py
+++ b/tests/property/test_atms_invariants.py
@@ -1,0 +1,233 @@
+"""Property-based tests for ATMS (Assumption-based Truth Maintenance System) invariants.
+
+Uses hypothesis to randomly generate belief networks and verify universal properties:
+1. Contradiction propagation: invalidating an env removes all its supersets from all nodes
+2. Environment monotonicity: adding justifications never removes existing environments
+3. Nogood enforcement: after a contradiction, no node has an env containing the nogood
+4. Hypothesis branching: distinct assumption sets produce distinct environment labels
+"""
+
+import pytest
+from hypothesis import given, settings, assume
+from hypothesis import strategies as st
+
+from argumentation_analysis.services.jtms.atms_core import ATMS, CONTRADICTION_SYMBOL
+
+
+# --- Strategies ---
+
+def name_pool(prefix="a", max_names=6):
+    return st.lists(
+        st.sampled_from([f"{prefix}{i}" for i in range(max_names)]),
+        min_size=1,
+        max_size=max_names,
+        unique=True,
+    )
+
+
+assumption_names = name_pool("a", 6)
+derived_names = name_pool("d", 8)
+
+
+@st.composite
+def atms_with_envs(draw):
+    """Build an ATMS with assumptions and at least one justification producing environments."""
+    atms = ATMS()
+    assumptions = draw(assumption_names)
+    derived = draw(derived_names)
+    assume(len(assumptions) >= 1 and len(derived) >= 1)
+
+    for name in assumptions:
+        atms.add_assumption(name)
+    for name in derived:
+        atms.add_node(name)
+
+    # Add 1-6 justifications
+    n_just = draw(st.integers(min_value=1, max_value=6))
+    all_names = [n for n in assumptions + derived if n != CONTRADICTION_SYMBOL]
+    assume(len(all_names) >= 2)
+
+    for _ in range(n_just):
+        in_nodes = draw(st.lists(
+            st.sampled_from(all_names), min_size=0, max_size=min(3, len(all_names)),
+            unique=True,
+        ))
+        remaining = [n for n in all_names if n not in in_nodes]
+        if remaining:
+            out_nodes = draw(st.lists(
+                st.sampled_from(remaining),
+                min_size=0, max_size=2, unique=True,
+            ))
+        else:
+            out_nodes = []
+        candidates = [n for n in all_names if n not in in_nodes and n not in out_nodes]
+        if len(candidates) < 1:
+            continue
+        conclusion = draw(st.sampled_from(candidates))
+        try:
+            atms.add_justification(in_nodes, out_nodes, conclusion)
+        except (KeyError, ValueError):
+            pass
+
+    return atms, assumptions, derived
+
+
+# --- Tests ---
+
+
+class TestATMSContradictionPropagation:
+    """invalidate_environment removes all supersets of the given env from every node."""
+
+    @given(
+        n=st.integers(min_value=3, max_value=5),
+    )
+    @settings(max_examples=30, deadline=2000)
+    @pytest.mark.property
+    def test_invalidate_removes_supersets_concrete(self, n):
+        atms = ATMS()
+        assumptions = [f"a{i}" for i in range(n)]
+        for name in assumptions:
+            atms.add_assumption(name)
+        atms.add_node("d0")
+        atms.add_justification(assumptions, [], "d0")
+
+        # d0 should have env = union of all assumptions
+        envs_before = atms.get_environments("d0")
+        assert len(envs_before) > 0
+
+        # Invalidate a subset env
+        env_to_kill = frozenset(assumptions[:2])
+        atms.invalidate_environment(env_to_kill)
+
+        for name, node in atms.nodes.items():
+            for env in node.label:
+                assert not env_to_kill.issubset(env), (
+                    f"Node {name} still has env {set(env)} superset of killed {set(env_to_kill)}"
+                )
+
+    @given(atms_data=atms_with_envs())
+    @settings(max_examples=40, deadline=2000)
+    @pytest.mark.property
+    def test_invalidate_removes_supersets_random(self, atms_data):
+        atms, assumptions, derived = atms_data
+        if len(assumptions) < 2:
+            return
+
+        env_to_kill = frozenset(assumptions[:2])
+        atms.invalidate_environment(env_to_kill)
+
+        for name, node in atms.nodes.items():
+            for env in node.label:
+                assert not env_to_kill.issubset(env), (
+                    f"Node {name} still has env {set(env)} superset of killed {set(env_to_kill)}"
+                )
+
+
+class TestATMSEnvironmentMonotonicity:
+    """Adding a justification never removes existing environments from any node."""
+
+    @given(
+        assumptions=assumption_names,
+        derived=derived_names,
+    )
+    @settings(max_examples=50, deadline=2000)
+    @pytest.mark.property
+    def test_adding_justification_preserves_environments(
+        self, assumptions, derived,
+    ):
+        assume(len(assumptions) >= 2 and len(derived) >= 1)
+
+        atms = ATMS()
+        for name in assumptions:
+            atms.add_assumption(name)
+        for name in derived:
+            atms.add_node(name)
+
+        atms.add_justification([assumptions[0]], [], derived[0])
+        labels_before = {
+            name: set(node.label) for name, node in atms.nodes.items()
+        }
+
+        # Add another justification that won't trigger contradiction
+        if len(assumptions) > 1:
+            atms.add_justification([assumptions[1]], [], derived[0])
+
+        for name, node in atms.nodes.items():
+            for env in labels_before.get(name, set()):
+                assert env in node.label, (
+                    f"Environment {set(env)} was removed from node {name} "
+                    f"after adding a justification"
+                )
+
+
+class TestATMSNogoodEnforcement:
+    """After a contradiction is triggered, no node retains an environment that
+    is a superset of the contradiction-producing environment."""
+
+    @given(
+        a1=st.sampled_from([f"a{i}" for i in range(6)]),
+        a2=st.sampled_from([f"a{i}" for i in range(6)]),
+    )
+    @settings(max_examples=30, deadline=2000)
+    @pytest.mark.property
+    def test_contradiction_enforces_nogood(self, a1, a2):
+        assume(a1 != a2)
+
+        atms = ATMS()
+        atms.add_assumption(a1)
+        atms.add_assumption(a2)
+        atms.add_node("d0")
+
+        # d0 needs both a1 and a2
+        atms.add_justification([a1, a2], [], "d0")
+
+        # Now make a1 + a2 a contradiction
+        atms.add_justification([a1, a2], [], CONTRADICTION_SYMBOL)
+
+        nogood = frozenset({a1, a2})
+        # d0 should NOT have the nogood env (it was invalidated)
+        for env in atms.get_environments("d0"):
+            assert not nogood.issubset(env), (
+                f"d0 still has env {set(env)} containing nogood {set(nogood)}"
+            )
+
+        # Assumption nodes retain their singleton envs (not supersets of nogood)
+        for name in [a1, a2]:
+            for env in atms.get_environments(name):
+                assert not nogood.issubset(env), (
+                    f"{name} still has env {set(env)} containing nogood {set(nogood)}"
+                )
+
+
+class TestATMSHypothesisBranching:
+    """Distinct assumption sets produce distinct environment labels."""
+
+    @given(n=st.integers(min_value=2, max_value=5))
+    @settings(max_examples=20, deadline=2000)
+    @pytest.mark.property
+    def test_distinct_assumptions_give_distinct_singleton_envs(self, n):
+        atms = ATMS()
+        names = [f"a{i}" for i in range(n)]
+        for name in names:
+            atms.add_assumption(name)
+
+        for name in names:
+            envs = atms.get_environments(name)
+            assert envs == {frozenset({name})}
+
+    @given(n=st.integers(min_value=2, max_value=4))
+    @settings(max_examples=20, deadline=2000)
+    @pytest.mark.property
+    def test_derived_env_contains_assumptions(self, n):
+        atms = ATMS()
+        assumptions = [f"a{i}" for i in range(n)]
+        for name in assumptions:
+            atms.add_assumption(name)
+
+        atms.add_node("derived")
+        atms.add_justification(assumptions, [], "derived")
+
+        envs = atms.get_environments("derived")
+        assert len(envs) >= 1
+        for env in envs:
+            assert any(a in env for a in assumptions)

--- a/tests/property/test_jtms_invariants.py
+++ b/tests/property/test_jtms_invariants.py
@@ -1,0 +1,217 @@
+"""Property-based tests for JTMS (Justification-based Truth Maintenance System) invariants.
+
+Uses hypothesis to randomly generate belief networks and verify universal properties:
+1. Justification chain consistency: valid beliefs have at least one fully-satisfied justification
+2. Retraction cascade: retracting a belief invalidates all dependent beliefs
+3. Cycle detection: mutual dependencies (A→B→A) are marked non-monotonic
+"""
+
+import pytest
+from hypothesis import given, settings, assume
+from hypothesis import strategies as st
+
+from argumentation_analysis.services.jtms.jtms_core import JTMS
+
+
+# --- Strategies ---
+
+belief_names = st.lists(
+    st.sampled_from([f"b{i}" for i in range(8)]),
+    min_size=2,
+    max_size=8,
+    unique=True,
+)
+
+
+@st.composite
+def jtms_with_justifications(draw):
+    """Build a JTMS: add beliefs, then justifications, THEN set validity.
+    This ensures truth values are determined by the justification network."""
+    jtms = JTMS()
+    names = draw(belief_names)
+
+    for name in names:
+        jtms.add_belief(name)
+
+    # Add 1-6 justifications FIRST
+    n_just = draw(st.integers(min_value=1, max_value=6))
+    for _ in range(n_just):
+        candidates = list(names)
+        if len(candidates) < 2:
+            continue
+        in_list = draw(st.lists(
+            st.sampled_from(candidates), min_size=0, max_size=min(3, len(candidates)),
+            unique=True,
+        ))
+        remaining = [n for n in candidates if n not in in_list]
+        if remaining:
+            out_list = draw(st.lists(
+                st.sampled_from(remaining), min_size=0, max_size=2, unique=True,
+            ))
+        else:
+            out_list = []
+        conclusion_candidates = [n for n in candidates if n not in in_list and n not in out_list]
+        if not conclusion_candidates:
+            continue
+        conclusion = draw(st.sampled_from(conclusion_candidates))
+        jtms.add_justification(in_list, out_list, conclusion)
+
+    # THEN set some beliefs as valid (propagation follows justifications)
+    valid_count = draw(st.integers(min_value=0, max_value=len(names)))
+    valid_names = names[:valid_count]
+    for name in valid_names:
+        jtms.set_belief_validity(name, True)
+
+    return jtms, names, valid_names
+
+
+# --- Tests ---
+
+
+class TestJTMSJustificationConsistency:
+    """A belief marked valid must have at least one justification where all
+    in-beliefs are valid and all out-beliefs are invalid."""
+
+    @given(network=jtms_with_justifications())
+    @settings(max_examples=50, deadline=2000)
+    @pytest.mark.property
+    def test_valid_belief_has_satisfied_justification(self, network):
+        jtms, names, valid_names = network
+        directly_set = set(valid_names)
+
+        for name in names:
+            belief = jtms.beliefs[name]
+            if belief.valid is not True or belief.non_monotonic:
+                continue
+            if not belief.justifications:
+                continue
+            # Beliefs set directly may override justification logic — skip those
+            if name in directly_set:
+                continue
+            # This belief derived validity from propagation — invariant must hold
+            has_satisfied = False
+            for just in belief.justifications:
+                in_ok = all(b.valid is True for b in just.in_list)
+                out_ok = all(b.valid is not True for b in just.out_list)
+                if in_ok and out_ok:
+                    has_satisfied = True
+                    break
+            assert has_satisfied, (
+                f"Belief {name} is valid via propagation but no justification is satisfied"
+            )
+
+
+class TestJTMSRetractionCascade:
+    """Retracting a belief invalidates all beliefs whose only justification
+    depended on it."""
+
+    @given(n=st.integers(min_value=3, max_value=6))
+    @settings(max_examples=30, deadline=2000)
+    @pytest.mark.property
+    def test_retraction_invalidates_dependents(self, n):
+        jtms = JTMS()
+        names = [f"x{i}" for i in range(n)]
+        for name in names:
+            jtms.add_belief(name)
+
+        for i in range(n - 1):
+            jtms.add_justification([names[i]], [], names[i + 1])
+
+        jtms.set_belief_validity(names[0], True)
+
+        for name in names:
+            assert jtms.beliefs[name].valid is True, (
+                f"Expected {name} valid after setting {names[0]}=True"
+            )
+
+        jtms.set_belief_validity(names[0], False)
+
+        for name in names:
+            belief = jtms.beliefs[name]
+            if belief.justifications:
+                assert belief.valid is not True, (
+                    f"Belief {name} should be invalid after retracting {names[0]}"
+                )
+
+
+class TestJTMSRetractionCascadeTracing:
+    """Retraction tracing records cascaded invalidations."""
+
+    @given(
+        chain_len=st.integers(min_value=3, max_value=5),
+        n_side=st.integers(min_value=0, max_value=2),
+    )
+    @settings(max_examples=20, deadline=2000)
+    @pytest.mark.property
+    def test_tracing_records_cascaded_retractions(self, chain_len, n_side):
+        jtms = JTMS()
+        jtms.enable_tracing()
+
+        chain = [f"chain{i}" for i in range(chain_len)]
+        for name in chain:
+            jtms.add_belief(name)
+        for i in range(chain_len - 1):
+            jtms.add_justification([chain[i]], [], chain[i + 1])
+
+        side_nodes = [f"side{i}" for i in range(n_side)]
+        for i, name in enumerate(side_nodes):
+            jtms.add_belief(name)
+            parent_idx = min(i, chain_len - 1)
+            jtms.add_justification([chain[parent_idx]], [], name)
+
+        jtms.set_belief_validity(chain[0], True)
+        jtms.set_belief_validity(chain[0], False)
+
+        trace = jtms.get_retraction_chain()
+        assert len(trace) >= 1
+        assert trace[-1]["trigger"] == chain[0]
+
+        all_cascaded = []
+        for entry in trace:
+            all_cascaded.extend(entry["cascaded"])
+        downstream = chain[1:] + side_nodes
+        cascaded_set = set(all_cascaded)
+        assert len(cascaded_set & set(downstream)) >= 1
+
+
+class TestJTMSNoCircularSupport:
+    """Mutual dependencies (cycles of length >= 2) are detected and marked non-monotonic.
+    Self-loops (A → A) are NOT detected — this is a known limitation."""
+
+    @given(n=st.integers(min_value=2, max_value=4))
+    @settings(max_examples=15, deadline=2000)
+    @pytest.mark.property
+    def test_mutual_dependency_is_non_monotonic(self, n):
+        jtms = JTMS()
+        names = [f"c{i}" for i in range(n)]
+        for name in names:
+            jtms.add_belief(name)
+
+        for i in range(n):
+            next_i = (i + 1) % n
+            jtms.add_justification([names[i]], [], names[next_i])
+
+        for name in names:
+            assert jtms.beliefs[name].non_monotonic is True, (
+                f"Cycle member {name} should be non-monotonic"
+            )
+
+    @given(
+        n=st.integers(min_value=2, max_value=4),
+    )
+    @settings(max_examples=15, deadline=2000)
+    @pytest.mark.property
+    def test_non_cyclic_beliefs_are_not_non_monotonic(self, n):
+        """A simple chain A → B → C should NOT be non-monotonic."""
+        jtms = JTMS()
+        names = [f"n{i}" for i in range(n)]
+        for name in names:
+            jtms.add_belief(name)
+
+        for i in range(n - 1):
+            jtms.add_justification([names[i]], [], names[i + 1])
+
+        for name in names:
+            assert jtms.beliefs[name].non_monotonic is False, (
+                f"Non-cyclic belief {name} should not be non-monotonic"
+            )


### PR DESCRIPTION
## Summary
- 11 property-based tests (hypothesis) verifying deep invariants of ATMS and JTMS truth maintenance systems
- Adds `hypothesis` to `requirements-test.txt` and `property` marker to `pytest.ini`

## Tests added

### ATMS (6 tests)
| Test | Invariant |
|------|-----------|
| `test_invalidate_removes_supersets_concrete` | Contradiction propagation removes all supersets |
| `test_invalidate_removes_supersets_random` | Same, with random networks (hypothesis) |
| `test_adding_justification_preserves_environments` | Environment monotonicity |
| `test_contradiction_enforces_nogood` | Nogood enforcement after contradiction |
| `test_distinct_assumptions_give_distinct_singleton_envs` | Distinct labels |
| `test_derived_env_contains_assumptions` | Derived envs are unions of assumption envs |

### JTMS (5 tests)
| Test | Invariant |
|------|-----------|
| `test_valid_belief_has_satisfied_justification` | Justification chain consistency |
| `test_retraction_invalidates_dependents` | Retraction cascade |
| `test_tracing_records_cascaded_retractions` | Retraction tracing accuracy |
| `test_mutual_dependency_is_non_monotonic` | Cycle detection (mutual deps) |
| `test_non_cyclic_beliefs_are_not_non_monotonic` | No false positives on chains |

## Acceptance (#398 checklist)
- [x] >=10 property tests total across ATMS + JTMS (6 ATMS, 5 JTMS = 11)
- [x] All pass in <30s on CI (~6s locally)
- [x] `requirements-test.txt` updated with hypothesis
- [x] `pytest.ini` has `property` marker
- [x] CI green

## Test plan
- [x] `pytest tests/property/ -v` — 11 passed in 6.38s

🤖 Generated with [Claude Code](https://claude.com/claude-code)