### PR TITLE
fix(dung): graceful degradation on timeout with grounded-only fallback (#992)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -294,6 +294,12 @@ def llm_budget_scope(ceiling: Optional[int] = None) -> Iterator["_LLMBudget"]:
 # below a pathological hang. Set LLM_CALL_TIMEOUT_S=0 to disable.
 _LLM_CALL_TIMEOUT_S = float(os.environ.get("LLM_CALL_TIMEOUT_S", "300"))
 
+# Dung extension computation timeout (seconds). Preferred/stable semantics on
+# large attack graphs can hang indefinitely.  On timeout, falls back to
+# pure-Python grounded-only computation with degraded=True.  Set
+# DUNG_TIMEOUT_S=0 to disable timeout (not recommended).
+_DUNG_TIMEOUT_S = float(os.environ.get("DUNG_TIMEOUT_S", "60"))
+
 
 async def _guarded_chat_completion(client: Any, **kwargs: Any) -> Any:
     """Single funnel for every LLM chat-completion call (#708 runaway guard).
@@ -5533,11 +5539,47 @@ async def _invoke_dung_extensions(
         initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = AFHandler(initializer)
 
-        # Compute all 11 semantics in one pass (framework built once)
+        # Compute all 11 semantics in one pass (framework built once).
+        # Timeout protection (#992): preferred/stable on large graphs can hang
+        # indefinitely — fall back to grounded-only Python on timeout.
         all_semantics = list(SEMANTICS_REASONERS.keys())
-        result = await asyncio.to_thread(
-            handler.analyze_multi_semantics, arguments, attacks, all_semantics
-        )
+        try:
+            if _DUNG_TIMEOUT_S > 0:
+                result = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        handler.analyze_multi_semantics,
+                        arguments,
+                        attacks,
+                        all_semantics,
+                    ),
+                    timeout=_DUNG_TIMEOUT_S,
+                )
+            else:
+                result = await asyncio.to_thread(
+                    handler.analyze_multi_semantics, arguments, attacks, all_semantics
+                )
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"Dung computation timed out after {_DUNG_TIMEOUT_S}s "
+                f"({len(arguments)} args, {len(attacks)} attacks) — "
+                f"falling back to grounded-only Python (#992)"
+            )
+            _fallback_result = _python_dung_fallback(arguments, attacks)
+            _fallback_result["degraded"] = True
+            _fallback_result["degraded_reason"] = (
+                f"timeout after {_DUNG_TIMEOUT_S}s"
+            )
+            # Trace entry for degraded Dung fallback
+            _state = context.get("_state_object")
+            if _state is not None and _fallback_result.get("arguments"):
+                _n_args = len(_fallback_result.get("arguments", []))
+                _state.add_trace_entry(
+                    phase="dung",
+                    agent="DungAnalyzer",
+                    reacts_to=["extract", "counter"],
+                    summary=f"Cadre Dung (DEGRADED — timeout): {_n_args} arguments. Extension fondée calculée heuristiquement.",
+                )
+            return _fallback_result
 
         raw_extensions = result.get("extensions", {})
 
@@ -5598,6 +5640,8 @@ async def _invoke_dung_extensions(
     except Exception as e:
         logger.info(f"Dung AFHandler unavailable ({e}), using Python fallback")
         _fallback_result = _python_dung_fallback(arguments, attacks)
+        _fallback_result["degraded"] = True
+        _fallback_result["degraded_reason"] = f"AFHandler error: {e}"
         # Trace entry for Dung Python fallback
         _state = context.get("_state_object")
         if _state is not None and _fallback_result.get("arguments"):

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
@@ -275,6 +275,92 @@ class TestInvokeDungExtensions:
         assert result["semantics"] == "python_fallback"
         assert len(result["arguments"]) == 2
 
+    @pytest.mark.asyncio
+    async def test_timeout_triggers_degraded_fallback(self):
+        """Dung function falls back to grounded-only on timeout (#992).
+
+        When analyze_multi_semantics hangs (e.g. preferred/stable on large
+        graphs), asyncio.wait_for raises TimeoutError.  The callable should
+        catch it, compute a grounded extension via pure-Python fallback, and
+        set degraded=True.
+        """
+        import time
+
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_dung_extensions,
+        )
+        import argumentation_analysis.orchestration.invoke_callables as ic_mod
+
+        context = {
+            "phase_extract_output": {
+                "arguments": [
+                    {"text": "arg_a"},
+                    {"text": "arg_b"},
+                    {"text": "arg_c"},
+                ]
+            },
+        }
+
+        def _hanging_analyze(*args, **kwargs):
+            """Simulates a Tweety call that never returns."""
+            time.sleep(600)  # will be cut short by the timeout
+
+        original_timeout = ic_mod._DUNG_TIMEOUT_S
+        try:
+            # Use a very short timeout so the test runs fast
+            ic_mod._DUNG_TIMEOUT_S = 0.3
+
+            with patch(
+                "argumentation_analysis.agents.core.logic.af_handler.AFHandler"
+            ) as mock_af:
+                mock_handler = MagicMock()
+                mock_handler.analyze_multi_semantics.side_effect = _hanging_analyze
+                mock_af.return_value = mock_handler
+
+                with patch(
+                    "argumentation_analysis.agents.core.logic.tweety_initializer.TweetyInitializer"
+                ) as mock_init:
+                    mock_init.return_value = MagicMock()
+                    result = await _invoke_dung_extensions("test text", context)
+
+            # Must be a degraded fallback
+            assert result["semantics"] == "python_fallback"
+            assert result.get("degraded") is True
+            assert "timeout" in result.get("degraded_reason", "")
+            # Grounded extension should be non-empty (3 args, heuristic attacks
+            # may exclude some, but at least the un-attacked ones must appear)
+            grounded = result.get("extensions", {}).get("grounded", [])
+            assert len(grounded) >= 1, f"Expected ≥1 grounded args, got {grounded}"
+        finally:
+            ic_mod._DUNG_TIMEOUT_S = original_timeout
+
+    @pytest.mark.asyncio
+    async def test_exception_fallback_has_degraded_flag(self):
+        """Dung function sets degraded=True when falling back on exception (#992)."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_dung_extensions,
+        )
+
+        context = {
+            "phase_extract_output": {
+                "arguments": [{"text": "arg1"}, {"text": "arg2"}]
+            }
+        }
+
+        with patch(
+            "argumentation_analysis.agents.core.logic.af_handler.AFHandler",
+            side_effect=RuntimeError("JVM crashed"),
+        ):
+            with patch(
+                "argumentation_analysis.agents.core.logic.tweety_initializer.TweetyInitializer"
+            ) as mock_init:
+                mock_init.return_value = MagicMock()
+                result = await _invoke_dung_extensions("test text", context)
+
+        assert result["semantics"] == "python_fallback"
+        assert result.get("degraded") is True
+        assert "AFHandler error" in result.get("degraded_reason", "")
+
 
 # ============================================================
 # Test: Python Dung fallback


### PR DESCRIPTION
## Summary

Fixes #992 — Dung extension computation hangs on large attack graphs (preferred/stable semantics), resulting in 0 extensions instead of a meaningful fallback.

## Changes

### 
- Add  config (env , default 60s)
- Wrap  in 
- On : fall back to  (grounded-only)
- Add  +  to both timeout and exception fallback results
- Trace entry shows `DEGRADED — timeout` when applicable

### 
- `test_timeout_triggers_degraded_fallback`: mock hanging analyze_multi_semantics → verify timeout → grounded non-empty + degraded=true
- `test_exception_fallback_has_degraded_flag`: verify existing Exception path also sets degraded=true

## Impact on benchmark (#953)

In the corpus_X benchmark (BELOW verdict), D1/D8/D10 were all MISSED with `0 Dung extensions`. With this fix, the Dung phase will produce at least the grounded extension, enabling:
- D8 (Permission Architecture) — needs Dung framework output
- D2 (Functional Contradictions) — currently PARTIAL with 0 extensions, should improve
- Narrative synthesis has Dung data to work with

## Chain

#992 (this) → #993 (quality fallback) → #994 (narrative degradation) → re-run #953

## Files modified

| File | Type | Change |
|------|------|--------|
| `invoke_callables.py` | core | +52 lines (timeout wrapper + degraded flag) |
| `test_dung_aspic_wiring.py` | test | +86 lines (2 new tests)