### PR TITLE
feat(orchestration): DAG-level parallel execution for spectacular workflow (#433)

### DIFF
--- a/argumentation_analysis/orchestration/workflow_dsl.py
+++ b/argumentation_analysis/orchestration/workflow_dsl.py
@@ -17,7 +17,9 @@ Usage:
     result = await workflow.execute(text, registry=registry)
 """
 
+import asyncio
 import logging
+import time
 from typing import (
     Callable,
     Dict,
@@ -25,6 +27,7 @@ from typing import (
     Any,
     Optional,
     Set,
+    Tuple,
 )
 from dataclasses import dataclass, field
 from enum import Enum
@@ -313,6 +316,9 @@ class WorkflowExecutor:
         """
         Execute a workflow definition.
 
+        Phases at the same DAG level execute concurrently via asyncio.gather().
+        Phases at different levels execute sequentially (respecting depends_on).
+
         Args:
             workflow: The workflow to execute
             input_data: Input data (typically text to analyze)
@@ -327,14 +333,11 @@ class WorkflowExecutor:
         Returns:
             Dict mapping phase name to PhaseResult.
         """
-        import time
-
         results: Dict[str, PhaseResult] = {}
         execution_order = workflow.get_execution_order()
         ctx = dict(context or {})
         ctx["input_data"] = input_data
 
-        # Inject state into context for invoke callables to access
         if state is not None:
             ctx["unified_state"] = state
 
@@ -346,168 +349,22 @@ class WorkflowExecutor:
         for level_idx, level_phases in enumerate(execution_order):
             logger.debug(f"Level {level_idx}: executing phases {level_phases}")
 
+            phase_coros = []
             for phase_name in level_phases:
                 phase = workflow.get_phase(phase_name)
-                if not phase:
-                    continue
-
-                start = time.time()
-
-                # Condition check — skip phase when condition returns False
-                if phase.condition is not None:
-                    try:
-                        if not phase.condition(ctx):
-                            results[phase_name] = PhaseResult(
-                                phase_name=phase_name,
-                                status=PhaseStatus.SKIPPED,
-                                capability=phase.capability,
-                                error="Condition not met",
-                            )
-                            logger.info(
-                                f"Phase '{phase_name}' skipped — " f"condition not met"
-                            )
-                            continue
-                    except Exception as cond_err:
-                        logger.warning(
-                            f"Condition eval failed for '{phase_name}': "
-                            f"{cond_err} — proceeding anyway"
-                        )
-
-                # Resolve capability
-                try:
-                    providers = self._registry.find_for_capability(phase.capability)
-                except Exception as resolve_err:
-                    duration = time.time() - start
-                    results[phase_name] = PhaseResult(
-                        phase_name=phase_name,
-                        status=PhaseStatus.FAILED,
-                        capability=phase.capability,
-                        error=f"Capability resolution error: {resolve_err}",
-                        duration_seconds=duration,
-                    )
-                    logger.error(
-                        f"Phase '{phase_name}' FAILED — "
-                        f"capability resolution error for '{phase.capability}': {resolve_err}"
-                    )
-                    continue
-
-                if not providers:
-                    if phase.optional:
-                        results[phase_name] = PhaseResult(
-                            phase_name=phase_name,
-                            status=PhaseStatus.SKIPPED,
-                            capability=phase.capability,
-                            error="No provider available (optional phase)",
-                        )
-                        logger.info(
-                            f"Phase '{phase_name}' skipped — "
-                            f"no provider for '{phase.capability}'"
-                        )
-                        continue
-                    else:
-                        results[phase_name] = PhaseResult(
-                            phase_name=phase_name,
-                            status=PhaseStatus.FAILED,
-                            capability=phase.capability,
-                            error=f"No provider for required capability '{phase.capability}'",
-                        )
-                        logger.error(
-                            f"Phase '{phase_name}' FAILED — "
-                            f"no provider for required capability '{phase.capability}'"
-                        )
-                        continue
-
-                # Use the first available provider
-                provider = providers[0]
-                try:
-                    import asyncio
-
-                    # Apply input transform if defined
-                    phase_input = input_data
-                    if phase.input_transform is not None:
-                        try:
-                            phase_input = phase.input_transform(input_data, ctx)
-                        except Exception as tf_err:
-                            logger.warning(
-                                f"Input transform failed for '{phase_name}': "
-                                f"{tf_err} — using original input"
-                            )
-                            phase_input = input_data
-
-                    output = None
-                    if provider.invoke is not None:
-                        if phase.loop_config is not None:
-                            # Iterative execution
-                            output = await self._execute_loop(
-                                phase,
-                                provider,
-                                phase_input,
-                                ctx,
-                                phase.loop_config,
-                            )
-                        elif phase.timeout_seconds:
-                            output = await asyncio.wait_for(
-                                provider.invoke(phase_input, ctx),
-                                timeout=phase.timeout_seconds,
-                            )
-                        else:
-                            output = await provider.invoke(phase_input, ctx)
-                    else:
-                        logger.warning(
-                            f"Phase '{phase_name}': component '{provider.name}' "
-                            f"has no invoke callable, output will be None"
-                        )
-
-                    duration = time.time() - start
-                    results[phase_name] = PhaseResult(
-                        phase_name=phase_name,
-                        status=PhaseStatus.COMPLETED,
-                        capability=phase.capability,
-                        component_used=provider.name,
-                        output=output,
-                        duration_seconds=duration,
+                if phase:
+                    phase_coros.append(
+                        self._execute_phase(phase, phase_name, input_data, ctx)
                     )
 
-                    # Store result in context for downstream phases
-                    ctx[f"phase_{phase_name}_result"] = results[phase_name]
-                    ctx[f"phase_{phase_name}_output"] = output
+            if not phase_coros:
+                continue
 
-                    # Write phase output to unified state if writer exists
-                    if (
-                        state is not None
-                        and state_writers
-                        and phase.capability in state_writers
-                    ):
-                        try:
-                            state_writers[phase.capability](output, state, ctx)
-                        except Exception as sw_err:
-                            logger.warning(
-                                f"State writer for '{phase.capability}' failed: {sw_err}"
-                            )
-
-                    logger.info(
-                        f"Phase '{phase_name}' completed "
-                        f"using '{provider.name}' ({duration:.2f}s)"
-                    )
-
-                except Exception as e:
-                    duration = time.time() - start
-                    results[phase_name] = PhaseResult(
-                        phase_name=phase_name,
-                        status=PhaseStatus.FAILED,
-                        capability=phase.capability,
-                        component_used=provider.name,
-                        error=str(e),
-                        duration_seconds=duration,
-                    )
-                    logger.error(f"Phase '{phase_name}' FAILED: {e}")
-
-                    # Log error in unified state
-                    if state is not None and hasattr(state, "log_error"):
-                        try:
-                            state.log_error(phase_name, str(e))
-                        except Exception:
-                            pass
+            level_results = await asyncio.gather(*phase_coros)
+            for phase_name, result, output in level_results:
+                self._store_phase_result(
+                    phase_name, result, output, results, ctx, state, state_writers
+                )
 
         # Summary
         completed = sum(
@@ -520,7 +377,6 @@ class WorkflowExecutor:
             f"{completed} completed, {failed} failed, {skipped} skipped"
         )
 
-        # Store workflow summary in unified state
         if state is not None and hasattr(state, "set_workflow_results"):
             try:
                 state.set_workflow_results(
@@ -536,6 +392,184 @@ class WorkflowExecutor:
                 logger.warning(f"Failed to store workflow results in state: {sw_err}")
 
         return results
+
+    async def _execute_phase(
+        self,
+        phase: WorkflowPhase,
+        phase_name: str,
+        input_data: Any,
+        ctx: Dict[str, Any],
+    ) -> Tuple[str, PhaseResult, Any]:
+        """Execute a single workflow phase, returning (name, result, output)."""
+        start = time.time()
+
+        # Condition check
+        if phase.condition is not None:
+            try:
+                if not phase.condition(ctx):
+                    return (
+                        phase_name,
+                        PhaseResult(
+                            phase_name=phase_name,
+                            status=PhaseStatus.SKIPPED,
+                            capability=phase.capability,
+                            error="Condition not met",
+                        ),
+                        None,
+                    )
+            except Exception as cond_err:
+                logger.warning(
+                    f"Condition eval failed for '{phase_name}': "
+                    f"{cond_err} — proceeding anyway"
+                )
+
+        # Resolve capability
+        try:
+            providers = self._registry.find_for_capability(phase.capability)
+        except Exception as resolve_err:
+            duration = time.time() - start
+            return (
+                phase_name,
+                PhaseResult(
+                    phase_name=phase_name,
+                    status=PhaseStatus.FAILED,
+                    capability=phase.capability,
+                    error=f"Capability resolution error: {resolve_err}",
+                    duration_seconds=duration,
+                ),
+                None,
+            )
+
+        if not providers:
+            if phase.optional:
+                return (
+                    phase_name,
+                    PhaseResult(
+                        phase_name=phase_name,
+                        status=PhaseStatus.SKIPPED,
+                        capability=phase.capability,
+                        error="No provider available (optional phase)",
+                    ),
+                    None,
+                )
+            return (
+                phase_name,
+                PhaseResult(
+                    phase_name=phase_name,
+                    status=PhaseStatus.FAILED,
+                    capability=phase.capability,
+                    error=f"No provider for required capability '{phase.capability}'",
+                ),
+                None,
+            )
+
+        provider = providers[0]
+        try:
+            phase_input = input_data
+            if phase.input_transform is not None:
+                try:
+                    phase_input = phase.input_transform(input_data, ctx)
+                except Exception as tf_err:
+                    logger.warning(
+                        f"Input transform failed for '{phase_name}': "
+                        f"{tf_err} — using original input"
+                    )
+                    phase_input = input_data
+
+            output = None
+            if provider.invoke is not None:
+                if phase.loop_config is not None:
+                    output = await self._execute_loop(
+                        phase,
+                        provider,
+                        phase_input,
+                        ctx,
+                        phase.loop_config,
+                    )
+                elif phase.timeout_seconds:
+                    output = await asyncio.wait_for(
+                        provider.invoke(phase_input, ctx),
+                        timeout=phase.timeout_seconds,
+                    )
+                else:
+                    output = await provider.invoke(phase_input, ctx)
+            else:
+                logger.warning(
+                    f"Phase '{phase_name}': component '{provider.name}' "
+                    f"has no invoke callable, output will be None"
+                )
+
+            duration = time.time() - start
+            return (
+                phase_name,
+                PhaseResult(
+                    phase_name=phase_name,
+                    status=PhaseStatus.COMPLETED,
+                    capability=phase.capability,
+                    component_used=provider.name,
+                    output=output,
+                    duration_seconds=duration,
+                ),
+                output,
+            )
+
+        except Exception as e:
+            duration = time.time() - start
+            return (
+                phase_name,
+                PhaseResult(
+                    phase_name=phase_name,
+                    status=PhaseStatus.FAILED,
+                    capability=phase.capability,
+                    component_used=provider.name,
+                    error=str(e),
+                    duration_seconds=duration,
+                ),
+                None,
+            )
+
+    def _store_phase_result(
+        self,
+        phase_name: str,
+        result: PhaseResult,
+        output: Any,
+        results: Dict[str, PhaseResult],
+        ctx: Dict[str, Any],
+        state: Any,
+        state_writers: Optional[Dict[str, Any]],
+    ) -> None:
+        """Store a phase result in results dict, context, and state."""
+        results[phase_name] = result
+
+        if result.status == PhaseStatus.COMPLETED:
+            ctx[f"phase_{phase_name}_result"] = result
+            ctx[f"phase_{phase_name}_output"] = output
+
+            if (
+                state is not None
+                and state_writers
+                and result.capability in state_writers
+            ):
+                try:
+                    state_writers[result.capability](output, state, ctx)
+                except Exception as sw_err:
+                    logger.warning(
+                        f"State writer for '{result.capability}' failed: {sw_err}"
+                    )
+
+            logger.info(
+                f"Phase '{phase_name}' completed "
+                f"using '{result.component_used}' ({result.duration_seconds:.2f}s)"
+            )
+        elif result.status == PhaseStatus.SKIPPED:
+            logger.info(f"Phase '{phase_name}' skipped — {result.error}")
+        elif result.status == PhaseStatus.FAILED:
+            logger.error(f"Phase '{phase_name}' FAILED — " f"{result.error}")
+            if state is not None and hasattr(state, "log_error"):
+                try:
+                    state.log_error(phase_name, str(result.error))
+                except Exception:
+                    pass
 
     async def _execute_loop(
         self,

--- a/tests/unit/argumentation_analysis/orchestration/test_parallel_execution.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_parallel_execution.py
@@ -1,0 +1,311 @@
+"""Tests for DAG-level parallel execution in WorkflowExecutor.
+
+Validates that phases at the same DAG level run concurrently via
+asyncio.gather(), and that dependency ordering is preserved across levels.
+"""
+
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from argumentation_analysis.core.capability_registry import (
+    CapabilityRegistry,
+    ComponentType,
+)
+from argumentation_analysis.orchestration.workflow_dsl import (
+    WorkflowBuilder,
+    WorkflowExecutor,
+    PhaseStatus,
+)
+
+
+def _make_slow_invoke(delay: float, result: str = "ok"):
+    """Create an async invoke callable with a configurable delay."""
+
+    async def _invoke(text, ctx):
+        await asyncio.sleep(delay)
+        return result
+
+    return _invoke
+
+
+class TestParallelPhasesExecuteConcurrently:
+    """Verify that independent phases at the same DAG level run in parallel."""
+
+    @pytest.mark.asyncio
+    async def test_parallel_phases_faster_than_sequential(self):
+        """Three independent phases (0.2s each) should complete in ~0.2s, not ~0.6s."""
+        registry = CapabilityRegistry()
+        for cap in ["cap_a", "cap_b", "cap_c"]:
+            registry.register(
+                name=f"comp_{cap}",
+                component_type=ComponentType.AGENT,
+                capabilities=[cap],
+                invoke=_make_slow_invoke(0.2, f"out_{cap}"),
+            )
+
+        workflow = (
+            WorkflowBuilder("parallel_test")
+            .add_phase("a", capability="cap_a")
+            .add_phase("b", capability="cap_b")
+            .add_phase("c", capability="cap_c")
+            .build()
+        )
+
+        executor = WorkflowExecutor(registry)
+        start = time.time()
+        results = await executor.execute(workflow, "input")
+        elapsed = time.time() - start
+
+        assert results["a"].status == PhaseStatus.COMPLETED
+        assert results["b"].status == PhaseStatus.COMPLETED
+        assert results["c"].status == PhaseStatus.COMPLETED
+        assert results["a"].output == "out_cap_a"
+        assert results["b"].output == "out_cap_b"
+        assert results["c"].output == "out_cap_c"
+        # Parallel: 0.2s + overhead. Sequential would be > 0.5s.
+        assert elapsed < 0.5, f"Expected parallel (<0.5s), got {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_parallel_execution_with_diamond_dag(self):
+        """Diamond DAG: A -> (B, C) -> D. B and C should run in parallel."""
+        registry = CapabilityRegistry()
+        registry.register(
+            name="comp_a",
+            component_type=ComponentType.AGENT,
+            capabilities=["cap_a"],
+            invoke=_make_slow_invoke(0.1, "out_a"),
+        )
+        registry.register(
+            name="comp_b",
+            component_type=ComponentType.AGENT,
+            capabilities=["cap_b"],
+            invoke=_make_slow_invoke(0.2, "out_b"),
+        )
+        registry.register(
+            name="comp_c",
+            component_type=ComponentType.AGENT,
+            capabilities=["cap_c"],
+            invoke=_make_slow_invoke(0.2, "out_c"),
+        )
+        registry.register(
+            name="comp_d",
+            component_type=ComponentType.AGENT,
+            capabilities=["cap_d"],
+            invoke=_make_slow_invoke(0.1, "out_d"),
+        )
+
+        workflow = (
+            WorkflowBuilder("diamond")
+            .add_phase("a", capability="cap_a")
+            .add_phase("b", capability="cap_b", depends_on=["a"])
+            .add_phase("c", capability="cap_c", depends_on=["a"])
+            .add_phase("d", capability="cap_d", depends_on=["b", "c"])
+            .build()
+        )
+
+        executor = WorkflowExecutor(registry)
+        start = time.time()
+        results = await executor.execute(workflow, "input")
+        elapsed = time.time() - start
+
+        assert all(r.status == PhaseStatus.COMPLETED for r in results.values())
+        # A(0.1) + max(B,C)(0.2) + D(0.1) = ~0.4s parallel
+        # Sequential would be: 0.1 + 0.2 + 0.2 + 0.1 = 0.6s
+        assert elapsed < 0.55, f"Expected parallel diamond (<0.55s), got {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_dependency_ordering_preserved(self):
+        """Phases at different levels must wait for their dependencies."""
+        execution_log = []
+
+        async def logging_invoke(cap_name):
+            async def _invoke(text, ctx):
+                execution_log.append(f"start_{cap_name}")
+                await asyncio.sleep(0.05)
+                execution_log.append(f"end_{cap_name}")
+                return f"out_{cap_name}"
+
+            return _invoke
+
+        registry = CapabilityRegistry()
+        for cap in ["cap_a", "cap_b", "cap_c"]:
+            registry.register(
+                name=f"comp_{cap}",
+                component_type=ComponentType.AGENT,
+                capabilities=[cap],
+                invoke=await logging_invoke(cap),
+            )
+
+        workflow = (
+            WorkflowBuilder("deps")
+            .add_phase("a", capability="cap_a")
+            .add_phase("b", capability="cap_b", depends_on=["a"])
+            .add_phase("c", capability="cap_c", depends_on=["b"])
+            .build()
+        )
+
+        executor = WorkflowExecutor(registry)
+        await executor.execute(workflow, "input")
+
+        # Verify strict ordering: a starts before b, b starts before c
+        idx_start_a = execution_log.index("start_cap_a")
+        idx_start_b = execution_log.index("start_cap_b")
+        idx_start_c = execution_log.index("start_cap_c")
+        assert idx_start_a < idx_start_b < idx_start_c
+
+    @pytest.mark.asyncio
+    async def test_parallel_mixed_success_failure(self):
+        """One phase failing at a level should not affect others at same level."""
+        registry = CapabilityRegistry()
+        registry.register(
+            name="comp_ok",
+            component_type=ComponentType.AGENT,
+            capabilities=["cap_ok"],
+            invoke=_make_slow_invoke(0.1, "out_ok"),
+        )
+
+        async def failing_invoke(text, ctx):
+            await asyncio.sleep(0.05)
+            raise RuntimeError("intentional failure")
+
+        registry.register(
+            name="comp_fail",
+            component_type=ComponentType.AGENT,
+            capabilities=["cap_fail"],
+            invoke=failing_invoke,
+        )
+        registry.register(
+            name="comp_also_ok",
+            component_type=ComponentType.AGENT,
+            capabilities=["cap_also_ok"],
+            invoke=_make_slow_invoke(0.1, "out_also_ok"),
+        )
+
+        workflow = (
+            WorkflowBuilder("mixed")
+            .add_phase("ok", capability="cap_ok")
+            .add_phase("fail", capability="cap_fail")
+            .add_phase("also_ok", capability="cap_also_ok")
+            .build()
+        )
+
+        executor = WorkflowExecutor(registry)
+        results = await executor.execute(workflow, "input")
+
+        assert results["ok"].status == PhaseStatus.COMPLETED
+        assert results["fail"].status == PhaseStatus.FAILED
+        assert "intentional failure" in results["fail"].error
+        assert results["also_ok"].status == PhaseStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_parallel_context_propagation(self):
+        """Results from parallel phases should all be available to downstream phases."""
+        downstream_ctx = {}
+
+        async def downstream_invoke(text, ctx):
+            downstream_ctx.update(ctx)
+            return "downstream_done"
+
+        registry = CapabilityRegistry()
+        for cap in ["cap_a", "cap_b"]:
+            registry.register(
+                name=f"comp_{cap}",
+                component_type=ComponentType.AGENT,
+                capabilities=[cap],
+                invoke=_make_slow_invoke(0.05, f"out_{cap}"),
+            )
+        registry.register(
+            name="comp_downstream",
+            component_type=ComponentType.AGENT,
+            capabilities=["cap_downstream"],
+            invoke=downstream_invoke,
+        )
+
+        workflow = (
+            WorkflowBuilder("ctx_prop")
+            .add_phase("a", capability="cap_a")
+            .add_phase("b", capability="cap_b")
+            .add_phase("downstream", capability="cap_downstream", depends_on=["a", "b"])
+            .build()
+        )
+
+        executor = WorkflowExecutor(registry)
+        results = await executor.execute(workflow, "input")
+
+        assert results["downstream"].status == PhaseStatus.COMPLETED
+        assert "phase_a_output" in downstream_ctx
+        assert "phase_b_output" in downstream_ctx
+        assert downstream_ctx["phase_a_output"] == "out_cap_a"
+        assert downstream_ctx["phase_b_output"] == "out_cap_b"
+
+    @pytest.mark.asyncio
+    async def test_parallel_with_optional_skipped(self):
+        """Skipped optional phases in parallel don't block other phases."""
+        registry = CapabilityRegistry()
+        registry.register(
+            name="comp_present",
+            component_type=ComponentType.AGENT,
+            capabilities=["cap_present"],
+            invoke=_make_slow_invoke(0.1, "out_present"),
+        )
+
+        workflow = (
+            WorkflowBuilder("opt_skip")
+            .add_phase("present", capability="cap_present")
+            .add_phase("missing", capability="cap_missing", optional=True)
+            .build()
+        )
+
+        executor = WorkflowExecutor(registry)
+        start = time.time()
+        results = await executor.execute(workflow, "input")
+        elapsed = time.time() - start
+
+        assert results["present"].status == PhaseStatus.COMPLETED
+        assert results["missing"].status == PhaseStatus.SKIPPED
+        assert elapsed < 0.25, f"Should complete quickly, got {elapsed:.2f}s"
+
+    @pytest.mark.asyncio
+    async def test_state_writers_called_for_parallel_phases(self):
+        """State writers should be called for each completed parallel phase."""
+        registry = CapabilityRegistry()
+        writer_calls = []
+
+        for cap in ["cap_a", "cap_b"]:
+            registry.register(
+                name=f"comp_{cap}",
+                component_type=ComponentType.AGENT,
+                capabilities=[cap],
+                invoke=_make_slow_invoke(0.05, f"out_{cap}"),
+            )
+
+        workflow = (
+            WorkflowBuilder("writers")
+            .add_phase("a", capability="cap_a")
+            .add_phase("b", capability="cap_b")
+            .build()
+        )
+
+        state = MagicMock()
+
+        def writer_a(output, st, ctx):
+            writer_calls.append(("a", output))
+
+        def writer_b(output, st, ctx):
+            writer_calls.append(("b", output))
+
+        state_writers = {"cap_a": writer_a, "cap_b": writer_b}
+
+        executor = WorkflowExecutor(registry)
+        results = await executor.execute(
+            workflow, "input", state=state, state_writers=state_writers
+        )
+
+        assert results["a"].status == PhaseStatus.COMPLETED
+        assert results["b"].status == PhaseStatus.COMPLETED
+        assert len(writer_calls) == 2
+        assert ("a", "out_cap_a") in writer_calls
+        assert ("b", "out_cap_b") in writer_calls


### PR DESCRIPTION
## Summary

Implements L1 DAG parallelism for the spectacular analysis workflow, targeting a **37% wall-clock reduction** (80s → ~50s) as identified in the profiling report from #422.

**Core change**: Refactor `WorkflowExecutor.execute()` to run independent phases at the same DAG level concurrently via `asyncio.gather()`, instead of iterating them sequentially.

### What changed

- **`workflow_dsl.py`** — Extracted `_execute_phase()` coroutine and `_store_phase_result()` helper from the main execution loop. Each DAG level now dispatches all its phases via `asyncio.gather()`.
- **`test_parallel_execution.py`** — 7 new test cases:
  1. Parallel phases complete faster than sequential (timing assertion)
  2. Diamond DAG parallelism (B+C concurrent after A, before D)
  3. Dependency ordering preserved (strict event ordering)
  4. Mixed success/failure at same level (failure isolation)
  5. Context propagation to downstream phases
  6. Optional skipped phases don't block others
  7. State writers called for all parallel phases

### Performance impact (from profiling report)

| Level | Phases (sequential) | Parallel speedup |
|-------|---------------------|------------------|
| L1 | quality + nl_to_logic + neural_detect + hierarchical_fallacy (34s) | 34s → ~11s |
| L2 | fol + pl + modal (7.5s) | no change (fol dominates) |
| L6 | jtms + debate (5.3s) | no change (debate dominates) |

**Theoretical total**: 80s → ~50s (-37%)

### Test plan

- [x] 7/7 new parallel execution tests pass
- [x] 31/31 workflow tests pass (24 existing + 7 new, no regressions)
- [x] 11/11 profiling report tests pass
- [x] `black` formatted
- [ ] CI green (lint + tests)

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)