### PR TITLE
fix(formal): DAG PL/FOL no longer short-circuits the 2-pass generator — Track LL (#705)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3766,7 +3766,19 @@ async def _invoke_propositional_logic(
     """
     # Build propositional formulas from upstream arguments
     args = _extract_arguments_from_context(input_text, context)
-    formulas: Optional[List[str]] = context.get("formulas")
+    # #705 Track LL: upstream formulas (DAG path: context["formulas"] or the
+    # nl_to_logic phase) are whole-text/complex and frequently fail Tweety. We
+    # capture them separately and run the robust 2-pass coordinated generator
+    # ALWAYS, then UNION the upstream extras on top — instead of letting the
+    # upstream formulas short-circuit the generator. That short-circuit was the
+    # asymmetry that made the sequential/DAG path lose PL/FOL to the zero-shot
+    # baseline; the conversational path already wins because it always runs the
+    # 2-pass. Per-formula Tweety isolation below keeps only parseable survivors,
+    # so unioning the upstream extras can only add verified count, never lower it.
+    upstream_formulas: List[str] = [
+        str(f).strip() for f in (context.get("formulas") or []) if f
+    ]
+    formulas: Optional[List[str]] = None
     argument_mapping: Dict[str, str] = {}
     shared_atoms: List[str] = []
 
@@ -3804,20 +3816,25 @@ async def _invoke_propositional_logic(
         ]
 
         if pl_translations:
-            # Use validated NL-to-logic formulas
-            formulas = [t["formula"] for t in pl_translations]
-            argument_mapping = {
-                t["formula"][:30]: t.get("original_text", "")[:60]
-                for t in pl_translations
-            }
-            pl_metrics["upstream_nl"] = len(formulas)
-            logger.info(
-                f"Using {len(formulas)} NL-to-logic PL translations "
-                f"(from upstream phase)"
+            # #705: capture upstream NL-to-logic formulas; do NOT short-circuit
+            # the 2-pass — they are unioned in after the robust generator runs.
+            upstream_formulas.extend(
+                t["formula"].strip() for t in pl_translations if t.get("formula")
             )
-        else:
-            # ── 2-pass coordinated pipeline (#547) ──────────────────────
-            # Try the coordinated 2-pass: Pass 1 (atom inventory) → Pass 2 (formulas with shared atoms)
+            argument_mapping.update(
+                {
+                    t["formula"][:30]: t.get("original_text", "")[:60]
+                    for t in pl_translations
+                }
+            )
+            pl_metrics["upstream_nl"] = len(upstream_formulas)
+            logger.info(
+                f"Captured {len(upstream_formulas)} upstream NL-to-logic PL "
+                f"formulas (unioned after 2-pass) (#705)"
+            )
+        # ── 2-pass coordinated pipeline (#547) — always runs now (#705 LL).
+        # Pass 1 (atom inventory) → Pass 2 (formulas using only shared atoms).
+        if not formulas:
             try:
                 import json as _json
 
@@ -3950,7 +3967,17 @@ async def _invoke_propositional_logic(
             except Exception as e:
                 logger.debug(f"PL 2-pass pipeline unavailable: {e}")
 
-            # Fallback: try on-the-fly NL translation if LLM available (and 2-pass didn't produce formulas)
+            # #705 Track LL: union upstream complex formulas (nl_to_logic /
+            # context["formulas"]) on top of the robust 2-pass formulas. The
+            # per-formula Tweety isolation below keeps only parseable ones, so
+            # this can only add verified survivors, never lower the count.
+            if formulas is None:
+                formulas = []
+            for f in upstream_formulas:
+                if f and f not in formulas:
+                    formulas.append(f)
+
+            # Fallback: on-the-fly NL translation only if nothing produced yet
             if not formulas:
                 try:
                     from argumentation_analysis.services.nl_to_logic import (
@@ -4109,7 +4136,15 @@ async def _invoke_fol_reasoning(
     (#208-H: wire NL-to-logic as pre-processing)
     """
     args = _extract_arguments_from_context(input_text, context)
-    formulas: Optional[List[str]] = context.get("formulas")
+    # #705 Track LL: capture upstream FOL formulas (DAG nl_to_logic /
+    # context["formulas"]) separately and run the robust 2-pass generator
+    # ALWAYS, then UNION the upstream extras — mirrors the PL fix so the
+    # sequential/DAG path stops losing FOL to the zero-shot baseline. Per-formula
+    # Tweety isolation keeps only parseable survivors.
+    upstream_formulas: List[str] = [
+        str(f).strip() for f in (context.get("formulas") or []) if f
+    ]
+    formulas: Optional[List[str]] = None
     fol_metadata_shared: Dict[str, Any] = {}
 
     # Retrieve state object for fol_shared_signature storage
@@ -4147,21 +4182,22 @@ async def _invoke_fol_reasoning(
         ]
 
         if fol_translations:
-            formulas = []
+            # #705: capture upstream NL-to-logic formulas; do NOT short-circuit
+            # the 2-pass — they are unioned in after the robust generator runs.
             for t in fol_translations:
                 # FOL formulas may be semicolon-separated
                 for f in t["formula"].split(";"):
                     f = f.strip()
-                    if f:
-                        formulas.append(f)
+                    if f and f not in upstream_formulas:
+                        upstream_formulas.append(f)
             logger.info(
-                f"Using {len(formulas)} NL-to-logic FOL translations "
-                f"(from upstream phase)"
+                f"Captured {len(upstream_formulas)} upstream NL-to-logic FOL "
+                f"formulas (unioned after 2-pass) (#705)"
             )
-        else:
-            # ── FOL 2-pass coordinated pipeline (#544) ───────────────────
-            # Pass 1: Extract shared FOL signature (sorts, predicates, constants) from full text
-            # Pass 2: Generate per-argument formulas using ONLY shared signature
+        # ── FOL 2-pass coordinated pipeline (#544) — always runs (#705 LL).
+        # Pass 1: shared signature (sorts/predicates/constants) from full text.
+        # Pass 2: per-argument formulas using ONLY the shared signature.
+        if not formulas:
             try:
                 # Honors the OpenRouter toggle via _get_openai_client.
                 client, model_id = _get_openai_client()
@@ -4273,7 +4309,16 @@ async def _invoke_fol_reasoning(
             except Exception as e:
                 logger.debug(f"FOL 2-pass pipeline unavailable: {e}")
 
-            # Fallback: try on-the-fly NL translation
+            # #705 Track LL: union upstream complex FOL formulas on top of the
+            # robust 2-pass formulas. Per-formula Tweety isolation (below) keeps
+            # only parseable survivors, so this can only add verified count.
+            if formulas is None:
+                formulas = []
+            for f in upstream_formulas:
+                if f and f not in formulas:
+                    formulas.append(f)
+
+            # Fallback: on-the-fly NL translation only if nothing produced yet
             if not formulas:
                 try:
                     from argumentation_analysis.services.nl_to_logic import (

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -607,14 +607,21 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             capability="propositional_logic",
             depends_on=["nl_to_logic"],
             optional=True,
-            timeout_seconds=180,
+            # #705 Track LL: the 2-pass coordinated generator now runs on the DAG
+            # path too (pass1 + per-arg pass2 + whole-text ≈ 12 LLM calls), so the
+            # old 180s ceiling timed the phase out (→ failed_phases). Time is not
+            # a constraint here; give the formal phases room to finish.
+            timeout_seconds=420,
         )
         .add_phase(
             "fol",
             capability="fol_reasoning",
             depends_on=["nl_to_logic"],
             optional=True,
-            timeout_seconds=180,
+            # #705 Track LL: FOL 2-pass + per-formula Tweety isolation is the
+            # slowest formal phase; 180s was the cause of the DAG fol collapse
+            # (failed_phases=['fol'] on A/C). Raised so it completes.
+            timeout_seconds=600,
         )
         .add_phase(
             "modal",

--- a/tests/unit/argumentation_analysis/orchestration/test_dag_formal_logic_union_ll.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dag_formal_logic_union_ll.py
@@ -1,0 +1,125 @@
+"""Tests for the DAG/sequential PL/FOL collapse fix (Track LL #705).
+
+The sequential (DAG) ``spectacular``/``full`` workflows run an ``nl_to_logic``
+phase whose whole-text formulas feed ``pl``/``fol``. Those formulas are complex
+and frequently fail Tweety, and — critically — their mere presence used to
+*short-circuit* the robust 2-pass coordinated generator (Pass 1 atom/signature
+inventory → Pass 2 per-argument formulas). The conversational path wins on PL/FOL
+precisely because it always runs that 2-pass; the DAG path lost to the zero-shot
+baseline (PL 1/1/3, FOL 0/52/0, ``failed_phases=['fol']``) because it didn't.
+
+These tests verify, with the LLM client and TweetyBridge mocked away (no real
+API, no JVM), that:
+
+  1. When upstream formulas are present (``context["formulas"]`` — the DAG case),
+     ``_invoke_propositional_logic`` / ``_invoke_fol_reasoning`` STILL reach the
+     2-pass generator (``_get_openai_client`` is called). Before #705 the upstream
+     branch short-circuited and the generator was never invoked.
+  2. The upstream formulas are UNIONED into the result rather than being the only
+     source (additive, anti-pendulum: we add the robust generator, we don't cap
+     the formal phases).
+  3. The conversational path (no upstream) is unchanged — still reaches the 2-pass.
+"""
+
+from unittest.mock import patch
+
+import argumentation_analysis.orchestration.invoke_callables as mod
+
+_LONG_TEXT = "This is a sufficiently long source text for the formal phase. " * 8
+
+_BRIDGE = "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge"
+
+
+class TestDagPlUnionsAndDoesNotShortCircuit:
+    """#705: upstream PL formulas no longer skip the 2-pass; they are unioned."""
+
+    async def test_upstream_formulas_still_reach_2pass(self):
+        calls = {"client": 0}
+
+        def _fake_client():
+            calls["client"] += 1
+            return (None, None)  # client unavailable → 2-pass body is a no-op
+
+        with patch.object(
+            mod, "_get_openai_client", side_effect=_fake_client
+        ), patch(_BRIDGE, side_effect=RuntimeError("no JVM")):
+            out = await mod._invoke_propositional_logic(
+                _LONG_TEXT, {"formulas": ["a", "b"]}
+            )
+
+        # Regression: before #705 the upstream branch short-circuited and the
+        # generator was never reached — calls["client"] would be 0.
+        assert calls["client"] >= 1
+        # Upstream formulas are unioned into the output, not dropped.
+        assert "a" in out["formulas"] and "b" in out["formulas"]
+        # JVM mocked away → graceful Python fallback, never a raise.
+        assert out.get("fallback") == "python"
+
+    async def test_upstream_nl_to_logic_translations_reach_2pass(self):
+        calls = {"client": 0}
+
+        def _fake_client():
+            calls["client"] += 1
+            return (None, None)
+
+        context = {
+            "phase_nl_to_logic_output": {
+                "translations": [
+                    {
+                        "logic_type": "propositional",
+                        "is_valid": True,
+                        "formula": "p",
+                        "original_text": "arg one",
+                    }
+                ]
+            },
+            "phase_extract_output": {"arguments": [{"text": "arg one"}]},
+        }
+        with patch.object(
+            mod, "_get_openai_client", side_effect=_fake_client
+        ), patch(_BRIDGE, side_effect=RuntimeError("no JVM")):
+            out = await mod._invoke_propositional_logic(_LONG_TEXT, context)
+
+        assert calls["client"] >= 1
+        assert "p" in out["formulas"]
+
+
+class TestDagFolUnionsAndDoesNotShortCircuit:
+    """#705: upstream FOL formulas no longer skip the 2-pass; they are unioned."""
+
+    async def test_upstream_formulas_still_reach_2pass(self):
+        calls = {"client": 0}
+
+        def _fake_client():
+            calls["client"] += 1
+            return (None, None)
+
+        with patch.object(
+            mod, "_get_openai_client", side_effect=_fake_client
+        ), patch(_BRIDGE, side_effect=RuntimeError("no JVM")):
+            out = await mod._invoke_fol_reasoning(
+                _LONG_TEXT, {"formulas": ["P(a)", "Q(b)"]}
+            )
+
+        assert calls["client"] >= 1
+        assert "P(a)" in out["formulas"] and "Q(b)" in out["formulas"]
+        assert out.get("fallback") == "python"
+
+
+class TestConversationalPathUnchanged:
+    """No upstream formulas → 2-pass still runs (HH conversational behaviour)."""
+
+    async def test_pl_no_upstream_reaches_2pass(self):
+        calls = {"client": 0}
+
+        def _fake_client():
+            calls["client"] += 1
+            return (None, None)
+
+        with patch.object(
+            mod, "_get_openai_client", side_effect=_fake_client
+        ), patch(_BRIDGE, side_effect=RuntimeError("no JVM")):
+            out = await mod._invoke_propositional_logic(_LONG_TEXT, {})
+
+        assert calls["client"] >= 1
+        assert isinstance(out, dict) and "formulas" in out


### PR DESCRIPTION
## Track LL — DAG/sequential PL/FOL robustness (#705, Epic #695)

Closes #705.

### The defect (per the issue, live-grounded on main `7eebc1d3`)
HH #697 made the **conversational** path crush zero-shot on PL/FOL (A/B/C: PL 45/154/77, FOL 63/33/62, 100% Tweety-verified). The **sequential/DAG** `pl`/`fol` phases use the *same* `_invoke_propositional_logic`/`_invoke_fol_reasoning` callables yet collapsed on the same run: PL 1/1/3, FOL 0/52/0 with `failed_phases=['fol']` on A and C. R224 gave PL 35/FOL 47 on C → the collapse is **non-deterministic** (reasoning-model formula variance). This is exactly the "tools don't finish the job" failure mode.

### Root cause
The DAG `spectacular`/`full` workflows run an `nl_to_logic` phase whose whole-text formulas feed `pl`/`fol` (`depends_on=["nl_to_logic"]`). Those formulas are complex (undeclared atoms, nested implications inside conjunctions, multi-word atoms) and frequently fail Tweety. Critically, their **mere presence short-circuited the robust 2-pass coordinated generator** (Pass 1 atom/signature inventory → Pass 2 per-argument formulas using only shared atoms). The conversational path wins precisely because it always runs that 2-pass; the DAG path didn't, so it fell to the zero-shot baseline. The `fol` collapse to `failed_phases=['fol']` was the spectacular `fol` phase's 180s `timeout_seconds` firing (the invoke fns never raise → a FAILED phase = `asyncio.wait_for` timeout in `WorkflowExecutor`).

### Fix (additive, anti-pendulum)
Rather than separately re-implementing PL atom pre-declaration on the upstream-formula path (DoD #2's literal wording), this **routes the DAG path through the exact generator that makes the conversational path win** — the most unifying fix and additive by construction:

- `_invoke_propositional_logic` / `_invoke_fol_reasoning`: capture upstream formulas (`context["formulas"]` + the `nl_to_logic` translations) **separately**, **always run the 2-pass coordinated generator**, then **UNION** the upstream extras on top. The 2-pass already builds the shared-atom signature (this is why the conversational path is 100% Tweety-verified). The per-formula Tweety isolation already in both functions means unioning the upstream complex formulas can **only add verified count, never lower it** (DoD #3 — per-formula degradation, already present, now also covers the DAG path).
- `build_spectacular_workflow`: bump `pl` timeout 180→420 and `fol` 180→600. The 2-pass adds ~11 LLM calls; on a reasoning model 180s was the actual cause of the DAG fol-phase timeout collapse.

**Conversational path is unchanged**: `_run_formal_logic_from_state` passes a context *without* `formulas`/`phase_nl_to_logic_output`, so `upstream_formulas` is empty and the 2-pass runs exactly as before (numbers stay identical).

Why this satisfies the DoD outcome: the 2-pass alone already produces PL/FOL far above zero-shot on A/B/C (conversational proves it), so the DAG path running the same 2-pass clears DoD #1 (≥ 0-shot, 100% Tweety-verified, no `failed_phases`) comfortably; the upstream union is additive gravy.

### Tests (DoD #4)
New mocked regression suite `test_dag_formal_logic_union_ll.py` (no LLM, no JVM):
- upstream formulas present (DAG case) → 2-pass **is reached** (`_get_openai_client` called — was 0 pre-fix because upstream short-circuited) and upstream formulas are **unioned** into the result;
- upstream `nl_to_logic` translations → same;
- FOL upstream → same;
- no upstream (conversational) → 2-pass still runs (unchanged).

Full local run (golden + formal + LL + HH): **59 passed**, 0 failures.

### DoD #5 — coordinator live-verify
The live A/B/C both-paths verify on the funded key (ai-01) is the final arbiter and will be run after merge (`scripts/measure_both_paths_vs_zeroshot.py --corpus A|B|C`). Results (counts-only, privacy-clean) will be posted to the workspace dashboard.

### Files removed and why
None — additive change only (Cleanup Gate N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)