### PR TITLE
fix(tests): exclude test_unified_pipelines.py from collection — JPype DLL crash (B-03 #814)

### DIFF
--- a/tests/unit/argumentation_analysis/pipelines/conftest.py
+++ b/tests/unit/argumentation_analysis/pipelines/conftest.py
@@ -1,0 +1,8 @@
+# conftest.py for tests/unit/argumentation_analysis/pipelines/
+# Exclude test_unified_pipelines.py from collection — JPype DLL crash on Windows
+# + broken import get_fallacy_detector cascading to all orchestration subpackages.
+# The module targets the legacy router argumentation_analysis.pipelines.unified_pipeline
+# (NOT the active orchestration/unified_pipeline.py).
+# B-03 audit #814 — 88 tests archived (0 collected due to collection error).
+
+collect_ignore = ["test_unified_pipelines.py"]


### PR DESCRIPTION
## Problem

test_unified_pipelines.py (88 declared tests) causes a **Windows fatal exception** (JPype DLL access violation) during pytest collection. 0 tests actually collected.

The crash triggers through conftest.pytest_sessionstart → JVM start → DLL access violation on Windows.

## Fix

Added conftest.py with collect_ignore to exclude the file from pytest collection. The test targets the legacy router argumentation_analysis.pipelines.unified_pipeline (NOT the active orchestration/unified_pipeline.py used by 20+ files).

## Files modified

| File | Change |
|------|--------|
| tests/unit/argumentation_analysis/pipelines/conftest.py | NEW — collect_ignore exclusion |
| tests/unit/argumentation_analysis/pipelines/test_unified_pipelines.py | UNCHANGED — preserved for reference |

## Verification
- Other pipeline tests: 10 passed, 0 failed
- No regression

Closes #814