### PR TITLE
test(fol,pl): FOL + PL value-gate regression guards (#976 #977)

### DIFF
--- a/docs/reports/subsystem_verdict.md
+++ b/docs/reports/subsystem_verdict.md
@@ -51,21 +51,21 @@ Verdict calibration:
 
 | Aspect | Finding |
 |--------|---------|
-| **Files** | `agents/core/logic/fol_handler.py`, `invoke_callables.py:4896-5350` |
-| **Produces** | Consistency check + query entailment via 3-solver chain: Prover9 → EProver → Tweety SimpleFolReasoner. Per-formula isolation (PR #954 fix). Fallback flag `solver_fallback` (PR #955). |
-| **Value-gate tests** | **NONE** in `test_value_gates.py`. |
-| **Blind spots** | (1) Solver fallback chain: same call silently produces different results depending on which binary is installed. (2) Tweety SimpleFolReasoner is incomplete — cannot decide all FOL consequences. (3) `create_belief_set_from_string()` blocks event loop (synchronous). (4) No FOL agent wrapper — raw service, not integrated into agent architecture. |
-| **Verdict** | **PARTIAL** — Per-formula isolation fixed (#954). Solver fallback wired (#955). But solver-dependent non-determinism and incomplete prover remain. |
+| **Files** | `agents/core/logic/fol_handler.py`, `invoke_callables.py:4915-5324` |
+| **Produces** | Consistency check + query entailment via 3-solver chain: Prover9 → EProver → Tweety SimpleFolReasoner. Per-formula isolation (PR #954 fix). Fallback flag `solver_fallback` (PR #955). Python fallback returns `fallback: "python"` with template `Asserted(argN)` predicates or NL-to-logic translations. |
+| **Value-gate tests** | **YES** — `TestFOLValueGate` (3 tests, **PASS** after #976). Asserts: (1) fallback='python' and consistent=False when Fallacious predicates present, (2) formulas are predicate-shaped (not zero/degenerate), (3) consistent is real bool when Tweety available. |
+| **Blind spots** | (1) Solver fallback chain: same call silently produces different results depending on which binary is installed. (2) Tweety SimpleFolReasoner is incomplete — cannot decide all FOL consequences. (3) NL-to-logic fallback produces structured formulas even without Tweety — fallback is honest but not verified. (4) `consistent` field in Python fallback may be `not has_fallacious` — a weak heuristic. |
+| **Verdict** | **PARTIAL** — Per-formula isolation fixed (#954). Solver fallback wired (#955). Value-gate regression guard added (#976). Solver-dependent non-determinism and incomplete prover remain. |
 
 ### 4. PL (Propositional Logic)
 
 | Aspect | Finding |
 |--------|---------|
-| **Files** | `agents/core/logic/propositional_logic_agent.py` |
-| **Produces** | `PropositionalBeliefSet` with declared propositions + formula strings, validated by Tweety. Query execution returns entailment via Tweety PL reasoner. |
-| **Value-gate tests** | **NONE** in `test_value_gates.py`. |
+| **Files** | `agents/core/logic/propositional_logic_agent.py`, `invoke_callables.py:4514-4912` |
+| **Produces** | `PropositionalBeliefSet` with declared propositions + formula strings, validated by Tweety. 2-pass coordinated pipeline: Pass 1 extracts shared atom inventory, Pass 2 generates per-argument formulas. Python fallback returns `fallback: "python"` with template pN variables or NL-to-logic translations. |
+| **Value-gate tests** | **YES** — `TestPLValueGate` (3 tests, **PASS** after #977). Asserts: (1) fallback='python' and satisfiable is bool when Tweety unavailable, (2) formulas contain PL operators or template vars (not zero/degenerate), (3) satisfiable is real bool when Tweety available. |
 | **Blind spots** | (1) Heavy LLM dependency — 2 LLM calls (propositions + formulas) with JSON parsing, 3 retries on failure. (2) `_filter_formulas()` silently drops LLM-invented propositional symbols without notification. (3) Only Tweety backend — no multi-solver chain like FOL. (4) Requires JVM. |
-| **Verdict** | **PARTIAL** — Produces real PL analysis when JVM+LLM available. LLM dependency is fragile. No value-gate test. |
+| **Verdict** | **PARTIAL** — Produces real PL analysis when JVM+LLM available. Value-gate regression guard added (#977). LLM dependency is fragile but honest. |
 
 ### 5. Modal Logic
 
@@ -176,8 +176,8 @@ Verdict calibration:
 |-----------|---------|-----------|----------|
 | Informal Fallacy | PARTIAL | ✅ (3/3 PASS) | Taxonomy substring-literal honestly characterised (#973), mock adapter fallback |
 | Dung/ASPIC | PARTIAL | ✅ (9/9 PASS) | ~~DFS shadowing + no size guard~~ FIXED (#970), Python fallback = grounded only |
-| FOL | PARTIAL | ❌ | Solver-dependent non-determinism |
-| PL | PARTIAL | ❌ | Heavy LLM dependency, JVM-only |
+| FOL | PARTIAL | ✅ (3/3 PASS) | Solver-dependent non-determinism, value-gate added (#976) |
+| PL | PARTIAL | ✅ (3/3 PASS) | Heavy LLM dependency, JVM-only, value-gate added (#977) |
 | Modal Logic | PARTIAL | ✅ (2/2 PASS) | Honest unavailable (#963), no pure-Python fallback |
 | Quality (9 virtues) | **TRUSTWORTHY** | ✅ (3/3 PASS) | Keyword limitation acceptable |
 | Counter-Argument | PARTIAL | ✅ (3/3 PASS) | Fabricated statistics removed (#962), template placeholder tagged |
@@ -247,3 +247,4 @@ Verdict calibration:
 | 2026-06-06 | myia-po-2023 | Dung DFS shadowing fixed + exponential guard (#970). Value-gate: 9/9 PASS. |
 | 2026-06-06 | myia-po-2023 | Governance fabricated probs → None (#971), Kemeny-Young Copeland fallback (#971). Value-gate: 9/9 PASS. |
 | 2026-06-06 | myia-po-2023 | Informal taxonomy value-gate: 3/3 PASS (#973). Coverage 10/12 core. Substring limitation honestly pinned. |
+| 2026-06-06 | myia-po-2023 | FOL + PL value-gate regression guards (#976 #977). Coverage: 12/12 core with value-gate tests. |

--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -1369,3 +1369,290 @@ class TestInformalTaxonomyValueGate:
             f"nom_vulgarisé match should contribute ≥0.7 confidence, "
             f"got {[r.get('confidence') for r in results]} (#973)."
         )
+
+
+# ============================================================
+# #976 (FB-17) — FOL: regression guard against #941 false-zero
+# ============================================================
+
+
+class TestFOLValueGate:
+    """Value-gate: FOL must not silently regress to the #941 false-zero.
+
+    The post-#941 capstone reports FOL 41/41 verified. Without a value-gate,
+    a regression that zeroes FOL output (solver change, C1 extractor break)
+    would pass CI in silence. These tests assert:
+      1. When JVM/Tweety is unavailable: honest 'fallback: python', not
+         fabricated consistent=True on template formulas with fallacies.
+      2. Template formulas are honestly template-shaped (Asserted(argN)),
+         not pretending to be LLM-generated.
+      3. When Tweety is available: consistent is a real bool, formulas > 0.
+    """
+
+    async def test_fol_fallback_reports_python_not_fabricated(self):
+        """FOL fallback must report 'fallback: python', not fabricated consistency.
+
+        When TweetyBridge fails and per-formula isolation saves nothing,
+        the Python fallback uses template formulas. It must NOT claim
+        consistent=True when formulas contain 'Fallacious' predicates
+        (which indicate undermined arguments -- consistent should be False).
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_fol_reasoning,
+        )
+
+        text = "Les renouvelables sont chères. Cependant, le solaire coûte moins."
+        context = {
+            "phase_hierarchical_fallacy_output": {
+                "fallacies": [
+                    {"type": "hasty_generalization", "fallacy_type": "hasty"},
+                ],
+            },
+        }
+
+        # Force TweetyBridge to fail AND no LLM -> pure Python fallback.
+        # TweetyBridge is imported locally inside the function, so we patch
+        # at the source module.
+        with patch(
+            "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
+            side_effect=RuntimeError("No JVM for test"),
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(None, None),
+        ):
+            result = await _invoke_fol_reasoning(text, context)
+
+        assert result.get("fallback") == "python", (
+            f"FOL fallback should be 'python', got fallback={result.get('fallback')} (#976)."
+        )
+        # Template formulas contain Fallacious -> consistent should be False
+        formulas = result.get("formulas", [])
+        has_fallacious = any("Fallacious" in f for f in formulas)
+        if has_fallacious:
+            assert result.get("consistent") is False, (
+                f"FOL fallback with Fallacious predicates claims consistent=True. "
+                f"Honest Python fallback must report consistent=False when formulas "
+                f"undermine arguments (#976). formulas={formulas}"
+            )
+
+    async def test_fol_template_formulas_are_honest(self):
+        """FOL fallback formulas must be non-empty and honestly typed.
+
+        When no Tweety is available, FOL falls back to either NL-to-logic
+        translations or Asserted(argN) templates. Both are honest — they
+        must produce non-empty formulas and report fallback='python'.
+        A regression to zero formulas would be the #941 false-zero.
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_fol_reasoning,
+        )
+
+        text = "Premise one. Premise two. Therefore conclusion."
+        context = {}
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
+            side_effect=RuntimeError("No JVM for test"),
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(None, None),
+        ):
+            result = await _invoke_fol_reasoning(text, context)
+
+        assert result.get("fallback") == "python", (
+            "Expected Python fallback when JVM unavailable (#976)."
+        )
+        formulas = result.get("formulas", [])
+        assert len(formulas) > 0, (
+            "FOL must produce >=1 formula even in fallback mode, "
+            "not zero formulas that would look like a false-zero (#976)."
+        )
+        # Formulas must be predicate-shaped (Pred(arg) or Asserted(arg))
+        # NOT bare text fragments — distinguishes structured fallback
+        # from degenerate empty output.
+        has_pred_form = any("(" in f and ")" in f for f in formulas)
+        assert has_pred_form, (
+            f"FOL fallback formulas should be predicate-shaped (contain parens), "
+            f"got {formulas}. Structured predicates distinguish fallback from "
+            f"degenerate plain-text output (#976)."
+        )
+
+    async def test_fol_consistent_is_bool_when_tweety_available(self):
+        """When Tweety path succeeds, 'consistent' must be a real bool.
+
+        If the Tweety path works (no fallback), the result must have
+        consistent as a proper boolean (not None, not missing), and
+        formulas must be non-empty -- this is the regression guard
+        against silently losing all verified formulas.
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_fol_reasoning,
+        )
+
+        text = "Socrates is mortal. All humans are mortal."
+        context = {}
+
+        # Simulate TweetyBridge returning a successful consistency check
+        mock_bridge = MagicMock()
+        mock_bridge.check_consistency.return_value = (True, "Consistent")
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
+            return_value=mock_bridge,
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(None, None),
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            return_value=(True, "Consistent"),
+        ):
+            result = await _invoke_fol_reasoning(text, context)
+
+        # When Tweety succeeds, consistent must be a bool
+        assert isinstance(result.get("consistent"), bool), (
+            f"FOL 'consistent' should be bool when Tweety succeeds, "
+            f"got {type(result.get('consistent'))}: {result.get('consistent')} (#976)."
+        )
+        # Formulas must be present (the regression guard)
+        formulas = result.get("formulas", [])
+        assert len(formulas) > 0, (
+            "FOL produced 0 formulas even in Tweety-success path. "
+            "A regression to zero would silently pass CI (#976)."
+        )
+
+
+# ============================================================
+# #977 (FB-18) — PL: regression guard on the 50/50 showcase metric
+# ============================================================
+
+
+class TestPLValueGate:
+    """Value-gate: PL must not silently regress to zero formulas.
+
+    The capstone reports PL 50/50 verified. Without a value-gate, a
+    regression that drops PL to 0 formulas would pass CI. These tests
+    mirror the FOL value-gate pattern:
+      1. Fallback reports 'fallback: python', not fabricated satisfiable.
+      2. Template formulas are honestly template-shaped (p1, p2, ...).
+      3. When Tweety is available: satisfiable is a real bool, formulas > 0.
+    """
+
+    async def test_pl_fallback_reports_python_not_fabricated(self):
+        """PL fallback must report 'fallback: python', not claim satisfiable=True
+        on empty formulas or fabricated model.
+
+        When TweetyBridge fails and per-formula isolation saves nothing,
+        the Python fallback must be honest about using templates.
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_propositional_logic,
+        )
+
+        text = "The data shows X. Therefore Y follows."
+        context = {}
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
+            side_effect=RuntimeError("No JVM for test"),
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(None, None),
+        ):
+            result = await _invoke_propositional_logic(text, context)
+
+        assert result.get("fallback") == "python", (
+            f"PL fallback should be 'python', got fallback={result.get('fallback')} (#977)."
+        )
+        # satisfiable must be a bool (not None, not missing)
+        assert isinstance(result.get("satisfiable"), bool), (
+            f"PL 'satisfiable' should be bool in fallback, "
+            f"got {type(result.get('satisfiable'))} (#977)."
+        )
+
+    async def test_pl_template_formulas_are_honest(self):
+        """PL fallback formulas must be non-empty and honestly typed.
+
+        When no Tweety is available, PL falls back to either NL-to-logic
+        translations or pN template variables. Both are honest — they
+        must produce non-empty formulas and report fallback='python'.
+        A regression to zero formulas would be the false-zero.
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_propositional_logic,
+        )
+
+        text = "First claim. Second claim. Third claim follows."
+        context = {}
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
+            side_effect=RuntimeError("No JVM for test"),
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(None, None),
+        ):
+            result = await _invoke_propositional_logic(text, context)
+
+        assert result.get("fallback") == "python", (
+            "Expected Python fallback when JVM unavailable (#977)."
+        )
+        formulas = result.get("formulas", [])
+        assert len(formulas) > 0, (
+            "PL must produce >=1 formula even in fallback mode, "
+            "not zero formulas that would look like a false-zero (#977)."
+        )
+        # Formulas must contain PL operators or be atomic propositions.
+        # Honest fallback produces either pN variables or sanitized NL-derived
+        # formulas — both are structured, not degenerate plain text.
+        has_structure = any(
+            any(op in f for op in ["=>", "||", "&&", "!", "<=>", "("])
+            or (f.startswith("p") and f[1:].isdigit())
+            for f in formulas
+        )
+        assert has_structure, (
+            f"PL fallback formulas should contain PL operators or template vars, "
+            f"got {formulas}. Structured formulas distinguish fallback from "
+            f"degenerate plain-text output (#977)."
+        )
+
+    async def test_pl_satisfiable_is_bool_when_tweety_available(self):
+        """When Tweety path succeeds, 'satisfiable' must be a real bool.
+
+        If the Tweety path works, the result must have satisfiable as
+        a proper boolean and formulas must be non-empty -- regression guard
+        against silently losing all verified formulas.
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_propositional_logic,
+        )
+
+        text = "If it rains then the ground is wet. It is raining."
+        context = {}
+
+        # Simulate TweetyBridge returning a successful consistency check
+        mock_bridge = MagicMock()
+        mock_bridge.check_consistency.return_value = (True, "Satisfiable")
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
+            return_value=mock_bridge,
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(None, None),
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            return_value=(True, "Satisfiable"),
+        ):
+            result = await _invoke_propositional_logic(text, context)
+
+        # When Tweety succeeds, satisfiable must be a bool
+        assert isinstance(result.get("satisfiable"), bool), (
+            f"PL 'satisfiable' should be bool when Tweety succeeds, "
+            f"got {type(result.get('satisfiable'))}: {result.get('satisfiable')} (#977)."
+        )
+        # Formulas must be present (the regression guard)
+        formulas = result.get("formulas", [])
+        assert len(formulas) > 0, (
+            "PL produced 0 formulas even in Tweety-success path. "
+            "A regression to zero would silently pass CI (#977)."
+        )


### PR DESCRIPTION
## FB-17 #976 + FB-18 #977 — FOL + PL value-gate regression guards

**Parent**: Epic #947 (Final Boss) — Phase 3 coverage  
**Lane**: po-2023 (conceptual/logic)  
**Queued behind**: FB-16 #973 (PR #979, edits same files)

### What

Adds 6 value-gate tests (3 FOL + 3 PL) to `test_value_gates.py`:

**FOL (TestFOLValueGate, #976):**
1. `test_fol_fallback_reports_python_not_fabricated` — When Tweety unavailable + fallacy context: `fallback=python`, `consistent=False` (not fabricated True on Fallacious predicates)
2. `test_fol_template_formulas_are_honest` — Fallback produces predicate-shaped formulas (not zero/degenerate) — regression guard vs #941 false-zero
3. `test_fol_consistent_is_bool_when_tweety_available` — When Tweety succeeds: `consistent` is real bool, formulas > 0

**PL (TestPLValueGate, #977):**
1. `test_pl_fallback_reports_python_not_fabricated` — When Tweety unavailable: `fallback=python`, `satisfiable` is bool (not None/missing)
2. `test_pl_template_formulas_are_honest` — Fallback produces structured formulas with PL operators or template vars
3. `test_pl_satisfiable_is_bool_when_tweety_available` — When Tweety succeeds: `satisfiable` is real bool, formulas > 0

### Why

The post-#941 capstone reports FOL 41/41 and PL 50/50 verified. Without value-gates, a regression that silently zeroes these metrics would pass CI. These tests pin the genuine behavior: honest fallback when solver unavailable, real verification when available.

### Anti-pendule

- Assert **genuine** behavior (fallback reports honestly, Tweety path produces real bools)
- No fabricated floors, no agent rewrites
- Tests adapt to whether NL-to-logic translator is available (both paths are honest)

### Files

| File | Change |
|------|--------|
| `tests/unit/argumentation_analysis/test_value_gates.py` | +287 lines (2 new test classes, 6 tests) |
| `docs/reports/subsystem_verdict.md` | §FOL + §PL updated: value-gate YES, summary table updated |

### DoD

- [x] ≥1 value-gate test for FOL (3/3 PASS)
- [x] ≥1 value-gate test for PL (3/3 PASS)
- [x] `subsystem_verdict.md` §FOL + §PL updated with test file:line and regression guard note
- [x] Existing tests stay green; CI green
- [x] Privacy: synthetic text only, opaque IDs, no corpus content

### Serialization note

This PR is queued behind FB-16 #973 (PR #979) which edits the same test file. If FB-16 merges first, this PR will need a rebase to incorporate the Informal taxonomy tests from FB-16.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>