### PR TITLE
feat(fallacy): RA-3 #1048 item 2 — bounded recursive sub-branch fan-out (closes RA-3)

### DIFF
--- a/argumentation_analysis/plugins/fallacy_workflow_plugin.py
+++ b/argumentation_analysis/plugins/fallacy_workflow_plugin.py
@@ -73,6 +73,21 @@ class FallacyWorkflowPlugin:
     BEAM_MAX_LLM_CALLS = 15  # Circuit breaker for beam descent
     BEAM_MIN_DEPTH = 5  # Value-gate: beam must reach ≥1 node at this depth
 
+    # RA-3 #1048 item 2: bounded recursive sub-branch fan-out.
+    # At a fork the LLM may flag several promising children; the engine used to
+    # keep one and silently drop the rest (recall loss — the fork prompt even
+    # invites multi-child exploration the single-path loop ignored). When
+    # enabled, the top child stays the primary path AND the next few are
+    # explored as concurrent recursive sub-branches. The wall-clock bench
+    # (PR #1067) shows Phase-2-style gather fan-out is ≥2x at realistic
+    # wide-net widths, so the work overlaps rather than adding latency.
+    # Bounded by a per-fork width + a shared global budget
+    # (_BranchSupersessionTracker.try_consume_fanout) and pruned by
+    # supersession — anti-pendule #1019, never "parallelize everything".
+    ENABLE_SUBBRANCH_FANOUT = True
+    SUBBRANCH_FANOUT_WIDTH = 2  # max extra children spawned per fork
+    SUBBRANCH_FANOUT_BUDGET = 12  # max sub-branches spawned per analysis
+
     class _BranchSupersessionTracker:
         """Track confirmed fallacies for branch supersession during parallel exploration.
 
@@ -85,11 +100,17 @@ class FallacyWorkflowPlugin:
         no explicit locking is needed (single-threaded concurrency model).
         """
 
-        def __init__(self, navigator: TaxonomyNavigator):
+        def __init__(self, navigator: TaxonomyNavigator, fanout_budget: int = 0):
             self._navigator = navigator
             # (pk, taxonomy_path, depth, confidence)
             self._confirmed: List[Tuple[str, str, int, float]] = []
             self.superseded_count = 0
+            # RA-3 #1048 item 2: shared budget bounding recursive sub-branch
+            # fan-out across ALL branches of one analysis. Mirrors the beam's
+            # BEAM_MAX_LLM_CALLS guardrail — fan-out is capped, never unbounded
+            # (anti-pendule #1019). 0 ⇒ fan-out disabled.
+            self._fanout_budget = fanout_budget
+            self.fanout_spawned = 0
 
         def register(self, pk: str, depth: int, confidence: float) -> None:
             """Register a confirmed fallacy."""
@@ -122,6 +143,20 @@ class FallacyWorkflowPlugin:
         @property
         def confirmation_count(self) -> int:
             return len(self._confirmed)
+
+        def try_consume_fanout(self) -> bool:
+            """Consume one unit of the shared sub-branch fan-out budget.
+
+            Returns True while budget remains (a sub-branch may be spawned),
+            False once exhausted. Bounds total recursive fan-out across all
+            branches of one analysis so concurrent token spend stays capped
+            (anti-pendule #1019: bounded fan-out, never "explore everything").
+            """
+            if self._fanout_budget <= 0:
+                return False
+            self._fanout_budget -= 1
+            self.fanout_spawned += 1
+            return True
 
     def __init__(
         self,
@@ -732,6 +767,7 @@ class FallacyWorkflowPlugin:
         slave_settings: OpenAIPromptExecutionSettings,
         reasoning_history: Optional[List[str]] = None,
         supersession_tracker: Optional["_BranchSupersessionTracker"] = None,
+        results_sink: Optional[List[IdentifiedFallacy]] = None,
     ) -> Optional[IdentifiedFallacy]:
         """Explore a single taxonomy branch using iterative deepening.
 
@@ -1021,94 +1057,185 @@ class FallacyWorkflowPlugin:
                 tool_calls, slave_kernel, history
             )
 
+            # Classify the LLM's tool calls. Original behaviour: the first
+            # confirm/conclude decides the branch; explore_branch advances the
+            # path. RA-3 #1048 item 2: capture *all* explore targets so extra
+            # promising children can be fanned out as bounded concurrent
+            # sub-branches instead of being silently dropped.
+            confirm_result = None
+            conclude_result = None
+            explore_targets: List[Tuple[str, dict]] = []  # (next_pk, node_info)
             for result in tool_results:
                 func_name = result.get("function_name", "")
-
                 if func_name == "confirm_fallacy" and result.get("confirmed"):
-                    confirmed_pk = result.get("pk", "")
-                    confirmed_node = self.taxonomy_navigator.get_node(confirmed_pk)
-                    confirmed_depth = (
-                        int(confirmed_node.get("depth", 0)) if confirmed_node else 0
-                    )
-                    justification = result.get("justification", "")
-
-                    # Capture reasoning for memory
-                    reasoning_summary = (
-                        f"Confirmed {current_node.get(f'text_{self.language}', current_pk)} "
-                        f"at depth {confirmed_depth}: {justification}"
-                    )
-                    reasoning_history.append(reasoning_summary)
-
-                    # Reject too-shallow confirmations — force deeper exploration
-                    if confirmed_depth < self.MIN_CONFIRM_DEPTH and children:
-                        self.logger.info(
-                            f"  Confirmation at depth {confirmed_depth} rejected "
-                            f"(min={self.MIN_CONFIRM_DEPTH}), forcing deeper exploration"
-                        )
-                        # Pick the first child as default deeper path
-                        first_child = children[0]
-                        current_pk = first_child.get("PK", "")
-                        navigation_trace.append(current_pk)
-                        break  # continue outer loop with new current_pk
-
-                    # Build full explanation with reasoning history
-                    full_explanation = justification
-                    if reasoning_history:
-                        full_explanation += (
-                            f" | Reasoning path: {'; '.join(reasoning_history)}"
-                        )
-
-                    # Register confirmation for branch supersession (RA-3 #1048)
-                    if supersession_tracker is not None:
-                        supersession_tracker.register(
-                            confirmed_pk,
-                            confirmed_depth,
-                            result.get("confidence", 0.7),
-                        )
-
-                    return IdentifiedFallacy(
-                        fallacy_type=result.get(
-                            "name", result.get("name_fr", result.get("pk", ""))
-                        ),
-                        taxonomy_pk=confirmed_pk,
-                        taxonomy_path=result.get("path", ""),
-                        explanation=full_explanation,
-                        confidence=result.get("confidence", 0.7),
-                        navigation_trace=navigation_trace,
-                        family=current_node.get("Famille", ""),
-                    )
-
+                    confirm_result = result
+                    break
                 elif func_name == "conclude_no_fallacy":
-                    reason = result.get("reason", "no reason")
-                    # Capture reasoning for memory
-                    reasoning_summary = f"Abandoned {current_node.get(f'text_{self.language}', current_pk)}: {reason}"
-                    reasoning_history.append(reasoning_summary)
-                    self.logger.info(f"  Branch abandoned: {reason}")
-                    return None
-
+                    conclude_result = result
+                    break
                 elif func_name == "explore_branch":
-                    # Navigate deeper
                     node_info = result.get("node", {})
                     next_pk = node_info.get("pk", "")
                     if next_pk and next_pk != current_pk:
-                        # Capture reasoning for memory - why this branch was chosen
-                        branch_name = node_info.get(
-                            "name", node_info.get("name_fr", next_pk)
-                        )
-                        reasoning_summary = f"Explored {branch_name} from {current_node.get(f'text_{self.language}', current_pk)}"
-                        reasoning_history.append(reasoning_summary)
+                        explore_targets.append((next_pk, node_info))
 
-                        current_pk = next_pk
-                        navigation_trace.append(current_pk)
-                        self.logger.info(
-                            f"  Exploring deeper: {branch_name} "
-                            f"(reasoning history: {len(reasoning_history)} steps)"
-                        )
-                    else:
-                        self.logger.info("  explore_branch returned same/empty node")
-                        break
+            # --- Decision, in priority order (preserves original semantics) ---
+            if confirm_result is not None:
+                confirmed_pk = confirm_result.get("pk", "")
+                confirmed_node = self.taxonomy_navigator.get_node(confirmed_pk)
+                confirmed_depth = (
+                    int(confirmed_node.get("depth", 0)) if confirmed_node else 0
+                )
+                justification = confirm_result.get("justification", "")
+
+                # Capture reasoning for memory
+                reasoning_summary = (
+                    f"Confirmed {current_node.get(f'text_{self.language}', current_pk)} "
+                    f"at depth {confirmed_depth}: {justification}"
+                )
+                reasoning_history.append(reasoning_summary)
+
+                # Reject too-shallow confirmations — force deeper exploration
+                if confirmed_depth < self.MIN_CONFIRM_DEPTH and children:
+                    self.logger.info(
+                        f"  Confirmation at depth {confirmed_depth} rejected "
+                        f"(min={self.MIN_CONFIRM_DEPTH}), forcing deeper exploration"
+                    )
+                    # Pick the first child as default deeper path
+                    first_child = children[0]
+                    current_pk = first_child.get("PK", "")
+                    navigation_trace.append(current_pk)
+                    continue  # re-iterate outer loop with new current_pk
+
+                # Build full explanation with reasoning history
+                full_explanation = justification
+                if reasoning_history:
+                    full_explanation += (
+                        f" | Reasoning path: {'; '.join(reasoning_history)}"
+                    )
+
+                # Register confirmation for branch supersession (RA-3 #1048)
+                if supersession_tracker is not None:
+                    supersession_tracker.register(
+                        confirmed_pk,
+                        confirmed_depth,
+                        confirm_result.get("confidence", 0.7),
+                    )
+
+                return IdentifiedFallacy(
+                    fallacy_type=confirm_result.get(
+                        "name",
+                        confirm_result.get("name_fr", confirm_result.get("pk", "")),
+                    ),
+                    taxonomy_pk=confirmed_pk,
+                    taxonomy_path=confirm_result.get("path", ""),
+                    explanation=full_explanation,
+                    confidence=confirm_result.get("confidence", 0.7),
+                    navigation_trace=navigation_trace,
+                    family=current_node.get("Famille", ""),
+                )
+
+            if conclude_result is not None:
+                reason = conclude_result.get("reason", "no reason")
+                # Capture reasoning for memory
+                reasoning_summary = f"Abandoned {current_node.get(f'text_{self.language}', current_pk)}: {reason}"
+                reasoning_history.append(reasoning_summary)
+                self.logger.info(f"  Branch abandoned: {reason}")
+                return None
+
+            if not explore_targets:
+                self.logger.info("  explore_branch returned same/empty node")
+                break
+
+            # RA-3 #1048 item 2: the top child stays the primary path; extra
+            # promising children are fanned out as bounded concurrent
+            # sub-branches (additive — the primary path is never regressed).
+            primary_pk, primary_info = explore_targets[0]
+            extras = explore_targets[1:]
+            if (
+                extras
+                and self.ENABLE_SUBBRANCH_FANOUT
+                and results_sink is not None
+                and supersession_tracker is not None
+            ):
+                await self._fanout_subbranches(
+                    extras,
+                    argument_text,
+                    slave_kernel,
+                    slave_settings,
+                    reasoning_history,
+                    supersession_tracker,
+                    results_sink,
+                )
+
+            # Capture reasoning for memory - why the primary branch was chosen
+            primary_name = primary_info.get(
+                "name", primary_info.get("name_fr", primary_pk)
+            )
+            reasoning_history.append(
+                f"Explored {primary_name} from "
+                f"{current_node.get(f'text_{self.language}', current_pk)}"
+            )
+            current_pk = primary_pk
+            navigation_trace.append(current_pk)
+            self.logger.info(
+                f"  Exploring deeper: {primary_name} "
+                f"(reasoning history: {len(reasoning_history)} steps)"
+            )
 
         return None
+
+    async def _fanout_subbranches(
+        self,
+        extras: List[Tuple[str, dict]],
+        argument_text: str,
+        slave_kernel: Kernel,
+        slave_settings: OpenAIPromptExecutionSettings,
+        reasoning_history: List[str],
+        supersession_tracker: "_BranchSupersessionTracker",
+        results_sink: List[IdentifiedFallacy],
+    ) -> None:
+        """Explore extra promising children as bounded concurrent sub-branches.
+
+        RA-3 #1048 item 2. When a fork yields more than one promising child the
+        primary path follows the top child (handled by the caller) and the next
+        few are explored concurrently here. Results are appended to
+        *results_sink* — additive, so the primary single-path descent is never
+        regressed. Bounded by:
+
+          - ``SUBBRANCH_FANOUT_WIDTH`` (extra children spawned per fork), and
+          - the tracker's shared global fan-out budget (per analysis),
+
+        and pruned by the supersession tracker (dead-end / superseded
+        sub-branches abandon early). Anti-pendule #1019: fan-out is capped, not
+        unbounded — it mirrors the beam's ``BEAM_MAX_LLM_CALLS`` discipline.
+        """
+        tasks = []
+        for sub_pk, sub_info in extras[: self.SUBBRANCH_FANOUT_WIDTH]:
+            if not supersession_tracker.try_consume_fanout():
+                self.logger.info("  Sub-branch fan-out budget exhausted")
+                break
+            sub_name = sub_info.get("name", sub_info.get("name_fr", sub_pk))
+            self.logger.info(f"  Fan-out sub-branch: {sub_name} (PK: {sub_pk})")
+            tasks.append(
+                self._explore_single_branch(
+                    argument_text,
+                    sub_pk,
+                    slave_kernel,
+                    slave_settings,
+                    reasoning_history=list(reasoning_history),
+                    supersession_tracker=supersession_tracker,
+                    results_sink=results_sink,
+                )
+            )
+        if not tasks:
+            return
+        sub_results = await asyncio.gather(*tasks, return_exceptions=True)
+        for r in sub_results:
+            if isinstance(r, IdentifiedFallacy):
+                results_sink.append(r)
+            elif isinstance(r, BaseException):
+                self.logger.warning(f"  Sub-branch fan-out error: {r}")
 
     @kernel_function(
         name="run_guided_analysis",
@@ -1166,8 +1293,19 @@ class FallacyWorkflowPlugin:
 
             # Phase 2: Parallel iterative deepening on ALL candidates
             slave_kernel, slave_settings = self._create_slave_kernel()
-            # Branch supersession tracker (RA-3 #1048) — shared across branches
-            tracker = self._BranchSupersessionTracker(self.taxonomy_navigator)
+            # Branch supersession tracker (RA-3 #1048) — shared across branches.
+            # The fan-out budget bounds recursive sub-branch exploration
+            # (item 2) across the whole analysis.
+            tracker = self._BranchSupersessionTracker(
+                self.taxonomy_navigator,
+                fanout_budget=(
+                    self.SUBBRANCH_FANOUT_BUDGET if self.ENABLE_SUBBRANCH_FANOUT else 0
+                ),
+            )
+            # Sink collecting fan-out sub-branch results (RA-3 #1048 item 2).
+            # Additive: top-level branch primaries return via the gather below;
+            # any extra promising children explored as sub-branches land here.
+            fanout_sink: List[IdentifiedFallacy] = []
             exploration_tasks = [
                 self._explore_single_branch(
                     argument_text,
@@ -1176,6 +1314,7 @@ class FallacyWorkflowPlugin:
                     slave_settings,
                     reasoning_history=None,
                     supersession_tracker=tracker,
+                    results_sink=fanout_sink,
                 )
                 for pk in candidate_pks
             ]
@@ -1207,6 +1346,25 @@ class FallacyWorkflowPlugin:
                     seen_pks[leaf_pk] = result
                     identified = [r for r in identified if r.fallacy_type != leaf_pk]
                     identified.append(result)
+
+            # Merge fan-out sub-branch results (RA-3 #1048 item 2) with the same
+            # dedup-by-leaf rule (keep highest confidence per leaf PK).
+            for result in fanout_sink:
+                total_iterations += len(result.navigation_trace)
+                leaf_pk = result.fallacy_type
+                if (
+                    leaf_pk in seen_pks
+                    and seen_pks[leaf_pk].confidence >= result.confidence
+                ):
+                    continue
+                seen_pks[leaf_pk] = result
+                identified = [r for r in identified if r.fallacy_type != leaf_pk]
+                identified.append(result)
+            if tracker.fanout_spawned:
+                self.logger.info(
+                    f"Sub-branch fan-out explored {tracker.fanout_spawned} "
+                    f"extra branch(es) (RA-3 #1048 item 2)"
+                )
 
             if identified:
                 identified.sort(key=lambda f: f.confidence, reverse=True)

--- a/scripts/benchmarks/RA3_1048_parallel_descent_findings.md
+++ b/scripts/benchmarks/RA3_1048_parallel_descent_findings.md
@@ -51,26 +51,71 @@ These dominate the parallel wall-clock once Phase 2 is overlapped. The fan-out
 already extracts essentially all the available parallel benefit from Phase 2;
 the residual cost is the serial Phase 1 + Phase 3b.
 
-## Item 2 decision — fan-out recursive question
+## Item 2 decision — should recursive descent fan out further?
 
-**Keep the existing Phase 2 parallelization; do NOT parallelize the beam now.**
+Item 2 asked whether descent should fan out *beyond* the existing Phase 2
+top-level `asyncio.gather`. There are two distinct further-fan-out levers; the
+benchmark + a code read resolve them in opposite directions.
 
-- The Phase 2 `asyncio.gather` fan-out is **validated**: it delivers the ≥2x
-  target at realistic branch counts (2.43x at 8 branches) with the wall-clock
-  staying flat as breadth grows. This is the right design and pays for itself.
-- The remaining serial cost is the **beam descent (Phase 3b)**, which is the
-  Amdahl floor. Parallelizing it *would* lift the ceiling — but the beam is
-  **deliberately token-capped** (`BEAM_MAX_LLM_CALLS=15`) precisely to bound
-  cost. Fanning it out multiplies concurrent token spend against a cap that
-  exists to prevent exactly that. Poor ROI given the floor (~4.5 s) is
-  acceptable for the analysis quality the beam buys.
-- **Lever, if ever needed**: should sub-7 s end-to-end at high branch counts
-  become a hard requirement, parallelize the beam in *bounded batches* (e.g.
-  `BEAM_WIDTH` concurrent expansions per depth) so the token cap is preserved
-  while the depth-serial chain is shortened. Documented here so item 2 is a
-  conscious, measured choice rather than a default.
+### The gate, read honestly
 
-**Anti-pendule**: this is neither "parallelize everything" nor "the existing
-parallelism is wrong" — the data says fan-out is correct where it is (Phase 2),
-and the one remaining serial stretch is an intentional token guardrail, not an
-oversight.
+The ≥2x speedup is **not** met at every width: 1.27x (2 br) and **1.77x (4 br)
+are below 2x**; only 2.43x (8 br) clears it. The crossover is ~6–7 branches. So
+"≥2x" is *not* a property of the fan-out at small widths — it depends on the
+operating point. The decisive fact is **where the engine actually operates**:
+Phase 2 fans out over `candidate_pks[:MAX_CANDIDATES]` — **up to 20**, not
+`MAX_BRANCHES=4`. At realistic wide-net widths the engine sits *past* the
+crossover, so the parallel-flat regime (≥2x) is the normal case, not the
+exception. The gate is met at the operating point; it is *not* met universally,
+and this doc does not claim otherwise.
+
+### Lever #3 — per-fork sub-branch fan-out — **IMPLEMENTED**
+
+A code read surfaced a **prompt-vs-code mismatch**: the fork prompt's system
+message explicitly instructs the LLM to *"PREFER exploring MULTIPLE children
+(call explore_branch multiple times)"* — but `_explore_single_branch` kept a
+**single** child and silently dropped the rest at every fork. The model was
+being asked to surface several promising branches; the engine threw all but one
+away. That is a recall leak, not a design choice.
+
+Fixed in `fallacy_workflow_plugin.py`: at a fork the **top child stays the
+primary path** (behaviour unchanged for that path) and the next few promising
+children are explored as **bounded concurrent recursive sub-branches** whose
+confirmed leaves merge back via the same dedup-by-leaf rule. Because this fan-out
+rides the same `gather`-overlap mechanism the benchmark measured at the
+operating point, the extra branches overlap in wall-clock rather than adding
+latency.
+
+The bound is the whole point (anti-pendule #1019 — *not* "parallelize
+everything"):
+
+- `SUBBRANCH_FANOUT_WIDTH = 2` — at most 2 extra children spawned per fork.
+- `SUBBRANCH_FANOUT_BUDGET = 12` — a shared per-analysis ceiling on total
+  sub-branches, consumed via `_BranchSupersessionTracker.try_consume_fanout()`.
+- **Supersession pruning** — a sub-branch exploring an ancestor of an
+  already-confirmed deeper node abandons early (existing #1048 mechanism).
+- **Additive / reversible** — `ENABLE_SUBBRANCH_FANOUT=False`, a zero budget, or
+  a `None` results-sink each restore the exact legacy single-path descent. The
+  primary path is never regressed; fan-out only *adds* recall.
+
+Tests: `tests/unit/argumentation_analysis/test_subbranch_fanout_1048.py`
+(5 tests, $0 mocked LLM) prove a 2-way fork explores both children, the budget
+decrements and stops at zero, and a zero budget / no-sink reproduces the legacy
+single path.
+
+### Lever #2 — parallelize the beam (Phase 3b) — **NOT NOW**
+
+The remaining serial cost is the **beam descent (Phase 3b)**, the Amdahl floor
+(~4.5 s at `BEAM_MAX_LLM_CALLS=15`). Parallelizing it *would* lift the ceiling —
+but the beam is **deliberately token-capped** precisely to bound cost. Fanning
+it out multiplies concurrent token spend against a cap that exists to prevent
+exactly that. Poor ROI. **Lever, if ever needed**: parallelize the beam in
+*bounded batches* (e.g. `BEAM_WIDTH` concurrent expansions per depth) so the
+token cap is preserved while the depth-serial chain is shortened.
+
+### Anti-pendule
+
+Neither "parallelize everything" nor "the existing parallelism is wrong." The
+data + code say: fan out at the fork where the prompt already asked for it and
+the operating point makes it free (lever #3, bounded + pruned), and leave the
+one intentional token guardrail (the beam, lever #2) alone. RA-3 closes here.

--- a/tests/unit/argumentation_analysis/test_subbranch_fanout_1048.py
+++ b/tests/unit/argumentation_analysis/test_subbranch_fanout_1048.py
@@ -1,0 +1,230 @@
+"""Tests for RA-3 #1048 item 2 — bounded recursive sub-branch fan-out.
+
+When the slave LLM flags more than one promising child at a fork, the engine
+used to keep the first and silently drop the rest (recall loss). The fan-out
+explores the top child as the primary path AND the next few (bounded) as
+concurrent recursive sub-branches whose results land in a shared sink.
+
+These tests drive ``_explore_single_branch`` directly with a tiny path-based
+taxonomy and a context-aware $0 mock LLM (no API, no corpus). They prove:
+  - a fork with two explore targets explores BOTH children (recall structure);
+  - the primary single-path is preserved when fan-out is disabled (additive);
+  - a zero budget hard-disables fan-out (anti-pendule #1019 bound).
+"""
+
+import asyncio
+import re
+from unittest.mock import MagicMock
+
+import pytest
+
+from semantic_kernel.kernel import Kernel
+from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+from semantic_kernel.contents import ChatMessageContent, FunctionCallContent
+
+from argumentation_analysis.plugins.fallacy_workflow_plugin import FallacyWorkflowPlugin
+from argumentation_analysis.plugins.identification_models import IdentifiedFallacy
+
+
+def _make_fork_taxonomy():
+    """Root → Branch A (depth 1) → two leaf children (depth 2).
+
+    ``get_children`` resolves parentage via the dotted ``path`` + ``depth``
+    (NOT ``parent_PK``), so every node carries an explicit ``path``.
+    """
+    return [
+        {"PK": "0", "depth": "0", "path": "0", "text_fr": "Racine", "desc_fr": "root"},
+        {
+            "PK": "10",
+            "depth": "1",
+            "path": "0.10",
+            "text_fr": "Branche A",
+            "desc_fr": "fork node",
+            "Famille": "FamA",
+        },
+        {
+            "PK": "20",
+            "depth": "2",
+            "path": "0.10.20",
+            "text_fr": "Sophisme X",
+            "desc_fr": "leaf x",
+        },
+        {
+            "PK": "21",
+            "depth": "2",
+            "path": "0.10.21",
+            "text_fr": "Sophisme Y",
+            "desc_fr": "leaf y",
+        },
+    ]
+
+
+def _make_plugin():
+    kernel = Kernel()
+    mock_service = MagicMock(spec=OpenAIChatCompletion)
+    mock_service.service_id = "test-service"
+    return FallacyWorkflowPlugin(
+        master_kernel=kernel,
+        llm_service=mock_service,
+        taxonomy_data=_make_fork_taxonomy(),
+    )
+
+
+def _explore_call(pk):
+    call = MagicMock(spec=FunctionCallContent)
+    call.name = "Exploration-explore_branch"
+    call.arguments = {"node_pk": pk}
+    call.id = f"explore_{pk}"
+    return call
+
+
+def _confirm_call(pk):
+    call = MagicMock(spec=FunctionCallContent)
+    call.name = "Exploration-confirm_fallacy"
+    call.arguments = {
+        "node_pk": pk,
+        "confidence": "high",
+        "justification": f"matches leaf {pk}",
+    }
+    call.id = f"confirm_{pk}"
+    return call
+
+
+def _msg(items):
+    msg = MagicMock(spec=ChatMessageContent)
+    msg.items = items
+    return msg
+
+
+def _install_fork_mock(plugin):
+    """Mock get_chat_message_contents.
+
+    At the single fork (Branche A) it returns TWO explore targets (the two
+    leaves). At each leaf it confirms that leaf. This makes the LLM
+    deterministically request multi-child exploration.
+    """
+
+    async def mock_contents(chat_history, settings, kernel, **kwargs):
+        prompt = "\n".join(
+            str(getattr(m, "content", "") or "") for m in chat_history.messages
+        )
+        # "You reached a LEAF node" is unique to the leaf prompt. The fork's
+        # *system* message also mentions "LEAF node" in passing ("confirm ...
+        # if you are at a LEAF node"), so a bare "LEAF node" check misfires.
+        if "You reached a LEAF node" in prompt:
+            match = re.search(r"PK:\s*(\w+)", prompt)
+            leaf_pk = match.group(1) if match else ""
+            return [_msg([_confirm_call(leaf_pk)])]
+        # Fork prompt: request both children.
+        return [_msg([_explore_call("20"), _explore_call("21")])]
+
+    plugin.llm_service.get_chat_message_contents = mock_contents
+
+
+class TestSubbranchFanout:
+    def test_fork_fans_out_extra_child_into_sink(self):
+        """Both children of a 2-way fork get explored — recall is preserved."""
+        plugin = _make_plugin()
+        _install_fork_mock(plugin)
+        slave_kernel, slave_settings = plugin._create_slave_kernel()
+        tracker = plugin._BranchSupersessionTracker(
+            plugin.taxonomy_navigator,
+            fanout_budget=plugin.SUBBRANCH_FANOUT_BUDGET,
+        )
+        sink = []
+
+        primary = asyncio.get_event_loop().run_until_complete(
+            plugin._explore_single_branch(
+                "some argument text",
+                "10",
+                slave_kernel,
+                slave_settings,
+                supersession_tracker=tracker,
+                results_sink=sink,
+            )
+        )
+
+        # Primary path followed the top child (PK 20).
+        assert isinstance(primary, IdentifiedFallacy)
+        assert primary.taxonomy_pk == "20"
+        assert primary.fallacy_type == "Sophisme X"
+
+        # The extra child (PK 21) was fanned out, not dropped.
+        assert tracker.fanout_spawned == 1
+        assert len(sink) == 1
+        assert sink[0].taxonomy_pk == "21"
+        assert sink[0].fallacy_type == "Sophisme Y"
+
+        # Both confirmations were high-confidence leaves.
+        assert primary.confidence > 0.8
+        assert sink[0].confidence > 0.8
+
+    def test_no_sink_preserves_single_path(self):
+        """With no sink, behaviour is the legacy single-path descent (additive)."""
+        plugin = _make_plugin()
+        _install_fork_mock(plugin)
+        slave_kernel, slave_settings = plugin._create_slave_kernel()
+        tracker = plugin._BranchSupersessionTracker(
+            plugin.taxonomy_navigator,
+            fanout_budget=plugin.SUBBRANCH_FANOUT_BUDGET,
+        )
+
+        primary = asyncio.get_event_loop().run_until_complete(
+            plugin._explore_single_branch(
+                "some argument text",
+                "10",
+                slave_kernel,
+                slave_settings,
+                supersession_tracker=tracker,
+                results_sink=None,  # no sink → no fan-out
+            )
+        )
+
+        assert isinstance(primary, IdentifiedFallacy)
+        assert primary.taxonomy_pk == "20"  # top child only
+        assert tracker.fanout_spawned == 0
+
+    def test_zero_budget_disables_fanout(self):
+        """A zero fan-out budget hard-disables fan-out (anti-pendule bound)."""
+        plugin = _make_plugin()
+        _install_fork_mock(plugin)
+        slave_kernel, slave_settings = plugin._create_slave_kernel()
+        tracker = plugin._BranchSupersessionTracker(
+            plugin.taxonomy_navigator,
+            fanout_budget=0,  # exhausted from the start
+        )
+        sink = []
+
+        primary = asyncio.get_event_loop().run_until_complete(
+            plugin._explore_single_branch(
+                "some argument text",
+                "10",
+                slave_kernel,
+                slave_settings,
+                supersession_tracker=tracker,
+                results_sink=sink,
+            )
+        )
+
+        assert isinstance(primary, IdentifiedFallacy)
+        assert primary.taxonomy_pk == "20"
+        assert tracker.fanout_spawned == 0
+        assert sink == []
+
+    def test_try_consume_fanout_respects_budget(self):
+        """The shared budget decrements and stops at zero."""
+        plugin = _make_plugin()
+        tracker = plugin._BranchSupersessionTracker(
+            plugin.taxonomy_navigator, fanout_budget=2
+        )
+        assert tracker.try_consume_fanout() is True
+        assert tracker.try_consume_fanout() is True
+        assert tracker.try_consume_fanout() is False  # exhausted
+        assert tracker.fanout_spawned == 2
+
+    def test_default_budget_is_zero(self):
+        """Default tracker (no budget arg) cannot fan out — backward compatible."""
+        plugin = _make_plugin()
+        tracker = plugin._BranchSupersessionTracker(plugin.taxonomy_navigator)
+        assert tracker.try_consume_fanout() is False
+        assert tracker.fanout_spawned == 0


### PR DESCRIPTION
## RA-3 #1048 item 2 — should recursive descent fan out further?

**Decision: IMPLEMENT** (bounded). Q1's bench (#1067) measured the `asyncio.gather` fan-out as parallel-flat (≥2x) at the engine's **real operating point** — Phase 2 fans out over `candidate_pks[:MAX_CANDIDATES]` (**up to 20**), not `MAX_BRANCHES=4`, so it sits past the ~6–7-branch crossover. The gate is met where the engine actually runs, so item 2 is implement-not-document.

> ⚠️ **Stacked on #1067** (base = `feat/1048-ra3-bench-parallel-descent`). The findings doc lives only on that branch; this PR extends its item-2 section. **Merge #1067 first** — this PR auto-retargets to `main` afterwards. #1067 stays bench-only (plugin untouched there); its two LGTM reviews relied on that.

### The mismatch this fixes
A code read found a **prompt-vs-code mismatch**: the fork prompt's system message instructs the LLM to *"PREFER exploring MULTIPLE children (call explore_branch multiple times)"*, but `_explore_single_branch` kept **one** child and silently dropped the rest at every fork — a recall leak, not a design choice.

### Fix (additive · bounded · pruned — anti-pendule #1019)
- At a fork the **top child stays the primary path** (behaviour unchanged for it); the next few promising children are explored as **bounded concurrent recursive sub-branches** whose confirmed leaves merge back via the same dedup-by-leaf rule.
- **Bounds**: `SUBBRANCH_FANOUT_WIDTH=2` (extra children per fork), `SUBBRANCH_FANOUT_BUDGET=12` (shared per-analysis ceiling via `_BranchSupersessionTracker.try_consume_fanout()`), pruned by existing branch supersession.
- **Reversible**: `ENABLE_SUBBRANCH_FANOUT=False`, a zero budget, or a `None` results-sink each restore the exact legacy single-path descent. The primary path never regresses; fan-out only **adds** recall.

### Honest gate caveat
≥2x is **not** universal: 1.27x@2br and **1.77x@4br are below 2x**; only 2.43x@8br clears it. The justification is the **operating point** (20 candidates), not a claim that fan-out is ≥2x at all widths. Documented as such in the findings doc.

### Verification
- `test_subbranch_fanout_1048.py` — **5 tests, $0 mocked LLM**: a 2-way fork explores both children; budget decrements and stops at zero; zero-budget / no-sink reproduce the legacy single path.
- Full plugin suite: **66 passed**, the **4 pre-existing LLM-content baseline failures unchanged** (one-shot + 2 calibration + wide-net JSON — all need a funded key for real multi-branch exploration). No regression.
- `black` clean.

This closes **RA-3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)