### PR TITLE
fix(orchestration): parent-harness fallacies register into UnifiedAnalysisState (#648)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -1324,25 +1324,43 @@ async def _run_parent_harness_fallback(
             logger.info("Parent harness: no additional fallacies found")
             return None
 
-        # Register any new fallacies into state
+        # Register any new fallacies into state (#648 Track HH).
+        # UnifiedAnalysisState exposes add_fallacy(fallacy_type, justification,
+        # target_arg_id) — NOT add_identified_fallacy (that singular method lives
+        # only on StateManagerPlugin / PhaseScopedState). The previous guard
+        # `hasattr(state, "add_identified_fallacy")` was always False here, so the
+        # harness silently dropped every fallacy it found (empty Section 3 +
+        # starved convergence on dense corpora). Prefer add_fallacy; keep the
+        # singular path only as a fallback for state types that provide it.
         added = 0
         for f in fallacies:
             if not isinstance(f, dict):
                 continue
-            if hasattr(state, "add_identified_fallacy"):
-                try:
-                    state.add_identified_fallacy(
-                        fallacy_type=f.get("fallacy_type") or f.get("nom", "unknown"),
-                        justification=f.get(
-                            "justification",
-                            f"Detected by parent harness (confidence: {f.get('confidence', 'N/A')})",
-                        ),
-                        confidence=f.get("confidence", 0.6),
-                        source_arg_id=f.get("source_arg_id"),
+            fallacy_type = (
+                f.get("fallacy_type") or f.get("type") or f.get("nom") or "unknown"
+            )
+            justification = (
+                f.get("justification")
+                or f.get("explanation")
+                or f"Detected by parent harness (confidence: {f.get('confidence', 'N/A')})"
+            )
+            target_arg_id = f.get("source_arg_id") or f.get("target_argument_id")
+            try:
+                if hasattr(state, "add_fallacy"):
+                    state.add_fallacy(
+                        fallacy_type=fallacy_type,
+                        justification=justification,
+                        target_arg_id=target_arg_id,
                     )
                     added += 1
-                except Exception:
-                    pass
+                elif hasattr(state, "add_identified_fallacy"):
+                    state.add_identified_fallacy(
+                        fallacy_type=fallacy_type,
+                        justification=justification,
+                    )
+                    added += 1
+            except Exception:
+                pass
 
         logger.info(
             "Parent harness: %d fallacies found, %d registered into state",

--- a/tests/unit/argumentation_analysis/orchestration/test_informal_taxonomy_injection_600.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_informal_taxonomy_injection_600.py
@@ -218,13 +218,23 @@ class TestParentHarnessFallback:
 
     @pytest.mark.asyncio
     async def test_harness_registers_fallacies(self):
-        """Harness registers found fallacies into state."""
+        """Harness registers found fallacies into a REAL UnifiedAnalysisState (#648).
+
+        Regression for Track HH: the previous version of this test used a bare
+        MagicMock state, on which every attribute (incl. the nonexistent
+        ``add_identified_fallacy``) auto-exists — so it passed while the harness
+        silently dropped every fallacy on the real state. Use the real state so
+        the registration path is actually exercised end-to-end.
+        """
         from argumentation_analysis.orchestration.conversational_orchestrator import (
             _run_parent_harness_fallback,
         )
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
 
-        mock_state = MagicMock()
-        mock_state.add_identified_fallacy = MagicMock()
+        state = UnifiedAnalysisState(initial_text="x")
+        # The real state must NOT have the singular method the old code relied on.
+        assert not hasattr(state, "add_identified_fallacy")
+        assert hasattr(state, "add_fallacy")
 
         fake_fallacies = [
             {
@@ -250,11 +260,43 @@ class TestParentHarnessFallback:
                 "exploration_method": "per_argument_parallel",
             },
         ):
-            result = await _run_parent_harness_fallback("long text" * 200, mock_state)
+            result = await _run_parent_harness_fallback("long text" * 200, state)
             assert result is not None
             assert result["fallacies_found"] == 2
             assert result["fallacies_registered"] == 2
-            assert mock_state.add_identified_fallacy.call_count == 2
+            # The fallacies must actually land in the canonical state field that
+            # DeepSynthesisAgent._build_fallacy_diagnoses reads.
+            assert len(state.identified_fallacies) == 2
+            types = {f["type"] for f in state.identified_fallacies.values()}
+            assert types == {"straw_man", "ad_hominem"}
+            targets = {
+                f.get("target_argument_id") for f in state.identified_fallacies.values()
+            }
+            assert targets == {"arg-1", "arg-2"}
+
+    @pytest.mark.asyncio
+    async def test_harness_singular_method_fallback(self):
+        """State types exposing only add_identified_fallacy still register (#648)."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_parent_harness_fallback,
+        )
+
+        # A state spec'd to expose ONLY the singular method (e.g. PhaseScopedState).
+        state = MagicMock(spec=["add_identified_fallacy"])
+
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables."
+            "_invoke_hierarchical_fallacy_per_argument",
+            new_callable=AsyncMock,
+            return_value={
+                "fallacies": [{"type": "post_hoc", "explanation": "x"}],
+                "exploration_method": "per_argument_parallel",
+            },
+        ):
+            result = await _run_parent_harness_fallback("long text" * 200, state)
+            assert result is not None
+            assert result["fallacies_registered"] == 1
+            assert state.add_identified_fallacy.call_count == 1
 
     @pytest.mark.asyncio
     async def test_harness_handles_import_error(self):


### PR DESCRIPTION
## Summary
Track HH (#648). Root cause is **not** a report-reader key mismatch (the body's original hypothesis) — code-verified:

- The deterministic parent-harness fallback **is already wired** ([conversational_orchestrator.py:621](argumentation_analysis/orchestration/conversational_orchestrator.py#L621)) and **does detect** fallacies on dense texts (>5000 chars).
- But its registration was guarded by `hasattr(state, "add_identified_fallacy")` ([line 1332, pre-fix](argumentation_analysis/orchestration/conversational_orchestrator.py#L1332)). **Runtime-verified** that `UnifiedAnalysisState` has **no** `add_identified_fallacy` (singular) — only `add_fallacy(fallacy_type, justification, target_arg_id)` and `add_identified_fallacies` (plural). The singular method lives only on `StateManagerPlugin` / `PhaseScopedState`.
- So the guard was **always False** here → every detected fallacy was silently dropped on the real state.

### Knock-on (matches corpus C report §3)
Empty `identified_fallacies` → empty Section 3 in the DeepSynthesis report **and** a starved convergence layer (a fallacy signal is 1 of the 5 `compute_argument_convergence` inputs) → corpus C scored 0 named fallacies and only 2 convergence verdicts vs 5 on A/B. One plumbing bug suppressed **both** the surface fallacy metric and the substance convergence metric.

## Fix
- Register via `state.add_fallacy(...)` (present on the real state); keep the singular method only as a fallback for state types that provide it.
- Robust key mapping: `fallacy_type`/`type`/`nom`, `justification`/`explanation`, `source_arg_id`/`target_argument_id`.

## Why the bug slipped through
The existing `test_harness_registers_fallacies` used a bare `MagicMock()` state — where **every** attribute (incl. the nonexistent `add_identified_fallacy`) auto-exists — so it passed while the real state dropped everything. Rewrote it to drive a **real `UnifiedAnalysisState`** and assert fallacies land in `state.identified_fallacies`; added a singular-method-fallback test.

## Test plan
- [x] `pytest tests/unit/argumentation_analysis/orchestration/test_informal_taxonomy_injection_600.py -q` → 23 passed
- [x] The rewritten test fails on the old code (registration skipped → 0 registered), passes on the fix
- [x] `flake8` clean on both files
- [ ] Re-run `scripts/scda_deepsynthesis_vs_baseline.py --corpus C` to confirm Section 3 + convergence recover (follow-up benchmark)

Note: black version drift — local/CI envs differ on pre-existing assert/list formatting; this PR touches **only** new lines, all clean under the CI black, and leaves pre-existing lines (already CI-accepted on main) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)