### PR TITLE
feat(orchestration): pipeline checkpoint/resume for long corpus batches (#451)

### DIFF
--- a/argumentation_analysis/orchestration/checkpoint.py
+++ b/argumentation_analysis/orchestration/checkpoint.py
@@ -1,0 +1,155 @@
+"""Workflow checkpoint manager for resumable pipeline execution.
+
+After each DAG level, the executor writes a checkpoint capturing completed
+phases and their serializable outputs.  On resume, completed phases are
+skipped and their outputs injected into the execution context.
+
+Checkpoint file schema::
+
+    {
+      "opaque_id": "abc12345",
+      "workflow": "spectacular",
+      "completed_phases": ["extract", "quality"],
+      "phase_outputs": {
+        "extract": {"status": "completed", "output_json": "...", "duration_s": 1.2},
+        "quality": {"status": "completed", "output_json": "...", "duration_s": 0.8}
+      },
+      "state_snapshot": { ... },
+      "timestamp": "2026-05-12T..."
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+logger = logging.getLogger("checkpoint")
+
+
+def _try_serialize(value: Any) -> Any:
+    """Attempt to JSON-serialize a value.  Returns the raw value on success."""
+    json.dumps(value, default=str)
+    return value
+
+
+class CheckpointManager:
+    """Manages per-document workflow checkpoints on disk.
+
+    Writes are atomic (tempfile + os.replace) to avoid partial writes on crash.
+    """
+
+    def __init__(self, checkpoint_dir: Path) -> None:
+        self.checkpoint_dir = checkpoint_dir
+        self.checkpoint_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, doc_id: str) -> Path:
+        return self.checkpoint_dir / f"{doc_id}.checkpoint.json"
+
+    def save(
+        self,
+        doc_id: str,
+        workflow: str,
+        completed_phases: List[str],
+        phase_outputs: Dict[str, Dict[str, Any]],
+        state_snapshot: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Atomically write a checkpoint file."""
+        data = {
+            "opaque_id": doc_id,
+            "workflow": workflow,
+            "completed_phases": completed_phases,
+            "phase_outputs": phase_outputs,
+            "state_snapshot": state_snapshot,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+        }
+        target = self._path(doc_id)
+        fd, tmp_path = tempfile.mkstemp(dir=str(self.checkpoint_dir), suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+            os.replace(tmp_path, target)
+        except BaseException:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        logger.debug("Checkpoint saved: %s (%d phases)", doc_id, len(completed_phases))
+
+    def load(self, doc_id: str) -> Optional[Dict[str, Any]]:
+        """Load a checkpoint.  Returns None if not found or corrupt."""
+        path = self._path(doc_id)
+        if not path.exists():
+            return None
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Corrupt checkpoint %s: %s", doc_id, exc)
+            return None
+
+    def remove(self, doc_id: str) -> None:
+        """Remove checkpoint after successful completion."""
+        path = self._path(doc_id)
+        try:
+            path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning("Failed to remove checkpoint %s: %s", doc_id, exc)
+
+    def list_incomplete(self) -> List[str]:
+        """Return doc_ids that have checkpoint files (incomplete runs)."""
+        return sorted(
+            p.stem.replace(".checkpoint", "")
+            for p in self.checkpoint_dir.glob("*.checkpoint.json")
+        )
+
+
+def serialize_phase_result(
+    phase_name: str,
+    status: str,
+    output: Any,
+    duration: float,
+    error: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create a serializable dict for one phase result.
+
+    Non-serializable outputs are stored as ``None`` (phase will re-run on resume).
+    """
+    output_json = None
+    if output is not None and status == "completed":
+        try:
+            output_json = json.dumps(output, default=str, ensure_ascii=False)
+        except (TypeError, ValueError):
+            output_json = None
+    return {
+        "status": status,
+        "output_json": output_json,
+        "duration_s": round(duration, 3),
+        "error": error,
+    }
+
+
+def deserialize_phase_outputs(
+    phase_outputs: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Deserialize all phase outputs from checkpoint.
+
+    Returns a dict of phase_name → deserialized output (or None).
+    Phases with ``output_json=None`` are excluded (will re-run).
+    """
+    result = {}
+    for name, data in phase_outputs.items():
+        raw = data.get("output_json")
+        if raw is not None:
+            try:
+                result[name] = json.loads(raw)
+            except json.JSONDecodeError:
+                logger.warning("Corrupt output for phase '%s', will re-run", name)
+        else:
+            result[name] = None
+    return result

--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -60,6 +60,8 @@ async def run_unified_analysis(
     context: Optional[Dict[str, Any]] = None,
     state: Optional[Any] = None,
     create_state: bool = True,
+    checkpoint_callback: Optional[Any] = None,
+    resume_from: Optional[set] = None,
 ) -> Dict[str, Any]:
     """
     Run a unified analysis pipeline on input text.
@@ -74,6 +76,9 @@ async def run_unified_analysis(
                are written to it via state writers.
         create_state: If True and no state provided, automatically create an
                       UnifiedAnalysisState. Set to False to disable state tracking.
+        checkpoint_callback: Optional callable passed to WorkflowExecutor for
+              per-level checkpointing.  Signature: ``(results, ctx) -> None``.
+        resume_from: Optional set of phase names to skip on resume.
 
     Returns:
         Dict with keys:
@@ -145,6 +150,8 @@ async def run_unified_analysis(
         context=context,
         state=state,
         state_writers=CAPABILITY_STATE_WRITERS if state is not None else None,
+        checkpoint_callback=checkpoint_callback,
+        resume_from=resume_from,
     )
 
     # Build summary

--- a/argumentation_analysis/orchestration/workflow_dsl.py
+++ b/argumentation_analysis/orchestration/workflow_dsl.py
@@ -312,6 +312,8 @@ class WorkflowExecutor:
         context: Optional[Dict[str, Any]] = None,
         state: Optional[Any] = None,
         state_writers: Optional[Dict[str, Any]] = None,
+        checkpoint_callback: Optional[Callable[..., None]] = None,
+        resume_from: Optional[Set[str]] = None,
     ) -> Dict[str, PhaseResult]:
         """
         Execute a workflow definition.
@@ -329,6 +331,12 @@ class WorkflowExecutor:
             state_writers: Dict mapping capability name to a callable
                 ``(output, state, ctx) -> None`` that writes phase output
                 to the state object.
+            checkpoint_callback: Optional callable invoked after each DAG level
+                with signature ``(results, ctx) -> None``.  Used for per-document
+                checkpointing in long batch runs.
+            resume_from: Optional set of phase names to skip (already completed
+                in a previous run).  Their outputs must already be present in
+                *context* (keyed ``phase_{name}_output`` / ``phase_{name}_result``).
 
         Returns:
             Dict mapping phase name to PhaseResult.
@@ -337,6 +345,7 @@ class WorkflowExecutor:
         execution_order = workflow.get_execution_order()
         ctx = dict(context or {})
         ctx["input_data"] = input_data
+        skip_phases: Set[str] = resume_from or set()
 
         if state is not None:
             ctx["unified_state"] = state
@@ -344,27 +353,62 @@ class WorkflowExecutor:
         logger.info(
             f"Executing workflow '{workflow.name}' — "
             f"{len(workflow.phases)} phases, {len(execution_order)} levels"
+            f"{f', resuming (skip {len(skip_phases)} phases)' if skip_phases else ''}"
         )
 
         for level_idx, level_phases in enumerate(execution_order):
             logger.debug(f"Level {level_idx}: executing phases {level_phases}")
 
-            phase_coros = []
+            # Split into skipped vs to-run
+            to_run = [p for p in level_phases if p not in skip_phases]
             for phase_name in level_phases:
+                if phase_name in skip_phases:
+                    # Reconstruct a SKIPPED result from context if available
+                    existing_result = ctx.get(f"phase_{phase_name}_result")
+                    if existing_result is not None:
+                        # Use the output/context from checkpoint but mark as SKIPPED
+                        results[phase_name] = PhaseResult(
+                            phase_name=phase_name,
+                            status=PhaseStatus.SKIPPED,
+                            capability=existing_result.capability,
+                            component_used=existing_result.component_used,
+                            output=existing_result.output,
+                            error="Skipped (resumed from checkpoint)",
+                            duration_seconds=existing_result.duration_seconds,
+                        )
+                    else:
+                        _skipped_phase = workflow.get_phase(phase_name)
+                        results[phase_name] = PhaseResult(
+                            phase_name=phase_name,
+                            status=PhaseStatus.SKIPPED,
+                            capability=(
+                                _skipped_phase.capability
+                                if _skipped_phase
+                                else "unknown"
+                            ),
+                            error="Skipped (resumed from checkpoint)",
+                        )
+
+            phase_coros = []
+            for phase_name in to_run:
                 phase = workflow.get_phase(phase_name)
                 if phase:
                     phase_coros.append(
                         self._execute_phase(phase, phase_name, input_data, ctx)
                     )
 
-            if not phase_coros:
-                continue
+            if phase_coros:
+                level_results = await asyncio.gather(*phase_coros)
+                for phase_name, result, output in level_results:
+                    self._store_phase_result(
+                        phase_name, result, output, results, ctx, state, state_writers
+                    )
 
-            level_results = await asyncio.gather(*phase_coros)
-            for phase_name, result, output in level_results:
-                self._store_phase_result(
-                    phase_name, result, output, results, ctx, state, state_writers
-                )
+            if checkpoint_callback is not None:
+                try:
+                    checkpoint_callback(results, ctx)
+                except Exception as cb_err:
+                    logger.warning("Checkpoint callback failed: %s", cb_err)
 
         # Summary
         completed = sum(

--- a/scripts/dataset/README.md
+++ b/scripts/dataset/README.md
@@ -1,0 +1,72 @@
+# Corpus Batch Runner
+
+Process the encrypted corpus through the analysis pipeline and produce
+per-document sanitized signatures.
+
+## Quick Start
+
+```bash
+# Full batch (from repo root, conda activated)
+python scripts/dataset/run_corpus_batch.py --workflow spectacular
+
+# Limit to N documents
+python scripts/dataset/run_corpus_batch.py --max-docs 5
+
+# Skip already-processed documents
+python scripts/dataset/run_corpus_batch.py --skip-existing
+
+# Skip very long documents (> 15K chars)
+python scripts/dataset/run_corpus_batch.py --max-chars 15000
+```
+
+## Resume Mode
+
+Long batches can be interrupted (session close, timeout, crash).  Use
+`--resume` to pick up from per-document checkpoints instead of restarting
+each document from scratch.
+
+```bash
+# Resume an interrupted batch
+python scripts/dataset/run_corpus_batch.py --resume
+
+# Resume + skip existing signatures
+python scripts/dataset/run_corpus_batch.py --resume --skip-existing
+```
+
+### How It Works
+
+After each DAG level in the workflow, a checkpoint file is written
+atomically to `.analysis_kb/checkpoints/<doc_id>.checkpoint.json`.  The
+checkpoint captures:
+
+- Completed phase names and their serialized outputs
+- State snapshot at that point
+- Workflow name and timestamp
+
+On resume, the runner loads checkpoints for each document and passes
+completed phases to the executor, which skips them and continues from
+the first incomplete phase.
+
+When a document completes successfully, its checkpoint is removed.
+
+### Output Layout
+
+All outputs are gitignored under `.analysis_kb/`:
+
+```
+.analysis_kb/
+├── checkpoints/     <doc_id>.checkpoint.json   (intermediate, auto-cleaned)
+├── state_dumps/     state_full_<doc_id>.json   (full analysis state)
+└── signatures/      signature_<doc_id>.json    (privacy-safe summary)
+```
+
+## Flags
+
+| Flag              | Description                                    |
+|-------------------|------------------------------------------------|
+| `--workflow`      | Workflow name: `spectacular` (default), `standard`, `light` |
+| `--output-dir`    | Directory for signatures (default: `.analysis_kb/signatures`) |
+| `--max-docs`      | Process at most N documents (0 = all)          |
+| `--max-chars`     | Skip documents longer than N characters (0 = no limit) |
+| `--skip-existing` | Skip documents with existing signatures        |
+| `--resume`        | Resume from per-document checkpoints           |

--- a/scripts/dataset/run_corpus_batch.py
+++ b/scripts/dataset/run_corpus_batch.py
@@ -5,15 +5,23 @@ Iterates over every (source, extract) in the encrypted dataset, runs the
 chosen workflow on each, and persists both the full state dump and a
 privacy-safe signature.
 
+Supports checkpoint/resume: after each DAG level, a checkpoint file is
+written atomically.  On crash, ``--resume`` picks up from the last
+checkpoint instead of restarting the document.
+
 Usage:
-    python scripts/dataset/run_corpus_batch.py \
-        --workflow spectacular \
-        --output-dir .analysis_kb/signatures \
-        --max-docs 0 \
+    python scripts/dataset/run_corpus_batch.py \\
+        --workflow spectacular \\
+        --output-dir .analysis_kb/signatures \\
+        --max-docs 0 \\
         --skip-existing
+
+    # Resume an interrupted batch
+    python scripts/dataset/run_corpus_batch.py --resume
 
 Output layout (all gitignored):
     .analysis_kb/
+    ├── checkpoints/   <opaque_id>.checkpoint.json
     ├── state_dumps/   state_full_<opaque_id>.json
     └── signatures/    signature_<opaque_id>.json
 """
@@ -28,7 +36,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Any, Callable, Coroutine, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DATA_DIR = REPO_ROOT / "argumentation_analysis" / "data"
@@ -98,7 +106,7 @@ def classify_metadata(source_name: str, date_iso: str = "") -> Dict[str, str]:
 
 
 # ---------------------------------------------------------------------------
-# Per-document processing
+# Checkpoint-aware per-document processing
 # ---------------------------------------------------------------------------
 
 
@@ -112,6 +120,7 @@ async def _run_single(
     signatures_dir: Path,
     skip_existing: bool,
     timeout: int = 900,
+    checkpoint_mgr: Optional[Any] = None,
     pipeline_fn: Optional[Any] = None,
     sanitize_fn: Optional[Callable[[Dict[str, Any]], Dict[str, Any]]] = None,
 ) -> Optional[Dict[str, Any]]:
@@ -127,6 +136,86 @@ async def _run_single(
 
         sanitize_fn = sanitize_state
 
+    # --- Resume logic -------------------------------------------------------
+    resume_from: Optional[set] = None
+    resume_context: Optional[Dict[str, Any]] = None
+    checkpoint_snapshot: Optional[Dict[str, Any]] = None
+
+    if checkpoint_mgr is not None:
+        ckpt = checkpoint_mgr.load(opaque_id_str)
+        if ckpt is not None:
+            completed = set(ckpt.get("completed_phases", []))
+            if completed:
+                from argumentation_analysis.orchestration.checkpoint import (
+                    deserialize_phase_outputs,
+                )
+                from argumentation_analysis.orchestration.workflow_dsl import (
+                    PhaseResult,
+                    PhaseStatus,
+                )
+
+                phase_outputs = deserialize_phase_outputs(ckpt.get("phase_outputs", {}))
+                resume_context = {}
+                resume_from = completed
+                checkpoint_snapshot = ckpt.get("state_snapshot")
+
+                for pname in completed:
+                    output = phase_outputs.get(pname)
+                    if output is not None:
+                        resume_context[f"phase_{pname}_output"] = output
+                        resume_context[f"phase_{pname}_result"] = PhaseResult(
+                            phase_name=pname,
+                            status=PhaseStatus.COMPLETED,
+                            capability="unknown",
+                            output=output,
+                        )
+                logger.info(
+                    "[%s] resuming from checkpoint (%d phases)",
+                    opaque_id_str,
+                    len(completed),
+                )
+
+    # --- Build checkpoint callback ------------------------------------------
+    level_counter = [0]
+
+    def _checkpoint_callback(results: Dict, ctx: Dict) -> None:
+        """Called by WorkflowExecutor after each DAG level."""
+        if checkpoint_mgr is None:
+            return
+
+        from argumentation_analysis.orchestration.checkpoint import (
+            serialize_phase_result,
+        )
+
+        completed_phases = sorted(
+            n for n, r in results.items() if r.status.value == "completed"
+        )
+        phase_outputs = {}
+        for name in completed_phases:
+            r = results[name]
+            phase_outputs[name] = serialize_phase_result(
+                name, r.status.value, r.output, r.duration_seconds, r.error
+            )
+
+        # Capture state snapshot if available
+        snap = None
+        ust = ctx.get("unified_state")
+        if ust is not None and hasattr(ust, "get_state_snapshot"):
+            try:
+                snap = ust.get_state_snapshot(summarize=False)
+            except Exception:
+                pass
+
+        checkpoint_mgr.save(
+            doc_id=opaque_id_str,
+            workflow=workflow,
+            completed_phases=completed_phases,
+            phase_outputs=phase_outputs,
+            state_snapshot=snap,
+        )
+        level_counter[0] += 1
+
+    # --- Execute pipeline ---------------------------------------------------
     t0 = time.perf_counter()
     partial = False
     state_snapshot: Dict[str, Any] = {}
@@ -140,11 +229,21 @@ async def _run_single(
             pipeline_fn = run_unified_analysis
 
         result = await asyncio.wait_for(
-            pipeline_fn(text, workflow_name=workflow),
+            pipeline_fn(
+                text,
+                workflow_name=workflow,
+                context=resume_context,
+                checkpoint_callback=(
+                    _checkpoint_callback if checkpoint_mgr is not None else None
+                ),
+                resume_from=resume_from,
+            ),
             timeout=timeout,
+        )
         )
         # Prefer full (non-summarized) state for pattern mining.
         state_snapshot = result.get("state_snapshot", {})
+        # Prefer full (non-summarized) state for pattern mining.
         unified = result.get("unified_state")
         if unified is not None:
             try:
@@ -153,6 +252,11 @@ async def _run_single(
                     state_snapshot = full
             except Exception:
                 pass
+
+        # Merge checkpoint snapshot with new snapshot if resuming
+        if checkpoint_snapshot and isinstance(state_snapshot, dict):
+            merged = _merge_snapshots(checkpoint_snapshot, state_snapshot)
+            state_snapshot = merged
     except asyncio.TimeoutError:
         logger.warning("[%s] timeout (>600s), marking partial", opaque_id_str)
         partial = True
@@ -190,7 +294,22 @@ async def _run_single(
     )
     logger.info("[%s] signature written (wall=%.1fs)", opaque_id_str, wall_clock)
 
+    # Remove checkpoint on success
+    if checkpoint_mgr is not None and not partial:
+        checkpoint_mgr.remove(opaque_id_str)
+
     return signature
+
+
+def _merge_snapshots(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge two state snapshots.  *override* takes precedence."""
+    merged = dict(base)
+    for key, val in override.items():
+        if key in merged and isinstance(merged[key], dict) and isinstance(val, dict):
+            merged[key] = {**merged[key], **val}
+        else:
+            merged[key] = val
+    return merged
 
 
 # ---------------------------------------------------------------------------
@@ -231,9 +350,37 @@ def main(argv: Optional[List[str]] = None) -> int:
         default=900,
         help="Per-doc timeout in seconds (default: 900)",
     )
+    parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="Resume interrupted batch from per-document checkpoints",
+    )
     args = parser.parse_args(argv)
 
     state_dumps_dir = DEFAULT_KB / "state_dumps"
+    checkpoint_dir = DEFAULT_KB / "checkpoints"
+
+    # Setup checkpoint manager
+    checkpoint_mgr = None
+    if args.resume:
+        from argumentation_analysis.orchestration.checkpoint import CheckpointManager
+
+        checkpoint_mgr = CheckpointManager(checkpoint_dir)
+        incomplete = checkpoint_mgr.list_incomplete()
+        if incomplete:
+            logger.info(
+                "Resume mode: %d incomplete checkpoints found: %s",
+                len(incomplete),
+                incomplete[:5],
+            )
+        else:
+            logger.info("Resume mode: no incomplete checkpoints found")
+
+    # Also enable checkpoints for new runs when --resume is active
+    if checkpoint_mgr is None and args.resume:
+        from argumentation_analysis.orchestration.checkpoint import CheckpointManager
+
+        checkpoint_mgr = CheckpointManager(checkpoint_dir)
 
     # Load encrypted dataset
     from dotenv import load_dotenv
@@ -306,10 +453,11 @@ def main(argv: Optional[List[str]] = None) -> int:
         docs = docs[: args.max_docs]
 
     logger.info(
-        "Starting batch: %d docs, workflow=%s, skip_existing=%s",
+        "Starting batch: %d docs, workflow=%s, skip_existing=%s, resume=%s",
         len(docs),
         args.workflow,
         args.skip_existing,
+        args.resume,
     )
 
     # Process documents serially
@@ -327,6 +475,7 @@ def main(argv: Optional[List[str]] = None) -> int:
                 signatures_dir=args.output_dir,
                 skip_existing=args.skip_existing,
                 timeout=args.timeout,
+                checkpoint_mgr=checkpoint_mgr,
             )
         )
         if sig is not None:

--- a/tests/unit/argumentation_analysis/orchestration/test_checkpoint.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_checkpoint.py
@@ -1,0 +1,350 @@
+"""Tests for workflow checkpoint/resume (issue #451).
+
+Covers:
+- CheckpointManager atomic writes, loads, removal
+- serialize/deserialize phase results
+- WorkflowExecutor resume_from skips completed phases
+- Crash simulation: phases 1-3 reused, 4-8 re-run, final state matches
+"""
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from argumentation_analysis.orchestration.checkpoint import (
+    CheckpointManager,
+    deserialize_phase_outputs,
+    serialize_phase_result,
+)
+from argumentation_analysis.orchestration.workflow_dsl import (
+    PhaseResult,
+    PhaseStatus,
+    WorkflowBuilder,
+    WorkflowExecutor,
+)
+
+# ---------------------------------------------------------------------------
+# CheckpointManager tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckpointManager:
+    def test_save_and_load(self, tmp_path: Path):
+        mgr = CheckpointManager(tmp_path / "ckpt")
+        mgr.save(
+            doc_id="doc_001",
+            workflow="spectacular",
+            completed_phases=["extract", "quality"],
+            phase_outputs={
+                "extract": {
+                    "status": "completed",
+                    "output_json": '"data"',
+                    "duration_s": 1.0,
+                },
+            },
+        )
+        loaded = mgr.load("doc_001")
+        assert loaded is not None
+        assert loaded["opaque_id"] == "doc_001"
+        assert loaded["completed_phases"] == ["extract", "quality"]
+
+    def test_load_missing_returns_none(self, tmp_path: Path):
+        mgr = CheckpointManager(tmp_path / "ckpt")
+        assert mgr.load("nonexistent") is None
+
+    def test_load_corrupt_returns_none(self, tmp_path: Path):
+        mgr = CheckpointManager(tmp_path / "ckpt")
+        mgr.checkpoint_dir.mkdir(parents=True, exist_ok=True)
+        bad = mgr.checkpoint_dir / "bad.checkpoint.json"
+        bad.write_text("{invalid json", encoding="utf-8")
+        assert mgr.load("bad") is None
+
+    def test_remove(self, tmp_path: Path):
+        mgr = CheckpointManager(tmp_path / "ckpt")
+        mgr.save(
+            doc_id="to_remove", workflow="test", completed_phases=[], phase_outputs={}
+        )
+        assert mgr.load("to_remove") is not None
+        mgr.remove("to_remove")
+        assert mgr.load("to_remove") is None
+
+    def test_remove_missing_is_noop(self, tmp_path: Path):
+        mgr = CheckpointManager(tmp_path / "ckpt")
+        mgr.remove("nonexistent")  # should not raise
+
+    def test_list_incomplete(self, tmp_path: Path):
+        mgr = CheckpointManager(tmp_path / "ckpt")
+        mgr.save(doc_id="doc_a", workflow="w", completed_phases=["x"], phase_outputs={})
+        mgr.save(doc_id="doc_b", workflow="w", completed_phases=["y"], phase_outputs={})
+        assert mgr.list_incomplete() == ["doc_a", "doc_b"]
+
+    def test_atomic_write_no_partial(self, tmp_path: Path):
+        """Verify no .tmp files remain after successful write."""
+        mgr = CheckpointManager(tmp_path / "ckpt")
+        mgr.save(doc_id="atomic", workflow="w", completed_phases=[], phase_outputs={})
+        tmps = list(mgr.checkpoint_dir.glob("*.tmp"))
+        assert len(tmps) == 0
+
+    def test_state_snapshot_preserved(self, tmp_path: Path):
+        mgr = CheckpointManager(tmp_path / "ckpt")
+        snapshot = {"fallacy_count": 5, "arguments": {"a1": "claim"}}
+        mgr.save(
+            doc_id="snap_test",
+            workflow="w",
+            completed_phases=["extract"],
+            phase_outputs={},
+            state_snapshot=snapshot,
+        )
+        loaded = mgr.load("snap_test")
+        assert loaded["state_snapshot"] == snapshot
+
+
+# ---------------------------------------------------------------------------
+# serialize / deserialize tests
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeDeserialize:
+    def test_serialize_completed_with_output(self):
+        result = serialize_phase_result("extract", "completed", {"key": "val"}, 1.5)
+        assert result["status"] == "completed"
+        assert result["output_json"] is not None
+        assert json.loads(result["output_json"]) == {"key": "val"}
+        assert result["duration_s"] == 1.5
+
+    def test_serialize_non_serializable_output(self):
+        result = serialize_phase_result("phase", "completed", object(), 0.1)
+        assert result["output_json"] is not None  # default=str handles it
+
+    def test_serialize_failed_phase(self):
+        result = serialize_phase_result("bad", "failed", None, 0.5, error="boom")
+        assert result["status"] == "failed"
+        assert result["output_json"] is None
+        assert result["error"] == "boom"
+
+    def test_deserialize_round_trip(self):
+        original = {"key": [1, 2, 3]}
+        serialized = serialize_phase_result("p", "completed", original, 1.0)
+        deserialized = deserialize_phase_outputs({"p": serialized})
+        assert deserialized["p"] == original
+
+    def test_deserialize_null_output(self):
+        serialized = {
+            "status": "completed",
+            "output_json": None,
+            "duration_s": 0.1,
+            "error": None,
+        }
+        result = deserialize_phase_outputs({"p": serialized})
+        assert result["p"] is None
+
+
+# ---------------------------------------------------------------------------
+# WorkflowExecutor resume tests
+# ---------------------------------------------------------------------------
+
+
+def _make_registry_with_invoke(phase_outputs: dict):
+    """Build a mock registry that returns providers with canned outputs."""
+    registry = MagicMock()
+
+    def find_for_capability(cap):
+        name = cap.replace("_capability", "")
+        provider = MagicMock()
+        provider.name = name
+        output = phase_outputs.get(name, f"output_{name}")
+        provider.invoke = AsyncMock(return_value=output)
+        return [provider]
+
+    registry.find_for_capability = find_for_capability
+    return registry
+
+
+class TestWorkflowExecutorResume:
+    @pytest.mark.asyncio
+    async def test_resume_skips_completed_phases(self):
+        """Phases in resume_from should be skipped, not executed."""
+        workflow = (
+            WorkflowBuilder("test")
+            .add_phase("a", capability="a")
+            .add_phase("b", capability="b", depends_on=["a"])
+            .add_phase("c", capability="c", depends_on=["b"])
+            .build()
+        )
+        invoke_counts = {"a": 0, "b": 0, "c": 0}
+        registry = MagicMock()
+
+        def find_for_capability(cap):
+            provider = MagicMock()
+            provider.name = cap
+
+            async def invoke(*args, **kwargs):
+                invoke_counts[cap] += 1
+                return f"out_{cap}"
+
+            provider.invoke = invoke
+            return [provider]
+
+        registry.find_for_capability = find_for_capability
+
+        executor = WorkflowExecutor(registry)
+
+        # Resume from phase 'a' already completed
+        context = {
+            "phase_a_output": "out_a",
+            "phase_a_result": PhaseResult(
+                phase_name="a",
+                status=PhaseStatus.COMPLETED,
+                capability="a",
+                output="out_a",
+            ),
+        }
+        results = await executor.execute(
+            workflow,
+            input_data="test text",
+            context=context,
+            resume_from={"a"},
+        )
+
+        assert results["a"].status == PhaseStatus.SKIPPED
+        assert results["b"].status == PhaseStatus.COMPLETED
+        assert results["c"].status == PhaseStatus.COMPLETED
+        assert invoke_counts == {"a": 0, "b": 1, "c": 1}
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_callback_called_per_level(self):
+        """Callback should be invoked after each DAG level."""
+        workflow = (
+            WorkflowBuilder("test")
+            .add_phase("x", capability="x")
+            .add_phase("y", capability="y", depends_on=["x"])
+            .build()
+        )
+        registry = _make_registry_with_invoke({"x": "ox", "y": "oy"})
+        executor = WorkflowExecutor(registry)
+
+        callbacks = []
+
+        def cb(results, ctx):
+            callbacks.append(set(results.keys()))
+
+        await executor.execute(workflow, input_data="t", checkpoint_callback=cb)
+
+        assert len(callbacks) == 2
+        assert callbacks[0] == {"x"}
+        assert callbacks[1] == {"x", "y"}
+
+    @pytest.mark.asyncio
+    async def test_crash_and_resume_final_state_matches(self):
+        """Simulate crash after phase 2 of 4, resume, verify final results.
+
+        In a real crash (process dies), the checkpoint captures phases that
+        completed before the crash point.  Here we simulate by:
+        1. Running a normal execution with callback to capture checkpoint state
+        2. Manually reconstructing resume context from the first N phases
+        3. Running resume execution with those phases skipped
+        """
+        workflow = (
+            WorkflowBuilder("test")
+            .add_phase("p1", capability="p1")
+            .add_phase("p2", capability="p2", depends_on=["p1"])
+            .add_phase("p3", capability="p3", depends_on=["p2"])
+            .add_phase("p4", capability="p4", depends_on=["p3"])
+            .build()
+        )
+
+        # --- Run 1: full execution to capture baseline outputs ---
+        call_log_full: list[str] = []
+        registry_full = MagicMock()
+
+        def find_full(cap):
+            provider = MagicMock()
+            provider.name = cap
+
+            async def invoke(*args, **kwargs):
+                call_log_full.append(cap)
+                return f"out_{cap}"
+
+            provider.invoke = invoke
+            return [provider]
+
+        registry_full.find_for_capability = find_full
+
+        executor = WorkflowExecutor(registry_full)
+        results_full = await executor.execute(workflow, input_data="t")
+
+        assert all(
+            results_full[p].status == PhaseStatus.COMPLETED
+            for p in ["p1", "p2", "p3", "p4"]
+        )
+
+        # Simulate: crash after p2, checkpoint has p1 + p2 outputs
+        crash_after = {"p1", "p2"}
+        checkpoint_outputs = {name: results_full[name].output for name in crash_after}
+
+        # --- Run 2: resume from checkpoint ---
+        call_log_resume: list[str] = []
+        registry_resume = MagicMock()
+
+        def find_resume(cap):
+            provider = MagicMock()
+            provider.name = cap
+
+            async def invoke(*args, **kwargs):
+                call_log_resume.append(cap)
+                return f"out_{cap}"
+
+            provider.invoke = invoke
+            return [provider]
+
+        registry_resume.find_for_capability = find_resume
+
+        context = {}
+        for name in crash_after:
+            context[f"phase_{name}_output"] = checkpoint_outputs[name]
+            context[f"phase_{name}_result"] = PhaseResult(
+                phase_name=name,
+                status=PhaseStatus.COMPLETED,
+                capability=name,
+                output=checkpoint_outputs[name],
+            )
+
+        executor2 = WorkflowExecutor(registry_resume)
+        resumed_results = await executor2.execute(
+            workflow,
+            input_data="t",
+            context=context,
+            resume_from=crash_after,
+        )
+
+        # p1, p2 skipped (from checkpoint); p3, p4 executed
+        assert call_log_resume == ["p3", "p4"]
+        assert resumed_results["p1"].status == PhaseStatus.SKIPPED
+        assert resumed_results["p2"].status == PhaseStatus.SKIPPED
+        assert resumed_results["p3"].status == PhaseStatus.COMPLETED
+        assert resumed_results["p4"].status == PhaseStatus.COMPLETED
+
+        # Final outputs match the full (non-crashed) run
+        assert context["phase_p1_output"] == results_full["p1"].output
+        assert context["phase_p2_output"] == results_full["p2"].output
+        assert resumed_results["p3"].output == results_full["p3"].output
+        assert resumed_results["p4"].output == results_full["p4"].output
+
+    @pytest.mark.asyncio
+    async def test_resume_without_context_reconstructs_skipped(self):
+        """When resume_from is set but context lacks entries, phases get SKIPPED."""
+        workflow = (
+            WorkflowBuilder("test")
+            .add_phase("a", capability="a")
+            .add_phase("b", capability="b", depends_on=["a"])
+            .build()
+        )
+        registry = _make_registry_with_invoke({"a": "oa", "b": "ob"})
+        executor = WorkflowExecutor(registry)
+
+        results = await executor.execute(workflow, input_data="t", resume_from={"a"})
+        assert results["a"].status == PhaseStatus.SKIPPED
+        assert results["b"].status == PhaseStatus.COMPLETED


### PR DESCRIPTION
## Summary

- **Checkpoint module**: `CheckpointManager` with atomic writes (tempfile + os.rename) for per-document workflow state
- **WorkflowExecutor resume**: `resume_from` param skips completed phases; `checkpoint_callback` invoked after each DAG level
- **Batch runner `--resume`**: picks up from checkpoints, injects serialized outputs into context, merges state snapshots
- **17 unit tests**: atomic writes, serialize/deserialize round-trip, resume skip verification, crash simulation
- **`scripts/dataset/README.md`**: usage docs for all flags including `--resume`

## Test plan

- [x] `pytest tests/unit/argumentation_analysis/orchestration/test_checkpoint.py` — 17/17 passed
- [ ] CI green (lint + test)

Closes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)