### PR TITLE
fix(tests): correct corpus batch SyntaxError + stale track_a assertion

### DIFF
--- a/scripts/dataset/run_corpus_batch.py
+++ b/scripts/dataset/run_corpus_batch.py
@@ -240,7 +240,6 @@ async def _run_single(
             ),
             timeout=timeout,
         )
-        )
         # Prefer full (non-summarized) state for pattern mining.
         state_snapshot = result.get("state_snapshot", {})
         # Prefer full (non-summarized) state for pattern mining.

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py
@@ -760,7 +760,7 @@ class TestTrackARegistration:
         _declare_tweety_slots(mock_registry)
 
         # Should call register_service for each handler
-        assert mock_registry.register_service.call_count == 16
+        assert mock_registry.register_service.call_count == 17
 
         # Check capability names
         registered_caps = set()
@@ -786,6 +786,8 @@ class TestTrackARegistration:
             "epistemic_argumentation",
             "defeasible_logic",
             "qbf_reasoning",
+            "asp_reasoning",
+            "answer_set_programming",
         }
         assert registered_caps == expected_caps
 


### PR DESCRIPTION
## Summary
- Remove duplicate `)` in `run_corpus_batch.py:243` introduced by PR #466
- Update `test_track_a_handlers.py` assertion `== 16` to `== 17` and add `asp_reasoning` + `answer_set_programming` to `expected_caps` after PR #495 added `asp_reasoning_handler`

## Test plan
- [x] `test_track_a_handlers.py` - 44 passed (was 1 failed)
- [x] `test_corpus_batch_runner.py` - 11 passed (was collection error)
- [ ] Full suite running (background)