### PR TITLE
feat(privacy): opaque_id, sanitize_state, and add_extract CLI (#409)

### DIFF
--- a/argumentation_analysis/evaluation/opaque_id.py
+++ b/argumentation_analysis/evaluation/opaque_id.py
@@ -1,0 +1,26 @@
+"""Deterministic opaque ID generation for privacy-safe references.
+
+Produces stable, non-reversible identifiers from sensitive source names.
+Same (name, salt) always yields the same 8-char hex prefix of sha256.
+"""
+
+import hashlib
+import os
+
+_DEFAULT_SALT = "epita-arg-analysis-2025"
+
+
+def opaque_id(source_name: str, salt: str | None = None) -> str:
+    """Return a deterministic 8-char opaque ID from a source name.
+
+    Args:
+        source_name: The sensitive identifier to obfuscate.
+        salt: Optional salt. Falls back to ``OPAQUE_ID_SALT`` env var,
+              then to a documented default.
+
+    Returns:
+        First 8 hex characters of ``sha256(salt + name)``.
+    """
+    effective_salt = salt or os.getenv("OPAQUE_ID_SALT", _DEFAULT_SALT)
+    digest = hashlib.sha256(f"{effective_salt}{source_name}".encode()).hexdigest()
+    return digest[:8]

--- a/argumentation_analysis/evaluation/sanitize_state.py
+++ b/argumentation_analysis/evaluation/sanitize_state.py
@@ -1,0 +1,110 @@
+"""State sanitizer — strips sensitive fields from analysis state snapshots.
+
+Produces a privacy-safe dict suitable for commits, dashboards, and reports.
+All quantitative aggregates (counts, scores, structures) are preserved.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from argumentation_analysis.evaluation.opaque_id import opaque_id
+
+# Fields to remove entirely from the top-level state snapshot.
+_STRIP_TOP_LEVEL = {
+    "raw_text",
+    "full_text",
+    "full_text_segment",
+    "raw_text_snippet",
+    "source_name",
+    "document_name",
+    "author",
+    "date_iso",
+    "url",
+}
+
+# Fields to replace with opaque IDs (key -> opaque_id(value)).
+_OPAQUE_REPLACE = {"source_id"}
+
+# Dict-valued fields where each entry's .text should be stripped but metadata kept.
+_TEXT_STRIP_DICTS = {"identified_arguments", "arguments"}
+
+# List-valued fields where each item may have sensitive sub-keys.
+_TEXT_STRIP_LISTS = {
+    "counter_arguments": {"counter_content", "generated_text"},
+    "extracts": set(),  # no text key to strip, keep as-is
+    "debate_transcripts": {"proponent_move", "opponent_move"},
+}
+
+# Fields that are purely narrative text — replace with length + cited_fields placeholder.
+_NARRATIVE_FIELDS = {"narrative_synthesis"}
+
+
+def _strip_text_from_dict(data: dict[str, Any], text_keys: set[str]) -> dict[str, Any]:
+    """Remove text-bearing keys from a dict, keep everything else."""
+    return {k: v for k, v in data.items() if k not in text_keys}
+
+
+def _strip_text_from_list(
+    items: list[dict[str, Any]], text_keys: set[str]
+) -> list[dict[str, Any]]:
+    """Remove text-bearing keys from each dict in a list."""
+    return [_strip_text_from_dict(item, text_keys) for item in items]
+
+
+def sanitize_state(state: dict[str, Any] | Any) -> dict[str, Any]:
+    """Strip sensitive fields, keep all quantitative aggregates.
+
+    Args:
+        state: A state dict (typically from ``state_snapshot`` in a golden
+               fixture) or a ``UnifiedAnalysisState`` instance.  If an object
+               with a ``model_dump`` or ``dict`` method is passed, it will be
+               serialized first.
+
+    Returns:
+        A new dict with all sensitive text removed, opaque IDs substituted,
+        and all counts/scores/structures preserved.
+    """
+    # Handle Pydantic models or objects with serialization.
+    if hasattr(state, "model_dump"):
+        data = state.model_dump()
+    elif hasattr(state, "dict"):
+        data = state.dict()
+    elif isinstance(state, dict):
+        data = copy.deepcopy(state)
+    else:
+        data = dict(state)
+
+    # 1. Strip top-level sensitive fields.
+    for field in _STRIP_TOP_LEVEL:
+        data.pop(field, None)
+
+    # 2. Replace identifying fields with opaque IDs.
+    for field in _OPAQUE_REPLACE:
+        if field in data and isinstance(data[field], str):
+            data[field] = opaque_id(data[field])
+
+    # 3. Strip text from dict-valued fields (identified_arguments, etc.).
+    for field in _TEXT_STRIP_DICTS:
+        if field in data and isinstance(data[field], dict):
+            data[field] = {
+                k: {"text_stripped": True} if isinstance(v, str) else v
+                for k, v in data[field].items()
+            }
+
+    # 4. Strip text from list-valued fields.
+    for field, text_keys in _TEXT_STRIP_LISTS.items():
+        if field in data and isinstance(data[field], list) and text_keys:
+            data[field] = _strip_text_from_list(data[field], text_keys)
+
+    # 5. Replace narrative text with length info.
+    for field in _NARRATIVE_FIELDS:
+        if field in data and isinstance(data[field], str):
+            original = data[field]
+            data[field] = {
+                "length": len(original),
+                "stripped": True,
+            }
+
+    return data

--- a/scripts/dataset/add_extract.py
+++ b/scripts/dataset/add_extract.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Add an extract to the encrypted dataset.
+
+Usage:
+    python scripts/dataset/add_extract.py \
+        --source-name "Speaker Name" \
+        --extract-text-file /path/to/plaintext.txt \
+        --metadata "discourse_type=populist,era=2025,regime_type=democracy"
+
+Workflow:
+    1. Load encrypted dataset in memory
+    2. Read plaintext from user-supplied file (never committed)
+    3. Append extract with metadata
+    4. Re-encrypt and save
+    5. Print opaque ID for use in PRs/dashboards
+
+Privacy: the plaintext file is never persisted under a tracked path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+# Repo root = 3 levels up from this script.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = REPO_ROOT / "argumentation_analysis" / "data"
+ENCRYPTED_PATH = DATA_DIR / "extract_sources.json.gz.enc"
+
+
+def _is_tracked(file_path: Path) -> bool:
+    """Return True if *file_path* is tracked by git."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", str(file_path)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def _parse_metadata(raw: str) -> dict[str, str]:
+    """Parse 'key=val,key2=val2' into a dict."""
+    meta: dict[str, str] = {}
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if "=" in pair:
+            k, v = pair.split("=", 1)
+            meta[k.strip()] = v.strip()
+    return meta
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Add an extract to the encrypted dataset."
+    )
+    parser.add_argument(
+        "--source-name", required=True, help="Display name of the source."
+    )
+    parser.add_argument(
+        "--extract-text-file",
+        required=True,
+        type=Path,
+        help="Path to a local plaintext file (never committed).",
+    )
+    parser.add_argument(
+        "--metadata",
+        default="",
+        help="Comma-separated key=value pairs (e.g. 'discourse_type=populist,era=2025').",
+    )
+    args = parser.parse_args(argv)
+
+    text_file = args.extract_text_file.resolve()
+
+    # --- Privacy guard ---
+    if _is_tracked(text_file):
+        print(
+            f"ERROR: {text_file} is tracked by git. "
+            "Provide a plaintext file outside the repo or gitignored.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not text_file.exists():
+        print(f"ERROR: file not found: {text_file}", file=sys.stderr)
+        return 1
+
+    plaintext = text_file.read_text(encoding="utf-8").strip()
+    if not plaintext:
+        print("ERROR: empty plaintext file.", file=sys.stderr)
+        return 1
+
+    # --- Load encrypted dataset ---
+    from dotenv import load_dotenv
+
+    load_dotenv(REPO_ROOT / ".env")
+
+    import os
+
+    passphrase = os.getenv("TEXT_CONFIG_PASSPHRASE")
+    if not passphrase:
+        print("ERROR: TEXT_CONFIG_PASSPHRASE not set in .env", file=sys.stderr)
+        return 1
+
+    from argumentation_analysis.core.utils.crypto_utils import derive_encryption_key
+    from argumentation_analysis.core.io_manager import (
+        load_extract_definitions,
+        save_extract_definitions,
+    )
+
+    key = derive_encryption_key(passphrase)
+    if not key:
+        print("ERROR: failed to derive encryption key.", file=sys.stderr)
+        return 1
+
+    b64_key = key.decode("utf-8")
+
+    definitions = load_extract_definitions(
+        config_file=ENCRYPTED_PATH,
+        b64_derived_key=b64_key,
+        raise_on_decrypt_error=True,
+    )
+
+    # --- Build new extract entry ---
+    metadata = _parse_metadata(args.metadata) if args.metadata else {}
+    new_extract = {
+        "source_name": args.source_name,
+        "source_type": metadata.get("source_type", "text"),
+        "schema": "v1",
+        "host_parts": metadata.get("host_parts", "local").split(","),
+        "path": metadata.get("path", ""),
+        "extracts": [
+            {
+                "full_text": plaintext,
+                "num_extract": 1,
+                "metadata": metadata,
+            }
+        ],
+    }
+
+    definitions.append(new_extract)
+
+    # --- Save re-encrypted ---
+    ok = save_extract_definitions(
+        extract_definitions=definitions,
+        config_file=ENCRYPTED_PATH,
+        b64_derived_key=b64_key,
+        embed_full_text=True,
+        text_retriever=lambda x: plaintext,
+    )
+    if not ok:
+        print("ERROR: failed to save encrypted dataset.", file=sys.stderr)
+        return 1
+
+    # --- Print opaque ID ---
+    from argumentation_analysis.evaluation.opaque_id import opaque_id
+
+    oid = opaque_id(args.source_name)
+    print(f"OK — extract added. opaque_id: {oid}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_add_extract.py
+++ b/tests/integration/test_add_extract.py
@@ -1,0 +1,146 @@
+"""Integration tests for scripts/dataset/add_extract.py.
+
+Uses mocked io_manager to avoid needing real encryption keys.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make the script importable.
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / "scripts" / "dataset"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import add_extract
+
+
+class TestParseMetadata:
+    def test_simple_keyval(self):
+        result = add_extract._parse_metadata("discourse_type=populist")
+        assert result == {"discourse_type": "populist"}
+
+    def test_multiple_keys(self):
+        result = add_extract._parse_metadata("a=1,b=2,c=3")
+        assert result == {"a": "1", "b": "2", "c": "3"}
+
+    def test_empty_string(self):
+        result = add_extract._parse_metadata("")
+        assert result == {}
+
+    def test_value_with_equals(self):
+        result = add_extract._parse_metadata("key=val=ue")
+        assert result == {"key": "val=ue"}
+
+
+class TestIsTracked:
+    def test_tracked_file(self, tmp_path):
+        # We mock subprocess.run to simulate git tracking
+        with patch("add_extract.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            assert add_extract._is_tracked(tmp_path / "somefile.txt") is True
+
+    def test_untracked_file(self, tmp_path):
+        with patch("add_extract.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=128)
+            assert add_extract._is_tracked(tmp_path / "somefile.txt") is False
+
+    def test_git_not_found(self, tmp_path):
+        with patch("add_extract.subprocess.run", side_effect=FileNotFoundError):
+            assert add_extract._is_tracked(tmp_path / "somefile.txt") is False
+
+
+class TestPrivacyGuard:
+    def test_refuses_tracked_file(self, tmp_path):
+        """add_extract must refuse if the plaintext file is git-tracked."""
+        plaintext = tmp_path / "tracked.txt"
+        plaintext.write_text("Some text", encoding="utf-8")
+
+        with patch("add_extract._is_tracked", return_value=True):
+            ret = add_extract.main(
+                [
+                    "--source-name",
+                    "Test",
+                    "--extract-text-file",
+                    str(plaintext),
+                ]
+            )
+        assert ret == 1
+
+    def test_refuses_nonexistent_file(self, tmp_path):
+        ret = add_extract.main(
+            [
+                "--source-name",
+                "Test",
+                "--extract-text-file",
+                str(tmp_path / "nonexistent.txt"),
+            ]
+        )
+        assert ret == 1
+
+    def test_refuses_empty_file(self, tmp_path):
+        plaintext = tmp_path / "empty.txt"
+        plaintext.write_text("", encoding="utf-8")
+        with patch("add_extract._is_tracked", return_value=False):
+            ret = add_extract.main(
+                [
+                    "--source-name",
+                    "Test",
+                    "--extract-text-file",
+                    str(plaintext),
+                ]
+            )
+        assert ret == 1
+
+
+class TestRoundtrip:
+    def test_add_and_reload(self, tmp_path):
+        """Roundtrip: add extract → reload → verify present."""
+        plaintext = tmp_path / "speech.txt"
+        plaintext.write_text("Citizens must have a voice.", encoding="utf-8")
+
+        saved_definitions: list = []
+
+        def mock_save(
+            extract_definitions,
+            config_file,
+            b64_derived_key,
+            embed_full_text=False,
+            config=None,
+            text_retriever=None,
+        ):
+            saved_definitions.extend(extract_definitions)
+            return True
+
+        with patch("add_extract._is_tracked", return_value=False), patch(
+            "argumentation_analysis.core.io_manager.load_extract_definitions",
+            return_value=[],
+        ), patch(
+            "argumentation_analysis.core.io_manager.save_extract_definitions",
+            side_effect=mock_save,
+        ), patch(
+            "argumentation_analysis.core.utils.crypto_utils.derive_encryption_key",
+            return_value=b"dGVzdGtleQ==",
+        ), patch.dict(
+            os.environ, {"TEXT_CONFIG_PASSPHRASE": "test"}
+        ):
+            ret = add_extract.main(
+                [
+                    "--source-name",
+                    "Test Speaker",
+                    "--extract-text-file",
+                    str(plaintext),
+                    "--metadata",
+                    "discourse_type=populist,era=2025",
+                ]
+            )
+
+        assert ret == 0
+        assert len(saved_definitions) == 1
+        assert saved_definitions[0]["source_name"] == "Test Speaker"

--- a/tests/unit/argumentation_analysis/evaluation/test_opaque_id.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_opaque_id.py
@@ -1,0 +1,59 @@
+"""Tests for argumentation_analysis.evaluation.opaque_id."""
+
+import os
+
+import pytest
+
+from argumentation_analysis.evaluation.opaque_id import opaque_id
+
+
+class TestOpaqueIdStability:
+    def test_same_input_same_output(self):
+        assert opaque_id("Speaker A") == opaque_id("Speaker A")
+
+    def test_different_salt_different_output(self):
+        a = opaque_id("Speaker A", salt="salt1")
+        b = opaque_id("Speaker A", salt="salt2")
+        assert a != b
+
+    def test_different_names_different_ids(self):
+        ids = {opaque_id(f"name_{i}") for i in range(100)}
+        assert len(ids) == 100  # no collisions
+
+
+class TestOpaqueIdFormat:
+    def test_length_is_8(self):
+        result = opaque_id("test")
+        assert len(result) == 8
+
+    def test_hex_chars_only(self):
+        result = opaque_id("test")
+        assert all(c in "0123456789abcdef" for c in result)
+
+
+class TestOpaqueIdSaltEnv:
+    def test_env_salt_used(self, monkeypatch):
+        monkeypatch.setenv("OPAQUE_ID_SALT", "env_salt_123")
+        a = opaque_id("test")
+        b = opaque_id("test", salt="env_salt_123")
+        assert a == b
+
+    def test_default_salt_without_env(self, monkeypatch):
+        monkeypatch.delenv("OPAQUE_ID_SALT", raising=False)
+        result = opaque_id("test")
+        assert len(result) == 8  # doesn't crash, uses default
+
+
+class TestOpaqueIdEdgeCases:
+    def test_empty_string(self):
+        result = opaque_id("")
+        assert len(result) == 8
+
+    def test_unicode_name(self):
+        result = opaque_id("François Mitterrand")
+        assert len(result) == 8
+        assert result == opaque_id("François Mitterrand")  # stable
+
+    def test_very_long_name(self):
+        result = opaque_id("x" * 10000)
+        assert len(result) == 8

--- a/tests/unit/argumentation_analysis/evaluation/test_sanitize_state.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_sanitize_state.py
@@ -1,0 +1,174 @@
+"""Tests for argumentation_analysis.evaluation.sanitize_state."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from argumentation_analysis.evaluation.sanitize_state import sanitize_state
+
+GOLDEN_FIXTURE = (
+    Path(__file__).resolve().parents[3]
+    / "golden"
+    / "fixtures"
+    / "spectacular"
+    / "doc_a_golden.json"
+)
+
+
+@pytest.fixture
+def golden_state():
+    with open(GOLDEN_FIXTURE, encoding="utf-8") as f:
+        data = json.load(f)
+    return data["state_snapshot"]
+
+
+class TestSanitizeTopLevel:
+    def test_raw_text_stripped(self, golden_state):
+        result = sanitize_state(golden_state)
+        assert "raw_text" not in result
+
+    def test_full_text_stripped(self):
+        state = {"full_text": "sensitive", "count": 5}
+        result = sanitize_state(state)
+        assert "full_text" not in result
+        assert result["count"] == 5
+
+    def test_source_name_stripped(self):
+        state = {"source_name": "Secret Speaker", "score": 0.9}
+        result = sanitize_state(state)
+        assert "source_name" not in result
+
+    def test_all_sensitive_fields_stripped(self):
+        state = {
+            "raw_text": "x",
+            "full_text": "x",
+            "full_text_segment": "x",
+            "raw_text_snippet": "x",
+            "source_name": "x",
+            "document_name": "x",
+            "author": "x",
+            "date_iso": "x",
+            "url": "x",
+        }
+        result = sanitize_state(state)
+        for field in state:
+            assert field not in result
+
+
+class TestSanitizeOpaqueReplace:
+    def test_source_id_opaque(self):
+        state = {"source_id": "Real Name"}
+        result = sanitize_state(state)
+        assert result["source_id"] != "Real Name"
+        assert len(result["source_id"]) == 8
+
+    def test_source_id_stable(self):
+        state = {"source_id": "Same Name"}
+        a = sanitize_state(state)
+        b = sanitize_state(state)
+        assert a["source_id"] == b["source_id"]
+
+
+class TestSanitizePreserved:
+    def test_counts_preserved(self, golden_state):
+        result = sanitize_state(golden_state)
+        assert "summary" not in result  # top-level summary is outside state_snapshot
+        # Check that analysis_tasks (counts) are preserved
+        if "analysis_tasks" in golden_state:
+            assert "analysis_tasks" in result
+
+    def test_scores_preserved(self, golden_state):
+        result = sanitize_state(golden_state)
+        if "argument_quality_scores" in golden_state:
+            assert "argument_quality_scores" in result
+            assert (
+                result["argument_quality_scores"]
+                == golden_state["argument_quality_scores"]
+            )
+
+    def test_structures_preserved(self, golden_state):
+        result = sanitize_state(golden_state)
+        # Dung frameworks should be fully preserved (no text)
+        if "dung_frameworks" in golden_state:
+            assert "dung_frameworks" in result
+            assert result["dung_frameworks"] == golden_state["dung_frameworks"]
+
+    def test_belief_data_preserved(self, golden_state):
+        result = sanitize_state(golden_state)
+        if "jtms_beliefs" in golden_state:
+            assert "jtms_beliefs" in result
+
+
+class TestSanitizeNarrative:
+    def test_narrative_replaced_with_length(self, golden_state):
+        result = sanitize_state(golden_state)
+        if "narrative_synthesis" in golden_state:
+            narr = result["narrative_synthesis"]
+            assert isinstance(narr, dict)
+            assert "length" in narr
+            assert narr["length"] == len(golden_state["narrative_synthesis"])
+            assert narr["stripped"] is True
+
+
+class TestSanitizeCounterArguments:
+    def test_counter_content_stripped(self, golden_state):
+        result = sanitize_state(golden_state)
+        if "counter_arguments" in result:
+            for ca in result["counter_arguments"]:
+                assert "counter_content" not in ca
+                assert "generated_text" not in ca
+                # strategy and strength should survive
+                assert "strategy" in ca
+
+
+class TestSanitizeIdempotence:
+    def test_idempotent(self):
+        state = {
+            "raw_text": "secret",
+            "source_id": "Name",
+            "narrative_synthesis": "A long narrative paragraph.",
+            "counter_arguments": [
+                {"strategy": "reductio", "counter_content": "text", "strength": 0.8}
+            ],
+            "score": 0.9,
+        }
+        first = sanitize_state(state)
+        second = sanitize_state(first)
+        # Stripped fields stay stripped; scores survive
+        assert first["score"] == second["score"] == 0.9
+        assert "raw_text" not in second
+
+    def test_idempotent_on_golden(self, golden_state):
+        first = sanitize_state(golden_state)
+        second = sanitize_state(first)
+        # Scores and structures must survive both passes
+        assert first["argument_quality_scores"] == second["argument_quality_scores"]
+        assert first["dung_frameworks"] == second["dung_frameworks"]
+
+
+class TestSanitizeIdentifiedArguments:
+    def test_arguments_text_stripped(self):
+        state = {
+            "identified_arguments": {
+                "arg1": "Sensitive argument text",
+                "arg2": "Another text",
+            }
+        }
+        result = sanitize_state(state)
+        assert "identified_arguments" in result
+        for v in result["identified_arguments"].values():
+            assert isinstance(v, dict)
+            assert v["text_stripped"] is True
+
+    def test_non_string_values_preserved(self):
+        state = {
+            "identified_arguments": {
+                "arg1": {"score": 0.9, "type": "premise"},
+            }
+        }
+        result = sanitize_state(state)
+        assert result["identified_arguments"]["arg1"] == {
+            "score": 0.9,
+            "type": "premise",
+        }


### PR DESCRIPTION
## Summary

Closes #409 — C.1 Privacy plumbing minimum for Epic C (Discourse Pattern Mining).

3 helpers + 3 test files:

- **opaque_id.py** — Deterministic sha256 identifier with env-based salt
- **sanitize_state.py** — Strips sensitive fields, preserves quantitative aggregates
- **scripts/dataset/add_extract.py** — CLI to append extracts to encrypted dataset

## Tests

37 tests (10 opaque_id, 17 sanitize_state, 10 add_extract). Golden fixture validated. black+flake8 clean.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>