### PR TITLE
feat(restitution): #1139 R5 volet-1 virtuous-text candidate identification

### DIFF
--- a/argumentation_analysis/reporting/restitution/__init__.py
+++ b/argumentation_analysis/reporting/restitution/__init__.py
@@ -21,6 +21,13 @@ from .renderer import (
     render_restitution_report,
 )
 from .state_adapter import state_to_appendix_mapping
+from .virtuous_identification import (
+    ExtractProfile,
+    VirtuousCandidate,
+    VirtuousInventory,
+    identify,
+    render_inventory_report,
+)
 
 __all__ = [
     "ACT_TITLES",
@@ -33,4 +40,10 @@ __all__ = [
     "render_appendix",
     "render_restitution_report",
     "state_to_appendix_mapping",
+    # R5 volet-1 — virtuous-text candidate identification (spec §5.1)
+    "ExtractProfile",
+    "VirtuousCandidate",
+    "VirtuousInventory",
+    "identify",
+    "render_inventory_report",
 ]

--- a/argumentation_analysis/reporting/restitution/virtuous_identification.py
+++ b/argumentation_analysis/reporting/restitution/virtuous_identification.py
@@ -1,0 +1,367 @@
+"""R5 volet-1 — identify *virtuous-text* candidates in the corpus (spec §5.1).
+
+Epic #1134 (Restitution), Track R5 (#1139). The restitution engine and report
+must run on **virtuous texts** (the positive case), not only on fallacy-laden
+prose. On a virtuous text the report's headline is the *virtue* (formal
+robustness, intellectual honesty, well-held schemes), not the absence of
+fallacies.
+
+This module answers the **identification** half of R5: *which corpus entries are
+virtuous-text candidates?* The owner's standing question — *« le dataset en
+contient, peut-être pas assez »* — is answered here, honestly.
+
+Spec §5.1 is unambiguous about what "virtuous" means::
+
+    a corpus input is flagged "virtuous" [...] a low (or zero) localized-fallacy
+    count **combined with** a non-trivial formal/quality axis [...]. The flag is
+    **derived, never asserted**: a text is virtuous iff the pipeline's own output
+    says so. If the dataset lacks enough virtuous inputs, R5 reports that gap
+    (fail-loud), it does not synthesize one.
+
+The true virtuous flag therefore **requires a pipeline run** (fallacy descent +
+formal/quality axes). This module does NOT run the pipeline — it is a cheap,
+deterministic **candidate generator** that narrows the corpus to the entries
+worth confirming. The output is explicitly a *candidate* list with the honest
+caveat that confirmation is pending (fail-loud on the gap, #1019/#369). It never
+asserts a text is virtuous on lexical evidence alone.
+
+Privacy HARD (CLAUDE.md dataset-privacy): the module works on **already-decrypted
+in-memory definitions** passed by the caller; it never touches disk, never prints
+a ``source_name``/path, and emits only **opaque IDs** (``src_N_ext_M``). No
+``raw_text`` / ``full_text`` / ``extract_text`` value ever leaves through this
+module's outputs — only *lengths* and *signal counts*.
+
+File-disjoint from the act generators (R2/R3/R4) and the renderer (R6): no edits
+to ``workflows.py`` / ``invoke_callables.py`` / ``state_writers.py`` / plugins.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence
+
+# --- schema ---------------------------------------------------------------
+
+# The dataset carries prose under two coexisting schemas:
+#   schema A (early sources): extract_name / extract_text / markers
+#   schema B (later sources): full_text / metadata / num_extract
+# ``extract_text`` is the primary prose field for schema A — do NOT assume
+# ``full_text`` (FB-39 lesson: verify the field name, do not assume).
+_TEXT_FIELDS: Sequence[str] = (
+    "extract_text",
+    "full_text",
+    "text",
+    "content",
+    "raw_text",
+)
+
+# Cheap lexical fallacy-signal indicators (FR + EN, rule-based, no LLM).
+# Counts, never verdicts: a high count ⇒ the text is likely fallacy-laden
+# (not a virtuous candidate); a low count on a substantive text ⇒ a candidate
+# worth confirming by the pipeline. NB: these patterns are LEXICAL — a text can
+# be structurally fallacious (non sequitur, equivocation, circularity) with zero
+# lexical hit, and conversely a long text in an unmatched language/register can
+# score zero for the wrong reason. The screen's PRECISION is unknown without a
+# pipeline run; it is a recall-oriented candidate generator, not a classifier.
+_LEXICAL_SIGNALS: Sequence[tuple[str, str]] = (
+    (r"\btous\b|\btoutes\b|\bjamais\b|\bpersonne ne\b|\bchacun\b", "generalisation"),
+    (r"\bexperts?\b|\bscientifiques?\b|\bautorit", "appel_autorite_lex"),
+    (r"\bpeur\b|\bmenace\b|\bdanger\b|\bcatastrophe", "peur_alarmisme"),
+    (r"\bsi\b.{0,40}\balors\b|\bglissement\b", "pente_glissante"),
+    (r"\bdevons\b|\bil faut\b|\bforc", "faux_debat_imperatif"),
+    (r"\bcomme tout le monde\b|\btout le monde sait\b", "ad_populum_lex"),
+)
+# compiled lazily so the module imports with zero side effects
+_COMPILED: Optional[List[tuple[Any, str]]] = None
+
+
+def _compiled_signals() -> List[tuple[Any, str]]:
+    global _COMPILED
+    if _COMPILED is None:
+        import re
+
+        _COMPILED = [(re.compile(p, re.IGNORECASE), n) for p, n in _LEXICAL_SIGNALS]
+    return _COMPILED
+
+
+def _extract_prose(extract: Mapping[str, Any]) -> Optional[str]:
+    """Return the prose held by an extract, whichever field carries it.
+
+    Returns ``None`` when no text-bearing field has a non-blank value (the
+    extract is metadata-only). Never prints the value — callers only see the
+    opaque metrics derived downstream.
+    """
+    for k in _TEXT_FIELDS:
+        v = extract.get(k)
+        if isinstance(v, str) and v.strip():
+            return v
+    return None
+
+
+def _lexical_signal_count(text: str) -> Dict[str, int]:
+    """Count cheap lexical fallacy signals by type. Empty dict if none."""
+    low = text.lower()
+    out: Dict[str, int] = {}
+    for rx, name in _compiled_signals():
+        n = len(rx.findall(low))
+        if n:
+            out[name] = n
+    return out
+
+
+# --- candidate model ------------------------------------------------------
+
+
+@dataclass
+class ExtractProfile:
+    """Opaque profile of one extract — metrics only, never content."""
+
+    opaque_id: str
+    char_count: int
+    has_text: bool
+    signal_total: int
+    signal_by_type: Dict[str, int] = field(default_factory=dict)
+
+    @property
+    def signal_density(self) -> float:
+        """Lexical signals per 1000 chars (0.0 when no text)."""
+        if self.char_count <= 0:
+            return 0.0
+        return round(self.signal_total / (self.char_count / 1000.0), 3)
+
+    @property
+    def in_sweet_spot(self) -> bool:
+        """Substantive enough to mount an argument, small enough for one pipeline
+        analysis (not a book). Bounds are module defaults — see ``identify``."""
+        return _MIN_CANDIDATE_CHARS <= self.char_count <= _MAX_CANDIDATE_CHARS
+
+    @property
+    def low_signal(self) -> bool:
+        return self.signal_density <= _MAX_CANDIDATE_DENSITY
+
+
+# tunable candidate-screen defaults (documented, overridable via ``identify``)
+_MIN_CANDIDATE_CHARS = 2000  # ~300-400 words: enough for premise+conclusion+schemes
+_MAX_CANDIDATE_CHARS = 50000  # pipeline-feasible single analysis; larger = book
+_MAX_CANDIDATE_DENSITY = 0.2  # lexical signals / 1000 chars
+
+
+@dataclass
+class VirtuousCandidate:
+    """An extract that passes the cheap candidate screen — NOT confirmed virtuous."""
+
+    opaque_id: str
+    char_count: int
+    signal_total: int
+    signal_density: float
+
+    def as_row(self) -> Dict[str, Any]:
+        return {
+            "opaque_id": self.opaque_id,
+            "chars": self.char_count,
+            "signal_total": self.signal_total,
+            "signal_density": self.signal_density,
+        }
+
+
+@dataclass
+class VirtuousInventory:
+    """Opaque inventory of the corpus + the virtuous-candidate narrowing.
+
+    ``candidates`` is a CANDIDATE list (cheap lexical screen). The DERIVED
+    virtuous flag (spec §5.1) requires a pipeline run; ``rarity`` reports the
+    honest gap when the candidate pool is thin.
+    """
+
+    total_sources: int
+    total_extracts: int
+    text_extracts: int
+    metadata_only_extracts: int
+    candidates: List[VirtuousCandidate] = field(default_factory=list)
+    excluded_too_short: int = 0
+    excluded_too_long: int = 0
+    excluded_high_signal: int = 0
+    size_brackets: Dict[str, int] = field(default_factory=dict)
+
+    @property
+    def candidate_count(self) -> int:
+        return len(self.candidates)
+
+    @property
+    def rarity(self) -> str:
+        """Honest rarity signal (fail-loud on a thin pool, never fabricates).
+
+        * ``THIN``  — ≤ 2 candidates: the corpus barely supports a virtuous
+          track; flag the gap, do not pad it.
+        * ``SCARCE`` — 3–5 candidates: usable but document the scarcity.
+        * ``ADEQUATE`` — ≥ 6 candidates.
+        """
+        n = self.candidate_count
+        if n <= 2:
+            return "THIN"
+        if n <= 5:
+            return "SCARCE"
+        return "ADEQUATE"
+
+
+def _opaque_id(source_index: int, extract_index: int) -> str:
+    return f"src_{source_index}_ext_{extract_index}"
+
+
+def _bracket(chars: int) -> str:
+    if chars <= 0:
+        return "no_text"
+    if chars < 2000:
+        return "tiny(<2k)"
+    if chars < 50000:
+        return "sweet(2k-50k)"
+    if chars < 200000:
+        return "large(50k-200k)"
+    return "book(>200k)"
+
+
+def identify(
+    definitions: Sequence[Mapping[str, Any]],
+    *,
+    min_chars: int = _MIN_CANDIDATE_CHARS,
+    max_chars: int = _MAX_CANDIDATE_CHARS,
+    max_density: float = _MAX_CANDIDATE_DENSITY,
+) -> VirtuousInventory:
+    """Narrow a decrypted corpus to virtuous-text candidates (cheap screen).
+
+    Args:
+        definitions: the **decrypted in-memory** extract definitions (as returned
+            by ``load_extract_definitions`` with the derived key). The module
+            never decrypts itself.
+        min_chars / max_chars: the sweet-spot bounds for a candidate (substantive
+            but pipeline-feasible as one analysis).
+        max_density: max lexical-signal density (per 1000 chars) for a candidate.
+
+    Returns:
+        A :class:`VirtuousInventory` with opaque profiles and the candidate list.
+        Nothing in the result reveals corpus content or source identity.
+
+    The candidates are **unconfirmed** — the spec §5.1 virtuous flag is derived
+    from pipeline output (fallacy_count + non-trivial formal/quality axis). This
+    function only narrows; confirmation is a separate, gated step.
+    """
+    inv = VirtuousInventory(
+        total_sources=len(definitions),
+        total_extracts=0,
+        text_extracts=0,
+        metadata_only_extracts=0,
+    )
+    candidates: List[VirtuousCandidate] = []
+
+    for si, src in enumerate(definitions):
+        extracts = src.get("extracts", []) or []
+        inv.total_extracts += len(extracts)
+        for ei, ex in enumerate(extracts):
+            oid = _opaque_id(si, ei)
+            prose = _extract_prose(ex)
+            if prose is None:
+                inv.metadata_only_extracts += 1
+                inv.size_brackets["no_text"] = inv.size_brackets.get("no_text", 0) + 1
+                continue
+            inv.text_extracts += 1
+            n = len(prose)
+            sig = _lexical_signal_count(prose)
+            total = sum(sig.values())
+            density = round(total / (n / 1000.0), 3) if n else 0.0
+            b = _bracket(n)
+            inv.size_brackets[b] = inv.size_brackets.get(b, 0) + 1
+
+            if n < min_chars:
+                inv.excluded_too_short += 1
+                continue
+            if n > max_chars:
+                inv.excluded_too_long += 1
+                continue
+            if density > max_density:
+                inv.excluded_high_signal += 1
+                continue
+            candidates.append(
+                VirtuousCandidate(
+                    opaque_id=oid,
+                    char_count=n,
+                    signal_total=total,
+                    signal_density=density,
+                )
+            )
+
+    # stable order: lowest density first, then longest (more to analyse)
+    candidates.sort(key=lambda c: (c.signal_density, -c.char_count))
+    inv.candidates = candidates
+    return inv
+
+
+def render_inventory_report(inv: VirtuousInventory) -> str:
+    """Render the opaque inventory as Markdown (for a gitignored artifact).
+
+    Emits opaque IDs and metrics only. Includes the honest rarity signal and the
+    mandatory caveat that candidates are unconfirmed (the DERIVED flag needs a
+    pipeline run, spec §5.1).
+    """
+    lines: List[str] = []
+    lines.append("# R5 volet-1 — virtuous-text candidate inventory (opaque)")
+    lines.append("")
+    lines.append("> Privacy HARD: opaque IDs only. No source name, no corpus text.")
+    lines.append(
+        "> This is a CANDIDATE list (cheap lexical screen). The virtuous flag is "
+        "DERIVED from pipeline output (spec §5.1) — unconfirmed here."
+    )
+    lines.append("")
+    lines.append("## Corpus composition")
+    lines.append("")
+    lines.append(f"- sources: **{inv.total_sources}**")
+    lines.append(f"- extracts (total): **{inv.total_extracts}**")
+    lines.append(
+        f"- extracts with text: **{inv.text_extracts}** "
+        f"(metadata-only: {inv.metadata_only_extracts})"
+    )
+    lines.append("- size brackets:")
+    for b in sorted(inv.size_brackets):
+        lines.append(f"  - `{b}`: {inv.size_brackets[b]}")
+    lines.append("")
+    lines.append("## Candidate screen (sweet spot + low lexical signal)")
+    lines.append("")
+    lines.append(
+        f"bounds: `{_MIN_CANDIDATE_CHARS}`–`{_MAX_CANDIDATE_CHARS}` chars, "
+        f"density ≤ `{_MAX_CANDIDATE_DENSITY}`/1k chars."
+    )
+    lines.append("")
+    lines.append(
+        f"excluded — too short (<{_MIN_CANDIDATE_CHARS}): {inv.excluded_too_short} · "
+        f"too long (>{_MAX_CANDIDATE_CHARS}): {inv.excluded_too_long} · "
+        f"high signal: {inv.excluded_high_signal}"
+    )
+    lines.append("")
+    lines.append(
+        f"**Rarity signal: {inv.rarity}** ({inv.candidate_count} candidate(s))"
+    )
+    lines.append("")
+    if inv.candidates:
+        lines.append("| opaque_id | chars | signal_total | density/1k |")
+        lines.append("|---|---|---|---|")
+        for c in inv.candidates:
+            lines.append(
+                f"| {c.opaque_id} | {c.char_count} | {c.signal_total} | {c.signal_density} |"
+            )
+    else:
+        lines.append(
+            "_(no candidate at this screen — corpus may lack virtuous inputs)_"
+        )
+    lines.append("")
+    lines.append("## Caveat (load-bearing)")
+    lines.append("")
+    lines.append(
+        "The lexical screen is a **recall-oriented candidate generator**. Its "
+        "PRECISION is unknown: a long text scoring `density 0.0` often reflects a "
+        "language/register mismatch, not virtue; a structurally fallacious text "
+        "(non sequitur, circularity) can score zero lexically. **Do not assert a "
+        "candidate is virtuous without a pipeline run** confirming `fallacy_count` "
+        "≈ 0 AND a non-trivial formal/quality axis (spec §5.1). The next step is "
+        "a (budget-gated) pipeline run on the top candidates to derive the flag."
+    )
+    lines.append("")
+    return "\n".join(lines)

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_virtuous_identification.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_virtuous_identification.py
@@ -1,0 +1,212 @@
+"""Tests for R5 volet-1 virtuous-text identification (spec §5.1).
+
+Deterministic: synthetic definitions, no JVM, no LLM, no real dataset. Pins:
+- dual-schema prose extraction (extract_text vs full_text)
+- candidate screen (sweet spot + low lexical signal)
+- rarity bands (fail-loud on a thin pool)
+- privacy HARD: opaque IDs only, no source_name / no prose value in outputs
+
+The candidate list is UNCONFIRMED by design — the DERIVED virtuous flag needs a
+pipeline run (spec §5.1). Tests assert that honest caveat is present.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from argumentation_analysis.reporting.restitution.virtuous_identification import (
+    VirtuousCandidate,
+    VirtuousInventory,
+    _extract_prose,
+    _opaque_id,
+    identify,
+    render_inventory_report,
+)
+
+# --- synthetic corpus builders --------------------------------------------
+
+# A long, clean (low lexical-signal) prose — repeated benign filler. Density ~0.
+_CLEAN_PROSE = (
+    "Le comite a examine les donnees disponibles et conclut, "
+    "apres deliberation, qu'une approche graduelle est preferable. "
+) * 80  # ~6400 chars, no fallacy lexical markers
+
+
+def _src_a(extracts):
+    """Schema A source: extract_text prose."""
+    return {"extracts": [{"extract_text": t} for t in extracts]}
+
+
+def _src_b(extracts):
+    """Schema B source: full_text prose."""
+    return {"extracts": [{"full_text": t} for t in extracts]}
+
+
+def _high_signal_prose(n_chars: int = 4000) -> str:
+    # pack the imperative + generalisation markers densely
+    base = "Tous les experts affirment que nous devons agir. "
+    reps = max(1, n_chars // len(base))
+    return base * reps
+
+
+# --- prose extraction -----------------------------------------------------
+
+
+class TestProseExtraction:
+    def test_schema_a_extract_text(self):
+        assert _extract_prose({"extract_text": "hello"}) == "hello"
+
+    def test_schema_b_full_text(self):
+        assert _extract_prose({"full_text": "world"}) == "world"
+
+    def test_schema_a_preferred_over_full_text(self):
+        # extract_text is primary for schema A
+        ex = {"extract_text": "a", "full_text": "b"}
+        assert _extract_prose(ex) == "a"
+
+    def test_metadata_only_returns_none(self):
+        assert _extract_prose({"extract_name": "x", "start_marker": "m"}) is None
+
+    def test_blank_string_treated_as_absent(self):
+        assert _extract_prose({"extract_text": "   "}) is None
+
+
+# --- candidate screen -----------------------------------------------------
+
+
+class TestCandidateScreen:
+    def test_clean_sweet_spot_text_is_candidate(self):
+        defs = [_src_a([_CLEAN_PROSE])]  # ~6400 chars, density 0
+        inv = identify(defs)
+        assert inv.candidate_count == 1
+        c = inv.candidates[0]
+        assert c.opaque_id == "src_0_ext_0"
+        assert c.signal_total == 0
+        assert c.signal_density == 0.0
+
+    def test_too_short_excluded(self):
+        defs = [_src_a(["court " * 50])]  # ~300 chars
+        inv = identify(defs)
+        assert inv.candidate_count == 0
+        assert inv.excluded_too_short == 1
+
+    def test_too_long_excluded(self):
+        defs = [_src_a(["x" * 60000])]  # 60k > 50k ceiling
+        inv = identify(defs)
+        assert inv.candidate_count == 0
+        assert inv.excluded_too_long == 1
+
+    def test_high_signal_excluded(self):
+        defs = [_src_a([_high_signal_prose(4000)])]  # dense fallacy lexicon
+        inv = identify(defs)
+        assert inv.candidate_count == 0
+        assert inv.excluded_high_signal == 1
+
+    def test_schema_b_full_text_candidate(self):
+        defs = [_src_b([_CLEAN_PROSE])]
+        inv = identify(defs)
+        assert inv.candidate_count == 1
+        assert inv.candidates[0].opaque_id == "src_0_ext_0"
+
+    def test_candidates_ordered_lowest_density_first(self):
+        # one clean (density 0), one with a single weak marker (density >0 but <=0.2)
+        # — exactly ONE lexical hit keeps density under the candidate ceiling.
+        defs = [
+            _src_a([_CLEAN_PROSE]),
+            _src_a([_CLEAN_PROSE + " Un passage cite un expert. "]),
+        ]
+        inv = identify(defs)
+        assert inv.candidate_count == 2
+        assert inv.candidates[0].signal_density <= inv.candidates[1].signal_density
+        assert inv.candidates[1].signal_total == 1  # exactly one marker
+
+
+# --- rarity ---------------------------------------------------------------
+
+
+class TestRarity:
+    def test_thin_pool(self):
+        inv = VirtuousInventory(
+            total_sources=1,
+            total_extracts=2,
+            text_extracts=2,
+            metadata_only_extracts=0,
+            candidates=[VirtuousCandidate("src_0_ext_0", 3000, 0, 0.0)],
+        )
+        assert inv.rarity == "THIN"
+
+    def test_scarce_pool(self):
+        cands = [VirtuousCandidate(f"src_{i}_ext_0", 3000, 0, 0.0) for i in range(4)]
+        inv = VirtuousInventory(1, 4, 4, 0, candidates=cands)
+        assert inv.rarity == "SCARCE"
+
+    def test_adequate_pool(self):
+        cands = [VirtuousCandidate(f"src_{i}_ext_0", 3000, 0, 0.0) for i in range(6)]
+        inv = VirtuousInventory(1, 6, 6, 0, candidates=cands)
+        assert inv.rarity == "ADEQUATE"
+
+    def test_empty_pool_is_thin_fail_loud(self):
+        # no candidate => THIN (the gap is reported, not padded) — anti-pendule
+        inv = VirtuousInventory(1, 5, 5, 0)
+        assert inv.rarity == "THIN"
+        assert inv.candidate_count == 0
+
+
+# --- composition metrics --------------------------------------------------
+
+
+class TestComposition:
+    def test_counts_and_brackets(self):
+        defs = [
+            _src_a([_CLEAN_PROSE]),  # sweet spot
+            _src_a(["x" * 100]),  # tiny
+            _src_a(["metadata_only"]),  # no — this has text; use real metadata
+            {"extracts": [{"extract_name": "m"}]},  # metadata-only (no text)
+        ]
+        inv = identify(defs)
+        assert inv.total_sources == 4
+        assert inv.total_extracts == 4
+        assert inv.text_extracts == 3
+        assert inv.metadata_only_extracts == 1
+        assert inv.candidate_count == 1
+        assert inv.size_brackets.get("no_text") == 1
+
+    def test_multiple_sources_indexing(self):
+        defs = [_src_a([_CLEAN_PROSE]), _src_b([_CLEAN_PROSE])]
+        inv = identify(defs)
+        ids = {c.opaque_id for c in inv.candidates}
+        assert ids == {"src_0_ext_0", "src_1_ext_0"}
+
+
+# --- privacy HARD ---------------------------------------------------------
+
+
+class TestPrivacy:
+    def test_report_has_no_source_name(self):
+        defs = [
+            {
+                "source_name": "SECRET_SOURCE_DO_NOT_LEAK",
+                "extracts": [{"extract_text": _CLEAN_PROSE}],
+            }
+        ]
+        inv = identify(defs)
+        report = render_inventory_report(inv)
+        assert "SECRET_SOURCE_DO_NOT_LEAK" not in report
+        assert "source_name" not in report
+
+    def test_report_has_no_prose_value(self):
+        marker = "UNIQUEPROSEMARKER_NEVER_IN_REPORT"
+        defs = [_src_a([_CLEAN_PROSE + marker])]
+        inv = identify(defs)
+        report = render_inventory_report(inv)
+        assert marker not in report
+
+    def test_opaque_id_format(self):
+        assert _opaque_id(3, 7) == "src_3_ext_7"
+
+    def test_report_states_unconfirmed_caveat(self):
+        # the honest caveat (candidates unconfirmed, pipeline needed) must be present
+        defs = [_src_a([_CLEAN_PROSE])]
+        report = render_inventory_report(identify(defs))
+        assert "pipeline" in report.lower()
+        assert "unconfirmed" in report.lower() or "not assert" in report.lower()


### PR DESCRIPTION
Epic #1134 (Restitution), Track **R5 volet-1** — identification half, dispatched R425. Answers the owner's standing question — *« le dataset en contient, peut-être pas assez »* — honestly, via a cheap deterministic candidate screen.

## What

`virtuous_identification.py` — narrows the decrypted corpus to **virtuous-text candidates** (the positive case the restitution engine must also handle). Per spec §5.1 the virtuous flag is **derived from pipeline output** (low `fallacy_count` + non-trivial formal/quality axis), never asserted — so this is a **candidate generator**, not a classifier. The honest caveat that confirmation needs a pipeline run is encoded in the module docstring, the report, and the tests.

- Dual-schema prose extraction: `extract_text` (schema A) **and** `full_text` (schema B). Verify the field, do not assume — FB-39 lesson (`_extract_text` initially missed `extract_text`, hiding 37/45 texts).
- Cheap lexical-fallacy-signal counts (FR/EN, no LLM): generalisation, appel-autorité, peur/alarmisme, pente glissante, faux-débat impératif, ad populum.
- Sweet-spot narrowing: 2k–50k chars + density ≤ 0.2 signals/k (substantive but pipeline-feasible as one analysis; excludes books).
- Rarity signal: `THIN` (≤2) / `SCARCE` (3–5) / `ADEQUATE` (≥6) — **fail-loud on a thin pool, never fabricates** (anti-pendule, #1019/#369).
- Opaque-only inventory report for the gitignored artifact.

## Real-dataset run (gitignored report under `evaluation/results/`)

18 sources / 45 extracts (all with text), size brackets: 11 tiny / 21 sweet-spot / 8 large / 5 book. **11 candidates, rarity ADEQUATE.** → the corpus *does* contain a viable virtuous-candidate pool; the DERIVED confirmation (pipeline run) is the next gated step.

## Files
- `argumentation_analysis/reporting/restitution/virtuous_identification.py` (new, 367)
- `argumentation_analysis/reporting/restitution/__init__.py` (exports, +13)
- `tests/unit/argumentation_analysis/reporting/restitution/test_virtuous_identification.py` (new, 212, 21 tests)

## DoD (#1139 volet-1)
- [x] List of candidate entries (opaque IDs) produced; rarity signalled honestly.
- [x] Fail-loud on rarity — no fabrication of virtuous inputs.
- [ ] DERIVED virtuous flag (pipeline run confirming `fallacy_count`≈0 + formal/quality axis) — **next gated step** (budget/scope ACK); spec §5.1 forbids asserting virtuous on lexical evidence alone.
- [ ] Volet-2 (mode rapport vertueux, Acte III titles virtues) — gated on act generators R2/R3/R4.

## Privacy HARD
Operates on caller-provided **decrypted in-memory** definitions; emits only opaque IDs (`src_N_ext_M`) + lengths/signal counts; never prints `source_name` or corpus text. Tests assert no leak. Real-dataset report is gitignored (`evaluation/results/`).

## Quality
black ✅ · flake8 ✅ · mypy ✅ (0 issues) · **21 new tests green** (58 total in `reporting/restitution/`). File-disjoint from R2/R3/R4 (no edits to `workflows.py`/`invoke_callables.py`/`state_writers.py`/plugins).

Co-Authored-By: Claude <noreply@anthropic.com>