### PR TITLE
docs(reports): harmonize spectacular bundle README + INDEX (#606)

### DIFF
--- a/docs/reports/INDEX.md
+++ b/docs/reports/INDEX.md
@@ -14,7 +14,7 @@ The SCDA (Spectacular Conversational Discourse Analysis) reports document the de
 
 | Directory | Description |
 |-----------|-------------|
-| [spectacular/](spectacular/) | Full artefact bundle: state dumps (6 formats), balance reports, cross-reference graphs, re-prompt traces for corpora A/B/C |
+| [spectacular/](spectacular/) | Full artefact bundle: state dumps (5 formats), balance reports, cross-reference graphs, re-prompt traces for corpora A/B/C (42 files, ~454K) |
 
 ### Sprint Audit Trail (chronological)
 

--- a/docs/reports/spectacular/README.md
+++ b/docs/reports/spectacular/README.md
@@ -1,6 +1,14 @@
-# SCDA Spectacular Demo Bundle
+# SCDA Spectacular Capstone Bundle
 
-This directory contains the full artefact bundle for Epic #530 (Spectacular Demonstrator for Conversational Analysis). Each corpus (A, B, C) is analyzed through the SCDA pipeline and exported in multiple formats with balance analysis and cross-reference graphs.
+Full artefact bundle for Epic #530 (Spectacular Demonstrator for Conversational Analysis). Three politically-diverse corpora analyzed through the 8-agent SCDA pipeline, exported in 6 formats with balance analysis, cross-reference graphs, and re-prompt traces.
+
+## Corpus Overview
+
+| Corpus | Arguments | Fallacies | Phases | Turns | Duration |
+|--------|-----------|-----------|--------|-------|----------|
+| A | 20 | 13 | 4 | 33 | ~39 min |
+| B | 17 | 17 | 4 | 28 | ~36 min |
+| C | 10 | 14 | 4 | 33 | ~41 min |
 
 ## Quick Start — What to Open First
 
@@ -8,23 +16,23 @@ This directory contains the full artefact bundle for Epic #530 (Spectacular Demo
 |--------------------|---------------|
 | Executive summary + all 4 properties | `../EPIC_530_SCDA_SPECTACULAR_FINAL_REPORT.md` |
 | Human-readable state dump | `corpus_A.md`, `corpus_B.md`, `corpus_C.md` |
+| Interactive HTML presentation | `corpus_A.html` (collapsible sections + summary cards) |
 | Conversation balance per corpus | `balance_corpus_A.md`, `balance_corpus_B.md`, `balance_corpus_C.md` |
 | Cross-reference graph visualization | `cross_ref_graph_corpus_A.mmd` (Mermaid), `*.dot` (Graphviz) |
 | Re-prompt trace evidence | `reprompt_trace_corpus_A.json` |
 | Machine-readable state | `corpus_A.json` |
-| HTML presentation | `corpus_A.html` |
-| Spreadsheet analysis | `corpus_A/csv/*.csv` |
+| Spreadsheet analysis | `A/csv/args.csv`, `A/csv/fallacies.csv`, etc. |
 
 ## Artefact Inventory
 
-### State Dumps (6 formats × 3 corpora)
+### State Dumps (5 formats × 3 corpora)
 
 | Format | Corpus A | Corpus B | Corpus C |
 |--------|----------|----------|----------|
 | JSON | `corpus_A.json` | `corpus_B.json` | `corpus_C.json` |
 | XML | `corpus_A.xml` | `corpus_B.xml` | `corpus_C.xml` |
 | Markdown | `corpus_A.md` | `corpus_B.md` | `corpus_C.md` |
-| CSV bundle | `corpus_A/csv/` | `corpus_B/csv/` | `corpus_C/csv/` |
+| CSV tables | `A/csv/*.csv` | `B/csv/*.csv` | `C/csv/*.csv` |
 | HTML | `corpus_A.html` | `corpus_B.html` | `corpus_C.html` |
 
 ### Balance Reports (Track Q)
@@ -49,10 +57,10 @@ This directory contains the full artefact bundle for Epic #530 (Spectacular Demo
 
 | Jury Question | Artefact | Answer |
 |---------------|----------|--------|
-| "Is the conversation balanced?" | `balance_corpus_*.md` | Shannon entropy balance score ~0.98-0.99 across all corpora |
+| "Is the conversation balanced?" | `balance_corpus_*.md` | Shannon entropy balance score, agent participation distribution |
 | "Is the state rich and interconnected?" | `cross_ref_graph_corpus_*.json` | 7 edge types, density metrics showing cascade propagation |
-| "Can you export in multiple formats?" | 18 state dump files across 6 formats | JSON, XML, Markdown, CSV, HTML, Rich CLI |
-| "How do you handle LLM failures?" | `reprompt_trace_corpus_*.json` | Fingerprint-delta tracking, ok/reran/gave_up outcomes |
+| "Can you export in multiple formats?" | 15+ state dump files across 5 formats | JSON, XML, Markdown, CSV, HTML |
+| "How do you handle LLM failures?" | `reprompt_trace_corpus_*.json` | Fingerprint-delta tracking, ok/reran/gave_up outcomes (12 events across 3 corpora) |
 | "What fallacies are detected?" | `corpus_*.md` fallacy section | 44 total fallacies across 3 corpora, 6 families |
 | "How do formal methods connect?" | `cross_ref_graph_corpus_*.mmd` | Visual showing argument→fallacy→JTMS→BR cascade |
 
@@ -63,9 +71,6 @@ All artefacts use opaque IDs only. No plaintext from the encrypted dataset is in
 ## Reproduction
 
 ```bash
-# Run SCDA on corpus A (gpt-5-mini, ~20 min)
-conda run -n projet-is-roo-new python examples/soutenance/run_corpus_a.py
-
-# Export all formats
-conda run -n projet-is-roo-new python scripts/analysis/export_scda_state.py --format all --output docs/reports/spectacular/
+# Generate the full bundle from pipeline outputs
+conda run -n projet-is-roo-new python scripts/analysis/generate_spectacular_bundle.py
 ```


### PR DESCRIPTION
## Summary

Post-merge harmonization of the spectacular bundle documentation (Track O Session 5, #606):

- **README.md**: Fix CSV path references (`A/csv/` not `corpus_A/csv/`), add corpus overview table with real stats from the generated bundle, update format count (5 not 6)
- **INDEX.md**: Update bundle description to match actual 42-file/~454K bundle

### Context

PR #614 (narrative + INDEX) was merged at `3ceff124`. PR #615 (po-2025 artefact bundle) is pending merge. This PR harmonizes the README written in sessions 1-2 with the actual file structure from sessions 3-4, fixing the path mismatch discovered during cross-link review.

### Dependencies

Should merge **after** PR #615 (spectacular bundle) to avoid conflicting with the README po-2025 included in that PR.

## Test Plan

- [x] README paths match actual artefact locations from PR #615
- [x] INDEX.md bundle description reflects real file count and size
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)