### PR TITLE
fix(fol): eprover→tweety binary-absent fallback (#949)

### DIFF
--- a/argumentation_analysis/agents/core/logic/fol_handler.py
+++ b/argumentation_analysis/agents/core/logic/fol_handler.py
@@ -257,16 +257,52 @@ class FOLHandler:
     async def fol_check_consistency(self, belief_set):
         """
         Checks if an FOL knowledge base is consistent using the configured solver.
+
+        When the configured external solver (eprover/prover9) is unavailable
+        (binary absent, RuntimeError), falls back to the in-JVM Tweety FOL
+        reasoner — mirroring the modal pattern (modal_handler.py:36-48).
+        Returns a ``solver_fallback`` flag in the result so callers can track
+        degradation.
         """
         self.logger.debug(
             f"Performing FOL consistency check with solver: {settings.solver.value}"
         )
         if settings.solver == SolverChoice.PROVER9:
-            return await self._fol_check_consistency_with_prover9(belief_set)
+            try:
+                return await self._fol_check_consistency_with_prover9(belief_set)
+            except RuntimeError as e:
+                self.logger.warning(
+                    f"Prover9 unavailable ({e}), falling back to Tweety FOL reasoner"
+                )
+                return await self._fol_check_consistency_with_tweety_fallback(belief_set)
         elif settings.solver == SolverChoice.EPROVER:
-            return await self._fol_check_consistency_with_eprover(belief_set)
+            try:
+                return await self._fol_check_consistency_with_eprover(belief_set)
+            except RuntimeError as e:
+                self.logger.warning(
+                    f"EProver unavailable ({e}), falling back to Tweety FOL reasoner"
+                )
+                return await self._fol_check_consistency_with_tweety_fallback(belief_set)
         else:
             return await self._fol_check_consistency_with_tweety(belief_set)
+
+    async def _fol_check_consistency_with_tweety_fallback(self, belief_set):
+        """Attempt Tweety FOL consistency check; returns solver_fallback=True on success."""
+        try:
+            result = await self._fol_check_consistency_with_tweety(belief_set)
+            # result is (bool, str) — inject fallback flag
+            is_consistent, msg = result
+            return is_consistent, msg, True  # solver_fallback=True
+        except Exception as tweety_err:
+            self.logger.error(
+                f"Tweety FOL fallback also failed: {tweety_err}",
+                exc_info=True,
+            )
+            # Both solvers failed — propagate original issue
+            raise RuntimeError(
+                f"FOL consistency check failed: external solver absent and "
+                f"Tweety fallback failed ({tweety_err})"
+            ) from tweety_err
 
     async def _fol_check_consistency_with_prover9(self, belief_set):
         logger.debug(
@@ -358,18 +394,35 @@ class FOLHandler:
             )
             raise RuntimeError(f"EProver consistency check failed: {e}") from e
 
-    def fol_query(self, belief_set, query_formula_str: str) -> bool:
+    def fol_query(self, belief_set, query_formula_str: str):
         """
         Checks if a query is entailed by a belief base using the configured solver.
+
+        When the external solver is unavailable (binary absent, RuntimeError),
+        falls back to the in-JVM Tweety reasoner.  Returns a tuple
+        ``(entailed: bool, solver_fallback: bool)`` so callers can track
+        degradation.
         """
         logger.debug(f"Performing FOL query with solver: {settings.solver.value}")
 
         if settings.solver == SolverChoice.PROVER9:
-            return self._fol_query_with_prover9(belief_set, query_formula_str)
+            try:
+                return self._fol_query_with_prover9(belief_set, query_formula_str), False
+            except RuntimeError as e:
+                logger.warning(
+                    f"Prover9 unavailable ({e}), falling back to Tweety FOL query"
+                )
+                return self._fol_query_with_tweety(belief_set, query_formula_str), True
         elif settings.solver == SolverChoice.EPROVER:
-            return self._fol_query_with_eprover(belief_set, query_formula_str)
+            try:
+                return self._fol_query_with_eprover(belief_set, query_formula_str), False
+            except RuntimeError as e:
+                logger.warning(
+                    f"EProver unavailable ({e}), falling back to Tweety FOL query"
+                )
+                return self._fol_query_with_tweety(belief_set, query_formula_str), True
         else:
-            return self._fol_query_with_tweety(belief_set, query_formula_str)
+            return self._fol_query_with_tweety(belief_set, query_formula_str), False
 
     def _fol_query_with_prover9(self, belief_set, query_formula_str: str) -> bool:
         """

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_fol_handler.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_fol_handler.py
@@ -1,0 +1,201 @@
+"""Tests for FOL handler solver fallback (#949).
+
+Verifies that when the configured external solver (eprover/prover9) is absent,
+FOLHandler gracefully falls back to the in-JVM Tweety reasoner — mirroring
+the modal pattern.  A ``solver_fallback`` flag is returned so callers can
+track degradation.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestFOLSolverFallback:
+    """Test graceful solver downgrade when external binary is absent."""
+
+    @pytest.fixture
+    def handler(self):
+        """Create a FOLHandler with a mock initializer."""
+        from argumentation_analysis.agents.core.logic.fol_handler import FOLHandler
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
+
+        mock_initializer = MagicMock(spec=TweetyInitializer)
+        mock_initializer.get_fol_parser.return_value = MagicMock()
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.fol_handler.settings"
+        ) as mock_settings:
+            mock_settings.solver = MagicMock()
+            mock_settings.solver.value = "eprover"
+            # Force tweety path for constructor
+            from argumentation_analysis.core.config import SolverChoice
+            mock_settings.solver = SolverChoice.TWEETY
+            handler = FOLHandler(initializer_instance=mock_initializer)
+            # Now override to eprover for test
+            mock_settings.solver = SolverChoice.EPROVER
+
+        handler._initializer_instance = mock_initializer
+        return handler
+
+    @pytest.mark.asyncio
+    async def test_eprover_absent_falls_back_to_tweety_consistency(self, handler):
+        """When eprover binary is absent, consistency check uses Tweety fallback."""
+        from argumentation_analysis.core.config import SolverChoice
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.fol_handler.settings"
+        ) as mock_settings:
+            mock_settings.solver = SolverChoice.EPROVER
+
+            # Mock eprover to raise RuntimeError (binary absent)
+            with patch.object(
+                handler,
+                "_fol_check_consistency_with_eprover",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("EProver binary not found"),
+            ):
+                # Mock tweety fallback to succeed
+                with patch.object(
+                    handler,
+                    "_fol_check_consistency_with_tweety",
+                    new_callable=AsyncMock,
+                    return_value=(True, "Tweety-based consistency check result: True"),
+                ):
+                    belief_set = MagicMock()
+                    belief_set.size.return_value = 2
+                    result = await handler.fol_check_consistency(belief_set)
+
+        # Result should be (is_consistent, msg, solver_fallback=True)
+        assert len(result) == 3
+        is_consistent, msg, solver_fallback = result
+        assert is_consistent is True
+        assert solver_fallback is True, "solver_fallback flag must be True when degraded"
+        assert "Tweety" in msg
+
+    @pytest.mark.asyncio
+    async def test_eprover_present_no_fallback(self, handler):
+        """When eprover is available, no fallback occurs."""
+        from argumentation_analysis.core.config import SolverChoice
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.fol_handler.settings"
+        ) as mock_settings:
+            mock_settings.solver = SolverChoice.EPROVER
+
+            with patch.object(
+                handler,
+                "_fol_check_consistency_with_eprover",
+                new_callable=AsyncMock,
+                return_value=(False, "EProver-based consistency check result: False"),
+            ):
+                belief_set = MagicMock()
+                belief_set.size.return_value = 2
+                result = await handler.fol_check_consistency(belief_set)
+
+        # No fallback — result is (is_consistent, msg) from eprover directly
+        assert len(result) == 2
+        is_consistent, msg = result
+        assert is_consistent is False
+        assert "EProver" in msg
+
+    @pytest.mark.asyncio
+    async def test_tweety_path_no_fallback(self, handler):
+        """When solver is Tweety directly, no fallback mechanism is needed."""
+        from argumentation_analysis.core.config import SolverChoice
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.fol_handler.settings"
+        ) as mock_settings:
+            mock_settings.solver = SolverChoice.TWEETY
+
+            with patch.object(
+                handler,
+                "_fol_check_consistency_with_tweety",
+                new_callable=AsyncMock,
+                return_value=(True, "Tweety-based consistency check result: True"),
+            ):
+                belief_set = MagicMock()
+                belief_set.size.return_value = 1
+                result = await handler.fol_check_consistency(belief_set)
+
+        # Direct Tweety path — 2-tuple, no fallback flag
+        assert len(result) == 2
+        is_consistent, msg = result
+        assert is_consistent is True
+
+    def test_eprover_absent_falls_back_to_tweety_query(self, handler):
+        """When eprover binary is absent, FOL query uses Tweety fallback."""
+        from argumentation_analysis.core.config import SolverChoice
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.fol_handler.settings"
+        ) as mock_settings:
+            mock_settings.solver = SolverChoice.EPROVER
+
+            with patch.object(
+                handler,
+                "_fol_query_with_eprover",
+                side_effect=RuntimeError("EProver binary not found"),
+            ):
+                with patch.object(
+                    handler,
+                    "_fol_query_with_tweety",
+                    return_value=True,
+                ):
+                    belief_set = MagicMock()
+                    result = handler.fol_query(belief_set, "mortal(socrates)")
+
+        # Result is (entailed, solver_fallback)
+        entailed, solver_fallback = result
+        assert entailed is True
+        assert solver_fallback is True, "solver_fallback must be True on query degradation"
+
+    def test_eprover_present_no_query_fallback(self, handler):
+        """When eprover is available, query returns (entailed, False)."""
+        from argumentation_analysis.core.config import SolverChoice
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.fol_handler.settings"
+        ) as mock_settings:
+            mock_settings.solver = SolverChoice.EPROVER
+
+            with patch.object(
+                handler,
+                "_fol_query_with_eprover",
+                return_value=True,
+            ):
+                belief_set = MagicMock()
+                result = handler.fol_query(belief_set, "mortal(socrates)")
+
+        entailed, solver_fallback = result
+        assert entailed is True
+        assert solver_fallback is False, "solver_fallback must be False when eprover works"
+
+    @pytest.mark.asyncio
+    async def test_both_solvers_absent_raises(self, handler):
+        """When both external and Tweety solvers fail, RuntimeError is raised."""
+        from argumentation_analysis.core.config import SolverChoice
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.fol_handler.settings"
+        ) as mock_settings:
+            mock_settings.solver = SolverChoice.EPROVER
+
+            with patch.object(
+                handler,
+                "_fol_check_consistency_with_eprover",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("EProver binary not found"),
+            ):
+                with patch.object(
+                    handler,
+                    "_fol_check_consistency_with_tweety",
+                    new_callable=AsyncMock,
+                    side_effect=NotImplementedError("Tweety also failed"),
+                ):
+                    belief_set = MagicMock()
+                    belief_set.size.return_value = 2
+                    with pytest.raises(RuntimeError, match="FOL consistency check failed"):
+                        await handler.fol_check_consistency(belief_set)


### PR DESCRIPTION
## Summary

Closes #949 (Epic #947, Phase 2 — FB-4)

When the configured external FOL solver (eprover/prover9) is absent, `FOLHandler` now gracefully falls back to the in-JVM Tweety FOL reasoner — mirroring the modal pattern (`modal_handler.py:36-48`). A `solver_fallback` flag is returned for degradation tracking.

## Changes

### `fol_handler.py` (+59/-6)
- `fol_check_consistency()`: try/except around eprover/prover9 → fallback to tweety on `RuntimeError`
- `fol_query()`: same pattern, returns `(entailed, solver_fallback)` tuple
- New `_fol_check_consistency_with_tweety_fallback()` method with `solver_fallback=True` flag
- `logger.warning` on fallback (detectable in dev/CI logs)

### `test_fol_handler.py` (new, 6 tests)
| Test | Result | Gate |
|------|--------|------|
| eprover absent → tweety fallback | PASS | `solver_fallback=True` |
| eprover present → no fallback | PASS | 2-tuple result |
| tweety direct path → no fallback | PASS | 2-tuple result |
| query fallback same pattern | PASS | `solver_fallback=True` |
| query no fallback when eprover works | PASS | `solver_fallback=False` |
| both solvers absent → RuntimeError | PASS | no silent failure |

## Local run
```
6 passed, 5 warnings in 4.11s
```

## DoD checklist
- [x] When eprover binary is absent, FOL uses in-JVM Tweety (verified by test)
- [x] `solver_fallback` flag returned for degradation tracking
- [x] WARNING log on fallback for dev/CI visibility
- [x] No regression on FOL per-formula isolation (`invoke_callables.py` untouched)
- [x] Both solvers absent → RuntimeError (not silent)

## Anti-pendule
Solver *selection* fallback only — does not touch per-formula isolation logic.

## Privacy
Synthetic formulas only, opaque IDs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>