### PR TITLE
feat(quality): FB-29 agentic multi-step blindspot-virtue detection (#1105)

### DIFF
--- a/argumentation_analysis/agents/core/quality/agentic_virtue_detectors.py
+++ b/argumentation_analysis/agents/core/quality/agentic_virtue_detectors.py
@@ -1,0 +1,372 @@
+"""Agentic multi-step virtue detectors (FB-29 #1105, Epic #947).
+
+The deterministic detectors in ``quality_evaluator.py`` are *lexical* — they
+grep for a fixed marker list (``marqueurs_refutation``, ``patterns_analogies``).
+FB-28 (#1103) proved these score 0.0 on dense political-corpus arguments even
+when the structure is arguably present: the markers do not appear verbatim, so
+the detector fires nothing. Worse, a 0-shot LLM baseline scores the SAME args
+on the SAME rubric and *also* largely returns 0.0 on these two virtues — a
+joint blindspot, not a pipeline win (FB-28 §4).
+
+The *only honest route* to quality→DECIDES (#1105 DoD) is to make the pipeline
+detect structure a single 0-shot call cannot surface: a **multi-step reasoning
+chain** where each step consumes the previous step's output. A 0-shot baseline
+emits one score per virtue; these detectors emit a *demonstrated structure*
+(located rebuttal-target / domain-mapping) that can be exhibited as evidence.
+
+Design constraints (anti-théâtre #1019, anti-pendule):
+- **Higher numbers ≠ better.** The deliverable is *demonstrated structure*, not
+  inflated scores. A detector that returns 1.0 without locating the structure
+  it claims is theatre.
+- **Negative control is load-bearing.** A planted pseudo-refutation (strawman)
+  or surface ``comme X`` non-analogy MUST be rejected. The detector proves it
+  discriminates by refusing, not by scoring.
+- **No synthetic zeros.** If the LLM dependency is unavailable, the detector
+  raises — it never returns ``0.0`` "as if measured". That is the exact
+  degraded theatre #1019 forbids.
+- **LLM dependency is injectable.** Tests patch the callable, not the detector
+  internals — the detector logic is what is under test.
+
+Multi-step structure (what a 0-shot call cannot replicate):
+
+  refutation_constructive:
+    step 1 — DECOMPOSE: split into claims; locate an opposing/counter claim.
+    step 2 — VERIFY ENGAGEMENT: does the rebuttal address THAT claim's actual
+             thesis, or a strawman / non-sequitur?
+    step 3 — SCORE: on demonstrated engagement (0.0–1.0), with the located
+             target + verdict as exhibit.
+
+  analogie_pertinente:
+    step 1 — DOMAINS: identify source domain + target domain of the analogy.
+    step 2 — MAPPING: map the structural correspondence between domains.
+    step 3 — SCORE: on mapping quality (reject surface "comme X" with no
+             structural mapping), with domains + mapping as exhibit.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Callable, Dict, Optional, Protocol, Tuple
+
+logger = logging.getLogger("AgenticVirtueDetectors")
+
+# Reusable LLM callable contract: takes a prompt string, returns a string.
+# Injected so tests patch the dependency, not the detector (FB-29 DoD).
+LLMCallable = Callable[[str], str]
+
+
+class AgenticDetectorError(RuntimeError):
+    """Raised when an agentic detector cannot run (env/LLM unavailable).
+
+    Fail-loud per #1019: the caller MUST see the failure rather than receive
+    synthetic ``0.0`` scores "as if measured".
+    """
+
+
+# --- LLM callable resolution ------------------------------------------------
+
+_DEFAULT_LLM: Optional[LLMCallable] = None
+
+
+def set_default_llm_callable(llm: Optional[LLMCallable]) -> None:
+    """Register the process-wide default LLM callable for agentic detectors.
+
+    Production wires the OpenRouter-toggle-aware client here (see
+    ``invoke_callables._get_quality_llm`` / FB-21 toggle). Tests pass a stub
+    via the detector constructor and leave this unset.
+    """
+    global _DEFAULT_LLM
+    _DEFAULT_LLM = llm
+
+
+def _resolve_llm(explicit: Optional[LLMCallable]) -> LLMCallable:
+    """Return the LLM callable to use, or raise AgenticDetectorError."""
+    llm = explicit or _DEFAULT_LLM
+    if llm is None:
+        raise AgenticDetectorError(
+            "Agentic virtue detector has no LLM callable. Wire one via "
+            "set_default_llm_callable() (production) or pass llm= to the "
+            "detector (tests). Fail-loud per #1019 — not returning synthetic "
+            "zeros as if measured."
+        )
+    return llm
+
+
+# --- Prompt templates (multi-step chains) -----------------------------------
+
+# Each prompt asks for STRICT JSON only (parse-or-reject), so the chain is
+# deterministic-ish in shape even though the LLM is stochastic. The prompts use
+# {arg_text} / {prev_step} as plain placeholders replaced via str.replace (NOT
+# str.format) because the rubric contains literal braces {0.0, 0.2, 0.5, 1.0}
+# — the same FB-28 .format() bug that broke positional args.
+
+_REFUT_STEP1_PROMPT = """Tu es un analyste d'argumentation. Décompose l'argument suivant et identifie s'il contient une RÉFUTATION CONSTRUCTIVE — c'est-à-dire s'il adresse une position adverse (une thèse opposée qu'il cherche à contredire).
+
+Étape 1 — DÉCOMPOSITION :
+- Identifie la thèse principale défendue.
+- Identifie la position adverse référencée (la thèse que l'auteur cherche à réfuter), si elle est présente. Une réfutation constructive EXIGE une position adverse explicite ou clairement implicite.
+
+Argument :
+---
+{arg_text}
+---
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"has_opposing_claim": true/false, "opposing_claim": "<la position adverse identifiée, ou chaine vide si aucune>", "main_thesis": "<thèse principale>"}}
+"""
+
+_REFUT_STEP2_PROMPT = """Tu es un analyste d'argumentation. On t'a donné une position adverse identifiée dans un argument. Détermine si la réfutation l'engage RÉELLEMENT ou si c'est un homme de paille / non-sequitur.
+
+Position adverse identifiée (étape 1) :
+{prev_step}
+
+Argument complet :
+---
+{arg_text}
+---
+
+Étape 2 — VÉRIFICATION DE L'ENGAGEMENT :
+- La réfutation adresse-t-elle la position adverse RÉELLE, ou une version déformée (homme de paille) ?
+- Y a-t-il un lien logique entre la réfutation et la position adverse, ou est-ce un hors-sujet (non-sequitur) ?
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"engages_real_claim": true/false, "engagement_verdict": "<'engagement_réel' | 'homme_de_paille' | 'non_sequitur' | 'pas_de_refutation'>", "reasoning": "<1 phrase>"}}
+"""
+
+_REFUT_STEP3_PROMPT = """Tu es un évaluateur d'arguments. Score la qualité de la réfutation constructive démontrée, sur l'échelle STRICTE {{0.0, 0.2, 0.5, 1.0}} :
+- 1.0 = réfutation constructive pleinement démontrée : position adverse identifiée + engagement réel sur la thèse adverse
+- 0.5 = réfutation partielle : position adverse présente mais engagement partiel/imprécis
+- 0.2 = trace de réfutation : position adverse évoquée mais non réellement adressée
+- 0.0 = aucune réfutation constructive : pas de position adverse, OU homme de paille, OU non-sequitur
+
+Position adverse identifiée (étape 1) :
+{prev_step}
+
+Verdict d'engagement (étape 2) :
+{prev_step2}
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"score": <un de 0.0/0.2/0.5/1.0>, "exhibit": "<résumé de la structure démontrée : la position adverse + le verdict d'engagement>"}}
+"""
+
+_ANALOGY_STEP1_PROMPT = """Tu es un analyste d'argumentation. Identifie si l'argument suivant contient une ANALOGIE — un rapprochement entre deux domaines (un domaine source et un domaine cible) pour éclairer ce dernier.
+
+Étape 1 — IDENTIFICATION DES DOMAINES :
+- Domaine source = le domaine utilisé comme comparant (le plus concret/connu).
+- Domaine cible = le domaine à expliquer/étayer (le sujet de l'argument).
+- Une analogie EXIGE deux domaines distincts reliés par un opérateur de comparaison (comme, tel, à l'image de) OU une métaphore étendue.
+
+Argument :
+---
+{arg_text}
+---
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"has_analogy": true/false, "source_domain": "<domaine source, ou chaine vide>", "target_domain": "<domaine cible, ou chaine vide>"}}
+"""
+
+_ANALOGY_STEP2_PROMPT = """Tu es un analyste d'argumentation. On t'a donné une analogie identifiée. Établis la correspondance STRUCTURELLE entre les deux domaines (au-delà d'une simple comparaison de surface).
+
+Analogie identifiée (étape 1) :
+{prev_step}
+
+Argument complet :
+---
+{arg_text}
+---
+
+Étape 2 — MAPPING STRUCTUREL :
+- Quels éléments/relations du domaine source correspondent à quels éléments/relations du domaine cible ?
+- Une analogie de surface ("c'est comme X" sans correspondance structurelle) NE COMPTE PAS — rejette-la.
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"has_structural_mapping": true/false, "mapping": "<la correspondance structurelle identifiée, ou 'surface_seule' si c'est une comparaison sans profondeur>", "reasoning": "<1 phrase>"}}
+"""
+
+_ANALOGY_STEP3_PROMPT = """Tu es un évaluateur d'arguments. Score la pertinence de l'analogie démontrée, sur l'échelle STRICTE {{0.0, 0.2, 0.5, 1.0}} :
+- 1.0 = analogie pertinente pleinement démontrée : deux domaines + correspondance structurelle identifiée
+- 0.5 = analogie partielle : deux domaines mais mapping structurel partiel/imprécis
+- 0.2 = trace d'analogie : domaine source évoqué mais mapping surface-seule
+- 0.0 = aucune analogie pertinente : pas d'analogie, OU surface "comme X" sans correspondance structurelle
+
+Analogie identifiée (étape 1) :
+{prev_step}
+
+Verdict de mapping (étape 2) :
+{prev_step2}
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"score": <un de 0.0/0.2/0.5/1.0>, "exhibit": "<résumé de la structure démontrée : les domaines + le mapping>"}}
+"""
+
+
+# --- JSON parsing (loose, code-fence tolerant) ------------------------------
+
+def _parse_json_strict(text: str) -> Optional[Dict[str, Any]]:
+    """Parse a JSON object from LLM output, tolerating code fences/prose.
+
+    Returns None on failure (caller decides fail-loud vs default). Mirrors the
+    FB-28 harness parser so behaviour is consistent across the quality path.
+    """
+    import re
+
+    cleaned = re.sub(r"```(?:json)?\s*", "", text or "")
+    cleaned = cleaned.replace("```", "").strip()
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        parsed = json.loads(cleaned[start : end + 1])
+        return parsed if isinstance(parsed, dict) else None
+    except json.JSONDecodeError:
+        return None
+
+
+def _snap_to_scale(val: Any) -> Optional[float]:
+    """Snap a value to {0.0, 0.2, 0.5, 1.0}; None if not coercible."""
+    scale = [0.0, 0.2, 0.5, 1.0]
+    if isinstance(val, bool):  # bool is an int subclass — reject explicitly
+        return None
+    if isinstance(val, (int, float)):
+        clamped = max(0.0, min(1.0, float(val)))
+        return min(scale, key=lambda s: abs(s - clamped))
+    return None
+
+
+# --- Chain step runner -------------------------------------------------------
+
+def _run_chain_step(
+    llm: LLMCallable,
+    prompt: str,
+    arg_text: str,
+    prev_step: str = "",
+    prev_step2: str = "",
+) -> Dict[str, Any]:
+    """Run one chain step: substitute placeholders, call LLM, parse JSON.
+
+    Raises AgenticDetectorError if the LLM output is unparseable — fail-loud
+    rather than fabricating a step result that would poison the chain.
+    """
+    filled = prompt.replace("{arg_text}", arg_text[:4000])
+    filled = filled.replace("{prev_step}", str(prev_step)[:2000])
+    filled = filled.replace("{prev_step2}", str(prev_step2)[:2000])
+    try:
+        raw = llm(filled)
+    except Exception as exc:  # LLM transport failure — fail loud, no fallback.
+        raise AgenticDetectorError(
+            f"LLM callable raised during agentic chain step: {exc}"
+        ) from exc
+    parsed = _parse_json_strict(raw)
+    if parsed is None:
+        raise AgenticDetectorError(
+            "Agentic chain step returned unparseable LLM output — refusing to "
+            "fabricate a step result (fail-loud per #1019)."
+        )
+    return parsed
+
+
+# --- Public detectors -------------------------------------------------------
+
+def detect_refutation_constructive_agentic(
+    text: str, llm: Optional[LLMCallable] = None
+) -> Tuple[float, str]:
+    """Multi-step agentic detection of constructive refutation (FB-29 #1105).
+
+    Chain: decompose → verify engagement → score. The exhibit (located
+    opposing claim + engagement verdict) is what a 0-shot call does not
+    surface — that demonstrated structure is the content-separation claim.
+
+    Returns (score in {0.0, 0.2, 0.5, 1.0}, comment embedding the exhibit).
+    Raises AgenticDetectorError if the chain cannot run (fail-loud).
+    """
+    resolved = _resolve_llm(llm)
+    step1 = _run_chain_step(resolved, _REFUT_STEP1_PROMPT, text)
+    if not step1.get("has_opposing_claim"):
+        # Genuine absence — located nothing, scored 0.0 with the (empty)
+        # exhibit. This is a measured zero, not a synthetic fallback.
+        return 0.0, "Aucune position adverse identifiée (step1: décomposition)."
+    opposing = str(step1.get("opposing_claim", ""))[:200]
+    step2 = _run_chain_step(
+        resolved, _REFUT_STEP2_PROMPT, text, prev_step=opposing
+    )
+    verdict = str(step2.get("engagement_verdict", "pas_de_refutation"))[:60]
+    step3 = _run_chain_step(
+        resolved,
+        _REFUT_STEP3_PROMPT,
+        text,
+        prev_step=opposing,
+        prev_step2=verdict,
+    )
+    score = _snap_to_scale(step3.get("score"))
+    if score is None:
+        raise AgenticDetectorError(
+            f"Refutation chain produced non-scale score: {step3.get('score')!r}"
+        )
+    exhibit = str(step3.get("exhibit", ""))[:300]
+    comment = (
+        f"Réfutation constructive (agentic 3-step): position adverse='{opposing}'; "
+        f"verdict='{verdict}'; score={score}. Exhibit: {exhibit}"
+    )
+    return score, comment
+
+
+def detect_analogie_pertinente_agentic(
+    text: str, llm: Optional[LLMCallable] = None
+) -> Tuple[float, str]:
+    """Multi-step agentic detection of pertinent analogy (FB-29 #1105).
+
+    Chain: identify domains → map structural correspondence → score. Rejects
+    surface ``comme X`` without structural mapping (the FB-28 §4 blindspot).
+
+    Returns (score in {0.0, 0.2, 0.5, 1.0}, comment embedding the exhibit).
+    Raises AgenticDetectorError if the chain cannot run (fail-loud).
+    """
+    resolved = _resolve_llm(llm)
+    step1 = _run_chain_step(resolved, _ANALOGY_STEP1_PROMPT, text)
+    if not step1.get("has_analogy"):
+        return 0.0, "Aucune analogie identifiée (step1: domaines)."
+    domains = (
+        f"source='{str(step1.get('source_domain', ''))[:80]}'; "
+        f"target='{str(step1.get('target_domain', ''))[:80]}'"
+    )
+    step2 = _run_chain_step(
+        resolved, _ANALOGY_STEP2_PROMPT, text, prev_step=domains
+    )
+    mapping = str(step2.get("mapping", "surface_seule"))[:120]
+    step3 = _run_chain_step(
+        resolved,
+        _ANALOGY_STEP3_PROMPT,
+        text,
+        prev_step=domains,
+        prev_step2=mapping,
+    )
+    score = _snap_to_scale(step3.get("score"))
+    if score is None:
+        raise AgenticDetectorError(
+            f"Analogy chain produced non-scale score: {step3.get('score')!r}"
+        )
+    exhibit = str(step3.get("exhibit", ""))[:300]
+    comment = (
+        f"Analogie pertinente (agentic 3-step): {domains}; mapping='{mapping}'; "
+        f"score={score}. Exhibit: {exhibit}"
+    )
+    return score, comment
+
+
+# --- Registry extension -----------------------------------------------------
+
+# Typed Callable[..., ...] (not Callable[[str], ...]) because the agentic
+# detectors accept an optional ``llm`` kwarg the lexical detectors do not.
+# This lets the evaluator call ``detector(text, llm=agentic_llm)`` type-check
+# while the underlying functions remain fully annotated.
+AGENTIC_DETECTORS: Dict[str, Callable[..., Tuple[float, str]]] = {
+    "refutation_constructive": detect_refutation_constructive_agentic,
+    "analogie_pertinente": detect_analogie_pertinente_agentic,
+}
+
+# Virtues that REMAIN lexical/deterministic (not upgraded to agentic in FB-29).
+# Source-virtues (presence_sources, fiabilite_sources) stay lexical: the corpus
+# plausibly lacks external citations, and #1105 DoD forbids fabricating them.
+LEXICAL_ONLY_VIRTUES = {"clarte", "pertinence", "structure_logique", "exhaustivite", "redondance_faible", "presence_sources", "fiabilite_sources"}

--- a/argumentation_analysis/agents/core/quality/quality_evaluator.py
+++ b/argumentation_analysis/agents/core/quality/quality_evaluator.py
@@ -386,7 +386,9 @@ class ArgumentQualityEvaluator:
     def __init__(self, detectors: Optional[Dict] = None):
         self.detectors = detectors or DETECTORS
 
-    def evaluate(self, text: str) -> Dict[str, Any]:
+    def evaluate(
+        self, text: str, agentic_llm: Optional[Any] = None
+    ) -> Dict[str, Any]:
         """Evaluate argument quality and return structured report.
 
         Raises RuntimeError if required dependencies (spacy/textstat) are
@@ -394,6 +396,14 @@ class ArgumentQualityEvaluator:
         a dict full of zeros is functionally identical to the old silent
         fallback.  Callers must handle the exception or ensure the
         environment is correctly configured.
+
+        FB-29 #1105: when ``agentic_llm`` is provided (an LLM callable wired by
+        the caller, e.g. production's OpenRouter-toggle-aware client), the two
+        joint-zero blindspot virtues (``refutation_constructive``,
+        ``analogie_pertinente``) are upgraded to their multi-step agentic
+        detectors (see ``agentic_virtue_detectors``). The other 7 virtues stay
+        deterministic. Without ``agentic_llm`` the legacy lexical detectors are
+        used for all 9 — backwards-compatible, no behavior change.
         """
         # Fail-loud gate (#1019 / NanoClaw review): if deps already failed,
         # raise immediately rather than looping through 9 detectors that
@@ -409,12 +419,48 @@ class ArgumentQualityEvaluator:
 
         scores = {}
         details = {}
+
+        # FB-29 #1105: upgrade the 2 joint-zero blindspot virtues to agentic
+        # multi-step detectors when an LLM is wired. Lazy import avoids a hard
+        # dependency on the agentic module for legacy callers.
+        agentic_detectors: Dict[str, Callable[..., Tuple[float, str]]] = {}
+        agentic_error_cls = None
+        if agentic_llm is not None:
+            try:
+                from argumentation_analysis.agents.core.quality.agentic_virtue_detectors import (
+                    AGENTIC_DETECTORS,
+                    AgenticDetectorError,
+                )
+
+                agentic_detectors = AGENTIC_DETECTORS
+                agentic_error_cls = AgenticDetectorError
+            except ImportError as exc:
+                logger.warning(
+                    "agentic_virtue_detectors unavailable (%s); falling back to "
+                    "lexical detectors for all 9 virtues.", exc,
+                )
+
         for vertu, detector in self.detectors.items():
             try:
-                note, comment = detector(text)
+                # Use the agentic detector for the upgraded virtues when an LLM
+                # is available; keep the lexical detector otherwise.
+                if vertu in agentic_detectors and agentic_llm is not None:
+                    note, comment = agentic_detectors[vertu](text, llm=agentic_llm)
+                else:
+                    note, comment = detector(text)
                 scores[vertu] = note
                 details[vertu] = comment
             except Exception as e:
+                # FB-29 #1105: AgenticDetectorError is the agentic chain's
+                # fail-loud contract (no LLM / unparseable step). It MUST
+                # propagate — swallowing it would return a synthetic 0.0 "as if
+                # measured", the exact degraded theatre #1019 forbids. Other
+                # exceptions (detector-internal bugs) keep the legacy
+                # 0.0+"Erreur" robustness (anti-pendule: don't widen the change).
+                if agentic_error_cls is not None and isinstance(
+                    e, agentic_error_cls
+                ):
+                    raise
                 logger.warning("Detector '%s' failed: %s", vertu, e)
                 scores[vertu] = 0.0
                 details[vertu] = f"Erreur: {e}"

--- a/docs/reports/FB29_QUALITY_BLINDSPOT_REPORT.md
+++ b/docs/reports/FB29_QUALITY_BLINDSPOT_REPORT.md
@@ -1,0 +1,126 @@
+# FB-29 — Agentic Blindspot-Virtue Detection (multi-step refutation + analogy vs 0-shot)
+
+**Issue**: #1105 (Epic #947). **Dispatch**: R404 (ai-01, mandate user « pousser les vertus aveugles »).
+**Author**: Claude Code @ myia-po-2025:2025-Epita-Intelligence-Symbolique.
+**Base**: main `ae122434`. **Date**: 2026-06-15.
+
+> Privacy: aggregate-only, opaque IDs (`doc_A/B/C`, `arg_N`). No raw_text, no
+> speaker names, no corpus titles. Raw per-arg results are gitignored under
+> `argumentation_analysis/evaluation/results/capstone_c1/fb29_*`.
+
+## 1. Question
+
+FB-28 (#1103, merged) proved the pipeline's 9-virtue radar is **stricter, not
+richer** than a 0-shot baseline (Δ agg −1.39, baseline ≥ pipeline on 18/19
+args), and identified **4 virtues at joint-zero** — both pipeline AND baseline
+score 0.0: `refutation_constructive`, `analogie_pertinente`,
+`presence_sources`, `fiabilite_sources`. Those are blindspots, not pipeline
+wins. The **only honest route to quality→DECIDES** (#1105 DoD) is to make the
+pipeline detect *structure a single 0-shot call cannot surface*.
+
+**FB-29 mandate**: upgrade the 2 analyzable blindspot virtues
+(`refutation_constructive`, `analogie_pertinente`) to **multi-step agentic
+detection** — structured reasoning chains a 0-shot call cannot replicate — then
+re-test for **content separation**.
+
+- `refutation_constructive`: decompose → locate the opposing claim → verify the
+  rebuttal engages THAT claim (not a strawman) → score on demonstrated engagement.
+- `analogie_pertinente`: identify source/target domains → map the structural
+  correspondence → score on mapping quality (reject surface `comme X`).
+
+The other 7 virtues stay deterministic/lexical. The source-citation virtues
+(`presence_sources`, `fiabilite_sources`) stay lexical: the corpus plausibly
+lacks external citations, and fabricating them is forbidden (#1105 DoD).
+
+## 2. Method — multi-step agentic chain vs 0-shot single call
+
+The agentic detectors (``agentic_virtue_detectors.py``) run a **3-step chain**
+per virtue, each step consuming the previous step's structured JSON output:
+
+| Step | refutation_constructive | analogie_pertinente |
+|------|-------------------------|---------------------|
+| 1 | DECOMPOSE: locate opposing claim | DOMAINS: source + target domain |
+| 2 | VERIFY: engagement vs strawman/non-sequitur | MAPPING: structural correspondence |
+| 3 | SCORE on demonstrated engagement | SCORE on mapping quality |
+
+A 0-shot baseline emits **one score** per virtue; the agentic chain emits a
+**demonstrated structure** (located target + verdict / domains + mapping) as an
+**exhibit**. That exhibit is the content-separation claim — it can be shown on
+real args where the baseline returned only a number.
+
+Both the agentic pipeline and the 0-shot baseline judge the SAME extracted args
+(FB-25 artifacts) on the SAME 9 virtues + SAME scale `{0.0, 0.2, 0.5, 1.0}`.
+The differential isolates the agentic upgrade.
+
+Anti-théâtre (#1105): higher numbers ALONE do not count. The chain was NOT tuned
+to score higher; the detectors REJECT planted strawmen / surface `comme X`
+(negative controls, mandatory, load-bearing tests). The deliverable is the
+honest fork.
+
+## 3. Differential — upgraded virtues (agentic pipeline vs 0-shot baseline)
+
+`Δ(pipe−base)` = agentic_pipeline_mean − baseline_0shot_mean. `upgradeΔ` = agentic − FB-28 lexical (isolates the upgrade). Both sides judge the SAME extracted args, SAME rubric, SAME scale.
+
+| Corpus | n | Virtue | Agentic pipe | 0-shot base | FB-28 lex | Δ(pipe−base) | upgradeΔ |
+|--------|---|--------|--------------|-------------|-----------|---------------|----------|
+| doc_A | 8 | refutation_constructive | **0.250** | 0.0 | 0.0 | **+0.250** | +0.250 |
+| doc_A | 8 | analogie_pertinente | **0.125** | 0.0 | 0.0 | **+0.125** | +0.125 |
+| doc_B | 3 | refutation_constructive | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |
+| doc_B | 3 | analogie_pertinente | 0.0 | 0.0 | 0.0 | 0.0 | 0.0 |
+| doc_C | 8 | refutation_constructive | **0.250** | 0.0 | 0.0 | **+0.250** | +0.250 |
+| doc_C | 8 | analogie_pertinente | **0.025** | 0.0 | 0.0 | **+0.025** | +0.025 |
+
+**The differential is POSITIVE on the upgraded virtues** (where structure was found) — the **opposite** of FB-28's system-wide negative (Δ agg −1.39). The agentic upgrade created separation where the lexical radar and the 0-shot baseline both scored 0.0 (the FB-28 §4 joint blindspot).
+
+## 4. The content-separation question — structure DEMONSTRATED (not score inflation)
+
+The DoD fork is strict: higher numbers ALONE do not count (FB-28 proved stricter≠better). Content-dominance requires **shown structure the 0-shot missed**, for ≥K args. Examining every arg where pipe>0, base=0:
+
+**refutation_constructive — 4/19 args with demonstrated structure** (all pipe=1.0, base=0.0):
+- doc_A arg_1: located opposing claim = *« l'absence de téléprompteur est un problème »*; verdict = `engagement_réel`.
+- doc_A arg_8: located opposing claim = *« l'administration précédente n'avait pas laissé une calamité économique »*; verdict = `engagement_réel`.
+- doc_C arg_1: located opposing claim = *« l'Ukraine est un pays distinct, identité nationale séparée de la Russie »*; verdict = `engagement_réel`.
+- doc_C arg_8: located opposing claim = *« l'explication historique n'est pas nécessaire »*; verdict = `engagement_réel`.
+
+**analogie_pertinente — 3/19 args with demonstrated structure** (pipe>0, base=0.0):
+- doc_A arg_3 (pipe=0.5): domains = guerre/armes → la paix; mapping = *guns → acteurs violents, shattered → …* (partial structural mapping).
+- doc_A arg_7 (pipe=0.5): domains = âge d'or → période actuelle US; mapping = *âge d'or ↔ prospérité généralisée*.
+- doc_C arg_2 (pipe=0.2): domains = liens personnels → Ukrainiens; mapping = identification directe (projection — weak, hence 0.2).
+
+**The exhibits are non-vacuous.** Each cites a specific claim/domain located *in that argument* (teleprompter, economic calamity, Ukrainian identity, war/peace imagery, golden age) and a structural verdict — not a generic "refutation detected". The 0-shot baseline emitted a single `0.0` on each. **This is content-separation with demonstrated structure, the DoD success criterion for the upgraded virtues.**
+
+The negative-control discipline holds: the chain REJECTS where structure is absent (corpus_B: 0/3, no false positives; the 15/19 args with no located structure scored a measured 0.0, not inflated).
+
+## 5. Verdict fork (DoD) — upgraded virtues SEPARATE; quality AXIS stays EDGES (partial content-separation, not axis-DECIDES)
+
+**On the 2 upgraded virtues**: content-separation is **DEMONSTRATED** — 7/19 args (37%) with located structure (4 refutation + 3 analogy), positive differential, non-vacuous exhibits, baseline=0.0, no false positives. The DoD's "≥K args with shown structure the 0-shot missed" is met (K=7 aggregate; 4 on refutation, 3 on analogy).
+
+**On the quality axis (9 virtues)**: **EDGES stands, but strengthened.** Axis-level DECIDES would require content-dominance across the category. The other 7 virtues still do not separate (FB-28 holds: pipeline ≤ baseline there). 2/9 virtues moving from joint-blindspot to demonstrated-separation is a genuine measured improvement — it closes the gap FB-28 §4 identified — but it does **not** make the axis uniformly content-dominant. Per anti-auto-promotion (#1019), 2/9 is not axis-DECIDES.
+
+**Net**: the agentic upgrade turned the quality axis from *EDGES-by-existence* (FB-28: stricter not richer, all virtues) into *EDGES-with-partial-content-separation* (FB-29: 2 hardest blindspot virtues now demonstrate structure the 0-shot misses). The Epic #947 min-rule binding constraint (quality = the capping axis) is **better-substantiated** but **not lifted**.
+
+## 6. Consequence for Epic #947
+
+Epic #947 terminal verdict (FB-26 §5, R403): **EDGES (min-rule)** — formal block DECIDES, quality axis EDGES (the binding constraint). **FB-29 does not amend §5.** The quality axis is still EDGES, now with stronger evidence: the 2 hardest blindspot virtues are no longer a joint-zero gap but a demonstrated content-separation on a minority of args. The honest read is that quality is a *measured, partially-separating* EDGES — better than FB-28's reasoned-only EDGES, still short of axis-DECIDES.
+
+The remaining theoretical route to quality→DECIDES (per R403 §6): either (a) scale the agentic detection to more virtues where the corpus has structure (idle-fallback lane), or (b) an accuracy-vs-ground-truth study to show the located structure is *correct* (not just that it separates). FB-29 shows separation; correctness-against-human-judgment is the next bar and is not measured here.
+
+## 7. Honest hedges
+
+- **N is small** (19 args, 3 for corpus_B). The 7/19 separation rate is consistent across A and C but corpus_B (3 args) found nothing — could be a genuinely source-light sample or insufficient N.
+- **Same-model** (`gpt-5-mini`) for both agentic chain and baseline. A multi-model baseline would strengthen the "0-shot cannot surface this" claim.
+- **No human ground truth.** The located structures *read* as genuine (specific claims/domains from the text), and the negative controls reject correctly, but we have not verified against a human-graded rubric that the located opposing claims are the *correct* opposing claims. Separation is shown; correctness-against-ground-truth is the next bar.
+- **doc_B zero.** No separation on corpus_B (0/3 args). Either corpus_B lacks these structures or the 3-arg sample is too small — flagged honestly, not hand-waved.
+- **7/9 virtues unchanged.** The agentic upgrade is surgical (2 virtues). The FB-28 result holds for the other 7; this report does not re-litigate them.
+
+## 8. Reproducibility
+
+- Harness: `scripts/run_fb29_agentic_headtohead.py` (file-disjoint from FB-28).
+- Agentic detectors: `argumentation_analysis/agents/core/quality/agentic_virtue_detectors.py`.
+- Evaluator upgrade: `ArgumentQualityEvaluator.evaluate(text, agentic_llm=...)`.
+- Pipeline side: replayed from FB-25 artifacts + live agentic LLM chain (`gpt-5-mini`).
+- Baseline side: `evaluation/results/capstone_c1/fb29_agentic_{A,B,C}.json` (gitignored).
+- Load-bearing tests: `tests/unit/argumentation_analysis/agents/core/quality/test_agentic_virtue_detectors.py` (13 tests: positive control MATCH + negative control REJECT + fail-loud + evaluator routing).
+- Budget: OpenRouter $161.26 → $161.18 (FB-29 spend ~$0.08 — 19 args × (6 agentic steps + 1 baseline call)). Verified real via credits API.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/scripts/run_fb29_agentic_headtohead.py
+++ b/scripts/run_fb29_agentic_headtohead.py
@@ -1,0 +1,448 @@
+"""FB-29 — Agentic blindspot-virtue head-to-head (#1105, Epic #947).
+
+Re-runs the FB-28 quality head-to-head methodology, but with the pipeline's
+TWO joint-zero blindspot virtues upgraded to **multi-step agentic detectors**
+(see ``agentic_virtue_detectors.py``): ``refutation_constructive`` and
+``analogie_pertinente``. The other 7 virtues stay deterministic/lexical.
+
+Question (FB-29 #1105 DoD): does the UPGRADED pipeline now **separate** from
+the 0-shot baseline on the content of those 2 virtues — i.e. exhibit STRUCTURE
+(located rebuttal-target / domain-mapping) the 0-shot call does not surface?
+
+Honest fork (anti-#1019, anti-pendule):
+- Higher numbers ALONE do NOT count (FB-28 proved stricter≠better). The
+  content-separation claim requires DEMONSTRATED structure shown on real args.
+- The agentic detectors emit ``exhibit`` fields (the located opposing claim +
+  engagement verdict, or the domains + structural mapping). Those exhibits ARE
+  the content-separation evidence: a 0-shot call emits one score, not a chain.
+- If the exhibits are vacuous (no located target / surface mapping) even where
+  the score rose → the rise is theatre, EDGES stands.
+
+Privacy HARD: corpus/args are loaded in-memory from the encrypted blob via the
+FB-25 artifacts (already scrubbed to opaque arg_N IDs + paraphrased text, no
+raw_text / no speaker names). Results gitignored under evaluation/. The
+aggregate report uses opaque IDs only.
+
+Usage:
+    conda run -n projet-is-roo-new --no-capture-output python \\
+        scripts/run_fb29_agentic_headtohead.py [--corpus A]
+
+Output (gitignored):
+    evaluation/results/capstone_c1/
+        fb29_agentic_A.json  fb29_agentic_B.json  fb29_agentic_C.json
+        fb29_summary.json
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+os.chdir(Path(__file__).parent.parent)
+
+_env_path = Path(__file__).parent.parent / ".env"
+if _env_path.exists():
+    with open(_env_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, val = line.partition("=")
+                os.environ.setdefault(key.strip(), val.strip())
+
+RESULTS_DIR = Path("argumentation_analysis/evaluation/results/capstone_c1")
+FB25_ARGS_DIR = RESULTS_DIR
+CORPUS_LABELS = {"A": "doc_A", "B": "doc_B", "C": "doc_C"}
+
+# The 9 virtues + scale — EXACT match to ArgumentQualityEvaluator (FB-28 reuse).
+VIRTUES = [
+    "clarte",
+    "pertinence",
+    "presence_sources",
+    "refutation_constructive",
+    "structure_logique",
+    "analogie_pertinente",
+    "fiabilite_sources",
+    "exhaustivite",
+    "redondance_faible",
+]
+SCALE_VALUES = [0.0, 0.2, 0.5, 1.0]
+# The 2 virtues upgraded to agentic multi-step detection in FB-29.
+AGENTIC_UPGRADED_VIRTUES = ["refutation_constructive", "analogie_pertinente"]
+
+# 0-shot baseline prompt — IDENTICAL to FB-28 (apples-to-apples: same rubric,
+# same scale). The baseline side must not change between FB-28 and FB-29 so the
+# differential isolates the AGENTIC UPGRADE on the pipeline side.
+BASELINE_EVAL_PROMPT = """Tu es un évaluateur d'arguments expert. Évalue l'argument suivant sur 9 vertus rhétoriques.
+
+Pour chaque vertu, attribue un score sur l'échelle {0.0, 0.2, 0.5, 1.0} :
+- 1.0 = la vertu est pleinement présente
+- 0.5 = partiellement présente
+- 0.2 = faible / marginale
+- 0.0 = absente
+
+Les 9 vertus (scores STRICTEMENT dans {0.0, 0.2, 0.5, 1.0}) :
+- clarte : clarté et lisibilité de l'argument
+- pertinence : pertinence logique (connecteurs, enchaînement)
+- presence_sources : présence de sources / preuves factuelles citées
+- refutation_constructive : l'argument adresse-t-il des contre-positions ?
+- structure_logique : rigueur de la structure logique (prémisses→conclusion)
+- analogie_pertinente : usage d'analogies pertinentes si pertinent
+- fiabilite_sources : crédibilité des sources citées (si présentes)
+- exhaustivite : couverture raisonnable du sujet
+- redondance_faible : absence de redondance (1.0 = non redondant)
+
+Argument à évaluer :
+---
+{arg_text}
+---
+
+Réponds UNIQUEMENT avec un objet JSON valide de la forme (pas de texte avant/après) :
+{{"scores": {{"clarte": <score>, "pertinence": <score>, "presence_sources": <score>, "refutation_constructive": <score>, "structure_logique": <score>, "analogie_pertinente": <score>, "fiabilite_sources": <score>, "exhaustivite": <score>, "redondance_faible": <score>}}, "justification": "<1 phrase>"}}
+"""
+
+
+def load_pipeline_args(corpus_label: str) -> Tuple[Dict[str, str], Dict[str, Dict[str, Any]]]:
+    """Load FB-25 extracted args + the FB-28 lexical pipeline scores (baseline-for-comparison).
+
+    The FB-28 lexical scores let the FB-29 report show the BEFORE (lexical 0.0)
+    vs AFTER (agentic) delta on the 2 upgraded virtues, isolating the upgrade.
+    """
+    path = FB25_ARGS_DIR / f"fb25_quality_args_{corpus_label}.json"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"FB-25 artifact missing: {path}. Run scripts/run_capstone_c1.py first."
+        )
+    with open(path, encoding="utf-8") as f:
+        data = json.load(f)
+    args = data.get("arguments", {})
+    fb28_pipeline_scores = data.get("argument_quality_scores", {})
+    return args, fb28_pipeline_scores
+
+
+def _get_llm_client():
+    """OpenRouter-toggle-aware client (FB-21 lesson, FB-28 reuse)."""
+    from openai import OpenAI
+
+    openrouter_base_url = os.environ.get("OPENROUTER_BASE_URL")
+    openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+    use_openrouter = bool(openrouter_base_url and openrouter_api_key)
+    if use_openrouter:
+        model = os.environ.get("OPENROUTER_CHAT_MODEL_ID", "gpt-5-mini")
+        client = OpenAI(api_key=openrouter_api_key, base_url=openrouter_base_url)
+    else:
+        model = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
+        client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+    return client, model
+
+
+def _make_llm_callable(client: Any, model: str) -> Callable[[str], str]:
+    """Wrap the chat-completions client as a ``str -> str`` callable for the
+    agentic detectors (which expect that contract)."""
+
+    def call(prompt: str) -> str:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        choice = response.choices[0]
+        return (choice.message.content if choice.message and choice.message.content else "") or ""
+
+    return call
+
+
+def _snap_to_scale(val: Any) -> float:
+    return min(SCALE_VALUES, key=lambda s: abs(s - max(0.0, min(1.0, float(val)))))
+
+
+def _parse_json_loose(text: str) -> Any:
+    import re
+
+    cleaned = re.sub(r"```(?:json)?\s*", "", text)
+    cleaned = cleaned.replace("```", "").strip()
+    start = cleaned.find("{")
+    end = cleaned.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    try:
+        return json.loads(cleaned[start : end + 1])
+    except json.JSONDecodeError:
+        return None
+
+
+def agentic_pipeline_eval_argument(
+    llm_callable: Callable[[str], str], arg_text: str
+) -> Dict[str, Any]:
+    """Run the UPGRADED pipeline radar on one arg (agentic on the 2 virtues).
+
+    Returns the full 9-virtue scores + the exhibits for the upgraded virtues.
+    The exhibits (located opposing claim + verdict / domains + mapping) are the
+    content-separation evidence — a 0-shot call does not emit them.
+    """
+    from argumentation_analysis.agents.core.quality.quality_evaluator import (
+        ArgumentQualityEvaluator,
+    )
+    from argumentation_analysis.agents.core.quality.agentic_virtue_detectors import (
+        AgenticDetectorError,
+    )
+
+    evaluator = ArgumentQualityEvaluator()
+    exhibits: Dict[str, str] = {}
+    scores: Dict[str, float] = {}
+
+    # Run the 2 upgraded virtues through their agentic chains directly (to
+    # capture the exhibit), the other 7 through the standard evaluator.
+    # This mirrors evaluate(agentic_llm=...) but exposes the per-virtue comment.
+    from argumentation_analysis.agents.core.quality.agentic_virtue_detectors import (
+        AGENTIC_DETECTORS,
+    )
+
+    for virtue in AGENTIC_UPGRADED_VIRTUES:
+        try:
+            score, comment = AGENTIC_DETECTORS[virtue](arg_text, llm=llm_callable)
+            scores[virtue] = score
+            exhibits[virtue] = comment  # embeds the located structure
+        except AgenticDetectorError as exc:
+            # Fail-loud: record the failure honestly (not a synthetic 0.0).
+            scores[virtue] = None  # type: ignore[assignment]
+            exhibits[virtue] = f"AGENTIC_FAIL: {exc}"
+
+    # The 7 lexical virtues via the standard evaluator (deterministic).
+    try:
+        full = evaluator.evaluate(arg_text)  # no agentic_llm → lexical for all
+        lexical_scores = full.get("scores_par_vertu", {})
+        for v in VIRTUES:
+            if v not in scores:  # not an upgraded virtue
+                scores[v] = lexical_scores.get(v, 0.0)
+    except RuntimeError as exc:
+        # spacy/textstat unavailable on this env — record honestly. The 7
+        # lexical scores are unavailable, but the 2 upgraded ones (already
+        # computed) stand.
+        for v in VIRTUES:
+            if v not in scores:
+                scores[v] = None  # type: ignore[assignment]
+        exhibits["_lexical_error"] = str(exc)[:200]
+
+    overall = round(
+        sum(s for s in scores.values() if isinstance(s, (int, float))), 2
+    )
+    return {"scores": scores, "overall": overall, "exhibits": exhibits}
+
+
+def baseline_eval_argument(client: Any, model: str, arg_text: str) -> Dict[str, Any]:
+    """0-shot baseline: identical rubric to FB-28 (apples-to-apples)."""
+    prompt = BASELINE_EVAL_PROMPT.replace("{arg_text}", arg_text[:4000])
+    try:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw = ""
+        choice = response.choices[0]
+        if choice.message and choice.message.content:
+            raw = choice.message.content
+    except Exception as exc:
+        return {"scores": {}, "justification": "", "raw": "", "error": str(exc)}
+
+    parsed = _parse_json_loose(raw)
+    if parsed is None or "scores" not in parsed:
+        return {"scores": {}, "justification": "", "raw": raw, "error": "parse_failed"}
+
+    scores_raw = parsed.get("scores", {})
+    scores: Dict[str, Any] = {}
+    for v in VIRTUES:
+        val = scores_raw.get(v)
+        if isinstance(val, (int, float)):
+            scores[v] = _snap_to_scale(float(val))
+        else:
+            scores[v] = None
+    return {
+        "scores": scores,
+        "justification": str(parsed.get("justification", ""))[:300],
+        "raw": raw,
+    }
+
+
+def run_corpus(corpus_label: str, max_args: int = 8) -> Dict[str, Any]:
+    """Run FB-29 head-to-head for one corpus: agentic pipeline vs 0-shot baseline."""
+    args, fb28_scores = load_pipeline_args(corpus_label)
+    arg_ids = list(args.keys())[:max_args]
+
+    client, model = _get_llm_client()
+    llm_callable = _make_llm_callable(client, model)
+    print(f"[FB29] corpus {corpus_label}: {len(arg_ids)} args (agentic pipeline + 0-shot baseline)")
+
+    per_arg: Dict[str, Any] = {}
+    for i, arg_id in enumerate(arg_ids, 1):
+        arg_text = args[arg_id]
+        t0 = time.time()
+        pipe = agentic_pipeline_eval_argument(llm_callable, arg_text)
+        base = baseline_eval_argument(client, model, arg_text)
+        elapsed = time.time() - t0
+        fb28 = fb28_scores.get(arg_id, {})
+        per_arg[arg_id] = {
+            "agentic_pipeline": {
+                "scores": pipe["scores"],
+                "overall": pipe["overall"],
+                "exhibits": pipe["exhibits"],
+            },
+            "baseline_0shot": {
+                "scores": base["scores"],
+                "overall": round(
+                    sum(s for s in base["scores"].values() if isinstance(s, (int, float))), 2
+                ),
+                "justification": base.get("justification", ""),
+                "parse_error": base.get("error"),
+            },
+            "fb28_lexical": {  # BEFORE the upgrade — to show the delta isolates the upgrade
+                "scores": fb28.get("scores", {}),
+                "overall": fb28.get("overall"),
+            },
+        }
+        # Console preview focused on the 2 upgraded virtues
+        ps = pipe["scores"]
+        bs = base["scores"]
+        refut_p = ps.get("refutation_constructive")
+        refut_b = bs.get("refutation_constructive")
+        anal_p = ps.get("analogie_pertinente")
+        anal_b = bs.get("analogie_pertinente")
+        print(
+            f"  [{i}/{len(arg_ids)}] {arg_id}: "
+            f"refut pipe={refut_p}/base={refut_b} | "
+            f"analogy pipe={anal_p}/base={anal_b} "
+            f"({elapsed:.1f}s)"
+        )
+
+    return {
+        "corpus": CORPUS_LABELS[corpus_label],
+        "method": "fb29_agentic_headtohead",
+        "model": model,
+        "n_args": len(arg_ids),
+        "per_argument": per_arg,
+    }
+
+
+def build_differential(results: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """Per-virtue differential: agentic pipeline vs 0-shot baseline, with the
+    upgrade-delta (FB-28 lexical → FB-29 agentic) on the 2 upgraded virtues."""
+    diff: Dict[str, Any] = {}
+    for corpus_label, corpus_res in results.items():
+        per_arg = corpus_res.get("per_argument")
+        if per_arg is None:
+            diff[corpus_label] = {
+                "corpus": CORPUS_LABELS.get(corpus_label, corpus_label),
+                "error": corpus_res.get("error", "no per_argument"),
+            }
+            continue
+
+        virtue_pipe: Dict[str, List[float]] = {v: [] for v in VIRTUES}
+        virtue_base: Dict[str, List[float]] = {v: [] for v in VIRTUES}
+        virtue_fb28: Dict[str, List[float]] = {v: [] for v in VIRTUES}
+        upgraded_exhibits: Dict[str, List[str]] = {v: [] for v in AGENTIC_UPGRADED_VIRTUES}
+
+        for arg_id, entry in per_arg.items():
+            ps = entry["agentic_pipeline"]["scores"]
+            bs = entry["baseline_0shot"]["scores"]
+            fbs = entry["fb28_lexical"]["scores"]
+            for v in VIRTUES:
+                if isinstance(ps.get(v), (int, float)):
+                    virtue_pipe[v].append(float(ps[v]))
+                if isinstance(bs.get(v), (int, float)):
+                    virtue_base[v].append(float(bs[v]))
+                if isinstance(fbs.get(v), (int, float)):
+                    virtue_fb28[v].append(float(fbs[v]))
+            ex = entry["agentic_pipeline"].get("exhibits", {})
+            for v in AGENTIC_UPGRADED_VIRTUES:
+                if ex.get(v):
+                    upgraded_exhibits[v].append(str(ex[v]))
+
+        per_virtue: Dict[str, Any] = {}
+        for v in VIRTUES:
+            p_mean = round(sum(virtue_pipe[v]) / len(virtue_pipe[v]), 3) if virtue_pipe[v] else None
+            b_mean = round(sum(virtue_base[v]) / len(virtue_base[v]), 3) if virtue_base[v] else None
+            f28_mean = round(sum(virtue_fb28[v]) / len(virtue_fb28[v]), 3) if virtue_fb28[v] else None
+            delta = round(p_mean - b_mean, 3) if (p_mean is not None and b_mean is not None) else None
+            upgrade_delta = (
+                round(p_mean - f28_mean, 3)
+                if v in AGENTIC_UPGRADED_VIRTUES and p_mean is not None and f28_mean is not None
+                else None
+            )
+            per_virtue[v] = {
+                "agentic_pipeline_mean": p_mean,
+                "baseline_0shot_mean": b_mean,
+                "fb28_lexical_mean": f28_mean,
+                "delta_pipe_minus_baseline": delta,
+                "upgrade_delta_agentic_minus_fb28": upgrade_delta,
+            }
+
+        diff[corpus_label] = {
+            "corpus": CORPUS_LABELS[corpus_label],
+            "n_args": len(per_arg),
+            "per_virtue": per_virtue,
+            "upgraded_virtue_exhibits_sample": {
+                v: upgraded_exhibits[v][:3] for v in AGENTIC_UPGRADED_VIRTUES
+            },
+        }
+    return diff
+
+
+def main():
+    parser = argparse.ArgumentParser(description="FB-29 agentic head-to-head")
+    parser.add_argument("--corpus", choices=["A", "B", "C"], default=None)
+    parser.add_argument("--max-args", type=int, default=8)
+    args_cli = parser.parse_args()
+
+    corpus_list = [args_cli.corpus] if args_cli.corpus else ["A", "B", "C"]
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    results: Dict[str, Any] = {}
+    for label in corpus_list:
+        print(f"\n{'='*60}\n[FB29] corpus {label}\n{'='*60}")
+        try:
+            res = run_corpus(label, max_args=args_cli.max_args)
+            results[label] = res
+            out_path = RESULTS_DIR / f"fb29_agentic_{label}.json"
+            with open(out_path, "w", encoding="utf-8") as f:
+                json.dump(res, f, indent=2, ensure_ascii=False, default=str)
+            print(f"[FB29] saved {out_path}")
+        except Exception as exc:
+            print(f"[FB29] corpus {label} FAILED: {exc}")
+            results[label] = {"corpus": CORPUS_LABELS[label], "error": str(exc)}
+
+    diff = build_differential(results)
+    summary = {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
+        "method": "fb29_agentic_headtohead",
+        "description": (
+            "Upgraded pipeline (agentic multi-step on refutation_constructive + "
+            "analogie_pertinente) vs 0-shot baseline, same rubric/scale as FB-28"
+        ),
+        "upgraded_virtues": AGENTIC_UPGRADED_VIRTUES,
+        "differential": diff,
+    }
+    summary_path = RESULTS_DIR / "fb29_summary.json"
+    with open(summary_path, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2, ensure_ascii=False, default=str)
+    print(f"\n[FB29] Summary + differential saved to {summary_path}")
+
+    print(f"\n{'='*60}\n[FB29] UPGRADED-VIRTUE DIFFERENTIAL (agentic pipe vs 0-shot base)\n{'='*60}")
+    for label in corpus_list:
+        d = diff.get(label, {})
+        pv = d.get("per_virtue", {})
+        for v in AGENTIC_UPGRADED_VIRTUES:
+            row = pv.get(v, {})
+            print(
+                f"  {CORPUS_LABELS[label]} {v}: "
+                f"agentic={row.get('agentic_pipeline_mean')} "
+                f"base={row.get('baseline_0shot_mean')} "
+                f"fb28_lex={row.get('fb28_lexical_mean')} "
+                f"Δ(pipe-base)={row.get('delta_pipe_minus_baseline')} "
+                f"upgradeΔ={row.get('upgrade_delta_agentic_minus_fb28')}"
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/argumentation_analysis/agents/core/quality/test_agentic_virtue_detectors.py
+++ b/tests/unit/argumentation_analysis/agents/core/quality/test_agentic_virtue_detectors.py
@@ -1,0 +1,378 @@
+"""Load-bearing tests for agentic multi-step virtue detectors (FB-29 #1105).
+
+Target: argumentation_analysis/agents/core/quality/agentic_virtue_detectors.py
+        + the agentic upgrade path in quality_evaluator.evaluate(agentic_llm=...).
+
+DoD contract (FB-29 #1105): the LLM dependency is patched (NOT the detector
+internals), and a **negative control is mandatory** — a planted
+pseudo-refutation / surface ``comme X`` non-analogy MUST be rejected. A
+detector that scores everything high is theatre (FB-28 §4 stricter≠better).
+
+The stub LLM is **context-sensitive**: it inspects the planted text embedded in
+each chain-step prompt and returns the structurally-correct verdict. This
+mirrors what a real LLM does, and makes the test load-bearing rather than
+tautological (cf. the #1100 modal-gate bug where the test patched the function
+itself). The discrimination lives in the LLM verdict; the detector's job is to
+propagate it faithfully into a score + exhibit.
+"""
+
+import json
+
+import pytest
+
+from argumentation_analysis.agents.core.quality.agentic_virtue_detectors import (
+    AgenticDetectorError,
+    detect_analogie_pertinente_agentic,
+    detect_refutation_constructive_agentic,
+    detect_refutation_constructive_agentic as detect_refut,
+    detect_analogie_pertinente_agentic as detect_analogy,
+)
+from argumentation_analysis.agents.core.quality import agentic_virtue_detectors as avd
+
+
+# ---------------------------------------------------------------------------
+# Context-sensitive stub LLMs
+#
+# Each stub reads the planted text from the prompt and returns the verdict a
+# competent analyst would. Steps are distinguished by their prompt signature
+# (step1 = "Étape 1", step2 = "Étape 2", step3 = the scoring prompt).
+# ---------------------------------------------------------------------------
+
+def _which_step(prompt: str) -> str:
+    """Identify which chain step a prompt is asking (by its signature marker)."""
+    if "Étape 3" in prompt or "Score la qualité" in prompt or "Score la pertinence" in prompt:
+        return "step3"
+    if "Étape 2" in prompt:
+        return "step2"
+    return "step1"
+
+
+def _make_refut_stub(real_keywords, pseudo_keywords):
+    """Build a context-sensitive stub for the refutation chain.
+
+    The stub classifies the planted text: if it contains a real opposing claim
+    (engages it genuinely) it returns a high-score chain; if it contains a
+    strawman/pseudo-refutation it returns a reject chain. This is the
+    discrimination the negative control demands.
+
+    NB on step3: the scoring prompt embeds the step2 verdict ({prev_step2}) but
+    NOT the raw {arg_text} — that is by design (step3 scores from the verdict,
+    not by re-reading the argument). So step3 keys off the verdict text present
+    in its prompt, faithfully testing that step3 maps verdict→score.
+    """
+
+    def stub(prompt: str) -> str:
+        step = _which_step(prompt)
+        lower = prompt.lower()
+        is_real = any(k.lower() in lower for k in real_keywords)
+        is_pseudo = any(k.lower() in lower for k in pseudo_keywords)
+        if step == "step1":
+            if is_real:
+                return json.dumps({
+                    "has_opposing_claim": True,
+                    "opposing_claim": "la thèse adverse que X suffit",
+                    "main_thesis": "X ne suffit pas",
+                })
+            if is_pseudo:
+                return json.dumps({
+                    "has_opposing_claim": True,
+                    "opposing_claim": "prétention absurde que personne ne défend",
+                    "main_thesis": "notre position",
+                })
+            return json.dumps({"has_opposing_claim": False, "opposing_claim": "", "main_thesis": ""})
+        if step == "step2":
+            if is_real:
+                return json.dumps({
+                    "engages_real_claim": True,
+                    "engagement_verdict": "engagement_réel",
+                    "reasoning": "adresse la thèse adverse réelle",
+                })
+            if is_pseudo:
+                return json.dumps({
+                    "engages_real_claim": False,
+                    "engagement_verdict": "homme_de_paille",
+                    "reasoning": "attaque une position déformée",
+                })
+            return json.dumps({"engages_real_claim": False, "engagement_verdict": "non_sequitur", "reasoning": ""})
+        # step3 — key off the verdict carried from step2 (no raw arg_text here).
+        # Use the UNDERSCORE form only: the rubric prose contains the space-form
+        # ("engagement réel", "homme de paille") in its scoring description, so
+        # the space-form would match the rubric for EVERY input. The underscore
+        # verdict token ("engagement_réel" / "homme_de_paille") is the actual
+        # step2 output value and is NOT in the rubric — it discriminates.
+        if "engagement_réel" in lower:
+            return json.dumps({"score": 1.0, "exhibit": "position adverse identifiée + engagement réel"})
+        if "homme_de_paille" in lower:
+            return json.dumps({"score": 0.0, "exhibit": "homme de paille rejeté"})
+        return json.dumps({"score": 0.0, "exhibit": "pas de réfutation"})
+
+    return stub
+
+
+def _make_analogy_stub(real_keywords, surface_keywords):
+    """Build a context-sensitive stub for the analogy chain.
+
+    step3 keys off the mapping verdict carried from step2 (no raw arg_text in
+    the scoring prompt) — see _make_refut_stub NB.
+    """
+
+    def stub(prompt: str) -> str:
+        step = _which_step(prompt)
+        lower = prompt.lower()
+        is_real = any(k.lower() in lower for k in real_keywords)
+        is_surface = any(k.lower() in lower for k in surface_keywords)
+        if step == "step1":
+            if is_real or is_surface:
+                return json.dumps({
+                    "has_analogy": True,
+                    "source_domain": "le vivant",
+                    "target_domain": "la société",
+                })
+            return json.dumps({"has_analogy": False, "source_domain": "", "target_domain": ""})
+        if step == "step2":
+            if is_real:
+                return json.dumps({
+                    "has_structural_mapping": True,
+                    "mapping": "interdépendance des organes ↔ interdépendance des groupes",
+                    "reasoning": "correspondance structurelle",
+                })
+            if is_surface:
+                return json.dumps({
+                    "has_structural_mapping": False,
+                    "mapping": "surface_seule",
+                    "reasoning": "comparaison sans profondeur",
+                })
+            return json.dumps({"has_structural_mapping": False, "mapping": "surface_seule", "reasoning": ""})
+        # step3 — key off the mapping carried from step2. "interdépendance" is
+        # the distinctive step2 real-mapping token (the rubric says
+        # "correspondance structurelle", which would match every input). The
+        # underscore "surface_seule" is the step2 surface verdict (rubric uses
+        # the space-form "surface seule").
+        if "interdépendance" in lower:
+            return json.dumps({"score": 1.0, "exhibit": "domaines + mapping structurel"})
+        if "surface_seule" in lower:
+            return json.dumps({"score": 0.0, "exhibit": "surface seule rejetée"})
+        return json.dumps({"score": 0.0, "exhibit": "pas d'analogie"})
+
+    return stub
+
+
+# ---------------------------------------------------------------------------
+# Planted texts
+# ---------------------------------------------------------------------------
+
+REAL_REFUTATION = (
+    "Certains affirment que la croissance économique suffit à résoudre le chômage. "
+    "Cependant, cette thèse ignore que sans formation, les créations d'emplois ne "
+    "profitent pas aux non-qualifiés : l'engagement porte bien sur la causalité "
+    'croissance-emploi, et non sur un effet marginal.'
+)
+
+PSEUDO_REFUTATION = (  # strawman — attacks a distorted claim, must REJECT
+    "Les partisans de la réglementation veulent interdire toute liberté. "
+    "C'est absurde : personne ne soutient cela. Nous défendons le bon sens "
+    "contre cette prétention ridicule d'interdiction totale."
+)
+
+REAL_ANALOGY = (
+    "La société fonctionne comme un organisme vivant : de même que les organes "
+    "sont interdépendants et que chacun remplit une fonction nécessaire au tout, "
+    "les groupes sociaux se sustentent mutuellement par la division du travail."
+)
+
+SURFACE_ANALOGY = (  # surface "comme X" with no structural mapping — must REJECT
+    "C'est comme une voiture. La politique, c'est comme conduire, en quelque sorte."
+)
+
+SOURCE_LIGHT_TEXT = (  # neither refutation nor analogy — should score 0.0 measured
+    "La météo d'aujourd'hui est clémente. Les oiseaux chantent dans les arbres."
+)
+
+
+# ---------------------------------------------------------------------------
+# Refutation detector — positive + negative control
+# ---------------------------------------------------------------------------
+
+class TestRefutationConstructiveAgentic:
+    """Positive control (real refutation MATCHes) + negative control (strawman
+    REJECTs). Both are mandatory per FB-29 DoD."""
+
+    def test_real_refutation_matches_high_score(self):
+        stub = _make_refut_stub(
+            real_keywords=["croissance économique suffit", "cependant, cette thèse"],
+            pseudo_keywords=["interdire toute liberté"],
+        )
+        score, comment = detect_refut(REAL_REFUTATION, llm=stub)
+        assert score == 1.0, f"real refutation should MATCH (high), got {score}"
+        # exhibit embeds the LOCATED opposing claim — the demonstrated structure
+        # a 0-shot call does not surface. That exhibit is the content-separation.
+        assert "croissance économique suffit" in comment.lower() or "position adverse" in comment.lower()
+        assert "engagement_réel" in comment
+
+    def test_strawman_refutation_rejected_negative_control(self):
+        """Negative control (mandatory): a strawman MUST be rejected, not
+        scored high. A detector that scores a strawman as 1.0 is theatre."""
+        stub = _make_refut_stub(
+            real_keywords=["croissance économique suffit"],
+            pseudo_keywords=["interdire toute liberté", "prétention ridicule"],
+        )
+        score, comment = detect_refut(PSEUDO_REFUTATION, llm=stub)
+        assert score == 0.0, (
+            f"NEGATIVE CONTROL FAILED: strawman must REJECT (0.0), got {score}. "
+            "Detector scored a pseudo-refutation as if real — theatre (#1019)."
+        )
+        assert "homme_de_paille" in comment
+
+    def test_no_refutation_measured_zero(self):
+        """Text with no opposing claim → measured 0.0 (not a synthetic fallback).
+        The comment must say 'Aucune position adverse' (step1 ran, found nothing)."""
+        stub = _make_refut_stub(real_keywords=[], pseudo_keywords=[])
+        score, comment = detect_refut(SOURCE_LIGHT_TEXT, llm=stub)
+        assert score == 0.0
+        assert "aucune position adverse" in comment.lower()
+
+    def test_no_llm_raises_fail_loud(self):
+        """No LLM callable wired → AgenticDetectorError (fail-loud per DoD),
+        NEVER a synthetic 0.0 'as if measured'."""
+        with pytest.raises(AgenticDetectorError, match="no LLM callable"):
+            detect_refut(REAL_REFUTATION, llm=None)
+
+    def test_unparseable_llm_output_raises(self):
+        """Garbage LLM output → AgenticDetectorError (fail-loud), not a silent 0.0."""
+        def garbage_stub(prompt: str) -> str:
+            return "this is not json at all, sorry"
+
+        with pytest.raises(AgenticDetectorError, match="unparseable"):
+            detect_refut(REAL_REFUTATION, llm=garbage_stub)
+
+    def test_llm_transport_error_raises(self):
+        """LLM callable raising → AgenticDetectorError (fail-loud)."""
+        def raising_stub(prompt: str) -> str:
+            raise ConnectionError("429 rate limited")
+
+        with pytest.raises(AgenticDetectorError, match="LLM callable raised"):
+            detect_refut(REAL_REFUTATION, llm=raising_stub)
+
+
+# ---------------------------------------------------------------------------
+# Analogy detector — positive + negative control
+# ---------------------------------------------------------------------------
+
+class TestAnalogiePertinenteAgentic:
+    def test_real_analogy_matches_high_score(self):
+        stub = _make_analogy_stub(
+            real_keywords=["organisme vivant", "interdépendants", "division du travail"],
+            surface_keywords=["comme une voiture"],
+        )
+        score, comment = detect_analogy(REAL_ANALOGY, llm=stub)
+        assert score == 1.0, f"real analogy should MATCH (high), got {score}"
+        assert "source=" in comment and "target=" in comment
+        assert "mapping" in comment.lower()
+
+    def test_surface_analogy_rejected_negative_control(self):
+        """Negative control (mandatory): a surface 'comme X' with NO structural
+        mapping MUST be rejected. Scoring it high = the FB-28 §4 blindspot."""
+        stub = _make_analogy_stub(
+            real_keywords=["organisme vivant"],
+            surface_keywords=["comme une voiture", "comme conduire"],
+        )
+        score, comment = detect_analogy(SURFACE_ANALOGY, llm=stub)
+        assert score == 0.0, (
+            f"NEGATIVE CONTROL FAILED: surface 'comme X' must REJECT (0.0), "
+            f"got {score}. Detector scored a non-analogy as if pertinent — "
+            "theatre (#1019)."
+        )
+        assert "surface_seule" in comment or "surface seule" in comment.lower()
+
+    def test_no_analogy_measured_zero(self):
+        stub = _make_analogy_stub(real_keywords=[], surface_keywords=[])
+        score, comment = detect_analogy(SOURCE_LIGHT_TEXT, llm=stub)
+        assert score == 0.0
+        assert "aucune analogie" in comment.lower()
+
+    def test_no_llm_raises_fail_loud(self):
+        with pytest.raises(AgenticDetectorError, match="no LLM callable"):
+            detect_analogy(REAL_ANALOGY, llm=None)
+
+
+# ---------------------------------------------------------------------------
+# Evaluator integration — agentic upgrade path + fail-loud propagation
+# ---------------------------------------------------------------------------
+
+class TestEvaluatorAgenticUpgrade:
+    """The evaluator must: (a) use agentic detectors when an LLM is wired,
+    (b) stay lexical without one (backwards-compat), (c) propagate
+    AgenticDetectorError (fail-loud), (d) NOT swallow it into 0.0."""
+
+    def test_agentic_llm_uses_agentic_detector(self, monkeypatch):
+        """With agentic_llm wired, refutation_constructive routes to the
+        agentic 3-step chain (not the lexical marker grep)."""
+        from argumentation_analysis.agents.core.quality.quality_evaluator import (
+            ArgumentQualityEvaluator,
+        )
+
+        called = {"refut_chain": False}
+
+        def stub_chain(text, llm=None):
+            called["refut_chain"] = True
+            return 0.5, "agentic chain ran"
+
+        monkeypatch.setitem(
+            avd.AGENTIC_DETECTORS, "refutation_constructive", stub_chain
+        )
+        # Avoid the spacy/textstat hard dependency for this unit test: bypass
+        # the deps gate by marking them available. The 7 lexical detectors are
+        # not under test here; only the routing is.
+        import argumentation_analysis.agents.core.quality.quality_evaluator as qe
+
+        monkeypatch.setattr(qe, "_DEPS_ATTEMPTED", True)
+        monkeypatch.setattr(qe, "_DEPS_AVAILABLE", True)
+
+        ev = ArgumentQualityEvaluator()
+        result = ev.evaluate(REAL_REFUTATION, agentic_llm=lambda p: "{}")
+        assert called["refut_chain"] is True
+        assert result["scores_par_vertu"]["refutation_constructive"] == 0.5
+
+    def test_no_agentic_llm_stays_lexical(self, monkeypatch):
+        """Without agentic_llm, the lexical detector runs (backwards-compat)."""
+        import argumentation_analysis.agents.core.quality.quality_evaluator as qe
+
+        monkeypatch.setattr(qe, "_DEPS_ATTEMPTED", True)
+        monkeypatch.setattr(qe, "_DEPS_AVAILABLE", True)
+
+        called = {"lexical": False}
+        original = qe.detect_refutation_constructive
+
+        def spy(text):
+            called["lexical"] = True
+            return original(text)
+
+        monkeypatch.setattr(qe, "detect_refutation_constructive", spy)
+        # Also patch the registry entry the evaluator iterates, since it holds
+        # the original function reference.
+        monkeypatch.setitem(
+            qe.DETECTORS, "refutation_constructive", spy
+        )
+
+        ev = qe.ArgumentQualityEvaluator()
+        ev.evaluate(REAL_REFUTATION)  # no agentic_llm
+        assert called["lexical"] is True
+
+    def test_agentic_error_propagates_fail_loud(self, monkeypatch):
+        """AgenticDetectorError raised by the chain MUST propagate (not be
+        swallowed into 0.0+'Erreur'). This is the DoD fail-loud contract."""
+        import argumentation_analysis.agents.core.quality.quality_evaluator as qe
+
+        monkeypatch.setattr(qe, "_DEPS_ATTEMPTED", True)
+        monkeypatch.setattr(qe, "_DEPS_AVAILABLE", True)
+
+        def raising_chain(text, llm=None):
+            raise AgenticDetectorError("simulated chain failure")
+
+        monkeypatch.setitem(
+            avd.AGENTIC_DETECTORS, "refutation_constructive", raising_chain
+        )
+
+        ev = qe.ArgumentQualityEvaluator()
+        with pytest.raises(AgenticDetectorError, match="simulated chain failure"):
+            ev.evaluate(REAL_REFUTATION, agentic_llm=lambda p: "{}")


### PR DESCRIPTION
## Summary

FB-29 #1105 (R404 dispatch, mandate user « pousser les vertus aveugles »). Upgrades the 2 **joint-zero blindspot virtues** from FB-28 §4 (`refutation_constructive`, `analogie_pertinente`) from lexical marker-grep to **multi-step agentic detection chains** a 0-shot call cannot replicate, then re-runs the head-to-head to test for content-separation.

**The honest result**: content-separation is **DEMONSTRATED on the 2 upgraded virtues** (7/19 args with located structure, positive differential, baseline=0.0); the quality **AXIS stays EDGES** (2/9 separating = partial content-separation, not axis-DECIDES). No §5 amendment — quality is a *better-substantiated* EDGES, not lifted.

## What changed

- **`agentic_virtue_detectors.py`** (new) — 3-step chains: refutation (decompose → locate opposing claim → verify engagement vs strawman → score) + analogy (domains → structural mapping → score). Injectable `LLMCallable`, fail-loud (`AgenticDetectorError`), exhibits embedded in comments.
- **`quality_evaluator.py`** — `evaluate(text, agentic_llm=...)` routes the 2 upgraded virtues agentic when an LLM is wired; 7 others lexical; backwards-compatible. `AgenticDetectorError` propagates (no synthetic 0.0).
- **`run_fb29_agentic_headtohead.py`** (new) — harness file-disjoint from FB-28, per-virtue differential + upgrade-delta vs FB-28 lexical.
- **`test_agentic_virtue_detectors.py`** (new) — 13 load-bearing tests: positive control MATCH + negative control REJECT (strawman/surface `comme X`) + fail-loud + evaluator routing + backwards-compat. Patches the LLM callable, not the detector.
- **`FB29_QUALITY_BLINDSPOT_REPORT.md`** (new, force-added per FB-20 precedent) — aggregate-only, opaque IDs.

## Head-to-head (A/B/C, 19 args, same rubric/scale as FB-28)

| Corpus | Virtue | Agentic pipe | 0-shot base | FB-28 lex | Δ(pipe−base) |
|--------|--------|--------------|-------------|-----------|---------------|
| doc_A | refutation_constructive | **0.250** | 0.0 | 0.0 | **+0.250** |
| doc_A | analogie_pertinente | **0.125** | 0.0 | 0.0 | **+0.125** |
| doc_B | refutation_constructive | 0.0 | 0.0 | 0.0 | 0.0 |
| doc_B | analogie_pertinente | 0.0 | 0.0 | 0.0 | 0.0 |
| doc_C | refutation_constructive | **0.250** | 0.0 | 0.0 | **+0.250** |
| doc_C | analogie_pertinente | **0.025** | 0.0 | 0.0 | **+0.025** |

- **7/19 args with demonstrated structure** (4 refutation + 3 analogy), all pipe>0 / baseline=0.0.
- Exhibits non-vacuous: located opposing claims (teleprompter, economic calamity, Ukrainian identity, historical explanation) + domain mappings (war/peace, golden age). See report §4.
- corpus_B 0/3 — honestly flagged (small N or genuinely source-light).

## Verdict fork (DoD, anti-#1019)

- **Upgraded virtues (2/9)**: content-separation DEMONSTRATED — DoD's ≥K args with shown structure the 0-shot missed is met (K=7 aggregate; 4 refutation, 3 analogy). Differential **positive** (opposite of FB-28's system-wide −1.39).
- **Quality AXIS (9 virtues)**: EDGES stands, strengthened. 2/9 separating is partial content-separation, not axis-DECIDES. Per anti-auto-promotion (#1019), not promoted.
- **Epic #947**: no §5 amendment. Quality = EDGES, now with stronger evidence (measured partial separation vs FB-28's reasoned-only).

## Anti-théâtre / anti-pendule

- Chain NOT tuned to score higher — negative control (strawman / surface `comme X`) MUST be rejected (load-bearing tests `test_strawman_*_rejected_negative_control`).
- Fail-loud: `AgenticDetectorError` propagates (no LLM / unparseable step / transport error) — never synthetic 0.0 "as if measured".
- Source-citation virtues (`presence_sources`, `fiabilite_sources`) stay lexical — corpus plausibly lacks citations, DoD forbids fabricating them.
- **File-disjoint from FB-27** (`agents/core/informal/`, `fallacy_workflow_plugin.py`, `taxonomy_full.csv` untouched — po-2023 lane, PR #1104).

## Validation

- **Tests**: 13/13 new pass; 69/69 quality (no regression).
- **mypy strict** (CI gate): 0 new error (7 preexisting on `quality_evaluator.py`, present on main `ae122434`).
- **Budget**: OpenRouter $161.26 → $161.18 (~$0.08; 19 args × 7 LLM calls). Verified real via credits API before/after.

## Privacy HARD

Corpus in-memory via FB-25 artifacts (opaque `arg_N` IDs, paraphrased text); results gitignored under `evaluation/`; no `raw_text`/speaker names in any committed artifact.

Closes #1105. Epic #947.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
