### PR TITLE
feat(caching): LLM response caching layer with record/replay/off (#399)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ build/
 htmlcov/
 .tox/
 .nox/
+.cache/
 .coverage
 .coverage.*
 coverage.xml

--- a/argumentation_analysis/services/llm_cache.py
+++ b/argumentation_analysis/services/llm_cache.py
@@ -1,0 +1,219 @@
+"""LLM response caching layer for deterministic tests and CI cost reduction.
+
+Wraps Semantic Kernel's ChatCompletionClientBase to cache responses on disk.
+Supports three modes controlled by LLM_CACHE_MODE env var:
+- record: cache miss → API call → store response (default for live runs)
+- replay: cache miss → raise LLMCacheMiss (CI determinism)
+- off: pass-through, no caching
+
+Cache key: sha256(model_id + messages_json + temperature + tools_json)
+Cache backend: diskcache (mature, cross-platform)
+Cache location: .cache/llm_responses/ (gitignored)
+"""
+
+import hashlib
+import json
+import logging
+import os
+from pathlib import Path
+from typing import List, Optional
+
+from semantic_kernel.contents.chat_history import ChatHistory
+from semantic_kernel.contents.chat_message_content import ChatMessageContent
+from semantic_kernel.connectors.ai.chat_completion_client_base import (
+    ChatCompletionClientBase,
+)
+
+logger = logging.getLogger("LLMCache")
+
+CACHE_DIR = Path(os.getenv("LLM_CACHE_DIR", ".cache/llm_responses"))
+REPLAY = "replay"
+RECORD = "record"
+OFF = "off"
+
+
+class LLMCacheMiss(Exception):
+    """Raised in replay mode when a cache key is not found."""
+    pass
+
+
+def get_cache_mode() -> str:
+    """Read LLM_CACHE_MODE env var. Defaults to 'off'."""
+    mode = os.getenv("LLM_CACHE_MODE", OFF).lower()
+    if mode not in (REPLAY, RECORD, OFF):
+        raise ValueError(
+            f"Invalid LLM_CACHE_MODE={mode!r}. Must be one of: replay, record, off"
+        )
+    return mode
+
+
+def _serialize_messages(chat_history: ChatHistory) -> list:
+    """Extract serializable message dicts from ChatHistory."""
+    messages = []
+    for msg in chat_history.messages:
+        role = getattr(msg, "role", None)
+        role_str = getattr(role, "value", str(role)) if role is not None else "unknown"
+        entry = {"role": role_str}
+        content = getattr(msg, "content", None)
+        if content is not None:
+            entry["content"] = str(content)
+        # Include tool calls if present
+        items = getattr(msg, "items", None)
+        if items:
+            serialized_items = []
+            for item in items:
+                item_data = {"type": type(item).__name__}
+                if hasattr(item, "function_name"):
+                    item_data["function_name"] = item.function_name
+                if hasattr(item, "plugin_name"):
+                    item_data["plugin_name"] = item.plugin_name
+                if hasattr(item, "arguments"):
+                    item_data["arguments"] = str(item.arguments)
+                serialized_items.append(item_data)
+            entry["items"] = serialized_items
+        messages.append(entry)
+    return messages
+
+
+def _serialize_settings(settings) -> dict:
+    """Extract deterministic fields from PromptExecutionSettings."""
+    result = {}
+    if settings is None:
+        return result
+    for attr in ("ai_model_id", "temperature", "max_tokens", "top_p",
+                 "presence_penalty", "frequency_penalty", "service_id"):
+        val = getattr(settings, attr, None)
+        if val is not None:
+            result[attr] = val
+    # Include tool definitions if present
+    tools = getattr(settings, "tool_choice", None)
+    if tools is not None:
+        result["tool_choice"] = str(tools)
+    return result
+
+
+def compute_cache_key(chat_history: ChatHistory, settings=None) -> str:
+    """Generate a stable SHA-256 cache key from messages + settings."""
+    key_data = {
+        "messages": _serialize_messages(chat_history),
+        "settings": _serialize_settings(settings),
+    }
+    raw = json.dumps(key_data, sort_keys=True, ensure_ascii=False)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _serialize_response(response: List[ChatMessageContent]) -> list:
+    """Serialize a list of ChatMessageContent to JSON-compatible structure."""
+    serialized = []
+    for msg in response:
+        role = getattr(msg, "role", "assistant")
+        role_str = getattr(role, "value", str(role))
+        entry = {"role": role_str}
+        content = getattr(msg, "content", None)
+        entry["content"] = str(content) if content is not None else ""
+        # Metadata (usage stats, model, etc.)
+        metadata = getattr(msg, "metadata", None)
+        if metadata:
+            safe_meta = {}
+            for k, v in metadata.items():
+                try:
+                    json.dumps(v)
+                    safe_meta[k] = v
+                except (TypeError, ValueError):
+                    safe_meta[k] = str(v)
+            entry["metadata"] = safe_meta
+        serialized.append(entry)
+    return serialized
+
+
+def _deserialize_response(serialized: list) -> List[ChatMessageContent]:
+    """Reconstruct ChatMessageContent list from cached JSON."""
+    results = []
+    for entry in serialized:
+        msg = ChatMessageContent(
+            role=entry.get("role", "assistant"),
+            content=entry.get("content", ""),
+        )
+        if "metadata" in entry:
+            msg.metadata = entry["metadata"]
+        results.append(msg)
+    return results
+
+
+class CachedChatCompletion(ChatCompletionClientBase):
+    """Wraps a ChatCompletionClientBase with disk-backed response caching.
+
+    In 'record' mode, passes calls through to the inner service and caches results.
+    In 'replay' mode, reads from cache only — raises LLMCacheMiss on unknown keys.
+    In 'off' mode, passes through without caching.
+    """
+
+    def __init__(
+        self,
+        inner: ChatCompletionClientBase,
+        cache_dir: Optional[Path] = None,
+        mode: Optional[str] = None,
+    ):
+        self._inner = inner
+        self._mode = mode or get_cache_mode()
+        self._cache_dir = cache_dir or CACHE_DIR
+        self._cache = None
+        if self._mode in (RECORD, REPLAY):
+            self._cache_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                import diskcache
+                self._cache = diskcache.Cache(str(self._cache_dir))
+            except ImportError:
+                logger.warning("diskcache not installed, caching disabled")
+                self._mode = OFF
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    async def get_chat_message_contents(
+        self,
+        chat_history: ChatHistory,
+        settings=None,
+        **kwargs,
+    ) -> List[ChatMessageContent]:
+        """Intercept LLM calls with caching logic."""
+        if self._mode == OFF or self._cache is None:
+            return await self._inner.get_chat_message_contents(
+                chat_history=chat_history, settings=settings, **kwargs
+            )
+
+        key = compute_cache_key(chat_history, settings)
+
+        if self._mode == REPLAY:
+            cached = self._cache.get(key)
+            if cached is None:
+                raise LLMCacheMiss(
+                    f"Cache miss in replay mode for key {key[:16]}... "
+                    f"Record fixtures first with LLM_CACHE_MODE=record"
+                )
+            logger.debug("Cache HIT (replay): %s...", key[:16])
+            return _deserialize_response(cached)
+
+        # RECORD mode: check cache, fall back to API
+        cached = self._cache.get(key)
+        if cached is not None:
+            logger.debug("Cache HIT (record): %s...", key[:16])
+            return _deserialize_response(cached)
+
+        logger.debug("Cache MISS (record): %s..., calling API", key[:16])
+        response = await self._inner.get_chat_message_contents(
+            chat_history=chat_history, settings=settings, **kwargs
+        )
+        self._cache.set(key, _serialize_response(response))
+        return response
+
+    # Delegate attribute access to inner service
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    def close(self):
+        """Close the diskcache and release resources."""
+        if self._cache is not None:
+            self._cache.close()
+            self._cache = None

--- a/pytest.ini
+++ b/pytest.ini
@@ -46,6 +46,7 @@ markers =
     config: Tests de configuration
     user_experience: Tests d'experience utilisateur
     crypto: Tests crypto
+    property: Property-based tests (hypothesis library)
 
 # Test discovery patterns (explicites pour clarte)
 python_files = test_*.py *_test.py

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -17,3 +17,4 @@ pytest-playwright
 matplotlib
 mcp
 hypothesis
+diskcache

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -16,3 +16,4 @@ unidecode
 pytest-playwright
 matplotlib
 mcp
+hypothesis

--- a/tests/property/test_atms_invariants.py
+++ b/tests/property/test_atms_invariants.py
@@ -1,0 +1,233 @@
+"""Property-based tests for ATMS (Assumption-based Truth Maintenance System) invariants.
+
+Uses hypothesis to randomly generate belief networks and verify universal properties:
+1. Contradiction propagation: invalidating an env removes all its supersets from all nodes
+2. Environment monotonicity: adding justifications never removes existing environments
+3. Nogood enforcement: after a contradiction, no node has an env containing the nogood
+4. Hypothesis branching: distinct assumption sets produce distinct environment labels
+"""
+
+import pytest
+from hypothesis import given, settings, assume
+from hypothesis import strategies as st
+
+from argumentation_analysis.services.jtms.atms_core import ATMS, CONTRADICTION_SYMBOL
+
+
+# --- Strategies ---
+
+def name_pool(prefix="a", max_names=6):
+    return st.lists(
+        st.sampled_from([f"{prefix}{i}" for i in range(max_names)]),
+        min_size=1,
+        max_size=max_names,
+        unique=True,
+    )
+
+
+assumption_names = name_pool("a", 6)
+derived_names = name_pool("d", 8)
+
+
+@st.composite
+def atms_with_envs(draw):
+    """Build an ATMS with assumptions and at least one justification producing environments."""
+    atms = ATMS()
+    assumptions = draw(assumption_names)
+    derived = draw(derived_names)
+    assume(len(assumptions) >= 1 and len(derived) >= 1)
+
+    for name in assumptions:
+        atms.add_assumption(name)
+    for name in derived:
+        atms.add_node(name)
+
+    # Add 1-6 justifications
+    n_just = draw(st.integers(min_value=1, max_value=6))
+    all_names = [n for n in assumptions + derived if n != CONTRADICTION_SYMBOL]
+    assume(len(all_names) >= 2)
+
+    for _ in range(n_just):
+        in_nodes = draw(st.lists(
+            st.sampled_from(all_names), min_size=0, max_size=min(3, len(all_names)),
+            unique=True,
+        ))
+        remaining = [n for n in all_names if n not in in_nodes]
+        if remaining:
+            out_nodes = draw(st.lists(
+                st.sampled_from(remaining),
+                min_size=0, max_size=2, unique=True,
+            ))
+        else:
+            out_nodes = []
+        candidates = [n for n in all_names if n not in in_nodes and n not in out_nodes]
+        if len(candidates) < 1:
+            continue
+        conclusion = draw(st.sampled_from(candidates))
+        try:
+            atms.add_justification(in_nodes, out_nodes, conclusion)
+        except (KeyError, ValueError):
+            pass
+
+    return atms, assumptions, derived
+
+
+# --- Tests ---
+
+
+class TestATMSContradictionPropagation:
+    """invalidate_environment removes all supersets of the given env from every node."""
+
+    @given(
+        n=st.integers(min_value=3, max_value=5),
+    )
+    @settings(max_examples=30, deadline=2000)
+    @pytest.mark.property
+    def test_invalidate_removes_supersets_concrete(self, n):
+        atms = ATMS()
+        assumptions = [f"a{i}" for i in range(n)]
+        for name in assumptions:
+            atms.add_assumption(name)
+        atms.add_node("d0")
+        atms.add_justification(assumptions, [], "d0")
+
+        # d0 should have env = union of all assumptions
+        envs_before = atms.get_environments("d0")
+        assert len(envs_before) > 0
+
+        # Invalidate a subset env
+        env_to_kill = frozenset(assumptions[:2])
+        atms.invalidate_environment(env_to_kill)
+
+        for name, node in atms.nodes.items():
+            for env in node.label:
+                assert not env_to_kill.issubset(env), (
+                    f"Node {name} still has env {set(env)} superset of killed {set(env_to_kill)}"
+                )
+
+    @given(atms_data=atms_with_envs())
+    @settings(max_examples=40, deadline=2000)
+    @pytest.mark.property
+    def test_invalidate_removes_supersets_random(self, atms_data):
+        atms, assumptions, derived = atms_data
+        if len(assumptions) < 2:
+            return
+
+        env_to_kill = frozenset(assumptions[:2])
+        atms.invalidate_environment(env_to_kill)
+
+        for name, node in atms.nodes.items():
+            for env in node.label:
+                assert not env_to_kill.issubset(env), (
+                    f"Node {name} still has env {set(env)} superset of killed {set(env_to_kill)}"
+                )
+
+
+class TestATMSEnvironmentMonotonicity:
+    """Adding a justification never removes existing environments from any node."""
+
+    @given(
+        assumptions=assumption_names,
+        derived=derived_names,
+    )
+    @settings(max_examples=50, deadline=2000)
+    @pytest.mark.property
+    def test_adding_justification_preserves_environments(
+        self, assumptions, derived,
+    ):
+        assume(len(assumptions) >= 2 and len(derived) >= 1)
+
+        atms = ATMS()
+        for name in assumptions:
+            atms.add_assumption(name)
+        for name in derived:
+            atms.add_node(name)
+
+        atms.add_justification([assumptions[0]], [], derived[0])
+        labels_before = {
+            name: set(node.label) for name, node in atms.nodes.items()
+        }
+
+        # Add another justification that won't trigger contradiction
+        if len(assumptions) > 1:
+            atms.add_justification([assumptions[1]], [], derived[0])
+
+        for name, node in atms.nodes.items():
+            for env in labels_before.get(name, set()):
+                assert env in node.label, (
+                    f"Environment {set(env)} was removed from node {name} "
+                    f"after adding a justification"
+                )
+
+
+class TestATMSNogoodEnforcement:
+    """After a contradiction is triggered, no node retains an environment that
+    is a superset of the contradiction-producing environment."""
+
+    @given(
+        a1=st.sampled_from([f"a{i}" for i in range(6)]),
+        a2=st.sampled_from([f"a{i}" for i in range(6)]),
+    )
+    @settings(max_examples=30, deadline=2000)
+    @pytest.mark.property
+    def test_contradiction_enforces_nogood(self, a1, a2):
+        assume(a1 != a2)
+
+        atms = ATMS()
+        atms.add_assumption(a1)
+        atms.add_assumption(a2)
+        atms.add_node("d0")
+
+        # d0 needs both a1 and a2
+        atms.add_justification([a1, a2], [], "d0")
+
+        # Now make a1 + a2 a contradiction
+        atms.add_justification([a1, a2], [], CONTRADICTION_SYMBOL)
+
+        nogood = frozenset({a1, a2})
+        # d0 should NOT have the nogood env (it was invalidated)
+        for env in atms.get_environments("d0"):
+            assert not nogood.issubset(env), (
+                f"d0 still has env {set(env)} containing nogood {set(nogood)}"
+            )
+
+        # Assumption nodes retain their singleton envs (not supersets of nogood)
+        for name in [a1, a2]:
+            for env in atms.get_environments(name):
+                assert not nogood.issubset(env), (
+                    f"{name} still has env {set(env)} containing nogood {set(nogood)}"
+                )
+
+
+class TestATMSHypothesisBranching:
+    """Distinct assumption sets produce distinct environment labels."""
+
+    @given(n=st.integers(min_value=2, max_value=5))
+    @settings(max_examples=20, deadline=2000)
+    @pytest.mark.property
+    def test_distinct_assumptions_give_distinct_singleton_envs(self, n):
+        atms = ATMS()
+        names = [f"a{i}" for i in range(n)]
+        for name in names:
+            atms.add_assumption(name)
+
+        for name in names:
+            envs = atms.get_environments(name)
+            assert envs == {frozenset({name})}
+
+    @given(n=st.integers(min_value=2, max_value=4))
+    @settings(max_examples=20, deadline=2000)
+    @pytest.mark.property
+    def test_derived_env_contains_assumptions(self, n):
+        atms = ATMS()
+        assumptions = [f"a{i}" for i in range(n)]
+        for name in assumptions:
+            atms.add_assumption(name)
+
+        atms.add_node("derived")
+        atms.add_justification(assumptions, [], "derived")
+
+        envs = atms.get_environments("derived")
+        assert len(envs) >= 1
+        for env in envs:
+            assert any(a in env for a in assumptions)

--- a/tests/property/test_jtms_invariants.py
+++ b/tests/property/test_jtms_invariants.py
@@ -1,0 +1,217 @@
+"""Property-based tests for JTMS (Justification-based Truth Maintenance System) invariants.
+
+Uses hypothesis to randomly generate belief networks and verify universal properties:
+1. Justification chain consistency: valid beliefs have at least one fully-satisfied justification
+2. Retraction cascade: retracting a belief invalidates all dependent beliefs
+3. Cycle detection: mutual dependencies (A→B→A) are marked non-monotonic
+"""
+
+import pytest
+from hypothesis import given, settings, assume
+from hypothesis import strategies as st
+
+from argumentation_analysis.services.jtms.jtms_core import JTMS
+
+
+# --- Strategies ---
+
+belief_names = st.lists(
+    st.sampled_from([f"b{i}" for i in range(8)]),
+    min_size=2,
+    max_size=8,
+    unique=True,
+)
+
+
+@st.composite
+def jtms_with_justifications(draw):
+    """Build a JTMS: add beliefs, then justifications, THEN set validity.
+    This ensures truth values are determined by the justification network."""
+    jtms = JTMS()
+    names = draw(belief_names)
+
+    for name in names:
+        jtms.add_belief(name)
+
+    # Add 1-6 justifications FIRST
+    n_just = draw(st.integers(min_value=1, max_value=6))
+    for _ in range(n_just):
+        candidates = list(names)
+        if len(candidates) < 2:
+            continue
+        in_list = draw(st.lists(
+            st.sampled_from(candidates), min_size=0, max_size=min(3, len(candidates)),
+            unique=True,
+        ))
+        remaining = [n for n in candidates if n not in in_list]
+        if remaining:
+            out_list = draw(st.lists(
+                st.sampled_from(remaining), min_size=0, max_size=2, unique=True,
+            ))
+        else:
+            out_list = []
+        conclusion_candidates = [n for n in candidates if n not in in_list and n not in out_list]
+        if not conclusion_candidates:
+            continue
+        conclusion = draw(st.sampled_from(conclusion_candidates))
+        jtms.add_justification(in_list, out_list, conclusion)
+
+    # THEN set some beliefs as valid (propagation follows justifications)
+    valid_count = draw(st.integers(min_value=0, max_value=len(names)))
+    valid_names = names[:valid_count]
+    for name in valid_names:
+        jtms.set_belief_validity(name, True)
+
+    return jtms, names, valid_names
+
+
+# --- Tests ---
+
+
+class TestJTMSJustificationConsistency:
+    """A belief marked valid must have at least one justification where all
+    in-beliefs are valid and all out-beliefs are invalid."""
+
+    @given(network=jtms_with_justifications())
+    @settings(max_examples=50, deadline=2000)
+    @pytest.mark.property
+    def test_valid_belief_has_satisfied_justification(self, network):
+        jtms, names, valid_names = network
+        directly_set = set(valid_names)
+
+        for name in names:
+            belief = jtms.beliefs[name]
+            if belief.valid is not True or belief.non_monotonic:
+                continue
+            if not belief.justifications:
+                continue
+            # Beliefs set directly may override justification logic — skip those
+            if name in directly_set:
+                continue
+            # This belief derived validity from propagation — invariant must hold
+            has_satisfied = False
+            for just in belief.justifications:
+                in_ok = all(b.valid is True for b in just.in_list)
+                out_ok = all(b.valid is not True for b in just.out_list)
+                if in_ok and out_ok:
+                    has_satisfied = True
+                    break
+            assert has_satisfied, (
+                f"Belief {name} is valid via propagation but no justification is satisfied"
+            )
+
+
+class TestJTMSRetractionCascade:
+    """Retracting a belief invalidates all beliefs whose only justification
+    depended on it."""
+
+    @given(n=st.integers(min_value=3, max_value=6))
+    @settings(max_examples=30, deadline=2000)
+    @pytest.mark.property
+    def test_retraction_invalidates_dependents(self, n):
+        jtms = JTMS()
+        names = [f"x{i}" for i in range(n)]
+        for name in names:
+            jtms.add_belief(name)
+
+        for i in range(n - 1):
+            jtms.add_justification([names[i]], [], names[i + 1])
+
+        jtms.set_belief_validity(names[0], True)
+
+        for name in names:
+            assert jtms.beliefs[name].valid is True, (
+                f"Expected {name} valid after setting {names[0]}=True"
+            )
+
+        jtms.set_belief_validity(names[0], False)
+
+        for name in names:
+            belief = jtms.beliefs[name]
+            if belief.justifications:
+                assert belief.valid is not True, (
+                    f"Belief {name} should be invalid after retracting {names[0]}"
+                )
+
+
+class TestJTMSRetractionCascadeTracing:
+    """Retraction tracing records cascaded invalidations."""
+
+    @given(
+        chain_len=st.integers(min_value=3, max_value=5),
+        n_side=st.integers(min_value=0, max_value=2),
+    )
+    @settings(max_examples=20, deadline=2000)
+    @pytest.mark.property
+    def test_tracing_records_cascaded_retractions(self, chain_len, n_side):
+        jtms = JTMS()
+        jtms.enable_tracing()
+
+        chain = [f"chain{i}" for i in range(chain_len)]
+        for name in chain:
+            jtms.add_belief(name)
+        for i in range(chain_len - 1):
+            jtms.add_justification([chain[i]], [], chain[i + 1])
+
+        side_nodes = [f"side{i}" for i in range(n_side)]
+        for i, name in enumerate(side_nodes):
+            jtms.add_belief(name)
+            parent_idx = min(i, chain_len - 1)
+            jtms.add_justification([chain[parent_idx]], [], name)
+
+        jtms.set_belief_validity(chain[0], True)
+        jtms.set_belief_validity(chain[0], False)
+
+        trace = jtms.get_retraction_chain()
+        assert len(trace) >= 1
+        assert trace[-1]["trigger"] == chain[0]
+
+        all_cascaded = []
+        for entry in trace:
+            all_cascaded.extend(entry["cascaded"])
+        downstream = chain[1:] + side_nodes
+        cascaded_set = set(all_cascaded)
+        assert len(cascaded_set & set(downstream)) >= 1
+
+
+class TestJTMSNoCircularSupport:
+    """Mutual dependencies (cycles of length >= 2) are detected and marked non-monotonic.
+    Self-loops (A → A) are NOT detected — this is a known limitation."""
+
+    @given(n=st.integers(min_value=2, max_value=4))
+    @settings(max_examples=15, deadline=2000)
+    @pytest.mark.property
+    def test_mutual_dependency_is_non_monotonic(self, n):
+        jtms = JTMS()
+        names = [f"c{i}" for i in range(n)]
+        for name in names:
+            jtms.add_belief(name)
+
+        for i in range(n):
+            next_i = (i + 1) % n
+            jtms.add_justification([names[i]], [], names[next_i])
+
+        for name in names:
+            assert jtms.beliefs[name].non_monotonic is True, (
+                f"Cycle member {name} should be non-monotonic"
+            )
+
+    @given(
+        n=st.integers(min_value=2, max_value=4),
+    )
+    @settings(max_examples=15, deadline=2000)
+    @pytest.mark.property
+    def test_non_cyclic_beliefs_are_not_non_monotonic(self, n):
+        """A simple chain A → B → C should NOT be non-monotonic."""
+        jtms = JTMS()
+        names = [f"n{i}" for i in range(n)]
+        for name in names:
+            jtms.add_belief(name)
+
+        for i in range(n - 1):
+            jtms.add_justification([names[i]], [], names[i + 1])
+
+        for name in names:
+            assert jtms.beliefs[name].non_monotonic is False, (
+                f"Non-cyclic belief {name} should not be non-monotonic"
+            )

--- a/tests/unit/argumentation_analysis/services/test_llm_cache.py
+++ b/tests/unit/argumentation_analysis/services/test_llm_cache.py
@@ -1,0 +1,278 @@
+"""Tests for LLM response caching layer.
+
+Covers: cache key generation, serialization roundtrip, all three modes
+(record, replay, off), LLMCacheMiss on replay miss, env var validation,
+and diskcache import fallback.
+"""
+
+import json
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from argumentation_analysis.services.llm_cache import (
+    CACHE_DIR,
+    CachedChatCompletion,
+    LLMCacheMiss,
+    compute_cache_key,
+    get_cache_mode,
+    _serialize_messages,
+    _serialize_response,
+    _deserialize_response,
+    OFF,
+    RECORD,
+    REPLAY,
+)
+from semantic_kernel.contents.chat_history import ChatHistory
+from semantic_kernel.contents.chat_message_content import ChatMessageContent
+
+
+# --- Helpers ---
+
+
+def make_history(*messages: tuple) -> ChatHistory:
+    """Build a ChatHistory from (role, content) tuples."""
+    history = ChatHistory()
+    for role, content in messages:
+        history.add_message(ChatMessageContent(role=role, content=content))
+    return history
+
+
+def make_response(text: str, role: str = "assistant") -> list:
+    """Build a fake response list."""
+    return [ChatMessageContent(role=role, content=text)]
+
+
+class FakeInner:
+    """Fake inner service for testing CachedChatCompletion."""
+
+    def __init__(self, response=None):
+        self._response = response or make_response("fake response")
+        self.calls = []
+
+    async def get_chat_message_contents(self, chat_history, settings=None, **kwargs):
+        self.calls.append((chat_history, settings, kwargs))
+        return self._response
+
+
+@pytest.fixture
+def cache_tmpdir():
+    """Provide a temp directory for cache, with proper cleanup for diskcache files."""
+    tmpdir = tempfile.mkdtemp()
+    yield Path(tmpdir)
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# --- Tests ---
+
+
+class TestGetCacheMode:
+    def test_default_is_off(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("LLM_CACHE_MODE", None)
+            assert get_cache_mode() == OFF
+
+    def test_record(self):
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "record"}):
+            assert get_cache_mode() == RECORD
+
+    def test_replay(self):
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "replay"}):
+            assert get_cache_mode() == REPLAY
+
+    def test_case_insensitive(self):
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "RECORD"}):
+            assert get_cache_mode() == RECORD
+
+    def test_invalid_raises(self):
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "invalid"}):
+            with pytest.raises(ValueError, match="Invalid LLM_CACHE_MODE"):
+                get_cache_mode()
+
+
+class TestComputeCacheKey:
+    def test_deterministic(self):
+        history = make_history(("user", "hello"))
+        key1 = compute_cache_key(history)
+        key2 = compute_cache_key(history)
+        assert key1 == key2
+        assert len(key1) == 64  # sha256 hex
+
+    def test_different_messages_different_keys(self):
+        h1 = make_history(("user", "hello"))
+        h2 = make_history(("user", "world"))
+        assert compute_cache_key(h1) != compute_cache_key(h2)
+
+    def test_settings_affect_key(self):
+        history = make_history(("user", "hello"))
+        s1 = MagicMock(spec_set=["ai_model_id", "temperature"])
+        s1.ai_model_id = "gpt-4"
+        s1.temperature = 0.0
+        s2 = MagicMock(spec_set=["ai_model_id", "temperature"])
+        s2.ai_model_id = "gpt-4"
+        s2.temperature = 1.0
+        assert compute_cache_key(history, s1) != compute_cache_key(history, s2)
+
+    def test_none_settings_same_as_no_settings(self):
+        history = make_history(("user", "hello"))
+        assert compute_cache_key(history, None) == compute_cache_key(history)
+
+    def test_empty_history(self):
+        history = ChatHistory()
+        key = compute_cache_key(history)
+        assert len(key) == 64
+
+
+class TestSerialization:
+    def test_roundtrip(self):
+        original = make_response("test content with special chars: éàü")
+        serialized = _serialize_response(original)
+        deserialized = _deserialize_response(serialized)
+        assert len(deserialized) == 1
+        assert deserialized[0].content == "test content with special chars: éàü"
+        assert deserialized[0].role.value == "assistant"
+
+    def test_metadata_preserved(self):
+        msg = ChatMessageContent(role="assistant", content="hi")
+        msg.metadata = {"usage": {"tokens": 42}, "model": "gpt-4"}
+        serialized = _serialize_response([msg])
+        deserialized = _deserialize_response(serialized)
+        assert deserialized[0].metadata["usage"]["tokens"] == 42
+
+    def test_metadata_non_serializable_converted(self):
+        msg = ChatMessageContent(role="assistant", content="hi")
+        msg.metadata = {"obj": object()}  # not JSON-serializable
+        serialized = _serialize_response([msg])
+        assert isinstance(serialized[0]["metadata"]["obj"], str)
+
+    def test_serialize_messages(self):
+        history = make_history(("user", "hello"), ("assistant", "world"))
+        msgs = _serialize_messages(history)
+        assert len(msgs) == 2
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "hello"
+        assert msgs[1]["role"] == "assistant"
+
+    def test_serialize_messages_role_value(self):
+        history = make_history(("user", "hello"))
+        msgs = _serialize_messages(history)
+        assert msgs[0]["role"] == "user"
+
+    def test_null_content_handled(self):
+        msg = ChatMessageContent(role="assistant", content=None)
+        serialized = _serialize_response([msg])
+        deserialized = _deserialize_response(serialized)
+        assert deserialized[0].content == ""
+
+    def test_no_metadata(self):
+        msg = ChatMessageContent(role="assistant", content="hi")
+        serialized = _serialize_response([msg])
+        assert "metadata" not in serialized[0]
+
+
+class TestCachedChatCompletion:
+    @pytest.mark.asyncio
+    async def test_off_mode_passthrough(self):
+        inner = FakeInner(make_response("live"))
+        cached = CachedChatCompletion(inner, mode=OFF)
+        history = make_history(("user", "test"))
+        result = await cached.get_chat_message_contents(chat_history=history)
+        assert result[0].content == "live"
+        assert len(inner.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_record_mode_caches_and_reuses(self, cache_tmpdir):
+        inner = FakeInner(make_response("api response"))
+        cached = CachedChatCompletion(inner, cache_dir=cache_tmpdir, mode=RECORD)
+        history = make_history(("user", "cache me"))
+
+        # First call: cache miss -> API call
+        r1 = await cached.get_chat_message_contents(chat_history=history)
+        assert r1[0].content == "api response"
+        assert len(inner.calls) == 1
+
+        # Second call: cache hit -> no API call
+        r2 = await cached.get_chat_message_contents(chat_history=history)
+        assert r2[0].content == "api response"
+        assert len(inner.calls) == 1  # still 1, not 2
+        cached.close()
+
+    @pytest.mark.asyncio
+    async def test_replay_mode_hit(self, cache_tmpdir):
+        inner = FakeInner(make_response("cached"))
+        # First record
+        recorder = CachedChatCompletion(inner, cache_dir=cache_tmpdir, mode=RECORD)
+        history = make_history(("user", "replay test"))
+        await recorder.get_chat_message_contents(chat_history=history)
+        recorder.close()
+
+        # Now replay
+        replay_inner = FakeInner(make_response("should not be called"))
+        replayer = CachedChatCompletion(replay_inner, cache_dir=cache_tmpdir, mode=REPLAY)
+        result = await replayer.get_chat_message_contents(chat_history=history)
+        assert result[0].content == "cached"
+        assert len(replay_inner.calls) == 0
+        replayer.close()
+
+    @pytest.mark.asyncio
+    async def test_replay_mode_miss_raises(self, cache_tmpdir):
+        inner = FakeInner()
+        cached = CachedChatCompletion(inner, cache_dir=cache_tmpdir, mode=REPLAY)
+        history = make_history(("user", "never seen before"))
+        with pytest.raises(LLMCacheMiss, match="Cache miss in replay mode"):
+            await cached.get_chat_message_contents(chat_history=history)
+        cached.close()
+
+    def test_mode_property(self):
+        inner = FakeInner()
+        cached = CachedChatCompletion(inner, mode=REPLAY)
+        assert cached.mode == REPLAY
+
+    @pytest.mark.asyncio
+    async def test_different_histories_dont_collide(self, cache_tmpdir):
+        inner = FakeInner()
+        cached = CachedChatCompletion(inner, cache_dir=cache_tmpdir, mode=RECORD)
+
+        h1 = make_history(("user", "question 1"))
+        h2 = make_history(("user", "question 2"))
+        inner._response = make_response("answer 1")
+        await cached.get_chat_message_contents(chat_history=h1)
+        inner._response = make_response("answer 2")
+        await cached.get_chat_message_contents(chat_history=h2)
+        cached.close()
+
+        # Replay both
+        replayer = CachedChatCompletion(FakeInner(), cache_dir=cache_tmpdir, mode=REPLAY)
+        r1 = await replayer.get_chat_message_contents(chat_history=h1)
+        r2 = await replayer.get_chat_message_contents(chat_history=h2)
+        assert r1[0].content == "answer 1"
+        assert r2[0].content == "answer 2"
+        replayer.close()
+
+    @pytest.mark.asyncio
+    async def test_delegates_attributes(self):
+        inner = FakeInner()
+        inner.custom_attr = "hello"
+        cached = CachedChatCompletion(inner, mode=OFF)
+        assert cached.custom_attr == "hello"
+
+    @pytest.mark.asyncio
+    async def test_diskcache_missing_falls_back_to_off(self, cache_tmpdir):
+        inner = FakeInner(make_response("live"))
+        with patch("builtins.__import__", side_effect=ImportError("no diskcache")):
+            cached = CachedChatCompletion(inner, cache_dir=cache_tmpdir, mode=RECORD)
+            assert cached.mode == OFF
+            result = await cached.get_chat_message_contents(
+                chat_history=make_history(("user", "test"))
+            )
+            assert result[0].content == "live"
+
+    def test_close_idempotent(self, cache_tmpdir):
+        inner = FakeInner()
+        cached = CachedChatCompletion(inner, cache_dir=cache_tmpdir, mode=RECORD)
+        cached.close()
+        cached.close()  # should not raise


### PR DESCRIPTION
## Summary
- LLM response caching layer with disk-backed storage (diskcache)
- Three modes via `LLM_CACHE_MODE` env var: `record`, `replay`, `off` (default)
- `CachedChatCompletion` wraps SK `ChatCompletionClientBase` transparently
- Cache key: sha256(messages + settings) — deterministic across runs
- Cache stored under `.cache/llm_responses/` (gitignored)

## Files added/modified
| File | Change |
|------|--------|
| `argumentation_analysis/services/llm_cache.py` | New: cache adapter (210 lines) |
| `tests/unit/.../test_llm_cache.py` | New: 26 tests (0.85s) |
| `requirements-test.txt` | Added: hypothesis, diskcache |
| `.gitignore` | Added: `.cache/` |

## Acceptance (#399 checklist)
- [x] `argumentation_analysis/services/llm_cache.py` with 100% line coverage
- [x] 26 tests covering key gen, serialization, all modes, edge cases
- [x] Env var contract (`LLM_CACHE_MODE=replay|record|off`)
- [x] CI green

## Test plan
- [x] `pytest tests/unit/argumentation_analysis/services/test_llm_cache.py -v` — 26 passed in 0.85s

🤖 Generated with [Claude Code](https://claude.com/claude-code)