### PR TITLE
feat(synthesis): convergent multidimensional synthesis (#634)

### DIFF
--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -170,6 +170,226 @@ def build_narrative(state: Any) -> str:
     return paragraph_1
 
 
+# ════════════════════════════════════════════════════════════════════
+# Convergent multidimensional synthesis (#634)
+#
+# The template synthesis above describes each KB in isolation. The real
+# spectacular insight is *convergence*: when several independent methods
+# (rhetorical fallacy detection, abstract argumentation, truth maintenance,
+# quality scoring, counter-argumentation) flag the SAME argument as weak,
+# that agreement is itself the finding — a verdict no single LLM pass
+# produces. The functions below compute per-argument convergence and weave
+# the convergent verdicts into the narrative.
+# ════════════════════════════════════════════════════════════════════
+
+QUALITY_WEAK_THRESHOLD = 5.0
+
+
+def _dung_rejected_args(state: Any) -> Dict[str, str]:
+    """Return {arg_id: semantics} for arguments present in a Dung framework
+    but absent from its accepted extension (i.e. rejected by that semantics)."""
+    rejected: Dict[str, str] = {}
+    frameworks = getattr(state, "dung_frameworks", {}) or {}
+    if not isinstance(frameworks, dict):
+        return rejected
+    for _fid, fw in frameworks.items():
+        if not isinstance(fw, dict):
+            continue
+        fw_args = fw.get("arguments", []) or []
+        if not isinstance(fw_args, list):
+            continue
+        semantics = fw.get("semantics", "grounded")
+        # Accepted members: prefer enriched dict (all_members), fall back to
+        # flat list-of-lists, then to a bare list.
+        ext = fw.get("extensions", [])
+        accepted: set = set()
+        if isinstance(ext, dict):
+            # Enriched form: {"all_members": [...]}; else semantics->list form:
+            # {"grounded": ["arg_1", ...], "preferred": [...]}
+            if "all_members" in ext:
+                accepted = set(ext.get("all_members", []) or [])
+            else:
+                for val in ext.values():
+                    if isinstance(val, list):
+                        for item in val:
+                            if isinstance(item, list):
+                                accepted.update(item)
+                            elif isinstance(item, str):
+                                accepted.add(item)
+                    elif isinstance(val, dict):
+                        accepted.update(val.get("all_members", []) or [])
+        elif isinstance(ext, list):
+            for item in ext:
+                if isinstance(item, list):
+                    accepted.update(item)
+                elif isinstance(item, str):
+                    accepted.add(item)
+        for arg in fw_args:
+            if isinstance(arg, str) and arg not in accepted:
+                # Don't overwrite a prior rejection from another framework
+                rejected.setdefault(arg, semantics)
+    return rejected
+
+
+def compute_argument_convergence(state: Any) -> Dict[str, Dict[str, Any]]:
+    """For each identified argument, count independent methods flagging it weak.
+
+    Reads raw state fields (works on both UnifiedAnalysisState and a namespace
+    built from a state dict). Returns a mapping
+    ``{arg_id: {"score": int, "signals": [(method, detail), ...]}}``.
+    """
+    args = getattr(state, "identified_arguments", {}) or {}
+    if not isinstance(args, dict):
+        return {}
+
+    fallacies = getattr(state, "identified_fallacies", {}) or {}
+    quality = getattr(state, "argument_quality_scores", {}) or {}
+    counters = getattr(state, "counter_arguments", []) or []
+    jtms = getattr(state, "jtms_beliefs", {}) or {}
+    rejected_by_dung = _dung_rejected_args(state)
+
+    # Pre-index fallacies by target argument
+    fallacy_by_arg: Dict[str, List[str]] = {}
+    if isinstance(fallacies, dict):
+        for _fid, fdata in fallacies.items():
+            if not isinstance(fdata, dict):
+                continue
+            tid = fdata.get("target_argument_id")
+            if tid:
+                fallacy_by_arg.setdefault(tid, []).append(fdata.get("type", "inconnu"))
+
+    # Pre-index counter-arguments by target (ID-based only — text matching is
+    # handled by get_argument_profile elsewhere; here we stay strict/cheap)
+    counter_by_arg: Dict[str, int] = {}
+    if isinstance(counters, list):
+        for ca in counters:
+            if isinstance(ca, dict):
+                tid = ca.get("target_arg_id")
+                if tid:
+                    counter_by_arg[tid] = counter_by_arg.get(tid, 0) + 1
+
+    result: Dict[str, Dict[str, Any]] = {}
+    for arg_id in args:
+        signals: List[tuple] = []
+
+        # 1. Rhetorical fallacy targeting this argument
+        if arg_id in fallacy_by_arg:
+            ftypes = sorted(set(fallacy_by_arg[arg_id]))
+            signals.append(("sophisme", ", ".join(ftypes)))
+
+        # 2. Low quality score
+        qs = quality.get(arg_id) if isinstance(quality, dict) else None
+        if isinstance(qs, dict):
+            overall = qs.get("overall")
+            if isinstance(overall, (int, float)) and overall < QUALITY_WEAK_THRESHOLD:
+                signals.append(("qualite faible", f"{overall:.1f}/10"))
+
+        # 3. Counter-argument generated against it
+        if arg_id in counter_by_arg:
+            signals.append(("contre-argument", str(counter_by_arg[arg_id])))
+
+        # 4. JTMS belief retracted / invalid
+        if isinstance(jtms, dict):
+            invalid = 0
+            for _bid, bdata in jtms.items():
+                if not isinstance(bdata, dict):
+                    continue
+                name = bdata.get("name", "")
+                if arg_id in name and bdata.get("valid") is False:
+                    invalid += 1
+            if invalid:
+                signals.append(("JTMS retracte", str(invalid)))
+
+        # 5. Rejected by Dung abstract argumentation
+        if arg_id in rejected_by_dung:
+            signals.append(("rejet Dung", rejected_by_dung[arg_id]))
+
+        if signals:
+            result[arg_id] = {"score": len(signals), "signals": signals}
+
+    return result
+
+
+def build_convergent_synthesis(state: Any) -> Dict[str, Any]:
+    """Build a spectacular synthesis surfacing cross-dimensional convergence.
+
+    Returns a dict with:
+      - ``narrative``: the base template narrative (backward-compatible)
+      - ``convergent_verdicts``: per-argument list flagged by >=2 methods
+      - ``emergent_insights``: human-readable convergence statements
+      - ``conclusion``: a one-line verdict suitable for ``final_conclusion``
+    """
+    base_narrative = build_narrative(state)
+    convergence = compute_argument_convergence(state)
+
+    # Convergent verdicts = arguments flagged by >=2 independent methods
+    verdicts = {aid: data for aid, data in convergence.items() if data["score"] >= 2}
+    # Sort by descending convergence score (strongest agreement first)
+    ordered = sorted(verdicts.items(), key=lambda kv: kv[1]["score"], reverse=True)
+
+    insights: List[str] = []
+    for arg_id, data in ordered:
+        method_phrases = []
+        for method, detail in data["signals"]:
+            if method == "sophisme":
+                method_phrases.append(f"detection rhetorique ({detail})")
+            elif method == "qualite faible":
+                method_phrases.append(f"score de qualite ({detail})")
+            elif method == "contre-argument":
+                method_phrases.append("contre-argumentation")
+            elif method == "JTMS retracte":
+                method_phrases.append("maintenance de verite (JTMS)")
+            elif method == "rejet Dung":
+                method_phrases.append(f"argumentation abstraite (Dung/{detail})")
+            else:
+                method_phrases.append(method)
+        joined = ", ".join(method_phrases)
+        insights.append(
+            f"**Verdict convergent sur {arg_id}** : {data['score']} methodes "
+            f"independantes concourent a le signaler ({joined}). "
+            f"Cette convergence inter-perspectives est inaccessible a une passe "
+            f"LLM unique."
+        )
+
+    # Build the conclusion line
+    if ordered:
+        strongest_id, strongest = ordered[0]
+        conclusion = (
+            f"Synthese convergente : {len(ordered)} argument(s) signale(s) par "
+            f"au moins deux methodes formelles independantes. "
+            f"Convergence maximale sur {strongest_id} "
+            f"({strongest['score']} methodes)."
+        )
+    elif convergence:
+        single = len(convergence)
+        conclusion = (
+            f"Aucune convergence multi-methodes : {single} argument(s) signale(s) "
+            f"par une seule methode. La structure argumentative resiste a "
+            f"l'examen croise."
+        )
+    else:
+        conclusion = (
+            "Aucun argument signale comme faible par les methodes d'analyse. "
+            "Structure argumentative robuste sur toutes les dimensions testees."
+        )
+
+    # Assemble the full narrative
+    full_parts = [base_narrative]
+    if insights:
+        full_parts.append("## Insights emergents (convergence inter-methodes)\n")
+        full_parts.append("\n\n".join(insights))
+    full_parts.append(f"\n**Conclusion** : {conclusion}")
+    full_narrative = "\n\n".join(full_parts)
+
+    return {
+        "narrative": full_narrative,
+        "base_narrative": base_narrative,
+        "convergent_verdicts": verdicts,
+        "emergent_insights": insights,
+        "conclusion": conclusion,
+    }
+
+
 class NarrativeSynthesisPlugin:
     """Semantic Kernel plugin for narrative synthesis (#351).
 
@@ -196,3 +416,24 @@ class NarrativeSynthesisPlugin:
         # Build a simple namespace object from dict for build_narrative
         ns = type("State", (), state_data)()
         return build_narrative(ns)
+
+    @kernel_function(
+        name="convergent_synthesis",
+        description="Generate a spectacular synthesis that surfaces "
+        "cross-dimensional convergence: arguments flagged weak by several "
+        "independent methods (fallacy detection, abstract argumentation, "
+        "truth maintenance, quality scoring, counter-argumentation). "
+        "Returns the full narrative plus convergent verdicts as JSON.",
+    )
+    def convergent_synthesize(self, state_json: str = "{}") -> str:
+        """Generate convergent synthesis from state JSON, returned as JSON."""
+        import json
+
+        try:
+            state_data = json.loads(state_json)
+        except (json.JSONDecodeError, TypeError):
+            state_data = {}
+
+        ns = type("State", (), state_data)()
+        result = build_convergent_synthesis(ns)
+        return json.dumps(result, ensure_ascii=False)

--- a/tests/unit/argumentation_analysis/test_convergent_synthesis.py
+++ b/tests/unit/argumentation_analysis/test_convergent_synthesis.py
@@ -1,0 +1,242 @@
+"""Tests for convergent multidimensional synthesis (#634).
+
+Validates that compute_argument_convergence detects when several independent
+methods (fallacy detection, abstract argumentation, truth maintenance, quality
+scoring, counter-argumentation) flag the same argument, and that
+build_convergent_synthesis surfaces named convergent verdicts and a conclusion.
+"""
+
+from argumentation_analysis.plugins.narrative_synthesis_plugin import (
+    compute_argument_convergence,
+    build_convergent_synthesis,
+    _dung_rejected_args,
+    NarrativeSynthesisPlugin,
+)
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+
+def _state_with_args(*descriptions: str) -> UnifiedAnalysisState:
+    state = UnifiedAnalysisState("Test discourse for convergence analysis.")
+    for desc in descriptions:
+        state.add_argument(desc)
+    return state
+
+
+class TestDungRejection:
+    """_dung_rejected_args handles the three extension storage shapes."""
+
+    def test_enriched_all_members_form(self):
+        state = _state_with_args("a", "b", "c")  # arg_1, arg_2, arg_3
+        state.dung_frameworks = {
+            "dung_1": {
+                "semantics": "grounded",
+                "arguments": ["arg_1", "arg_2", "arg_3"],
+                "extensions": {"all_members": ["arg_1", "arg_2"]},
+            }
+        }
+        rejected = _dung_rejected_args(state)
+        assert rejected == {"arg_3": "grounded"}
+
+    def test_semantics_to_list_form(self):
+        state = _state_with_args("a", "b", "c")
+        # This is the shape add_dung_framework stores (Dict[str, List[str]])
+        state.add_dung_framework(
+            name="fw",
+            arguments=["arg_1", "arg_2", "arg_3"],
+            attacks=[["arg_1", "arg_3"]],
+            extensions={"grounded": ["arg_1", "arg_2"]},
+        )
+        rejected = _dung_rejected_args(state)
+        assert "arg_3" in rejected
+
+    def test_list_of_lists_form(self):
+        state = _state_with_args("a", "b", "c")
+        state.dung_frameworks = {
+            "dung_1": {
+                "semantics": "preferred",
+                "arguments": ["arg_1", "arg_2", "arg_3"],
+                "extensions": [["arg_1"], ["arg_2"]],
+            }
+        }
+        rejected = _dung_rejected_args(state)
+        assert rejected == {"arg_3": "preferred"}
+
+    def test_no_frameworks_returns_empty(self):
+        state = _state_with_args("a")
+        assert _dung_rejected_args(state) == {}
+
+    def test_all_args_accepted_none_rejected(self):
+        state = _state_with_args("a", "b")
+        state.dung_frameworks = {
+            "dung_1": {
+                "arguments": ["arg_1", "arg_2"],
+                "extensions": {"all_members": ["arg_1", "arg_2"]},
+            }
+        }
+        assert _dung_rejected_args(state) == {}
+
+
+class TestComputeConvergence:
+    """compute_argument_convergence counts independent weakness signals."""
+
+    def test_single_method_scores_one(self):
+        state = _state_with_args("strong argument")
+        state.add_fallacy("ad_hominem", "attack on person", "arg_1")
+        conv = compute_argument_convergence(state)
+        assert conv["arg_1"]["score"] == 1
+        methods = [m for m, _ in conv["arg_1"]["signals"]]
+        assert methods == ["sophisme"]
+
+    def test_two_methods_scores_two(self):
+        state = _state_with_args("weak argument")
+        state.add_fallacy("straw_man", "distortion", "arg_1")
+        state.add_quality_score("arg_1", {"clarte": 2.0}, 2.5)  # < 5.0 threshold
+        conv = compute_argument_convergence(state)
+        assert conv["arg_1"]["score"] == 2
+        methods = {m for m, _ in conv["arg_1"]["signals"]}
+        assert methods == {"sophisme", "qualite faible"}
+
+    def test_three_methods_convergence(self):
+        state = _state_with_args("doomed argument")
+        state.add_fallacy("false_dilemma", "either/or", "arg_1")
+        state.add_quality_score("arg_1", {"coherence": 1.0}, 2.0)
+        state.add_counter_argument(
+            "doomed argument",
+            "reductio counter",
+            "reductio",
+            0.9,
+            target_arg_id="arg_1",
+        )
+        conv = compute_argument_convergence(state)
+        assert conv["arg_1"]["score"] == 3
+
+    def test_dung_rejection_counts_as_signal(self):
+        state = _state_with_args("a", "b")
+        state.add_fallacy("ad_hominem", "attack", "arg_2")
+        state.dung_frameworks = {
+            "dung_1": {
+                "semantics": "grounded",
+                "arguments": ["arg_1", "arg_2"],
+                "extensions": {"all_members": ["arg_1"]},  # arg_2 rejected
+            }
+        }
+        conv = compute_argument_convergence(state)
+        assert conv["arg_2"]["score"] == 2
+        methods = {m for m, _ in conv["arg_2"]["signals"]}
+        assert methods == {"sophisme", "rejet Dung"}
+
+    def test_jtms_invalid_belief_counts(self):
+        state = _state_with_args("retracted argument")
+        # belief name must contain the arg_id to match
+        state.add_jtms_belief("belief_for_arg_1", False, justifications=["undermined"])
+        state.add_quality_score("arg_1", {"x": 1.0}, 2.0)
+        conv = compute_argument_convergence(state)
+        assert conv["arg_1"]["score"] == 2
+        methods = {m for m, _ in conv["arg_1"]["signals"]}
+        assert methods == {"JTMS retracte", "qualite faible"}
+
+    def test_high_quality_not_flagged(self):
+        state = _state_with_args("good argument")
+        state.add_quality_score("arg_1", {"clarte": 9.0}, 8.5)  # above threshold
+        conv = compute_argument_convergence(state)
+        assert "arg_1" not in conv  # no signals at all
+
+    def test_clean_argument_absent_from_result(self):
+        state = _state_with_args("clean", "flawed")
+        state.add_fallacy("ad_hominem", "attack", "arg_2")
+        conv = compute_argument_convergence(state)
+        assert "arg_1" not in conv
+        assert "arg_2" in conv
+
+    def test_empty_state_returns_empty(self):
+        state = UnifiedAnalysisState("nothing here")
+        assert compute_argument_convergence(state) == {}
+
+
+class TestBuildConvergentSynthesis:
+    """build_convergent_synthesis produces named verdicts + conclusion."""
+
+    def test_convergent_verdict_named(self):
+        state = _state_with_args("doomed")
+        state.add_fallacy("false_dilemma", "either/or", "arg_1")
+        state.add_quality_score("arg_1", {"coherence": 1.0}, 2.0)
+        result = build_convergent_synthesis(state)
+        assert "arg_1" in result["convergent_verdicts"]
+        assert any("arg_1" in ins for ins in result["emergent_insights"])
+        # The named verdict cites the argument id
+        assert "Verdict convergent sur arg_1" in result["narrative"]
+
+    def test_single_signal_not_a_convergent_verdict(self):
+        state = _state_with_args("mildly flawed")
+        state.add_fallacy("ad_hominem", "attack", "arg_1")  # only 1 method
+        result = build_convergent_synthesis(state)
+        assert result["convergent_verdicts"] == {}
+        assert "une seule methode" in result["conclusion"]
+
+    def test_robust_structure_no_signals(self):
+        state = _state_with_args("solid")
+        state.add_quality_score("arg_1", {"clarte": 9.0}, 9.0)
+        result = build_convergent_synthesis(state)
+        assert result["convergent_verdicts"] == {}
+        assert "robuste" in result["conclusion"]
+
+    def test_verdicts_ordered_by_convergence_strength(self):
+        state = _state_with_args("two-method", "three-method")
+        # arg_1: 2 methods
+        state.add_fallacy("straw_man", "distortion", "arg_1")
+        state.add_quality_score("arg_1", {"x": 1.0}, 2.0)
+        # arg_2: 3 methods
+        state.add_fallacy("false_dilemma", "either/or", "arg_2")
+        state.add_quality_score("arg_2", {"x": 1.0}, 1.5)
+        state.add_counter_argument(
+            "three-method", "counter", "reductio", 0.8, target_arg_id="arg_2"
+        )
+        result = build_convergent_synthesis(state)
+        # Strongest (arg_2, score 3) must appear before arg_1 in insights
+        insights_text = "\n".join(result["emergent_insights"])
+        assert insights_text.index("arg_2") < insights_text.index("arg_1")
+        assert "arg_2" in result["conclusion"]  # max convergence cited
+
+    def test_base_narrative_preserved(self):
+        state = _state_with_args("arg")
+        state.add_fallacy("ad_hominem", "attack", "arg_1")
+        state.add_quality_score("arg_1", {"x": 1.0}, 2.0)
+        result = build_convergent_synthesis(state)
+        # Backward compat: base template narrative still embedded
+        assert result["base_narrative"]
+        assert result["base_narrative"] in result["narrative"]
+
+
+class TestKernelFunctionWrapper:
+    """The plugin exposes convergent_synthesize for SK invocation."""
+
+    def test_convergent_synthesize_returns_json(self):
+        import json
+
+        plugin = NarrativeSynthesisPlugin()
+        state_json = json.dumps(
+            {
+                "identified_arguments": {"arg_1": "doomed argument"},
+                "identified_fallacies": {
+                    "fallacy_1": {
+                        "type": "false_dilemma",
+                        "justification": "either/or",
+                        "target_argument_id": "arg_1",
+                    }
+                },
+                "argument_quality_scores": {"arg_1": {"scores": {}, "overall": 2.0}},
+            }
+        )
+        out = plugin.convergent_synthesize(state_json)
+        parsed = json.loads(out)
+        assert "narrative" in parsed
+        assert "arg_1" in parsed["convergent_verdicts"]
+
+    def test_convergent_synthesize_handles_bad_json(self):
+        plugin = NarrativeSynthesisPlugin()
+        out = plugin.convergent_synthesize("not valid json{")
+        import json
+
+        parsed = json.loads(out)
+        # Empty state → robust-structure conclusion, no crash
+        assert "conclusion" in parsed


### PR DESCRIPTION
## Summary

Targets the **spectacular-analysis gap**: the template-based `build_narrative()` concatenates independent per-KB counts with zero cross-dimensional reasoning, producing flat output with no named verdicts and `conclusion_present:false` on every corpus. This is the diagnosed root cause of pipeline synthesis losing to a one-shot LLM on specificity (0 named fallacies, 1 citation vs 12, 210 words vs 527 in the #592 DeepSynthesis-vs-0-shot benchmark).

The fix detects **convergence**: when several *independent* methods concur that the same argument is weak, that agreement is itself the emergent multidimensional insight a one-shot LLM cannot produce.

## What's added (`narrative_synthesis_plugin.py`)

- `_dung_rejected_args(state)` — extracts Dung-rejected arguments across all 3 extension storage shapes (dict `all_members`, dict semantics→list, list-of-lists).
- `compute_argument_convergence(state)` — per argument, counts independent weakness signals: `sophisme` (fallacy targeting it), `qualite faible` (overall < 5.0), `contre-argument` (counter targeting it), `JTMS retracte` (invalid belief naming it), `rejet Dung` (rejected extension).
- `build_convergent_synthesis(state)` — emits **named convergent verdicts** (args flagged by ≥2 methods), `emergent_insights` ordered by descending convergence strength, and a `conclusion` citing maximum convergence. Backward-compatible: base template narrative still embedded.
- `convergent_synthesize(state_json)` `@kernel_function` for SK invocation.

## Tests

- 20 new unit tests (`test_convergent_synthesis.py`): Dung rejection across 3 shapes, 1/2/3-method convergence, named verdicts, ordering, kernel-function wrapper, bad-JSON resilience.
- 15 existing narrative-synthesis regression tests still green (35 total pass in 1.3s).
- `black --check` clean, `flake8` clean.

## Privacy

Pure structural logic over opaque arg IDs (`arg_1`...). No dataset plaintext or source names — grep-verified.

## Follow-ups (Sprint 12)

- Track CC: LLM prose layer on top of this convergence skeleton.
- Track DD: re-run #592 benchmark with new synthesis to prove ≥3 categories + specificity win.

Closes #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)