### PR TITLE
fix(plugins): LogicAgentPlugin with real FOL/Modal validation (#477)

### DIFF
--- a/argumentation_analysis/agents/factory.py
+++ b/argumentation_analysis/agents/factory.py
@@ -55,13 +55,14 @@ AGENT_SPECIALITY_MAP = {
         "ranking",
         "aspic",
         "belief_revision",
+        "logic_agents",
     ],
     "quality": ["quality_scoring"],
     "debate": ["debate"],
     "counter_argument": ["counter_argument"],
     "governance": ["governance"],
     "sherlock": [],  # Sherlock uses its own investigation tools
-    "watson": ["tweety_logic"],
+    "watson": ["tweety_logic", "logic_agents"],
 }
 
 # Registry of plugin name → (module_path, class_name) for lazy loading
@@ -118,6 +119,11 @@ _PLUGIN_REGISTRY = {
     "belief_revision": (
         "argumentation_analysis.plugins.belief_revision_plugin",
         "BeliefRevisionPlugin",
+    ),
+    # PL/FOL/Modal logic operations (#477)
+    "logic_agents": (
+        "argumentation_analysis.plugins.logic_agent_plugin",
+        "LogicAgentPlugin",
     ),
     "narrative_synthesis": (
         "argumentation_analysis.plugins.narrative_synthesis_plugin",

--- a/argumentation_analysis/core/state_manager_plugin.py
+++ b/argumentation_analysis/core/state_manager_plugin.py
@@ -674,9 +674,7 @@ class StateManagerPlugin:
         self, arg_id: str, scores_json: str, overall: str = "0.5"
     ) -> str:
         try:
-            scores = (
-                json.loads(scores_json) if isinstance(scores_json, str) else scores_json
-            )
+            scores = json.loads(scores_json) if isinstance(scores_json, str) else scores_json
             self._state.add_quality_score(arg_id, scores, float(overall))
             return f"OK: Quality scores added for {arg_id}"
         except Exception as e:
@@ -696,9 +694,7 @@ class StateManagerPlugin:
         try:
             arguments = json.loads(arguments_json)
             attacks = json.loads(attacks_json)
-            extensions = (
-                json.loads(extensions_json) if extensions_json != "{}" else None
-            )
+            extensions = json.loads(extensions_json) if extensions_json != "{}" else None
             df_id = self._state.add_dung_framework(name, arguments, attacks, extensions)
             return df_id
         except Exception as e:

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -312,6 +312,29 @@ def setup_registry(
     except ImportError as e:
         skipped.append(("tweety_logic_plugin", str(e)))
 
+    # --- LogicAgentPlugin: PL/FOL/Modal @kernel_function methods (#477) ---
+    try:
+        from argumentation_analysis.plugins.logic_agent_plugin import LogicAgentPlugin
+
+        registry.register_plugin(
+            name="logic_agent_plugin",
+            plugin_class=LogicAgentPlugin,
+            capabilities=[
+                "propositional_reasoning",
+                "first_order_reasoning",
+                "modal_reasoning",
+            ],
+            metadata={
+                "description": (
+                    "SK plugin exposing PL/FOL/Modal logic operations as "
+                    "@kernel_function methods for LLM agents (#477)"
+                )
+            },
+        )
+        registered.append("logic_agent_plugin")
+    except ImportError as e:
+        skipped.append(("logic_agent_plugin", str(e)))
+
     # --- Logic agent capabilities (#71 Formal Verification) ---
     logic_capabilities = [
         (

--- a/argumentation_analysis/plugins/logic_agent_plugin.py
+++ b/argumentation_analysis/plugins/logic_agent_plugin.py
@@ -1,0 +1,352 @@
+"""Logic Agent SK Plugin — exposes PL/FOL/Modal agent methods as @kernel_function.
+
+Wraps the three logic agents (PropositionalLogicAgent, FOLLogicAgent,
+ModalLogicAgent) so that LLM agents in AgentGroupChat can call core
+logic operations as tools: parse formulas, execute queries, validate,
+check consistency, and translate text to belief sets.
+
+Issue #477: Decorate PL/FOL/Modal logic agents with @kernel_function.
+"""
+
+import json
+import logging
+from typing import Optional
+
+from semantic_kernel.functions import kernel_function
+
+logger = logging.getLogger(__name__)
+
+
+def _jvm_available() -> bool:
+    """Check if JVM/TweetyBridge is available."""
+    try:
+        from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
+        return TweetyBridge.get_instance().is_jvm_ready()
+    except Exception:
+        return False
+
+
+def _error_json(msg: str) -> str:
+    return json.dumps({"error": msg})
+
+
+class LogicAgentPlugin:
+    """Semantic Kernel plugin exposing PL/FOL/Modal logic operations.
+
+    Provides @kernel_function methods for:
+    1. Parsing and validating formulas in each logic type
+    2. Executing queries against belief sets
+    3. Checking consistency of belief sets
+    4. Translating natural language to formal belief sets (LLM-required)
+
+    Usage:
+        kernel.add_plugin(LogicAgentPlugin(), plugin_name="logic_agents")
+    """
+
+    # --- Propositional Logic (PL) ---
+
+    @kernel_function(
+        name="parse_pl_formula",
+        description=(
+            "Analyser et valider une formule de logique propositionnelle. "
+            "Vérifie la syntaxe via TweetyProject. "
+            "Entrée: formule PL (ex: 'a => b', '!(p && q)'). "
+            "Retourne JSON: {'is_valid', 'formula', 'error'}."
+        ),
+    )
+    def parse_pl_formula(self, formula: str) -> str:
+        """Validate a propositional logic formula syntax."""
+        if not _jvm_available():
+            return _error_json("JVM/Tweety non disponible")
+
+        try:
+            from argumentation_analysis.agents.core.logic.tweety_bridge import (
+                TweetyBridge,
+            )
+
+            bridge = TweetyBridge.get_instance()
+            is_valid = bridge.validate_pl_formula(formula)
+            return json.dumps(
+                {"is_valid": is_valid, "formula": formula, "error": None}
+            )
+        except Exception as e:
+            return _error_json(str(e))
+
+    @kernel_function(
+        name="execute_pl_query",
+        description=(
+            "Exécuter une requête PL sur un ensemble de croyances. "
+            "Entrée: JSON {'belief_set': 'a => b\\nb', 'query': 'b'}. "
+            "Retourne JSON: {'result', 'query', 'belief_set', 'accepted'}."
+        ),
+    )
+    def execute_pl_query(self, payload: str) -> str:
+        """Execute a propositional logic query against a belief set."""
+        if not _jvm_available():
+            return _error_json("JVM/Tweety non disponible")
+
+        try:
+            params = json.loads(payload) if isinstance(payload, str) else payload
+            belief_set = params.get("belief_set", "")
+            query = params.get("query", "")
+
+            from argumentation_analysis.agents.core.logic.tweety_bridge import (
+                TweetyBridge,
+            )
+
+            bridge = TweetyBridge.get_instance()
+            accepted, message = bridge.execute_pl_query(belief_set, query)
+            return json.dumps(
+                {
+                    "result": message,
+                    "query": query,
+                    "belief_set": belief_set[:200],
+                    "truncated": len(belief_set) > 200,
+                    "accepted": accepted,
+                }
+            )
+        except Exception as e:
+            return _error_json(str(e))
+
+    @kernel_function(
+        name="check_pl_consistency",
+        description=(
+            "Vérifier la cohérence d'un ensemble de croyances propositionnelles. "
+            "Entrée: ensemble de croyances PL (formules séparées par \\n). "
+            "Retourne JSON: {'is_consistent', 'belief_set', 'message'}."
+        ),
+    )
+    def check_pl_consistency(self, belief_set: str) -> str:
+        """Check consistency of a propositional belief set."""
+        if not _jvm_available():
+            return _error_json("JVM/Tweety non disponible")
+
+        try:
+            from argumentation_analysis.agents.core.logic.tweety_bridge import (
+                TweetyBridge,
+            )
+
+            bridge = TweetyBridge.get_instance()
+            is_consistent, message = bridge.check_consistency(
+                belief_set, logic_type="propositional"
+            )
+            return json.dumps(
+                {
+                    "is_consistent": is_consistent,
+                    "belief_set": belief_set[:200],
+                    "truncated": len(belief_set) > 200,
+                    "message": message,
+                }
+            )
+        except Exception as e:
+            return _error_json(str(e))
+
+    # --- First-Order Logic (FOL) ---
+
+    @kernel_function(
+        name="execute_fol_query",
+        description=(
+            "Exécuter une requête FOL sur un ensemble de croyances. "
+            "Entrée: JSON {'belief_set': 'forall X: (p(X) => q(X))\\nexists Y: p(Y)', "
+            "'query': 'exists Z: q(Z)'}. "
+            "Retourne JSON: {'result', 'query', 'accepted'}."
+        ),
+    )
+    def execute_fol_query(self, payload: str) -> str:
+        """Execute a first-order logic query against a belief set."""
+        if not _jvm_available():
+            return _error_json("JVM/Tweety non disponible")
+
+        try:
+            params = json.loads(payload) if isinstance(payload, str) else payload
+            belief_set = params.get("belief_set", "")
+            query = params.get("query", "")
+
+            from argumentation_analysis.agents.core.logic.tweety_bridge import (
+                TweetyBridge,
+            )
+
+            bridge = TweetyBridge.get_instance()
+            accepted, message = bridge.execute_fol_query(belief_set, query)
+            return json.dumps(
+                {
+                    "result": message,
+                    "query": query,
+                    "belief_set": belief_set[:200],
+                    "truncated": len(belief_set) > 200,
+                    "accepted": accepted,
+                }
+            )
+        except Exception as e:
+            return _error_json(str(e))
+
+    @kernel_function(
+        name="check_fol_consistency",
+        description=(
+            "Vérifier la cohérence d'un ensemble de croyances FOL. "
+            "Entrée: ensemble de croyances FOL. "
+            "Retourne JSON: {'is_consistent', 'message'}."
+        ),
+    )
+    def check_fol_consistency(self, belief_set: str) -> str:
+        """Check consistency of a FOL belief set."""
+        if not _jvm_available():
+            return _error_json("JVM/Tweety non disponible")
+
+        try:
+            from argumentation_analysis.agents.core.logic.tweety_bridge import (
+                TweetyBridge,
+            )
+
+            bridge = TweetyBridge.get_instance()
+            is_consistent, message = bridge.check_consistency(
+                belief_set, logic_type="fol"
+            )
+            return json.dumps(
+                {
+                    "is_consistent": is_consistent,
+                    "belief_set": belief_set[:200],
+                    "truncated": len(belief_set) > 200,
+                    "message": message,
+                }
+            )
+        except Exception as e:
+            return _error_json(str(e))
+
+    # --- Modal Logic ---
+
+    @kernel_function(
+        name="execute_modal_query",
+        description=(
+            "Exécuter une requête modale sur un ensemble de croyances. "
+            "Entrée: JSON {'belief_set': 'constant a\\nconstant b\\n[](a => b)', "
+            "'query': '[](a)', 'logic_type': 'K'}. "
+            "Types de logique: K, T, S5. "
+            "Retourne JSON: {'result', 'query', 'accepted'}."
+        ),
+    )
+    def execute_modal_query(self, payload: str) -> str:
+        """Execute a modal logic query against a belief set."""
+        if not _jvm_available():
+            return _error_json("JVM/Tweety non disponible")
+
+        try:
+            params = json.loads(payload) if isinstance(payload, str) else payload
+            belief_set = params.get("belief_set", "")
+            query = params.get("query", "")
+            logic_type = params.get("logic_type", "K")
+
+            from argumentation_analysis.agents.core.logic.tweety_bridge import (
+                TweetyBridge,
+            )
+
+            bridge = TweetyBridge.get_instance()
+            accepted, message = bridge.execute_modal_query(
+                belief_set, query, logic_type=logic_type
+            )
+            return json.dumps(
+                {
+                    "result": message,
+                    "query": query,
+                    "belief_set": belief_set[:200],
+                    "truncated": len(belief_set) > 200,
+                    "accepted": accepted,
+                    "logic_type": logic_type,
+                }
+            )
+        except Exception as e:
+            return _error_json(str(e))
+
+    @kernel_function(
+        name="check_modal_consistency",
+        description=(
+            "Vérifier la cohérence d'un ensemble de croyances modales. "
+            "Entrée: JSON {'belief_set': '...formulas...', 'logic_type': 'K'}. "
+            "Retourne JSON: {'is_consistent', 'message'}."
+        ),
+    )
+    def check_modal_consistency(self, payload: str) -> str:
+        """Check consistency of a modal belief set."""
+        if not _jvm_available():
+            return _error_json("JVM/Tweety non disponible")
+
+        try:
+            params = json.loads(payload) if isinstance(payload, str) else payload
+            belief_set = params.get("belief_set", "")
+            logic_type = params.get("logic_type", "K")
+
+            from argumentation_analysis.agents.core.logic.tweety_bridge import (
+                TweetyBridge,
+            )
+
+            bridge = TweetyBridge.get_instance()
+            is_consistent, message = bridge.check_consistency(
+                belief_set, logic_type=f"modal_{logic_type.lower()}"
+            )
+            return json.dumps(
+                {
+                    "is_consistent": is_consistent,
+                    "belief_set": belief_set[:200],
+                    "truncated": len(belief_set) > 200,
+                    "message": message,
+                    "logic_type": logic_type,
+                }
+            )
+        except Exception as e:
+            return _error_json(str(e))
+
+    # --- Cross-logic utilities ---
+
+    @kernel_function(
+        name="validate_formula",
+        description=(
+            "Valider la syntaxe d'une formule logique. "
+            "Entrée: JSON {'formula': 'a => b', 'logic_type': 'propositional'}. "
+            "Types: 'propositional', 'fol', 'modal'. "
+            "Retourne JSON: {'is_valid', 'formula', 'logic_type'}."
+        ),
+    )
+    def validate_formula(self, payload: str) -> str:
+        """Validate a formula's syntax for the given logic type."""
+        if not _jvm_available():
+            return _error_json("JVM/Tweety non disponible")
+
+        try:
+            params = json.loads(payload) if isinstance(payload, str) else payload
+            formula = params.get("formula", "")
+            logic_type = params.get("logic_type", "propositional")
+
+            from argumentation_analysis.agents.core.logic.tweety_bridge import (
+                TweetyBridge,
+            )
+
+            bridge = TweetyBridge.get_instance()
+
+            if logic_type == "propositional":
+                is_valid = bridge.validate_pl_formula(formula)
+            elif logic_type == "fol":
+                is_valid, _ = bridge.check_consistency(formula, logic_type="fol")
+            elif logic_type == "modal":
+                is_valid, _ = bridge.check_consistency(
+                    formula, logic_type="modal_k"
+                )
+            else:
+                return _error_json(f"Unknown logic_type: {logic_type}")
+
+            return json.dumps(
+                {
+                    "is_valid": is_valid,
+                    "formula": formula,
+                    "logic_type": logic_type,
+                }
+            )
+        except Exception as e:
+            return json.dumps(
+                {
+                    "is_valid": False,
+                    "formula": params.get("formula", ""),
+                    "logic_type": params.get("logic_type", "propositional"),
+                    "error": str(e),
+                }
+            )

--- a/tests/unit/argumentation_analysis/plugins/test_logic_agent_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_logic_agent_plugin.py
@@ -1,0 +1,487 @@
+"""Tests for LogicAgentPlugin — PL/FOL/Modal @kernel_function methods (#477).
+
+Validates:
+- All 8 @kernel_function methods are registered and callable
+- JVM-unavailable path returns proper error JSON
+- Each method delegates to TweetyBridge correctly
+- Input parsing (JSON strings) works for multi-param methods
+- Registry registration in setup_registry
+- AGENT_SPECIALITY_MAP includes logic_agents
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_bridge(**kwargs):
+    """Create a mock TweetyBridge instance with default returns."""
+    bridge = MagicMock()
+    bridge.validate_pl_formula.return_value = kwargs.get("validate_pl", True)
+    bridge.execute_pl_query.return_value = (
+        kwargs.get("pl_accepted", True),
+        kwargs.get("pl_message", "Query accepted"),
+    )
+    bridge.execute_fol_query.return_value = (
+        kwargs.get("fol_accepted", True),
+        kwargs.get("fol_message", "FOL query accepted"),
+    )
+    bridge.execute_modal_query.return_value = (
+        kwargs.get("modal_accepted", True),
+        kwargs.get("modal_message", "Modal query accepted"),
+    )
+    bridge.check_consistency.return_value = (
+        kwargs.get("consistent", True),
+        kwargs.get("consistency_msg", "Consistent"),
+    )
+    return bridge
+
+
+def _patch_jvm_available(value: bool):
+    """Return a patch context for _jvm_available."""
+    return patch(
+        "argumentation_analysis.plugins.logic_agent_plugin._jvm_available",
+        return_value=value,
+    )
+
+
+def _patch_tweety_bridge(bridge_mock):
+    """Return a patch that makes TweetyBridge.get_instance() return bridge_mock.
+
+    TweetyBridge is imported locally inside each method body
+    (``from ... import TweetyBridge``), so we must patch the source module's
+    attribute rather than the plugin module.
+    """
+    mock_cls = MagicMock()
+    mock_cls.get_instance.return_value = bridge_mock
+    return patch(
+        "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
+        mock_cls,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test: kernel_function registration
+# ---------------------------------------------------------------------------
+
+
+class TestKernelFunctionRegistration:
+    """Verify all methods are decorated and discoverable."""
+
+    def test_plugin_has_8_kernel_functions(self):
+        from argumentation_analysis.plugins.logic_agent_plugin import LogicAgentPlugin
+
+        plugin = LogicAgentPlugin()
+        methods = [
+            m for m in dir(plugin)
+            if not m.startswith("_") and callable(getattr(plugin, m))
+        ]
+        expected = {
+            "parse_pl_formula",
+            "execute_pl_query",
+            "check_pl_consistency",
+            "execute_fol_query",
+            "check_fol_consistency",
+            "execute_modal_query",
+            "check_modal_consistency",
+            "validate_formula",
+        }
+        assert expected.issubset(set(methods))
+
+    def test_methods_have_kernel_function_decorator(self):
+        from argumentation_analysis.plugins.logic_agent_plugin import LogicAgentPlugin
+
+        plugin = LogicAgentPlugin()
+        # SK stores metadata on the function object
+        for method_name in [
+            "parse_pl_formula",
+            "execute_pl_query",
+            "check_pl_consistency",
+            "execute_fol_query",
+            "check_fol_consistency",
+            "execute_modal_query",
+            "check_modal_consistency",
+            "validate_formula",
+        ]:
+            func = getattr(plugin, method_name)
+            # @kernel_function adds __kernel_function__ metadata
+            assert hasattr(func, "__kernel_function__"), (
+                f"{method_name} missing @kernel_function decorator"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test: JVM-unavailable path
+# ---------------------------------------------------------------------------
+
+
+class TestJVMUnavailable:
+    """All methods should return error JSON when JVM is down."""
+
+    @pytest.fixture()
+    def plugin(self):
+        from argumentation_analysis.plugins.logic_agent_plugin import LogicAgentPlugin
+        return LogicAgentPlugin()
+
+    def test_parse_pl_formula_no_jvm(self, plugin):
+        with _patch_jvm_available(False):
+            result = json.loads(plugin.parse_pl_formula("a => b"))
+        assert "error" in result
+        assert "JVM" in result["error"]
+
+    def test_execute_pl_query_no_jvm(self, plugin):
+        with _patch_jvm_available(False):
+            result = json.loads(
+                plugin.execute_pl_query('{"belief_set":"a","query":"a"}')
+            )
+        assert "error" in result
+
+    def test_check_pl_consistency_no_jvm(self, plugin):
+        with _patch_jvm_available(False):
+            result = json.loads(plugin.check_pl_consistency("a"))
+        assert "error" in result
+
+    def test_execute_fol_query_no_jvm(self, plugin):
+        with _patch_jvm_available(False):
+            result = json.loads(
+                plugin.execute_fol_query('{"belief_set":"p(X)","query":"p(X)"}')
+            )
+        assert "error" in result
+
+    def test_check_fol_consistency_no_jvm(self, plugin):
+        with _patch_jvm_available(False):
+            result = json.loads(plugin.check_fol_consistency("p(X)"))
+        assert "error" in result
+
+    def test_execute_modal_query_no_jvm(self, plugin):
+        with _patch_jvm_available(False):
+            result = json.loads(
+                plugin.execute_modal_query('{"belief_set":"[]a","query":"a"}')
+            )
+        assert "error" in result
+
+    def test_check_modal_consistency_no_jvm(self, plugin):
+        with _patch_jvm_available(False):
+            result = json.loads(
+                plugin.check_modal_consistency('{"belief_set":"[]a"}')
+            )
+        assert "error" in result
+
+    def test_validate_formula_no_jvm(self, plugin):
+        with _patch_jvm_available(False):
+            result = json.loads(
+                plugin.validate_formula('{"formula":"a","logic_type":"propositional"}')
+            )
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Test: PL methods
+# ---------------------------------------------------------------------------
+
+
+class TestPLMethods:
+    """Propositional logic methods delegate to TweetyBridge."""
+
+    @pytest.fixture()
+    def plugin_and_bridge(self):
+        from argumentation_analysis.plugins.logic_agent_plugin import LogicAgentPlugin
+        bridge = _make_bridge(validate_pl=True)
+        return LogicAgentPlugin(), bridge
+
+    def test_parse_pl_formula_valid(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(plugin.parse_pl_formula("a => b"))
+
+        assert result["is_valid"] is True
+        assert result["formula"] == "a => b"
+        bridge.validate_pl_formula.assert_called_once_with("a => b")
+
+    def test_parse_pl_formula_invalid(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        bridge.validate_pl_formula.return_value = False
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(plugin.parse_pl_formula("invalid!!"))
+
+        assert result["is_valid"] is False
+
+    def test_execute_pl_query(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(
+                plugin.execute_pl_query(
+                    '{"belief_set": "a => b\\nb", "query": "b"}'
+                )
+            )
+
+        assert result["accepted"] is True
+        assert result["query"] == "b"
+        bridge.execute_pl_query.assert_called_once()
+
+    def test_check_pl_consistency(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(plugin.check_pl_consistency("a => b\nb"))
+
+        assert result["is_consistent"] is True
+        bridge.check_consistency.assert_called_once_with(
+            "a => b\nb", logic_type="propositional"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: FOL methods
+# ---------------------------------------------------------------------------
+
+
+class TestFOLMethods:
+    """First-order logic methods delegate correctly."""
+
+    @pytest.fixture()
+    def plugin_and_bridge(self):
+        from argumentation_analysis.plugins.logic_agent_plugin import LogicAgentPlugin
+        bridge = _make_bridge()
+        return LogicAgentPlugin(), bridge
+
+    def test_execute_fol_query(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(
+                plugin.execute_fol_query(
+                    '{"belief_set": "forall X: p(X)", "query": "exists Y: p(Y)"}'
+                )
+            )
+
+        assert result["accepted"] is True
+        assert result["query"] == "exists Y: p(Y)"
+        bridge.execute_fol_query.assert_called_once()
+
+    def test_check_fol_consistency(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(plugin.check_fol_consistency("forall X: p(X)"))
+
+        assert result["is_consistent"] is True
+        bridge.check_consistency.assert_called_once_with(
+            "forall X: p(X)", logic_type="fol"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test: Modal methods
+# ---------------------------------------------------------------------------
+
+
+class TestModalMethods:
+    """Modal logic methods handle logic_type correctly."""
+
+    @pytest.fixture()
+    def plugin_and_bridge(self):
+        from argumentation_analysis.plugins.logic_agent_plugin import LogicAgentPlugin
+        bridge = _make_bridge()
+        return LogicAgentPlugin(), bridge
+
+    def test_execute_modal_query_default_logic(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(
+                plugin.execute_modal_query(
+                    '{"belief_set": "[](a => b)", "query": "[]b"}'
+                )
+            )
+
+        assert result["accepted"] is True
+        assert result["logic_type"] == "K"
+
+    def test_execute_modal_query_s5(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(
+                plugin.execute_modal_query(
+                    '{"belief_set": "[]a", "query": "a", "logic_type": "S5"}'
+                )
+            )
+
+        assert result["logic_type"] == "S5"
+
+    def test_check_modal_consistency(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(
+                plugin.check_modal_consistency(
+                    '{"belief_set": "[]a", "logic_type": "T"}'
+                )
+            )
+
+        assert result["is_consistent"] is True
+        assert result["logic_type"] == "T"
+        bridge.check_consistency.assert_called_once()
+        call_kwargs = bridge.check_consistency.call_args
+        assert "modal_t" in call_kwargs[1]["logic_type"]
+
+
+# ---------------------------------------------------------------------------
+# Test: Cross-logic validate_formula
+# ---------------------------------------------------------------------------
+
+
+class TestValidateFormula:
+    """validate_formula dispatches to correct logic type."""
+
+    @pytest.fixture()
+    def plugin_and_bridge(self):
+        from argumentation_analysis.plugins.logic_agent_plugin import LogicAgentPlugin
+        bridge = _make_bridge()
+        return LogicAgentPlugin(), bridge
+
+    def test_validate_propositional(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(
+                plugin.validate_formula(
+                    '{"formula": "a => b", "logic_type": "propositional"}'
+                )
+            )
+
+        assert result["is_valid"] is True
+        assert result["logic_type"] == "propositional"
+        bridge.validate_pl_formula.assert_called_once_with("a => b")
+
+    def test_validate_fol(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(
+                plugin.validate_formula(
+                    '{"formula": "forall X: p(X)", "logic_type": "fol"}'
+                )
+            )
+
+        assert result["is_valid"] is True
+        assert result["logic_type"] == "fol"
+        bridge.check_consistency.assert_called_once_with(
+            "forall X: p(X)", logic_type="fol"
+        )
+
+    def test_validate_modal(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(
+                plugin.validate_formula(
+                    '{"formula": "[](a => b)", "logic_type": "modal"}'
+                )
+            )
+
+        assert result["is_valid"] is True
+        assert result["logic_type"] == "modal"
+        bridge.check_consistency.assert_called_once_with(
+            "[](a => b)", logic_type="modal_k"
+        )
+
+    def test_validate_invalid_formula_returns_false(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        bridge.check_consistency.return_value = (False, "Parse error")
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(
+                plugin.validate_formula(
+                    '{"formula": "!!!invalid", "logic_type": "fol"}'
+                )
+            )
+
+        assert result["is_valid"] is False
+
+    def test_validate_unknown_logic_type(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(
+                plugin.validate_formula(
+                    '{"formula": "a", "logic_type": "temporal"}'
+                )
+            )
+
+        assert "error" in result
+        assert "temporal" in result["error"]
+
+    def test_validate_default_logic_type(self, plugin_and_bridge):
+        plugin, bridge = plugin_and_bridge
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(
+                plugin.validate_formula('{"formula": "a"}')
+            )
+
+        assert result["logic_type"] == "propositional"
+
+
+# ---------------------------------------------------------------------------
+# Test: Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    """Exceptions from TweetyBridge are caught and returned as JSON."""
+
+    @pytest.fixture()
+    def plugin(self):
+        from argumentation_analysis.plugins.logic_agent_plugin import LogicAgentPlugin
+        return LogicAgentPlugin()
+
+    def test_parse_pl_formula_exception(self, plugin):
+        bridge = MagicMock()
+        bridge.validate_pl_formula.side_effect = RuntimeError("Parse failed")
+        with _patch_jvm_available(True), _patch_tweety_bridge(bridge):
+            result = json.loads(plugin.parse_pl_formula("bad"))
+
+        assert "error" in result
+        assert "Parse failed" in result["error"]
+
+    def test_execute_pl_query_bad_json(self, plugin):
+        with _patch_jvm_available(True):
+            result = json.loads(plugin.execute_pl_query("not json"))
+
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Test: Registry and factory integration
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIntegration:
+    """LogicAgentPlugin is registered in CapabilityRegistry."""
+
+    def test_plugin_registered_in_setup_registry(self):
+        from argumentation_analysis.orchestration.registry_setup import setup_registry
+
+        registry = setup_registry(include_optional=False)
+        reg = registry._registrations.get("logic_agent_plugin")
+        assert reg is not None
+        caps = reg.capabilities
+        assert "propositional_reasoning" in caps
+        assert "first_order_reasoning" in caps
+        assert "modal_reasoning" in caps
+
+
+class TestFactoryIntegration:
+    """AGENT_SPECIALITY_MAP includes logic_agents."""
+
+    def test_formal_logic_has_logic_agents(self):
+        from argumentation_analysis.agents.factory import AGENT_SPECIALITY_MAP
+
+        assert "logic_agents" in AGENT_SPECIALITY_MAP["formal_logic"]
+
+    def test_watson_has_logic_agents(self):
+        from argumentation_analysis.agents.factory import AGENT_SPECIALITY_MAP
+
+        assert "logic_agents" in AGENT_SPECIALITY_MAP["watson"]
+
+    def test_plugin_registry_has_logic_agents(self):
+        from argumentation_analysis.agents.factory import _PLUGIN_REGISTRY
+
+        assert "logic_agents" in _PLUGIN_REGISTRY
+        module_path, class_name = _PLUGIN_REGISTRY["logic_agents"]
+        assert "logic_agent_plugin" in module_path
+        assert class_name == "LogicAgentPlugin"


### PR DESCRIPTION
## Summary

Clean reimplementation of G.10 (#477) addressing all CHANGES_REQUESTED from Round 100 review.

### Bugs fixed
- **validate_formula no-op** (CRITICAL): FOL/Modal validation was calling `bridge.execute_fol_query("", "")` with empty strings — always returned `is_valid: True`. Now uses `bridge.check_consistency(formula, logic_type=...)` which actually parses and validates the formula.
- **Parameter `input` shadows built-in** (MINOR): Renamed to `payload` in 4 methods (`execute_pl_query`, `execute_fol_query`, `execute_modal_query`, `check_modal_consistency`)
- **Silent truncation** (MINOR): Added `"truncated": true/false` field to all `belief_set[:200]` responses
- **Unknown logic_type** (MINOR): Returns error JSON instead of silently passing

### Files changed (clean from main `a26bf015`)
- `argumentation_analysis/plugins/logic_agent_plugin.py` — NEW, 8 @kernel_function methods
- `tests/unit/argumentation_analysis/plugins/test_logic_agent_plugin.py` — 31 tests (27 + 4 new)
- `argumentation_analysis/agents/factory.py` — AGENT_SPECIALITY_MAP + _PLUGIN_REGISTRY wiring
- `argumentation_analysis/orchestration/registry_setup.py` — plugin registration
- `argumentation_analysis/core/state_manager_plugin.py` — black reformat

### Test plan
- [x] 31/31 tests passing
- [x] validate_formula FOL now calls check_consistency
- [x] validate_formula Modal now calls check_consistency
- [x] Invalid formula returns `is_valid: False`
- [x] Unknown logic_type returns error

Supersedes #485 (stack entremêlée).

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)