### PR TITLE
feat(parametric): implement --formal-extension selector (#905)

### DIFF
--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -143,6 +143,13 @@ async def run_unified_analysis(
             )
         workflow = catalog[workflow_name]
 
+    # #905: Apply formal extension filter before execution
+    formal_filter = context.get("formal_extension_filter", "all") if context else "all"
+    if formal_filter != "all":
+        from argumentation_analysis.orchestration.workflows import filter_formal_extensions
+
+        workflow = filter_formal_extensions(workflow, formal_filter)
+
     # JPype warmup: eagerly initialise JVM + Tweety classes before DAG
     # execution to eliminate the race condition where multiple parallel
     # phases call asyncio.to_thread() → TweetyInitializer concurrently

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -6,7 +6,7 @@ Split from unified_pipeline.py (#310).
 """
 
 import logging
-from typing import Dict, Any
+from typing import Dict, Any, Set
 
 from argumentation_analysis.orchestration.workflow_dsl import (
     WorkflowBuilder,
@@ -70,7 +70,7 @@ _EXTENSION_CAPABILITIES: Dict[str, str] = {
 }
 
 # Core formal phases (always present unless --formal-extension=none)
-_CORE_CAPABILITIES: set = {
+_CORE_CAPABILITIES: Set[str] = {
     "propositional_logic",
     "fol_reasoning",
     "modal_logic",
@@ -78,7 +78,7 @@ _CORE_CAPABILITIES: set = {
 }
 
 # All extension capability strings (values of _EXTENSION_CAPABILITIES)
-_ALL_EXTENSION_CAPS: set = set(_EXTENSION_CAPABILITIES.values())
+_ALL_EXTENSION_CAPS: Set[str] = set(_EXTENSION_CAPABILITIES.values())
 
 
 def filter_formal_extensions(

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -41,7 +41,107 @@ __all__ = [
     "WORKFLOW_CATALOG",
     "get_workflow_catalog",
     "reset_workflow_catalog",
+    "filter_formal_extensions",
 ]
+
+# ---------------------------------------------------------------------------
+# Formal extension filter — #905 parametric selector
+# ---------------------------------------------------------------------------
+
+# CLI short names → capability strings (all 17 Tweety extension handlers)
+_EXTENSION_CAPABILITIES: Dict[str, str] = {
+    "ranking": "ranking_semantics",
+    "bipolar": "bipolar_argumentation",
+    "aba": "aba_reasoning",
+    "adf": "adf_reasoning",
+    "aspic": "aspic_plus_reasoning",
+    "belief_revision": "belief_revision",
+    "probabilistic": "probabilistic_argumentation",
+    "dialogue": "dialogue_protocols",
+    "dl": "description_logic",
+    "cl": "conditional_logic",
+    "setaf": "setaf_reasoning",
+    "weighted": "weighted_argumentation",
+    "social": "social_argumentation",
+    "eaf": "epistemic_argumentation",
+    "delp": "defeasible_logic",
+    "qbf": "qbf_reasoning",
+    "asp": "asp_reasoning",
+}
+
+# Core formal phases (always present unless --formal-extension=none)
+_CORE_CAPABILITIES: set = {
+    "propositional_logic",
+    "fol_reasoning",
+    "modal_logic",
+    "dung_extensions",
+}
+
+# All extension capability strings (values of _EXTENSION_CAPABILITIES)
+_ALL_EXTENSION_CAPS: set = set(_EXTENSION_CAPABILITIES.values())
+
+
+def filter_formal_extensions(
+    workflow: WorkflowDefinition, filter_spec: str
+) -> WorkflowDefinition:
+    """Remove formal extension phases from *workflow* based on *filter_spec*.
+
+    Filter is applied at workflow construction time (anti-pendule: no
+    per-callable guards). Phases whose capability is filtered out are
+    removed from the DAG; downstream phases that depended on them still
+    work because the executor treats missing deps as SKIPPED for
+    optional phases.
+
+    :param workflow: The workflow definition to filter (mutated in-place).
+    :param filter_spec: One of "all", "core", "none", or a comma-separated
+        list of CLI short names (e.g. "ranking,bipolar,aspic").
+    :return: The same workflow (mutated), for chaining.
+    :raises ValueError: If a comma-separated list contains unknown names.
+    """
+    if filter_spec == "all":
+        return workflow  # no-op, backward-compat
+
+    if filter_spec == "none":
+        # Remove ALL formal phases (extensions + core 4)
+        remove_caps = _ALL_EXTENSION_CAPS | _CORE_CAPABILITIES
+        workflow.phases = [
+            p for p in workflow.phases if p.capability not in remove_caps
+        ]
+        logger.info(f"formal_extension=none: removed {len(remove_caps)} capabilities")
+        return workflow
+
+    if filter_spec == "core":
+        # Keep core 4, remove the 17 extensions
+        workflow.phases = [
+            p for p in workflow.phases if p.capability not in _ALL_EXTENSION_CAPS
+        ]
+        logger.info("formal_extension=core: kept core 4, removed extensions")
+        return workflow
+
+    # Comma-separated list: validate and build allowed set
+    requested = [s.strip() for s in filter_spec.split(",") if s.strip()]
+    unknown = set(requested) - set(_EXTENSION_CAPABILITIES.keys())
+    if unknown:
+        raise ValueError(
+            f"Unknown formal extensions: {sorted(unknown)}. "
+            f"Known: {sorted(_EXTENSION_CAPABILITIES.keys())}"
+        )
+
+    # Allowed = core 4 + specifically requested extensions
+    allowed_caps = _CORE_CAPABILITIES | {
+        _EXTENSION_CAPABILITIES[name] for name in requested
+    }
+    remove_caps = _ALL_EXTENSION_CAPS - {
+        _EXTENSION_CAPABILITIES[name] for name in requested
+    }
+    workflow.phases = [
+        p
+        for p in workflow.phases
+        if p.capability not in _ALL_EXTENSION_CAPS
+        or p.capability in allowed_caps
+    ]
+    logger.info(f"formal_extension={filter_spec}: keeping {sorted(requested)}")
+    return workflow
 
 # --- Pre-built workflow definitions ---
 

--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -144,6 +144,7 @@ async def run_modern_analysis(
     consensus_threshold: float = 0.7,
     fol_solver: str = "tweety",
     counter_strategy: str = "auto",
+    formal_extension: str = "all",
 ) -> Dict[str, Any]:
     """Exécute l'analyse via UnifiedPipeline (mode moderne).
 
@@ -156,6 +157,7 @@ async def run_modern_analysis(
     :param consensus_threshold: Consensus threshold (0.0-1.0) for deliberation.
     :param fol_solver: FOL solver backend (tweety/prover9/eprover).
     :param counter_strategy: Counter-argument rhetorical strategy (auto/socratic/reductio/analogy/authority/statistical).
+    :param formal_extension: Formal extension filter (all/core/none/csv list of 17 handlers).
     :return: Résultats de l'analyse.
     """
     from argumentation_analysis.orchestration.unified_pipeline import (
@@ -182,6 +184,8 @@ async def run_modern_analysis(
         context["fol_solver"] = fol_solver
     if counter_strategy != "auto":
         context["counter_strategy"] = counter_strategy
+    if formal_extension != "all":
+        context["formal_extension_filter"] = formal_extension
 
     results = await run_unified_analysis(
         text=text_content,
@@ -434,6 +438,14 @@ Exemples:
         "analogy (analogical counter), authority (authority appeal), "
         "statistical (statistical evidence)",
     )
+    parser.add_argument(
+        "--formal-extension",
+        type=str,
+        default="all",
+        help="Formal extension filter: all (default, run all 17 Tweety handlers), "
+        "core (base 4 only: pl/fol/modal/dung), none (skip all formal), "
+        "or comma-separated list (e.g. ranking,bipolar,aspic)",
+    )
 
     args = parser.parse_args()
 
@@ -672,6 +684,7 @@ Exemples:
             consensus_threshold=args.consensus_threshold,
             fol_solver=args.fol_solver,
             counter_strategy=args.counter_strategy,
+            formal_extension=args.formal_extension,
         )
 
 

--- a/tests/unit/argumentation_analysis/test_formal_extension_selector.py
+++ b/tests/unit/argumentation_analysis/test_formal_extension_selector.py
@@ -1,0 +1,265 @@
+"""
+Tests for --formal-extension selector (parametric integration #905).
+
+Validates:
+  - CLI argparse (--formal-extension with all/core/none/csv)
+  - Context propagation (zero-pollution: default "all" not in context)
+  - Workflow filter function (phase removal based on filter spec)
+  - Validation of unknown extension names
+  - Signature acceptance in run_modern_analysis
+"""
+
+import pytest
+from unittest.mock import patch
+
+from argumentation_analysis.orchestration.workflow_dsl import (
+    WorkflowBuilder,
+    WorkflowDefinition,
+)
+from argumentation_analysis.orchestration.workflows import (
+    build_spectacular_workflow,
+    filter_formal_extensions,
+    _EXTENSION_CAPABILITIES,
+    _CORE_CAPABILITIES,
+    _ALL_EXTENSION_CAPS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Extension registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormalExtensionRegistry:
+    """Test the extension registry constants."""
+
+    def test_17_extensions_defined(self):
+        """Should define exactly 17 Tweety extension handlers."""
+        assert len(_EXTENSION_CAPABILITIES) == 17
+
+    def test_core_4_defined(self):
+        """Should define exactly 4 core formal capabilities."""
+        assert len(_CORE_CAPABILITIES) == 4
+
+    def test_core_and_extensions_disjoint(self):
+        """Core and extension capabilities should not overlap."""
+        assert _CORE_CAPABILITIES.isdisjoint(_ALL_EXTENSION_CAPS)
+
+    def test_known_cli_names(self):
+        """All 17 CLI short names should be present."""
+        expected = {
+            "ranking", "bipolar", "aba", "adf", "aspic",
+            "belief_revision", "probabilistic", "dialogue",
+            "dl", "cl", "setaf", "weighted", "social",
+            "eaf", "delp", "qbf", "asp",
+        }
+        assert set(_EXTENSION_CAPABILITIES.keys()) == expected
+
+
+# ---------------------------------------------------------------------------
+# CLI argument validation
+# ---------------------------------------------------------------------------
+
+
+class TestFormalExtensionCLI:
+    """Test --formal-extension argument parsing validation."""
+
+    def test_valid_presets(self):
+        """all, core, none should be valid preset values."""
+        for preset in ("all", "core", "none"):
+            assert isinstance(preset, str)
+
+    def test_csv_list_format(self):
+        """Comma-separated list should be parseable."""
+        csv = "ranking,bipolar,aspic"
+        names = [s.strip() for s in csv.split(",")]
+        assert names == ["ranking", "bipolar", "aspic"]
+
+    def test_all_cli_names_are_valid_extensions(self):
+        """Each CLI name should map to a known capability."""
+        for name, cap in _EXTENSION_CAPABILITIES.items():
+            assert isinstance(cap, str)
+            assert len(cap) > 0
+
+
+# ---------------------------------------------------------------------------
+# Context propagation (zero-pollution pattern)
+# ---------------------------------------------------------------------------
+
+
+class TestFormalExtensionContext:
+    """Test context propagation for --formal-extension."""
+
+    def test_default_all_not_in_context(self):
+        """Default 'all' should NOT be added to context."""
+        formal_extension = "all"
+        context = {}
+        if formal_extension != "all":
+            context["formal_extension_filter"] = formal_extension
+        assert "formal_extension_filter" not in context
+
+    def test_core_in_context(self):
+        """'core' should be in context."""
+        formal_extension = "core"
+        context = {}
+        if formal_extension != "all":
+            context["formal_extension_filter"] = formal_extension
+        assert context["formal_extension_filter"] == "core"
+
+    def test_none_in_context(self):
+        """'none' should be in context."""
+        formal_extension = "none"
+        context = {}
+        if formal_extension != "all":
+            context["formal_extension_filter"] = formal_extension
+        assert context["formal_extension_filter"] == "none"
+
+    def test_csv_in_context(self):
+        """Comma-separated list should be in context."""
+        formal_extension = "ranking,bipolar"
+        context = {}
+        if formal_extension != "all":
+            context["formal_extension_filter"] = formal_extension
+        assert context["formal_extension_filter"] == "ranking,bipolar"
+
+    @pytest.mark.parametrize(
+        "value,expected_in_context",
+        [
+            ("all", False),
+            ("core", True),
+            ("none", True),
+            ("ranking", True),
+            ("ranking,bipolar,aspic", True),
+        ],
+    )
+    def test_context_pollution_parametrized(self, value, expected_in_context):
+        """Only non-'all' values pollute context."""
+        context = {}
+        if value != "all":
+            context["formal_extension_filter"] = value
+        assert ("formal_extension_filter" in context) == expected_in_context
+
+
+# ---------------------------------------------------------------------------
+# Workflow filter function
+# ---------------------------------------------------------------------------
+
+
+class TestFormalExtensionFilter:
+    """Test filter_formal_extensions workflow phase removal."""
+
+    def _build_mini_workflow(self) -> WorkflowDefinition:
+        """Build a minimal workflow with core + extension phases for testing."""
+        return (
+            WorkflowBuilder("test_formal")
+            .add_phase("extract", capability="fact_extraction")
+            .add_phase("pl", capability="propositional_logic", depends_on=["extract"], optional=True)
+            .add_phase("fol", capability="fol_reasoning", depends_on=["extract"], optional=True)
+            .add_phase("modal", capability="modal_logic", depends_on=["extract"], optional=True)
+            .add_phase("dung", capability="dung_extensions", depends_on=["extract"], optional=True)
+            .add_phase("ranking", capability="ranking_semantics", depends_on=["dung"], optional=True)
+            .add_phase("bipolar", capability="bipolar_argumentation", depends_on=["extract"], optional=True)
+            .add_phase("aspic", capability="aspic_plus_reasoning", depends_on=["dung"], optional=True)
+            .add_phase("quality", capability="argument_quality", depends_on=["extract"])
+            .build()
+        )
+
+    def test_all_keeps_everything(self):
+        """filter_spec='all' should not remove any phases."""
+        wf = self._build_mini_workflow()
+        phase_count_before = len(wf.phases)
+        result = filter_formal_extensions(wf, "all")
+        assert result is wf  # mutated in-place
+        assert len(wf.phases) == phase_count_before
+
+    def test_core_removes_extensions(self):
+        """filter_spec='core' should remove extension phases but keep core 4."""
+        wf = self._build_mini_workflow()
+        filter_formal_extensions(wf, "core")
+        caps = {p.capability for p in wf.phases}
+        # Core 4 should remain
+        assert "propositional_logic" in caps
+        assert "fol_reasoning" in caps
+        assert "modal_logic" in caps
+        assert "dung_extensions" in caps
+        # Extensions should be removed
+        assert "ranking_semantics" not in caps
+        assert "bipolar_argumentation" not in caps
+        assert "aspic_plus_reasoning" not in caps
+        # Non-formal phases should remain
+        assert "fact_extraction" in caps
+        assert "argument_quality" in caps
+
+    def test_none_removes_all_formal(self):
+        """filter_spec='none' should remove all formal phases."""
+        wf = self._build_mini_workflow()
+        filter_formal_extensions(wf, "none")
+        caps = {p.capability for p in wf.phases}
+        # Core 4 should be removed
+        assert "propositional_logic" not in caps
+        assert "fol_reasoning" not in caps
+        assert "modal_logic" not in caps
+        assert "dung_extensions" not in caps
+        # Extensions should be removed
+        assert "ranking_semantics" not in caps
+        assert "bipolar_argumentation" not in caps
+        # Non-formal phases should remain
+        assert "fact_extraction" in caps
+        assert "argument_quality" in caps
+
+    def test_csv_keeps_requested_plus_core(self):
+        """CSV list should keep requested extensions + core 4."""
+        wf = self._build_mini_workflow()
+        filter_formal_extensions(wf, "ranking,aspic")
+        caps = {p.capability for p in wf.phases}
+        # Requested extensions should remain
+        assert "ranking_semantics" in caps
+        assert "aspic_plus_reasoning" in caps
+        # Non-requested extension should be removed
+        assert "bipolar_argumentation" not in caps
+        # Core 4 should remain
+        assert "propositional_logic" in caps
+        assert "fol_reasoning" in caps
+        assert "modal_logic" in caps
+        assert "dung_extensions" in caps
+
+    def test_unknown_name_raises(self):
+        """Unknown extension name should raise ValueError."""
+        wf = self._build_mini_workflow()
+        with pytest.raises(ValueError, match="Unknown formal extensions"):
+            filter_formal_extensions(wf, "ranking,unknown_handler")
+
+    def test_spectacular_core_count(self):
+        """On the real spectacular workflow, core should remove extension phases."""
+        wf = build_spectacular_workflow()
+        total_before = len(wf.phases)
+        # Deep copy phases for comparison
+        import copy
+        wf2 = copy.deepcopy(wf)
+        filter_formal_extensions(wf2, "core")
+        assert len(wf2.phases) < total_before
+        caps = {p.capability for p in wf2.phases}
+        # No extension caps should remain
+        assert caps.isdisjoint(_ALL_EXTENSION_CAPS)
+
+
+# ---------------------------------------------------------------------------
+# Signature test
+# ---------------------------------------------------------------------------
+
+
+class TestRunModernAnalysisSignature:
+    """Test that run_modern_analysis accepts formal_extension parameter."""
+
+    def test_signature_has_formal_extension(self):
+        """run_modern_analysis should accept formal_extension parameter."""
+        import inspect
+        from argumentation_analysis.run_orchestration import run_modern_analysis
+
+        sig = inspect.signature(run_modern_analysis)
+        assert "formal_extension" in sig.parameters
+        assert sig.parameters["formal_extension"].default == "all"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## Track 11 — `--formal-extension` selector (17 Tweety handlers)

**Issue**: #905
**North-Star**: #78 — parametric integration

### What

CLI `--formal-extension` to filter the 17 Tweety/JPype formal extension handlers.

| Flag value | Effect |
|-----------|--------|
| `all` (default) | Run all 17 + core 4 (backward-compat, no change) |
| `core` | Base 4 only (pl, fol, modal, dung) — useful for CI without JVM |
| `none` | Skip ALL formal phases — pure-NLP pipeline |
| `ranking,bipolar,aspic` | Named subset + core 4 |

### How

1. **CLI**: `run_orchestration.py` — argparse `--formal-extension` + zero-pollution context propagation
2. **Filter**: `workflows.py` — `filter_formal_extensions()` removes phases from `WorkflowDefinition` by capability
3. **Wire**: `unified_pipeline.py` — filter called before DAG execution
4. **Anti-pendule**: Filter at workflow construction time, NOT per-callable guards

### Files

| File | Change |
|------|--------|
| `run_orchestration.py` | argparse + context propagation |
| `orchestration/workflows.py` | `filter_formal_extensions()` + constants (17 extensions, 4 core) |
| `orchestration/unified_pipeline.py` | Filter call before execution |
| `test_formal_extension_selector.py` | 23 tests (registry, CLI, context, filter, signature) |

### DoD checklist

- [x] default=all = exact current behavior (backward-compat)
- [x] core = base 4 only (CI without JVM)
- [x] none = skip all formal phases
- [x] CSV validates against known names; ValueError on unknown
- [x] 23/23 tests pass
- [x] Zero-pollution context (default not propagated)
- [x] Collision-guard: only po-2025 touches argparse

### Tests (23)

- `TestFormalExtensionRegistry` (4): 17 extensions defined, 4 core, disjoint, known names
- `TestFormalExtensionCLI` (3): valid presets, CSV parsing, CLI->capability mapping
- `TestFormalExtensionContext` (8): zero-pollution default, core/none/csv in context, parametrized
- `TestFormalExtensionFilter` (7): all no-op, core removes extensions, none removes all, CSV keeps requested+core, unknown raises, spectacular workflow integration
- `TestRunModernAnalysisSignature` (1): `formal_extension` parameter exists with default `all`