### PR TITLE
fix(conversational): wrap run_conversational_analysis in llm_budget_scope (#950)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -492,6 +492,54 @@ async def run_conversational_analysis(
     """
     start_time = time.time()
 
+    # 0a. Activate per-run LLM-call circuit breaker (#950).
+    # Mirrors workflow_dsl.py:334 — every LLM call from every phase counts
+    # against one ceiling, so a degenerate counter-arg sweep cannot run away
+    # into thousands of round-trips (issue #708 origin).  Re-entrant: if a
+    # budget scope is already active (e.g. from a parent orchestrator), it is
+    # reused without resetting the count.
+    from argumentation_analysis.orchestration.invoke_callables import (
+        llm_budget_scope,
+    )
+
+    with llm_budget_scope():
+        return await _run_conversational_analysis_inner(
+            text=text,
+            max_turns_per_phase=max_turns_per_phase,
+            agent_names=agent_names,
+            spectacular=spectacular,
+            extraction_max_turns=extraction_max_turns,
+            formal_max_turns=formal_max_turns,
+            synthesis_max_turns=synthesis_max_turns,
+            reanalysis_max_turns=reanalysis_max_turns,
+            enable_growth_validation=enable_growth_validation,
+            growth_re_prompt_limit=growth_re_prompt_limit,
+            enable_tool_gating=enable_tool_gating,
+            enable_reprompt_tracing=enable_reprompt_tracing,
+            source_metadata=source_metadata,
+            selector_context=selector_context,
+        )
+
+
+async def _run_conversational_analysis_inner(
+    text: str,
+    max_turns_per_phase: int = 5,
+    agent_names: Optional[List[str]] = None,
+    spectacular: bool = True,
+    extraction_max_turns: int = 7,
+    formal_max_turns: int = 5,
+    synthesis_max_turns: int = 10,
+    reanalysis_max_turns: int = 5,
+    enable_growth_validation: bool = True,
+    growth_re_prompt_limit: int = 2,
+    enable_tool_gating: bool = False,
+    enable_reprompt_tracing: bool = False,
+    source_metadata: Optional[Dict[str, str]] = None,
+    selector_context: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Inner implementation of run_conversational_analysis, already inside llm_budget_scope."""
+    start_time = time.time()
+
     # 0b. Env var override for growth validation (#597)
     _env_growth = os.environ.get("ENABLE_GROWTH_VALIDATION", "").lower()
     if _env_growth in ("0", "false", "no"):

--- a/tests/unit/argumentation_analysis/orchestration/test_conversational_llm_budget.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversational_llm_budget.py
@@ -1,0 +1,99 @@
+"""Tests for conversational path LLM budget coverage (#950).
+
+Verifies that the conversational orchestrator runs under the LLM budget
+circuit breaker, mirroring the sequential path (workflow_dsl.py:334).
+
+Epic #947 Phase 2 — FB-5.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+
+class TestConversationalLLMBudget:
+    """Verify run_conversational_analysis enters llm_budget_scope."""
+
+    def test_llm_budget_scope_importable(self):
+        """llm_budget_scope can be imported from invoke_callables."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            llm_budget_scope,
+        )
+
+        assert callable(llm_budget_scope)
+
+    @pytest.mark.asyncio
+    async def test_conversational_enters_budget_scope(self):
+        """run_conversational_analysis must enter llm_budget_scope."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _llm_budget,
+        )
+
+        # Mock _run_conversational_analysis_inner to check if budget is active
+        budget_active = False
+
+        async def _mock_inner(**kwargs):
+            nonlocal budget_active
+            budget_active = _llm_budget.get() is not None
+            return {"state_snapshot": {}, "conversation_log": [], "metrics": {}}
+
+        with patch(
+            "argumentation_analysis.orchestration.conversational_orchestrator"
+            "._run_conversational_analysis_inner",
+            side_effect=_mock_inner,
+        ):
+            from argumentation_analysis.orchestration.conversational_orchestrator import (
+                run_conversational_analysis,
+            )
+
+            result = await run_conversational_analysis("Test text")
+
+        assert budget_active, (
+            "run_conversational_analysis did NOT enter llm_budget_scope — "
+            "conversational LLM calls are uncapped (runaway risk from #708)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_budget_scope_exits_after_run(self):
+        """Budget scope must be cleaned up after run_conversational_analysis."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _llm_budget,
+        )
+
+        async def _mock_inner(**kwargs):
+            return {"state_snapshot": {}, "conversation_log": [], "metrics": {}}
+
+        with patch(
+            "argumentation_analysis.orchestration.conversational_orchestrator"
+            "._run_conversational_analysis_inner",
+            side_effect=_mock_inner,
+        ):
+            from argumentation_analysis.orchestration.conversational_orchestrator import (
+                run_conversational_analysis,
+            )
+
+            await run_conversational_analysis("Test text")
+
+        # After the run, budget should be cleared
+        assert _llm_budget.get() is None, "Budget scope leaked after run"
+
+    @pytest.mark.asyncio
+    async def test_budget_exceeded_stops_conversational(self):
+        """LLMBudgetExceeded from inner run propagates (budget enforcement works)."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            LLMBudgetExceeded,
+        )
+
+        async def _mock_inner(**kwargs):
+            raise LLMBudgetExceeded("Simulated budget exceeded")
+
+        with patch(
+            "argumentation_analysis.orchestration.conversational_orchestrator"
+            "._run_conversational_analysis_inner",
+            side_effect=_mock_inner,
+        ):
+            from argumentation_analysis.orchestration.conversational_orchestrator import (
+                run_conversational_analysis,
+            )
+
+            with pytest.raises(LLMBudgetExceeded, match="Simulated budget exceeded"):
+                await run_conversational_analysis("Test text")


### PR DESCRIPTION
## Summary

Closes #950 (Epic #947, Phase 2 — FB-5)

The LLM budget circuit breaker (`llm_budget_scope`, default 500 calls) was only active in the sequential/DAG path (`workflow_dsl.py:334`). The conversational orchestrator ran WITHOUT budget — the counter-arg runaway (8h/12.4K calls, issue #708) could still reproduce on the conversational path.

## Verdict

**Conversational path was NOT covered by the LLM budget.** Confirmed by:
- `grep llm_budget_scope` → only in `workflow_dsl.py`
- `conversational_orchestrator.py` → zero references to `llm_budget` or `_LLMBudget`
- `_run_phase` calls `AgentGroupChat.invoke()` with no budget protection

## Fix

`run_conversational_analysis` now enters `llm_budget_scope` before delegating to `_run_conversational_analysis_inner`. Re-entrant: if a parent orchestrator already set a budget, it is reused without reset.

### Files changed

| File | Change |
|------|--------|
| `conversational_orchestrator.py` | +48 lines: thin wrapper with `llm_budget_scope()` + inner function |
| `test_conversational_llm_budget.py` (new) | 4 tests pinning coverage |

### Tests (4 passed, 3.60s)

| Test | Gate |
|------|------|
| budget scope entered during run | `_llm_budget.get() is not None` |
| budget scope cleaned up after run | `_llm_budget.get() is None` |
| `LLMBudgetExceeded` propagates | budget enforcement works |
| `llm_budget_scope` importable | baseline check |

## DoD checklist
- [x] Documented verdict: conversational path WAS NOT covered → NOW covered
- [x] Conversational run enters `llm_budget_scope` (verified by test)
- [x] Test pins coverage so it can't regress silently
- [x] Re-entrant: nested scope reuses existing budget

## Anti-pendule
Verify-then-fix approach. No changes to the budget mechanism itself — only wiring the conversational path into it. No ceiling change.

## Collision-guard
Only `conversational_orchestrator.py` + new test file. Disjoint from #941, FB-3, FB-4.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>