### PR TITLE
fix(spectacular): FB-36 resolve per-arg recursion hang — fail-loud, no recursion (#1123)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3566,7 +3566,27 @@ async def _invoke_hierarchical_fallacy(
             per_arg_fallacies = per_arg_result.get("fallacies", [])
             merged = _merge_fallacy_results(wide_fallacies, per_arg_fallacies)
             result["fallacies"] = merged
-            result["extraction_method"] = "widenet+perarg_union"
+            # FB-36 (#1123): label honestly. When the per-argument pass was
+            # skipped fail-loud (no extractable arguments — recursion fix), this
+            # is wide-net-only, NOT a union; surface the skip at the result
+            # level too so the report/state layer sees the per-arg lift was
+            # lost (fail-loud, anti-theater #1019).
+            if per_arg_result.get("per_argument_skipped"):
+                result["extraction_method"] = "widenet_only_no_perarg_args"
+                result["degraded"] = True
+                _existing_err = result.get("last_error")
+                result["last_error"] = (
+                    ("; " + _existing_err if _existing_err else "")
+                    + "per-argument fallacy lift skipped (no extractable arguments)"
+                ).lstrip("; ")
+                logger.warning(
+                    "Per-argument fallacy lift skipped (FB-36 #1123): no "
+                    "extractable arguments — wide-net result only, per-arg "
+                    "recall lift lost (widenet=%d fallacies retained)",
+                    len(wide_fallacies),
+                )
+            else:
+                result["extraction_method"] = "widenet+perarg_union"
             logger.info(
                 "Fallacy recall lift: widenet=%d, perarg=%d, merged=%d",
                 len(wide_fallacies),
@@ -3926,10 +3946,36 @@ async def _invoke_hierarchical_fallacy_per_argument(
         arguments = _extract_arguments_for_parallel(input_text, context)
 
         if not arguments:
-            logger.info(
-                "No individual arguments extracted — falling back to single-text analysis"
+            # FB-36 (#1123): do NOT recurse into _invoke_hierarchical_fallacy
+            # here. This per-argument pass is invoked AFTER the wide-net "llm"
+            # descent already ran (its results are merged by the caller at the
+            # ``_merge_fallacy_results`` site), so re-entering the wide-net path
+            # is redundant — and worse, that path calls THIS function again, so
+            # with no extractable arguments (no state args, no
+            # ``phase_extract_output``, no ``\n\n`` paragraph breaks — e.g. an
+            # encrypted corpus loaded as a single block) it recurses
+            # indefinitely. That infinite loop is the doc_A spectacular+full
+            # >2h hang (ruled out of the descent by FB-35, isolated here).
+            # Return fail-loud instead: the caller keeps the wide-net fallacies
+            # and the per-arg pass is marked degraded (anti-theater #1019).
+            logger.warning(
+                "Per-argument fallacy harness found no extractable arguments "
+                "(no state args / no phase_extract_output / no \\n\\n paragraph "
+                "breaks) — skipping per-argument pass fail-loud (FB-36 #1123, "
+                "no recursion). In a full pipeline this means the extract "
+                "phase produced no splittable arguments for this input; the "
+                "wide-net result is retained by the caller."
             )
-            return await _invoke_hierarchical_fallacy(input_text, context)
+            return {
+                "fallacies": [],
+                "exploration_method": "per_argument_skipped_no_args",
+                "per_argument_skipped": True,
+                "degraded": True,
+                "last_error": (
+                    "no arguments extracted for per-argument fallacy "
+                    "(wide-net result retained by caller)"
+                ),
+            }
 
         logger.info(
             "Parent harness: running parallel fallacy detection on %d arguments",

--- a/tests/unit/argumentation_analysis/test_fb36_recursion_fix.py
+++ b/tests/unit/argumentation_analysis/test_fb36_recursion_fix.py
@@ -1,0 +1,122 @@
+"""FB-36 #1123 — per-argument fallacy harness recursion fix.
+
+The ``_invoke_hierarchical_fallacy_per_argument`` harness used to fall back to
+``_invoke_hierarchical_fallacy`` when ``_extract_arguments_for_parallel``
+returned no arguments. Since the wide-net "llm" path that re-enters CALLS the
+per-argument harness again, this was an infinite recursion whenever no arguments
+could be extracted (no state args, no ``phase_extract_output``, and no ``\\n\\n``
+paragraph breaks — e.g. an encrypted corpus loaded as a single block). That
+loop is the doc_A ``spectacular``+``full`` >2h hang (the descent was ruled out
+by FB-35; the per-arg recursion is the real cause).
+
+The fix: return fail-loud (degraded + last_error, wide-net result retained by
+the caller) instead of recursing. These tests pin that behavior.
+"""
+import pytest
+
+from unittest.mock import AsyncMock, patch
+
+import argumentation_analysis.orchestration.invoke_callables as ic
+
+
+# A single block of text (>20 chars, NO double-newline paragraph breaks) — this
+# is the trigger condition (Source 3 of _extract_arguments_for_parallel returns
+# nothing), mimicking an encrypted corpus loaded as one block.
+SINGLE_BLOCK = (
+    "This is one continuous paragraph with no double newline breaks anywhere. "
+    "It is long enough to exceed the 20-character minimum filter. "
+) * 3
+
+MULTI_BLOCK = (
+    "First argument paragraph that is long enough to pass the filter.\n\n"
+    "Second argument paragraph that is also long enough to pass.\n\n"
+    "Third argument paragraph likewise above the threshold."
+)
+
+
+class TestExtractArgumentsTrigger:
+    """Pin the recursion TRIGGER condition (no args for a single block)."""
+
+    def test_single_block_empty_context_yields_no_args(self):
+        args = ic._extract_arguments_for_parallel(SINGLE_BLOCK, {})
+        assert args == [], (
+            "a single-block text with an empty context must yield no arguments "
+            "(the recursion trigger) — Source 3 needs \\n\\n breaks"
+        )
+
+    def test_multi_block_yields_args(self):
+        args = ic._extract_arguments_for_parallel(MULTI_BLOCK, {})
+        assert len(args) >= 2, "paragraph-split (Source 3) must still extract args"
+
+    def test_state_identified_arguments_source(self):
+        class _FakeState:
+            identified_arguments = {"arg_1": "A real argument long enough.", "arg_2": "x"}
+
+        args = ic._extract_arguments_for_parallel(
+            SINGLE_BLOCK, {"_state_object": _FakeState()}
+        )
+        # Only arg_1 passes the >20-char filter (Source 1).
+        assert len(args) == 1
+        assert args[0][0] == "arg_1"
+
+
+class TestPerArgNoRecursion:
+    """The core FB-36 fix: per-arg returns fail-loud, does NOT recurse."""
+
+    @pytest.mark.asyncio
+    async def test_no_recursion_on_single_block(self):
+        """A single-block text + empty context must NOT recurse into
+        _invoke_hierarchical_fallacy (the pre-FB-36 infinite loop)."""
+        with patch.object(
+            ic, "_invoke_hierarchical_fallacy", new_callable=AsyncMock
+        ) as spy_hier:
+            result = await ic._invoke_hierarchical_fallacy_per_argument(
+                SINGLE_BLOCK, {}
+            )
+
+        # The recursion target must NEVER be called.
+        assert spy_hier.call_count == 0, (
+            "per-argument harness recursed into _invoke_hierarchical_fallacy "
+            "(the FB-36 #1123 >2h hang root cause) — must return fail-loud instead"
+        )
+        # Fail-loud return contract.
+        assert isinstance(result, dict)
+        assert result.get("fallacies") == []
+        assert result.get("exploration_method") == "per_argument_skipped_no_args"
+        assert result.get("per_argument_skipped") is True
+        assert result.get("degraded") is True
+        assert "no arguments" in result.get("last_error", "").lower()
+
+    @pytest.mark.asyncio
+    async def test_no_recursion_is_fast_not_infinite(self):
+        """Regression guard: before the fix this call infinite-looped (the >2h
+        hang). With the spy it would have returned after one mock call; the
+        decisive check is that we reach the assert (no hang) AND the spy is
+        untouched — proving the early fail-loud return path, not the recursion."""
+        import time
+
+        t0 = time.time()
+        with patch.object(
+            ic, "_invoke_hierarchical_fallacy", new_callable=AsyncMock
+        ) as spy_hier:
+            result = await ic._invoke_hierarchical_fallacy_per_argument(
+                SINGLE_BLOCK, {}
+            )
+        elapsed = time.time() - t0
+        assert spy_hier.call_count == 0
+        assert elapsed < 5.0, (
+            f"per-arg took {elapsed:.1f}s — should be instant (early fail-loud "
+            "return), not looping"
+        )
+        assert result.get("per_argument_skipped") is True
+
+
+class TestPerArgNormalPathUntouched:
+    """When arguments ARE available, the per-arg harness still proceeds
+    (recursion fix only changes the 0-args branch). We verify the args are
+    detected; the full plugin path needs an LLM and is covered by the
+    integration harness, not here."""
+
+    def test_multi_block_would_proceed(self):
+        args = ic._extract_arguments_for_parallel(MULTI_BLOCK, {})
+        assert args, "multi-block text yields args → per-arg harness proceeds (not the fix path)"


### PR DESCRIPTION
## Summary

Resolves the real `doc_A` `spectacular`+`full` >2h hang (the descent was ruled out by FB-35 #1121; this is the actual cause).

**Root cause**: `_invoke_hierarchical_fallacy_per_argument` (invoke_callables.py) recursed into `_invoke_hierarchical_fallacy` when `_extract_arguments_for_parallel` returned `[]`. The wide-net "llm" path it re-enters calls THIS harness again, so with no extractable arguments (no state args / no `phase_extract_output` / no `\n\n` paragraph breaks — an encrypted corpus loaded as a single block) it recursed **indefinitely** → the >2h wall-clock sink.

**Fix** (anti-pendule — subtraction, no added cap; anti-theater #1019): return **fail-loud** (`degraded=True` + `last_error`, wide-net result retained by the caller) instead of recursing. Caller labels honestly: `widenet_only_no_perarg_args` + degraded propagation, not `widenet+perarg_union`.

Closes #1123.

## DoD

- [x] **Per-phase instrumentation names the hanging phase (wall-clock evidence).** The "hanging phase" was not a nominal pipeline phase — it was the infinite recursion sitting *between* the wide-net and the per-arg pass. Per-phase instrumentation shows **all 25 nominal phases complete; none hang** (`extract`, `hierarchical_fallacy`, `neural_detect`, `nl_to_logic`, `quality`, `text_to_kb`, `counter`, `fol`, `governance`, `kb_to_tweety`, `modal`, `pl`, `stakes`, `bipolar`, `debate`, `dung_extensions`, `fol_solver`, `jtms`, `modal_solver`, `atms`, `ranking`, `formal_synthesis`, `tweety_interpretation`, `synthesis`, `deep_synthesis`; 3 failed = caught errors, not hangs). The recursion was the wall-clock sink.
- [x] **Root cause fixed fail-loud (no silent timeout-swallow).** Returns `degraded=True` + `last_error`; caller propagates. No `asyncio.wait_for` blanket-kills anything.
- [x] **`spectacular`+`full` completes on `doc_A` within a bounded budget.** Diagnostic (900s ceiling): **COMPLETED in 280.6s** (was >2h pre-fix). `fb36_diag_A_*.json` under `evaluation/results/fb36/`.
- [x] **Latent recursion resolved + unit test.** `'falling back to single-text'` log = 0 (old recursion path never taken); `hierarchical_entries = 2` (legit wide-net calls, not a loop — a true recursion trips `RECURSION_ABORT` at ≥3, which did NOT fire). 6 unit tests (`test_fb36_recursion_fix.py`): trigger condition, no-recursion (spy untouched), fast-not-infinite (regression guard), normal-path untouched.
- [x] **Richness on `doc_B`/`doc_C` unchanged.** Proven by construction: the fix modifies **only** the `if not arguments:` branch of the per-arg harness. A light probe confirms `doc_B`/`doc_C` never take that branch — both extract args via Source 3 (`\n\n` paragraph split) and proceed on the **NORMAL path** (untouched by this fix). Only `doc_A` (single-block, 0 args) hits the fixed branch.

### Path-probe (Source 3 = `\n\n` paragraph split)

| corpus | chars | `\n\n` paragraphs | Source3 args | path taken |
|--------|-------|-------------------|--------------|------------|
| doc_A  | 58K   | 1                 | 0            | **0-args → fail-loud skip** (the fix) |
| doc_B  | 3M    | 38661             | 7            | **NORMAL** (fix untouched) |
| doc_C  | 46K   | 120               | 10           | **NORMAL** (fix untouched) |

Code executed for `doc_B`/`doc_C` is byte-identical before/after this PR → richness unchanged by construction (superior to a costly 3M-char empirical run, which would timeout on corpus size, not the fix).

## Anti-pendule

- ❌ No blanket `asyncio.wait_for` that swallows the error (would hide the bug). Fixed fail-loud at the actual cause.
- ❌ No re-added depth cap (FB-30 #1107 subtracted it on purpose; FB-35 #1121's breaker already bounds cost orthogonally). No `BEAM_*` naming.
- ✅ Diagnostic-first: instrumented, named the cause (recursion, not a phase), fixed that.

## Privacy HARD

Opaque IDs only (`doc_A`/`doc_B`/`doc_C`) in this PR, commits, and the diagnostic JSON. No `raw_text`/source names anywhere. Diagnostic harness references the encrypted dataset path → **untracked** (FB-34/FB-35 precedent); raw outputs gitignored under `evaluation/results/fb36/`. A definitive leak audit confirmed **0/2901 corpus chunks** present un-redacted in the diagnostic log (the harness runs a global redact-filter over overlapping 40-char corpus windows + redacted stdout wrapper + no-full-traceback exception handler).

## Test plan

- [x] `pytest tests/unit/argumentation_analysis/test_fb36_recursion_fix.py -v` → 6 passed
- [x] `mypy --strict argumentation_analysis/orchestration/invoke_callables.py` → Success (the only CI gate)
- [x] Diagnostic `doc_A` spectacular+full → COMPLETED 280.6s (bounded)
- [x] Leak audit → CLEAN (0/2901)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
