### PR TITLE
feat(orchestration): wire BeliefRevisionPlugin into spectacular workflow

### DIFF
--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -554,6 +554,7 @@ def build_spectacular_workflow() -> WorkflowDefinition:
         L4  aspic_analysis                        (from dung)
         L5  counter                               (from quality)
         L6  jtms | debate                         (from counter)
+        L6b belief_revision                       (from jtms + dung)
         L7  atms                                  (from jtms)
         L8  governance | formal_synthesis         (aggregation)
     """
@@ -699,6 +700,13 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             "tweety_interpretation",
             capability="formal_result_interpretation",
             depends_on=["fol", "modal", "dung_extensions", "aspic_analysis", "ranking"],
+            optional=True,
+        )
+        # L6b — Belief revision (Dalal/Levi distance under contradictions) (#507)
+        .add_phase(
+            "belief_revision",
+            capability="belief_revision",
+            depends_on=["jtms", "dung_extensions"],
             optional=True,
         )
         .build()

--- a/tests/unit/argumentation_analysis/orchestration/test_belief_revision_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_belief_revision_spectacular.py
@@ -1,0 +1,43 @@
+"""Tests for BeliefRevisionPlugin wiring in spectacular (#507)."""
+
+
+class TestBeliefRevisionSpectacularPhase:
+    """Verify belief_revision phase exists in spectacular with correct DAG deps."""
+
+    def test_spectacular_has_belief_revision_phase(self):
+        from argumentation_analysis.orchestration.workflows import (
+            build_spectacular_workflow,
+        )
+
+        wf = build_spectacular_workflow()
+        phase = {p.name: p for p in wf.phases}
+        assert "belief_revision" in phase
+        assert phase["belief_revision"].capability == "belief_revision"
+        assert "jtms" in phase["belief_revision"].depends_on
+        assert "dung_extensions" in phase["belief_revision"].depends_on
+        assert phase["belief_revision"].optional is True
+
+    def test_spectacular_phase_count_with_belief_revision(self):
+        from argumentation_analysis.orchestration.workflows import (
+            build_spectacular_workflow,
+        )
+
+        wf = build_spectacular_workflow()
+        assert len(wf.phases) == 21
+
+    def test_belief_revision_state_writer_exists(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            CAPABILITY_STATE_WRITERS,
+        )
+
+        assert "belief_revision" in CAPABILITY_STATE_WRITERS
+
+    def test_belief_revision_service_in_registry(self):
+        from argumentation_analysis.orchestration.registry_setup import setup_registry
+
+        registry = setup_registry()
+        providers = registry.find_for_capability("belief_revision")
+        names = [p.name for p in providers]
+        assert any("belief_revision" in n for n in names)
+        provider = next(p for p in providers if "belief_revision" in p.name)
+        assert provider.invoke is not None


### PR DESCRIPTION
## Summary
- Add `belief_revision` phase to spectacular workflow, depends_on jtms + dung_extensions
- Uses existing `_invoke_belief_revision` callable and `_write_belief_revision_to_state` writer
- Spectacular workflow: 20 → 21 phases

## Changes
- **workflows.py**: New phase `belief_revision` with DAG deps on `jtms` and `dung_extensions`
- **4 tests**: Phase presence, DAG deps, state writer, registry resolution

## Test plan
- [x] `pytest tests/unit/argumentation_analysis/orchestration/test_belief_revision_spectacular.py -v` — 4 passed
- [ ] CI green
- [ ] Verify spectacular state shows non-empty belief revision field

Closes #507

🤖 Generated with [Claude Code](https://claude.com/claude-code)