### PR TITLE
fix(narrative): eliminate template-rebuild fallback, fix state key mismatch (#1019 subsystem 2)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -5786,9 +5786,9 @@ async def _invoke_narrative_synthesis(
     build_narrative to generate 1-2 paragraphs weaving together quality,
     fallacies, JTMS, ATMS, Dung, and formal logic results.
 
-    #994: Falls back to reading phase outputs directly from context when
-    the state-based narrative is empty/fallback, ensuring non-empty output
-    even when some upstream phases are degraded or missing.
+    #1019: No template-rebuild fallback.  If the state is empty, the
+    narrative phase returns the sentinel as-is — the root cause (missing
+    state, phase failures) must be fixed upstream, not papered over.
     """
     from argumentation_analysis.plugins.narrative_synthesis_plugin import (
         build_narrative,
@@ -5803,11 +5803,16 @@ async def _invoke_narrative_synthesis(
         "une synthese narrative"
     )
 
-    # Reconstruct state from context if possible
-    state = context.get("_state_object")
+    # Resolve state: prefer _state_object (set by WorkflowExecutor since
+    # workflow_dsl.py writes both unified_state and _state_object), then
+    # fall back to unified_state for backward compatibility.
+    state = context.get("_state_object") or context.get("unified_state")
+
     if not isinstance(state, UnifiedAnalysisState):
+        # No state was passed — reconstruct from context phase outputs
+        # so that build_narrative() has something to work with.
         state = UnifiedAnalysisState(input_text[:200])
-        # Populate from context outputs
+        populated = 0
         for key, value in context.items():
             if key.startswith("phase_") and key.endswith("_output"):
                 cap = key[len("phase_") : -len("_output")]
@@ -5815,145 +5820,48 @@ async def _invoke_narrative_synthesis(
                 if writer and isinstance(value, dict):
                     try:
                         writer(value, state, context)
+                        populated += 1
                     except Exception:
                         logger.warning(
                             "State writer for '%s' failed during narrative reconstruction",
                             cap,
                             exc_info=True,
                         )
+        logger.info(
+            "Narrative: no UnifiedAnalysisState in context, reconstructed "
+            "from %d phase outputs", populated,
+        )
 
     narrative = build_narrative(state)
-    degraded = False
 
-    # #994: If state-based narrative is the fallback message, try reading
-    # phase outputs directly from context to produce a non-empty synthesis.
     if not narrative or _FALLBACK_SENTINEL in narrative:
-        parts: list[str] = []
-
-        # Arguments
-        extract_out = context.get("phase_extract_output", {})
-        raw_args = (
-            extract_out.get("arguments", []) if isinstance(extract_out, dict) else []
-        )
-        if raw_args:
-            parts.append(
-                f"L'analyse a extrait {len(raw_args)} argument(s) du texte."
+        # #1019: Fail explicit — no template rebuild.
+        # Log diagnostic info so the root cause can be identified.
+        phase_keys = [k for k in context if k.startswith("phase_") and k.endswith("_output")]
+        state_fields = [
+            attr for attr in (
+                "argument_quality_scores", "identified_fallacies",
+                "counter_arguments", "jtms_beliefs", "dung_frameworks",
+                "fol_analysis_results", "propositional_analysis_results",
+                "modal_analysis_results", "atms_contexts",
             )
-
-        # Fallacies
-        fallacy_out = context.get("phase_hierarchical_fallacy_output", {})
-        fallacies_raw = (
-            fallacy_out.get("fallacies", []) if isinstance(fallacy_out, dict) else []
+            if getattr(state, attr, None)
+        ]
+        logger.warning(
+            "Narrative synthesis produced empty/fallback result. "
+            "Available phase outputs: %s. Populated state fields: %s. "
+            "Root cause: upstream phases did not produce enough data "
+            "for narrative synthesis.",
+            phase_keys, state_fields,
         )
-        if fallacies_raw:
-            types = set()
-            for f in fallacies_raw:
-                if isinstance(f, dict):
-                    t = f.get("type", "")
-                    if t:
-                        types.add(t)
-            types_str = ", ".join(sorted(types)) if types else f"{len(fallacies_raw)} sophisme(s)"
-            parts.append(
-                f"L'analyse a detecte {len(fallacies_raw)} sophisme(s) "
-                f"({types_str}), ce qui fragilise la structure argumentative."
-            )
-
-        # Counter-arguments
-        ca_out = context.get("phase_counter_output", {})
-        ca_list = (
-            ca_out.get("llm_counter_arguments", [])
-            if isinstance(ca_out, dict)
-            else []
-        )
-        if ca_list:
-            parts.append(
-                f"Des contre-arguments ont ete generes ({len(ca_list)}), "
-                f"identifiant des points de contestation."
-            )
-
-        # Formal logic
-        pl_out = context.get("phase_pl_output", {})
-        fol_out = context.get("phase_fol_output", {})
-        pl_formulas = (
-            len(pl_out.get("formulas", [])) if isinstance(pl_out, dict) else 0
-        )
-        fol_formulas = (
-            len(fol_out.get("formulas", [])) if isinstance(fol_out, dict) else 0
-        )
-        formal_total = pl_formulas + fol_formulas
-        if formal_total > 0:
-            parts.append(
-                f"L'analyse formelle a produit {formal_total} formule(s) "
-                f"({pl_formulas} PL, {fol_formulas} FOL)."
-            )
-
-        # Dung extensions
-        dung_out = context.get("phase_dung_extensions_output", {})
-        if isinstance(dung_out, dict):
-            dung_args = dung_out.get("arguments", [])
-            degraded_flag = dung_out.get("degraded", False)
-            if dung_args:
-                desc = (
-                    f"L'argumentation abstraite (Dung) a analyse {len(dung_args)} argument(s)"
-                )
-                if degraded_flag:
-                    desc += " en mode degrade (extension fondee uniquement)"
-                parts.append(desc + ".")
-
-        # JTMS beliefs
-        jtms_out = context.get("phase_jtms_output", {})
-        if isinstance(jtms_out, dict):
-            beliefs = jtms_out.get("beliefs", [])
-            if beliefs:
-                parts.append(
-                    f"Le systeme JTMS maintient {len(beliefs)} croyance(s)."
-                )
-
-        # Quality scores
-        quality_out = context.get("phase_argument_quality_output", {})
-        if isinstance(quality_out, dict):
-            per_arg = quality_out.get("per_argument_scores", {})
-            if per_arg:
-                scores = [
-                    v.get("note_finale", 0)
-                    for v in per_arg.values()
-                    if isinstance(v, dict)
-                ]
-                avg = sum(scores) / len(scores) if scores else 0
-                degraded_flag = any(
-                    v.get("degraded", False)
-                    for v in per_arg.values()
-                    if isinstance(v, dict)
-                )
-                q_desc = (
-                    f"L'evaluation de la qualite argumentative couvre "
-                    f"{len(per_arg)} argument(s), avec une note moyenne de "
-                    f"{avg:.1f}/9."
-                )
-                if degraded_flag:
-                    q_desc += " (mode degrade - heuristiques)"
-                parts.append(q_desc)
-
-        if parts:
-            narrative = " ".join(parts)
-            degraded = True
-            logger.info(
-                "Narrative synthesis rebuilt from context phase outputs "
-                "(state was empty/fallback). %d parts assembled.",
-                len(parts),
-            )
 
     paragraph_count = (narrative.count("\n\n") + 1) if narrative else 0
 
-    result = {
+    return {
         "narrative": narrative,
         "paragraph_count": paragraph_count,
         "referenced_fields": _count_referenced_fields(state),
     }
-    if degraded:
-        result["degraded"] = True
-        result["degraded_reason"] = "rebuilt from context (state-based narrative was empty)"
-    return result
 
 
 def _count_referenced_fields(state: Any) -> int:

--- a/argumentation_analysis/orchestration/workflow_dsl.py
+++ b/argumentation_analysis/orchestration/workflow_dsl.py
@@ -386,6 +386,7 @@ class WorkflowExecutor:
 
         if state is not None:
             ctx["unified_state"] = state
+            ctx["_state_object"] = state
 
         # Structured logging with correlation_id
         correlation_id = (

--- a/tests/unit/argumentation_analysis/orchestration/test_narrative_synthesis_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_narrative_synthesis_spectacular.py
@@ -102,50 +102,56 @@ class TestNarrativeSynthesisRegistration:
 
 
 class TestNarrativeSynthesisGracefulDegradation:
-    """Test narrative synthesis produces non-empty output from context (#994)."""
+    """Test narrative synthesis state resolution and fail-loud behavior (#1019)."""
 
     @pytest.mark.asyncio
-    async def test_narrative_from_context_when_state_empty(self):
-        """When state is empty, narrative rebuilds from context phase outputs."""
+    async def test_narrative_uses_state_object_from_context(self):
+        """When _state_object is in context, it is used directly (#1019)."""
+        from unittest.mock import patch, MagicMock
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_narrative_synthesis,
         )
 
-        context = {
-            "phase_extract_output": {
-                "arguments": [
-                    {"text": "Argument about national defense"},
-                    {"text": "Another argument about technology"},
-                ]
-            },
-            "phase_hierarchical_fallacy_output": {
-                "fallacies": [
-                    {"type": "Appel a l'autorite", "target_text": "Argument about defense"},
-                ]
-            },
-            "phase_counter_output": {
-                "llm_counter_arguments": [
-                    {"target_argument": "Argument about national defense", "counter_argument": "Counter 1"}
-                ]
-            },
-        }
+        mock_state = MagicMock()
+        valid_narrative = "L'analyse a detecte 3 sophisme(s)."
+        context = {"_state_object": mock_state}
 
-        result = await _invoke_narrative_synthesis("test text", context)
+        with patch(
+            "argumentation_analysis.plugins.narrative_synthesis_plugin.build_narrative",
+            return_value=valid_narrative,
+        ):
+            result = await _invoke_narrative_synthesis("test text", context)
 
-        # Must be non-empty
-        assert result["narrative"], f"Expected non-empty narrative, got: {result}"
-        # Should mention extracted args count
-        assert "2 argument(s)" in result["narrative"]
-        # Should mention fallacy
-        assert "1 sophisme(s)" in result["narrative"]
-        # Should mention counter-arguments
-        assert "contre-arguments" in result["narrative"].lower()
-        # Degraded flag
-        assert result.get("degraded") is True
+        assert result["narrative"] == valid_narrative
+        assert result.get("degraded") is not True
 
     @pytest.mark.asyncio
-    async def test_sentinel_triggers_context_rebuild(self):
-        """When build_narrative returns the fallback sentinel, context rebuild activates (#994)."""
+    async def test_narrative_uses_unified_state_fallback(self):
+        """When _state_object is absent but unified_state is present, use it (#1019)."""
+        from unittest.mock import patch, MagicMock
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_narrative_synthesis,
+        )
+
+        mock_state = MagicMock()
+        valid_narrative = "Analyse complete avec 5 arguments."
+        context = {"unified_state": mock_state}
+
+        with patch(
+            "argumentation_analysis.plugins.narrative_synthesis_plugin.build_narrative",
+            return_value=valid_narrative,
+        ):
+            result = await _invoke_narrative_synthesis("test text", context)
+
+        assert result["narrative"] == valid_narrative
+        assert result.get("degraded") is not True
+
+    @pytest.mark.asyncio
+    async def test_sentinel_no_template_rebuild(self):
+        """When build_narrative returns sentinel, no template rebuild occurs (#1019).
+
+        The sentinel is returned as-is — root cause must be fixed upstream.
+        """
         from unittest.mock import patch, MagicMock
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_narrative_synthesis,
@@ -164,18 +170,18 @@ class TestNarrativeSynthesisGracefulDegradation:
         }
         with patch(
             "argumentation_analysis.plugins.narrative_synthesis_plugin.build_narrative",
-            return_value=sentinel,
+            return_value=sentinel + ". Seules des donnees partielles sont disponibles.",
         ):
             result = await _invoke_narrative_synthesis("test text", context)
 
-        # Should have rebuilt from context
-        assert result["narrative"], f"Expected rebuilt narrative, got: {result}"
-        assert "2 argument(s)" in result["narrative"]
-        assert result.get("degraded") is True
+        # Sentinel should be returned as-is, NO template rebuild
+        assert sentinel in result["narrative"]
+        assert result.get("degraded") is not True
+        assert "degraded_reason" not in result
 
     @pytest.mark.asyncio
     async def test_non_degraded_path_no_rebuild(self):
-        """When build_narrative returns valid prose, no degraded flag is set (#994)."""
+        """When build_narrative returns valid prose, no degraded flag is set."""
         from unittest.mock import patch, MagicMock
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_narrative_synthesis,


### PR DESCRIPTION
## Problem (#1019 subsystem 2)

Narrative synthesis produced empty/fallback output because `build_narrative(state)` received an empty state. The root cause was a **key mismatch**: `WorkflowExecutor` wrote the state as `ctx["unified_state"]` but `_invoke_narrative_synthesis` looked for `ctx["_state_object"]`.

When the state was not found, a 100-line template-rebuild fallback (#994) assembled count-based prose from phase outputs — producing shallow output that flagged `degraded: True` (which no upstream consumer ever acted on = theater).

## Fix

### 1. State key fix (`workflow_dsl.py:388`)

Added `ctx["_state_object"] = state` alongside the existing `ctx["unified_state"] = state`. This is the single-line root cause fix — invoke callables now find the state.

### 2. Template rebuild removal (`invoke_callables.py`)

Removed the entire `if not narrative or _FALLBACK_SENTINEL in narrative:` template-rebuild block (100+ lines). Per #1019 mandate: no fallback, fail explicit. When `build_narrative()` returns the sentinel, it is returned as-is with a WARNING log showing available phase outputs and state fields for diagnosis.

### 3. Backward compatibility

`_invoke_narrative_synthesis` now checks both `_state_object` and `unified_state` (in that order), ensuring compatibility with both the pipeline path and any callers that use the old key.

## DoD checklist (#1019)

- [x] `degraded=True` retiré (plus de degraded flag dans le résultat)
- [x] Phase produit un résultat RÉEL (via state writers) ou retourne le sentinel explicitement
- [x] Aucun nouveau fallback introduit
- [x] 35/35 tests pass (narrative + workflow_dsl)

## Files changed

| File | Change | Lines |
|------|--------|-------|
| `workflow_dsl.py` | +1 line: add `_state_object` to context | +1 |
| `invoke_callables.py` | Remove template rebuild, add diagnostic logging | -85 net |
| `test_narrative_synthesis_spectacular.py` | Update tests for new behavior | ~86 |

## Impact on FB-8 dimensions

This fix primarily impacts **D5** (Historical Parallel) and **D10** (Negation as Method) — dimensions that were `MISSED` because narrative was producing template text instead of generative synthesis. With the state key fixed, `build_narrative()` will now receive populated state and produce real synthesis prose.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>