### PR TITLE
fix(governance): honest conflict probs + Kemeny Copeland fallback (#971)

### DIFF
--- a/argumentation_analysis/agents/core/governance/conflict_resolution.py
+++ b/argumentation_analysis/agents/core/governance/conflict_resolution.py
@@ -37,7 +37,7 @@ def resolve_conflict(conflict, strategy="collaborative"):
 def collaborative_mediation(conflict):
     return {
         "resolution_type": "collaborative",
-        "success_probability": 0.8,
+        "success_probability": None,  # Not measured — placeholder (#971)
         "agents": conflict["agents"],
         "details": "Agents seek common ground.",
     }
@@ -46,7 +46,7 @@ def collaborative_mediation(conflict):
 def competitive_mediation(conflict):
     return {
         "resolution_type": "competitive",
-        "success_probability": 0.5,
+        "success_probability": None,  # Not measured — placeholder (#971)
         "agents": conflict["agents"],
         "details": "Agents compete for their preferred outcome.",
     }
@@ -55,7 +55,7 @@ def competitive_mediation(conflict):
 def compromise_mediation(conflict):
     return {
         "resolution_type": "compromise",
-        "success_probability": 0.7,
+        "success_probability": None,  # Not measured — placeholder (#971)
         "agents": conflict["agents"],
         "details": "Agents agree to a middle ground.",
     }

--- a/argumentation_analysis/agents/core/governance/social_choice.py
+++ b/argumentation_analysis/agents/core/governance/social_choice.py
@@ -141,24 +141,33 @@ def copeland(
     return winner, scores
 
 
+# Maximum candidate count for exact Kemeny-Young (O(n!) enumeration).
+# Beyond this threshold, the safe wrapper falls back to Copeland (#971).
+_MAX_KEMENY_CANDIDATES = 8
+
+
 def kemeny_young(
     ballots: List[List[str]],
     options: List[str],
 ) -> Tuple[List[str], int]:
     """Kemeny-Young method: find the ranking minimizing total disagreement.
 
-    Warning: O(n!) complexity — only practical for ≤8 candidates.
+    Warning: O(n!) complexity — only practical for ≤_MAX_KEMENY_CANDIDATES candidates.
+    Raises ValueError above that threshold.  Use kemeny_young_safe() for automatic
+    Copeland fallback (#971).
 
     Args:
         ballots: List of ranked preference lists.
         options: All candidate options.
 
     Returns:
-        (optimal_ranking, min_distance)
+        (optimal_ranking, kemeny_score)
     """
-    if len(options) > 8:
+    if len(options) > _MAX_KEMENY_CANDIDATES:
         raise ValueError(
-            f"Kemeny-Young is impractical for {len(options)} candidates (max 8)"
+            f"Kemeny-Young is impractical for {len(options)} candidates "
+            f"(max {_MAX_KEMENY_CANDIDATES}). "
+            f"Use kemeny_young_safe() for Copeland fallback. (#971)"
         )
 
     # Build pairwise preference matrix
@@ -190,6 +199,35 @@ def kemeny_young(
             best_ranking = list(perm)
 
     return best_ranking, best_score
+
+
+def kemeny_young_safe(
+    ballots: List[List[str]],
+    options: List[str],
+) -> Tuple[List[str], int, bool]:
+    """Kemeny-Young with Copeland fallback for large candidate sets (#971).
+
+    When the number of candidates is within the enumeration limit, delegates
+    to kemeny_young() for the exact result.  When it exceeds the limit,
+    falls back to a Copeland-score-based ranking (O(n²) instead of O(n!)).
+
+    Args:
+        ballots: List of ranked preference lists.
+        options: All candidate options.
+
+    Returns:
+        (ranking, score, approximate) where approximate=True means the
+        ranking is a Copeland approximation, not an exact Kemeny-Young result.
+    """
+    if len(options) <= _MAX_KEMENY_CANDIDATES:
+        ranking, score = kemeny_young(ballots, options)
+        return ranking, score, False
+    # Copeland fallback — O(n²) polynomial approximation
+    _, copeland_scores = copeland(ballots, options)
+    ranking = sorted(
+        options, key=lambda o: copeland_scores.get(o, 0), reverse=True
+    )
+    return ranking, -1, True
 
 
 def schulze(

--- a/argumentation_analysis/plugins/governance_plugin.py
+++ b/argumentation_analysis/plugins/governance_plugin.py
@@ -142,12 +142,22 @@ class GovernancePlugin:
             return json.dumps({"winner": winner, "strongest_paths": paths})
         elif method_name == "kemeny_young":
             from argumentation_analysis.agents.core.governance.social_choice import (
-                kemeny_young,
+                kemeny_young_safe,
             )
 
-            ranking, score = kemeny_young(ballots, options)
-            return json.dumps({"winner": ranking[0] if ranking else None,
-                               "ranking": ranking, "kemeny_score": score})
+            ranking, score, approximate = kemeny_young_safe(ballots, options)
+            result = {
+                "winner": ranking[0] if ranking else None,
+                "ranking": ranking,
+                "kemeny_score": score,
+                "approximate": approximate,
+            }
+            if approximate:
+                result["fallback"] = (
+                    "Copeland approximation — Kemeny-Young unavailable "
+                    f"for {len(options)} candidates (#971)"
+                )
+            return json.dumps(result)
         else:
             return json.dumps({"error": f"Unknown method: {method_name}"})
 

--- a/docs/reports/subsystem_verdict.md
+++ b/docs/reports/subsystem_verdict.md
@@ -113,9 +113,9 @@ Verdict calibration:
 |--------|---------|
 | **Files** | `agents/core/governance/governance_methods.py`, `simulation.py`, `social_choice.py`, `conflict_resolution.py`, `metrics.py` |
 | **Produces** | 7 voting methods (majority, plurality, Borda, Condorcet, quadratic, byzantine, raft). `simulate_governance()` returns winner, satisfaction, coalitions, conflict history. |
-| **Value-gate tests** | **NONE** in `test_value_gates.py`. |
-| **Blind spots** | (1) `conflict_resolution.py` returns hardcoded success probabilities (0.8/0.5/0.7) — no actual mediation logic. (2) Kemeny-Young is O(n!), raises `ValueError` for >8 candidates, no fallback. (3) `byzantine_consensus` uses `np.random.choice` for faulty agents — not reproducible. (4) Requires agents with `.decide()` + `.preferences` interface — silently fails otherwise. |
-| **Verdict** | **PARTIAL** — Voting methods are real implementations. Conflict resolution is hardcoded. Kemeny-Young has size limit without fallback. |
+| **Value-gate tests** | **YES** — `TestGovernanceValueGate` (3 tests, PASS) + `TestConflictResolutionHonestProb` (3 tests, PASS) + `TestKemenyYoungSafeFallback` (3 tests, PASS). |
+| **Blind spots** | (1) ~~`conflict_resolution.py` returns hardcoded success probabilities (0.8/0.5/0.7)~~ — **FIXED (#971)**: returns `None` (honest placeholder). (2) ~~Kemeny-Young is O(n!), raises `ValueError` for >8 candidates, no fallback~~ — **FIXED (#971)**: `kemeny_young_safe()` falls back to Copeland (O(n²)) with `approximate=True` flag. (3) `byzantine_consensus` uses `np.random.choice` for faulty agents — not reproducible. (4) Requires agents with `.decide()` + `.preferences` interface — silently fails otherwise. |
+| **Verdict** | **PARTIAL** — Voting methods are real implementations. ~~Conflict resolution is hardcoded.~~ Fabricated probabilities fixed (#971). Kemeny-Young has Copeland fallback (#971). Byzantine randomness remains. |
 
 ### 10. JTMS (Justification-based Truth Maintenance)
 
@@ -182,7 +182,7 @@ Verdict calibration:
 | Quality (9 virtues) | **TRUSTWORTHY** | ✅ (3/3 PASS) | Keyword limitation acceptable |
 | Counter-Argument | PARTIAL | ✅ (3/3 PASS) | Fabricated statistics removed (#962), template placeholder tagged |
 | Debate | PARTIAL | ✅ (5/5 PASS) | ~~English-only scoring~~ fixed (#967), dead protocol code |
-| Governance | PARTIAL | ✅ (3/3 PASS) | Hardcoded conflict resolution, Kemeny O(n!) |
+| Governance | PARTIAL | ✅ (9/9 PASS) | ~~Hardcoded conflict resolution~~ fixed (#971), ~~Kemeny O(n!)~~ Copeland fallback (#971) |
 | JTMS | PARTIAL | ✅ (3/3 PASS) | networkx silent dependency, exponential ATMS |
 | Narrative Synthesis | **TRUSTWORTHY** | ✅ (3/3 PASS) | Template-only by design |
 | Fact Extraction | PARTIAL | ✅ (3/3 PASS) | LLM marker hallucination |
@@ -245,3 +245,4 @@ Verdict calibration:
 | 2026-06-06 | myia-po-2023 | Value-gate coverage raised: Dung ✅, Governance ✅, JTMS ✅ (#965). Coverage: 9/12 core with value-gate tests. |
 | 2026-06-06 | myia-po-2023 | Debate scoring i18n: EN+FR connectors bilingue (#967). Value-gate: 5/5 PASS. |
 | 2026-06-06 | myia-po-2023 | Dung DFS shadowing fixed + exponential guard (#970). Value-gate: 9/9 PASS. |
+| 2026-06-06 | myia-po-2023 | Governance fabricated probs → None (#971), Kemeny-Young Copeland fallback (#971). Value-gate: 9/9 PASS. |

--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -1164,3 +1164,120 @@ class TestDungExponentialGuard:
         assert "arg_0" in ext, (
             f"arg_0 should be in grounded extension of chain, got {ext} (#970)."
         )
+
+
+# ============================================================
+# #971 (FB-15) — Governance fabricated probs + Kemeny fallback
+# ============================================================
+
+
+class TestConflictResolutionHonestProb:
+    """Value-gate: conflict resolution must not return fabricated probabilities.
+
+    After #971, all three mediation strategies return success_probability=None
+    (honest placeholder) instead of fabricated floats (0.8/0.5/0.7).
+    """
+
+    def test_collaborative_no_fabricated_prob(self):
+        """Collaborative mediation must return None probability, not 0.8."""
+        from argumentation_analysis.agents.core.governance.conflict_resolution import (
+            collaborative_mediation,
+        )
+
+        conflict = {"agents": ["A", "B"], "conflict_level": 1.0}
+        result = collaborative_mediation(conflict)
+        assert result["success_probability"] is None, (
+            f"Collaborative success_probability should be None (not measured), "
+            f"got {result['success_probability']} (#971)."
+        )
+        assert result["resolution_type"] == "collaborative"
+
+    def test_competitive_no_fabricated_prob(self):
+        """Competitive mediation must return None probability, not 0.5."""
+        from argumentation_analysis.agents.core.governance.conflict_resolution import (
+            competitive_mediation,
+        )
+
+        conflict = {"agents": ["A", "B"], "conflict_level": 1.0}
+        result = competitive_mediation(conflict)
+        assert result["success_probability"] is None, (
+            f"Competitive success_probability should be None (not measured), "
+            f"got {result['success_probability']} (#971)."
+        )
+
+    def test_compromise_no_fabricated_prob(self):
+        """Compromise mediation must return None probability, not 0.7."""
+        from argumentation_analysis.agents.core.governance.conflict_resolution import (
+            compromise_mediation,
+        )
+
+        conflict = {"agents": ["A", "B"], "conflict_level": 1.0}
+        result = compromise_mediation(conflict)
+        assert result["success_probability"] is None, (
+            f"Compromise success_probability should be None (not measured), "
+            f"got {result['success_probability']} (#971)."
+        )
+
+
+class TestKemenyYoungSafeFallback:
+    """Value-gate: kemeny_young_safe falls back to Copeland for large sets.
+
+    For ≤8 candidates, exact Kemeny-Young is used (approximate=False).
+    For >8 candidates, Copeland approximation is returned (approximate=True).
+    """
+
+    def test_exact_for_small_sets(self):
+        """3 candidates → exact Kemeny-Young, approximate=False."""
+        from argumentation_analysis.agents.core.governance.social_choice import (
+            kemeny_young_safe,
+        )
+
+        ballots = [
+            ["A", "B", "C"],
+            ["A", "C", "B"],
+            ["B", "A", "C"],
+        ]
+        ranking, score, approximate = kemeny_young_safe(ballots, ["A", "B", "C"])
+        assert approximate is False, (
+            f"3 candidates should use exact Kemeny, got approximate={approximate} (#971)."
+        )
+        assert ranking[0] == "A", (
+            f"A should win with 2 first-preference ballots, got {ranking} (#971)."
+        )
+        assert score > 0
+
+    def test_fallback_for_large_sets(self):
+        """10 candidates → Copeland fallback, approximate=True."""
+        from argumentation_analysis.agents.core.governance.social_choice import (
+            kemeny_young_safe,
+            _MAX_KEMENY_CANDIDATES,
+        )
+
+        options = [f"C{i}" for i in range(_MAX_KEMENY_CANDIDATES + 2)]
+        # Everyone agrees: C0 > C1 > C2 > ... > C9
+        ballots = [options] * 5
+
+        ranking, score, approximate = kemeny_young_safe(ballots, options)
+        assert approximate is True, (
+            f"{len(options)} candidates should trigger Copeland fallback, "
+            f"got approximate={approximate} (#971)."
+        )
+        assert ranking[0] == "C0", (
+            f"C0 should win with unanimous preferences, got {ranking} (#971)."
+        )
+        assert score == -1, (
+            f"Fallback score should be -1 (sentinel), got {score} (#971)."
+        )
+
+    def test_exact_kemeny_raises_for_large_sets(self):
+        """Direct kemeny_young() must still raise ValueError for >8."""
+        from argumentation_analysis.agents.core.governance.social_choice import (
+            kemeny_young,
+            _MAX_KEMENY_CANDIDATES,
+        )
+
+        options = [f"C{i}" for i in range(_MAX_KEMENY_CANDIDATES + 2)]
+        ballots = [options] * 3
+
+        with pytest.raises(ValueError, match="impractical"):
+            kemeny_young(ballots, options)


### PR DESCRIPTION
## Summary

Fixes #971 — Governance fabricated success probabilities + Kemeny-Young fallback.

Epic #947 "Final Boss" — Phase 3, FB-15.

## Changes

### conflict_resolution.py
- Replaced fabricated `success_probability` (0.8/0.5/0.7) with honest `None` placeholder
- Anti-pendule: removed the fabricated numbers, did NOT add a fake formula

### social_choice.py
- Added `_MAX_KEMENY_CANDIDATES = 8` constant (explicit)
- Added `kemeny_young_safe()` wrapper with Copeland fallback for >8 candidates
- Fallback returns `(ranking, -1, approximate=True)` — honest sentinel, not fake Kemeny
- Original `kemeny_young()` keeps its `ValueError` for direct callers who want exact

### governance_plugin.py
- Switched from `kemeny_young()` to `kemeny_young_safe()`
- JSON output includes `approximate: true` + `fallback` message when Copeland used

### test_value_gates.py (+6 tests, all PASS)
- `TestConflictResolutionHonestProb`: 3/3 — assert all 3 strategies return `None` probability
- `TestKemenyYoungSafeFallback`: 3/3 — exact for small, Copeland for large, ValueError for raw

### subsystem_verdict.md
- Governance blind spot #1 (fabricated probs) → FIXED
- Governance blind spot #2 (Kemeny no fallback) → FIXED
- Value-gate coverage: 9/9 PASS

## Anti-pendule verification
- ✅ Removed fabricated numbers (`None`, not fake formula)
- ✅ Copeland is a documented approximation with honest flag, not silent downgrade
- ✅ Original `kemeny_young()` contract unchanged (still raises for >8)

## Test results
```
6 passed in 14.03s
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>