### PR TITLE
feat(report): discourse pattern report with SVG visualizations (#412)

### DIFF
--- a/argumentation_analysis/evaluation/opaque_id.py
+++ b/argumentation_analysis/evaluation/opaque_id.py
@@ -1,0 +1,26 @@
+"""Deterministic opaque ID generation for privacy-safe references.
+
+Produces stable, non-reversible identifiers from sensitive source names.
+Same (name, salt) always yields the same 8-char hex prefix of sha256.
+"""
+
+import hashlib
+import os
+
+_DEFAULT_SALT = "epita-arg-analysis-2025"
+
+
+def opaque_id(source_name: str, salt: str | None = None) -> str:
+    """Return a deterministic 8-char opaque ID from a source name.
+
+    Args:
+        source_name: The sensitive identifier to obfuscate.
+        salt: Optional salt. Falls back to ``OPAQUE_ID_SALT`` env var,
+              then to a documented default.
+
+    Returns:
+        First 8 hex characters of ``sha256(salt + name)``.
+    """
+    effective_salt = salt or os.getenv("OPAQUE_ID_SALT", _DEFAULT_SALT)
+    digest = hashlib.sha256(f"{effective_salt}{source_name}".encode()).hexdigest()
+    return digest[:8]

--- a/argumentation_analysis/evaluation/pattern_mining.py
+++ b/argumentation_analysis/evaluation/pattern_mining.py
@@ -1,0 +1,471 @@
+"""Discourse pattern mining — aggregate signatures into corpus-level patterns.
+
+Consumes ``signature_*.json`` files produced by the C.2 batch runner and
+produces spectral, asymmetry, co-occurrence, formal detector, and
+cross-coverage analyses.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, Sequence, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Fallacy family mapping — Tricherie (8.x) vs Influence (2.x)
+# ---------------------------------------------------------------------------
+
+# Tricherie: self-bias fallacies (arranger les faits, changement de cap, pensée biaisée)
+TRICHERIE_TYPES = frozenset(
+    {
+        "cherry_picking",
+        "confirmation_bias",
+        "rationalization",
+        "moving_the_goalposts",
+        "special_pleading",
+        "biased_sampling",
+        "false_cause",
+        "hasty_generalization",
+    }
+)
+
+# Influence: inductive fallacies (procédé rhétorique, émotion, manipulation mentale)
+INFLUENCE_TYPES = frozenset(
+    {
+        "ad_hominem",
+        "appeal_to_authority",
+        "appeal_to_emotion",
+        "appeal_to_fear",
+        "bandwagon",
+        "red_herring",
+        "straw_man",
+        "slippery_slope",
+        "false_dilemma",
+        "loaded_question",
+        "circular_reasoning",
+        "equivocation",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Formal pattern detector protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class FormalPatternDetector(Protocol):
+    """Extensible detector for formal logic patterns in a signature."""
+
+    name: str
+
+    def detect(self, signature: Dict[str, Any]) -> Dict[str, float]:
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Built-in detectors
+# ---------------------------------------------------------------------------
+
+
+class DungTopologyDetector:
+    """Extract topological features from Dung argumentation frameworks."""
+
+    name = "dung_topology"
+
+    def detect(self, signature: Dict[str, Any]) -> Dict[str, float]:
+        state = signature.get("state", signature)
+        dung = state.get("dung_frameworks", {})
+        if not dung:
+            return {
+                "n_args": 0.0,
+                "n_attacks": 0.0,
+                "density": 0.0,
+                "n_extensions": 0.0,
+                "max_extension_size": 0.0,
+            }
+
+        # Use first framework
+        fw = next(iter(dung.values())) if isinstance(dung, dict) else dung
+        args = fw.get("arguments", [])
+        attacks = fw.get("attacks", [])
+        extensions = fw.get("extensions", {})
+        n = len(args)
+        n_atk = len(attacks)
+        max_ext = n * (n - 1) if n > 1 else 1
+        density = n_atk / max_ext if max_ext > 0 else 0.0
+
+        all_exts = []
+        for ext_list in extensions.values():
+            if isinstance(ext_list, list):
+                if ext_list and isinstance(ext_list[0], list):
+                    all_exts.extend(ext_list)
+                else:
+                    all_exts.append(ext_list)
+
+        return {
+            "n_args": float(n),
+            "n_attacks": float(n_atk),
+            "density": round(density, 4),
+            "n_extensions": float(len(all_exts)),
+            "max_extension_size": float(max((len(e) for e in all_exts), default=0)),
+        }
+
+
+class AtmsBranchingDetector:
+    """Extract ATMS context branching features."""
+
+    name = "atms_branching"
+
+    def detect(self, signature: Dict[str, Any]) -> Dict[str, float]:
+        state = signature.get("state", signature)
+        contexts = state.get("atms_contexts", [])
+        if not contexts:
+            return {
+                "max_depth": 0.0,
+                "avg_assumptions": 0.0,
+                "contradiction_rate": 0.0,
+            }
+
+        n = len(contexts)
+        assumption_counts = [len(c.get("assumptions", [])) for c in contexts]
+        contradictions = sum(1 for c in contexts if c.get("status") == "contradictory")
+
+        return {
+            "max_depth": float(max(assumption_counts, default=0)),
+            "avg_assumptions": round(sum(assumption_counts) / n if n > 0 else 0.0, 2),
+            "contradiction_rate": round(contradictions / n if n > 0 else 0.0, 4),
+        }
+
+
+class JtmsRetractionRateDetector:
+    """Extract JTMS retraction rate features."""
+
+    name = "jtms_retraction_rate"
+
+    def detect(self, signature: Dict[str, Any]) -> Dict[str, float]:
+        state = signature.get("state", signature)
+        beliefs = state.get("jtms_beliefs", {})
+        retraction_chain = state.get("jtms_retraction_chain", [])
+
+        n_beliefs = len(beliefs)
+        n_retractions = len(retraction_chain)
+        n_justifications = len(
+            {b.get("justification") for b in beliefs.values() if isinstance(b, dict)}
+        )
+
+        return {
+            "n_beliefs": float(n_beliefs),
+            "n_justifications": float(n_justifications),
+            "retraction_rate": round(
+                n_retractions / n_beliefs if n_beliefs > 0 else 0.0, 4
+            ),
+        }
+
+
+# Default registry — extend by appending to this list
+FORMAL_DETECTORS: List[FormalPatternDetector] = [
+    DungTopologyDetector(),
+    AtmsBranchingDetector(),
+    JtmsRetractionRateDetector(),
+]
+
+
+# ---------------------------------------------------------------------------
+# Spectral analysis
+# ---------------------------------------------------------------------------
+
+
+def fallacy_spectrum(
+    signatures: Sequence[Dict[str, Any]],
+    by: str = "cluster_id",
+) -> Dict[str, Dict[str, float]]:
+    """Compute relative fallacy frequency per cluster.
+
+    Returns:
+        ``{cluster_id: {fallacy_type: relative_freq}}``
+    """
+    clusters: Dict[str, Counter] = defaultdict(Counter)
+    cluster_total: Dict[str, int] = defaultdict(int)
+
+    for sig in signatures:
+        state = sig.get("state", sig)
+        metadata = sig.get("metadata", {})
+        cluster_key = metadata.get(by, "unknown")
+
+        fallacies = state.get("identified_fallacies", {})
+        if isinstance(fallacies, dict):
+            for f_data in fallacies.values():
+                if isinstance(f_data, dict):
+                    ftype = f_data.get("type", "unknown")
+                    clusters[cluster_key][ftype] += 1
+                    cluster_total[cluster_key] += 1
+
+    result: Dict[str, Dict[str, float]] = {}
+    for cid, counts in clusters.items():
+        total = cluster_total[cid]
+        result[cid] = {
+            ftype: round(count / total, 4) if total > 0 else 0.0
+            for ftype, count in counts.items()
+        }
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Asymmetry Tricherie ↔ Influence
+# ---------------------------------------------------------------------------
+
+
+def trick_vs_influence_ratio(
+    signatures: Sequence[Dict[str, Any]],
+    by: str = "cluster_id",
+) -> Dict[str, Dict[str, float]]:
+    """Compute Tricherie/Influence asymmetry per cluster.
+
+    Returns per cluster:
+        - tricherie_share: relative freq of Tricherie-family fallacies
+        - influence_share: relative freq of Influence-family fallacies
+        - ratio: influence / tricherie (bounded to 1e9)
+        - asymmetry: (influence - tricherie) / (influence + tricherie) ∈ [-1, 1]
+    """
+    clusters: Dict[str, Counter] = defaultdict(Counter)
+
+    for sig in signatures:
+        state = sig.get("state", sig)
+        metadata = sig.get("metadata", {})
+        cluster_key = metadata.get(by, "unknown")
+
+        fallacies = state.get("identified_fallacies", {})
+        if isinstance(fallacies, dict):
+            for f_data in fallacies.values():
+                if isinstance(f_data, dict):
+                    ftype = f_data.get("type", "")
+                    if ftype in TRICHERIE_TYPES:
+                        clusters[cluster_key]["tricherie"] += 1
+                    elif ftype in INFLUENCE_TYPES:
+                        clusters[cluster_key]["influence"] += 1
+
+    total_all = sum(
+        c.get("tricherie", 0) + c.get("influence", 0) for c in clusters.values()
+    )
+
+    result: Dict[str, Dict[str, float]] = {}
+    for cid, counts in clusters.items():
+        t = counts.get("tricherie", 0)
+        i = counts.get("influence", 0)
+        total = total_all if total_all > 0 else 1
+
+        t_share = round(t / total, 4)
+        i_share = round(i / total, 4)
+        ratio = round(min(i / t, 1e9), 4) if t > 0 else (1e9 if i > 0 else 0.0)
+        asym = round((i - t) / (i + t), 4) if (i + t) > 0 else 0.0
+
+        result[cid] = {
+            "tricherie_share": t_share,
+            "influence_share": i_share,
+            "ratio": ratio,
+            "asymmetry": asym,
+        }
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Co-occurrence matrix
+# ---------------------------------------------------------------------------
+
+
+def cooccurrence_matrix(
+    signatures: Sequence[Dict[str, Any]],
+    unit: str = "argument",
+    top_n: int = 20,
+) -> Dict[str, Any]:
+    """Compute fallacy co-occurrence matrix with support/confidence/lift/jaccard.
+
+    Args:
+        signatures: List of signature dicts from C.2.
+        unit: "argument" (same extracted argument) or "doc" (same document).
+        top_n: Number of top pairs to return by lift.
+
+    Returns:
+        ``{pairs: [{a, b, support, confidence, lift, jaccard}], unit_count}``
+    """
+    pair_counts: Counter = Counter()
+    type_counts: Counter = Counter()
+    unit_count = 0
+
+    for sig in signatures:
+        state = sig.get("state", sig)
+        fallacies = state.get("identified_fallacies", {})
+
+        if unit == "argument":
+            # Group fallacies by their source argument
+            arg_fallacies: Dict[str, set] = defaultdict(set)
+            if isinstance(fallacies, dict):
+                for f_data in fallacies.values():
+                    if isinstance(f_data, dict):
+                        src = f_data.get("source_arg", "__none__")
+                        ftype = f_data.get("type", "unknown")
+                        arg_fallacies[src].add(ftype)
+
+            for ftypes in arg_fallacies.values():
+                if len(ftypes) > 1:
+                    unit_count += 1
+                    for ft in ftypes:
+                        type_counts[ft] += 1
+                    for a in sorted(ftypes):
+                        for b in sorted(ftypes):
+                            if a < b:
+                                pair_counts[(a, b)] += 1
+        else:  # doc-level
+            doc_types: set = set()
+            if isinstance(fallacies, dict):
+                for f_data in fallacies.values():
+                    if isinstance(f_data, dict):
+                        doc_types.add(f_data.get("type", "unknown"))
+
+            if len(doc_types) > 1:
+                unit_count += 1
+                for ft in doc_types:
+                    type_counts[ft] += 1
+                for a in sorted(doc_types):
+                    for b in sorted(doc_types):
+                        if a < b:
+                            pair_counts[(a, b)] += 1
+
+    total_units = max(unit_count, 1)
+    pairs = []
+    for (a, b), support in pair_counts.items():
+        sa = type_counts[a]
+        sb = type_counts[b]
+        conf_ab = support / sa if sa > 0 else 0.0
+        expected = (sa / total_units) * (sb / total_units)
+        lift = support / (total_units * expected) if expected > 0 else 0.0
+        jaccard = support / (sa + sb - support) if (sa + sb - support) > 0 else 0.0
+        pairs.append(
+            {
+                "a": a,
+                "b": b,
+                "support": support,
+                "confidence": round(conf_ab, 4),
+                "lift": round(lift, 4),
+                "jaccard": round(jaccard, 4),
+            }
+        )
+
+    pairs.sort(key=lambda p: p["lift"], reverse=True)
+    return {"pairs": pairs[:top_n], "unit_count": unit_count}
+
+
+# ---------------------------------------------------------------------------
+# Cross-coverage informal ↔ formal
+# ---------------------------------------------------------------------------
+
+
+def cross_coverage(
+    signatures: Sequence[Dict[str, Any]],
+) -> Dict[str, Dict[str, float]]:
+    """Measure co-occurrence of informal fallacies with formal logic signals.
+
+    For each fallacy type, reports the rate at which the same unit also has:
+      - FOL invalidity
+      - Dung edge without support
+      - JTMS retraction
+    """
+    fallacy_units: Dict[str, int] = defaultdict(int)
+    cross_units: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+    total = 0
+
+    for sig in signatures:
+        state = sig.get("state", sig)
+        fallacies = state.get("identified_fallacies", {})
+
+        # Formal signals
+        has_fol_invalid = False
+        fol_results = state.get("fol_analysis_results", [])
+        if isinstance(fol_results, list):
+            for r in fol_results:
+                if isinstance(r, dict) and not r.get("valid", True):
+                    has_fol_invalid = True
+
+        has_dung_unsupported = False
+        dung = state.get("dung_frameworks", {})
+        attacks = []
+        if isinstance(dung, dict):
+            for fw in dung.values():
+                if isinstance(fw, dict):
+                    attacks.extend(fw.get("attacks", []))
+        if attacks:
+            args_with_support = set()
+            args_attacked = set()
+            for atk in attacks:
+                if isinstance(atk, dict):
+                    args_attacked.add(atk.get("to", ""))
+            for atk in attacks:
+                if isinstance(atk, dict):
+                    args_with_support.add(atk.get("from", ""))
+            unsupported = args_attacked - args_with_support
+            # Simplified: any arg attacked but not attacking others
+            if unsupported:
+                has_dung_unsupported = True
+
+        has_jtms_retraction = len(state.get("jtms_retraction_chain", [])) > 0
+
+        formal_signals: Dict[str, bool] = {
+            "fol_invalid": has_fol_invalid,
+            "dung_unsupported": has_dung_unsupported,
+            "jtms_retraction": has_jtms_retraction,
+        }
+
+        if isinstance(fallacies, dict):
+            total += 1
+            for f_data in fallacies.values():
+                if isinstance(f_data, dict):
+                    ftype = f_data.get("type", "unknown")
+                    fallacy_units[ftype] += 1
+                    for signal, present in formal_signals.items():
+                        if present:
+                            cross_units[ftype][signal] += 1
+
+    result: Dict[str, Dict[str, float]] = {}
+    for ftype in fallacy_units:
+        n = fallacy_units[ftype]
+        result[ftype] = {}
+        for signal in ["fol_invalid", "dung_unsupported", "jtms_retraction"]:
+            result[ftype][signal] = round(
+                cross_units[ftype].get(signal, 0) / n if n > 0 else 0.0, 4
+            )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Run all formal detectors on a signature
+# ---------------------------------------------------------------------------
+
+
+def run_formal_detectors(
+    signature: Dict[str, Any],
+    detectors: Optional[List[FormalPatternDetector]] = None,
+) -> Dict[str, Dict[str, float]]:
+    """Run all formal pattern detectors on a single signature.
+
+    Args:
+        signature: A single signature dict.
+        detectors: Override detector list. Defaults to FORMAL_DETECTORS.
+
+    Returns:
+        ``{detector_name: {metric: value}}``
+    """
+    if detectors is None:
+        detectors = FORMAL_DETECTORS
+
+    results: Dict[str, Dict[str, float]] = {}
+    for det in detectors:
+        try:
+            results[det.name] = det.detect(signature)
+        except Exception:
+            results[det.name] = {"error": 1.0}
+    return results

--- a/argumentation_analysis/evaluation/sanitize_state.py
+++ b/argumentation_analysis/evaluation/sanitize_state.py
@@ -1,0 +1,110 @@
+"""State sanitizer — strips sensitive fields from analysis state snapshots.
+
+Produces a privacy-safe dict suitable for commits, dashboards, and reports.
+All quantitative aggregates (counts, scores, structures) are preserved.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from argumentation_analysis.evaluation.opaque_id import opaque_id
+
+# Fields to remove entirely from the top-level state snapshot.
+_STRIP_TOP_LEVEL = {
+    "raw_text",
+    "full_text",
+    "full_text_segment",
+    "raw_text_snippet",
+    "source_name",
+    "document_name",
+    "author",
+    "date_iso",
+    "url",
+}
+
+# Fields to replace with opaque IDs (key -> opaque_id(value)).
+_OPAQUE_REPLACE = {"source_id"}
+
+# Dict-valued fields where each entry's .text should be stripped but metadata kept.
+_TEXT_STRIP_DICTS = {"identified_arguments", "arguments"}
+
+# List-valued fields where each item may have sensitive sub-keys.
+_TEXT_STRIP_LISTS = {
+    "counter_arguments": {"counter_content", "generated_text"},
+    "extracts": set(),  # no text key to strip, keep as-is
+    "debate_transcripts": {"proponent_move", "opponent_move"},
+}
+
+# Fields that are purely narrative text — replace with length + cited_fields placeholder.
+_NARRATIVE_FIELDS = {"narrative_synthesis"}
+
+
+def _strip_text_from_dict(data: dict[str, Any], text_keys: set[str]) -> dict[str, Any]:
+    """Remove text-bearing keys from a dict, keep everything else."""
+    return {k: v for k, v in data.items() if k not in text_keys}
+
+
+def _strip_text_from_list(
+    items: list[dict[str, Any]], text_keys: set[str]
+) -> list[dict[str, Any]]:
+    """Remove text-bearing keys from each dict in a list."""
+    return [_strip_text_from_dict(item, text_keys) for item in items]
+
+
+def sanitize_state(state: dict[str, Any] | Any) -> dict[str, Any]:
+    """Strip sensitive fields, keep all quantitative aggregates.
+
+    Args:
+        state: A state dict (typically from ``state_snapshot`` in a golden
+               fixture) or a ``UnifiedAnalysisState`` instance.  If an object
+               with a ``model_dump`` or ``dict`` method is passed, it will be
+               serialized first.
+
+    Returns:
+        A new dict with all sensitive text removed, opaque IDs substituted,
+        and all counts/scores/structures preserved.
+    """
+    # Handle Pydantic models or objects with serialization.
+    if hasattr(state, "model_dump"):
+        data = state.model_dump()
+    elif hasattr(state, "dict"):
+        data = state.dict()
+    elif isinstance(state, dict):
+        data = copy.deepcopy(state)
+    else:
+        data = dict(state)
+
+    # 1. Strip top-level sensitive fields.
+    for field in _STRIP_TOP_LEVEL:
+        data.pop(field, None)
+
+    # 2. Replace identifying fields with opaque IDs.
+    for field in _OPAQUE_REPLACE:
+        if field in data and isinstance(data[field], str):
+            data[field] = opaque_id(data[field])
+
+    # 3. Strip text from dict-valued fields (identified_arguments, etc.).
+    for field in _TEXT_STRIP_DICTS:
+        if field in data and isinstance(data[field], dict):
+            data[field] = {
+                k: {"text_stripped": True} if isinstance(v, str) else v
+                for k, v in data[field].items()
+            }
+
+    # 4. Strip text from list-valued fields.
+    for field, text_keys in _TEXT_STRIP_LISTS.items():
+        if field in data and isinstance(data[field], list) and text_keys:
+            data[field] = _strip_text_from_list(data[field], text_keys)
+
+    # 5. Replace narrative text with length info.
+    for field in _NARRATIVE_FIELDS:
+        if field in data and isinstance(data[field], str):
+            original = data[field]
+            data[field] = {
+                "length": len(original),
+                "stripped": True,
+            }
+
+    return data

--- a/docs/reports/discourse_patterns.md
+++ b/docs/reports/discourse_patterns.md
@@ -1,0 +1,71 @@
+# Discourse Pattern Report
+
+**Generated**: 2026-05-03 22:47 UTC
+**Documents analyzed**: 8
+**Clusters**: 2 (debate, propaganda)
+**Workflow**: spectacular 17 phases
+
+---
+
+## 1. Fallacy Spectra by Cluster
+
+| Cluster | ad_hominem | appeal_to_fear | false_dilemma | straw_man |
+|---------|---------|---------|---------|---------|
+| debate | 0.00 | 0.00 | 0.50 | 0.50 |
+| propaganda | 0.50 | 0.50 | 0.00 | 0.00 |
+
+## 2. Tricherie ↔ Influence Asymmetry
+
+| Cluster | Tricherie | Influence | Ratio | Asymmetry |
+|---------|-----------|-----------|-------|----------|
+| debate | 0.000 | 0.375 | 1000000000.00 | +1.000 |
+| propaganda | 0.000 | 0.625 | 1000000000.00 | +1.000 |
+
+## 3. Co-occurrence Top-20
+
+| Fallacy A | Fallacy B | Support | Confidence | Lift | Jaccard |
+|-----------|-----------|---------|------------|------|--------|
+| ad_hominem | appeal_to_fear | 5 | 1.000 | 1.00 | 1.000 |
+
+_Units with co-occurrences: 5_
+
+## 4. Formal Pattern Detectors
+
+### dung_topology
+
+| Cluster | n_args | n_attacks | density | n_extensions | max_extension_size |
+|------|------|------|------|------|------|
+| debate | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
+| propaganda | 2.000 | 1.000 | 0.500 | 1.000 | 1.000 |
+
+### atms_branching
+
+| Cluster | max_depth | avg_assumptions | contradiction_rate |
+|------|------|------|------|
+| debate | 0.000 | 0.000 | 0.000 |
+| propaganda | 0.000 | 0.000 | 0.000 |
+
+### jtms_retraction_rate
+
+| Cluster | n_beliefs | n_justifications | retraction_rate |
+|------|------|------|------|
+| debate | 0.000 | 0.000 | 0.000 |
+| propaganda | 1.000 | 1.000 | 0.000 |
+
+## 5. Cross-coverage: Informal ↔ Formal
+
+| Fallacy Type | Fol_Invalid | Dung_Unsupported | Jtms_Retraction |
+|------|------|------|------|
+| ad_hominem | 0.00 | 1.00 | 0.00 |
+| appeal_to_fear | 0.00 | 1.00 | 0.00 |
+| false_dilemma | 1.00 | 0.00 | 1.00 |
+| straw_man | 1.00 | 0.00 | 1.00 |
+
+_Hypothesis: manipulation = camouflaging formal errors?_
+
+## 6. Limitations & Next Steps
+
+- Coverage limited to available corpus subset
+- Sampling bias toward represented discourse types
+- Formal detector registry is extensible (see `pattern_mining.FORMAL_DETECTORS`)
+- Future: temporal comparison, richer metadata, LLM-assisted narrative

--- a/docs/reports/discourse_patterns/asymmetry_chart.svg
+++ b/docs/reports/discourse_patterns/asymmetry_chart.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 300" width="340" height="300">
+<text x="170" y="20" font-size="13" fill="#2c3e50" text-anchor="middle">Tricherie vs Influence Asymmetry</text>
+<rect x="100" y="173" width="60" height="0" fill="#8b4513" opacity="0.8"/>
+<rect x="100" y="173" width="60" height="67" fill="#2c3e50" opacity="0.8"/>
+<text x="130" y="258" font-size="8" fill="#333" text-anchor="middle">debate</text>
+<text x="130" y="272" font-size="8" fill="#666" text-anchor="middle">+1.00</text>
+<rect x="200" y="128" width="60" height="0" fill="#8b4513" opacity="0.8"/>
+<rect x="200" y="128" width="60" height="112" fill="#2c3e50" opacity="0.8"/>
+<text x="230" y="258" font-size="8" fill="#333" text-anchor="middle">propaganda</text>
+<text x="230" y="272" font-size="8" fill="#666" text-anchor="middle">+1.00</text>
+<text x="30" y="80" font-size="9" fill="#2c3e50" text-anchor="middle">Influence</text>
+<text x="30" y="200" font-size="9" fill="#8b4513" text-anchor="middle">Tricherie</text>
+</svg>

--- a/docs/reports/discourse_patterns/heatmap_fallacies.svg
+++ b/docs/reports/discourse_patterns/heatmap_fallacies.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 210" width="260" height="210">
+<text x="145" y="25" font-size="8" fill="#333" text-anchor="middle" transform="rotate(-45,145,25)">ad_hominem</text>
+<text x="195" y="25" font-size="8" fill="#333" text-anchor="middle" transform="rotate(-45,195,25)">appeal_to_fe</text>
+<text x="115" y="59" font-size="8" fill="#333" text-anchor="end">ad_hominem</text>
+<rect x="120" y="30" width="49" height="49" fill="#f0f0f0" opacity="0.8"/>
+<rect x="170" y="30" width="49" height="49" fill="#2c3e50" opacity="0.8"/>
+<text x="195" y="59" font-size="7" fill="white" text-anchor="middle">1.0</text>
+<text x="115" y="109" font-size="8" fill="#333" text-anchor="end">appeal_to_fe</text>
+<rect x="120" y="80" width="49" height="49" fill="#2c3e50" opacity="0.8"/>
+<text x="145" y="109" font-size="7" fill="white" text-anchor="middle">1.0</text>
+<rect x="170" y="80" width="49" height="49" fill="#f0f0f0" opacity="0.8"/>
+<text x="130" y="195" font-size="12" fill="#2c3e50" text-anchor="middle">Fallacy Co-occurrence Heatmap (lift)</text>
+</svg>

--- a/docs/reports/discourse_patterns/spectrum_radar_debate.svg
+++ b/docs/reports/discourse_patterns/spectrum_radar_debate.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 124" width="500" height="124">
+<text x="250" y="20" font-size="13" fill="#2c3e50" text-anchor="middle">Fallacy Spectrum — debate</text>
+<text x="125" y="55" font-size="9" fill="#333" text-anchor="end">straw_man</text>
+<rect x="130" y="40" width="330" height="18" fill="#2c3e50" opacity="0.7"/>
+<text x="465" y="55" font-size="8" fill="#333" text-anchor="start">0.50</text>
+<text x="125" y="77" font-size="9" fill="#333" text-anchor="end">false_dilemma</text>
+<rect x="130" y="62" width="330" height="18" fill="#2c3e50" opacity="0.7"/>
+<text x="465" y="77" font-size="8" fill="#333" text-anchor="start">0.50</text>
+</svg>

--- a/docs/reports/discourse_patterns/spectrum_radar_propaganda.svg
+++ b/docs/reports/discourse_patterns/spectrum_radar_propaganda.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 124" width="500" height="124">
+<text x="250" y="20" font-size="13" fill="#2c3e50" text-anchor="middle">Fallacy Spectrum — propaganda</text>
+<text x="125" y="55" font-size="9" fill="#333" text-anchor="end">ad_hominem</text>
+<rect x="130" y="40" width="330" height="18" fill="#2c3e50" opacity="0.7"/>
+<text x="465" y="55" font-size="8" fill="#333" text-anchor="start">0.50</text>
+<text x="125" y="77" font-size="9" fill="#333" text-anchor="end">appeal_to_fear</text>
+<rect x="130" y="62" width="330" height="18" fill="#2c3e50" opacity="0.7"/>
+<text x="465" y="77" font-size="8" fill="#333" text-anchor="start">0.50</text>
+</svg>

--- a/scripts/dataset/add_extract.py
+++ b/scripts/dataset/add_extract.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Add an extract to the encrypted dataset.
+
+Usage:
+    python scripts/dataset/add_extract.py \
+        --source-name "Speaker Name" \
+        --extract-text-file /path/to/plaintext.txt \
+        --metadata "discourse_type=populist,era=2025,regime_type=democracy"
+
+Workflow:
+    1. Load encrypted dataset in memory
+    2. Read plaintext from user-supplied file (never committed)
+    3. Append extract with metadata
+    4. Re-encrypt and save
+    5. Print opaque ID for use in PRs/dashboards
+
+Privacy: the plaintext file is never persisted under a tracked path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+# Repo root = 3 levels up from this script.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = REPO_ROOT / "argumentation_analysis" / "data"
+ENCRYPTED_PATH = DATA_DIR / "extract_sources.json.gz.enc"
+
+
+def _is_tracked(file_path: Path) -> bool:
+    """Return True if *file_path* is tracked by git."""
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "--error-unmatch", str(file_path)],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+        )
+        return result.returncode == 0
+    except FileNotFoundError:
+        return False
+
+
+def _parse_metadata(raw: str) -> dict[str, str]:
+    """Parse 'key=val,key2=val2' into a dict."""
+    meta: dict[str, str] = {}
+    for pair in raw.split(","):
+        pair = pair.strip()
+        if "=" in pair:
+            k, v = pair.split("=", 1)
+            meta[k.strip()] = v.strip()
+    return meta
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Add an extract to the encrypted dataset."
+    )
+    parser.add_argument(
+        "--source-name", required=True, help="Display name of the source."
+    )
+    parser.add_argument(
+        "--extract-text-file",
+        required=True,
+        type=Path,
+        help="Path to a local plaintext file (never committed).",
+    )
+    parser.add_argument(
+        "--metadata",
+        default="",
+        help="Comma-separated key=value pairs (e.g. 'discourse_type=populist,era=2025').",
+    )
+    args = parser.parse_args(argv)
+
+    text_file = args.extract_text_file.resolve()
+
+    # --- Privacy guard ---
+    if _is_tracked(text_file):
+        print(
+            f"ERROR: {text_file} is tracked by git. "
+            "Provide a plaintext file outside the repo or gitignored.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not text_file.exists():
+        print(f"ERROR: file not found: {text_file}", file=sys.stderr)
+        return 1
+
+    plaintext = text_file.read_text(encoding="utf-8").strip()
+    if not plaintext:
+        print("ERROR: empty plaintext file.", file=sys.stderr)
+        return 1
+
+    # --- Load encrypted dataset ---
+    from dotenv import load_dotenv
+
+    load_dotenv(REPO_ROOT / ".env")
+
+    import os
+
+    passphrase = os.getenv("TEXT_CONFIG_PASSPHRASE")
+    if not passphrase:
+        print("ERROR: TEXT_CONFIG_PASSPHRASE not set in .env", file=sys.stderr)
+        return 1
+
+    from argumentation_analysis.core.utils.crypto_utils import derive_encryption_key
+    from argumentation_analysis.core.io_manager import (
+        load_extract_definitions,
+        save_extract_definitions,
+    )
+
+    key = derive_encryption_key(passphrase)
+    if not key:
+        print("ERROR: failed to derive encryption key.", file=sys.stderr)
+        return 1
+
+    b64_key = key.decode("utf-8")
+
+    definitions = load_extract_definitions(
+        config_file=ENCRYPTED_PATH,
+        b64_derived_key=b64_key,
+        raise_on_decrypt_error=True,
+    )
+
+    # --- Build new extract entry ---
+    metadata = _parse_metadata(args.metadata) if args.metadata else {}
+    new_extract = {
+        "source_name": args.source_name,
+        "source_type": metadata.get("source_type", "text"),
+        "schema": "v1",
+        "host_parts": metadata.get("host_parts", "local").split(","),
+        "path": metadata.get("path", ""),
+        "extracts": [
+            {
+                "full_text": plaintext,
+                "num_extract": 1,
+                "metadata": metadata,
+            }
+        ],
+    }
+
+    definitions.append(new_extract)
+
+    # --- Save re-encrypted ---
+    ok = save_extract_definitions(
+        extract_definitions=definitions,
+        config_file=ENCRYPTED_PATH,
+        b64_derived_key=b64_key,
+        embed_full_text=True,
+        text_retriever=lambda x: plaintext,
+    )
+    if not ok:
+        print("ERROR: failed to save encrypted dataset.", file=sys.stderr)
+        return 1
+
+    # --- Print opaque ID ---
+    from argumentation_analysis.evaluation.opaque_id import opaque_id
+
+    oid = opaque_id(args.source_name)
+    print(f"OK — extract added. opaque_id: {oid}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dataset/build_pattern_report.py
+++ b/scripts/dataset/build_pattern_report.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Build discourse pattern report from signature files.
+
+Usage:
+    python scripts/dataset/build_pattern_report.py [--signatures-dir .analysis_kb/signatures]
+
+Reads ``signature_*.json`` files, runs pattern mining (C.3), and generates:
+- ``docs/reports/discourse_patterns.md``
+- ``docs/reports/discourse_patterns/*.svg`` (heatmap, radar, asymmetry)
+"""
+import argparse
+import json
+import pathlib
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Sequence
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+
+# Privacy: forbidden strings in any committed output
+FORBIDDEN = ("raw_text", "full_text", "source_name", '"text":', "author")
+
+
+# ---------------------------------------------------------------------------
+# SVG generation helpers (no external dependencies)
+# ---------------------------------------------------------------------------
+
+def _svg_header(w: int, h: int) -> str:
+    return f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" width="{w}" height="{h}">\n'
+
+
+def _svg_text(x: int, y: int, text: str, size: int = 11, anchor: str = "start",
+              color: str = "#333", angle: int = 0) -> str:
+    transform = f' transform="rotate({angle},{x},{y})"' if angle else ""
+    return (f'<text x="{x}" y="{y}" font-size="{size}" '
+            f'fill="{color}" text-anchor="{anchor}"{transform}>{text}</text>\n')
+
+
+def _svg_rect(x: int, y: int, w: int, h: int, fill: str, opacity: float = 1.0) -> str:
+    return (f'<rect x="{x}" y="{y}" width="{w}" height="{h}" '
+            f'fill="{fill}" opacity="{opacity}"/>\n')
+
+
+def _lerp_color(val: float, low: str = "#f0f0f0", high: str = "#2c3e50") -> str:
+    """Interpolate between low and high hex colors based on val ∈ [0, 1]."""
+    if val <= 0:
+        return low
+    if val >= 1:
+        return high
+    lr, lg, lb = int(low[1:3], 16), int(low[3:5], 16), int(low[5:7], 16)
+    hr, hg, hb = int(high[1:3], 16), int(high[3:5], 16), int(high[5:7], 16)
+    r = int(lr + (hr - lr) * val)
+    g = int(lg + (hg - lg) * val)
+    b = int(lb + (hb - lb) * val)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def generate_heatmap_svg(pairs: List[Dict[str, Any]], top_n: int = 15) -> str:
+    """Generate co-occurrence heatmap SVG from pattern_mining pairs."""
+    if not pairs:
+        return _svg_header(400, 200) + _svg_text(200, 100, "No co-occurrence data", 14, "middle") + "</svg>"
+
+    types = sorted({p["a"] for p in pairs} | {p["b"] for p in pairs})[:top_n]
+    n = len(types)
+    cell = max(30, min(50, 500 // max(n, 1)))
+    margin_l, margin_t = 120, 30
+    w = margin_l + n * cell + 40
+    h = margin_t + n * cell + 80
+
+    pair_map = {}
+    for p in pairs:
+        pair_map[(p["a"], p["b"])] = p["lift"]
+        pair_map[(p["b"], p["a"])] = p["lift"]
+
+    max_lift = max((p["lift"] for p in pairs), default=1.0) or 1.0
+    svg = _svg_header(w, h)
+
+    # Column headers
+    for i, t in enumerate(types):
+        x = margin_l + i * cell + cell // 2
+        svg += _svg_text(x, margin_t - 5, t[:12], 8, "middle", angle=-45)
+
+    # Row headers + cells
+    for j, tb in enumerate(types):
+        y = margin_t + j * cell + cell // 2 + 4
+        svg += _svg_text(margin_l - 5, y, tb[:12], 8, "end")
+        for i, ta in enumerate(types):
+            cx = margin_l + i * cell
+            cy = margin_t + j * cell
+            lift = pair_map.get((ta, tb), 0)
+            norm = min(lift / max_lift, 1.0) if max_lift > 0 else 0
+            fill = _lerp_color(norm)
+            svg += _svg_rect(cx, cy, cell - 1, cell - 1, fill, 0.8)
+            if lift > 0:
+                svg += _svg_text(cx + cell // 2, cy + cell // 2 + 4,
+                                 f"{lift:.1f}", 7, "middle", "white")
+
+    svg += _svg_text(w // 2, h - 15, "Fallacy Co-occurrence Heatmap (lift)", 12, "middle", "#2c3e50")
+    svg += "</svg>"
+    return svg
+
+
+def generate_radar_svg(spectrum: Dict[str, Dict[str, float]],
+                       cluster_id: str) -> str:
+    """Generate a simple radar-like bar chart for one cluster's fallacy spectrum."""
+    fallacies = spectrum.get(cluster_id, {})
+    if not fallacies:
+        return _svg_header(400, 200) + _svg_text(200, 100, f"No data for {cluster_id}", 14, "middle") + "</svg>"
+
+    items = sorted(fallacies.items(), key=lambda x: -x[1])[:12]
+    n = len(items)
+    bar_h = 18
+    margin_l, margin_t = 130, 40
+    w = 500
+    h = margin_t + n * (bar_h + 4) + 40
+
+    svg = _svg_header(w, h)
+    svg += _svg_text(w // 2, 20, f"Fallacy Spectrum — {cluster_id}", 13, "middle", "#2c3e50")
+
+    max_val = max((v for _, v in items), default=1.0) or 1.0
+    for i, (ftype, freq) in enumerate(items):
+        y = margin_t + i * (bar_h + 4)
+        svg += _svg_text(margin_l - 5, y + bar_h - 3, ftype[:18], 9, "end")
+        bar_w = int((freq / max_val) * (w - margin_l - 40))
+        svg += _svg_rect(margin_l, y, bar_w, bar_h, "#2c3e50", 0.7)
+        svg += _svg_text(margin_l + bar_w + 5, y + bar_h - 3, f"{freq:.2f}", 8)
+
+    svg += "</svg>"
+    return svg
+
+
+def generate_asymmetry_svg(asymmetry: Dict[str, Dict[str, float]]) -> str:
+    """Generate Tricherie vs Influence asymmetry bar chart."""
+    if not asymmetry:
+        return _svg_header(400, 200) + _svg_text(200, 100, "No asymmetry data", 14, "middle") + "</svg>"
+
+    clusters = sorted(asymmetry.keys())
+    n = len(clusters)
+    bar_w = 60
+    margin_l, margin_t = 100, 40
+    gap = 40
+    w = margin_l + n * (bar_w + gap) + 40
+    h = 300
+
+    svg = _svg_header(w, h)
+    svg += _svg_text(w // 2, 20, "Tricherie vs Influence Asymmetry", 13, "middle", "#2c3e50")
+
+    max_val = 1.0
+    for i, cid in enumerate(clusters):
+        x = margin_l + i * (bar_w + gap)
+        d = asymmetry[cid]
+        t_share = d.get("tricherie_share", 0)
+        i_share = d.get("influence_share", 0)
+        total = t_share + i_share
+
+        # Tricherie bar (bottom, dark)
+        t_h = int((t_share / max_val) * 180) if max_val > 0 else 0
+        svg += _svg_rect(x, 240 - t_h - int((i_share / max_val) * 180),
+                         bar_w, t_h, "#8b4513", 0.8)
+
+        # Influence bar (top, blue)
+        i_h = int((i_share / max_val) * 180) if max_val > 0 else 0
+        svg += _svg_rect(x, 240 - i_h, bar_w, i_h, "#2c3e50", 0.8)
+
+        svg += _svg_text(x + bar_w // 2, 258, cid[:10], 8, "middle")
+        asym_val = d.get("asymmetry", 0)
+        svg += _svg_text(x + bar_w // 2, 272, f"{asym_val:+.2f}", 8, "middle", "#666")
+
+    svg += _svg_text(30, 80, "Influence", 9, "middle", "#2c3e50")
+    svg += _svg_text(30, 200, "Tricherie", 9, "middle", "#8b4513")
+    svg += "</svg>"
+    return svg
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+def load_signatures(signatures_dir: pathlib.Path) -> List[Dict[str, Any]]:
+    """Load all signature_*.json files from directory."""
+    sigs = []
+    if not signatures_dir.is_dir():
+        return sigs
+    for p in sorted(signatures_dir.glob("signature_*.json")):
+        try:
+            sigs.append(json.loads(p.read_text(encoding="utf-8")))
+        except (json.JSONDecodeError, OSError):
+            continue
+    return sigs
+
+
+def privacy_guard(content: str) -> None:
+    """Exit with error if forbidden strings found in content."""
+    lower = content.lower()
+    for f in FORBIDDEN:
+        if f.lower() in lower:
+            print(f"PRIVACY GUARD: forbidden string '{f}' found in report", file=sys.stderr)
+            sys.exit(1)
+
+
+def build_report(signatures: List[Dict[str, Any]],
+                 output_dir: pathlib.Path,
+                 report_path: pathlib.Path) -> pathlib.Path:
+    """Generate discourse_patterns.md + SVG charts."""
+    from argumentation_analysis.evaluation.pattern_mining import (
+        cooccurrence_matrix,
+        cross_coverage,
+        fallacy_spectrum,
+        run_formal_detectors,
+        trick_vs_influence_ratio,
+        FORMAL_DETECTORS,
+    )
+
+    n_docs = len(signatures)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    # 1. Spectral analysis
+    spectrum = fallacy_spectrum(signatures)
+    cluster_ids = sorted(spectrum.keys())
+
+    # 2. Asymmetry
+    asymmetry = trick_vs_influence_ratio(signatures)
+
+    # 3. Co-occurrence
+    coocc = cooccurrence_matrix(signatures, top_n=20)
+
+    # 4. Formal detectors
+    formal_results = {}
+    for sig in signatures:
+        cid = sig.get("metadata", {}).get("cluster_id", "unknown")
+        if cid not in formal_results:
+            formal_results[cid] = run_formal_detectors(sig)
+
+    # 5. Cross-coverage
+    xcov = cross_coverage(signatures)
+
+    # --- Build markdown ---
+    md = f"# Discourse Pattern Report\n\n"
+    md += f"**Generated**: {now}\n"
+    md += f"**Documents analyzed**: {n_docs}\n"
+    md += f"**Clusters**: {len(cluster_ids)} ({', '.join(cluster_ids) or 'none'})\n"
+    md += f"**Workflow**: spectacular 17 phases\n\n"
+    md += "---\n\n"
+
+    # Section 2: Spectra
+    md += "## 1. Fallacy Spectra by Cluster\n\n"
+    if spectrum:
+        all_types = sorted({t for c in spectrum.values() for t in c})
+        md += "| Cluster | " + " | ".join(all_types[:10]) + " |\n"
+        md += "|" + "---------|" * (len(all_types[:10]) + 1) + "\n"
+        for cid in cluster_ids:
+            vals = [f"{spectrum[cid].get(t, 0):.2f}" for t in all_types[:10]]
+            md += f"| {cid} | " + " | ".join(vals) + " |\n"
+        md += "\n"
+    else:
+        md += "_No spectral data available._\n\n"
+
+    # Section 3: Asymmetry
+    md += "## 2. Tricherie ↔ Influence Asymmetry\n\n"
+    if asymmetry:
+        md += "| Cluster | Tricherie | Influence | Ratio | Asymmetry |\n"
+        md += "|---------|-----------|-----------|-------|----------|\n"
+        for cid in sorted(asymmetry.keys()):
+            d = asymmetry[cid]
+            md += (f"| {cid} | {d.get('tricherie_share', 0):.3f} | "
+                   f"{d.get('influence_share', 0):.3f} | "
+                   f"{d.get('ratio', 0):.2f} | "
+                   f"{d.get('asymmetry', 0):+.3f} |\n")
+        md += "\n"
+    else:
+        md += "_No asymmetry data._\n\n"
+
+    # Section 4: Co-occurrences
+    md += "## 3. Co-occurrence Top-20\n\n"
+    if coocc.get("pairs"):
+        md += "| Fallacy A | Fallacy B | Support | Confidence | Lift | Jaccard |\n"
+        md += "|-----------|-----------|---------|------------|------|--------|\n"
+        for p in coocc["pairs"][:20]:
+            md += (f"| {p['a']} | {p['b']} | {p['support']} | "
+                   f"{p['confidence']:.3f} | {p['lift']:.2f} | "
+                   f"{p['jaccard']:.3f} |\n")
+        md += f"\n_Units with co-occurrences: {coocc.get('unit_count', 0)}_\n\n"
+    else:
+        md += "_No co-occurrence data._\n\n"
+
+    # Section 5: Formal patterns
+    md += "## 4. Formal Pattern Detectors\n\n"
+    for det in FORMAL_DETECTORS:
+        md += f"### {det.name}\n\n"
+        if formal_results:
+            md += "| Cluster | " + " | ".join(k for k in next(iter(formal_results.values())).get(det.name, {}).keys()) + " |\n"
+            header_cols = list(next(iter(formal_results.values())).get(det.name, {}).keys())
+            md += "|" + "------|" * (len(header_cols) + 1) + "\n"
+            for cid, results in sorted(formal_results.items()):
+                vals = results.get(det.name, {})
+                md += f"| {cid} | " + " | ".join(f"{vals.get(k, 0):.3f}" for k in header_cols) + " |\n"
+        md += "\n"
+
+    # Section 6: Cross-coverage
+    md += "## 5. Cross-coverage: Informal ↔ Formal\n\n"
+    if xcov:
+        signals = ["fol_invalid", "dung_unsupported", "jtms_retraction"]
+        md += "| Fallacy Type | " + " | ".join(s.title() for s in signals) + " |\n"
+        md += "|" + "------|" * (len(signals) + 1) + "\n"
+        for ftype in sorted(xcov.keys()):
+            vals = [f"{xcov[ftype].get(s, 0):.2f}" for s in signals]
+            md += f"| {ftype} | " + " | ".join(vals) + " |\n"
+        md += "\n_Hypothesis: manipulation = camouflaging formal errors?_\n\n"
+    else:
+        md += "_No cross-coverage data._\n\n"
+
+    # Section 7: Limitations
+    md += "## 6. Limitations & Next Steps\n\n"
+    md += "- Coverage limited to available corpus subset\n"
+    md += "- Sampling bias toward represented discourse types\n"
+    md += "- Formal detector registry is extensible (see `pattern_mining.FORMAL_DETECTORS`)\n"
+    md += "- Future: temporal comparison, richer metadata, LLM-assisted narrative\n"
+
+    # Privacy guard
+    privacy_guard(md)
+
+    # Write report
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(md, encoding="utf-8")
+
+    # Write SVGs
+    svg_dir = output_dir / "discourse_patterns"
+    svg_dir.mkdir(parents=True, exist_ok=True)
+
+    (svg_dir / "heatmap_fallacies.svg").write_text(
+        generate_heatmap_svg(coocc.get("pairs", [])), encoding="utf-8")
+    (svg_dir / "asymmetry_chart.svg").write_text(
+        generate_asymmetry_svg(asymmetry), encoding="utf-8")
+
+    for cid in cluster_ids[:5]:
+        (svg_dir / f"spectrum_radar_{cid}.svg").write_text(
+            generate_radar_svg(spectrum, cid), encoding="utf-8")
+
+    return report_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build discourse pattern report from signature files")
+    parser.add_argument("--signatures-dir", type=pathlib.Path,
+                        default=pathlib.Path(".analysis_kb/signatures"))
+    args = parser.parse_args()
+
+    signatures = load_signatures(args.signatures_dir)
+    if not signatures:
+        print("No signature files found. Generate them with pattern-rerun first.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    report_path = REPO_ROOT / "docs" / "reports" / "discourse_patterns.md"
+    output_dir = REPO_ROOT / "docs" / "reports"
+
+    result = build_report(signatures, output_dir, report_path)
+    print(f"Report: {result}")
+    print(f"SVGs:   {output_dir / 'discourse_patterns'}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/dataset/run_corpus_batch.py
+++ b/scripts/dataset/run_corpus_batch.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Corpus batch runner — encrypted corpus → per-doc sanitized signatures.
+
+Iterates over every (source, extract) in the encrypted dataset, runs the
+chosen workflow on each, and persists both the full state dump and a
+privacy-safe signature.
+
+Usage:
+    python scripts/dataset/run_corpus_batch.py \
+        --workflow spectacular \
+        --output-dir .analysis_kb/signatures \
+        --max-docs 0 \
+        --skip-existing
+
+Output layout (all gitignored):
+    .analysis_kb/
+    ├── state_dumps/   state_full_<opaque_id>.json
+    └── signatures/    signature_<opaque_id>.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Coroutine, Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DATA_DIR = REPO_ROOT / "argumentation_analysis" / "data"
+ENCRYPTED_PATH = DATA_DIR / "extract_sources.json.gz.enc"
+DEFAULT_KB = REPO_ROOT / ".analysis_kb"
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+logger = logging.getLogger("corpus_batch")
+
+
+# ---------------------------------------------------------------------------
+# Metadata classifier — simple heuristics from source_name / date
+# ---------------------------------------------------------------------------
+
+
+def classify_metadata(source_name: str, date_iso: str = "") -> Dict[str, str]:
+    """Infer discourse_type, era, regime_type from source metadata.
+
+    This is a best-effort heuristic.  When metadata is unavailable the
+    fields default to ``"unknown"``.
+    """
+    meta: Dict[str, str] = {
+        "discourse_type": "unknown",
+        "era": "unknown",
+        "regime_type": "unknown",
+        "year_bucket": "unknown",
+    }
+    name_lower = source_name.lower()
+
+    # Era from date
+    if date_iso and len(date_iso) >= 4:
+        try:
+            year = int(date_iso[:4])
+            meta["era"] = str(year)
+            bucket = f"{(year // 5) * 5}-{(year // 5) * 5 + 4}"
+            meta["year_bucket"] = bucket
+        except ValueError:
+            pass
+
+    # Discourse type heuristics (very loose)
+    political_kw = {"discours", "president", "ministre", "chancelier", "speech"}
+    media_kw = {"editorial", "tribune", "chronique", "op-ed"}
+    scientific_kw = {"etude", "rapport", "study", "report"}
+    if any(kw in name_lower for kw in political_kw):
+        meta["discourse_type"] = "political"
+    elif any(kw in name_lower for kw in media_kw):
+        meta["discourse_type"] = "media"
+    elif any(kw in name_lower for kw in scientific_kw):
+        meta["discourse_type"] = "scientific"
+
+    # Regime type (default for Western democracies)
+    meta["regime_type"] = "democracy"
+
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Per-document processing
+# ---------------------------------------------------------------------------
+
+
+async def _run_single(
+    text: str,
+    source_name: str,
+    opaque_id_str: str,
+    workflow: str,
+    metadata: Dict[str, str],
+    state_dumps_dir: Path,
+    signatures_dir: Path,
+    skip_existing: bool,
+    pipeline_fn: Optional[Any] = None,
+    sanitize_fn: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Process one document and write outputs.  Returns signature dict or None."""
+
+    sig_path = signatures_dir / f"signature_{opaque_id_str}.json"
+    if skip_existing and sig_path.exists():
+        logger.info("[%s] skip (signature exists)", opaque_id_str)
+        return None
+
+    if sanitize_fn is None:
+        from argumentation_analysis.evaluation.sanitize_state import sanitize_state
+
+        sanitize_fn = sanitize_state
+
+    t0 = time.perf_counter()
+    partial = False
+    state_snapshot: Dict[str, Any] = {}
+
+    try:
+        if pipeline_fn is None:
+            from argumentation_analysis.orchestration.unified_pipeline import (
+                run_unified_analysis,
+            )
+
+            pipeline_fn = run_unified_analysis
+
+        result = await asyncio.wait_for(
+            pipeline_fn(text, workflow_name=workflow),
+            timeout=600,
+        )
+        state_snapshot = result.get("state_snapshot", {})
+    except asyncio.TimeoutError:
+        logger.warning("[%s] timeout (>600s), marking partial", opaque_id_str)
+        partial = True
+    except Exception as exc:
+        logger.error("[%s] error: %s", opaque_id_str, exc)
+        partial = True
+
+    wall_clock = round(time.perf_counter() - t0, 1)
+
+    # Write full state dump
+    state_dumps_dir.mkdir(parents=True, exist_ok=True)
+    dump_path = state_dumps_dir / f"state_full_{opaque_id_str}.json"
+    dump_path.write_text(
+        json.dumps(state_snapshot, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    logger.info(
+        "[%s] state dump written (%d bytes)", opaque_id_str, dump_path.stat().st_size
+    )
+
+    # Build sanitized signature
+    sanitized = sanitize_fn(state_snapshot)
+    signature: Dict[str, Any] = {
+        "opaque_id": opaque_id_str,
+        "metadata": metadata,
+        "workflow": workflow,
+        "wall_clock_s": wall_clock,
+        "state": sanitized,
+    }
+    if partial:
+        signature["partial"] = True
+
+    signatures_dir.mkdir(parents=True, exist_ok=True)
+    sig_path.write_text(
+        json.dumps(signature, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    logger.info("[%s] signature written (wall=%.1fs)", opaque_id_str, wall_clock)
+
+    return signature
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Corpus batch runner")
+    parser.add_argument(
+        "--workflow",
+        default="spectacular",
+        help="Workflow name (default: spectacular)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_KB / "signatures",
+        help="Directory for sanitized signatures (gitignored)",
+    )
+    parser.add_argument(
+        "--max-docs", type=int, default=0, help="Max docs to process (0 = all)"
+    )
+    parser.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Skip docs with existing signatures",
+    )
+    args = parser.parse_args(argv)
+
+    state_dumps_dir = DEFAULT_KB / "state_dumps"
+
+    # Load encrypted dataset
+    from dotenv import load_dotenv
+
+    load_dotenv(REPO_ROOT / ".env")
+    passphrase = os.getenv("TEXT_CONFIG_PASSPHRASE")
+    if not passphrase:
+        logger.error("TEXT_CONFIG_PASSPHRASE not set in .env")
+        return 1
+
+    from argumentation_analysis.core.utils.crypto_utils import derive_encryption_key
+    from argumentation_analysis.core.io_manager import load_extract_definitions
+    from argumentation_analysis.evaluation.opaque_id import opaque_id
+
+    key = derive_encryption_key(passphrase)
+    if not key:
+        logger.error("Failed to derive encryption key")
+        return 1
+
+    definitions = load_extract_definitions(
+        config_file=ENCRYPTED_PATH,
+        b64_derived_key=key.decode("utf-8"),
+        raise_on_decrypt_error=True,
+    )
+
+    # Flatten to (source_name, full_text, metadata) tuples
+    docs: List[Dict[str, Any]] = []
+    for source_def in definitions:
+        src_name = source_def.get("source_name", "unknown")
+        src_meta = source_def.get("metadata", {})
+        date_iso = src_meta.get("date_iso", source_def.get("date", ""))
+        classified = classify_metadata(src_name, date_iso)
+        # Merge source-level metadata into classified
+        for k, v in src_meta.items():
+            classified.setdefault(k, v)
+
+        for extract in source_def.get("extracts", []):
+            full_text = extract.get("full_text", "")
+            if not full_text:
+                continue
+            oid = opaque_id(src_name)
+            docs.append(
+                {
+                    "source_name": src_name,
+                    "opaque_id": oid,
+                    "full_text": full_text,
+                    "metadata": classified,
+                }
+            )
+
+    if args.max_docs > 0:
+        docs = docs[: args.max_docs]
+
+    logger.info(
+        "Starting batch: %d docs, workflow=%s, skip_existing=%s",
+        len(docs),
+        args.workflow,
+        args.skip_existing,
+    )
+
+    # Process documents serially
+    signatures: List[Dict[str, Any]] = []
+    for i, doc in enumerate(docs, 1):
+        logger.info("[%d/%d] Processing %s", i, len(docs), doc["opaque_id"])
+        sig = asyncio.run(
+            _run_single(
+                text=doc["full_text"],
+                source_name=doc["source_name"],
+                opaque_id_str=doc["opaque_id"],
+                workflow=args.workflow,
+                metadata=doc["metadata"],
+                state_dumps_dir=state_dumps_dir,
+                signatures_dir=args.output_dir,
+                skip_existing=args.skip_existing,
+            )
+        )
+        if sig is not None:
+            signatures.append(sig)
+
+    logger.info(
+        "Batch complete: %d/%d signatures produced",
+        len(signatures),
+        len(docs),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_add_extract.py
+++ b/tests/integration/test_add_extract.py
@@ -1,0 +1,146 @@
+"""Integration tests for scripts/dataset/add_extract.py.
+
+Uses mocked io_manager to avoid needing real encryption keys.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Make the script importable.
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / "scripts" / "dataset"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import add_extract
+
+
+class TestParseMetadata:
+    def test_simple_keyval(self):
+        result = add_extract._parse_metadata("discourse_type=populist")
+        assert result == {"discourse_type": "populist"}
+
+    def test_multiple_keys(self):
+        result = add_extract._parse_metadata("a=1,b=2,c=3")
+        assert result == {"a": "1", "b": "2", "c": "3"}
+
+    def test_empty_string(self):
+        result = add_extract._parse_metadata("")
+        assert result == {}
+
+    def test_value_with_equals(self):
+        result = add_extract._parse_metadata("key=val=ue")
+        assert result == {"key": "val=ue"}
+
+
+class TestIsTracked:
+    def test_tracked_file(self, tmp_path):
+        # We mock subprocess.run to simulate git tracking
+        with patch("add_extract.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            assert add_extract._is_tracked(tmp_path / "somefile.txt") is True
+
+    def test_untracked_file(self, tmp_path):
+        with patch("add_extract.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=128)
+            assert add_extract._is_tracked(tmp_path / "somefile.txt") is False
+
+    def test_git_not_found(self, tmp_path):
+        with patch("add_extract.subprocess.run", side_effect=FileNotFoundError):
+            assert add_extract._is_tracked(tmp_path / "somefile.txt") is False
+
+
+class TestPrivacyGuard:
+    def test_refuses_tracked_file(self, tmp_path):
+        """add_extract must refuse if the plaintext file is git-tracked."""
+        plaintext = tmp_path / "tracked.txt"
+        plaintext.write_text("Some text", encoding="utf-8")
+
+        with patch("add_extract._is_tracked", return_value=True):
+            ret = add_extract.main(
+                [
+                    "--source-name",
+                    "Test",
+                    "--extract-text-file",
+                    str(plaintext),
+                ]
+            )
+        assert ret == 1
+
+    def test_refuses_nonexistent_file(self, tmp_path):
+        ret = add_extract.main(
+            [
+                "--source-name",
+                "Test",
+                "--extract-text-file",
+                str(tmp_path / "nonexistent.txt"),
+            ]
+        )
+        assert ret == 1
+
+    def test_refuses_empty_file(self, tmp_path):
+        plaintext = tmp_path / "empty.txt"
+        plaintext.write_text("", encoding="utf-8")
+        with patch("add_extract._is_tracked", return_value=False):
+            ret = add_extract.main(
+                [
+                    "--source-name",
+                    "Test",
+                    "--extract-text-file",
+                    str(plaintext),
+                ]
+            )
+        assert ret == 1
+
+
+class TestRoundtrip:
+    def test_add_and_reload(self, tmp_path):
+        """Roundtrip: add extract → reload → verify present."""
+        plaintext = tmp_path / "speech.txt"
+        plaintext.write_text("Citizens must have a voice.", encoding="utf-8")
+
+        saved_definitions: list = []
+
+        def mock_save(
+            extract_definitions,
+            config_file,
+            b64_derived_key,
+            embed_full_text=False,
+            config=None,
+            text_retriever=None,
+        ):
+            saved_definitions.extend(extract_definitions)
+            return True
+
+        with patch("add_extract._is_tracked", return_value=False), patch(
+            "argumentation_analysis.core.io_manager.load_extract_definitions",
+            return_value=[],
+        ), patch(
+            "argumentation_analysis.core.io_manager.save_extract_definitions",
+            side_effect=mock_save,
+        ), patch(
+            "argumentation_analysis.core.utils.crypto_utils.derive_encryption_key",
+            return_value=b"dGVzdGtleQ==",
+        ), patch.dict(
+            os.environ, {"TEXT_CONFIG_PASSPHRASE": "test"}
+        ):
+            ret = add_extract.main(
+                [
+                    "--source-name",
+                    "Test Speaker",
+                    "--extract-text-file",
+                    str(plaintext),
+                    "--metadata",
+                    "discourse_type=populist,era=2025",
+                ]
+            )
+
+        assert ret == 0
+        assert len(saved_definitions) == 1
+        assert saved_definitions[0]["source_name"] == "Test Speaker"

--- a/tests/integration/test_corpus_batch_runner.py
+++ b/tests/integration/test_corpus_batch_runner.py
@@ -1,0 +1,170 @@
+"""Integration tests for scripts/dataset/run_corpus_batch.py.
+
+Uses injected mock pipeline to avoid API calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parents[2] / "scripts" / "dataset"
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import run_corpus_batch as runner
+
+
+def _mock_pipeline(return_value):
+    return AsyncMock(return_value=return_value)
+
+
+def _mock_sanitize(state):
+    """Simple sanitizer that strips raw_text."""
+    state = dict(state)
+    state.pop("raw_text", None)
+    return state
+
+
+# ---------------------------------------------------------------------------
+# classify_metadata tests
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyMetadata:
+    def test_default_unknown(self):
+        meta = runner.classify_metadata("Some Document")
+        assert meta["discourse_type"] == "unknown"
+        assert meta["era"] == "unknown"
+
+    def test_political_keyword(self):
+        meta = runner.classify_metadata("Discours du President")
+        assert meta["discourse_type"] == "political"
+
+    def test_media_keyword(self):
+        meta = runner.classify_metadata("Editorial du Monde")
+        assert meta["discourse_type"] == "media"
+
+    def test_scientific_keyword(self):
+        meta = runner.classify_metadata("Rapport sur le climat")
+        assert meta["discourse_type"] == "scientific"
+
+    def test_era_from_date(self):
+        meta = runner.classify_metadata("Test", date_iso="2024-06-15")
+        assert meta["era"] == "2024"
+        assert meta["year_bucket"] == "2020-2024"
+
+
+# ---------------------------------------------------------------------------
+# _run_single tests (mocked pipeline)
+# ---------------------------------------------------------------------------
+
+
+class TestRunSingle:
+    @pytest.mark.asyncio
+    async def test_produces_signature(self, tmp_path):
+        """Processing a doc produces a sanitized signature file."""
+        mock_result = {
+            "state_snapshot": {
+                "raw_text": "Sensitive text",
+                "source_id": "doc_test",
+                "argument_quality_scores": {"a1": {"overall": 0.9}},
+            }
+        }
+
+        sig = await runner._run_single(
+            text="Test text",
+            source_name="Test Source",
+            opaque_id_str="abcd1234",
+            workflow="spectacular",
+            metadata={"discourse_type": "political"},
+            state_dumps_dir=tmp_path / "dumps",
+            signatures_dir=tmp_path / "sigs",
+            skip_existing=False,
+            pipeline_fn=_mock_pipeline(mock_result),
+            sanitize_fn=_mock_sanitize,
+        )
+
+        assert sig is not None
+        assert sig["opaque_id"] == "abcd1234"
+        assert sig["workflow"] == "spectacular"
+        assert sig["metadata"]["discourse_type"] == "political"
+        assert "raw_text" not in sig["state"]
+        assert sig["state"]["argument_quality_scores"]["a1"]["overall"] == 0.9
+
+        # Files exist
+        assert (tmp_path / "dumps" / "state_full_abcd1234.json").exists()
+        assert (tmp_path / "sigs" / "signature_abcd1234.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_skip_existing(self, tmp_path):
+        """skip_existing=True returns None when signature exists."""
+        sigs = tmp_path / "sigs"
+        sigs.mkdir()
+        (sigs / "signature_abcd1234.json").write_text("{}", encoding="utf-8")
+
+        sig = await runner._run_single(
+            text="x",
+            source_name="x",
+            opaque_id_str="abcd1234",
+            workflow="spectacular",
+            metadata={},
+            state_dumps_dir=tmp_path / "dumps",
+            signatures_dir=sigs,
+            skip_existing=True,
+            sanitize_fn=_mock_sanitize,
+        )
+        assert sig is None
+
+    @pytest.mark.asyncio
+    async def test_partial_on_error(self, tmp_path):
+        """Pipeline error produces partial signature."""
+        failing = AsyncMock(side_effect=RuntimeError("LLM error"))
+
+        sig = await runner._run_single(
+            text="x",
+            source_name="x",
+            opaque_id_str="err12345",
+            workflow="spectacular",
+            metadata={},
+            state_dumps_dir=tmp_path / "dumps",
+            signatures_dir=tmp_path / "sigs",
+            skip_existing=False,
+            pipeline_fn=failing,
+            sanitize_fn=_mock_sanitize,
+        )
+
+        assert sig is not None
+        assert sig.get("partial") is True
+
+    @pytest.mark.asyncio
+    async def test_partial_on_timeout(self, tmp_path):
+        """Timeout produces partial signature."""
+
+        async def _slow(*a, **kw):
+            await asyncio.sleep(10)
+
+        slow_fn = AsyncMock(side_effect=_slow)
+
+        with patch(
+            "run_corpus_batch.asyncio.wait_for", side_effect=asyncio.TimeoutError
+        ):
+            sig = await runner._run_single(
+                text="x",
+                source_name="x",
+                opaque_id_str="tmo12345",
+                workflow="spectacular",
+                metadata={},
+                state_dumps_dir=tmp_path / "dumps",
+                signatures_dir=tmp_path / "sigs",
+                skip_existing=False,
+                pipeline_fn=slow_fn,
+                sanitize_fn=_mock_sanitize,
+            )
+
+        assert sig is not None
+        assert sig.get("partial") is True

--- a/tests/integration/test_pattern_report.py
+++ b/tests/integration/test_pattern_report.py
@@ -1,0 +1,294 @@
+"""Integration tests for build_pattern_report.py (C.4 — Issue #412).
+
+Uses synthetic fixture signatures to validate report generation,
+SVG output, and privacy guard without requiring real corpus data.
+"""
+
+import json
+import pathlib
+import textwrap
+
+import pytest
+
+from argumentation_analysis.evaluation.pattern_mining import (
+    FORMAL_DETECTORS,
+    cooccurrence_matrix,
+    cross_coverage,
+    fallacy_spectrum,
+    run_formal_detectors,
+    trick_vs_influence_ratio,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic fixture signatures
+# ---------------------------------------------------------------------------
+
+def _make_signature(
+    cluster_id: str = "test_cluster",
+    fallacies: dict | None = None,
+    dung_args: int = 0,
+    dung_attacks: int = 0,
+    jtms_retractions: int = 0,
+    fol_valid: bool = True,
+) -> dict:
+    """Build a minimal synthetic signature for testing."""
+    fallacies = fallacies or {}
+    identified = {}
+    for i, (ftype, src) in enumerate(fallacies.items()):
+        identified[f"f{i}"] = {"type": ftype, "source_arg": src}
+
+    dung_fw = {}
+    if dung_args > 0:
+        dung_fw["fw0"] = {
+            "arguments": [f"arg{j}" for j in range(dung_args)],
+            "attacks": [
+                {"from": f"arg{j}", "to": f"arg{j+1}"}
+                for j in range(min(dung_attacks, dung_args - 1))
+            ],
+            "extensions": {"grounded": [[f"arg{j}" for j in range(dung_args)]]},
+        }
+
+    jtms_beliefs = {f"b{j}": {"justification": f"j{j}"} for j in range(dung_args)}
+    state = {
+        "identified_fallacies": identified,
+        "dung_frameworks": dung_fw,
+        "jtms_beliefs": jtms_beliefs,
+        "jtms_retraction_chain": [{"from": f"b{j}", "to": f"b{j+1}"} for j in range(jtms_retractions)],
+        "fol_analysis_results": [] if fol_valid else [{"valid": False}],
+        "atms_contexts": [],
+    }
+    return {"metadata": {"cluster_id": cluster_id}, "state": state}
+
+
+@pytest.fixture
+def synthetic_signatures():
+    """3 documents across 2 clusters with varied fallacy profiles."""
+    return [
+        _make_signature(
+            "propaganda",
+            {"ad_hominem": "arg0", "appeal_to_fear": "arg1", "straw_man": "arg0"},
+            dung_args=4, dung_attacks=3, jtms_retractions=2, fol_valid=False,
+        ),
+        _make_signature(
+            "propaganda",
+            {"ad_hominem": "arg0", "bandwagon": "arg2", "cherry_picking": "arg3"},
+            dung_args=2, dung_attacks=1, jtms_retractions=0,
+        ),
+        _make_signature(
+            "debate",
+            {"straw_man": "arg0", "false_dilemma": "arg1", "red_herring": "arg2"},
+            dung_args=3, dung_attacks=2, jtms_retractions=1, fol_valid=False,
+        ),
+    ]
+
+
+@pytest.fixture
+def sig_dir(tmp_path, synthetic_signatures):
+    """Write synthetic signatures to temp directory as JSON files."""
+    for i, sig in enumerate(synthetic_signatures):
+        (tmp_path / f"signature_{i:03d}.json").write_text(
+            json.dumps(sig), encoding="utf-8"
+        )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Test: pattern_mining functions on synthetic data
+# ---------------------------------------------------------------------------
+
+class TestPatternMining:
+    """Verify pattern_mining functions produce valid output on synthetic data."""
+
+    def test_fallacy_spectrum_returns_clusters(self, synthetic_signatures):
+        spectrum = fallacy_spectrum(synthetic_signatures)
+        assert "propaganda" in spectrum
+        assert "debate" in spectrum
+        # Relative frequencies should sum to ~1.0 per cluster
+        for cid, types in spectrum.items():
+            total = sum(types.values())
+            assert 0.0 < total <= 1.01, f"Cluster {cid} sum={total}"
+
+    def test_fallacy_spectrum_values(self, synthetic_signatures):
+        spectrum = fallacy_spectrum(synthetic_signatures)
+        # propaganda cluster has ad_hominem in both docs → should have highest freq
+        prop = spectrum["propaganda"]
+        assert "ad_hominem" in prop
+        assert prop["ad_hominem"] > 0
+
+    def test_trick_vs_influence_ratio(self, synthetic_signatures):
+        asym = trick_vs_influence_ratio(synthetic_signatures)
+        assert "propaganda" in asym
+        assert "debate" in asym
+        for cid, d in asym.items():
+            assert "tricherie_share" in d
+            assert "influence_share" in d
+            assert "asymmetry" in d
+            assert -1.0 <= d["asymmetry"] <= 1.0
+
+    def test_cooccurrence_matrix(self, synthetic_signatures):
+        coocc = cooccurrence_matrix(synthetic_signatures, top_n=10)
+        assert "pairs" in coocc
+        assert "unit_count" in coocc
+        # With co-occurring fallacies in same source_arg, we should get some pairs
+        assert coocc["unit_count"] >= 0
+
+    def test_cross_coverage(self, synthetic_signatures):
+        xcov = cross_coverage(synthetic_signatures)
+        assert isinstance(xcov, dict)
+        # At least one fallacy type should appear
+        if xcov:
+            for ftype, signals in xcov.items():
+                for sig_name in ["fol_invalid", "dung_unsupported", "jtms_retraction"]:
+                    assert sig_name in signals
+
+    def test_formal_detectors(self, synthetic_signatures):
+        for sig in synthetic_signatures:
+            results = run_formal_detectors(sig)
+            assert len(results) == len(FORMAL_DETECTORS)
+            for det in FORMAL_DETECTORS:
+                assert det.name in results
+                metrics = results[det.name]
+                assert all(isinstance(v, float) for v in metrics.values())
+
+
+# ---------------------------------------------------------------------------
+# Test: build_pattern_report functions
+# ---------------------------------------------------------------------------
+
+class TestReportBuilder:
+    """Test report generation and SVG output."""
+
+    def test_load_signatures(self, sig_dir, synthetic_signatures):
+        from scripts.dataset.build_pattern_report import load_signatures
+
+        loaded = load_signatures(sig_dir)
+        assert len(loaded) == len(synthetic_signatures)
+
+    def test_load_signatures_empty_dir(self, tmp_path):
+        from scripts.dataset.build_pattern_report import load_signatures
+
+        assert load_signatures(tmp_path) == []
+        assert load_signatures(tmp_path / "nonexistent") == []
+
+    def test_build_report_generates_markdown(self, sig_dir, tmp_path):
+        from scripts.dataset.build_pattern_report import load_signatures, build_report
+
+        sigs = load_signatures(sig_dir)
+        report_path = tmp_path / "discourse_patterns.md"
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = build_report(sigs, output_dir, report_path)
+        assert result == report_path
+        assert report_path.exists()
+
+        content = report_path.read_text(encoding="utf-8")
+        assert "# Discourse Pattern Report" in content
+        assert "## 1. Fallacy Spectra by Cluster" in content
+        assert "## 2. Tricherie" in content
+        assert "## 3. Co-occurrence" in content
+        assert "## 4. Formal Pattern Detectors" in content
+        assert "## 5. Cross-coverage" in content
+        assert "## 6. Limitations" in content
+
+    def test_build_report_generates_svgs(self, sig_dir, tmp_path):
+        from scripts.dataset.build_pattern_report import load_signatures, build_report
+
+        sigs = load_signatures(sig_dir)
+        report_path = tmp_path / "discourse_patterns.md"
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        build_report(sigs, output_dir, report_path)
+
+        svg_dir = output_dir / "discourse_patterns"
+        assert svg_dir.is_dir()
+        assert (svg_dir / "heatmap_fallacies.svg").exists()
+        assert (svg_dir / "asymmetry_chart.svg").exists()
+
+        # Heatmap should contain SVG markup
+        heatmap = (svg_dir / "heatmap_fallacies.svg").read_text(encoding="utf-8")
+        assert "<svg" in heatmap
+        assert "</svg>" in heatmap
+
+    def test_build_report_generates_radar_svgs(self, sig_dir, tmp_path):
+        from scripts.dataset.build_pattern_report import load_signatures, build_report
+
+        sigs = load_signatures(sig_dir)
+        report_path = tmp_path / "discourse_patterns.md"
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        build_report(sigs, output_dir, report_path)
+
+        svg_dir = output_dir / "discourse_patterns"
+        radar_files = list(svg_dir.glob("spectrum_radar_*.svg"))
+        # Should have at least one radar for each cluster (up to 5)
+        assert len(radar_files) >= 1
+
+    def test_privacy_guard_blocks_forbidden_strings(self):
+        from scripts.dataset.build_pattern_report import privacy_guard
+
+        for forbidden in ["raw_text", "full_text", "source_name", '"text":', "author"]:
+            with pytest.raises(SystemExit, match="1"):
+                privacy_guard(f"This has {forbidden} in it")
+
+    def test_privacy_guard_allows_clean_content(self):
+        from scripts.dataset.build_pattern_report import privacy_guard
+
+        # Should not raise
+        privacy_guard("Clean content with no forbidden strings")
+        privacy_guard("Fallacy spectra and co-occurrence data")
+
+
+# ---------------------------------------------------------------------------
+# Test: SVG generation edge cases
+# ---------------------------------------------------------------------------
+
+class TestSVGGeneration:
+    """Test SVG generation with edge-case inputs."""
+
+    def test_heatmap_empty_pairs(self):
+        from scripts.dataset.build_pattern_report import generate_heatmap_svg
+
+        svg = generate_heatmap_svg([])
+        assert "<svg" in svg
+        assert "No co-occurrence data" in svg
+
+    def test_radar_empty_cluster(self):
+        from scripts.dataset.build_pattern_report import generate_radar_svg
+
+        svg = generate_radar_svg({}, "nonexistent")
+        assert "<svg" in svg
+        assert "No data for nonexistent" in svg
+
+    def test_asymmetry_empty(self):
+        from scripts.dataset.build_pattern_report import generate_asymmetry_svg
+
+        svg = generate_asymmetry_svg({})
+        assert "<svg" in svg
+        assert "No asymmetry data" in svg
+
+    def test_heatmap_with_data(self):
+        from scripts.dataset.build_pattern_report import generate_heatmap_svg
+
+        pairs = [
+            {"a": "ad_hominem", "b": "straw_man", "lift": 2.5},
+            {"a": "appeal_to_fear", "b": "bandwagon", "lift": 1.8},
+            {"a": "ad_hominem", "b": "appeal_to_fear", "lift": 3.1},
+        ]
+        svg = generate_heatmap_svg(pairs)
+        assert "<svg" in svg
+        assert "ad_hominem" in svg
+        assert "2.5" in svg
+
+    def test_asymmetry_with_data(self):
+        from scripts.dataset.build_pattern_report import generate_asymmetry_svg
+
+        data = {
+            "cluster_a": {"tricherie_share": 0.3, "influence_share": 0.7, "asymmetry": 0.4},
+            "cluster_b": {"tricherie_share": 0.6, "influence_share": 0.2, "asymmetry": -0.5},
+        }
+        svg = generate_asymmetry_svg(data)
+        assert "<svg" in svg
+        assert "cluster_a" in svg

--- a/tests/unit/argumentation_analysis/evaluation/test_opaque_id.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_opaque_id.py
@@ -1,0 +1,59 @@
+"""Tests for argumentation_analysis.evaluation.opaque_id."""
+
+import os
+
+import pytest
+
+from argumentation_analysis.evaluation.opaque_id import opaque_id
+
+
+class TestOpaqueIdStability:
+    def test_same_input_same_output(self):
+        assert opaque_id("Speaker A") == opaque_id("Speaker A")
+
+    def test_different_salt_different_output(self):
+        a = opaque_id("Speaker A", salt="salt1")
+        b = opaque_id("Speaker A", salt="salt2")
+        assert a != b
+
+    def test_different_names_different_ids(self):
+        ids = {opaque_id(f"name_{i}") for i in range(100)}
+        assert len(ids) == 100  # no collisions
+
+
+class TestOpaqueIdFormat:
+    def test_length_is_8(self):
+        result = opaque_id("test")
+        assert len(result) == 8
+
+    def test_hex_chars_only(self):
+        result = opaque_id("test")
+        assert all(c in "0123456789abcdef" for c in result)
+
+
+class TestOpaqueIdSaltEnv:
+    def test_env_salt_used(self, monkeypatch):
+        monkeypatch.setenv("OPAQUE_ID_SALT", "env_salt_123")
+        a = opaque_id("test")
+        b = opaque_id("test", salt="env_salt_123")
+        assert a == b
+
+    def test_default_salt_without_env(self, monkeypatch):
+        monkeypatch.delenv("OPAQUE_ID_SALT", raising=False)
+        result = opaque_id("test")
+        assert len(result) == 8  # doesn't crash, uses default
+
+
+class TestOpaqueIdEdgeCases:
+    def test_empty_string(self):
+        result = opaque_id("")
+        assert len(result) == 8
+
+    def test_unicode_name(self):
+        result = opaque_id("François Mitterrand")
+        assert len(result) == 8
+        assert result == opaque_id("François Mitterrand")  # stable
+
+    def test_very_long_name(self):
+        result = opaque_id("x" * 10000)
+        assert len(result) == 8

--- a/tests/unit/argumentation_analysis/evaluation/test_pattern_mining.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_pattern_mining.py
@@ -1,0 +1,406 @@
+"""Tests for argumentation_analysis.evaluation.pattern_mining."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from argumentation_analysis.evaluation.pattern_mining import (
+    FORMAL_DETECTORS,
+    AtmsBranchingDetector,
+    DungTopologyDetector,
+    FormalPatternDetector,
+    JtmsRetractionRateDetector,
+    cooccurrence_matrix,
+    cross_coverage,
+    fallacy_spectrum,
+    run_formal_detectors,
+    trick_vs_influence_ratio,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic signatures
+# ---------------------------------------------------------------------------
+
+
+def _sig(fallacies, cluster="A", **extra_state):
+    """Build a minimal signature dict for testing."""
+    fallacy_dict = {}
+    for i, (ftype, family) in enumerate(fallacies):
+        fallacy_dict[f"f{i}"] = {
+            "type": ftype,
+            "family": family,
+            "source_arg": f"arg_{i % 3}",
+        }
+
+    state = {
+        "identified_fallacies": fallacy_dict,
+        "dung_frameworks": extra_state.get("dung_frameworks", {}),
+        "atms_contexts": extra_state.get("atms_contexts", []),
+        "jtms_beliefs": extra_state.get("jtms_beliefs", {}),
+        "jtms_retraction_chain": extra_state.get("jtms_retraction_chain", []),
+        "fol_analysis_results": extra_state.get("fol_analysis_results", []),
+    }
+    return {
+        "opaque_id": f"test_{cluster}",
+        "metadata": {"cluster_id": cluster},
+        "state": state,
+    }
+
+
+@pytest.fixture
+def sigs_political():
+    """3 signatures in cluster 'political' with mixed fallacies."""
+    return [
+        _sig(
+            [("ad_hominem", "relevance"), ("straw_man", "distortion")],
+            cluster="political",
+        ),
+        _sig(
+            [("slippery_slope", "causal"), ("false_dilemma", "presumption")],
+            cluster="political",
+        ),
+        _sig(
+            [("ad_hominem", "relevance"), ("hasty_generalization", "inductive")],
+            cluster="political",
+        ),
+    ]
+
+
+@pytest.fixture
+def sigs_media():
+    """2 signatures in cluster 'media' with influence-heavy fallacies."""
+    return [
+        _sig(
+            [("appeal_to_emotion", "emotion"), ("bandwagon", "relevance")],
+            cluster="media",
+        ),
+        _sig(
+            [("appeal_to_emotion", "emotion"), ("appeal_to_authority", "authority")],
+            cluster="media",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# fallacy_spectrum
+# ---------------------------------------------------------------------------
+
+
+class TestFallacySpectrum:
+    def test_distribution(self, sigs_political):
+        result = fallacy_spectrum(sigs_political, by="cluster_id")
+        assert "political" in result
+        spec = result["political"]
+        # ad_hominem appears twice in 6 total → 0.3333
+        assert spec.get("ad_hominem", 0) == pytest.approx(0.3333, abs=0.01)
+
+    def test_empty_signatures(self):
+        result = fallacy_spectrum([], by="cluster_id")
+        assert result == {}
+
+    def test_multiple_clusters(self, sigs_political, sigs_media):
+        all_sigs = sigs_political + sigs_media
+        result = fallacy_spectrum(all_sigs, by="cluster_id")
+        assert "political" in result
+        assert "media" in result
+
+
+# ---------------------------------------------------------------------------
+# trick_vs_influence_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestTrickVsInfluence:
+    def test_influence_heavy_cluster(self, sigs_media):
+        result = trick_vs_influence_ratio(sigs_media, by="cluster_id")
+        media = result["media"]
+        assert media["influence_share"] > 0
+        assert media["asymmetry"] > 0  # More influence than tricherie
+
+    def test_mixed_cluster(self, sigs_political):
+        result = trick_vs_influence_ratio(sigs_political, by="cluster_id")
+        pol = result["political"]
+        assert "tricherie_share" in pol
+        assert "influence_share" in pol
+        assert "ratio" in pol
+        assert "asymmetry" in pol
+
+    def test_all_influence_asymmetry_one(self):
+        sigs = [
+            _sig(
+                [("appeal_to_emotion", "emotion"), ("bandwagon", "relevance")],
+                cluster="all_inf",
+            )
+        ]
+        result = trick_vs_influence_ratio(sigs, by="cluster_id")
+        assert result["all_inf"]["asymmetry"] == pytest.approx(1.0, abs=0.01)
+
+    def test_empty(self):
+        result = trick_vs_influence_ratio([])
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# cooccurrence_matrix
+# ---------------------------------------------------------------------------
+
+
+class TestCooccurrenceMatrix:
+    def test_basic_cooccurrence(self):
+        """2 docs with arg containing [A,B] each → support(A,B)=2, lift>1."""
+        sigs = [
+            {
+                "metadata": {"cluster_id": "X"},
+                "state": {
+                    "identified_fallacies": {
+                        "f0": {
+                            "type": "ad_hominem",
+                            "family": "rel",
+                            "source_arg": "arg_shared",
+                        },
+                        "f1": {
+                            "type": "straw_man",
+                            "family": "dist",
+                            "source_arg": "arg_shared",
+                        },
+                    },
+                },
+            },
+            {
+                "metadata": {"cluster_id": "X"},
+                "state": {
+                    "identified_fallacies": {
+                        "f0": {
+                            "type": "ad_hominem",
+                            "family": "rel",
+                            "source_arg": "arg_shared",
+                        },
+                        "f1": {
+                            "type": "straw_man",
+                            "family": "dist",
+                            "source_arg": "arg_shared",
+                        },
+                    },
+                },
+            },
+            _sig(
+                [("false_dilemma", "pres")],
+                cluster="X",
+            ),
+        ]
+        result = cooccurrence_matrix(sigs, unit="argument")
+        pairs = result["pairs"]
+        hm_sm = [p for p in pairs if p["a"] == "ad_hominem" and p["b"] == "straw_man"]
+        assert len(hm_sm) == 1
+        assert hm_sm[0]["support"] == 2
+        assert hm_sm[0]["lift"] >= 1.0
+
+    def test_doc_level(self):
+        sigs = [
+            _sig(
+                [("ad_hominem", "rel"), ("straw_man", "dist")],
+                cluster="X",
+            ),
+        ]
+        result = cooccurrence_matrix(sigs, unit="doc")
+        assert result["unit_count"] >= 1
+
+    def test_no_pairs(self):
+        sigs = [_sig([("ad_hominem", "rel")], cluster="X")]
+        result = cooccurrence_matrix(sigs, unit="argument")
+        assert result["pairs"] == []
+
+    def test_top_n(self):
+        sigs = [_sig([("a", "x"), ("b", "x")], cluster="X")]
+        result = cooccurrence_matrix(sigs, top_n=1)
+        assert len(result["pairs"]) <= 1
+
+
+# ---------------------------------------------------------------------------
+# Formal detectors
+# ---------------------------------------------------------------------------
+
+
+class TestDungTopologyDetector:
+    def test_empty(self):
+        det = DungTopologyDetector()
+        result = det.detect({"state": {}})
+        assert result["n_args"] == 0.0
+        assert result["density"] == 0.0
+
+    def test_with_framework(self):
+        sig = {
+            "state": {
+                "dung_frameworks": {
+                    "fw1": {
+                        "arguments": ["a1", "a2", "a3"],
+                        "attacks": [
+                            {"from": "a1", "to": "a2"},
+                            {"from": "a2", "to": "a3"},
+                        ],
+                        "extensions": {
+                            "grounded": ["a1", "a3"],
+                            "preferred": [["a1", "a3"]],
+                        },
+                    }
+                }
+            }
+        }
+        det = DungTopologyDetector()
+        result = det.detect(sig)
+        assert result["n_args"] == 3.0
+        assert result["n_attacks"] == 2.0
+        assert result["density"] > 0
+        assert result["max_extension_size"] == 2.0
+
+    def test_no_division_by_zero(self):
+        """0 args → density=0, no crash."""
+        sig = {
+            "state": {
+                "dung_frameworks": {
+                    "fw1": {
+                        "arguments": [],
+                        "attacks": [],
+                        "extensions": {},
+                    }
+                }
+            }
+        }
+        result = DungTopologyDetector().detect(sig)
+        assert result["density"] == 0.0
+
+
+class TestAtmsBranchingDetector:
+    def test_empty(self):
+        result = AtmsBranchingDetector().detect({"state": {}})
+        assert result["max_depth"] == 0.0
+        assert result["contradiction_rate"] == 0.0
+
+    def test_with_contexts(self):
+        sig = {
+            "state": {
+                "atms_contexts": [
+                    {"assumptions": ["a1", "a2"], "status": "consistent"},
+                    {"assumptions": ["a3"], "status": "contradictory"},
+                ]
+            }
+        }
+        result = AtmsBranchingDetector().detect(sig)
+        assert result["max_depth"] == 2.0
+        assert result["avg_assumptions"] == 1.5
+        assert result["contradiction_rate"] == 0.5
+
+
+class TestJtmsRetractionRateDetector:
+    def test_empty(self):
+        result = JtmsRetractionRateDetector().detect({"state": {}})
+        assert result["n_beliefs"] == 0.0
+        assert result["retraction_rate"] == 0.0
+
+    def test_with_retractions(self):
+        sig = {
+            "state": {
+                "jtms_beliefs": {
+                    "b1": {"status": "IN", "justification": "j1"},
+                    "b2": {"status": "OUT", "justification": "j2"},
+                    "b3": {"status": "IN", "justification": "j1"},
+                },
+                "jtms_retraction_chain": [{"cascade_id": "c1"}],
+            }
+        }
+        result = JtmsRetractionRateDetector().detect(sig)
+        assert result["n_beliefs"] == 3.0
+        assert result["retraction_rate"] == pytest.approx(0.3333, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# run_formal_detectors
+# ---------------------------------------------------------------------------
+
+
+class TestRunFormalDetectors:
+    def test_default_registry(self):
+        sig = {
+            "state": {"dung_frameworks": {}, "atms_contexts": [], "jtms_beliefs": {}}
+        }
+        result = run_formal_detectors(sig)
+        assert "dung_topology" in result
+        assert "atms_branching" in result
+        assert "jtms_retraction_rate" in result
+
+    def test_custom_detector(self):
+        class DummyDetector:
+            name = "dummy"
+
+            def detect(self, sig):
+                return {"value": 42.0}
+
+        result = run_formal_detectors({}, detectors=[DummyDetector()])
+        assert result["dummy"]["value"] == 42.0
+
+    def test_detector_error_handled(self):
+        class FailingDetector:
+            name = "fail"
+
+            def detect(self, sig):
+                raise ValueError("boom")
+
+        result = run_formal_detectors({}, detectors=[FailingDetector()])
+        assert result["fail"]["error"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# cross_coverage
+# ---------------------------------------------------------------------------
+
+
+class TestCrossCoverage:
+    def test_with_formal_signals(self):
+        sig = {
+            "state": {
+                "identified_fallacies": {
+                    "f1": {
+                        "type": "ad_hominem",
+                        "family": "relevance",
+                        "source_arg": "a1",
+                    },
+                },
+                "fol_analysis_results": [{"valid": False}],
+                "jtms_retraction_chain": [{"cascade_id": "c1"}],
+                "dung_frameworks": {},
+            }
+        }
+        result = cross_coverage([sig])
+        assert "ad_hominem" in result
+        assert result["ad_hominem"]["fol_invalid"] == 1.0
+        assert result["ad_hominem"]["jtms_retraction"] == 1.0
+
+    def test_empty(self):
+        result = cross_coverage([])
+        assert result == {}
+
+    def test_no_formal_signals(self):
+        sigs = [
+            _sig([("ad_hominem", "rel")], cluster="X"),
+        ]
+        result = cross_coverage(sigs)
+        for ftype, signals in result.items():
+            for rate in signals.values():
+                assert rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Registry count
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_three_built_in_detectors(self):
+        assert len(FORMAL_DETECTORS) == 3
+
+    def test_all_implement_protocol(self):
+        for det in FORMAL_DETECTORS:
+            assert isinstance(det, FormalPatternDetector)
+            assert hasattr(det, "name")
+            assert callable(det.detect)

--- a/tests/unit/argumentation_analysis/evaluation/test_sanitize_state.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_sanitize_state.py
@@ -1,0 +1,174 @@
+"""Tests for argumentation_analysis.evaluation.sanitize_state."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from argumentation_analysis.evaluation.sanitize_state import sanitize_state
+
+GOLDEN_FIXTURE = (
+    Path(__file__).resolve().parents[3]
+    / "golden"
+    / "fixtures"
+    / "spectacular"
+    / "doc_a_golden.json"
+)
+
+
+@pytest.fixture
+def golden_state():
+    with open(GOLDEN_FIXTURE, encoding="utf-8") as f:
+        data = json.load(f)
+    return data["state_snapshot"]
+
+
+class TestSanitizeTopLevel:
+    def test_raw_text_stripped(self, golden_state):
+        result = sanitize_state(golden_state)
+        assert "raw_text" not in result
+
+    def test_full_text_stripped(self):
+        state = {"full_text": "sensitive", "count": 5}
+        result = sanitize_state(state)
+        assert "full_text" not in result
+        assert result["count"] == 5
+
+    def test_source_name_stripped(self):
+        state = {"source_name": "Secret Speaker", "score": 0.9}
+        result = sanitize_state(state)
+        assert "source_name" not in result
+
+    def test_all_sensitive_fields_stripped(self):
+        state = {
+            "raw_text": "x",
+            "full_text": "x",
+            "full_text_segment": "x",
+            "raw_text_snippet": "x",
+            "source_name": "x",
+            "document_name": "x",
+            "author": "x",
+            "date_iso": "x",
+            "url": "x",
+        }
+        result = sanitize_state(state)
+        for field in state:
+            assert field not in result
+
+
+class TestSanitizeOpaqueReplace:
+    def test_source_id_opaque(self):
+        state = {"source_id": "Real Name"}
+        result = sanitize_state(state)
+        assert result["source_id"] != "Real Name"
+        assert len(result["source_id"]) == 8
+
+    def test_source_id_stable(self):
+        state = {"source_id": "Same Name"}
+        a = sanitize_state(state)
+        b = sanitize_state(state)
+        assert a["source_id"] == b["source_id"]
+
+
+class TestSanitizePreserved:
+    def test_counts_preserved(self, golden_state):
+        result = sanitize_state(golden_state)
+        assert "summary" not in result  # top-level summary is outside state_snapshot
+        # Check that analysis_tasks (counts) are preserved
+        if "analysis_tasks" in golden_state:
+            assert "analysis_tasks" in result
+
+    def test_scores_preserved(self, golden_state):
+        result = sanitize_state(golden_state)
+        if "argument_quality_scores" in golden_state:
+            assert "argument_quality_scores" in result
+            assert (
+                result["argument_quality_scores"]
+                == golden_state["argument_quality_scores"]
+            )
+
+    def test_structures_preserved(self, golden_state):
+        result = sanitize_state(golden_state)
+        # Dung frameworks should be fully preserved (no text)
+        if "dung_frameworks" in golden_state:
+            assert "dung_frameworks" in result
+            assert result["dung_frameworks"] == golden_state["dung_frameworks"]
+
+    def test_belief_data_preserved(self, golden_state):
+        result = sanitize_state(golden_state)
+        if "jtms_beliefs" in golden_state:
+            assert "jtms_beliefs" in result
+
+
+class TestSanitizeNarrative:
+    def test_narrative_replaced_with_length(self, golden_state):
+        result = sanitize_state(golden_state)
+        if "narrative_synthesis" in golden_state:
+            narr = result["narrative_synthesis"]
+            assert isinstance(narr, dict)
+            assert "length" in narr
+            assert narr["length"] == len(golden_state["narrative_synthesis"])
+            assert narr["stripped"] is True
+
+
+class TestSanitizeCounterArguments:
+    def test_counter_content_stripped(self, golden_state):
+        result = sanitize_state(golden_state)
+        if "counter_arguments" in result:
+            for ca in result["counter_arguments"]:
+                assert "counter_content" not in ca
+                assert "generated_text" not in ca
+                # strategy and strength should survive
+                assert "strategy" in ca
+
+
+class TestSanitizeIdempotence:
+    def test_idempotent(self):
+        state = {
+            "raw_text": "secret",
+            "source_id": "Name",
+            "narrative_synthesis": "A long narrative paragraph.",
+            "counter_arguments": [
+                {"strategy": "reductio", "counter_content": "text", "strength": 0.8}
+            ],
+            "score": 0.9,
+        }
+        first = sanitize_state(state)
+        second = sanitize_state(first)
+        # Stripped fields stay stripped; scores survive
+        assert first["score"] == second["score"] == 0.9
+        assert "raw_text" not in second
+
+    def test_idempotent_on_golden(self, golden_state):
+        first = sanitize_state(golden_state)
+        second = sanitize_state(first)
+        # Scores and structures must survive both passes
+        assert first["argument_quality_scores"] == second["argument_quality_scores"]
+        assert first["dung_frameworks"] == second["dung_frameworks"]
+
+
+class TestSanitizeIdentifiedArguments:
+    def test_arguments_text_stripped(self):
+        state = {
+            "identified_arguments": {
+                "arg1": "Sensitive argument text",
+                "arg2": "Another text",
+            }
+        }
+        result = sanitize_state(state)
+        assert "identified_arguments" in result
+        for v in result["identified_arguments"].values():
+            assert isinstance(v, dict)
+            assert v["text_stripped"] is True
+
+    def test_non_string_values_preserved(self):
+        state = {
+            "identified_arguments": {
+                "arg1": {"score": 0.9, "type": "premise"},
+            }
+        }
+        result = sanitize_state(state)
+        assert result["identified_arguments"]["arg1"] == {
+            "score": 0.9,
+            "type": "premise",
+        }


### PR DESCRIPTION
## Summary

- **C.4 Discourse signature report** — consumes `pattern_mining` API from C.3 (#411) to generate `docs/reports/discourse_patterns.md` with 6 analytical sections + SVG visualizations
- `build_pattern_report.py`: Markdown report (spectra, asymmetry, co-occurrence, formal detectors, cross-coverage, limitations) + SVG charts (heatmap, radar bars, asymmetry bars)
- Privacy guard: blocks forbidden strings (`raw_text`, `full_text`, `source_name`, `author`, `"text":`) in any committed output
- 18 integration tests covering report generation, SVG edge cases, pattern_mining integration, and privacy guard
- Generated initial report with synthetic fixture data (2 clusters: propaganda, debate)

## Dependencies

- **Requires C.3 (#411 / PR #427)** — `pattern_mining.py` must be merged first
- **Requires C.1 (#409 / PR #425)** — `opaque_id.py`, `sanitize_state.py`
- **Requires C.2 (#410 / PR #426)** — batch runner producing `signature_*.json`

## Files

| File | Description |
|------|-------------|
| `scripts/dataset/build_pattern_report.py` | Report generator CLI (365 lines) |
| `tests/integration/test_pattern_report.py` | 18 integration tests |
| `docs/reports/discourse_patterns.md` | Generated report (synthetic data) |
| `docs/reports/discourse_patterns/*.svg` | 4 SVG visualization charts |

## Test plan

- [x] 18/18 integration tests pass
- [x] Privacy guard blocks all forbidden strings
- [x] SVG generation handles empty/edge-case data
- [x] Report generates valid markdown with all 6 sections

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)