### PR TITLE
fix(cli): remove deprecated --mode legacy (#915)

### DIFF
--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -5,11 +5,13 @@
 Script pour lancer l'orchestration des agents d'analyse argumentative.
 
 Ce script permet de lancer l'analyse argumentative depuis la racine du projet.
-Il offre deux modes :
+Il offre plusieurs modes d'orchestration :
 
-  - **Moderne (défaut)** : utilise UnifiedPipeline avec 17 workflows pré-construits
+  - **Pipeline (défaut)** : utilise UnifiedPipeline avec 17 workflows pré-construits
     (CapabilityRegistry + WorkflowDSL + state tracking).
-  - **Legacy** : utilise l'ancien AnalysisRunner (--legacy flag).
+  - **Conversational** : agents dialoguent via AgentGroupChat.
+  - **Hierarchical** : StrategicManager → Lego WorkflowExecutor.
+  - **Sherlock Modern** : investigation multi-agent.
 
 Exemples :
     # Workflow standard (défaut) sur un fichier
@@ -21,8 +23,8 @@ Exemples :
     # Lister les workflows disponibles
     python argumentation_analysis/run_orchestration.py --list-workflows
 
-    # Mode legacy (ancien pipeline)
-    python argumentation_analysis/run_orchestration.py --file texte.txt --legacy
+    # Mode conversationnel
+    python argumentation_analysis/run_orchestration.py --text "Mon argument" --mode conversational
 """
 
 import sys
@@ -251,22 +253,6 @@ async def run_modern_analysis(
     return results
 
 
-async def run_legacy_analysis(
-    text_content: str,
-    llm_service: Any,
-) -> None:
-    """Exécute l'analyse via l'ancien AnalysisRunner (mode legacy).
-
-    :param text_content: Le contenu textuel à analyser.
-    :param llm_service: L'instance du service LLM initialisée.
-    """
-    logging.error(
-        "Le mode legacy (AnalysisRunner) a été supprimé. "
-        "Utilisez --mode pipeline (défaut) ou --mode conversational. "
-        "Voir docs/architecture/ORCHESTRATION_MODES.md pour les détails."
-    )
-    raise SystemExit(1)
-
 
 async def main():
     """Fonction principale du script."""
@@ -281,7 +267,6 @@ Exemples:
   %(prog)s --file texte.txt --workflow formal_extended  # Full formal chain
   %(prog)s --list-workflows                    # Lister les workflows
   %(prog)s --file texte.txt --output results.json  # Sauvegarder résultats
-  %(prog)s --file texte.txt --legacy           # Mode legacy (AnalysisRunner)
   %(prog)s --text "Mon argument" --mode conversational  # Mode conversationnel (agents dialoguent)
         """,
     )
@@ -335,20 +320,13 @@ Exemples:
             "pipeline",
             "conversational",
             "hierarchical",
-            "legacy",
             "sherlock_modern",
         ],
         default="pipeline",
         help="Mode d'orchestration: pipeline (séquentiel, défaut), "
         "conversational (agents dialoguent via AgentGroupChat), "
         "hierarchical (strategic planning → Lego execution), "
-        "legacy (ancien AnalysisRunner), "
         "sherlock_modern (investigation multi-agent, #357)",
-    )
-    parser.add_argument(
-        "--legacy",
-        action="store_true",
-        help="Raccourci pour --mode legacy",
     )
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Afficher les logs détaillés"
@@ -466,9 +444,6 @@ Exemples:
 
     # Initialisation de l'environnement
     llm_service = await setup_environment()
-    if not llm_service and args.legacy:
-        logging.error("Service LLM requis pour le mode legacy.")
-        return
 
     # Récupération du texte selon la source choisie
     text_content = None
@@ -519,13 +494,9 @@ Exemples:
 
     # Déterminer le mode d'orchestration
     mode = args.mode
-    if args.legacy:
-        mode = "legacy"
 
     # Exécution de l'analyse
-    if mode == "legacy":
-        await run_legacy_analysis(text_content, llm_service)
-    elif mode == "sherlock_modern":
+    if mode == "sherlock_modern":
         from argumentation_analysis.orchestration.sherlock_modern_orchestrator import (
             SherlockModernOrchestrator,
         )

--- a/docs/architecture/ORCHESTRATION_MODES.md
+++ b/docs/architecture/ORCHESTRATION_MODES.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-The system supports **6 orchestration modes**, each suited to different analysis scenarios. Five are wired into the CLI (`--mode`); one is active but dedicated to investigation scenarios via scripts.
+The system supports **5 orchestration modes**, each suited to different analysis scenarios. Four are wired into the CLI (`--mode`); one is active but dedicated to investigation scenarios via scripts.
 
 | Mode | CLI-selectable | Status | Key Class | Use Case |
 |------|---------------|--------|-----------|----------|
@@ -12,7 +12,6 @@ The system supports **6 orchestration modes**, each suited to different analysis
 | **Conversational** | ✅ `--mode conversational` | ACTIVE | `ConversationalOrchestrator` | Rich multi-agent dialogue with cross-KB synergies |
 | **Hierarchical** | ✅ `--mode hierarchical` | ACTIVE | `HierarchicalOrchestrator` | Strategic planning → Lego execution (bridge) |
 | **Sherlock Modern** | ✅ `--mode sherlock_modern` | ACTIVE | `SherlockModernOrchestrator` | Investigation multi-agent (#357) |
-| **Legacy** | ⚠️ `--mode legacy` (deprecated) | INERT | — | Hardcoded error message (AnalysisRunner removed) |
 | **Cluedo** | ❌ script-only | ACTIVE | `CluedoExtendedOrchestrator` | Sherlock-Watson investigation game |
 
 > **Note (scoping #912):** Cluedo is not reachable via `--mode` — it uses dedicated scripts and `__main__` entry points. Making it CLI-selectable requires an implementation issue (lane argparse, po-2025).
@@ -217,9 +216,6 @@ python run_orchestration.py --text "Your argument text" --mode hierarchical
 
 # List available workflows
 python run_orchestration.py --list-workflows
-
-# Legacy mode (AnalysisRunner)
-python run_orchestration.py --file text.txt --mode legacy
 ```
 
 ## API Quick Reference


### PR DESCRIPTION
## Summary

Removes the inert `--mode legacy` choice and `--legacy` shortcut flag. Legacy mode was a hardcoded error (SystemExit) since AnalysisRunner was removed — argparse now rejects it with a proper "invalid choice" message instead.

Closes #915

## Changes

### `argumentation_analysis/run_orchestration.py` (-33 LOC net)
- **Removed** `"legacy"` from `--mode` argparse choices
- **Removed** `--legacy` shortcut flag
- **Removed** `run_legacy_analysis()` function (was just `raise SystemExit(1)`)
- **Removed** legacy check in `main()` (`if args.legacy: mode = "legacy"`)
- **Updated** module docstring (4 modes listed instead of 2 + legacy)
- **Updated** epilog examples (removed `--legacy` line)

### `docs/architecture/ORCHESTRATION_MODES.md` (-3 LOC)
- Updated overview: "6 orchestration modes" → "5 orchestration modes"
- Removed Legacy row from mode table
- Removed legacy CLI example

## Testing

```bash
# Verify legacy is rejected
python -c "import argparse; p=argparse.ArgumentParser(); p.add_argument(--mode, choices=[pipeline,conversational,hierarchical,sherlock_modern]); p.parse_args([--mode,legacy])"
# → error: invalid choice: 'legacy'

# mypy strict — 0 new errors (2 pre-existing)
conda run -n projet-is-roo-new python -m mypy argumentation_analysis/run_orchestration.py --strict
```

## Breaking change

`--mode legacy` and `--legacy` now produce argparse errors instead of RuntimeError. Both were already unusable (hardcoded error), so this is a **net improvement** in error clarity.

## À valider par lutilisateur