### PR TITLE
feat(orchestration): phase max_turns configurability + convergence field mapping fix (#553)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -370,6 +370,10 @@ async def run_conversational_analysis(
     max_turns_per_phase: int = 5,
     agent_names: Optional[List[str]] = None,
     spectacular: bool = True,
+    extraction_max_turns: int = 7,
+    formal_max_turns: int = 5,
+    synthesis_max_turns: int = 10,
+    reanalysis_max_turns: int = 5,
 ) -> Dict[str, Any]:
     """Run a full conversational analysis on the input text.
 
@@ -380,10 +384,14 @@ async def run_conversational_analysis(
 
     Args:
         text: Input text to analyze.
-        max_turns_per_phase: Max agent turns per phase.
+        max_turns_per_phase: Default max turns per phase (overridden by specific params).
         agent_names: Optional subset of agent names to use.
         spectacular: If True, use UnifiedAnalysisState for 28+/32 field
             coverage matching the spectacular workflow profile (#363).
+        extraction_max_turns: Max turns for Extraction & Detection phase.
+        formal_max_turns: Max turns for Formal Analysis & Quality phase.
+        synthesis_max_turns: Max turns for Synthesis & Debate phase.
+        reanalysis_max_turns: Max turns for Re-Analysis phase (if triggered).
 
     Returns dict with state snapshot, conversation history, and metrics.
     """
@@ -448,13 +456,13 @@ async def run_conversational_analysis(
         {
             "name": "Extraction & Detection",
             "agents": ["ProjectManager", "ExtractAgent", "InformalAgent"],
-            "max_turns": 7,  # More turns for thorough extraction
+            "max_turns": extraction_max_turns,
             "initial_prompt": extraction_prompt,
         },
         {
             "name": "Formal Analysis & Quality",
             "agents": ["ProjectManager", "FormalAgent", "QualityAgent"],
-            "max_turns": 5,
+            "max_turns": formal_max_turns,
             "initial_prompt": (
                 "Continuez l'analyse en tenant compte des resultats de Phase 1.\n"
                 "CROSS-KB: Les sophismes detectes doivent influencer :\n"
@@ -471,7 +479,7 @@ async def run_conversational_analysis(
                 "CounterAgent",
                 "GovernanceAgent",
             ],
-            "max_turns": 10,  # Extra turns for exhaustive counter-argumentation
+            "max_turns": synthesis_max_turns,
             "initial_prompt": (
                 "Finalisez l'analyse en exploitant TOUTES les contributions precedentes.\n"
                 "CROSS-KB: Utilisez les resultats des phases 1 et 2 :\n"
@@ -572,7 +580,7 @@ async def run_conversational_analysis(
                         "QualityAgent",
                         "GovernanceAgent",
                     ],
-                    "max_turns": 5,
+                    "max_turns": reanalysis_max_turns,
                     "initial_prompt": (
                         "Re-analysez en tenant compte des resultats de l'analyse formelle.\n"
                         "JTMS a retracte certaines croyances. Re-evaluez :\n"

--- a/argumentation_analysis/orchestration/trace_analyzer.py
+++ b/argumentation_analysis/orchestration/trace_analyzer.py
@@ -181,8 +181,11 @@ class ConversationalTraceAnalyzer:
                 metrics.state_fields_populated += 1
 
         # Count specific dimensions
-        if isinstance(state_snapshot.get("identified_arguments"), list):
-            metrics.arguments_found = len(state_snapshot["identified_arguments"])
+        identified_args = state_snapshot.get("identified_arguments")
+        if isinstance(identified_args, dict):
+            metrics.arguments_found = len(identified_args)
+        elif isinstance(identified_args, list):
+            metrics.arguments_found = len(identified_args)
         if isinstance(state_snapshot.get("identified_fallacies"), list):
             metrics.fallacies_found = len(state_snapshot["identified_fallacies"])
         if isinstance(state_snapshot.get("argument_quality_scores"), dict):

--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -310,6 +310,30 @@ Exemples:
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Afficher les logs détaillés"
     )
+    parser.add_argument(
+        "--extraction-turns",
+        type=int,
+        default=7,
+        help="Max turns for Extraction & Detection phase (default: 7)",
+    )
+    parser.add_argument(
+        "--formal-turns",
+        type=int,
+        default=5,
+        help="Max turns for Formal Analysis & Quality phase (default: 5)",
+    )
+    parser.add_argument(
+        "--synthesis-turns",
+        type=int,
+        default=10,
+        help="Max turns for Synthesis & Debate phase (default: 10)",
+    )
+    parser.add_argument(
+        "--reanalysis-turns",
+        type=int,
+        default=5,
+        help="Max turns for Re-Analysis phase if triggered (default: 5)",
+    )
 
     args = parser.parse_args()
 
@@ -441,6 +465,10 @@ Exemples:
         results = await run_conversational_analysis(
             text=text_content,
             max_turns_per_phase=5,
+            extraction_max_turns=args.extraction_turns,
+            formal_max_turns=args.formal_turns,
+            synthesis_max_turns=args.synthesis_turns,
+            reanalysis_max_turns=args.reanalysis_turns,
         )
 
         # Afficher le résumé

--- a/tests/unit/argumentation_analysis/test_counteragent_restructure.py
+++ b/tests/unit/argumentation_analysis/test_counteragent_restructure.py
@@ -57,11 +57,8 @@ class TestSynthesisPhaseConfig:
 
     def test_synthesis_max_turns_at_least_10(self):
         """Synthesis phase must have >= 10 turns for exhaustive counter-argumentation."""
-        # The phase configs are built with hardcoded values in the function
-        # We check by reading the relevant section
         import inspect
         from argumentation_analysis.orchestration import conversational_orchestrator as co
 
-        source = inspect.getsource(co.run_conversational_analysis)
-        # Look for the Synthesis & Debate max_turns
-        assert "max_turns\": 10" in source or "max_turns\": 10" in source
+        sig = inspect.signature(co.run_conversational_analysis)
+        assert sig.parameters["synthesis_max_turns"].default >= 10

--- a/tests/unit/argumentation_analysis/test_phase_config_convergence_553.py
+++ b/tests/unit/argumentation_analysis/test_phase_config_convergence_553.py
@@ -1,0 +1,104 @@
+"""Tests for #553: phase max_turns configurability + _check_convergence field mapping fix."""
+
+import inspect
+import pytest
+
+from argumentation_analysis.orchestration.conversational_orchestrator import (
+    run_conversational_analysis,
+)
+from argumentation_analysis.orchestration.trace_analyzer import ConversationalTraceAnalyzer
+
+
+class TestConvergenceFieldMapping:
+    """Fix 1: _check_convergence reports correct arguments_found from dict state."""
+
+    def test_arguments_found_from_dict(self):
+        """identified_arguments is a Dict[str, str], not a list — must be counted."""
+        analyzer = ConversationalTraceAnalyzer()
+        snapshot = {
+            "identified_arguments": {
+                "arg_001": "First argument",
+                "arg_002": "Second argument",
+                "arg_003": "Third argument",
+            }
+        }
+        metrics = analyzer.compute_convergence(snapshot)
+        assert metrics.arguments_found == 3
+
+    def test_arguments_found_from_list_backwards_compat(self):
+        """If someone passes a list, still works."""
+        analyzer = ConversationalTraceAnalyzer()
+        snapshot = {"identified_arguments": ["arg1", "arg2"]}
+        metrics = analyzer.compute_convergence(snapshot)
+        assert metrics.arguments_found == 2
+
+    def test_arguments_found_zero_when_missing(self):
+        """No identified_arguments key → 0."""
+        analyzer = ConversationalTraceAnalyzer()
+        snapshot = {"other_field": "value"}
+        metrics = analyzer.compute_convergence(snapshot)
+        assert metrics.arguments_found == 0
+
+    def test_arguments_found_zero_when_empty_dict(self):
+        """Empty dict → 0."""
+        analyzer = ConversationalTraceAnalyzer()
+        snapshot = {"identified_arguments": {}}
+        metrics = analyzer.compute_convergence(snapshot)
+        assert metrics.arguments_found == 0
+
+    def test_fallacies_still_counted(self):
+        """identified_fallacies (list) should still work."""
+        analyzer = ConversationalTraceAnalyzer()
+        snapshot = {
+            "identified_fallacies": [
+                {"type": "ad_hominem"},
+                {"type": "straw_man"},
+            ]
+        }
+        metrics = analyzer.compute_convergence(snapshot)
+        assert metrics.fallacies_found == 2
+
+    def test_counter_arguments_counted(self):
+        """counter_arguments (list) should still work."""
+        analyzer = ConversationalTraceAnalyzer()
+        snapshot = {
+            "counter_arguments": [
+                {"strategy": "reductio"},
+                {"strategy": "counter_example"},
+            ]
+        }
+        metrics = analyzer.compute_convergence(snapshot)
+        assert metrics.counter_arguments_count == 2
+
+
+class TestPhaseMaxTurnsConfigurable:
+    """Fix 2: phase max_turns are configurable via function params."""
+
+    def test_function_accepts_four_turn_params(self):
+        """run_conversational_analysis has extraction/formal/synthesis/reanalysis params."""
+        sig = inspect.signature(run_conversational_analysis)
+        assert "extraction_max_turns" in sig.parameters
+        assert "formal_max_turns" in sig.parameters
+        assert "synthesis_max_turns" in sig.parameters
+        assert "reanalysis_max_turns" in sig.parameters
+
+    def test_defaults_match_previous_hardcoded(self):
+        """Defaults should match the previous hardcoded values (7, 5, 10, 5)."""
+        sig = inspect.signature(run_conversational_analysis)
+        assert sig.parameters["extraction_max_turns"].default == 7
+        assert sig.parameters["formal_max_turns"].default == 5
+        assert sig.parameters["synthesis_max_turns"].default == 10
+        assert sig.parameters["reanalysis_max_turns"].default == 5
+
+    def test_no_hardcoded_max_turns_in_phase_configs_source(self):
+        """Verify hardcoded integers are removed from phase_configs in source."""
+        import argumentation_analysis.orchestration.conversational_orchestrator as mod
+
+        source = inspect.getsource(mod)
+        # Check that the phase config section uses the param names, not literals
+        # The pattern '"max_turns": 7,' or '"max_turns": 5,' should NOT appear
+        # (only the param references like extraction_max_turns should)
+        for hardcoded in ['"max_turns": 7,', '"max_turns": 5,', '"max_turns": 10,']:
+            assert hardcoded not in source, (
+                f"Found hardcoded {hardcoded} in source — should use param instead"
+            )


### PR DESCRIPTION
## Summary
- Fix convergence field mapping: `identified_arguments` is `Dict[str, str]` not `list`, causing `arguments_found` to always report 0 in trace analyzer
- Make phase max_turns configurable via 4 new params: `extraction_max_turns`, `formal_max_turns`, `synthesis_max_turns`, `reanalysis_max_turns`
- Add CLI flags `--extraction-turns`, `--formal-turns`, `--synthesis-turns`, `--reanalysis-turns` to `run_orchestration.py`
- Defaults match previous hardcoded values (7/5/10/5) — no breaking change

## Problem Addressed
Two bugs from #548 investigation:
1. `trace_analyzer.py` checked `isinstance(state["identified_arguments"], list)` but `UnifiedAnalysisState.identified_arguments` is `Dict[str, str]` — so convergence always reported 0 arguments
2. Phase max_turns were hardcoded (7/5/8/5) making the global `max_turns_per_phase` knob useless

## Test Plan
- [x] 9 unit tests: 6 convergence field mapping + 3 phase config verification
- [x] All tests pass
- [ ] Re-test on corpus_dense_A with configurable turns (post-merge)

Closes #553