### PR TITLE
feat(orchestration): RA-10 #1069 — restore 3-tier delegation (M3) as a selectable axis

### DIFF
--- a/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
+++ b/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
@@ -1,0 +1,327 @@
+"""
+M3 — True hierarchical 3-tier delegation orchestrator (RA-10 #1069 / ORC-2).
+
+Restores the dormant strategic→tactical→operational delegation chain as a
+*selectable* orchestration axis, comparable to the M2 "bridge" path
+(`HierarchicalOrchestrator` → `objectives_to_workflow` → `WorkflowExecutor`).
+
+Why dormant, not deleted
+------------------------
+The 3-tier decomposition / translation logic in
+``strategic/manager.py``, ``tactical/coordinator.py`` and
+``interfaces/tactical_operational.py`` is fully intact. The chain is unwired
+*only* because two pub/sub auto-subscription points were deliberately
+commented out:
+
+* ``TaskCoordinator._subscribe_to_strategic_directives`` (coordinator.py:257)
+* ``OperationalManager._subscribe_to_messages`` (operational/manager.py:310)
+
+Rather than re-enable async pub/sub (and its message-bus race conditions),
+M3 drives the tiers by **explicit sequential calls** — deterministic, unit
+testable, and reusing the existing translation logic untouched.
+
+Anti-pendule (#1019 / north-star R311)
+--------------------------------------
+M3 does **not** replace the DAG/bridge (M2). Both remain selectable via the
+``--hierarchical-mode {bridge,delegation}`` flag. Degraded delegation
+**fails loud**:
+
+* If the strategic tier yields zero objectives, raise :class:`DelegationError`
+  instead of silently injecting a hardcoded objective list. (The M2 bridge's
+  hardcoded 4-objective fallback at ``orchestrator.py:102-128`` is the explicit
+  contrast point this module refuses to imitate.)
+* If a required operational capability has no provider, the per-task result is
+  an honest ``status="failed"`` propagated upward — never a heuristic
+  substitution.
+"""
+
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+import logging
+
+from argumentation_analysis.orchestration.hierarchical.strategic.manager import (
+    StrategicManager,
+)
+from argumentation_analysis.orchestration.hierarchical.tactical.coordinator import (
+    TaskCoordinator,
+)
+from argumentation_analysis.orchestration.hierarchical.interfaces.tactical_operational import (
+    TacticalOperationalInterface,
+)
+from argumentation_analysis.orchestration.hierarchical.hierarchy_bridge import (
+    RegistryBackedOperationalRegistry,
+)
+
+logger = logging.getLogger(__name__)
+
+# Type alias for the operational tier seam: a command dict in, a result dict out.
+OperationalExecutor = Callable[[Dict[str, Any]], Awaitable[Dict[str, Any]]]
+
+
+class DelegationError(RuntimeError):
+    """Raised when the 3-tier delegation chain cannot proceed honestly.
+
+    M3 fails loud rather than fabricating a degraded result (anti-pendule
+    #1019). This covers: an empty strategic objective set, a tactical
+    decomposition that yields no tasks, and a missing operational tier.
+    """
+
+
+async def _absent_operational_executor(command: Dict[str, Any]) -> Dict[str, Any]:
+    """Default executor when neither an executor nor a registry was provided.
+
+    Fails loud on first invocation — M3 has no operational tier to delegate to,
+    and silently returning a stub result would be exactly the heuristic theatre
+    #1019 forbids.
+    """
+    raise DelegationError(
+        "No operational_executor and no capability_registry provided — the M3 "
+        "delegation chain has no operational tier to delegate to. Refusing a "
+        "heuristic no-op fallback (anti-pendule #1019)."
+    )
+
+
+def make_registry_operational_executor(
+    capability_registry: Any,
+) -> OperationalExecutor:
+    """Build the default production operational executor backed by the registry.
+
+    Routes each operational command through the SAME `CapabilityRegistry`
+    providers M2 uses, but via the 3-tier control flow rather than a DAG. A
+    command whose required capabilities have no provider yields an honest
+    ``status="failed"`` result (surfaced upward), NOT a heuristic fallback.
+
+    Args:
+        capability_registry: A `CapabilityRegistry` exposing providers.
+
+    Returns:
+        An async ``command -> result`` callable.
+    """
+    op_registry = RegistryBackedOperationalRegistry(capability_registry)
+
+    async def _executor(command: Dict[str, Any]) -> Dict[str, Any]:
+        required = command.get("required_capabilities") or []
+        chosen: Optional[str] = next(
+            (cap for cap in required if op_registry.has_capability(cap)), None
+        )
+        base = {
+            "task_id": command.get("tactical_task_id"),
+            "objective_id": command.get("objective_id"),
+        }
+        if chosen is None:
+            # Fail loud per-task: no provider covers the required capabilities.
+            return {
+                **base,
+                "status": "failed",
+                "reason": "no_provider_for_required_capabilities",
+                "required_capabilities": list(required),
+            }
+        input_data = {
+            "description": command.get("description", ""),
+            "text_extracts": command.get("text_extracts", []),
+            "parameters": command.get("parameters", {}),
+            "strategic_objective_description": command.get(
+                "strategic_objective_description", ""
+            ),
+        }
+        result = await op_registry.invoke_capability(
+            chosen, input_data, command.get("context")
+        )
+        if result is None:
+            return {
+                **base,
+                "status": "failed",
+                "reason": "provider_returned_none",
+                "capability": chosen,
+            }
+        return {
+            **base,
+            "status": "completed",
+            "capability": chosen,
+            "outputs": result,
+        }
+
+    return _executor
+
+
+class DelegationOrchestrator:
+    """M3 — explicit strategic→tactical→operational delegation.
+
+    The three tiers are driven by direct sequential calls (no pub/sub):
+
+    1. **S** — ``StrategicManager.initialize_analysis`` → NL objectives.
+       Fail loud if empty.
+    2. **T** — ``TaskCoordinator.process_strategic_objectives`` decomposes the
+       objectives into ``tactical_state.tasks["pending"]``.
+    3. **T→O** — for each pending task,
+       ``TacticalOperationalInterface.translate_task_to_command`` builds the
+       operational command, which is then augmented with the originating
+       strategic objective's NL description (decomposition only carries the
+       ``objective_id``, so the intent is re-attached here to flow S→T→O), and
+       handed to the injectable ``operational_executor``.
+    4. **O→T→S** — results are aggregated per objective and passed to
+       ``StrategicManager.evaluate_final_results`` for the final verdict.
+
+    The two seams (``strategic_manager`` and ``operational_executor``) are
+    injectable so the chain can be unit tested without an LLM or live agents.
+    """
+
+    def __init__(
+        self,
+        strategic_manager: Optional[StrategicManager] = None,
+        tactical_coordinator: Optional[TaskCoordinator] = None,
+        tactical_operational_interface: Optional[TacticalOperationalInterface] = None,
+        operational_executor: Optional[OperationalExecutor] = None,
+        capability_registry: Any = None,
+        middleware: Any = None,
+    ):
+        self.logger = logging.getLogger(__name__)
+        self.capability_registry = capability_registry
+        self.middleware = middleware
+
+        self.strategic_manager = strategic_manager or StrategicManager(
+            middleware=middleware
+        )
+        self.tactical_coordinator = tactical_coordinator or TaskCoordinator(
+            middleware=middleware
+        )
+        # Interface MUST share the coordinator's tactical state so the bottom-up
+        # result-processing updates the same task records the coordinator created.
+        self.interface = tactical_operational_interface or TacticalOperationalInterface(
+            tactical_state=self.tactical_coordinator.state,
+            middleware=middleware,
+        )
+
+        if operational_executor is not None:
+            self.operational_executor = operational_executor
+        elif capability_registry is not None:
+            self.operational_executor = make_registry_operational_executor(
+                capability_registry
+            )
+        else:
+            self.operational_executor = _absent_operational_executor
+
+    async def analyze(self, text: str) -> Dict[str, Any]:
+        """Run the full S→T→O delegation chain on ``text``.
+
+        Returns a dict with the objectives, task count, per-task operational
+        results, and the strategic evaluation/conclusion.
+
+        Raises:
+            DelegationError: if the strategic tier yields no objectives or the
+                tactical tier decomposes them into zero tasks (fail loud).
+        """
+        # --- S: strategic tier ---------------------------------------------
+        strategic_result = self.strategic_manager.initialize_analysis(text)
+        objectives: List[Dict[str, Any]] = strategic_result.get("objectives", []) or []
+        if not objectives:
+            raise DelegationError(
+                "Strategic tier produced zero objectives — refusing to fabricate "
+                "a hardcoded objective list (anti-pendule #1019). M3 fails loud "
+                "where the M2 bridge would inject 4 default objectives."
+            )
+        obj_map = {obj["id"]: obj for obj in objectives}
+        self.logger.info("M3 strategic tier produced %d objective(s).", len(objectives))
+
+        # --- T: tactical decomposition -------------------------------------
+        decomposition = self.tactical_coordinator.process_strategic_objectives(
+            objectives
+        )
+        pending_tasks = list(self.tactical_coordinator.state.get_pending_tasks())
+        if not pending_tasks:
+            raise DelegationError(
+                f"Tactical tier decomposed {len(objectives)} objective(s) into "
+                "zero tasks — the delegation chain is broken; refusing a silent "
+                "no-op (anti-pendule #1019)."
+            )
+        self.logger.info(
+            "M3 tactical tier decomposed into %d task(s).", len(pending_tasks)
+        )
+
+        # --- T→O: translate + execute each task ----------------------------
+        operational_results: List[Dict[str, Any]] = []
+        for task in pending_tasks:
+            command = self.interface.translate_task_to_command(task)
+            # Thread the strategic NL intent S→T→O. Decomposition carries only
+            # the objective_id, so re-attach the originating objective's NL
+            # description here — this is the write side of the write→read chain.
+            objective = obj_map.get(command.get("objective_id"))
+            command["strategic_objective_description"] = (
+                objective.get("description", "") if objective else ""
+            )
+            result = await self.operational_executor(command)
+            operational_results.append(result)
+            # Bottom-up: feed the result back through the tactical interface so
+            # the shared tactical state reflects task completion.
+            try:
+                self.interface.process_operational_result(command, result)
+            except Exception as exc:  # noqa: BLE001 — best-effort bookkeeping
+                self.logger.warning(
+                    "process_operational_result failed for %s: %s",
+                    command.get("id"),
+                    exc,
+                )
+
+        # --- O→T→S: aggregate + strategic evaluation -----------------------
+        eval_input = self._aggregate_results_by_objective(
+            objectives, operational_results
+        )
+        final = self.strategic_manager.evaluate_final_results(eval_input)
+
+        return {
+            "mode": "delegation",
+            "objectives": objectives,
+            "tasks_created": decomposition.get("tasks_created", len(pending_tasks)),
+            "operational_results": operational_results,
+            "evaluation": final.get("evaluation"),
+            "conclusion": final.get("conclusion"),
+        }
+
+    @staticmethod
+    def _aggregate_results_by_objective(
+        objectives: List[Dict[str, Any]],
+        operational_results: List[Dict[str, Any]],
+    ) -> Dict[str, Dict[str, float]]:
+        """Compute a per-objective success_rate from the operational results.
+
+        Shapes the input expected by ``StrategicManager.evaluate_final_results``:
+        ``{obj_id: {"success_rate": float}}``. The rate is the fraction of an
+        objective's tasks that completed (failures count honestly against it).
+        """
+        by_obj: Dict[str, List[Dict[str, Any]]] = {obj["id"]: [] for obj in objectives}
+        for result in operational_results:
+            oid = result.get("objective_id")
+            if oid in by_obj:
+                by_obj[oid].append(result)
+
+        eval_input: Dict[str, Dict[str, float]] = {}
+        for oid, results in by_obj.items():
+            if not results:
+                success_rate = 0.0
+            else:
+                completed = sum(1 for r in results if r.get("status") == "completed")
+                success_rate = completed / len(results)
+            eval_input[oid] = {"success_rate": success_rate}
+        return eval_input
+
+
+async def run_delegation_analysis(
+    text: str,
+    capability_registry: Any = None,
+    strategic_manager: Optional[StrategicManager] = None,
+    operational_executor: Optional[OperationalExecutor] = None,
+    middleware: Any = None,
+    **kwargs: Any,
+) -> Dict[str, Any]:
+    """Convenience entry point for M3 delegation analysis.
+
+    Mirrors ``run_hierarchical_analysis`` (M2) so the two modes are symmetric
+    selectable axes. Extra ``kwargs`` are accepted and ignored for signature
+    compatibility with the M2 convenience function.
+    """
+    orchestrator = DelegationOrchestrator(
+        strategic_manager=strategic_manager,
+        operational_executor=operational_executor,
+        capability_registry=capability_registry,
+        middleware=middleware,
+    )
+    return await orchestrator.analyze(text)

--- a/argumentation_analysis/orchestration/hierarchical/orchestrator.py
+++ b/argumentation_analysis/orchestration/hierarchical/orchestrator.py
@@ -224,14 +224,39 @@ class HierarchicalOrchestrator:
 async def run_hierarchical_analysis(
     text: str,
     capability_registry: Optional[CapabilityRegistry] = None,
+    mode: str = "bridge",
     **kwargs: Any,
 ) -> Dict[str, Any]:
     """
     Convenience entry point for hierarchical analysis.
 
-    Creates a ``HierarchicalOrchestrator`` and runs the analysis.
-    Used by ``run_orchestration.py --mode hierarchical``.
+    Two selectable, comparable axes (anti-pendule #1019 / north-star R311 —
+    the DAG is NOT thrown away):
+
+    * ``mode="bridge"`` (default, M2) — short-circuits the 3-tier chain via
+      ``objectives_to_workflow`` → ``WorkflowExecutor`` (Lego/DAG).
+    * ``mode="delegation"`` (M3, RA-10 #1069) — true strategic→tactical→
+      operational delegation driven by explicit sequential calls. Fails loud
+      on a degraded chain instead of falling back to hardcoded objectives.
+
+    Used by ``run_orchestration.py --mode hierarchical --hierarchical-mode ...``.
     """
+    if mode == "delegation":
+        # Imported lazily to avoid a hard dependency cycle for the M2 path.
+        from argumentation_analysis.orchestration.hierarchical.delegation_orchestrator import (
+            run_delegation_analysis,
+        )
+
+        return await run_delegation_analysis(
+            text,
+            capability_registry=capability_registry,
+            **kwargs,
+        )
+    if mode != "bridge":
+        raise ValueError(
+            f"Unknown hierarchical mode {mode!r}; expected 'bridge' or 'delegation'."
+        )
+
     orchestrator = HierarchicalOrchestrator(
         capability_registry=capability_registry,
     )

--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -255,7 +255,6 @@ async def run_modern_analysis(
     return results
 
 
-
 async def main():
     """Fonction principale du script."""
     parser = argparse.ArgumentParser(
@@ -331,6 +330,16 @@ Exemples:
         "hierarchical (strategic planning → Lego execution), "
         "cluedo (investigation Sherlock-Watson-Oracle, #914), "
         "sherlock_modern (investigation multi-agent, #357)",
+    )
+    parser.add_argument(
+        "--hierarchical-mode",
+        type=str,
+        choices=["bridge", "delegation"],
+        default="bridge",
+        help="Sub-mode for --mode hierarchical (RA-10 #1069): "
+        "bridge (M2, default — strategic objectives → Lego/DAG execution), "
+        "delegation (M3 — true strategic→tactical→operational 3-tier delegation, "
+        "fails loud on a degraded chain instead of hardcoded fallback).",
     )
     parser.add_argument(
         "--verbose", "-v", action="store_true", help="Afficher les logs détaillés"
@@ -614,28 +623,50 @@ Exemples:
             run_hierarchical_analysis,
         )
 
-        logging.info("Mode HIÉRARCHIQUE : StrategicManager → Lego WorkflowExecutor")
-        results = await run_hierarchical_analysis(text=text_content)
+        hier_mode = getattr(args, "hierarchical_mode", "bridge")
+        if hier_mode == "delegation":
+            logging.info(
+                "Mode HIÉRARCHIQUE (M3 delegation) : "
+                "Strategic → Tactical → Operational (3-tier explicit chain)"
+            )
+        else:
+            logging.info(
+                "Mode HIÉRARCHIQUE (M2 bridge) : StrategicManager → Lego WorkflowExecutor"
+            )
+        results = await run_hierarchical_analysis(text=text_content, mode=hier_mode)
 
         # Afficher le résumé
-        summary = results.get("summary", {})
         conclusion = results.get("conclusion", "")
         objectives = results.get("objectives", [])
 
         print(f"\n{'='*60}")
-        print(f" Mode hiérarchique — {summary.get('total', 0)} phases")
-        print(f"{'='*60}")
-        print(f"  Objectifs stratégiques : {len(objectives)}")
-        for obj in objectives:
+        if results.get("mode") == "delegation":
+            op_results = results.get("operational_results", [])
+            completed = sum(1 for r in op_results if r.get("status") == "completed")
+            print(f" Mode hiérarchique (M3 delegation) — {len(op_results)} tâches")
+            print(f"{'='*60}")
+            print(f"  Objectifs stratégiques : {len(objectives)}")
+            for obj in objectives:
+                print(
+                    f"    - [{obj.get('priority', '?').upper()}] {obj.get('description', '?')}"
+                )
+            print(f"  Tâches créées      : {results.get('tasks_created', 0)}")
+            print(f"  Tâches complétées  : {completed}/{len(op_results)}")
+        else:
+            summary = results.get("summary", {})
+            print(f" Mode hiérarchique (M2 bridge) — {summary.get('total', 0)} phases")
+            print(f"{'='*60}")
+            print(f"  Objectifs stratégiques : {len(objectives)}")
+            for obj in objectives:
+                print(
+                    f"    - [{obj.get('priority', '?').upper()}] {obj.get('description', '?')}"
+                )
             print(
-                f"    - [{obj.get('priority', '?').upper()}] {obj.get('description', '?')}"
+                f"  Phases complétées : {summary.get('completed', 0)}/{summary.get('total', 0)}"
             )
-        print(
-            f"  Phases complétées : {summary.get('completed', 0)}/{summary.get('total', 0)}"
-        )
-        print(f"  Phases échouées   : {summary.get('failed', 0)}")
-        print(f"  Phases sautées    : {summary.get('skipped', 0)}")
-        print(f"  Durée : {results.get('duration_seconds', 0):.1f}s")
+            print(f"  Phases échouées   : {summary.get('failed', 0)}")
+            print(f"  Phases sautées    : {summary.get('skipped', 0)}")
+            print(f"  Durée : {results.get('duration_seconds', 0):.1f}s")
         if conclusion:
             print(f"\n  Conclusion : {conclusion}")
         print(f"{'='*60}\n")
@@ -689,9 +720,13 @@ Exemples:
         print(f"{'='*60}")
         print(f"  Trace steps     : {len(trace) if isinstance(trace, list) else 'N/A'}")
         if investigation:
-            print(f"  Investigation   : {json.dumps(investigation, ensure_ascii=False, default=str)[:300]}")
+            print(
+                f"  Investigation   : {json.dumps(investigation, ensure_ascii=False, default=str)[:300]}"
+            )
         if solution:
-            print(f"  Solution        : {json.dumps(solution, ensure_ascii=False, default=str)[:300]}")
+            print(
+                f"  Solution        : {json.dumps(solution, ensure_ascii=False, default=str)[:300]}"
+            )
         print(f"{'='*60}\n")
 
         # Save if requested

--- a/docs/reports/RA10_M3_vs_M2_delegation_note.md
+++ b/docs/reports/RA10_M3_vs_M2_delegation_note.md
@@ -1,0 +1,157 @@
+<!--
+PROVENANCE (Cleanup Gate / global CLAUDE.md "Consolider != Archiver")
+  Role:        report / design — comparison note for a deactivation-reversal restore
+  Origin:      RA-10 #1069 (ORC-2) — "Restore hierarchical 3-tier delegation as a
+               comparable, selectable orchestration axis"
+  Restores:    the dormant strategic→tactical→operational chain (M3), NOT a new design
+  Base:        58d1fcba
+  Author:      Claude Code @ myia-po-2023:2025-Epita-Intelligence-Symbolique
+  Date:        2026-06-12
+  Privacy:     opaque corpus IDs only; no raw_text / author / title (dataset discipline)
+-->
+
+# RA-10 #1069 — M3 (true 3-tier delegation) vs M2 (bridge/DAG): comparison note
+
+## 0. TL;DR
+
+`--mode hierarchical` now exposes **two comparable, selectable axes** via
+`--hierarchical-mode {bridge,delegation}` (default `bridge`, backward-compatible):
+
+| Axis | Flag | Control flow | Objective source | Degraded behavior |
+|------|------|--------------|------------------|-------------------|
+| **M2** (shipped) | `--hierarchical-mode bridge` | Strategic objectives → `objectives_to_workflow` → `WorkflowExecutor` (Lego/DAG) | LLM if kernel, else hardcoded 4-objective fallback injected at `orchestrator.py:102-128` | Silently substitutes 4 default objectives |
+| **M3** (restored, RA-10) | `--hierarchical-mode delegation` | Explicit S→T→O sequential calls through the 3 tiers | LLM if kernel, else RA-4 `_fallback_objectives()` tagged `source="degraded"` | **Fails loud** (`DelegationError`) when the chain is truly empty / has no operational tier |
+
+This is the anti-pendule requirement of #1019 / north-star R311 honored: **the DAG
+is not thrown away** — M3 is added beside it, both runnable from the same entry point.
+
+---
+
+## 1. Why the 3-tier chain was dormant (audit)
+
+The decomposition / translation logic across the three tiers is **fully intact**.
+The chain was dormant only because two pub/sub auto-subscription points were
+**deliberately commented out**:
+
+- `TaskCoordinator._subscribe_to_strategic_directives` — `tactical/coordinator.py:257`
+  (`# self.adapter.subscribe_to_directives(handle_directive)`, "disabled due to API changes").
+- `OperationalManager._subscribe_to_messages` — `operational/manager.py:310`.
+
+**Design consequence:** rather than re-enable async pub/sub (and reintroduce the
+message-bus races that motivated the deactivation), M3 drives the tiers by
+**explicit sequential calls**. This is deterministic, unit-testable, and reuses
+every existing translation method untouched (`process_strategic_objectives`,
+`_decompose_objective_to_tasks`, `translate_task_to_command`,
+`process_operational_result`, `evaluate_final_results`).
+
+---
+
+## 2. The two paths, side by side
+
+### M2 — bridge (`HierarchicalOrchestrator.analyze`, `orchestrator.py`)
+
+```
+StrategicManager.initialize_analysis(text)        # objectives (LLM or hardcoded-4)
+  └─> objectives_to_workflow(objectives, registry) # objectives → Lego workflow (DAG)
+        └─> WorkflowExecutor.execute()             # phases run in DAG order
+              └─> evaluate_final_results()         # success_rate per phase → conclusion
+```
+The 3-tier control structure is **short-circuited**: tactical/operational tiers are
+not traversed; the DAG executor maps objective keywords → capabilities directly.
+
+### M3 — delegation (`DelegationOrchestrator.analyze`, `delegation_orchestrator.py`)
+
+```
+S:  StrategicManager.initialize_analysis(text)            # objectives
+    └─ FAIL LOUD if objectives == []  (DelegationError)   # ← contrast to M2's hardcoded-4
+T:  TaskCoordinator.process_strategic_objectives(objs)    # objectives → tactical_state.tasks["pending"]
+    └─ FAIL LOUD if 0 tasks  (DelegationError)
+T→O: for task in pending:
+       command = interface.translate_task_to_command(task)
+       command["strategic_objective_description"] = obj_map[task.objective_id].description  # ← S→T→O NL thread
+       result  = await operational_executor(command)      # registry providers OR injected stub
+       interface.process_operational_result(command, result)  # bottom-up
+O→T→S: aggregate per-objective success_rate → StrategicManager.evaluate_final_results()
+```
+
+**Key restoration detail — the NL thread.** `_decompose_objective_to_tasks` carries
+only `objective_id` into each task (not the strategic NL description). M3 re-attaches
+the originating objective's description onto the operational command
+(`strategic_objective_description`) so the **strategic intent reaches the operational
+tier** — this is the "strategic NL objective flows S→T→O" DoD item, and it is the
+property the write→read chain test asserts.
+
+---
+
+## 3. Reference corpus comparison (opaque ID: `corpus_ref_A`)
+
+`corpus_ref_A` = the single opaque reference text used for both invocations. Run the
+two axes against the **same** input and diff the run summaries:
+
+```bash
+# M2 (bridge / DAG)
+conda run -n projet-is --no-capture-output python argumentation_analysis/run_orchestration.py \
+    --mode hierarchical --hierarchical-mode bridge \
+    --file <corpus_ref_A> --output results/ra10/corpus_ref_A_m2.json   # results/ is gitignored
+
+# M3 (true 3-tier delegation)
+conda run -n projet-is --no-capture-output python argumentation_analysis/run_orchestration.py \
+    --mode hierarchical --hierarchical-mode delegation \
+    --file <corpus_ref_A> --output results/ra10/corpus_ref_A_m3.json
+```
+
+### 3.1 Structural comparison — VERIFIED from code
+
+| Dimension | M2 (bridge) | M3 (delegation) |
+|-----------|-------------|-----------------|
+| Tiers traversed | S → DAG executor | S → T → O → T → S (all three) |
+| Objective→work mapping | `_OBJECTIVE_CAPABILITY_MAP` keyword → capability (DAG) | `_decompose_objective_to_tasks` keyword → task, then `translate_task_to_command` → operational command |
+| Operational dispatch | `WorkflowExecutor` over `CapabilityRegistry` | `operational_executor` over the **same** `CapabilityRegistry` (via `RegistryBackedOperationalRegistry.invoke_capability`) |
+| Strategic NL reaches O tier | No (DAG consumes capabilities, not the NL objective) | **Yes** (`strategic_objective_description` threaded onto each command) |
+| Empty-objective handling | Injects hardcoded 4 (`orchestrator.py:102-128`) | `DelegationError` (fail loud) |
+| Missing-provider handling | Phase failure inside DAG | Per-task `status="failed"`, `reason="no_provider_for_required_capabilities"`, surfaced upward (no fabrication) |
+| Result shape | `summary{total/completed/failed}`, `conclusion` | `operational_results[]`, `tasks_created`, `evaluation`, `conclusion`, `mode="delegation"` |
+
+### 3.2 Empirical chain evidence — VERIFIED (unit, zero-API)
+
+The S→T→O NL-flow and fail-loud properties are proven deterministically by
+`tests/unit/orchestration/test_hierarchical_delegation.py` (9 tests, all passing,
+no API key required):
+
+- `test_strategic_objective_flows_s_to_t_to_o` — a unique strategic-intent marker set
+  at tier S surfaces verbatim on the operational command after crossing the **real**
+  tactical decomposition + translation tiers (the write→read chain).
+- `test_multiple_objectives_each_thread_their_intent` — per-objective intent isolation
+  (no cross-talk).
+- `test_empty_objectives_fails_loud`, `test_absent_operational_tier_fails_loud`,
+  `test_run_delegation_analysis_routes_to_chain` — `DelegationError` instead of a
+  degraded silent result.
+- `test_registry_executor_missing_provider_is_honest_failure` — honest `status="failed"`,
+  not a heuristic substitution.
+- `test_registry_executor_invokes_real_provider_with_intent` — the default registry
+  executor routes the strategic NL intent through to the provider.
+- `test_run_hierarchical_analysis_unknown_mode_raises` /
+  `test_run_hierarchical_analysis_delegation_mode_dispatches` — the mode selector
+  routes correctly and M3 fails loud where M2 would not.
+
+### 3.3 Live LLM run — NOT executed on this machine (RAPPORTE)
+
+A funded API key was not available on the executing machine (`myia-po-2023`, API
+quota tight). The end-to-end LLM-driven comparison numbers (objective counts,
+per-objective success rates, conclusions on `corpus_ref_A`) are therefore **not
+filled in here** rather than fabricated (SDDD scepticism: VERIFIED vs RAPPORTE).
+The recipe in §3 reproduces the run once a funded key is present; the structural
+(§3.1) and unit-chain (§3.2) evidence already establishes that both axes are
+runnable and that M3 traverses all three tiers with the NL thread intact.
+
+---
+
+## 4. Anti-pendule ledger (#1019 / R311)
+
+- **Added, not replaced.** `HierarchicalOrchestrator` remains pure-M2; M3 lives in a
+  new `delegation_orchestrator.py`. The selector is additive (`mode="bridge"` default).
+- **No new hardcoded objective list.** M3 consumes RA-4's existing `_fallback_objectives()`
+  (tagged `source="degraded"`); it introduces zero new hardcoded objectives.
+- **Degraded = loud.** Empty chain → `DelegationError`; missing provider → honest
+  `status="failed"`. No heuristic substitution anywhere in the M3 path.
+- **DAG preserved.** The Lego/`WorkflowExecutor` path is untouched and still the default.

--- a/tests/unit/orchestration/test_hierarchical_delegation.py
+++ b/tests/unit/orchestration/test_hierarchical_delegation.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+"""
+Tests for the M3 true 3-tier delegation orchestrator (RA-10 #1069 / ORC-2).
+===========================================================================
+
+Covers the DoD of #1069:
+- 3-tier path runnable + selectable (DelegationOrchestrator + mode routing).
+- Strategic NL objective flows S→T→O — a write→read chain test asserting a
+  unique strategic-intent marker reaches the operational command/provider.
+- No heuristic fallback — a degraded delegation fails loud (#1019):
+    * empty strategic objectives → DelegationError
+    * absent operational tier → DelegationError
+    * missing capability provider → honest status="failed" (not fabrication)
+
+Async note: this directory's local ``pytest.ini`` uses STRICT asyncio mode
+(not the repo root's ``asyncio_mode = auto``), so the module-level
+``pytestmark = pytest.mark.asyncio`` below is required for the ``async def``
+tests to run.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from argumentation_analysis.orchestration.hierarchical.delegation_orchestrator import (
+    DelegationError,
+    DelegationOrchestrator,
+    make_registry_operational_executor,
+    run_delegation_analysis,
+)
+from argumentation_analysis.orchestration.hierarchical.orchestrator import (
+    run_hierarchical_analysis,
+)
+
+# This dir's local pytest.ini uses strict asyncio mode — mark every (async) test.
+pytestmark = pytest.mark.asyncio
+
+
+# A deliberately unique, keyword-free marker. Keyword-free so the tactical
+# decomposition falls through to its generic branch (it must NOT match the
+# "identifier"+"arguments" or "détecter"+"sophisme" heuristics), which proves
+# the NL intent is threaded explicitly rather than via the keyword router.
+STRATEGIC_MARKER = "UNIQUE_STRATEGIC_INTENT_zeta42_opaque"
+
+
+class _FakeStrategicManager:
+    """Strategic-tier seam: returns canned objectives, records eval input.
+
+    Replacing the real ``StrategicManager`` keeps the test free of LLM/middleware
+    while still exercising the REAL tactical decomposition + T→O translation.
+    """
+
+    def __init__(self, objectives):
+        self._objectives = objectives
+        self.eval_calls = []
+
+    def initialize_analysis(self, text):
+        return {"objectives": self._objectives, "strategic_plan": {}}
+
+    def evaluate_final_results(self, results):
+        self.eval_calls.append(results)
+        return {
+            "conclusion": "stub-conclusion",
+            "evaluation": {"overall_success_rate": 1.0},
+        }
+
+
+class _FakeProvider:
+    def __init__(self, name, invoke):
+        self.name = name
+        self.invoke = invoke
+
+
+class _FakeRegistry:
+    """Minimal CapabilityRegistry surface used by RegistryBackedOperationalRegistry."""
+
+    def __init__(self, providers_by_cap=None):
+        self._providers_by_cap = providers_by_cap or {}
+
+    def find_for_capability(self, capability):
+        return self._providers_by_cap.get(capability, [])
+
+
+# ---------------------------------------------------------------------------
+# S→T→O write→read chain
+# ---------------------------------------------------------------------------
+
+
+async def test_strategic_objective_flows_s_to_t_to_o():
+    """The strategic NL objective (write) reaches the operational command (read).
+
+    This is the core #1069 chain test: a unique strategic-intent marker, set at
+    the strategic tier, must surface verbatim on the operational command after
+    crossing the real tactical decomposition + translation tiers.
+    """
+    objectives = [{"id": "obj-1", "description": STRATEGIC_MARKER, "priority": "high"}]
+    captured = []
+
+    async def stub_executor(command):
+        captured.append(command)
+        return {
+            "task_id": command.get("tactical_task_id"),
+            "objective_id": command.get("objective_id"),
+            "status": "completed",
+            "outputs": {"ok": True},
+        }
+
+    orchestrator = DelegationOrchestrator(
+        strategic_manager=_FakeStrategicManager(objectives),
+        operational_executor=stub_executor,
+        middleware=MagicMock(),
+    )
+
+    result = await orchestrator.analyze("some source text")
+
+    assert result["mode"] == "delegation"
+    assert result["tasks_created"] >= 1
+    assert len(captured) >= 1
+    # write→read: the NL intent crossed S→T→O intact.
+    assert captured[0]["strategic_objective_description"] == STRATEGIC_MARKER
+    assert captured[0]["objective_id"] == "obj-1"
+    # The strategic tier received an aggregated per-objective success_rate.
+    assert orchestrator.strategic_manager.eval_calls
+    assert "obj-1" in orchestrator.strategic_manager.eval_calls[0]
+
+
+async def test_multiple_objectives_each_thread_their_intent():
+    """Each objective's NL intent reaches its own task's command (no cross-talk)."""
+    objectives = [
+        {"id": "obj-1", "description": "ALPHA_intent_opaque", "priority": "high"},
+        {"id": "obj-2", "description": "BETA_intent_opaque", "priority": "medium"},
+    ]
+    captured = {}
+
+    async def stub_executor(command):
+        captured[command["objective_id"]] = command["strategic_objective_description"]
+        return {
+            "task_id": command.get("tactical_task_id"),
+            "objective_id": command.get("objective_id"),
+            "status": "completed",
+        }
+
+    orchestrator = DelegationOrchestrator(
+        strategic_manager=_FakeStrategicManager(objectives),
+        operational_executor=stub_executor,
+        middleware=MagicMock(),
+    )
+    await orchestrator.analyze("text")
+
+    assert captured["obj-1"] == "ALPHA_intent_opaque"
+    assert captured["obj-2"] == "BETA_intent_opaque"
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud — no heuristic fallback (#1019)
+# ---------------------------------------------------------------------------
+
+
+async def test_empty_objectives_fails_loud():
+    """Zero strategic objectives must raise, not silently inject defaults."""
+    orchestrator = DelegationOrchestrator(
+        strategic_manager=_FakeStrategicManager([]),
+        operational_executor=lambda cmd: None,  # never reached
+        middleware=MagicMock(),
+    )
+    with pytest.raises(DelegationError):
+        await orchestrator.analyze("text")
+
+
+async def test_absent_operational_tier_fails_loud():
+    """No executor and no registry → the chain has no operational tier → raise."""
+    objectives = [
+        {"id": "obj-1", "description": "generic_opaque_task", "priority": "high"}
+    ]
+    orchestrator = DelegationOrchestrator(
+        strategic_manager=_FakeStrategicManager(objectives),
+        middleware=MagicMock(),
+    )  # no operational_executor, no capability_registry
+    with pytest.raises(DelegationError):
+        await orchestrator.analyze("text")
+
+
+async def test_run_delegation_analysis_routes_to_chain():
+    """The convenience fn builds + runs the chain (and fails loud on empty tier)."""
+    objectives = [
+        {"id": "obj-1", "description": "generic_opaque_task", "priority": "high"}
+    ]
+    with pytest.raises(DelegationError):
+        await run_delegation_analysis(
+            "text",
+            strategic_manager=_FakeStrategicManager(objectives),
+            middleware=MagicMock(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Default registry-backed executor — honest failure vs real routing
+# ---------------------------------------------------------------------------
+
+
+async def test_registry_executor_missing_provider_is_honest_failure():
+    """A required capability with no provider yields status=failed, not a raise
+    and not a fabricated success."""
+    executor = make_registry_operational_executor(_FakeRegistry())
+    result = await executor(
+        {
+            "tactical_task_id": "t1",
+            "objective_id": "obj-1",
+            "required_capabilities": ["fallacy_detection"],
+        }
+    )
+    assert result["status"] == "failed"
+    assert result["reason"] == "no_provider_for_required_capabilities"
+
+
+async def test_registry_executor_invokes_real_provider_with_intent():
+    """The default executor routes the strategic NL intent to the provider."""
+
+    async def fake_invoke(input_data, context):
+        return {"echo": input_data.get("strategic_objective_description")}
+
+    registry = _FakeRegistry(
+        {"fallacy_detection": [_FakeProvider("informal_v1", fake_invoke)]}
+    )
+    executor = make_registry_operational_executor(registry)
+    result = await executor(
+        {
+            "tactical_task_id": "t1",
+            "objective_id": "obj-2",
+            "required_capabilities": ["fallacy_detection"],
+            "strategic_objective_description": "INTENT_MARK_opaque",
+        }
+    )
+    assert result["status"] == "completed"
+    assert result["capability"] == "fallacy_detection"
+    assert result["outputs"]["echo"] == "INTENT_MARK_opaque"
+
+
+# ---------------------------------------------------------------------------
+# Mode routing on the shared hierarchical entry point
+# ---------------------------------------------------------------------------
+
+
+async def test_run_hierarchical_analysis_unknown_mode_raises():
+    with pytest.raises(ValueError):
+        await run_hierarchical_analysis("text", mode="nonsense")
+
+
+async def test_run_hierarchical_analysis_delegation_mode_dispatches():
+    """mode='delegation' routes to the M3 chain (proven by its fail-loud on an
+    absent operational tier, which the M2 bridge would not raise).
+
+    The fake strategic_manager + MagicMock middleware are threaded through
+    ``**kwargs`` so no real LLM/MessageMiddleware is constructed in the test.
+    """
+    objectives = [
+        {"id": "obj-1", "description": "generic_opaque_task", "priority": "high"}
+    ]
+    with pytest.raises(DelegationError):
+        await run_hierarchical_analysis(
+            "text",
+            mode="delegation",
+            strategic_manager=_FakeStrategicManager(objectives),
+            middleware=MagicMock(),
+        )


### PR DESCRIPTION
Closes #1069 (RA-10 / ORC-2).

## What

Restores the dormant strategic→tactical→operational delegation chain (**M3**) as a
**comparable, selectable** orchestration axis beside the shipped **M2** bridge/DAG path.
The 3-tier decomposition/translation logic was fully intact — the chain was dormant only
because two pub/sub auto-subscriptions are deliberately commented out
(`tactical/coordinator.py:257`, `operational/manager.py:310`). M3 drives the tiers by
**explicit sequential calls** rather than re-enabling pub/sub (and its message-bus races).

Selectable via `--hierarchical-mode {bridge,delegation}` (default `bridge`, fully
backward-compatible). `HierarchicalOrchestrator` (M2/DAG) is **untouched** and stays the default.

## DoD (#1069)

- [x] **3-tier path runnable + selectable** via mode flag — `DelegationOrchestrator` +
  `run_hierarchical_analysis(..., mode=...)` + CLI `--hierarchical-mode`.
- [x] **Strategic NL objective flows S→T→O** (write→read chain test) — decomposition carries
  only `objective_id`, so `analyze()` re-attaches the originating objective's NL description
  onto each operational command (`strategic_objective_description`). Asserted by a chain test
  crossing the **real** tactical decomposition + T→O translation.
- [x] **Comparison note M3 vs M2** on 1 reference corpus (opaque IDs) —
  `docs/reports/RA10_M3_vs_M2_delegation_note.md`.
- [x] **No heuristic fallback — degraded delegation fails loud (#1019)** — empty objectives /
  zero tasks / absent operational tier → `DelegationError`; missing capability provider →
  honest `status="failed"`, never a fabricated result.

## Anti-pendule (#1019 / north-star R311)

- **Added, not replaced.** M3 lives in a new `delegation_orchestrator.py`; the selector is
  additive (`mode="bridge"` default). The DAG/`WorkflowExecutor` path is preserved.
- **No new hardcoded objectives.** M3 reuses RA-4's existing `_fallback_objectives()`
  (tagged `source="degraded"`); it introduces zero new hardcoded objectives. M3 fails loud
  where the M2 bridge would inject 4 default objectives (`orchestrator.py:102-128`).

## Tests

`tests/unit/orchestration/test_hierarchical_delegation.py` — 9 tests, **zero-API**
(strategic + operational seams injected). Local run: **21 passed** (9 new + 12 existing
`test_hierarchical_managers.py`, no regression). `black --check` clean on all 4 code files.

## Live LLM run

The end-to-end LLM-driven comparison numbers on the reference corpus were **not executed**
on the authoring machine (API quota); the note provides the reproducible recipe and is
explicit (VERIFIED structural + unit evidence vs RAPPORTE live run) rather than fabricating
numbers.

## Files removed and why

N/A — no file deletions in this PR (3 new files, 2 edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)