### PR TITLE
feat(convergence): run narrative_synthesis in build_full_workflow — Track II (#698)

### DIFF
--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -227,6 +227,24 @@ def build_full_workflow() -> WorkflowDefinition:
             depends_on=["dung_extensions"],
             optional=True,
         )
+        # Convergence synthesis (II #698): compute the 5-signal convergence
+        # metric in-run on the sequential `full` path too (previously only
+        # build_spectacular_workflow ran it). Depends on every phase that
+        # populates a convergence signal: hierarchical_fallacy (sophisme),
+        # quality (qualité faible), counter (contre-argument), jtms (JTMS
+        # rétracté), dung_extensions (rejet Dung).
+        .add_phase(
+            "narrative_synthesis",
+            capability="narrative_synthesis",
+            depends_on=[
+                "quality",
+                "hierarchical_fallacy",
+                "counter",
+                "jtms",
+                "dung_extensions",
+            ],
+            optional=True,
+        )
         .build()
     )
 

--- a/tests/unit/argumentation_analysis/orchestration/test_narrative_synthesis_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_narrative_synthesis_spectacular.py
@@ -70,3 +70,31 @@ class TestNarrativeSynthesisRegistration:
         assert "atms" in deps
         assert "dung_extensions" in deps
         assert phase["narrative_synthesis"].optional is True
+
+    def test_full_has_narrative_synthesis_phase(self):
+        """II #698: the sequential `full` path computes convergence in-run too.
+
+        Previously only build_spectacular_workflow ran narrative_synthesis, so
+        the `full` path produced no convergence metric in-run. This wires it,
+        depending on every phase that populates one of the 5 convergence
+        signals.
+        """
+        from argumentation_analysis.orchestration.workflows import (
+            build_full_workflow,
+        )
+
+        wf = build_full_workflow()
+        phase = {p.name: p for p in wf.phases}
+        assert "narrative_synthesis" in phase
+        assert phase["narrative_synthesis"].capability == "narrative_synthesis"
+        deps = phase["narrative_synthesis"].depends_on
+        # All 5 convergence-signal producers must be upstream dependencies.
+        for signal_phase in (
+            "quality",
+            "hierarchical_fallacy",
+            "counter",
+            "jtms",
+            "dung_extensions",
+        ):
+            assert signal_phase in deps, f"{signal_phase} missing from deps"
+        assert phase["narrative_synthesis"].optional is True


### PR DESCRIPTION
## Track II — Convergence in the sequential `full` path (#698)

Parent Epic: #695.

### The gap (grounded)
`build_full_workflow` did **NOT** run `narrative_synthesis` — only `build_spectacular_workflow` invoked it. `narrative_synthesis_plugin.compute_argument_convergence` is what produces the convergence depth metric (the 5-signal: fallacy / quality / counter / jtms / dung). So the individual/sequential `full` path computed **no convergence in-run** — convergence only existed if you separately called the plugin or ran `spectacular`. That was a blind spot: a user running `full` got no convergence signal.

### Change
- `build_full_workflow` now adds a `narrative_synthesis` phase, depending on **all 5 convergence-signal producers** that exist in the `full` DAG: `quality`, `hierarchical_fallacy`, `counter`, `jtms`, `dung_extensions`. `optional=True` (graceful, never hard-fails the run).
- `_invoke_narrative_synthesis` + its state writer were already wired (capability-keyed), so no new invoke/writer code needed.
- `spectacular` is untouched (still runs narrative_synthesis on its own dep shape).

### Tests
- `test_full_has_narrative_synthesis_phase` — asserts `build_full_workflow` includes a `narrative_synthesis` phase with all 5 signal-producer deps and `optional=True`.
- Existing `test_spectacular_has_narrative_synthesis_phase` unchanged (no regression).
- 6/6 in the file pass; `black` + `flake8` clean.

### DoD
- [x] Unit test: `build_full_workflow` includes `narrative_synthesis` with correct dependencies.
- [ ] Live-verify on corpus C (funded key): `run_unified_analysis(text, workflow_name="full")` → `compute_argument_convergence(state)` max depth ≥3 in-run. *(coordinator will live-verify post-merge)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)