### PR TITLE
fix(capstone): brick-health 13/13 — fix CSV fallback for hierarchical_fallacy (#928)

### DIFF
--- a/scripts/capstone_brick_health.py
+++ b/scripts/capstone_brick_health.py
@@ -157,9 +157,14 @@ async def test_brick_hierarchical_fallacy() -> BrickResult:
                     reader = csv.DictReader(f)
                     matches = []
                     for row in reader:
-                        term = row.get("nom_vulgarise", "").lower()
-                        if term and term in CORPUS_A.lower():
-                            matches.append(row.get("nom_vulgarise", ""))
+                        # Search in text_fr (primary name column) and Famille
+                        for col in ("text_fr", "Famille", "Sous-Famille"):
+                            term = row.get(col, "").strip().lower()
+                            if term and term in CORPUS_A.lower():
+                                matches.append(row.get("text_fr", "").strip())
+                                break
+                # Deduplicate
+                matches = list(dict.fromkeys(matches))
                 fallacies = matches
                 method = f"csv_fallback_{len(matches)}_matches"
         except Exception:


### PR DESCRIPTION
## Summary

Fix the `hierarchical_fallacy` brick in `scripts/capstone_brick_health.py` to achieve **13/13 PASS** on corpus_A.

## Problem

The CSV fallback for the fallacy brick searched the `nom_vulgarise` column which is mostly empty in `argumentum_fallacies_taxonomy.csv`. As a result, the fallback found 0 matches and the brick reported FAIL.

## Fix

Changed the CSV fallback to search across `text_fr`, `Famille`, and `Sous-Famille` columns (which contain the actual fallacy names), with deduplication.

## Results — 13/13 bricks PASS (7.2s on corpus_A)

| Brick | Result | Detail |
|-------|--------|--------|
| fact_extraction | ✅ PASS | 5 claims (heuristic) |
| hierarchical_fallacy | ✅ PASS | 1 match (csv_fallback) |
| quality_evaluator | ✅ PASS | 5 scored args |
| counter_argument | ✅ PASS | parsed + strategy |
| jtms | ✅ PASS | 15 beliefs with deps |
| governance | ✅ PASS | conflicts + resolutions + vote |
| debate | ✅ PASS | 6 quality dimensions |
| aspic | ✅ PASS | 2 surviving, 3 defeated (python) |
| propositional_logic | ✅ PASS | 5 formulas |
| fol_reasoning | ✅ PASS | 5 formulas |
| modal_logic | ✅ PASS | 1 formula, valid=True |
| dung_extensions | ✅ PASS | 5 args (native) |
| narrative_synthesis | ✅ PASS | 134 chars |

Report saved to `argumentation_analysis/evaluation/results/capstone_brick_health/brick_health_report.json` (gitignored).

## À valider par lutilisateur