### PR TITLE
fix(determinism): model-aware params for reasoning models — Track AA (#686)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ OPENAI_CHAT_MODEL_ID="gpt-5-mini"
 # LLM_TEMPERATURE=0.0
 # LLM_SEED=42
 # LLM_DETERMINISTIC_MODE=""
+#
+# Reasoning models (gpt-5*, o1*, o3*) reject temperature/seed with a 400.
+# When such a model is detected, determinism params are suppressed automatically.
+# To force sending them anyway (you know your endpoint accepts them):
+# LLM_FORCE_SAMPLING_PARAMS=1
 
 # Pour OpenRouter (alternative provider — bascule de secours si quota OpenAI épuisé)
 # Définir les 2 vars ci-dessous active automatiquement le routage via OpenRouter

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -88,12 +88,44 @@ __all__ = [
 ]
 
 
+_REASONING_MODEL_PREFIXES: Tuple[str, ...] = (
+    "gpt-5",
+    "o1",
+    "o3",
+    "openai/gpt-5",
+    "openai/o1",
+    "openai/o3",
+)
+
+
+def _resolve_model_id() -> str:
+    """Resolve the active chat model id from environment (mirrors _get_openai_client)."""
+    openrouter_base_url = os.environ.get("OPENROUTER_BASE_URL")
+    openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+    if openrouter_base_url and openrouter_api_key:
+        return os.environ.get(
+            "OPENROUTER_CHAT_MODEL_ID",
+            os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini"),
+        )
+    return os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+
+
+def _is_reasoning_model(model_id: str) -> bool:
+    """Return True if *model_id* belongs to a known reasoning-model family."""
+    lower = model_id.lower()
+    return any(lower.startswith(p) for p in _REASONING_MODEL_PREFIXES)
+
+
 def _get_determinism_params() -> Dict[str, Any]:
     """Read determinism settings from environment variables.
 
     Supports two modes:
     - LLM_DETERMINISTIC_MODE=1: shorthand for temperature=0, seed=42
     - LLM_TEMPERATURE / LLM_SEED: fine-grained overrides (take precedence)
+
+    When the active chat model is a known reasoning model (gpt-5*, o1*, o3*),
+    temperature/seed are suppressed unless ``LLM_FORCE_SAMPLING_PARAMS=1`` is set,
+    because reasoning models typically reject those parameters with a 400 BadRequest.
 
     Returns a dict suitable for merging into ``client.chat.completions.create()``.
     """
@@ -113,6 +145,22 @@ def _get_determinism_params() -> Dict[str, Any]:
             params["seed"] = int(seed_str)
         except ValueError:
             pass
+
+    if params and _is_reasoning_model(_resolve_model_id()):
+        if os.environ.get("LLM_FORCE_SAMPLING_PARAMS"):
+            logger.warning(
+                "Determinism params forced on reasoning model '%s' — may 400.",
+                _resolve_model_id(),
+            )
+        else:
+            logger.warning(
+                "Determinism requested but reasoning model '%s' does not support "
+                "temperature/seed — params suppressed. Set LLM_FORCE_SAMPLING_PARAMS=1 "
+                "to override.",
+                _resolve_model_id(),
+            )
+            params = {}
+
     return params
 
 

--- a/docs/reports/extraction_variance_xx_680.md
+++ b/docs/reports/extraction_variance_xx_680.md
@@ -1,8 +1,30 @@
 # Track XX (#680): Extraction Run-to-Run Variance Report
 
+> **Updated by Track AA (#686):** The determinism knob is now **model-aware** — reasoning models (gpt-5*, o1*, o3*) automatically suppress temperature/seed params to avoid a 400 BadRequest. See the [Reasoning-Model Caveat](#reasoning-model-caveat-aa-686) section.
+
 ## Summary
 
 Characterization of non-determinism sources in the argument extraction pipeline. A **determinism knob** is implemented (`LLM_DETERMINISTIC_MODE`, `LLM_TEMPERATURE`, `LLM_SEED` env vars) that propagates `temperature=0` + `seed=42` (or custom values) to all 10 LLM call sites in `invoke_callables.py`. Downstream parsing and aggregation are confirmed deterministic.
+
+## Reasoning-Model Caveat (AA #686)
+
+Reasoning models (gpt-5 family, o1, o3) **reject** `temperature` and `seed` parameters with a `400 BadRequest`. Since the cluster's production model is `gpt-5-mini`, the knob would be a foot-gun if applied naively.
+
+**Solution**: `_get_determinism_params()` now detects the active model (via `OPENAI_CHAT_MODEL_ID` / `OPENROUTER_CHAT_MODEL_ID`) and **suppresses** temperature/seed for known reasoning-model prefixes. A `WARN` log is emitted when determinism is requested but unsupported.
+
+| Prefix | Classification |
+|--------|---------------|
+| `gpt-5` | Reasoning — suppress |
+| `o1` | Reasoning — suppress |
+| `o3` | Reasoning — suppress |
+| `openai/gpt-5` | Reasoning — suppress |
+| `openai/o1` | Reasoning — suppress |
+| `openai/o3` | Reasoning — suppress |
+| `gpt-4o` | Standard — allow |
+| `gpt-4` | Standard — allow |
+| Others | Standard — allow |
+
+**Escape hatch**: Set `LLM_FORCE_SAMPLING_PARAMS=1` to force sending temperature/seed regardless of model detection (e.g. for self-hosted endpoints that accept these params even on reasoning architectures).
 
 ## Sources of Non-Determinism
 
@@ -85,8 +107,9 @@ def _get_determinism_params() -> Dict[str, Any]:
 | `LLM_DETERMINISTIC_MODE` | Set `temperature=0` + `seed=42` | Not set (no effect) |
 | `LLM_TEMPERATURE` | Override temperature (float) | Not set |
 | `LLM_SEED` | Set seed (int) | Not set |
+| `LLM_FORCE_SAMPLING_PARAMS` | Force temperature/seed even on reasoning models | Not set |
 
-Fine-grained overrides take precedence over the shorthand.
+Fine-grained overrides take precedence over the shorthand. Reasoning models suppress params unless force flag is set.
 
 ### Usage
 
@@ -114,6 +137,13 @@ The knob applies to all 10 raw-SDK LLM call sites in `invoke_callables.py` (fact
 - 3 JSON parsing determinism tests
 - 3 extraction metrics determinism tests
 - 6 source wiring verification tests
+
+- 14 tests in `tests/unit/argumentation_analysis/test_track_aa_model_aware_determinism.py`:
+
+  - 3 model resolution tests (`_resolve_model_id`)
+  - 17 reasoning model classification tests (`_is_reasoning_model`, parametrized)
+  - 9 model-aware determinism tests (suppression, allow-list, force flag, fine-grained)
+  - 1 backward-compat test (XX default behavior preserved)
 
 ## Deferred
 

--- a/tests/unit/argumentation_analysis/test_track_aa_model_aware_determinism.py
+++ b/tests/unit/argumentation_analysis/test_track_aa_model_aware_determinism.py
@@ -1,0 +1,295 @@
+"""Tests for Track AA (#686): model-aware determinism.
+
+Covers:
+  1. Reasoning model + deterministic mode → params suppressed
+  2. Non-reasoning model + deterministic mode → temperature/seed present
+  3. Force flag re-enables params for reasoning models
+  4. Unset env vars → {} unchanged
+  5. _resolve_model_id and _is_reasoning_model unit tests
+"""
+
+import os
+
+import pytest
+
+
+def _clear_det_env():
+    """Remove all determinism-related env vars."""
+    for key in (
+        "LLM_DETERMINISTIC_MODE",
+        "LLM_TEMPERATURE",
+        "LLM_SEED",
+        "LLM_FORCE_SAMPLING_PARAMS",
+        "OPENAI_CHAT_MODEL_ID",
+        "OPENROUTER_CHAT_MODEL_ID",
+        "OPENROUTER_BASE_URL",
+        "OPENROUTER_API_KEY",
+    ):
+        os.environ.pop(key, None)
+
+
+class TestResolveModelId:
+    """_resolve_model_id picks the right model from env."""
+
+    def setup_method(self):
+        self._saved = {}
+        for key in (
+            "OPENAI_CHAT_MODEL_ID",
+            "OPENROUTER_CHAT_MODEL_ID",
+            "OPENROUTER_BASE_URL",
+            "OPENROUTER_API_KEY",
+        ):
+            self._saved[key] = os.environ.get(key)
+
+    def teardown_method(self):
+        for key, val in self._saved.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    def test_default_model(self):
+        """OPENAI_CHAT_MODEL_ID explicitly set to known value."""
+        _clear_det_env()
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-5-mini"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _resolve_model_id,
+            )
+
+            assert _resolve_model_id() == "gpt-5-mini"
+        finally:
+            os.environ.pop("OPENAI_CHAT_MODEL_ID", None)
+
+    def test_openai_model_id(self):
+        """OPENAI_CHAT_MODEL_ID overrides default."""
+        _clear_det_env()
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-4o"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _resolve_model_id,
+            )
+
+            assert _resolve_model_id() == "gpt-4o"
+        finally:
+            os.environ.pop("OPENAI_CHAT_MODEL_ID", None)
+
+    def test_openrouter_model_preferred(self):
+        """When OpenRouter is configured, OPENROUTER_CHAT_MODEL_ID is used."""
+        _clear_det_env()
+        os.environ["OPENROUTER_BASE_URL"] = "https://openrouter.ai/api/v1"
+        os.environ["OPENROUTER_API_KEY"] = "sk-or-test"
+        os.environ["OPENROUTER_CHAT_MODEL_ID"] = "openai/gpt-4o"
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-5-mini"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _resolve_model_id,
+            )
+
+            assert _resolve_model_id() == "openai/gpt-4o"
+        finally:
+            _clear_det_env()
+
+
+class TestIsReasoningModel:
+    """_is_reasoning_model correctly classifies model ids."""
+
+    @pytest.mark.parametrize(
+        "model_id,expected",
+        [
+            ("gpt-5-mini", True),
+            ("gpt-5", True),
+            ("gpt-5-turbo", True),
+            ("o1-preview", True),
+            ("o1-mini", True),
+            ("o3-mini", True),
+            ("o3", True),
+            ("openai/gpt-5-mini", True),
+            ("openai/o1-preview", True),
+            ("openai/o3-mini", True),
+            ("gpt-4o", False),
+            ("gpt-4o-mini", False),
+            ("gpt-4-turbo", False),
+            ("claude-3-opus", False),
+            ("mistral-large", False),
+            ("deepseek-chat", False),
+        ],
+    )
+    def test_reasoning_classification(self, model_id, expected):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _is_reasoning_model,
+        )
+
+        assert _is_reasoning_model(model_id) is expected
+
+
+class TestModelAwareDeterminism:
+    """_get_determinism_params respects model type."""
+
+    def setup_method(self):
+        self._saved = {}
+        for key in (
+            "LLM_DETERMINISTIC_MODE",
+            "LLM_TEMPERATURE",
+            "LLM_SEED",
+            "LLM_FORCE_SAMPLING_PARAMS",
+            "OPENAI_CHAT_MODEL_ID",
+            "OPENROUTER_CHAT_MODEL_ID",
+            "OPENROUTER_BASE_URL",
+            "OPENROUTER_API_KEY",
+        ):
+            self._saved[key] = os.environ.get(key)
+
+    def teardown_method(self):
+        for key, val in self._saved.items():
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    def test_reasoning_model_suppresses_params(self):
+        """gpt-5-mini + LLM_DETERMINISTIC_MODE=1 → params suppressed."""
+        _clear_det_env()
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-5-mini"
+        os.environ["LLM_DETERMINISTIC_MODE"] = "1"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _get_determinism_params,
+            )
+
+            assert _get_determinism_params() == {}
+        finally:
+            _clear_det_env()
+
+    def test_reasoning_model_openrouter_slug_suppresses(self):
+        """openai/gpt-5-mini + deterministic mode → suppressed."""
+        _clear_det_env()
+        os.environ["OPENROUTER_BASE_URL"] = "https://openrouter.ai/api/v1"
+        os.environ["OPENROUTER_API_KEY"] = "sk-or-test"
+        os.environ["OPENROUTER_CHAT_MODEL_ID"] = "openai/gpt-5-mini"
+        os.environ["LLM_DETERMINISTIC_MODE"] = "1"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _get_determinism_params,
+            )
+
+            assert _get_determinism_params() == {}
+        finally:
+            _clear_det_env()
+
+    def test_o1_suppresses(self):
+        """o1-preview + deterministic mode → suppressed."""
+        _clear_det_env()
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "o1-preview"
+        os.environ["LLM_DETERMINISTIC_MODE"] = "1"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _get_determinism_params,
+            )
+
+            assert _get_determinism_params() == {}
+        finally:
+            _clear_det_env()
+
+    def test_o3_suppresses(self):
+        """o3-mini + deterministic mode → suppressed."""
+        _clear_det_env()
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "o3-mini"
+        os.environ["LLM_DETERMINISTIC_MODE"] = "1"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _get_determinism_params,
+            )
+
+            assert _get_determinism_params() == {}
+        finally:
+            _clear_det_env()
+
+    def test_non_reasoning_model_allows_params(self):
+        """gpt-4o + deterministic mode → temperature/seed present."""
+        _clear_det_env()
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-4o"
+        os.environ["LLM_DETERMINISTIC_MODE"] = "1"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _get_determinism_params,
+            )
+
+            result = _get_determinism_params()
+            assert result["temperature"] == 0.0
+            assert result["seed"] == 42
+        finally:
+            _clear_det_env()
+
+    def test_force_flag_reenables_on_reasoning_model(self):
+        """gpt-5-mini + deterministic + LLM_FORCE_SAMPLING_PARAMS=1 → params present."""
+        _clear_det_env()
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-5-mini"
+        os.environ["LLM_DETERMINISTIC_MODE"] = "1"
+        os.environ["LLM_FORCE_SAMPLING_PARAMS"] = "1"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _get_determinism_params,
+            )
+
+            result = _get_determinism_params()
+            assert result["temperature"] == 0.0
+            assert result["seed"] == 42
+        finally:
+            _clear_det_env()
+
+    def test_unset_env_returns_empty(self):
+        """No determinism env vars → {} regardless of model."""
+        _clear_det_env()
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-5-mini"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _get_determinism_params,
+            )
+
+            assert _get_determinism_params() == {}
+        finally:
+            _clear_det_env()
+
+    def test_fine_grained_override_suppressed_on_reasoning(self):
+        """LLM_TEMPERATURE=0.3 + gpt-5-mini → suppressed."""
+        _clear_det_env()
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-5-mini"
+        os.environ["LLM_TEMPERATURE"] = "0.3"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _get_determinism_params,
+            )
+
+            assert _get_determinism_params() == {}
+        finally:
+            _clear_det_env()
+
+    def test_fine_grained_override_kept_on_non_reasoning(self):
+        """LLM_TEMPERATURE=0.3 + gpt-4o → kept."""
+        _clear_det_env()
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-4o"
+        os.environ["LLM_TEMPERATURE"] = "0.3"
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _get_determinism_params,
+            )
+
+            result = _get_determinism_params()
+            assert result == {"temperature": 0.3}
+        finally:
+            _clear_det_env()
+
+
+class TestXxTestsStillPass:
+    """Verify existing XX tests still pass with the new model-aware behavior."""
+
+    def test_xx_default_empty_still_works(self):
+        """Original XX test: no env vars → {}."""
+        _clear_det_env()
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _get_determinism_params,
+        )
+
+        # Default model is gpt-5-mini (reasoning) but no det mode → {}
+        assert _get_determinism_params() == {}

--- a/tests/unit/argumentation_analysis/test_track_xx_extraction_variance.py
+++ b/tests/unit/argumentation_analysis/test_track_xx_extraction_variance.py
@@ -39,6 +39,10 @@ class TestGetDeterminismParams:
 
         os.environ.pop("LLM_TEMPERATURE", None)
         os.environ.pop("LLM_SEED", None)
+        os.environ.pop("LLM_FORCE_SAMPLING_PARAMS", None)
+        # Use a standard (non-reasoning) model so params are not suppressed
+        prev_model = os.environ.get("OPENAI_CHAT_MODEL_ID")
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-4o"
         os.environ["LLM_DETERMINISTIC_MODE"] = "1"
         try:
             result = _get_determinism_params()
@@ -46,6 +50,10 @@ class TestGetDeterminismParams:
             assert result["seed"] == 42
         finally:
             os.environ.pop("LLM_DETERMINISTIC_MODE", None)
+            if prev_model is None:
+                os.environ.pop("OPENAI_CHAT_MODEL_ID", None)
+            else:
+                os.environ["OPENAI_CHAT_MODEL_ID"] = prev_model
 
     def test_temperature_override(self):
         """LLM_TEMPERATURE=0.5 → temperature=0.5 only."""
@@ -55,12 +63,19 @@ class TestGetDeterminismParams:
 
         os.environ.pop("LLM_DETERMINISTIC_MODE", None)
         os.environ.pop("LLM_SEED", None)
+        os.environ.pop("LLM_FORCE_SAMPLING_PARAMS", None)
+        prev_model = os.environ.get("OPENAI_CHAT_MODEL_ID")
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-4o"
         os.environ["LLM_TEMPERATURE"] = "0.5"
         try:
             result = _get_determinism_params()
             assert result == {"temperature": 0.5}
         finally:
             os.environ.pop("LLM_TEMPERATURE", None)
+            if prev_model is None:
+                os.environ.pop("OPENAI_CHAT_MODEL_ID", None)
+            else:
+                os.environ["OPENAI_CHAT_MODEL_ID"] = prev_model
 
     def test_seed_override(self):
         """LLM_SEED=123 → seed=123 only."""
@@ -70,12 +85,19 @@ class TestGetDeterminismParams:
 
         os.environ.pop("LLM_DETERMINISTIC_MODE", None)
         os.environ.pop("LLM_TEMPERATURE", None)
+        os.environ.pop("LLM_FORCE_SAMPLING_PARAMS", None)
+        prev_model = os.environ.get("OPENAI_CHAT_MODEL_ID")
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-4o"
         os.environ["LLM_SEED"] = "123"
         try:
             result = _get_determinism_params()
             assert result == {"seed": 123}
         finally:
             os.environ.pop("LLM_SEED", None)
+            if prev_model is None:
+                os.environ.pop("OPENAI_CHAT_MODEL_ID", None)
+            else:
+                os.environ["OPENAI_CHAT_MODEL_ID"] = prev_model
 
     def test_individual_overrides_take_precedence(self):
         """LLM_TEMPERATURE and LLM_SEED override LLM_DETERMINISTIC_MODE values."""
@@ -83,6 +105,9 @@ class TestGetDeterminismParams:
             _get_determinism_params,
         )
 
+        os.environ.pop("LLM_FORCE_SAMPLING_PARAMS", None)
+        prev_model = os.environ.get("OPENAI_CHAT_MODEL_ID")
+        os.environ["OPENAI_CHAT_MODEL_ID"] = "gpt-4o"
         os.environ["LLM_DETERMINISTIC_MODE"] = "1"
         os.environ["LLM_TEMPERATURE"] = "0.7"
         os.environ["LLM_SEED"] = "999"
@@ -94,6 +119,10 @@ class TestGetDeterminismParams:
             os.environ.pop("LLM_DETERMINISTIC_MODE", None)
             os.environ.pop("LLM_TEMPERATURE", None)
             os.environ.pop("LLM_SEED", None)
+            if prev_model is None:
+                os.environ.pop("OPENAI_CHAT_MODEL_ID", None)
+            else:
+                os.environ["OPENAI_CHAT_MODEL_ID"] = prev_model
 
     def test_invalid_temperature_ignored(self):
         """Non-numeric LLM_TEMPERATURE is silently skipped."""


### PR DESCRIPTION
## Summary

- Make `_get_determinism_params()` model-aware: detects reasoning models (gpt-5*, o1*, o3*, openai/ prefixed variants) and suppresses temperature/seed params to prevent 400 BadRequest
- Add `LLM_FORCE_SAMPLING_PARAMS=1` escape hatch for users who know their endpoint accepts these params
- Emit WARN log when determinism is requested but unsupported for the active model
- Update XX tests to explicitly set `OPENAI_CHAT_MODEL_ID=gpt-4o` to avoid .env interference

## Files changed

| File | Change |
|------|--------|
| `argumentation_analysis/orchestration/invoke_callables.py` | +3 helpers (`_resolve_model_id`, `_is_reasoning_model`, `_REASONING_MODEL_PREFIXES`), model-aware suppression in `_get_determinism_params()` |
| `tests/unit/argumentation_analysis/test_track_aa_model_aware_determinism.py` | NEW — 29 tests (model resolution, classification, suppression, force flag, backward-compat) |
| `tests/unit/argumentation_analysis/test_track_xx_extraction_variance.py` | Fix 4 tests to set model id explicitly (gpt-4o) to avoid .env gpt-5-mini interference |
| `.env.example` | Document `LLM_FORCE_SAMPLING_PARAMS` env var |
| `docs/reports/extraction_variance_xx_680.md` | Add reasoning-model caveat section (AA #686) |

## Test plan

- [x] 29 new AA tests pass (model resolution, reasoning classification, suppression, force flag)
- [x] 20 existing XX tests pass (backward-compat preserved with explicit model id)
- [x] mypy strict clean on `invoke_callables.py`
- [ ] Live determinism verification deferred to ai-01 (API quota required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
