### PR TITLE
fix(scripts): add_extract.py text_retriever crash

### DIFF
--- a/scripts/dataset/add_extract.py
+++ b/scripts/dataset/add_extract.py
@@ -134,6 +134,7 @@ def main(argv: list[str] | None = None) -> int:
         "schema": "v1",
         "host_parts": metadata.get("host_parts", "local").split(","),
         "path": metadata.get("path", ""),
+        "full_text": plaintext,
         "extracts": [
             {
                 "full_text": plaintext,
@@ -151,7 +152,7 @@ def main(argv: list[str] | None = None) -> int:
         config_file=ENCRYPTED_PATH,
         b64_derived_key=b64_key,
         embed_full_text=True,
-        text_retriever=lambda x: plaintext,
+        text_retriever=lambda source_info, **_kwargs: source_info.get("full_text", ""),
     )
     if not ok:
         print("ERROR: failed to save encrypted dataset.", file=sys.stderr)


### PR DESCRIPTION
## Summary
- Fix `TypeError: unexpected keyword argument 'app_config'` in `add_extract.py` when `io_manager.save_extract_definitions` calls the text_retriever lambda with `app_config=config`
- Add `full_text` at source dict level (not just extract level) so `io_manager` finds it directly without needing the retriever fallback
- Change lambda from `lambda x: plaintext` to `lambda source_info, **_kwargs: source_info.get("full_text", "")` — accepts kwargs and returns source's own text

## Test plan
- [x] Ran `add_extract.py` with a test file — no TypeError, clean save
- [x] Verified source-level `full_text` populated for new entries
- [x] Verified existing dataset loads and saves correctly with new retriever

🤖 Generated with [Claude Code](https://claude.com/claude-code)