### PR TITLE
fix(capstone): C1 extractor reads FOL consistent + Dung extensions shape

### DIFF
--- a/scripts/run_capstone_c1.py
+++ b/scripts/run_capstone_c1.py
@@ -176,31 +176,41 @@ def _extract_phase_metrics(snapshot: Dict[str, Any]) -> Dict[str, Any]:
             1 for _ in pl_results.get("formulas", [])
         ) if pl_results.get("satisfiable") is not None else 0
 
-    # FOL formulas
+    # FOL formulas — state uses "consistent" (not "satisfiable" which is PL-only)
     fol_results = snapshot.get("fol_analysis_results", [])
     if isinstance(fol_results, list):
         fol_formulas = sum(len(r.get("formulas", [])) for r in fol_results if isinstance(r, dict))
         fol_verified = sum(
-            1 for r in fol_results if isinstance(r, dict) and r.get("satisfiable") is not None
+            1 for r in fol_results if isinstance(r, dict) and r.get("consistent") is not None
             for _ in r.get("formulas", [])
         )
         metrics["fol_formulas"] = fol_formulas
         metrics["fol_verified"] = fol_verified
     elif isinstance(fol_results, dict):
         metrics["fol_formulas"] = len(fol_results.get("formulas", []))
-        metrics["fol_verified"] = len(fol_results.get("formulas", [])) if fol_results.get("satisfiable") is not None else 0
+        metrics["fol_verified"] = len(fol_results.get("formulas", [])) if fol_results.get("consistent") is not None else 0
 
-    # Dung extensions — field is dung_frameworks (dict)
+    # Dung extensions — state shape is {df_id: {name, arguments, attacks, extensions: {sem: [members]}}}
     dung = snapshot.get("dung_frameworks", snapshot.get("dung_extensions", {}))
     if isinstance(dung, dict):
-        all_ext = dung.get("all_extensions", dung)
-        if isinstance(all_ext, dict):
-            metrics["dung_semantics_count"] = len(all_ext)
-            metrics["dung_extensions"] = {
-                k: {"count": v.get("count", 0) if isinstance(v, dict) else 0}
-                for k, v in all_ext.items()
-                if k not in ("arguments", "attacks", "provider", "semantics")
-            }
+        total_ext_count = 0
+        dung_ext_detail = {}
+        for df_id, fw in dung.items():
+            if not isinstance(fw, dict):
+                continue
+            extensions = fw.get("extensions", {})
+            if isinstance(extensions, dict):
+                fw_ext_count = sum(len(members) for members in extensions.values() if isinstance(members, list))
+                total_ext_count += fw_ext_count
+                if fw_ext_count > 0:
+                    dung_ext_detail[df_id] = {
+                        "name": fw.get("name", df_id),
+                        "semantics": {sem: len(members) for sem, members in extensions.items() if isinstance(members, list)},
+                        "count": fw_ext_count,
+                    }
+        metrics["dung_framework_count"] = len(dung)
+        metrics["dung_total_extensions"] = total_ext_count
+        metrics["dung_extensions"] = dung_ext_detail
 
     # Counter-arguments
     counter_args = snapshot.get("counter_arguments", [])
@@ -365,7 +375,7 @@ async def run_capstone_c1(corpus_list: List[str]) -> None:
                 "pl_formulas": integral.get("phases", {}).get("pl_formulas"),
                 "fol_formulas": integral.get("phases", {}).get("fol_formulas"),
                 "counter_arguments": integral.get("phases", {}).get("counter_arguments_count"),
-                "dung_semantics": integral.get("phases", {}).get("dung_semantics_count"),
+                "dung_semantics": integral.get("phases", {}).get("dung_total_extensions"),
             },
             "baseline": {
                 "elapsed": baseline_scrubbed.get("elapsed_seconds"),

--- a/tests/unit/scripts/test_run_capstone_c1.py
+++ b/tests/unit/scripts/test_run_capstone_c1.py
@@ -1,0 +1,177 @@
+"""Tests for run_capstone_c1._extract_phase_metrics — verify FOL and Dung counters.
+
+Grounded from issue #941:
+- FOL state uses "consistent" (not "satisfiable" which is PL-only)
+- Dung state shape is {df_id: {name, arguments, attacks, extensions: {sem: [members]}}}
+"""
+import pytest
+
+
+# Import the function under test
+from scripts.run_capstone_c1 import _extract_phase_metrics
+
+
+class TestExtractPhaseMetricsFOL:
+    """Verify FOL counter reads 'consistent' from state entries."""
+
+    def test_fol_list_consistent_true(self):
+        """FOL entries with consistent=True should count as verified."""
+        snapshot = {
+            "fol_analysis_results": [
+                {"formulas": ["P(x)"], "consistent": True},
+                {"formulas": ["Q(x)", "R(x)"], "consistent": True},
+            ]
+        }
+        metrics = _extract_phase_metrics(snapshot)
+        assert metrics["fol_formulas"] == 3
+        assert metrics["fol_verified"] == 3
+
+    def test_fol_list_consistent_false_still_counted(self):
+        """FOL entries with consistent=False should still count formulas."""
+        snapshot = {
+            "fol_analysis_results": [
+                {"formulas": ["P(x)"], "consistent": False},
+            ]
+        }
+        metrics = _extract_phase_metrics(snapshot)
+        assert metrics["fol_formulas"] == 1
+        # consistent is not None → counted as verified (the formula was checked)
+        assert metrics["fol_verified"] == 1
+
+    def test_fol_list_satisfiable_key_ignored(self):
+        """FOL entries using old 'satisfiable' key should NOT be counted as verified.
+        This verifies we don't regress to the old bug."""
+        snapshot = {
+            "fol_analysis_results": [
+                {"formulas": ["P(x)"], "satisfiable": True},
+            ]
+        }
+        metrics = _extract_phase_metrics(snapshot)
+        assert metrics["fol_formulas"] == 1
+        # No "consistent" key → consistent is None → not counted
+        assert metrics["fol_verified"] == 0
+
+    def test_fol_dict_consistent(self):
+        """Single FOL dict result uses 'consistent'."""
+        snapshot = {
+            "fol_analysis_results": {
+                "formulas": ["P(x)", "Q(x)"],
+                "consistent": True,
+            }
+        }
+        metrics = _extract_phase_metrics(snapshot)
+        assert metrics["fol_formulas"] == 2
+        assert metrics["fol_verified"] == 2
+
+    def test_fol_empty(self):
+        """Empty FOL results should yield 0."""
+        snapshot = {"fol_analysis_results": []}
+        metrics = _extract_phase_metrics(snapshot)
+        assert metrics["fol_formulas"] == 0
+        assert metrics["fol_verified"] == 0
+
+
+class TestExtractPhaseMetricsDung:
+    """Verify Dung counter reads extensions from framework entries."""
+
+    def test_dung_single_framework_with_extensions(self):
+        """Single framework with extensions should count correctly."""
+        snapshot = {
+            "dung_frameworks": {
+                "dung_001": {
+                    "name": "Test Framework",
+                    "arguments": ["a1", "a2", "a3"],
+                    "attacks": [["a2", "a1"]],
+                    "extensions": {
+                        "grounded": ["a1", "a3"],
+                        "preferred": [["a1", "a3"], ["a2"]],
+                    },
+                },
+            }
+        }
+        metrics = _extract_phase_metrics(snapshot)
+        assert metrics["dung_framework_count"] == 1
+        # grounded: 2 members, preferred: 2 lists (counted as 2)
+        assert metrics["dung_total_extensions"] == 4
+        assert "dung_001" in metrics["dung_extensions"]
+
+    def test_dung_multiple_frameworks(self):
+        """Multiple frameworks should aggregate correctly."""
+        snapshot = {
+            "dung_frameworks": {
+                "dung_001": {
+                    "name": "FW1",
+                    "arguments": ["a1"],
+                    "attacks": [],
+                    "extensions": {"grounded": ["a1"]},
+                },
+                "dung_002": {
+                    "name": "FW2",
+                    "arguments": ["b1", "b2"],
+                    "attacks": [["b2", "b1"]],
+                    "extensions": {
+                        "grounded": ["b1"],
+                        "preferred": [["b1"], ["b2"]],
+                    },
+                },
+            }
+        }
+        metrics = _extract_phase_metrics(snapshot)
+        assert metrics["dung_framework_count"] == 2
+        # dung_001: 1, dung_002: 3
+        assert metrics["dung_total_extensions"] == 4
+
+    def test_dung_empty_extensions(self):
+        """Framework with empty extensions dict should yield 0."""
+        snapshot = {
+            "dung_frameworks": {
+                "dung_001": {
+                    "name": "Empty",
+                    "arguments": ["a1"],
+                    "attacks": [],
+                    "extensions": {},
+                },
+            }
+        }
+        metrics = _extract_phase_metrics(snapshot)
+        assert metrics["dung_framework_count"] == 1
+        assert metrics["dung_total_extensions"] == 0
+        # No entry in dung_extensions detail (0 extensions)
+        assert metrics["dung_extensions"] == {}
+
+    def test_dung_no_extensions_key(self):
+        """Framework without 'extensions' key should not crash."""
+        snapshot = {
+            "dung_frameworks": {
+                "dung_001": {
+                    "name": "No Extensions",
+                    "arguments": ["a1"],
+                    "attacks": [],
+                },
+            }
+        }
+        metrics = _extract_phase_metrics(snapshot)
+        assert metrics["dung_framework_count"] == 1
+        assert metrics["dung_total_extensions"] == 0
+
+    def test_dung_missing_field(self):
+        """No dung_frameworks at all should yield 0."""
+        snapshot = {}
+        metrics = _extract_phase_metrics(snapshot)
+        assert metrics.get("dung_framework_count", 0) == 0
+        assert metrics.get("dung_total_extensions", 0) == 0
+
+
+class TestExtractPhaseMetricsPL:
+    """Verify PL counter still works (unchanged by FOL fix)."""
+
+    def test_pl_satisfiable(self):
+        """PL uses 'satisfiable' — should be unaffected."""
+        snapshot = {
+            "propositional_analysis_results": [
+                {"formulas": ["p & q"], "satisfiable": True},
+            ]
+        }
+        metrics = _extract_phase_metrics(snapshot)
+        assert metrics["pl_formulas"] == 1
+        assert metrics["pl_verified"] == 1


### PR DESCRIPTION
## Summary

Fixes #941 — false negatives in the C1 report extractor (`scripts/run_capstone_c1.py::_extract_phase_metrics`).

The extractor was under-reporting FOL verified (0/0 on all 3 corpus) and Dung extensions (count=0 on all frameworks). The data was present in the state — the report was reading wrong keys.

## Defects fixed

### Defect 2 — FOL verified 0/0 (false negative)
- Extractor guarded on `r.get("satisfiable")` but FOL state entries use `"consistent"` (`shared_state.py:764`)
- `satisfiable` always `None` → `fol_verified = 0` unconditionally
- **Fix**: read `"consistent"` for the FOL counter

### Defect 3 — Dung count=0 (false negative)
- Extractor assumed shape `{all_extensions: {count: N}}` but actual state shape is `{df_id: {name, arguments, attacks, extensions: {sem: [members]}}}` (`shared_state.py:551-556`)
- Fallthrough → always 0
- **Fix**: iterate frameworks, read `fw["extensions"]`, count members per semantics

## Tests

- 11 new unit tests in `tests/unit/scripts/test_run_capstone_c1.py`
- 5 FOL tests (consistent true/false/None/empty, regression guard on satisfiable)
- 5 Dung tests (single/multiple frameworks, empty extensions, missing key, missing field)
- 1 PL regression guard (satisfiable still works)

## Files modified

| File | Change |
|------|--------|
| `scripts/run_capstone_c1.py` | FOL: `satisfiable` → `consistent`; Dung: new shape parser (+23/-10) |
| `tests/unit/scripts/test_run_capstone_c1.py` | New: 11 unit tests (+177) |

## DoD #941

- [x] Compteur FOL lit `consistent` (pas `satisfiable`)
- [x] Compteur Dung lit `dung_frameworks[*]["extensions"]` et compte
- [ ] Re-run Capstone C1 corpus_A : FOL verified > 0 ET Dung count > 0 → **#945** (deep-queue, post-merge)
- [x] Test unitaire extracteur : state synthétique → compteurs > 0

## Privacy

IDs opaques (corpus_A) everywhere. No raw_text in artefacts. Run outputs gitignored.