### PR TITLE
feat(orchestration): route external solvers EProver/Prover9/SPASS in spectacular

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -80,6 +80,8 @@ __all__ = [
     "_invoke_kb_to_tweety",
     "_invoke_tweety_interpretation",
     "_invoke_analysis_synthesis",
+    "_invoke_external_fol_solver",
+    "_invoke_external_modal_solver",
 ]
 
 
@@ -4091,3 +4093,189 @@ async def _invoke_tweety_interpretation(
     except Exception as e:
         logger.warning(f"TweetyInterpretation failed: {e}")
         return {"error": str(e), "interpretation": ""}
+
+
+# ---------------------------------------------------------------------------
+# External solver routing — FOL → EProver/Prover9, Modal → SPASS (#504)
+# ---------------------------------------------------------------------------
+
+
+async def _invoke_external_fol_solver(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Route FOL formulas to external solver (EProver/Prover9) with fallback (#504).
+
+    Picks up formulas from the FOL phase output. Tries EProver via Tweety
+    EFOLReasoner first, then Prover9 subprocess. Falls back to TweetyBridge
+    (the default FOL path) when neither external solver is available.
+    """
+    fol_output = context.get("phase_fol_output", {})
+    if not isinstance(fol_output, dict):
+        fol_output = {}
+    formulas = fol_output.get("formulas", [input_text])
+    if not isinstance(formulas, list):
+        formulas = [str(formulas)]
+
+    fol_signature = fol_output.get("fol_signature", [])
+
+    # Try EProver via Tweety EFOLReasoner
+    try:
+        from argumentation_analysis.core.config import settings
+        from argumentation_analysis.agents.core.logic.tweety_bridge import (
+            TweetyBridge,
+        )
+        from argumentation_analysis.agents.core.logic.fol_logic_agent import (
+            FOLLogicAgent,
+        )
+
+        # Check if EProver is configured
+        if getattr(settings, "fol_solver", None) == "eprover":
+            bridge = TweetyBridge()
+            meta = FOLLogicAgent.extract_fol_metadata(formulas)
+            sig = meta.get("signature_lines", fol_signature)
+            belief_set_str = "\n".join(str(f) for f in sig + [""] + formulas)
+            is_consistent, msg = await asyncio.to_thread(
+                bridge.check_consistency, belief_set_str, "first_order"
+            )
+            return {
+                "formulas": formulas,
+                "consistent": bool(is_consistent),
+                "solver": "eprover",
+                "message": msg,
+                "logic_type": "first_order",
+            }
+    except Exception as e:
+        logger.info(f"EProver unavailable ({e}), trying Prover9")
+
+    # Try Prover9 subprocess
+    try:
+        from argumentation_analysis.core.prover9_runner import run_prover9
+
+        belief_set_str = "\n".join(str(f) for f in fol_signature + [""] + formulas)
+        prover9_input = f"formulas(sos).\n{belief_set_str}\nend_of_list.\n"
+        result = await asyncio.to_thread(run_prover9, prover9_input)
+        proved = "THEOREM PROVED" in result or "Proof found" in result
+        return {
+            "formulas": formulas,
+            "consistent": proved,
+            "solver": "prover9",
+            "raw_output": result[:500],
+            "logic_type": "first_order",
+        }
+    except FileNotFoundError:
+        logger.info("Prover9 binary not found, falling back to TweetyBridge")
+    except Exception as e:
+        logger.info(f"Prover9 failed ({e}), falling back to TweetyBridge")
+
+    # Fallback: TweetyBridge (default path)
+    try:
+        from argumentation_analysis.agents.core.logic.tweety_bridge import (
+            TweetyBridge,
+        )
+        from argumentation_analysis.agents.core.logic.fol_logic_agent import (
+            FOLLogicAgent,
+        )
+
+        bridge = TweetyBridge()
+        meta = FOLLogicAgent.extract_fol_metadata(formulas)
+        sig = meta.get("signature_lines", fol_signature)
+        belief_set_str = "\n".join(str(f) for f in sig + [""] + formulas)
+        is_consistent, msg = await asyncio.to_thread(
+            bridge.check_consistency, belief_set_str, "first_order"
+        )
+        return {
+            "formulas": formulas,
+            "consistent": bool(is_consistent),
+            "solver": "tweety_fallback",
+            "message": msg,
+            "logic_type": "first_order",
+        }
+    except Exception as e:
+        return {
+            "formulas": formulas,
+            "consistent": None,
+            "solver": "none",
+            "error": str(e),
+            "logic_type": "first_order",
+        }
+
+
+async def _invoke_external_modal_solver(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Route modal formulas to SPASS with TweetyBridge fallback (#504).
+
+    Picks up formulas from the modal phase output. Tries SPASS via
+    SPASSMlReasoner first. Falls back to TweetyBridge when SPASS is
+    not available.
+    """
+    modal_output = context.get("phase_modal_output", {})
+    if not isinstance(modal_output, dict):
+        modal_output = {}
+    formulas = modal_output.get("formulas", [input_text])
+    if not isinstance(formulas, list):
+        formulas = [str(formulas)]
+
+    modalities = modal_output.get("modalities", ["none_detected"])
+
+    # Try SPASS via ModalHandler
+    try:
+        from argumentation_analysis.core.config import settings, ModalSolverChoice
+        from argumentation_analysis.agents.core.logic.modal_handler import (
+            ModalHandler,
+        )
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
+
+        if not settings.modal_solver == ModalSolverChoice.SPASS:
+            object.__setattr__(settings, "modal_solver", ModalSolverChoice.SPASS)
+        initializer = TweetyInitializer()
+        handler = ModalHandler(initializer_instance=initializer)
+        belief_set_str = "\n".join(str(f) for f in formulas)
+        is_consistent, msg = await asyncio.to_thread(
+            handler.is_modal_kb_consistent, belief_set_str
+        )
+        return {
+            "formulas": formulas,
+            "valid": bool(is_consistent),
+            "modalities": modalities,
+            "solver": "spass",
+            "message": msg,
+            "logic_type": "modal",
+        }
+    except Exception as e:
+        logger.info(f"SPASS modal solver unavailable ({e}), falling back to Tweety")
+
+    # Fallback: TweetyBridge
+    try:
+        from argumentation_analysis.agents.core.logic.tweety_bridge import (
+            TweetyBridge,
+        )
+
+        bridge = TweetyBridge()
+        belief_set_str = "\n".join(str(f) for f in formulas)
+        logic_type = context.get("modal_logic_type", "K")
+        accepted, msg = await asyncio.to_thread(
+            bridge.execute_modal_query,
+            belief_set_str,
+            belief_set_str,
+            logic_type=logic_type,
+        )
+        return {
+            "formulas": formulas,
+            "valid": accepted,
+            "modalities": modalities,
+            "solver": "tweety_fallback",
+            "message": msg,
+            "logic_type": "modal",
+        }
+    except Exception as e:
+        return {
+            "formulas": formulas,
+            "valid": None,
+            "modalities": modalities,
+            "solver": "none",
+            "error": str(e),
+            "logic_type": "modal",
+        }

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -56,6 +56,8 @@ from argumentation_analysis.orchestration.invoke_callables import (
     _invoke_tweety_interpretation,
     _invoke_analysis_synthesis,
     _invoke_narrative_synthesis,
+    _invoke_external_fol_solver,
+    _invoke_external_modal_solver,
 )
 
 logger = logging.getLogger("UnifiedPipeline")
@@ -516,6 +518,33 @@ def setup_registry(
         registered.append("narrative_synthesis_service")
     except Exception as e:
         skipped.append(("narrative_synthesis_service", str(e)))
+
+    # --- External solver routing services (#504) ---
+    for name, caps, desc, invoke_fn in [
+        (
+            "external_fol_solver_service",
+            ["external_fol_solving"],
+            "Route FOL formulas to EProver/Prover9 with TweetyBridge fallback",
+            _invoke_external_fol_solver,
+        ),
+        (
+            "external_modal_solver_service",
+            ["external_modal_solving"],
+            "Route modal formulas to SPASS with TweetyBridge fallback",
+            _invoke_external_modal_solver,
+        ),
+    ]:
+        try:
+            registry.register_service(
+                name=name,
+                service_class=type(name, (), {}),
+                capabilities=caps,
+                metadata={"description": desc},
+                invoke=invoke_fn,
+            )
+            registered.append(name)
+        except Exception as e:
+            skipped.append((name, str(e)))
 
     # --- Analysis synthesis service (#508) ---
     try:

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -49,6 +49,8 @@ __all__ = [
     "_write_qbf_to_state",
     "_write_collaborative_analysis_to_state",
     "_write_narrative_synthesis_to_state",
+    "_write_external_fol_solver_to_state",
+    "_write_external_modal_solver_to_state",
     "CAPABILITY_STATE_WRITERS",
 ]
 
@@ -889,6 +891,8 @@ def _write_tweety_interpretation_to_state(
             add_extract("formal_interpretation", interpretation)
         elif hasattr(state, "formal_interpretation"):
             state.formal_interpretation = interpretation
+
+
 def _write_analysis_synthesis_to_state(
     output: Any, state: Any, ctx: dict[str, Any]
 ) -> None:
@@ -903,6 +907,48 @@ def _write_analysis_synthesis_to_state(
                 "phase_count": output.get("phase_count", 0),
                 "overall_completeness": output.get("overall_completeness", 0.0),
             }
+
+
+def _write_external_fol_solver_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
+    """Write external FOL solver results to UnifiedAnalysisState (#504)."""
+    if not output or not isinstance(output, dict):
+        return
+    solver = output.get("solver", "none")
+    consistent = output.get("consistent")
+    if isinstance(state, dict):
+        state["external_fol_solver"] = {
+            "solver": solver,
+            "consistent": consistent,
+        }
+    else:
+        if hasattr(state, "fol_analysis_results") and isinstance(
+            state.fol_analysis_results, dict
+        ):
+            state.fol_analysis_results["external_solver"] = solver
+            state.fol_analysis_results["external_consistent"] = consistent
+
+
+def _write_external_modal_solver_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
+    """Write external modal solver results to UnifiedAnalysisState (#504)."""
+    if not output or not isinstance(output, dict):
+        return
+    solver = output.get("solver", "none")
+    valid = output.get("valid")
+    if isinstance(state, dict):
+        state["external_modal_solver"] = {
+            "solver": solver,
+            "valid": valid,
+        }
+    else:
+        if hasattr(state, "modal_analysis_results") and isinstance(
+            state.modal_analysis_results, dict
+        ):
+            state.modal_analysis_results["external_solver"] = solver
+            state.modal_analysis_results["external_valid"] = valid
 
 
 CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
@@ -946,4 +992,6 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "kb_to_tweety": _write_kb_to_tweety_to_state,
     "formal_result_interpretation": _write_tweety_interpretation_to_state,
     "analysis_synthesis": _write_analysis_synthesis_to_state,
+    "external_fol_solving": _write_external_fol_solver_to_state,
+    "external_modal_solving": _write_external_modal_solver_to_state,
 }

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -602,6 +602,20 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             depends_on=["nl_to_logic"],
             optional=True,
         )
+        # L2c — external solver routing: FOL→EProver/Prover9 (#504)
+        .add_phase(
+            "fol_solver",
+            capability="external_fol_solving",
+            depends_on=["fol"],
+            optional=True,
+        )
+        # L2d — external solver routing: Modal→SPASS (#504)
+        .add_phase(
+            "modal_solver",
+            capability="external_modal_solving",
+            depends_on=["modal"],
+            optional=True,
+        )
         # L3 — Dung extensions (from fallacy + PL results)
         .add_phase(
             "dung_extensions",

--- a/tests/unit/argumentation_analysis/orchestration/test_external_solver_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_external_solver_spectacular.py
@@ -1,0 +1,141 @@
+"""Tests for external solver routing in spectacular workflow (#504).
+
+Verifies that fol_solver and modal_solver phases exist in spectacular,
+are registered as services in the registry, and have state writers.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestExternalSolverSpectacular:
+    """Verify external solver phases in spectacular workflow."""
+
+    def test_spectacular_has_fol_solver_phase(self):
+        from argumentation_analysis.orchestration.workflows import (
+            build_spectacular_workflow,
+        )
+
+        wf = build_spectacular_workflow()
+        phase = {p.name: p for p in wf.phases}
+        assert "fol_solver" in phase
+        assert phase["fol_solver"].capability == "external_fol_solving"
+        assert "fol" in phase["fol_solver"].depends_on
+        assert phase["fol_solver"].optional is True
+
+    def test_spectacular_has_modal_solver_phase(self):
+        from argumentation_analysis.orchestration.workflows import (
+            build_spectacular_workflow,
+        )
+
+        wf = build_spectacular_workflow()
+        phase = {p.name: p for p in wf.phases}
+        assert "modal_solver" in phase
+        assert phase["modal_solver"].capability == "external_modal_solving"
+        assert "modal" in phase["modal_solver"].depends_on
+        assert phase["modal_solver"].optional is True
+
+    def test_spectacular_phase_count_with_solvers(self):
+        from argumentation_analysis.orchestration.workflows import (
+            build_spectacular_workflow,
+        )
+
+        wf = build_spectacular_workflow()
+        assert len(wf.phases) == 27
+
+    def test_external_fol_solver_service_registered(self):
+        from argumentation_analysis.orchestration.registry_setup import setup_registry
+
+        registry = setup_registry()
+        providers = registry.find_for_capability("external_fol_solving")
+        names = [p.name for p in providers]
+        assert "external_fol_solver_service" in names
+        provider = next(p for p in providers if p.name == "external_fol_solver_service")
+        assert provider.invoke is not None
+
+    def test_external_modal_solver_service_registered(self):
+        from argumentation_analysis.orchestration.registry_setup import setup_registry
+
+        registry = setup_registry()
+        providers = registry.find_for_capability("external_modal_solving")
+        names = [p.name for p in providers]
+        assert "external_modal_solver_service" in names
+        provider = next(
+            p for p in providers if p.name == "external_modal_solver_service"
+        )
+        assert provider.invoke is not None
+
+    def test_external_fol_solver_state_writer(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_external_fol_solver_to_state,
+        )
+
+        state = MagicMock()
+        state.fol_analysis_results = {}
+        output = {
+            "formulas": ["P(a)", "Q(b)"],
+            "consistent": True,
+            "solver": "eprover",
+        }
+        _write_external_fol_solver_to_state(output, state, {})
+        assert state.fol_analysis_results == {
+            "external_solver": "eprover",
+            "external_consistent": True,
+        }
+
+    def test_external_modal_solver_state_writer(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_external_modal_solver_to_state,
+        )
+
+        state = MagicMock()
+        state.modal_analysis_results = {}
+        output = {
+            "formulas": ["[]p", "<>q"],
+            "valid": True,
+            "solver": "spass",
+        }
+        _write_external_modal_solver_to_state(output, state, {})
+        assert state.modal_analysis_results == {
+            "external_solver": "spass",
+            "external_valid": True,
+        }
+
+    def test_invoke_external_fol_solver_fallback(self):
+        """When no external solver is available, falls back to TweetyBridge."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_external_fol_solver,
+        )
+        import asyncio
+
+        async def _run():
+            ctx = {
+                "phase_fol_output": {
+                    "formulas": ["Asserted(arg1)"],
+                    "fol_signature": [],
+                }
+            }
+            result = await _invoke_external_fol_solver("test text", ctx)
+            assert "solver" in result
+            assert result["logic_type"] == "first_order"
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_invoke_external_modal_solver_fallback(self):
+        """When SPASS is unavailable, falls back to TweetyBridge."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_external_modal_solver,
+        )
+        import asyncio
+
+        async def _run():
+            ctx = {
+                "phase_modal_output": {
+                    "formulas": ["[]p -> <>q"],
+                    "modalities": ["necessity"],
+                }
+            }
+            result = await _invoke_external_modal_solver("test text", ctx)
+            assert "solver" in result
+            assert result["logic_type"] == "modal"
+
+        asyncio.get_event_loop().run_until_complete(_run())


### PR DESCRIPTION
Route FOL formulas to EProver/Prover9 and modal formulas to SPASS in spectacular workflow. Adds fol_solver and modal_solver phases with graceful fallback to TweetyBridge when binaries absent. Spectacular 25 to 27 phases. Closes #504. 9 unit tests passed.