### PR TITLE
fix(a-10): surface configured model name in local_llm results (residue #876)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -2229,7 +2229,7 @@ async def _invoke_local_llm(input_text: str, context: Dict[str, Any]) -> Dict[st
         logger.info("Local LLM endpoint unavailable — skipping")
         result = {
             "status": "skipped: endpoint_unavailable",
-            "model": service.model_id if hasattr(service, "model_id") else "unknown",
+            "model": getattr(service, "model", "unknown"),
         }
         _state = context.get("_state_object")
         if _state is not None and hasattr(_state, "local_llm_results"):
@@ -2265,7 +2265,7 @@ async def _invoke_local_llm(input_text: str, context: Dict[str, Any]) -> Dict[st
     result = {
         "status": "completed",
         "response": response if isinstance(response, str) else str(response),
-        "model": service.model_id if hasattr(service, "model_id") else "local",
+        "model": getattr(service, "model", "local"),
         "input_length": len(input_text),
     }
 

--- a/tests/unit/argumentation_analysis/orchestration/test_local_llm_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_local_llm_wiring.py
@@ -112,7 +112,7 @@ class TestInvokeLocalLLMStateWriter:
         mock_service = MagicMock()
         mock_service.is_available = AsyncMock(return_value=True)
         mock_service.chat_completion = AsyncMock(return_value="Response")
-        mock_service.model_id = "local"
+        mock_service.model = "local"
 
         with patch(
             "argumentation_analysis.services.local_llm_service.LocalLLMService",
@@ -131,7 +131,7 @@ class TestInvokeLocalLLMStateWriter:
         mock_service = MagicMock()
         mock_service.is_available = AsyncMock(return_value=True)
         mock_service.chat_completion = AsyncMock(return_value="OK")
-        mock_service.model_id = "local"
+        mock_service.model = "local"
 
         with patch(
             "argumentation_analysis.services.local_llm_service.LocalLLMService",
@@ -156,3 +156,42 @@ class TestInvokeLocalLLMStateWriter:
             result = await _invoke_local_llm("Test", {})
 
         assert result["status"] == "skipped: endpoint_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_model_name_surfaces_in_result(self):
+        """Configured model name should surface in result (residue #876 fix)."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_local_llm
+
+        mock_service = MagicMock()
+        mock_service.is_available = AsyncMock(return_value=True)
+        mock_service.chat_completion = AsyncMock(return_value="Analysis result")
+        mock_service.model = "llama3-8b"
+
+        with patch(
+            "argumentation_analysis.services.local_llm_service.LocalLLMService",
+            return_value=mock_service,
+        ):
+            result = await _invoke_local_llm("Test input", {})
+
+        assert result["model"] == "llama3-8b", (
+            f"Expected model='llama3-8b', got model='{result.get('model')}'"
+        )
+
+    @pytest.mark.asyncio
+    async def test_model_name_surfaces_when_unavailable(self):
+        """Configured model name should surface even when endpoint unavailable."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_local_llm
+
+        mock_service = MagicMock()
+        mock_service.is_available = AsyncMock(return_value=False)
+        mock_service.model = "mistral-7b"
+
+        with patch(
+            "argumentation_analysis.services.local_llm_service.LocalLLMService",
+            return_value=mock_service,
+        ):
+            result = await _invoke_local_llm("Test input", {})
+
+        assert result["model"] == "mistral-7b", (
+            f"Expected model='mistral-7b', got model='{result.get('model')}'"
+        )


### PR DESCRIPTION
## Summary

Fixes residue found by verification PR #878 on PR #876.

LocalLLMService stores the model name as `service.model`, but `_invoke_local_llm` was reading `service.model_id` (attribute never set) — always falling back to `"unknown"`/`"local"` instead of the configured model name.

## Changes
- `invoke_callables.py`: Changed `service.model_id` to `getattr(service, "model", ...)` in both the unavailable and completed paths
- `test_local_llm_wiring.py`: Fixed mocks from `model_id` to `model`, added 2 tests verifying model name surfaces correctly

## Tests
```
11 passed (test_local_llm_wiring.py)
mypy strict: Success
```

## À valider par l'utilisateur
Rien — le model name est cosmétique dans les résultats state, pas fonctionnel. Le fix garantit juste que le nom configuré apparaît au lieu de "unknown".