### PR TITLE
chore(docs): remove RealLLMOrchestrator references from docstrings/comments (batch 3 g3)

### DIFF
--- a/argumentation_analysis/orchestration/pipeline_utils.py
+++ b/argumentation_analysis/orchestration/pipeline_utils.py
@@ -8,7 +8,7 @@ Utility classes and functions to enhance UnifiedPipeline with:
 - Structured metrics collection
 - Batch analysis with concurrency control
 
-Issue #215: Feature parity with archived RealLLMOrchestrator
+Issue #215: Pipeline utilities for caching, metrics, and batch processing
 """
 
 import asyncio
@@ -48,7 +48,7 @@ class AnalysisCache:
     """
     TTL-based cache for analysis results.
 
-    Provides caching similar to the archived RealLLMOrchestrator's cache
+    Provides TTL-based caching for pipeline analysis results
     with configurable TTL and automatic cleanup.
 
     Usage:
@@ -195,8 +195,8 @@ class PipelineMetrics:
     """
     Structured metrics collector for pipeline analysis.
 
-    Replaces the basic metrics dict from archived RealLLMOrchestrator with
-    a more comprehensive tracking system.
+    Structured metrics collector for pipeline analysis with
+    comprehensive tracking and per-type breakdowns.
 
     Usage:
         metrics = PipelineMetrics()
@@ -417,7 +417,7 @@ async def run_batch_analysis(
     """
     Run multiple analyses concurrently with semaphore control.
 
-    Replicates the batch_analyze functionality from archived RealLLMOrchestrator.
+    Batch analysis with concurrency control, caching, and metrics tracking.
 
     Args:
         requests: List of analysis requests

--- a/project_core/core_from_scripts/unified_report_generator.py
+++ b/project_core/core_from_scripts/unified_report_generator.py
@@ -174,7 +174,7 @@ def generate_component_report(
     API simplifiée pour générer un rapport depuis n'importe quel composant refactorisé.
 
     Args:
-        component_name: Nom du composant (RealLLMOrchestrator, ConversationOrchestrator, etc.)
+        component_name: Nom du composant (UnifiedPipeline, ConversationOrchestrator, etc.)
         analysis_data: Données d'analyse à inclure
         analysis_type: Type d'analyse (orchestration, conversation, text_analysis, etc.)
         output_format: Format de sortie (markdown, json, html, console)

--- a/scripts/validation/main.py
+++ b/scripts/validation/main.py
@@ -322,7 +322,7 @@ class UnifiedValidationSystem:
     # _validate_configuration_coherence, _validate_ecosystem, _validate_source_management,
     # _validate_orchestration_modes, _validate_verbosity_levels, _validate_output_formats,
     # _validate_cli_interface, _validate_orchestration, _test_conversation_orchestrator,
-    # _test_real_llm_orchestrator, _validate_integration, _test_orchestrator_handoff,  # noqa: E501 — legacy comment, RealLLMOrchestrator retired
+    # _test_real_llm_orchestrator, _validate_integration, _test_orchestrator_handoff,  # noqa: E501 — legacy method retired (migrated to UnifiedPipeline)
     # _test_config_mapping, _validate_performance, _benchmark_orchestration,
     # _benchmark_throughput, et _validate_simple SONT SUPPRIMÉES ICI.
     # Leur logique est maintenant dans les modules validateurs séparés.

--- a/tests/unit/argumentation_analysis/orchestration/test_pipeline_utils.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_pipeline_utils.py
@@ -2,7 +2,7 @@
 """
 Tests for pipeline utilities.
 
-Issue #215: Feature parity with archived RealLLMOrchestrator
+Issue #215: Tests for pipeline utilities (caching, metrics, batch)
 """
 
 import asyncio


### PR DESCRIPTION
## Sprint 13.C — Batch 3 Groupe 3 : Nettoyage commentaires/docstrings

Clean up 4 files still mentioning `RealLLMOrchestrator` in docstrings and comments. Replace with `UnifiedPipeline` or neutral wording.

### Files changed (4)

| File | Change |
|------|--------|
| `argumentation_analysis/orchestration/pipeline_utils.py` | 4 docstrings: removed "archived RealLLMOrchestrator" references |
| `tests/unit/.../test_pipeline_utils.py` | Module docstring: updated reference |
| `project_core/core_from_scripts/unified_report_generator.py` | Param doc: `RealLLMOrchestrator` → `UnifiedPipeline` |
| `scripts/validation/main.py` | Legacy comment: updated retirement note |

### Validation

- **Tests**: 11/11 pass (`test_pipeline_utils.py`)
- **mypy strict**: 0 new errors (4 pre-existing, verified on clean main)
- **grep RealLLMOrchestrator**: 0 matches in these 4 files

### Scope

Documentation/comments only. **Zero behavior change.**

Part of Sprint 13.C batch 3 (audit PR #735 merged), group 3.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>