### PR TITLE
feat(orchestration): add synthesis phase to spectacular workflow

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -79,6 +79,7 @@ __all__ = [
     "_invoke_text_to_kb",
     "_invoke_kb_to_tweety",
     "_invoke_tweety_interpretation",
+    "_invoke_analysis_synthesis",
 ]
 
 
@@ -3803,6 +3804,106 @@ def _count_referenced_fields(state: Any) -> int:
         if val and (isinstance(val, (list, dict)) and len(val) > 0):
             count += 1
     return count
+
+
+# ---------------------------------------------------------------------------
+# Analysis synthesis invoke callable (#508)
+# ---------------------------------------------------------------------------
+
+
+async def _invoke_analysis_synthesis(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Aggregate all analysis phase outputs into a structured synthesis (#508).
+
+    Collects results from quality, fallacy, counter-argument, debate,
+    governance, and formal phases (from context), and produces a
+    structured summary with scores and key findings.
+    """
+    state = context.get("_state_object")
+    phase_results = {}
+
+    # Collect phase outputs from context
+    for key, val in context.items():
+        if (
+            key.startswith("phase_")
+            and key.endswith("_output")
+            and isinstance(val, dict)
+        ):
+            phase_name = key[len("phase_") : -len("_output")]
+            phase_results[phase_name] = val
+
+    # Build structured synthesis from state if available
+    sections = {}
+
+    # Quality summary
+    quality_scores = getattr(state, "argument_quality_scores", None) if state else None
+    if quality_scores and isinstance(quality_scores, (list, dict)):
+        sections["quality"] = {
+            "evaluated": (
+                len(quality_scores)
+                if isinstance(quality_scores, list)
+                else len(quality_scores)
+            ),
+            "summary": f"{len(quality_scores)} arguments evaluated",
+        }
+
+    # Fallacy summary
+    fallacies = getattr(state, "identified_fallacies", None) if state else None
+    if fallacies and isinstance(fallacies, list):
+        sections["fallacies"] = {
+            "count": len(fallacies),
+            "types": list(
+                set(f.get("type", "unknown") for f in fallacies if isinstance(f, dict))
+            ),
+        }
+
+    # Counter-argument summary
+    counter_args = getattr(state, "counter_arguments", None) if state else None
+    if counter_args and isinstance(counter_args, list):
+        sections["counter_arguments"] = {
+            "generated": len(counter_args),
+        }
+
+    # JTMS beliefs
+    jtms_beliefs = getattr(state, "jtms_beliefs", None) if state else None
+    if jtms_beliefs and isinstance(jtms_beliefs, (list, dict)):
+        sections["beliefs"] = {
+            "tracked": (
+                len(jtms_beliefs)
+                if isinstance(jtms_beliefs, list)
+                else len(jtms_beliefs)
+            ),
+        }
+
+    # Formal results
+    for field_name in [
+        "dung_frameworks",
+        "fol_analysis_results",
+        "propositional_analysis_results",
+        "modal_analysis_results",
+    ]:
+        formal = getattr(state, field_name, None) if state else None
+        if formal and isinstance(formal, (list, dict)):
+            sections[field_name] = {"present": True, "size": len(formal)}
+
+    # Overall assessment
+    total_phases = len(phase_results)
+    sections_count = len(sections)
+    overall_completeness = (
+        sections_count / max(total_phases, 1) if total_phases > 0 else 0.0
+    )
+
+    return {
+        "synthesis": sections,
+        "phase_count": total_phases,
+        "sections_count": sections_count,
+        "overall_completeness": round(overall_completeness, 2),
+        "phase_results_summary": {
+            name: "completed" if "error" not in res else f"error: {res['error'][:50]}"
+            for name, res in phase_results.items()
+        },
+    }
 
 
 # --- State writers: map capability → (output, state, ctx) → None ---

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -54,6 +54,7 @@ from argumentation_analysis.orchestration.invoke_callables import (
     _invoke_text_to_kb,
     _invoke_kb_to_tweety,
     _invoke_tweety_interpretation,
+    _invoke_analysis_synthesis,
 )
 
 logger = logging.getLogger("UnifiedPipeline")
@@ -496,6 +497,23 @@ def setup_registry(
             registered.append(name)
         except Exception as e:
             skipped.append((name, str(e)))
+    # --- Analysis synthesis service (#508) ---
+    try:
+        registry.register_service(
+            name="analysis_synthesis_service",
+            service_class=type("analysis_synthesis_service", (), {}),
+            capabilities=["analysis_synthesis"],
+            metadata={
+                "description": (
+                    "Terminal aggregation of all analysis phase outputs "
+                    "into a structured synthesis report"
+                )
+            },
+            invoke=_invoke_analysis_synthesis,
+        )
+        registered.append("analysis_synthesis_service")
+    except Exception as e:
+        skipped.append(("analysis_synthesis_service", str(e)))
 
     # --- Collaborative multi-agent debate (#175) ---
     try:

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -889,6 +889,20 @@ def _write_tweety_interpretation_to_state(
             add_extract("formal_interpretation", interpretation)
         elif hasattr(state, "formal_interpretation"):
             state.formal_interpretation = interpretation
+def _write_analysis_synthesis_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
+    """Write analysis synthesis results to UnifiedAnalysisState (#508)."""
+    if not output or not isinstance(output, dict):
+        return
+    synthesis = output.get("synthesis", {})
+    if isinstance(synthesis, dict) and synthesis:
+        if hasattr(state, "analysis_synthesis"):
+            state.analysis_synthesis = {
+                "synthesis": synthesis,
+                "phase_count": output.get("phase_count", 0),
+                "overall_completeness": output.get("overall_completeness", 0.0),
+            }
 
 
 CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
@@ -931,4 +945,5 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "nl_extraction": _write_text_to_kb_to_state,
     "kb_to_tweety": _write_kb_to_tweety_to_state,
     "formal_result_interpretation": _write_tweety_interpretation_to_state,
+    "analysis_synthesis": _write_analysis_synthesis_to_state,
 }

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -557,6 +557,7 @@ def build_spectacular_workflow() -> WorkflowDefinition:
         L6b belief_revision                       (from jtms + dung)
         L7  atms                                  (from jtms)
         L8  governance | formal_synthesis         (aggregation)
+        L9  synthesis                               (terminal aggregation)
     """
     return (
         WorkflowBuilder("spectacular_analysis")
@@ -707,6 +708,19 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             "belief_revision",
             capability="belief_revision",
             depends_on=["jtms", "dung_extensions"],
+            optional=True,
+        )
+        # L9 — terminal synthesis aggregation (#508)
+        .add_phase(
+            "synthesis",
+            capability="analysis_synthesis",
+            depends_on=[
+                "quality",
+                "counter",
+                "debate",
+                "governance",
+                "formal_synthesis",
+            ],
             optional=True,
         )
         .build()

--- a/tests/unit/argumentation_analysis/orchestration/test_synthesis_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_synthesis_spectacular.py
@@ -1,0 +1,67 @@
+"""Tests for synthesis phase wiring in spectacular (#508)."""
+
+from unittest.mock import MagicMock
+
+
+class TestSynthesisSpectacularPhase:
+    """Verify synthesis phase exists in spectacular with correct DAG deps."""
+
+    def test_spectacular_has_synthesis_phase(self):
+        from argumentation_analysis.orchestration.workflows import (
+            build_spectacular_workflow,
+        )
+
+        wf = build_spectacular_workflow()
+        phase = {p.name: p for p in wf.phases}
+        assert "synthesis" in phase
+        assert phase["synthesis"].capability == "analysis_synthesis"
+        deps = phase["synthesis"].depends_on
+        assert "quality" in deps
+        assert "counter" in deps
+        assert "debate" in deps
+        assert "governance" in deps
+        assert "formal_synthesis" in deps
+        assert phase["synthesis"].optional is True
+
+    def test_spectacular_phase_count_with_synthesis(self):
+        from argumentation_analysis.orchestration.workflows import (
+            build_spectacular_workflow,
+        )
+
+        wf = build_spectacular_workflow()
+        assert len(wf.phases) == 21
+
+    def test_analysis_synthesis_state_writer_registered(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            CAPABILITY_STATE_WRITERS,
+        )
+
+        assert "analysis_synthesis" in CAPABILITY_STATE_WRITERS
+
+    def test_analysis_synthesis_service_in_registry(self):
+        from argumentation_analysis.orchestration.registry_setup import setup_registry
+
+        registry = setup_registry()
+        providers = registry.find_for_capability("analysis_synthesis")
+        names = [p.name for p in providers]
+        assert "analysis_synthesis_service" in names
+        provider = next(p for p in providers if p.name == "analysis_synthesis_service")
+        assert provider.invoke is not None
+
+    def test_write_analysis_synthesis_to_state(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_analysis_synthesis_to_state,
+        )
+
+        state = MagicMock()
+        output = {
+            "synthesis": {
+                "quality": {"evaluated": 3},
+                "fallacies": {"count": 2},
+            },
+            "phase_count": 5,
+            "overall_completeness": 0.8,
+        }
+        _write_analysis_synthesis_to_state(output, state, {})
+        assert state.analysis_synthesis["phase_count"] == 5
+        assert state.analysis_synthesis["overall_completeness"] == 0.8


### PR DESCRIPTION
## Summary
- Add terminal `synthesis` phase to spectacular workflow, depends_on quality/counter/debate/governance/formal_synthesis
- Aggregates all analysis outputs into a structured synthesis report
- Spectacular workflow: 20 → 21 phases

## Changes
- **workflows.py**: New phase `synthesis` with capability `analysis_synthesis`
- **invoke_callables.py**: `_invoke_analysis_synthesis` collecting state fields into sections
- **state_writers.py**: `_write_analysis_synthesis_to_state` populating `state.analysis_synthesis`
- **registry_setup.py**: `analysis_synthesis_service` registration
- **5 tests**: Phase presence, DAG deps, state writer, registry, synthesis output

## Test plan
- [x] `pytest tests/unit/argumentation_analysis/orchestration/test_synthesis_spectacular.py -v` — 5 passed
- [ ] CI green
- [ ] Verify spectacular state ends with populated `analysis_synthesis` field

Closes #508

🤖 Generated with [Claude Code](https://claude.com/claude-code)