### PR TITLE
feat(formal-logic): PL/FOL volet-1 writers on conversational path + harden except blocks — Track HH (#697)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -897,6 +897,38 @@ async def run_conversational_analysis(
         except Exception as e:
             logger.warning(f"Counter-argument enrichment post-processing failed: {e}")
 
+    # 5b-7. Formal logic enrichment — PL/FOL volet-1 writers (HH #697)
+    # The conversational dialogue routes formal logic to belief_sets, leaving
+    # propositional_analysis_results / fol_analysis_results empty (PL/FOL = 0,
+    # losing to the zero-shot baseline). Mirror the Dung/modal/ASPIC
+    # post-processors: reuse the sequential Tweety-verified PL/FOL invoke
+    # callables so the collaborative path emits the same volet-1 formulas.
+    if (
+        spectacular
+        and hasattr(state, "propositional_analysis_results")
+        and not state.propositional_analysis_results
+        and not getattr(state, "fol_analysis_results", None)
+    ):
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _run_formal_logic_from_state,
+            )
+
+            formal_result = await _run_formal_logic_from_state(state, text)
+            if formal_result and (
+                formal_result.get("pl_added") or formal_result.get("fol_added")
+            ):
+                conversation_log.append(
+                    {
+                        "phase": "post_processing",
+                        "type": "formal_logic_enrichment",
+                        "pl_formulas": formal_result["pl_added"],
+                        "fol_formulas": formal_result["fol_added"],
+                    }
+                )
+        except Exception as e:
+            logger.warning(f"Formal logic enrichment post-processing failed: {e}")
+
     # 5c. Deep Synthesis post-phase (#534)
     # Run DeepSynthesisAgent on the accumulated state to produce a 9-section
     # grounded markdown report. Appended as terminal step after all agents.

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -580,6 +580,88 @@ async def _generate_counter_arguments_from_state(state: Any) -> Dict[str, Any]:
     return {"added": added, "targets": len(targets)}
 
 
+async def _run_formal_logic_from_state(
+    state: Any, input_text: str = ""
+) -> Dict[str, int]:
+    """Populate PL/FOL volet-1 writers on the conversational path (HH #697).
+
+    The conversational dialogue routes formal logic to ``belief_sets`` and never
+    calls the volet-1 writers, so ``propositional_analysis_results`` /
+    ``fol_analysis_results`` stay empty (PL/FOL = 0) — losing the quantitative
+    axis vs the zero-shot baseline. This deterministic post-processor mirrors the
+    Dung/modal/ASPIC ones: it reuses ``_invoke_propositional_logic`` /
+    ``_invoke_fol_reasoning`` so the formulas are Tweety-verified exactly as on
+    the sequential path, then writes them back via the state's add_* methods.
+    """
+    result = {"pl_added": 0, "fol_added": 0}
+
+    ident = getattr(state, "identified_arguments", None)
+    if isinstance(ident, dict):
+        arg_texts = [str(v).strip() for v in ident.values() if v]
+    elif isinstance(ident, list):
+        arg_texts = [
+            (
+                str(
+                    a.get("text") or a.get("description") or a.get("content") or ""
+                ).strip()
+                if isinstance(a, dict)
+                else str(a).strip()
+            )
+            for a in ident
+        ]
+    else:
+        return result
+    arg_texts = [t for t in arg_texts if t]
+    if not arg_texts:
+        return result
+
+    context: Dict[str, Any] = {
+        "_state_object": state,
+        "phase_extract_output": {"arguments": [{"text": t} for t in arg_texts]},
+        "source_metadata": {"opaque_id": getattr(state, "source_id", "conversational")},
+    }
+
+    # Propositional logic — only if not already populated.
+    if hasattr(state, "add_propositional_analysis_result") and not getattr(
+        state, "propositional_analysis_results", None
+    ):
+        try:
+            pl_out = await _invoke_propositional_logic(input_text, context)
+            formulas = pl_out.get("formulas", []) if isinstance(pl_out, dict) else []
+            if formulas:
+                state.add_propositional_analysis_result(
+                    formulas,
+                    bool(pl_out.get("satisfiable", False)),
+                    pl_out.get("model", {}) or {},
+                )
+                result["pl_added"] = len(formulas)
+        except Exception as e:
+            logger.warning(f"Conversational PL enrichment failed: {e}")
+
+    # First-order logic — only if not already populated.
+    if hasattr(state, "add_fol_analysis_result") and not getattr(
+        state, "fol_analysis_results", None
+    ):
+        try:
+            fol_out = await _invoke_fol_reasoning(input_text, context)
+            formulas = fol_out.get("formulas", []) if isinstance(fol_out, dict) else []
+            if formulas:
+                state.add_fol_analysis_result(
+                    formulas,
+                    bool(fol_out.get("consistent", False)),
+                    fol_out.get("inferences", []) or [],
+                    float(fol_out.get("confidence", 0.0) or 0.0),
+                )
+                sig = fol_out.get("fol_signature", [])
+                if isinstance(sig, list) and sig:
+                    state.fol_signature = sig
+                result["fol_added"] = len(formulas)
+        except Exception as e:
+            logger.warning(f"Conversational FOL enrichment failed: {e}")
+
+    return result
+
+
 async def _invoke_counter_argument(
     input_text: str, context: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -3937,6 +4019,9 @@ async def _invoke_propositional_logic(
     except Exception as san_err:
         logger.debug(f"PL sanitizer unavailable ({san_err}), using raw formulas")
 
+    # Bind bridge outside the try so the except isolation loop can reference it
+    # even if TweetyBridge import/construction itself raises (#697 Track HH).
+    bridge = None
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
 
@@ -3964,15 +4049,16 @@ async def _invoke_propositional_logic(
             f"Attempting per-formula isolation with {len(formulas)} formulas."
         )
         valid_formulas = []
-        for formula in formulas:
-            try:
-                single_bs = str(formula)
-                await asyncio.to_thread(
-                    bridge.check_consistency, single_bs, "propositional"
-                )
-                valid_formulas.append(formula)
-            except Exception:
-                logger.debug(f"PL formula rejected by Tweety: {formula}")
+        if bridge is not None:
+            for formula in formulas:
+                try:
+                    single_bs = str(formula)
+                    await asyncio.to_thread(
+                        bridge.check_consistency, single_bs, "propositional"
+                    )
+                    valid_formulas.append(formula)
+                except Exception:
+                    logger.debug(f"PL formula rejected by Tweety: {formula}")
 
         if valid_formulas:
             pl_metrics["post_tweety"] = len(valid_formulas)
@@ -4248,6 +4334,9 @@ async def _invoke_fol_reasoning(
                 f"Argument undermined by {f.get('type', f.get('fallacy_type', 'unknown'))} fallacy"
             )
 
+    # Bind bridge outside the try so the except isolation loop can reference it
+    # even if TweetyBridge import/construction itself raises (#697 Track HH).
+    bridge = None
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
         from argumentation_analysis.agents.core.logic.fol_logic_agent import (
@@ -4312,17 +4401,18 @@ async def _invoke_fol_reasoning(
         # This handles the case where one bad formula causes the entire
         # batch to fail in Tweety's parser.
         valid_formulas = []
-        for formula in formulas:
-            try:
-                single_meta = FOLLogicAgent.extract_fol_metadata([formula])
-                single_sig = single_meta.get("signature_lines", [])
-                single_bs = "\n".join(str(f) for f in single_sig + [""] + [formula])
-                await asyncio.to_thread(
-                    bridge.check_consistency, single_bs, "first_order"
-                )
-                valid_formulas.append(formula)
-            except Exception:
-                logger.debug(f"FOL formula rejected by Tweety: {formula}")
+        if bridge is not None:
+            for formula in formulas:
+                try:
+                    single_meta = FOLLogicAgent.extract_fol_metadata([formula])
+                    single_sig = single_meta.get("signature_lines", [])
+                    single_bs = "\n".join(str(f) for f in single_sig + [""] + [formula])
+                    await asyncio.to_thread(
+                        bridge.check_consistency, single_bs, "first_order"
+                    )
+                    valid_formulas.append(formula)
+                except Exception:
+                    logger.debug(f"FOL formula rejected by Tweety: {formula}")
 
         if valid_formulas:
             meta = FOLLogicAgent.extract_fol_metadata(valid_formulas)

--- a/tests/unit/argumentation_analysis/orchestration/test_formal_logic_conversational_hh.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_formal_logic_conversational_hh.py
@@ -1,0 +1,198 @@
+"""Tests for the conversational PL/FOL volet-1 gap (Track HH #697).
+
+The conversational dialogue routes formal logic to ``belief_sets`` and never
+calls the volet-1 writers, so ``propositional_analysis_results`` /
+``fol_analysis_results`` stayed empty (PL/FOL = 0), losing to the zero-shot
+baseline on the formal axis. These tests verify, with mocked invoke callables
+(no real LLM, no JVM/Tweety), that:
+
+  1. ``_run_formal_logic_from_state`` sweeps every identified argument and writes
+     PL and FOL results back via the state's add_* methods, handling
+     ``identified_arguments`` as a dict (conversational) OR a list.
+  2. It is a no-op when there are no arguments, and skips a layer that is
+     already populated (idempotent post-processor).
+  3. A failing invoke callable is caught per-layer and never sinks the other.
+  4. The PL/FOL except blocks degrade gracefully when ``TweetyBridge`` import /
+     construction itself raises (``bridge = None`` guard) — the phase returns a
+     Python fallback dict instead of raising into ``failed_phases``.
+  5. The conversational orchestrator imports cleanly with the 5b-7 block wired in.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import argumentation_analysis.orchestration.invoke_callables as mod
+
+
+class _FakeState:
+    """Minimal stand-in for UnifiedAnalysisState (real lists, real add_*)."""
+
+    def __init__(self, identified_arguments, pl=None, fol=None):
+        self.identified_arguments = identified_arguments
+        self.propositional_analysis_results = pl if pl is not None else []
+        self.fol_analysis_results = fol if fol is not None else []
+        self.fol_signature = []
+        self.source_id = "test_corpus"
+
+    def add_propositional_analysis_result(
+        self, formulas, satisfiable, model=None, arg_id=None
+    ):
+        self.propositional_analysis_results.append(
+            {"formulas": formulas, "satisfiable": satisfiable, "model": model or {}}
+        )
+        return f"pl_{len(self.propositional_analysis_results)}"
+
+    def add_fol_analysis_result(
+        self, formulas, consistent, inferences, confidence=0.0, arg_id=None
+    ):
+        self.fol_analysis_results.append(
+            {"formulas": formulas, "consistent": consistent, "confidence": confidence}
+        )
+        return f"fol_{len(self.fol_analysis_results)}"
+
+
+def _pl_resp(formulas):
+    return {"formulas": formulas, "satisfiable": True, "model": {"p1": True}}
+
+
+def _fol_resp(formulas):
+    return {
+        "formulas": formulas,
+        "consistent": True,
+        "inferences": ["i"],
+        "confidence": 0.8,
+        "fol_signature": ["sort A"],
+    }
+
+
+class TestRunFormalLogicFromState:
+    """The post-processor populates both volet-1 writers, dict OR list args."""
+
+    async def test_dict_arguments_populate_both_layers(self):
+        state = _FakeState(
+            {"arg_1": "all men are mortal", "arg_2": "socrates is a man"}
+        )
+        with patch.object(
+            mod,
+            "_invoke_propositional_logic",
+            new=AsyncMock(return_value=_pl_resp(["p1", "p2"])),
+        ), patch.object(
+            mod,
+            "_invoke_fol_reasoning",
+            new=AsyncMock(return_value=_fol_resp(["forall X: (M(X))"])),
+        ):
+            out = await mod._run_formal_logic_from_state(state, "source text")
+
+        assert out == {"pl_added": 2, "fol_added": 1}
+        assert len(state.propositional_analysis_results) == 1
+        assert state.propositional_analysis_results[0]["formulas"] == ["p1", "p2"]
+        assert len(state.fol_analysis_results) == 1
+        assert state.fol_signature == ["sort A"]
+
+    async def test_list_of_dict_arguments_supported(self):
+        state = _FakeState([{"text": "a1"}, {"description": "a2"}, {"content": "a3"}])
+        with patch.object(
+            mod,
+            "_invoke_propositional_logic",
+            new=AsyncMock(return_value=_pl_resp(["p1"])),
+        ), patch.object(
+            mod,
+            "_invoke_fol_reasoning",
+            new=AsyncMock(return_value=_fol_resp(["P(a)"])),
+        ):
+            out = await mod._run_formal_logic_from_state(state, "src")
+        assert out["pl_added"] == 1
+        assert out["fol_added"] == 1
+
+    async def test_list_of_plain_strings_supported(self):
+        state = _FakeState(["bare arg one", "bare arg two"])
+        with patch.object(
+            mod,
+            "_invoke_propositional_logic",
+            new=AsyncMock(return_value=_pl_resp(["p1"])),
+        ), patch.object(
+            mod,
+            "_invoke_fol_reasoning",
+            new=AsyncMock(return_value=_fol_resp(["Q(b)"])),
+        ):
+            out = await mod._run_formal_logic_from_state(state, "src")
+        assert out["pl_added"] == 1 and out["fol_added"] == 1
+
+    async def test_no_args_is_noop(self):
+        state = _FakeState({})
+        pl = AsyncMock(return_value=_pl_resp(["p1"]))
+        with patch.object(mod, "_invoke_propositional_logic", new=pl):
+            out = await mod._run_formal_logic_from_state(state, "src")
+        assert out == {"pl_added": 0, "fol_added": 0}
+        pl.assert_not_called()
+
+    async def test_already_populated_pl_is_skipped(self):
+        state = _FakeState({"arg_1": "x"}, pl=[{"id": "pl_existing"}])
+        pl = AsyncMock(return_value=_pl_resp(["p1"]))
+        with patch.object(mod, "_invoke_propositional_logic", new=pl), patch.object(
+            mod,
+            "_invoke_fol_reasoning",
+            new=AsyncMock(return_value=_fol_resp(["P(a)"])),
+        ):
+            out = await mod._run_formal_logic_from_state(state, "src")
+        # PL already present => not regenerated; FOL still produced.
+        assert out["pl_added"] == 0
+        assert out["fol_added"] == 1
+        pl.assert_not_called()
+
+    async def test_pl_invoke_failure_does_not_sink_fol(self):
+        state = _FakeState({"arg_1": "x"})
+        with patch.object(
+            mod,
+            "_invoke_propositional_logic",
+            new=AsyncMock(side_effect=RuntimeError("transient")),
+        ), patch.object(
+            mod,
+            "_invoke_fol_reasoning",
+            new=AsyncMock(return_value=_fol_resp(["P(a)"])),
+        ):
+            out = await mod._run_formal_logic_from_state(state, "src")
+        assert out["pl_added"] == 0
+        assert out["fol_added"] == 1
+
+    async def test_unknown_args_type_returns_zero(self):
+        state = _FakeState(None)
+        out = await mod._run_formal_logic_from_state(state, "src")
+        assert out == {"pl_added": 0, "fol_added": 0}
+
+
+class TestExceptBlockHardening:
+    """A TweetyBridge construction failure must degrade, not raise (#697 HH)."""
+
+    async def test_pl_bridge_failure_degrades_to_python_fallback(self):
+        context = {"formulas": ["p1", "p2"]}
+        with patch(
+            "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
+            side_effect=RuntimeError("no JVM"),
+        ):
+            out = await mod._invoke_propositional_logic("text", context)
+        # No exception bubbled; we still get a usable result dict.
+        assert isinstance(out, dict)
+        assert "formulas" in out
+        assert out.get("fallback") == "python"
+
+    async def test_fol_bridge_failure_degrades_to_python_fallback(self):
+        context = {"formulas": ["P(a)", "Q(b)"]}
+        with patch(
+            "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
+            side_effect=RuntimeError("no JVM"),
+        ):
+            out = await mod._invoke_fol_reasoning("text", context)
+        assert isinstance(out, dict)
+        assert "formulas" in out
+        # Python fallback path sets confidence and does not raise.
+        assert "confidence" in out
+
+
+class TestConversationalWiring:
+    """The 5b-7 post-processor edit must keep the orchestrator importable."""
+
+    def test_orchestrator_imports_and_helper_present(self):
+        import argumentation_analysis.orchestration.conversational_orchestrator as co
+
+        assert hasattr(co, "run_conversational_analysis")
+        assert hasattr(mod, "_run_formal_logic_from_state")


### PR DESCRIPTION
## Track HH #697 — Epic #695

Closes the conversational formal-logic gap: the dialogue path routed PL/FOL to `belief_sets` and never called the volet-1 writers, leaving `propositional_analysis_results` / `fol_analysis_results` **empty (PL/FOL = 0)** — the one axis where the collaborative path lost to the zero-shot baseline (12/12 PL/FOL formulas).

### What changed
- **New `_run_formal_logic_from_state(state)`** in `invoke_callables.py` — a deterministic post-processor mirroring the existing Dung/modal/ASPIC ones. It **reuses** `_invoke_propositional_logic` / `_invoke_fol_reasoning`, so the conversational formulas are **Tweety-verified exactly as on the sequential path**, then writes them back via `state.add_propositional_analysis_result` / `add_fol_analysis_result` (+ `fol_signature`). Handles `identified_arguments` as a **dict** (conversational `UnifiedAnalysisState`) OR a **list**. Per-layer `try/except` so a PL failure never sinks FOL.
- **5b-7 block** in `conversational_orchestrator.py` (between 5b-6 counter-args and 5c synthesis), gated `if spectacular and <PL/FOL empty>`, wrapped in try/except, logged to `conversation_log`.
- **Hardened the PL/FOL except blocks** (defense-in-depth, addresses the non-deterministic phase collapse documented in the project memory): `bridge` was bound *inside* the `try` but referenced in the `except` per-formula isolation loop. If `TweetyBridge` import/construction itself raised, the except hit a `NameError` → the whole phase landed in `failed_phases` → PL/FOL = 0. Now `bridge = None` is bound **before** the `try` and the isolation loop is guarded `if bridge is not None:`, falling through to the Python fallback instead of raising.

### Tests
10 new unit tests (`test_formal_logic_conversational_hh.py`), fully mocked — **no real LLM, no JVM/Tweety**:
- dict / list-of-dict / list-of-string `identified_arguments` all populate both layers
- no-args no-op; already-populated layer is skipped (idempotent)
- per-layer failure isolation (PL raises → FOL still written)
- **bridge-construction-failure graceful degradation** (patch `TweetyBridge` to raise → returns Python-fallback dict, no exception)
- orchestrator imports + helper present (wiring)

`black` clean, `flake8` clean. GG (`test_counter_argument_caps_gg.py`, 13 tests) still green — same file touched.

### Serialization note
This is the second of the serial invoke_callables.py / conversational post-processor tracks (GG → **HH** → JJ). GG (#696) is merged; JJ (#699) rebases on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)