### PR TITLE
feat(plugins): TweetyResultInterpretationPlugin — formal results to NL (#476)

### DIFF
--- a/argumentation_analysis/agents/factory.py
+++ b/argumentation_analysis/agents/factory.py
@@ -47,14 +47,14 @@ _factory_logger = logging.getLogger("AgentFactory")
 AGENT_SPECIALITY_MAP = {
     "project_manager": ["narrative_synthesis"],
     "informal_fallacy": ["french_fallacy", "fallacy_workflow", "toulmin"],
-    "extract": ["toulmin"],
-    "formal_logic": ["tweety_logic", "nl_to_logic", "atms", "ranking", "aspic", "belief_revision"],
+    "extract": ["toulmin", "text_to_kb"],
+    "formal_logic": ["tweety_logic", "nl_to_logic", "atms", "ranking", "aspic", "belief_revision", "logic_agents", "text_to_kb", "kb_to_tweety", "tweety_interpretation"],
     "quality": ["quality_scoring"],
     "debate": ["debate"],
     "counter_argument": ["counter_argument"],
     "governance": ["governance"],
     "sherlock": [],  # Sherlock uses its own investigation tools
-    "watson": ["tweety_logic"],
+    "watson": ["tweety_logic", "logic_agents"],
 }
 
 # Registry of plugin name → (module_path, class_name) for lazy loading
@@ -119,6 +119,26 @@ _PLUGIN_REGISTRY = {
     "toulmin": (
         "argumentation_analysis.plugins.toulmin_plugin",
         "ToulminPlugin",
+    ),
+    # PL/FOL/Modal logic operations (#477)
+    "logic_agents": (
+        "argumentation_analysis.plugins.logic_agent_plugin",
+        "LogicAgentPlugin",
+    ),
+    # NL → KB extraction with iterative descent (#474)
+    "text_to_kb": (
+        "argumentation_analysis.plugins.text_to_kb_plugin",
+        "TextToKBPlugin",
+    ),
+    # KB → Tweety formula translation with retry (#475)
+    "kb_to_tweety": (
+        "argumentation_analysis.plugins.kb_to_tweety_plugin",
+        "KBToTweetyPlugin",
+    ),
+    # Formal results → NL interpretation (#476)
+    "tweety_interpretation": (
+        "argumentation_analysis.plugins.tweety_result_interpretation_plugin",
+        "TweetyResultInterpretationPlugin",
     ),
     # Complex plugins (need constructor args — loaded via special handling)
     # "exploration": needs TaxonomyNavigator — loaded by FallacyWorkflowPlugin

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -312,6 +312,100 @@ def setup_registry(
     except ImportError as e:
         skipped.append(("tweety_logic_plugin", str(e)))
 
+    # --- LogicAgentPlugin: PL/FOL/Modal @kernel_function methods (#477) ---
+    try:
+        from argumentation_analysis.plugins.logic_agent_plugin import LogicAgentPlugin
+
+        registry.register_plugin(
+            name="logic_agent_plugin",
+            plugin_class=LogicAgentPlugin,
+            capabilities=[
+                "propositional_reasoning",
+                "first_order_reasoning",
+                "modal_reasoning",
+            ],
+            metadata={
+                "description": (
+                    "SK plugin exposing PL/FOL/Modal logic operations as "
+                    "@kernel_function methods for LLM agents (#477)"
+                )
+            },
+        )
+        registered.append("logic_agent_plugin")
+    except ImportError as e:
+        skipped.append(("logic_agent_plugin", str(e)))
+
+    # --- TextToKBPlugin: NL extraction with iterative descent (#474) ---
+    try:
+        from argumentation_analysis.plugins.text_to_kb_plugin import TextToKBPlugin
+
+        registry.register_plugin(
+            name="text_to_kb_plugin",
+            plugin_class=TextToKBPlugin,
+            capabilities=["nl_extraction", "argument_extraction", "kb_construction"],
+            metadata={
+                "description": (
+                    "NL→KB extraction with iterative descent. Extracts arguments, "
+                    "premises, conclusions, beliefs, and FOL signatures (#474)"
+                )
+            },
+        )
+        registered.append("text_to_kb_plugin")
+    except ImportError as e:
+        skipped.append(("text_to_kb_plugin", str(e)))
+
+    # --- KBToTweetyPlugin: KB → Tweety formula translation (#475) ---
+    try:
+        from argumentation_analysis.plugins.kb_to_tweety_plugin import KBToTweetyPlugin
+
+        registry.register_plugin(
+            name="kb_to_tweety_plugin",
+            plugin_class=KBToTweetyPlugin,
+            capabilities=[
+                "kb_to_tweety",
+                "formula_translation",
+                "tweety_validation",
+            ],
+            metadata={
+                "description": (
+                    "Translate KB entries to Tweety formulas with "
+                    "translate-validate-retry loop for PL, FOL, Modal, "
+                    "Dung, and ASPIC (#475)"
+                )
+            },
+        )
+        registered.append("kb_to_tweety_plugin")
+    except ImportError as e:
+        skipped.append(("logic_agent_plugin", str(e)))
+
+    # --- TweetyResultInterpretationPlugin: formal results → NL (#476) ---
+    try:
+        from argumentation_analysis.plugins.tweety_result_interpretation_plugin import (
+            TweetyResultInterpretationPlugin,
+        )
+
+        registry.register_plugin(
+            name="tweety_result_interpretation_plugin",
+            plugin_class=TweetyResultInterpretationPlugin,
+            capabilities=[
+                "formal_result_interpretation",
+                "dung_interpretation",
+                "fol_interpretation",
+                "aspic_interpretation",
+                "ranking_interpretation",
+                "belief_revision_interpretation",
+            ],
+            metadata={
+                "description": (
+                    "SK plugin converting formal analysis results (Dung, FOL, ASPIC, "
+                    "ranking, belief revision) into NL explanations (#476)"
+                )
+            },
+        )
+        registered.append("tweety_result_interpretation_plugin")
+    except ImportError as e:
+        skipped.append(("tweety_result_interpretation_plugin", str(e)))
+
     # --- Logic agent capabilities (#71 Formal Verification) ---
     logic_capabilities = [
         (

--- a/argumentation_analysis/plugins/tweety_result_interpretation_plugin.py
+++ b/argumentation_analysis/plugins/tweety_result_interpretation_plugin.py
@@ -1,0 +1,323 @@
+"""TweetyResultInterpretationPlugin — Tweety formal results to NL narrative.
+
+Interprets formal analysis results (Dung extensions, FOL models, ASPIC attacks,
+ranking scores, belief revisions) into human-readable NL explanations.
+Provides both template-based (no LLM) and LLM-ready @kernel_function methods.
+
+Issue #476: Semantic plugin TweetyResultInterpretationPlugin.
+"""
+
+import json
+import logging
+from typing import Dict, List, Optional
+
+from semantic_kernel.functions import kernel_function
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Template-based interpreters (no LLM required)
+# ---------------------------------------------------------------------------
+
+
+def _interpret_dung(extensions: Dict, arguments: List[str] = None) -> str:
+    """Generate NL interpretation of Dung framework analysis."""
+    parts = []
+    args_text = f"{len(arguments)} arguments" if arguments else "des arguments"
+
+    if "grounded" in extensions:
+        grounded = extensions["grounded"]
+        if isinstance(grounded, dict):
+            grounded = grounded.get("set", [])
+        if grounded:
+            parts.append(
+                f"L'extension groundee (acceptee sans controversy) contient "
+                f"{len(grounded)} argument(s): {', '.join(str(a) for a in grounded[:10])}."
+            )
+        else:
+            parts.append("Aucun argument n'est accepte dans l'extension groundee.")
+
+    if "preferred" in extensions:
+        pref = extensions["preferred"]
+        if isinstance(pref, dict):
+            pref = pref.get("set", [])
+        if pref:
+            parts.append(
+                f"L'extension preferee contient {len(pref)} argument(s)."
+            )
+
+    if "stable" in extensions:
+        stable = extensions["stable"]
+        if isinstance(stable, dict):
+            stable = stable.get("set", [])
+        if stable:
+            parts.append(
+                f"L'extension stable identifie {len(stable)} argument(s) accepte(s)."
+            )
+
+    if not parts:
+        parts.append(f"Analyse Dung completee sur {args_text}.")
+
+    return " ".join(parts)
+
+
+def _interpret_fol(result: Dict) -> str:
+    """Generate NL interpretation of FOL reasoning result."""
+    accepted = result.get("accepted", False)
+    query = result.get("query", "")
+    message = result.get("message", result.get("result", ""))
+
+    if accepted:
+        return (
+            f"La requete '{query}' est acceptee (deductible de l'ensemble de croyances). "
+            f"{message}"
+        )
+    return (
+        f"La requete '{query}' n'est pas acceptee. {message}"
+    )
+
+
+def _interpret_aspic(result: Dict) -> str:
+    """Generate NL interpretation of ASPIC+ analysis."""
+    parts = []
+
+    strict = result.get("strict_rules", [])
+    defeasible = result.get("defeasible_rules", [])
+    attacks = result.get("attacks", [])
+
+    if strict:
+        parts.append(f"{len(strict)} regle(s) stricte(s) identifiee(s).")
+    if defeasible:
+        parts.append(f"{len(defeasible)} regle(s) defaisable(s) identifiee(s).")
+    if attacks:
+        parts.append(f"{len(attacks)} attaque(s) entre arguments.")
+
+    if not parts:
+        parts.append("Analyse ASPIC completee.")
+
+    return " ".join(parts)
+
+
+def _interpret_ranking(result: Dict) -> str:
+    """Generate NL interpretation of ranking semantics."""
+    rankings = result.get("rankings", result.get("scores", {}))
+    if isinstance(rankings, list):
+        rankings = {str(i): v for i, v in enumerate(rankings)}
+
+    if not rankings:
+        return "Classement des arguments complete."
+
+    sorted_items = sorted(rankings.items(), key=lambda x: float(x[1]) if isinstance(x[1], (int, float)) else 0, reverse=True)
+    top = sorted_items[:5]
+    parts = [f"Top arguments: {', '.join(f'{k} ({v})' for k, v in top)}."]
+    return " ".join(parts)
+
+
+def _interpret_belief_revision(result: Dict) -> str:
+    """Generate NL interpretation of belief revision."""
+    parts = []
+    removed = result.get("removed_beliefs", [])
+    added = result.get("added_beliefs", [])
+    revised = result.get("revised_beliefs", [])
+
+    if removed:
+        parts.append(f"{len(removed)} croyance(s) retiree(s).")
+    if added:
+        parts.append(f"{len(added)} croyance(s) ajoutee(s).")
+    if revised:
+        parts.append(f"{len(revised)} croyance(s) revisee(s).")
+
+    if not parts:
+        parts.append("Aucune revision de croyance necessaire.")
+
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Plugin class
+# ---------------------------------------------------------------------------
+
+
+class TweetyResultInterpretationPlugin:
+    """Semantic Kernel plugin for interpreting Tweety formal results.
+
+    Provides @kernel_function methods that convert formal analysis output
+    (Dung extensions, FOL query results, ASPIC attacks, etc.) into
+    human-readable NL explanations.
+
+    Usage:
+        kernel.add_plugin(
+            TweetyResultInterpretationPlugin(),
+            plugin_name="tweety_result_interpretation",
+        )
+    """
+
+    @kernel_function(
+        name="interpret_dung_results",
+        description=(
+            "Interpreter les resultats d'analyse Dung en langage naturel. "
+            "Entree: JSON {'extensions': {'grounded': [...], 'preferred': [...], ...}, "
+            "'arguments': [...]}. "
+            "Retourne texte NL explicatif."
+        ),
+    )
+    def interpret_dung_results(self, input: str) -> str:
+        """Interpret Dung framework analysis results."""
+        try:
+            params = json.loads(input) if isinstance(input, str) else input
+        except (json.JSONDecodeError, TypeError):
+            return "Impossible d'interpreter les resultats Dung: JSON invalide."
+
+        extensions = params.get("extensions", {})
+        arguments = params.get("arguments", [])
+        return _interpret_dung(extensions, arguments)
+
+    @kernel_function(
+        name="interpret_fol_results",
+        description=(
+            "Interpreter les resultats de raisonnement FOL en langage naturel. "
+            "Entree: JSON {'accepted': true/false, 'query': '...', 'message': '...'}. "
+            "Retourne texte NL explicatif."
+        ),
+    )
+    def interpret_fol_results(self, input: str) -> str:
+        """Interpret FOL query results."""
+        try:
+            params = json.loads(input) if isinstance(input, str) else input
+        except (json.JSONDecodeError, TypeError):
+            return "Impossible d'interpreter les resultats FOL: JSON invalide."
+        return _interpret_fol(params)
+
+    @kernel_function(
+        name="interpret_aspic_results",
+        description=(
+            "Interpreter les resultats d'analyse ASPIC+ en langage naturel. "
+            "Entree: JSON avec regles strictes/defaisables et attaques. "
+            "Retourne texte NL explicatif."
+        ),
+    )
+    def interpret_aspic_results(self, input: str) -> str:
+        """Interpret ASPIC+ analysis results."""
+        try:
+            params = json.loads(input) if isinstance(input, str) else input
+        except (json.JSONDecodeError, TypeError):
+            return "Impossible d'interpreter les resultats ASPIC: JSON invalide."
+        return _interpret_aspic(params)
+
+    @kernel_function(
+        name="interpret_ranking_results",
+        description=(
+            "Interpreter les resultats de classement d'arguments en langage naturel. "
+            "Entree: JSON avec scores/classements. "
+            "Retourne texte NL avec top arguments."
+        ),
+    )
+    def interpret_ranking_results(self, input: str) -> str:
+        """Interpret ranking semantics results."""
+        try:
+            params = json.loads(input) if isinstance(input, str) else input
+        except (json.JSONDecodeError, TypeError):
+            return "Impossible d'interpreter les resultats de classement: JSON invalide."
+        return _interpret_ranking(params)
+
+    @kernel_function(
+        name="interpret_belief_revision_results",
+        description=(
+            "Interpreter les resultats de revision de croyances. "
+            "Entree: JSON avec croyances retirees/ajoutees/revisees. "
+            "Retourne texte NL explicatif."
+        ),
+    )
+    def interpret_belief_revision_results(self, input: str) -> str:
+        """Interpret belief revision results."""
+        try:
+            params = json.loads(input) if isinstance(input, str) else input
+        except (json.JSONDecodeError, TypeError):
+            return "Impossible d'interpreter les resultats: JSON invalide."
+        return _interpret_belief_revision(params)
+
+    @kernel_function(
+        name="interpret_full_analysis",
+        description=(
+            "Synthese NL globale de tous les resultats formels. "
+            "Entree: JSON avec sous-resultats dung, fol, aspic, ranking, belief_revision. "
+            "Retourne synthese NL multi-paragraphes."
+        ),
+    )
+    def interpret_full_analysis(self, input: str) -> str:
+        """Generate a full NL synthesis of all formal analysis results."""
+        try:
+            params = json.loads(input) if isinstance(input, str) else input
+        except (json.JSONDecodeError, TypeError):
+            return "Impossible de generer la synthese: JSON invalide."
+
+        sections = []
+
+        if "dung" in params:
+            sections.append(
+                "**Analyse Dung**: " + _interpret_dung(
+                    params["dung"].get("extensions", {}),
+                    params["dung"].get("arguments", []),
+                )
+            )
+
+        if "fol" in params:
+            sections.append(
+                "**Raisonnement FOL**: " + _interpret_fol(params["fol"])
+            )
+
+        if "aspic" in params:
+            sections.append(
+                "**Analyse ASPIC+**: " + _interpret_aspic(params["aspic"])
+            )
+
+        if "ranking" in params:
+            sections.append(
+                "**Classement**: " + _interpret_ranking(params["ranking"])
+            )
+
+        if "belief_revision" in params:
+            sections.append(
+                "**Revision des croyances**: "
+                + _interpret_belief_revision(params["belief_revision"])
+            )
+
+        if not sections:
+            return "Aucun resultat formel a interpreter."
+
+        return "\n\n".join(sections)
+
+    @kernel_function(
+        name="write_interpretation_to_state",
+        description=(
+            "Ecrire l'interpretation NL dans l'etat d'analyse. "
+            "Entree: JSON {'interpretation': '...', 'section': 'narrative_synthesis'}. "
+            "Retourne confirmation."
+        ),
+    )
+    def write_interpretation_to_state(self, input: str, state: object = None) -> str:
+        """Write interpretation results to analysis state."""
+        if state is None:
+            return json.dumps({"error": "No state provided"})
+
+        try:
+            params = json.loads(input) if isinstance(input, str) else input
+        except (json.JSONDecodeError, TypeError):
+            return json.dumps({"error": "Invalid JSON input"})
+
+        interpretation = params.get("interpretation", "")
+        if not interpretation:
+            return json.dumps({"error": "Empty interpretation"})
+
+        # Try to write to state's narrative_synthesis or add_extract
+        written = False
+        add_extract = getattr(state, "add_extract", None)
+        if callable(add_extract):
+            add_extract("formal_interpretation", interpretation)
+            written = True
+
+        return json.dumps({
+            "written": written,
+            "length": len(interpretation),
+        })

--- a/tests/unit/argumentation_analysis/plugins/test_tweety_result_interpretation_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_tweety_result_interpretation_plugin.py
@@ -1,0 +1,377 @@
+"""Tests for TweetyResultInterpretationPlugin — formal results to NL (#476).
+
+Validates:
+- Template-based interpreters for Dung, FOL, ASPIC, ranking, belief revision
+- @kernel_function methods parse JSON input and return NL text
+- Full analysis synthesis combines multiple interpreters
+- write_interpretation_to_state integrates with analysis state
+- Registry and factory integration
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock
+
+from argumentation_analysis.plugins.tweety_result_interpretation_plugin import (
+    TweetyResultInterpretationPlugin,
+    _interpret_aspic,
+    _interpret_belief_revision,
+    _interpret_dung,
+    _interpret_fol,
+    _interpret_ranking,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test: Template-based interpreters
+# ---------------------------------------------------------------------------
+
+
+class TestInterpretDung:
+    def test_grounded_extension_with_args(self):
+        result = _interpret_dung(
+            {"grounded": ["a1", "a2"]},
+            arguments=["a1", "a2", "a3"],
+        )
+        assert "groundee" in result.lower() or "grounded" in result.lower()
+        assert "2" in result
+
+    def test_grounded_extension_empty(self):
+        result = _interpret_dung({"grounded": []})
+        assert "aucun" in result.lower()
+
+    def test_grounded_extension_dict_format(self):
+        result = _interpret_dung({"grounded": {"set": ["x", "y"]}})
+        assert "2" in result
+
+    def test_preferred_extension(self):
+        result = _interpret_dung({"preferred": ["a", "b", "c"]})
+        assert "preferee" in result.lower() or "3" in result
+
+    def test_preferred_dict_format(self):
+        result = _interpret_dung({"preferred": {"set": ["a"]}})
+        assert "1" in result
+
+    def test_stable_extension(self):
+        result = _interpret_dung({"stable": ["s1", "s2"]})
+        assert "stable" in result.lower()
+
+    def test_stable_dict_format(self):
+        result = _interpret_dung({"stable": {"set": ["s1"]}})
+        assert "1" in result
+
+    def test_no_extensions(self):
+        result = _interpret_dung({}, arguments=["a"])
+        assert "completee" in result.lower()
+
+    def test_multiple_extensions(self):
+        result = _interpret_dung(
+            {"grounded": ["a"], "preferred": ["a", "b"], "stable": ["a", "b", "c"]},
+            arguments=["a", "b", "c"],
+        )
+        assert "groundee" in result.lower() or "grounded" in result.lower()
+        assert "preferee" in result.lower()
+        assert "stable" in result.lower()
+
+
+class TestInterpretFOL:
+    def test_accepted(self):
+        result = _interpret_fol({
+            "accepted": True,
+            "query": "mortal(socrate)",
+            "message": "Proof found",
+        })
+        assert "acceptee" in result.lower()
+        assert "mortal(socrate)" in result
+
+    def test_rejected(self):
+        result = _interpret_fol({
+            "accepted": False,
+            "query": "immortal(socrate)",
+            "message": "No proof",
+        })
+        assert "pas acceptee" in result.lower()
+
+    def test_missing_fields(self):
+        result = _interpret_fol({})
+        assert result  # non-empty even with empty input
+
+    def test_result_field_fallback(self):
+        result = _interpret_fol({
+            "accepted": True,
+            "query": "p",
+            "result": "Derived",
+        })
+        assert "Derived" in result
+
+
+class TestInterpretAspic:
+    def test_with_rules_and_attacks(self):
+        result = _interpret_aspic({
+            "strict_rules": ["p => q"],
+            "defeasible_rules": ["r => s", "t => u"],
+            "attacks": [["a1", "a2"], ["a3", "a4"]],
+        })
+        assert "1" in result  # 1 strict rule
+        assert "2" in result  # 2 defeasible rules
+        assert "attaque" in result.lower()
+
+    def test_empty(self):
+        result = _interpret_aspic({})
+        assert "completee" in result.lower()
+
+    def test_only_strict(self):
+        result = _interpret_aspic({"strict_rules": ["a => b"]})
+        assert "1" in result
+
+    def test_only_attacks(self):
+        result = _interpret_aspic({"attacks": [["x", "y"]]})
+        assert "attaque" in result.lower()
+
+
+class TestInterpretRanking:
+    def test_with_scores(self):
+        result = _interpret_ranking({
+            "rankings": {"arg1": 0.9, "arg2": 0.5, "arg3": 0.3},
+        })
+        assert "arg1" in result
+        assert "0.9" in result
+
+    def test_with_list_rankings(self):
+        result = _interpret_ranking({"rankings": [0.8, 0.6, 0.4]})
+        assert result  # non-empty
+
+    def test_empty(self):
+        result = _interpret_ranking({})
+        assert "complete" in result.lower()
+
+    def test_scores_field(self):
+        result = _interpret_ranking({"scores": {"a": 5, "b": 3}})
+        assert "a" in result
+
+
+class TestInterpretBeliefRevision:
+    def test_all_operations(self):
+        result = _interpret_belief_revision({
+            "removed_beliefs": ["b1"],
+            "added_beliefs": ["b2", "b3"],
+            "revised_beliefs": ["b4"],
+        })
+        assert "1" in result  # removed
+        assert "2" in result  # added
+        assert "1" in result  # revised
+
+    def test_no_changes(self):
+        result = _interpret_belief_revision({})
+        assert "aucune" in result.lower()
+
+    def test_only_removed(self):
+        result = _interpret_belief_revision({"removed_beliefs": ["x"]})
+        assert "retiree" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test: Plugin @kernel_function methods
+# ---------------------------------------------------------------------------
+
+
+class TestPluginDungResults:
+    def test_interpret_dung_results(self):
+        plugin = TweetyResultInterpretationPlugin()
+        input_json = json.dumps({
+            "extensions": {"grounded": ["a", "b"], "stable": ["a", "b", "c"]},
+            "arguments": ["a", "b", "c"],
+        })
+        result = plugin.interpret_dung_results(input_json)
+        assert "groundee" in result.lower() or "grounded" in result.lower()
+        assert "stable" in result.lower()
+
+    def test_bad_json(self):
+        plugin = TweetyResultInterpretationPlugin()
+        result = plugin.interpret_dung_results("not json")
+        assert "invalide" in result.lower()
+
+
+class TestPluginFOLResults:
+    def test_interpret_fol_results(self):
+        plugin = TweetyResultInterpretationPlugin()
+        input_json = json.dumps({
+            "accepted": True,
+            "query": "p(X)",
+            "message": "Proved",
+        })
+        result = plugin.interpret_fol_results(input_json)
+        assert "acceptee" in result.lower()
+
+    def test_bad_json(self):
+        plugin = TweetyResultInterpretationPlugin()
+        result = plugin.interpret_fol_results("{bad")
+        assert "invalide" in result.lower()
+
+
+class TestPluginASPICResults:
+    def test_interpret_aspic_results(self):
+        plugin = TweetyResultInterpretationPlugin()
+        input_json = json.dumps({
+            "strict_rules": ["p => q"],
+            "defeasible_rules": ["r => s"],
+            "attacks": [["a1", "a2"]],
+        })
+        result = plugin.interpret_aspic_results(input_json)
+        assert "1" in result
+        assert "attaque" in result.lower()
+
+    def test_bad_json(self):
+        plugin = TweetyResultInterpretationPlugin()
+        result = plugin.interpret_aspic_results("bad")
+        assert "invalide" in result.lower()
+
+
+class TestPluginRankingResults:
+    def test_interpret_ranking_results(self):
+        plugin = TweetyResultInterpretationPlugin()
+        input_json = json.dumps({"rankings": {"x": 0.9, "y": 0.5}})
+        result = plugin.interpret_ranking_results(input_json)
+        assert "x" in result
+
+    def test_bad_json(self):
+        plugin = TweetyResultInterpretationPlugin()
+        result = plugin.interpret_ranking_results("x")
+        assert "invalide" in result.lower()
+
+
+class TestPluginBeliefRevisionResults:
+    def test_interpret_belief_revision_results(self):
+        plugin = TweetyResultInterpretationPlugin()
+        input_json = json.dumps({
+            "removed_beliefs": ["b1"],
+            "added_beliefs": ["b2"],
+        })
+        result = plugin.interpret_belief_revision_results(input_json)
+        assert "retiree" in result.lower()
+        assert "ajoutee" in result.lower()
+
+    def test_bad_json(self):
+        plugin = TweetyResultInterpretationPlugin()
+        result = plugin.interpret_belief_revision_results("bad")
+        assert "invalide" in result.lower()
+
+
+class TestPluginFullAnalysis:
+    def test_full_analysis_all_sections(self):
+        plugin = TweetyResultInterpretationPlugin()
+        input_json = json.dumps({
+            "dung": {
+                "extensions": {"grounded": ["a"]},
+                "arguments": ["a"],
+            },
+            "fol": {"accepted": True, "query": "p", "message": "OK"},
+            "aspic": {"strict_rules": ["p => q"], "defeasible_rules": [], "attacks": []},
+            "ranking": {"rankings": {"x": 0.8}},
+            "belief_revision": {"removed_beliefs": ["b1"], "added_beliefs": [], "revised_beliefs": []},
+        })
+        result = plugin.interpret_full_analysis(input_json)
+        assert "**Analyse Dung**" in result
+        assert "**Raisonnement FOL**" in result
+        assert "**Analyse ASPIC+**" in result
+        assert "**Classement**" in result
+        assert "**Revision des croyances**" in result
+
+    def test_full_analysis_partial(self):
+        plugin = TweetyResultInterpretationPlugin()
+        input_json = json.dumps({
+            "dung": {"extensions": {}, "arguments": ["a"]},
+            "fol": {"accepted": False, "query": "q", "message": "No proof"},
+        })
+        result = plugin.interpret_full_analysis(input_json)
+        assert "**Analyse Dung**" in result
+        assert "**Raisonnement FOL**" in result
+        assert "ASPIC" not in result
+
+    def test_full_analysis_empty(self):
+        plugin = TweetyResultInterpretationPlugin()
+        result = plugin.interpret_full_analysis(json.dumps({}))
+        assert "aucun" in result.lower()
+
+    def test_full_analysis_bad_json(self):
+        plugin = TweetyResultInterpretationPlugin()
+        result = plugin.interpret_full_analysis("bad")
+        assert "invalide" in result.lower()
+
+
+class TestPluginWriteToState:
+    def test_writes_via_add_extract(self):
+        plugin = TweetyResultInterpretationPlugin()
+        state = MagicMock()
+        input_json = json.dumps({
+            "interpretation": "Dung analysis found 3 accepted arguments.",
+        })
+        result_json = plugin.write_interpretation_to_state(input_json, state=state)
+        result = json.loads(result_json)
+        assert result["written"] is True
+        state.add_extract.assert_called_once_with(
+            "formal_interpretation",
+            "Dung analysis found 3 accepted arguments.",
+        )
+
+    def test_no_state(self):
+        plugin = TweetyResultInterpretationPlugin()
+        result_json = plugin.write_interpretation_to_state("{}", state=None)
+        result = json.loads(result_json)
+        assert "error" in result
+
+    def test_empty_interpretation(self):
+        plugin = TweetyResultInterpretationPlugin()
+        state = MagicMock()
+        result_json = plugin.write_interpretation_to_state(
+            json.dumps({"interpretation": ""}), state=state
+        )
+        result = json.loads(result_json)
+        assert "error" in result
+
+    def test_bad_json(self):
+        plugin = TweetyResultInterpretationPlugin()
+        state = MagicMock()
+        result_json = plugin.write_interpretation_to_state("bad", state=state)
+        result = json.loads(result_json)
+        assert "error" in result
+
+    def test_state_without_add_extract(self):
+        plugin = TweetyResultInterpretationPlugin()
+        state = MagicMock(spec=[])  # No methods at all
+        result_json = plugin.write_interpretation_to_state(
+            json.dumps({"interpretation": "test"}), state=state
+        )
+        result = json.loads(result_json)
+        assert result["written"] is False
+
+
+# ---------------------------------------------------------------------------
+# Test: Registry and factory integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIntegration:
+    def test_plugin_registered(self):
+        from argumentation_analysis.orchestration.registry_setup import setup_registry
+
+        registry = setup_registry(include_optional=False)
+        reg = registry._registrations.get("tweety_result_interpretation_plugin")
+        assert reg is not None
+        assert "formal_result_interpretation" in reg.capabilities
+        assert "dung_interpretation" in reg.capabilities
+
+
+class TestFactoryIntegration:
+    def test_formal_logic_has_interpretation(self):
+        from argumentation_analysis.agents.factory import AGENT_SPECIALITY_MAP
+
+        assert "tweety_interpretation" in AGENT_SPECIALITY_MAP["formal_logic"]
+
+    def test_plugin_registry_entry(self):
+        from argumentation_analysis.agents.factory import _PLUGIN_REGISTRY
+
+        assert "tweety_interpretation" in _PLUGIN_REGISTRY
+        module_path, class_name = _PLUGIN_REGISTRY["tweety_interpretation"]
+        assert "tweety_result_interpretation_plugin" in module_path
+        assert class_name == "TweetyResultInterpretationPlugin"


### PR DESCRIPTION
## Summary
- New `TweetyResultInterpretationPlugin` with 7 `@kernel_function` methods converting formal analysis results into French NL explanations
- Template-based interpreters (no LLM required) for Dung extensions, FOL queries, ASPIC attacks, ranking scores, and belief revisions
- `interpret_full_analysis` synthesizes all result types into multi-section NL report
- `write_interpretation_to_state` integrates with analysis state via `add_extract`
- Registered in `CapabilityRegistry` with 6 capabilities
- Added to `formal_logic` agent speciality in `AGENT_SPECIALITY_MAP`

## Test plan
- [x] 46 unit tests covering all interpreters, plugin methods, error handling, registry and factory integration
- [x] All tests pass locally (46 passed, 0 failed)
- [x] No pipeline regressions

Closes #476