### PR TITLE
fix(polish): 4 reviewer nits — dead branch, float guard, dup line, test gaps (#1003)

### DIFF
--- a/argumentation_analysis/agents/core/quality/quality_evaluator.py
+++ b/argumentation_analysis/agents/core/quality/quality_evaluator.py
@@ -25,9 +25,6 @@ logger = logging.getLogger("ArgumentQualityEvaluator")
 _nlp = None
 _flesch_reading_ease = None
 _DEPS_AVAILABLE = False
-
-
-_DEPS_AVAILABLE = False
 _DEPS_ATTEMPTED = False
 
 

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -292,13 +292,21 @@ def llm_budget_scope(ceiling: Optional[int] = None) -> Iterator["_LLMBudget"]:
 # conversational-spectacular path hung ~50 min on one unbounded call. Generous
 # default (300s) — far above a legitimate reasoning-model call (<2 min) but well
 # below a pathological hang. Set LLM_CALL_TIMEOUT_S=0 to disable.
-_LLM_CALL_TIMEOUT_S = float(os.environ.get("LLM_CALL_TIMEOUT_S", "300"))
+def _safe_float_env(key: str, default: float) -> float:
+    """Read a float from an env var, falling back to *default* on bad input."""
+    try:
+        return float(os.environ.get(key, str(default)))
+    except (ValueError, TypeError):
+        return default
+
+
+_LLM_CALL_TIMEOUT_S = _safe_float_env("LLM_CALL_TIMEOUT_S", 300.0)
 
 # Dung extension computation timeout (seconds). Preferred/stable semantics on
 # large attack graphs can hang indefinitely.  On timeout, falls back to
 # pure-Python grounded-only computation with degraded=True.  Set
 # DUNG_TIMEOUT_S=0 to disable timeout (not recommended).
-_DUNG_TIMEOUT_S = float(os.environ.get("DUNG_TIMEOUT_S", "60"))
+_DUNG_TIMEOUT_S = _safe_float_env("DUNG_TIMEOUT_S", 60.0)
 
 
 async def _guarded_chat_completion(client: Any, **kwargs: Any) -> Any:

--- a/scripts/run_benchmark_fb8.py
+++ b/scripts/run_benchmark_fb8.py
@@ -322,12 +322,9 @@ def _normalize_fallacy_type(raw: str) -> str:
     Lowercases, strips, and applies the FR→EN alias map if applicable.
     """
     key = raw.lower().strip()
-    # Direct alias hit
+    # Direct alias hit; otherwise return key verbatim (already lowercase).
     if key in FALLACY_FR_EN_ALIASES:
         return FALLACY_FR_EN_ALIASES[key]
-    # Also try underscored form (pipeline sometimes uses snake_case EN)
-    if "_" in key:
-        return key
     return key
 
 

--- a/tests/unit/argumentation_analysis/orchestration/test_external_solvers.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_external_solvers.py
@@ -248,3 +248,30 @@ class TestRegistryASPService:
         reg = registry._registrations.get("modal_logic_service")
         assert reg is not None
         assert "modal_logic" in reg.capabilities
+
+
+class TestSafeFloatEnv:
+    """Test _safe_float_env guards against non-numeric env vars (#1003)."""
+
+    def test_valid_numeric_string(self):
+        """Numeric string is parsed correctly."""
+        import argumentation_analysis.orchestration.invoke_callables as mod
+
+        with patch.dict("os.environ", {"_TEST_FLOAT": "42.5"}):
+            assert mod._safe_float_env("_TEST_FLOAT", 10.0) == 42.5
+
+    def test_non_numeric_falls_back_to_default(self):
+        """Non-numeric env var falls back to default without crash."""
+        import argumentation_analysis.orchestration.invoke_callables as mod
+
+        with patch.dict("os.environ", {"_TEST_FLOAT": "not_a_number"}):
+            assert mod._safe_float_env("_TEST_FLOAT", 10.0) == 10.0
+
+    def test_missing_key_falls_back_to_default(self):
+        """Missing env var falls back to default."""
+        import argumentation_analysis.orchestration.invoke_callables as mod
+
+        env = {"_TEST_FLOAT": "irrelevant"}
+        env.pop("_TEST_FLOAT_MISSING", None)
+        with patch.dict("os.environ", env, clear=False):
+            assert mod._safe_float_env("_TEST_FLOAT_MISSING", 99.0) == 99.0

--- a/tests/unit/argumentation_analysis/orchestration/test_narrative_synthesis_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_narrative_synthesis_spectacular.py
@@ -144,6 +144,58 @@ class TestNarrativeSynthesisGracefulDegradation:
         assert result.get("degraded") is True
 
     @pytest.mark.asyncio
+    async def test_sentinel_triggers_context_rebuild(self):
+        """When build_narrative returns the fallback sentinel, context rebuild activates (#994)."""
+        from unittest.mock import patch, MagicMock
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_narrative_synthesis,
+        )
+
+        sentinel = (
+            "L'analyse n'a pas produit suffisamment de donnees pour generer "
+            "une synthese narrative"
+        )
+        mock_state = MagicMock()
+        context = {
+            "_state_object": mock_state,
+            "phase_extract_output": {
+                "arguments": [{"text": "Arg1"}, {"text": "Arg2"}]
+            },
+        }
+        with patch(
+            "argumentation_analysis.plugins.narrative_synthesis_plugin.build_narrative",
+            return_value=sentinel,
+        ):
+            result = await _invoke_narrative_synthesis("test text", context)
+
+        # Should have rebuilt from context
+        assert result["narrative"], f"Expected rebuilt narrative, got: {result}"
+        assert "2 argument(s)" in result["narrative"]
+        assert result.get("degraded") is True
+
+    @pytest.mark.asyncio
+    async def test_non_degraded_path_no_rebuild(self):
+        """When build_narrative returns valid prose, no degraded flag is set (#994)."""
+        from unittest.mock import patch, MagicMock
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_narrative_synthesis,
+        )
+
+        valid_narrative = "L'argument principal repose sur une analogie solide."
+        mock_state = MagicMock()
+        context = {"_state_object": mock_state}
+
+        with patch(
+            "argumentation_analysis.plugins.narrative_synthesis_plugin.build_narrative",
+            return_value=valid_narrative,
+        ):
+            result = await _invoke_narrative_synthesis("test text", context)
+
+        assert result["narrative"] == valid_narrative
+        assert result.get("degraded") is not True
+        assert "degraded_reason" not in result
+
+    @pytest.mark.asyncio
     async def test_narrative_empty_context_still_returns(self):
         """Even with completely empty context, narrative callable does not crash."""
         from argumentation_analysis.orchestration.unified_pipeline import (


### PR DESCRIPTION
## Polish sweep — 4 reviewer nits (#1003)

Addresses non-blocking reviewer comments from #998/#999/#1000/#1001, grouped into a single sweep.

### Changes

| Nit | File | Fix |
|-----|------|-----|
| Dead branch | `scripts/run_benchmark_fb8.py` | Removed unreachable `if "_" in key` in `_normalize_fallacy_type` — both branches returned `key` verbatim |
| `float()` crash | `invoke_callables.py` | Added `_safe_float_env()` helper — `DUNG_TIMEOUT_S`/`LLM_CALL_TIMEOUT_S` no longer crash on non-numeric env vars |
| Duplicate line | `quality_evaluator.py` | Removed duplicate `_DEPS_AVAILABLE = False` assignment (lines 27+30 → line 27 only) |
| Missing tests | `test_narrative_synthesis_spectacular.py` | Added sentinel-branch + non-degraded path tests for narrative rebuild (#994 coverage) |
| Missing tests | `test_external_solvers.py` | Added `TestSafeFloatEnv` (valid numeric, non-numeric fallback, missing key) |

### Anti-pendule check
- No logic changes to Phase 4 fixes already merged/reviewed
- `_safe_float_env` is additive guard, no behavior change for valid inputs
- Dead branch removal = subtraction only
- Tests are additive coverage

### Collision guard
- invoke_callables.py: ONLY the `_safe_float_env` helper + its use at module level. Does NOT touch any Dung/Quality/Narrative logic (#999/#1000/#1001 merged code untouched).

### Test results
40/40 passed locally (po-2023, conda projet-is).

Closes #1003