### PR TITLE
feat(synthesis): substantive convergent insight paragraph — Track QQ (#667)

### DIFF
--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -316,6 +316,57 @@ def compute_argument_convergence(state: Any) -> Dict[str, Dict[str, Any]]:
     return result
 
 
+def _build_substantive_insight(
+    arg_id: str,
+    score: int,
+    method_phrases: List[str],
+    data: Dict[str, Any],
+) -> str:
+    """Build a substantive insight paragraph for high-convergence verdicts (>=3 methods).
+
+    Produces a conclusion anchored in the actual signals: names the argument,
+    lists the converging methods, and states WHY the cross-method agreement
+    makes the argument's weakness over-determined rather than a single-method
+    opinion.
+    """
+    joined = ", ".join(method_phrases)
+
+    signal_reasons = []
+    for method, detail in data["signals"]:
+        if method == "sophisme":
+            signal_reasons.append(
+                f"la detection rhetorique a identifie un probleme ({detail})"
+            )
+        elif method == "qualite faible":
+            signal_reasons.append(
+                f"le scoring de qualite signale une faiblesse ({detail})"
+            )
+        elif method == "contre-argument":
+            signal_reasons.append("un contre-argument solide a ete oppose")
+        elif method == "JTMS retracte":
+            signal_reasons.append(
+                "le systeme de maintenance de verite (JTMS) a retracte "
+                "la croyance associee"
+            )
+        elif method == "rejet Dung":
+            signal_reasons.append(
+                f"l'analyse argumentative abstraite (Dung) rejette l'argument "
+                f"({detail})"
+            )
+
+    reasons_text = " ; en outre, ".join(signal_reasons)
+
+    return (
+        f"**Insight convergent sur {arg_id}** : {score} methodes independantes "
+        f"concourent a signaler cet argument comme faible ({joined}). "
+        f"Cette faiblesse est sur-determinee, et non le produit d'une seule "
+        f"perspective : {reasons_text}. "
+        f"Un tel accord inter-methodes est inaccessible a une analyse "
+        f"LLM monotone et constitue un insight emergent propre au systeme "
+        f"multi-agents."
+    )
+
+
 def build_convergent_synthesis(state: Any) -> Dict[str, Any]:
     """Build a spectacular synthesis surfacing cross-dimensional convergence.
 
@@ -350,12 +401,17 @@ def build_convergent_synthesis(state: Any) -> Dict[str, Any]:
             else:
                 method_phrases.append(method)
         joined = ", ".join(method_phrases)
-        insights.append(
-            f"**Verdict convergent sur {arg_id}** : {data['score']} methodes "
-            f"independantes concourent a le signaler ({joined}). "
-            f"Cette convergence inter-perspectives est inaccessible a une passe "
-            f"LLM unique."
-        )
+        score = data["score"]
+        if score >= 3:
+            insight = _build_substantive_insight(arg_id, score, method_phrases, data)
+            insights.append(insight)
+        else:
+            insights.append(
+                f"**Verdict convergent sur {arg_id}** : {score} methodes "
+                f"independantes concourent a le signaler ({joined}). "
+                f"Cette convergence inter-perspectives est inaccessible a une passe "
+                f"LLM unique."
+            )
 
     # Build the conclusion line
     if ordered:
@@ -404,7 +460,12 @@ _PROSE_INSTRUCTIONS = (
     "'argumentation abstraite', 'maintenance de verite', 'scoring de qualite'). "
     "(3) Do not invent claims or details absent from the evidence. "
     "(4) Each paragraph covers one argument; cite at least two methods by name. "
-    "(5) Maximum 300 words."
+    "(5) For arguments flagged by 3+ methods, produce a SUBSTANTIVE CONCLUSION: "
+    "state WHY the cross-method agreement makes the weakness over-determined — "
+    "not just list methods, but articulate the insight that emerges from their "
+    "concordance (e.g. 'the argument combines X AND Y AND Z, making its weakness "
+    "structural rather than circumstantial'). "
+    "(6) Maximum 400 words."
 )
 
 

--- a/tests/unit/argumentation_analysis/plugins/test_track_qq_convergent_insight.py
+++ b/tests/unit/argumentation_analysis/plugins/test_track_qq_convergent_insight.py
@@ -1,0 +1,253 @@
+"""Tests for Track QQ (#667): Convergent insight paragraph.
+
+Tests cover:
+  1. _build_substantive_insight produces structured paragraph for >=3 methods
+  2. build_convergent_synthesis uses substantive insight for >=3, standard for <3
+  3. Insight is anchored in actual signals, not generic
+  4. LLM prose prompt includes substantive conclusion instruction
+"""
+
+import pytest
+
+from argumentation_analysis.plugins.narrative_synthesis_plugin import (
+    _build_substantive_insight,
+    build_convergent_synthesis,
+    _build_prose_prompt,
+)
+
+
+def _make_state_with_convergence(verdicts: dict) -> object:
+    """Create a mock state with compute_argument_convergence-style data."""
+
+    class MockState:
+        pass
+
+    state = MockState()
+    # build_convergent_synthesis calls compute_argument_convergence which reads
+    # from state attributes. We patch via monkeypatch in tests that need it.
+    state.identified_arguments = {}
+    state.identified_fallacies = {}
+    state.quality_scores = {}
+    state.counter_arguments = {}
+    state.jtms_beliefs = []
+    state.dung_framework = {}
+    state.belief_revision_results = {}
+    return state
+
+
+class TestBuildSubstantiveInsight:
+    """_build_substantive_insight produces structured paragraph."""
+
+    def test_basic_3_method_insight(self):
+        data = {
+            "score": 3,
+            "signals": [
+                ("sophisme", "Post hoc"),
+                ("qualite faible", "0.32"),
+                ("rejet Dung", "rejected"),
+            ],
+        }
+        result = _build_substantive_insight(
+            "arg_1",
+            3,
+            [
+                "detection rhetorique (Post hoc)",
+                "score de qualite (0.32)",
+                "argumentation abstraite (Dung/rejected)",
+            ],
+            data,
+        )
+        assert "**Insight convergent sur arg_1**" in result
+        assert "3 methodes independantes" in result
+        assert "sur-determinee" in result
+        assert "detection rhetorique" in result
+        assert "scoring de qualite" in result
+        assert "Dung" in result
+        assert "insight emergent" in result
+
+    def test_4_method_includes_jtms(self):
+        data = {
+            "score": 4,
+            "signals": [
+                ("sophisme", "Ad hominem"),
+                ("qualite faible", "0.25"),
+                ("JTMS retracte", "retracted"),
+                ("rejet Dung", "attacked"),
+            ],
+        }
+        result = _build_substantive_insight(
+            "arg_3",
+            4,
+            [
+                "detection rhetorique (Ad hominem)",
+                "score de qualite (0.25)",
+                "maintenance de verite (JTMS)",
+                "argumentation abstraite (Dung/attacked)",
+            ],
+            data,
+        )
+        assert "4 methodes independantes" in result
+        assert "JTMS" in result
+        assert "retracte" in result
+
+    def test_includes_counter_argument(self):
+        data = {
+            "score": 3,
+            "signals": [
+                ("sophisme", "Non sequitur"),
+                ("contre-argument", "counter"),
+                ("rejet Dung", "defeated"),
+            ],
+        }
+        result = _build_substantive_insight(
+            "arg_5",
+            3,
+            [
+                "detection rhetorique (Non sequitur)",
+                "contre-argumentation",
+                "argumentation abstraite (Dung/defeated)",
+            ],
+            data,
+        )
+        assert "contre-argument" in result
+
+    def test_insight_not_generic(self):
+        """Insight must reference actual signal details, not be a template."""
+        data = {
+            "score": 3,
+            "signals": [
+                ("sophisme", "Post hoc"),
+                ("qualite faible", "0.32"),
+                ("rejet Dung", "rejected"),
+            ],
+        }
+        result = _build_substantive_insight(
+            "arg_1",
+            3,
+            [
+                "detection rhetorique (Post hoc)",
+                "score de qualite (0.32)",
+                "argumentation abstraite (Dung/rejected)",
+            ],
+            data,
+        )
+        # Must contain specific signal details
+        assert "Post hoc" in result
+        assert "0.32" in result
+        assert "rejected" in result
+
+
+class TestBuildConvergentSynthesisInsight:
+    """build_convergent_synthesis uses substantive insight for >=3 methods."""
+
+    def test_substantive_for_3plus(self, monkeypatch):
+        """Verdicts with score >= 3 get substantive insight."""
+        convergence_data = {
+            "arg_1": {
+                "score": 3,
+                "signals": [
+                    ("sophisme", "Post hoc"),
+                    ("qualite faible", "0.3"),
+                    ("rejet Dung", "rejected"),
+                ],
+            },
+        }
+        monkeypatch.setattr(
+            "argumentation_analysis.plugins.narrative_synthesis_plugin.compute_argument_convergence",
+            lambda state: convergence_data,
+        )
+        state = _make_state_with_convergence({})
+        result = build_convergent_synthesis(state)
+        insights = result["emergent_insights"]
+        assert len(insights) == 1
+        assert "sur-determinee" in insights[0]
+
+    def test_standard_for_2(self, monkeypatch):
+        """Verdicts with score 2 get standard (non-substantive) insight."""
+        convergence_data = {
+            "arg_1": {
+                "score": 2,
+                "signals": [
+                    ("sophisme", "Post hoc"),
+                    ("qualite faible", "0.3"),
+                ],
+            },
+        }
+        monkeypatch.setattr(
+            "argumentation_analysis.plugins.narrative_synthesis_plugin.compute_argument_convergence",
+            lambda state: convergence_data,
+        )
+        state = _make_state_with_convergence({})
+        result = build_convergent_synthesis(state)
+        insights = result["emergent_insights"]
+        assert len(insights) == 1
+        assert "sur-determinee" not in insights[0]
+        assert "Verdict convergent" in insights[0]
+
+    def test_mixed_scores(self, monkeypatch):
+        """Mix of >=3 and <3 produces appropriate insight types."""
+        convergence_data = {
+            "arg_1": {
+                "score": 3,
+                "signals": [
+                    ("sophisme", "X"),
+                    ("qualite faible", "0.3"),
+                    ("rejet Dung", "r"),
+                ],
+            },
+            "arg_2": {
+                "score": 2,
+                "signals": [
+                    ("sophisme", "Y"),
+                    ("qualite faible", "0.4"),
+                ],
+            },
+        }
+        monkeypatch.setattr(
+            "argumentation_analysis.plugins.narrative_synthesis_plugin.compute_argument_convergence",
+            lambda state: convergence_data,
+        )
+        state = _make_state_with_convergence({})
+        result = build_convergent_synthesis(state)
+        insights = result["emergent_insights"]
+        assert len(insights) == 2
+        # First is substantive (score 3)
+        assert "Insight convergent" in insights[0]
+        assert "sur-determinee" in insights[0]
+        # Second is standard (score 2)
+        assert "Verdict convergent" in insights[1]
+
+
+class TestProsePromptSubstantive:
+    """LLM prose prompt includes substantive conclusion instruction."""
+
+    def test_prompt_mentions_substantive(self):
+        synthesis = {
+            "convergent_verdicts": {
+                "arg_1": {
+                    "score": 3,
+                    "signals": [("sophisme", "X"), ("qualite faible", "0.3")],
+                },
+            },
+            "conclusion": "test",
+        }
+        prompt = _build_prose_prompt(synthesis)
+        assert "SUBSTANTIVE CONCLUSION" in prompt
+        assert "over-determined" in prompt
+
+    def test_prompt_evidence_includes_3plus_methods(self):
+        synthesis = {
+            "convergent_verdicts": {
+                "arg_1": {
+                    "score": 3,
+                    "signals": [
+                        ("sophisme", "X"),
+                        ("qualite faible", "0.3"),
+                        ("rejet Dung", "r"),
+                    ],
+                },
+            },
+            "conclusion": "test",
+        }
+        prompt = _build_prose_prompt(synthesis)
+        assert "3 methods" in prompt


### PR DESCRIPTION
## Summary

- Add `_build_substantive_insight()` producing anchored, signal-grounded insight paragraphs when 3+ independent methods converge on an argument
- `build_convergent_synthesis` routes score>=3 to substantive insight, score<3 to standard verdict
- Enrich prose prompt (`_PROSE_INSTRUCTIONS`) with SUBSTANTIVE CONCLUSION instruction for over-determined verdicts; increase max words 300->400
- 9 new unit tests covering insight content, routing, and prose prompt

## Track QQ (#667) — Convergent Insight Paragraph

The convergence system now produces **substantive** conclusions when 3+ methods agree. Instead of a one-line verdict, the system generates a paragraph explaining *why* each method flagged the argument, anchoring the insight in actual signal details (fallacy name, quality score, Dung status, JTMS retraction).

### Changed files

| File | Change |
|------|--------|
| `argumentation_analysis/plugins/narrative_synthesis_plugin.py` | +68 lines: `_build_substantive_insight()`, routing in `build_convergent_synthesis`, prose prompt enrichment |
| `tests/unit/argumentation_analysis/plugins/test_track_qq_convergent_insight.py` | NEW: 9 tests (4 substantive insight, 3 routing, 2 prose prompt) |

### Test plan

- [x] 9 unit tests pass (`test_track_qq_convergent_insight.py`)
- [x] Privacy grep: no source names, opaque IDs only
- [x] Black formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)