### PR TITLE
fix(orchestration): hard per-call LLM timeout guard (#730-bis defense-in-depth)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -285,6 +285,14 @@ def llm_budget_scope(ceiling: Optional[int] = None) -> Iterator["_LLMBudget"]:
         _llm_budget.reset(token)
 
 
+# Defense-in-depth (#730-bis): hard per-call wall-clock cap so a single stalled
+# network round-trip cannot hang an entire analysis run. Observed live: the
+# conversational-spectacular path hung ~50 min on one unbounded call. Generous
+# default (300s) — far above a legitimate reasoning-model call (<2 min) but well
+# below a pathological hang. Set LLM_CALL_TIMEOUT_S=0 to disable.
+_LLM_CALL_TIMEOUT_S = float(os.environ.get("LLM_CALL_TIMEOUT_S", "300"))
+
+
 async def _guarded_chat_completion(client: Any, **kwargs: Any) -> Any:
     """Single funnel for every LLM chat-completion call (#708 runaway guard).
 
@@ -294,6 +302,11 @@ async def _guarded_chat_completion(client: Any, **kwargs: Any) -> Any:
     counter sweep) cannot run away into thousands of round-trips. Inert when no
     budget scope is active, so a direct unit-test call of a single callable is
     unaffected.
+
+    Each call is also bounded by ``_LLM_CALL_TIMEOUT_S`` (#730-bis): on a stalled
+    round-trip an ``asyncio.TimeoutError`` propagates and is handled by the
+    callers' existing ``except`` blocks (batch dropped / coverage retry) instead
+    of hanging the whole run.
     """
     budget = _llm_budget.get()
     if budget is not None:
@@ -304,6 +317,11 @@ async def _guarded_chat_completion(client: Any, **kwargs: Any) -> Any:
                 f"({budget.count} > {budget.ceiling}) in a single analysis run "
                 f"— runaway guard (issue #708)."
             )
+    if _LLM_CALL_TIMEOUT_S > 0:
+        return await asyncio.wait_for(
+            client.chat.completions.create(**kwargs),
+            timeout=_LLM_CALL_TIMEOUT_S,
+        )
     return await client.chat.completions.create(**kwargs)
 
 

--- a/tests/unit/argumentation_analysis/orchestration/test_llm_budget_guard_ll_bis.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_llm_budget_guard_ll_bis.py
@@ -240,3 +240,36 @@ class TestExecutorActivatesBudget:
 
         assert results["p"].status == PhaseStatus.FAILED
         assert "runaway" in (results["p"].error or "")
+
+
+class TestLLMCallTimeoutGuard:
+    """#730-bis: a stalled chat-completion call is bounded by _LLM_CALL_TIMEOUT_S.
+
+    Live-observed failure: the conversational-spectacular path hung ~50 min on a
+    single unbounded round-trip. The funnel now wraps the call in
+    asyncio.wait_for so one stalled call raises TimeoutError (handled by callers)
+    instead of hanging the whole run.
+    """
+
+    async def test_stalled_call_times_out(self):
+        async def slow_create(**kwargs):
+            await asyncio.sleep(5.0)
+            return MagicMock()
+
+        client = MagicMock()
+        client.chat.completions.create = AsyncMock(side_effect=slow_create)
+        with patch.object(mod, "_LLM_CALL_TIMEOUT_S", 0.05):
+            with pytest.raises(asyncio.TimeoutError):
+                await _guarded_chat_completion(client, model="m", messages=[])
+
+    async def test_fast_call_returns_normally(self):
+        client = _counting_client()
+        with patch.object(mod, "_LLM_CALL_TIMEOUT_S", 5.0):
+            resp = await _guarded_chat_completion(client, model="m", messages=[])
+        assert resp.choices[0].message.content == "[]"
+
+    async def test_disabled_timeout_does_not_wrap(self):
+        client = _counting_client()
+        with patch.object(mod, "_LLM_CALL_TIMEOUT_S", 0):
+            resp = await _guarded_chat_completion(client, model="m", messages=[])
+        assert resp.choices[0].message.content == "[]"


### PR DESCRIPTION
## Context — live-observed hang

While running the Epic #695 live re-verify on corpus_C, the **conversational-spectacular path hung ~50 minutes** on a single chat-completion call (process: 98s CPU over 56 min wall-clock = pure network-I/O wait, never returning).

Root cause: `_guarded_chat_completion` — the funnel **every** LLM call passes through — issues `client.chat.completions.create(**kwargs)` with **no per-call timeout**. One stalled round-trip hangs the entire analysis run indefinitely.

This is exactly the **defense-in-depth recommended in the #729 root-cause analysis (R248)** but never implemented: po-2023's #729 fix delivered batching (10→4) + `asyncio.gather` parallelization, which reduces *how many* sequential calls happen, but does nothing if a *single* call stalls.

## Fix (anti-pendulum)

A per-call wall-clock bound — **not** a phase-budget raise:

```python
_LLM_CALL_TIMEOUT_S = float(os.environ.get("LLM_CALL_TIMEOUT_S", "300"))
...
if _LLM_CALL_TIMEOUT_S > 0:
    return await asyncio.wait_for(
        client.chat.completions.create(**kwargs), timeout=_LLM_CALL_TIMEOUT_S
    )
```

- **300s default** — far above a legitimate reasoning-model call (<2 min), well below a pathological hang.
- Env-overridable via `LLM_CALL_TIMEOUT_S`; `0` disables.
- On timeout, `asyncio.TimeoutError` propagates and is absorbed by callers' **existing** `except` blocks (gather batch dropped / GG-bis coverage retry) — graceful degradation instead of an infinite hang.

## Verification

- `TestLLMCallTimeoutGuard`: stalled call times out (<0.05s with patched bound), fast call returns normally, disabled (`=0`) does not wrap.
- 18/18 budget-guard tests + 71 orchestration tests (counter-args, 2-pass PL/FOL, budget) green.
- mypy strict (8-file CI scope): clean.

## Files removed and why

None — single source edit + test append (+51 lines).