### PR TITLE
refactor(capability): rename ATMS capability to atms_reasoning (#473)

### DIFF
--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -182,9 +182,8 @@ def setup_registry(
             name="atms_service",
             service_class=ATMSCore,
             capabilities=[
-                "assumption_based_reasoning",
-                "environment_tracking",
                 "atms_reasoning",
+                "environment_tracking",
             ],
             metadata={
                 "description": "Assumption-based Truth Maintenance System (ATMS)"

--- a/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
+++ b/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
@@ -71,7 +71,7 @@ class SherlockModernOrchestrator:
         "phase_quality_output": "argument_quality",
         "phase_counter_output": "counter_argument_generation",
         "phase_jtms_output": "belief_maintenance",
-        "phase_atms_output": "assumption_based_reasoning",
+        "phase_atms_output": "atms_reasoning",
     }
 
     def __init__(self, state: Optional[UnifiedAnalysisState] = None):

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -819,7 +819,7 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "argument_quality": _write_quality_to_state,
     "counter_argument_generation": _write_counter_argument_to_state,
     "belief_maintenance": _write_jtms_to_state,
-    "assumption_based_reasoning": _write_atms_to_state,
+    "atms_reasoning": _write_atms_to_state,
     "adversarial_debate": _write_debate_to_state,
     "governance_simulation": _write_governance_to_state,
     "neural_fallacy_detection": _write_camembert_to_state,

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -632,7 +632,7 @@ def build_spectacular_workflow() -> WorkflowDefinition:
         # L7 — ATMS multi-context (from JTMS beliefs)
         .add_phase(
             "atms",
-            capability="assumption_based_reasoning",
+            capability="atms_reasoning",
             depends_on=["jtms"],
             optional=True,
         )

--- a/argumentation_analysis/workflows/formal_verification.py
+++ b/argumentation_analysis/workflows/formal_verification.py
@@ -159,7 +159,7 @@ def build_formal_verification_workflow() -> WorkflowDefinition:
         # ATMS assumption-based reasoning — complements JTMS with environment tracking (#292)
         .add_phase(
             "atms_tracking",
-            capability="assumption_based_reasoning",
+            capability="atms_reasoning",
             depends_on=["jtms_tracking"],
             optional=True,
         )

--- a/docs/architecture/CAPABILITY_DUALITY.md
+++ b/docs/architecture/CAPABILITY_DUALITY.md
@@ -1,0 +1,57 @@
+# Capability Duality
+
+## Principle
+
+Each capability in the system can be provided by two paths:
+
+1. **Pipeline path** (`_invoke_*` callable) — Used by `WorkflowExecutor` during DAG-based pipeline execution. Each callable receives `(input_text, context)` and returns a result dict.
+
+2. **SK plugin path** (`@kernel_function`) — Used by conversational agents via Semantic Kernel's function-calling mechanism. The LLM discovers and invokes these methods autonomously.
+
+When both paths exist for the same capability, this is called a **duality**. Dualities are acceptable when both paths converge on the same backend implementation and share state through `UnifiedAnalysisState`.
+
+## Invariant
+
+> **Every capability duality must be documented in `ACCEPTED_DUALITIES`** in `tests/integration/test_capability_duality_invariant.py`.
+
+The CI enforces this invariant. Undocumented dualities cause test failures.
+
+## Accepted Dualities
+
+| Capability | Plugin | Invoke Callable | Convergence Point |
+|---|---|---|---|
+| `argument_quality` | `QualityScoringPlugin` | `_invoke_quality_evaluator` | `ArgumentQualityEvaluator` |
+| `counter_argument_generation` | `CounterArgumentAgent` @kf | `_invoke_counter_argument` | Same agent |
+| `adversarial_debate` | `DebateAgent` @kf | `_invoke_debate_analysis` | Same agent |
+| `governance_simulation` | `GovernancePlugin` | `_invoke_governance` | `GovernanceAgent` |
+| `belief_maintenance` | `JTMSPlugin` | `_invoke_jtms` | `JTMS` core |
+| `atms_reasoning` | `ATMSPlugin` | `_invoke_atms` | `ATMS` core |
+| `aspic_plus_reasoning` | `ASPICPlugin` | `_invoke_aspic` | ASPIC handler |
+| `ranking_semantics` | `RankingPlugin` | `_invoke_ranking` | Ranking handler |
+| `dung_extensions` | `TweetyLogicPlugin` | `_invoke_dung_extensions` | Dung handler |
+| `propositional_logic` | `TweetyLogicPlugin` + `LogiqueComplexePlugin` | `_invoke_propositional_logic` | Tweety PL |
+| `fol_reasoning` | `TweetyLogicPlugin` | `_invoke_fol_reasoning` | Tweety FOL |
+| `modal_logic` | `TweetyLogicPlugin` | `_invoke_modal_logic` | Tweety Modal |
+| `fact_extraction` | — | `_invoke_fact_extraction` | Heuristic extractor |
+| `nl_to_logic_translation` | `NLToLogicPlugin` | `_invoke_nl_to_logic` | NLToLogicTranslator |
+| `belief_revision` | `BeliefRevisionPlugin` | `_invoke_belief_revision` | Tweety revision |
+| `neural_fallacy_detection` | `FrenchFallacyPlugin` | `_invoke_camembert_fallacy` | Detection backend |
+| `formal_synthesis` | `NarrativeSynthesisPlugin` | `_invoke_formal_synthesis` | Aggregation logic |
+| `narrative_synthesis` | `NarrativeSynthesisPlugin` | `_invoke_narrative_synthesis` | Synthesis logic |
+
+## Architecture Decision
+
+The duality exists because the system operates in two modes:
+
+- **Pipeline mode**: `WorkflowExecutor` orchestrates phases via `_invoke_*` callables with DAG parallelism
+- **Conversational mode**: SK `AgentGroupChat` lets agents discover and call `@kernel_function` methods
+
+Both modes must produce equivalent results for the same input. The state writers (`CAPABILITY_STATE_WRITERS`) normalize the output into `UnifiedAnalysisState` regardless of which path was taken.
+
+## Adding a New Duality
+
+1. Implement the capability in both paths (invoke callable + plugin method)
+2. Ensure both use the same underlying implementation
+3. Add an entry to `ACCEPTED_DUALITIES` in the invariant test
+4. Add a row to the table above
+5. Ensure the state writer handles the output of both paths identically

--- a/scripts/profile_spectacular.py
+++ b/scripts/profile_spectacular.py
@@ -438,7 +438,7 @@ def generate_report(profiling: Dict[str, Any]) -> str:
             if p["capability"]
             in (
                 "belief_maintenance",
-                "assumption_based_reasoning",
+                "atms_reasoning",
             )
         ]
         other_phases = [

--- a/tests/integration/test_capability_duality_invariant.py
+++ b/tests/integration/test_capability_duality_invariant.py
@@ -1,0 +1,160 @@
+"""Capability duality invariant test.
+
+Ensures that no capability silently diverges between the @kernel_function
+path (SK plugins) and the _invoke_* callable path (pipeline).  When both
+exist for the same capability, the duality must be explicitly documented.
+
+See docs/architecture/CAPABILITY_DUALITY.md for the accepted dualities.
+"""
+
+import pytest
+from argumentation_analysis.core.capability_registry import CapabilityRegistry
+from argumentation_analysis.orchestration.registry_setup import setup_registry
+
+# ---------------------------------------------------------------------------
+# Accepted dualities — capabilities that intentionally have both a plugin
+# (kernel_function) and an invoke callable.  Each entry maps a capability
+# name to a short rationale.
+#
+# NOTE (Epic G pre-wiring): Most dualities are listed as PENDING because
+# the SK plugins are not yet wired into CapabilityRegistry (G.1 #468).
+# Once G.1 lands, these will become real dualities enforced by
+# test_dual_capabilities_are_documented.
+# ---------------------------------------------------------------------------
+
+ACCEPTED_DUALITIES: dict[str, str] = {
+    "argument_quality": "QualityScoringPlugin wraps ArgumentQualityEvaluator (same backend)",
+    "counter_argument_generation": "CounterArgumentAgent @kernel_functions delegate to _invoke_counter_argument",
+    "adversarial_debate": "DebateAgent @kernel_functions delegate to _invoke_debate_analysis",
+    "governance_simulation": "GovernancePlugin wraps GovernanceAgent (same backend)",
+    "belief_maintenance": "JTMSPlugin wraps JTMS core; _invoke_jtms uses same core",
+    "atms_reasoning": "ATMSPlugin wraps ATMS core; _invoke_atms uses same core",
+    "aspic_plus_reasoning": "ASPICPlugin wraps ASPIC handler; _invoke_aspic uses same handler",
+    "ranking_semantics": "RankingPlugin wraps ranking handler; _invoke_ranking uses same handler",
+    "dung_extensions": "TweetyLogicPlugin exposes Dung handler; _invoke_dung_extensions uses same",
+    "propositional_logic": "TweetyLogicPlugin + LogiqueComplexePlugin; _invoke_propositional_logic same backend",
+    "fol_reasoning": "TweetyLogicPlugin; _invoke_fol_reasoning same backend",
+    "modal_logic": "TweetyLogicPlugin; _invoke_modal_logic same backend",
+    "fact_extraction": "_invoke_fact_extraction callable; potential NL extraction plugin",
+    "nl_to_logic_translation": "NLToLogicPlugin @kernel_functions; _invoke_nl_to_logic callable",
+    "belief_revision": "BeliefRevisionPlugin; _invoke_belief_revision same backend",
+    "neural_fallacy_detection": "FrenchFallacyPlugin wraps detection; _invoke_camembert_fallacy callable",
+    "formal_synthesis": "NarrativeSynthesisPlugin; _invoke_formal_synthesis aggregates formal results",
+}
+
+
+@pytest.fixture(scope="module")
+def registry():
+    """Build a fully populated registry."""
+    return setup_registry()
+
+
+def _get_invoke_capabilities(registry: CapabilityRegistry) -> set[str]:
+    """Collect all capabilities served by an _invoke_* callable (any component type)."""
+    caps = set()
+    for reg in registry.get_all_registrations():
+        if reg.invoke is not None:
+            caps.update(reg.capabilities)
+    return caps
+
+
+def _get_plugin_capabilities(registry: CapabilityRegistry) -> set[str]:
+    """Collect all capabilities served by a registered plugin."""
+    caps = set()
+    for reg in registry.get_all_registrations():
+        # Plugins registered via register_plugin
+        from argumentation_analysis.core.capability_registry import ComponentType
+
+        if reg.component_type == ComponentType.PLUGIN:
+            caps.update(reg.capabilities)
+    return caps
+
+
+def _get_primary_invoke_capabilities(registry: CapabilityRegistry) -> set[str]:
+    """Invoke capabilities that are the primary capability of a service (not
+    agent sub-capabilities like 'virtue_detection' or 'debate_scoring')."""
+    from argumentation_analysis.orchestration.state_writers import (
+        CAPABILITY_STATE_WRITERS,
+    )
+
+    invoke_caps = _get_invoke_capabilities(registry)
+    # Only include capabilities that have state writers — these are the
+    # primary pipeline capabilities. Agent sub-capabilities are secondary.
+    return invoke_caps & set(CAPABILITY_STATE_WRITERS.keys())
+
+
+class TestCapabilityDualityInvariant:
+    """Every capability must be provided by either an invoke callable or a
+    plugin (or both, if documented).  Undocumented dualities are errors."""
+
+    def test_dual_capabilities_are_documented(self, registry):
+        invoke_caps = _get_invoke_capabilities(registry)
+        plugin_caps = _get_plugin_capabilities(registry)
+        dual = invoke_caps & plugin_caps
+
+        undocumented = dual - set(ACCEPTED_DUALITIES.keys())
+        assert not undocumented, (
+            f"Undocumented capability dualities found: {sorted(undocumented)}.\n"
+            f"Each must be added to ACCEPTED_DUALITIES with a rationale, "
+            f"or one implementation path must be removed.\n"
+            f"See docs/architecture/CAPABILITY_DUALITY.md for guidance."
+        )
+
+    def test_accepted_dualities_still_have_invoke(self, registry):
+        """Verify that capabilities in ACCEPTED_DUALITIES still have invoke providers."""
+        invoke_caps = _get_invoke_capabilities(registry)
+        missing = set(ACCEPTED_DUALITIES.keys()) - invoke_caps
+        assert not missing, (
+            f"ACCEPTED_DUALITIES entries without invoke providers: "
+            f"{sorted(missing)}.\n"
+            f"The _invoke_* callable was likely removed or renamed. Update the list."
+        )
+
+    def test_spectacular_workflow_capabilities_have_providers(self, registry):
+        """Every capability in the spectacular workflow has at least one provider."""
+        from argumentation_analysis.orchestration.workflows import (
+            build_spectacular_workflow,
+        )
+
+        wf = build_spectacular_workflow()
+        all_caps = registry.get_all_capabilities()
+
+        unprovided = []
+        for phase in wf.phases:
+            if phase.capability not in all_caps and not phase.optional:
+                unprovided.append(phase.capability)
+
+        assert (
+            not unprovided
+        ), f"Required workflow capabilities without providers: {unprovided}"
+
+    def test_primary_invoke_capabilities_cover_workflow(self, registry):
+        """Primary pipeline capabilities cover most workflow phases.
+
+        This test catches silent capability removals — if an _invoke_*
+        callable or its state writer is deleted without updating the workflow,
+        it will surface here.
+        """
+        from argumentation_analysis.orchestration.workflows import (
+            build_spectacular_workflow,
+        )
+
+        primary = _get_primary_invoke_capabilities(registry)
+        wf = build_spectacular_workflow()
+
+        uncovered_optional = []
+        for phase in wf.phases:
+            if phase.capability not in primary and phase.optional:
+                uncovered_optional.append(phase.capability)
+
+        # These are expected to be missing (no invoke or no state writer yet)
+        expected_missing = {
+            "hierarchical_fallacy_detection",
+            "narrative_synthesis",
+        }
+        actual_missing = set(uncovered_optional) - expected_missing
+        assert not actual_missing, (
+            f"Optional workflow capabilities unexpectedly without "
+            f"primary invoke coverage: {sorted(actual_missing)}.\n"
+            f"Either add _invoke_* + state_writer or update expected_missing."
+        )

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
@@ -90,7 +90,7 @@ MOCK_OUTPUTS = {
         "transcript": [{"proponent": "P arg", "opponent": "O counter"}],
         "winner": "opponent",
     },
-    "assumption_based_reasoning": {
+    "atms_reasoning": {
         "atms_contexts": [
             {
                 "hypothesis_id": "h_trust",
@@ -268,7 +268,7 @@ def _make_mock_state_writers():
     writers["argument_quality"] = _write_quality
     writers["counter_argument_generation"] = _write_counter
     writers["belief_maintenance"] = _write_jtms
-    writers["assumption_based_reasoning"] = _write_atms
+    writers["atms_reasoning"] = _write_atms
     writers["adversarial_debate"] = _write_debate
     writers["governance_simulation"] = _write_governance
     writers["hierarchical_fallacy_detection"] = _write_fallacy

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
@@ -126,4 +126,4 @@ class TestSpectacularWorkflowDAG:
     def test_spectacular_includes_atms(self):
         wf = build_spectacular_workflow()
         caps = wf.get_required_capabilities()
-        assert "assumption_based_reasoning" in caps
+        assert "atms_reasoning" in caps

--- a/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
+++ b/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
@@ -89,7 +89,7 @@ class TestBuildFormalVerificationWorkflow:
             "defeasible_logic",
             "qbf_reasoning",
             # ATMS assumption-based reasoning (#292)
-            "assumption_based_reasoning",
+            "atms_reasoning",
         }
         assert expected == set(caps)
 


### PR DESCRIPTION
## Summary
- **G.6 #473**: Rename ATMS capability from `assumption_based_reasoning` to `atms_reasoning` to resolve ABA/ATMS collision
- **G.5 #472**: Add capability duality invariant test (4 checks) + CAPABILITY_DUALITY.md documentation

### G.6 — ATMS capability rename
- ATMS uses dedicated `atms_reasoning`, ABA keeps `aba_reasoning`
- Updated 5 source files + 3 test files
- 61/61 spectacular workflow tests pass

### G.5 — Capability duality invariant
- `test_capability_duality_invariant.py`: 4 invariant checks
  - Dual capabilities are documented
  - Accepted dualities still have invoke providers
  - Spectacular workflow capabilities have providers
  - Primary invoke capabilities cover workflow phases
- `docs/architecture/CAPABILITY_DUALITY.md`: Documents all accepted dualities

## Test plan
- [x] 61/61 spectacular workflow DAG + regression tests pass
- [x] 4/4 capability duality invariant tests pass
- [x] Black formatting clean
- [x] No remaining references to `assumption_based_reasoning`

Closes #473, Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)