### PR TITLE
fix(detection): eliminate Type Inconnu + wide-net whole-text fusion pass (#655)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -56,23 +56,74 @@ def _detect_language(text: str) -> str:
     scores: Dict[str, int] = {"de": 0, "fr": 0, "en": 0}
 
     de_markers = [
-        r"\bder\b", r"\bdie\b", r"\bdas\b", r"\bund\b", r"\bist\b",
-        r"\bein\b", r"\beine\b", r"\bden\b", r"\bmit\b", r"\bfür\b",
-        r"\bauf\b", r"\bdes\b", r"\bsich\b", r"\bnicht\b", r"\bvon\b",
-        r"\bsind\b", r"\bwird\b", r"\bdurch\b", r"\bwir\b", r"\bals\b",
-        r"\bauch\b", r"\bnoch\b", r"\bnach\b", r"\büber\b",
+        r"\bder\b",
+        r"\bdie\b",
+        r"\bdas\b",
+        r"\bund\b",
+        r"\bist\b",
+        r"\bein\b",
+        r"\beine\b",
+        r"\bden\b",
+        r"\bmit\b",
+        r"\bfür\b",
+        r"\bauf\b",
+        r"\bdes\b",
+        r"\bsich\b",
+        r"\bnicht\b",
+        r"\bvon\b",
+        r"\bsind\b",
+        r"\bwird\b",
+        r"\bdurch\b",
+        r"\bwir\b",
+        r"\bals\b",
+        r"\bauch\b",
+        r"\bnoch\b",
+        r"\bnach\b",
+        r"\büber\b",
     ]
     fr_markers = [
-        r"\ble\b", r"\bla\b", r"\bles\b", r"\bde\b", r"\bdes\b",
-        r"\bet\b", r"\best\b", r"\bque\b", r"\bqui\b", r"\bdu\b",
-        r"\bun\b", r"\bune\b", r"\bpour\b", r"\bdans\b", r"\bsur\b",
-        r"\bce\b", r"\bil\b", r"\bne\b", r"\bse\b", r"\bsont\b",
+        r"\ble\b",
+        r"\bla\b",
+        r"\bles\b",
+        r"\bde\b",
+        r"\bdes\b",
+        r"\bet\b",
+        r"\best\b",
+        r"\bque\b",
+        r"\bqui\b",
+        r"\bdu\b",
+        r"\bun\b",
+        r"\bune\b",
+        r"\bpour\b",
+        r"\bdans\b",
+        r"\bsur\b",
+        r"\bce\b",
+        r"\bil\b",
+        r"\bne\b",
+        r"\bse\b",
+        r"\bsont\b",
     ]
     en_markers = [
-        r"\bthe\b", r"\band\b", r"\bis\b", r"\bto\b", r"\bof\b",
-        r"\bin\b", r"\bthat\b", r"\bfor\b", r"\bit\b", r"\bwith\b",
-        r"\bas\b", r"\bwas\b", r"\bon\b", r"\bare\b", r"\bhave\b",
-        r"\bthis\b", r"\bwe\b", r"\bour\b", r"\bthey\b", r"\bnot\b",
+        r"\bthe\b",
+        r"\band\b",
+        r"\bis\b",
+        r"\bto\b",
+        r"\bof\b",
+        r"\bin\b",
+        r"\bthat\b",
+        r"\bfor\b",
+        r"\bit\b",
+        r"\bwith\b",
+        r"\bas\b",
+        r"\bwas\b",
+        r"\bon\b",
+        r"\bare\b",
+        r"\bhave\b",
+        r"\bthis\b",
+        r"\bwe\b",
+        r"\bour\b",
+        r"\bthey\b",
+        r"\bnot\b",
     ]
 
     for pattern in de_markers:
@@ -367,7 +418,10 @@ def create_conversational_agents(
         speciality = config["speciality"]
         state_cls = agent_state_class.get(name)
         plugins = get_plugin_instances(
-            speciality, state=state, kernel=kernel, llm_service=llm_service,
+            speciality,
+            state=state,
+            kernel=kernel,
+            llm_service=llm_service,
             state_plugin_class=state_cls,
         )
 
@@ -454,7 +508,10 @@ async def run_conversational_analysis(
     # 0e. Re-prompt trace accumulator (#609)
     reprompt_extractor = None
     if enable_reprompt_tracing:
-        from argumentation_analysis.reporting.reprompt_trace import RepromptTraceExtractor
+        from argumentation_analysis.reporting.reprompt_trace import (
+            RepromptTraceExtractor,
+        )
+
         reprompt_extractor = RepromptTraceExtractor()
 
     # 1. Setup kernel + LLM
@@ -481,6 +538,7 @@ async def run_conversational_analysis(
     agent_state_class = {}
     if enable_tool_gating:
         from argumentation_analysis.core.phase_scoped_state import AGENT_PHASE_MAP
+
         agent_state_class = dict(AGENT_PHASE_MAP)
         logger.info(
             f"Tool gating enabled: {len(agent_state_class)} agents get phase-scoped state plugins"
@@ -488,7 +546,10 @@ async def run_conversational_analysis(
 
     # 3. Create all agents
     all_agents = create_conversational_agents(
-        kernel, state, "conversational_llm", agent_names,
+        kernel,
+        state,
+        "conversational_llm",
+        agent_names,
         agent_state_class=agent_state_class,
     )
     agent_by_name = {a.name: a for a in all_agents}
@@ -671,7 +732,8 @@ async def run_conversational_analysis(
                             "\n\nRAPPEL : Le texte est en allemand. Traduisez mentalement "
                             "en anglais pour la detection de sophismes. "
                             "Conservez les citations en allemand."
-                            if detected_lang == "de" else ""
+                            if detected_lang == "de"
+                            else ""
                         )
                     ),
                 }
@@ -1154,15 +1216,14 @@ async def _run_phase(
                         logger.info(
                             f"  [{phase_name}] Growth re-prompt {rp + 1}/{growth_re_prompt_limit}"
                         )
-                        await chat.add_chat_message(
-                            _RE_PROMPT_FEEDBACK
-                        )
+                        await chat.add_chat_message(_RE_PROMPT_FEEDBACK)
                         async for rp_response in chat.invoke():
                             msg_entry = {
                                 "phase": phase_name,
                                 "turn": turn,
                                 "agent": getattr(
-                                    rp_response, "name",
+                                    rp_response,
+                                    "name",
                                     getattr(rp_response, "role", "?"),
                                 ),
                                 "content": str(
@@ -1175,7 +1236,17 @@ async def _run_phase(
                         fp_after = _get_growth_fingerprint(state)
                         # Record re-prompt trace (#609)
                         if reprompt_extractor is not None:
-                            rp_outcome = "ok" if _validate_state_growth(fp_before, fp_after, phase_name) else ("reran" if rp + 1 < growth_re_prompt_limit else "gave_up")
+                            rp_outcome = (
+                                "ok"
+                                if _validate_state_growth(
+                                    fp_before, fp_after, phase_name
+                                )
+                                else (
+                                    "reran"
+                                    if rp + 1 < growth_re_prompt_limit
+                                    else "gave_up"
+                                )
+                            )
                             reprompt_extractor.record(
                                 phase_name=phase_name,
                                 turn=turn,
@@ -1183,14 +1254,22 @@ async def _run_phase(
                                 fingerprint_before=fp_before,
                                 fingerprint_after=fp_after,
                                 outcome=rp_outcome,
-                                agent_name=getattr(rp_response, "name", getattr(rp_response, "role", "?")),
+                                agent_name=getattr(
+                                    rp_response,
+                                    "name",
+                                    getattr(rp_response, "role", "?"),
+                                ),
                             )
                         if _validate_state_growth(fp_before, fp_after, phase_name):
                             break
 
         if total_re_prompts > 0:
             messages.append(
-                {"phase": phase_name, "type": "growth_validation", "re_prompt_count": total_re_prompts}
+                {
+                    "phase": phase_name,
+                    "type": "growth_validation",
+                    "re_prompt_count": total_re_prompts,
+                }
             )
 
         return messages
@@ -1263,7 +1342,9 @@ async def _run_phase(
                                 "phase": phase_name,
                                 "turn": turn,
                                 "agent": agent.name,
-                                "content": rp_content[:500] if rp_content else "(empty)",
+                                "content": (
+                                    rp_content[:500] if rp_content else "(empty)"
+                                ),
                                 "re_prompt": rp + 1,
                             }
                         )
@@ -1271,7 +1352,17 @@ async def _run_phase(
                         fp_after = _get_growth_fingerprint(state)
                         # Record re-prompt trace (#609)
                         if reprompt_extractor is not None:
-                            rp_outcome = "ok" if _validate_state_growth(fp_before, fp_after, phase_name) else ("reran" if rp + 1 < growth_re_prompt_limit else "gave_up")
+                            rp_outcome = (
+                                "ok"
+                                if _validate_state_growth(
+                                    fp_before, fp_after, phase_name
+                                )
+                                else (
+                                    "reran"
+                                    if rp + 1 < growth_re_prompt_limit
+                                    else "gave_up"
+                                )
+                            )
                             reprompt_extractor.record(
                                 phase_name=phase_name,
                                 turn=turn,
@@ -1297,10 +1388,52 @@ async def _run_phase(
 
     if total_re_prompts > 0:
         messages.append(
-            {"phase": phase_name, "type": "growth_validation", "re_prompt_count": total_re_prompts}
+            {
+                "phase": phase_name,
+                "type": "growth_validation",
+                "re_prompt_count": total_re_prompts,
+            }
         )
 
     return messages
+
+
+_UNUSABLE_FALLACY_NAMES = frozenset(
+    {
+        "Type Inconnu",
+        "Type inconnu",
+        "type inconnu",
+        "TYPE INCONNU",
+        "unknown",
+        "Unknown",
+        "Sophisme inconnu",
+        "",
+    }
+)
+
+
+def _is_usable_fallacy_type(name: str) -> bool:
+    """Return False for empty, generic, or machine-generated fallacy type names (#655 Track KK)."""
+    if not name or not name.strip():
+        return False
+    if name.strip() in _UNUSABLE_FALLACY_NAMES:
+        return False
+    if name.startswith("unknown_class_"):
+        return False
+    return True
+
+
+def _extract_fallacy_type(fallacy_dict: Dict[str, Any]) -> str:
+    """Extract the best available fallacy type name from a fallacy dict (#655 Track KK).
+
+    Tries multiple key names in priority order, then validates via
+    _is_usable_fallacy_type. Returns "" if no usable name found.
+    """
+    for key in ("fallacy_type", "type", "nom", "name", "name_fr"):
+        val = fallacy_dict.get(key, "")
+        if isinstance(val, str) and _is_usable_fallacy_type(val):
+            return val.strip()
+    return ""
 
 
 async def _run_parent_harness_fallback(
@@ -1310,35 +1443,77 @@ async def _run_parent_harness_fallback(
 
     Always fires on texts > 5000 chars to catch fallacies the single-pass
     InformalAgent may have missed. Falls back silently if unavailable.
+
+    #655 Track KK: skips fallacies with unusable type names (Type Inconnu,
+    unknown, empty) and adds a wide-net whole-text fusion pass after the
+    per-argument pass to capture framing/tonal fallacies.
     """
     try:
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_hierarchical_fallacy_per_argument,
+            _invoke_hierarchical_fallacy,
         )
 
         context = {"_state_object": state}
-        result = await _invoke_hierarchical_fallacy_per_argument(text, context)
 
-        fallacies = result.get("fallacies", [])
+        # --- Per-argument pass (existing) ---
+        per_arg_result = await _invoke_hierarchical_fallacy_per_argument(text, context)
+        fallacies = per_arg_result.get("fallacies", [])
+
+        # --- Wide-net whole-text fusion pass (#655 Track KK) ---
+        # Catch framing, tonal, or discourse-level fallacies that span
+        # multiple arguments and are invisible in per-argument extraction.
+        whole_text_fallacies: List[Dict[str, Any]] = []
+        if len(text) > 500:
+            try:
+                whole_result = await _invoke_hierarchical_fallacy(text, context)
+                whole_text_fallacies = whole_result.get("fallacies", [])
+            except Exception as e:
+                logger.debug("Wide-net whole-text pass failed: %s", e)
+
+        # Deduplicate whole-text findings against per-argument results
+        per_arg_signatures: set = set()
+        for f in fallacies:
+            if isinstance(f, dict):
+                sig = (
+                    str(f.get("taxonomy_pk") or f.get("fallacy_type") or ""),
+                    str(f.get("source_arg_id") or ""),
+                )
+                per_arg_signatures.add(sig)
+
+        extra_count = 0
+        for wf in whole_text_fallacies:
+            if not isinstance(wf, dict):
+                continue
+            sig = (
+                str(wf.get("taxonomy_pk") or wf.get("fallacy_type") or ""),
+                "",
+            )
+            if sig not in per_arg_signatures:
+                wf["source_arg_id"] = "whole_text"
+                wf["wide_net"] = True
+                fallacies.append(wf)
+                extra_count += 1
+
+        if extra_count:
+            logger.info(
+                "Wide-net whole-text pass: %d additional fallacies", extra_count
+            )
+
         if not fallacies:
             logger.info("Parent harness: no additional fallacies found")
             return None
 
-        # Register any new fallacies into state (#648 Track HH).
-        # UnifiedAnalysisState exposes add_fallacy(fallacy_type, justification,
-        # target_arg_id) — NOT add_identified_fallacy (that singular method lives
-        # only on StateManagerPlugin / PhaseScopedState). The previous guard
-        # `hasattr(state, "add_identified_fallacy")` was always False here, so the
-        # harness silently dropped every fallacy it found (empty Section 3 +
-        # starved convergence on dense corpora). Prefer add_fallacy; keep the
-        # singular path only as a fallback for state types that provide it.
+        # Register fallacies into state — skip unusable type names (#655 Track KK).
         added = 0
+        skipped_unusable = 0
         for f in fallacies:
             if not isinstance(f, dict):
                 continue
-            fallacy_type = (
-                f.get("fallacy_type") or f.get("type") or f.get("nom") or "unknown"
-            )
+            fallacy_type = _extract_fallacy_type(f)
+            if not fallacy_type:
+                skipped_unusable += 1
+                continue
             justification = (
                 f.get("justification")
                 or f.get("explanation")
@@ -1363,9 +1538,12 @@ async def _run_parent_harness_fallback(
                 pass
 
         logger.info(
-            "Parent harness: %d fallacies found, %d registered into state",
+            "Parent harness: %d fallacies found (%d whole-text extra), "
+            "%d registered, %d skipped (unusable type)",
             len(fallacies),
+            extra_count,
             added,
+            skipped_unusable,
         )
 
         return {
@@ -1373,7 +1551,11 @@ async def _run_parent_harness_fallback(
             "type": "parent_harness",
             "fallacies_found": len(fallacies),
             "fallacies_registered": added,
-            "exploration_method": result.get("exploration_method", "per_argument_parallel"),
+            "fallacies_skipped_unusable": skipped_unusable,
+            "wide_net_extras": extra_count,
+            "exploration_method": per_arg_result.get(
+                "exploration_method", "per_argument_parallel"
+            ),
         }
 
     except ImportError:
@@ -1666,7 +1848,11 @@ def _build_dung_framework_from_state(state: Any) -> Optional[Dict[str, Any]]:
                     break
             # Source: find which argument the counter supports
             for aid, desc in state.identified_arguments.items():
-                if desc and counter_text and (counter_text[:40] in desc or desc[:40] in counter_text):
+                if (
+                    desc
+                    and counter_text
+                    and (counter_text[:40] in desc or desc[:40] in counter_text)
+                ):
                     source_id = aid
                     break
             if source_id and target_id and source_id != target_id:
@@ -1805,11 +1991,7 @@ def _detect_and_run_modal_analysis(state: Any) -> Optional[Dict[str, Any]]:
     return {
         "modal_results": results_count,
         "modalities_found": list(
-            {
-                m
-                for r in state.modal_analysis_results
-                for m in r.get("modalities", [])
-            }
+            {m for r in state.modal_analysis_results for m in r.get("modalities", [])}
         ),
     }
 
@@ -1889,8 +2071,9 @@ def _build_aspic_from_state(state: Any) -> Optional[Dict[str, Any]]:
             arg_ids = list(state.identified_arguments.keys())
             target = f.get("target_argument_id", "")
             target_text = f.get("target_argument", "")
-            if (target and target == (arg_ids[i] if i < len(arg_ids) else "")) or \
-               (target_text and target_text.lower()[:30] in desc.lower()):
+            if (target and target == (arg_ids[i] if i < len(arg_ids) else "")) or (
+                target_text and target_text.lower()[:30] in desc.lower()
+            ):
                 is_undermined = True
                 break
         if is_undermined:
@@ -1959,8 +2142,11 @@ def _run_belief_revision_from_state(state: Any) -> Optional[Dict[str, Any]]:
 
     # Collect beliefs that should be revised (targeted by fallacies)
     jtms_beliefs = getattr(state, "jtms_beliefs", {})
-    original_beliefs = [bdata.get("name", "") for bdata in jtms_beliefs.values()
-                        if bdata.get("valid", False)]
+    original_beliefs = [
+        bdata.get("name", "")
+        for bdata in jtms_beliefs.values()
+        if bdata.get("valid", False)
+    ]
     if not original_beliefs:
         return None
 

--- a/argumentation_analysis/plugins/fallacy_workflow_plugin.py
+++ b/argumentation_analysis/plugins/fallacy_workflow_plugin.py
@@ -200,7 +200,9 @@ class FallacyWorkflowPlugin:
         "obstruktion": "obstruction",
     }
 
-    def _map_fallacy_to_root_pk(self, fallacy_name: str, roots_index: Dict[str, str]) -> Optional[str]:
+    def _map_fallacy_to_root_pk(
+        self, fallacy_name: str, roots_index: Dict[str, str]
+    ) -> Optional[str]:
         """Map a free-text fallacy name to the closest root PK via keyword matching.
 
         Supports FR/EN/DE keywords via a three-pass strategy:
@@ -219,22 +221,56 @@ class FallacyWorkflowPlugin:
 
         root_keywords = {
             "authority": ["autorit", "autorität", "berufung auf"],
-            "ad hominem": ["ad hominem", "attaque", "personne", "personenangriff", "ad-personam"],
+            "ad hominem": [
+                "ad hominem",
+                "attaque",
+                "personne",
+                "personenangriff",
+                "ad-personam",
+            ],
             "straw man": ["paille", "distortion", "strohmann", "strohmann-argument"],
             "slippery slope": ["pente glissante", "dammbruch", "rückführung"],
             "emotion": ["émotion", "sentiment", "gefühl", "emotionale appellation"],
-            "false dilemma": ["faux dilemme", "dilemme", "entweder-oder", "schwarz-weiß"],
-            "hasty generalization": ["généralisation", "vorschnelle verallgemeinerung", "übergeneralisierung"],
-            "circular reasoning": ["circulaire", "pétition", "zirkelschluss", "zirkulär"],
+            "false dilemma": [
+                "faux dilemme",
+                "dilemme",
+                "entweder-oder",
+                "schwarz-weiß",
+            ],
+            "hasty generalization": [
+                "généralisation",
+                "vorschnelle verallgemeinerung",
+                "übergeneralisierung",
+            ],
+            "circular reasoning": [
+                "circulaire",
+                "pétition",
+                "zirkelschluss",
+                "zirkulär",
+            ],
             "red herring": ["hareng", "diversion", "roter hering", "nebenthema"],
             "tu quoque": ["tu quoque", "hypocrisie", "heuchlerisch"],
-            "guilt by association": ["association", "culpabilité", "schuld durch assoziation"],
-            "bandwagon": ["ad populum", "majeure", "mitläufereffekt", "mehrheitsargument"],
+            "guilt by association": [
+                "association",
+                "culpabilité",
+                "schuld durch assoziation",
+            ],
+            "bandwagon": [
+                "ad populum",
+                "majeure",
+                "mitläufereffekt",
+                "mehrheitsargument",
+            ],
             "tradition": ["tradition", "traditionsargument"],
             "non sequitur": ["non sequitur", "inconséquence", "nicht zwingend"],
             "poisoning the well": ["empoisonnement", "brunnenvergiftung"],
             "no true scotsman": ["vrai écossais", "wahrer schotte", "kein wahrer"],
-            "false cause": ["fausse cause", "causalité", "fehlschluss der ursache", "post hoc"],
+            "false cause": [
+                "fausse cause",
+                "causalité",
+                "fehlschluss der ursache",
+                "post hoc",
+            ],
             "loaded question": ["question chargée", "suggestivfrage", "fangfrage"],
             "manipulation": ["manipulation", "beeinflussung"],
             "appeal to fear": ["angst", "appell an die angst"],
@@ -770,7 +806,9 @@ class FallacyWorkflowPlugin:
             # Phase 1: Wide-net candidate selection (#578)
             candidate_pks = await self._wide_net_candidates(argument_text)
             if not candidate_pks:
-                self.logger.info("Wide-net produced no candidates — falling back to one-shot")
+                self.logger.info(
+                    "Wide-net produced no candidates — falling back to one-shot"
+                )
                 return await self._run_one_shot(argument_text)
 
             self.logger.info(
@@ -804,7 +842,10 @@ class FallacyWorkflowPlugin:
                 if isinstance(result, IdentifiedFallacy):
                     total_iterations += len(result.navigation_trace)
                     leaf_pk = result.fallacy_type
-                    if leaf_pk in seen_pks and seen_pks[leaf_pk].confidence >= result.confidence:
+                    if (
+                        leaf_pk in seen_pks
+                        and seen_pks[leaf_pk].confidence >= result.confidence
+                    ):
                         continue
                     seen_pks[leaf_pk] = result
                     identified = [r for r in identified if r.fallacy_type != leaf_pk]
@@ -856,7 +897,10 @@ class FallacyWorkflowPlugin:
                 file_handler.close()
 
     def _persist_trace(
-        self, trace_log_path: Optional[str], result: "FallacyAnalysisResult", argument_text: str
+        self,
+        trace_log_path: Optional[str],
+        result: "FallacyAnalysisResult",
+        argument_text: str,
     ) -> None:
         """Persist structured taxonomy traversal trace to JSON file."""
         if not trace_log_path:
@@ -868,15 +912,17 @@ class FallacyWorkflowPlugin:
                 parent_chain = []
                 if node and node.get("path"):
                     parent_chain = node["path"].split(" > ")
-                trace_entries.append({
-                    "taxonomy_node_id": fallacy.taxonomy_pk,
-                    "fallacy_type": fallacy.fallacy_type,
-                    "parent_chain": parent_chain,
-                    "navigation_trace": fallacy.navigation_trace,
-                    "decision_rationale": fallacy.explanation,
-                    "citation_excerpt": argument_text[:200],
-                    "confidence": fallacy.confidence,
-                })
+                trace_entries.append(
+                    {
+                        "taxonomy_node_id": fallacy.taxonomy_pk,
+                        "fallacy_type": fallacy.fallacy_type,
+                        "parent_chain": parent_chain,
+                        "navigation_trace": fallacy.navigation_trace,
+                        "decision_rationale": fallacy.explanation,
+                        "citation_excerpt": argument_text[:200],
+                        "confidence": fallacy.confidence,
+                    }
+                )
 
             trace_data = {
                 "exploration_method": result.exploration_method,
@@ -894,6 +940,44 @@ class FallacyWorkflowPlugin:
             self.logger.info(f"Trace persisted to {trace_log_path}")
         except Exception as e:
             self.logger.warning(f"Failed to persist trace: {e}")
+
+    def _match_taxonomy_name(self, text: str) -> str:
+        """Try to find a taxonomy fallacy name within free-form LLM text (#655 Track KK).
+
+        Returns the longest matching taxonomy name, or "" if nothing matches.
+        """
+        known_names: list[str] = []
+        for node in self.taxonomy_navigator.taxonomy_data:
+            for key in ("text_fr", "nom_vulgarisé"):
+                name = node.get(key, "")
+                if name and len(name) > 4:
+                    known_names.append(name)
+        # Also check common French fallacy names not in taxonomy
+        known_names.extend(
+            [
+                "Ad hominem",
+                "Appel à l'autorité",
+                "Pente glissante",
+                "Homme de paille",
+                "Faux dilemme",
+                "Pétition de principe",
+                "Appel à la tradition",
+                "Appel à la nouveauté",
+                "Généralisation hâtive",
+                "Fausse cause",
+                "Appel aux émotions",
+                "Changement de sujet",
+                "Fausse équivalence",
+                "Empoisonnement du puits",
+                "Appel à l'ignorance",
+            ]
+        )
+        text_lower = text.lower()
+        best = ""
+        for name in known_names:
+            if name.lower() in text_lower and len(name) > len(best):
+                best = name
+        return best
 
     def _build_compact_taxonomy(self, max_depth: int = 4) -> str:
         """Build a compact taxonomy representation (PK + name + path) to fit in context."""
@@ -944,43 +1028,56 @@ class FallacyWorkflowPlugin:
             )
             raw = str(response).strip()
 
-            # Try to parse structured response
+            # Try to parse structured JSON response
             try:
-                if "```json" in raw:
-                    raw = raw.split("```json")[1].split("```")[0]
-                elif "```" in raw:
-                    raw = raw.split("```")[1].split("```")[0]
-                start = raw.find("{")
-                end = raw.rfind("}") + 1
+                text_to_parse = raw
+                if "```json" in text_to_parse:
+                    text_to_parse = text_to_parse.split("```json")[1].split("```")[0]
+                elif "```" in text_to_parse:
+                    text_to_parse = text_to_parse.split("```")[1].split("```")[0]
+                start = text_to_parse.find("{")
+                end = text_to_parse.rfind("}") + 1
                 if start >= 0 and end > start:
-                    parsed = json.loads(raw[start:end])
-                    fallacy = IdentifiedFallacy(
-                        fallacy_type=parsed.get("fallacy_name", raw),
-                        taxonomy_pk=parsed.get("taxonomy_pk", ""),
-                        explanation=parsed.get("explanation", ""),
-                        confidence=float(parsed.get("confidence", 0.5)),
-                        navigation_trace=[],
-                    )
-                    result = FallacyAnalysisResult(
-                        fallacies=[fallacy],
-                        exploration_method="one_shot",
-                    )
-                    return result.model_dump_json(indent=2)
+                    parsed = json.loads(text_to_parse[start:end])
+                    fallacy_name = parsed.get("fallacy_name", "")
+                    if fallacy_name:
+                        fallacy = IdentifiedFallacy(
+                            fallacy_type=fallacy_name,
+                            taxonomy_pk=parsed.get("taxonomy_pk", ""),
+                            explanation=parsed.get("explanation", ""),
+                            confidence=float(parsed.get("confidence", 0.5)),
+                            navigation_trace=[],
+                        )
+                        result = FallacyAnalysisResult(
+                            fallacies=[fallacy],
+                            exploration_method="one_shot",
+                        )
+                        return result.model_dump_json(indent=2)
             except (json.JSONDecodeError, ValueError, TypeError):
                 pass
 
-            # Plain text fallback
-            fallacy = IdentifiedFallacy(
-                fallacy_type=raw[:200],
-                taxonomy_pk="",
-                explanation="One-shot identification (plain text response)",
-                confidence=0.3,
-                navigation_trace=[],
+            # Fallback: try to match a taxonomy name in the raw text (#655 Track KK).
+            matched_name = self._match_taxonomy_name(raw)
+            if matched_name:
+                fallacy = IdentifiedFallacy(
+                    fallacy_type=matched_name,
+                    taxonomy_pk="",
+                    explanation="One-shot identification (taxonomy name extracted from response)",
+                    confidence=0.35,
+                    navigation_trace=[],
+                )
+                result = FallacyAnalysisResult(
+                    fallacies=[fallacy], exploration_method="one_shot"
+                )
+                return result.model_dump_json(indent=2)
+
+            # No usable fallacy found — return empty rather than garbage
+            self.logger.warning(
+                "One-shot: could not extract usable fallacy name from response"
             )
-            result = FallacyAnalysisResult(
-                fallacies=[fallacy], exploration_method="one_shot"
+            return json.dumps(
+                {"fallacies": [], "exploration_method": "one_shot_no_match"}
             )
-            return result.model_dump_json(indent=2)
 
         except Exception as e:
             self.logger.error(f"One-shot fallback failed: {e}")

--- a/tests/unit/argumentation_analysis/test_track_kk_detection_recall.py
+++ b/tests/unit/argumentation_analysis/test_track_kk_detection_recall.py
@@ -1,0 +1,356 @@
+"""Tests for Track KK (#655): Detection recall — eliminate Type Inconnu + wide-net pass.
+
+Tests cover:
+  1. _is_usable_fallacy_type filter
+  2. _extract_fallacy_type multi-key extraction
+  3. Parent harness skips unusable types
+  4. Parent harness wide-net whole-text fusion
+  5. One-shot _match_taxonomy_name extraction
+"""
+
+import asyncio
+import pytest
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+
+def _get_harness_module():
+    from argumentation_analysis.orchestration import conversational_orchestrator as mod
+
+    return mod
+
+
+class TestIsUsableFallacyType:
+    """_is_usable_fallacy_type rejects empty/generic fallacy type names."""
+
+    def test_rejects_empty(self):
+        mod = _get_harness_module()
+        assert mod._is_usable_fallacy_type("") is False
+
+    def test_rejects_whitespace(self):
+        mod = _get_harness_module()
+        assert mod._is_usable_fallacy_type("   ") is False
+
+    def test_rejects_type_inconnu_variants(self):
+        mod = _get_harness_module()
+        for variant in ("Type Inconnu", "Type inconnu", "type inconnu", "TYPE INCONNU"):
+            assert mod._is_usable_fallacy_type(variant) is False
+
+    def test_rejects_unknown(self):
+        mod = _get_harness_module()
+        assert mod._is_usable_fallacy_type("unknown") is False
+        assert mod._is_usable_fallacy_type("Unknown") is False
+
+    def test_rejects_sophisme_inconnu(self):
+        mod = _get_harness_module()
+        assert mod._is_usable_fallacy_type("Sophisme inconnu") is False
+
+    def test_rejects_unknown_class_prefix(self):
+        mod = _get_harness_module()
+        assert mod._is_usable_fallacy_type("unknown_class_5") is False
+
+    def test_accepts_valid_names(self):
+        mod = _get_harness_module()
+        assert mod._is_usable_fallacy_type("Ad hominem") is True
+        assert mod._is_usable_fallacy_type("slippery slope") is True
+        assert mod._is_usable_fallacy_type("Empoisonnement du puits") is True
+
+
+class TestExtractFallacyType:
+    """_extract_fallacy_type tries multiple keys and validates."""
+
+    def test_prefers_fallacy_type(self):
+        mod = _get_harness_module()
+        d = {"fallacy_type": "Ad hominem", "type": "other", "nom": "third"}
+        assert mod._extract_fallacy_type(d) == "Ad hominem"
+
+    def test_falls_back_to_type(self):
+        mod = _get_harness_module()
+        d = {"type": "slippery slope", "nom": "third"}
+        assert mod._extract_fallacy_type(d) == "slippery slope"
+
+    def test_falls_back_to_nom(self):
+        mod = _get_harness_module()
+        d = {"nom": "Faux dilemme"}
+        assert mod._extract_fallacy_type(d) == "Faux dilemme"
+
+    def test_skips_unusable_value(self):
+        mod = _get_harness_module()
+        d = {"fallacy_type": "unknown", "type": "Ad hominem"}
+        assert mod._extract_fallacy_type(d) == "Ad hominem"
+
+    def test_returns_empty_when_all_unusable(self):
+        mod = _get_harness_module()
+        d = {"fallacy_type": "Type Inconnu", "type": "unknown", "nom": ""}
+        assert mod._extract_fallacy_type(d) == ""
+
+    def test_returns_empty_for_empty_dict(self):
+        mod = _get_harness_module()
+        assert mod._extract_fallacy_type({}) == ""
+
+    def test_ignores_non_string_values(self):
+        mod = _get_harness_module()
+        d = {"fallacy_type": 42, "type": None, "nom": "Ad hominem"}
+        assert mod._extract_fallacy_type(d) == "Ad hominem"
+
+
+class TestParentHarnessSkipsUnusable:
+    """Parent harness _run_parent_harness_fallback skips unusable types."""
+
+    @pytest.fixture()
+    def mock_invoke(self, monkeypatch):
+        """Mock the invoke_callables module to return controlled data."""
+        fake_module = type("FakeInvoke", (), {})()
+        fake_results = {
+            "per_arg": {
+                "fallacies": [
+                    {"fallacy_type": "Ad hominem", "explanation": "real"},
+                    {"fallacy_type": "Type Inconnu", "explanation": "bad"},
+                    {"type": "unknown", "explanation": "also bad"},
+                    {"fallacy_type": "slippery slope", "explanation": "good"},
+                ],
+                "exploration_method": "per_argument_parallel",
+            },
+            "whole_text": {"fallacies": []},
+        }
+
+        async def fake_per_arg(text, context):
+            return fake_results["per_arg"]
+
+        async def fake_whole_text(text, context):
+            return fake_results["whole_text"]
+
+        fake_module._invoke_hierarchical_fallacy_per_argument = fake_per_arg
+        fake_module._invoke_hierarchical_fallacy = fake_whole_text
+
+        import argumentation_analysis.orchestration.conversational_orchestrator as co_mod
+
+        original_import = co_mod.__dict__.get("__original_import__", __import__)
+
+        import importlib
+        import sys
+
+        monkeypatch.setitem(
+            sys.modules,
+            "argumentation_analysis.orchestration.invoke_callables",
+            fake_module,
+        )
+
+    def test_skips_unusable_types(self, mock_invoke):
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_parent_harness_fallback,
+        )
+
+        state = UnifiedAnalysisState("test text for harness")
+        result = asyncio.get_event_loop().run_until_complete(
+            _run_parent_harness_fallback("test text", state)
+        )
+        assert result is not None
+        assert result["fallacies_registered"] == 2
+        assert result["fallacies_skipped_unusable"] == 2
+
+    def test_only_valid_types_in_state(self, mock_invoke):
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_parent_harness_fallback,
+        )
+
+        state = UnifiedAnalysisState("test text for harness")
+        asyncio.get_event_loop().run_until_complete(
+            _run_parent_harness_fallback("test text", state)
+        )
+        fallacy_types = {v.get("type", "") for v in state.identified_fallacies.values()}
+        assert "Ad hominem" in fallacy_types
+        assert "slippery slope" in fallacy_types
+        assert "Type Inconnu" not in fallacy_types
+        assert "unknown" not in fallacy_types
+
+
+class TestParentHarnessWideNet:
+    """Wide-net whole-text pass adds extra fallacies not in per-argument results."""
+
+    @pytest.fixture()
+    def mock_invoke_with_widenet(self, monkeypatch):
+        fake_module = type("FakeInvoke", (), {})()
+
+        async def fake_per_arg(text, context):
+            return {
+                "fallacies": [
+                    {
+                        "fallacy_type": "Ad hominem",
+                        "explanation": "per-arg",
+                        "taxonomy_pk": "PK1",
+                    },
+                ],
+                "exploration_method": "per_argument_parallel",
+            }
+
+        async def fake_whole_text(text, context):
+            return {
+                "fallacies": [
+                    {
+                        "fallacy_type": "Appel à la tradition",
+                        "explanation": "whole-text only",
+                        "taxonomy_pk": "PK99",
+                    },
+                ],
+            }
+
+        fake_module._invoke_hierarchical_fallacy_per_argument = fake_per_arg
+        fake_module._invoke_hierarchical_fallacy = fake_whole_text
+
+        import sys
+
+        monkeypatch.setitem(
+            sys.modules,
+            "argumentation_analysis.orchestration.invoke_callables",
+            fake_module,
+        )
+
+    def test_wide_net_extras_counted(self, mock_invoke_with_widenet):
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_parent_harness_fallback,
+        )
+
+        state = UnifiedAnalysisState("A longer text " * 100)
+        result = asyncio.get_event_loop().run_until_complete(
+            _run_parent_harness_fallback("A longer text " * 100, state)
+        )
+        assert result is not None
+        assert result["wide_net_extras"] == 1
+        assert result["fallacies_registered"] == 2
+
+    def test_wide_net_deduplication(self, monkeypatch):
+        """Whole-text finding that duplicates per-arg is not double-counted."""
+        fake_module = type("FakeInvoke", (), {})()
+
+        async def fake_per_arg(text, context):
+            return {
+                "fallacies": [
+                    {
+                        "fallacy_type": "Ad hominem",
+                        "explanation": "per-arg",
+                        "taxonomy_pk": "PK1",
+                    },
+                ],
+                "exploration_method": "per_argument_parallel",
+            }
+
+        async def fake_whole_text(text, context):
+            return {
+                "fallacies": [
+                    {
+                        "fallacy_type": "Ad hominem",
+                        "explanation": "duplicate",
+                        "taxonomy_pk": "PK1",
+                    },
+                ],
+            }
+
+        fake_module._invoke_hierarchical_fallacy_per_argument = fake_per_arg
+        fake_module._invoke_hierarchical_fallacy = fake_whole_text
+
+        import sys
+
+        monkeypatch.setitem(
+            sys.modules,
+            "argumentation_analysis.orchestration.invoke_callables",
+            fake_module,
+        )
+
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_parent_harness_fallback,
+        )
+
+        state = UnifiedAnalysisState("A longer text " * 100)
+        result = asyncio.get_event_loop().run_until_complete(
+            _run_parent_harness_fallback("A longer text " * 100, state)
+        )
+        assert result["wide_net_extras"] == 0
+        assert result["fallacies_registered"] == 1
+
+
+class TestParentHarnessEmpty:
+    """Parent harness returns None when no fallacies found."""
+
+    def test_returns_none_on_empty(self, monkeypatch):
+        fake_module = type("FakeInvoke", (), {})()
+
+        async def fake_per_arg(text, context):
+            return {"fallacies": [], "exploration_method": "per_argument_parallel"}
+
+        async def fake_whole_text(text, context):
+            return {"fallacies": []}
+
+        fake_module._invoke_hierarchical_fallacy_per_argument = fake_per_arg
+        fake_module._invoke_hierarchical_fallacy = fake_whole_text
+
+        import sys
+
+        monkeypatch.setitem(
+            sys.modules,
+            "argumentation_analysis.orchestration.invoke_callables",
+            fake_module,
+        )
+
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_parent_harness_fallback,
+        )
+
+        state = UnifiedAnalysisState("short")
+        result = asyncio.get_event_loop().run_until_complete(
+            _run_parent_harness_fallback("short", state)
+        )
+        assert result is None
+
+
+class TestOneShotMatchTaxonomyName:
+    """_match_taxonomy_name extracts fallacy names from raw LLM text."""
+
+    @pytest.fixture()
+    def plugin_cls(self):
+        from argumentation_analysis.plugins.fallacy_workflow_plugin import (
+            FallacyWorkflowPlugin,
+        )
+
+        return FallacyWorkflowPlugin
+
+    def test_matches_common_fallacy_in_text(self, plugin_cls):
+        plugin = plugin_cls.__new__(plugin_cls)
+        plugin.taxonomy_navigator = type("TN", (), {"taxonomy_data": []})()
+        result = plugin._match_taxonomy_name(
+            "The fallacy here is clearly an Ad hominem attack"
+        )
+        assert result == "Ad hominem"
+
+    def test_matches_french_name(self, plugin_cls):
+        plugin = plugin_cls.__new__(plugin_cls)
+        plugin.taxonomy_navigator = type("TN", (), {"taxonomy_data": []})()
+        result = plugin._match_taxonomy_name("Il s'agit d'un Faux dilemme classique")
+        assert result == "Faux dilemme"
+
+    def test_returns_empty_for_no_match(self, plugin_cls):
+        plugin = plugin_cls.__new__(plugin_cls)
+        plugin.taxonomy_navigator = type("TN", (), {"taxonomy_data": []})()
+        result = plugin._match_taxonomy_name("nothing relevant here")
+        assert result == ""
+
+    def test_prefers_longer_match(self, plugin_cls):
+        plugin = plugin_cls.__new__(plugin_cls)
+        plugin.taxonomy_navigator = type("TN", (), {"taxonomy_data": []})()
+        text = "This is a Généralisation hâtive"
+        result = plugin._match_taxonomy_name(text)
+        assert "Généralisation hâtive" in result
+
+    def test_matches_taxonomy_node_name(self, plugin_cls):
+        plugin = plugin_cls.__new__(plugin_cls)
+        plugin.taxonomy_navigator = type(
+            "TN",
+            (),
+            {
+                "taxonomy_data": [
+                    {"text_fr": "Appel à l'autorité", "PK": "1", "depth": 2},
+                ]
+            },
+        )()
+        result = plugin._match_taxonomy_name("C'est un appel à l'autorité manifeste")
+        assert result == "Appel à l'autorité"


### PR DESCRIPTION
## Summary

Track KK (#655) — Detection recall improvements targeting the fallacy pipeline.

- **Filter unusable type names**: `_is_usable_fallacy_type()` and `_extract_fallacy_type()` helpers discard detections with empty, "Type Inconnu", "unknown", or "unknown_class_N" names before they enter state. Applied in `_run_parent_harness_fallback`.
- **Wide-net whole-text fusion pass**: After per-argument analysis, the parent harness now also runs `_invoke_hierarchical_fallacy` on the full text to capture framing/tonal fallacies that span multiple arguments. Deduplicates against per-argument results by `(taxonomy_pk, source)`.
- **One-shot taxonomy matching**: `_run_one_shot` in `fallacy_workflow_plugin.py` no longer emits raw LLM garbage as `fallacy_type`. `_match_taxonomy_name()` extracts a known taxonomy name from the response text. Returns empty fallacies when no usable name is found.

## Files changed

| File | Change |
|------|--------|
| `conversational_orchestrator.py` | Added `_is_usable_fallacy_type`, `_extract_fallacy_type`, wide-net pass in `_run_parent_harness_fallback` |
| `fallacy_workflow_plugin.py` | Added `_match_taxonomy_name`, rewrote `_run_one_shot` to never emit garbage types |
| `test_track_kk_detection_recall.py` | 24 new unit tests |

## Test plan

- [x] 24 new unit tests pass (filter, extraction, parent harness skip, wide-net, one-shot matching)
- [x] 47 existing DeepSynthesis + AGM source tests still pass (regression)
- [x] Black formatting applied
- [x] Privacy grep CLEAN (no source text, opaque IDs only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)