### PR TITLE
fix(orchestration): route formal types in _select_orchestrator (#885 follow-up)

### DIFF
--- a/argumentation_analysis/orchestration/service_manager.py
+++ b/argumentation_analysis/orchestration/service_manager.py
@@ -587,6 +587,10 @@ class OrchestrationServiceManager:
             "comprehensive": self.fact_checking_orchestrator,
             "fallacy_analysis": self.fact_checking_orchestrator,
             "rhetorical": self.fact_checking_orchestrator,
+            # Formal analysis types — routed via fact_checking since #885
+            "logical": self.fact_checking_orchestrator,
+            "modal": self.fact_checking_orchestrator,
+            "propositional": self.fact_checking_orchestrator,
         }
 
         result = orchestrator_map.get(analysis_type.lower())

--- a/tests/unit/argumentation_analysis/orchestration/test_service_manager.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_service_manager.py
@@ -858,25 +858,34 @@ class TestSelectOrchestrator:
         )
 
     def test_logical_type(self, manager):
-        assert manager._select_orchestrator("logical") is manager.llm_orchestrator
+        # Routed to fact_checking since RealLLMOrchestrator removal (#885)
+        assert (
+            manager._select_orchestrator("logical")
+            is manager.fact_checking_orchestrator
+        )
 
     def test_modal_type(self, manager):
-        assert manager._select_orchestrator("modal") is manager.llm_orchestrator
+        assert (
+            manager._select_orchestrator("modal")
+            is manager.fact_checking_orchestrator
+        )
 
     def test_propositional_type(self, manager):
-        assert manager._select_orchestrator("propositional") is manager.llm_orchestrator
+        assert (
+            manager._select_orchestrator("propositional")
+            is manager.fact_checking_orchestrator
+        )
 
-    def test_unknown_type_defaults_to_llm(self, manager):
-        assert manager._select_orchestrator("unknown_xyz") is manager.llm_orchestrator
+    def test_unknown_type_returns_none(self, manager):
+        # Unknown types return None (no fallback to removed RealLLMOrchestrator)
+        assert manager._select_orchestrator("unknown_xyz") is None
 
     def test_case_insensitive(self, manager):
         assert manager._select_orchestrator("CLUEDO") is manager.cluedo_orchestrator
 
-    def test_unified_analysis_defaults_to_llm(self, manager):
-        # "unified_analysis" is not in the map, so defaults to llm_orchestrator
-        assert (
-            manager._select_orchestrator("unified_analysis") is manager.llm_orchestrator
-        )
+    def test_unified_analysis_returns_none(self, manager):
+        # "unified_analysis" is not in the map, returns None (no fallback)
+        assert manager._select_orchestrator("unified_analysis") is None
 
 
 # ========================================================================


### PR DESCRIPTION
## Summary

Follow-up to #885 (RealLLMOrchestrator removal). Three formal analysis types (`logical`, `modal`, `propositional`) were left unmapped in `_select_orchestrator()`, causing the method to return `None` and silently fall through to `_run_hierarchical_analysis` instead of routing to the fact-checking orchestrator.

## Changes

| File | Change |
|------|--------|
| `service_manager.py` | Add `logical`/`modal`/`propositional` → `fact_checking_orchestrator` routing |
| `test_service_manager.py` | Update 5 tests: formal types → `fact_checking_orchestrator`, unknown types → `None` |

## Test Results

- `TestSelectOrchestrator`: **15/15 PASS** (was 14/15 before fix)
- Pre-existing `test_analyze_text_interface` failure unchanged (async MagicMock issue, not related)
- Full suite: 105/106 pass (1 pre-existing)

## Cleanup Gate

| File | Type | Last useful date | Reason |
|------|------|-----------------|--------|
| None deleted | — | — | Behavior fix only |

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>