### PR TITLE
fix(dung): DFS cycle detection shadowing + exponential size guard (#970)

### DIFF
--- a/argumentation_analysis/agents/core/logic/dung_native.py
+++ b/argumentation_analysis/agents/core/logic/dung_native.py
@@ -20,6 +20,11 @@ from typing import Dict, FrozenSet, List, Optional, Set, Tuple
 
 logger = logging.getLogger("DungNative")
 
+# Maximum argument count for exponential enumeration semantics.
+# Beyond this threshold, only grounded (polynomial) is computed;
+# other semantics report honest unavailability (#970).
+_MAX_ENUM_ARGS = 15
+
 
 class DungFramework:
     """Pure-Python implementation of Dung's argumentation framework.
@@ -104,7 +109,16 @@ class DungFramework:
         """Compute all admissible sets.
 
         A set S is admissible iff it is conflict-free and defends all its members.
+
+        Raises RuntimeError if the framework has more than _MAX_ENUM_ARGS arguments
+        (exponential enumeration would be too costly).
         """
+        if len(self.arguments) > _MAX_ENUM_ARGS:
+            raise RuntimeError(
+                f"Framework has {len(self.arguments)} arguments, exceeding "
+                f"enumeration limit ({_MAX_ENUM_ARGS}). Admissible sets "
+                f"computation is unavailable — use grounded_extension() instead. (#970)"
+            )
         result = [frozenset()]  # empty set is always admissible
         args_list = sorted(self.arguments)
 
@@ -144,7 +158,15 @@ class DungFramework:
 
         A set S is stable iff it is conflict-free and attacks every argument
         not in S.
+
+        Raises RuntimeError if the framework has more than _MAX_ENUM_ARGS arguments.
         """
+        if len(self.arguments) > _MAX_ENUM_ARGS:
+            raise RuntimeError(
+                f"Framework has {len(self.arguments)} arguments, exceeding "
+                f"enumeration limit ({_MAX_ENUM_ARGS}). Stable extensions "
+                f"computation is unavailable. (#970)"
+            )
         result = []
         args_list = sorted(self.arguments)
 
@@ -192,7 +214,7 @@ class DungFramework:
 
     def framework_properties(self) -> Dict:
         """Compute framework properties (pure Python, no JVM)."""
-        # Detect cycles using DFS
+        # Detect cycles using DFS — iterate adjacency, not all attacks (#970)
         has_cycle = False
         visited = set()
         rec_stack = set()
@@ -200,13 +222,13 @@ class DungFramework:
         def _dfs(node: str) -> bool:
             visited.add(node)
             rec_stack.add(node)
-            for _, tgt in self.attacks:
-                if _ == node:
-                    if tgt in rec_stack:
+            # Build adjacency: targets attacked by node (outgoing edges)
+            for tgt in self.attacked_by(node):
+                if tgt in rec_stack:
+                    return True
+                if tgt not in visited:
+                    if _dfs(tgt):
                         return True
-                    if tgt not in visited:
-                        if _dfs(tgt):
-                            return True
             rec_stack.discard(node)
             return False
 

--- a/docs/reports/subsystem_verdict.md
+++ b/docs/reports/subsystem_verdict.md
@@ -44,7 +44,7 @@ Verdict calibration:
 | **Files** | `agents/core/logic/dung_native.py`, `af_handler.py`, `aspic_handler.py`, `invoke_callables.py:5441-5645` |
 | **Produces** | Dung: up to 11 semantics (grounded/preferred/stable/complete/admissible/etc.) via Tweety JVM. Pure-Python fallback computes grounded extension via iterative fixpoint. ASPIC: structured argumentation with rule-based inference. |
 | **Value-gate tests** | **NONE** in `test_value_gates.py`. |
-| **Blind spots** | (1) Python fallback (`_python_dung_fallback`) only computes grounded — 10 other semantics unavailable without JVM. (2) `dung_native.py` framework_properties() DFS cycle detection has variable shadowing bug (`_` used in loop then unpack). (3) Exponential subset enumeration for preferred/stable — no size guard. (4) ASPIC requires JVM, no pure-Python fallback. |
+| **Blind spots** | (1) Python fallback (`_python_dung_fallback`) only computes grounded — 10 other semantics unavailable without JVM. (2) ~~`dung_native.py` framework_properties() DFS cycle detection has variable shadowing bug~~ — **FIXED (#970)**: rewritten to use `attacked_by()` adjacency. (3) ~~Exponential subset enumeration for preferred/stable — no size guard~~ — **FIXED (#970)**: `RuntimeError` raised above `_MAX_ENUM_ARGS=15`, grounded still works. (4) ASPIC requires JVM, no pure-Python fallback. |
 | **Verdict** | **PARTIAL** — Pure-Python grounded is real fixpoint. JVM path produces 11 semantics. Missing: value-gate tests, size guard, ASPIC fallback. |
 
 ### 3. FOL (First-Order Logic)
@@ -175,7 +175,7 @@ Verdict calibration:
 | Subsystem | Verdict | Value-Gate | Key Risk |
 |-----------|---------|-----------|----------|
 | Informal Fallacy | PARTIAL | ❌ | Taxonomy keyword-only, mock adapter fallback |
-| Dung/ASPIC | PARTIAL | ✅ (4/4 PASS) | Python fallback = grounded only (10/11 semantics missing) |
+| Dung/ASPIC | PARTIAL | ✅ (9/9 PASS) | ~~DFS shadowing + no size guard~~ FIXED (#970), Python fallback = grounded only |
 | FOL | PARTIAL | ❌ | Solver-dependent non-determinism |
 | PL | PARTIAL | ❌ | Heavy LLM dependency, JVM-only |
 | Modal Logic | PARTIAL | ✅ (2/2 PASS) | Honest unavailable (#963), no pure-Python fallback |
@@ -244,3 +244,4 @@ Verdict calibration:
 | 2026-06-06 | myia-po-2023 | Update: Modal UNTRUSTED→PARTIAL (#963), Counter-arg fix (#962), Satellites UNTRUSTED→PARTIAL (#964). 0 UNTRUSTED remaining. |
 | 2026-06-06 | myia-po-2023 | Value-gate coverage raised: Dung ✅, Governance ✅, JTMS ✅ (#965). Coverage: 9/12 core with value-gate tests. |
 | 2026-06-06 | myia-po-2023 | Debate scoring i18n: EN+FR connectors bilingue (#967). Value-gate: 5/5 PASS. |
+| 2026-06-06 | myia-po-2023 | Dung DFS shadowing fixed + exponential guard (#970). Value-gate: 9/9 PASS. |

--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -1068,3 +1068,99 @@ class TestJTMSValueGate:
         assert jtms.beliefs["C"].valid is True, (
             "A→B→C: C should be True after chain propagation from A"
         )
+
+
+# ============================================================
+# #970 (FB-14) — Dung DFS shadowing + exponential guard
+# ============================================================
+
+
+class TestDungDFSCycleDetection:
+    """Value-gate: framework_properties() must correctly detect cycles.
+
+    The old DFS iterated ALL attacks and used `_` as loop variable then
+    compared `_ == node` — this was shadowing the convention and also
+    iterating the entire attack set per node. After #970, it uses
+    attacked_by() for proper adjacency.
+    """
+
+    def test_triangle_cycle_detected(self):
+        """3-cycle (a→b→c→a) must report has_cycles=True."""
+        from argumentation_analysis.agents.core.logic.dung_native import DungFramework
+
+        fw = DungFramework.triangle()
+        props = fw.framework_properties()
+        assert props["has_cycles"] is True, (
+            f"Triangle framework should have cycles, got {props['has_cycles']} (#970)."
+        )
+
+    def test_acyclic_no_false_cycle(self):
+        """Reinstatement (a→b→c, no back-edge) must report has_cycles=False."""
+        from argumentation_analysis.agents.core.logic.dung_native import DungFramework
+
+        fw = DungFramework.reinstatement()
+        props = fw.framework_properties()
+        assert props["has_cycles"] is False, (
+            f"Reinstatement framework should NOT have cycles, got {props['has_cycles']} (#970)."
+        )
+
+
+class TestDungExponentialGuard:
+    """Value-gate: exponential enumeration must raise above threshold.
+
+    Beyond _MAX_ENUM_ARGS, admissible/stable must raise RuntimeError
+    with an honest message — not silently blow up or return fake data.
+    """
+
+    def test_admissible_raises_above_threshold(self):
+        """Admissible sets must raise RuntimeError for large frameworks."""
+        from argumentation_analysis.agents.core.logic.dung_native import (
+            DungFramework,
+            _MAX_ENUM_ARGS,
+        )
+
+        fw = DungFramework()
+        for i in range(_MAX_ENUM_ARGS + 5):
+            fw.add_argument(f"arg_{i}")
+            if i > 0:
+                fw.add_attack(f"arg_{i-1}", f"arg_{i}")
+
+        with pytest.raises(RuntimeError, match="enumeration limit"):
+            fw.admissible_sets()
+
+    def test_stable_raises_above_threshold(self):
+        """Stable extensions must raise RuntimeError for large frameworks."""
+        from argumentation_analysis.agents.core.logic.dung_native import (
+            DungFramework,
+            _MAX_ENUM_ARGS,
+        )
+
+        fw = DungFramework()
+        for i in range(_MAX_ENUM_ARGS + 5):
+            fw.add_argument(f"arg_{i}")
+
+        with pytest.raises(RuntimeError, match="enumeration limit"):
+            fw.stable_extensions()
+
+    def test_grounded_works_above_threshold(self):
+        """Grounded (polynomial) must still work above the exponential limit."""
+        from argumentation_analysis.agents.core.logic.dung_native import (
+            DungFramework,
+            _MAX_ENUM_ARGS,
+        )
+
+        fw = DungFramework()
+        for i in range(_MAX_ENUM_ARGS + 5):
+            fw.add_argument(f"arg_{i}")
+            if i > 0:
+                fw.add_attack(f"arg_{i-1}", f"arg_{i}")
+
+        # Grounded is polynomial — must NOT raise
+        ext = fw.grounded_extension()
+        assert isinstance(ext, frozenset), (
+            f"Grounded extension should be frozenset, got {type(ext)} (#970)."
+        )
+        # In a chain a0→a1→a2→...→aN, grounded = {a0}
+        assert "arg_0" in ext, (
+            f"arg_0 should be in grounded extension of chain, got {ext} (#970)."
+        )


### PR DESCRIPTION
## Summary

FB-14 (#970): Fix 2 real bugs in Dung pure-Python implementation.

### Bug 1 — DFS cycle detection (framework_properties)

**Before**: Iterated ALL attacks with `for _, tgt in self.attacks` then compared `_ == node` — variable shadowing + O(|attacks|) per node instead of adjacency lookup.

**After**: Uses `self.attacked_by(node)` for proper O(out-degree) adjacency.

### Bug 2 — Exponential enumeration guard

**Before**: `admissible_sets()` and `stable_extensions()` enumerate all subsets (O(2^n)) with no size limit — could hang on large frameworks.

**After**: `_MAX_ENUM_ARGS=15` threshold. Above limit, raises `RuntimeError` with honest "unavailable" message. Grounded extension (polynomial fixpoint) still works above limit.

### Value-gate tests (5 new, all PASS)

| Test | Asserts |
|------|---------|
| test_triangle_cycle_detected | 3-cycle reports has_cycles=True |
| test_acyclic_no_false_cycle | Chain reports has_cycles=False |
| test_admissible_raises_above_threshold | RuntimeError above limit |
| test_stable_raises_above_threshold | RuntimeError above limit |
| test_grounded_works_above_threshold | Grounded still works above limit |

### Anti-pendule compliance

- Guard raises HONEST RuntimeError — does not silently return empty/fake extensions
- Does not remove any semantics — just guards the exponential ones
- Grounded (polynomial) still works at any size

### Files changed

| File | Change |
|------|--------|
| argumentation_analysis/agents/core/logic/dung_native.py | DFS rewrite + _MAX_ENUM_ARGS guard + admissible/stable guards |
| tests/unit/argumentation_analysis/test_value_gates.py | +5 value-gate tests |
| docs/reports/subsystem_verdict.md | Dung blind spots marked FIXED |

Closes #970