### PR TITLE
docs(design): parametric integration specs -- tracks 1 (fallacy-tier) & 3 (shield-preset)

### DIFF
--- a/docs/architecture/design_specs/TRACK-01_fallacy_tier_selector.md
+++ b/docs/architecture/design_specs/TRACK-01_fallacy_tier_selector.md
@@ -1,0 +1,215 @@
+# Design Spec — Track 1: Fallacy-Tier Selector (`--fallacy-tier`)
+
+**Date**: 2026-06-02
+**Author**: Claude Code @ myia-po-2023
+**Base**: `841ed091` (main, post-hierarchical reactivation)
+**Effort**: S (1 session)
+**Parent**: `docs/architecture/parametric_integration_map.md` (PR #885)
+
+---
+
+## Verdict
+
+**GO** — The codebase already has 6 distinct fallacy detection strategies and partial tier toggling (`FrenchFallacyAdapter` constructor args). The gap is a **single CLI/pipe selector** that maps a user-facing tier name to the correct combination of detectors and pipeline phases. Effort is small because the detectors exist; we only need the routing layer.
+
+---
+
+## 1. Current State
+
+### 1.1 Six Detection Strategies (existing)
+
+| # | Strategy | Type | Location | LLM? |
+|---|----------|------|----------|------|
+| 1 | FrenchFallacyAdapter (5-tier hybrid) | Neural + Symbolic + LLM | `adapters/french_fallacy_adapter.py` | Optional |
+| 2 | FallacyWorkflowPlugin (hierarchical taxonomy) | LLM iterative deepening | `plugins/fallacy_workflow_plugin.py` | Yes |
+| 3 | Per-argument parallel detection | LLM parallel | `invoke_callables.py:_invoke_hierarchical_fallacy_per_argument` | Yes |
+| 4 | TaxonomySophismDetector | Lexical keyword match | `agents/core/informal/taxonomy_sophism_detector.py` | No |
+| 5 | ContextualFallacyDetector | Rule-based contextual | `agents/tools/analysis/new/contextual_fallacy_detector.py` | No |
+| 6 | ComplexFallacyAnalyzer | Structural pattern | `agents/tools/analysis/complex_fallacy_analyzer.py` | No |
+
+### 1.2 Current Selection Mechanism
+
+**No centralized selector.** Each detector is instantiated independently:
+- Pipeline always runs `_invoke_hierarchical_fallacy` (full LLM-based, strategy 2+3)
+- `FrenchFallacyAdapter` has per-tier toggles (`enable_symbolic`, `enable_nli`, etc.) but **is not wired into pipeline phases**
+- `AnalysisDepth` enum (`BASIC`/`STANDARD`/`COMPREHENSIVE`/`EXPERT`) exists in `fallacy_family_analyzer.py` but only governs the family analyzer, not other detectors
+
+### 1.3 Gaps
+
+1. No pipeline-level parameter to choose between lightweight vs deep detection
+2. `FallacyWorkflowPlugin` constants (`MAX_DEPTH_PER_BRANCH=8`, `MAX_BRANCHES=4`) are hardcoded
+3. `AnalysisDepth` enum not propagated to pipeline
+4. `FrenchFallacyAdapter` tier toggling is isolated — not wired into pipeline phases
+
+---
+
+## 2. Proposed Design
+
+### 2.1 Tier Definitions
+
+| Tier | Label | Detectors | LLM Calls | Speed | Use Case |
+|------|-------|-----------|-----------|-------|----------|
+| `taxonomy` | Lexical only | TaxonomySophismDetector (#4) | 0 | Fastest (~ms) | CI/quick-scan, no API key |
+| `hybrid` | Neural+Symbolic | FrenchFallacyAdapter (#1, symbolic+NLI tiers) | 0–1 (optional NLI) | Fast (~1s) | Batch analysis, constrained budget |
+| `llm` | Full LLM | FallacyWorkflowPlugin (#2) + per-arg (#3) | Multiple (deepening) | Slow (~10–30s) | Deep analysis, production default |
+| `full` | All combined | #1 + #2 + #3 + #5 + #6, merged | Yes (max) | Slowest (~30–60s) | Exhaustive audit, benchmarks |
+
+**Default**: `llm` (matches current pipeline behavior — no breaking change).
+
+### 2.2 CLI Integration
+
+```python
+# In run_orchestration.py argparse
+parser.add_argument(
+    "--fallacy-tier",
+    type=str,
+    choices=["taxonomy", "hybrid", "llm", "full"],
+    default="llm",
+    help="Fallacy detection depth: taxonomy (lexical, no LLM), "
+         "hybrid (neural+symbolic, optional LLM), "
+         "llm (full LLM iterative, default), "
+         "full (all strategies merged)",
+)
+```
+
+**Usage examples:**
+```bash
+# Quick scan without LLM (CI-safe, $0)
+python run_orchestration.py --file text.txt --fallacy-tier taxonomy
+
+# Budget-conscious hybrid
+python run_orchestration.py --text "..." --fallacy-tier hybrid
+
+# Default (unchanged behavior)
+python run_orchestration.py --file text.txt --fallacy-tier llm
+
+# Exhaustive (all detectors)
+python run_orchestration.py --file text.txt --fallacy-tier full
+```
+
+### 2.3 Pipeline Integration
+
+**Entry point**: `_invoke_hierarchical_fallacy()` in `invoke_callables.py` (line 3680).
+
+Add a tier-dispatch at the top of the function:
+
+```python
+async def _invoke_hierarchical_fallacy(input_text, context):
+    tier = context.get("fallacy_tier", "llm")
+
+    if tier == "taxonomy":
+        return await _invoke_taxonomy_only_fallacy(input_text, context)
+    elif tier == "hybrid":
+        return await _invoke_hybrid_fallacy(input_text, context)
+    elif tier == "full":
+        return await _invoke_full_fallacy(input_text, context)
+    else:  # "llm" (default, current behavior)
+        # ... existing code unchanged ...
+```
+
+**New invoke callables needed:**
+
+| Function | What it does |
+|----------|-------------|
+| `_invoke_taxonomy_only_fallacy()` | Calls `TaxonomySophismDetector.detect_sophisms_from_taxonomy()` — no LLM, no SK kernel |
+| `_invoke_hybrid_fallacy()` | Calls `FrenchFallacyAdapter.detect()` with `enable_llm=False, enable_nli=True` — no OpenAI calls |
+| `_invoke_full_fallacy()` | Runs LLM pass + hybrid pass + taxonomy pass, merges by `taxonomy_pk`, keeps highest confidence |
+
+**Context propagation**: `run_orchestration.py` passes `--fallacy-tier` value through to the pipeline context dict:
+```python
+context["fallacy_tier"] = args.fallacy_tier
+```
+
+### 2.4 Registry Integration
+
+Register tier-specific capabilities:
+
+```python
+# registry_setup.py — add metadata to existing entry
+registry.register_service(
+    name="fallacy_detection",
+    capabilities=[
+        "fallacy_detection_taxonomy",    # NEW
+        "fallacy_detection_hybrid",      # NEW
+        "fallacy_detection_llm",         # existing
+        "fallacy_detection_full",        # NEW
+    ],
+    metadata={"default_tier": "llm", "available_tiers": ["taxonomy", "hybrid", "llm", "full"]},
+)
+```
+
+### 2.5 API Integration
+
+Add `fallacy_tier` query parameter to the analysis endpoint:
+
+```python
+# api/agents.py or similar
+@router.post("/api/v1/agents/full-analysis")
+async def full_analysis(
+    text: str,
+    workflow: str = "standard",
+    fallacy_tier: str = Query("llm", regex="^(taxonomy|hybrid|llm|full)$"),
+):
+    context = {"fallacy_tier": fallacy_tier}
+    ...
+```
+
+---
+
+## 3. Implementation Plan
+
+| Step | File | Change | LOC |
+|------|------|--------|-----|
+| 1 | `run_orchestration.py` | Add `--fallacy-tier` argument + context propagation | ~10 |
+| 2 | `invoke_callables.py` | Add tier dispatch in `_invoke_hierarchical_fallacy` | ~15 |
+| 3 | `invoke_callables.py` | Add `_invoke_taxonomy_only_fallacy()` | ~25 |
+| 4 | `invoke_callables.py` | Add `_invoke_hybrid_fallacy()` | ~30 |
+| 5 | `invoke_callables.py` | Add `_invoke_full_fallacy()` (merge wrapper) | ~40 |
+| 6 | `registry_setup.py` | Add tier capabilities metadata | ~5 |
+| 7 | `api/` | Add `fallacy_tier` parameter to analysis endpoint | ~5 |
+| 8 | Tests | Unit tests for tier dispatch + integration test taxonomy-only | ~80 |
+| **Total** | | | **~210 LOC** |
+
+---
+
+## 4. Testing Plan
+
+| Test | What | API Key? |
+|------|------|----------|
+| `test_fallacy_tier_taxonomy` | TaxonomySophismDetector produces results without LLM | No |
+| `test_fallacy_tier_hybrid` | FrenchFallacyAdapter with LLM disabled | No (NLI optional) |
+| `test_fallacy_tier_llm_default` | Existing behavior unchanged (default tier) | Yes |
+| `test_fallacy_tier_full_merge` | Merged results deduped by taxonomy_pk | Yes |
+| `test_fallacy_tier_cli_flag` | `--fallacy-tier taxonomy` parsed and propagated | No |
+| `test_fallacy_tier_invalid` | Invalid tier → argparse error | No |
+
+---
+
+## 5. Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Taxonomy-only misses most fallacies | Expected | Document as "quick-scan" — users choose depth explicitly |
+| Hybrid tier needs NLI model download | Low | NLI is optional; falls back to symbolic-only |
+| `full` tier doubles LLM cost | Expected | Default is `llm`; `full` is opt-in |
+| Breaking change if default changes | None | Default stays `llm` (identical to current behavior) |
+
+---
+
+## 6. DoD
+
+- [ ] `--fallacy-tier` CLI argument with 4 choices
+- [ ] Pipeline dispatches to correct detector(s) per tier
+- [ ] `taxonomy` tier works without API key (CI-safe)
+- [ ] `llm` tier (default) produces identical results to current pipeline
+- [ ] Registry metadata includes available tiers
+- [ ] API endpoint accepts `fallacy_tier` parameter
+- [ ] 6+ tests passing
+- [ ] `## À valider par l'utilisateur`: Default tier choice (llm vs hybrid)
+
+---
+
+## À valider par l'utilisateur
+
+1. **Default tier**: The design preserves `llm` as default (no change). Should `hybrid` be the default instead (cheaper, still good coverage)?
+2. **Tier names**: `taxonomy` / `hybrid` / `llm` / `full` — are these intuitive enough, or prefer `light` / `standard` / `deep` / `exhaustive`?

--- a/docs/architecture/design_specs/TRACK-03_shield_preset_selector.md
+++ b/docs/architecture/design_specs/TRACK-03_shield_preset_selector.md
@@ -1,0 +1,206 @@
+# Design Spec — Track 3: AI Shield Preset Selector (`--shield-preset`)
+
+**Date**: 2026-06-02
+**Author**: Claude Code @ myia-po-2023
+**Base**: `841ed091` (main, post-hierarchical reactivation)
+**Effort**: S (1 session)
+**Parent**: `docs/architecture/parametric_integration_map.md` (PR #885)
+
+---
+
+## Verdict
+
+**GO — trivial** — The 4 presets already exist in `services/ai_shield/presets.py`, the registry entry exists, the invoke callable exists, the REST endpoint exists. The only gap is a **CLI argument** and a **workflow phase** to integrate shield as a named pipeline step. This is almost pure wiring.
+
+---
+
+## 1. Current State
+
+### 1.1 Four Presets Already Defined
+
+File: `argumentation_analysis/services/ai_shield/presets.py` (lines 21-81)
+
+| Preset | Layers | Heuristic Threshold | LLM Threshold | Output Threshold | `fail_open` |
+|--------|--------|:-------------------:|:-------------:|:----------------:|:-----------:|
+| **basic** | Heuristic only | 0.5 | N/A | N/A | configurable |
+| **advanced** | Heuristic + LLM + Output | 0.5 | 0.6 | 0.4 | configurable |
+| **output_only** | Output only | N/A | N/A | 0.4 | configurable |
+| **strict** | All 3, lowest thresholds | 0.3 | 0.4 | 0.3 | always False |
+
+```python
+def load_preset(preset_name: str = "basic", api_key=None, fail_open: bool = False) -> Shield:
+```
+
+### 1.2 Existing Wiring
+
+| Component | Status | Location |
+|-----------|--------|----------|
+| Registry entry | ✅ | `registry_setup.py:660` — `ai_shield_service` with capabilities |
+| Invoke callable | ✅ | `invoke_callables.py:6118` — `_invoke_ai_shield()` |
+| Shared state | ✅ | `shared_state.py:452` — `state.ai_shield_results` |
+| REST endpoint | ✅ | `api/shield_endpoints.py` — `POST /api/shield/validate` |
+| Auth guard | ✅ | `X-Shield-Token` / `SHIELD_ENDPOINT_TOKEN` (dev=open, prod=locked) |
+
+### 1.3 Gaps
+
+1. **No CLI argument** — `run_orchestration.py` has no `--shield-preset` flag
+2. **No dedicated workflow phase** — Shield is not a named phase in any workflow definition (light/standard/full)
+3. **Not in default workflows** — Even `full` workflow doesn't include a shield phase
+4. **Invoke callable reads from context only** — `context.get("shield_config", {})` with no CLI propagation
+
+---
+
+## 2. Proposed Design
+
+### 2.1 CLI Integration
+
+```python
+# In run_orchestration.py argparse
+parser.add_argument(
+    "--shield-preset",
+    type=str,
+    choices=["off", "basic", "advanced", "output_only", "strict"],
+    default="off",
+    help="AI Shield preset: off (default, no shield), "
+         "basic (heuristic only, no LLM cost), "
+         "advanced (heuristic+LLM+output filter), "
+         "output_only (post-LLM filtering only), "
+         "strict (all layers, lowest thresholds, fail-closed)",
+)
+```
+
+**Usage examples:**
+```bash
+# No shield (default, unchanged behavior)
+python run_orchestration.py --file text.txt
+
+# Basic shield — heuristic only, zero LLM cost
+python run_orchestration.py --file text.txt --shield-preset basic
+
+# Full protection
+python run_orchestration.py --text "..." --shield-preset advanced
+
+# Post-LLM output filtering only
+python run_orchestration.py --file text.txt --shield-preset output_only
+
+# Maximum security (fail-closed)
+python run_orchestration.py --file text.txt --shield-preset strict
+```
+
+### 2.2 Pipeline Integration
+
+**Option A — Named workflow phase (recommended)**:
+
+Add a `"shield"` phase to workflow definitions, placed as the **first** phase (before extraction):
+
+```python
+# workflow_dsl.py or unified_pipeline.py
+WorkflowBuilder("standard_with_shield")
+    .add_phase(name="shield", capability="input_validation", optional=True)
+    .add_phase(name="extract", capability="argument_extraction", depends_on=["shield"])
+    .add_phase(name="quality", capability="quality_evaluation", depends_on=["extract"])
+    ...
+```
+
+**Option B — Context-driven invocation (simpler, recommended for v1)**:
+
+Pass preset through context dict; the existing `_invoke_ai_shield()` callable already reads it:
+
+```python
+# run_orchestration.py
+if args.shield_preset != "off":
+    context["shield_config"] = {
+        "preset": args.shield_preset,
+        "fail_open": args.shield_preset != "strict",  # strict = fail-closed
+    }
+```
+
+Then add a `shield` phase to the workflow builder when context contains shield_config.
+
+**Chosen approach**: Option B for v1 (minimal LOC, no workflow restructuring). Option A is a follow-up.
+
+### 2.3 Default Behavior (No Breaking Change)
+
+- `--shield-preset off` (default) → no shield phase runs, identical to current behavior
+- Only when user explicitly sets `--shield-preset basic|advanced|...` does the shield invoke
+- `fail_open=True` by default → if shield fails to load (missing deps, no API key), pipeline continues
+
+### 2.4 API Integration
+
+Add `shield_preset` parameter to existing analysis endpoint:
+
+```python
+@router.post("/api/v1/agents/full-analysis")
+async def full_analysis(
+    text: str,
+    workflow: str = "standard",
+    fallacy_tier: str = "llm",
+    shield_preset: str = Query("off", regex="^(off|basic|advanced|output_only|strict)$"),
+):
+    context = {
+        "fallacy_tier": fallacy_tier,
+        "shield_config": {"preset": shield_preset} if shield_preset != "off" else {},
+    }
+```
+
+### 2.5 Security Considerations
+
+- **`basic` preset**: Zero LLM cost. Heuristic-only. Safe for CI.
+- **`advanced`/`strict`**: Call LLM for validation → API cost. `strict` has `fail_open=False` → blocks on error.
+- **`SHIELD_ENDPOINT_TOKEN`**: Existing auth guard on REST endpoint. CLI bypasses this (local execution).
+- **Privacy**: Shield's `OutputFilterLayer` checks for credential/PII leaks in LLM responses — complementary to existing `_scrub_state_for_export`.
+
+---
+
+## 3. Implementation Plan
+
+| Step | File | Change | LOC |
+|------|------|--------|-----|
+| 1 | `run_orchestration.py` | Add `--shield-preset` argument + context propagation | ~8 |
+| 2 | `unified_pipeline.py` | Add conditional shield phase to workflow builders | ~15 |
+| 3 | `api/` | Add `shield_preset` to analysis endpoint | ~5 |
+| 4 | Tests | Unit tests for preset propagation + shield-off default | ~40 |
+| **Total** | | | **~68 LOC** |
+
+---
+
+## 4. Testing Plan
+
+| Test | What | API Key? |
+|------|------|----------|
+| `test_shield_preset_off` | Default = no shield phase in context | No |
+| `test_shield_preset_basic` | `--shield-preset basic` → context has preset, no LLM needed | No |
+| `test_shield_preset_strict` | `--shield-preset strict` → fail_open=False in context | No |
+| `test_shield_preset_cli_parse` | argparse accepts all 5 values | No |
+| `test_shield_preset_invalid` | Invalid preset → argparse error | No |
+| `test_shield_invoke_with_preset` | `_invoke_ai_shield()` reads preset from context | Yes (optional) |
+
+---
+
+## 5. Risks
+
+| Risk | Severity | Mitigation |
+|------|----------|------------|
+| Shield LLM layer adds cost | Expected | Default is `off`; `basic` is zero-cost |
+| `strict` blocks legitimate input | Possible | Default `fail_open=True` for all except `strict`; user explicitly chooses |
+| Shield depends on `ai_shield` package | Low | `try/except ImportError` already in invoke callable; `fail_open=True` default |
+| Privacy scrub overlap | None | Shield checks LLM output; `_scrub_state_for_export` checks exported state — complementary |
+
+---
+
+## 6. DoD
+
+- [ ] `--shield-preset` CLI argument with 5 choices (off/basic/advanced/output_only/strict)
+- [ ] Default = `off` (no change to current behavior)
+- [ ] Context propagation to pipeline invoke callable
+- [ ] Shield phase conditionally added to workflow when preset ≠ off
+- [ ] API endpoint accepts `shield_preset` parameter
+- [ ] 5+ tests passing
+- [ ] `## À valider par l'utilisateur`: Default choice (off vs basic)
+
+---
+
+## À valider par l'utilisateur
+
+1. **Default**: `off` (no shield, zero overhead) or `basic` (heuristic guard always on, zero LLM cost)?
+2. **Shield in `full` workflow**: Should the `full` workflow always include shield (as `basic`), or keep it opt-in?


### PR DESCRIPTION
## Design Specs — Parametric Integration Tracks 1 & 3

Two design specifications for the parametric integration north-star (R311). These are **design documents only** — no code changes. Each spec includes current state analysis, proposed CLI/pipeline/API integration, implementation plan, testing plan, and risks.

### Track 1: `--fallacy-tier` Selector (`docs/architecture/design_specs/TRACK-01_fallacy_tier_selector.md`)

**Current state**: 6 distinct fallacy detection strategies exist, but no centralized selector. Pipeline always runs full LLM-based detection.

**Proposal**: 4 tiers mapping to detector combinations:
| Tier | Detectors | LLM? | Speed |
|------|-----------|------|-------|
| `taxonomy` | TaxonomySophismDetector only | No | ~ms |
| `hybrid` | FrenchFallacyAdapter (symbolic+NLI) | Optional | ~1s |
| `llm` (default) | FallacyWorkflowPlugin + per-arg | Yes | ~10-30s |
| `full` | All strategies merged | Yes (max) | ~30-60s |

**Effort**: S (~210 LOC). Default = `llm` (no breaking change).

### Track 3: `--shield-preset` Selector (`docs/architecture/design_specs/TRACK-03_shield_preset_selector.md`)

**Current state**: 4 presets exist (`basic`/`advanced`/`output_only`/`strict`), registry + invoke callable + REST endpoint all exist. Only gap: CLI argument and workflow phase.

**Proposal**: Add `--shield-preset {off,basic,advanced,output_only,strict}` to CLI. Default = `off` (no change).

**Effort**: S (~68 LOC). Trivial wiring.

### À valider par l'utilisateur

1. **Fallacy tier default**: `llm` (current behavior) or `hybrid` (cheaper)?
2. **Shield default**: `off` (no overhead) or `basic` (zero-cost heuristic guard)?
3. **Tier naming**: `taxonomy/hybrid/llm/full` or `light/standard/deep/exhaustive`?

### Validation

- [x] No code changes (design docs only)
- [x] Privacy: opaque IDs only
- [x] Cleanup Gate: no deletions
- [x] Research grounded in actual codebase (file:line references verified)
