### PR TITLE
fix(tests): skip 90 dead Gen 1 trace_analyzer tests (B-07 #811)

### DIFF
--- a/tests/unit/argumentation_analysis/reporting/test_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_trace_analyzer.py
@@ -17,6 +17,13 @@ from argumentation_analysis.reporting.trace_analyzer import (
     InformalExploration,
 )
 
+# Gen 1 trace_analyzer — superseded by enhanced_real_time_trace_analyzer (Gen 3).
+# No consumer outside tests. Pipeline uses analysis_runner_v2 + enhanced_pm_analysis_runner.
+# B-07 audit #811 — 54 dead tests archived.
+pytestmark = pytest.mark.skip(
+    "Gen 1 trace_analyzer superseded by enhanced_real_time_trace_analyzer (B-07 #811)"
+)
+
 # ── ExtractMetadata ──
 
 

--- a/tests/unit/argumentation_analysis/test_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/test_trace_analyzer.py
@@ -13,6 +13,12 @@ le suivi d'évolution d'état et la génération de rapports.
 
 import pytest
 import json
+
+# Legacy copy of Gen 1 trace_analyzer tests — same dead module as reporting/test_trace_analyzer.py.
+# Superseded by enhanced_real_time_trace_analyzer (Gen 3). B-07 audit #811 — 36 dead tests archived.
+pytestmark = pytest.mark.skip(
+    "Legacy Gen 1 trace_analyzer copy — superseded by enhanced_real_time_trace_analyzer (B-07 #811)"
+)
 import tempfile
 import os
 from pathlib import Path


### PR DESCRIPTION
<<'PRBODY'
## What

Skip 90 dead Gen 1  tests — superseded by Gen 3 .

## Files modified

| File | Change |
|------|--------|
|  | + skip (54 tests) |
|  | + skip (36 tests, legacy copy) |

## Context

B-07 audit (#763) identified  as **Gen 1 DEAD code** — no import outside tests. The pipeline uses  (Gen 3, wired in  + ).

3-generation lineage:

| Gen | Source | Tests | Wiring |
|-----|--------|-------|--------|
| 1 |  | 54 + 36 (legacy copy) | ❌ none (DEAD) |
| 2 |  | 54 | scripts only |
| 3 |  | 131 | ✅ active runners |

## Verification

- Gen 1: 90 skipped (54 + 36), 0 failed
- Gen 3: 131 passed, 0 failed (no regression)

Closes #811

🤖 Generated with [Claude Code](https://claude.com/claude-code)
PRBODY