### PR TITLE
fix(tests): set jpype.__version__ on mock — fix API/Starlette cluster (15 errors)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,7 +96,9 @@ except (ImportError, AttributeError):
 _disable_jvm_early_check = any(arg == "--disable-jvm-session" for arg in sys.argv)
 if _disable_jvm_early_check:
     print("[INFO] Early check: --disable-jvm-session detected. Mocking jpype globally.")
-    sys.modules["jpype"] = MagicMock()
+    _mock_jpype = MagicMock()
+    _mock_jpype.__version__ = "1.6.0-mock"
+    sys.modules["jpype"] = _mock_jpype
     sys.modules["jpype.imports"] = MagicMock()
 
 # Désactive la vérification de l'environnement Conda pour les tests E2E


### PR DESCRIPTION
## Summary

When `--disable-jvm-session` is passed, `tests/conftest.py` installs a `MagicMock` for the `jpype` module. `argumentation_analysis.core.bootstrap._check_critical_requirements` then reads `jpype.__version__` to log it, but `MagicMock.__getattr__('__version__')` raises `AttributeError` (the dunder is treated as a magic name by `unittest.mock`).

The error surfaces as `AttributeError: __version__` at `bootstrap.py:281` during FastAPI app startup, which propagates as a fixture-setup error for every test that uses `TestClient(app)`.

Fix: set `__version__` explicitly on the mock before installing it into `sys.modules`.

## Cluster impact

Closes the **API/Starlette ERROR cluster** identified in the round 114 audit (`docs/reports/TEST_HEALTH` cluster table — 15 ERRORs across `test_fastapi_gpt4o_authentique.py` and `test_fastapi_simple.py`).

| | Before | After |
|---|---:|---:|
| `tests/unit/api/` | 64 passed / 15 ERROR | 79 passed / 0 ERROR |

Tests verified locally on `myia-po-2023` (`projet-is` conda env).

## Test plan
- [x] `pytest tests/unit/api/ --disable-jvm-session` → 79 passed, 4 skipped, 1 xpassed, 0 errors
- [x] `pytest tests/unit/api/test_fastapi_simple.py` → 7 passed
- [ ] CI lint + automated-tests green
- [ ] NanoClaw review

Diff: +3 / -1, `tests/conftest.py` only.

Privacy clean: 0 dataset content touched.

---

Claude Code @ myia-po-2023:2025-Epita-Intelligence-Symbolique