### PR TITLE
feat(lint): mypy strict mode on 8 core orchestration modules (#401)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
         run: |
           conda run -n projet-is --no-capture-output flake8 argumentation_analysis/ tests/ api/ project_core/
 
+      - name: Type check (mypy strict — core orchestration)
+        shell: pwsh
+        run: |
+          conda run -n projet-is --no-capture-output python -m mypy --config-file pyproject.toml argumentation_analysis/core/capability_registry.py argumentation_analysis/core/shared_state.py argumentation_analysis/orchestration/workflow_dsl.py argumentation_analysis/orchestration/registry_setup.py argumentation_analysis/orchestration/workflows.py argumentation_analysis/orchestration/invoke_callables.py argumentation_analysis/orchestration/state_writers.py argumentation_analysis/agents/factory.py
+
   automated-tests:
     runs-on: windows-latest
     # Run tests independently of lint — lint failures should not block test execution

--- a/api/mobile_endpoints.py
+++ b/api/mobile_endpoints.py
@@ -100,19 +100,23 @@ async def mobile_analyze(request: TextRequest):
         arguments = []
         for i, arg in enumerate(result_dict.get("identified_arguments", {}).items()):
             arg_id, desc = arg
-            arguments.append(ArgumentResult(
-                id=arg_id,
-                text=desc,
-                conclusion=desc,
-            ))
+            arguments.append(
+                ArgumentResult(
+                    id=arg_id,
+                    text=desc,
+                    conclusion=desc,
+                )
+            )
 
         fallacies_raw = result_dict.get("identified_fallacies", {})
         if not arguments and result_dict.get("summary"):
-            arguments.append(ArgumentResult(
-                id="summary",
-                text=result_dict["summary"],
-                conclusion=result_dict.get("summary", ""),
-            ))
+            arguments.append(
+                ArgumentResult(
+                    id="summary",
+                    text=result_dict["summary"],
+                    conclusion=result_dict.get("summary", ""),
+                )
+            )
 
         return AnalyzeResponse(
             text=request.text,
@@ -123,11 +127,13 @@ async def mobile_analyze(request: TextRequest):
         logger.error(f"Mobile analyze failed: {e}")
         return AnalyzeResponse(
             text=request.text,
-            arguments=[ArgumentResult(
-                id="error",
-                text=f"Analysis unavailable: {e}",
-                conclusion=str(e),
-            )],
+            arguments=[
+                ArgumentResult(
+                    id="error",
+                    text=f"Analysis unavailable: {e}",
+                    conclusion=str(e),
+                )
+            ],
             overall_quality=0.0,
         )
 
@@ -149,11 +155,13 @@ async def mobile_fallacies(request: TextRequest):
         fallacies = []
         for fid, fdata in result_dict.get("identified_fallacies", {}).items():
             if isinstance(fdata, dict):
-                fallacies.append(FallacyInstance(
-                    type=fdata.get("type", fid),
-                    confidence=0.8,
-                    explanation=fdata.get("justification", ""),
-                ))
+                fallacies.append(
+                    FallacyInstance(
+                        type=fdata.get("type", fid),
+                        confidence=0.8,
+                        explanation=fdata.get("justification", ""),
+                    )
+                )
 
         return FallacyResponse(
             text=request.text,
@@ -187,7 +195,10 @@ async def mobile_validate(request: TextRequest):
             valid=bool(toulmin.claim and toulmin.data),
             formalization=ValidationFormalization(
                 type="toulmin",
-                premises=[d.content if hasattr(d, "content") else str(d) for d in (toulmin.data or [])],
+                premises=[
+                    d.content if hasattr(d, "content") else str(d)
+                    for d in (toulmin.data or [])
+                ],
                 conclusion=toulmin.claim or "",
                 rule=toulmin.warrant or "",
             ),
@@ -233,7 +244,9 @@ async def mobile_chat(request: ChatRequest):
 
         result = await run_unified_analysis(request.message, workflow_name="light")
         result_dict = result if isinstance(result, dict) else {"raw": str(result)}
-        summary = result_dict.get("summary", result_dict.get("raw", "Analysis complete."))
+        summary = result_dict.get(
+            "summary", result_dict.get("raw", "Analysis complete.")
+        )
 
         return ChatResponse(
             message=summary,

--- a/api/proposal_endpoints.py
+++ b/api/proposal_endpoints.py
@@ -154,8 +154,14 @@ async def list_capabilities():
         for name, reg in registry._registrations.items():
             info = CapabilityInfo(
                 name=name,
-                type=reg.component_type.value if hasattr(reg.component_type, "value") else str(reg.component_type),
-                capabilities=list(reg.capabilities) if hasattr(reg, "capabilities") else [],
+                type=(
+                    reg.component_type.value
+                    if hasattr(reg.component_type, "value")
+                    else str(reg.component_type)
+                ),
+                capabilities=(
+                    list(reg.capabilities) if hasattr(reg, "capabilities") else []
+                ),
             )
             if "agent" in info.type.lower():
                 agents.append(info)
@@ -165,8 +171,13 @@ async def list_capabilities():
                 services.append(info)
 
         workflows = [
-            "light", "standard", "full", "auto",
-            "democratech", "debate_tournament", "fact_check",
+            "light",
+            "standard",
+            "full",
+            "auto",
+            "democratech",
+            "debate_tournament",
+            "fact_check",
         ]
 
         return CapabilitiesResponse(
@@ -212,6 +223,4 @@ async def run_custom_workflow(request: CustomWorkflowRequest):
         )
     except Exception as e:
         logger.error(f"Custom workflow failed: {e}")
-        return WorkflowResult(
-            workflow=request.workflow, status="failed", error=str(e)
-        )
+        return WorkflowResult(workflow=request.workflow, status="failed", error=str(e))

--- a/api/proposal_models.py
+++ b/api/proposal_models.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Dict, List, Literal, Optional
 from pydantic import BaseModel, Field
 
-
 # ──── Enums ────
 
 
@@ -43,14 +42,17 @@ class VoteCreate(BaseModel):
 class DeliberationRequest(BaseModel):
     proposal_id: str = Field(..., description="ID of the proposal to deliberate on")
     workflow: str = Field(
-        "democratech", description="Workflow to use (democratech, debate_tournament, fact_check)"
+        "democratech",
+        description="Workflow to use (democratech, debate_tournament, fact_check)",
     )
     options: Dict = Field(default_factory=dict, description="Workflow-specific options")
 
 
 class CustomWorkflowRequest(BaseModel):
     text: str = Field(..., description="Input text for analysis")
-    workflow: str = Field(..., description="Workflow name (light, standard, full, auto)")
+    workflow: str = Field(
+        ..., description="Workflow name (light, standard, full, auto)"
+    )
     options: Dict = Field(default_factory=dict)
 
 

--- a/api/proposal_service.py
+++ b/api/proposal_service.py
@@ -134,7 +134,11 @@ class ProposalStore:
 
 
 async def run_deliberation_workflow(
-    store: ProposalStore, delib_id: str, proposal_text: str, workflow: str, options: Dict
+    store: ProposalStore,
+    delib_id: str,
+    proposal_text: str,
+    workflow: str,
+    options: Dict,
 ):
     """Execute a deliberation workflow asynchronously.
 
@@ -147,15 +151,15 @@ async def run_deliberation_workflow(
     try:
         # Try to run via UnifiedPipeline
         results = await _run_pipeline(proposal_text, workflow, options)
-        store.update_deliberation(delib_id, DeliberationStatus.COMPLETED, results=results)
+        store.update_deliberation(
+            delib_id, DeliberationStatus.COMPLETED, results=results
+        )
         store.set_analysis_results(proposal_id, results)
         store.update_status(proposal_id, ProposalStatus.DECIDED)
         logger.info(f"Deliberation {delib_id} completed successfully")
     except Exception as e:
         logger.error(f"Deliberation {delib_id} failed: {e}")
-        store.update_deliberation(
-            delib_id, DeliberationStatus.FAILED, error=str(e)
-        )
+        store.update_deliberation(delib_id, DeliberationStatus.FAILED, error=str(e))
         store.update_status(proposal_id, ProposalStatus.PENDING)
 
 

--- a/argumentation_analysis/adapters/french_fallacy_adapter.py
+++ b/argumentation_analysis/adapters/french_fallacy_adapter.py
@@ -51,7 +51,9 @@ _FALLACY_LABELS_LEGACY = [
 ]
 
 _TAXONOMY_CSV = Path(__file__).resolve().parent.parent / "data" / "taxonomy_medium.csv"
-_TAXONOMY_FULL_CSV = Path(__file__).resolve().parent.parent / "data" / "taxonomy_full.csv"
+_TAXONOMY_FULL_CSV = (
+    Path(__file__).resolve().parent.parent / "data" / "taxonomy_full.csv"
+)
 
 # Maps taxonomy text_fr label → PK for downstream hierarchical descent
 _TAXONOMY_LABEL_TO_PK: Dict[str, int] = {}
@@ -571,9 +573,7 @@ class NLIFallacyDetector:
     # Threshold for Stage 1: minimum confidence on a family to drill down
     HIERARCHICAL_STAGE1_THRESHOLD = 0.3
 
-    def _nli_hierarchical_classify(
-        self, text: str
-    ) -> List[FallacyDetection]:
+    def _nli_hierarchical_classify(self, text: str) -> List[FallacyDetection]:
         """2-stage hierarchical NLI classification.
 
         Stage 1: classify against the 7 depth-1 families.
@@ -608,9 +608,7 @@ class NLIFallacyDetector:
 
             detections: List[FallacyDetection] = []
 
-            for label, score in zip(
-                stage1_result["labels"], stage1_result["scores"]
-            ):
+            for label, score in zip(stage1_result["labels"], stage1_result["scores"]):
                 if score < self.HIERARCHICAL_STAGE1_THRESHOLD:
                     continue
 
@@ -629,12 +627,9 @@ class NLIFallacyDetector:
                             confidence=round(score, 3),
                             source="nli_hierarchical",
                             description=(
-                                f"NLI hierarchical stage-1 "
-                                f"({self._model_name})"
+                                f"NLI hierarchical stage-1 " f"({self._model_name})"
                             ),
-                            taxonomy_pk=family_node["pk"]
-                            if family_node
-                            else None,
+                            taxonomy_pk=family_node["pk"] if family_node else None,
                         )
                     )
                     continue
@@ -919,7 +914,9 @@ class SelfHostedLLMFallacyDetector:
         import os
 
         self._endpoint = endpoint or os.environ.get("SELF_HOSTED_LLM_ENDPOINT", "")
-        self._api_key = api_key or os.environ.get("SELF_HOSTED_LLM_API_KEY", "not-needed")
+        self._api_key = api_key or os.environ.get(
+            "SELF_HOSTED_LLM_API_KEY", "not-needed"
+        )
         self._model = model or os.environ.get("SELF_HOSTED_LLM_MODEL", "")
         self._timeout = timeout
         self._available = None
@@ -951,7 +948,10 @@ class SelfHostedLLMFallacyDetector:
         payload = {
             "model": self._model,
             "messages": [
-                {"role": "system", "content": "Tu es un expert en logique et argumentation. Réponds en JSON uniquement."},
+                {
+                    "role": "system",
+                    "content": "Tu es un expert en logique et argumentation. Réponds en JSON uniquement.",
+                },
                 {"role": "user", "content": prompt},
             ],
             "temperature": 0.1,
@@ -1061,7 +1061,7 @@ class LLMFallacyDetector:
         "Reponds UNIQUEMENT en JSON valide avec cette structure:\n"
         '{"fallacies": [{"type": "...", "confidence": 0.XX, '
         '"explanation": "...", "target_text": "..."}]}\n\n'
-        "Si aucun sophisme n'est detecte, reponds: {\"fallacies\": []}\n\n"
+        'Si aucun sophisme n\'est detecte, reponds: {"fallacies": []}\n\n'
         "Types de sophismes connus:\n"
         "- Attaque personnelle (Ad Hominem)\n"
         "- Appel a la popularite (Ad Populum)\n"
@@ -1136,9 +1136,7 @@ class LLMFallacyDetector:
             # Strip markdown code fences if present
             if raw.startswith("```"):
                 lines = raw.split("\n")
-                raw = "\n".join(
-                    l for l in lines if not l.startswith("```")
-                )
+                raw = "\n".join(l for l in lines if not l.startswith("```"))
 
             data = _json.loads(raw)
             fallacies_data = data.get("fallacies", [])
@@ -1276,7 +1274,13 @@ class FrenchFallacyAdapter(AbstractFallacyDetector):
         """At least one tier must be available."""
         return any(
             t is not None and t.is_available()
-            for t in [self._symbolic, self._self_hosted_llm, self._camembert, self._nli, self._llm]
+            for t in [
+                self._symbolic,
+                self._self_hosted_llm,
+                self._camembert,
+                self._nli,
+                self._llm,
+            ]
         )
 
     def get_available_tiers(self) -> List[str]:
@@ -1333,16 +1337,10 @@ class FrenchFallacyAdapter(AbstractFallacyDetector):
 
         # Tier 2: NLI zero-shot (deprecated, shadowed by self-hosted LLM)
         if self._nli and self._nli.is_available():
-            nli_results = self._nli.detect(
-                text, hierarchical=self._nli_hierarchical
-            )
+            nli_results = self._nli.detect(text, hierarchical=self._nli_hierarchical)
             all_detections.extend(nli_results)
             if nli_results:
-                tier_name = (
-                    "nli_hierarchical"
-                    if self._nli_hierarchical
-                    else "nli"
-                )
+                tier_name = "nli_hierarchical" if self._nli_hierarchical else "nli"
                 result.tiers_used.append(tier_name)
 
         # Tier 0: Remote LLM zero-shot

--- a/argumentation_analysis/agents/core/logic/dung_native.py
+++ b/argumentation_analysis/agents/core/logic/dung_native.py
@@ -111,9 +111,7 @@ class DungFramework:
         for size in range(1, len(args_list) + 1):
             for combo in combinations(args_list, size):
                 s = frozenset(combo)
-                if self.is_conflict_free(s) and all(
-                    self.defends(s, arg) for arg in s
-                ):
+                if self.is_conflict_free(s) and all(self.defends(s, arg) for arg in s):
                     result.append(s)
         return result
 
@@ -171,7 +169,9 @@ class DungFramework:
         # Credulous: accepted in at least one preferred extension
         credulously_accepted = any(arg in ext for ext in preferred)
         # Skeptical: accepted in all preferred extensions
-        skeptically_accepted = all(arg in ext for ext in preferred) if preferred else False
+        skeptically_accepted = (
+            all(arg in ext for ext in preferred) if preferred else False
+        )
 
         return {
             "in_grounded": arg in grounded,
@@ -223,9 +223,7 @@ class DungFramework:
             "num_attacks": len(self.attacks),
             "has_cycles": has_cycle,
             "self_attacking": self_attacking,
-            "unattacked": sorted(
-                a for a in self.arguments if not self.attackers_of(a)
-            ),
+            "unattacked": sorted(a for a in self.arguments if not self.attackers_of(a)),
         }
 
     @classmethod

--- a/argumentation_analysis/agents/core/logic/qbf_native.py
+++ b/argumentation_analysis/agents/core/logic/qbf_native.py
@@ -341,9 +341,7 @@ def credulous_acceptance_qbf(
                 if attacker not in ext:
                     # Must be counter-attacked by someone in ext
                     counter_attacked = any(
-                        a[0] in ext and a[1] == attacker
-                        for a in attacks
-                        if len(a) >= 2
+                        a[0] in ext and a[1] == attacker for a in attacks if len(a) >= 2
                     )
                     if not counter_attacked:
                         admissible = False

--- a/argumentation_analysis/agents/core/logic/tweety_bridge.py
+++ b/argumentation_analysis/agents/core/logic/tweety_bridge.py
@@ -242,6 +242,7 @@ class TweetyBridge:
             raise RuntimeError("JVM not started.")
         if self._qbf_handler is None:
             from .qbf_handler import QBFHandler
+
             self._qbf_handler = QBFHandler(self._initializer)
         return self._qbf_handler
 

--- a/argumentation_analysis/agents/core/oracle/hypothesis_tracker.py
+++ b/argumentation_analysis/agents/core/oracle/hypothesis_tracker.py
@@ -175,9 +175,7 @@ class HypothesisTracker:
                 hyp.coherent = False
                 # Identify the actual contradicting evidence per assumption
                 # rather than always blaming the latest call (review #386).
-                blames = sorted(
-                    {self._contradicted_by[a] for a in contradicted}
-                )
+                blames = sorted({self._contradicted_by[a] for a in contradicted})
                 hyp.retraction_reason = (
                     f"Contradicted by evidence {blames} — "
                     f"assumptions {sorted(contradicted)} conflict with evidence"
@@ -214,8 +212,7 @@ class HypothesisTracker:
         for hyp in self._hypotheses.values():
             status = "COHERENT" if hyp.coherent else "RETRACTED"
             lines.append(
-                f"  [{status}] {hyp.id} ({hyp.name}): "
-                f"assumptions={hyp.assumptions}"
+                f"  [{status}] {hyp.id} ({hyp.name}): " f"assumptions={hyp.assumptions}"
             )
             if not hyp.coherent:
                 lines.append(f"    Reason: {hyp.retraction_reason}")

--- a/argumentation_analysis/agents/factory.py
+++ b/argumentation_analysis/agents/factory.py
@@ -1,6 +1,6 @@
-# Fichier : argumentation_analysis/agents/agent_factory.py
+from __future__ import annotations
 
-from typing import Any, List, Optional, Type
+from typing import Any, List, Optional, Type, Union
 from semantic_kernel import Kernel
 from semantic_kernel.functions import KernelFunction
 from semantic_kernel.agents import Agent, ChatCompletionAgent
@@ -218,9 +218,7 @@ def load_plugins_for_agent(
             # Complex plugins need kernel + llm_service
             if plugin_name == "fallacy_workflow":
                 if llm_service is not None:
-                    instance = plugin_cls(
-                        master_kernel=kernel, llm_service=llm_service
-                    )
+                    instance = plugin_cls(master_kernel=kernel, llm_service=llm_service)
                 else:
                     _factory_logger.debug(
                         "Skipping '%s': requires llm_service", plugin_name
@@ -253,30 +251,25 @@ class AgentFactory:
         config_name: str = "simple",
         trace_log_path: Optional[str] = None,
         taxonomy_file_path: Optional[str] = None,
-    ) -> Agent:
-        # La logique de création des plugins est déléguée à l'agent lui-même.
-        # La factory se contente de passer la configuration.
-        # Cela élimine la logique dupliquée et les incohérences.
+    ) -> Union[Agent, "TracedAgent"]:
         agent_to_create = InformalFallacyAgent(
             kernel=self.kernel,
             config_name=config_name,
-            taxonomy_file_path=taxonomy_file_path,  # Ajout du passage de l'argument manquant
+            taxonomy_file_path=taxonomy_file_path,
             llm_service_id=self.llm_service_id,
         )
 
         if trace_log_path:
-            return TracedAgent(  # type: ignore[return-value]
+            return TracedAgent(
                 agent_to_wrap=agent_to_create, trace_log_path=trace_log_path
             )
         return agent_to_create
 
-    def create_agent(self, agent_type: AgentType, **kwargs: Any) -> FallacyAgentBase:
-        # Cette méthode est maintenant le point d'entrée principal.
-        # Elle peut utiliser create_informal_fallacy_agent si nécessaire.
+    def create_agent(
+        self, agent_type: AgentType, **kwargs: Any
+    ) -> Union[Agent, "TracedAgent"]:
         if agent_type == AgentType.INFORMAL_FALLACY:
-            # Fait le pont avec la nouvelle méthode de création détaillée
-            # On passe les kwargs pour permettre plus de flexibilité (comme 'config_name')
-            return self.create_informal_fallacy_agent(**kwargs)  # type: ignore[return-value]
+            return self.create_informal_fallacy_agent(**kwargs)
 
         # --- Importation locale pour briser le cycle d'importation ---
         from .sherlock_jtms_agent import SherlockJTMSAgent
@@ -294,11 +287,11 @@ class AgentFactory:
         if "llm_service_id" not in kwargs:
             kwargs["llm_service_id"] = self.llm_service_id
 
-        return agent_class(kernel=self.kernel, **kwargs)  # type: ignore[return-value]
+        return agent_class(kernel=self.kernel, **kwargs)  # type: ignore[return-value]  # SherlockJTMSAgent doesn't inherit Agent
 
     def create_project_manager_agent(
         self, trace_log_path: Optional[str] = None
-    ) -> Agent:
+    ) -> Union[Agent, "TracedAgent"]:
         plugins: list[Any] = [ProjectManagementPlugin()]
         with open(
             "argumentation_analysis/agents/prompts/ProjectManagerAgent/skprompt.txt",
@@ -314,12 +307,12 @@ class AgentFactory:
             plugins=plugins,
         )
         if trace_log_path:
-            return TracedAgent(agent_to_wrap=agent, trace_log_path=trace_log_path)  # type: ignore[return-value]
+            return TracedAgent(agent_to_wrap=agent, trace_log_path=trace_log_path)
         return agent
 
     def create_sherlock_agent(
         self, agent_name: str = "Sherlock", trace_log_path: Optional[str] = None
-    ) -> Agent:
+    ) -> Union[Agent, "TracedAgent"]:
         return self._create_agent(
             agent_class=SherlockEnqueteAgent,
             agent_name=agent_name,
@@ -333,7 +326,7 @@ class AgentFactory:
         trace_log_path: Optional[str] = None,
         constants: Optional[List[str]] = None,
         system_prompt: Optional[str] = None,
-    ) -> Agent:
+    ) -> Union[Agent, "TracedAgent"]:
         return self._create_agent(
             agent_class=WatsonLogicAssistant,
             agent_name=agent_name,
@@ -347,7 +340,7 @@ class AgentFactory:
         self,
         agent_name: str = "CounterArgumentAgent",
         trace_log_path: Optional[str] = None,
-    ) -> Agent:
+    ) -> Union[Agent, "TracedAgent"]:
         """Create a counter-argument generation agent."""
         from argumentation_analysis.agents.core.counter_argument.counter_agent import (
             CounterArgumentAgent,
@@ -365,7 +358,7 @@ class AgentFactory:
         personality: str = "The Scholar",
         position: str = "for",
         trace_log_path: Optional[str] = None,
-    ) -> Agent:
+    ) -> Union[Agent, "TracedAgent"]:
         """Create a debate agent with specified personality and position."""
         from argumentation_analysis.agents.core.debate.debate_agent import (
             DebateAgent,
@@ -385,17 +378,7 @@ class AgentFactory:
         trace_log_path: Optional[str] = None,
         enable_auto_function_calling: bool = False,
         **kwargs: Any,
-    ) -> Agent:
-        """Create an agent instance with optional auto function calling.
-
-        Args:
-            agent_class: The agent class to instantiate.
-            trace_log_path: Optional path for execution tracing.
-            enable_auto_function_calling: If True, configure the agent's kernel
-                execution settings so it can auto-invoke @kernel_function plugins
-                during AgentGroupChat conversations. Required for conversational mode.
-            **kwargs: Additional agent-specific parameters.
-        """
+    ) -> Union[Agent, "TracedAgent"]:
         if "service_id" not in kwargs:
             kwargs["service_id"] = self.llm_service_id
 
@@ -405,7 +388,8 @@ class AgentFactory:
             self._enable_function_choice_behavior(agent)
 
         if trace_log_path:
-            return TracedAgent(agent_to_wrap=agent, trace_log_path=trace_log_path)  # type: ignore[return-value,arg-type]
+            # TracedAgent expects ChatCompletionAgent; callers always pass subclasses
+            return TracedAgent(agent_to_wrap=agent, trace_log_path=trace_log_path)  # type: ignore[arg-type]
         return agent
 
     def _enable_function_choice_behavior(self, agent: Agent) -> None:
@@ -426,7 +410,7 @@ class AgentFactory:
                 object.__setattr__(agent, "function_choice_behavior", fcb)
             else:
                 # Fallback: store for manual use by orchestrator
-                agent._function_choice_behavior = fcb  # type: ignore[attr-defined]
+                object.__setattr__(agent, "_function_choice_behavior", fcb)
         except Exception as e:
             import logging
 

--- a/argumentation_analysis/agents/factory.py
+++ b/argumentation_analysis/agents/factory.py
@@ -1,6 +1,6 @@
 # Fichier : argumentation_analysis/agents/agent_factory.py
 
-from typing import List, Optional, Type
+from typing import Any, List, Optional, Type
 from semantic_kernel import Kernel
 from semantic_kernel.functions import KernelFunction
 from semantic_kernel.agents import Agent, ChatCompletionAgent
@@ -103,8 +103,11 @@ _PLUGIN_REGISTRY = {
 
 
 def get_plugin_instances(
-    agent_speciality: str, state=None, kernel=None, llm_service=None
-) -> list:
+    agent_speciality: str,
+    state: Any = None,
+    kernel: Optional[Kernel] = None,
+    llm_service: Any = None,
+) -> list[Any]:
     """Return instantiated plugin objects for an agent's speciality.
 
     Useful for ChatCompletionAgent(plugins=[...]) scoping where each agent
@@ -167,8 +170,11 @@ def get_plugin_instances(
 
 
 def load_plugins_for_agent(
-    kernel: Kernel, agent_speciality: str, state=None, llm_service=None
-) -> list:
+    kernel: Kernel,
+    agent_speciality: str,
+    state: Any = None,
+    llm_service: Any = None,
+) -> list[str]:
     """Load only the plugins relevant to an agent's speciality onto its kernel.
 
     Always loads StateManagerPlugin (if state is provided) as the shared
@@ -259,18 +265,18 @@ class AgentFactory:
         )
 
         if trace_log_path:
-            return TracedAgent(
+            return TracedAgent(  # type: ignore[return-value]
                 agent_to_wrap=agent_to_create, trace_log_path=trace_log_path
             )
         return agent_to_create
 
-    def create_agent(self, agent_type: AgentType, **kwargs) -> FallacyAgentBase:
+    def create_agent(self, agent_type: AgentType, **kwargs: Any) -> FallacyAgentBase:
         # Cette méthode est maintenant le point d'entrée principal.
         # Elle peut utiliser create_informal_fallacy_agent si nécessaire.
         if agent_type == AgentType.INFORMAL_FALLACY:
             # Fait le pont avec la nouvelle méthode de création détaillée
             # On passe les kwargs pour permettre plus de flexibilité (comme 'config_name')
-            return self.create_informal_fallacy_agent(**kwargs)
+            return self.create_informal_fallacy_agent(**kwargs)  # type: ignore[return-value]
 
         # --- Importation locale pour briser le cycle d'importation ---
         from .sherlock_jtms_agent import SherlockJTMSAgent
@@ -288,18 +294,18 @@ class AgentFactory:
         if "llm_service_id" not in kwargs:
             kwargs["llm_service_id"] = self.llm_service_id
 
-        return agent_class(kernel=self.kernel, **kwargs)
+        return agent_class(kernel=self.kernel, **kwargs)  # type: ignore[return-value]
 
     def create_project_manager_agent(
         self, trace_log_path: Optional[str] = None
     ) -> Agent:
-        plugins = [ProjectManagementPlugin()]
+        plugins: list[Any] = [ProjectManagementPlugin()]
         with open(
             "argumentation_analysis/agents/prompts/ProjectManagerAgent/skprompt.txt",
             "r",
         ) as f:
             prompt = f.read()
-        llm_service = self.kernel.get_service(self.llm_service_id)
+        llm_service: Any = self.kernel.get_service(self.llm_service_id)
         agent = ChatCompletionAgent(
             kernel=self.kernel,
             service=llm_service,
@@ -308,7 +314,7 @@ class AgentFactory:
             plugins=plugins,
         )
         if trace_log_path:
-            return TracedAgent(agent_to_wrap=agent, trace_log_path=trace_log_path)
+            return TracedAgent(agent_to_wrap=agent, trace_log_path=trace_log_path)  # type: ignore[return-value]
         return agent
 
     def create_sherlock_agent(
@@ -378,7 +384,7 @@ class AgentFactory:
         agent_class: Type[Agent],
         trace_log_path: Optional[str] = None,
         enable_auto_function_calling: bool = False,
-        **kwargs,
+        **kwargs: Any,
     ) -> Agent:
         """Create an agent instance with optional auto function calling.
 
@@ -399,7 +405,7 @@ class AgentFactory:
             self._enable_function_choice_behavior(agent)
 
         if trace_log_path:
-            return TracedAgent(agent_to_wrap=agent, trace_log_path=trace_log_path)
+            return TracedAgent(agent_to_wrap=agent, trace_log_path=trace_log_path)  # type: ignore[return-value,arg-type]
         return agent
 
     def _enable_function_choice_behavior(self, agent: Agent) -> None:
@@ -420,7 +426,7 @@ class AgentFactory:
                 object.__setattr__(agent, "function_choice_behavior", fcb)
             else:
                 # Fallback: store for manual use by orchestrator
-                agent._function_choice_behavior = fcb
+                agent._function_choice_behavior = fcb  # type: ignore[attr-defined]
         except Exception as e:
             import logging
 

--- a/argumentation_analysis/cli/output_formatter.py
+++ b/argumentation_analysis/cli/output_formatter.py
@@ -16,6 +16,7 @@ Usage:
 Sections: Extraction / Formal Logic / Fallacies / JTMS / ATMS / Dung /
 Counter-arguments / Debate / Quality / Narrative (#364).
 """
+
 import json
 from typing import Any, Dict, List, Optional
 
@@ -89,13 +90,15 @@ def render_spectacular_result(result: Dict[str, Any], console: Optional[Any] = N
     non_empty = _count_non_empty(state_snapshot)
     coverage = non_empty / total_fields * 100 if total_fields else 0
 
-    console.print(Panel(
-        f"[bold]Workflow:[/bold] {workflow}\n"
-        f"[bold]Phases:[/bold] {completed}/{total} completed\n"
-        f"[bold]State coverage:[/bold] {non_empty}/{total_fields} fields ({coverage:.0f}%)",
-        title="[bold cyan]Spectacular Rhetorical Analysis[/bold cyan]",
-        border_style="cyan",
-    ))
+    console.print(
+        Panel(
+            f"[bold]Workflow:[/bold] {workflow}\n"
+            f"[bold]Phases:[/bold] {completed}/{total} completed\n"
+            f"[bold]State coverage:[/bold] {non_empty}/{total_fields} fields ({coverage:.0f}%)",
+            title="[bold cyan]Spectacular Rhetorical Analysis[/bold cyan]",
+            border_style="cyan",
+        )
+    )
 
     # Sections
     _render_extraction(console, state_snapshot)
@@ -171,12 +174,16 @@ def _render_fallacies(console, state: Dict[str, Any]):
         table.add_column("Justification")
         for fid, data in list(fallacies.items())[:10]:
             ftype = data.get("type", "?") if isinstance(data, dict) else "?"
-            just = data.get("justification", "") if isinstance(data, dict) else str(data)
+            just = (
+                data.get("justification", "") if isinstance(data, dict) else str(data)
+            )
             table.add_row(fid, ftype, _truncate(just, 60))
         console.print(table)
     if neural:
-        console.print(f"  {len(neural)} neural detection scores "
-                      f"({_section_ref(9)} for quality impact)")
+        console.print(
+            f"  {len(neural)} neural detection scores "
+            f"({_section_ref(9)} for quality impact)"
+        )
 
 
 def _render_jtms(console, state: Dict[str, Any]):
@@ -227,7 +234,9 @@ def _render_counter_arguments(console, state: Dict[str, Any]):
     console.print(f"\n[bold]7. Counter-arguments[/bold] ({_section_ref(7)})")
     for ca in counters[:5]:
         strategy = ca.get("strategy", "?")
-        content = _truncate(str(ca.get("counter_content", ca.get("original_argument", ""))))
+        content = _truncate(
+            str(ca.get("counter_content", ca.get("original_argument", "")))
+        )
         console.print(f"  [{strategy}] {content}")
 
 

--- a/argumentation_analysis/core/bootstrap.py
+++ b/argumentation_analysis/core/bootstrap.py
@@ -277,6 +277,7 @@ def _pre_init_safety_checks(project_root: Path, env_path: Path) -> bool:
     # Check 2: jpype availability (critical for JVM)
     try:
         import jpype
+
         logger.debug(f"jpype version {jpype.__version__} is available")
     except ImportError as e:
         logger.critical(
@@ -306,6 +307,7 @@ def _pre_init_safety_checks(project_root: Path, env_path: Path) -> bool:
     psutil_available = False
     try:
         import psutil
+
         psutil_available = True
         available_memory_gb = psutil.virtual_memory().available / (1024**3)
         if available_memory_gb < 0.5:  # Less than 512MB

--- a/argumentation_analysis/core/capability_registry.py
+++ b/argumentation_analysis/core/capability_registry.py
@@ -45,13 +45,13 @@ class ComponentRegistration:
 
     name: str
     component_type: ComponentType
-    component_class: Optional[Type] = None
-    factory: Optional[Callable] = None
+    component_class: Optional[Type[Any]] = None
+    factory: Optional[Callable[..., Any]] = None
     capabilities: List[str] = field(default_factory=list)
     requires: List[str] = field(default_factory=list)
     parameters: Dict[str, Any] = field(default_factory=dict)
     metadata: Dict[str, Any] = field(default_factory=dict)
-    invoke: Optional[Callable] = None  # async (input_text: str, context: Dict) -> Any
+    invoke: Optional[Callable[..., Any]] = None  # async (input_text: str, context: Dict) -> Any
 
     @property
     def provides(self) -> List[str]:
@@ -77,7 +77,7 @@ class CapabilityRegistry:
     puis de les decouvrir dynamiquement par capability requise.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._registrations: Dict[str, ComponentRegistration] = {}
         self._capability_index: Dict[str, Set[str]] = (
             {}
@@ -92,13 +92,13 @@ class CapabilityRegistry:
         self,
         name: str,
         component_type: ComponentType,
-        component_class: Optional[Type] = None,
-        factory: Optional[Callable] = None,
+        component_class: Optional[Type[Any]] = None,
+        factory: Optional[Callable[..., Any]] = None,
         capabilities: Optional[List[str]] = None,
         requires: Optional[List[str]] = None,
         parameters: Optional[Dict[str, Any]] = None,
         metadata: Optional[Dict[str, Any]] = None,
-        invoke: Optional[Callable] = None,
+        invoke: Optional[Callable[..., Any]] = None,
     ) -> "ComponentRegistration":
         """
         Enregistre un composant dans le registre.
@@ -161,10 +161,10 @@ class CapabilityRegistry:
     def register_agent(
         self,
         name: str,
-        agent_class: Type,
+        agent_class: Type[Any],
         capabilities: Optional[List[str]] = None,
         requires: Optional[List[str]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> "ComponentRegistration":
         """Shorthand for registering an agent."""
         return self.register(
@@ -179,10 +179,10 @@ class CapabilityRegistry:
     def register_plugin(
         self,
         name: str,
-        plugin_class: Type,
+        plugin_class: Type[Any],
         capabilities: Optional[List[str]] = None,
         requires: Optional[List[str]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> "ComponentRegistration":
         """Shorthand for registering a plugin."""
         return self.register(
@@ -197,11 +197,11 @@ class CapabilityRegistry:
     def register_service(
         self,
         name: str,
-        service_class: Optional[Type] = None,
-        factory: Optional[Callable] = None,
+        service_class: Optional[Type[Any]] = None,
+        factory: Optional[Callable[..., Any]] = None,
         capabilities: Optional[List[str]] = None,
         requires: Optional[List[str]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> "ComponentRegistration":
         """Shorthand for registering a service."""
         return self.register(
@@ -447,7 +447,7 @@ class ServiceDiscovery:
         metadata: Dict[str, Any] = field(default_factory=dict)
         priority: int = 0  # Higher = preferred
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._providers: Dict[str, "ServiceDiscovery.ProviderRegistration"] = {}
         self._type_index: Dict[str, Set[str]] = {}  # type -> set of provider names
         logger.info("ServiceDiscovery initialized")
@@ -493,7 +493,7 @@ class ServiceDiscovery:
         api_key: Optional[str] = None,
         models: Optional[List[str]] = None,
         priority: int = 0,
-        **kwargs,
+        **kwargs: Any,
     ) -> "ServiceDiscovery.ProviderRegistration":
         """Register an LLM provider."""
         return self.register_provider(
@@ -514,7 +514,7 @@ class ServiceDiscovery:
         model: Optional[str] = None,
         dimensions: Optional[int] = None,
         priority: int = 0,
-        **kwargs,
+        **kwargs: Any,
     ) -> "ServiceDiscovery.ProviderRegistration":
         """Register an embedding provider."""
         return self.register_provider(
@@ -533,7 +533,7 @@ class ServiceDiscovery:
         name: str,
         endpoint: Optional[str] = None,
         priority: int = 0,
-        **kwargs,
+        **kwargs: Any,
     ) -> "ServiceDiscovery.ProviderRegistration":
         """Register a speech-to-text provider."""
         return self.register_provider(

--- a/argumentation_analysis/core/capability_registry.py
+++ b/argumentation_analysis/core/capability_registry.py
@@ -51,7 +51,9 @@ class ComponentRegistration:
     requires: List[str] = field(default_factory=list)
     parameters: Dict[str, Any] = field(default_factory=dict)
     metadata: Dict[str, Any] = field(default_factory=dict)
-    invoke: Optional[Callable[..., Any]] = None  # async (input_text: str, context: Dict) -> Any
+    invoke: Optional[Callable[..., Any]] = (
+        None  # async (input_text: str, context: Dict) -> Any
+    )
 
     @property
     def provides(self) -> List[str]:

--- a/argumentation_analysis/core/jvm_setup.py
+++ b/argumentation_analysis/core/jvm_setup.py
@@ -19,6 +19,7 @@ from tqdm.auto import tqdm
 
 class JVMStartupTimeoutError(TimeoutError):
     """Exception raised when JVM startup exceeds the configured timeout."""
+
     pass
 
 
@@ -835,7 +836,9 @@ def initialize_jvm(force_restart=False, session_fixture_owns_jvm=False) -> bool:
         native_libs_dir = PROJ_ROOT / settings.jvm.native_libs_dir
         if native_libs_dir.exists():
             classpath.append(str(native_libs_dir.resolve()))
-            logger.info(f"Native SAT dir prepended to classpath: {native_libs_dir.resolve()}")
+            logger.info(
+                f"Native SAT dir prepended to classpath: {native_libs_dir.resolve()}"
+            )
         classpath.extend(jar_entries)
 
         try:
@@ -891,7 +894,11 @@ def initialize_jvm(force_restart=False, session_fixture_owns_jvm=False) -> bool:
             )
 
             # Get timeout from settings or use default
-            startup_timeout = getattr(settings.jvm, 'startup_timeout_seconds', DEFAULT_JVM_STARTUP_TIMEOUT_SECONDS)
+            startup_timeout = getattr(
+                settings.jvm,
+                "startup_timeout_seconds",
+                DEFAULT_JVM_STARTUP_TIMEOUT_SECONDS,
+            )
 
             def _do_start_jvm():
                 """Inner function to start JVM for timeout wrapper."""

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -1,7 +1,7 @@
 # core/shared_state.py
 import json
 from dataclasses import dataclass, field
-from typing import Dict, List, Any, Optional
+from typing import Dict, List, Any, Optional, cast
 import logging
 
 # Logger spécifique pour l'état
@@ -61,8 +61,8 @@ class RhetoricalAnalysisState:
         self.belief_sets = {}
         self.query_log = []
         self.answers = {}
-        self.extracts = []
-        self.errors = []
+        self.extracts: List[Dict[str, Any]] = []
+        self.errors: List[Dict[str, Any]] = []
         self.final_conclusion = None
         self._next_agent_designated = None
         state_logger.debug(
@@ -162,7 +162,7 @@ class RhetoricalAnalysisState:
 
     def add_answer(
         self, task_id: str, author_agent: str, answer_text: str, source_ids: List[str]
-    ):
+    ) -> None:
         """Ajoute la réponse d'un agent à une tâche spécifiques."""
         if task_id not in self.analysis_tasks:
             state_logger.warning(
@@ -180,7 +180,7 @@ class RhetoricalAnalysisState:
             f"État answers après ajout réponse pour {task_id}: {self.answers}"
         )
 
-    def set_conclusion(self, conclusion: str):
+    def set_conclusion(self, conclusion: str) -> None:
         """Enregistre la conclusion finale de l'analyse."""
         self.final_conclusion = conclusion
         state_logger.info(f"Conclusion finale enregistrée : '{conclusion[:60]}...'")
@@ -188,13 +188,13 @@ class RhetoricalAnalysisState:
             f"État final_conclusion après enregistrement: {self.final_conclusion is not None}"
         )
 
-    def add_identified_arguments(self, arguments: List[str]):
+    def add_identified_arguments(self, arguments: List[str]) -> None:
         """Ajoute une liste d'arguments identifiés."""
         state_logger.info(f"Ajout de {len(arguments)} arguments identifiés...")
         for arg_desc in arguments:
             self.add_argument(arg_desc)
 
-    def add_identified_fallacies(self, fallacies: List[Dict[str, str]]):
+    def add_identified_fallacies(self, fallacies: List[Dict[str, str]]) -> None:
         """Ajoute une liste de sophismes identifiés."""
         state_logger.info(f"Ajout de {len(fallacies)} sophismes identifiés...")
         for fallacy_data in fallacies:
@@ -206,7 +206,7 @@ class RhetoricalAnalysisState:
                 # On pourrait aussi extraire la citation et la passer dans la justification
             )
 
-    def mark_task_as_answered(self, task_id: str, answer: str, author: str = "Unknown"):
+    def mark_task_as_answered(self, task_id: str, answer: str, author: str = "Unknown") -> None:
         """Marque une tâche comme terminée en lui ajoutant une réponse."""
         if task_id not in self.analysis_tasks:
             state_logger.warning(
@@ -226,7 +226,7 @@ class RhetoricalAnalysisState:
         # On pourrait avoir une logique plus complexe, mais pour l'instant on prend la dernière créée
         return unanswered_tasks[-1]
 
-    def designate_next_agent(self, agent_name: str):
+    def designate_next_agent(self, agent_name: str) -> None:
         """Désigne l'agent qui doit parler au prochain tour."""
         self._next_agent_designated = agent_name
         state_logger.info(f"Prochain agent désigné: '{agent_name}'")
@@ -271,11 +271,11 @@ class RhetoricalAnalysisState:
             state_logger.info(f"Désignation pour '{agent_name}' consommée.")
         return agent_name
 
-    def reset_state(self):
+    def reset_state(self) -> None:
         """Réinitialise l'état à son état initial (vide sauf texte brut)."""
         state_logger.info(">>> Réinitialisation de l'état d'analyse...")
         initial_text = self.raw_text
-        self.__init__(initial_text)
+        self.__init__(initial_text)  # type: ignore[misc]
         assert not self.analysis_tasks, "Reset analysis_tasks failed"
         assert not self.identified_arguments, "Reset identified_arguments failed"
         assert not self.identified_fallacies, "Reset identified_fallacies failed"
@@ -325,7 +325,7 @@ class RhetoricalAnalysisState:
                 "next_agent_designated": self._next_agent_designated,
             }
         else:
-            return json.loads(self.to_json(indent=None))
+            return cast(Dict[str, Any], json.loads(self.to_json(indent=None)))
 
     def to_json(self, indent: Optional[int] = 2) -> str:
         """Sérialise l'état actuel en chaîne JSON."""
@@ -476,7 +476,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         name: str,
         arguments: List[str],
         attacks: List[List[str]],
-        extensions: Optional[Dict[str, List]] = None,
+        extensions: Optional[Dict[str, List[str]]] = None,
     ) -> str:
         """Add a Dung argumentation framework."""
         df_id = self._generate_id("dung", self.dung_frameworks)
@@ -848,7 +848,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
 
     def get_fallacious_arguments(self) -> List[ArgumentProfile]:
         """Return ArgumentProfiles for arguments targeted by at least one fallacy."""
-        targeted_ids: set = set()
+        targeted_ids: set[str] = set()
         for _fid, fdata in self.identified_fallacies.items():
             tid = fdata.get("target_argument_id")
             if tid and tid in self.identified_arguments:
@@ -860,7 +860,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         total = len(self.identified_arguments)
 
         # Collect sets of arg_ids that have each enrichment
-        with_fallacy: set = set()
+        with_fallacy: set[str] = set()
         for _fid, fdata in self.identified_fallacies.items():
             tid = fdata.get("target_argument_id")
             if tid and tid in self.identified_arguments:
@@ -871,7 +871,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         )
 
         # Counter-arguments use text matching
-        with_counter: set = set()
+        with_counter: set[str] = set()
         for arg_id, desc in self.identified_arguments.items():
             if not desc:
                 continue
@@ -888,7 +888,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
                     break
 
         # Formal verification (NL-to-logic translations)
-        with_formal: set = set()
+        with_formal: set[str] = set()
         for arg_id, desc in self.identified_arguments.items():
             if not desc:
                 continue
@@ -900,7 +900,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
                     break
 
         # JTMS beliefs
-        with_jtms: set = set()
+        with_jtms: set[str] = set()
         for arg_id, desc in self.identified_arguments.items():
             for _bid, bdata in self.jtms_beliefs.items():
                 belief_name = bdata.get("name", "")

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -20,6 +20,7 @@ if not state_logger.handlers and not state_logger.propagate:
 @dataclass
 class ArgumentProfile:
     """Aggregated view of all analysis data for a single argument."""
+
     arg_id: str
     description: str
     fallacies: List[Dict[str, Any]] = field(default_factory=list)
@@ -206,7 +207,9 @@ class RhetoricalAnalysisState:
                 # On pourrait aussi extraire la citation et la passer dans la justification
             )
 
-    def mark_task_as_answered(self, task_id: str, answer: str, author: str = "Unknown") -> None:
+    def mark_task_as_answered(
+        self, task_id: str, answer: str, author: str = "Unknown"
+    ) -> None:
         """Marque une tâche comme terminée en lui ajoutant une réponse."""
         if task_id not in self.analysis_tasks:
             state_logger.warning(
@@ -438,7 +441,10 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         return ca_id
 
     def add_quality_score(
-        self, arg_id: str, scores: Dict[str, float], overall: float,
+        self,
+        arg_id: str,
+        scores: Dict[str, float],
+        overall: float,
         llm_assessment: Optional[str] = None,
     ) -> None:
         """Add quality evaluation scores for an argument.

--- a/argumentation_analysis/core/state_manager_plugin.py
+++ b/argumentation_analysis/core/state_manager_plugin.py
@@ -204,7 +204,12 @@ class StateManagerPlugin:
         self._logger.info(
             f"Appel add_belief_set (state id: {id(self._state)}): Type='{logic_type}'..."
         )
-        valid_logic_types = {"propositional": "Propositional", "pl": "Propositional", "fol": "FOL", "first_order": "FOL"}
+        valid_logic_types = {
+            "propositional": "Propositional",
+            "pl": "Propositional",
+            "fol": "FOL",
+            "first_order": "FOL",
+        }
         normalized_logic_type = logic_type.strip().lower()
 
         if normalized_logic_type not in valid_logic_types:
@@ -270,7 +275,9 @@ class StateManagerPlugin:
         try:
             import json as _json
 
-            parsed_vars = _json.loads(variables) if isinstance(variables, str) else variables
+            parsed_vars = (
+                _json.loads(variables) if isinstance(variables, str) else variables
+            )
             tr_id = self._state.add_nl_to_logic_translation(
                 original_text=original_text[:200],
                 formula=formula,
@@ -403,11 +410,15 @@ class StateManagerPlugin:
                 confidence=confidence,
             )
 
-            self._logger.info(f" -> Belief '{belief_name}' created with ExtendedBelief metadata")
+            self._logger.info(
+                f" -> Belief '{belief_name}' created with ExtendedBelief metadata"
+            )
             return f"OK: Belief '{belief_name}' created by {agent_source}"
 
         except Exception as e:
-            self._logger.error(f"Error creating JTMS belief '{belief_name}': {e}", exc_info=True)
+            self._logger.error(
+                f"Error creating JTMS belief '{belief_name}': {e}", exc_info=True
+            )
             return f"FUNC_ERROR: Error creating belief: {e}"
 
     @kernel_function(
@@ -437,9 +448,13 @@ class StateManagerPlugin:
             session = self._state._jtms_session
 
             # Add justification with agent source tracking
-            session.add_justification(in_list, out_list, conclusion, agent_source=agent_source)
+            session.add_justification(
+                in_list, out_list, conclusion, agent_source=agent_source
+            )
 
-            self._logger.info(f" -> Justification for '{conclusion}' added by {agent_source}")
+            self._logger.info(
+                f" -> Justification for '{conclusion}' added by {agent_source}"
+            )
             return f"OK: Justification for '{conclusion}' added by {agent_source}"
 
         except Exception as e:
@@ -557,14 +572,18 @@ class StateManagerPlugin:
             if belief_name not in session.extended_beliefs:
                 # Try partial match (agents may use slightly different names)
                 candidates = [
-                    name for name in session.extended_beliefs
-                    if belief_name.lower() in name.lower() or name.lower() in belief_name.lower()
+                    name
+                    for name in session.extended_beliefs
+                    if belief_name.lower() in name.lower()
+                    or name.lower() in belief_name.lower()
                 ]
                 if candidates:
                     belief_name = candidates[0]
                     self._logger.info(f" -> Partial match: using '{belief_name}'")
                 else:
-                    return f"FUNC_ERROR: Belief '{belief_name}' not found in JTMS session."
+                    return (
+                        f"FUNC_ERROR: Belief '{belief_name}' not found in JTMS session."
+                    )
 
             ext_belief = session.extended_beliefs[belief_name]
 
@@ -576,10 +595,14 @@ class StateManagerPlugin:
 
             # Record retraction in extended belief via modification history
             import datetime as _dt
-            ext_belief.record_modification("retract", {
-                "reason": reason,
-                "timestamp": _dt.datetime.now().isoformat(),
-            })
+
+            ext_belief.record_modification(
+                "retract",
+                {
+                    "reason": reason,
+                    "timestamp": _dt.datetime.now().isoformat(),
+                },
+            )
             ext_belief.context["retracted"] = True
             ext_belief.context["retraction_reason"] = reason
 
@@ -604,10 +627,13 @@ class StateManagerPlugin:
                 f" -> Belief '{belief_name}' retracted. {len(affected)} dependent beliefs affected."
             )
             import json
+
             return json.dumps(result, ensure_ascii=False, indent=2)
 
         except Exception as e:
-            self._logger.error(f"Error retracting belief '{belief_name}': {e}", exc_info=True)
+            self._logger.error(
+                f"Error retracting belief '{belief_name}': {e}", exc_info=True
+            )
             return f"FUNC_ERROR: Error retracting belief: {e}"
 
 

--- a/argumentation_analysis/evaluation/conversational_benchmark.py
+++ b/argumentation_analysis/evaluation/conversational_benchmark.py
@@ -164,14 +164,18 @@ class BenchmarkReport:
                 "avg_wall_clock": sum(r.wall_clock_seconds for r in mode_runs) / n,
                 "avg_arguments": sum(r.argument_count for r in mode_runs) / n,
                 "avg_fallacies": sum(r.fallacy_count for r in mode_runs) / n,
-                "avg_quality_scores": sum(r.quality_scores_count for r in mode_runs) / n,
-                "avg_counter_args": sum(r.counter_argument_count for r in mode_runs) / n,
+                "avg_quality_scores": sum(r.quality_scores_count for r in mode_runs)
+                / n,
+                "avg_counter_args": sum(r.counter_argument_count for r in mode_runs)
+                / n,
                 "avg_jtms_beliefs": sum(r.jtms_belief_count for r in mode_runs) / n,
-                "avg_field_fill_rate": sum(r.state_field_fill_rate for r in mode_runs) / n,
+                "avg_field_fill_rate": sum(r.state_field_fill_rate for r in mode_runs)
+                / n,
                 "avg_cross_ref": sum(r.cross_ref_density for r in mode_runs) / n,
                 "avg_messages": sum(r.total_messages for r in mode_runs) / n,
                 "run_count": n,
-                "error_rate": sum(1 for r in self.runs if r.mode == mode and r.error) / len([r for r in self.runs if r.mode == mode]),
+                "error_rate": sum(1 for r in self.runs if r.mode == mode and r.error)
+                / len([r for r in self.runs if r.mode == mode]),
             }
 
 
@@ -216,7 +220,9 @@ def extract_metrics(
                     filled += 1
             else:
                 filled += 1
-    metrics.state_field_fill_rate = filled / len(ALL_STATE_FIELDS) if ALL_STATE_FIELDS else 0
+    metrics.state_field_fill_rate = (
+        filled / len(ALL_STATE_FIELDS) if ALL_STATE_FIELDS else 0
+    )
 
     # Cross-reference density
     try:
@@ -229,8 +235,8 @@ def extract_metrics(
             with_formal = enrichment.get("with_formal_verification", 0)
             # Density = average enrichment coverage across 4 dimensions
             metrics.cross_ref_density = (
-                (with_quality + with_fallacy + with_counter + with_formal) / (4 * total)
-            )
+                with_quality + with_fallacy + with_counter + with_formal
+            ) / (4 * total)
     except Exception:
         pass
 
@@ -306,8 +312,10 @@ class ConversationalBenchmarkRunner:
 
         # Per-run table
         lines.append("## Per-Run Results\n")
-        lines.append(f"{'Text':<20} {'Mode':<15} {'Args':>5} {'Fall':>5} {'Qual':>5} "
-                      f"{'CAs':>5} {'JTMS':>5} {'Fill':>6} {'XRef':>6} {'Time':>7} {'Msgs':>5}")
+        lines.append(
+            f"{'Text':<20} {'Mode':<15} {'Args':>5} {'Fall':>5} {'Qual':>5} "
+            f"{'CAs':>5} {'JTMS':>5} {'Fill':>6} {'XRef':>6} {'Time':>7} {'Msgs':>5}"
+        )
         lines.append("-" * 100)
         for r in report.runs:
             if r.error:

--- a/argumentation_analysis/evaluation/fallacy_benchmark.py
+++ b/argumentation_analysis/evaluation/fallacy_benchmark.py
@@ -455,9 +455,7 @@ class BenchmarkReport:
 
     results: List[DetectionResult] = field(default_factory=list)
     mode_scores: Dict[str, Dict[str, float]] = field(default_factory=dict)
-    family_scores: Dict[str, Dict[str, Dict[str, float]]] = field(
-        default_factory=dict
-    )
+    family_scores: Dict[str, Dict[str, Dict[str, float]]] = field(default_factory=dict)
     summary: str = ""
 
     def compute_scores(self):
@@ -484,9 +482,7 @@ class BenchmarkReport:
                 continue
             families: Dict[str, list] = {}
             for r in mode_results:
-                case = next(
-                    (c for c in BENCHMARK_CASES if c["id"] == r.case_id), None
-                )
+                case = next((c for c in BENCHMARK_CASES if c["id"] == r.case_id), None)
                 if case:
                     fam = case["expected_family"]
                     families.setdefault(fam, []).append(r)
@@ -828,10 +824,10 @@ class FallacyBenchmarkRunner:
             lines.append("")
         # Per-family breakdown
         lines.append("## Per-Family Breakdown\n")
-        all_families = sorted(
-            set(c["expected_family"] for c in BENCHMARK_CASES)
+        all_families = sorted(set(c["expected_family"] for c in BENCHMARK_CASES))
+        lines.append(
+            f"{'Family':<25} {'Mode':<14} {'Prec':>6} {'Recall':>7} {'NameSim':>8} {'N':>3}"
         )
-        lines.append(f"{'Family':<25} {'Mode':<14} {'Prec':>6} {'Recall':>7} {'NameSim':>8} {'N':>3}")
         lines.append("-" * 70)
         for fam in all_families:
             for mode in ("free", "one_shot", "constrained"):

--- a/argumentation_analysis/evaluation/plugin_benchmark.py
+++ b/argumentation_analysis/evaluation/plugin_benchmark.py
@@ -39,15 +39,17 @@ PLUGIN_BENCHMARK_CASES: Dict[str, List[dict]] = {
             "id": "gov_01",
             "function": "social_choice_vote",
             "args": {
-                "input_json": json.dumps({
-                    "method": "copeland",
-                    "ballots": [
-                        ["A", "B", "C"],
-                        ["A", "C", "B"],
-                        ["B", "A", "C"],
-                    ],
-                    "options": ["A", "B", "C"],
-                }),
+                "input_json": json.dumps(
+                    {
+                        "method": "copeland",
+                        "ballots": [
+                            ["A", "B", "C"],
+                            ["A", "C", "B"],
+                            ["B", "A", "C"],
+                        ],
+                        "options": ["A", "B", "C"],
+                    }
+                ),
             },
             "expected": {"has_winner": True, "winner_is": "A"},
             "difficulty": "easy",
@@ -56,11 +58,13 @@ PLUGIN_BENCHMARK_CASES: Dict[str, List[dict]] = {
             "id": "gov_02",
             "function": "detect_conflicts_fn",
             "args": {
-                "positions_json": json.dumps({
-                    "agent_a": "Le climat change dû aux activités humaines",
-                    "agent_b": "Le climat change naturellement",
-                    "agent_c": "Le climat change dû aux activités humaines",
-                }),
+                "positions_json": json.dumps(
+                    {
+                        "agent_a": "Le climat change dû aux activités humaines",
+                        "agent_b": "Le climat change naturellement",
+                        "agent_c": "Le climat change dû aux activités humaines",
+                    }
+                ),
             },
             "expected": {"has_conflicts": True, "conflict_count": 1},
             "difficulty": "easy",
@@ -69,10 +73,12 @@ PLUGIN_BENCHMARK_CASES: Dict[str, List[dict]] = {
             "id": "gov_03",
             "function": "compute_consensus_metrics",
             "args": {
-                "results_json": json.dumps({
-                    "votes": ["A", "A", "A", "A", "A", "B", "B", "B", "C", "C"],
-                    "winner": "A",
-                }),
+                "results_json": json.dumps(
+                    {
+                        "votes": ["A", "A", "A", "A", "A", "B", "B", "B", "C", "C"],
+                        "winner": "A",
+                    }
+                ),
             },
             "expected": {"has_consensus_rate": True},
             "difficulty": "easy",
@@ -81,14 +87,16 @@ PLUGIN_BENCHMARK_CASES: Dict[str, List[dict]] = {
             "id": "gov_04",
             "function": "find_condorcet_winner",
             "args": {
-                "input_json": json.dumps({
-                    "ballots": [
-                        ["A", "B", "C"],
-                        ["A", "C", "B"],
-                        ["A", "B", "C"],
-                    ],
-                    "options": ["A", "B", "C"],
-                }),
+                "input_json": json.dumps(
+                    {
+                        "ballots": [
+                            ["A", "B", "C"],
+                            ["A", "C", "B"],
+                            ["A", "B", "C"],
+                        ],
+                        "options": ["A", "B", "C"],
+                    }
+                ),
             },
             "expected": {"condorcet_winner_is": "A"},
             "difficulty": "medium",
@@ -250,10 +258,12 @@ PLUGIN_BENCHMARK_CASES: Dict[str, List[dict]] = {
             "id": "tl_02",
             "function": "analyze_dung_framework",
             "args": {
-                "framework_json": json.dumps({
-                    "arguments": ["a", "b", "c"],
-                    "attacks": [["a", "b"], ["b", "c"]],
-                }),
+                "framework_json": json.dumps(
+                    {
+                        "arguments": ["a", "b", "c"],
+                        "attacks": [["a", "b"], ["b", "c"]],
+                    }
+                ),
             },
             "expected": {"returns_json": True},
             "difficulty": "hard",
@@ -290,11 +300,13 @@ PLUGIN_BENCHMARK_CASES: Dict[str, List[dict]] = {
             "id": "aspic_01",
             "function": "analyze_aspic",
             "args": {
-                "rules_json": json.dumps({
-                    "strict_rules": [["p", "q"]],
-                    "defeasible_rules": [],
-                    "preferences": {},
-                }),
+                "rules_json": json.dumps(
+                    {
+                        "strict_rules": [["p", "q"]],
+                        "defeasible_rules": [],
+                        "preferences": {},
+                    }
+                ),
             },
             "expected": {"returns_json": True},
             "difficulty": "hard",
@@ -312,10 +324,12 @@ PLUGIN_BENCHMARK_CASES: Dict[str, List[dict]] = {
             "id": "rank_01",
             "function": "rank_arguments",
             "args": {
-                "framework_json": json.dumps({
-                    "arguments": ["a", "b"],
-                    "attacks": [["a", "b"]],
-                }),
+                "framework_json": json.dumps(
+                    {
+                        "arguments": ["a", "b"],
+                        "attacks": [["a", "b"]],
+                    }
+                ),
                 "method": "grounded",
             },
             "expected": {"returns_json": True},
@@ -545,15 +559,15 @@ class PluginBenchmarkSuite:
         # Default: no-arg constructor
         return cls()
 
-    def _validate_output(
-        self, expected: dict, actual_raw: str
-    ) -> tuple:
+    def _validate_output(self, expected: dict, actual_raw: str) -> tuple:
         """Validate plugin output against expected criteria.
 
         Returns (passed: bool, details: str).
         """
         try:
-            actual = json.loads(actual_raw) if isinstance(actual_raw, str) else actual_raw
+            actual = (
+                json.loads(actual_raw) if isinstance(actual_raw, str) else actual_raw
+            )
         except (json.JSONDecodeError, TypeError):
             actual = {"raw": actual_raw}
 
@@ -562,7 +576,10 @@ class PluginBenchmarkSuite:
         if "has_winner" in expected:
             if "winner" not in actual:
                 failures.append("missing 'winner' key")
-            if expected.get("winner_is") and actual.get("winner") != expected["winner_is"]:
+            if (
+                expected.get("winner_is")
+                and actual.get("winner") != expected["winner_is"]
+            ):
                 failures.append(
                     f"winner={actual.get('winner')} != {expected['winner_is']}"
                 )
@@ -597,9 +614,7 @@ class PluginBenchmarkSuite:
         if "note_finale_gte" in expected:
             nf = actual.get("note_finale", 0)
             if isinstance(nf, (int, float)) and nf < expected["note_finale_gte"]:
-                failures.append(
-                    f"note_finale={nf} < {expected['note_finale_gte']}"
-                )
+                failures.append(f"note_finale={nf} < {expected['note_finale_gte']}")
 
         if "has_note_moyenne" in expected:
             if "note_moyenne" not in actual:
@@ -621,13 +636,17 @@ class PluginBenchmarkSuite:
                 failures.append("empty results")
 
         if "has_beliefs" in expected:
-            if not actual or ("beliefs" not in str(actual) and "belief" not in str(actual)):
+            if not actual or (
+                "beliefs" not in str(actual) and "belief" not in str(actual)
+            ):
                 failures.append("no beliefs in state")
 
         if "min_types" in expected:
             items = actual if isinstance(actual, list) else []
             if len(items) < expected["min_types"]:
-                failures.append(f"only {len(items)} types, need >= {expected['min_types']}")
+                failures.append(
+                    f"only {len(items)} types, need >= {expected['min_types']}"
+                )
 
         if "has_tiers" in expected:
             if not actual or (isinstance(actual, dict) and not actual.get("tiers")):
@@ -664,9 +683,7 @@ class PluginBenchmarkSuite:
         details = "; ".join(failures) if failures else "OK"
         return passed, details
 
-    def run_single(
-        self, plugin_name: str, case: dict
-    ) -> PluginBenchmarkResult:
+    def run_single(self, plugin_name: str, case: dict) -> PluginBenchmarkResult:
         """Run a single benchmark case against a plugin."""
         case_id = case["id"]
         function_name = case["function"]
@@ -700,8 +717,11 @@ class PluginBenchmarkSuite:
                 try:
                     loop = asyncio.get_running_loop()
                     import concurrent.futures
+
                     with concurrent.futures.ThreadPoolExecutor() as pool:
-                        raw_output = pool.submit(asyncio.run, raw_output).result(timeout=30)
+                        raw_output = pool.submit(asyncio.run, raw_output).result(
+                            timeout=30
+                        )
                 except RuntimeError:
                     raw_output = asyncio.run(raw_output)
 

--- a/argumentation_analysis/evaluation/run_agentic_eval.py
+++ b/argumentation_analysis/evaluation/run_agentic_eval.py
@@ -209,12 +209,14 @@ async def run_multi_round(
                 for pr in tr.phase_results.values()
                 if hasattr(pr, "status") and pr.status.value == "completed"
             )
-            round_stats.append({
-                "round": tr.turn_number,
-                "phases_completed": completed,
-                "confidence": round(tr.confidence, 3),
-                "duration": round(tr.duration_seconds, 1),
-            })
+            round_stats.append(
+                {
+                    "round": tr.turn_number,
+                    "phases_completed": completed,
+                    "confidence": round(tr.confidence, 3),
+                    "duration": round(tr.duration_seconds, 1),
+                }
+            )
 
     return {
         "mode": "multi_round",
@@ -252,7 +254,14 @@ async def score_with_judge(
         "actionability": score.actionability,
         "overall": score.overall,
         "composite": round(
-            (score.completeness + score.accuracy + score.depth + score.coherence + score.actionability) / 5,
+            (
+                score.completeness
+                + score.accuracy
+                + score.depth
+                + score.coherence
+                + score.actionability
+            )
+            / 5,
             2,
         ),
         "reasoning": score.reasoning,
@@ -317,7 +326,11 @@ async def run_agentic_eval(
         # 2) Multi-round conversational
         try:
             multi = await run_multi_round(
-                text, doc_id, workflow, full_registry, CAPABILITY_STATE_WRITERS,
+                text,
+                doc_id,
+                workflow,
+                full_registry,
+                CAPABILITY_STATE_WRITERS,
                 max_rounds=max_rounds,
             )
             all_results.append(multi)
@@ -409,15 +422,23 @@ def _compute_summary(
     max_rounds: int,
 ) -> Dict[str, Any]:
     """Compute aggregate summary."""
-    single_results = [r for r in results if r.get("mode") == "single_pass" and "error" not in r]
-    multi_results = [r for r in results if r.get("mode") == "multi_round" and "error" not in r]
+    single_results = [
+        r for r in results if r.get("mode") == "single_pass" and "error" not in r
+    ]
+    multi_results = [
+        r for r in results if r.get("mode") == "multi_round" and "error" not in r
+    ]
 
     def avg(values):
         return round(sum(values) / max(len(values), 1), 2)
 
     # Aggregate scores
-    single_scores = [c.get("single_pass", {}) for c in judge_comparisons if "single_pass" in c]
-    multi_scores = [c.get("multi_round", {}) for c in judge_comparisons if "multi_round" in c]
+    single_scores = [
+        c.get("single_pass", {}) for c in judge_comparisons if "single_pass" in c
+    ]
+    multi_scores = [
+        c.get("multi_round", {}) for c in judge_comparisons if "multi_round" in c
+    ]
 
     single_composites = [s["composite"] for s in single_scores if "composite" in s]
     multi_composites = [s["composite"] for s in multi_scores if "composite" in s]
@@ -428,8 +449,12 @@ def _compute_summary(
         "n_docs": len(single_results),
         "single_pass": {
             "avg_duration": avg([r["duration_seconds"] for r in single_results]),
-            "avg_non_empty_fields": avg([r["non_empty_fields"] for r in single_results]),
-            "avg_composite_score": avg(single_composites) if single_composites else None,
+            "avg_non_empty_fields": avg(
+                [r["non_empty_fields"] for r in single_results]
+            ),
+            "avg_composite_score": (
+                avg(single_composites) if single_composites else None
+            ),
             "scores_by_dimension": _avg_dimension_scores(single_scores),
         },
         "multi_round": {
@@ -487,9 +512,15 @@ def _print_summary(summary: Dict[str, Any]):
     print(f"\n{'Metric':<25} {'Single-pass':>12} {'Multi-round':>12} {'Delta':>8}")
     print("-" * 60)
     dr = delta.get("duration_ratio", "?")
-    print(f"{'Duration (avg)':<25} {sp.get('avg_duration', '?'):>10}s {mr.get('avg_duration', '?'):>10}s {f'x{dr}':>8}")
-    print(f"{'Non-empty fields':<25} {sp.get('avg_non_empty_fields', '?'):>12} {mr.get('avg_non_empty_fields', '?'):>12}")
-    print(f"{'Composite score':<25} {sp.get('avg_composite_score', '?'):>12} {mr.get('avg_composite_score', '?'):>12} {delta.get('composite', '?'):>8}")
+    print(
+        f"{'Duration (avg)':<25} {sp.get('avg_duration', '?'):>10}s {mr.get('avg_duration', '?'):>10}s {f'x{dr}':>8}"
+    )
+    print(
+        f"{'Non-empty fields':<25} {sp.get('avg_non_empty_fields', '?'):>12} {mr.get('avg_non_empty_fields', '?'):>12}"
+    )
+    print(
+        f"{'Composite score':<25} {sp.get('avg_composite_score', '?'):>12} {mr.get('avg_composite_score', '?'):>12} {delta.get('composite', '?'):>8}"
+    )
 
     for dim in ["completeness", "accuracy", "depth", "coherence", "actionability"]:
         sp_val = sp.get("scores_by_dimension", {}).get(dim, "?")
@@ -502,9 +533,13 @@ def _print_summary(summary: Dict[str, Any]):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Agentic conversation evaluation (#97)")
+    parser = argparse.ArgumentParser(
+        description="Agentic conversation evaluation (#97)"
+    )
     parser.add_argument("--max-docs", type=int, default=3, help="Max documents")
-    parser.add_argument("--max-text", type=int, default=5000, help="Max text chars per doc")
+    parser.add_argument(
+        "--max-text", type=int, default=5000, help="Max text chars per doc"
+    )
     parser.add_argument("--rounds", type=int, default=3, help="Max conversation rounds")
     parser.add_argument(
         "--output",

--- a/argumentation_analysis/evaluation/run_iteration.py
+++ b/argumentation_analysis/evaluation/run_iteration.py
@@ -183,9 +183,7 @@ def _build_iteration_workflow(iter_num: int, capabilities: List[str]):
             valid_deps = [
                 d
                 for d in deps
-                if any(
-                    p[0] == d and p[1] in capabilities for p in phase_order
-                )
+                if any(p[0] == d and p[1] in capabilities for p in phase_order)
             ]
             builder.add_phase(
                 name=phase_name,

--- a/argumentation_analysis/orchestration/conversation_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversation_orchestrator.py
@@ -599,7 +599,8 @@ class ConversationOrchestrator:
                 "fallacies_count": len(fallacies),
                 "sophistication_score": min(len(fallacies) * 0.2 + 0.3, 1.0),
                 "main_issues": [
-                    f.get("type", f.get("fallacy_type", "unknown")) for f in fallacies[:5]
+                    f.get("type", f.get("fallacy_type", "unknown"))
+                    for f in fallacies[:5]
                 ],
                 "raw_result": result,
             }

--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -131,10 +131,10 @@ AGENT_CONFIG = {
             "   is_valid=True/False, variables=JSON. confidence=0.0-1.0)\n\n"
             "ETAPE 2 — Validation Tweety :\n"
             "1. Pour les formules valides, appeelle check_propositional_consistency(\n"
-            "   input='{\"formulas\": [\"p => q\", \"q\"]}') \n"
+            '   input=\'{"formulas": ["p => q", "q"]}\') \n'
             "2. Pour FOL: check_fol_consistency(input='{\"formulas\": [...]}')\n"
             "3. Pour les modalites (possibilite/obligation): check_modal_satisfiability(\n"
-            "   input='{\"formula\": \"<>P\", \"logic_type\": \"S5\"}')\n"
+            '   input=\'{"formula": "<>P", "logic_type": "S5"}\')\n'
             "4. Si inconstistances: signalez au PM\n\n"
             "ETAPE 3 — Analyse Dung (Argumentation Abstraite) :\n"
             "1. Construis un graphe d'attaque depuis les arguments et sophismes detectes\n"
@@ -168,7 +168,7 @@ AGENT_CONFIG = {
             "   evaluate_argument_quality(text='...') → scores sur 9 vertus\n"
             "3. PUIS, utilise evaluate_with_cross_kb_context(text='...', cross_kb_context=JSON) "
             "en passant les sophismes detectes et resultats formels en contexte JSON :\n"
-            "   cross_kb_context = '{\"fallacies\": [...], \"formal_inconsistencies\": [...]}'\n"
+            '   cross_kb_context = \'{"fallacies": [...], "formal_inconsistencies": [...]}\'\n'
             "4. Le plugin retourne des scores de base + des recommandations d'ajustement\n"
             "5. Applique ton propre raisonnement LLM pour produire des scores AJUSTES finaux\n\n"
             "CROSS-KB (#208-I) — ajustements bases sur les autres agents :\n"
@@ -216,12 +216,12 @@ AGENT_CONFIG = {
         "instructions": (
             "Tu es l'agent de gouvernance et vote. Tu disposes de ces outils SPECIFIQUES :\n"
             "- detect_conflicts(positions_json) : detecte les conflits entre positions d'agents. "
-            "Input: JSON mapping noms d'agents → positions (ex: '{\"DebateAgent\": \"pour\", \"CounterAgent\": \"contre\"}')\n"
+            'Input: JSON mapping noms d\'agents → positions (ex: \'{"DebateAgent": "pour", "CounterAgent": "contre"}\')\n'
             "- compute_consensus_metrics(results_json) : calcule taux de consensus. "
             "Input: JSON avec 'votes' et 'winner'\n"
             "- social_choice_vote(input_json) : lance un vote formel. "
             "Input: JSON avec 'method' (copeland/schulze/stv/approval), 'ballots' (listes de preferences), 'options' (candidats). "
-            "Ex: '{\"method\": \"copeland\", \"ballots\": [[\"A\",\"B\",\"C\"],[\"B\",\"A\",\"C\"]], \"options\": [\"A\",\"B\",\"C\"]}'\n"
+            'Ex: \'{"method": "copeland", "ballots": [["A","B","C"],["B","A","C"]], "options": ["A","B","C"]}\'\n'
             "- find_condorcet_winner(input_json) : trouve le vainqueur de Condorcet. "
             "Input: JSON avec 'ballots' et 'options'\n\n"
             "Quand le PM te donne la parole :\n"
@@ -479,7 +479,12 @@ async def run_conversational_analysis(
             if needs_reanalysis:
                 reanalysis_cfg = {
                     "name": "Re-Analysis",
-                    "agents": ["ProjectManager", "InformalAgent", "QualityAgent", "GovernanceAgent"],
+                    "agents": [
+                        "ProjectManager",
+                        "InformalAgent",
+                        "QualityAgent",
+                        "GovernanceAgent",
+                    ],
                     "max_turns": 5,
                     "initial_prompt": (
                         "Re-analysez en tenant compte des resultats de l'analyse formelle.\n"
@@ -506,7 +511,9 @@ async def run_conversational_analysis(
                     )
 
                     try:
-                        trace.begin_phase(phase_name, state.get_state_snapshot(summarize=False))
+                        trace.begin_phase(
+                            phase_name, state.get_state_snapshot(summarize=False)
+                        )
                     except Exception:
                         trace.begin_phase(phase_name)
 
@@ -528,7 +535,9 @@ async def run_conversational_analysis(
                             content=msg.get("content", ""),
                         )
                     try:
-                        trace.end_phase(phase_name, state.get_state_snapshot(summarize=False))
+                        trace.end_phase(
+                            phase_name, state.get_state_snapshot(summarize=False)
+                        )
                     except Exception:
                         trace.end_phase(phase_name)
 
@@ -590,8 +599,12 @@ async def run_conversational_analysis(
                 )
             elif agent == "FormalAgent":
                 capabilities_used.update(
-                    ["nl_to_logic_translation", "fol_reasoning", "modal_logic",
-                     "propositional_logic"]
+                    [
+                        "nl_to_logic_translation",
+                        "fol_reasoning",
+                        "modal_logic",
+                        "propositional_logic",
+                    ]
                 )
             elif agent == "QualityAgent":
                 capabilities_used.add("argument_quality")
@@ -680,14 +693,18 @@ def _check_convergence(state, phase_name: str, messages: list) -> bool:
     """
     # Signal 1: conclusion set during Synthesis
     if state and state.final_conclusion:
-        logger.info(f"  [{phase_name}] CONVERGENCE: final conclusion set, exiting early")
+        logger.info(
+            f"  [{phase_name}] CONVERGENCE: final conclusion set, exiting early"
+        )
         return True
 
     # Signal 2: stagnation detection (last 2 messages empty or identical)
     if len(messages) >= 3:
         recent = [m.get("content", "") for m in messages[-2:]]
         if all(c in ("(empty)", "", "ERROR") or len(c) < 10 for c in recent):
-            logger.info(f"  [{phase_name}] CONVERGENCE: stagnation detected, exiting early")
+            logger.info(
+                f"  [{phase_name}] CONVERGENCE: stagnation detected, exiting early"
+            )
             return True
 
     return False
@@ -701,7 +718,11 @@ def _select_next_agent(
     Falls back to round-robin if no designation or designated agent not in phase.
     """
     # Check if PM designated a specific agent
-    if state and hasattr(state, "_next_agent_designated") and state._next_agent_designated:
+    if (
+        state
+        and hasattr(state, "_next_agent_designated")
+        and state._next_agent_designated
+    ):
         designated = state._next_agent_designated
         state._next_agent_designated = None  # Consume the designation
 
@@ -712,7 +733,9 @@ def _select_next_agent(
                 return agent
 
         # Designated agent not in this phase, fall through to round-robin
-        logger.debug(f"  PM designated '{designated}' but not in phase agents, using round-robin")
+        logger.debug(
+            f"  PM designated '{designated}' but not in phase agents, using round-robin"
+        )
 
     # Round-robin fallback
     return agents[turn % len(agents)]
@@ -838,7 +861,9 @@ async def _resolve_phase_conflicts(
     Returns:
         List of resolution results applied to the state.
     """
-    from argumentation_analysis.services.jtms.conflict_resolution import ConflictResolver
+    from argumentation_analysis.services.jtms.conflict_resolution import (
+        ConflictResolver,
+    )
 
     resolver = ConflictResolver()
     resolutions = []
@@ -853,9 +878,19 @@ async def _resolve_phase_conflicts(
 
     # Pattern 1: Fallacy vs High Quality
     try:
-        fallacies_dict = state.identified_fallacies if hasattr(state, "identified_fallacies") else {}
-        fallacies = list(fallacies_dict.values()) if isinstance(fallacies_dict, dict) else fallacies_dict
-        quality_scores = state.argument_quality_scores if hasattr(state, "argument_quality_scores") else {}
+        fallacies_dict = (
+            state.identified_fallacies if hasattr(state, "identified_fallacies") else {}
+        )
+        fallacies = (
+            list(fallacies_dict.values())
+            if isinstance(fallacies_dict, dict)
+            else fallacies_dict
+        )
+        quality_scores = (
+            state.argument_quality_scores
+            if hasattr(state, "argument_quality_scores")
+            else {}
+        )
 
         if fallacies and quality_scores:
             for fallacy in fallacies:
@@ -874,12 +909,15 @@ async def _resolve_phase_conflicts(
                                     "agents": {
                                         "InformalAgent": {
                                             "belief_name": f"FALLACY:{fallacy.get('type', fallacy.get('fallacy_type', 'unknown'))}",
-                                            "confidence": fallacy.get("confidence", 0.7),
+                                            "confidence": fallacy.get(
+                                                "confidence", 0.7
+                                            ),
                                             "evidence": fallacy.get("explanation", ""),
                                         },
                                         "QualityAgent": {
                                             "belief_name": f"QUALITY:{target_arg}",
-                                            "confidence": score / 9.0,  # Normalize to 0-1
+                                            "confidence": score
+                                            / 9.0,  # Normalize to 0-1
                                             "evidence": f"Quality score {score}/9",
                                         },
                                     },
@@ -940,7 +978,11 @@ def _retract_fallacious_beliefs(
         return None
 
     fallacies_dict = getattr(state, "identified_fallacies", {})
-    fallacies = list(fallacies_dict.values()) if isinstance(fallacies_dict, dict) else fallacies_dict
+    fallacies = (
+        list(fallacies_dict.values())
+        if isinstance(fallacies_dict, dict)
+        else fallacies_dict
+    )
     if not fallacies:
         return None
 
@@ -964,7 +1006,8 @@ def _retract_fallacious_beliefs(
         else:
             # Try common patterns: arg_N, argument_N, belief about arg_N
             candidates = [
-                name for name in session.extended_beliefs
+                name
+                for name in session.extended_beliefs
                 if target_arg.lower() in name.lower()
                 or name.lower() in target_arg.lower()
             ]
@@ -988,10 +1031,14 @@ def _retract_fallacious_beliefs(
 
             # Record retraction in extended belief via modification history
             import datetime
-            ext_belief.record_modification("retract", {
-                "reason": reason,
-                "timestamp": datetime.datetime.now().isoformat(),
-            })
+
+            ext_belief.record_modification(
+                "retract",
+                {
+                    "reason": reason,
+                    "timestamp": datetime.datetime.now().isoformat(),
+                },
+            )
             ext_belief.context["retracted"] = True
             ext_belief.context["retraction_reason"] = reason
 

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -17,6 +17,7 @@ logger = logging.getLogger("UnifiedPipeline")
 # Ensure .env is loaded so OPENAI_API_KEY is available for all invoke callables
 try:
     from dotenv import load_dotenv
+
     load_dotenv()
 except ImportError:
     pass
@@ -99,7 +100,9 @@ def _get_openai_client() -> Tuple[Any, str]:
 # Each callable: async (input_text: str, context: Dict[str, Any]) -> Any
 
 
-async def _invoke_quality_evaluator(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_quality_evaluator(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke 9-virtue argument quality evaluator on each extracted argument.
 
     Evaluates individual arguments from upstream fact_extraction rather than
@@ -120,9 +123,7 @@ async def _invoke_quality_evaluator(input_text: str, context: Dict[str, Any]) ->
     # (#289) Read fallacy output to penalize arguments affected by fallacies
     fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
     detected_fallacies = (
-        fallacy_output.get("fallacies", [])
-        if isinstance(fallacy_output, dict)
-        else []
+        fallacy_output.get("fallacies", []) if isinstance(fallacy_output, dict) else []
     )
     # Build a map: arg_index → list of fallacy types targeting that argument
     fallacy_targets: Dict[int, list[str]] = {}
@@ -134,7 +135,9 @@ async def _invoke_quality_evaluator(input_text: str, context: Dict[str, Any]) ->
         if target_text and raw_args:
             target_lower = target_text.lower()[:80]
             for idx, a in enumerate(raw_args[:8]):
-                a_text = (a.get("text", str(a)) if isinstance(a, dict) else str(a)).lower()
+                a_text = (
+                    a.get("text", str(a)) if isinstance(a, dict) else str(a)
+                ).lower()
                 if target_lower in a_text or a_text[:40] in target_lower:
                     fallacy_targets.setdefault(idx, []).append(str(fallacy_type))
                     break
@@ -152,7 +155,9 @@ async def _invoke_quality_evaluator(input_text: str, context: Dict[str, Any]) ->
                 if i in fallacy_targets:
                     penalty = min(0.3 * len(fallacy_targets[i]), 0.6)
                     original_score = result.get("note_finale", 0)
-                    result["note_finale"] = max(0, original_score - original_score * penalty)
+                    result["note_finale"] = max(
+                        0, original_score - original_score * penalty
+                    )
                     result["fallacy_penalty"] = {
                         "applied": True,
                         "fallacies": fallacy_targets[i],
@@ -183,18 +188,14 @@ async def _invoke_quality_evaluator(input_text: str, context: Dict[str, Any]) ->
                         continue
                     eid = enr.get("arg_id", "")
                     if eid in results and isinstance(results[eid], dict):
-                        results[eid]["llm_assessment"] = enr.get(
-                            "llm_assessment", ""
-                        )
+                        results[eid]["llm_assessment"] = enr.get("llm_assessment", "")
                         results[eid]["reasoning_assessment"] = enr.get(
                             "reasoning_assessment", ""
                         )
                         results[eid]["evidence_quality"] = enr.get(
                             "evidence_quality", ""
                         )
-                        results[eid]["bias_indicators"] = enr.get(
-                            "bias_indicators", []
-                        )
+                        results[eid]["bias_indicators"] = enr.get("bias_indicators", [])
 
             output = {
                 "per_argument_scores": results,
@@ -292,7 +293,7 @@ async def _llm_enrich_quality(
                     continue
                 ftype = f.get("type", f.get("fallacy_type", "unknown"))
                 target = f.get("target_argument", "")[:80]
-                fallacy_lines.append(f"  - {ftype}: \"{target}\"")
+                fallacy_lines.append(f'  - {ftype}: "{target}"')
             if fallacy_lines:
                 fallacy_context = (
                     "\n\nDETECTED FALLACIES in this text:\n"
@@ -326,7 +327,10 @@ async def _llm_enrich_quality(
                         '"llm_assessment": "Brief qualitative narrative..."}]}'
                     ),
                 },
-                {"role": "user", "content": "\n\n".join(score_summary) + fallacy_context},
+                {
+                    "role": "user",
+                    "content": "\n\n".join(score_summary) + fallacy_context,
+                },
             ],
         )
         raw = response.choices[0].message.content or ""
@@ -344,7 +348,9 @@ async def _llm_enrich_quality(
     return None
 
 
-async def _invoke_counter_argument(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_counter_argument(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke counter-argument analysis via plugin + LLM enrichment."""
     from argumentation_analysis.agents.core.counter_argument.counter_agent import (
         CounterArgumentPlugin,
@@ -542,7 +548,9 @@ def _evaluate_counter_arguments(
     return llm_counters
 
 
-async def _invoke_debate_analysis(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_debate_analysis(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke debate argument analysis via plugin + LLM adversarial assessment."""
     from argumentation_analysis.agents.core.debate.debate_agent import DebatePlugin
 
@@ -618,16 +626,17 @@ async def _invoke_debate_analysis(input_text: str, context: Dict[str, Any]) -> D
                     if isinstance(scores, dict):
                         note = scores.get("note_finale", "?")
                         penalty = scores.get("fallacy_penalty", {})
-                        suffix = " [PENALIZED by fallacy]" if penalty.get("applied") else ""
+                        suffix = (
+                            " [PENALIZED by fallacy]" if penalty.get("applied") else ""
+                        )
                         quality_lines.append(f"  {key}: {note}/10{suffix}")
                 if quality_lines:
-                    debate_parts.append(
-                        "QUALITY SCORES:\n" + "\n".join(quality_lines)
-                    )
+                    debate_parts.append("QUALITY SCORES:\n" + "\n".join(quality_lines))
             # (#289) Cross-KB: JTMS beliefs inform debate about retracted claims
             if isinstance(jtms_output, dict) and jtms_output.get("beliefs"):
                 retracted = [
-                    k for k, v in jtms_output["beliefs"].items()
+                    k
+                    for k, v in jtms_output["beliefs"].items()
                     if isinstance(v, dict) and not v.get("valid", True)
                 ]
                 if retracted:
@@ -635,7 +644,9 @@ async def _invoke_debate_analysis(input_text: str, context: Dict[str, Any]) -> D
                         f"RETRACTED BELIEFS (JTMS): {', '.join(retracted[:5])}"
                     )
                 if not jtms_output.get("formal_consistency", True):
-                    debate_parts.append("WARNING: Formal inconsistency detected in PL/FOL analysis")
+                    debate_parts.append(
+                        "WARNING: Formal inconsistency detected in PL/FOL analysis"
+                    )
 
             debate_material = (
                 "\n\n".join(debate_parts) if debate_parts else input_text[:1500]
@@ -684,7 +695,9 @@ async def _invoke_debate_analysis(input_text: str, context: Dict[str, Any]) -> D
     return base_scores  # type: ignore[no-any-return]
 
 
-async def _invoke_governance(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_governance(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke governance analysis via plugin + LLM-powered deliberation assessment."""
     from argumentation_analysis.plugins.governance_plugin import GovernancePlugin
 
@@ -734,11 +747,13 @@ async def _invoke_governance(input_text: str, context: Dict[str, Any]) -> Dict[s
             for agent in options:
                 pref = [a for a in options if a != agent] + [agent]
                 ballots.append(pref)
-            vote_input = json.dumps({
-                "method": "copeland",
-                "ballots": ballots,
-                "options": options,
-            })
+            vote_input = json.dumps(
+                {
+                    "method": "copeland",
+                    "ballots": ballots,
+                    "options": options,
+                }
+            )
             vote_result = json.loads(plugin.social_choice_vote(vote_input))
         except Exception as e:
             logger.debug(f"Social choice vote skipped: {e}")
@@ -792,12 +807,15 @@ async def _invoke_governance(input_text: str, context: Dict[str, Any]) -> Dict[s
             )
             if per_arg_scores:
                 avg_score = sum(
-                    s.get("note_finale", 0) for s in per_arg_scores.values()
+                    s.get("note_finale", 0)
+                    for s in per_arg_scores.values()
                     if isinstance(s, dict)
                 ) / max(len(per_arg_scores), 1)
                 penalized = sum(
-                    1 for s in per_arg_scores.values()
-                    if isinstance(s, dict) and s.get("fallacy_penalty", {}).get("applied")
+                    1
+                    for s in per_arg_scores.values()
+                    if isinstance(s, dict)
+                    and s.get("fallacy_penalty", {}).get("applied")
                 )
                 context_parts.append(
                     f"Quality assessment: avg score {avg_score:.1f}/10, "
@@ -817,7 +835,8 @@ async def _invoke_governance(input_text: str, context: Dict[str, Any]) -> Dict[s
                 context_parts.append(f"Fallacies detected: {', '.join(ftypes)}")
             if isinstance(jtms_output, dict):
                 retracted = [
-                    k for k, v in jtms_output.get("beliefs", {}).items()
+                    k
+                    for k, v in jtms_output.get("beliefs", {}).items()
                     if isinstance(v, dict) and not v.get("valid", True)
                 ]
                 if retracted:
@@ -920,9 +939,7 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
     # Fallacies
     fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
     detected_fallacies = (
-        fallacy_output.get("fallacies", [])
-        if isinstance(fallacy_output, dict)
-        else []
+        fallacy_output.get("fallacies", []) if isinstance(fallacy_output, dict) else []
     )
 
     # Counter-arguments
@@ -942,7 +959,9 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
 
     # ── Build belief names ───────────────────────────────────────────
     def _text(item: Any) -> str:
-        return (item.get("text", str(item)) if isinstance(item, dict) else str(item))[:80]
+        return (item.get("text", str(item)) if isinstance(item, dict) else str(item))[
+            :80
+        ]
 
     arg_beliefs = [_text(a) for a in raw_args[:10]]
     claim_beliefs = [_text(c) for c in raw_claims[:6]]
@@ -955,7 +974,11 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
     for i, name in enumerate(arg_beliefs + claim_beliefs):
         is_arg = i < len(arg_beliefs)
         belief_type = "premise" if is_arg else "claim"
-        confidence: float = float(per_arg_scores.get(f"arg_{i+1}", per_arg_scores.get(f"argument_{i+1}", {})).get("note_finale", 0.5))
+        confidence: float = float(
+            per_arg_scores.get(
+                f"arg_{i+1}", per_arg_scores.get(f"argument_{i+1}", {})
+            ).get("note_finale", 0.5)
+        )
         session.add_belief(
             name,
             agent_source="unified_pipeline",
@@ -1036,7 +1059,10 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
             )
             # The defeat holds when the fallacy is IN and the argument is OUT
             session.add_justification(
-                [fallacy_name], [target_arg], defeat_name, agent_source="fallacy_detector"
+                [fallacy_name],
+                [target_arg],
+                defeat_name,
+                agent_source="fallacy_detector",
             )
             # Retract the undermined argument
             session.jtms.set_belief_validity(target_arg, False)
@@ -1071,7 +1097,10 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
                     confidence=confidence,
                 )
                 session.add_justification(
-                    [ca_text], [matched], rebuttal_name, agent_source="counter_argument_generator"
+                    [ca_text],
+                    [matched],
+                    rebuttal_name,
+                    agent_source="counter_argument_generator",
                 )
 
     # ── Step 5b: Formal inconsistency → flag in belief network (#285) ─
@@ -1081,8 +1110,16 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
             inconsistency_name,
             agent_source="formal_logic",
             context={
-                "pl_satisfiable": pl_output.get("satisfiable") if isinstance(pl_output, dict) else None,
-                "fol_satisfiable": fol_output.get("satisfiable") if isinstance(fol_output, dict) else None,
+                "pl_satisfiable": (
+                    pl_output.get("satisfiable")
+                    if isinstance(pl_output, dict)
+                    else None
+                ),
+                "fol_satisfiable": (
+                    fol_output.get("satisfiable")
+                    if isinstance(fol_output, dict)
+                    else None
+                ),
             },
             confidence=0.9,
         )
@@ -1132,12 +1169,20 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
     return {
         "beliefs": beliefs_output,
         "belief_count": len(session.extended_beliefs),
-        "justified_count": sum(1 for b in session.jtms.beliefs.values() if b.justifications),
+        "justified_count": sum(
+            1 for b in session.jtms.beliefs.values() if b.justifications
+        ),
         "valid_count": sum(1 for b in session.jtms.beliefs.values() if b.valid is True),
-        "undermined_count": sum(1 for b in session.jtms.beliefs.values() if b.valid is False),
+        "undermined_count": sum(
+            1 for b in session.jtms.beliefs.values() if b.valid is False
+        ),
         "fallacy_count": len(fallacy_beliefs),
-        "counter_argument_count": len([ca for ca in counter_args[:4] if isinstance(ca, dict)]),
-        "has_real_dependencies": bool(arg_beliefs and (claim_beliefs or fallacy_beliefs)),
+        "counter_argument_count": len(
+            [ca for ca in counter_args[:4] if isinstance(ca, dict)]
+        ),
+        "has_real_dependencies": bool(
+            arg_beliefs and (claim_beliefs or fallacy_beliefs)
+        ),
         "formal_consistency": formal_consistency,
         "session_version": session.version,
         "consistency_checks": session.consistency_checks,
@@ -1167,9 +1212,7 @@ async def _invoke_atms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
 
     fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
     detected_fallacies = (
-        fallacy_output.get("fallacies", [])
-        if isinstance(fallacy_output, dict)
-        else []
+        fallacy_output.get("fallacies", []) if isinstance(fallacy_output, dict) else []
     )
 
     quality_output = context.get("phase_quality_output", {})
@@ -1181,7 +1224,9 @@ async def _invoke_atms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
 
     # ── Helper ───────────────────────────────────────────────────────
     def _text(item: Any) -> str:
-        return (item.get("text", str(item)) if isinstance(item, dict) else str(item))[:60]
+        return (item.get("text", str(item)) if isinstance(item, dict) else str(item))[
+            :60
+        ]
 
     # ── Step 1: Arguments → assumptions ──────────────────────────────
     arg_names: list[str] = []
@@ -1214,7 +1259,9 @@ async def _invoke_atms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
         fallacy_type = f.get("type", f.get("fallacy_type", f"fallacy_{i+1}"))
         contra_name = f"CONTRA:{fallacy_type}"[:60]
         atms.add_node(contra_name)
-        target_arg = arg_names[i] if i < len(arg_names) else arg_names[0] if arg_names else None
+        target_arg = (
+            arg_names[i] if i < len(arg_names) else arg_names[0] if arg_names else None
+        )
         if target_arg:
             atms.add_justification([target_arg], [], contra_name)
             # Mark as contradiction — the assumption leads to inconsistency
@@ -1237,9 +1284,7 @@ async def _invoke_atms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
         if not node_data["is_assumption"]:
             for env in node_data["environments"]:
                 if atms.is_consistent(frozenset(env)):
-                    consistent_envs.append(
-                        {"belief": node_name, "environment": env}
-                    )
+                    consistent_envs.append({"belief": node_name, "environment": env})
 
     # ── Step 5: Multi-context hypothesis testing (#349) ──────────────
     hypotheses = _generate_hypotheses(
@@ -1269,16 +1314,18 @@ async def _invoke_atms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
                     contradicting_beliefs.append(name)
                     break
 
-        atms_contexts.append({
-            "hypothesis_id": hyp["id"],
-            "label": hyp["label"],
-            "assumptions": sorted(hyp_assumptions),
-            "coherent": is_consistent,
-            "derivable_beliefs": sorted(set(derivable_beliefs)),
-            "contradicting_beliefs": sorted(set(contradicting_beliefs)),
-            "derivation_count": len(derivable_beliefs),
-            "contradiction_count": len(contradicting_beliefs),
-        })
+        atms_contexts.append(
+            {
+                "hypothesis_id": hyp["id"],
+                "label": hyp["label"],
+                "assumptions": sorted(hyp_assumptions),
+                "coherent": is_consistent,
+                "derivable_beliefs": sorted(set(derivable_beliefs)),
+                "contradicting_beliefs": sorted(set(contradicting_beliefs)),
+                "derivation_count": len(derivable_beliefs),
+                "contradiction_count": len(contradicting_beliefs),
+            }
+        )
 
     return {
         "assumption_count": len(assumptions),
@@ -1308,11 +1355,13 @@ def _generate_hypotheses(
     hypotheses = []
 
     # Hypothesis 1: Accept all arguments (full trust context)
-    hypotheses.append({
-        "id": "h_full_trust",
-        "label": "All arguments accepted",
-        "assumptions": list(arg_names),
-    })
+    hypotheses.append(
+        {
+            "id": "h_full_trust",
+            "label": "All arguments accepted",
+            "assumptions": list(arg_names),
+        }
+    )
 
     # Hypothesis 2: Exclude arguments implicated in fallacies
     fallacy_targets = set()
@@ -1327,20 +1376,27 @@ def _generate_hypotheses(
     clean_args = [
         a
         for a in arg_names
-        if not any(t and (a == t or a.startswith(t) or t.startswith(a)) for t in fallacy_targets)
+        if not any(
+            t and (a == t or a.startswith(t) or t.startswith(a))
+            for t in fallacy_targets
+        )
     ]
     if clean_args and set(clean_args) != set(arg_names):
-        hypotheses.append({
-            "id": "h_fallacy_excluded",
-            "label": "Arguments implicated in fallacies excluded",
-            "assumptions": list(clean_args),
-        })
+        hypotheses.append(
+            {
+                "id": "h_fallacy_excluded",
+                "label": "Arguments implicated in fallacies excluded",
+                "assumptions": list(clean_args),
+            }
+        )
     elif len(arg_names) >= 2:
-        hypotheses.append({
-            "id": "h_partial_accept",
-            "label": "Partial acceptance (last argument excluded)",
-            "assumptions": list(arg_names[:-1]),
-        })
+        hypotheses.append(
+            {
+                "id": "h_partial_accept",
+                "label": "Partial acceptance (last argument excluded)",
+                "assumptions": list(arg_names[:-1]),
+            }
+        )
 
     # Hypothesis 3: Only high-quality arguments (if quality data available)
     if per_arg_scores:
@@ -1356,36 +1412,47 @@ def _generate_hypotheses(
                         scores = candidate
                         break
             if isinstance(scores, dict):
-                if float(str(scores.get("overall", scores.get("note_finale", 0)))) >= 3.0:
+                if (
+                    float(str(scores.get("overall", scores.get("note_finale", 0))))
+                    >= 3.0
+                ):
                     high_quality.append(arg_name)
         if high_quality and set(high_quality) != set(arg_names):
-            hypotheses.append({
-                "id": "h_high_quality",
-                "label": "Only high-quality arguments",
-                "assumptions": list(high_quality),
-            })
+            hypotheses.append(
+                {
+                    "id": "h_high_quality",
+                    "label": "Only high-quality arguments",
+                    "assumptions": list(high_quality),
+                }
+            )
 
     # Hypothesis 4: Minimal set -- first argument only (skeptical context)
     if len(arg_names) >= 2:
-        hypotheses.append({
-            "id": "h_skeptical",
-            "label": "Skeptical: single argument only",
-            "assumptions": [arg_names[0]],
-        })
+        hypotheses.append(
+            {
+                "id": "h_skeptical",
+                "label": "Skeptical: single argument only",
+                "assumptions": [arg_names[0]],
+            }
+        )
 
     # Ensure at least 3 hypotheses
     if len(hypotheses) < 3 and len(arg_names) >= 3:
         mid = len(arg_names) // 2
-        hypotheses.append({
-            "id": "h_first_half",
-            "label": "First half of arguments",
-            "assumptions": list(arg_names[:mid]),
-        })
+        hypotheses.append(
+            {
+                "id": "h_first_half",
+                "label": "First half of arguments",
+                "assumptions": list(arg_names[:mid]),
+            }
+        )
 
     return hypotheses[:4]
 
 
-async def _invoke_camembert_fallacy(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_camembert_fallacy(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke self-hosted LLM fallacy detector via SK function calling (#297).
 
     Replaces the dead CamemBERT Tier 2.5 with a self-hosted LLM endpoint
@@ -1472,7 +1539,9 @@ async def _invoke_local_llm(input_text: str, context: Dict[str, Any]) -> Dict[st
     return await service.chat_completion(messages)
 
 
-async def _invoke_semantic_index(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_semantic_index(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke semantic index service for argument search."""
     from argumentation_analysis.services.semantic_index_service import (
         SemanticIndexService,
@@ -1580,9 +1649,7 @@ def _generate_attacks_from_args(
             if target_text:
                 best_overlap = 0
                 for arg in arguments:
-                    overlap = len(
-                        set(target_text.split()) & set(arg.lower().split())
-                    )
+                    overlap = len(set(target_text.split()) & set(arg.lower().split()))
                     if overlap > best_overlap:
                         best_overlap = overlap
                         target_arg = arg
@@ -2023,7 +2090,9 @@ async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict[str, A
         return _python_aspic_fallback(args, strict, defeasible, fallacies, context)
 
 
-async def _invoke_belief_revision(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_belief_revision(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke belief revision — revise beliefs based on counter-arguments and fallacies.
 
     Uses upstream counter-arguments or fallacy detections as new evidence that
@@ -2094,7 +2163,9 @@ async def _invoke_belief_revision(input_text: str, context: Dict[str, Any]) -> D
         }
 
 
-async def _invoke_probabilistic(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_probabilistic(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke probabilistic argumentation handler with JVM fallback."""
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
@@ -2703,6 +2774,7 @@ async def _invoke_qbf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
         logger.info(f"QBF JVM handler unavailable ({e}), using native Python fallback")
         try:
             from argumentation_analysis.agents.core.logic.qbf_native import analyze_qbf
+
             return await asyncio.to_thread(analyze_qbf, quantifiers, formula)
         except Exception as e2:
             logger.warning(f"QBF native fallback also failed: {e2}")
@@ -2791,6 +2863,7 @@ async def _invoke_hierarchical_fallacy(
         # marks this phase as FAILED instead of silently returning empty results.
         # This makes debugging possible when the phase produces 0 fallacies.
         import traceback
+
         logger.error(
             "Hierarchical fallacy detection failed with unexpected error:\n%s",
             traceback.format_exc(),
@@ -2834,7 +2907,9 @@ def _normalize_fallacies_with_quotes(items: list[Any]) -> list[Dict[str, Any]]:
     return result
 
 
-async def _invoke_fact_extraction(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_fact_extraction(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Extract verifiable claims and arguments from text using LLM with heuristic fallback."""
     import re
 
@@ -2912,7 +2987,9 @@ async def _invoke_fact_extraction(input_text: str, context: Dict[str, Any]) -> D
     }
 
 
-async def _invoke_propositional_logic(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_propositional_logic(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke propositional logic analysis — translate arguments to propositions.
 
     If NL-to-logic translations are available from an upstream phase, uses
@@ -2928,12 +3005,11 @@ async def _invoke_propositional_logic(input_text: str, context: Dict[str, Any]) 
         # (#208-H) Check if NL-to-logic phase already produced PL translations
         nl_output = context.get("phase_nl_to_logic_output", {})
         nl_translations = (
-            nl_output.get("translations", [])
-            if isinstance(nl_output, dict)
-            else []
+            nl_output.get("translations", []) if isinstance(nl_output, dict) else []
         )
         pl_translations = [
-            t for t in nl_translations
+            t
+            for t in nl_translations
             if isinstance(t, dict)
             and t.get("logic_type") == "propositional"
             and t.get("is_valid")
@@ -3007,7 +3083,8 @@ async def _invoke_propositional_logic(input_text: str, context: Dict[str, Any]) 
             "model": {f"p{i+1}": True for i in range(len(args))},
             "message": msg,
             "logic_type": "propositional",
-            "argument_mapping": argument_mapping or {f"p{i+1}": a[:60] for i, a in enumerate(args)},
+            "argument_mapping": argument_mapping
+            or {f"p{i+1}": a[:60] for i, a in enumerate(args)},
         }
     except Exception as e:
         # Fallback: basic consistency check
@@ -3022,12 +3099,15 @@ async def _invoke_propositional_logic(input_text: str, context: Dict[str, Any]) 
             "satisfiable": not has_contradiction,
             "model": {f"p{i+1}": True for i in range(len(args))},
             "logic_type": "propositional",
-            "argument_mapping": argument_mapping or {f"p{i+1}": a[:60] for i, a in enumerate(args)},
+            "argument_mapping": argument_mapping
+            or {f"p{i+1}": a[:60] for i, a in enumerate(args)},
             "fallback": "python",
         }
 
 
-async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_fol_reasoning(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke first-order logic analysis — translate arguments to FOL predicates.
 
     If NL-to-logic translations are available from an upstream phase, uses
@@ -3040,12 +3120,11 @@ async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dic
         # (#208-H) Check if NL-to-logic phase already produced FOL translations
         nl_output = context.get("phase_nl_to_logic_output", {})
         nl_translations = (
-            nl_output.get("translations", [])
-            if isinstance(nl_output, dict)
-            else []
+            nl_output.get("translations", []) if isinstance(nl_output, dict) else []
         )
         fol_translations = [
-            t for t in nl_translations
+            t
+            for t in nl_translations
             if isinstance(t, dict)
             and t.get("logic_type") == "fol"
             and t.get("is_valid")
@@ -3125,7 +3204,9 @@ async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dic
 
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
-        from argumentation_analysis.agents.core.logic.fol_logic_agent import FOLLogicAgent
+        from argumentation_analysis.agents.core.logic.fol_logic_agent import (
+            FOLLogicAgent,
+        )
 
         bridge = TweetyBridge()
         # Pre-declare signature (sorts + types) for Tweety FolParser (#348)
@@ -3152,7 +3233,10 @@ async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dic
         # Still extract signature metadata even in fallback (#348)
         fol_signature = []
         try:
-            from argumentation_analysis.agents.core.logic.fol_logic_agent import FOLLogicAgent
+            from argumentation_analysis.agents.core.logic.fol_logic_agent import (
+                FOLLogicAgent,
+            )
+
             meta = FOLLogicAgent.extract_fol_metadata(formulas)
             fol_signature = meta.get("signature_lines", [])
         except Exception:
@@ -3169,7 +3253,9 @@ async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dic
         }
 
 
-async def _invoke_nl_to_logic(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_nl_to_logic(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Translate extracted NL arguments to formal logic with validation (#173).
 
     Uses LLM to generate propositional/FOL formulas, validates via Tweety
@@ -3188,16 +3274,18 @@ async def _invoke_nl_to_logic(input_text: str, context: Dict[str, Any]) -> Dict[
 
     translations = []
     for t in batch_result.translations:
-        translations.append({
-            "original_text": t.original_text[:200],
-            "formula": t.formula,
-            "logic_type": t.logic_type,
-            "is_valid": t.is_valid,
-            "validation_message": t.validation_message,
-            "attempts": t.attempts,
-            "variables": t.variables,
-            "confidence": t.confidence,
-        })
+        translations.append(
+            {
+                "original_text": t.original_text[:200],
+                "formula": t.formula,
+                "logic_type": t.logic_type,
+                "is_valid": t.is_valid,
+                "validation_message": t.validation_message,
+                "attempts": t.attempts,
+                "variables": t.variables,
+                "confidence": t.confidence,
+            }
+        )
 
     valid_count = sum(1 for t in translations if t["is_valid"])
     return {
@@ -3211,7 +3299,9 @@ async def _invoke_nl_to_logic(input_text: str, context: Dict[str, Any]) -> Dict[
     }
 
 
-async def _invoke_modal_logic(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_modal_logic(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke modal logic analysis via TweetyBridge (JVM required)."""
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
@@ -3237,7 +3327,9 @@ async def _invoke_modal_logic(input_text: str, context: Dict[str, Any]) -> Dict[
         return {"error": str(e), "formulas": [], "valid": False, "modalities": []}
 
 
-async def _invoke_dung_extensions(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_dung_extensions(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke Dung framework extension computation via AFHandler (JVM required).
 
     Builds attack graph from extracted arguments and detected fallacies,
@@ -3253,7 +3345,9 @@ async def _invoke_dung_extensions(input_text: str, context: Dict[str, Any]) -> D
     # 3. Compute extensions via Tweety (or Python fallback)
     try:
         from argumentation_analysis.agents.core.logic.af_handler import AFHandler
-        from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
 
         initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = AFHandler(initializer)
@@ -3328,9 +3422,7 @@ def _python_dung_fallback(
                 any(att in attack_map.get(g, []) for g in grounded)
                 for att in attacked_by[arg]
             )
-            if defended and all(
-                att not in grounded for att in attack_map.get(arg, [])
-            ):
+            if defended and all(att not in grounded for att in attack_map.get(arg, [])):
                 # Also check: arg doesn't attack itself (conflict-free)
                 grounded.add(arg)
                 changed = True
@@ -3351,7 +3443,9 @@ def _python_dung_fallback(
     }
 
 
-async def _invoke_formal_synthesis(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_formal_synthesis(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Aggregate all formal analysis results from upstream phases into a unified report."""
     phase_results = {}
     overall_scores = []
@@ -3403,16 +3497,22 @@ async def _invoke_formal_synthesis(input_text: str, context: Dict[str, Any]) -> 
     }
 
 
-async def _invoke_narrative_synthesis(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
+async def _invoke_narrative_synthesis(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
     """Invoke narrative synthesis to produce readable prose from all phase outputs (#351).
 
     Reads state from context (populated by prior phases) and calls
     build_narrative to generate 1-2 paragraphs weaving together quality,
     fallacies, JTMS, ATMS, Dung, and formal logic results.
     """
-    from argumentation_analysis.plugins.narrative_synthesis_plugin import build_narrative
+    from argumentation_analysis.plugins.narrative_synthesis_plugin import (
+        build_narrative,
+    )
     from argumentation_analysis.core.shared_state import UnifiedAnalysisState
-    from argumentation_analysis.orchestration.state_writers import CAPABILITY_STATE_WRITERS
+    from argumentation_analysis.orchestration.state_writers import (
+        CAPABILITY_STATE_WRITERS,
+    )
 
     # Reconstruct state from context if possible
     state = context.get("_state_object")
@@ -3469,5 +3569,3 @@ def _count_referenced_fields(state: Any) -> int:
 # Each writer extracts relevant data from phase output and writes to
 # UnifiedAnalysisState via its typed add_*() methods.
 # Writers are defensive: guard with isinstance checks and .get() everywhere.
-
-

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -99,7 +99,7 @@ def _get_openai_client() -> Tuple[Any, str]:
 # Each callable: async (input_text: str, context: Dict[str, Any]) -> Any
 
 
-async def _invoke_quality_evaluator(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_quality_evaluator(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke 9-virtue argument quality evaluator on each extracted argument.
 
     Evaluates individual arguments from upstream fact_extraction rather than
@@ -125,7 +125,7 @@ async def _invoke_quality_evaluator(input_text: str, context: Dict[str, Any]) ->
         else []
     )
     # Build a map: arg_index → list of fallacy types targeting that argument
-    fallacy_targets: Dict[int, list] = {}
+    fallacy_targets: Dict[int, list[str]] = {}
     for f in detected_fallacies:
         if not isinstance(f, dict):
             continue
@@ -136,7 +136,7 @@ async def _invoke_quality_evaluator(input_text: str, context: Dict[str, Any]) ->
             for idx, a in enumerate(raw_args[:8]):
                 a_text = (a.get("text", str(a)) if isinstance(a, dict) else str(a)).lower()
                 if target_lower in a_text or a_text[:40] in target_lower:
-                    fallacy_targets.setdefault(idx, []).append(fallacy_type)
+                    fallacy_targets.setdefault(idx, []).append(str(fallacy_type))
                     break
 
     if raw_args:
@@ -218,9 +218,9 @@ async def _invoke_quality_evaluator(input_text: str, context: Dict[str, Any]) ->
         return await asyncio.to_thread(evaluator.evaluate, input_text)
 
 
-def _aggregate_virtue_scores(per_arg_results: Dict) -> Dict[str, float]:
+def _aggregate_virtue_scores(per_arg_results: Dict[str, Any]) -> Dict[str, float]:
     """Average virtue scores across all evaluated arguments."""
-    all_virtues: Dict[str, list] = {}
+    all_virtues: Dict[str, list[float]] = {}
     for result in per_arg_results.values():
         if not isinstance(result, dict):
             continue
@@ -237,8 +237,8 @@ def _aggregate_virtue_scores(per_arg_results: Dict) -> Dict[str, float]:
 
 async def _llm_enrich_quality(
     heuristic_results: Dict[str, Any],
-    raw_args: List,
-    detected_fallacies: Optional[List] = None,
+    raw_args: List[Any],
+    detected_fallacies: Optional[List[Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     """LLM enrichment pass for quality evaluation (#290).
 
@@ -338,19 +338,19 @@ async def _llm_enrich_quality(
         start = text_content.find("{")
         end = text_content.rfind("}") + 1
         if start >= 0 and end > start:
-            return json.loads(text_content[start:end])
+            return json.loads(text_content[start:end])  # type: ignore[no-any-return]
     except Exception as e:
         logger.debug(f"LLM quality enrichment skipped: {e}")
     return None
 
 
-async def _invoke_counter_argument(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_counter_argument(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke counter-argument analysis via plugin + LLM enrichment."""
     from argumentation_analysis.agents.core.counter_argument.counter_agent import (
         CounterArgumentPlugin,
     )
 
-    plugin = CounterArgumentPlugin()
+    plugin = CounterArgumentPlugin()  # type: ignore[no-untyped-call]
     parsed_json = plugin.parse_argument(input_text)
     strategy_json = plugin.suggest_strategy(input_text)
     parsed = json.loads(parsed_json)
@@ -462,8 +462,8 @@ async def _invoke_counter_argument(input_text: str, context: Dict[str, Any]) -> 
 
 
 def _evaluate_counter_arguments(
-    llm_counters: List[Dict], input_text: str
-) -> List[Dict]:
+    llm_counters: List[Dict[str, Any]], input_text: str
+) -> List[Dict[str, Any]]:
     """Auto-evaluate each LLM counter-argument using CounterArgumentEvaluator (#294).
 
     Wraps each LLM-generated dict into proper Argument/CounterArgument dataclass
@@ -482,7 +482,7 @@ def _evaluate_counter_arguments(
     except ImportError:
         return llm_counters
 
-    evaluator = CounterArgumentEvaluator()
+    evaluator = CounterArgumentEvaluator()  # type: ignore[no-untyped-call]
     strength_map = {
         "weak": ArgumentStrength.WEAK,
         "moderate": ArgumentStrength.MODERATE,
@@ -542,11 +542,11 @@ def _evaluate_counter_arguments(
     return llm_counters
 
 
-async def _invoke_debate_analysis(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_debate_analysis(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke debate argument analysis via plugin + LLM adversarial assessment."""
     from argumentation_analysis.agents.core.debate.debate_agent import DebatePlugin
 
-    plugin = DebatePlugin()
+    plugin = DebatePlugin()  # type: ignore[no-untyped-call]
     scores_json = plugin.analyze_argument_quality(input_text)
     base_scores = json.loads(scores_json)
 
@@ -580,7 +580,7 @@ async def _invoke_debate_analysis(input_text: str, context: Dict[str, Any]) -> D
             )
             jtms_output = context.get("phase_jtms_output", {})
 
-            def _txt(item):
+            def _txt(item: Any) -> str:
                 return (
                     item.get("text", str(item)) if isinstance(item, dict) else str(item)
                 )
@@ -681,10 +681,10 @@ async def _invoke_debate_analysis(input_text: str, context: Dict[str, Any]) -> D
     except Exception as e:
         logger.warning(f"LLM debate assessment failed: {e}")
 
-    return base_scores
+    return base_scores  # type: ignore[no-any-return]
 
 
-async def _invoke_governance(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_governance(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke governance analysis via plugin + LLM-powered deliberation assessment."""
     from argumentation_analysis.plugins.governance_plugin import GovernancePlugin
 
@@ -809,8 +809,8 @@ async def _invoke_governance(input_text: str, context: Dict[str, Any]) -> Dict:
                 else []
             )
             if raw_fallacies:
-                ftypes = [
-                    f.get("type", f.get("fallacy_type", "unknown"))
+                ftypes: list[str] = [
+                    str(f.get("type", f.get("fallacy_type", "unknown")))
                     for f in raw_fallacies[:5]
                     if isinstance(f, dict)
                 ]
@@ -885,7 +885,7 @@ async def _invoke_governance(input_text: str, context: Dict[str, Any]) -> Dict:
     return result
 
 
-async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke JTMS belief maintenance with ExtendedBelief and agent metadata (#214).
 
     Builds a proper belief network from upstream phase outputs:
@@ -941,7 +941,7 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict:
     )
 
     # ── Build belief names ───────────────────────────────────────────
-    def _text(item):
+    def _text(item: Any) -> str:
         return (item.get("text", str(item)) if isinstance(item, dict) else str(item))[:80]
 
     arg_beliefs = [_text(a) for a in raw_args[:10]]
@@ -955,7 +955,7 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict:
     for i, name in enumerate(arg_beliefs + claim_beliefs):
         is_arg = i < len(arg_beliefs)
         belief_type = "premise" if is_arg else "claim"
-        confidence = per_arg_scores.get(f"arg_{i+1}", per_arg_scores.get(f"argument_{i+1}", {})).get("note_finale", 0.5)
+        confidence: float = float(per_arg_scores.get(f"arg_{i+1}", per_arg_scores.get(f"argument_{i+1}", {})).get("note_finale", 0.5))
         session.add_belief(
             name,
             agent_source="unified_pipeline",
@@ -991,13 +991,13 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict:
 
     # ── Step 4: Fallacies → retract undermined beliefs + propagation ─
     fallacy_beliefs = []
-    session.jtms.enable_tracing()  # Track retraction cascades (#350)
+    session.jtms.enable_tracing()  # type: ignore[no-untyped-call]  # Track retraction cascades (#350)
     for i, f in enumerate(detected_fallacies[:6]):
         if not isinstance(f, dict):
             continue
         fallacy_type = f.get("type", f.get("fallacy_type", f"fallacy_{i+1}"))
         fallacy_name = f"FALLACY:{fallacy_type}"[:80]
-        confidence = f.get("confidence", f.get("severity", 0.7))
+        confidence = float(f.get("confidence", f.get("severity", 0.7)))  # type: ignore[arg-type]
         session.add_belief(
             fallacy_name,
             agent_source="fallacy_detector",
@@ -1047,7 +1047,7 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict:
             continue
         ca_text = ca.get("counter_argument", f"counter_arg_{i+1}")[:80]
         target = ca.get("target_argument", "")[:40]
-        confidence = ca.get("confidence", 0.6)
+        confidence = float(ca.get("confidence", 0.6))
         session.add_belief(
             ca_text,
             agent_source="counter_argument_generator",
@@ -1145,7 +1145,7 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict:
     }
 
 
-async def _invoke_atms(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_atms(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke ATMS assumption-based reasoning (#292).
 
     Builds an ATMS from upstream outputs: arguments and claims become assumption
@@ -1180,11 +1180,11 @@ async def _invoke_atms(input_text: str, context: Dict[str, Any]) -> Dict:
     )
 
     # ── Helper ───────────────────────────────────────────────────────
-    def _text(item):
+    def _text(item: Any) -> str:
         return (item.get("text", str(item)) if isinstance(item, dict) else str(item))[:60]
 
     # ── Step 1: Arguments → assumptions ──────────────────────────────
-    arg_names = []
+    arg_names: list[str] = []
     for a in raw_args[:8]:
         name = _text(a)
         atms.add_assumption(name)
@@ -1221,7 +1221,7 @@ async def _invoke_atms(input_text: str, context: Dict[str, Any]) -> Dict:
             atms.add_justification([contra_name], [], "\u22a5")  # ⊥
 
     # ── Step 4: Build result ─────────────────────────────────────────
-    environments = {}
+    environments: Dict[str, Dict[str, Any]] = {}
     for name in arg_names + claim_names:
         if name in atms.nodes:
             envs = atms.get_environments(name)
@@ -1232,7 +1232,7 @@ async def _invoke_atms(input_text: str, context: Dict[str, Any]) -> Dict:
             }
 
     assumptions = atms.get_assumptions()
-    consistent_envs = []
+    consistent_envs: list[Dict[str, Any]] = []
     for node_name, node_data in environments.items():
         if not node_data["is_assumption"]:
             for env in node_data["environments"]:
@@ -1356,7 +1356,7 @@ def _generate_hypotheses(
                         scores = candidate
                         break
             if isinstance(scores, dict):
-                if scores.get("overall", scores.get("note_finale", 0)) >= 3.0:
+                if float(str(scores.get("overall", scores.get("note_finale", 0)))) >= 3.0:
                     high_quality.append(arg_name)
         if high_quality and set(high_quality) != set(arg_names):
             hypotheses.append({
@@ -1385,7 +1385,7 @@ def _generate_hypotheses(
     return hypotheses[:4]
 
 
-async def _invoke_camembert_fallacy(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_camembert_fallacy(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke self-hosted LLM fallacy detector via SK function calling (#297).
 
     Replaces the dead CamemBERT Tier 2.5 with a self-hosted LLM endpoint
@@ -1463,7 +1463,7 @@ async def _invoke_camembert_fallacy(input_text: str, context: Dict[str, Any]) ->
         }
 
 
-async def _invoke_local_llm(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_local_llm(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke local LLM service for text analysis."""
     from argumentation_analysis.services.local_llm_service import LocalLLMService
 
@@ -1472,7 +1472,7 @@ async def _invoke_local_llm(input_text: str, context: Dict[str, Any]) -> Dict:
     return await service.chat_completion(messages)
 
 
-async def _invoke_semantic_index(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_semantic_index(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke semantic index service for argument search."""
     from argumentation_analysis.services.semantic_index_service import (
         SemanticIndexService,
@@ -1485,7 +1485,7 @@ async def _invoke_semantic_index(input_text: str, context: Dict[str, Any]) -> Di
 
 async def _invoke_speech_transcription(
     input_text: str, context: Dict[str, Any]
-) -> Dict:
+) -> Dict[str, Any]:
     """Invoke speech transcription — requires audio_path in context."""
     return {
         "status": "ready",
@@ -1572,7 +1572,7 @@ def _generate_attacks_from_args(
                 continue
             fallacy_label = f.get("type", f.get("fallacy_type", f"fallacy_{i}"))
             # Try to match fallacy to argument by text content
-            target_text = (
+            target_text = str(
                 f.get("target_text", f.get("argument", f.get("text", "")))
             ).lower()[:60]
             target_arg = None
@@ -1750,7 +1750,7 @@ def _enrich_ranking_with_justification(
     return result
 
 
-async def _invoke_ranking(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_ranking(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke ranking semantics handler with JVM fallback.
 
     Enriches ranking with Dung extension data and strength justification.
@@ -1766,7 +1766,7 @@ async def _invoke_ranking(input_text: str, context: Dict[str, Any]) -> Dict:
             RankingHandler,
         )
 
-        handler = RankingHandler()
+        handler = RankingHandler()  # type: ignore[no-untyped-call]
         result = await asyncio.to_thread(handler.rank_arguments, args, attacks, method)
         # Enrich Tweety result with strength justification
         if isinstance(result, dict) and "ranking" in result:
@@ -1778,7 +1778,7 @@ async def _invoke_ranking(input_text: str, context: Dict[str, Any]) -> Dict:
         return _enrich_ranking_with_justification(result, args, attacks, context)
 
 
-async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke bipolar argumentation handler with JVM fallback."""
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
@@ -1792,7 +1792,7 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict:
             BipolarHandler,
         )
 
-        handler = BipolarHandler()
+        handler = BipolarHandler()  # type: ignore[no-untyped-call]
         return await asyncio.to_thread(
             handler.analyze_bipolar_framework, args, attacks, supports, fw_type
         )
@@ -1808,7 +1808,7 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict:
         }
 
 
-async def _invoke_aba(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_aba(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke ABA handler with JVM fallback."""
     args = _extract_arguments_from_context(input_text, context)
     assumptions = context.get("assumptions") or args[:3]
@@ -1819,7 +1819,7 @@ async def _invoke_aba(input_text: str, context: Dict[str, Any]) -> Dict:
     try:
         from argumentation_analysis.agents.core.logic.aba_handler import ABAHandler
 
-        handler = ABAHandler()
+        handler = ABAHandler()  # type: ignore[no-untyped-call]
         return await asyncio.to_thread(
             handler.analyze_aba_framework, assumptions, rules, contraries, semantics
         )
@@ -1834,7 +1834,7 @@ async def _invoke_aba(input_text: str, context: Dict[str, Any]) -> Dict:
         }
 
 
-async def _invoke_adf(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_adf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke ADF handler with JVM fallback."""
     args = _extract_arguments_from_context(input_text, context)
     statements = context.get("statements") or args
@@ -1846,7 +1846,7 @@ async def _invoke_adf(input_text: str, context: Dict[str, Any]) -> Dict:
     try:
         from argumentation_analysis.agents.core.logic.adf_handler import ADFHandler
 
-        handler = ADFHandler()
+        handler = ADFHandler()  # type: ignore[no-untyped-call]
         return await asyncio.to_thread(
             handler.analyze_adf, statements, conditions, semantics
         )
@@ -1867,7 +1867,7 @@ def _python_aspic_fallback(
     args: List[str],
     strict: List[str],
     defeasible: List[str],
-    fallacies: List,
+    fallacies: List[Any],
     context: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Pure-Python ASPIC+ fallback that interprets defensibility.
@@ -1919,8 +1919,8 @@ def _python_aspic_fallback(
         reasons = []
         if is_undermined:
             status = "undermined"
-            matching_fallacies = [
-                f.get("type", f.get("fallacy_type", "unknown"))
+            matching_fallacies: list[str] = [
+                str(f.get("type", f.get("fallacy_type", "unknown")))
                 for f in fallacies
                 if isinstance(f, dict)
             ]
@@ -1965,7 +1965,7 @@ def _python_aspic_fallback(
     }
 
 
-async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke ASPIC+ handler with JVM fallback.
 
     Generates meaningful strict and defeasible rules from the argument structure:
@@ -2006,7 +2006,7 @@ async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict:
         # Fallacy-based defeat: if a fallacy targets an argument, it's defeasible
         for j, f in enumerate(fallacies[:3]):
             if isinstance(f, dict):
-                ft = f.get("type", f.get("fallacy_type", "unknown"))
+                ft = str(f.get("type", f.get("fallacy_type", "unknown")))
                 defeasible.append(f"detected({ft[:30]}) => undermined_{j+1}")
 
     axioms = context.get("axioms")
@@ -2014,7 +2014,7 @@ async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict:
     try:
         from argumentation_analysis.agents.core.logic.aspic_handler import ASPICHandler
 
-        handler = ASPICHandler()
+        handler = ASPICHandler()  # type: ignore[no-untyped-call]
         return await asyncio.to_thread(
             handler.analyze_aspic_framework, strict, defeasible, axioms
         )
@@ -2023,7 +2023,7 @@ async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict:
         return _python_aspic_fallback(args, strict, defeasible, fallacies, context)
 
 
-async def _invoke_belief_revision(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_belief_revision(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke belief revision — revise beliefs based on counter-arguments and fallacies.
 
     Uses upstream counter-arguments or fallacy detections as new evidence that
@@ -2063,7 +2063,7 @@ async def _invoke_belief_revision(input_text: str, context: Dict[str, Any]) -> D
             BeliefRevisionHandler,
         )
 
-        handler = BeliefRevisionHandler()
+        handler = BeliefRevisionHandler()  # type: ignore[no-untyped-call]
         return await asyncio.to_thread(handler.revise, beliefs, new_belief, method)
     except Exception as e:
         logger.info(f"Belief revision handler unavailable ({e}), using Python fallback")
@@ -2094,7 +2094,7 @@ async def _invoke_belief_revision(input_text: str, context: Dict[str, Any]) -> D
         }
 
 
-async def _invoke_probabilistic(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_probabilistic(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke probabilistic argumentation handler with JVM fallback."""
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
@@ -2107,7 +2107,7 @@ async def _invoke_probabilistic(input_text: str, context: Dict[str, Any]) -> Dic
             ProbabilisticHandler,
         )
 
-        handler = ProbabilisticHandler()
+        handler = ProbabilisticHandler()  # type: ignore[no-untyped-call]
         return await asyncio.to_thread(
             handler.analyze_probabilistic_framework, args, attacks, probs
         )
@@ -2131,7 +2131,7 @@ async def _invoke_probabilistic(input_text: str, context: Dict[str, Any]) -> Dic
         }
 
 
-async def _invoke_dialogue(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_dialogue(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke dialogue protocol handler with JVM fallback.
 
     Organizes arguments into proponent/opponent positions using upstream data:
@@ -2172,7 +2172,7 @@ async def _invoke_dialogue(input_text: str, context: Dict[str, Any]) -> Dict:
             DialogueHandler,
         )
 
-        handler = DialogueHandler()
+        handler = DialogueHandler()  # type: ignore[no-untyped-call]
         return await asyncio.to_thread(
             handler.execute_dialogue,
             pro_args,
@@ -2250,7 +2250,7 @@ async def _invoke_dialogue(input_text: str, context: Dict[str, Any]) -> Dict:
         }
 
 
-async def _invoke_dl(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_dl(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke Description Logic handler (#86) with JVM fallback."""
     tbox = context.get("tbox", [])
     abox_concepts = context.get("abox_concepts", [])
@@ -2262,7 +2262,7 @@ async def _invoke_dl(input_text: str, context: Dict[str, Any]) -> Dict:
             TweetyInitializer,
         )
 
-        initializer = TweetyInitializer()
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = DLHandler(initializer)
         kb = await asyncio.to_thread(
             handler.create_knowledge_base, tbox, abox_concepts, abox_roles
@@ -2287,7 +2287,7 @@ async def _invoke_dl(input_text: str, context: Dict[str, Any]) -> Dict:
         }
 
 
-async def _invoke_cl(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_cl(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke Conditional Logic handler (#86) with JVM fallback."""
     conditionals = context.get("conditionals", [])
     query_conclusion = context.get("query_conclusion")
@@ -2299,7 +2299,7 @@ async def _invoke_cl(input_text: str, context: Dict[str, Any]) -> Dict:
             TweetyInitializer,
         )
 
-        initializer = TweetyInitializer()
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = CLHandler(initializer)
         kb = await asyncio.to_thread(handler.create_knowledge_base, conditionals)
         if query_conclusion:
@@ -2325,7 +2325,7 @@ async def _invoke_cl(input_text: str, context: Dict[str, Any]) -> Dict:
         }
 
 
-async def _invoke_sat(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_sat(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke SAT solver handler (#86)."""
     from argumentation_analysis.agents.core.logic.sat_handler import SATHandler
 
@@ -2351,7 +2351,7 @@ async def _invoke_sat(input_text: str, context: Dict[str, Any]) -> Dict:
 # --- SetAF / Weighted AF / Social AF invoke functions (#87) ---
 
 
-async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke Set Argumentation Framework handler (#87) with JVM fallback."""
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
@@ -2365,7 +2365,7 @@ async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict:
             TweetyInitializer,
         )
 
-        initializer = TweetyInitializer()
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = SetAFHandler(initializer)
         return await asyncio.to_thread(handler.analyze_setaf, args, attacks, semantics)
     except Exception as e:
@@ -2379,7 +2379,7 @@ async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict:
         }
 
 
-async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke Weighted AF handler (#87) with JVM fallback."""
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
@@ -2395,7 +2395,7 @@ async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict:
             TweetyInitializer,
         )
 
-        initializer = TweetyInitializer()
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = WeightedHandler(initializer)
         return await asyncio.to_thread(
             handler.analyze_weighted_framework, args, attacks, semantics
@@ -2413,7 +2413,7 @@ async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict:
         }
 
 
-async def _invoke_social(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_social(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke Social AF handler (#87) with JVM fallback."""
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
@@ -2431,7 +2431,7 @@ async def _invoke_social(input_text: str, context: Dict[str, Any]) -> Dict:
             TweetyInitializer,
         )
 
-        initializer = TweetyInitializer()
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = SocialHandler(initializer)
         return await asyncio.to_thread(
             handler.analyze_social_framework, args, attacks, votes
@@ -2444,7 +2444,7 @@ async def _invoke_social(input_text: str, context: Dict[str, Any]) -> Dict:
 def _python_social_fallback(
     args: List[str],
     attacks: List[List[str]],
-    votes: Dict,
+    votes: Dict[str, Any],
     context: Dict[str, Any],
 ) -> Dict[str, Any]:
     """Pure-Python Social AF fallback using upstream data as social votes.
@@ -2557,9 +2557,9 @@ def _python_eaf_fallback(
             surviving.add(str(a).lower()[:30])
 
     # Compute epistemic states
-    epistemic = {}
-    believed_args = []
-    disbelieved_args = []
+    epistemic: Dict[str, Dict[str, Any]] = {}
+    believed_args: list[str] = []
+    disbelieved_args: list[str] = []
     for arg in args:
         confidence = 0.6  # base confidence
         believed = True
@@ -2632,7 +2632,7 @@ def _python_eaf_fallback(
 # --- EAF / DeLP / QBF invoke functions (#88, #89, #90) ---
 
 
-async def _invoke_eaf(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_eaf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke Epistemic AF handler (#88) with JVM fallback."""
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
@@ -2647,7 +2647,7 @@ async def _invoke_eaf(input_text: str, context: Dict[str, Any]) -> Dict:
             TweetyInitializer,
         )
 
-        initializer = TweetyInitializer()
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = EAFHandler(initializer)
         return await asyncio.to_thread(
             handler.analyze_epistemic_framework, args, attacks, beliefs, semantics
@@ -2657,7 +2657,7 @@ async def _invoke_eaf(input_text: str, context: Dict[str, Any]) -> Dict:
         return _python_eaf_fallback(args, attacks, semantics, context)
 
 
-async def _invoke_delp(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_delp(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke DeLP handler (#89) with JVM fallback."""
     program_text = context.get("program", input_text[:500])
     queries = context.get("queries", [])
@@ -2669,7 +2669,7 @@ async def _invoke_delp(input_text: str, context: Dict[str, Any]) -> Dict:
             TweetyInitializer,
         )
 
-        initializer = TweetyInitializer()
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = DeLPHandler(initializer)
         return await asyncio.to_thread(
             handler.analyze_delp, program_text, queries, criterion
@@ -2685,7 +2685,7 @@ async def _invoke_delp(input_text: str, context: Dict[str, Any]) -> Dict:
         }
 
 
-async def _invoke_qbf(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_qbf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke QBF handler (#90) with JVM fallback."""
     quantifiers = context.get("quantifiers", [])
     formula = context.get("formula", input_text[:200])
@@ -2696,7 +2696,7 @@ async def _invoke_qbf(input_text: str, context: Dict[str, Any]) -> Dict:
             TweetyInitializer,
         )
 
-        initializer = TweetyInitializer()
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = QBFHandler(initializer)
         return await asyncio.to_thread(handler.analyze_qbf, quantifiers, formula)
     except Exception as e:
@@ -2720,7 +2720,7 @@ async def _invoke_qbf(input_text: str, context: Dict[str, Any]) -> Dict:
 
 async def _invoke_hierarchical_fallacy(
     input_text: str, context: Dict[str, Any]
-) -> Dict:
+) -> Dict[str, Any]:
     """Invoke hierarchical taxonomy-guided fallacy detection.
 
     Uses FallacyWorkflowPlugin with iterative deepening (master-slave kernel)
@@ -2775,7 +2775,7 @@ async def _invoke_hierarchical_fallacy(
         result_json = await plugin.run_guided_analysis(argument_text=input_text)
         result = json.loads(result_json)
         result["extraction_method"] = result.get("exploration_method", "unknown")
-        return result
+        return result  # type: ignore[no-any-return]
 
     except (ImportError, RuntimeError) as e:
         # Expected failures: missing dependencies or API key — return empty gracefully
@@ -2801,7 +2801,7 @@ async def _invoke_hierarchical_fallacy(
 # --- Invoke callables for logic agent capabilities (#71 Formal Verification) ---
 
 
-def _normalize_items_with_quotes(items: list) -> list:
+def _normalize_items_with_quotes(items: list[Any]) -> list[Dict[str, Any]]:
     """Normalize argument/claim items: accept both str and dict with source_quote."""
     result = []
     for item in items:
@@ -2817,7 +2817,7 @@ def _normalize_items_with_quotes(items: list) -> list:
     return result
 
 
-def _normalize_fallacies_with_quotes(items: list) -> list:
+def _normalize_fallacies_with_quotes(items: list[Any]) -> list[Dict[str, Any]]:
     """Normalize fallacy items to include source_quote."""
     result = []
     for item in items:
@@ -2834,7 +2834,7 @@ def _normalize_fallacies_with_quotes(items: list) -> list:
     return result
 
 
-async def _invoke_fact_extraction(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_fact_extraction(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Extract verifiable claims and arguments from text using LLM with heuristic fallback."""
     import re
 
@@ -2899,7 +2899,7 @@ async def _invoke_fact_extraction(input_text: str, context: Dict[str, Any]) -> D
 
     # Heuristic fallback
     sentences = re.split(r"(?<=[.!?])\s+", input_text.strip())
-    claims = [s.strip() for s in sentences if len(s.strip()) > 20]
+    claims = [s.strip() for s in sentences if len(s.strip()) > 20]  # type: ignore[misc]
     return {
         "arguments": [],
         "claims": claims,
@@ -2912,7 +2912,7 @@ async def _invoke_fact_extraction(input_text: str, context: Dict[str, Any]) -> D
     }
 
 
-async def _invoke_propositional_logic(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_propositional_logic(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke propositional logic analysis — translate arguments to propositions.
 
     If NL-to-logic translations are available from an upstream phase, uses
@@ -3027,7 +3027,7 @@ async def _invoke_propositional_logic(input_text: str, context: Dict[str, Any]) 
         }
 
 
-async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke first-order logic analysis — translate arguments to FOL predicates.
 
     If NL-to-logic translations are available from an upstream phase, uses
@@ -3077,8 +3077,8 @@ async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dic
                 valid = [t for t in batch.translations if t.is_valid]
                 if valid:
                     formulas = []
-                    for t in valid:
-                        for f in t.formula.split(";"):
+                    for t in valid:  # type: ignore[assignment]
+                        for f in t.formula.split(";"):  # type: ignore[attr-defined]
                             f = f.strip()
                             if f:
                                 formulas.append(f)
@@ -3169,7 +3169,7 @@ async def _invoke_fol_reasoning(input_text: str, context: Dict[str, Any]) -> Dic
         }
 
 
-async def _invoke_nl_to_logic(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_nl_to_logic(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Translate extracted NL arguments to formal logic with validation (#173).
 
     Uses LLM to generate propositional/FOL formulas, validates via Tweety
@@ -3211,7 +3211,7 @@ async def _invoke_nl_to_logic(input_text: str, context: Dict[str, Any]) -> Dict:
     }
 
 
-async def _invoke_modal_logic(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_modal_logic(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke modal logic analysis via TweetyBridge (JVM required)."""
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
@@ -3237,7 +3237,7 @@ async def _invoke_modal_logic(input_text: str, context: Dict[str, Any]) -> Dict:
         return {"error": str(e), "formulas": [], "valid": False, "modalities": []}
 
 
-async def _invoke_dung_extensions(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_dung_extensions(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke Dung framework extension computation via AFHandler (JVM required).
 
     Builds attack graph from extracted arguments and detected fallacies,
@@ -3255,7 +3255,7 @@ async def _invoke_dung_extensions(input_text: str, context: Dict[str, Any]) -> D
         from argumentation_analysis.agents.core.logic.af_handler import AFHandler
         from argumentation_analysis.agents.core.logic.tweety_initializer import TweetyInitializer
 
-        initializer = TweetyInitializer()
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = AFHandler(initializer)
 
         # Compute multiple semantics for comprehensive analysis
@@ -3308,15 +3308,15 @@ def _python_dung_fallback(
 
     # Build attack maps
     arg_set = set(arguments)
-    attack_map = {a: [] for a in arg_set}  # attacker → targets
-    attacked_by = {a: [] for a in arg_set}  # target → attackers
+    attack_map: Dict[str, list[str]] = {a: [] for a in arg_set}  # attacker -> targets
+    attacked_by: Dict[str, list[str]] = {a: [] for a in arg_set}  # target -> attackers
     for attacker, target in attacks:
         if attacker in arg_set and target in arg_set:
             attack_map[attacker].append(target)
             attacked_by[target].append(attacker)
 
     # Grounded extension: iterative fixpoint
-    grounded = set()
+    grounded: set[str] = set()
     changed = True
     while changed:
         changed = False
@@ -3351,7 +3351,7 @@ def _python_dung_fallback(
     }
 
 
-async def _invoke_formal_synthesis(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_formal_synthesis(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Aggregate all formal analysis results from upstream phases into a unified report."""
     phase_results = {}
     overall_scores = []
@@ -3403,7 +3403,7 @@ async def _invoke_formal_synthesis(input_text: str, context: Dict[str, Any]) -> 
     }
 
 
-async def _invoke_narrative_synthesis(input_text: str, context: Dict[str, Any]) -> Dict:
+async def _invoke_narrative_synthesis(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke narrative synthesis to produce readable prose from all phase outputs (#351).
 
     Reads state from context (populated by prior phases) and calls
@@ -3412,6 +3412,7 @@ async def _invoke_narrative_synthesis(input_text: str, context: Dict[str, Any]) 
     """
     from argumentation_analysis.plugins.narrative_synthesis_plugin import build_narrative
     from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+    from argumentation_analysis.orchestration.state_writers import CAPABILITY_STATE_WRITERS
 
     # Reconstruct state from context if possible
     state = context.get("_state_object")
@@ -3442,7 +3443,7 @@ async def _invoke_narrative_synthesis(input_text: str, context: Dict[str, Any]) 
     }
 
 
-def _count_referenced_fields(state) -> int:
+def _count_referenced_fields(state: Any) -> int:
     """Count how many state fields have data (used as references in narrative)."""
     count = 0
     for field_name in [

--- a/argumentation_analysis/orchestration/open_domain_investigation.py
+++ b/argumentation_analysis/orchestration/open_domain_investigation.py
@@ -166,9 +166,7 @@ class OpenDomainInvestigator:
                 )
         return attributions
 
-    def _build_hypothesis_summary(
-        self, hypotheses: List[Dict]
-    ) -> Dict[str, str]:
+    def _build_hypothesis_summary(self, hypotheses: List[Dict]) -> Dict[str, str]:
         """Build a human-readable hypothesis summary."""
         summary = {}
         for hyp in hypotheses:
@@ -176,9 +174,7 @@ class OpenDomainInvestigator:
             coherent = hyp.get("coherent", False)
             assumptions = hyp.get("assumptions", [])
             status = "COHERENT" if coherent else "INCOHERENT"
-            summary[hyp_id] = (
-                f"{status} — assumptions: {assumptions}"
-            )
+            summary[hyp_id] = f"{status} — assumptions: {assumptions}"
         return summary
 
     def _build_conclusion(
@@ -217,13 +213,9 @@ class OpenDomainInvestigator:
             supported = [a for a in attributions if a.coherent]
             undermined = [a for a in attributions if not a.coherent]
             if supported:
-                lines.append(
-                    f"  Supported attributions: {len(supported)}"
-                )
+                lines.append(f"  Supported attributions: {len(supported)}")
             if undermined:
-                lines.append(
-                    f"  Undermined attributions: {len(undermined)}"
-                )
+                lines.append(f"  Undermined attributions: {len(undermined)}")
 
         # Attribution narrative
         if coherent_hyps and incoherent_hyps:

--- a/argumentation_analysis/orchestration/pipeline_utils.py
+++ b/argumentation_analysis/orchestration/pipeline_utils.py
@@ -27,9 +27,11 @@ logger = logging.getLogger("PipelineUtils")
 # 1. TTL-BASED CACHING
 # =============================================================================
 
+
 @dataclass
 class CacheEntry:
     """A cached result with metadata."""
+
     value: Any
     created_at: float
     ttl_seconds: float
@@ -76,20 +78,16 @@ class AnalysisCache:
         }
 
     def _generate_key(
-        self,
-        text: str,
-        analysis_type: str,
-        parameters: Optional[Dict[str, Any]] = None
+        self, text: str, analysis_type: str, parameters: Optional[Dict[str, Any]] = None
     ) -> str:
         """Generate a unique cache key from inputs."""
-        content = f"{text}:{analysis_type}:{json.dumps(parameters or {}, sort_keys=True)}"
+        content = (
+            f"{text}:{analysis_type}:{json.dumps(parameters or {}, sort_keys=True)}"
+        )
         return hashlib.md5(content.encode()).hexdigest()
 
     def get(
-        self,
-        text: str,
-        analysis_type: str,
-        parameters: Optional[Dict[str, Any]] = None
+        self, text: str, analysis_type: str, parameters: Optional[Dict[str, Any]] = None
     ) -> Optional[Any]:
         """
         Get a cached result if available and not expired.
@@ -120,7 +118,7 @@ class AnalysisCache:
         analysis_type: str,
         result: Any,
         parameters: Optional[Dict[str, Any]] = None,
-        ttl_override: Optional[float] = None
+        ttl_override: Optional[float] = None,
     ) -> None:
         """
         Cache a result.
@@ -175,15 +173,15 @@ class AnalysisCache:
         }
 
 
-
-
 # =============================================================================
 # 2. STRUCTURED METRICS COLLECTION
 # =============================================================================
 
+
 @dataclass
 class AnalysisMetric:
     """A single analysis metric entry."""
+
     timestamp: float
     analysis_type: str
     duration_seconds: float
@@ -227,22 +225,24 @@ class PipelineMetrics:
         success: bool,
         confidence: Optional[float] = None,
         error: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
         """Record a single analysis metric."""
         # Enforce max entries
         if len(self._metrics) >= self._max_entries:
             self._metrics.pop(0)
 
-        self._metrics.append(AnalysisMetric(
-            timestamp=time.time(),
-            analysis_type=analysis_type,
-            duration_seconds=duration_seconds,
-            success=success,
-            confidence=confidence,
-            error=error,
-            metadata=metadata or {},
-        ))
+        self._metrics.append(
+            AnalysisMetric(
+                timestamp=time.time(),
+                analysis_type=analysis_type,
+                duration_seconds=duration_seconds,
+                success=success,
+                confidence=confidence,
+                error=error,
+                metadata=metadata or {},
+            )
+        )
 
     def track(self, analysis_type: str, metadata: Optional[Dict[str, Any]] = None):
         """
@@ -290,7 +290,9 @@ class PipelineMetrics:
         # Compute averages
         for type_data in by_type.values():
             count = type_data["count"]
-            type_data["avg_duration"] = type_data["total_duration"] / count if count > 0 else 0
+            type_data["avg_duration"] = (
+                type_data["total_duration"] / count if count > 0 else 0
+            )
             confs = type_data["avg_confidence"]
             type_data["avg_confidence"] = sum(confs) / len(confs) if confs else None
 
@@ -304,7 +306,9 @@ class PipelineMetrics:
             "failed": len(failed),
             "success_rate": len(successful) / len(self._metrics),
             "avg_duration_seconds": sum(durations) / len(durations),
-            "avg_confidence": sum(confidences) / len(confidences) if confidences else None,
+            "avg_confidence": (
+                sum(confidences) / len(confidences) if confidences else None
+            ),
             "uptime_seconds": time.time() - self._start_time,
             "by_analysis_type": by_type,
         }
@@ -338,7 +342,7 @@ class _MetricsContext:
         self,
         metrics: PipelineMetrics,
         analysis_type: str,
-        metadata: Optional[Dict[str, Any]] = None
+        metadata: Optional[Dict[str, Any]] = None,
     ):
         self._metrics = metrics
         self._analysis_type = analysis_type
@@ -380,9 +384,11 @@ class _MetricsContext:
 # 3. BATCH ANALYSIS WITH CONCURRENCY CONTROL
 # =============================================================================
 
+
 @dataclass
 class BatchRequest:
     """A single request in a batch."""
+
     id: str
     text: str
     analysis_type: str
@@ -392,6 +398,7 @@ class BatchRequest:
 @dataclass
 class BatchResult:
     """Result of a single batch request."""
+
     id: str
     success: bool
     result: Optional[Any] = None

--- a/argumentation_analysis/orchestration/real_llm_orchestrator.py
+++ b/argumentation_analysis/orchestration/real_llm_orchestrator.py
@@ -10,6 +10,7 @@ DEPRECATED: Use these alternatives instead:
 - For conversational analysis: argumentation_analysis.orchestration.conversation_orchestrator.ConversationOrchestrator
 - For analysis requests: argumentation_analysis.core.shared_state.UnifiedAnalysisState
 """
+
 import warnings
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -22,6 +23,7 @@ class LLMAnalysisRequest:
 
     Use UnifiedAnalysisState or direct agent invocation instead.
     """
+
     text: str
     analysis_type: str
     context: Optional[Dict[str, Any]] = None
@@ -35,6 +37,7 @@ class LLMAnalysisResult:
 
     Use UnifiedAnalysisState or analysis plugins instead.
     """
+
     request_id: str
     analysis_type: str
     result: Dict[str, Any]
@@ -86,6 +89,7 @@ class RealLLMOrchestrator:
 def _get_conversation_logger():
     """Lazy import to avoid circular dependencies."""
     from .conversation_orchestrator import ConversationLogger
+
     return ConversationLogger
 
 
@@ -113,8 +117,8 @@ class RealConversationLogger:
 
 # Export list for backward compatibility
 __all__ = [
-    'RealLLMOrchestrator',
-    'LLMAnalysisRequest',
-    'LLMAnalysisResult',
-    'RealConversationLogger',
+    "RealLLMOrchestrator",
+    "LLMAnalysisRequest",
+    "LLMAnalysisResult",
+    "RealConversationLogger",
 ]

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -54,6 +54,7 @@ from argumentation_analysis.orchestration.invoke_callables import (
 
 logger = logging.getLogger("UnifiedPipeline")
 
+
 def setup_registry(
     include_optional: bool = True,
 ) -> CapabilityRegistry:
@@ -86,9 +87,9 @@ def setup_registry(
         register_counter_arg(registry)  # type: ignore[no-untyped-call]
         # Wire invoke callable (registration was created by register_counter_arg)
         if "counter_argument_agent" in registry._registrations:
-            registry._registrations[
-                "counter_argument_agent"
-            ].invoke = _invoke_counter_argument
+            registry._registrations["counter_argument_agent"].invoke = (
+                _invoke_counter_argument
+            )
         registered.append("counter_argument_agent")
     except ImportError as e:
         skipped.append(("counter_argument_agent", str(e)))
@@ -527,5 +528,3 @@ def _declare_tweety_slots(registry: CapabilityRegistry) -> None:
             # Fall back to slot declaration if JVM not available
             for cap in caps:
                 registry.declare_slot(cap, requires=["jvm"], description=desc)
-
-

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -83,7 +83,7 @@ def setup_registry(
             register_with_capability_registry as register_counter_arg,
         )
 
-        register_counter_arg(registry)
+        register_counter_arg(registry)  # type: ignore[no-untyped-call]
         # Wire invoke callable (registration was created by register_counter_arg)
         if "counter_argument_agent" in registry._registrations:
             registry._registrations[

--- a/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
+++ b/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
@@ -129,7 +129,9 @@ class SherlockModernOrchestrator:
         if agent not in self._agents:
             self._agents.append(agent)
 
-    async def investigate(self, discourse: str, context: Optional[Dict] = None) -> InvestigationResult:
+    async def investigate(
+        self, discourse: str, context: Optional[Dict] = None
+    ) -> InvestigationResult:
         """Run full investigation on discourse text. Resets state on entry
         (review #383: idempotency)."""
         self._reset()
@@ -152,7 +154,8 @@ class SherlockModernOrchestrator:
     async def _phase_extraction(self, text: str):
         """Phase 1: Identify claims in the discourse."""
         result = await self._invoke_safe(
-            "_invoke_extract", text,
+            "_invoke_extract",
+            text,
             fallback={"extracts": [], "arguments": [], "claims": []},
         )
         self._ctx["phase_extract_output"] = result
@@ -173,7 +176,8 @@ class SherlockModernOrchestrator:
     async def _phase_fallacy_detection(self, text: str):
         """Phase 2: Detect argumentative inconsistencies."""
         result = await self._invoke_safe(
-            "_invoke_hierarchical_fallacy", text,
+            "_invoke_hierarchical_fallacy",
+            text,
             fallback={"fallacies": {}, "total": 0},
         )
         self._ctx["phase_hierarchical_fallacy_output"] = result
@@ -182,10 +186,16 @@ class SherlockModernOrchestrator:
         fallacies = result.get("fallacies", [])
         if isinstance(fallacies, dict):
             count = len(fallacies)
-            types = list(set(v.get("type", "") for v in fallacies.values() if isinstance(v, dict)))
+            types = list(
+                set(
+                    v.get("type", "") for v in fallacies.values() if isinstance(v, dict)
+                )
+            )
         elif isinstance(fallacies, list):
             count = len(fallacies)
-            types = list(set(f.get("type", "") for f in fallacies if isinstance(f, dict)))
+            types = list(
+                set(f.get("type", "") for f in fallacies if isinstance(f, dict))
+            )
         else:
             count = result.get("total", 0)
             types = []
@@ -204,7 +214,8 @@ class SherlockModernOrchestrator:
     async def _phase_quality(self, text: str):
         """Phase 3: Evaluate argument reliability."""
         result = await self._invoke_safe(
-            "_invoke_quality_evaluator", text,
+            "_invoke_quality_evaluator",
+            text,
             fallback={"per_argument_scores": {}, "note_finale": 0.0},
         )
         self._ctx["phase_quality_output"] = result
@@ -229,7 +240,8 @@ class SherlockModernOrchestrator:
     async def _phase_cross_examination(self, text: str):
         """Phase 4: Cross-examine via counter-arguments."""
         result = await self._invoke_safe(
-            "_invoke_counter_argument", text,
+            "_invoke_counter_argument",
+            text,
             fallback={"counter_arguments": [], "suggested_strategy": {}},
         )
         self._ctx["phase_counter_output"] = result
@@ -237,7 +249,11 @@ class SherlockModernOrchestrator:
 
         counters = result.get("counter_arguments", [])
         strategy = result.get("suggested_strategy", {})
-        strat_name = strategy.get("strategy_name", "general") if isinstance(strategy, dict) else "general"
+        strat_name = (
+            strategy.get("strategy_name", "general")
+            if isinstance(strategy, dict)
+            else "general"
+        )
 
         self._add_step(
             phase="cross_examination",
@@ -255,7 +271,8 @@ class SherlockModernOrchestrator:
     async def _phase_belief_tracking(self, text: str):
         """Phase 5: Track belief propagation via JTMS."""
         result = await self._invoke_safe(
-            "_invoke_jtms", text,
+            "_invoke_jtms",
+            text,
             fallback={"beliefs": {}, "retraction_chain": []},
         )
         self._ctx["phase_jtms_output"] = result
@@ -263,8 +280,16 @@ class SherlockModernOrchestrator:
 
         beliefs = result.get("beliefs", {})
         retraction_chain = result.get("retraction_chain", [])
-        valid = sum(1 for v in beliefs.values() if isinstance(v, dict) and v.get("valid") is True)
-        invalid = sum(1 for v in beliefs.values() if isinstance(v, dict) and v.get("valid") is False)
+        valid = sum(
+            1
+            for v in beliefs.values()
+            if isinstance(v, dict) and v.get("valid") is True
+        )
+        invalid = sum(
+            1
+            for v in beliefs.values()
+            if isinstance(v, dict) and v.get("valid") is False
+        )
 
         self._add_step(
             phase="belief_tracking",
@@ -286,7 +311,8 @@ class SherlockModernOrchestrator:
     async def _phase_hypothesis_branching(self, text: str):
         """Phase 6: Branch hypotheses via ATMS."""
         result = await self._invoke_safe(
-            "_invoke_atms", text,
+            "_invoke_atms",
+            text,
             fallback={"atms_contexts": [], "has_contradictions": False},
         )
         self._ctx["phase_atms_output"] = result
@@ -301,11 +327,13 @@ class SherlockModernOrchestrator:
         self._hypotheses = []
         for ctx in contexts:
             if isinstance(ctx, dict):
-                self._hypotheses.append({
-                    "id": ctx.get("hypothesis_id", "unknown"),
-                    "coherent": ctx.get("coherent", False),
-                    "assumptions": ctx.get("assumptions", []),
-                })
+                self._hypotheses.append(
+                    {
+                        "id": ctx.get("hypothesis_id", "unknown"),
+                        "coherent": ctx.get("coherent", False),
+                        "assumptions": ctx.get("assumptions", []),
+                    }
+                )
 
         self._add_step(
             phase="hypothesis_branching",
@@ -325,7 +353,8 @@ class SherlockModernOrchestrator:
     async def _phase_solution_synthesis(self):
         """Phase 7: Synthesize investigation solution."""
         result = await self._invoke_safe(
-            "_invoke_narrative_synthesis", "",
+            "_invoke_narrative_synthesis",
+            "",
             fallback={"narrative": "", "paragraph_count": 0},
         )
         self._ctx["phase_narrative_synthesis_output"] = result
@@ -369,14 +398,21 @@ class SherlockModernOrchestrator:
             lines.append("\nHypotheses:")
             for h in self._hypotheses:
                 status = "COHERENT" if h.get("coherent") else "INCOHERENT"
-                lines.append(f"  - {h['id']}: {status} (assumptions: {h.get('assumptions', [])})")
+                lines.append(
+                    f"  - {h['id']}: {status} (assumptions: {h.get('assumptions', [])})"
+                )
         return "\n".join(lines)
 
     def _build_result(self) -> InvestigationResult:
         """Build the final investigation result."""
         trace_dicts = [
-            {"step": s.step, "phase": s.phase, "agent": s.agent,
-             "findings": s.findings, "conclusion": s.conclusion}
+            {
+                "step": s.step,
+                "phase": s.phase,
+                "agent": s.agent,
+                "findings": s.findings,
+                "conclusion": s.conclusion,
+            }
             for s in self._trace
         ]
         reasoning = [s.conclusion for s in self._trace if s.conclusion]

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -71,7 +71,9 @@ def _write_quality_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> Non
             llm_assessment = result.get("llm_assessment")  # (#290)
             if isinstance(overall, (int, float)) and (scores or overall > 0):
                 state.add_quality_score(
-                    str(arg_id), scores, float(overall),
+                    str(arg_id),
+                    scores,
+                    float(overall),
                     llm_assessment=llm_assessment,
                 )
         return
@@ -100,7 +102,9 @@ def _write_quality_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> Non
         state.add_quality_score(arg_id, scores, float(overall))
 
 
-def _write_counter_argument_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
+def _write_counter_argument_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
     """Write counter-argument results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -196,12 +200,8 @@ def _write_atms_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
         env_list = env_data.get("environments", [])
         # For ATMS, "valid" = has at least one consistent environment
         valid = len(env_list) > 0
-        justifications = [
-            f"assumption_env:{sorted(e)}" for e in env_list[:5]
-        ]
-        state.add_jtms_belief(
-            f"ATMS:{name}", valid, justifications=justifications
-        )
+        justifications = [f"assumption_env:{sorted(e)}" for e in env_list[:5]]
+        state.add_jtms_belief(f"ATMS:{name}", valid, justifications=justifications)
     # Store summary metadata
     state.add_jtms_belief(
         "ATMS:summary",
@@ -322,7 +322,9 @@ def _write_camembert_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> N
         )
 
 
-def _write_hierarchical_fallacy_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
+def _write_hierarchical_fallacy_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
     """Write hierarchical taxonomy-guided fallacy results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -347,7 +349,9 @@ def _write_hierarchical_fallacy_to_state(output: Any, state: Any, ctx: dict[str,
         state.add_fallacy(fallacy_type=fallacy_type, justification=full_justification)
 
 
-def _write_semantic_index_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
+def _write_semantic_index_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
     """Write semantic index results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -412,7 +416,9 @@ def _write_aspic_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     state.add_aspic_result(reasoner_type, extensions, statistics)
 
 
-def _write_belief_revision_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
+def _write_belief_revision_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
     """Write belief revision results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -497,7 +503,9 @@ def _write_adf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     )
 
 
-def _write_fact_extraction_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
+def _write_fact_extraction_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
     """Write fact extraction results to state (populates extracts + base fields)."""
     if not output or not isinstance(output, dict):
         return
@@ -611,7 +619,9 @@ def _write_nl_to_logic_to_state(output: Any, state: Any, ctx: dict[str, Any]) ->
             )
 
 
-def _write_dung_extensions_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
+def _write_dung_extensions_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
     """Write Dung extension computation results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -639,7 +649,9 @@ def _write_dung_extensions_to_state(output: Any, state: Any, ctx: dict[str, Any]
                 )
 
 
-def _write_formal_synthesis_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
+def _write_formal_synthesis_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
     """Write formal synthesis report to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -781,7 +793,9 @@ def _write_qbf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     )
 
 
-def _write_collaborative_analysis_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
+def _write_collaborative_analysis_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
     """Write collaborative multi-agent debate results to state (#175)."""
     from argumentation_analysis.orchestration.collaborative_debate import (
         _write_collaborative_to_state,
@@ -790,7 +804,9 @@ def _write_collaborative_analysis_to_state(output: Any, state: Any, ctx: dict[st
     _write_collaborative_to_state(output, state, ctx)
 
 
-def _write_narrative_synthesis_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
+def _write_narrative_synthesis_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
     """Write narrative synthesis results to UnifiedAnalysisState (#351)."""
     if not output or not isinstance(output, dict):
         return

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -53,7 +53,7 @@ __all__ = [
 ]
 
 
-def _write_quality_to_state(output, state, ctx) -> None:
+def _write_quality_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write quality evaluator results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -100,7 +100,7 @@ def _write_quality_to_state(output, state, ctx) -> None:
         state.add_quality_score(arg_id, scores, float(overall))
 
 
-def _write_counter_argument_to_state(output, state, ctx) -> None:
+def _write_counter_argument_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write counter-argument results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -149,7 +149,7 @@ def _write_counter_argument_to_state(output, state, ctx) -> None:
     state.add_counter_argument(original, strategy_name, strategy_name, float(score))
 
 
-def _write_jtms_to_state(output, state, ctx) -> None:
+def _write_jtms_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write JTMS results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -178,7 +178,7 @@ def _write_jtms_to_state(output, state, ctx) -> None:
         state.jtms_retraction_chain = retraction_chain
 
 
-def _write_atms_to_state(output, state, ctx) -> None:
+def _write_atms_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write ATMS assumption-based reasoning results to UnifiedAnalysisState (#292).
 
     Stores each node's environment info as a JTMS belief for compatibility.
@@ -219,7 +219,7 @@ def _write_atms_to_state(output, state, ctx) -> None:
         state.atms_contexts = atms_contexts
 
 
-def _write_debate_to_state(output, state, ctx) -> None:
+def _write_debate_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write debate analysis results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -246,7 +246,7 @@ def _write_debate_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_governance_to_state(output, state, ctx) -> None:
+def _write_governance_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write governance results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -305,7 +305,7 @@ def _write_governance_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_camembert_to_state(output, state, ctx) -> None:
+def _write_camembert_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write CamemBERT neural fallacy results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -322,7 +322,7 @@ def _write_camembert_to_state(output, state, ctx) -> None:
         )
 
 
-def _write_hierarchical_fallacy_to_state(output, state, ctx) -> None:
+def _write_hierarchical_fallacy_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write hierarchical taxonomy-guided fallacy results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -347,7 +347,7 @@ def _write_hierarchical_fallacy_to_state(output, state, ctx) -> None:
         state.add_fallacy(fallacy_type=fallacy_type, justification=full_justification)
 
 
-def _write_semantic_index_to_state(output, state, ctx) -> None:
+def _write_semantic_index_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write semantic index results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -366,7 +366,7 @@ def _write_semantic_index_to_state(output, state, ctx) -> None:
         )
 
 
-def _write_speech_to_state(output, state, ctx) -> None:
+def _write_speech_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write speech transcription results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -384,7 +384,7 @@ def _write_speech_to_state(output, state, ctx) -> None:
         )
 
 
-def _write_ranking_to_state(output, state, ctx) -> None:
+def _write_ranking_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write ranking semantics results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -398,7 +398,7 @@ def _write_ranking_to_state(output, state, ctx) -> None:
     state.add_ranking_result(method, arguments, comparisons)
 
 
-def _write_aspic_to_state(output, state, ctx) -> None:
+def _write_aspic_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write ASPIC+ analysis results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -412,7 +412,7 @@ def _write_aspic_to_state(output, state, ctx) -> None:
     state.add_aspic_result(reasoner_type, extensions, statistics)
 
 
-def _write_belief_revision_to_state(output, state, ctx) -> None:
+def _write_belief_revision_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write belief revision results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -426,7 +426,7 @@ def _write_belief_revision_to_state(output, state, ctx) -> None:
     state.add_belief_revision_result(method, original, revised)
 
 
-def _write_dialogue_to_state(output, state, ctx) -> None:
+def _write_dialogue_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write dialogue protocol results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -438,7 +438,7 @@ def _write_dialogue_to_state(output, state, ctx) -> None:
     state.add_dialogue_result(topic, outcome, trace)
 
 
-def _write_probabilistic_to_state(output, state, ctx) -> None:
+def _write_probabilistic_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write probabilistic argumentation results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -451,7 +451,7 @@ def _write_probabilistic_to_state(output, state, ctx) -> None:
     state.add_probabilistic_result(arguments, acceptance)
 
 
-def _write_bipolar_to_state(output, state, ctx) -> None:
+def _write_bipolar_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write bipolar argumentation results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -465,7 +465,7 @@ def _write_bipolar_to_state(output, state, ctx) -> None:
     state.add_bipolar_result(fw_type, arguments, supports)
 
 
-def _write_aba_to_state(output, state, ctx) -> None:
+def _write_aba_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write ABA reasoning results to UnifiedAnalysisState (stored as Dung framework)."""
     if not output or not isinstance(output, dict):
         return
@@ -481,7 +481,7 @@ def _write_aba_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_adf_to_state(output, state, ctx) -> None:
+def _write_adf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write ADF reasoning results to UnifiedAnalysisState (stored as Dung framework)."""
     if not output or not isinstance(output, dict):
         return
@@ -497,7 +497,7 @@ def _write_adf_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_fact_extraction_to_state(output, state, ctx) -> None:
+def _write_fact_extraction_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write fact extraction results to state (populates extracts + base fields)."""
     if not output or not isinstance(output, dict):
         return
@@ -538,7 +538,7 @@ def _write_fact_extraction_to_state(output, state, ctx) -> None:
         state.add_task(f"Fact extraction: {summary[:200]}")
 
 
-def _write_propositional_to_state(output, state, ctx) -> None:
+def _write_propositional_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write propositional logic analysis results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -552,7 +552,7 @@ def _write_propositional_to_state(output, state, ctx) -> None:
     state.add_propositional_analysis_result(formulas, bool(satisfiable), model)
 
 
-def _write_fol_to_state(output, state, ctx) -> None:
+def _write_fol_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write FOL reasoning results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -578,7 +578,7 @@ def _write_fol_to_state(output, state, ctx) -> None:
             state.fol_signature = fol_signature
 
 
-def _write_modal_to_state(output, state, ctx) -> None:
+def _write_modal_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write modal logic analysis results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -592,7 +592,7 @@ def _write_modal_to_state(output, state, ctx) -> None:
     state.add_modal_analysis_result(formulas, bool(valid), modalities)
 
 
-def _write_nl_to_logic_to_state(output, state, ctx) -> None:
+def _write_nl_to_logic_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write NL-to-formal-logic translation results to UnifiedAnalysisState (#173)."""
     if not output or not isinstance(output, dict):
         return
@@ -611,7 +611,7 @@ def _write_nl_to_logic_to_state(output, state, ctx) -> None:
             )
 
 
-def _write_dung_extensions_to_state(output, state, ctx) -> None:
+def _write_dung_extensions_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write Dung extension computation results to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -639,7 +639,7 @@ def _write_dung_extensions_to_state(output, state, ctx) -> None:
                 )
 
 
-def _write_formal_synthesis_to_state(output, state, ctx) -> None:
+def _write_formal_synthesis_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write formal synthesis report to UnifiedAnalysisState."""
     if not output or not isinstance(output, dict):
         return
@@ -653,7 +653,7 @@ def _write_formal_synthesis_to_state(output, state, ctx) -> None:
     state.add_formal_synthesis_report(summary, phase_results, float(overall_validity))
 
 
-def _write_dl_to_state(output, state, ctx) -> None:
+def _write_dl_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write Description Logic results to UnifiedAnalysisState (#86)."""
     if not output or not isinstance(output, dict):
         return
@@ -667,7 +667,7 @@ def _write_dl_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_cl_to_state(output, state, ctx) -> None:
+def _write_cl_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write Conditional Logic results to UnifiedAnalysisState (#86)."""
     if not output or not isinstance(output, dict):
         return
@@ -681,7 +681,7 @@ def _write_cl_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_sat_to_state(output, state, ctx) -> None:
+def _write_sat_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write SAT solver results to UnifiedAnalysisState (#86)."""
     if not output or not isinstance(output, dict):
         return
@@ -703,7 +703,7 @@ def _write_sat_to_state(output, state, ctx) -> None:
         )
 
 
-def _write_setaf_to_state(output, state, ctx) -> None:
+def _write_setaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write SetAF results to UnifiedAnalysisState (#87)."""
     if not output or not isinstance(output, dict):
         return
@@ -715,7 +715,7 @@ def _write_setaf_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_weighted_to_state(output, state, ctx) -> None:
+def _write_weighted_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write Weighted AF results to UnifiedAnalysisState (#87)."""
     if not output or not isinstance(output, dict):
         return
@@ -731,7 +731,7 @@ def _write_weighted_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_social_to_state(output, state, ctx) -> None:
+def _write_social_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write Social AF results to UnifiedAnalysisState (#87)."""
     if not output or not isinstance(output, dict):
         return
@@ -745,7 +745,7 @@ def _write_social_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_eaf_to_state(output, state, ctx) -> None:
+def _write_eaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write EAF results to UnifiedAnalysisState (#88)."""
     if not output or not isinstance(output, dict):
         return
@@ -757,7 +757,7 @@ def _write_eaf_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_delp_to_state(output, state, ctx) -> None:
+def _write_delp_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write DeLP results to UnifiedAnalysisState (#89)."""
     if not output or not isinstance(output, dict):
         return
@@ -770,7 +770,7 @@ def _write_delp_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_qbf_to_state(output, state, ctx) -> None:
+def _write_qbf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write QBF results to UnifiedAnalysisState (#90)."""
     if not output or not isinstance(output, dict):
         return
@@ -781,7 +781,7 @@ def _write_qbf_to_state(output, state, ctx) -> None:
     )
 
 
-def _write_collaborative_analysis_to_state(output, state, ctx) -> None:
+def _write_collaborative_analysis_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write collaborative multi-agent debate results to state (#175)."""
     from argumentation_analysis.orchestration.collaborative_debate import (
         _write_collaborative_to_state,
@@ -790,7 +790,7 @@ def _write_collaborative_analysis_to_state(output, state, ctx) -> None:
     _write_collaborative_to_state(output, state, ctx)
 
 
-def _write_narrative_synthesis_to_state(output, state, ctx) -> None:
+def _write_narrative_synthesis_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write narrative synthesis results to UnifiedAnalysisState (#351)."""
     if not output or not isinstance(output, dict):
         return

--- a/argumentation_analysis/orchestration/trace_analyzer.py
+++ b/argumentation_analysis/orchestration/trace_analyzer.py
@@ -125,7 +125,9 @@ class ConversationalTraceAnalyzer:
             f"{sum(len(p.turns) for p in self.phases)} turns"
         )
 
-    def begin_phase(self, phase_name: str, state_snapshot: Optional[Dict] = None) -> None:
+    def begin_phase(
+        self, phase_name: str, state_snapshot: Optional[Dict] = None
+    ) -> None:
         """Begin tracking a new conversational phase."""
         if self._current_phase and not self._current_phase.end_time:
             self._current_phase.end_time = time.time()
@@ -184,7 +186,9 @@ class ConversationalTraceAnalyzer:
         if isinstance(state_snapshot.get("identified_fallacies"), list):
             metrics.fallacies_found = len(state_snapshot["identified_fallacies"])
         if isinstance(state_snapshot.get("argument_quality_scores"), dict):
-            metrics.quality_scores_count = len(state_snapshot["argument_quality_scores"])
+            metrics.quality_scores_count = len(
+                state_snapshot["argument_quality_scores"]
+            )
         if isinstance(state_snapshot.get("counter_arguments"), list):
             metrics.counter_arguments_count = len(state_snapshot["counter_arguments"])
 
@@ -208,15 +212,17 @@ class ConversationalTraceAnalyzer:
 
         phase_summaries = []
         for phase in self.phases:
-            phase_summaries.append({
-                "name": phase.name,
-                "turns": len(phase.turns),
-                "duration_seconds": round(phase.duration, 1),
-                "agents": phase.agents_active,
-                "total_content_chars": phase.total_content,
-                "state_before": phase.state_before,
-                "state_after": phase.state_after,
-            })
+            phase_summaries.append(
+                {
+                    "name": phase.name,
+                    "turns": len(phase.turns),
+                    "duration_seconds": round(phase.duration, 1),
+                    "agents": phase.agents_active,
+                    "total_content_chars": phase.total_content,
+                    "state_before": phase.state_before,
+                    "state_after": phase.state_after,
+                }
+            )
 
         report = {
             "total_phases": len(self.phases),

--- a/argumentation_analysis/orchestration/workflow_dsl.py
+++ b/argumentation_analysis/orchestration/workflow_dsl.py
@@ -235,7 +235,7 @@ class WorkflowBuilder:
         name: str,
         capability: str,
         condition: Callable[[Dict[str, Any]], bool],
-        **kwargs,
+        **kwargs: Any,
     ) -> "WorkflowBuilder":
         """Add a phase that only executes when condition(ctx) returns True."""
         return self.add_phase(name, capability, condition=condition, **kwargs)
@@ -246,7 +246,7 @@ class WorkflowBuilder:
         capability: str,
         max_iterations: int = 3,
         convergence_fn: Optional[Callable[[Any, Any], bool]] = None,
-        **kwargs,
+        **kwargs: Any,
     ) -> "WorkflowBuilder":
         """Add a phase that loops until convergence or max_iterations."""
         loop_cfg = LoopConfig(

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -261,8 +261,11 @@ def _should_rerun_fallacy(context: Dict[str, Any]) -> bool:
     # Method 2: scan beliefs dict for invalid entries
     beliefs = jtms_output.get("beliefs", {})
     if isinstance(beliefs, dict):
-        retracted = [name for name, bdata in beliefs.items()
-                     if isinstance(bdata, dict) and bdata.get("valid") is False]
+        retracted = [
+            name
+            for name, bdata in beliefs.items()
+            if isinstance(bdata, dict) and bdata.get("valid") is False
+        ]
         if retracted:
             return True
 
@@ -346,8 +349,7 @@ def build_iterative_analysis_workflow() -> WorkflowDefinition:
             capability="adversarial_debate",
             depends_on=["counter"],
             optional=True,
-        )
-        .build()
+        ).build()
     )
 
 
@@ -726,9 +728,9 @@ def get_workflow_catalog() -> Dict[str, WorkflowDefinition]:
                 build_formal_verification_workflow,
             )
 
-            WORKFLOW_CATALOG[
-                "formal_verification"
-            ] = build_formal_verification_workflow()
+            WORKFLOW_CATALOG["formal_verification"] = (
+                build_formal_verification_workflow()
+            )
         except Exception as e:
             logger.warning(f"Formal verification workflow not registered: {e}")
         # Comprehensive analysis (LLM-only, benchmark-optimized)
@@ -769,5 +771,3 @@ def reset_workflow_catalog() -> None:
     global WORKFLOW_CATALOG
     WORKFLOW_CATALOG = {}
     logger.debug("Workflow catalog reset to empty state")
-
-

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -18,7 +18,7 @@ try:
         build_sherlock_modern_workflow,
     )
 except ImportError:
-    build_sherlock_modern_workflow = None  # type: ignore[assignment,misc]
+    build_sherlock_modern_workflow = None  # type: ignore[assignment]
 
 logger = logging.getLogger("UnifiedPipeline")
 
@@ -384,20 +384,20 @@ def build_nl_to_logic_workflow() -> WorkflowDefinition:
 def build_quality_gated_counter_workflow() -> WorkflowDefinition:
     """Quality-gated counter-argument with iterative refinement (Loop 3)."""
 
-    def quality_gate(ctx):
+    def quality_gate(ctx: Dict[str, Any]) -> bool:
         """Only generate counter-argument if quality score > 3.0."""
         output = ctx.get("phase_quality_output")
         if not output or not isinstance(output, dict):
             return True  # proceed if no quality data
-        return output.get("note_finale", 0) > 3.0
+        return bool(output.get("note_finale", 0) > 3.0)
 
-    def counter_quality_convergence(prev, curr):
+    def counter_quality_convergence(prev: Any, curr: Any) -> bool:
         """Converge when counter-argument quality stops improving."""
         if not isinstance(prev, dict) or not isinstance(curr, dict):
             return False
         prev_score = prev.get("note_finale", 0)
         curr_score = curr.get("note_finale", 0)
-        return curr_score >= prev_score  # stop when no improvement
+        return bool(curr_score >= prev_score)  # stop when no improvement
 
     return (
         WorkflowBuilder("quality_gated_counter")
@@ -683,7 +683,7 @@ def get_workflow_catalog() -> Dict[str, WorkflowDefinition]:
                 build_collaborative_analysis_workflow,
             )
 
-            WORKFLOW_CATALOG["collaborative"] = build_collaborative_analysis_workflow()
+            WORKFLOW_CATALOG["collaborative"] = build_collaborative_analysis_workflow()  # type: ignore[no-untyped-call]
         except Exception as e:
             logger.warning(f"Collaborative workflow not registered: {e}")
         # Macro workflows (Track D)
@@ -746,7 +746,7 @@ def get_workflow_catalog() -> Dict[str, WorkflowDefinition]:
                 build_sherlock_modern_workflow,
             )
 
-            wf = build_sherlock_modern_workflow()
+            wf = build_sherlock_modern_workflow()  # type: ignore[no-untyped-call]
             if wf is not None:  # builder returns None on failure (review #382)
                 WORKFLOW_CATALOG["sherlock_modern"] = wf
             else:

--- a/argumentation_analysis/pipelines/orchestration/orchestrators/specialized/real_llm_orchestrator.py
+++ b/argumentation_analysis/pipelines/orchestration/orchestrators/specialized/real_llm_orchestrator.py
@@ -10,6 +10,7 @@ DEPRECATED: Use these alternatives instead:
 - For pipeline orchestration: argumentation_analysis.orchestration.unified_pipeline.UnifiedPipeline
 - For conversational analysis: argumentation_analysis.orchestration.conversation_orchestrator.ConversationOrchestrator
 """
+
 import warnings
 
 
@@ -47,4 +48,4 @@ class RealLLMOrchestratorWrapper:
         )
 
 
-__all__ = ['RealLLMOrchestratorWrapper']
+__all__ = ["RealLLMOrchestratorWrapper"]

--- a/argumentation_analysis/plugins/analysis_tools/logic/contextual_fallacy_analyzer.py
+++ b/argumentation_analysis/plugins/analysis_tools/logic/contextual_fallacy_analyzer.py
@@ -154,7 +154,9 @@ class EnhancedContextualFallacyAnalyzer:
             )
             self.logger.info("NLP models loaded successfully.")
         except Exception as e:
-            self.logger.warning("Could not load NLP models, falling back to heuristic: %s", e)
+            self.logger.warning(
+                "Could not load NLP models, falling back to heuristic: %s", e
+            )
             models = {}
         return models
 

--- a/argumentation_analysis/plugins/atms_plugin.py
+++ b/argumentation_analysis/plugins/atms_plugin.py
@@ -60,7 +60,9 @@ class ATMSPlugin:
 
     @staticmethod
     def _json_result(success: bool, data: dict = None, error: str = None) -> str:
-        return json.dumps({"success": success, **(data or {}), **({"error": error} if error else {})})
+        return json.dumps(
+            {"success": success, **(data or {}), **({"error": error} if error else {})}
+        )
 
     # ------------------------------------------------------------------
     # Kernel functions
@@ -165,7 +167,9 @@ class ATMSPlugin:
     ) -> str:
         try:
             atms, _ = self._get_or_create(instance_id)
-            assumption_set = frozenset(n.strip() for n in assumptions.split(",") if n.strip())
+            assumption_set = frozenset(
+                n.strip() for n in assumptions.split(",") if n.strip()
+            )
             derivable = []
             for name, node in atms.nodes.items():
                 if node.is_assumption or name == "\u22a5":

--- a/argumentation_analysis/plugins/exploration_plugin.py
+++ b/argumentation_analysis/plugins/exploration_plugin.py
@@ -60,8 +60,10 @@ class ExplorationPlugin:
                     or node.get("nom_vulgarisé", "")
                     or node.get(f"text_{self._alt_lang}", "")
                 ),
-                "description": node.get(f"desc_{lang}", "") or node.get(f"desc_{self._alt_lang}", ""),
-                "example": node.get(f"example_{lang}", "") or node.get(f"example_{self._alt_lang}", ""),
+                "description": node.get(f"desc_{lang}", "")
+                or node.get(f"desc_{self._alt_lang}", ""),
+                "example": node.get(f"example_{lang}", "")
+                or node.get(f"example_{self._alt_lang}", ""),
                 "depth": node.get("depth", ""),
                 "is_leaf": len(children) == 0,
             },
@@ -73,8 +75,12 @@ class ExplorationPlugin:
                         or c.get("nom_vulgarisé", "")
                         or c.get(f"text_{self._alt_lang}", "")
                     ),
-                    "description": c.get(f"desc_{lang}", "") or c.get(f"desc_{self._alt_lang}", ""),
-                    "example": (c.get(f"example_{lang}", "") or c.get(f"example_{self._alt_lang}", ""))[:200],
+                    "description": c.get(f"desc_{lang}", "")
+                    or c.get(f"desc_{self._alt_lang}", ""),
+                    "example": (
+                        c.get(f"example_{lang}", "")
+                        or c.get(f"example_{self._alt_lang}", "")
+                    )[:200],
                 }
                 for c in children
             ],

--- a/argumentation_analysis/plugins/fallacy_workflow_plugin.py
+++ b/argumentation_analysis/plugins/fallacy_workflow_plugin.py
@@ -87,7 +87,9 @@ class FallacyWorkflowPlugin:
                 self.logger.error(f"Error reading taxonomy file: {e}")
 
         self.taxonomy_navigator = TaxonomyNavigator(taxonomy_data=data)
-        self.exploration_plugin = ExplorationPlugin(self.taxonomy_navigator, language=self.language)
+        self.exploration_plugin = ExplorationPlugin(
+            self.taxonomy_navigator, language=self.language
+        )
 
         if self.taxonomy_navigator.get_root_nodes():
             self.logger.info(
@@ -271,7 +273,9 @@ class FallacyWorkflowPlugin:
             if reasoning_history:
                 reasoning_context = (
                     "\n--- PREVIOUS REASONING (for context) ---\n"
-                    + "\n".join(f"{i+1}. {r}" for i, r in enumerate(reasoning_history[-3:]))
+                    + "\n".join(
+                        f"{i+1}. {r}" for i, r in enumerate(reasoning_history[-3:])
+                    )
                     + "\n"
                 )
 
@@ -301,9 +305,7 @@ class FallacyWorkflowPlugin:
                 options_text += f"  - {cname} (ID: {cpk}): {cdesc}\n"
                 if cexample:
                     options_text += f"    Example: {cexample}\n"
-                options_text += (
-                    f"    → Call explore_branch(node_pk='{cpk}') to explore this branch.\n"
-                )
+                options_text += f"    → Call explore_branch(node_pk='{cpk}') to explore this branch.\n"
 
             prompt = (
                 f'Text to analyze: "{argument_text[:500]}"\n\n'
@@ -403,7 +405,9 @@ class FallacyWorkflowPlugin:
                         )
 
                     return IdentifiedFallacy(
-                        fallacy_type=result.get("name", result.get("name_fr", result.get("pk", ""))),
+                        fallacy_type=result.get(
+                            "name", result.get("name_fr", result.get("pk", ""))
+                        ),
                         taxonomy_pk=confirmed_pk,
                         taxonomy_path=result.get("path", ""),
                         explanation=full_explanation,
@@ -414,9 +418,7 @@ class FallacyWorkflowPlugin:
                 elif func_name == "conclude_no_fallacy":
                     reason = result.get("reason", "no reason")
                     # Capture reasoning for memory
-                    reasoning_summary = (
-                        f"Abandoned {current_node.get(f'text_{self.language}', current_pk)}: {reason}"
-                    )
+                    reasoning_summary = f"Abandoned {current_node.get(f'text_{self.language}', current_pk)}: {reason}"
                     reasoning_history.append(reasoning_summary)
                     self.logger.info(f"  Branch abandoned: {reason}")
                     return None
@@ -427,10 +429,10 @@ class FallacyWorkflowPlugin:
                     next_pk = node_info.get("pk", "")
                     if next_pk and next_pk != current_pk:
                         # Capture reasoning for memory - why this branch was chosen
-                        branch_name = node_info.get('name', node_info.get('name_fr', next_pk))
-                        reasoning_summary = (
-                            f"Explored {branch_name} from {current_node.get(f'text_{self.language}', current_pk)}"
+                        branch_name = node_info.get(
+                            "name", node_info.get("name_fr", next_pk)
                         )
+                        reasoning_summary = f"Explored {branch_name} from {current_node.get(f'text_{self.language}', current_pk)}"
                         reasoning_history.append(reasoning_summary)
 
                         current_pk = next_pk
@@ -568,8 +570,11 @@ class FallacyWorkflowPlugin:
             # Each branch gets its own reasoning history (no shared state)
             exploration_tasks = [
                 self._explore_single_branch(
-                    argument_text, pk, slave_kernel, slave_settings,
-                    reasoning_history=None  # Each branch starts fresh
+                    argument_text,
+                    pk,
+                    slave_kernel,
+                    slave_settings,
+                    reasoning_history=None,  # Each branch starts fresh
                 )
                 for pk in candidate_pks
             ]

--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -48,7 +48,11 @@ def build_narrative(state: Any) -> str:
                 f"{len(quality)} argument(s), avec une note moyenne de "
                 f"{avg:.1f}/5."
             )
-            weak = [k for k, v in quality.items() if isinstance(v, dict) and v.get("overall", 0) < 3]
+            weak = [
+                k
+                for k, v in quality.items()
+                if isinstance(v, dict) and v.get("overall", 0) < 3
+            ]
             if weak:
                 quality_desc += f" {len(weak)} argument(s) presentent des faiblesses significatives."
             parts.append(quality_desc)
@@ -58,7 +62,9 @@ def build_narrative(state: Any) -> str:
     neural_fallacies = getattr(state, "neural_fallacy_scores", [])
     total_fallacies = len(fallacies) + len(neural_fallacies)
     if total_fallacies:
-        types = [v.get("type", "inconnu") for v in fallacies.values() if isinstance(v, dict)]
+        types = [
+            v.get("type", "inconnu") for v in fallacies.values() if isinstance(v, dict)
+        ]
         types_str = ", ".join(set(types)) if types else f"{total_fallacies} sophisme(s)"
         fallacy_text = (
             f"L'analyse a detecte {total_fallacies} sophisme(s) "
@@ -82,8 +88,16 @@ def build_narrative(state: Any) -> str:
     # ── JTMS beliefs ───────────────────────────────────────────────
     jtms_beliefs = getattr(state, "jtms_beliefs", {})
     if jtms_beliefs:
-        valid_count = sum(1 for v in jtms_beliefs.values() if isinstance(v, dict) and v.get("valid") is True)
-        invalid_count = sum(1 for v in jtms_beliefs.values() if isinstance(v, dict) and v.get("valid") is False)
+        valid_count = sum(
+            1
+            for v in jtms_beliefs.values()
+            if isinstance(v, dict) and v.get("valid") is True
+        )
+        invalid_count = sum(
+            1
+            for v in jtms_beliefs.values()
+            if isinstance(v, dict) and v.get("valid") is False
+        )
         jtms_text = (
             f"Le systeme JTMS maintient {len(jtms_beliefs)} croyance(s): "
             f"{valid_count} valide(s), {invalid_count} rejetee(s)."
@@ -100,7 +114,9 @@ def build_narrative(state: Any) -> str:
     # ── ATMS multi-context ─────────────────────────────────────────
     atms_contexts = getattr(state, "atms_contexts", [])
     if atms_contexts:
-        coherent = sum(1 for c in atms_contexts if isinstance(c, dict) and c.get("coherent"))
+        coherent = sum(
+            1 for c in atms_contexts if isinstance(c, dict) and c.get("coherent")
+        )
         incoherent = len(atms_contexts) - coherent
         parts.append(
             f"L'analyse ATMS multi-contextes a teste {len(atms_contexts)} hypothese(s): "

--- a/argumentation_analysis/plugins/nl_to_logic_plugin.py
+++ b/argumentation_analysis/plugins/nl_to_logic_plugin.py
@@ -44,16 +44,18 @@ class NLToLogicPlugin:
         translator = NLToLogicTranslator(max_retries=3, logic_type="propositional")
         result = await translator.translate(text, logic_type="propositional")
 
-        return json.dumps({
-            "original_text": result.original_text[:200],
-            "formula": result.formula,
-            "logic_type": result.logic_type,
-            "is_valid": result.is_valid,
-            "validation_message": result.validation_message,
-            "attempts": result.attempts,
-            "variables": result.variables,
-            "confidence": result.confidence,
-        })
+        return json.dumps(
+            {
+                "original_text": result.original_text[:200],
+                "formula": result.formula,
+                "logic_type": result.logic_type,
+                "is_valid": result.is_valid,
+                "validation_message": result.validation_message,
+                "attempts": result.attempts,
+                "variables": result.variables,
+                "confidence": result.confidence,
+            }
+        )
 
     @kernel_function(
         name="translate_to_fol",
@@ -71,16 +73,18 @@ class NLToLogicPlugin:
         translator = NLToLogicTranslator(max_retries=3, logic_type="fol")
         result = await translator.translate(text, logic_type="fol")
 
-        return json.dumps({
-            "original_text": result.original_text[:200],
-            "formula": result.formula,
-            "logic_type": result.logic_type,
-            "is_valid": result.is_valid,
-            "validation_message": result.validation_message,
-            "attempts": result.attempts,
-            "variables": result.variables,
-            "confidence": result.confidence,
-        })
+        return json.dumps(
+            {
+                "original_text": result.original_text[:200],
+                "formula": result.formula,
+                "logic_type": result.logic_type,
+                "is_valid": result.is_valid,
+                "validation_message": result.validation_message,
+                "attempts": result.attempts,
+                "variables": result.variables,
+                "confidence": result.confidence,
+            }
+        )
 
     @kernel_function(
         name="translate_batch_to_pl",
@@ -103,21 +107,23 @@ class NLToLogicPlugin:
         translator = NLToLogicTranslator(max_retries=3, logic_type="propositional")
         batch = await translator.translate_batch(arguments, logic_type="propositional")
 
-        return json.dumps({
-            "translations": [
-                {
-                    "original_text": t.original_text[:200],
-                    "formula": t.formula,
-                    "is_valid": t.is_valid,
-                    "variables": t.variables,
-                    "confidence": t.confidence,
-                }
-                for t in batch.translations
-            ],
-            "overall_consistency": batch.overall_consistency,
-            "consistency_message": batch.consistency_message,
-            "method": batch.method,
-        })
+        return json.dumps(
+            {
+                "translations": [
+                    {
+                        "original_text": t.original_text[:200],
+                        "formula": t.formula,
+                        "is_valid": t.is_valid,
+                        "variables": t.variables,
+                        "confidence": t.confidence,
+                    }
+                    for t in batch.translations
+                ],
+                "overall_consistency": batch.overall_consistency,
+                "consistency_message": batch.consistency_message,
+                "method": batch.method,
+            }
+        )
 
     @kernel_function(
         name="translate_batch_to_fol",
@@ -140,21 +146,23 @@ class NLToLogicPlugin:
         translator = NLToLogicTranslator(max_retries=3, logic_type="fol")
         batch = await translator.translate_batch(arguments, logic_type="fol")
 
-        return json.dumps({
-            "translations": [
-                {
-                    "original_text": t.original_text[:200],
-                    "formula": t.formula,
-                    "is_valid": t.is_valid,
-                    "variables": t.variables,
-                    "confidence": t.confidence,
-                }
-                for t in batch.translations
-            ],
-            "overall_consistency": batch.overall_consistency,
-            "consistency_message": batch.consistency_message,
-            "method": batch.method,
-        })
+        return json.dumps(
+            {
+                "translations": [
+                    {
+                        "original_text": t.original_text[:200],
+                        "formula": t.formula,
+                        "is_valid": t.is_valid,
+                        "variables": t.variables,
+                        "confidence": t.confidence,
+                    }
+                    for t in batch.translations
+                ],
+                "overall_consistency": batch.overall_consistency,
+                "consistency_message": batch.consistency_message,
+                "method": batch.method,
+            }
+        )
 
 
 def _parse_json_or_default(text: str, default: dict) -> dict:

--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -162,7 +162,9 @@ async def run_modern_analysis(
     print(f"\n{'='*60}")
     print(f" Résultats — Workflow: {results.get('workflow_name', workflow_name)}")
     print(f"{'='*60}")
-    print(f"  Phases complétées : {summary.get('completed', 0)}/{summary.get('total', 0)}")
+    print(
+        f"  Phases complétées : {summary.get('completed', 0)}/{summary.get('total', 0)}"
+    )
     print(f"  Phases échouées   : {summary.get('failed', 0)}")
     print(f"  Phases sautées    : {summary.get('skipped', 0)}")
 
@@ -183,11 +185,11 @@ async def run_modern_analysis(
     state_snapshot = results.get("state_snapshot")
     if state_snapshot:
         non_empty = sum(
-            1
-            for v in state_snapshot.values()
-            if v and v not in ([], {}, "", None, 0)
+            1 for v in state_snapshot.values() if v and v not in ([], {}, "", None, 0)
         )
-        print(f"\n  État unifié : {non_empty} champs non-vides sur {len(state_snapshot)}")
+        print(
+            f"\n  État unifié : {non_empty} champs non-vides sur {len(state_snapshot)}"
+        )
 
     print(f"{'='*60}\n")
 
@@ -417,9 +419,16 @@ Exemples:
             output_path.parent.mkdir(parents=True, exist_ok=True)
             with open(output_path, "w", encoding="utf-8") as f:
                 json.dump(
-                    {"trace": result.trace, "solution": result.solution,
-                     "agents": result.agents_used, "hypotheses": result.hypotheses},
-                    f, ensure_ascii=False, indent=2, default=str,
+                    {
+                        "trace": result.trace,
+                        "solution": result.solution,
+                        "agents": result.agents_used,
+                        "hypotheses": result.hypotheses,
+                    },
+                    f,
+                    ensure_ascii=False,
+                    indent=2,
+                    default=str,
                 )
             logging.info(f"Results saved to {output_path}")
     elif mode == "conversational":
@@ -464,10 +473,13 @@ Exemples:
                 render_result = {
                     "workflow_name": results.get("workflow_name", "conversational"),
                     "state_snapshot": results.get("state_snapshot", {}),
-                    "summary": results.get("summary", {
-                        "completed": len(results.get("phases", [])),
-                        "total": len(results.get("phases", [])),
-                    }),
+                    "summary": results.get(
+                        "summary",
+                        {
+                            "completed": len(results.get("phases", [])),
+                            "total": len(results.get("phases", [])),
+                        },
+                    ),
                     "capabilities_used": results.get("capabilities_used", []),
                 }
                 render_spectacular_result(render_result)

--- a/argumentation_analysis/services/ai_shield/layers/__init__.py
+++ b/argumentation_analysis/services/ai_shield/layers/__init__.py
@@ -1,7 +1,11 @@
 """Shield validation layers."""
 
 from argumentation_analysis.services.ai_shield.layers.heuristic import HeuristicLayer
-from argumentation_analysis.services.ai_shield.layers.llm_validator import LLMValidatorLayer
-from argumentation_analysis.services.ai_shield.layers.output_filter import OutputFilterLayer
+from argumentation_analysis.services.ai_shield.layers.llm_validator import (
+    LLMValidatorLayer,
+)
+from argumentation_analysis.services.ai_shield.layers.output_filter import (
+    OutputFilterLayer,
+)
 
 __all__ = ["HeuristicLayer", "LLMValidatorLayer", "OutputFilterLayer"]

--- a/argumentation_analysis/services/ai_shield/layers/heuristic.py
+++ b/argumentation_analysis/services/ai_shield/layers/heuristic.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, Optional
 
 from argumentation_analysis.services.ai_shield.shield import ShieldLayer, LayerResult
 
-
 # ── Pattern definitions ──────────────────────────────────────────────
 
 INJECTION_PATTERNS = [
@@ -71,9 +70,7 @@ class HeuristicLayer(ShieldLayer):
         custom_patterns: Optional[List[str]] = None,
     ):
         super().__init__(name="heuristic", threshold=threshold, enabled=enabled)
-        self._injection_re = [
-            re.compile(p, re.IGNORECASE) for p in INJECTION_PATTERNS
-        ]
+        self._injection_re = [re.compile(p, re.IGNORECASE) for p in INJECTION_PATTERNS]
         self._bias_re = [re.compile(p, re.IGNORECASE) for p in BIAS_KEYWORDS]
         self._manipulation_re = [
             re.compile(p, re.IGNORECASE) for p in MANIPULATION_PATTERNS
@@ -98,25 +95,41 @@ class HeuristicLayer(ShieldLayer):
         for pattern in self._injection_re:
             m = pattern.search(text)
             if m:
-                matches.append({"type": "injection", "match": m.group(), "pattern": pattern.pattern})
+                matches.append(
+                    {
+                        "type": "injection",
+                        "match": m.group(),
+                        "pattern": pattern.pattern,
+                    }
+                )
                 score += 0.4
 
         for pattern in self._bias_re:
             m = pattern.search(text)
             if m:
-                matches.append({"type": "bias", "match": m.group(), "pattern": pattern.pattern})
+                matches.append(
+                    {"type": "bias", "match": m.group(), "pattern": pattern.pattern}
+                )
                 score += 0.3
 
         for pattern in self._manipulation_re:
             m = pattern.search(text)
             if m:
-                matches.append({"type": "manipulation", "match": m.group(), "pattern": pattern.pattern})
+                matches.append(
+                    {
+                        "type": "manipulation",
+                        "match": m.group(),
+                        "pattern": pattern.pattern,
+                    }
+                )
                 score += 0.5
 
         for pattern in self._custom_re:
             m = pattern.search(text)
             if m:
-                matches.append({"type": "custom", "match": m.group(), "pattern": pattern.pattern})
+                matches.append(
+                    {"type": "custom", "match": m.group(), "pattern": pattern.pattern}
+                )
                 score += 0.3
 
         score = min(score, 1.0)

--- a/argumentation_analysis/services/ai_shield/layers/output_filter.py
+++ b/argumentation_analysis/services/ai_shield/layers/output_filter.py
@@ -12,7 +12,6 @@ from typing import Any, Dict, List, Optional
 
 from argumentation_analysis.services.ai_shield.shield import ShieldLayer, LayerResult
 
-
 # ── Leak detection patterns ──────────────────────────────────────────
 
 SYSTEM_PROMPT_LEAKS = [
@@ -25,11 +24,11 @@ SYSTEM_PROMPT_LEAKS = [
 
 CREDENTIAL_PATTERNS = [
     # API keys and tokens
-    r"sk-[a-zA-Z0-9]{20,}",                     # OpenAI-style
-    r"sk-or-v1-[a-zA-Z0-9]{40,}",               # OpenRouter
-    r"Bearer\s+[a-zA-Z0-9\-._~+/]+=*",          # Bearer tokens
+    r"sk-[a-zA-Z0-9]{20,}",  # OpenAI-style
+    r"sk-or-v1-[a-zA-Z0-9]{40,}",  # OpenRouter
+    r"Bearer\s+[a-zA-Z0-9\-._~+/]+=*",  # Bearer tokens
     r"api[_-]?key\s*[=:]\s*['\"]?[a-zA-Z0-9]{16,}",  # Generic API key
-    r"password\s*[=:]\s*['\"]?[^\s'\"]{8,}",     # Passwords
+    r"password\s*[=:]\s*['\"]?[^\s'\"]{8,}",  # Passwords
     r"secret\s*[=:]\s*['\"]?[a-zA-Z0-9]{16,}",  # Secrets
 ]
 
@@ -46,8 +45,8 @@ PII_PATTERNS = [
 
 PATH_PATTERNS = [
     # File paths
-    r"[A-Z]:\\[\w\\]+",                          # Windows paths
-    r"/(?:home|root|etc|var|usr)/[\w/]+",         # Unix paths
+    r"[A-Z]:\\[\w\\]+",  # Windows paths
+    r"/(?:home|root|etc|var|usr)/[\w/]+",  # Unix paths
     # Environment variables
     r"\$\{?\w+_(?:KEY|SECRET|TOKEN|PASSWORD)\}?",
 ]
@@ -107,7 +106,11 @@ class OutputFilterLayer(ShieldLayer):
                 if m:
                     # Redact the match for safety
                     matched = m.group()
-                    redacted = matched[:4] + "***" + matched[-4:] if len(matched) > 8 else "***"
+                    redacted = (
+                        matched[:4] + "***" + matched[-4:]
+                        if len(matched) > 8
+                        else "***"
+                    )
                     matches.append({"type": "credential", "match": redacted})
                     score += 0.6
                     break
@@ -116,7 +119,11 @@ class OutputFilterLayer(ShieldLayer):
             for pattern in self._pii_re:
                 for m in pattern.finditer(text):
                     matched = m.group()
-                    redacted = matched[:3] + "***" + matched[-3:] if len(matched) > 6 else "***"
+                    redacted = (
+                        matched[:3] + "***" + matched[-3:]
+                        if len(matched) > 6
+                        else "***"
+                    )
                     matches.append({"type": "pii", "match": redacted})
                     score += 0.3
                     if score >= 1.0:

--- a/argumentation_analysis/services/ai_shield/presets.py
+++ b/argumentation_analysis/services/ai_shield/presets.py
@@ -10,8 +10,12 @@ from typing import Optional
 
 from argumentation_analysis.services.ai_shield.shield import Shield
 from argumentation_analysis.services.ai_shield.layers.heuristic import HeuristicLayer
-from argumentation_analysis.services.ai_shield.layers.llm_validator import LLMValidatorLayer
-from argumentation_analysis.services.ai_shield.layers.output_filter import OutputFilterLayer
+from argumentation_analysis.services.ai_shield.layers.llm_validator import (
+    LLMValidatorLayer,
+)
+from argumentation_analysis.services.ai_shield.layers.output_filter import (
+    OutputFilterLayer,
+)
 
 
 def load_preset(

--- a/argumentation_analysis/services/jtms/extended_belief.py
+++ b/argumentation_analysis/services/jtms/extended_belief.py
@@ -178,7 +178,9 @@ class JTMSSession:
     def set_fact(self, name: str, is_true: bool = True):
         """Declare a belief as ground truth."""
         if name not in self.jtms.beliefs:
-            self.add_belief(name, "system_fact", {"description": "Auto-added as a fact"})
+            self.add_belief(
+                name, "system_fact", {"description": "Auto-added as a fact"}
+            )
         self.jtms.set_belief_validity(name, is_true)
         self.last_modified = datetime.now()
 
@@ -191,10 +193,12 @@ class JTMSSession:
         contradiction = "_CONTRADICTION_"
         if contradiction in self.jtms.beliefs:
             if self.jtms.beliefs[contradiction].valid:
-                conflicts.append({
-                    "type": "contradiction_detected",
-                    "belief": contradiction,
-                })
+                conflicts.append(
+                    {
+                        "type": "contradiction_detected",
+                        "belief": contradiction,
+                    }
+                )
 
         for name, belief in self.jtms.beliefs.items():
             if belief.non_monotonic:

--- a/argumentation_analysis/services/jtms/jtms_core.py
+++ b/argumentation_analysis/services/jtms/jtms_core.py
@@ -98,7 +98,7 @@ class Belief:
                 conclusion.compute_truth_statement()
                 # Track cascade: conclusion was valid, now retracted
                 if (
-                    hasattr(self, '_jtms_ref')
+                    hasattr(self, "_jtms_ref")
                     and self._jtms_ref is not None
                     and self._jtms_ref._tracing_enabled
                     and old_valid is True
@@ -174,12 +174,14 @@ class JTMS:
         belief = self.beliefs[belief_name]
         old_valid = belief.valid
         if self._tracing_enabled and old_valid is True and validity is not True:
-            self._retraction_trace.append({
-                "trigger": belief_name,
-                "retracted": [belief_name],
-                "cascaded": [],
-                "reason": f"directly set to {validity}",
-            })
+            self._retraction_trace.append(
+                {
+                    "trigger": belief_name,
+                    "retracted": [belief_name],
+                    "cascaded": [],
+                    "reason": f"directly set to {validity}",
+                }
+            )
         belief.set_truth_value(validity)
 
     def add_justification(

--- a/argumentation_analysis/services/nl_to_logic.py
+++ b/argumentation_analysis/services/nl_to_logic.py
@@ -438,9 +438,7 @@ class NLToLogicTranslator:
 
         if logic_type == "propositional":
             # Try to parse as PL formula
-            result = await asyncio.to_thread(
-                bridge.validate_pl_formula, formula
-            )
+            result = await asyncio.to_thread(bridge.validate_pl_formula, formula)
             if result:
                 return True, "Valid propositional formula (Tweety)"
             else:
@@ -449,19 +447,22 @@ class NLToLogicTranslator:
             # FOL: build signature from metadata and validate all formulas together
             fol_formulas = [f.strip() for f in formula.split(";") if f.strip()]
 
-            if fol_metadata and (fol_metadata.get("sorts") or fol_metadata.get("constants_raw")):
+            if fol_metadata and (
+                fol_metadata.get("sorts") or fol_metadata.get("constants_raw")
+            ):
                 # Use programmatic signature building for robust constant handling
                 return await asyncio.to_thread(
-                    self._validate_fol_with_signature, bridge, fol_formulas, fol_metadata
+                    self._validate_fol_with_signature,
+                    bridge,
+                    fol_formulas,
+                    fol_metadata,
                 )
             else:
                 # Fallback: try parsing each formula without signature (old behavior)
                 errors = []
                 for f in fol_formulas:
                     try:
-                        await asyncio.to_thread(
-                            bridge.fol_handler.parse_fol_formula, f
-                        )
+                        await asyncio.to_thread(bridge.fol_handler.parse_fol_formula, f)
                     except (ValueError, Exception) as e:
                         errors.append(f"'{f}': {e}")
                 if errors:
@@ -525,10 +526,14 @@ class NLToLogicTranslator:
                         all_declared_constants.add(arg)
 
         try:
-            FolSignature = jpype.JClass("org.tweetyproject.logics.fol.syntax.FolSignature")
+            FolSignature = jpype.JClass(
+                "org.tweetyproject.logics.fol.syntax.FolSignature"
+            )
             Sort = jpype.JClass("org.tweetyproject.logics.commons.syntax.Sort")
             Constant = jpype.JClass("org.tweetyproject.logics.commons.syntax.Constant")
-            Predicate = jpype.JClass("org.tweetyproject.logics.commons.syntax.Predicate")
+            Predicate = jpype.JClass(
+                "org.tweetyproject.logics.commons.syntax.Predicate"
+            )
             FolParser = jpype.JClass("org.tweetyproject.logics.fol.parser.FolParser")
             ArrayList = jpype.JClass("java.util.ArrayList")
             String = jpype.JClass("java.lang.String")
@@ -553,7 +558,11 @@ class NLToLogicTranslator:
             # Step 3: Create and add predicates with their argument sorts
             # Handle both formats: {"Pred": ["Sort1"]} and {"Pred": "description"}
             for pred_name, arg_info in predicates_data.items():
-                if isinstance(arg_info, list) and arg_info and isinstance(arg_info[0], str):
+                if (
+                    isinstance(arg_info, list)
+                    and arg_info
+                    and isinstance(arg_info[0], str)
+                ):
                     # New format: list of sort names
                     java_arg_sorts = ArrayList()
                     for arg_sort_name in arg_info:
@@ -603,7 +612,10 @@ class NLToLogicTranslator:
                 return False, "; ".join(errors)
 
             formula_count = len(fol_formulas)
-            return True, f"Valid FOL formulas ({formula_count} formulas, Tweety with signature)"
+            return (
+                True,
+                f"Valid FOL formulas ({formula_count} formulas, Tweety with signature)",
+            )
 
         except jpype.JException as e:
             error_msg = str(e.getMessage()) if hasattr(e, "getMessage") else str(e)
@@ -675,7 +687,11 @@ class NLToLogicTranslator:
                 return False, f"Unmatched parentheses in '{f}'"
 
             # Check for predicates: at least one CamelCase word followed by (
-            if not re.search(r"[A-Z][a-zA-Z]*\(", f) and "forall" not in f and "exists" not in f:
+            if (
+                not re.search(r"[A-Z][a-zA-Z]*\(", f)
+                and "forall" not in f
+                and "exists" not in f
+            ):
                 return False, f"No predicates found in '{f}'"
 
         return True, "Valid FOL formulas (Python)"
@@ -741,10 +757,22 @@ class NLToLogicTranslator:
         """
         # Extract simple propositions from argument markers
         markers = [
-            "therefore", "because", "since", "thus", "hence",
-            "consequently", "so", "if", "then",
+            "therefore",
+            "because",
+            "since",
+            "thus",
+            "hence",
+            "consequently",
+            "so",
+            "if",
+            "then",
             # French markers
-            "donc", "car", "puisque", "parce que", "si", "alors",
+            "donc",
+            "car",
+            "puisque",
+            "parce que",
+            "si",
+            "alors",
         ]
 
         sentences = re.split(r"[.!?;]", text)
@@ -763,9 +791,7 @@ class NLToLogicTranslator:
                     f"{var_names[i]} => {var_names[i+1]}"
                     for i in range(len(var_names) - 1)
                 ]
-                formula = " && ".join(
-                    [var_names[0]] + implications
-                )
+                formula = " && ".join([var_names[0]] + implications)
             elif variables:
                 formula = list(variables.keys())[0]
             else:
@@ -785,8 +811,7 @@ class NLToLogicTranslator:
 
         else:  # FOL
             sentences_clean = [
-                re.sub(r"[^a-zA-Z0-9\s]", "", s).strip()
-                for s in sentences[:5]
+                re.sub(r"[^a-zA-Z0-9\s]", "", s).strip() for s in sentences[:5]
             ]
             formulas = []
             predicates = {}

--- a/argumentation_analysis/services/semantic_index_service.py
+++ b/argumentation_analysis/services/semantic_index_service.py
@@ -374,9 +374,7 @@ class SemanticIndexService:
                 continue
 
             arg_id = f"arg_{i+1}"
-            source_quote = (
-                arg.get("source_quote", "") if isinstance(arg, dict) else ""
-            )
+            source_quote = arg.get("source_quote", "") if isinstance(arg, dict) else ""
 
             # Build metadata tags
             tags: Dict[str, str] = {
@@ -404,7 +402,11 @@ class SemanticIndexService:
                 if isinstance(virtues, dict):
                     # Store weakest virtue for targeted search
                     weakest = min(
-                        ((k, v) for k, v in virtues.items() if isinstance(v, (int, float))),
+                        (
+                            (k, v)
+                            for k, v in virtues.items()
+                            if isinstance(v, (int, float))
+                        ),
                         key=lambda x: x[1],
                         default=None,
                     )
@@ -531,38 +533,47 @@ class SemanticIndexService:
             chunks = []
             for arg in arguments:
                 if isinstance(arg, dict):
-                    chunks.append({
-                        "text": arg.get("text", str(arg)),
-                        "source_quote": arg.get("source_quote", ""),
-                        "chunk_type": "argument",
-                    })
+                    chunks.append(
+                        {
+                            "text": arg.get("text", str(arg)),
+                            "source_quote": arg.get("source_quote", ""),
+                            "chunk_type": "argument",
+                        }
+                    )
                 elif isinstance(arg, str) and len(arg) >= 10:
-                    chunks.append({
-                        "text": arg,
-                        "source_quote": "",
-                        "chunk_type": "argument",
-                    })
+                    chunks.append(
+                        {
+                            "text": arg,
+                            "source_quote": "",
+                            "chunk_type": "argument",
+                        }
+                    )
 
             for claim in claims:
                 if isinstance(claim, dict):
-                    chunks.append({
-                        "text": claim.get("text", str(claim)),
-                        "source_quote": claim.get("source_quote", ""),
-                        "chunk_type": "claim",
-                    })
+                    chunks.append(
+                        {
+                            "text": claim.get("text", str(claim)),
+                            "source_quote": claim.get("source_quote", ""),
+                            "chunk_type": "claim",
+                        }
+                    )
                 elif isinstance(claim, str) and len(claim) >= 10:
-                    chunks.append({
-                        "text": claim,
-                        "source_quote": "",
-                        "chunk_type": "claim",
-                    })
+                    chunks.append(
+                        {
+                            "text": claim,
+                            "source_quote": "",
+                            "chunk_type": "claim",
+                        }
+                    )
 
             if chunks:
                 return chunks
 
         # Fallback: sentence-level splitting
         import re
-        sentences = re.split(r'(?<=[.!?])\s+', text)
+
+        sentences = re.split(r"(?<=[.!?])\s+", text)
         return [
             {"text": s.strip(), "source_quote": "", "chunk_type": "sentence"}
             for s in sentences

--- a/argumentation_analysis/services/web_api/app.py
+++ b/argumentation_analysis/services/web_api/app.py
@@ -17,6 +17,7 @@ FrameworkService, LogicService) remain available at their original import paths
 under argumentation_analysis.services.web_api.services.* and are used by the
 MCP server.
 """
+
 import warnings
 
 warnings.warn(
@@ -25,6 +26,7 @@ warnings.warn(
     DeprecationWarning,
     stacklevel=2,
 )
+
 
 # Minimal shim: create_app returns a stub that raises on use
 def create_app(*args, **kwargs):

--- a/argumentation_analysis/visualization/dung_viz.py
+++ b/argumentation_analysis/visualization/dung_viz.py
@@ -35,6 +35,7 @@ def render_attack_graph(
     """
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
         import networkx as nx
@@ -81,8 +82,12 @@ def render_attack_graph(
     )
     nx.draw_networkx_labels(G, pos, ax=ax, font_size=8, font_weight="bold")
     nx.draw_networkx_edges(
-        G, pos, ax=ax, edge_color="#666",
-        arrowsize=20, arrowstyle="-|>",
+        G,
+        pos,
+        ax=ax,
+        edge_color="#666",
+        arrowsize=20,
+        arrowstyle="-|>",
         connectionstyle="arc3,rad=0.1",
     )
 
@@ -99,8 +104,12 @@ def render_attack_graph(
         for sem, exts in extensions.items():
             stats_text += f"\n{sem}: {len(exts)} ext(s)"
     ax.text(
-        0.02, 0.02, stats_text, transform=ax.transAxes,
-        fontsize=8, verticalalignment="bottom",
+        0.02,
+        0.02,
+        stats_text,
+        transform=ax.transAxes,
+        fontsize=8,
+        verticalalignment="bottom",
         bbox=dict(boxstyle="round", facecolor="wheat", alpha=0.5),
     )
 

--- a/argumentation_analysis/visualization/html_report.py
+++ b/argumentation_analysis/visualization/html_report.py
@@ -514,12 +514,14 @@ def render_html_report(
     fallacy_by_family: Dict[str, list] = {}
     for fid, fdata in fallacies.items():
         family = fdata.get("family", "unknown")
-        fallacy_by_family.setdefault(family, []).append({
-            "id": fid,
-            "type": fdata.get("type", ""),
-            "source_arg": fdata.get("source_arg", ""),
-            "confidence": fdata.get("confidence", 0),
-        })
+        fallacy_by_family.setdefault(family, []).append(
+            {
+                "id": fid,
+                "type": fdata.get("type", ""),
+                "source_arg": fdata.get("source_arg", ""),
+                "confidence": fdata.get("confidence", 0),
+            }
+        )
 
     # Precompute heatmap grid: list of {family, cells: [{conf: float|None}]}
     arg_ids = list(arguments.keys())
@@ -569,7 +571,9 @@ def render_html_report(
     pattern_ctx = None
     if pattern_data:
         spectrum = pattern_data.get("spectrum", {})
-        spectrum_types = sorted({t for c in spectrum.values() for t in c}) if spectrum else []
+        spectrum_types = (
+            sorted({t for c in spectrum.values() for t in c}) if spectrum else []
+        )
         cluster_ids = sorted(spectrum.keys()) if spectrum else []
         pattern_ctx = {
             "spectrum": spectrum,
@@ -584,7 +588,9 @@ def render_html_report(
     html = template.render(
         source_id=state.get("source_id", "unknown"),
         workflow_name=state.get("workflow_name", "unknown"),
-        summary=state.get("summary", {"completed": 0, "total": 0, "failed": 0, "skipped": 0}),
+        summary=state.get(
+            "summary", {"completed": 0, "total": 0, "failed": 0, "skipped": 0}
+        ),
         capabilities=state.get("capabilities_used", []),
         arguments=arguments,
         arg_ids=arg_ids,
@@ -615,10 +621,20 @@ def render_html_report(
         dung_status=dung_status,
         atms_tree_data=json.dumps(atms_root),
         # Helper functions
-        _score_badge=lambda v: f'<span class="badge {"badge-green" if float(v) >= 0.8 else "badge-orange" if float(v) >= 0.6 else "badge-red"}">{v:.0%}</span>' if isinstance(v, (int, float)) else v,
-        _score_cell=lambda v: f'<span style="color:{_score_color(float(v))};font-weight:600;">{v:.2f}</span>' if isinstance(v, (int, float)) else str(v),
+        _score_badge=lambda v: (
+            f'<span class="badge {"badge-green" if float(v) >= 0.8 else "badge-orange" if float(v) >= 0.6 else "badge-red"}">{v:.0%}</span>'
+            if isinstance(v, (int, float))
+            else v
+        ),
+        _score_cell=lambda v: (
+            f'<span style="color:{_score_color(float(v))};font-weight:600;">{v:.2f}</span>'
+            if isinstance(v, (int, float))
+            else str(v)
+        ),
         _heat_color=_heat_color,
-        _pattern_heat_bg=lambda v: f"rgba(88,166,255,{min(v * 0.8, 0.6):.2f})" if v > 0 else "transparent",
+        _pattern_heat_bg=lambda v: (
+            f"rgba(88,166,255,{min(v * 0.8, 0.6):.2f})" if v > 0 else "transparent"
+        ),
         _status_badge=lambda s: f'<span class="badge {"badge-green" if "accepted" in s else "badge-red" if s == "rejected" else "badge-blue"}">{s.replace("_", " ")}</span>',
     )
 
@@ -633,11 +649,19 @@ if __name__ == "__main__":
     import argparse
     import sys
 
-    parser = argparse.ArgumentParser(description="Render HTML report from spectacular state JSON")
-    parser.add_argument("state_json", help="Path to state JSON file (golden fixture format)")
+    parser = argparse.ArgumentParser(
+        description="Render HTML report from spectacular state JSON"
+    )
+    parser.add_argument(
+        "state_json", help="Path to state JSON file (golden fixture format)"
+    )
     parser.add_argument("output_html", help="Output HTML file path")
-    parser.add_argument("--pattern-json", help="Optional path to pattern mining JSON for section 10")
-    parser.add_argument("--indent", action="store_true", help="Pretty-print HTML output")
+    parser.add_argument(
+        "--pattern-json", help="Optional path to pattern mining JSON for section 10"
+    )
+    parser.add_argument(
+        "--indent", action="store_true", help="Pretty-print HTML output"
+    )
     args = parser.parse_args()
 
     state_path = pathlib.Path(args.state_json)

--- a/argumentation_analysis/visualization/pipeline_viz.py
+++ b/argumentation_analysis/visualization/pipeline_viz.py
@@ -29,6 +29,7 @@ def render_pipeline_dashboard(
     """
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
     except ImportError:
@@ -99,8 +100,13 @@ def _render_counts_panel(ax, state: Dict[str, Any]) -> None:
     ax.set_xlabel("Count")
     ax.set_title("Extraction Results")
     for bar, val in zip(bars, values):
-        ax.text(bar.get_width() + 0.3, bar.get_y() + bar.get_height() / 2,
-                str(val), va="center", fontsize=10)
+        ax.text(
+            bar.get_width() + 0.3,
+            bar.get_y() + bar.get_height() / 2,
+            str(val),
+            va="center",
+            fontsize=10,
+        )
 
 
 def _render_fallacy_panel(ax, state: Dict[str, Any]) -> None:
@@ -117,13 +123,21 @@ def _render_fallacy_panel(ax, state: Dict[str, Any]) -> None:
         items = {}
 
     if not items:
-        ax.text(0.5, 0.5, "No fallacies\ndetected", ha="center", va="center", fontsize=12)
+        ax.text(
+            0.5, 0.5, "No fallacies\ndetected", ha="center", va="center", fontsize=12
+        )
         ax.set_title("Fallacy Distribution")
         return
 
     labels = list(items.keys())[:8]
     sizes = [items[l] for l in labels]
-    ax.pie(sizes, labels=labels, autopct="%1.0f%%", startangle=90, textprops={"fontsize": 8})
+    ax.pie(
+        sizes,
+        labels=labels,
+        autopct="%1.0f%%",
+        startangle=90,
+        textprops={"fontsize": 8},
+    )
     ax.set_title(f"Fallacy Distribution ({sum(sizes)} total)")
 
 
@@ -178,20 +192,29 @@ def _render_phase_status(ax, state: Dict[str, Any]) -> None:
     if not phases:
         # Try to count non-empty fields
         non_empty = sum(
-            1 for k, v in state.items()
+            1
+            for k, v in state.items()
             if v and k not in ("raw_text", "source_info") and not k.startswith("phase_")
         )
         ax.text(
-            0.5, 0.5,
+            0.5,
+            0.5,
             f"{non_empty} non-empty\noutput fields",
-            ha="center", va="center", fontsize=16, fontweight="bold",
+            ha="center",
+            va="center",
+            fontsize=16,
+            fontweight="bold",
         )
         ax.set_title("Pipeline Output")
         return
 
-    colors = ["#4CAF50" if s == 1 else "#F44336" if s == 0 else "#FFC107" for s in statuses]
+    colors = [
+        "#4CAF50" if s == 1 else "#F44336" if s == 0 else "#FFC107" for s in statuses
+    ]
     ax.barh(phases, statuses, color=colors)
     ax.set_xlim(0, 1.2)
     ax.set_xticks([0, 0.5, 1])
     ax.set_xticklabels(["Error", "Empty", "OK"])
-    ax.set_title(f"Phase Status ({sum(1 for s in statuses if s == 1)}/{len(phases)} OK)")
+    ax.set_title(
+        f"Phase Status ({sum(1 for s in statuses if s == 1)}/{len(phases)} OK)"
+    )

--- a/argumentation_analysis/visualization/quality_viz.py
+++ b/argumentation_analysis/visualization/quality_viz.py
@@ -55,6 +55,7 @@ def render_quality_radar(
     """
     try:
         import matplotlib
+
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
         import numpy as np
@@ -84,8 +85,13 @@ def render_quality_radar(
     # Add overall score
     overall = sum(values[:-1]) / max(n, 1)
     ax.text(
-        0.5, -0.08, f"Score global: {overall:.2f}",
-        transform=ax.transAxes, ha="center", size=12, weight="bold",
+        0.5,
+        -0.08,
+        f"Score global: {overall:.2f}",
+        transform=ax.transAxes,
+        ha="center",
+        size=12,
+        weight="bold",
     )
 
     plt.tight_layout()

--- a/environment.yml
+++ b/environment.yml
@@ -68,6 +68,7 @@ dependencies:
   - black>=23.0.0      # Python code formatter
   - flake8>=6.0.0      # Linting tool
   - isort>=5.12.0      # Import sorter (optionnel mais recommandé)
+  - mypy>=1.0.0        # Static type checker
 
   # La section pip est pour les paquets non disponibles ou problématiques sur Conda
   - pip:

--- a/project_core/core_from_scripts/environment_manager.debug.py
+++ b/project_core/core_from_scripts/environment_manager.debug.py
@@ -6,16 +6,16 @@ import shlex
 
 print("--- ENV MANAGER SUPER MINIMAL ---")
 parser = argparse.ArgumentParser()
-parser.add_argument('--command', '-c', type=str, required=True)
+parser.add_argument("--command", "-c", type=str, required=True)
 # Ignorer les autres arguments pour l'instant
-parser.add_argument('--env-name', '-e', type=str, default=None)
+parser.add_argument("--env-name", "-e", type=str, default=None)
 args = parser.parse_args()
 
 print(f"Commande reçue: {args.command}")
 
 try:
     # shlex.split pour gérer les arguments avec espaces
-    command_list = shlex.split(args.command, posix=(os.name != 'nt'))
+    command_list = shlex.split(args.command, posix=(os.name != "nt"))
     print(f"Commande découpée: {command_list}")
 
     # Exécution directe sans conda run
@@ -23,8 +23,8 @@ try:
         command_list,
         check=False,
         text=True,
-        capture_output=True, # Capturer la sortie pour le débogage
-        encoding='utf-8'
+        capture_output=True,  # Capturer la sortie pour le débogage
+        encoding="utf-8",
     )
 
     print("--- SORTIE DU SOUS-PROCESSUS ---")

--- a/project_core/llm/models/commit_analysis.py
+++ b/project_core/llm/models/commit_analysis.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel, Field, ConfigDict
 from typing import List
 
+
 class CommitAnalysis(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
     """
@@ -11,9 +12,9 @@ class CommitAnalysis(BaseModel):
     )
     technical_debt_signals: List[str] = Field(
         description="A list of identified technical debt signals, such as commented-out code, TODOs, or complex logic.",
-        default_factory=list
+        default_factory=list,
     )
     quality_leaps: List[str] = Field(
         description="A list of identified quality leaps, such as significant refactoring, removal of dead code, or addition of tests.",
-        default_factory=list
+        default_factory=list,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,3 +147,30 @@ show_missing = true
 where = ["."]
 include = ["argumentation_analysis*"]
 exclude = ["tests*"]
+
+# --- mypy configuration (Issue #401) ---
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+follow_imports = "silent"
+ignore_missing_imports = true
+
+# Strict enforcement for core orchestration modules
+[[tool.mypy.overrides]]
+module = [
+    "argumentation_analysis.core.capability_registry",
+    "argumentation_analysis.core.shared_state",
+    "argumentation_analysis.orchestration.workflow_dsl",
+    "argumentation_analysis.orchestration.registry_setup",
+    "argumentation_analysis.orchestration.workflows",
+    "argumentation_analysis.orchestration.invoke_callables",
+    "argumentation_analysis.orchestration.state_writers",
+    "argumentation_analysis.agents.factory",
+]
+strict = true
+disallow_untyped_defs = true
+disallow_any_generics = true
+warn_unused_ignores = true
+warn_return_any = true

--- a/tests/agents/core/logic/test_tweety_bridge.py
+++ b/tests/agents/core/logic/test_tweety_bridge.py
@@ -184,6 +184,7 @@ class TestTweetyBridge(unittest.TestCase):
     def test_async_lock_is_asyncio_lock(self):
         """Vérifie que _get_async_lock retourne un asyncio.Lock."""
         import asyncio
+
         lock = TweetyBridge._get_async_lock()
         self.assertIsInstance(lock, asyncio.Lock)
 
@@ -221,7 +222,7 @@ class TestTweetyBridgeAsync(unittest.IsolatedAsyncioTestCase):
 
         try:
             # Mock the sync initialize_jvm to avoid actual JVM startup
-            with patch.object(TweetyBridge, 'initialize_jvm') as mock_init:
+            with patch.object(TweetyBridge, "initialize_jvm") as mock_init:
                 bridge = TweetyBridge.get_instance()
                 await bridge.async_initialize_jvm()
                 mock_init.assert_called_once()
@@ -256,7 +257,7 @@ class TestTweetyBridgeAsync(unittest.IsolatedAsyncioTestCase):
         asyncio.Lock.release = tracked_release
 
         try:
-            with patch.object(TweetyBridge, 'shutdown_jvm') as mock_shutdown:
+            with patch.object(TweetyBridge, "shutdown_jvm") as mock_shutdown:
                 bridge = TweetyBridge.get_instance()
                 await bridge.async_shutdown_jvm()
                 mock_shutdown.assert_called_once()

--- a/tests/bench/test_spectacular_perf.py
+++ b/tests/bench/test_spectacular_perf.py
@@ -25,7 +25,6 @@ pytestmark = [
 
 from argumentation_analysis.evaluation import BenchmarkRunner, ModelRegistry
 
-
 DATASET_PATH = os.path.join(
     os.path.dirname(__file__),
     "..",
@@ -65,17 +64,37 @@ def _count_populated_fields(state):
     if not state:
         return 0
     field_keys = [
-        "identified_arguments", "identified_fallacies", "belief_sets",
-        "extracts", "counter_arguments", "argument_quality_scores",
-        "jtms_beliefs", "jtms_retraction_chain", "dung_frameworks",
-        "governance_decisions", "debate_transcripts", "neural_fallacy_scores",
-        "ranking_results", "aspic_results", "fol_analysis_results",
-        "propositional_analysis_results", "modal_analysis_results",
-        "formal_synthesis_reports", "nl_to_logic_translations",
-        "atms_contexts", "narrative_synthesis", "final_conclusion",
-        "answers", "query_log", "belief_revision_results",
-        "dialogue_results", "probabilistic_results", "bipolar_results",
-        "fol_signature", "workflow_results", "semantic_index_refs",
+        "identified_arguments",
+        "identified_fallacies",
+        "belief_sets",
+        "extracts",
+        "counter_arguments",
+        "argument_quality_scores",
+        "jtms_beliefs",
+        "jtms_retraction_chain",
+        "dung_frameworks",
+        "governance_decisions",
+        "debate_transcripts",
+        "neural_fallacy_scores",
+        "ranking_results",
+        "aspic_results",
+        "fol_analysis_results",
+        "propositional_analysis_results",
+        "modal_analysis_results",
+        "formal_synthesis_reports",
+        "nl_to_logic_translations",
+        "atms_contexts",
+        "narrative_synthesis",
+        "final_conclusion",
+        "answers",
+        "query_log",
+        "belief_revision_results",
+        "dialogue_results",
+        "probabilistic_results",
+        "bipolar_results",
+        "fol_signature",
+        "workflow_results",
+        "semantic_index_refs",
         "transcription_segments",
     ]
     count = 0
@@ -100,13 +119,15 @@ def benchmark_results(benchmark_runner):
     results = {}
     for wf in ["standard", "spectacular"]:
         for doc_idx in [0, 1, 2]:
-            result = asyncio.run(benchmark_runner.run_cell(
-                workflow_name=wf,
-                model_name="default",
-                document_index=doc_idx,
-                max_text_chars=3000,
-                timeout=WALL_CLOCK_TIMEOUT,
-            ))
+            result = asyncio.run(
+                benchmark_runner.run_cell(
+                    workflow_name=wf,
+                    model_name="default",
+                    document_index=doc_idx,
+                    max_text_chars=3000,
+                    timeout=WALL_CLOCK_TIMEOUT,
+                )
+            )
             key = f"{wf}_{OPAQUE_IDS.get(doc_idx, f'doc_{doc_idx}')}"
             results[key] = {
                 "success": result.success,
@@ -120,6 +141,7 @@ def benchmark_results(benchmark_runner):
 
 
 # --- Performance Tests ---
+
 
 class TestSpectacularPerformance:
     """Wall-clock and state size benchmarks."""
@@ -170,7 +192,12 @@ class TestSpectacularCoverage:
         for doc in ["doc_A", "doc_B", "doc_C"]:
             std = benchmark_results[f"standard_{doc}"]
             spec = benchmark_results[f"spectacular_{doc}"]
-            if std["success"] and spec["success"] and std["state_snapshot"] and spec["state_snapshot"]:
+            if (
+                std["success"]
+                and spec["success"]
+                and std["state_snapshot"]
+                and spec["state_snapshot"]
+            ):
                 std_fields = _count_populated_fields(std["state_snapshot"])
                 spec_fields = _count_populated_fields(spec["state_snapshot"])
                 assert spec_fields >= std_fields, (
@@ -193,9 +220,9 @@ class TestSpectacularCoverage:
             if r["success"] and r["state_snapshot"]:
                 fallacies = r["state_snapshot"].get("identified_fallacies", {})
                 neural = r["state_snapshot"].get("neural_fallacy_scores", [])
-                assert len(fallacies) > 0 or len(neural) > 0, (
-                    f"{doc}: no fallacies detected"
-                )
+                assert (
+                    len(fallacies) > 0 or len(neural) > 0
+                ), f"{doc}: no fallacies detected"
 
     def test_spectacular_has_formal_logic(self, benchmark_results):
         """Spectacular produces FOL analysis on doc_A."""
@@ -209,9 +236,9 @@ class TestSpectacularCoverage:
         r = benchmark_results["spectacular_doc_A"]
         if r["success"] and r["state_snapshot"]:
             narrative = r["state_snapshot"].get("narrative_synthesis", "")
-            assert narrative and len(narrative.strip()) > 0, (
-                "doc_A: no narrative synthesis produced"
-            )
+            assert (
+                narrative and len(narrative.strip()) > 0
+            ), "doc_A: no narrative synthesis produced"
 
 
 class TestComparisonMetrics:
@@ -220,7 +247,9 @@ class TestComparisonMetrics:
     def test_perf_summary(self, benchmark_results):
         """Print performance summary table (informational, always passes)."""
         print("\n")
-        print(f"{'Workflow':<15} {'Doc':<6} {'Time(s)':>8} {'Phases':>8} {'Fields':>8} {'Size(KB)':>10}")
+        print(
+            f"{'Workflow':<15} {'Doc':<6} {'Time(s)':>8} {'Phases':>8} {'Fields':>8} {'Size(KB)':>10}"
+        )
         print("-" * 60)
         for wf in ["standard", "spectacular"]:
             for doc in ["doc_A", "doc_B", "doc_C"]:
@@ -240,8 +269,11 @@ class TestComparisonMetrics:
     def test_no_plaintext_in_results(self, benchmark_results):
         """Verify no source names or plaintext content leaked into results."""
         sensitive_fields = [
-            "raw_text", "source_name", "full_text",
-            "extract_text", "content",
+            "raw_text",
+            "source_name",
+            "full_text",
+            "extract_text",
+            "content",
         ]
         for key, r in benchmark_results.items():
             if not r["state_snapshot"]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,7 +297,8 @@ def pytest_configure(config):
         "no_jvm_session: marks tests that should not start the shared JVM session",
     )
     config.addinivalue_line(
-        "markers", "jvm_test: (deprecated, use jpype) marks tests that require the JVM to be started."
+        "markers",
+        "jvm_test: (deprecated, use jpype) marks tests that require the JVM to be started.",
     )
 
     if MOCK_DOTENV:

--- a/tests/golden/test_spectacular.py
+++ b/tests/golden/test_spectacular.py
@@ -37,6 +37,7 @@ def state(golden):
 
 # ── Helpers ──
 
+
 def _non_empty_count(data: dict) -> int:
     """Count keys whose value is non-empty (list/dict with items, non-empty str, non-zero number)."""
     count = 0
@@ -91,6 +92,7 @@ def _extract_cited_fields(narrative: str, state: dict) -> set:
 
 # ── Structural regression tests ──
 
+
 class TestGoldenFixtureIntegrity:
     """Verify the fixture file itself is well-formed."""
 
@@ -111,7 +113,9 @@ class TestGoldenFixtureIntegrity:
 
     def test_no_plaintext_source_content(self, golden):
         raw = golden["state_snapshot"].get("raw_text", "")
-        assert raw.startswith("[REDACTED"), "Golden fixture must not contain plaintext source"
+        assert raw.startswith(
+            "[REDACTED"
+        ), "Golden fixture must not contain plaintext source"
 
 
 class TestFieldCoverage:
@@ -151,7 +155,9 @@ class TestAtmsContexts:
 
     def test_at_least_one_contradictory_context(self, state):
         statuses = [c["status"] for c in state["atms_contexts"]]
-        assert "contradictory" in statuses, "Expected at least one contradictory ATMS context"
+        assert (
+            "contradictory" in statuses
+        ), "Expected at least one contradictory ATMS context"
 
 
 class TestDungFrameworks:
@@ -226,18 +232,22 @@ class TestNarrativeSynthesis:
 
     def test_narrative_synthesis_present(self, state):
         narrative = state.get("narrative_synthesis", "")
-        assert len(narrative) > 100, "Narrative synthesis should be substantial (>100 chars)"
+        assert (
+            len(narrative) > 100
+        ), "Narrative synthesis should be substantial (>100 chars)"
 
     def test_narrative_cites_at_least_5_fields(self, state):
         narrative = state["narrative_synthesis"]
         cited = _extract_cited_fields(narrative, state)
-        assert len(cited) >= 5, (
-            f"Narrative should cite ≥5 state fields, cites {len(cited)}: {cited}"
-        )
+        assert (
+            len(cited) >= 5
+        ), f"Narrative should cite ≥5 state fields, cites {len(cited)}: {cited}"
 
     def test_narrative_references_sections(self, state):
         narrative = state["narrative_synthesis"]
-        assert "Section" in narrative, "Narrative should include section cross-references"
+        assert (
+            "Section" in narrative
+        ), "Narrative should include section cross-references"
 
 
 class TestCrossFieldConsistency:
@@ -249,17 +259,17 @@ class TestCrossFieldConsistency:
         # Neural scores should cover at least the detected fallacies
         neural_types = {s["fallacy"] for s in neural}
         fallacy_types = {f["type"] for f in fallacies.values()}
-        assert fallacy_types.issubset(neural_types), (
-            f"Some detected fallacies not in neural scores: {fallacy_types - neural_types}"
-        )
+        assert fallacy_types.issubset(
+            neural_types
+        ), f"Some detected fallacies not in neural scores: {fallacy_types - neural_types}"
 
     def test_dung_arguments_are_subset_of_identified(self, state):
         identified = set(state.get("identified_arguments", {}).keys())
         fw = next(iter(state.get("dung_frameworks", {}).values()), {})
         dung_args = set(fw.get("arguments", []))
-        assert dung_args.issubset(identified), (
-            f"Dung references unknown args: {dung_args - identified}"
-        )
+        assert dung_args.issubset(
+            identified
+        ), f"Dung references unknown args: {dung_args - identified}"
 
     def test_counter_arguments_target_existing_args(self, state):
         identified = set(state.get("identified_arguments", {}).keys())

--- a/tests/integration/test_agent_family.py
+++ b/tests/integration/test_agent_family.py
@@ -64,9 +64,7 @@ def test_agent_performance(agent_factory, agent_type, test_case):
         AgentType.INFORMAL_FALLACY,
     }
     if agent_type in _broken_types:
-        pytest.xfail(
-            f"{agent_type.name}: invalid model_id in test environment"
-        )
+        pytest.xfail(f"{agent_type.name}: invalid model_id in test environment")
 
     # Arrange
     agent = agent_factory.create_agent(agent_type)

--- a/tests/integration/test_conversational_orchestration_integration.py
+++ b/tests/integration/test_conversational_orchestration_integration.py
@@ -8,6 +8,7 @@ Tests the full conversational pipeline with mock LLM, verifying:
 5. State snapshot benchmark (non-empty fields)
 6. Convergence detection via trace report
 """
+
 import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
@@ -18,7 +19,6 @@ from argumentation_analysis.orchestration.conversational_orchestrator import (
     run_conversational_analysis,
 )
 from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
-
 
 SAMPLE_TEXT = (
     "L'IA est dangereuse car Elon Musk l'a dit. "
@@ -79,9 +79,15 @@ class TestConversationalPipelineIntegration:
             )
 
         required_fields = [
-            "mode", "phases", "conversation_log", "total_messages",
-            "duration_seconds", "state_snapshot", "state_non_empty_fields",
-            "unified_state", "trace_report",
+            "mode",
+            "phases",
+            "conversation_log",
+            "total_messages",
+            "duration_seconds",
+            "state_snapshot",
+            "state_non_empty_fields",
+            "unified_state",
+            "trace_report",
         ]
         for field in required_fields:
             assert field in result, f"Missing required field: {field}"
@@ -135,9 +141,9 @@ class TestAgentPluginSpecialization:
         """Every agent has non-empty instructions."""
         for name, config in AGENT_CONFIG.items():
             assert "instructions" in config, f"Agent {name} missing instructions"
-            assert len(config["instructions"]) > 20, (
-                f"Agent {name} has suspiciously short instructions"
-            )
+            assert (
+                len(config["instructions"]) > 20
+            ), f"Agent {name} has suspiciously short instructions"
 
     def test_plugin_instances_created_for_all_specialities(self):
         """get_plugin_instances succeeds for every agent speciality."""
@@ -160,9 +166,9 @@ class TestAgentPluginSpecialization:
         ]
         # Allow some overlap but not all same
         unique = set(specialities)
-        assert len(unique) >= 4, (
-            f"Expected at least 4 distinct specialities, got {len(unique)}: {unique}"
-        )
+        assert (
+            len(unique) >= 4
+        ), f"Expected at least 4 distinct specialities, got {len(unique)}: {unique}"
 
 
 @pytest.mark.integration
@@ -344,9 +350,9 @@ class TestConversationLog:
             )
 
         agents_in_log = set(entry["agent"] for entry in result["conversation_log"])
-        assert len(agents_in_log) >= 2, (
-            f"Expected multiple agents in log, got: {agents_in_log}"
-        )
+        assert (
+            len(agents_in_log) >= 2
+        ), f"Expected multiple agents in log, got: {agents_in_log}"
 
 
 # =============================================================================
@@ -379,9 +385,7 @@ class TestRealAgentCreationWithMockedLLM:
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Analysis complete."
 
-        with patch.dict(
-            "os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}
-        ), patch(
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}), patch(
             "openai.resources.chat.completions.Completions.create",
             return_value=mock_response,
         ):
@@ -440,9 +444,7 @@ class TestRealAgentCreationWithMockedLLM:
         mock_response.choices = [MagicMock()]
         mock_response.choices[0].message.content = "Analysis complete."
 
-        with patch.dict(
-            "os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}
-        ), patch(
+        with patch.dict("os.environ", {"OPENAI_API_KEY": "sk-test-fake-key"}), patch(
             "openai.resources.chat.completions.Completions.create",
             return_value=mock_response,
         ):

--- a/tests/integration/test_enrichment_workflow.py
+++ b/tests/integration/test_enrichment_workflow.py
@@ -7,6 +7,7 @@ Validates:
 - README points to Discourse Pattern Mining
 - Privacy guard catches intentional leaks
 """
+
 import pathlib
 import subprocess
 import sys
@@ -26,7 +27,8 @@ class TestTasksCLI:
     def test_pattern_add_requires_args(self):
         result = subprocess.run(
             [sys.executable, str(TASKS_CLI), "pattern-add"],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode != 0
         assert "--source" in result.stderr or "--source" in result.stdout
@@ -34,7 +36,8 @@ class TestTasksCLI:
     def test_pattern_rerun_graceful_missing_script(self):
         result = subprocess.run(
             [sys.executable, str(TASKS_CLI), "pattern-rerun", "--skip-existing"],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 1
         assert "not found" in result.stderr.lower()
@@ -42,7 +45,8 @@ class TestTasksCLI:
     def test_pattern_report_graceful_missing_script(self):
         result = subprocess.run(
             [sys.executable, str(TASKS_CLI), "pattern-report"],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode == 1
         assert "not found" in result.stderr.lower()
@@ -50,7 +54,8 @@ class TestTasksCLI:
     def test_invalid_command_exits_error(self):
         result = subprocess.run(
             [sys.executable, str(TASKS_CLI), "nonexistent"],
-            capture_output=True, text=True,
+            capture_output=True,
+            text=True,
         )
         assert result.returncode != 0
 
@@ -111,6 +116,8 @@ class TestPrivacyGuard:
         idx = content.find("Discourse Pattern Mining")
         if idx == -1:
             return
-        section = content[idx:idx + 2000]
+        section = content[idx : idx + 2000]
         for forbidden in ("full_text", "raw_text", "source_name"):
-            assert forbidden not in section, f"LEAK: {forbidden} in README pattern section"
+            assert (
+                forbidden not in section
+            ), f"LEAK: {forbidden} in README pattern section"

--- a/tests/notebooks/test_spectacular_tour.py
+++ b/tests/notebooks/test_spectacular_tour.py
@@ -1,13 +1,15 @@
 """Smoke tests for the spectacular full tour notebook."""
+
 import json
 import pathlib
 
 import pytest
 
-
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
 NOTEBOOK_PATH = REPO_ROOT / "examples" / "notebooks" / "spectacular_full_tour.ipynb"
-FIXTURE_PATH = REPO_ROOT / "tests" / "golden" / "fixtures" / "spectacular" / "doc_a_golden.json"
+FIXTURE_PATH = (
+    REPO_ROOT / "tests" / "golden" / "fixtures" / "spectacular" / "doc_a_golden.json"
+)
 
 
 class TestSpectacularTourNotebook:
@@ -28,7 +30,9 @@ class TestSpectacularTourNotebook:
         assert NOTEBOOK_PATH.exists(), f"Notebook not found at {NOTEBOOK_PATH}"
 
     def test_minimum_15_cells(self, notebook_cells):
-        assert len(notebook_cells) >= 15, f"Expected >= 15 cells, got {len(notebook_cells)}"
+        assert (
+            len(notebook_cells) >= 15
+        ), f"Expected >= 15 cells, got {len(notebook_cells)}"
 
     def test_has_markdown_and_code_cells(self, notebook_cells):
         cell_types = {c["cell_type"] for c in notebook_cells}
@@ -38,35 +42,34 @@ class TestSpectacularTourNotebook:
     def test_all_17_capabilities_referenced(self, notebook_cells, golden_state):
         capabilities = set(golden_state["capabilities_used"])
         all_source = " ".join(
-            " ".join(cell.get("source", []))
-            for cell in notebook_cells
+            " ".join(cell.get("source", [])) for cell in notebook_cells
         )
         for cap in capabilities:
             assert cap in all_source, f"Capability '{cap}' not referenced in notebook"
 
     def test_no_plaintext_source_content(self, notebook_cells):
         all_source = " ".join(
-            " ".join(cell.get("source", []))
-            for cell in notebook_cells
+            " ".join(cell.get("source", [])) for cell in notebook_cells
         )
         forbidden = ["raw_text", "full_text", "source_name", "author", "speaker"]
         for word in forbidden:
             # Allow 'raw_text' only as dict key access patterns like state["raw_text"]
             # but not actual content
-            assert f'"{word}"' not in all_source.lower() or word == "raw_text", (
-                f"Potentially sensitive '{word}' found in notebook"
-            )
+            assert (
+                f'"{word}"' not in all_source.lower() or word == "raw_text"
+            ), f"Potentially sensitive '{word}' found in notebook"
 
     def test_opaque_id_only(self, notebook_cells):
         all_source = " ".join(
-            " ".join(cell.get("source", []))
-            for cell in notebook_cells
+            " ".join(cell.get("source", [])) for cell in notebook_cells
         )
         assert "doc_A" in all_source, "Opaque ID doc_A not found"
         # The notebook loads from the golden fixture file (doc_a_golden.json) which is fine
         # What matters is that displayed outputs use opaque IDs, not source names
         assert "source_name" not in all_source, "Should not reference source_name field"
-        assert "author" not in all_source.lower(), "Should not reference author metadata"
+        assert (
+            "author" not in all_source.lower()
+        ), "Should not reference author metadata"
 
     def test_section_structure(self, notebook_cells):
         """Verify all 8 major sections exist as markdown headers."""
@@ -87,7 +90,9 @@ class TestSpectacularTourNotebook:
             "Narrative Synthesis",
         ]
         for section in sections:
-            assert section in all_md, f"Section '{section}' not found in notebook markdown"
+            assert (
+                section in all_md
+            ), f"Section '{section}' not found in notebook markdown"
 
     def test_golden_fixture_loads(self, golden_state):
         assert golden_state["source_id"] == "doc_A"
@@ -126,4 +131,6 @@ class TestSpectacularTourNotebook:
             if c["cell_type"] == "code"
         ]
         uses_display = any("display(HTML" in src for src in code_sources)
-        assert uses_display, "Notebook should use IPython display(HTML(...)) for rich output"
+        assert (
+            uses_display
+        ), "Notebook should use IPython display(HTML(...)) for rich output"

--- a/tests/property/test_atms_invariants.py
+++ b/tests/property/test_atms_invariants.py
@@ -13,8 +13,8 @@ from hypothesis import strategies as st
 
 from argumentation_analysis.services.jtms.atms_core import ATMS, CONTRADICTION_SYMBOL
 
-
 # --- Strategies ---
+
 
 def name_pool(prefix="a", max_names=6):
     return st.lists(
@@ -48,16 +48,24 @@ def atms_with_envs(draw):
     assume(len(all_names) >= 2)
 
     for _ in range(n_just):
-        in_nodes = draw(st.lists(
-            st.sampled_from(all_names), min_size=0, max_size=min(3, len(all_names)),
-            unique=True,
-        ))
+        in_nodes = draw(
+            st.lists(
+                st.sampled_from(all_names),
+                min_size=0,
+                max_size=min(3, len(all_names)),
+                unique=True,
+            )
+        )
         remaining = [n for n in all_names if n not in in_nodes]
         if remaining:
-            out_nodes = draw(st.lists(
-                st.sampled_from(remaining),
-                min_size=0, max_size=2, unique=True,
-            ))
+            out_nodes = draw(
+                st.lists(
+                    st.sampled_from(remaining),
+                    min_size=0,
+                    max_size=2,
+                    unique=True,
+                )
+            )
         else:
             out_nodes = []
         candidates = [n for n in all_names if n not in in_nodes and n not in out_nodes]
@@ -101,9 +109,9 @@ class TestATMSContradictionPropagation:
 
         for name, node in atms.nodes.items():
             for env in node.label:
-                assert not env_to_kill.issubset(env), (
-                    f"Node {name} still has env {set(env)} superset of killed {set(env_to_kill)}"
-                )
+                assert not env_to_kill.issubset(
+                    env
+                ), f"Node {name} still has env {set(env)} superset of killed {set(env_to_kill)}"
 
     @given(atms_data=atms_with_envs())
     @settings(max_examples=40, deadline=2000)
@@ -118,9 +126,9 @@ class TestATMSContradictionPropagation:
 
         for name, node in atms.nodes.items():
             for env in node.label:
-                assert not env_to_kill.issubset(env), (
-                    f"Node {name} still has env {set(env)} superset of killed {set(env_to_kill)}"
-                )
+                assert not env_to_kill.issubset(
+                    env
+                ), f"Node {name} still has env {set(env)} superset of killed {set(env_to_kill)}"
 
 
 class TestATMSEnvironmentMonotonicity:
@@ -133,7 +141,9 @@ class TestATMSEnvironmentMonotonicity:
     @settings(max_examples=50, deadline=2000)
     @pytest.mark.property
     def test_adding_justification_preserves_environments(
-        self, assumptions, derived,
+        self,
+        assumptions,
+        derived,
     ):
         assume(len(assumptions) >= 2 and len(derived) >= 1)
 
@@ -144,9 +154,7 @@ class TestATMSEnvironmentMonotonicity:
             atms.add_node(name)
 
         atms.add_justification([assumptions[0]], [], derived[0])
-        labels_before = {
-            name: set(node.label) for name, node in atms.nodes.items()
-        }
+        labels_before = {name: set(node.label) for name, node in atms.nodes.items()}
 
         # Add another justification that won't trigger contradiction
         if len(assumptions) > 1:
@@ -187,16 +195,16 @@ class TestATMSNogoodEnforcement:
         nogood = frozenset({a1, a2})
         # d0 should NOT have the nogood env (it was invalidated)
         for env in atms.get_environments("d0"):
-            assert not nogood.issubset(env), (
-                f"d0 still has env {set(env)} containing nogood {set(nogood)}"
-            )
+            assert not nogood.issubset(
+                env
+            ), f"d0 still has env {set(env)} containing nogood {set(nogood)}"
 
         # Assumption nodes retain their singleton envs (not supersets of nogood)
         for name in [a1, a2]:
             for env in atms.get_environments(name):
-                assert not nogood.issubset(env), (
-                    f"{name} still has env {set(env)} containing nogood {set(nogood)}"
-                )
+                assert not nogood.issubset(
+                    env
+                ), f"{name} still has env {set(env)} containing nogood {set(nogood)}"
 
 
 class TestATMSHypothesisBranching:

--- a/tests/property/test_jtms_invariants.py
+++ b/tests/property/test_jtms_invariants.py
@@ -12,7 +12,6 @@ from hypothesis import strategies as st
 
 from argumentation_analysis.services.jtms.jtms_core import JTMS
 
-
 # --- Strategies ---
 
 belief_names = st.lists(
@@ -39,18 +38,29 @@ def jtms_with_justifications(draw):
         candidates = list(names)
         if len(candidates) < 2:
             continue
-        in_list = draw(st.lists(
-            st.sampled_from(candidates), min_size=0, max_size=min(3, len(candidates)),
-            unique=True,
-        ))
+        in_list = draw(
+            st.lists(
+                st.sampled_from(candidates),
+                min_size=0,
+                max_size=min(3, len(candidates)),
+                unique=True,
+            )
+        )
         remaining = [n for n in candidates if n not in in_list]
         if remaining:
-            out_list = draw(st.lists(
-                st.sampled_from(remaining), min_size=0, max_size=2, unique=True,
-            ))
+            out_list = draw(
+                st.lists(
+                    st.sampled_from(remaining),
+                    min_size=0,
+                    max_size=2,
+                    unique=True,
+                )
+            )
         else:
             out_list = []
-        conclusion_candidates = [n for n in candidates if n not in in_list and n not in out_list]
+        conclusion_candidates = [
+            n for n in candidates if n not in in_list and n not in out_list
+        ]
         if not conclusion_candidates:
             continue
         conclusion = draw(st.sampled_from(conclusion_candidates))
@@ -96,9 +106,9 @@ class TestJTMSJustificationConsistency:
                 if in_ok and out_ok:
                     has_satisfied = True
                     break
-            assert has_satisfied, (
-                f"Belief {name} is valid via propagation but no justification is satisfied"
-            )
+            assert (
+                has_satisfied
+            ), f"Belief {name} is valid via propagation but no justification is satisfied"
 
 
 class TestJTMSRetractionCascade:
@@ -120,18 +130,18 @@ class TestJTMSRetractionCascade:
         jtms.set_belief_validity(names[0], True)
 
         for name in names:
-            assert jtms.beliefs[name].valid is True, (
-                f"Expected {name} valid after setting {names[0]}=True"
-            )
+            assert (
+                jtms.beliefs[name].valid is True
+            ), f"Expected {name} valid after setting {names[0]}=True"
 
         jtms.set_belief_validity(names[0], False)
 
         for name in names:
             belief = jtms.beliefs[name]
             if belief.justifications:
-                assert belief.valid is not True, (
-                    f"Belief {name} should be invalid after retracting {names[0]}"
-                )
+                assert (
+                    belief.valid is not True
+                ), f"Belief {name} should be invalid after retracting {names[0]}"
 
 
 class TestJTMSRetractionCascadeTracing:
@@ -192,9 +202,9 @@ class TestJTMSNoCircularSupport:
             jtms.add_justification([names[i]], [], names[next_i])
 
         for name in names:
-            assert jtms.beliefs[name].non_monotonic is True, (
-                f"Cycle member {name} should be non-monotonic"
-            )
+            assert (
+                jtms.beliefs[name].non_monotonic is True
+            ), f"Cycle member {name} should be non-monotonic"
 
     @given(
         n=st.integers(min_value=2, max_value=4),
@@ -212,6 +222,6 @@ class TestJTMSNoCircularSupport:
             jtms.add_justification([names[i]], [], names[i + 1])
 
         for name in names:
-            assert jtms.beliefs[name].non_monotonic is False, (
-                f"Non-cyclic belief {name} should not be non-monotonic"
-            )
+            assert (
+                jtms.beliefs[name].non_monotonic is False
+            ), f"Non-cyclic belief {name} should not be non-monotonic"

--- a/tests/scenarios/test_scenario_fixtures.py
+++ b/tests/scenarios/test_scenario_fixtures.py
@@ -1,4 +1,5 @@
 """Smoke tests for scenario fixtures and manifest validation."""
+
 import pathlib
 
 import pytest
@@ -16,6 +17,7 @@ MANIFEST_PATH = SCENARIOS_DIR / "manifest.yaml"
 
 # Import schema from scenarios directory
 import sys
+
 sys.path.insert(0, str(SCENARIOS_DIR.parent))
 from scenarios.schema import ScenarioManifest, ScenarioSpec, load_manifest
 
@@ -61,24 +63,40 @@ class TestScenarioManifest:
 
     def test_all_expected_capabilities_valid(self):
         known_capabilities = {
-            "fact_extraction", "argument_quality", "nl_to_logic",
-            "neural_fallacy_detection", "hierarchical_fallacy_detection",
-            "propositional_logic", "first_order_logic", "modal_logic",
-            "dung_extensions", "aspic_analysis", "counter_argumentation",
-            "jtms_belief_revision", "debate_protocol",
-            "assumption_based_reasoning", "governance_simulation",
-            "formal_synthesis", "narrative_synthesis",
+            "fact_extraction",
+            "argument_quality",
+            "nl_to_logic",
+            "neural_fallacy_detection",
+            "hierarchical_fallacy_detection",
+            "propositional_logic",
+            "first_order_logic",
+            "modal_logic",
+            "dung_extensions",
+            "aspic_analysis",
+            "counter_argumentation",
+            "jtms_belief_revision",
+            "debate_protocol",
+            "assumption_based_reasoning",
+            "governance_simulation",
+            "formal_synthesis",
+            "narrative_synthesis",
         }
         manifest = load_manifest(MANIFEST_PATH)
         for s in manifest.scenarios:
             for cap in s.expected_capabilities:
-                assert cap in known_capabilities, f"Unknown capability '{cap}' in {s.id}"
+                assert (
+                    cap in known_capabilities
+                ), f"Unknown capability '{cap}' in {s.id}"
 
     def test_acceptance_thresholds_reasonable(self):
         manifest = load_manifest(MANIFEST_PATH)
         for s in manifest.scenarios:
-            assert 1 <= s.acceptance_min_args <= 20, f"{s.id}: min_args={s.acceptance_min_args}"
-            assert 0 <= s.acceptance_min_fallacies <= 10, f"{s.id}: min_fallacies={s.acceptance_min_fallacies}"
+            assert (
+                1 <= s.acceptance_min_args <= 20
+            ), f"{s.id}: min_args={s.acceptance_min_args}"
+            assert (
+                0 <= s.acceptance_min_fallacies <= 10
+            ), f"{s.id}: min_fallacies={s.acceptance_min_fallacies}"
 
 
 class TestScenarioContent:
@@ -87,7 +105,13 @@ class TestScenarioContent:
     def test_five_scenarios_present(self):
         manifest = load_manifest(MANIFEST_PATH)
         assert len(manifest.scenarios) == 5
-        expected_themes = {"public_policy", "science", "media", "fact_checking", "philosophy"}
+        expected_themes = {
+            "public_policy",
+            "science",
+            "media",
+            "fact_checking",
+            "philosophy",
+        }
         actual_themes = {s.theme for s in manifest.scenarios}
         assert actual_themes == expected_themes
 

--- a/tests/soutenance/test_slide_deck.py
+++ b/tests/soutenance/test_slide_deck.py
@@ -7,6 +7,7 @@ Validates:
 - Build output is gitignored
 - All assets under 100KB
 """
+
 import pathlib
 import re
 import sys
@@ -32,9 +33,7 @@ class TestSlideSource:
         content = SLIDES_MD.read_text(encoding="utf-8")
         sections = SLIDE_SEPARATOR.split(content)
         non_empty = [s.strip() for s in sections if s.strip()]
-        assert len(non_empty) >= 25, (
-            f"Expected >= 25 slides, found {len(non_empty)}"
-        )
+        assert len(non_empty) >= 25, f"Expected >= 25 slides, found {len(non_empty)}"
 
     def test_has_frontmatter(self):
         content = SLIDES_MD.read_text(encoding="utf-8")
@@ -48,9 +47,7 @@ class TestSlideSource:
     def test_no_plaintext_extracts(self):
         content = SLIDES_MD.read_text(encoding="utf-8").lower()
         for field in SENSITIVE_FIELDS:
-            assert field not in content, (
-                f"Found sensitive field '{field}' in slides.md"
-            )
+            assert field not in content, f"Found sensitive field '{field}' in slides.md"
 
     def test_opaque_ids_only(self):
         content = SLIDES_MD.read_text(encoding="utf-8")
@@ -107,12 +104,10 @@ class TestBuildScript:
         section_count = html.count("<section data-markdown>")
         md_content = SLIDES_MD.read_text(encoding="utf-8")
         _, body = parse_frontmatter(md_content)
-        md_sections = [
-            s.strip() for s in SLIDE_SEPARATOR.split(body) if s.strip()
-        ]
-        assert section_count == len(md_sections), (
-            f"HTML has {section_count} sections but source has {len(md_sections)}"
-        )
+        md_sections = [s.strip() for s in SLIDE_SEPARATOR.split(body) if s.strip()]
+        assert section_count == len(
+            md_sections
+        ), f"HTML has {section_count} sections but source has {len(md_sections)}"
 
     def test_build_output_under_100kb(self, tmp_path):
         from build_deck import build_deck

--- a/tests/test_readme_quickstart.py
+++ b/tests/test_readme_quickstart.py
@@ -6,6 +6,7 @@ Validates:
 - All referenced artifact paths exist
 - Quickstart commands reference valid entry points
 """
+
 import pathlib
 import re
 
@@ -29,7 +30,9 @@ class TestReadmeQuickstart:
 
     def test_has_demo_section(self):
         content = README.read_text(encoding="utf-8")
-        assert "Demo Spectaculaire" in content or "DEMO SPECTACULAIRE" in content.upper()
+        assert (
+            "Demo Spectaculaire" in content or "DEMO SPECTACULAIRE" in content.upper()
+        )
 
     def test_has_quickstart_commands(self):
         content = README.read_text(encoding="utf-8")
@@ -52,7 +55,9 @@ class TestQuickstartTape:
     """Tests for docs/demo/quickstart.tape."""
 
     def test_tape_exists(self):
-        assert QUICKSTART_TAPE.is_file(), f"quickstart.tape not found at {QUICKSTART_TAPE}"
+        assert (
+            QUICKSTART_TAPE.is_file()
+        ), f"quickstart.tape not found at {QUICKSTART_TAPE}"
 
     def test_tape_has_output_directive(self):
         content = QUICKSTART_TAPE.read_text(encoding="utf-8")
@@ -60,7 +65,9 @@ class TestQuickstartTape:
 
     def test_tape_references_spectacular(self):
         content = QUICKSTART_TAPE.read_text(encoding="utf-8")
-        assert "spectacular" in content.lower(), "Tape must reference spectacular workflow"
+        assert (
+            "spectacular" in content.lower()
+        ), "Tape must reference spectacular workflow"
 
     def test_tape_references_build_deck(self):
         content = QUICKSTART_TAPE.read_text(encoding="utf-8")
@@ -94,7 +101,9 @@ class TestArtifactPaths:
         txt_files = list(scenarios_dir.glob("*.txt"))
         if not txt_files:
             return
-        assert len(txt_files) >= 5, f"Expected >= 5 scenario .txt files, found {len(txt_files)}"
+        assert (
+            len(txt_files) >= 5
+        ), f"Expected >= 5 scenario .txt files, found {len(txt_files)}"
 
     def test_notebook_exists_or_skip(self):
         nb = REPO_ROOT / "examples" / "notebooks" / "spectacular_full_tour.ipynb"

--- a/tests/test_regression_golden.py
+++ b/tests/test_regression_golden.py
@@ -65,15 +65,15 @@ GOLDEN_TEXTS = {
 # Minimum thresholds per workflow type
 THRESHOLDS = {
     "light": {
-        "min_arguments": 2,       # heuristic extraction is conservative
+        "min_arguments": 2,  # heuristic extraction is conservative
         "min_quality_scores": 1,
         "min_counter_arguments": 1,
     },
     "standard": {
         "min_arguments": 3,
-        "min_fallacies": 0,        # hierarchical detector may not always fire
+        "min_fallacies": 0,  # hierarchical detector may not always fire
         "min_quality_scores": 1,
-        "min_fol_formulas": 0,     # NL-to-logic depends on LLM availability
+        "min_fol_formulas": 0,  # NL-to-logic depends on LLM availability
         "min_belief_sets": 1,
         "min_counter_arguments": 1,
     },
@@ -98,7 +98,9 @@ def _check_thresholds(
 
     n_quality = len(state.argument_quality_scores)
     if n_quality < thresholds.get("min_quality_scores", 0):
-        violations.append(f"quality_scores: {n_quality} < {thresholds['min_quality_scores']}")
+        violations.append(
+            f"quality_scores: {n_quality} < {thresholds['min_quality_scores']}"
+        )
 
     n_fol = len(state.fol_analysis_results)
     if n_fol < thresholds.get("min_fol_formulas", 0):
@@ -110,7 +112,9 @@ def _check_thresholds(
 
     n_counter = len(state.counter_arguments)
     if n_counter < thresholds.get("min_counter_arguments", 0):
-        violations.append(f"counter_arguments: {n_counter} < {thresholds['min_counter_arguments']}")
+        violations.append(
+            f"counter_arguments: {n_counter} < {thresholds['min_counter_arguments']}"
+        )
 
     return violations
 
@@ -136,58 +140,74 @@ class TestGoldenLightWorkflow:
         """Light workflow extracts at least 2 arguments from each golden text."""
         text = GOLDEN_TEXTS[text_name]
         result = await run_unified_analysis(
-            text=text, workflow_name="light", registry=registry,
+            text=text,
+            workflow_name="light",
+            registry=registry,
         )
         state = result["unified_state"]
         assert isinstance(state, UnifiedAnalysisState)
         n_args = len(state.identified_arguments)
-        assert n_args >= THRESHOLDS["light"]["min_arguments"], (
-            f"[{text_name}/light] Expected >= {THRESHOLDS['light']['min_arguments']} arguments, got {n_args}"
-        )
+        assert (
+            n_args >= THRESHOLDS["light"]["min_arguments"]
+        ), f"[{text_name}/light] Expected >= {THRESHOLDS['light']['min_arguments']} arguments, got {n_args}"
 
     @pytest.mark.parametrize("text_name", list(GOLDEN_TEXTS.keys()))
     async def test_light_produces_quality_scores(self, registry, text_name):
         """Light workflow produces quality evaluation scores."""
         text = GOLDEN_TEXTS[text_name]
         result = await run_unified_analysis(
-            text=text, workflow_name="light", registry=registry,
+            text=text,
+            workflow_name="light",
+            registry=registry,
         )
         state = result["unified_state"]
         n_quality = len(state.argument_quality_scores)
-        assert n_quality >= THRESHOLDS["light"]["min_quality_scores"], (
-            f"[{text_name}/light] Expected >= {THRESHOLDS['light']['min_quality_scores']} quality scores, got {n_quality}"
-        )
+        assert (
+            n_quality >= THRESHOLDS["light"]["min_quality_scores"]
+        ), f"[{text_name}/light] Expected >= {THRESHOLDS['light']['min_quality_scores']} quality scores, got {n_quality}"
 
     @pytest.mark.parametrize("text_name", list(GOLDEN_TEXTS.keys()))
     async def test_light_produces_counter_arguments(self, registry, text_name):
         """Light workflow generates at least 1 counter-argument."""
         text = GOLDEN_TEXTS[text_name]
         result = await run_unified_analysis(
-            text=text, workflow_name="light", registry=registry,
+            text=text,
+            workflow_name="light",
+            registry=registry,
         )
         state = result["unified_state"]
         n_counter = len(state.counter_arguments)
-        assert n_counter >= THRESHOLDS["light"]["min_counter_arguments"], (
-            f"[{text_name}/light] Expected >= {THRESHOLDS['light']['min_counter_arguments']} counter-arguments, got {n_counter}"
-        )
+        assert (
+            n_counter >= THRESHOLDS["light"]["min_counter_arguments"]
+        ), f"[{text_name}/light] Expected >= {THRESHOLDS['light']['min_counter_arguments']} counter-arguments, got {n_counter}"
 
     @pytest.mark.parametrize("text_name", list(GOLDEN_TEXTS.keys()))
     async def test_light_phases_complete(self, registry, text_name):
         """Light workflow: extract + quality + counter all complete."""
         text = GOLDEN_TEXTS[text_name]
         result = await run_unified_analysis(
-            text=text, workflow_name="light", registry=registry,
+            text=text,
+            workflow_name="light",
+            registry=registry,
         )
         phases = result["phases"]
-        assert phases["extract"].status.value == "completed", f"[{text_name}] extract phase not completed"
-        assert phases["quality"].status.value == "completed", f"[{text_name}] quality phase not completed"
-        assert phases["counter"].status.value == "completed", f"[{text_name}] counter phase not completed"
+        assert (
+            phases["extract"].status.value == "completed"
+        ), f"[{text_name}] extract phase not completed"
+        assert (
+            phases["quality"].status.value == "completed"
+        ), f"[{text_name}] quality phase not completed"
+        assert (
+            phases["counter"].status.value == "completed"
+        ), f"[{text_name}] counter phase not completed"
 
     async def test_light_state_snapshot_has_all_fields(self, registry):
         """Light workflow state snapshot includes expected dimension counts."""
         text = GOLDEN_TEXTS["vaccins"]
         result = await run_unified_analysis(
-            text=text, workflow_name="light", registry=registry,
+            text=text,
+            workflow_name="light",
+            registry=registry,
         )
         snapshot = result["state_snapshot"]
         assert "counter_argument_count" in snapshot
@@ -218,69 +238,85 @@ class TestGoldenStandardWorkflow:
         """Standard workflow meets all quality thresholds."""
         text = GOLDEN_TEXTS[text_name]
         result = await run_unified_analysis(
-            text=text, workflow_name="standard", registry=registry,
+            text=text,
+            workflow_name="standard",
+            registry=registry,
         )
         state = result["unified_state"]
-        violations = _check_thresholds(state, THRESHOLDS["standard"], f"{text_name}/standard")
-        assert violations == [], (
-            f"[{text_name}/standard] Threshold violations: {'; '.join(violations)}"
+        violations = _check_thresholds(
+            state, THRESHOLDS["standard"], f"{text_name}/standard"
         )
+        assert (
+            violations == []
+        ), f"[{text_name}/standard] Threshold violations: {'; '.join(violations)}"
 
     @pytest.mark.parametrize("text_name", list(GOLDEN_TEXTS.keys()))
     async def test_standard_produces_fallacies(self, registry, text_name):
         """Standard workflow detects at least 1 fallacy per text."""
         text = GOLDEN_TEXTS[text_name]
         result = await run_unified_analysis(
-            text=text, workflow_name="standard", registry=registry,
+            text=text,
+            workflow_name="standard",
+            registry=registry,
         )
         state = result["unified_state"]
         n_fallacies = len(state.identified_fallacies)
-        assert n_fallacies >= 1, (
-            f"[{text_name}/standard] Expected >= 1 fallacy, got {n_fallacies}"
-        )
+        assert (
+            n_fallacies >= 1
+        ), f"[{text_name}/standard] Expected >= 1 fallacy, got {n_fallacies}"
 
     @pytest.mark.parametrize("text_name", list(GOLDEN_TEXTS.keys()))
     async def test_standard_produces_fol_results(self, registry, text_name):
         """Standard workflow produces FOL analysis results."""
         text = GOLDEN_TEXTS[text_name]
         result = await run_unified_analysis(
-            text=text, workflow_name="standard", registry=registry,
+            text=text,
+            workflow_name="standard",
+            registry=registry,
         )
         state = result["unified_state"]
-        assert len(state.fol_analysis_results) >= 1, (
-            f"[{text_name}/standard] No FOL analysis results"
-        )
+        assert (
+            len(state.fol_analysis_results) >= 1
+        ), f"[{text_name}/standard] No FOL analysis results"
 
     @pytest.mark.parametrize("text_name", list(GOLDEN_TEXTS.keys()))
     async def test_standard_produces_jtms_beliefs(self, registry, text_name):
         """Standard workflow creates JTMS beliefs."""
         text = GOLDEN_TEXTS[text_name]
         result = await run_unified_analysis(
-            text=text, workflow_name="standard", registry=registry,
+            text=text,
+            workflow_name="standard",
+            registry=registry,
         )
         state = result["unified_state"]
         n_jtms = len(state.jtms_beliefs)
-        assert n_jtms >= 1, (
-            f"[{text_name}/standard] Expected >= 1 JTMS belief, got {n_jtms}"
-        )
+        assert (
+            n_jtms >= 1
+        ), f"[{text_name}/standard] Expected >= 1 JTMS belief, got {n_jtms}"
 
     async def test_standard_enrichment_summary(self, registry):
         """Standard workflow produces a valid enrichment summary."""
         text = GOLDEN_TEXTS["climat"]
         result = await run_unified_analysis(
-            text=text, workflow_name="standard", registry=registry,
+            text=text,
+            workflow_name="standard",
+            registry=registry,
         )
         state = result["unified_state"]
         summary = state.get_enrichment_summary()
         assert summary["total_arguments"] >= 3
         assert summary["with_quality_score"] >= 1
-        assert summary["with_fallacy_analysis"] >= 0  # may be 0 if no fallacy targets matched
+        assert (
+            summary["with_fallacy_analysis"] >= 0
+        )  # may be 0 if no fallacy targets matched
 
     async def test_standard_argument_profiles(self, registry):
         """Standard workflow produces argument profiles with cross-references."""
         text = GOLDEN_TEXTS["peine_de_mort"]
         result = await run_unified_analysis(
-            text=text, workflow_name="standard", registry=registry,
+            text=text,
+            workflow_name="standard",
+            registry=registry,
         )
         state = result["unified_state"]
         for arg_id in list(state.identified_arguments.keys())[:3]:
@@ -305,22 +341,30 @@ class TestRegressionSnapshots:
         """Light workflow result always has the same top-level keys."""
         text = GOLDEN_TEXTS["vaccins"]
         result = await run_unified_analysis(
-            text=text, workflow_name="light", registry=registry,
+            text=text,
+            workflow_name="light",
+            registry=registry,
         )
         expected_keys = {
-            "workflow_name", "phases", "summary",
-            "capabilities_used", "capabilities_missing",
-            "unified_state", "state_snapshot",
+            "workflow_name",
+            "phases",
+            "summary",
+            "capabilities_used",
+            "capabilities_missing",
+            "unified_state",
+            "state_snapshot",
         }
-        assert expected_keys.issubset(set(result.keys())), (
-            f"Missing keys: {expected_keys - set(result.keys())}"
-        )
+        assert expected_keys.issubset(
+            set(result.keys())
+        ), f"Missing keys: {expected_keys - set(result.keys())}"
 
     async def test_state_snapshot_dimensions_stable(self, registry):
         """State snapshot always includes all expected dimension counts."""
         text = GOLDEN_TEXTS["climat"]
         result = await run_unified_analysis(
-            text=text, workflow_name="light", registry=registry,
+            text=text,
+            workflow_name="light",
+            registry=registry,
         )
         snapshot = result["state_snapshot"]
         expected_dimensions = [

--- a/tests/unit/argumentation_analysis/adapters/test_french_fallacy_adapter.py
+++ b/tests/unit/argumentation_analysis/adapters/test_french_fallacy_adapter.py
@@ -274,7 +274,10 @@ class TestFrenchFallacyAdapter:
         )
 
         adapter = FrenchFallacyAdapter(
-            enable_symbolic=False, enable_self_hosted_llm=False, enable_nli=False, enable_llm=False
+            enable_symbolic=False,
+            enable_self_hosted_llm=False,
+            enable_nli=False,
+            enable_llm=False,
         )
         assert not adapter.is_available()
 
@@ -284,7 +287,10 @@ class TestFrenchFallacyAdapter:
         )
 
         adapter = FrenchFallacyAdapter(
-            enable_symbolic=False, enable_self_hosted_llm=False, enable_nli=False, enable_llm=False
+            enable_symbolic=False,
+            enable_self_hosted_llm=False,
+            enable_nli=False,
+            enable_llm=False,
         )
         assert adapter.get_available_tiers() == []
 
@@ -295,7 +301,10 @@ class TestFrenchFallacyAdapter:
         )
 
         adapter = FrenchFallacyAdapter(
-            enable_symbolic=False, enable_self_hosted_llm=False, enable_nli=False, enable_llm=False
+            enable_symbolic=False,
+            enable_self_hosted_llm=False,
+            enable_nli=False,
+            enable_llm=False,
         )
         result = adapter.detect("test text")
         assert result["total_fallacies"] == 0
@@ -309,7 +318,10 @@ class TestFrenchFallacyAdapter:
         )
 
         adapter = FrenchFallacyAdapter(
-            enable_symbolic=True, enable_self_hosted_llm=False, enable_nli=False, enable_llm=False
+            enable_symbolic=True,
+            enable_self_hosted_llm=False,
+            enable_nli=False,
+            enable_llm=False,
         )
         # Mock the symbolic detector
         mock_detections = [FallacyDetection("Ad Hominem", 1.0, "symbolic", "tu es nul")]
@@ -332,7 +344,10 @@ class TestFrenchFallacyAdapter:
         )
 
         adapter = FrenchFallacyAdapter(
-            enable_symbolic=True, enable_self_hosted_llm=False, enable_nli=True, enable_llm=False
+            enable_symbolic=True,
+            enable_self_hosted_llm=False,
+            enable_nli=True,
+            enable_llm=False,
         )
         symbolic_result = [FallacyDetection("Ad Hominem", 1.0, "symbolic", "tu es nul")]
         nli_result = [FallacyDetection("Ad Hominem", 0.7, "nli")]
@@ -359,7 +374,10 @@ class TestFrenchFallacyAdapter:
         )
 
         adapter = FrenchFallacyAdapter(
-            enable_symbolic=True, enable_self_hosted_llm=False, enable_nli=False, enable_llm=False
+            enable_symbolic=True,
+            enable_self_hosted_llm=False,
+            enable_nli=False,
+            enable_llm=False,
         )
         adapter._symbolic.detect = MagicMock(
             return_value=[FallacyDetection("Ad Hominem", 1.0, "symbolic")]
@@ -379,7 +397,10 @@ class TestFrenchFallacyAdapter:
         )
 
         adapter = FrenchFallacyAdapter(
-            enable_symbolic=True, enable_self_hosted_llm=False, enable_nli=False, enable_llm=False
+            enable_symbolic=True,
+            enable_self_hosted_llm=False,
+            enable_nli=False,
+            enable_llm=False,
         )
         adapter._symbolic.detect = MagicMock(return_value=[])
         adapter._symbolic._available = True

--- a/tests/unit/argumentation_analysis/adapters/test_nli_hierarchical.py
+++ b/tests/unit/argumentation_analysis/adapters/test_nli_hierarchical.py
@@ -15,7 +15,6 @@ from argumentation_analysis.adapters.french_fallacy_adapter import (
     _TAXONOMY_PK_TO_NODE,
 )
 
-
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -91,9 +90,7 @@ class TestLoadTaxonomyHierarchy:
                 assert sub["depth"] == 2
 
     def test_pk_to_node_populated(self, hierarchy):
-        assert len(_TAXONOMY_PK_TO_NODE) > 100, (
-            "PK lookup should have many entries"
-        )
+        assert len(_TAXONOMY_PK_TO_NODE) > 100, "PK lookup should have many entries"
         # Spot check: PK 1 = Insuffisance
         assert _TAXONOMY_PK_TO_NODE[1]["label"] == "Insuffisance"
 
@@ -131,9 +128,15 @@ class TestHierarchicalStage1:
             if len(candidate_labels) == 7:
                 # Stage 1 call
                 return _mock_classifier_result(
-                    ["Insuffisance", "Influence", "Tricherie",
-                     "Obstruction", "Abus de langage",
-                     "Erreur math\u00e9matique", "Erreur de raisonnement"],
+                    [
+                        "Insuffisance",
+                        "Influence",
+                        "Tricherie",
+                        "Obstruction",
+                        "Abus de langage",
+                        "Erreur math\u00e9matique",
+                        "Erreur de raisonnement",
+                    ],
                     [0.8, 0.2, 0.1, 0.05, 0.04, 0.03, 0.02],
                 )
             # Stage 2 call -- return low scores so we stay at family level
@@ -181,9 +184,9 @@ class TestHierarchicalStage2:
             call_count["n"] += 1
             if call_count["n"] == 1:
                 # Stage 1: Obstruction wins
-                ordered = sorted(candidate_labels,
-                                 key=lambda x: x == "Obstruction",
-                                 reverse=True)
+                ordered = sorted(
+                    candidate_labels, key=lambda x: x == "Obstruction", reverse=True
+                )
                 scores = [0.7] + [0.05] * (len(ordered) - 1)
                 return _mock_classifier_result(ordered, scores)
             else:
@@ -214,9 +217,9 @@ class TestHierarchicalStage2:
             call_count["n"] += 1
             if call_count["n"] == 1:
                 # Stage 1: Influence scores high
-                ordered = sorted(candidate_labels,
-                                 key=lambda x: x == "Influence",
-                                 reverse=True)
+                ordered = sorted(
+                    candidate_labels, key=lambda x: x == "Influence", reverse=True
+                )
                 scores = [0.6] + [0.05] * (len(ordered) - 1)
                 return _mock_classifier_result(ordered, scores)
             else:
@@ -371,9 +374,7 @@ class TestAdapterHierarchicalIntegration:
         adapter._nli = mock_nli
 
         result = adapter.detect("test text")
-        mock_nli.detect.assert_called_once_with(
-            "test text", hierarchical=True
-        )
+        mock_nli.detect.assert_called_once_with("test text", hierarchical=True)
         assert "nli_hierarchical" in result["tiers_used"]
 
     def test_adapter_detect_calls_nli_flat_by_default(self):
@@ -388,6 +389,4 @@ class TestAdapterHierarchicalIntegration:
         adapter._nli = mock_nli
 
         adapter.detect("test text")
-        mock_nli.detect.assert_called_once_with(
-            "test text", hierarchical=False
-        )
+        mock_nli.detect.assert_called_once_with("test text", hierarchical=False)

--- a/tests/unit/argumentation_analysis/adapters/test_self_hosted_llm_fallacy_detector.py
+++ b/tests/unit/argumentation_analysis/adapters/test_self_hosted_llm_fallacy_detector.py
@@ -19,7 +19,6 @@ from argumentation_analysis.adapters.french_fallacy_adapter import (
     FallacyDetection,
 )
 
-
 # -- Availability Tests -----------------------------------------------------
 
 
@@ -102,24 +101,26 @@ class TestSelfHostedLLMDetection:
 
     def _mock_response(self, fallacies):
         return {
-            "choices": [
-                {
-                    "message": {
-                        "content": json.dumps({"fallacies": fallacies})
-                    }
-                }
-            ]
+            "choices": [{"message": {"content": json.dumps({"fallacies": fallacies})}}]
         }
 
     @pytest.mark.asyncio
     async def test_detect_single_fallacy(self, detector):
         mock_client = self._make_mock_client(
-            self._mock_response([
-                {"type": "Appel à la popularité (Ad Populum)", "confidence": 0.92, "explanation": "Test"}
-            ])
+            self._mock_response(
+                [
+                    {
+                        "type": "Appel à la popularité (Ad Populum)",
+                        "confidence": 0.92,
+                        "explanation": "Test",
+                    }
+                ]
+            )
         )
         with patch("httpx.AsyncClient", return_value=mock_client):
-            results = await detector.detect_async("Tout le monde le fait donc c'est bien")
+            results = await detector.detect_async(
+                "Tout le monde le fait donc c'est bien"
+            )
         assert len(results) == 1
         assert results[0].fallacy_type == "Appel à la popularité (Ad Populum)"
         assert results[0].confidence == 0.92
@@ -128,10 +129,16 @@ class TestSelfHostedLLMDetection:
     @pytest.mark.asyncio
     async def test_detect_multiple_fallacies(self, detector):
         mock_client = self._make_mock_client(
-            self._mock_response([
-                {"type": "Ad Hominem", "confidence": 0.85, "explanation": "Attack"},
-                {"type": "Pente glissante", "confidence": 0.78, "explanation": "Slope"},
-            ])
+            self._mock_response(
+                [
+                    {"type": "Ad Hominem", "confidence": 0.85, "explanation": "Attack"},
+                    {
+                        "type": "Pente glissante",
+                        "confidence": 0.78,
+                        "explanation": "Slope",
+                    },
+                ]
+            )
         )
         with patch("httpx.AsyncClient", return_value=mock_client):
             results = await detector.detect_async("Test text")

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_af_handler_extended.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_af_handler_extended.py
@@ -53,6 +53,7 @@ def mock_jpype():
             attack.getAttacker.return_value = source
             attack.getAttacked.return_value = target
             return attack
+
         mock_attack_cls = MagicMock(side_effect=make_attack)
 
         def jclass_side_effect(class_name):

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_fol_signature_predeclaration.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_fol_signature_predeclaration.py
@@ -59,7 +59,9 @@ class TestExtractFolMetadata:
             "forall X: (Fallacious(X) => !FullySupported(X))",
         ]
         meta = FOLLogicAgent.extract_fol_metadata(formulas)
-        assert len(meta["predicates"]) >= 3  # Asserted, Fallacious, Undermines, FullySupported
+        assert (
+            len(meta["predicates"]) >= 3
+        )  # Asserted, Fallacious, Undermines, FullySupported
         assert len(meta["constants"]) >= 2  # arg1, arg2, fallacy1
         assert len(meta["signature_lines"]) >= 3
 

--- a/tests/unit/argumentation_analysis/agents/core/quality/test_quality_virtue_detectors.py
+++ b/tests/unit/argumentation_analysis/agents/core/quality/test_quality_virtue_detectors.py
@@ -212,7 +212,9 @@ class TestArgumentQualityEvaluator:
 
 class TestEvaluerArgument:
     def test_convenience_function(self):
-        result = qe.evaluer_argument("Selon l'OMS, c'est vrai car les données le montrent.")
+        result = qe.evaluer_argument(
+            "Selon l'OMS, c'est vrai car les données le montrent."
+        )
         assert "note_finale" in result
 
 

--- a/tests/unit/argumentation_analysis/core/test_bootstrap.py
+++ b/tests/unit/argumentation_analysis/core/test_bootstrap.py
@@ -457,7 +457,9 @@ class TestPreInitSafetyChecks:
         with patch("pathlib.Path.exists", return_value=True), patch(
             "pathlib.Path.is_dir", return_value=False
         ):
-            result = _pre_init_safety_checks(Path("C:/test/file.txt"), Path("C:/test/.env"))
+            result = _pre_init_safety_checks(
+                Path("C:/test/file.txt"), Path("C:/test/.env")
+            )
             assert result is False
 
     def test_warns_for_pycharm_environment(self):

--- a/tests/unit/argumentation_analysis/core/test_jvm_setup.py
+++ b/tests/unit/argumentation_analysis/core/test_jvm_setup.py
@@ -14,17 +14,22 @@ class TestJVMStartupTimeout:
 
     def test_default_timeout_value(self):
         """Vérifie que le timeout par défaut est de 60 secondes."""
-        from argumentation_analysis.core.jvm_setup import DEFAULT_JVM_STARTUP_TIMEOUT_SECONDS
+        from argumentation_analysis.core.jvm_setup import (
+            DEFAULT_JVM_STARTUP_TIMEOUT_SECONDS,
+        )
+
         assert DEFAULT_JVM_STARTUP_TIMEOUT_SECONDS == 60
 
     def test_timeout_exception_is_timeout_error_subclass(self):
         """Vérifie que JVMStartupTimeoutError est une sous-classe de TimeoutError."""
         from argumentation_analysis.core.jvm_setup import JVMStartupTimeoutError
+
         assert issubclass(JVMStartupTimeoutError, TimeoutError)
 
     def test_timeout_exception_message(self):
         """Vérifie que l'exception contient le message attendu."""
         from argumentation_analysis.core.jvm_setup import JVMStartupTimeoutError
+
         msg = "JVM startup exceeded timeout of 30 seconds"
         exc = JVMStartupTimeoutError(msg)
         assert msg in str(exc)

--- a/tests/unit/argumentation_analysis/evaluation/test_benchmark_conversational.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_benchmark_conversational.py
@@ -3,6 +3,7 @@
 Verifies list_available_workflows includes conversational and
 run_unified_analysis normalizes conversational result format.
 """
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -31,7 +32,10 @@ class TestListAvailableWorkflows:
 
     def test_fallback_includes_conversational(self):
         """Fallback list includes 'conversational' even when import fails."""
-        with patch.dict("sys.modules", {"argumentation_analysis.orchestration.unified_pipeline": None}):
+        with patch.dict(
+            "sys.modules",
+            {"argumentation_analysis.orchestration.unified_pipeline": None},
+        ):
             # Force re-import to trigger fallback
             import importlib
             import argumentation_analysis.evaluation.multi_model_benchmark as mod
@@ -78,7 +82,9 @@ class TestRunUnifiedAnalysisConversational:
             new_callable=AsyncMock,
             return_value=mock_conv_result,
         ):
-            result = await run_unified_analysis("test text", workflow_name="conversational")
+            result = await run_unified_analysis(
+                "test text", workflow_name="conversational"
+            )
 
         assert "summary" in result
         assert result["summary"]["completed"] == 3
@@ -99,7 +105,9 @@ class TestRunUnifiedAnalysisConversational:
             side_effect=ImportError("Module not available"),
         ):
             # Should fall back to standard workflow without raising
-            result = await run_unified_analysis("test text", workflow_name="conversational")
+            result = await run_unified_analysis(
+                "test text", workflow_name="conversational"
+            )
 
         assert result is not None
         # Fell back to standard pipeline, workflow name from catalog

--- a/tests/unit/argumentation_analysis/evaluation/test_capability_eval.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_capability_eval.py
@@ -38,10 +38,10 @@ from argumentation_analysis.evaluation.capability_eval import (
     EVAL_WORKFLOW_PHASES,
 )
 
-
 # ---------------------------------------------------------------------------
 # CapabilityConfig
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 class TestCapabilityConfig:
@@ -65,17 +65,28 @@ class TestCapabilityConfig:
 # PRESET_CONFIGS
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestPresetConfigs:
     def test_all_required_configs_present(self):
-        required = {"baseline", "quality", "fallacy", "counter", "debate", "logic", "full"}
+        required = {
+            "baseline",
+            "quality",
+            "fallacy",
+            "counter",
+            "debate",
+            "logic",
+            "full",
+        }
         assert required.issubset(set(PRESET_CONFIGS.keys()))
 
     def test_baseline_is_minimal(self):
         assert PRESET_CONFIGS["baseline"].capabilities == ["fact_extraction"]
 
     def test_full_has_most_capabilities(self):
-        cap_counts = {name: len(cfg.capabilities) for name, cfg in PRESET_CONFIGS.items()}
+        cap_counts = {
+            name: len(cfg.capabilities) for name, cfg in PRESET_CONFIGS.items()
+        }
         assert cap_counts["full"] == max(cap_counts.values())
 
     def test_all_configs_have_descriptions(self):
@@ -87,13 +98,16 @@ class TestPresetConfigs:
 # FilteredRegistry
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestFilteredRegistry:
     def _make_registry(self, caps_per_provider):
         """Build a mock registry where find_for_capability returns providers."""
         registry = MagicMock()
+
         def find(capability):
             return caps_per_provider.get(capability, [])
+
         registry.find_for_capability.side_effect = find
         return registry
 
@@ -131,16 +145,32 @@ class TestFilteredRegistry:
 # EvalCell
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestEvalCell:
-    def _make_cell(self, overall=4.0, depth=4.0, completeness=4.0,
-                   accuracy=4.0, coherence=4.0, actionability=4.0):
+    def _make_cell(
+        self,
+        overall=4.0,
+        depth=4.0,
+        completeness=4.0,
+        accuracy=4.0,
+        coherence=4.0,
+        actionability=4.0,
+    ):
         return EvalCell(
-            config_name="test", capabilities_active=["cap_a"],
-            document_name="doc_001", document_index=0,
-            phases_run=3, phases_skipped=1, phases_failed=0,
-            overall=overall, depth=depth, completeness=completeness,
-            accuracy=accuracy, coherence=coherence, actionability=actionability,
+            config_name="test",
+            capabilities_active=["cap_a"],
+            document_name="doc_001",
+            document_index=0,
+            phases_run=3,
+            phases_skipped=1,
+            phases_failed=0,
+            overall=overall,
+            depth=depth,
+            completeness=completeness,
+            accuracy=accuracy,
+            coherence=coherence,
+            actionability=actionability,
         )
 
     def test_composite_all_equal(self):
@@ -148,22 +178,38 @@ class TestEvalCell:
         assert cell.composite_score == pytest.approx(4.0, abs=0.01)
 
     def test_composite_only_overall(self):
-        cell = self._make_cell(overall=5.0, depth=0, completeness=0,
-                               accuracy=0, coherence=0, actionability=0)
+        cell = self._make_cell(
+            overall=5.0,
+            depth=0,
+            completeness=0,
+            accuracy=0,
+            coherence=0,
+            actionability=0,
+        )
         # 5.0 * 0.40 = 2.0
         assert cell.composite_score == pytest.approx(2.0, abs=0.01)
 
     def test_timestamp_auto_set(self):
         cell = EvalCell(
-            config_name="c", capabilities_active=[], document_name="d",
-            document_index=0, phases_run=0, phases_skipped=0, phases_failed=0,
+            config_name="c",
+            capabilities_active=[],
+            document_name="d",
+            document_index=0,
+            phases_run=0,
+            phases_skipped=0,
+            phases_failed=0,
         )
         assert cell.timestamp != ""
 
     def test_no_error_by_default(self):
         cell = EvalCell(
-            config_name="c", capabilities_active=[], document_name="d",
-            document_index=0, phases_run=0, phases_skipped=0, phases_failed=0,
+            config_name="c",
+            capabilities_active=[],
+            document_name="d",
+            document_index=0,
+            phases_run=0,
+            phases_skipped=0,
+            phases_failed=0,
         )
         assert cell.judge_error is None
 
@@ -171,6 +217,7 @@ class TestEvalCell:
 # ---------------------------------------------------------------------------
 # _build_eval_workflow
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 class TestBuildEvalWorkflow:
@@ -198,14 +245,22 @@ class TestBuildEvalWorkflow:
 # run_single_cell
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestRunSingleCell:
     def _make_executor(self, status_map=None):
         """Build a mock WorkflowExecutor that returns fixed phase statuses."""
-        from argumentation_analysis.orchestration.workflow_dsl import PhaseResult, PhaseStatus
+        from argumentation_analysis.orchestration.workflow_dsl import (
+            PhaseResult,
+            PhaseStatus,
+        )
 
         if status_map is None:
-            status_map = {"extract": "completed", "quality": "completed", "fallacy": "skipped"}
+            status_map = {
+                "extract": "completed",
+                "quality": "completed",
+                "fallacy": "skipped",
+            }
 
         async def fake_execute(workflow, input_data, state=None, **kwargs):
             results = {}
@@ -224,15 +279,19 @@ class TestRunSingleCell:
     async def test_counts_phases_correctly(self):
         config = PRESET_CONFIGS["quality"]
         registry = MagicMock()
-        executor = self._make_executor({
-            "extract": "completed",
-            "quality": "completed",
-            "fallacy": "skipped",
-            "other": "failed",
-        })
+        executor = self._make_executor(
+            {
+                "extract": "completed",
+                "quality": "completed",
+                "fallacy": "skipped",
+                "other": "failed",
+            }
+        )
         workflow = _build_eval_workflow()
 
-        with patch("argumentation_analysis.evaluation.capability_eval.FilteredRegistry") as mock_fr:
+        with patch(
+            "argumentation_analysis.evaluation.capability_eval.FilteredRegistry"
+        ) as mock_fr:
             mock_fr.return_value = registry
             cell = await run_single_cell(
                 config=config,
@@ -256,7 +315,9 @@ class TestRunSingleCell:
         executor = self._make_executor({"extract": "completed"})
         workflow = _build_eval_workflow()
 
-        with patch("argumentation_analysis.evaluation.capability_eval.FilteredRegistry"):
+        with patch(
+            "argumentation_analysis.evaluation.capability_eval.FilteredRegistry"
+        ):
             cell = await run_single_cell(
                 config=config,
                 document_text="Test",
@@ -282,14 +343,21 @@ class TestRunSingleCell:
         workflow = _build_eval_workflow()
 
         fake_score = JudgeScore(
-            completeness=4.0, accuracy=3.5, depth=4.5,
-            coherence=4.0, actionability=3.8, overall=4.2,
-            reasoning="Good.", judge_model="test-model",
+            completeness=4.0,
+            accuracy=3.5,
+            depth=4.5,
+            coherence=4.0,
+            actionability=3.8,
+            overall=4.2,
+            reasoning="Good.",
+            judge_model="test-model",
         )
         judge = MagicMock()
         judge.evaluate = AsyncMock(return_value=fake_score)
 
-        with patch("argumentation_analysis.evaluation.capability_eval.FilteredRegistry"):
+        with patch(
+            "argumentation_analysis.evaluation.capability_eval.FilteredRegistry"
+        ):
             cell = await run_single_cell(
                 config=config,
                 document_text="Test text",
@@ -314,7 +382,9 @@ class TestRunSingleCell:
         judge = MagicMock()
         judge.evaluate = AsyncMock(side_effect=RuntimeError("API error"))
 
-        with patch("argumentation_analysis.evaluation.capability_eval.FilteredRegistry"):
+        with patch(
+            "argumentation_analysis.evaluation.capability_eval.FilteredRegistry"
+        ):
             cell = await run_single_cell(
                 config=config,
                 document_text="Test",
@@ -334,15 +404,24 @@ class TestRunSingleCell:
 # compute_marginal_scores
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestComputeMarginalScores:
     def _make_cell(self, caps, overall):
         c = EvalCell(
-            config_name="c", capabilities_active=list(caps),
-            document_name="d", document_index=0,
-            phases_run=0, phases_skipped=0, phases_failed=0,
-            overall=overall, depth=overall, completeness=overall,
-            accuracy=overall, coherence=overall, actionability=overall,
+            config_name="c",
+            capabilities_active=list(caps),
+            document_name="d",
+            document_index=0,
+            phases_run=0,
+            phases_skipped=0,
+            phases_failed=0,
+            overall=overall,
+            depth=overall,
+            completeness=overall,
+            accuracy=overall,
+            coherence=overall,
+            actionability=overall,
         )
         return c
 
@@ -385,15 +464,24 @@ class TestComputeMarginalScores:
 # compute_synergies
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestComputeSynergies:
     def _make_cell(self, caps, overall):
         c = EvalCell(
-            config_name="c", capabilities_active=list(caps),
-            document_name="d", document_index=0,
-            phases_run=0, phases_skipped=0, phases_failed=0,
-            overall=overall, depth=overall, completeness=overall,
-            accuracy=overall, coherence=overall, actionability=overall,
+            config_name="c",
+            capabilities_active=list(caps),
+            document_name="d",
+            document_index=0,
+            phases_run=0,
+            phases_skipped=0,
+            phases_failed=0,
+            overall=overall,
+            depth=overall,
+            completeness=overall,
+            accuracy=overall,
+            coherence=overall,
+            actionability=overall,
         )
         return c
 
@@ -416,15 +504,24 @@ class TestComputeSynergies:
 # build_report
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestBuildReport:
     def _make_cell(self, cfg, doc, overall):
         c = EvalCell(
-            config_name=cfg, capabilities_active=["cap_a"],
-            document_name=doc, document_index=0,
-            phases_run=1, phases_skipped=0, phases_failed=0,
-            overall=overall, depth=overall, completeness=overall,
-            accuracy=overall, coherence=overall, actionability=overall,
+            config_name=cfg,
+            capabilities_active=["cap_a"],
+            document_name=doc,
+            document_index=0,
+            phases_run=1,
+            phases_skipped=0,
+            phases_failed=0,
+            overall=overall,
+            depth=overall,
+            completeness=overall,
+            accuracy=overall,
+            coherence=overall,
+            actionability=overall,
         )
         return c
 
@@ -461,16 +558,25 @@ class TestBuildReport:
 # write_cells_jsonl
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestWriteCellsJsonl:
     def test_writes_valid_jsonl(self, tmp_path):
         cells = [
             EvalCell(
-                config_name="baseline", capabilities_active=["fact_extraction"],
-                document_name="doc_001", document_index=0,
-                phases_run=2, phases_skipped=1, phases_failed=0,
-                overall=4.0, depth=3.5, completeness=4.0,
-                accuracy=4.0, coherence=4.2, actionability=3.8,
+                config_name="baseline",
+                capabilities_active=["fact_extraction"],
+                document_name="doc_001",
+                document_index=0,
+                phases_run=2,
+                phases_skipped=1,
+                phases_failed=0,
+                overall=4.0,
+                depth=3.5,
+                completeness=4.0,
+                accuracy=4.0,
+                coherence=4.2,
+                actionability=3.8,
                 reasoning="Decent.",
             )
         ]
@@ -493,6 +599,7 @@ class TestWriteCellsJsonl:
 # write_report
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestWriteReport:
     def test_creates_json_and_markdown(self, tmp_path):
@@ -500,24 +607,28 @@ class TestWriteReport:
             configs_evaluated=["baseline", "full"],
             num_documents=5,
             total_cells=10,
-            config_scores=[{
-                "config_name": "full",
-                "capabilities": ["cap_a", "cap_b"],
-                "n_docs": 5,
-                "avg_composite": 0.8,
-                "avg_overall": 4.0,
-                "avg_depth": 3.5,
-                "avg_completeness": 3.8,
-                "avg_phases_run": 6.0,
-            }],
-            marginal_scores=[{
-                "capability": "cap_a",
-                "avg_score_with": 4.0,
-                "avg_score_without": 3.0,
-                "marginal_contribution": 1.0,
-                "n_with": 5,
-                "n_without": 5,
-            }],
+            config_scores=[
+                {
+                    "config_name": "full",
+                    "capabilities": ["cap_a", "cap_b"],
+                    "n_docs": 5,
+                    "avg_composite": 0.8,
+                    "avg_overall": 4.0,
+                    "avg_depth": 3.5,
+                    "avg_completeness": 3.8,
+                    "avg_phases_run": 6.0,
+                }
+            ],
+            marginal_scores=[
+                {
+                    "capability": "cap_a",
+                    "avg_score_with": 4.0,
+                    "avg_score_without": 3.0,
+                    "marginal_contribution": 1.0,
+                    "n_with": 5,
+                    "n_without": 5,
+                }
+            ],
             best_config="full",
             best_composite=0.8,
         )
@@ -529,7 +640,9 @@ class TestWriteReport:
     def test_json_valid(self, tmp_path):
         report = CapabilityEvalReport()
         write_report(report, tmp_path)
-        data = json.loads((tmp_path / "capability_eval_report.json").read_text(encoding="utf-8"))
+        data = json.loads(
+            (tmp_path / "capability_eval_report.json").read_text(encoding="utf-8")
+        )
         assert "total_cells" in data
 
     def test_markdown_has_section_headers(self, tmp_path):
@@ -558,12 +671,12 @@ class TestStateWritersRegression:
 
         # Read the source code of run_single_cell to verify state_writers is passed
         source = inspect.getsource(run_single_cell)
-        assert "state_writers" in source, (
-            "run_single_cell must pass state_writers to executor.execute()"
-        )
-        assert "CAPABILITY_STATE_WRITERS" in source, (
-            "run_single_cell must import and use CAPABILITY_STATE_WRITERS"
-        )
+        assert (
+            "state_writers" in source
+        ), "run_single_cell must pass state_writers to executor.execute()"
+        assert (
+            "CAPABILITY_STATE_WRITERS" in source
+        ), "run_single_cell must import and use CAPABILITY_STATE_WRITERS"
 
 
 class TestEnumerateRegression:
@@ -580,9 +693,9 @@ class TestEnumerateRegression:
 
         source = inspect.getsource(capability_eval)
         # Ensure .index(doc) is NOT used in the main loop
-        assert "documents.index(doc)" not in source, (
-            "Main loop must use enumerate(documents), not documents.index(doc)"
-        )
+        assert (
+            "documents.index(doc)" not in source
+        ), "Main loop must use enumerate(documents), not documents.index(doc)"
 
     def test_main_loop_has_enumerate(self):
         """Verify enumerate(documents) is used."""
@@ -590,6 +703,6 @@ class TestEnumerateRegression:
         from argumentation_analysis.evaluation import capability_eval
 
         source = inspect.getsource(capability_eval)
-        assert "enumerate(documents)" in source, (
-            "Main loop must use enumerate(documents)"
-        )
+        assert (
+            "enumerate(documents)" in source
+        ), "Main loop must use enumerate(documents)"

--- a/tests/unit/argumentation_analysis/evaluation/test_conversational_benchmark.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_conversational_benchmark.py
@@ -24,7 +24,6 @@ from argumentation_analysis.evaluation.conversational_benchmark import (
 )
 from argumentation_analysis.core.shared_state import UnifiedAnalysisState
 
-
 # ── Test Data ─────────────────────────────────────────────────────────────
 
 
@@ -79,9 +78,9 @@ class TestBenchmarkTexts:
 
     def test_texts_contain_french_content(self):
         for text_id, text in BENCHMARK_TEXTS.items():
-            assert any(w in text.lower() for w in ["les", "que", "est", "des"]), (
-                f"{text_id} doesn't look like French text"
-            )
+            assert any(
+                w in text.lower() for w in ["les", "que", "est", "des"]
+            ), f"{text_id} doesn't look like French text"
 
 
 # ============================================================
@@ -164,19 +163,21 @@ class TestBenchmarkReport:
         runs = []
         for text_id in ["text_a", "text_b"]:
             for mode in ["standard", "full", "conversational"]:
-                runs.append(RunMetrics(
-                    text_id=text_id,
-                    mode=mode,
-                    wall_clock_seconds=100.0 if mode != "conversational" else 300.0,
-                    argument_count=5,
-                    fallacy_count=2,
-                    quality_scores_count=4,
-                    counter_argument_count=3,
-                    jtms_belief_count=5,
-                    state_field_fill_rate=0.45,
-                    cross_ref_density=0.3,
-                    total_messages=15 if mode == "conversational" else 0,
-                ))
+                runs.append(
+                    RunMetrics(
+                        text_id=text_id,
+                        mode=mode,
+                        wall_clock_seconds=100.0 if mode != "conversational" else 300.0,
+                        argument_count=5,
+                        fallacy_count=2,
+                        quality_scores_count=4,
+                        counter_argument_count=3,
+                        jtms_belief_count=5,
+                        state_field_fill_rate=0.45,
+                        cross_ref_density=0.3,
+                        total_messages=15 if mode == "conversational" else 0,
+                    )
+                )
         return runs
 
     def test_compute_averages(self):
@@ -262,9 +263,12 @@ class TestReportFormatting:
     def test_summary_contains_table(self):
         runs = [
             RunMetrics(
-                text_id="test", mode="standard",
-                wall_clock_seconds=50.0, argument_count=5,
-                fallacy_count=2, state_field_fill_rate=0.45,
+                text_id="test",
+                mode="standard",
+                wall_clock_seconds=50.0,
+                argument_count=5,
+                fallacy_count=2,
+                state_field_fill_rate=0.45,
             ),
         ]
         report = BenchmarkReport(runs=runs)

--- a/tests/unit/argumentation_analysis/evaluation/test_plugin_benchmark.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_plugin_benchmark.py
@@ -27,7 +27,6 @@ from argumentation_analysis.evaluation.plugin_benchmark import (
     PluginBenchmarkSuite,
 )
 
-
 # ============================================================
 # Benchmark cases structure
 # ============================================================
@@ -73,9 +72,9 @@ class TestBenchmarkCases:
         valid = {"easy", "medium", "hard"}
         for plugin, cases in PLUGIN_BENCHMARK_CASES.items():
             for case in cases:
-                assert case["difficulty"] in valid, (
-                    f"{case['id']}: invalid difficulty '{case['difficulty']}'"
-                )
+                assert (
+                    case["difficulty"] in valid
+                ), f"{case['id']}: invalid difficulty '{case['difficulty']}'"
 
     def test_case_ids_unique(self):
         """Test that all case IDs are unique."""
@@ -93,9 +92,9 @@ class TestBenchmarkCases:
         """Test that Tier A plugins (no deps) have >= 3 cases each."""
         tier_a = ["governance", "quality_scoring", "atms"]
         for plugin in tier_a:
-            assert len(PLUGIN_BENCHMARK_CASES[plugin]) >= 3, (
-                f"Tier A plugin {plugin} should have >= 3 cases"
-            )
+            assert (
+                len(PLUGIN_BENCHMARK_CASES[plugin]) >= 3
+            ), f"Tier A plugin {plugin} should have >= 3 cases"
 
     def test_total_case_count(self):
         """Test total case count is in expected range."""
@@ -165,12 +164,18 @@ class TestPluginBenchmarkReport:
         report = PluginBenchmarkReport()
         report.results = [
             PluginBenchmarkResult(
-                case_id="gov_01", plugin_name="governance",
-                function_name="social_choice_vote", passed=True, latency_ms=5.0,
+                case_id="gov_01",
+                plugin_name="governance",
+                function_name="social_choice_vote",
+                passed=True,
+                latency_ms=5.0,
             ),
             PluginBenchmarkResult(
-                case_id="gov_02", plugin_name="governance",
-                function_name="detect_conflicts_fn", passed=False, latency_ms=3.0,
+                case_id="gov_02",
+                plugin_name="governance",
+                function_name="detect_conflicts_fn",
+                passed=False,
+                latency_ms=3.0,
                 error="test error",
             ),
         ]
@@ -360,7 +365,9 @@ class TestQualityScoringBenchmark:
     def test_list_virtues(self):
         """Test that list_virtues returns exactly 9 virtues."""
         suite = PluginBenchmarkSuite()
-        result = suite.run_single("quality_scoring", PLUGIN_BENCHMARK_CASES["quality_scoring"][2])
+        result = suite.run_single(
+            "quality_scoring", PLUGIN_BENCHMARK_CASES["quality_scoring"][2]
+        )
         assert result.passed
         assert result.error == ""
 
@@ -496,9 +503,9 @@ class TestPluginRegistry:
         """Test that registry covers all benchmarked plugins."""
         suite = PluginBenchmarkSuite()
         for plugin_name in PLUGIN_BENCHMARK_CASES:
-            assert plugin_name in suite.PLUGIN_REGISTRY, (
-                f"{plugin_name} missing from PLUGIN_REGISTRY"
-            )
+            assert (
+                plugin_name in suite.PLUGIN_REGISTRY
+            ), f"{plugin_name} missing from PLUGIN_REGISTRY"
 
     def test_registry_entry_format(self):
         """Test that registry entries have correct format."""
@@ -558,13 +565,16 @@ class TestEdgeCases:
         """Test running a case for an unavailable plugin."""
         suite = PluginBenchmarkSuite()
         with patch.object(suite, "_instantiate_plugin", return_value=None):
-            result = suite.run_single("nonexistent", {
-                "id": "test_01",
-                "function": "test",
-                "args": {},
-                "expected": {},
-                "difficulty": "easy",
-            })
+            result = suite.run_single(
+                "nonexistent",
+                {
+                    "id": "test_01",
+                    "function": "test",
+                    "args": {},
+                    "expected": {},
+                    "difficulty": "easy",
+                },
+            )
         assert result.error != ""
         assert "not available" in result.error
 
@@ -574,13 +584,16 @@ class TestEdgeCases:
         mock_plugin = MagicMock(spec=[])
         # No attribute 'nonexistent_fn'
         with patch.object(suite, "_instantiate_plugin", return_value=mock_plugin):
-            result = suite.run_single("test", {
-                "id": "test_01",
-                "function": "nonexistent_fn",
-                "args": {},
-                "expected": {},
-                "difficulty": "easy",
-            })
+            result = suite.run_single(
+                "test",
+                {
+                    "id": "test_01",
+                    "function": "nonexistent_fn",
+                    "args": {},
+                    "expected": {},
+                    "difficulty": "easy",
+                },
+            )
         assert "not found" in result.error
 
     def test_run_single_exception_in_function(self):
@@ -589,13 +602,16 @@ class TestEdgeCases:
         mock_plugin = MagicMock()
         mock_plugin.test_fn.side_effect = ValueError("test error")
         with patch.object(suite, "_instantiate_plugin", return_value=mock_plugin):
-            result = suite.run_single("test", {
-                "id": "test_01",
-                "function": "test_fn",
-                "args": {},
-                "expected": {},
-                "difficulty": "easy",
-            })
+            result = suite.run_single(
+                "test",
+                {
+                    "id": "test_01",
+                    "function": "test_fn",
+                    "args": {},
+                    "expected": {},
+                    "difficulty": "easy",
+                },
+            )
         assert result.error != ""
         assert not result.passed
         assert "EXCEPTION" in result.validation_details
@@ -624,11 +640,14 @@ class TestEdgeCases:
         mock_plugin.test_fn.return_value = async_fn()
 
         with patch.object(suite, "_instantiate_plugin", return_value=mock_plugin):
-            result = suite.run_single("test", {
-                "id": "async_01",
-                "function": "test_fn",
-                "args": {},
-                "expected": {"returns_json": True},
-                "difficulty": "easy",
-            })
+            result = suite.run_single(
+                "test",
+                {
+                    "id": "async_01",
+                    "function": "test_fn",
+                    "args": {},
+                    "expected": {"returns_json": True},
+                    "difficulty": "easy",
+                },
+            )
         assert result.passed

--- a/tests/unit/argumentation_analysis/evaluation/test_run_llm_judge.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_run_llm_judge.py
@@ -28,10 +28,10 @@ from argumentation_analysis.evaluation.run_llm_judge import (
 )
 from argumentation_analysis.evaluation.judge import LLMJudge, JudgeScore
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def make_benchmark_entry(
     workflow="standard",
@@ -73,6 +73,7 @@ def make_judge_score(overall=4.0, depth=3.5) -> JudgeScore:
 # ---------------------------------------------------------------------------
 # JudgeResult
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 class TestJudgeResult:
@@ -116,19 +117,35 @@ class TestJudgeResult:
 
     def test_timestamp_auto_set(self):
         jr = JudgeResult(
-            workflow_name="w", model_name="m", document_name="d",
-            document_index=0, judge_model="j",
-            completeness=1, accuracy=1, depth=1, coherence=1,
-            actionability=1, overall=1, reasoning="",
+            workflow_name="w",
+            model_name="m",
+            document_name="d",
+            document_index=0,
+            judge_model="j",
+            completeness=1,
+            accuracy=1,
+            depth=1,
+            coherence=1,
+            actionability=1,
+            overall=1,
+            reasoning="",
         )
         assert jr.timestamp != ""
 
     def test_no_error_by_default(self):
         jr = JudgeResult(
-            workflow_name="w", model_name="m", document_name="d",
-            document_index=0, judge_model="j",
-            completeness=1, accuracy=1, depth=1, coherence=1,
-            actionability=1, overall=1, reasoning="",
+            workflow_name="w",
+            model_name="m",
+            document_name="d",
+            document_index=0,
+            judge_model="j",
+            completeness=1,
+            accuracy=1,
+            depth=1,
+            coherence=1,
+            actionability=1,
+            overall=1,
+            reasoning="",
         )
         assert jr.error is None
 
@@ -136,6 +153,7 @@ class TestJudgeResult:
 # ---------------------------------------------------------------------------
 # load_benchmark_results
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 class TestLoadBenchmarkResults:
@@ -174,6 +192,7 @@ class TestLoadBenchmarkResults:
 # ---------------------------------------------------------------------------
 # run_judge_on_results
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 class TestRunJudgeOnResults:
@@ -258,7 +277,10 @@ class TestRunJudgeOnResults:
     @pytest.mark.asyncio
     async def test_result_fields_populated_from_score(self):
         entry = make_benchmark_entry(
-            workflow="formal_debate", model="openrouter", doc_name="corpus_007", doc_idx=6
+            workflow="formal_debate",
+            model="openrouter",
+            doc_name="corpus_007",
+            doc_idx=6,
         )
         score = make_judge_score(overall=3.8, depth=4.2)
         score.completeness = 4.5
@@ -281,6 +303,7 @@ class TestRunJudgeOnResults:
 # ---------------------------------------------------------------------------
 # build_report
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.unit
 class TestBuildReport:
@@ -355,6 +378,7 @@ class TestBuildReport:
 # write_scores_jsonl
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestWriteScoresJsonl:
     def test_creates_file_with_correct_entries(self, tmp_path):
@@ -365,8 +389,12 @@ class TestWriteScoresJsonl:
                 document_name="doc_001",
                 document_index=0,
                 judge_model="gpt-5-mini",
-                completeness=4.0, accuracy=4.0, depth=4.0,
-                coherence=4.0, actionability=4.0, overall=4.0,
+                completeness=4.0,
+                accuracy=4.0,
+                depth=4.0,
+                coherence=4.0,
+                actionability=4.0,
+                overall=4.0,
                 reasoning="Good.",
             )
         ]
@@ -389,27 +417,38 @@ class TestWriteScoresJsonl:
 # write_report
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.unit
 class TestWriteReport:
     def test_creates_json_and_markdown(self, tmp_path):
         report = JudgeReport(
             total_cells_evaluated=5,
             total_errors=0,
-            aggregates=[{
-                "model_name": "default",
-                "workflow_name": "standard",
-                "n_docs": 5,
+            aggregates=[
+                {
+                    "model_name": "default",
+                    "workflow_name": "standard",
+                    "n_docs": 5,
+                    "avg_composite": 0.75,
+                    "avg_overall": 4.0,
+                    "avg_completeness": 3.8,
+                    "avg_accuracy": 4.2,
+                    "avg_depth": 3.5,
+                    "avg_coherence": 4.0,
+                    "avg_actionability": 3.9,
+                }
+            ],
+            best_by_quality={
+                "model": "default",
+                "workflow": "standard",
                 "avg_composite": 0.75,
                 "avg_overall": 4.0,
-                "avg_completeness": 3.8,
-                "avg_accuracy": 4.2,
+            },
+            best_by_depth={
+                "model": "default",
+                "workflow": "standard",
                 "avg_depth": 3.5,
-                "avg_coherence": 4.0,
-                "avg_actionability": 3.9,
-            }],
-            best_by_quality={"model": "default", "workflow": "standard",
-                             "avg_composite": 0.75, "avg_overall": 4.0},
-            best_by_depth={"model": "default", "workflow": "standard", "avg_depth": 3.5},
+            },
         )
         out = tmp_path / "report"
         write_report(report, out)
@@ -473,9 +512,7 @@ class TestMaxDocsRegression:
                 judge_model="test-model",
             )
         )
-        results = await run_judge_on_results(
-            entries_3_docs, mock_judge, max_docs=2
-        )
+        results = await run_judge_on_results(entries_3_docs, mock_judge, max_docs=2)
         # Only 2 docs should have been evaluated
         assert len(results) == 2
         doc_names = {r.document_name for r in results}
@@ -496,9 +533,7 @@ class TestMaxDocsRegression:
                 judge_model="test-model",
             )
         )
-        results = await run_judge_on_results(
-            entries_3_docs, mock_judge, max_docs=1
-        )
+        results = await run_judge_on_results(entries_3_docs, mock_judge, max_docs=1)
         assert len(results) == 1
 
     async def test_max_docs_none_evaluates_all(self, entries_3_docs):
@@ -516,7 +551,5 @@ class TestMaxDocsRegression:
                 judge_model="test-model",
             )
         )
-        results = await run_judge_on_results(
-            entries_3_docs, mock_judge, max_docs=None
-        )
+        results = await run_judge_on_results(entries_3_docs, mock_judge, max_docs=None)
         assert len(results) == 3

--- a/tests/unit/argumentation_analysis/orchestration/test_auto_evaluate_governance.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_auto_evaluate_governance.py
@@ -5,6 +5,7 @@ Verifies that:
 2. Governance auto-runs social_choice_vote when positions are available
 3. State writer uses evaluation scores and vote results
 """
+
 import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -105,12 +106,16 @@ class TestCounterArgumentAutoEvaluation:
         mock_plugin.parse_argument.return_value = '{"premise": "test"}'
         mock_plugin.suggest_strategy.return_value = '{"strategy_name": "test"}'
 
-        llm_response = json.dumps([{
-            "counter_argument": "Bon contre-argument avec des preuves solides.",
-            "strategy_used": "counter-example",
-            "target_argument": "Test argument",
-            "strength": "strong",
-        }])
+        llm_response = json.dumps(
+            [
+                {
+                    "counter_argument": "Bon contre-argument avec des preuves solides.",
+                    "strategy_used": "counter-example",
+                    "target_argument": "Test argument",
+                    "strength": "strong",
+                }
+            ]
+        )
 
         mock_message = MagicMock()
         mock_message.content = llm_response
@@ -152,10 +157,12 @@ class TestGovernanceAutoVote:
         mock_plugin = MagicMock()
         mock_plugin.list_governance_methods.return_value = '["majority", "copeland"]'
         mock_plugin.detect_conflicts_fn.return_value = "[]"
-        mock_plugin.social_choice_vote.return_value = json.dumps({
-            "winner": "agent_1",
-            "copeland_scores": {"agent_1": 2, "agent_2": 1, "agent_3": 0},
-        })
+        mock_plugin.social_choice_vote.return_value = json.dumps(
+            {
+                "winner": "agent_1",
+                "copeland_scores": {"agent_1": 2, "agent_2": 1, "agent_3": 0},
+            }
+        )
 
         with patch(
             "argumentation_analysis.plugins.governance_plugin.GovernancePlugin",
@@ -216,17 +223,19 @@ class TestStateWriterEvaluationScore:
 
         state = UnifiedAnalysisState(initial_text="test")
         output = {
-            "llm_counter_arguments": [{
-                "counter_argument": "Good counter",
-                "target_argument": "Original",
-                "strategy_used": "distinction",
-                "strength": "weak",  # would map to 0.3
-                "evaluation": {
-                    "overall_score": 0.72,  # should be used instead
-                    "relevance": 0.8,
-                    "logical_strength": 0.7,
-                },
-            }]
+            "llm_counter_arguments": [
+                {
+                    "counter_argument": "Good counter",
+                    "target_argument": "Original",
+                    "strategy_used": "distinction",
+                    "strength": "weak",  # would map to 0.3
+                    "evaluation": {
+                        "overall_score": 0.72,  # should be used instead
+                        "relevance": 0.8,
+                        "logical_strength": 0.7,
+                    },
+                }
+            ]
         }
         _write_counter_argument_to_state(output, state, {})
 
@@ -242,12 +251,14 @@ class TestStateWriterEvaluationScore:
 
         state = UnifiedAnalysisState(initial_text="test")
         output = {
-            "llm_counter_arguments": [{
-                "counter_argument": "Counter",
-                "target_argument": "Original",
-                "strategy_used": "test",
-                "strength": "strong",
-            }]
+            "llm_counter_arguments": [
+                {
+                    "counter_argument": "Counter",
+                    "target_argument": "Original",
+                    "strategy_used": "test",
+                    "strength": "strong",
+                }
+            ]
         }
         _write_counter_argument_to_state(output, state, {})
 

--- a/tests/unit/argumentation_analysis/orchestration/test_camembert_invoke.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_camembert_invoke.py
@@ -3,6 +3,7 @@
 Verifies the self-hosted LLM fallacy detection invoke function that replaced
 the dead CamemBERT adapter (PR #299).
 """
+
 import json
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
@@ -32,17 +33,19 @@ class TestInvokeCamemBERTFallacy:
 
         mock_plugin = MagicMock()
         mock_plugin.run_guided_analysis = AsyncMock(
-            return_value=json.dumps({
-                "fallacies": [
-                    {
-                        "fallacy_type": "Ad Hominem",
-                        "confidence": 0.92,
-                        "explanation": "Attack on person",
-                        "taxonomy_pk": "1.1",
-                    }
-                ],
-                "exploration_method": "self_hosted",
-            })
+            return_value=json.dumps(
+                {
+                    "fallacies": [
+                        {
+                            "fallacy_type": "Ad Hominem",
+                            "confidence": 0.92,
+                            "explanation": "Attack on person",
+                            "taxonomy_pk": "1.1",
+                        }
+                    ],
+                    "exploration_method": "self_hosted",
+                }
+            )
         )
 
         env = {
@@ -50,23 +53,28 @@ class TestInvokeCamemBERTFallacy:
             "SELF_HOSTED_LLM_MODEL": "test-model",
         }
 
-        with patch.dict("os.environ", env, clear=True), \
-             patch("argumentation_analysis.orchestration.invoke_callables.FallacyWorkflowPlugin",
-                   create=True) as mock_fwp_cls, \
-             patch("openai.AsyncOpenAI"), \
-             patch("semantic_kernel.kernel.Kernel"), \
-             patch("semantic_kernel.connectors.ai.open_ai.OpenAIChatCompletion"):
+        with patch.dict("os.environ", env, clear=True), patch(
+            "argumentation_analysis.orchestration.invoke_callables.FallacyWorkflowPlugin",
+            create=True,
+        ) as mock_fwp_cls, patch("openai.AsyncOpenAI"), patch(
+            "semantic_kernel.kernel.Kernel"
+        ), patch(
+            "semantic_kernel.connectors.ai.open_ai.OpenAIChatCompletion"
+        ):
             # Make the plugin class importable inside the function
-            with patch.dict("sys.modules", {
-                "openai": MagicMock(AsyncOpenAI=MagicMock()),
-                "semantic_kernel.kernel": MagicMock(Kernel=MagicMock()),
-                "semantic_kernel.connectors.ai.open_ai": MagicMock(
-                    OpenAIChatCompletion=MagicMock()
-                ),
-                "argumentation_analysis.plugins.fallacy_workflow_plugin": MagicMock(
-                    FallacyWorkflowPlugin=MagicMock(return_value=mock_plugin)
-                ),
-            }):
+            with patch.dict(
+                "sys.modules",
+                {
+                    "openai": MagicMock(AsyncOpenAI=MagicMock()),
+                    "semantic_kernel.kernel": MagicMock(Kernel=MagicMock()),
+                    "semantic_kernel.connectors.ai.open_ai": MagicMock(
+                        OpenAIChatCompletion=MagicMock()
+                    ),
+                    "argumentation_analysis.plugins.fallacy_workflow_plugin": MagicMock(
+                        FallacyWorkflowPlugin=MagicMock(return_value=mock_plugin)
+                    ),
+                },
+            ):
                 result = await _invoke_camembert_fallacy(
                     "Tu es stupide donc ton argument est faux.", {}
                 )
@@ -100,8 +108,9 @@ class TestInvokeCamemBERTFallacy:
             "SELF_HOSTED_LLM_MODEL": "test-model",
         }
 
-        with patch.dict("os.environ", env, clear=True), \
-             patch.dict("sys.modules", {"openai": None}):
+        with patch.dict("os.environ", env, clear=True), patch.dict(
+            "sys.modules", {"openai": None}
+        ):
             result = await _invoke_camembert_fallacy("test text", {})
 
         # Should return graceful fallback, not crash

--- a/tests/unit/argumentation_analysis/orchestration/test_camembert_workflow_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_camembert_workflow_wiring.py
@@ -7,6 +7,7 @@ Verifies:
 4. InformalAgent in conversational mode has FrenchFallacyPlugin
 5. State writer correctly maps CamemBERT output
 """
+
 import pytest
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/argumentation_analysis/orchestration/test_conversational_orchestrator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversational_orchestrator.py
@@ -26,7 +26,6 @@ from argumentation_analysis.agents.factory import (
 )
 from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
 
-
 # ── Fixtures ──
 
 
@@ -133,9 +132,7 @@ class TestAgentConfig:
         for name, config in AGENT_CONFIG.items():
             speciality = config["speciality"]
             plugins = AGENT_SPECIALITY_MAP.get(speciality, [])
-            assert (
-                len(plugins) <= 2
-            ), f"{name} has {len(plugins)} plugins — too many"
+            assert len(plugins) <= 2, f"{name} has {len(plugins)} plugins — too many"
 
     def test_plugin_isolation_informal_no_tweety(self):
         """InformalAgent should NOT have tweety_logic plugin."""
@@ -192,9 +189,7 @@ class TestCreateConversationalAgents:
             return_value=[MagicMock()],
         ):
             MockAgent.return_value = MagicMock()
-            agents = create_conversational_agents(
-                mock_kernel, state, "test_llm"
-            )
+            agents = create_conversational_agents(mock_kernel, state, "test_llm")
             assert len(agents) == 8
 
     def test_creates_subset_of_agents(self, mock_kernel, state):
@@ -540,7 +535,9 @@ class TestRunConversationalAnalysis:
 
         phase_names_seen = []
 
-        async def tracking_run_phase(agents, prompt, max_turns=5, phase_name="", state=None):
+        async def tracking_run_phase(
+            agents, prompt, max_turns=5, phase_name="", state=None
+        ):
             phase_names_seen.append(phase_name)
             return [
                 {

--- a/tests/unit/argumentation_analysis/orchestration/test_conversational_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversational_spectacular.py
@@ -3,6 +3,7 @@
 Verifies that run_conversational_analysis uses UnifiedAnalysisState when
 spectacular=True and produces result format matching the unified pipeline.
 """
+
 import inspect
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -53,9 +54,7 @@ class TestSpectacularStateUpgrade:
     """Verify UnifiedAnalysisState is used in spectacular mode."""
 
     @pytest.mark.asyncio
-    async def test_spectacular_true_uses_unified_state(
-        self, mock_conversational_deps
-    ):
+    async def test_spectacular_true_uses_unified_state(self, mock_conversational_deps):
         from argumentation_analysis.orchestration.conversational_orchestrator import (
             run_conversational_analysis,
         )
@@ -119,9 +118,7 @@ class TestSpectacularStateUpgrade:
         ):
             mock_run_phase.return_value = []
 
-            result = await run_conversational_analysis(
-                "test text", spectacular=False
-            )
+            result = await run_conversational_analysis("test text", spectacular=False)
 
         assert result["workflow_name"] == "conversational"
         assert isinstance(result["unified_state"], RhetoricalAnalysisState)
@@ -132,9 +129,7 @@ class TestSpectacularResultFormat:
     """Verify result format matches unified pipeline output."""
 
     @pytest.mark.asyncio
-    async def test_result_has_unified_pipeline_keys(
-        self, mock_conversational_deps
-    ):
+    async def test_result_has_unified_pipeline_keys(self, mock_conversational_deps):
         from argumentation_analysis.orchestration.conversational_orchestrator import (
             run_conversational_analysis,
         )
@@ -158,9 +153,7 @@ class TestSpectacularResultFormat:
             "._should_add_reanalysis_phase",
             return_value=False,
         ):
-            result = await run_conversational_analysis(
-                "test text", spectacular=True
-            )
+            result = await run_conversational_analysis("test text", spectacular=True)
 
         # Unified pipeline expects these keys
         assert "workflow_name" in result
@@ -180,9 +173,7 @@ class TestSpectacularResultFormat:
         assert "total_messages" in summary
 
     @pytest.mark.asyncio
-    async def test_result_has_coverage_metrics(
-        self, mock_conversational_deps
-    ):
+    async def test_result_has_coverage_metrics(self, mock_conversational_deps):
         from argumentation_analysis.orchestration.conversational_orchestrator import (
             run_conversational_analysis,
         )
@@ -206,9 +197,7 @@ class TestSpectacularResultFormat:
             "._should_add_reanalysis_phase",
             return_value=False,
         ):
-            result = await run_conversational_analysis(
-                "test text", spectacular=True
-            )
+            result = await run_conversational_analysis("test text", spectacular=True)
 
         assert "state_non_empty_fields" in result
         assert "state_total_fields" in result
@@ -256,9 +245,7 @@ class TestSpectacularCapabilityMapping:
             "._should_add_reanalysis_phase",
             return_value=False,
         ):
-            result = await run_conversational_analysis(
-                "test text", spectacular=True
-            )
+            result = await run_conversational_analysis("test text", spectacular=True)
 
         caps = result["capabilities_used"]
         assert "fact_extraction" in caps
@@ -277,9 +264,9 @@ class TestUnifiedAnalysisStateFields:
         state = UnifiedAnalysisState("test text")
         snapshot = state.get_state_snapshot(summarize=False)
         # Must have ≥ 28 fields for spectacular coverage
-        assert len(snapshot) >= 28, (
-            f"UnifiedAnalysisState has {len(snapshot)} fields, need >= 28"
-        )
+        assert (
+            len(snapshot) >= 28
+        ), f"UnifiedAnalysisState has {len(snapshot)} fields, need >= 28"
 
     def test_unified_state_inherits_rhetorical(self):
         state = UnifiedAnalysisState("test text")
@@ -345,6 +332,6 @@ class TestUnifiedAnalysisStateFields:
         non_empty = sum(
             1 for v in snapshot.values() if v and v not in ([], {}, "", None, 0)
         )
-        assert non_empty >= 28, (
-            f"Only {non_empty}/{len(snapshot)} fields non-empty after mock population"
-        )
+        assert (
+            non_empty >= 28
+        ), f"Only {non_empty}/{len(snapshot)} fields non-empty after mock population"

--- a/tests/unit/argumentation_analysis/orchestration/test_critical_coverage.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_critical_coverage.py
@@ -41,7 +41,6 @@ from argumentation_analysis.orchestration.workflow_dsl import (
 )
 from argumentation_analysis.core.capability_registry import CapabilityRegistry
 
-
 # ============================================================
 # pipeline_utils.py edge cases
 # ============================================================
@@ -271,6 +270,7 @@ class TestWorkflowCatalog:
         get_workflow_catalog()
         reset_workflow_catalog()
         from argumentation_analysis.orchestration.workflows import WORKFLOW_CATALOG
+
         assert len(WORKFLOW_CATALOG) == 0
 
 
@@ -513,12 +513,17 @@ class TestWorkflowStateWriter:
         def mock_writer(output, state, ctx):
             written.append(output)
 
-        mock_state = type("State", (), {"log_error": lambda s, p, e: None, "set_workflow_results": lambda s, n, d: None})()
+        mock_state = type(
+            "State",
+            (),
+            {
+                "log_error": lambda s, p, e: None,
+                "set_workflow_results": lambda s, n, d: None,
+            },
+        )()
 
         workflow = (
-            WorkflowBuilder("sw_test")
-            .add_phase("p1", capability="test_cap")
-            .build()
+            WorkflowBuilder("sw_test").add_phase("p1", capability="test_cap").build()
         )
         executor = WorkflowExecutor(registry)
         results = await executor.execute(
@@ -548,12 +553,17 @@ class TestWorkflowStateWriter:
         def bad_writer(output, state, ctx):
             raise RuntimeError("writer failed")
 
-        mock_state = type("State", (), {"log_error": lambda s, p, e: None, "set_workflow_results": lambda s, n, d: None})()
+        mock_state = type(
+            "State",
+            (),
+            {
+                "log_error": lambda s, p, e: None,
+                "set_workflow_results": lambda s, n, d: None,
+            },
+        )()
 
         workflow = (
-            WorkflowBuilder("sw_err")
-            .add_phase("p1", capability="test_cap")
-            .build()
+            WorkflowBuilder("sw_err").add_phase("p1", capability="test_cap").build()
         )
         executor = WorkflowExecutor(registry)
         results = await executor.execute(

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
@@ -15,7 +15,6 @@ import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 # ============================================================
 # Test: _invoke_dung_extensions uses helper functions
 # ============================================================
@@ -115,9 +114,7 @@ class TestInvokeDungExtensions:
         )
 
         context = {
-            "phase_extract_output": {
-                "arguments": [{"text": "arg1"}, {"text": "arg2"}]
-            }
+            "phase_extract_output": {"arguments": [{"text": "arg1"}, {"text": "arg2"}]}
         }
 
         with patch(
@@ -151,9 +148,7 @@ class TestInvokeDungExtensions:
         )
 
         context = {
-            "phase_extract_output": {
-                "arguments": [{"text": "arg1"}, {"text": "arg2"}]
-            }
+            "phase_extract_output": {"arguments": [{"text": "arg1"}, {"text": "arg2"}]}
         }
 
         with patch(
@@ -334,8 +329,9 @@ class TestCrossKBFallacyAttacks:
 
         assert len(attacks) > 0
         # The fallacy should target the first argument (text overlap)
-        assert any("professeur" in a[1].lower() or "dupont" in a[1].lower()
-                    for a in attacks)
+        assert any(
+            "professeur" in a[1].lower() or "dupont" in a[1].lower() for a in attacks
+        )
 
     def test_fallacy_label_in_attack(self):
         """Attack labels include fallacy type."""
@@ -354,8 +350,10 @@ class TestCrossKBFallacyAttacks:
 
         attacks = _generate_attacks_from_args(arguments, context)
         assert len(attacks) > 0
-        assert any("appel" in str(a[0]).lower() or "autorite" in str(a[0]).lower()
-                    for a in attacks)
+        assert any(
+            "appel" in str(a[0]).lower() or "autorite" in str(a[0]).lower()
+            for a in attacks
+        )
 
     def test_counter_argument_attacks(self):
         """Counter-arguments generate attack relations."""
@@ -466,9 +464,7 @@ class TestWorkflowDungPhases:
         )
 
         wf = build_jtms_dung_loop_workflow()
-        dung_phase = next(
-            (p for p in wf.phases if p.name == "dung_extensions"), None
-        )
+        dung_phase = next((p for p in wf.phases if p.name == "dung_extensions"), None)
         assert dung_phase is not None
         assert dung_phase.capability == "dung_extensions"
 

--- a/tests/unit/argumentation_analysis/orchestration/test_groupchat_turn_strategy.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_groupchat_turn_strategy.py
@@ -17,7 +17,6 @@ from argumentation_analysis.orchestration.conversational_executor import (
 )
 from argumentation_analysis.orchestration.workflow_dsl import PhaseStatus
 
-
 # --- Fixtures ---
 
 

--- a/tests/unit/argumentation_analysis/orchestration/test_invoke_jtms.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_invoke_jtms.py
@@ -2,6 +2,7 @@
 
 Verifies the JTMS phase builds proper belief networks from upstream phases.
 """
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -15,7 +16,10 @@ class TestInvokeJTMS:
 
         context = {
             "phase_extract_output": {
-                "arguments": [{"text": "Evidence supports the claim"}, {"text": "Statistical data confirms"}],
+                "arguments": [
+                    {"text": "Evidence supports the claim"},
+                    {"text": "Statistical data confirms"},
+                ],
                 "claims": [{"text": "The policy is effective"}],
             }
         }

--- a/tests/unit/argumentation_analysis/orchestration/test_llm_enrich_quality.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_llm_enrich_quality.py
@@ -3,6 +3,7 @@
 Verifies LLM enrichment pass in the quality evaluator pipeline phase,
 including fallacy context integration and per-argument llm_assessment.
 """
+
 import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -59,15 +60,19 @@ class TestLlmEnrichQuality:
             _llm_enrich_quality,
         )
 
-        llm_response = json.dumps({
-            "enrichments": [{
-                "arg_id": "arg_1",
-                "implicit_assumptions": ["The economy is stable"],
-                "reasoning_assessment": "moderate",
-                "evidence_quality": "weak",
-                "improvement_suggestion": "Add empirical data",
-            }]
-        })
+        llm_response = json.dumps(
+            {
+                "enrichments": [
+                    {
+                        "arg_id": "arg_1",
+                        "implicit_assumptions": ["The economy is stable"],
+                        "reasoning_assessment": "moderate",
+                        "evidence_quality": "weak",
+                        "improvement_suggestion": "Add empirical data",
+                    }
+                ]
+            }
+        )
 
         mock_message = MagicMock()
         mock_message.content = llm_response
@@ -84,10 +89,12 @@ class TestLlmEnrichQuality:
             return_value=(mock_client, "gpt-5-mini"),
         ):
             result = await _llm_enrich_quality(
-                {"arg_1": {
-                    "note_finale": 5.0,
-                    "scores_par_vertu": {"clarity": 6.0, "coherence": 4.0},
-                }},
+                {
+                    "arg_1": {
+                        "note_finale": 5.0,
+                        "scores_par_vertu": {"clarity": 6.0, "coherence": 4.0},
+                    }
+                },
                 [{"text": "The economy grows because of tax cuts"}],
             )
 
@@ -165,7 +172,10 @@ class TestLlmEnrichQuality:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         heuristic = {
-            f"arg_{i}": {"note_finale": float(i), "scores_par_vertu": {"clarity": float(i)}}
+            f"arg_{i}": {
+                "note_finale": float(i),
+                "scores_par_vertu": {"clarity": float(i)},
+            }
             for i in range(1, 8)
         }
         raw_args = [{"text": f"Argument {i}"} for i in range(1, 8)]
@@ -181,6 +191,7 @@ class TestLlmEnrichQuality:
         user_msg = call_args.kwargs["messages"][1]["content"]
         # Count [arg_N] occurrences
         import re
+
         arg_refs = re.findall(r"\[arg_\d+\]", user_msg)
         assert len(arg_refs) <= 4
 
@@ -364,13 +375,15 @@ class TestLlmEnrichQualityWithFallacies:
         }
 
         enrichment_data = {
-            "enrichments": [{
-                "arg_id": "arg_1",
-                "reasoning_assessment": "moderate",
-                "evidence_quality": "weak",
-                "bias_indicators": ["confirmation bias"],
-                "llm_assessment": "This argument relies on unsubstantiated claims.",
-            }]
+            "enrichments": [
+                {
+                    "arg_id": "arg_1",
+                    "reasoning_assessment": "moderate",
+                    "evidence_quality": "weak",
+                    "bias_indicators": ["confirmation bias"],
+                    "llm_assessment": "This argument relies on unsubstantiated claims.",
+                }
+            ]
         }
 
         with patch(
@@ -388,7 +401,9 @@ class TestLlmEnrichQualityWithFallacies:
             result = await _invoke_quality_evaluator("Test", context)
 
         arg1 = result["per_argument_scores"]["arg_1"]
-        assert arg1["llm_assessment"] == "This argument relies on unsubstantiated claims."
+        assert (
+            arg1["llm_assessment"] == "This argument relies on unsubstantiated claims."
+        )
         assert arg1["reasoning_assessment"] == "moderate"
         assert arg1["evidence_quality"] == "weak"
         assert arg1["bias_indicators"] == ["confirmation bias"]
@@ -413,9 +428,7 @@ class TestLlmEnrichQualityWithFallacies:
             return_value=None,
         ):
             context = {
-                "phase_extract_output": {
-                    "arguments": [{"text": "A simple argument"}]
-                }
+                "phase_extract_output": {"arguments": [{"text": "A simple argument"}]}
             }
             result = await _invoke_quality_evaluator("Test", context)
 
@@ -432,8 +445,10 @@ class TestQualityStateWriterLlmAssessment:
 
         state = UnifiedAnalysisState(initial_text="test")
         state.add_quality_score(
-            "arg_1", {"clarity": 7.0}, 7.0,
-            llm_assessment="Strong argument with good evidence."
+            "arg_1",
+            {"clarity": 7.0},
+            7.0,
+            llm_assessment="Strong argument with good evidence.",
         )
         entry = state.argument_quality_scores["arg_1"]
         assert entry["llm_assessment"] == "Strong argument with good evidence."

--- a/tests/unit/argumentation_analysis/orchestration/test_nl_to_logic_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_nl_to_logic_wiring.py
@@ -2,9 +2,9 @@
 
 Verifies the 3-tier fallback: upstream translations → on-the-fly translator → templates.
 """
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
-
 
 TWEETY_BRIDGE_PATH = (
     "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge"
@@ -90,7 +90,10 @@ class TestPropositionalLogicNLWiring:
 
         # Mock TweetyBridge since fallback path calls check_consistency
         with patch(TWEETY_BRIDGE_PATH) as MockBridge:
-            MockBridge.return_value.check_consistency.return_value = (True, "consistent")
+            MockBridge.return_value.check_consistency.return_value = (
+                True,
+                "consistent",
+            )
             result = await _invoke_propositional_logic("text", context)
         assert result["logic_type"] == "propositional"
         # Invalid translations are skipped → falls back to on-the-fly or template
@@ -153,7 +156,9 @@ class TestPropositionalLogicNLWiring:
 
         context = _make_context_with_args(["Some argument text here"])
 
-        with patch.dict("sys.modules", {"argumentation_analysis.services.nl_to_logic": None}):
+        with patch.dict(
+            "sys.modules", {"argumentation_analysis.services.nl_to_logic": None}
+        ):
             result = await _invoke_propositional_logic("text", context)
 
         assert result["logic_type"] == "propositional"
@@ -275,7 +280,9 @@ class TestFOLReasoningNLWiring:
 
         context = _make_context_with_args(["Some argument text here"])
 
-        with patch.dict("sys.modules", {"argumentation_analysis.services.nl_to_logic": None}):
+        with patch.dict(
+            "sys.modules", {"argumentation_analysis.services.nl_to_logic": None}
+        ):
             result = await _invoke_fol_reasoning("text", context)
 
         assert result["logic_type"] == "first_order"

--- a/tests/unit/argumentation_analysis/orchestration/test_pipeline_utils.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_pipeline_utils.py
@@ -94,7 +94,7 @@ class TestPipelineMetrics:
         assert summary["total_analyses"] == 3
         assert summary["successful"] == 2
         assert summary["failed"] == 1
-        assert summary["success_rate"] == 2/3
+        assert summary["success_rate"] == 2 / 3
 
     def test_confidence_aggregation(self):
         """Test confidence score aggregation."""

--- a/tests/unit/argumentation_analysis/orchestration/test_pipeline_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_pipeline_wiring.py
@@ -12,7 +12,6 @@ import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 # ============================================================
 # Test: Workflow definitions include formal reasoning phases
 # ============================================================
@@ -283,9 +282,7 @@ class TestJTMSKeyFixes:
 
         result = await _invoke_jtms("test", context)
         # Should find a FALLACY:appeal_to_authority belief
-        fallacy_beliefs = [
-            k for k in result["beliefs"] if k.startswith("FALLACY:")
-        ]
+        fallacy_beliefs = [k for k in result["beliefs"] if k.startswith("FALLACY:")]
         assert len(fallacy_beliefs) >= 1
         assert "appeal_to_authority" in fallacy_beliefs[0]
 
@@ -312,9 +309,7 @@ class TestJTMSKeyFixes:
         }
 
         result = await _invoke_jtms("test", context)
-        fallacy_beliefs = [
-            k for k in result["beliefs"] if k.startswith("FALLACY:")
-        ]
+        fallacy_beliefs = [k for k in result["beliefs"] if k.startswith("FALLACY:")]
         assert len(fallacy_beliefs) >= 1
         assert "ad_hominem" in fallacy_beliefs[0]
 
@@ -436,7 +431,10 @@ class TestGovernanceCrossKB:
             "phase_debate_output": {},
             "phase_counter_output": {
                 "llm_counter_arguments": [
-                    {"strategy_used": "reductio", "counter_argument": "If we follow..."},
+                    {
+                        "strategy_used": "reductio",
+                        "counter_argument": "If we follow...",
+                    },
                 ],
             },
             "phase_quality_output": {},
@@ -504,7 +502,10 @@ class TestDebateCrossKB:
             },
             "phase_hierarchical_fallacy_output": {
                 "fallacies": [
-                    {"type": "appeal_to_authority", "justification": "Cites celebrity opinion"},
+                    {
+                        "type": "appeal_to_authority",
+                        "justification": "Cites celebrity opinion",
+                    },
                 ],
             },
             "phase_counter_output": {},
@@ -524,4 +525,8 @@ class TestDebateCrossKB:
 
         result = await _invoke_debate_analysis("test", context)
         # Basic structure check — LLM enrichment won't fire without API key
-        assert "argument_scores" in result or "scores" in result or isinstance(result, dict)
+        assert (
+            "argument_scores" in result
+            or "scores" in result
+            or isinstance(result, dict)
+        )

--- a/tests/unit/argumentation_analysis/orchestration/test_pm_reprompting.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_pm_reprompting.py
@@ -23,6 +23,7 @@ class TestShouldRerunFallacy:
         from argumentation_analysis.orchestration.unified_pipeline import (
             _should_rerun_fallacy,
         )
+
         return _should_rerun_fallacy
 
     def test_returns_true_when_retracted_beliefs_via_undermined_count(self):
@@ -113,6 +114,7 @@ class TestIncrementFallacyRerun:
         from argumentation_analysis.orchestration.unified_pipeline import (
             _increment_fallacy_rerun,
         )
+
         ctx = {}
         _increment_fallacy_rerun(ctx)
         assert ctx["_fallacy_rerun_count"] == 1
@@ -121,6 +123,7 @@ class TestIncrementFallacyRerun:
         from argumentation_analysis.orchestration.unified_pipeline import (
             _increment_fallacy_rerun,
         )
+
         ctx = {"_fallacy_rerun_count": 1}
         _increment_fallacy_rerun(ctx)
         assert ctx["_fallacy_rerun_count"] == 2
@@ -164,7 +167,13 @@ class TestBuildIterativeWorkflow:
 
         wf = build_iterative_analysis_workflow()
         phase_names = [p.name for p in wf.phases]
-        for expected in ["extract", "hierarchical_fallacy", "quality", "counter", "jtms"]:
+        for expected in [
+            "extract",
+            "hierarchical_fallacy",
+            "quality",
+            "counter",
+            "jtms",
+        ]:
             assert expected in phase_names, f"Missing phase: {expected}"
 
     def test_fallacy_reanalysis_depends_on_jtms(self):
@@ -186,9 +195,9 @@ class TestBuildIterativeWorkflow:
 
         reset_workflow_catalog()
         catalog = get_workflow_catalog()
-        assert "iterative" in catalog, (
-            f"'iterative' not in catalog keys: {list(catalog.keys())}"
-        )
+        assert (
+            "iterative" in catalog
+        ), f"'iterative' not in catalog keys: {list(catalog.keys())}"
         assert catalog["iterative"].name == "iterative_analysis"
         reset_workflow_catalog()
 
@@ -207,9 +216,9 @@ class TestBuildIterativeWorkflow:
 
         jtms_pos = flat_order.index("jtms")
         reanalysis_pos = flat_order.index("fallacy_reanalysis")
-        assert reanalysis_pos > jtms_pos, (
-            f"fallacy_reanalysis ({reanalysis_pos}) should come after jtms ({jtms_pos})"
-        )
+        assert (
+            reanalysis_pos > jtms_pos
+        ), f"fallacy_reanalysis ({reanalysis_pos}) should come after jtms ({jtms_pos})"
 
 
 # ---------------------------------------------------------------------------
@@ -224,6 +233,7 @@ class TestShouldAddReanalysisPhase:
         from argumentation_analysis.orchestration.conversational_orchestrator import (
             _should_add_reanalysis_phase,
         )
+
         return _should_add_reanalysis_phase
 
     def test_returns_true_when_low_fallacy_coverage(self):

--- a/tests/unit/argumentation_analysis/orchestration/test_real_llm_orchestrator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_real_llm_orchestrator.py
@@ -166,7 +166,9 @@ class TestLLMAnalysisResult:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead")
+@pytest.mark.skip(
+    reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead"
+)
 class TestRealLLMOrchestratorInit:
     """Tests for RealLLMOrchestrator initialization."""
 
@@ -218,7 +220,9 @@ class TestRealLLMOrchestratorInit:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead")
+@pytest.mark.skip(
+    reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead"
+)
 class TestMetricsAndCache:
     """Tests for metrics tracking and cache operations."""
 
@@ -300,7 +304,9 @@ class TestMetricsAndCache:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead")
+@pytest.mark.skip(
+    reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead"
+)
 class TestInitialize:
     """Tests for the initialize() async method."""
 
@@ -341,7 +347,9 @@ class TestInitialize:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead")
+@pytest.mark.skip(
+    reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead"
+)
 class TestBasicAnalyzerFactories:
     """Tests for the _create_basic_*_analyzer factory methods."""
 
@@ -396,7 +404,9 @@ class TestBasicAnalyzerFactories:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead")
+@pytest.mark.skip(
+    reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead"
+)
 class TestAnalyzeText:
     """Tests for analyze_text() with various analysis types."""
 
@@ -553,7 +563,9 @@ class TestAnalyzeText:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead")
+@pytest.mark.skip(
+    reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead"
+)
 class TestCachingBehavior:
     """Tests for cache integration in analyze_text."""
 
@@ -621,7 +633,9 @@ class TestCachingBehavior:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead")
+@pytest.mark.skip(
+    reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead"
+)
 class TestBatchAnalyze:
     """Tests for batch_analyze() method."""
 
@@ -666,7 +680,9 @@ class TestBatchAnalyze:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead")
+@pytest.mark.skip(
+    reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead"
+)
 class TestOrchestrateAnalysis:
     """Tests for orchestrate_analysis() high-level method."""
 
@@ -702,7 +718,9 @@ class TestOrchestrateAnalysis:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead")
+@pytest.mark.skip(
+    reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead"
+)
 class TestErrorHandling:
     """Tests for error handling in analyze_text."""
 
@@ -746,7 +764,9 @@ class TestErrorHandling:
 # ============================================================================
 
 
-@pytest.mark.skip(reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead")
+@pytest.mark.skip(
+    reason="RealLLMOrchestrator archived (#215) - use UnifiedPipeline tests instead"
+)
 class TestLogicalAnalysis:
     """Tests for _analyze_logical which requires PropositionalLogicAgent."""
 

--- a/tests/unit/argumentation_analysis/orchestration/test_regression_golden.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_regression_golden.py
@@ -28,7 +28,6 @@ from argumentation_analysis.orchestration.workflow_dsl import (
 )
 from argumentation_analysis.core.capability_registry import CapabilityRegistry
 
-
 # ── Golden input text (known to contain fallacies + arguments) ────────────
 
 GOLDEN_TEXT = (
@@ -57,8 +56,12 @@ GOLDEN_TEXT = (
 MOCK_EXTRACTION_OUTPUT = {
     # _write_fact_extraction_to_state reads "arguments" (list of {text, source_quote?})
     "arguments": [
-        {"text": "La réforme des retraites est nécessaire car tous les pays européens l'ont déjà faite."},
-        {"text": "Si nous n'agissons pas maintenant, le système s'effondrera dans cinq ans."},
+        {
+            "text": "La réforme des retraites est nécessaire car tous les pays européens l'ont déjà faite."
+        },
+        {
+            "text": "Si nous n'agissons pas maintenant, le système s'effondrera dans cinq ans."
+        },
         {"text": "Travailler plus longtemps est dans l'ordre des choses."},
         {"text": "Le déficit atteindra 2.3% du PIB d'ici 2030."},
         {"text": "Pensez à vos enfants — il faut agir pour leur avenir."},
@@ -72,28 +75,73 @@ MOCK_EXTRACTION_OUTPUT = {
 MOCK_HIERARCHICAL_FALLACY_OUTPUT = {
     # _write_hierarchical_fallacy_to_state reads "fallacies" (list of dicts)
     "fallacies": [
-        {"type": "Argument d'autorité", "confidence": 0.85, "explanation": "Appel à l'autorité des autres pays", "taxonomy_pk": "4"},
-        {"type": "Appel à la peur", "confidence": 0.92, "explanation": "Menace d'effondrement du système", "taxonomy_pk": "340"},
+        {
+            "type": "Argument d'autorité",
+            "confidence": 0.85,
+            "explanation": "Appel à l'autorité des autres pays",
+            "taxonomy_pk": "4",
+        },
+        {
+            "type": "Appel à la peur",
+            "confidence": 0.92,
+            "explanation": "Menace d'effondrement du système",
+            "taxonomy_pk": "340",
+        },
     ],
 }
 
 MOCK_QUALITY_OUTPUT = {
     # _write_quality_to_state reads "per_argument_scores" (dict arg_id → {scores_par_vertu, note_finale, llm_assessment})
     "per_argument_scores": {
-        "arg_1": {"scores_par_vertu": {"clarity": 0.6, "relevance": 0.5}, "note_finale": 0.45, "llm_assessment": "Weak authority argument"},
-        "arg_2": {"scores_par_vertu": {"clarity": 0.7, "relevance": 0.4}, "note_finale": 0.35, "llm_assessment": "Fear-based"},
-        "arg_3": {"scores_par_vertu": {"clarity": 0.5, "relevance": 0.3}, "note_finale": 0.30, "llm_assessment": "Naturalistic fallacy"},
-        "arg_4": {"scores_par_vertu": {"clarity": 0.8, "relevance": 0.7}, "note_finale": 0.65, "llm_assessment": "Quantitative but assumption-based"},
-        "arg_5": {"scores_par_vertu": {"clarity": 0.6, "relevance": 0.2}, "note_finale": 0.25, "llm_assessment": "Emotional appeal"},
+        "arg_1": {
+            "scores_par_vertu": {"clarity": 0.6, "relevance": 0.5},
+            "note_finale": 0.45,
+            "llm_assessment": "Weak authority argument",
+        },
+        "arg_2": {
+            "scores_par_vertu": {"clarity": 0.7, "relevance": 0.4},
+            "note_finale": 0.35,
+            "llm_assessment": "Fear-based",
+        },
+        "arg_3": {
+            "scores_par_vertu": {"clarity": 0.5, "relevance": 0.3},
+            "note_finale": 0.30,
+            "llm_assessment": "Naturalistic fallacy",
+        },
+        "arg_4": {
+            "scores_par_vertu": {"clarity": 0.8, "relevance": 0.7},
+            "note_finale": 0.65,
+            "llm_assessment": "Quantitative but assumption-based",
+        },
+        "arg_5": {
+            "scores_par_vertu": {"clarity": 0.6, "relevance": 0.2},
+            "note_finale": 0.25,
+            "llm_assessment": "Emotional appeal",
+        },
     },
 }
 
 MOCK_COUNTER_OUTPUT = {
     # _write_counter_argument_to_state reads "llm_counter_arguments" (list of dicts)
     "llm_counter_arguments": [
-        {"target_argument": "La réforme est nécessaire car tous les pays européens l'ont faite.", "counter_argument": "L'argument d'autorité ignore les spécificités nationales.", "strategy_used": "counter_example", "strength": "strong"},
-        {"target_argument": "Le système s'effondrera dans cinq ans.", "counter_argument": "Les projections à 5 ans sont rarement fiables.", "strategy_used": "reductio_ad_absurdum", "strength": "moderate"},
-        {"target_argument": "Travailler plus longtemps est dans l'ordre des choses.", "counter_argument": "Ce qui est 'naturel' n'est pas nécessairement juste.", "strategy_used": "distinction", "strength": "strong"},
+        {
+            "target_argument": "La réforme est nécessaire car tous les pays européens l'ont faite.",
+            "counter_argument": "L'argument d'autorité ignore les spécificités nationales.",
+            "strategy_used": "counter_example",
+            "strength": "strong",
+        },
+        {
+            "target_argument": "Le système s'effondrera dans cinq ans.",
+            "counter_argument": "Les projections à 5 ans sont rarement fiables.",
+            "strategy_used": "reductio_ad_absurdum",
+            "strength": "moderate",
+        },
+        {
+            "target_argument": "Travailler plus longtemps est dans l'ordre des choses.",
+            "counter_argument": "Ce qui est 'naturel' n'est pas nécessairement juste.",
+            "strategy_used": "distinction",
+            "strength": "strong",
+        },
     ],
 }
 
@@ -109,21 +157,38 @@ MOCK_JTMS_OUTPUT = {
 MOCK_NL_TO_LOGIC_OUTPUT = {
     # _write_nl_to_logic_to_state reads "translations" (list of {formula, logic_type, is_valid, ...})
     "translations": [
-        {"original_text": "Si réforme européenne alors réforme française nécessaire", "formula": "european_reform => french_reform_needed", "logic_type": "propositional", "is_valid": True, "confidence": 0.8},
-        {"original_text": "Si croissance 1.8% alors déficit 2.3%", "formula": "growth_1_8 => deficit_2_3", "logic_type": "propositional", "is_valid": True, "confidence": 0.7},
+        {
+            "original_text": "Si réforme européenne alors réforme française nécessaire",
+            "formula": "european_reform => french_reform_needed",
+            "logic_type": "propositional",
+            "is_valid": True,
+            "confidence": 0.8,
+        },
+        {
+            "original_text": "Si croissance 1.8% alors déficit 2.3%",
+            "formula": "growth_1_8 => deficit_2_3",
+            "logic_type": "propositional",
+            "is_valid": True,
+            "confidence": 0.7,
+        },
     ],
 }
 
 MOCK_PL_OUTPUT = {
     # _write_propositional_to_state reads "formulas", "satisfiable", "model"
-    "formulas": ["european_reform => french_reform_needed", "growth_1_8 => deficit_2_3"],
+    "formulas": [
+        "european_reform => french_reform_needed",
+        "growth_1_8 => deficit_2_3",
+    ],
     "satisfiable": True,
     "model": {"european_reform": True, "french_reform_needed": True},
 }
 
 MOCK_FOL_OUTPUT = {
     # _write_fol_to_state reads "formulas", "consistent", "inferences", "confidence"
-    "formulas": ["forall x (EuropeanCountry(x) => ReformDone(x)) => ReformNeeded(France)"],
+    "formulas": [
+        "forall x (EuropeanCountry(x) => ReformDone(x)) => ReformNeeded(France)"
+    ],
     "consistent": True,
     "inferences": ["ReformNeeded(France)"],
     "confidence": 0.85,
@@ -135,7 +200,10 @@ MOCK_DEBATE_OUTPUT = {
     "llm_debate_assessment": {
         "key_exchanges": [
             {"point": "Reform is necessary", "rebuttal": "Reform model is flawed"},
-            {"point": "All countries did it", "rebuttal": "National specificities differ"},
+            {
+                "point": "All countries did it",
+                "rebuttal": "National specificities differ",
+            },
         ],
     },
 }
@@ -155,7 +223,11 @@ MOCK_GOVERNANCE_OUTPUT = {
 MOCK_CAMEMBERT_OUTPUT = {
     # _write_camembert_to_state reads "detections" (list of {text, label, confidence})
     "detections": [
-        {"text": "Pensez à vos enfants", "label": "Appel à l'émotion", "confidence": 0.78},
+        {
+            "text": "Pensez à vos enfants",
+            "label": "Appel à l'émotion",
+            "confidence": 0.78,
+        },
     ],
 }
 
@@ -197,21 +269,22 @@ def _build_golden_registry() -> CapabilityRegistry:
         # Override ALL registrations matching this capability (not just the first)
         for reg_name, reg in registry._registrations.items():
             if cap_name in reg.capabilities:
+
                 async def _mock_invoke(input_text, context, _out=mock_output):
                     return _out
+
                 reg.invoke = _mock_invoke
 
     # Also override any remaining registrations that have real invoke callables
     # but aren't in our mock map (e.g. speech, semantic_indexing, etc.)
     # — set them to return empty dicts so they don't make real calls
     for reg_name, reg in registry._registrations.items():
-        has_mock = any(
-            cap in mock_map
-            for cap in reg.capabilities
-        )
+        has_mock = any(cap in mock_map for cap in reg.capabilities)
         if not has_mock and reg.invoke is not None:
+
             async def _noop_invoke(input_text, context):
                 return {}
+
             reg.invoke = _noop_invoke
 
     return registry
@@ -234,7 +307,9 @@ class TestGoldenStatePipeline:
     def golden_state(self):
         return UnifiedAnalysisState(GOLDEN_TEXT)
 
-    async def test_standard_workflow_populates_arguments(self, golden_registry, golden_state):
+    async def test_standard_workflow_populates_arguments(
+        self, golden_registry, golden_state
+    ):
         """Standard workflow extracts ≥3 arguments into state."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             build_standard_workflow,
@@ -250,11 +325,13 @@ class TestGoldenStatePipeline:
             state_writers=CAPABILITY_STATE_WRITERS,
         )
 
-        assert len(golden_state.identified_arguments) >= 3, (
-            f"Expected ≥3 arguments, got {len(golden_state.identified_arguments)}"
-        )
+        assert (
+            len(golden_state.identified_arguments) >= 3
+        ), f"Expected ≥3 arguments, got {len(golden_state.identified_arguments)}"
 
-    async def test_standard_workflow_populates_fallacies(self, golden_registry, golden_state):
+    async def test_standard_workflow_populates_fallacies(
+        self, golden_registry, golden_state
+    ):
         """Standard workflow detects ≥1 fallacy into state."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             build_standard_workflow,
@@ -270,11 +347,13 @@ class TestGoldenStatePipeline:
             state_writers=CAPABILITY_STATE_WRITERS,
         )
 
-        assert len(golden_state.identified_fallacies) >= 1, (
-            f"Expected ≥1 fallacy, got {len(golden_state.identified_fallacies)}"
-        )
+        assert (
+            len(golden_state.identified_fallacies) >= 1
+        ), f"Expected ≥1 fallacy, got {len(golden_state.identified_fallacies)}"
 
-    async def test_standard_workflow_populates_quality_scores(self, golden_registry, golden_state):
+    async def test_standard_workflow_populates_quality_scores(
+        self, golden_registry, golden_state
+    ):
         """Standard workflow produces ≥2 quality scores."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             build_standard_workflow,
@@ -290,11 +369,13 @@ class TestGoldenStatePipeline:
             state_writers=CAPABILITY_STATE_WRITERS,
         )
 
-        assert len(golden_state.argument_quality_scores) >= 2, (
-            f"Expected ≥2 quality scores, got {len(golden_state.argument_quality_scores)}"
-        )
+        assert (
+            len(golden_state.argument_quality_scores) >= 2
+        ), f"Expected ≥2 quality scores, got {len(golden_state.argument_quality_scores)}"
 
-    async def test_standard_workflow_populates_fol_results(self, golden_registry, golden_state):
+    async def test_standard_workflow_populates_fol_results(
+        self, golden_registry, golden_state
+    ):
         """Standard workflow produces ≥1 FOL analysis result."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             build_standard_workflow,
@@ -310,11 +391,13 @@ class TestGoldenStatePipeline:
             state_writers=CAPABILITY_STATE_WRITERS,
         )
 
-        assert len(golden_state.fol_analysis_results) >= 1, (
-            f"Expected ≥1 FOL result, got {len(golden_state.fol_analysis_results)}"
-        )
+        assert (
+            len(golden_state.fol_analysis_results) >= 1
+        ), f"Expected ≥1 FOL result, got {len(golden_state.fol_analysis_results)}"
 
-    async def test_standard_workflow_populates_counter_arguments(self, golden_registry, golden_state):
+    async def test_standard_workflow_populates_counter_arguments(
+        self, golden_registry, golden_state
+    ):
         """Standard workflow produces counter-arguments."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             build_standard_workflow,
@@ -330,11 +413,13 @@ class TestGoldenStatePipeline:
             state_writers=CAPABILITY_STATE_WRITERS,
         )
 
-        assert len(golden_state.counter_arguments) >= 1, (
-            f"Expected ≥1 counter-argument, got {len(golden_state.counter_arguments)}"
-        )
+        assert (
+            len(golden_state.counter_arguments) >= 1
+        ), f"Expected ≥1 counter-argument, got {len(golden_state.counter_arguments)}"
 
-    async def test_standard_workflow_populates_jtms_beliefs(self, golden_registry, golden_state):
+    async def test_standard_workflow_populates_jtms_beliefs(
+        self, golden_registry, golden_state
+    ):
         """Standard workflow produces JTMS beliefs."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             build_standard_workflow,
@@ -350,11 +435,13 @@ class TestGoldenStatePipeline:
             state_writers=CAPABILITY_STATE_WRITERS,
         )
 
-        assert len(golden_state.jtms_beliefs) >= 1, (
-            f"Expected ≥1 JTMS belief, got {len(golden_state.jtms_beliefs)}"
-        )
+        assert (
+            len(golden_state.jtms_beliefs) >= 1
+        ), f"Expected ≥1 JTMS belief, got {len(golden_state.jtms_beliefs)}"
 
-    async def test_standard_workflow_populates_debate(self, golden_registry, golden_state):
+    async def test_standard_workflow_populates_debate(
+        self, golden_registry, golden_state
+    ):
         """Standard workflow produces debate transcript."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             build_standard_workflow,
@@ -370,11 +457,13 @@ class TestGoldenStatePipeline:
             state_writers=CAPABILITY_STATE_WRITERS,
         )
 
-        assert len(golden_state.debate_transcripts) >= 1, (
-            f"Expected ≥1 debate transcript, got {len(golden_state.debate_transcripts)}"
-        )
+        assert (
+            len(golden_state.debate_transcripts) >= 1
+        ), f"Expected ≥1 debate transcript, got {len(golden_state.debate_transcripts)}"
 
-    async def test_standard_workflow_populates_governance(self, golden_registry, golden_state):
+    async def test_standard_workflow_populates_governance(
+        self, golden_registry, golden_state
+    ):
         """Standard workflow produces governance decisions."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             build_standard_workflow,
@@ -390,9 +479,9 @@ class TestGoldenStatePipeline:
             state_writers=CAPABILITY_STATE_WRITERS,
         )
 
-        assert len(golden_state.governance_decisions) >= 1, (
-            f"Expected ≥1 governance decision, got {len(golden_state.governance_decisions)}"
-        )
+        assert (
+            len(golden_state.governance_decisions) >= 1
+        ), f"Expected ≥1 governance decision, got {len(golden_state.governance_decisions)}"
 
 
 # ============================================================
@@ -426,9 +515,15 @@ class TestGoldenSnapshotConsistency:
         snapshot = state.get_state_snapshot(summarize=True)
 
         # Core fields from #309 thresholds
-        assert snapshot.get("argument_count", 0) >= 3, f"argument_count: {snapshot.get('argument_count', 0)}"
-        assert snapshot.get("fallacy_count", 0) >= 1, f"fallacy_count: {snapshot.get('fallacy_count', 0)}"
-        assert snapshot.get("quality_scores_count", 0) >= 2, f"quality_scores_count: {snapshot.get('quality_scores_count', 0)}"
+        assert (
+            snapshot.get("argument_count", 0) >= 3
+        ), f"argument_count: {snapshot.get('argument_count', 0)}"
+        assert (
+            snapshot.get("fallacy_count", 0) >= 1
+        ), f"fallacy_count: {snapshot.get('fallacy_count', 0)}"
+        assert (
+            snapshot.get("quality_scores_count", 0) >= 2
+        ), f"quality_scores_count: {snapshot.get('quality_scores_count', 0)}"
 
     async def test_snapshot_has_correct_keys(self):
         """State snapshot has all expected summary keys."""
@@ -549,6 +644,7 @@ class TestGoldenIntegration:
     async def test_run_unified_analysis_standard_thresholds(self):
         """run_unified_analysis('standard') meets minimum thresholds."""
         import os
+
         if not os.environ.get("OPENAI_API_KEY"):
             pytest.skip("OPENAI_API_KEY not set")
 
@@ -565,16 +661,17 @@ class TestGoldenIntegration:
         assert state is not None, "Pipeline did not produce unified_state"
 
         snapshot = state.get_state_snapshot(summarize=True)
-        assert snapshot.get("argument_count", 0) >= 3, (
-            f"Expected ≥3 arguments, got {snapshot.get('argument_count', 0)}"
-        )
-        assert snapshot.get("fallacy_count", 0) >= 1, (
-            f"Expected ≥1 fallacy, got {snapshot.get('fallacy_count', 0)}"
-        )
+        assert (
+            snapshot.get("argument_count", 0) >= 3
+        ), f"Expected ≥3 arguments, got {snapshot.get('argument_count', 0)}"
+        assert (
+            snapshot.get("fallacy_count", 0) >= 1
+        ), f"Expected ≥1 fallacy, got {snapshot.get('fallacy_count', 0)}"
 
     async def test_run_unified_analysis_returns_state_snapshot(self):
         """run_unified_analysis returns state_snapshot in result dict."""
         import os
+
         if not os.environ.get("OPENAI_API_KEY"):
             pytest.skip("OPENAI_API_KEY not set")
 
@@ -609,9 +706,9 @@ class TestGoldenWorkflowStructure:
         )
 
         wf = build_standard_workflow()
-        assert len(wf.phases) >= 10, (
-            f"Expected ≥10 phases, got {len(wf.phases)}: {[p.name for p in wf.phases]}"
-        )
+        assert (
+            len(wf.phases) >= 10
+        ), f"Expected ≥10 phases, got {len(wf.phases)}: {[p.name for p in wf.phases]}"
 
     def test_full_workflow_phase_count(self):
         """Full workflow has ≥12 phases."""
@@ -620,9 +717,9 @@ class TestGoldenWorkflowStructure:
         )
 
         wf = build_full_workflow()
-        assert len(wf.phases) >= 12, (
-            f"Expected ≥12 phases, got {len(wf.phases)}: {[p.name for p in wf.phases]}"
-        )
+        assert (
+            len(wf.phases) >= 12
+        ), f"Expected ≥12 phases, got {len(wf.phases)}: {[p.name for p in wf.phases]}"
 
     def test_standard_workflow_has_required_capabilities(self):
         """Standard workflow includes core capabilities."""
@@ -653,9 +750,9 @@ class TestGoldenWorkflowStructure:
 
         light_caps = set(p.capability for p in light.phases)
         standard_caps = set(p.capability for p in standard.phases)
-        assert light_caps.issubset(standard_caps), (
-            f"Light has caps not in standard: {light_caps - standard_caps}"
-        )
+        assert light_caps.issubset(
+            standard_caps
+        ), f"Light has caps not in standard: {light_caps - standard_caps}"
 
     def test_state_writers_cover_standard_capabilities(self):
         """All standard workflow capabilities have state writers."""

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
@@ -35,7 +35,10 @@ def _reset_catalog():
 # Deterministic mock outputs for each capability
 MOCK_OUTPUTS = {
     "fact_extraction": {
-        "extracts": [{"id": "e1", "content": "claim_1"}, {"id": "e2", "content": "claim_2"}],
+        "extracts": [
+            {"id": "e1", "content": "claim_1"},
+            {"id": "e2", "content": "claim_2"},
+        ],
         "arguments": [{"id": "a1", "description": "arg_1"}],
     },
     "argument_quality": {
@@ -89,8 +92,16 @@ MOCK_OUTPUTS = {
     },
     "assumption_based_reasoning": {
         "atms_contexts": [
-            {"hypothesis_id": "h_trust", "coherent": True, "assumptions": ["source_reliable"]},
-            {"hypothesis_id": "h_skeptical", "coherent": False, "assumptions": ["source_unreliable"]},
+            {
+                "hypothesis_id": "h_trust",
+                "coherent": True,
+                "assumptions": ["source_reliable"],
+            },
+            {
+                "hypothesis_id": "h_skeptical",
+                "coherent": False,
+                "assumptions": ["source_unreliable"],
+            },
         ],
         "has_contradictions": True,
     },
@@ -216,7 +227,9 @@ def _make_mock_state_writers():
         if isinstance(output, dict):
             for tr in output.get("translations", []):
                 state.add_nl_to_logic_translation(
-                    "text", tr.get("formula", ""), tr.get("logic_type", "fol"),
+                    "text",
+                    tr.get("formula", ""),
+                    tr.get("logic_type", "fol"),
                     tr.get("is_valid", True),
                 )
 
@@ -289,10 +302,22 @@ class TestSpectacularWorkflowGolden:
     """Golden regression tests for build_spectacular_workflow()."""
 
     EXPECTED_PHASES = {
-        "extract", "quality", "nl_to_logic", "neural_detect",
-        "hierarchical_fallacy", "pl", "fol", "modal",
-        "dung_extensions", "aspic_analysis", "counter",
-        "jtms", "debate", "atms", "governance", "formal_synthesis",
+        "extract",
+        "quality",
+        "nl_to_logic",
+        "neural_detect",
+        "hierarchical_fallacy",
+        "pl",
+        "fol",
+        "modal",
+        "dung_extensions",
+        "aspic_analysis",
+        "counter",
+        "jtms",
+        "debate",
+        "atms",
+        "governance",
+        "formal_synthesis",
         "narrative_synthesis",
     }
 
@@ -322,7 +347,10 @@ class TestSpectacularWorkflowGolden:
         wf = build_spectacular_workflow()
         levels = wf.get_execution_order()
         assert set(levels[1]) == {
-            "hierarchical_fallacy", "neural_detect", "nl_to_logic", "quality",
+            "hierarchical_fallacy",
+            "neural_detect",
+            "nl_to_logic",
+            "quality",
         }
 
     def test_l2_includes_formal_logic_and_counter(self):
@@ -473,8 +501,7 @@ class TestSpectacularWorkflowGolden:
         _, state = await _execute_workflow(wf)
         snapshot = state.get_state_snapshot(summarize=True)
         populated = sum(
-            1 for k, v in snapshot.items()
-            if isinstance(v, (int, float)) and v > 0
+            1 for k, v in snapshot.items() if isinstance(v, (int, float)) and v > 0
         )
         assert populated >= 15
 
@@ -495,8 +522,13 @@ class TestSherlockModernWorkflowGolden:
     """Golden regression tests for build_sherlock_modern_workflow()."""
 
     EXPECTED_PHASES = {
-        "extract", "hierarchical_fallacy", "quality", "counter",
-        "jtms", "atms", "narrative_synthesis",
+        "extract",
+        "hierarchical_fallacy",
+        "quality",
+        "counter",
+        "jtms",
+        "atms",
+        "narrative_synthesis",
     }
 
     def test_workflow_builds(self):

--- a/tests/unit/argumentation_analysis/orchestration/test_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_trace_analyzer.py
@@ -21,7 +21,6 @@ from argumentation_analysis.orchestration.trace_analyzer import (
     _count_state_fields,
 )
 
-
 # ── Dataclass properties ──
 
 
@@ -35,10 +34,13 @@ class TestPhaseTrace:
         assert p.duration == 0.0
 
     def test_total_content(self):
-        p = PhaseTrace(name="test", turns=[
-            TurnTrace(phase="test", turn=1, agent="A", content_length=100),
-            TurnTrace(phase="test", turn=2, agent="B", content_length=250),
-        ])
+        p = PhaseTrace(
+            name="test",
+            turns=[
+                TurnTrace(phase="test", turn=1, agent="A", content_length=100),
+                TurnTrace(phase="test", turn=2, agent="B", content_length=250),
+            ],
+        )
         assert p.total_content == 350
 
     def test_total_content_empty(self):
@@ -46,11 +48,14 @@ class TestPhaseTrace:
         assert p.total_content == 0
 
     def test_agents_active(self):
-        p = PhaseTrace(name="test", turns=[
-            TurnTrace(phase="test", turn=1, agent="PM", content_length=10),
-            TurnTrace(phase="test", turn=2, agent="Extract", content_length=20),
-            TurnTrace(phase="test", turn=3, agent="PM", content_length=15),
-        ])
+        p = PhaseTrace(
+            name="test",
+            turns=[
+                TurnTrace(phase="test", turn=1, agent="PM", content_length=10),
+                TurnTrace(phase="test", turn=2, agent="Extract", content_length=20),
+                TurnTrace(phase="test", turn=3, agent="PM", content_length=15),
+            ],
+        )
         active = p.agents_active
         assert set(active) == {"PM", "Extract"}
 
@@ -72,20 +77,28 @@ class TestConvergenceMetrics:
         assert m.coverage_ratio == 0.0
 
     def test_is_converged_true(self):
-        m = ConvergenceMetrics(arguments_found=3, fallacies_found=1, quality_scores_count=2)
+        m = ConvergenceMetrics(
+            arguments_found=3, fallacies_found=1, quality_scores_count=2
+        )
         assert m.is_converged is True
 
     def test_is_converged_no_arguments(self):
-        m = ConvergenceMetrics(arguments_found=0, fallacies_found=1, quality_scores_count=2)
+        m = ConvergenceMetrics(
+            arguments_found=0, fallacies_found=1, quality_scores_count=2
+        )
         assert m.is_converged is False
 
     def test_is_converged_no_quality(self):
-        m = ConvergenceMetrics(arguments_found=3, fallacies_found=0, quality_scores_count=0)
+        m = ConvergenceMetrics(
+            arguments_found=3, fallacies_found=0, quality_scores_count=0
+        )
         assert m.is_converged is False
 
     def test_is_converged_zero_fallacies_ok(self):
         """Zero fallacies is valid (text may not contain any)."""
-        m = ConvergenceMetrics(arguments_found=2, fallacies_found=0, quality_scores_count=1)
+        m = ConvergenceMetrics(
+            arguments_found=2, fallacies_found=0, quality_scores_count=1
+        )
         assert m.is_converged is True
 
 
@@ -233,21 +246,27 @@ class TestGenerateReport:
         analyzer.begin_phase("Extraction", {"text": "hello", "args": []})
         analyzer.record_turn("Extraction", 1, "PM", "Let's extract arguments")
         analyzer.record_turn("Extraction", 2, "ExtractAgent", "Found 2 arguments")
-        analyzer.end_phase("Extraction", {
-            "text": "hello",
-            "identified_arguments": [{"id": "a1"}, {"id": "a2"}],
-            "identified_fallacies": [],
-            "argument_quality_scores": {"a1": 6},
-        })
+        analyzer.end_phase(
+            "Extraction",
+            {
+                "text": "hello",
+                "identified_arguments": [{"id": "a1"}, {"id": "a2"}],
+                "identified_fallacies": [],
+                "argument_quality_scores": {"a1": 6},
+            },
+        )
 
         analyzer.begin_phase("Synthesis")
         analyzer.record_turn("Synthesis", 1, "PM", "Synthesize")
-        analyzer.end_phase("Synthesis", {
-            "text": "hello",
-            "identified_arguments": [{"id": "a1"}, {"id": "a2"}],
-            "identified_fallacies": [{"type": "ad_hominem"}],
-            "argument_quality_scores": {"a1": 6, "a2": 3},
-        })
+        analyzer.end_phase(
+            "Synthesis",
+            {
+                "text": "hello",
+                "identified_arguments": [{"id": "a1"}, {"id": "a2"}],
+                "identified_fallacies": [{"type": "ad_hominem"}],
+                "argument_quality_scores": {"a1": 6, "a2": 3},
+            },
+        )
 
         analyzer.stop()
         return analyzer

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -735,7 +735,9 @@ class TestInvokeCallables:
         result = await _invoke_jtms(
             "First claim here. Second claim here. Third claim here.", {}
         )
-        assert result["belief_count"] >= 3  # 3 sentences + possible synthetic conclusion
+        assert (
+            result["belief_count"] >= 3
+        )  # 3 sentences + possible synthetic conclusion
         assert isinstance(result["beliefs"], dict)
         # New format: beliefs with validity, justifications (repr), and content
         for name, data in result["beliefs"].items():
@@ -2221,6 +2223,7 @@ class TestHierarchicalFallacyWorkflow:
             orig_async_client = openai_mod.AsyncOpenAI
 
             from unittest.mock import AsyncMock
+
             mock_plugin_instance = MagicMock()
             mock_plugin_instance.run_guided_analysis = AsyncMock(
                 side_effect=ValueError("Unexpected LLM response format"),

--- a/tests/unit/argumentation_analysis/orchestration/test_workflow_robustness.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_workflow_robustness.py
@@ -427,7 +427,9 @@ class TestCodeInjectionInputs:
                 workflow_name,
             )
         except asyncio.TimeoutError:
-            pytest.skip(f"Pipeline timeout ({_timeout_for(workflow_name)}s) for adversarial input in {workflow_name} workflow — LLM latency")
+            pytest.skip(
+                f"Pipeline timeout ({_timeout_for(workflow_name)}s) for adversarial input in {workflow_name} workflow — LLM latency"
+            )
         assert_valid_result(result, workflow_name)
 
 

--- a/tests/unit/argumentation_analysis/plugins/test_fallacy_workflow_calibration.py
+++ b/tests/unit/argumentation_analysis/plugins/test_fallacy_workflow_calibration.py
@@ -51,13 +51,13 @@ from tests.fixtures.calibrated_fallacy_texts import (
 # Leaf nodes are auto-confirmed by the plugin (no children).
 # Map: depth-1 PK -> depth-2 child PK to navigate to.
 _BRANCH_TO_LEAF = {
-    "1": "2",       # Insuffisance -> Argument bâclé
-    "175": "176",   # Influence -> Procédé rhétorique
-    "594": "595",   # Erreur mathématique -> Généralisation abusive
-    "696": "697",   # Erreur de raisonnement -> Causalité douteuse
-    "798": "833",   # Abus de langage -> Comparaison fallacieuse
-    "887": "888",   # Tricherie -> Arranger les faits
-    "1280": "1360", # Obstruction -> Ad hominem
+    "1": "2",  # Insuffisance -> Argument bâclé
+    "175": "176",  # Influence -> Procédé rhétorique
+    "594": "595",  # Erreur mathématique -> Généralisation abusive
+    "696": "697",  # Erreur de raisonnement -> Causalité douteuse
+    "798": "833",  # Abus de langage -> Comparaison fallacieuse
+    "887": "888",  # Tricherie -> Arranger les faits
+    "1280": "1360",  # Obstruction -> Ad hominem
 }
 
 # Branches to select in Phase 1 for each test scenario.
@@ -76,7 +76,12 @@ class TestFallacyWorkflowCalibration:
     @pytest.fixture
     def workflow_plugin(self, mock_llm_service, mock_kernel):
         """Crée une instance du plugin avec des mocks."""
-        taxonomy_path = Path(project_root_for_test) / "argumentation_analysis" / "data" / "taxonomy_medium.csv"
+        taxonomy_path = (
+            Path(project_root_for_test)
+            / "argumentation_analysis"
+            / "data"
+            / "taxonomy_medium.csv"
+        )
 
         # Create a real Kernel instance with mocked service
         kernel = Kernel()
@@ -99,7 +104,9 @@ class TestFallacyWorkflowCalibration:
         - At least MAX_BRANCHES (4) distinct fallacies are identified.
         - Each detected fallacy has a valid taxonomy PK and navigation trace.
         """
-        result_json = asyncio.run(workflow_plugin.run_guided_analysis(CALIBRATED_TEXT_8_FALLACIES))
+        result_json = asyncio.run(
+            workflow_plugin.run_guided_analysis(CALIBRATED_TEXT_8_FALLACIES)
+        )
 
         result = json.loads(result_json)
 
@@ -114,14 +121,12 @@ class TestFallacyWorkflowCalibration:
 
         # Verify each detected fallacy has a valid taxonomy PK
         for f in detected:
-            assert f.get("taxonomy_pk"), (
-                f"Detected fallacy missing taxonomy_pk: {f}"
-            )
+            assert f.get("taxonomy_pk"), f"Detected fallacy missing taxonomy_pk: {f}"
 
         # Verify exploration method is iterative_deepening (not one-shot fallback)
-        assert result.get("exploration_method") == "iterative_deepening", (
-            f"Expected iterative_deepening, got {result.get('exploration_method')}"
-        )
+        assert (
+            result.get("exploration_method") == "iterative_deepening"
+        ), f"Expected iterative_deepening, got {result.get('exploration_method')}"
 
     def test_epita_text_2_fallacies(self, workflow_plugin):
         """
@@ -139,7 +144,9 @@ class TestFallacyWorkflowCalibration:
 
         result = json.loads(result_json)
 
-        detected_names = [f.get("fallacy_type", "").lower() for f in result.get("fallacies", [])]
+        detected_names = [
+            f.get("fallacy_type", "").lower() for f in result.get("fallacies", [])
+        ]
 
         # Vérifier qu'on a au moins 2 détections (one per branch)
         assert len(result.get("fallacies", [])) >= 2, (
@@ -152,7 +159,9 @@ class TestFallacyWorkflowCalibration:
             "rhétorique" in d or "autorité" in d or "authority" in d
             for d in detected_names
         )
-        assert has_influence, f"Expected Influence branch detection, got: {detected_names}"
+        assert (
+            has_influence
+        ), f"Expected Influence branch detection, got: {detected_names}"
 
         # Vérifier ad hominem
         has_ad_hominem = any("hominem" in d or "attaque" in d for d in detected_names)
@@ -174,9 +183,9 @@ class TestFallacyWorkflowCalibration:
             # Si des sophismes sont détectés, ils doivent avoir une faible confiance
             for f in fallacies:
                 confidence = f.get("confidence", 1.0)
-                assert confidence < 0.5, (
-                    f"False positive detected with high confidence: {f}"
-                )
+                assert (
+                    confidence < 0.5
+                ), f"False positive detected with high confidence: {f}"
 
 
 # Fixtures mock
@@ -259,7 +268,7 @@ def mock_llm_service():
             if "Current position:" in content:
                 # Extract the position name after "Current position:"
                 idx = content.index("Current position:")
-                rest = content[idx + len("Current position:"):].strip()
+                rest = content[idx + len("Current position:") :].strip()
                 # Take the first line
                 return rest.split("\n")[0].strip()
         return ""
@@ -334,20 +343,24 @@ def mock_llm_service():
         text_type = _detect_text(chat_history)
 
         if text_type == "neutral":
-            response_json = json.dumps({
-                "fallacy_name": "none",
-                "taxonomy_pk": "",
-                "explanation": "No fallacy detected",
-                "confidence": 0.1,
-            })
+            response_json = json.dumps(
+                {
+                    "fallacy_name": "none",
+                    "taxonomy_pk": "",
+                    "explanation": "No fallacy detected",
+                    "confidence": 0.1,
+                }
+            )
         else:
             # Generic fallacy detection for one-shot path
-            response_json = json.dumps({
-                "fallacy_name": "Procédé rhétorique",
-                "taxonomy_pk": "176",
-                "explanation": "Rhetorical device detected",
-                "confidence": 0.5,
-            })
+            response_json = json.dumps(
+                {
+                    "fallacy_name": "Procédé rhétorique",
+                    "taxonomy_pk": "176",
+                    "explanation": "Rhetorical device detected",
+                    "confidence": 0.5,
+                }
+            )
 
         mock_response = MagicMock(spec=ChatMessageContent)
         mock_response.__str__ = lambda self: response_json

--- a/tests/unit/argumentation_analysis/plugins/test_fallacy_workflow_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_fallacy_workflow_plugin.py
@@ -655,7 +655,9 @@ class TestFileHandlerDefensiveGuard:
 
         assert len(plugin.logger.handlers) == handler_count_before
 
-    async def test_string_none_no_file_created(self, plugin, mock_llm_service, tmp_path):
+    async def test_string_none_no_file_created(
+        self, plugin, mock_llm_service, tmp_path
+    ):
         """Passing 'None' (string) must not create a file named 'None'."""
         mock_llm_service.get_chat_message_contents.side_effect = RuntimeError("stop")
         mock_llm_service.get_chat_message_content.side_effect = RuntimeError("stop")
@@ -665,6 +667,7 @@ class TestFileHandlerDefensiveGuard:
         none_file = tmp_path / "None"
         # Also check CWD isn't polluted
         import os
+
         assert not os.path.exists("None"), "File named 'None' should not be created"
 
     async def test_empty_string_no_file_created(self, plugin, mock_llm_service):
@@ -697,4 +700,5 @@ class TestFileHandlerDefensiveGuard:
 
         # Handler is removed in finally, but the file should exist
         import os
+
         assert os.path.exists(log_file), "Log file should be created for valid path"

--- a/tests/unit/argumentation_analysis/plugins/test_nl_to_logic_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_nl_to_logic_plugin.py
@@ -46,7 +46,9 @@ class TestNLToLogicPlugin:
             "argumentation_analysis.services.nl_to_logic.NLToLogicTranslator"
         ) as MockTranslator:
             MockTranslator.return_value.translate = AsyncMock(return_value=mock_result)
-            result_str = await plugin.translate_to_pl("If it rains then the ground is wet")
+            result_str = await plugin.translate_to_pl(
+                "If it rains then the ground is wet"
+            )
 
         result = json.loads(result_str)
         assert result["formula"] == "rain => wet"
@@ -134,7 +136,9 @@ class TestNLToLogicPlugin:
         with patch(
             "argumentation_analysis.services.nl_to_logic.NLToLogicTranslator"
         ) as MockTranslator:
-            MockTranslator.return_value.translate_batch = AsyncMock(return_value=mock_batch)
+            MockTranslator.return_value.translate_batch = AsyncMock(
+                return_value=mock_batch
+            )
             result_str = await plugin.translate_batch_to_pl(
                 json.dumps({"arguments": ["arg1", "arg2"]})
             )
@@ -174,7 +178,9 @@ class TestNLToLogicPlugin:
         with patch(
             "argumentation_analysis.services.nl_to_logic.NLToLogicTranslator"
         ) as MockTranslator:
-            MockTranslator.return_value.translate_batch = AsyncMock(return_value=mock_batch)
+            MockTranslator.return_value.translate_batch = AsyncMock(
+                return_value=mock_batch
+            )
             result_str = await plugin.translate_batch_to_fol(
                 json.dumps({"arguments": ["Socrates is human"]})
             )

--- a/tests/unit/argumentation_analysis/reporting/test_enhanced_real_time_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_enhanced_real_time_trace_analyzer.py
@@ -486,7 +486,9 @@ class TestEnhancedRealTimeTraceAnalyzer:
 
     def test_save_report_invalid_path(self, analyzer):
         """Test que save_enhanced_report retourne False si l'écriture échoue."""
-        with patch("builtins.open", side_effect=PermissionError("Cannot write to path")):
+        with patch(
+            "builtins.open", side_effect=PermissionError("Cannot write to path")
+        ):
             result = analyzer.save_enhanced_report("/nonexistent/path/report.md")
         assert result is False
 

--- a/tests/unit/argumentation_analysis/reporting/test_enhanced_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_enhanced_trace_analyzer.py
@@ -501,7 +501,9 @@ class TestEnhancedRealTimeTraceAnalyzer:
         analyzer.start_capture()
         analyzer.start_pm_phase("p1", "Test", ["A"])
         analyzer.stop_capture()
-        with patch("builtins.open", side_effect=PermissionError("Cannot write to path")):
+        with patch(
+            "builtins.open", side_effect=PermissionError("Cannot write to path")
+        ):
             result = analyzer.save_enhanced_report("/nonexistent/path/report.md")
         assert result is False
 

--- a/tests/unit/argumentation_analysis/reporting/test_real_time_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_real_time_trace_analyzer.py
@@ -438,7 +438,9 @@ class TestRealTimeTraceAnalyzer:
 
     def test_save_report_invalid_path(self, analyzer):
         """Test que save_conversation_report retourne False si l'écriture échoue."""
-        with patch("builtins.open", side_effect=PermissionError("Cannot write to path")):
+        with patch(
+            "builtins.open", side_effect=PermissionError("Cannot write to path")
+        ):
             result = analyzer.save_conversation_report("/nonexistent/path/report.md")
         assert result is False
 

--- a/tests/unit/argumentation_analysis/services/test_crypto_service.py
+++ b/tests/unit/argumentation_analysis/services/test_crypto_service.py
@@ -97,7 +97,9 @@ class TestKeyManagement:
 
     def test_save_key_bad_path(self, svc, key):
         """Test que save_key retourne False si l'écriture échoue."""
-        with patch("builtins.open", side_effect=PermissionError("Cannot write to path")):
+        with patch(
+            "builtins.open", side_effect=PermissionError("Cannot write to path")
+        ):
             assert svc.save_key(key, "/nonexistent/path/key.bin") is False
 
     def test_load_key_nonexistent(self, svc):

--- a/tests/unit/argumentation_analysis/services/test_extended_belief.py
+++ b/tests/unit/argumentation_analysis/services/test_extended_belief.py
@@ -10,7 +10,6 @@ from argumentation_analysis.services.jtms.extended_belief import (
 from argumentation_analysis.services.jtms.conflict_resolution import ConflictResolver
 from argumentation_analysis.services.jtms.jtms_core import JTMS, Belief, Justification
 
-
 # ── ExtendedBelief ──────────────────────────────────────────────────
 
 
@@ -166,10 +165,12 @@ class TestConflictResolver:
 
     def test_resolve_by_confidence(self):
         resolver = ConflictResolver()
-        conflict = self._make_conflict({
-            "sherlock": {"belief_name": "hyp_X", "confidence": 0.9},
-            "watson": {"belief_name": "hyp_X", "confidence": 0.3},
-        })
+        conflict = self._make_conflict(
+            {
+                "sherlock": {"belief_name": "hyp_X", "confidence": 0.9},
+                "watson": {"belief_name": "hyp_X", "confidence": 0.3},
+            }
+        )
         result = resolver.resolve(conflict, strategy="confidence_based")
         assert result["resolved"] is True
         assert result["chosen_agent"] == "sherlock"
@@ -177,18 +178,20 @@ class TestConflictResolver:
 
     def test_resolve_by_evidence(self):
         resolver = ConflictResolver()
-        conflict = self._make_conflict({
-            "agent_a": {
-                "belief_name": "b1",
-                "confidence": 0.5,
-                "justification_count": 4,
-            },
-            "agent_b": {
-                "belief_name": "b1",
-                "confidence": 0.9,
-                "justification_count": 1,
-            },
-        })
+        conflict = self._make_conflict(
+            {
+                "agent_a": {
+                    "belief_name": "b1",
+                    "confidence": 0.5,
+                    "justification_count": 4,
+                },
+                "agent_b": {
+                    "belief_name": "b1",
+                    "confidence": 0.9,
+                    "justification_count": 1,
+                },
+            }
+        )
         result = resolver.resolve(conflict, strategy="evidence_based")
         assert result["resolved"] is True
         # agent_a: 4*0.5=2.0, agent_b: 1*0.9=0.9 → agent_a wins
@@ -196,20 +199,24 @@ class TestConflictResolver:
 
     def test_resolve_by_consensus_needs_3_agents(self):
         resolver = ConflictResolver()
-        conflict = self._make_conflict({
-            "a": {"belief_name": "b1", "valid": True},
-            "b": {"belief_name": "b1", "valid": False},
-        })
+        conflict = self._make_conflict(
+            {
+                "a": {"belief_name": "b1", "valid": True},
+                "b": {"belief_name": "b1", "valid": False},
+            }
+        )
         result = resolver.resolve(conflict, strategy="consensus")
         assert result["resolved"] is False
 
     def test_resolve_by_consensus_majority(self):
         resolver = ConflictResolver()
-        conflict = self._make_conflict({
-            "a": {"belief_name": "b1", "valid": True},
-            "b": {"belief_name": "b1", "valid": True},
-            "c": {"belief_name": "b1", "valid": False},
-        })
+        conflict = self._make_conflict(
+            {
+                "a": {"belief_name": "b1", "valid": True},
+                "b": {"belief_name": "b1", "valid": True},
+                "c": {"belief_name": "b1", "valid": False},
+            }
+        )
         result = resolver.resolve(conflict, strategy="consensus")
         assert result["resolved"] is True
 
@@ -230,36 +237,44 @@ class TestConflictResolver:
 
     def test_resolve_by_temporal(self):
         resolver = ConflictResolver()
-        conflict = self._make_conflict({
-            "a": {"belief_name": "b1", "timestamp": "2026-03-25T10:00:00"},
-            "b": {"belief_name": "b1", "timestamp": "2026-03-25T12:00:00"},
-        })
+        conflict = self._make_conflict(
+            {
+                "a": {"belief_name": "b1", "timestamp": "2026-03-25T10:00:00"},
+                "b": {"belief_name": "b1", "timestamp": "2026-03-25T12:00:00"},
+            }
+        )
         result = resolver.resolve(conflict, strategy="temporal")
         assert result["resolved"] is True
         assert result["chosen_agent"] == "b"
 
     def test_invalid_strategy_falls_back(self):
         resolver = ConflictResolver()
-        conflict = self._make_conflict({
-            "a": {"belief_name": "b1", "confidence": 0.5},
-        })
+        conflict = self._make_conflict(
+            {
+                "a": {"belief_name": "b1", "confidence": 0.5},
+            }
+        )
         result = resolver.resolve(conflict, strategy="nonexistent")
         assert result["strategy_used"] == "confidence_based"
 
     def test_resolution_history(self):
         resolver = ConflictResolver()
-        conflict = self._make_conflict({
-            "a": {"belief_name": "b1", "confidence": 0.5},
-        })
+        conflict = self._make_conflict(
+            {
+                "a": {"belief_name": "b1", "confidence": 0.5},
+            }
+        )
         resolver.resolve(conflict)
         resolver.resolve(conflict)
         assert len(resolver.get_history()) == 2
 
     def test_stats(self):
         resolver = ConflictResolver()
-        conflict = self._make_conflict({
-            "a": {"belief_name": "b1", "confidence": 0.5},
-        })
+        conflict = self._make_conflict(
+            {
+                "a": {"belief_name": "b1", "confidence": 0.5},
+            }
+        )
         resolver.resolve(conflict, strategy="confidence_based")
         resolver.resolve(conflict, strategy="evidence_based")
         stats = resolver.get_stats()
@@ -275,21 +290,25 @@ class TestConflictResolver:
 class TestServiceImports:
     def test_import_extended_belief_from_init(self):
         from argumentation_analysis.services.jtms import ExtendedBelief
+
         eb = ExtendedBelief("test")
         assert eb.name == "test"
 
     def test_import_session_from_init(self):
         from argumentation_analysis.services.jtms import JTMSSession
+
         s = JTMSSession("s1", "agent")
         assert s.session_id == "s1"
 
     def test_import_resolver_from_init(self):
         from argumentation_analysis.services.jtms import ConflictResolver
+
         r = ConflictResolver()
         assert len(r.STRATEGIES) == 5
 
     def test_import_core_still_works(self):
         from argumentation_analysis.services.jtms import JTMS, Belief, Justification
+
         jtms = JTMS()
         jtms.add_belief("test")
         assert "test" in jtms.beliefs

--- a/tests/unit/argumentation_analysis/services/test_jtms_conflict_resolution.py
+++ b/tests/unit/argumentation_analysis/services/test_jtms_conflict_resolution.py
@@ -203,7 +203,9 @@ class TestHistoryAndStats:
         assert stats["by_strategy"]["confidence_based"] == 1
 
     def test_auto_conflict_id(self, resolver):
-        result = resolver.resolve({"beliefs": {"a": {"belief_name": "x", "confidence": 0.5}}})
+        result = resolver.resolve(
+            {"beliefs": {"a": {"belief_name": "x", "confidence": 0.5}}}
+        )
         assert "conflict_" in result["conflict_id"]
 
     def test_timestamp_in_result(self, resolver, simple_conflict):

--- a/tests/unit/argumentation_analysis/test_ai_shield.py
+++ b/tests/unit/argumentation_analysis/test_ai_shield.py
@@ -13,9 +13,10 @@ from argumentation_analysis.services.ai_shield.shield import (
     LayerResult,
 )
 from argumentation_analysis.services.ai_shield.layers.heuristic import HeuristicLayer
-from argumentation_analysis.services.ai_shield.layers.output_filter import OutputFilterLayer
+from argumentation_analysis.services.ai_shield.layers.output_filter import (
+    OutputFilterLayer,
+)
 from argumentation_analysis.services.ai_shield.presets import load_preset
-
 
 # ── Heuristic Layer Tests ────────────────────────────────────────────
 
@@ -311,5 +312,7 @@ class TestPresets:
     def test_basic_preset_passes_clean(self):
         """Basic preset passes clean input."""
         shield = load_preset("basic")
-        result = shield.validate_input("Please analyze this argument about climate change")
+        result = shield.validate_input(
+            "Please analyze this argument about climate change"
+        )
         assert result.passed is True

--- a/tests/unit/argumentation_analysis/test_atms_multi_context.py
+++ b/tests/unit/argumentation_analysis/test_atms_multi_context.py
@@ -82,9 +82,7 @@ class TestInvokeAtmsMultiContext:
     def test_at_least_3_contexts_generated(self):
         context = {
             "phase_extract_output": {
-                "arguments": [
-                    {"text": "Arg " + str(i)} for i in range(5)
-                ],
+                "arguments": [{"text": "Arg " + str(i)} for i in range(5)],
                 "claims": [{"text": "Claim"}],
             },
         }
@@ -168,7 +166,9 @@ class TestAtmsStateWriter:
     def test_atms_contexts_stored_in_state(self):
         state = UnifiedAnalysisState("test text")
         output = {
-            "environments": {"node_a": {"is_assumption": True, "environments": [["x"]]}},
+            "environments": {
+                "node_a": {"is_assumption": True, "environments": [["x"]]}
+            },
             "assumption_count": 1,
             "node_count": 2,
             "consistent_derivations": [],

--- a/tests/unit/argumentation_analysis/test_camembert_integration.py
+++ b/tests/unit/argumentation_analysis/test_camembert_integration.py
@@ -9,7 +9,6 @@ import pytest
 from unittest.mock import MagicMock, patch, PropertyMock
 from pathlib import Path
 
-
 # ── CamemBERT label mapping tests ────────────────────────────────────
 
 
@@ -90,7 +89,9 @@ class TestCamemBERTFallacyDetector:
         mock_tokenizer.return_value = {"input_ids": torch.tensor([[1, 2, 3]])}
 
         # Create mock output with logits for class 0 (Ad Hominem) having highest score
-        mock_logits = torch.tensor([[5.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]])
+        mock_logits = torch.tensor(
+            [[5.0, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]]
+        )
         mock_output = MagicMock()
         mock_output.logits = mock_logits
 
@@ -122,7 +123,9 @@ class TestCamemBERTFallacyDetector:
         mock_tokenizer.return_value = {"input_ids": torch.tensor([[1, 2, 3]])}
 
         # Uniform logits → all classes ~0.077 confidence → below 0.99
-        mock_logits = torch.tensor([[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]])
+        mock_logits = torch.tensor(
+            [[1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]]
+        )
         mock_output = MagicMock()
         mock_output.logits = mock_logits
 

--- a/tests/unit/argumentation_analysis/test_collaborative_debate.py
+++ b/tests/unit/argumentation_analysis/test_collaborative_debate.py
@@ -22,7 +22,6 @@ from argumentation_analysis.orchestration.collaborative_debate import (
     build_collaborative_analysis_workflow,
 )
 
-
 # --- Role definitions ---
 
 

--- a/tests/unit/argumentation_analysis/test_fol_constant_predeclaration.py
+++ b/tests/unit/argumentation_analysis/test_fol_constant_predeclaration.py
@@ -18,7 +18,6 @@ from argumentation_analysis.services.nl_to_logic import (
     normalize_operators,
 )
 
-
 # ── _extract_fol_metadata tests ────────────────────────────────────────
 
 
@@ -66,9 +65,7 @@ class TestExtractFolMetadata:
         # But constants are extracted and a default Thing sort is created
         assert "Thing" in metadata["sorts"]
         assert "socrates" in metadata["sorts"]["Thing"]
-        assert metadata["constants_raw"] == {
-            "socrates": "the philosopher Socrates"
-        }
+        assert metadata["constants_raw"] == {"socrates": "the philosopher Socrates"}
 
     def test_no_sorts_creates_default_thing_sort(self):
         """When no sorts declared but constants exist, creates a 'Thing' sort."""
@@ -391,7 +388,10 @@ class TestTranslateWithLLMFolMetadata:
                     )
 
         assert result.is_valid is True
-        assert result.formula == "forall X: (Human(X) => Mortal(X)); Human(socrates); Human(plato)"
+        assert (
+            result.formula
+            == "forall X: (Human(X) => Mortal(X)); Human(socrates); Human(plato)"
+        )
 
         # Verify metadata was extracted and passed
         meta = captured_metadata["fol_metadata"]

--- a/tests/unit/argumentation_analysis/test_jtms_retraction.py
+++ b/tests/unit/argumentation_analysis/test_jtms_retraction.py
@@ -61,7 +61,9 @@ class TestStateManagerJTMSMethods:
 
     def test_jtms_query_beliefs_returns_json(self):
         """jtms_query_beliefs returns valid JSON with belief metadata."""
-        self.plugin.jtms_create_belief("belief_X", agent_source="Agent1", confidence=0.9)
+        self.plugin.jtms_create_belief(
+            "belief_X", agent_source="Agent1", confidence=0.9
+        )
         result = self.plugin.jtms_query_beliefs()
         parsed = json.loads(result)
         assert isinstance(parsed, list)
@@ -143,9 +145,7 @@ class TestStateManagerJTMSMethods:
 
     def test_jtms_retract_no_session(self):
         """jtms_retract_belief returns error when no session exists."""
-        result = self.plugin.jtms_retract_belief(
-            belief_name="anything", reason="test"
-        )
+        result = self.plugin.jtms_retract_belief(belief_name="anything", reason="test")
         assert "FUNC_ERROR" in result
 
     def test_add_belief_set_fol(self):
@@ -182,9 +182,7 @@ class TestRetractFallaciousBeliefs:
 
     def setup_method(self):
         self.state = RhetoricalAnalysisState("Test text")
-        self.session = JTMSSession(
-            session_id="test_jtms", owner_agent="test"
-        )
+        self.session = JTMSSession(session_id="test_jtms", owner_agent="test")
         self.state._jtms_session = self.session
 
     def test_retract_matching_fallacy(self):

--- a/tests/unit/argumentation_analysis/test_llm_fallacy_detector.py
+++ b/tests/unit/argumentation_analysis/test_llm_fallacy_detector.py
@@ -6,6 +6,7 @@ Verifies that:
 3. Respects confidence threshold
 4. FrenchFallacyAdapter defaults to CamemBERT disabled
 """
+
 import json
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -18,6 +19,7 @@ class TestLLMFallacyDetector:
         from argumentation_analysis.adapters.french_fallacy_adapter import (
             LLMFallacyDetector,
         )
+
         return LLMFallacyDetector(confidence_threshold=0.4)
 
     def test_is_available_with_api_key(self):
@@ -40,22 +42,24 @@ class TestLLMFallacyDetector:
             LLMFallacyDetector,
         )
 
-        llm_response = json.dumps({
-            "fallacies": [
-                {
-                    "type": "Argument d'autorite (Appeal to Authority)",
-                    "confidence": 0.85,
-                    "explanation": "Utilise une autorite non pertinente",
-                    "target_text": "Elon Musk a dit que",
-                },
-                {
-                    "type": "Generalisation hative (Hasty Generalization)",
-                    "confidence": 0.3,  # below threshold
-                    "explanation": "Pas assez d'exemples",
-                    "target_text": "Tous les...",
-                },
-            ]
-        })
+        llm_response = json.dumps(
+            {
+                "fallacies": [
+                    {
+                        "type": "Argument d'autorite (Appeal to Authority)",
+                        "confidence": 0.85,
+                        "explanation": "Utilise une autorite non pertinente",
+                        "target_text": "Elon Musk a dit que",
+                    },
+                    {
+                        "type": "Generalisation hative (Hasty Generalization)",
+                        "confidence": 0.3,  # below threshold
+                        "explanation": "Pas assez d'exemples",
+                        "target_text": "Tous les...",
+                    },
+                ]
+            }
+        )
 
         mock_message = MagicMock()
         mock_message.content = llm_response
@@ -72,7 +76,9 @@ class TestLLMFallacyDetector:
         with patch.object(
             detector, "_get_openai_client", return_value=(mock_client, "gpt-5-mini")
         ):
-            result = await detector.detect_async("L'IA est dangereuse car Elon Musk l'a dit.")
+            result = await detector.detect_async(
+                "L'IA est dangereuse car Elon Musk l'a dit."
+            )
 
         # First fallacy above threshold
         assert len(result) == 1

--- a/tests/unit/argumentation_analysis/test_narrative_synthesis.py
+++ b/tests/unit/argumentation_analysis/test_narrative_synthesis.py
@@ -41,7 +41,12 @@ def _rich_state() -> UnifiedAnalysisState:
     state.add_jtms_belief("premise_A", True, justifications=[])
     state.add_jtms_belief("premise_B", False, justifications=["retracted"])
     state.jtms_retraction_chain = [
-        {"trigger": "premise_B", "retracted": ["premise_B"], "cascaded": ["claim_X"], "reason": "inconsistency"}
+        {
+            "trigger": "premise_B",
+            "retracted": ["premise_B"],
+            "cascaded": ["claim_X"],
+            "reason": "inconsistency",
+        }
     ]
 
     # ATMS
@@ -52,7 +57,10 @@ def _rich_state() -> UnifiedAnalysisState:
 
     # Dung
     state.dung_frameworks = {
-        "framework_1": {"extensions": [["arg_1"], ["arg_2"]], "attacks": [["arg_1", "arg_2"]]}
+        "framework_1": {
+            "extensions": [["arg_1"], ["arg_2"]],
+            "attacks": [["arg_1", "arg_2"]],
+        }
     }
 
     # Formal logic
@@ -99,8 +107,19 @@ class TestBuildNarrative:
     def test_at_least_5_distinct_references(self):
         state = _rich_state()
         result = build_narrative(state)
-        keywords = ["qualite", "sophisme", "croyance", "hypothese", "contre-argument",
-                     "dung", "logique", "jtms", "atms", "retraction", "extension"]
+        keywords = [
+            "qualite",
+            "sophisme",
+            "croyance",
+            "hypothese",
+            "contre-argument",
+            "dung",
+            "logique",
+            "jtms",
+            "atms",
+            "retraction",
+            "extension",
+        ]
         found = sum(1 for kw in keywords if kw in result.lower())
         assert found >= 5, f"Only {found} references found in: {result[:200]}"
 
@@ -139,6 +158,7 @@ class TestNarrativeSynthesisPlugin:
     def test_plugin_synthesize(self):
         plugin = NarrativeSynthesisPlugin()
         import json
+
         state_dict = {
             "argument_quality_scores": {"arg_1": {"overall": 3.5}},
             "identified_fallacies": {"f_1": {"type": "ad_hominem"}},

--- a/tests/unit/argumentation_analysis/test_nl_to_logic.py
+++ b/tests/unit/argumentation_analysis/test_nl_to_logic.py
@@ -9,7 +9,6 @@ import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 # ── Service unit tests ───────────────────────────────────────────────────
 
 
@@ -272,9 +271,7 @@ class TestNLToLogicPipelineIntegration:
         registry = setup_registry(include_optional=False)
         # Check capability exists
         found = registry.find_agents_for_capability("nl_to_logic_translation")
-        assert found or "nl_to_logic_service" in str(
-            registry._registrations.keys()
-        )
+        assert found or "nl_to_logic_service" in str(registry._registrations.keys())
 
     def test_state_writer_in_dict(self):
         """nl_to_logic_translation has a state writer."""
@@ -362,7 +359,9 @@ class TestNLToLogicPipelineIntegration:
             "phase_extract_output": {
                 "arguments": [
                     {"text": "Rain causes wet ground and dangerous conditions."},
-                    {"text": "Climate change accelerates extreme weather events globally."},
+                    {
+                        "text": "Climate change accelerates extreme weather events globally."
+                    },
                 ],
             },
         }

--- a/tests/unit/argumentation_analysis/test_open_domain_investigation.py
+++ b/tests/unit/argumentation_analysis/test_open_domain_investigation.py
@@ -37,36 +37,85 @@ SAMPLE_DISCOURSE = (
 
 MOCK_INVESTIGATION = InvestigationResult(
     trace=[
-        {"step": 1, "phase": "extraction", "agent": "ExtractAgent",
-         "findings": {"claims_found": 2, "arguments_found": 1}, "conclusion": "Found 2 claims"},
-        {"step": 2, "phase": "fallacy_detection", "agent": "InformalAnalysisAgent",
-         "findings": {"fallacy_count": 2, "types": ["ad_hominem", "generalisation_hative"]},
-         "conclusion": "Detected 2 fallacies"},
-        {"step": 3, "phase": "quality_evaluation", "agent": "QualityScoringPlugin",
-         "findings": {"overall_score": 3.5, "arguments_evaluated": 2}, "conclusion": "Score 3.5/10"},
-        {"step": 4, "phase": "cross_examination", "agent": "CounterArgumentAgent",
-         "findings": {"counter_arguments": 1, "strategy": "reductio"},
-         "conclusion": "Cross-exam produced 1 counter"},
-        {"step": 5, "phase": "belief_tracking", "agent": "JTMS",
-         "findings": {"beliefs_total": 3, "beliefs_valid": 2, "beliefs_invalid": 1},
-         "conclusion": "3 beliefs, 1 retracted"},
-        {"step": 6, "phase": "hypothesis_branching", "agent": "ATMS",
-         "findings": {"hypotheses_tested": 2, "coherent": 1, "incoherent": 1},
-         "conclusion": "1 coherent, 1 incoherent"},
-        {"step": 7, "phase": "solution_synthesis", "agent": "NarrativeSynthesisPlugin",
-         "findings": {"paragraph_count": 1}, "conclusion": "Synthesis complete"},
+        {
+            "step": 1,
+            "phase": "extraction",
+            "agent": "ExtractAgent",
+            "findings": {"claims_found": 2, "arguments_found": 1},
+            "conclusion": "Found 2 claims",
+        },
+        {
+            "step": 2,
+            "phase": "fallacy_detection",
+            "agent": "InformalAnalysisAgent",
+            "findings": {
+                "fallacy_count": 2,
+                "types": ["ad_hominem", "generalisation_hative"],
+            },
+            "conclusion": "Detected 2 fallacies",
+        },
+        {
+            "step": 3,
+            "phase": "quality_evaluation",
+            "agent": "QualityScoringPlugin",
+            "findings": {"overall_score": 3.5, "arguments_evaluated": 2},
+            "conclusion": "Score 3.5/10",
+        },
+        {
+            "step": 4,
+            "phase": "cross_examination",
+            "agent": "CounterArgumentAgent",
+            "findings": {"counter_arguments": 1, "strategy": "reductio"},
+            "conclusion": "Cross-exam produced 1 counter",
+        },
+        {
+            "step": 5,
+            "phase": "belief_tracking",
+            "agent": "JTMS",
+            "findings": {"beliefs_total": 3, "beliefs_valid": 2, "beliefs_invalid": 1},
+            "conclusion": "3 beliefs, 1 retracted",
+        },
+        {
+            "step": 6,
+            "phase": "hypothesis_branching",
+            "agent": "ATMS",
+            "findings": {"hypotheses_tested": 2, "coherent": 1, "incoherent": 1},
+            "conclusion": "1 coherent, 1 incoherent",
+        },
+        {
+            "step": 7,
+            "phase": "solution_synthesis",
+            "agent": "NarrativeSynthesisPlugin",
+            "findings": {"paragraph_count": 1},
+            "conclusion": "Synthesis complete",
+        },
     ],
     reasoning_chain=[
-        "Found 2 claims", "Detected 2 fallacies", "Score 3.5/10",
-        "Cross-exam produced 1 counter", "3 beliefs, 1 retracted",
-        "1 coherent, 1 incoherent", "Synthesis complete",
+        "Found 2 claims",
+        "Detected 2 fallacies",
+        "Score 3.5/10",
+        "Cross-exam produced 1 counter",
+        "3 beliefs, 1 retracted",
+        "1 coherent, 1 incoherent",
+        "Synthesis complete",
     ],
-    agents_used=["ExtractAgent", "InformalAnalysisAgent", "QualityScoringPlugin",
-                  "CounterArgumentAgent", "JTMS", "ATMS", "NarrativeSynthesisPlugin"],
+    agents_used=[
+        "ExtractAgent",
+        "InformalAnalysisAgent",
+        "QualityScoringPlugin",
+        "CounterArgumentAgent",
+        "JTMS",
+        "ATMS",
+        "NarrativeSynthesisPlugin",
+    ],
     agent_count=7,
     hypotheses=[
         {"id": "h_full_trust", "coherent": True, "assumptions": ["trust_all_sources"]},
-        {"id": "h_skeptical", "coherent": False, "assumptions": ["doubt_fallacious_sources"]},
+        {
+            "id": "h_skeptical",
+            "coherent": False,
+            "assumptions": ["doubt_fallacious_sources"],
+        },
     ],
     solution="Investigation summary: multiple fallacies detected under full trust hypothesis.",
 )
@@ -85,7 +134,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_A"))
@@ -95,7 +145,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_B"))
@@ -105,7 +156,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document(SAMPLE_DISCOURSE))
@@ -115,7 +167,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_A"))
@@ -126,7 +179,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_A"))
@@ -136,7 +190,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document(SAMPLE_DISCOURSE))
@@ -148,7 +203,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             _run(inv.investigate_document(SAMPLE_DISCOURSE))
@@ -160,7 +216,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             _run(inv.investigate_document(SAMPLE_DISCOURSE))
             assert inv.state is state
@@ -169,7 +226,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_X"))
@@ -180,7 +238,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document(SAMPLE_DISCOURSE))
@@ -193,7 +252,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_A"))
@@ -202,23 +262,32 @@ class TestOpenDomainInvestigator:
 
     def test_empty_state_fallback(self):
         empty_result = InvestigationResult(
-            trace=[], reasoning_chain=[], agents_used=[], agent_count=0,
-            hypotheses=[], solution="",
+            trace=[],
+            reasoning_chain=[],
+            agents_used=[],
+            agent_count=0,
+            hypotheses=[],
+            solution="",
         )
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=empty_result,
+            new_callable=AsyncMock,
+            return_value=empty_result,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document("empty", "doc_C"))
-            assert "insufficient" in result.conclusion.lower() or "partial" in result.conclusion.lower()
+            assert (
+                "insufficient" in result.conclusion.lower()
+                or "partial" in result.conclusion.lower()
+            )
 
     def test_claims_analyzed_count(self):
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document(SAMPLE_DISCOURSE))
@@ -229,7 +298,8 @@ class TestOpenDomainInvestigator:
         with patch(
             "argumentation_analysis.orchestration.sherlock_modern_orchestrator"
             ".SherlockModernOrchestrator.investigate",
-            new_callable=AsyncMock, return_value=MOCK_INVESTIGATION,
+            new_callable=AsyncMock,
+            return_value=MOCK_INVESTIGATION,
         ):
             inv = _mocked_investigator()
             result = _run(inv.investigate_document(SAMPLE_DISCOURSE, "doc_A"))
@@ -243,8 +313,11 @@ class TestAttribution:
 
     def test_creation(self):
         attr = Attribution(
-            claim="test claim", attribution="Author claims X",
-            hypothesis_id="h1", coherent=True, confidence=0.8,
+            claim="test claim",
+            attribution="Author claims X",
+            hypothesis_id="h1",
+            coherent=True,
+            confidence=0.8,
         )
         assert attr.claim == "test claim"
         assert attr.coherent is True
@@ -252,8 +325,10 @@ class TestAttribution:
 
     def test_defaults(self):
         attr = Attribution(
-            claim="test", attribution="test",
-            hypothesis_id="h1", coherent=False,
+            claim="test",
+            attribution="test",
+            hypothesis_id="h1",
+            coherent=False,
         )
         assert attr.confidence == 0.0
 
@@ -263,6 +338,7 @@ class TestDemoScript:
 
     def test_demo_file_exists(self):
         from pathlib import Path
+
         demo_path = Path(
             "examples/02_core_system_demos/scripts_demonstration"
             "/demo_sherlock_investigation.py"
@@ -271,6 +347,7 @@ class TestDemoScript:
 
     def test_demo_has_run_function(self):
         import importlib.util
+
         spec = importlib.util.spec_from_file_location(
             "demo_sherlock",
             "examples/02_core_system_demos/scripts_demonstration"

--- a/tests/unit/argumentation_analysis/test_plugin_per_agent.py
+++ b/tests/unit/argumentation_analysis/test_plugin_per_agent.py
@@ -21,7 +21,6 @@ from argumentation_analysis.agents.factory import (
     load_plugins_for_agent,
 )
 
-
 # --- Plugin map structure ---
 
 

--- a/tests/unit/argumentation_analysis/test_rich_output_formatter.py
+++ b/tests/unit/argumentation_analysis/test_rich_output_formatter.py
@@ -16,8 +16,8 @@ from argumentation_analysis.cli.output_formatter import (
     SECTIONS,
 )
 
-
 # ── Fixtures ──
+
 
 @pytest.fixture
 def sample_result():
@@ -25,7 +25,10 @@ def sample_result():
     return {
         "workflow_name": "standard",
         "state_snapshot": {
-            "identified_arguments": {"arg1": "All men are mortal", "arg2": "Socrates is a man"},
+            "identified_arguments": {
+                "arg1": "All men are mortal",
+                "arg2": "Socrates is a man",
+            },
             "extracts": [{"claim": "claim1"}, {"claim": "claim2"}],
             "fol_analysis_results": [{"formula": "∀x Man(x)→Mortal(x)"}],
             "propositional_analysis_results": [{"formula": "P → Q"}],
@@ -33,7 +36,10 @@ def sample_result():
             "nl_to_logic_translations": [{"source": "text", "logic": "P→Q"}],
             "identified_fallacies": {
                 "f1": {"type": "ad_hominem", "justification": "Attacks the person"},
-                "f2": {"type": "straw_man", "justification": "Misrepresents the argument"},
+                "f2": {
+                    "type": "straw_man",
+                    "justification": "Misrepresents the argument",
+                },
             },
             "neural_fallacy_scores": [{"fallacy": "ad_hominem", "score": 0.85}],
             "jtms_beliefs": {
@@ -47,7 +53,9 @@ def sample_result():
             "counter_arguments": [
                 {"strategy": "reductio", "counter_content": "If P then contradiction"},
             ],
-            "debate_transcripts": [{"round": 1, "proponent": "arg1", "opponent": "counter1"}],
+            "debate_transcripts": [
+                {"round": 1, "proponent": "arg1", "opponent": "counter1"}
+            ],
             "governance_decisions": [{"method": "majority", "result": "accepted"}],
             "argument_quality_scores": {
                 "arg1": {"overall": 0.85},
@@ -71,6 +79,7 @@ def empty_result():
 
 
 # ── Helper function tests ──
+
 
 class TestSectionRef:
     def test_valid_section_numbers(self):
@@ -112,6 +121,7 @@ class TestCountNonEmpty:
 
 # ── Plain renderer tests ──
 
+
 class TestRenderPlain:
     def test_renders_without_error(self, sample_result, capsys):
         _render_plain(sample_result)
@@ -126,6 +136,7 @@ class TestRenderPlain:
 
 
 # ── Rich renderer tests ──
+
 
 class TestRenderSpectacularResult:
     def test_rich_render_with_mock_console(self, sample_result):
@@ -178,9 +189,11 @@ class TestRenderStateSnapshot:
 
 # ── Individual section renderer tests ──
 
+
 class TestSectionRenderers:
     def test_extraction_section(self):
         from argumentation_analysis.cli.output_formatter import _render_extraction
+
         console = MagicMock()
         state = {"identified_arguments": {"a1": "test arg"}}
         _render_extraction(console, state)
@@ -188,12 +201,14 @@ class TestSectionRenderers:
 
     def test_extraction_empty(self):
         from argumentation_analysis.cli.output_formatter import _render_extraction
+
         console = MagicMock()
         _render_extraction(console, {})
         assert console.print.call_count == 0
 
     def test_formal_logic_section(self):
         from argumentation_analysis.cli.output_formatter import _render_formal_logic
+
         console = MagicMock()
         state = {"fol_analysis_results": [{"formula": "∀x P(x)"}]}
         _render_formal_logic(console, state)
@@ -201,6 +216,7 @@ class TestSectionRenderers:
 
     def test_fallacies_section(self):
         from argumentation_analysis.cli.output_formatter import _render_fallacies
+
         console = MagicMock()
         state = {
             "identified_fallacies": {
@@ -212,6 +228,7 @@ class TestSectionRenderers:
 
     def test_jtms_section(self):
         from argumentation_analysis.cli.output_formatter import _render_jtms
+
         console = MagicMock()
         state = {
             "jtms_beliefs": {
@@ -224,6 +241,7 @@ class TestSectionRenderers:
 
     def test_dung_section(self):
         from argumentation_analysis.cli.output_formatter import _render_dung
+
         console = MagicMock()
         state = {
             "dung_frameworks": {
@@ -234,7 +252,10 @@ class TestSectionRenderers:
         assert console.print.call_count >= 1
 
     def test_counter_arguments_section(self):
-        from argumentation_analysis.cli.output_formatter import _render_counter_arguments
+        from argumentation_analysis.cli.output_formatter import (
+            _render_counter_arguments,
+        )
+
         console = MagicMock()
         state = {
             "counter_arguments": [{"strategy": "reductio", "counter_content": "test"}]
@@ -244,6 +265,7 @@ class TestSectionRenderers:
 
     def test_debate_section(self):
         from argumentation_analysis.cli.output_formatter import _render_debate
+
         console = MagicMock()
         state = {
             "debate_transcripts": [{"round": 1}],
@@ -254,15 +276,15 @@ class TestSectionRenderers:
 
     def test_quality_section(self):
         from argumentation_analysis.cli.output_formatter import _render_quality
+
         console = MagicMock()
-        state = {
-            "argument_quality_scores": {"arg1": {"overall": 0.85}}
-        }
+        state = {"argument_quality_scores": {"arg1": {"overall": 0.85}}}
         _render_quality(console, state)
         assert console.print.call_count >= 1
 
     def test_narrative_section(self):
         from argumentation_analysis.cli.output_formatter import _render_narrative
+
         console = MagicMock()
         state = {"final_conclusion": "The argument is sound."}
         result = {"state_snapshot": state}
@@ -271,6 +293,7 @@ class TestSectionRenderers:
 
     def test_narrative_with_cross_refs(self):
         from argumentation_analysis.cli.output_formatter import _render_narrative
+
         console = MagicMock()
         state = {
             "final_conclusion": "Conclusion here",
@@ -287,6 +310,7 @@ class TestSectionRenderers:
 
 # ── Cross-reference tests ──
 
+
 class TestCrossReferences:
     def test_sections_list_complete(self):
         assert len(SECTIONS) == 10
@@ -297,9 +321,8 @@ class TestCrossReferences:
         """Quality section should cross-ref to fallacies (#3)."""
         console = MagicMock()
         from argumentation_analysis.cli.output_formatter import _render_quality
-        state = {
-            "argument_quality_scores": {"arg1": {"overall": 0.5}}
-        }
+
+        state = {"argument_quality_scores": {"arg1": {"overall": 0.5}}}
         _render_quality(console, state)
         printed = str(console.print.call_args_list)
         assert "Section 3" in printed

--- a/tests/unit/argumentation_analysis/test_semantic_index_chunking.py
+++ b/tests/unit/argumentation_analysis/test_semantic_index_chunking.py
@@ -20,11 +20,20 @@ class TestChunkByArguments:
         """Arguments from fact_extraction are chunked individually."""
         extraction = {
             "arguments": [
-                {"text": "The climate is changing due to CO2 emissions", "source_quote": "para 2"},
-                {"text": "Renewable energy reduces carbon footprint", "source_quote": "para 5"},
+                {
+                    "text": "The climate is changing due to CO2 emissions",
+                    "source_quote": "para 2",
+                },
+                {
+                    "text": "Renewable energy reduces carbon footprint",
+                    "source_quote": "para 5",
+                },
             ],
             "claims": [
-                {"text": "We should invest in solar power", "source_quote": "conclusion"},
+                {
+                    "text": "We should invest in solar power",
+                    "source_quote": "conclusion",
+                },
             ],
         }
         chunks = SemanticIndexService.chunk_by_arguments("raw text", extraction)
@@ -62,7 +71,10 @@ class TestChunkByArguments:
             uploaded.append(1) or f"doc_{len(uploaded)}"
         )
         doc_ids = service.index_arguments(
-            arguments=[{"text": "ok"}, {"text": "This is long enough to be a real argument"}],
+            arguments=[
+                {"text": "ok"},
+                {"text": "This is long enough to be a real argument"},
+            ],
             source_name="test",
         )
         # Only the long argument gets indexed (short ones skipped)

--- a/tests/unit/argumentation_analysis/test_shared_state_cross_ref.py
+++ b/tests/unit/argumentation_analysis/test_shared_state_cross_ref.py
@@ -17,8 +17,12 @@ def _make_state() -> UnifiedAnalysisState:
     a3 = state.add_argument("Climate change requires immediate policy action")
 
     # 2 fallacies targeting arg_1 and arg_2
-    state.add_fallacy("Ad Hominem", "Attacks the source not the claim", target_arg_id=a1)
-    state.add_fallacy("Straw Man", "Misrepresents the original position", target_arg_id=a2)
+    state.add_fallacy(
+        "Ad Hominem", "Attacks the source not the claim", target_arg_id=a1
+    )
+    state.add_fallacy(
+        "Straw Man", "Misrepresents the original position", target_arg_id=a2
+    )
 
     # Quality scores for all 3 (arg_1 weak, arg_2 medium, arg_3 strong)
     state.add_quality_score(a1, {"clarity": 3.0, "relevance": 4.0}, overall=3.5)

--- a/tests/unit/argumentation_analysis/test_sherlock_atms_branching.py
+++ b/tests/unit/argumentation_analysis/test_sherlock_atms_branching.py
@@ -170,8 +170,11 @@ class TestHypothesisDataclass:
 
     def test_with_values(self):
         hyp = Hypothesis(
-            id="h1", name="Test", assumptions=["a", "b"],
-            description="desc", coherent=False,
+            id="h1",
+            name="Test",
+            assumptions=["a", "b"],
+            description="desc",
+            coherent=False,
             retraction_reason="contradicted",
         )
         assert hyp.coherent is False

--- a/tests/unit/argumentation_analysis/test_sherlock_modern_orchestrator.py
+++ b/tests/unit/argumentation_analysis/test_sherlock_modern_orchestrator.py
@@ -46,27 +46,39 @@ class TestSherlockModernOrchestrator:
     def test_uses_at_least_5_agents(self):
         orch = SherlockModernOrchestrator()
         result = _run(orch.investigate(SAMPLE_DISCOURSE))
-        assert result.agent_count >= 5, (
-            f"Expected >= 5 agents, got {result.agent_count}: {result.agents_used}"
-        )
+        assert (
+            result.agent_count >= 5
+        ), f"Expected >= 5 agents, got {result.agent_count}: {result.agents_used}"
 
     def test_agents_include_required_types(self):
         orch = SherlockModernOrchestrator()
         result = _run(orch.investigate(SAMPLE_DISCOURSE))
         agents_lower = [a.lower() for a in result.agents_used]
-        assert any("extract" in a for a in agents_lower), f"Missing ExtractAgent in {result.agents_used}"
-        assert any("fallacy" in a or "informal" in a for a in agents_lower), f"Missing fallacy agent in {result.agents_used}"
-        assert any("quality" in a for a in agents_lower), f"Missing quality agent in {result.agents_used}"
-        assert any("counter" in a for a in agents_lower), f"Missing counter-arg agent in {result.agents_used}"
-        assert any("jtms" in a for a in agents_lower), f"Missing JTMS in {result.agents_used}"
-        assert any("atms" in a for a in agents_lower), f"Missing ATMS in {result.agents_used}"
+        assert any(
+            "extract" in a for a in agents_lower
+        ), f"Missing ExtractAgent in {result.agents_used}"
+        assert any(
+            "fallacy" in a or "informal" in a for a in agents_lower
+        ), f"Missing fallacy agent in {result.agents_used}"
+        assert any(
+            "quality" in a for a in agents_lower
+        ), f"Missing quality agent in {result.agents_used}"
+        assert any(
+            "counter" in a for a in agents_lower
+        ), f"Missing counter-arg agent in {result.agents_used}"
+        assert any(
+            "jtms" in a for a in agents_lower
+        ), f"Missing JTMS in {result.agents_used}"
+        assert any(
+            "atms" in a for a in agents_lower
+        ), f"Missing ATMS in {result.agents_used}"
 
     def test_trace_has_7_steps(self):
         orch = SherlockModernOrchestrator()
         result = _run(orch.investigate(SAMPLE_DISCOURSE))
-        assert len(result.trace) >= 7, (
-            f"Expected >= 7 trace steps, got {len(result.trace)}"
-        )
+        assert (
+            len(result.trace) >= 7
+        ), f"Expected >= 7 trace steps, got {len(result.trace)}"
 
     def test_trace_steps_have_required_fields(self):
         orch = SherlockModernOrchestrator()
@@ -83,9 +95,13 @@ class TestSherlockModernOrchestrator:
         result = _run(orch.investigate(SAMPLE_DISCOURSE))
         phases = [s["phase"] for s in result.trace]
         expected = [
-            "extraction", "fallacy_detection", "quality_evaluation",
-            "cross_examination", "belief_tracking",
-            "hypothesis_branching", "solution_synthesis",
+            "extraction",
+            "fallacy_detection",
+            "quality_evaluation",
+            "cross_examination",
+            "belief_tracking",
+            "hypothesis_branching",
+            "solution_synthesis",
         ]
         for expected_phase in expected:
             assert expected_phase in phases, f"Missing phase: {expected_phase}"
@@ -135,6 +151,7 @@ class TestSherlockModernOrchestrator:
             ".SherlockModernOrchestrator._invoke_safe",
             new_callable=AsyncMock,
         ) as mock_invoke:
+
             async def fake_invoke(func_name, text, fallback):
                 return dict(fallback)
 
@@ -172,8 +189,11 @@ class TestInvestigationStep:
 
     def test_creation(self):
         step = InvestigationStep(
-            step=1, phase="test", agent="Agent",
-            findings={"k": "v"}, conclusion="test conclusion",
+            step=1,
+            phase="test",
+            agent="Agent",
+            findings={"k": "v"},
+            conclusion="test conclusion",
         )
         assert step.step == 1
         assert step.phase == "test"

--- a/tests/unit/argumentation_analysis/test_sherlock_scenarios.py
+++ b/tests/unit/argumentation_analysis/test_sherlock_scenarios.py
@@ -27,12 +27,18 @@ MOCK_RESULT = OpenDomainResult(
     claims_analyzed=3,
     attributions=[
         Attribution(
-            claim="test", attribution="Author supported under h_trust",
-            hypothesis_id="h_trust", coherent=True, confidence=0.8,
+            claim="test",
+            attribution="Author supported under h_trust",
+            hypothesis_id="h_trust",
+            coherent=True,
+            confidence=0.8,
         ),
         Attribution(
-            claim="test", attribution="Author undermined under h_skeptical",
-            hypothesis_id="h_skeptical", coherent=False, confidence=0.3,
+            claim="test",
+            attribution="Author undermined under h_skeptical",
+            hypothesis_id="h_skeptical",
+            coherent=False,
+            confidence=0.3,
         ),
     ],
     hypothesis_summary={
@@ -53,18 +59,19 @@ class TestScenarioRunner:
 
     def test_scenario_file_exists(self):
         from pathlib import Path
-        path = Path(
-            "examples/03_demos_overflow/sherlock_modern/run_scenarios.py"
-        )
+
+        path = Path("examples/03_demos_overflow/sherlock_modern/run_scenarios.py")
         assert path.exists()
 
     def test_scenarios_doc_exists(self):
         from pathlib import Path
+
         path = Path("docs/sherlock/scenarios.md")
         assert path.exists()
 
     def test_scenario_definitions_valid(self):
         import importlib.util
+
         spec = importlib.util.spec_from_file_location(
             "run_scenarios",
             "examples/03_demos_overflow/sherlock_modern/run_scenarios.py",
@@ -82,6 +89,7 @@ class TestScenarioRunner:
     def test_opaque_ids_no_plaintext(self):
         """Scenarios use opaque IDs, never source names."""
         import importlib.util
+
         spec = importlib.util.spec_from_file_location(
             "run_scenarios",
             "examples/03_demos_overflow/sherlock_modern/run_scenarios.py",
@@ -92,12 +100,13 @@ class TestScenarioRunner:
         sensitive_patterns = ["full_text", "raw_text", "speaker", "author"]
         scenario_text = str(mod.SCENARIOS)
         for pattern in sensitive_patterns:
-            assert pattern not in scenario_text.lower() or pattern == "author", (
-                f"Sensitive pattern '{pattern}' found in scenario definitions"
-            )
+            assert (
+                pattern not in scenario_text.lower() or pattern == "author"
+            ), f"Sensitive pattern '{pattern}' found in scenario definitions"
 
     def test_run_scenario_returns_result(self):
         import importlib.util
+
         spec = importlib.util.spec_from_file_location(
             "run_scenarios",
             "examples/03_demos_overflow/sherlock_modern/run_scenarios.py",
@@ -110,8 +119,14 @@ class TestScenarioRunner:
             ".SherlockModernOrchestrator.investigate",
             new_callable=AsyncMock,
             return_value=InvestigationResult(
-                trace=[{"step": 1, "phase": "extraction", "findings": {"claims_found": 2},
-                       "conclusion": "Found claims"}],
+                trace=[
+                    {
+                        "step": 1,
+                        "phase": "extraction",
+                        "findings": {"claims_found": 2},
+                        "conclusion": "Found claims",
+                    }
+                ],
                 reasoning_chain=["Found claims"],
                 agents_used=["ExtractAgent"],
                 agent_count=1,
@@ -130,6 +145,7 @@ class TestScenarioPrivacy:
     def test_no_plaintext_in_docs(self):
         """Scenarios doc uses only opaque IDs."""
         from pathlib import Path
+
         content = Path("docs/sherlock/scenarios.md").read_text(encoding="utf-8")
         assert "doc_A" in content
         assert "doc_B" in content

--- a/tests/unit/argumentation_analysis/visualization/test_html_report.py
+++ b/tests/unit/argumentation_analysis/visualization/test_html_report.py
@@ -5,7 +5,13 @@ import pathlib
 
 import pytest
 
-FIXTURE_PATH = pathlib.Path(__file__).parent.parent.parent.parent / "golden" / "fixtures" / "spectacular" / "doc_a_golden.json"
+FIXTURE_PATH = (
+    pathlib.Path(__file__).parent.parent.parent.parent
+    / "golden"
+    / "fixtures"
+    / "spectacular"
+    / "doc_a_golden.json"
+)
 
 
 @pytest.fixture
@@ -164,14 +170,32 @@ class TestHTMLReport:
                 "debate": {"straw_man": 0.4, "false_dilemma": 0.6},
             },
             "asymmetry": {
-                "propaganda": {"tricherie_share": 0.2, "influence_share": 0.8, "asymmetry": 0.6},
-                "debate": {"tricherie_share": 0.5, "influence_share": 0.5, "asymmetry": 0.0},
+                "propaganda": {
+                    "tricherie_share": 0.2,
+                    "influence_share": 0.8,
+                    "asymmetry": 0.6,
+                },
+                "debate": {
+                    "tricherie_share": 0.5,
+                    "influence_share": 0.5,
+                    "asymmetry": 0.0,
+                },
             },
             "cooccurrence_pairs": [
-                {"a": "ad_hominem", "b": "appeal_to_fear", "support": 5, "lift": 2.3, "jaccard": 0.45},
+                {
+                    "a": "ad_hominem",
+                    "b": "appeal_to_fear",
+                    "support": 5,
+                    "lift": 2.3,
+                    "jaccard": 0.45,
+                },
             ],
             "cross_coverage": {
-                "ad_hominem": {"fol_invalid": 0.0, "dung_unsupported": 1.0, "jtms_retraction": 0.0},
+                "ad_hominem": {
+                    "fol_invalid": 0.0,
+                    "dung_unsupported": 1.0,
+                    "jtms_retraction": 0.0,
+                },
             },
         }
         html = render_html_report(golden_state, pattern_data=pattern)

--- a/tests/unit/examples/test_demonstration_epita_spectacular.py
+++ b/tests/unit/examples/test_demonstration_epita_spectacular.py
@@ -1,4 +1,5 @@
 """Smoke tests for demonstration_epita_spectacular.py — #361"""
+
 import json
 import subprocess
 import sys
@@ -29,8 +30,14 @@ class TestDemonstrationSpectacular:
     def test_full_demo_contains_all_steps(self):
         r = _run(["--quiet"])
         output = r.stdout
-        for step_name in ("Extraction & Claims", "Formal Logic", "Fallacy Detection",
-                          "Argumentation Frameworks", "Adversarial Debate", "Unified Synthesis"):
+        for step_name in (
+            "Extraction & Claims",
+            "Formal Logic",
+            "Fallacy Detection",
+            "Argumentation Frameworks",
+            "Adversarial Debate",
+            "Unified Synthesis",
+        ):
             assert step_name in output, f"Missing step: {step_name}"
 
     def test_json_full_output_valid(self):
@@ -67,7 +74,9 @@ class TestDemonstrationSpectacular:
         r = _run(["--quiet", "--step", "4"])
         assert "Grounded" in r.stdout
         assert "JTMS" in r.stdout
-        assert "retraction cascade" in r.stdout.lower() or "Retraction cascade" in r.stdout
+        assert (
+            "retraction cascade" in r.stdout.lower() or "Retraction cascade" in r.stdout
+        )
 
     def test_step_6_synthesis_quality(self):
         r = _run(["--quiet", "--step", "6"])
@@ -80,6 +89,7 @@ class TestDemonstrationSpectacular:
         sys.path.insert(0, str(SCRIPT.parent))
         try:
             import importlib
+
             mod_name = "demonstration_epita_spectacular"
             spec = importlib.util.spec_from_file_location(mod_name, SCRIPT)
             mod = importlib.util.module_from_spec(spec)
@@ -87,9 +97,26 @@ class TestDemonstrationSpectacular:
 
             result = mod.MOCK_SPECTACULAR_RESULT
             assert len(result["steps"]) == 6
-            assert result["steps"]["1_extraction"]["output"]["extraction_stats"]["claims"] == 5
-            assert len(result["steps"]["3_fallacy_detection"]["output"]["detected_fallacies"]) == 6
-            assert len(result["steps"]["4_argumentation_frameworks"]["output"]["dung"]["extensions"]["grounded"]) == 3
+            assert (
+                result["steps"]["1_extraction"]["output"]["extraction_stats"]["claims"]
+                == 5
+            )
+            assert (
+                len(
+                    result["steps"]["3_fallacy_detection"]["output"][
+                        "detected_fallacies"
+                    ]
+                )
+                == 6
+            )
+            assert (
+                len(
+                    result["steps"]["4_argumentation_frameworks"]["output"]["dung"][
+                        "extensions"
+                    ]["grounded"]
+                )
+                == 3
+            )
             assert result["steps"]["6_synthesis"]["output"]["field_count"] == 32
         finally:
             sys.path.pop(0)
@@ -99,6 +126,7 @@ class TestDemonstrationSpectacular:
         sys.path.insert(0, str(SCRIPT.parent))
         try:
             import importlib.util
+
             mod_name = "demonstration_epita_spectacular"
             spec = importlib.util.spec_from_file_location(mod_name, SCRIPT)
             mod = importlib.util.module_from_spec(spec)

--- a/tests/unit/examples/test_spectacular_notebook.py
+++ b/tests/unit/examples/test_spectacular_notebook.py
@@ -1,4 +1,5 @@
 """Smoke tests for spectacular_analysis_tour.ipynb — #362"""
+
 import json
 import subprocess
 import sys
@@ -6,7 +7,10 @@ from pathlib import Path
 
 import pytest
 
-NOTEBOOK = Path(__file__).resolve().parent.parent.parent.parent / "notebooks/spectacular_analysis_tour.ipynb"
+NOTEBOOK = (
+    Path(__file__).resolve().parent.parent.parent.parent
+    / "notebooks/spectacular_analysis_tour.ipynb"
+)
 SCRIPT = Path(__file__).resolve().parent.parent.parent.parent / (
     "examples/02_core_system_demos/scripts_demonstration/demonstration_epita_spectacular.py"
 )
@@ -36,8 +40,15 @@ class TestSpectacularNotebook:
 
         nb = nbformat.read(NOTEBOOK, as_version=4)
         all_text = " ".join(c.source for c in nb.cells)
-        for step_name in ("Extraction", "Formal Logic", "Fallacy", "Dung", "JTMS",
-                          "Adversarial", "Synthesis"):
+        for step_name in (
+            "Extraction",
+            "Formal Logic",
+            "Fallacy",
+            "Dung",
+            "JTMS",
+            "Adversarial",
+            "Synthesis",
+        ):
             assert step_name in all_text, f"Notebook missing: {step_name}"
 
     def test_notebook_no_sensitive_data(self):
@@ -59,10 +70,7 @@ class TestSpectacularNotebook:
         assert "demonstration_epita_spectacular" in code_text
         assert "MOCK_SPECTACULAR_RESULT" in code_text
 
-    @pytest.mark.skipif(
-        not SCRIPT.exists(),
-        reason="Demo script dependency not found"
-    )
+    @pytest.mark.skipif(not SCRIPT.exists(), reason="Demo script dependency not found")
     def test_notebook_executes_headless(self, tmp_path):
         """Execute the notebook via nbconvert and verify no errors.
 
@@ -72,25 +80,36 @@ class TestSpectacularNotebook:
         executed = tmp_path / "spectacular_analysis_tour_executed.ipynb"
         result = subprocess.run(
             [
-                sys.executable, "-m", "jupyter", "nbconvert",
-                "--to", "notebook", "--execute",
+                sys.executable,
+                "-m",
+                "jupyter",
+                "nbconvert",
+                "--to",
+                "notebook",
+                "--execute",
                 "--ExecutePreprocessor.timeout=60",
                 str(NOTEBOOK),
-                "--output", str(executed),
+                "--output",
+                str(executed),
             ],
-            capture_output=True, text=True, timeout=120,
+            capture_output=True,
+            text=True,
+            timeout=120,
         )
-        assert result.returncode == 0, f"Notebook execution failed:\n{result.stderr[:500]}"
+        assert (
+            result.returncode == 0
+        ), f"Notebook execution failed:\n{result.stderr[:500]}"
         assert executed.exists()
 
         import nbformat
+
         nb = nbformat.read(executed, as_version=4)
         error_cells = [
-            c for c in nb.cells
+            c
+            for c in nb.cells
             if c.cell_type == "code"
-            and any(
-                o.get("output_type") == "error"
-                for o in c.get("outputs", [])
-            )
+            and any(o.get("output_type") == "error" for o in c.get("outputs", []))
         ]
-        assert len(error_cells) == 0, f"Cells with errors: {[c.source[:50] for c in error_cells]}"
+        assert (
+            len(error_cells) == 0
+        ), f"Cells with errors: {[c.source[:50] for c in error_cells]}"

--- a/tests/unit/libs/mcp/client/test_session.py
+++ b/tests/unit/libs/mcp/client/test_session.py
@@ -294,7 +294,11 @@ class TestCreateSession:
         """create_session() creates ProcessStdioTransport with command."""
         # Use echo as a safe test command that outputs valid JSON
         session = await create_session(
-            command=["python", "-c", "import sys; print('{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{}}}'); sys.stdout.flush()"]
+            command=[
+                "python",
+                "-c",
+                'import sys; print(\'{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05","capabilities":{}}}\'); sys.stdout.flush()',
+            ]
         )
 
         try:

--- a/tests/unit/libs/mcp/client/test_stdio.py
+++ b/tests/unit/libs/mcp/client/test_stdio.py
@@ -65,7 +65,9 @@ class TestStdioTransport:
         write_hook = MagicMock()
 
         # send() writes to _stdin (the subprocess's stdin stream)
-        transport = StdioTransport(stdin=mock_stdin, stdout=MagicMock(), write_hook=write_hook)
+        transport = StdioTransport(
+            stdin=mock_stdin, stdout=MagicMock(), write_hook=write_hook
+        )
 
         request = JSONRPCRequest(id=1, method="test")
         await transport.send(request)
@@ -110,9 +112,13 @@ class TestStdioTransport:
         read_hook = MagicMock()
 
         # receive() reads from _stdout (the subprocess's stdout stream)
-        mock_stdout.readline = MagicMock(return_value=b'{"jsonrpc":"2.0","id":1,"result":{}}\n')
+        mock_stdout.readline = MagicMock(
+            return_value=b'{"jsonrpc":"2.0","id":1,"result":{}}\n'
+        )
 
-        transport = StdioTransport(stdin=MagicMock(), stdout=mock_stdout, read_hook=read_hook)
+        transport = StdioTransport(
+            stdin=MagicMock(), stdout=mock_stdout, read_hook=read_hook
+        )
 
         await transport.receive()
 
@@ -235,7 +241,11 @@ class TestProcessStdioTransport:
         """ProcessStdioTransport can send and receive to subprocess."""
         # Use Python to echo JSON-RPC responses
         transport = ProcessStdioTransport(
-            command=["python", "-c", "import sys; print('{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}')"]
+            command=[
+                "python",
+                "-c",
+                'import sys; print(\'{"jsonrpc":"2.0","id":1,"result":{}}\')',
+            ]
         )
 
         try:

--- a/tests/unit/orchestration/hierarchical/templates/test_templates.py
+++ b/tests/unit/orchestration/hierarchical/templates/test_templates.py
@@ -24,10 +24,10 @@ from argumentation_analysis.orchestration.hierarchical.templates.analysis_tool_t
     ANALYSIS_TOOL_CONFIG_EXAMPLE,
 )
 
-
 # ============================================================
 # BaseAgent (agent_template)
 # ============================================================
+
 
 class TestBaseAgent:
     def test_init_with_name(self):
@@ -68,6 +68,7 @@ class TestBaseAgent:
 # ============================================================
 # BaseOrchestrationStrategy (strategy_template)
 # ============================================================
+
 
 class TestBaseOrchestrationStrategy:
     def test_init_with_name(self):
@@ -121,6 +122,7 @@ class TestBaseOrchestrationStrategy:
 # BaseAnalysisType (analysis_type_template)
 # ============================================================
 
+
 class TestBaseAnalysisType:
     def test_init_with_name(self):
         t = BaseAnalysisType({"name": "my_analysis"})
@@ -165,6 +167,7 @@ class TestBaseAnalysisType:
 # ============================================================
 # BaseAnalysisTool (analysis_tool_template)
 # ============================================================
+
 
 class TestBaseAnalysisTool:
     def test_init_with_name(self):

--- a/tests/unit/scripts/test_auto_env.py
+++ b/tests/unit/scripts/test_auto_env.py
@@ -109,9 +109,7 @@ class TestEnsureEnvAsGuard:
         assert "ERREUR CRITIQUE" in exception_message
         assert "MAUVAIS ENVIRONNEMENT CONDA ACTIF" in exception_message
         assert "Environnement attendu   : 'projet-is'" in exception_message
-        assert (
-            "Environnement détecté (CONDA_DEFAULT_ENV) : 'base'" in exception_message
-        )
+        assert "Environnement détecté (CONDA_DEFAULT_ENV) : 'base'" in exception_message
 
     def test_ensure_env_silent_mode(self):
         """Vérifie le mode silencieux et non silencieux."""
@@ -125,7 +123,9 @@ class TestEnsureEnvAsGuard:
                     in str(call)
                     for call in mock_print.call_args_list
                 )
-                assert found_call, "Le message de succès n'a pas été affiché en mode non-silencieux."
+                assert (
+                    found_call
+                ), "Le message de succès n'a pas été affiché en mode non-silencieux."
 
         # En mode silencieux, on ne s'attend pas à un print
         with patch.dict(os.environ, env, clear=True):

--- a/tests/unit/test_interface_web_starlette.py
+++ b/tests/unit/test_interface_web_starlette.py
@@ -92,6 +92,7 @@ def client(mock_service_manager):
     Builds fresh routes and middleware per test to avoid state pollution
     from prior tests in long sessions (Issue #276).
     """
+
     @asynccontextmanager
     async def test_lifespan(app):
         app.state.service_manager = mock_service_manager

--- a/tests/validation_sherlock_watson/conftest.py
+++ b/tests/validation_sherlock_watson/conftest.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 # 1. Rate limiting between LLM API calls
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(autouse=True, scope="function")
 def rate_limit():
     """
@@ -60,6 +61,7 @@ def rate_limit():
 # ---------------------------------------------------------------------------
 # 2. Session-level API key check
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(autouse=True, scope="session")
 def api_key_required():
@@ -112,14 +114,13 @@ def require_openai_api_key():
     """
     api_key = os.environ.get("OPENAI_API_KEY", "")
     if not api_key:
-        pytest.skip(
-            "OPENAI_API_KEY not set -- skipping LLM-dependent validation test"
-        )
+        pytest.skip("OPENAI_API_KEY not set -- skipping LLM-dependent validation test")
 
 
 # ---------------------------------------------------------------------------
 # 3. Async workflow timeout wrapper
 # ---------------------------------------------------------------------------
+
 
 @pytest.fixture(scope="function")
 def workflow_timeout():
@@ -255,6 +256,7 @@ def clean_oracle_state():
 # 5. Safe JSON serializer for SK objects
 # ---------------------------------------------------------------------------
 
+
 @pytest.fixture(scope="function")
 def safe_json_serialize():
     """
@@ -294,6 +296,7 @@ def safe_json_serialize():
         # Handle enum types (AuthorRole, QueryType, etc.)
         try:
             import enum
+
             if isinstance(obj, enum.Enum):
                 return obj.value
         except Exception:
@@ -302,11 +305,18 @@ def safe_json_serialize():
         # Handle SK ChatMessageContent
         try:
             from semantic_kernel.contents import ChatMessageContent
+
             if isinstance(obj, ChatMessageContent):
                 return {
-                    "role": str(obj.role.value) if hasattr(obj.role, 'value') else str(obj.role),
+                    "role": (
+                        str(obj.role.value)
+                        if hasattr(obj.role, "value")
+                        else str(obj.role)
+                    ),
                     "content": str(obj.content) if obj.content else "",
-                    "name": str(obj.name) if hasattr(obj, 'name') and obj.name else None,
+                    "name": (
+                        str(obj.name) if hasattr(obj, "name") and obj.name else None
+                    ),
                 }
         except ImportError:
             pass
@@ -314,6 +324,7 @@ def safe_json_serialize():
         # Handle SK ChatHistory
         try:
             from semantic_kernel.contents import ChatHistory
+
             if isinstance(obj, ChatHistory):
                 return [_clean(msg) for msg in obj.messages]
         except (ImportError, AttributeError):
@@ -326,6 +337,7 @@ def safe_json_serialize():
         # Handle datetime
         try:
             from datetime import datetime, date
+
             if isinstance(obj, (datetime, date)):
                 return obj.isoformat()
         except Exception:
@@ -346,6 +358,7 @@ def safe_json_serialize():
 
         try:
             from collections import deque
+
             if isinstance(obj, deque):
                 return [_clean(item) for item in obj]
         except ImportError:


### PR DESCRIPTION
## Summary

- Add `[tool.mypy]` configuration to `pyproject.toml` with strict enforcement for 8 core orchestration modules
- ~130 type annotation fixes across 8 target files
- Add mypy CI step to `.github/workflows/ci.yml` lint-and-format job

## Changes

### Configuration (`pyproject.toml`)
- Global mypy config: Python 3.10, `ignore_missing_imports`, `follow_imports = silent`
- Per-module strict overrides: `disallow_untyped_defs`, `disallow_any_generics`, `warn_unused_ignores`, `warn_return_any`

### Type annotations
- All 32 state writer callables typed as `(output: Any, state: Any, ctx: dict[str, Any]) -> None`
- Inner helper functions in `invoke_callables.py` and `workflows.py`
- Generic type params: `Dict[str, Any]`, `Type[Any]`, `Callable[..., Any]`
- Targeted `# type: ignore[error-code]` for SK/JVM interop boundaries

### CI (`.github/workflows/ci.yml`)
- New step in `lint-and-format` job: Type check (mypy strict - core orchestration)

## Test plan
- [x] `mypy --strict` passes on all 8 modules with 0 errors
- [x] Existing unit tests pass (26 capability_registry, 24 workflow_dsl)
- [x] No new bare `# type: ignore` without specific error code
- [ ] CI green

Closes #401