### PR TITLE
fix(orchestration): wire DelegatingSelectionStrategy into SK-native AgentGroupChat (#1051)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -151,6 +151,12 @@ def _detect_language(text: str) -> str:
 # See ARCHEOLOGIE_ORCHESTRATION.md section 3 for rationale.
 # ---------------------------------------------------------------------------
 
+# NOTE (RA-6 #1051): The inline "ProjectManager" ChatCompletionAgent defined below
+# is the CANONICAL PM for the conversational path. It uses StateManagerPlugin's
+# designate_next_agent() kernel function, which writes to state._next_agent_designated.
+# DelegatingSelectionStrategy (wired in _run_phase) reads that field to honour PM
+# designation. The separate ProjectManagerAgent in agents/core/pm/pm_agent.py serves
+# a different entry point (enhanced_pm_analysis_runner.py) and is NOT used here.
 AGENT_CONFIG = {
     "ProjectManager": {
         "speciality": "project_manager",
@@ -1365,7 +1371,29 @@ async def _run_phase(
             AgentGroupChat,
         )
 
-        chat = AgentGroupChat(agents=agents)
+        # RA-6 #1051: Wire DelegatingSelectionStrategy so PM designation
+        # (state._next_agent_designated set via designate_next_agent) is actually
+        # consumed by the SK-native AgentGroupChat. Without this, the PM "directs
+        # into the void" — designation is written but never read on this path.
+        selection = None
+        if state is not None and hasattr(state, "consume_next_agent_designation"):
+            try:
+                from argumentation_analysis.core.strategies import (
+                    DelegatingSelectionStrategy,
+                )
+
+                selection = DelegatingSelectionStrategy(
+                    agents=agents, state=state
+                )
+            except (ImportError, TypeError, ValueError):
+                logger.warning(
+                    "DelegatingSelectionStrategy unavailable, using SK default selection"
+                )
+
+        chat = AgentGroupChat(
+            agents=agents,
+            selection_strategy=selection,
+        )
         # Add initial prompt to the group chat
         await chat.add_chat_message(
             chat_history.messages[-1] if chat_history.messages else initial_prompt

--- a/tests/unit/argumentation_analysis/test_ra6_pm_designation.py
+++ b/tests/unit/argumentation_analysis/test_ra6_pm_designation.py
@@ -1,0 +1,210 @@
+"""
+RA-6 #1051 — Regression test: PM designation is consumed on the SK-native path.
+
+The conversational orchestrator's _run_phase() creates an AgentGroupChat with
+a DelegatingSelectionStrategy that reads state.consume_next_agent_designation().
+This test verifies:
+
+1. DelegatingSelectionStrategy honours PM designation (core unit test)
+2. The wiring in _run_phase actually passes selection_strategy to AgentGroupChat
+3. PM designation is consumed (not left dangling) after selection
+
+These tests run WITHOUT API keys (mock agents, real state).
+"""
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestDelegatingSelectionHonoursPM:
+    """Core: DelegatingSelectionStrategy consumes PM designation."""
+
+    @pytest.fixture
+    def strategy_components(self):
+        try:
+            from argumentation_analysis.core.strategies import (
+                DelegatingSelectionStrategy,
+            )
+            from argumentation_analysis.core.shared_state import (
+                RhetoricalAnalysisState,
+            )
+        except ImportError:
+            pytest.skip("DelegatingSelectionStrategy or RhetoricalAnalysisState not importable")
+
+        state = RhetoricalAnalysisState("Texte de test pour l'analyse rhétorique.")
+
+        pm = MagicMock()
+        pm.name = "ProjectManager"
+
+        extract = MagicMock()
+        extract.name = "ExtractAgent"
+
+        informal = MagicMock()
+        informal.name = "InformalAnalysisAgent"
+
+        agents = [pm, extract, informal]
+        strategy = DelegatingSelectionStrategy(agents, state)
+        return state, strategy, agents, pm, extract, informal
+
+    def test_designation_consumed_by_strategy(self, strategy_components):
+        """PM designates ExtractAgent → strategy returns ExtractAgent → designation consumed."""
+        state, strategy, agents, pm, extract, _ = strategy_components
+
+        # PM designates ExtractAgent
+        state.designate_next_agent("ExtractAgent")
+        assert state._next_agent_designated == "ExtractAgent"
+
+        # Strategy reads and consumes the designation
+        selected = asyncio.run(strategy.next(agents, []))
+        assert selected == extract, f"Expected ExtractAgent, got {selected.name}"
+
+        # Designation consumed (no leak to next turn)
+        assert state.consume_next_agent_designation() is None
+
+    def test_no_designation_falls_to_default(self, strategy_components):
+        """Without designation, strategy returns the default PM agent."""
+        state, strategy, agents, pm, _, _ = strategy_components
+
+        # No designation set
+        assert state._next_agent_designated is None
+
+        selected = asyncio.run(strategy.next(agents, []))
+        assert selected == pm, f"Expected PM, got {selected.name}"
+
+    def test_designation_consumed_after_single_read(self, strategy_components):
+        """After one selection, the designation is cleared (no double-read)."""
+        state, strategy, agents, pm, extract, _ = strategy_components
+
+        state.designate_next_agent("ExtractAgent")
+
+        # First read: returns ExtractAgent
+        first = asyncio.run(strategy.next(agents, []))
+        assert first == extract
+
+        # Second read: designation consumed, returns PM default
+        second = asyncio.run(strategy.next(agents, []))
+        assert second == pm
+
+
+class TestRunPhaseWiring:
+    """Verify _run_phase wires DelegatingSelectionStrategy into AgentGroupChat."""
+
+    def test_run_phase_creates_strategy_when_state_available(self):
+        """_run_phase should pass selection_strategy to AgentGroupChat when state is available."""
+        try:
+            from argumentation_analysis.core.shared_state import (
+                RhetoricalAnalysisState,
+            )
+        except ImportError:
+            pytest.skip("RhetoricalAnalysisState not importable")
+
+        state = RhetoricalAnalysisState("Test text")
+        pm = MagicMock()
+        pm.name = "ProjectManager"
+        extract = MagicMock()
+        extract.name = "ExtractAgent"
+        agents = [pm, extract]
+
+        captured_strategy = None
+
+        async def mock_add_chat_message(msg):
+            pass
+
+        async def mock_invoke():
+            return
+            yield  # Make it an async generator
+
+        class MockAgentGroupChat:
+            def __init__(self, *args, **kwargs):
+                nonlocal captured_strategy
+                captured_strategy = kwargs.get("selection_strategy")
+                self.agents = args[0] if args else kwargs.get("agents", [])
+
+            async def add_chat_message(self, msg):
+                pass
+
+            async def invoke(self):
+                return
+                yield
+
+        # Patch the import that _run_phase uses: it does
+        #   from semantic_kernel.agents.group_chat.agent_group_chat import AgentGroupChat
+        with patch(
+            "semantic_kernel.agents.group_chat.agent_group_chat.AgentGroupChat",
+            MockAgentGroupChat,
+        ):
+            try:
+                asyncio.run(self._call_run_phase(agents, state))
+            except Exception:
+                pass  # We only care about the strategy being passed
+
+        # Verify strategy was captured and is correct type
+        if captured_strategy is not None:
+            from argumentation_analysis.core.strategies import (
+                DelegatingSelectionStrategy,
+            )
+
+            assert isinstance(
+                captured_strategy, DelegatingSelectionStrategy
+            ), f"Expected DelegatingSelectionStrategy, got {type(captured_strategy)}"
+        else:
+            pytest.fail("selection_strategy was not passed to AgentGroupChat")
+
+    async def _call_run_phase(self, agents, state):
+        """Helper to call _run_phase with minimal args."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_phase,
+        )
+
+        return await _run_phase(
+            agents=agents,
+            initial_prompt="Test prompt",
+            max_turns=1,
+            phase_name="test",
+            state=state,
+            enable_growth_validation=False,
+        )
+
+
+class TestDesignationIntegration:
+    """Integration: state → designation → strategy → correct agent selected."""
+
+    def test_full_designation_round_trip(self):
+        """Simulate a complete PM designation round-trip with real state."""
+        try:
+            from argumentation_analysis.core.strategies import (
+                DelegatingSelectionStrategy,
+            )
+            from argumentation_analysis.core.shared_state import (
+                RhetoricalAnalysisState,
+            )
+        except ImportError:
+            pytest.skip("Required classes not importable")
+
+        state = RhetoricalAnalysisState("Le texte source de l'analyse.")
+
+        agents = [MagicMock(name=f"Agent{i}") for i in range(4)]
+        agents[0].name = "ProjectManager"
+        agents[1].name = "ExtractAgent"
+        agents[2].name = "InformalAnalysisAgent"
+        agents[3].name = "SherlockEnqueteAgent"
+
+        strategy = DelegatingSelectionStrategy(agents, state)
+
+        # Turn 1: PM designates InformalAnalysisAgent
+        state.designate_next_agent("InformalAnalysisAgent")
+        selected = asyncio.run(strategy.next(agents, []))
+        assert selected.name == "InformalAnalysisAgent"
+        assert state._next_agent_designated is None  # consumed
+
+        # Turn 2: PM designates SherlockEnqueteAgent
+        state.designate_next_agent("SherlockEnqueteAgent")
+        selected = asyncio.run(strategy.next(agents, []))
+        assert selected.name == "SherlockEnqueteAgent"
+        assert state._next_agent_designated is None  # consumed
+
+        # Turn 3: No designation → PM default
+        selected = asyncio.run(strategy.next(agents, []))
+        assert selected.name == "ProjectManager"


### PR DESCRIPTION
## RA-6 #1051 — PM designation is a no-op on the SK-native conversational path

### Problem

The PM calls \designate_next_agent()\ via StateManagerPlugin — state IS modified — but on the primary SK-native path, \AgentGroupChat(agents=agents)\ was instantiated **without** \selection_strategy\. SK's internal round-robin never reads \_next_agent_designated\. Net effect: PM directs into the void.

### Fix

1. **Wire DelegatingSelectionStrategy** into _run_phase's AgentGroupChat instantiation
2. **Document inline PM** as canonical for conversational path
3. **5 regression tests** proving designation is consumed

### Test Results

5 passed (test_ra6_pm_designation.py)
18 passed (test_strategies.py — no regression)

### Anti-pendule

- Round-robin fallback path preserved
- No changes to pm_agent.py or enhanced_pm_analysis_runner.py

Closes #1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)