### PR TITLE
feat(semantic-index): wire is_available() guard -- Track KK (#700)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -2026,14 +2026,25 @@ async def _invoke_local_llm(input_text: str, context: Dict[str, Any]) -> Dict[st
 async def _invoke_semantic_index(
     input_text: str, context: Dict[str, Any]
 ) -> Dict[str, Any]:
-    """Invoke semantic index service for argument search."""
+    """Invoke semantic index service for argument search.
+
+    KK #700: consults ``is_available()`` before attempting indexing.
+    Returns explicit status: ``ran`` (endpoint up, indexed) or
+    ``skipped: endpoint_unavailable`` (no silent optional skip).
+    """
     from argumentation_analysis.services.semantic_index_service import (
         SemanticIndexService,
     )
 
     service = SemanticIndexService()
+    if not service.is_available():
+        return {
+            "status": "skipped: endpoint_unavailable",
+            "reason": "SemanticIndexService at 127.0.0.1:9001 is not reachable",
+        }
+
     results = await asyncio.to_thread(service.search, input_text)
-    return {"results": results}
+    return {"status": "ran", "results": results}
 
 
 async def _invoke_speech_transcription(

--- a/tests/unit/argumentation_analysis/orchestration/test_semantic_indexing_guard_kk.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_semantic_indexing_guard_kk.py
@@ -1,0 +1,43 @@
+"""Tests for semantic_indexing is_available() guard (Track KK #700).
+
+Verifies that _invoke_semantic_index consults is_available() and returns
+an explicit status instead of silently skipping.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import argumentation_analysis.orchestration.invoke_callables as mod
+
+_SERVICE_PATH = (
+    "argumentation_analysis.services.semantic_index_service.SemanticIndexService"
+)
+
+
+class TestSemanticIndexGuard:
+    """_invoke_semantic_index branches on is_available()."""
+
+    async def test_endpoint_down_returns_explicit_skip(self):
+        """When is_available() is False, returns skipped: endpoint_unavailable."""
+        mock_service = MagicMock()
+        mock_service.is_available.return_value = False
+
+        with patch(_SERVICE_PATH, return_value=mock_service):
+            result = await mod._invoke_semantic_index("some text", {})
+
+        assert result["status"] == "skipped: endpoint_unavailable"
+        assert "not reachable" in result["reason"]
+        mock_service.search.assert_not_called()
+
+    async def test_endpoint_up_returns_ran(self):
+        """When is_available() is True, runs search and returns ran."""
+        mock_service = MagicMock()
+        mock_service.is_available.return_value = True
+        mock_service.search.return_value = [{"doc_id": "test", "relevance": 0.9}]
+
+        with patch(_SERVICE_PATH, return_value=mock_service), patch(
+            "asyncio.to_thread", side_effect=lambda fn, *a, **kw: fn(*a, **kw)
+        ):
+            result = await mod._invoke_semantic_index("some text", {})
+
+        assert result["status"] == "ran"
+        assert result["results"] == [{"doc_id": "test", "relevance": 0.9}]


### PR DESCRIPTION
## Summary
- `_invoke_semantic_index` now consults `is_available()` before attempting indexing
- Returns explicit status: `"ran"` when endpoint is up, `"skipped: endpoint_unavailable"` when down
- No more silent optional skip — the phase reports honestly

## Changes
| File | Change |
|------|--------|
| `argumentation_analysis/orchestration/invoke_callables.py` | +18 is_available() guard + explicit status |
| `tests/unit/argumentation_analysis/orchestration/test_semantic_indexing_guard_kk.py` | New: 2 tests (endpoint down/up) |

## Test plan
- [x] 2/2 tests green (endpoint down = explicit skip, endpoint up = ran)
- [x] Syntax check pass

Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)