### PR TITLE
fix(cleanup): remove dead orchestrator refs post-#885

### DIFF
--- a/argumentation_analysis/pipelines/unified_pipeline.py
+++ b/argumentation_analysis/pipelines/unified_pipeline.py
@@ -292,12 +292,9 @@ async def _run_orchestration_pipeline(
     elif orchestration_mode == "conversation" or ":" in text:
         orchestrator = ConversationOrchestrator(llm_service, config)
         analysis_method = orchestrator.orchestrate_dialogue_analysis
-    elif orchestration_mode == "logique" or "tous les hommes" in text.lower():
-        orchestrator = LogiqueComplexeOrchestrator(llm_service, config)
-        analysis_method = orchestrator.orchestrate_complex_logical_analysis
-    else:  # Fallback sur l'orchestrateur LLM générique
-        orchestrator = RealLLMOrchestrator(llm_service, config)
-        analysis_method = orchestrator.orchestrate_multi_llm_analysis
+    else:  # Fallback sur l'orchestrateur conversationnel générique
+        orchestrator = ConversationOrchestrator(llm_service, config)
+        analysis_method = orchestrator.orchestrate_dialogue_analysis
 
     logger.info(f"Orchestrateur sélectionné: {orchestrator.__class__.__name__}")
 

--- a/project_core/rhetorical_analysis_from_scripts/educational_showcase_system.py
+++ b/project_core/rhetorical_analysis_from_scripts/educational_showcase_system.py
@@ -83,13 +83,10 @@ try:
     from argumentation_analysis.orchestration.unified_pipeline import (
         run_unified_analysis,
     )
-    from argumentation_analysis.orchestration.real_llm_orchestrator import (
-        RealConversationLogger,
-    )
-
-    # NOTE: L'import de source_management a été déplacé à l'extérieur du bloc try
+    # RealConversationLogger removed (#885) — use ConversationLogger directly
     from argumentation_analysis.orchestration.conversation_orchestrator import (
         ConversationOrchestrator,
+        ConversationLogger as RealConversationLogger,
     )
     from argumentation_analysis.core.report_generation import (
         UnifiedReportGenerator,

--- a/scripts/validation/validation_traces_master_fixed.py
+++ b/scripts/validation/validation_traces_master_fixed.py
@@ -51,9 +51,7 @@ from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 from argumentation_analysis.orchestration.cluedo_extended_orchestrator import (
     run_cluedo_oracle_game,
 )
-from argumentation_analysis.orchestration.logique_complexe_orchestrator import (
-    LogiqueComplexeOrchestrator,
-)
+# LogiqueComplexeOrchestrator removed (#885) — superseded by FOL/Tweety via Registry
 from argumentation_analysis.agents.core.pm.sherlock_enquete_agent import (
     SherlockEnqueteAgent,
     SherlockTools,
@@ -334,8 +332,16 @@ class MasterTraceValidator:
             # Capture du timestamp de début
             start_time = datetime.datetime.now()
 
-            # Création de l'orchestrateur logique complexe
-            orchestrateur = LogiqueComplexeOrchestrator(kernel)
+            # LogiqueComplexeOrchestrator removed (#885) — skip Einstein orchestration
+            self.logger.warning(
+                "LogiqueComplexeOrchestrator removed (#885). "
+                "Use FOL/Tweety via CapabilityRegistry instead."
+            )
+            return {
+                "case_name": case_name,
+                "status": "skipped",
+                "reason": "LogiqueComplexeOrchestrator removed (#885)",
+            }
 
             # Création des agents spécialisés avec outils
             sherlock_tools = SherlockTools(kernel)

--- a/tests/integration/workers/worker_einstein_tweety.py
+++ b/tests/integration/workers/worker_einstein_tweety.py
@@ -61,17 +61,8 @@ def einstein_riddle_state():
 
 @pytest.fixture
 def logique_complexe_orchestrator():
-    """Fixture pour l'orchestrateur de logique complexe."""
-    try:
-        from argumentation_analysis.orchestration.logique_complexe_orchestrator import (
-            LogiqueComplexeOrchestrator,
-        )
-        from semantic_kernel import Kernel
-
-        kernel = Kernel()
-        return LogiqueComplexeOrchestrator(kernel=kernel)
-    except ImportError:
-        pytest.skip("LogiqueComplexeOrchestrator non disponible")
+    """Fixture removed — LogiqueComplexeOrchestrator deleted (#885)."""
+    pytest.skip("LogiqueComplexeOrchestrator removed (#885)")
 
 
 @pytest.fixture

--- a/tests/unit/orchestration/test_specialized_orchestrators.py
+++ b/tests/unit/orchestration/test_specialized_orchestrators.py
@@ -53,9 +53,7 @@ try:
     from argumentation_analysis.orchestration.conversation_orchestrator import (
         ConversationOrchestrator,
     )
-    from argumentation_analysis.orchestration.logique_complexe_orchestrator import (
-        LogiqueComplexeOrchestrator,
-    )
+    # LogiqueComplexeOrchestrator removed (#885) — superseded by FOL/Tweety via Registry
     from argumentation_analysis.config.settings import AppSettings
 
     SPECIALIZED_AVAILABLE = True
@@ -161,35 +159,6 @@ class TestConversationOrchestrator:
         assert "TRACE ANALYTIQUE" in result["report"]
 
 
-class TestLogiqueComplexeOrchestrator:
-    """Tests pour l'orchestrateur de logique complexe."""
-
-    @pytest.fixture
-    def logic_orchestrator(self, mock_kernel: Kernel):
-        """Instance de LogiqueComplexeOrchestrator pour les tests."""
-        return LogiqueComplexeOrchestrator(kernel=mock_kernel)
-
-    def test_logic_orchestrator_initialization(self, logic_orchestrator):
-        """Test de l'initialisation de l'orchestrateur de logique complexe."""
-        # La classe a une définition minimale maintenant.
-        assert logic_orchestrator.kernel is not None
-        assert hasattr(logic_orchestrator, "_logger")
-
-    @pytest.mark.asyncio
-    async def test_run_einstein_puzzle_simulation(self, logic_orchestrator):
-        """Test de la seule méthode disponible (simulation)."""
-        puzzle_data = {"test": "data"}
-        # Mock de la méthode pour la prévisibilité
-        logic_orchestrator.run_einstein_puzzle = AsyncMock(
-            return_value={"solution": "mocked", "success": True}
-        )
-
-        result = await logic_orchestrator.run_einstein_puzzle(puzzle_data)
-
-        logic_orchestrator.run_einstein_puzzle.assert_called_once_with(puzzle_data)
-        assert result["success"] is True
-        assert result["solution"] == "mocked"
-
 
 class TestSpecializedOrchestratorsIntegration:
     """Tests d'intégration entre orchestrateurs spécialisés."""
@@ -202,8 +171,7 @@ class TestSpecializedOrchestratorsIntegration:
         convo = ConversationOrchestrator(mode="demo")
         assert isinstance(convo, ConversationOrchestrator)
 
-        logic = LogiqueComplexeOrchestrator(kernel=mock_kernel)
-        assert isinstance(logic, LogiqueComplexeOrchestrator)
+        # LogiqueComplexeOrchestrator removed (#885) — only cluedo+conversation tested
 
     @pytest.mark.asyncio
     @patch(
@@ -214,13 +182,8 @@ class TestSpecializedOrchestratorsIntegration:
         "argumentation_analysis.orchestration.conversation_orchestrator.ConversationOrchestrator.run_demo_conversation",
         new_callable=AsyncMock,
     )
-    @patch(
-        "argumentation_analysis.orchestration.logique_complexe_orchestrator.LogiqueComplexeOrchestrator.run_einstein_puzzle",
-        new_callable=AsyncMock,
-    )
     async def test_orchestrator_collaboration_mocked(
         self,
-        mock_logic_run,
         mock_convo_run,
         mock_cluedo_run,
         mock_kernel: Kernel,
@@ -229,7 +192,6 @@ class TestSpecializedOrchestratorsIntegration:
         """Test de collaboration simulée entre les orchestrateurs."""
         mock_cluedo_run.return_value = {"workflow_info": {"status": "completed"}}
         mock_convo_run.return_value = {"status": "success", "report": "report"}
-        mock_logic_run.return_value = {"solution": "mocked", "success": True}
 
         complex_text = "Un texte complexe pour tester tout le monde."
 
@@ -241,21 +203,17 @@ class TestSpecializedOrchestratorsIntegration:
         await cluedo_orchestrator.setup_workflow()
 
         conversation_orchestrator = ConversationOrchestrator(mode="demo")
-        logic_orchestrator = LogiqueComplexeOrchestrator(kernel=mock_kernel)
 
         investigation_result = await cluedo_orchestrator.execute_workflow(complex_text)
         dialogue_result = await conversation_orchestrator.run_demo_conversation(
             complex_text
         )
-        logic_result = await logic_orchestrator.run_einstein_puzzle({})
 
         mock_cluedo_run.assert_called_once_with(complex_text)
         mock_convo_run.assert_called_once_with(complex_text)
-        mock_logic_run.assert_called_once_with({})
 
         assert "workflow_info" in investigation_result
         assert "report" in dialogue_result
-        assert "success" in logic_result
 
 
 if __name__ == "__main__":

--- a/tests/unit/orchestration/test_unified_orchestrations.py
+++ b/tests/unit/orchestration/test_unified_orchestrations.py
@@ -31,9 +31,7 @@ try:
     from argumentation_analysis.orchestration.conversation_orchestrator import (
         ConversationOrchestrator,
     )
-    from argumentation_analysis.orchestration.real_llm_orchestrator import (
-        RealLLMOrchestrator,
-    )
+    # RealLLMOrchestrator removed (#885) — superseded by UnifiedPipeline
     from argumentation_analysis.utils.tweety_error_analyzer import (
         TweetyErrorAnalyzer,
         TweetyErrorFeedback,
@@ -126,21 +124,7 @@ class TestUnifiedOrchestrations:
         assert isinstance(conv_state, dict)
         assert conv_state["mode"] == "demo"
 
-    @pytest.mark.xfail(
-        reason="RealLLMOrchestrator deprecated — .mode/.config attributes removed (#274)",
-        strict=True,
-    )
-    def test_real_llm_orchestrator_configuration(self):
-        """Test de configuration du RealLLMOrchestrator."""
-        orchestrator = RealLLMOrchestrator(mode="real")
-
-        assert orchestrator.mode == "real"
-        assert hasattr(orchestrator, "config")
-        assert isinstance(orchestrator.config, dict)
-
-        # Test default config values
-        assert orchestrator.config.get("retry_attempts") == 3
-        assert orchestrator.config.get("cache_enabled") is True
+    # RealLLMOrchestrator removed (#885) — test deleted
 
     def test_multi_agent_coordination(self):
         """Test de coordination multi-agents."""
@@ -248,108 +232,6 @@ class TestUnifiedOrchestrations:
                 orch.cleanup()
 
 
-class TestRealLLMOrchestrationAdvanced:
-    """Tests avancés pour RealLLMOrchestrator."""
-
-    def _create_authentic_gpt4o_mini_instance(self):
-        """Crée une instance authentique de gpt-5-mini au lieu d'un mock."""
-        config = UnifiedConfig()
-        # Assurez-vous que la méthode get_kernel_with_gpt4o_mini existe et est correcte
-        if hasattr(config, "get_kernel_with_gpt4o_mini"):
-            return asyncio.run(config.get_kernel_with_gpt4o_mini())
-        # Fallback ou erreur si la méthode n'existe pas
-        raise AttributeError(
-            "UnifiedConfig n'a pas de méthode 'get_kernel_with_gpt4o_mini'"
-        )
-
-    def _make_authentic_llm_call(self, prompt: str) -> str:
-        """Fait un appel authentique à gpt-5-mini."""
-        try:
-            kernel = self._create_authentic_gpt4o_mini_instance()
-            result = asyncio.run(kernel.invoke("chat", input=prompt))
-            return str(result)
-        except Exception as e:
-            logger.warning(f"Appel LLM authentique échoué: {e}")
-            return "Authentic LLM call failed"
-
-    def setup_method(self):
-        """Configuration initiale pour chaque test."""
-        self.test_text = "L'Ukraine a été créée par la Russie. Donc Poutine a raison."
-        self.mock_llm_service = MagicMock()
-        self.mock_llm_service.invoke = AsyncMock(return_value="Mock LLM response")
-
-    @pytest.mark.xfail(
-        reason="RealLLMOrchestrator deprecated — .kernel/.is_initialized attributes removed (#274)",
-        strict=True,
-    )
-    def test_real_llm_orchestrator_initialization(self):
-        """Test d'initialisation complète du RealLLMOrchestrator."""
-        orchestrator = RealLLMOrchestrator(mode="real", kernel=self.mock_llm_service)
-
-        # Before initialization
-        assert not orchestrator.is_initialized
-        assert hasattr(orchestrator, "kernel")
-        assert orchestrator.kernel is self.mock_llm_service
-
-        # Check status API
-        status = orchestrator.get_status()
-        assert isinstance(status, dict)
-        assert status["is_initialized"] is False
-
-    def test_bnf_feedback_integration(self):
-        """Test d'intégration avec TweetyErrorAnalyzer pour feedback BNF."""
-        orchestrator = RealLLMOrchestrator(kernel=self.mock_llm_service)
-
-        # Simuler une erreur Tweety
-        error_text = "Predicate 'invalid_pred' has not been declared"
-
-        analyzer = TweetyErrorAnalyzer()
-        feedback = analyzer.analyze_error(error_text)
-
-        assert hasattr(feedback, "error_type")
-        assert hasattr(feedback, "corrections")
-        assert hasattr(feedback, "bnf_rules")
-
-    @patch("config.unified_config.UnifiedConfig.get_kernel_with_gpt4o_mini")
-    def test_intelligent_retry_mechanism(self, mock_get_kernel):
-        """Test du mécanisme de retry intelligent avec un kernel mocké."""
-        # Configurer le mock pour simuler un LLM qui échoue puis réussit
-        mock_kernel_instance = MagicMock(spec=Kernel)
-        mock_kernel_instance.invoke = AsyncMock(
-            side_effect=[Exception("First attempt fails"), "Success on retry"]
-        )
-        mock_get_kernel.return_value = mock_kernel_instance
-
-        # L'orchestrateur va maintenant utiliser le kernel mocké via la config
-        orchestrator = RealLLMOrchestrator(kernel=mock_kernel_instance)
-
-        # Le test original peut continuer, en supposant que l'orchestrateur est
-        # conçu pour gérer une exception et potentiellement réessayer.
-        try:
-            result = orchestrator.run_real_llm_orchestration(self.test_text)
-            # Le test attend un succès au deuxième essai
-            assert isinstance(result, dict)
-            # On pourrait même vérifier que le service a été appelé deux fois
-            # assert mock_kernel_instance.invoke.call_count == 2
-        except Exception:
-            # Si un retry n'est pas implémenté, le test échouera ici, ce qui est attendu.
-            pass
-
-    def test_semantic_kernel_integration(self):
-        """Test d'intégration avec Semantic Kernel."""
-        orchestrator = RealLLMOrchestrator(kernel=self.mock_llm_service)
-
-        # Test d'initialisation du kernel
-        if hasattr(orchestrator, "initialize"):
-            orchestrator.initialize()
-
-        # Vérifier que le kernel est configuré
-        if hasattr(orchestrator, "kernel"):
-            assert (
-                orchestrator.kernel is not None or orchestrator.kernel is None
-            )  # Selon implémentation
-
-
 class TestUnifiedSystemCoordination:
     """Tests de coordination système unifiée."""
 
@@ -368,11 +250,7 @@ class TestUnifiedSystemCoordination:
 
         assert conv_orchestrator is not None
 
-        # Test avec configuration LLM réel
-        real_config = UnifiedConfig(orchestration_type="REAL")
-        real_orchestrator = RealLLMOrchestrator(config=real_config)
-
-        assert real_orchestrator is not None
+        # RealLLMOrchestrator removed (#885) — only conversation mapping tested
 
     def test_agent_to_orchestrator_communication(self):
         """Test de communication agent vers orchestrateur."""
@@ -385,36 +263,7 @@ class TestUnifiedSystemCoordination:
                 if hasattr(agent, "orchestrator"):
                     assert agent.orchestrator is not None
 
-    @pytest.mark.xfail(
-        reason="RealLLMOrchestrator deprecated — .get_status()/.get_metrics() removed (#274)",
-        strict=True,
-    )
-    def test_conversation_to_real_llm_handoff(self):
-        """Test de handoff entre orchestrateurs."""
-        # Phase 1: Orchestration conversationnelle
-        conv_orchestrator = ConversationOrchestrator(mode="demo")
-        conv_result = conv_orchestrator.run_orchestration(self.test_text)
-
-        assert isinstance(conv_result, str)
-
-        # Get conversation state for handoff
-        conv_state = conv_orchestrator.get_conversation_state()
-        assert isinstance(conv_state, dict)
-        assert "mode" in conv_state
-
-        # Phase 2: Create real LLM orchestrator
-        mock_llm = MagicMock()
-        real_orchestrator = RealLLMOrchestrator(kernel=mock_llm)
-
-        # Verify status before initialization
-        status = real_orchestrator.get_status()
-        assert isinstance(status, dict)
-        assert not status["is_initialized"]
-
-        # Verify metrics API
-        metrics = real_orchestrator.get_metrics()
-        assert isinstance(metrics, dict)
-        assert metrics["total_requests"] == 0
+    # test_conversation_to_real_llm_handoff removed (#885) — RealLLMOrchestrator deleted
 
     def test_authentic_mode_validation(self):
         """Test de validation du mode authentique."""


### PR DESCRIPTION
## Summary

Cleanup of dead references left after #887 deleted `RealLLMOrchestrator` and `LogiqueComplexeOrchestrator`. Several callers still had dangling imports and dead code paths that would crash if reached.

## Files removed and why

| File | Type | Last useful date | Reason |
|------|------|-----------------|--------|
| N/A (no deletions) | — | — | Only editing existing files to remove dead refs |

## Changes

| File | Change |
|------|--------|
| `unified_pipeline.py` | Replace `LogiqueComplexeOrchestrator`/`RealLLMOrchestrator` branches with `ConversationOrchestrator` fallback |
| `educational_showcase_system.py` | Replace `RealConversationLogger` import with `ConversationLogger` alias |
| `validation_traces_master_fixed.py` | Replace `LogiqueComplexeOrchestrator` usage with skip+warning |
| `worker_einstein_tweety.py` | Skip `LogiqueComplexe` fixture (module deleted) |
| `test_specialized_orchestrators.py` | Remove `TestLogiqueComplexeOrchestrator` class, simplify integration tests |
| `test_unified_orchestrations.py` | Remove `TestRealLLMOrchestrationAdvanced` class + RealLLM handoff test |

## Verification

- 30 tests passing (3 test files)
- 0 dead Python imports remaining (`grep -rn` verified)
- `unified_pipeline.py` import succeeds
- `educational_showcase_system.py` edit verified (alias chain works)

## Related

- #885 (original scoping), #887 (deletion of the 2 orchestrators)
- Follow-up to R311b plan (orchestration consolidation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)