### PR TITLE
feat(parity): conversational quality sweep + language-aware extraction — Track JJ (#699)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -929,6 +929,31 @@ async def run_conversational_analysis(
         except Exception as e:
             logger.warning(f"Formal logic enrichment post-processing failed: {e}")
 
+    # 5b-8. Quality sweep enrichment (JJ #699)
+    # The conversational QualityAgent depends on the agent turn budget; when it
+    # runs out the dialogue emits 0 quality scores (path-dependent, some corpora
+    # end at 0). Mirror the other post-processors: reuse the robust sequential
+    # 9-virtue evaluator over every identified argument so the collaborative path
+    # always has quality scores. Gated on under-production — fills gaps only.
+    n_quality = len(getattr(state, "argument_quality_scores", {}) or {})
+    if spectacular and n_args and n_quality < n_args:
+        try:
+            from argumentation_analysis.orchestration.invoke_callables import (
+                _run_quality_sweep_from_state,
+            )
+
+            q_result = await _run_quality_sweep_from_state(state)
+            if q_result and q_result.get("added"):
+                conversation_log.append(
+                    {
+                        "phase": "post_processing",
+                        "type": "quality_sweep_enrichment",
+                        "added": q_result["added"],
+                    }
+                )
+        except Exception as e:
+            logger.warning(f"Quality sweep post-processing failed: {e}")
+
     # 5c. Deep Synthesis post-phase (#534)
     # Run DeepSynthesisAgent on the accumulated state to produce a 9-section
     # grounded markdown report. Appended as terminal step after all agents.

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -662,6 +662,74 @@ async def _run_formal_logic_from_state(
     return result
 
 
+async def _run_quality_sweep_from_state(state: Any) -> Dict[str, int]:
+    """Score every identified argument's quality on the conversational path (JJ #699).
+
+    The conversational ``QualityAgent`` depends on the agent turn budget; when the
+    budget runs out the dialogue emits 0 quality scores, so the collaborative path
+    is non-deterministic and some corpora end with quality = 0. This deterministic
+    post-processor mirrors the Dung/modal/ASPIC/PL/FOL ones: it reuses the robust
+    sequential ``_invoke_quality_evaluator`` (9-virtue evaluator, deterministic —
+    the LLM enrichment pass is optional) over ``state.identified_arguments`` and
+    writes every score back via ``state.add_quality_score``. Gated by the caller on
+    under-production, so it only fills gaps — it never overwrites agent scores.
+    """
+    result = {"added": 0}
+
+    ident = getattr(state, "identified_arguments", None)
+    if isinstance(ident, dict):
+        arg_texts = [str(v).strip() for v in ident.values() if v]
+    elif isinstance(ident, list):
+        arg_texts = [
+            (
+                str(
+                    a.get("text") or a.get("description") or a.get("content") or ""
+                ).strip()
+                if isinstance(a, dict)
+                else str(a).strip()
+            )
+            for a in ident
+        ]
+    else:
+        return result
+    arg_texts = [t for t in arg_texts if t]
+    if not arg_texts:
+        return result
+
+    if not hasattr(state, "add_quality_score"):
+        return result
+
+    context: Dict[str, Any] = {
+        "phase_extract_output": {"arguments": [{"text": t} for t in arg_texts]},
+    }
+    try:
+        q_out = await _invoke_quality_evaluator("", context)
+    except Exception as e:
+        logger.warning(f"Conversational quality sweep failed: {e}")
+        return result
+
+    if not isinstance(q_out, dict):
+        return result
+
+    per_arg = q_out.get("per_argument_scores")
+    if isinstance(per_arg, dict) and per_arg:
+        already = set(getattr(state, "argument_quality_scores", {}) or {})
+        for arg_id, scored in per_arg.items():
+            if arg_id in already or not isinstance(scored, dict):
+                continue
+            try:
+                state.add_quality_score(
+                    arg_id,
+                    scored.get("scores_par_vertu", {}) or {},
+                    float(scored.get("note_finale", 0.0) or 0.0),
+                    llm_assessment=scored.get("llm_assessment"),
+                )
+                result["added"] += 1
+            except Exception as e:
+                logger.debug(f"add_quality_score failed for {arg_id}: {e}")
+    return result
+
+
 async def _invoke_counter_argument(
     input_text: str, context: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -3662,6 +3730,29 @@ async def _invoke_fact_extraction(
 
         if client:
             det_params = _get_determinism_params()
+            # JJ #699: non-English dense text under-recalls (corpus B/DE extracts
+            # ~2 args vs ~7/5 for A/C-EN), starving every downstream layer. The
+            # English-only prompt gives the model no cue to analyze in the source
+            # language. Detect the language (reusing the tested heuristic) and add
+            # a language-aware instruction so non-English extraction reaches parity.
+            lang_clause = ""
+            try:
+                from argumentation_analysis.orchestration.conversational_orchestrator import (
+                    _detect_language,
+                )
+
+                _lang = _detect_language(input_text)
+                _lang_names = {"de": "German", "fr": "French", "en": "English"}
+                if _lang in _lang_names and _lang != "en":
+                    lang_clause = (
+                        f" The source text is in {_lang_names[_lang]}. Analyze it in "
+                        f"its original language and extract ALL distinct arguments and "
+                        f"claims with the SAME thoroughness as you would for English — "
+                        f"do not under-extract because the text is non-English. Keep "
+                        f"the 'text' descriptions in {_lang_names[_lang]}."
+                    )
+            except Exception:
+                lang_clause = ""
             response = await client.chat.completions.create(
                 model=model_id,
                 messages=[
@@ -3676,7 +3767,8 @@ async def _invoke_fact_extraction(
                             "Focus on: (1) identifying distinct argumentative positions, "
                             "(2) extracting factual claims that can be verified, "
                             "(3) noting rhetorical strategies used (without labeling them as fallacies). "
-                            "Respond with ONLY a JSON object:\n"
+                            + lang_clause
+                            + " Respond with ONLY a JSON object:\n"
                             '{"arguments": [{"text": "arg description", "source_quote": "exact quote..."}], '
                             '"claims": [{"text": "claim description", "source_quote": "exact quote..."}], '
                             '"summary": "brief analysis summary"}'

--- a/tests/unit/argumentation_analysis/orchestration/test_quality_sweep_lang_jj.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_quality_sweep_lang_jj.py
@@ -1,0 +1,166 @@
+"""Tests for the conversational quality sweep + language-aware extraction (Track JJ #699).
+
+Two collaborative-path blind spots, both verified here with the LLM mocked away
+(no real API, no JVM):
+
+  1. **Quality = 0 on the conversational path.** The conversational ``QualityAgent``
+     depends on the agent turn budget; when it runs out the dialogue emits 0 quality
+     scores, so some corpora end with quality = 0 (path-dependent, non-deterministic).
+     ``_run_quality_sweep_from_state`` mirrors the Dung/modal/ASPIC/PL/FOL
+     post-processors: it reuses the robust *sequential* 9-virtue
+     ``_invoke_quality_evaluator`` over every ``identified_argument`` and writes the
+     scores back via ``state.add_quality_score`` — deterministic, gap-filling only.
+
+  2. **Non-English under-extraction.** The English-only extraction prompt gave the
+     model no cue to analyze in the source language, so dense non-English text
+     under-recalled (corpus B/DE ~2 args vs ~7/5 for A/C-EN), starving every
+     downstream layer. ``_invoke_fact_extraction`` now detects the language (reusing
+     the tested heuristic) and injects a language-aware instruction for non-English
+     text. English text is left unchanged.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import argumentation_analysis.orchestration.invoke_callables as mod
+
+# German sentence rich in _detect_language DE markers (der/die/das/und/ist/ein/mit).
+_DE_TEXT = (
+    "Der Staat ist die Grundlage der Ordnung und das Volk muss mit Vernunft "
+    "handeln. Eine starke Wirtschaft ist der Schlüssel und die Politik wird "
+    "durch klare Regeln bestimmt. Wir sind für den Fortschritt. " * 4
+)
+_EN_TEXT = (
+    "The state is the basis of order and the people must act with reason. A "
+    "strong economy is the key and policy is determined by clear rules. We are "
+    "for progress and the future of the nation depends on it. " * 4
+)
+
+
+class _FakeState:
+    """Minimal stand-in for UnifiedAnalysisState used by the quality sweep."""
+
+    def __init__(self, identified_arguments, prefilled=None):
+        self.identified_arguments = identified_arguments
+        self.argument_quality_scores = dict(prefilled or {})
+
+    def add_quality_score(self, arg_id, scores, overall, llm_assessment=None):
+        self.argument_quality_scores[arg_id] = {
+            "scores": scores,
+            "overall": overall,
+            "llm_assessment": llm_assessment,
+        }
+
+
+def _canned_quality_output(arg_ids):
+    """Shape mirrors _invoke_quality_evaluator's per_argument_scores return."""
+    return {
+        "per_argument_scores": {
+            aid: {
+                "note_finale": 0.6,
+                "scores_par_vertu": {"clarity": 0.7, "coherence": 0.5},
+                "llm_assessment": None,
+            }
+            for aid in arg_ids
+        },
+        "aggregate_score": 0.6,
+        "arguments_evaluated": len(arg_ids),
+    }
+
+
+class TestQualitySweepFromState:
+    """#699 defect 1: deterministic quality sweep fills the conversational gap."""
+
+    async def test_dict_arguments_get_scored(self):
+        state = _FakeState({"a1": "Argument one text.", "a2": "Argument two text."})
+        with patch.object(
+            mod,
+            "_invoke_quality_evaluator",
+            new=AsyncMock(return_value=_canned_quality_output(["arg_1", "arg_2"])),
+        ):
+            out = await mod._run_quality_sweep_from_state(state)
+        assert out["added"] == 2
+        assert len(state.argument_quality_scores) == 2
+
+    async def test_list_of_dicts_arguments_get_scored(self):
+        state = _FakeState(
+            [{"text": "Argument one text."}, {"description": "Argument two text."}]
+        )
+        with patch.object(
+            mod,
+            "_invoke_quality_evaluator",
+            new=AsyncMock(return_value=_canned_quality_output(["arg_1", "arg_2"])),
+        ):
+            out = await mod._run_quality_sweep_from_state(state)
+        assert out["added"] == 2
+
+    async def test_already_scored_ids_are_skipped(self):
+        # arg_1 already present → only arg_2 is newly added (gap-filling, no overwrite).
+        state = _FakeState(
+            {"a1": "one", "a2": "two"},
+            prefilled={"arg_1": {"scores": {}, "overall": 0.9}},
+        )
+        with patch.object(
+            mod,
+            "_invoke_quality_evaluator",
+            new=AsyncMock(return_value=_canned_quality_output(["arg_1", "arg_2"])),
+        ):
+            out = await mod._run_quality_sweep_from_state(state)
+        assert out["added"] == 1
+        # Pre-existing agent score untouched.
+        assert state.argument_quality_scores["arg_1"]["overall"] == 0.9
+
+    async def test_no_arguments_is_noop(self):
+        state = _FakeState({})
+        with patch.object(mod, "_invoke_quality_evaluator", new=AsyncMock()) as ev:
+            out = await mod._run_quality_sweep_from_state(state)
+        assert out["added"] == 0
+        ev.assert_not_called()
+
+    async def test_state_without_add_method_is_noop(self):
+        bare = SimpleNamespace(identified_arguments={"a1": "one"})
+        with patch.object(mod, "_invoke_quality_evaluator", new=AsyncMock()) as ev:
+            out = await mod._run_quality_sweep_from_state(bare)
+        assert out["added"] == 0
+        ev.assert_not_called()
+
+
+def _make_fake_client(capture):
+    """Fake OpenAI client whose create() records the system prompt then returns JSON."""
+
+    async def _create(*args, **kwargs):
+        capture["messages"] = kwargs.get("messages", [])
+        msg = SimpleNamespace(
+            content='{"arguments": [], "claims": [], "summary": "ok"}'
+        )
+        return SimpleNamespace(choices=[SimpleNamespace(message=msg)])
+
+    completions = SimpleNamespace(create=_create)
+    chat = SimpleNamespace(completions=completions)
+    return SimpleNamespace(chat=chat)
+
+
+class TestLanguageAwareExtraction:
+    """#699 defect 2: non-English extraction gets a language-aware instruction."""
+
+    async def _run(self, text):
+        capture = {}
+        client = _make_fake_client(capture)
+        with patch.object(mod, "_get_openai_client", return_value=(client, "model-x")):
+            await mod._invoke_fact_extraction(text, {})
+        system = next(
+            (m["content"] for m in capture["messages"] if m["role"] == "system"), ""
+        )
+        return system
+
+    async def test_german_text_injects_language_clause(self):
+        system = await self._run(_DE_TEXT)
+        assert "German" in system
+        assert "original language" in system
+        # The JSON contract still follows the clause.
+        assert "Respond with ONLY a JSON object" in system
+
+    async def test_english_text_has_no_language_clause(self):
+        system = await self._run(_EN_TEXT)
+        assert "German" not in system
+        assert "original language" not in system


### PR DESCRIPTION
## Track JJ (#699) — collaborative-path parity: quality + non-English extraction

Two blind spots that let the **conversational path** lose to zero-shot on individual corpora, both fixed additively (anti-pendulum — no phase is capped or removed).

### Defect 1 — Quality = 0 on the conversational path
The conversational `QualityAgent` depends on the agent turn budget; when it runs out the dialogue emits **0 quality scores** (path-dependent, non-deterministic — some corpora end at 0). New deterministic post-processor `_run_quality_sweep_from_state` mirrors the existing Dung/modal/ASPIC/PL/FOL post-processors (**5b-8**): it reuses the robust *sequential* 9-virtue `_invoke_quality_evaluator` over every identified argument and writes scores back via `state.add_quality_score`.
- **Gated on under-production** (`n_quality < n_args`) → fills gaps only, never overwrites agent scores.
- The 9-virtue evaluator is deterministic (LLM enrichment is optional), so the score is reproducible — not turn-budget dependent.

### Defect 2 — Non-English under-extraction
The English-only extraction prompt gave the model no cue to analyze in the source language, so dense non-English text under-recalled (corpus B within-30%-of-A/C DoD). `_invoke_fact_extraction` now detects the language (reusing the tested `_detect_language` heuristic) and injects a language-aware instruction for non-English text; **English is unchanged**.

### Tests (no LLM, no JVM)
7 mocked tests in `test_quality_sweep_lang_jj.py`:
- quality sweep over dict/list arguments, skip-already-scored gap-fill, no-op guards (empty args / state without `add_quality_score`);
- language clause injected for DE, absent for EN.

`black` + `flake8` clean. LLM routed via `_get_openai_client()` (toggle #675).

### DoD
- [x] Deterministic quality scores on the conversational path (post-processor, not turn-budget dependent)
- [x] Language-aware extraction for non-English corpora
- [x] Unit tests (no LLM)
- [ ] Coordinator live-verify on A/B/C (quality >0 both paths; corpus B args within 30% of A/C) — after merge, funded key

Closes #699

🤖 Generated with [Claude Code](https://claude.com/claude-code)