### PR TITLE
feat(synthesis): LLM prose layer over convergent synthesis — Track CC (#636)

### DIFF
--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -4,6 +4,8 @@ Produces 1-2 paragraphs of human-readable narrative weaving together
 results from all analysis KBs (fallacies, JTMS, ATMS, Dung, quality,
 counter-arguments). Reads from UnifiedAnalysisState and generates
 prose without LLM calls — purely template-based for reliability.
+Track CC (#636) adds an optional LLM prose layer over the convergent
+synthesis skeleton produced by Track BB (#634).
 """
 
 import logging
@@ -390,12 +392,53 @@ def build_convergent_synthesis(state: Any) -> Dict[str, Any]:
     }
 
 
+_PROSE_INSTRUCTIONS = (
+    "You are an expert argumentation analyst. Transform the structured convergence "
+    "evidence below into polished analytical prose in French. "
+    "Rules: (1) Only reference arguments, fallacies, and methods listed in the evidence. "
+    "(2) Name every concordant method explicitly (e.g. 'detection rhetorique', "
+    "'argumentation abstraite', 'maintenance de verite', 'scoring de qualite'). "
+    "(3) Do not invent claims or details absent from the evidence. "
+    "(4) Each paragraph covers one argument; cite at least two methods by name. "
+    "(5) Maximum 300 words."
+)
+
+
+def _build_prose_prompt(synthesis_result: Dict[str, Any]) -> str:
+    """Build a strictly-grounded LLM prompt from convergent synthesis evidence."""
+    verdicts = synthesis_result.get("convergent_verdicts", {})
+    conclusion = synthesis_result.get("conclusion", "")
+
+    if verdicts:
+        evidence_lines = []
+        for arg_id, data in sorted(verdicts.items(), key=lambda kv: -kv[1]["score"]):
+            sig_parts = [f"{m}: {d}" for m, d in data["signals"]]
+            evidence_lines.append(
+                f"- {arg_id} ({data['score']} methods): {'; '.join(sig_parts)}"
+            )
+        evidence_block = "\n".join(evidence_lines)
+    else:
+        evidence_block = "(no convergent arguments detected)"
+
+    return (
+        f"{_PROSE_INSTRUCTIONS}\n\n"
+        f"## Convergence Evidence\n{evidence_block}\n\n"
+        f"## Structural Conclusion\n{conclusion}\n\n"
+        f"Write the analytical prose report:"
+    )
+
+
 class NarrativeSynthesisPlugin:
     """Semantic Kernel plugin for narrative synthesis (#351).
 
     Produces human-readable analysis summaries by weaving together
-    outputs from all pipeline phases.
+    outputs from all pipeline phases. Pass an SK Kernel instance to
+    enable the LLM prose layer (Track CC #636); without it the plugin
+    falls back to template-based output.
     """
+
+    def __init__(self, kernel: Optional[Any] = None) -> None:
+        self._kernel = kernel
 
     @kernel_function(
         name="narrative_synthesis",
@@ -437,3 +480,46 @@ class NarrativeSynthesisPlugin:
         ns = type("State", (), state_data)()
         result = build_convergent_synthesis(ns)
         return json.dumps(result, ensure_ascii=False)
+
+    @kernel_function(
+        name="narrate_convergence",
+        description="Generate LLM-grounded analytical prose over convergent "
+        "synthesis results. Each verdict paragraph cites the concordant methods "
+        "by name with specific evidence (fallacy type, quality score, Dung "
+        "semantics, JTMS retraction). Strictly grounded — no hallucinated claims. "
+        "Falls back to template narrative when no LLM kernel is configured or "
+        "when the LLM call fails.",
+    )
+    async def narrate_convergence(self, state_json: str = "{}") -> str:
+        """Generate LLM-polished prose from convergent synthesis evidence.
+
+        Calls build_convergent_synthesis internally, then invokes the kernel's
+        LLM with a strictly grounded prompt. Falls back to the template narrative
+        when no kernel is configured, no convergent verdicts exist, or the LLM
+        call raises an exception.
+        """
+        import json
+
+        try:
+            state_data = json.loads(state_json)
+        except (json.JSONDecodeError, TypeError):
+            state_data = {}
+
+        ns = type("State", (), state_data)()
+        synthesis = build_convergent_synthesis(ns)
+
+        if not synthesis.get("convergent_verdicts") or self._kernel is None:
+            return synthesis["narrative"]
+
+        prompt = _build_prose_prompt(synthesis)
+        try:
+            result = await self._kernel.invoke_prompt(prompt)
+            prose = str(result).strip()
+            if prose:
+                return prose
+            return synthesis["narrative"]
+        except Exception:
+            logger.warning(
+                "narrate_convergence: LLM call failed, falling back to template"
+            )
+            return synthesis["narrative"]

--- a/tests/unit/argumentation_analysis/plugins/test_narrate_convergence.py
+++ b/tests/unit/argumentation_analysis/plugins/test_narrate_convergence.py
@@ -1,0 +1,289 @@
+"""Tests for Track CC: LLM prose layer over convergent synthesis (#636).
+
+Validates that narrate_convergence:
+- Falls back gracefully to template narrative when no kernel is configured
+- Falls back when no convergent verdicts exist (score < 2)
+- Falls back on LLM exception
+- Calls invoke_prompt with a grounded prompt when verdicts + kernel available
+- Returns LLM prose when the call succeeds
+- _build_prose_prompt embeds arg IDs and method names from evidence
+"""
+
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from argumentation_analysis.plugins.narrative_synthesis_plugin import (
+    NarrativeSynthesisPlugin,
+    _build_prose_prompt,
+    build_convergent_synthesis,
+)
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_kernel():
+    """Minimal mock kernel exposing async invoke_prompt."""
+    kernel = MagicMock()
+    kernel.invoke_prompt = AsyncMock(return_value="Mocked LLM prose output.")
+    return kernel
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _convergent_state() -> UnifiedAnalysisState:
+    """State with arg_1 flagged by 3 independent methods (convergence score=3)."""
+    state = UnifiedAnalysisState("Test discourse for LLM prose narration.")
+    state.add_argument("A weak argument susceptible to multiple analytical methods.")
+    # Signal 1: fallacy targeting arg_1
+    state.add_fallacy("straw_man", "Distortion of original position.", "arg_1")
+    # Signal 2: low quality score (< QUALITY_WEAK_THRESHOLD=5.0)
+    state.add_quality_score("arg_1", {"clarte": 2.0, "coherence": 2.5}, 2.5)
+    # Signal 3: counter-argument with target_arg_id
+    state.add_counter_argument(
+        "A weak argument susceptible to multiple analytical methods.",
+        "This argument misrepresents the opposing view.",
+        "reductio",
+        0.8,
+        "arg_1",
+    )
+    return state
+
+
+def _convergent_state_json() -> str:
+    state = _convergent_state()
+    return json.dumps(
+        {
+            "identified_arguments": {
+                k: (v if isinstance(v, dict) else {"description": str(v)})
+                for k, v in (state.identified_arguments or {}).items()
+            },
+            "identified_fallacies": state.identified_fallacies or {},
+            "argument_quality_scores": state.argument_quality_scores or {},
+            "counter_arguments": state.counter_arguments or [],
+            "jtms_beliefs": {},
+            "dung_frameworks": {},
+        },
+        ensure_ascii=False,
+        default=str,
+    )
+
+
+def _single_method_state_json() -> str:
+    """State with arg_1 flagged by 1 method only — no convergence."""
+    return json.dumps(
+        {
+            "identified_arguments": {"arg_1": {"description": "solo arg"}},
+            "identified_fallacies": {
+                "f1": {
+                    "type": "ad_hominem",
+                    "justification": "attack on person",
+                    "target_argument_id": "arg_1",
+                }
+            },
+            "argument_quality_scores": {},
+            "counter_arguments": [],
+            "jtms_beliefs": {},
+            "dung_frameworks": {},
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# _build_prose_prompt
+# ---------------------------------------------------------------------------
+
+
+class TestBuildProsePrompt:
+    """_build_prose_prompt embeds grounded evidence in the prompt."""
+
+    def test_contains_arg_id(self):
+        state = _convergent_state()
+        synthesis = build_convergent_synthesis(state)
+        prompt = _build_prose_prompt(synthesis)
+        assert "arg_1" in prompt
+
+    def test_contains_method_names(self):
+        state = _convergent_state()
+        synthesis = build_convergent_synthesis(state)
+        prompt = _build_prose_prompt(synthesis)
+        assert "sophisme" in prompt
+        assert "qualite faible" in prompt
+
+    def test_contains_structural_conclusion(self):
+        state = _convergent_state()
+        synthesis = build_convergent_synthesis(state)
+        prompt = _build_prose_prompt(synthesis)
+        assert synthesis["conclusion"] in prompt
+
+    def test_no_convergence_shows_placeholder(self):
+        state = UnifiedAnalysisState("test")
+        state.add_argument("strong arg")
+        synthesis = build_convergent_synthesis(state)
+        assert not synthesis["convergent_verdicts"]
+        prompt = _build_prose_prompt(synthesis)
+        assert "no convergent" in prompt.lower()
+
+    def test_returns_str(self):
+        state = _convergent_state()
+        synthesis = build_convergent_synthesis(state)
+        assert isinstance(_build_prose_prompt(synthesis), str)
+
+
+# ---------------------------------------------------------------------------
+# Fallback behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestNarrateConvergenceFallback:
+    """narrate_convergence falls back gracefully in all failure modes."""
+
+    @pytest.mark.asyncio
+    async def test_fallback_no_kernel_returns_str(self):
+        plugin = NarrativeSynthesisPlugin(kernel=None)
+        result = await plugin.narrate_convergence(state_json=_convergent_state_json())
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_no_verdicts_no_llm_call(self, fake_kernel):
+        """Single-method arg (score=1) → no convergence → invoke_prompt not called."""
+        plugin = NarrativeSynthesisPlugin(kernel=fake_kernel)
+        result = await plugin.narrate_convergence(
+            state_json=_single_method_state_json()
+        )
+        fake_kernel.invoke_prompt.assert_not_called()
+        assert isinstance(result, str)
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_llm_exception(self, fake_kernel):
+        """invoke_prompt raises → graceful fallback, no exception propagated."""
+        fake_kernel.invoke_prompt = AsyncMock(side_effect=RuntimeError("API down"))
+        plugin = NarrativeSynthesisPlugin(kernel=fake_kernel)
+        result = await plugin.narrate_convergence(state_json=_convergent_state_json())
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_empty_llm_response(self, fake_kernel):
+        """Empty LLM string → fallback to template narrative."""
+        fake_kernel.invoke_prompt = AsyncMock(return_value="")
+        plugin = NarrativeSynthesisPlugin(kernel=fake_kernel)
+        result = await plugin.narrate_convergence(state_json=_convergent_state_json())
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    @pytest.mark.asyncio
+    async def test_fallback_on_bad_json(self):
+        """Malformed JSON → parsed as empty state → template narrative."""
+        plugin = NarrativeSynthesisPlugin(kernel=None)
+        result = await plugin.narrate_convergence(state_json="not-json{{{")
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# LLM prose path (mock kernel)
+# ---------------------------------------------------------------------------
+
+
+class TestNarrateConvergenceWithMockedKernel:
+    """narrate_convergence calls invoke_prompt and surfaces its prose."""
+
+    @pytest.mark.asyncio
+    async def test_llm_prose_returned(self, fake_kernel):
+        expected = "Mocked LLM prose: convergent analysis of arg_1."
+        fake_kernel.invoke_prompt = AsyncMock(return_value=expected)
+        plugin = NarrativeSynthesisPlugin(kernel=fake_kernel)
+        result = await plugin.narrate_convergence(state_json=_convergent_state_json())
+        assert expected in result
+
+    @pytest.mark.asyncio
+    async def test_invoke_prompt_called_once(self, fake_kernel):
+        plugin = NarrativeSynthesisPlugin(kernel=fake_kernel)
+        await plugin.narrate_convergence(state_json=_convergent_state_json())
+        fake_kernel.invoke_prompt.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_prompt_contains_arg_id_and_method(self, fake_kernel):
+        """The prompt passed to invoke_prompt contains evidence details."""
+        captured: list = []
+
+        async def capture(prompt, **kwargs):
+            captured.append(prompt)
+            return "prose"
+
+        fake_kernel.invoke_prompt = capture
+        plugin = NarrativeSynthesisPlugin(kernel=fake_kernel)
+        await plugin.narrate_convergence(state_json=_convergent_state_json())
+
+        assert captured, "invoke_prompt was not called"
+        prompt = captured[0]
+        assert "arg_1" in prompt
+        assert "sophisme" in prompt
+
+    @pytest.mark.asyncio
+    async def test_result_is_always_str(self, fake_kernel):
+        """str() is called on invoke_prompt result."""
+        fake_kernel.invoke_prompt = AsyncMock(return_value=42)
+        plugin = NarrativeSynthesisPlugin(kernel=fake_kernel)
+        result = await plugin.narrate_convergence(state_json=_convergent_state_json())
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# Plugin construction
+# ---------------------------------------------------------------------------
+
+
+class TestNarrativeSynthesisPluginInit:
+    """NarrativeSynthesisPlugin accepts optional kernel without breaking BB."""
+
+    def test_no_kernel_default(self):
+        plugin = NarrativeSynthesisPlugin()
+        assert plugin._kernel is None
+
+    def test_kernel_stored(self, fake_kernel):
+        plugin = NarrativeSynthesisPlugin(kernel=fake_kernel)
+        assert plugin._kernel is fake_kernel
+
+    def test_synthesize_still_works(self):
+        plugin = NarrativeSynthesisPlugin()
+        result = plugin.synthesize(state_json="{}")
+        assert isinstance(result, str)
+
+    def test_convergent_synthesize_still_works(self):
+        plugin = NarrativeSynthesisPlugin()
+        result = plugin.convergent_synthesize(state_json="{}")
+        data = json.loads(result)
+        assert "narrative" in data
+        assert "convergent_verdicts" in data
+
+
+# ---------------------------------------------------------------------------
+# Integration (requires real LLM — skipped without API key)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_api
+class TestNarrateConvergenceIntegration:
+    """Integration test with real LLM service (skipped without API key)."""
+
+    @pytest.mark.asyncio
+    async def test_real_llm_returns_non_empty_prose(self):
+        from semantic_kernel import Kernel
+        from argumentation_analysis.core.llm_service import create_llm_service
+
+        kernel = Kernel()
+        kernel.add_service(create_llm_service("narration_test"))
+        plugin = NarrativeSynthesisPlugin(kernel=kernel)
+        result = await plugin.narrate_convergence(state_json=_convergent_state_json())
+        assert isinstance(result, str)
+        assert len(result) > 0, "Expected non-empty prose from LLM"


### PR DESCRIPTION
## Summary

Track CC (#636), implemented by **po-2025**. Adds the LLM prose layer on top of the Track BB (#634) convergent-synthesis skeleton — the second step toward closing the specificity gap with one-shot LLMs.

- `_build_prose_prompt` builds a strictly-grounded prompt embedding arg IDs, concordant method names, signal details, and the structural conclusion.
- `NarrativeSynthesisPlugin.__init__(kernel=None)` — optional SK kernel; all existing `@kernel_function` methods unchanged without it (backward-compat).
- `narrate_convergence` (async `@kernel_function`) — invokes the LLM when convergent verdicts exist; falls back to the template narrative when the kernel is None, no verdicts exist, the LLM raises, or returns empty.

## Verification (coordinator, on branch)

- 54 tests pass: 19 new CC + 20 BB + 15 narrative regression (1.5s).
- `black --check` clean, `flake8` clean.
- Privacy grep CLEAN (opaque IDs only).

## Credit

Implementation by po-2025 (commit `6877a338`, Co-Authored-By Sonnet 4.6). PR opened + verified + merged by coordinator (ai-01) as po-2025 went idle after pushing the branch without opening the PR.

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)