### PR TITLE
feat(synthesis): adjudication section grounded vs claimed fallacy families — Track NN (#659)

### DIFF
--- a/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
+++ b/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
@@ -135,6 +135,11 @@ class DeepSynthesisAgent(BaseAgent):
         # Empty when no kernel/verdicts; renderer falls back to template statements.
         report.convergence_prose = await self._llm_convergence_prose(state)
 
+        # Adjudication table (Track NN #659) — grounded vs claimed families.
+        report.adjudication_table = self._build_adjudication_table(
+            report.fallacy_diagnoses, report.convergent_verdicts
+        )
+
         # Section 9 — final synthesis (tries LLM, falls back to template)
         try:
             thesis = await self._llm_synthesis(report)
@@ -681,6 +686,20 @@ class DeepSynthesisAgent(BaseAgent):
                 "the argumentative structure resists cross-method scrutiny._\n"
             )
 
+        # Adjudication (Track NN #659) — grounded vs claimed families
+        sections.append("## Adjudication: Claimed vs Grounded Fallacy Families\n")
+        if report.adjudication_table:
+            sections.append("| Family | Status | Evidence |")
+            sections.append("|--------|--------|----------|")
+            for row in report.adjudication_table:
+                icon = "✅" if row["status"] == "grounded" else "⚠️"
+                sections.append(
+                    f"| {row['family']} | {icon} {row['status']} | {row['evidence']} |"
+                )
+            sections.append("")
+        else:
+            sections.append("_No fallacy families to adjudicate._\n")
+
         # S9 — Final synthesis
         sections.append(
             report.final_synthesis
@@ -871,6 +890,56 @@ class DeepSynthesisAgent(BaseAgent):
         if report.final_synthesis:
             n += 1
         return n
+
+    @staticmethod
+    def _build_adjudication_table(
+        fallacy_diagnoses: List[FallacyDiagnosis],
+        convergent_verdicts: List[ConvergentVerdict],
+    ) -> List[Dict[str, str]]:
+        """Track NN #659 — adjudicate claimed vs grounded fallacy families.
+
+        For each detected family, decide:
+        - 'grounded': at least one per-argument detection targets an argument
+          that also appears in a convergent verdict (cross-method confirmed).
+        - 'claimed': detected, but no per-argument anchor with convergence
+          (wide-net only, or per-arg but without cross-method support).
+        """
+        converged_args: Dict[str, ConvergentVerdict] = {
+            v.arg_id: v for v in convergent_verdicts
+        }
+        family_entries: Dict[str, List[FallacyDiagnosis]] = {}
+        for fd in fallacy_diagnoses:
+            family_entries.setdefault(fd.family, []).append(fd)
+
+        rows: List[Dict[str, str]] = []
+        for family in sorted(family_entries):
+            entries = family_entries[family]
+            grounded_args = [
+                a for fd in entries for a in fd.impacted_args if a in converged_args
+            ]
+            if grounded_args:
+                best = grounded_args[0]
+                v = converged_args[best]
+                evidence = (
+                    f"`{best}` — {v.score} independent method(s): "
+                    f"{', '.join(v.methods)}"
+                )
+                rows.append(
+                    {"family": family, "status": "grounded", "evidence": evidence}
+                )
+            else:
+                per_arg_ids = sorted({a for fd in entries for a in fd.impacted_args})
+                if per_arg_ids:
+                    evidence = (
+                        f"per-argument detection "
+                        f"(`{'`, `'.join(per_arg_ids)}`) — no cross-method confirmation"
+                    )
+                else:
+                    evidence = "wide-net (whole-text) detection only — no argument-level anchor"
+                rows.append(
+                    {"family": family, "status": "claimed", "evidence": evidence}
+                )
+        return rows
 
     async def _llm_convergence_prose(self, state: Any) -> str:
         """Track GG #644 — LLM prose for the convergence section.

--- a/argumentation_analysis/agents/core/synthesis/deep_synthesis_models.py
+++ b/argumentation_analysis/agents/core/synthesis/deep_synthesis_models.py
@@ -134,6 +134,9 @@ class DeepSynthesisReport:
     # Empty when no kernel is configured or no verdicts exist; renderer then
     # falls back to the template verdict statements.
     convergence_prose: str = ""
+    # Adjudication table (Track NN #659) — grounded vs claimed fallacy families.
+    # Each entry: {"family": str, "status": "grounded"|"claimed", "evidence": str}
+    adjudication_table: List[Dict[str, str]] = field(default_factory=list)
     # Metadata
     report_timestamp: str = field(default_factory=lambda: datetime.now().isoformat())
     total_state_fields: int = 0
@@ -154,6 +157,7 @@ class DeepSynthesisReport:
             "convergent_verdicts": [v.__dict__ for v in self.convergent_verdicts],
             "convergence_conclusion": self.convergence_conclusion,
             "convergence_prose": self.convergence_prose,
+            "adjudication_table": self.adjudication_table,
             "report_timestamp": self.report_timestamp,
             "total_state_fields": self.total_state_fields,
             "sections_populated": self.sections_populated,

--- a/tests/unit/argumentation_analysis/test_track_nn_adjudication.py
+++ b/tests/unit/argumentation_analysis/test_track_nn_adjudication.py
@@ -1,0 +1,190 @@
+"""Tests for Track NN — Narrative d'adjudication (#659).
+
+Verifies that _build_adjudication_table correctly classifies fallacy families
+as 'grounded' (per-argument detection + cross-method convergence) or 'claimed'
+(detected but not backed by convergence), and that render_markdown includes
+the adjudication section in the generated report.
+"""
+
+import pytest
+
+from argumentation_analysis.agents.core.synthesis.deep_synthesis_agent import (
+    DeepSynthesisAgent,
+)
+from argumentation_analysis.agents.core.synthesis.deep_synthesis_models import (
+    ConvergentVerdict,
+    DeepSynthesisReport,
+    FallacyDiagnosis,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_verdict(arg_id: str, score: int = 3, methods=None) -> ConvergentVerdict:
+    return ConvergentVerdict(
+        arg_id=arg_id,
+        score=score,
+        methods=methods or ["sophisme", "qualite faible", "JTMS retracte"],
+        statement=f"{arg_id} flagged by {score} methods.",
+    )
+
+
+def _make_fallacy(
+    fid: str, family: str, impacted_args: list | None = None
+) -> FallacyDiagnosis:
+    return FallacyDiagnosis(
+        fallacy_id=fid,
+        family=family,
+        taxonomy_path=f"fallacy/{family}/type",
+        textual_span="Some textual span.",
+        commentary="Some commentary.",
+        impacted_args=impacted_args or [],
+    )
+
+
+# ---------------------------------------------------------------------------
+# _build_adjudication_table unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAdjudicationTable:
+    """DeepSynthesisAgent._build_adjudication_table."""
+
+    def test_grounded_family_when_arg_in_verdict(self):
+        """Family is 'grounded' when its per-arg fallacy targets a converged arg."""
+        diagnoses = [_make_fallacy("f1", "relevance", ["arg_1"])]
+        verdicts = [_make_verdict("arg_1", score=3)]
+        table = DeepSynthesisAgent._build_adjudication_table(diagnoses, verdicts)
+        assert len(table) == 1
+        row = table[0]
+        assert row["family"] == "relevance"
+        assert row["status"] == "grounded"
+        assert "arg_1" in row["evidence"]
+        assert "3" in row["evidence"]
+
+    def test_claimed_wide_net_family(self):
+        """Family with no impacted_args (wide-net) is 'claimed'."""
+        diagnoses = [_make_fallacy("f1", "causal", [])]
+        verdicts = [_make_verdict("arg_1")]
+        table = DeepSynthesisAgent._build_adjudication_table(diagnoses, verdicts)
+        assert len(table) == 1
+        row = table[0]
+        assert row["family"] == "causal"
+        assert row["status"] == "claimed"
+        assert "whole-text" in row["evidence"]
+
+    def test_claimed_per_arg_no_convergence(self):
+        """Per-arg fallacy targeting an arg not in any convergent verdict → 'claimed'."""
+        diagnoses = [_make_fallacy("f1", "presumption", ["arg_5"])]
+        verdicts = [_make_verdict("arg_1")]  # arg_5 not in verdicts
+        table = DeepSynthesisAgent._build_adjudication_table(diagnoses, verdicts)
+        assert len(table) == 1
+        row = table[0]
+        assert row["status"] == "claimed"
+        assert "arg_5" in row["evidence"]
+        assert "no cross-method" in row["evidence"]
+
+    def test_empty_inputs(self):
+        """No diagnoses → empty table."""
+        table = DeepSynthesisAgent._build_adjudication_table([], [])
+        assert table == []
+
+    def test_no_verdicts(self):
+        """All families 'claimed' when no convergent verdicts."""
+        diagnoses = [
+            _make_fallacy("f1", "relevance", ["arg_1"]),
+            _make_fallacy("f2", "causal", []),
+        ]
+        table = DeepSynthesisAgent._build_adjudication_table(diagnoses, [])
+        assert all(r["status"] == "claimed" for r in table)
+
+    def test_multiple_families_mixed(self):
+        """Mixed: one grounded, one claimed (per-arg no convergence), one wide-net."""
+        diagnoses = [
+            _make_fallacy("f1", "relevance", ["arg_1"]),  # grounded
+            _make_fallacy("f2", "presumption", ["arg_9"]),  # per-arg, no convergence
+            _make_fallacy("f3", "inductive", []),  # wide-net
+        ]
+        verdicts = [_make_verdict("arg_1")]
+        table = DeepSynthesisAgent._build_adjudication_table(diagnoses, verdicts)
+        assert len(table) == 3
+        statuses = {r["family"]: r["status"] for r in table}
+        assert statuses["relevance"] == "grounded"
+        assert statuses["presumption"] == "claimed"
+        assert statuses["inductive"] == "claimed"
+
+    def test_family_picks_best_grounded_arg(self):
+        """When a family has multiple diagnoses, the first converged arg is cited."""
+        diagnoses = [
+            _make_fallacy("f1", "relevance", ["arg_3"]),  # not converged
+            _make_fallacy("f2", "relevance", ["arg_1"]),  # converged
+        ]
+        verdicts = [_make_verdict("arg_1", score=4)]
+        table = DeepSynthesisAgent._build_adjudication_table(diagnoses, verdicts)
+        assert len(table) == 1
+        row = table[0]
+        assert row["status"] == "grounded"
+        assert "arg_1" in row["evidence"]
+        assert "4" in row["evidence"]
+
+    def test_families_sorted_alphabetically(self):
+        """Families appear in alphabetical order."""
+        diagnoses = [
+            _make_fallacy("f1", "relevance", []),
+            _make_fallacy("f2", "causal", []),
+            _make_fallacy("f3", "ambiguity", []),
+        ]
+        table = DeepSynthesisAgent._build_adjudication_table(diagnoses, [])
+        families = [r["family"] for r in table]
+        assert families == sorted(families)
+
+
+# ---------------------------------------------------------------------------
+# render_markdown integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMarkdownAdjudicationSection:
+    """render_markdown includes Adjudication section."""
+
+    def _report_with_adjudication(self, table):
+        report = DeepSynthesisReport()
+        report.adjudication_table = table
+        return report
+
+    def test_adjudication_section_present_in_markdown(self):
+        """render_markdown always contains the Adjudication heading."""
+        report = self._report_with_adjudication([])
+        md = DeepSynthesisAgent.render_markdown(report)
+        assert "Adjudication" in md
+
+    def test_grounded_family_rendered_with_checkmark(self):
+        """Grounded family renders with ✅ icon."""
+        table = [
+            {
+                "family": "relevance",
+                "status": "grounded",
+                "evidence": "arg_1 — 3 methods",
+            }
+        ]
+        report = self._report_with_adjudication(table)
+        md = DeepSynthesisAgent.render_markdown(report)
+        assert "✅" in md
+        assert "relevance" in md
+        assert "arg_1" in md
+
+    def test_claimed_family_rendered_with_warning(self):
+        """Claimed family renders with ⚠️ icon."""
+        table = [{"family": "causal", "status": "claimed", "evidence": "wide-net only"}]
+        report = self._report_with_adjudication(table)
+        md = DeepSynthesisAgent.render_markdown(report)
+        assert "⚠️" in md
+        assert "causal" in md
+
+    def test_empty_adjudication_table_renders_placeholder(self):
+        """Empty table renders placeholder text."""
+        report = self._report_with_adjudication([])
+        md = DeepSynthesisAgent.render_markdown(report)
+        assert "No fallacy families to adjudicate" in md


### PR DESCRIPTION
## Summary

- Adds `_build_adjudication_table(fallacy_diagnoses, convergent_verdicts)` to `DeepSynthesisAgent`: for each detected family, classifies as **grounded** (per-arg fallacy + cross-method convergence) or **claimed** (wide-net only, or per-arg without convergence confirmation)
- Adds `adjudication_table: List[Dict]` field to `DeepSynthesisReport`, serialised in `to_dict()`
- Renders a markdown table between Convergent Verdicts and S9, with ✅/⚠️ icons — the jury sees at a glance which families survive the anchored examination vs which are ungrounded name-drops

## Design

```
Grounded = family has per-arg fallacy targeting arg_X AND arg_X is in convergent_verdicts
Claimed  = detected but no such anchor:
           - wide-net (whole_text) only → "wide-net detection only — no argument-level anchor"
           - per-arg but not converged → "per-arg detection — no cross-method confirmation"
```

This distinguishes the pipeline's adjudication from 0-shot name-dropping: a 0-shot can claim any family, the pipeline proves grounding by cross-method convergence.

## Files

| File | Change |
|------|--------|
| `deep_synthesis_agent.py` | `_build_adjudication_table` static method + wiring in `synthesize()` + rendering in `render_markdown()` |
| `deep_synthesis_models.py` | `adjudication_table` field added to `DeepSynthesisReport` + `to_dict()` |
| `test_track_nn_adjudication.py` | 12 new tests (NEW FILE) |

## Test plan

- [x] 12 unit tests pass: grounded/claimed classification, wide-net vs per-arg, empty inputs, no verdicts, mixed families, alphabetical ordering, render_markdown integration
- [x] `black --check` clean
- [x] `flake8 --max-line-length=120` clean
- [x] Privacy grep clean

Closes #659

🤖 Generated with [Claude Code](https://claude.com/claude-code)