### PR TITLE
feat(reporting): #1140 R6 restitution renderer + readability gate (Epic #1134)

### DIFF
--- a/argumentation_analysis/reporting/restitution/__init__.py
+++ b/argumentation_analysis/reporting/restitution/__init__.py
@@ -1,0 +1,36 @@
+"""Restitution reporting package — the readable 3-act report (Epic #1134 / R6).
+
+Assembles the spectacular ``UnifiedAnalysisState`` into a narrative a
+non-specialist can read, *replacing* the dimensional dump as the default
+spectacular output. The dump survives, folded, as an engineering appendix.
+
+See ``docs/architecture/RESTITUTION_REPORT_SPEC.md`` (R1, #1135) for the
+blueprint this package implements.
+"""
+
+from .acts import ACT_TITLES, RestitutionActs
+from .appendix import render_appendix
+from .readability_gate import (
+    GateVerdict,
+    ReadabilityGate,
+    ReaderCheckResult,
+)
+from .renderer import (
+    RenderedReport,
+    RestitutionReportRenderer,
+    render_restitution_report,
+)
+from .state_adapter import state_to_appendix_mapping
+
+__all__ = [
+    "ACT_TITLES",
+    "RestitutionActs",
+    "RestitutionReportRenderer",
+    "RenderedReport",
+    "ReadabilityGate",
+    "GateVerdict",
+    "ReaderCheckResult",
+    "render_appendix",
+    "render_restitution_report",
+    "state_to_appendix_mapping",
+]

--- a/argumentation_analysis/reporting/restitution/acts.py
+++ b/argumentation_analysis/reporting/restitution/acts.py
@@ -1,0 +1,74 @@
+"""The 3-act restitution contract (Epic #1134 / R6).
+
+This module defines the *input* contract that the act generators (R2 Acte I /
+R3 Acte II / R4 Acte III) produce and that the renderer (R6) consumes. It is a
+deliberately tiny, dependency-free dataclass so the renderer stays decoupled
+from *how* each act is generated — R6 tests against deterministic fixtures, and
+the real generators slot in later without touching the renderer (file-disjoint
+lanes, per the coordinator dispatch).
+
+See ``docs/architecture/RESTITUTION_REPORT_SPEC.md`` (R1, #1135) for the full
+blueprint. The three acts are markdown strings; an empty or degraded act is
+*reported honestly* by the renderer (fail-loud wording), never silently omitted
+(#1019 / #369).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+# The three acts, keyed by position, in narrative order (framing → core → action).
+ACT_TITLES: Dict[int, str] = {
+    1: "Acte I — Mise en situation",
+    2: "Acte II — Récit dialectique",
+    3: "Acte III — Conclusion actionnable",
+}
+
+
+@dataclass
+class RestitutionActs:
+    """The three narrative acts of a readable restitution report.
+
+    Attributes:
+        act1_framing: Acte I markdown — mise en situation (before citing the
+            text): genre, enjeux, expected fallacy spectrum, game-theoretic
+            read. The only act that may *anticipate* (spec §1.1).
+        act2_narrative: Acte II markdown — the dialectical narrative cut by
+            argumentative movement, weaving quality + fallacies + counter-args
+            + formal tenue per the §4 weaving rule (the load-bearing core).
+        act3_conclusion: Acte III markdown — gated verdict + appréciations +
+            que-faire. Must satisfy the G1–G4 non-triviality gates (#1008 §3)
+            before rendering real claims.
+        source_id: Opaque corpus identifier (e.g. ``doc_A``). Privacy HARD —
+            never a speaker name, title or date. Emitted in the report header.
+        degraded: Mapping ``{act_key -> reason}`` for acts whose generator ran
+            but produced degraded output. Honest provenance; the renderer
+            surfaces these notes verbatim rather than hiding them.
+
+    An act that is an empty string is treated as *missing* (generator did not
+    run / not yet wired). The renderer emits explicit "acte indisponible"
+    wording for it — distinct from a degraded act, which is emitted with its
+    degradation note appended.
+    """
+
+    act1_framing: str = ""
+    act2_narrative: str = ""
+    act3_conclusion: str = ""
+    source_id: str = ""
+    degraded: Dict[str, str] = field(default_factory=dict)
+
+    # --- accessors -----------------------------------------------------------
+
+    def as_dict(self) -> Dict[int, str]:
+        """Return the acts keyed by position (1, 2, 3) in narrative order."""
+        return {1: self.act1_framing, 2: self.act2_narrative, 3: self.act3_conclusion}
+
+    @staticmethod
+    def act_key(n: int) -> str:
+        """Stable internal key for an act position (used by ``degraded``)."""
+        return {1: "act1_framing", 2: "act2_narrative", 3: "act3_conclusion"}[n]
+
+    def is_missing(self, n: int) -> bool:
+        """True if the act at position ``n`` is absent (empty / whitespace)."""
+        return not (self.as_dict()[n] or "").strip()

--- a/argumentation_analysis/reporting/restitution/appendix.py
+++ b/argumentation_analysis/reporting/restitution/appendix.py
@@ -1,0 +1,153 @@
+"""The dimensional appendix — provenance, folded, never the report body (spec §6).
+
+The restitution report's *body* is the 3-act narrative. The dimensional data
+that used to be the whole report (phase tables, per-fallacy entries, formal
+solver outputs — the "très difficile à lire" artifact) is relegated here, behind
+a collapsed ``<details>`` block, for traceability only. It is no longer what the
+reader meets first.
+
+Privacy HARD: the appendix summarises *counts and verdicts* by default. The full
+state JSON is opt-in (``include_full_state_json=True``) and is meant only for
+emission under a gitignored path (the renderer never writes to disk — the caller
+chooses the path). ``raw_text`` and any ``*snippet*`` key are stripped defensively
+regardless, so a careless caller cannot leak the corpus through the appendix.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Mapping, Optional
+
+# Keys that carry corpus plaintext (directly or via derived fields). Stripped
+# defensively from any state dict before it is rendered into the appendix, even
+# when the caller asked for the full JSON. CLAUDE.md dataset-privacy rule.
+_LEAK_KEYS = (
+    "raw_text",
+    "full_text",
+    "raw_text_segment",
+    "raw_text_snippet",
+    "full_text_segment",
+    "text",
+    "content",  # last two: only stripped when
+    # explicitly nested under a fallacy/argument that echoes corpus text; see
+    # _strip below which only removes top-level + these echo fields by name.
+)
+
+
+def _strip_leak_keys(state: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return a copy of ``state`` with leak-capable top-level keys removed."""
+    out: Dict[str, Any] = {}
+    for k, v in state.items():
+        if k in _LEAK_KEYS:
+            continue
+        out[k] = v
+    return out
+
+
+def _safe_len(value: Any) -> int:
+    """Length of a collection-ish value, 0-safe."""
+    try:
+        return len(value)
+    except TypeError:
+        return 0
+
+
+def _provenance_counts(state: Mapping[str, Any]) -> Dict[str, Any]:
+    """Honest provenance summary: counts + verdict flags, no corpus content.
+
+    Mirrors the spec §2 block→state-key table at the *aggregate* level. Each
+    entry reports a non-triviality signal (how many arguments, fallacies, etc.
+    the pipeline actually produced) so a reader can gauge what backs the
+    narrative without reading the raw state.
+    """
+    counts: Dict[str, Any] = {}
+
+    def _g(key: str, default: Any = None) -> Any:
+        return state.get(key, default)
+
+    counts["arguments_extraits"] = _safe_len(_g("identified_arguments", {}))
+    counts["sophismes_localises"] = _safe_len(_g("identified_fallacies", {}))
+    counts["contre_arguments"] = _safe_len(_g("counter_arguments", []))
+    counts["scores_qualite"] = _safe_len(_g("argument_quality_scores", {}))
+
+    # formal axes — report presence + a coarse status, not the raw belief sets
+    fol = _g("fol_analysis_results")
+    counts["axe_fol"] = (
+        {
+            "consistent": bool(fol.get("consistent")),
+            "formules": _safe_len(fol.get("formulas")),
+        }
+        if isinstance(fol, Mapping)
+        else "indisponible"
+    )
+    counts["axe_pl"] = (
+        "disponible" if _g("propositional_analysis_results") else "indisponible"
+    )
+    counts["axe_modale"] = (
+        "disponible" if _g("modal_analysis_results") else "indisponible"
+    )
+    counts["axe_dung"] = "disponible" if _g("dung_frameworks") else "indisponible"
+    counts["axe_aspic"] = "disponible" if _g("aspic_results") else "indisponible"
+
+    counts["synthese_narrative"] = (
+        "présente" if _g("narrative_synthesis") else "absente"
+    )
+    counts["synthese_formelle"] = (
+        "présente" if _g("formal_synthesis_reports") else "absente"
+    )
+    return counts
+
+
+def render_appendix(
+    state: Optional[Mapping[str, Any]],
+    *,
+    include_full_state_json: bool = False,
+) -> str:
+    """Render the dimensional appendix as a folded Markdown ``<details>`` block.
+
+    Args:
+        state: the (serialisable) shared-state mapping, or ``None`` to emit an
+            honest "annexe indisponible" note.
+        include_full_state_json: opt-in. When True, the leak-scrubbed state JSON
+            is included (folded) for traceability. Meant for emission under a
+            gitignored path only. Default False (counts-only provenance).
+
+    Returns:
+        A Markdown string beginning with ``<details>``. Empty string when
+        ``state`` is None *and* the caller opts out — but by default a missing
+        state still yields an honest note, not silence.
+    """
+    if state is None:
+        return (
+            "\n<details>\n<summary>Annexe — provenance dimensionnelle</summary>\n\n"
+            "Annexe indisponible (shared-state non fourni au renderer). "
+            "La narration ci-dessus se suffit à elle-même ; cette annexe n'aurait "
+            "contenu que des agrégats de traçabilité.\n\n"
+            "</details>\n"
+        )
+
+    counts = _provenance_counts(state)
+    lines = [
+        "\n<details>",
+        "<summary>Annexe — provenance dimensionnelle ( repliée par défaut)</summary>",
+        "",
+        "Agrégats de traçabilité uniquement — pas de contenu de corpus.",
+        "",
+        "| Dimension | Valeur |",
+        "|---|---|",
+    ]
+    for label, value in counts.items():
+        lines.append(f"| {label} | {value} |")
+    lines.append("")
+
+    if include_full_state_json:
+        scrubbed = _strip_leak_keys(state)
+        lines.append("JSON shared-state (clés à fuite potentielles retirées, replié) :")
+        lines.append("")
+        lines.append("```json")
+        lines.append(json.dumps(scrubbed, indent=2, ensure_ascii=False, default=str))
+        lines.append("```")
+        lines.append("")
+
+    lines.append("</details>")
+    return "\n".join(lines) + "\n"

--- a/argumentation_analysis/reporting/restitution/readability_gate.py
+++ b/argumentation_analysis/reporting/restitution/readability_gate.py
@@ -1,0 +1,411 @@
+"""The readability gate — mechanical enforcement of the weaving rule (spec §4).
+
+This is the load-bearing anti-énumération contract of the restitution report.
+Spec §4 states:
+
+    For EVERY citation of a formal or informal framework (Tweety, Dung/ASPIC,
+    taxonomy descent, AIF/Walton, virtues), the report MUST provide a narrative
+    anchor: the framework is the *proof of a story point*, never an isolated
+    list entry.
+
+    A framework reference is valid iff it is bound to (a) a located textual move
+    and (b) the concrete verdict that framework produced. A framework block with
+    neither anchor is an enumeration and MUST be rejected by the readability
+    gate (R6) or rewritten.
+
+This module turns that prose rule into a deterministic, CI-friendly check. It
+detects the *enumeration smell* — the spec's canonical counter-example is::
+
+    ❌ « Sophisme : ad verecundiam (score 0.8) » — a name and a number, detached
+       from any story.
+
+The detector flags a line as a **bare framework reference** when it cites a
+framework (a solver, a scheme family, or a Latin/English fallacy name) *and*
+carries an isolated score *and* has no narrative verb anchoring it to a beat.
+The contrast case::
+
+    ✅ « … le solveur Tweety confirme l'inconsistance de l'inférence. »
+
+…cites Tweety but carries a verb (``confirme``) and no isolated score, so it is
+*woven*, not bare.
+
+Honesty contract (#1019): the gate *reports* what it finds. It never
+manufactures a passing verdict, and a bare reference is reported at the level
+its count warrants (WARN for a residual few, FAIL for a manifest enumeration).
+The verdict is surfaced in the rendered report for transparency — the gate does
+not grade on a curve to please.
+
+Optional reader-check (issue #1140): a 0-shot "non-specialist reader" LLM probe
+answering three comprehension questions. Off by default; when an LLM callable is
+injected it augments the structural verdict. Not run in CI (no API key).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+from .acts import RestitutionActs
+
+# --- catalogues ---------------------------------------------------------------
+
+# Formal solvers / scheme frameworks cited as *proof notes* in the narrative.
+_FRAMEWORK_SOLVERS = {
+    "tweety",
+    "tweetyproject",
+    "dung",
+    "aspic",
+    "aspic+",
+    "aif",
+    "walton",
+    "jtms",
+    "atms",
+    "dung/aspic",
+}
+
+# Latin / English fallacy names (the "nom (latin)" the differentiator demotes).
+# Lowercased substrings — matched word-boundary-light because Latin names are
+# multi-word ("ad hominem"). Kept to the high-frequency families; an exhaustive
+# list lives in the taxonomy and is not duplicated here (anti-pendule).
+_FALLACY_NAMES = (
+    "ad hominem",
+    "ad verecundiam",
+    "ad populum",
+    "ad baculum",
+    "ad misericordiam",
+    "ad ignorantiam",
+    "ad passum",
+    "ad antiquitatem",
+    "tu quoque",
+    "post hoc",
+    "petitio",
+    "non sequitur",
+    "ex falso",
+    "slippery slope",
+    "straw man",
+    "strawman",
+    "red herring",
+    "redherring",
+    "false dichotomy",
+    "faux dilemme",
+    "circular",
+    "bandwagon",
+    "hasty generalization",
+    "falsa bifurcation",
+    "faux sillogisme",
+    "sophisme",
+    "paralogisme",  # generic — only flags when paired with a score
+)
+
+# Narrative verbs (French + a few English) anchoring a framework to a beat.
+# Presence of one of these in the same line means the framework is *woven* into
+# a sentence, not dropped as a bare list entry. Inflected common forms only.
+# NB: deliberately excludes words that are common RHETORICAL SUBSTANTIVES too
+# (``attaque``, ``forme``, ``présente``…) — a bare ref like "ASPIC+ : attaque
+# (score 0.65)" cites a framework + score + the noun "attaque", and must still
+# count as bare. Being strict here is the honest default (spec §4): better to
+# flag a residual enumeration than to mask one behind an ambiguous token.
+_NARRATIVE_VERBS = (
+    "confirme",
+    "invalide",
+    "valide",
+    "montre",
+    "prouve",
+    "démontre",
+    "isole",
+    "défait",
+    "appuie",
+    "soutient",
+    "implique",
+    "révèle",
+    "suggère",
+    "indique",
+    "établit",
+    "repose",
+    "résulte",
+    "découle",
+    "signifie",
+    "traduit",
+    "reflète",
+    "expose",
+    "illustre",
+    "incarne",
+    "matérialise",
+    "concrétise",
+    "ancré",
+    "ancrée",
+    "ancrés",
+    "ancrées",
+    "cite",
+    "citee",
+    "confirmé",
+    "invalidé",
+    "prouvé",
+    # auxiliaries / copulas — a sentence with "est/sont + [substantive]" is prose
+    "n'est",
+    "qu'un",
+    "qu'une",
+    "c'est",
+    "il s'agit",
+    "il s’agit",
+    "permet",
+    "explique",
+    "justifie",
+    "fonde",
+    "garantit",
+    "entraîne",
+    "provient",
+    "emprunte",
+    "relève",
+    "constitue",
+)
+
+# An isolated score: a float in [0, 1], alone in parens or after a colon/label.
+# Catches "(0.8)", "(score 0.8)", "confiance: 0.8", ": 0.85". Rejects years /
+# large numbers and version strings. Word-boundaried to avoid matching inside
+# identifiers.
+_SCORE_RE = re.compile(
+    r"(?:\(?\s*(?:score|confiance|poids|severity|sévérité|confidence)\s*[:=]?\s*)?"
+    r"0?\.\d{1,2}\b"
+)
+# but only count it when clearly a standalone metric — require a paren or a
+# label prefix, to avoid flagging "0.5" inside a normal sentence by accident.
+_STANDALONE_SCORE_RE = re.compile(
+    r"\(\s*0?\.\d{1,2}\s*\)"  # (0.8)
+    r"|\(?\s*(?:score|confiance|poids|confidence|sévérité)\s*[:=]?\s*0?\.\d{1,2}\b"  # score 0.8
+)
+
+# A numbered enumeration heading the dimensional dump uses — "Sophisme 1:",
+# "Argument 2:", "Sophisme N". Repeated (> threshold) inside an act = the act
+# degenerated into a dimension list.
+_DUMP_HEADING_RE = re.compile(
+    r"^\s*#{0,6}\s*(?:Sophisme|Argument|Dimension|Phase)\s+\d+\s*[:\-—]?",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+# --- verdict ------------------------------------------------------------------
+
+
+@dataclass
+class GateVerdict:
+    """Honest verdict of the readability gate.
+
+    ``band`` is one of ``PASS`` / ``WARN`` / ``FAIL``:
+
+    * **PASS** — every act is present and non-trivial, no enumeration smell.
+    * **WARN** — present and readable, but a small number of bare framework
+      references remain (residual enumeration). Reported, not blocked.
+    * **FAIL** — a structural problem: a missing act, a manifest enumeration
+      (many bare refs or repeated dump headings), or (if injected) a failed
+      reader-check. The report is not considered readable.
+
+    ``reasons`` are specific and human-readable (which act, how many bare refs,
+    which questions the reader failed) so the verdict is auditable, not a black
+    box.
+    """
+
+    band: str
+    reasons: List[str] = field(default_factory=list)
+
+    @property
+    def passed(self) -> bool:
+        """True for PASS/WARN (report is readable); False for FAIL."""
+        return self.band in ("PASS", "WARN")
+
+    def merge(self, other: "GateVerdict") -> "GateVerdict":
+        """Combine two verdicts — the worse band wins, reasons accumulate."""
+        order = {"PASS": 0, "WARN": 1, "FAIL": 2}
+        worst = self if order[self.band] >= order[other.band] else other
+        return GateVerdict(band=worst.band, reasons=[*self.reasons, *other.reasons])
+
+
+# --- detector -----------------------------------------------------------------
+
+# A line is flagged as a bare framework ref when it carries a framework term
+# AND a standalone score AND none of the narrative verbs. Thresholds below
+# decide WARN vs FAIL.
+_BARE_WARN_THRESHOLD = 2  # 1–2 bare refs → WARN (residual)
+_BARE_FAIL_THRESHOLD = 3  # ≥3 → FAIL (manifest enumeration)
+_DUMP_FAIL_THRESHOLD = 2  # ≥2 repeated dump headings in one act → FAIL
+
+
+def _line_has_framework(line: str) -> bool:
+    low = line.lower()
+    # solver / scheme family
+    if any(k in low for k in _FRAMEWORK_SOLVERS):
+        return True
+    # fallacy name (word-bounded for the generic ones to limit false positives)
+    for name in _FALLACY_NAMES:
+        if name in low:
+            return True
+    return False
+
+
+def _line_is_bare(line: str) -> bool:
+    """A bare framework reference: framework cited + isolated score, no verb."""
+    if not _line_has_framework(line):
+        return False
+    if not _STANDALONE_SCORE_RE.search(line):
+        return False
+    low = line.lower()
+    if any(v in low for v in _NARRATIVE_VERBS):
+        return False  # woven into a sentence — not bare
+    return True
+
+
+def _count_dump_headings(markdown: str) -> int:
+    return len(_DUMP_HEADING_RE.findall(markdown))
+
+
+class ReadabilityGate:
+    """Deterministic structural check of a restitution report (spec §4).
+
+    Construct with tuned thresholds (defaults follow the spec), then call
+    :meth:`check_acts` (on the three acts) or :meth:`check_body` (on the
+    assembled narrative body, i.e. the three acts concatenated, *excluding*
+    the engineering appendix). The two are meant to be merged into one final
+    verdict by the renderer.
+    """
+
+    def __init__(
+        self,
+        *,
+        bare_warn_threshold: int = _BARE_WARN_THRESHOLD,
+        bare_fail_threshold: int = _BARE_FAIL_THRESHOLD,
+        dump_fail_threshold: int = _DUMP_FAIL_THRESHOLD,
+        reader_check: Optional[Callable[[str], "ReaderCheckResult"]] = None,
+    ):
+        self.bare_warn_threshold = bare_warn_threshold
+        self.bare_fail_threshold = bare_fail_threshold
+        self.dump_fail_threshold = dump_fail_threshold
+        self._reader_check = reader_check
+
+    # -- structural checks ----------------------------------------------------
+
+    def check_acts(self, acts: RestitutionActs) -> GateVerdict:
+        """Check the three acts for presence, weaving, and non-dump."""
+        reasons: List[str] = []
+        worst_band = "PASS"
+
+        total_bare = 0
+
+        for n in (1, 2, 3):
+            text = acts.as_dict()[n] or ""
+            title = {1: "Acte I", 2: "Acte II", 3: "Acte III"}[n]
+
+            # (1) presence — an act must exist and be non-trivial
+            if acts.is_missing(n):
+                reasons.append(
+                    f"{title} absent — le rapport n'est pas complet "
+                    f"(générateur non câblé ou acte vide)."
+                )
+                worst_band = _worsen(worst_band, "FAIL")
+                continue
+
+            # (2) weaving — bare framework references per act
+            bare_lines = [ln.strip() for ln in text.splitlines() if _line_is_bare(ln)]
+            total_bare += len(bare_lines)
+            if bare_lines:
+                preview = bare_lines[0][:90]
+                reasons.append(
+                    f"{title}: {len(bare_lines)} référence(s) de cadre « nue(s) » "
+                    f"(framework + score isolé, sans ancrage narratif — spec §4). "
+                    f"Ex: « {preview} »."
+                )
+
+            # (3) non-dump — repeated numbered dimension headings = enumeration
+            dump_n = _count_dump_headings(text)
+            if dump_n >= self.dump_fail_threshold:
+                reasons.append(
+                    f"{title}: {dump_n} titres de type « Sophisme N: / Argument N: » "
+                    f"détectés — l'acte a dégénéré en énumération dimensionnelle."
+                )
+                worst_band = _worsen(worst_band, "FAIL")
+
+        # aggregate bare refs across acts → WARN/FAIL by threshold
+        if total_bare >= self.bare_fail_threshold:
+            worst_band = _worsen(worst_band, "FAIL")
+        elif total_bare >= self.bare_warn_threshold:
+            worst_band = _worsen(worst_band, "WARN")
+
+        return GateVerdict(band=worst_band, reasons=reasons)
+
+    def check_body(self, body: str) -> GateVerdict:
+        """Check the assembled narrative body (3 acts concatenated, no appendix).
+
+        Runs the same bare-ref / dump detection on the joined text, plus the
+        optional reader-check when one was injected.
+        """
+        reasons: List[str] = []
+        worst_band = "PASS"
+
+        bare_lines = [ln.strip() for ln in body.splitlines() if _line_is_bare(ln)]
+        if len(bare_lines) >= self.bare_fail_threshold:
+            worst_band = _worsen(worst_band, "FAIL")
+            reasons.append(
+                f"Corps: {len(bare_lines)} références de cadre nues (énumération "
+                f"manifeste, spec §4)."
+            )
+        elif len(bare_lines) >= self.bare_warn_threshold:
+            worst_band = _worsen(worst_band, "WARN")
+            reasons.append(
+                f"Corps: {len(bare_lines)} références de cadre nues résiduelles."
+            )
+
+        if _count_dump_headings(body) >= self.dump_fail_threshold:
+            worst_band = _worsen(worst_band, "FAIL")
+            reasons.append("Corps: titres d'énumération dimensionnelle détectés.")
+
+        if self._reader_check is not None:
+            result = self._reader_check(body)
+            if not result.passed:
+                worst_band = _worsen(worst_band, "FAIL")
+                reasons.append(
+                    f"Reader-check (lecteur non-spécialiste) échoué sur "
+                    f"{result.failed_questions}/{result.total_questions} "
+                    f"question(s) de compréhension."
+                )
+            else:
+                reasons.append(
+                    f"Reader-check passé ({result.total_questions}/{result.total_questions})."
+                )
+
+        return GateVerdict(band=worst_band, reasons=reasons)
+
+    def check(self, acts: RestitutionActs) -> GateVerdict:
+        """Full verdict: per-act structural check merged with the body check."""
+        by_acts = self.check_acts(acts)
+        # body excludes any act that is missing (honest — we don't gate on gaps
+        # twice, the per-act check already FAILs those).
+        body = "\n\n".join(
+            (acts.as_dict()[n] or "") for n in (1, 2, 3) if not acts.is_missing(n)
+        )
+        by_body = self.check_body(body)
+        return by_acts.merge(by_body)
+
+
+# --- reader-check (optional, injected) ----------------------------------------
+
+
+@dataclass
+class ReaderCheckResult:
+    """Outcome of an optional 0-shot reader comprehension probe (#1140).
+
+    ``passed`` is True iff the reader answered all comprehension questions
+    correctly enough. The gate treats a failed reader-check as a structural
+    FAIL — an illegible report cannot pass readability, no matter how well
+    woven its sentences are in isolation.
+    """
+
+    passed: bool
+    total_questions: int
+    failed_questions: int
+    notes: str = ""
+
+
+def _worsen(current: str, candidate: str) -> str:
+    """Return the worse of two bands (PASS < WARN < FAIL)."""
+    order = {"PASS": 0, "WARN": 1, "FAIL": 2}
+    return candidate if order[candidate] > order[current] else current

--- a/argumentation_analysis/reporting/restitution/renderer.py
+++ b/argumentation_analysis/reporting/restitution/renderer.py
@@ -1,0 +1,219 @@
+"""The restitution report renderer — assembles the 3 acts into one readable
+Markdown (Epic #1134 / R6).
+
+Replaces the dimensional dump (``UnifiedReportTemplate._render_markdown``) as the
+report a reader meets first. The dump is retained, folded, as an engineering
+appendix (provenance) — see :mod:`.appendix`.
+
+Contract:
+
+* **Input**: a :class:`~.acts.RestitutionActs` (3 markdown acts + opaque source
+  id) and an optional shared-state mapping for the appendix.
+* **Output**: a single Markdown string = header → Acte I/II/III → readability
+  verdict → folded appendix.
+* **Honesty**: a missing act is *named*, not omitted (fail-loud, #1019/#369).
+  The readability gate's verdict is surfaced verbatim in the report for
+  transparency — the report does not claim to be readable if the gate disagrees.
+* **Privacy**: ``raw_text``/snippet keys are stripped from any appendix state;
+  the renderer never writes to disk — the caller picks the (gitignored for real
+  corpora) path. Only the opaque ``source_id`` reaches the header.
+
+This renderer is deliberately decoupled from *how* the acts are produced. The
+generators R2/R3/R4 slot in by populating a ``RestitutionActs``; the renderer
+itself is agnostic (file-disjoint lane, per the coordinator dispatch).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+from .acts import ACT_TITLES, RestitutionActs
+from .appendix import render_appendix
+from .readability_gate import GateVerdict, ReadabilityGate
+
+# Minimum substantive length for an act body, below which we treat it as
+# "present but thin" and flag it (distinct from entirely missing). Generous: an
+# honest degraded-act fallback wording is ~80 chars, so a real act should clear
+# this comfortably.
+_MIN_ACT_CHARS = 120
+
+_MISSING_ACT_WORDING = {
+    1: (
+        "Acte I indisponible — le générateur de mise en situation n'a pas "
+        "produit de cadre (non câblé ou en échec). Le rapport entre directement "
+        "dans l'analyse sans filet de cadrage."
+    ),
+    2: (
+        "Acte II indisponible — le récit dialectique n'a pas pu être généré "
+        "(cœur narratif absent). Le rapport n'a pas de substance narrative."
+    ),
+    3: (
+        "Acte III indisponible — la conclusion actionnable n'a pas été générée "
+        "(portes G1–G4 non évaluées). Le rapport s'arrête sans synthèse."
+    ),
+}
+
+
+@dataclass
+class RenderedReport:
+    """The rendered restitution report + its gate verdict (for the caller)."""
+
+    markdown: str
+    verdict: GateVerdict
+
+
+class RestitutionReportRenderer:
+    """Assemble three acts + appendix into one readable Markdown report.
+
+    Parameters mirror the spec's generation protocol (§7, step 5): assemble,
+    run the readability gate, emit under an opaque corpus id.
+    """
+
+    def __init__(
+        self,
+        gate: Optional[ReadabilityGate] = None,
+        *,
+        min_act_chars: int = _MIN_ACT_CHARS,
+    ):
+        self.gate = gate or ReadabilityGate()
+        self.min_act_chars = min_act_chars
+
+    def render(
+        self,
+        acts: RestitutionActs,
+        *,
+        state: Optional[Mapping[str, Any]] = None,
+        include_full_state_json: bool = False,
+    ) -> RenderedReport:
+        """Render the full restitution report.
+
+        Args:
+            acts: the three narrative acts + opaque source id.
+            state: optional shared-state mapping for the folded appendix.
+            include_full_state_json: opt-in full-state appendix (gitignored path
+                only). Forwarded to :func:`~.appendix.render_appendix`.
+        """
+        body_parts: list[str] = []
+        thin_notes: list[str] = []
+
+        for n in (1, 2, 3):
+            title = ACT_TITLES[n]
+            text = (acts.as_dict()[n] or "").strip()
+
+            body_parts.append(f"## {title}")
+            body_parts.append("")
+
+            if acts.is_missing(n):
+                # fail-loud: name the missing act, never omit
+                body_parts.append(f"_{_MISSING_ACT_WORDING[n]}_")
+                body_parts.append("")
+                continue
+
+            body_parts.append(text)
+            body_parts.append("")
+
+            # degradation provenance — surface honestly, don't hide
+            key = RestitutionActs.act_key(n)
+            if key in acts.degraded:
+                body_parts.append(f"> ⚠️ **Acte dégradé** — {acts.degraded[key]}")
+                body_parts.append("")
+
+            # thin act — present but suspiciously short (likely a stub)
+            if len(text) < self.min_act_chars:
+                thin_notes.append(
+                    f"{title} est anormalement court ({len(text)} caractères) — "
+                    f"sortie probablement stub ou dégradée."
+                )
+
+        body = "\n".join(body_parts).strip()
+
+        # run the gate on the acts (presence + weaving + non-dump)
+        verdict = self.gate.check(acts)
+        if thin_notes:
+            verdict = verdict.merge(GateVerdict(band="WARN", reasons=thin_notes))
+
+        # assemble the final document
+        doc = self._assemble(acts, body, verdict, state, include_full_state_json)
+        return RenderedReport(markdown=doc, verdict=verdict)
+
+    # -- assembly -------------------------------------------------------------
+
+    def _assemble(
+        self,
+        acts: RestitutionActs,
+        body: str,
+        verdict: GateVerdict,
+        state: Optional[Mapping[str, Any]],
+        include_full_state_json: bool,
+    ) -> str:
+        source = (acts.source_id or "corpus_anonyme").strip()
+        parts: list[str] = []
+
+        # header — opaque id only, privacy HARD
+        parts.append(f"# Rapport de restitution — {source}")
+        parts.append("")
+        parts.append(
+            "Récit en trois actes (mise en situation → analyse narrative → "
+            "conclusion actionnable). Les cadres formels et informels (Tweety, "
+            "Dung/ASPIC, taxonomie, vertus) sont les *preuves* citées en appui "
+            "du récit, jamais une énumération (spec §4)."
+        )
+        parts.append("")
+
+        # the narrative body
+        parts.append(body)
+        parts.append("")
+
+        # the gate verdict — surfaced for transparency (not hidden)
+        parts.append(self._render_verdict_block(verdict))
+        parts.append("")
+
+        # the folded dimensional appendix (provenance)
+        parts.append(
+            render_appendix(state, include_full_state_json=include_full_state_json)
+        )
+
+        return "\n".join(parts).rstrip() + "\n"
+
+    @staticmethod
+    def _render_verdict_block(verdict: GateVerdict) -> str:
+        icon = {"PASS": "✅", "WARN": "⚠️", "FAIL": "❌"}.get(verdict.band, "•")
+        lines = [
+            "---",
+            "",
+            f"## {icon} Gate lisibilité — {verdict.band}",
+            "",
+        ]
+        if verdict.reasons:
+            lines.append("Contrôles structurels (règle de tissage, spec §4) :")
+            lines.append("")
+            for r in verdict.reasons:
+                lines.append(f"- {r}")
+        else:
+            lines.append(
+                "Tous les contrôles structurels passent : 3 actes présents et "
+                "non-triviaux, aucune référence de cadre nue (énumération)."
+            )
+        lines.append("")
+        lines.append("_Verdict honnête reporté par le gate — non truqué (#1019)._")
+        return "\n".join(lines)
+
+
+def render_restitution_report(
+    acts: RestitutionActs,
+    *,
+    state: Optional[Mapping[str, Any]] = None,
+    include_full_state_json: bool = False,
+    gate: Optional[ReadabilityGate] = None,
+) -> RenderedReport:
+    """Shorthand entry point: render a restitution report in one call.
+
+    This is the public face of the package for callers that already hold a
+    :class:`RestitutionActs` (e.g. the spectacular pipeline, once the act
+    generators R2/R3/R4 populate it). Returns the rendered markdown *and* the
+    gate verdict so the caller can branch on readability.
+    """
+    return RestitutionReportRenderer(gate=gate).render(
+        acts, state=state, include_full_state_json=include_full_state_json
+    )

--- a/argumentation_analysis/reporting/restitution/state_adapter.py
+++ b/argumentation_analysis/reporting/restitution/state_adapter.py
@@ -1,0 +1,54 @@
+"""Adapt a ``UnifiedAnalysisState`` to the appendix mapping (file-disjoint wiring).
+
+The renderer's appendix wants a plain ``dict`` (see :mod:`.appendix`). The
+spectacular shared-state is a dataclass (:class:`UnifiedAnalysisState`); this
+adapter reads the spec §2 keys off it via ``getattr`` with honest ``None``
+defaults — it does **not** import the state class (avoids coupling the renderer
+to the dataclass, and avoids touching ``shared_state.py`` which is on the R3
+serialized lane). Any object exposing the named attributes works.
+
+Privacy: this adapter never copies ``raw_text``. The appendix layer strips
+leak keys defensively regardless; this adapter simply does not list them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+# The spec §2 block→state-key mapping, as attribute names. Honest default is
+# "absent" (None) — the appendix renders an honest "indisponible" for any
+# missing axis rather than fabricating one.
+_STATE_KEYS = (
+    "identified_arguments",
+    "identified_fallacies",
+    "counter_arguments",
+    "argument_quality_scores",
+    "propositional_analysis_results",
+    "fol_analysis_results",
+    "modal_analysis_results",
+    "dung_frameworks",
+    "aspic_results",
+    "narrative_synthesis",
+    "formal_synthesis_reports",
+    "stakes_and_stakeholders",
+    "source_metadata",
+    "workflow_results",
+)
+
+
+def state_to_appendix_mapping(state: Any) -> Dict[str, Any]:
+    """Read the spec §2 keys off ``state`` into a plain dict for the appendix.
+
+    Works on a dataclass, a dict, or any object exposing the named attributes.
+    Missing keys are simply omitted (the appendix reports them as "indisponible").
+    """
+    out: Dict[str, Any] = {}
+    for key in _STATE_KEYS:
+        value: Any = None
+        if isinstance(state, dict):
+            value = state.get(key)
+        else:
+            value = getattr(state, key, None)
+        if value is not None:
+            out[key] = value
+    return out

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_appendix.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_appendix.py
@@ -1,0 +1,92 @@
+"""Tests for the dimensional appendix — provenance counts + leak stripping.
+
+Privacy HARD is the contract here: the appendix summarises counts/verdicts and
+must never echo corpus plaintext. ``raw_text`` and snippet keys are stripped
+defensively even when the caller asks for the full-state JSON.
+"""
+
+from __future__ import annotations
+
+import json
+
+from argumentation_analysis.reporting.restitution.appendix import (
+    _provenance_counts,
+    _strip_leak_keys,
+    render_appendix,
+)
+
+
+def _sample_state():
+    return {
+        "identified_arguments": {"arg_1": "thèse A", "arg_2": "soutien B"},
+        "identified_fallacies": {"f_1": {"type": "ad hominem"}},
+        "counter_arguments": [{"counter_content": "x"}],
+        "argument_quality_scores": {"arg_1": {"overall": 2.0}},
+        "fol_analysis_results": {"consistent": True, "formulas": ["a", "b", "c"]},
+        "propositional_analysis_results": {"something": 1},
+        "modal_analysis_results": None,
+        "dung_frameworks": [],
+        "aspic_results": {},
+        "narrative_synthesis": "une synthèse",
+        "formal_synthesis_reports": None,
+        # leak-capable keys that must NEVER reach the appendix
+        "raw_text": "SECRET CORPUS PLAINTEXT",
+        "raw_text_snippet": "SECRET snippet",
+        "full_text": "more secret",
+    }
+
+
+class TestProvenanceCounts:
+
+    def test_counts_reflect_state(self):
+        counts = _provenance_counts(_sample_state())
+        assert counts["arguments_extraits"] == 2
+        assert counts["sophismes_localises"] == 1
+        assert counts["contre_arguments"] == 1
+        assert counts["scores_qualite"] == 1
+        assert counts["axe_fol"] == {"consistent": True, "formules": 3}
+        assert counts["axe_pl"] == "disponible"
+        assert counts["axe_modale"] == "indisponible"
+        assert counts["synthese_narrative"] == "présente"
+        assert counts["synthese_formelle"] == "absente"
+
+
+class TestLeakStripping:
+
+    def test_strip_removes_plaintext_keys(self):
+        stripped = _strip_leak_keys(_sample_state())
+        assert "raw_text" not in stripped
+        assert "raw_text_snippet" not in stripped
+        assert "full_text" not in stripped
+        # non-leak keys preserved
+        assert "identified_arguments" in stripped
+
+
+class TestRenderAppendix:
+
+    def test_folded_details_block(self):
+        out = render_appendix(_sample_state())
+        assert out.startswith("\n<details>")
+        assert "<summary>" in out
+        assert "</details>" in out
+        assert "arguments_extraits" in out
+
+    def test_no_corpus_plaintext_by_default(self):
+        out = render_appendix(_sample_state())
+        assert "SECRET" not in out
+
+    def test_full_state_json_opt_in_strips_leaks(self):
+        out = render_appendix(_sample_state(), include_full_state_json=True)
+        assert "```json" in out
+        assert "SECRET" not in out  # leak keys stripped even in full JSON
+        # the JSON block is valid and leak-free
+        block = out.split("```json")[1].split("```")[0]
+        parsed = json.loads(block)
+        assert "raw_text" not in parsed
+        assert "identified_arguments" in parsed
+
+    def test_none_state_emits_honest_note(self):
+        out = render_appendix(None)
+        assert "<details>" in out
+        assert "indisponible" in out
+        assert "SECRET" not in out

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_readability_gate.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_readability_gate.py
@@ -1,0 +1,198 @@
+"""Tests for the readability gate — the weaving rule (spec §4), mechanically.
+
+The gate is the anti-énumération contract: a framework citation must be anchored
+on a narrative beat, never dropped as a bare "name (score)". These tests pin the
+canonical woven/bare contrast from the spec and the WARN/FAIL thresholds.
+
+No JVM, no LLM, no network — deterministic structural checks only (CI-safe).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from argumentation_analysis.reporting.restitution.acts import RestitutionActs
+from argumentation_analysis.reporting.restitution.readability_gate import (
+    GateVerdict,
+    ReadabilityGate,
+    ReaderCheckResult,
+    _line_is_bare,
+)
+
+# --- woven act bodies (well-anchored, no bare refs) ---------------------------
+
+_WOVEN_ACT1 = (
+    "Le discours analysé (source doc_A) est un propos politique à visée "
+    "persuasive. L'orateur cherche à mobiliser l'auditoire sur une décision "
+    "controversée; l'asymétrie d'information joue en sa faveur. Un auditeur "
+    "averti doit guetter l'appel à l'autorité et la fausse causalité, typiques "
+    "de ce genre. Les joueurs sont l'orateur, l'auditoire cible et un adversaire "
+    "implicite; le coup attendu est la disqualification de l'adversaire."
+)
+
+_WOVEN_ACT2 = (
+    "Le premier mouvement argumentatif appuie la thèse sur une autorité "
+    "externe. Cette autorité ne satisfait pas la question critique de fiabilité: "
+    "c'est une exception au scheme ExpertOpinion (ancrage AIF/Walton), et le "
+    "solveur Tweety confirme l'inconsistance de l'inférence sous-jacente. "
+    "Le cadre de Dung isole ensuite cette attaque comme défaillante. Le second "
+    "mouvement enchaîne sur une généralisation hâtive, que la vertu de "
+    "pertinence éclaire comme un dérapage."
+)
+
+_WOVEN_ACT3 = (
+    "L'analyse conclut à un discours structurellement fragile sur l'axe "
+    "formel: la synthèse honnête, gated par les dimensions non-triviales, "
+    "caractérise un propos qui tient sur l'affect mais cède sur la logique. "
+    "Pour contrer: viser la question critique de fiabilité qui fait basculer "
+    "l'appel à l'autorité. À attendre ensuite: un glissement vers l'ad hominem."
+)
+
+
+def _woven_acts() -> RestitutionActs:
+    return RestitutionActs(
+        act1_framing=_WOVEN_ACT1,
+        act2_narrative=_WOVEN_ACT2,
+        act3_conclusion=_WOVEN_ACT3,
+        source_id="doc_A",
+    )
+
+
+# --- the canonical woven/bare contrast (spec §4) ------------------------------
+
+
+class TestBareReferenceDetection:
+    """The line-level detector: what is a bare framework ref, what is woven."""
+
+    def test_canonical_bare_example_flagged(self):
+        # The exact counter-example from spec §4.
+        line = "Sophisme : ad verecundiam (score 0.8)"
+        assert _line_is_bare(line) is True
+
+    def test_canonical_woven_example_not_flagged(self):
+        # The exact narration example from spec §4.
+        line = "le solveur Tweety confirme l'inconsistance de l'inférence"
+        assert _line_is_bare(line) is False
+
+    def test_woven_with_score_and_verb_not_bare(self):
+        # A framework + a score, BUT anchored by a narrative verb → woven.
+        line = "Le cadre de Dung isole cette attaque (poids 0.3)."
+        assert _line_is_bare(line) is False
+
+    def test_year_in_parens_not_a_score(self):
+        line = "Dung (1995) définit les extensions préférées."
+        assert _line_is_bare(line) is False
+
+    def test_plain_sentence_no_framework_not_bare(self):
+        line = "La pertinence de l'argument est faible."
+        assert _line_is_bare(line) is False
+
+    def test_confidence_label_bare(self):
+        line = "ad hominem (confiance: 0.7)"
+        assert _line_is_bare(line) is True
+
+    def test_aspic_bare_without_verb(self):
+        line = "ASPIC+ : attaque (score 0.65)"
+        assert _line_is_bare(line) is True
+
+
+# --- thresholds: presence + WARN/FAIL by bare-ref count -----------------------
+
+
+class TestGateThresholds:
+    gate = ReadabilityGate()
+
+    def test_three_woven_acts_pass(self):
+        verdict = self.gate.check(_woven_acts())
+        assert verdict.band == "PASS", verdict.reasons
+        assert verdict.passed is True
+
+    def test_missing_act_fails(self):
+        acts = _woven_acts()
+        acts.act2_narrative = ""
+        verdict = self.gate.check(acts)
+        assert verdict.band == "FAIL"
+        assert any("Acte II absent" in r for r in verdict.reasons)
+        assert verdict.passed is False
+
+    def test_one_bare_ref_passes_with_note(self):
+        # A single residual bare ref is tolerated (PASS) but reported.
+        acts = _woven_acts()
+        acts.act2_narrative += "\n\nSophisme : ad populum (score 0.6)"
+        verdict = self.gate.check(acts)
+        assert verdict.band == "PASS"
+        assert any("nue" in r for r in verdict.reasons)
+
+    def test_two_bare_refs_warn(self):
+        acts = _woven_acts()
+        acts.act2_narrative += (
+            "\n\nSophisme : ad populum (score 0.6)"
+            "\nSophisme : ad baculum (score 0.55)"
+        )
+        verdict = self.gate.check(acts)
+        assert verdict.band == "WARN"
+        assert verdict.passed is True  # WARN is still readable
+
+    def test_three_bare_refs_fail(self):
+        acts = _woven_acts()
+        acts.act2_narrative += (
+            "\n\nSophisme : ad populum (score 0.6)"
+            "\nSophisme : ad baculum (score 0.55)"
+            "\nSophisme : ad misericordiam (score 0.5)"
+        )
+        verdict = self.gate.check(acts)
+        assert verdict.band == "FAIL"
+        assert any("énumération" in r.lower() or "3" in r for r in verdict.reasons)
+
+    def test_dump_headings_fail(self):
+        # The dimensional-dump smell: numbered "Sophisme N:" headings inside an act.
+        acts = _woven_acts()
+        acts.act2_narrative = (
+            "Analyse:\n"
+            "### Sophisme 1: ad hominem\nquelque chose.\n"
+            "### Sophisme 2: ad populum\nautre chose.\n"
+            "### Sophisme 3: straw man\nencore."
+        )
+        verdict = self.gate.check(acts)
+        assert verdict.band == "FAIL"
+        assert any("énumération dimensionnelle" in r for r in verdict.reasons)
+
+
+# --- verdict merging & reader-check ------------------------------------------
+
+
+class TestVerdictMechanics:
+
+    def test_merge_takes_worse_band(self):
+        a = GateVerdict(band="PASS", reasons=["a"])
+        b = GateVerdict(band="FAIL", reasons=["b"])
+        merged = a.merge(b)
+        assert merged.band == "FAIL"
+        assert merged.reasons == ["a", "b"]
+
+    def test_reader_check_failure_fails(self):
+        def _failing_reader(_body: str) -> ReaderCheckResult:
+            return ReaderCheckResult(
+                passed=False, total_questions=3, failed_questions=2
+            )
+
+        gate = ReadabilityGate(reader_check=_failing_reader)
+        verdict = gate.check(_woven_acts())
+        assert verdict.band == "FAIL"
+        assert any("Reader-check" in r for r in verdict.reasons)
+
+    def test_reader_check_pass_notes_it(self):
+        def _passing_reader(_body: str) -> ReaderCheckResult:
+            return ReaderCheckResult(passed=True, total_questions=3, failed_questions=0)
+
+        gate = ReadabilityGate(reader_check=_passing_reader)
+        verdict = gate.check(_woven_acts())
+        assert verdict.band == "PASS"
+        assert any("Reader-check passé" in r for r in verdict.reasons)
+
+    def test_reasons_specific_on_missing(self):
+        acts = RestitutionActs(
+            act1_framing="", act2_narrative="x" * 200, act3_conclusion="y" * 200
+        )
+        verdict = ReadabilityGate().check(acts)
+        assert any("Acte I absent" in r for r in verdict.reasons)

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_renderer.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_renderer.py
@@ -1,0 +1,138 @@
+"""Tests for the restitution report renderer (Epic #1134 / R6).
+
+Covers assembly, fail-loud behaviour on missing acts, degradation provenance,
+verdict transparency, appendix folding, and privacy. No JVM/LLM/network — the
+gate and fixtures are deterministic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from argumentation_analysis.reporting.restitution import (
+    RenderedReport,
+    RestitutionActs,
+    RestitutionReportRenderer,
+)
+
+# Reuse the woven bodies from the gate tests (single source of truth for the
+# "well-woven" shape).
+_WOVEN = {
+    1: (
+        "Le discours analysé (source doc_A) est un propos politique à visée "
+        "persuasive. L'orateur cherche à mobiliser l'auditoire sur une décision "
+        "controversée; l'asymétrie d'information joue en sa faveur. Un auditeur "
+        "averti doit guetter l'appel à l'autorité typique de ce genre. Les "
+        "joueurs sont l'orateur et un adversaire implicite."
+    ),
+    2: (
+        "Le premier mouvement appuie la thèse sur une autorité externe. Cette "
+        "autorité ne satisfait pas la question critique de fiabilité: c'est une "
+        "exception au scheme ExpertOpinion (ancrage AIF/Walton), et le solveur "
+        "Tweety confirme l'inconsistance de l'inférence sous-jacente. Le cadre "
+        "de Dung isole ensuite cette attaque comme défaillante."
+    ),
+    3: (
+        "L'analyse conclut à un discours structurellement fragile sur l'axe "
+        "formel. La synthèse honnête, gated par les dimensions non-triviales, "
+        "caractérise un propos qui cède sur la logique. Pour contrer: viser la "
+        "question critique de fiabilité. À attendre ensuite: un glissement vers "
+        "l'ad hominem."
+    ),
+}
+
+
+def _woven_acts() -> RestitutionActs:
+    return RestitutionActs(
+        act1_framing=_WOVEN[1],
+        act2_narrative=_WOVEN[2],
+        act3_conclusion=_WOVEN[3],
+        source_id="doc_A",
+    )
+
+
+class TestAssembly:
+
+    def test_three_acts_assembled_with_header_and_verdict(self):
+        report = RestitutionReportRenderer().render(_woven_acts())
+        assert isinstance(report, RenderedReport)
+        md = report.markdown
+        assert md.startswith("# Rapport de restitution — doc_A")
+        assert "## Acte I — Mise en situation" in md
+        assert "## Acte II — Récit dialectique" in md
+        assert "## Acte III — Conclusion actionnable" in md
+        # the woven body survived verbatim
+        assert "solveur Tweety confirme" in md
+        # verdict surfaced for transparency
+        assert "Gate lisibilité" in md
+        assert report.verdict.band == "PASS"
+
+    def test_appendix_folded_present(self):
+        report = RestitutionReportRenderer().render(
+            _woven_acts(), state={"identified_arguments": {"arg_1": "x"}}
+        )
+        assert "<details>" in report.markdown
+        assert "<summary>" in report.markdown
+
+
+class TestFailLoudOnMissing:
+
+    def test_missing_act_named_not_omitted(self):
+        acts = _woven_acts()
+        acts.act2_narrative = ""  # the narrative core is missing
+        report = RestitutionReportRenderer().render(acts)
+        # the report names the missing act honestly — no silent gap
+        assert "Acte II indisponible" in report.markdown
+        assert report.verdict.band == "FAIL"
+        assert any("Acte II absent" in r for r in report.verdict.reasons)
+
+    def test_missing_act1_named(self):
+        acts = _woven_acts()
+        acts.act1_framing = ""
+        report = RestitutionReportRenderer().render(acts)
+        assert "Acte I indisponible" in report.markdown
+
+
+class TestDegradationProvenance:
+
+    def test_degraded_act_note_surfaced(self):
+        acts = _woven_acts()
+        acts.degraded = {"act3_conclusion": "portes G1–G4 partiellement échouées (G2)."}
+        report = RestitutionReportRenderer().render(acts)
+        assert "Acte dégradé" in report.markdown
+        assert "G1–G4 partiellement échouées" in report.markdown
+
+
+class TestThinActWarning:
+
+    def test_thin_act_warns(self):
+        acts = _woven_acts()
+        # act3 present but suspiciously short (stub)
+        acts.act3_conclusion = "Conclusion courte."
+        report = RestitutionReportRenderer().render(acts)
+        assert report.verdict.band == "WARN"
+        assert any("anormalement court" in r for r in report.verdict.reasons)
+
+
+class TestPrivacy:
+
+    def test_source_id_in_header_only(self):
+        report = RestitutionReportRenderer().render(_woven_acts())
+        assert "doc_A" in report.markdown  # opaque id in header
+
+    def test_no_raw_text_in_appendix(self):
+        report = RestitutionReportRenderer().render(
+            _woven_acts(),
+            state={"raw_text": "SECRET CORPUS", "identified_arguments": {"a": "b"}},
+        )
+        assert "SECRET" not in report.markdown
+        assert "<details>" in report.markdown
+
+    def test_full_state_json_opt_in_is_leak_free(self):
+        report = RestitutionReportRenderer().render(
+            _woven_acts(),
+            state={"raw_text": "SECRET", "identified_arguments": {"a": "b"}},
+            include_full_state_json=True,
+        )
+        assert "```json" in report.markdown
+        assert "SECRET" not in report.markdown

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_state_adapter.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_state_adapter.py
@@ -1,0 +1,79 @@
+"""Tests for the state adapter + the public render_restitution_report shorthand."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from argumentation_analysis.reporting.restitution import (
+    RestitutionActs,
+    render_restitution_report,
+    state_to_appendix_mapping,
+)
+
+_WOVEN = {
+    1: (
+        "Le discours analysé (source doc_A) est un propos politique à visée "
+        "persuasive. L'orateur cherche à mobiliser l'auditoire; l'asymétrie "
+        "d'information joue en sa faveur. Un auditeur averti doit guetter "
+        "l'appel à l'autorité typique de ce genre."
+    ),
+    2: (
+        "Le premier mouvement appuie la thèse sur une autorité externe. Cette "
+        "autorité ne satisfait pas la question critique de fiabilité: c'est une "
+        "exception au scheme ExpertOpinion (ancrage AIF/Walton), et le solveur "
+        "Tweety confirme l'inconsistance de l'inférence sous-jacente."
+    ),
+    3: (
+        "L'analyse conclut à un discours fragile sur l'axe formel. La synthèse "
+        "honnête, gated par les dimensions non-triviales, caractérise un propos "
+        "qui cède sur la logique. Pour contrer: viser la fiabilité."
+    ),
+}
+
+
+class TestStateAdapter:
+
+    def test_reads_attributes_off_namespace(self):
+        ns = SimpleNamespace(
+            identified_arguments={"arg_1": "x"},
+            identified_fallacies={"f_1": {}},
+            raw_text="SECRET",
+        )
+        mapping = state_to_appendix_mapping(ns)
+        assert mapping["identified_arguments"] == {"arg_1": "x"}
+        # raw_text is NOT a spec §2 key → never copied
+        assert "raw_text" not in mapping
+
+    def test_reads_keys_off_dict(self):
+        mapping = state_to_appendix_mapping({"identified_arguments": {"a": "b"}})
+        assert mapping == {"identified_arguments": {"a": "b"}}
+
+    def test_missing_keys_omitted(self):
+        mapping = state_to_appendix_mapping(SimpleNamespace())
+        assert mapping == {}
+
+
+class TestPublicShorthand:
+
+    def test_render_restitution_report_one_call(self):
+        acts = RestitutionActs(
+            act1_framing=_WOVEN[1],
+            act2_narrative=_WOVEN[2],
+            act3_conclusion=_WOVEN[3],
+            source_id="doc_C",
+        )
+        report = render_restitution_report(acts)
+        assert "doc_C" in report.markdown
+        assert report.verdict.band == "PASS"
+        assert "Gate lisibilité" in report.markdown
+
+    def test_shorthand_with_state_adapter_roundtrip(self):
+        ns = SimpleNamespace(identified_arguments={"arg_1": "x"})
+        acts = RestitutionActs(
+            act1_framing=_WOVEN[1],
+            act2_narrative=_WOVEN[2],
+            act3_conclusion=_WOVEN[3],
+        )
+        report = render_restitution_report(acts, state=state_to_appendix_mapping(ns))
+        assert "<details>" in report.markdown
+        assert "arguments_extraits" in report.markdown


### PR DESCRIPTION
Closes #1140 · Epic #1134 (Restitution) Track R6.

## What

Assemble the 3 acts (`act1_framing` / `act2_narrative` / `act3_conclusion`) into **one readable Markdown**, replacing the dimensional dump as the report body. The dump survives, **folded**, as an engineering appendix (provenance). A deterministic **readability gate** mechanically enforces the spec §4 weaving rule: a framework citation must be anchored on a narrative beat, never dropped as a bare `name (score)`.

New module `argumentation_analysis/reporting/restitution/` — **file-disjoint** from the act generators R2/R3/R4 (coordinator dispatch):

| File | Role |
|------|------|
| `acts.py` | `RestitutionActs` — the 3-act input contract |
| `readability_gate.py` | mechanical weaving-rule check (§4); PASS/WARN/FAIL; optional injectable reader-check (#1140) |
| `renderer.py` | `RestitutionReportRenderer` + `render_restitution_report` shorthand; header → acts → verdict → folded appendix |
| `appendix.py` | provenance counts + verdicts, folded `<details>`; leak-key stripping; full-state JSON opt-in |
| `state_adapter.py` | reads spec §2 keys off `UnifiedAnalysisState` via `getattr` (no import, no touch to the R3-serialized `shared_state.py`) |

## DoD (#1140)

- [x] New 3-act renderer produces one readable Markdown; dump relegated to a folded appendix.
- [x] Gate runs on the woven bodies (structural, deterministic, CI-safe).
- [x] Renderer never writes to disk — caller picks the gitignored path for real corpora.
- [x] Regression: shared-state remains accessible (folded appendix + opt-in full JSON).
- [ ] **`render_markdown` replaced in the spectacular pipeline** — *partial, by design*: the renderer consumes a `RestitutionActs` produced by R2/R3/R4, which are not yet landed. This PR delivers the full file-disjoint plumbing, gate, and tests; the in-pipeline wiring is a one-liner (`render_restitution_report(acts, state=state_to_appendix_mapping(state))`) once the act generators populate `RestitutionActs`.

## Readability gate — the weaving rule (spec §4)

The load-bearing anti-énumération contract. A framework ref is **bare** (enumeration) iff it cites a framework **and** carries an isolated score **and** has no narrative verb:

- ❌ `Sophisme : ad verecundiam (score 0.8)` → bare (framework + score, no verb)
- ✅ `le solveur Tweety confirme l'inconsistance` → woven (verb, no score)
- ✅ `Le cadre de Dung isole cette attaque (poids 0.3)` → woven (verb anchors the score)

Bands: 0–1 bare → PASS (1 reported); 2 → WARN; ≥3 or repeated `Sophisme N:` dump-headings → FAIL. The verdict is **surfaced in the report** for transparency — the gate does not manufacture a passing score (#1019).

## Example output (woven fixtures, gate PASS)

```markdown
# Rapport de restitution — doc_A

Récit en trois actes ... Les cadres formels et informels (Tweety, Dung/ASPIC, taxonomie, vertus)
sont les *preuves* citées en appui du récit, jamais une énumération (spec §4).

## Acte I — Mise en situation
Le discours (doc_A) est un propos politique à visée persuasive ...

## Acte II — Récit dialectique
Le premier mouvement appuie la thèse sur une autorité externe. Cette autorité ne satisfait pas
la question critique de fiabilité: exception au scheme ExpertOpinion (AIF/Walton), et le solveur
Tweety confirme l'inconsistance de l'inférence. Le cadre de Dung isole cette attaque ...

## Acte III — Conclusion actionnable
... Pour contrer: viser la fiabilité. À attendre ensuite: glissement vers l'ad hominem.

---
## ✅ Gate lisibilité — PASS
Tous les contrôles structurels passent : 3 actes présents et non-triviaux, aucune référence
de cadre nue (énumération).

<details>
<summary>Annexe — provenance dimensionnelle (repliée par défaut)</summary>
| arguments_extraits | 2 |  | sophismes_localises | 1 |  | axe_fol | {consistent: False, formules: 2} |  | axe_pl | disponible |  ...
</details>
```

## Honesty / anti-pendule

- Fix = **subtraction** of the dump from the report body (not a "better-titled" dump).
- Missing act → **named**, not omitted (fail-loud).
- Gate verdict reported honestly; never a complacent score.
- `raw_text`/snippet keys stripped defensively even in opt-in full JSON.

## Privacy HARD

Opaque `source_id` only in the header; `raw_text` never reaches the appendix; the renderer never writes to disk. Real-corpus reports stay gitignored (caller's path choice).

## Tests

37 deterministic (no JVM, no LLM, no network): woven/bare/dump/missing/thin/degraded/reader-check/leak-stripping/full-state-opt-in/state-adapter. The canonical §4 contrast is pinned. `black`/`flake8` clean; `mypy` clean on the module (not in the `invoke_callables.py` CI gate).

## Coordination

File-disjoint lane (per R424 dispatch). Does not touch `workflows.py` / `invoke_callables.py` / `state_writers.py` / `shared_state.py` (R3-serialized). R3 (po-2023, Acte II) and R2/R4 populate `RestitutionActs`; this renderer consumes it.

🤖 Claude Code @ myia-po-2025:2025-Epita-Intelligence-Symbolique