### PR TITLE
fix(api): lazy-import spacy in fact_claim_extractor — FastAPI boots on broken torch (#882)

### DIFF
--- a/argumentation_analysis/agents/tools/analysis/fact_claim_extractor.py
+++ b/argumentation_analysis/agents/tools/analysis/fact_claim_extractor.py
@@ -11,7 +11,6 @@ import re
 from typing import Dict, List, Any, Optional, Set, Tuple
 from dataclasses import dataclass
 from enum import Enum
-import spacy
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
@@ -97,14 +96,21 @@ class FactClaimExtractor:
         self.language = language
 
         # Tentative de chargement du modèle spaCy
+        # Lazy import: spacy triggers torch import chain which can fail with
+        # OSError (WinError 182, broken DLL) or ImportError on some envs.
+        # Importing here instead of module-level allows the module to be
+        # collected/imported without crashing (e.g. test collection, API boot).
         try:
+            import spacy  # noqa: E402 — lazy import for env resilience
+
             if language == "fr":
                 self.nlp = spacy.load("fr_core_news_sm")
             else:
                 self.nlp = spacy.load("en_core_web_sm")
-        except OSError:
+        except (OSError, ImportError) as e:
             self.logger.warning(
-                f"Modèle spaCy {language} non trouvé, utilisation du modèle de base"
+                f"spaCy ou modèle {language} non disponible ({type(e).__name__}: {e}), "
+                f"utilisation du mode dégradé"
             )
             self.nlp = None
 

--- a/tests/unit/argumentation_analysis/agents/tools/test_fact_claim_lazy_import.py
+++ b/tests/unit/argumentation_analysis/agents/tools/test_fact_claim_lazy_import.py
@@ -1,0 +1,49 @@
+"""Tests for fact_claim_extractor lazy-import hardening (#882)."""
+import pytest
+
+
+class TestFactClaimExtractorLazyImport:
+    """Verify that importing FactClaimExtractor does not crash on broken torch/spacy."""
+
+    def test_module_import_succeeds_without_torch(self):
+        """Module import should succeed even if spacy/torch chain is broken.
+
+        Regression test for #882: import spacy was at module level and
+        crashed with OSError (WinError 182) when torch DLL was broken.
+        After fix, the import is deferred to __init__ and caught gracefully.
+        """
+        from argumentation_analysis.agents.tools.analysis.fact_claim_extractor import (
+            FactClaimExtractor,
+            ClaimType,
+            FactualClaim,
+        )
+
+        # Classes should be importable without any spacy/torch involvement
+        assert ClaimType.STATISTICAL.value == "statistical"
+        assert hasattr(FactualClaim, "__dataclass_fields__")
+
+    def test_instantiation_degrades_gracefully_without_model(self):
+        """FactClaimExtractor should degrade to nlp=None when spacy model is unavailable."""
+        from argumentation_analysis.agents.tools.analysis.fact_claim_extractor import (
+            FactClaimExtractor,
+        )
+
+        extractor = FactClaimExtractor(language="fr")
+        # Whether nlp is loaded depends on the environment, but instantiation
+        # must not raise any exception
+        assert hasattr(extractor, "nlp")
+
+    def test_extract_with_no_nlp(self):
+        """Extraction should still work (regex-based) when spacy is unavailable."""
+        from argumentation_analysis.agents.tools.analysis.fact_claim_extractor import (
+            FactClaimExtractor,
+        )
+
+        extractor = FactClaimExtractor(language="fr")
+        # Force degraded mode for testing
+        extractor.nlp = None
+
+        # Should not crash even without NLP model
+        text = "Le prix a augmenté de 15% en 2024."
+        result = extractor.extract_factual_claims(text)
+        assert isinstance(result, list)


### PR DESCRIPTION
## Summary

Partially-fixes #882 — FastAPI now boots successfully on machines with broken torch DLLs (WinError 182).

## Root cause

`fact_claim_extractor.py:14` had `import spacy` at module level. This triggered a transitive `import torch` through the spacy/thinc chain. On machines with torch 2.2.2, the DLL `fbgemm.dll` fails to load with `OSError` (WinError 182). Since thinc only catches `ImportError` (not `OSError`), the crash propagated and blocked all imports of `fact_claim_extractor`, including via `api/main.py`.

## Changes
- **`fact_claim_extractor.py`**: Deferred `import spacy` from module-level to inside `FactClaimExtractor.__init__`. Extended exception catch from `OSError` only to `(OSError, ImportError)`.
- **`test_fact_claim_lazy_import.py`**: 3 tests (import without torch, degradation to nlp=None, regex extraction still works).

## Verification
- FastAPI boots: `from api.main import app` → **53 routes loaded** (was crash before)
- Module import: `from fact_claim_extractor import FactClaimExtractor` → OK
- Tests: 3 passed

## Note
The **canonical fix** remains upgrading torch to >= 2.4 in the conda env. This PR is a **code hardening** that makes the system resilient to broken optional dependencies.

## Files removed and why
None.

## Files removed and why
RAS — defensive hardening, no behavioral change when spacy is available.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>