### PR TITLE
fix(audit): static text-label boundary audit — Track TT (#672)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -2036,13 +2036,13 @@ def _build_aspic_from_state(state: Any) -> Optional[Dict[str, Any]]:
 
         # Fallacy-targeted arguments are defeasible regardless
         is_undermined = False
+        current_arg_id = f"arg_{i + 1}"
         for f in fallacies:
             if not isinstance(f, dict):
                 continue
             target = f.get("target_argument_id", "")
             target_text = f.get("target_argument", "")
-            arg_ids = list(state.identified_arguments.keys())
-            if target and target == (arg_ids[i] if i < len(arg_ids) else ""):
+            if target and target == current_arg_id:
                 is_undermined = True
                 break
             if target_text and target_text.lower()[:30] in desc.lower():
@@ -2065,13 +2065,13 @@ def _build_aspic_from_state(state: Any) -> Optional[Dict[str, Any]]:
         if not desc:
             continue
         is_undermined = False
+        current_arg_id = f"arg_{i + 1}"
         for f in fallacies:
             if not isinstance(f, dict):
                 continue
-            arg_ids = list(state.identified_arguments.keys())
             target = f.get("target_argument_id", "")
             target_text = f.get("target_argument", "")
-            if (target and target == (arg_ids[i] if i < len(arg_ids) else "")) or (
+            if (target and target == current_arg_id) or (
                 target_text and target_text.lower()[:30] in desc.lower()
             ):
                 is_undermined = True

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -1414,16 +1414,13 @@ def _generate_hypotheses(
     # Hypothesis 3: Only high-quality arguments (if quality data available)
     if per_arg_scores:
         high_quality = []
-        for arg_name in arg_names:
-            # Direct lookup first; fall back to exact-match against str(arg_id).
-            # Avoid arg_name[:30] in str(arg_id) — it falsely matched unrelated
-            # IDs like "counter_argument" / "target_argument" (review #376).
-            scores = per_arg_scores.get(arg_name)
+        # Build positional mapping: arg_names[i] -> canonical key "arg_{i+1}"
+        # per_arg_scores is keyed by canonical arg_id, arg_names are free text.
+        for idx, arg_name in enumerate(arg_names):
+            canonical = f"arg_{idx + 1}"
+            scores = per_arg_scores.get(canonical)
             if not isinstance(scores, dict):
-                for arg_id, candidate in per_arg_scores.items():
-                    if isinstance(candidate, dict) and str(arg_id) == arg_name:
-                        scores = candidate
-                        break
+                scores = per_arg_scores.get(arg_name)
             if isinstance(scores, dict):
                 if (
                     float(str(scores.get("overall", scores.get("note_finale", 0))))
@@ -2568,7 +2565,9 @@ def _python_social_fallback(
                 v[0] / (v[0] + v[1]) if isinstance(v, tuple) and sum(v) > 0 else 0.5
             )
         # Signal 2: quality score boost
-        q = quality_scores.get(arg)
+        # quality_scores keyed by canonical arg_id ("arg_N"), args are free text
+        canonical = f"arg_{i + 1}"
+        q = quality_scores.get(canonical, quality_scores.get(arg))
         quality_boost = 0.0
         if isinstance(q, (int, float)):
             quality_boost = q * 0.3  # quality contributes 30%

--- a/argumentation_analysis/reporting/cross_reference_graph.py
+++ b/argumentation_analysis/reporting/cross_reference_graph.py
@@ -135,9 +135,21 @@ class CrossReferenceGraph:
         arguments = getattr(state, "identified_arguments", None) or {}
         if isinstance(arguments, dict):
             for arg_id, arg_data in arguments.items():
-                label = str(arg_data)[:60] if not isinstance(arg_data, dict) else arg_data.get("text", arg_id)[:60]
-                self.add_node(Node(id=str(arg_id), label=label, node_type="argument",
-                                   metadata={"data": arg_data} if isinstance(arg_data, dict) else {}))
+                label = (
+                    str(arg_data)[:60]
+                    if not isinstance(arg_data, dict)
+                    else arg_data.get("text", arg_id)[:60]
+                )
+                self.add_node(
+                    Node(
+                        id=str(arg_id),
+                        label=label,
+                        node_type="argument",
+                        metadata=(
+                            {"data": arg_data} if isinstance(arg_data, dict) else {}
+                        ),
+                    )
+                )
         elif isinstance(arguments, list):
             for i, arg in enumerate(arguments):
                 arg_id = getattr(arg, "id", None) or f"arg_{i}"
@@ -148,30 +160,60 @@ class CrossReferenceGraph:
         fallacies = getattr(state, "identified_fallacies", None) or {}
         if isinstance(fallacies, dict):
             for f_id, f_data in fallacies.items():
-                label = str(f_data)[:60] if not isinstance(f_data, dict) else f_data.get("fallacy_type", f_id)[:60]
-                self.add_node(Node(id=str(f_id), label=label, node_type="fallacy",
-                                   metadata={"data": f_data} if isinstance(f_data, dict) else {}))
+                label = (
+                    str(f_data)[:60]
+                    if not isinstance(f_data, dict)
+                    else f_data.get("fallacy_type", f_id)[:60]
+                )
+                self.add_node(
+                    Node(
+                        id=str(f_id),
+                        label=label,
+                        node_type="fallacy",
+                        metadata={"data": f_data} if isinstance(f_data, dict) else {},
+                    )
+                )
                 # Edge: argument -> fallacy (via target_arg_id)
-                if isinstance(f_data, dict) and "target_arg_id" in f_data:
-                    target = str(f_data["target_arg_id"])
-                    self.add_edge(Edge(source=target, target=str(f_id),
-                                       edge_type=EdgeType.ARGUMENT_FALLACY))
+                if isinstance(f_data, dict) and "target_argument_id" in f_data:
+                    target = str(f_data["target_argument_id"])
+                    self.add_edge(
+                        Edge(
+                            source=target,
+                            target=str(f_id),
+                            edge_type=EdgeType.ARGUMENT_FALLACY,
+                        )
+                    )
         elif isinstance(fallacies, list):
             for i, f in enumerate(fallacies):
                 f_id = getattr(f, "id", None) or f"fal_{i}"
                 label = getattr(f, "fallacy_type", str(f))[:60]
                 self.add_node(Node(id=str(f_id), label=label, node_type="fallacy"))
-                target = getattr(f, "target_arg_id", None)
+                target = getattr(f, "target_argument_id", None)
                 if target:
-                    self.add_edge(Edge(source=str(target), target=str(f_id),
-                                       edge_type=EdgeType.ARGUMENT_FALLACY))
+                    self.add_edge(
+                        Edge(
+                            source=str(target),
+                            target=str(f_id),
+                            edge_type=EdgeType.ARGUMENT_FALLACY,
+                        )
+                    )
 
         # 3. JTMS beliefs
         beliefs = getattr(state, "jtms_beliefs", None) or {}
         for b_id, b_data in beliefs.items():
-            label = b_data.get("name", str(b_id))[:60] if isinstance(b_data, dict) else str(b_id)[:60]
-            self.add_node(Node(id=str(b_id), label=label, node_type="jtms_belief",
-                               metadata={"data": b_data} if isinstance(b_data, dict) else {}))
+            label = (
+                b_data.get("name", str(b_id))[:60]
+                if isinstance(b_data, dict)
+                else str(b_id)[:60]
+            )
+            self.add_node(
+                Node(
+                    id=str(b_id),
+                    label=label,
+                    node_type="jtms_belief",
+                    metadata={"data": b_data} if isinstance(b_data, dict) else {},
+                )
+            )
 
         # Edge: fallacy -> jtms_retraction (via retraction chain)
         retraction_chain = getattr(state, "jtms_retraction_chain", None) or []
@@ -180,19 +222,35 @@ class CrossReferenceGraph:
                 fallacy_id = str(entry.get("fallacy_id", ""))
                 belief_id = str(entry.get("belief_id", ""))
                 if fallacy_id and belief_id:
-                    self.add_edge(Edge(source=fallacy_id, target=belief_id,
-                                       edge_type=EdgeType.FALLACY_JTMS_RETRACTION))
+                    self.add_edge(
+                        Edge(
+                            source=fallacy_id,
+                            target=belief_id,
+                            edge_type=EdgeType.FALLACY_JTMS_RETRACTION,
+                        )
+                    )
 
         # 4. Belief revisions
         revisions = getattr(state, "belief_revision_results", None) or []
         for i, rev in enumerate(revisions):
             rev_id = rev.get("id", f"rev_{i}") if isinstance(rev, dict) else f"rev_{i}"
-            label = rev.get("description", rev_id)[:60] if isinstance(rev, dict) else str(rev)[:60]
-            self.add_node(Node(id=str(rev_id), label=label, node_type="belief_revision"))
+            label = (
+                rev.get("description", rev_id)[:60]
+                if isinstance(rev, dict)
+                else str(rev)[:60]
+            )
+            self.add_node(
+                Node(id=str(rev_id), label=label, node_type="belief_revision")
+            )
             # Edge: jtms_belief -> belief_revision
             if isinstance(rev, dict) and "belief_id" in rev:
-                self.add_edge(Edge(source=str(rev["belief_id"]), target=str(rev_id),
-                                   edge_type=EdgeType.JTMS_BELIEF_REVISION))
+                self.add_edge(
+                    Edge(
+                        source=str(rev["belief_id"]),
+                        target=str(rev_id),
+                        edge_type=EdgeType.JTMS_BELIEF_REVISION,
+                    )
+                )
 
         # 5. Counter-arguments
         counters = getattr(state, "counter_arguments", None) or []
@@ -200,20 +258,32 @@ class CrossReferenceGraph:
             if isinstance(ca, dict):
                 ca_id = ca.get("id", f"ca_{len(self.edges)}")
                 label = ca.get("counter_content", ca_id)[:60]
-                self.add_node(Node(id=str(ca_id), label=label, node_type="counter_argument"))
+                self.add_node(
+                    Node(id=str(ca_id), label=label, node_type="counter_argument")
+                )
                 target = ca.get("target_arg_id")
                 if target:
-                    self.add_edge(Edge(source=str(target), target=str(ca_id),
-                                       edge_type=EdgeType.ARGUMENT_COUNTER))
+                    self.add_edge(
+                        Edge(
+                            source=str(target),
+                            target=str(ca_id),
+                            edge_type=EdgeType.ARGUMENT_COUNTER,
+                        )
+                    )
 
         # 6. Quality scores
         quality = getattr(state, "argument_quality_scores", None) or {}
         for arg_id, q_data in quality.items():
             q_id = f"qual_{arg_id}"
             overall = q_data.get("overall", 0) if isinstance(q_data, dict) else 0
-            self.add_node(Node(id=q_id, label=f"Q:{overall:.1f}", node_type="quality_score"))
-            self.add_edge(Edge(source=str(arg_id), target=q_id,
-                               edge_type=EdgeType.ARGUMENT_QUALITY))
+            self.add_node(
+                Node(id=q_id, label=f"Q:{overall:.1f}", node_type="quality_score")
+            )
+            self.add_edge(
+                Edge(
+                    source=str(arg_id), target=q_id, edge_type=EdgeType.ARGUMENT_QUALITY
+                )
+            )
 
         # 7. Debate transcripts
         debates = getattr(state, "debate_transcripts", None) or []
@@ -221,7 +291,9 @@ class CrossReferenceGraph:
             if isinstance(dt, dict):
                 dt_id = dt.get("id", f"debate_{len(self.edges)}")
                 label = dt.get("topic", dt_id)[:60]
-                self.add_node(Node(id=str(dt_id), label=label, node_type="debate_outcome"))
+                self.add_node(
+                    Node(id=str(dt_id), label=label, node_type="debate_outcome")
+                )
 
         # 8. Governance decisions
         governance = getattr(state, "governance_decisions", None) or []
@@ -229,12 +301,19 @@ class CrossReferenceGraph:
             if isinstance(gd, dict):
                 gd_id = gd.get("id", f"gov_{len(self.edges)}")
                 winner = gd.get("winner", "?")
-                self.add_node(Node(id=str(gd_id), label=f"Vote:{winner}", node_type="governance"))
+                self.add_node(
+                    Node(id=str(gd_id), label=f"Vote:{winner}", node_type="governance")
+                )
                 # Edge: governance -> debate_outcome
                 debate_ref = gd.get("debate_id")
                 if debate_ref:
-                    self.add_edge(Edge(source=str(gd_id), target=str(debate_ref),
-                                       edge_type=EdgeType.GOVERNANCE_DEBATE))
+                    self.add_edge(
+                        Edge(
+                            source=str(gd_id),
+                            target=str(debate_ref),
+                            edge_type=EdgeType.GOVERNANCE_DEBATE,
+                        )
+                    )
 
     def density(self) -> float:
         """Compute graph density: ``|E| / (|V| * (|V| - 1))`` for directed graph."""
@@ -259,7 +338,9 @@ class CrossReferenceGraph:
             key = edge.edge_type.value
             edge_type_counts[key] = edge_type_counts.get(key, 0) + 1
         for node in self.nodes.values():
-            node_type_counts[node.node_type] = node_type_counts.get(node.node_type, 0) + 1
+            node_type_counts[node.node_type] = (
+                node_type_counts.get(node.node_type, 0) + 1
+            )
 
         return CrossReferenceReport(
             total_nodes=len(self.nodes),
@@ -274,12 +355,21 @@ class CrossReferenceGraph:
         """Serialize graph to JSON."""
         data = {
             "nodes": [
-                {"id": n.id, "label": n.label, "type": n.node_type, "metadata": n.metadata}
+                {
+                    "id": n.id,
+                    "label": n.label,
+                    "type": n.node_type,
+                    "metadata": n.metadata,
+                }
                 for n in self.nodes.values()
             ],
             "edges": [
-                {"source": e.source, "target": e.target, "type": e.edge_type.value,
-                 "weight": e.weight}
+                {
+                    "source": e.source,
+                    "target": e.target,
+                    "type": e.edge_type.value,
+                    "weight": e.weight,
+                }
                 for e in self.edges
             ],
         }
@@ -297,7 +387,12 @@ class CrossReferenceGraph:
             "debate_outcome": "#607D8B",
             "governance": "#795548",
         }
-        lines = ["digraph CrossReference {", '  rankdir=LR;', '  node [shape=box, style=filled];', ""]
+        lines = [
+            "digraph CrossReference {",
+            "  rankdir=LR;",
+            "  node [shape=box, style=filled];",
+            "",
+        ]
         for nid, node in self.nodes.items():
             color = type_colors.get(node.node_type, "#E0E0E0")
             safe_id = nid.replace(" ", "_").replace("-", "_").replace(".", "_")
@@ -326,13 +421,28 @@ class CrossReferenceGraph:
         }
         lines = ["graph LR"]
         for nid, node in self.nodes.items():
-            safe_id = nid.replace(" ", "_").replace("-", "_").replace(".", "_").replace("/", "_")
+            safe_id = (
+                nid.replace(" ", "_")
+                .replace("-", "_")
+                .replace(".", "_")
+                .replace("/", "_")
+            )
             safe_label = node.label.replace('"', "'").replace("\n", " ")[:30]
             open_b, close_b = type_shapes.get(node.node_type, ("[", "]"))
-            lines.append(f"  {safe_id}{open_b}\"{safe_label}\"{close_b}")
+            lines.append(f'  {safe_id}{open_b}"{safe_label}"{close_b}')
         for edge in self.edges:
-            src = edge.source.replace(" ", "_").replace("-", "_").replace(".", "_").replace("/", "_")
-            tgt = edge.target.replace(" ", "_").replace("-", "_").replace(".", "_").replace("/", "_")
+            src = (
+                edge.source.replace(" ", "_")
+                .replace("-", "_")
+                .replace(".", "_")
+                .replace("/", "_")
+            )
+            tgt = (
+                edge.target.replace(" ", "_")
+                .replace("-", "_")
+                .replace(".", "_")
+                .replace("/", "_")
+            )
             label = edge.edge_type.value.split("->")[-1]
             lines.append(f"  {src} -->|{label}| {tgt}")
         return "\n".join(lines)

--- a/docs/reports/static_audit_tt_672.md
+++ b/docs/reports/static_audit_tt_672.md
@@ -1,0 +1,98 @@
+# Static Audit Report — Track TT (#672)
+
+**Date**: 2026-05-22
+**Base commit**: `606fa622` (post-SS)
+**Scope**: Text-label ↔ canonical arg_id boundary audit
+**Method**: Static code analysis, no API calls
+
+---
+
+## 1. Background
+
+LL (#662) and RR (#670) revealed the same bug class: upstream objects named by **free text** (e.g., "The policy increases...") while downstream lookups use **canonical arg_id** (`arg_1`, `arg_2`, ...) → silently dead signals. 2 of 5 convergence signals were dead from origin.
+
+This audit systematically checks ALL text↔arg_id boundaries in the pipeline.
+
+---
+
+## 2. Audit Methodology
+
+For each site where arg identifiers appear as dict keys, set lookups, or string matching:
+- **Producer**: what format is the key? (canonical `arg_N` or free text)
+- **Consumer**: what format does the lookup expect?
+- **Verdict**: SAFE (consistent), AT-RISK (mismatch possible), BUG (confirmed mismatch)
+
+---
+
+## 3. Findings
+
+### BUG A2: cross_reference_graph.py — key name mismatch
+**File**: `argumentation_analysis/reporting/cross_reference_graph.py` (lines 155, 164)
+**Pattern**: `"target_arg_id"` lookup but fallacy dicts store `"target_argument_id"`
+**Impact**: No fallacy→argument edges in cross-reference graph. 0 edges ever created.
+**Fix**: Changed key from `"target_arg_id"` to `"target_argument_id"`.
+
+### BUG A1: conversational_orchestrator.py — ASPIC+ positional index
+**File**: `argumentation_analysis/orchestration/conversational_orchestrator.py` (lines 2039-2050, 2068-2078)
+**Pattern**: `arg_ids[i]` positional comparison instead of canonical `f"arg_{i+1}"`
+**Impact**: Fallacy undermining classification only works when fallacy targets the i-th argument by position. Defeated-by-fallacy classification in ASPIC+ is unreliable.
+**Fix**: Replaced `arg_ids[i]` with `current_arg_id = f"arg_{i+1}"` derived from loop index.
+
+### BUG IC5: invoke_callables.py — ATMS hypothesis quality lookup
+**File**: `argumentation_analysis/orchestration/invoke_callables.py` (lines 1414-1432)
+**Pattern**: `per_arg_scores.get(arg_name)` where `arg_name` is free text and keys are canonical
+**Impact**: `h_high_quality` ATMS hypothesis never populated from actual quality scores.
+**Fix**: Positional mapping `f"arg_{idx+1}"` as primary lookup key.
+
+### BUG IC6: invoke_callables.py — social scoring quality lookup
+**File**: `argumentation_analysis/orchestration/invoke_callables.py` (line 2571)
+**Pattern**: `quality_scores.get(arg)` where `arg` is free text and keys are canonical
+**Impact**: Social AF fallback never incorporates quality signal.
+**Fix**: Positional mapping `f"arg_{i+1}"` as primary lookup key.
+
+---
+
+## 4. AT-RISK Sites (no fix applied — documented for awareness)
+
+| ID | File | Pattern | Risk |
+|----|------|---------|------|
+| N1-1 | narrative_synthesis_plugin.py:266 | Dung arg resolution heuristic | Resolution may fail for heavily-truncated text; graceful degradation |
+| N1-4 | narrative_synthesis_plugin.py:295 | Fallacy target_argument_id from LLM | LLM may return free text; `add_fallacy` validates but doesn't resolve |
+| SW3 | state_writers.py:86 | Legacy ctx default `"arg_input"` | Quality score orphaned under `"arg_input"` key |
+| IC4 | invoke_callables.py:1054 | JTMS fallacy substring match | May match wrong belief for short target text |
+| DA2 | deep_synthesis_agent.py:907 | Adjudication target format | Same root cause as N1-4 |
+| DA3 | deep_synthesis_agent.py:204 | Argument map fallacy target | Same root cause as N1-4 |
+| DA6 | deep_synthesis_agent.py:390 | Counter-arg target_arg_ids field name | Possible list vs string mismatch |
+
+---
+
+## 5. SAFE Sites (confirmed correct)
+
+| # | File | Site | Why safe |
+|---|------|------|----------|
+| N1-3 | narrative_synthesis_plugin.py | JTMS `startswith(arg_N:)` | Explicit canonical prefix by design |
+| SW1 | state_writers.py | `_resolve_target_arg_id` | Resolver function, returns canonical or None |
+| SW2 | state_writers.py | Quality key iteration | Both sides canonical |
+| SW5 | state_writers.py | JTMS storage | `startswith` matching, robust |
+| IC1 | invoke_callables.py | Quality arg_id gen | `f"arg_{i+1}"` canonical |
+| IC3 | invoke_callables.py | JTMS belief naming | `f"arg_{i+1}:"` canonical prefix |
+| IC7/IC8 | invoke_callables.py | Parallel arg extraction | Canonical from state or generated |
+| DA1 | deep_synthesis_agent.py | Convergence import | Canonical from upstream |
+| DA4 | deep_synthesis_agent.py | Counter-arg text match | Substring against descriptions, canonical ID result |
+| DA5 | deep_synthesis_agent.py | Weak args detection | Canonical key iteration |
+| A4 | cross_reference_graph.py | Counter-arg edges | Correct key `"target_arg_id"` for counter-args |
+| A5 | conversational_orchestrator.py | Dung framework build | Canonical iteration + text fallback |
+| A8-A14 | Various | Export/render/state tools | Count-only, export-only, or canonical-aware |
+
+---
+
+## 6. Summary
+
+| Category | Count |
+|----------|-------|
+| **BUG (fixed)** | 4 |
+| **AT-RISK (documented)** | 7 |
+| **SAFE** | 15 |
+| **Total sites audited** | 26 |
+
+All 4 BUG fixes use the same pattern: replace free-text lookup with positional canonical key `f"arg_{idx+1}"` (matching the `add_argument` ID generation convention). No API calls required.

--- a/tests/unit/argumentation_analysis/test_track_tt_text_label_audit.py
+++ b/tests/unit/argumentation_analysis/test_track_tt_text_label_audit.py
@@ -1,0 +1,276 @@
+"""Tests for Track TT (#672): Static audit text-label ↔ canonical arg_id boundary.
+
+Tests cover:
+  1. cross_reference_graph uses correct fallacy key (target_argument_id)
+  2. ASPIC+ fallacy undermining uses canonical arg_id, not positional index
+  3. ATMS hypothesis quality lookup uses canonical key, not free text
+  4. Social scoring quality lookup uses canonical key, not free text
+"""
+
+import pytest
+
+
+class TestCrossReferenceGraphFallacyKey:
+    """BUG A2 fix: cross_reference_graph reads target_argument_id, not target_arg_id."""
+
+    def test_fallacy_edge_created_with_correct_key(self):
+        """Fallacy entries with target_argument_id produce edges."""
+        from argumentation_analysis.reporting.cross_reference_graph import (
+            CrossReferenceGraph,
+            EdgeType,
+        )
+
+        class MockState:
+            identified_arguments = {"arg_1": "First argument text", "arg_2": "Second"}
+            identified_fallacies = {
+                "fal_1": {
+                    "fallacy_type": "Ad hominem",
+                    "target_argument_id": "arg_1",
+                },
+            }
+            jtms_beliefs = {}
+            jtms_retraction_chain = []
+            counter_arguments = {}
+            dung_framework = {}
+            argument_quality_scores = {}
+            belief_revision_results = {}
+
+        graph = CrossReferenceGraph()
+        graph.build_from_state(MockState())
+        edges = graph.edges
+        fallacy_edges = [e for e in edges if e.edge_type == EdgeType.ARGUMENT_FALLACY]
+        assert len(fallacy_edges) == 1
+        assert fallacy_edges[0].source == "arg_1"
+        assert fallacy_edges[0].target == "fal_1"
+
+    def test_no_fallacy_edge_with_wrong_key(self):
+        """Fallacy entries with target_arg_id (wrong key) produce NO edges."""
+        from argumentation_analysis.reporting.cross_reference_graph import (
+            CrossReferenceGraph,
+            EdgeType,
+        )
+
+        class MockState:
+            identified_arguments = {"arg_1": "First argument text"}
+            identified_fallacies = {
+                "fal_1": {
+                    "fallacy_type": "Ad hominem",
+                    "target_arg_id": "arg_1",
+                },
+            }
+            jtms_beliefs = {}
+            jtms_retraction_chain = []
+            counter_arguments = {}
+            dung_framework = {}
+            argument_quality_scores = {}
+            belief_revision_results = {}
+
+        graph = CrossReferenceGraph()
+        graph.build_from_state(MockState())
+        edges = graph.edges
+        fallacy_edges = [e for e in edges if e.edge_type == EdgeType.ARGUMENT_FALLACY]
+        assert len(fallacy_edges) == 0
+
+    def test_multiple_fallacies_multiple_edges(self):
+        """Multiple fallacies targeting different args produce multiple edges."""
+        from argumentation_analysis.reporting.cross_reference_graph import (
+            CrossReferenceGraph,
+            EdgeType,
+        )
+
+        class MockState:
+            identified_arguments = {
+                "arg_1": "First",
+                "arg_2": "Second",
+                "arg_3": "Third",
+            }
+            identified_fallacies = {
+                "fal_1": {
+                    "fallacy_type": "Post hoc",
+                    "target_argument_id": "arg_1",
+                },
+                "fal_2": {
+                    "fallacy_type": "Ad hominem",
+                    "target_argument_id": "arg_3",
+                },
+            }
+            jtms_beliefs = {}
+            jtms_retraction_chain = []
+            counter_arguments = {}
+            dung_framework = {}
+            argument_quality_scores = {}
+            belief_revision_results = {}
+
+        graph = CrossReferenceGraph()
+        graph.build_from_state(MockState())
+        edges = graph.edges
+        fallacy_edges = [e for e in edges if e.edge_type == EdgeType.ARGUMENT_FALLACY]
+        assert len(fallacy_edges) == 2
+        targets = {e.source for e in fallacy_edges}
+        assert targets == {"arg_1", "arg_3"}
+
+
+class TestASPICFallacyUndermining:
+    """BUG A1 fix: ASPIC+ uses canonical arg_id, not positional index."""
+
+    def _make_state_with_fallacies(self, fallacies_targeting):
+        """Create a mock state with arguments and fallacies.
+
+        fallacies_targeting: list of canonical arg_ids that have fallacies
+        """
+
+        class MockState:
+            identified_arguments = {
+                "arg_1": "This is proven fact about economic policy",
+                "arg_2": "The data suggests economic improvement probably",
+                "arg_3": "We always see market fluctuations",
+            }
+            identified_fallacies = {}
+
+        state = MockState()
+        state.identified_fallacies = {
+            f"fal_{i}": {
+                "fallacy_type": "Test fallacy",
+                "target_argument_id": tid,
+            }
+            for i, tid in enumerate(fallacies_targeting)
+        }
+        return state
+
+    def test_fallacy_on_third_arg_detected(self):
+        """Fallacy targeting arg_3 should undermine arg_3, not arg_1 or arg_2."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _build_aspic_from_state,
+        )
+
+        state = self._make_state_with_fallacies(["arg_3"])
+        result = _build_aspic_from_state(state)
+        if result is None:
+            pytest.skip("ASPIC framework returned None")
+        defeated = result.get("defeated", [])
+        assert len(defeated) > 0
+
+    def test_no_fallacy_no_undermining(self):
+        """Without fallacies, no arguments should be defeated."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _build_aspic_from_state,
+        )
+
+        state = self._make_state_with_fallacies([])
+        result = _build_aspic_from_state(state)
+        if result is None:
+            pytest.skip("ASPIC framework returned None")
+        defeated = result.get("defeated", [])
+        assert len(defeated) == 0
+
+
+class TestATMSHypothesisQualityLookup:
+    """BUG IC5 fix: hypothesis quality lookup uses canonical key."""
+
+    def test_high_quality_hypothesis_populated(self):
+        """h_high_quality populated when quality scores use canonical keys."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _generate_hypotheses,
+        )
+
+        arg_names = ["First argument text", "Second argument text"]
+        claim_names = ["Conclusion 1"]
+        fallacies = []
+        per_arg_scores = {
+            "arg_1": {"overall": 7.5},
+            "arg_2": {"overall": 2.0},
+        }
+        hypotheses = _generate_hypotheses(
+            arg_names, claim_names, fallacies, per_arg_scores
+        )
+        hq = [h for h in hypotheses if h["id"] == "h_high_quality"]
+        assert len(hq) == 1
+        assert arg_names[0] in hq[0]["assumptions"]
+        assert arg_names[1] not in hq[0]["assumptions"]
+
+    def test_all_low_quality_no_hypothesis(self):
+        """No h_high_quality when all scores are below threshold."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _generate_hypotheses,
+        )
+
+        arg_names = ["First argument text", "Second argument text"]
+        claim_names = ["Conclusion 1"]
+        fallacies = []
+        per_arg_scores = {
+            "arg_1": {"overall": 1.0},
+            "arg_2": {"overall": 2.0},
+        }
+        hypotheses = _generate_hypotheses(
+            arg_names, claim_names, fallacies, per_arg_scores
+        )
+        hq = [h for h in hypotheses if h["id"] == "h_high_quality"]
+        assert len(hq) == 0
+
+    def test_all_high_quality_no_hypothesis(self):
+        """No h_high_quality when ALL args are high quality (same as h_full_trust)."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _generate_hypotheses,
+        )
+
+        arg_names = ["First argument text", "Second argument text"]
+        claim_names = ["Conclusion 1"]
+        fallacies = []
+        per_arg_scores = {
+            "arg_1": {"overall": 8.0},
+            "arg_2": {"overall": 9.0},
+        }
+        hypotheses = _generate_hypotheses(
+            arg_names, claim_names, fallacies, per_arg_scores
+        )
+        hq = [h for h in hypotheses if h["id"] == "h_high_quality"]
+        assert len(hq) == 0
+
+    def test_empty_scores_no_crash(self):
+        """Empty per_arg_scores does not crash."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _generate_hypotheses,
+        )
+
+        hypotheses = _generate_hypotheses(["arg text"], ["claim"], [], {})
+        assert isinstance(hypotheses, list)
+        assert len(hypotheses) >= 1
+
+
+class TestSocialScoringQualityLookup:
+    """BUG IC6 fix: social scoring quality lookup uses canonical key."""
+
+    def test_quality_boost_applied_with_canonical_key(self):
+        """Social scoring incorporates quality when keyed by canonical arg_id."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _python_social_fallback,
+        )
+
+        args = ["First argument", "Second argument"]
+        attacks = []
+        votes = {}
+        context = {
+            "phase_quality_output": {
+                "quality_scores": {
+                    "arg_1": {"overall": 0.9},
+                    "arg_2": {"overall": 0.2},
+                },
+            },
+        }
+        result = _python_social_fallback(args, attacks, votes, context)
+        scores = result["social_scores"]
+        assert scores["First argument"] > scores["Second argument"]
+
+    def test_no_quality_boost_without_data(self):
+        """Social scoring works without quality data (base scores only)."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _python_social_fallback,
+        )
+
+        args = ["First argument", "Second argument"]
+        attacks = []
+        votes = {}
+        context = {}
+        result = _python_social_fallback(args, attacks, votes, context)
+        scores = result["social_scores"]
+        assert len(scores) == 2


### PR DESCRIPTION
## Summary

Static audit of ALL text-label ↔ canonical arg_id boundaries in the pipeline. Found and fixed **4 bugs** — all the same class as LL (JTMS) and RR (Dung): upstream produces free-text keys, downstream expects canonical `arg_N`.

### Bugs fixed

| Bug | File | Impact |
|-----|------|--------|
| A2 | `cross_reference_graph.py` | Wrong key `"target_arg_id"` → `"target_argument_id"`. **0 fallacy→argument edges ever created** in cross-reference graph. |
| A1 | `conversational_orchestrator.py` | ASPIC+ used positional `arg_ids[i]` instead of canonical `f"arg_{i+1}"`. Fallacy undermining classification unreliable. |
| IC5 | `invoke_callables.py` | ATMS `h_high_quality` hypothesis never populated — free-text lookup in canonical-keyed quality dict. |
| IC6 | `invoke_callables.py` | Social AF fallback quality signal lost — same free-text vs canonical mismatch. |

### Audit results

26 sites audited across 4 target files + 13 extended files:
- **4 BUG** (fixed)
- **7 AT-RISK** (documented in report, not fixed — graceful degradation or low-impact)
- **15 SAFE** (confirmed correct)

### Changed files

| File | Change |
|------|--------|
| `argumentation_analysis/reporting/cross_reference_graph.py` | Fix key `target_arg_id` → `target_argument_id` (2 sites) |
| `argumentation_analysis/orchestration/conversational_orchestrator.py` | Fix ASPIC+ positional index → canonical `arg_{i+1}` (2 sites) |
| `argumentation_analysis/orchestration/invoke_callables.py` | Fix hypothesis + social quality lookup: positional canonical key (2 sites) |
| `tests/unit/argumentation_analysis/test_track_tt_text_label_audit.py` | NEW: 11 tests (9 pass, 2 skip) |
| `docs/reports/static_audit_tt_672.md` | NEW: full audit report |

### Test plan

- [x] 11 unit tests (9 pass, 2 ASPIC+ skip — need fuller state mock)
- [x] Privacy grep: clean (opaque IDs only)
- [x] Black formatting applied
- [x] No API calls — all synthetic state

🤖 Generated with [Claude Code](https://claude.com/claude-code)