### PR TITLE
fix(privacy): extend _scrub_state_for_export for DAG path dung_frameworks arguments[]

### DIFF
--- a/scripts/analysis/generate_spectacular_bundle.py
+++ b/scripts/analysis/generate_spectacular_bundle.py
@@ -230,6 +230,28 @@ def _scrub_state_for_export(state_data: Dict[str, Any]) -> Dict[str, Any]:
                 scrubbed_nl.append(entry)
         cleaned["nl_to_logic_translations"] = scrubbed_nl
 
+    # Twelfth pass: scrub nested structures containing argument descriptions
+    # (dung_frameworks, ranking_results, probabilistic_results, bipolar_results)
+    # These store List[str] under key "arguments" with raw NL descriptions
+    # that bypass the identified_arguments scrub (Pass 2).
+    for dim_key in ("dung_frameworks", "ranking_results", "probabilistic_results", "bipolar_results"):
+        dim = cleaned.get(dim_key)
+        if not isinstance(dim, dict):
+            continue
+        for item_id, item_val in dim.items():
+            if not isinstance(item_val, dict):
+                continue
+            args_list = item_val.get("arguments")
+            if isinstance(args_list, list):
+                item_val["arguments"] = [
+                    ("<scrubbed>" if isinstance(a, str) and len(a) > 10 else a)
+                    for a in args_list
+                ]
+            # Also scrub "name" field (often contains NL descriptions)
+            name = item_val.get("name")
+            if isinstance(name, str) and len(name) > 20:
+                item_val["name"] = "<scrubbed>"
+
     # Final pass: global regex scrub on ALL remaining strings (values AND keys)
     cleaned = _global_entity_scrub(cleaned)
 

--- a/tests/unit/scripts/analysis/test_generate_spectacular_bundle_privacy.py
+++ b/tests/unit/scripts/analysis/test_generate_spectacular_bundle_privacy.py
@@ -399,3 +399,114 @@ class TestVector4Integration:
         }
         result = _scrub_state_for_export(state)
         assert result["identified_arguments"]["arg_1"]["confidence"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Vector 5 — DAG path: dung_frameworks / ranking / probabilistic arguments[]
+# ---------------------------------------------------------------------------
+
+class TestVector5DAGArgumentsDescription:
+    """Verify scrubbing of arguments[].description on DAG path structures.
+
+    Discovered in R276-R280: dung_frameworks[*].arguments is a List[str]
+    of raw NL descriptions that bypassed the identified_arguments scrub.
+    Same pattern in ranking_results, probabilistic_results, bipolar_results.
+    """
+
+    def _make_dag_state(self):
+        return {
+            "identified_arguments": {
+                "arg_1": {"premisses": "safe", "conclusion": "safe", "confidence": 0.8},
+            },
+            "dung_frameworks": {
+                "dung_1": {
+                    "name": "A framework about sanctions against Russia",
+                    "arguments": [
+                        "The speaker argues that economic sanctions against Russia are ineffective",
+                        "Counter-argument: sanctions have weakened the Russian economy",
+                        "short",
+                    ],
+                    "attacks": [["arg_1", "arg_2"]],
+                    "extensions": {"preferred": ["arg_1", "arg_3"]},
+                },
+            },
+            "ranking_results": {
+                "rank_1": {
+                    "method": "burden",
+                    "arguments": [
+                        "First argument about Ukraine sovereignty",
+                        "Second argument about NATO expansion",
+                    ],
+                    "comparisons": [],
+                },
+            },
+            "probabilistic_results": {
+                "prob_1": {
+                    "arguments": [
+                        "Trump claimed the election was stolen",
+                        "Biden won the popular vote",
+                    ],
+                    "acceptance_probabilities": {"arg_1": 0.7},
+                },
+            },
+            "bipolar_results": {
+                "bip_1": {
+                    "framework_type": "bipolar",
+                    "arguments": [
+                        "Netanyahu defended the military operation in Israel",
+                    ],
+                    "supports": [],
+                },
+            },
+        }
+
+    def test_dung_arguments_list_scrubbed(self):
+        result = _scrub_state_for_export(self._make_dag_state())
+        dung_args = result["dung_frameworks"]["dung_1"]["arguments"]
+        assert dung_args[0] == "<scrubbed>"
+        assert dung_args[1] == "<scrubbed>"
+        # Short string (< 10 chars) preserved
+        assert dung_args[2] == "short"
+
+    def test_dung_name_scrubbed_when_long(self):
+        result = _scrub_state_for_export(self._make_dag_state())
+        assert result["dung_frameworks"]["dung_1"]["name"] == "<scrubbed>"
+
+    def test_dung_non_string_fields_preserved(self):
+        result = _scrub_state_for_export(self._make_dag_state())
+        assert result["dung_frameworks"]["dung_1"]["attacks"] == [["arg_1", "arg_2"]]
+        assert result["dung_frameworks"]["dung_1"]["extensions"] == {"preferred": ["arg_1", "arg_3"]}
+
+    def test_ranking_results_arguments_scrubbed(self):
+        result = _scrub_state_for_export(self._make_dag_state())
+        rank_args = result["ranking_results"]["rank_1"]["arguments"]
+        assert rank_args[0] == "<scrubbed>"
+        assert rank_args[1] == "<scrubbed>"
+
+    def test_probabilistic_results_arguments_scrubbed(self):
+        result = _scrub_state_for_export(self._make_dag_state())
+        prob_args = result["probabilistic_results"]["prob_1"]["arguments"]
+        assert prob_args[0] == "<scrubbed>"
+        assert prob_args[1] == "<scrubbed>"
+
+    def test_bipolar_results_arguments_scrubbed(self):
+        result = _scrub_state_for_export(self._make_dag_state())
+        bip_args = result["bipolar_results"]["bip_1"]["arguments"]
+        assert bip_args[0] == "<scrubbed>"
+
+    def test_dag_entity_grep_zero_hits(self):
+        """Gold standard: no entity names in scrubbed DAG state."""
+        result = _scrub_state_for_export(self._make_dag_state())
+        serialized = json.dumps(result).lower()
+        entity_fragments = [
+            "trump", "biden", "putin", "poutine", "zelensky",
+            "macron", "netanyahu", "ukraine", "russia", "israel",
+            "nato", "crimea", "kremlin",
+        ]
+        for fragment in entity_fragments:
+            assert fragment not in serialized, f"Entity '{fragment}' leaked in DAG scrub"
+
+    def test_identified_arguments_unaffected(self):
+        """Pass 2 (identified_arguments) should still work alongside Pass 12."""
+        result = _scrub_state_for_export(self._make_dag_state())
+        assert result["identified_arguments"]["arg_1"]["confidence"] == 0.8


### PR DESCRIPTION
## Fix

Closes #741

### Problem

`_scrub_state_for_export` (11 passes) covers `identified_arguments[].premisses/conclusion` but **misses** `dung_frameworks[*].arguments` (and `ranking_results/probabilistic_results/bipolar_results`) on the DAG spectacular path. These structures store `List[str]` descriptions under key `"arguments"` that bypass Pass 2.

Result: `*_dag_spectacular.synthesis.md` leaked nominative content while `*_conversational.synthesis.md` was clean.

### Fix

Add **12th pass** to `_scrub_state_for_export` that scrubs:
- `dung_frameworks[*].arguments` (List[str] → scrubbed for strings >10 chars)
- `ranking_results[*].arguments`
- `probabilistic_results[*].arguments`
- `bipolar_results[*].arguments`
- `dung_frameworks[*].name` (long NL names scrubbed)

Short strings (less than 10 chars) are preserved (IDs, short labels).

### Testing

- **8 new tests** in `TestVector5DAGArgumentsDescription` covering all 4 structures + entity grep gold standard
- **46/46 tests pass** (all 5 vectors, 0.35s)
- Gold standard: grep for entity names in serialized output returns 0 hits

### Files Changed

| File | Change |
|------|--------|
| `scripts/analysis/generate_spectacular_bundle.py` | Add 12th pass (17 LOC) |
| `tests/unit/scripts/analysis/test_generate_spectacular_bundle_privacy.py` | Add Vector 5 tests (120 LOC) |

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>