### PR TITLE
test(informal): taxonomy value-gate — fires on literal, empty on paraphrase (#973)

### DIFF
--- a/docs/reports/subsystem_verdict.md
+++ b/docs/reports/subsystem_verdict.md
@@ -33,9 +33,9 @@ Verdict calibration:
 |--------|---------|
 | **Files** | `agents/core/informal/informal_agent.py`, `taxonomy_sophism_detector.py`, `informal_agent_adapter.py` |
 | **Produces** | `List[Dict]` with `nom`, `justification`, `confidence`. Three tiers: (1) LLM semantic analysis via SK, (2) lexical taxonomy matching (keyword→fallacy name), (3) adapter mock fallback |
-| **Value-gate tests** | **NONE** in `test_value_gates.py`. Brick-health (#944) checks presence only. |
-| **Blind spots** | (1) Taxonomy detector uses naive substring matching — cannot detect a genuine *ad hominem* unless "ad hominem" literally appears in text. (2) Adapter fallback (`informal_agent_adapter.py:111-126`) uses mock objects — returns test doubles, not analysis. (3) `analyze_rhetoric()` and `analyze_context()` are commented out (never implemented in BaseAgent version). |
-| **Verdict** | **PARTIAL** — Tier 1 (LLM) works when SK kernel available; Tier 2 (taxonomy) is keyword-only; Tier 3 (adapter) is mock. No value-gate test. |
+| **Value-gate tests** | **YES** — `TestInformalTaxonomyValueGate` (3 tests, PASS). Asserts detector fires on literal `nom_vulgarisé`, returns empty on paraphrase, and confidence ≥0.7 on match. |
+| **Blind spots** | (1) Taxonomy detector uses naive substring matching — fires only when `nom_vulgarisé` or `Name` literally appears in text. Entries with `nan` nom_vulgarisé (e.g. "Ad hominem" PK=1360) only get 0.1 per description keyword — below the 0.3 threshold. Value-gate test **pins this**: fires on "trouver des excuses" (has nom_vulgarisé), empty on paraphrase. (2) Adapter fallback (`informal_agent_adapter.py:111-126`) uses mock objects — returns test doubles, not analysis. (3) `analyze_rhetoric()` and `analyze_context()` are commented out (never implemented in BaseAgent version). |
+| **Verdict** | **PARTIAL** — Tier 1 (LLM) works when SK kernel available; Tier 2 (taxonomy) is substring-literal, now honestly characterised by value-gate tests (#973); Tier 3 (adapter) is mock. Coverage: 10/12 core subsystems. |
 
 ### 2. Dung/ASPIC Abstract Argumentation
 
@@ -174,7 +174,7 @@ Verdict calibration:
 
 | Subsystem | Verdict | Value-Gate | Key Risk |
 |-----------|---------|-----------|----------|
-| Informal Fallacy | PARTIAL | ❌ | Taxonomy keyword-only, mock adapter fallback |
+| Informal Fallacy | PARTIAL | ✅ (3/3 PASS) | Taxonomy substring-literal honestly characterised (#973), mock adapter fallback |
 | Dung/ASPIC | PARTIAL | ✅ (9/9 PASS) | ~~DFS shadowing + no size guard~~ FIXED (#970), Python fallback = grounded only |
 | FOL | PARTIAL | ❌ | Solver-dependent non-determinism |
 | PL | PARTIAL | ❌ | Heavy LLM dependency, JVM-only |
@@ -246,3 +246,4 @@ Verdict calibration:
 | 2026-06-06 | myia-po-2023 | Debate scoring i18n: EN+FR connectors bilingue (#967). Value-gate: 5/5 PASS. |
 | 2026-06-06 | myia-po-2023 | Dung DFS shadowing fixed + exponential guard (#970). Value-gate: 9/9 PASS. |
 | 2026-06-06 | myia-po-2023 | Governance fabricated probs → None (#971), Kemeny-Young Copeland fallback (#971). Value-gate: 9/9 PASS. |
+| 2026-06-06 | myia-po-2023 | Informal taxonomy value-gate: 3/3 PASS (#973). Coverage 10/12 core. Substring limitation honestly pinned. |

--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -14,6 +14,8 @@ Philosophy (from #944 harness):
 Privacy: synthetic argument text only, opaque IDs, no raw_text/full_text.
 """
 
+import logging
+
 import pytest
 from unittest.mock import MagicMock, AsyncMock, patch
 
@@ -1281,3 +1283,89 @@ class TestKemenyYoungSafeFallback:
 
         with pytest.raises(ValueError, match="impractical"):
             kemeny_young(ballots, options)
+
+
+# ============================================================
+# #973 (FB-16) — Informal Fallacy: substrate-literal taxonomy value-gate
+# ============================================================
+
+
+class TestInformalTaxonomyValueGate:
+    """Value-gate: taxonomy detector fires on literal fallacy names, empty on paraphrase.
+
+    The TaxonomySophismDetector uses substring matching (nom_vulgarisé/text_fr
+    in text_lower). It genuinely detects fallacies when their canonical name
+    appears literally, but returns near-empty on paraphrased descriptions.
+    Both behaviours are REAL and must be pinned by tests — not hidden (#973).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _init_detector(self):
+        """Create a TaxonomySophismDetector with a mock kernel."""
+        from unittest.mock import MagicMock
+
+        from argumentation_analysis.agents.core.informal.taxonomy_sophism_detector import (
+            TaxonomySophismDetector,
+        )
+        from argumentation_analysis.agents.core.informal.informal_definitions import (
+            InformalAnalysisPlugin,
+        )
+
+        kernel = MagicMock()
+        plugin = InformalAnalysisPlugin(kernel=kernel)
+        self.detector = TaxonomySophismDetector.__new__(TaxonomySophismDetector)
+        self.detector.plugin = plugin
+        self.detector._taxonomy_cache = None
+        self.detector.logger = logging.getLogger("TestInformal")
+
+    def test_fires_on_literal_fallacy_name(self):
+        """Detector MUST find a fallacy when its nom_vulgarisé appears literally.
+
+        Uses 'trouver des excuses' (PK=62, nom_vulgarisé='Trouver des excuses')
+        which has a non-empty nom_vulgarisé — the substring match fires.
+        """
+        text = (
+            "Il ne fait que trouver des excuses pour ne pas admettre "
+            "qu'il avait tort depuis le début."
+        )
+        results = self.detector.detect_sophisms_from_taxonomy(text)
+        assert len(results) >= 1, (
+            f"Detector should find ≥1 fallacy when 'trouver des excuses' appears "
+            f"literally, got {len(results)} results (#973)."
+        )
+        # Verify the detection method is taxonomy lexical
+        assert any(r.get("detection_method") == "taxonomy_lexical" for r in results), (
+            f"Expected 'taxonomy_lexical' detection method, got "
+            f"{[r.get('detection_method') for r in results]} (#973)."
+        )
+
+    def test_empty_on_paraphrased_description(self):
+        """Detector MUST return empty when fallacy is described without its name.
+
+        A paraphrased excuse-making (without 'trouver des excuses') should not
+        match. This pins the substring limitation — not a bug, just the
+        detector's scope.
+        """
+        text = (
+            "Au lieu de reconnaître son erreur, il a préféré tourner "
+            "autour du pot et éviter le sujet."
+        )
+        results = self.detector.detect_sophisms_from_taxonomy(text)
+        assert len(results) == 0, (
+            f"Detector should return 0 on paraphrased text (no literal fallacy name), "
+            f"got {len(results)}: {[r.get('nom_vulgarise','') for r in results]}. "
+            f"This characterises the substring limitation (#973)."
+        )
+
+    def test_nom_vulgarise_match_confidence(self):
+        """nom_vulgarisé match contributes ≥0.7 confidence (crosses 0.3 threshold)."""
+        text = "C'est de l'inertie mentale pure."
+        results = self.detector.detect_sophisms_from_taxonomy(text)
+        assert len(results) >= 1, (
+            f"Detector should find 'inertie mentale' (nom_vulgarisé match), "
+            f"got {len(results)} results (#973)."
+        )
+        assert any(r.get("confidence", 0) >= 0.7 for r in results), (
+            f"nom_vulgarisé match should contribute ≥0.7 confidence, "
+            f"got {[r.get('confidence') for r in results]} (#973)."
+        )


### PR DESCRIPTION
## Summary

Fixes #973 — Informal Fallacy taxonomy detector value-gate (Epic #947 Phase 3 coverage completion).

## What this does

Adds value-gate tests that **pin the real, calibrated behaviour** of the TaxonomySophismDetector — not hide its limitations, not rewrite the NLP.

### test_value_gates.py (+3 tests, all PASS)
- `test_fires_on_literal_fallacy_name`: "trouver des excuses" (PK=62, nom_vulgarisé non-empty) is detected via substring match
- `test_empty_on_paraphrased_description`: paraphrased excuse-making returns 0 results — pins the substring limitation
- `test_nom_vulgarise_match_confidence`: nom_vulgarisé match contributes ≥0.7 confidence (above 0.3 threshold)

### subsystem_verdict.md
- §1 Informal: value-gate NONE → YES (3/3 PASS)
- Substring limitation honestly characterised with specifics
- Coverage: **10/12** core subsystems (was 9/12)

## Key discovery

"Ad hominem" (PK=1360) has `nom_vulgarisé=nan` and `Name=""` — the detector only scores 0.1 per description keyword, below the 0.3 threshold. So even a literal "ad hominem" in text is NOT detected. The test uses "trouver des excuses" (PK=62, has nom_vulgarisé) as a calibratable case instead.

## Anti-pendule
- Tests assert what the detector ACTUALLY produces (fire + empty)
- No floor invented, no NLP rewrite, no detector modifications
- Limitation is documented, not hidden

## Test results
```
3 passed in 5.10s
```

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>