### PR TITLE
fix(quality): provision real quality-radar deps — refuted WinError 182 (#1088)

### DIFF
--- a/argumentation_analysis/agents/core/quality/quality_evaluator.py
+++ b/argumentation_analysis/agents/core/quality/quality_evaluator.py
@@ -9,10 +9,12 @@ Dependencies:
     - spacy (fr_core_news_sm model) — REQUIRED
     - textstat (Flesch readability) — REQUIRED
 
-If spacy/textstat cannot load (e.g. torch DLL conflict on Windows),
-the evaluator raises RuntimeError instead of silently producing
-heuristic scores.  Callers must handle the exception or ensure the
-environment is correctly configured (see dll_guard).
+If spacy/textstat/model cannot load, the evaluator raises RuntimeError
+instead of silently producing heuristic scores. The usual cause is a
+missing dependency (`textstat` package or the `fr_core_news_sm` spaCy
+model — see setup_project_env.ps1, FB-23 #1088); the torch DLL conflict
+(WinError 182, #882) is the rarer fallback covered by dll_guard. Callers
+must handle the exception or ensure the environment is correctly configured.
 """
 
 import argumentation_analysis.core.dll_guard  # noqa: F401 — defense in depth (#1019)
@@ -70,14 +72,18 @@ def _load_deps():
         _DEPS_AVAILABLE = True
         return True
     except (ImportError, OSError, RuntimeError) as exc:
-        # ImportError: spacy/textstat not installed
-        # OSError: WinError 182 — torch DLL load failure propagates through spacy (#993)
-        # RuntimeError: other DLL incompatibilities
+        # ImportError: spacy/textstat not installed (most common cause — ensure
+        #   `textstat` and `python -m spacy download fr_core_news_sm` are provisioned;
+        #   see setup_project_env.ps1 and environment.yml, FB-23 #1088).
+        # OSError [E050]: spaCy model `fr_core_news_sm` not downloaded.
+        # OSError [WinError 182]: torch DLL conflict (#882) — rare on recent envs;
+        #   dll_guard pre-loads torch before jpype as defense-in-depth.
         raise RuntimeError(
-            f"Quality evaluation requires spacy and textstat, but import failed: {exc}. "
-            "On Windows, this is typically the torch DLL conflict (WinError 182). "
-            "Fix: ensure dll_guard is imported at the entry point BEFORE jpype. "
-            "See docs/architecture/TORCH_DLL_REPAIR_RECIPE.md for the full recipe."
+            f"Quality evaluation requires spacy, textstat and the fr_core_news_sm "
+            f"model, but a dependency failed: {exc}. Most often this is a missing "
+            f"package (textstat) or model (run `python -m spacy download "
+            f"fr_core_news_sm`). See setup_project_env.ps1 and "
+            f"docs/architecture/TORCH_DLL_REPAIR_RECIPE.md (WinError 182 fallback)."
         ) from exc
 
 
@@ -348,10 +354,10 @@ class ArgumentQualityEvaluator:
         # is the exact "degraded theatre" the mandate forbids.
         if _DEPS_ATTEMPTED and not _DEPS_AVAILABLE:
             raise RuntimeError(
-                "Cannot evaluate quality: spacy/textstat are not available. "
-                "Ensure dll_guard is imported before jpype and the conda "
-                "environment is activated. "
-                "See docs/architecture/TORCH_DLL_REPAIR_RECIPE.md."
+                "Cannot evaluate quality: spacy/textstat/model are not available. "
+                "Ensure textstat is installed and the fr_core_news_sm model is "
+                "downloaded (`python -m spacy download fr_core_news_sm`), and the "
+                "conda environment is activated. See setup_project_env.ps1."
             )
 
         scores = {}

--- a/docs/architecture/TORCH_DLL_REPAIR_RECIPE.md
+++ b/docs/architecture/TORCH_DLL_REPAIR_RECIPE.md
@@ -4,6 +4,24 @@
 **Scope**: Read-only investigation + recipe document. Zero code changes (lane po-2025).
 **Target**: po-2025 applies the fix described here when implementing #1019 subsystem 1.
 
+> **⚠️ UPDATE (FB-23 #1088, 2026-06-14)** — The recipe below assumes the
+> quality-radar failure is caused by the WinError 182 DLL conflict. On
+> `projet-is` (po-2023) this was **empirically refuted**: a fresh-process
+> repro with jpype loaded *before* spaCy loaded `fr_core_news_sm` cleanly
+> (no WinError 182). The **actual root cause was missing dependencies**:
+> `textstat` was not declared in any env spec, and the `fr_core_news_sm`
+> spaCy model was never downloaded by `setup_project_env.ps1`. The durable
+> fix for #1088 therefore (a) declares `textstat` in `environment.yml` +
+> `requirements.txt`, (b) adds a `python -m spacy download fr_core_news_sm`
+> step to `setup_project_env.ps1`, and (c) rewords the evaluator's error
+> message to point at the likely-actual cause (missing dep/model) first.
+> The WinError 182 DLL-ordering fix below remains valid as defense-in-depth
+> (and applies on environments where the conflict does manifest, e.g. some
+> torch/jpype version combos) — but it is **not** the quality-radar's
+> primary failure mode on this cluster. Verify the actual root cause with a
+> fresh-process repro before applying the DLL recipe.
+
+
 ---
 
 ## 1. Root Cause

--- a/environment.yml
+++ b/environment.yml
@@ -72,6 +72,7 @@ dependencies:
 
   # La section pip est pour les paquets non disponibles ou problématiques sur Conda
   - pip:
+    - textstat  # FB-23 #1088: readability (Flesch) for the quality-radar clarte detector
     - semantic-kernel>=1.33.0
     - flask_socketio>=5.3.6
     - playwright

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ sentence-transformers
 semantic-kernel>=1.5.0,<2.0.0
 numpy
 spacy
+textstat  # FB-23 #1088: readability (Flesch) for the quality-radar clarte detector
 clingo
 unidecode
 markdown

--- a/setup_project_env.ps1
+++ b/setup_project_env.ps1
@@ -65,6 +65,24 @@ catch {
     exit 1
 }
 
+# 2.1 Téléchargement du modèle spaCy français (FB-23 #1088 : quality-radar)
+#     spacy n'est qu'un runtime ; le modèle de langue `fr_core_news_sm` est un
+#     artefact séparé (non-Python-package dans requirements). Sans lui,
+#     ArgumentQualityEvaluator lève (détection qualité = FAILED sur Windows).
+Write-Host "[INFO] Téléchargement du modèle spaCy 'fr_core_news_sm' (quality-radar)..." -ForegroundColor Green
+try {
+    conda run -n $EnvName python -m spacy download fr_core_news_sm
+    if ($LASTEXITCODE -ne 0) {
+        throw "Le téléchargement du modèle spaCy a échoué."
+    }
+    Write-Host "[SUCCÈS] Modèle spaCy 'fr_core_news_sm' installé." -ForegroundColor Green
+}
+catch {
+    Write-Host "[ERREUR] Impossible de télécharger le modèle spaCy (nécessaire au quality-radar)." -ForegroundColor Red
+    Write-Host "Message: $($_.Exception.Message)"
+    exit 1
+}
+
 # 3. Provisioning des outils portables (JDK, etc.) AVANT la configuration de l'environnement
 #    pour permettre au script Python de créer/modifier le fichier .env avec JAVA_HOME.
 Write-Host "[INFO] Lancement du provisioning des outils portables (JDK...)." -ForegroundColor Green

--- a/tests/unit/argumentation_analysis/agents/core/quality/test_quality_virtue_detectors.py
+++ b/tests/unit/argumentation_analysis/agents/core/quality/test_quality_virtue_detectors.py
@@ -16,10 +16,17 @@ import argumentation_analysis.agents.core.quality.quality_evaluator as qe
 @pytest.fixture(autouse=True)
 def mock_load_deps():
     with patch.object(qe, "_load_deps", return_value=False):
-        # Also ensure globals are set to fallback state
+        # Ensure globals reflect a consistent fallback state. Resetting
+        # _DEPS_ATTEMPTED=False matters: evaluate()'s fail-loud gate
+        # (quality_evaluator.py) raises when `_DEPS_ATTEMPTED and not
+        # _DEPS_AVAILABLE`. Without this reset, a prior test that triggered
+        # the real _load_deps leaves _DEPS_ATTEMPTED=True, and the gate
+        # fires here even though this fixture mocks _load_deps to never
+        # attempt. See FB-23 #1088.
         qe._nlp = None
         qe._flesch_reading_ease = None
         qe._DEPS_AVAILABLE = False
+        qe._DEPS_ATTEMPTED = False
         yield
 
 


### PR DESCRIPTION
FB-23 #1088 (Epic #947 Final Boss). Quality dimension FAILED on every corpus, attributed to WinError 182. Fresh-process repro REFUTED that: spaCy + fr_core_news_sm load cleanly even with jpype-first ordering. Verified root cause = missing deps (textstat not in any spec; fr_core_news_sm never downloaded by setup). Durable fix: textstat in environment.yml+requirements.txt, spacy download step in setup_project_env.ps1, reworded error messages, recipe-doc correction note, + fix latent inter-test pollution (autouse fixture resets _DEPS_ATTEMPTED). Verified on projet-is: _invoke_quality_evaluator real path aggregate_score=3.3, 3 args scored non-trivially; quality dir 53 passed/0 failed (no regression). WinError 182 NOT reproducible. Out of scope: test_llm_enrich_quality (8 pre-existing fails on origin/main). Unblocks po-2025 #1087 quality numbers on Windows-native (WSL now optional). Closes #1088. See full body in commit f3c856fd.