### PR TITLE
test(quality): FB-38 adversarial cross-verify — no inflation, EDGES holds (recovers #1129)

### DIFF
--- a/docs/reports/FB38_ADVERSARIAL_CROSSVERIFY.md
+++ b/docs/reports/FB38_ADVERSARIAL_CROSSVERIFY.md
@@ -1,0 +1,179 @@
+# FB-38 — Adversarial cross-verify (po-2023, independent of po-2025's measurement)
+
+**Track**: FB-38 #1127 · **Role**: adversarial cross-verify (reserved per coordinator R417 + #1127) · **Target**: po-2025's PR #1128 (`feat/1127-fb38-quality-agentic`, commit `84d28a73`)
+**Author**: Claude Code @ myia-po-2023:2025-Epita-Intelligence-Symbolique · **Date**: 2026-06-16
+
+> Privacy: opaque IDs only. This report references code paths, test probes, and
+> detector mechanics — no `raw_text`, no source/speaker identifiers.
+
+---
+
+## TL;DR — verdict
+
+**FB-38 HOLDS. The EDGES verdict is honestly earned. No inflation.**
+
+The load-bearing property that makes po-2025's `pertinence +0.516` separation
+trustworthy — *the agentic detectors faithfully propagate the step3 LLM verdict
+without floor-up* — is **independently verified** by 24 adversarial probes
+(`test_fb38_adversarial_verify.py`, this PR). The measurement instrument (the 5
+new detectors + the head-to-head script) is sound and non-inflationary; the
+measured bidirectional split (2/7 separates, 2/7 stricter, 3/7 neutral) is a
+genuine split, not dominance — so EDGES (not DECIDES) is correctly earned. I do
+**not** amend po-2025's §5 axis verdict.
+
+---
+
+## Why this cross-verify exists
+
+po-2025 both **produced** the FB-38 measurement (PR #1128) and **reported** the
+axis verdict. Per #1127 + R417, the verdict must be adversarially cross-verified
+before it weighs on Epic #947 closure (po-2025 cannot verify its own number —
+conflict of interest). This is the same role po-2023 played for FB-29 (#1114).
+
+The measurement I cannot reproduce: the live +0.516 number comes from
+gitignored per-corpus runs (`evaluation/results/capstone_c1/fb38_*.json`) that
+need API spend — po-2025's runs lane. **But the measurement *instrument* is
+verifiable**, and that is what makes the number trustworthy: if the detectors
+could inflate, the separation could be an artefact of detector code, not the
+LLM locating genuine structure. So I stress-test the no-inflation property.
+
+---
+
+## Method — call-order stubs that DECOUPLE step3 from the verdict
+
+po-2025's own 30 tests use **prompt-content-keyed stubs** that COUPLE step3's
+score to step2's verdict (digression→0.0, toutes_pertinentes→1.0) — a coherent
+chain. That tests positive/negative matching. It does **not** isolate the
+inflation vector: it cannot answer "if step3 returns a low score while steps 1-2
+report a strong argument, does the detector floor it up?".
+
+These probes use **call-order stubs** (closure with a counter, fresh per detector
+invocation) that always emit "strong/real" step1+step2 structure (so no
+early-return gate fires) but hand step3 a **controlled** score (0.0 / 0.2 / 0.5
+/ 1.0) regardless of the verdict. The detector must return EXACTLY that
+controlled score. A floor-up surfaces as a returned score higher than controlled.
+
+This mirrors the FB-29 cross-verify technique (`test_fb29_adversarial_verify.py`).
+
+---
+
+## Results — 24 probes, all PASS
+
+### 1. No-upward-inflation (11 probes) ✅ — the load-bearing claim
+For all 5 new detectors, a controlled LOW step3 score (0.0, 0.2, 0.5) propagates
+**faithfully** even when steps 1-2 say "real/strong":
+
+| Detector | 0.0 propagates | 0.2 propagates | 0.5 propagates |
+|----------|:---:|:---:|:---:|
+| pertinence (the +0.516 separator) | ✅ | ✅ | ✅ |
+| clarte | ✅ | ✅ | — |
+| structure_logique | ✅ | ✅ | — |
+| exhaustivite | ✅ | ✅ | — |
+| redondance_faible | ✅ | ✅ | — |
+
+**No floor-up found.** The detector code is `score = _snap_to_scale(step3.get("score"))`
+used directly — there is no code path that lifts a low step3 score based on the
+step1/step2 verdict. Therefore po-2025's separation numbers reflect the LLM's
+honest read of located structure, not a tuning artefact.
+
+### 2. Bidirectional fidelity (3 probes) ✅
+A controlled HIGH step3 score (1.0) also propagates faithfully (pertinence,
+structure, redondance). The detector is a **pure pass-through** of the step3
+verdict — not a one-directional correction. This rules out a "ceiling" that
+would mask the measurement in the other direction.
+
+### 3. Exhibit non-vacant (6 probes) ✅ — anti-theatre #1019
+Every detector embeds the `exhibit` (located structure a 0-shot cannot emit) in
+its returned comment, and the exhibit is non-empty. The content-separation
+evidence is **real**, not a bare score. The step2 verdict token also surfaces in
+the comment (proves the verify-step output is retained, not discarded).
+
+### 4. Fail-loud on corruption (4 probes) ✅ — bounds the measurement
+- Non-numeric score (string `"high"`) → `AgenticDetectorError` (fail-loud). ✅
+- `bool` score (`True`, an int subclass) → rejected → raises (verified the
+  explicit bool guard in `_snap_to_scale`). ✅
+- Numeric off-scale (`0.7`) → **snaps to nearest** (0.7→0.5), does NOT raise.
+  This is a deliberate tolerance band, **not** an inflation vector — see below.
+
+---
+
+## The one finding — `_snap_to_scale` snaps numeric off-scale values
+
+My first probe run surfaced this (1 initial fail, since corrected). `_snap_to_scale`
+snaps a numeric value to the nearest of `{0.0, 0.2, 0.5, 1.0}` rather than failing
+loud on a mid-scale value (`0.7`→`0.5`, `0.4`→`0.5`, `0.1`→`0.2`).
+
+**Is this inflation? No** — for two reasons:
+
+1. **Symmetric.** The head-to-head script applies the SAME `_snap_to_scale` to
+   the 0-shot baseline side (`run_fb29_agentic_headtohead.py`: `scores[v] = _snap_to_scale(float(val))`).
+   Snapping cannot bias the pipe-vs-base differential — both sides snap identically.
+2. **Narrow band.** The LLM is asked for strict `{0.0, 0.2, 0.5, 1.0}` and mostly
+   complies; snapping only catches minor imprecision (±0.1 around each scale
+   point) and rounds both up and down (0.4→0.5 up, 0.6→0.5 down).
+
+The fail-loud guarantee holds where it matters: non-numeric / bool corruption
+cannot quietly inject a fabricated score. I record this as a **verified
+property** (the probe asserts 0.7→0.5), not a defect. No change to po-2025's code
+recommended.
+
+---
+
+## Also verified (source read, not probed)
+
+- **All 5 detectors are genuinely 3-step** (decompose → verify/locate → score)
+  with `prev_step` threading between steps — the chain is real, not three
+  parallel independent calls.
+- **2 source-virtues (`presence_sources`, `fiabilite_sources`) deliberately kept
+  lexical.** The module docstring states why: the corpus plausibly lacks external
+  citations, so agenticizing them would fabricate sources the text does not
+  contain = degraded theatre (#1019). This is an honest subtraction, not an
+  oversight. It also means the 7/9 "agentic" headline is honest — the remaining
+  2/9 are correctly un-agentizable for this corpus.
+- **Head-to-head fairness**: same model (`gpt-5-mini`, single client+model for
+  both agentic and baseline paths), same scale `[0.0, 0.2, 0.5, 1.0]`, same rubric
+  (`BASELINE_EVAL_PROMPT` byte-identical to FB-28). Separation reflects
+  methodology (multi-step locate→verify→score vs single-shot), not model capacity.
+
+---
+
+## Verdict on the axis (EDGES) — concurs with po-2025
+
+The no-inflation property HOLDS, and the methodology is fair (same-model,
+symmetric snapping, genuine multi-step chains with non-vacuous exhibits).
+Therefore the measured **bidirectional split** (2/7 separates, 2/7 stricter,
+3/7 neutral) is honest. A split is not dominance — DECIDES requires clean
+one-directional separation, which the data does not show. **EDGES is correctly
+earned.** I concur with po-2025's §5 verdict and add no amendment.
+
+### Honest limitations (same shape as FB-29 cross-verify)
+1. **Live numbers not reproduced** — the +0.516 / −0.289 figures come from
+   gitignored runs needing API spend (po-2025's lane). I verified the *instrument*,
+   not the *run*.
+2. **No ground truth** — without a gold-standard quality score per arg, the
+   bidirectional split cannot be resolved into "agentic is more correct" (po-2025
+   hedges this too). My probes confirm the detectors don't *force* a direction;
+   they don't establish which direction is *true*.
+3. **Discrimination delegated to the LLM verdict chain** — there is no
+   detector-level strawman guard beyond the planted pseudo-structure negative
+   controls (which po-2025 unit-tests). A genuinely adversarial input that fools
+   the step2 verify-call would propagate. This is inherent to LLM-grounded
+   detection and is documented, not a defect.
+
+---
+
+## DoD — what this cross-verify delivers
+
+- [x] Independent no-inflation verification of the 5 new detectors (24 probes).
+- [x] Anti-theatre check (exhibits non-vacant) + fail-loud bounds.
+- [x] Methodology fairness check (same-model/scale/rubric, symmetric snapping).
+- [x] Axis-verdict concurrence (EDGES holds) with honest limitations — no §5 amendment.
+- [x] Standing-guard probe file committed (`test_fb38_adversarial_verify.py`) —
+      merges as a companion to #1128 (test-only, file-disjoint from po-2025's
+      detector code; targets the same branch so it runs against the real code).
+
+**Net for Epic #947**: the quality-axis EDGES verdict is independently
+corroborated and may bear on the closure decision. The formal axis (DECIDES)
++ quality axis (EDGES, now cross-verified) stand as po-2025 measured them.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/tests/unit/argumentation_analysis/agents/core/quality/test_fb38_adversarial_verify.py
+++ b/tests/unit/argumentation_analysis/agents/core/quality/test_fb38_adversarial_verify.py
@@ -1,0 +1,338 @@
+"""FB-38 adversarial cross-verify (po-2023, independent of po-2025's own tests).
+
+Role (per #1127 / coordinator R417): adversarially verify po-2025's FB-38
+quality-axis verdict BEFORE it weighs on Epic #947 closure. po-2025 produced
+the measurement; this file independently stress-tests the **no-inflation**
+property that makes the measurement trustworthy.
+
+The load-bearing claim under test
+---------------------------------
+po-2025 reports `pertinence` separates +0.516 vs the same-model 0-shot baseline
+(the strongest content-separation in the FB-28/29/38 arc). That number is only
+honest IF the agentic detector faithfully propagates the step3 LLM verdict —
+i.e. it must NOT floor a low step3 score up to a higher bucket, nor mask a high
+step3 score. If a floor-up existed, the separation could be an artefact of the
+detector code tuning scores higher, not the LLM locating genuine structure.
+
+Method (mirrors test_fb29_adversarial_verify.py)
+------------------------------------------------
+Each detector runs a 3-step chain (step1 decompose → step2 verify → step3 score).
+po-2025's own tests use prompt-content-keyed stubs that COUPLE step3's score to
+step2's verdict (digression→0.0, toutes_pertinentes→1.0) — a coherent chain.
+That tests positive/negative matching, but does NOT isolate the inflation vector.
+
+These probes use **call-order stubs** that DECOUPLE step3's score from the
+verdict: steps 1-2 always return "strong/real" structure (so no early-return
+gate fires), while step3 returns a CONTROLLED score (0.0 / 0.2 / 0.5 / 1.0)
+regardless of the verdict. We then assert the detector returns EXACTLY that
+controlled score. A floor-up would surface here as a returned score higher than
+the controlled one.
+
+Anti-theatre is also checked: the `exhibit` (the located structure a 0-shot
+cannot emit) must be non-vacant in the returned comment.
+"""
+
+import json
+from typing import Callable
+
+import pytest
+
+from argumentation_analysis.agents.core.quality.agentic_virtue_detectors import (
+    detect_clarte_agentic,
+    detect_pertinence_agentic,
+    detect_structure_logique_agentic,
+    detect_exhaustivite_agentic,
+    detect_redondance_faible_agentic,
+    AgenticDetectorError,
+)
+
+
+# ── Call-order stub factory ──────────────────────────────────────────────────
+# Each detector calls the LLM exactly 3 times in sequence (step1, step2, step3).
+# We discriminate by invocation count, NOT prompt content — this is what lets us
+# hand step3 a score that CONTRADICTS the step2 verdict, the inflation probe.
+
+
+def _make_order_stub(step1: dict, step2: dict, step3: dict) -> Callable[[str], str]:
+    """Return a stub that emits step1/step2/step3 JSON by call order.
+
+    Reset per closure (fresh counter per detector invocation). The ``step3``
+    dict carries the CONTROLLED score we want to test for faithful propagation.
+    """
+    seq = [step1, step2, step3]
+    counter = {"n": 0}
+
+    def stub(prompt: str) -> str:
+        i = counter["n"]
+        counter["n"] += 1
+        return json.dumps(seq[i] if i < len(seq) else seq[-1])
+
+    return stub
+
+
+# Per-detector "strong structure" step1/step2 payloads (so no early-return gate
+# fires) — step3 is supplied per-probe with the controlled score.
+
+_PERT_STEP1_STRONG = {
+    "has_thesis": True,
+    "thesis": "la thèse défendue est solide",
+    "digressions": "",
+}
+_PERT_STEP2_STRONG = {
+    "has_digression": False,
+    "relevance_verdict": "toutes_pertinentes",
+    "located_digression": "",
+}
+
+_CLARTE_STEP1_OBSTACLE = {  # has_clarity_obstacle=True → does NOT early-return 1.0
+    "has_clarity_obstacle": True,
+    "obstacles": "anaphore non résolvable",
+}
+_CLARTE_STEP2 = {"clarity_verdict": "opaque_réel"}
+
+_STRUCT_STEP1_STRONG = {
+    "has_chain": True,
+    "premises": "les prémisses énoncées",
+    "conclusion": "la conclusion déduite",
+}
+_STRUCT_STEP2_STRONG = {
+    "chain_holds": True,
+    "structure_verdict": "progression_logique",
+    "reasoning": "la conclusion suit des prémisses",
+}
+
+_EXHAUST_STEP1 = {
+    "subject": "le sujet traité",
+    "expected_dimensions": "dimensions attendues",
+}
+_EXHAUST_STEP2 = {
+    "coverage_verdict": "couverture_large",
+    "missing_dimensions": "",
+}
+
+_REDOND_STEP1 = {"distinct_points": "1. point A; 2. point B; 3. point C"}
+_REDOND_STEP2 = {
+    "has_semantic_redundancy": False,
+    "redundancy_verdict": "points_distincts",
+    "located_redundancy": "",
+}
+
+
+def _step3(score: float, exhibit: str = "structure démontrée localisée") -> dict:
+    return {"score": score, "exhibit": exhibit}
+
+
+# ── No-upward-inflation probes (the load-bearing tests) ──────────────────────
+
+
+class TestNoUpwardInflation:
+    """A controlled LOW step3 score (with steps 1-2 saying 'real/strong') must
+    propagate faithfully — no code-level floor-up. If these fail high, the
+    pertinence +0.516 separation could be an inflation artefact."""
+
+    # --- pertinence (the reported +0.516 separator — highest priority) ---
+
+    def test_pertinence_zero_propagates_when_steps_say_strong(self):
+        stub = _make_order_stub(
+            _PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.0)
+        )
+        score, _ = detect_pertinence_agentic("text", llm=stub)
+        assert score == 0.0, (
+            "pertinence floored a 0.0 step3 score up — potential inflation "
+            "(steps 1-2 said 'toutes_pertinentes' but step3 said 0.0)"
+        )
+
+    def test_pertinence_low_score_no_floor_up(self):
+        stub = _make_order_stub(
+            _PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.2)
+        )
+        score, _ = detect_pertinence_agentic("text", llm=stub)
+        assert score == 0.2
+
+    def test_pertinence_mid_score_propagates(self):
+        stub = _make_order_stub(
+            _PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.5)
+        )
+        score, _ = detect_pertinence_agentic("text", llm=stub)
+        assert score == 0.5
+
+    # --- clarte ---
+
+    def test_clarte_zero_propagates_when_obstacle_present(self):
+        stub = _make_order_stub(
+            _CLARTE_STEP1_OBSTACLE, _CLARTE_STEP2, _step3(0.0)
+        )
+        score, _ = detect_clarte_agentic("text", llm=stub)
+        assert score == 0.0
+
+    def test_clarte_low_score_no_floor_up(self):
+        stub = _make_order_stub(
+            _CLARTE_STEP1_OBSTACLE, _CLARTE_STEP2, _step3(0.2)
+        )
+        score, _ = detect_clarte_agentic("text", llm=stub)
+        assert score == 0.2
+
+    # --- structure_logique ---
+
+    def test_structure_zero_propagates_when_chain_present(self):
+        stub = _make_order_stub(
+            _STRUCT_STEP1_STRONG, _STRUCT_STEP2_STRONG, _step3(0.0)
+        )
+        score, _ = detect_structure_logique_agentic("text", llm=stub)
+        assert score == 0.0
+
+    def test_structure_low_score_no_floor_up(self):
+        stub = _make_order_stub(
+            _STRUCT_STEP1_STRONG, _STRUCT_STEP2_STRONG, _step3(0.2)
+        )
+        score, _ = detect_structure_logique_agentic("text", llm=stub)
+        assert score == 0.2
+
+    # --- exhaustivite ---
+
+    def test_exhaustivite_zero_propagates(self):
+        stub = _make_order_stub(
+            _EXHAUST_STEP1, _EXHAUST_STEP2, _step3(0.0)
+        )
+        score, _ = detect_exhaustivite_agentic("text", llm=stub)
+        assert score == 0.0
+
+    def test_exhaustivite_low_score_no_floor_up(self):
+        stub = _make_order_stub(
+            _EXHAUST_STEP1, _EXHAUST_STEP2, _step3(0.2)
+        )
+        score, _ = detect_exhaustivite_agentic("text", llm=stub)
+        assert score == 0.2
+
+    # --- redondance_faible ---
+
+    def test_redondance_zero_propagates_when_points_distinct(self):
+        stub = _make_order_stub(
+            _REDOND_STEP1, _REDOND_STEP2, _step3(0.0)
+        )
+        score, _ = detect_redondance_faible_agentic("text", llm=stub)
+        assert score == 0.0
+
+    def test_redondance_low_score_no_floor_up(self):
+        stub = _make_order_stub(
+            _REDOND_STEP1, _REDOND_STEP2, _step3(0.2)
+        )
+        score, _ = detect_redondance_faible_agentic("text", llm=stub)
+        assert score == 0.2
+
+
+class TestBidirectionalFidelity:
+    """The mirror check: a controlled HIGH step3 score must ALSO propagate
+    faithfully (not masked down). Confirms the detector uses step3 verbatim in
+    BOTH directions — it is a pure pass-through of the LLM verdict, not a
+    one-directional correction."""
+
+    def test_pertinence_high_score_propagates(self):
+        stub = _make_order_stub(
+            _PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(1.0)
+        )
+        score, _ = detect_pertinence_agentic("text", llm=stub)
+        assert score == 1.0
+
+    def test_structure_high_score_propagates(self):
+        stub = _make_order_stub(
+            _STRUCT_STEP1_STRONG, _STRUCT_STEP2_STRONG, _step3(1.0)
+        )
+        score, _ = detect_structure_logique_agentic("text", llm=stub)
+        assert score == 1.0
+
+    def test_redondance_high_score_propagates(self):
+        stub = _make_order_stub(
+            _REDOND_STEP1, _REDOND_STEP2, _step3(1.0)
+        )
+        score, _ = detect_redondance_faible_agentic("text", llm=stub)
+        assert score == 1.0
+
+
+class TestExhibitNonVacant:
+    """Anti-theatre (#1019): the `exhibit` (located structure a 0-shot cannot
+    emit) must be embedded and non-empty in the returned comment — the
+    content-separation evidence is real, not a bare score."""
+
+    @pytest.mark.parametrize(
+        "detect, s1, s2",
+        [
+            (detect_pertinence_agentic, _PERT_STEP1_STRONG, _PERT_STEP2_STRONG),
+            (detect_clarte_agentic, _CLARTE_STEP1_OBSTACLE, _CLARTE_STEP2),
+            (detect_structure_logique_agentic, _STRUCT_STEP1_STRONG, _STRUCT_STEP2_STRONG),
+            (detect_exhaustivite_agentic, _EXHAUST_STEP1, _EXHAUST_STEP2),
+            (detect_redondance_faible_agentic, _REDOND_STEP1, _REDOND_STEP2),
+        ],
+    )
+    def test_exhibit_embedded_non_empty(self, detect, s1, s2):
+        marker = "LOCATED_STRUCTURE_MARKER_X"
+        stub = _make_order_stub(s1, s2, _step3(0.5, exhibit=marker))
+        _, comment = detect("text", llm=stub)
+        assert marker in comment, (
+            f"{detect.__name__}: exhibit not embedded in comment — content-"
+            f"separation evidence is vacant (theatre risk #1019)"
+        )
+
+    def test_pertinence_comment_carries_verdict(self):
+        """The step2 verdict token must surface in the comment — proves the
+        chain's verify-step output is retained, not discarded."""
+        stub = _make_order_stub(
+            _PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.5)
+        )
+        _, comment = detect_pertinence_agentic("text", llm=stub)
+        assert "toutes_pertinentes" in comment
+
+
+class TestFailLoudOnCorruptedStep:
+    """Bounds the measurement against a corrupted chain. Two distinct cases:
+
+    1. Non-numeric score (string / None / bool) → ``AgenticDetectorError``
+       (fail-loud). A corrupted chain cannot quietly inject a fabricated score.
+    2. Numeric but off-scale (e.g. 0.7) → snapped to the nearest scale value
+       (0.7→0.5), NOT raised. This is a deliberate tolerance: the LLM is asked
+       for strict {0.0,0.2,0.5,1.0} and mostly complies; minor imprecision is
+       snapped rather than failing the whole chain. It is NOT an inflation
+       vector because the head-to-head script applies the SAME ``_snap_to_scale``
+       to the 0-shot baseline side (symmetric) — snapping cannot bias the
+       pipe-vs-base differential."""
+
+    def test_pertinence_nonscale_string_raises(self):
+        stub = _make_order_stub(
+            _PERT_STEP1_STRONG,
+            _PERT_STEP2_STRONG,
+            {"score": "high", "exhibit": "x"},  # string, not coercible
+        )
+        with pytest.raises(AgenticDetectorError):
+            detect_pertinence_agentic("text", llm=stub)
+
+    def test_structure_string_score_raises(self):
+        stub = _make_order_stub(
+            _STRUCT_STEP1_STRONG,
+            _STRUCT_STEP2_STRONG,
+            {"score": "high", "exhibit": "x"},  # string, not float
+        )
+        with pytest.raises(AgenticDetectorError):
+            detect_structure_logique_agentic("text", llm=stub)
+
+    def test_pertinence_midscale_snaps_symmetric(self):
+        """0.7 (off-scale numeric) snaps to 0.5 (nearest) — tolerance, not
+        fail-loud. Symmetric with the baseline's _snap_to_scale, so it cannot
+        bias the pipe-vs-base measurement."""
+        stub = _make_order_stub(
+            _PERT_STEP1_STRONG,
+            _PERT_STEP2_STRONG,
+            {"score": 0.7, "exhibit": "x"},
+        )
+        score, _ = detect_pertinence_agentic("text", llm=stub)
+        assert score == 0.5, f"0.7 should snap to 0.5, got {score}"
+
+    def test_structure_bool_score_raises(self):
+        """bool is an int subclass but must be rejected (True==1 would snap to
+        1.0) — _snap_to_scale explicitly returns None for bool."""
+        stub = _make_order_stub(
+            _STRUCT_STEP1_STRONG,
+            _STRUCT_STEP2_STRONG,
+            {"score": True, "exhibit": "x"},
+        )
+        with pytest.raises(AgenticDetectorError):
+            detect_structure_logique_agentic("text", llm=stub)

--- a/tests/unit/argumentation_analysis/agents/core/quality/test_fb38_adversarial_verify.py
+++ b/tests/unit/argumentation_analysis/agents/core/quality/test_fb38_adversarial_verify.py
@@ -46,7 +46,6 @@ from argumentation_analysis.agents.core.quality.agentic_virtue_detectors import 
     AgenticDetectorError,
 )
 
-
 # ── Call-order stub factory ──────────────────────────────────────────────────
 # Each detector calls the LLM exactly 3 times in sequence (step1, step2, step3).
 # We discriminate by invocation count, NOT prompt content — this is what lets us
@@ -133,9 +132,7 @@ class TestNoUpwardInflation:
     # --- pertinence (the reported +0.516 separator — highest priority) ---
 
     def test_pertinence_zero_propagates_when_steps_say_strong(self):
-        stub = _make_order_stub(
-            _PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.0)
-        )
+        stub = _make_order_stub(_PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.0))
         score, _ = detect_pertinence_agentic("text", llm=stub)
         assert score == 0.0, (
             "pertinence floored a 0.0 step3 score up — potential inflation "
@@ -143,80 +140,60 @@ class TestNoUpwardInflation:
         )
 
     def test_pertinence_low_score_no_floor_up(self):
-        stub = _make_order_stub(
-            _PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.2)
-        )
+        stub = _make_order_stub(_PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.2))
         score, _ = detect_pertinence_agentic("text", llm=stub)
         assert score == 0.2
 
     def test_pertinence_mid_score_propagates(self):
-        stub = _make_order_stub(
-            _PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.5)
-        )
+        stub = _make_order_stub(_PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.5))
         score, _ = detect_pertinence_agentic("text", llm=stub)
         assert score == 0.5
 
     # --- clarte ---
 
     def test_clarte_zero_propagates_when_obstacle_present(self):
-        stub = _make_order_stub(
-            _CLARTE_STEP1_OBSTACLE, _CLARTE_STEP2, _step3(0.0)
-        )
+        stub = _make_order_stub(_CLARTE_STEP1_OBSTACLE, _CLARTE_STEP2, _step3(0.0))
         score, _ = detect_clarte_agentic("text", llm=stub)
         assert score == 0.0
 
     def test_clarte_low_score_no_floor_up(self):
-        stub = _make_order_stub(
-            _CLARTE_STEP1_OBSTACLE, _CLARTE_STEP2, _step3(0.2)
-        )
+        stub = _make_order_stub(_CLARTE_STEP1_OBSTACLE, _CLARTE_STEP2, _step3(0.2))
         score, _ = detect_clarte_agentic("text", llm=stub)
         assert score == 0.2
 
     # --- structure_logique ---
 
     def test_structure_zero_propagates_when_chain_present(self):
-        stub = _make_order_stub(
-            _STRUCT_STEP1_STRONG, _STRUCT_STEP2_STRONG, _step3(0.0)
-        )
+        stub = _make_order_stub(_STRUCT_STEP1_STRONG, _STRUCT_STEP2_STRONG, _step3(0.0))
         score, _ = detect_structure_logique_agentic("text", llm=stub)
         assert score == 0.0
 
     def test_structure_low_score_no_floor_up(self):
-        stub = _make_order_stub(
-            _STRUCT_STEP1_STRONG, _STRUCT_STEP2_STRONG, _step3(0.2)
-        )
+        stub = _make_order_stub(_STRUCT_STEP1_STRONG, _STRUCT_STEP2_STRONG, _step3(0.2))
         score, _ = detect_structure_logique_agentic("text", llm=stub)
         assert score == 0.2
 
     # --- exhaustivite ---
 
     def test_exhaustivite_zero_propagates(self):
-        stub = _make_order_stub(
-            _EXHAUST_STEP1, _EXHAUST_STEP2, _step3(0.0)
-        )
+        stub = _make_order_stub(_EXHAUST_STEP1, _EXHAUST_STEP2, _step3(0.0))
         score, _ = detect_exhaustivite_agentic("text", llm=stub)
         assert score == 0.0
 
     def test_exhaustivite_low_score_no_floor_up(self):
-        stub = _make_order_stub(
-            _EXHAUST_STEP1, _EXHAUST_STEP2, _step3(0.2)
-        )
+        stub = _make_order_stub(_EXHAUST_STEP1, _EXHAUST_STEP2, _step3(0.2))
         score, _ = detect_exhaustivite_agentic("text", llm=stub)
         assert score == 0.2
 
     # --- redondance_faible ---
 
     def test_redondance_zero_propagates_when_points_distinct(self):
-        stub = _make_order_stub(
-            _REDOND_STEP1, _REDOND_STEP2, _step3(0.0)
-        )
+        stub = _make_order_stub(_REDOND_STEP1, _REDOND_STEP2, _step3(0.0))
         score, _ = detect_redondance_faible_agentic("text", llm=stub)
         assert score == 0.0
 
     def test_redondance_low_score_no_floor_up(self):
-        stub = _make_order_stub(
-            _REDOND_STEP1, _REDOND_STEP2, _step3(0.2)
-        )
+        stub = _make_order_stub(_REDOND_STEP1, _REDOND_STEP2, _step3(0.2))
         score, _ = detect_redondance_faible_agentic("text", llm=stub)
         assert score == 0.2
 
@@ -228,23 +205,17 @@ class TestBidirectionalFidelity:
     one-directional correction."""
 
     def test_pertinence_high_score_propagates(self):
-        stub = _make_order_stub(
-            _PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(1.0)
-        )
+        stub = _make_order_stub(_PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(1.0))
         score, _ = detect_pertinence_agentic("text", llm=stub)
         assert score == 1.0
 
     def test_structure_high_score_propagates(self):
-        stub = _make_order_stub(
-            _STRUCT_STEP1_STRONG, _STRUCT_STEP2_STRONG, _step3(1.0)
-        )
+        stub = _make_order_stub(_STRUCT_STEP1_STRONG, _STRUCT_STEP2_STRONG, _step3(1.0))
         score, _ = detect_structure_logique_agentic("text", llm=stub)
         assert score == 1.0
 
     def test_redondance_high_score_propagates(self):
-        stub = _make_order_stub(
-            _REDOND_STEP1, _REDOND_STEP2, _step3(1.0)
-        )
+        stub = _make_order_stub(_REDOND_STEP1, _REDOND_STEP2, _step3(1.0))
         score, _ = detect_redondance_faible_agentic("text", llm=stub)
         assert score == 1.0
 
@@ -259,7 +230,11 @@ class TestExhibitNonVacant:
         [
             (detect_pertinence_agentic, _PERT_STEP1_STRONG, _PERT_STEP2_STRONG),
             (detect_clarte_agentic, _CLARTE_STEP1_OBSTACLE, _CLARTE_STEP2),
-            (detect_structure_logique_agentic, _STRUCT_STEP1_STRONG, _STRUCT_STEP2_STRONG),
+            (
+                detect_structure_logique_agentic,
+                _STRUCT_STEP1_STRONG,
+                _STRUCT_STEP2_STRONG,
+            ),
             (detect_exhaustivite_agentic, _EXHAUST_STEP1, _EXHAUST_STEP2),
             (detect_redondance_faible_agentic, _REDOND_STEP1, _REDOND_STEP2),
         ],
@@ -276,9 +251,7 @@ class TestExhibitNonVacant:
     def test_pertinence_comment_carries_verdict(self):
         """The step2 verdict token must surface in the comment — proves the
         chain's verify-step output is retained, not discarded."""
-        stub = _make_order_stub(
-            _PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.5)
-        )
+        stub = _make_order_stub(_PERT_STEP1_STRONG, _PERT_STEP2_STRONG, _step3(0.5))
         _, comment = detect_pertinence_agentic("text", llm=stub)
         assert "toutes_pertinentes" in comment
 


### PR DESCRIPTION
Recovers po-2023's FB-38 adversarial cross-verify (originally **#1129**), which GitHub auto-closed when its stacked base branch `feat/1127-fb38-quality-agentic` was deleted on the #1128 squash-merge. Re-based onto main `e55804c4` as a fresh branch — the 2 files are NEW and file-disjoint, so the rebase is trivial (no conflict with #1128's detector code).

## What
- `test_fb38_adversarial_verify.py` — 24 call-order adversarial probes (decouple step3 score from step2 verdict) proving **no upward inflation** across the 5 new FB-38 detectors. **24/24 pass** against the merged detectors on main.
- `FB38_ADVERSARIAL_CROSSVERIFY.md` — the cross-verify report (opaque IDs only, leak-audited).

## Verdict (po-2023, independent lane)
FB-38 **HOLDS — EDGES honestly earned, no inflation**. The `pertinence +0.516` separation is real (not a code-level floor-up); the measured result is a bidirectional split (2/7 separates, 2/7 stricter, 3/7 neutral) = not dominance → DECIDES not earned. Concurs with po-2025's #1128 verdict.

→ The Epic #947 quality axis EDGES is now **independently cross-verified** and can bear on closure.

Privacy: opaque IDs only, 0 deletions, test-only + report (no production behavior change).

Refs #1127 (FB-38), #947.

🤖 Coordinator ai-01 — R418 (stale-branch recovery)