### PR TITLE
fix(convergence): wire JTMS signal in compute_argument_convergence — Track LL (#656)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -970,12 +970,18 @@ async def _invoke_jtms(input_text: str, context: Dict[str, Any]) -> Dict[str, An
             :80
         ]
 
-    arg_beliefs = [_text(a) for a in raw_args[:10]]
+    _raw_arg_texts = [_text(a) for a in raw_args[:10]]
     claim_beliefs = [_text(c) for c in raw_claims[:6]]
 
-    if not arg_beliefs and not claim_beliefs:
+    if not _raw_arg_texts and not claim_beliefs:
         sentences = [s.strip() for s in input_text.split(".") if len(s.strip()) > 10]
-        arg_beliefs = [s[:80] for s in sentences[:8]]
+        _raw_arg_texts = [s[:73] for s in sentences[:8]]
+
+    # Prefix each belief name with its arg_id so compute_argument_convergence
+    # can index JTMS signals by arg_id (startswith "arg_N:").  Without the
+    # prefix, names are raw text excerpts and the arg_id substring check never
+    # matches, silently dropping the JTMS convergence signal for every corpus.
+    arg_beliefs = [f"arg_{i+1}:{t[:66]}" for i, t in enumerate(_raw_arg_texts)]
 
     # ── Step 1: Add argument and claim beliefs (with ExtendedBelief metadata) ─
     for i, name in enumerate(arg_beliefs + claim_beliefs):
@@ -3050,7 +3056,9 @@ async def _invoke_hierarchical_fallacy_per_argument(
         arguments = _extract_arguments_for_parallel(input_text, context)
 
         if not arguments:
-            logger.info("No individual arguments extracted — falling back to single-text analysis")
+            logger.info(
+                "No individual arguments extracted — falling back to single-text analysis"
+            )
             return await _invoke_hierarchical_fallacy(input_text, context)
 
         logger.info(
@@ -3123,8 +3131,7 @@ async def _invoke_hierarchical_fallacy_per_argument(
 
         # Parallel execution via asyncio.gather
         tasks = [
-            _analyze_single_arg(arg_text, arg_id)
-            for arg_id, arg_text in arguments
+            _analyze_single_arg(arg_text, arg_id) for arg_id, arg_text in arguments
         ]
         per_arg_results = await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -3162,16 +3169,25 @@ async def _invoke_hierarchical_fallacy_per_argument(
                 continue
             seen[key] = f
             deduped = [
-                x for x in deduped
-                if (str(x.get("taxonomy_pk") or x.get("fallacy_type") or ""), str(x.get("source_arg_id") or "")) != key
+                x
+                for x in deduped
+                if (
+                    str(x.get("taxonomy_pk") or x.get("fallacy_type") or ""),
+                    str(x.get("source_arg_id") or ""),
+                )
+                != key
             ]
             deduped.append(f)
 
-        exploration_method = "+".join(sorted(methods_used)) if methods_used else "per_argument_parallel"
+        exploration_method = (
+            "+".join(sorted(methods_used)) if methods_used else "per_argument_parallel"
+        )
 
         logger.info(
             "Parent harness: %d fallacies from %d arguments (deduped to %d)",
-            len(all_fallacies), len(arguments), len(deduped),
+            len(all_fallacies),
+            len(arguments),
+            len(deduped),
         )
 
         return {
@@ -3193,6 +3209,7 @@ async def _invoke_hierarchical_fallacy_per_argument(
         }
     except Exception as e:
         import traceback
+
         logger.error(
             "Per-argument hierarchical fallacy detection failed:\n%s",
             traceback.format_exc(),
@@ -3241,7 +3258,11 @@ def _extract_arguments_for_parallel(
     # Source 3: split by paragraph breaks (heuristic fallback)
     paragraphs = [p.strip() for p in input_text.split("\n\n") if p.strip()]
     if len(paragraphs) >= 2:
-        return [(f"paragraph_{i+1}", p) for i, p in enumerate(paragraphs[:10]) if len(p) > 20]
+        return [
+            (f"paragraph_{i+1}", p)
+            for i, p in enumerate(paragraphs[:10])
+            if len(p) > 20
+        ]
 
     return []
 
@@ -3436,7 +3457,9 @@ async def _invoke_propositional_logic(
 
                 api_key = os.environ.get("OPENAI_API_KEY", "")
                 if api_key and input_text and len(input_text) > 100:
-                    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+                    base_url = os.environ.get(
+                        "OPENAI_BASE_URL", "https://api.openai.com/v1"
+                    )
                     model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
                     client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
@@ -3460,19 +3483,29 @@ async def _invoke_propositional_logic(
                     raw_atoms = props_data.get("propositions", [])
 
                     # Validate atoms: must be alphanumeric + underscore
-                    valid_atoms = [a for a in raw_atoms if re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", a)]
+                    valid_atoms = [
+                        a for a in raw_atoms if re.match(r"^[a-zA-Z_][a-zA-Z0-9_]*$", a)
+                    ]
                     if valid_atoms:
                         shared_atoms = valid_atoms
-                        logger.info(f"PL 2-pass Pass 1: {len(shared_atoms)} atoms extracted from full text")
+                        logger.info(
+                            f"PL 2-pass Pass 1: {len(shared_atoms)} atoms extracted from full text"
+                        )
 
                         # Store in state
-                        if state_obj is not None and hasattr(state_obj, "atomic_propositions"):
-                            source_id = context.get("source_metadata", {}).get("opaque_id", "default")
+                        if state_obj is not None and hasattr(
+                            state_obj, "atomic_propositions"
+                        ):
+                            source_id = context.get("source_metadata", {}).get(
+                                "opaque_id", "default"
+                            )
                             state_obj.atomic_propositions[source_id] = shared_atoms
 
                     # ── Pass 2: Per-argument formula generation with shared atoms ──
                     if shared_atoms and args:
-                        atoms_json = _json.dumps({"propositions": shared_atoms}, indent=2)
+                        atoms_json = _json.dumps(
+                            {"propositions": shared_atoms}, indent=2
+                        )
                         for arg_text in args[:6]:
                             pass2_prompt = (
                                 "You are an expert in propositional logic. Translate the text "
@@ -3488,7 +3521,9 @@ async def _invoke_propositional_logic(
                             try:
                                 pass2_resp = await client.chat.completions.create(
                                     model=model_id,
-                                    messages=[{"role": "user", "content": pass2_prompt}],
+                                    messages=[
+                                        {"role": "user", "content": pass2_prompt}
+                                    ],
                                 )
                                 pass2_raw = pass2_resp.choices[0].message.content or ""
                                 formulas_data = _parse_json_from_llm(pass2_raw)
@@ -3556,6 +3591,7 @@ async def _invoke_propositional_logic(
         from argumentation_analysis.agents.core.logic.pl_formula_sanitizer import (
             PLFormulaSanitizer,
         )
+
         sanitizer = PLFormulaSanitizer()
         san_result = sanitizer.sanitize_batch(formulas)
         if san_result.sanitized_formulas:
@@ -3661,7 +3697,9 @@ async def _invoke_fol_reasoning(
 
                 api_key = os.environ.get("OPENAI_API_KEY", "")
                 if api_key and input_text and len(input_text) > 100:
-                    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+                    base_url = os.environ.get(
+                        "OPENAI_BASE_URL", "https://api.openai.com/v1"
+                    )
                     model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
                     client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
@@ -3709,9 +3747,15 @@ async def _invoke_fol_reasoning(
                         )
 
                         # Store in state
-                        if state_obj is not None and hasattr(state_obj, "fol_shared_signature"):
-                            source_id = context.get("source_metadata", {}).get("opaque_id", "default")
-                            state_obj.fol_shared_signature[source_id] = fol_metadata_shared
+                        if state_obj is not None and hasattr(
+                            state_obj, "fol_shared_signature"
+                        ):
+                            source_id = context.get("source_metadata", {}).get(
+                                "opaque_id", "default"
+                            )
+                            state_obj.fol_shared_signature[source_id] = (
+                                fol_metadata_shared
+                            )
 
                         # ── Pass 2: Per-argument FOL formula generation ──
                         if args:
@@ -3733,9 +3777,13 @@ async def _invoke_fol_reasoning(
                                 try:
                                     pass2_resp = await client.chat.completions.create(
                                         model=model_id,
-                                        messages=[{"role": "user", "content": pass2_prompt}],
+                                        messages=[
+                                            {"role": "user", "content": pass2_prompt}
+                                        ],
                                     )
-                                    pass2_raw = pass2_resp.choices[0].message.content or ""
+                                    pass2_raw = (
+                                        pass2_resp.choices[0].message.content or ""
+                                    )
                                     formulas_data = _parse_json_from_llm(pass2_raw)
                                     arg_formulas = formulas_data.get("formulas", [])
                                     for f in arg_formulas:
@@ -3743,7 +3791,9 @@ async def _invoke_fol_reasoning(
                                         if f and f not in formulas:
                                             formulas.append(f)
                                 except Exception as arg_err:
-                                    logger.debug(f"FOL Pass 2 failed for argument: {arg_err}")
+                                    logger.debug(
+                                        f"FOL Pass 2 failed for argument: {arg_err}"
+                                    )
 
                             if formulas:
                                 logger.info(
@@ -4804,23 +4854,31 @@ async def _invoke_deep_synthesis(
             report = await agent.synthesize(state, source_metadata=source_meta)
         except (ValueError, Exception) as agent_err:
             # Agent init failed (no LLM service) — use static builders directly
-            logger.info(f"Agent instantiation failed ({agent_err}), using static builders")
+            logger.info(
+                f"Agent instantiation failed ({agent_err}), using static builders"
+            )
             source_meta = context.get("source_metadata", {})
             report = DeepSynthesisReport(
-                source_overview=DeepSynthesisAgent._build_source_overview(state, source_meta),
+                source_overview=DeepSynthesisAgent._build_source_overview(
+                    state, source_meta
+                ),
                 argument_map=DeepSynthesisAgent._build_argument_map(state),
                 fallacy_diagnoses=DeepSynthesisAgent._build_fallacy_diagnoses(state),
                 formal_findings=DeepSynthesisAgent._build_formal_findings(state),
                 dung_structure=DeepSynthesisAgent._build_dung_structure(state),
                 belief_retractions=DeepSynthesisAgent._build_belief_retractions(state),
                 counter_arguments=DeepSynthesisAgent._build_counter_arguments(state),
-                cross_text_parallels=DeepSynthesisAgent._build_cross_text_parallels(state),
+                cross_text_parallels=DeepSynthesisAgent._build_cross_text_parallels(
+                    state
+                ),
             )
             report.final_synthesis = await DeepSynthesisAgent._build_final_synthesis(
                 state, report, []
             )
             report.total_state_fields = DeepSynthesisAgent._count_state_fields(state)
-            report.sections_populated = DeepSynthesisAgent._count_populated_sections(report)
+            report.sections_populated = DeepSynthesisAgent._count_populated_sections(
+                report
+            )
 
         markdown = DeepSynthesisAgent.render_markdown(report)
 

--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -291,13 +291,17 @@ def compute_argument_convergence(state: Any) -> Dict[str, Dict[str, Any]]:
             signals.append(("contre-argument", str(counter_by_arg[arg_id])))
 
         # 4. JTMS belief retracted / invalid
+        # Beliefs are named "arg_N:<text_excerpt>" (see _invoke_jtms).  Use
+        # startswith for a precise match — substring check would false-positive
+        # on defeat beliefs and other arg_id occurrences in text.
+        jtms_prefix = f"{arg_id}:"
         if isinstance(jtms, dict):
             invalid = 0
             for _bid, bdata in jtms.items():
                 if not isinstance(bdata, dict):
                     continue
                 name = bdata.get("name", "")
-                if arg_id in name and bdata.get("valid") is False:
+                if name.startswith(jtms_prefix) and bdata.get("valid") is False:
                     invalid += 1
             if invalid:
                 signals.append(("JTMS retracte", str(invalid)))

--- a/tests/unit/argumentation_analysis/orchestration/test_invoke_jtms.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_invoke_jtms.py
@@ -54,8 +54,9 @@ class TestInvokeJTMS:
 
         assert result["undermined_count"] > 0
         assert result["fallacy_count"] == 1
-        # The argument belief should be invalid
-        arg_belief = result["beliefs"].get("He is wrong because he is biased")
+        # Belief names carry an "arg_N:" prefix so compute_argument_convergence
+        # can index JTMS signals by arg_id (startswith check).
+        arg_belief = result["beliefs"].get("arg_1:He is wrong because he is biased")
         assert arg_belief is not None
         assert arg_belief["valid"] is False
 
@@ -103,7 +104,9 @@ class TestInvokeJTMS:
         }
         result = await _invoke_jtms("text", context)
 
-        arg_belief = result["beliefs"].get("A well-structured argument with evidence")
+        arg_belief = result["beliefs"].get(
+            "arg_1:A well-structured argument with evidence"
+        )
         assert arg_belief is not None
         assert "quality" in arg_belief
         assert arg_belief["quality"]["quality_score"] == 7.5

--- a/tests/unit/argumentation_analysis/test_track_ll_convergence_depth.py
+++ b/tests/unit/argumentation_analysis/test_track_ll_convergence_depth.py
@@ -1,0 +1,304 @@
+"""Tests for Track LL — JTMS convergence depth wiring fix (#656).
+
+Root-cause investigation summary:
+- compute_argument_convergence signal 4 (JTMS) checked ``arg_id in belief_name``
+  where belief_name was a raw text excerpt.  ``arg_id`` strings ("arg_1" etc.)
+  almost never appear in argument text, so the JTMS signal was a dead letter for
+  every corpus.
+- Fix: _invoke_jtms now names arg beliefs "arg_N:<text_excerpt[:66]>" so
+  compute_argument_convergence's startswith check ``name.startswith("arg_N:")``
+  fires correctly when a belief is retracted.
+
+Tests cover:
+1. JTMS signal fires when a belief prefixed with "arg_N:" is retracted
+2. No false positives from defeat beliefs or ATMS entries
+3. Fallback-sentence arg beliefs also carry the prefix
+4. _invoke_jtms output keys carry the prefix (integration with state writers)
+5. Convergence depth ≥3 achievable: fallacy + quality + JTMS for the same arg
+"""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from argumentation_analysis.plugins.narrative_synthesis_plugin import (
+    compute_argument_convergence,
+)
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_JTMS_WEAK_THRESHOLD = 5.0  # from QUALITY_WEAK_THRESHOLD in plugin
+
+
+def _state_with_jtms_retracted(arg_id: str, belief_text: str) -> SimpleNamespace:
+    """Minimal state: one arg, one retracted JTMS belief using the new naming."""
+    return SimpleNamespace(
+        identified_arguments={arg_id: "Some argument description"},
+        identified_fallacies={},
+        argument_quality_scores={},
+        counter_arguments=[],
+        jtms_beliefs={
+            "jtms_0001": {
+                "name": f"{arg_id}:{belief_text[:66]}",
+                "valid": False,
+                "justifications": [],
+            }
+        },
+        dung_frameworks={},
+    )
+
+
+def _state_with_jtms_valid(arg_id: str, belief_text: str) -> SimpleNamespace:
+    """State: JTMS belief present but still valid (should NOT trigger signal)."""
+    return SimpleNamespace(
+        identified_arguments={arg_id: "Some argument"},
+        identified_fallacies={},
+        argument_quality_scores={},
+        counter_arguments=[],
+        jtms_beliefs={
+            "jtms_0001": {
+                "name": f"{arg_id}:{belief_text[:66]}",
+                "valid": True,
+                "justifications": [],
+            }
+        },
+        dung_frameworks={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# JTMS signal tests
+# ---------------------------------------------------------------------------
+
+
+class TestJTMSConvergenceSignal:
+    """compute_argument_convergence — JTMS signal (signal 4)."""
+
+    def test_jtms_signal_fires_for_retracted_prefixed_belief(self):
+        """Belief 'arg_1:...' with valid=False → JTMS signal fires."""
+        state = _state_with_jtms_retracted("arg_1", "The policy increases inequality")
+        result = compute_argument_convergence(state)
+        assert "arg_1" in result
+        methods = [m for m, _ in result["arg_1"]["signals"]]
+        assert "JTMS retracte" in methods
+
+    def test_jtms_signal_absent_when_valid(self):
+        """Belief valid=True → JTMS signal should NOT fire."""
+        state = _state_with_jtms_valid("arg_1", "The policy increases inequality")
+        result = compute_argument_convergence(state)
+        if "arg_1" in result:
+            methods = [m for m, _ in result["arg_1"]["signals"]]
+            assert "JTMS retracte" not in methods
+
+    def test_jtms_no_false_positive_defeat_belief(self):
+        """Defeat belief 'defeat:fallacy→arg_1:...' should NOT match arg_1 signal."""
+        state = SimpleNamespace(
+            identified_arguments={"arg_1": "Some argument"},
+            identified_fallacies={},
+            argument_quality_scores={},
+            counter_arguments=[],
+            jtms_beliefs={
+                "jtms_d1": {
+                    # Defeat belief: name starts with "defeat:", not "arg_1:"
+                    "name": "defeat:ad_hominem→arg_1:The policy inc",
+                    "valid": False,
+                    "justifications": [],
+                }
+            },
+            dung_frameworks={},
+        )
+        result = compute_argument_convergence(state)
+        # No JTMS signal because the defeat belief does NOT start with "arg_1:"
+        if "arg_1" in result:
+            methods = [m for m, _ in result["arg_1"]["signals"]]
+            assert "JTMS retracte" not in methods
+
+    def test_jtms_no_false_positive_other_arg_in_text(self):
+        """Belief 'arg_2:... mentions arg_1 ...' should NOT match arg_1."""
+        state = SimpleNamespace(
+            identified_arguments={"arg_1": "A", "arg_2": "B"},
+            identified_fallacies={},
+            argument_quality_scores={},
+            counter_arguments=[],
+            jtms_beliefs={
+                "jtms_0001": {
+                    # arg_2's belief text happens to mention "arg_1"
+                    "name": "arg_2:The argument against arg_1 positio",
+                    "valid": False,
+                    "justifications": [],
+                }
+            },
+            dung_frameworks={},
+        )
+        result = compute_argument_convergence(state)
+        # arg_1 should NOT get a JTMS signal (belief starts with "arg_2:")
+        if "arg_1" in result:
+            methods = [m for m, _ in result["arg_1"]["signals"]]
+            assert "JTMS retracte" not in methods
+        # arg_2 SHOULD get the JTMS signal
+        assert "arg_2" in result
+        assert "JTMS retracte" in [m for m, _ in result["arg_2"]["signals"]]
+
+    def test_jtms_no_false_positive_atms_belief(self):
+        """ATMS:name beliefs should not match any arg_id."""
+        state = SimpleNamespace(
+            identified_arguments={"arg_1": "A"},
+            identified_fallacies={},
+            argument_quality_scores={},
+            counter_arguments=[],
+            jtms_beliefs={
+                "jtms_a1": {
+                    "name": "ATMS:node_0",
+                    "valid": False,
+                    "justifications": [],
+                },
+                "jtms_a2": {
+                    "name": "ATMS:summary",
+                    "valid": True,
+                    "justifications": [],
+                },
+            },
+            dung_frameworks={},
+        )
+        result = compute_argument_convergence(state)
+        if "arg_1" in result:
+            methods = [m for m, _ in result["arg_1"]["signals"]]
+            assert "JTMS retracte" not in methods
+
+
+# ---------------------------------------------------------------------------
+# Convergence depth ≥3 with JTMS fix
+# ---------------------------------------------------------------------------
+
+
+class TestConvergenceDepthImprovement:
+    """After fix: fallacy + quality + JTMS = convergence ≥3 for same arg."""
+
+    def test_three_signals_achievable_with_jtms(self):
+        """Combining fallacy + quality + JTMS produces score ≥3 for arg_1."""
+        state = UnifiedAnalysisState("Test discourse.")
+        state.add_argument("A rhetorically weak argument with low quality.")
+
+        # Signal 1: fallacy targeting arg_1
+        state.add_fallacy("ad_hominem", "Attacks the person, not the idea.", "arg_1")
+
+        # Signal 2: low quality score
+        state.add_quality_score("arg_1", {"clarte": 1.5, "coherence": 2.0}, 1.8)
+
+        # Signal 4: JTMS belief retracted — using the new "arg_N:..." naming
+        state.add_jtms_belief(
+            "arg_1:A rhetorically weak argument with low",
+            valid=False,
+            justifications=["FALLACY:ad_hominem retracted it"],
+        )
+
+        result = compute_argument_convergence(state)
+        assert "arg_1" in result
+        score = result["arg_1"]["score"]
+        assert score >= 3, f"Expected convergence ≥3, got {score}"
+        methods = [m for m, _ in result["arg_1"]["signals"]]
+        assert "sophisme" in methods
+        assert "qualite faible" in methods
+        assert "JTMS retracte" in methods
+
+    def test_four_signals_achievable_with_jtms_and_dung(self):
+        """fallacy + quality + JTMS + Dung = convergence ≥4."""
+        state = UnifiedAnalysisState("Multi-signal test discourse.")
+        state.add_argument("A weak argument.")
+
+        state.add_fallacy("straw_man", "Distorts the position.", "arg_1")
+        state.add_quality_score("arg_1", {"clarte": 2.0}, 2.0)
+        state.add_jtms_belief(
+            "arg_1:A weak argument.",
+            valid=False,
+            justifications=["retracted by fallacy"],
+        )
+        state.add_dung_framework(
+            "test_af",
+            arguments=["fallacy_straw_man", "arg_1"],
+            attacks=[["fallacy_straw_man", "arg_1"]],
+            extensions={"grounded": ["fallacy_straw_man"]},
+        )
+
+        result = compute_argument_convergence(state)
+        assert "arg_1" in result
+        assert result["arg_1"]["score"] >= 4
+
+
+# ---------------------------------------------------------------------------
+# _invoke_jtms output key naming
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeJTMSBeliefNaming:
+    """Verify _invoke_jtms output uses "arg_N:..." keys for arg beliefs."""
+
+    async def test_arg_beliefs_carry_prefix(self):
+        """Arg beliefs in output dict start with 'arg_N:' prefix."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_jtms
+
+        context = {
+            "phase_extract_output": {
+                "arguments": [
+                    {"text": "First argument text"},
+                    {"text": "Second argument text"},
+                ],
+                "claims": [],
+            }
+        }
+        result = await _invoke_jtms("input", context)
+
+        assert "arg_1:First argument text" in result["beliefs"]
+        assert "arg_2:Second argument text" in result["beliefs"]
+
+    async def test_retracted_belief_carries_prefix(self):
+        """Retracted arg belief key starts with 'arg_N:' after fallacy retraction."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_jtms
+
+        context = {
+            "phase_extract_output": {
+                "arguments": [{"text": "A biased argument"}],
+                "claims": [],
+            },
+            "phase_hierarchical_fallacy_output": {
+                "fallacies": [{"fallacy_type": "bias", "explanation": "biased"}]
+            },
+        }
+        result = await _invoke_jtms("input", context)
+
+        # The arg belief must use the new prefixed naming
+        belief_key = "arg_1:A biased argument"
+        assert belief_key in result["beliefs"]
+        assert result["beliefs"][belief_key]["valid"] is False
+
+    async def test_claim_beliefs_unchanged(self):
+        """Claim beliefs do NOT get the arg_N prefix — only arg beliefs do."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_jtms
+
+        context = {
+            "phase_extract_output": {
+                "arguments": [{"text": "Premise one"}],
+                "claims": [{"text": "Conclusion statement"}],
+            }
+        }
+        result = await _invoke_jtms("input", context)
+
+        # Claims are not prefixed
+        assert "Conclusion statement" in result["beliefs"]
+        # Arg IS prefixed
+        assert "arg_1:Premise one" in result["beliefs"]
+
+    async def test_sentence_fallback_beliefs_carry_prefix(self):
+        """When no args from upstream, sentence-split beliefs are also prefixed."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_jtms
+
+        context = {"phase_extract_output": {"arguments": [], "claims": []}}
+        text = "First sentence here. Second sentence here."
+        result = await _invoke_jtms(text, context)
+
+        # At least one belief should carry the arg_N: prefix
+        prefixed = [k for k in result["beliefs"] if k.startswith("arg_")]
+        assert len(prefixed) >= 1


### PR DESCRIPTION
## Summary

- **Root cause**: `_invoke_jtms` named arg beliefs as raw text excerpts (80-char slices), so the `arg_id in name` substring check in `compute_argument_convergence` (signal 4) never matched — JTMS signal was silently dropped for **every corpus**
- **Fix**: prefix each arg belief key with `arg_{i+1}:` in `_invoke_jtms`; update convergence check to `name.startswith(f"{arg_id}:")` to avoid false positives from defeat beliefs (`defeat:fallacy→arg_1:...`) and ATMS entries
- **Tests**: updated 2 existing tests in `test_invoke_jtms.py`; added 11 new tests in `test_track_ll_convergence_depth.py` covering signal firing, false-positive guards, and convergence depth ≥3

## Technical detail

```
Before: arg_beliefs = [text[:80], ...]  # raw text
        check: arg_id in name            # "arg_1" never in "The policy increases..."

After:  arg_beliefs = [f"arg_{i+1}:{t[:66]}", ...]  # prefixed
        check: name.startswith(f"{arg_id}:")          # exact match
```

Defeat beliefs and ATMS entries do not start with `arg_N:` — no false positives.

## Test plan

- [x] `pytest tests/unit/argumentation_analysis/test_track_ll_convergence_depth.py` — 11 tests pass
- [x] `pytest tests/unit/argumentation_analysis/orchestration/test_invoke_jtms.py` — 8 tests pass
- [x] `black --check` — clean
- [x] `flake8` — clean
- [x] Privacy grep — clean

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)