### PR TITLE
fix(api): mobile endpoint runtime fixes — #846 #847 #848 (A-15)

### DIFF
--- a/api/mobile_endpoints.py
+++ b/api/mobile_endpoints.py
@@ -196,13 +196,13 @@ async def mobile_validate(request: TextRequest):
             formalization=ValidationFormalization(
                 type="toulmin",
                 premises=[
-                    d.content if hasattr(d, "content") else str(d)
+                    d.text if hasattr(d, "text") else str(d)
                     for d in (toulmin.data or [])
                 ],
-                conclusion=toulmin.claim or "",
-                rule=toulmin.warrant or "",
+                conclusion=toulmin.claim.text if toulmin.claim and hasattr(toulmin.claim, "text") else (str(toulmin.claim) if toulmin.claim else ""),
+                rule=toulmin.warrant.text if toulmin.warrant and hasattr(toulmin.warrant, "text") else (str(toulmin.warrant) if toulmin.warrant else ""),
             ),
-            explanation=toulmin.qualifier or "Analysis complete",
+            explanation=toulmin.qualifier.text if toulmin.qualifier and hasattr(toulmin.qualifier, "text") else (str(toulmin.qualifier) if toulmin.qualifier else "Analysis complete"),
             execution_time=time.time() - start,
         )
     except Exception as e:
@@ -222,7 +222,7 @@ async def mobile_chat(request: ChatRequest):
     try:
         from argumentation_analysis.core.llm_service import create_llm_service
 
-        llm = create_llm_service()
+        llm = create_llm_service(service_id="mobile_chat")
         if llm and hasattr(llm, "generate"):
             response = await llm.generate(
                 f"You are an AI assistant specialized in analyzing arguments. "

--- a/tests/unit/api/test_mobile_endpoints.py
+++ b/tests/unit/api/test_mobile_endpoints.py
@@ -6,18 +6,35 @@ Validates:
 - POST /api/mobile/validate — logical validation
 - POST /api/mobile/chat — chat assistant
 - Input validation (text too short)
-- Graceful error handling when pipeline unavailable
+- Error handling with specific assertions (no broad try/except masking)
+- Response contracts match TypeScript frontend types
+
+Fixes #848: Tests use specific assertions and fail on real bugs.
+Fixes #846: Tests verify create_llm_service is called with service_id.
+Fixes #847: Tests verify Toulmin fields are serialized as strings.
+
+Note: These tests construct a standalone FastAPI app with just the mobile
+router (avoids torch DLL crash from api.main import chain on Windows).
 """
 
 import pytest
 from unittest.mock import patch, AsyncMock
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from api.main import app
+from api.mobile_endpoints import mobile_router
 
 
 @pytest.fixture
-def client():
+def app():
+    """Create a minimal FastAPI app with just the mobile router."""
+    _app = FastAPI()
+    _app.include_router(mobile_router, prefix="/api")
+    return _app
+
+
+@pytest.fixture
+def client(app):
     return TestClient(app, raise_server_exceptions=False)
 
 
@@ -25,30 +42,13 @@ def client():
 
 
 class TestMobileAnalyze:
-    def test_analyze_returns_200(self, client):
-        resp = client.post(
-            "/api/mobile/analyze",
-            json={
-                "text": "All men are mortal. Socrates is a man. Therefore Socrates is mortal."
-            },
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert "text" in data
-        assert "arguments" in data
-        assert "overall_quality" in data
-
-    def test_analyze_validation_short_text(self, client):
-        resp = client.post("/api/mobile/analyze", json={"text": "hi"})
-        assert resp.status_code == 422  # text too short (min 5)
-
     @patch("argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis")
-    def test_analyze_with_pipeline_results(self, mock_run, client):
+    def test_analyze_returns_200_with_pipeline(self, mock_run, client):
         mock_run.return_value = {
-            "identified_arguments": {"arg1": "Main argument about climate change"},
+            "identified_arguments": {"arg1": "Main argument about climate"},
             "identified_fallacies": {},
             "overall_quality": 0.8,
-            "summary": "Argument analysis complete",
+            "summary": "Analysis complete",
         }
         resp = client.post(
             "/api/mobile/analyze",
@@ -56,8 +56,14 @@ class TestMobileAnalyze:
         )
         assert resp.status_code == 200
         data = resp.json()
+        assert data["text"] == "Climate change is real because scientists agree."
         assert len(data["arguments"]) >= 1
+        assert data["arguments"][0]["id"] == "arg1"
         assert data["overall_quality"] == 0.8
+
+    def test_analyze_validation_short_text(self, client):
+        resp = client.post("/api/mobile/analyze", json={"text": "hi"})
+        assert resp.status_code == 422  # text too short (min 5)
 
     @patch(
         "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
@@ -70,7 +76,9 @@ class TestMobileAnalyze:
         )
         assert resp.status_code == 200
         data = resp.json()
+        # Specific: quality should be 0.0 on failure (#848)
         assert data["overall_quality"] == 0.0
+        # Specific: error argument should be present
         assert any(
             "error" in arg["id"].lower() or "unavailable" in arg["text"].lower()
             for arg in data["arguments"]
@@ -81,17 +89,6 @@ class TestMobileAnalyze:
 
 
 class TestMobileFallacies:
-    def test_fallacies_returns_200(self, client):
-        resp = client.post(
-            "/api/mobile/fallacies",
-            json={"text": "Everyone agrees with me, so I must be right."},
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert "text" in data
-        assert "fallacies" in data
-        assert "execution_time" in data
-
     @patch("argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis")
     def test_fallacies_with_results(self, mock_run, client):
         mock_run.return_value = {
@@ -119,7 +116,9 @@ class TestMobileFallacies:
         )
         assert resp.status_code == 200
         data = resp.json()
-        assert data["fallacies"] == []
+        # Specific: fallacies should be empty list, not None (#848)
+        assert isinstance(data["fallacies"], list)
+        assert len(data["fallacies"]) == 0
         assert data["execution_time"] >= 0
 
 
@@ -127,29 +126,85 @@ class TestMobileFallacies:
 
 
 class TestMobileValidate:
-    def test_validate_returns_200(self, client):
-        resp = client.post(
-            "/api/mobile/validate",
-            json={
-                "text": "If it rains then the road is wet. It rains. Therefore the road is wet."
-            },
-        )
-        assert resp.status_code == 200
-        data = resp.json()
-        assert "valid" in data
-        assert "formalization" in data
-        assert "explanation" in data
-
     def test_validate_short_text_rejected(self, client):
         resp = client.post("/api/mobile/validate", json={"text": "hi"})
         assert resp.status_code == 422
+
+    @patch(
+        "argumentation_analysis.agents.tools.analysis.new.semantic_argument_analyzer.SemanticArgumentAnalyzer.run"
+    )
+    def test_validate_toulmin_fields_are_strings(self, mock_run, client):
+        """Validate endpoint must return Toulmin fields as strings (#847)."""
+        from argumentation_analysis.core.models.toulmin_model import (
+            ToulminAnalysisResult,
+            ToulminComponent,
+        )
+
+        mock_run.return_value = ToulminAnalysisResult(
+            claim=ToulminComponent(text="The road is wet", confidence_score=0.9, source_sentences=[0]),
+            data=[
+                ToulminComponent(text="It rains", confidence_score=0.8, source_sentences=[0]),
+                ToulminComponent(text="Rain causes wetness", confidence_score=0.7, source_sentences=[0]),
+            ],
+            warrant=ToulminComponent(text="Rain causes wet roads", confidence_score=0.85, source_sentences=[0]),
+            qualifier=ToulminComponent(text="certainly", confidence_score=0.9, source_sentences=[0]),
+        )
+
+        resp = client.post(
+            "/api/mobile/validate",
+            json={"text": "If it rains then the road is wet. It rains. Therefore the road is wet."},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        form = data["formalization"]
+
+        # #847: all fields must be strings per mobile contract
+        assert isinstance(form["conclusion"], str), f"conclusion should be str, got {type(form['conclusion'])}"
+        assert form["conclusion"] == "The road is wet"
+        assert isinstance(form["rule"], str), f"rule should be str, got {type(form['rule'])}"
+        assert form["rule"] == "Rain causes wet roads"
+        assert isinstance(data["explanation"], str), f"explanation should be str, got {type(data['explanation'])}"
+        assert data["explanation"] == "certainly"
+        # Premises must be a list of strings
+        assert isinstance(form["premises"], list)
+        for p in form["premises"]:
+            assert isinstance(p, str), f"premise should be str, got {type(p)}: {p}"
+        assert form["premises"] == ["It rains", "Rain causes wetness"]
+
+    @patch(
+        "argumentation_analysis.agents.tools.analysis.new.semantic_argument_analyzer.SemanticArgumentAnalyzer.run",
+        side_effect=RuntimeError("Analyzer error"),
+    )
+    def test_validate_handles_failure(self, mock_run, client):
+        resp = client.post(
+            "/api/mobile/validate",
+            json={"text": "Test validation failure handling."},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Specific: valid should be False on failure
+        assert data["valid"] is False
 
 
 # ──── Chat Endpoint ────
 
 
 class TestMobileChat:
-    def test_chat_returns_200(self, client):
+    def test_chat_empty_message_rejected(self, client):
+        resp = client.post("/api/mobile/chat", json={"message": ""})
+        assert resp.status_code == 422
+
+    def test_chat_missing_message(self, client):
+        resp = client.post("/api/mobile/chat", json={})
+        assert resp.status_code == 422
+
+    @patch("argumentation_analysis.core.llm_service.create_llm_service")
+    def test_chat_calls_create_llm_service_with_service_id(self, mock_create, client):
+        """create_llm_service must be called with service_id parameter (#846)."""
+        mock_llm = AsyncMock()
+        mock_llm.generate = AsyncMock(return_value="A fallacy is a flaw in reasoning.")
+        mock_create.return_value = mock_llm
+
         resp = client.post(
             "/api/mobile/chat",
             json={"message": "What is a logical fallacy?"},
@@ -158,15 +213,24 @@ class TestMobileChat:
         data = resp.json()
         assert "message" in data
         assert "timestamp" in data
+        # #846: verify create_llm_service was called with service_id
+        mock_create.assert_called_once_with(service_id="mobile_chat")
+
+    @patch("argumentation_analysis.core.llm_service.create_llm_service", return_value=None)
+    @patch("argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis")
+    def test_chat_fallback_when_llm_unavailable(self, mock_pipeline, mock_create, client):
+        """When LLM service is None, falls back to pipeline."""
+        mock_pipeline.return_value = {
+            "summary": "Analysis result from pipeline fallback",
+        }
+        resp = client.post(
+            "/api/mobile/chat",
+            json={"message": "Tell me about fallacies"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "message" in data
         assert len(data["message"]) > 0
-
-    def test_chat_empty_message_rejected(self, client):
-        resp = client.post("/api/mobile/chat", json={"message": ""})
-        assert resp.status_code == 422
-
-    def test_chat_missing_message(self, client):
-        resp = client.post("/api/mobile/chat", json={})
-        assert resp.status_code == 422
 
 
 # ──── Response Contract ────
@@ -187,13 +251,14 @@ class TestResponseContract:
             json={"text": "Test the response contract shape"},
         ).json()
 
+        # Specific type assertions
         assert isinstance(data["text"], str)
         assert isinstance(data["arguments"], list)
         assert isinstance(data["overall_quality"], (int, float))
         if data["arguments"]:
             arg = data["arguments"][0]
-            assert "id" in arg
-            assert "text" in arg
+            assert isinstance(arg["id"], str)
+            assert isinstance(arg["text"], str)
 
     @patch("argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis")
     def test_fallacy_response_shape(self, mock_run, client):
@@ -207,11 +272,12 @@ class TestResponseContract:
             json={"text": "Test the fallacy response shape"},
         ).json()
 
+        # Specific type assertions
         assert isinstance(data["text"], str)
         assert isinstance(data["fallacies"], list)
         assert isinstance(data["execution_time"], (int, float))
         if data["fallacies"]:
             f = data["fallacies"][0]
-            assert "type" in f
-            assert "confidence" in f
-            assert "explanation" in f
+            assert isinstance(f["type"], str)
+            assert isinstance(f["confidence"], (int, float))
+            assert isinstance(f["explanation"], str)


### PR DESCRIPTION
## Summary

A-15 grouped PR fixing 3 mobile endpoint bugs identified in audit.

### #846 — `create_llm_service` missing `service_id` parameter
- `mobile_chat` endpoint called `create_llm_service()` without required `service_id`
- **Fix**: `create_llm_service(service_id="mobile_chat")`
- **Impact**: Chat endpoint was broken (TypeError at runtime)

### #847 — Toulmin fields return ToulminComponent objects instead of strings
- `mobile_validate` endpoint serialized raw `ToulminComponent` objects (not strings) for `conclusion`, `rule`, `explanation`, `premises`
- Mobile TypeScript frontend expects strings per contract
- **Fix**: Access `.text` attribute with `hasattr` guards + `str()` fallback
- **Impact**: Validate endpoint returned non-string values breaking mobile app parsing

### #848 — Tests with broad try/except masking real bugs
- Existing tests used broad exception handlers that masked failures as passes
- **Fix**: Rewritten 14 tests with specific assertions, standalone FastAPI app (avoids torch DLL crash on Windows)
- Test coverage: analyze (3), fallacies (2), validate (3), chat (4), response contracts (2)

## Files changed

| File | Change |
|------|--------|
| `api/mobile_endpoints.py` | #846 service_id fix + #847 Toulmin .text serialization |
| `tests/unit/api/test_mobile_endpoints.py` | #848 rewritten 14 tests with specific assertions |

## Testing

```
14 passed in 8.92s  (tests/unit/api/test_mobile_endpoints.py)
```

Tests use standalone FastAPI app with `mobile_router` only (avoids torch DLL import chain on Windows per known issue in conftest.py).

## Related

- Epic: A-15 (R307 deep queue dispatch)
- Issues: #846, #847, #848
- ⚠ PR #868 (JTMS import guard) also touches `api/main.py` — merge sequentially