### PR TITLE
docs(audit): A-14 Interface Web integration audit (Epic A #742, closes #775)

### DIFF
--- a/docs/reports/integration_audit/A-14_interface_web.md
+++ b/docs/reports/integration_audit/A-14_interface_web.md
@@ -1,118 +1,193 @@
-# Audit A-14: Interface Web
+# Audit A-14: Projet 3.1.1 — Interface Web pour l'Analyse Argumentative
 
-**Issue**: #168 | **SUIVI**: Score 65% | **Date audit**: 2026-05-31
+**Issue**: #775 (A-14) | **Epic**: #742 | **Date audit**: 2026-06-01
+**Auditeur**: Claude Code @ myia-po-2023
 
-## Status: 🟡 Partial
+---
 
-## What was delivered (student source)
+## 0. Synthèse en 1 phrase
 
-Student project delivered a web interface for the argumentation analysis platform. The deliverable includes:
+Le projet étudiant `interface_web/` (~1808 LOC Python, 4 modules, 8 templates HTML, auteurs Erwin Rodrigues, Robin de Bastos, SUIVI 65%) a été **partiellement intégré** — l'application Starlette sert le frontend React et expose les routes d'analyse basique, mais les routes JTMS (543 LOC) sont orphelines (Flask Blueprint jamais monté dans Starlette), les routes agents (débat, gouvernance, qualité, contre-arguments) n'existent que dans FastAPI (`api/agent_routes.py`), et les deux serveurs (Starlette :5003 et FastAPI :8095) partagent le même template `dashboard.html` en dupliqué.
 
-- A server-side application serving both API endpoints and a React frontend
-- Analysis capabilities exposed via HTTP routes
-- Agent interaction routes (quality evaluation, counter-arguments, debate, governance)
-- WebSocket support for streaming analysis results
-- A React-based single-page application for user interaction
+**Verdict**: 🟡 **INTÉGRÉ partiellement (dual-serveur fragmenté)** — le frontend est fonctionnel mais l'architecture est scindée entre deux serveurs qui ne partagent pas les routes agents. Le répertoire racine est sanctuarisé (référence pédagogique conservée + template load-bearing).
 
-Issue #168 requested integration of agent routes into the web interface.
+---
 
-## What exists in argumentation_analysis/
+## 1. Cadrage R281c — 4 étapes
 
-### Two separate web applications
+### 1.1 Localiser la version consolidée
 
-**Starlette app (port 5003):**
-- **`interface_web/app.py`** — Starlette application with 6 routes
-- Serves the React frontend (static files from `services/web_api/interface-web-argumentative/build/`)
-- Provides `/api/*` routes for analysis
+Le projet étudiant `interface_web/` est un cas hybride — il contient à la fois du code étudiant et du scaffolding professeur :
 
-**FastAPI app (port 8000):**
-- **`api/main.py`** — FastAPI application with 8 routers
-- **`api/agent_routes.py`** — Agent routes added by PR #197 (quality, counter-arguments, debate, governance, full-analysis)
-- **`api/websocket_routes.py`** — WebSocket streaming for real-time results
-- Additional routers for proposals, mobile, and other features
+| Fichier | LOC approx | Rôle | Origine |
+| --- | --- | --- | --- |
+| `interface_web/app.py` | ~355 | Starlette ASGI app — sert frontend React + routes analyse | Étudiant (migration Flask → Starlette) |
+| `interface_web/routes/jtms_routes.py` | ~543 | Flask Blueprint — 5 routes JTMS (dashboard, playground, sessions, sherlock_watson, tutorial) | Étudiant |
+| `interface_web/api/jtms_integration.py` | ~546 | Abstraction layer JTMS backend — session management, belief CRUD | Étudiant |
+| `interface_web/services/jtms_websocket.py` | ~364 | WebSocket service — real-time belief propagation | Étudiant |
+| `interface_web/templates/` | 8 HTML | dashboard.html (principal) + 6 templates JTMS + index.html | Mixte |
+| `api/main.py` | ~120 | FastAPI app — sert même `dashboard.html` + 5 routes agents | Professeur |
+| `api/endpoints.py` | ~210 | FastAPI endpoints — analyze, framework, informal, status | Professeur |
+| `api/agent_routes.py` | ~393 | FastAPI routes — quality, counter-args, debate, governance, full | Professeur |
+| `services/web_api/interface-web-argumentative/` | ~5815 JS | React SPA — 39 fichiers, 9 tabs, D3.js | Professeur |
 
-### Frontend
+**Architecture dual-serveur** :
 
-- **React build** at `services/web_api/interface-web-argumentative/build/` — served by the Starlette app
+| Serveur | Port | Framework | Routes agents | Sert React |
+| --- | --- | --- | --- | --- |
+| `interface_web/app.py` | 5003 | Starlette | `/api/analyze`, `/api/v1/framework/analyze` | ✅ (`build/` via StaticFiles) |
+| `api/main.py` | 8095 | FastAPI | `/api/v1/agents/*` (quality, debate, governance, counter, full) | ❌ |
 
-### Legacy routes
+### 1.2 Préservation fonctionnelle
 
-- **`interface_web/routes/jtms_routes.py`** — JTMS-specific routes still using Flask imports (dead code under Starlette migration)
+| Fonctionnalité étudiante | Préservée ? | Où | Notes |
+| --- | --- | --- | --- |
+| Application web (Starlette) | ✅ Identique | `interface_web/app.py` | Migration Flask → Starlette par l'étudiant |
+| Route analyse textuelle | ✅ Identique | `app.py` `/api/analyze` | Via `ServiceManager.analyze_text()` |
+| Route analyse Dung | ✅ Identique | `app.py` `/api/v1/framework/analyze` | Via `ServiceManager.analyze_dung_framework()` |
+| Dashboard HTML | ✅ Identique | `templates/dashboard.html` | Servi par Starlette ET FastAPI (dupliqué) |
+| Routes JTMS (5 routes) | ⚠️ Orphelines | `routes/jtms_routes.py` | Flask Blueprint — **jamais monté** dans Starlette |
+| Intégration JTMS backend | ⚠️ Orpheline | `api/jtms_integration.py` | Flask Blueprint dependency |
+| WebSocket belief propagation | ⚠️ Orpheline | `services/jtms_websocket.py` | Non connecté au Starlette app |
+| Templates JTMS (6) | ✅ Existent | `templates/jtms/` | Accessibles via filesystem mais routes non montées |
+| Frontend React (9 tabs) | ✅ Supérieur | `services/web_api/interface-web-argumentative/` | 5815 LOC, D3.js, 39 fichiers — professeur |
+| Routes agents (5) | ✅ Supérieur | `api/agent_routes.py` | quality, counter, debate, governance, full — FastAPI |
+| Issue #168 routes web agents | ❌ Non résolu | — | Issue fermée sans implémentation complète |
 
-## Preservation Assessment
+**Score de préservation**: 6/11 fonctionnalités préservées (55%). Les 5 manquantes sont : 3 routes JTMS orphelines (Flask→Starlette mismatch), 1 WebSocket orphelin, 1 gap routes agents dans Starlette. Le cœur fonctionnel (analyse basique + Dung) est préservé.
 
-| Aspect | Status | Notes |
-|--------|--------|-------|
-| React frontend | **Preserved** | Build served by Starlette |
-| Analysis API | **Preserved** | Both apps expose analysis endpoints |
-| Agent routes (quality, debate, etc.) | **Preserved in FastAPI** | Added by PR #197 |
-| WebSocket streaming | **Preserved in FastAPI** | `websocket_routes.py` |
-| JTMS routes | **Broken** | Flask imports under Starlette |
-| Route coherence | **Fragmented** | Two apps on different ports, overlapping concerns |
+### 1.3 Dilutions / Régressions
 
-## Gap Analysis
+#### Dilution 1: Routes JTMS orphelines (Flask → Starlette mismatch)
 
-### Gap 1: TWO separate apps that don't share routing
+**Localisation**: `interface_web/routes/jtms_routes.py` (543 LOC) utilise Flask Blueprint (`from flask import Blueprint`). L'application Starlette (`app.py`) ne monte PAS ce blueprint — les routes sont mortes.
+**Impact**: HIGH — 543 LOC de code JTMS web (dashboard, playground, sessions, sherlock_watson, tutorial) + 546 LOC d'intégration backend + 364 LOC WebSocket = **~1453 LOC orphelins** (80% du code étudiant).
+**Assessment**: Le mismatch Flask/Starlette est un artefact de la migration — les routes existent mais ne sont pas accessibles. La réécriture en routes Starlette est un travail de portage, pas de refonte.
+**Fix-intent**: `fix(a-14): port jtms_routes from Flask Blueprint to Starlette routes and mount in app.py`
 
-The system runs two independent web applications:
+#### Dilution 2: Dual-serveur fragmenté (routes agents absentes de Starlette)
 
-- **Starlette** on port 5003 — serves the React frontend and basic `/api/*` routes
-- **FastAPI** on port 8000 — serves `/api/v1/*` routes with agent capabilities, WebSocket streaming
+**Localisation**: `api/agent_routes.py` (393 LOC) expose 5 endpoints agents dans FastAPI, mais `interface_web/app.py` (Starlette) qui sert le React frontend n'a PAS ces routes. Le React frontend ne peut pas atteindre les endpoints agents.
+**Impact**: HIGH — le React SPA a des components pour debate, governance, spectacular (39 fichiers, 5815 LOC) mais les endpoints backend correspondants ne sont pas accessibles depuis le même serveur que le frontend.
+**Assessment**: C'est le gap identifié par l'issue #168 (fermée sans résolution complète). Les routes existent dans FastAPI mais le CORS/ports différenciés rendent l'accès difficile pour le frontend.
+**Fix-intent**: `fix(a-14): add agent routes to Starlette app or proxy FastAPI routes from Starlette`
 
-These apps do not share routing, middleware, or session state. A request to one cannot be forwarded to the other. This creates a fragmented architecture where functionality is split across two ports with no unified entry point.
+#### Dilution 3: Template dashboard dupliqué
 
-**Impact**: High. Users and consumers must know which port serves which feature. The API surface is non-discoverable.
+**Localisation**: `api/main.py:84` référence `interface_web/templates/dashboard.html` directement. Les deux serveurs servent le même fichier.
+**Impact**: LOW — fonctionnel mais crée un couplage caché entre `api/` et `interface_web/`. Si le template bouge, FastAPI casse.
+**Assessment**: Couplage acceptable mais à documenter.
 
-### Gap 2: Issue #168 routes in FastAPI, not Starlette
+### 1.4 Statut du répertoire racine `interface_web/`
 
-Issue #168 specifically requested agent routes in the web interface. PR #197 added them to the FastAPI app (`api/agent_routes.py`), but the Starlette app (`interface_web/app.py`) — which serves the actual user-facing frontend — did not receive these routes. The issue was closed, but the target application was not the one modified.
+**Verdict**: 🟢 **Sanctuarisé — référence pédagogique conservée** (mandate R300)
 
-**Impact**: High. The frontend (served by Starlette on port 5003) has no access to agent routes. Users must interact with a separate port 8000 service that has no UI.
+- **5 imports live Python** — `interface_web/app.py` importe `ServiceManager` + `nlp_model_manager`, `interface_web/routes/jtms_routes.py` importe `JTMSService` + `JTMSSessionManager` + modèles
+- **1 référence load-bearing** — `api/main.py:84` charge `interface_web/templates/dashboard.html`
+- **39 fichiers React** — `services/web_api/interface-web-argumentative/src/` est servi par `interface_web/app.py`
+- **SUIVI** : 65% — "Partiellement intégré"
 
-### Gap 3: JTMS routes still use Flask (dead under Starlette)
+---
 
-`interface_web/routes/jtms_routes.py` contains Flask-style route definitions (`@app.route`, `Flask()` imports). The parent app was migrated from Flask to Starlette, rendering these routes dead code. They will never be invoked.
+## 2. Matrice des capabilities
 
-**Impact**: Medium. JTMS functionality is unavailable via the web interface. The dead code also creates confusion for developers expecting Flask patterns.
+| Capability | Module | Serveur | Statut |
+| --- | --- | --- | --- |
+| Analyse textuelle | `interface_web/app.py` | Starlette :5003 | ✅ Identique |
+| Analyse Dung framework | `interface_web/app.py` | Starlette :5003 | ✅ Identique |
+| Dashboard HTML | `templates/dashboard.html` | Starlette + FastAPI | ✅ Identique (dupliqué) |
+| Frontend React (9 tabs) | `services/web_api/.../build/` | Starlette :5003 | ✅ Supérieur |
+| JTMS dashboard/playground | `routes/jtms_routes.py` | Flask (non monté) | ⚠️ Orphelin |
+| JTMS backend integration | `api/jtms_integration.py` | Flask (non monté) | ⚠️ Orphelin |
+| JTMS WebSocket | `services/jtms_websocket.py` | Non connecté | ⚠️ Orphelin |
+| Quality endpoint | `api/agent_routes.py` | FastAPI :8095 | ✅ Supérieur |
+| Counter-argument endpoint | `api/agent_routes.py` | FastAPI :8095 | ✅ Supérieur |
+| Debate endpoint | `api/agent_routes.py` | FastAPI :8095 | ✅ Supérieur |
+| Governance endpoint | `api/agent_routes.py` | FastAPI :8095 | ✅ Supérieur |
+| Full analysis endpoint | `api/agent_routes.py` | FastAPI :8095 | ✅ Supérieur |
 
-### Gap 4: React frontend only calls Starlette `/api/*`, not FastAPI `/api/v1/agents/*`
+---
 
-The React frontend's API calls are hardcoded to the Starlette app's `/api/*` endpoints. The new agent routes on FastAPI's `/api/v1/agents/*` have no UI consumer. The frontend and the agent routes are on different ports with no cross-origin wiring documented.
+## 3. Cartographie des connections
 
-**Impact**: High. New features (quality evaluation, debate, governance, counter-arguments) have backend routes but no user interface. They are effectively API-only features invisible to end users.
+```text
+interface_web/                            argumentation_analysis/
+├── app.py (Starlette) ──────────────────► orchestration/service_manager.py
+│   ├── /api/analyze ──► ServiceManager.analyze_text()
+│   ├── /api/v1/framework ──► analyze_dung_framework()
+│   ├── /dashboard ──► templates/dashboard.html
+│   └── /static ──► services/web_api/.../build/ (React SPA)
+│
+├── routes/jtms_routes.py (Flask) ─── ⚠️ ORPHELIN
+│   (543 LOC Flask Blueprint — non monté dans Starlette)
+│
+├── api/jtms_integration.py ───────── ⚠️ ORPHELIN
+│   (546 LOC — dépend de Flask Blueprint)
+│
+├── services/jtms_websocket.py ─────── ⚠️ ORPHELIN
+│   (364 LOC WebSocket — non connecté)
+│
+└── templates/
+    ├── dashboard.html ───────────────► Aussi servi par api/main.py (FastAPI)
+    └── jtms/*.html ──────────────────► 6 templates JTMS (routes non montées)
 
-### Gap 5: New debate/quality/governance routes have NO UI consumer
+api/ (FastAPI, professeur)
+├── main.py ──► GET /dashboard (sert interface_web/templates/dashboard.html)
+├── endpoints.py ──► /api/analyze, /api/status, /api/v1/framework, /api/v1/informal
+├── agent_routes.py ──► /api/v1/agents/{quality,counter,debate,governance,full}
+└── websocket_routes.py ──► WebSocket router
 
-The FastAPI agent routes added by PR #197 (debate, quality, governance, counter-arguments, full-analysis) are backend-only. No React components, pages, or API client code calls these endpoints.
+services/web_api/interface-web-argumentative/ (React, professeur)
+└── src/ (39 fichiers JS)
+    ├── components/ (6) : ArgumentAnalyzer, FallacyDetector, etc.
+    ├── components/debate/ (6) : DebateArena, AgentPanel, etc.
+    ├── components/governance/ (7) : GovernanceDashboard, VotingPanel, etc.
+    ├── components/spectacular/ (10) : DungGraph, JtmsBeliefTree, etc.
+    └── services/ (7) : api.js, debateApi.js, proposalApi.js, etc.
+```
 
-**Impact**: Medium. The routes are functional via direct HTTP calls (curl, Postman, programmatic) but are not accessible through the web interface.
+---
 
-## Recommended Action
+## 4. Fix-intents
 
-### Short-term (stabilize)
+| # | Issue proposée | Priorité | Action |
+| --- | --- | --- | --- |
+| F1 | `fix(a-14): port JTMS routes from Flask Blueprint to Starlette and mount in app.py` | **MEDIUM** | Réécrire `jtms_routes.py` en routes Starlette, monter dans `app.py`. Débloque ~1453 LOC orphelin |
+| F2 | `fix(a-14): add agent routes to Starlette or proxy FastAPI routes` | **MEDIUM** | Ajouter les 5 endpoints agents (quality, counter, debate, governance, full) au Starlette app OU configurer un reverse proxy |
+| F3 | `fix(a-14): deduplicate dashboard.html serving between FastAPI and Starlette` | **LOW** | Documenter le couplage ou centraliser le template |
 
-1. **Migrate JTMS routes from Flask to Starlette** — Rewrite `jtms_routes.py` using Starlette routing. This restores JTMS web access and removes dead Flask code.
-2. **Document the two-app architecture** — Add a clear section to `docs/guides/` explaining which app serves which purpose, which port to use, and why two apps exist.
+---
 
-### Medium-term (unify)
+## 5. Conclusion
 
-3. **Merge into a single application** — Evaluate migrating all Starlette routes into the FastAPI app (FastAPI is a superset of Starlette). This would give a single entry point with both the frontend and all API routes. Alternatively, make Starlette a reverse proxy to FastAPI for API routes.
-4. **Add React pages for agent features** — Create UI components for quality evaluation, debate, governance, and counter-argument features that call the FastAPI endpoints.
-5. **Close the loop on Issue #168** — Verify that the agent routes are accessible from the same app that serves the frontend, fulfilling the original issue intent.
+Le projet 3.1.1 est **partiellement intégré** — l'application Starlette sert le frontend React et expose les routes d'analyse basique, mais la majorité du code étudiant (JTMS routes + integration + WebSocket = ~1453 LOC, 80%) est **orpheline** suite au mismatch Flask/Starlette. Les routes agents (5 endpoints) n'existent que dans FastAPI, pas dans le Starlette qui sert le frontend.
 
-### Long-term (cleanup)
+**Architecture dual-serveur** : le système fonctionne en pratique avec deux serveurs parallèles (Starlette :5003 pour le frontend, FastAPI :8095 pour l'API complète), mais cette fragmentation empêche le frontend React d'accéder aux endpoints agents qui ne sont pas sur le même serveur.
 
-6. **Remove dead Flask code** — After JTMS routes are migrated, delete all Flask imports and patterns from the web interface codebase.
+**Contraste avec les autres audits** : A-14 est le seul audit qui porte sur un **frontend/UI** plutôt que sur un agent métier ou un service infrastructure. Le verdict 🟡 reflète la nature hybride du projet — le scaffolding professeur (React SPA, FastAPI) est supérieur, mais le code étudiant (JTMS web) est orphelin.
 
-## Source Files
+**Cas d'usage soutenance** : le frontend React avec ses 9 tabs est un excellent point d'entrée pour la démo — mais les tabs debate/governance/spectacular nécessitent que les endpoints FastAPI soient accessibles (soit par proxy, soit par ajout au Starlette).
 
-| File | Role |
-|------|------|
-| `interface_web/app.py` | Starlette app (port 5003, frontend + basic API) |
-| `api/main.py` | FastAPI app (port 8000, agent routes + WebSocket) |
-| `api/agent_routes.py` | Agent routes (quality, debate, governance, etc.) |
-| `api/websocket_routes.py` | WebSocket streaming |
-| `interface_web/routes/jtms_routes.py` | JTMS routes (dead Flask code) |
-| `services/web_api/interface-web-argumentative/build/` | React frontend build |
-| PR #197 | Added agent routes to FastAPI |
-| Issue #168 | Original integration request (CLOSED) |
+**Test coverage** : `tests/unit/test_interface_web_starlette.py` couvre le Starlette app basique.
+
+**Le répertoire `interface_web/` est sanctuarisé** (mandate R300) — conservé comme référence pédagogique + template load-bearing (dashboard.html servi par FastAPI).
+
+---
+
+## 6. Fichiers sources
+
+- `interface_web/app.py` — Starlette ASGI app (355 LOC)
+- `interface_web/routes/jtms_routes.py` — Flask Blueprint JTMS routes (543 LOC, orphelin)
+- `interface_web/api/jtms_integration.py` — JTMS backend abstraction (546 LOC, orphelin)
+- `interface_web/services/jtms_websocket.py` — WebSocket belief propagation (364 LOC, orphelin)
+- `interface_web/templates/` — 8 HTML templates
+- `api/main.py` — FastAPI app (sert dashboard.html)
+- `api/agent_routes.py` — 5 endpoints agents (393 LOC)
+- `services/web_api/interface-web-argumentative/` — React SPA (5815 LOC JS)
+- `docs/projets/sujets/3.1.1_Interface_Web_Analyse_Argumentative.md` — Sujet spec
+
+## À valider par l'utilisateur
+
+- Architecture dual-serveur (Starlette :5003 + FastAPI :8095) — est-ce intentionnel ou un gap à résoudre ?
+- Les routes JTMS Flask orphelines (~1453 LOC) — faut-il les porter en Starlette ou les marquer comme legacy ?
+- Issue #168 fermée sans résolution complète — confirmer que les routes agents restent dans FastAPI uniquement


### PR DESCRIPTION
## Audit A-14: Projet 3.1.1 - Interface Web

**Issue**: #775 (A-14) | **Epic**: #742

### Verdict: YELLOW PARTIALLY INTEGRATED (dual-serveur fragmente)

### Key findings
- ~1808 LOC etudiant : Starlette app + JTMS routes + integration + WebSocket
- Architecture dual-serveur : Starlette (:5003, frontend) + FastAPI (:8095, API complete)
- ~1453 LOC JTMS orphelins (80% du code etudiant) : Flask Blueprint jamais monte dans Starlette
- 5 routes agents existent uniquement dans FastAPI
- React SPA (5815 LOC JS, 39 fichiers, 9 tabs)
- Score preservation: 6/11 (55%)

### Fix-intents
| # | Issue | Priorite |
|---|-------|----------|
| F1 | Port JTMS routes Flask to Starlette | MEDIUM |
| F2 | Add agent routes to Starlette or proxy | MEDIUM |
| F3 | Deduplicate dashboard.html | LOW |

### Sanctuary
Preserve (load-bearing template + 5 imports).

## A valider par l'utilisateur
- Architecture dual-serveur intentionnelle ou gap ?
- Routes JTMS Flask orphelines : porter en Starlette ou legacy ?
