### PR TITLE
fix(orchestration): repair main RED — mypy strict on parallelized PL/FOL pass 2 (#729)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -4324,7 +4324,7 @@ async def _invoke_propositional_logic(
                         _pl_batch_size = 3
                         _pl_targets = args[:10]
 
-                        async def _pl_batch_coro(_batch: list) -> list:
+                        async def _pl_batch_coro(_batch: list[str]) -> list[str]:
                             if len(_batch) == 1:
                                 _texts_block = f"Text:\n{_batch[0][:2000]}"
                             else:
@@ -4348,7 +4348,10 @@ async def _invoke_propositional_logic(
                                 **det_params,
                             )
                             _raw = _resp.choices[0].message.content or ""
-                            return _parse_json_from_llm(_raw).get("formulas", [])
+                            _pl_out: list[str] = _parse_json_from_llm(_raw).get(
+                                "formulas", []
+                            )
+                            return _pl_out
 
                         _pl_coros = [
                             _pl_batch_coro(_pl_targets[_bi:_bi + _pl_batch_size])
@@ -4356,7 +4359,7 @@ async def _invoke_propositional_logic(
                         ]
                         _pl_results = await asyncio.gather(*_pl_coros, return_exceptions=True)
                         for _idx, _res in enumerate(_pl_results):
-                            if isinstance(_res, Exception):
+                            if isinstance(_res, BaseException):
                                 logger.debug(f"PL Pass 2 batch {_idx} failed: {_res}")
                                 continue
                             for f in _res:
@@ -4716,7 +4719,7 @@ async def _invoke_fol_reasoning(
                             _fol_batch_size = 3
                             _fol_targets = args[:10]
 
-                            async def _fol_batch_coro(_batch: list) -> list:
+                            async def _fol_batch_coro(_batch: list[str]) -> list[str]:
                                 if len(_batch) == 1:
                                     _texts_block = f"Text:\n{_batch[0][:2000]}"
                                 else:
@@ -4742,7 +4745,10 @@ async def _invoke_fol_reasoning(
                                     **det_params,
                                 )
                                 _raw = _resp.choices[0].message.content or ""
-                                return _parse_json_from_llm(_raw).get("formulas", [])
+                                _fol_out: list[str] = _parse_json_from_llm(_raw).get(
+                                    "formulas", []
+                                )
+                                return _fol_out
 
                             _fol_coros = [
                                 _fol_batch_coro(_fol_targets[_bi:_bi + _fol_batch_size])
@@ -4750,7 +4756,7 @@ async def _invoke_fol_reasoning(
                             ]
                             _fol_results = await asyncio.gather(*_fol_coros, return_exceptions=True)
                             for _idx, _res in enumerate(_fol_results):
-                                if isinstance(_res, Exception):
+                                if isinstance(_res, BaseException):
                                     logger.debug(f"FOL Pass 2 batch {_idx} failed: {_res}")
                                     continue
                                 for f in _res:


### PR DESCRIPTION
## Context — main is RED

Commit \`9536010a\` (\`perf(formal): parallelize PL/FOL pass 2 batches with asyncio.gather (#729)\`) turned **main CI red**. Diagnosis:

- The gating step is **`Type check (mypy strict — core orchestration)`** — `black`/`flake8` steps are `continue-on-error` (they report 60 pre-existing reformats + a few E704/E127/W391 in unrelated files under the newer pinned linter versions, but do NOT fail the job).
- mypy strict reported **6 errors in `invoke_callables.py`** introduced by the `asyncio.gather(..., return_exceptions=True)` change.

```
invoke_callables.py:4327: error: Missing type arguments for generic type "list"  [type-arg]
invoke_callables.py:4351: error: Returning Any from function declared to return "list[Any]"  [no-any-return]
invoke_callables.py:4362: error: Item "BaseException" of "list[Any] | BaseException" has no attribute "__iter__"  [union-attr]
invoke_callables.py:4719: error: Missing type arguments for generic type "list"  [type-arg]
invoke_callables.py:4745: error: Returning Any from function declared to return "list[Any]"  [no-any-return]
invoke_callables.py:4756: error: Item "BaseException" of "list[Any] | BaseException" has no attribute "__iter__"  [union-attr]
```

## Root cause

`asyncio.gather(..., return_exceptions=True)` returns `list[Any | BaseException]`. The result iteration guarded with `isinstance(_res, Exception)` — but `BaseException` is broader than `Exception`, so mypy could not narrow `_res` to a list before `for f in _res`. The batch coroutines also used bare `list` annotations and returned `Any` from `.get("formulas", [])`.

## Fix (both PL ~4327 and FOL ~4719 blocks)

- `_pl_batch_coro` / `_fol_batch_coro`: `list` → `list[str]` for params and return type
- typed local (`_pl_out` / `_fol_out: list[str]`) before `return` → fixes `no-any-return`
- `isinstance(_res, Exception)` → `isinstance(_res, BaseException)` → mypy narrows `_res` to `list[str]` for the iteration → fixes `union-attr`

**No behavior change** — same parallelization, same exception handling at runtime (`BaseException` is a strict superset; the only added catches are `KeyboardInterrupt`/`SystemExit`/`CancelledError`, which `gather` would surface as results here anyway).

## Verification

- `mypy --config-file pyproject.toml` on the exact 8-file CI scope → **Success: no issues found**
- 53 tests green: `test_pl_2pass_pipeline` + `test_fol_2pass_pipeline` + `test_counter_argument_caps_gg`

## Files removed and why

None — single-file edit (+12/−6).