### PR TITLE
feat(synthesis): plumb source_metadata for qualitative reports -- Track PP (#715)

### DIFF
--- a/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
+++ b/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
@@ -178,6 +178,27 @@ class DeepSynthesisAgent(BaseAgent):
     ) -> SourceOverview:
         text = getattr(state, "raw_text", "")
         meta = meta or {}
+        speaker = meta.get("speaker", "")
+        date_or_year = meta.get("date_or_year", "")
+        venue = meta.get("venue", "")
+        topic = meta.get("topic", "")
+        register = meta.get("register", "")
+        synopsis = meta.get("synopsis", "")
+        # PP #715: build rich contextual frame when context is available
+        parts = [f"Source '{meta.get('opaque_id', '?')}'"]
+        if speaker:
+            parts.append(f"by {speaker}")
+        if date_or_year:
+            parts.append(f"({date_or_year})")
+        if venue:
+            parts.append(f"at {venue}")
+        if topic:
+            parts.append(f"— Topic: {topic}")
+        parts.append(
+            f"— {meta.get('discourse_type', '?')} discourse "
+            f"in {meta.get('language', '?')}, {meta.get('era', '?')} era, "
+            f"{len(text)} characters."
+        )
         return SourceOverview(
             opaque_id=meta.get("opaque_id", "unknown"),
             era=meta.get("era", ""),
@@ -185,11 +206,13 @@ class DeepSynthesisAgent(BaseAgent):
             discourse_type=meta.get("discourse_type", ""),
             length_chars=len(text),
             length_words=len(text.split()) if text else 0,
-            contextual_frame=(
-                f"Source '{meta.get('opaque_id', '?')}' — {meta.get('discourse_type', '?')} "
-                f"discourse in {meta.get('language', '?')}, {meta.get('era', '?')} era, "
-                f"{len(text)} characters."
-            ),
+            contextual_frame=" ".join(parts),
+            speaker=speaker,
+            date_or_year=date_or_year,
+            venue=venue,
+            topic=topic,
+            register=register,
+            synopsis=synopsis,
         )
 
     @staticmethod
@@ -1005,19 +1028,51 @@ class DeepSynthesisAgent(BaseAgent):
                     f"{verdict_lines}\n"
                     f"Convergence conclusion: {report.convergence_conclusion}\n"
                 )
+            # PP #715: build context-aware prompt with discourse metadata
+            so = report.source_overview
+            context_block = ""
+            if so.speaker or so.topic or so.venue:
+                context_block = (
+                    f"\nDiscourse context: "
+                    f"Speaker: {so.speaker or 'unknown'}. "
+                    f"Date/era: {so.date_or_year or so.era or 'unknown'}. "
+                    f"Venue: {so.venue or 'unknown'}. "
+                    f"Topic: {so.topic or 'unknown'}. "
+                    f"Register: {so.register or 'unknown'}. "
+                    f"Synopsis: {so.synopsis or 'not available'}.\n"
+                )
+            top_fallacies = ""
+            if report.fallacy_diagnoses:
+                top_3 = sorted(report.fallacy_diagnoses, key=lambda f: f.confidence, reverse=True)[:3]
+                top_fallacies = "\nTop fallacies:\n" + "\n".join(
+                    f"- {f.family}/{f.fallacy_type}: {f.explanation[:120]}"
+                    for f in top_3
+                )
+            top_counters = ""
+            if report.counter_arguments:
+                best = max(report.counter_arguments, key=lambda c: c.score)
+                top_counters = (
+                    f"\nStrongest counter-argument (score {best.score:.2f}): "
+                    f"{best.content[:150]}\n"
+                )
             prompt = (
                 "Write a 2-3 paragraph closing thesis for the following analysis report. "
-                "Do NOT summarize — take a position grounded in the evidence. "
-                f"The analysis found {len(report.argument_map)} arguments, "
+                "You are writing an intelligence-style briefing. Contextualize the speaker, "
+                "occasion, and central thesis. Weave the diagnostics into a narrative. "
+                "Cite specific findings. Take a position grounded in the evidence. "
+                "Do NOT just list counts."
+                f"\n\nSource: {so.contextual_frame}"
+                f"{context_block}"
+                f"\nThe analysis found {len(report.argument_map)} arguments, "
                 f"{len(report.fallacy_diagnoses)} fallacies, "
                 f"{len(report.formal_findings)} formal findings, "
                 f"and {len(report.counter_arguments)} counter-arguments. "
-                "Key fallacy families: "
+                f"Key fallacy families: "
                 f"{', '.join(set(f.family for f in report.fallacy_diagnoses)) or 'none'}. "
-                "Dung grounded extension: "
-                f"{', '.join(report.dung_structure.grounded_extension) or 'none'}. "
-                "Strongest counter-argument score: "
-                f"{max((c.score for c in report.counter_arguments), default=0):.2f}."
+                f"Dung grounded extension: "
+                f"{', '.join(report.dung_structure.grounded_extension) or 'none'}."
+                f"{top_fallacies}"
+                f"{top_counters}"
                 f"{convergence_block}"
             )
             # Use SK chat completion

--- a/argumentation_analysis/agents/core/synthesis/deep_synthesis_models.py
+++ b/argumentation_analysis/agents/core/synthesis/deep_synthesis_models.py
@@ -16,6 +16,13 @@ class SourceOverview:
     length_chars: int = 0
     length_words: int = 0
     contextual_frame: str = ""
+    # PP #715: enriched context fields for qualitative synthesis
+    speaker: str = ""
+    date_or_year: str = ""
+    venue: str = ""
+    topic: str = ""
+    register: str = ""
+    synopsis: str = ""
 
 
 @dataclass

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -433,6 +433,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         self.workflow_results: Dict[str, Any] = {}
         # Narrative synthesis (#351)
         self.narrative_synthesis: str = ""
+        # PP #715: source-level metadata for qualitative synthesis
+        self.source_metadata: Dict[str, str] = {}
         # PL 2-pass pipeline: shared atom inventory (#547)
         self.atomic_propositions: Dict[str, List[str]] = {}
         # FOL 2-pass pipeline: shared signature per source (#544)

--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -460,6 +460,7 @@ async def run_conversational_analysis(
     growth_re_prompt_limit: int = 2,
     enable_tool_gating: bool = False,
     enable_reprompt_tracing: bool = False,
+    source_metadata: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """Run a full conversational analysis on the input text.
 
@@ -970,6 +971,9 @@ async def run_conversational_analysis(
                 "language": detected_lang if detected_lang != "unknown" else "",
                 "discourse_type": "",
             }
+            # PP #715: merge caller-provided source_metadata
+            if source_metadata:
+                source_meta.update(source_metadata)
             ctx = {
                 "_state_object": state,
                 "source_metadata": source_meta,

--- a/scripts/measure_both_paths_vs_zeroshot.py
+++ b/scripts/measure_both_paths_vs_zeroshot.py
@@ -53,6 +53,19 @@ ZERO_SHOT = {
     "C": {"counter_arguments": 18, "pl_formulas": 12, "fol_formulas": 12, "fallacies": 0},
 }
 CORPUS_SRC_IDX = {"A": 11, "B": 3, "C": 2}
+# PP #715: opaque metadata per corpus for qualitative synthesis.
+# speaker/venue are generic descriptors — no real names in commits.
+CORPUS_METADATA = {
+    "A": {"speaker": "Speaker_A", "date_or_year": "era_A",
+          "venue": "venue_A", "topic": "geopolitics_A",
+          "register": "formal", "synopsis": "Speech about territory and sovereignty"},
+    "B": {"speaker": "Speaker_B", "date_or_year": "era_B",
+          "venue": "venue_B", "topic": "geopolitics_B",
+          "register": "formal", "synopsis": "Collection of speeches on historical events"},
+    "C": {"speaker": "Speaker_C", "date_or_year": "era_C",
+          "venue": "venue_C", "topic": "geopolitics_C",
+          "register": "formal", "synopsis": "Address on territorial disputes and historical claims"},
+}
 OUTPUTS_DIR = Path("outputs/deep_analysis")
 
 
@@ -162,6 +175,7 @@ async def _generate_deep_synthesis(
             "source_metadata": {
                 "opaque_id": f"corpus_{corpus_label}",
                 "source_type": "encrypted_dataset",
+                **CORPUS_METADATA.get(corpus_label, {}),
             },
         }
         ds = await _invoke_deep_synthesis("", ctx)


### PR DESCRIPTION
## Summary
Root cause: `DeepSynthesisAgent` received empty `source_metadata` (`era=""`, `discourse_type=""`), so `_llm_synthesis` sent only counts to the LLM — producing mechanical counting instead of contextual narrative.

### Changes
| File | Change |
|------|--------|
| `deep_synthesis_models.py` | +6 fields on SourceOverview (speaker, date_or_year, venue, topic, register, synopsis) |
| `deep_synthesis_agent.py` | `_build_source_overview` builds rich contextual_frame; `_llm_synthesis` uses context-aware prompt with discourse metadata + top fallacies/counter-args |
| `conversational_orchestrator.py` | +`source_metadata` param on `run_conversational_analysis()`, merged into deep synthesis call |
| `shared_state.py` | +`source_metadata` dict field on `UnifiedAnalysisState` |
| `measure_both_paths_vs_zeroshot.py` | `CORPUS_METADATA` with opaque descriptors per corpus |

### Privacy
Output lives in gitignored `outputs/`. Only opaque IDs in commits.

Closes #715

🤖 Generated with [Claude Code](https://claude.com/claude-code)