### PR TITLE
fix(a-14): WS proxy limitation docs + restore accent + env docs (#858)

### DIFF
--- a/interface_web/app.py
+++ b/interface_web/app.py
@@ -5,16 +5,26 @@ Interface Web pour l'Analyse Argumentative EPITA (Version Starlette — Frontend
 
 Application Starlette servant de **frontend-only proxy** vers le backend FastAPI.
 - Sert l'application React (build static) sur `/`
-- Proxy les requetes `/api/*` et `/ws/*` vers le backend FastAPI
+- Proxy les requetes `/api/*` vers le backend FastAPI
 - Ne contient aucune logique metier (ServiceManager, NLP, JVM)
 
 Architecture (issue #844):
   Navigateur -> Starlette(:5003) -> React SPA (static)
                                 -> /api/* -> FastAPI(:8095)
-                                -> /ws/*  -> FastAPI(:8095)
 
-Version: 3.0.0
-Date: 2026-06-01
+Limitations:
+  - WebSocket relay NOT implemented. Clients must connect to FastAPI directly
+    for WS streaming (ws://FASTAPI_HOST:FASTAPI_PORT/ws/*).
+
+Environment Variables (two-server deployment model):
+  FASTAPI_HOST     — Backend FastAPI host (default: 127.0.0.1)
+  FASTAPI_PORT     — Backend FastAPI port (default: 8095)
+  PORT             — Starlette proxy port (default: 5003)
+  REACT_APP_BACKEND_URL — Frontend build-time API base URL for React SPA
+                     (set before `npm run build` in services/web_api/)
+
+Version: 3.1.0
+Date: 2026-06-02
 """
 
 import logging
@@ -153,42 +163,39 @@ async def api_proxy(request: Request):
 
 async def ws_proxy(websocket: WebSocket):
     """
-    Proxy WebSocket vers FastAPI.
-    Etablit la connexion avec le client, puis relay bidirectionnel avec FastAPI.
+    Proxy WebSocket vers FastAPI — limitation documentee (#858).
+
+    Le relais WS bidirectionnel n'est pas implemente car httpx ne supporte
+    pas les WebSocket de maniere stable. Les clients doivent se connecter
+    directement au backend FastAPI pour les flux WS.
+
+    Cette route existe pour:
+    1. Detecter les tentatives de connexion WS via le proxy
+    2. Retourner une erreur explicite avec l'URL du backend a utiliser
+    3. Eviter une connexion silencieusement droppee
     """
     await websocket.accept()
 
-    # Extraire le path et construire l'URL WebSocket FastAPI
     path = websocket.url.path
     ws_target_url = f"ws://{FASTAPI_HOST}:{FASTAPI_PORT}{path}"
 
-    logger.info(f"WS Proxy: {path} -> {ws_target_url}")
+    logger.warning(
+        f"WS Proxy: client attempted WS via proxy ({path}). "
+        f"WS relay not supported — redirecting to {ws_target_url}"
+    )
 
-    try:
-        async with httpx.AsyncClient() as client:
-            async with client.stream("GET", ws_target_url) as backend_ws:
-                # Relay bidirectionnel
-                async def relay_to_backend():
-                    try:
-                        while True:
-                            data = await websocket.receive_text()
-                            # Forward to backend
-                    except WebSocketDisconnect:
-                        logger.info(f"WS Proxy: client deconnecte ({path})")
-
-                # Pour l'instant, les WebSocket FastAPI sont accessibles directement.
-                # Ce proxy est un placeholder pour une future implementation complete.
-                await websocket.send_json(
-                    {
-                        "type": "proxy_info",
-                        "message": f"Connect FastAPI WebSocket directly at {ws_target_url}",
-                    }
-                )
-                await websocket.close()
-
-    except Exception as e:
-        logger.error(f"WS Proxy error ({path}): {e}")
-        await websocket.close(code=1011, reason=str(e))
+    await websocket.send_json(
+        {
+            "type": "ws_relay_unavailable",
+            "error": "WebSocket relay not implemented via proxy",
+            "detail": (
+                "This proxy does not relay WebSocket connections. "
+                "Connect directly to the FastAPI backend."
+            ),
+            "target_url": ws_target_url,
+        }
+    )
+    await websocket.close(code=1011, reason="WS relay not supported — use backend directly")
 
 
 # ==============================================================================
@@ -201,7 +208,7 @@ async def examples_endpoint(request: Request):
     examples = [
         {
             "title": "Logique Propositionnelle",
-            "text": "Si il pleut, alors la route est mouillee. Il pleut. Donc la route est mouillee.",
+            "text": "Si il pleut, alors la route est mouillée. Il pleut. Donc la route est mouillée.",
             "type": "propositional",
         },
         {

--- a/tests/unit/api/test_starlette_proxy.py
+++ b/tests/unit/api/test_starlette_proxy.py
@@ -1,4 +1,4 @@
-"""Tests for Starlette frontend proxy (issue #844).
+"""Tests for Starlette frontend proxy (issue #844, #858).
 
 Validates:
 - ServiceManager and NLP imports are removed
@@ -7,6 +7,9 @@ Validates:
 - Examples endpoint is local (hardcoded)
 - Dashboard is local
 - No backend coupling remains
+- WS proxy returns explicit error (not silent drop)
+- Accent in examples text is preserved
+- Environment variables documented
 """
 
 import pytest
@@ -21,7 +24,6 @@ class TestStarletteProxyStructure:
         """interface_web.app should NOT import ServiceManager."""
         import interface_web.app as app_module
 
-        # Check that ServiceManager is NOT in the module
         assert not hasattr(app_module, "ServiceManager"), (
             "ServiceManager should not be imported in proxy mode"
         )
@@ -92,3 +94,100 @@ class TestStarletteProxyConfig:
 
         assert "build" in str(app_module.STATIC_FILES_DIR)
         assert "interface-web-argumentative" in str(app_module.STATIC_FILES_DIR)
+
+
+class TestWSProxyLimitation:
+    """Verify WS proxy behavior documents limitation (#858)."""
+
+    def test_ws_proxy_function_exists(self):
+        """ws_proxy should be defined in module."""
+        import interface_web.app as app_module
+
+        assert hasattr(app_module, "ws_proxy"), (
+            "ws_proxy function should exist for WS connection handling"
+        )
+
+    def test_ws_proxy_sends_explicit_error(self):
+        """ws_proxy should send ws_relay_unavailable before closing."""
+        import interface_web.app as app_module
+        import inspect
+
+        source = inspect.getsource(app_module.ws_proxy)
+        # Verify the function sends explicit error JSON
+        assert "ws_relay_unavailable" in source, (
+            "ws_proxy should send 'ws_relay_unavailable' type"
+        )
+        assert "target_url" in source, (
+            "ws_proxy should include target_url for client redirect"
+        )
+        # Verify it does NOT contain dead code (relay_to_backend)
+        assert "relay_to_backend" not in source, (
+            "ws_proxy should not contain dead relay_to_backend function"
+        )
+
+    def test_ws_proxy_closes_with_1011(self):
+        """ws_proxy should close with code 1011 (internal error)."""
+        import interface_web.app as app_module
+        import inspect
+
+        source = inspect.getsource(app_module.ws_proxy)
+        assert "1011" in source, (
+            "ws_proxy should close with code 1011"
+        )
+
+
+class TestExamplesAccent:
+    """Verify accent is preserved in examples (#858)."""
+
+    def test_mouillee_has_accent(self):
+        """Example text should use 'mouillée' with accent."""
+        import interface_web.app as app_module
+
+        source = open(app_module.__file__, encoding="utf-8").read()
+        assert "mouillée" in source, (
+            "Examples should contain 'mouillée' with proper accent"
+        )
+        # Ensure the unaccented version is NOT present
+        assert "mouillee" not in source, (
+            "Found 'mouillee' without accent — should be 'mouillée'"
+        )
+
+
+class TestEnvDocumentation:
+    """Verify environment variables are documented in module docstring (#858)."""
+
+    def test_fastapi_host_documented(self):
+        """FASTAPI_HOST should appear in module docstring."""
+        import interface_web.app as app_module
+
+        docstring = app_module.__doc__
+        assert "FASTAPI_HOST" in docstring, (
+            "FASTAPI_HOST should be documented in module docstring"
+        )
+
+    def test_fastapi_port_documented(self):
+        """FASTAPI_PORT should appear in module docstring."""
+        import interface_web.app as app_module
+
+        docstring = app_module.__doc__
+        assert "FASTAPI_PORT" in docstring, (
+            "FASTAPI_PORT should be documented in module docstring"
+        )
+
+    def test_react_app_backend_url_documented(self):
+        """REACT_APP_BACKEND_URL should be documented."""
+        import interface_web.app as app_module
+
+        docstring = app_module.__doc__
+        assert "REACT_APP_BACKEND_URL" in docstring, (
+            "REACT_APP_BACKEND_URL should be documented for frontend build"
+        )
+
+    def test_ws_limitation_documented(self):
+        """WS relay limitation should be documented."""
+        import interface_web.app as app_module
+
+        docstring = app_module.__doc__
+        assert "WebSocket" in docstring or "WS" in docstring, (
+            "WebSocket limitation should be documented"
+        )


### PR DESCRIPTION
## Summary

A-14 follow-up: complete WS proxy documentation, restore accent, document env vars.

### Changes

| Item | Detail |
|------|--------|
| **WS proxy** | Replaced dead code (`relay_to_backend` never called) with explicit error. Sends `ws_relay_unavailable` JSON with `target_url` before closing (code 1011). Documents limitation clearly. |
| **Accent** | Restored `mouillée` in examples endpoint (was `mouillee`). |
| **Env docs** | Documented `FASTAPI_HOST`, `FASTAPI_PORT`, `PORT`, `REACT_APP_BACKEND_URL` in module docstring for two-server deployment model. |
| **Tests** | Added 8 new tests (17 total): WS proxy structure, accent check, env documentation. |

## Anti-pendule check
- ✅ No ServiceManager/NLP/JVM reintroduced in Starlette
- ✅ Proxy `/api/*` preserved (completed, not removed)

## Testing

```
17 passed in 1.23s  (tests/unit/api/test_starlette_proxy.py)
```

## Related

- Issue: #858
- Follow-up to: PR #851 (Starlette → frontend-only proxy)
- Part of: A-14 (R307 deep queue dispatch)