### PR TITLE
chore(service_manager): remove dead OpenAI client construction (#1080)

### DIFF
--- a/argumentation_analysis/orchestration/service_manager.py
+++ b/argumentation_analysis/orchestration/service_manager.py
@@ -767,7 +767,6 @@ class OrchestrationServiceManager:
 
         try:
             # Utiliser l'API OpenAI async pour les vrais appels LLM non-bloquants
-            import openai
             import time
 
             api_key = (
@@ -799,8 +798,6 @@ INSTRUCTIONS:
 
 Réponds au format JSON avec les clés: arguments, sophismes, structure_rhetorique, coherence, recommandations."""
 
-            # Configuration OpenAI standard avec AsyncOpenAI
-            client = openai.AsyncOpenAI(api_key=api_key)
             model = "gpt-5-mini"
 
             # Mesurer le temps de début
@@ -858,7 +855,6 @@ Réponds au format JSON avec les clés: arguments, sophismes, structure_rhetoriq
 
         try:
             # Utiliser l'API OpenAI async pour les vrais appels LLM non-bloquants
-            import openai
             import time
 
             api_key = (
@@ -892,8 +888,6 @@ INSTRUCTIONS OPÉRATIONNELLES:
 
 Réponds au format JSON avec les clés: entites, relations, patterns, persuasion, premisses, conclusions, biais, validite_logique."""
 
-            # Configuration OpenAI standard avec AsyncOpenAI
-            client = openai.AsyncOpenAI(api_key=api_key)
             model = "gpt-5-mini"
 
             # Mesurer le temps de début


### PR DESCRIPTION
## Summary
Removes dead `client = openai.AsyncOpenAI(api_key=api_key)` construction at two sites in `orchestration/service_manager.py`, discovered by the AUDIT-LLM-ROUTING sweep (#1078, report `docs/reports/AUDIT_LLM_ROUTING.md` §2.1). Tracked in #1080.

## Context
`_run_tactical_analysis` (~:803) and `_run_operational_analysis` (~:896) construct an OpenAI client that is **never read** — the actual LLM call goes through `await self.kernel.invoke(chat_function)` (:814 / :906). The construction also reads `settings.openai.api_key` (not the OpenRouter toggle), so it is technically a bypass, but since it is unused it is **not a functional leak** — a code smell, and a false-positive for future LLM-routing audits.

## Fix (anti-pendulum: remove only, add nothing)
- Removed `client = openai.AsyncOpenAI(api_key=api_key)` at both sites.
- Removed the now-unused local `import openai` at both sites (else flake8 F401 fails CI).
- Removed the stale `# Configuration OpenAI standard avec AsyncOpenAI` comments.
- **Preserved** the `api_key` precondition guard (still a meaningful config check — not dead).

Zero behavior change — the client was never used.

## Verification
- `projet-is` env: **125 service_manager tests pass** (`tests/unit/test_service_manager_complete.py` + `tests/unit/argumentation_analysis/orchestration/test_service_manager.py`).
- The single failure (`TestRunSpecializedAnalysis::test_analyze_text_interface`: `MagicMock can't be used in 'await'` at `_run_specialized_analysis:637`) is **pre-existing** — verified to fail identically on `origin/main` (it mocks an orchestrator with `MagicMock` where `AsyncMock` is needed; unrelated to this change).
- No remaining `import openai` / `AsyncOpenAI` in the file (verified via ripgrep). The only `openai` references left are `settings.openai.api_key` attribute reads (the precondition guard).

## Scope / disjointness
- File-disjoint from open PRs #1084 (router/debate/adapter/judge) and #1085 (pl_handler) — no collision.
- Does **not** touch the 4 files fixed by #1077.
- Privacy HARD: no dataset content.

Closes #1080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)