### PR TITLE
fix(runaway): global per-run LLM-call circuit breaker + counter caps/timeout — Track LL-bis (#708)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -13,7 +13,7 @@ import logging
 import os
 import re
 from contextlib import contextmanager
-from typing import Dict, Any, Optional, List, Tuple
+from typing import Dict, Any, Iterator, Optional, List, Tuple
 
 logger = logging.getLogger("UnifiedPipeline")
 
@@ -263,7 +263,7 @@ _llm_budget: "contextvars.ContextVar[Optional[_LLMBudget]]" = contextvars.Contex
 
 
 @contextmanager
-def llm_budget_scope(ceiling: Optional[int] = None):
+def llm_budget_scope(ceiling: Optional[int] = None) -> Iterator["_LLMBudget"]:
     """Activate a per-run LLM-call circuit breaker for the duration of the block.
 
     Every ``_guarded_chat_completion`` call made within (including in child

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -7,10 +7,12 @@ Split from unified_pipeline.py (#310).
 """
 
 import asyncio
+import contextvars
 import json
 import logging
 import os
 import re
+from contextlib import contextmanager
 from typing import Dict, Any, Optional, List, Tuple
 
 logger = logging.getLogger("UnifiedPipeline")
@@ -26,6 +28,9 @@ except ImportError:
 # Export all underscore-prefixed functions for star-import in unified_pipeline facade
 __all__ = [
     "_get_openai_client",
+    "_guarded_chat_completion",
+    "llm_budget_scope",
+    "LLMBudgetExceeded",
     "_invoke_quality_evaluator",
     "_aggregate_virtue_scores",
     "_llm_enrich_quality",
@@ -198,6 +203,107 @@ def _get_openai_client() -> Tuple[Any, str]:
         return AsyncOpenAI(api_key=api_key, base_url=base_url), model_id
     except ImportError:
         return None, ""
+
+
+# --- Global per-run LLM-call circuit breaker (issue #708, Track LL-bis) ---
+#
+# A single analysis run funnels EVERY LLM chat-completion through
+# ``_guarded_chat_completion``, which counts the call against a per-run budget.
+# This is the only backstop that covers *every* phase: the counter-argument
+# chain (``_extract_arguments_from_context`` → ``_invoke_counter_argument`` →
+# ``_generate_counters_for_targets``) is otherwise uncapped and scales with the
+# upstream argument count, which is what produced the 8h / ~12,417-call DAG
+# runaway. Anti-pendulum: the ceiling is generous-but-finite (a healthy
+# ``spectacular`` run is ~60-100 calls), so it never bites a real run but stops
+# a runaway dead. It does NOT re-introduce a small per-phase cap (that would
+# undo the GG #696 volume win).
+
+
+class LLMBudgetExceeded(RuntimeError):
+    """Raised when one analysis run exceeds its global LLM-call ceiling (#708).
+
+    Caught per-phase by the workflow executor / each ``_invoke_*`` try/except,
+    so it degrades a runaway into a graceful fallback rather than propagating.
+    """
+
+
+class _LLMBudget:
+    """Mutable per-run LLM-call counter shared across phase sub-tasks.
+
+    Stored in a ``ContextVar`` set once at the start of a run. asyncio copies
+    the *context* (the var binding) into every child task spawned via
+    ``asyncio.gather`` / ``asyncio.wait_for``, but the bound object is shared by
+    reference — so incrementing ``count`` from any phase task aggregates into one
+    global per-run total. (A plain int in a ContextVar would NOT aggregate,
+    because each task gets its own binding.)
+    """
+
+    __slots__ = ("count", "ceiling")
+
+    def __init__(self, ceiling: int) -> None:
+        self.count = 0
+        self.ceiling = ceiling
+
+
+def _default_llm_call_budget() -> int:
+    """Generous per-run LLM-call ceiling (override via ``LLM_CALL_BUDGET``).
+
+    Healthy ``spectacular`` run ~60-100 calls; the default 500 never bites a
+    healthy run but stops a 12K-call runaway.
+    """
+    try:
+        return max(1, int(os.environ.get("LLM_CALL_BUDGET", "500")))
+    except (TypeError, ValueError):
+        return 500
+
+
+_llm_budget: "contextvars.ContextVar[Optional[_LLMBudget]]" = contextvars.ContextVar(
+    "llm_call_budget", default=None
+)
+
+
+@contextmanager
+def llm_budget_scope(ceiling: Optional[int] = None):
+    """Activate a per-run LLM-call circuit breaker for the duration of the block.
+
+    Every ``_guarded_chat_completion`` call made within (including in child
+    asyncio tasks) counts against one shared ceiling; exceeding it raises
+    ``LLMBudgetExceeded``. Re-entrant: a nested scope reuses the already-active
+    budget so the count stays global across the whole run.
+    """
+    existing = _llm_budget.get()
+    if existing is not None:
+        # Already inside a budget scope — keep one global count, don't reset it.
+        yield existing
+        return
+    budget = _LLMBudget(ceiling if ceiling is not None else _default_llm_call_budget())
+    token = _llm_budget.set(budget)
+    try:
+        yield budget
+    finally:
+        _llm_budget.reset(token)
+
+
+async def _guarded_chat_completion(client: Any, **kwargs: Any) -> Any:
+    """Single funnel for every LLM chat-completion call (#708 runaway guard).
+
+    Increments the active per-run budget (if any) and raises
+    ``LLMBudgetExceeded`` past the ceiling *before* issuing the network call, so
+    a degenerate upstream (e.g. a large argument list feeding the uncapped
+    counter sweep) cannot run away into thousands of round-trips. Inert when no
+    budget scope is active, so a direct unit-test call of a single callable is
+    unaffected.
+    """
+    budget = _llm_budget.get()
+    if budget is not None:
+        budget.count += 1
+        if budget.count > budget.ceiling:
+            raise LLMBudgetExceeded(
+                f"Global LLM-call budget exceeded "
+                f"({budget.count} > {budget.ceiling}) in a single analysis run "
+                f"— runaway guard (issue #708)."
+            )
+    return await client.chat.completions.create(**kwargs)
 
 
 # --- Invoke callables for registered components ---
@@ -408,7 +514,8 @@ async def _llm_enrich_quality(
                 )
 
         det_params = _get_determinism_params()
-        response = await client.chat.completions.create(
+        response = await _guarded_chat_completion(
+            client,
             model=model_id,
             messages=[
                 {
@@ -512,7 +619,8 @@ async def _generate_counters_for_targets(
         batch = targets[start : start + batch_size]
         targets_text = "\n".join(f"{i+1}. {t}" for i, t in enumerate(batch))
         try:
-            response = await client.chat.completions.create(
+            response = await _guarded_chat_completion(
+                client,
                 model=model_id,
                 messages=[
                     {"role": "system", "content": system_prompt},
@@ -1003,7 +1111,8 @@ async def _invoke_debate_analysis(
             )
 
             det_params = _get_determinism_params()
-            response = await client.chat.completions.create(
+            response = await _guarded_chat_completion(
+                client,
                 model=model_id,
                 messages=[
                     {
@@ -1202,7 +1311,8 @@ async def _invoke_governance(
             )
 
             det_params = _get_determinism_params()
-            response = await client.chat.completions.create(
+            response = await _guarded_chat_completion(
+                client,
                 model=model_id,
                 messages=[
                     {
@@ -1957,13 +2067,17 @@ def _extract_arguments_from_context(
     ]:
         phase_out = context.get(phase_key, {})
         if isinstance(phase_out, dict):
-            # Primary: explicit arguments list (from fact_extraction LLM)
+            # Primary: explicit arguments list (from fact_extraction LLM).
+            # Generous cap [:40] (#708, anti-pendulum): this list feeds the
+            # uncapped counter sweep; bounding it stops a degenerate upstream
+            # from driving thousands of LLM calls, while 40 still far exceeds
+            # the 0-shot argument volume (the GG #696 volume win is preserved).
             if "arguments" in phase_out:
                 args = phase_out["arguments"]
                 if isinstance(args, list) and args:
                     return [
                         a.get("text", str(a)) if isinstance(a, dict) else str(a)
-                        for a in args
+                        for a in args[:40]
                     ]
             # Secondary: claims list (from fact_extraction heuristic fallback)
             if "claims" in phase_out:
@@ -3753,7 +3867,8 @@ async def _invoke_fact_extraction(
                     )
             except Exception:
                 lang_clause = ""
-            response = await client.chat.completions.create(
+            response = await _guarded_chat_completion(
+                client,
                 model=model_id,
                 messages=[
                     {
@@ -3944,7 +4059,8 @@ async def _invoke_propositional_logic(
                         f"Text:\n{input_text[:4000]}"
                     )
                     det_params = _get_determinism_params()
-                    pass1_resp = await client.chat.completions.create(
+                    pass1_resp = await _guarded_chat_completion(
+                        client,
                         model=model_id,
                         messages=[{"role": "user", "content": pass1_prompt}],
                         **det_params,
@@ -3993,7 +4109,8 @@ async def _invoke_propositional_logic(
                                 f"Allowed propositions:\n{atoms_json}"
                             )
                             try:
-                                pass2_resp = await client.chat.completions.create(
+                                pass2_resp = await _guarded_chat_completion(
+                                    client,
                                     model=model_id,
                                     messages=[
                                         {"role": "user", "content": pass2_prompt}
@@ -4035,7 +4152,8 @@ async def _invoke_propositional_logic(
                                 f"Text:\n{input_text[:4000]}\n\n"
                                 f"Allowed propositions:\n{_json.dumps({'propositions': shared_atoms}, indent=2)}"
                             )
-                            wt_resp = await client.chat.completions.create(
+                            wt_resp = await _guarded_chat_completion(
+                                client,
                                 model=model_id,
                                 messages=[{"role": "user", "content": wt_prompt}],
                                 **det_params,
@@ -4314,7 +4432,8 @@ async def _invoke_fol_reasoning(
                         f"Text:\n{input_text[:4000]}"
                     )
                     det_params = _get_determinism_params()
-                    pass1_resp = await client.chat.completions.create(
+                    pass1_resp = await _guarded_chat_completion(
+                        client,
                         model=model_id,
                         messages=[{"role": "user", "content": pass1_prompt}],
                         **det_params,
@@ -4371,7 +4490,8 @@ async def _invoke_fol_reasoning(
                                     f"Signature:\n{sig_json}"
                                 )
                                 try:
-                                    pass2_resp = await client.chat.completions.create(
+                                    pass2_resp = await _guarded_chat_completion(
+                                        client,
                                         model=model_id,
                                         messages=[
                                             {"role": "user", "content": pass2_prompt}

--- a/argumentation_analysis/orchestration/workflow_dsl.py
+++ b/argumentation_analysis/orchestration/workflow_dsl.py
@@ -317,6 +317,41 @@ class WorkflowExecutor:
         checkpoint_callback: Optional[Callable[..., None]] = None,
         resume_from: Optional[Set[str]] = None,
     ) -> Dict[str, PhaseResult]:
+        """Execute a workflow under a per-run LLM-call circuit breaker (#708).
+
+        Thin wrapper around :meth:`_execute_impl` that activates a global
+        per-run LLM-call budget (see ``invoke_callables.llm_budget_scope``).
+        Every phase's LLM calls count against one ceiling, so a degenerate
+        upstream (e.g. a large argument list feeding the uncapped counter
+        sweep) cannot run away into thousands of round-trips. The budget is
+        the only backstop that covers *every* phase. Re-entrant: a nested
+        workflow reuses the already-active budget.
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            llm_budget_scope,
+        )
+
+        with llm_budget_scope():
+            return await self._execute_impl(
+                workflow,
+                input_data,
+                context=context,
+                state=state,
+                state_writers=state_writers,
+                checkpoint_callback=checkpoint_callback,
+                resume_from=resume_from,
+            )
+
+    async def _execute_impl(
+        self,
+        workflow: WorkflowDefinition,
+        input_data: Any,
+        context: Optional[Dict[str, Any]] = None,
+        state: Optional[Any] = None,
+        state_writers: Optional[Dict[str, Any]] = None,
+        checkpoint_callback: Optional[Callable[..., None]] = None,
+        resume_from: Optional[Set[str]] = None,
+    ) -> Dict[str, PhaseResult]:
         """
         Execute a workflow definition.
 
@@ -361,6 +396,7 @@ class WorkflowExecutor:
         ctx["correlation_id"] = correlation_id
 
         from argumentation_analysis.orchestration.structured_logging import PhaseLogger
+
         slog = PhaseLogger(self._base_logger, correlation_id=correlation_id)
 
         slog.info(
@@ -409,7 +445,10 @@ class WorkflowExecutor:
                 if phase:
                     slog.info(
                         "Starting phase",
-                        extra={"phase_name": phase_name, "capability": phase.capability},
+                        extra={
+                            "phase_name": phase_name,
+                            "capability": phase.capability,
+                        },
                     )
                     phase_coros.append(
                         self._execute_phase(phase, phase_name, input_data, ctx)

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -686,11 +686,16 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             optional=True,
             timeout_seconds=180,
         )
-        # L5 — counter-argument generation
+        # L5 — counter-argument generation.
+        # timeout_seconds=420 (#708, anti-pendulum): the counter sweep is the
+        # only LLM-heavy phase that scales with the upstream argument count;
+        # generous enough never to bite a healthy run, but a finite wall-clock
+        # bound so a degenerate upstream cannot run away for hours.
         .add_phase(
             "counter",
             capability="counter_argument_generation",
             depends_on=["quality"],
+            timeout_seconds=420,
         )
         # L6 — JTMS belief tracking + adversarial debate (parallel)
         .add_phase(

--- a/tests/unit/argumentation_analysis/orchestration/test_belief_revision_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_belief_revision_spectacular.py
@@ -23,7 +23,10 @@ class TestBeliefRevisionSpectacularPhase:
         )
 
         wf = build_spectacular_workflow()
-        assert len(wf.phases) == 27
+        # Canary: bump this when build_spectacular_workflow gains/loses a phase
+        # (catches an accidental dropped/duplicated phase). 28 incl. the
+        # belief_revision phase wired here.
+        assert len(wf.phases) == 28
 
     def test_belief_revision_state_writer_exists(self):
         from argumentation_analysis.orchestration.state_writers import (

--- a/tests/unit/argumentation_analysis/orchestration/test_external_solver_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_external_solver_spectacular.py
@@ -40,7 +40,10 @@ class TestExternalSolverSpectacular:
         )
 
         wf = build_spectacular_workflow()
-        assert len(wf.phases) == 27
+        # Canary: bump this when build_spectacular_workflow gains/loses a phase
+        # (catches an accidental dropped/duplicated phase). 28 incl. the L5
+        # external fol_solver + modal_solver phases.
+        assert len(wf.phases) == 28
 
     def test_external_fol_solver_service_registered(self):
         from argumentation_analysis.orchestration.registry_setup import setup_registry

--- a/tests/unit/argumentation_analysis/orchestration/test_llm_budget_guard_ll_bis.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_llm_budget_guard_ll_bis.py
@@ -1,0 +1,242 @@
+"""Tests for the global per-run LLM-call circuit breaker (Track LL-bis #708).
+
+The DAG ``spectacular`` workflow had no backstop against a runaway: the
+counter-argument chain (``_extract_arguments_from_context`` →
+``_invoke_counter_argument`` → ``_generate_counters_for_targets``) is uncapped
+and scales with the upstream argument count, and the ``counter`` phase had no
+``timeout_seconds``. A degenerate upstream once drove an 8h / ~12,417-call /
+0-JSON run. This module verifies, with a mocked LLM (no real API), the three
+parts of the fix:
+
+  1. A per-run budget (``llm_budget_scope`` + ``_guarded_chat_completion``)
+     funnels EVERY chat-completion through one shared counter and raises
+     ``LLMBudgetExceeded`` past the ceiling — so a pathological argument list
+     cannot produce more than ``ceiling`` LLM calls. The guard is inert outside
+     a scope (single-callable unit tests are unaffected) and re-entrant (a
+     nested scope shares one global count).
+  2. ``_extract_arguments_from_context`` caps its primary ``arguments`` branch
+     at 40 (generous-but-finite; anti-pendulum — the GG #696 volume win, which
+     far exceeds the ~15 zero-shot argument volume, is preserved).
+  3. ``build_spectacular_workflow().get_phase("counter")`` has a
+     ``timeout_seconds`` wall-clock bound.
+
+And that ``WorkflowExecutor.execute`` activates the budget for every phase.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import argumentation_analysis.orchestration.invoke_callables as mod
+from argumentation_analysis.orchestration.invoke_callables import (
+    LLMBudgetExceeded,
+    _guarded_chat_completion,
+    llm_budget_scope,
+)
+from argumentation_analysis.orchestration.workflow_dsl import (
+    PhaseStatus,
+    WorkflowBuilder,
+    WorkflowExecutor,
+)
+from argumentation_analysis.orchestration.workflows import build_spectacular_workflow
+
+
+def _counting_client():
+    """Mock client whose create() counts invocations and returns an empty array."""
+
+    async def fake_create(**kwargs):
+        resp = MagicMock()
+        choice = MagicMock()
+        choice.message.content = "[]"
+        resp.choices = [choice]
+        return resp
+
+    client = MagicMock()
+    client.chat.completions.create = AsyncMock(side_effect=fake_create)
+    return client
+
+
+class TestBudgetBreakerFires:
+    """The funnel raises past the ceiling and never exceeds it."""
+
+    async def test_breaker_fires_past_ceiling(self):
+        client = _counting_client()
+        with llm_budget_scope(ceiling=5):
+            # The 6th call trips the breaker (count would become 6 > 5).
+            for _ in range(5):
+                await _guarded_chat_completion(client, model="m", messages=[])
+            with pytest.raises(LLMBudgetExceeded):
+                await _guarded_chat_completion(client, model="m", messages=[])
+
+    async def test_create_called_exactly_ceiling_times(self):
+        client = _counting_client()
+        with llm_budget_scope(ceiling=5):
+            for _ in range(5):
+                await _guarded_chat_completion(client, model="m", messages=[])
+            with pytest.raises(LLMBudgetExceeded):
+                await _guarded_chat_completion(client, model="m", messages=[])
+        # The tripping call raises BEFORE issuing the network round-trip, so the
+        # real create() ran exactly `ceiling` times — the runaway is capped.
+        assert client.chat.completions.create.call_count == 5
+
+
+class TestBudgetInertOutsideScope:
+    """Without an active scope the funnel is a transparent pass-through."""
+
+    async def test_no_scope_never_raises(self):
+        client = _counting_client()
+        # 1000 calls, no scope => no counting, no raise (single-callable tests
+        # and any non-run caller are unaffected).
+        for _ in range(1000):
+            await _guarded_chat_completion(client, model="m", messages=[])
+        assert client.chat.completions.create.call_count == 1000
+
+
+class TestBudgetReentrant:
+    """A nested scope reuses the active budget — one global count per run."""
+
+    async def test_nested_scope_shares_count(self):
+        client = _counting_client()
+        with llm_budget_scope(ceiling=3):
+            await _guarded_chat_completion(client, model="m", messages=[])
+            # Nested scope must NOT reset the count back to 0.
+            with llm_budget_scope(ceiling=999) as inner:
+                assert inner.ceiling == 3  # inner yields the existing budget
+                await _guarded_chat_completion(client, model="m", messages=[])
+                await _guarded_chat_completion(client, model="m", messages=[])
+                # 4th call across the whole run trips the ceiling of 3.
+                with pytest.raises(LLMBudgetExceeded):
+                    await _guarded_chat_completion(client, model="m", messages=[])
+
+
+class TestBudgetAggregatesAcrossTasks:
+    """The mutable budget aggregates across concurrent asyncio tasks.
+
+    asyncio copies the *context* (var binding) into each child task, but the
+    bound ``_LLMBudget`` object is shared by reference, so concurrent phase
+    sub-tasks increment ONE counter (a plain int in a ContextVar would not).
+    """
+
+    async def test_gather_shares_one_counter(self):
+        client = _counting_client()
+
+        async def worker():
+            await _guarded_chat_completion(client, model="m", messages=[])
+
+        with pytest.raises(LLMBudgetExceeded):
+            with llm_budget_scope(ceiling=4):
+                # 6 concurrent calls against a ceiling of 4 must trip.
+                await asyncio.gather(*(worker() for _ in range(6)))
+
+
+class TestBudgetCeilingResolution:
+    """Ceiling comes from the explicit arg, else env LLM_CALL_BUDGET, else 500."""
+
+    async def test_env_override(self):
+        with patch.dict("os.environ", {"LLM_CALL_BUDGET": "7"}):
+            with llm_budget_scope() as budget:
+                assert budget.ceiling == 7
+
+    async def test_default_when_unset(self):
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("LLM_CALL_BUDGET", None)
+            with llm_budget_scope() as budget:
+                assert budget.ceiling == 500
+
+    async def test_malformed_env_falls_back_to_500(self):
+        with patch.dict("os.environ", {"LLM_CALL_BUDGET": "not-a-number"}):
+            with llm_budget_scope() as budget:
+                assert budget.ceiling == 500
+
+
+class TestExtractArgumentsCap:
+    """The primary `arguments` branch is capped generously at 40."""
+
+    def test_primary_branch_caps_at_40(self):
+        context = {
+            "phase_extract_output": {
+                "arguments": [{"text": f"argument {i}"} for i in range(200)]
+            }
+        }
+        out = mod._extract_arguments_from_context("", context)
+        # 200 pathological args => bounded to 40, not the full 200.
+        assert len(out) == 40
+        assert out[0] == "argument 0"
+        assert out[-1] == "argument 39"
+
+    def test_small_lists_unaffected(self):
+        context = {
+            "phase_extract_output": {
+                "arguments": [{"text": f"argument {i}"} for i in range(15)]
+            }
+        }
+        out = mod._extract_arguments_from_context("", context)
+        # 15 (= ~zero-shot volume) passes through untouched; cap never bites.
+        assert len(out) == 15
+
+
+class TestCounterPhaseTimeout:
+    """The counter phase carries a wall-clock bound (no longer unbounded)."""
+
+    def test_counter_phase_has_timeout(self):
+        wf = build_spectacular_workflow()
+        counter = wf.get_phase("counter")
+        assert counter is not None
+        assert counter.timeout_seconds is not None
+        assert counter.timeout_seconds == 420
+
+    def test_counter_is_the_only_uncapped_path_now_bounded(self):
+        # Sanity: the phase exists and depends on quality (its place in the DAG).
+        wf = build_spectacular_workflow()
+        counter = wf.get_phase("counter")
+        assert "quality" in counter.depends_on
+
+
+class TestExecutorActivatesBudget:
+    """WorkflowExecutor.execute wraps execution in a live budget scope."""
+
+    async def test_budget_active_inside_phase_invoke(self):
+        seen = {}
+
+        async def invoke(phase_input, ctx):
+            # Inside a phase invoked by the executor, the per-run budget MUST be
+            # active — this proves the wiring covers every phase.
+            seen["budget"] = mod._llm_budget.get()
+            return {"ok": True}
+
+        provider = SimpleNamespace(name="fake", invoke=invoke)
+        registry = MagicMock()
+        registry.find_for_capability = MagicMock(return_value=[provider])
+
+        wf = WorkflowBuilder("t").add_phase("p", capability="cap").build()
+        executor = WorkflowExecutor(registry)
+        results = await executor.execute(wf, "input text")
+
+        assert results["p"].status == PhaseStatus.COMPLETED
+        assert seen["budget"] is not None  # budget was live during the phase
+
+    async def test_budget_inactive_outside_executor(self):
+        # Outside any execute() call, no budget is active (inert by default).
+        assert mod._llm_budget.get() is None
+
+    async def test_breaker_in_phase_degrades_gracefully(self):
+        # A phase that trips the breaker must degrade to a FAILED PhaseResult,
+        # not propagate LLMBudgetExceeded out of the run (DoD #708).
+        async def invoke(phase_input, ctx):
+            raise LLMBudgetExceeded("simulated runaway")
+
+        provider = SimpleNamespace(name="fake", invoke=invoke)
+        registry = MagicMock()
+        registry.find_for_capability = MagicMock(return_value=[provider])
+
+        wf = WorkflowBuilder("t").add_phase("p", capability="cap").build()
+        executor = WorkflowExecutor(registry)
+        # Must not raise — the executor catches it per-phase.
+        results = await executor.execute(wf, "input text")
+
+        assert results["p"].status == PhaseStatus.FAILED
+        assert "runaway" in (results["p"].error or "")


### PR DESCRIPTION
Closes #708. Part of Epic #695 (zero blind spots).

## Problem

The DAG `spectacular` workflow had no backstop against a runaway. Live-verifying LL #705's DoD on corpus A / DAG ran away ~8h (~12,417 LLM round-trips, 0 JSON written). Grounded root cause (verified by reading `argumentation_analysis/orchestration/`): every formal/logic phase is bounded, but the **counter-argument chain is the only uncapped LLM path that scales with the upstream argument count**, with no global circuit breaker anywhere:

- `_extract_arguments_from_context` primary `arguments` branch was uncapped (siblings capped `claims[:8]`, sentences `[:6]`).
- `_invoke_counter_argument` targets = ALL fallacies + ALL args; `_generate_counters_for_targets` explicitly uncapped (batch=12).
- The `counter` phase had no `timeout_seconds` — the only LLM-heavy phase without one.

## Fix (defense-in-depth, anti-pendulum)

Generous-but-finite bounds + a global breaker. **NOT a small per-phase cap** — that would undo the GG #696 volume win (counter-args ≥ 0-shot).

1. **Global per-run LLM-call circuit breaker.** Every chat-completion is funnelled through `_guarded_chat_completion`, counting the call against a per-run `_LLMBudget` (mutable object in a `ContextVar`, set once at the top of `WorkflowExecutor.execute` via the re-entrant `llm_budget_scope`). asyncio copies the var binding into each child phase task, but the bound object is shared by reference → every phase increments **one** counter. Past the ceiling (default **500**, override `LLM_CALL_BUDGET`; healthy `spectacular` run ~60-100) it raises `LLMBudgetExceeded`, which the executor catches per-phase → graceful `FAILED`, never propagates. Inert when no scope is active (single-callable unit tests unaffected).
2. **Generous `[:40]` cap** on the `_extract_arguments_from_context` primary branch (the uncapped feed into the counter sweep). 40 still far exceeds the ~15 zero-shot argument volume.
3. **`timeout_seconds=420`** on the `counter` phase in `build_spectacular_workflow`.

## Tests

New `tests/unit/.../orchestration/test_llm_budget_guard_ll_bis.py` (15, mocked client — no LLM/JVM):
- breaker fires past ceiling and `create()` runs **exactly** `ceiling` times (raise happens before the network round-trip);
- inert outside a scope (1000 calls, no raise);
- re-entrant nested scope shares one count;
- budget aggregates across `asyncio.gather` tasks;
- ceiling resolves from arg → `LLM_CALL_BUDGET` env → default 500 (malformed env → 500);
- extract caps at 40 (200 args → 40), small lists untouched;
- `get_phase("counter").timeout_seconds == 420`;
- executor activates the budget for every phase **and** degrades a breaker trip to a `FAILED` PhaseResult (never propagates).

All targeted regression suites green (GG counter-caps, LL/HH formal logic, checkpoint, parallelism, convergence, external_solver, belief_revision: no regressions from the funnel rerouting).

## Files removed and why

None — no deletions.

## Drive-by (blind-spot cleanup)

Restored 2 stale phase-count canaries `27 → 28` in `test_external_solver_spectacular.py` and `test_belief_revision_spectacular.py` — **red on main** since a 28th phase landed without bumping them. Confirmed pre-existing (fail identically on clean `9522b229`). Added a comment so the next phase author bumps the canary.

## Scope / deferred

- **Scope: DAG executor only.** The conversational path is turn-bounded (`max_turns_per_phase`), not a runaway vector; the guard is inert there (no active budget).
- **Deferred:** the guarded LL live re-verify (`measure_both_paths_vs_zeroshot.py --paths dag --corpus A` with wall-clock + LLM-call caps, then A/B/C) needs the funded OpenRouter key — held for the next funded window, not this credits-tight window. The structural defect this PR fixes is verified independently by the mocked tests.

## Known separate blind spot (out of scope, flagged)

`test_informal_taxonomy_injection_600.py::TestParentHarnessFallback` (2 tests) is red on main, **pre-existing and unrelated** to this change (#600 territory). Flagged on the workspace dashboard for separate follow-up; not fixed here to keep this PR focused on #708.

🤖 Generated with [Claude Code](https://claude.com/claude-code)