### PR TITLE
feat(orchestration): CounterAgent restructure — target fallacious args + quantity target (#551)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -240,19 +240,31 @@ AGENT_CONFIG = {
         "speciality": "counter_argument",
         "instructions": (
             "Tu es l'agent de contre-argumentation. Quand le PM te donne la parole :\n"
-            "1. Lis les arguments, sophismes ET scores de qualite dans l'etat\n"
-            "2. CIBLE en priorite :\n"
-            "   a. Les arguments marques comme fallacieux par InformalAgent\n"
-            "   b. Les arguments avec le score de qualite le plus bas\n"
+            "1. Lis l'etat courant via get_current_state_snapshot()\n"
+            "2. IDENTIFIE tes cibles dans cet ordre de priorite :\n"
+            "   a. TOUS les arguments marques comme fallacieux par InformalAgent\n"
+            "   b. Les 3 arguments avec le score de qualite le plus bas\n"
             "   c. Les arguments formellement inconsistants (si FormalAgent l'a signale)\n"
-            "3. Utilise parse_argument() et suggest_strategy() pour choisir ta strategie\n"
-            "4. Genere des contre-arguments precis (reductio, contre-exemple, distinction, reformulation)\n\n"
-            "CROSS-KB (#208-I) : Adapte ta strategie au type de faiblesse :\n"
-            "- Sophisme ad hominem → reformulation\n"
-            "- Generalisation hative → contre-exemple\n"
-            "- Faux dilemme → distinction\n"
-            "- Inconsistance logique → reductio ad absurdum\n"
-            "Fournis des contre-arguments substantiels, pas des templates."
+            "3. Pour CHAQUE cible, genere un contre-argument dedie :\n"
+            "   - Appelle identify_vulnerabilities(text=argument_cible)\n"
+            "   - Choisis la strategie en fonction du type de faiblesse :\n"
+            "     * Sophisme ad hominem → reformulation\n"
+            "     * Generalisation hative → contre-exemple\n"
+            "     * Faux dilemme → distinction\n"
+            "     * Inconsistance logique → reductio ad absurdum\n"
+            "     * Score evidence faible → contre-exemple avec sources\n"
+            "     * Assertion forte sans preuve → distinction\n"
+            "   - Genere le contre-argument via suggest_strategy()\n"
+            "4. Pour chaque contre-argument, appelle add_counter_argument(\n"
+            "   target_argument_id=..., strategy='...', counter_text='...')\n"
+            "5. OBJECTIF : produire au moins 1 contre-argument par cible identifiee.\n"
+            "   Tu dois traiter TOUTES les cibles, pas seulement la premiere.\n\n"
+            "CROSS-KB (#208-I) : Chaque contre-argument DOIT referenceer explicitement :\n"
+            "- Le type de faiblesse cible (fallacy type ou quality dimension)\n"
+            "- La citation exacte du passage contre-argue\n"
+            "- La strategie rhetorique choisie et POURQUOI elle est adaptee\n\n"
+            "QUANTITE : Vise au minimum 10 contre-arguments sur un texte dense.\n"
+            "Un seul contre-argument generique = echec. Chaque cible merit un contre-argument dedie."
         ),
     },
     "GovernanceAgent": {
@@ -450,12 +462,15 @@ async def run_conversational_analysis(
                 "CounterAgent",
                 "GovernanceAgent",
             ],
-            "max_turns": 8,  # More turns for debate + vote + conclusion
+            "max_turns": 10,  # Extra turns for exhaustive counter-argumentation
             "initial_prompt": (
                 "Finalisez l'analyse en exploitant TOUTES les contributions precedentes.\n"
                 "CROSS-KB: Utilisez les resultats des phases 1 et 2 :\n"
                 "- DebateAgent : ciblez les arguments avec les scores les plus bas\n"
-                "- CounterAgent : ciblez en priorite les arguments fallacieux\n"
+                "- CounterAgent : TRAITEZ SYSTEMATIQUEMENT chaque argument fallacieux ET chaque "
+                "argument faible. Ne vous contentez pas d'un contre-argument generique. "
+                "Pour CHAQUE cible, produisez un contre-argument dedie avec la strategie "
+                "rhetorique adaptee au type de faiblesse. Visez au moins 10 contre-arguments.\n"
                 "- GovernanceAgent : evaluez le consensus en tenant compte de la qualite globale\n"
                 "Menez un debat adversarial, generez des contre-arguments, evaluez le consensus, "
                 "et produisez une conclusion finale."

--- a/tests/unit/argumentation_analysis/test_counteragent_restructure.py
+++ b/tests/unit/argumentation_analysis/test_counteragent_restructure.py
@@ -1,0 +1,67 @@
+"""Tests for CounterAgent restructure — #551.
+
+Validates:
+- CounterAgent instructions reference fallacy targeting
+- CounterAgent instructions reference quality score targeting
+- CounterAgent instructions reference strategy-per-weakness mapping
+- CounterAgent instructions specify quantity target (>= 10)
+- Synthesis & Debate phase has max_turns >= 10
+"""
+
+import pytest
+
+from argumentation_analysis.orchestration.conversational_orchestrator import (
+    AGENT_CONFIG,
+)
+
+
+class TestCounterAgentInstructions:
+    """Test CounterAgent instructions target fallacious arguments."""
+
+    def test_instructions_reference_fallacies(self):
+        """CounterAgent must target fallacious arguments specifically."""
+        instructions = AGENT_CONFIG["CounterAgent"]["instructions"]
+        assert "fallacieux" in instructions.lower() or "fallacy" in instructions.lower()
+
+    def test_instructions_reference_quality_scores(self):
+        """CounterAgent must target weak arguments by quality score."""
+        instructions = AGENT_CONFIG["CounterAgent"]["instructions"]
+        assert "qualite" in instructions.lower() or "quality" in instructions.lower()
+        assert "score" in instructions.lower() or "score" in instructions.lower()
+
+    def test_instructions_reference_strategy_mapping(self):
+        """CounterAgent must map strategy to weakness type."""
+        instructions = AGENT_CONFIG["CounterAgent"]["instructions"]
+        # Check at least one strategy mapping
+        assert "reductio" in instructions.lower() or "reformulation" in instructions.lower()
+        assert "contre-exemple" in instructions.lower() or "distinction" in instructions.lower()
+
+    def test_instructions_specify_quantity_target(self):
+        """CounterAgent must aim for at least 10 counter-arguments."""
+        instructions = AGENT_CONFIG["CounterAgent"]["instructions"]
+        assert "10" in instructions
+
+    def test_instructions_specify_per_target(self):
+        """CounterAgent must produce per-target counter-arguments."""
+        instructions = AGENT_CONFIG["CounterAgent"]["instructions"]
+        assert "CHAQUE" in instructions or "chaque" in instructions.lower()
+
+    def test_instructions_reference_state_read(self):
+        """CounterAgent must read state snapshot."""
+        instructions = AGENT_CONFIG["CounterAgent"]["instructions"]
+        assert "get_current_state_snapshot" in instructions
+
+
+class TestSynthesisPhaseConfig:
+    """Test Synthesis & Debate phase configuration."""
+
+    def test_synthesis_max_turns_at_least_10(self):
+        """Synthesis phase must have >= 10 turns for exhaustive counter-argumentation."""
+        # The phase configs are built with hardcoded values in the function
+        # We check by reading the relevant section
+        import inspect
+        from argumentation_analysis.orchestration import conversational_orchestrator as co
+
+        source = inspect.getsource(co.run_conversational_analysis)
+        # Look for the Synthesis & Debate max_turns
+        assert "max_turns\": 10" in source or "max_turns\": 10" in source


### PR DESCRIPTION
## Summary
- Restructure CounterAgent instructions to mandate per-target counter-argumentation with explicit strategy-per-weakness mapping
- Set quantity target >= 10 counter-args per dense text with priority on fallacious args, top-3 weakest, formal inconsistencies
- Raise Synthesis and Debate phase max_turns from 8 to 10 for extra CounterAgent turns
- Phase prompt explicitly instructs CounterAgent to treat ALL identified targets

## Problem Addressed
Baseline 0-shot LLM produces 15-18 counter-arguments on dense corpora while pipeline CounterAgent produced 0-8. Root cause: CounterAgent was called once with generic prompt not per-target.

## Test Plan
- [x] 7 unit tests: 6 instruction validation + 1 phase config verification
- [x] All tests pass
- [ ] Manual validation on dense corpus

Closes #551