### PR TITLE
feat(llm): reversible OpenRouter provider toggle to bypass OpenAI quota

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,8 +16,13 @@ OPENAI_API_KEY="sk-..."
 OPENAI_CHAT_MODEL_ID="gpt-5-mini"
 # BASE_URL="" # Override OpenAI base URL if needed
 
-# Pour OpenRouter (alternative provider)
+# Pour OpenRouter (alternative provider — bascule de secours si quota OpenAI épuisé)
+# Définir les 2 vars ci-dessous active automatiquement le routage via OpenRouter
+# (compatible OpenAI). Retirer OPENROUTER_BASE_URL pour revenir à OpenAI.
+# Le slug modèle doit être préfixé par le provider (ex. "openai/gpt-5-mini").
 # OPENROUTER_API_KEY="sk-or-v1-..."
+# OPENROUTER_BASE_URL="https://openrouter.ai/api/v1"
+# OPENROUTER_CHAT_MODEL_ID="openai/gpt-5-mini"
 
 # Pour Azure OpenAI
 # AZURE_OPENAI_ENDPOINT="https://your-azure-endpoint.openai.azure.com/"

--- a/argumentation_analysis/core/llm_service.py
+++ b/argumentation_analysis/core/llm_service.py
@@ -108,13 +108,27 @@ def create_llm_service(
             f"Veuillez mettre à jour votre fichier .env avec OPENAI_CHAT_MODEL_ID={new_model_id}"
         )
         model_id = new_model_id
-    # Récupération directe depuis l'environnement
-    api_key = os.environ.get("OPENAI_API_KEY")
+    # --- Sélection du provider : bascule OpenRouter si configurée ---
+    # Si OPENROUTER_BASE_URL est défini (+ OPENROUTER_API_KEY), les appels sont
+    # routés vers OpenRouter (API compatible OpenAI). Sinon, le comportement
+    # OpenAI officiel reste inchangé. Toggle réversible : retirer
+    # OPENROUTER_BASE_URL du .env pour revenir à OpenAI.
+    openrouter_base_url = os.environ.get("OPENROUTER_BASE_URL")
+    openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+    use_openrouter = bool(openrouter_base_url and openrouter_api_key)
+
+    if use_openrouter:
+        api_key = openrouter_api_key
+        # OpenRouter exige des slugs préfixés par le provider (ex. "openai/gpt-5-mini")
+        model_id = os.getenv("OPENROUTER_CHAT_MODEL_ID", model_id)
+    else:
+        api_key = os.environ.get("OPENAI_API_KEY")
     org_id = os.environ.get("OPENAI_ORG_ID")
 
     if not api_key:
         raise ValueError(
-            "La variable d'environnement OPENAI_API_KEY n'est pas définie."
+            "Aucune clé API LLM définie. Définissez OPENAI_API_KEY, ou "
+            "OPENROUTER_API_KEY + OPENROUTER_BASE_URL pour router via OpenRouter."
         )
 
     resilient_client = get_resilient_async_client()
@@ -122,11 +136,16 @@ def create_llm_service(
 
     try:
         if service_type == "OpenAIChatCompletion":
+            provider_label = (
+                "OpenRouter" if use_openrouter else "l'API OpenAI officielle"
+            )
             logger.info(
-                "Configuration Service: OpenAIChatCompletion pour l'API OpenAI officielle..."
+                f"Configuration Service: OpenAIChatCompletion pour {provider_label}..."
             )
 
             client_kwargs = {"api_key": api_key, "http_client": resilient_client}
+            if use_openrouter:
+                client_kwargs["base_url"] = openrouter_base_url
             if org_id:
                 client_kwargs["organization"] = org_id
 

--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -28,12 +28,12 @@ from typing import Any, Dict, List, Optional
 
 import semantic_kernel as sk
 from semantic_kernel.agents import ChatCompletionAgent
-from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 from semantic_kernel.connectors.ai.function_choice_behavior import (
     FunctionChoiceBehavior,
 )
 from semantic_kernel.contents.chat_history import ChatHistory
 
+from argumentation_analysis.core.llm_service import create_llm_service
 from argumentation_analysis.core.shared_state import (
     RhetoricalAnalysisState,
     UnifiedAnalysisState,
@@ -515,19 +515,25 @@ async def run_conversational_analysis(
         reprompt_extractor = RepromptTraceExtractor()
 
     # 1. Setup kernel + LLM
+    # Route through create_llm_service so the OpenRouter toggle applies: if
+    # OPENROUTER_BASE_URL + OPENROUTER_API_KEY are set, calls go to OpenRouter
+    # (OpenAI-compatible); otherwise the official OpenAI endpoint is used. This
+    # is the single linchpin service shared by every conversational agent and
+    # plugin, so the toggle here covers the whole pipeline. force_authentic=True
+    # preserves the prior behavior (a real LLM was always built here, never a
+    # mock, even under PYTEST_CURRENT_TEST).
     kernel = sk.Kernel()
-    api_key = os.environ.get("OPENAI_API_KEY", "")
-    if not api_key:
-        raise RuntimeError(
-            "OPENAI_API_KEY not found. Conversational mode requires an LLM. "
-            "Ensure .env is loaded."
-        )
     model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
-    llm_service = OpenAIChatCompletion(
-        service_id="conversational_llm",
-        ai_model_id=model_id,
-        api_key=api_key,
-    )
+    try:
+        llm_service = create_llm_service(
+            service_id="conversational_llm",
+            model_id=model_id,
+            force_authentic=True,
+        )
+    except ValueError as e:
+        raise RuntimeError(
+            f"{e} Conversational mode requires an LLM. Ensure .env is loaded."
+        )
     kernel.add_service(llm_service)
 
     # 2. Setup shared state (#363: UnifiedAnalysisState for spectacular coverage)

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -89,18 +89,36 @@ __all__ = [
 
 
 def _get_openai_client() -> Tuple[Any, str]:
-    """Create an AsyncOpenAI client from environment variables.
+    """Create an AsyncOpenAI client + model id from environment variables.
 
-    Returns (client, model_id) or (None, "") if API key unavailable.
+    Honors the OpenRouter toggle (mirrors create_llm_service): if
+    OPENROUTER_BASE_URL + OPENROUTER_API_KEY are set, the client targets
+    OpenRouter (OpenAI-compatible) with the provider-prefixed
+    OPENROUTER_CHAT_MODEL_ID; otherwise the official OpenAI endpoint is used.
+    This routes every raw-SDK caller through the same provider, so they no
+    longer hit OpenAI's quota when OpenRouter is configured.
+
+    Returns (client, model_id) or (None, "") if no API key is available.
     """
-    api_key = os.environ.get("OPENAI_API_KEY", "")
+    openrouter_base_url = os.environ.get("OPENROUTER_BASE_URL")
+    openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+    if openrouter_base_url and openrouter_api_key:
+        api_key = openrouter_api_key
+        base_url = openrouter_base_url
+        model_id = os.environ.get(
+            "OPENROUTER_CHAT_MODEL_ID",
+            os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini"),
+        )
+    else:
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+        base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+
     if not api_key:
         return None, ""
     try:
         from openai import AsyncOpenAI
 
-        base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-        model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
         return AsyncOpenAI(api_key=api_key, base_url=base_url), model_id
     except ImportError:
         return None, ""
@@ -2952,24 +2970,21 @@ async def _invoke_hierarchical_fallacy(
         }
 
     try:
-        from openai import AsyncOpenAI
         from semantic_kernel.kernel import Kernel
-        from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+        from argumentation_analysis.core.llm_service import create_llm_service
         from argumentation_analysis.plugins.fallacy_workflow_plugin import (
             FallacyWorkflowPlugin,
         )
 
-        api_key = os.environ.get("OPENAI_API_KEY", "")
-        if not api_key:
-            raise RuntimeError("No OPENAI_API_KEY available")
-
-        base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-        model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
-
-        async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-        llm_service = OpenAIChatCompletion(
-            ai_model_id=model_id,
-            async_client=async_client,
+        # Route through create_llm_service so the OpenRouter toggle applies:
+        # OPENROUTER_BASE_URL + OPENROUTER_API_KEY -> OpenRouter (OpenAI-compatible),
+        # else the official OpenAI endpoint. Building OpenAIChatCompletion directly
+        # here bypassed the toggle and kept hitting OpenAI's quota even when
+        # OpenRouter was configured. force_authentic=True preserves the prior
+        # always-real-service behavior (never a mock under PYTEST_CURRENT_TEST).
+        llm_service = create_llm_service(
+            service_id="fallacy_widenet",
+            force_authentic=True,
         )
         master_kernel = Kernel()
         master_kernel.add_service(llm_service)
@@ -2985,7 +3000,7 @@ async def _invoke_hierarchical_fallacy(
         result["extraction_method"] = result.get("exploration_method", "unknown")
         return result  # type: ignore[no-any-return]
 
-    except (ImportError, RuntimeError) as e:
+    except (ImportError, RuntimeError, ValueError) as e:
         # Expected failures: missing dependencies or API key — return empty gracefully
         logger.warning("Hierarchical fallacy detection unavailable: %s", e)
         return {
@@ -3037,19 +3052,11 @@ async def _invoke_hierarchical_fallacy_per_argument(
         }
 
     try:
-        from openai import AsyncOpenAI
         from semantic_kernel.kernel import Kernel
-        from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+        from argumentation_analysis.core.llm_service import create_llm_service
         from argumentation_analysis.plugins.fallacy_workflow_plugin import (
             FallacyWorkflowPlugin,
         )
-
-        api_key = os.environ.get("OPENAI_API_KEY", "")
-        if not api_key:
-            raise RuntimeError("No OPENAI_API_KEY available")
-
-        base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-        model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
 
         # Extract individual arguments from context or input text
         arguments = _extract_arguments_for_parallel(input_text, context)
@@ -3063,6 +3070,15 @@ async def _invoke_hierarchical_fallacy_per_argument(
         logger.info(
             "Parent harness: running parallel fallacy detection on %d arguments",
             len(arguments),
+        )
+
+        # Route through create_llm_service so the OpenRouter toggle applies (see
+        # _invoke_hierarchical_fallacy). Build the service once and share it across
+        # the per-argument plugin instances; each keeps its own master_kernel for
+        # isolation. force_authentic=True preserves the always-real behavior.
+        shared_llm_service = create_llm_service(
+            service_id="fallacy_widenet_perarg",
+            force_authentic=True,
         )
 
         # Create plugin instances — one per argument for isolation
@@ -3079,17 +3095,12 @@ async def _invoke_hierarchical_fallacy_per_argument(
             """
             plugin = None
             try:
-                async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-                llm_service = OpenAIChatCompletion(
-                    ai_model_id=model_id,
-                    async_client=async_client,
-                )
                 master_kernel = Kernel()
-                master_kernel.add_service(llm_service)
+                master_kernel.add_service(shared_llm_service)
 
                 plugin = FallacyWorkflowPlugin(
                     master_kernel=master_kernel,
-                    llm_service=llm_service,
+                    llm_service=shared_llm_service,
                     taxonomy_file_path=taxonomy_path,
                 )
 
@@ -3198,7 +3209,7 @@ async def _invoke_hierarchical_fallacy_per_argument(
             "parallel_executed": True,
         }
 
-    except (ImportError, RuntimeError) as e:
+    except (ImportError, RuntimeError, ValueError) as e:
         logger.warning("Per-argument hierarchical fallacy detection unavailable: %s", e)
         return {
             "fallacies": [],
@@ -3465,16 +3476,11 @@ async def _invoke_propositional_logic(
             # ── 2-pass coordinated pipeline (#547) ──────────────────────
             # Try the coordinated 2-pass: Pass 1 (atom inventory) → Pass 2 (formulas with shared atoms)
             try:
-                from openai import AsyncOpenAI
                 import json as _json
 
-                api_key = os.environ.get("OPENAI_API_KEY", "")
-                if api_key and input_text and len(input_text) > 100:
-                    base_url = os.environ.get(
-                        "OPENAI_BASE_URL", "https://api.openai.com/v1"
-                    )
-                    model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
-                    client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+                # Honors the OpenRouter toggle via _get_openai_client.
+                client, model_id = _get_openai_client()
+                if client is not None and input_text and len(input_text) > 100:
 
                     # ── Pass 1: Atom inventory from full source text ──
                     pass1_prompt = (
@@ -3768,15 +3774,9 @@ async def _invoke_fol_reasoning(
             # Pass 1: Extract shared FOL signature (sorts, predicates, constants) from full text
             # Pass 2: Generate per-argument formulas using ONLY shared signature
             try:
-                from openai import AsyncOpenAI
-
-                api_key = os.environ.get("OPENAI_API_KEY", "")
-                if api_key and input_text and len(input_text) > 100:
-                    base_url = os.environ.get(
-                        "OPENAI_BASE_URL", "https://api.openai.com/v1"
-                    )
-                    model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
-                    client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+                # Honors the OpenRouter toggle via _get_openai_client.
+                client, model_id = _get_openai_client()
+                if client is not None and input_text and len(input_text) > 100:
 
                     # ── Pass 1: Shared FOL signature from full text ──
                     pass1_prompt = (

--- a/argumentation_analysis/plugins/fallacy_workflow_plugin.py
+++ b/argumentation_analysis/plugins/fallacy_workflow_plugin.py
@@ -26,6 +26,9 @@ from semantic_kernel.connectors.ai.open_ai import (
 from semantic_kernel.connectors.ai.function_choice_behavior import (
     FunctionChoiceBehavior,
 )
+from semantic_kernel.connectors.ai.chat_completion_client_base import (
+    ChatCompletionClientBase,
+)
 from semantic_kernel.contents import (
     ChatHistory,
     FunctionCallContent,
@@ -67,7 +70,7 @@ class FallacyWorkflowPlugin:
     def __init__(
         self,
         master_kernel: Kernel,
-        llm_service: OpenAIChatCompletion,
+        llm_service: ChatCompletionClientBase,
         taxonomy_file_path: Optional[str] = None,
         taxonomy_data: Optional[list] = None,
         logger: Optional[logging.Logger] = None,

--- a/tests/unit/argumentation_analysis/test_llm_service.py
+++ b/tests/unit/argumentation_analysis/test_llm_service.py
@@ -66,19 +66,23 @@ class TestLLMService:
         ), f"L'ID du modèle du service ({service.ai_model_id}) ne correspond pas à celui de l'environnement ({self.model_id})."
 
     def test_create_llm_service_missing_api_key(self):
-        """Teste que la création du service échoue sans clé API."""
-        # Supprimer temporairement la clé API de l'environnement
-        if "OPENAI_API_KEY" in os.environ:
-            del os.environ["OPENAI_API_KEY"]
+        """Teste que la création du service échoue sans aucun provider configuré."""
+        # Supprimer temporairement toute clé API de l'environnement : ni OpenAI,
+        # ni le couple OpenRouter (base_url + api_key) ne doit rester défini,
+        # sinon la factory bascule sur le provider encore configuré.
+        for var in (
+            "OPENAI_API_KEY",
+            "OPENROUTER_API_KEY",
+            "OPENROUTER_BASE_URL",
+        ):
+            os.environ.pop(var, None)
 
         with pytest.raises(ValueError) as excinfo:
             create_llm_service(
                 service_id="test_service", model_id=self.model_id, force_authentic=True
             )
 
-        assert "La variable d'environnement OPENAI_API_KEY n'est pas définie." in str(
-            excinfo.value
-        )
+        assert "Aucune clé API LLM définie" in str(excinfo.value)
 
         assert "OPENAI_API_KEY" in str(excinfo.value)
 

--- a/tests/unit/argumentation_analysis/test_llm_service.py
+++ b/tests/unit/argumentation_analysis/test_llm_service.py
@@ -61,9 +61,22 @@ class TestLLMService:
         assert isinstance(
             service, OpenAIChatCompletion
         ), "Le service devrait être une instance de OpenAIChatCompletion."
+
+        # Le modèle attendu dépend du provider actif : en mode OpenRouter
+        # (OPENROUTER_BASE_URL + OPENROUTER_API_KEY définis), la factory substitue
+        # le slug préfixé OPENROUTER_CHAT_MODEL_ID ; sinon le modèle OpenAI demandé.
+        use_openrouter = bool(
+            os.environ.get("OPENROUTER_BASE_URL")
+            and os.environ.get("OPENROUTER_API_KEY")
+        )
+        expected_model = (
+            os.environ.get("OPENROUTER_CHAT_MODEL_ID", self.model_id)
+            if use_openrouter
+            else self.model_id
+        )
         assert (
-            service.ai_model_id == self.model_id
-        ), f"L'ID du modèle du service ({service.ai_model_id}) ne correspond pas à celui de l'environnement ({self.model_id})."
+            service.ai_model_id == expected_model
+        ), f"L'ID du modèle du service ({service.ai_model_id}) ne correspond pas au modèle attendu ({expected_model})."
 
     def test_create_llm_service_missing_api_key(self):
         """Teste que la création du service échoue sans aucun provider configuré."""


### PR DESCRIPTION
## Summary

Adds a **reversible** provider toggle to `create_llm_service`: when both `OPENROUTER_BASE_URL` and `OPENROUTER_API_KEY` are set, chat completions route through OpenRouter (OpenAI-compatible API). Removing `OPENROUTER_BASE_URL` reverts to OpenAI with zero code change.

**Why:** OpenAI account hit a 429 quota exhaustion, blocking #658 live DoD measurement (Volets 1 & 2) and any other live-API work across the cluster. The user confirmed OpenRouter still has quota. Root cause of the prior inability to switch: the `AsyncOpenAI` `client_kwargs` never passed `base_url`, so the SDK always hit OpenAI's official endpoint regardless of env.

## Changes

- **`argumentation_analysis/core/llm_service.py`**: provider-selection block (`use_openrouter = bool(base_url and api_key)`), `base_url` wired into `client_kwargs`, OpenRouter-prefixed model slug via `OPENROUTER_CHAT_MODEL_ID`, and a clearer missing-key `ValueError` that names both providers.
- **`.env.example`**: documents the toggle under the OpenRouter section (commented `OPENROUTER_BASE_URL` + `OPENROUTER_CHAT_MODEL_ID`).
- **`tests/unit/argumentation_analysis/test_llm_service.py`**: `test_create_llm_service_missing_api_key` now clears the OpenRouter env vars too, so it genuinely exercises the "no provider configured" path; assertion updated to the new error message.

## Added scope (post-review, commits 2 & 3)

The first review (`feat(llm)` factory, 3 files) only covered `create_llm_service`. But the toggle alone is insufficient: several call sites built LLM clients **directly from `OPENAI_API_KEY`**, bypassing the factory entirely — so they kept hitting OpenAI's exhausted quota even with OpenRouter configured. These were found and fixed:

- **`argumentation_analysis/orchestration/conversational_orchestrator.py`**: kernel LLM setup now routes through `create_llm_service(service_id="conversational_llm", force_authentic=True)` instead of constructing `OpenAIChatCompletion` from raw env.
- **`argumentation_analysis/orchestration/invoke_callables.py`** — eliminates the raw-SDK bypass at 5 sites:
  - `_get_openai_client()` rewritten to mirror the toggle (covers all raw-`AsyncOpenAI` callers).
  - `_invoke_hierarchical_fallacy` + `_invoke_hierarchical_fallacy_per_argument` (wide-net Phase 1) now build their kernel via `create_llm_service(force_authentic=True)`; the per-arg path shares one service instance.
  - The two inline PL/FOL 2-pass sites (#547 atom inventory, #544 FOL signature) now use `_get_openai_client()`.
  - Left intentionally untouched: `_invoke_self_hosted_llm_fallacy` (self-hosted endpoint path, separate provider).

## Validation

- `pytest tests/unit/argumentation_analysis/test_llm_service.py tests/unit/argumentation_analysis/core/test_llm_service_extended.py -q` → **15 passed**
- `black --check` + `flake8` on all modified source files → clean
- **Live end-to-end:** the #658 consolidated measurement (corpus C, dense ~46K source) ran the full pipeline through OpenRouter for ~50 min with **0 quota / 429 errors** (all LLM calls HTTP 200 to `openrouter.ai`) — confirming every bypass site is now routed. RR convergence depth ≥3 reproduced. (Volet-1 formula survival is a pre-existing Tweety gap, unrelated to this PR; tracked separately.)

## Rebase

Rebased onto `main` @ 861992b2 (now includes #674 + #676). Both files touched by both PRs (`invoke_callables.py`, `conversational_orchestrator.py`) are **hunk-disjoint** with #676's canonical-arg_id signal fix — verified before rebase, clean replay.

## Backward compatibility

Fully backward compatible. With no OpenRouter env vars set, behavior is identical to before (OpenAI official endpoint). The toggle is opt-in and one-line reversible.

Unblocks live-API work cluster-wide (#658 measurement, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
