### PR TITLE
fix(counter-arg): remove fabricated 15% statistic from statistical template (#960)

### DIFF
--- a/argumentation_analysis/agents/core/counter_argument/strategies.py
+++ b/argumentation_analysis/agents/core/counter_argument/strategies.py
@@ -253,9 +253,17 @@ class RhetoricalStrategies:
         )
 
     def _generate_statistical_counter(self, argument: Argument) -> str:
+        """Generate a statistical counter-argument template (no fabricated data).
+
+        Returns a schematic placeholder that frames the statistical challenge
+        without inventing specific numbers — actual data would be needed to
+        substantiate the objection.
+        """
         return (
-            "in only 15% of studied cases was this cause-effect relationship observed, "
-            "far from a general rule"
+            "[template/placeholder] a statistical counter would challenge the "
+            "claimed cause-effect relationship as holding in only a limited "
+            "fraction of cases — the strength of this objection depends on "
+            "actual data"
         )
 
     def _fallback_counter_argument(

--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_strategies.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_strategies.py
@@ -404,10 +404,15 @@ class TestHelperGenerators:
         result = strategies._generate_analogy(arg)
         assert "path" in result.lower() or "detour" in result.lower()
 
-    def test_statistical_counter(self, strategies):
+    def test_statistical_counter_no_fabricated_stat(self, strategies):
+        """_generate_statistical_counter must not emit fabricated precise percentages."""
         arg = _make_argument()
         result = strategies._generate_statistical_counter(arg)
-        assert "15%" in result
+        # The template must describe the challenge schematically without inventing data
+        assert "statistical" in result.lower() or "counter" in result.lower()
+        # MUST NOT contain fabricated precise percentages (#960)
+        assert "15%" not in result
+        assert "template/placeholder" in result
 
     def test_fallback_counter(self, strategies):
         arg = _make_argument()

--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -446,3 +446,108 @@ class TestFactExtractionValueGate:
                 f"Non-factual text produced high-confidence claim ({claim.confidence}): "
                 f"{claim.claim_text}"
             )
+
+
+# =====================================================================
+# 6. Counter-argument — no fabricated statistics (#960)
+# =====================================================================
+
+
+class TestCounterArgValueGate:
+    """Assert the statistical-counter strategy does not emit fabricated data.
+
+    The template fallback for statistical evidence must not invent specific
+    percentages and present them as findings. A regression that re-introduces
+    fabricated numbers must fail CI (#960, decision-B rule).
+    """
+
+    def test_statistical_counter_no_fabricated_percentage(self):
+        """_generate_statistical_counter must not contain invented percentages."""
+        from argumentation_analysis.agents.core.counter_argument.strategies import (
+            RhetoricalStrategies,
+        )
+        from argumentation_analysis.agents.core.counter_argument.definitions import (
+            Argument,
+            CounterArgumentType,
+            RhetoricalStrategy,
+        )
+
+        strategies = RhetoricalStrategies()
+        arg = Argument(
+            content="This policy always works.",
+            premises=["The data shows consistent results"],
+            conclusion="This policy always works",
+            argument_type="inductive",
+            confidence=0.8,
+        )
+
+        # Test via the full apply path (DIRECT_REFUTATION)
+        result = strategies.apply_strategy(
+            RhetoricalStrategy.STATISTICAL_EVIDENCE,
+            arg,
+            CounterArgumentType.DIRECT_REFUTATION,
+        )
+        assert isinstance(result, str)
+        assert len(result) > 0, "Statistical evidence strategy returned empty string"
+        # MUST NOT contain fabricated precise percentages
+        assert "15%" not in result, (
+            "Statistical counter still contains fabricated '15%' statistic (#960)"
+        )
+
+    def test_statistical_counter_tagged_as_template(self):
+        """Template-fallback output must be tagged as placeholder."""
+        from argumentation_analysis.agents.core.counter_argument.strategies import (
+            RhetoricalStrategies,
+        )
+        from argumentation_analysis.agents.core.counter_argument.definitions import (
+            Argument,
+        )
+
+        strategies = RhetoricalStrategies()
+        arg = Argument(
+            content="Test argument",
+            premises=["Test premise"],
+            conclusion="Test conclusion",
+            argument_type="deductive",
+            confidence=0.5,
+        )
+
+        result = strategies._generate_statistical_counter(arg)
+        assert "template/placeholder" in result, (
+            "Statistical template output must be tagged [template/placeholder] "
+            "so downstream consumers know it is not evidenced data (#960)"
+        )
+
+    def test_other_four_strategies_unchanged(self):
+        """The 4 non-statistical strategies must still produce non-empty output."""
+        from argumentation_analysis.agents.core.counter_argument.strategies import (
+            RhetoricalStrategies,
+        )
+        from argumentation_analysis.agents.core.counter_argument.definitions import (
+            Argument,
+            CounterArgumentType,
+            RhetoricalStrategy,
+        )
+
+        strategies = RhetoricalStrategies()
+        arg = Argument(
+            content="Tous les chats sont noirs.",
+            premises=["Tous les chats observés sont noirs"],
+            conclusion="Tous les chats sont noirs",
+            argument_type="deductive",
+            confidence=0.7,
+        )
+
+        non_stat_strategies = [
+            RhetoricalStrategy.SOCRATIC_QUESTIONING,
+            RhetoricalStrategy.REDUCTIO_AD_ABSURDUM,
+            RhetoricalStrategy.ANALOGICAL_COUNTER,
+            RhetoricalStrategy.AUTHORITY_APPEAL,
+        ]
+        for strat in non_stat_strategies:
+            result = strategies.apply_strategy(
+                strat, arg, CounterArgumentType.DIRECT_REFUTATION
+            )
+            assert isinstance(result, str) and len(result) > 0, (
+                f"Strategy {strat.name} returned empty output after #960 fix"
+            )


### PR DESCRIPTION
## #960 — Counter-arg fabricated stat fix (FB-9)

**Epic #947 "Final Boss" — Phase 4 must-fix**

### Problem
`_generate_statistical_counter()` (`strategies.py:255-259`) returned an invented precise percentage ("in only 15% of studied cases…") as if it were a real finding. This would immediately discredit the pipeline in the #953 benchmark.

### Fix
- Replaced fabricated stat with a schematic placeholder tagged `[template/placeholder]` — no invented numbers
- Strategy preserved: statistical-counter still produces a coherent challenge
- Downstream consumers can identify template output vs real data

### Value-gate tests (decision-B rule)
- `TestCounterArgValueGate` (3 new tests in `test_value_gates.py`):
  1. `test_statistical_counter_no_fabricated_percentage` — asserts no "15%" in output
  2. `test_statistical_counter_tagged_as_template` — asserts `[template/placeholder]` tag present
  3. `test_other_four_strategies_unchanged` — verifies other 4 strategies still work

### Files changed
- `argumentation_analysis/agents/core/counter_argument/strategies.py` (+12/-3)
- `tests/unit/argumentation_analysis/agents/core/counter_argument/test_strategies.py` (+8/-3)
- `tests/unit/argumentation_analysis/test_value_gates.py` (+62/-0)

### Verification
- [x] 70 passed, 2 xfailed (modal #941), 0 failures
- [x] No fabricated percentage in statistical template
- [x] Template tagged as placeholder
- [x] Other 4 strategies unaffected
- [x] Privacy: no corpus content, code fix only

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>