### PR TITLE
fix(counter-args): remove ≤5 cap + sweep all targets — Track GG (#696)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -871,6 +871,32 @@ async def run_conversational_analysis(
         except Exception as e:
             logger.warning(f"Belief revision post-processing failed: {e}")
 
+    # 5b-6. Counter-argument enrichment (GG #696)
+    # The conversational dialogue under-produces counter-arguments (often 1),
+    # losing to the zero-shot baseline on the quantitative axis. Sweep every
+    # identified argument and ensure >=1 counter-argument per argument, so the
+    # collaborative path matches the sequential path's coverage.
+    n_args = len(getattr(state, "identified_arguments", []) or [])
+    n_cas = len(getattr(state, "counter_arguments", []) or [])
+    if spectacular and n_args and n_cas < n_args:
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _generate_counter_arguments_from_state,
+            )
+
+            ca_result = await _generate_counter_arguments_from_state(state)
+            if ca_result and ca_result.get("added"):
+                conversation_log.append(
+                    {
+                        "phase": "post_processing",
+                        "type": "counter_argument_enrichment",
+                        "added": ca_result["added"],
+                        "targets": ca_result["targets"],
+                    }
+                )
+        except Exception as e:
+            logger.warning(f"Counter-argument enrichment post-processing failed: {e}")
+
     # 5c. Deep Synthesis post-phase (#534)
     # Run DeepSynthesisAgent on the accumulated state to produce a 9-section
     # grounded markdown report. Appended as terminal step after all agents.

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -454,6 +454,132 @@ async def _llm_enrich_quality(
     return None
 
 
+def _parse_counter_array(raw: str) -> List[Dict[str, Any]]:
+    """Extract a JSON array of counter-argument dicts from an LLM response."""
+    text_content = (raw or "").strip()
+    if "```json" in text_content:
+        text_content = text_content.split("```json")[1].split("```")[0]
+    elif "```" in text_content:
+        text_content = text_content.split("```")[1].split("```")[0]
+    start_arr = text_content.find("[")
+    end_arr = text_content.rfind("]") + 1
+    if start_arr >= 0 and end_arr > start_arr:
+        try:
+            parsed = json.loads(text_content[start_arr:end_arr])
+            if isinstance(parsed, list):
+                return [c for c in parsed if isinstance(c, dict)]
+        except Exception:
+            pass
+    start = text_content.find("{")
+    end = text_content.rfind("}") + 1
+    if start >= 0 and end > start:
+        try:
+            obj = json.loads(text_content[start:end])
+            if isinstance(obj, dict):
+                return [obj]
+        except Exception:
+            pass
+    return []
+
+
+async def _generate_counters_for_targets(
+    client: Any,
+    model_id: str,
+    targets: List[str],
+    batch_size: int = 12,
+) -> List[Dict[str, Any]]:
+    """Generate one counter-argument per target via the LLM (GG #696).
+
+    No cap on the number of targets — every fallacious/weak argument is swept,
+    so the pipeline beats the zero-shot baseline on counter-argument volume
+    instead of losing to it. Long target lists are split into batches because a
+    single mega-prompt silently drops items past the first handful.
+    """
+    counters: List[Dict[str, Any]] = []
+    det_params = _get_determinism_params()
+    system_prompt = (
+        "You are an expert in argumentation and counter-argument generation. "
+        "For EACH argument/fallacy listed, generate a targeted counter-argument "
+        "using the most appropriate strategy: reductio ad absurdum, "
+        "counter-example, distinction, reformulation, or concession+pivot. "
+        "Return EXACTLY one counter-argument per listed item. "
+        "Respond with ONLY a JSON array:\n"
+        '[{"counter_argument": "text", "strategy_used": "name", '
+        '"target_argument": "which argument", "strength": "weak|moderate|strong", '
+        '"reasoning": "why this works"}, ...]'
+    )
+    for start in range(0, len(targets), batch_size):
+        batch = targets[start : start + batch_size]
+        targets_text = "\n".join(f"{i+1}. {t}" for i, t in enumerate(batch))
+        try:
+            response = await client.chat.completions.create(
+                model=model_id,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": targets_text},
+                ],
+                **det_params,
+            )
+            raw = response.choices[0].message.content or ""
+            counters.extend(_parse_counter_array(raw))
+        except Exception as e:
+            logger.warning(
+                f"Counter-argument batch [{start}:{start + batch_size}] failed: {e}"
+            )
+    return counters
+
+
+async def _generate_counter_arguments_from_state(state: Any) -> Dict[str, Any]:
+    """Ensure >=1 counter-argument per identified argument (GG #696).
+
+    The conversational path under-produces counter-arguments (the agent emits a
+    handful before its turn budget runs out), so the collaborative path loses to
+    the zero-shot baseline on volume. This deterministic post-processor mirrors
+    the Dung/modal/ASPIC post-processors: after the dialogue, it sweeps every
+    identified argument and generates a targeted counter-argument, written back
+    via ``state.add_counter_argument``.
+    """
+    args = getattr(state, "identified_arguments", []) or []
+    targets: List[str] = []
+    for a in args:
+        if isinstance(a, dict):
+            text = a.get("text") or a.get("description") or a.get("content") or ""
+        else:
+            text = str(a)
+        text = str(text).strip()
+        if text:
+            targets.append(text)
+    if not targets:
+        return {"added": 0, "targets": 0}
+
+    client, model_id = _get_openai_client()
+    if not client:
+        return {"added": 0, "targets": len(targets)}
+
+    counters = await _generate_counters_for_targets(client, model_id, targets)
+    counters = _evaluate_counter_arguments(counters, targets[0])
+
+    added = 0
+    for ca in counters:
+        if not isinstance(ca, dict):
+            continue
+        content = ca.get("counter_argument", "")
+        if not content:
+            continue
+        score = float(ca.get("evaluation_score", ca.get("score", 0.0)) or 0.0)
+        try:
+            state.add_counter_argument(
+                original_arg=str(ca.get("target_argument", ""))[:300],
+                counter_content=str(content),
+                strategy=str(ca.get("strategy_used", "")),
+                score=score,
+            )
+            added += 1
+        except Exception as e:
+            logger.debug(f"add_counter_argument failed: {e}")
+    return {"added": added, "targets": len(targets)}
+
+
 async def _invoke_counter_argument(
     input_text: str, context: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -491,9 +617,13 @@ async def _invoke_counter_argument(
                 else {}
             )
 
-            # Build targets: fallacious arguments first, then weakest by quality
+            # Build targets: ALL fallacious arguments + ALL arguments by quality.
+            # GG #696: the previous top-3 fallacies + 5-total caps held output to
+            # <=5 counter-arguments, losing to the zero-shot baseline on volume.
+            # Sweep every target; _generate_counters_for_targets batches the
+            # LLM calls so coverage stays reliable on dense corpora.
             targets = []
-            for f in fallacies[:3]:  # Top 3 fallacies
+            for f in fallacies:
                 if isinstance(f, dict):
                     targets.append(
                         f"[FALLACY: {f.get('type', f.get('fallacy_type', ''))}] "
@@ -510,51 +640,15 @@ async def _invoke_counter_argument(
             scored_args.sort(key=lambda x: x[0])  # weakest first
 
             for score, text in scored_args:
-                if text and len(targets) < 5:
+                if text:
                     targets.append(f"[quality={score:.1f}/10] {text}")
 
             if not targets:
                 targets = [input_text[:500]]
 
-            # Ask for counter-arguments for ALL targets at once
-            targets_text = "\n".join(f"{i+1}. {t}" for i, t in enumerate(targets))
-            det_params = _get_determinism_params()
-            response = await client.chat.completions.create(
-                model=model_id,
-                messages=[
-                    {
-                        "role": "system",
-                        "content": (
-                            "You are an expert in argumentation and counter-argument generation. "
-                            "For EACH argument/fallacy listed, generate a targeted counter-argument "
-                            "using the most appropriate strategy: reductio ad absurdum, "
-                            "counter-example, distinction, reformulation, or concession+pivot. "
-                            "Respond with ONLY a JSON array:\n"
-                            '[{"counter_argument": "text", "strategy_used": "name", '
-                            '"target_argument": "which argument", "strength": "weak|moderate|strong", '
-                            '"reasoning": "why this works"}, ...]'
-                        ),
-                    },
-                    {"role": "user", "content": targets_text},
-                ],
-                **det_params,
+            llm_counters = await _generate_counters_for_targets(
+                client, model_id, targets
             )
-            raw = response.choices[0].message.content or ""
-            text_content = raw.strip()
-            if "```json" in text_content:
-                text_content = text_content.split("```json")[1].split("```")[0]
-            elif "```" in text_content:
-                text_content = text_content.split("```")[1].split("```")[0]
-            # Try to parse as array first, then single object
-            start_arr = text_content.find("[")
-            end_arr = text_content.rfind("]") + 1
-            if start_arr >= 0 and end_arr > start_arr:
-                llm_counters = json.loads(text_content[start_arr:end_arr])
-            else:
-                start = text_content.find("{")
-                end = text_content.rfind("}") + 1
-                if start >= 0 and end > start:
-                    llm_counters = [json.loads(text_content[start:end])]
     except Exception as e:
         logger.warning(f"LLM counter-argument enrichment failed: {e}")
 

--- a/scripts/measure_both_paths_vs_zeroshot.py
+++ b/scripts/measure_both_paths_vs_zeroshot.py
@@ -1,0 +1,248 @@
+"""Head-to-head measurement: DAG-spectacular vs Conversational vs Zero-shot.
+
+Exposes the real gaps with real numbers across EVERY dimension, on a single
+corpus, so we can see where each orchestration path beats / loses to zero-shot.
+
+  - Path A: run_unified_analysis(workflow_name="spectacular")  [DAG, single run]
+  - Path B: run_conversational_analysis(spectacular=True)       [SK AgentGroupChat]
+  - Zero-shot reference: docs/reports/BASELINE_0SHOT_2026-05-16.md (corpus C)
+
+Counts are privacy-clean (cardinalities only, no dataset text). Output goes
+under outputs/ (gitignored).
+
+Usage:
+    conda run -n projet-is-roo-new --no-capture-output python scripts/measure_both_paths_vs_zeroshot.py [--corpus C]
+
+Output: outputs/deep_analysis/both_paths_vs_zeroshot_<corpus>.json
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+os.chdir(Path(__file__).parent.parent)
+
+_env_path = Path(__file__).parent.parent / ".env"
+if _env_path.exists():
+    with open(_env_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, val = line.partition("=")
+                os.environ.setdefault(key.strip(), val.strip())
+
+from argumentation_analysis.core.utils.crypto_utils import derive_encryption_key
+from argumentation_analysis.core.io_manager import load_extract_definitions
+
+# Zero-shot reference numbers (BASELINE_0SHOT_2026-05-16.md), per corpus.
+ZERO_SHOT = {
+    "A": {"counter_arguments": 15, "pl_formulas": 14, "fol_formulas": 8, "fallacies": 0},
+    "B": {"counter_arguments": 12, "pl_formulas": 15, "fol_formulas": 13, "fallacies": 0},
+    "C": {"counter_arguments": 18, "pl_formulas": 12, "fol_formulas": 12, "fallacies": 0},
+}
+CORPUS_SRC_IDX = {"A": 11, "B": 3, "C": 2}
+OUTPUTS_DIR = Path("outputs/deep_analysis")
+
+
+def load_corpus(label: str) -> str:
+    key = derive_encryption_key(os.environ["TEXT_CONFIG_PASSPHRASE"])
+    defs = load_extract_definitions(
+        Path("argumentation_analysis/data/extract_sources.json.gz.enc"), key
+    )
+    text = defs[CORPUS_SRC_IDX[label]].get("full_text", "")
+    return text[:60000] if len(text) > 60000 else text
+
+
+def count_dimensions(state: Any) -> Dict[str, Any]:
+    """Privacy-clean cardinalities across every analysis dimension."""
+    if state is None:
+        return {"error": "no state"}
+
+    def _list(attr):
+        return getattr(state, attr, []) or []
+
+    def _dict(attr):
+        return getattr(state, attr, {}) or {}
+
+    pl_results = _list("propositional_analysis_results")
+    fol_results = _list("fol_analysis_results")
+    pl_formulas = sum(len(r.get("formulas", [])) for r in pl_results)
+    fol_formulas = sum(len(r.get("formulas", [])) for r in fol_results)
+    pl_verified = sum(
+        len(r.get("formulas", []))
+        for r in pl_results
+        if r.get("satisfiable") is not None
+    )
+    fol_verified = sum(
+        len(r.get("formulas", []))
+        for r in fol_results
+        if r.get("consistent") is not None
+    )
+
+    # Convergence depth (in-run if narrative ran, else recompute)
+    try:
+        from argumentation_analysis.plugins.narrative_synthesis_plugin import (
+            compute_argument_convergence,
+        )
+
+        conv = compute_argument_convergence(state)
+        max_conv = max((d["score"] for d in conv.values()), default=0)
+        args_with_signals = len(conv)
+    except Exception as e:
+        max_conv = -1
+        args_with_signals = -1
+        conv = {"_err": str(e)}
+
+    return {
+        "identified_arguments": len(_dict("identified_arguments")),
+        "identified_fallacies": len(_dict("identified_fallacies")),
+        "counter_arguments": len(_list("counter_arguments")),
+        "argument_quality_scores": len(_dict("argument_quality_scores")),
+        "jtms_beliefs": len(_dict("jtms_beliefs")),
+        "jtms_retraction_chain": len(_list("jtms_retraction_chain")),
+        "dung_frameworks": len(_dict("dung_frameworks")),
+        "aspic_results": len(_list("aspic_results")),
+        "belief_sets": len(_dict("belief_sets")),
+        "nl_to_logic_translations": len(_list("nl_to_logic_translations")),
+        "pl_entries": len(pl_results),
+        "pl_formulas": pl_formulas,
+        "pl_verified": pl_verified,
+        "fol_entries": len(fol_results),
+        "fol_formulas": fol_formulas,
+        "fol_verified": fol_verified,
+        "convergence_max_depth": max_conv,
+        "convergence_args_with_signals": args_with_signals,
+        "narrative_synthesis_len": len(getattr(state, "narrative_synthesis", "") or ""),
+    }
+
+
+def verdict_vs_zeroshot(dims: Dict[str, Any], zs: Dict[str, int]) -> Dict[str, str]:
+    """For each quantitative axis zero-shot competes on: WIN / TIE / LOSS."""
+    out = {}
+    for axis in ("counter_arguments", "pl_formulas", "fol_formulas"):
+        ours = dims.get(axis, 0)
+        theirs = zs.get(axis, 0)
+        if ours > theirs:
+            out[axis] = f"WIN ({ours} vs {theirs})"
+        elif ours == theirs:
+            out[axis] = f"TIE ({ours} vs {theirs})"
+        else:
+            out[axis] = f"LOSS ({ours} vs {theirs})"
+    # Formal verification: zero-shot is 0-verified by construction.
+    out["pl_verified"] = f"ours={dims.get('pl_verified', 0)} vs zero-shot=0"
+    out["fol_verified"] = f"ours={dims.get('fol_verified', 0)} vs zero-shot=0"
+    return out
+
+
+async def run_path_dag(text: str) -> Dict[str, Any]:
+    from argumentation_analysis.orchestration.unified_pipeline import (
+        run_unified_analysis,
+    )
+
+    start = time.time()
+    raw = await run_unified_analysis(text=text, workflow_name="spectacular")
+    duration = time.time() - start
+    state = raw.get("unified_state")
+    return {
+        "path": "dag_spectacular",
+        "duration_s": round(duration, 1),
+        "summary": raw.get("summary", {}),
+        "capabilities_missing": raw.get("capabilities_missing", []),
+        "dimensions": count_dimensions(state),
+    }
+
+
+async def run_path_conversational(text: str) -> Dict[str, Any]:
+    from argumentation_analysis.orchestration.conversational_orchestrator import (
+        run_conversational_analysis,
+    )
+
+    start = time.time()
+    res = await run_conversational_analysis(
+        text=text, max_turns_per_phase=10, spectacular=True
+    )
+    duration = time.time() - start
+    state = res.get("unified_state")
+    return {
+        "path": "conversational",
+        "duration_s": round(duration, 1),
+        "summary": res.get("summary", {}),
+        "dimensions": count_dimensions(state),
+    }
+
+
+async def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", default="C", choices=["A", "B", "C"])
+    ap.add_argument(
+        "--paths",
+        default="dag,conversational",
+        help="comma list: dag,conversational",
+    )
+    args = ap.parse_args()
+
+    label = args.corpus
+    zs = ZERO_SHOT[label]
+    text = load_corpus(label)
+    print(f"[corpus {label}] loaded {len(text):,} chars")
+
+    out_dir = OUTPUTS_DIR
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    results: Dict[str, Any] = {
+        "corpus": label,
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "zero_shot_reference": zs,
+        "paths": {},
+    }
+
+    wanted = [p.strip() for p in args.paths.split(",")]
+
+    if "dag" in wanted:
+        print("\n=== PATH A: DAG spectacular (run_unified_analysis) ===")
+        try:
+            r = await run_path_dag(text)
+            r["verdict_vs_zeroshot"] = verdict_vs_zeroshot(r["dimensions"], zs)
+            results["paths"]["dag_spectacular"] = r
+            print(json.dumps(r["dimensions"], indent=2))
+            print("VERDICT:", json.dumps(r["verdict_vs_zeroshot"], indent=2))
+        except Exception as e:
+            import traceback
+
+            results["paths"]["dag_spectacular"] = {
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }
+            print(f"DAG path FAILED: {e}")
+
+    if "conversational" in wanted:
+        print("\n=== PATH B: Conversational (run_conversational_analysis) ===")
+        try:
+            r = await run_path_conversational(text)
+            r["verdict_vs_zeroshot"] = verdict_vs_zeroshot(r["dimensions"], zs)
+            results["paths"]["conversational"] = r
+            print(json.dumps(r["dimensions"], indent=2))
+            print("VERDICT:", json.dumps(r["verdict_vs_zeroshot"], indent=2))
+        except Exception as e:
+            import traceback
+
+            results["paths"]["conversational"] = {
+                "error": str(e),
+                "traceback": traceback.format_exc(),
+            }
+            print(f"Conversational path FAILED: {e}")
+
+    out_file = out_dir / f"both_paths_vs_zeroshot_{label}.json"
+    with open(out_file, "w", encoding="utf-8") as f:
+        json.dump(results, f, indent=2, ensure_ascii=False, default=str)
+    print(f"\nSaved: {out_file}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/unit/argumentation_analysis/orchestration/test_counter_argument_caps_gg.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_counter_argument_caps_gg.py
@@ -1,0 +1,201 @@
+"""Tests for the counter-argument volume defect (Track GG #696).
+
+The pipeline used to cap counter-arguments at <=5 (top-3 fallacies + 5 total
+targets) on the sequential path and under-produce them on the conversational
+path, losing to the zero-shot baseline on the quantitative axis. These tests
+verify, with a mocked LLM (no real API), that:
+
+  1. ``_generate_counters_for_targets`` sweeps EVERY target (no cap) and batches
+     long target lists across multiple LLM calls.
+  2. ``_invoke_counter_argument`` builds one target per fallacy AND per argument
+     (no top-3 / total-5 caps).
+  3. ``_generate_counter_arguments_from_state`` produces >=1 counter-argument per
+     identified argument and writes each back via ``add_counter_argument``.
+  4. The conversational orchestrator module imports cleanly with the new 5b-6
+     post-processor wired in.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import argumentation_analysis.orchestration.invoke_callables as mod
+
+
+def _resp(content: str):
+    """Build a fake OpenAI chat completion response carrying ``content``."""
+    response = MagicMock()
+    choice = MagicMock()
+    choice.message.content = content
+    response.choices = [choice]
+    return response
+
+
+def _client_one_per_target():
+    """Mock client whose create() returns one counter per listed target line."""
+
+    async def fake_create(**kwargs):
+        user_msg = kwargs["messages"][1]["content"]
+        n = len([ln for ln in user_msg.splitlines() if ln.strip()])
+        arr = [
+            {
+                "counter_argument": f"Counter {i}",
+                "strategy_used": "distinction",
+                "target_argument": f"target {i}",
+                "strength": "moderate",
+                "reasoning": "because",
+            }
+            for i in range(n)
+        ]
+        return _resp(json.dumps(arr))
+
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(side_effect=fake_create)
+    return client
+
+
+class TestParseCounterArray:
+    """_parse_counter_array tolerates fenced, bare, and single-object JSON."""
+
+    def test_plain_array(self):
+        raw = '[{"counter_argument": "x"}, {"counter_argument": "y"}]'
+        out = mod._parse_counter_array(raw)
+        assert len(out) == 2
+        assert out[0]["counter_argument"] == "x"
+
+    def test_json_fenced_array(self):
+        raw = '```json\n[{"counter_argument": "x"}]\n```'
+        out = mod._parse_counter_array(raw)
+        assert len(out) == 1
+
+    def test_single_object_wrapped_to_list(self):
+        raw = '{"counter_argument": "only one"}'
+        out = mod._parse_counter_array(raw)
+        assert out == [{"counter_argument": "only one"}]
+
+    def test_garbage_returns_empty(self):
+        assert mod._parse_counter_array("no json here") == []
+        assert mod._parse_counter_array("") == []
+
+
+class TestGenerateCountersForTargets:
+    """The batching helper has NO cap and aggregates across batches."""
+
+    async def test_no_cap_sweeps_all_targets(self):
+        client = _client_one_per_target()
+        targets = [f"arg {i}" for i in range(25)]
+        out = await mod._generate_counters_for_targets(
+            client, "model", targets, batch_size=12
+        )
+        # 25 targets => one counter each, never capped at 5.
+        assert len(out) == 25
+
+    async def test_batches_split_long_target_lists(self):
+        client = _client_one_per_target()
+        targets = [f"arg {i}" for i in range(25)]
+        await mod._generate_counters_for_targets(
+            client, "model", targets, batch_size=12
+        )
+        # 25 / 12 => batches of 12, 12, 1 => 3 LLM calls.
+        assert client.chat.completions.create.call_count == 3
+
+    async def test_one_batch_failure_does_not_sink_others(self):
+        calls = {"n": 0}
+
+        async def flaky_create(**kwargs):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise RuntimeError("transient")
+            return _resp('[{"counter_argument": "ok"}]')
+
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(side_effect=flaky_create)
+        targets = [f"arg {i}" for i in range(24)]  # 2 batches of 12
+        out = await mod._generate_counters_for_targets(
+            client, "model", targets, batch_size=12
+        )
+        # First batch raised, second succeeded => still get the survivor.
+        assert len(out) == 1
+
+
+class TestInvokeCounterArgumentNoCaps:
+    """_invoke_counter_argument targets every fallacy AND every argument."""
+
+    async def test_all_fallacies_and_args_become_targets(self):
+        context = {
+            "phase_extract_output": {
+                "arguments": [{"text": f"argument number {i}"} for i in range(10)]
+            },
+            "phase_hierarchical_fallacy_output": {
+                "fallacies": [
+                    {"type": f"fallacy_{i}", "explanation": "e"} for i in range(6)
+                ]
+            },
+            "phase_quality_output": {"per_argument_scores": {}},
+        }
+        captured = AsyncMock(return_value=[])
+        with patch.object(
+            mod, "_get_openai_client", return_value=(MagicMock(), "model")
+        ), patch.object(mod, "_generate_counters_for_targets", new=captured):
+            await mod._invoke_counter_argument("some input text", context)
+
+        # Positional call: (client, model_id, targets)
+        targets = captured.call_args.args[2]
+        # 6 fallacies (not capped to 3) + 10 args (not capped to 5) = 16.
+        assert len(targets) == 16
+        assert sum(1 for t in targets if t.startswith("[FALLACY:")) == 6
+
+
+class TestGenerateCounterArgumentsFromState:
+    """The conversational post-processor sweeps every identified argument."""
+
+    async def test_one_counter_per_argument_written_back(self):
+        state = MagicMock()
+        state.identified_arguments = [{"text": "a1"}, {"text": "a2"}, {"text": "a3"}]
+        state.add_counter_argument = MagicMock(return_value="ca_1")
+        client = _client_one_per_target()
+        with patch.object(
+            mod, "_get_openai_client", return_value=(client, "model")
+        ), patch.object(mod, "_evaluate_counter_arguments", side_effect=lambda c, t: c):
+            result = await mod._generate_counter_arguments_from_state(state)
+
+        assert result["targets"] == 3
+        assert result["added"] == 3
+        assert state.add_counter_argument.call_count == 3
+
+    async def test_no_args_is_noop(self):
+        state = MagicMock()
+        state.identified_arguments = []
+        result = await mod._generate_counter_arguments_from_state(state)
+        assert result == {"added": 0, "targets": 0}
+
+    async def test_no_client_reports_targets_but_adds_nothing(self):
+        state = MagicMock()
+        state.identified_arguments = [{"text": "a1"}, {"text": "a2"}]
+        state.add_counter_argument = MagicMock()
+        with patch.object(mod, "_get_openai_client", return_value=(None, "")):
+            result = await mod._generate_counter_arguments_from_state(state)
+        assert result == {"added": 0, "targets": 2}
+        state.add_counter_argument.assert_not_called()
+
+    async def test_plain_string_arguments_supported(self):
+        state = MagicMock()
+        state.identified_arguments = ["bare string arg one", "bare string arg two"]
+        state.add_counter_argument = MagicMock(return_value="ca")
+        client = _client_one_per_target()
+        with patch.object(
+            mod, "_get_openai_client", return_value=(client, "model")
+        ), patch.object(mod, "_evaluate_counter_arguments", side_effect=lambda c, t: c):
+            result = await mod._generate_counter_arguments_from_state(state)
+        assert result["targets"] == 2
+        assert result["added"] == 2
+
+
+class TestConversationalWiring:
+    """The 5b-6 post-processor edit must keep the orchestrator importable."""
+
+    def test_orchestrator_imports_and_helper_present(self):
+        import argumentation_analysis.orchestration.conversational_orchestrator as co
+
+        assert hasattr(co, "run_conversational_analysis")
+        # The helper the 5b-6 block calls must exist on the invoke module.
+        assert hasattr(mod, "_generate_counter_arguments_from_state")


### PR DESCRIPTION
## Track GG — Counter-argument volume defect (#696)

Parent Epic: #695. Self-picked (workers silent ~3h; po-2025 reassigned to KK #700 to avoid collision).

### The defect (grounded, live-verified)
The pipeline **lost to the zero-shot baseline** on counter-argument volume:
- Sequential (DAG spectacular), corpus C: **5** counter-args vs zero-shot **18** → LOSS
- Conversational, corpus C: **1** counter-arg vs **18** → LOSS

Two root causes in `invoke_callables._invoke_counter_argument`:
- line ~496 `for f in fallacies[:3]` — capped fallacy targets at 3
- line ~513 `if text and len(targets) < 5` — capped total targets at 5

→ at most 5 counter-arguments regardless of how many arguments/fallacies the corpus actually had. The conversational path produced even fewer because the agent runs out of turn budget.

### The fix
1. **DAG path** — removed both caps. Every fallacy AND every argument is now a target. New `_generate_counters_for_targets` **batches** the LLM calls (batch_size=12) so a single mega-prompt no longer silently drops items past the first handful, and one failed batch no longer sinks the rest.
2. **Conversational path** — added a deterministic **5b-6 post-processor** mirroring the existing Dung/modal/ASPIC ones: after the dialogue, sweep every `identified_argument` and ensure ≥1 counter-argument each via `_generate_counter_arguments_from_state`. Gated by `if spectacular and n_args and n_cas < n_args`.

Anti-pendulum: the caps were **deleted**, not swapped for a higher cap.

### Tests (no real API — mocked LLM)
13 new unit tests in `test_counter_argument_caps_gg.py`:
- `_parse_counter_array` tolerates fenced / bare / single-object / garbage JSON
- `_generate_counters_for_targets` sweeps all 25 targets (no cap), splits into 3 batches, isolates batch failures
- `_invoke_counter_argument` builds 16 targets from 6 fallacies + 10 args (was capped at 5)
- `_generate_counter_arguments_from_state` writes ≥1 CA per argument, handles no-args / no-client / plain-string args
- conversational orchestrator stays importable with 5b-6 wired

`black` + `flake8` clean.

### Live verification
`scripts/measure_both_paths_vs_zeroshot.py` (privacy-clean: cardinalities only, gitignored output) is the head-to-head harness. Live A/B/C run on the funded key (ai-01) to follow as a PR comment — DoD: counter-args ≥ zero-shot on every corpus, both paths.

### Files removed and why
None — additive change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)