### PR TITLE
feat(orchestration): phase-scoped state plugins for tool gating (#605)

### DIFF
--- a/argumentation_analysis/agents/factory.py
+++ b/argumentation_analysis/agents/factory.py
@@ -168,6 +168,7 @@ def get_plugin_instances(
     state: Any = None,
     kernel: Optional[Kernel] = None,
     llm_service: Any = None,
+    state_plugin_class: Optional[type] = None,
 ) -> list[Any]:
     """Return instantiated plugin objects for an agent's speciality.
 
@@ -179,22 +180,32 @@ def get_plugin_instances(
         state: Optional RhetoricalAnalysisState for StateManagerPlugin.
         kernel: Optional SK Kernel for complex plugins (e.g. FallacyWorkflowPlugin).
         llm_service: Optional LLM service for complex plugins.
+        state_plugin_class: Optional phase-scoped state plugin class to use
+            instead of the full StateManagerPlugin (#605). When provided,
+            this class is instantiated with ``state`` and used as the state
+            plugin. Pass ``None`` (default) to use the full StateManagerPlugin.
 
     Returns:
-        List of plugin instances (StateManagerPlugin first if state provided).
+        List of plugin instances (state plugin first if state provided).
     """
     instances = []
 
-    # Always include StateManager if state is available
+    # State plugin: phase-scoped class or full StateManagerPlugin
     if state is not None:
         try:
-            mod = importlib.import_module(
-                "argumentation_analysis.core.state_manager_plugin"
-            )
-            plugin_cls = getattr(mod, "StateManagerPlugin")
-            instances.append(plugin_cls(state=state))
+            if state_plugin_class is not None:
+                instances.append(state_plugin_class(state=state))
+                _factory_logger.debug(
+                    "Using phase-scoped state plugin: %s", state_plugin_class.__name__
+                )
+            else:
+                mod = importlib.import_module(
+                    "argumentation_analysis.core.state_manager_plugin"
+                )
+                plugin_cls = getattr(mod, "StateManagerPlugin")
+                instances.append(plugin_cls(state=state))
         except Exception as e:
-            _factory_logger.debug("StateManagerPlugin not instantiated: %s", e)
+            _factory_logger.debug("State plugin not instantiated: %s", e)
 
     # Load speciality plugins
     plugin_names = AGENT_SPECIALITY_MAP.get(agent_speciality, [])

--- a/argumentation_analysis/core/phase_scoped_state.py
+++ b/argumentation_analysis/core/phase_scoped_state.py
@@ -1,0 +1,500 @@
+"""Phase-scoped state plugins for tool-gating per phase (#605).
+
+Each agent receives only the StateManagerPlugin functions relevant to its phase,
+instead of the full ~30-method surface. This prevents cross-phase tool pollution.
+
+Classes:
+    _SharedStateBase: 5 common methods (read, task control, turn designation)
+    ExtractionPhaseState: Phase 1 — argument/extract/fallacy writes
+    FormalPhaseState: Phase 2 — belief/formal/JTMS/quality writes
+    SynthesisPhaseState: Phase 3 — counter/governance/debate/conclusion writes
+"""
+
+import json
+import logging
+from typing import List, Dict, Optional
+
+from semantic_kernel.functions import kernel_function
+
+from .shared_state import RhetoricalAnalysisState
+
+sm_logger = logging.getLogger("Orchestration.PhaseState")
+
+
+class _SharedStateBase:
+    """Base for phase-scoped state plugins — read + task control methods."""
+
+    _state: "RhetoricalAnalysisState"
+    _logger: logging.Logger
+
+    def __init__(self, state: "RhetoricalAnalysisState"):
+        self._state = state
+        self._logger = sm_logger
+
+    @kernel_function(
+        description="Récupère un aperçu de l'état actuel de l'analyse.",
+        name="get_current_state_snapshot",
+    )
+    def get_current_state_snapshot(self, summarize: bool = True) -> str:
+        try:
+            snapshot_dict = self._state.get_state_snapshot(summarize=summarize)
+            indent = 2 if not summarize else None
+            return json.dumps(snapshot_dict, indent=indent, ensure_ascii=False, default=str)
+        except Exception as e:
+            self._logger.error(f"Snapshot error: {e}", exc_info=True)
+            return json.dumps({"error": str(e)})
+
+    @kernel_function(
+        description="Ajoute une nouvelle tâche d'analyse à l'état.",
+        name="add_analysis_task",
+    )
+    def add_analysis_task(self, description: str) -> str:
+        try:
+            task_id = self._state.add_task(description)
+            return task_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Marque une tâche comme répondue dans l'état.",
+        name="mark_task_as_answered",
+    )
+    def mark_task_as_answered(self, task_id: str, answer: str) -> str:
+        try:
+            self._state.mark_task_as_answered(task_id, answer)
+            return f"OK: Tâche {task_id} marquée comme répondue."
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute une réponse d'un agent à une tâche d'analyse.",
+        name="add_answer",
+    )
+    def add_answer(self, task_id: str, author_agent: str, answer_text: str, source_ids: List[str]) -> str:
+        try:
+            self._state.add_answer(task_id, author_agent, answer_text, source_ids)
+            return f"OK: Réponse pour {task_id} ajoutée."
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Désigne quel agent doit parler au prochain tour.",
+        name="designate_next_agent",
+    )
+    def designate_next_agent(self, agent_name: str) -> str:
+        try:
+            self._state.designate_next_agent(agent_name)
+            return f"OK. Agent '{agent_name}' désigné pour le prochain tour."
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Extraction & Detection
+# ---------------------------------------------------------------------------
+
+class ExtractionPhaseState(_SharedStateBase):
+    """State plugin scoped for Phase 1 — Extraction & Detection.
+
+    Exposes: read + task control + argument/extract writes + fallacy writes.
+    """
+
+    @kernel_function(
+        description="Ajoute un argument identifié à l'état.",
+        name="add_identified_argument",
+    )
+    def add_identified_argument(self, description: str) -> str:
+        try:
+            arg_id = self._state.add_argument(description)
+            return arg_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute une liste d'arguments identifiés à l'état.",
+        name="add_identified_arguments",
+    )
+    def add_identified_arguments(self, arguments: List[str]) -> str:
+        try:
+            self._state.add_identified_arguments(arguments)
+            return f"OK: {len(arguments)} arguments ajoutés."
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute un sophisme identifié à l'état.",
+        name="add_identified_fallacy",
+    )
+    def add_identified_fallacy(
+        self,
+        fallacy_type: str,
+        justification: str,
+        target_argument_id: Optional[str] = None,
+    ) -> str:
+        try:
+            fallacy_id = self._state.add_fallacy(fallacy_type, justification, target_argument_id)
+            return fallacy_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute une liste de sophismes identifiés à l'état.",
+        name="add_identified_fallacies",
+    )
+    def add_identified_fallacies(self, fallacies: List[Dict[str, str]]) -> str:
+        try:
+            self._state.add_identified_fallacies(fallacies)
+            return f"OK: {len(fallacies)} sophismes ajoutés."
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute un extrait textuel identifié pendant l'extraction.",
+        name="add_extract",
+    )
+    def add_extract(self, name: str, content: str) -> str:
+        try:
+            ext_id = self._state.add_extract(name, content)
+            return ext_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute un score de détection neurale de sophisme.",
+        name="add_neural_fallacy_score",
+    )
+    def add_neural_fallacy_score(self, text_segment: str, label: str, confidence: str = "0.5") -> str:
+        try:
+            nf_id = self._state.add_neural_fallacy_score(text_segment, label, float(confidence))
+            return nf_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Formal Analysis & Quality
+# ---------------------------------------------------------------------------
+
+class FormalPhaseState(_SharedStateBase):
+    """State plugin scoped for Phase 2 — Formal Analysis & Quality.
+
+    Exposes: read + task control + belief/formal/JTMS/quality writes.
+    """
+
+    @kernel_function(
+        description="Ajoute un belief set formel à l'état.",
+        name="add_belief_set",
+    )
+    def add_belief_set(self, logic_type: str, content: str) -> str:
+        valid_logic_types = {"propositional": "Propositional", "pl": "Propositional", "fol": "FOL", "first_order": "FOL"}
+        normalized = logic_type.strip().lower()
+        if normalized not in valid_logic_types:
+            return f"FUNC_ERROR: Type logique '{logic_type}' non supporté."
+        try:
+            bs_id = self._state.add_belief_set(valid_logic_types[normalized], content)
+            return bs_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Enregistre une requête formelle et son résultat brut.",
+        name="log_query_result",
+    )
+    def log_query_result(self, belief_set_id: str, query: str, raw_result: str) -> str:
+        try:
+            log_id = self._state.log_query(belief_set_id, query, raw_result)
+            return log_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Enregistre une traduction NL → logique formelle.",
+        name="add_nl_to_logic_translation",
+    )
+    def add_nl_to_logic_translation(
+        self,
+        original_text: str,
+        formula: str,
+        logic_type: str,
+        is_valid: str = "true",
+        variables: str = "{}",
+        confidence: str = "0.7",
+    ) -> str:
+        try:
+            parsed_vars = json.loads(variables) if isinstance(variables, str) else variables
+            tr_id = self._state.add_nl_to_logic_translation(
+                original_text=original_text[:200], formula=formula, logic_type=logic_type,
+                is_valid=is_valid.lower() in ("true", "1", "yes"),
+                variables=parsed_vars, confidence=float(confidence),
+            )
+            return tr_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute des scores de qualité pour un argument.",
+        name="add_quality_score",
+    )
+    def add_quality_score(self, arg_id: str, scores_json: str, overall: str = "0.5") -> str:
+        try:
+            scores = json.loads(scores_json) if isinstance(scores_json, str) else scores_json
+            self._state.add_quality_score(arg_id, scores, float(overall))
+            return f"OK: Quality scores added for {arg_id}"
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute un framework d'argumentation de Dung.",
+        name="add_dung_framework",
+    )
+    def add_dung_framework(
+        self, name: str, arguments_json: str, attacks_json: str, extensions_json: str = "{}",
+    ) -> str:
+        try:
+            arguments = json.loads(arguments_json)
+            attacks = json.loads(attacks_json)
+            extensions = json.loads(extensions_json) if extensions_json != "{}" else None
+            df_id = self._state.add_dung_framework(name, arguments, attacks, extensions)
+            return df_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute un résultat d'analyse ASPIC+.",
+        name="add_aspic_result",
+    )
+    def add_aspic_result(self, reasoner_type: str, extensions_json: str, statistics_json: str) -> str:
+        try:
+            extensions = json.loads(extensions_json)
+            statistics = json.loads(statistics_json)
+            as_id = self._state.add_aspic_result(reasoner_type, extensions, statistics)
+            return as_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute un résultat de révision de croyances.",
+        name="add_belief_revision_result",
+    )
+    def add_belief_revision_result(self, method: str, original_json: str, revised_json: str) -> str:
+        try:
+            original = json.loads(original_json)
+            revised = json.loads(revised_json)
+            br_id = self._state.add_belief_revision_result(method, original, revised)
+            return br_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute un résultat de ranking sémantique.",
+        name="add_ranking_result",
+    )
+    def add_ranking_result(self, method: str, arguments_json: str, comparisons_json: str) -> str:
+        try:
+            arguments = json.loads(arguments_json)
+            comparisons = json.loads(comparisons_json)
+            rk_id = self._state.add_ranking_result(method, arguments, comparisons)
+            return rk_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    # --- JTMS methods ---
+
+    @kernel_function(
+        description="Crée une croyance JTMS avec métadonnées étendues.",
+        name="jtms_create_belief",
+    )
+    def jtms_create_belief(
+        self, belief_name: str, agent_source: str = "unknown",
+        confidence: float = 0.5, context: Optional[str] = None,
+    ) -> str:
+        self._logger.info(f"jtms_create_belief: '{belief_name}', source={agent_source}")
+        try:
+            from argumentation_analysis.services.jtms.extended_belief import JTMSSession
+            if not hasattr(self._state, "_jtms_session"):
+                self._state._jtms_session = JTMSSession(session_id="shared_jtms", owner_agent="phase_state")
+            session = self._state._jtms_session
+            context_dict = {}
+            if context:
+                try:
+                    context_dict = json.loads(context)
+                except (json.JSONDecodeError, TypeError):
+                    context_dict = {"raw": context}
+            session.add_belief(belief_name, agent_source=agent_source, context=context_dict, confidence=confidence)
+            if hasattr(self._state, "add_jtms_belief"):
+                self._state.add_jtms_belief(name=belief_name, valid=True, justifications=[])
+            return f"OK: Belief '{belief_name}' created by {agent_source}"
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute une justification JTMS entre croyances.",
+        name="jtms_add_justification",
+    )
+    def jtms_add_justification(
+        self, in_list: List[str], out_list: List[str], conclusion: str, agent_source: str = "unknown",
+    ) -> str:
+        try:
+            from argumentation_analysis.services.jtms.extended_belief import JTMSSession
+            if not hasattr(self._state, "_jtms_session"):
+                self._state._jtms_session = JTMSSession(session_id="shared_jtms", owner_agent="phase_state")
+            self._state._jtms_session.add_justification(in_list, out_list, conclusion, agent_source=agent_source)
+            return f"OK: Justification for '{conclusion}' added by {agent_source}"
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Interroge les croyances JTMS avec métadonnées.",
+        name="jtms_query_beliefs",
+    )
+    def jtms_query_beliefs(self, agent_filter: Optional[str] = None) -> str:
+        try:
+            from argumentation_analysis.services.jtms.extended_belief import JTMSSession
+            if not hasattr(self._state, "_jtms_session"):
+                return "FUNC_ERROR: No JTMS session initialized."
+            session = self._state._jtms_session
+            results = []
+            for name, ext_belief in session.extended_beliefs.items():
+                if agent_filter and ext_belief.agent_source != agent_filter:
+                    continue
+                results.append({
+                    "name": name, "valid": ext_belief.valid,
+                    "agent_source": ext_belief.agent_source, "confidence": ext_belief.confidence,
+                })
+            return json.dumps(results, ensure_ascii=False, indent=2)
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Vérifie la cohérence de la session JTMS.",
+        name="jtms_check_consistency",
+    )
+    def jtms_check_consistency(self) -> str:
+        try:
+            from argumentation_analysis.services.jtms.extended_belief import JTMSSession
+            if not hasattr(self._state, "_jtms_session"):
+                return "FUNC_ERROR: No JTMS session initialized."
+            session = self._state._jtms_session
+            result = session.check_consistency()
+            return json.dumps({
+                "is_consistent": result.get("is_consistent", True),
+                "conflicts_detected": result.get("conflicts", []),
+                "total_beliefs": len(session.extended_beliefs),
+            }, ensure_ascii=False, indent=2)
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Rétracte une croyance JTMS et propage.",
+        name="jtms_retract_belief",
+    )
+    def jtms_retract_belief(self, belief_name: str, reason: str = "") -> str:
+        self._logger.info(f"jtms_retract_belief: '{belief_name}', reason='{reason[:60]}'")
+        try:
+            from argumentation_analysis.services.jtms.extended_belief import JTMSSession
+            if not hasattr(self._state, "_jtms_session"):
+                return "FUNC_ERROR: No JTMS session initialized."
+            session = self._state._jtms_session
+            if belief_name not in session.extended_beliefs:
+                candidates = [n for n in session.extended_beliefs if belief_name.lower() in n.lower()]
+                if candidates:
+                    belief_name = candidates[0]
+                else:
+                    return f"FUNC_ERROR: Belief '{belief_name}' not found."
+            ext_belief = session.extended_beliefs[belief_name]
+            was_valid = ext_belief.valid
+            session.jtms.set_belief_validity(belief_name, None)
+            import datetime as _dt
+            ext_belief.record_modification("retract", {"reason": reason, "timestamp": _dt.datetime.now().isoformat()})
+            ext_belief.context["retracted"] = True
+            ext_belief.context["retraction_reason"] = reason
+            if hasattr(self._state, "jtms_beliefs"):
+                for bid, bdata in self._state.jtms_beliefs.items():
+                    if bdata.get("name") == belief_name:
+                        bdata["valid"] = False
+                        bdata["retracted"] = True
+                        bdata["retraction_reason"] = reason
+                        break
+            affected = [n for n, b in session.extended_beliefs.items() if n != belief_name and not b.valid]
+            return json.dumps({"retracted_belief": belief_name, "was_valid": was_valid, "affected_count": len(affected)}, ensure_ascii=False)
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Synthesis & Debate
+# ---------------------------------------------------------------------------
+
+class SynthesisPhaseState(_SharedStateBase):
+    """State plugin scoped for Phase 3 — Synthesis & Debate.
+
+    Exposes: read + task control + counter/governance/debate/conclusion writes.
+    """
+
+    @kernel_function(
+        description="Ajoute un contre-argument.",
+        name="add_counter_argument",
+    )
+    def add_counter_argument(
+        self, original_arg: str, counter_content: str, strategy: str,
+        score: str = "0.5", target_arg_id: str = "",
+    ) -> str:
+        try:
+            ca_id = self._state.add_counter_argument(
+                original_arg, counter_content, strategy, float(score),
+                target_arg_id=target_arg_id or None,
+            )
+            return ca_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute une décision de gouvernance/vote.",
+        name="add_governance_decision",
+    )
+    def add_governance_decision(self, method: str, winner: str, scores_json: str) -> str:
+        try:
+            scores = json.loads(scores_json)
+            gd_id = self._state.add_governance_decision(method, winner, scores)
+            return gd_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Ajoute une transcription de débat.",
+        name="add_debate_transcript",
+    )
+    def add_debate_transcript(self, topic: str, exchanges_json: str, winner: str = "") -> str:
+        try:
+            exchanges = json.loads(exchanges_json)
+            dt_id = self._state.add_debate_transcript(topic, exchanges, winner if winner else None)
+            return dt_id
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+    @kernel_function(
+        description="Enregistre la conclusion finale de l'analyse.",
+        name="set_final_conclusion",
+    )
+    def set_final_conclusion(self, conclusion: str) -> str:
+        try:
+            self._state.set_conclusion(conclusion)
+            return "OK: Conclusion finale enregistrée."
+        except Exception as e:
+            return f"FUNC_ERROR: {e}"
+
+
+# ---------------------------------------------------------------------------
+# Agent → Phase mapping
+# ---------------------------------------------------------------------------
+
+AGENT_PHASE_MAP = {
+    "ExtractAgent": ExtractionPhaseState,
+    "InformalAgent": ExtractionPhaseState,
+    "FormalAgent": FormalPhaseState,
+    "QualityAgent": FormalPhaseState,
+    "DebateAgent": SynthesisPhaseState,
+    "CounterAgent": SynthesisPhaseState,
+    "GovernanceAgent": SynthesisPhaseState,
+    # ProjectManager gets full StateManagerPlugin (appears in all phases)
+}

--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -326,20 +326,32 @@ def create_conversational_agents(
     state: RhetoricalAnalysisState,
     llm_service_id: str,
     agent_names: Optional[List[str]] = None,
+    agent_state_class: Optional[Dict[str, type]] = None,
 ) -> List[ChatCompletionAgent]:
     """Create agents with specialized plugins for conversational mode.
 
     Each agent gets:
-    - StateManagerPlugin (shared, for reading/writing analysis state)
+    - StateManagerPlugin (or phase-scoped variant if tool gating is enabled)
     - Its own specialized plugins (loaded via factory.get_plugin_instances())
     - FunctionChoiceBehavior.Auto() for auto tool invocation
 
     Plugin loading is delegated to the central factory registry
     (AGENT_SPECIALITY_MAP + _PLUGIN_REGISTRY) to avoid duplication.
+
+    Args:
+        kernel: SK Kernel instance.
+        state: Shared analysis state.
+        llm_service_id: LLM service ID in the kernel.
+        agent_names: Optional subset of agent names to create.
+        agent_state_class: Optional mapping of agent_name → phase-scoped state
+            plugin class (#605). When provided, the mapped agent gets the
+            scoped class instead of the full StateManagerPlugin.
     """
     from argumentation_analysis.agents.factory import get_plugin_instances
 
     llm_service = kernel.get_service(llm_service_id)
+    if agent_state_class is None:
+        agent_state_class = {}
 
     if agent_names is None:
         agent_names = list(AGENT_CONFIG.keys())
@@ -353,8 +365,10 @@ def create_conversational_agents(
 
         # Get plugin instances from central factory registry
         speciality = config["speciality"]
+        state_cls = agent_state_class.get(name)
         plugins = get_plugin_instances(
-            speciality, state=state, kernel=kernel, llm_service=llm_service
+            speciality, state=state, kernel=kernel, llm_service=llm_service,
+            state_plugin_class=state_cls,
         )
 
         agent = ChatCompletionAgent(
@@ -370,8 +384,10 @@ def create_conversational_agents(
         )
         agents.append(agent)
         plugin_names = [type(p).__name__ for p in plugins]
+        state_type = state_cls.__name__ if state_cls else "StateManagerPlugin"
         logger.info(
-            f"Created agent '{name}' (speciality={speciality}) with plugins: {plugin_names}"
+            f"Created agent '{name}' (speciality={speciality}, state={state_type}) "
+            f"with plugins: {plugin_names}"
         )
 
     return agents
@@ -388,6 +404,7 @@ async def run_conversational_analysis(
     reanalysis_max_turns: int = 5,
     enable_growth_validation: bool = True,
     growth_re_prompt_limit: int = 2,
+    enable_tool_gating: bool = False,
 ) -> Dict[str, Any]:
     """Run a full conversational analysis on the input text.
 
@@ -409,6 +426,8 @@ async def run_conversational_analysis(
         enable_growth_validation: If True, re-prompt agents on zero-growth
             turns in Extraction/Detection/Re-Analysis phases (#597).
         growth_re_prompt_limit: Max re-prompts per turn when growth is absent.
+        enable_tool_gating: If True, use phase-scoped state plugins so agents
+            only see StateManagerPlugin functions relevant to their phase (#605).
 
     Returns dict with state snapshot, conversation history, and metrics.
     """
@@ -418,6 +437,11 @@ async def run_conversational_analysis(
     _env_growth = os.environ.get("ENABLE_GROWTH_VALIDATION", "").lower()
     if _env_growth in ("0", "false", "no"):
         enable_growth_validation = False
+
+    # 0c. Env var override for tool gating (#605)
+    _env_gating = os.environ.get("ENABLE_TOOL_GATING", "").lower()
+    if _env_gating in ("1", "true", "yes"):
+        enable_tool_gating = True
 
     # 1. Setup kernel + LLM
     kernel = sk.Kernel()
@@ -439,9 +463,19 @@ async def run_conversational_analysis(
     state_cls = UnifiedAnalysisState if spectacular else RhetoricalAnalysisState
     state = state_cls(text)
 
+    # 2b. Build agent → phase-scoped state plugin mapping (#605)
+    agent_state_class = {}
+    if enable_tool_gating:
+        from argumentation_analysis.core.phase_scoped_state import AGENT_PHASE_MAP
+        agent_state_class = dict(AGENT_PHASE_MAP)
+        logger.info(
+            f"Tool gating enabled: {len(agent_state_class)} agents get phase-scoped state plugins"
+        )
+
     # 3. Create all agents
     all_agents = create_conversational_agents(
-        kernel, state, "conversational_llm", agent_names
+        kernel, state, "conversational_llm", agent_names,
+        agent_state_class=agent_state_class,
     )
     agent_by_name = {a.name: a for a in all_agents}
 

--- a/docs/reports/SCDA_TOOL_GATING_2026-05.md
+++ b/docs/reports/SCDA_TOOL_GATING_2026-05.md
@@ -1,0 +1,134 @@
+# SCDA Tool Gating Report — Phase-Scoped StateManagerPlugin
+
+**Date:** 2026-05-18
+**Issue:** #605 (Track N)
+**Status:** Implementation complete, pending PR review
+
+## 1. Summary
+
+Implements phase-scoped state plugins to restrict which `@kernel_function` methods each agent can invoke, restoring the V0 architectural principle that agents should only see tools relevant to their role. The mechanism uses composition (not runtime filters) — each agent receives a dedicated state plugin class that exposes only its phase's methods.
+
+## 2. Problem
+
+All 8 conversational agents receive the full `StateManagerPlugin` with ~30 `@kernel_function` methods. This means:
+- InformalAgent (Phase 1) can see `add_dung_framework()`, `add_belief_set()`, `set_final_conclusion()` — formal and synthesis tools
+- FormalAgent (Phase 2) can see `add_identified_argument()`, `add_counter_argument()` — extraction and synthesis tools
+- Agents have ~30 tool definitions in their prompt context, causing pollution and potential hallucinated tool calls
+
+`AGENT_SPECIALITY_MAP` already scopes per-agent plugins correctly, but StateManagerPlugin is shared and unscoped.
+
+## 3. Solution
+
+### 3.1 Phase-Scoped State Classes
+
+New file: `argumentation_analysis/core/phase_scoped_state.py`
+
+| Class | Phase | Methods | Description |
+|-------|-------|---------|-------------|
+| `_SharedStateBase` | All | 5 | Read, task control, turn designation |
+| `ExtractionPhaseState` | Phase 1 | 5 + 6 = 11 | + argument, extract, fallacy writes |
+| `FormalPhaseState` | Phase 2 | 5 + 13 = 18 | + belief, formal, JTMS, quality writes |
+| `SynthesisPhaseState` | Phase 3 | 5 + 4 = 9 | + counter, governance, debate, conclusion |
+
+### 3.2 Method Distribution
+
+| Category | Methods | Shared | Extraction | Formal | Synthesis |
+|----------|---------|--------|------------|--------|-----------|
+| Read | `get_current_state_snapshot` | ✅ | ✅ | ✅ | ✅ |
+| Task control | `add_analysis_task`, `mark_task_as_answered`, `add_answer` | ✅ | ✅ | ✅ | ✅ |
+| Turn control | `designate_next_agent` | ✅ | ✅ | ✅ | ✅ |
+| Arguments | `add_identified_argument`, `add_identified_arguments` | | ✅ | | |
+| Fallacies | `add_identified_fallacy`, `add_identified_fallacies`, `add_neural_fallacy_score` | | ✅ | | |
+| Extracts | `add_extract` | | ✅ | | |
+| Logic | `add_belief_set`, `log_query_result`, `add_nl_to_logic_translation` | | | ✅ | |
+| Quality | `add_quality_score` | | | ✅ | |
+| Dung | `add_dung_framework` | | | ✅ | |
+| ASPIC | `add_aspic_result` | | | ✅ | |
+| Belief revision | `add_belief_revision_result` | | | ✅ | |
+| Ranking | `add_ranking_result` | | | ✅ | |
+| JTMS | `jtms_create_belief`, `jtms_add_justification`, `jtms_query_beliefs`, `jtms_check_consistency`, `jtms_retract_belief` | | | ✅ | |
+| Counter | `add_counter_argument` | | | | ✅ |
+| Governance | `add_governance_decision` | | | | ✅ |
+| Debate | `add_debate_transcript` | | | | ✅ |
+| Conclusion | `set_final_conclusion` | | | | ✅ |
+
+### 3.3 Agent Mapping
+
+| Agent | Phase | State Plugin |
+|-------|-------|-------------|
+| ExtractAgent | Extraction | `ExtractionPhaseState` |
+| InformalAgent | Extraction | `ExtractionPhaseState` |
+| FormalAgent | Formal | `FormalPhaseState` |
+| QualityAgent | Formal | `FormalPhaseState` |
+| DebateAgent | Synthesis | `SynthesisPhaseState` |
+| CounterAgent | Synthesis | `SynthesisPhaseState` |
+| GovernanceAgent | Synthesis | `SynthesisPhaseState` |
+| **ProjectManager** | **All** | **`StateManagerPlugin`** (full access) |
+
+ProjectManager retains the full StateManagerPlugin because it participates in all 3 phases as the coordinating agent.
+
+### 3.4 Tool Surface Reduction
+
+| Agent | Before (tools visible) | After (tools visible) | Reduction |
+|-------|----------------------|----------------------|-----------|
+| ExtractAgent | ~30 | 11 | 63% |
+| InformalAgent | ~30 | 11 | 63% |
+| FormalAgent | ~30 | 18 | 40% |
+| QualityAgent | ~30 | 18 | 40% |
+| DebateAgent | ~30 | 9 | 70% |
+| CounterAgent | ~30 | 9 | 70% |
+| GovernanceAgent | ~30 | 9 | 70% |
+| ProjectManager | ~30 | ~30 | 0% |
+
+## 4. Implementation Details
+
+### 4.1 Backward Compatibility
+
+- `enable_tool_gating: bool = False` — default OFF, zero impact on existing runs
+- Env var override: `ENABLE_TOOL_GATING=1` enables gating
+- Full `StateManagerPlugin` is unchanged — backward compat for all existing code
+
+### 4.2 Modified Files
+
+| File | Change |
+|------|--------|
+| `argumentation_analysis/core/phase_scoped_state.py` | NEW — 4 classes, 28 methods, agent mapping |
+| `argumentation_analysis/agents/factory.py` | `get_plugin_instances()` accepts `state_plugin_class` param |
+| `argumentation_analysis/orchestration/conversational_orchestrator.py` | `enable_tool_gating` param + env var + `agent_state_class` dict |
+
+### 4.3 Test Coverage
+
+File: `tests/unit/argumentation_analysis/core/test_phase_scoped_state.py`
+
+| Test Class | Tests | Validates |
+|-----------|-------|-----------|
+| `TestSharedStateBase` | 4 | Shared methods present on all phases |
+| `TestExtractionPhaseState` | 5 | Method set, isolation, delegation |
+| `TestFormalPhaseState` | 5 | Method set, isolation, delegation |
+| `TestSynthesisPhaseState` | 4 | Method set, isolation, delegation |
+| `TestAgentPhaseMap` | 5 | Agent→phase mapping correctness |
+| `TestMethodCounts` | 1 | Regression guard (5+6+13+4=28) |
+
+**24 tests, all passing.**
+
+## 5. DoD Status
+
+| Criterion | Status | Evidence |
+|-----------|--------|----------|
+| Per-phase tool sets declared | ✅ MET | `phase_scoped_state.py` with 3 classes |
+| Filter wired into agent creation | ✅ MET | `factory.py` + `orchestrator.py` `agent_state_class` |
+| Test coverage | ✅ MET | 24 unit tests, 0 failures |
+| Telemetry | ✅ MET | Logger shows `state=<ClassName>` at agent creation |
+| Backward compat flag | ✅ MET | `enable_tool_gating=False` default + env var |
+| Report | ✅ MET | This file |
+| PR | Pending | Coordinator review required (core orchestrator code) |
+
+## 6. Files
+
+| File | Description |
+|------|-------------|
+| `argumentation_analysis/core/phase_scoped_state.py` | Phase-scoped state plugin classes |
+| `argumentation_analysis/agents/factory.py` | Updated `get_plugin_instances()` |
+| `argumentation_analysis/orchestration/conversational_orchestrator.py` | Updated `run_conversational_analysis()` + `create_conversational_agents()` |
+| `tests/unit/argumentation_analysis/core/test_phase_scoped_state.py` | 24 unit tests |
+| `docs/reports/SCDA_TOOL_GATING_2026-05.md` | This report |

--- a/tests/unit/argumentation_analysis/core/test_phase_scoped_state.py
+++ b/tests/unit/argumentation_analysis/core/test_phase_scoped_state.py
@@ -1,0 +1,261 @@
+"""Unit tests for phase-scoped state plugins (#605).
+
+Verifies that each phase-scoped class exposes only the intended @kernel_function
+methods and that delegation to the underlying state works correctly.
+"""
+
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from argumentation_analysis.core.phase_scoped_state import (
+    _SharedStateBase,
+    ExtractionPhaseState,
+    FormalPhaseState,
+    SynthesisPhaseState,
+    AGENT_PHASE_MAP,
+)
+from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _kernel_function_names(cls) -> set[str]:
+    """Return the set of @kernel_function method names on a class (own + inherited)."""
+    names = set()
+    for name, method in inspect.getmembers(cls, predicate=inspect.isfunction):
+        if hasattr(method, "__kernel_function__") or hasattr(method, "__sk_function__"):
+            names.add(name)
+    return names
+
+
+@pytest.fixture
+def mock_state():
+    """Create a mock RhetoricalAnalysisState (not spec-limited — state methods vary)."""
+    state = MagicMock()
+    state.get_state_snapshot.return_value = {"identified_arguments": []}
+    state.add_task.return_value = "task_1"
+    state.add_argument.return_value = "arg_1"
+    state.add_fallacy.return_value = "fallacy_1"
+    state.add_extract.return_value = "ext_1"
+    state.add_belief_set.return_value = "bs_1"
+    state.log_query.return_value = "log_1"
+    state.add_nl_to_logic_translation.return_value = "tr_1"
+    state.add_quality_score.return_value = "OK"
+    state.add_dung_framework.return_value = "df_1"
+    state.add_aspic_result.return_value = "as_1"
+    state.add_belief_revision_result.return_value = "br_1"
+    state.add_ranking_result.return_value = "rk_1"
+    state.add_counter_argument.return_value = "ca_1"
+    state.add_governance_decision.return_value = "gd_1"
+    state.add_debate_transcript.return_value = "dt_1"
+    state.add_neural_fallacy_score.return_value = "nf_1"
+    state.designate_next_agent.return_value = None
+    state.mark_task_as_answered.return_value = None
+    state.add_answer.return_value = None
+    state.set_conclusion.return_value = None
+    state.add_identified_arguments.return_value = None
+    state.add_identified_fallacies.return_value = None
+    return state
+
+
+# ---------------------------------------------------------------------------
+# Test: Shared base methods
+# ---------------------------------------------------------------------------
+
+class TestSharedStateBase:
+    def test_shared_methods_present_on_all_phases(self):
+        """All 3 phase classes inherit the 5 shared methods."""
+        shared = _kernel_function_names(_SharedStateBase)
+        expected = {
+            "get_current_state_snapshot",
+            "add_analysis_task",
+            "mark_task_as_answered",
+            "add_answer",
+            "designate_next_agent",
+        }
+        assert shared == expected
+
+    def test_extraction_inherits_shared(self):
+        shared = _kernel_function_names(_SharedStateBase)
+        extraction = _kernel_function_names(ExtractionPhaseState)
+        assert shared.issubset(extraction)
+
+    def test_formal_inherits_shared(self):
+        shared = _kernel_function_names(_SharedStateBase)
+        formal = _kernel_function_names(FormalPhaseState)
+        assert shared.issubset(formal)
+
+    def test_synthesis_inherits_shared(self):
+        shared = _kernel_function_names(_SharedStateBase)
+        synthesis = _kernel_function_names(SynthesisPhaseState)
+        assert shared.issubset(synthesis)
+
+
+# ---------------------------------------------------------------------------
+# Test: Phase-specific method isolation
+# ---------------------------------------------------------------------------
+
+class TestExtractionPhaseState:
+    EXPECTED = {
+        # Shared (5)
+        "get_current_state_snapshot", "add_analysis_task", "mark_task_as_answered",
+        "add_answer", "designate_next_agent",
+        # Extraction-specific (6)
+        "add_identified_argument", "add_identified_arguments",
+        "add_identified_fallacy", "add_identified_fallacies",
+        "add_extract", "add_neural_fallacy_score",
+    }
+
+    def test_exposes_only_expected_methods(self):
+        actual = _kernel_function_names(ExtractionPhaseState)
+        assert actual == self.EXPECTED
+
+    def test_does_not_expose_formal_methods(self):
+        actual = _kernel_function_names(ExtractionPhaseState)
+        assert "add_belief_set" not in actual
+        assert "jtms_create_belief" not in actual
+        assert "add_dung_framework" not in actual
+
+    def test_does_not_expose_synthesis_methods(self):
+        actual = _kernel_function_names(ExtractionPhaseState)
+        assert "add_counter_argument" not in actual
+        assert "set_final_conclusion" not in actual
+        assert "add_debate_transcript" not in actual
+
+    def test_delegation_add_argument(self, mock_state):
+        plugin = ExtractionPhaseState(state=mock_state)
+        result = plugin.add_identified_argument("Test argument")
+        mock_state.add_argument.assert_called_once_with("Test argument")
+        assert result == "arg_1"
+
+    def test_delegation_add_fallacy(self, mock_state):
+        plugin = ExtractionPhaseState(state=mock_state)
+        result = plugin.add_identified_fallacy("post_hoc", "Justification", "arg_1")
+        mock_state.add_fallacy.assert_called_once_with("post_hoc", "Justification", "arg_1")
+        assert result == "fallacy_1"
+
+
+class TestFormalPhaseState:
+    EXPECTED = {
+        # Shared (5)
+        "get_current_state_snapshot", "add_analysis_task", "mark_task_as_answered",
+        "add_answer", "designate_next_agent",
+        # Formal-specific (13)
+        "add_belief_set", "log_query_result", "add_nl_to_logic_translation",
+        "add_quality_score", "add_dung_framework", "add_aspic_result",
+        "add_belief_revision_result", "add_ranking_result",
+        "jtms_create_belief", "jtms_add_justification", "jtms_query_beliefs",
+        "jtms_check_consistency", "jtms_retract_belief",
+    }
+
+    def test_exposes_only_expected_methods(self):
+        actual = _kernel_function_names(FormalPhaseState)
+        assert actual == self.EXPECTED
+
+    def test_does_not_expose_extraction_methods(self):
+        actual = _kernel_function_names(FormalPhaseState)
+        assert "add_identified_argument" not in actual
+        assert "add_identified_fallacy" not in actual
+        assert "add_extract" not in actual
+
+    def test_does_not_expose_synthesis_methods(self):
+        actual = _kernel_function_names(FormalPhaseState)
+        assert "add_counter_argument" not in actual
+        assert "set_final_conclusion" not in actual
+
+    def test_delegation_add_belief_set(self, mock_state):
+        plugin = FormalPhaseState(state=mock_state)
+        result = plugin.add_belief_set("propositional", "p => q")
+        mock_state.add_belief_set.assert_called_once_with("Propositional", "p => q")
+        assert result == "bs_1"
+
+    def test_invalid_logic_type(self, mock_state):
+        plugin = FormalPhaseState(state=mock_state)
+        result = plugin.add_belief_set("modal", "[]p")
+        assert "FUNC_ERROR" in result
+        mock_state.add_belief_set.assert_not_called()
+
+
+class TestSynthesisPhaseState:
+    EXPECTED = {
+        # Shared (5)
+        "get_current_state_snapshot", "add_analysis_task", "mark_task_as_answered",
+        "add_answer", "designate_next_agent",
+        # Synthesis-specific (4)
+        "add_counter_argument", "add_governance_decision",
+        "add_debate_transcript", "set_final_conclusion",
+    }
+
+    def test_exposes_only_expected_methods(self):
+        actual = _kernel_function_names(SynthesisPhaseState)
+        assert actual == self.EXPECTED
+
+    def test_does_not_expose_extraction_methods(self):
+        actual = _kernel_function_names(SynthesisPhaseState)
+        assert "add_identified_argument" not in actual
+        assert "add_identified_fallacy" not in actual
+
+    def test_does_not_expose_formal_methods(self):
+        actual = _kernel_function_names(SynthesisPhaseState)
+        assert "add_belief_set" not in actual
+        assert "jtms_create_belief" not in actual
+
+    def test_delegation_set_conclusion(self, mock_state):
+        plugin = SynthesisPhaseState(state=mock_state)
+        result = plugin.set_final_conclusion("Final analysis conclusion")
+        mock_state.set_conclusion.assert_called_once_with("Final analysis conclusion")
+        assert "OK" in result
+
+
+# ---------------------------------------------------------------------------
+# Test: Agent → Phase mapping
+# ---------------------------------------------------------------------------
+
+class TestAgentPhaseMap:
+    def test_all_specialist_agents_mapped(self):
+        expected_agents = {
+            "ExtractAgent", "InformalAgent",
+            "FormalAgent", "QualityAgent",
+            "DebateAgent", "CounterAgent", "GovernanceAgent",
+        }
+        assert set(AGENT_PHASE_MAP.keys()) == expected_agents
+
+    def test_project_manager_not_mapped(self):
+        """PM is not mapped — it gets full StateManagerPlugin."""
+        assert "ProjectManager" not in AGENT_PHASE_MAP
+
+    def test_extraction_agents(self):
+        assert AGENT_PHASE_MAP["ExtractAgent"] is ExtractionPhaseState
+        assert AGENT_PHASE_MAP["InformalAgent"] is ExtractionPhaseState
+
+    def test_formal_agents(self):
+        assert AGENT_PHASE_MAP["FormalAgent"] is FormalPhaseState
+        assert AGENT_PHASE_MAP["QualityAgent"] is FormalPhaseState
+
+    def test_synthesis_agents(self):
+        assert AGENT_PHASE_MAP["DebateAgent"] is SynthesisPhaseState
+        assert AGENT_PHASE_MAP["CounterAgent"] is SynthesisPhaseState
+        assert AGENT_PHASE_MAP["GovernanceAgent"] is SynthesisPhaseState
+
+
+# ---------------------------------------------------------------------------
+# Test: Method counts (regression guard)
+# ---------------------------------------------------------------------------
+
+class TestMethodCounts:
+    def test_total_method_count(self):
+        """Total methods across all phases should match expected count."""
+        shared = _kernel_function_names(_SharedStateBase)
+        extraction_only = _kernel_function_names(ExtractionPhaseState) - shared
+        formal_only = _kernel_function_names(FormalPhaseState) - shared
+        synthesis_only = _kernel_function_names(SynthesisPhaseState) - shared
+
+        assert len(shared) == 5
+        assert len(extraction_only) == 6
+        assert len(formal_only) == 13
+        assert len(synthesis_only) == 4
+        # Total: 5 + 6 + 13 + 4 = 28


### PR DESCRIPTION
## Summary

Implements phase-scoped state plugins to restrict which `@kernel_function` methods each agent can invoke, restoring the V0 architectural principle that agents should only see tools relevant to their role.

- **3 phase-scoped classes**: `ExtractionPhaseState` (11 methods), `FormalPhaseState` (18 methods), `SynthesisPhaseState` (9 methods) — replacing the full ~30-method `StateManagerPlugin` for specialist agents
- **ProjectManager** retains full `StateManagerPlugin` (participates in all phases)
- **Backward compat**: `enable_tool_gating=False` by default, env var `ENABLE_TOOL_GATING=1` to opt-in
- **24 unit tests** all passing, covering method isolation, delegation, and agent→phase mapping

## Files changed

| File | Change |
|------|--------|
| `argumentation_analysis/core/phase_scoped_state.py` | NEW — 4 classes, 28 methods, agent mapping |
| `argumentation_analysis/agents/factory.py` | `get_plugin_instances()` accepts `state_plugin_class` param |
| `argumentation_analysis/orchestration/conversational_orchestrator.py` | `enable_tool_gating` param + env var + `agent_state_class` dict |
| `tests/unit/argumentation_analysis/core/test_phase_scoped_state.py` | NEW — 24 unit tests |
| `docs/reports/SCDA_TOOL_GATING_2026-05.md` | NEW — full report |

## Test plan

- [x] `pytest tests/unit/argumentation_analysis/core/test_phase_scoped_state.py -v` — 24 passed
- [x] `pytest tests/unit/argumentation_analysis/core/test_capability_registry.py -v` — no regression
- [ ] Manual: `ENABLE_TOOL_GATING=1 python scripts/scda_audit.py --corpus A` — verify pipeline runs without errors
- [ ] Review: agent creation logs show correct state plugin class per agent

Closes #605

🤖 Generated with [Claude Code](https://claude.com/claude-code)