### PR TITLE
fix(synthesis): Belief Revision Trace reads AGM contractions (#642)

### DIFF
--- a/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
+++ b/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
@@ -125,9 +125,10 @@ class DeepSynthesisAgent(BaseAgent):
 
         # Convergence layer (Track DD #637) — cross-method agreement, computed
         # before section 9 so both the LLM and template thesis can ground in it.
-        report.convergent_verdicts, report.convergence_conclusion = (
-            self._build_convergent_verdicts(state)
-        )
+        (
+            report.convergent_verdicts,
+            report.convergence_conclusion,
+        ) = self._build_convergent_verdicts(state)
 
         # Section 9 — final synthesis (tries LLM, falls back to template)
         try:
@@ -321,8 +322,10 @@ class DeepSynthesisAgent(BaseAgent):
 
     @staticmethod
     def _build_belief_retractions(state: Any) -> List[BeliefRetraction]:
+        retractions: List[BeliefRetraction] = []
+
+        # Source 1: JTMS retraction cascade chain (jtms_core → jtms_retraction_chain)
         chain = getattr(state, "jtms_retraction_chain", [])
-        retractions = []
         for entry in chain:
             retractions.append(
                 BeliefRetraction(
@@ -331,6 +334,26 @@ class DeepSynthesisAgent(BaseAgent):
                     trigger=entry.get("trigger", ""),
                 )
             )
+
+        # Source 2: AGM belief revision results (conversational_orchestrator
+        # _run_belief_revision_from_state → belief_revision_results).
+        # Each entry has {id, method, original: List[str], revised: List[str]}.
+        # Beliefs present in original but absent from revised were contracted.
+        br_results = getattr(state, "belief_revision_results", [])
+        for br in br_results:
+            original = set(br.get("original", []))
+            revised = set(br.get("revised", []))
+            contracted = original - revised
+            method = br.get("method", "unknown")
+            for belief in contracted:
+                retractions.append(
+                    BeliefRetraction(
+                        belief_name=belief,
+                        was_valid=True,
+                        trigger=f"{method}_contraction",
+                    )
+                )
+
         return retractions
 
     @staticmethod

--- a/tests/unit/argumentation_analysis/test_belief_retraction_agm_source.py
+++ b/tests/unit/argumentation_analysis/test_belief_retraction_agm_source.py
@@ -1,0 +1,119 @@
+"""Tests for Track FF (#642): Belief Revision Trace reads AGM source.
+
+The DeepSynthesis report Section 6 must surface contractions from BOTH:
+  - jtms_retraction_chain (JTMS cascade retractions)
+  - belief_revision_results (AGM belief revision contractions)
+"""
+import pytest
+
+from argumentation_analysis.agents.core.synthesis.deep_synthesis_agent import (
+    DeepSynthesisAgent,
+)
+from argumentation_analysis.agents.core.synthesis.deep_synthesis_models import (
+    BeliefRetraction,
+)
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+
+def _make_state():
+    return UnifiedAnalysisState(initial_text="test text for BR trace")
+
+
+class TestBeliefRetractionAGMSource:
+    """_build_belief_retractions must read belief_revision_results."""
+
+    def test_agm_contraction_surfaces_in_retractions(self):
+        state = _make_state()
+        state.add_belief_revision_result(
+            method="fallacy_contraction",
+            original=["b1", "b2", "b3", "b4"],
+            revised=[],
+        )
+        retractions = DeepSynthesisAgent._build_belief_retractions(state)
+        assert len(retractions) == 4
+        names = {r.belief_name for r in retractions}
+        assert names == {"b1", "b2", "b3", "b4"}
+
+    def test_agm_partial_contraction(self):
+        state = _make_state()
+        state.add_belief_revision_result(
+            method="consistency_check",
+            original=["b1", "b2", "b3"],
+            revised=["b2"],
+        )
+        retractions = DeepSynthesisAgent._build_belief_retractions(state)
+        contracted = {r.belief_name for r in retractions}
+        assert contracted == {"b1", "b3"}
+        assert all(r.was_valid is True for r in retractions)
+
+    def test_agm_no_contraction(self):
+        state = _make_state()
+        state.add_belief_revision_result(
+            method="fallacy_contraction",
+            original=["b1", "b2"],
+            revised=["b1", "b2"],
+        )
+        retractions = DeepSynthesisAgent._build_belief_retractions(state)
+        assert len(retractions) == 0
+
+    def test_agm_trigger_includes_method(self):
+        state = _make_state()
+        state.add_belief_revision_result(
+            method="fallacy_contraction",
+            original=["b1"],
+            revised=[],
+        )
+        retractions = DeepSynthesisAgent._build_belief_retractions(state)
+        assert retractions[0].trigger == "fallacy_contraction_contraction"
+
+    def test_both_sources_merged(self):
+        state = _make_state()
+        # JTMS source
+        state.jtms_retraction_chain.append(
+            {"belief_name": "jtms_b1", "was_valid": True, "trigger": "cascade"}
+        )
+        # AGM source
+        state.add_belief_revision_result(
+            method="fallacy_contraction",
+            original=["agm_b1", "agm_b2"],
+            revised=["agm_b1"],
+        )
+        retractions = DeepSynthesisAgent._build_belief_retractions(state)
+        assert len(retractions) == 2  # 1 JTMS + 1 AGM contracted
+        names = {r.belief_name for r in retractions}
+        assert names == {"jtms_b1", "agm_b2"}
+
+    def test_empty_state_returns_empty(self):
+        state = _make_state()
+        retractions = DeepSynthesisAgent._build_belief_retractions(state)
+        assert retractions == []
+
+    def test_multiple_agm_entries(self):
+        state = _make_state()
+        state.add_belief_revision_result(
+            method="m1",
+            original=["a", "b"],
+            revised=["a"],
+        )
+        state.add_belief_revision_result(
+            method="m2",
+            original=["c", "d", "e"],
+            revised=["e"],
+        )
+        retractions = DeepSynthesisAgent._build_belief_retractions(state)
+        contracted = {r.belief_name for r in retractions}
+        assert contracted == {"b", "c", "d"}
+
+    def test_agm_result_shape_is_belief_retraction(self):
+        state = _make_state()
+        state.add_belief_revision_result(
+            method="test",
+            original=["x"],
+            revised=[],
+        )
+        retractions = DeepSynthesisAgent._build_belief_retractions(state)
+        r = retractions[0]
+        assert isinstance(r, BeliefRetraction)
+        assert r.belief_name == "x"
+        assert r.was_valid is True
+        assert "test" in r.trigger


### PR DESCRIPTION
## Summary

Fixes #642 — Section 6 (Belief Revision Trace) rendered empty ("_No belief retractions in this run._") despite the orchestrator logging "4 beliefs contracted (4 → 0)".

## Root cause

`_build_belief_retractions` only read `state.jtms_retraction_chain` (JTMS cascade). AGM belief revision (`_run_belief_revision_from_state`) writes to `state.belief_revision_results` instead — two completely separate state keys with no synchronization. The convergence layer's JTMS signal found the data via a different path, creating the within-report contradiction.

## Fix

`_build_belief_retractions` now reads **both** sources:
1. `jtms_retraction_chain` (JTMS cascade retractions) — existing behavior preserved
2. `belief_revision_results` (AGM contractions) — new source, computes contracted beliefs as `set(original) - set(revised)` per entry

## Tests

- 8 new unit tests (`test_belief_retraction_agm_source.py`): full/partial/no contraction, both sources merged, multiple AGM entries, result shape, trigger naming
- 29 existing synthesis tests still green (37 total)
- `black --check` clean, `flake8` clean
- Privacy grep: CLEAN

## Files changed

- `argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py` — `_build_belief_retractions` expanded to dual-source
- `tests/unit/argumentation_analysis/test_belief_retraction_agm_source.py` — NEW, 8 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>