### PR TITLE
feat(benchmark): add corpus_X to encrypted dataset (#1018)

### DIFF
--- a/scripts/run_benchmark_fb8.py
+++ b/scripts/run_benchmark_fb8.py
@@ -51,8 +51,8 @@ DATASET_PATH = Path("argumentation_analysis/data/extract_sources.json.gz.enc")
 YARDSTICK_PATH = Path("docs/reports/corpus_x_yardstick.md")
 
 # corpus_X index in extract_sources.json.gz.enc
-# Default: None (must be specified via --corpus-idx or configured after dataset update)
-CORPUS_X_IDX = None
+# Added via #1018 — public manifesto fixture, 6742 chars
+CORPUS_X_IDX = 17
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds corpus_X (public manifesto fixture, 6742 chars) to the encrypted dataset `extract_sources.json.gz.enc` as **index 17**.

## Changes

| File | Change |
|------|--------|
| `extract_sources.json.gz.enc` | Added corpus_X as entry #18 (idx=17) with `full_text` |
| `scripts/run_benchmark_fb8.py` | Set `CORPUS_X_IDX = 17` (was `None`) |

## Why

corpus_X existed only as a gitignored local file (`evaluation/results/corpus_X.txt`) on myia-po-2025. The #1002 re-run was blocked because no other machine could access it. Now any machine can run:

```bash
python scripts/run_benchmark_fb8.py --corpus-idx 17
```

## Verification

- Load/save/load roundtrip: 17 → 18 entries ✅
- `load_corpus_text(idx=17)` returns 6742 chars ✅
- `embed_full_text=True` preserved all existing entries ✅

Closes #1018

🤖 Generated with [Claude Code](https://claude.com/claude-code)