### PR TITLE
fix(orchestration): register narrative_synthesis service in pipeline registry

### DIFF
--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -55,6 +55,7 @@ from argumentation_analysis.orchestration.invoke_callables import (
     _invoke_kb_to_tweety,
     _invoke_tweety_interpretation,
     _invoke_analysis_synthesis,
+    _invoke_narrative_synthesis,
 )
 
 logger = logging.getLogger("UnifiedPipeline")
@@ -497,6 +498,25 @@ def setup_registry(
             registered.append(name)
         except Exception as e:
             skipped.append((name, str(e)))
+    # --- Narrative synthesis service (#503) ---
+    try:
+        registry.register_service(
+            name="narrative_synthesis_service",
+            service_class=type("narrative_synthesis_service", (), {}),
+            capabilities=["narrative_synthesis"],
+            metadata={
+                "description": (
+                    "Produce readable prose narrative weaving together all "
+                    "analysis phase outputs (quality, fallacies, JTMS, ATMS, "
+                    "Dung, formal logic)"
+                )
+            },
+            invoke=_invoke_narrative_synthesis,
+        )
+        registered.append("narrative_synthesis_service")
+    except Exception as e:
+        skipped.append(("narrative_synthesis_service", str(e)))
+
     # --- Analysis synthesis service (#508) ---
     try:
         registry.register_service(

--- a/tests/unit/argumentation_analysis/orchestration/test_narrative_synthesis_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_narrative_synthesis_spectacular.py
@@ -1,0 +1,72 @@
+"""Tests for narrative_synthesis service registration in spectacular (#503).
+
+The narrative_synthesis phase existed in workflows.py and had a state writer,
+but was missing the service registration in registry_setup.py — causing the
+phase to be skipped in pipeline mode.
+"""
+
+from unittest.mock import MagicMock
+
+
+class TestNarrativeSynthesisRegistration:
+    """Verify narrative_synthesis service is properly registered."""
+
+    def test_narrative_synthesis_service_in_registry(self):
+        from argumentation_analysis.orchestration.registry_setup import setup_registry
+
+        registry = setup_registry()
+        providers = registry.find_for_capability("narrative_synthesis")
+        names = [p.name for p in providers]
+        assert "narrative_synthesis_service" in names
+        provider = next(p for p in providers if p.name == "narrative_synthesis_service")
+        assert provider.invoke is not None
+
+    def test_narrative_synthesis_state_writer_registered(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            CAPABILITY_STATE_WRITERS,
+        )
+
+        assert "narrative_synthesis" in CAPABILITY_STATE_WRITERS
+
+    def test_write_narrative_synthesis_to_state(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_narrative_synthesis_to_state,
+        )
+
+        state = MagicMock()
+        output = {
+            "narrative": "The argument demonstrates strong logical coherence.",
+            "paragraph_count": 1,
+            "referenced_fields": 3,
+        }
+        _write_narrative_synthesis_to_state(output, state, {})
+        assert state.narrative_synthesis == (
+            "The argument demonstrates strong logical coherence."
+        )
+
+    def test_write_narrative_synthesis_empty_output(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_narrative_synthesis_to_state,
+        )
+
+        state = MagicMock()
+        # Empty output should not raise and should not set narrative_synthesis
+        _write_narrative_synthesis_to_state({}, state, {})
+        # MagicMock creates phantom attrs, so just verify no string was assigned
+        assert not isinstance(getattr(state, "narrative_synthesis", ""), str)
+
+    def test_spectacular_has_narrative_synthesis_phase(self):
+        from argumentation_analysis.orchestration.workflows import (
+            build_spectacular_workflow,
+        )
+
+        wf = build_spectacular_workflow()
+        phase = {p.name: p for p in wf.phases}
+        assert "narrative_synthesis" in phase
+        assert phase["narrative_synthesis"].capability == "narrative_synthesis"
+        deps = phase["narrative_synthesis"].depends_on
+        assert "quality" in deps
+        assert "jtms" in deps
+        assert "atms" in deps
+        assert "dung_extensions" in deps
+        assert phase["narrative_synthesis"].optional is True


### PR DESCRIPTION
Register narrative_synthesis_service in registry_setup.py. The phase existed in workflows.py and had invoke callable + state writer, but no service registration causing WorkflowExecutor to skip it in pipeline mode. Closes #503. 5 unit tests passed.