### PR TITLE
fix(pipeline): solver defaults — eprover for FOL, spass for modal (#939)

### DIFF
--- a/argumentation_analysis/core/config.py
+++ b/argumentation_analysis/core/config.py
@@ -33,18 +33,18 @@ class ArgAnalysisSettings(BaseSettings):
 
     #
     # Le choix du solveur à utiliser pour les opérations de logique FOL.
-    # 'tweety' (défaut) utilise le pont JPype vers TweetyProject (SimpleFolReasoner).
+    # 'eprover' (défaut) utilise EProver via Tweety's EFOLReasoner — robust (#939).
     # 'prover9' utilise un appel à un processus externe Prover9.
-    # 'eprover' utilise EProver via Tweety's EFOLReasoner (requires eprover binary).
+    # 'tweety' fallback — SimpleFolReasoner via JPype, last resort only.
     #
-    solver: SolverChoice = SolverChoice.TWEETY
+    solver: SolverChoice = SolverChoice.EPROVER
 
     #
     # Le choix du solveur pour la logique modale.
-    # 'tweety' (défaut) utilise SimpleMlReasoner.
-    # 'spass' utilise SPASSMlReasoner (requires SPASS binary).
+    # 'spass' (défaut) utilise SPASSMlReasoner — robust (#939).
+    # 'tweety' fallback — SimpleMlReasoner, last resort only.
     #
-    modal_solver: ModalSolverChoice = ModalSolverChoice.TWEETY
+    modal_solver: ModalSolverChoice = ModalSolverChoice.SPASS
 
     #
     # Le choix du solveur pour la logique propositionnelle.

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -4913,10 +4913,10 @@ async def _invoke_fol_reasoning(
     ]
     formulas: Optional[List[str]] = None
     fol_metadata_shared: Dict[str, Any] = {}
-    # #900: Record the FOL solver choice from parametric selector
-    fol_solver_choice = context.get("fol_solver", "tweety")
+    # #900/#939: Default to eprover (robust), tweety is fallback of last resort
+    fol_solver_choice = context.get("fol_solver", "eprover")
     fol_metadata_shared["fol_solver"] = fol_solver_choice
-    if fol_solver_choice != "tweety":
+    if fol_solver_choice != "eprover":
         logger.info(f"FOL solver override: {fol_solver_choice} (parametric selector --fol-solver)")
 
     # Retrieve state object for fol_shared_signature storage
@@ -5371,7 +5371,7 @@ async def _invoke_modal_logic(
             modalities.append("possibility")
     modalities = list(set(modalities)) or ["none_detected"]
 
-    modal_solver = context.get("modal_solver", "tweety")  # tweety, spass
+    modal_solver = context.get("modal_solver", "spass")  # #939: spass default, tweety is last resort
 
     # SPASS routing (#479): set settings.modal_solver for this request
     if modal_solver == "spass":
@@ -6084,7 +6084,7 @@ async def _invoke_external_fol_solver(
             from argumentation_analysis.core.config import settings
             fol_solver = str(settings.solver)  # SolverChoice enum → str
         except Exception:
-            fol_solver = "tweety"
+            fol_solver = "eprover"  # #939: eprover default, not tweety
 
     # Try EProver via Tweety EFOLReasoner
     try:

--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -144,7 +144,7 @@ async def run_modern_analysis(
     shield_preset: str = "off",
     vote_method: str = "copeland",
     consensus_threshold: float = 0.7,
-    fol_solver: str = "tweety",
+    fol_solver: str = "eprover",
     counter_strategy: str = "auto",
     formal_extension: str = "all",
 ) -> Dict[str, Any]:
@@ -182,7 +182,7 @@ async def run_modern_analysis(
         context["vote_method"] = vote_method
     if consensus_threshold != 0.7:
         context["consensus_threshold"] = consensus_threshold
-    if fol_solver != "tweety":
+    if fol_solver != "eprover":
         context["fol_solver"] = fol_solver
     if counter_strategy != "auto":
         context["counter_strategy"] = counter_strategy
@@ -403,10 +403,10 @@ Exemples:
         "--fol-solver",
         type=str,
         choices=["tweety", "prover9", "eprover"],
-        default="tweety",
-        help="FOL solver backend: tweety (default, Java/TweetyProject), "
+        default="eprover",
+        help="FOL solver backend: eprover (default, robust external solver), "
         "prover9 (external Prover9 binary, skip if absent), "
-        "eprover (external E Prover binary, skip if absent)",
+        "tweety (Java/TweetyProject, fallback of last resort)",
     )
     parser.add_argument(
         "--counter-strategy",

--- a/tests/unit/argumentation_analysis/test_fol_solver_selector.py
+++ b/tests/unit/argumentation_analysis/test_fol_solver_selector.py
@@ -21,9 +21,9 @@ class TestFOLSolverCLI:
     """Test --fol-solver argument parsing."""
 
     def test_fol_solver_default(self):
-        """Default solver should be 'tweety'."""
+        """Default solver should be 'eprover' (#939: robust solver as default)."""
         valid_solvers = {"tweety", "prover9", "eprover"}
-        default = "tweety"
+        default = "eprover"
         assert default in valid_solvers
 
     def test_fol_solver_choices(self):
@@ -48,10 +48,10 @@ class TestFOLSolverContext:
     """Test context propagation for --fol-solver."""
 
     def test_default_not_in_context(self):
-        """Default 'tweety' should NOT be added to context (zero-pollution)."""
-        fol_solver = "tweety"
+        """Default 'eprover' should NOT be added to context (zero-pollution)."""
+        fol_solver = "eprover"
         context = {}
-        if fol_solver != "tweety":
+        if fol_solver != "eprover":
             context["fol_solver"] = fol_solver
         assert "fol_solver" not in context
 
@@ -59,30 +59,30 @@ class TestFOLSolverContext:
         """Non-default 'prover9' should be in context."""
         fol_solver = "prover9"
         context = {}
-        if fol_solver != "tweety":
+        if fol_solver != "eprover":
             context["fol_solver"] = fol_solver
         assert context["fol_solver"] == "prover9"
 
-    def test_eprover_in_context(self):
-        """Non-default 'eprover' should be in context."""
-        fol_solver = "eprover"
+    def test_tweety_in_context(self):
+        """Non-default 'tweety' should be in context (explicit override)."""
+        fol_solver = "tweety"
         context = {}
-        if fol_solver != "tweety":
+        if fol_solver != "eprover":
             context["fol_solver"] = fol_solver
-        assert context["fol_solver"] == "eprover"
+        assert context["fol_solver"] == "tweety"
 
     @pytest.mark.parametrize(
         "solver,expected_in_context",
         [
-            ("tweety", False),
+            ("eprover", False),
             ("prover9", True),
-            ("eprover", True),
+            ("tweety", True),
         ],
     )
     def test_context_pollution_parametrized(self, solver, expected_in_context):
         """Parametrized: only non-default solver pollutes context."""
         context = {}
-        if solver != "tweety":
+        if solver != "eprover":
             context["fol_solver"] = solver
         assert ("fol_solver" in context) == expected_in_context
 
@@ -110,14 +110,14 @@ class TestFOLSolverResolution:
         assert fol_solver is None
         # In real code: str(settings.solver) would be consulted
 
-    def test_default_tweety_when_no_context_no_settings(self):
-        """When both context and settings are unavailable, default is 'tweety'."""
+    def test_default_eprover_when_no_context_no_settings(self):
+        """When both context and settings are unavailable, default is 'eprover'."""
         context = {}
         fol_solver = context.get("fol_solver", None)
         if fol_solver is None:
-            # Simulate settings unavailable
-            fol_solver = "tweety"
-        assert fol_solver == "tweety"
+            # Simulate settings unavailable — #939: eprover is the new default
+            fol_solver = "eprover"
+        assert fol_solver == "eprover"
 
 
 # ---------------------------------------------------------------------------
@@ -147,11 +147,11 @@ class TestSettingsSolverBugFix:
         values = {s.value for s in SolverChoice}
         assert values == {"tweety", "prover9", "eprover"}
 
-    def test_settings_default_solver_is_tweety(self):
-        """Default settings.solver should be SolverChoice.TWEETY."""
+    def test_settings_default_solver_is_eprover(self):
+        """Default settings.solver should be SolverChoice.EPROVER (#939)."""
         from argumentation_analysis.core.config import SolverChoice
 
-        assert SolverChoice.TWEETY.value == "tweety"
+        assert SolverChoice.EPROVER.value == "eprover"
 
 
 # ---------------------------------------------------------------------------
@@ -168,11 +168,11 @@ class TestFOLReasoningMetadata:
         fol_metadata_shared = {"fol_solver": fol_solver_choice}
         assert fol_metadata_shared["fol_solver"] == "prover9"
 
-    def test_metadata_default_tweety(self):
-        """When no context override, fol_solver should be 'tweety'."""
-        fol_solver_choice = "tweety"
+    def test_metadata_default_eprover(self):
+        """When no context override, fol_solver should be 'eprover'."""
+        fol_solver_choice = "eprover"
         fol_metadata_shared = {"fol_solver": fol_solver_choice}
-        assert fol_metadata_shared["fol_solver"] == "tweety"
+        assert fol_metadata_shared["fol_solver"] == "eprover"
 
     def test_metadata_preserved_on_reassignment(self):
         """fol_solver should survive the fol_metadata_shared reassignment
@@ -205,7 +205,7 @@ class TestRunModernAnalysisSignature:
 
         sig = inspect.signature(run_modern_analysis)
         assert "fol_solver" in sig.parameters
-        assert sig.parameters["fol_solver"].default == "tweety"
+        assert sig.parameters["fol_solver"].default == "eprover"
 
 
 # ---------------------------------------------------------------------------
@@ -293,8 +293,8 @@ class TestExternalFOLSolverConsumer:
         assert result.get("logic_type") == "first_order"
         assert result.get("solver") in ("prover9", "tweety_fallback", "tweety")
 
-    async def test_default_tweety_uses_tweety_fallback(self):
-        """When context has no fol_solver, default tweety path should be used."""
+    async def test_default_eprover_uses_eprover_branch(self):
+        """When context has no fol_solver, default eprover path should be used (#939)."""
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_external_fol_solver,
         )
@@ -320,8 +320,8 @@ class TestExternalFOLSolverConsumer:
             })
             result = await _invoke_external_fol_solver("test formula", context)
 
-        # Default tweety path → tweety_fallback
-        assert result.get("solver") == "tweety_fallback"
+        # Default eprover path → eprover (or tweety_fallback if eprover unavailable)
+        assert result.get("solver") in ("eprover", "tweety_fallback")
         assert result.get("logic_type") == "first_order"
 
     async def test_no_context_falls_back_gracefully(self):


### PR DESCRIPTION
## Summary

Le pipeline production utilisait par défaut des solvers Tweety naifs alors que des solvers robustes (eprover, SPASS) existent déjà comme options. Fix : changer les 4 defaults pour utiliser les solvers les plus puissants disponibles.

## Changes

| Solver | Before (naif) | After (robuste) |
|--------|---------------|-----------------|
| FOL | `tweety` | `eprover` |
| Modal | `tweety` | `spass` |
| FOL external fallback | `tweety` | `eprover` |
| CLI --fol-solver | `tweety` | `eprover` |

PL solver reste `tweety` (PL fonctionne correctement avec Tweety).

## Files modified (4)

- `argumentation_analysis/core/config.py` — SolverChoice defaults: EPROVER, SPASS
- `argumentation_analysis/orchestration/invoke_callables.py` — 3 default changes (lines 4917, 5374, 6087)
- `argumentation_analysis/run_orchestration.py` — CLI default + zero-pollution guard
- `tests/unit/argumentation_analysis/test_fol_solver_selector.py` — 23/23 tests updated

## Verification

- `pytest tests/unit/argumentation_analysis/test_fol_solver_selector.py` — 23 passed
- Tests environment (`conftest.py:464`) force `ARG_ANALYSIS_SOLVER=tweety` → no test impact

Closes #939