### PR TITLE
fix(state): add arg_id to PL/FOL/NL-to-logic for reliable formal verification tracking (#571)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -703,6 +703,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         consistent: bool,
         inferences: List[str],
         confidence: float = 0.0,
+        arg_id: Optional[str] = None,
     ) -> str:
         """Add a first-order logic analysis result."""
         fol_id = self._generate_id("fol", self.fol_analysis_results)
@@ -713,6 +714,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "inferences": inferences,
             "confidence": confidence,
         }
+        if arg_id:
+            entry["arg_id"] = arg_id
         self.fol_analysis_results.append(entry)
         state_logger.info(f"FOL analysis added: {fol_id} (consistent={consistent})")
         return fol_id
@@ -722,6 +725,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         formulas: List[str],
         satisfiable: bool,
         model: Optional[Dict[str, bool]] = None,
+        arg_id: Optional[str] = None,
     ) -> str:
         """Add a propositional logic analysis result."""
         pl_id = self._generate_id("pl", self.propositional_analysis_results)
@@ -731,6 +735,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "satisfiable": satisfiable,
             "model": model or {},
         }
+        if arg_id:
+            entry["arg_id"] = arg_id
         self.propositional_analysis_results.append(entry)
         state_logger.info(f"PL analysis added: {pl_id} (satisfiable={satisfiable})")
         return pl_id
@@ -781,6 +787,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         is_valid: bool,
         variables: Optional[Dict[str, str]] = None,
         confidence: float = 0.0,
+        arg_id: Optional[str] = None,
     ) -> str:
         """Add a NL-to-formal-logic translation result (#173)."""
         tr_id = self._generate_id("nll", self.nl_to_logic_translations)
@@ -793,6 +800,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "variables": variables or {},
             "confidence": confidence,
         }
+        if arg_id:
+            entry["arg_id"] = arg_id
         self.nl_to_logic_translations.append(entry)
         state_logger.info(
             f"NL→logic translation added: {tr_id} ({logic_type}, valid={is_valid})"
@@ -848,13 +857,23 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             if arg_id in belief_name or (arg_desc and arg_desc[:40] in belief_name):
                 profile.jtms_beliefs.append(bdata)
 
-        # Formal results — NL-to-logic translations whose original_text matches
-        if arg_desc:
+        # Formal results — PL/FOL/NL-to-logic matched by arg_id or text
+        for pl in self.propositional_analysis_results:
+            if pl.get("arg_id") == arg_id:
+                profile.formal_results.append(pl)
+        for fol in self.fol_analysis_results:
+            if fol.get("arg_id") == arg_id:
+                profile.formal_results.append(fol)
+        for tr in self.nl_to_logic_translations:
+            if tr.get("arg_id") == arg_id:
+                profile.formal_results.append(tr)
+                continue
+            if not arg_desc:
+                continue
+            orig = tr.get("original_text", "")
             match_prefix = arg_desc[:60]
-            for tr in self.nl_to_logic_translations:
-                orig = tr.get("original_text", "")
-                if orig and (match_prefix in orig or orig in arg_desc):
-                    profile.formal_results.append(tr)
+            if orig and (match_prefix in orig or orig in arg_desc):
+                profile.formal_results.append(tr)
 
         return profile
 
@@ -914,15 +933,32 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
                     with_counter.add(arg_id)
                     break
 
-        # Formal verification (NL-to-logic translations)
+        # Formal verification: check PL, FOL, and NL-to-logic translations
         with_formal: set[str] = set()
-        for arg_id, desc in self.identified_arguments.items():
-            if not desc:
+        # PL results with arg_id
+        for pl in self.propositional_analysis_results:
+            aid = pl.get("arg_id")
+            if aid and aid in self.identified_arguments:
+                with_formal.add(aid)
+        # FOL results with arg_id
+        for fol in self.fol_analysis_results:
+            aid = fol.get("arg_id")
+            if aid and aid in self.identified_arguments:
+                with_formal.add(aid)
+        # NL-to-logic translations: prefer arg_id, fall back to text match
+        for tr in self.nl_to_logic_translations:
+            aid = tr.get("arg_id")
+            if aid and aid in self.identified_arguments:
+                with_formal.add(aid)
                 continue
-            match_prefix = desc[:60]
-            for tr in self.nl_to_logic_translations:
-                orig = tr.get("original_text", "")
-                if orig and (match_prefix in orig or orig in desc):
+            orig = tr.get("original_text", "")
+            if not orig:
+                continue
+            for arg_id, desc in self.identified_arguments.items():
+                if arg_id in with_formal or not desc:
+                    continue
+                match_prefix = desc[:60]
+                if match_prefix in orig or orig in desc:
                     with_formal.add(arg_id)
                     break
 

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -429,7 +429,12 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         self.fol_shared_signature: Dict[str, Dict[str, Any]] = {}
 
     def add_counter_argument(
-        self, original_arg: str, counter_content: str, strategy: str, score: float
+        self,
+        original_arg: str,
+        counter_content: str,
+        strategy: str,
+        score: float,
+        target_arg_id: Optional[str] = None,
     ) -> str:
         """Add a counter-argument result."""
         ca_id = self._generate_id("ca", self.counter_arguments)
@@ -440,6 +445,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "strategy": strategy,
             "score": score,
         }
+        if target_arg_id:
+            entry["target_arg_id"] = target_arg_id
         self.counter_arguments.append(entry)
         state_logger.info(f"Counter-argument added: {ca_id} (strategy: {strategy})")
         return ca_id
@@ -817,19 +824,23 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         if arg_id in self.argument_quality_scores:
             profile.quality_score = self.argument_quality_scores[arg_id]
 
-        # Counter-arguments — matched by substring on original_argument text
+        # Counter-arguments — prefer ID-based matching, fall back to text
         arg_desc = description
-        if arg_desc:
+        for ca in self.counter_arguments:
+            if ca.get("target_arg_id") == arg_id:
+                profile.counter_arguments.append(ca)
+                continue
+            if not arg_desc:
+                continue
+            original = ca.get("original_argument", "")
             match_prefix = arg_desc[:60]
-            for ca in self.counter_arguments:
-                original = ca.get("original_argument", "")
-                if original and (
-                    original == arg_desc
-                    or original[:60] == match_prefix
-                    or match_prefix in original
-                    or original in arg_desc
-                ):
-                    profile.counter_arguments.append(ca)
+            if original and (
+                original == arg_desc
+                or original[:60] == match_prefix
+                or match_prefix in original
+                or original in arg_desc
+            ):
+                profile.counter_arguments.append(ca)
 
         # JTMS beliefs referencing this argument (by name containing arg_id or description prefix)
         for _bid, bdata in self.jtms_beliefs.items():
@@ -880,15 +891,21 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             self.identified_arguments.keys()
         )
 
-        # Counter-arguments use text matching
+        # Counter-arguments: prefer ID-based matching, fall back to text matching
         with_counter: set[str] = set()
-        for arg_id, desc in self.identified_arguments.items():
-            if not desc:
+        for ca in self.counter_arguments:
+            tid = ca.get("target_arg_id")
+            if tid and tid in self.identified_arguments:
+                with_counter.add(tid)
                 continue
-            match_prefix = desc[:60]
-            for ca in self.counter_arguments:
-                original = ca.get("original_argument", "")
-                if original and (
+            original = ca.get("original_argument", "")
+            if not original:
+                continue
+            for arg_id, desc in self.identified_arguments.items():
+                if arg_id in with_counter or not desc:
+                    continue
+                match_prefix = desc[:60]
+                if (
                     original == desc
                     or original[:60] == match_prefix
                     or match_prefix in original

--- a/argumentation_analysis/core/state_manager_plugin.py
+++ b/argumentation_analysis/core/state_manager_plugin.py
@@ -670,15 +670,24 @@ class StateManagerPlugin:
             return f"FUNC_ERROR: {e}"
 
     @kernel_function(
-        description="Add a counter-argument result. Params: original_arg, counter_content, strategy, score (0-1).",
+        description="Add a counter-argument result. Params: original_arg, counter_content, strategy, score (0-1), target_arg_id (optional).",
         name="add_counter_argument",
     )
     def add_counter_argument(
-        self, original_arg: str, counter_content: str, strategy: str, score: str = "0.5"
+        self,
+        original_arg: str,
+        counter_content: str,
+        strategy: str,
+        score: str = "0.5",
+        target_arg_id: str = "",
     ) -> str:
         try:
             ca_id = self._state.add_counter_argument(
-                original_arg, counter_content, strategy, float(score)
+                original_arg,
+                counter_content,
+                strategy,
+                float(score),
+                target_arg_id=target_arg_id or None,
             )
             return ca_id
         except Exception as e:

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -8,7 +8,7 @@ Split from unified_pipeline.py (#310).
 """
 
 import logging
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 
 logger = logging.getLogger("UnifiedPipeline")
 
@@ -104,6 +104,32 @@ def _write_quality_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> Non
         state.add_quality_score(arg_id, scores, float(overall))
 
 
+def _resolve_target_arg_id(state: Any, target_text: str) -> Optional[str]:
+    """Resolve target text to an arg_id from identified_arguments.
+
+    Checks exact ID match first, then text-based matching.
+    Returns None if no match found.
+    """
+    if not target_text:
+        return None
+    # Direct ID match
+    if target_text in state.identified_arguments:
+        return target_text
+    # Text-based matching (same heuristic as get_enrichment_summary)
+    for arg_id, desc in state.identified_arguments.items():
+        if not desc:
+            continue
+        match_prefix = desc[:60]
+        if (
+            target_text == desc
+            or target_text[:60] == match_prefix
+            or match_prefix in target_text
+            or target_text in desc
+        ):
+            return arg_id
+    return None
+
+
 def _write_counter_argument_to_state(
     output: Any, state: Any, ctx: dict[str, Any]
 ) -> None:
@@ -127,7 +153,10 @@ def _write_counter_argument_to_state(
                 score = float(evaluation["overall_score"])
             else:
                 score = strength_map.get(str(llm_ca.get("strength", "")).lower(), 0.5)
-            state.add_counter_argument(target, counter_text, strategy_name, score)
+            arg_id = _resolve_target_arg_id(state, target)
+            state.add_counter_argument(
+                target, counter_text, strategy_name, score, target_arg_id=arg_id
+            )
         return
 
     # Backward compat: single LLM counter-argument
@@ -137,7 +166,10 @@ def _write_counter_argument_to_state(
         counter_text = str(llm_ca.get("counter_argument", ""))
         strategy_name = str(llm_ca.get("strategy_used", "unknown"))
         score = strength_map.get(str(llm_ca.get("strength", "")).lower(), 0.5)
-        state.add_counter_argument(target, counter_text, strategy_name, score)
+        arg_id = _resolve_target_arg_id(state, target)
+        state.add_counter_argument(
+            target, counter_text, strategy_name, score, target_arg_id=arg_id
+        )
         return
 
     # Fallback to heuristic plugin output
@@ -152,7 +184,10 @@ def _write_counter_argument_to_state(
     score = strategy.get("confidence", 0.0)
     if not isinstance(score, (int, float)):
         score = 0.0
-    state.add_counter_argument(original, strategy_name, strategy_name, float(score))
+    arg_id = _resolve_target_arg_id(state, original)
+    state.add_counter_argument(
+        original, strategy_name, strategy_name, float(score), target_arg_id=arg_id
+    )
 
 
 def _write_jtms_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/tests/unit/argumentation_analysis/test_counter_arg_tracking_570.py
+++ b/tests/unit/argumentation_analysis/test_counter_arg_tracking_570.py
@@ -1,0 +1,188 @@
+"""Tests for counter-argument ID-based tracking fix (#570).
+
+Verifies that counter-arguments linked by target_arg_id are correctly
+counted in get_enrichment_summary() even when text matching fails.
+"""
+import pytest
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+
+def _make_state_with_id_tracking():
+    """Create a state with 5 arguments and 5 counter-arguments linked by ID.
+
+    The counter-argument original_argument texts are intentionally different
+    from the argument descriptions to prove ID-based matching works.
+    """
+    state = UnifiedAnalysisState("Full text for testing counter-argument tracking.")
+
+    args = []
+    descriptions = [
+        "The economy is growing due to increased exports",
+        "Immigration has no effect on wages",
+        "Climate change requires immediate policy action",
+        "Education funding should be tripled",
+        "Universal basic income reduces poverty",
+    ]
+    for desc in descriptions:
+        args.append(state.add_argument(desc))
+
+    # Counter-arguments with mismatched text but correct target_arg_id
+    ca_data = [
+        ("Exports are not the main driver", "reductio_ad_absurdum", 0.8),
+        ("Wage studies show mixed results", "counter-example", 0.7),
+        ("Policy alone is insufficient", "distinction", 0.9),
+        ("Tripling is not cost-effective", "reformulation", 0.6),
+        ("UBI creates dependency loops", "reductio_ad_absurdum", 0.85),
+    ]
+    for ca_text, strategy, score, arg_id in zip(
+        [d[0] for d in ca_data],
+        [d[1] for d in ca_data],
+        [d[2] for d in ca_data],
+        args,
+    ):
+        state.add_counter_argument(
+            original_arg=ca_text,
+            counter_content=f"Counter to {ca_text}",
+            strategy=strategy,
+            score=score,
+            target_arg_id=arg_id,
+        )
+
+    return state, args
+
+
+class TestCounterArgumentIDTracking:
+    """Test that target_arg_id-based linking works for enrichment summary."""
+
+    def test_id_tracking_all_5_matched(self):
+        """5 CAs with target_arg_id → with_counter_argument == 5."""
+        state, args = _make_state_with_id_tracking()
+        summary = state.get_enrichment_summary()
+        assert summary["total_arguments"] == 5
+        assert summary["with_counter_argument"] == 5
+
+    def test_id_tracking_text_mismatch_doesnt_matter(self):
+        """Even when text doesn't match, ID linkage works."""
+        state, args = _make_state_with_id_tracking()
+        for ca in state.counter_arguments:
+            assert ca["target_arg_id"] in args
+            # Verify text doesn't match (proof ID is needed)
+            original = ca["original_argument"]
+            arg_desc = state.identified_arguments[ca["target_arg_id"]]
+            assert original != arg_desc
+
+    def test_profile_gets_counter_args_by_id(self):
+        """get_argument_profile returns CAs linked by ID."""
+        state, args = _make_state_with_id_tracking()
+        for arg_id in args:
+            profile = state.get_argument_profile(arg_id)
+            assert len(profile.counter_arguments) == 1
+
+    def test_mixed_id_and_text_matching(self):
+        """CAs with target_arg_id AND text-matching both counted."""
+        state = UnifiedAnalysisState("text")
+        a1 = state.add_argument("Argument about X")
+        a2 = state.add_argument("Argument about Y")
+
+        # CA1: linked by ID (text doesn't match)
+        state.add_counter_argument(
+            "Completely different text",
+            "Counter 1",
+            "counter-example",
+            0.8,
+            target_arg_id=a1,
+        )
+        # CA2: linked by text match (no target_arg_id)
+        state.add_counter_argument(
+            "Argument about Y",
+            "Counter 2",
+            "reformulation",
+            0.7,
+        )
+
+        summary = state.get_enrichment_summary()
+        assert summary["with_counter_argument"] == 2
+
+    def test_no_target_arg_id_falls_back_to_text(self):
+        """Without target_arg_id, text matching still works."""
+        state = UnifiedAnalysisState("text")
+        state.add_argument("The economy is growing due to increased exports")
+        state.add_counter_argument(
+            "The economy is growing due to increased exports",
+            "Counter content",
+            "counter-example",
+            0.7,
+        )
+        summary = state.get_enrichment_summary()
+        assert summary["with_counter_argument"] == 1
+
+    def test_invalid_target_arg_id_ignored(self):
+        """target_arg_id pointing to non-existent arg falls back to text."""
+        state = UnifiedAnalysisState("text")
+        state.add_argument("Real argument text here")
+        state.add_counter_argument(
+            "Real argument text here",
+            "Counter",
+            "counter-example",
+            0.7,
+            target_arg_id="arg_999",
+        )
+        summary = state.get_enrichment_summary()
+        # Falls back to text matching and succeeds
+        assert summary["with_counter_argument"] == 1
+
+
+class TestCounterArgumentIDTrackingViaStateWriters:
+    """Test the _resolve_target_arg_id helper from state_writers."""
+
+    def test_resolve_by_exact_id(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _resolve_target_arg_id,
+        )
+
+        state = UnifiedAnalysisState("text")
+        a1 = state.add_argument("Some argument")
+        result = _resolve_target_arg_id(state, a1)
+        assert result == a1
+
+    def test_resolve_by_text_match(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _resolve_target_arg_id,
+        )
+
+        state = UnifiedAnalysisState("text")
+        state.add_argument("The economy is growing due to exports")
+        result = _resolve_target_arg_id(state, "The economy is growing due to exports")
+        assert result is not None
+        assert result.startswith("arg_")
+
+    def test_resolve_by_prefix_match(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _resolve_target_arg_id,
+        )
+
+        state = UnifiedAnalysisState("text")
+        state.add_argument("This is a long argument about climate policy reform")
+        # Text is a prefix of the arg description (60 chars match)
+        result = _resolve_target_arg_id(state, "This is a long argument about climate policy reform")
+        assert result is not None
+
+    def test_resolve_returns_none_for_no_match(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _resolve_target_arg_id,
+        )
+
+        state = UnifiedAnalysisState("text")
+        state.add_argument("Something about cats")
+        result = _resolve_target_arg_id(state, "Something completely different about dogs")
+        assert result is None
+
+    def test_resolve_empty_target(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _resolve_target_arg_id,
+        )
+
+        state = UnifiedAnalysisState("text")
+        state.add_argument("Some argument")
+        result = _resolve_target_arg_id(state, "")
+        assert result is None

--- a/tests/unit/argumentation_analysis/test_formal_verification_tracking_571.py
+++ b/tests/unit/argumentation_analysis/test_formal_verification_tracking_571.py
@@ -1,0 +1,126 @@
+"""Tests for formal verification ID-based tracking fix (#571).
+
+Verifies that PL/FOL/NL-to-logic translations linked by arg_id are correctly
+counted in get_enrichment_summary() even when text matching fails.
+"""
+import pytest
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+
+def _make_state_with_formal_by_id():
+    """Create a state with 3 arguments and formal results linked by arg_id."""
+    state = UnifiedAnalysisState("Full text for testing formal verification tracking.")
+
+    a1 = state.add_argument("The economy is growing due to increased exports")
+    a2 = state.add_argument("Immigration has no effect on wages")
+    a3 = state.add_argument("Climate change requires immediate policy action")
+
+    # PL result linked to arg_1
+    state.add_propositional_analysis_result(
+        formulas=["Exports(x) → Growth(x)"],
+        satisfiable=True,
+        model={"Exports": True, "Growth": True},
+        arg_id=a1,
+    )
+
+    # FOL result linked to arg_2
+    state.add_fol_analysis_result(
+        formulas=["∀x. Immigration(x) → ¬WageEffect(x)"],
+        consistent=True,
+        inferences=["¬WageEffect(john)"],
+        confidence=0.85,
+        arg_id=a2,
+    )
+
+    # NL-to-logic translation linked to arg_3
+    state.add_nl_to_logic_translation(
+        original_text="Completely different text",
+        formula="requires(climate_change, policy_action)",
+        logic_type="FOL",
+        is_valid=True,
+        arg_id=a3,
+    )
+
+    return state, [a1, a2, a3]
+
+
+class TestFormalVerificationIDTracking:
+    """Test arg_id-based linking for formal verification enrichment."""
+
+    def test_all_3_formal_matched_by_id(self):
+        state, args = _make_state_with_formal_by_id()
+        summary = state.get_enrichment_summary()
+        assert summary["total_arguments"] == 3
+        assert summary["with_formal_verification"] == 3
+
+    def test_profile_gets_pl_result_by_id(self):
+        state, args = _make_state_with_formal_by_id()
+        profile = state.get_argument_profile(args[0])
+        formal_types = {r.get("logic_type") or "PL" for r in profile.formal_results}
+        # PL result is present (no logic_type field, but has satisfiable)
+        assert any("satisfiable" in r for r in profile.formal_results)
+
+    def test_profile_gets_fol_result_by_id(self):
+        state, args = _make_state_with_formal_by_id()
+        profile = state.get_argument_profile(args[1])
+        assert any("consistent" in r for r in profile.formal_results)
+
+    def test_profile_gets_nl_translation_by_id(self):
+        state, args = _make_state_with_formal_by_id()
+        profile = state.get_argument_profile(args[2])
+        assert any(r.get("logic_type") == "FOL" for r in profile.formal_results)
+
+    def test_mixed_id_and_text_matching(self):
+        """Both ID-linked and text-matched formal results counted."""
+        state = UnifiedAnalysisState("text")
+        a1 = state.add_argument("The economy is growing")
+        a2 = state.add_argument("Immigration has effects")
+
+        # arg_1: linked by ID (text doesn't match)
+        state.add_nl_to_logic_translation(
+            "Different text entirely",
+            "p → q",
+            "PL",
+            is_valid=True,
+            arg_id=a1,
+        )
+        # arg_2: linked by text match (no arg_id)
+        state.add_nl_to_logic_translation(
+            "Immigration has effects",
+            "r ∧ s",
+            "FOL",
+            is_valid=True,
+        )
+
+        summary = state.get_enrichment_summary()
+        assert summary["with_formal_verification"] == 2
+
+    def test_nl_translation_without_arg_id_uses_text(self):
+        state = UnifiedAnalysisState("text")
+        state.add_argument("Climate change is real")
+        state.add_nl_to_logic_translation(
+            "Climate change is real",
+            "climate_change_real(x)",
+            "FOL",
+            is_valid=True,
+        )
+        summary = state.get_enrichment_summary()
+        assert summary["with_formal_verification"] == 1
+
+    def test_pl_result_without_arg_id_not_counted(self):
+        """PL results without arg_id and without text match are not counted."""
+        state = UnifiedAnalysisState("text")
+        state.add_argument("Some argument")
+        state.add_propositional_analysis_result(
+            formulas=["p → q"],
+            satisfiable=True,
+        )
+        summary = state.get_enrichment_summary()
+        # No text match possible (PL results have no original_text)
+        assert summary["with_formal_verification"] == 0
+
+    def test_empty_state(self):
+        state = UnifiedAnalysisState("text")
+        summary = state.get_enrichment_summary()
+        assert summary["with_formal_verification"] == 0
+        assert summary["total_arguments"] == 0


### PR DESCRIPTION
## Summary
- Add optional `arg_id` parameter to `add_propositional_analysis_result()`, `add_fol_analysis_result()`, and `add_nl_to_logic_translation()` for direct ID-based linking
- Update `get_enrichment_summary()` to check PL, FOL, and NL-to-logic translations for formal verification (was only checking NL-to-logic)
- Update `get_argument_profile()` formal results to match by ID first, falling back to text-matching

## Root Cause
`with_formal_verification` was computed only from `nl_to_logic_translations` using text-matching, ignoring `propositional_analysis_results` and `fol_analysis_results` entirely. Even for NL-to-logic, the text-matching was fragile.

## Test Plan
- [x] 8 new tests in `test_formal_verification_tracking_571.py`
- [x] 64 existing shared_state/cross-ref tests GREEN (zero regression)

Closes #571