### PR TITLE
fix(state): add target_arg_id to counter-arguments for reliable enrichment tracking (#570)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -429,7 +429,12 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         self.fol_shared_signature: Dict[str, Dict[str, Any]] = {}
 
     def add_counter_argument(
-        self, original_arg: str, counter_content: str, strategy: str, score: float
+        self,
+        original_arg: str,
+        counter_content: str,
+        strategy: str,
+        score: float,
+        target_arg_id: Optional[str] = None,
     ) -> str:
         """Add a counter-argument result."""
         ca_id = self._generate_id("ca", self.counter_arguments)
@@ -440,6 +445,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "strategy": strategy,
             "score": score,
         }
+        if target_arg_id:
+            entry["target_arg_id"] = target_arg_id
         self.counter_arguments.append(entry)
         state_logger.info(f"Counter-argument added: {ca_id} (strategy: {strategy})")
         return ca_id
@@ -817,19 +824,23 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         if arg_id in self.argument_quality_scores:
             profile.quality_score = self.argument_quality_scores[arg_id]
 
-        # Counter-arguments — matched by substring on original_argument text
+        # Counter-arguments — prefer ID-based matching, fall back to text
         arg_desc = description
-        if arg_desc:
+        for ca in self.counter_arguments:
+            if ca.get("target_arg_id") == arg_id:
+                profile.counter_arguments.append(ca)
+                continue
+            if not arg_desc:
+                continue
+            original = ca.get("original_argument", "")
             match_prefix = arg_desc[:60]
-            for ca in self.counter_arguments:
-                original = ca.get("original_argument", "")
-                if original and (
-                    original == arg_desc
-                    or original[:60] == match_prefix
-                    or match_prefix in original
-                    or original in arg_desc
-                ):
-                    profile.counter_arguments.append(ca)
+            if original and (
+                original == arg_desc
+                or original[:60] == match_prefix
+                or match_prefix in original
+                or original in arg_desc
+            ):
+                profile.counter_arguments.append(ca)
 
         # JTMS beliefs referencing this argument (by name containing arg_id or description prefix)
         for _bid, bdata in self.jtms_beliefs.items():
@@ -880,15 +891,21 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             self.identified_arguments.keys()
         )
 
-        # Counter-arguments use text matching
+        # Counter-arguments: prefer ID-based matching, fall back to text matching
         with_counter: set[str] = set()
-        for arg_id, desc in self.identified_arguments.items():
-            if not desc:
+        for ca in self.counter_arguments:
+            tid = ca.get("target_arg_id")
+            if tid and tid in self.identified_arguments:
+                with_counter.add(tid)
                 continue
-            match_prefix = desc[:60]
-            for ca in self.counter_arguments:
-                original = ca.get("original_argument", "")
-                if original and (
+            original = ca.get("original_argument", "")
+            if not original:
+                continue
+            for arg_id, desc in self.identified_arguments.items():
+                if arg_id in with_counter or not desc:
+                    continue
+                match_prefix = desc[:60]
+                if (
                     original == desc
                     or original[:60] == match_prefix
                     or match_prefix in original

--- a/argumentation_analysis/core/state_manager_plugin.py
+++ b/argumentation_analysis/core/state_manager_plugin.py
@@ -670,15 +670,24 @@ class StateManagerPlugin:
             return f"FUNC_ERROR: {e}"
 
     @kernel_function(
-        description="Add a counter-argument result. Params: original_arg, counter_content, strategy, score (0-1).",
+        description="Add a counter-argument result. Params: original_arg, counter_content, strategy, score (0-1), target_arg_id (optional).",
         name="add_counter_argument",
     )
     def add_counter_argument(
-        self, original_arg: str, counter_content: str, strategy: str, score: str = "0.5"
+        self,
+        original_arg: str,
+        counter_content: str,
+        strategy: str,
+        score: str = "0.5",
+        target_arg_id: str = "",
     ) -> str:
         try:
             ca_id = self._state.add_counter_argument(
-                original_arg, counter_content, strategy, float(score)
+                original_arg,
+                counter_content,
+                strategy,
+                float(score),
+                target_arg_id=target_arg_id or None,
             )
             return ca_id
         except Exception as e:

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -8,7 +8,7 @@ Split from unified_pipeline.py (#310).
 """
 
 import logging
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 logger = logging.getLogger("UnifiedPipeline")
 
@@ -104,6 +104,32 @@ def _write_quality_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> Non
         state.add_quality_score(arg_id, scores, float(overall))
 
 
+def _resolve_target_arg_id(state: Any, target_text: str) -> Optional[str]:
+    """Resolve target text to an arg_id from identified_arguments.
+
+    Checks exact ID match first, then text-based matching.
+    Returns None if no match found.
+    """
+    if not target_text:
+        return None
+    # Direct ID match
+    if target_text in state.identified_arguments:
+        return target_text
+    # Text-based matching (same heuristic as get_enrichment_summary)
+    for arg_id, desc in state.identified_arguments.items():
+        if not desc:
+            continue
+        match_prefix = desc[:60]
+        if (
+            target_text == desc
+            or target_text[:60] == match_prefix
+            or match_prefix in target_text
+            or target_text in desc
+        ):
+            return arg_id
+    return None
+
+
 def _write_counter_argument_to_state(
     output: Any, state: Any, ctx: dict[str, Any]
 ) -> None:
@@ -127,7 +153,10 @@ def _write_counter_argument_to_state(
                 score = float(evaluation["overall_score"])
             else:
                 score = strength_map.get(str(llm_ca.get("strength", "")).lower(), 0.5)
-            state.add_counter_argument(target, counter_text, strategy_name, score)
+            arg_id = _resolve_target_arg_id(state, target)
+            state.add_counter_argument(
+                target, counter_text, strategy_name, score, target_arg_id=arg_id
+            )
         return
 
     # Backward compat: single LLM counter-argument
@@ -137,7 +166,10 @@ def _write_counter_argument_to_state(
         counter_text = str(llm_ca.get("counter_argument", ""))
         strategy_name = str(llm_ca.get("strategy_used", "unknown"))
         score = strength_map.get(str(llm_ca.get("strength", "")).lower(), 0.5)
-        state.add_counter_argument(target, counter_text, strategy_name, score)
+        arg_id = _resolve_target_arg_id(state, target)
+        state.add_counter_argument(
+            target, counter_text, strategy_name, score, target_arg_id=arg_id
+        )
         return
 
     # Fallback to heuristic plugin output
@@ -152,7 +184,10 @@ def _write_counter_argument_to_state(
     score = strategy.get("confidence", 0.0)
     if not isinstance(score, (int, float)):
         score = 0.0
-    state.add_counter_argument(original, strategy_name, strategy_name, float(score))
+    arg_id = _resolve_target_arg_id(state, original)
+    state.add_counter_argument(
+        original, strategy_name, strategy_name, float(score), target_arg_id=arg_id
+    )
 
 
 def _write_jtms_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/tests/unit/argumentation_analysis/test_counter_arg_tracking_570.py
+++ b/tests/unit/argumentation_analysis/test_counter_arg_tracking_570.py
@@ -1,0 +1,188 @@
+"""Tests for counter-argument ID-based tracking fix (#570).
+
+Verifies that counter-arguments linked by target_arg_id are correctly
+counted in get_enrichment_summary() even when text matching fails.
+"""
+import pytest
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+
+def _make_state_with_id_tracking():
+    """Create a state with 5 arguments and 5 counter-arguments linked by ID.
+
+    The counter-argument original_argument texts are intentionally different
+    from the argument descriptions to prove ID-based matching works.
+    """
+    state = UnifiedAnalysisState("Full text for testing counter-argument tracking.")
+
+    args = []
+    descriptions = [
+        "The economy is growing due to increased exports",
+        "Immigration has no effect on wages",
+        "Climate change requires immediate policy action",
+        "Education funding should be tripled",
+        "Universal basic income reduces poverty",
+    ]
+    for desc in descriptions:
+        args.append(state.add_argument(desc))
+
+    # Counter-arguments with mismatched text but correct target_arg_id
+    ca_data = [
+        ("Exports are not the main driver", "reductio_ad_absurdum", 0.8),
+        ("Wage studies show mixed results", "counter-example", 0.7),
+        ("Policy alone is insufficient", "distinction", 0.9),
+        ("Tripling is not cost-effective", "reformulation", 0.6),
+        ("UBI creates dependency loops", "reductio_ad_absurdum", 0.85),
+    ]
+    for ca_text, strategy, score, arg_id in zip(
+        [d[0] for d in ca_data],
+        [d[1] for d in ca_data],
+        [d[2] for d in ca_data],
+        args,
+    ):
+        state.add_counter_argument(
+            original_arg=ca_text,
+            counter_content=f"Counter to {ca_text}",
+            strategy=strategy,
+            score=score,
+            target_arg_id=arg_id,
+        )
+
+    return state, args
+
+
+class TestCounterArgumentIDTracking:
+    """Test that target_arg_id-based linking works for enrichment summary."""
+
+    def test_id_tracking_all_5_matched(self):
+        """5 CAs with target_arg_id → with_counter_argument == 5."""
+        state, args = _make_state_with_id_tracking()
+        summary = state.get_enrichment_summary()
+        assert summary["total_arguments"] == 5
+        assert summary["with_counter_argument"] == 5
+
+    def test_id_tracking_text_mismatch_doesnt_matter(self):
+        """Even when text doesn't match, ID linkage works."""
+        state, args = _make_state_with_id_tracking()
+        for ca in state.counter_arguments:
+            assert ca["target_arg_id"] in args
+            # Verify text doesn't match (proof ID is needed)
+            original = ca["original_argument"]
+            arg_desc = state.identified_arguments[ca["target_arg_id"]]
+            assert original != arg_desc
+
+    def test_profile_gets_counter_args_by_id(self):
+        """get_argument_profile returns CAs linked by ID."""
+        state, args = _make_state_with_id_tracking()
+        for arg_id in args:
+            profile = state.get_argument_profile(arg_id)
+            assert len(profile.counter_arguments) == 1
+
+    def test_mixed_id_and_text_matching(self):
+        """CAs with target_arg_id AND text-matching both counted."""
+        state = UnifiedAnalysisState("text")
+        a1 = state.add_argument("Argument about X")
+        a2 = state.add_argument("Argument about Y")
+
+        # CA1: linked by ID (text doesn't match)
+        state.add_counter_argument(
+            "Completely different text",
+            "Counter 1",
+            "counter-example",
+            0.8,
+            target_arg_id=a1,
+        )
+        # CA2: linked by text match (no target_arg_id)
+        state.add_counter_argument(
+            "Argument about Y",
+            "Counter 2",
+            "reformulation",
+            0.7,
+        )
+
+        summary = state.get_enrichment_summary()
+        assert summary["with_counter_argument"] == 2
+
+    def test_no_target_arg_id_falls_back_to_text(self):
+        """Without target_arg_id, text matching still works."""
+        state = UnifiedAnalysisState("text")
+        state.add_argument("The economy is growing due to increased exports")
+        state.add_counter_argument(
+            "The economy is growing due to increased exports",
+            "Counter content",
+            "counter-example",
+            0.7,
+        )
+        summary = state.get_enrichment_summary()
+        assert summary["with_counter_argument"] == 1
+
+    def test_invalid_target_arg_id_ignored(self):
+        """target_arg_id pointing to non-existent arg falls back to text."""
+        state = UnifiedAnalysisState("text")
+        state.add_argument("Real argument text here")
+        state.add_counter_argument(
+            "Real argument text here",
+            "Counter",
+            "counter-example",
+            0.7,
+            target_arg_id="arg_999",
+        )
+        summary = state.get_enrichment_summary()
+        # Falls back to text matching and succeeds
+        assert summary["with_counter_argument"] == 1
+
+
+class TestCounterArgumentIDTrackingViaStateWriters:
+    """Test the _resolve_target_arg_id helper from state_writers."""
+
+    def test_resolve_by_exact_id(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _resolve_target_arg_id,
+        )
+
+        state = UnifiedAnalysisState("text")
+        a1 = state.add_argument("Some argument")
+        result = _resolve_target_arg_id(state, a1)
+        assert result == a1
+
+    def test_resolve_by_text_match(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _resolve_target_arg_id,
+        )
+
+        state = UnifiedAnalysisState("text")
+        state.add_argument("The economy is growing due to exports")
+        result = _resolve_target_arg_id(state, "The economy is growing due to exports")
+        assert result is not None
+        assert result.startswith("arg_")
+
+    def test_resolve_by_prefix_match(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _resolve_target_arg_id,
+        )
+
+        state = UnifiedAnalysisState("text")
+        state.add_argument("This is a long argument about climate policy reform")
+        # Text is a prefix of the arg description (60 chars match)
+        result = _resolve_target_arg_id(state, "This is a long argument about climate policy reform")
+        assert result is not None
+
+    def test_resolve_returns_none_for_no_match(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _resolve_target_arg_id,
+        )
+
+        state = UnifiedAnalysisState("text")
+        state.add_argument("Something about cats")
+        result = _resolve_target_arg_id(state, "Something completely different about dogs")
+        assert result is None
+
+    def test_resolve_empty_target(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _resolve_target_arg_id,
+        )
+
+        state = UnifiedAnalysisState("text")
+        state.add_argument("Some argument")
+        result = _resolve_target_arg_id(state, "")
+        assert result is None


### PR DESCRIPTION
## Summary
- Add optional `target_arg_id` parameter to `add_counter_argument()` in `UnifiedAnalysisState` for direct ID-based linking
- Update `get_enrichment_summary()` and `get_argument_profile()` to match counter-arguments by `target_arg_id` first, falling back to existing text-matching heuristic
- Add `_resolve_target_arg_id()` helper in `state_writers.py` that resolves LLM-provided `target_argument` text to an arg_id from `identified_arguments`
- Update `StateManagerPlugin.add_counter_argument` kernel function to accept `target_arg_id`

## Root Cause
Counter-arguments were tracked via fragile text-matching between LLM-rephrased `target_argument` text and argument descriptions. The LLM often reformats/summarizes the target text, causing all four match conditions to fail, resulting in `with_counter_argument: 0` despite successful generation.

## Test Plan
- [x] 11 new tests in `test_counter_arg_tracking_570.py` (6 state-level + 5 state_writers helper)
- [x] 56 existing shared_state/cross-ref tests GREEN (zero regression)
- [x] Pre-existing `test_plugin_per_agent` failures (unrelated: PM speciality map)

Closes #570