### PR TITLE
chore(tests): skip 302 dormant hierarchical tests + README (B-09 #798)

### DIFF
--- a/tests/unit/orchestration/hierarchical/README.md
+++ b/tests/unit/orchestration/hierarchical/README.md
@@ -1,7 +1,32 @@
-# Répertoire de Tests : hierarchical
+# Tests: Hierarchical Orchestration Mode
 
-Ce répertoire contient les tests pour hierarchical.
+## Status: DORMANT
 
-## Fichiers de test
+The hierarchical orchestration mode (Strategic → Tactical → Operational) is **not activated** in the current pipeline. It is defined in `argumentation_analysis/orchestration/hierarchical/` but never wired into `CapabilityRegistry` or any active workflow.
 
-Aucun fichier de test trouvé dans ce répertoire.
+All tests in this directory are **skipped** via `pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")`.
+
+## Test Coverage
+
+| Directory | Files | Tests | Description |
+|-----------|-------|-------|-------------|
+| `strategic/`   | 3  | ~90  | Strategic planner, state, resource allocator          |
+| `tactical/`    | 4  | ~120 | Tactical resolver (basic + advanced), state, progress |
+| `operational/` | 2  | ~60  | Operational state, feedback mechanism                 |
+| `templates/`   | 1  | ~32  | Task/situation/report templates                       |
+| **Total**      | **10** | **~302** |                                                  |
+
+## Activation Prerequisites
+
+To reactivate these tests:
+1. Wire `HierarchicalOrchestrator` into `CapabilityRegistry` (`registry_setup.py`)
+2. Add a workflow phase in `WorkflowDSL` that uses the hierarchical mode
+3. Remove the `pytestmark` line from each test file
+4. Verify against a live hierarchical run
+
+## Reference
+
+- Audit report: `docs/reports/test_audit/B-09_orchestration.md`
+- Issue: #798
+- Epic: B-09 (#765)
+- CLAUDE.md: Orchestration Modes → Hierarchical → DORMANT

--- a/tests/unit/orchestration/hierarchical/operational/test_feedback_mechanism.py
+++ b/tests/unit/orchestration/hierarchical/operational/test_feedback_mechanism.py
@@ -13,6 +13,8 @@ from argumentation_analysis.orchestration.hierarchical.operational.feedback_mech
     FeedbackManager,
 )
 
+pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
+
 # ============================================================
 # RhetoricalToolsFeedback
 # ============================================================

--- a/tests/unit/orchestration/hierarchical/operational/test_operational_state.py
+++ b/tests/unit/orchestration/hierarchical/operational/test_operational_state.py
@@ -12,6 +12,8 @@ from argumentation_analysis.orchestration.hierarchical.operational.state import 
     OperationalState,
 )
 
+pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
+
 
 @pytest.fixture
 def state():

--- a/tests/unit/orchestration/hierarchical/strategic/test_resource_allocator.py
+++ b/tests/unit/orchestration/hierarchical/strategic/test_resource_allocator.py
@@ -14,6 +14,8 @@ from argumentation_analysis.orchestration.hierarchical.strategic.state import (
     StrategicState,
 )
 
+pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
+
 
 @pytest.fixture
 def state():

--- a/tests/unit/orchestration/hierarchical/strategic/test_strategic_planner.py
+++ b/tests/unit/orchestration/hierarchical/strategic/test_strategic_planner.py
@@ -14,6 +14,8 @@ from argumentation_analysis.orchestration.hierarchical.strategic.state import (
     StrategicState,
 )
 
+pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
+
 
 @pytest.fixture
 def state():

--- a/tests/unit/orchestration/hierarchical/strategic/test_strategic_state.py
+++ b/tests/unit/orchestration/hierarchical/strategic/test_strategic_state.py
@@ -11,6 +11,8 @@ from argumentation_analysis.orchestration.hierarchical.strategic.state import (
     StrategicState,
 )
 
+pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
+
 
 @pytest.fixture
 def state():

--- a/tests/unit/orchestration/hierarchical/tactical/test_progress_monitor.py
+++ b/tests/unit/orchestration/hierarchical/tactical/test_progress_monitor.py
@@ -15,6 +15,8 @@ from argumentation_analysis.orchestration.hierarchical.tactical.state import (
     TacticalState,
 )
 
+pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
+
 
 @pytest.fixture
 def state():

--- a/tests/unit/orchestration/hierarchical/tactical/test_tactical_resolver.py
+++ b/tests/unit/orchestration/hierarchical/tactical/test_tactical_resolver.py
@@ -5,6 +5,7 @@
 Tests unitaires pour le Résolveur de Conflits de l'architecture hiérarchique.
 """
 
+import pytest
 import unittest
 import sys
 import os
@@ -37,6 +38,8 @@ from argumentation_analysis.orchestration.hierarchical.tactical.resolver import 
 from argumentation_analysis.orchestration.hierarchical.tactical.state import (
     TacticalState,
 )
+
+pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
 
 
 class TestConflictResolver(unittest.TestCase):

--- a/tests/unit/orchestration/hierarchical/tactical/test_tactical_resolver_advanced.py
+++ b/tests/unit/orchestration/hierarchical/tactical/test_tactical_resolver_advanced.py
@@ -5,6 +5,7 @@
 Tests avancés pour le module orchestration.hierarchical.tactical.resolver.
 """
 
+import pytest
 import unittest
 import sys
 import os
@@ -37,6 +38,8 @@ from argumentation_analysis.orchestration.hierarchical.tactical.resolver import 
 from argumentation_analysis.orchestration.hierarchical.tactical.state import (
     TacticalState,
 )
+
+pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
 
 
 class TestTacticalResolverAdvanced(unittest.TestCase):

--- a/tests/unit/orchestration/hierarchical/tactical/test_tactical_state.py
+++ b/tests/unit/orchestration/hierarchical/tactical/test_tactical_state.py
@@ -3,6 +3,7 @@
 Tests pour le module state.py du niveau tactique.
 """
 
+import pytest
 import unittest
 import json
 from unittest.mock import patch, MagicMock
@@ -10,6 +11,8 @@ from unittest.mock import patch, MagicMock
 from argumentation_analysis.orchestration.hierarchical.tactical.state import (
     TacticalState,
 )
+
+pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
 
 
 class TestTacticalState(unittest.TestCase):

--- a/tests/unit/orchestration/hierarchical/templates/test_templates.py
+++ b/tests/unit/orchestration/hierarchical/templates/test_templates.py
@@ -24,6 +24,8 @@ from argumentation_analysis.orchestration.hierarchical.templates.analysis_tool_t
     ANALYSIS_TOOL_CONFIG_EXAMPLE,
 )
 
+pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
+
 # ============================================================
 # BaseAgent (agent_template)
 # ============================================================


### PR DESCRIPTION
## Summary
Skip 302 dormant hierarchical tests in `tests/unit/orchestration/hierarchical/` and add documentation README. The hierarchical orchestration mode (Strategic→Tactical→Operational) is not wired into `CapabilityRegistry` or any active workflow — these tests protect code that is never executed in production.

**Approach: skip (not delete)** via module-level `pytestmark`. Tests remain functional and can be reactivated by wiring the hierarchical mode into the pipeline.

Closes #798

## Files modified (Cleanup-Gate — 11 files, >5 deletions equivalent)
| File | Type | Action | Reason |
|------|------|--------|--------|
| `test_feedback_mechanism.py` | dormant test | add pytestmark skip | Operational mode dormant |
| `test_operational_state.py` | dormant test | add pytestmark skip | Same |
| `test_resource_allocator.py` | dormant test | add pytestmark skip | Strategic mode dormant |
| `test_strategic_planner.py` | dormant test | add pytestmark skip | Same |
| `test_strategic_state.py` | dormant test | add pytestmark skip | Same |
| `test_progress_monitor.py` | dormant test | add pytestmark skip | Tactical mode dormant |
| `test_tactical_resolver.py` | dormant test | add pytestmark skip | Same |
| `test_tactical_resolver_advanced.py` | dormant test | add pytestmark skip | Same |
| `test_tactical_state.py` | dormant test | add pytestmark skip | Same |
| `test_templates.py` | dormant test | add pytestmark skip | Templates dormant |
| `README.md` | documentation | rewrite | Document dormant status + activation prerequisites |

## Origin check
All 10 test files trace to `argumentation_analysis/orchestration/hierarchical/` which implements the Hierarchical mode listed as DORMANT in CLAUDE.md Orchestration Modes table.

## Verification
- `pytest tests/unit/orchestration/hierarchical/ -q` → 302 skipped, 0 failed, 0 errors

## Anti-pendule compliance
- Archive ≠ delete: tests are skipped, not removed. Reactivation path documented.
- "Dormant" justified by mode never wired into pipeline (CLAUDE.md confirms), not by "tests fail".

## À valider par l'utilisateur
RAS

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
