### PR TITLE
fix(benchmark): fair gpt-5 0-shot baseline + honest convergence report (#592)

### DIFF
--- a/docs/reports/spectacular/convergence_benchmark_corpus_A.md
+++ b/docs/reports/spectacular/convergence_benchmark_corpus_A.md
@@ -1,0 +1,102 @@
+# Convergence Benchmark — Corpus A (DeepSynthesis vs 0-shot)
+
+**Date:** 2026-05-20 · **Harness:** `scripts/scda_deepsynthesis_vs_baseline.py` (#592)
+**Pipeline build:** main `5e8eba0f` (Track DD convergence wiring, #637/#639 merged)
+**Model (both sides):** `gpt-5-mini` · **Corpus:** `corpus_dense_A` (~58K chars, opaque ID)
+**Raw outputs:** `outputs/deep_analysis/corpus_dense_A/` (gitignored — aggregate only here)
+
+> Privacy: all identifiers are opaque (`arg_N`, `fallacy_*`). No source text, no
+> nominative content, no LLM-paraphrased premises/conclusions are reproduced.
+
+---
+
+## 1. Headline — honest verdict
+
+With a **fair baseline** (see §2), the pipeline wins **2 of 4** scored advantage
+categories, **below the ≥3 threshold** the harness uses for "spectacular".
+
+| Scored category | Pipeline | 0-shot | Pipeline wins? |
+|---|---|---|---|
+| More textual citations | 85 | 55 | ✅ |
+| More named fallacies | 6 | 6 | ➖ tie |
+| Formal methods unique to pipeline | 4 named | 5 named | ❌ |
+| Cross-text parallels unique | "present" | absent | ✅ (but false-positive, §3) |
+
+**Verdict by the script's own bar: FAIL (2/4).** This is the real signal behind
+the user's directive — *"tant que les analyses ne sont pas spectaculaires, il y a
+du boulot."* There is boulot.
+
+## 2. The first run was a hollow win — fixed
+
+The initial run reported a 4/4 PASS, but the **baseline produced 0 words**:
+`gpt-5-mini` is a reasoning model and the `max_tokens=4096` budget (a) is rejected
+by the gpt-5 API in favor of `max_completion_tokens`, and (b) was entirely consumed
+by hidden reasoning tokens, returning empty visible content. A win against an empty
+opponent is not a win. Fixed in this PR: `max_completion_tokens=16384` + graceful
+fallback for older models. The numbers in §1 are from the **fair** re-run (baseline
+= 3015 words, 8 sections).
+
+## 3. Why the surface metrics under-sell the pipeline
+
+The harness scores **vocabulary presence**, not **computational substance**:
+
+- **Formal methods are name-dropped, not computed, by the 0-shot.** The baseline
+  writes *"Cadre ASPIC+/Dung : les arguments sont attaquables par rebuttal /
+  undermining / undercutting"* and closes with *"il faudrait formaliser quelques
+  arguments en logique propositionnelle ou ASPIC+ pour montrer où les attaques
+  s'appliquent."* It **describes** the frameworks; it never builds one. Yet
+  `detect_formal_method_findings` matches the bare keywords (`dung`, `framework`,
+  `attaque`, `aspic`…) and credits the baseline with **5 formal methods** — one
+  more than the pipeline.
+- **Cross-text parallels is a section-header false-positive.** The pipeline's S8
+  literally says *"No cross-text parallels in this run (single-corpus analysis)"*,
+  but the heading "Cross-Text Rhetorical Parallels" trips the `cross-text` marker.
+  The pipeline is credited for an **empty** section.
+- **Named-fallacy tie hides an anchoring gap.** Both name 6 families, but the
+  metric never checks whether a fallacy is **tied to a specific argument**. The
+  pipeline's are (see §4); the 0-shot's float free.
+
+## 4. What the pipeline actually does that a 0-shot structurally cannot
+
+These are **computed artifacts**, present in the pipeline report and absent (only
+described) in the baseline — and **none are in the scoring rubric**:
+
+- **Computed Dung framework**: 32 arguments, 26 attacks, a concrete **27-member
+  grounded extension** (explicit membership list), and an explicit attack relation
+  (`fallacy_Post hoc → arg_1`, `fallacy_Straw man → arg_2`, …). The 0-shot never
+  emits a membership set or an edge list.
+- **Convergent verdicts (Track DD, the genuine differentiator):** 5 arguments
+  flagged by **≥2 independent methods**, with the strongest, `arg_1`, flagged by
+  **5 distinct analyses** — rhetorical fallacy detection + quality scoring (0.2/10)
+  + counter-argumentation + JTMS truth-maintenance + Dung rejection. A single LLM
+  pass cannot run five independent solvers and report their *actual* agreement.
+  This cross-method convergence is the spectacular insight — and the benchmark
+  does not measure it at all.
+
+## 5. Pipeline quality gaps found during this run (real bugs)
+
+- **Belief Revision Trace renders empty.** The orchestrator log shows *"Belief
+  revision: 4 beliefs contracted (4 → 0)"*, but report S6 prints *"No belief
+  retractions in this run."* The convergence layer reads JTMS-invalid beliefs from
+  a different source than S6, so `arg_1`'s "JTMS retracté" signal and the empty S6
+  contradict each other. Rendering/source-of-truth mismatch.
+- **PL/Modal findings are thin.** The PL finding contains only extraction-metadata
+  atoms, not computed formulas — the long-standing Tweety constant-declaration
+  bottleneck. Modal finding is empty.
+
+## 6. Recommended next work (the boulot)
+
+1. **Score substance, not vocabulary** (harness): add a **convergence-depth**
+   metric (count of args flagged by ≥2 independent methods; max convergence) and a
+   **computed-artifact** metric (presence of an explicit grounded-extension
+   membership set, an attack edge list, numeric inconsistency measures, a JTMS
+   retraction count). These are unfakeable by a 0-shot.
+2. **Fix the cross-text false-positive**: detect populated content, not the heading.
+3. **Fix the Belief Revision Trace rendering** so S6 reflects the contractions the
+   orchestrator actually computed (and reconcile with the convergence JTMS signal).
+4. **Address the PL formula bottleneck** (constant pre-declaration in the signature)
+   so Finding shows real formulas instead of extraction metadata.
+
+Once (1) lands, re-run on corpora A/B/C: the expectation is that the pipeline's
+margin widens decisively on the *substance* metrics even where it ties or trails on
+the surface ones — which is the honest definition of "spectacular" for this system.

--- a/scripts/scda_deepsynthesis_vs_baseline.py
+++ b/scripts/scda_deepsynthesis_vs_baseline.py
@@ -9,6 +9,7 @@ Usage:
 
 Outputs: outputs/deep_analysis/ (gitignored)
 """
+
 import argparse
 import asyncio
 import json
@@ -68,7 +69,7 @@ def load_corpus(corpus_id: str) -> str:
     text = src.get("full_text", "")
 
     if corpus_id == "B":
-        speech_markers = re.split(r'(?=\d{4}\.\d{2}\.\d{2})', text)
+        speech_markers = re.split(r"(?=\d{4}\.\d{2}\.\d{2})", text)
         best_chunk = ""
         for chunk in speech_markers:
             if 30000 <= len(chunk) <= 60000:
@@ -79,7 +80,7 @@ def load_corpus(corpus_id: str) -> str:
             boundary = text.find("\n\n", start)
             if boundary > 0:
                 start = boundary
-            best_chunk = text[start:start + 50000]
+            best_chunk = text[start : start + 50000]
         text = best_chunk
 
     return text
@@ -104,20 +105,37 @@ def count_textual_citations(text: str) -> int:
 def count_named_fallacies_with_taxonomy(text: str) -> list[dict]:
     """Extract named fallacies with taxonomy paths."""
     fallacy_families = [
-        "Appel à l'autorité", "Appel a l'autorite", "Appeal to authority",
-        "Appel à la popularité", "Appel a la popularite", "Bandwagon",
-        "Appel à l'émotion", "Appeal to emotion",
-        "Attaque personnelle", "Ad hominem",
-        "Pente glissante", "Slippery slope",
-        "Faux dilemme", "False dilemma", "Black and white",
-        "Homme de paille", "Straw man",
-        "Pétition de principe", "Begging the question", "Circular reasoning",
-        "Hasty generalization", "Généralisation hâtive",
-        "Post hoc", "Corrélation causale",
+        "Appel à l'autorité",
+        "Appel a l'autorite",
+        "Appeal to authority",
+        "Appel à la popularité",
+        "Appel a la popularite",
+        "Bandwagon",
+        "Appel à l'émotion",
+        "Appeal to emotion",
+        "Attaque personnelle",
+        "Ad hominem",
+        "Pente glissante",
+        "Slippery slope",
+        "Faux dilemme",
+        "False dilemma",
+        "Black and white",
+        "Homme de paille",
+        "Straw man",
+        "Pétition de principe",
+        "Begging the question",
+        "Circular reasoning",
+        "Hasty generalization",
+        "Généralisation hâtive",
+        "Post hoc",
+        "Corrélation causale",
         "Non sequitur",
-        "Appel à l'ignorance", "Appeal to ignorance",
-        "Fausse équivalence", "False equivalence",
-        "Red herring", "Hareng rouge",
+        "Appel à l'ignorance",
+        "Appeal to ignorance",
+        "Fausse équivalence",
+        "False equivalence",
+        "Red herring",
+        "Hareng rouge",
         "Tu quoque",
         "Cherry picking",
         "Reductio ad absurdum",
@@ -126,20 +144,57 @@ def count_named_fallacies_with_taxonomy(text: str) -> list[dict]:
     lines = text.lower()
     for fallacy in fallacy_families:
         if fallacy.lower() in lines:
-            found.append({"name": fallacy, "has_taxonomy": ">" in text or "/" in text or ":" in text})
+            found.append(
+                {
+                    "name": fallacy,
+                    "has_taxonomy": ">" in text or "/" in text or ":" in text,
+                }
+            )
     return found
 
 
 def detect_formal_method_findings(text: str) -> dict:
     """Check for formal method markers in report."""
     markers = {
-        "tweety_kb": any(kw in text.lower() for kw in ["tweety", "belief set", "ensemble de croyances", "pl satisfiability"]),
-        "dung_extensions": any(kw in text.lower() for kw in ["dung", "extension", "attaque", "framework", "cadre de dung"]),
-        "aspic_inconsistency": any(kw in text.lower() for kw in ["aspic", "inconsistance", "defeasible", "strict rule"]),
-        "fol_analysis": any(kw in text.lower() for kw in ["first-order logic", "fol", "logique du premier ordre", "prédicat", "quantifie"]),
-        "pl_analysis": any(kw in text.lower() for kw in ["propositional", "pl ", "logique propositionnelle", "sat solver"]),
-        "modal_analysis": any(kw in text.lower() for kw in ["modal logic", "modalité", "nécessairement", "possibly"]),
-        "agm_revision": any(kw in text.lower() for kw in ["agm", "belief revision", "rétractation", "contraction"]),
+        "tweety_kb": any(
+            kw in text.lower()
+            for kw in [
+                "tweety",
+                "belief set",
+                "ensemble de croyances",
+                "pl satisfiability",
+            ]
+        ),
+        "dung_extensions": any(
+            kw in text.lower()
+            for kw in ["dung", "extension", "attaque", "framework", "cadre de dung"]
+        ),
+        "aspic_inconsistency": any(
+            kw in text.lower()
+            for kw in ["aspic", "inconsistance", "defeasible", "strict rule"]
+        ),
+        "fol_analysis": any(
+            kw in text.lower()
+            for kw in [
+                "first-order logic",
+                "fol",
+                "logique du premier ordre",
+                "prédicat",
+                "quantifie",
+            ]
+        ),
+        "pl_analysis": any(
+            kw in text.lower()
+            for kw in ["propositional", "pl ", "logique propositionnelle", "sat solver"]
+        ),
+        "modal_analysis": any(
+            kw in text.lower()
+            for kw in ["modal logic", "modalité", "nécessairement", "possibly"]
+        ),
+        "agm_revision": any(
+            kw in text.lower()
+            for kw in ["agm", "belief revision", "rétractation", "contraction"]
+        ),
     }
     return {k: v for k, v in markers.items() if v}
 
@@ -147,10 +202,18 @@ def detect_formal_method_findings(text: str) -> dict:
 def detect_cross_text_parallels(text: str) -> bool:
     """Check for intertextual/cross-corpus references."""
     markers = [
-        "cross-text", "cross text", "intertextuel", "parallèle",
-        "comparison with", "similar to", "pattern also found",
-        "comparaison avec", "similaire à", "pattern également",
-        "récurrence", "motif récurrent",
+        "cross-text",
+        "cross text",
+        "intertextuel",
+        "parallèle",
+        "comparison with",
+        "similar to",
+        "pattern also found",
+        "comparaison avec",
+        "similaire à",
+        "pattern également",
+        "récurrence",
+        "motif récurrent",
     ]
     return any(m in text.lower() for m in markers)
 
@@ -163,7 +226,7 @@ def analyze_report(text: str) -> dict:
         "formal_method_findings": detect_formal_method_findings(text),
         "has_cross_text_parallels": detect_cross_text_parallels(text),
         "word_count": len(text.split()),
-        "section_count": len(re.findall(r'^#{1,3}\s', text, re.MULTILINE)),
+        "section_count": len(re.findall(r"^#{1,3}\s", text, re.MULTILINE)),
     }
 
 
@@ -178,15 +241,31 @@ async def run_baseline_0shot(text: str, model: str = "gpt-4o-mini") -> str:
     if len(text) > 30000:
         truncated += "\n\n[... texte tronqué ...]"
 
-    response = client.chat.completions.create(
-        model=model,
-        messages=[
-            {"role": "system", "content": "Tu es un expert en analyse rhétorique et en logique formelle."},
-            {"role": "user", "content": BASELINE_PROMPT + truncated},
-        ],
-        temperature=0.3,
-        max_tokens=4096,
-    )
+    # gpt-5 family rejects `max_tokens` (needs `max_completion_tokens`) and
+    # non-default `temperature`; fall back gracefully for older models.
+    messages = [
+        {
+            "role": "system",
+            "content": "Tu es un expert en analyse rhétorique et en logique formelle.",
+        },
+        {"role": "user", "content": BASELINE_PROMPT + truncated},
+    ]
+    # gpt-5 reasoning models spend completion tokens on hidden reasoning before
+    # any visible output, so the budget must be generous or the answer comes back
+    # empty. 16384 leaves ample room for a full analysis after reasoning.
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=messages,
+            max_completion_tokens=16384,
+        )
+    except openai.BadRequestError:
+        response = client.chat.completions.create(
+            model=model,
+            messages=messages,
+            temperature=0.3,
+            max_tokens=4096,
+        )
     return response.choices[0].message.content
 
 
@@ -236,7 +315,7 @@ async def run_comparison(corpus_id: str, skip_pipeline: bool = False) -> dict:
             print("WARNING: No DeepSynthesis report generated")
 
         # Also save state for reference
-        if state and hasattr(state, 'get_state_snapshot'):
+        if state and hasattr(state, "get_state_snapshot"):
             snap = state.get_state_snapshot(summarize=True)
             with open(out_dir / "pipeline_state.json", "w", encoding="utf-8") as f:
                 json.dump(snap, f, indent=2, ensure_ascii=False, default=str)
@@ -246,12 +325,16 @@ async def run_comparison(corpus_id: str, skip_pipeline: bool = False) -> dict:
 
         results["pipeline_duration"] = round(pipeline_duration, 1)
         results["pipeline_turns"] = len(conversation_log)
-        results["deepsynth_word_count"] = len(deepsynth_report.split()) if deepsynth_report else 0
+        results["deepsynth_word_count"] = (
+            len(deepsynth_report.split()) if deepsynth_report else 0
+        )
     else:
         print("\n--- Step 1: SKIPPED (using cached results) ---")
         # Try to load cached
         cached_report = out_dir / "deepsynth_report.md"
-        deepsynth_report = cached_report.read_text(encoding="utf-8") if cached_report.exists() else ""
+        deepsynth_report = (
+            cached_report.read_text(encoding="utf-8") if cached_report.exists() else ""
+        )
         results["pipeline_duration"] = "cached"
         results["pipeline_turns"] = "cached"
 
@@ -328,7 +411,10 @@ async def run_comparison(corpus_id: str, skip_pipeline: bool = False) -> dict:
         pipeline_advantages.append("more_named_fallacies")
     if ds_formal and not bl_formal:
         pipeline_advantages.append("formal_methods_unique_to_pipeline")
-    if comparison["deltas"]["cross_text_parallels"]["pipeline"] and not comparison["deltas"]["cross_text_parallels"]["baseline"]:
+    if (
+        comparison["deltas"]["cross_text_parallels"]["pipeline"]
+        and not comparison["deltas"]["cross_text_parallels"]["baseline"]
+    ):
         pipeline_advantages.append("cross_text_parallels_unique")
 
     comparison["verdict"] = {
@@ -342,12 +428,24 @@ async def run_comparison(corpus_id: str, skip_pipeline: bool = False) -> dict:
 
     # Print summary
     print(f"\n--- Comparison Summary: {info['label']} ---")
-    print(f"Pipeline report: {ds_analysis.get('word_count', 0)} words, {ds_analysis.get('section_count', 0)} sections")
-    print(f"Baseline report: {bl_analysis.get('word_count', 0)} words, {bl_analysis.get('section_count', 0)} sections")
-    print(f"Textual citations: pipeline={ds_analysis.get('textual_citations', 0)}, baseline={bl_analysis.get('textual_citations', 0)}")
-    print(f"Named fallacies: pipeline={len(ds_fallacies)}, baseline={len(bl_fallacies)}")
-    print(f"Formal methods: pipeline={list(ds_formal.keys())}, baseline={list(bl_formal.keys())}")
-    print(f"Cross-text parallels: pipeline={ds_analysis.get('has_cross_text_parallels', False)}, baseline={bl_analysis.get('has_cross_text_parallels', False)}")
+    print(
+        f"Pipeline report: {ds_analysis.get('word_count', 0)} words, {ds_analysis.get('section_count', 0)} sections"
+    )
+    print(
+        f"Baseline report: {bl_analysis.get('word_count', 0)} words, {bl_analysis.get('section_count', 0)} sections"
+    )
+    print(
+        f"Textual citations: pipeline={ds_analysis.get('textual_citations', 0)}, baseline={bl_analysis.get('textual_citations', 0)}"
+    )
+    print(
+        f"Named fallacies: pipeline={len(ds_fallacies)}, baseline={len(bl_fallacies)}"
+    )
+    print(
+        f"Formal methods: pipeline={list(ds_formal.keys())}, baseline={list(bl_formal.keys())}"
+    )
+    print(
+        f"Cross-text parallels: pipeline={ds_analysis.get('has_cross_text_parallels', False)}, baseline={bl_analysis.get('has_cross_text_parallels', False)}"
+    )
     print(f"Pipeline advantages: {pipeline_advantages}")
     print(f"Meets ≥3 categories threshold: {comparison['verdict']['meets_threshold']}")
     print(f"\nSaved to {out_dir}/")
@@ -357,10 +455,12 @@ async def run_comparison(corpus_id: str, skip_pipeline: bool = False) -> dict:
 
 async def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--corpus", required=True,
-                        help="Corpus ID (A, B, C) or 'all'")
-    parser.add_argument("--skip-pipeline", action="store_true",
-                        help="Skip pipeline run, use cached results")
+    parser.add_argument("--corpus", required=True, help="Corpus ID (A, B, C) or 'all'")
+    parser.add_argument(
+        "--skip-pipeline",
+        action="store_true",
+        help="Skip pipeline run, use cached results",
+    )
     args = parser.parse_args()
 
     corpora = ["A", "B", "C"] if args.corpus.lower() == "all" else [args.corpus.upper()]
@@ -378,7 +478,9 @@ async def main():
             label = c["corpus_label"]
             v = c["verdict"]
             icon = "PASS" if v["meets_threshold"] else "FAIL"
-            print(f"  [{icon}] {label}: {len(v['pipeline_advantage_categories'])} advantage categories — {v['pipeline_advantage_categories']}")
+            print(
+                f"  [{icon}] {label}: {len(v['pipeline_advantage_categories'])} advantage categories — {v['pipeline_advantage_categories']}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **Bug fix**: the #592 benchmark called the 0-shot baseline with `max_tokens=4096`. The gpt-5 API rejects this (needs `max_completion_tokens`), and a reasoning model spends that budget on hidden reasoning — returning **empty content**. The first run's 4/4 "PASS" was a hollow win against a 0-word opponent.
- **Fix**: `max_completion_tokens=16384` with a graceful `BadRequestError` fallback for older models.
- **Honest re-run (corpus A, ~58K, gpt-5-mini both sides)**: pipeline wins **2/4** advantage categories — **below** the ≥3 "spectacular" threshold. Report at `docs/reports/spectacular/convergence_benchmark_corpus_A.md` (aggregate-only, opaque IDs; raw outputs gitignored).

## Why 2/4 is the real signal (not a regression)
The harness scores **vocabulary**, not **computation**:
- The 0-shot **name-drops** Dung/ASPIC ("les arguments sont attaquables par rebuttal/undermining") and even closes by saying it *would* formalize — yet `detect_formal_method_findings` credits it with 5 formal methods on bare keywords.
- `cross_text_parallels` is a **section-header false-positive** (pipeline's S8 is empty but the heading trips the marker).
- The genuine, unfakeable differentiators — a **computed 27-member grounded extension** + attack edge list, and **5 convergent verdicts** (arg_1 flagged by 5 independent methods) — are **not in the rubric at all**.

## Pipeline gaps found during the run (follow-ups, documented in the report)
- Belief Revision Trace renders "No retractions" despite the orchestrator logging 4 contractions (source-of-truth mismatch with the convergence JTMS signal).
- PL/Modal findings are thin (Tweety constant-declaration bottleneck).

## Next work (the boulot)
1. Add **convergence-depth** + **computed-artifact** metrics to the harness (unfakeable by a 0-shot).
2. Fix the cross-text false-positive (detect populated content, not the heading).
3. Fix the BR trace rendering.
4. Address the PL formula bottleneck.

## Files removed and why
None — additive (1 new report) + 1 script bug-fix.

## Test plan
- [x] `black --check` clean on the script
- [x] Privacy grep CLEAN (no nominative content, no raw_text/premisses fields)
- [x] Fair baseline produces real output (3015 words) — verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)