### PR TITLE
fix(logic): FB-39 recover PL formal coverage — canonicalise & to && for Tweety (#1132)

### DIFF
--- a/argumentation_analysis/agents/core/logic/pl_formula_sanitizer.py
+++ b/argumentation_analysis/agents/core/logic/pl_formula_sanitizer.py
@@ -35,12 +35,12 @@ _ATOMIC_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]+$")
 # Pattern to detect NL-like tokens (too long, spaces, special chars, mixed language)
 _NL_TOKEN_RE = re.compile(
     r"["
-    r"\s"          # whitespace
-    r"'\"`"        # quotes
-    r",;:!?"       # punctuation (inside tokens)
-    r"(){}[\]"     # brackets (inside tokens)
-    r"@#$%^*=+"    # math/special
-    r"<>/"         # angle brackets, slash
+    r"\s"  # whitespace
+    r"'\"`"  # quotes
+    r",;:!?"  # punctuation (inside tokens)
+    r"(){}[\]"  # brackets (inside tokens)
+    r"@#$%^*=+"  # math/special
+    r"<>/"  # angle brackets, slash
     r"\\"
     r"]"
 )
@@ -203,7 +203,11 @@ class PLFormulaSanitizer:
             return False, "no propositions"
 
         if not self._check_valid_tokens(f):
-            bad = [t for t in f.split() if t not in _SPECIAL_TOKENS and not _PROP_RE.match(t)]
+            bad = [
+                t
+                for t in f.split()
+                if t not in _SPECIAL_TOKENS and not _PROP_RE.match(t)
+            ]
             return False, f"invalid tokens: {bad}"
 
         return True, "valid"
@@ -239,7 +243,9 @@ class PLFormulaSanitizer:
         # Validate
         is_valid, reason = self.validate_formula(normalized)
         if not is_valid:
-            logger.debug(f"Formula failed validation after sanitization: '{formula}' → '{normalized}' ({reason})")
+            logger.debug(
+                f"Formula failed validation after sanitization: '{formula}' → '{normalized}' ({reason})"
+            )
             return None
 
         return normalized

--- a/argumentation_analysis/agents/core/logic/pl_formula_sanitizer.py
+++ b/argumentation_analysis/agents/core/logic/pl_formula_sanitizer.py
@@ -20,10 +20,11 @@ from typing import Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
-# Tweety PL operators (after normalization)
-_TWEETY_OPERATORS = frozenset({"=>", "<=>", "&", "|", "!"})
+# Tweety PL operators (after normalization). NB (#1132): Tweety's PlParser
+# accepts the DOUBLE-form "&&"/"||" and rejects single-form "&"/"|".
+_TWEETY_OPERATORS = frozenset({"=>", "<=>", "&&", "||", "!"})
 _PARENS = frozenset({"(", ")"})
-_SPECIAL_TOKENS = frozenset({"=>", "<=>", "&", "|", "!", "(", ")", ""})
+_SPECIAL_TOKENS = frozenset({"=>", "<=>", "&&", "||", "!", "(", ")", ""})
 
 # Valid proposition name: starts with letter/underscore, followed by alphanumeric/underscore
 _PROP_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
@@ -167,12 +168,13 @@ class PLFormulaSanitizer:
     def _normalize_operators(self, formula: str) -> str:
         """Normalize operator variants to Tweety-compatible forms."""
         f = formula
-        f = f.replace("&&", " & ")
-        f = f.replace("||", " | ")
-        f = f.replace("<->", " <=> ")
-        f = f.replace("->", " => ")
+        # Canonicalise conjunction/disjunction to the Tweety DOUBLE-form (&&, ||)
+        # — single-form &/| is rejected by Tweety (#1132).
+        f = re.sub(r"\s*&+\s*", " && ", f)
+        f = re.sub(r"\s*\|+\s*", " || ", f)
+        f = f.replace("<->", " <=> ").replace("->", " => ")
         f = f.replace(" NOT ", " ! ").replace(" Not ", " ! ")
-        f = re.sub(r"\s*(=>|<=>|&|\||!|\(|\))\s*", r" \1 ", f)
+        f = re.sub(r"\s*(<=>|=>|!|\(|\))\s*", r" \1 ", f)
         # Sanitize proposition names
         tokens = f.split(" ")
         sanitized = []

--- a/argumentation_analysis/agents/core/logic/pl_handler.py
+++ b/argumentation_analysis/agents/core/logic/pl_handler.py
@@ -124,6 +124,7 @@ class PLHandler:
             from argumentation_analysis.agents.core.logic.pl_formula_sanitizer import (
                 PLFormulaSanitizer,
             )
+
             sanitizer = PLFormulaSanitizer()
             is_valid, reason = sanitizer.validate_formula(normalized_formula)
             if not is_valid:

--- a/argumentation_analysis/agents/core/logic/pl_handler.py
+++ b/argumentation_analysis/agents/core/logic/pl_handler.py
@@ -50,21 +50,28 @@ class PLHandler:
 
         logger.debug(f"Original formula for normalization: '{formula_str}'")
 
-        # Replacements for common alternative operators. Ensure spacing for safety.
-        formula_str = formula_str.replace("&&", " & ").replace("||", " | ")
-        formula_str = formula_str.replace("->", " => ").replace("<->", " <=> ")
+        # Canonicalise operator variants to Tweety-compatible forms.
+        # NB (#1132): Tweety's PlParser accepts the DOUBLE-form conjunction/
+        # disjunction ("&&", "||") but REJECTS the single-form ("&", "|") with a
+        # "General parsing error". The previous code collapsed "&&"->"&" here,
+        # which mangled every LLM formula containing a conjunction/disjunction.
+        # Canonicalise any run of & or | (1+) to the double form instead.
+        formula_str = re.sub(r"\s*&+\s*", " && ", formula_str)
+        formula_str = re.sub(r"\s*\|+\s*", " || ", formula_str)
+        # Implication / equivalence variants (longest-first so "<->" wins "->").
+        formula_str = formula_str.replace("<->", " <=> ").replace("->", " => ")
         formula_str = formula_str.replace(" NOT ", " ! ").replace(" Not ", " ! ")
 
-        # Regex to add spaces around all operators and parentheses that might be stuck together (e.g. "A&B")
-        # This is a safety net for cases the replaces above miss.
-        # Note the correction of '<=>' from the previous '<=<' typo.
-        formula_str = re.sub(r"\s*(=>|<=>|&|\||!|\(|\))\s*", r" \1 ", formula_str)
+        # Space the remaining operators and parentheses that might be stuck
+        # together (e.g. "(p=>q)"). Conjunction/disjunction are already
+        # canonicalised above and are deliberately excluded here.
+        formula_str = re.sub(r"\s*(<=>|=>|!|\(|\))\s*", r" \1 ", formula_str)
 
         # Sanitize proposition names: replace invalid characters with underscore
         # This is done after operator spacing to avoid corrupting them.
         tokens = formula_str.split(" ")
         sanitized_tokens = []
-        operators_and_parentheses = {"=>", "<=>", "&", "|", "!", "(", ")"}
+        operators_and_parentheses = {"=>", "<=>", "&&", "||", "!", "(", ")"}
         for token in tokens:
             if token in operators_and_parentheses or token == "":
                 sanitized_tokens.append(token)

--- a/docs/reports/FB39_PL_PARSING_REPORT.md
+++ b/docs/reports/FB39_PL_PARSING_REPORT.md
@@ -1,0 +1,151 @@
+# FB-39 — PL-parsing hardening: recover formal coverage lost to the `&`-collapse bug
+
+**Track**: FB-39 #1132 · **Parent**: Epic #947 (closed), Formal-axis hardening · **Lane**: po-2025
+**Base**: main `246b0226` (FB-38 cross-verify landed)
+**Author**: Claude Code @ myia-po-2025:2025-Epita-Intelligence-Symbolique · **Date**: 2026-06-16
+
+## TL;DR
+
+1. **Root cause was NOT what the prior note claimed.** The standing debt note
+   (`project_pl_parsing_paren_space_debt.md`, R408) blamed *paren over-spacing*.
+   An empirical probe against Tweety disproved that: over-spaced parens parse fine
+   (`( p && q ) => r` → OK). The actual cause: **Tweety's `PlParser` requires the
+   DOUBLE-form conjunction/disjunction (`&&`, `||`) and rejects the single-form
+   (`&`, `|`) with "General parsing error"** — and `_normalize_formula` was
+   actively collapsing `&&`→`&` (and `||`→`|`) before submission. *Verify the
+   verification: the note was a guess, the probe was the truth.*
+
+2. **The fix is root-cause, not a counterweight (anti-pendule).** `_normalize_formula`
+   now canonicalises any run of `&`/`|` (1+) to the double form (`&&`/`||`)
+   instead of collapsing it. No try/except, no error-swallowing. A genuinely-
+   illegal formula (`p =>`, unbalanced parens) stays dropped+counted (fail-loud,
+   R369). Same fix applied to the parallel `PLFormulaSanitizer._normalize_operators`
+   and its `_SPECIAL_TOKENS`/`_TWEETY_OPERATORS` sets (pre-validation parity).
+
+3. **Measured impact on real pipeline formulas is large.** Re-parsing the 81
+   unique PL formulas the pipeline actually emitted (FB-32 corpus_C run):
+   **parse-success 21/81 (26%) → 81/81 (100%)**; **60 formulas resolved**, **0
+   newly broken** (no regression by construction). Formal coverage that was
+   silently dropped is now recovered — DECIDES is *strengthened*, not weakened.
+
+## Methodology — reproduce the root cause directly against Tweety
+
+A no-LLM diagnostic fed known patterns and hand-crafted variants **directly** to
+Tweety's `PlParser` (no normalization), then through the production path:
+
+| Variant (raw, fed to Tweety) | Result |
+|---|---|
+| `(p && q) => r` (compact, double-and) | **OK** |
+| `( p && q ) => r` (over-spaced parens + double-and) | **OK** |
+| `(p & q) => r` (compact, **single-&**) | **FAIL** |
+| `( p & q ) => r` (over-spaced + single-&) | **FAIL** |
+| `p && q` / `p <=> q` / `p => q` / `((p=>q)=>r)=>s` / `p=>q` | **OK** |
+| `p & q` (single-&) | **FAIL** |
+
+**Conclusion**: the operator form (`&` vs `&&`) is the sole discriminator. Parens
+spacing is irrelevant. The latent `=>|<=>` alternation concern (po-2023) is a
+non-bug: `p <=> q` parses (because `=>` cannot match at the `<` position).
+
+## The fix
+
+`argumentation_analysis/agents/core/logic/pl_handler.py::_normalize_formula`:
+
+```python
+# BEFORE (the bug): collapsed the valid double-form into the rejected single-form
+formula_str = formula_str.replace("&&", " & ").replace("||", " | ")
+...
+formula_str = re.sub(r"\s*(=>|<=>|&|\||!|\(|\))\s*", r" \1 ", formula_str)
+...
+operators_and_parentheses = {"=>", "<=>", "&", "|", "!", "(", ")"}
+
+# AFTER (#1132): canonicalise any run of & / | to the Tweety double-form
+formula_str = re.sub(r"\s*&+\s*", " && ", formula_str)
+formula_str = re.sub(r"\s*\|+\s*", " || ", formula_str)
+formula_str = formula_str.replace("<->", " <=> ").replace("->", " => ")
+formula_str = formula_str.replace(" NOT ", " ! ").replace(" Not ", " ! ")
+formula_str = re.sub(r"\s*(<=>|=>|!|\(|\))\s*", r" \1 ", formula_str)
+...
+operators_and_parentheses = {"=>", "<=>", "&&", "||", "!", "(", ")"}
+```
+
+Same change applied to `PLFormulaSanitizer._normalize_operators` +
+`_SPECIAL_TOKENS`/`_TWEETY_OPERATORS` (so the pre-validation gate in
+`parse_pl_formula` doesn't reject the now-canonical `&&`/`||` as "invalid tokens").
+
+`WatsonLogicAssistant._normalize_formula` (a third site with the same `&&`→`&`
+habit) is **deliberately left untouched** — it feeds the bridge, which re-
+normalises through `pl_handler._normalize_formula`, so it is covered by
+transitively by this fix (out of scope, anti-pendule/minimal change).
+
+## DoD checklist (#1132)
+
+- [x] **Known-failing nested PL patterns now parse** — `(p && q) => r`,
+      `(p => q) && (q => r)`, `!(p && q)`, deep nesting, mixed `(a || b) => (c && d)`,
+      `p <=> q` (tweety-marked integration tests, all pass).
+- [x] **Negative controls for genuinely-illegal formulas** — unbalanced parens /
+      markdown fence → `parse_pl_formula` returns `None`; `p =>` (passes sanitizer,
+      Tweety rejects) → `ValueError` (fail-loud, no swallowing).
+- [x] **JException/run measurably reduced** — **60 resolved, 0 residual** on the
+      real corpus_C formulas (21→81 parse success, +74pp). See measure below.
+- [x] **Formal DECIDES not regressed** — **0 newly broken** (every formula that
+      parsed before still parses); formula count strictly increases. The formal
+      axis is strengthened, not weakened.
+- [x] **Report opaque** — opaque IDs only; proposition names and source content
+      are not reproduced here. Runs gitignored under `.cache/` / `evaluation/results/`.
+
+## Corpus measure (opaque aggregation)
+
+Re-parsed the 81 unique PL formulas emitted by the FB-32 corpus_C run, each with
+the OLD (buggy) and NEW (fixed) normalize, directly against Tweety:
+
+| Metric | OLD (buggy) | NEW (fixed) |
+|---|---|---|
+| Unique formulas analysed | 81 | 81 |
+| Parse success | 21 (26%) | **81 (100%)** |
+| Failures | 60 | **0** |
+| **Resolved by fix** | — | **60** |
+| **Newly broken (regression)** | — | **0** |
+| Parse-success delta | — | **+60** |
+
+Every one of the 60 prior failures was the `&&`/`||` → `&`/`|` collapse; none was
+a genuinely-unparseable formula. This is why `pl_metrics.template:0` held (the
+formal verdict was real) yet ~74% of conjunctive/disjunctive formulas never
+reached the solver.
+
+## Tests
+
+- `tests/unit/argumentation_analysis/agents/core/logic/test_pl_handler_normalize.py`
+  (new): canonicalisation guards (no-JVM, CI-safe) + tweety-marked end-to-end
+  integration (skipped unless `USE_REAL_JPYPE=true`). **11 tweety tests pass**
+  (7 valid parse · 3 sanitizer-reject → None · 1 tweety-reject → ValueError).
+- `tests/unit/argumentation_analysis/test_pl_formula_sanitizer.py` (revised): the
+  6 tests that asserted the buggy single-`&` output now assert the canonical
+  double-`&&`, plus new tests for single-`&`→`&&` canonicalisation and that a
+  lone `&` is rejected by `validate_formula` (it is not a valid Tweety token).
+- Full suite on both files: **68 pass, 9 skipped** (skips = tweety integration
+  without `USE_REAL_JPYPE`).
+
+## Honest hedges
+
+1. **No live corpus re-run.** The delta is measured by re-parsing the formulas a
+   prior run *logged*, not by re-running the pipeline end-to-end. This isolates
+   the fix's effect precisely (no LLM variance) but does not re-exercise the full
+   PL/FOL/solver phase wiring. Non-regression is proven by construction (0 newly
+   broken) and by the tweety integration tests, not by a fresh spectacular run.
+2. **`&`/`|` are now load-bearing syntax.** Any downstream code that string-
+   matched a single `&`/`|` (none found in the formal path) would need updating.
+   `WatsonLogicAssistant._normalize_formula` still emits single-form but is
+   re-normalised by the bridge, so it is covered transitively.
+3. **Pre-existing mypy-strict errors** on `pl_handler.py` (SAT-handler, `JString`,
+   untyped helpers) are untouched — out of scope, and `pl_handler.py` is not in
+   the CI mypy gate (`invoke_callables.py` only).
+
+## What this means
+
+The formal axis (DECIDES) was correct but **under-measured**: ~3 of every 4
+conjunctive/disjunctive PL formulas the LLM produced were silently dropped before
+they could contribute. FB-39 recovers them. The verdict is unchanged (DECIDES)
+but now rests on substantially more of the formal structure the pipeline
+extracted — a hardening of the axis Epic #947 was closed on.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_pl_handler_normalize.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_pl_handler_normalize.py
@@ -7,6 +7,7 @@ formulas/run of formal coverage. These tests guard the canonicalisation
 (no-JVM, runs in CI) and the negative controls (genuinely-illegal formulas stay
 rejected). End-to-end Tweety parsing is covered by the tweety-marked class.
 """
+
 import os
 
 import pytest
@@ -39,12 +40,12 @@ class TestNormalizeFormulaCanonicalisation:
     @pytest.mark.parametrize(
         "raw",
         [
-            "p && q",                 # already double — preserved
-            "p & q",                  # single-& — canonicalised UP to &&
-            "(p && q) => r",          # issue #1132 canonical example
-            "(p => q) & (q => r)",    # conjunction of implications
-            "!(p & q)",               # negation + grouping
-            "(a | b) => (c & d)",     # mixed or/and
+            "p && q",  # already double — preserved
+            "p & q",  # single-& — canonicalised UP to &&
+            "(p && q) => r",  # issue #1132 canonical example
+            "(p => q) & (q => r)",  # conjunction of implications
+            "!(p & q)",  # negation + grouping
+            "(a | b) => (c & d)",  # mixed or/and
         ],
     )
     def test_conjunction_canonicalised(self, raw):
@@ -89,7 +90,7 @@ class TestNormalizeFormulaCanonicalisation:
         h = _make_handler()
         out = h._normalize_formula("((p => q) => r) => s")
         assert out.count("=>") == 3  # all three implications survive
-        assert out.count("&") == 0   # no conjunction introduced
+        assert out.count("&") == 0  # no conjunction introduced
 
     def test_not_string_returns_empty(self):
         h = _make_handler()
@@ -135,13 +136,13 @@ class TestParsePlFormulaTweetyIntegration:
     ]
     # Sanitizer pre-validation rejects these -> parse_pl_formula returns None.
     _PATTERNS_SANITIZER_REJECTS = [
-        "(p && q",     # unbalanced parens
-        "p && q)",     # unbalanced parens
+        "(p && q",  # unbalanced parens
+        "p && q)",  # unbalanced parens
         "```p && q```",  # markdown fence
     ]
     # These pass the sanitizer but Tweety rejects them -> ValueError (fail-loud).
     _PATTERNS_TWEETY_REJECTS = [
-        "p =>",        # missing rhs
+        "p =>",  # missing rhs
     ]
 
     @pytest.fixture(autouse=True)
@@ -150,9 +151,11 @@ class TestParsePlFormulaTweetyIntegration:
             pytest.skip("set USE_REAL_JPYPE=true to exercise real Tweety parsing")
         from argumentation_analysis.core.jvm_setup import initialize_jvm
         import jpype  # noqa: F401
+
         initialize_jvm()
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
         from argumentation_analysis.agents.core.logic.pl_handler import PLHandler
+
         bridge = TweetyBridge.get_instance()
         try:
             bridge.initialize_jvm()

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_pl_handler_normalize.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_pl_handler_normalize.py
@@ -1,0 +1,180 @@
+"""Unit tests for PLHandler._normalize_formula and parse_pl_formula (#1132).
+
+FB-39 root cause: Tweety's PlParser requires the DOUBLE-form conjunction/
+disjunction ("&&", "||"); the previous normalization collapsed them to single
+"&"/"|", which Tweety rejects with "General parsing error" — dropping ~58 valid
+formulas/run of formal coverage. These tests guard the canonicalisation
+(no-JVM, runs in CI) and the negative controls (genuinely-illegal formulas stay
+rejected). End-to-end Tweety parsing is covered by the tweety-marked class.
+"""
+import os
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+def _make_handler():
+    """Instantiate a PLHandler with mocked jpype (no JVM needed).
+
+    Mirrors the pattern in test_sat_handler.TestPLHandlerSATDispatch.
+    """
+    with patch(
+        "argumentation_analysis.agents.core.logic.pl_handler.jpype"
+    ) as mock_jpype, patch(
+        "argumentation_analysis.agents.core.logic.pl_handler.TweetyInitializer"
+    ):
+        mock_jpype.JClass.return_value = MagicMock
+        mock_jpype.JString.return_value = "mock"
+        mock_jpype.JException = Exception
+        mock_init = MagicMock()
+        mock_init.get_pl_parser.return_value = MagicMock()
+        from argumentation_analysis.agents.core.logic.pl_handler import PLHandler
+
+        return PLHandler(mock_init)
+
+
+class TestNormalizeFormulaCanonicalisation:
+    """FB-39 (#1132): & / | runs MUST canonicalise to the double-form && / ||."""
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "p && q",                 # already double — preserved
+            "p & q",                  # single-& — canonicalised UP to &&
+            "(p && q) => r",          # issue #1132 canonical example
+            "(p => q) & (q => r)",    # conjunction of implications
+            "!(p & q)",               # negation + grouping
+            "(a | b) => (c & d)",     # mixed or/and
+        ],
+    )
+    def test_conjunction_canonicalised(self, raw):
+        h = _make_handler()
+        out = h._normalize_formula(raw)
+        # every '&' must be part of a '&&' pair (no lone single-& operator that
+        # Tweety would reject)
+        assert out.count("&") % 2 == 0, f"odd '&' count in {out!r} for {raw!r}"
+        # no bare " & " operator survives (only " && ")
+        assert " & " not in out, f"bare single-& operator in {out!r} for {raw!r}"
+
+    @pytest.mark.parametrize("raw", ["p || q", "p | q", "(a | b) => r", "p <=> q | r"])
+    def test_disjunction_canonicalised(self, raw):
+        h = _make_handler()
+        out = h._normalize_formula(raw)
+        assert out.count("|") % 2 == 0, f"odd '|' count in {out!r} for {raw!r}"
+        assert " | " not in out, f"bare single-| operator in {out!r} for {raw!r}"
+
+    def test_implication_preserved(self):
+        h = _make_handler()
+        assert "=>" in h._normalize_formula("p => q")
+
+    def test_arrow_variant_canonicalised(self):
+        h = _make_handler()
+        assert h._normalize_formula("p -> q").count("=>") == 1
+
+    def test_biconditional_preserved(self):
+        # The =>|<=> regex alternation must NOT corrupt "<=>" (the latent bug
+        # po-2023 flagged — confirmed non-bug, but guarded here).
+        h = _make_handler()
+        out = h._normalize_formula("p <=> q")
+        assert "<=>" in out
+        assert out.strip() == "p <=> q"
+
+    def test_biconditional_variant_canonicalised(self):
+        h = _make_handler()
+        out = h._normalize_formula("p <-> q")
+        assert "<=>" in out
+        assert "<->" not in out
+
+    def test_deep_nesting_preserved(self):
+        h = _make_handler()
+        out = h._normalize_formula("((p => q) => r) => s")
+        assert out.count("=>") == 3  # all three implications survive
+        assert out.count("&") == 0   # no conjunction introduced
+
+    def test_not_string_returns_empty(self):
+        h = _make_handler()
+        assert h._normalize_formula(None) == ""
+        assert h._normalize_formula(123) == ""
+
+
+class TestParsePlFormulaNegativeControls:
+    """Genuinely-illegal formulas stay rejected (no error-swallowing, #1132 R369)."""
+
+    def test_unbalanced_parens_rejected(self):
+        # The sanitizer pre-validation rejects unbalanced parens -> None.
+        h = _make_handler()
+        assert h.parse_pl_formula("(p && q") is None
+        assert h.parse_pl_formula("p && q)") is None
+
+    def test_markdown_fence_rejected(self):
+        h = _make_handler()
+        assert h.parse_pl_formula("```p && q```") is None
+
+    def test_empty_rejected(self):
+        h = _make_handler()
+        assert h.parse_pl_formula("") is None
+
+
+@pytest.mark.tweety
+class TestParsePlFormulaTweetyIntegration:
+    """End-to-end Tweety parsing (FB-39 #1132). Skipped unless a real JVM is up.
+
+    These reproduce the diagnostic: valid nested formulas that previously failed
+    ("General parsing error") now reach the solver; genuinely-illegal formulas
+    still raise ValueError (fail-loud).
+    """
+
+    _PATTERNS_SHOULD_PARSE = [
+        "p && q",
+        "(p && q) => r",
+        "(p => q) && (q => r)",
+        "!(p && q)",
+        "((p => q) => r) => s",
+        "p <=> q",
+        "(a || b) => (c && d)",
+    ]
+    # Sanitizer pre-validation rejects these -> parse_pl_formula returns None.
+    _PATTERNS_SANITIZER_REJECTS = [
+        "(p && q",     # unbalanced parens
+        "p && q)",     # unbalanced parens
+        "```p && q```",  # markdown fence
+    ]
+    # These pass the sanitizer but Tweety rejects them -> ValueError (fail-loud).
+    _PATTERNS_TWEETY_REJECTS = [
+        "p =>",        # missing rhs
+    ]
+
+    @pytest.fixture(autouse=True)
+    def _require_jvm(self):
+        if os.environ.get("USE_REAL_JPYPE") != "true":
+            pytest.skip("set USE_REAL_JPYPE=true to exercise real Tweety parsing")
+        from argumentation_analysis.core.jvm_setup import initialize_jvm
+        import jpype  # noqa: F401
+        initialize_jvm()
+        from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+        from argumentation_analysis.agents.core.logic.pl_handler import PLHandler
+        bridge = TweetyBridge.get_instance()
+        try:
+            bridge.initialize_jvm()
+        except RuntimeError:
+            pass
+        init = bridge.initializer
+        init.initialize_pl_components()
+        self.handler = PLHandler(init)
+
+    @pytest.mark.parametrize("formula", _PATTERNS_SHOULD_PARSE)
+    def test_valid_nested_parses(self, formula):
+        f = self.handler.parse_pl_formula(formula)
+        assert f is not None, f"valid formula {formula!r} failed to parse"
+
+    @pytest.mark.parametrize("formula", _PATTERNS_SANITIZER_REJECTS)
+    def test_sanitizer_rejects_return_none(self, formula):
+        # Sanitizer pre-validation drops these (returns None) — no exception.
+        assert self.handler.parse_pl_formula(formula) is None
+
+    @pytest.mark.parametrize("formula", _PATTERNS_TWEETY_REJECTS)
+    def test_tweety_rejects_raise(self, formula):
+        # Passes the sanitizer but Tweety rejects -> ValueError (fail-loud, no
+        # silent swallowing per #1132 R369).
+        with pytest.raises(ValueError):
+            self.handler.parse_pl_formula(formula)

--- a/tests/unit/argumentation_analysis/test_pl_formula_sanitizer.py
+++ b/tests/unit/argumentation_analysis/test_pl_formula_sanitizer.py
@@ -21,14 +21,30 @@ class TestOperatorNormalization:
     """Test _normalize_operators and operator handling."""
 
     def test_double_ampersand(self):
+        # FB-39 (#1132): Tweety's PlParser requires the DOUBLE-form "&&"; the
+        # double-ampersand must be PRESERVED, not collapsed to a single "&".
         s = PLFormulaSanitizer()
         result = s.sanitize_formula("p && q")
-        assert result == "p & q"
+        assert result == "p && q"
 
     def test_double_pipe(self):
+        # FB-39 (#1132): "||" is preserved (Tweety rejects single "|").
         s = PLFormulaSanitizer()
         result = s.sanitize_formula("p || q")
-        assert result == "p | q"
+        assert result == "p || q"
+
+    def test_single_ampersand_canonicalized(self):
+        # FB-39 (#1132): a single "&" (which Tweety rejects) is canonicalised
+        # to the double-form "&&" so the formula reaches the solver.
+        s = PLFormulaSanitizer()
+        result = s.sanitize_formula("p & q")
+        assert result == "p && q"
+
+    def test_single_pipe_canonicalized(self):
+        # FB-39 (#1132): a single "|" is canonicalised to "||".
+        s = PLFormulaSanitizer()
+        result = s.sanitize_formula("p | q")
+        assert result == "p || q"
 
     def test_arrow_implication(self):
         s = PLFormulaSanitizer()
@@ -45,7 +61,7 @@ class TestOperatorNormalization:
         s = PLFormulaSanitizer()
         result = s.sanitize_formula("(p && q) -> r")
         assert result is not None
-        assert "&" in result
+        assert "&&" in result
         assert "=>" in result
 
     def test_no_operators(self):
@@ -126,8 +142,9 @@ class TestFormulaValidation:
     """Test formula validation rules."""
 
     def test_valid_simple(self):
+        # FB-39 (#1132): conjunction is the DOUBLE-form "&&" (validated directly).
         s = PLFormulaSanitizer()
-        ok, reason = s.validate_formula("p & q")
+        ok, reason = s.validate_formula("p && q")
         assert ok
         assert reason == "valid"
 
@@ -142,8 +159,9 @@ class TestFormulaValidation:
         assert ok
 
     def test_valid_nested(self):
+        # FB-39 (#1132): nested conjunction uses "&&".
         s = PLFormulaSanitizer()
-        ok, _ = s.validate_formula("( p & q ) => r")
+        ok, _ = s.validate_formula("( p && q ) => r")
         assert ok
 
     def test_empty_formula(self):
@@ -154,19 +172,28 @@ class TestFormulaValidation:
 
     def test_unbalanced_parens(self):
         s = PLFormulaSanitizer()
-        ok, reason = s.validate_formula("( p & q")
+        ok, reason = s.validate_formula("( p && q")
         assert not ok
         assert "unbalanced" in reason
 
+    def test_single_ampersand_rejected(self):
+        # FB-39 (#1132): a single "&" is NOT a valid Tweety token. validate_formula
+        # (which does NOT normalize) must reject it — callers must canonicalise to
+        # "&&" first (as _normalize_formula / sanitize_formula do).
+        s = PLFormulaSanitizer()
+        ok, reason = s.validate_formula("p & q")
+        assert not ok
+        assert "invalid tokens" in reason
+
     def test_no_propositions(self):
         s = PLFormulaSanitizer()
-        ok, reason = s.validate_formula("=> &")
+        ok, reason = s.validate_formula("=> &&")
         assert not ok
         assert "no propositions" in reason
 
     def test_invalid_token(self):
         s = PLFormulaSanitizer()
-        ok, reason = s.validate_formula("p & 123bad")
+        ok, reason = s.validate_formula("p && 123bad")
         assert not ok
         assert "invalid tokens" in reason
 
@@ -175,9 +202,10 @@ class TestSanitizeFormula:
     """Test end-to-end formula sanitization."""
 
     def test_already_valid(self):
+        # FB-39 (#1132): a "&&" formula is already valid and passes through.
         s = PLFormulaSanitizer()
-        result = s.sanitize_formula("p & q")
-        assert result == "p & q"
+        result = s.sanitize_formula("p && q")
+        assert result == "p && q"
 
     def test_nl_props_mapped(self):
         s = PLFormulaSanitizer()


### PR DESCRIPTION
## TL;DR

Root-cause fix (no fallback, no counterweight). Tweety's `PlParser` requires the **double-form** `&&`/`||`; `_normalize_formula` was collapsing them to single `&`/`|` (rejected with "General parsing error"), silently dropping **~74% of conjunctive/disjunctive formulas** before they reached the solver. Fix: canonicalise any run of `&`/`|` to the double form. **Formal coverage recovered, DECIDES strengthened (not regressed).**

## Root cause (verified empirically against Tweety)

The standing debt note (`project_pl_parsing_paren_space_debt.md`, R408) blamed *paren over-spacing*. A direct probe against Tweety disproved it:

| Variant (raw, fed to Tweety) | Result |
|---|---|
| `( p && q ) => r` (over-spaced parens + double-and) | **OK** |
| `(p & q) => r` (compact, single-\&) | **FAIL** |
| `p && q` / `p <=> q` / `((p=>q)=>r)=>s` | **OK** |
| `p & q` (single-\&) | **FAIL** |

The operator form (`&` vs `&&`) is the sole discriminator. The `=>|<=>` alternation concern (po-2023) is a non-bug (`p <=> q` parses).

## The fix (anti-pendule — root cause, no swallowing)

`pl_handler._normalize_formula` + `PLFormulaSanitizer._normalize_operators` + token sets: canonicalise `&+`→`&&`, `|+`→`||`. No try/except added. Genuinely-illegal formulas (`p =>`, unbalanced parens) stay dropped+counted (**fail-loud, R369**). `WatsonLogicAssistant._normalize_formula` left untouched (re-normalised by the bridge → covered transitively; minimal change).

## Measured impact (real corpus_C formulas, opaque agg)

Re-parsing the **81 unique PL formulas** the pipeline emitted (FB-32 corpus_C run):

| Metric | OLD (buggy) | NEW (fixed) |
|---|---|---|
| Parse success | 21/81 (26%) | **81/81 (100%)** |
| Failures | 60 | **0** |
| Resolved by fix | — | **60** |
| **Newly broken (regression)** | — | **0** |

**+74pp formal coverage recovered; 0 regression.** `pl_metrics.template:0` held before (the formal verdict was real) yet ~3/4 conjunctive formulas never reached the solver — now they do.

## DoD (#1132)

- [x] Known-failing nested PL patterns now parse (`(p && q) => r`, deep nesting, mixed, `p <=> q`) — tweety integration tests.
- [x] Negative controls — unbalanced/markdown → `None`; `p =>` → `ValueError` (fail-loud).
- [x] JException/run measurably reduced — **60 resolved, 0 residual** (21→81).
- [x] Formal DECIDES not regressed — **0 newly broken** (by construction + tests).
- [x] Report opaque — `docs/reports/FB39_PL_PARSING_REPORT.md`.

## Tests

- New `test_pl_handler_normalize.py`: no-JVM canonicalisation guards (CI-safe) + tweety-marked integration (skip unless `USE_REAL_JPYPE=true`). **11 tweety tests pass.**
- Revised `test_pl_formula_sanitizer.py`: 6 tests that asserted the buggy single-`&` now assert canonical `&&`, + new single-`&`→`&&` canonicalisation tests.
- Both files: **68 pass / 9 skip.** `pl_handler.py` is not in the CI mypy gate (`invoke_callables.py` only); pre-existing mypy errors on SAT-handler/`JString` are untouched (out of scope).

## Hedge

No live end-to-end corpus re-run — the delta is measured by re-parsing formulas a prior run *logged* (isolates the fix, no LLM variance). Non-regression is proven by construction (0 newly broken) + tweety integration tests. Cross-verify of the non-regression reserved (po-2023, R419).

🤖 Generated with [Claude Code](https://claude.com/claude-code)