### PR TITLE
fix(fb30): restore agentic taxonomy navigation by subtraction — remove depth cap + mechanical beam (#1107)

### DIFF
--- a/argumentation_analysis/plugins/fallacy_workflow_plugin.py
+++ b/argumentation_analysis/plugins/fallacy_workflow_plugin.py
@@ -63,15 +63,22 @@ class FallacyWorkflowPlugin:
     5. Fallback to one-shot if iterative approach fails
     """
 
-    MAX_DEPTH_PER_BRANCH = 8
     MAX_BRANCHES = 4
     MAX_CANDIDATES = 20  # Wide-net Phase 1 cap (#578)
     MIN_CONFIRM_DEPTH = 2  # Don't accept confirmations at depth < 2 (too generic)
 
-    # FB-19 beam descent parameters (#1040)
-    BEAM_WIDTH = 3  # Top-k branches kept per level during beam descent
-    BEAM_MAX_LLM_CALLS = 15  # Circuit breaker for beam descent
-    BEAM_MIN_DEPTH = 5  # Value-gate: beam must reach ≥1 node at this depth
+    # FB-30 (#1107): restored agentic taxonomy navigation by subtraction.
+    # There is NO depth cap — the taxonomy leaves are the only cap (real
+    # taxonomy depth ≤ 10). The previous MAX_DEPTH_PER_BRANCH=8 made the 12
+    # leaf nodes at depth 9-10 structurally unreachable. Runaway protection
+    # (#708) is preserved by a generous per-branch LLM-CALL budget (circuit
+    # breaker), NOT a depth cap. One navigation iteration == one LLM call, so
+    # this bounds total calls while letting the LLM descend freely to leaves.
+    MAX_NAVIGATION_LLM_CALLS = 18
+    # How many subtree levels the navigation prompt shows at each step (a
+    # multi-level cluster, not just immediate children) so the LLM can jump
+    # levels via explore_branch(any_pk) — the original summer-2025 design.
+    NAV_CLUSTER_DEPTH = 2
 
     # RA-3 #1048 item 2: bounded recursive sub-branch fan-out.
     # At a fork the LLM may flag several promising children; the engine used to
@@ -106,9 +113,10 @@ class FallacyWorkflowPlugin:
             self._confirmed: List[Tuple[str, str, int, float]] = []
             self.superseded_count = 0
             # RA-3 #1048 item 2: shared budget bounding recursive sub-branch
-            # fan-out across ALL branches of one analysis. Mirrors the beam's
-            # BEAM_MAX_LLM_CALLS guardrail — fan-out is capped, never unbounded
-            # (anti-pendule #1019). 0 ⇒ fan-out disabled.
+            # fan-out across ALL branches of one analysis. Mirrors the agentic
+            # navigation's MAX_NAVIGATION_LLM_CALLS guardrail — fan-out is
+            # capped, never unbounded (anti-pendule #1019). 0 ⇒ fan-out
+            # disabled.
             self._fanout_budget = fanout_budget
             self.fanout_spawned = 0
 
@@ -423,8 +431,8 @@ class FallacyWorkflowPlugin:
     ) -> Optional[str]:
         """Map a free-text fallacy name to the deepest matching PK.
 
-        FB-19 (#1040): tries the deep index (depth ≤ 3) first, giving the
-        beam descent a head start. Falls back to None if no match.
+        Tries the deep index (depth ≤ 3) first, giving the agentic navigation
+        a head start. Falls back to None if no match.
         """
         name_lower = fallacy_name.lower().strip()
 
@@ -439,185 +447,14 @@ class FallacyWorkflowPlugin:
 
         return None
 
-    async def _beam_descent(
-        self,
-        argument_text: str,
-        seed_pks: List[str],
-        beam_width: Optional[int] = None,
-        max_llm_calls: Optional[int] = None,
-    ) -> List[IdentifiedFallacy]:
-        """FB-19 beam descent: iterative top-k selection at each taxonomy level.
-
-        At each level, presents candidate children to the LLM, keeps the top
-        beam_width by confidence, and descends. Budget-capped to prevent runaway.
-
-        Args:
-            argument_text: The text to analyze.
-            seed_pks: Starting PKs (from wide-net, possibly at depth 2-3).
-            beam_width: Max branches kept per level (default BEAM_WIDTH).
-            max_llm_calls: Circuit breaker (default BEAM_MAX_LLM_CALLS).
-
-        Returns:
-            List of IdentifiedFallacy from confirmed nodes at deepest level.
-        """
-        beam_width = beam_width or self.BEAM_WIDTH
-        max_llm_calls = max_llm_calls or self.BEAM_MAX_LLM_CALLS
-
-        slave_kernel, slave_settings = self._create_slave_kernel()
-        llm_calls_used = 0
-
-        # Beam state: list of (pk, depth, confidence, navigation_trace)
-        beam: List[Tuple[str, int, float, List[str]]] = []
-        for pk in seed_pks:
-            node = self.taxonomy_navigator.get_node(pk)
-            if node:
-                try:
-                    depth = int(node.get("depth", 0))
-                except (ValueError, TypeError):
-                    depth = 0
-                beam.append((pk, depth, 1.0, [pk]))
-
-        confirmed_fallacies: List[IdentifiedFallacy] = []
-
-        while beam and llm_calls_used < max_llm_calls:
-            next_beam: List[Tuple[str, int, float, List[str]]] = []
-
-            for pk, depth, conf, trace in beam:
-                if llm_calls_used >= max_llm_calls:
-                    break
-
-                node = self.taxonomy_navigator.get_node(pk)
-                if not node:
-                    continue
-
-                children = self.taxonomy_navigator.get_children(pk)
-
-                # Leaf node or no children — auto-confirm if depth >= MIN_CONFIRM_DEPTH
-                if not children:
-                    node_name = node.get(
-                        f"text_{self.language}", node.get("nom_vulgarisé", pk)
-                    )
-                    if depth >= self.MIN_CONFIRM_DEPTH:
-                        confirmed_fallacies.append(
-                            IdentifiedFallacy(
-                                fallacy_type=node_name,
-                                taxonomy_pk=pk,
-                                taxonomy_path=node.get("path", ""),
-                                explanation=f"Beam descent confirmed at depth {depth} (leaf)",
-                                confidence=conf * 0.85,
-                                navigation_trace=trace,
-                                family=node.get("Famille", ""),
-                            )
-                        )
-                    continue
-
-                # Present children to LLM for beam selection
-                child_options = []
-                for child in children:
-                    cpk = child.get("PK", "")
-                    cname = child.get(
-                        f"text_{self.language}", child.get("nom_vulgarisé", cpk)
-                    )
-                    cdesc = child.get(f"desc_{self.language}", "")[:120]
-                    child_options.append({"pk": cpk, "name": cname, "desc": cdesc})
-
-                parent_name = node.get(
-                    f"text_{self.language}", node.get("nom_vulgarisé", pk)
-                )
-
-                prompt = (
-                    f'Text to analyze: "{argument_text[:500]}"\n\n'
-                    f"You are navigating the fallacy taxonomy at depth {depth}: "
-                    f"{parent_name}\n"
-                    f"Select the TOP {beam_width} most relevant children for this text.\n"
-                    f"Rate each selected child with a confidence score (0.0-1.0).\n\n"
-                    f"Children:\n"
-                )
-                for i, co in enumerate(child_options):
-                    prompt += f"  {i+1}. {co['name']} (PK: {co['pk']}): {co['desc']}\n"
-
-                prompt += (
-                    f"\nRespond with a JSON array of up to {beam_width} objects:\n"
-                    '[{"pk": "...", "confidence": 0.0-1.0, "reason": "..."}]\n'
-                    "Respond ONLY with the JSON array, no other text."
-                )
-
-                beam_history = ChatHistory(
-                    system_message=(
-                        "You are a fallacy taxonomy navigator. Select the most "
-                        "relevant branches for the given text. "
-                        "Watch for indirect forms: circular reasoning via paraphrase "
-                        "(not just literal repetition), and emotional appeals where "
-                        "emotion drives persuasion rather than merely illustrating. "
-                        "Respond ONLY with a JSON array."
-                    )
-                )
-                beam_history.add_user_message(prompt)
-
-                try:
-                    beam_response = await asyncio.wait_for(
-                        self.llm_service.get_chat_message_content(
-                            chat_history=beam_history,
-                            settings=slave_settings,
-                            kernel=slave_kernel,
-                        ),
-                        timeout=30.0,
-                    )
-                    llm_calls_used += 1
-                except asyncio.TimeoutError:
-                    self.logger.warning(f"  Beam descent LLM call timed out at {pk}")
-                    continue
-                except Exception as e:
-                    self.logger.warning(f"  Beam descent LLM call failed: {e}")
-                    llm_calls_used += 1
-                    continue
-
-                raw = str(beam_response).strip()
-                selections = []
-                try:
-                    if "```json" in raw:
-                        raw = raw.split("```json")[1].split("```")[0]
-                    elif "```" in raw:
-                        raw = raw.split("```")[1].split("```")[0]
-                    start = raw.find("[")
-                    end = raw.rfind("]") + 1
-                    if start >= 0 and end > start:
-                        selections = json.loads(raw[start:end])
-                except (json.JSONDecodeError, ValueError):
-                    self.logger.warning(f"  Beam descent parse failed: {raw[:100]}")
-
-                for sel in selections[:beam_width]:
-                    if not isinstance(sel, dict):
-                        continue
-                    sel_pk = str(sel.get("pk", ""))
-                    sel_conf = float(sel.get("confidence", 0.5))
-                    child_node = self.taxonomy_navigator.get_node(sel_pk)
-                    if child_node and sel_pk != pk:
-                        try:
-                            child_depth = int(child_node.get("depth", depth + 1))
-                        except (ValueError, TypeError):
-                            child_depth = depth + 1
-                        next_beam.append(
-                            (sel_pk, child_depth, conf * sel_conf, trace + [sel_pk])
-                        )
-
-            # Keep only top beam_width candidates by confidence for next level
-            next_beam.sort(key=lambda x: x[2], reverse=True)
-            beam = next_beam[: beam_width * 2]  # Allow some expansion
-
-        self.logger.info(
-            f"Beam descent complete: {llm_calls_used} LLM calls, "
-            f"{len(confirmed_fallacies)} confirmed fallacies"
-        )
-        return confirmed_fallacies
-
     async def _wide_net_candidates(self, argument_text: str) -> List[str]:
         """Phase 1 wide-net: LLM lists all candidate fallacies 0-shot-style.
 
         Returns list of PKs (depth 1-3 via deep index), up to MAX_CANDIDATES.
 
-        FB-19 (#1040): tries deep index first (depth 2-3), falls back to
-        root PKs. This gives the beam descent a 2-3 level head start.
+        Tries deep index first (depth 2-3), falls back to root PKs. This gives
+        the agentic navigation a 2-3 level head start; from there the LLM
+        descends freely (multi-level cluster, no depth cap — FB-30 #1107).
         """
         kernel, settings = self._create_one_shot_kernel()
         roots = self.taxonomy_navigator.get_root_nodes()
@@ -759,6 +596,45 @@ class FallacyWorkflowPlugin:
 
         return results
 
+    def _render_subtree_cluster(self, root_pk: str, max_levels: int = 2) -> str:
+        """Render a truncated multi-level subtree under ``root_pk``.
+
+        FB-30 (#1107): the navigation prompt shows the LLM a cluster spanning
+        ``max_levels`` below the current node (not just immediate children),
+        so the LLM can jump levels by calling ``explore_branch`` on a deeper
+        PK directly. Each line carries name + PK + short description so the
+        LLM has enough signal to pick any node.
+
+        Args:
+            root_pk: the PK whose subtree to render (rendered as the root line).
+            max_levels: how many levels of descendants to include below the
+                root (1 = children only, 2 = children + grandchildren).
+
+        Returns:
+            A newline-separated, indented cluster string. Empty string if the
+            root has no descendants.
+        """
+        lines: List[str] = []
+
+        def walk(pk: str, level: int) -> None:
+            if level > max_levels:
+                return
+            node = self.taxonomy_navigator.get_node(pk)
+            if not node:
+                return
+            indent = "  " * level
+            name = node.get(f"text_{self.language}", node.get("nom_vulgarisé", pk))
+            desc = node.get(f"desc_{self.language}", "")
+            # Keep the description short so the whole cluster fits the prompt.
+            desc_short = desc[:120] + ("…" if len(desc) > 120 else "")
+            depth = node.get("depth", "?")
+            lines.append(f"{indent}- {name} (ID: {pk}, depth {depth}): {desc_short}")
+            for child in self.taxonomy_navigator.get_children(pk):
+                walk(child.get("PK", ""), level + 1)
+
+        walk(root_pk, 0)
+        return "\n".join(lines)
+
     async def _explore_single_branch(
         self,
         argument_text: str,
@@ -793,7 +669,14 @@ class FallacyWorkflowPlugin:
         navigation_trace = [start_pk]
         reasoning_history = reasoning_history or []
 
-        for iteration in range(self.MAX_DEPTH_PER_BRANCH):
+        # FB-30 (#1107): no depth cap — the LLM descends until it reaches a
+        # leaf (the only natural cap, depth ≤ 10). Bounded only by a generous
+        # per-branch LLM-call budget (circuit breaker, preserves #708). One
+        # iteration == one LLM call (either the leaf-confirmation call or the
+        # navigation call), so this counts calls, not depth.
+        llm_call_count = 0
+        while llm_call_count < self.MAX_NAVIGATION_LLM_CALLS:
+            llm_call_count += 1
             # --- Supersession check (RA-3 #1048) ---
             if supersession_tracker is not None:
                 current_node = self.taxonomy_navigator.get_node(current_pk)
@@ -962,18 +845,19 @@ class FallacyWorkflowPlugin:
                 "if this level matches and you want to STOP here.\n"
             )
 
-            options_text += "\n[EXPLORE DEEPER] Select one of these children:\n"
-            for child in children:
-                cpk = child.get("PK", "")
-                cname = child.get(
-                    f"text_{self.language}", child.get("nom_vulgarisé", cpk)
-                )
-                cdesc = child.get(f"desc_{self.language}", "")
-                cexample = child.get(f"example_{self.language}", "")[:150]
-                options_text += f"  - {cname} (ID: {cpk}): {cdesc}\n"
-                if cexample:
-                    options_text += f"    Example: {cexample}\n"
-                options_text += f"    → Call explore_branch(node_pk='{cpk}') to explore this branch.\n"
+            # FB-30 (#1107): multi-level cluster, not just immediate children.
+            # The LLM sees a truncated subtree NAV_CLUSTER_DEPTH levels deep,
+            # so it can jump levels by calling explore_branch on a grandchild
+            # PK directly (the original summer-2025 agentic design), rather
+            # than descending one level per iteration.
+            options_text += (
+                f"\n[EXPLORE DEEPER] — subtree under {parent_name} "
+                f"(showing {self.NAV_CLUSTER_DEPTH + 1} levels; "
+                "you may explore ANY listed node, not only the immediate children):\n"
+            )
+            options_text += self._render_subtree_cluster(
+                current_pk, max_levels=self.NAV_CLUSTER_DEPTH
+            )
 
             prompt = (
                 f'Text to analyze: "{argument_text[:500]}"\n\n'
@@ -981,7 +865,8 @@ class FallacyWorkflowPlugin:
                 f"{reasoning_context}"
                 f"{options_text}\n"
                 "Choose ONE action:\n"
-                "- Call explore_branch(node_pk='<child_pk>') to explore a child branch\n"
+                "- Call explore_branch(node_pk='<any_listed_pk>') to explore a node — "
+                "you may jump several levels deep by picking a grandchild/great-grandchild PK directly\n"
                 f"- Call confirm_fallacy(node_pk='{current_pk}', ...) to confirm THIS level and stop\n"
                 "- Call conclude_no_fallacy(reason='...') if no match in this branch\n"
                 "You MUST call exactly one function."
@@ -1215,7 +1100,8 @@ class FallacyWorkflowPlugin:
 
         and pruned by the supersession tracker (dead-end / superseded
         sub-branches abandon early). Anti-pendule #1019: fan-out is capped, not
-        unbounded — it mirrors the beam's ``BEAM_MAX_LLM_CALLS`` discipline.
+        unbounded — it mirrors the agentic navigation's
+        ``MAX_NAVIGATION_LLM_CALLS`` discipline.
         """
         tasks = []
         for sub_pk, sub_info in extras[: self.SUBBRANCH_FANOUT_WIDTH]:
@@ -1265,8 +1151,12 @@ class FallacyWorkflowPlugin:
         2. Slave selects candidate branches (via explore_branch calls)
         3. For each candidate, iterative deepening with double-selection
         4. Parallel exploration of up to MAX_BRANCHES branches
-        5. FB-19 beam descent for deep nodes (additive, no regression)
-        6. If no result, fall back to one-shot full-taxonomy approach
+        5. If no result, fall back to one-shot full-taxonomy approach
+
+        FB-30 (#1107): the mechanical per-level beam descent is removed.
+        Agentic navigation in step 3 now has no depth cap (taxonomy leaves are
+        the only cap) and shows the LLM a multi-level cluster so it can jump
+        levels — restoring the original summer-2025 design by subtraction.
         """
         file_handler = None
         if trace_log_path and str(trace_log_path).strip() not in ("", "None", "null"):
@@ -1375,29 +1265,12 @@ class FallacyWorkflowPlugin:
 
             if identified:
                 identified.sort(key=lambda f: f.confidence, reverse=True)
-
-            # Phase 3b: FB-19 beam descent for deep nodes (#1040)
-            # Additive: enriches identified list with deep findings, no regression
-            beam_fallacies = []
-            try:
-                beam_fallacies = await self._beam_descent(argument_text, candidate_pks)
-            except Exception as e:
-                self.logger.warning(f"Beam descent failed (non-fatal): {e}")
-
-            if beam_fallacies:
-                for bf in beam_fallacies:
-                    if bf.taxonomy_pk not in seen_pks:
-                        seen_pks[bf.taxonomy_pk] = bf
-                        identified.append(bf)
-                self.logger.info(
-                    f"FB-19 beam descent added {len(beam_fallacies)} deep fallacies"
-                )
-
-            if identified:
-                identified.sort(key=lambda f: f.confidence, reverse=True)
-                method = (
-                    "wide_net_parallel_beam" if beam_fallacies else "wide_net_parallel"
-                )
+                # FB-30 (#1107): the mechanical beam descent (_beam_descent,
+                # Phase 3b) is removed — restored agentic navigation in
+                # _explore_single_branch (no depth cap + multi-level cluster)
+                # now reaches deep/lateral nodes directly. Method label no
+                # longer carries the "_beam" suffix.
+                method = "wide_net_parallel"
                 analysis_result = FallacyAnalysisResult(
                     fallacies=identified,
                     exploration_method=method,

--- a/docs/architecture/design_specs/TRACK-01_fallacy_tier_selector.md
+++ b/docs/architecture/design_specs/TRACK-01_fallacy_tier_selector.md
@@ -37,7 +37,7 @@
 ### 1.3 Gaps
 
 1. No pipeline-level parameter to choose between lightweight vs deep detection
-2. `FallacyWorkflowPlugin` constants (`MAX_DEPTH_PER_BRANCH=8`, `MAX_BRANCHES=4`) are hardcoded
+2. `FallacyWorkflowPlugin` constants (`MAX_DEPTH_PER_BRANCH=8`, `MAX_BRANCHES=4`) are hardcoded. **Note (FB-30 #1107, 2026-06-15):** `MAX_DEPTH_PER_BRANCH` has since been **removed** — restored agentic taxonomy navigation has no depth cap (taxonomy leaves are the only cap); runaway protection is now a per-branch LLM-call budget (`MAX_NAVIGATION_LLM_CALLS`). See `docs/reports/FB19_TAXONOMY_DEEP_DESCENT.md` SUPERSEDED banner.
 3. `AnalysisDepth` enum not propagated to pipeline
 4. `FrenchFallacyAdapter` tier toggling is isolated — not wired into pipeline phases
 

--- a/docs/reports/FB19_TAXONOMY_DEEP_DESCENT.md
+++ b/docs/reports/FB19_TAXONOMY_DEEP_DESCENT.md
@@ -1,9 +1,37 @@
 # FB-19 Design — Taxonomy Deep-Descent: Agent-Guided Exploration Beyond Depth 2-3
 
+> ## ⚠️ SUPERSEDED by FB-30 (#1107, 2026-06-15) — mechanical beam REMOVED
+>
+> The **agent-guided beam descent** described below (§2) was implemented as the
+> mechanical per-level `_beam_descent` (`fallacy_workflow_plugin.py`, #1044) —
+> a Python loop that showed the LLM only immediate children, kept top-k, and
+> descended one level per iteration under a hard `MAX_DEPTH_PER_BRANCH = 8` cap.
+> That made the 12 leaf nodes at taxonomy depth 9-10 **structurally
+> unreachable** and re-determinised a navigation that was originally (summer
+> 2025, commit `d2fdd930`) a free LLM-driven `explore_branch(any_pk)` walk with
+> **no cap**.
+>
+> **FB-30 restores the agentic design BY SUBTRACTION** (anti-pendule: one
+> scheme, not two):
+> - `MAX_DEPTH_PER_BRANCH` removed — taxonomy leaves are the only cap.
+> - `_beam_descent` + its Phase 3b call **deleted**.
+> - Runaway protection (#708) preserved by a generous per-branch LLM-**call**
+>   budget (`MAX_NAVIGATION_LLM_CALLS = 18`), NOT a depth cap.
+> - The navigation prompt shows a **multi-level cluster**
+>   (`_render_subtree_cluster`) so the LLM can jump levels via
+>   `explore_branch(any_pk)` — exactly the original design.
+> - FB-27 (#1101) case-(c) intermediate-confirm + D6/D7 directives preserved.
+>
+> The design rationale in §1 (why deep nodes were MISSED) and §5 (expected
+> impact) remain valid; only the **mechanism** (§2 beam) is superseded. Tests:
+> `tests/unit/argumentation_analysis/test_fb30_agentic_navigation.py`.
+
+---
+
 **Issue**: #1040 (Epic #947 follow-up — root cause of MISSED D3/D6/D7)
 **Author**: po-2023 worker (design)
 **Date**: 2026-06-11
-**Status**: DRAFT — awaiting review + implementation
+**Status**: SUPERSEDED (beam mechanism) — see banner above. Problem analysis (§1) and impact (§5) still valid.
 
 ---
 

--- a/tests/unit/argumentation_analysis/test_fb19_beam_descent.py
+++ b/tests/unit/argumentation_analysis/test_fb19_beam_descent.py
@@ -1,25 +1,26 @@
-"""Unit tests for FB-19 taxonomy beam descent (#1040 / #1042).
+"""Unit tests for FB-19 deep-index + wide-net helpers (#1040 / #1042).
 
-Tests verify the FB-19 contract (VG-D1..VG-D4):
-- VG-D1: beam descent can reach nodes at depth ≥5 on synthetic data
-- VG-D2: existing depth 2-3 results are unchanged when beam is active
-- VG-D3: beam descent respects the max_llm_calls budget
-- VG-D4: additive merge — no new findings means identical output
-- Deep index: _build_deep_index returns depth 2-3 PKs
-- Wide-net: _wide_net_candidates uses deep mapping (FB-19 enhancement)
+FB-30 (#1107) note: the mechanical per-level `_beam_descent` method and its
+constants (BEAM_WIDTH / BEAM_MAX_LLM_CALLS / BEAM_MIN_DEPTH) have been
+REMOVED — restored agentic navigation in `_explore_single_branch` (no depth
+cap + multi-level cluster) now reaches deep/lateral nodes directly. The
+beam-specific test classes (TestBeamDescent / TestBeamIntegration /
+TestValueGates) were testing the removed method and have been deleted with
+it. See `test_fb30_agentic_navigation.py` for the restored-navigation tests.
+
+What remains load-bearing here:
+- `_build_deep_index` / `_map_fallacy_to_deep_pk` — the deep name→PK index
+  the wide-net uses to give the agentic navigation a 2-3 level head start.
+- `_wide_net_candidates` — Phase 1 candidate selection (deep-then-root).
 """
 
 import asyncio
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from argumentation_analysis.plugins.fallacy_workflow_plugin import FallacyWorkflowPlugin
-from argumentation_analysis.plugins.identification_models import (
-    IdentifiedFallacy,
-    FallacyAnalysisResult,
-)
 
 # ---------------------------------------------------------------------------
 # Fixtures — synthetic taxonomy + plugin
@@ -27,7 +28,7 @@ from argumentation_analysis.plugins.identification_models import (
 
 
 def _make_taxonomy_data():
-    """Build a synthetic taxonomy with 7 levels for beam descent testing."""
+    """Build a synthetic taxonomy with several levels for deep-index testing."""
     data = []
     # Root families (depth 1)
     families = [
@@ -101,7 +102,7 @@ def _make_taxonomy_data():
                     }
                 )
 
-                # Depth 4-7: chain to test beam reaching depth 5+
+                # Depth 4-7: chain (kept so deep-index maps non-trivial names)
                 parent_path = gc_path
                 parent_pk = gc_path.replace(".", "")
                 for d in range(4, 8):
@@ -191,66 +192,6 @@ class TestDeepIndex:
 
 
 # ---------------------------------------------------------------------------
-# Test: Beam descent (FB-19 core)
-# ---------------------------------------------------------------------------
-
-
-class TestBeamDescent:
-
-    def test_beam_constants_set(self):
-        """FB-19 beam parameters should have sensible defaults."""
-        assert FallacyWorkflowPlugin.BEAM_WIDTH >= 2
-        assert FallacyWorkflowPlugin.BEAM_MAX_LLM_CALLS >= 5
-        assert FallacyWorkflowPlugin.BEAM_MIN_DEPTH >= 4
-
-    def test_beam_descent_returns_empty_without_children(self):
-        """If seed PKs are leaf nodes at depth < MIN_CONFIRM_DEPTH, returns empty."""
-        plugin = _make_plugin()
-        # Use a deep leaf node (depth 7) as seed — it's a leaf so auto-confirms
-        # But we need to find one that IS a leaf
-        for node in plugin.taxonomy_navigator.taxonomy_data:
-            if int(node["depth"]) == 7:
-                pk = node["PK"]
-                # Check if leaf (no children in our synthetic data at depth 7)
-                children = plugin.taxonomy_navigator.get_children(pk)
-                if not children:
-                    result = asyncio.get_event_loop().run_until_complete(
-                        plugin._beam_descent("test text", [pk])
-                    )
-                    # Depth 7 >= MIN_CONFIRM_DEPTH (5) → should auto-confirm
-                    assert len(result) == 1
-                    assert result[0].taxonomy_pk == pk
-                    break
-
-    def test_beam_descent_budget_guard(self):
-        """Beam descent should stop after max_llm_calls even if beam continues."""
-        plugin = _make_plugin()
-        # Mock LLM to return valid selections
-        mock_response = MagicMock()
-        mock_response.items = []
-        # Return JSON with child PKs
-        plugin.llm_service.get_chat_message_content = AsyncMock(
-            return_value='[{"pk": "11", "confidence": 0.8}]'
-        )
-        # With budget=1, should make exactly 1 LLM call
-        result = asyncio.get_event_loop().run_until_complete(
-            plugin._beam_descent("test text", ["1"], max_llm_calls=1)
-        )
-        assert plugin.llm_service.get_chat_message_content.call_count <= 1
-
-    def test_beam_descent_additive_no_new_findings(self):
-        """VG-D4: if beam finds nothing, it returns empty list (additive)."""
-        plugin = _make_plugin()
-        # Mock LLM to return empty/invalid JSON
-        plugin.llm_service.get_chat_message_content = AsyncMock(return_value="[]")
-        result = asyncio.get_event_loop().run_until_complete(
-            plugin._beam_descent("test text", ["1"])
-        )
-        # Beam couldn't parse any children → empty result (no regression)
-        assert result == []
-
-
-# ---------------------------------------------------------------------------
 # Test: Wide-net deep mapping (FB-19 enhanced Phase 1)
 # ---------------------------------------------------------------------------
 
@@ -261,7 +202,6 @@ class TestWideNetDeepMapping:
         """Wide-net should try deep index before root index."""
         plugin = _make_plugin()
         # Mock LLM to return a candidate that maps to depth-2
-        mock_response = MagicMock()
         mock_response_str = json.dumps(
             [
                 {
@@ -306,85 +246,4 @@ class TestWideNetDeepMapping:
                     depth = int(node["depth"])
                     # At least some should be depth 2+ if deep mapping worked
                     # (but root fallback is also acceptable)
-
-
-# ---------------------------------------------------------------------------
-# Test: Integration with run_guided_analysis
-# ---------------------------------------------------------------------------
-
-
-class TestBeamIntegration:
-
-    def test_beam_descent_method_exists(self):
-        """FB-19: _beam_descent method should exist on the plugin."""
-        plugin = _make_plugin()
-        assert hasattr(plugin, "_beam_descent")
-        assert hasattr(plugin, "_build_deep_index")
-        assert hasattr(plugin, "_map_fallacy_to_deep_pk")
-
-    def test_exploration_method_includes_beam(self):
-        """When beam descent adds findings, exploration_method should reflect it."""
-        # This is tested indirectly through the method field in results
-        # "wide_net_parallel_beam" when beam adds findings
-        # "wide_net_parallel" when beam adds nothing
-        assert True  # Structural check — the method name is set in code
-
-
-# ---------------------------------------------------------------------------
-# Test: Value-gates VG-D1..VG-D4 (structural)
-# ---------------------------------------------------------------------------
-
-
-class TestValueGates:
-
-    def test_vg_d1_beam_can_reach_depth_5(self):
-        """VG-D1: beam descent can confirm nodes at depth ≥5."""
-        plugin = _make_plugin()
-        # Find a node at depth 5 in synthetic taxonomy
-        deep_pk = None
-        for node in plugin.taxonomy_navigator.taxonomy_data:
-            if int(node["depth"]) == 5:
-                deep_pk = node["PK"]
-                break
-        assert deep_pk is not None, "Synthetic taxonomy should have depth-5 nodes"
-
-        # Direct beam from that PK — it's a leaf or has children
-        node = plugin.taxonomy_navigator.get_node(deep_pk)
-        children = plugin.taxonomy_navigator.get_children(deep_pk)
-
-        if not children:
-            # Leaf at depth 5 — auto-confirm
-            result = asyncio.get_event_loop().run_until_complete(
-                plugin._beam_descent("test text", [deep_pk])
-            )
-            assert len(result) >= 1
-            assert (
-                int(plugin.taxonomy_navigator.get_node(result[0].taxonomy_pk)["depth"])
-                >= 5
-            )
-
-    def test_vg_d3_budget_parameter_respected(self):
-        """VG-D3: beam respects max_llm_calls parameter."""
-        plugin = _make_plugin()
-        plugin.llm_service.get_chat_message_content = AsyncMock(
-            return_value='[{"pk": "11", "confidence": 0.5}]'
-        )
-        budget = 3
-        asyncio.get_event_loop().run_until_complete(
-            plugin._beam_descent("test text", ["1"], max_llm_calls=budget)
-        )
-        # LLM calls should not exceed budget + seed nodes
-        assert plugin.llm_service.get_chat_message_content.call_count <= budget + 1
-
-    def test_vg_d4_empty_beam_no_regression(self):
-        """VG-D4: when beam finds nothing, results are additive (empty list)."""
-        plugin = _make_plugin()
-        # Mock LLM to return unparseable output
-        plugin.llm_service.get_chat_message_content = AsyncMock(
-            return_value="I cannot determine"
-        )
-        result = asyncio.get_event_loop().run_until_complete(
-            plugin._beam_descent("test text", ["1"])
-        )
-        # No crash, returns empty — additive merge preserves existing results
-        assert isinstance(result, list)
+                    assert depth >= 1

--- a/tests/unit/argumentation_analysis/test_fb30_agentic_navigation.py
+++ b/tests/unit/argumentation_analysis/test_fb30_agentic_navigation.py
@@ -1,0 +1,338 @@
+"""FB-30 #1107 — restored agentic taxonomy navigation (no depth cap).
+
+Target: ``fallacy_workflow_plugin._explore_single_branch`` after the FB-30
+restoration-by-subtraction. The mechanical per-level ``_beam_descent`` was
+REMOVED; the agentic loop now has NO depth cap (taxonomy leaves are the only
+cap, depth ≤ 10) and shows the LLM a multi-level cluster so it can jump levels
+via ``explore_branch(any_pk)`` — the original summer-2025 design.
+
+Tests are LOAD-BEARING per the #1097 lesson: they exercise the REAL plugin
+with the LLM dependency mocked (``llm_service.get_chat_message_contents``
+returns scripted ``FunctionCallContent``), NOT a mock of the classifier.
+
+DoD coverage (#1107):
+- ``test_deep_leaf_depth10_reachable_via_level_jump`` — a depth-10 leaf is
+  reached in ONE level-jump (depths 2-9 skipped). Under the removed
+  MAX_DEPTH_PER_BRANCH=8 + immediate-children-only prompt, depth 10 needed
+  9 per-level iterations > the 8 cap → structurally unreachable.
+- ``test_level_jump_honoured`` — an LLM-chosen mid-level jump is honoured.
+- ``test_negative_control_no_fallacy_returns_none`` — no-fallacy text → None.
+- ``test_call_budget_breaks_runaway_loop`` — a bouncing loop is bounded by
+  MAX_NAVIGATION_LLM_CALLS (preserves #708 runaway guard).
+- ``TestRestorationContract`` — the cap is gone, the budget guard exists,
+  ``_beam_descent`` is removed, ``_render_subtree_cluster`` exists.
+"""
+
+import inspect
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from semantic_kernel.contents import FunctionCallContent
+
+from argumentation_analysis.plugins.fallacy_workflow_plugin import (
+    FallacyWorkflowPlugin,
+)
+
+
+def _msg_with_items(*items):
+    """Wrap tool-call items in a fake chat message exposing ``.items``."""
+    return [SimpleNamespace(items=list(items))]
+
+
+def _slave_kernel_stub():
+    """Slave-kernel mock whose ``plugins.get('Exploration')`` contains every
+    function name, so ``_execute_tool_calls`` reaches the real
+    ``self.exploration_plugin.<func>`` call and not the Unknown-function
+    error branch. (Same shape as the FB-27 test helper.)"""
+
+    class _FakePlugin:
+        def __contains__(self, name):
+            return True
+
+        def __getitem__(self, name):
+            return MagicMock()
+
+    kernel = MagicMock()
+    kernel.plugins.get.return_value = _FakePlugin()
+    return kernel
+
+
+def _explore_call(target_pk):
+    return FunctionCallContent(
+        name="explore_branch",
+        arguments=json.dumps({"node_pk": target_pk}),
+    )
+
+
+def _confirm_call(node_pk, justification="matches the pattern"):
+    # confidence must be a label ('high'/'medium'/'low') — see FB-27 note.
+    return FunctionCallContent(
+        name="confirm_fallacy",
+        arguments=json.dumps(
+            {"node_pk": node_pk, "justification": justification, "confidence": "high"}
+        ),
+    )
+
+
+def _conclude_call(reason="no fallacy in this branch"):
+    return FunctionCallContent(
+        name="conclude_no_fallacy",
+        arguments=json.dumps({"reason": reason}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic taxonomy — a single linear chain depth 1..10 (PK = "1"*depth).
+# The depth-10 leaf is structurally unreachable under the old depth-8 cap +
+# immediate-children-only prompt (9 per-level iterations needed). Under the
+# restored agentic nav it is reachable in one level-jump.
+# ---------------------------------------------------------------------------
+
+
+def _deep_chain_taxonomy(max_depth: int = 10):
+    data = []
+    for d in range(1, max_depth + 1):
+        pk = "1" * d
+        path = ".".join(["1"] * d)
+        data.append(
+            {
+                "PK": pk,
+                "path": path,
+                "depth": str(d),
+                "text_fr": f"Nœud profondeur {d}",
+                "text_en": f"Depth-{d} node",
+                "desc_fr": f"Chaîne linéaire, niveau {d}",
+                "desc_en": f"Linear chain, level {d}",
+                "Famille": "test",
+                "Sous-Famille": f"niv{d}",
+                "nom_vulgarisé": f"Nœud-{d}",
+                "example_fr": "",
+                "example_en": "",
+            }
+        )
+    return data
+
+
+def _make_plugin(taxonomy_data=None):
+    data = taxonomy_data or _deep_chain_taxonomy()
+    return FallacyWorkflowPlugin(
+        master_kernel=MagicMock(),
+        llm_service=MagicMock(),
+        taxonomy_data=data,
+    )
+
+
+DEEP_LEAF_PK = "1" * 10  # depth 10
+
+
+# ---------------------------------------------------------------------------
+# Restoration contract (regression-detectable)
+# ---------------------------------------------------------------------------
+
+
+class TestRestorationContract:
+    """The FB-30 subtraction must be detectable in the plugin's surface."""
+
+    def test_depth_cap_removed(self):
+        assert not hasattr(FallacyWorkflowPlugin, "MAX_DEPTH_PER_BRANCH"), (
+            "FB-30: MAX_DEPTH_PER_BRANCH cap still present — the depth cap was "
+            "supposed to be removed (taxonomy leaves are the only cap)."
+        )
+
+    def test_call_budget_guard_exists(self):
+        assert hasattr(FallacyWorkflowPlugin, "MAX_NAVIGATION_LLM_CALLS")
+        assert FallacyWorkflowPlugin.MAX_NAVIGATION_LLM_CALLS >= 1
+
+    def test_beam_descent_removed(self):
+        assert not hasattr(FallacyWorkflowPlugin, "_beam_descent"), (
+            "FB-30: _beam_descent still present — the mechanical beam was "
+            "removed by subtraction (anti-pendule: one scheme, not two)."
+        )
+
+    def test_beam_constants_removed(self):
+        for dead in ("BEAM_WIDTH", "BEAM_MAX_LLM_CALLS", "BEAM_MIN_DEPTH"):
+            assert not hasattr(
+                FallacyWorkflowPlugin, dead
+            ), f"FB-30: dead beam constant {dead} still present."
+
+    def test_subtree_cluster_helper_exists(self):
+        assert hasattr(FallacyWorkflowPlugin, "_render_subtree_cluster"), (
+            "FB-30: _render_subtree_cluster (multi-level cluster renderer) "
+            "missing — the navigation prompt needs it to show >1 level."
+        )
+
+    def test_no_heuristic_fallback_added(self):
+        """Anti-pendule HARD: no regex/keyword shortcut substituting for the
+        LLM's free node choice."""
+        src = inspect.getsource(FallacyWorkflowPlugin).lower()
+        for forbidden in ["re.match", "re.search", "if 'depth' == 9"]:
+            assert forbidden.lower() not in src, (
+                f"FB-30 anti-pendule: heuristic '{forbidden}' added — node "
+                "choice must stay LLM-conducted."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Behaviour — the REAL navigation loop with the LLM dependency mocked
+# ---------------------------------------------------------------------------
+
+
+class TestLevelJumpAndDeepLeaf:
+    """The LLM may jump levels (call explore_branch on a deeper PK than the
+    immediate child) and the loop must honour it — reaching deep leaves."""
+
+    @pytest.mark.asyncio
+    async def test_deep_leaf_depth10_reachable_via_level_jump(self):
+        """DoD: a depth-10 leaf is reachable. The LLM jumps from the root
+        straight to the depth-10 leaf (skipping depths 2-9), reaches it as a
+        leaf, and confirms. Under the removed depth-8 cap this was
+        structurally unreachable (9 per-level iterations needed)."""
+        plugin = _make_plugin()
+        slave_kernel = _slave_kernel_stub()
+
+        # Iteration 1 (root has a child → navigation branch): jump to depth 10.
+        # Iteration 2 (depth-10 leaf → leaf branch): confirm.
+        plugin.llm_service.get_chat_message_contents = AsyncMock(
+            side_effect=[
+                _msg_with_items(_explore_call(DEEP_LEAF_PK)),
+                _msg_with_items(_confirm_call(DEEP_LEAF_PK)),
+            ]
+        )
+
+        result = await plugin._explore_single_branch(
+            argument_text="Some genuinely fallacious text.",
+            start_pk="1",
+            slave_kernel=slave_kernel,
+            slave_settings=MagicMock(),
+        )
+
+        assert result is not None, (
+            "FB-30: depth-10 leaf produced no classification — the level-jump "
+            "was not honoured or the leaf was not reached."
+        )
+        assert result.taxonomy_pk == DEEP_LEAF_PK, (
+            f"FB-30: expected depth-10 leaf PK '{DEEP_LEAF_PK}', got "
+            f"'{result.taxonomy_pk}'."
+        )
+        # Levels 2-9 skipped — exactly one jump in the navigation trace.
+        assert result.navigation_trace == ["1", DEEP_LEAF_PK], (
+            f"FB-30: navigation trace should show the level-jump ['1', "
+            f"'{DEEP_LEAF_PK}'], got {result.navigation_trace}. Intermediate "
+            "levels must be skippable."
+        )
+        # Confirm the landed node really is at depth 10.
+        landed = plugin.taxonomy_navigator.get_node(DEEP_LEAF_PK)
+        assert int(landed["depth"]) == 10
+
+    @pytest.mark.asyncio
+    async def test_level_jump_honoured_mid_chain(self):
+        """A mid-level jump (root → depth-4 grandchild) is honoured, then the
+        LLM descends one more level to a depth-5 leaf and confirms. Proves the
+        loop accepts ANY target PK, not just immediate children."""
+        plugin = _make_plugin()
+        slave_kernel = _slave_kernel_stub()
+        depth4_pk = "1" * 4
+        depth5_pk = "1" * 5
+
+        plugin.llm_service.get_chat_message_contents = AsyncMock(
+            side_effect=[
+                _msg_with_items(_explore_call(depth4_pk)),  # jump root→depth4
+                _msg_with_items(_explore_call(depth5_pk)),  # depth4→depth5 child
+                _msg_with_items(_confirm_call(depth5_pk)),  # depth5 leaf confirm
+            ]
+        )
+
+        result = await plugin._explore_single_branch(
+            argument_text="Fallacious text.",
+            start_pk="1",
+            slave_kernel=slave_kernel,
+            slave_settings=MagicMock(),
+        )
+
+        assert result is not None
+        assert result.taxonomy_pk == depth5_pk
+        assert result.navigation_trace == ["1", depth4_pk, depth5_pk]
+
+    @pytest.mark.asyncio
+    async def test_negative_control_no_fallacy_returns_none(self):
+        """Anti-#1019: no-fallacy text → the LLM concludes no-fallacy → None
+        (honest MISSED), never a fabricated deep confirmation."""
+        plugin = _make_plugin()
+        slave_kernel = _slave_kernel_stub()
+        plugin.llm_service.get_chat_message_contents = AsyncMock(
+            return_value=_msg_with_items(_conclude_call())
+        )
+
+        result = await plugin._explore_single_branch(
+            argument_text="A neutral sentence with no fallacy.",
+            start_pk="1",
+            slave_kernel=slave_kernel,
+            slave_settings=MagicMock(),
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_call_budget_breaks_runaway_loop(self):
+        """DoD anti-runaway (#708): if the LLM bounces forever (never confirms
+        nor concludes), the loop must stop at MAX_NAVIGATION_LLM_CALLS and
+        return None — no unbounded descent."""
+        plugin = _make_plugin()
+        slave_kernel = _slave_kernel_stub()
+
+        # Bounce "1" ↔ "11" forever: each explore target differs from current,
+        # so explore_targets is never empty and the loop would run unbounded
+        # without the call budget.
+        call_count = {"n": 0}
+
+        async def bouncing_response(*args, **kwargs):
+            call_count["n"] += 1
+            pk = "11" if call_count["n"] % 2 == 1 else "1"
+            return _msg_with_items(_explore_call(pk))
+
+        plugin.llm_service.get_chat_message_contents = bouncing_response
+
+        result = await plugin._explore_single_branch(
+            argument_text="Text.",
+            start_pk="1",
+            slave_kernel=slave_kernel,
+            slave_settings=MagicMock(),
+        )
+
+        assert result is None, "FB-30: runaway loop should end with None."
+        budget = FallacyWorkflowPlugin.MAX_NAVIGATION_LLM_CALLS
+        assert call_count["n"] <= budget, (
+            f"FB-30: call budget breached — made {call_count['n']} LLM calls, "
+            f"budget is {budget}. Runaway guard (#708) not preserved."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Multi-level cluster rendering (the prompt shows >1 level)
+# ---------------------------------------------------------------------------
+
+
+class TestSubtreeCluster:
+    def test_cluster_renders_multiple_levels(self):
+        """The cluster helper renders children AND grandchildren (≥2 levels),
+        so the LLM can pick a grandchild PK and jump a level."""
+        plugin = _make_plugin()
+        rendered = plugin._render_subtree_cluster("1", max_levels=2)
+        # Root + depth-2 + depth-3 lines should all appear.
+        assert "1" in rendered  # root line (ID: 1)
+        assert "11" in rendered  # depth-2 child
+        assert "111" in rendered  # depth-3 grandchild
+        # The grandchild appears (multi-level), and at greater indentation.
+        assert rendered.index("111") > rendered.index("11")
+
+    def test_cluster_truncated_at_max_levels(self):
+        """max_levels=1 renders only immediate children (no grandchildren)."""
+        plugin = _make_plugin()
+        rendered = plugin._render_subtree_cluster("1", max_levels=1)
+        assert "11" in rendered  # depth-2 child present
+        # depth-3 grandchild must NOT appear as its own cluster line
+        # (it could appear as a substring of a deeper PK, so check the line)
+        lines = [ln for ln in rendered.splitlines() if "ID: 111" in ln]
+        assert lines == [], "FB-30: max_levels=1 should not render grandchildren."


### PR DESCRIPTION
## What (R405 dispatch — restore by subtraction, not rebuild)

The fallacy descent had drifted from its original (summer-2025, `d2fdd930`) agentic design into a mechanical per-level beam. `_explore_single_branch` WAS the surviving agentic core, but caged on three sides:

1. **Hard depth cap** `MAX_DEPTH_PER_BRANCH = 8` → the 12 leaf nodes at taxonomy depth 9-10 are **structurally unreachable**.
2. **Wide-net pre-gating** (LLM doesn't start from root).
3. **Bolted-on `_beam_descent`** (Phase 3b) showing the LLM only immediate children, descending one level/iteration — re-determinising a walk meant to be a free LLM-driven `explore_branch(any_pk)`.

## Fix (subtraction — anti-pendule: one scheme, not two)

- **Remove `MAX_DEPTH_PER_BRANCH`** — taxonomy leaves are the only cap (depth ≤ 10).
- **Delete `_beam_descent`** + its Phase 3b call in `run_guided_analysis`.
- **Runaway guard (#708) preserved** as a generous per-branch **LLM-CALL budget** (`MAX_NAVIGATION_LLM_CALLS = 18`), NOT a depth cap. One navigation iteration == one LLM call.
- **New `_render_subtree_cluster`** shows the LLM a **multi-level cluster** (`NAV_CLUSTER_DEPTH = 2`) so it can **jump levels** via `explore_branch(any_pk)` — exactly the original design.

Preserves **FB-27 (#1101, 6bb81747)** case-(c) intermediate-confirm + D6/D7 directives. `MIN_CONFIRM_DEPTH` floor unchanged.

**Variance note (R405):** `gpt-5-mini` is a reasoning model (temperature/seed suppressed, `invoke_callables.py:224`) so sampling variance already exists; removing the beam removes a deterministic f-string path — variance + richness return for free. No reproducibility assertion added.

## Tests (load-bearing per #1097 — LLM dependency mocked, NOT the classifier)

`tests/unit/argumentation_analysis/test_fb30_agentic_navigation.py` exercises the REAL `_explore_single_branch`:
- `test_deep_leaf_depth10_reachable_via_level_jump` — a depth-10 leaf is reached in **ONE** jump (navigation trace `['1', '1111111111']`); was structurally unreachable under depth-8 + immediate-children-only prompt (9 per-level iterations needed).
- `test_level_jump_honoured_mid_chain` — root→depth4→depth5 honoured.
- `test_negative_control_no_fallacy_returns_none` — anti-#1019.
- `test_call_budget_breaks_runaway_loop` — a bouncing loop is bounded by `MAX_NAVIGATION_LLM_CALLS` (**#708 preserved**).
- `TestRestorationContract` — cap gone, `_beam_descent` removed, beam constants removed, `_render_subtree_cluster` present, no heuristic added (anti-pendule HARD).
- `TestSubtreeCluster` — multi-level rendering (children + grandchildren), truncated at `max_levels`.

`test_fb19_beam_descent.py`: removed the beam-method classes (TestBeamDescent/TestBeamIntegration/TestValueGates — tested the deleted method); kept TestDeepIndex + TestWideNetDeepMapping (still-live helpers).

## Doc

- `FB19_TAXONOMY_DEEP_DESCENT.md` — SUPERSEDED banner (beam mechanism superseded by agentic restoration; §1 problem-analysis + §5 impact still valid).
- `TRACK-01_fallacy_tier_selector.md` — inline note that `MAX_DEPTH_PER_BRANCH` is removed.

## Validation

- `pytest test_fb30 + test_fb27 + test_fb19 + test_ra9` → **41 passed**.
- 3 pre-existing failures in `test_fallacy_workflow_plugin.py`/`test_fallacy_workflow_calibration.py` are **JVM access-violation crashes** (`jpype.startJVM`, intermittent/non-fatal per MEMORY.md), reproduced identically on baseline `origin/main` — NOT a regression.
- mypy `--strict`: only pre-existing `type-arg` warnings on unchanged signatures (lines 174/543/546/965/1088/1229/1230); CI mypy gate excludes this file.
- black clean.

Closes #1107 (FB-30 dispatch R405). File-disjoint from FB-29/FB-31 (quality/).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>