### PR TITLE
fix(orchestration): one-shot fallback on per-argument fallacy timeout (#652)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3060,7 +3060,17 @@ async def _invoke_hierarchical_fallacy_per_argument(
 
         # Create plugin instances — one per argument for isolation
         async def _analyze_single_arg(arg_text: str, arg_id: str) -> Dict[str, Any]:
-            """Analyze a single argument with its own plugin instance."""
+            """Analyze a single argument with its own plugin instance.
+
+            On timeout, retry once with the fast one-shot path before giving
+            up (#652 Track II). The full guided analysis (wide-net + iterative
+            deepening) is several LLM calls and exceeds budget under API
+            latency; returning empty here directly starves the report's fallacy
+            section AND the convergence layer (fallacy is one of its inputs).
+            The one-shot is a single taxonomy-mapped call, so it recovers
+            recall cheaply when the API is slow.
+            """
+            plugin = None
             try:
                 async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
                 llm_service = OpenAIChatCompletion(
@@ -3078,13 +3088,34 @@ async def _invoke_hierarchical_fallacy_per_argument(
 
                 result_json = await asyncio.wait_for(
                     plugin.run_guided_analysis(argument_text=arg_text),
-                    timeout=60.0,
+                    timeout=120.0,
                 )
                 result: Dict[str, Any] = json.loads(result_json)
                 result["source_arg_id"] = arg_id
                 return result
             except asyncio.TimeoutError:
-                logger.warning("Timeout analyzing argument %s", arg_id)
+                logger.warning(
+                    "Timeout analyzing argument %s — retrying with fast one-shot",
+                    arg_id,
+                )
+                if plugin is not None:
+                    try:
+                        oneshot_json = await asyncio.wait_for(
+                            plugin.run_guided_analysis(
+                                argument_text=arg_text, use_one_shot=True
+                            ),
+                            timeout=45.0,
+                        )
+                        oneshot: Dict[str, Any] = json.loads(oneshot_json)
+                        oneshot["source_arg_id"] = arg_id
+                        oneshot["timed_out_fallback"] = True
+                        return oneshot
+                    except Exception as e:
+                        logger.warning(
+                            "One-shot fallback also failed for argument %s: %s",
+                            arg_id,
+                            e,
+                        )
                 return {"fallacies": [], "source_arg_id": arg_id, "timed_out": True}
             except Exception as e:
                 logger.warning("Error analyzing argument %s: %s", arg_id, e)

--- a/tests/unit/argumentation_analysis/orchestration/test_parent_harness_578.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_parent_harness_578.py
@@ -380,6 +380,76 @@ class TestInvokeHierarchicalFallacyPerArgument:
         assert result["parallel_executed"] is True
 
     @pytest.mark.asyncio
+    async def test_timeout_falls_back_to_oneshot(self):
+        """On primary timeout, the fast one-shot retry recovers the fallacy (#652)."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_hierarchical_fallacy_per_argument,
+        )
+
+        arguments = [
+            ("arg_1", "First argument text is long enough for the test here"),
+        ]
+
+        # Primary guided path hangs (times out); one-shot returns quickly.
+        async def guided(*args, **kwargs):
+            if kwargs.get("use_one_shot"):
+                return json.dumps({
+                    "fallacies": [
+                        {"fallacy_type": "post_hoc", "taxonomy_pk": "pk_2", "confidence": 0.7}
+                    ],
+                    "exploration_method": "one_shot",
+                })
+            await asyncio.sleep(10)
+            return json.dumps({"fallacies": [], "exploration_method": "wide_net"})
+
+        instance = MagicMock()
+        instance.run_guided_analysis = guided
+
+        mock_plugin_class = MagicMock(return_value=instance)
+        mock_llm_service = AsyncMock()
+        mock_llm_service.get_chat_message_contents = AsyncMock(return_value=[])
+
+        modules = {
+            "openai": MagicMock(AsyncOpenAI=MagicMock(return_value=MagicMock())),
+            "semantic_kernel.kernel": MagicMock(Kernel=MagicMock),
+            "semantic_kernel.connectors.ai.open_ai": MagicMock(
+                OpenAIChatCompletion=MagicMock(return_value=mock_llm_service),
+            ),
+            "argumentation_analysis.plugins.fallacy_workflow_plugin": MagicMock(
+                FallacyWorkflowPlugin=mock_plugin_class,
+            ),
+        }
+
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.os.path.isfile",
+            return_value=True,
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables._extract_arguments_for_parallel",
+            return_value=arguments,
+        ), patch.dict("sys.modules", modules), patch(
+            "argumentation_analysis.orchestration.invoke_callables.os.environ",
+            {"OPENAI_API_KEY": "test-key", "OPENAI_BASE_URL": "https://api.test.com/v1", "OPENAI_CHAT_MODEL_ID": "test-model"},
+        ):
+            original_wait_for = asyncio.wait_for
+
+            # Force only the primary (120s) call to time out; the one-shot
+            # (45s) keeps its real budget so its instant coro completes.
+            async def patched_wait_for(coro, timeout=60):
+                if timeout == 120.0:
+                    return await original_wait_for(coro, timeout=0.5)
+                return await original_wait_for(coro, timeout=timeout)
+
+            with patch(
+                "argumentation_analysis.orchestration.invoke_callables.asyncio.wait_for",
+                side_effect=patched_wait_for,
+            ):
+                result = await _invoke_hierarchical_fallacy_per_argument("full text", {})
+
+        # The one-shot fallback recovered the fallacy instead of returning empty.
+        assert len(result["fallacies"]) == 1
+        assert result["fallacies"][0]["fallacy_type"] == "post_hoc"
+
+    @pytest.mark.asyncio
     async def test_no_api_key_returns_unavailable(self):
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_hierarchical_fallacy_per_argument,


### PR DESCRIPTION
## Summary
- Raises the per-argument fallacy-detection timeout 60s → 120s in `_invoke_hierarchical_fallacy_per_argument._analyze_single_arg` ([invoke_callables.py:3079](argumentation_analysis/orchestration/invoke_callables.py#L3079)).
- On `asyncio.TimeoutError`, retries once with the fast one-shot path (`run_guided_analysis(..., use_one_shot=True)` — single taxonomy-mapped LLM call) under a 45s budget, instead of returning empty.
- Closes #652.

## Why
Two consecutive benchmark runs on the same corpus / same main showed large variance traced to this timeout:
- Degraded run: **9/10** arguments timed out → pipeline named **1** fallacy, 23 citations, convergence verdict_count 2.
- Healthier run: **5** timeouts → pipeline named **4** fallacies, 75 citations, convergence verdict_count 8.

Empty per-argument results starve both the report's fallacy section and the convergence layer (fallacy is one of its 5 inputs — same failure class as #648, but latency-driven not plumbing-driven). This is a live-demo failure mode: slow API → thin analysis.

## Test plan
- [x] New `test_timeout_falls_back_to_oneshot`: primary times out, one-shot recovers the fallacy.
- [x] `test_parent_harness_578.py` suite green (14 passed).
- [x] flake8 clean; black-clean on added lines (pre-existing version-drift untouched).
- [x] Privacy grep clean (code-only change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)