### PR TITLE
docs(a-05): update PRESENTATION_KICKOFF.md Flask→FastAPI/Starlette (#813)

### DIFF
--- a/docs/projets/sujets/aide/PRESENTATION_KICKOFF.md
+++ b/docs/projets/sujets/aide/PRESENTATION_KICKOFF.md
@@ -41,9 +41,10 @@ L'Intelligence Symbolique combine les approches symboliques traditionnelles de l
 ```
 ┌─────────────────────┐     ┌─────────────────────┐     ┌─────────────────────┐
 │                     │     │                     │     │                     │
-│  Interface Web      │     │  API Web            │     │  Moteur d'analyse   │
-│  (React/Vue)        │◄───►│  (Flask)            │◄───►│  argumentative      │
-│                     │     │                     │     │                     │
+│  Interface Web      │     │  API Backend        │     │  Moteur d'analyse   │
+│  (React SPA)        │◄───►│  (FastAPI :8095)    │◄───►│  argumentative      │
+│  via Starlette      │     │                     │     │                     │
+│  proxy :5003        │     │                     │     │                     │
 └─────────────────────┘     └─────────────────────┘     └─────────────────────┘
                                                                ▲
                                                                │
@@ -71,13 +72,15 @@ L'Intelligence Symbolique combine les approches symboliques traditionnelles de l
    - Agents spécialisés pour différentes tâches
    - Intégration avec TweetyProject pour l'analyse formelle
 
-2. **API Web**
+2. **API Backend (FastAPI)**
    - Interface REST pour accéder aux fonctionnalités
    - Modèles de données standardisés
    - Services métier pour chaque type d'analyse
+   - Orchestration via CapabilityRegistry + UnifiedPipeline
 
-3. **Interface Web** (à développer)
-   - Application web moderne
+3. **Interface Web (Starlette + React)**
+   - Application React servie par Starlette (proxy frontend)
+   - Starlette proxie les requêtes `/api/*` vers FastAPI
    - Visualisations interactives
    - Expérience utilisateur intuitive
 


### PR DESCRIPTION
## Summary
Update the architecture diagram and component descriptions in `PRESENTATION_KICKOFF.md` to reflect the A-14 Option-1 decision: FastAPI is the single API surface, Starlette is a frontend-only proxy.

The document still referenced `(Flask)` in the architecture diagram and described the API as "API Web" — now correctly labeled as "API Backend (FastAPI :8095)" with Starlette proxy `:5003`.

Closes #813

## Changes
- Architecture diagram: `(Flask)` → `(FastAPI :8095)` with Starlette proxy `:5003`
- Component 2: "API Web" → "API Backend (FastAPI)" with CapabilityRegistry mention
- Component 3: "Interface Web (à développer)" → "Interface Web (Starlette + React)" with proxy description

## À valider par l'utilisateur
RAS

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
