### PR TITLE
fix(logic): add missing PLHandler.check_consistency — unmask latent PL=0 bug (#1083)

### DIFF
--- a/argumentation_analysis/agents/core/logic/pl_handler.py
+++ b/argumentation_analysis/agents/core/logic/pl_handler.py
@@ -1,7 +1,7 @@
 import jpype
 import re
 import logging
-from typing import Optional, List
+from typing import Optional, List, Tuple
 
 # La configuration du logging (appel à setup_logging()) est supposée être faite globalement,
 # par exemple au point d'entrée de l'application ou dans conftest.py pour les tests.
@@ -170,6 +170,31 @@ class PLHandler:
                 exc_info=True,
             )
             raise
+
+    def check_consistency(self, belief_set: str) -> Tuple[bool, str]:
+        """Uniform handler API mirroring ``FOLHandler.check_consistency``.
+
+        ``TweetyBridge.check_consistency(belief_set, "propositional")`` dispatches
+        here. PLHandler previously exposed only ``pl_check_consistency`` /
+        ``pl_check_consistency_sat``, so the dispatch raised ``AttributeError`` on
+        *every* formula — collapsing the per-formula isolation loop in
+        ``_invoke_propositional_logic`` to 0 survivors (PL=0), which RA-8 #1066
+        unmasked once it removed the Python-heuristic fallback (#1083).
+
+        Delegates to ``pl_check_consistency`` (Tweety). Parse errors propagate
+        unchanged so the per-formula isolation keeps valid formulas and rejects
+        unparseable ones rather than swallowing the whole batch.
+
+        Returns:
+            Tuple[bool, str]: ``(is_consistent, message)``.
+        """
+        is_consistent = self.pl_check_consistency(belief_set)
+        msg = (
+            "PL knowledge base is consistent."
+            if is_consistent
+            else "PL knowledge base entails a contradiction."
+        )
+        return bool(is_consistent), msg
 
     def pl_check_consistency(
         self, knowledge_base_str: str, constants: Optional[List[str]] = None

--- a/docs/reports/FB20_PHASE4_TERMINAL_REPORT.md
+++ b/docs/reports/FB20_PHASE4_TERMINAL_REPORT.md
@@ -97,7 +97,9 @@ completes, this section will be refreshed.
 
 ### 2.C Formal Logic Analysis
 
-- **PL verdicts**: **25 formulas** (non-zero, unlike corpora B/C which both yielded PL=0 today) — on the 2026-06-10 run the LLM-generated formula syntax was parseable by Tweety. **Noting a PL regression risk**: today's runs (B/C) all yielded PL=0, suggesting the formula-generation or Tweety-parsing path may have degraded between 06-10 and 06-13. Flagged for investigation.
+- **PL verdicts**: ~~25 formulas~~ **CORRECTED by FB-21 #1083** (see below). The 25 were **Python-heuristic fallback** (`"fallback": "python"`, `has_contradiction = any(f.startswith("!"))`) synthesizing a non-empty result when Tweety could not parse — **not real Tweety verification**. This was the exact #1019 theater mode: a non-zero PL count masking a broken verification path.
+
+  > **FB-21 #1083 correction**: `TweetyBridge.check_consistency("propositional")` dispatched to `PLHandler.check_consistency` — a method that **never existed** (PLHandler only exposed `pl_check_consistency`/`pl_check_consistency_sat`). Every formula raised `AttributeError`, collapsing the per-formula isolation loop to 0 survivors. On 06-10 this was masked by a Python fallback; **RA-8 #1066** (`c685ed5e`) correctly removed that theater-fallback (replaced with fail-loud `RuntimeError`), exposing the latent bug as PL=0 on 06-13. FB-21 fixes it by adding the missing `PLHandler.check_consistency` (mirrors `FOLHandler`). Post-fix corpus_C re-run: **pl_verified=18** (real 2-pass LLM formulas, `template:0`, 3/4 implications Tweety-verified per-formula in isolated test). The "PL regression 06-10→06-13" hypothesis (§5.3 below) is **REFUTED** — there was no regression, only a latent bug unmasked by anti-theater work.
 - **FOL consistency**: **8 formulas, all 8 verified**.
 - **Abstract argumentation (Dung/ASPIC)**: 12 frameworks, 1 130 extensions.
 
@@ -109,11 +111,11 @@ completes, this section will be refreshed.
 
 ### 2.E Convergence Synthesis
 
-- **5-signal convergence**: fallacies (8) + counter-args (16) + jtms (44) + dung (1 130) + **PL (25)**. Quality MISSING (4/5), but PL is present here (unlike B/C) — so this corpus shows the strongest formal-logic convergence of the three.
+- **5-signal convergence**: fallacies (8) + counter-args (16) + jtms (44) + dung (1 130) + ~~PL (25)~~ (FB-21 #1083: those 25 were Python-fallback theater, not real Tweety — see §2.C). Quality MISSING (4/5). corpus_A's strongest real formal signals are FOL 8/8 + 12 Dung frameworks.
 
 ### 2.CONCLUSION — corpus_A verdict vs 0-shot
 
-> _Provisional: the pipeline DECIDES on formal grounding (PL 25 formulas + FOL 8/8 + 12 Dung frameworks + 16 counter-args + 44 JTMS) the baseline cannot produce. corpus_A is the strongest case — it is the only corpus where PL verification succeeded. Verdict **EDGES to DECIDES** pending the fresh post-fix run confirmation (the 06-10 provenance caps certainty). See §5._
+> _FB-21 #1083 correction: the earlier "PL 25 → EDGES to DECIDES" framing rested on the 06-10 PL count, which FB-21 proved was Python-heuristic fallback theater (not Tweety verification). With that corrected, corpus_A's real formal grounding is FOL 8/8 + 12 Dung frameworks + 16 counter-args + 44 JTMS — still a genuine EDGES over the baseline, but no longer the unique PL-deciding corpus. Verdict **EDGES** (aligned with corpora B/C)._
 
 ---
 
@@ -192,15 +194,16 @@ Scored against the 11-category rubric. Ordinal scale: **DECIDES** (pipeline stri
 
 | Corpus | score_B | ordinal_B |
 |--------|---------|-----------|
-| doc_C | FOL 15/15, 12 Dung fw, 20 counter-args, 46 JTMS, 10 fallacies — but PL=0, quality MISSING | **EDGES** |
-| doc_A | PL **25** (only corpus with PL verdicts) + FOL 8/8, 12 Dung fw, 16 counter-args, 44 JTMS, 8 fallacies — quality MISSING *(06-10 provenance)* | **EDGES→DECIDES** |
-| doc_B | FOL 12/12, 12 Dung fw, 12 counter-args, 40 JTMS, 6 fallacies (truncated) — PL=0, quality MISSING | **EDGES** |
+| doc_C | FOL 15/15, 12 Dung fw, 20 counter-args, 46 JTMS, 10 fallacies — PL=0 (pre-#1083), quality MISSING | **EDGES** |
+| doc_A | ~~PL **25**~~ (FB-21: that was Python-fallback theater, not Tweety) + FOL 8/8, 12 Dung fw, 16 counter-args, 44 JTMS, 8 fallacies — quality MISSING *(06-10 provenance)* | **EDGES** |
+| doc_B | FOL 12/12, 12 Dung fw, 12 counter-args, 40 JTMS, 6 fallacies (truncated) — PL=0 (pre-#1083), quality MISSING | **EDGES** |
+
+> **FB-21 #1083 update**: the "PL=0 on B/C" gap was a **latent code bug** (`PLHandler.check_consistency` missing), not "Tweety rejects LLM-generated syntax" as originally written. FB-21 adds the missing method; a post-fix corpus_C re-run yields **pl_verified=18** (real 2-pass LLM formulas, per-formula Tweety-isolated). The PL axis is no longer structurally capped — but the quality radar gap (spacy) remains, so the verdict stays EDGES pending a full A/B/C re-run with #1083. The "PL regression 06-10→06-13" risk in §5.3 is **REFUTED** (latent bug, not regression).
 
 **Why EDGES, not DECIDES**: the pipeline produces formal artifacts (FOL verified, Dung extensions,
 JTMS beliefs, counter-arguments) that the 0-shot baseline structurally **cannot** — that is a
 genuine DECIDES axis. But two honest gaps cap it at EDGES this run:
-1. **PL verification gap** (Tweety rejects LLM-generated syntax) → the propositional-logic axis
-   produces 0 verdicts, so one of the 11 categories is effectively TIES/MISSED, not DECIDES.
+1. **PL verification gap** (~~Tweety rejects LLM-generated syntax~~ → **latent missing-method bug, FIXED by #1083**; the corpus_A "PL=25" was heuristic-fallback theater, not real verification). Post-#1083 corpus_C shows PL=18 real; a full re-run would lift this axis — not yet reflected in the corpus-specific scores above.
 2. **Quality radar MISSING** (spacy WinError 182) → the 9-virtue quality category is unevaluated.
 
 The FOL + Dung + JTMS + counter-argument + fallacy axes still DECIDE; the min-rule across the
@@ -232,13 +235,13 @@ Epic verdict = min(ordinal_B_doc_A, ordinal_B_doc_B, ordinal_B_doc_C)
 |--------|-----------|
 | doc_C | EDGES |
 | doc_B | EDGES |
-| doc_A | EDGES→DECIDES (06-10 provenance; PL=25 is the deciding factor, but re-run pending) |
+| doc_A | EDGES (FB-21: the earlier "EDGES→DECIDES" was inflated by Python-fallback PL theater — corrected; corpus_A aligns with B/C) |
 
 **Epic verdict (min rule) = EDGES**. No corpus at LOSES. The closure bar (≥ EDGES, no LOSES) is **met**.
 
-The verdict is capped at EDGES (not DECIDES) for two honest reasons:
-1. **PL regression risk**: corpus_A (06-10) shows PL=25, but today's corpus_B and corpus_C both yield PL=0 (Tweety rejects LLM-generated formula syntax). If the post-fix re-run of corpus_A also yields PL=0, even doc_A drops to EDGES. The PL axis is the swing factor.
-2. **Quality radar gap**: the spacy/textstat WinError 182 failure is structural across all three corpora — the 9-virtue quality category is unevaluated everywhere.
+The verdict is capped at EDGES (not DECIDES) for the following honest reasons:
+1. **PL axis (~~regression risk~~ → RESOLVED by FB-21 #1083)**: the apparent "PL 06-10=25 → 06-13=0" was **not a regression**. The 06-10 "25" was Python-heuristic fallback theater; the 06-13 "0" was RA-8 #1066 correctly killing that theater, exposing a latent bug (`PLHandler.check_consistency` missing). FB-21 #1083 fixes the bug — post-fix corpus_C shows **pl_verified=18** (real). The PL axis is no longer a swing factor capping DECIDES; a full A/B/C re-run with #1083 would lift it. Not reflected in the corpus scores above because the re-run is not yet complete for A/B.
+2. **Quality radar gap**: the spacy/textstat WinError 182 failure is structural across all three corpora — the 9-virtue quality category is unevaluated everywhere. **This is now the single remaining cap on DECIDES.**
 
 A DECIDES verdict would require both the PL axis (all corpora) and the quality axis to produce verdicts — out of FB-20 scope (plumbing, not brick-fix per dispatch).
 
@@ -271,10 +274,18 @@ A DECIDES verdict would require both the PL axis (all corpora) and the quality a
 58s with arguments=0/fallacies=0 — the exact anti-theater failure mode this report must avoid.
 
 **Known degradations this run (honest, not fabricated)**:
-- `quality` phase FAILED (spacy/textstat WinError 182, torch DLL order) → no 9-virtue radar.
-- `pl` phase FAILED (Tweety solvers reject LLM-generated formula syntax) → 0 PL verdicts.
+- `quality` phase FAILED (spacy/textstat WinError 182, torch DLL order) → no 9-virtue radar. **Now the single remaining cap on DECIDES** post-FB-21.
+- ~~`pl` phase FAILED (Tweety solvers reject LLM-generated formula syntax) → 0 PL verdicts.~~ **CORRECTED by FB-21 #1083**: the real cause was a missing `PLHandler.check_consistency` method (not formula syntax). Post-fix corpus_C: pl_verified=18. The corpus_A "PL=25" was Python-fallback theater.
 - `probabilistic` FAILED (Tweety JAR missing class) / `stakes` FAILED (`'str' has no .get`).
 - `fallacy_families` aggregated to `unknown` (per-fallacy family field not populated in snapshot).
 
 **Anti-pendule note**: This is a RUN + curated report, not a code-fix track. The PR #1077 plumbing
 fix was necessary to make the measurement honest (anti-theater), not a brick re-fix.
+
+**Post-publication correction (FB-21 #1083)**: this report originally attributed PL=0 to
+"Tweety rejecting LLM-generated formula syntax" and corpus_A's PL=25 to "the only corpus where
+verification succeeded". FB-21's investigation disproved both: corpus_A's 25 were Python-heuristic
+fallback theater (the exact #1019 anti-pattern), and the PL=0 was a latent missing-method bug
+unmasked by RA-8's correct removal of that fallback. The verdict remains **EDGES** (quality gap
+still caps DECIDES), but the PL axis is no longer a cap and corpus_A no longer claimed as the
+unique PL-deciding corpus. Corrections marked inline above with `~~strikethrough~~` + FB-21 note.

--- a/docs/reports/FB21_PL_VERIFICATION_ROOT_CAUSE.md
+++ b/docs/reports/FB21_PL_VERIFICATION_ROOT_CAUSE.md
@@ -1,0 +1,140 @@
+# FB-21 — PL Verification Root-Cause Analysis (#1083)
+
+**Track**: FB-21 #1083 — Epic #947 (Final Boss), PL formal-verification gap
+**Date**: 2026-06-14
+**Base**: main `f8b39ed8`
+**Privacy**: Opaque IDs only. Synthetic test arguments only (no corpus content). $0-API for diagnosis.
+
+---
+
+## Summary
+
+The FB-20 terminal report (#1068) attributed **PL=0 on corpus_B/C** to "Tweety rejecting LLM-generated
+formula syntax" and **corpus_A's PL=25** to "the only corpus where verification succeeded". **Both
+claims were wrong.** FB-21 proves:
+
+1. **corpus_A's PL=25 was Python-heuristic fallback theater** (`"fallback": "python"`,
+   `has_contradiction = any(f.startswith("!"))`), not real Tweety verification — the exact #1019
+   anti-pattern the Epic exists to kill.
+2. **PL=0 on B/C was a latent missing-method bug**, unmasked by RA-8 #1066's *correct* removal of
+   that fallback. It was **not** a formula-syntax issue, and **not** a regression in `nl_to_logic`.
+
+The fix adds the missing `PLHandler.check_consistency` (mirroring `FOLHandler`). Post-fix corpus_C
+re-run yields **pl_verified=18** (real 2-pass LLM formulas, `template:0`, per-formula Tweety-isolated).
+
+---
+
+## Investigation method (SDDD triple grounding)
+
+### Technique (code = truth)
+
+**Git archaeology** discriminated the two hypotheses the issue framed:
+
+- **H1 (regression in `nl_to_logic` 06-10 → 06-13)**: REFUTED. The only commit touching
+  `nl_to_logic.py` in the window is `b613ee5a` (#1077 toggle fix). The PL prompt has not changed.
+- The real regression window is on `invoke_callables.py`: commit **`c685ed5e` (RA-8 #1066)**
+  removed the Python-heuristic PL fallback and replaced it with fail-loud `RuntimeError`. That
+  diff exposed a bug that had been **latent** all along.
+
+### Empirical probe (decisive, $0-API)
+
+A diagnostic called the exact code path `_invoke_propositional_logic` uses:
+
+```
+PLHandler has 'check_consistency'?        False   ← TweetyBridge.check_consistency(prop) dispatches HERE (tweety_bridge.py:274)
+PLHandler has 'pl_check_consistency'?     True    ← but only THIS exists (Tweety)
+PLHandler has 'pl_check_consistency_sat'? True    ← and THIS (PySAT, but python-sat NOT installed)
+[ATTR] 'p => q': AttributeError -> 'PLHandler' object has no attribute 'check_consistency'
+```
+
+**Every** formula — even the textbook `p => q` — raised `AttributeError`, collapsing the per-formula
+isolation loop (`invoke_callables.py:4586`) to 0 survivors → `RuntimeError` → PL=0. This is
+independent of formula content, so it is **not** H2 (provider variance) either.
+
+### Verification of the existing path
+
+`PLHandler.pl_check_consistency` (Tweety) **works** — and the suspect formula
+`transfers => imposed` parses fine (consistent=True). The real Tweety parser rejects only specific
+operator-precedence shapes (`&&`/`||` without parentheses, under-parenthesized nested `=>`), which
+the per-formula isolation loop already handles correctly. The PySAT alternative
+(`pl_check_consistency_sat`) is unavailable (`python-sat` not installed).
+
+---
+
+## Root cause
+
+Two layers, one fix:
+
+| Layer | Fact | Effect |
+|-------|------|--------|
+| **Latent bug** | `TweetyBridge.check_consistency("propositional")` → `PLHandler.check_consistency` — a method that **never existed** (PLHandler only exposed `pl_check_consistency` / `pl_check_consistency_sat`). | Every PL formula → `AttributeError` → batch collapses to 0. PL was **always** broken on the dispatch path. |
+| **Theater mask** | `_invoke_propositional_logic` had a Python-heuristic fallback that synthesized a non-empty `formulas` list (`has_contradiction = any(f.startswith("!"))`) whenever Tweety failed. | On 06-10 (corpus_A) this returned 25 "formulas" — reported as "PL verified" but they were heuristic, not Tweety. |
+| **Anti-theater (RA-8 #1066)** | Correctly removed the Python fallback, replaced with fail-loud `RuntimeError`. | Exposed the latent bug → PL=0 on 06-13. RA-8 did the right thing; it is not at fault. |
+
+### The bitter irony
+
+RA-8 was the **anti-theater** fix. It removed a heuristic that faked non-zero PL. But the code it
+left calling (`bridge.check_consistency(prop)`) routed to a missing method — producing a *new*
+theater-like symptom (PL silently = 0). The anti-theater mandate (#1019) means both the heuristic
+theater (06-10) and the silent-zero theater (06-13) must be corrected, and the report must say so.
+
+---
+
+## The fix (anti-pendule: complete the missing method, no counterweight)
+
+`argumentation_analysis/agents/core/logic/pl_handler.py`:
+
+```python
+def check_consistency(self, belief_set: str) -> Tuple[bool, str]:
+    """Uniform handler API mirroring FOLHandler.check_consistency (#1083)."""
+    is_consistent = self.pl_check_consistency(belief_set)
+    msg = ("PL knowledge base is consistent." if is_consistent
+           else "PL knowledge base entails a contradiction.")
+    return bool(is_consistent), msg
+```
+
+- Completes the API parity with `FOLHandler.check_consistency` (which already exists and works).
+- Delegates to the existing **working** `pl_check_consistency` (Tweety).
+- Parse errors propagate unchanged → per-formula isolation keeps valid formulas, rejects unparseable
+  ones, never swallows the batch.
+- No try/except widening, no `pl_check_consistency_sat` detour (PySAT not installed).
+
+### Regression guard
+
+`tests/agents/core/logic/test_tweety_bridge.py::test_pl_check_consistency_delegation` asserts the
+dispatch now reaches `PLHandler.check_consistency` (mocked: fast, $0-API) and that a real JVM
+accepts the textbook `p => q`. **No such test existed before — that is why the bug shipped.**
+
+---
+
+## Verification (DoD)
+
+| DoD item | Evidence |
+|----------|----------|
+| Root cause identified (regression vs variance) | H1 refuted (git: prompt unchanged); latent missing-method bug unmasked by RA-8 #1066. See §Investigation. |
+| Fix at correct layer (prompt/validation, not error-swallow) | Added the missing method at the dispatch target. No try/except widened, no fallback restored. |
+| PL > 0 verified on real corpus re-run | corpus_C re-run post-fix: `pl_verified=18` (gitignored `integral_C.json`, fresh `2026-06-14T00:40`). |
+| Anti-theater (not template `p1/p2` dummies) | Isolated call of `_invoke_propositional_logic` on synthetic opaque args: `pl_metrics={template:0, pass1_atoms:9, pass2_candidates:4, post_tweety:3, isolation_survivors:3}`, formulas are real implications (`economic_sanctions_imposed => trade_volumes_decrease`, etc.), 0 bare-atom dummies, `rejected_count=1` (malformed `&` correctly isolated out). |
+| Finding documented + FB-20 report corrected | This doc + FB-20 report §2.C/§2.E/§2.CONCLUSION/§5.1/§5.3/§7 corrections (marked `~~strikethrough~~` + FB-21 note). |
+
+---
+
+## Impact on Epic #947 verdict
+
+- **PL axis is no longer a cap on DECIDES.** The "PL=0" gap was the *code bug*, now fixed.
+- **corpus_A is no longer the unique "PL-deciding" corpus** — its 25 were theater.
+- **Verdict remains EDGES**: the **quality radar** (spacy WinError 182) is now the single remaining
+  cap on a clean DECIDES. A full A/B/C re-run with #1083 would lift the PL axis; the quality axis
+  needs a separate fix (DLL load order, out of FB-21 scope).
+- **Anti-theater dividend**: the investigation corrected a theater claim (corpus_A PL=25) *that this
+  very report had made*. This is the mandate working as intended.
+
+---
+
+## Privacy / scope
+
+- Synthetic test arguments only (no corpus content). Diagnosis was $0-API (JVM/Tweety only).
+- File-disjoint from #1079 (po-2023): that targets `router.py` / `collaborative_debate.py` /
+  `french_fallacy_adapter.py` / `judge.py`. This fix touches `pl_handler.py` + `test_tweety_bridge.py` + the
+  FB-20 report doc. Zero overlap.
+- No deletions (Cleanup Gate N/A).

--- a/tests/agents/core/logic/test_tweety_bridge.py
+++ b/tests/agents/core/logic/test_tweety_bridge.py
@@ -141,6 +141,32 @@ class TestTweetyBridge(unittest.TestCase):
             except Exception as e:
                 self.fail(f"fol_query a levé une exception inattendue: {e}")
 
+    def test_pl_check_consistency_delegation(self):
+        """PLHandler exposes the uniform check_consistency API (#1083).
+
+        Regression guard: TweetyBridge.check_consistency(belief, "propositional")
+        must dispatch to PLHandler.check_consistency. Before #1083, PLHandler only
+        exposed pl_check_consistency/pl_check_consistency_sat, so the dispatch raised
+        AttributeError on every formula -> the per-formula isolation loop in
+        _invoke_propositional_logic collapsed to 0 survivors (PL=0).
+        """
+        belief_set = "p => q"
+        if not self.use_real_jpype:
+            self.mock_pl_handler_instance.check_consistency.return_value = (
+                True,
+                "consistent",
+            )
+            ok, msg = self.bridge.check_consistency(belief_set, "propositional")
+            self.mock_pl_handler_instance.check_consistency.assert_called_once_with(
+                belief_set
+            )
+            self.assertTrue(ok)
+            self.assertEqual(msg, "consistent")
+        else:
+            # Real JVM: the textbook implication must parse and report consistent.
+            ok, _msg = self.bridge.check_consistency(belief_set, "propositional")
+            self.assertTrue(ok)
+
     def test_validate_pl_formula_delegation(self):
         """Vérifie que validate_pl_formula délègue correctement."""
         formula = "a => b"


### PR DESCRIPTION
## Summary

Fixes **#1083** (FB-21 — Epic #947 PL formal-verification gap). The FB-20 report attributed PL=0 on corpus_B/C to "Tweety rejecting LLM-generated formula syntax" and corpus_A PL=25 to "the only corpus where verification succeeded". **Both were wrong.**

## Root cause (investigate-then-fix)

`TweetyBridge.check_consistency(belief, "propositional")` dispatches to `PLHandler.check_consistency` (`tweety_bridge.py:274`) — a method that **never existed** (PLHandler only exposed `pl_check_consistency`/`pl_check_consistency_sat`). Every formula raised `AttributeError`, collapsing the per-formula isolation loop (`invoke_callables.py:4586`) to 0 survivors → PL=0. Independent of formula content (even `p => q` failed).

**Hypotheses discriminated:**
- **H1 (nl_to_logic regression 06-10→06-13): REFUTED** — git log shows the only commit touching `nl_to_logic.py` in the window is `b613ee5a` (#1077 toggle fix); the PL prompt is unchanged.
- **Real cause**: `c685ed5e` (RA-8 #1066) correctly removed a Python-heuristic PL fallback (`"fallback": "python"`, `has_contradiction = any(f.startswith("!"))`) — the #1019 theater mode — and replaced it with fail-loud `RuntimeError`. That exposed this **latent** missing-method bug as PL=0. RA-8 did the right thing; it is not at fault.

**The bitter irony**: the 06-10 corpus_A "PL=25 verified" was that Python-heuristic **fallback theater**, not real Tweety verification. This report had cited it as the strongest formal-logic convergence. Corrected below.

## The fix (anti-pendule: complete the missing method, no counterweight)

`pl_handler.py` — add `check_consistency` mirroring `FOLHandler.check_consistency`, delegating to the existing **working** `pl_check_consistency` (Tweety). Parse errors propagate unchanged → per-formula isolation keeps valid formulas, rejects unparseable ones, never swallows the batch. No try/except widened, no fallback restored.

```python
def check_consistency(self, belief_set: str) -> Tuple[bool, str]:
    is_consistent = self.pl_check_consistency(belief_set)
    msg = ("PL knowledge base is consistent." if is_consistent
           else "PL knowledge base entails a contradiction.")
    return bool(is_consistent), msg
```

## Verification (DoD #1083)

| Item | Evidence |
|------|----------|
| Root cause identified | H1 refuted by git log; latent missing-method bug unmasked by RA-8 #1066 |
| Fix at correct layer | Added missing method at dispatch target; no error-swallow |
| PL>0 on real corpus | corpus_C re-run post-fix: **pl_verified=18** (was 0) |
| Anti-theater (not template dummies) | Isolated `_invoke_propositional_logic`: `pl_metrics={template:0, pass2_candidates:4, post_tweety:3, isolation_survivors:3}`, real implication formulas, 0 bare-atom dummies |
| Finding documented | `docs/reports/FB21_PL_VERIFICATION_ROOT_CAUSE.md` |
| Report corrected | FB-20 report §2.C/§2.E/§2.CONCLUSION/§5.1/§5.3/§7 (marked `~~strikethrough~~`) |

## Tests

New regression guard `test_pl_check_consistency_delegation` — **no prior test asserted this dispatch, which is why the bug shipped.** 11/11 `test_tweety_bridge.py` pass. mypy strict gate: `pl_handler.py` is NOT in the CI-checked module list (the 10 pre-existing mypy errors are in code I did not touch; none reference the new method).

## Impact on Epic #947 verdict

- **PL axis no longer a cap on DECIDES.** The "PL=0" gap was the code bug, now fixed.
- **corpus_A no longer the unique PL-deciding corpus** — its 25 were theater.
- **Verdict stays EDGES**: the **quality radar** (spacy WinError 182) is now the single remaining cap on a clean DECIDES. A full A/B/C re-run with this fix would lift the PL axis.

## Scope / privacy

- Synthetic test arguments only (no corpus content). Diagnosis $0-API (JVM/Tweety).
- **File-disjoint from #1079** (po-2023: router/debate/adapter/judge). This touches `pl_handler.py` + `test_tweety_bridge.py` + FB-20/FB-21 docs. Zero overlap.
- No deletions (Cleanup Gate N/A).

🤖 Generated with [Claude Code](https://claude.com/claude-code)