### PR TITLE
feat(dung): extend _invoke_dung_extensions to 11 Tweety semantics (#478)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -367,7 +367,6 @@ async def _invoke_counter_argument(
     try:
         client, model_id = _get_openai_client()
         if client:
-
             # Collect fallacious arguments + weakest arguments for targeted CAs
             extract_output = context.get("phase_extract_output", {})
             arguments = extract_output.get("arguments", [])
@@ -562,7 +561,6 @@ async def _invoke_debate_analysis(
     try:
         client, model_id = _get_openai_client()
         if client:
-
             # Build adversarial debate from upstream analysis
             extract_output = context.get("phase_extract_output", {})
             raw_arguments = extract_output.get("arguments", [])
@@ -763,7 +761,6 @@ async def _invoke_governance(
     try:
         client, model_id = _get_openai_client()
         if client:
-
             # Build context from upstream phases
             context_parts = []
             if arguments:
@@ -3272,7 +3269,6 @@ async def _invoke_fol_reasoning(
         has_fallacious = any("Fallacious" in f for f in formulas)
         fol_signature = []
         try:
-
             meta = FOLLogicAgent.extract_fol_metadata(formulas)
             fol_signature = meta.get("signature_lines", [])
         except Exception:
@@ -3370,7 +3366,9 @@ async def _invoke_dung_extensions(
     """Invoke Dung framework extension computation via AFHandler (JVM required).
 
     Builds attack graph from extracted arguments and detected fallacies,
-    then computes grounded, preferred, and stable extensions via Tweety.
+    then computes all 11 Dung semantics via Tweety: grounded, preferred,
+    stable, complete, admissible, conflict_free, semi_stable, stage, cf2,
+    ideal, naive.
     Falls back to pure-Python computation when JVM is unavailable.
     """
     # 1. Extract arguments from upstream phases
@@ -3381,7 +3379,10 @@ async def _invoke_dung_extensions(
 
     # 3. Compute extensions via Tweety (or Python fallback)
     try:
-        from argumentation_analysis.agents.core.logic.af_handler import AFHandler
+        from argumentation_analysis.agents.core.logic.af_handler import (
+            AFHandler,
+            SEMANTICS_REASONERS,
+        )
         from argumentation_analysis.agents.core.logic.tweety_initializer import (
             TweetyInitializer,
         )
@@ -3389,30 +3390,45 @@ async def _invoke_dung_extensions(
         initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = AFHandler(initializer)
 
-        # Compute multiple semantics for comprehensive analysis
-        all_extensions = {}
-        for semantics in ("grounded", "preferred", "stable"):
-            try:
-                result = await asyncio.to_thread(
-                    handler.analyze_dung_framework, arguments, attacks, semantics
-                )
-                ext = result.get("extensions", {})
-                if isinstance(ext, dict):
-                    all_extensions[semantics] = ext
-            except Exception:
-                pass
+        # Compute all 11 semantics in one pass (framework built once)
+        all_semantics = list(SEMANTICS_REASONERS.keys())
+        result = await asyncio.to_thread(
+            handler.analyze_multi_semantics, arguments, attacks, all_semantics
+        )
 
-        # Use preferred as primary if available
-        primary = all_extensions.get("preferred", all_extensions.get("grounded", {}))
+        raw_extensions = result.get("extensions", {})
+
+        # Enrich: for each semantics, add sizes and argument membership
+        enriched_extensions = {}
+        for sem, ext_data in raw_extensions.items():
+            if isinstance(ext_data, dict) and "error" in ext_data:
+                enriched_extensions[sem] = ext_data
+                continue
+            extensions_list = ext_data if isinstance(ext_data, list) else []
+            enriched_extensions[sem] = {
+                "extensions": extensions_list,
+                "count": len(extensions_list),
+                "sizes": [len(ext) for ext in extensions_list],
+                "all_members": sorted({arg for ext in extensions_list for arg in ext}),
+            }
+
+        # Use preferred as primary, fallback to grounded
+        primary = enriched_extensions.get(
+            "preferred", enriched_extensions.get("grounded", {})
+        )
+
         return {
             "semantics": "multi",
             "extensions": primary,
-            "all_extensions": all_extensions,
+            "all_extensions": enriched_extensions,
             "arguments": arguments,
             "attacks": attacks,
             "statistics": {
                 "arguments_count": len(arguments),
                 "attacks_count": len(attacks),
+                "semantics_computed": len(
+                    [v for v in enriched_extensions.values() if "count" in v]
+                ),
             },
         }
     except Exception as e:

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
@@ -43,8 +43,8 @@ class TestInvokeDungExtensions:
             "argumentation_analysis.agents.core.logic.af_handler.AFHandler"
         ) as mock_af:
             mock_handler = MagicMock()
-            mock_handler.analyze_dung_framework.return_value = {
-                "extensions": {"grounded": ["arg_0"]},
+            mock_handler.analyze_multi_semantics.return_value = {
+                "extensions": {"grounded": [["arg_0"]]},
             }
             mock_af.return_value = mock_handler
 
@@ -54,8 +54,8 @@ class TestInvokeDungExtensions:
                 mock_init.return_value = MagicMock()
                 result = await _invoke_dung_extensions("test text", context)
 
-        # Should have called AFHandler with extracted arguments
-        call_args = mock_handler.analyze_dung_framework.call_args
+        # Should have called analyze_multi_semantics with extracted arguments
+        call_args = mock_handler.analyze_multi_semantics.call_args
         args_passed = call_args[0][0]  # First positional arg = arguments
         assert len(args_passed) == 2
         assert "impots" in args_passed[0].lower() or "impots" in args_passed[0]
@@ -88,7 +88,7 @@ class TestInvokeDungExtensions:
             "argumentation_analysis.agents.core.logic.af_handler.AFHandler"
         ) as mock_af:
             mock_handler = MagicMock()
-            mock_handler.analyze_dung_framework.return_value = {
+            mock_handler.analyze_multi_semantics.return_value = {
                 "extensions": {},
             }
             mock_af.return_value = mock_handler
@@ -100,18 +100,32 @@ class TestInvokeDungExtensions:
                 result = await _invoke_dung_extensions("test text", context)
 
         # Attacks should have been generated from the fallacy
-        call_args = mock_handler.analyze_dung_framework.call_args
+        call_args = mock_handler.analyze_multi_semantics.call_args
         attacks_passed = call_args[0][1]  # Second positional arg = attacks
         assert len(attacks_passed) > 0
-        # The fallacy should attack the targeted argument
         assert any("fallacy" in str(a).lower() for a in attacks_passed)
 
     @pytest.mark.asyncio
     async def test_returns_multi_semantics(self):
-        """Dung function computes multiple semantics (grounded, preferred, stable)."""
+        """Dung function computes all 11 semantics via analyze_multi_semantics."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_dung_extensions,
         )
+
+        # Simulate result with 11 semantics
+        all_sems = {
+            "grounded": [["arg1"]],
+            "preferred": [["arg1"], ["arg2"]],
+            "stable": [["arg1", "arg2"]],
+            "complete": [["arg1"]],
+            "admissible": [["arg1"], ["arg1", "arg2"]],
+            "conflict_free": [["arg1"], ["arg2"], ["arg1", "arg2"]],
+            "semi_stable": [["arg1", "arg2"]],
+            "stage": [["arg1", "arg2"]],
+            "cf2": [["arg1", "arg2"]],
+            "ideal": [["arg1"]],
+            "naive": [["arg1", "arg2"]],
+        }
 
         context = {
             "phase_extract_output": {"arguments": [{"text": "arg1"}, {"text": "arg2"}]}
@@ -121,8 +135,9 @@ class TestInvokeDungExtensions:
             "argumentation_analysis.agents.core.logic.af_handler.AFHandler"
         ) as mock_af:
             mock_handler = MagicMock()
-            mock_handler.analyze_dung_framework.return_value = {
-                "extensions": {"set": ["arg1"]},
+            mock_handler.analyze_multi_semantics.return_value = {
+                "extensions": all_sems,
+                "statistics": {"arguments_count": 2, "attacks_count": 0},
             }
             mock_af.return_value = mock_handler
 
@@ -134,11 +149,107 @@ class TestInvokeDungExtensions:
 
         assert result["semantics"] == "multi"
         assert "all_extensions" in result
-        assert "grounded" in result["all_extensions"]
-        assert "preferred" in result["all_extensions"]
-        assert "stable" in result["all_extensions"]
+        # All 11 semantics should be present
+        expected_semantics = [
+            "grounded",
+            "preferred",
+            "stable",
+            "complete",
+            "admissible",
+            "conflict_free",
+            "semi_stable",
+            "stage",
+            "cf2",
+            "ideal",
+            "naive",
+        ]
+        for sem in expected_semantics:
+            assert sem in result["all_extensions"], f"Missing semantics: {sem}"
         assert "arguments" in result
         assert "attacks" in result
+
+    @pytest.mark.asyncio
+    async def test_enriched_extensions_format(self):
+        """Dung extensions include count, sizes, and all_members per semantics."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_dung_extensions,
+        )
+
+        all_sems = {
+            "grounded": [["a", "c"]],
+            "preferred": [["a", "c"], ["b"]],
+            "stable": [["a", "c"]],
+        }
+
+        context = {
+            "phase_extract_output": {
+                "arguments": [{"text": "a"}, {"text": "b"}, {"text": "c"}]
+            }
+        }
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.af_handler.AFHandler"
+        ) as mock_af:
+            mock_handler = MagicMock()
+            mock_handler.analyze_multi_semantics.return_value = {
+                "extensions": all_sems,
+                "statistics": {"arguments_count": 3, "attacks_count": 1},
+            }
+            mock_af.return_value = mock_handler
+
+            with patch(
+                "argumentation_analysis.agents.core.logic.tweety_initializer.TweetyInitializer"
+            ) as mock_init:
+                mock_init.return_value = MagicMock()
+                result = await _invoke_dung_extensions("test text", context)
+
+        # Check enriched format
+        grounded = result["all_extensions"]["grounded"]
+        assert grounded["count"] == 1
+        assert grounded["sizes"] == [2]
+        assert sorted(grounded["all_members"]) == ["a", "c"]
+
+        preferred = result["all_extensions"]["preferred"]
+        assert preferred["count"] == 2
+        assert sorted(preferred["all_members"]) == ["a", "b", "c"]
+
+        # Statistics should include semantics_computed
+        assert result["statistics"]["semantics_computed"] == 3
+
+    @pytest.mark.asyncio
+    async def test_semantics_error_handled(self):
+        """Semantics that fail computation are reported as errors, not skipped."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_dung_extensions,
+        )
+
+        all_sems = {
+            "grounded": [["a"]],
+            "cf2": {"error": "CF2Reasoner not available"},
+        }
+
+        context = {"phase_extract_output": {"arguments": [{"text": "a"}]}}
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.af_handler.AFHandler"
+        ) as mock_af:
+            mock_handler = MagicMock()
+            mock_handler.analyze_multi_semantics.return_value = {
+                "extensions": all_sems,
+                "statistics": {"arguments_count": 1, "attacks_count": 0},
+            }
+            mock_af.return_value = mock_handler
+
+            with patch(
+                "argumentation_analysis.agents.core.logic.tweety_initializer.TweetyInitializer"
+            ) as mock_init:
+                mock_init.return_value = MagicMock()
+                result = await _invoke_dung_extensions("test text", context)
+
+        # Error semantics preserved as-is
+        assert "error" in result["all_extensions"]["cf2"]
+        # Successful semantics enriched
+        assert "count" in result["all_extensions"]["grounded"]
 
     @pytest.mark.asyncio
     async def test_fallback_to_python(self):

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -993,8 +993,9 @@ class TestInvokeCallables:
         )
 
         mock_handler = MagicMock()
-        mock_handler.analyze_dung_framework.return_value = {
-            "extensions": {"preferred": []}
+        mock_handler.analyze_multi_semantics.return_value = {
+            "extensions": {"preferred": []},
+            "statistics": {"arguments_count": 1, "attacks_count": 0},
         }
 
         # Patch at the module level where the import happens inside the function
@@ -1002,7 +1003,8 @@ class TestInvokeCallables:
             "sys.modules",
             {
                 "argumentation_analysis.agents.core.logic.af_handler": MagicMock(
-                    AFHandler=MagicMock(return_value=mock_handler)
+                    AFHandler=MagicMock(return_value=mock_handler),
+                    SEMANTICS_REASONERS={"preferred": "x", "grounded": "y"},
                 ),
                 "argumentation_analysis.agents.core.logic.tweety_initializer": MagicMock(
                     TweetyInitializer=MagicMock()
@@ -1010,8 +1012,8 @@ class TestInvokeCallables:
             },
         ):
             result = await _invoke_dung_extensions("text", {})
-        # Should have called with default placeholder argument
-        call_args = mock_handler.analyze_dung_framework.call_args
+        # Should have called analyze_multi_semantics with default placeholder argument
+        call_args = mock_handler.analyze_multi_semantics.call_args
         assert call_args[0][0] == ["argument_placeholder"]
 
     async def test_invoke_formal_synthesis_no_phases(self):


### PR DESCRIPTION
## Summary

- Replace the 3-semantics loop (grounded/preferred/stable) with `analyze_multi_semantics()` which computes all 11 Dung semantics in a single pass
- Enriches state output with per-semantics `count`, `sizes`, and `all_members`
- Framework built once (vs 3x before), shared across all 11 reasoners

### Semantics now computed
grounded, preferred, stable, complete, admissible, conflict_free, semi_stable, stage, cf2, ideal, naive

### Files changed
- `invoke_callables.py` — `_invoke_dung_extensions` uses `analyze_multi_semantics` with `SEMANTICS_REASONERS.keys()` + enriched output format
- `test_dung_aspic_wiring.py` — Updated mocks to `analyze_multi_semantics`, added 3 new tests (11-semantics coverage, enriched format, error handling)
- `test_unified_pipeline.py` — Updated mock for `analyze_multi_semantics` + `SEMANTICS_REASONERS` patch

### Acceptance criteria (#478)
- [x] Extend `_invoke_dung_extensions` to all 11 semantics
- [x] State `dung_frameworks` enriched: per-semantics extensions + sizes + arguments members
- [x] Test: 11 semantics present in output (mock covers all 11)
- [x] Performance: single `asyncio.to_thread` call with framework built once (GIL consideration: JPype blocks GIL, parallelism not beneficial)

## Test plan
- [x] 32/32 dung wiring tests pass
- [x] 68/68 formal verification + spectacular DAG tests pass
- [x] 6/6 unified pipeline dung tests pass
- [x] Black + flake8 clean

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)