### PR TITLE
feat(scripts): pre/post Epic G baseline comparison tools (#481)

### DIFF
--- a/scripts/compare_results.py
+++ b/scripts/compare_results.py
@@ -1,0 +1,221 @@
+"""Compare pre/post Epic G baseline results (#481).
+
+Reads JSON result files from analysis_kb/results/ and produces
+a markdown comparison report with aggregate metrics.
+
+Usage:
+    python analysis_kb/compare_results.py --pre doc_2 --post doc_2_epic_g
+    python analysis_kb/compare_results.py --all
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+RESULTS_DIR = Path("analysis_kb/results")
+REPORTS_DIR = Path("analysis_kb/reports")
+
+
+def load_result(name: str) -> Optional[Dict[str, Any]]:
+    path = RESULTS_DIR / f"{name}.json"
+    if not path.exists():
+        print(f"Warning: {path} not found", file=sys.stderr)
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def count_non_empty(data: Dict[str, Any]) -> int:
+    """Count non-empty top-level fields."""
+    return sum(
+        1
+        for v in data.values()
+        if v is not None and v != "" and v != [] and v != {} and v != 0
+    )
+
+
+def extract_metrics(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract comparable metrics from a result file."""
+    return {
+        "non_empty_fields": data.get("non_empty_fields", 0),
+        "total_fields": data.get("total_fields", 0),
+        "duration_seconds": data.get("duration_seconds", 0),
+        "phases_completed": data.get("phases_completed", "0/0"),
+        "phases_failed": data.get("phases_failed", 0),
+        "arguments_count": data.get("arguments_count", 0),
+        "fallacies_count": data.get("fallacies_count", 0),
+        "jtms_beliefs_count": data.get("jtms_beliefs_count", 0),
+        "formal_results_keys": data.get("formal_results_keys", []),
+        "counter_arguments_count": data.get("counter_arguments_count", 0),
+        "quality_scores": data.get("quality_scores", {}),
+        "debate_results_keys": data.get("debate_results_keys", []),
+        "governance_results_keys": data.get("governance_results_keys", []),
+        "state_json_size_bytes": data.get("state_json_size_bytes", 0),
+        "capabilities_used": data.get("capabilities_used", []),
+        "capabilities_missing": data.get("capabilities_missing", []),
+    }
+
+
+def compare_pair(
+    pre_name: str, post_name: str
+) -> Optional[Dict[str, Any]]:
+    """Compare pre/post results for a single document."""
+    pre = load_result(pre_name)
+    post = load_result(post_name)
+    if pre is None or post is None:
+        return None
+
+    pre_m = extract_metrics(pre)
+    post_m = extract_metrics(post)
+
+    # Calculate field coverage improvement
+    pre_coverage = pre_m["non_empty_fields"] / max(pre_m["total_fields"], 1) * 100
+    post_coverage = post_m["non_empty_fields"] / max(post_m["total_fields"], 1) * 100
+
+    # New capabilities gained
+    pre_caps = set(pre_m["capabilities_used"])
+    post_caps = set(post_m["capabilities_used"])
+    new_caps = post_caps - pre_caps
+
+    return {
+        "pre_name": pre_name,
+        "post_name": post_name,
+        "pre": pre_m,
+        "post": post_m,
+        "coverage_delta": round(post_coverage - pre_coverage, 1),
+        "new_capabilities": sorted(new_caps),
+        "formal_results_delta": len(post_m["formal_results_keys"])
+        - len(pre_m["formal_results_keys"]),
+    }
+
+
+def generate_report(
+    comparisons: List[Dict[str, Any]], title: str = "Epic G Pre/Post Comparison"
+) -> str:
+    """Generate markdown report from comparisons."""
+    lines = [
+        f"# {title}",
+        f"",
+        f"Generated: {datetime.now().isoformat()}",
+        f"Documents compared: {len(comparisons)}",
+        "",
+    ]
+
+    # Summary table
+    lines.append("## Summary")
+    lines.append("")
+    lines.append(
+        "| Document | Pre Coverage | Post Coverage | Delta | New Caps | Formal Keys Delta |"
+    )
+    lines.append(
+        "|----------|-------------|--------------|-------|----------|-------------------|"
+    )
+
+    for c in comparisons:
+        pre_cov = f'{c["pre"]["non_empty_fields"]}/{c["pre"]["total_fields"]}'
+        post_cov = f'{c["post"]["non_empty_fields"]}/{c["post"]["total_fields"]}'
+        lines.append(
+            f'| {c["pre_name"]} | {pre_cov} | {post_cov} | '
+            f'{c["coverage_delta"]:+.1f}% | {len(c["new_capabilities"])} | '
+            f'{c["formal_results_delta"]:+d} |'
+        )
+
+    lines.append("")
+
+    # Per-document detail
+    for c in comparisons:
+        lines.append(f"## {c['pre_name']}")
+        lines.append("")
+        lines.append("### Field Coverage")
+        lines.append(f"- Arguments: {c['pre']['arguments_count']} → {c['post']['arguments_count']}")
+        lines.append(f"- Fallacies: {c['pre']['fallacies_count']} → {c['post']['fallacies_count']}")
+        lines.append(f"- JTMS beliefs: {c['pre']['jtms_beliefs_count']} → {c['post']['jtms_beliefs_count']}")
+        lines.append(
+            f"- Counter-arguments: {c['pre']['counter_arguments_count']} → {c['post']['counter_arguments_count']}"
+        )
+        lines.append(
+            f"- Formal results: {c['pre']['formal_results_keys']} → {c['post']['formal_results_keys']}"
+        )
+        lines.append(
+            f"- State size: {c['pre']['state_json_size_bytes']}B → {c['post']['state_json_size_bytes']}B"
+        )
+        lines.append(
+            f"- Duration: {c['pre']['duration_seconds']:.1f}s → {c['post']['duration_seconds']:.1f}s"
+        )
+        lines.append("")
+
+        if c["new_capabilities"]:
+            lines.append("### New Capabilities")
+            for cap in c["new_capabilities"]:
+                lines.append(f"- `{cap}`")
+            lines.append("")
+
+        # Regression check
+        if c["coverage_delta"] < -10:
+            lines.append(
+                f"**WARNING: Regression detected ({c['coverage_delta']:.1f}%)**"
+            )
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Compare pre/post Epic G baselines")
+    parser.add_argument("--pre", nargs="+", help="Pre-result filenames (without .json)")
+    parser.add_argument("--post", nargs="+", help="Post-result filenames (without .json)")
+    parser.add_argument("--all", action="store_true", help="Compare all doc_*_pipeline_full vs doc_*_epic_g_full")
+    parser.add_argument("--output", default=None, help="Output file (default: stdout)")
+    args = parser.parse_args()
+
+    comparisons = []
+
+    if args.all:
+        # Find pre/post pairs
+        pre_files = sorted(RESULTS_DIR.glob("doc_*_pipeline_full.json"))
+        for pre_path in pre_files:
+            pre_name = pre_path.stem
+            # Derive post name
+            post_name = pre_name.replace("_pipeline_full", "_epic_g_full")
+            c = compare_pair(pre_name, post_name)
+            if c:
+                comparisons.append(c)
+    elif args.pre and args.post:
+        for pre_name, post_name in zip(args.pre, args.post):
+            c = compare_pair(pre_name, post_name)
+            if c:
+                comparisons.append(c)
+    else:
+        # Default: compare all existing results
+        for f in sorted(RESULTS_DIR.glob("doc_*_pipeline_full.json")):
+            name = f.stem
+            pre_m = extract_metrics(load_result(name))
+            empty_m = {"non_empty_fields": 0, "total_fields": 0, "duration_seconds": 0,
+                        "phases_completed": "0/0", "phases_failed": 0, "arguments_count": 0,
+                        "fallacies_count": 0, "jtms_beliefs_count": 0, "formal_results_keys": [],
+                        "counter_arguments_count": 0, "quality_scores": {},
+                        "debate_results_keys": [], "governance_results_keys": [],
+                        "state_json_size_bytes": 0, "capabilities_used": [],
+                        "capabilities_missing": []}
+            c = {"pre_name": name, "post_name": "(pending)", "pre": pre_m,
+                 "post": empty_m, "coverage_delta": 0, "new_capabilities": [],
+                 "formal_results_delta": 0}
+            comparisons.append(c)
+
+    report = generate_report(comparisons)
+
+    if args.output:
+        REPORTS_DIR.mkdir(parents=True, exist_ok=True)
+        out_path = REPORTS_DIR / args.output
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(report)
+        print(f"Report written to {out_path}")
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_epic_g_baselines.py
+++ b/scripts/run_epic_g_baselines.py
@@ -1,0 +1,222 @@
+"""Run Epic G baselines on 3 opaque documents (#481).
+
+Runs the spectacular and formal_extended workflows on selected documents
+and saves results to analysis_kb/results/.
+
+Usage:
+    python analysis_kb/run_epic_g_baselines.py --workflow spectacular
+    python analysis_kb/run_epic_g_baselines.py --workflow formal_extended
+    python analysis_kb/run_epic_g_baselines.py --all
+
+Note: Requires OPENAI_API_KEY in .env and the encrypted dataset passphrase.
+      This script is gitignored — results contain aggregate metrics only.
+"""
+
+import argparse
+import json
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Add project root to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+RESULTS_DIR = Path("analysis_kb/results")
+RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+# 3 opaque documents from the encrypted dataset
+DOC_IDS = ["src0_ext0", "src3_ext0", "src6_ext0"]
+
+
+def load_document_text(doc_id: str) -> Optional[str]:
+    """Load document text from the encrypted dataset."""
+    try:
+        from argumentation_analysis.core.io_manager import load_extract_definitions
+        from argumentation_analysis.core.environment import get_text_config_passphrase
+
+        passphrase = get_text_config_passphrase()
+        if not passphrase:
+            print(f"Warning: No passphrase available for dataset", file=sys.stderr)
+            return None
+
+        definitions = load_extract_definitions(passphrase)
+        for source in definitions:
+            for extract in source.get("extracts", []):
+                if extract.get("id") == doc_id or f"src{definitions.index(source)}_ext{source.get('extracts', []).index(extract)}" == doc_id:
+                    return extract.get("full_text", "")
+        print(f"Warning: Document '{doc_id}' not found in dataset", file=sys.stderr)
+        return None
+    except Exception as e:
+        print(f"Error loading dataset: {e}", file=sys.stderr)
+        return None
+
+
+def run_workflow_on_text(
+    text: str, doc_id: str, workflow_name: str
+) -> Dict[str, Any]:
+    """Run a workflow on text and return metrics."""
+    try:
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            UnifiedPipeline,
+        )
+
+        pipeline = UnifiedPipeline()
+        registry = pipeline.registry
+
+        from argumentation_analysis.orchestration.workflows import get_workflow_catalog
+        catalog = get_workflow_catalog()
+
+        if workflow_name not in catalog:
+            print(f"Workflow '{workflow_name}' not in catalog. Available: {list(catalog.keys())}", file=sys.stderr)
+            return {"error": f"Workflow '{workflow_name}' not found"}
+
+        start = time.time()
+        result = pipeline.run_workflow(workflow_name, text)
+        duration = time.time() - start
+
+        # Extract metrics from result
+        state = result.get("state")
+        if state is not None:
+            metrics = extract_state_metrics(state)
+        else:
+            metrics = {"error": "No state returned"}
+
+        metrics.update({
+            "document": doc_id,
+            "mode": "pipeline",
+            "workflow": workflow_name,
+            "duration_seconds": round(duration, 1),
+            "timestamp": datetime.now().isoformat(),
+        })
+        return metrics
+
+    except Exception as e:
+        return {
+            "document": doc_id,
+            "mode": "pipeline",
+            "workflow": workflow_name,
+            "error": str(e),
+            "timestamp": datetime.now().isoformat(),
+        }
+
+
+def extract_state_metrics(state: Any) -> Dict[str, Any]:
+    """Extract aggregate metrics from a UnifiedAnalysisState."""
+    metrics = {
+        "non_empty_fields": 0,
+        "total_fields": 0,
+        "arguments_count": 0,
+        "fallacies_count": 0,
+        "jtms_beliefs_count": 0,
+        "formal_results_keys": [],
+        "counter_arguments_count": 0,
+        "quality_scores": {},
+        "debate_results_keys": [],
+        "governance_results_keys": [],
+        "state_json_size_bytes": 0,
+        "capabilities_used": [],
+        "capabilities_missing": [],
+    }
+
+    try:
+        # Count non-empty fields
+        if hasattr(state, "to_dict"):
+            d = state.to_dict()
+        elif hasattr(state, "__dict__"):
+            d = {k: v for k, v in state.__dict__.items() if not k.startswith("_")}
+        else:
+            d = {}
+
+        metrics["total_fields"] = len(d)
+        metrics["non_empty_fields"] = sum(
+            1 for v in d.values()
+            if v is not None and v != "" and v != [] and v != {}
+        )
+        metrics["state_json_size_bytes"] = len(json.dumps(d, default=str))
+
+        # Specific counts
+        if hasattr(state, "arguments"):
+            metrics["arguments_count"] = len(state.arguments) if state.arguments else 0
+        if hasattr(state, "fallacies"):
+            metrics["fallacies_count"] = len(state.fallacies) if state.fallacies else 0
+        if hasattr(state, "jtms_beliefs"):
+            metrics["jtms_beliefs_count"] = len(state.jtms_beliefs) if state.jtms_beliefs else 0
+        if hasattr(state, "formal_results"):
+            metrics["formal_results_keys"] = list(state.formal_results.keys()) if state.formal_results else []
+        if hasattr(state, "counter_arguments"):
+            metrics["counter_arguments_count"] = len(state.counter_arguments) if state.counter_arguments else 0
+        if hasattr(state, "quality_scores"):
+            metrics["quality_scores"] = state.quality_scores if state.quality_scores else {}
+        if hasattr(state, "debate_results"):
+            metrics["debate_results_keys"] = list(state.debate_results.keys()) if state.debate_results else []
+        if hasattr(state, "governance_results"):
+            metrics["governance_results_keys"] = list(state.governance_results.keys()) if state.governance_results else []
+
+    except Exception as e:
+        metrics["extraction_error"] = str(e)
+
+    return metrics
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run Epic G baselines")
+    parser.add_argument(
+        "--workflow",
+        default="spectacular",
+        help="Workflow to run (default: spectacular)",
+    )
+    parser.add_argument(
+        "--docs",
+        nargs="+",
+        default=DOC_IDS,
+        help=f"Document IDs to analyze (default: {DOC_IDS})",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Run both spectacular and formal_extended workflows",
+    )
+    args = parser.parse_args()
+
+    workflows = [args.workflow]
+    if args.all:
+        workflows = ["spectacular", "formal_extended"]
+
+    for workflow_name in workflows:
+        print(f"\n{'='*60}")
+        print(f"Running workflow: {workflow_name}")
+        print(f"Documents: {args.docs}")
+        print(f"{'='*60}\n")
+
+        for doc_id in args.docs:
+            print(f"Loading {doc_id}...", end=" ")
+            text = load_document_text(doc_id)
+            if not text:
+                print("SKIP (not found)")
+                continue
+            print(f"({len(text)} chars)")
+
+            print(f"Running {workflow_name} on {doc_id}...", end=" ", flush=True)
+            result = run_workflow_on_text(text, doc_id, workflow_name)
+
+            if "error" in result:
+                print(f"ERROR: {result['error']}")
+            else:
+                print(
+                    f"OK ({result.get('duration_seconds', 0):.1f}s, "
+                    f"{result.get('non_empty_fields', 0)}/{result.get('total_fields', 0)} fields)"
+                )
+
+            # Save result
+            suffix = "epic_g" if workflow_name == "spectacular" else workflow_name
+            out_name = f"{doc_id}_{suffix}.json"
+            out_path = RESULTS_DIR / out_name
+            with open(out_path, "w", encoding="utf-8") as f:
+                json.dump(result, f, indent=2, default=str, ensure_ascii=False)
+            print(f"  Saved to {out_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **compare_results.py**: Reads JSON result files and produces markdown comparison report with aggregate metrics (field coverage, capabilities, duration, formal results keys)
- **run_epic_g_baselines.py**: Orchestrator to run spectacular/formal_extended workflows on 3 opaque docs (src0_ext0, src3_ext0, src6_ext0)
- **Pre-baseline captured** from existing results (2026-04-05): 12-15/34 field coverage, no formal results
- **Post-baseline pending** — run after all Epic G PRs are merged

Closes #481

## Test plan

- [x] `compare_results.py` runs and produces markdown output from existing baseline results
- [x] `run_epic_g_baselines.py` syntax valid and imports correctly
- [x] Privacy: reports contain only aggregate metrics with opaque IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)