### PR TITLE
docs(fb-28): #1102 quality content-dominance head-to-head — EDGES confirmed

### DIFF
--- a/docs/reports/FB28_QUALITY_HEADTOHEAD_REPORT.md
+++ b/docs/reports/FB28_QUALITY_HEADTOHEAD_REPORT.md
@@ -1,0 +1,142 @@
+# FB-28 — Quality Axis Content-Dominance Test (0-shot baseline vs pipeline 9-virtue radar)
+
+**Issue**: #1102 (Epic #947). **Dispatch**: R402b (ai-01, mandate user « pousse encore »).
+**Author**: Claude Code @ myia-po-2025:2025-Epita-Intelligence-Symbolique.
+**Base**: main `a04f627b`. **Date**: 2026-06-15.
+
+> Privacy: aggregate-only, opaque IDs (`doc_A/B/C`, `arg_N`). No raw_text, no
+> speaker names, no corpus titles. Raw per-arg results are gitignored under
+> `argumentation_analysis/evaluation/results/capstone_c1/fb28_*`.
+
+## 1. Question
+
+Epic #947 is at its terminal verdict **EDGES** (FB-26 #1099). The **quality axis
+is the only non-DECIDES axis** (§5.1/§5.3): the pipeline's 9-virtue radar
+demonstrates *existence-dominance* (the 0-shot baseline emits no radar) but
+had not been tested for *content-dominance*. **Mandate**: test rigorously whether
+the pipeline's quality evaluation **separates** from a 0-shot baseline on the
+**content** — if yes, quality → DECIDES; if not, it stays EDGES, honestly.
+
+## 2. Method — apples-to-apples head-to-head
+
+The pipeline radar evaluates the **extracted arguments** (deterministic radar,
+FB-25). To isolate *content-dominance* from *extraction-variance*, the **same
+extracted arguments** (from the replayable FB-25 artifacts) are fed to a **0-shot
+LLM baseline**, asked to evaluate each argument on the **same 9 virtues** with
+the **same scale** `{0.0, 0.2, 0.5, 1.0}`. The differential is then pure
+*evaluation-capability* on identical units.
+
+| Side | Source | Determinism |
+|------|--------|-------------|
+| Pipeline | `ArgumentQualityEvaluator` (rule + LLM-assessment), native radar (FB-25 #1095) | deterministic (spread 0.000000) |
+| Baseline | 0-shot LLM (`gpt-5-mini` via OpenRouter), structured JSON eval on same rubric | stochastic (LLM) |
+
+Both sides judge the same `arg_1..arg_N` (N≤8 per corpus, same FB-25 window).
+Anti-théâtre (#1019): the pipeline radar was **NOT tuned** to score higher —
+the radar code is byte-identical to main. The deliverable is the honest
+differential, whichever direction it goes.
+
+## 3. Differential — overall (pipeline vs baseline)
+
+| Corpus | n args | Pipeline overall mean | Baseline overall mean | Δ (pipe−base) | pipe > base |
+|--------|--------|-----------------------|-----------------------|---------------|-------------|
+| doc_A | 8 | **1.70** | 2.33 | **−0.63** | 1 / 8 |
+| doc_B | 3 | **1.67** | 3.97 | **−2.30** | 0 / 3 |
+| doc_C | 8 | **1.63** | 3.05 | **−1.43** | 0 / 8 |
+| **Aggregate (19 args)** | 19 | **~1.66** | **~3.04** | **−1.39** | **1 / 19** |
+
+**The differential is negative on all three corpora.** The 0-shot baseline
+scores systematically **higher** than the pipeline on the same arguments
+(18/19 args: baseline ≥ pipeline). The pipeline radar is **more restrictive**
+than the LLM baseline — it is not *generous*, it is *strict*.
+
+## 4. Differential — per virtue (aggregate across A/B/C)
+
+`Δ` = pipeline_mean − baseline_mean (positive = pipeline stricter-better; negative = baseline scored higher).
+
+| Virtue | Pipe (typical) | Base (typical) | Δ | Read |
+|--------|----------------|----------------|---|------|
+| clarte | 0.20–0.44 | 0.63–1.00 | −0.19 to −0.74 | Baseline generously credits readability; pipeline Flesch-based, stricter |
+| pertinence | 0.20–0.24 | 0.39–0.83 | −0.19 to −0.63 | Baseline credits connectors LLM-perceived; pipeline lexical-only |
+| presence_sources | 0.0 | 0.0–0.50 | −0.50 (B) / 0 (A,C) | Tie at 0 on source-light text; baseline sees 1 source in B |
+| refutation_constructive | 0.0 | 0.0 | 0.0 | **Tie** — neither detects constructive refutation |
+| structure_logique | 0.0 | 0.18–0.30 | −0.18 to −0.30 | Baseline credits perceived logic; pipeline lexical-only |
+| analogie_pertinente | 0.0 | 0.0 | 0.0 | **Tie** — neither detects analogy |
+| fiabilite_sources | 0.0 | 0.0–0.13 | −0.13 (B) / ~0 (A,C) | Tie at 0 — source-light text |
+| exhaustivite | 0.06–0.19 | 0.15–0.24 | −0.03 to −0.18 | Baseline marginally higher |
+| redondance_faible | 1.0 | 0.90–1.00 | **+0.10** | **Pipeline ≥ baseline** — deterministic non-redundancy detection |
+
+**Where the pipeline separates from the baseline (Δ ≥ 0)**:
+- `redondance_faibre`: pipeline **≥** baseline (deterministic sentence-count +
+  repetition heuristic vs LLM judgment) — the one virtue where the pipeline's
+  deterministic detection is as-good-or-better.
+- `presence_sources`, `refutation_constructive`, `analogie_pertinente`,
+  `fiabilite_sources`: **tie at ~0.0** on source-light, dense text — neither
+  side detects these virtues (honest joint-blindspot, not a pipeline failure).
+
+**Where the baseline scores higher (Δ < 0)**:
+- `clarte`, `pertinence`, `structure_logique`, `exhaustivite`: the LLM baseline
+  is consistently more generous, crediting perceived readability/logic that the
+  pipeline's lexical heuristics do not surface.
+
+## 5. Verdict fork (DoD) — **EDGES, confirmed rigorously (not DECIDES)**
+
+DECIDES would require the pipeline to demonstrate **content-dominance**: its
+evaluation must *separate* from the baseline's — either richer, more anchored,
+or detecting virtues the baseline cannot. **The measurement shows the opposite
+on 18/19 arguments**: the pipeline is *more restrictive* than, not *richer than*,
+the 0-shot baseline.
+
+- The pipeline's only content-edge is `redondance_faible` (deterministic
+  non-redundancy), and a set of joint-zero virtues where neither side fires on
+  source-light text. That is **not content-dominance**.
+- The pipeline's real edge is **existence-dominance + determinism**: it emits a
+  **reproducible** (spread 0.000000), **structured** 9-virtue radar the baseline
+  cannot emit natively, and it is **stricter** (less generous) than a stochastic
+  LLM judgment. Those are real properties — but they are *process* properties
+  (deterministic, structured, conservative), not *content-separation* properties.
+
+**Per the #1019 anti-auto-promotion mandate, this is EDGES, not DECIDES.**
+Promoting quality to DECIDES would require either (a) the radar to detect
+virtues the baseline structurally cannot (it does not — the joint-zero virtues
+are a joint blindspot, not a pipeline win), or (b) the radar to be measurably
+more *accurate* than the LLM against a ground-truth rubric (not measured here,
+and the LLM's higher scores are not evidence of LLM correctness — just
+generosity). **EDGES reasoned > DECIDES maximal weakly-claimed.**
+
+## 6. Consequence for the Epic #947 terminal verdict
+
+The Epic verdict (§5, FB-26 #1099) stands at **EDGES (min-rule)**:
+formal-logic block DECIDES (Tweety-verified artifacts structurally impossible
+for 0-shot), quality axis EDGES (existence + determinism + strictness, not
+content-separation). **FB-28 confirms EDGES on the quality axis is the
+correct, honestly-measured call — it is not a cap-on-excuse; the measurement
+shows the pipeline does not separate from the baseline on content.**
+
+No §5 amendment is proposed (the fork resolves to EDGES, the current verdict).
+
+## 7. Honest hedges (traceable, not clean-story)
+
+- **N is small** (19 args total, 3 for corpus_B due to truncation). The
+  direction (baseline ≥ pipeline) is consistent across all 3 corpora and 18/19
+  args, but a larger N could sharpen the per-virtue deltas.
+- **Same-model comparison**: both pipeline-assessment and baseline use
+  `gpt-5-mini`. The pipeline's *deterministic* part (rule + Flesch) is what
+  differs from the baseline's *stochastic* judgment. A multi-model baseline
+  would strengthen the content-dominance claim either way.
+- **No ground truth**: without a human-graded rubric, we cannot say the
+  pipeline's stricter scores are *more correct* than the baseline's generous
+  ones — only that they do not *separate* (which is what DECIDES requires).
+- **Variance**: baseline is stochastic; 1 run/corpus captured (radar side is
+  deterministic, spread 0.000000). The idle-fallback re-measure (post FB-27
+  merge) can capture baseline variance if needed.
+
+## 8. Reproducibility
+
+- Harness: `scripts/run_fb28_quality_headtohead.py` (file-disjoint from FB-27).
+- Pipeline side: replayed from `evaluation/results/capstone_c1/fb25_quality_args_{A,B,C}.json` (FB-25 artifacts, deterministic).
+- Baseline side: `evaluation/results/capstone_c1/fb28_headtohead_{A,B,C}.json` (gitignored).
+- Assembled differential: `evaluation/results/capstone_c1/fb28_summary.json` (gitignored).
+- Budget: OpenRouter $163.39 → $161.29 (FB-28 spend ~$2.10 for 19 baseline evals + 1 retry on C). Verified real via credits API before spend (FB-21).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/scripts/run_fb28_quality_headtohead.py
+++ b/scripts/run_fb28_quality_headtohead.py
@@ -1,0 +1,373 @@
+"""FB-28 — Quality axis content-dominance test (#1102, Epic #947).
+
+Head-to-head: pipeline 9-virtue radar (deterministic, from FB-25 artifacts)
+vs 0-shot LLM baseline evaluating the SAME extracted arguments on the SAME
+9 virtues + SAME scale {0.0, 0.2, 0.5, 1.0}.
+
+The comparison isolates *content-dominance* (does the pipeline's analytical
+content separate from the baseline's?) from *existence-dominance* (does the
+pipeline emit a radar the baseline does not?). By feeding the baseline the
+SAME extracted args, we neutralise extraction-variance: both sides judge the
+same units. The differential is then pure evaluation-capability.
+
+Anti-théâtre (#1019): the pipeline radar is NOT tuned to score higher. The
+deliverable is the honest differential, whichever direction it goes.
+
+Privacy HARD: corpus/args are loaded in-memory from the encrypted blob via
+the FB-25 artifacts (already scrubbed to opaque arg_N IDs + paraphrased text,
+no raw_text / no speaker names). Results are gitignored under evaluation/.
+The aggregate report (docs/reports/) uses opaque IDs only.
+
+Usage:
+    conda run -n projet-is-roo-new --no-capture-output python \\
+        scripts/run_fb28_quality_headtohead.py [--corpus A]
+
+Output (gitignored):
+    evaluation/results/capstone_c1/
+        fb28_headtohead_A.json  fb28_headtohead_B.json  fb28_headtohead_C.json
+        fb28_summary.json
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+os.chdir(Path(__file__).parent.parent)
+
+# Load .env (OPENROUTER_API_KEY / OPENROUTER_BASE_URL / OPENAI_API_KEY)
+_env_path = Path(__file__).parent.parent / ".env"
+if _env_path.exists():
+    with open(_env_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, val = line.partition("=")
+                os.environ.setdefault(key.strip(), val.strip())
+
+RESULTS_DIR = Path("argumentation_analysis/evaluation/results/capstone_c1")
+FB25_ARGS_DIR = RESULTS_DIR  # fb25_quality_args_{A,B,C}.json live here
+CORPUS_LABELS = {"A": "doc_A", "B": "doc_B", "C": "doc_C"}
+
+# The 9 virtues — EXACT match to ArgumentQualityEvaluator.VERTUES (quality_evaluator.py:217).
+VIRTUES = [
+    "clarte",
+    "pertinence",
+    "presence_sources",
+    "refutation_constructive",
+    "structure_logique",
+    "analogie_pertinente",
+    "fiabilite_sources",
+    "exhaustivite",
+    "redondance_faible",
+]
+SCALE_VALUES = [0.0, 0.2, 0.5, 1.0]
+MAX_SCALE = 1.0
+N_VIRTUES = len(VIRTUES)  # 9
+
+# 0-shot baseline prompt: evaluate ONE argument on the SAME 9 virtues + SAME scale.
+# This makes the differential apples-to-apples (same units, same rubric).
+BASELINE_EVAL_PROMPT = """Tu es un évaluateur d'arguments expert. Évalue l'argument suivant sur 9 vertus rhétoriques.
+
+Pour chaque vertu, attribue un score sur l'échelle {0.0, 0.2, 0.5, 1.0} :
+- 1.0 = la vertu est pleinement présente
+- 0.5 = partiellement présente
+- 0.2 = faible / marginale
+- 0.0 = absente
+
+Les 9 vertus (scores STRICTEMENT dans {0.0, 0.2, 0.5, 1.0}) :
+- clarte : clarté et lisibilité de l'argument
+- pertinence : pertinence logique (connecteurs, enchaînement)
+- presence_sources : présence de sources / preuves factuelles citées
+- refutation_constructive : l'argument adresse-t-il des contre-positions ?
+- structure_logique : rigueur de la structure logique (prémisses→conclusion)
+- analogie_pertinente : usage d'analogies pertinentes si pertinent
+- fiabilite_sources : crédibilité des sources citées (si présentes)
+- exhaustivite : couverture raisonnable du sujet
+- redondance_faible : absence de redondance (1.0 = non redondant)
+
+Argument à évaluer :
+---
+{arg_text}
+---
+
+Réponds UNIQUEMENT avec un objet JSON valide de la forme (pas de texte avant/après) :
+{{"scores": {{"clarte": <score>, "pertinence": <score>, "presence_sources": <score>, "refutation_constructive": <score>, "structure_logique": <score>, "analogie_pertinente": <score>, "fiabilite_sources": <score>, "exhaustivite": <score>, "redondance_faible": <score>}}, "justification": "<1 phrase>"}}
+"""
+
+
+def load_pipeline_args(corpus_label: str) -> Tuple[Dict[str, str], Dict[str, Dict[str, Any]]]:
+    """Load FB-25 extracted args + pipeline radar scores (replayable artifacts).
+
+    Returns (arg_id -> paraphrased text, arg_id -> {scores, overall, llm_assessment}).
+    The arg text here is already the pipeline's paraphrased extraction (opaque,
+    no raw_text) — safe to feed the baseline.
+    """
+    path = FB25_ARGS_DIR / f"fb25_quality_args_{corpus_label}.json"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"FB-25 artifact missing: {path}. Run scripts/run_capstone_c1.py first "
+            "(or restore the FB-25 quality run)."
+        )
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    args = data.get("arguments", {})
+    pipeline_scores = data.get("argument_quality_scores", {})
+    return args, pipeline_scores
+
+
+def _get_llm_client():
+    """OpenRouter-toggle-aware client (same provider as pipeline, FB-21 lesson)."""
+    from openai import OpenAI
+
+    openrouter_base_url = os.environ.get("OPENROUTER_BASE_URL")
+    openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+    use_openrouter = bool(openrouter_base_url and openrouter_api_key)
+    if use_openrouter:
+        model = os.environ.get("OPENROUTER_CHAT_MODEL_ID", "gpt-5-mini")
+        client = OpenAI(api_key=openrouter_api_key, base_url=openrouter_base_url)
+    else:
+        model = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+        client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+    return client, model
+
+
+def baseline_eval_argument(client: Any, model: str, arg_text: str) -> Dict[str, Any]:
+    """Ask the 0-shot baseline to evaluate one arg on the 9 virtues + scale.
+
+    Returns {"scores": {virtue: float}, "justification": str, "raw": str}.
+    On parse failure, scores default to None (honest unavailable, not fabricated).
+    """
+    prompt = BASELINE_EVAL_PROMPT.replace("{arg_text}", arg_text[:4000])
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw = ""
+        choice = response.choices[0]
+        if choice.message and choice.message.content:
+            raw = choice.message.content
+    except Exception as exc:
+        return {"scores": {}, "justification": "", "raw": "", "error": str(exc)}
+
+    # Parse JSON (tolerate markdown code fences / leading text)
+    parsed = _parse_json_loose(raw)
+    if parsed is None or "scores" not in parsed:
+        return {"scores": {}, "justification": "", "raw": raw, "error": "parse_failed"}
+
+    scores_raw = parsed.get("scores", {})
+    # Coerce to scale values; clamp to {0.0, 0.2, 0.5, 1.0} (snap to nearest).
+    scores = {}
+    for v in VIRTUES:
+        val = scores_raw.get(v)
+        if isinstance(val, (int, float)):
+            scores[v] = _snap_to_scale(float(val))
+        else:
+            scores[v] = None  # honest unavailable
+    return {
+        "scores": scores,
+        "justification": str(parsed.get("justification", ""))[:300],
+        "raw": raw,
+    }
+
+
+def _snap_to_scale(val: float) -> float:
+    """Snap a float to the nearest scale value {0.0, 0.2, 0.5, 1.0}."""
+    return min(SCALE_VALUES, key=lambda s: abs(s - max(0.0, min(1.0, val))))
+
+
+def _parse_json_loose(text: str) -> Any:
+    """Parse JSON tolerating code fences and surrounding prose."""
+    import re
+
+    # Strip markdown code fences
+    cleaned = re.sub(r"```(?:json)?\s*", "", text)
+    cleaned = cleaned.replace("```", "").strip()
+    # Find first {...} block
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        return json.loads(cleaned[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+
+
+def overall_from_scores(scores: Dict[str, Any]) -> float:
+    """Sum of non-None scores (same aggregation as pipeline: overall = sum)."""
+    return round(sum(v for v in scores.values() if isinstance(v, (int, float))), 2)
+
+
+def run_headtohead_corpus(corpus_label: str, max_args: int = 8) -> Dict[str, Any]:
+    """Run head-to-head for one corpus: pipeline (loaded) vs baseline (live)."""
+    args, pipeline_scores = load_pipeline_args(corpus_label)
+    arg_ids = list(args.keys())[:max_args]  # cap to match pipeline radar window
+
+    client, model = _get_llm_client()
+    print(f"[FB28] corpus {corpus_label}: {len(arg_ids)} args to evaluate (baseline)")
+
+    per_arg = {}
+    for i, arg_id in enumerate(arg_ids, 1):
+        arg_text = args[arg_id]
+        t0 = time.time()
+        baseline_result = baseline_eval_argument(client, model, arg_text)
+        elapsed = time.time() - t0
+        pipe = pipeline_scores.get(arg_id, {})
+        per_arg[arg_id] = {
+            "pipeline": {
+                "scores": pipe.get("scores", {}),
+                "overall": pipe.get("overall"),
+            },
+            "baseline": {
+                "scores": baseline_result["scores"],
+                "overall": overall_from_scores(baseline_result["scores"]),
+                "justification": baseline_result.get("justification", ""),
+                "parse_error": baseline_result.get("error"),
+                "elapsed_s": round(elapsed, 1),
+            },
+        }
+        print(
+            f"  [{i}/{len(arg_ids)}] {arg_id}: "
+            f"pipeline_overall={pipe.get('overall')}  "
+            f"baseline_overall={per_arg[arg_id]['baseline']['overall']}  "
+            f"({elapsed:.1f}s)"
+        )
+
+    return {
+        "corpus": CORPUS_LABELS[corpus_label],
+        "method": "fb28_headtohead",
+        "model": model,
+        "n_args": len(arg_ids),
+        "per_argument": per_arg,
+    }
+
+
+def build_differential(results: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """Build the per-virtue + per-corpus differential table.
+
+    For each virtue and corpus: mean pipeline score, mean baseline score,
+    delta (pipeline - baseline), and the per-arg win/tie/lose counts.
+    """
+    diff = {}
+    for corpus_label, corpus_res in results.items():
+        per_arg = corpus_res.get("per_argument")
+        if per_arg is None:
+            # corpus errored (no per_argument) — record honest unavailable
+            diff[corpus_label] = {
+                "corpus": CORPUS_LABELS.get(corpus_label, corpus_label),
+                "error": corpus_res.get("error", "no per_argument"),
+            }
+            continue
+        n = len(per_arg)
+        # Per-virtue means (only args where BOTH sides scored that virtue)
+        virtue_means = {v: {"pipeline": [], "baseline": []} for v in VIRTUES}
+        overall_pipe = []
+        overall_base = []
+        win_tie_lose = {"pipeline_gt": 0, "tie": 0, "baseline_ge": 0}
+        for arg_id, entry in per_arg.items():
+            ps = entry["pipeline"]["scores"]
+            bs = entry["baseline"]["scores"]
+            po = entry["pipeline"]["overall"]
+            bo = entry["baseline"]["overall"]
+            if isinstance(po, (int, float)):
+                overall_pipe.append(po)
+            if isinstance(bo, (int, float)):
+                overall_base.append(bo)
+            # overall comparison
+            if isinstance(po, (int, float)) and isinstance(bo, (int, float)):
+                if po > bo:
+                    win_tie_lose["pipeline_gt"] += 1
+                elif po == bo:
+                    win_tie_lose["tie"] += 1
+                else:
+                    win_tie_lose["baseline_ge"] += 1
+            for v in VIRTUES:
+                pv = ps.get(v)
+                bv = bs.get(v)
+                if isinstance(pv, (int, float)):
+                    virtue_means[v]["pipeline"].append(pv)
+                if isinstance(bv, (int, float)):
+                    virtue_means[v]["baseline"].append(bv)
+
+        # Aggregate per-virtue
+        per_virtue = {}
+        for v in VIRTUES:
+            p_list = virtue_means[v]["pipeline"]
+            b_list = virtue_means[v]["baseline"]
+            p_mean = round(sum(p_list) / len(p_list), 3) if p_list else None
+            b_mean = round(sum(b_list) / len(b_list), 3) if b_list else None
+            delta = round(p_mean - b_mean, 3) if (p_mean is not None and b_mean is not None) else None
+            per_virtue[v] = {
+                "pipeline_mean": p_mean,
+                "baseline_mean": b_mean,
+                "delta_pipeline_minus_baseline": delta,
+            }
+
+        diff[corpus_label] = {
+            "corpus": CORPUS_LABELS[corpus_label],
+            "n_args": n,
+            "overall_mean": {
+                "pipeline": round(sum(overall_pipe) / len(overall_pipe), 3) if overall_pipe else None,
+                "baseline": round(sum(overall_base) / len(overall_base), 3) if overall_base else None,
+            },
+            "overall_win_tie_lose": win_tie_lose,
+            "per_virtue": per_virtue,
+        }
+    return diff
+
+
+def main():
+    parser = argparse.ArgumentParser(description="FB-28 quality head-to-head")
+    parser.add_argument("--corpus", choices=["A", "B", "C"], default=None)
+    parser.add_argument("--max-args", type=int, default=8)
+    args_cli = parser.parse_args()
+
+    corpus_list = [args_cli.corpus] if args_cli.corpus else ["A", "B", "C"]
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    results = {}
+    for label in corpus_list:
+        print(f"\n{'='*60}\n[FB28] corpus {label}\n{'='*60}")
+        try:
+            res = run_headtohead_corpus(label, max_args=args_cli.max_args)
+            results[label] = res
+            out_path = RESULTS_DIR / f"fb28_headtohead_{label}.json"
+            with open(out_path, "w", encoding="utf-8") as f:
+                json.dump(res, f, indent=2, ensure_ascii=False, default=str)
+            print(f"[FB28] saved {out_path}")
+        except Exception as exc:
+            print(f"[FB28] corpus {label} FAILED: {exc}")
+            results[label] = {"corpus": CORPUS_LABELS[label], "error": str(exc)}
+
+    diff = build_differential(results)
+    summary = {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "method": "fb28_quality_headtohead",
+        "description": "Pipeline 9-virtue radar vs 0-shot baseline on SAME extracted args",
+        "differential": diff,
+    }
+    summary_path = RESULTS_DIR / "fb28_summary.json"
+    with open(summary_path, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2, ensure_ascii=False, default=str)
+    print(f"\n[FB28] Summary + differential saved to {summary_path}")
+
+    # Console differential preview
+    print(f"\n{'='*60}\n[FB28] DIFFERENTIAL (pipeline - baseline)\n{'='*60}")
+    for label in corpus_list:
+        d = diff.get(label, {})
+        om = d.get("overall_mean", {})
+        wtl = d.get("overall_win_tie_lose", {})
+        print(
+            f"  {CORPUS_LABELS[label]}: overall pipe={om.get('pipeline')} "
+            f"base={om.get('baseline')} | win/tie/lose={wtl}"
+        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## #1102 — FB-28 Quality content-dominance head-to-head — EDGES confirmed

Closes #1102. Dispatch R402b (ai-01, mandate « pousse encore »). File-disjoint from FB-27 (po-2023, prompts).

## Question

Epic #947 terminal verdict = **EDGES** (FB-26 #1099). The **quality axis is the only non-DECIDES axis**: the pipeline's 9-virtue radar shows *existence-dominance* (baseline emits no radar) but had not been tested for *content-dominance*. **This PR tests it rigorously.**

## Method — apples-to-apples

The pipeline radar evaluates **extracted args** (deterministic, FB-25). To isolate *content-dominance* from *extraction-variance*, the **SAME extracted args** (replayable FB-25 artifacts) are fed to a **0-shot LLM baseline** asked to evaluate each arg on the **same 9 virtues + same scale `{0.0, 0.2, 0.5, 1.0}`**. Differential = pure evaluation-capability on identical units.

| Side | Source | Determinism |
|------|--------|-------------|
| Pipeline | `ArgumentQualityEvaluator` native radar (FB-25 #1095) | deterministic (spread 0.000000) |
| Baseline | 0-shot `gpt-5-mini` (OpenRouter), structured JSON on same rubric | stochastic |

Anti-théâtre (#1019): the radar was **NOT tuned** to score higher — `ArgumentQualityEvaluator` is byte-identical to main. The deliverable is the honest differential, whichever direction.

## Result — overall differential

| Corpus | n | Pipeline mean | Baseline mean | Δ (pipe−base) | pipe > base |
|--------|---|---------------|---------------|---------------|-------------|
| doc_A | 8 | **1.70** | 2.33 | **−0.63** | 1/8 |
| doc_B | 3 | **1.67** | 3.97 | **−2.30** | 0/3 |
| doc_C | 8 | **1.63** | 3.05 | **−1.43** | 0/8 |
| **Agg** | 19 | **~1.66** | **~3.04** | **−1.39** | **1/19** |

**The differential is NEGATIVE on all 3 corpora.** The 0-shot baseline scores systematically **higher** than the pipeline on 18/19 args. The pipeline radar is **more restrictive**, not richer.

## Result — per virtue

- **Pipeline ≥ baseline**: `redondance_faible` (deterministic non-redundancy, Δ +0.10) — the one content-edge.
- **Tie at ~0.0** (joint blindspot on source-light text): `presence_sources`, `refutation_constructive`, `analogie_pertinente`, `fiabilite_sources` — neither side fires.
- **Baseline > pipeline**: `clarte`, `pertinence`, `structure_logique`, `exhaustivite` — LLM more generous (credits perceived readability/logic that lexical heuristics miss).

## Verdict fork (DoD) — **EDGES, confirmed (NOT DECIDES)**

DECIDES requires the pipeline to *separate* from the baseline on content. **The measurement shows the opposite on 18/19 args**: the pipeline is more restrictive than, not richer than, the baseline. The pipeline's real edge is **existence + determinism + strictness** (process properties), **not content-separation**. Promoting to DECIDES would be the auto-promotion #1019 forbids.

→ **No §5 amendment** (the fork resolves to EDGES, the current Epic verdict). The Epic #947 terminal verdict EDGES is confirmed as the **honestly-measured** call, not a cap-on-excuse.

## Deliverables

- `scripts/run_fb28_quality_headtohead.py` — harness (file-disjoint from FB-27)
- `docs/reports/FB28_QUALITY_HEADTOHEAD_REPORT.md` — aggregate-only report, opaque IDs (force-added, follows FB-20 precedent — `.gitignore:46 *_report*.md` ignores dumps, not Epic deliverables)
- gitignored (replayable): `evaluation/results/capstone_c1/fb28_headtohead_{A,B,C}.json` + `fb28_summary.json`

## DoD checklist

- [x] Baseline 0-shot quality judgment captured A/B/C (same args, same 9 virtues, same scale)
- [x] Pipeline 9-virtue radar captured (replayed from deterministic FB-25 artifacts)
- [x] Per-virtue differential table (pipeline > / = / baseline =)
- [x] Honest DECIDES-vs-EDGES fork with proof — **EDGES**, anti-auto-promotion #1019
- [x] No §5 amendment (EDGES = current verdict, confirmed measured not capped)
- [x] Privacy HARD (in-memory corpus, opaque IDs, gitignored results, no raw_text)
- [x] Anti-théâtre (radar not tuned; EDGES measured is a valid result)

## Budget

OpenRouter $163.39 → $161.29 (FB-28 ~$2.10: 19 baseline evals + 1 C retry). Verified real via credits API before spend (FB-21 apply-to-budget).

## CI note

- Lint job (mypy strict) scope = `argumentation_analysis/` source only — this PR touches `scripts/` + `docs/` (out of scope). The harness has 6 mypy hints (same `no-untyped-def` pattern as the existing tracked `scripts/run_capstone_c1.py`, which has 14) — accepted for `scripts/`.
- `automated-tests` job: no test files changed (harness is a measurement script, not a unit-tested brick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
