### PR TITLE
fix(spectacular): #1115 remove template narrative_synthesis phase (anti-pendule)

### DIFF
--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -866,12 +866,15 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             depends_on=["fol", "modal", "aspic_analysis"],
             optional=True,
         )
-        .add_phase(
-            "narrative_synthesis",
-            capability="narrative_synthesis",
-            depends_on=["quality", "jtms", "atms", "dung_extensions"],
-            optional=True,
-        )
+        # NOTE (#1115): the template `narrative_synthesis` phase was REMOVED from
+        # the spectacular workflow. Its `build_narrative()` prose was an f-string
+        # over state counts (N arguments, M fallacies...) -> near-identical prose
+        # regardless of model -> a determinization residue (#1109) that killed
+        # richness AND variance. The canonical spectacular deliverable is the
+        # LLM-conducted `deep_synthesis` 9-section report (Section 9 fail-loud per
+        # FB-31 #1108). Removal is by subtraction (anti-pendule): the LLM path is
+        # now the only narrative path on spectacular. The capability stays wired in
+        # the standard (L243) and full (L358) workflows for non-spectacular runs.
         # L1b — KB extraction from extracted facts (#506)
         .add_phase(
             "text_to_kb",
@@ -921,7 +924,6 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             capability="deep_synthesis",
             depends_on=[
                 "synthesis",
-                "narrative_synthesis",
                 "belief_revision",
                 "stakes",
             ],

--- a/argumentation_analysis/visualization/html_report.py
+++ b/argumentation_analysis/visualization/html_report.py
@@ -277,11 +277,15 @@ tr:hover { background: rgba(88,166,255,0.05); }
 </table>
 </div>
 
-{# ── Section 9: Narrative Synthesis ── #}
+{# ── Section 9: Narrative Synthesis (template prose — present only when the
+   workflow produced it; the spectacular workflow no longer does (#1115), so
+   this section stays empty there while standard/full/sherlock keep it). ── #}
+{% if narrative_synthesis %}
 <h2>9. Narrative Synthesis</h2>
 <div class="section">
   <div class="narrative">{{ narrative_synthesis }}</div>
 </div>
+{% endif %}
 
 {# ── Section 10: Discourse Pattern Mining (optional) ── #}
 {% if pattern_data %}

--- a/tests/golden/test_spectacular.py
+++ b/tests/golden/test_spectacular.py
@@ -10,7 +10,12 @@ Definition of Done (#365):
   - state.dung_frameworks has non-trivial structure
   - state.fol_analysis_results has ≥5 formulas
   - state.jtms_retraction_chain has ≥1 cascade
-  - state.narrative_synthesis present and cites ≥5 fields
+
+Note (#1115): the spectacular workflow no longer produces `narrative_synthesis`
+(the template phase was removed — determinization residue per #1109 §5). The
+frozen fixture still carries a historical `narrative_synthesis` field, so the
+`TestNarrativeSynthesis` tests below validate that frozen artifact (a regression
+guard on the fixture), not on the live spectacular path.
 """
 
 import json

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
@@ -310,33 +310,55 @@ class TestSpectacularWorkflowGolden:
         "pl",
         "fol",
         "modal",
+        "fol_solver",
+        "modal_solver",
         "dung_extensions",
+        "ranking",
+        "bipolar",
+        "probabilistic",
         "aspic_analysis",
         "counter",
+        "stakes",
         "jtms",
         "debate",
         "atms",
         "governance",
         "formal_synthesis",
-        "narrative_synthesis",
+        "text_to_kb",
+        "kb_to_tweety",
+        "tweety_interpretation",
+        "belief_revision",
+        "synthesis",
+        "deep_synthesis",
     }
 
-    def test_phase_count_is_17(self):
+    def test_phase_count_is_28(self):
+        # #1115: narrative_synthesis template phase removed from spectacular
+        # (determinization residue #1109 §5); count reflects real phase set.
         wf = build_spectacular_workflow()
-        assert len(wf.phases) == 17
+        assert len(wf.phases) == 28
 
     def test_all_expected_phases_present(self):
         wf = build_spectacular_workflow()
         assert {p.name for p in wf.phases} == self.EXPECTED_PHASES
 
+    def test_narrative_template_not_in_spectacular(self):
+        """#1115: load-bearing — template narrative_synthesis phase removed from
+        spectacular; the LLM-conducted deep_synthesis is the sole narrative path."""
+        wf = build_spectacular_workflow()
+        assert "narrative_synthesis" not in {p.name for p in wf.phases}
+
     def test_dag_validates_clean(self):
         wf = build_spectacular_workflow()
         assert wf.validate() == []
 
-    def test_execution_order_has_6_levels(self):
+    def test_execution_order_has_8_levels(self):
+        # #1115: DAG grew via #504/#506/#507/#508/#534 (solvers, KB/tweety,
+        # belief_revision, synthesis, deep_synthesis) — execution order is now
+        # 8 levels. Folded DAG test debt per ai-01 R407.
         wf = build_spectacular_workflow()
         levels = wf.get_execution_order()
-        assert len(levels) == 6
+        assert len(levels) == 8
 
     def test_extract_is_sole_entry_point(self):
         wf = build_spectacular_workflow()
@@ -346,11 +368,14 @@ class TestSpectacularWorkflowGolden:
     def test_l1_parallel_phases(self):
         wf = build_spectacular_workflow()
         levels = wf.get_execution_order()
+        # L1 = the 4 fan-out phases after extract, PLUS text_to_kb (#506 KB
+        # extraction depends only on extract). #1115 folded DAG debt.
         assert set(levels[1]) == {
             "hierarchical_fallacy",
             "neural_detect",
             "nl_to_logic",
             "quality",
+            "text_to_kb",
         }
 
     def test_l2_includes_formal_logic_and_counter(self):
@@ -369,21 +394,38 @@ class TestSpectacularWorkflowGolden:
         atms = wf.get_phase("atms")
         assert "jtms" in atms.depends_on
 
-    def test_formal_synthesis_terminal(self):
+    def test_formal_synthesis_aggregates_three_logic_families(self):
+        # #1115: formal_synthesis is no longer terminal (deep_synthesis is the
+        # final spectacular deliverable). Assert its aggregation deps + that it
+        # runs in the late formal-aggregation level, not the terminal level.
         wf = build_spectacular_workflow()
         synth = wf.get_phase("formal_synthesis")
         assert "fol" in synth.depends_on
         assert "modal" in synth.depends_on
         assert "aspic_analysis" in synth.depends_on
         levels = wf.get_execution_order()
-        assert "formal_synthesis" in levels[-1]
+        # formal_synthesis runs in the formal-aggregation level (5 of 0..7); the
+        # terminal level is deep_synthesis (#534).
+        assert "formal_synthesis" in levels[5]
+        assert levels[-1] == ["deep_synthesis"]
 
     @pytest.mark.asyncio
-    async def test_all_16_phases_complete(self):
+    async def test_all_phases_complete_or_optional_skipped(self):
+        # #1115: the spectacular workflow has 28 phases (was 16/17); exact-count
+        # asserts went stale as the DAG grew. Assert the load-bearing invariant
+        # instead: no phase FAILED, and the non-optional phases all COMPLETED.
         wf = build_spectacular_workflow()
         results, state = await _execute_workflow(wf)
-        completed = [r for r in results.values() if r.status == PhaseStatus.COMPLETED]
-        assert len(completed) == 17
+        failed = [r for r in results.values() if r.status == PhaseStatus.FAILED]
+        assert failed == [], f"Phases failed: {[r for r in results if results[r].status == PhaseStatus.FAILED]}"
+        for name, phase in [(p.name, p) for p in wf.phases]:
+            result = results.get(name)
+            if result is None:
+                continue
+            if not getattr(phase, "optional", True):
+                assert result.status == PhaseStatus.COMPLETED, (
+                    f"Non-optional phase {name} did not complete: {result.status}"
+                )
 
     @pytest.mark.asyncio
     async def test_no_failed_phases(self):
@@ -511,8 +553,10 @@ class TestSpectacularWorkflowGolden:
         _, state = await _execute_workflow(wf)
         assert "spectacular_analysis" in state.workflow_results
         wf_data = state.workflow_results["spectacular_analysis"]
-        assert wf_data["completed"] == 17
+        # #1115: spectacular has 28 phases; assert none failed rather than a stale
+        # exact count (the DAG grew via #504/#506/#507/#508/#534).
         assert wf_data["failed"] == 0
+        assert wf_data["completed"] == len(wf.phases)
 
 
 # ── Sherlock Modern Workflow Golden Tests ────────────────────────────────────
@@ -613,7 +657,9 @@ class TestWorkflowCatalogGolden:
         catalog = get_workflow_catalog()
         assert "spectacular" in catalog
         assert catalog["spectacular"].name == "spectacular_analysis"
-        assert len(catalog["spectacular"].phases) == 17
+        # #1115: spectacular has 28 phases (narrative_synthesis template removed;
+        # DAG grew via #504/#506/#507/#508/#534).
+        assert len(catalog["spectacular"].phases) == 28
 
     def test_catalog_includes_sherlock_modern(self):
         catalog = get_workflow_catalog()

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
@@ -28,8 +28,12 @@ class TestSpectacularWorkflowDAG:
         assert wf.name == "spectacular_analysis"
 
     def test_phase_count(self):
+        # #1115: the template `narrative_synthesis` phase was REMOVED from the
+        # spectacular workflow (determinization residue per #1109 §5). The count
+        # reflects the real phase set (#504 solvers, #506 KB/tweety, #507
+        # belief_revision, #508 synthesis, #534 deep_synthesis, ...).
         wf = build_spectacular_workflow()
-        assert len(wf.phases) == 17
+        assert len(wf.phases) == 28
 
     def test_all_expected_phases_present(self):
         wf = build_spectacular_workflow()
@@ -43,17 +47,39 @@ class TestSpectacularWorkflowDAG:
             "pl",
             "fol",
             "modal",
+            "fol_solver",
+            "modal_solver",
             "dung_extensions",
+            "ranking",
+            "bipolar",
+            "probabilistic",
             "aspic_analysis",
             "counter",
+            "stakes",
             "jtms",
             "debate",
             "atms",
             "governance",
             "formal_synthesis",
-            "narrative_synthesis",
+            "text_to_kb",
+            "kb_to_tweety",
+            "tweety_interpretation",
+            "belief_revision",
+            "synthesis",
+            "deep_synthesis",
         }
         assert expected == phase_names
+
+    def test_narrative_template_removed_from_spectacular(self):
+        """#1115: load-bearing — the template narrative_synthesis phase must NOT
+        be in the spectacular workflow. Its f-string prose killed richness/variance
+        (#1109). Removal is by subtraction; the LLM-conducted deep_synthesis is
+        the sole narrative path on spectacular."""
+        wf = build_spectacular_workflow()
+        phase_names = {p.name for p in wf.phases}
+        assert "narrative_synthesis" not in phase_names
+        # deep_synthesis no longer depends on the removed template phase
+        assert "narrative_synthesis" not in wf.get_phase("deep_synthesis").depends_on
 
     def test_all_capabilities_unique(self):
         wf = build_spectacular_workflow()


### PR DESCRIPTION
## Summary

Closes #1115. FB-33 (#1113) audit found the `narrative_synthesis` phase was still wired into the spectacular workflow despite FB-31's "always-skipped" claim. Its `build_narrative()` is an f-string over state counts (N arguments, M fallacies...) -> near-identical prose regardless of model -> a **determinization residue (#1109 sec4/5)** that killed richness AND variance. The canonical spectacular deliverable is the LLM-conducted `deep_synthesis` 9-section report (Section 9 fail-loud per FB-31 #1108); the template narrative was only "habillage" surfaced alongside it.

**Fix = subtraction (anti-pendule)**: the LLM path is now the ONLY narrative path on spectacular. No "smarter template" counterweight added.

## Changes

| File | Change | Why |
|------|--------|-----|
| `orchestration/workflows.py` | Remove narrative_synthesis phase from build_spectacular_workflow + drop from deep_synthesis depends_on | The template phase itself (spectacular-only) |
| `visualization/html_report.py` | Guard Narrative section on field presence (Jinja if-block) | Shared renderer: render only when produced; spectacular no longer, standard/full/sherlock still do |
| `tests/.../test_spectacular_workflow_dag.py` | Phase count 17->28, expected set = real 28 phases, +load-bearing test_narrative_template_removed_from_spectacular | Pre-existing DAG debt + #1115 removal guard |
| `tests/.../test_spectacular_regression_suite.py` | TestSpectacularWorkflowGolden expected set + counts to reality (28 phases, 8 levels); replaced fragile exact-completed with load-bearing invariants (no FAILED; non-optional COMPLETED); +removal guard | Fold pre-existing DAG debt (ai-01 R407) |
| `tests/golden/test_spectacular.py` | DoD docstring clarification | Frozen fixture still carries historical narrative; tests validate the frozen artifact, not the live path |

## What is NOT touched

- **DeepSynthesisAgent.ARTIFACT_FIELDS** keeps narrative_synthesis as an OPTIONAL citable field — getattr-defensive (verified), returns None gracefully. No code change needed.
- **standard / full / sherlock_modern workflows** keep the phase (only spectacular is de-castrated per #1115 scope).
- **TestSherlockModernWorkflowGolden** assertions — that workflow legitimately still has the phase. Untouched.
- **invoke_callables.py** — po-2025 file (#1117 wiring, MERGED f12226be). File-disjoint.

## Anti-pendule verification

- Every change is **subtraction or documentation**. The one deletion removes a template bypass so the LLM path is the only one.
- No smarter template / heuristic / counterweight added. No threshold lowered. No determinism forced.
- FB-18 grounded synthesis + restored agentic descent NOT touched.

## Validation

- test_spectacular_workflow_dag.py + test_spectacular_regression_suite.py + tests/golden/test_spectacular.py: **92 passed** (re-run post-rebase on f12226be).
- Verified programmatically: spectacular = 28 phases (was 29), narrative_synthesis NOT in spectacular, deep_synthesis.depends_on no longer references it, standard/full/sherlock STILL have it.

## Coordination

Per ai-01 R407: prepared in draft, **rebased onto post-wiring main** (f12226be, #1117 MERGED — po-2025 invoke_callables.py L6338 wiring landed). File-disjoint from FB-32. Opening now that the wiring gate is cleared.

Refs #1113 (FB-33 audit), #1109 (sec4 residual items — closes the last one).

Generated with Claude Code