### PR TITLE
feat(orchestration): structured logging with correlation IDs (#454)

### DIFF
--- a/argumentation_analysis/orchestration/structured_logging.py
+++ b/argumentation_analysis/orchestration/structured_logging.py
@@ -1,0 +1,141 @@
+"""Structured logging for orchestration with correlation IDs.
+
+Provides a JSON-capable log formatter and a PhaseLogger adapter that
+injects ``correlation_id`` and ``phase_name`` into every log record.
+
+Output mode is controlled by the ``LOG_FORMAT`` environment variable:
+- ``LOG_FORMAT=json`` → JSON lines to stderr (for production / corpus runs)
+- anything else → human-readable format (default, for dev / tests)
+
+Usage in orchestration modules::
+
+    from argumentation_analysis.orchestration.structured_logging import get_phase_logger
+
+    logger = get_phase_logger("workflow_executor", correlation_id="run-abc")
+    logger.info("Phase completed", phase_name="extract", duration=1.2)
+"""
+import json
+import logging
+import os
+import sys
+import uuid
+from typing import Any, Dict, Optional
+
+
+class JsonFormatter(logging.Formatter):
+    """Emit one JSON object per log line."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        obj: Dict[str, Any] = {
+            "timestamp": self.formatTime(record, self.datefmt or "%Y-%m-%dT%H:%M:%S"),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        # Merge extra fields from the record
+        for key in ("correlation_id", "phase_name", "duration", "workflow",
+                     "capability", "phases_total", "phases_completed"):
+            val = getattr(record, key, None)
+            if val is not None:
+                obj[key] = val
+
+        if record.exc_info and record.exc_info[1]:
+            obj["exception"] = self.formatException(record.exc_info)
+
+        return json.dumps(obj, ensure_ascii=False, default=str)
+
+
+class HumanFormatter(logging.Formatter):
+    """Human-readable formatter with optional correlation/phase context."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        base = super().format(record)
+        cid = getattr(record, "correlation_id", None)
+        phase = getattr(record, "phase_name", None)
+        prefix_parts = []
+        if cid:
+            prefix_parts.append(f"[{cid[:8]}]")
+        if phase:
+            prefix_parts.append(f"[{phase}]")
+        if prefix_parts:
+            return " ".join(prefix_parts) + " " + base
+        return base
+
+
+class PhaseLogger(logging.LoggerAdapter):
+    """Logger adapter that injects correlation_id and phase_name."""
+
+    def __init__(
+        self,
+        logger: logging.Logger,
+        correlation_id: Optional[str] = None,
+        phase_name: Optional[str] = None,
+    ):
+        extra: Dict[str, Any] = {}
+        if correlation_id:
+            extra["correlation_id"] = correlation_id
+        if phase_name:
+            extra["phase_name"] = phase_name
+        super().__init__(logger, extra)
+
+    def process(self, msg: str, kwargs: Any) -> tuple:
+        extra = dict(self.extra)
+        # Allow per-call overrides via extra kwarg
+        if "extra" in kwargs:
+            extra.update(kwargs["extra"])
+        kwargs["extra"] = extra
+        return msg, kwargs
+
+    def with_phase(self, phase_name: str) -> "PhaseLogger":
+        """Return a child adapter with an updated phase_name."""
+        return PhaseLogger(
+            self.logger,
+            correlation_id=self.extra.get("correlation_id"),
+            phase_name=phase_name,
+        )
+
+
+def generate_correlation_id() -> str:
+    """Generate a new correlation ID (UUID4)."""
+    return str(uuid.uuid4())
+
+
+def get_phase_logger(
+    name: str,
+    correlation_id: Optional[str] = None,
+    phase_name: Optional[str] = None,
+) -> PhaseLogger:
+    """Get a PhaseLogger for the given module name.
+
+    If LOG_FORMAT=json is set, configures the root handler to use JSON output.
+    Otherwise, uses human-readable format.
+    """
+    _configure_root_if_needed()
+    logger = logging.getLogger(name)
+    return PhaseLogger(logger, correlation_id=correlation_id, phase_name=phase_name)
+
+
+_configured = False
+
+
+def _configure_root_if_needed():
+    """One-time configuration of the root logger handler."""
+    global _configured
+    if _configured:
+        return
+    _configured = True
+
+    log_format = os.environ.get("LOG_FORMAT", "").lower()
+    handler = logging.StreamHandler(sys.stderr)
+
+    if log_format == "json":
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler.setFormatter(
+            HumanFormatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+                           datefmt="%H:%M:%S")
+        )
+
+    root = logging.getLogger("argumentation_analysis.orchestration")
+    if not root.handlers:
+        root.addHandler(handler)

--- a/argumentation_analysis/orchestration/workflow_dsl.py
+++ b/argumentation_analysis/orchestration/workflow_dsl.py
@@ -20,6 +20,7 @@ Usage:
 import asyncio
 import logging
 import time
+import uuid
 from typing import (
     Callable,
     Dict,
@@ -304,6 +305,7 @@ class WorkflowExecutor:
             registry: CapabilityRegistry instance for resolving capabilities.
         """
         self._registry = registry
+        self._base_logger = logging.getLogger("orchestration.workflow_executor")
 
     async def execute(
         self,
@@ -350,10 +352,22 @@ class WorkflowExecutor:
         if state is not None:
             ctx["unified_state"] = state
 
-        logger.info(
+        # Structured logging with correlation_id
+        correlation_id = (
+            ctx.get("correlation_id")
+            or (getattr(state, "run_id", None) if state else None)
+            or str(uuid.uuid4())
+        )
+        ctx["correlation_id"] = correlation_id
+
+        from argumentation_analysis.orchestration.structured_logging import PhaseLogger
+        slog = PhaseLogger(self._base_logger, correlation_id=correlation_id)
+
+        slog.info(
             f"Executing workflow '{workflow.name}' — "
             f"{len(workflow.phases)} phases, {len(execution_order)} levels"
-            f"{f', resuming (skip {len(skip_phases)} phases)' if skip_phases else ''}"
+            f"{f', resuming (skip {len(skip_phases)} phases)' if skip_phases else ''}",
+            extra={"workflow": workflow.name, "phases_total": len(workflow.phases)},
         )
 
         for level_idx, level_phases in enumerate(execution_order):
@@ -393,6 +407,10 @@ class WorkflowExecutor:
             for phase_name in to_run:
                 phase = workflow.get_phase(phase_name)
                 if phase:
+                    slog.info(
+                        "Starting phase",
+                        extra={"phase_name": phase_name, "capability": phase.capability},
+                    )
                     phase_coros.append(
                         self._execute_phase(phase, phase_name, input_data, ctx)
                     )
@@ -416,9 +434,14 @@ class WorkflowExecutor:
         )
         failed = sum(1 for r in results.values() if r.status == PhaseStatus.FAILED)
         skipped = sum(1 for r in results.values() if r.status == PhaseStatus.SKIPPED)
-        logger.info(
+        slog.info(
             f"Workflow '{workflow.name}' finished: "
-            f"{completed} completed, {failed} failed, {skipped} skipped"
+            f"{completed} completed, {failed} failed, {skipped} skipped",
+            extra={
+                "workflow": workflow.name,
+                "phases_completed": completed,
+                "phases_total": len(results),
+            },
         )
 
         if state is not None and hasattr(state, "set_workflow_results"):

--- a/docs/architecture/LOGGING.md
+++ b/docs/architecture/LOGGING.md
@@ -1,0 +1,78 @@
+# Structured Logging
+
+## Overview
+
+Orchestration modules use structured logging with correlation IDs to enable per-document tracing across all pipeline phases. This allows filtering logs for a specific analysis run and tracking request flow through extract → fallacy → FOL → synthesis.
+
+## Architecture
+
+```
+argumentation_analysis/orchestration/structured_logging.py  ← core module
+  ├── JsonFormatter    — JSON lines to stderr
+  ├── HumanFormatter   — human-readable with [correlation_id] prefix
+  ├── PhaseLogger      — logging.LoggerAdapter with correlation_id + phase_name
+  └── get_phase_logger() — factory, respects LOG_FORMAT env var
+```
+
+## Environment Variables
+
+| Variable | Values | Default | Description |
+|----------|--------|---------|-------------|
+| `LOG_FORMAT` | `json`, anything else | human-readable | `json` → JSON lines to stderr for production |
+
+## Usage
+
+### In orchestration code
+
+```python
+from argumentation_analysis.orchestration.structured_logging import get_phase_logger
+
+# One logger per module, correlation_id set once
+slog = get_phase_logger("workflow_executor", correlation_id="run-abc-123")
+
+# Per-phase logging
+slog.info("Phase completed", extra={"phase_name": "extract", "duration": 1.2})
+
+# Child logger for a specific phase
+phase_log = slog.with_phase("fol_validate")
+phase_log.info("Validation result")  # includes correlation_id + phase_name
+```
+
+### In WorkflowExecutor
+
+The executor automatically generates or accepts a `correlation_id`:
+1. If `ctx["correlation_id"]` is set → uses it
+2. If `state.run_id` exists → uses it
+3. Otherwise → generates UUID4
+
+The correlation_id is stored in `ctx` and propagates to all phase executions.
+
+## JSON Output Example
+
+```json
+{"timestamp": "2026-05-14T10:30:00", "level": "INFO", "logger": "orchestration.workflow_executor", "message": "Starting phase", "correlation_id": "abc12345-6789", "phase_name": "extract", "capability": "fact_extraction"}
+```
+
+## Recommended jq Queries
+
+```bash
+# Filter by correlation ID
+python run_analysis.py 2>&1 | jq 'select(.correlation_id == "abc12345")'
+
+# All phase transitions
+python run_analysis.py 2>&1 | jq 'select(.phase_name) | {timestamp, phase_name, message}'
+
+# Failed phases only
+python run_analysis.py 2>&1 | jq 'select(.level == "ERROR" and .phase_name)'
+
+# Duration summary per phase
+python run_analysis.py 2>&1 | jq 'select(.duration) | {phase_name, duration}'
+```
+
+## Testing
+
+```bash
+pytest tests/unit/argumentation_analysis/orchestration/test_structured_logging.py
+```
+
+12 tests covering: PhaseLogger injection, JsonFormatter output, HumanFormatter prefix, LOG_FORMAT env control, correlation propagation across phases.

--- a/tests/unit/argumentation_analysis/orchestration/test_structured_logging.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_structured_logging.py
@@ -1,0 +1,170 @@
+"""Tests for structured logging with correlation IDs (#454).
+
+Validates:
+- PhaseLogger injects correlation_id and phase_name into log records
+- JsonFormatter produces valid JSON output
+- HumanFormatter includes correlation prefix
+- correlation_id propagates across a multi-phase workflow run
+- LOG_FORMAT=json activates JSON output
+"""
+import json
+import logging
+import os
+import uuid
+
+import pytest
+
+from argumentation_analysis.orchestration.structured_logging import (
+    HumanFormatter,
+    JsonFormatter,
+    PhaseLogger,
+    generate_correlation_id,
+    get_phase_logger,
+)
+
+
+class TestPhaseLogger:
+    """Test PhaseLogger adapter."""
+
+    def test_correlation_id_injected(self):
+        logger = logging.getLogger("test_correlation")
+        adapter = PhaseLogger(logger, correlation_id="abc-123")
+        record = adapter.logger.makeRecord(
+            "test", logging.INFO, "", 0, "hello", (), None
+        )
+        adapter.process("hello", {"extra": {}})
+        # The extra should be in the kwargs
+        assert adapter.extra.get("correlation_id") == "abc-123"
+
+    def test_phase_name_injected(self):
+        adapter = PhaseLogger(
+            logging.getLogger("test_phase"),
+            correlation_id="cid",
+            phase_name="extract",
+        )
+        assert adapter.extra.get("phase_name") == "extract"
+
+    def test_with_phase_returns_child(self):
+        parent = PhaseLogger(
+            logging.getLogger("test_child"),
+            correlation_id="parent-cid",
+        )
+        child = parent.with_phase("fallacy_detect")
+        assert child.extra.get("correlation_id") == "parent-cid"
+        assert child.extra.get("phase_name") == "fallacy_detect"
+        # Parent should NOT have phase_name
+        assert "phase_name" not in parent.extra
+
+    def test_generate_correlation_id(self):
+        cid = generate_correlation_id()
+        # Must be a valid UUID
+        uuid.UUID(cid)  # raises ValueError if invalid
+
+
+class TestJsonFormatter:
+    """Test JSON log formatter."""
+
+    def test_produces_valid_json(self):
+        formatter = JsonFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="test message", args=(), exc_info=None,
+        )
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["message"] == "test message"
+        assert parsed["level"] == "INFO"
+        assert "timestamp" in parsed
+
+    def test_includes_correlation_id(self):
+        formatter = JsonFormatter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="with correlation", args=(), exc_info=None,
+        )
+        record.correlation_id = "cid-456"
+        record.phase_name = "extract"
+        output = formatter.format(record)
+        parsed = json.loads(output)
+        assert parsed["correlation_id"] == "cid-456"
+        assert parsed["phase_name"] == "extract"
+
+
+class TestHumanFormatter:
+    """Test human-readable formatter."""
+
+    def test_no_prefix_without_context(self):
+        formatter = HumanFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="plain message", args=(), exc_info=None,
+        )
+        output = formatter.format(record)
+        assert output == "plain message"
+
+    def test_prefix_with_correlation_id(self):
+        formatter = HumanFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="contextual message", args=(), exc_info=None,
+        )
+        record.correlation_id = "abcdefgh-1234"
+        output = formatter.format(record)
+        assert "[abcdefgh]" in output
+        assert "contextual message" in output
+
+    def test_prefix_with_phase_name(self):
+        formatter = HumanFormatter("%(message)s")
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="phase message", args=(), exc_info=None,
+        )
+        record.phase_name = "extract"
+        output = formatter.format(record)
+        assert "[extract]" in output
+
+
+class TestLogFormatEnv:
+    """Test LOG_FORMAT environment variable control."""
+
+    def test_json_format_env(self, monkeypatch):
+        # Reset the configured flag
+        import argumentation_analysis.orchestration.structured_logging as sl_mod
+        monkeypatch.setenv("LOG_FORMAT", "json")
+        monkeypatch.setattr(sl_mod, "_configured", False)
+
+        slog = get_phase_logger("test_env_json", correlation_id="env-test")
+        # Verify we got a PhaseLogger
+        assert isinstance(slog, PhaseLogger)
+        assert slog.extra["correlation_id"] == "env-test"
+
+    def test_human_format_default(self, monkeypatch):
+        import argumentation_analysis.orchestration.structured_logging as sl_mod
+        monkeypatch.delenv("LOG_FORMAT", raising=False)
+        monkeypatch.setattr(sl_mod, "_configured", False)
+
+        slog = get_phase_logger("test_env_human", correlation_id="human-test")
+        assert isinstance(slog, PhaseLogger)
+
+
+class TestCorrelationPropagation:
+    """Test that correlation_id propagates across simulated multi-phase run."""
+
+    def test_correlation_propagates_across_phases(self):
+        cid = str(uuid.uuid4())
+        phases = ["extract", "fallacy_detect", "fol_validate", "synthesis"]
+
+        collected = []
+        for phase_name in phases:
+            slog = get_phase_logger(
+                "test_propagation", correlation_id=cid, phase_name=phase_name
+            )
+            collected.append({
+                "correlation_id": slog.extra.get("correlation_id"),
+                "phase_name": slog.extra.get("phase_name"),
+            })
+
+        # All entries share the same correlation_id
+        assert all(e["correlation_id"] == cid for e in collected)
+        # Each has its own phase_name
+        assert [e["phase_name"] for e in collected] == phases


### PR DESCRIPTION
## Summary

- New module `argumentation_analysis/orchestration/structured_logging.py` with PhaseLogger, JsonFormatter, HumanFormatter
- WorkflowExecutor auto-generates or accepts `correlation_id`, propagates it across all phases
- `LOG_FORMAT=json` env var activates JSON lines to stderr (for production/corpus runs)
- Human-readable default for dev/tests with `[correlation_id] [phase_name]` prefix
- 12 tests covering: injection, JSON output, human prefix, env control, correlation propagation
- Doc `docs/architecture/LOGGING.md` with usage, examples, jq queries

## Test plan
- [x] pytest tests/unit/argumentation_analysis/orchestration/test_structured_logging.py - 12/12 passed
- [x] No regressions in existing orchestration tests

Closes #454

Generated with Claude Code