### PR TITLE
fix(logic): FOL signature pre-declaration with extended regex + per-formula retry (#434)

### DIFF
--- a/argumentation_analysis/agents/core/logic/fol_logic_agent.py
+++ b/argumentation_analysis/agents/core/logic/fol_logic_agent.py
@@ -523,6 +523,10 @@ RÉPONDS EN FORMAT JSON :
         required by Tweety's FolParser — without it, unknown constants cause
         parse failures (#348).
 
+        Handles accented characters (e.g. estPrésident), numeric constants
+        (e.g. arg1), and function symbols (e.g. f(x)) in addition to the
+        standard CamelCase predicate patterns.
+
         Returns:
             Dict with keys: sorts (Dict[str, List[str]]), predicates (Dict[str, int]),
             constants (set), signature_lines (List[str]).
@@ -533,15 +537,16 @@ RÉPONDS EN FORMAT JSON :
         constants: Set[str] = set()
         variables: Set[str] = set()
 
-        # Note: this regex assumes flat predicate applications with simple
-        # argument lists. Nested predicates like P(Q(x), y) and operators
-        # inside argument lists are not supported (review #375).
+        # Extended regex: handle accented chars, digits, and underscores in names.
+        # Matches both predicate (CamelCase) and function (lowercase) applications.
+        # Examples: EstHomme(x), est_president(x, y), P1(a, b), asserte(c1)
         for formula in formulas:
-            for match in re.finditer(r"([A-Z][A-Za-z_]*)\(([^)]+)\)", formula):
+            for match in re.finditer(
+                r"([A-Za-z_À-ÖØ-öø-ÿ][A-Za-z0-9_À-ÖØ-öø-ÿ]*)\(([^)]+)\)", formula
+            ):
                 pred_name = match.group(1)
                 args_str = match.group(2)
                 args = [a.strip() for a in args_str.split(",")]
-                # Filter empty args (malformed input like P(, x)).
                 args = [a for a in args if a]
                 arity = len(args)
                 if not arity:
@@ -549,23 +554,63 @@ RÉPONDS EN FORMAT JSON :
                 if pred_name not in predicates or predicates[pred_name] < arity:
                     predicates[pred_name] = arity
                 for arg in args:
+                    # Variable: starts with uppercase letter (X, Y, Z)
+                    # Constant: starts with lowercase or digit (socrates, c1, 42)
                     if arg[0].isupper():
                         variables.add(arg)
                     else:
                         constants.add(arg)
 
+        # Also scan for standalone lowercase identifiers not inside predicates
+        # (e.g. in "forall X: (Est(X) => Mortel(X))", there are no standalone constants,
+        #  but in "socrates && platon", socrates/platon are constants)
+        for formula in formulas:
+            # Remove already-recognized predicate applications to avoid false positives
+            stripped = re.sub(
+                r"[A-Za-z_À-ÖØ-öø-ÿ][A-Za-z0-9_À-ÖØ-öø-ÿ]*\([^)]*\)", "", formula
+            )
+            for match in re.finditer(r"\b([a-z_À-öø-ÿ][a-z0-9_À-öø-ÿ]*)\b", stripped):
+                word = match.group(1)
+                if word not in (
+                    "forall",
+                    "exists",
+                    "and",
+                    "or",
+                    "not",
+                    "true",
+                    "false",
+                ):
+                    constants.add(word)
+
+        # Sanitize constants: Tweety identifiers must be alphanumeric ASCII + underscore
+        # Replace accented characters with ASCII equivalents for Tweety compatibility
+        sanitized_constants = set()
+        for c in constants:
+            sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", c)
+            if sanitized and not sanitized[0].isdigit():
+                sanitized_constants.add(sanitized)
+            else:
+                sanitized_constants.add(f"c_{sanitized}")
+
         # Build sort declarations from constants
-        # Default sort "thing" collects all lowercase constants
-        sorts: Dict[str, List[str]] = {"thing": sorted(constants)}
-        signature_lines = [f"thing = {{{', '.join(sorted(constants))}}}"]
-        for pred_name, arity in sorted(predicates.items()):
+        sorted_consts = sorted(sanitized_constants)
+        sorts: Dict[str, List[str]] = {"thing": sorted_consts}
+        signature_lines = [f"thing = {{{', '.join(sorted_consts)}}}"]
+        # Sanitize predicate names in signature for Tweety compatibility
+        sanitized_predicates: Dict[str, int] = {}
+        for pred_name, arity in predicates.items():
+            safe_name = re.sub(r"[^a-zA-Z0-9_]", "_", pred_name)
+            if safe_name and not safe_name[0].isdigit():
+                sanitized_predicates[safe_name] = arity
+            else:
+                sanitized_predicates[f"pred_{safe_name}"] = arity
             sort_args = ", ".join(["thing"] * arity)
-            signature_lines.append(f"type({pred_name}({sort_args}))")
+            signature_lines.append(f"type({safe_name}({sort_args}))")
 
         return {
             "sorts": sorts,
-            "predicates": predicates,
-            "constants": constants,
+            "predicates": sanitized_predicates,
+            "constants": sanitized_constants,
             "variables": variables,
             "signature_lines": signature_lines,
         }

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3227,15 +3227,51 @@ async def _invoke_fol_reasoning(
             "logic_type": "first_order",
             "argument_count": len(args),
         }
-    except Exception:
-        # Fallback: check for contradiction in generated formulas
+    except Exception as tweety_err:
+        logger.warning(
+            f"FOL Tweety parse failed ({tweety_err}). "
+            f"Attempting per-formula isolation with {len(formulas)} formulas."
+        )
+        # Retry: isolate valid formulas by parsing each individually.
+        # This handles the case where one bad formula causes the entire
+        # batch to fail in Tweety's parser.
+        valid_formulas = []
+        for formula in formulas:
+            try:
+                single_meta = FOLLogicAgent.extract_fol_metadata([formula])
+                single_sig = single_meta.get("signature_lines", [])
+                single_bs = "\n".join(str(f) for f in single_sig + [""] + [formula])
+                await asyncio.to_thread(
+                    bridge.check_consistency, single_bs, "first_order"
+                )
+                valid_formulas.append(formula)
+            except Exception:
+                logger.debug(f"FOL formula rejected by Tweety: {formula}")
+
+        if valid_formulas:
+            meta = FOLLogicAgent.extract_fol_metadata(valid_formulas)
+            fol_signature = meta.get("signature_lines", [])
+            logger.info(
+                f"FOL per-formula isolation: {len(valid_formulas)}/{len(formulas)} "
+                f"formulas accepted by Tweety"
+            )
+            return {
+                "formulas": valid_formulas,
+                "fol_signature": fol_signature,
+                "fol_metadata": meta,
+                "consistent": True,
+                "inferences": inferences,
+                "confidence": 0.6,
+                "logic_type": "first_order",
+                "argument_count": len(args),
+                "isolation_retry": True,
+                "rejected_count": len(formulas) - len(valid_formulas),
+            }
+
+        # All formulas failed — use Python fallback
         has_fallacious = any("Fallacious" in f for f in formulas)
-        # Still extract signature metadata even in fallback (#348)
         fol_signature = []
         try:
-            from argumentation_analysis.agents.core.logic.fol_logic_agent import (
-                FOLLogicAgent,
-            )
 
             meta = FOLLogicAgent.extract_fol_metadata(formulas)
             fol_signature = meta.get("signature_lines", [])
@@ -3250,6 +3286,7 @@ async def _invoke_fol_reasoning(
             "logic_type": "first_order",
             "argument_count": len(args),
             "fallback": "python",
+            "diagnostic": str(tweety_err),
         }
 
 

--- a/tests/unit/argumentation_analysis/agents/test_fol_signature_extraction.py
+++ b/tests/unit/argumentation_analysis/agents/test_fol_signature_extraction.py
@@ -1,0 +1,117 @@
+"""Tests for FOL signature extraction with extended symbol support.
+
+Validates extract_fol_metadata handles accented characters, numeric constants,
+function symbols, and edge cases. Also tests per-formula isolation retry logic
+in the FOL invoke callable.
+"""
+
+import pytest
+
+from argumentation_analysis.agents.core.logic.fol_logic_agent import FOLLogicAgent
+
+
+class TestExtractFolMetadataExtended:
+    """Test extract_fol_metadata with extended regex patterns."""
+
+    def test_standard_predicates(self):
+        """Standard CamelCase predicates with lowercase constants."""
+        formulas = ["Mortal(socrates)", "Human(plato)"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+
+        assert "Mortal" in meta["predicates"]
+        assert "Human" in meta["predicates"]
+        assert meta["predicates"]["Mortal"] == 1
+        assert "socrates" in meta["constants"]
+        assert "plato" in meta["constants"]
+
+    def test_accented_constants(self):
+        """Accented characters in predicate/constant names are sanitized for Tweety."""
+        formulas = ["EstPrésident(macron)"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+
+        # Predicate name sanitized: EstPrésident -> EstPr_sident
+        assert "EstPr_sident" in meta["predicates"]
+        # Constant sanitized: macron (no accent, stays as-is)
+        assert "macron" in meta["constants"]
+
+    def test_numeric_constant_suffixes(self):
+        """Numeric suffixes in constants (arg1, fallacy2) should be captured."""
+        formulas = ["Asserted(arg1)", "Undermines(fallacy2, arg3)"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+
+        assert "Asserted" in meta["predicates"]
+        assert "Undermines" in meta["predicates"]
+        assert meta["predicates"]["Undermines"] == 2
+        assert "arg1" in meta["constants"]
+        assert "fallacy2" in meta["constants"]
+        assert "arg3" in meta["constants"]
+
+    def test_multiple_arities(self):
+        """Same predicate with different arities — should keep max arity."""
+        formulas = ["P(a)", "P(a, b)", "P(x, y, z)"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+
+        assert meta["predicates"]["P"] == 3
+
+    def test_variables_detected(self):
+        """Uppercase identifiers in args should be classified as variables."""
+        formulas = ["forall X: (Human(X) => Mortal(X))"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+
+        assert "X" in meta["variables"]
+        assert "Human" in meta["predicates"]
+        assert "Mortal" in meta["predicates"]
+
+    def test_signature_lines_format(self):
+        """Signature lines should follow Tweety BNF format."""
+        formulas = ["P(a)", "Q(a, b)"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+        sig = meta["signature_lines"]
+
+        # Sort declaration: thing = {a, b}
+        assert any("thing" in line and "a" in line and "b" in line for line in sig)
+        # Type declarations
+        assert any("type(P(thing))" in line for line in sig)
+        assert any("type(Q(thing, thing))" in line for line in sig)
+
+    def test_empty_formulas(self):
+        """Empty formula list should return empty metadata."""
+        meta = FOLLogicAgent.extract_fol_metadata([])
+
+        assert meta["predicates"] == {}
+        assert meta["constants"] == set()
+        assert meta["variables"] == set()
+        assert meta["signature_lines"] == ["thing = {}"]
+
+    def test_quantified_formula_with_implication(self):
+        """Complex formula with forall, =>, and multiple predicates."""
+        formulas = ["forall X: (Fallacious(X) => !FullySupported(X))"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+
+        assert "Fallacious" in meta["predicates"]
+        assert "FullySupported" in meta["predicates"]
+        assert "X" in meta["variables"]
+        assert len(meta["constants"]) == 0  # No lowercase args
+
+    def test_mixed_formulas_batch(self):
+        """Batch of diverse formulas — all symbols extracted correctly."""
+        formulas = [
+            "Asserted(arg1)",
+            "Undermines(fallacy1, arg1)",
+            "Fallacious(arg1)",
+            "forall X: (Fallacious(X) => !FullySupported(X))",
+        ]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+
+        assert len(meta["predicates"]) >= 4
+        assert "arg1" in meta["constants"]
+        assert "fallacy1" in meta["constants"]
+        assert "X" in meta["variables"]
+
+    def test_predicate_with_underscore(self):
+        """Predicates and constants with underscores should be captured."""
+        formulas = ["is_valid(test_case)"]
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+
+        assert "is_valid" in meta["predicates"]
+        assert "test_case" in meta["constants"]


### PR DESCRIPTION
## Summary

Fixes the "1 formula only" bottleneck in the FOL phase. The root cause was Tweety's FolParser rejecting formulas containing accented characters, numeric constants, or undeclared symbols — causing a silent fallback to template-based generation.

### What changed

**1. Extended regex in `extract_fol_metadata`** (`fol_logic_agent.py`)

The original regex `([A-Z][A-Za-z_]*)\(([^)]+)\)` only matched ASCII CamelCase predicates. The new regex handles:
- Accented characters: `EstPrésident(macron)` → predicate `EstPr_sident`, constant `macron`
- Numeric suffixes: `Asserted(arg1)`, `Undermines(fallacy2, arg3)`
- Underscored identifiers: `is_valid(test_case)`
- Both predicate names and constant names are sanitized to ASCII-safe identifiers

**2. Per-formula isolation retry in `_invoke_fol_reasoning`** (`invoke_callables.py`)

When Tweety rejects the full formula batch, the code now:
1. Parses each formula individually with its own extracted signature
2. Collects the valid ones ( Tweety-accepted)
3. Returns the valid subset instead of falling back to templates
4. Logs diagnostic info about rejected formulas

**3. 10 new tests** (`test_fol_signature_extraction.py`)

Covering: standard predicates, accented chars, numeric suffixes, multiple arities, variables, empty formulas, quantified formulas, mixed batches, underscores, and sanitization.

### Test plan

- [x] 10/10 new signature extraction tests pass
- [x] 3/3 existing FOL agent tests pass
- [x] 31/31 workflow tests pass (no regressions)
- [x] `black` formatted
- [ ] CI green (lint + tests)

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)