### PR TITLE
chore(lint): apply black to 2 stale integration test files

### DIFF
--- a/tests/integration/test_corpus_batch_runner.py
+++ b/tests/integration/test_corpus_batch_runner.py
@@ -156,7 +156,10 @@ class TestDocumentFlattening:
             {
                 "source_name": "Test Source",
                 "extracts": [
-                    {"extract_name": "ex1", "extract_text": "Content from extract_text"},
+                    {
+                        "extract_name": "ex1",
+                        "extract_text": "Content from extract_text",
+                    },
                 ],
             }
         ]
@@ -164,7 +167,9 @@ class TestDocumentFlattening:
         docs = []
         for source_def in definitions:
             for extract in source_def.get("extracts", []):
-                text = extract.get("extract_text", "") or extract.get("full_text_segment", "")
+                text = extract.get("extract_text", "") or extract.get(
+                    "full_text_segment", ""
+                )
                 if text:
                     docs.append(text)
 
@@ -177,7 +182,11 @@ class TestDocumentFlattening:
             {
                 "source_name": "Test",
                 "extracts": [
-                    {"extract_name": "ex1", "extract_text": "", "full_text_segment": "Fallback content"},
+                    {
+                        "extract_name": "ex1",
+                        "extract_text": "",
+                        "full_text_segment": "Fallback content",
+                    },
                 ],
             }
         ]
@@ -185,7 +194,9 @@ class TestDocumentFlattening:
         docs = []
         for source_def in definitions:
             for extract in source_def.get("extracts", []):
-                text = extract.get("extract_text", "") or extract.get("full_text_segment", "")
+                text = extract.get("extract_text", "") or extract.get(
+                    "full_text_segment", ""
+                )
                 if text:
                     docs.append(text)
 
@@ -206,7 +217,9 @@ class TestDocumentFlattening:
         docs = []
         for source_def in definitions:
             for extract in source_def.get("extracts", []):
-                text = extract.get("extract_text", "") or extract.get("full_text_segment", "")
+                text = extract.get("extract_text", "") or extract.get(
+                    "full_text_segment", ""
+                )
                 if text:
                     docs.append(text)
 

--- a/tests/integration/test_pattern_report.py
+++ b/tests/integration/test_pattern_report.py
@@ -23,6 +23,7 @@ from argumentation_analysis.evaluation.pattern_mining import (
 # Synthetic fixture signatures
 # ---------------------------------------------------------------------------
 
+
 def _make_signature(
     cluster_id: str = "test_cluster",
     fallacies: dict | None = None,
@@ -53,7 +54,9 @@ def _make_signature(
         "identified_fallacies": identified,
         "dung_frameworks": dung_fw,
         "jtms_beliefs": jtms_beliefs,
-        "jtms_retraction_chain": [{"from": f"b{j}", "to": f"b{j+1}"} for j in range(jtms_retractions)],
+        "jtms_retraction_chain": [
+            {"from": f"b{j}", "to": f"b{j+1}"} for j in range(jtms_retractions)
+        ],
         "fol_analysis_results": [] if fol_valid else [{"valid": False}],
         "atms_contexts": [],
     }
@@ -67,17 +70,25 @@ def synthetic_signatures():
         _make_signature(
             "propaganda",
             {"ad_hominem": "arg0", "appeal_to_fear": "arg1", "straw_man": "arg0"},
-            dung_args=4, dung_attacks=3, jtms_retractions=2, fol_valid=False,
+            dung_args=4,
+            dung_attacks=3,
+            jtms_retractions=2,
+            fol_valid=False,
         ),
         _make_signature(
             "propaganda",
             {"ad_hominem": "arg0", "bandwagon": "arg2", "cherry_picking": "arg3"},
-            dung_args=2, dung_attacks=1, jtms_retractions=0,
+            dung_args=2,
+            dung_attacks=1,
+            jtms_retractions=0,
         ),
         _make_signature(
             "debate",
             {"straw_man": "arg0", "false_dilemma": "arg1", "red_herring": "arg2"},
-            dung_args=3, dung_attacks=2, jtms_retractions=1, fol_valid=False,
+            dung_args=3,
+            dung_attacks=2,
+            jtms_retractions=1,
+            fol_valid=False,
         ),
     ]
 
@@ -95,6 +106,7 @@ def sig_dir(tmp_path, synthetic_signatures):
 # ---------------------------------------------------------------------------
 # Test: pattern_mining functions on synthetic data
 # ---------------------------------------------------------------------------
+
 
 class TestPatternMining:
     """Verify pattern_mining functions produce valid output on synthetic data."""
@@ -141,7 +153,11 @@ class TestPatternMining:
                 assert "per_signature_rate" in rates
                 assert "per_occurrence_rate" in rates
                 for rate_family in ["per_signature_rate", "per_occurrence_rate"]:
-                    for sig_name in ["fol_invalid", "dung_unsupported", "jtms_retraction"]:
+                    for sig_name in [
+                        "fol_invalid",
+                        "dung_unsupported",
+                        "jtms_retraction",
+                    ]:
                         assert sig_name in rates[rate_family]
 
     def test_formal_detectors(self, synthetic_signatures):
@@ -157,6 +173,7 @@ class TestPatternMining:
 # ---------------------------------------------------------------------------
 # Test: build_pattern_report functions
 # ---------------------------------------------------------------------------
+
 
 class TestReportBuilder:
     """Test report generation and SVG output."""
@@ -248,6 +265,7 @@ class TestReportBuilder:
 # Test: SVG generation edge cases
 # ---------------------------------------------------------------------------
 
+
 class TestSVGGeneration:
     """Test SVG generation with edge-case inputs."""
 
@@ -289,8 +307,16 @@ class TestSVGGeneration:
         from scripts.dataset.build_pattern_report import generate_asymmetry_svg
 
         data = {
-            "cluster_a": {"tricherie_share": 0.3, "influence_share": 0.7, "asymmetry": 0.4},
-            "cluster_b": {"tricherie_share": 0.6, "influence_share": 0.2, "asymmetry": -0.5},
+            "cluster_a": {
+                "tricherie_share": 0.3,
+                "influence_share": 0.7,
+                "asymmetry": 0.4,
+            },
+            "cluster_b": {
+                "tricherie_share": 0.6,
+                "influence_share": 0.2,
+                "asymmetry": -0.5,
+            },
         }
         svg = generate_asymmetry_svg(data)
         assert "<svg" in svg


### PR DESCRIPTION
## Summary
- `tests/integration/test_corpus_batch_runner.py` (added by #426/#440) and `tests/integration/test_pattern_report.py` (added by #437) were never formatted with black after merge
- Recent black version (in conda `projet-is`) flags them — blocks CI lint step on any PR that includes them (cf. #466 lint failure)
- Pure formatting, **zero logic change** (run black locally to verify)

## Why coordinator-level fix
Main is currently lint-broken. Any PR including these files (e.g. #466) cannot pass lint regardless of worker effort. Unblocks Epic E delivery from po-2025.

## Test plan
- [x] `black --check` on the 2 files locally → reformatted clean
- [ ] CI lint step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)