### PR TITLE
fix(debate): accept string quality descriptors in suggest_debate_strategy (#538)

### DIFF
--- a/argumentation_analysis/agents/core/debate/debate_agent.py
+++ b/argumentation_analysis/agents/core/debate/debate_agent.py
@@ -18,7 +18,58 @@ import random
 import statistics
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
+
+_DESCRIPTOR_MAP: Dict[str, float] = {
+    "high": 0.85,
+    "élevé": 0.85,
+    "eleve": 0.85,
+    "strong": 0.8,
+    "fort": 0.8,
+    "medium": 0.5,
+    "moyen": 0.5,
+    "mixed": 0.5,
+    "mitigé": 0.5,
+    "mitige": 0.5,
+    "moderate": 0.5,
+    "modéré": 0.5,
+    "modere": 0.5,
+    "low": 0.2,
+    "faible": 0.2,
+    "weak": 0.2,
+    "faible": 0.2,
+    "very_low": 0.1,
+    "très_faible": 0.1,
+    "tres_faible": 0.1,
+}
+
+
+def _coerce_score(value: Union[str, int, float]) -> float:
+    """Convert a quality score to float, handling string descriptors.
+
+    Maps known qualitative descriptors (high/medium/low and FR equivalents)
+    to numeric scores. Unknown strings default to 0.5 (neutral).
+
+    Args:
+        value: Numeric value or qualitative descriptor string.
+
+    Returns:
+        Float score in [0, 1].
+    """
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _DESCRIPTOR_MAP:
+            return _DESCRIPTOR_MAP[normalized]
+        try:
+            return float(normalized)
+        except ValueError:
+            logger.warning(
+                "Unknown quality descriptor '%s', defaulting to 0.5", value
+            )
+            return 0.5
+    return 0.5
 
 from pydantic import PrivateAttr
 from semantic_kernel import Kernel
@@ -119,7 +170,7 @@ class DebatePlugin:
     ) -> str:
         """Suggest a debate strategy based on context."""
         turn = int(turn_number) if turn_number.isdigit() else 0
-        opp = float(opponent_strength)
+        opp = _coerce_score(opponent_strength)
 
         if turn < 3:
             strategy = "balanced"

--- a/tests/unit/argumentation_analysis/agents/core/debate/test_debate.py
+++ b/tests/unit/argumentation_analysis/agents/core/debate/test_debate.py
@@ -1050,3 +1050,174 @@ class TestDebateModerator:
         assert state.phase == DebatePhase.CONCLUDED
         assert len(state.arguments) == 14  # 2+6+4+2
         assert state.winner is not None
+
+
+# ---------------------------------------------------------------------------
+# _coerce_score tests (SCDA Sprint 2 — #538)
+# ---------------------------------------------------------------------------
+
+
+class TestCoerceScore:
+    """Test _coerce_score handles string quality descriptors robustly."""
+
+    def test_numeric_int(self):
+        """Integer input converts to float."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score(1) == 1.0
+        assert _coerce_score(0) == 0.0
+
+    def test_numeric_float(self):
+        """Float input passes through."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score(0.85) == 0.85
+        assert _coerce_score(0.0) == 0.0
+
+    def test_high_descriptor(self):
+        """'high' maps to 0.85."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score("high") == 0.85
+
+    def test_elevé_descriptor(self):
+        """French 'élevé' maps to 0.85."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score("élevé") == 0.85
+
+    def test_medium_descriptor(self):
+        """'medium' maps to 0.5."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score("medium") == 0.5
+
+    def test_mixed_descriptor(self):
+        """'mixed' maps to 0.5 — the original crash case."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score("mixed") == 0.5
+
+    def test_moyen_descriptor(self):
+        """French 'moyen' maps to 0.5."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score("moyen") == 0.5
+
+    def test_low_descriptor(self):
+        """'low' maps to 0.2."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score("low") == 0.2
+
+    def test_faible_descriptor(self):
+        """French 'faible' maps to 0.2."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score("faible") == 0.2
+
+    def test_unknown_string_defaults_neutral(self):
+        """Unknown descriptor defaults to 0.5 with warning."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score("inconclusive") == 0.5
+        assert _coerce_score("N/A") == 0.5
+
+    def test_numeric_string(self):
+        """String containing a number converts correctly."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score("0.75") == 0.75
+        assert _coerce_score("0.3") == 0.3
+
+    def test_whitespace_trimmed(self):
+        """Whitespace around descriptor is trimmed."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score("  high  ") == 0.85
+        assert _coerce_score(" mixed ") == 0.5
+
+    def test_case_insensitive(self):
+        """Descriptor matching is case-insensitive."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score("High") == 0.85
+        assert _coerce_score("MIXED") == 0.5
+        assert _coerce_score("Low") == 0.2
+
+    def test_non_string_non_numeric_defaults(self):
+        """Non-string, non-numeric input defaults to 0.5."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            _coerce_score,
+        )
+
+        assert _coerce_score(None) == 0.5
+
+
+class TestSuggestDebateStrategyWithDescriptors:
+    """Test suggest_debate_strategy with string descriptors."""
+
+    def test_mixed_strength_no_crash(self):
+        """'mixed' opponent strength does not raise ValueError."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            DebatePlugin,
+        )
+
+        plugin = DebatePlugin()
+        result = plugin.suggest_debate_strategy(
+            phase="main_arguments", turn_number="5", opponent_strength="mixed"
+        )
+        data = json.loads(result)
+        assert "strategy" in data
+
+    def test_high_strength_aggressive(self):
+        """'high' opponent strength triggers aggressive strategy."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            DebatePlugin,
+        )
+
+        plugin = DebatePlugin()
+        result = plugin.suggest_debate_strategy(
+            phase="main_arguments", turn_number="5", opponent_strength="high"
+        )
+        data = json.loads(result)
+        assert data["strategy"] == "aggressive"
+
+    def test_low_strength_evidence_heavy(self):
+        """'low' opponent strength after turn 3 triggers evidence_heavy."""
+        from argumentation_analysis.agents.core.debate.debate_agent import (
+            DebatePlugin,
+        )
+
+        plugin = DebatePlugin()
+        result = plugin.suggest_debate_strategy(
+            phase="main_arguments", turn_number="5", opponent_strength="low"
+        )
+        data = json.loads(result)
+        assert data["strategy"] == "evidence_heavy"


### PR DESCRIPTION
## Summary

- Replace bare `float()` coercion in `DebatePlugin.suggest_debate_strategy()` with `_coerce_score()` helper
- Maps known qualitative descriptors (high/medium/low + FR equivalents like élevé/moyen/faible) to numeric scores
- Unknown strings default to 0.5 (neutral) with a warning instead of raising `ValueError`
- Fixes the `could not convert string to float: 'mixed'` crash observed during SCDA Sprint 1 audit on all 3 corpora

## Changes

**`argumentation_analysis/agents/core/debate/debate_agent.py`**
- Add `_DESCRIPTOR_MAP` lookup table (EN + FR descriptors → float scores)
- Add `_coerce_score()` function: handles int/float/str/unknown inputs
- Update `suggest_debate_strategy()` line 122: `float(opponent_strength)` → `_coerce_score(opponent_strength)`

**`tests/unit/argumentation_analysis/agents/core/debate/test_debate.py`**
- `TestCoerceScore` — 14 unit tests covering all descriptor families, edge cases
- `TestSuggestDebateStrategyWithDescriptors` — 3 integration tests with string descriptors

## Test plan

- [x] 17/17 new tests pass (`pytest -k "TestCoerceScore or TestSuggestDebateStrategyWithDescriptors"`)
- [x] Existing debate tests unaffected
- [x] Original crash case `'mixed'` now resolves to 0.5 without error

Closes #538

🤖 Generated with [Claude Code](https://claude.com/claude-code)