### PR TITLE
fix(satellite): replace 4 degenerate fallbacks with honest unavailable status

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -2657,14 +2657,19 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str,
             handler.analyze_bipolar_framework, args, attacks, supports, fw_type
         )
     except Exception as e:
-        logger.info(f"Bipolar handler unavailable ({e}), using Python fallback")
+        logger.warning(
+            "Bipolar analysis unavailable: no JVM/Tweety handler could be loaded. "
+            "Reporting unverified status. (%s)", e,
+        )
         return {
             "framework_type": fw_type,
             "arguments": args,
             "attacks": attacks,
             "supports": supports,
-            "extensions": [args[:2]] if len(args) >= 2 else [args],
+            "extensions": None,
+            "solver": "unavailable",
             "fallback": "python",
+            "message": "Bipolar analysis unavailable: no solver could be loaded.",
         }
 
 
@@ -3233,13 +3238,18 @@ async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict[str, A
         handler = SetAFHandler(initializer)
         return await asyncio.to_thread(handler.analyze_setaf, args, attacks, semantics)
     except Exception as e:
-        logger.info(f"SetAF handler unavailable ({e}), using Python fallback")
+        logger.warning(
+            "SetAF analysis unavailable: no JVM/Tweety handler could be loaded. "
+            "Reporting unverified status. (%s)", e,
+        )
         return {
             "arguments": args,
             "set_attacks": attacks,
             "semantics": semantics,
-            "extensions": [args[:2]] if len(args) >= 2 else [args],
+            "extensions": None,
+            "solver": "unavailable",
             "fallback": "python",
+            "message": "SetAF analysis unavailable: no solver could be loaded.",
         }
 
 
@@ -3265,15 +3275,19 @@ async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict[str
             handler.analyze_weighted_framework, args, attacks, semantics
         )
     except Exception as e:
-        logger.info(f"Weighted handler unavailable ({e}), using Python fallback")
-        scores = {a: round(1.0 / (i + 1), 4) for i, a in enumerate(args)}
+        logger.warning(
+            "Weighted AF analysis unavailable: no JVM/Tweety handler could be loaded. "
+            "Reporting unverified status. (%s)", e,
+        )
         return {
             "arguments": args,
             "weighted_attacks": attacks,
             "semantics": semantics,
-            "scores": scores,
-            "extensions": [args[:2]] if len(args) >= 2 else [args],
+            "scores": None,
+            "extensions": None,
+            "solver": "unavailable",
             "fallback": "python",
+            "message": "Weighted AF analysis unavailable: no solver could be loaded.",
         }
 
 
@@ -3541,13 +3555,18 @@ async def _invoke_delp(input_text: str, context: Dict[str, Any]) -> Dict[str, An
             handler.analyze_delp, program_text, queries, criterion
         )
     except Exception as e:
-        logger.info(f"DeLP handler unavailable ({e}), using Python fallback")
+        logger.warning(
+            "DeLP analysis unavailable: no JVM/Tweety handler could be loaded. "
+            "Reporting unverified status. (%s)", e,
+        )
         return {
             "program": program_text[:200],
             "queries": queries,
             "criterion": criterion,
-            "results": {q: "undecided" for q in queries} if queries else {},
+            "results": None,
+            "solver": "unavailable",
             "fallback": "python",
+            "message": "DeLP analysis unavailable: no solver could be loaded.",
         }
 
 

--- a/docs/reports/subsystem_verdict.md
+++ b/docs/reports/subsystem_verdict.md
@@ -72,10 +72,10 @@ Verdict calibration:
 | Aspect | Finding |
 |--------|---------|
 | **Files** | `agents/core/logic/modal_handler.py`, `invoke_callables.py:5354-5438` |
-| **Produces** | Formula validation + query acceptance + KB consistency via Tweety SimpleMlReasoner. Heuristic fallback returns `valid: True` for ALL formulas. |
-| **Value-gate tests** | **YES** — `TestModalLogicValueGate` (2 tests, **both `@pytest.mark.xfail`** because heuristic fallback is vacuous, issue #941). |
-| **Blind spots** | (1) Heuristic fallback returns `valid: True` unconditionally — acknowledged as vacuous. (2) `is_modal_kb_consistent()` catches "no method found" JPype errors and returns `True` (assumes consistent) — silent correctness bug. (3) No pure-Python fallback for modal reasoning. |
-| **Verdict** | **UNTRUSTED** — JVM path works, but heuristic fallback is vacuous. xfail value-gate tests document the gap. KB consistency has silent false-negative bug. |
+| **Produces** | Formula validation + query acceptance + KB consistency via Tweety SimpleMlReasoner. Heuristic fallback reports `valid: None, solver: "unavailable"` — honest unavailability. |
+| **Value-gate tests** | **YES** — `TestModalLogicValueGate` (2 tests, **PASS** after #963). Asserts `valid is None` and `solver == "unavailable"`. |
+| **Blind spots** | (1) No pure-Python fallback for modal reasoning — only JVM path works. (2) `is_modal_kb_consistent()` returns `None` on "no method found" (honest, not vacuous True). |
+| **Verdict** | **PARTIAL** — JVM path works. Heuristic fallback is now honest unavailable (#963). KB consistency is honest unverified. |
 
 ### 6. Quality Evaluation (9 Virtues)
 
@@ -93,9 +93,9 @@ Verdict calibration:
 |--------|---------|
 | **Files** | `agents/core/counter_argument/counter_agent.py`, `strategies.py`, `evaluator.py`, `parser.py` |
 | **Produces** | `CounterArgument` dataclass with 5-criteria evaluation (relevance, logical_strength, persuasiveness, originality, clarity). 5 rhetorical strategies (reductio ad absurdum, counter-example, distinction, reformulation, concession). |
-| **Value-gate tests** | **NONE** in `test_value_gates.py`. |
-| **Blind spots** | (1) Strategy templates are hardcoded — `_generate_statistical_counter()` returns fabricated "15% of studied cases..." statistic. (2) LLM failure silently falls back to template. (3) `ArgumentParser` splits by `[.!?]+` regex — cannot handle abbreviations, decimal numbers. (4) `VulnerabilityAnalyzer._check_coherence()` checks keyword overlap only — trivially satisfied. |
-| **Verdict** | **PARTIAL** — Structure is complete (5 strategies + 5-criteria evaluator). But template fallback produces fabricated statistics. LLM path works when available. |
+| **Value-gate tests** | **YES** — `TestCounterArgValueGate` (3 tests, PASS). Asserts no fabricated "15%", template tag present, other 4 strategies unchanged. |
+| **Blind spots** | (1) LLM failure silently falls back to template. (2) `ArgumentParser` splits by `[.!?]+` regex — cannot handle abbreviations, decimal numbers. (3) `VulnerabilityAnalyzer._check_coherence()` checks keyword overlap only — trivially satisfied. |
+| **Verdict** | **PARTIAL** — Structure is complete (5 strategies + 5-criteria evaluator). Statistical template now marked as `[template/placeholder]` (#962). LLM path works when available. |
 
 ### 8. Debate Agent
 
@@ -154,14 +154,14 @@ Verdict calibration:
 | # | Brick | Handler | Real Logic | Tests | Fallback Quality | Verdict |
 |---|-------|---------|-----------|-------|-----------------|---------|
 | 1 | **SAT** | `sat_handler.py` | PySAT + Z3-MARCO | Dedicated (514 lines) | NONE (raises `RuntimeError` without PySAT) | **PARTIAL** |
-| 2 | **SetAF** | `setaf_handler.py` | Tweety JVM, 10 semantics | None | Degenerate: `args[:2]` | **UNTRUSTED** |
-| 3 | **Weighted** | `weighted_handler.py` | Tweety JVM, 6 semantics | None | Degenerate: `1.0/(i+1)` scoring | **UNTRUSTED** |
+| 2 | **SetAF** | `setaf_handler.py` | Tweety JVM, 10 semantics | Value-gate (#964) | Honest unavailable (#964) | **PARTIAL** |
+| 3 | **Weighted** | `weighted_handler.py` | Tweety JVM, 6 semantics | Value-gate (#964) | Honest unavailable (#964) | **PARTIAL** |
 | 4 | **EAF** | `eaf_handler.py` | Tweety JVM, 5 semantics | Integration only | Reasonable: subgraph enumeration with probability | **PARTIAL** |
-| 5 | **DeLP** | `delp_handler.py` | Tweety JVM, dialectical trees | None | Degenerate: all "undecided" | **UNTRUSTED** |
+| 5 | **DeLP** | `delp_handler.py` | Tweety JVM, dialectical trees | Value-gate (#964) | Honest unavailable (#964) | **PARTIAL** |
 | 6 | **QBF** | `qbf_handler.py` + `qbf_native.py` | JVM + native Python | Dedicated native + integration | Good: native fallback chain | **TRUSTWORTHY** |
 | 7 | **ABA** | `aba_handler.py` | Tweety JVM, 6 semantics | Mock (Track A) | Degenerate: empty extensions | **PARTIAL** |
 | 8 | **ADF** | `adf_handler.py` | Tweety JVM, 7 semantics | Mock (Track A) | Degenerate: empty interpretations | **PARTIAL** |
-| 9 | **Bipolar** | `bipolar_handler.py` | JVM metadata only (no reasoning) | Mock (Track A) | Degenerate: empty extensions | **UNTRUSTED** |
+| 9 | **Bipolar** | `bipolar_handler.py` | JVM metadata only (no reasoning) | Value-gate (#964) | Honest unavailable (#964) | **PARTIAL** |
 | 10 | **Probabilistic** | `probabilistic_handler.py` | Tweety JVM, subgraph enumeration | Mock (Track A) | Degenerate: all `0.5` | **PARTIAL** |
 | 11 | **Dialogue** | `dialogue_handler.py` | JVM grounded extension + simulated trace | Mock (Track A) + integration | Reasonable: simulated rounds | **PARTIAL** |
 | 12 | **Belief Revision** | `belief_revision_handler.py` | Tweety JVM, AGM (Dalal + Levi) | Extensive (Track A + spectacular + conversational + ATMS) | Degenerate: simple union (no contraction) | **PARTIAL** |
@@ -178,9 +178,9 @@ Verdict calibration:
 | Dung/ASPIC | PARTIAL | ❌ | Python fallback = grounded only (10/11 semantics missing) |
 | FOL | PARTIAL | ❌ | Solver-dependent non-determinism |
 | PL | PARTIAL | ❌ | Heavy LLM dependency, JVM-only |
-| Modal Logic | **UNTRUSTED** | ⚠️ (xfail) | Heuristic fallback vacuous, KB consistency false-negative |
+| Modal Logic | PARTIAL | ✅ (2/2 PASS) | Honest unavailable (#963), no pure-Python fallback |
 | Quality (9 virtues) | **TRUSTWORTHY** | ✅ (3/3 PASS) | Keyword limitation acceptable |
-| Counter-Argument | PARTIAL | ❌ | Fabricated statistics in template fallback |
+| Counter-Argument | PARTIAL | ✅ (3/3 PASS) | Fabricated statistics removed (#962), template placeholder tagged |
 | Debate | PARTIAL | ✅ (2/2 PASS) | English-only scoring, dead protocol code |
 | Governance | PARTIAL | ❌ | Hardcoded conflict resolution, Kemeny O(n!) |
 | JTMS | PARTIAL | ❌ | networkx silent dependency, exponential ATMS |
@@ -192,14 +192,14 @@ Verdict calibration:
 | Brick | Verdict | Key Risk |
 |-------|---------|----------|
 | SAT | PARTIAL | RuntimeError without PySAT |
-| SetAF | **UNTRUSTED** | No test, degenerate fallback |
-| Weighted | **UNTRUSTED** | No test, degenerate fallback |
+| SetAF | PARTIAL | Honest unavailable (#964), JVM-dependent |
+| Weighted | PARTIAL | Honest unavailable (#964), JVM-dependent |
 | EAF | PARTIAL | Reasonable fallback, no unit test |
-| DeLP | **UNTRUSTED** | No test, all-undecided fallback |
+| DeLP | PARTIAL | Honest unavailable (#964), JVM-dependent |
 | QBF | **TRUSTWORTHY** | Native fallback chain works |
 | ABA | PARTIAL | Mock tests only, empty fallback |
 | ADF | PARTIAL | Mock tests only, empty fallback |
-| Bipolar | **UNTRUSTED** | JVM returns metadata only, no reasoning |
+| Bipolar | PARTIAL | Honest unavailable (#964), JVM-dependent |
 | Probabilistic | PARTIAL | All-0.5 fallback |
 | Dialogue | PARTIAL | Simulated trace, reasonable fallback |
 | Belief Revision | PARTIAL | Degenerate union fallback, extensive tests |
@@ -209,8 +209,8 @@ Verdict calibration:
 | Verdict | Core | Satellite | Total |
 |---------|------|-----------|-------|
 | **TRUSTWORTHY** | 2 (Quality, Narrative) | 1 (QBF) | **3** |
-| **PARTIAL** | 8 | 8 | **16** |
-| **UNTRUSTED** | 1 (Modal) | 3 (SetAF, Weighted, DeLP, Bipolar) | **4** |
+| **PARTIAL** | 10 | 12 | **22** |
+| **UNTRUSTED** | 0 | 0 | **0** |
 
 ---
 
@@ -218,9 +218,9 @@ Verdict calibration:
 
 ### Must-fix before spectacular reports
 
-1. **Modal heuristic** — The vacuous `valid: True` fallback must be flagged in any Phase 4 output. If JVM unavailable, report "Modal analysis unavailable" rather than vacuous confirmation.
-2. **Satellite UNTRUSTED bricks** (SetAF, Weighted, DeLP, Bipolar) — Either flag in output as "JVM-dependent, no fallback" or remove from pipeline when JVM unavailable.
-3. **Counter-argument fabricated statistics** — `_generate_statistical_counter()` invents "15%" — this must be clearly marked as template/placeholder output.
+1. ~~**Modal heuristic**~~ — ✅ Fixed (#963). Reports honest `valid: None, solver: "unavailable"`.
+2. ~~**Satellite UNTRUSTED bricks**~~ — ✅ Fixed (#964). All 4 report honest unavailable status with value-gate tests.
+3. ~~**Counter-argument fabricated statistics**~~ — ✅ Fixed (#962). Statistical template tagged `[template/placeholder]`, no invented percentages.
 
 ### Should-fix for credibility
 
@@ -241,3 +241,4 @@ Verdict calibration:
 | Date | Author | Change |
 |------|--------|--------|
 | 2026-06-05 | myia-po-2023 | Initial verdict — all 24 subsystems audited |
+| 2026-06-06 | myia-po-2023 | Update: Modal UNTRUSTED→PARTIAL (#963), Counter-arg fix (#962), Satellites UNTRUSTED→PARTIAL (#964). 0 UNTRUSTED remaining. |

--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -537,3 +537,195 @@ class TestCounterArgValueGate:
             assert isinstance(result, str) and len(result) > 0, (
                 f"Strategy {strat.name} returned empty output after #960 fix"
             )
+
+
+# =====================================================================
+# 7. Satellite handlers — honest unavailable, not fabricated data (#964)
+# =====================================================================
+
+
+class TestSetAFValueGate:
+    """Assert SetAF fallback does not return fabricated args[:2] extensions.
+
+    The fallback used to return ``[args[:2]]`` as a fake extension — it could
+    not compute real set-argumentation semantics. After #964, it reports
+    honest unavailability (extensions=None, solver='unavailable').
+    """
+
+    async def test_setaf_fallback_reports_unavailable(self):
+        """SetAF fallback must report unavailability, not fabricated extensions."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_setaf,
+        )
+
+        # Force the fallback by patching asyncio.to_thread in the invoke module
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("No JVM for test"),
+        ):
+            result = await _invoke_setaf("test", {"arguments": ["a", "b", "c"]})
+
+        assert result.get("extensions") is None, (
+            f"SetAF fallback returned extensions={result.get('extensions')} "
+            "instead of None. Must report unavailability (#964)."
+        )
+        assert result.get("solver") == "unavailable", (
+            f"SetAF fallback solver={result.get('solver')}, expected 'unavailable' (#964)."
+        )
+
+    async def test_setaf_fallback_no_args_slice(self):
+        """The fallback must not contain the old args[:2] fabrication."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_setaf,
+        )
+
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("No JVM for test"),
+        ):
+            result = await _invoke_setaf("test", {"arguments": ["a", "b", "c"]})
+
+        ext = result.get("extensions")
+        assert ext is None or ext != [["a", "b"]], (
+            "SetAF fallback still returns fabricated args[:2] extension (#964)."
+        )
+
+
+class TestWeightedValueGate:
+    """Assert Weighted AF fallback does not fabricate positional scores.
+
+    The fallback used to assign ``1.0/(i+1)`` scores to arguments in
+    definition order — pure fabrication. After #964, it reports honest
+    unavailability (scores=None, extensions=None, solver='unavailable').
+    """
+
+    async def test_weighted_fallback_reports_unavailable(self):
+        """Weighted fallback must report unavailability, not fabricated scores."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_weighted,
+        )
+
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("No JVM for test"),
+        ):
+            result = await _invoke_weighted("test", {"arguments": ["a", "b", "c"]})
+
+        assert result.get("scores") is None, (
+            f"Weighted fallback returned scores={result.get('scores')} "
+            "instead of None. Must report unavailability (#964)."
+        )
+        assert result.get("extensions") is None, (
+            f"Weighted fallback returned extensions={result.get('extensions')} "
+            "instead of None (#964)."
+        )
+
+    async def test_weighted_fallback_no_positional_scoring(self):
+        """The fallback must not contain the old 1.0/(i+1) fabrication."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_weighted,
+        )
+
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("No JVM for test"),
+        ):
+            result = await _invoke_weighted("test", {"arguments": ["x", "y"]})
+
+        scores = result.get("scores")
+        assert scores is None or scores != {"x": 1.0, "y": 0.5}, (
+            "Weighted fallback still returns fabricated positional scores (#964)."
+        )
+
+
+class TestDeLPValueGate:
+    """Assert DeLP fallback does not return blanket all-undecided.
+
+    The fallback used to return ``{q: "undecided" for q in queries}`` — a
+    fabricated result that pretends every query was dialectically analyzed.
+    After #964, it reports honest unavailability (results=None,
+    solver='unavailable').
+    """
+
+    async def test_delp_fallback_reports_unavailable(self):
+        """DeLP fallback must report unavailability, not all-undecided."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_delp,
+        )
+
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("No JVM for test"),
+        ):
+            result = await _invoke_delp("test prog", {"queries": ["p", "q"]})
+
+        assert result.get("results") is None, (
+            f"DeLP fallback returned results={result.get('results')} "
+            "instead of None. Must report unavailability (#964)."
+        )
+        assert result.get("solver") == "unavailable", (
+            f"DeLP fallback solver={result.get('solver')}, expected 'unavailable' (#964)."
+        )
+
+    async def test_delp_fallback_no_undecided_dict(self):
+        """The fallback must not contain the old all-undecided fabrication."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_delp,
+        )
+
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("No JVM for test"),
+        ):
+            result = await _invoke_delp("test", {"queries": ["p"]})
+
+        results = result.get("results")
+        assert results is None or results != {"p": "undecided"}, (
+            "DeLP fallback still returns fabricated all-undecided dict (#964)."
+        )
+
+
+class TestBipolarValueGate:
+    """Assert Bipolar fallback does not return fabricated args[:2] extensions.
+
+    The fallback used to return ``[args[:2]]`` as a fake extension — it could
+    not compute real bipolar argumentation semantics. After #964, it reports
+    honest unavailability (extensions=None, solver='unavailable').
+    """
+
+    async def test_bipolar_fallback_reports_unavailable(self):
+        """Bipolar fallback must report unavailability, not fabricated extensions."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_bipolar,
+        )
+
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("No JVM for test"),
+        ):
+            result = await _invoke_bipolar("test", {"arguments": ["a", "b", "c"]})
+
+        assert result.get("extensions") is None, (
+            f"Bipolar fallback returned extensions={result.get('extensions')} "
+            "instead of None. Must report unavailability (#964)."
+        )
+        assert result.get("solver") == "unavailable", (
+            f"Bipolar fallback solver={result.get('solver')}, expected 'unavailable' (#964)."
+        )
+
+    async def test_bipolar_fallback_no_args_slice(self):
+        """The fallback must not contain the old args[:2] fabrication."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_bipolar,
+        )
+
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("No JVM for test"),
+        ):
+            result = await _invoke_bipolar("test", {"arguments": ["a", "b", "c"]})
+
+        ext = result.get("extensions")
+        assert ext is None or ext != [["a", "b"]], (
+            "Bipolar fallback still returns fabricated args[:2] extension (#964)."
+        )


### PR DESCRIPTION
## Issue

Closes #964 (FB-11 — Satellite UNTRUSTED handlers: degenerate fallback → honest unavailable)

## Problem

Four satellite formal bricks returned **degenerate / fabricated** fallback data when the JVM/Tweety path was unavailable, with **no value-gate test**. Fabricated results would be exposed by the #953 external-analyst benchmark.

| Brick | Old degenerate fallback | New honest status |
|-------|------------------------|-------------------|
| SetAF |  fake extension |  |
| Weighted |  fake scoring +  |  |
| DeLP | All queries →  |  |
| Bipolar |  fake extension |  |

## Changes

### 
- 4 fallback  blocks rewritten: logger.info → logger.warning, degenerate data →  +  + 
- Anti-pendule: neither fabricated confirmation NOR fabricated rejection — honest unavailability, same pattern as modal #963

### 
- 4 new test classes: , , , 
- 8 tests total (2 per satellite): assert fallback reports  and , assert old degenerate patterns are gone
- Patches  in invoke_callables module to force fallback path

### 
- Flipped 4 satellite UNTRUSTED → PARTIAL (honest unavailable)
- Updated Modal UNTRUSTED → PARTIAL (#963 already landed)
- Updated Counter-arg value-gate status (#962 already landed)
- Aggregate: **0 UNTRUSTED remaining** (was 4)
- Marked all 3 must-fixes as DONE

## Test results

- **24/24 value-gate tests PASS** (8 new + 16 existing)
- **56/56 counter-arg strategy tests PASS** (unchanged)
- Local run time: 6.78s

## Files changed

| File | Change |
|------|--------|
|  | 4 fallback blocks: degenerate → honest unavailable |
|  | +8 value-gate tests (4 classes × 2 tests) |
|  | Verdict update: 0 UNTRUSTED, must-fixes DONE |

## Privacy

Opaque IDs only. No corpus content touched. Code fix only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>