### PR TITLE
docs(R317): CaseAI scoping + 3 design specs for next-cycle selectors (#901)

### DIFF
--- a/docs/architecture/design_specs/TRACK-counter-strategy.md
+++ b/docs/architecture/design_specs/TRACK-counter-strategy.md
@@ -1,0 +1,135 @@
+# TRACK-counter-strategy — Design Spec
+
+**ID**: TRACK-counter-strategy
+**Issue**: #901 (North-Star, po-2023 lane)
+**Effort**: S (~120 LOC)
+**Owner**: po-2023 (conceptual, non-argparse → po-2025 implements CLI)
+**Date**: 2026-06-02
+
+---
+
+## Summary
+
+Expose the 5 rhetorical counter-argument strategies as a selectable `--counter-strategy` parameter, allowing users to force a specific strategy or use the default auto-selection logic.
+
+---
+
+## Current State
+
+### Strategies (5)
+
+Defined in `argumentation_analysis/agents/core/counter_argument/definitions.py`:
+
+| Strategy | Enum | Description |
+|----------|------|-------------|
+| Socratic Questioning | `SOCRATIC_QUESTIONING` | Challenge assumptions through targeted questions |
+| Reductio ad Absurdum | `REDUCTIO_AD_ABSURDUM` | Show the argument leads to absurd consequences |
+| Analogical Counter | `ANALOGICAL_COUNTER` | Use analogies to illustrate flaws |
+| Authority Appeal | `AUTHORITY_APPEAL` | Cite experts/research contradicting the claim |
+| Statistical Evidence | `STATISTICAL_EVIDENCE` | Use data/studies to contradict |
+
+### Auto-Selection Logic
+
+`RhetoricalStrategies.suggest_strategy(argument_type, content)` in `strategies.py` picks based on:
+- Content keywords (`"statistique"` → STATISTICAL_EVIDENCE, `"tous"` → ANALOGICAL_COUNTER)
+- Argument type mapping (`deductive` → REDUCTIO_AD_ABSURDUM, etc.)
+- Default fallback → SOCRATIC_QUESTIONING
+
+### Current Wiring
+
+- `_invoke_counter_argument()` in `invoke_callables.py:979` — uses `plugin.suggest_strategy()` then `plugin.generate_counter_argument()`
+- No CLI flag, no context parameter, no way to force a specific strategy
+- The `suggest_strategy()` result is used to pick the template, but LLM enrichment can override
+
+---
+
+## Proposed Design
+
+### CLI Signature
+
+```bash
+python -m argumentation_analysis.run_orchestration \
+  --mode pipeline \
+  --counter-strategy auto           # default: auto-selection
+  --counter-strategy socratic       # force Socratic questioning
+  --counter-strategy reductio       # force Reductio ad Absurdum
+  --counter-strategy analogy        # force Analogical Counter
+  --counter-strategy authority      # force Authority Appeal
+  --counter-strategy statistical    # force Statistical Evidence
+```
+
+### Choices
+
+| Value | Strategy | Effect |
+|-------|----------|--------|
+| `auto` (default) | Auto-selected | Current behavior unchanged |
+| `socratic` | `SOCRATIC_QUESTIONING` | Force Socratic method |
+| `reductio` | `REDUCTIO_AD_ABSURDUM` | Force reductio ad absurdum |
+| `analogy` | `ANALOGICAL_COUNTER` | Force analogical counter |
+| `authority` | `AUTHORITY_APPEAL` | Force authority appeal |
+| `statistical` | `STATISTICAL_EVIDENCE` | Force statistical evidence |
+
+### Context Propagation
+
+```python
+# run_orchestration.py
+parser.add_argument(
+    "--counter-strategy",
+    choices=["auto", "socratic", "reductio", "analogy", "authority", "statistical"],
+    default="auto",
+)
+context["counter_strategy"] = args.counter_strategy
+```
+
+### Pipeline Dispatch
+
+In `_invoke_counter_argument()` (invoke_callables.py:979):
+
+```python
+# After plugin instantiation:
+forced_strategy = context.get("counter_strategy", "auto")
+if forced_strategy != "auto":
+    from argumentation_analysis.agents.core.counter_argument.definitions import RhetoricalStrategy
+    strategy_map = {
+        "socratic": RhetoricalStrategy.SOCRATIC_QUESTIONING,
+        "reductio": RhetoricalStrategy.REDUCTIO_AD_ABSURDUM,
+        "analogy": RhetoricalStrategy.ANALOGICAL_COUNTER,
+        "authority": RhetoricalStrategy.AUTHORITY_APPEAL,
+        "statistical": RhetoricalStrategy.STATISTICAL_EVIDENCE,
+    }
+    # Override auto-selection with forced strategy
+    strategy = {"strategy": strategy_map[forced_strategy].value}
+```
+
+### Point of Wiring
+
+- **CLI**: `run_orchestration.py` → `argparse` (1 argument)
+- **Context**: `run_unified_analysis(context={"counter_strategy": ...})`
+- **Dispatch**: `_invoke_counter_argument()` line ~990, after `plugin.suggest_strategy()`
+- **Tests**: `tests/unit/argumentation_analysis/test_counter_strategy_selector.py`
+
+### LOC Estimate
+
+| Change | LOC |
+|--------|-----|
+| argparse addition | 6 |
+| context propagation | 1 |
+| dispatch logic in invoke_callables | 15 |
+| tests (6 parametrized) | 90 |
+| **Total** | **~112** |
+
+---
+
+## Backward Compatibility
+
+- Default `auto` = exact current behavior (no breaking change)
+- Forced strategies only change the template selection; LLM enrichment still runs
+- No changes to `RhetoricalStrategies` class or `definitions.py`
+
+---
+
+## Questions for User
+
+1. **Naming**: `--counter-strategy` or `--rhetorical-strategy`? (Currently `--counter-strategy` feels more user-facing)
+2. **Multiple strategies**: Should we support `--counter-strategy socratic,statistical` (apply multiple strategies to different arguments)? Or single-only for simplicity?
+3. **Auto-mode enhancement**: Should `auto` also consider fallacy types (e.g., `Appeal to Authority` → `AUTHORITY_APPEAL` strategy)?

--- a/docs/architecture/design_specs/TRACK-democratech-params.md
+++ b/docs/architecture/design_specs/TRACK-democratech-params.md
@@ -1,0 +1,162 @@
+# TRACK-democratech-params — Design Spec
+
+**ID**: TRACK-democratech-params
+**Issue**: #901 (North-Star, po-2023 lane)
+**Effort**: S (~90 LOC)
+**Owner**: po-2023 (conceptual, non-argparse → po-2025 implements CLI)
+**Date**: 2026-06-02
+
+---
+
+## Summary
+
+Expose governance/voting parameters (`--vote-method`, `--consensus-threshold`) as CLI parameters, allowing users to select the voting algorithm and consensus threshold for the governance phase.
+
+---
+
+## Current State
+
+### Voting Methods (7)
+
+Defined in `argumentation_analysis/agents/core/governance/governance_methods.py`:
+
+| Method | Function | Description |
+|--------|----------|-------------|
+| Majority | `majority_voting()` | Each agent votes top choice; most votes wins |
+| Plurality | `plurality_voting()` | Alias for majority (single-winner) |
+| Borda | `borda_count()` | Preference scoring: n-1 for top, n-2 for second, etc. |
+| Condorcet | `condorcet_method()` | Pairwise comparison; Borda fallback if no winner |
+| Quadratic | `quadratic_voting()` | Budget-based allocation with personality-aware spending |
+| Byzantine | `byzantine_consensus()` | Fault-tolerant consensus with traitor tolerance |
+| Raft | `raft_consensus()` | Leader-based distributed consensus |
+
+### Governance Plugin
+
+`argumentation_analysis/plugins/governance_plugin.py` exposes 6 `@kernel_function` methods:
+
+| Method | Signature |
+|--------|-----------|
+| `detect_conflicts_fn` | `(positions_json) → conflicts_json` |
+| `resolve_conflict_fn` | `(conflict_json, strategy) → resolution_json` |
+| `compute_consensus_metrics` | `(results_json) → metrics_json` |
+| `list_governance_methods` | `() → methods_json` |
+| `social_choice_vote` | `(input_json with method) → winner_json` |
+| `find_condorcet_winner` | `(input_json) → winner_json` |
+
+### Current Wiring
+
+- `_invoke_governance()` in `invoke_callables.py:1324` — hardcodes `method="copeland"` for social choice voting
+- `resolve_conflict_fn()` hardcodes `strategy="collaborative"`
+- No CLI flag, no context parameter
+- `consensus_threshold` not exposed anywhere (hardcoded in metrics calculation)
+
+---
+
+## Proposed Design
+
+### CLI Signature
+
+```bash
+python -m argumentation_analysis.run_orchestration \
+  --vote-method majority           # default: copeland (current behavior)
+  --vote-method borda
+  --vote-method condorcet
+  --vote-method quadratic
+  --consensus-threshold 0.7        # default: 0.5 (50%)
+```
+
+### Vote Method Choices
+
+| Value | Method | Description |
+|-------|--------|-------------|
+| `copeland` (default) | Copeland method | Current behavior (pairwise wins scoring) |
+| `majority` | `majority_voting()` | Simple majority |
+| `borda` | `borda_count()` | Preference-based scoring |
+| `condorcet` | `condorcet_method()` | Pairwise comparison |
+| `quadratic` | `quadratic_voting()` | Budget-based quadratic |
+| `byzantine` | `byzantine_consensus()` | Fault-tolerant consensus |
+| `raft` | `raft_consensus()` | Leader-based consensus |
+
+### Context Propagation
+
+```python
+# run_orchestration.py
+parser.add_argument(
+    "--vote-method",
+    choices=["copeland", "majority", "borda", "condorcet", "quadratic", "byzantine", "raft"],
+    default="copeland",
+)
+parser.add_argument(
+    "--consensus-threshold",
+    type=float,
+    default=0.5,
+    help="Consensus threshold (0.0-1.0). Default: 0.5",
+)
+context["vote_method"] = args.vote_method
+context["consensus_threshold"] = args.consensus_threshold
+```
+
+### Pipeline Dispatch
+
+In `_invoke_governance()` (invoke_callables.py:1324):
+
+```python
+# Replace hardcoded "copeland":
+vote_method = context.get("vote_method", "copeland")
+vote_input = json.dumps({
+    "method": vote_method,    # was: "copeland"
+    "ballots": ballots,
+    "options": options,
+})
+vote_result = json.loads(plugin.social_choice_vote(vote_input))
+
+# Use consensus threshold in metrics:
+consensus_threshold = context.get("consensus_threshold", 0.5)
+metrics_json = plugin.compute_consensus_metrics(json.dumps({
+    **vote_result,
+    "threshold": consensus_threshold,
+}))
+```
+
+### Point of Wiring
+
+- **CLI**: `run_orchestration.py` → argparse (2 arguments)
+- **Context**: `run_unified_analysis(context={"vote_method": ..., "consensus_threshold": ...})`
+- **Dispatch**: `_invoke_governance()` lines ~1378 (vote method) and ~1383 (threshold)
+- **Tests**: `tests/unit/argumentation_analysis/test_democratech_params.py`
+
+### LOC Estimate
+
+| Change | LOC |
+|--------|-----|
+| argparse additions (2 args) | 14 |
+| context propagation | 2 |
+| vote method dispatch | 5 |
+| consensus threshold usage | 8 |
+| tests (8 parametrized) | 65 |
+| **Total** | **~94** |
+
+---
+
+## Backward Compatibility
+
+- Default `copeland` = exact current behavior (no breaking change)
+- Default `consensus_threshold=0.5` = 50% majority (standard)
+- Governance phase is already optional in non-spectacular workflows
+
+---
+
+## Implementation Notes
+
+- **Validation**: `--consensus-threshold` must be in [0.0, 1.0]; argparse `type=float` + validation in dispatch
+- **Social choice**: `social_choice_vote()` already accepts a `method` field — just replace the hardcoded `"copeland"`
+- **Plurality**: Excluded from choices (alias for majority, adds confusion)
+- **Threshold**: Used in `compute_consensus_metrics()` to classify consensus as "achieved" or "failed"
+
+---
+
+## Questions for User
+
+1. **Default method**: Keep `copeland` (current) or switch to `majority` (more intuitive)?
+2. **Conflict resolution strategy**: Also expose as `--conflict-strategy collaborative|competitive|avoidant|compromising`? Or keep hardcoded `collaborative`?
+3. **Agent count**: Should we expose `--governance-agents N` (number of simulated agents)? Currently hardcoded to `len(arguments[:6])`.

--- a/docs/architecture/design_specs/TRACK-formal-extension.md
+++ b/docs/architecture/design_specs/TRACK-formal-extension.md
@@ -1,0 +1,164 @@
+# TRACK-formal-extension — Design Spec
+
+**ID**: TRACK-formal-extension
+**Issue**: #901 (North-Star, po-2023 lane)
+**Effort**: M (~180 LOC)
+**Owner**: po-2023 (conceptual, non-argparse → po-2025 implements CLI)
+**Date**: 2026-06-02
+
+---
+
+## Summary
+
+Expose the formal logic extension handlers (Tweety/JPype) as a selectable `--formal-extension` parameter, allowing users to pick which advanced formal reasoning capabilities run in the pipeline.
+
+---
+
+## Current State
+
+### Formal Extension Handlers (17 invoke callables)
+
+All in `argumentation_analysis/orchestration/invoke_callables.py`:
+
+| Handler | Line | Capability | Status |
+|---------|------|-----------|--------|
+| `_invoke_ranking` | 2583 | `ranking` | Active in spectacular |
+| `_invoke_bipolar` | 2641 | `bipolar` | Active in spectacular |
+| `_invoke_aba` | 2667 | `aba` | Active in spectacular |
+| `_invoke_adf` | 2697 | `adf` | Active in spectacular |
+| `_invoke_aspic` | 2798 | `aspic_analysis` | Active in spectacular |
+| `_invoke_probabilistic` | 2929 | `probabilistic` | Active in spectacular |
+| `_invoke_dialogue` | 2968 | `dialogue_games` | Active in spectacular |
+| `_invoke_dl` | 3087 | `description_logic` | Active in spectacular |
+| `_invoke_cl` | 3124 | `cl` | Active in spectacular |
+| `_invoke_sat` | 3162 | `sat` | Active in spectacular |
+| `_invoke_setaf` | 3188 | `setaf` | Active in spectacular |
+| `_invoke_weighted` | 3216 | `weighted` | Active in spectacular |
+| `_invoke_social` | 3250 | `social` | Active in spectacular |
+| `_invoke_eaf` | 3471 | `eaf` | Active in spectacular |
+| `_invoke_delp` | 3496 | `delp` | Active in spectacular |
+| `_invoke_qbf` | 3524 | `qbf` | Active in spectacular |
+| `_invoke_asp_reasoning` | 3555 | `asp_reasoning` | Active in spectacular |
+
+### Base Formal Phases (always run in spectacular)
+
+| Handler | Line | Capability |
+|---------|------|-----------|
+| `_invoke_propositional_logic` | 4465 | `pl` |
+| `_invoke_fol_reasoning` | 4866 | `fol` |
+| `_invoke_modal_logic` | 5318 | `modal` |
+| `_invoke_dung_extensions` | 5405 | `dung_extensions` |
+
+### Wiring
+
+- All 17 are registered as capabilities in `registry_setup.py` and appear as phases in the `spectacular` workflow
+- They require JPype/Tweety JVM — skipped gracefully if unavailable
+- No CLI flag to enable/disable individual extensions
+
+---
+
+## Proposed Design
+
+### CLI Signature
+
+```bash
+python -m argumentation_analysis.run_orchestration \
+  --formal-extension all              # default: run all 17
+  --formal-extension core             # only base 4 (pl, fol, modal, dung)
+  --formal-extension ranking,bipolar  # specific subset
+  --formal-extension none             # skip all formal extensions
+```
+
+### Extension Groups
+
+| Group | Extensions | Description |
+|-------|-----------|-------------|
+| `core` | pl, fol, modal, dung_extensions | Always-run base formal phases |
+| `dung-family` | ranking, bipolar, setaf, weighted, social, eaf | Dung semantics variants |
+| `structured` | aspic, aba, adf, delp | Structured argumentation |
+| `logic-extended` | dl, cl, sat, qbf, asp, dialogue, probabilistic | Advanced logic |
+
+### CLI Choices
+
+```
+--formal-extension all|core|none|<comma-separated-list>
+```
+
+Default: `all` (current behavior — no breaking change).
+
+### Context Propagation
+
+```python
+# run_orchestration.py
+parser.add_argument(
+    "--formal-extension",
+    default="all",
+    help="Formal extensions to run: all, core, none, or comma-separated list",
+)
+context["formal_extension_filter"] = args.formal_extension
+```
+
+### Pipeline Dispatch
+
+In the spectacular workflow builder (or `_invoke_*` callables):
+
+```python
+formal_filter = context.get("formal_extension_filter", "all")
+
+if formal_filter == "none":
+    # Skip all formal phases
+    return {"status": "skipped", "reason": "formal_extension=none"}
+elif formal_filter == "core":
+    # Only run pl/fol/modal/dung, skip the 17 extensions
+    if capability not in ("pl", "fol", "modal", "dung_extensions"):
+        return {"status": "skipped", "reason": f"not in core: {capability}"}
+elif formal_filter != "all":
+    # Parse comma-separated list
+    allowed = set(formal_filter.split(","))
+    if capability not in allowed:
+        return {"status": "skipped", "reason": f"not in filter: {capability}"}
+```
+
+### Point of Wiring
+
+- **CLI**: `run_orchestration.py` → argparse (1 argument)
+- **Context**: `run_unified_analysis(context={"formal_extension_filter": ...})`
+- **Dispatch**: Each `_invoke_*` callable reads context at entry; OR workflow builder filters phases
+- **Preferred**: Filter at workflow construction time (remove phases from WorkflowDefinition before execution)
+- **Tests**: `tests/unit/argumentation_analysis/test_formal_extension_selector.py`
+
+### LOC Estimate
+
+| Change | LOC |
+|--------|-----|
+| argparse addition | 7 |
+| context propagation | 1 |
+| workflow phase filter function | 30 |
+| invoke-callable guards (or workflow filter) | 25 |
+| tests (8 parametrized) | 120 |
+| **Total** | **~183** |
+
+---
+
+## Backward Compatibility
+
+- Default `all` = exact current behavior
+- `core` provides a fast path for CI (skip 17 Tweety phases, keep base 4)
+- `none` enables pure-NLP pipeline (fallacy + quality + synthesis only)
+- No changes to individual invoke callables — filter is at workflow level
+
+---
+
+## Implementation Notes
+
+- **JVM dependency**: The `--formal-extension core` option reduces JVM load (4 phases instead of 21), useful for CI without JPype
+- **Comma-separated parsing**: Validate against the 17 known extensions; error on unknown names
+- **Workflow-level filtering** is cleaner than per-callable guards — modify `workflows.py` spectacular builder to respect the filter
+
+---
+
+## Questions for User
+
+1. **Default**: Should `all` remain default, or should `core` be the new default (faster CI, fewer JVM crashes)?
+2. **Group shortcuts**: Are the 4 groups (`core`, `dung-family`, `structured`, `logic-extended`) useful, or should we only support explicit comma-separated lists?
+3. **Validation**: Should unknown extension names be a hard error, or silently ignored (with a warning)?

--- a/docs/reports/caseai_scoping_R317.md
+++ b/docs/reports/caseai_scoping_R317.md
@@ -1,0 +1,162 @@
+# CaseAI Scoping Report — R317
+
+**Date**: 2026-06-02
+**Author**: po-2023 (worker, non-argparse lane)
+**Source**: Issue #901, North-Star parametric integration (#78)
+
+---
+
+## 1. What is CaseAI?
+
+CaseAI is a **Medieval Murder Mystery Detective Game** — a single-page browser application built with Phaser.js 3. The player investigates a procedurally-generated crime in a medieval smithy, questions suspects (powered by OpenAI gpt-4o), gathers alibi/observation notes, and uses a tau-prolog Watson deduction system to identify the liar.
+
+### Architecture
+
+| Component | Technology | Role |
+|-----------|-----------|------|
+| Game engine | Phaser.js 3 (CDN) | 2D rendering, sprite physics, room navigation |
+| Logic engine | tau-prolog 0.3.2 (CDN) | Watson deduction (`liar(Person) :- alibi(P,R1), observed(P,R2), R1 \= R2`) |
+| LLM | OpenAI gpt-4o (direct API) | Plot generation, suspect dialogue, fact extraction |
+| Audio | Web Audio API | Ambient music, sound effects |
+| Assets | Custom fonts, character sprites, map backgrounds | Medieval visual theme |
+
+### Files (31 files, ~180 KB total)
+
+```
+CaseAI/
+├── index.html           # SPA entry point, loads all scripts via CDN
+├── smithy.json          # Level geometry (9 rooms, collision data)
+├── favicon.ico
+├── static/
+│   ├── assets/medieval/smithy/   # 2 map backgrounds (day/night)
+│   ├── fonts/                    # 3 custom fonts (BarberChop, JMH Typewriter, WaHandwriting)
+│   ├── scripts/                  # 14 JS files (game logic)
+│   ├── sounds/                   # 7 audio files (music, SFX)
+│   └── style/style.css          # Styling
+```
+
+### Game Flow
+
+1. **Init**: User enters OpenAI API key → `generatePlot()` creates random seed → `createPlot()` asks gpt-4o to flesh out scenario
+2. **Questioning**: Click suspect on map → type question → `ask()` sends to gpt-4o with suspect-specific prompt → `createMapper()` extracts structured facts → notes appear
+3. **Deduction**: After each question, `watsonHasFound()` runs Prolog query against extracted alibi/observation facts
+4. **Accusation**: Click "YOU are the murderer!" → compare with `backend.plot.solution.murderer` → show Watson explanation
+
+---
+
+## 2. Integration Status
+
+### Current Wiring: ZERO
+
+| Aspect | Status |
+|--------|--------|
+| References in `argumentation_analysis/` | **0** (confirmed by grep) |
+| REST/WebSocket to Python backend | **None** |
+| CapabilityRegistry entry | **None** |
+| WorkflowDSL phase | **None** |
+| CLI integration | **None** |
+
+### Backend Equivalents Already Integrated
+
+The Cluedo/Oracle system in `argumentation_analysis/` covers the same conceptual ground:
+
+| CaseAI concept | Integrated equivalent | File |
+|----------------|----------------------|------|
+| Suspect questioning | `MoriartyInterrogatorAgent` | `agents/core/oracle/moriarty_interrogator_agent.py` |
+| Cluedo dataset | `CluedoDataset` (634 LOC) | `agents/core/oracle/cluedo_dataset.py` |
+| Game state | `CluedoOracleState` (1708 LOC) | `core/cluedo_oracle_state.py` |
+| 3-agent workflow | `CluedoExtendedOrchestrator` | `orchestration/cluedo_components/` |
+| Pipeline mode | `--mode cluedo` | `run_orchestration.py` |
+| Prolog deduction | Tweety/JPype (Java) | `agents/core/logic/` |
+
+**Audit A-17 verdict**: 50% integration score. Backend = fully integrated. Frontend = orphaned.
+
+---
+
+## 3. Integration Options
+
+### Option A: API Bridge (Medium effort, ~300 LOC)
+
+Replace direct OpenAI calls in `back.js` with calls to the project's FastAPI backend:
+
+- **Endpoint**: `POST /api/v1/cluedo/investigate` (new route in `api/main.py`)
+- **Replace**: `chatAIHistory()` / `chatAIPrompt()` → HTTP fetch to FastAPI
+- **Benefits**: Uses `MoriartyInterrogatorAgent` (strategic lying) instead of flat gpt-4o prompts; uses `CluedoOracleState` for consistent game state
+- **SANCTUAIRE**: Only add code in `argumentation_analysis/` + `api/`. CaseAI/ untouched.
+
+### Option B: Capability Exposure (Low effort, ~80 LOC)
+
+Register CaseAI as a **frontend capability** in the registry, making it discoverable:
+
+- Add `caseai_frontend` capability to `CapabilityRegistry` (metadata-only)
+- Add a FastAPI route that serves CaseAI's `index.html` with injected API endpoint
+- **Benefits**: CaseAI appears in the capability catalog, can be launched via API
+- **Limitation**: Still uses direct OpenAI calls, no backend integration
+
+### Option C: Documentation Only (Minimal effort, ~0 LOC)
+
+Mark CaseAI as a **pedagogical reference frontend** — valuable for demonstrations but architecturally separate. No code changes.
+
+- Update `parametric_integration_map.md` §D with "FRONTEND REFERENCE — not a backend candidate"
+- Add CaseAI to the project docs as a demo showcase
+- **Benefits**: Honest scoping, no wasted effort on forced integration
+
+---
+
+## 4. GO/NO-GO Verdict
+
+### **GO for Option C (Documentation Only)**
+
+**Rationale**:
+
+1. **Orphan architecture**: CaseAI has zero imports, zero API calls, zero runtime connection to `argumentation_analysis/`. Bridging would require rewriting `back.js` to call FastAPI instead of OpenAI — a fundamental rearchitecture of the frontend.
+
+2. **Backend already integrated**: The Cluedo game logic (dataset, state, agents, orchestrator) is already fully wired into the unified pipeline via `--mode cluedo`. CaseAI's frontend adds visual/gameplay value but no analytical capability.
+
+3. **Pedagogical value**: CaseAI is an excellent demo for soutenances — a tangible, visual murder mystery game. It should be preserved as-is and showcased, not refactored to call a different backend.
+
+4. **Cost/benefit**: Option A (API bridge) would take ~300 LOC + significant frontend rewrite for marginal analytical gain. Option B (capability exposure) adds metadata without real integration. Option C is honest and zero-cost.
+
+5. **SANCTUAIRE**: CaseAI is a student project directory. The integration mandate (North-Star R311) says "every non-obsolete component becomes selectable" — but CaseAI is a **frontend visualization**, not a backend component. It doesn't belong in the pipeline; it belongs in demos.
+
+### Recommendation
+
+- **Mark §D of parametric_integration_map.md**: `CaseAI → FRONTEND REFERENCE (pedagogical demo, not pipeline candidate)`
+- **Add to `examples/` documentation**: Reference CaseAI as a visual Cluedo demo
+- **No code changes** in `argumentation_analysis/` or `CaseAI/`
+
+---
+
+## 5. Dependencies
+
+| Dependency | Version | CDN | Required |
+|-----------|---------|-----|----------|
+| Phaser.js | 3.x (latest) | jsdelivr | Yes |
+| tau-prolog | 0.3.2 | jsdelivr | Yes |
+| OpenAI API | gpt-4o | Direct | Yes (user key) |
+
+No Python dependencies. No npm. No build step. Fully static.
+
+---
+
+## Appendix: File Analysis
+
+| File | LOC (est.) | Role |
+|------|-----------|------|
+| `index.html` | 50 | SPA shell, CDN imports |
+| `smithy.json` | 120 | Level geometry |
+| `back.js` | 500 | Core backend: API calls, plot gen, Prolog |
+| `prompt.js` | 200 | LLM prompt templates |
+| `globals.js` | 150 | Game state singleton |
+| `game.js` | 180 | Newspaper, play button |
+| `view.js` | 120 | View switching |
+| `testimony.js` | 150 | Suspect questioning UI |
+| `canvas.js` | 100 | Phaser scene init |
+| `map.js` | 80 | Wall collision data |
+| `floating.js` | 70 | Draggable notes |
+| `picture.js` | 60 | Suspect portraits |
+| `note.js` | 80 | Note creation |
+| `sound.js` | 50 | Audio management |
+| `settings.js` | 40 | API key input |
+| `style.css` | 200 | Styling |
+| **Total JS** | **~1980** | |


### PR DESCRIPTION
## Summary

Issue #901 — North-Star parametric integration, po-2023 lane (non-argparse, docs only).

### Deliverables (4/4 DoD items)

**1. CaseAI Scoping Report** → `docs/reports/caseai_scoping_R317.md`
- **Verdict: GO for Documentation Only** (Option C)
- CaseAI is a standalone Phaser.js medieval murder mystery game (31 files, ~1980 LOC JS)
- Zero connection to `argumentation_analysis/` backend (0 imports, 0 API calls)
- Backend equivalent (Cluedo) already fully integrated via `--mode cluedo`
- Recommendation: mark as "FRONTEND REFERENCE (pedagogical demo)" in parametric_integration_map.md §D
- SANCTUAIRE respected: no changes to `CaseAI/`

**2. TRACK-counter-strategy.md** → `docs/architecture/design_specs/TRACK-counter-strategy.md`
- `--counter-strategy auto|socratic|reductio|analogy|authority|statistical`
- 5 rhetorical strategies from `definitions.py`, ~112 LOC estimate
- Default `auto` (no breaking change)

**3. TRACK-formal-extension.md** → `docs/architecture/design_specs/TRACK-formal-extension.md`
- `--formal-extension all|core|none|<comma-list>` for 17 Tweety handlers
- Group shortcuts: core (4), dung-family (6), structured (4), logic-extended (7)
- ~183 LOC estimate. Default `all` (no breaking change)

**4. TRACK-democratech-params.md** → `docs/architecture/design_specs/TRACK-democratech-params.md`
- `--vote-method copeland|majority|borda|condorcet|quadratic|byzantine|raft`
- `--consensus-threshold 0.0-1.0`
- ~94 LOC estimate. Defaults: `copeland`, `0.5` (no breaking change)

### DoD Checklist
- [x] Rapport scoping CaseAI avec verdict GO/NO-GO
- [x] 3 design specs déposées (feed le prochain cycle d'impl)
- [x] Privacy clean, aucun fichier touché hors docs/

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>