### PR TITLE
feat(report): discourse pattern report with SVG visualizations (#412) [rebased]

### DIFF
--- a/docs/reports/discourse_patterns.md
+++ b/docs/reports/discourse_patterns.md
@@ -1,0 +1,71 @@
+# Discourse Pattern Report
+
+**Generated**: 2026-05-03 22:47 UTC
+**Documents analyzed**: 8
+**Clusters**: 2 (debate, propaganda)
+**Workflow**: spectacular 17 phases
+
+---
+
+## 1. Fallacy Spectra by Cluster
+
+| Cluster | ad_hominem | appeal_to_fear | false_dilemma | straw_man |
+|---------|---------|---------|---------|---------|
+| debate | 0.00 | 0.00 | 0.50 | 0.50 |
+| propaganda | 0.50 | 0.50 | 0.00 | 0.00 |
+
+## 2. Tricherie ↔ Influence Asymmetry
+
+| Cluster | Tricherie | Influence | Ratio | Asymmetry |
+|---------|-----------|-----------|-------|----------|
+| debate | 0.000 | 0.375 | 1000000000.00 | +1.000 |
+| propaganda | 0.000 | 0.625 | 1000000000.00 | +1.000 |
+
+## 3. Co-occurrence Top-20
+
+| Fallacy A | Fallacy B | Support | Confidence | Lift | Jaccard |
+|-----------|-----------|---------|------------|------|--------|
+| ad_hominem | appeal_to_fear | 5 | 1.000 | 1.00 | 1.000 |
+
+_Units with co-occurrences: 5_
+
+## 4. Formal Pattern Detectors
+
+### dung_topology
+
+| Cluster | n_args | n_attacks | density | n_extensions | max_extension_size |
+|------|------|------|------|------|------|
+| debate | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
+| propaganda | 2.000 | 1.000 | 0.500 | 1.000 | 1.000 |
+
+### atms_branching
+
+| Cluster | max_depth | avg_assumptions | contradiction_rate |
+|------|------|------|------|
+| debate | 0.000 | 0.000 | 0.000 |
+| propaganda | 0.000 | 0.000 | 0.000 |
+
+### jtms_retraction_rate
+
+| Cluster | n_beliefs | n_justifications | retraction_rate |
+|------|------|------|------|
+| debate | 0.000 | 0.000 | 0.000 |
+| propaganda | 1.000 | 1.000 | 0.000 |
+
+## 5. Cross-coverage: Informal ↔ Formal
+
+| Fallacy Type | Fol_Invalid | Dung_Unsupported | Jtms_Retraction |
+|------|------|------|------|
+| ad_hominem | 0.00 | 1.00 | 0.00 |
+| appeal_to_fear | 0.00 | 1.00 | 0.00 |
+| false_dilemma | 1.00 | 0.00 | 1.00 |
+| straw_man | 1.00 | 0.00 | 1.00 |
+
+_Hypothesis: manipulation = camouflaging formal errors?_
+
+## 6. Limitations & Next Steps
+
+- Coverage limited to available corpus subset
+- Sampling bias toward represented discourse types
+- Formal detector registry is extensible (see `pattern_mining.FORMAL_DETECTORS`)
+- Future: temporal comparison, richer metadata, LLM-assisted narrative

--- a/docs/reports/discourse_patterns.md
+++ b/docs/reports/discourse_patterns.md
@@ -1,6 +1,6 @@
 # Discourse Pattern Report
 
-**Generated**: 2026-05-03 22:47 UTC
+**Generated**: 2026-05-04 19:25 UTC
 **Documents analyzed**: 8
 **Clusters**: 2 (debate, propaganda)
 **Workflow**: spectacular 17 phases
@@ -18,16 +18,12 @@
 
 | Cluster | Tricherie | Influence | Ratio | Asymmetry |
 |---------|-----------|-----------|-------|----------|
-| debate | 0.000 | 0.375 | 1000000000.00 | +1.000 |
-| propaganda | 0.000 | 0.625 | 1000000000.00 | +1.000 |
+| debate | 0.000 | 1.000 | 1000000000.00 | +1.000 |
+| propaganda | 0.000 | 1.000 | 1000000000.00 | +1.000 |
 
 ## 3. Co-occurrence Top-20
 
-| Fallacy A | Fallacy B | Support | Confidence | Lift | Jaccard |
-|-----------|-----------|---------|------------|------|--------|
-| ad_hominem | appeal_to_fear | 5 | 1.000 | 1.00 | 1.000 |
-
-_Units with co-occurrences: 5_
+_No co-occurrence data._
 
 ## 4. Formal Pattern Detectors
 
@@ -36,11 +32,11 @@ _Units with co-occurrences: 5_
 | Cluster | n_args | n_attacks | density | n_extensions | max_extension_size |
 |------|------|------|------|------|------|
 | debate | 0.000 | 0.000 | 0.000 | 0.000 | 0.000 |
-| propaganda | 2.000 | 1.000 | 0.500 | 1.000 | 1.000 |
+| propaganda | 2.000 | 1.000 | 0.500 | 0.000 | 0.000 |
 
 ### atms_branching
 
-| Cluster | max_depth | avg_assumptions | contradiction_rate |
+| Cluster | max_assumption_count | avg_assumptions | contradiction_rate |
 |------|------|------|------|
 | debate | 0.000 | 0.000 | 0.000 |
 | propaganda | 0.000 | 0.000 | 0.000 |
@@ -49,19 +45,19 @@ _Units with co-occurrences: 5_
 
 | Cluster | n_beliefs | n_justifications | retraction_rate |
 |------|------|------|------|
-| debate | 0.000 | 0.000 | 0.000 |
-| propaganda | 1.000 | 1.000 | 0.000 |
+| debate | 1.000 | 1.000 | 0.000 |
+| propaganda | 0.000 | 0.000 | 0.000 |
 
 ## 5. Cross-coverage: Informal ↔ Formal
 
 | Fallacy Type | Fol_Invalid | Dung_Unsupported | Jtms_Retraction |
 |------|------|------|------|
-| ad_hominem | 0.00 | 1.00 | 0.00 |
-| appeal_to_fear | 0.00 | 1.00 | 0.00 |
-| false_dilemma | 1.00 | 0.00 | 1.00 |
-| straw_man | 1.00 | 0.00 | 1.00 |
+| ad_hominem | 0.00 | 0.00 | 0.00 |
+| appeal_to_fear | 0.00 | 0.00 | 0.00 |
+| false_dilemma | 1.00 | 0.00 | 0.00 |
+| straw_man | 1.00 | 0.00 | 0.00 |
 
-_Hypothesis: manipulation = camouflaging formal errors?_
+_Rates = fraction of signatures with this fallacy that also exhibit each formal signal._
 
 ## 6. Limitations & Next Steps
 

--- a/docs/reports/discourse_patterns/asymmetry_chart.svg
+++ b/docs/reports/discourse_patterns/asymmetry_chart.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 300" width="340" height="300">
 <text x="170" y="20" font-size="13" fill="#2c3e50" text-anchor="middle">Tricherie vs Influence Asymmetry</text>
-<rect x="100" y="173" width="60" height="0" fill="#8b4513" opacity="0.8"/>
-<rect x="100" y="173" width="60" height="67" fill="#2c3e50" opacity="0.8"/>
+<rect x="100" y="60" width="60" height="0" fill="#8b4513" opacity="0.8"/>
+<rect x="100" y="60" width="60" height="180" fill="#2c3e50" opacity="0.8"/>
 <text x="130" y="258" font-size="8" fill="#333" text-anchor="middle">debate</text>
 <text x="130" y="272" font-size="8" fill="#666" text-anchor="middle">+1.00</text>
-<rect x="200" y="128" width="60" height="0" fill="#8b4513" opacity="0.8"/>
-<rect x="200" y="128" width="60" height="112" fill="#2c3e50" opacity="0.8"/>
+<rect x="200" y="60" width="60" height="0" fill="#8b4513" opacity="0.8"/>
+<rect x="200" y="60" width="60" height="180" fill="#2c3e50" opacity="0.8"/>
 <text x="230" y="258" font-size="8" fill="#333" text-anchor="middle">propaganda</text>
 <text x="230" y="272" font-size="8" fill="#666" text-anchor="middle">+1.00</text>
 <text x="30" y="80" font-size="9" fill="#2c3e50" text-anchor="middle">Influence</text>

--- a/docs/reports/discourse_patterns/asymmetry_chart.svg
+++ b/docs/reports/discourse_patterns/asymmetry_chart.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 340 300" width="340" height="300">
+<text x="170" y="20" font-size="13" fill="#2c3e50" text-anchor="middle">Tricherie vs Influence Asymmetry</text>
+<rect x="100" y="173" width="60" height="0" fill="#8b4513" opacity="0.8"/>
+<rect x="100" y="173" width="60" height="67" fill="#2c3e50" opacity="0.8"/>
+<text x="130" y="258" font-size="8" fill="#333" text-anchor="middle">debate</text>
+<text x="130" y="272" font-size="8" fill="#666" text-anchor="middle">+1.00</text>
+<rect x="200" y="128" width="60" height="0" fill="#8b4513" opacity="0.8"/>
+<rect x="200" y="128" width="60" height="112" fill="#2c3e50" opacity="0.8"/>
+<text x="230" y="258" font-size="8" fill="#333" text-anchor="middle">propaganda</text>
+<text x="230" y="272" font-size="8" fill="#666" text-anchor="middle">+1.00</text>
+<text x="30" y="80" font-size="9" fill="#2c3e50" text-anchor="middle">Influence</text>
+<text x="30" y="200" font-size="9" fill="#8b4513" text-anchor="middle">Tricherie</text>
+</svg>

--- a/docs/reports/discourse_patterns/heatmap_fallacies.svg
+++ b/docs/reports/discourse_patterns/heatmap_fallacies.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 210" width="260" height="210">
+<text x="145" y="25" font-size="8" fill="#333" text-anchor="middle" transform="rotate(-45,145,25)">ad_hominem</text>
+<text x="195" y="25" font-size="8" fill="#333" text-anchor="middle" transform="rotate(-45,195,25)">appeal_to_fe</text>
+<text x="115" y="59" font-size="8" fill="#333" text-anchor="end">ad_hominem</text>
+<rect x="120" y="30" width="49" height="49" fill="#f0f0f0" opacity="0.8"/>
+<rect x="170" y="30" width="49" height="49" fill="#2c3e50" opacity="0.8"/>
+<text x="195" y="59" font-size="7" fill="white" text-anchor="middle">1.0</text>
+<text x="115" y="109" font-size="8" fill="#333" text-anchor="end">appeal_to_fe</text>
+<rect x="120" y="80" width="49" height="49" fill="#2c3e50" opacity="0.8"/>
+<text x="145" y="109" font-size="7" fill="white" text-anchor="middle">1.0</text>
+<rect x="170" y="80" width="49" height="49" fill="#f0f0f0" opacity="0.8"/>
+<text x="130" y="195" font-size="12" fill="#2c3e50" text-anchor="middle">Fallacy Co-occurrence Heatmap (lift)</text>
+</svg>

--- a/docs/reports/discourse_patterns/heatmap_fallacies.svg
+++ b/docs/reports/discourse_patterns/heatmap_fallacies.svg
@@ -1,13 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 260 210" width="260" height="210">
-<text x="145" y="25" font-size="8" fill="#333" text-anchor="middle" transform="rotate(-45,145,25)">ad_hominem</text>
-<text x="195" y="25" font-size="8" fill="#333" text-anchor="middle" transform="rotate(-45,195,25)">appeal_to_fe</text>
-<text x="115" y="59" font-size="8" fill="#333" text-anchor="end">ad_hominem</text>
-<rect x="120" y="30" width="49" height="49" fill="#f0f0f0" opacity="0.8"/>
-<rect x="170" y="30" width="49" height="49" fill="#2c3e50" opacity="0.8"/>
-<text x="195" y="59" font-size="7" fill="white" text-anchor="middle">1.0</text>
-<text x="115" y="109" font-size="8" fill="#333" text-anchor="end">appeal_to_fe</text>
-<rect x="120" y="80" width="49" height="49" fill="#2c3e50" opacity="0.8"/>
-<text x="145" y="109" font-size="7" fill="white" text-anchor="middle">1.0</text>
-<rect x="170" y="80" width="49" height="49" fill="#f0f0f0" opacity="0.8"/>
-<text x="130" y="195" font-size="12" fill="#2c3e50" text-anchor="middle">Fallacy Co-occurrence Heatmap (lift)</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 200" width="400" height="200">
+<text x="200" y="100" font-size="14" fill="#333" text-anchor="middle">No co-occurrence data</text>
 </svg>

--- a/docs/reports/discourse_patterns/spectrum_radar_debate.svg
+++ b/docs/reports/discourse_patterns/spectrum_radar_debate.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 124" width="500" height="124">
 <text x="250" y="20" font-size="13" fill="#2c3e50" text-anchor="middle">Fallacy Spectrum — debate</text>
-<text x="125" y="55" font-size="9" fill="#333" text-anchor="end">straw_man</text>
+<text x="125" y="55" font-size="9" fill="#333" text-anchor="end">false_dilemma</text>
 <rect x="130" y="40" width="330" height="18" fill="#2c3e50" opacity="0.7"/>
 <text x="465" y="55" font-size="8" fill="#333" text-anchor="start">0.50</text>
-<text x="125" y="77" font-size="9" fill="#333" text-anchor="end">false_dilemma</text>
+<text x="125" y="77" font-size="9" fill="#333" text-anchor="end">straw_man</text>
 <rect x="130" y="62" width="330" height="18" fill="#2c3e50" opacity="0.7"/>
 <text x="465" y="77" font-size="8" fill="#333" text-anchor="start">0.50</text>
 </svg>

--- a/docs/reports/discourse_patterns/spectrum_radar_debate.svg
+++ b/docs/reports/discourse_patterns/spectrum_radar_debate.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 124" width="500" height="124">
+<text x="250" y="20" font-size="13" fill="#2c3e50" text-anchor="middle">Fallacy Spectrum — debate</text>
+<text x="125" y="55" font-size="9" fill="#333" text-anchor="end">straw_man</text>
+<rect x="130" y="40" width="330" height="18" fill="#2c3e50" opacity="0.7"/>
+<text x="465" y="55" font-size="8" fill="#333" text-anchor="start">0.50</text>
+<text x="125" y="77" font-size="9" fill="#333" text-anchor="end">false_dilemma</text>
+<rect x="130" y="62" width="330" height="18" fill="#2c3e50" opacity="0.7"/>
+<text x="465" y="77" font-size="8" fill="#333" text-anchor="start">0.50</text>
+</svg>

--- a/docs/reports/discourse_patterns/spectrum_radar_propaganda.svg
+++ b/docs/reports/discourse_patterns/spectrum_radar_propaganda.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 124" width="500" height="124">
+<text x="250" y="20" font-size="13" fill="#2c3e50" text-anchor="middle">Fallacy Spectrum — propaganda</text>
+<text x="125" y="55" font-size="9" fill="#333" text-anchor="end">ad_hominem</text>
+<rect x="130" y="40" width="330" height="18" fill="#2c3e50" opacity="0.7"/>
+<text x="465" y="55" font-size="8" fill="#333" text-anchor="start">0.50</text>
+<text x="125" y="77" font-size="9" fill="#333" text-anchor="end">appeal_to_fear</text>
+<rect x="130" y="62" width="330" height="18" fill="#2c3e50" opacity="0.7"/>
+<text x="465" y="77" font-size="8" fill="#333" text-anchor="start">0.50</text>
+</svg>

--- a/scripts/dataset/build_pattern_report.py
+++ b/scripts/dataset/build_pattern_report.py
@@ -297,16 +297,17 @@ def build_report(signatures: List[Dict[str, Any]],
                 md += f"| {cid} | " + " | ".join(f"{vals.get(k, 0):.3f}" for k in header_cols) + " |\n"
         md += "\n"
 
-    # Section 6: Cross-coverage
+    # Section 6: Cross-coverage (using per_signature_rate as primary metric)
     md += "## 5. Cross-coverage: Informal ↔ Formal\n\n"
     if xcov:
         signals = ["fol_invalid", "dung_unsupported", "jtms_retraction"]
         md += "| Fallacy Type | " + " | ".join(s.title() for s in signals) + " |\n"
         md += "|" + "------|" * (len(signals) + 1) + "\n"
         for ftype in sorted(xcov.keys()):
-            vals = [f"{xcov[ftype].get(s, 0):.2f}" for s in signals]
+            rate = xcov[ftype].get("per_signature_rate", {})
+            vals = [f"{rate.get(s, 0):.2f}" for s in signals]
             md += f"| {ftype} | " + " | ".join(vals) + " |\n"
-        md += "\n_Hypothesis: manipulation = camouflaging formal errors?_\n\n"
+        md += "\n_Rates = fraction of signatures with this fallacy that also exhibit each formal signal._\n\n"
     else:
         md += "_No cross-coverage data._\n\n"
 

--- a/scripts/dataset/build_pattern_report.py
+++ b/scripts/dataset/build_pattern_report.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Build discourse pattern report from signature files.
+
+Usage:
+    python scripts/dataset/build_pattern_report.py [--signatures-dir .analysis_kb/signatures]
+
+Reads ``signature_*.json`` files, runs pattern mining (C.3), and generates:
+- ``docs/reports/discourse_patterns.md``
+- ``docs/reports/discourse_patterns/*.svg`` (heatmap, radar, asymmetry)
+"""
+import argparse
+import json
+import pathlib
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Sequence
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent.parent
+
+# Privacy: forbidden strings in any committed output
+FORBIDDEN = ("raw_text", "full_text", "source_name", '"text":', "author")
+
+
+# ---------------------------------------------------------------------------
+# SVG generation helpers (no external dependencies)
+# ---------------------------------------------------------------------------
+
+def _svg_header(w: int, h: int) -> str:
+    return f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" width="{w}" height="{h}">\n'
+
+
+def _svg_text(x: int, y: int, text: str, size: int = 11, anchor: str = "start",
+              color: str = "#333", angle: int = 0) -> str:
+    transform = f' transform="rotate({angle},{x},{y})"' if angle else ""
+    return (f'<text x="{x}" y="{y}" font-size="{size}" '
+            f'fill="{color}" text-anchor="{anchor}"{transform}>{text}</text>\n')
+
+
+def _svg_rect(x: int, y: int, w: int, h: int, fill: str, opacity: float = 1.0) -> str:
+    return (f'<rect x="{x}" y="{y}" width="{w}" height="{h}" '
+            f'fill="{fill}" opacity="{opacity}"/>\n')
+
+
+def _lerp_color(val: float, low: str = "#f0f0f0", high: str = "#2c3e50") -> str:
+    """Interpolate between low and high hex colors based on val ∈ [0, 1]."""
+    if val <= 0:
+        return low
+    if val >= 1:
+        return high
+    lr, lg, lb = int(low[1:3], 16), int(low[3:5], 16), int(low[5:7], 16)
+    hr, hg, hb = int(high[1:3], 16), int(high[3:5], 16), int(high[5:7], 16)
+    r = int(lr + (hr - lr) * val)
+    g = int(lg + (hg - lg) * val)
+    b = int(lb + (hb - lb) * val)
+    return f"#{r:02x}{g:02x}{b:02x}"
+
+
+def generate_heatmap_svg(pairs: List[Dict[str, Any]], top_n: int = 15) -> str:
+    """Generate co-occurrence heatmap SVG from pattern_mining pairs."""
+    if not pairs:
+        return _svg_header(400, 200) + _svg_text(200, 100, "No co-occurrence data", 14, "middle") + "</svg>"
+
+    types = sorted({p["a"] for p in pairs} | {p["b"] for p in pairs})[:top_n]
+    n = len(types)
+    cell = max(30, min(50, 500 // max(n, 1)))
+    margin_l, margin_t = 120, 30
+    w = margin_l + n * cell + 40
+    h = margin_t + n * cell + 80
+
+    pair_map = {}
+    for p in pairs:
+        pair_map[(p["a"], p["b"])] = p["lift"]
+        pair_map[(p["b"], p["a"])] = p["lift"]
+
+    max_lift = max((p["lift"] for p in pairs), default=1.0) or 1.0
+    svg = _svg_header(w, h)
+
+    # Column headers
+    for i, t in enumerate(types):
+        x = margin_l + i * cell + cell // 2
+        svg += _svg_text(x, margin_t - 5, t[:12], 8, "middle", angle=-45)
+
+    # Row headers + cells
+    for j, tb in enumerate(types):
+        y = margin_t + j * cell + cell // 2 + 4
+        svg += _svg_text(margin_l - 5, y, tb[:12], 8, "end")
+        for i, ta in enumerate(types):
+            cx = margin_l + i * cell
+            cy = margin_t + j * cell
+            lift = pair_map.get((ta, tb), 0)
+            norm = min(lift / max_lift, 1.0) if max_lift > 0 else 0
+            fill = _lerp_color(norm)
+            svg += _svg_rect(cx, cy, cell - 1, cell - 1, fill, 0.8)
+            if lift > 0:
+                svg += _svg_text(cx + cell // 2, cy + cell // 2 + 4,
+                                 f"{lift:.1f}", 7, "middle", "white")
+
+    svg += _svg_text(w // 2, h - 15, "Fallacy Co-occurrence Heatmap (lift)", 12, "middle", "#2c3e50")
+    svg += "</svg>"
+    return svg
+
+
+def generate_radar_svg(spectrum: Dict[str, Dict[str, float]],
+                       cluster_id: str) -> str:
+    """Generate a simple radar-like bar chart for one cluster's fallacy spectrum."""
+    fallacies = spectrum.get(cluster_id, {})
+    if not fallacies:
+        return _svg_header(400, 200) + _svg_text(200, 100, f"No data for {cluster_id}", 14, "middle") + "</svg>"
+
+    items = sorted(fallacies.items(), key=lambda x: -x[1])[:12]
+    n = len(items)
+    bar_h = 18
+    margin_l, margin_t = 130, 40
+    w = 500
+    h = margin_t + n * (bar_h + 4) + 40
+
+    svg = _svg_header(w, h)
+    svg += _svg_text(w // 2, 20, f"Fallacy Spectrum — {cluster_id}", 13, "middle", "#2c3e50")
+
+    max_val = max((v for _, v in items), default=1.0) or 1.0
+    for i, (ftype, freq) in enumerate(items):
+        y = margin_t + i * (bar_h + 4)
+        svg += _svg_text(margin_l - 5, y + bar_h - 3, ftype[:18], 9, "end")
+        bar_w = int((freq / max_val) * (w - margin_l - 40))
+        svg += _svg_rect(margin_l, y, bar_w, bar_h, "#2c3e50", 0.7)
+        svg += _svg_text(margin_l + bar_w + 5, y + bar_h - 3, f"{freq:.2f}", 8)
+
+    svg += "</svg>"
+    return svg
+
+
+def generate_asymmetry_svg(asymmetry: Dict[str, Dict[str, float]]) -> str:
+    """Generate Tricherie vs Influence asymmetry bar chart."""
+    if not asymmetry:
+        return _svg_header(400, 200) + _svg_text(200, 100, "No asymmetry data", 14, "middle") + "</svg>"
+
+    clusters = sorted(asymmetry.keys())
+    n = len(clusters)
+    bar_w = 60
+    margin_l, margin_t = 100, 40
+    gap = 40
+    w = margin_l + n * (bar_w + gap) + 40
+    h = 300
+
+    svg = _svg_header(w, h)
+    svg += _svg_text(w // 2, 20, "Tricherie vs Influence Asymmetry", 13, "middle", "#2c3e50")
+
+    max_val = 1.0
+    for i, cid in enumerate(clusters):
+        x = margin_l + i * (bar_w + gap)
+        d = asymmetry[cid]
+        t_share = d.get("tricherie_share", 0)
+        i_share = d.get("influence_share", 0)
+        total = t_share + i_share
+
+        # Tricherie bar (bottom, dark)
+        t_h = int((t_share / max_val) * 180) if max_val > 0 else 0
+        svg += _svg_rect(x, 240 - t_h - int((i_share / max_val) * 180),
+                         bar_w, t_h, "#8b4513", 0.8)
+
+        # Influence bar (top, blue)
+        i_h = int((i_share / max_val) * 180) if max_val > 0 else 0
+        svg += _svg_rect(x, 240 - i_h, bar_w, i_h, "#2c3e50", 0.8)
+
+        svg += _svg_text(x + bar_w // 2, 258, cid[:10], 8, "middle")
+        asym_val = d.get("asymmetry", 0)
+        svg += _svg_text(x + bar_w // 2, 272, f"{asym_val:+.2f}", 8, "middle", "#666")
+
+    svg += _svg_text(30, 80, "Influence", 9, "middle", "#2c3e50")
+    svg += _svg_text(30, 200, "Tricherie", 9, "middle", "#8b4513")
+    svg += "</svg>"
+    return svg
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+def load_signatures(signatures_dir: pathlib.Path) -> List[Dict[str, Any]]:
+    """Load all signature_*.json files from directory."""
+    sigs = []
+    if not signatures_dir.is_dir():
+        return sigs
+    for p in sorted(signatures_dir.glob("signature_*.json")):
+        try:
+            sigs.append(json.loads(p.read_text(encoding="utf-8")))
+        except (json.JSONDecodeError, OSError):
+            continue
+    return sigs
+
+
+def privacy_guard(content: str) -> None:
+    """Exit with error if forbidden strings found in content."""
+    lower = content.lower()
+    for f in FORBIDDEN:
+        if f.lower() in lower:
+            print(f"PRIVACY GUARD: forbidden string '{f}' found in report", file=sys.stderr)
+            sys.exit(1)
+
+
+def build_report(signatures: List[Dict[str, Any]],
+                 output_dir: pathlib.Path,
+                 report_path: pathlib.Path) -> pathlib.Path:
+    """Generate discourse_patterns.md + SVG charts."""
+    from argumentation_analysis.evaluation.pattern_mining import (
+        cooccurrence_matrix,
+        cross_coverage,
+        fallacy_spectrum,
+        run_formal_detectors,
+        trick_vs_influence_ratio,
+        FORMAL_DETECTORS,
+    )
+
+    n_docs = len(signatures)
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    # 1. Spectral analysis
+    spectrum = fallacy_spectrum(signatures)
+    cluster_ids = sorted(spectrum.keys())
+
+    # 2. Asymmetry
+    asymmetry = trick_vs_influence_ratio(signatures)
+
+    # 3. Co-occurrence
+    coocc = cooccurrence_matrix(signatures, top_n=20)
+
+    # 4. Formal detectors
+    formal_results = {}
+    for sig in signatures:
+        cid = sig.get("metadata", {}).get("cluster_id", "unknown")
+        if cid not in formal_results:
+            formal_results[cid] = run_formal_detectors(sig)
+
+    # 5. Cross-coverage
+    xcov = cross_coverage(signatures)
+
+    # --- Build markdown ---
+    md = f"# Discourse Pattern Report\n\n"
+    md += f"**Generated**: {now}\n"
+    md += f"**Documents analyzed**: {n_docs}\n"
+    md += f"**Clusters**: {len(cluster_ids)} ({', '.join(cluster_ids) or 'none'})\n"
+    md += f"**Workflow**: spectacular 17 phases\n\n"
+    md += "---\n\n"
+
+    # Section 2: Spectra
+    md += "## 1. Fallacy Spectra by Cluster\n\n"
+    if spectrum:
+        all_types = sorted({t for c in spectrum.values() for t in c})
+        md += "| Cluster | " + " | ".join(all_types[:10]) + " |\n"
+        md += "|" + "---------|" * (len(all_types[:10]) + 1) + "\n"
+        for cid in cluster_ids:
+            vals = [f"{spectrum[cid].get(t, 0):.2f}" for t in all_types[:10]]
+            md += f"| {cid} | " + " | ".join(vals) + " |\n"
+        md += "\n"
+    else:
+        md += "_No spectral data available._\n\n"
+
+    # Section 3: Asymmetry
+    md += "## 2. Tricherie ↔ Influence Asymmetry\n\n"
+    if asymmetry:
+        md += "| Cluster | Tricherie | Influence | Ratio | Asymmetry |\n"
+        md += "|---------|-----------|-----------|-------|----------|\n"
+        for cid in sorted(asymmetry.keys()):
+            d = asymmetry[cid]
+            md += (f"| {cid} | {d.get('tricherie_share', 0):.3f} | "
+                   f"{d.get('influence_share', 0):.3f} | "
+                   f"{d.get('ratio', 0):.2f} | "
+                   f"{d.get('asymmetry', 0):+.3f} |\n")
+        md += "\n"
+    else:
+        md += "_No asymmetry data._\n\n"
+
+    # Section 4: Co-occurrences
+    md += "## 3. Co-occurrence Top-20\n\n"
+    if coocc.get("pairs"):
+        md += "| Fallacy A | Fallacy B | Support | Confidence | Lift | Jaccard |\n"
+        md += "|-----------|-----------|---------|------------|------|--------|\n"
+        for p in coocc["pairs"][:20]:
+            md += (f"| {p['a']} | {p['b']} | {p['support']} | "
+                   f"{p['confidence']:.3f} | {p['lift']:.2f} | "
+                   f"{p['jaccard']:.3f} |\n")
+        md += f"\n_Units with co-occurrences: {coocc.get('unit_count', 0)}_\n\n"
+    else:
+        md += "_No co-occurrence data._\n\n"
+
+    # Section 5: Formal patterns
+    md += "## 4. Formal Pattern Detectors\n\n"
+    for det in FORMAL_DETECTORS:
+        md += f"### {det.name}\n\n"
+        if formal_results:
+            md += "| Cluster | " + " | ".join(k for k in next(iter(formal_results.values())).get(det.name, {}).keys()) + " |\n"
+            header_cols = list(next(iter(formal_results.values())).get(det.name, {}).keys())
+            md += "|" + "------|" * (len(header_cols) + 1) + "\n"
+            for cid, results in sorted(formal_results.items()):
+                vals = results.get(det.name, {})
+                md += f"| {cid} | " + " | ".join(f"{vals.get(k, 0):.3f}" for k in header_cols) + " |\n"
+        md += "\n"
+
+    # Section 6: Cross-coverage
+    md += "## 5. Cross-coverage: Informal ↔ Formal\n\n"
+    if xcov:
+        signals = ["fol_invalid", "dung_unsupported", "jtms_retraction"]
+        md += "| Fallacy Type | " + " | ".join(s.title() for s in signals) + " |\n"
+        md += "|" + "------|" * (len(signals) + 1) + "\n"
+        for ftype in sorted(xcov.keys()):
+            vals = [f"{xcov[ftype].get(s, 0):.2f}" for s in signals]
+            md += f"| {ftype} | " + " | ".join(vals) + " |\n"
+        md += "\n_Hypothesis: manipulation = camouflaging formal errors?_\n\n"
+    else:
+        md += "_No cross-coverage data._\n\n"
+
+    # Section 7: Limitations
+    md += "## 6. Limitations & Next Steps\n\n"
+    md += "- Coverage limited to available corpus subset\n"
+    md += "- Sampling bias toward represented discourse types\n"
+    md += "- Formal detector registry is extensible (see `pattern_mining.FORMAL_DETECTORS`)\n"
+    md += "- Future: temporal comparison, richer metadata, LLM-assisted narrative\n"
+
+    # Privacy guard
+    privacy_guard(md)
+
+    # Write report
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    report_path.write_text(md, encoding="utf-8")
+
+    # Write SVGs
+    svg_dir = output_dir / "discourse_patterns"
+    svg_dir.mkdir(parents=True, exist_ok=True)
+
+    (svg_dir / "heatmap_fallacies.svg").write_text(
+        generate_heatmap_svg(coocc.get("pairs", [])), encoding="utf-8")
+    (svg_dir / "asymmetry_chart.svg").write_text(
+        generate_asymmetry_svg(asymmetry), encoding="utf-8")
+
+    for cid in cluster_ids[:5]:
+        (svg_dir / f"spectrum_radar_{cid}.svg").write_text(
+            generate_radar_svg(spectrum, cid), encoding="utf-8")
+
+    return report_path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build discourse pattern report from signature files")
+    parser.add_argument("--signatures-dir", type=pathlib.Path,
+                        default=pathlib.Path(".analysis_kb/signatures"))
+    args = parser.parse_args()
+
+    signatures = load_signatures(args.signatures_dir)
+    if not signatures:
+        print("No signature files found. Generate them with pattern-rerun first.",
+              file=sys.stderr)
+        sys.exit(1)
+
+    report_path = REPO_ROOT / "docs" / "reports" / "discourse_patterns.md"
+    output_dir = REPO_ROOT / "docs" / "reports"
+
+    result = build_report(signatures, output_dir, report_path)
+    print(f"Report: {result}")
+    print(f"SVGs:   {output_dir / 'discourse_patterns'}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_pattern_report.py
+++ b/tests/integration/test_pattern_report.py
@@ -1,0 +1,294 @@
+"""Integration tests for build_pattern_report.py (C.4 — Issue #412).
+
+Uses synthetic fixture signatures to validate report generation,
+SVG output, and privacy guard without requiring real corpus data.
+"""
+
+import json
+import pathlib
+import textwrap
+
+import pytest
+
+from argumentation_analysis.evaluation.pattern_mining import (
+    FORMAL_DETECTORS,
+    cooccurrence_matrix,
+    cross_coverage,
+    fallacy_spectrum,
+    run_formal_detectors,
+    trick_vs_influence_ratio,
+)
+
+# ---------------------------------------------------------------------------
+# Synthetic fixture signatures
+# ---------------------------------------------------------------------------
+
+def _make_signature(
+    cluster_id: str = "test_cluster",
+    fallacies: dict | None = None,
+    dung_args: int = 0,
+    dung_attacks: int = 0,
+    jtms_retractions: int = 0,
+    fol_valid: bool = True,
+) -> dict:
+    """Build a minimal synthetic signature for testing."""
+    fallacies = fallacies or {}
+    identified = {}
+    for i, (ftype, src) in enumerate(fallacies.items()):
+        identified[f"f{i}"] = {"type": ftype, "source_arg": src}
+
+    dung_fw = {}
+    if dung_args > 0:
+        dung_fw["fw0"] = {
+            "arguments": [f"arg{j}" for j in range(dung_args)],
+            "attacks": [
+                {"from": f"arg{j}", "to": f"arg{j+1}"}
+                for j in range(min(dung_attacks, dung_args - 1))
+            ],
+            "extensions": {"grounded": [[f"arg{j}" for j in range(dung_args)]]},
+        }
+
+    jtms_beliefs = {f"b{j}": {"justification": f"j{j}"} for j in range(dung_args)}
+    state = {
+        "identified_fallacies": identified,
+        "dung_frameworks": dung_fw,
+        "jtms_beliefs": jtms_beliefs,
+        "jtms_retraction_chain": [{"from": f"b{j}", "to": f"b{j+1}"} for j in range(jtms_retractions)],
+        "fol_analysis_results": [] if fol_valid else [{"valid": False}],
+        "atms_contexts": [],
+    }
+    return {"metadata": {"cluster_id": cluster_id}, "state": state}
+
+
+@pytest.fixture
+def synthetic_signatures():
+    """3 documents across 2 clusters with varied fallacy profiles."""
+    return [
+        _make_signature(
+            "propaganda",
+            {"ad_hominem": "arg0", "appeal_to_fear": "arg1", "straw_man": "arg0"},
+            dung_args=4, dung_attacks=3, jtms_retractions=2, fol_valid=False,
+        ),
+        _make_signature(
+            "propaganda",
+            {"ad_hominem": "arg0", "bandwagon": "arg2", "cherry_picking": "arg3"},
+            dung_args=2, dung_attacks=1, jtms_retractions=0,
+        ),
+        _make_signature(
+            "debate",
+            {"straw_man": "arg0", "false_dilemma": "arg1", "red_herring": "arg2"},
+            dung_args=3, dung_attacks=2, jtms_retractions=1, fol_valid=False,
+        ),
+    ]
+
+
+@pytest.fixture
+def sig_dir(tmp_path, synthetic_signatures):
+    """Write synthetic signatures to temp directory as JSON files."""
+    for i, sig in enumerate(synthetic_signatures):
+        (tmp_path / f"signature_{i:03d}.json").write_text(
+            json.dumps(sig), encoding="utf-8"
+        )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Test: pattern_mining functions on synthetic data
+# ---------------------------------------------------------------------------
+
+class TestPatternMining:
+    """Verify pattern_mining functions produce valid output on synthetic data."""
+
+    def test_fallacy_spectrum_returns_clusters(self, synthetic_signatures):
+        spectrum = fallacy_spectrum(synthetic_signatures)
+        assert "propaganda" in spectrum
+        assert "debate" in spectrum
+        # Relative frequencies should sum to ~1.0 per cluster
+        for cid, types in spectrum.items():
+            total = sum(types.values())
+            assert 0.0 < total <= 1.01, f"Cluster {cid} sum={total}"
+
+    def test_fallacy_spectrum_values(self, synthetic_signatures):
+        spectrum = fallacy_spectrum(synthetic_signatures)
+        # propaganda cluster has ad_hominem in both docs → should have highest freq
+        prop = spectrum["propaganda"]
+        assert "ad_hominem" in prop
+        assert prop["ad_hominem"] > 0
+
+    def test_trick_vs_influence_ratio(self, synthetic_signatures):
+        asym = trick_vs_influence_ratio(synthetic_signatures)
+        assert "propaganda" in asym
+        assert "debate" in asym
+        for cid, d in asym.items():
+            assert "tricherie_share" in d
+            assert "influence_share" in d
+            assert "asymmetry" in d
+            assert -1.0 <= d["asymmetry"] <= 1.0
+
+    def test_cooccurrence_matrix(self, synthetic_signatures):
+        coocc = cooccurrence_matrix(synthetic_signatures, top_n=10)
+        assert "pairs" in coocc
+        assert "unit_count" in coocc
+        # With co-occurring fallacies in same source_arg, we should get some pairs
+        assert coocc["unit_count"] >= 0
+
+    def test_cross_coverage(self, synthetic_signatures):
+        xcov = cross_coverage(synthetic_signatures)
+        assert isinstance(xcov, dict)
+        # At least one fallacy type should appear
+        if xcov:
+            for ftype, signals in xcov.items():
+                for sig_name in ["fol_invalid", "dung_unsupported", "jtms_retraction"]:
+                    assert sig_name in signals
+
+    def test_formal_detectors(self, synthetic_signatures):
+        for sig in synthetic_signatures:
+            results = run_formal_detectors(sig)
+            assert len(results) == len(FORMAL_DETECTORS)
+            for det in FORMAL_DETECTORS:
+                assert det.name in results
+                metrics = results[det.name]
+                assert all(isinstance(v, float) for v in metrics.values())
+
+
+# ---------------------------------------------------------------------------
+# Test: build_pattern_report functions
+# ---------------------------------------------------------------------------
+
+class TestReportBuilder:
+    """Test report generation and SVG output."""
+
+    def test_load_signatures(self, sig_dir, synthetic_signatures):
+        from scripts.dataset.build_pattern_report import load_signatures
+
+        loaded = load_signatures(sig_dir)
+        assert len(loaded) == len(synthetic_signatures)
+
+    def test_load_signatures_empty_dir(self, tmp_path):
+        from scripts.dataset.build_pattern_report import load_signatures
+
+        assert load_signatures(tmp_path) == []
+        assert load_signatures(tmp_path / "nonexistent") == []
+
+    def test_build_report_generates_markdown(self, sig_dir, tmp_path):
+        from scripts.dataset.build_pattern_report import load_signatures, build_report
+
+        sigs = load_signatures(sig_dir)
+        report_path = tmp_path / "discourse_patterns.md"
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        result = build_report(sigs, output_dir, report_path)
+        assert result == report_path
+        assert report_path.exists()
+
+        content = report_path.read_text(encoding="utf-8")
+        assert "# Discourse Pattern Report" in content
+        assert "## 1. Fallacy Spectra by Cluster" in content
+        assert "## 2. Tricherie" in content
+        assert "## 3. Co-occurrence" in content
+        assert "## 4. Formal Pattern Detectors" in content
+        assert "## 5. Cross-coverage" in content
+        assert "## 6. Limitations" in content
+
+    def test_build_report_generates_svgs(self, sig_dir, tmp_path):
+        from scripts.dataset.build_pattern_report import load_signatures, build_report
+
+        sigs = load_signatures(sig_dir)
+        report_path = tmp_path / "discourse_patterns.md"
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        build_report(sigs, output_dir, report_path)
+
+        svg_dir = output_dir / "discourse_patterns"
+        assert svg_dir.is_dir()
+        assert (svg_dir / "heatmap_fallacies.svg").exists()
+        assert (svg_dir / "asymmetry_chart.svg").exists()
+
+        # Heatmap should contain SVG markup
+        heatmap = (svg_dir / "heatmap_fallacies.svg").read_text(encoding="utf-8")
+        assert "<svg" in heatmap
+        assert "</svg>" in heatmap
+
+    def test_build_report_generates_radar_svgs(self, sig_dir, tmp_path):
+        from scripts.dataset.build_pattern_report import load_signatures, build_report
+
+        sigs = load_signatures(sig_dir)
+        report_path = tmp_path / "discourse_patterns.md"
+        output_dir = tmp_path / "output"
+        output_dir.mkdir()
+
+        build_report(sigs, output_dir, report_path)
+
+        svg_dir = output_dir / "discourse_patterns"
+        radar_files = list(svg_dir.glob("spectrum_radar_*.svg"))
+        # Should have at least one radar for each cluster (up to 5)
+        assert len(radar_files) >= 1
+
+    def test_privacy_guard_blocks_forbidden_strings(self):
+        from scripts.dataset.build_pattern_report import privacy_guard
+
+        for forbidden in ["raw_text", "full_text", "source_name", '"text":', "author"]:
+            with pytest.raises(SystemExit, match="1"):
+                privacy_guard(f"This has {forbidden} in it")
+
+    def test_privacy_guard_allows_clean_content(self):
+        from scripts.dataset.build_pattern_report import privacy_guard
+
+        # Should not raise
+        privacy_guard("Clean content with no forbidden strings")
+        privacy_guard("Fallacy spectra and co-occurrence data")
+
+
+# ---------------------------------------------------------------------------
+# Test: SVG generation edge cases
+# ---------------------------------------------------------------------------
+
+class TestSVGGeneration:
+    """Test SVG generation with edge-case inputs."""
+
+    def test_heatmap_empty_pairs(self):
+        from scripts.dataset.build_pattern_report import generate_heatmap_svg
+
+        svg = generate_heatmap_svg([])
+        assert "<svg" in svg
+        assert "No co-occurrence data" in svg
+
+    def test_radar_empty_cluster(self):
+        from scripts.dataset.build_pattern_report import generate_radar_svg
+
+        svg = generate_radar_svg({}, "nonexistent")
+        assert "<svg" in svg
+        assert "No data for nonexistent" in svg
+
+    def test_asymmetry_empty(self):
+        from scripts.dataset.build_pattern_report import generate_asymmetry_svg
+
+        svg = generate_asymmetry_svg({})
+        assert "<svg" in svg
+        assert "No asymmetry data" in svg
+
+    def test_heatmap_with_data(self):
+        from scripts.dataset.build_pattern_report import generate_heatmap_svg
+
+        pairs = [
+            {"a": "ad_hominem", "b": "straw_man", "lift": 2.5},
+            {"a": "appeal_to_fear", "b": "bandwagon", "lift": 1.8},
+            {"a": "ad_hominem", "b": "appeal_to_fear", "lift": 3.1},
+        ]
+        svg = generate_heatmap_svg(pairs)
+        assert "<svg" in svg
+        assert "ad_hominem" in svg
+        assert "2.5" in svg
+
+    def test_asymmetry_with_data(self):
+        from scripts.dataset.build_pattern_report import generate_asymmetry_svg
+
+        data = {
+            "cluster_a": {"tricherie_share": 0.3, "influence_share": 0.7, "asymmetry": 0.4},
+            "cluster_b": {"tricherie_share": 0.6, "influence_share": 0.2, "asymmetry": -0.5},
+        }
+        svg = generate_asymmetry_svg(data)
+        assert "<svg" in svg
+        assert "cluster_a" in svg

--- a/tests/integration/test_pattern_report.py
+++ b/tests/integration/test_pattern_report.py
@@ -135,11 +135,14 @@ class TestPatternMining:
     def test_cross_coverage(self, synthetic_signatures):
         xcov = cross_coverage(synthetic_signatures)
         assert isinstance(xcov, dict)
-        # At least one fallacy type should appear
+        # New structure: {ftype: {"per_signature_rate": {...}, "per_occurrence_rate": {...}}}
         if xcov:
-            for ftype, signals in xcov.items():
-                for sig_name in ["fol_invalid", "dung_unsupported", "jtms_retraction"]:
-                    assert sig_name in signals
+            for ftype, rates in xcov.items():
+                assert "per_signature_rate" in rates
+                assert "per_occurrence_rate" in rates
+                for rate_family in ["per_signature_rate", "per_occurrence_rate"]:
+                    for sig_name in ["fol_invalid", "dung_unsupported", "jtms_retraction"]:
+                        assert sig_name in rates[rate_family]
 
     def test_formal_detectors(self, synthetic_signatures):
         for sig in synthetic_signatures:


### PR DESCRIPTION
## Summary

**C.4 Discourse signature report** — consumes `pattern_mining` API from C.3 (#430, merged) to generate `docs/reports/discourse_patterns.md` with 6 analytical sections + SVG visualizations.

### Changes (rebased clean from main `91ce9940`)
- `scripts/dataset/build_pattern_report.py` — Markdown report generator (spectra, asymmetry, co-occurrence, formal detectors, cross-coverage, limitations) + SVG charts
- `tests/integration/test_pattern_report.py` — 18 tests covering all report functions + privacy guard
- `docs/reports/discourse_patterns.md` — Demo report with synthetic data
- `docs/reports/discourse_patterns/*.svg` — 4 SVG visualizations (heatmap, 2 radars, asymmetry bars)

### Fixes since original #428
- **Cross-coverage API adaptation**: Uses `per_signature_rate` from corrected `cross_coverage()` (C.3 fix). Old code accessed flat dict, now correctly accesses nested `{per_signature_rate: {...}, per_occurrence_rate: {...}}`.
- **Report re-rendered** with corrected metrics
- **13 duplicate files eliminated** (C.1/C.2/C.3 already on main via #425/#426/#430)
- Clean cherry-pick — only 7 C.4-specific files in diff

### Test plan
- [x] 18/18 tests pass (`pytest tests/integration/test_pattern_report.py -v`)
- [x] Privacy guard blocks forbidden strings (raw_text, full_text, source_name, author)
- [x] Cross-coverage uses `per_signature_rate` (coordinator's requested metric)
- [x] All SVGs render correctly with empty and populated data

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)