### PR TITLE
test(fb29): #1105 adversarial cross-verify of FB-29 (no inflation, fair baseline) — Epic #947

### DIFF
--- a/docs/reports/FB29_ADVERSARIAL_VERIFY.md
+++ b/docs/reports/FB29_ADVERSARIAL_VERIFY.md
@@ -1,0 +1,167 @@
+# FB-29 — Adversarial Cross-Verification (anti-self-confirmation)
+
+**Issue**: #1105 (Epic #947). **Dispatch**: R404b (ai-01) → `po-2023 | adversarial-verify FB-29 (anti-self-confirmation) | deep-queue, conditionnel sur PR #1105`.
+**Reviewer**: Claude Code @ myia-po-2023:2025-Epita-Intelligence-Symbolique (independent lane — did NOT write FB-29).
+**Target**: PR #1106 (merged `70669eab`) — po-2025's agentic multi-step blindspot-virtue detection.
+**Date**: 2026-06-15.
+
+> Privacy: this report references only opaque IDs (`doc_A/B/C`, `arg_N`) and the
+> exhibit phrases already published in the merged `FB29_QUALITY_BLINDSPOT_REPORT.md`
+> (paraphrased located claims, no speaker names/titles/dates). No `raw_text`.
+
+---
+
+## 1. Mandate
+
+The coordinator (R404b) queued an **independent adversarial cross-verification**
+of po-2025's FB-29 claim before letting it bear on the Epic #947 quality verdict.
+The specific concern: is the agentic chain's positive differential
+(**7/19 args with "demonstrated structure"**, baseline=0.0) **genuine
+content-separation**, or **self-confirmation theatre** — a chain tuned to score
+higher, a crippled baseline, vacuous "exhibits", or non-load-bearing negative
+controls? The DoD itself (#1105) names the trap: *"Higher numbers alone do NOT
+count."*
+
+This report is the result of reading the implementation + harness + report and
+running independent probes. It does **not** modify po-2025's code (file-disjoint
+verify lane); the only artifact added is a new adversarial test file + this report.
+
+---
+
+## 2. What was verified (method)
+
+| Check | How | Result |
+|-------|-----|--------|
+| **Baseline fairness** | Diffed `BASELINE_EVAL_PROMPT` in `run_fb29_agentic_headtohead.py` vs `run_fb28_quality_headtohead.py` | **Byte-identical** — the differential isolates the agentic upgrade, not a rubric asymmetry. |
+| **Author tests load-bearing** | Ran the 13 tests in `test_agentic_virtue_detectors.py` independently (`conda run -n projet-is`) | **13/13 PASS** (1.52s). |
+| **No upward inflation** | Wrote 6 NEW adversarial probes (`test_fb29_adversarial_verify.py`) attacking the "chain tuned to score higher" vector | **6/6 PASS** — detector faithfully propagates low/zero scores. |
+| **Chain-not-tuned discipline** | Read `agentic_virtue_detectors.py` step3 rubric + the harness corpus_B handling | Strict rubric (strawman→0.0, surface→0.0); rejects where structure absent. |
+| **Fail-loud** | Read `_resolve_llm` / `_run_chain_step` / evaluator error path | `AgenticDetectorError` propagates; `None` on failure; never synthetic 0.0. |
+| **Exhibits non-vacuous** | Read report §4 exhibits | Specific located claims/domains per arg (not generic "refutation detected"). |
+| **Live reproducibility** | Attempted to re-run the head-to-head | **Not possible on this machine** — FB-25 artifacts (`fb25_quality_args_*.json`) are gitignored on po-2025's machine, absent here. See §5. |
+
+---
+
+## 3. Solid properties (genuine anti-theater)
+
+1. **Apples-to-apples baseline.** The 0-shot baseline uses the *exact* FB-28
+   prompt (verified by diff) — same 9 virtues, same `{0.0, 0.2, 0.5, 1.0}` scale,
+   same rubric. It is not secretly told to score these virtues low. The positive
+   differential is therefore attributable to the **multi-step structure**, not a
+   crippled baseline. This is the single most important anti-theater property and
+   it holds.
+
+2. **The chain is NOT tuned to score higher.** The step3 scoring rubric is strict:
+   strawman / non-sequitur → 0.0; surface `comme X` → 0.0. The empirical evidence
+   is that the chain **rejects where structure is absent**: corpus_B returns 0/3,
+   and 15/19 args score a measured 0.0 (not inflated). A theatre chain would have
+   manufactured positives on corpus_B too; it did not.
+
+3. **No upward inflation (independently probed).** My 6 adversarial probes feed
+   the detector a *real-refutation* chain (step1 real, step2 `engagement_réel`)
+   but a **controlled LOW/ZERO step3 score**. The detector returns exactly that
+   low/zero score — it never floors a 0.2 up to 1.0, never overrides a 0.0 verdict
+   upward. The detector is a faithful propagator of the LLM's verdict, high *or*
+   low. (If FB-29 were theatre, `test_refut_zero_score_propagates_when_steps_say_real`
+   would fail — it passes.)
+
+4. **Fail-loud is real.** No-LLM, unparseable-output, and transport-error all
+   raise `AgenticDetectorError`; the harness records `None` + `"AGENTIC_FAIL"`
+   rather than a synthetic 0.0. No degraded-theatre fallback (#1019).
+
+5. **Exhibits are non-vacuous.** The 7 separating args each cite a specific
+   located claim/domain *from that argument* (téléprompteur, calamité économique,
+   identité ukrainienne, explication historique; domains guerre/paix, âge d'or) —
+   not a generic "refutation detected". A 0-shot call emitted a bare 0.0 on each.
+   This is shown structure, the DoD success criterion.
+
+6. **No auto-promotion.** po-2025 explicitly refuses axis-DECIDES (2/9 virtues
+   separating ≠ axis-dominance). Anti-#1019 honored.
+
+---
+
+## 4. Honest limitations found (po-2025 flagged most; one is new)
+
+- **Same model both sides.** `gpt-5-mini` judges both the 3-step chain and the
+  0-shot baseline. The demonstrated separation is therefore *"vs gpt-5-mini
+  0-shot"*, not *"vs any conceivable 0-shot"*. A stronger 1-shot model (e.g.
+  gpt-5) might surface the same structure in one call, collapsing the separation.
+  (po-2025 §7 hedge 2; the claim "a 0-shot call *cannot* replicate" should be read
+  as scoped to this model.)
+
+- **No human ground truth.** The located structures *read* as genuine but are not
+  verified against a human-graded rubric — are the 4 "located opposing claims" the
+  *correct* opposing claims, or plausible confabulations? Separation is shown;
+  correctness-against-ground-truth is the next bar and is unmeasured. (po-2025 §6/§7.)
+
+- **N is small** (19 args; 3 for corpus_B). corpus_B 0/3 could be a genuinely
+  source-light sample or insufficient N. (po-2025 §7.)
+
+- **[NEW] Discrimination is fully delegated to the LLM verdict chain; the detector
+  has no independent strawman-rejection guard.** The unit-test negative control
+  proves the detector *faithfully propagates* an "homme_de_paille" verdict into a
+  0.0 — it does **not** prove the detector independently catches strawmen. The
+  actual real-vs-strawman classification lives in the LLM's step2/step3 verdicts.
+  If a future or flakier LLM returned an *inconsistent* chain (step2 `homme_de_paille`
+  but step3 score=1.0), the detector would propagate the 1.0 (false positive) —
+  there is no detector-level defense. The current `gpt-5-mini` honors the chain
+  (empirically: corpus_B 0/3, 15/19 measured-zero), so this is a **robustness note
+  for whoever scales this to more virtues (the idle-fallback lane)**, not a current
+  hole. Worth recording: the anti-theater guarantee here is *empirical* (this LLM
+  behaves), not *structural* (the detector enforces it).
+
+---
+
+## 5. What I could NOT independently verify
+
+- **The live 7/19 number.** Re-running `run_fb29_agentic_headtohead.py` requires
+  the FB-25 extracted-args artifacts (`fb25_quality_args_{A,B,C}.json`), which are
+  gitignored and live only on po-2025's machine. I verified the **methodology**
+  (fairness, anti-inflation, fail-loud, exhibits) and the **test layer**, but I did
+  not reproduce the live LLM run. To fully close the loop, po-2025 (or a run on a
+  machine with the artifacts + OpenRouter key) would re-execute and confirm the
+  7/19 + per-corpus means. Given the methodology is sound and the budget is ~$0.08,
+  this is low-risk to defer, but it is the one claim taken on po-2025's evidence
+  rather than independently reproduced.
+
+---
+
+## 6. Verdict
+
+**FB-29's content-separation claim HOLDS under adversarial scrutiny.** It is not
+self-confirmation theatre:
+
+- The baseline is fair (identical rubric, not crippled).
+- The chain is not tuned to score higher (strict rubric; rejects where structure
+  is absent; 6 independent probes confirm no upward inflation).
+- The fail-loud is real; the exhibits are non-vacuous; the hedges are honest.
+
+**On the Epic #947 quality axis**: I **concur with po-2025's fork** —
+content-separation is **demonstrated on the 2 upgraded virtues** (2/9), the
+quality **AXIS stays EDGES** (partial content-separation, not axis-DECIDES). **No
+§5 amendment warranted.** This is a *better-substantiated* EDGES (measured partial
+separation vs FB-28's reasoned-only), exactly as po-2025 stated — no more, no less.
+
+**Caveat from R405**: FB-29's number was measured under the *castrated* pipeline.
+The coordinator's standing direction (R405/#1109) is to **re-measure the quality
+axis after de-castration** (FB-30 + FB-31 land). So this strengthened-EDGES may
+itself shift once the descent/synthesis sites are un-bridled. FB-29 stands as a
+valid *internal* check (its own before/after is honest), but it is not the final
+quality measurement for the Epic.
+
+---
+
+## 7. Artifacts added (this verify lane, file-disjoint)
+
+- `tests/unit/argumentation_analysis/agents/core/quality/test_fb29_adversarial_verify.py`
+  — 6 load-bearing probes (5 inflation + 1 exhibit-audit). Uses a call-order stub
+  (keys off the chain's sequential step1→step2→step3 call sequence, not prompt
+  text) so it is robust to prompt wording and independent of po-2025's fixtures.
+  All 6 PASS.
+- This report.
+
+No change to po-2025's `agentic_virtue_detectors.py`, `quality_evaluator.py`,
+`run_fb29_agentic_headtohead.py`, or `FB29_QUALITY_BLINDSPOT_REPORT.md`. Lane:
+po-2023 (verify only).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/tests/unit/argumentation_analysis/agents/core/quality/test_fb29_adversarial_verify.py
+++ b/tests/unit/argumentation_analysis/agents/core/quality/test_fb29_adversarial_verify.py
@@ -1,0 +1,172 @@
+"""FB-29 adversarial cross-verification (anti-self-confirmation) — po-2023 lane.
+
+Companion to po-2025's ``test_agentic_virtue_detectors.py`` (PR #1106, #1105).
+These tests were NOT written by the FB-29 author; they attack the specific
+self-confirmation / theatre vector the R404b dispatch asked an independent eye
+to check: **is the agentic chain tuned to score higher, or is it an honest
+propagator of the LLM's verdict?**
+
+The author's negative controls (strawman / surface ``comme X`` REJECT) prove the
+detector refuses when the *LLM* says "no structure". They do NOT, by themselves,
+prove the detector lacks an **upward bias** — i.e. that it would also faithfully
+propagate a *low* score the LLM emits on a real-looking refutation. A detector
+that floors low scores up, or inflates a 0.0 verdict, would still pass the
+author's strawman test (which checks score==0.0) while being theatre on the
+positive side.
+
+These probes close that gap. They use a **call-order stub** (keys off the chain's
+sequential step1→step2→step3 call sequence, NOT prompt-text markers) so they are
+robust to prompt wording and genuinely independent of the author's fixtures.
+
+DoD contract preserved: the LLM *dependency* is patched (the callable), not the
+detector internals. The detector logic (chain, snap-to-scale, exhibit embedding)
+is what runs and what is under test.
+
+Findings recorded in ``docs/reports/FB29_ADVERSARIAL_VERIFY.md``.
+"""
+
+import json
+
+from argumentation_analysis.agents.core.quality.agentic_virtue_detectors import (
+    detect_analogie_pertinente_agentic as detect_analogy,
+    detect_refutation_constructive_agentic as detect_refut,
+)
+
+# A text shaped like a real refutation — the stub ignores its content and
+# returns a controlled chain, so any non-empty text works. We use a neutral
+# stand-in (not the author's REAL_REFUTATION fixture) to stay fixture-independent.
+_NEUTRAL_REFUTATION_TEXT = (
+    "Certains soutiennent la thèse A. Nous contestons cette thèse pour des "
+    "raisons précises, en adressant directement ses prémisses."
+)
+_NEUTRAL_ANALOGY_TEXT = (
+    "Le mécanisme évoque un système connu : un domaine source éclaire un domaine "
+    "cible par une correspondance structurelle."
+)
+
+
+def _refut_chain_stub(controlled_score: float):
+    """Return a 'real refutation' chain (step1 real, step2 engagement_réel) but
+    a CONTROLLED step3 score. Keys off call sequence (robust to prompt text)."""
+
+    state = {"n": 0}
+
+    def stub(prompt: str) -> str:
+        state["n"] += 1
+        if state["n"] == 1:  # step1 — claim an opposing claim IS present
+            return json.dumps(
+                {
+                    "has_opposing_claim": True,
+                    "opposing_claim": "la thèse adverse A",
+                    "main_thesis": "la thèse adverse A est contestée",
+                }
+            )
+        if state["n"] == 2:  # step2 — claim REAL engagement (not strawman)
+            return json.dumps(
+                {
+                    "engages_real_claim": True,
+                    "engagement_verdict": "engagement_réel",
+                    "reasoning": "adresse la thèse adverse réelle",
+                }
+            )
+        # step3 — CONTROLLED score (the variable under test)
+        return json.dumps(
+            {"score": controlled_score, "exhibit": "chaîne contrôlée (sondage d'inflation)"}
+        )
+
+    return stub
+
+
+def _analogy_chain_stub(controlled_score: float):
+    """Return a 'real analogy' chain (step1 domains, step2 structural mapping)
+    but a CONTROLLED step3 score."""
+
+    state = {"n": 0}
+
+    def stub(prompt: str) -> str:
+        state["n"] += 1
+        if state["n"] == 1:
+            return json.dumps(
+                {
+                    "has_analogy": True,
+                    "source_domain": "domaine source",
+                    "target_domain": "domaine cible",
+                }
+            )
+        if state["n"] == 2:
+            return json.dumps(
+                {
+                    "has_structural_mapping": True,
+                    "mapping": "correspondance structurelle contrôlée",
+                    "reasoning": "mapping non-surface",
+                }
+            )
+        return json.dumps(
+            {"score": controlled_score, "exhibit": "chaîne contrôlée (sondage d'inflation)"}
+        )
+
+    return stub
+
+
+class TestNoUpwardInflation:
+    """The detector MUST faithfully propagate a LOW / ZERO score the LLM emits,
+    even when the upstream steps (step1/step2) report a fully-real refutation.
+    A detector that inflates 0.0→higher or floors low scores up is theatre
+    (the exact 'chain tuned to score higher' vector)."""
+
+    def test_refut_zero_score_propagates_when_steps_say_real(self):
+        """step1=real, step2=engagement_réel, but step3=0.0 → detector MUST
+        return 0.0. Proves no upward override of a zero verdict."""
+        score, comment = detect_refut(
+            _NEUTRAL_REFUTATION_TEXT, llm=_refut_chain_stub(0.0)
+        )
+        assert score == 0.0, (
+            f"INFLATION DETECTED: step1/step2 said 'real refutation' but step3 "
+            f"scored 0.0 — detector returned {score} instead of honoring the 0.0. "
+            "The chain would be theatre (upward override of a zero verdict)."
+        )
+
+    def test_refut_low_score_propagates_no_floor_up(self):
+        """step3=0.2 (trace) → detector MUST return 0.2, NOT 1.0 or 0.5."""
+        score, _ = detect_refut(_NEUTRAL_REFUTATION_TEXT, llm=_refut_chain_stub(0.2))
+        assert score == 0.2, (
+            f"INFLATION DETECTED: LLM step3 score was 0.2 but detector returned "
+            f"{score} — the chain inflates a trace score upward (theatre)."
+        )
+
+    def test_refut_mid_score_propagates(self):
+        """step3=0.5 → detector MUST return 0.5 (faithful mid propagation)."""
+        score, _ = detect_refut(_NEUTRAL_REFUTATION_TEXT, llm=_refut_chain_stub(0.5))
+        assert score == 0.5
+
+    def test_analogy_zero_score_propagates_when_steps_say_real(self):
+        """Analogous inflation probe for the analogy chain: step1=domains,
+        step2=structural mapping, but step3=0.0 → MUST return 0.0."""
+        score, _ = detect_analogy(
+            _NEUTRAL_ANALOGY_TEXT, llm=_analogy_chain_stub(0.0)
+        )
+        assert score == 0.0, (
+            f"INFLATION DETECTED (analogy): upstream said 'real analogy' but "
+            f"step3=0.0 — detector returned {score} instead of 0.0."
+        )
+
+    def test_analogy_low_score_propagates_no_floor_up(self):
+        score, _ = detect_analogy(_NEUTRAL_ANALOGY_TEXT, llm=_analogy_chain_stub(0.2))
+        assert score == 0.2
+
+
+class TestExhibitEmbedsControlledStructure:
+    """The exhibit (demonstrated structure) must embed the step2 verdict + the
+    controlled score, so a reviewer can audit what the chain actually located —
+    not a generic 'refutation detected'. This is the content-separation
+    artifact a 0-shot call does not emit."""
+
+    def test_refut_exhibit_embeds_verdict_and_score(self):
+        score, comment = detect_refut(
+            _NEUTRAL_REFUTATION_TEXT, llm=_refut_chain_stub(0.5)
+        )
+        assert score == 0.5
+        # The comment must carry the located opposing claim + verdict + score
+        # so the exhibited structure is auditable, not a bare number.
+        assert "engagement_réel" in comment
+        assert "score=0.5" in comment


### PR DESCRIPTION
## Independent adversarial cross-verification of FB-29 (#1105, PR #1106)

**Lane**: po-2023 (verify-only). **Dispatch**: R404b (ai-01) `po-2023 | adversarial-verify FB-29 (anti-self-confirmation) | conditionnel sur PR #1105` — condition met (#1106 merged `70669eab`).

**Question answered**: is po-2025's positive differential (7/19 args with "demonstrated structure", baseline=0.0) **genuine content-separation**, or **self-confirmation theatre** (chain tuned to score higher / crippled baseline / vacuous exhibits)?

### Verdict: claim HOLDS — genuine content-separation on the 2 upgraded virtues; quality AXIS stays EDGES

Verified independently (not by re-reading po-2025's report):

| Check | Result |
|-------|--------|
| **Baseline fairness** (diff vs FB-28 harness) | ✅ `BASELINE_EVAL_PROMPT` **byte-identical** to FB-28 — differential isolates the agentic upgrade, not a rubric asymmetry |
| **Author tests** (13, run independently) | ✅ 13/13 PASS |
| **No upward inflation** (6 NEW probes) | ✅ 6/6 PASS — detector faithfully propagates LOW/ZERO scores; never floors 0.2→1.0 or overrides a 0.0 verdict up |
| **Chain-not-tuned** | ✅ strict rubric (strawman→0.0, surface→0.0); rejects where structure absent (corpus_B 0/3, 15/19 measured-zero) |
| **Fail-loud** | ✅ `AgenticDetectorError` propagates; `None` on failure; no synthetic 0.0 |
| **Exhibits non-vacuous** | ✅ specific located claims/domains per arg |

### What I could NOT verify
- **Live 7/19 repro**: the FB-25 artifacts (`fb25_quality_args_*.json`) are gitignored on po-2025's machine, absent on mine. I verified methodology + test layer; the live LLM run was not independently reproduced (~$0.08 to re-run on a machine with the artifacts + key).

### One new robustness note (not a current hole)
The unit-test negative control proves the detector **faithfully propagates** a strawman verdict into 0.0 — it does **not** prove the detector independently catches strawmen. The discrimination is delegated to the LLM verdict chain (step2/step3). If a flakier LLM returned an inconsistent chain, the detector would propagate the false positive. Current `gpt-5-mini` honors the chain (empirically), so this is a note for whoever scales this to more virtues (idle-fallback lane), not a defect today.

### Files
- `tests/.../test_fb29_adversarial_verify.py` — 6 load-bearing probes (5 inflation + 1 exhibit-audit), call-order stub independent of po-2025's fixtures.
- `docs/reports/FB29_ADVERSARIAL_VERIFY.md` — full report.

**File-disjoint** from po-2025's code (no change to `agentic_virtue_detectors.py` / `quality_evaluator.py` / harness / FB-29 report). Also disjoint from my FB-30 #1110 (informal/ lane) and po-2025's FB-31 #1111 (synthesis/ lane).

### Epic #947 impact
Concur with po-2025's fork: content-separation demonstrated on 2/9 virtues → quality **AXIS stays EDGES** (strengthened, not DECIDES). No §5 amendment. Per R405/#1109, the quality axis will be **re-measured after de-castration** (FB-30 + FB-31 land) — FB-29's number was measured under the castrated pipeline and may shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)