### PR TITLE
fix(llm): honor OpenRouter toggle in 3 client sites that bypassed it (#1068)

### DIFF
--- a/argumentation_analysis/plugins/coordinated_logic_plugin.py
+++ b/argumentation_analysis/plugins/coordinated_logic_plugin.py
@@ -38,14 +38,27 @@ def _parse_json_from_llm(raw: str) -> dict:
 
 
 def _get_openai_client():
-    """Create an AsyncOpenAI client from environment config."""
+    """Create an AsyncOpenAI client from environment config.
+
+    Honors the OpenRouter toggle (same logic as core.llm_service.create_llm_service)
+    so coordinated-logic phases route via OpenRouter when configured.
+    """
     from openai import AsyncOpenAI
 
-    api_key = os.environ.get("OPENAI_API_KEY", "")
+    openrouter_base_url = os.environ.get("OPENROUTER_BASE_URL")
+    openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+    use_openrouter = bool(openrouter_base_url and openrouter_api_key)
+    if use_openrouter:
+        api_key = openrouter_api_key
+        base_url = openrouter_base_url
+        model_id = os.environ.get("OPENROUTER_CHAT_MODEL_ID", "gpt-5-mini")
+    else:
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+        base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+
     if not api_key:
         return None, "", ""
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-    model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
     return AsyncOpenAI(api_key=api_key, base_url=base_url), model_id, api_key
 
 

--- a/argumentation_analysis/services/ai_shield/layers/llm_validator.py
+++ b/argumentation_analysis/services/ai_shield/layers/llm_validator.py
@@ -35,9 +35,20 @@ class LLMValidatorLayer(ShieldLayer):
         model: Optional[str] = None,
     ):
         super().__init__(name="llm_validator", threshold=threshold, enabled=enabled)
-        self._api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
-        self._model = model or os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
-        self._base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        # Honor the OpenRouter toggle (same logic as core.llm_service.create_llm_service).
+        # Without this the shield's LLM validator hit the official OpenAI endpoint
+        # (429 quota) and silently failed-open instead of performing real analysis.
+        openrouter_base_url = os.environ.get("OPENROUTER_BASE_URL")
+        openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+        use_openrouter = bool(openrouter_base_url and openrouter_api_key)
+        if use_openrouter and not api_key:
+            self._api_key = openrouter_api_key
+            self._model = model or os.environ.get("OPENROUTER_CHAT_MODEL_ID", "gpt-5-mini")
+            self._base_url = openrouter_base_url
+        else:
+            self._api_key = api_key or os.environ.get("OPENAI_API_KEY", "")
+            self._model = model or os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+            self._base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
 
     def validate(self, text: str, **kwargs) -> LayerResult:
         """Validate input using LLM analysis.

--- a/argumentation_analysis/services/nl_to_logic.py
+++ b/argumentation_analysis/services/nl_to_logic.py
@@ -273,12 +273,25 @@ class NLToLogicTranslator:
         """Translate via LLM with validate-retry loop."""
         from openai import AsyncOpenAI
 
-        api_key = os.environ.get("OPENAI_API_KEY", "")
+        # Honor the OpenRouter toggle (same logic as core.llm_service.create_llm_service).
+        # Without this, nl_to_logic instantiated its own AsyncOpenAI against the
+        # official OpenAI endpoint, hit 429 quota, and silently fell back to the
+        # heuristic translator — degrading formal-logic phases without any signal.
+        openrouter_base_url = os.environ.get("OPENROUTER_BASE_URL")
+        openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+        use_openrouter = bool(openrouter_base_url and openrouter_api_key)
+        if use_openrouter:
+            api_key = openrouter_api_key
+            base_url = openrouter_base_url
+            model_id = os.environ.get("OPENROUTER_CHAT_MODEL_ID", "gpt-5-mini")
+        else:
+            api_key = os.environ.get("OPENAI_API_KEY", "")
+            base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+            model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+
         if not api_key:
             return self._translate_heuristic(text, logic_type)
 
-        base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-        model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
         client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
         system_prompt = (

--- a/scripts/run_capstone_c1.py
+++ b/scripts/run_capstone_c1.py
@@ -263,14 +263,29 @@ def _extract_phase_metrics(snapshot: Dict[str, Any]) -> Dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 async def run_zeroshot_baseline(corpus_label: str, text: str) -> Dict[str, Any]:
-    """Run 0-shot LLM baseline (single prompt, no tools)."""
+    """Run 0-shot LLM baseline (single prompt, no tools).
+
+    Honors the OpenRouter toggle so the baseline uses the SAME provider as the
+    integral pipeline (create_llm_service). Without this, the baseline hit the
+    official OpenAI endpoint and 429'd on quota while the pipeline (via
+    OpenRouter) succeeded — making the integral-vs-baseline comparison compare
+    two different providers instead of two methods on the same model.
+    """
     print(f"[C1] Starting 0-shot baseline for corpus {corpus_label}...")
     t0 = time.time()
 
-    # Use OpenAI client directly (no SK needed for a single prompt)
     from openai import OpenAI
-    client = OpenAI()  # reads OPENAI_API_KEY from env
-    model = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+    openrouter_base_url = os.environ.get("OPENROUTER_BASE_URL")
+    openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+    use_openrouter = bool(openrouter_base_url and openrouter_api_key)
+    if use_openrouter:
+        api_key = openrouter_api_key
+        model = os.environ.get("OPENROUTER_CHAT_MODEL_ID", "gpt-5-mini")
+        client = OpenAI(api_key=api_key, base_url=openrouter_base_url)
+    else:
+        api_key = os.environ.get("OPENAI_API_KEY")
+        model = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+        client = OpenAI(api_key=api_key)  # reads OPENAI_API_KEY from env
 
     prompt = ZEROSHOT_PROMPT.format(text=text[:8000])  # Limit text for baseline (token budget)
     response = client.chat.completions.create(


### PR DESCRIPTION
## Summary

Three modules instantiated their own `OpenAI`/`AsyncOpenAI` client reading `OPENAI_BASE_URL` directly, **ignoring the `OPENROUTER_BASE_URL`+`OPENROUTER_API_KEY` toggle** that `core.llm_service.create_llm_service` honors. With the toggle ON, these sites still hit the official OpenAI endpoint, 429'd on quota, and **silently fell back** to degraded paths — the exact anti-theater (#1019) failure mode.

### Root cause discovered during FB-20 #1068

The FB-20 corpus_C integral run completed in ~58s but produced `arguments: 0, fallacies: 0` — the pipeline ran but its LLM phases were silently degraded. Investigation found:
- `OPENROUTER_BASE_URL` was missing from `.env` (key present, base_url absent) → toggle `bool(base_url and key)` was `False` everywhere
- **Even with the toggle active**, these 3 code sites bypassed it via direct client instantiation

### Sites fixed (same toggle logic as `create_llm_service`)

| File | Site | Degraded fallback when bypassed |
|------|------|--------------------------------|
| `services/nl_to_logic.py` | `_translate_with_llm` | heuristic translator (no real NL→logic) |
| `plugins/coordinated_logic_plugin.py` | `_get_openai_client` | coordinated PL/FOL phases skipped |
| `services/ai_shield/layers/llm_validator.py` | `LLMValidatorLayer.__init__` | fail-open shield (no real safety analysis) |
| `scripts/run_capstone_c1.py` | `run_zeroshot_baseline` | baseline 429 → integral-vs-baseline compared two providers |

All four retain **identical behavior** when the OpenRouter toggle is OFF (fallback to official OpenAI endpoint).

## Anti-pendule note

This is a **removal of the bypass**, not an added counterweight. Each site now routes through the same toggle as the canonical `create_llm_service` — no new config knob, no parallel mechanism.

## Test plan

- [x] Syntax check all 4 files (`ast.parse`)
- [ ] No regression on official-OpenAI path (toggle OFF → identical behavior, guarded by `if use_openrouter: ... else: <original code>`)
- [ ] FB-20 corpus_C re-run with toggle ON → `arguments > 0, fallacies > 0` (non-degraded)

## Related

- FB-20 #1068 (Phase 4 terminal report — blocked on this for honest measurement)
- Epic #1045 (Agentic Redressement — CLOSED, but the toggle leak was masking its effect)
- Anti-theater mandate #1019

🤖 Generated with [Claude Code](https://claude.com/claude-code)