### PR TITLE
fix(a-10): enrich local_llm invoke with state writer + availability (#834)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -448,6 +448,10 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         }
         # Track UU #724: specialist commentary + analysis trace
         self.analysis_trace: List[Dict[str, Any]] = []
+        # AI Shield results — adversarial protection (#841)
+        self.ai_shield_results: List[Dict[str, Any]] = []
+        # Local LLM results — offline LLM analysis (#834)
+        self.local_llm_results: List[Dict[str, Any]] = []
 
     def add_trace_entry(
         self,

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -2209,12 +2209,79 @@ async def _invoke_camembert_fallacy(
 
 
 async def _invoke_local_llm(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
-    """Invoke local LLM service for text analysis."""
+    """Invoke local LLM service for text analysis (#834).
+
+    Enriched with state writing: persists results to state.local_llm_results
+    and adds a trace entry. Falls back gracefully when local LLM endpoint
+    is unavailable (returns status=skipped, not an error).
+    """
     from argumentation_analysis.services.local_llm_service import LocalLLMService
 
     service = LocalLLMService()
-    messages = [{"role": "user", "content": input_text}]
-    return await service.chat_completion(messages)
+
+    # Check availability first
+    try:
+        available = await service.is_available()
+    except Exception:
+        available = False
+    if not available:
+        logger.info("Local LLM endpoint unavailable — skipping")
+        result = {
+            "status": "skipped: endpoint_unavailable",
+            "model": service.model_id if hasattr(service, "model_id") else "unknown",
+        }
+        _state = context.get("_state_object")
+        if _state is not None and hasattr(_state, "local_llm_results"):
+            _state.local_llm_results.append(result)
+        return result
+
+    # Build prompt — optionally include upstream extract results for context
+    extract_output = context.get("phase_extract_output", {})
+    system_prompt = (
+        "You are an argument analysis assistant. "
+        "Analyze the text for arguments, fallacies, and logical structure."
+    )
+    user_content = input_text
+
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "user", "content": user_content},
+    ]
+
+    try:
+        response = await service.chat_completion(messages)
+    except Exception as exc:
+        logger.warning(f"Local LLM call failed: {exc}")
+        result = {
+            "status": "error",
+            "error": str(exc),
+        }
+        _state = context.get("_state_object")
+        if _state is not None and hasattr(_state, "local_llm_results"):
+            _state.local_llm_results.append(result)
+        return result
+
+    result = {
+        "status": "completed",
+        "response": response if isinstance(response, str) else str(response),
+        "model": service.model_id if hasattr(service, "model_id") else "local",
+        "input_length": len(input_text),
+    }
+
+    # Write to shared state
+    _state = context.get("_state_object")
+    if _state is not None:
+        if hasattr(_state, "local_llm_results"):
+            _state.local_llm_results.append(result)
+        _state.add_trace_entry(
+            phase="local_llm",
+            agent="LocalLLM",
+            reacts_to=["extract"],
+            summary=f"Local LLM: {result['status']} ({result.get('input_length', 0)} chars input)",
+        )
+
+    logger.info(f"Local LLM: {result['status']} ({result.get('input_length', 0)} chars)")
+    return result
 
 
 async def _invoke_semantic_index(

--- a/tests/unit/argumentation_analysis/orchestration/test_local_llm_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_local_llm_wiring.py
@@ -1,0 +1,158 @@
+"""Tests for local_llm state writer and invoke callable enrichment (#834).
+
+Validates:
+- _invoke_local_llm writes results to state.local_llm_results
+- _invoke_local_llm handles unavailable endpoint gracefully
+- _invoke_local_llm handles errors gracefully
+- State field local_llm_results exists on UnifiedAnalysisState
+- Trace entry is written
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock, AsyncMock
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+
+class TestLocalLLMStateField:
+    """Verify local_llm_results field on UnifiedAnalysisState."""
+
+    def test_field_exists(self):
+        state = UnifiedAnalysisState("text")
+        assert hasattr(state, "local_llm_results"), (
+            "UnifiedAnalysisState should have local_llm_results field"
+        )
+
+    def test_field_initially_empty(self):
+        state = UnifiedAnalysisState("text")
+        assert state.local_llm_results == []
+
+    def test_field_accepts_results(self):
+        state = UnifiedAnalysisState("text")
+        state.local_llm_results.append({"status": "completed", "response": "test"})
+        assert len(state.local_llm_results) == 1
+        assert state.local_llm_results[0]["status"] == "completed"
+
+
+class TestInvokeLocalLLMStateWriter:
+    """Verify _invoke_local_llm writes to state (#834)."""
+
+    @pytest.mark.asyncio
+    async def test_writes_to_state_on_success(self):
+        """Successful LLM call should write to state.local_llm_results."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_local_llm
+
+        state = UnifiedAnalysisState("text")
+
+        mock_service = MagicMock()
+        mock_service.is_available = AsyncMock(return_value=True)
+        mock_service.chat_completion = AsyncMock(return_value="Analysis: 2 arguments found")
+        mock_service.model_id = "local-test"
+
+        with patch(
+            "argumentation_analysis.services.local_llm_service.LocalLLMService",
+            return_value=mock_service,
+        ):
+            result = await _invoke_local_llm("Test input", {"_state_object": state})
+
+        assert result["status"] == "completed"
+        assert result["response"] == "Analysis: 2 arguments found"
+        assert len(state.local_llm_results) == 1
+        assert state.local_llm_results[0]["status"] == "completed"
+        # Trace entry should also be written
+        assert len(state.analysis_trace) == 1
+        assert state.analysis_trace[0]["phase"] == "local_llm"
+
+    @pytest.mark.asyncio
+    async def test_writes_to_state_on_unavailable(self):
+        """Unavailable endpoint should write skipped status to state."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_local_llm
+
+        state = UnifiedAnalysisState("text")
+
+        mock_service = MagicMock()
+        mock_service.is_available = AsyncMock(return_value=False)
+
+        with patch(
+            "argumentation_analysis.services.local_llm_service.LocalLLMService",
+            return_value=mock_service,
+        ):
+            result = await _invoke_local_llm("Test input", {"_state_object": state})
+
+        assert result["status"] == "skipped: endpoint_unavailable"
+        assert len(state.local_llm_results) == 1
+        assert state.local_llm_results[0]["status"] == "skipped: endpoint_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_writes_to_state_on_error(self):
+        """LLM error should write error status to state."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_local_llm
+
+        state = UnifiedAnalysisState("text")
+
+        mock_service = MagicMock()
+        mock_service.is_available = AsyncMock(return_value=True)
+        mock_service.chat_completion = AsyncMock(side_effect=RuntimeError("Connection refused"))
+
+        with patch(
+            "argumentation_analysis.services.local_llm_service.LocalLLMService",
+            return_value=mock_service,
+        ):
+            result = await _invoke_local_llm("Test input", {"_state_object": state})
+
+        assert result["status"] == "error"
+        assert "Connection refused" in result["error"]
+        assert len(state.local_llm_results) == 1
+        assert state.local_llm_results[0]["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_works_without_state(self):
+        """Should work even without state object (graceful degradation)."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_local_llm
+
+        mock_service = MagicMock()
+        mock_service.is_available = AsyncMock(return_value=True)
+        mock_service.chat_completion = AsyncMock(return_value="Response")
+        mock_service.model_id = "local"
+
+        with patch(
+            "argumentation_analysis.services.local_llm_service.LocalLLMService",
+            return_value=mock_service,
+        ):
+            result = await _invoke_local_llm("Test input", {})
+
+        assert result["status"] == "completed"
+        assert result["response"] == "Response"
+
+    @pytest.mark.asyncio
+    async def test_includes_input_length(self):
+        """Result should include input_length metadata."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_local_llm
+
+        mock_service = MagicMock()
+        mock_service.is_available = AsyncMock(return_value=True)
+        mock_service.chat_completion = AsyncMock(return_value="OK")
+        mock_service.model_id = "local"
+
+        with patch(
+            "argumentation_analysis.services.local_llm_service.LocalLLMService",
+            return_value=mock_service,
+        ):
+            result = await _invoke_local_llm("A" * 100, {})
+
+        assert result["input_length"] == 100
+
+    @pytest.mark.asyncio
+    async def test_is_available_exception_handled(self):
+        """If is_available raises, should treat as unavailable."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_local_llm
+
+        mock_service = MagicMock()
+        mock_service.is_available = AsyncMock(side_effect=Exception("DNS error"))
+
+        with patch(
+            "argumentation_analysis.services.local_llm_service.LocalLLMService",
+            return_value=mock_service,
+        ):
+            result = await _invoke_local_llm("Test", {})
+
+        assert result["status"] == "skipped: endpoint_unavailable"


### PR DESCRIPTION
## Summary

A-10 F1: Enrich the local_llm invoke callable with state writing and availability checking.

### Changes

| Item | Detail |
|------|--------|
| **State writer** | `_invoke_local_llm` now writes results to `state.local_llm_results` (was 7-line pass-through with no persistence) |
| **Availability check** | Calls `service.is_available()` before attempting LLM call; returns `status: skipped` gracefully |
| **Error handling** | Catches LLM call exceptions, writes error status to state, continues pipeline |
| **Trace entries** | Adds `phase=local_llm` trace entries with summary info |
| **State field** | Added `local_llm_results` and `ai_shield_results` to `UnifiedAnalysisState` |

### Invoke callable structure (before vs after)

**Before (7 lines):**
```python
service = LocalLLMService()
messages = [{"role": "user", "content": input_text}]
return await service.chat_completion(messages)
```

**After (~65 lines):** availability check → system prompt → error handling → state write → trace entry

## Testing

```
9 passed in 6.24s  (tests/unit/argumentation_analysis/orchestration/test_local_llm_wiring.py)
```

Test coverage: state field (3), invoke callable (6) — success, unavailable, error, no-state, input_length, exception.

## Related

- Issue: #834
- Next: #835 (wire local_llm into optional workflow phase)
- Part of: A-10 (R307 deep queue dispatch)