### PR TITLE
feat(evaluation): discourse pattern mining module (#411) [reopened from #427]

### DIFF
--- a/argumentation_analysis/evaluation/pattern_mining.py
+++ b/argumentation_analysis/evaluation/pattern_mining.py
@@ -1,0 +1,486 @@
+"""Discourse pattern mining — aggregate signatures into corpus-level patterns.
+
+Consumes ``signature_*.json`` files produced by the C.2 batch runner and
+produces spectral, asymmetry, co-occurrence, formal detector, and
+cross-coverage analyses.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Protocol, Sequence, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Fallacy family mapping — Tricherie (8.x) vs Influence (2.x)
+# ---------------------------------------------------------------------------
+
+# Tricherie: self-bias fallacies (arranger les faits, changement de cap, pensée biaisée)
+TRICHERIE_TYPES = frozenset(
+    {
+        "cherry_picking",
+        "confirmation_bias",
+        "rationalization",
+        "moving_the_goalposts",
+        "special_pleading",
+        "biased_sampling",
+        "false_cause",
+        "hasty_generalization",
+    }
+)
+
+# Influence: inductive fallacies (procédé rhétorique, émotion, manipulation mentale)
+INFLUENCE_TYPES = frozenset(
+    {
+        "ad_hominem",
+        "appeal_to_authority",
+        "appeal_to_emotion",
+        "appeal_to_fear",
+        "bandwagon",
+        "red_herring",
+        "straw_man",
+        "slippery_slope",
+        "false_dilemma",
+        "loaded_question",
+        "circular_reasoning",
+        "equivocation",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Formal pattern detector protocol
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class FormalPatternDetector(Protocol):
+    """Extensible detector for formal logic patterns in a signature."""
+
+    name: str
+
+    def detect(self, signature: Dict[str, Any]) -> Dict[str, float]: ...
+
+
+# ---------------------------------------------------------------------------
+# Built-in detectors
+# ---------------------------------------------------------------------------
+
+
+class DungTopologyDetector:
+    """Extract topological features from Dung argumentation frameworks."""
+
+    name = "dung_topology"
+
+    def detect(self, signature: Dict[str, Any]) -> Dict[str, float]:
+        state = signature.get("state", signature)
+        dung = state.get("dung_frameworks", {})
+        if not dung:
+            return {
+                "n_args": 0.0,
+                "n_attacks": 0.0,
+                "density": 0.0,
+                "n_extensions": 0.0,
+                "max_extension_size": 0.0,
+            }
+
+        # Use first framework
+        fw = next(iter(dung.values())) if isinstance(dung, dict) else dung
+        args = fw.get("arguments", [])
+        attacks = fw.get("attacks", [])
+        extensions = fw.get("extensions", {})
+        n = len(args)
+        n_atk = len(attacks)
+        max_ext = n * (n - 1) if n > 1 else 1
+        # Directed-edge density (n*(n-1)), not undirected (n*(n-1)/2)
+        density = n_atk / max_ext if max_ext > 0 else 0.0
+
+        all_exts = []
+        for ext_list in extensions.values():
+            if isinstance(ext_list, list):
+                if ext_list and isinstance(ext_list[0], list):
+                    all_exts.extend(ext_list)
+                else:
+                    all_exts.append(ext_list)
+
+        return {
+            "n_args": float(n),
+            "n_attacks": float(n_atk),
+            "density": round(density, 4),
+            "n_extensions": float(len(all_exts)),
+            "max_extension_size": float(max((len(e) for e in all_exts), default=0)),
+        }
+
+
+class AtmsBranchingDetector:
+    """Extract ATMS context branching features."""
+
+    name = "atms_branching"
+
+    def detect(self, signature: Dict[str, Any]) -> Dict[str, float]:
+        state = signature.get("state", signature)
+        contexts = state.get("atms_contexts", [])
+        if not contexts:
+            return {
+                "max_assumption_count": 0.0,
+                "avg_assumptions": 0.0,
+                "contradiction_rate": 0.0,
+            }
+
+        n = len(contexts)
+        assumption_counts = [len(c.get("assumptions", [])) for c in contexts]
+        contradictions = sum(1 for c in contexts if c.get("status") == "contradictory")
+
+        return {
+            "max_assumption_count": float(max(assumption_counts, default=0)),
+            "avg_assumptions": round(sum(assumption_counts) / n if n > 0 else 0.0, 2),
+            "contradiction_rate": round(contradictions / n if n > 0 else 0.0, 4),
+        }
+
+
+class JtmsRetractionRateDetector:
+    """Extract JTMS retraction rate features."""
+
+    name = "jtms_retraction_rate"
+
+    def detect(self, signature: Dict[str, Any]) -> Dict[str, float]:
+        state = signature.get("state", signature)
+        beliefs = state.get("jtms_beliefs", {})
+        retraction_chain = state.get("jtms_retraction_chain", [])
+
+        n_beliefs = len(beliefs)
+        n_retractions = len(retraction_chain)
+        n_justifications = len(
+            {b.get("justification") for b in beliefs.values() if isinstance(b, dict)}
+        )
+
+        return {
+            "n_beliefs": float(n_beliefs),
+            "n_justifications": float(n_justifications),
+            "retraction_rate": round(
+                n_retractions / n_beliefs if n_beliefs > 0 else 0.0, 4
+            ),
+        }
+
+
+_logger = logging.getLogger(__name__)
+
+
+# Default registry — extend by appending to this list
+FORMAL_DETECTORS: List[FormalPatternDetector] = [
+    DungTopologyDetector(),
+    AtmsBranchingDetector(),
+    JtmsRetractionRateDetector(),
+]
+
+
+# ---------------------------------------------------------------------------
+# Spectral analysis
+# ---------------------------------------------------------------------------
+
+
+def fallacy_spectrum(
+    signatures: Sequence[Dict[str, Any]],
+    by: str = "cluster_id",
+) -> Dict[str, Dict[str, float]]:
+    """Compute relative fallacy frequency per cluster.
+
+    Returns:
+        ``{cluster_id: {fallacy_type: relative_freq}}``
+    """
+    clusters: Dict[str, Counter] = defaultdict(Counter)
+    cluster_total: Dict[str, int] = defaultdict(int)
+
+    for sig in signatures:
+        state = sig.get("state", sig)
+        metadata = sig.get("metadata", {})
+        cluster_key = metadata.get(by, "unknown")
+
+        fallacies = state.get("identified_fallacies", {})
+        if isinstance(fallacies, dict):
+            for f_data in fallacies.values():
+                if isinstance(f_data, dict):
+                    ftype = f_data.get("type", "unknown")
+                    clusters[cluster_key][ftype] += 1
+                    cluster_total[cluster_key] += 1
+
+    result: Dict[str, Dict[str, float]] = {}
+    for cid, counts in clusters.items():
+        total = cluster_total[cid]
+        result[cid] = {
+            ftype: round(count / total, 4) if total > 0 else 0.0
+            for ftype, count in counts.items()
+        }
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Asymmetry Tricherie ↔ Influence
+# ---------------------------------------------------------------------------
+
+
+def trick_vs_influence_ratio(
+    signatures: Sequence[Dict[str, Any]],
+    by: str = "cluster_id",
+) -> Dict[str, Dict[str, float]]:
+    """Compute Tricherie/Influence asymmetry per cluster.
+
+    Returns per cluster:
+        - tricherie_share: proportion of Tricherie-family fallacies within this cluster
+        - influence_share: proportion of Influence-family fallacies within this cluster
+        - ratio: influence / tricherie (bounded to 1e9)
+        - asymmetry: (influence - tricherie) / (influence + tricherie) ∈ [-1, 1]
+    """
+    clusters: Dict[str, Counter] = defaultdict(Counter)
+
+    for sig in signatures:
+        state = sig.get("state", sig)
+        metadata = sig.get("metadata", {})
+        cluster_key = metadata.get(by, "unknown")
+
+        fallacies = state.get("identified_fallacies", {})
+        if isinstance(fallacies, dict):
+            for f_data in fallacies.values():
+                if isinstance(f_data, dict):
+                    ftype = f_data.get("type", "")
+                    if ftype in TRICHERIE_TYPES:
+                        clusters[cluster_key]["tricherie"] += 1
+                    elif ftype in INFLUENCE_TYPES:
+                        clusters[cluster_key]["influence"] += 1
+
+    result: Dict[str, Dict[str, float]] = {}
+    for cid, counts in clusters.items():
+        t = counts.get("tricherie", 0)
+        i = counts.get("influence", 0)
+        total = t + i if (t + i) > 0 else 1
+
+        t_share = round(t / total, 4)
+        i_share = round(i / total, 4)
+        ratio = round(min(i / t, 1e9), 4) if t > 0 else (1e9 if i > 0 else 0.0)
+        asym = round((i - t) / (i + t), 4) if (i + t) > 0 else 0.0
+
+        result[cid] = {
+            "tricherie_share": t_share,
+            "influence_share": i_share,
+            "ratio": ratio,
+            "asymmetry": asym,
+        }
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Co-occurrence matrix
+# ---------------------------------------------------------------------------
+
+
+def cooccurrence_matrix(
+    signatures: Sequence[Dict[str, Any]],
+    unit: str = "argument",
+    top_n: int = 20,
+) -> Dict[str, Any]:
+    """Compute fallacy co-occurrence matrix with support/confidence/lift/jaccard.
+
+    Args:
+        signatures: List of signature dicts from C.2.
+        unit: "argument" (same extracted argument) or "doc" (same document).
+        top_n: Number of top pairs to return by lift.
+
+    Returns:
+        ``{pairs: [{a, b, support, confidence, lift, jaccard}], unit_count}``
+    """
+    pair_counts: Counter = Counter()
+    type_counts: Counter = Counter()
+    total_units = 0
+
+    for sig in signatures:
+        state = sig.get("state", sig)
+        fallacies = state.get("identified_fallacies", {})
+
+        if unit == "argument":
+            arg_fallacies: Dict[str, set] = defaultdict(set)
+            if isinstance(fallacies, dict):
+                for f_data in fallacies.values():
+                    if isinstance(f_data, dict):
+                        src = f_data.get("source_arg", "__none__")
+                        ftype = f_data.get("type", "unknown")
+                        arg_fallacies[src].add(ftype)
+
+            for ftypes in arg_fallacies.values():
+                total_units += 1
+                for ft in ftypes:
+                    type_counts[ft] += 1
+                if len(ftypes) > 1:
+                    for a in sorted(ftypes):
+                        for b in sorted(ftypes):
+                            if a < b:
+                                pair_counts[(a, b)] += 1
+        else:  # doc-level
+            doc_types: set = set()
+            if isinstance(fallacies, dict):
+                for f_data in fallacies.values():
+                    if isinstance(f_data, dict):
+                        doc_types.add(f_data.get("type", "unknown"))
+
+            total_units += 1
+            for ft in doc_types:
+                type_counts[ft] += 1
+            if len(doc_types) > 1:
+                for a in sorted(doc_types):
+                    for b in sorted(doc_types):
+                        if a < b:
+                            pair_counts[(a, b)] += 1
+
+    denominator = max(total_units, 1)
+    pairs = []
+    for (a, b), support in pair_counts.items():
+        sa = type_counts[a]
+        sb = type_counts[b]
+        conf_ab = support / sa if sa > 0 else 0.0
+        expected = (sa / denominator) * (sb / denominator)
+        lift = support / (denominator * expected) if expected > 0 else 0.0
+        jaccard = support / (sa + sb - support) if (sa + sb - support) > 0 else 0.0
+        pairs.append(
+            {
+                "a": a,
+                "b": b,
+                "support": support,
+                "confidence": round(conf_ab, 4),
+                "lift": round(lift, 4),
+                "jaccard": round(jaccard, 4),
+            }
+        )
+
+    pairs.sort(key=lambda p: p["lift"], reverse=True)
+    return {"pairs": pairs[:top_n], "unit_count": total_units}
+
+
+# ---------------------------------------------------------------------------
+# Cross-coverage informal ↔ formal
+# ---------------------------------------------------------------------------
+
+
+def cross_coverage(
+    signatures: Sequence[Dict[str, Any]],
+) -> Dict[str, Dict[str, Dict[str, float]]]:
+    """Measure co-occurrence of informal fallacies with formal logic signals.
+
+    For each fallacy type, reports two rate families:
+
+      - ``per_signature_rate``: among signatures containing this fallacy type,
+        what fraction also exhibit each formal signal. Counts each signature
+        once regardless of how many times the fallacy occurs.
+      - ``per_occurrence_rate``: among occurrences of this fallacy type, what
+        fraction co-occur with each formal signal. A signature with 3
+        fallacies + a formal signal counts 3 toward the numerator.
+
+    Formal signals:
+      - FOL invalidity
+      - Dung edge without support (noisy heuristic — see docs)
+      - JTMS retraction
+    """
+    # Track both counting modes
+    sig_seen: Dict[str, set] = defaultdict(set)  # ftype -> set of sig indices
+    sig_with_signal: Dict[str, Dict[str, set]] = defaultdict(lambda: defaultdict(set))
+    occ_total: Dict[str, int] = defaultdict(int)
+    occ_with_signal: Dict[str, Dict[str, int]] = defaultdict(lambda: defaultdict(int))
+
+    for idx, sig in enumerate(signatures):
+        state = sig.get("state", sig)
+        fallacies = state.get("identified_fallacies", {})
+
+        has_fol_invalid = False
+        fol_results = state.get("fol_analysis_results", [])
+        if isinstance(fol_results, list):
+            for r in fol_results:
+                if isinstance(r, dict) and not r.get("valid", True):
+                    has_fol_invalid = True
+
+        # Noisy heuristic: arg attacked but not attacking others
+        has_dung_unsupported = False
+        dung = state.get("dung_frameworks", {})
+        attacks = []
+        if isinstance(dung, dict):
+            for fw in dung.values():
+                if isinstance(fw, dict):
+                    attacks.extend(fw.get("attacks", []))
+        if attacks:
+            args_attacked = set()
+            args_with_support = set()
+            for atk in attacks:
+                if isinstance(atk, dict):
+                    args_attacked.add(atk.get("to", ""))
+                    args_with_support.add(atk.get("from", ""))
+            if args_attacked - args_with_support:
+                has_dung_unsupported = True
+
+        has_jtms_retraction = len(state.get("jtms_retraction_chain", [])) > 0
+
+        formal_signals = {
+            "fol_invalid": has_fol_invalid,
+            "dung_unsupported": has_dung_unsupported,
+            "jtms_retraction": has_jtms_retraction,
+        }
+
+        if isinstance(fallacies, dict):
+            for f_data in fallacies.values():
+                if isinstance(f_data, dict):
+                    ftype = f_data.get("type", "unknown")
+                    occ_total[ftype] += 1
+                    sig_seen[ftype].add(idx)
+                    for signal, present in formal_signals.items():
+                        if present:
+                            occ_with_signal[ftype][signal] += 1
+                            sig_with_signal[ftype][signal].add(idx)
+
+    result: Dict[str, Dict[str, Dict[str, float]]] = {}
+    for ftype in sig_seen:
+        n_occ = occ_total[ftype] if occ_total[ftype] > 0 else 1
+        n_sig = len(sig_seen[ftype]) if len(sig_seen[ftype]) > 0 else 1
+        result[ftype] = {
+            "per_signature_rate": {},
+            "per_occurrence_rate": {},
+        }
+        for signal in ["fol_invalid", "dung_unsupported", "jtms_retraction"]:
+            result[ftype]["per_signature_rate"][signal] = round(
+                len(sig_with_signal[ftype].get(signal, set())) / n_sig, 4
+            )
+            result[ftype]["per_occurrence_rate"][signal] = round(
+                occ_with_signal[ftype].get(signal, 0) / n_occ, 4
+            )
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Run all formal detectors on a signature
+# ---------------------------------------------------------------------------
+
+
+def run_formal_detectors(
+    signature: Dict[str, Any],
+    detectors: Optional[List[FormalPatternDetector]] = None,
+) -> Dict[str, Dict[str, float]]:
+    """Run all formal pattern detectors on a single signature.
+
+    Args:
+        signature: A single signature dict.
+        detectors: Override detector list. Defaults to FORMAL_DETECTORS.
+
+    Returns:
+        ``{detector_name: {metric: value}}``
+    """
+    if detectors is None:
+        detectors = FORMAL_DETECTORS
+
+    results: Dict[str, Dict[str, float]] = {}
+    for det in detectors:
+        try:
+            results[det.name] = det.detect(signature)
+        except Exception as exc:
+            _logger.warning("detector %s failed: %s", det.name, exc, exc_info=True)
+            results[det.name] = {"error": 1.0}
+    return results

--- a/tests/unit/argumentation_analysis/evaluation/test_pattern_mining.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_pattern_mining.py
@@ -1,0 +1,433 @@
+"""Tests for argumentation_analysis.evaluation.pattern_mining."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from argumentation_analysis.evaluation.pattern_mining import (
+    FORMAL_DETECTORS,
+    AtmsBranchingDetector,
+    DungTopologyDetector,
+    FormalPatternDetector,
+    JtmsRetractionRateDetector,
+    cooccurrence_matrix,
+    cross_coverage,
+    fallacy_spectrum,
+    run_formal_detectors,
+    trick_vs_influence_ratio,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic signatures
+# ---------------------------------------------------------------------------
+
+
+def _sig(fallacies, cluster="A", **extra_state):
+    """Build a minimal signature dict for testing."""
+    fallacy_dict = {}
+    for i, (ftype, family) in enumerate(fallacies):
+        fallacy_dict[f"f{i}"] = {
+            "type": ftype,
+            "family": family,
+            "source_arg": f"arg_{i % 3}",
+        }
+
+    state = {
+        "identified_fallacies": fallacy_dict,
+        "dung_frameworks": extra_state.get("dung_frameworks", {}),
+        "atms_contexts": extra_state.get("atms_contexts", []),
+        "jtms_beliefs": extra_state.get("jtms_beliefs", {}),
+        "jtms_retraction_chain": extra_state.get("jtms_retraction_chain", []),
+        "fol_analysis_results": extra_state.get("fol_analysis_results", []),
+    }
+    return {
+        "opaque_id": f"test_{cluster}",
+        "metadata": {"cluster_id": cluster},
+        "state": state,
+    }
+
+
+@pytest.fixture
+def sigs_political():
+    """3 signatures in cluster 'political' with mixed fallacies."""
+    return [
+        _sig(
+            [("ad_hominem", "relevance"), ("straw_man", "distortion")],
+            cluster="political",
+        ),
+        _sig(
+            [("slippery_slope", "causal"), ("false_dilemma", "presumption")],
+            cluster="political",
+        ),
+        _sig(
+            [("ad_hominem", "relevance"), ("hasty_generalization", "inductive")],
+            cluster="political",
+        ),
+    ]
+
+
+@pytest.fixture
+def sigs_media():
+    """2 signatures in cluster 'media' with influence-heavy fallacies."""
+    return [
+        _sig(
+            [("appeal_to_emotion", "emotion"), ("bandwagon", "relevance")],
+            cluster="media",
+        ),
+        _sig(
+            [("appeal_to_emotion", "emotion"), ("appeal_to_authority", "authority")],
+            cluster="media",
+        ),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# fallacy_spectrum
+# ---------------------------------------------------------------------------
+
+
+class TestFallacySpectrum:
+    def test_distribution(self, sigs_political):
+        result = fallacy_spectrum(sigs_political, by="cluster_id")
+        assert "political" in result
+        spec = result["political"]
+        # ad_hominem appears twice in 6 total → 0.3333
+        assert spec.get("ad_hominem", 0) == pytest.approx(0.3333, abs=0.01)
+
+    def test_empty_signatures(self):
+        result = fallacy_spectrum([], by="cluster_id")
+        assert result == {}
+
+    def test_multiple_clusters(self, sigs_political, sigs_media):
+        all_sigs = sigs_political + sigs_media
+        result = fallacy_spectrum(all_sigs, by="cluster_id")
+        assert "political" in result
+        assert "media" in result
+
+
+# ---------------------------------------------------------------------------
+# trick_vs_influence_ratio
+# ---------------------------------------------------------------------------
+
+
+class TestTrickVsInfluence:
+    def test_influence_heavy_cluster(self, sigs_media):
+        result = trick_vs_influence_ratio(sigs_media, by="cluster_id")
+        media = result["media"]
+        assert media["influence_share"] == pytest.approx(1.0, abs=0.01)
+        assert media["asymmetry"] == pytest.approx(1.0, abs=0.01)
+
+    def test_mixed_cluster(self, sigs_political):
+        result = trick_vs_influence_ratio(sigs_political, by="cluster_id")
+        pol = result["political"]
+        assert "tricherie_share" in pol
+        assert "influence_share" in pol
+        assert "ratio" in pol
+        assert "asymmetry" in pol
+
+    def test_all_influence_asymmetry_one(self):
+        sigs = [
+            _sig(
+                [("appeal_to_emotion", "emotion"), ("bandwagon", "relevance")],
+                cluster="all_inf",
+            )
+        ]
+        result = trick_vs_influence_ratio(sigs, by="cluster_id")
+        assert result["all_inf"]["asymmetry"] == pytest.approx(1.0, abs=0.01)
+
+    def test_empty(self):
+        result = trick_vs_influence_ratio([])
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# cooccurrence_matrix
+# ---------------------------------------------------------------------------
+
+
+class TestCooccurrenceMatrix:
+    def test_basic_cooccurrence(self):
+        """2 docs with arg containing [A,B] each → support(A,B)=2, lift>=1."""
+        sigs = [
+            {
+                "metadata": {"cluster_id": "X"},
+                "state": {
+                    "identified_fallacies": {
+                        "f0": {
+                            "type": "ad_hominem",
+                            "family": "rel",
+                            "source_arg": "arg_shared",
+                        },
+                        "f1": {
+                            "type": "straw_man",
+                            "family": "dist",
+                            "source_arg": "arg_shared",
+                        },
+                    },
+                },
+            },
+            {
+                "metadata": {"cluster_id": "X"},
+                "state": {
+                    "identified_fallacies": {
+                        "f0": {
+                            "type": "ad_hominem",
+                            "family": "rel",
+                            "source_arg": "arg_shared",
+                        },
+                        "f1": {
+                            "type": "straw_man",
+                            "family": "dist",
+                            "source_arg": "arg_shared",
+                        },
+                    },
+                },
+            },
+            _sig(
+                [("false_dilemma", "pres")],
+                cluster="X",
+            ),
+        ]
+        result = cooccurrence_matrix(sigs, unit="argument")
+        # total_units counts all arg groups: 2 multi + 1 single = 3
+        assert result["unit_count"] == 3
+        pairs = result["pairs"]
+        hm_sm = [p for p in pairs if p["a"] == "ad_hominem" and p["b"] == "straw_man"]
+        assert len(hm_sm) == 1
+        assert hm_sm[0]["support"] == 2
+        assert hm_sm[0]["lift"] >= 1.0
+
+    def test_doc_level(self):
+        sigs = [
+            _sig(
+                [("ad_hominem", "rel"), ("straw_man", "dist")],
+                cluster="X",
+            ),
+        ]
+        result = cooccurrence_matrix(sigs, unit="doc")
+        assert result["unit_count"] >= 1
+
+    def test_no_pairs(self):
+        sigs = [_sig([("ad_hominem", "rel")], cluster="X")]
+        result = cooccurrence_matrix(sigs, unit="argument")
+        assert result["pairs"] == []
+        # Single-fallacy arg still counted as a unit
+        assert result["unit_count"] == 1
+
+    def test_top_n(self):
+        sigs = [_sig([("a", "x"), ("b", "x")], cluster="X")]
+        result = cooccurrence_matrix(sigs, top_n=1)
+        assert len(result["pairs"]) <= 1
+
+
+# ---------------------------------------------------------------------------
+# Formal detectors
+# ---------------------------------------------------------------------------
+
+
+class TestDungTopologyDetector:
+    def test_empty(self):
+        det = DungTopologyDetector()
+        result = det.detect({"state": {}})
+        assert result["n_args"] == 0.0
+        assert result["density"] == 0.0
+
+    def test_with_framework(self):
+        sig = {
+            "state": {
+                "dung_frameworks": {
+                    "fw1": {
+                        "arguments": ["a1", "a2", "a3"],
+                        "attacks": [
+                            {"from": "a1", "to": "a2"},
+                            {"from": "a2", "to": "a3"},
+                        ],
+                        "extensions": {
+                            "grounded": ["a1", "a3"],
+                            "preferred": [["a1", "a3"]],
+                        },
+                    }
+                }
+            }
+        }
+        det = DungTopologyDetector()
+        result = det.detect(sig)
+        assert result["n_args"] == 3.0
+        assert result["n_attacks"] == 2.0
+        assert result["density"] > 0
+        assert result["max_extension_size"] == 2.0
+
+    def test_no_division_by_zero(self):
+        """0 args → density=0, no crash."""
+        sig = {
+            "state": {
+                "dung_frameworks": {
+                    "fw1": {
+                        "arguments": [],
+                        "attacks": [],
+                        "extensions": {},
+                    }
+                }
+            }
+        }
+        result = DungTopologyDetector().detect(sig)
+        assert result["density"] == 0.0
+
+
+class TestAtmsBranchingDetector:
+    def test_empty(self):
+        result = AtmsBranchingDetector().detect({"state": {}})
+        assert result["max_assumption_count"] == 0.0
+        assert result["contradiction_rate"] == 0.0
+
+    def test_with_contexts(self):
+        sig = {
+            "state": {
+                "atms_contexts": [
+                    {"assumptions": ["a1", "a2"], "status": "consistent"},
+                    {"assumptions": ["a3"], "status": "contradictory"},
+                ]
+            }
+        }
+        result = AtmsBranchingDetector().detect(sig)
+        assert result["max_assumption_count"] == 2.0
+        assert result["avg_assumptions"] == 1.5
+        assert result["contradiction_rate"] == 0.5
+
+
+class TestJtmsRetractionRateDetector:
+    def test_empty(self):
+        result = JtmsRetractionRateDetector().detect({"state": {}})
+        assert result["n_beliefs"] == 0.0
+        assert result["retraction_rate"] == 0.0
+
+    def test_with_retractions(self):
+        sig = {
+            "state": {
+                "jtms_beliefs": {
+                    "b1": {"status": "IN", "justification": "j1"},
+                    "b2": {"status": "OUT", "justification": "j2"},
+                    "b3": {"status": "IN", "justification": "j1"},
+                },
+                "jtms_retraction_chain": [{"cascade_id": "c1"}],
+            }
+        }
+        result = JtmsRetractionRateDetector().detect(sig)
+        assert result["n_beliefs"] == 3.0
+        assert result["retraction_rate"] == pytest.approx(0.3333, abs=0.01)
+
+
+# ---------------------------------------------------------------------------
+# run_formal_detectors
+# ---------------------------------------------------------------------------
+
+
+class TestRunFormalDetectors:
+    def test_default_registry(self):
+        sig = {
+            "state": {"dung_frameworks": {}, "atms_contexts": [], "jtms_beliefs": {}}
+        }
+        result = run_formal_detectors(sig)
+        assert "dung_topology" in result
+        assert "atms_branching" in result
+        assert "jtms_retraction_rate" in result
+
+    def test_custom_detector(self):
+        class DummyDetector:
+            name = "dummy"
+
+            def detect(self, sig):
+                return {"value": 42.0}
+
+        result = run_formal_detectors({}, detectors=[DummyDetector()])
+        assert result["dummy"]["value"] == 42.0
+
+    def test_detector_error_handled(self):
+        class FailingDetector:
+            name = "fail"
+
+            def detect(self, sig):
+                raise ValueError("boom")
+
+        result = run_formal_detectors({}, detectors=[FailingDetector()])
+        assert result["fail"]["error"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# cross_coverage
+# ---------------------------------------------------------------------------
+
+
+class TestCrossCoverage:
+    def test_with_formal_signals(self):
+        sig = {
+            "state": {
+                "identified_fallacies": {
+                    "f1": {
+                        "type": "ad_hominem",
+                        "family": "relevance",
+                        "source_arg": "a1",
+                    },
+                },
+                "fol_analysis_results": [{"valid": False}],
+                "jtms_retraction_chain": [{"cascade_id": "c1"}],
+                "dung_frameworks": {},
+            }
+        }
+        result = cross_coverage([sig])
+        assert "ad_hominem" in result
+        assert result["ad_hominem"]["per_signature_rate"]["fol_invalid"] == 1.0
+        assert result["ad_hominem"]["per_signature_rate"]["jtms_retraction"] == 1.0
+        assert result["ad_hominem"]["per_occurrence_rate"]["fol_invalid"] == 1.0
+
+    def test_empty(self):
+        result = cross_coverage([])
+        assert result == {}
+
+    def test_no_formal_signals(self):
+        sigs = [
+            _sig([("ad_hominem", "rel")], cluster="X"),
+        ]
+        result = cross_coverage(sigs)
+        for ftype, rate_families in result.items():
+            for rates in rate_families.values():
+                for rate in rates.values():
+                    assert rate == 0.0
+
+    def test_per_signature_vs_occurrence(self):
+        """Signature with 2 ad_hominem + 1 FOL invalid → occ rate = 1.0, sig rate = 1.0."""
+        sig = {
+            "state": {
+                "identified_fallacies": {
+                    "f1": {"type": "ad_hominem", "family": "rel", "source_arg": "a1"},
+                    "f2": {"type": "ad_hominem", "family": "rel", "source_arg": "a2"},
+                    "f3": {"type": "straw_man", "family": "dist", "source_arg": "a3"},
+                },
+                "fol_analysis_results": [{"valid": False}],
+                "dung_frameworks": {},
+                "jtms_retraction_chain": [],
+            }
+        }
+        result = cross_coverage([sig])
+        # ad_hominem: 2 occurrences, 1 sig → both rates = 1.0
+        assert result["ad_hominem"]["per_occurrence_rate"]["fol_invalid"] == 1.0
+        assert result["ad_hominem"]["per_signature_rate"]["fol_invalid"] == 1.0
+        # straw_man: 1 occurrence, 1 sig → both rates = 1.0
+        assert result["straw_man"]["per_occurrence_rate"]["fol_invalid"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Registry count
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_three_built_in_detectors(self):
+        assert len(FORMAL_DETECTORS) == 3
+
+    def test_all_implement_protocol(self):
+        for det in FORMAL_DETECTORS:
+            assert isinstance(det, FormalPatternDetector)
+            assert hasattr(det, "name")
+            assert callable(det.detect)


### PR DESCRIPTION
## Summary
Reopened from #427 (auto-closed when base `feat/corpus-batch-runner-410` got squash-merged into main as #426).

Adds discourse pattern mining module with all C.3 deliverables.

## Closes
- #411

## Files
- `argumentation_analysis/evaluation/pattern_mining.py` (+486)
- `tests/unit/argumentation_analysis/evaluation/test_pattern_mining.py` (+433)

## Fixes applied (vs original #427)
Real issues:
1. `trick_vs_influence_ratio`: shares now computed intra-cluster (t+i denominator)
2. `cooccurrence_matrix`: total_units counts ALL units (lift bias removed)
3. `cross_coverage`: dual output (per_signature_rate + per_occurrence_rate)

Concerns:
- Dung density documented as directed-edge (n*(n-1))
- `dung_unsupported` documented as noisy heuristic
- `max_depth` renamed to `max_assumption_count`
- `run_formal_detectors` logs detector failures via `logger.warning`

## Test plan
- [x] 26 unit tests passing locally
- [ ] CI green (will run on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)