### PR TITLE
fix(llm): route production OpenAI-client sites through the OpenRouter toggle (#1079)

### DIFF
--- a/argumentation_analysis/adapters/french_fallacy_adapter.py
+++ b/argumentation_analysis/adapters/french_fallacy_adapter.py
@@ -1090,24 +1090,36 @@ class LLMFallacyDetector:
         self._service_discovery = service_discovery
         self._available = None
         self._threshold = confidence_threshold
+        # RA anti-théâtre #1019: observable degradation state. Set True when an
+        # actual API call fails (a bare [] return would be indistinguishable
+        # from "no fallacies found"). Consumers check ``last_degraded``.
+        self._last_degraded: bool = False
+        self._last_error = None
+
+    @property
+    def last_degraded(self) -> bool:
+        """True if the most recent detect_async() failed (API error), else False.
+
+        #1019 signal: distinguishes "LLM tier failed" from "no fallacies found".
+        """
+        return self._last_degraded
 
     def _get_openai_client(self):
-        """Get OpenAI-compatible client and model, same as unified_pipeline."""
-        import os
+        """Get OpenAI-compatible client and model via the canonical toggle.
 
-        api_key = os.environ.get("OPENAI_API_KEY")
+        RA anti-théâtre #1079: routes through ``resolve_chat_endpoint`` (honors
+        the OpenRouter toggle) instead of reading OPENAI_* only, so this tier
+        hits the same provider as the rest of the pipeline (no silent 429).
+        """
+        from argumentation_analysis.core.llm_service import resolve_chat_endpoint
+
+        api_key, base_url, model = resolve_chat_endpoint(default_model="gpt-4o-mini")
         if not api_key:
             return None, None
         try:
             from openai import AsyncOpenAI
 
-            base_url = os.environ.get("OPENAI_BASE_URL")
-            client = AsyncOpenAI(
-                api_key=api_key,
-                **({"base_url": base_url} if base_url else {}),
-            )
-            model = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-4o-mini")
-            return client, model
+            return AsyncOpenAI(api_key=api_key, base_url=base_url), model
         except ImportError:
             return None, None
 
@@ -1122,6 +1134,10 @@ class LLMFallacyDetector:
         client, model = self._get_openai_client()
         if client is None:
             return []
+
+        # Reset per-call degradation state (set on failure below).
+        self._last_degraded = False
+        self._last_error = None
 
         try:
             import json as _json
@@ -1178,7 +1194,17 @@ class LLMFallacyDetector:
             return detections
 
         except Exception as e:
-            logger.error(f"LLM detection failed: {e}")
+            # RA anti-théâtre #1019: a bare [] is indistinguishable from "no
+            # fallacies found". Emit an observable degraded signal a consumer
+            # can act on (detector.last_degraded / .last_error) instead of the
+            # silent [] that previously masked tier failures.
+            self._last_degraded = True
+            self._last_error = str(e)
+            logger.warning(
+                "[DEGRADED] LLMFallacyDetector.detect_async failed: %s "
+                "(returning [] — check detector.last_degraded)",
+                e,
+            )
             return []
 
     def detect(self, text: str) -> List[FallacyDetection]:

--- a/argumentation_analysis/core/llm_service.py
+++ b/argumentation_analysis/core/llm_service.py
@@ -7,7 +7,7 @@ from semantic_kernel.connectors.ai.open_ai import (
     OpenAIChatCompletion,
     AzureChatCompletion,
 )
-from typing import Union, AsyncGenerator, List
+from typing import Union, AsyncGenerator, List, Tuple
 import httpx
 from openai import AsyncOpenAI
 import json
@@ -34,6 +34,43 @@ if not logger.handlers and not logger.propagate:
     logger.addHandler(handler)
     logger.setLevel(logging.INFO)
 logger.info("<<<<< MODULE llm_service.py LOADED >>>>>")
+
+
+def resolve_chat_endpoint(default_model: str = "gpt-5-mini") -> Tuple[str, str, str]:
+    """Resolve the chat endpoint honoring the OpenRouter toggle.
+
+    Single canonical source of truth for routing raw-SDK (non-kernel) LLM
+    chat calls. Mirrors the toggle embedded in :func:`create_llm_service`
+    (this module) and ``orchestration.invoke_callables._get_openai_client``.
+    Anti-pendule (#1019 / anti-théâtre): consults ``OPENROUTER_BASE_URL`` +
+    ``OPENROUTER_API_KEY`` first and falls back to ``OPENAI_*``. Do NOT add a
+    new knob — every raw-SDK caller must go through this so they no longer hit
+    the official OpenAI quota (→ 429 → silent fallback) when OpenRouter is on.
+
+    Args:
+        default_model: model id used when neither ``OPENROUTER_CHAT_MODEL_ID``
+            nor ``OPENAI_CHAT_MODEL_ID`` is set.
+
+    Returns:
+        ``(api_key, base_url, model_id)``. ``api_key`` is ``""`` when no key
+        is configured (callers treat this as "no LLM available"). When the
+        OpenRouter toggle is on, ``base_url`` is the OpenRouter endpoint and
+        ``model_id`` is the provider-prefixed ``OPENROUTER_CHAT_MODEL_ID``.
+    """
+    openrouter_base_url = os.environ.get("OPENROUTER_BASE_URL")
+    openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+    if openrouter_base_url and openrouter_api_key:
+        api_key = openrouter_api_key
+        base_url = openrouter_base_url
+        model_id = os.environ.get(
+            "OPENROUTER_CHAT_MODEL_ID",
+            os.environ.get("OPENAI_CHAT_MODEL_ID", default_model),
+        )
+    else:
+        api_key = os.environ.get("OPENAI_API_KEY", "")
+        base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
+        model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", default_model)
+    return api_key, base_url, model_id
 
 
 # La signature de la fonction est conservée pour la compatibilité, mais on utilise create_llm_service

--- a/argumentation_analysis/evaluation/judge.py
+++ b/argumentation_analysis/evaluation/judge.py
@@ -87,7 +87,6 @@ class LLMJudge:
             model_registry: Optional ModelRegistry for model switching.
         """
         from openai import AsyncOpenAI
-        import os
 
         # Prepare the prompt with smart summarization
         prepared = self._prepare_results_for_judge(analysis_results)
@@ -109,9 +108,17 @@ class LLMJudge:
             model_registry.activate(self.model_name)
 
         try:
-            model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
-            base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-            api_key = os.environ.get("OPENAI_API_KEY", "")
+            # RA anti-théâtre #1079: honor the OpenRouter toggle so the LLM
+            # judge scores the same provider the pipeline used (no silent 429
+            # → zeroed-score fallback masking the real quality).
+            from argumentation_analysis.core.llm_service import resolve_chat_endpoint
+
+            api_key, base_url, model_id = resolve_chat_endpoint()
+            if not api_key:
+                raise ValueError(
+                    "No LLM API key configured (set OPENAI_API_KEY, or "
+                    "OPENROUTER_API_KEY + OPENROUTER_BASE_URL)."
+                )
 
             client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 

--- a/argumentation_analysis/orchestration/collaborative_debate.py
+++ b/argumentation_analysis/orchestration/collaborative_debate.py
@@ -109,13 +109,15 @@ async def _invoke_collaborative_analysis(
     Returns a dict with per-role outputs and final synthesis.
     """
     from openai import AsyncOpenAI
+    from argumentation_analysis.core.llm_service import resolve_chat_endpoint
 
-    api_key = os.environ.get("OPENAI_API_KEY", "")
+    # RA anti-théâtre #1079: route through the OpenRouter toggle (canonical
+    # resolver) so the collaborative debate hits the same provider as the rest
+    # of the pipeline instead of bypassing to official OpenAI → 429.
+    api_key, base_url, model_id = resolve_chat_endpoint()
     if not api_key:
         return _fallback_collaborative(input_text, context)
 
-    base_url = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-    model_id = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
     client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
     # Gather upstream context

--- a/argumentation_analysis/orchestration/router.py
+++ b/argumentation_analysis/orchestration/router.py
@@ -146,8 +146,11 @@ class TextAnalysisRouter:
                       are actually available (have registered providers).
         """
         self.registry = registry
-        self._api_key = os.environ.get("OPENAI_API_KEY")
-        self._model = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+        # RA anti-théâtre #1079: honor the OpenRouter toggle so routing uses the
+        # same provider as the rest of the pipeline (no silent 429 fallback).
+        from argumentation_analysis.core.llm_service import resolve_chat_endpoint
+
+        self._api_key, self._base_url, self._model = resolve_chat_endpoint()
 
     # ----------------------------------------------------------
     # Public API
@@ -236,7 +239,9 @@ class TextAnalysisRouter:
         """Use LLM to determine which capabilities to activate."""
         from openai import AsyncOpenAI
 
-        client = AsyncOpenAI(api_key=self._api_key)
+        # Client built from the toggle-resolved endpoint (init); base_url ensures
+        # OpenRouter is targeted when the toggle is on (anti-théâtre #1079).
+        client = AsyncOpenAI(api_key=self._api_key, base_url=self._base_url)
 
         # Build capability list for the prompt
         cap_lines = []

--- a/tests/unit/argumentation_analysis/core/test_llm_routing_toggle.py
+++ b/tests/unit/argumentation_analysis/core/test_llm_routing_toggle.py
@@ -1,0 +1,240 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for the OpenRouter routing toggle (RA anti-théâtre #1079).
+
+Two layers:
+1. ``resolve_chat_endpoint`` — the canonical resolver in ``core.llm_service``.
+   Env-injected, $0-API: proves the OPENROUTER_* toggle is consulted and that
+   OPENAI_* is the fallback.
+2. Site wiring — proves each production bypass site (router,
+   collaborative_debate, judge, french_fallacy_adapter) now routes the resolved
+   ``base_url`` into its ``AsyncOpenAI`` client instead of hardcoding the
+   official endpoint.
+
+These are the regression guards for the #1079 fix track (leaks surfaced by the
+AUDIT-LLM-ROUTING sweep #1078).
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# 1. Canonical resolver
+# ---------------------------------------------------------------------------
+
+
+class TestResolveChatEndpoint:
+    """resolve_chat_endpoint honors the OPENROUTER_* toggle."""
+
+    def test_openrouter_toggle_on_routes_to_openrouter(self):
+        from argumentation_analysis.core.llm_service import resolve_chat_endpoint
+
+        env = {
+            "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENROUTER_API_KEY": "sk-or-test",
+            "OPENROUTER_CHAT_MODEL_ID": "openai/gpt-5-mini",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            api_key, base_url, model_id = resolve_chat_endpoint()
+        assert api_key == "sk-or-test"
+        assert base_url == "https://openrouter.ai/api/v1"
+        assert model_id == "openai/gpt-5-mini"
+
+    def test_openrouter_model_falls_back_to_openai_chat_model(self):
+        from argumentation_analysis.core.llm_service import resolve_chat_endpoint
+
+        env = {
+            "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENROUTER_API_KEY": "sk-or-test",
+            "OPENAI_CHAT_MODEL_ID": "gpt-5-mini",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            _, _, model_id = resolve_chat_endpoint()
+        assert model_id == "gpt-5-mini"
+
+    def test_no_openrouter_falls_back_to_openai_official(self):
+        from argumentation_analysis.core.llm_service import resolve_chat_endpoint
+
+        env = {"OPENAI_API_KEY": "sk-test", "OPENAI_CHAT_MODEL_ID": "gpt-5-mini"}
+        with patch.dict("os.environ", env, clear=True):
+            api_key, base_url, model_id = resolve_chat_endpoint()
+        assert api_key == "sk-test"
+        assert base_url == "https://api.openai.com/v1"
+        assert model_id == "gpt-5-mini"
+
+    def test_no_key_returns_empty(self):
+        from argumentation_analysis.core.llm_service import resolve_chat_endpoint
+
+        with patch.dict("os.environ", {}, clear=True):
+            api_key, base_url, model_id = resolve_chat_endpoint()
+        assert api_key == ""
+        assert base_url == "https://api.openai.com/v1"
+        assert model_id == "gpt-5-mini"  # default
+
+    def test_partial_openrouter_falls_back_to_openai(self):
+        """Key without base_url (or vice-versa) must NOT enable the toggle."""
+        from argumentation_analysis.core.llm_service import resolve_chat_endpoint
+
+        env = {
+            "OPENROUTER_API_KEY": "sk-or-test",  # no OPENROUTER_BASE_URL
+            "OPENAI_API_KEY": "sk-openai",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            api_key, _, _ = resolve_chat_endpoint()
+        assert api_key == "sk-openai"  # toggle OFF → OpenAI fallback
+
+
+# ---------------------------------------------------------------------------
+# 2. Production sites route the resolved base_url into their client
+# ---------------------------------------------------------------------------
+
+
+class TestSitesConsultToggle:
+    """Each #1079 bypass site passes the OpenRouter base_url to its client."""
+
+    async def test_collaborative_debate_uses_openrouter_base_url(self):
+        from argumentation_analysis.orchestration.collaborative_debate import (
+            _invoke_collaborative_analysis,
+        )
+
+        captured = {}
+
+        class _FakeClient:
+            class chat:
+                class completions:
+                    @staticmethod
+                    async def create(**kwargs):
+                        return _mock_completion()
+
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        env = {
+            "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENROUTER_API_KEY": "sk-or-test",
+            "OPENROUTER_CHAT_MODEL_ID": "openai/gpt-5-mini",
+        }
+        with patch.dict("os.environ", env, clear=True), patch(
+            "openai.AsyncOpenAI", side_effect=_FakeClient
+        ):
+            await _invoke_collaborative_analysis("some text", {})
+        # The client must target OpenRouter, not the official OpenAI endpoint.
+        assert captured.get("base_url") == "https://openrouter.ai/api/v1"
+        assert captured.get("api_key") == "sk-or-test"
+
+    async def test_router_builds_client_with_toggle_base_url(self):
+        from argumentation_analysis.orchestration.router import TextAnalysisRouter
+
+        env = {
+            "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENROUTER_API_KEY": "sk-or-test",
+            "OPENROUTER_CHAT_MODEL_ID": "openai/gpt-5-mini",
+        }
+        with patch.dict("os.environ", env, clear=True):
+            router = TextAnalysisRouter()
+        # __init__ must derive the endpoint from the toggle.
+        assert router._api_key == "sk-or-test"
+        assert router._base_url == "https://openrouter.ai/api/v1"
+        assert router._model == "openai/gpt-5-mini"
+
+    async def test_french_fallacy_adapter_get_client_uses_toggle(self):
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            LLMFallacyDetector,
+        )
+
+        captured = {}
+
+        class _FakeAsyncOpenAI:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        env = {
+            "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENROUTER_API_KEY": "sk-or-test",
+            "OPENROUTER_CHAT_MODEL_ID": "openai/gpt-5-mini",
+        }
+        with patch.dict("os.environ", env, clear=True), patch(
+            "openai.AsyncOpenAI", side_effect=_FakeAsyncOpenAI
+        ):
+            client, model = LLMFallacyDetector()._get_openai_client()
+        assert client is not None
+        assert captured.get("base_url") == "https://openrouter.ai/api/v1"
+        assert model == "openai/gpt-5-mini"
+
+    async def test_judge_routes_through_toggle(self):
+        from argumentation_analysis.evaluation.judge import LLMJudge
+
+        captured = {}
+
+        class _FakeClient:
+            class chat:
+                class completions:
+                    @staticmethod
+                    async def create(**kwargs):
+                        return _mock_completion(
+                            content='{"completeness": 3, "accuracy": 3, "depth": 3, '
+                            '"coherence": 3, "actionability": 3, "overall": 3, '
+                            '"reasoning": "ok"}'
+                        )
+
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        env = {
+            "OPENROUTER_BASE_URL": "https://openrouter.ai/api/v1",
+            "OPENROUTER_API_KEY": "sk-or-test",
+            "OPENROUTER_CHAT_MODEL_ID": "openai/gpt-5-mini",
+        }
+        with patch.dict("os.environ", env, clear=True), patch(
+            "openai.AsyncOpenAI", side_effect=_FakeClient
+        ):
+            await LLMJudge().evaluate("text", "standard", {})
+        assert captured.get("base_url") == "https://openrouter.ai/api/v1"
+        assert captured.get("api_key") == "sk-or-test"
+
+    async def test_fallacy_adapter_emits_degraded_signal_on_failure(self):
+        """#1019: an API failure sets last_degraded (no silent [])."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            LLMFallacyDetector,
+        )
+
+        class _FailingClient:
+            class chat:
+                class completions:
+                    @staticmethod
+                    async def create(**kwargs):
+                        raise RuntimeError("upstream 429")
+
+            def __init__(self, **kwargs):
+                pass
+
+        env = {"OPENAI_API_KEY": "sk-test"}
+        detector = LLMFallacyDetector()
+        with patch.dict("os.environ", env, clear=True), patch(
+            "openai.AsyncOpenAI", side_effect=_FailingClient
+        ):
+            result = await detector.detect_async("some text")
+        assert result == []  # return type preserved (tier-fallback contract)
+        assert detector.last_degraded is True  # observable signal present
+        assert "429" in (detector._last_error or "")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_completion(
+    content: str = '{"capabilities": [], "workflow_complexity": "standard"}',
+):
+    """Build a minimal mock OpenAI chat completion response."""
+    from unittest.mock import MagicMock
+
+    message = MagicMock()
+    message.content = content
+    choice = MagicMock()
+    choice.message = message
+    response = MagicMock()
+    response.choices = [choice]
+    return response

--- a/tests/unit/argumentation_analysis/test_collaborative_debate.py
+++ b/tests/unit/argumentation_analysis/test_collaborative_debate.py
@@ -295,7 +295,18 @@ class TestInvokeCollaborativeAnalysis:
         """Without API key, should use heuristic fallback."""
         context = {"phase_extract_output": {"arguments": [{"text": "Test argument"}]}}
 
-        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+        # Blank BOTH providers so the toggle (now honored via resolve_chat_endpoint,
+        # #1079) resolves to no key → heuristic fallback. Robust to --allow-dotenv
+        # or OS env carrying OPENROUTER_*.
+        with patch.dict(
+            "os.environ",
+            {
+                "OPENAI_API_KEY": "",
+                "OPENROUTER_API_KEY": "",
+                "OPENROUTER_BASE_URL": "",
+            },
+            clear=False,
+        ):
             result = await _invoke_collaborative_analysis("test text", context)
 
         assert result["interaction_type"] == "fallback_heuristic"


### PR DESCRIPTION
## What

Fix track for **#1079** (filed by the AUDIT-LLM-ROUTING sweep **#1078**, report `docs/reports/AUDIT_LLM_ROUTING.md`).

The audit found **4 production sites** that instantiated their own `AsyncOpenAI` reading `OPENAI_*` only, **bypassing** the `OPENROUTER_BASE_URL`+`OPENROUTER_API_KEY` toggle honored by `core.llm_service.create_llm_service`. When the toggle is ON, these sites still hit the official endpoint → **429 → silent fallback** — the exact anti-théâtre #1019 failure mode that masked Epic #1045's effect in the FB-20 measurement (a "successful" 58s run produced `arguments:0, fallacies:0`).

## Fix (anti-pendule #1019: remove the bypass, do NOT add a knob)

Added **ONE canonical resolver**, `resolve_chat_endpoint()`, in `core/llm_service.py` (the toggle's home), mirroring `invoke_callables._get_openai_client`. Each site builds its client from the resolved `(api_key, base_url, model)`:

| Site | Change |
|------|--------|
| `orchestration/router.py` | `__init__` derives `_api_key/_base_url/_model` from the resolver; `_route_with_llm` builds `AsyncOpenAI(api_key, base_url=...)` |
| `orchestration/collaborative_debate.py` | `_invoke_collaborative_analysis` resolves via the helper (early heuristic fallback still signaled) |
| `evaluation/judge.py` | `evaluate` resolves via the helper; raises on missing key (caught by the existing zeroed-score fallback) |
| `adapters/french_fallacy_adapter.py` | `LLMFallacyDetector._get_openai_client` routes via the helper; **`detect_async` emits an observable `last_degraded` signal on API failure** instead of a bare `[]` indistinguishable from "no fallacies found" (exact #1019 shape) |

## Degraded signal (#1019)

`LLMFallacyDetector.detect_async` previously swallowed API errors into `[]` with no signal. It now sets `last_degraded=True` + `last_error` (a property consumers can check) and logs a `[DEGRADED]` line. Return type is preserved (`List[FallacyDetection]`) to keep the multi-tier fallback contract intact; the signal is the enabling change.

## Tests

New `tests/unit/argumentation_analysis/core/test_llm_routing_toggle.py` (env-injected, **$0-API**):
- `resolve_chat_endpoint` honors the toggle — 5 cases (toggle ON → OpenRouter; model fallback; toggle OFF → official; no key → empty; partial toggle → fallback).
- Each of the 4 sites passes the OpenRouter `base_url` into its `AsyncOpenAI` client (mock-captured kwargs).
- `detect_async` sets `last_degraded` on failure.

Hardened the collaborative no-key test to blank `OPENROUTER_*` so its "no key → heuristic" premise holds now that the toggle is honored.

**124 affected tests pass** (router, collaborative_debate, judge_advanced, french_fallacy_adapter, llm_service, + new toggle test). black clean.

## Lane / scope

- **Disjoint from po-2025's #1083** (PL regression — `nl_to_logic`/PL prompt, already HONORS post-#1077).
- **Does NOT touch the 4 files fixed by #1077** (`nl_to_logic`, `coordinated_logic_plugin`, `llm_validator`, `run_capstone_c1`).
- LOW-priority sites (embeddings, legacy `unified_production_analyzer`, `narrative_agent`) left for a follow-up — documented in the audit; this PR targets the HIGH/MEDIUM production sites + the silent-degradation path.

No dataset content; opaque IDs only.

Closes #1079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)