### PR TITLE
fix(pipeline): add narrative_synthesis phase to standard workflow (#981)

### DIFF
--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -237,6 +237,20 @@ def build_standard_workflow() -> WorkflowDefinition:
             depends_on=["counter"],
             optional=True,
         )
+        # Narrative synthesis (#981): produce a structured narrative from all
+        # analysis results. Depends on phases that populate convergence signals.
+        .add_phase(
+            "narrative_synthesis",
+            capability="narrative_synthesis",
+            depends_on=[
+                "quality",
+                "hierarchical_fallacy",
+                "counter",
+                "jtms",
+                "dung_extensions",
+            ],
+            optional=True,
+        )
         # Local LLM offline analysis (#835 A-10) — skipped if endpoint absent
         .add_phase(
             "local_llm",


### PR DESCRIPTION
## Summary

The narrative_synthesis capability was fully registered (registry + invoke callable + state writer) but the default standard workflow never included it as a phase. This caused --mode pipeline (defaulting to --workflow standard) to silently skip narrative synthesis.

Conversational mode worked because the LLM autonomously discovers and calls the NarrativeSynthesisPlugin kernel_function — no pipeline phase needed.

## Root cause

build_standard_workflow() in workflows.py had no narrative_synthesis phase. Both build_full_workflow() and build_spectacular_workflow() included it.

## Fix

Added narrative_synthesis phase to build_standard_workflow() with the same dependency set used in full:
- quality, hierarchical_fallacy, counter, jtms, dung_extensions

All 5 dependencies already exist in the standard workflow. Phase is optional=True matching the existing pattern.

## Verification

Built workflow standard_analysis with 15 phases (was 14). narrative_synthesis phase present with correct deps. No circular dependency, no import errors.

## Files changed

argumentation_analysis/orchestration/workflows.py (+14 lines)

## Related

- Roadmap P0 no.1 (narrative_synthesis pipeline activation)
- Epic 947 Phase 3 coverage