### PR TITLE
feat(strategic): RA-4 #1049 item 3 — tactical consumption of strategic objectives

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -42,6 +42,49 @@ def _preflight_solver_check() -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# RA-4 #1049 item 3 — Strategic objective consumption by tactical callables
+# ---------------------------------------------------------------------------
+
+def _get_strategic_directives(context: Dict[str, Any]) -> Tuple[str, List[str]]:
+    """Extract active strategic objectives from state and format as NL directives.
+
+    Returns:
+        Tuple of (formatted_directives_text, list_of_objective_ids).
+        The text is empty string if no objectives are available.
+    """
+    state = context.get("_state_object")
+    if state is None:
+        return "", []
+
+    objectives = getattr(state, "strategic_objectives", [])
+    if not objectives:
+        return "", []
+
+    active = [
+        obj for obj in objectives
+        if isinstance(obj, dict) and obj.get("status", "active") in ("active", "in_progress")
+    ]
+    if not active:
+        return "", []
+
+    lines = []
+    obj_ids: List[str] = []
+    for obj in active[:5]:  # Cap at 5 to avoid prompt bloat
+        oid = obj.get("objective_id", obj.get("id", f"obj_{len(obj_ids)+1}"))
+        desc = obj.get("description", obj.get("text", ""))
+        priority = obj.get("priority", "normal")
+        if desc:
+            lines.append(f"[{oid}] (priority: {priority}) {desc}")
+            obj_ids.append(str(oid))
+
+    if not lines:
+        return "", []
+
+    header = "STRATEGIC DIRECTIVES — the PM has identified these long-term analysis goals. Prioritize detection and analysis aligned with these objectives:"
+    return f"{header}\n" + "\n".join(lines), obj_ids
+
+
 # Ensure .env is loaded so OPENAI_API_KEY is available for all invoke callables
 try:
     from dotenv import load_dotenv
@@ -2265,7 +2308,11 @@ async def _invoke_camembert_fallacy(
             llm_service=llm_service,
         )
 
-        result_json = await plugin.run_guided_analysis(argument_text=input_text)
+        # RA-4 #1049 item 3: inject strategic directives into LLM prompt
+        _strat_text_cam, _strat_ids_cam = _get_strategic_directives(context)
+        _effective_text_cam = f"{_strat_text_cam}\n\n{input_text}" if _strat_text_cam else input_text
+
+        result_json = await plugin.run_guided_analysis(argument_text=_effective_text_cam)
         result = json.loads(result_json)
 
         # Map hierarchical result to adapter format
@@ -2281,7 +2328,7 @@ async def _invoke_camembert_fallacy(
                     "taxonomy_pk": f.get("taxonomy_pk", ""),
                 }
 
-        return {
+        _ret = {
             "detected_fallacies": detected,
             "arguments": {},
             "tiers_used": ["self_hosted_llm"],
@@ -2289,6 +2336,9 @@ async def _invoke_camembert_fallacy(
             "total_fallacies": len(detected),
             "extraction_method": result.get("exploration_method", "self_hosted"),
         }
+        if _strat_ids_cam:
+            _ret["strategic_objective_ids"] = _strat_ids_cam
+        return _ret
 
     except Exception as e:
         logger.warning("Self-hosted LLM fallacy detection failed: %s", e)
@@ -3453,9 +3503,15 @@ async def _invoke_hierarchical_fallacy(
             taxonomy_file_path=taxonomy_path,
         )
 
-        result_json = await plugin.run_guided_analysis(argument_text=input_text)
+        # RA-4 #1049 item 3: inject strategic directives into LLM prompt
+        _strat_text, _strat_ids = _get_strategic_directives(context)
+        _effective_text = f"{_strat_text}\n\n{input_text}" if _strat_text else input_text
+
+        result_json = await plugin.run_guided_analysis(argument_text=_effective_text)
         result = json.loads(result_json)
         result["extraction_method"] = result.get("exploration_method", "unknown")
+        if _strat_ids:
+            result["strategic_objective_ids"] = _strat_ids
 
         # Per-argument enrichment pass: run _invoke_hierarchical_fallacy_per_argument
         # and merge extras into the wide-net results to lift recall on dense text.
@@ -4575,6 +4631,11 @@ async def _invoke_fol_reasoning(
     those validated formulas. Otherwise falls back to template generation.
     (#208-H: wire NL-to-logic as pre-processing)
     """
+    # RA-4 #1049 item 3: inject strategic directives for LLM-guided FOL translation
+    _strat_text_fol, _strat_ids_fol = _get_strategic_directives(context)
+    if _strat_text_fol:
+        input_text = f"{_strat_text_fol}\n\n{input_text}"
+
     args = _extract_arguments_from_context(input_text, context)
     # #705 Track LL: capture upstream FOL formulas (DAG nl_to_logic /
     # context["formulas"]) separately and run the robust 2-pass generator
@@ -4911,6 +4972,7 @@ async def _invoke_fol_reasoning(
             "logic_type": "first_order",
             "argument_count": len(args),
             "fol_metrics": fol_metrics,
+            **({"strategic_objective_ids": _strat_ids_fol} if _strat_ids_fol else {}),
         }
     except Exception as tweety_err:
         logger.warning(
@@ -4954,6 +5016,7 @@ async def _invoke_fol_reasoning(
                 "isolation_retry": True,
                 "rejected_count": len(formulas) - len(valid_formulas),
                 "fol_metrics": fol_metrics,
+                **({"strategic_objective_ids": _strat_ids_fol} if _strat_ids_fol else {}),
             }
 
         # All formulas failed — no heuristic fallback (#1019)
@@ -4983,9 +5046,8 @@ async def _invoke_fol_reasoning(
             "solver": "none",
             "diagnostic": str(tweety_err),
             "fol_metrics": fol_metrics,
+            **({"strategic_objective_ids": _strat_ids_fol} if _strat_ids_fol else {}),
         }
-
-
 async def _invoke_nl_to_logic(
     input_text: str, context: Dict[str, Any]
 ) -> Dict[str, Any]:

--- a/tests/unit/argumentation_analysis/test_ra4_item3_tactical_consumption.py
+++ b/tests/unit/argumentation_analysis/test_ra4_item3_tactical_consumption.py
@@ -1,0 +1,290 @@
+"""RA-4 #1049 item 3 — Tactical consumption of strategic objectives.
+
+Verifies that invoke callables can read strategic objectives from the state
+object passed via context, and that their output references the objective IDs.
+
+Chain: PM writes objectives → bridge syncs to UnifiedAnalysisState →
+       callable reads via _get_strategic_directives → output includes IDs.
+
+These tests are UNIT-level: they test the helper and the injection wiring
+without making LLM calls (mocked plugin/client).
+"""
+
+import asyncio
+import json
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.orchestration.invoke_callables import (
+    _get_strategic_directives,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+def _run(coro):
+    """Run an async coroutine synchronously."""
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Layer 6: _get_strategic_directives unit tests
+# ---------------------------------------------------------------------------
+class TestGetStrategicDirectives:
+    """Unit tests for the strategic directives extraction helper."""
+
+    def test_no_state_object_returns_empty(self):
+        """Without _state_object, must return empty text and empty IDs."""
+        text, ids = _get_strategic_directives({})
+        assert text == ""
+        assert ids == []
+
+    def test_no_objectives_returns_empty(self):
+        """With state but no objectives, must return empty."""
+        state = MagicMock()
+        state.strategic_objectives = []
+        text, ids = _get_strategic_directives({"_state_object": state})
+        assert text == ""
+        assert ids == []
+
+    def test_completed_objectives_filtered_out(self):
+        """Objectives with status='completed' must not appear."""
+        state = MagicMock()
+        state.strategic_objectives = [
+            {"objective_id": "obj-1", "description": "Done", "status": "completed"},
+        ]
+        text, ids = _get_strategic_directives({"_state_object": state})
+        assert text == ""
+        assert ids == []
+
+    def test_active_objective_formatted(self):
+        """Active objective must be formatted with ID and priority."""
+        state = MagicMock()
+        state.strategic_objectives = [
+            {
+                "objective_id": "obj-fallacy-1",
+                "description": "Focus on ad hominem detection",
+                "status": "active",
+                "priority": "high",
+            },
+        ]
+        text, ids = _get_strategic_directives({"_state_object": state})
+        assert "obj-fallacy-1" in text
+        assert "ad hominem detection" in text
+        assert "high" in text
+        assert ids == ["obj-fallacy-1"]
+
+    def test_in_progress_objective_included(self):
+        """Objectives with status='in_progress' must be included."""
+        state = MagicMock()
+        state.strategic_objectives = [
+            {"id": "obj-42", "text": "Analyser la cohérence", "status": "in_progress"},
+        ]
+        text, ids = _get_strategic_directives({"_state_object": state})
+        assert "obj-42" in text
+        assert ids == ["obj-42"]
+
+    def test_cap_at_five_objectives(self):
+        """More than 5 active objectives must be capped."""
+        state = MagicMock()
+        state.strategic_objectives = [
+            {"objective_id": f"obj-{i}", "description": f"Task {i}", "status": "active"}
+            for i in range(10)
+        ]
+        text, ids = _get_strategic_directives({"_state_object": state})
+        assert len(ids) == 5
+        assert "obj-0" in text
+        assert "obj-4" in text
+        # obj-5 through obj-9 should NOT be present
+        assert "obj-9" not in text
+
+    def test_header_present_when_objectives_exist(self):
+        """The STRATEGIC DIRECTIVES header must be present when objectives exist."""
+        state = MagicMock()
+        state.strategic_objectives = [
+            {"objective_id": "obj-1", "description": "Test", "status": "active"},
+        ]
+        text, ids = _get_strategic_directives({"_state_object": state})
+        assert "STRATEGIC DIRECTIVES" in text
+
+    def test_description_fallback_to_text_key(self):
+        """If 'description' is missing, fall back to 'text' key."""
+        state = MagicMock()
+        state.strategic_objectives = [
+            {"objective_id": "obj-X", "text": "From text key", "status": "active"},
+        ]
+        text, ids = _get_strategic_directives({"_state_object": state})
+        assert "From text key" in text
+
+    def test_objective_without_description_skipped(self):
+        """Objectives without description or text must be skipped."""
+        state = MagicMock()
+        state.strategic_objectives = [
+            {"objective_id": "obj-empty", "status": "active"},
+        ]
+        text, ids = _get_strategic_directives({"_state_object": state})
+        assert text == ""
+        assert ids == []
+
+
+# ---------------------------------------------------------------------------
+# Layer 7: Write→Read chain (PM writes O → callable reads O → output refs O)
+# ---------------------------------------------------------------------------
+class TestWriteReadChain:
+    """End-to-end chain: state has objectives → callable output references them."""
+
+    def test_fallacy_callable_includes_strategic_ids(self):
+        """_invoke_hierarchical_fallacy output must include strategic_objective_ids
+        when the state has active objectives."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_hierarchical_fallacy,
+        )
+
+        # Build a real UnifiedAnalysisState with objectives
+        state = UnifiedAnalysisState("Test text for strategic fallacy analysis.")
+        state.strategic_objectives = [
+            {
+                "objective_id": "obj-fallacy-focus",
+                "description": "Prioritize ad populum detection in political discourse",
+                "status": "active",
+                "priority": "high",
+            },
+        ]
+
+        context = {
+            "_state_object": state,
+            "arguments": ["arg1", "arg2"],
+        }
+
+        # Mock the plugin to avoid LLM calls
+        mock_result = json.dumps({
+            "fallacies": [
+                {
+                    "fallacy_type": "ad_populum",
+                    "confidence": 0.85,
+                    "explanation": "Detected via strategic directive focus",
+                }
+            ],
+            "exploration_method": "taxonomy_guided",
+        })
+
+        mock_plugin = MagicMock()
+        mock_plugin.run_guided_analysis = AsyncMock(return_value=mock_result)
+
+        # Mock at the import source — FallacyWorkflowPlugin is imported locally
+        with patch(
+            "argumentation_analysis.plugins.fallacy_workflow_plugin.FallacyWorkflowPlugin",
+            return_value=mock_plugin,
+        ), patch(
+            "argumentation_analysis.core.llm_service.create_llm_service",
+            return_value=MagicMock(),
+        ), patch(
+            "semantic_kernel.kernel.Kernel",
+            return_value=MagicMock(),
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables._invoke_hierarchical_fallacy_per_argument",
+            side_effect=ImportError("no enrichment"),
+        ):
+            result = _run(_invoke_hierarchical_fallacy("Test input", context))
+
+        # Value-gate: output MUST reference the strategic objective
+        assert "strategic_objective_ids" in result, (
+            "Output must include strategic_objective_ids when state has active objectives"
+        )
+        assert "obj-fallacy-focus" in result["strategic_objective_ids"], (
+            "strategic_objective_ids must contain the objective ID from state"
+        )
+
+    def test_fallacy_callable_no_ids_without_objectives(self):
+        """When state has no objectives, output must NOT include strategic_objective_ids."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_hierarchical_fallacy,
+        )
+
+        state = UnifiedAnalysisState("Test text.")
+        state.strategic_objectives = []
+
+        context = {
+            "_state_object": state,
+            "arguments": ["arg1"],
+        }
+
+        mock_result = json.dumps({
+            "fallacies": [],
+            "exploration_method": "taxonomy_guided",
+        })
+
+        mock_plugin = MagicMock()
+        mock_plugin.run_guided_analysis = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "argumentation_analysis.plugins.fallacy_workflow_plugin.FallacyWorkflowPlugin",
+            return_value=mock_plugin,
+        ), patch(
+            "argumentation_analysis.core.llm_service.create_llm_service",
+            return_value=MagicMock(),
+        ), patch(
+            "semantic_kernel.kernel.Kernel",
+            return_value=MagicMock(),
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables._invoke_hierarchical_fallacy_per_argument",
+            side_effect=ImportError("no enrichment"),
+        ):
+            result = _run(_invoke_hierarchical_fallacy("Test input", context))
+
+        assert "strategic_objective_ids" not in result, (
+            "Output must NOT include strategic_objective_ids when no active objectives"
+        )
+
+    def test_fallacy_receives_directives_in_prompt(self):
+        """Verify the LLM actually receives strategic directives in the argument_text."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_hierarchical_fallacy,
+        )
+
+        state = UnifiedAnalysisState("Test text.")
+        state.strategic_objectives = [
+            {
+                "objective_id": "obj-directive-check",
+                "description": "MANDATORY: detect appeal_to_authority",
+                "status": "active",
+                "priority": "high",
+            },
+        ]
+
+        context = {"_state_object": state}
+
+        mock_result = json.dumps({"fallacies": [], "exploration_method": "test"})
+        mock_plugin = MagicMock()
+        mock_plugin.run_guided_analysis = AsyncMock(return_value=mock_result)
+
+        with patch(
+            "argumentation_analysis.plugins.fallacy_workflow_plugin.FallacyWorkflowPlugin",
+            return_value=mock_plugin,
+        ), patch(
+            "argumentation_analysis.core.llm_service.create_llm_service",
+            return_value=MagicMock(),
+        ), patch(
+            "semantic_kernel.kernel.Kernel",
+            return_value=MagicMock(),
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables._invoke_hierarchical_fallacy_per_argument",
+            side_effect=ImportError("no enrichment"),
+        ):
+            _run(_invoke_hierarchical_fallacy("Original input text", context))
+
+        # The plugin must have been called with directives prepended
+        call_args = mock_plugin.run_guided_analysis.call_args
+        actual_text = call_args.kwargs.get("argument_text", "")
+        assert "STRATEGIC DIRECTIVES" in actual_text, (
+            "Plugin must receive strategic directives in argument_text"
+        )
+        assert "obj-directive-check" in actual_text, (
+            "Plugin argument_text must contain the objective ID"
+        )
+        assert "Original input text" in actual_text, (
+            "Original input text must be preserved after directives"
+        )


### PR DESCRIPTION
## Summary

RA-4 #1049 item 3: Tactical callables now consume strategic objectives written by the PM layer.

### What changed

**Helper function** ():
- `_get_strategic_directives(context)`: extracts active objectives from `state.strategic_objectives` via `context["_state_object"]`, formats as NL directives, returns `(text, objective_id_list)`

**Injection points** (3 callables modified):
1. `_invoke_hierarchical_fallacy` (main path) — directives prepended to `argument_text` before `plugin.run_guided_analysis()`
2. `_invoke_camembert_fallacy` (self-hosted LLM) — same injection pattern
3. `_invoke_fol_reasoning` — directives prepended to `input_text` before 2-pass FOL generation

**Output tracing**:
- Each modified callable adds `strategic_objective_ids` to its result dict when objectives are present (empty → absent, not empty list)

**Tests** (12 new):
- 9 helper unit tests (empty state, completed filter, active/in_progress, cap at 5, header, description fallback, skip no-desc)
- 3 write→read chain tests (output includes IDs, no IDs without objectives, prompt receives directives)

### Value-gate

- PM writes objective → bridge syncs to state → callable reads from state → output references objective ID — **end-to-end verified by test**
- No objectives in state → no injection → no `strategic_objective_ids` in output (clean passthrough)

### Testing

```
42 passed (12 new + 14 RA-4 bridge + 16 RA-8 anti-theater)
0 regressions
```

Part of Epic #1045 Agentic Redressement.