### PR TITLE
feat(benchmark): FR↔EN fallacy alias map for FB-8 yardstick scoring (#995)

### DIFF
--- a/scripts/run_benchmark_fb8.py
+++ b/scripts/run_benchmark_fb8.py
@@ -268,6 +268,70 @@ def _extract_full_state(snapshot: Dict[str, Any]) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# FR↔EN Fallacy alias map (#995)
+# ---------------------------------------------------------------------------
+
+# Derived from taxonomy_full.csv (text_fr → text_en canonical).
+# Covers the 8 families + all yardstick markers (D1-D10).
+# Each key is a normalised (lowercased) FR label produced by the pipeline;
+# each value is the EN canonical marker expected by the yardstick scorer.
+FALLACY_FR_EN_ALIASES: Dict[str, str] = {
+    # Insufficiency family
+    "généralisation hâtive": "hasty_generalization",
+    "rationalisation": "rationalization",
+    "appel à l'ignorance": "appeal_to_ignorance",
+    "argument d'omniscience": "argument_from_omniscience",
+    # Influence family
+    "appel à l'émotion": "appeal_to_emotion",
+    "appel à la peur": "appeal_to_fear",
+    "appel à la pitié": "appeal_to_pity",
+    "appel à la flatterie": "appeal_to_flattery",
+    "appel au ridicule": "appeal_to_ridicule",
+    # Faulty logics family
+    "raisonnement circulaire": "circular_reasoning",
+    "argument circulaire": "circular_reasoning",
+    "définition circulaire": "circular_reasoning",
+    "pente glissante": "slippery_slope",
+    "faux dilemme": "false_dilemma",
+    "fausse dichotomie": "false_dilemma",
+    "pétition de principe": "begging_question",
+    "non-séquitur": "non_sequitur",
+    # Cheating family
+    "homme de paille": "straw_man",
+    "appel à l'identité": "appeal_to_identity",
+    "effet de mode": "bandwagon_effect",
+    "fausse équivalence": "false_equivalence",
+    # Obstruction family
+    "ad populum": "ad_populum",
+    "raison de la majorité": "ad_populum",
+    "appel à la bande": "bandwagon_fallacy",
+    "atteinte personnelle": "ad_hominem",
+    # Misleading language family
+    "équivoque": "equivocation",
+    "ambiguïté": "ambiguity",
+    # Additional yardstick-specific markers
+    "appel à l'autorité": "appeal_to_authority",
+    "tromperie implicite": "implicit_deception",
+    "sophisme naturel": "naturalistic_fallacy",
+}
+
+
+def _normalize_fallacy_type(raw: str) -> str:
+    """Normalize a fallacy type string for matching.
+
+    Lowercases, strips, and applies the FR→EN alias map if applicable.
+    """
+    key = raw.lower().strip()
+    # Direct alias hit
+    if key in FALLACY_FR_EN_ALIASES:
+        return FALLACY_FR_EN_ALIASES[key]
+    # Also try underscored form (pipeline sometimes uses snake_case EN)
+    if "_" in key:
+        return key
+    return key
+
+
+# ---------------------------------------------------------------------------
 # Scoring engine
 # ---------------------------------------------------------------------------
 
@@ -284,8 +348,11 @@ def score_against_yardstick(pipeline_output: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(fallacies, dict):
         for _fid, fdata in fallacies.items():
             if isinstance(fdata, dict):
-                ft = fdata.get("family", fdata.get("fallacy_type", "")).lower()
-                fallacy_types.add(ft)
+                # Collect both family and fallacy_type, normalize each
+                for field in ("family", "fallacy_type"):
+                    raw = fdata.get(field, "")
+                    if raw:
+                        fallacy_types.add(_normalize_fallacy_type(raw))
                 # Also check for specific markers in description
                 desc = fdata.get("description", "").lower()
                 if "circul" in desc or "begging" in desc or "question" in desc:

--- a/tests/unit/scripts/test_run_benchmark_fb8.py
+++ b/tests/unit/scripts/test_run_benchmark_fb8.py
@@ -1,0 +1,118 @@
+"""Tests for FB-8 benchmark runner FR↔EN alias map (#995).
+
+Verifies that the fallacy type normalizer correctly maps French pipeline
+labels to English canonical markers expected by the yardstick scorer.
+"""
+
+import pytest
+
+
+class TestFallacyAliasMap:
+    """Verify FR→EN fallacy alias normalization (#995)."""
+
+    def test_faux_dilemme_maps_to_false_dilemma(self):
+        """'Faux dilemme' (FR) must map to 'false_dilemma' (EN yardstick)."""
+        from scripts.run_benchmark_fb8 import _normalize_fallacy_type
+
+        assert _normalize_fallacy_type("Faux dilemme") == "false_dilemma"
+
+    def test_appel_emotion_maps_to_appeal_to_emotion(self):
+        """'Appel à l'émotion' (FR) must map to 'appeal_to_emotion' (EN)."""
+        from scripts.run_benchmark_fb8 import _normalize_fallacy_type
+
+        assert _normalize_fallacy_type("Appel à l'émotion") == "appeal_to_emotion"
+
+    def test_appel_identite_maps_to_appeal_to_identity(self):
+        """'Appel à l'identité' (FR) must map to 'appeal_to_identity' (EN)."""
+        from scripts.run_benchmark_fb8 import _normalize_fallacy_type
+
+        assert _normalize_fallacy_type("Appel à l'identité") == "appeal_to_identity"
+
+    def test_argument_circulaire_maps_to_circular_reasoning(self):
+        """'Argument circulaire' (FR) must map to 'circular_reasoning' (EN)."""
+        from scripts.run_benchmark_fb8 import _normalize_fallacy_type
+
+        assert _normalize_fallacy_type("Argument circulaire") == "circular_reasoning"
+
+    def test_raison_majorite_maps_to_ad_populum(self):
+        """'Raison de la majorité' (FR) must map to 'ad_populum' (EN)."""
+        from scripts.run_benchmark_fb8 import _normalize_fallacy_type
+
+        assert _normalize_fallacy_type("Raison de la majorité") == "ad_populum"
+
+    def test_pente_glissante_maps_to_slippery_slope(self):
+        """'Pente glissante' (FR) must map to 'slippery_slope' (EN)."""
+        from scripts.run_benchmark_fb8 import _normalize_fallacy_type
+
+        assert _normalize_fallacy_type("Pente glissante") == "slippery_slope"
+
+    def test_en_snake_case_passes_through(self):
+        """EN snake_case markers already in canonical form pass through."""
+        from scripts.run_benchmark_fb8 import _normalize_fallacy_type
+
+        assert _normalize_fallacy_type("circular_reasoning") == "circular_reasoning"
+        assert _normalize_fallacy_type("ad_populum") == "ad_populum"
+
+    def test_unknown_returns_lowered(self):
+        """Unknown FR labels are returned lowercased (no crash)."""
+        from scripts.run_benchmark_fb8 import _normalize_fallacy_type
+
+        result = _normalize_fallacy_type("Sophisme inconnu")
+        assert result == "sophisme inconnu"
+
+
+class TestScorerWithAliasMap:
+    """Verify the scorer correctly applies FR→EN aliases on real-ish data."""
+
+    def test_fr_fallacies_score_against_yardstick(self):
+        """French-detected fallacies must be credited against EN yardstick markers.
+
+        This is the core #995 fix: the scorer should recognize 'Faux dilemme'
+        as matching the 'false_dilemma' yardstick marker for D1 scoring.
+        """
+        from scripts.run_benchmark_fb8 import score_against_yardstick
+
+        # Simulate pipeline output with FR-only fallacy labels
+        pipeline_output = {
+            "phases": {
+                "fallacies": {
+                    "f1": {
+                        "family": "Faux dilemme",
+                        "fallacy_type": "Faux dilemme",
+                        "description": "Présente deux options alors qu'il y en a plus",
+                        "confidence": 0.85,
+                    },
+                    "f2": {
+                        "family": "Appel à l'identité",
+                        "fallacy_type": "Appel à l'identité",
+                        "description": "Appartenance au groupe comme preuve",
+                        "confidence": 0.75,
+                    },
+                    "f3": {
+                        "family": "Raison de la majorité",
+                        "fallacy_type": "Raison de la majorité",
+                        "description": "Populist rhetoric from elite position",
+                        "confidence": 0.70,
+                    },
+                },
+                "fallacies_count": 3,
+                "arguments": {"arg_1": "Test arg"},
+                "arguments_count": 1,
+                "counter_arguments": ["CA1"],
+                "propositional_analysis_results": [],
+                "fol_analysis_results": [],
+                "dung_frameworks": {},
+                "quality_scores": {},
+                "narrative_synthesis": "",
+            },
+        }
+
+        scorecard = score_against_yardstick(pipeline_output)
+
+        # D3 (Populist Rhetoric) should now score at least PARTIAL because
+        # "Raison de la majorité" → "ad_populum" is recognized
+        d3_score = scorecard["D3"]["score"]
+        assert d3_score in ("MATCH", "PARTIAL"), (
+            f"D3 should score MATCH or PARTIAL with FR ad_populum alias, "
+            f"got {d3_score}. Scorer: {scorecard['D3']['synthesis']}"
+        )


### PR DESCRIPTION
## Summary
The FB-8 benchmark scorer expected EN canonical markers (circular_reasoning, ad_populum, false_dilemma...) but the pipeline detects fallacies with FR labels (Faux dilemme, Raison de la majorité, Appel à l'émotion...). This caused false-negative scoring on D1/D3/D6/D7.

## Changes
- Added `FALLACY_FR_EN_ALIASES` constant (30+ mappings, derived from `taxonomy_full.csv` text_fr→text_en columns)
- Added `_normalize_fallacy_type()` function applied in the scorer's fallacy_type collection
- Both `family` and `fallacy_type` fields are now normalized through the alias map
- EN snake_case markers pass through unchanged

## DoD (#995)
- [x] Alias table covers 8 families + yardstick markers (D1-D10)
- [x] Scorer matches FR-detected fallacies against EN yardstick markers
- [x] Test: 'Faux dilemme' → 'false_dilemma' scores correctly
- [x] Test: D3 (Populist Rhetoric) passes from MISSED→PARTIAL via 'Raison de la majorité'→ad_populum
- [x] 9/9 tests PASS

## Anti-pendule
- No broad substring matching — explicit family→marker aliases only
- Taxonomy CSV checked first: carries both text_fr and text_en columns

**Files**: run_benchmark_fb8.py + new test file. No invoke_callables.py (reserved po-2025).