### PR TITLE
fix(tests): skip spectacular notebook tests when nbformat/jupyter absent

### DIFF
--- a/tests/unit/examples/test_spectacular_notebook.py
+++ b/tests/unit/examples/test_spectacular_notebook.py
@@ -1,6 +1,8 @@
 """Smoke tests for spectacular_analysis_tour.ipynb — #362"""
 
+import importlib.util
 import json
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -15,8 +17,12 @@ SCRIPT = Path(__file__).resolve().parent.parent.parent.parent / (
     "examples/02_core_system_demos/scripts_demonstration/demonstration_epita_spectacular.py"
 )
 
+_HAS_NBFORMAT = importlib.util.find_spec("nbformat") is not None
+_HAS_JUPYTER = importlib.util.find_spec("jupyter") is not None
+
 
 @pytest.mark.skipif(not NOTEBOOK.exists(), reason="Notebook not found")
+@pytest.mark.skipif(not _HAS_NBFORMAT, reason="nbformat not installed (optional test dep)")
 class TestSpectacularNotebook:
     """Verify the Jupyter companion notebook structure and execution."""
 
@@ -71,6 +77,7 @@ class TestSpectacularNotebook:
         assert "MOCK_SPECTACULAR_RESULT" in code_text
 
     @pytest.mark.skipif(not SCRIPT.exists(), reason="Demo script dependency not found")
+    @pytest.mark.skipif(not _HAS_JUPYTER, reason="jupyter not installed (optional test dep)")
     def test_notebook_executes_headless(self, tmp_path):
         """Execute the notebook via nbconvert and verify no errors.
 


### PR DESCRIPTION
## Summary

6 tests in [tests/unit/examples/test_spectacular_notebook.py](tests/unit/examples/test_spectacular_notebook.py) fail with `ModuleNotFoundError` on environments that lack `nbformat` / `jupyter` (e.g. the `projet-is` conda env on `myia-po-2023`). These are smoke tests for an optional Jupyter notebook artifact (`notebooks/spectacular_analysis_tour.ipynb`) — they should skip gracefully, mirroring the existing `@pytest.mark.skipif(not NOTEBOOK.exists())` pattern already in the file.

## Changes

- Add module-level `_HAS_NBFORMAT` / `_HAS_JUPYTER` probes via `importlib.util.find_spec`.
- Class-level `@pytest.mark.skipif(not _HAS_NBFORMAT)` covers the 5 nbformat tests.
- Test-level `@pytest.mark.skipif(not _HAS_JUPYTER)` on `test_notebook_executes_headless` (uses `python -m jupyter nbconvert` via subprocess).

## Test plan

- [x] `pytest tests/unit/examples/test_spectacular_notebook.py -v` on `projet-is` (no nbformat/jupyter) → **6 skipped** (was 6 FAILED before fix)
- [x] Skips are descriptive: "nbformat not installed (optional test dep)" / "jupyter not installed (optional test dep)"
- [ ] Environments with `nbformat`/`jupyter` available run the tests normally (verified by review of skipif logic — no behavior change when deps present)

## Context

Surfaced during T2 test health audit (dispatch round 109/114). Part of a series of fix PRs targeting individual clusters from the test failure manifest. Previously closed in this series:

- [PR #517](https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/pull/517) — `run_corpus_batch.py` SyntaxError + stale `track_a` assertion (merged)
- [PR #518](https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/pull/518) — API/Starlette `jpype.__version__` MagicMock cluster (open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)