### PR TITLE
fix(quality): neutralize faulty torch so rule-based spaCy model loads natively (FB-25 #1093)

### DIFF
--- a/argumentation_analysis/agents/core/quality/quality_evaluator.py
+++ b/argumentation_analysis/agents/core/quality/quality_evaluator.py
@@ -23,6 +23,7 @@ import json
 import logging
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
@@ -34,6 +35,49 @@ _nlp = None
 _flesch_reading_ease = None
 _DEPS_AVAILABLE = False
 _DEPS_ATTEMPTED = False
+_TORCH_NEUTRALIZED = False
+
+
+def _neutralize_faulty_torch() -> None:
+    """Make spaCy's transitive optional ``torch`` import skippable when torch's
+    Windows DLL faults (WinError 182 / fbgemm.dll, issue #882).
+
+    Background (FB-25 #1093): on Windows envs where ``torch`` is installed but
+    its native DLL faults (e.g. torch 2.2.2 in ``projet-is-roo-new``), spaCy's
+    ``import spacy`` pulls thinc, which does an *optional* ``import torch``.
+    thinc catches ``ImportError`` but NOT ``OSError`` — so the DLL fault
+    propagates and blocks spaCy entirely, even though the ``fr_core_news_sm``
+    model is rule-based (non-neural) and does not need torch at all.
+
+    Fix (anti-pendule: remove the poisoning, do not add a counterweight):
+    detect the faulty torch and plant a ``None`` sentinel in ``sys.modules``.
+    A subsequent ``import torch`` then raises ``ImportError`` ("import of name
+    halted; None in sys.modules"), which thinc catches gracefully and skips.
+
+    This is a no-op when torch is genuinely absent (thinc already handles that)
+    or when torch imports cleanly (neural path stays available — important so
+    the wide-net / camembert path is unaffected in healthy-torch envs). It only
+    fires when torch is installed-but-broken, in which case the neural path was
+    never usable in this process anyway.
+    """
+    global _TORCH_NEUTRALIZED
+    if _TORCH_NEUTRALIZED:
+        return
+    try:
+        import torch  # noqa: F401
+        return  # torch imports cleanly — nothing to do.
+    except ImportError:
+        return  # torch genuinely absent — thinc already handles this fine.
+    except OSError as exc:
+        # Broken torch (DLL fault). Block it so thinc skips its optional import.
+        sys.modules["torch"] = None  # type: ignore[assignment]
+        _TORCH_NEUTRALIZED = True
+        logger.warning(
+            "torch import faulted (%s); blocking it on the quality path so the "
+            "rule-based fr_core_news_sm model loads. Neural path unavailable in "
+            "this process. See issue #882, FB-25 #1093.",
+            exc,
+        )
 
 
 def _load_deps():
@@ -57,6 +101,9 @@ def _load_deps():
         return True
     _DEPS_ATTEMPTED = True
     try:
+        # FB-25 #1093: neutralise a faulty torch BEFORE importing spacy, so
+        # thinc's optional torch import is skipped instead of poisoning spaCy.
+        _neutralize_faulty_torch()
         import spacy
         from textstat import flesch_reading_ease
 

--- a/tests/unit/argumentation_analysis/agents/core/quality/test_quality_virtue_detectors.py
+++ b/tests/unit/argumentation_analysis/agents/core/quality/test_quality_virtue_detectors.py
@@ -5,6 +5,9 @@ Tests the individual detect_* functions and ArgumentQualityEvaluator.evaluate().
 Uses mocked _load_deps to avoid torch DLL crash and test fallback heuristics.
 """
 
+import builtins
+import sys
+
 import pytest
 from unittest.mock import patch
 
@@ -232,3 +235,65 @@ class TestVertuesAndDetectors:
 
     def test_detector_count(self):
         assert len(qe.DETECTORS) == 9
+
+
+class TestNeutralizeFaultyTorch:
+    """FB-25 #1093 — regression guard for the broken-torch → None-sentinel fix.
+
+    No prior test asserted that spaCy's transitive optional ``import torch``
+    (via thinc) is made skippable when torch's Windows DLL faults (issue #882).
+    That is why the fault blocked the whole quality path in envs with a broken
+    torch (e.g. torch 2.2.2 in ``projet-is-roo-new``). See FB-21 lesson:
+    "the bug shipped because nothing asserted the dispatch".
+    """
+
+    def teardown_method(self) -> None:
+        # Restore module-global state between tests.
+        qe._TORCH_NEUTRALIZED = False
+        sys.modules.pop("torch", None)
+
+    def _patched_import(self, behaviour):
+        """Return a fake ``__import__`` that applies ``behaviour`` for torch."""
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "torch":
+                return behaviour()
+            return real_import(name, *args, **kwargs)
+
+        return fake_import
+
+    def test_faulty_torch_is_blocked(self):
+        """A faulty torch (OSError) must be neutralised so thinc can skip it."""
+        with patch("builtins.__import__",
+                   side_effect=self._patched_import(
+                       lambda: (_ for _ in ()).throw(
+                           OSError("[WinError 182] simulated fbgemm.dll fault")))):
+            qe._neutralize_faulty_torch()
+
+        assert qe._TORCH_NEUTRALIZED is True
+        assert sys.modules.get("torch") is None  # sentinel planted
+
+    def test_absent_torch_is_not_blocked(self):
+        """Genuinely-absent torch (ImportError) is left to thinc's own handling."""
+        with patch("builtins.__import__",
+                   side_effect=self._patched_import(
+                       lambda: (_ for _ in ()).throw(ModuleNotFoundError(
+                           "No module named 'torch'")))):
+            qe._neutralize_faulty_torch()
+
+        assert qe._TORCH_NEUTRALIZED is False
+        assert "torch" not in sys.modules  # no sentinel planted
+
+    def test_healthy_torch_is_not_blocked(self):
+        """A cleanly-importing torch must stay available (neural path intact)."""
+
+        class _DummyTorch:
+            __version__ = "99.99.99"
+
+        sys.modules.pop("torch", None)
+        with patch("builtins.__import__",
+                   side_effect=self._patched_import(lambda: _DummyTorch())):
+            qe._neutralize_faulty_torch()
+
+        assert qe._TORCH_NEUTRALIZED is False


### PR DESCRIPTION
## What & why (FB-25 #1093, Epic #947 final gate — item 1)

On Windows envs where `torch` is installed but its native DLL faults (`WinError 182` / `fbgemm.dll`, issue #882 — e.g. torch 2.2.2 in `projet-is-roo-new`), spaCy's `import spacy` pulls thinc, which does an *optional* `import torch`. thinc catches `ImportError` but **not** `OSError` — so the DLL fault propagates and blocks spaCy entirely, even though the `fr_core_news_sm` model is **rule-based (non-neural) and does not need torch**. The quality radar therefore fails loud on these envs (fail-loud gate #1019 is respected, but the radar is unusable).

This was the reconciliation surfaced in R399 between #1091 (deps fix, `projet-is`) and #1092 (WSL path): the diagnosis is **env-specific**. `projet-is-roo-new` has a broken torch, so #1091's deps fix alone does NOT unblock it there. This PR unblocks the native path in broken-torch envs without an env rebuild.

## Fix (anti-pendule: remove the poisoning, no counterweight)

`_neutralize_faulty_torch()` (new, typed `-> None`) runs inside `_load_deps()` **before** `import spacy`:
- try `import torch`; if it raises **OSError** (DLL fault) → plant a `None` sentinel in `sys.modules["torch"]`. A subsequent `import torch` then raises `ImportError` ("import of name halted; None in sys.modules"), which thinc catches gracefully and skips → spaCy loads the rule-based model.
- **no-op** when torch is genuinely absent (`ImportError`, thinc already handles) or imports cleanly (neural path stays available — critical so the wide-net / camembert path is unaffected in healthy-torch envs like `projet-is`).

It only fires when torch is installed-but-broken, in which case the neural path was never usable in this process anyway. Idempotent (`_TORCH_NEUTRALIZED` guard).

## Proof (native `projet-is-roo-new`, helper-driven — no manual `sys.modules` hack)

Real `ArgumentQualityEvaluator.evaluate` on `corpus_C` (4000-char opaque excerpt, dataset in-memory):

```text
note_finale: 2.0 | note_moyenne: 0.222 | non-zero virtues: 3/9
VERDICT: NATIVE quality works via integrated helper ✅
```

Values are **identical to WSL (#1092) and the R399 manual probe** (note_finale 2.0, Flesch 46.34) — the radar is deterministic; the fix only changes whether it can run at all on broken-torch envs.

## Tests

- New `TestNeutralizeFaultyTorch` (3 cases): faulty→blocked, absent→noop, healthy→noop. **FB-21 lesson**: the bug shipped because nothing asserted this dispatch.
- Full quality dir: **56 passed, 0 failed**. Existing `TestDllFailureFailLoud::test_dll_failure_raises_runtime_error` still passes (it patches spacy/textstat directly, independent of torch — my helper runs first, neutralizes the real broken torch, then the patched-spacy ImportError still fires the expected RuntimeError).
- mypy strict on the file: **0 new errors** (7 pre-existing on origin/main, all about untyped `_load_deps` — unchanged).

## Scope / privacy

2 files: `quality_evaluator.py` (+ helper + call) + test file (+ regression class). File-disjoint from FB-26 #1094 (po-2023, audit doc + verdict section). Privacy HARD: opaque corpus IDs, aggregate-only output, dataset consumed in-memory. No heuristic fallback added (#1019 honored — real spaCy/textstat values).

Closes the native half of the Epic #947 quality gate; combined with the WSL path (#1092 merged) the radar is now runnable everywhere. Item 2 of FB-25 (A/B/C re-measure + report fold) follows in a separate commit, serialized with po-2023 on `FB20_PHASE4_TERMINAL_REPORT.md`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
