### PR TITLE
fix(synthesis): FB-31 de-drift Section 9 — fail-loud, no count-template fallback (#1108)

### DIFF
--- a/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
+++ b/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
@@ -275,22 +275,24 @@ class DeepSynthesisAgent(BaseAgent):
         analysis_trace = getattr(state, "analysis_trace", [])
         report._raw_analysis_trace = analysis_trace if analysis_trace else []
 
-        # Section 9 — final synthesis (tries LLM, falls back to template)
+        # Section 9 — final synthesis (FB-31 #1108: fail-loud, NO template fallback).
+        # Mirrors the FB-18 grounded-transversal standard just below: when the
+        # LLM is unavailable the status says so explicitly instead of dressing
+        # up a count-template (f-string emitting "N arguments, M fallacies…")
+        # as the synthesis. That count-template was a determinization residue
+        # (#1109): an identical f-string emitted regardless of model, killing
+        # both richness AND variance. Fix = subtraction (remove the fallback),
+        # not a counterweight — per #1019 anti-theater.
         try:
             thesis = await self._llm_synthesis(report)
             if thesis:
                 report.final_synthesis = thesis
+                report.final_synthesis_status = "llm"
             else:
-                report.final_synthesis = (
-                    await DeepSynthesisAgent._build_final_synthesis(
-                        state, report, transcript
-                    )
-                )
+                report.final_synthesis_status = "unavailable"
         except Exception as e:
-            logger.warning(f"LLM synthesis failed, using template: {e}")
-            report.final_synthesis = await DeepSynthesisAgent._build_final_synthesis(
-                state, report, transcript
-            )
+            logger.warning(f"LLM synthesis failed (final_synthesis): {e}")
+            report.final_synthesis_status = "failed"
 
         # FB-18 Mode A (#1039) — grounded transversal synthesis + value-gates.
         # No template fallback here: when the LLM is unavailable the status
@@ -621,150 +623,6 @@ class DeepSynthesisAgent(BaseAgent):
             )
         return verdicts, synthesis.get("conclusion", "")
 
-    @staticmethod
-    async def _build_final_synthesis(
-        state: Any, report: DeepSynthesisReport, transcript: Optional[List[Dict]] = None
-    ) -> str:
-        """Section 9: 6-section political-rhetorical briefing (template fallback)."""
-        so = report.source_overview
-        stakes_data = getattr(report, "_raw_stakes", {}) or {}
-        stakes_list = stakes_data.get("stakes", [])
-        sh_list = stakes_data.get("stakeholders", [])
-        register = stakes_data.get("rhetorical_register", "")
-        arena = stakes_data.get("discursive_arena", "")
-
-        # Section 1 — Contexte & énonciation
-        s1 = (
-            f"## 1. Contexte & énonciation\n\n"
-            f"This {so.discourse_type or 'unknown'} discourse originates from source "
-            f"'{so.opaque_id}', delivered in {so.language or 'unknown'} during the "
-            f"{so.era or 'unknown'} era"
-        )
-        if so.speaker:
-            s1 += f" by {so.speaker}"
-        if so.venue:
-            s1 += f" at {so.venue}"
-        if so.topic:
-            s1 += f" on the topic of {so.topic}"
-        s1 += f". The text comprises {so.length_words:,} words.\n"
-        if register:
-            s1 += f"Rhetorical register: {register}. "
-        if arena:
-            s1 += f"Discursive arena: {arena}."
-        s1 += "\n"
-
-        # Section 2 — Enjeux soulevés
-        s2 = "## 2. Enjeux soulevés\n\n"
-        if stakes_list:
-            for s in stakes_list[:5]:
-                s2 += (
-                    f"- **{s.get('stake_type', 'unknown')}**: "
-                    f"{s.get('description', 'No description')}\n"
-                )
-        else:
-            s2 += "No typed stakes were extracted for this discourse.\n"
-
-        # Section 3 — Parties engagées & positionnement
-        s3 = "## 3. Parties engagées & positionnement\n\n"
-        if sh_list:
-            for sh in sh_list[:5]:
-                s3 += (
-                    f"- **{sh.get('name', '?')}** (role: {sh.get('role', '?')}, "
-                    f"stance: {sh.get('stance', '?')})\n"
-                )
-        else:
-            s3 += "No stakeholders were identified in this analysis.\n"
-
-        # Section 4 — Ressorts rhétoriques
-        n_args = len(report.argument_map)
-        n_fallacies = len(report.fallacy_diagnoses)
-        n_formal = len(report.formal_findings)
-        n_counters = len(report.counter_arguments)
-        families = sorted(set(f.family for f in report.fallacy_diagnoses))
-        dung_ext = ", ".join(report.dung_structure.grounded_extension) or "none"
-        s4 = (
-            f"## 4. Ressorts rhétoriques\n\n"
-            f"The analysis identified **{n_args} arguments**, "
-            f"**{n_fallacies} fallacies** across {len(families)} families "
-            f"({', '.join(families) or 'none'}), and **{n_formal} formal findings**. "
-            f"Dung grounded extension: [{dung_ext}].\n"
-        )
-        if report.fallacy_diagnoses:
-            top = sorted(
-                report.fallacy_diagnoses,
-                key=lambda f: len(f.commentary),
-                reverse=True,
-            )[:3]
-            s4 += "\nTop fallacies:\n"
-            for f in top:
-                s4 += f"- {f.family} ({f.taxonomy_path}): " f"{f.commentary[:120]}\n"
-        if report.counter_arguments:
-            best = max(report.counter_arguments, key=lambda c: c.score)
-            s4 += (
-                f"\nStrongest counter-argument (score {best.score:.2f}, "
-                f"strategy: {best.strategy}): {best.counter_content[:120]}...\n"
-            )
-
-        # Section 5 — Voix des spécialistes
-        specialist_commentary = getattr(report, "_specialist_commentary", "")
-        trace_data = getattr(report, "_raw_analysis_trace", [])
-        s5 = "## 5. Voix des spécialistes\n\n"
-        has_content = False
-        if specialist_commentary:
-            s5 += f"{specialist_commentary}\n"
-            has_content = True
-        if trace_data:
-            for entry in trace_data:
-                agent = entry.get("agent", "?")
-                reacts = ", ".join(entry.get("reacts_to", []))
-                summary = entry.get("summary", "")
-                s5 += f'- [{agent}] (réagit à: {reacts}) → "{summary}"\n'
-            has_content = True
-        if not has_content and report.convergent_verdicts:
-            s5 += (
-                "No specialist commentaries were deposited "
-                "during this analysis run.\n\n"
-            )
-            s5 += "Convergent verdicts (cross-method agreement):\n"
-            for v in report.convergent_verdicts:
-                s5 += f"- {v.arg_id}: {v.score} methods ({', '.join(v.methods)})\n"
-        elif not has_content:
-            s5 += (
-                "No specialist commentaries were deposited during this analysis run. "
-                "No cross-method convergence was detected.\n"
-            )
-
-        # Section 6 — Lecture politique
-        s6 = (
-            f"## 6. Lecture politique\n\n"
-            f"This {so.discourse_type or 'unknown'} discourse deploys "
-            f"{n_args} arguments across {len(families)} fallacy families, "
-            f"revealing a structured rhetorical strategy."
-        )
-        if register:
-            s6 += f" The dominant register is **{register}**"
-            if arena:
-                s6 += f", deployed in a **{arena}** arena"
-            s6 += "."
-        s6 += (
-            f"\n\nThe multi-agent orchestration identified {n_fallacies} fallacies "
-            f"and {n_counters} counter-arguments, with {n_formal} formal-method "
-            f"findings providing independent verification. "
-            f"The Dung grounded extension contains [{dung_ext}], "
-            f"indicating which arguments survive dialectical scrutiny."
-        )
-        if report.convergent_verdicts:
-            n_conv = len(report.convergent_verdicts)
-            s6 += (
-                f"\n\nCrucially, **{n_conv} argument(s) converge across independent "
-                f"methods**, signalling robustness in the diagnostic findings. "
-                f"This cross-method agreement is the signature insight unavailable "
-                f"to a single LLM pass."
-            )
-        s6 += "\n"
-
-        return "\n".join([s1, s2, s3, s4, s5, s6])
-
     # ------------------------------------------------------------------
     # Markdown rendering
     # ------------------------------------------------------------------
@@ -993,12 +851,20 @@ class DeepSynthesisAgent(BaseAgent):
                 sections.append(f"- {icon} `{gate}`")
             sections.append("")
 
-        # S9 — Final synthesis
-        sections.append(
-            report.final_synthesis
-            if report.final_synthesis
-            else "_Final synthesis not generated._\n"
-        )
+        # S9 — Final synthesis (FB-31 #1108: fail-loud). When the LLM did not
+        # produce a synthesis, surface the explicit status — mirroring the
+        # grounded-synthesis block above — instead of dressing up counts as a
+        # template synthesis (the determinization residue #1109 removed).
+        sections.append("## 9. Final Synthesis\n")
+        if report.final_synthesis:
+            sections.append(report.final_synthesis)
+            sections.append("")
+        else:
+            status = report.final_synthesis_status or "not generated"
+            sections.append(
+                f"_Final synthesis {status} — no LLM-conducted synthesis "
+                f"was produced for this run._\n"
+            )
 
         return "\n".join(sections)
 

--- a/argumentation_analysis/agents/core/synthesis/deep_synthesis_models.py
+++ b/argumentation_analysis/agents/core/synthesis/deep_synthesis_models.py
@@ -135,6 +135,12 @@ class DeepSynthesisReport:
     counter_arguments: List[CounterArgumentEntry] = field(default_factory=list)
     cross_text_parallels: List[CrossTextParallel] = field(default_factory=list)
     final_synthesis: str = ""
+    # FB-31 #1108 — Section 9 status (fail-loud, mirrors grounded_synthesis_status):
+    # "llm" (LLM-conducted synthesis), "unavailable" (no LLM / empty result),
+    # "failed" (LLM raised). When the status is not "llm", final_synthesis is
+    # empty — there is NO count-template fallback dressed up as synthesis (the
+    # determinization residue #1019/#1109 says to remove, not institutionalize).
+    final_synthesis_status: str = ""
     convergent_verdicts: List[ConvergentVerdict] = field(default_factory=list)
     convergence_conclusion: str = ""
     # LLM-polished prose for the convergence section (Track GG #644).
@@ -170,6 +176,7 @@ class DeepSynthesisReport:
             "counter_arguments": [c.__dict__ for c in self.counter_arguments],
             "cross_text_parallels": [p.__dict__ for p in self.cross_text_parallels],
             "final_synthesis": self.final_synthesis,
+            "final_synthesis_status": self.final_synthesis_status,
             "convergent_verdicts": [v.__dict__ for v in self.convergent_verdicts],
             "convergence_conclusion": self.convergence_conclusion,
             "convergence_prose": self.convergence_prose,

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -6358,9 +6358,12 @@ async def _invoke_deep_synthesis(
                     state
                 ),
             )
-            report.final_synthesis = await DeepSynthesisAgent._build_final_synthesis(
-                state, report, []
-            )
+            # FB-31 #1108: no LLM in the static-builder path → Section 9 is
+            # fail-loud. final_synthesis stays empty and the status says
+            # "unavailable" explicitly — NOT a count-template masquerading as
+            # the synthesis (the determinization residue #1109/#1019 removes).
+            report.final_synthesis = ""
+            report.final_synthesis_status = "unavailable"
             report.total_state_fields = DeepSynthesisAgent._count_state_fields(state)
             report.sections_populated = DeepSynthesisAgent._count_populated_sections(
                 report

--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -1,5 +1,18 @@
 """Narrative Synthesis Plugin for Spectacular Analysis Pipeline (#351).
 
+.. warning::
+    **TEMPLATE-BASED (non-LLM) SUMMARY — NOT the analytical spectacular
+    synthesis.** FB-31 #1108: this plugin weaves f-strings over state
+    counts ("N arguments, M fallacies…") and so emits near-identical prose
+    regardless of the input model — it is a *determinization residue*
+    (#1109) that kills both richness and variance. It must NOT be mistaken
+    for the LLM-conducted analysis. The reference analytical synthesis is
+    ``DeepSynthesisAgent.grounded_transversal_synthesis`` (FB-18 #1039,
+    fail-loud, value-gated) and Section 9 ``final_synthesis`` (FB-31,
+    fail-loud ``final_synthesis_status``). This plugin stays for backward
+    compatibility as a *template summary* only; do not wire it as the
+    pipeline's "spectacular" deliverable.
+
 Produces 1-2 paragraphs of human-readable narrative weaving together
 results from all analysis KBs (fallacies, JTMS, ATMS, Dung, quality,
 counter-arguments). Reads from UnifiedAnalysisState and generates
@@ -531,6 +544,17 @@ def _build_prose_prompt(synthesis_result: Dict[str, Any]) -> str:
 
 class NarrativeSynthesisPlugin:
     """Semantic Kernel plugin for narrative synthesis (#351).
+
+    .. warning::
+        **Template summary (non-LLM) — not the analytical synthesis** (FB-31
+        #1108). The ``narrative_synthesis`` / ``convergent_synthesize``
+        kernel functions are f-string templates; ``narrate_convergence`` has
+        an LLM prose layer but SILENTLY falls back to template output when
+        no kernel is configured or the LLM call fails. That fallback is
+        indistinguishable from LLM output to a downstream reader — treat any
+        narrative from this plugin as a *count-summary*, not the grounded
+        analysis (see ``DeepSynthesisAgent.grounded_transversal_synthesis``
+        and Section 9 ``final_synthesis`` for the fail-loud analytical path).
 
     Produces human-readable analysis summaries by weaving together
     outputs from all pipeline phases. Pass an SK Kernel instance to

--- a/tests/unit/argumentation_analysis/test_deep_synthesis_agent.py
+++ b/tests/unit/argumentation_analysis/test_deep_synthesis_agent.py
@@ -130,9 +130,11 @@ def _build_report_from_state(state, meta=None):
         counter_arguments=Cls._build_counter_arguments(state),
         cross_text_parallels=Cls._build_cross_text_parallels(state),
     )
-    report.final_synthesis = asyncio.get_event_loop().run_until_complete(
-        Cls._build_final_synthesis(state, report, [])
-    )
+    # FB-31 #1108: Section 9 has no LLM in the static-builder path → fail-loud.
+    # The count-template fallback (_build_final_synthesis) was removed; the
+    # status says "unavailable" and final_synthesis stays empty.
+    report.final_synthesis = ""
+    report.final_synthesis_status = "unavailable"
     report.total_state_fields = Cls._count_state_fields(state)
     report.sections_populated = Cls._count_populated_sections(report)
     return report
@@ -293,13 +295,41 @@ class TestSectionBuilders:
         parallels = DeepSynthesisAgent._build_cross_text_parallels(state)
         assert parallels == []
 
-    def test_s9_final_synthesis(self, state):
+    def test_s9_final_synthesis_fail_loud_no_llm(self, state):
+        """FB-31 #1108: without an LLM, Section 9 is FAIL-LOUD — final_synthesis
+        is empty, status is "unavailable", and the rendered markdown contains
+        NO count-prose ("identified **N arguments**…"). The previous count-
+        template fallback was a determinization residue (#1109) emitting an
+        identical f-string regardless of model; it is deleted, not replaced."""
         report = _build_report_from_state(state)
-        assert len(report.final_synthesis) > 100
-        assert "argument" in report.final_synthesis.lower()
-        # WW #725: 6-section structure in template fallback
-        assert "## 1." in report.final_synthesis
-        assert "## 6." in report.final_synthesis
+        # Fail-loud contract: empty synthesis + explicit status
+        assert report.final_synthesis == ""
+        assert report.final_synthesis_status == "unavailable"
+        # Anti-theater: the markdown must NOT dress up counts as synthesis.
+        md = DeepSynthesisAgent.render_markdown(report)
+        count_marker = "identified **"  # the count-template's signature phrasing
+        assert count_marker not in md, (
+            "FB-31 NEGATIVE CONTROL FAILED: count-prose found in rendered "
+            "markdown despite the no-LLM path — template imposture not removed."
+        )
+        # Fail-loud surfaces the explicit status in the Section 9 block (mirrors
+        # the grounded-synthesis block). "## 1."/"## 6." are legitimate report
+        # sections (Source Overview, Belief Revision Trace) — NOT the deleted
+        # synthesis template — so they are not the distinguishing marker here.
+        assert "## 9. Final Synthesis" in md
+        assert "unavailable" in md, (
+            "FB-31: Section 9 must surface its fail-loud status explicitly, "
+            "not a generic 'not generated' fallback."
+        )
+
+    def test_s9_final_synthesis_status_field_serialized(self, state):
+        """FB-31 #1108: final_synthesis_status is part of the report's dict
+        serialization (mirrors grounded_synthesis_status) so downstream
+        consumers can branch on it rather than guessing from prose."""
+        report = _build_report_from_state(state)
+        d = report.to_dict()
+        assert "final_synthesis_status" in d
+        assert d["final_synthesis_status"] == "unavailable"
 
 
 # =========================================================================
@@ -459,22 +489,6 @@ class TestConvergenceWiring:
         md = DeepSynthesisAgent.render_markdown(report)
         assert "## Convergent Verdicts (cross-method agreement)" in md
         assert "resists cross-method scrutiny" in md
-
-    def test_final_synthesis_references_convergence(self):
-        state = _convergent_state()
-        report = DeepSynthesisReport(
-            source_overview=DeepSynthesisAgent._build_source_overview(state, {}),
-            argument_map=DeepSynthesisAgent._build_argument_map(state),
-            fallacy_diagnoses=DeepSynthesisAgent._build_fallacy_diagnoses(state),
-        )
-        report.convergent_verdicts, report.convergence_conclusion = (
-            DeepSynthesisAgent._build_convergent_verdicts(state)
-        )
-        thesis = asyncio.get_event_loop().run_until_complete(
-            DeepSynthesisAgent._build_final_synthesis(state, report, [])
-        )
-        assert "## 5." in thesis
-        assert "arg_2" in thesis
 
     def test_to_dict_includes_convergent_verdicts(self):
         state = _convergent_state()
@@ -687,125 +701,56 @@ def _ww_build_report(state=None, meta=None):
         report._raw_stakes = stakes_data
     else:
         report._raw_stakes = {}
-    # Rebuild final synthesis with stakes data attached
-    report.final_synthesis = asyncio.get_event_loop().run_until_complete(
-        DeepSynthesisAgent._build_final_synthesis(state, report, [])
-    )
+    # FB-31 #1108: the count-template (_build_final_synthesis) was removed;
+    # Section 9 is now LLM-conducted. In this no-LLM unit helper we leave the
+    # synthesis empty and mark the status explicitly (fail-loud — NOT a
+    # template masquerade). The stakes data attached above is still consumed
+    # by the LLM prompt tests (TestLLMSynthesisPromptSixSections).
+    report.final_synthesis = ""
+    report.final_synthesis_status = "unavailable"
     return report
 
 
-class TestSixSectionBriefing:
-    """WW #725: template fallback produces 6 numbered sections."""
+class TestSixSectionFailLoudNoLLM:
+    """FB-31 #1108: with no LLM, Section 9 is fail-loud.
 
-    def test_all_six_sections_present(self):
-        report = _ww_build_report()
-        thesis = report.final_synthesis
-        assert "## 1." in thesis
-        assert "## 2." in thesis
-        assert "## 3." in thesis
-        assert "## 4." in thesis
-        assert "## 5." in thesis
-        assert "## 6." in thesis
+    Replaces the WW #725 template-fallback tests (``TestSixSectionBriefing`` /
+    ``TestSixSectionEmptyState``). The count-template that dressed up empty
+    state as six numbered ``## 1.``..``## 6.`` sections was the determinization
+    residue (#1109/#1019) and has been removed. A spectacular synthesis is now
+    LLM-conducted or absent — never a template masquerade.
 
-    def test_sections_in_order(self):
-        report = _ww_build_report()
-        thesis = report.final_synthesis
-        pos = [thesis.index(f"## {i}.") for i in range(1, 7)]
-        assert pos == sorted(pos), "Sections must appear in order 1-6"
+    With no LLM available (the case for the static-builder path exercised here),
+    ``final_synthesis`` is empty, ``final_synthesis_status`` says so explicitly,
+    and the count-template block does not resurface.
+    """
 
-    def test_section_1_contains_context(self):
-        report = _ww_build_report()
-        thesis = report.final_synthesis
-        s1_start = thesis.index("## 1.")
-        s2_start = thesis.index("## 2.")
-        s1 = thesis[s1_start:s2_start]
-        assert "corpus_ww_A" in s1
-        assert "political" in s1.lower()
-
-    def test_section_2_mentions_stakes(self):
-        report = _ww_build_report()
-        thesis = report.final_synthesis
-        s2_start = thesis.index("## 2.")
-        s3_start = thesis.index("## 3.")
-        s2 = thesis[s2_start:s3_start]
-        assert "security" in s2.lower() or "stake" in s2.lower()
-
-    def test_section_3_mentions_stakeholders(self):
-        report = _ww_build_report()
-        thesis = report.final_synthesis
-        s3_start = thesis.index("## 3.")
-        s4_start = thesis.index("## 4.")
-        s3 = thesis[s3_start:s4_start]
-        assert "Speaker_A" in s3 or "stakeholder" in s3.lower()
-
-    def test_section_4_mentions_fallacies(self):
-        report = _ww_build_report()
-        thesis = report.final_synthesis
-        s4_start = thesis.index("## 4.")
-        s5_start = thesis.index("## 5.")
-        s4 = thesis[s4_start:s5_start]
-        assert "fallac" in s4.lower()
-
-    def test_section_5_specialist_graceful(self):
-        report = _ww_build_report()
-        thesis = report.final_synthesis
-        s5_start = thesis.index("## 5.")
-        s6_start = thesis.index("## 6.")
-        s5 = thesis[s5_start:s6_start]
-        # Without UU commentaries, should show graceful message
-        assert (
-            "No specialist commentaries" in s5
-            or "No cross-method" in s5
-            or "convergent" in s5.lower()
-        )
-
-    def test_section_6_political_reading(self):
-        report = _ww_build_report()
-        thesis = report.final_synthesis
-        s6_start = thesis.index("## 6.")
-        s6 = thesis[s6_start:]
-        assert len(s6) > 100  # substantive content
-        assert "mobilization" in s6.lower() or "rhetorical" in s6.lower()
-
-    def test_no_real_names_privacy(self):
-        report = _ww_build_report()
-        thesis = report.final_synthesis
-        # Should NOT contain any raw names from the fixture text
-        assert "Speaker_A" in thesis  # opaque ID is fine
-        # Verify section 6 doesn't leak
-        s6_start = thesis.index("## 6.")
-        s6 = thesis[s6_start:]
-        assert "opaque" in DeepSynthesisAgent.SYSTEM_PROMPT.lower()
-
-
-class TestSixSectionEmptyState:
-    """WW #725: 6 sections produced even with minimal data."""
-
-    def test_minimal_state_produces_six_sections(self):
+    def test_minimal_state_empty_synthesis_unavailable(self):
+        """Minimal state + no LLM → empty synthesis, explicit 'unavailable'."""
         state = UnifiedAnalysisState("A short discourse about something.")
-        report = DeepSynthesisReport(
-            source_overview=DeepSynthesisAgent._build_source_overview(state, {}),
-        )
-        report._raw_stakes = {}
-        thesis = asyncio.get_event_loop().run_until_complete(
-            DeepSynthesisAgent._build_final_synthesis(state, report, [])
-        )
-        assert "## 1." in thesis
-        assert "## 6." in thesis
+        report = _build_report_from_state(state)
+        assert report.final_synthesis == ""
+        assert report.final_synthesis_status == "unavailable"
 
-    def test_no_stakes_graceful_message(self):
+    def test_no_count_template_residue(self):
+        """The deleted count-template block must not resurface as synthesis."""
         state = UnifiedAnalysisState("A short discourse.")
-        report = DeepSynthesisReport(
-            source_overview=DeepSynthesisAgent._build_source_overview(state, {}),
-        )
-        report._raw_stakes = {}
-        thesis = asyncio.get_event_loop().run_until_complete(
-            DeepSynthesisAgent._build_final_synthesis(state, report, [])
-        )
-        s2_start = thesis.index("## 2.")
-        s3_start = thesis.index("## 3.")
-        s2 = thesis[s2_start:s3_start]
-        assert "No typed stakes" in s2 or "no stakes" in s2.lower()
+        report = _build_report_from_state(state)
+        # The signature count-template markers ("## 1. Context", "## 6. Lecture")
+        # must not appear in the synthesis — that would mean the template was
+        # reinstated (the very determinization residue this change removes).
+        assert "## 1. Context" not in report.final_synthesis
+        assert "## 6. Lecture" not in report.final_synthesis
+        assert report.final_synthesis == ""
+
+    def test_status_field_serialized_to_dict(self):
+        """The fail-loud status is visible downstream via to_dict()."""
+        state = UnifiedAnalysisState("A short discourse.")
+        report = _build_report_from_state(state)
+        d = report.to_dict()
+        assert "final_synthesis_status" in d
+        assert d["final_synthesis_status"] == "unavailable"
+        assert d["final_synthesis"] == ""
 
 
 class TestLLMSynthesisPromptSixSections:


### PR DESCRIPTION
## FB-31 #1108 — Spectacular synthesis de-drift (Section 9 fail-loud)

Resolves #1108. Lane: **synthesis**. Runs after FB-29 (#1106, merged). File-disjoint from FB-30 (fallacy_workflow).

### The bug (one root cause, two complaints)

The spectacular synthesis (Section 9) was castrated by a **determinization residue**: a count-template fallback (`_build_final_synthesis`) emitted an identical f-string — *"N arguments, M fallacies…"* — regardless of which LLM ran it. That single template is the root cause of **both** long-standing complaints:

- *"perte de richesse / déterminisation"* → the template emitted counts, not analysis
- *"toujours le même texte bridé"* → the template was an f-string, identical across models (gpt-5-mini already suppresses temperature/seed), so variance was zero

**Fix = SUBTRACTION** (per #1019 anti-theater, #1109 anti-pendule): remove the template so the LLM-conducted path is the *only* one. Richness + variance return for free on the LLM path. Without an LLM, the synthesis is **absent** and the status says so explicitly — never a template imposture.

### Changes

| File | Change |
|------|--------|
| `deep_synthesis_models.py` | Add `final_synthesis_status` (`"llm"`\|`"unavailable"`\|`"failed"`), mirrored on the FB-18 `grounded_synthesis_status` reference model; serialized in `to_dict()`. |
| `deep_synthesis_agent.py` | Section 9 now `try → _llm_synthesis → "llm"/"unavailable"/"failed"`. **DELETED `_build_final_synthesis`** (the count-template). `render_markdown` Section 9 surfaces the explicit status (mirrors the grounded-synthesis block) instead of a generic "not generated" fallback. |
| `invoke_callables.py` | No-LLM static-builder path sets `final_synthesis=""` + `status="unavailable"` (fail-loud, not a count-template masquerade). |
| `narrative_synthesis_plugin.py` | Labeled module + class docstrings as **TEMPLATE-BASED (non-LLM) SUMMARY** → points to `grounded_transversal_synthesis` + Section 9 as the reference analytical path. |
| `test_deep_synthesis_agent.py` | Replaced `TestSixSectionBriefing` + `TestSixSectionEmptyState` (count-template structure tests) with `TestSixSectionFailLoudNoLLM` (empty synthesis + `"unavailable"` status + no count-prose residue). |

### FB-18 is the reference model (untouched)

The FB-18 grounded-transversal synthesis already had the correct fail-loud contract (`status` field, value-gates VG-1..VG-4, no template fallback). Section 9 now mirrors it. **The FB-18 path is not modified** — it is the reference.

### Variance HARD (per #1108 DoD)

No reproducibility assertion is added. The LLM-conducted path produces model-dependent prose and no template clamps it. The golden `test_spectacular.py` (structure-only) is untouched and stays structure-only.

### Code removed (transparency)

No **files** deleted (Cleanup Gate Rule 1 N/A). One **method** deleted: `DeepSynthesisAgent._build_final_synthesis` (~144 lines, the count-template). The 10 `TestSixSectionBriefing` tests + 2 `TestSixSectionEmptyState` tests that asserted the count-template's `"## 1.".."## 6."` structure were removed (they tested the residue) and replaced by 1 fail-loud contract class.

### Validation

- `pytest tests/unit/argumentation_analysis/test_deep_synthesis_agent.py` → **51 passed**
- `golden test_spectacular.py` + `test_synthesis_spectacular.py` + `test_fb18_grounded_synthesis.py` + `test_deep_synthesis_wiring.py` → **65 passed, 1 PRE-EXISTING failure** (`test_spectacular_phase_count_with_synthesis`: stale `29 != 21` phase count; confirmed failing identically with these changes stashed — unrelated to FB-31, not a regression)
- `mypy --config-file pyproject.toml argumentation_analysis/orchestration/invoke_callables.py` (the gated file) → **Success: no issues**
- No new mypy errors (synthesis files are not in the strict CI gate; baseline 18 → 17 after, net −1 from the deleted method)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
