### PR TITLE
fix(scoring): add 'type' field to scorer + alias 'appel au nombre'→'ad_populum' (#1033)

### DIFF
--- a/scripts/run_benchmark_fb8.py
+++ b/scripts/run_benchmark_fb8.py
@@ -304,6 +304,7 @@ FALLACY_FR_EN_ALIASES: Dict[str, str] = {
     # Obstruction family
     "ad populum": "ad_populum",
     "raison de la majorité": "ad_populum",
+    "appel au nombre": "ad_populum",
     "appel à la bande": "bandwagon_fallacy",
     "atteinte personnelle": "ad_hominem",
     # Misleading language family
@@ -345,8 +346,9 @@ def score_against_yardstick(pipeline_output: Dict[str, Any]) -> Dict[str, Any]:
     if isinstance(fallacies, dict):
         for _fid, fdata in fallacies.items():
             if isinstance(fdata, dict):
-                # Collect both family and fallacy_type, normalize each
-                for field in ("family", "fallacy_type"):
+                # Collect family, fallacy_type, and type fields, normalize each
+                # Note: pipeline stores fallacies with "type" field (not "family"/"fallacy_type")
+                for field in ("family", "fallacy_type", "type"):
                     raw = fdata.get(field, "")
                     if raw:
                         fallacy_types.add(_normalize_fallacy_type(raw))
@@ -363,7 +365,7 @@ def score_against_yardstick(pipeline_output: Dict[str, Any]) -> Dict[str, Any]:
     elif isinstance(fallacies, list):
         for f in fallacies:
             if isinstance(f, dict):
-                ft = f.get("family", f.get("fallacy_type", "")).lower()
+                ft = f.get("type", f.get("family", f.get("fallacy_type", ""))).lower()
                 fallacy_types.add(ft)
 
     args = phases.get("arguments", {})


### PR DESCRIPTION
@
## Problem

The benchmark scorer `run_benchmark_fb8.py:348-349` iterated over `("family", "fallacy_type")` to extract detected fallacies — but the pipeline stores them with key `"type"`. Result: **every detected fallacy was invisible to the scorer**, producing systematic false-negatives.

Additionally, `"appel au nombre"` (appeal to numbers/popularity) is semantically `ad_populum` but was missing from `FALLACY_FR_EN_ALIASES`.

## Fix (minimal, anti-pendule)

- Added `"type"` to the field tuple alongside `"family"` and `"fallacy_type"` (read-all-with-fallback, not scorer tuning)
- Added alias `"appel au nombre" → "ad_populum"` in the FR/EN alias table

## Impact

Re-scoring the corpus_X benchmark data with the fixed scorer:
- **D3 Populist**: MISSED → **MATCH** (+1)
- MATCH/10: 2 → **3**
- D6/D7 remain TRUE detection gaps (not instrument issues)

## Files changed
- `scripts/run_benchmark_fb8.py`: +5 lines (field tuple + alias entry)

Closes #1033 (instrument fix portion)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
@