### PR TITLE
feat(synthesis): wire DeepSynthesisAgent as terminal phase + CLI runner (#534)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -545,6 +545,39 @@ async def run_conversational_analysis(
         except Exception as e:
             logger.warning(f"Re-analysis phase check failed: {e}")
 
+    # 5c. Deep Synthesis post-phase (#534)
+    # Run DeepSynthesisAgent on the accumulated state to produce a 9-section
+    # grounded markdown report. Appended as terminal step after all agents.
+    deep_synthesis_result = None
+    if spectacular:
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _invoke_deep_synthesis,
+            )
+
+            source_meta = {
+                "opaque_id": source_id or "unknown",
+                "era": "",
+                "language": "",
+                "discourse_type": "",
+            }
+            ctx = {
+                "_state_object": state,
+                "source_metadata": source_meta,
+            }
+            deep_synthesis_result = await _invoke_deep_synthesis("", ctx)
+            if "error" not in deep_synthesis_result:
+                logger.info(
+                    f"Deep synthesis completed: "
+                    f"{deep_synthesis_result.get('sections_populated', '?')}/9 sections"
+                )
+            else:
+                logger.warning(
+                    f"Deep synthesis skipped: {deep_synthesis_result.get('error', '?')}"
+                )
+        except Exception as e:
+            logger.warning(f"Deep synthesis post-phase failed: {e}")
+
     # 6. Stop trace and build results
     trace.stop()
     duration = time.time() - start_time
@@ -569,6 +602,7 @@ async def run_conversational_analysis(
         "conversation_log": conversation_log,
         "total_messages": len(conversation_log),
         "duration_seconds": duration,
+        "deep_synthesis": deep_synthesis_result,
         "state_snapshot": state_snapshot,
         "state_non_empty_fields": non_empty,
         "state_total_fields": len(state_snapshot),

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -594,6 +594,22 @@ def setup_registry(
     if skipped:
         logger.debug(f"Skipped components: {[s[0] for s in skipped]}")
 
+    # Deep synthesis service (#532)
+    try:
+        registry.register_service(
+            name="deep_synthesis_service",
+            service_class=type("DeepSynthesisService", (), {}),
+            capabilities=["deep_synthesis", "multi_page_report", "grounded_analysis"],
+            metadata={
+                "description": "Aggregates spectacular-run state into multi-page grounded markdown report (9 sections)",
+                "sections": 9,
+            },
+            invoke=_invoke_deep_synthesis,
+        )
+        registered.append("deep_synthesis_service")
+    except Exception as e:
+        skipped.append(("deep_synthesis_service", str(e)))
+
     return registry
 
 
@@ -721,19 +737,3 @@ def _declare_tweety_slots(registry: CapabilityRegistry) -> None:
             # Fall back to slot declaration if JVM not available
             for cap in caps:
                 registry.declare_slot(cap, requires=["jvm"], description=desc)
-
-    # Deep synthesis service (#532)
-    try:
-        registry.register_service(
-            name="deep_synthesis_service",
-            service_class=type("DeepSynthesisService", (), {}),
-            capabilities=["deep_synthesis", "multi_page_report", "grounded_analysis"],
-            metadata={
-                "description": "Aggregates spectacular-run state into multi-page grounded markdown report (9 sections)",
-                "sections": 9,
-            },
-            invoke=_invoke_deep_synthesis,
-        )
-        registered.append("deep_synthesis_service")
-    except Exception as e:
-        skipped.append(("deep_synthesis_service", str(e)))

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -749,6 +749,18 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             ],
             optional=True,
         )
+        # L10 — Deep synthesis: grounded 9-section markdown report (#534)
+        .add_phase(
+            "deep_synthesis",
+            capability="deep_synthesis",
+            depends_on=[
+                "synthesis",
+                "narrative_synthesis",
+                "belief_revision",
+            ],
+            optional=False,
+            timeout_seconds=180,
+        )
         .build()
     )
 

--- a/scripts/run_deep_synthesis.py
+++ b/scripts/run_deep_synthesis.py
@@ -1,0 +1,192 @@
+"""Deep Synthesis runner — produces 9-section grounded markdown reports (#534).
+
+Runs the spectacular (or conversational) workflow on a source from the
+encrypted dataset, then invokes DeepSynthesisAgent to produce a multi-page
+markdown analysis under outputs/deep_analysis/ (gitignored).
+
+Usage:
+    # Run on a specific source from the encrypted dataset
+    python scripts/run_deep_synthesis.py --source src0_ext0
+
+    # Run on raw text (for testing)
+    python scripts/run_deep_synthesis.py --text "Some argumentative text to analyze..."
+
+    # Choose workflow
+    python scripts/run_deep_synthesis.py --source src0_ext0 --workflow conversational
+
+    # Specify output path
+    python scripts/run_deep_synthesis.py --source src0_ext0 --output outputs/deep_analysis/custom.md
+"""
+import argparse
+import asyncio
+import json
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+OUTPUT_DIR = Path("outputs/deep_analysis")
+
+
+async def run_from_source(source_id: str, workflow: str = "spectacular") -> dict:
+    """Run full workflow + deep synthesis on a dataset source."""
+    from argumentation_analysis.core.io_manager import load_extract_definitions
+    from argumentation_analysis.core.environment import ensure_environment
+
+    ensure_environment()
+
+    # Load text from encrypted dataset
+    definitions = load_extract_definitions()
+    text = None
+    source_meta = {}
+    for source in definitions:
+        for extract in source.get("extracts", []):
+            eid = f"src{source.get('source_num', '?')}_ext{extract.get('extract_num', '?')}"
+            if eid == source_id:
+                text = extract.get("full_text", "") or extract.get("text", "")
+                source_meta = {
+                    "opaque_id": source_id,
+                    "era": extract.get("era", ""),
+                    "language": extract.get("language", ""),
+                    "discourse_type": extract.get("discourse_type", ""),
+                }
+                break
+        if text:
+            break
+
+    if not text:
+        available = set()
+        for s in definitions:
+            for e in s.get("extracts", []):
+                available.add(f"src{s.get('source_num', '?')}_ext{e.get('extract_num', '?')}")
+        print(f"ERROR: Source '{source_id}' not found. Available: {sorted(available)}")
+        sys.exit(1)
+
+    print(f"Source: {source_id} ({len(text)} chars)")
+    return await run_on_text(text, source_meta, workflow)
+
+
+async def run_on_text(
+    text: str,
+    source_meta: Optional[dict] = None,
+    workflow: str = "spectacular",
+) -> dict:
+    """Run workflow + deep synthesis on raw text."""
+    from argumentation_analysis.orchestration.invoke_callables import _invoke_deep_synthesis
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+    source_meta = source_meta or {"opaque_id": "inline_text", "era": "", "language": "", "discourse_type": ""}
+
+    # Build a populated state from the spectacular pipeline
+    print(f"Running {workflow} workflow...")
+    start = time.time()
+
+    state = UnifiedAnalysisState(text)
+
+    if workflow == "spectacular":
+        try:
+            from argumentation_analysis.orchestration.unified_pipeline import UnifiedPipeline
+            pipeline = UnifiedPipeline()
+            pipeline.setup_registry()
+            results = await pipeline.run_unified_analysis(
+                text=text,
+                workflow_name="spectacular",
+                source_id=source_meta.get("opaque_id", "unknown"),
+            )
+            # Extract the state from pipeline results
+            if isinstance(results, dict):
+                state = results.get("unified_state", results.get("state", state))
+                if not isinstance(state, UnifiedAnalysisState):
+                    state = UnifiedAnalysisState(text)
+        except Exception as e:
+            print(f"WARNING: Pipeline run failed ({e}), using empty state")
+    elif workflow == "conversational":
+        try:
+            from argumentation_analysis.orchestration.conversational_orchestrator import (
+                run_conversational_analysis,
+            )
+            results = await run_conversational_analysis(
+                text=text,
+                source_id=source_meta.get("opaque_id", "unknown"),
+                spectacular=True,
+            )
+            state = results.get("unified_state", state)
+        except Exception as e:
+            print(f"WARNING: Conversational run failed ({e}), using empty state")
+
+    pipeline_duration = time.time() - start
+    print(f"Workflow completed in {pipeline_duration:.1f}s")
+
+    # Run deep synthesis
+    print("Running deep synthesis...")
+    ctx = {
+        "_state_object": state,
+        "source_metadata": source_meta,
+    }
+    ds_result = await _invoke_deep_synthesis("", ctx)
+
+    if "error" in ds_result:
+        print(f"ERROR: Deep synthesis failed: {ds_result['error']}")
+        sys.exit(1)
+
+    ds_result["pipeline_duration_s"] = pipeline_duration
+    return ds_result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Run DeepSynthesisAgent on a corpus source or raw text"
+    )
+    source_group = parser.add_mutually_exclusive_group(required=True)
+    source_group.add_argument("--source", help="Source ID from encrypted dataset (e.g. src0_ext0)")
+    source_group.add_argument("--text", help="Raw text to analyze")
+    parser.add_argument(
+        "--workflow",
+        choices=["spectacular", "conversational"],
+        default="spectacular",
+        help="Workflow to run before deep synthesis (default: spectacular)",
+    )
+    parser.add_argument("--output", help="Output markdown file path")
+    args = parser.parse_args()
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    if args.source:
+        result = asyncio.run(run_from_source(args.source, args.workflow))
+    else:
+        meta = {"opaque_id": "inline", "era": "", "language": "", "discourse_type": ""}
+        result = asyncio.run(run_on_text(args.text, meta, args.workflow))
+
+    # Determine output path
+    if args.output:
+        out_path = Path(args.output)
+    else:
+        ts = datetime.now().strftime("%Y%m%dT%H%M%S")
+        opaque = "inline"
+        if args.source:
+            opaque = args.source
+        out_path = OUTPUT_DIR / f"{opaque}_{ts}.md"
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write markdown
+    markdown = result.get("markdown", "")
+    out_path.write_text(markdown, encoding="utf-8")
+
+    # Summary
+    print(f"\n{'='*60}")
+    print(f"Deep Synthesis Report")
+    print(f"{'='*60}")
+    print(f"Output: {out_path}")
+    print(f"Sections: {result.get('sections_populated', '?')}/9")
+    print(f"State fields consumed: {result.get('total_state_fields', '?')}")
+    print(f"Markdown length: {len(markdown)} chars")
+    print(f"Pipeline duration: {result.get('pipeline_duration_s', '?')}s")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/argumentation_analysis/test_deep_synthesis_wiring.py
+++ b/tests/unit/argumentation_analysis/test_deep_synthesis_wiring.py
@@ -1,0 +1,234 @@
+"""Integration tests for DeepSynthesisAgent wiring (#534).
+
+Tests verify:
+- DAG ordering: deep_synthesis phase runs after its dependencies
+- File output: invoke callable produces valid markdown with non-empty sections
+- Conversational orchestrator includes deep_synthesis result
+- CLI runner argument parsing
+"""
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.agents.core.synthesis.deep_synthesis_agent import (
+    DeepSynthesisAgent,
+)
+from argumentation_analysis.agents.core.synthesis.deep_synthesis_models import (
+    DeepSynthesisReport,
+)
+
+
+def _make_fixture_state() -> UnifiedAnalysisState:
+    """Build a fixture state with data in key analysis dimensions."""
+    state = UnifiedAnalysisState(
+        "The speaker argues that national sovereignty requires immediate action. "
+        "They claim that foreign powers threaten our independence. "
+        "However, the evidence shows cooperation yields better outcomes. "
+        "We must defend our borders against external interference."
+    )
+    state.add_argument("National sovereignty requires immediate action")
+    state.add_argument("Foreign powers threaten our independence")
+    state.add_argument("Cooperation yields better outcomes")
+    state.add_argument("We must defend our borders against external interference")
+    state.add_fallacy("ad hominem", "Attacks foreign powers instead of argument", "arg_1")
+    state.add_fallacy("slippery slope", "Suggests sovereignty loss without evidence", "arg_2")
+    state.add_dung_framework(
+        name="main_framework",
+        arguments=["arg_1", "arg_2", "arg_3", "arg_4"],
+        attacks=[["arg_3", "arg_1"], ["arg_3", "arg_2"]],
+        extensions={
+            "grounded": ["arg_3", "arg_4"],
+            "preferred": [["arg_3", "arg_4"]],
+            "stable": [["arg_3", "arg_4"]],
+        },
+    )
+    state.add_counter_argument(
+        original_arg="Foreign powers threaten our independence",
+        counter_content="Historical data shows alliances strengthen sovereignty",
+        strategy="counter-example",
+        score=8.5,
+    )
+    return state
+
+
+# =========================================================================
+# Test: DAG ordering in spectacular workflow
+# =========================================================================
+
+
+class TestDAGOrdering:
+
+    def test_deep_synthesis_phase_exists_in_spectacular(self):
+        """deep_synthesis phase should be present in the spectacular workflow."""
+        from argumentation_analysis.orchestration.workflows import build_spectacular_workflow
+
+        wf = build_spectacular_workflow()
+        phase_names = [p.name for p in wf.phases]
+        assert "deep_synthesis" in phase_names, (
+            f"deep_synthesis not in spectacular phases: {phase_names}"
+        )
+
+    def test_deep_synthesis_depends_on_correct_phases(self):
+        """deep_synthesis should depend on synthesis, narrative_synthesis, belief_revision."""
+        from argumentation_analysis.orchestration.workflows import build_spectacular_workflow
+
+        wf = build_spectacular_workflow()
+        ds_phase = next(p for p in wf.phases if p.name == "deep_synthesis")
+        assert set(ds_phase.depends_on) == {"synthesis", "narrative_synthesis", "belief_revision"}
+
+    def test_deep_synthesis_is_after_synthesis(self):
+        """deep_synthesis must come after synthesis in the phase list."""
+        from argumentation_analysis.orchestration.workflows import build_spectacular_workflow
+
+        wf = build_spectacular_workflow()
+        phase_names = [p.name for p in wf.phases]
+        synthesis_idx = phase_names.index("synthesis")
+        ds_idx = phase_names.index("deep_synthesis")
+        assert ds_idx > synthesis_idx
+
+    def test_deep_synthesis_not_optional_in_spectacular(self):
+        """deep_synthesis should be non-optional in the spectacular workflow."""
+        from argumentation_analysis.orchestration.workflows import build_spectacular_workflow
+
+        wf = build_spectacular_workflow()
+        ds_phase = next(p for p in wf.phases if p.name == "deep_synthesis")
+        assert ds_phase.optional is False
+
+    def test_deep_synthesis_has_timeout(self):
+        """deep_synthesis should have a timeout_seconds set."""
+        from argumentation_analysis.orchestration.workflows import build_spectacular_workflow
+
+        wf = build_spectacular_workflow()
+        ds_phase = next(p for p in wf.phases if p.name == "deep_synthesis")
+        assert ds_phase.timeout_seconds is not None
+        assert ds_phase.timeout_seconds > 0
+
+    def test_deep_synthesis_capability_registered(self):
+        """The deep_synthesis capability should be registered in the registry."""
+        from argumentation_analysis.orchestration.registry_setup import setup_registry
+
+        registry = setup_registry()
+        providers = registry.find_services_for_capability("deep_synthesis")
+        assert len(providers) > 0, "No service registered for deep_synthesis capability"
+
+
+# =========================================================================
+# Test: File output via invoke callable
+# =========================================================================
+
+
+class TestFileOutput:
+
+    def test_invoke_produces_markdown_file(self, tmp_path):
+        """Invoke callable should write markdown to the specified output path."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_deep_synthesis
+
+        state = _make_fixture_state()
+        output_file = tmp_path / "test_report.md"
+
+        ctx = {
+            "_state_object": state,
+            "source_metadata": {
+                "opaque_id": "test_corpus",
+                "era": "2020s",
+                "language": "en",
+                "discourse_type": "populist",
+            },
+            "deep_synthesis_output_path": str(output_file),
+        }
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _invoke_deep_synthesis("", ctx)
+        )
+
+        assert "error" not in result
+        assert output_file.exists()
+        content = output_file.read_text(encoding="utf-8")
+        assert len(content) > 500
+
+    def test_markdown_has_required_sections(self, tmp_path):
+        """Output markdown should have non-empty sections 1, 2, 3 minimum."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_deep_synthesis
+
+        state = _make_fixture_state()
+        output_file = tmp_path / "sections_report.md"
+
+        ctx = {
+            "_state_object": state,
+            "source_metadata": {
+                "opaque_id": "test_corpus",
+                "era": "2020s",
+                "language": "en",
+                "discourse_type": "populist",
+            },
+            "deep_synthesis_output_path": str(output_file),
+        }
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _invoke_deep_synthesis("", ctx)
+        )
+
+        content = output_file.read_text(encoding="utf-8")
+        assert "## 1. Source Overview" in content
+        assert "## 2. Argument Map" in content
+        assert "## 3. Fallacy Diagnosis" in content
+        assert result["sections_populated"] >= 3
+
+    def test_invoke_without_output_path(self):
+        """Invoke callable should work without deep_synthesis_output_path."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_deep_synthesis
+
+        state = _make_fixture_state()
+        ctx = {
+            "_state_object": state,
+            "source_metadata": {
+                "opaque_id": "test_no_path",
+                "era": "2020s",
+                "language": "en",
+                "discourse_type": "populist",
+            },
+        }
+
+        result = asyncio.get_event_loop().run_until_complete(
+            _invoke_deep_synthesis("", ctx)
+        )
+
+        assert "error" not in result
+        assert "markdown" in result
+        assert len(result["markdown"]) > 500
+
+
+# =========================================================================
+# Test: CLI runner argument parsing
+# =========================================================================
+
+
+class TestCLIRunner:
+
+    def test_cli_imports(self):
+        """CLI runner module should import without errors."""
+        import importlib
+        mod = importlib.import_module("scripts.run_deep_synthesis")
+        assert hasattr(mod, "run_on_text")
+        assert hasattr(mod, "run_from_source")
+        assert hasattr(mod, "main")
+
+    def test_cli_run_on_text(self):
+        """run_on_text should produce a valid result dict without full pipeline."""
+        from scripts.run_deep_synthesis import run_on_text
+
+        # Patch pipeline imports to avoid actual LLM calls
+        with patch.dict("sys.modules", {
+            "argumentation_analysis.orchestration.unified_pipeline": None,
+            "argumentation_analysis.orchestration.conversational_orchestrator": None,
+        }):
+            meta = {"opaque_id": "cli_test", "era": "", "language": "en", "discourse_type": "other"}
+            result = asyncio.run(run_on_text("Test argument text.", meta, "spectacular"))
+
+        assert "markdown" in result
+        assert result["sections_populated"] >= 1


### PR DESCRIPTION
## Summary

- Adds `deep_synthesis` as a terminal phase in the spectacular workflow (depends_on synthesis, narrative_synthesis, belief_revision; non-optional; 180s timeout)
- Adds post-phase deep synthesis hook in conversational orchestrator (spectacular mode only)
- Fixes registry registration bug (moved from `_declare_tweety_slots` to `setup_registry` where `registered`/`skipped` locals exist)
- CLI runner `scripts/run_deep_synthesis.py` with `--source` (encrypted dataset ID) or `--text` flags, `--workflow` choice, and `--output` path
- 11 integration tests: DAG ordering (6), file output (3), CLI runner (2)

## Files changed

| File | Change |
|------|--------|
| `workflows.py` | Modified — add `deep_synthesis` terminal phase to spectacular full |
| `conversational_orchestrator.py` | Modified — post-phase deep synthesis on spectacular runs |
| `registry_setup.py` | Modified — fix registration moved to `setup_registry()` |
| `scripts/run_deep_synthesis.py` | **NEW** — CLI runner with --source/--text/--workflow/--output |
| `test_deep_synthesis_wiring.py` | **NEW** — 11 integration tests |

## Test plan

- [x] 32 tests pass (21 agent + 11 wiring): `pytest tests/unit/argumentation_analysis/test_deep_synthesis_agent.py tests/unit/argumentation_analysis/test_deep_synthesis_wiring.py -v`
- [x] DAG ordering verified: deep_synthesis depends on synthesis, narrative_synthesis, belief_revision
- [x] File output verified: markdown created with sections 1, 2, 3 non-empty
- [ ] Manual run on corpus_dense_A (requires LLM, ~10 min) — post-merge

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)