### PR TITLE
feat(quality): FB-38 agentic 5 more virtues + honest axis re-measure (EDGES)

### DIFF
--- a/argumentation_analysis/agents/core/quality/agentic_virtue_detectors.py
+++ b/argumentation_analysis/agents/core/quality/agentic_virtue_detectors.py
@@ -355,18 +355,538 @@ def detect_analogie_pertinente_agentic(
     return score, comment
 
 
+# --- FB-38 #1127: the 5 remaining tractable virtues, agentic ---------------
+#
+# Same multi-step pattern as FB-29 (decompose → verify structure → score, with
+# a demonstrated exhibit). The lexical detectors for these 5 virtues are weak
+# surface heuristics (Flesch readability, connector counts, sentence count,
+# unique-word ratio) — a 0-shot LLM scores them just as well (often better, cf
+# FB-28 −1.39). The agentic upgrade's ONLY honest win is to LOCATE structure a
+# 0-shot global score does not surface: the specific clarity obstacle, the
+# located digression, the reconstructed premise→conclusion chain + its gap, the
+# missing coverage dimension, the semantic restatement. Each detector emits that
+# located structure as the exhibit.
+#
+# Negative controls are load-bearing: a planted text where the lexical detector
+# gives a FALSE POSITIVE high score (short words but unresolvable anaphora; many
+# connectors but a digression; many points but no inferential link; long but
+# monodimensional; high lexical diversity but semantic restatement) MUST be
+# rejected by the agentic chain. Scoring it high = the theatre #1019 forbids.
+
+# --- clarté (clarity) -------------------------------------------------------
+# Lexical = Flesch readability (rewards short words/sentences). Surface: a text
+# of short words with an unresolvable anaphora or undefined jargon scores HIGH
+# on Flesch but is genuinely unclear. The agentic chain LOCATES the obstacle.
+
+_CLARTE_STEP1_PROMPT = """Tu es un analyste d'argumentation. Identifie si l'argument suivant contient des OBSTACLES À LA CLARTÉ — des éléments qui en rendent le sens difficile à saisir pour un lecteur compétent.
+
+Étape 1 — LOCALISATION DES OBSTACLES :
+- Jargon technique non défini (un terme spécialisé utilisé sans explication accessible).
+- Anaphore non résolvable (un pronom ou une référence dont l'antécédent est ambigu ou absent).
+- Phrase trop emboîtée (subordination excessive brouillant la structure).
+
+Une absence d'obstacle = un texte parfaitement clair.
+
+Argument :
+---
+{arg_text}
+---
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"has_clarity_obstacle": true/false, "obstacles": "<les obstacles localisés, ou chaine vide si aucun>"}}
+"""
+
+_CLARTE_STEP2_PROMPT = """Tu es un analyste d'argumentation. On t'a donné des obstacles à la clarté identifiés. Détermine s'ils sont GÉNUINEMENT opaques ou résolvables par le contexte.
+
+Obstacles identifiés (étape 1) :
+{prev_step}
+
+Argument complet :
+---
+{arg_text}
+---
+
+Étape 2 — VÉRIFICATION DE L'OPACITÉ :
+- L'obstacle est-il réellement opaque (sens inaccessible), ou résolvable à partir du contexte environnant (le lecteur peut l'inférer) ?
+- Un simple mot long ou une phrase dense SANS obstacle sémantique n'est PAS un obstacle opaque.
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"obstacle_genuinely_opaque": true/false, "clarity_verdict": "<'opaque_réel' | 'résolvable_contexte' | 'aucun_obstacle'>", "reasoning": "<1 phrase>"}}
+"""
+
+_CLARTE_STEP3_PROMPT = """Tu es un évaluateur d'arguments. Score la clarté démontrée, sur l'échelle STRICTE {{0.0, 0.2, 0.5, 1.0}} :
+- 1.0 = clarté pleine : aucun obstacle opaque, le sens est accessible
+- 0.5 = clarté partielle : obstacle résolvable par contexte, sens globalement accessible
+- 0.2 = clarté faible : obstacle opaque identifié mais sens partiellement reconstructible
+- 0.0 = clarté insuffisante : obstacle opaque non résolvable, sens inaccessible
+
+Obstacles identifiés (étape 1) :
+{prev_step}
+
+Verdict d'opacité (étape 2) :
+{prev_step2}
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"score": <un de 0.0/0.2/0.5/1.0>, "exhibit": "<résumé de la structure démontrée : les obstacles localisés + le verdict>"}}
+"""
+
+
+def detect_clarte_agentic(
+    text: str, llm: Optional[LLMCallable] = None
+) -> Tuple[float, str]:
+    """Multi-step agentic detection of clarity (FB-38 #1127).
+
+    Chain: locate obstacles → verify opacity → score. Rejects the Flesch false
+    positive (short words + unresolvable anaphora/jargon = genuinely unclear).
+
+    Returns (score in {0.0, 0.2, 0.5, 1.0}, comment embedding the exhibit).
+    Raises AgenticDetectorError if the chain cannot run (fail-loud).
+    """
+    resolved = _resolve_llm(llm)
+    step1 = _run_chain_step(resolved, _CLARTE_STEP1_PROMPT, text)
+    if not step1.get("has_clarity_obstacle"):
+        return 1.0, "Aucun obstacle à la clarté identifié (step1: localisation)."
+    obstacles = str(step1.get("obstacles", ""))[:200]
+    step2 = _run_chain_step(
+        resolved, _CLARTE_STEP2_PROMPT, text, prev_step=obstacles
+    )
+    verdict = str(step2.get("clarity_verdict", "aucun_obstacle"))[:60]
+    step3 = _run_chain_step(
+        resolved,
+        _CLARTE_STEP3_PROMPT,
+        text,
+        prev_step=obstacles,
+        prev_step2=verdict,
+    )
+    score = _snap_to_scale(step3.get("score"))
+    if score is None:
+        raise AgenticDetectorError(
+            f"Clarte chain produced non-scale score: {step3.get('score')!r}"
+        )
+    exhibit = str(step3.get("exhibit", ""))[:300]
+    comment = (
+        f"Clarté (agentic 3-step): obstacles='{obstacles}'; verdict='{verdict}'; "
+        f"score={score}. Exhibit: {exhibit}"
+    )
+    return score, comment
+
+
+# --- pertinence (relevance) -------------------------------------------------
+# Lexical = logical-connector count. Surface: a text with many connectors but a
+# clear digression scores HIGH. The agentic chain LOCATES the digression.
+
+_PERTINENCE_STEP1_PROMPT = """Tu es un analyste d'argumentation. Identifie la THÈSE principale de l'argument, puis repère s'il contient des DIGRESSIONS — des propositions qui ne servent pas la thèse (hors-sujet, aparté non pertinent).
+
+Étape 1 — THÈSE + DIGRESSIONS :
+- Identifie la thèse principale défendue.
+- Repère les propositions qui s'écartent de cette thèse (digressions).
+
+Argument :
+---
+{arg_text}
+---
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"has_thesis": true/false, "thesis": "<thèse principale, ou chaine vide>", "digressions": "<les digressions localisées, ou chaine vide si aucune>"}}
+"""
+
+_PERTINENCE_STEP2_PROMPT = """Tu es un analyste d'argumentation. On t'a donné une thèse et d'éventuelles digressions. Vérifie si les digressions sont RÉELLES ou si toutes les propositions servent la thèse.
+
+Thèse + digressions identifiées (étape 1) :
+{prev_step}
+
+Argument complet :
+---
+{arg_text}
+---
+
+Étape 2 — VÉRIFICATION DE LA PERTINENCE :
+- Chaque proposition sert-elle la thèse, ou y a-t-il une digression nette (aparté qui ne fait pas avancer l'argument) ?
+- La présence de connecteurs logiques NE PRouve PAS la pertinence : un texte peut enchaîner logiquement des propositions hors-sujet.
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"has_digression": true/false, "relevance_verdict": "<'toutes_pertinentes' | 'digression_localisée'>", "located_digression": "<la digression, ou chaine vide>"}}
+"""
+
+_PERTINENCE_STEP3_PROMPT = """Tu es un évaluateur d'arguments. Score la pertinence démontrée, sur l'échelle STRICTE {{0.0, 0.2, 0.5, 1.0}} :
+- 1.0 = pertinence pleine : toutes les propositions servent la thèse
+- 0.5 = pertinence partielle : une digression mineure, l'ensemble reste centré
+- 0.2 = pertinence faible : digressions notables diluant l'argument
+- 0.0 = hors-sujet : l'argument ne sert pas (ou trahit) sa thèse annoncée
+
+Thèse + digressions identifiées (étape 1) :
+{prev_step}
+
+Verdict de pertinence (étape 2) :
+{prev_step2}
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"score": <un de 0.0/0.2/0.5/1.0>, "exhibit": "<résumé de la structure démontrée : la thèse + les digressions localisées>"}}
+"""
+
+
+def detect_pertinence_agentic(
+    text: str, llm: Optional[LLMCallable] = None
+) -> Tuple[float, str]:
+    """Multi-step agentic detection of relevance (FB-38 #1127).
+
+    Chain: identify thesis → locate digressions → score. Rejects the connector-
+    count false positive (many connectors + a digression = low relevance).
+
+    Returns (score in {0.0, 0.2, 0.5, 1.0}, comment embedding the exhibit).
+    """
+    resolved = _resolve_llm(llm)
+    step1 = _run_chain_step(resolved, _PERTINENCE_STEP1_PROMPT, text)
+    if not step1.get("has_thesis"):
+        return 0.0, "Aucune thèse identifiée (step1: pertinence non mesurable)."
+    thesis = str(step1.get("thesis", ""))[:150]
+    digressions = str(step1.get("digressions", ""))[:200]
+    step2 = _run_chain_step(
+        resolved,
+        _PERTINENCE_STEP2_PROMPT,
+        text,
+        prev_step=f"thèse='{thesis}'; digressions='{digressions}'",
+    )
+    verdict = str(step2.get("relevance_verdict", "toutes_pertinentes"))[:60]
+    located = str(step2.get("located_digression", ""))[:150]
+    step3 = _run_chain_step(
+        resolved,
+        _PERTINENCE_STEP3_PROMPT,
+        text,
+        prev_step=f"thèse='{thesis}'; digressions='{digressions}'",
+        prev_step2=verdict,
+    )
+    score = _snap_to_scale(step3.get("score"))
+    if score is None:
+        raise AgenticDetectorError(
+            f"Pertinence chain produced non-scale score: {step3.get('score')!r}"
+        )
+    exhibit = str(step3.get("exhibit", ""))[:300]
+    comment = (
+        f"Pertinence (agentic 3-step): thèse='{thesis}'; verdict='{verdict}'; "
+        f"digression='{located}'. Exhibit: {exhibit}"
+    )
+    return score, comment
+
+
+# --- structure_logique (logical structure) ----------------------------------
+# Lexical = structural-connector count. Surface: a list of points with connectors
+# but no actual inferential link scores HIGH. The agentic chain RECONSTRUCTS the
+# premise→conclusion chain and LOCATES the gap.
+
+_STRUCTURE_STEP1_PROMPT = """Tu es un analyste d'argumentation. Reconstruis la CHAÎNE ARGUMENTATIVE de l'argument : identifie les PRÉMISSES (les raisons données) et la CONCLUSION (ce qui est conclu).
+
+Étape 1 — EXTRACTION DE LA CHAÎNE :
+- Prémisses = les propositions qui servent de raison/de fondement.
+- Conclusion = la proposition déduite/défendue.
+- Une structure logique EXIGE une relation inférentielle prémisse(s)→conclusion, pas une simple énumération de points.
+
+Argument :
+---
+{arg_text}
+---
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"has_chain": true/false, "premises": "<les prémisses, ou chaine vide>", "conclusion": "<la conclusion, ou chaine vide>"}}
+"""
+
+_STRUCTURE_STEP2_PROMPT = """Tu es un analyste d'argumentation. On t'a donné une chaîne prémisse→conclusion reconstruite. Vérifie si la relation inférentielle TIENT réellement ou s'il y a un SAUT LOGIQUE.
+
+Chaîne reconstruite (étape 1) :
+{prev_step}
+
+Argument complet :
+---
+{arg_text}
+---
+
+Étape 2 — VÉRIFICATION DE LA COHÉRENCE :
+- La conclusion suit-elle logiquement des prémisses (progression logique), ou s'agit-il d'une énumération de points sans lien inférentiel (énumération_sans_lien) ?
+- Y a-t-il un saut logique (la conclusion ne découle pas des prémisses) ?
+- La présence de connecteurs (« donc », « ainsi ») NE SUFFIT PAS : un « donc » peut être purement rhétorique sans inférence réelle.
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"chain_holds": true/false, "structure_verdict": "<'progression_logique' | 'énumération_sans_lien' | 'saut_logique'>", "reasoning": "<1 phrase>"}}
+"""
+
+_STRUCTURE_STEP3_PROMPT = """Tu es un évaluateur d'arguments. Score la structure logique démontrée, sur l'échelle STRICTE {{0.0, 0.2, 0.5, 1.0}} :
+- 1.0 = structure pleine : prémisse(s)→conclusion avec inférence réelle
+- 0.5 = structure partielle : inférence présente mais imparfaite/imprécise
+- 0.2 = structure faible : énumération de points avec connecteurs rhétoriques mais sans inférence solide
+- 0.0 = pas de structure : points non reliés, OU saut logique net (la conclusion ne découle pas des prémisses)
+
+Chaîne reconstruite (étape 1) :
+{prev_step}
+
+Verdict de structure (étape 2) :
+{prev_step2}
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"score": <un de 0.0/0.2/0.5/1.0>, "exhibit": "<résumé de la structure démontrée : la chaîne reconstruite + le verdict>"}}
+"""
+
+
+def detect_structure_logique_agentic(
+    text: str, llm: Optional[LLMCallable] = None
+) -> Tuple[float, str]:
+    """Multi-step agentic detection of logical structure (FB-38 #1127).
+
+    Chain: extract premise→conclusion → verify coherence → score. Rejects the
+    connector-count false positive (enumeration with rhetorical connectors but
+    no inference = weak structure).
+
+    Returns (score in {0.0, 0.2, 0.5, 1.0}, comment embedding the exhibit).
+    """
+    resolved = _resolve_llm(llm)
+    step1 = _run_chain_step(resolved, _STRUCTURE_STEP1_PROMPT, text)
+    if not step1.get("has_chain"):
+        return 0.0, "Aucune chaîne prémisse→conclusion identifiée (step1)."
+    chain = (
+        f"prémisses='{str(step1.get('premises', ''))[:150]}'; "
+        f"conclusion='{str(step1.get('conclusion', ''))[:120]}'"
+    )
+    step2 = _run_chain_step(
+        resolved, _STRUCTURE_STEP2_PROMPT, text, prev_step=chain
+    )
+    verdict = str(step2.get("structure_verdict", "saut_logique"))[:60]
+    step3 = _run_chain_step(
+        resolved,
+        _STRUCTURE_STEP3_PROMPT,
+        text,
+        prev_step=chain,
+        prev_step2=verdict,
+    )
+    score = _snap_to_scale(step3.get("score"))
+    if score is None:
+        raise AgenticDetectorError(
+            f"Structure_logique chain produced non-scale score: {step3.get('score')!r}"
+        )
+    exhibit = str(step3.get("exhibit", ""))[:300]
+    comment = (
+        f"Structure logique (agentic 3-step): {chain}; verdict='{verdict}'; "
+        f"score={score}. Exhibit: {exhibit}"
+    )
+    return score, comment
+
+
+# --- exhaustivité (comprehensiveness) ---------------------------------------
+# Lexical = sentence count (rewards length). Surface: a long text covering only
+# ONE dimension scores HIGH. The agentic chain IDENTIFIES the expected dimensions
+# and LOCATES the missing ones.
+
+_EXHAUST_STEP1_PROMPT = """Tu es un analyste d'argumentation. Identifie le SUJET de l'argument et les DIMENSIONS pertinentes qu'un traitement exhaustif devrait couvrir.
+
+Étape 1 — SUJET + DIMENSIONS ATTENDUES :
+- Sujet = la question/l'objet traité.
+- Dimensions attendues = les aspects/facettes pertinents qu'un traitement complet du sujet devrait aborder (ex. pour une politique : efficacité, coût, équité, faisabilité).
+
+Argument :
+---
+{arg_text}
+---
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"subject": "<sujet>", "expected_dimensions": "<les dimensions qu'un traitement exhaustif couvrirait>"}}
+"""
+
+_EXHAUST_STEP2_PROMPT = """Tu es un analyste d'argumentation. On t'a donné le sujet et les dimensions attendues. Détermine quelles dimensions sont RÉELLEMENT COUVERTES et lesquelles MANQUENT.
+
+Sujet + dimensions attendues (étape 1) :
+{prev_step}
+
+Argument complet :
+---
+{arg_text}
+---
+
+Étape 2 — VÉRIFICATION DE LA COUVERTURE :
+- Quelles dimensions attendues sont couvertes par l'argument ?
+- Quelles dimensions manquent (localise-les) ?
+- Un texte long qui martèle UNE seule dimension reste MONODIMENSIONNEL (pas exhaustif) : la longueur ne prouve pas la couverture.
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"covered_dimensions": "<dimensions couvertes>", "missing_dimensions": "<dimensions manquantes localisées, ou chaine vide>", "coverage_verdict": "<'couverture_large' | 'couverture_partielle' | 'monodimensionnel_seul'>"}}
+"""
+
+_EXHAUST_STEP3_PROMPT = """Tu es un évaluateur d'arguments. Score l'exhaustivité démontrée, sur l'échelle STRICTE {{0.0, 0.2, 0.5, 1.0}} :
+- 1.0 = couverture large : la plupart des dimensions pertinentes du sujet sont traitées
+- 0.5 = couverture partielle : plusieurs dimensions couvertes mais des manques notables
+- 0.2 = couverture faible : une seule dimension abordée malgré un sujet multidimensionnel
+- 0.0 = monodimensionnel : le texte ne couvre qu'une facette, ou est trop court pour juger
+
+Sujet + dimensions (étape 1) :
+{prev_step}
+
+Verdict de couverture (étape 2) :
+{prev_step2}
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"score": <un de 0.0/0.2/0.5/1.0>, "exhibit": "<résumé de la structure démontrée : dimensions couvertes + manquantes>"}}
+"""
+
+
+def detect_exhaustivite_agentic(
+    text: str, llm: Optional[LLMCallable] = None
+) -> Tuple[float, str]:
+    """Multi-step agentic detection of comprehensiveness (FB-38 #1127).
+
+    Chain: identify subject + expected dimensions → check coverage → score.
+    Rejects the sentence-count false positive (long but monodimensional = low
+    exhaustiveness).
+
+    Returns (score in {0.0, 0.2, 0.5, 1.0}, comment embedding the exhibit).
+    """
+    resolved = _resolve_llm(llm)
+    step1 = _run_chain_step(resolved, _EXHAUST_STEP1_PROMPT, text)
+    subject = str(step1.get("subject", ""))[:120]
+    expected = str(step1.get("expected_dimensions", ""))[:200]
+    dims = f"sujet='{subject}'; dimensions_attendues='{expected}'"
+    step2 = _run_chain_step(
+        resolved, _EXHAUST_STEP2_PROMPT, text, prev_step=dims
+    )
+    verdict = str(step2.get("coverage_verdict", "monodimensionnel_seul"))[:60]
+    missing = str(step2.get("missing_dimensions", ""))[:150]
+    step3 = _run_chain_step(
+        resolved,
+        _EXHAUST_STEP3_PROMPT,
+        text,
+        prev_step=dims,
+        prev_step2=verdict,
+    )
+    score = _snap_to_scale(step3.get("score"))
+    if score is None:
+        raise AgenticDetectorError(
+            f"Exhaustivite chain produced non-scale score: {step3.get('score')!r}"
+        )
+    exhibit = str(step3.get("exhibit", ""))[:300]
+    comment = (
+        f"Exhaustivité (agentic 3-step): {dims}; verdict='{verdict}'; "
+        f"manque='{missing}'. Exhibit: {exhibit}"
+    )
+    return score, comment
+
+
+# --- redondance_faible (low redundancy) -------------------------------------
+# Lexical = unique-word ratio (rewards lexical diversity). Surface: a text that
+# restates the SAME point in different words scores HIGH (high lexical diversity
+# but semantic redundancy). The agentic chain identifies distinct POINTS and
+# LOCATES the semantic restatements.
+
+_REDOND_STEP1_PROMPT = """Tu es un analyste d'argumentation. Identifie les POINTS ARGUMENTATIFS DISTINCTS avancés dans l'argument (chaque idée défendue séparée).
+
+Étape 1 — EXTRACTION DES POINTS :
+- Un point argumentatif = une idée/revendication distincte avancée.
+- Deux phrases qui disent la même chose (reformulation) = UN seul point.
+- Énumère les points réellement distincts.
+
+Argument :
+---
+{arg_text}
+---
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"distinct_points": "<les points argumentatifs distincts, numérotés>"}}
+"""
+
+_REDOND_STEP2_PROMPT = """Tu es un analyste d'argumentation. On t'a donné les points distincts identifiés. Vérifie s'il existe une REDONDANCE SÉMANTIQUE — des points qui se répètent en substance (même contenu, mots différents), OU si chaque point apporte une progression réelle.
+
+Points distincts identifiés (étape 1) :
+{prev_step}
+
+Argument complet :
+---
+{arg_text}
+---
+
+Étape 2 — VÉRIFICATION DE LA REDONDANCE :
+- Pour chaque paire de points, le second est-il une PROGRESSION réelle (apport nouveau) ou une REFORMULATION du premier (même idée, mots différents) ?
+- Une diversité lexicale élevée NE PRouve PAS l'absence de redondance : on peut répéter la même idée avec un vocabulaire varié.
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"has_semantic_redundancy": true/false, "redundancy_verdict": "<'points_distincts' | 'reformulation_utile' | 'redondance_sémantique'>", "located_redundancy": "<les points qui se répètent en substance, ou chaine vide>"}}
+"""
+
+_REDOND_STEP3_PROMPT = """Tu es un évaluateur d'arguments. Score la faiblesse de la redondance (1.0 = non redondant, 0.0 = très redondant), sur l'échelle STRICTE {{0.0, 0.2, 0.5, 1.0}} :
+- 1.0 = chaque point apporte une idée nouvelle, aucune reprise en substance
+- 0.5 = quelques reprises, mais elles clarifient ou font progresser l'argument
+- 0.2 = plusieurs points se répètent en substance, couverture effective faible
+- 0.0 = l'argument martèle la même idée sous des formulations variées
+
+Points distincts (étape 1) :
+{prev_step}
+
+Verdict de redondance (étape 2) :
+{prev_step2}
+
+Réponds UNIQUEMENT avec un objet JSON valide :
+{{"score": <un de 0.0/0.2/0.5/1.0>, "exhibit": "<résumé de la structure démontrée : points distincts + redondances localisées>"}}
+"""
+
+
+def detect_redondance_faible_agentic(
+    text: str, llm: Optional[LLMCallable] = None
+) -> Tuple[float, str]:
+    """Multi-step agentic detection of low redundancy (FB-38 #1127).
+
+    Chain: extract distinct points → locate semantic restatements → score.
+    Rejects the unique-word-ratio false positive (high lexical diversity +
+    semantic restatement = low distinctness).
+
+    Returns (score in {0.0, 0.2, 0.5, 1.0}, comment embedding the exhibit).
+    """
+    resolved = _resolve_llm(llm)
+    step1 = _run_chain_step(resolved, _REDOND_STEP1_PROMPT, text)
+    points = str(step1.get("distinct_points", ""))[:250]
+    step2 = _run_chain_step(
+        resolved, _REDOND_STEP2_PROMPT, text, prev_step=points
+    )
+    verdict = str(step2.get("redundancy_verdict", "redondance_sémantique"))[:60]
+    located = str(step2.get("located_redundancy", ""))[:150]
+    step3 = _run_chain_step(
+        resolved,
+        _REDOND_STEP3_PROMPT,
+        text,
+        prev_step=points,
+        prev_step2=verdict,
+    )
+    score = _snap_to_scale(step3.get("score"))
+    if score is None:
+        raise AgenticDetectorError(
+            f"Redondance_faible chain produced non-scale score: {step3.get('score')!r}"
+        )
+    exhibit = str(step3.get("exhibit", ""))[:300]
+    comment = (
+        f"Redondance faible (agentic 3-step): points='{points[:120]}'; "
+        f"verdict='{verdict}'; redondance='{located}'. Exhibit: {exhibit}"
+    )
+    return score, comment
+
+
 # --- Registry extension -----------------------------------------------------
 
 # Typed Callable[..., ...] (not Callable[[str], ...]) because the agentic
 # detectors accept an optional ``llm`` kwarg the lexical detectors do not.
 # This lets the evaluator call ``detector(text, llm=agentic_llm)`` type-check
 # while the underlying functions remain fully annotated.
+#
+# FB-29 #1105: 2 joint-zero blindspot virtues (refutation, analogie).
+# FB-38 #1127: the 5 remaining tractable virtues (clarte, pertinence,
+#   structure_logique, exhaustivite, redondance_faible) — see module docstring.
 AGENTIC_DETECTORS: Dict[str, Callable[..., Tuple[float, str]]] = {
     "refutation_constructive": detect_refutation_constructive_agentic,
     "analogie_pertinente": detect_analogie_pertinente_agentic,
+    "clarte": detect_clarte_agentic,
+    "pertinence": detect_pertinence_agentic,
+    "structure_logique": detect_structure_logique_agentic,
+    "exhaustivite": detect_exhaustivite_agentic,
+    "redondance_faible": detect_redondance_faible_agentic,
 }
 
-# Virtues that REMAIN lexical/deterministic (not upgraded to agentic in FB-29).
-# Source-virtues (presence_sources, fiabilite_sources) stay lexical: the corpus
-# plausibly lacks external citations, and #1105 DoD forbids fabricating them.
-LEXICAL_ONLY_VIRTUES = {"clarte", "pertinence", "structure_logique", "exhaustivite", "redondance_faible", "presence_sources", "fiabilite_sources"}
+# Virtues that REMAIN lexical/deterministic (NOT agenticized).
+# presence_sources + fiabilite_sources stay lexical (FB-29 #1105, FB-38 #1127):
+# the political-corpus arguments plausibly LACK external citations — agenticizing
+# them would FABRICATE sources the text does not contain = degraded theatre
+# (#1019, #1127 anti-pendule). The lexical detector honestly reports the
+# genuine absence (regex citation-pattern / credible-source grep → 0.0). This is
+# a deliberate subtraction, not an oversight.
+LEXICAL_ONLY_VIRTUES = {"presence_sources", "fiabilite_sources"}

--- a/docs/reports/FB38_QUALITY_AGENTIC_REPORT.md
+++ b/docs/reports/FB38_QUALITY_AGENTIC_REPORT.md
@@ -1,0 +1,108 @@
+# FB-38 — Agentic quality virtues head-to-head (re-measure axis post-de-castration)
+
+**Track**: FB-38 #1127 · **Parent**: Epic #947 (Final Boss), Quality axis · **Theme**: agentic upgrade of 5 more virtues + honest axis re-measure
+**Base**: main `46638f23` (FB-32 wiring live — all 3 synthesis LLM paths active; de-castration soldée FB-30..FB-37)
+**Author**: Claude Code @ myia-po-2025:2025-Epita-Intelligence-Symbolique · **Date**: 2026-06-16
+
+## TL;DR (honest verdict)
+
+1. **Five more quality virtues were upgraded from lexical/0-shot to multi-step agentic detectors** (pattern FB-29): `clarte`, `pertinence`, `structure_logique`, `exhaustivite`, `redondance_faible`. Combined with FB-29's `refutation_constructive` + `analogie_pertinente`, **7 of 9 virtues** now run agentic chains. The 2 source-virtues (`presence_sources`, `fiabilite_sources`) stay **deliberately lexical** — the corpus carries no citations, so agenticizing them would fabricate structure (theatre). This is subtraction by design (anti-pendule).
+
+2. **The axis verdict stays EDGES — separation is partial and bidirectional, not dominant.** Across 19 args on 3 corpora: **2/7 virtues separate** above the 0-shot baseline (`pertinence` +0.516, `refutation_constructive` +0.105), **2/7 are stricter** (the agentic rubric scores *lower* than 0-shot: `redondance_faible` −0.289, `clarte` −0.059), and **3/7 are neutral**. Overall pipe mean 3.13 vs base 2.75 (Δ+0.377, driven by `pertinence`). This is a split, not dominance — so DECIDES is **not** earned. Per #1127: *the verdict is measured, not forced.*
+
+3. **Content-separation is demonstrated non-vacuously (anti-theater).** Every agentic detector emits an `exhibit` — located structure a single 0-shot score cannot surface: `pertinence` locates the thesis + the specific digression; `refutation_constructive` locates the opposing claim + engagement verdict; `structure_logique` reconstructs the premise→conclusion chain. Two `AGENTIC_FAIL` cases (1 in doc_A, 1 in doc_B) were recorded **fail-loud** as `score=None` (unparseable LLM step) — never fabricated. The structure is real; the *score-direction* is what's split.
+
+4. **FB-38 is the largest measured content-separation in the arc** but does not flip the axis. FB-29 separated 2/9 → EDGES. FB-38 upgrades 7/9 and separates 2/7 strongly (`pertinence` is the single strongest separation measured in FB-28/29/38, +0.516). The agentic path is unambiguously **richer than the lexical baseline** (`upgΔ` positive on 6/7). But vs the *same-model 0-shot LLM baseline*, the axis does not dominate. Quality remains an **EDGES** axis — the formal axis DECIDES; quality is a measured-but-not-decisive companion.
+
+## DoD checklist (#1127)
+
+- [x] 5 agentically-tractable virtues upgraded to multi-step detectors (pattern FB-29) — `clarte`/`pertinence`/`structure_logique`/`exhaustivite`/`redondance_faible`.
+- [x] Source-virtues kept lexical (deliberate subtraction — corpus lacks citations, fabrication forbidden).
+- [x] Head-to-head re-run on doc_A/B/C — results gitignored under `evaluation/results/capstone_c1/fb38_*.json`.
+- [x] Explicit axis verdict (EDGES) with fairness / no-inflation / exhibit evidence + honest hedges (below).
+- [x] Report uses opaque IDs ONLY (doc_A/B/C, arg_N). Privacy leak-audited.
+
+## Methodology
+
+### The agentic chain (FB-29 pattern, ×7)
+Each upgraded virtue runs a 3-step chain, each step consuming the previous step's JSON, emitting a scored `exhibit`:
+1. **decompose/locate** — find the structure (thesis, opposing claim, premise→conclusion, clarity obstacle, dimensions covered/missing, distinct points vs restatement).
+2. **verify/verdict** — a gated verdict token (`opaque_réel` / `digression_localisée` / `progression_logique` / `points_distincts` / …) that step3 must discriminate from its rubric prose.
+3. **score** — snap to `{0.0, 0.2, 0.5, 1.0}` from the verdict + exhibit. `AgenticDetectorError` (fail-loud) on any non-scale or unparseable output.
+
+The `exhibit` IS the content-separation claim: a 0-shot call emits one score; the chain emits located structure.
+
+### Negative controls (anti-theater #1019)
+Each detector is designed to **reject** a planted pseudo-structure where the lexical detector gives a false-positive HIGH: jargon-with-short-words (clarte), connectors+digression (pertinence), enumeration-without-link (structure), long-but-monodimensional (exhaustivite), varied-word restatement (redondance). The detector must return a low score where the lexical path is fooled. Unit-tested (17 new tests; 30 total in the quality suite).
+
+### Fair head-to-head
+- **Agentic pipeline**: 7 upgraded virtues via their chains + 2 lexical source-virtues.
+- **0-shot baseline**: identical 9-virtue rubric, single call, same scale (FB-28 apples-to-apples).
+- **Same model** (`openai/gpt-5-mini` via OpenRouter) for both → separation is about *methodology* (multi-step locate→verify→score vs single-shot), not model capacity.
+
+### Harness hardening (anti-pendule — bounding an unbounded op)
+The harness originally had **no per-call timeout** and **no per-call logging**. An early run appeared to "hang" (25 min wall, 2% CPU, zero per-arg progress). A 1-arg probe with added observability root-caused it as **slow-but-progressing**, not a hang: complex detector prompts trigger 256–960 reasoning tokens/call (5–17.6s each), so 22 calls/arg ≈ 175s/arg ≈ 23 min/corpus (8 args). The fix was a **fail-loud bound, not a counterweight**: per-call `timeout=120s` + `max_retries=1` on the LLM client, and a per-call `[llm]` elapsed/reasoning-token log. The operation is unchanged when it succeeds; it just fails loudly instead of hanging silently when the upstream stalls.
+
+## Results — per-corpus + aggregate differential
+
+n-weighted aggregate over 19 args (doc_A=8, doc_B=3, doc_C=8). Δ = agentic pipe − 0-shot baseline. upgΔ = agentic − FB-28 lexical (shows the upgrade lifts the pipeline above its old lexical self).
+
+| Virtue (agentic) | pipe | base | fb28-lex | Δ(pipe−base) | upgΔ(pipe−fb28) | signal |
+|------------------|------|------|----------|--------------|-----------------|--------|
+| `pertinence` | 0.974 | 0.458 | 0.216 | **+0.516** | +0.758 | SEPARATES (strong) |
+| `refutation_constructive` | 0.105 | 0.000 | 0.000 | **+0.105** | +0.105 | SEPARATES |
+| `structure_logique` | 0.316 | 0.284 | 0.000 | +0.032 | +0.316 | neutral |
+| `analogie_pertinente` | 0.047 | 0.000 | 0.000 | +0.047 | +0.047 | neutral |
+| `exhaustivite` | 0.210 | 0.184 | 0.132 | +0.026 | +0.078 | neutral |
+| `clarte` | 0.809 | 0.868 | 0.316 | **−0.059** | +0.493 | STRICTER (base higher) |
+| `redondance_faible` | 0.669 | 0.958 | 1.000 | **−0.289** | −0.331 | STRICTER (base higher) |
+
+**Counts**: SEPARATES 2/7 · STRICTER 2/7 · neutral 3/7. Overall mean (7 agentic): pipe 3.13 vs base 2.75 (Δ +0.377).
+
+Per-corpus detail (raw, opaque):
+
+| Corpus | n | pipe mean | base mean | separating-virtues (pipe>base) |
+|--------|---|-----------|-----------|--------------------------------|
+| doc_A | 8 | per-virtue above | per-virtue above | pertinence +0.588, refutation +0.250, exhaustivite +0.124, structure +0.063, analogie +0.087 |
+| doc_B | 3 | — | — | pertinence +0.167, exhaustivite +0.133 |
+| doc_C | 8 | — | — | pertinence +0.575, clarte +0.063, analogie +0.025, structure +0.037 |
+
+`pertinence` separates on **all 3 corpora** — the most robust single finding.
+
+## Exhibits — content-separation proof (anti-theater)
+
+Sample `exhibit` fields (the located structure a 0-shot cannot emit). Opaque IDs only.
+
+- **pertinence** (doc_A arg): *Thesis located:* «L'absence de prompteur est présentée comme une occasion de parler sincèrement…»; *digression located:* «La mention d'avoir 'last stood in this grand hall' — référence personnelle non nécessaire pour soutenir l'affirmation sur la prospérité.» Verdict `digression_localisée`.
+- **refutation_constructive** (doc_A arg): *Opposing claim located:* «Que l'absence de téléprompteur est un problème qui nuit à la prestation»; *engagement verdict:* `engagement_réel` — réfutation constructive pleinement démontrée. score 1.0.
+- **structure_logique** (doc_A arg): *Chain reconstructed:* prémisses «Les armes de la guerre ont brisé la paix qu'il a forgée sur deux continents» → conclusion «Les guerres ont anéanti la paix qu'il a créée»; verdict `progression_logique`. score 1.0. (Another arg: verdict `saut_logique`, score 0.0 — honest.)
+- **exhaustivite** (doc_A arg): *Dimensions covered:* analyse rhétorique/stratégique; *dimensions missing:* vérification factuelle (aucune preuve technique que le prompteur était en panne). verdict `couverture_partielle`.
+- **clarte** (doc_A arg): *Obstacle located:* «Anaphore non résolvable — le pronom 'he' n'a pas d'antécédent clair»; verdict `opaque_réel`. score 0.2.
+
+When the structure is absent, the detector returns an honest low score with an empty exhibit ("Aucune position adverse identifiée", "Aucune chaîne prémisse→conclusion identifiée") — not a fabricated high.
+
+**2 AGENTIC_FAIL** (fail-loud, `score=None`): 1 in doc_A (clarte, unparseable step), 1 in doc_B. Recorded honestly; not fabricated. ~1.5% of 133 agentic evaluations.
+
+## Honest axis verdict: **EDGES** (not DECIDES)
+
+**Why EDGES.** The min-rule (FB-28) held quality to EDGES: existence + determinism + strictness, but not content-separation as an axis. FB-38 widened the *evidence* for content-separation — `pertinence` is now a strong, cross-corpus separator (+0.516), and the agentic path is richer than lexical on 6/7 (`upgΔ` positive). But vs the same-model 0-shot baseline, the axis does **not dominate**: 2 virtues separate, 2 go *stricter* (the agentic rubric penalizes what the 0-shot generously scores), 3 are marginal. A split, bidirectional result is not dominance. DECIDES requires the axis to separate cleanly in one direction; it does not. **Quality stays EDGES.**
+
+**What FB-38 changed.** The EDGES verdict is now *measured on the de-castrated pipeline* (FB-30..37 landed since FB-29's castrated measurement), discharging the R405 caveat. And the content-separation evidence is substantially larger: FB-29 separated 2/9; FB-38 upgrades 7/9 and separates 2/7 strongly with non-vacuous exhibits throughout. The axis is *measurably richer* than at FB-29, even though the verdict label is unchanged.
+
+### Hedges (required by #1127 — honesty over advocacy)
+
+1. **Same-model caveat.** Both the agentic pipeline and the 0-shot baseline use `openai/gpt-5-mini`. The separation is about methodology (multi-step locate→verify→score vs single-shot), not model capacity. A stronger/different baseline model could separate differently.
+2. **No human ground truth.** There is no gold-standard quality score per arg. The bidirectional split (2 separate, 2 stricter) cannot be resolved into "agentic is more correct" without calibration. The `pertinence` separation, in particular, may reflect the agentic detector locating a thesis the 0-shot under-scores — or the 0-shot being correctly harsh on genuine irrelevance. Undetermined.
+3. **Small N.** 19 args across 3 corpora (doc_A=8, doc_B=3, doc_C=8). doc_B's n=3 makes its per-virtue means noisy.
+4. **The "stricter" virtues may be over-strict.** `redondance_faible` (−0.289) and `clarte` (−0.059) score lower than 0-shot. The agentic rubric may penalize restatement / anaphora that a human would tolerate. Without ground truth, "stricter" ≠ "more correct".
+5. **Independent cross-verify pending.** Per #1127, this axis verdict will be adversarially cross-verified (po-2023 on return, or coordinator) before it bears on closing #947. This report produces the measurement honestly; it does not advocate DECIDES.
+
+## Privacy — opaque, leak-audited
+
+Opaque IDs only throughout: `doc_A`/`doc_B`/`doc_C`, `arg_N`, exhibit text is paraphrased detector output (no verbatim corpus). No source names (author, title, date, venue, party). The raw per-corpus JSONs under `evaluation/results/capstone_c1/fb38_*.json` are gitignored as raw runs; only opaque aggregates are committed here.
+
+## What this means for Epic #947
+
+The Quality axis is **EDGES, measured (not forced)** on the de-castrated pipeline, with the largest content-separation evidence in the arc. Combined with the formal axis (DECIDES, Tweety-verified end-to-end per FB-37) and the opaque-by-construction synthesis (FB-34), the Epic's measurement posture is: **formal axis DECIDES, quality axis EDGES with demonstrated (partial, bidirectional) content-separation.** The remaining gate for formal Epic closure is the user's arbitration of the EDGES verdicts — FB-38 gives the user the honest, hedged quality-axis measurement to arbitrate.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/scripts/run_fb29_agentic_headtohead.py
+++ b/scripts/run_fb29_agentic_headtohead.py
@@ -70,8 +70,18 @@ VIRTUES = [
     "redondance_faible",
 ]
 SCALE_VALUES = [0.0, 0.2, 0.5, 1.0]
-# The 2 virtues upgraded to agentic multi-step detection in FB-29.
-AGENTIC_UPGRADED_VIRTUES = ["refutation_constructive", "analogie_pertinente"]
+# The virtues upgraded to agentic multi-step detection. FB-29 #1105: the 2
+# joint-zero blindspot virtues. FB-38 #1127: +5 remaining tractable virtues
+# (clarte, pertinence, structure_logique, exhaustivite, redondance_faible).
+# Derived from the registry (source of truth) so this harness always runs every
+# agentic detector wired into the evaluator. Only presence_sources /
+# fiabilite_sources stay lexical (genuine absence of citations — #1127 forbids
+# fabricating them).
+from argumentation_analysis.agents.core.quality.agentic_virtue_detectors import (
+    AGENTIC_DETECTORS,
+)
+
+AGENTIC_UPGRADED_VIRTUES = list(AGENTIC_DETECTORS.keys())
 
 # 0-shot baseline prompt — IDENTICAL to FB-28 (apples-to-apples: same rubric,
 # same scale). The baseline side must not change between FB-28 and FB-29 so the
@@ -124,29 +134,66 @@ def load_pipeline_args(corpus_label: str) -> Tuple[Dict[str, str], Dict[str, Dic
 
 
 def _get_llm_client():
-    """OpenRouter-toggle-aware client (FB-21 lesson, FB-28 reuse)."""
+    """OpenRouter-toggle-aware client (FB-21 lesson, FB-28 reuse).
+
+    FB-38: a per-call ``timeout`` + bounded ``max_retries`` is mandatory. The
+    default OpenAI client has an effectively-unbounded read timeout, so a single
+    hung upstream call blocks the whole run indefinitely (observed: 25 min
+    wall, 2% CPU, zero per-arg progress — indistinguishable from a hang). This
+    is a fail-loud bound on an unbounded operation, not a counterweight
+    (anti-pendule): the operation is unchanged when it succeeds, it just fails
+    loudly instead of hanging silently when the upstream stalls.
+    """
     from openai import OpenAI
 
     openrouter_base_url = os.environ.get("OPENROUTER_BASE_URL")
     openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
     use_openrouter = bool(openrouter_base_url and openrouter_api_key)
+    # Generous ceiling for reasoning-model calls on complex detector prompts.
+    call_timeout = float(os.environ.get("FB38_CALL_TIMEOUT", "120"))
     if use_openrouter:
         model = os.environ.get("OPENROUTER_CHAT_MODEL_ID", "gpt-5-mini")
-        client = OpenAI(api_key=openrouter_api_key, base_url=openrouter_base_url)
+        client = OpenAI(
+            api_key=openrouter_api_key,
+            base_url=openrouter_base_url,
+            timeout=call_timeout,
+            max_retries=1,
+        )
     else:
         model = os.environ.get("OPENAI_CHAT_MODEL_ID", "gpt-5-mini")
-        client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+        client = OpenAI(
+            api_key=os.environ.get("OPENAI_API_KEY"),
+            timeout=call_timeout,
+            max_retries=1,
+        )
     return client, model
 
 
 def _make_llm_callable(client: Any, model: str) -> Callable[[str], str]:
     """Wrap the chat-completions client as a ``str -> str`` callable for the
-    agentic detectors (which expect that contract)."""
+    agentic detectors (which expect that contract).
+
+    FB-38: logs per-call elapsed + reasoning-token count to stderr, so a
+    slow-but-progressing run is visible and distinguishable from a hang.
+    """
 
     def call(prompt: str) -> str:
+        t0 = time.time()
         response = client.chat.completions.create(
             model=model,
             messages=[{"role": "user", "content": prompt}],
+        )
+        dt = time.time() - t0
+        usage = getattr(response, "usage", None)
+        rtoks = (
+            getattr(usage.completion_tokens_details, "reasoning_tokens", None)
+            if usage and getattr(usage, "completion_tokens_details", None)
+            else None
+        )
+        print(
+            f"    [llm] {dt:.1f}s rtok={rtoks} prompt_len={len(prompt)}",
+            file=sys.stderr,
+            flush=True,
         )
         choice = response.choices[0]
         return (choice.message.content if choice.message and choice.message.content else "") or ""
@@ -302,17 +349,25 @@ def run_corpus(corpus_label: str, max_args: int = 8) -> Dict[str, Any]:
                 "overall": fb28.get("overall"),
             },
         }
-        # Console preview focused on the 2 upgraded virtues
+        # Console preview: how many upgraded virtues does the agentic pipeline
+        # separate ABOVE the 0-shot baseline on THIS arg (pipe>base). The
+        # content-separation claim lives in these per-arg separations + exhibits.
         ps = pipe["scores"]
         bs = base["scores"]
-        refut_p = ps.get("refutation_constructive")
-        refut_b = bs.get("refutation_constructive")
-        anal_p = ps.get("analogie_pertinente")
-        anal_b = bs.get("analogie_pertinente")
+        base_overall = round(
+            sum(s for s in bs.values() if isinstance(s, (int, float))), 2
+        )
+        up_separating = sum(
+            1
+            for v in AGENTIC_UPGRADED_VIRTUES
+            if isinstance(ps.get(v), (int, float))
+            and isinstance(bs.get(v), (int, float))
+            and float(ps[v]) > float(bs[v])
+        )
         print(
             f"  [{i}/{len(arg_ids)}] {arg_id}: "
-            f"refut pipe={refut_p}/base={refut_b} | "
-            f"analogy pipe={anal_p}/base={anal_b} "
+            f"pipe={pipe['overall']}/base={base_overall} | "
+            f"upgraded-separating={up_separating}/{len(AGENTIC_UPGRADED_VIRTUES)} "
             f"({elapsed:.1f}s)"
         )
 
@@ -390,45 +445,52 @@ def build_differential(results: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="FB-29 agentic head-to-head")
+    parser = argparse.ArgumentParser(description="FB-29/FB-38 agentic head-to-head")
     parser.add_argument("--corpus", choices=["A", "B", "C"], default=None)
     parser.add_argument("--max-args", type=int, default=8)
+    parser.add_argument(
+        "--out-prefix",
+        default="fb38",
+        help="Output filename prefix (default fb38; FB-29 frozen results are fb29_*).",
+    )
     args_cli = parser.parse_args()
 
     corpus_list = [args_cli.corpus] if args_cli.corpus else ["A", "B", "C"]
+    out_prefix = args_cli.out_prefix
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
     results: Dict[str, Any] = {}
     for label in corpus_list:
-        print(f"\n{'='*60}\n[FB29] corpus {label}\n{'='*60}")
+        print(f"\n{'='*60}\n[{out_prefix.upper()}] corpus {label}\n{'='*60}")
         try:
             res = run_corpus(label, max_args=args_cli.max_args)
             results[label] = res
-            out_path = RESULTS_DIR / f"fb29_agentic_{label}.json"
+            out_path = RESULTS_DIR / f"{out_prefix}_agentic_{label}.json"
             with open(out_path, "w", encoding="utf-8") as f:
                 json.dump(res, f, indent=2, ensure_ascii=False, default=str)
-            print(f"[FB29] saved {out_path}")
+            print(f"[{out_prefix.upper()}] saved {out_path}")
         except Exception as exc:
-            print(f"[FB29] corpus {label} FAILED: {exc}")
+            print(f"[{out_prefix.upper()}] corpus {label} FAILED: {exc}")
             results[label] = {"corpus": CORPUS_LABELS[label], "error": str(exc)}
 
     diff = build_differential(results)
     summary = {
         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S"),
-        "method": "fb29_agentic_headtohead",
+        "method": f"{out_prefix}_agentic_headtohead",
         "description": (
-            "Upgraded pipeline (agentic multi-step on refutation_constructive + "
-            "analogie_pertinente) vs 0-shot baseline, same rubric/scale as FB-28"
+            f"Upgraded pipeline (agentic multi-step on {len(AGENTIC_UPGRADED_VIRTUES)} "
+            f"virtues: {', '.join(AGENTIC_UPGRADED_VIRTUES)}) vs 0-shot baseline, "
+            "same rubric/scale as FB-28"
         ),
         "upgraded_virtues": AGENTIC_UPGRADED_VIRTUES,
         "differential": diff,
     }
-    summary_path = RESULTS_DIR / "fb29_summary.json"
+    summary_path = RESULTS_DIR / f"{out_prefix}_summary.json"
     with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(summary, f, indent=2, ensure_ascii=False, default=str)
-    print(f"\n[FB29] Summary + differential saved to {summary_path}")
+    print(f"\n[{out_prefix.upper()}] Summary + differential saved to {summary_path}")
 
-    print(f"\n{'='*60}\n[FB29] UPGRADED-VIRTUE DIFFERENTIAL (agentic pipe vs 0-shot base)\n{'='*60}")
+    print(f"\n{'='*60}\n[{out_prefix.upper()}] UPGRADED-VIRTUE DIFFERENTIAL (agentic pipe vs 0-shot base)\n{'='*60}")
     for label in corpus_list:
         d = diff.get(label, {})
         pv = d.get("per_virtue", {})

--- a/tests/unit/argumentation_analysis/agents/core/quality/test_agentic_virtue_detectors.py
+++ b/tests/unit/argumentation_analysis/agents/core/quality/test_agentic_virtue_detectors.py
@@ -26,6 +26,11 @@ from argumentation_analysis.agents.core.quality.agentic_virtue_detectors import 
     detect_refutation_constructive_agentic,
     detect_refutation_constructive_agentic as detect_refut,
     detect_analogie_pertinente_agentic as detect_analogy,
+    detect_clarte_agentic as detect_clarte,
+    detect_pertinence_agentic as detect_pertinence,
+    detect_structure_logique_agentic as detect_structure,
+    detect_exhaustivite_agentic as detect_exhaust,
+    detect_redondance_faible_agentic as detect_redond,
 )
 from argumentation_analysis.agents.core.quality import agentic_virtue_detectors as avd
 
@@ -39,8 +44,20 @@ from argumentation_analysis.agents.core.quality import agentic_virtue_detectors 
 # ---------------------------------------------------------------------------
 
 def _which_step(prompt: str) -> str:
-    """Identify which chain step a prompt is asking (by its signature marker)."""
-    if "Étape 3" in prompt or "Score la qualité" in prompt or "Score la pertinence" in prompt:
+    """Identify which chain step a prompt is asking (by its signature marker).
+
+    FB-29 step3 prompts open with "Score la qualité/pertinence"; FB-38 step3
+    prompts open with "Score la clarté/...". The robust universal step3 signal:
+    every step3 prompt embeds the ``"exhibit":`` JSON key, which no step1/step2
+    does. (The step2 verdict tokens are underscore-form precisely so step3 can
+    discriminate them from the rubric prose — see the detectors' module docstring.)
+    """
+    if (
+        "Étape 3" in prompt
+        or '"exhibit"' in prompt
+        or "Score la qualité" in prompt
+        or "Score la pertinence" in prompt
+    ):
         return "step3"
     if "Étape 2" in prompt:
         return "step2"
@@ -296,6 +313,346 @@ class TestAnalogiePertinenteAgentic:
 
 
 # ---------------------------------------------------------------------------
+# FB-38 #1127 — the 5 remaining tractable virtues, agentic
+#
+# Same context-sensitive-stub pattern: step1/step2 classify the planted text;
+# step3 keys off the verdict token carried from step2 (underscore-form, NOT in
+# the rubric prose). Each negative control is a text where the LEXICAL detector
+# gives a FALSE-POSITIVE high score (the agentic chain must REJECT) — that
+# discrimination is the content-separation claim, not the score itself.
+# ---------------------------------------------------------------------------
+
+
+def _make_clarte_stub(jargon_keywords):
+    """clarté stub: jargon (short words, unresolvable) must REJECT; clear text
+    scores high. The lexical Flesch detector would score jargon HIGH on short
+    words — the negative control."""
+    def stub(prompt: str) -> str:
+        step = _which_step(prompt)
+        lower = prompt.lower()
+        is_jargon = any(k.lower() in lower for k in jargon_keywords)
+        if step == "step1":
+            if is_jargon:
+                return json.dumps({"has_clarity_obstacle": True, "obstacles": "jargon technique non défini (Q-GERT, TLN)"})
+            return json.dumps({"has_clarity_obstacle": False, "obstacles": ""})
+        if step == "step2":
+            if is_jargon:
+                return json.dumps({"obstacle_genuinely_opaque": True, "clarity_verdict": "opaque_réel", "reasoning": "jargon non résolvable"})
+            return json.dumps({"obstacle_genuinely_opaque": False, "clarity_verdict": "aucun_obstacle", "reasoning": ""})
+        if "opaque_réel" in lower:
+            return json.dumps({"score": 0.0, "exhibit": "jargon opaque localisé"})
+        if "résolvable_contexte" in lower:
+            return json.dumps({"score": 0.5, "exhibit": "obstacle résolvable"})
+        return json.dumps({"score": 1.0, "exhibit": "aucun obstacle"})
+
+    return stub
+
+
+def _make_pertinence_stub(digression_keywords):
+    """pertinence stub: a digression (even with connectors) must REJECT; focused
+    text scores high. The lexical connector-count would score a digressive text
+    HIGH — the negative control."""
+    def stub(prompt: str) -> str:
+        step = _which_step(prompt)
+        lower = prompt.lower()
+        is_digression = any(k.lower() in lower for k in digression_keywords)
+        if step == "step1":
+            return json.dumps({
+                "has_thesis": True,
+                "thesis": "la thèse défendue",
+                "digressions": "aparté sur le chat" if is_digression else "",
+            })
+        if step == "step2":
+            if is_digression:
+                return json.dumps({"has_digression": True, "relevance_verdict": "digression_localisée", "located_digression": "aparté hors-sujet"})
+            return json.dumps({"has_digression": False, "relevance_verdict": "toutes_pertinentes", "located_digression": ""})
+        if "digression_localisée" in lower:
+            return json.dumps({"score": 0.0, "exhibit": "digression localisée"})
+        if "toutes_pertinentes" in lower:
+            return json.dumps({"score": 1.0, "exhibit": "toutes pertinentes"})
+        return json.dumps({"score": 0.5, "exhibit": "pertinence partielle"})
+
+    return stub
+
+
+def _make_structure_stub(real_keywords, saut_keywords):
+    """structure_logique stub: an enumeration with rhetorical 'donc' but no
+    inference (saut logique) must REJECT; a real premise→conclusion scores high.
+    The lexical connector-count would score the saut HIGH — the negative control."""
+    def stub(prompt: str) -> str:
+        step = _which_step(prompt)
+        lower = prompt.lower()
+        is_real = any(k.lower() in lower for k in real_keywords)
+        is_saut = any(k.lower() in lower for k in saut_keywords)
+        if step == "step1":
+            return json.dumps({
+                "has_chain": True,
+                "premises": "prémisses identifiées",
+                "conclusion": "conclusion",
+            })
+        if step == "step2":
+            if is_real:
+                return json.dumps({"chain_holds": True, "structure_verdict": "progression_logique", "reasoning": "inférence réelle"})
+            if is_saut:
+                return json.dumps({"chain_holds": False, "structure_verdict": "saut_logique", "reasoning": "la conclusion ne découle pas des prémisses"})
+            return json.dumps({"chain_holds": False, "structure_verdict": "énumération_sans_lien", "reasoning": ""})
+        if "progression_logique" in lower:
+            return json.dumps({"score": 1.0, "exhibit": "chaîne prémisse→conclusion tenue"})
+        if "saut_logique" in lower:
+            return json.dumps({"score": 0.0, "exhibit": "saut logique rejeté"})
+        if "énumération_sans_lien" in lower:
+            return json.dumps({"score": 0.0, "exhibit": "énumération sans lien rejetée"})
+        return json.dumps({"score": 0.5, "exhibit": "structure partielle"})
+
+    return stub
+
+
+def _make_exhaust_stub(broad_keywords, mono_keywords):
+    """exhaustivité stub: a long but monodimensional text must REJECT; broad
+    coverage scores high. The lexical sentence-count would score a long
+    monodimensional text HIGH — the negative control."""
+    def stub(prompt: str) -> str:
+        step = _which_step(prompt)
+        lower = prompt.lower()
+        is_broad = any(k.lower() in lower for k in broad_keywords)
+        is_mono = any(k.lower() in lower for k in mono_keywords)
+        if step == "step1":
+            return json.dumps({"subject": "le sujet", "expected_dimensions": "efficacité, coût, équité, faisabilité"})
+        if step == "step2":
+            if is_broad:
+                return json.dumps({"covered_dimensions": "plusieurs dimensions", "missing_dimensions": "", "coverage_verdict": "couverture_large"})
+            if is_mono:
+                return json.dumps({"covered_dimensions": "efficacité seule", "missing_dimensions": "coût, équité, faisabilité absents", "coverage_verdict": "monodimensionnel_seul"})
+            return json.dumps({"covered_dimensions": "", "missing_dimensions": "", "coverage_verdict": "couverture_partielle"})
+        if "couverture_large" in lower:
+            return json.dumps({"score": 1.0, "exhibit": "couverture large des dimensions"})
+        if "monodimensionnel_seul" in lower:
+            return json.dumps({"score": 0.0, "exhibit": "monodimensionnel rejeté"})
+        if "couverture_partielle" in lower:
+            return json.dumps({"score": 0.5, "exhibit": "couverture partielle"})
+        return json.dumps({"score": 0.2, "exhibit": "couverture faible"})
+
+    return stub
+
+
+def _make_redond_stub(distinct_keywords, redundant_keywords):
+    """redondance_faible stub: semantic restatement (same idea, varied words)
+    must REJECT; genuinely distinct points score high. The lexical unique-word
+    ratio would score a varied-word restatement HIGH (low redundancy) — the
+    negative control."""
+    def stub(prompt: str) -> str:
+        step = _which_step(prompt)
+        lower = prompt.lower()
+        is_distinct = any(k.lower() in lower for k in distinct_keywords)
+        is_redundant = any(k.lower() in lower for k in redundant_keywords)
+        if step == "step1":
+            return json.dumps({"distinct_points": "points identifiés"})
+        if step == "step2":
+            if is_distinct:
+                return json.dumps({"has_semantic_redundancy": False, "redundancy_verdict": "points_distincts", "located_redundancy": ""})
+            if is_redundant:
+                return json.dumps({"has_semantic_redundancy": True, "redundancy_verdict": "redondance_sémantique", "located_redundancy": "même idée reformulée"})
+            return json.dumps({"has_semantic_redundancy": False, "redundancy_verdict": "reformulation_utile", "located_redundancy": ""})
+        if "points_distincts" in lower:
+            return json.dumps({"score": 1.0, "exhibit": "points réellement distincts"})
+        if "redondance_sémantique" in lower:
+            return json.dumps({"score": 0.0, "exhibit": "redondance sémantique rejetée"})
+        if "reformulation_utile" in lower:
+            return json.dumps({"score": 0.5, "exhibit": "reformulation utile"})
+        return json.dumps({"score": 0.2, "exhibit": "redondance notable"})
+
+    return stub
+
+
+# --- Planted texts (FB-38) ---
+
+CLEAR_TEXT = (  # no clarity obstacle → measured 1.0
+    "La photosynthèse convertit l'énergie solaire en énergie chimique. "
+    "Les plantes utilisent ce processus pour produire leur propre nourriture."
+)
+JARGON_TEXT = (  # short words but unresolvable jargon → Flesch false-positive HIGH, agentic REJECT
+    "Le Q-GERT module le TLN via le protocole X-47. C'est crucial pour le résultat final obtenu."
+)
+RELEVANT_TEXT = (  # focused argument, all propositions serve the thesis
+    "La fiscalité écologique réduit les émissions carbone. En effet, taxer les "
+    "pollueurs modifie les comportements industriels vers des pratiques plus propres, "
+    "ce qui baisse durablement l'empreinte carbone du pays."
+)
+DIGRESSIVE_TEXT = (  # connectors + a clear digression → connector-count false-positive HIGH
+    "Nous devons réduire la dette publique. En effet, la dette étouffe l'économie. "
+    "Par ailleurs, mon chat est roux et dort beaucoup. Donc, la rigueur budgétaire s'impose."
+)
+CHAINED_TEXT = (  # real premise→conclusion inference
+    "Tous les mammifères possèdent un cœur. La baleine est un mammifère. "
+    "Donc, la baleine possède un cœur."
+)
+ENUMERATION_TEXT = (  # points + 'donc' but the conclusion doesn't follow → saut logique
+    "Il pleut. La route est mouillée. Donc, la politique monétaire doit changer radicalement."
+)
+BROAD_TEXT = (  # covers multiple dimensions of the subject
+    "Sur la réforme fiscale, il faut juger l'efficacité économique, le coût pour les "
+    "ménages, l'équité sociale et la faisabilité politique."
+)
+MONODIM_TEXT = (  # long, many sentences, but ONE dimension only → sentence-count false-positive HIGH
+    "Ce médicament est efficace. Son efficacité est prouvée par des essais cliniques. "
+    "Les patients guérissent vite grâce à lui. Le taux de guérison est élevé. "
+    "Son efficacité dépasse largement celle des alternatives disponibles."
+)
+DISTINCT_TEXT = (  # genuinely distinct points
+    "Premièrement, la mesure réduit les inégalités. Deuxièmement, elle encourage "
+    "l'innovation technique. Troisièmement, elle renforce la souveraineté du pays."
+)
+SEMANTIC_RESTATEMENT_TEXT = (  # same idea, varied words → unique-word-ratio false-positive HIGH
+    "Il faut investir dans l'éducation. Nos écoles méritent davantage de moyens. "
+    "L'enseignement doit rester une priorité budgétaire. Former notre jeunesse est un impératif national."
+)
+
+
+# --- FB-38 detector tests (positive + negative-control + fail-loud each) ---
+
+class TestClarteAgentic:
+    def test_clear_text_measured_high(self):
+        stub = _make_clarte_stub(jargon_keywords=["q-gert"])
+        score, comment = detect_clarte(CLEAR_TEXT, llm=stub)
+        assert score == 1.0, f"clear text should score high, got {score}"
+        assert "aucun obstacle" in comment.lower()
+
+    def test_jargon_rejected_negative_control(self):
+        """Negative control: unresolvable jargon (short words) must REJECT. A
+        lexical Flesch detector would score it HIGH — the agentic chain locates
+        the obstacle and rejects. Scoring it high = theatre (#1019)."""
+        stub = _make_clarte_stub(jargon_keywords=["q-gert", "tln", "x-47"])
+        score, comment = detect_clarte(JARGON_TEXT, llm=stub)
+        assert score == 0.0, (
+            f"NEGATIVE CONTROL FAILED: unresolvable jargon must REJECT (0.0), "
+            f"got {score}. Flesch scores short-word jargon high — theatre."
+        )
+        assert "opaque_réel" in comment
+
+    def test_no_llm_raises_fail_loud(self):
+        with pytest.raises(AgenticDetectorError, match="no LLM callable"):
+            detect_clarte(CLEAR_TEXT, llm=None)
+
+
+class TestPertinenceAgentic:
+    def test_relevant_text_matches_high(self):
+        stub = _make_pertinence_stub(digression_keywords=["chat", "dort"])
+        score, comment = detect_pertinence(RELEVANT_TEXT, llm=stub)
+        assert score == 1.0, f"focused text should score high, got {score}"
+        assert "toutes_pertinentes" in comment
+
+    def test_digression_rejected_negative_control(self):
+        """Negative control: connectors + a digression must REJECT. A lexical
+        connector-count would score it HIGH (many connectors) — the agentic
+        chain locates the digression."""
+        stub = _make_pertinence_stub(digression_keywords=["chat", "dort"])
+        score, comment = detect_pertinence(DIGRESSIVE_TEXT, llm=stub)
+        assert score == 0.0, (
+            f"NEGATIVE CONTROL FAILED: digression must REJECT (0.0), got {score}. "
+            "Connector-count would score a digressive text high — theatre."
+        )
+        assert "digression_localisée" in comment
+
+    def test_no_thesis_measured_zero(self):
+        """No thesis identified → measured 0.0 (the gate short-circuits)."""
+        def no_thesis_stub(prompt: str) -> str:
+            if _which_step(prompt) == "step1":
+                return json.dumps({"has_thesis": False, "thesis": "", "digressions": ""})
+            return json.dumps({})
+
+        score, comment = detect_pertinence(SOURCE_LIGHT_TEXT, llm=no_thesis_stub)
+        assert score == 0.0
+        assert "aucune thèse" in comment.lower()
+
+    def test_no_llm_raises_fail_loud(self):
+        with pytest.raises(AgenticDetectorError, match="no LLM callable"):
+            detect_pertinence(RELEVANT_TEXT, llm=None)
+
+
+class TestStructureLogiqueAgentic:
+    def test_real_chain_matches_high(self):
+        stub = _make_structure_stub(real_keywords=["mammifères", "baleine"], saut_keywords=["politique monétaire"])
+        score, comment = detect_structure(CHAINED_TEXT, llm=stub)
+        assert score == 1.0, f"real premise→conclusion should score high, got {score}"
+        assert "progression_logique" in comment
+
+    def test_enumeration_saut_rejected_negative_control(self):
+        """Negative control: points + rhetorical 'donc' but no inference (saut
+        logique) must REJECT. A lexical connector-count would score it HIGH —
+        the agentic chain verifies the inference and rejects the gap."""
+        stub = _make_structure_stub(real_keywords=["mammifères"], saut_keywords=["politique monétaire", "pleut"])
+        score, comment = detect_structure(ENUMERATION_TEXT, llm=stub)
+        assert score == 0.0, (
+            f"NEGATIVE CONTROL FAILED: saut logique must REJECT (0.0), got {score}. "
+            "Connector-count would score an enumeration with 'donc' high — theatre."
+        )
+        assert "saut_logique" in comment or "énumération_sans_lien" in comment
+
+    def test_no_chain_measured_zero(self):
+        def no_chain_stub(prompt: str) -> str:
+            if _which_step(prompt) == "step1":
+                return json.dumps({"has_chain": False, "premises": "", "conclusion": ""})
+            return json.dumps({})
+
+        score, comment = detect_structure(SOURCE_LIGHT_TEXT, llm=no_chain_stub)
+        assert score == 0.0
+        assert "aucune chaîne" in comment.lower()
+
+    def test_no_llm_raises_fail_loud(self):
+        with pytest.raises(AgenticDetectorError, match="no LLM callable"):
+            detect_structure(CHAINED_TEXT, llm=None)
+
+
+class TestExhaustiviteAgentic:
+    def test_broad_coverage_matches_high(self):
+        stub = _make_exhaust_stub(broad_keywords=["équité sociale", "faisabilité politique"], mono_keywords=["taux de guérison"])
+        score, comment = detect_exhaust(BROAD_TEXT, llm=stub)
+        assert score == 1.0, f"broad coverage should score high, got {score}"
+        assert "couverture_large" in comment
+
+    def test_monodimensional_rejected_negative_control(self):
+        """Negative control: long but monodimensional text must REJECT. A
+        lexical sentence-count would score it HIGH (many sentences) — the
+        agentic chain identifies the missing dimensions."""
+        stub = _make_exhaust_stub(broad_keywords=["équité sociale"], mono_keywords=["taux de guérison", "essais cliniques"])
+        score, comment = detect_exhaust(MONODIM_TEXT, llm=stub)
+        assert score == 0.0, (
+            f"NEGATIVE CONTROL FAILED: monodimensional text must REJECT (0.0), "
+            f"got {score}. Sentence-count rewards length, not coverage — theatre."
+        )
+        assert "monodimensionnel_seul" in comment
+
+    def test_no_llm_raises_fail_loud(self):
+        with pytest.raises(AgenticDetectorError, match="no LLM callable"):
+            detect_exhaust(BROAD_TEXT, llm=None)
+
+
+class TestRedondanceFaibleAgentic:
+    def test_distinct_points_matches_high(self):
+        stub = _make_redond_stub(distinct_keywords=["premièrement", "deuxièmement"], redundant_keywords=["écoles méritent"])
+        score, comment = detect_redond(DISTINCT_TEXT, llm=stub)
+        assert score == 1.0, f"distinct points should score high, got {score}"
+        assert "points_distincts" in comment
+
+    def test_semantic_restatement_rejected_negative_control(self):
+        """Negative control: same idea in varied words must REJECT. A lexical
+        unique-word ratio would score it HIGH (varied vocabulary = 'low
+        redundancy') — the agentic chain locates the semantic restatement."""
+        stub = _make_redond_stub(distinct_keywords=["premièrement"], redundant_keywords=["écoles méritent", "former notre jeunesse", "impératif national"])
+        score, comment = detect_redond(SEMANTIC_RESTATEMENT_TEXT, llm=stub)
+        assert score == 0.0, (
+            f"NEGATIVE CONTROL FAILED: semantic restatement must REJECT (0.0), "
+            f"got {score}. Unique-word-ratio rewards lexical variety, not "
+            "semantic distinctness — theatre."
+        )
+        assert "redondance_sémantique" in comment
+
+    def test_no_llm_raises_fail_loud(self):
+        with pytest.raises(AgenticDetectorError, match="no LLM callable"):
+            detect_redond(DISTINCT_TEXT, llm=None)
+
+
+# ---------------------------------------------------------------------------
 # Evaluator integration — agentic upgrade path + fail-loud propagation
 # ---------------------------------------------------------------------------
 
@@ -306,7 +663,11 @@ class TestEvaluatorAgenticUpgrade:
 
     def test_agentic_llm_uses_agentic_detector(self, monkeypatch):
         """With agentic_llm wired, refutation_constructive routes to the
-        agentic 3-step chain (not the lexical marker grep)."""
+        agentic 3-step chain (not the lexical marker grep).
+
+        FB-38 note: AGENTIC_DETECTORS now holds 7 virtues. The other 6 are
+        stubbed to benign no-ops so evaluate() completes — only the refutation
+        *routing* is under test here (not the other chains' behaviour)."""
         from argumentation_analysis.agents.core.quality.quality_evaluator import (
             ArgumentQualityEvaluator,
         )
@@ -317,9 +678,15 @@ class TestEvaluatorAgenticUpgrade:
             called["refut_chain"] = True
             return 0.5, "agentic chain ran"
 
+        def benign_stub(text, llm=None):
+            return 0.0, "stubbed (not under test)"
+
         monkeypatch.setitem(
             avd.AGENTIC_DETECTORS, "refutation_constructive", stub_chain
         )
+        for v in list(avd.AGENTIC_DETECTORS):
+            if v != "refutation_constructive":
+                monkeypatch.setitem(avd.AGENTIC_DETECTORS, v, benign_stub)
         # Avoid the spacy/textstat hard dependency for this unit test: bypass
         # the deps gate by marking them available. The 7 lexical detectors are
         # not under test here; only the routing is.


### PR DESCRIPTION
## Summary

**FB-38 #1127** — upgrade 5 more quality virtues to multi-step agentic detectors (pattern FB-29) + honest axis re-measure on the de-castrated pipeline (discharges the R405 caveat: quality axis was last measured under the castrated pipeline at FB-29; FB-30..37 have since landed).

- **5 new agentic detectors**: `clarte`, `pertinence`, `structure_logique`, `exhaustivite`, `redondance_faible` (each a 3-step locate→verify→score chain emitting an `exhibit`).
- **7/9 virtues now agentic**; the 2 source-virtues (`presence_sources`, `fiabilite_sources`) stay **deliberately lexical** — the corpus carries no citations, so agenticizing them would fabricate structure (theatre). Subtraction by design (anti-pendule).

## Honest axis verdict: **EDGES** (not DECIDES)

Measured across 19 args / 3 corpora (doc_A=8, doc_B=3, doc_C=8), same-model fair head-to-head (`openai/gpt-5-mini` for both agentic pipeline and 0-shot baseline):

| signal | count |
|--------|-------|
| SEPARATES (pipe > base, Δ > +0.05) | **2/7** (`pertinence` +0.516, `refutation_constructive` +0.105) |
| STRICTER (pipe < base, Δ < −0.05) | **2/7** (`redondance_faible` −0.289, `clarte` −0.059) |
| neutral | **3/7** |

Overall pipe mean 3.13 vs base 2.75 (Δ +0.377, driven by `pertinence`). A **split, bidirectional** result is **not dominance** → DECIDES is not earned. Per #1127, the verdict is measured, not forced.

**Content-separation is demonstrated non-vacuously (anti-theater #1019):** every detector emits a located `exhibit` (thesis + digression, opposing claim + engagement verdict, premise→conclusion chain, covered/missing dimensions, clarity obstacle) that a single 0-shot score cannot surface. 2 `AGENTIC_FAIL` cases recorded **fail-loud** (`score=None`, no fabrication). `pertinence` is the strongest single-virtue separation measured in the FB-28/29/38 arc (+0.516, separates on all 3 corpora).

## DoD (#1127)
- [x] 5 agentically-tractable virtues upgraded to multi-step detectors
- [x] Source-virtues kept lexical (deliberate subtraction)
- [x] Head-to-head re-run doc_A/B/C — results gitignored under `evaluation/results/capstone_c1/fb38_*.json`
- [x] Explicit axis verdict (EDGES) + fairness/no-inflation/exhibit evidence + honest hedges
- [x] Opaque IDs only (leak-audited: 0 source-name markers)

## Harness hardening (anti-pendule — bounding an unbounded op)
The FB-29 harness had no per-call timeout and no per-call logging. An early run appeared to "hang" (25 min, 2% CPU, 0 per-arg progress). A 1-arg probe with added observability root-caused it as **slow-but-progressing**: complex detector prompts trigger 256–960 reasoning tokens/call (5–17.6s), so 22 calls/arg ≈ 175s/arg. The fix is a **fail-loud bound, not a counterweight**: per-call `timeout=120s` + `max_retries=1` + a per-call `[llm]` elapsed/reasoning-token log. Unchanged when it succeeds; fails loudly instead of hanging silently.

## Files changed

| File | Change |
|------|--------|
| `agentic_virtue_detectors.py` | +5 detector fns, +15 prompt templates, `AGENTIC_DETECTORS` 2→7, `LEXICAL_ONLY_VIRTUES` 7→2 |
| `test_agentic_virtue_detectors.py` | +17 unit tests (positive + negative-control + measured-zero + fail-loud), 30 total |
| `run_fb29_agentic_headtohead.py` | per-call timeout fail-loud + `[llm]` observability + `AGENTIC_UPGRADED_VIRTUES` derived from registry |
| `docs/reports/FB38_QUALITY_AGENTIC_REPORT.md` | full report (opaque IDs, leak-audited) — force-added (gitignored `*_report*.md`) |

No deletions (cleanup-gate N/A). mypy strict clean on the detectors module; 92 quality tests pass; CI mypy gate (`invoke_callables.py`) untouched.

## Cross-verify clause (#1127)
This axis verdict will be **adversarially cross-verified** (po-2023 on return, or coordinator) before it bears on closing #947. This PR produces the measurement honestly; it does **not** advocate DECIDES.

Closes #1127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
