### PR TITLE
chore(gitignore): exclude leak-capable scratch scripts from accidental commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,17 @@ docs/reports/CORRECTIONS_PATCHES_*
 docs/reports/CORRECTION_ANALYSE_*
 docs/reports/ORGANISATION_WORKSPACE.md
 docs/reports/test-hierarchy-data/
+
+# Local scratch diagnostic/benchmark scripts + generated bench reports (one-shot, never commit).
+# These decrypt the corpus IN-MEMORY via load_extract_definitions (sanctioned), but
+# _peek_sources.py and _list_docs.py PRINT plaintext previews to stdout (text[:300],
+# text[:120]) — a leak vector if their output is captured/logged. Real outputs already
+# land in gitignored paths (analysis_kb/, evaluation/results/). Dead one-shot scratch
+# from the May/Jun benchmarking era; kept locally for reference. Use `git add -f` to commit.
+scripts/_peek_sources.py
+scripts/_list_docs.py
+scripts/_deep_analysis.py
+scripts/_write_c03_report.py
+scripts/run_baselines.py
+docs/reports/spectacular_perf_bench.md
+docs/reports/spectacular_vs_baseline.md


### PR DESCRIPTION
## What

Excludes 7 untracked one-shot scratch files (May/Jun benchmarking era) from accidental commit by adding them to `.gitignore`. **Pure addition — no file is deleted**; all remain locally, use `git add -f` if one ever needs committing.

| File | Role | Privacy concern |
|------|------|-----------------|
| `scripts/_peek_sources.py` | scratch diagnostic | ⚠️ **prints plaintext** corpus `text[:300]` to stdout |
| `scripts/_list_docs.py` | scratch diagnostic | ⚠️ **prints plaintext** `text[:120]` to stdout |
| `scripts/_deep_analysis.py` | scratch analysis runner | decrypts in-memory; writes to `analysis_kb/` (already gitignored) |
| `scripts/_write_c03_report.py` | one-shot report generator | output `C-03_*.md` already committed; script is dead |
| `scripts/run_baselines.py` | one-shot bench harness | logs source `name` (metadata); outputs the 2 reports below |
| `docs/reports/spectacular_perf_bench.md` | bench output (opaque) | stale (pre-de-castration numbers) |
| `docs/reports/spectacular_vs_baseline.md` | bench output (opaque) | stale |

## Why (privacy HARD)

Repo discipline (#1 rule): *"When in doubt, gitignore. Better to over-ignore."* These showed as `??` (untracked, NOT gitignored) → vulnerable to an accidental `git add scripts/` or `git add .`. Two of them decrypt the corpus in-memory (sanctioned via `load_extract_definitions`) but then **print plaintext previews to stdout** — a leak vector if their output is ever captured/logged. Gitingoring them closes that accidental-commit path. All real outputs already land in gitignored paths (`analysis_kb/`, `evaluation/results/`, `.cache/`).

## Verification

```
$ git check-ignore -v scripts/_peek_sources.py scripts/_list_docs.py scripts/_deep_analysis.py scripts/_write_c03_report.py scripts/run_baselines.py docs/reports/spectacular_perf_bench.md docs/reports/spectacular_vs_baseline.md
.gitignore:210:scripts/_peek_sources.py
.gitignore:211:scripts/_list_docs.py
.gitignore:212:scripts/_deep_analysis.py
.gitignore:213:scripts/_write_c03_report.py
.gitignore:214:scripts/run_baselines.py
.gitignore:215:docs/reports/spectacular_perf_bench.md
.gitignore:216:docs/reports/spectacular_vs_baseline.md
```
All 7 match. `scripts/__init__.py` (package marker) confirmed **not** ignored — preserved (explicit paths used to avoid a `_*.py` glob collision).

## Scope / anti-overstep

- **No deletion** (respects cleanup gate). Files kept locally for reference.
- These files are not mine (May/Jun scratch, predates FB-30..38); gitingoring is the least-intrusive mitigation and does not affect anyone's tracked files (none were tracked).
- CI: trivial `.gitignore`-only change, targets `main` → CI will run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)