### PR TITLE
test(value-gate): #1097 make TestModalLogicValueGate load-bearing

### DIFF
--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -118,33 +118,34 @@ class TestModalLogicValueGate:
         The heuristic fallback must NOT return valid=True for a formula
         it cannot actually verify. It must return valid=None with
         solver='unavailable' (#961).
+
+        #1097: this test is now LOAD-BEARING. We patch the SOLVER ROUTE
+        (``asyncio.to_thread`` — the SPASS L5180 and Tweety L5201 routes both
+        go through it), NOT ``_invoke_modal_logic`` itself. The real function
+        runs: both solver routes raise, fall through to the honest fallback
+        (L5218-5230), and we assert its ACTUAL output. A regression that
+        reintroduces ``valid=True`` in the real fallback is now caught.
+        Aligned with the 12 other satellite gates (SetAF/Weighted/DeLP/...).
         """
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_modal_logic,
         )
 
-        # Force the heuristic fallback path by patching both solver routes
-        # to raise (simulating no JVM/no SPASS/no Tweety)
+        # Force BOTH solver routes (SPASS + Tweety) to raise by patching
+        # asyncio.to_thread — the real _invoke_modal_logic runs end-to-end,
+        # reaches its honest fallback, and we assert its ACTUAL output.
         with patch(
-            "argumentation_analysis.orchestration.invoke_callables._invoke_modal_logic",
-            side_effect=lambda text, ctx: {
-                "formulas": ctx.get("formulas", [text]),
-                "valid": None,
-                "modalities": ["necessity"],
-                "logic_type": "modal",
-                "solver": "unavailable",
-                "fallback": "python",
-                "message": "Modal analysis unavailable: no solver could be loaded.",
-            },
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("No solver for test"),
         ):
             result = await _invoke_modal_logic("[](P)", {"formulas": ["[](P)"]})
 
         assert result.get("valid") is None, (
             f"Modal fallback returned valid={result.get('valid')} instead of None. "
-            "When no solver is available, must report unavailability, not valid=True (#961)."
+            "When no solver is available, must report unavailability, not valid=True (#961/#1097)."
         )
         assert result.get("solver") == "unavailable", (
-            f"Modal fallback solver={result.get('solver')}, expected 'unavailable' (#961)."
+            f"Modal fallback solver={result.get('solver')}, expected 'unavailable' (#961/#1097)."
         )
 
     async def test_heuristic_does_not_fabricate_valid_true(self):
@@ -152,34 +153,31 @@ class TestModalLogicValueGate:
 
         This is the anti-pendule guard: we test honest 'unavailable'
         (valid=None), NOT a fabricated valid:False.
+
+        #1097: LOAD-BEARING — patches ``asyncio.to_thread`` (the solver route)
+        so the real ``_invoke_modal_logic`` runs and reaches its honest
+        fallback. A regression reintroducing ``valid=True`` is caught here;
+        the old test (patching the function itself) would have passed through it.
         """
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_modal_logic,
         )
 
         with patch(
-            "argumentation_analysis.orchestration.invoke_callables._invoke_modal_logic",
-            side_effect=lambda text, ctx: {
-                "formulas": ctx.get("formulas", [text]),
-                "valid": None,
-                "modalities": [],
-                "logic_type": "modal",
-                "solver": "unavailable",
-                "fallback": "python",
-                "message": "Modal analysis unavailable.",
-            },
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("No solver for test"),
         ):
             result = await _invoke_modal_logic("[](P)", {"formulas": ["[](P)"]})
 
         # Must NOT be True (vacuous) — must be None (honest unavailability)
         assert result.get("valid") is not True, (
             "Modal fallback still returns valid=True — the vacuous confirmation "
-            "bug from #941 is not fixed."
+            "bug from #941 is not fixed (#1097)."
         )
         # Must also NOT be False (fabricated rejection) — anti-pendule
         assert result.get("valid") is not False, (
             "Modal fallback returns valid=False — this is a fabricated rejection, "
-            "not honest unavailability. Anti-pendule: report None, not invented verdict."
+            "not honest unavailability. Anti-pendule: report None, not invented verdict (#1097)."
         )
 
 


### PR DESCRIPTION
## #1097 — make `TestModalLogicValueGate` load-bearing

Closes #1097. Dispatch R401 (ai-01). File-disjoint from FB20 report work (po-2023 lane).

## The bug

The two modal-logic tests patched `_invoke_modal_logic` **itself** with a `side_effect` lambda returning a hardcoded dict:

```python
with patch("...invoke_callables._invoke_modal_logic",
           side_effect=lambda text, ctx: {... "valid": None, "solver": "unavailable" ...}):
    result = await _invoke_modal_logic("[](P)", {"formulas": ["[](P)"]})
```

The real `_invoke_modal_logic` **never ran** — `result` came from the mock. The assertion checked the lambda's hardcoded values, so a regression reintroducing `valid=True` in the **real** fallback (#961 / #1019 anti-theater) would pass CI silently. **Zero protection.**

## The fix (test-only, +24/−26)

Patch the **solver route** (`asyncio.to_thread`), aligned with the 12 other satellite gates (SetAF/Weighted/DeLP/Bipolar/EAF/ABA/ADF/Probabilistic/Dialogue/BeliefRevision/ASPIC/QBF):

```python
with patch("...invoke_callables.asyncio.to_thread",
           side_effect=RuntimeError("No solver for test")):
    result = await _invoke_modal_logic("[](P)", {"formulas": ["[](P)"]})
```

The real `_invoke_modal_logic` now runs end-to-end: the SPASS route (L5180) and Tweety route (L5201) both go through `asyncio.to_thread`, both raise, fall through to the honest fallback (L5218–5230), and the assertion checks its **actual** output (`valid=None`, `solver="unavailable"`).

## Red-before-green proof (DoD #3)

- **GREEN**: 2 passed on current code (real fallback returns `valid=None`).
- **RED**: temporarily flipped the real fallback L5225 `valid: None` → `valid: True` (simulating the #961 regression). Both tests **FAILED** with the exact assertion messages:
  - `Modal fallback returned valid=True instead of None. When no solver is available, must report unavailability, not valid=True (#961/#1097).`
  - `Modal fallback still returns valid=True — the vacuous confirmation bug from #941 is not fixed (#1097).`
- Restored the prod file to `valid: None`. **No code change** — `invoke_callables.py` is byte-identical to main (`git diff --stat` shows only `test_value_gates.py`).

This is the test that was **non-load-bearing** before (would have passed through the `valid=True` regression) and **load-bearing** after (catches it).

## Anti-pendule

Per dispatch: did NOT delete/skip/rename the test, did NOT rename the assertions. Method names (`test_heuristic_reports_unavailable_not_true`, `test_heuristic_does_not_fabricate_valid_true`) and assertions (on `valid`/`solver`) are intact — only the patch target changed so the real fallback output is exercised. The real fallback IS correct (#961); this is a **test-strength** fix, not a prod fix.

## DoD checklist

- [x] Patch the solver route (`asyncio.to_thread`), not `_invoke_modal_logic`
- [x] Real `_invoke_modal_logic` executes; assertion checks its actual output (`valid=None` + `solver=unavailable`)
- [x] A regression reintroducing `valid=True` WOULD be caught (red-before-green proven above)
- [x] CI gate (mypy strict) unaffected — scope is `argumentation_analysis/` code source only; `invoke_callables.py` byte-identical to main
- [x] 2/2 modal gate tests load-bearing (the 33 other failures in `test_value_gates.py` are preexisting + environmental — see note)

## Note: preexisting failures (not this PR's regression)

`pytest test_value_gates.py` locally in `projet-is-roo-new` shows 33 failures on SAT/EAF/ABA/ADF/Probabilistic/Dialogue/BeliefRevision/ASPIC. **Proven preexisting**: I stashed this PR's change, checked out `main` (`9e9726f9`), ran the same sample (TestSATValueGate + TestASPICValueGate) → **identical failures**. Root cause is environmental (e.g. SAT: `RuntimeError: PySAT is not installed` — `python-sat` absent from `projet-is-roo-new` locally, present in CI's `projet-is` + PySAT). These classes are disjoint from `TestModalLogicValueGate` and cannot be affected by a test-only change to 2 methods. The CI `automated-tests` job runs on `projet-is` with the full dep set where these pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
