### PR TITLE
feat(api): expose vote_method + consensus_threshold in FastAPI (#910)

### DIFF
--- a/api/proposal_endpoints.py
+++ b/api/proposal_endpoints.py
@@ -204,11 +204,15 @@ async def run_custom_workflow(request: CustomWorkflowRequest):
             run_unified_analysis,
         )
 
-        # Build context from parametric selectors (#903)
+        # Build context from parametric selectors (#903, #910)
         context: Dict[str, Any] = {}
         context["fallacy_tier"] = request.fallacy_tier
         if request.shield_preset != "off":
             context["shield_config"] = {"preset": request.shield_preset}
+        if request.vote_method != "copeland":
+            context["vote_method"] = request.vote_method
+        if request.consensus_threshold != 0.7:
+            context["consensus_threshold"] = request.consensus_threshold
 
         result = await run_unified_analysis(
             request.text,

--- a/api/proposal_models.py
+++ b/api/proposal_models.py
@@ -64,6 +64,17 @@ class CustomWorkflowRequest(BaseModel):
         "off",
         description="AI Shield preset: off (default), basic, advanced, output_only, strict",
     )
+    # Parametric selectors — democratech track (north-star R311, #910)
+    vote_method: Literal["copeland", "approval", "stv", "schulze", "kemeny_young"] = Field(
+        "copeland",
+        description="Social choice voting method for governance analysis",
+    )
+    consensus_threshold: float = Field(
+        0.7,
+        ge=0.0,
+        le=1.0,
+        description="Consensus threshold (0.0–1.0) for governance metrics",
+    )
     # dung_provider deferred to #908 — needs real consumption wiring
 
 

--- a/tests/unit/api/test_parametric_api.py
+++ b/tests/unit/api/test_parametric_api.py
@@ -1,7 +1,9 @@
-"""Tests for parametric selector exposure in the FastAPI API (#903).
+"""Tests for parametric selector exposure in the FastAPI API (#903, #910).
 
-Validates that CustomWorkflowRequest accepts fallacy_tier and shield_preset
-fields and that they propagate correctly to the pipeline context.
+Validates that CustomWorkflowRequest accepts parametric fields
+(fallacy_tier, shield_preset, vote_method, consensus_threshold)
+and that they propagate correctly to the pipeline context with the
+EXACT keys consumed by invoke_callables.py.
 """
 
 from unittest.mock import AsyncMock, patch
@@ -21,6 +23,8 @@ class TestCustomWorkflowRequestModel:
         req = CustomWorkflowRequest(text="Some argument text", workflow="standard")
         assert req.fallacy_tier == "llm"
         assert req.shield_preset == "off"
+        assert req.vote_method == "copeland"
+        assert req.consensus_threshold == 0.7
 
     def test_explicit_values(self):
         from api.proposal_models import CustomWorkflowRequest
@@ -30,9 +34,13 @@ class TestCustomWorkflowRequestModel:
             workflow="full",
             fallacy_tier="taxonomy",
             shield_preset="strict",
+            vote_method="schulze",
+            consensus_threshold=0.5,
         )
         assert req.fallacy_tier == "taxonomy"
         assert req.shield_preset == "strict"
+        assert req.vote_method == "schulze"
+        assert req.consensus_threshold == 0.5
 
     def test_all_fallacy_tiers(self):
         from api.proposal_models import CustomWorkflowRequest
@@ -52,6 +60,24 @@ class TestCustomWorkflowRequestModel:
             )
             assert req.shield_preset == preset
 
+    def test_all_vote_methods(self):
+        from api.proposal_models import CustomWorkflowRequest
+
+        for method in ("copeland", "approval", "stv", "schulze", "kemeny_young"):
+            req = CustomWorkflowRequest(
+                text="test text", workflow="light", vote_method=method
+            )
+            assert req.vote_method == method
+
+    def test_consensus_threshold_bounds(self):
+        from api.proposal_models import CustomWorkflowRequest
+
+        for val in (0.0, 0.3, 0.5, 0.7, 1.0):
+            req = CustomWorkflowRequest(
+                text="test text", workflow="light", consensus_threshold=val
+            )
+            assert req.consensus_threshold == val
+
     def test_invalid_fallacy_tier_rejected(self):
         from api.proposal_models import CustomWorkflowRequest
         from pydantic import ValidationError
@@ -70,6 +96,33 @@ class TestCustomWorkflowRequestModel:
                 text="test text", workflow="light", shield_preset="invalid"
             )
 
+    def test_invalid_vote_method_rejected(self):
+        from api.proposal_models import CustomWorkflowRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            CustomWorkflowRequest(
+                text="test text", workflow="light", vote_method="borda"
+            )
+
+    def test_invalid_consensus_threshold_rejected(self):
+        from api.proposal_models import CustomWorkflowRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            CustomWorkflowRequest(
+                text="test text", workflow="light", consensus_threshold=1.5
+            )
+
+    def test_consensus_threshold_negative_rejected(self):
+        from api.proposal_models import CustomWorkflowRequest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            CustomWorkflowRequest(
+                text="test text", workflow="light", consensus_threshold=-0.1
+            )
+
 
 # ──── Context propagation tests ────
 
@@ -77,8 +130,8 @@ class TestCustomWorkflowRequestModel:
 class TestContextPropagation:
     """Test that selectors build correct context dict."""
 
-    def test_default_context_no_shield(self):
-        """When shield_preset='off' (default), no shield_config in context."""
+    def test_default_context_no_overrides(self):
+        """Defaults produce minimal context (only fallacy_tier)."""
         from api.proposal_models import CustomWorkflowRequest
 
         req = CustomWorkflowRequest(text="test", workflow="light")
@@ -86,26 +139,47 @@ class TestContextPropagation:
         context["fallacy_tier"] = req.fallacy_tier
         if req.shield_preset != "off":
             context["shield_config"] = {"preset": req.shield_preset}
+        if req.vote_method != "copeland":
+            context["vote_method"] = req.vote_method
+        if req.consensus_threshold != 0.7:
+            context["consensus_threshold"] = req.consensus_threshold
 
         assert context == {"fallacy_tier": "llm"}
 
-    def test_shield_preset_adds_config(self):
-        """When shield_preset != 'off', shield_config appears in context."""
+    def test_vote_method_propagated(self):
+        """Non-default vote_method appears in context."""
         from api.proposal_models import CustomWorkflowRequest
 
         req = CustomWorkflowRequest(
-            text="test", workflow="light", shield_preset="advanced"
+            text="test", workflow="light", vote_method="schulze"
         )
         context = {}
         context["fallacy_tier"] = req.fallacy_tier
-        if req.shield_preset != "off":
-            context["shield_config"] = {"preset": req.shield_preset}
+        if req.vote_method != "copeland":
+            context["vote_method"] = req.vote_method
+        if req.consensus_threshold != 0.7:
+            context["consensus_threshold"] = req.consensus_threshold
 
-        assert context["fallacy_tier"] == "llm"
-        assert context["shield_config"] == {"preset": "advanced"}
+        assert context["vote_method"] == "schulze"
 
-    def test_both_params_propagated(self):
-        """Both fallacy_tier and shield_preset propagated together."""
+    def test_consensus_threshold_propagated(self):
+        """Non-default consensus_threshold appears in context."""
+        from api.proposal_models import CustomWorkflowRequest
+
+        req = CustomWorkflowRequest(
+            text="test", workflow="light", consensus_threshold=0.5
+        )
+        context = {}
+        context["fallacy_tier"] = req.fallacy_tier
+        if req.vote_method != "copeland":
+            context["vote_method"] = req.vote_method
+        if req.consensus_threshold != 0.7:
+            context["consensus_threshold"] = req.consensus_threshold
+
+        assert context["consensus_threshold"] == 0.5
+
+    def test_all_selectors_propagated(self):
+        """All selectors propagated together."""
         from api.proposal_models import CustomWorkflowRequest
 
         req = CustomWorkflowRequest(
@@ -113,17 +187,25 @@ class TestContextPropagation:
             workflow="full",
             fallacy_tier="full",
             shield_preset="strict",
+            vote_method="kemeny_young",
+            consensus_threshold=0.3,
         )
         context = {}
         context["fallacy_tier"] = req.fallacy_tier
         if req.shield_preset != "off":
             context["shield_config"] = {"preset": req.shield_preset}
+        if req.vote_method != "copeland":
+            context["vote_method"] = req.vote_method
+        if req.consensus_threshold != 0.7:
+            context["consensus_threshold"] = req.consensus_threshold
 
         assert context["fallacy_tier"] == "full"
         assert context["shield_config"] == {"preset": "strict"}
+        assert context["vote_method"] == "kemeny_young"
+        assert context["consensus_threshold"] == 0.3
 
 
-# ──── API endpoint test (mocked pipeline) ────
+# ──── API endpoint tests (mocked pipeline) ────
 
 
 class TestWorkflowEndpoint:
@@ -163,8 +245,8 @@ class TestWorkflowEndpoint:
                 assert context.get("fallacy_tier") == "llm"
 
     @pytest.mark.asyncio
-    async def test_endpoint_with_selectors(self):
-        """Endpoint passes selectors to pipeline context."""
+    async def test_endpoint_with_fallacy_shield_selectors(self):
+        """Endpoint passes fallacy_tier + shield_preset to pipeline context."""
         from fastapi.testclient import TestClient
 
         from api.main import app
@@ -196,3 +278,116 @@ class TestWorkflowEndpoint:
             if context is not None:
                 assert context.get("fallacy_tier") == "taxonomy"
                 assert context.get("shield_config") == {"preset": "basic"}
+
+    @pytest.mark.asyncio
+    async def test_endpoint_vote_method_consumer(self):
+        """CONSUMPTION TEST: vote_method=schulze reaches pipeline context.
+
+        Consumer: invoke_callables.py:1378 reads context.get("vote_method", "copeland").
+        This test proves the key name is EXACTLY what the consumer expects.
+        """
+        from fastapi.testclient import TestClient
+
+        from api.main import app
+
+        mock_result = {
+            "workflow_name": "full",
+            "summary": {"completed": 0, "failed": 0, "skipped": 0, "total": 0},
+        }
+
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            new=AsyncMock(return_value=mock_result),
+        ) as mock_pipeline:
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/api/workflow/custom",
+                json={
+                    "text": "Test argument text here",
+                    "workflow": "full",
+                    "vote_method": "schulze",
+                },
+            )
+            assert response.status_code == 200
+
+            # Verify EXACT key consumed by invoke_callables.py:1378
+            call_kwargs = mock_pipeline.call_args
+            context = call_kwargs.kwargs.get("context")
+            assert context is not None, "Pipeline context must be passed"
+            assert context.get("vote_method") == "schulze"
+
+    @pytest.mark.asyncio
+    async def test_endpoint_consensus_threshold_consumer(self):
+        """CONSUMPTION TEST: consensus_threshold=0.5 reaches pipeline context.
+
+        Consumer: invoke_callables.py:1529 reads context.get("consensus_threshold", 0.7).
+        This test proves the key name is EXACTLY what the consumer expects.
+        """
+        from fastapi.testclient import TestClient
+
+        from api.main import app
+
+        mock_result = {
+            "workflow_name": "full",
+            "summary": {"completed": 0, "failed": 0, "skipped": 0, "total": 0},
+        }
+
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            new=AsyncMock(return_value=mock_result),
+        ) as mock_pipeline:
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/api/workflow/custom",
+                json={
+                    "text": "Test argument text here",
+                    "workflow": "full",
+                    "consensus_threshold": 0.5,
+                },
+            )
+            assert response.status_code == 200
+
+            # Verify EXACT key consumed by invoke_callables.py:1529
+            call_kwargs = mock_pipeline.call_args
+            context = call_kwargs.kwargs.get("context")
+            assert context is not None, "Pipeline context must be passed"
+            assert context.get("consensus_threshold") == 0.5
+
+    @pytest.mark.asyncio
+    async def test_endpoint_all_selectors_consumer(self):
+        """CONSUMPTION TEST: all selectors reach pipeline context together."""
+        from fastapi.testclient import TestClient
+
+        from api.main import app
+
+        mock_result = {
+            "workflow_name": "full",
+            "summary": {"completed": 0, "failed": 0, "skipped": 0, "total": 0},
+        }
+
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            new=AsyncMock(return_value=mock_result),
+        ) as mock_pipeline:
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/api/workflow/custom",
+                json={
+                    "text": "Test argument text here",
+                    "workflow": "full",
+                    "fallacy_tier": "taxonomy",
+                    "shield_preset": "advanced",
+                    "vote_method": "kemeny_young",
+                    "consensus_threshold": 0.3,
+                },
+            )
+            assert response.status_code == 200
+
+            # Verify ALL keys reach the pipeline context with exact names
+            call_kwargs = mock_pipeline.call_args
+            context = call_kwargs.kwargs.get("context")
+            assert context is not None
+            assert context["fallacy_tier"] == "taxonomy"
+            assert context["shield_config"] == {"preset": "advanced"}
+            assert context["vote_method"] == "kemeny_young"
+            assert context["consensus_threshold"] == 0.3


### PR DESCRIPTION
## Summary

API parity for democratech parametric selectors (#906, already merged at CLI level).

Exposes 2 new optional fields on `POST /api/workflow/custom`:

| Field | Choices | Default |
|-------|---------|---------|
| `vote_method` | copeland, approval, stv, schulze, kemeny_young | copeland |
| `consensus_threshold` | float 0.0-1.0 | 0.7 |

## Consumer verification (anti-inerte R321)

Keys propagated are EXACTLY those consumed by `invoke_callables.py`:
- `vote_method` → consumed at :1378 → `social_choice_vote`
- `consensus_threshold` → consumed at :1529 → `consensus_met`

## Files changed (api/ only, 0 argparse collision)

- `api/proposal_models.py` — 2 new fields on `CustomWorkflowRequest`
- `api/proposal_endpoints.py` — context propagation (non-defaults only)
- `tests/unit/api/test_parametric_api.py` — 20 tests (was 11), including 3 consumer-verified endpoint tests

## Tests

```
20/20 passed in 10.84s
```

New tests:
- `test_all_vote_methods` — 5 methods accepted
- `test_consensus_threshold_bounds` — 0.0, 0.3, 0.5, 0.7, 1.0
- `test_invalid_vote_method_rejected` — ValidationError on `borda`
- `test_invalid_consensus_threshold_rejected` — ValidationError on 1.5
- `test_consensus_threshold_negative_rejected` — ValidationError on -0.1
- `test_endpoint_vote_method_consumer` — **CONSUMPTION TEST**: `vote_method=schulze` reaches pipeline context
- `test_endpoint_consensus_threshold_consumer` — **CONSUMPTION TEST**: `consensus_threshold=0.5` reaches pipeline context
- `test_endpoint_all_selectors_consumer` — all 4 selectors in one request

## À valider par l'utilisateur

RAS — backward-compatible defaults, no breaking change.

Closes #910

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>