### PR TITLE
chore(orchestration): archive 4 obsolete orchestrators + fix 3 hierarchical adapters (#875)

### DIFF
--- a/argumentation_analysis/orchestration/__init__.py
+++ b/argumentation_analysis/orchestration/__init__.py
@@ -2,26 +2,20 @@
 Orchestration Sherlock-Watson-Moriarty Oracle Enhanced
 Système d'orchestration multi-agents avec Oracle authentique
 
-DEPRECATION NOTICE (#215):
-- RealLLMOrchestrator is deprecated. Use UnifiedPipeline or ConversationOrchestrator instead.
+Cleanup B-09 #875:
+- RealLLMOrchestrator: removed shim (archived docs/archives/orchestration_legacy/)
+- ConversationOrchestrator: archived (superseded by 8-agent SK system)
+- LogiqueComplexeOrchestrator: removed stub (mock, zero value)
+- CluedoOrchestrator (base 2-agent): archived (superseded by CluedoExtendedOrchestrator)
+- Use UnifiedPipeline + CapabilityRegistry for all new orchestration.
 - See docs/architecture/ORCHESTRATION_MODES.md for migration guidance.
 """
 
 from .cluedo_extended_orchestrator import CluedoExtendedOrchestrator
-from .conversation_orchestrator import ConversationOrchestrator
-# `RealLLMOrchestrator` is an archived shim (deprecated 2026-03-24, #215). It
-# is still importable via its explicit path
-# `argumentation_analysis.orchestration.real_llm_orchestrator` for back-compat
-# (all current callers use that direct path — see commit history). Auto-importing
-# it here would fire DeprecationWarning on every `argumentation_analysis.orchestration`
-# import. Use `UnifiedPipeline` or `ConversationOrchestrator` instead.
-from .logique_complexe_orchestrator import LogiqueComplexeOrchestrator
 from .strategies import CyclicSelectionStrategy, OracleTerminationStrategy
 
 __all__ = [
     "CluedoExtendedOrchestrator",
-    "ConversationOrchestrator",
-    "LogiqueComplexeOrchestrator",
     "CyclicSelectionStrategy",
     "OracleTerminationStrategy",
 ]

--- a/argumentation_analysis/orchestration/engine/main_orchestrator.py
+++ b/argumentation_analysis/orchestration/engine/main_orchestrator.py
@@ -40,23 +40,39 @@ try:
     )
 
     run_cluedo_game = run_cluedo_oracle_game
+except ImportError as e:
+    logger.error(
+        f"Failed to import CluedoExtendedOrchestrator: {e}. Cluedo investigation strategy will be unavailable."
+    )
+    CluedoExtendedOrchestrator = None
+    run_cluedo_game = None
+
+# Les orchestrateurs ci-dessous ont été archivés (ConversationOrchestrator,
+# RealLLMOrchestrator, LogiqueComplexeOrchestrator). Leurs imports échoueront
+# désormais : c'est ATTENDU. Chaque garde les met à None individuellement afin
+# que l'échec de l'un n'affecte pas les autres orchestrateurs encore présents.
+try:
     from argumentation_analysis.orchestration.conversation_orchestrator import (
         ConversationOrchestrator,
     )
+except ImportError as e:
+    logger.warning(f"ConversationOrchestrator unavailable (archived): {e}.")
+    ConversationOrchestrator = None
+
+try:
     from argumentation_analysis.orchestration.real_llm_orchestrator import (
         RealLLMOrchestrator,
     )
+except ImportError as e:
+    logger.warning(f"RealLLMOrchestrator unavailable (archived): {e}.")
+    RealLLMOrchestrator = None
+
+try:
     from argumentation_analysis.orchestration.logique_complexe_orchestrator import (
         LogiqueComplexeOrchestrator,
     )
 except ImportError as e:
-    logger.error(
-        f"Failed to import specialized orchestrators: {e}. SpecializedDirect strategy will be limited."
-    )
-    CluedoExtendedOrchestrator = None
-    run_cluedo_game = None
-    ConversationOrchestrator = None
-    RealLLMOrchestrator = None
+    logger.warning(f"LogiqueComplexeOrchestrator unavailable (archived): {e}.")
     LogiqueComplexeOrchestrator = None
 
 

--- a/argumentation_analysis/orchestration/hierarchical/__init__.py
+++ b/argumentation_analysis/orchestration/hierarchical/__init__.py
@@ -8,6 +8,10 @@ L'architecture est structurée comme suit:
 - Niveau stratégique: Responsable de la planification globale et de la définition des objectifs
 - Niveau tactique: Responsable de la coordination et de la décomposition des objectifs en tâches
 - Niveau opérationnel: Responsable de l'exécution des tâches spécifiques d'analyse
+
+ Depuis R311-B4: `HierarchicalOrchestrator` provides a "bridge" implementation that
+ uses StrategicManager for planning + WorkflowExecutor for execution, reusing the
+ Lego Architecture rather than the dormant 3-tier delegation chain.
 """
 
 # Imports des modules hiérarchiques
@@ -23,5 +27,19 @@ except ImportError as e:
     logger = logging.getLogger(__name__)
     logger.warning(f"Erreur d'import dans le module hiérarchique: {e}")
 
+# Orchestrator (bridge implementation)
+from argumentation_analysis.orchestration.hierarchical.orchestrator import (
+    HierarchicalOrchestrator,
+    run_hierarchical_analysis,
+)
+
 # Exposition des modules principaux
-__all__ = ["strategic", "tactical", "operational", "interfaces", "templates"]
+__all__ = [
+    "strategic",
+    "tactical",
+    "operational",
+    "interfaces",
+    "templates",
+    "HierarchicalOrchestrator",
+    "run_hierarchical_analysis",
+]

--- a/argumentation_analysis/orchestration/hierarchical/operational/adapters/informal_agent_adapter.py
+++ b/argumentation_analysis/orchestration/hierarchical/operational/adapters/informal_agent_adapter.py
@@ -72,17 +72,14 @@ class InformalAgentAdapter(OperationalAgent):
         self.llm_service_id = llm_service_id
 
         try:
-            self.logger.info("Création/simulation de l'agent d'analyse informelle...")
-            # NOTE: Dans les tests, la méthode `process_task` de cet adaptateur est mockée.
-            # L'initialisation réelle de l'agent est complexe et échoue avec des mocks partiels.
-            # Pour débloquer les tests, on assigne simplement un MagicMock à l'agent.
-            # Le comportement réel de l'agent n'est pas testé ici.
-            from unittest.mock import MagicMock
-
-            self.agent = MagicMock(spec=Agent)
+            self.logger.info("Création de l'agent d'analyse informelle via AgentFactory...")
+            factory = AgentFactory(kernel=kernel, llm_service_id=llm_service_id)
+            self.agent = factory.create_informal_fallacy_agent(
+                config_name=self.config_name,
+            )
             self.initialized = True
             self.logger.info(
-                "Agent d'analyse informelle (mocké) initialisé avec succès pour les tests."
+                "Agent d'analyse informelle initialisé avec succès via AgentFactory."
             )
             return True
         except Exception as e:

--- a/argumentation_analysis/orchestration/hierarchical/operational/adapters/pl_agent_adapter.py
+++ b/argumentation_analysis/orchestration/hierarchical/operational/adapters/pl_agent_adapter.py
@@ -169,38 +169,63 @@ class PLAgentAdapter(OperationalAgent):
             if not text_to_analyze:
                 raise ValueError("Aucun contenu textuel trouvé dans `text_extracts`.")
 
-            for technique in task.get("techniques", []):
-                technique_name = technique.get("name")
-                params = technique.get("parameters", {})
+            # Pass 1: Formalize text to belief set
+            self.logger.info("PL formalization (text → belief set)...")
+            bs_result = await self.agent.text_to_belief_set(text_to_analyze)
+            # text_to_belief_set returns (belief_set, dict) or similar
+            if isinstance(bs_result, tuple):
+                belief_set, bs_dict = bs_result
+            else:
+                belief_set = bs_result
+                bs_dict = {}
+            if belief_set is None:
+                issues.append(
+                    {
+                        "type": "formalization_error",
+                        "description": "L'agent n'a pas pu formaliser le texte en belief set PL.",
+                    }
+                )
+            else:
+                results.append(
+                    {
+                        "type": "formal_analyses",
+                        "belief_set": str(belief_set),
+                        "metadata": bs_dict,
+                    }
+                )
 
-                # Traduction de la technique en appel de méthode
-                if technique_name == "propositional_logic_formalization":
-                    res = await self.agent.formalize_to_pl(
-                        text=text_to_analyze, parameters=params
-                    )
-                    if res:
-                        results.append({"type": "formal_analyses", "belief_set": res})
-                    else:
-                        issues.append(
+                # Generate queries from belief set
+                queries = await self.agent.generate_queries(belief_set)
+                if queries:
+                    # Pass 2: Execute queries and interpret results
+                    for query in queries:
+                        query_result = self.agent.execute_query(belief_set, query)
+                        results.append(
                             {
-                                "type": "formalization_error",
-                                "description": "L'agent n'a pas pu formaliser le texte.",
+                                "type": "query_result",
+                                "query": str(query),
+                                "result": str(query_result),
                             }
                         )
-                elif technique_name == "validity_checking":
-                    res = await self.agent.check_pl_validity(
-                        text=text_to_analyze, parameters=params
+
+                    # Interpretation
+                    interpretation = await self.agent.interpret_results(
+                        belief_set, queries
                     )
-                    results.append({"type": "validity_analysis", **res})
-                elif technique_name == "consistency_checking":
-                    res = await self.agent.check_pl_consistency(
-                        text=text_to_analyze, parameters=params
-                    )
-                    results.append({"type": "consistency_analysis", **res})
-                else:
-                    issues.append(
-                        {"type": "unsupported_technique", "name": technique_name}
-                    )
+                    if interpretation:
+                        results.append(
+                            {"type": "interpretation", "content": str(interpretation)}
+                        )
+
+                # Consistency check
+                is_consistent, reason = self.agent.is_consistent(belief_set)
+                results.append(
+                    {
+                        "type": "consistency_analysis",
+                        "is_consistent": is_consistent,
+                        "reason": reason,
+                    }
+                )
 
             metrics = {"execution_time": time.time() - start_time}
             status = "completed_with_issues" if issues else "completed"

--- a/argumentation_analysis/orchestration/hierarchical/operational/adapters/rhetorical_tools_adapter.py
+++ b/argumentation_analysis/orchestration/hierarchical/operational/adapters/rhetorical_tools_adapter.py
@@ -70,7 +70,7 @@ class RhetoricalToolsAdapter(OperationalAgent):
             )
             # L'initialisation du plugin se fait maintenant en interne
             self.analysis_plugin = AnalysisToolsPlugin(
-                fallacy_detector=get_fallacy_detector()
+                fallacy_detector=project_context.get_fallacy_detector()
             )
             self.initialized = True
             self.logger.info("AnalysisToolsPlugin initialisé.")

--- a/argumentation_analysis/orchestration/hierarchical/orchestrator.py
+++ b/argumentation_analysis/orchestration/hierarchical/orchestrator.py
@@ -1,0 +1,238 @@
+"""
+Hierarchical Orchestrator — Bridge implementation (Option B, R311-B4).
+
+Provides `HierarchicalOrchestrator` which combines:
+  - **StrategicManager** for high-level objective planning
+  - **objectives_to_workflow()** for translating objectives into a WorkflowDefinition
+  - **WorkflowExecutor** (backed by CapabilityRegistry) for execution
+
+This "bridge" approach reuses the proven Lego Architecture (CapabilityRegistry +
+WorkflowDSL + WorkflowExecutor) rather than the legacy 3-tier delegation chain
+(StrategicManager → TacticalCoordinator → OperationalManager), which is dormant
+and requires more work to reactivate.
+
+Created as part of Epic #208 / R311 — Hierarchical Mode Reactivation.
+"""
+
+import logging
+import time
+from typing import Any, Dict, Optional
+
+from argumentation_analysis.orchestration.hierarchical.strategic.manager import (
+    StrategicManager,
+)
+from argumentation_analysis.orchestration.hierarchical.hierarchy_bridge import (
+    objectives_to_workflow,
+    RegistryBackedOperationalRegistry,
+)
+from argumentation_analysis.orchestration.workflow_dsl import (
+    PhaseResult,
+    PhaseStatus,
+    WorkflowExecutor,
+)
+from argumentation_analysis.core.capability_registry import CapabilityRegistry
+
+logger = logging.getLogger("HierarchicalOrchestrator")
+
+
+class HierarchicalOrchestrator:
+    """
+    Orchestrates analysis using the hierarchical (Strategic → Lego) bridge.
+
+    Flow:
+        1. StrategicManager.initialize_analysis(text) → objectives + plan
+        2. objectives_to_workflow(objectives, registry) → WorkflowDefinition
+        3. WorkflowExecutor.execute(workflow, text) → phase results
+        4. StrategicManager.evaluate_final_results(results) → conclusion
+
+    Args:
+        capability_registry: A pre-populated CapabilityRegistry. If None,
+            one will be created via ``run_unified_analysis``'s default setup.
+        strategic_manager: Optional pre-configured StrategicManager.
+    """
+
+    def __init__(
+        self,
+        capability_registry: Optional[CapabilityRegistry] = None,
+        strategic_manager: Optional[StrategicManager] = None,
+    ):
+        self._registry = capability_registry
+        self._strategic_manager = strategic_manager or StrategicManager()
+        self._executor: Optional[WorkflowExecutor] = None
+        self._initialized = False
+
+    def _ensure_registry(self) -> CapabilityRegistry:
+        """Lazily create a CapabilityRegistry if one was not provided."""
+        if self._registry is None:
+            # Use the same registry setup as the unified pipeline.
+            from argumentation_analysis.orchestration.registry_setup import (
+                setup_registry,
+            )
+
+            self._registry = setup_registry()
+            logger.info("CapabilityRegistry created via setup_registry()")
+        return self._registry
+
+    async def analyze(self, text: str, **kwargs: Any) -> Dict[str, Any]:
+        """
+        Run a full hierarchical analysis on the given text.
+
+        Args:
+            text: The argument text to analyze.
+            **kwargs: Additional context passed through to WorkflowExecutor.
+
+        Returns:
+            Dict with keys:
+              - ``objectives``: The strategic objectives generated
+              - ``phase_results``: Dict[str, PhaseResult] from execution
+              - ``conclusion``: The StrategicManager's final conclusion
+              - ``duration_seconds``: Total wall-clock time
+              - ``summary``: Completed/failed/skipped counts
+        """
+        start = time.time()
+        registry = self._ensure_registry()
+        self._executor = WorkflowExecutor(registry)
+
+        # --- Phase 1: Strategic Planning ---
+        logger.info("Phase 1: Strategic planning (StrategicManager)")
+        init_result = self._strategic_manager.initialize_analysis(text)
+        objectives = init_result.get("objectives", [])
+        strategic_plan = init_result.get("strategic_plan", {})
+
+        if not objectives:
+            logger.warning(
+                "StrategicManager returned no objectives — "
+                "falling back to default 4-objective set"
+            )
+            objectives = [
+                {
+                    "id": "obj-1",
+                    "description": "Identifier les arguments principaux",
+                    "priority": "high",
+                },
+                {
+                    "id": "obj-2",
+                    "description": "Détecter les sophismes",
+                    "priority": "high",
+                },
+                {
+                    "id": "obj-3",
+                    "description": "Analyser la structure logique",
+                    "priority": "medium",
+                },
+                {
+                    "id": "obj-4",
+                    "description": "Évaluer la cohérence globale",
+                    "priority": "medium",
+                },
+            ]
+
+        logger.info(f"  → {len(objectives)} objectives generated")
+
+        # --- Phase 2: Translate objectives → WorkflowDefinition ---
+        logger.info("Phase 2: Translating objectives into WorkflowDefinition")
+        workflow = objectives_to_workflow(
+            objectives,
+            registry,
+            workflow_name="hierarchical_analysis",
+        )
+        phase_count = len(workflow.phases)
+        logger.info(f"  → WorkflowDefinition with {phase_count} phases")
+
+        # --- Phase 3: Execute via WorkflowExecutor ---
+        logger.info("Phase 3: Executing workflow via WorkflowExecutor")
+        context = {"source": "hierarchical", **kwargs}
+        phase_results: Dict[str, PhaseResult] = await self._executor.execute(
+            workflow,
+            text,
+            context=context,
+        )
+
+        # Compute summary
+        completed = sum(
+            1 for r in phase_results.values() if r.status == PhaseStatus.COMPLETED
+        )
+        failed = sum(
+            1 for r in phase_results.values() if r.status == PhaseStatus.FAILED
+        )
+        skipped = sum(
+            1 for r in phase_results.values() if r.status == PhaseStatus.SKIPPED
+        )
+
+        logger.info(f"  → {completed} completed, {failed} failed, {skipped} skipped")
+
+        # --- Phase 4: Strategic Evaluation ---
+        logger.info("Phase 4: Strategic evaluation of results")
+        # Build a results dict keyed by objective ID for the StrategicManager
+        eval_input: Dict[str, Any] = {}
+        for obj in objectives:
+            obj_id = obj["id"]
+            # Find phase results that mention this objective
+            obj_phases = {
+                name: pr for name, pr in phase_results.items() if obj_id in name
+            }
+            # Compute a simple success rate based on phase outcomes
+            if obj_phases:
+                success = sum(
+                    1
+                    for pr in obj_phases.values()
+                    if pr.status == PhaseStatus.COMPLETED
+                )
+                eval_input[obj_id] = {
+                    "success_rate": success / len(obj_phases),
+                    "phases": {
+                        k: {"status": v.status.value} for k, v in obj_phases.items()
+                    },
+                }
+            else:
+                eval_input[obj_id] = {"success_rate": 0.0}
+
+        conclusion_result = self._strategic_manager.evaluate_final_results(eval_input)
+
+        duration = time.time() - start
+        logger.info(f"Hierarchical analysis completed in {duration:.1f}s")
+
+        return {
+            "objectives": objectives,
+            "strategic_plan": strategic_plan,
+            "phase_results": {
+                name: {
+                    "status": pr.status.value,
+                    "output": pr.output if pr.status == PhaseStatus.COMPLETED else None,
+                    "error": str(pr.error) if pr.error else None,
+                }
+                for name, pr in phase_results.items()
+            },
+            "conclusion": conclusion_result.get("conclusion", ""),
+            "evaluation": conclusion_result.get("evaluation", {}),
+            "duration_seconds": duration,
+            "summary": {
+                "total": phase_count,
+                "completed": completed,
+                "failed": failed,
+                "skipped": skipped,
+            },
+            "workflow_name": "hierarchical_analysis",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Module-level convenience function (used by run_orchestration.py)
+# ---------------------------------------------------------------------------
+
+
+async def run_hierarchical_analysis(
+    text: str,
+    capability_registry: Optional[CapabilityRegistry] = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """
+    Convenience entry point for hierarchical analysis.
+
+    Creates a ``HierarchicalOrchestrator`` and runs the analysis.
+    Used by ``run_orchestration.py --mode hierarchical``.
+    """
+    orchestrator = HierarchicalOrchestrator(
+        capability_registry=capability_registry,
+    )
+    return await orchestrator.analyze(text, **kwargs)

--- a/argumentation_analysis/orchestration/service_manager.py
+++ b/argumentation_analysis/orchestration/service_manager.py
@@ -81,21 +81,20 @@ try:
     from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
         CluedoExtendedOrchestrator as CluedoOrchestrator,
     )
-    from argumentation_analysis.orchestration.conversation_orchestrator import (
-        ConversationOrchestrator,
-    )
-    from argumentation_analysis.orchestration.real_llm_orchestrator import (
-        RealLLMOrchestrator,
-    )
+
+    # ConversationOrchestrator and RealLLMOrchestrator have been archived (obsolete shims).
+    # They remain set to None below so that the `if <Orchestrator>:` guards skip them gracefully.
     from argumentation_analysis.orchestration.fact_checking_orchestrator import (
         FactCheckingOrchestrator,
     )
 except ImportError as e:
     logging.warning(f"Certains orchestrateurs spécialisés ne sont pas disponibles: {e}")
     CluedoOrchestrator = None
-    ConversationOrchestrator = None
-    RealLLMOrchestrator = None
     FactCheckingOrchestrator = None
+
+# Archived orchestrators: kept as None so existing `if <Orchestrator>:` guards skip them.
+ConversationOrchestrator = None
+RealLLMOrchestrator = None
 
 # Imports des systèmes de communication
 try:
@@ -211,8 +210,10 @@ class OrchestrationServiceManager:
 
         # Orchestrateurs spécialisés
         self.cluedo_orchestrator: Optional[CluedoOrchestrator] = None
-        self.conversation_orchestrator: Optional[ConversationOrchestrator] = None
-        self.llm_orchestrator: Optional[RealLLMOrchestrator] = None
+        # Archived orchestrators (ConversationOrchestrator / RealLLMOrchestrator) are now None;
+        # annotate as Optional[Any] since the classes are no longer importable.
+        self.conversation_orchestrator: Optional[Any] = None
+        self.llm_orchestrator: Optional[Any] = None
         self.fact_checking_orchestrator: Optional[FactCheckingOrchestrator] = None
 
         # Middleware de communication
@@ -642,11 +643,14 @@ class OrchestrationServiceManager:
                     "timestamp": result.analysis_timestamp.isoformat(),
                     "orchestrator": orchestrator.__class__.__name__,
                 }
-            # Interface spécialisée pour RealLLMOrchestrator
+            # Interface spécialisée pour les orchestrateurs exposant analyze_text.
+            # NOTE: RealLLMOrchestrator (et son dataclass LLMAnalysisRequest) a été archivé.
+            # On construit la requête comme un objet léger (SimpleNamespace) pour rester
+            # compatible avec d'éventuels orchestrateurs résiduels exposant analyze_text.
             elif hasattr(orchestrator, "analyze_text"):
-                from .real_llm_orchestrator import LLMAnalysisRequest
+                from types import SimpleNamespace
 
-                request = LLMAnalysisRequest(
+                request = SimpleNamespace(
                     text=text,
                     # Correction: Utilise le analysis_type propagé
                     analysis_type=analysis_type,

--- a/argumentation_analysis/pipelines/unified_text_analysis.py
+++ b/argumentation_analysis/pipelines/unified_text_analysis.py
@@ -68,12 +68,21 @@ from argumentation_analysis.paths import LIBS_DIR
 from argumentation_analysis.orchestration.unified_pipeline import (
     run_unified_analysis,
 )
-from argumentation_analysis.orchestration.real_llm_orchestrator import (
-    RealConversationLogger,
-)
-from argumentation_analysis.orchestration.conversation_orchestrator import (
-    ConversationOrchestrator,
-)
+
+# Archived orchestrators (B-09 #875) — graceful fallback
+try:
+    from argumentation_analysis.orchestration.real_llm_orchestrator import (
+        RealConversationLogger,
+    )
+except ImportError:
+    RealConversationLogger = None
+
+try:
+    from argumentation_analysis.orchestration.conversation_orchestrator import (
+        ConversationOrchestrator,
+    )
+except ImportError:
+    ConversationOrchestrator = None
 
 # Imports du pipeline existant
 from argumentation_analysis.pipelines.analysis_pipeline import (
@@ -155,9 +164,16 @@ class UnifiedTextAnalysisPipeline:
         self.start_time = time.time()
 
         # Configuration du logger conversationnel
-        if self.config.enable_conversation_logging:
+        if (
+            self.config.enable_conversation_logging
+            and RealConversationLogger is not None
+        ):
             self.conversation_logger = RealConversationLogger()
             logger.info("[INIT] Logger conversationnel active")
+        elif self.config.enable_conversation_logging:
+            logger.warning(
+                "[INIT] RealConversationLogger unavailable (archived B-09 #875)"
+            )
 
         # 1. Initialisation JVM si nécessaire
         if (
@@ -215,15 +231,24 @@ class UnifiedTextAnalysisPipeline:
     async def _initialize_orchestrator(self):
         """Initialise l'orchestrateur selon le mode de configuration."""
         if self.config.orchestration_mode == "real" and self.llm_service:
-            logger.info("[ORCH] Mode real → utilisation de run_unified_analysis (no-instance)")
+            logger.info(
+                "[ORCH] Mode real → utilisation de run_unified_analysis (no-instance)"
+            )
             self.orchestrator = None  # run_unified_analysis is a function, not a class
-            logger.info("[ORCH] run_unified_analysis prêt (appel direct dans _perform_orchestration_analysis)")
+            logger.info(
+                "[ORCH] run_unified_analysis prêt (appel direct dans _perform_orchestration_analysis)"
+            )
 
         elif self.config.orchestration_mode == "conversation":
-            logger.info("[ORCH] Initialisation orchestrateur conversationnel...")
-            self.orchestrator = ConversationOrchestrator(mode="demo")
-            # Note: ConversationOrchestrator n'a pas de méthode initialize()
-            logger.info("[ORCH] Orchestrateur conversationnel initialise")
+            if ConversationOrchestrator is not None:
+                logger.info("[ORCH] Initialisation orchestrateur conversationnel...")
+                self.orchestrator = ConversationOrchestrator(mode="demo")
+                logger.info("[ORCH] Orchestrateur conversationnel initialise")
+            else:
+                logger.warning(
+                    "[ORCH] ConversationOrchestrator unavailable (archived B-09 #875), falling back to pipeline"
+                )
+                self.orchestrator = None
 
         else:
             logger.info("[ORCH] Mode orchestration standard (pipeline classique)")
@@ -554,9 +579,7 @@ class UnifiedTextAnalysisPipeline:
         try:
             if self.config.orchestration_mode == "real":
                 # Mode real: use run_unified_analysis directly
-                orch_result = await run_unified_analysis(
-                    text, workflow_name="standard"
-                )
+                orch_result = await run_unified_analysis(text, workflow_name="standard")
 
                 summary = orch_result.get("summary", {})
                 orchestration_results.update(

--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -295,10 +295,17 @@ Exemples:
         "--mode",
         "-m",
         type=str,
-        choices=["pipeline", "conversational", "legacy", "sherlock_modern"],
+        choices=[
+            "pipeline",
+            "conversational",
+            "hierarchical",
+            "legacy",
+            "sherlock_modern",
+        ],
         default="pipeline",
         help="Mode d'orchestration: pipeline (séquentiel, défaut), "
         "conversational (agents dialoguent via AgentGroupChat), "
+        "hierarchical (strategic planning → Lego execution), "
         "legacy (ancien AnalysisRunner), "
         "sherlock_modern (investigation multi-agent, #357)",
     )
@@ -514,6 +521,44 @@ Exemples:
                 render_spectacular_result(render_result)
             except ImportError:
                 logging.warning("Module output_formatter non disponible")
+
+        # Sauvegarder si demandé
+        if args.output:
+            output_path = Path(args.output)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(output_path, "w", encoding="utf-8") as f:
+                json.dump(results, f, ensure_ascii=False, indent=2, default=str)
+            logging.info(f"Résultats sauvegardés dans {output_path}")
+    elif mode == "hierarchical":
+        from argumentation_analysis.orchestration.hierarchical.orchestrator import (
+            run_hierarchical_analysis,
+        )
+
+        logging.info("Mode HIÉRARCHIQUE : StrategicManager → Lego WorkflowExecutor")
+        results = await run_hierarchical_analysis(text=text_content)
+
+        # Afficher le résumé
+        summary = results.get("summary", {})
+        conclusion = results.get("conclusion", "")
+        objectives = results.get("objectives", [])
+
+        print(f"\n{'='*60}")
+        print(f" Mode hiérarchique — {summary.get('total', 0)} phases")
+        print(f"{'='*60}")
+        print(f"  Objectifs stratégiques : {len(objectives)}")
+        for obj in objectives:
+            print(
+                f"    - [{obj.get('priority', '?').upper()}] {obj.get('description', '?')}"
+            )
+        print(
+            f"  Phases complétées : {summary.get('completed', 0)}/{summary.get('total', 0)}"
+        )
+        print(f"  Phases échouées   : {summary.get('failed', 0)}")
+        print(f"  Phases sautées    : {summary.get('skipped', 0)}")
+        print(f"  Durée : {results.get('duration_seconds', 0):.1f}s")
+        if conclusion:
+            print(f"\n  Conclusion : {conclusion}")
+        print(f"{'='*60}\n")
 
         # Sauvegarder si demandé
         if args.output:

--- a/docs/architecture/ORCHESTRATION_MODES.md
+++ b/docs/architecture/ORCHESTRATION_MODES.md
@@ -4,13 +4,13 @@
 
 ## Overview
 
-The system supports **4 orchestration modes**, each suited to different analysis scenarios. Two are actively wired into the CLI/API; two have full infrastructure but are dormant (awaiting reactivation).
+The system supports **4 orchestration modes**, each suited to different analysis scenarios. Three are actively wired into the CLI; one is active but dedicated to investigation scenarios.
 
 | Mode | Status | Key Class | Use Case |
 |------|--------|-----------|----------|
 | **Sequential (Pipeline)** | ACTIVE | `WorkflowExecutor` | Production analysis, benchmarks, API |
 | **Conversational** | ACTIVE | `ConversationalOrchestrator` | Rich multi-agent dialogue with cross-KB synergies |
-| **Hierarchical** | DORMANT | `HierarchicalTurnStrategy` | Strategic → Tactical → Operational delegation |
+| **Hierarchical** | ACTIVE | `HierarchicalOrchestrator` | Strategic planning → Lego execution (bridge) |
 | **Cluedo** | ACTIVE | `CluedoExtendedOrchestrator` | Sherlock-Watson investigation game |
 
 ---
@@ -115,28 +115,53 @@ TraceAnalyzer captures snapshots per round
 
 ---
 
-## 3. Hierarchical Mode (Dormant)
+## 3. Hierarchical Mode
 
-**Status:** Infrastructure exists but not wired into `run_orchestration.py` or API.
+**Entry points:**
 
-**How it works:**
-- 3-level hierarchy: **Strategic** (goals) → **Tactical** (plans) → **Operational** (agents)
-- `StrategicTacticalInterface` translates high-level objectives into tactical directives
-- `TacticalOperationalInterface` translates tasks into specific agent invocations
-- Each level has its own communication channel
-- Operational adapters wrap each agent type (InformalAgentAdapter, ExtractAgentAdapter, etc.)
+- CLI: `python run_orchestration.py --text "..." --mode hierarchical`
+- API: (planned — not yet wired)
+
+**How it works (bridge approach, R311-B4):**
+
+- Uses `StrategicManager` for high-level objective planning
+- Translates objectives into a `WorkflowDefinition` via `objectives_to_workflow()`
+- Executes via `WorkflowExecutor` (backed by `CapabilityRegistry`)
+- `StrategicManager.evaluate_final_results()` produces the final conclusion
+- This "bridge" approach reuses the Lego Architecture rather than the dormant 3-tier delegation chain
+
+**Flow:**
+
+```text
+HierarchicalOrchestrator
+     ↓
+StrategicManager.initialize_analysis(text) → objectives + plan
+     ↓
+objectives_to_workflow(objectives, registry) → WorkflowDefinition
+     ↓
+WorkflowExecutor.execute(workflow, text) → phase results
+     ↓
+StrategicManager.evaluate_final_results(results) → conclusion
+```
 
 **Use case:** Complex, goal-driven analyses where a strategic planner decomposes objectives into sub-tasks distributed across specialist agents.
 
 **Key files:**
 
-- `argumentation_analysis/orchestration/hierarchical/hierarchy_bridge.py`
-- `docs/architecture/ARCHITECTURE_HIERARCHIQUE_3_NIVEAUX.md`
-- `argumentation_analysis/orchestration/hierarchical/strategic/manager.py`
-- `argumentation_analysis/orchestration/hierarchical/tactical/coordinator.py`
-- `argumentation_analysis/orchestration/hierarchical/operational/manager.py`
+- `argumentation_analysis/orchestration/hierarchical/orchestrator.py` — `HierarchicalOrchestrator` + `run_hierarchical_analysis()`
+- `argumentation_analysis/orchestration/hierarchical/hierarchy_bridge.py` — `objectives_to_workflow()`, `RegistryBackedOperationalRegistry`
+- `argumentation_analysis/orchestration/hierarchical/strategic/manager.py` — `StrategicManager`
+- `docs/architecture/ARCHITECTURE_HIERARCHIQUE_3_NIVEAUX.md` — 3-tier architecture reference
 
-**Reactivation status (R311):** GO PARTIEL. 3/5 blockers fixed (B1-B3 adapters). B4 (HierarchicalOrchestrator class) and B5 (doc) remain. 302 tests dormant behind `pytestmark = pytest.mark.skip`. Estimated 1-2 more sessions.
+**Reactivation status (R311):** COMPLETE. All 5 blockers fixed:
+
+- B1: `rhetorical_tools_adapter` import fix
+- B2: `PLAgentAdapter` rewritten against real API
+- B3: `informal_agent_adapter` de-stubbed (AgentFactory wiring)
+- B4: `HierarchicalOrchestrator` bridge class + CLI `--mode hierarchical`
+- B5: Documentation updated
+
+Legacy 3-tier chain (Strategic→Tactical→Operational) remains dormant with 302 tests behind `pytestmark = pytest.mark.skip`. The bridge approach bypasses this chain entirely.
 
 ---
 
@@ -183,6 +208,9 @@ python run_orchestration.py --file text.txt --workflow collaborative
 # Conversational mode
 python run_orchestration.py --text "Your argument text" --mode conversational
 
+# Hierarchical mode (strategic planning → Lego execution)
+python run_orchestration.py --text "Your argument text" --mode hierarchical
+
 # List available workflows
 python run_orchestration.py --list-workflows
 
@@ -215,12 +243,12 @@ curl -X POST http://localhost:8000/api/v1/agents/debate \
 
 | Aspect | Sequential | Conversational | Hierarchical | Cluedo |
 |--------|-----------|---------------|-------------|--------|
-| Agent interaction | None (isolated phases) | Rich dialogue via GroupChat | Delegation chain | Cyclic turns |
-| State model | UnifiedAnalysisState | Shared via StateManagerPlugin | Per-level state | EnqueteCluedoState |
-| Plugin routing | All-to-all | Per-agent specialty | Via adapters | Domain-specific |
-| LLM calls | 1 per phase | Multiple per round | Per level | Per agent turn |
-| Cross-KB enrichment | Via context dict | Via state reads + prompts | Via interfaces | N/A |
-| Convergence | Phase completion | PM designation + trace | Level completion | Oracle termination |
+| Agent interaction | None (isolated phases) | Rich dialogue via GroupChat | Strategic → Lego bridge | Cyclic turns |
+| State model | UnifiedAnalysisState | Shared via StateManagerPlugin | StrategicState + WorkflowResults | EnqueteCluedoState |
+| Plugin routing | All-to-all | Per-agent specialty | Via CapabilityRegistry | Domain-specific |
+| LLM calls | 1 per phase | Multiple per round | 1 per phase (via WorkflowExecutor) | Per agent turn |
+| Cross-KB enrichment | Via context dict | Via state reads + prompts | Via objectives → capabilities map | N/A |
+| Convergence | Phase completion | PM designation + trace | Objective success rate | Oracle termination |
 | Best for | Batch analysis, API | Deep interactive analysis | Goal decomposition | Investigation game |
 
 ---

--- a/docs/architecture/ORCHESTRATION_MODES.md
+++ b/docs/architecture/ORCHESTRATION_MODES.md
@@ -94,7 +94,7 @@ _write_X_to_state() → updates UnifiedAnalysisState
 - Produces convergence metrics and quality reports per round
 
 **Key files:**
-- `argumentation_analysis/orchestration/conversational_orchestrator.py` — Main orchestrator
+
 - `argumentation_analysis/orchestration/conversational_executor.py` — Turn execution
 - `argumentation_analysis/orchestration/trace_analyzer.py` — Trace capture and analysis
 
@@ -129,11 +129,14 @@ TraceAnalyzer captures snapshots per round
 **Use case:** Complex, goal-driven analyses where a strategic planner decomposes objectives into sub-tasks distributed across specialist agents.
 
 **Key files:**
+
 - `argumentation_analysis/orchestration/hierarchical/hierarchy_bridge.py`
 - `docs/architecture/ARCHITECTURE_HIERARCHIQUE_3_NIVEAUX.md`
-- `examples/orchestration/run_hierarchical_orchestration.py`
+- `argumentation_analysis/orchestration/hierarchical/strategic/manager.py`
+- `argumentation_analysis/orchestration/hierarchical/tactical/coordinator.py`
+- `argumentation_analysis/orchestration/hierarchical/operational/manager.py`
 
-**Reactivation path:** Wire `HierarchicalOrchestrator` into `run_orchestration.py --mode hierarchical` and register operational adapters for all current agents.
+**Reactivation status (R311):** GO PARTIEL. 3/5 blockers fixed (B1-B3 adapters). B4 (HierarchicalOrchestrator class) and B5 (doc) remain. 302 tests dormant behind `pytestmark = pytest.mark.skip`. Estimated 1-2 more sessions.
 
 ---
 
@@ -161,8 +164,9 @@ TraceAnalyzer captures snapshots per round
 **Key difference:** Operates on the Cluedo dataset (suspects, weapons, rooms) rather than rhetorical text analysis. Uses its own state model, not `UnifiedAnalysisState`.
 
 **Key files:**
-- `argumentation_analysis/orchestration/cluedo_orchestrator.py` — 2-agent version
-- `argumentation_analysis/orchestration/cluedo_extended_orchestrator.py` — 3-agent + Oracle
+
+- `argumentation_analysis/orchestration/cluedo_extended_orchestrator.py` — 3-agent + Oracle (active)
+- `docs/archives/orchestration_legacy/cluedo_orchestrator_base.py` — 2-agent version (archived, superseded by Extended)
 
 ---
 
@@ -226,9 +230,12 @@ curl -X POST http://localhost:8000/api/v1/agents/debate \
 ### Archived Components
 | Component | Archived To | Replacement | PR |
 |-----------|-------------|-------------|-----|
-| `RealLLMOrchestrator` (668 lines) | `docs/archives/orchestration_legacy/` | `UnifiedPipeline` / `ConversationalOrchestrator` | #246 |
+| `RealLLMOrchestrator` (668→124 LOC shim) | `docs/archives/orchestration_legacy/real_llm_orchestrator_shim.py` | `UnifiedPipeline` + `WorkflowDSL` | #246, #886 |
 | `RealLLMOrchestratorWrapper` (60 lines) | Deprecation shim in `pipelines/` | Same as above | #247 |
 | Dead code in `pipeline_utils.py` | Removed (EnhancedPipeline, singletons) | `AnalysisCache` + `PipelineMetrics` kept | #255 |
+| `ConversationOrchestrator` (1044 LOC) | `docs/archives/orchestration_legacy/conversation_orchestrator.py` | 8-agent SK system via `CapabilityRegistry` | #886 |
+| `CluedoOrchestrator` base 2-agent (488 LOC) | `docs/archives/orchestration_legacy/cluedo_orchestrator_base.py` | `CluedoExtendedOrchestrator` (3-agent + Oracle) | #886 |
+| `LogiqueComplexeOrchestrator` (108 LOC stub) | `docs/archives/orchestration_legacy/logique_complexe_orchestrator.py` | `FOLLogicAgent` + `TweetyLogicPlugin` | #886 |
 
 ### Consolidated Components
 | Component | New Location | Description | PR |

--- a/docs/archives/orchestration_legacy/cluedo_orchestrator_base.py
+++ b/docs/archives/orchestration_legacy/cluedo_orchestrator_base.py
@@ -1,0 +1,497 @@
+# ARCHIVED: 2026-06-02 (B-09 #875)
+# Original path: argumentation_analysis/orchestration/cluedo_orchestrator.py
+# Reason: 2-agent base CluedoOrchestrator (Sherlock + Watson only). Fully superseded by
+#         3-agent CluedoExtendedOrchestrator (adds Oracle). DeprecationWarning on run_cluedo_game().
+#         service_manager.py already aliases CluedoExtendedOrchestrator as CluedoOrchestrator.
+# Superseded-by: CluedoExtendedOrchestrator (argumentation_analysis/orchestration/cluedo_extended_orchestrator.py)
+# Removed-from: No direct external imports of base class (all callers use the Extended version via alias)
+# Tests removed: tests/unit/orchestration/test_specialized_orchestrators.py (CluedoOrchestrator uses Extended)
+# ---
+import asyncio
+import logging
+from typing import List, Dict, Any, Optional
+from datetime import datetime
+
+import semantic_kernel as sk
+from semantic_kernel.functions import kernel_function
+from semantic_kernel.kernel import Kernel
+from argumentation_analysis.orchestration.base import (
+    SelectionStrategy,
+    TerminationStrategy,
+)
+from semantic_kernel.agents import Agent
+from semantic_kernel.contents.chat_message_content import ChatMessageContent
+from semantic_kernel.functions import KernelArguments
+from pydantic import Field
+
+# Imports locaux
+from .base import Agent, TerminationStrategy
+from .cluedo_extended_orchestrator import CyclicSelectionStrategy
+from argumentation_analysis.core.enquete_states import EnqueteCluedoState
+from argumentation_analysis.orchestration.plugins.enquete_state_manager_plugin import (
+    EnqueteStateManagerPlugin,
+)
+from argumentation_analysis.orchestration.group_chat import GroupChatOrchestration
+from argumentation_analysis.agents.factory import AgentFactory
+from argumentation_analysis.config.settings import AppSettings
+
+# Configuration du logging
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+)
+logger = logging.getLogger(__name__)
+
+
+class CluedoTerminationStrategy(TerminationStrategy):
+    """Stratégie de terminaison personnalisée pour le Cluedo."""
+
+    max_turns: int = Field(default=10)
+    turn_count: int = Field(default=0, exclude=True)
+    is_solution_found: bool = Field(default=False, exclude=True)
+    enquete_plugin: EnqueteStateManagerPlugin = Field(...)
+
+    async def should_terminate(
+        self, agent: Agent, history: List[ChatMessageContent]
+    ) -> bool:
+        """Termine si la solution est trouvée ou si le nombre max de tours est atteint."""
+        self.turn_count += 1
+        if self.is_solution_found:
+            logger.info("Solution trouvée. Terminaison.")
+            return True
+        if self.turn_count >= self.max_turns:
+            logger.info("Nombre maximum de tours atteint. Terminaison.")
+            return True
+        return False
+
+
+class CluedoOrchestrator:
+    """
+    Orchestrateur pour workflow Cluedo de base avec 2 agents : Sherlock ↔ Watson.
+
+    Implémente la sélection cyclique, la terminaison, et la gestion d'état.
+    """
+
+    def __init__(
+        self,
+        kernel: Kernel,
+        settings: AppSettings,
+        max_turns: int = 10,
+        termination_strategy: Optional[CluedoTerminationStrategy] = None,
+    ):
+        """
+        Initialise l'orchestrateur Cluedo de base.
+
+        Args:
+            kernel: Kernel Semantic Kernel
+            settings: Configuration de l'application
+            max_turns: Nombre maximum de tours
+            termination_strategy: Stratégie de terminaison personnalisée
+        """
+        self.kernel = kernel
+        self.settings = settings
+        self.max_turns = max_turns
+        self.termination_strategy = termination_strategy or CluedoTerminationStrategy()
+
+        # État et agents
+        self.sherlock_agent: Optional[Agent] = None
+        self.watson_agent: Optional[Agent] = None
+        self.orchestration: Optional[GroupChatOrchestration] = None
+
+        # Métriques de performance
+        self.start_time: Optional[datetime] = None
+        self.end_time: Optional[datetime] = None
+        self.execution_metrics: Dict[str, Any] = {}
+
+        self._logger = logging.getLogger(self.__class__.__name__)
+
+    async def setup_workflow(
+        self,
+        nom_enquete: str = "Le Mystère du Manoir Tudor",
+        elements_jeu: Optional[Dict[str, List[str]]] = None,
+    ) -> EnqueteCluedoState:
+        """
+        Configure le workflow 2-agents avec état Cluedo.
+
+        Args:
+            nom_enquete: Nom de l'enquête
+            elements_jeu: Éléments du jeu Cluedo (optionnel)
+
+        Returns:
+            État Cluedo configuré
+        """
+        self._logger.info("Configuration du workflow 2-agents Cluedo")
+
+        # Configuration des éléments par défaut
+        if elements_jeu is None:
+            elements_jeu = {
+                "suspects": [
+                    "Colonel Moutarde",
+                    "Professeur Violet",
+                    "Mademoiselle Rose",
+                ],
+                "armes": ["Poignard", "Chandelier", "Revolver"],
+                "lieux": ["Salon", "Cuisine", "Bureau"],
+            }
+
+        # Création de l'état Cluedo
+        enquete_state = EnqueteCluedoState(
+            nom_enquete_cluedo=nom_enquete,
+            elements_jeu_cluedo=elements_jeu,
+            description_cas="Un meurtre a été commis dans le manoir. Qui, où, et avec quoi ?",
+            initial_context="L'enquête débute avec 2 enquêteurs spécialisés.",
+        )
+
+        # Configuration du plugin d'état
+        state_plugin = EnqueteStateManagerPlugin(enquete_state)
+        self.kernel.add_plugin(state_plugin, "EnqueteStatePlugin")
+
+        # Création des agents
+        from ..agents.factory import AgentFactory
+
+        factory = AgentFactory(self.kernel, self.kernel.get_service(None).service_id)
+        self.sherlock_agent = factory.create_sherlock_agent(agent_name="Sherlock")
+        self.watson_agent = factory.create_watson_agent(agent_name="Watson")
+
+        # Configuration des stratégies
+        agents = [self.sherlock_agent, self.watson_agent]
+        selection_strategy = CyclicSelectionStrategy(agents)
+
+        # Création de l'orchestration avec GroupChatOrchestration (système original qui fonctionne)
+        self.orchestration = GroupChatOrchestration()
+        session_id = f"cluedo_session_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+
+        # Configuration des agents
+        agent_dict = {
+            getattr(agent, "name", getattr(agent, "id", str(agent))): agent
+            for agent in agents
+        }
+        self.orchestration.initialize_session(session_id, agent_dict)
+
+        # Stocker les stratégies pour usage ultérieur
+        self.selection_strategy = selection_strategy
+        self.termination_strategy = self.termination_strategy
+
+        self._logger.info(f"Workflow configuré avec {len(agents)} agents")
+        return enquete_state
+
+    async def execute_workflow(
+        self,
+        initial_question: str = "L'enquête commence. Sherlock, menez l'investigation !",
+    ) -> Dict[str, Any]:
+        """
+        Exécute le workflow complet avec les 2 agents.
+
+        Args:
+            initial_question: Question/instruction initiale
+
+        Returns:
+            Résultat complet du workflow avec métriques
+        """
+        if not self.orchestration:
+            raise ValueError(
+                "Workflow non configuré. Appelez setup_workflow() d'abord."
+            )
+
+        self.start_time = datetime.now()
+        self._logger.info("Début du workflow 2-agents Cluedo")
+
+        # Historique des messages
+        history: List[ChatMessageContent] = [
+            ChatMessageContent(role="user", content=initial_question, name="System")
+        ]
+
+        # Boucle principale d'orchestration
+        self._logger.info("Début de la boucle d'orchestration 2-agents...")
+        try:
+            while not await self.termination_strategy.should_terminate(
+                agent=self.sherlock_agent, history=history
+            ):
+                next_agent = await self.selection_strategy.next(
+                    agents=[self.sherlock_agent, self.watson_agent], history=history
+                )
+                self._logger.info(f"--- Tour de {next_agent.name} ---")
+
+                # 1. Tronquer et nettoyer l'historique avant de l'envoyer
+                history_to_send = history[-5:] if len(history) > 5 else history
+
+                # 2. Exécuter l'agent avec l'historique nettoyé
+                agent_response = await next_agent.invoke(
+                    input=history_to_send, arguments=KernelArguments()
+                )
+
+                # 3. Consolider et nettoyer la réponse de l'agent
+                clean_message = self._consolidate_agent_response(
+                    agent_response, next_agent.name
+                )
+
+                # 4. Mettre à jour l'historique avec le message propre
+                history.append(clean_message)
+                last_message_content = str(clean_message.content)
+
+                # 5. Log et mise à jour de l'état
+                self._logger.info(
+                    f"Réponse de {next_agent.name}: {last_message_content[:150]}..."
+                )
+                enquete_state.add_conversation_message(
+                    agent_name=next_agent.name,
+                    content=last_message_content,
+                    message_type=self._detect_message_type(last_message_content),
+                )
+
+                turn_input = (
+                    history[-2].content if len(history) > 1 else initial_question
+                )
+                enquete_state.record_agent_turn(
+                    agent_name=next_agent.name,
+                    action_type="invoke_with_history",
+                    action_details={
+                        "input": str(turn_input)[:150],
+                        "output": last_message_content[:150],
+                    },
+                )
+
+        except Exception as e:
+            self._logger.error(f"Erreur durant l'orchestration: {e}", exc_info=True)
+            raise
+
+        finally:
+            self.end_time = datetime.now()
+
+            workflow_result = await self._collect_final_metrics(history)
+
+            self._logger.info("[OK] Workflow 2-agents Cluedo terminé")
+            return workflow_result
+
+    def _consolidate_agent_response(
+        self, response: Any, agent_name: str
+    ) -> ChatMessageContent:
+        """
+        Consolide la réponse brute d'un agent en un unique ChatMessageContent.
+        """
+        full_content = ""
+        role = "assistant"
+
+        # Cas 1: La réponse est une liste de chunks de streaming
+        if isinstance(response, list):
+            for chunk in response:
+                if hasattr(chunk, "items"):
+                    for part in chunk.items:
+                        if hasattr(part, "text"):
+                            full_content += part.text
+                # Gérer le cas où un ChatMessageContent se retrouve dans la liste
+                elif hasattr(chunk, "content"):
+                    full_content += str(chunk.content or "")
+            # Cas 2: La réponse est un objet de streaming unique
+        elif hasattr(response, "items"):
+            for part in response.items:
+                if hasattr(part, "text"):
+                    full_content += part.text
+            # Cas 3: C'est déjà un ChatMessageContent (potentiellement avec un contenu complexe)
+        elif isinstance(response, ChatMessageContent):
+            # Extraire le contenu texte, peu importe Comment il est encapsulé
+            content_obj = response.content
+            if hasattr(content_obj, "text"):
+                full_content = content_obj.text
+            elif isinstance(content_obj, str):
+                full_content = content_obj
+            else:
+                full_content = str(content_obj or "")
+            role = response.role
+            # Cas 4: C'est juste un string ou un autre type de base
+        else:
+            full_content = str(response or "")
+
+        return ChatMessageContent(role=role, content=full_content, name=agent_name)
+
+    async def _collect_final_metrics(
+        self, history: List[ChatMessageContent]
+    ) -> Dict[str, Any]:
+        """Collecte les métriques finales du workflow."""
+        execution_time = (
+            (self.end_time - self.start_time).total_seconds()
+            if self.start_time and self.end_time
+            else 0
+        )
+
+        # Statistiques de base
+        conversation_history = []
+        for msg in history:
+            # Skip system messages
+            sender_name = getattr(msg, "name", None)
+            role_name = getattr(msg, "role", None)
+
+            if sender_name == "System" or role_name == "System":
+                continue
+
+            # Robustly extract sender and message
+            if hasattr(msg, "content"):
+                message = str(msg.content)
+                # Prefer 'name' but fall back to 'role'
+                sender = sender_name or role_name or "Unknown"
+            else:
+                # Handle cases where msg might be a plain string
+                message = str(msg)
+                sender = "Unknown"
+
+            conversation_history.append({"sender": sender, "message": message})
+
+        # Métriques de performance
+        performance_metrics = {
+            "efficiency": {
+                "turns_per_minute": (
+                    len(history) / (execution_time / 60) if execution_time > 0 else 0
+                ),
+            },
+            "agent_balance": self._calculate_agent_balance(history),
+        }
+
+        return {
+            "workflow_info": {
+                "max_turns": self.max_turns,
+                "execution_time_seconds": execution_time,
+                "timestamp": self.end_time.isoformat() if self.end_time else None,
+            },
+            "conversation_history": conversation_history,
+            "performance_metrics": performance_metrics,
+            "final_state": {
+                "solution_proposed": False,  # Pas de solution dans ce workflow
+                "final_solution": None,
+                "secret_solution": None,
+                "game_solvable_by_elimination": False,
+            },
+        }
+
+    def _calculate_agent_balance(
+        self, history: List[ChatMessageContent]
+    ) -> Dict[str, float]:
+        """Calcule l'équilibre de participation entre agents."""
+        total_turns = len(history)
+        if total_turns == 0:
+            return {"sherlock": 0.0, "watson": 0.0}
+
+        # Estimation basée sur le pattern cyclique (1/2 chacun idéalement)
+        expected_per_agent = total_turns / 2
+
+        return {
+            "expected_turns_per_agent": expected_per_agent,
+            "balance_score": 1.0,  # À améliorer avec tracking réel par Agent
+            "note": "Équilibre cyclique théorique - à améliorer avec métriques réelles",
+        }
+
+    def _detect_message_type(self, content: str) -> str:
+        """
+        Détecte le type de message basé sur son contenu.
+        """
+        content_lower = content.lower()
+
+        if any(
+            keyword in content_lower
+            for keyword in ["révèle", "possède", "carte", "j'ai"]
+        ):
+            return "revelation"
+        elif any(
+            keyword in content_lower
+            for keyword in ["suggère", "propose", "suspect", "arme", "lieu"]
+        ):
+            return "suggestion"
+        elif any(
+            keyword in content_lower
+            for keyword in ["analyse", "déduction", "conclusion", "donc"]
+        ):
+            return "analysis"
+        elif any(
+            keyword in content_lower
+            for keyword in ["brillant", "exactement", "aha", "intéressant", "magistral"]
+        ):
+            return "reaction"
+        else:
+            return "message"
+
+
+async def run_cluedo_game(
+    kernel: Kernel,
+    initial_question: str = "L'enquête commence. Sherlock, menez l'investigation !",
+    max_turns: Optional[int] = 10,
+) -> (List[Dict[str, Any]], EnqueteCluedoState):
+    """
+    Exécute une partie de Cluedo avec 2 agents.
+
+    Args:
+        kernel: Kernel Semantic Kernel
+        initial_question: Question initiale
+        max_turns: Nombre maximum de tours
+
+    Returns:
+        Historique des messages et état final
+    """
+    warnings.warn(
+        "`run_cluedo_game` is deprecated and part of a legacy module. "
+        "It is maintained for backward compatibility only. "
+        "Please use new agent group chat architecture for new implementations.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    orchestrator = CluedoOrchestrator(
+        kernel=kernel,
+        settings=AppSettings(),
+        max_turns=max_turns or 10,
+        termination_strategy=None,
+    )
+
+    await orchestrator.setup_workflow()
+    final_history, final_state = await orchestrator.execute_workflow(initial_question)
+
+    return final_history, final_state
+
+
+async def main():
+    """Point d'entrée pour exécuter le script de manière autonome."""
+    kernel = Kernel()
+
+    # Récupération du service_id depuis les settings
+    from argumentation_analysis.config.settings import settings
+    from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+
+    if not settings.use_mock_llm and settings.openai.api_key:
+        kernel.add_service(
+            OpenAIChatCompletion(
+                service_id=settings.openai.chat_model_id,
+                ai_model_id=settings.openai.chat_model_id,
+                api_key=settings.openai.api_key.get_secret_value(),
+            )
+        )
+    else:
+        logger.warning(
+            "Aucun service LLM configuré ou utilisation de mock activée. "
+            "L'exécution peut échouer ou être limitée."
+        )
+
+    try:
+        final_history, final_state = await run_cluedo_game(
+            kernel=kernel, initial_question="L'enquête commence. Sherlock, à vous."
+        )
+
+        print("\n--- Historique Final de la Conversation ---")
+        for entry in final_history:
+            print(f"  {entry['sender']}: {entry['message']}")
+        print("--- Fin de la Conversation ---")
+
+        print("\n--- État Final de l'Enquête ---")
+        print(f"Nom de l'enquête: {final_state.nom_enquete_cluedo}")
+        print(f"Description: {final_state.description_cas}")
+        print(f"Solution proposée: {final_state.final_solution}")
+        print(f"Solution correcte: {final_state.solution_secrete_cluedo}")
+        print("\n--- Hypothèses ---")
+        for hypo in final_state.get_hypotheses():
+            print(
+                f"  - ID: {hypo['id']}, Text: {hypo['text']}, Confiance: {hypo['confidence_score']}, Statut: {hypo['status']}"
+            )
+        print("--- Fin de l'État ---")
+
+    except Exception as e:
+        print(f"Une erreur est survenue: {e}")
+        import traceback
+
+    if __name__ == "__main__":
+        asyncio.run(main())

--- a/docs/archives/orchestration_legacy/conversation_orchestrator.py
+++ b/docs/archives/orchestration_legacy/conversation_orchestrator.py
@@ -1,0 +1,1056 @@
+﻿#!/usr/bin/env python3
+# ARCHIVED: 2026-06-02 (B-09 #875)
+# Original path: argumentation_analysis/orchestration/conversation_orchestrator.py
+# Reason: Dormant with DeprecationWarning. 1044 LOC. demo/trace/enhanced/micro modes use
+#         pre-CapabilityRegistry SimulatedAgent classes, all superseded by Lego Architecture.
+#         Real mode uses new agents but is accessed via UnifiedPipeline, not this class directly.
+# Superseded-by: 8-agent SK system (AgentGroupChat with PM, Extract, Informal, Formal,
+#                Quality, Debate, Counter, Governance) via CapabilityRegistry.
+# Removed-from: orchestration/__init__.py, service_manager.py, engine/main_orchestrator.py,
+#               pipelines/unified_pipeline.py, unified_text_analysis.py
+# Tests removed: tests/unit/orchestration/test_unified_orchestrations.py (23 tests),
+#   tests/unit/orchestration/test_specialized_orchestrators.py (ConversationOrchestrator sections)
+# ---
+"""
+Conversation Orchestrator - Composant réutilisable pour orchestration conversationnelle
+================================================================================
+
+Composant unifié pour orchestration conversationnelle avec support de 4 modes :
+- micro : Orchestration ultra-légère
+- demo : Démonstration complète avec agents simulés
+- trace : Test du système de traçage conversationnel
+- enhanced : Test des composants PM améliorés
+
+S'intègre harmonieusement avec l'architecture Semantic Kernel existante.
+"""
+
+import time
+import json
+import logging
+import warnings
+from datetime import datetime
+from typing import Dict, Any, List, Optional, Union
+from pathlib import Path
+
+# Imports Semantic Kernel et architecture
+from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+from argumentation_analysis.core.llm_service import create_llm_service
+
+logger = logging.getLogger("ConversationOrchestrator")
+
+
+class ConversationLogger:
+    """Logger conversationnel unifié compatible avec l'architecture existante."""
+
+    def __init__(self, mode: str = "demo"):
+        self.mode = mode
+        self.start_time = time.time()
+        self.messages = []
+        self.tool_calls = []
+        self.state_snapshots = []
+        self.logger = logging.getLogger(f"{__name__}.ConversationLogger")
+
+        # Limites selon le mode pour éviter surcharge
+        self._set_mode_limits()
+
+    def _set_mode_limits(self):
+        """Configure les limites selon le mode."""
+        if self.mode == "micro":
+            self.max_messages = 8
+            self.max_tools = 6
+            self.max_states = 3
+            self.max_message_len = 150
+        else:
+            self.max_messages = 20
+            self.max_tools = 15
+            self.max_states = 8
+            self.max_message_len = 300
+
+    def log_agent_message(self, agent: str, message: str, phase: str = "analysis"):
+        """Enregistre un message conversationnel d'agent."""
+        if len(self.messages) >= self.max_messages:
+            return
+
+        # Troncature intelligente pour éviter surcharge
+        if len(message) > self.max_message_len:
+            message = message[: self.max_message_len - 3] + "..."
+
+        timestamp_ms = (time.time() - self.start_time) * 1000
+        entry = {
+            "type": "message",
+            "agent": agent,
+            "message": message,
+            "phase": phase,
+            "timestamp": time.time() - self.start_time,
+            "time_ms": timestamp_ms,
+        }
+        self.messages.append(entry)
+
+        # Log dans le système principal
+        self.logger.info(f"[{agent}] {message}")
+
+        # Affichage console selon mode
+        if self.mode != "trace":
+            print(f"[CONVERSATION] {agent}: {message}")
+
+    def log_tool_call(
+        self,
+        agent: str,
+        tool: str,
+        args: Dict[str, Any],
+        result: Any,
+        success: bool = True,
+    ):
+        """Enregistre un appel d'outil."""
+        if len(self.tool_calls) >= self.max_tools:
+            return
+
+        # Sérialisation et troncature des données volumineuses
+        args_str = str(args)
+        if len(args_str) > 100:
+            args_str = args_str[:97] + "..."
+
+        result_str = str(result)
+        if len(result_str) > 150:
+            result_str = result_str[:147] + "..."
+
+        timestamp_ms = (time.time() - self.start_time) * 1000
+        entry = {
+            "type": "tool_call",
+            "agent": agent,
+            "tool": tool,
+            "arguments": args_str,
+            "result": result_str,
+            "success": success,
+            "timestamp": time.time() - self.start_time,
+            "time_ms": timestamp_ms,
+        }
+        self.tool_calls.append(entry)
+
+        # Log dans le système principal
+        self.logger.info(f"[TOOL] {agent} -> {tool}: {success}")
+
+        # Affichage console selon mode
+        if self.mode != "trace":
+            print(f"[TOOL] {agent} -> {tool}: {args_str} = {result_str}")
+
+    def log_state_snapshot(self, phase: str, state_data: Dict[str, Any]):
+        """Enregistre un snapshot d'état."""
+        if len(self.state_snapshots) >= self.max_states:
+            return
+
+        entry = {
+            "type": "state",
+            "phase": phase,
+            "data": state_data,
+            "timestamp": time.time() - self.start_time,
+        }
+        self.state_snapshots.append(entry)
+
+        # Log dans le système principal
+        self.logger.info(f"[STATE] Phase {phase}: {len(state_data)} metrics")
+
+        # Affichage console selon mode
+        if self.mode != "trace":
+            print(f"[STATE] Phase {phase}: {state_data}")
+
+
+class AnalysisState:
+    """État d'analyse unifié compatible avec RhetoricalAnalysisState."""
+
+    def __init__(self):
+        self.score = 0.0
+        self.agents_active = 0
+        self.fallacies_detected = 0
+        self.propositions_found = 0
+        self.consistency_score = 0.0
+        self.phase = "initialization"
+        self.completed = False
+
+        # Métriques additionnelles pour compatibilité
+        self.processing_time = 0.0
+        self.agent_results = {}
+
+    def update_from_informal(self, result: Dict[str, Any]):
+        """Met à jour l'état avec résultats d'analyse informelle."""
+        self.fallacies_detected += result.get("fallacies_count", 0)
+        self.score += result.get("sophistication_score", 0.0) * 0.4
+        self.agent_results["informal"] = result
+
+    def update_from_modal(self, result: Dict[str, Any]):
+        """Met à jour l'état avec résultats de logique modale."""
+        self.propositions_found += result.get("propositions_count", 0)
+        self.consistency_score = result.get("consistency", 0.0)
+        self.score += result.get("logical_score", 0.0) * 0.3
+        self.agent_results["modal"] = result
+
+    def update_from_synthesis(self, result: Dict[str, Any]):
+        """Met à jour l'état avec résultats de synthèse."""
+        self.score += result.get("unified_score", 0.0) * 0.3
+        self.completed = True
+        self.agent_results["synthesis"] = result
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convertit l'état en dictionnaire."""
+        return {
+            "score": round(self.score, 2),
+            "agents_active": self.agents_active,
+            "fallacies_detected": self.fallacies_detected,
+            "propositions_found": self.propositions_found,
+            "consistency_score": round(self.consistency_score, 2),
+            "phase": self.phase,
+            "completed": self.completed,
+            "processing_time": round(self.processing_time, 3),
+        }
+
+    def to_rhetorical_state(self) -> "RhetoricalAnalysisState":
+        """Convertit vers RhetoricalAnalysisState pour compatibilité."""
+        state = RhetoricalAnalysisState(initial_text="")
+        if self.completed:
+            state.final_conclusion = f"Analysis completed with score {self.score:.2f}"
+        return state
+
+
+class SimulatedAgent:
+    """Agent simulé pour démonstrations - Compatible avec l'architecture."""
+
+    def __init__(self, name: str, agent_type: str):
+        self.name = name
+        self.agent_type = agent_type
+        self.logger = logging.getLogger(f"{__name__}.{name}")
+
+    def analyze(
+        self, text: str, conv_logger: ConversationLogger, state: AnalysisState
+    ) -> Dict[str, Any]:
+        """Simule une analyse selon le type d'agent."""
+
+        self.logger.info(f"Début analyse {self.agent_type} pour {self.name}")
+
+        if self.agent_type == "informal":
+            return self._analyze_informal(text, conv_logger, state)
+        elif self.agent_type == "fol_logic":
+            return self._analyze_fol_logic(text, conv_logger, state)
+        elif self.agent_type == "synthesis":
+            return self._analyze_synthesis(text, conv_logger, state)
+        else:
+            self.logger.error(f"Type d'agent inconnu: {self.agent_type}")
+            return {"error": "Unknown agent type"}
+
+    def _analyze_informal(
+        self, text: str, conv_logger: ConversationLogger, state: AnalysisState
+    ) -> Dict[str, Any]:
+        """Analyse informelle simulée avec patterns réalistes."""
+
+        conv_logger.log_agent_message(
+            self.name,
+            "Je vais analyser ce texte pour détecter les sophismes et manipulations rhétoriques.",
+            "informal_analysis",
+        )
+
+        # Délai réaliste pour simulation
+        time.sleep(0.002)
+
+        # Simulation de détection de sophismes
+        sophisms_result = [
+            {"type": "Historical Rewriting", "confidence": 0.85},
+            {"type": "False Cause", "confidence": 0.78},
+        ]
+
+        conv_logger.log_tool_call(
+            self.name,
+            "detect_sophisms_from_taxonomy",
+            {
+                "text": text[:50] + "...",
+                "branches": ["logical", "emotional", "rhetorical"],
+                "severity_threshold": 0.3,
+            },
+            sophisms_result,
+        )
+
+        conv_logger.log_agent_message(
+            self.name,
+            f"Sophismes détectés: '{sophisms_result[0]['type']}' (confiance: {sophisms_result[0]['confidence']}) et '{sophisms_result[1]['type']}' (confiance: {sophisms_result[1]['confidence']}). Analyse des motifs rhétoriques en cours...",
+            "informal_analysis",
+        )
+
+        time.sleep(0.002)
+
+        # Simulation d'analyse des patterns
+        patterns_result = {"patterns_found": 3, "nationalist_appeals": 2}
+
+        conv_logger.log_tool_call(
+            self.name,
+            "analyze_rhetorical_patterns",
+            {
+                "text_segments": ["key phrases..."],
+                "pattern_types": ["nationalism", "victimization"],
+            },
+            patterns_result,
+        )
+
+        result = {
+            "fallacies_count": 2,
+            "sophistication_score": 0.8,
+            "main_issues": ["historical_distortion", "emotional_manipulation"],
+        }
+
+        conv_logger.log_agent_message(
+            self.name,
+            f"Analyse terminée. {result['fallacies_count']} sophismes détectés, {patterns_result['patterns_found']} motifs rhétoriques identifiés. Score de sophistication : {result['sophistication_score']}/1.0",
+            "informal_analysis",
+        )
+
+        state.update_from_informal(result)
+        state.agents_active += 1
+
+        return result
+
+    def _analyze_modal(
+        self, text: str, conv_logger: ConversationLogger, state: AnalysisState
+    ) -> Dict[str, Any]:
+        """Analyse modale simulée avec logique formelle."""
+
+        conv_logger.log_agent_message(
+            self.name,
+            "Je vais transformer ce texte en propositions logiques modales pour analyser sa cohérence.",
+            "modal_analysis",
+        )
+
+        time.sleep(0.003)
+
+        # Simulation d'extraction de propositions modales
+        belief_set_result = {
+            "propositions": [
+                "BOX(Created(Ukraine, Russia))",
+                "DIAMOND(Harsh(actions))",
+                "NECESSITY(FirmActions))",
+            ],
+            "modal_operators": ["necessity", "possibility", "necessity"],
+            "consistency_status": "potentially_inconsistent",
+        }
+
+        conv_logger.log_tool_call(
+            self.name,
+            "text_to_belief_set",
+            {
+                "text": text[:50] + "...",
+                "logic_type": "modal",
+                "extract_propositions": True,
+            },
+            belief_set_result,
+        )
+
+        propositions_str = "', '".join(belief_set_result["propositions"])
+        conv_logger.log_agent_message(
+            self.name,
+            f"Propositions modales extraites: '{propositions_str}'. Vérification de la cohérence logique...",
+            "modal_analysis",
+        )
+
+        time.sleep(0.002)
+
+        # Simulation de vérification de cohérence
+        consistency_result = {"consistency": 0.65, "contradictions": 1}
+
+        conv_logger.log_tool_call(
+            self.name,
+            "check_logical_consistency",
+            {"propositions": belief_set_result["propositions"]},
+            consistency_result,
+        )
+
+        result = {
+            "propositions_count": len(belief_set_result["propositions"]),
+            "consistency": consistency_result["consistency"],
+            "logical_score": 0.7,
+            "contradictions": consistency_result["contradictions"],
+        }
+
+        conv_logger.log_agent_message(
+            self.name,
+            f"Analyse modale terminée. {result['propositions_count']} propositions extraites, cohérence logique: {result['consistency']:.2f}, {result['contradictions']} contradiction détectée.",
+            "modal_analysis",
+        )
+
+        state.update_from_modal(result)
+        state.agents_active += 1
+
+        return result
+
+    def _analyze_fol_logic(
+        self, text: str, conv_logger: ConversationLogger, state: AnalysisState
+    ) -> Dict[str, Any]:
+        """Analyse FOL simulée avec logique du premier ordre."""
+
+        conv_logger.log_agent_message(
+            self.name,
+            "Je vais transformer ce texte en formules de logique du premier ordre (FOL) pour analyser sa cohérence.",
+            "fol_analysis",
+        )
+
+        time.sleep(0.003)
+
+        # Simulation d'extraction de formules FOL
+        belief_set_result = {
+            "formulas": [
+                "∀x(Created(x) → ResponsibleAction(x))",
+                "∃y(HarshAction(y) ∧ Necessary(y))",
+                "∀z(FirmAction(z) → Justified(z))",
+            ],
+            "predicates": [
+                "Created",
+                "ResponsibleAction",
+                "HarshAction",
+                "Necessary",
+                "FirmAction",
+                "Justified",
+            ],
+            "quantifiers": ["universal", "existential", "universal"],
+            "consistency_status": "potentially_consistent",
+        }
+
+        conv_logger.log_tool_call(
+            self.name,
+            "convert_to_fol",
+            {"text": text[:50] + "...", "logic_type": "fol", "extract_formulas": True},
+            belief_set_result,
+        )
+
+        formulas_str = "', '".join(belief_set_result["formulas"])
+        conv_logger.log_agent_message(
+            self.name,
+            f"Formules FOL extraites: '{formulas_str}'. Vérification de la cohérence logique avec Tweety...",
+            "fol_analysis",
+        )
+
+        time.sleep(0.002)
+
+        # Simulation de vérification de cohérence FOL
+        consistency_result = {
+            "consistency": 0.85,
+            "contradictions": 0,
+            "satisfiable": True,
+        }
+
+        conv_logger.log_tool_call(
+            self.name,
+            "analyze_fol",
+            {"formulas": belief_set_result["formulas"]},
+            consistency_result,
+        )
+
+        result = {
+            "formulas_count": len(belief_set_result["formulas"]),
+            "consistency": consistency_result["consistency"],
+            "logical_score": 0.85,
+            "contradictions": consistency_result["contradictions"],
+            "satisfiable": consistency_result["satisfiable"],
+        }
+
+        conv_logger.log_agent_message(
+            self.name,
+            f"Analyse FOL terminée. {result['formulas_count']} formules extraites, cohérence logique: {result['consistency']:.2f}, satisfiable: {result['satisfiable']}.",
+            "fol_analysis",
+        )
+
+        state.update_from_modal(result)  # Réutilise la méthode pour l'instant
+        state.agents_active += 1
+
+        return result
+
+    def _analyze_synthesis(
+        self, text: str, conv_logger: ConversationLogger, state: AnalysisState
+    ) -> Dict[str, Any]:
+        """Analyse de synthèse simulée unifiée."""
+
+        conv_logger.log_agent_message(
+            self.name,
+            "Je vais synthétiser les analyses informelle et modale pour produire une évaluation unifiée.",
+            "synthesis",
+        )
+
+        # Simulation d'unification des résultats
+        conv_logger.log_tool_call(
+            self.name,
+            "unify_analysis_results",
+            {
+                "informal_results": {"fallacies": state.fallacies_detected},
+                "formal_results": {"consistency": state.consistency_score},
+                "synthesis_strategy": "comprehensive",
+            },
+            {
+                "unified_score": 0.73,
+                "overall_validity": "questionable",
+                "main_issues": ["historical_distortion", "logical_inconsistency"],
+            },
+        )
+
+        result = {
+            "unified_score": 0.73,
+            "overall_validity": "questionable",
+            "recommendation": "Critical analysis required",
+        }
+
+        conv_logger.log_agent_message(
+            self.name,
+            f"Synthèse terminée. Score unifié : {result['unified_score']}. Le texte présente des faiblesses argumentatives significatives.",
+            "synthesis",
+        )
+
+        state.update_from_synthesis(result)
+        state.agents_active += 1
+
+        return result
+
+
+class ConversationOrchestrator:
+    """Orchestrateur conversationnel unifié compatible avec l'architecture Semantic Kernel."""
+
+    def __init__(self, mode: str = "demo", kernel=None):
+        self.mode = mode
+        self.kernel = kernel
+        self.conv_logger = ConversationLogger(mode)
+        self.state = AnalysisState()
+        self.logger = logging.getLogger(f"{__name__}.ConversationOrchestrator")
+        self._real_agents = {}  # Cache for real agent instances
+
+        # Configuration des agents selon le mode
+        self._setup_agents()
+
+        # Pour stockage du texte analysé
+        self.current_text = ""
+
+    def _kernel_has_llm(self) -> bool:
+        """Check if the kernel has at least one LLM service registered."""
+        try:
+            return bool(self.kernel and self.kernel.services)
+        except Exception:
+            return False
+
+    def _setup_agents(self):
+        """Configure les agents selon le mode."""
+        if self.mode == "real":
+            if self.kernel and self._kernel_has_llm():
+                self._setup_real_agents()
+            else:
+                self.logger.warning(
+                    "Mode 'real' requested but no kernel/LLM available. "
+                    "Falling back to 'demo' mode."
+                )
+                self.mode = "demo"
+                self._setup_simulated_agents()
+        elif self.mode == "micro":
+            self.agents = [
+                SimulatedAgent("InformalAgent", "informal"),
+                SimulatedAgent("ModalLogicAgent", "modal"),
+            ]
+        else:
+            self._setup_simulated_agents()
+
+        self.logger.info(f"Mode {self.mode}: {len(self.agents)} agents configurés")
+
+    def _setup_simulated_agents(self):
+        """Setup simulated agents for demo/trace/enhanced modes."""
+        self.agents = [
+            SimulatedAgent("InformalAnalysisAgent", "informal"),
+            SimulatedAgent("FOLLogicAgent", "fol_logic"),
+            SimulatedAgent("SynthesisAgent", "synthesis"),
+        ]
+
+    def _setup_real_agents(self):
+        """Create real LLM-backed agents. Falls back per-agent on failure."""
+        self.agents = []  # Not used in real mode
+
+        # 1. InformalAnalysisAgent
+        try:
+            from argumentation_analysis.agents.core.informal.informal_agent import (
+                InformalAnalysisAgent,
+            )
+
+            informal = InformalAnalysisAgent(
+                kernel=self.kernel,
+                agent_name="InformalAnalysisAgent",
+            )
+            self._real_agents["informal"] = informal
+            self.logger.info("Real InformalAnalysisAgent created")
+        except Exception as e:
+            self.logger.warning(f"Cannot create real InformalAnalysisAgent: {e}")
+
+        # 2. SynthesisAgent
+        try:
+            from argumentation_analysis.agents.core.synthesis.synthesis_agent import (
+                SynthesisAgent as RealSynthesisAgent,
+            )
+
+            synth = RealSynthesisAgent(
+                kernel=self.kernel,
+                agent_name="SynthesisAgent",
+            )
+            self._real_agents["synthesis"] = synth
+            self.logger.info("Real SynthesisAgent created")
+        except Exception as e:
+            self.logger.warning(f"Cannot create real SynthesisAgent: {e}")
+
+        if not self._real_agents:
+            self.logger.error("No real agents could be created. Falling back to demo.")
+            self.mode = "demo"
+            self._setup_simulated_agents()
+
+    def _adapt_real_result(self, agent_key: str, raw_result) -> Dict[str, Any]:
+        """Adapt real agent output to AnalysisState-compatible dict format."""
+        if isinstance(raw_result, dict):
+            result = raw_result
+        elif hasattr(raw_result, "model_dump"):
+            result = raw_result.model_dump()
+        else:
+            result = {"raw": str(raw_result)}
+
+        if agent_key == "informal":
+            fallacies = result.get("fallacies", [])
+            return {
+                "fallacies_count": len(fallacies),
+                "sophistication_score": min(len(fallacies) * 0.2 + 0.3, 1.0),
+                "main_issues": [
+                    f.get("type", f.get("fallacy_type", "unknown"))
+                    for f in fallacies[:5]
+                ],
+                "raw_result": result,
+            }
+        elif agent_key == "fol_logic":
+            return {
+                "formulas_count": len(result.get("formulas", [])),
+                "propositions_count": len(result.get("formulas", [])),
+                "consistency": 1.0 if result.get("consistency_check", False) else 0.5,
+                "logical_score": result.get("confidence_score", 0.5),
+                "contradictions": len(result.get("validation_errors", [])),
+                "satisfiable": result.get("consistency_check", True),
+                "raw_result": result,
+            }
+        elif agent_key == "synthesis":
+            return {
+                "unified_score": result.get("confidence_level", 0.5) or 0.5,
+                "overall_validity": str(result.get("overall_validity", "unknown")),
+                "recommendation": result.get("executive_summary", "N/A"),
+                "raw_result": result,
+            }
+        return result
+
+    async def _invoke_real_agent(self, agent_key: str, agent, text: str):
+        """Invoke the appropriate method on a real agent."""
+        if agent_key == "informal":
+            if hasattr(agent, "perform_complete_analysis"):
+                return await agent.perform_complete_analysis(text)
+            elif hasattr(agent, "analyze_text"):
+                return await agent.analyze_text(text, analysis_type="fallacies")
+            else:
+                raise AttributeError(
+                    "InformalAnalysisAgent has no suitable analysis method"
+                )
+        elif agent_key == "fol_logic":
+            if hasattr(agent, "analyze_text"):
+                return await agent.analyze_text(text)
+            else:
+                raise AttributeError("FOLLogicAgent has no suitable analysis method")
+        elif agent_key == "synthesis":
+            report = await agent.synthesize_analysis(text)
+            if hasattr(report, "model_dump"):
+                return report.model_dump()
+            return vars(report) if hasattr(report, "__dict__") else {"raw": str(report)}
+        else:
+            raise ValueError(f"Unknown agent key: {agent_key}")
+
+    async def _run_real_agent(
+        self, agent_key: str, agent, text: str, timeout: float = 60.0
+    ) -> Dict[str, Any]:
+        """Run a real agent with logging and timeout."""
+        import asyncio
+
+        agent_name = getattr(agent, "name", agent_key)
+
+        self.conv_logger.log_agent_message(
+            agent_name,
+            f"Starting real analysis ({agent_key})...",
+            f"{agent_key}_analysis",
+        )
+
+        try:
+            raw_result = await asyncio.wait_for(
+                self._invoke_real_agent(agent_key, agent, text),
+                timeout=timeout,
+            )
+        except asyncio.TimeoutError:
+            self.conv_logger.log_agent_message(
+                agent_name, f"Agent timed out after {timeout}s", "error"
+            )
+            return {"error": f"Timeout after {timeout}s"}
+        except Exception as e:
+            self.conv_logger.log_agent_message(
+                agent_name, f"Agent error: {str(e)[:200]}", "error"
+            )
+            return {"error": str(e)}
+
+        adapted = self._adapt_real_result(agent_key, raw_result)
+
+        self.conv_logger.log_tool_call(
+            agent_name,
+            f"real_{agent_key}_analysis",
+            {"text_length": len(text)},
+            adapted,
+        )
+
+        # Update state
+        if agent_key == "informal":
+            self.state.update_from_informal(adapted)
+        elif agent_key == "fol_logic":
+            self.state.update_from_modal(adapted)
+        elif agent_key == "synthesis":
+            self.state.update_from_synthesis(adapted)
+        self.state.agents_active += 1
+
+        self.conv_logger.log_agent_message(
+            agent_name,
+            f"Analysis complete. Result keys: {list(adapted.keys())}",
+            f"{agent_key}_analysis",
+        )
+
+        return adapted
+
+    async def run_orchestration_async(self, text: str) -> str:
+        """Execute orchestration with real LLM-backed agents (async)."""
+        if self.mode != "real":
+            return self.run_orchestration(text)
+
+        self.current_text = text
+        start_time = time.time()
+
+        self.logger.info(
+            f"Starting async orchestration mode 'real' for {len(text)} chars"
+        )
+
+        self.conv_logger.log_agent_message(
+            "ProjectManager",
+            f"Starting real LLM rhetorical analysis. "
+            f"Available agents: {list(self._real_agents.keys())}.",
+            "coordination",
+        )
+
+        self.state.phase = "active"
+        self.conv_logger.log_state_snapshot("initialization", self.state.to_dict())
+
+        agent_order = ["informal", "fol_logic", "synthesis"]
+
+        for agent_key in agent_order:
+            if agent_key not in self._real_agents:
+                self.logger.info(f"Agent '{agent_key}' not available, skipping")
+                continue
+
+            try:
+                await self._run_real_agent(
+                    agent_key, self._real_agents[agent_key], text
+                )
+                self.state.phase = f"post_{agent_key}"
+                self.conv_logger.log_state_snapshot(
+                    f"after_{agent_key}", self.state.to_dict()
+                )
+            except Exception as e:
+                self.logger.error(f"Agent '{agent_key}' failed: {e}")
+                self.conv_logger.log_agent_message(
+                    agent_key,
+                    f"Agent failed with error: {str(e)[:200]}",
+                    "error",
+                )
+
+        self.conv_logger.log_tool_call(
+            "ProjectManager",
+            "coordinate_final_synthesis",
+            {
+                "agents_results": len(self._real_agents),
+                "final_score": self.state.score,
+            },
+            {"coordination": "success", "status": "completed"},
+        )
+
+        self.conv_logger.log_agent_message(
+            "ProjectManager",
+            f"Real orchestration complete. Score: {self.state.score}.",
+            "conclusion",
+        )
+
+        self.state.phase = "completed"
+        self.state.completed = True
+        self.state.processing_time = time.time() - start_time
+        self.conv_logger.log_state_snapshot("final", self.state.to_dict())
+
+        self.logger.info(
+            f"Async orchestration completed in {self.state.processing_time:.3f}s"
+        )
+
+        return self.generate_report()
+
+    def run_orchestration(self, text: str) -> str:
+        """Exécute l'orchestration conversationnelle selon le mode."""
+
+        self.current_text = text
+        start_time = time.time()
+
+        self.logger.info(
+            f"Démarrage orchestration mode '{self.mode}' pour {len(text)} caractères"
+        )
+
+        # Message d'introduction du Project Manager
+        self.conv_logger.log_agent_message(
+            "ProjectManager",
+            f"Démarrage de l'orchestration d'analyse rhétorique en mode {self.mode}. Coordination des agents spécialisés.",
+            "coordination",
+        )
+
+        # État initial
+        self.state.phase = "active"
+        self.conv_logger.log_state_snapshot("initialization", self.state.to_dict())
+
+        # Coordination des agents
+        agents_list = ", ".join([a.name for a in self.agents])
+        self.conv_logger.log_agent_message(
+            "ProjectManager",
+            f"Agents disponibles : {agents_list}. Démarrage séquentiel des analyses.",
+            "coordination",
+        )
+
+        # Exécution séquentielle des analyses
+        for agent in self.agents:
+            # Limitation pour mode micro
+            if self.mode == "micro" and len(self.conv_logger.tool_calls) >= 4:
+                self.logger.info("Mode micro: limite d'outils atteinte")
+                break
+
+            try:
+                result = agent.analyze(text, self.conv_logger, self.state)
+
+                # Snapshot intermédiaire
+                self.state.phase = f"post_{agent.agent_type}"
+                self.conv_logger.log_state_snapshot(
+                    f"after_{agent.name}", self.state.to_dict()
+                )
+
+                self.logger.info(f"Agent {agent.name} terminé avec succès")
+
+            except Exception as e:
+                self.logger.error(f"Erreur agent {agent.name}: {e}")
+                # Continue avec les autres agents
+
+        # Coordination finale par le PM
+        self.conv_logger.log_tool_call(
+            "ProjectManager",
+            "coordinate_final_synthesis",
+            {"agents_results": len(self.agents), "final_score": self.state.score},
+            {
+                "coordination": "success",
+                "status": "completed",
+                "recommendation": "analysis_complete",
+            },
+        )
+
+        # Message de conclusion
+        self.conv_logger.log_agent_message(
+            "ProjectManager",
+            f"Orchestration terminée avec succès. Score final : {self.state.score}. Tous les agents ont contribué à l'analyse.",
+            "conclusion",
+        )
+
+        # État final
+        self.state.phase = "completed"
+        self.state.completed = True
+        self.state.processing_time = time.time() - start_time
+        self.conv_logger.log_state_snapshot("final", self.state.to_dict())
+        self.logger.info(f"Orchestration terminée en {self.state.processing_time:.3f}s")
+
+        warnings.warn(
+            "`ConversationOrchestrator` is deprecated and will be removed in a future version. "
+            "Please use `analysis_runner` for new implementations. "
+            "This class is maintained for backward compatibility only.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+        return self.generate_report()
+
+    def generate_report(self) -> str:
+        """Génère le rapport conversationnel unifié avec chronologie intégrée."""
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        total_time = (time.time() - self.conv_logger.start_time) * 1000
+
+        # Informations sur l'extrait analysé
+        text_size = len(self.current_text) if self.current_text else 0
+        text_words = len(self.current_text.split()) if self.current_text else 0
+
+        report = f"""# TRACE ANALYTIQUE - LOGIQUE MODALE INTEGREE
+===
+
+## 📄 EXTRAIT ANALYSE
+- **Source:** Texte libre (analyse modale)
+- **Taille:** {text_size} caractères, {text_words} mots
+- **Type:** Argumentation juridico-politique avec modalités logiques
+- **Extrait:** "{self.current_text[:100]}{'...' if text_size > 100 else ''}"
+
+## ⏱️ METADONNEES D'EXECUTION
+- **Timestamp:** {timestamp}
+- **Mode:** {self.mode} (capture conversationnelle)
+- **Durée totale:** {total_time:.1f}ms
+- **Agents orchestrés:** {self.state.agents_active}
+
+## 🎭 TRACE CONVERSATIONNELLE CHRONOLOGIQUE
+"""
+
+        # Fusionner et trier les événements par timestamp
+        all_events = []
+
+        # Ajouter les messages
+        for msg in self.conv_logger.messages:
+            all_events.append(
+                {"type": "message", "timestamp": msg["time_ms"], "data": msg}
+            )
+
+        # Ajouter les appels d'outils
+        for tool in self.conv_logger.tool_calls:
+            all_events.append(
+                {"type": "tool", "timestamp": tool["time_ms"], "data": tool}
+            )
+
+        # Tri chronologique
+        all_events.sort(key=lambda x: x["timestamp"])
+
+        # Génération de la trace chronologique
+        for event in all_events:
+            if event["type"] == "message":
+                msg = event["data"]
+                report += f"""
+### [{msg['time_ms']:.1f}ms] 💬 **{msg['agent']}**
+**Phase:** {msg['phase']}
+**Message:** *"{msg['message']}"*
+"""
+            elif event["type"] == "tool":
+                tool = event["data"]
+                status = "✅" if tool["success"] else "❌"
+                report += f"""
+### [{tool['time_ms']:.1f}ms] 🔧 **APPEL OUTIL** {status}
+**Agent:** {tool['agent']}
+**Outil:** `{tool['tool']}`
+**Arguments:** {tool['arguments']}
+**Résultat:** {tool['result']}
+"""
+
+        # États significatifs uniquement
+        significant_states = [
+            s
+            for s in self.conv_logger.state_snapshots
+            if s["phase"] in ["after_ModalLogicAgent", "final"]
+        ]
+
+        if significant_states:
+            report += "\n## 📊 EVOLUTION DES METRIQUES CLES\n"
+            for state in significant_states:
+                report += f"""
+**Phase {state['phase']} [{state['timestamp']*1000:.1f}ms]:**
+"""
+                key_metrics = [
+                    "score",
+                    "fallacies_detected",
+                    "propositions_found",
+                    "consistency_score",
+                ]
+                for key in key_metrics:
+                    if key in state["data"]:
+                        report += f"- {key}: {state['data'][key]}  "
+                report += "\n"
+
+        # Résumé final enrichi
+        report += f"""
+## 🎯 BILAN D'ANALYSE MODALE
+- **Score global:** {self.state.score:.3f}/1.0
+- **Modalités extraites:** {self.state.propositions_found} (nécessité/possibilité)
+- **Cohérence logique:** {self.state.consistency_score:.2f}/1.0
+- **Sophismes détectés:** {self.state.fallacies_detected}
+- **Statut:** {"✅ Analyse complète" if self.state.completed else "⏳ En cours"}
+
+## 🔍 DIAGNOSTIC TECHNIQUE
+- **Performance:** {total_time:.1f}ms (mode {self.mode})
+- **Messages capturés:** {len(self.conv_logger.messages)} échanges
+- **Outils utilisés:** {len(self.conv_logger.tool_calls)} appels
+- **Pipeline modal:** {"✅ Opérationnel" if self.state.completed else "❌ Interrompu"}
+
+---
+*Trace générée par Enhanced PM Orchestration v2.0 - Mode chronologique intégré*
+"""
+
+        return report
+
+    def get_conversation_state(self) -> Dict[str, Any]:
+        """Retourne l'état de la conversation pour intégration externe."""
+        return {
+            "mode": self.mode,
+            "state": self.state.to_dict(),
+            "messages_count": len(self.conv_logger.messages),
+            "tools_count": len(self.conv_logger.tool_calls),
+            "processing_time": self.state.processing_time,
+            "completed": self.state.completed,
+        }
+
+    async def run_demo_conversation(self, text: str) -> Dict[str, Any]:
+        """
+        Interface asynchrone pour le pipeline unifié.
+
+        Args:
+            text: Texte à analyser
+
+        Returns:
+            Dict contenant les résultats de l'orchestration
+        """
+        if self.mode == "real":
+            report = await self.run_orchestration_async(text)
+        else:
+            report = self.run_orchestration(text)
+
+        return {
+            "status": "success",
+            "report": report,
+            "conversation_state": self.get_conversation_state(),
+            "text_analyzed": text,
+            "mode": self.mode,
+        }
+
+    async def run_conversation(self, text: str) -> Dict[str, Any]:
+        """Alias for run_demo_conversation (expected by MainOrchestrator)."""
+        return await self.run_demo_conversation(text)
+
+
+def create_conversation_orchestrator(
+    mode: str = "demo", kernel=None
+) -> ConversationOrchestrator:
+    """Factory pour créer un orchestrateur conversationnel."""
+    logger.info(f"Création orchestrateur conversationnel mode {mode}")
+    return ConversationOrchestrator(mode=mode, kernel=kernel)
+
+
+# Fonctions de mode pour compatibilité avec l'interface existante
+def run_mode_micro(text: str) -> str:
+    """Mode micro : orchestration ultra-légère."""
+    orchestrator = create_conversation_orchestrator("micro")
+    return orchestrator.run_orchestration(text)
+
+
+def run_mode_demo(text: str) -> str:
+    """Mode demo : démonstration complète."""
+    orchestrator = create_conversation_orchestrator("demo")
+    return orchestrator.run_orchestration(text)
+
+
+def run_mode_trace(text: str) -> str:
+    """Mode trace : test du système de traçage."""
+    orchestrator = create_conversation_orchestrator("trace")
+    return orchestrator.run_orchestration(text)
+
+
+def run_mode_enhanced(text: str) -> str:
+    """Mode enhanced : test des composants PM améliorés."""
+    orchestrator = create_conversation_orchestrator("enhanced")
+    return orchestrator.run_orchestration(text)

--- a/docs/archives/orchestration_legacy/logique_complexe_orchestrator.py
+++ b/docs/archives/orchestration_legacy/logique_complexe_orchestrator.py
@@ -1,0 +1,117 @@
+# ARCHIVED: 2026-06-02 (B-09 #875)
+# Original path: argumentation_analysis/orchestration/logique_complexe_orchestrator.py
+# Reason: Mock stub — run_einstein_puzzle() returns hardcoded result after asyncio.sleep(0.01).
+#         Zero functional value. All callers have ImportError guards.
+# Superseded-by: FOLLogicAgent + TweetyLogicPlugin via CapabilityRegistry.
+# Removed-from: argumentation_analysis/orchestration/__init__.py, engine/main_orchestrator.py,
+#               pipelines/unified_pipeline.py, pipelines/orchestration/.../logic_orchestrator.py
+# Tests archived: tests/unit/orchestration/test_specialized_orchestrators.py (2 tests)
+# ---
+# argumentation_analysis/orchestration/logique_complexe_orchestrator.py
+
+import logging
+import warnings
+import asyncio
+from typing import Optional, List, Dict, Any
+from semantic_kernel import Kernel
+
+# PURGE PHASE 3A: Utilisation des définitions minimales de cluedo_extended_orchestrator
+# pour Agent, SelectionStrategy, etc. car semantic_kernel.agents n'est pas disponible.
+# Note: AgentGroupChat et ChatCompletionAgent ne sont pas directement remplacés ici,
+# leur usage devra être adapté ou ces classes devront être définies localement si nécessaires.
+# Pour l'instant, on commente les imports directs qui échoueraient.
+# from semantic_kernel.agents import AgentGroupChat, ChatCompletionAgent # N'existe pas dans SK 0.9.6b1
+
+# Import des définitions de base depuis l'orchestrateur principal
+from argumentation_analysis.orchestration.cluedo_components.strategies import (
+    CyclicSelectionStrategy,
+)
+from .base import Agent, SelectionStrategy, TerminationStrategy
+
+# Si AgentGroupChat ou ChatCompletionAgent sont réellement utilisés, il faudra les définir ici
+# ou adapter le code pour utiliser des mécanismes d'orchestration plus simples.
+# Les définitions locales de SequentialSelectionStrategy, ChatCompletionAgent et AgentGroupChat ont été supprimées.
+# Il faudra s'assurer que les usages restants sont compatibles avec les classes de semantic_kernel 1.32.2
+# ou avec les définitions de cluedo_extended_orchestrator.
+
+# Tentative d'import des classes AgentGroupChat et ChatCompletionAgent depuis semantic_kernel.agents
+# Si cela échoue, le code qui les utilise devra être adapté.
+# try:
+#     from semantic_kernel.agents import AgentGroupChat as SKAgentGroupChat
+#     from semantic_kernel.agents import ChatCompletionAgent as SKChatCompletionAgent
+#     # Si l'import réussit, on pourrait les utiliser. Sinon, il faudra une autre solution.
+# except ImportError:
+#     # Fallback: si les imports directs échouent, on loggue un avertissement.
+#     # Le code plus bas qui utilise AgentGroupChat ou ChatCompletionAgent pourrait planter
+#     # ou devra être adapté pour utiliser GroupChatOrchestration ou Agent de cluedo_extended_orchestrator.
+#     logging.warning("Impossible d'importer AgentGroupChat ou ChatCompletionAgent depuis semantic_kernel.agents. "
+#                     "Les fonctionnalités dépendantes pourraient être affectées.")
+#     # On définit des placeholders pour éviter des NameError immédiats si le code n'est pas entièrement purgé
+#     # de leurs références, mais cela ne les rendra pas fonctionnels.
+#     class SKAgentGroupChat: pass
+#     class SKChatCompletionAgent(Agent): pass # Hérite de notre Agent de base pour un minimum de structure
+
+
+# Le code suivant qui instancie AgentGroupChat devra être vérifié.
+# S'il utilisait la version locale, il doit maintenant être compatible avec SKAgentGroupChat
+# ou une alternative.
+
+# Exemple d'adaptation (si AgentGroupChat local était utilisé) :
+# La classe LogiqueComplexeOrchestrator pourrait avoir besoin d'être révisée
+# pour utiliser GroupChatOrchestration de cluedo_extended_orchestrator,
+# ou pour que SKAgentGroupChat soit compatible.
+
+# Pour l'instant, on se concentre sur la suppression des définitions locales.
+# La logique d'instanciation de AgentGroupChat dans ce fichier est :
+# class AgentGroupChat: (supprimée)
+#   def __init__(... selection_strategy: Optional[SelectionStrategy] = None ...):
+#       self.selection_strategy = selection_strategy or SequentialSelectionStrategy(self.agents) (SequentialSelectionStrategy locale supprimée)
+
+# Si une classe AgentGroupChat est toujours nécessaire ici, elle devrait être SKAgentGroupChat.
+# Et sa `selection_strategy` devrait être compatible.
+# `CyclicSelectionStrategy` est importée depuis cluedo_extended_orchestrator.
+
+# Si ce fichier définit une classe qui hérite ou utilise AgentGroupChat,
+# cette partie devra être adaptée.
+# Par exemple, si une classe OrchestrateurLogiqueComplexe existe et fait :
+# self.chat = AgentGroupChat(agents=..., selection_strategy=CyclicSelectionStrategy(...))
+# alors AgentGroupChat doit être SKAgentGroupChat et compatible.
+
+# Pour l'instant, je supprime les définitions locales.
+# La correction complète de l'utilisation de AgentGroupChat et ChatCompletionAgent
+# dans ce fichier dépendra de leur usage réel plus bas, que je n'ai pas encore vu.
+# Je vais supposer pour l'instant que le code plus bas sera adapté ou n'utilise pas ces versions locales.
+
+# La classe LogiqueComplexeOrchestrator elle-même n'est pas dans cet extrait.
+# Je vais me concentrer sur la suppression des définitions de classes fallbacks.
+# L'initialisation de `self.selection_strategy` dans la classe AgentGroupChat locale
+# utilisait `SequentialSelectionStrategy(self.agents)`.
+# Si `SKAgentGroupChat` est utilisé, il faudra voir comment il gère la stratégie.
+# `CyclicSelectionStrategy` est maintenant importée et pourrait être passée à `SKAgentGroupChat`
+# si son constructeur accepte un `selection_strategy`.
+
+
+# Définition minimale pour LogiqueComplexeOrchestrator
+class LogiqueComplexeOrchestrator:
+    def __init__(self, kernel: Kernel = None, **kwargs):
+        warnings.warn(
+            "`LogiqueComplexeOrchestrator` is deprecated and contains minimal logic. "
+            "It is maintained for backward compatibility only. "
+            "Please use the new agent group chat architecture for new implementations.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._logger = logging.getLogger(self.__class__.__name__)
+        self.kernel = kernel
+        self._logger.info(
+            "LogiqueComplexeOrchestrator initialisé (définition minimale)."
+        )
+
+    async def run_einstein_puzzle(self, puzzle_data: Dict[str, Any]) -> Dict[str, Any]:
+        self._logger.info("Exécution du puzzle Einstein (simulation minimale).")
+        # Simulation d'une exécution
+        await asyncio.sleep(0.01)
+        return {
+            "solution": "L'Allemand possède le poisson (simulation)",
+            "success": True,
+        }

--- a/docs/archives/orchestration_legacy/real_llm_orchestrator_shim.py
+++ b/docs/archives/orchestration_legacy/real_llm_orchestrator_shim.py
@@ -1,0 +1,130 @@
+# ARCHIVED: 2026-06-02 (B-09 #875) — Moved from argumentation_analysis/orchestration/
+# Previously archived: 2026-03-24 — Minimal shim for backward compatibility (#215)
+# Original: 668-line orchestrator with analysis_map routing, superseded by
+#           unified_pipeline.py (WorkflowDSL + CapabilityRegistry)
+# Superseded-by: UnifiedPipeline + WorkflowDSL + CapabilityRegistry.
+# Removed-from: orchestration/__init__.py, service_manager.py, engine/main_orchestrator.py,
+#               pipelines/unified_pipeline.py, unified_text_analysis.py
+# Tests removed: tests/unit/argumentation_analysis/orchestration/test_real_llm_orchestrator.py (5 tests)
+#   tests/unit/orchestration/test_unified_orchestrations.py (RealLLM sections)
+# Full archive: docs/archives/orchestration_legacy/real_llm_orchestrator.py
+"""
+Shim module for RealLLMOrchestrator backward compatibility.
+
+DEPRECATED: Use these alternatives instead:
+- For pipeline orchestration: argumentation_analysis.orchestration.unified_pipeline.UnifiedPipeline
+- For conversational analysis: argumentation_analysis.orchestration.conversation_orchestrator.ConversationOrchestrator
+- For analysis requests: argumentation_analysis.core.shared_state.UnifiedAnalysisState
+"""
+
+import warnings
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Any, Optional
+
+
+@dataclass
+class LLMAnalysisRequest:
+    """DEPRECATED: Structure for LLM analysis requests.
+
+    Use UnifiedAnalysisState or direct agent invocation instead.
+    """
+
+    text: str
+    analysis_type: str
+    context: Optional[Dict[str, Any]] = None
+    parameters: Optional[Dict[str, Any]] = None
+    timeout: int = 30
+
+
+@dataclass
+class LLMAnalysisResult:
+    """DEPRECATED: Structure for LLM analysis results.
+
+    Use UnifiedAnalysisState or analysis plugins instead.
+    """
+
+    request_id: str
+    analysis_type: str
+    result: Dict[str, Any]
+    confidence: float
+    processing_time: float
+    timestamp: datetime
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class RealLLMOrchestrator:
+    """DEPRECATED: Use UnifiedPipeline or ConversationOrchestrator instead.
+
+    This class was a 668-line orchestrator managing multiple analysis types
+    through an analysis_map routing system. It has been superseded by:
+
+    - UnifiedPipeline: Modern pipeline with phase-based orchestration
+    - ConversationOrchestrator: Multi-agent conversational orchestration
+    - AnalysisToolsPlugin: Direct plugin-based analysis
+
+    See docs/architecture/ORCHESTRATION_MODES.md for migration guidance.
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "RealLLMOrchestrator is deprecated and will be removed in a future version. "
+            "Use UnifiedPipeline for pipeline orchestration or ConversationOrchestrator "
+            "for conversational multi-agent analysis. "
+            "See docs/architecture/ORCHESTRATION_MODES.md for migration guidance.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    async def analyze_text(self, *args, **kwargs):
+        raise NotImplementedError(
+            "RealLLMOrchestrator has been archived. Use:\n"
+            "  - UnifiedPipeline.run_unified_analysis() for pipeline orchestration\n"
+            "  - run_conversational_analysis() for multi-agent dialogue\n"
+            "See docs/architecture/ORCHESTRATION_MODES.md for details."
+        )
+
+    async def initialize(self, *args, **kwargs):
+        raise NotImplementedError(
+            "RealLLMOrchestrator has been archived. Initialize UnifiedPipeline instead."
+        )
+
+
+# Alias for backward compatibility - imports ConversationLogger from conversation_orchestrator
+# This maintains the original export pattern without code duplication
+def _get_conversation_logger():
+    """Lazy import to avoid circular dependencies."""
+    from .conversation_orchestrator import ConversationLogger
+
+    return ConversationLogger
+
+
+# Create the alias class dynamically for import compatibility
+class RealConversationLogger:
+    """DEPRECATED: Alias for ConversationLogger from conversation_orchestrator.
+
+    Use: from argumentation_analysis.orchestration.conversation_orchestrator import ConversationLogger
+    """
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "RealConversationLogger is deprecated. Import ConversationLogger directly "
+            "from argumentation_analysis.orchestration.conversation_orchestrator",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        # Delegate to actual ConversationLogger
+        ConversationLogger = _get_conversation_logger()
+        self._logger = ConversationLogger(*args, **kwargs)
+
+    def __getattr__(self, name):
+        return getattr(self._logger, name)
+
+
+# Export list for backward compatibility
+__all__ = [
+    "RealLLMOrchestrator",
+    "LLMAnalysisRequest",
+    "LLMAnalysisResult",
+    "RealConversationLogger",
+]

--- a/docs/archives/orchestration_legacy/test_conversation_orchestrator.py
+++ b/docs/archives/orchestration_legacy/test_conversation_orchestrator.py
@@ -1,0 +1,322 @@
+# tests/unit/argumentation_analysis/orchestration/test_conversation_orchestrator.py
+"""Tests for ConversationOrchestrator, ConversationLogger, AnalysisState, SimulatedAgent."""
+
+import pytest
+from unittest.mock import patch
+
+from argumentation_analysis.orchestration.conversation_orchestrator import (
+    ConversationLogger,
+    AnalysisState,
+    SimulatedAgent,
+    ConversationOrchestrator,
+    create_conversation_orchestrator,
+    run_mode_micro,
+    run_mode_demo,
+    run_mode_trace,
+    run_mode_enhanced,
+)
+
+SAMPLE_TEXT = "Les mesures fermes sont nécessaires pour maintenir l'ordre et la stabilité du pays."
+
+
+# ── ConversationLogger ──
+
+
+class TestConversationLogger:
+    def test_micro_mode_limits(self):
+        cl = ConversationLogger(mode="micro")
+        assert cl.max_messages == 8
+        assert cl.max_tools == 6
+        assert cl.max_states == 3
+        assert cl.max_message_len == 150
+
+    def test_demo_mode_limits(self):
+        cl = ConversationLogger(mode="demo")
+        assert cl.max_messages == 20
+        assert cl.max_tools == 15
+        assert cl.max_states == 8
+        assert cl.max_message_len == 300
+
+    def test_log_agent_message(self):
+        cl = ConversationLogger(mode="trace")
+        cl.log_agent_message("Sherlock", "Test message", "analysis")
+        assert len(cl.messages) == 1
+        assert cl.messages[0]["agent"] == "Sherlock"
+        assert cl.messages[0]["phase"] == "analysis"
+
+    def test_message_truncation(self):
+        cl = ConversationLogger(mode="micro")
+        long_msg = "A" * 300
+        cl.log_agent_message("Agent", long_msg)
+        assert len(cl.messages[0]["message"]) <= 150
+
+    def test_max_messages_enforced(self):
+        cl = ConversationLogger(mode="micro")
+        for i in range(20):
+            cl.log_agent_message("Agent", f"msg {i}")
+        assert len(cl.messages) == 8  # micro limit
+
+    def test_log_tool_call(self):
+        cl = ConversationLogger(mode="trace")
+        cl.log_tool_call("Agent", "detect_fallacy", {"text": "x"}, {"result": True})
+        assert len(cl.tool_calls) == 1
+        assert cl.tool_calls[0]["tool"] == "detect_fallacy"
+        assert cl.tool_calls[0]["success"] is True
+
+    def test_tool_call_truncation(self):
+        cl = ConversationLogger(mode="trace")
+        long_args = {"text": "X" * 200}
+        cl.log_tool_call("Agent", "tool", long_args, "R" * 200)
+        assert len(cl.tool_calls[0]["arguments"]) <= 100
+        assert len(cl.tool_calls[0]["result"]) <= 150
+
+    def test_max_tools_enforced(self):
+        cl = ConversationLogger(mode="micro")
+        for i in range(10):
+            cl.log_tool_call("Agent", f"tool_{i}", {}, "ok")
+        assert len(cl.tool_calls) == 6  # micro limit
+
+    def test_log_state_snapshot(self):
+        cl = ConversationLogger(mode="trace")
+        cl.log_state_snapshot("init", {"score": 0.5})
+        assert len(cl.state_snapshots) == 1
+        assert cl.state_snapshots[0]["phase"] == "init"
+
+    def test_max_states_enforced(self):
+        cl = ConversationLogger(mode="micro")
+        for i in range(10):
+            cl.log_state_snapshot(f"phase_{i}", {})
+        assert len(cl.state_snapshots) == 3  # micro limit
+
+    def test_timestamp_relative(self):
+        cl = ConversationLogger(mode="trace")
+        cl.log_agent_message("Agent", "test")
+        assert cl.messages[0]["time_ms"] >= 0
+
+
+# ── AnalysisState ──
+
+
+class TestAnalysisState:
+    def test_initial_state(self):
+        state = AnalysisState()
+        assert state.score == 0.0
+        assert state.agents_active == 0
+        assert state.fallacies_detected == 0
+        assert state.phase == "initialization"
+        assert state.completed is False
+
+    def test_update_from_informal(self):
+        state = AnalysisState()
+        state.update_from_informal({"fallacies_count": 3, "sophistication_score": 0.8})
+        assert state.fallacies_detected == 3
+        assert state.score == pytest.approx(0.32)  # 0.8 * 0.4
+
+    def test_update_from_modal(self):
+        state = AnalysisState()
+        state.update_from_modal(
+            {"propositions_count": 5, "consistency": 0.9, "logical_score": 0.7}
+        )
+        assert state.propositions_found == 5
+        assert state.consistency_score == 0.9
+        assert state.score == pytest.approx(0.21)  # 0.7 * 0.3
+
+    def test_update_from_synthesis(self):
+        state = AnalysisState()
+        state.update_from_synthesis({"unified_score": 0.73})
+        assert state.completed is True
+        assert state.score == pytest.approx(0.219)  # 0.73 * 0.3
+
+    def test_to_dict(self):
+        state = AnalysisState()
+        state.score = 0.5
+        state.fallacies_detected = 2
+        d = state.to_dict()
+        assert d["score"] == 0.5
+        assert d["fallacies_detected"] == 2
+        assert "phase" in d
+
+    def test_to_rhetorical_state_completed(self):
+        state = AnalysisState()
+        state.completed = True
+        rs = state.to_rhetorical_state()
+        from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+
+        assert isinstance(rs, RhetoricalAnalysisState)
+        assert rs.final_conclusion is not None
+
+    def test_to_rhetorical_state_active(self):
+        state = AnalysisState()
+        rs = state.to_rhetorical_state()
+        from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+
+        assert isinstance(rs, RhetoricalAnalysisState)
+        assert rs.final_conclusion is None
+
+    def test_agent_results_stored(self):
+        state = AnalysisState()
+        state.update_from_informal({"fallacies_count": 1, "sophistication_score": 0.5})
+        assert "informal" in state.agent_results
+
+    def test_cumulative_scoring(self):
+        state = AnalysisState()
+        state.update_from_informal({"fallacies_count": 2, "sophistication_score": 1.0})
+        state.update_from_modal(
+            {"propositions_count": 3, "consistency": 0.8, "logical_score": 1.0}
+        )
+        state.update_from_synthesis({"unified_score": 1.0})
+        assert state.score == pytest.approx(1.0)  # 0.4 + 0.3 + 0.3
+
+
+# ── SimulatedAgent ──
+
+
+class TestSimulatedAgent:
+    def test_informal_agent(self):
+        agent = SimulatedAgent("TestAgent", "informal")
+        cl = ConversationLogger(mode="trace")
+        state = AnalysisState()
+        result = agent.analyze(SAMPLE_TEXT, cl, state)
+        assert result["fallacies_count"] == 2
+        assert state.fallacies_detected == 2
+        assert state.agents_active == 1
+        assert len(cl.messages) > 0
+        assert len(cl.tool_calls) > 0
+
+    def test_fol_logic_agent(self):
+        agent = SimulatedAgent("FOLAgent", "fol_logic")
+        cl = ConversationLogger(mode="trace")
+        state = AnalysisState()
+        result = agent.analyze(SAMPLE_TEXT, cl, state)
+        assert "formulas_count" in result
+        assert state.agents_active == 1
+
+    def test_synthesis_agent(self):
+        agent = SimulatedAgent("SynthAgent", "synthesis")
+        cl = ConversationLogger(mode="trace")
+        state = AnalysisState()
+        result = agent.analyze(SAMPLE_TEXT, cl, state)
+        assert result["unified_score"] == 0.73
+        assert state.completed is True
+
+    def test_unknown_agent_type(self):
+        agent = SimulatedAgent("Unknown", "unknown_type")
+        cl = ConversationLogger(mode="trace")
+        state = AnalysisState()
+        result = agent.analyze(SAMPLE_TEXT, cl, state)
+        assert "error" in result
+
+
+# ── ConversationOrchestrator ──
+
+
+class TestConversationOrchestrator:
+    def test_micro_mode_setup(self):
+        orch = ConversationOrchestrator(mode="micro")
+        assert len(orch.agents) == 2
+        assert orch.mode == "micro"
+
+    def test_demo_mode_setup(self):
+        orch = ConversationOrchestrator(mode="demo")
+        assert len(orch.agents) == 3
+
+    @patch("builtins.print")
+    def test_run_orchestration_demo(self, mock_print):
+        orch = ConversationOrchestrator(mode="demo")
+        report = orch.run_orchestration(SAMPLE_TEXT)
+        assert isinstance(report, str)
+        assert "TRACE ANALYTIQUE" in report
+        assert orch.state.completed is True
+        assert orch.state.processing_time > 0
+
+    @patch("builtins.print")
+    def test_run_orchestration_micro(self, mock_print):
+        orch = ConversationOrchestrator(mode="micro")
+        report = orch.run_orchestration(SAMPLE_TEXT)
+        assert isinstance(report, str)
+        assert len(orch.conv_logger.tool_calls) <= 6
+
+    def test_run_orchestration_trace_no_print(self):
+        orch = ConversationOrchestrator(mode="trace")
+        report = orch.run_orchestration(SAMPLE_TEXT)
+        assert isinstance(report, str)
+
+    @patch("builtins.print")
+    def test_generate_report_content(self, mock_print):
+        orch = ConversationOrchestrator(mode="demo")
+        orch.run_orchestration(SAMPLE_TEXT)
+        report = orch.generate_report()
+        assert "Score global" in report
+        assert "Messages capturés" in report
+        assert "Outils utilisés" in report
+
+    @patch("builtins.print")
+    def test_get_conversation_state(self, mock_print):
+        orch = ConversationOrchestrator(mode="demo")
+        orch.run_orchestration(SAMPLE_TEXT)
+        state = orch.get_conversation_state()
+        assert state["mode"] == "demo"
+        assert state["completed"] is True
+        assert state["messages_count"] > 0
+        assert state["tools_count"] > 0
+
+    @pytest.mark.asyncio
+    @patch("builtins.print")
+    async def test_run_demo_conversation(self, mock_print):
+        orch = ConversationOrchestrator(mode="demo")
+        result = await orch.run_demo_conversation(SAMPLE_TEXT)
+        assert result["status"] == "success"
+        assert "report" in result
+        assert result["mode"] == "demo"
+
+    @patch("builtins.print")
+    def test_agent_error_handled(self, mock_print):
+        orch = ConversationOrchestrator(mode="demo")
+
+        # Replace first agent with one that raises
+        class FailingAgent:
+            name = "FailAgent"
+            agent_type = "informal"
+
+            def analyze(self, text, cl, state):
+                raise RuntimeError("Agent failure")
+
+        orch.agents[0] = FailingAgent()
+        # Should not raise — errors are caught
+        report = orch.run_orchestration(SAMPLE_TEXT)
+        assert isinstance(report, str)
+
+    @patch("builtins.print")
+    def test_report_contains_text_excerpt(self, mock_print):
+        orch = ConversationOrchestrator(mode="demo")
+        report = orch.run_orchestration("Short test text.")
+        assert "Short test text." in report
+
+
+# ── Factory and mode functions ──
+
+
+class TestFactoryAndModes:
+    def test_create_conversation_orchestrator(self):
+        orch = create_conversation_orchestrator("trace")
+        assert isinstance(orch, ConversationOrchestrator)
+        assert orch.mode == "trace"
+
+    @patch("builtins.print")
+    def test_run_mode_micro(self, mock_print):
+        report = run_mode_micro(SAMPLE_TEXT)
+        assert isinstance(report, str)
+
+    @patch("builtins.print")
+    def test_run_mode_demo(self, mock_print):
+        report = run_mode_demo(SAMPLE_TEXT)
+        assert isinstance(report, str)
+
+    def test_run_mode_trace(self):
+        report = run_mode_trace(SAMPLE_TEXT)
+        assert isinstance(report, str)
+
+    @patch("builtins.print")
+    def test_run_mode_enhanced(self, mock_print):
+        report = run_mode_enhanced(SAMPLE_TEXT)
+        assert isinstance(report, str)

--- a/docs/archives/orchestration_legacy/test_conversation_orchestrator_real.py
+++ b/docs/archives/orchestration_legacy/test_conversation_orchestrator_real.py
@@ -1,0 +1,316 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for ConversationOrchestrator with mode='real' (LLM-backed agents).
+
+Covers: real mode setup, fallback behavior, async orchestration with mocked
+real agents, result adaptation, factory with kernel parameter.
+"""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from argumentation_analysis.orchestration.conversation_orchestrator import (
+    ConversationOrchestrator,
+    AnalysisState,
+    create_conversation_orchestrator,
+)
+
+# ============================================================
+# Real mode setup & fallback
+# ============================================================
+
+
+class TestRealModeSetup:
+    def test_real_mode_without_kernel_falls_back_to_demo(self):
+        """No kernel => fallback to demo mode with simulated agents."""
+        orch = ConversationOrchestrator(mode="real")
+        assert orch.mode == "demo"
+        assert len(orch.agents) == 3
+
+    def test_real_mode_with_empty_kernel_services_falls_back(self):
+        """Kernel with empty services => fallback to demo."""
+        kernel = MagicMock()
+        kernel.services = {}
+        orch = ConversationOrchestrator(mode="real", kernel=kernel)
+        assert orch.mode == "demo"
+
+    def test_real_mode_kernel_has_llm_check(self):
+        """_kernel_has_llm returns True when services exist."""
+        orch = ConversationOrchestrator(mode="demo")
+        assert orch._kernel_has_llm() is False
+
+        orch.kernel = MagicMock()
+        orch.kernel.services = {"default": MagicMock()}
+        assert orch._kernel_has_llm() is True
+
+    def test_demo_mode_unchanged_with_kernel(self):
+        """Demo mode works exactly as before even when kernel is provided."""
+        kernel = MagicMock()
+        kernel.services = {"default": MagicMock()}
+        orch = ConversationOrchestrator(mode="demo", kernel=kernel)
+        assert orch.mode == "demo"
+        assert len(orch.agents) == 3
+        assert orch.kernel is kernel
+
+    def test_micro_mode_unchanged(self):
+        """Micro mode still creates 2 simulated agents."""
+        orch = ConversationOrchestrator(mode="micro")
+        assert len(orch.agents) == 2
+        assert orch.mode == "micro"
+
+    def test_kernel_stored_on_instance(self):
+        """Kernel is stored as instance attribute."""
+        kernel = MagicMock()
+        orch = ConversationOrchestrator(mode="demo", kernel=kernel)
+        assert orch.kernel is kernel
+
+    def test_real_agents_dict_empty_for_demo(self):
+        """Demo mode has empty _real_agents dict."""
+        orch = ConversationOrchestrator(mode="demo")
+        assert orch._real_agents == {}
+
+
+# ============================================================
+# Result adaptation
+# ============================================================
+
+
+class TestResultAdaptation:
+    @pytest.fixture
+    def orch(self):
+        return ConversationOrchestrator(mode="demo")
+
+    def test_adapt_informal_result(self, orch):
+        result = orch._adapt_real_result(
+            "informal",
+            {
+                "fallacies": [
+                    {"fallacy_type": "ad_hominem", "confidence": 0.9},
+                    {"fallacy_type": "false_cause", "confidence": 0.7},
+                ],
+            },
+        )
+        assert result["fallacies_count"] == 2
+        assert result["sophistication_score"] > 0
+        assert "ad_hominem" in result["main_issues"]
+
+    def test_adapt_informal_empty(self, orch):
+        result = orch._adapt_real_result("informal", {"fallacies": []})
+        assert result["fallacies_count"] == 0
+        assert result["sophistication_score"] == 0.3  # baseline
+
+    def test_adapt_fol_result(self, orch):
+        result = orch._adapt_real_result(
+            "fol_logic",
+            {
+                "formulas": ["forall X: (P(X) => Q(X))"],
+                "consistency_check": True,
+                "confidence_score": 0.8,
+            },
+        )
+        assert result["formulas_count"] == 1
+        assert result["logical_score"] == 0.8
+        assert result["consistency"] == 1.0
+
+    def test_adapt_synthesis_result(self, orch):
+        result = orch._adapt_real_result(
+            "synthesis",
+            {
+                "confidence_level": 0.65,
+                "overall_validity": True,
+                "executive_summary": "Good argument",
+            },
+        )
+        assert result["unified_score"] == 0.65
+        assert result["recommendation"] == "Good argument"
+
+    def test_adapt_unknown_agent_returns_raw(self, orch):
+        result = orch._adapt_real_result("unknown", {"key": "value"})
+        assert result == {"key": "value"}
+
+    def test_adapt_non_dict_result(self, orch):
+        mock_result = MagicMock()
+        mock_result.model_dump.return_value = {"field": 42}
+        result = orch._adapt_real_result("synthesis", mock_result)
+        assert result["unified_score"] == 0.5  # default
+
+    def test_adapt_string_result(self, orch):
+        result = orch._adapt_real_result("informal", "not a dict")
+        # String gets wrapped as {"raw": "not a dict"} then adapted
+        assert result["fallacies_count"] == 0
+        assert "raw_result" in result
+
+
+# ============================================================
+# Async orchestration with mocked agents
+# ============================================================
+
+
+class TestRealModeExecution:
+    @pytest.fixture
+    def mock_informal(self):
+        agent = AsyncMock()
+        agent.name = "InformalAnalysisAgent"
+        agent.perform_complete_analysis = AsyncMock(
+            return_value={
+                "fallacies": [
+                    {"fallacy_type": "ad_hominem", "confidence": 0.9},
+                ],
+                "categories": {"RELEVANCE": ["ad_hominem"]},
+            }
+        )
+        return agent
+
+    @pytest.fixture
+    def mock_synthesis(self):
+        agent = AsyncMock()
+        agent.name = "SynthesisAgent"
+        report = MagicMock()
+        report.model_dump.return_value = {
+            "confidence_level": 0.7,
+            "overall_validity": True,
+            "executive_summary": "Test summary",
+        }
+        agent.synthesize_analysis = AsyncMock(return_value=report)
+        return agent
+
+    @pytest.fixture
+    def orch_real(self, mock_informal, mock_synthesis):
+        """Orchestrator in forced real mode with mocked agents."""
+        orch = ConversationOrchestrator(mode="demo")
+        orch.mode = "real"
+        orch._real_agents = {
+            "informal": mock_informal,
+            "synthesis": mock_synthesis,
+        }
+        return orch
+
+    @pytest.mark.asyncio
+    async def test_run_orchestration_async_basic(self, orch_real):
+        report = await orch_real.run_orchestration_async("Test text for analysis.")
+        assert isinstance(report, str)
+        assert orch_real.state.completed
+        assert orch_real.state.agents_active >= 1
+
+    @pytest.mark.asyncio
+    async def test_run_orchestration_async_calls_agents(
+        self, orch_real, mock_informal, mock_synthesis
+    ):
+        await orch_real.run_orchestration_async("Test text.")
+        mock_informal.perform_complete_analysis.assert_called_once_with("Test text.")
+        mock_synthesis.synthesize_analysis.assert_called_once_with("Test text.")
+
+    @pytest.mark.asyncio
+    async def test_run_orchestration_async_state_updates(self, orch_real):
+        await orch_real.run_orchestration_async("Test text.")
+        assert orch_real.state.fallacies_detected >= 1
+        assert orch_real.state.score > 0
+        assert orch_real.state.completed
+
+    @pytest.mark.asyncio
+    async def test_non_real_mode_delegates_to_sync(self):
+        orch = ConversationOrchestrator(mode="demo")
+        report = await orch.run_orchestration_async("Test text.")
+        assert isinstance(report, str)
+        assert "TRACE ANALYTIQUE" in report
+
+    @pytest.mark.asyncio
+    async def test_agent_failure_does_not_crash(self):
+        orch = ConversationOrchestrator(mode="demo")
+        orch.mode = "real"
+        failing_agent = AsyncMock()
+        failing_agent.name = "FailAgent"
+        failing_agent.perform_complete_analysis = AsyncMock(
+            side_effect=RuntimeError("LLM down")
+        )
+        orch._real_agents = {"informal": failing_agent}
+
+        report = await orch.run_orchestration_async("Test text.")
+        assert isinstance(report, str)
+        assert orch.state.phase == "completed"
+
+    @pytest.mark.asyncio
+    async def test_agent_timeout_handled(self):
+        orch = ConversationOrchestrator(mode="demo")
+        orch.mode = "real"
+
+        async def slow_agent(text):
+            await asyncio.sleep(10)
+            return {}
+
+        slow = MagicMock()
+        slow.name = "SlowAgent"
+        slow.perform_complete_analysis = slow_agent
+        orch._real_agents = {"informal": slow}
+
+        report = await orch.run_orchestration_async("Test text.")
+        assert isinstance(report, str)
+
+    @pytest.mark.asyncio
+    async def test_run_demo_conversation_real_mode(self, orch_real):
+        result = await orch_real.run_demo_conversation("Test text")
+        assert result["status"] == "success"
+        assert result["mode"] == "real"
+
+    @pytest.mark.asyncio
+    async def test_run_conversation_alias(self, orch_real):
+        result = await orch_real.run_conversation("Test text")
+        assert result["status"] == "success"
+
+
+# ============================================================
+# Factory with kernel
+# ============================================================
+
+
+class TestFactoryWithKernel:
+    def test_create_with_kernel(self):
+        kernel = MagicMock()
+        orch = create_conversation_orchestrator("demo", kernel=kernel)
+        assert orch.kernel is kernel
+        assert orch.mode == "demo"
+
+    def test_create_without_kernel(self):
+        orch = create_conversation_orchestrator("demo")
+        assert orch.kernel is None
+        assert orch.mode == "demo"
+
+
+# ============================================================
+# Invoke real agent dispatching
+# ============================================================
+
+
+class TestInvokeRealAgent:
+    @pytest.mark.asyncio
+    async def test_invoke_informal_perform_complete(self):
+        orch = ConversationOrchestrator(mode="demo")
+        agent = AsyncMock()
+        agent.perform_complete_analysis = AsyncMock(return_value={"fallacies": []})
+        result = await orch._invoke_real_agent("informal", agent, "text")
+        assert result == {"fallacies": []}
+
+    @pytest.mark.asyncio
+    async def test_invoke_informal_analyze_text_fallback(self):
+        orch = ConversationOrchestrator(mode="demo")
+        agent = MagicMock(spec=[])  # no perform_complete_analysis
+        agent.analyze_text = AsyncMock(return_value={"fallacies": []})
+        result = await orch._invoke_real_agent("informal", agent, "text")
+        assert result == {"fallacies": []}
+
+    @pytest.mark.asyncio
+    async def test_invoke_synthesis(self):
+        orch = ConversationOrchestrator(mode="demo")
+        report = MagicMock()
+        report.model_dump.return_value = {"confidence_level": 0.8}
+        agent = AsyncMock()
+        agent.synthesize_analysis = AsyncMock(return_value=report)
+        result = await orch._invoke_real_agent("synthesis", agent, "text")
+        assert result == {"confidence_level": 0.8}
+
+    @pytest.mark.asyncio
+    async def test_invoke_unknown_raises(self):
+        orch = ConversationOrchestrator(mode="demo")
+        with pytest.raises(ValueError, match="Unknown agent key"):
+            await orch._invoke_real_agent("unknown", MagicMock(), "text")

--- a/docs/archives/orchestration_legacy/test_real_llm_orchestrator.py
+++ b/docs/archives/orchestration_legacy/test_real_llm_orchestrator.py
@@ -1,0 +1,101 @@
+"""
+Tests unitaires pour les modeles de donnees de real_llm_orchestrator.py.
+
+Couvre:
+- LLMAnalysisRequest / LLMAnalysisResult dataclasses
+
+Issue: #36 (test coverage)
+
+DEPRECATION NOTICE (#215):
+RealLLMOrchestrator has been archived. Its behavior tests have been removed.
+Use tests for UnifiedPipeline or ConversationOrchestrator instead.
+
+Only the dataclass tests (TestLLMAnalysisRequest, TestLLMAnalysisResult) remain.
+"""
+
+from dataclasses import asdict
+from datetime import datetime
+
+# ============================================================================
+# Dataclass tests
+# ============================================================================
+
+
+class TestLLMAnalysisRequest:
+    """Tests for the LLMAnalysisRequest dataclass."""
+
+    def test_basic_creation(self):
+        from argumentation_analysis.orchestration.real_llm_orchestrator import (
+            LLMAnalysisRequest,
+        )
+
+        req = LLMAnalysisRequest(text="Hello", analysis_type="syntactic")
+        assert req.text == "Hello"
+        assert req.analysis_type == "syntactic"
+        assert req.context is None
+        assert req.parameters is None
+        assert req.timeout == 30
+
+    def test_full_creation(self):
+        from argumentation_analysis.orchestration.real_llm_orchestrator import (
+            LLMAnalysisRequest,
+        )
+
+        req = LLMAnalysisRequest(
+            text="Test",
+            analysis_type="semantic",
+            context={"domain": "politics"},
+            parameters={"depth": 3},
+            timeout=60,
+        )
+        assert req.context == {"domain": "politics"}
+        assert req.parameters == {"depth": 3}
+        assert req.timeout == 60
+
+    def test_asdict(self):
+        from argumentation_analysis.orchestration.real_llm_orchestrator import (
+            LLMAnalysisRequest,
+        )
+
+        req = LLMAnalysisRequest(text="x", analysis_type="y")
+        d = asdict(req)
+        assert d["text"] == "x"
+        assert d["analysis_type"] == "y"
+
+
+class TestLLMAnalysisResult:
+    """Tests for the LLMAnalysisResult dataclass."""
+
+    def test_basic_creation(self):
+        from argumentation_analysis.orchestration.real_llm_orchestrator import (
+            LLMAnalysisResult,
+        )
+
+        now = datetime.now()
+        res = LLMAnalysisResult(
+            request_id="req_1",
+            analysis_type="syntactic",
+            result={"success": True},
+            confidence=0.95,
+            processing_time=1.23,
+            timestamp=now,
+        )
+        assert res.request_id == "req_1"
+        assert res.confidence == 0.95
+        assert res.metadata is None
+
+    def test_with_metadata(self):
+        from argumentation_analysis.orchestration.real_llm_orchestrator import (
+            LLMAnalysisResult,
+        )
+
+        res = LLMAnalysisResult(
+            request_id="req_2",
+            analysis_type="semantic",
+            result={},
+            confidence=0.5,
+            processing_time=0.1,
+            timestamp=datetime.now(),
+            metadata={"error": False},
+        )
+        assert res.metadata == {"error": False}

--- a/docs/archives/orchestration_legacy/test_specialized_orchestrators.py
+++ b/docs/archives/orchestration_legacy/test_specialized_orchestrators.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Tests Unitaires pour les Orchestrateurs Spécialisés
+===================================================
+
+Tests pour valider le fonctionnement des orchestrateurs spécialisés :
+- CluedoOrchestrator (enquêtes et investigations)
+- ConversationOrchestrator (analyses conversationnelles)
+- LogiqueComplexeOrchestrator (logique complexe)
+
+Auteur: Intelligence Symbolique EPITA
+Date: 10/06/2025
+"""
+
+import pytest
+import asyncio
+import logging
+from unittest.mock import patch, AsyncMock, Mock
+from typing import Dict, Any, List, Optional
+from semantic_kernel import Kernel
+from semantic_kernel.connectors.ai.chat_completion_client_base import (
+    ChatCompletionClientBase,
+)
+
+
+@pytest.fixture
+def llm_service() -> Mock:
+    """Fixture pour un service LLM mocké, compatible avec ChatCompletionClientBase."""
+    mock_service = Mock(spec=ChatCompletionClientBase)
+    # Le kernel a besoin d'un service_id pour enregistrer le service.
+    mock_service.service_id = "mock_llm_service"
+    return mock_service
+
+
+@pytest.fixture
+def mock_kernel(llm_service: Mock) -> Kernel:
+    """Fixture pour un kernel Semantic Kernel avec un service LLM mocké."""
+    kernel = Kernel()
+    kernel.add_service(llm_service)
+    return kernel
+
+
+# Configuration du logging pour les tests
+logging.basicConfig(level=logging.WARNING)
+
+# Imports à tester
+try:
+    from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
+        CluedoExtendedOrchestrator as CluedoOrchestrator,
+    )
+    from argumentation_analysis.orchestration.conversation_orchestrator import (
+        ConversationOrchestrator,
+    )
+    from argumentation_analysis.orchestration.logique_complexe_orchestrator import (
+        LogiqueComplexeOrchestrator,
+    )
+    from argumentation_analysis.config.settings import AppSettings
+
+    SPECIALIZED_AVAILABLE = True
+except ImportError as e:
+    SPECIALIZED_AVAILABLE = False
+    pytestmark = pytest.mark.skip(f"Orchestrateurs spécialisés non disponibles: {e}")
+
+
+@pytest.fixture
+def mock_settings() -> Mock:
+    """Fixture pour un mock de AppSettings."""
+    settings = Mock(spec=AppSettings)
+    settings.openai = Mock()
+    settings.openai.api_key = "test_key"
+    # Configurez d'autres attributs nécessaires de settings ici
+    return settings
+
+
+class TestCluedoOrchestrator:
+    """Tests pour l'orchestrateur Cluedo (investigations)."""
+
+    @pytest.fixture
+    def cluedo_orchestrator(self, mock_kernel: Kernel, mock_settings: Mock):
+        """Instance de CluedoOrchestrator pour les tests."""
+        return CluedoOrchestrator(kernel=mock_kernel, settings=mock_settings)
+
+    @pytest.fixture
+    def investigation_text(self):
+        """Texte d'enquête pour les tests."""
+        return "Le témoin A dit X, le témoin B dit Y. Qui dit vrai ?"
+
+    def test_cluedo_orchestrator_initialization(self, cluedo_orchestrator, mock_kernel):
+        """Test de l'initialisation de l'orchestrateur Cluedo."""
+        assert cluedo_orchestrator.kernel == mock_kernel
+        assert cluedo_orchestrator.oracle_state is None
+        assert cluedo_orchestrator.sherlock_agent is None
+        assert cluedo_orchestrator.execution_metrics == {}
+
+    @pytest.mark.asyncio
+    async def test_execute_workflow_simulation(
+        self, cluedo_orchestrator, investigation_text
+    ):
+        """Test de la méthode publique execute_workflow (simulation)."""
+        # On simule que le setup a été fait.
+        cluedo_orchestrator.orchestration = Mock()
+        cluedo_orchestrator.oracle_state = Mock()
+
+        # On mock directement la méthode execute_workflow pour ne pas tester toute la logique interne complexe
+        expected_result = {
+            "workflow_info": {"status": "completed"},
+            "solution_analysis": {"success": True},
+            "conversation_history": [],
+        }
+        cluedo_orchestrator.execute_workflow = AsyncMock(return_value=expected_result)
+
+        result = await cluedo_orchestrator.execute_workflow(investigation_text)
+
+        cluedo_orchestrator.execute_workflow.assert_called_once_with(investigation_text)
+        assert result["workflow_info"]["status"] == "completed"
+        assert result["solution_analysis"]["success"] is True
+
+
+class TestConversationOrchestrator:
+    """Tests pour l'orchestrateur de conversation."""
+
+    @pytest.fixture
+    def conversation_orchestrator(self):
+        """Instance de ConversationOrchestrator pour les tests."""
+        # Le constructeur a changé, il ne prend plus de llm_service ou config.
+        return ConversationOrchestrator(mode="demo")
+
+    @pytest.fixture
+    def dialogue_text(self):
+        """Texte de dialogue pour les tests."""
+        return "Alice: Pense à A. Bob: Non, pense à B."
+
+    def test_conversation_orchestrator_initialization(self, conversation_orchestrator):
+        """Test de l'initialisation de l'orchestrateur de conversation."""
+        assert conversation_orchestrator.mode == "demo"
+        assert conversation_orchestrator.state is not None
+        assert conversation_orchestrator.conv_logger is not None
+        assert len(conversation_orchestrator.agents) > 0
+
+    @pytest.mark.asyncio
+    async def test_run_demo_conversation(
+        self, conversation_orchestrator, dialogue_text
+    ):
+        """Test de l'orchestration d'une conversation en mode démo."""
+        conversation_orchestrator.run_demo_conversation = AsyncMock(
+            return_value={
+                "report": "TRACE ANALYTIQUE something",
+                "conversation_state": {"completed": True},
+                "mode": "demo",
+            }
+        )
+        # La méthode à tester est maintenant `run_demo_conversation`
+        result = await conversation_orchestrator.run_demo_conversation(dialogue_text)
+
+        assert "report" in result
+        assert "conversation_state" in result
+        assert result["mode"] == "demo"
+        assert result["conversation_state"]["completed"] is True
+        assert "TRACE ANALYTIQUE" in result["report"]
+
+
+class TestLogiqueComplexeOrchestrator:
+    """Tests pour l'orchestrateur de logique complexe."""
+
+    @pytest.fixture
+    def logic_orchestrator(self, mock_kernel: Kernel):
+        """Instance de LogiqueComplexeOrchestrator pour les tests."""
+        return LogiqueComplexeOrchestrator(kernel=mock_kernel)
+
+    def test_logic_orchestrator_initialization(self, logic_orchestrator):
+        """Test de l'initialisation de l'orchestrateur de logique complexe."""
+        # La classe a une définition minimale maintenant.
+        assert logic_orchestrator.kernel is not None
+        assert hasattr(logic_orchestrator, "_logger")
+
+    @pytest.mark.asyncio
+    async def test_run_einstein_puzzle_simulation(self, logic_orchestrator):
+        """Test de la seule méthode disponible (simulation)."""
+        puzzle_data = {"test": "data"}
+        # Mock de la méthode pour la prévisibilité
+        logic_orchestrator.run_einstein_puzzle = AsyncMock(
+            return_value={"solution": "mocked", "success": True}
+        )
+
+        result = await logic_orchestrator.run_einstein_puzzle(puzzle_data)
+
+        logic_orchestrator.run_einstein_puzzle.assert_called_once_with(puzzle_data)
+        assert result["success"] is True
+        assert result["solution"] == "mocked"
+
+
+class TestSpecializedOrchestratorsIntegration:
+    """Tests d'intégration entre orchestrateurs spécialisés."""
+
+    def test_orchestrator_instantiation(self, mock_kernel: Kernel, mock_settings: Mock):
+        """Test de l'instanciation correcte des orchestrateurs."""
+        cluedo = CluedoOrchestrator(kernel=mock_kernel, settings=mock_settings)
+        assert isinstance(cluedo, CluedoOrchestrator)
+
+        convo = ConversationOrchestrator(mode="demo")
+        assert isinstance(convo, ConversationOrchestrator)
+
+        logic = LogiqueComplexeOrchestrator(kernel=mock_kernel)
+        assert isinstance(logic, LogiqueComplexeOrchestrator)
+
+    @pytest.mark.asyncio
+    @patch(
+        "argumentation_analysis.orchestration.cluedo_extended_orchestrator.CluedoExtendedOrchestrator.execute_workflow",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "argumentation_analysis.orchestration.conversation_orchestrator.ConversationOrchestrator.run_demo_conversation",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "argumentation_analysis.orchestration.logique_complexe_orchestrator.LogiqueComplexeOrchestrator.run_einstein_puzzle",
+        new_callable=AsyncMock,
+    )
+    async def test_orchestrator_collaboration_mocked(
+        self,
+        mock_logic_run,
+        mock_convo_run,
+        mock_cluedo_run,
+        mock_kernel: Kernel,
+        mock_settings: Mock,
+    ):
+        """Test de collaboration simulée entre les orchestrateurs."""
+        mock_cluedo_run.return_value = {"workflow_info": {"status": "completed"}}
+        mock_convo_run.return_value = {"status": "success", "report": "report"}
+        mock_logic_run.return_value = {"solution": "mocked", "success": True}
+
+        complex_text = "Un texte complexe pour tester tout le monde."
+
+        cluedo_orchestrator = CluedoOrchestrator(
+            kernel=mock_kernel, settings=mock_settings
+        )
+        # La méthode setup_workflow est nécessaire avant execute_workflow
+        cluedo_orchestrator.setup_workflow = AsyncMock()
+        await cluedo_orchestrator.setup_workflow()
+
+        conversation_orchestrator = ConversationOrchestrator(mode="demo")
+        logic_orchestrator = LogiqueComplexeOrchestrator(kernel=mock_kernel)
+
+        investigation_result = await cluedo_orchestrator.execute_workflow(complex_text)
+        dialogue_result = await conversation_orchestrator.run_demo_conversation(
+            complex_text
+        )
+        logic_result = await logic_orchestrator.run_einstein_puzzle({})
+
+        mock_cluedo_run.assert_called_once_with(complex_text)
+        mock_convo_run.assert_called_once_with(complex_text)
+        mock_logic_run.assert_called_once_with({})
+
+        assert "workflow_info" in investigation_result
+        assert "report" in dialogue_result
+        assert "success" in logic_result
+
+
+if __name__ == "__main__":
+    # Exécution des tests si le script est lancé directement
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/docs/archives/orchestration_legacy/test_unified_orchestrations.py
+++ b/docs/archives/orchestration_legacy/test_unified_orchestrations.py
@@ -1,0 +1,597 @@
+#!/usr/bin/env python3
+"""
+Tests unitaires avancés pour les orchestrations unifiées
+======================================================
+
+Suite finale de tests pour ConversationOrchestrator, RealLLMOrchestrator,
+et coordination système complète avec composants authentiques.
+"""
+
+# Imports pour les mocks et les tests
+from unittest.mock import MagicMock, AsyncMock, patch
+import logging
+from semantic_kernel import Kernel
+from config.unified_config import UnifiedConfig
+
+import pytest
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+from typing import Dict, Any, List
+
+# Ajout du chemin pour les imports
+PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+logger = logging.getLogger(__name__)
+
+try:
+    from argumentation_analysis.orchestration.conversation_orchestrator import (
+        ConversationOrchestrator,
+    )
+    from argumentation_analysis.orchestration.real_llm_orchestrator import (
+        RealLLMOrchestrator,
+    )
+    from argumentation_analysis.utils.tweety_error_analyzer import (
+        TweetyErrorAnalyzer,
+        TweetyErrorFeedback,
+    )
+    from argumentation_analysis.agents.core.logic.first_order_logic_agent_adapter import (
+        FOLLogicAgent,
+    )
+
+    REAL_COMPONENTS_AVAILABLE = True
+except ImportError as e:
+    print(f"Avertissement: Composants réels non disponibles: {e}")
+    REAL_COMPONENTS_AVAILABLE = False
+
+    # Mocks de fallback
+    class ConversationOrchestrator:
+        def __init__(self, mode="demo", config=None):
+            self.mode = mode
+            self.config = config
+            self.agents = []
+            self.state = {}
+
+        def run_orchestration(self, text: str) -> str:
+            return f"Mock orchestration {self.mode}: {text[:50]}..."
+
+        def get_agents(self) -> List:
+            return self.agents
+
+        def get_state(self) -> Dict:
+            return self.state
+
+    class RealLLMOrchestrator:
+        def __init__(self, mode="real", kernel=None, config=None):
+            self.mode = mode
+            self.kernel = kernel
+            self.config = config
+            self.agents = {}
+            self.rhetorical_analyzer = None  # Pour la compatibilité des tests
+
+        def initialize(self) -> bool:
+            return True
+
+        def run_real_llm_orchestration(self, text: str) -> Dict[str, Any]:
+            return {
+                "status": "success",
+                "analysis": f"Mock real LLM analysis: {text[:50]}...",
+                "agents_used": ["RealAgent1", "RealAgent2"],
+                "trace": "Mock trace",
+                "bnf_feedback": None,
+            }
+
+    class TweetyErrorAnalyzer:
+        def analyze_error(self, error_text: str) -> Any:
+            return type(
+                "TweetyErrorFeedback",
+                (),
+                {
+                    "error_type": "MOCK_ERROR",
+                    "corrections": ["Mock correction"],
+                    "bnf_rules": ["Mock BNF rule"],
+                    "confidence": 0.9,
+                },
+            )()
+
+
+class TestUnifiedOrchestrations:
+    """Tests avancés pour les orchestrations unifiées."""
+
+    def setup_method(self):
+        """Configuration initiale pour chaque test."""
+        self.test_text = "L'Ukraine a été créée par la Russie. Donc Poutine a raison."
+        self.test_config = UnifiedConfig(
+            logic_type="FOL",
+            mock_level="PARTIAL",  # On utilise des mocks partiels maintenant
+            orchestration_type="UNIFIED",
+            require_real_gpt=False,  # On n'exige plus le vrai GPT
+            require_real_tweety=False,  # Doit être False si le mock_level n'est pas 'NONE'
+            require_full_taxonomy=False,  # Doit aussi être False pour un mock partiel
+        )
+
+    def test_conversation_orchestrator_initialization(self):
+        """Test d'initialisation avancée du ConversationOrchestrator."""
+        orchestrator = ConversationOrchestrator(mode="demo")
+
+        assert orchestrator.mode == "demo"
+        assert hasattr(orchestrator, "agents")
+        assert hasattr(orchestrator, "state")
+
+        # Test conversation state API
+        conv_state = orchestrator.get_conversation_state()
+        assert isinstance(conv_state, dict)
+        assert conv_state["mode"] == "demo"
+
+    @pytest.mark.xfail(
+        reason="RealLLMOrchestrator deprecated — .mode/.config attributes removed (#274)",
+        strict=True,
+    )
+    def test_real_llm_orchestrator_configuration(self):
+        """Test de configuration du RealLLMOrchestrator."""
+        orchestrator = RealLLMOrchestrator(mode="real")
+
+        assert orchestrator.mode == "real"
+        assert hasattr(orchestrator, "config")
+        assert isinstance(orchestrator.config, dict)
+
+        # Test default config values
+        assert orchestrator.config.get("retry_attempts") == 3
+        assert orchestrator.config.get("cache_enabled") is True
+
+    def test_multi_agent_coordination(self):
+        """Test de coordination multi-agents."""
+        orchestrator = ConversationOrchestrator(mode="demo")
+
+        # Vérifier que les agents sont configurés
+        agents = (
+            orchestrator.get_agents()
+            if hasattr(orchestrator, "get_agents")
+            else orchestrator.agents
+        )
+        assert isinstance(agents, list)
+
+        # Test de coordination basique
+        result = orchestrator.run_orchestration(self.test_text)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_shared_state_management(self):
+        """Test de gestion d'état partagé entre agents."""
+        orchestrator = ConversationOrchestrator(mode="demo")
+
+        # Test de l'état initial
+        if hasattr(orchestrator, "get_state"):
+            state = orchestrator.get_state()
+            assert isinstance(state, dict)
+
+        # Test de mise à jour d'état après orchestration
+        result = orchestrator.run_orchestration(self.test_text)
+
+        # Vérifier que l'état a été mis à jour
+        if hasattr(orchestrator, "state"):
+            assert orchestrator.state is not None
+
+    def test_error_recovery_mechanisms(self):
+        """Test des mécanismes de récupération d'erreur."""
+        orchestrator = ConversationOrchestrator(mode="demo")
+
+        # Test avec texte problématique
+        problematic_texts = [
+            "",  # Texte vide
+            "A" * 10000,  # Texte très long
+            "🤔💭🧠",  # Emojis uniquement
+            None,  # Valeur None (si géré)
+        ]
+
+        for text in problematic_texts:
+            try:
+                if text is not None:
+                    result = orchestrator.run_orchestration(text)
+                    assert isinstance(result, str)
+            except Exception as e:
+                # Vérifier que l'erreur est appropriée
+                assert isinstance(e, (ValueError, TypeError, AttributeError))
+
+    def test_trace_generation_quality(self):
+        """Test de la qualité de génération des traces."""
+        orchestrator = ConversationOrchestrator(mode="trace")
+
+        result = orchestrator.run_orchestration(self.test_text)
+
+        # Vérifier la structure de la trace
+        assert isinstance(result, str)
+        assert len(result) > len(self.test_text)  # La trace doit être plus riche
+
+        # Vérifier les éléments attendus dans une trace
+        trace_indicators = ["trace", "agent", "step", "analysis", "→", "•"]
+        has_trace_elements = any(
+            indicator in result.lower() for indicator in trace_indicators
+        )
+        assert has_trace_elements
+
+    def test_performance_orchestration(self):
+        """Test de performance de l'orchestration."""
+        orchestrator = ConversationOrchestrator(mode="micro")
+
+        start_time = time.time()
+
+        # Exécuter plusieurs orchestrations
+        for i in range(3):
+            text = f"Test {i}: Analyse rapide nécessaire."
+            result = orchestrator.run_orchestration(text)
+            assert isinstance(result, str)
+
+        elapsed_time = time.time() - start_time
+
+        # Performance : moins de 3 secondes pour 3 orchestrations micro
+        assert elapsed_time < 3.0
+
+    def test_resource_management(self):
+        """Test de gestion des ressources."""
+        # Test de création/destruction multiple d'orchestrateurs
+        orchestrators = []
+
+        for i in range(5):
+            orch = ConversationOrchestrator(mode="micro")
+            orchestrators.append(orch)
+
+        # Tous les orchestrateurs doivent être créés correctement
+        assert len(orchestrators) == 5
+
+        # Test de nettoyage
+        for orch in orchestrators:
+            if hasattr(orch, "cleanup"):
+                orch.cleanup()
+
+
+class TestRealLLMOrchestrationAdvanced:
+    """Tests avancés pour RealLLMOrchestrator."""
+
+    def _create_authentic_gpt4o_mini_instance(self):
+        """Crée une instance authentique de gpt-5-mini au lieu d'un mock."""
+        config = UnifiedConfig()
+        # Assurez-vous que la méthode get_kernel_with_gpt4o_mini existe et est correcte
+        if hasattr(config, "get_kernel_with_gpt4o_mini"):
+            return asyncio.run(config.get_kernel_with_gpt4o_mini())
+        # Fallback ou erreur si la méthode n'existe pas
+        raise AttributeError(
+            "UnifiedConfig n'a pas de méthode 'get_kernel_with_gpt4o_mini'"
+        )
+
+    def _make_authentic_llm_call(self, prompt: str) -> str:
+        """Fait un appel authentique à gpt-5-mini."""
+        try:
+            kernel = self._create_authentic_gpt4o_mini_instance()
+            result = asyncio.run(kernel.invoke("chat", input=prompt))
+            return str(result)
+        except Exception as e:
+            logger.warning(f"Appel LLM authentique échoué: {e}")
+            return "Authentic LLM call failed"
+
+    def setup_method(self):
+        """Configuration initiale pour chaque test."""
+        self.test_text = "L'Ukraine a été créée par la Russie. Donc Poutine a raison."
+        self.mock_llm_service = MagicMock()
+        self.mock_llm_service.invoke = AsyncMock(return_value="Mock LLM response")
+
+    @pytest.mark.xfail(
+        reason="RealLLMOrchestrator deprecated — .kernel/.is_initialized attributes removed (#274)",
+        strict=True,
+    )
+    def test_real_llm_orchestrator_initialization(self):
+        """Test d'initialisation complète du RealLLMOrchestrator."""
+        orchestrator = RealLLMOrchestrator(mode="real", kernel=self.mock_llm_service)
+
+        # Before initialization
+        assert not orchestrator.is_initialized
+        assert hasattr(orchestrator, "kernel")
+        assert orchestrator.kernel is self.mock_llm_service
+
+        # Check status API
+        status = orchestrator.get_status()
+        assert isinstance(status, dict)
+        assert status["is_initialized"] is False
+
+    def test_bnf_feedback_integration(self):
+        """Test d'intégration avec TweetyErrorAnalyzer pour feedback BNF."""
+        orchestrator = RealLLMOrchestrator(kernel=self.mock_llm_service)
+
+        # Simuler une erreur Tweety
+        error_text = "Predicate 'invalid_pred' has not been declared"
+
+        analyzer = TweetyErrorAnalyzer()
+        feedback = analyzer.analyze_error(error_text)
+
+        assert hasattr(feedback, "error_type")
+        assert hasattr(feedback, "corrections")
+        assert hasattr(feedback, "bnf_rules")
+
+    @patch("config.unified_config.UnifiedConfig.get_kernel_with_gpt4o_mini")
+    def test_intelligent_retry_mechanism(self, mock_get_kernel):
+        """Test du mécanisme de retry intelligent avec un kernel mocké."""
+        # Configurer le mock pour simuler un LLM qui échoue puis réussit
+        mock_kernel_instance = MagicMock(spec=Kernel)
+        mock_kernel_instance.invoke = AsyncMock(
+            side_effect=[Exception("First attempt fails"), "Success on retry"]
+        )
+        mock_get_kernel.return_value = mock_kernel_instance
+
+        # L'orchestrateur va maintenant utiliser le kernel mocké via la config
+        orchestrator = RealLLMOrchestrator(kernel=mock_kernel_instance)
+
+        # Le test original peut continuer, en supposant que l'orchestrateur est
+        # conçu pour gérer une exception et potentiellement réessayer.
+        try:
+            result = orchestrator.run_real_llm_orchestration(self.test_text)
+            # Le test attend un succès au deuxième essai
+            assert isinstance(result, dict)
+            # On pourrait même vérifier que le service a été appelé deux fois
+            # assert mock_kernel_instance.invoke.call_count == 2
+        except Exception:
+            # Si un retry n'est pas implémenté, le test échouera ici, ce qui est attendu.
+            pass
+
+    def test_semantic_kernel_integration(self):
+        """Test d'intégration avec Semantic Kernel."""
+        orchestrator = RealLLMOrchestrator(kernel=self.mock_llm_service)
+
+        # Test d'initialisation du kernel
+        if hasattr(orchestrator, "initialize"):
+            orchestrator.initialize()
+
+        # Vérifier que le kernel est configuré
+        if hasattr(orchestrator, "kernel"):
+            assert (
+                orchestrator.kernel is not None or orchestrator.kernel is None
+            )  # Selon implémentation
+
+
+class TestUnifiedSystemCoordination:
+    """Tests de coordination système unifiée."""
+
+    def setup_method(self):
+        """Configuration initiale pour chaque test."""
+        self.test_text = "L'Ukraine a été créée par la Russie. Donc Poutine a raison."
+        self.unified_config = UnifiedConfig(
+            logic_type="FOL", mock_level="NONE", orchestration_type="UNIFIED"
+        )
+
+    def test_config_to_orchestration_mapping(self):
+        """Test du mapping configuration vers orchestration."""
+        # Test avec configuration conversation
+        conv_config = UnifiedConfig(orchestration_type="CONVERSATION")
+        conv_orchestrator = ConversationOrchestrator()
+
+        assert conv_orchestrator is not None
+
+        # Test avec configuration LLM réel
+        real_config = UnifiedConfig(orchestration_type="REAL")
+        real_orchestrator = RealLLMOrchestrator(config=real_config)
+
+        assert real_orchestrator is not None
+
+    def test_agent_to_orchestrator_communication(self):
+        """Test de communication agent vers orchestrateur."""
+        orchestrator = ConversationOrchestrator(mode="demo")
+
+        # Test que les agents peuvent communiquer avec l'orchestrateur
+        if hasattr(orchestrator, "agents") and orchestrator.agents:
+            # Vérifier que les agents ont accès à l'orchestrateur
+            for agent in orchestrator.agents:
+                if hasattr(agent, "orchestrator"):
+                    assert agent.orchestrator is not None
+
+    @pytest.mark.xfail(
+        reason="RealLLMOrchestrator deprecated — .get_status()/.get_metrics() removed (#274)",
+        strict=True,
+    )
+    def test_conversation_to_real_llm_handoff(self):
+        """Test de handoff entre orchestrateurs."""
+        # Phase 1: Orchestration conversationnelle
+        conv_orchestrator = ConversationOrchestrator(mode="demo")
+        conv_result = conv_orchestrator.run_orchestration(self.test_text)
+
+        assert isinstance(conv_result, str)
+
+        # Get conversation state for handoff
+        conv_state = conv_orchestrator.get_conversation_state()
+        assert isinstance(conv_state, dict)
+        assert "mode" in conv_state
+
+        # Phase 2: Create real LLM orchestrator
+        mock_llm = MagicMock()
+        real_orchestrator = RealLLMOrchestrator(kernel=mock_llm)
+
+        # Verify status before initialization
+        status = real_orchestrator.get_status()
+        assert isinstance(status, dict)
+        assert not status["is_initialized"]
+
+        # Verify metrics API
+        metrics = real_orchestrator.get_metrics()
+        assert isinstance(metrics, dict)
+        assert metrics["total_requests"] == 0
+
+    def test_authentic_mode_validation(self):
+        """Test de validation du mode authentique."""
+        # ConversationOrchestrator doesn't accept config= directly
+        # Test the orchestrator and config independently
+        orchestrator = ConversationOrchestrator(mode="demo")
+
+        assert orchestrator.mode == "demo"
+        conv_state = orchestrator.get_conversation_state()
+        assert isinstance(conv_state, dict)
+        assert "mode" in conv_state
+
+        # Verify authentic config separately
+        authentic_config = UnifiedConfig(
+            logic_type="FOL",
+            mock_level="NONE",
+            require_real_gpt=True,
+            require_real_tweety=True,
+        )
+        assert authentic_config.mock_level.value == "none"
+        assert authentic_config.require_real_gpt is True
+        assert authentic_config.require_real_tweety is True
+
+
+class TestOrchestrationPerformanceAndRobustness:
+    """Tests de performance et robustesse des orchestrations."""
+
+    def test_concurrent_orchestrations(self):
+        """Test d'orchestrations concurrentes."""
+        import threading
+        import queue
+
+        results = queue.Queue()
+
+        def run_orchestration(text_id):
+            orchestrator = ConversationOrchestrator(mode="micro")
+            result = orchestrator.run_orchestration(f"Test concurrent {text_id}")
+            results.put((text_id, result))
+
+        # Lancer plusieurs orchestrations en parallèle
+        threads = []
+        for i in range(3):
+            thread = threading.Thread(target=run_orchestration, args=(i,))
+            threads.append(thread)
+            thread.start()
+
+        # Attendre la fin
+        for thread in threads:
+            thread.join(timeout=5.0)
+
+        # Vérifier les résultats
+        assert results.qsize() == 3
+
+        collected_results = []
+        while not results.empty():
+            collected_results.append(results.get())
+
+        assert len(collected_results) == 3
+
+    def test_memory_usage_stability(self):
+        """Test de stabilité de l'utilisation mémoire."""
+        import gc
+
+        orchestrator = ConversationOrchestrator(mode="micro")
+
+        # Exécuter plusieurs orchestrations
+        for i in range(10):
+            text = f"Test mémoire {i}: " + "Data " * 100
+            result = orchestrator.run_orchestration(text)
+            assert isinstance(result, str)
+
+            # Forcer garbage collection
+            if i % 3 == 0:
+                gc.collect()
+
+        # Test que l'orchestrateur est toujours fonctionnel
+        final_result = orchestrator.run_orchestration("Test final")
+        assert isinstance(final_result, str)
+
+    def test_error_propagation_and_handling(self):
+        """Test de propagation et gestion d'erreurs."""
+        orchestrator = ConversationOrchestrator(mode="demo")
+
+        # Test avec différents types d'erreurs
+        error_cases = [
+            ("", "empty_text"),
+            ("A" * 50000, "very_long_text"),
+            ("🔥💥⚡", "special_chars_only"),
+        ]
+
+        for text, case_name in error_cases:
+            try:
+                result = orchestrator.run_orchestration(text)
+                # Si aucune erreur, vérifier que le résultat est valide
+                assert isinstance(result, str)
+                print(f"✓ Cas {case_name}: Géré gracieusement")
+            except Exception as e:
+                # Si erreur, vérifier qu'elle est appropriée
+                assert isinstance(e, (ValueError, TypeError, RuntimeError))
+                print(f"✓ Cas {case_name}: Erreur appropriée - {type(e).__name__}")
+
+    def test_orchestration_chain_stability(self):
+        """Test de stabilité des chaînes d'orchestration."""
+        texts = [
+            "Premier texte d'analyse.",
+            "Deuxième texte plus complexe avec argumentation.",
+            "Troisième texte final pour vérifier la stabilité.",
+        ]
+
+        orchestrator = ConversationOrchestrator(mode="demo")
+
+        results = []
+        for i, text in enumerate(texts):
+            result = orchestrator.run_orchestration(text)
+            results.append(result)
+
+            # Vérifier la consistance
+            assert isinstance(result, str)
+            assert len(result) > 0
+
+            # L'orchestrateur doit rester stable
+            assert hasattr(orchestrator, "mode")
+            assert orchestrator.mode == "demo"
+
+        # Tous les résultats doivent être uniques et valides
+        assert len(results) == 3
+        assert len(set(results)) >= 1  # Au moins un résultat unique
+
+
+@pytest.mark.skipif(
+    not REAL_COMPONENTS_AVAILABLE, reason="Composants réels non disponibles"
+)
+class TestAuthenticOrchestrationIntegration:
+    """Tests d'intégration authentique (sans mocks)."""
+
+    def test_fol_agent_integration(self):
+        """Test d'intégration avec FOLLogicAgent réel."""
+        config = UnifiedConfig(logic_type="FOL", mock_level="NONE")
+        orchestrator = ConversationOrchestrator(mode="demo")
+
+        # Vérifier que l'agent FOL est configuré
+        if hasattr(orchestrator, "agents"):
+            fol_agents = [
+                a
+                for a in orchestrator.agents
+                if "FOLLogicAgent" in str(type(a).__name__)
+            ]
+            if fol_agents:
+                assert len(fol_agents) > 0
+
+    def test_tweety_error_analyzer_integration(self):
+        """Test d'intégration avec TweetyErrorAnalyzer réel."""
+        analyzer = TweetyErrorAnalyzer()
+
+        # Test avec erreur Tweety réelle
+        error_text = "Predicate 'unknown_pred' has not been declared in rule"
+        feedback = analyzer.analyze_error(error_text)
+
+        assert feedback.error_type is not None
+        assert len(feedback.corrections) > 0
+        assert feedback.confidence > 0.0
+
+    def test_unified_config_full_integration(self):
+        """Test d'intégration complète avec UnifiedConfig."""
+        config = UnifiedConfig(
+            logic_type="FOL",
+            mock_level="NONE",
+            orchestration_type="UNIFIED",
+            require_real_gpt=True,
+            require_real_tweety=True,
+        )
+
+        assert config.logic_type.value == "fol"
+        assert config.mock_level.value == "none"
+        assert config.require_real_gpt == True
+        assert config.require_real_tweety == True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/scripts/validation/validation_traces_master_fixed.py
+++ b/scripts/validation/validation_traces_master_fixed.py
@@ -51,9 +51,13 @@ from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
     run_cluedo_oracle_game,
 )
-from argumentation_analysis.orchestration.logique_complexe_orchestrator import (
-    LogiqueComplexeOrchestrator,
-)
+
+try:
+    from argumentation_analysis.orchestration.logique_complexe_orchestrator import (
+        LogiqueComplexeOrchestrator,
+    )
+except ImportError:
+    LogiqueComplexeOrchestrator = None  # Archived B-09 #875
 from argumentation_analysis.agents.core.pm.sherlock_enquete_agent import (
     SherlockEnqueteAgent,
     SherlockTools,

--- a/tests/unit/argumentation_analysis/reporting/test_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/reporting/test_trace_analyzer.py
@@ -17,13 +17,6 @@ from argumentation_analysis.reporting.trace_analyzer import (
     InformalExploration,
 )
 
-# Gen 1 trace_analyzer — superseded by enhanced_real_time_trace_analyzer (Gen 3).
-# No consumer outside tests. Pipeline uses analysis_runner_v2 + enhanced_pm_analysis_runner.
-# B-07 audit #811 — 54 dead tests archived.
-pytestmark = pytest.mark.skip(
-    "Gen 1 trace_analyzer superseded by enhanced_real_time_trace_analyzer (B-07 #811)"
-)
-
 # ── ExtractMetadata ──
 
 

--- a/tests/unit/argumentation_analysis/test_trace_analyzer.py
+++ b/tests/unit/argumentation_analysis/test_trace_analyzer.py
@@ -14,11 +14,6 @@ le suivi d'évolution d'état et la génération de rapports.
 import pytest
 import json
 
-# Legacy copy of Gen 1 trace_analyzer tests — same dead module as reporting/test_trace_analyzer.py.
-# Superseded by enhanced_real_time_trace_analyzer (Gen 3). B-07 audit #811 — 36 dead tests archived.
-pytestmark = pytest.mark.skip(
-    "Legacy Gen 1 trace_analyzer copy — superseded by enhanced_real_time_trace_analyzer (B-07 #811)"
-)
 import tempfile
 import os
 from pathlib import Path

--- a/tests/unit/orchestration/hierarchical/operational/test_feedback_mechanism.py
+++ b/tests/unit/orchestration/hierarchical/operational/test_feedback_mechanism.py
@@ -13,8 +13,6 @@ from argumentation_analysis.orchestration.hierarchical.operational.feedback_mech
     FeedbackManager,
 )
 
-pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
-
 # ============================================================
 # RhetoricalToolsFeedback
 # ============================================================

--- a/tests/unit/orchestration/hierarchical/operational/test_operational_state.py
+++ b/tests/unit/orchestration/hierarchical/operational/test_operational_state.py
@@ -12,8 +12,6 @@ from argumentation_analysis.orchestration.hierarchical.operational.state import 
     OperationalState,
 )
 
-pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
-
 
 @pytest.fixture
 def state():

--- a/tests/unit/orchestration/hierarchical/strategic/test_resource_allocator.py
+++ b/tests/unit/orchestration/hierarchical/strategic/test_resource_allocator.py
@@ -14,8 +14,6 @@ from argumentation_analysis.orchestration.hierarchical.strategic.state import (
     StrategicState,
 )
 
-pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
-
 
 @pytest.fixture
 def state():

--- a/tests/unit/orchestration/hierarchical/strategic/test_strategic_planner.py
+++ b/tests/unit/orchestration/hierarchical/strategic/test_strategic_planner.py
@@ -14,8 +14,6 @@ from argumentation_analysis.orchestration.hierarchical.strategic.state import (
     StrategicState,
 )
 
-pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
-
 
 @pytest.fixture
 def state():

--- a/tests/unit/orchestration/hierarchical/strategic/test_strategic_state.py
+++ b/tests/unit/orchestration/hierarchical/strategic/test_strategic_state.py
@@ -11,8 +11,6 @@ from argumentation_analysis.orchestration.hierarchical.strategic.state import (
     StrategicState,
 )
 
-pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
-
 
 @pytest.fixture
 def state():

--- a/tests/unit/orchestration/hierarchical/tactical/test_progress_monitor.py
+++ b/tests/unit/orchestration/hierarchical/tactical/test_progress_monitor.py
@@ -15,8 +15,6 @@ from argumentation_analysis.orchestration.hierarchical.tactical.state import (
     TacticalState,
 )
 
-pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
-
 
 @pytest.fixture
 def state():

--- a/tests/unit/orchestration/hierarchical/tactical/test_tactical_resolver.py
+++ b/tests/unit/orchestration/hierarchical/tactical/test_tactical_resolver.py
@@ -39,8 +39,6 @@ from argumentation_analysis.orchestration.hierarchical.tactical.state import (
     TacticalState,
 )
 
-pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
-
 
 class TestConflictResolver(unittest.TestCase):
     """Tests unitaires pour le Résolveur de Conflits."""

--- a/tests/unit/orchestration/hierarchical/tactical/test_tactical_resolver_advanced.py
+++ b/tests/unit/orchestration/hierarchical/tactical/test_tactical_resolver_advanced.py
@@ -39,8 +39,6 @@ from argumentation_analysis.orchestration.hierarchical.tactical.state import (
     TacticalState,
 )
 
-pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
-
 
 class TestTacticalResolverAdvanced(unittest.TestCase):
     """Tests avancés pour le résolveur de conflits tactique."""

--- a/tests/unit/orchestration/hierarchical/tactical/test_tactical_state.py
+++ b/tests/unit/orchestration/hierarchical/tactical/test_tactical_state.py
@@ -12,8 +12,6 @@ from argumentation_analysis.orchestration.hierarchical.tactical.state import (
     TacticalState,
 )
 
-pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
-
 
 class TestTacticalState(unittest.TestCase):
     """Tests pour la classe TacticalState."""

--- a/tests/unit/orchestration/hierarchical/templates/test_templates.py
+++ b/tests/unit/orchestration/hierarchical/templates/test_templates.py
@@ -24,8 +24,6 @@ from argumentation_analysis.orchestration.hierarchical.templates.analysis_tool_t
     ANALYSIS_TOOL_CONFIG_EXAMPLE,
 )
 
-pytestmark = pytest.mark.skip("Hierarchical mode dormant — not in active pipeline (B-09 #798)")
-
 # ============================================================
 # BaseAgent (agent_template)
 # ============================================================

--- a/tests/unit/orchestration/test_hierarchical_managers.py
+++ b/tests/unit/orchestration/test_hierarchical_managers.py
@@ -46,7 +46,6 @@ try:
     HIERARCHICAL_AVAILABLE = True
 except ImportError as e:
     HIERARCHICAL_AVAILABLE = False
-    pytestmark = pytest.mark.skip(f"Gestionnaires hiérarchiques non disponibles: {e}")
 
 
 class TestStrategicManager:


### PR DESCRIPTION
## Summary

Archives 4 obsolete orchestrators with proof of supersede (#875), fixes all 5 hierarchical reactivation blockers (B1-B5, R311), and re-enables 302 previously-dormant hierarchical tests.

## Files archived (with supersede proof)

| File | LOC | Reason | Superseded-by |
|------|-----|--------|---------------|
| `real_llm_orchestrator.py` | 124 | Shim raising NotImplementedError | `UnifiedPipeline` + `WorkflowDSL` |
| `conversation_orchestrator.py` | 1044 | Dormant, DeprecationWarning | 8-agent SK system via `CapabilityRegistry` |
| `cluedo_orchestrator.py` (base 2-agent) | 488 | DeprecationWarning, superseded | `CluedoExtendedOrchestrator` (3-agent) |
| `logique_complexe_orchestrator.py` | 108 | Mock stub (sleep+hardcoded) | `FOLLogicAgent` + `TweetyLogicPlugin` |

5 test files archived (all tested obsolete code).

## Hierarchical Reactivation (R311) — All blockers fixed

| Blocker | Fix | File |
|---------|-----|------|
| B1 | `rhetorical_tools_adapter` import fix | `operational/adapters/rhetorical_tools_adapter.py` |
| B2 | `PLAgentAdapter` rewritten against real API | `operational/adapters/pl_agent_adapter.py` |
| B3 | `informal_agent_adapter` de-stubbed (AgentFactory) | `operational/adapters/informal_agent_adapter.py` |
| B4 | NEW `HierarchicalOrchestrator` bridge + CLI `--mode hierarchical` | `hierarchical/orchestrator.py` |
| B5 | ORCHESTRATION_MODES.md: DORMANT to ACTIVE | `docs/architecture/ORCHESTRATION_MODES.md` |

## Tests re-enabled (E5)

Removed `pytestmark = pytest.mark.skip` from 13 files: 302 hierarchical + 90 trace = 392 tests re-enabled, all passing.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>