### PR TITLE
feat(restitution): R2 #1136 — Acte I framing by derived taxonomy spectrum

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -438,6 +438,13 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         # the R6 renderer to populate RestitutionActs.act2_narrative. Empty until
         # the act2_narrative phase runs; the renderer reports the gap honestly.
         self.act2_narrative: str = ""
+        # Restitution Acte I — mise en situation (framing): genre, enjeux,
+        # spectre attendu (derived from taxonomy common_contexts), game-theoretic
+        # read. Epic #1134 / R2 #1136. LLM-conducted, produced BEFORE the
+        # microscope (the only act that may anticipate, spec §1.1). Consumed by
+        # the R6 renderer to populate RestitutionActs.act1_framing. Empty until
+        # the act1_framing phase runs; the renderer reports the gap honestly.
+        self.act1_framing: str = ""
         # PP #715: source-level metadata for qualitative synthesis
         self.source_metadata: Dict[str, str] = {}
         # PL 2-pass pipeline: shared atom inventory (#547)

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -5961,6 +5961,107 @@ async def _invoke_act2_narrative(
     }
 
 
+async def _invoke_act1_framing(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Invoke the Acte I framing generator (Epic #1134 / R2 #1136).
+
+    Builds the deterministic framing evidence (metadata + enjeux + derived
+    spectrum + game-theoretic read), then conducts the narrative via the LLM
+    (fail-loud, no template — #1108/#405). The result populates
+    ``state.act1_framing``, the key the R6 renderer consumes for
+    ``RestitutionActs.act1_framing``.
+
+    Mirrors ``_invoke_act2_narrative``: the LLM is resolved into an async
+    callable from a kernel + default service. Absent service → fail-loud
+    unavailable (anti-pendule #1019/#369).
+    """
+    from argumentation_analysis.reporting.restitution.act1_framing_plugin import (
+        Act1Result,
+        build_act1_framing,
+    )
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+    from argumentation_analysis.orchestration.state_writers import (
+        CAPABILITY_STATE_WRITERS,
+    )
+
+    state = context.get("_state_object") or context.get("unified_state")
+    if not isinstance(state, UnifiedAnalysisState):
+        state = UnifiedAnalysisState(input_text[:200])
+        populated = 0
+        for key, value in context.items():
+            if key.startswith("phase_") and key.endswith("_output"):
+                cap = key[len("phase_") : -len("_output")]
+                writer = CAPABILITY_STATE_WRITERS.get(cap)
+                if writer and isinstance(value, dict):
+                    try:
+                        writer(value, state, context)
+                        populated += 1
+                    except Exception:
+                        logger.warning(
+                            "State writer for '%s' failed during Acte I "
+                            "reconstruction",
+                            cap,
+                            exc_info=True,
+                        )
+        logger.info(
+            "Acte I: no UnifiedAnalysisState in context, reconstructed from "
+            "%d phase outputs",
+            populated,
+        )
+
+    llm_service_id: Optional[str] = None
+    kernel: Any = None
+    try:
+        from semantic_kernel import Kernel
+
+        kernel = Kernel()
+        try:
+            from argumentation_analysis.core.llm_service import create_llm_service
+
+            llm = create_llm_service(service_id="default")
+            if llm:
+                kernel.add_service(llm)
+                llm_service_id = "default"
+        except Exception:
+            llm_service_id = None
+    except Exception:
+        llm_service_id = None
+
+    async def _llm(prompt: str) -> str:
+        if not llm_service_id or kernel is None:
+            return ""
+        settings = kernel.get_prompt_execution_settings_from_service_id(
+            llm_service_id
+        )
+        result = await kernel.invoke_prompt(
+            function_name="act1_framing_conducted",
+            plugin_name="restitution",
+            prompt=prompt,
+            settings=settings,
+        )
+        return str(result) if result else ""
+
+    result: Act1Result = await build_act1_framing(
+        state, llm_callable=_llm if llm_service_id else None
+    )
+
+    gate_band = result.gate_verdict.band if result.gate_verdict is not None else None
+    if result.status != "woven":
+        logger.warning(
+            "Acte I framing status=%s (fail-loud). llm_service_id=%s.",
+            result.status,
+            llm_service_id,
+        )
+
+    return {
+        "act1_framing": result.narrative,
+        "status": result.status,
+        "gate_band": gate_band,
+        "degraded": result.degraded,
+    }
+
+
 def _count_referenced_fields(state: Any) -> int:
     """Count how many state fields have data (used as references in narrative)."""
     count = 0

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -58,6 +58,7 @@ from argumentation_analysis.orchestration.invoke_callables import (
     _invoke_analysis_synthesis,
     _invoke_narrative_synthesis,
     _invoke_act2_narrative,
+    _invoke_act1_framing,
     _invoke_external_fol_solver,
     _invoke_external_modal_solver,
     _invoke_deep_synthesis,
@@ -567,6 +568,25 @@ def setup_registry(
         registered.append("act2_narrative_service")
     except Exception as e:
         skipped.append(("act2_narrative_service", str(e)))
+
+    # --- Acte I framing narrative service (#1136, Epic #1134) ---
+    try:
+        registry.register_service(
+            name="act1_framing_service",
+            service_class=type("act1_framing_service", (), {}),
+            capabilities=["act1_framing"],
+            metadata={
+                "description": (
+                    "Generate the Acte I framing — mise en situation: genre, "
+                    "enjeux, derived expected fallacy spectrum, game-theoretic "
+                    "read. LLM-conducted, fail-loud. Consumed by the R6 renderer."
+                )
+            },
+            invoke=_invoke_act1_framing,
+        )
+        registered.append("act1_framing_service")
+    except Exception as e:
+        skipped.append(("act1_framing_service", str(e)))
 
     # --- External solver routing services (#504) ---
     for name, caps, desc, invoke_fn in [

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -919,6 +919,23 @@ def _write_act2_narrative_to_state(
         state.act2_narrative = narrative
 
 
+def _write_act1_framing_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
+    """Write the Acte I framing narrative to UnifiedAnalysisState (#1136).
+
+    Populates ``state.act1_framing`` — the key the R6 renderer consumes for
+    ``RestitutionActs.act1_framing``. Empty/unavailable results are left as the
+    empty default so the renderer reports the gap honestly (fail-loud,
+    #1108/#1019 — never fabricate a framing here).
+    """
+    if not output or not isinstance(output, dict):
+        return
+    narrative = output.get("act1_framing", "")
+    if isinstance(narrative, str) and narrative:
+        state.act1_framing = narrative
+
+
 def _write_text_to_kb_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write TextToKB extraction results to UnifiedAnalysisState (#506)."""
     if not output or not isinstance(output, dict):
@@ -1097,6 +1114,7 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "nl_to_logic_translation": _write_nl_to_logic_to_state,
     "narrative_synthesis": _write_narrative_synthesis_to_state,
     "act2_narrative": _write_act2_narrative_to_state,
+    "act1_framing": _write_act1_framing_to_state,
     "nl_extraction": _write_text_to_kb_to_state,
     "kb_to_tweety": _write_kb_to_tweety_to_state,
     "formal_result_interpretation": _write_tweety_interpretation_to_state,

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -930,6 +930,19 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             optional=False,
             timeout_seconds=180,
         )
+        # L11a — Acte I framing (Epic #1134 / R2 #1136). Mise en situation:
+        # genre, enjeux, derived expected fallacy spectrum, game-theoretic read.
+        # LLM-conducted + fail-loud, produced BEFORE the microscope (the only
+        # act that may anticipate, spec §1.1). Depends on extract (metadata) +
+        # stakes (enjeux/game-theoretic) — NOT on the analysis phases, which are
+        # Acte II's domain. Robust: fail-loud when the LLM is unavailable.
+        .add_phase(
+            "act1_framing",
+            capability="act1_framing",
+            depends_on=["extract", "stakes"],
+            optional=False,
+            timeout_seconds=180,
+        )
         # L11 — Acte II dialectical narrative (Epic #1134 / R3 #1137). Cut by
         # argumentative movement, woven per spec §4, LLM-conducted + fail-loud
         # (no template — #1108/#405). Depends on deep_synthesis so the full

--- a/argumentation_analysis/reporting/restitution/act1_framing_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act1_framing_plugin.py
@@ -1,0 +1,569 @@
+"""Acte I generator — mise en situation (framing), before the microscope.
+
+Epic #1134 (Restitution) / Track R2 #1136. LLM-conducted, woven per spec §4.
+Consumed by the R6 renderer to populate ``RestitutionActs.act1_framing``.
+
+Design (spec §1.1 + §4 + §7, issue #1136, dispatch coord R428):
+  - Everything that makes Acte II legible, produced BEFORE citing the text:
+    1. **Le texte** — discourse genre, speaker role, channel, context (opaque
+       metadata).
+    2. **Les enjeux** — what is at stake, for whom, what asymmetry.
+    3. **Le spectre attendu** — the fallacies an informed listener should watch
+       for given this *genre* of discourse. **Anticipation, not detection** —
+       DERIVED by walking the taxonomy: families whose ``common_contexts`` match
+       the discourse genre. Never hardcoded (DoD).
+    4. **La lecture game-theoretic** — players, interests, expected moves,
+       asymmetric info (from stakeholders + the argument inventory structure).
+  - Acte I is the ONLY act that may anticipate (spec §1.1). Every framework
+    citation still gets a narrative anchor (passes the §4 gate — this module
+    self-checks with ``ReadabilityGate``).
+  - **LLM-conducted**: the framing VARIES by corpus (no template #1108/#405).
+    Fail-loud when no LLM is injected — empty string + explicit status; the
+    renderer reports the gap honestly (anti-pendule #1019/#369). Missing
+    metadata is named ("contexte non renseigné"), never invented.
+
+Privacy HARD: opaque IDs only (``Speaker_A``, ``era_A``, ``State_Q``). The
+prompt carries the OPAQUE_ID_DIRECTIVE (FB-34). Corpus-derived fields
+(stakes/stakeholders text) are truncated before entering the prompt. The
+taxonomy families are constants (safe to surface).
+
+Testability: ``build_act1_evidence`` is deterministic (no LLM/JVM/API); the LLM
+is an injectable async callable ``Callable[[str], Awaitable[str]]`` (FB-29/38),
+so unit tests pass a stub and need no kernel.
+
+Mirrors the R3 act-plugin pattern (``act2_narrative_plugin``) — R4 will mirror
+this in turn (same 3 infra files, append-only).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+import yaml  # type: ignore[import-untyped]
+
+from .readability_gate import GateVerdict, ReadabilityGate
+
+logger = logging.getLogger(__name__)
+
+# An async LLM callable: prompt in, completion text out (FB-29/38 injectable).
+LlmCallable = Callable[[str], Awaitable[str]]
+
+# Truncation caps for corpus-derived fields entering the prompt.
+_STAKE_CAP = 200
+_STAKEHOLDER_CAP = 120
+_META_CAP = 160
+
+# Single source of truth: the taxonomy families YAML (same data the
+# TaxonomyExplorerPlugin loads). We read it directly to stay file-disjoint from
+# the SK plugin_framework (heavy JVM deps) and keep the restitution package
+# dependency-free. If the file moves, the loader fails-loud (no spectrum).
+_FALLACY_FAMILIES_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
+    "plugin_framework",
+    "core",
+    "plugins",
+    "standard",
+    "taxonomy_explorer",
+    "data",
+    "fallacy_families.yaml",
+)
+
+# Reserved genre sentinel when no genre signal is present → the spectrum is the
+# full taxonomy (general watch-list), reported honestly.
+_GENRE_UNKNOWN = "__unknown__"
+
+
+# --- evidence dataclasses ----------------------------------------------------
+
+
+@dataclass
+class ExpectedFamily:
+    """One fallacy family an informed listener should watch for (anticipation)."""
+
+    family_id: str
+    name_fr: str
+    matched_contexts: List[str]  # the common_contexts that matched the genre
+    severity_weight: float
+
+
+@dataclass
+class StakeholderInfo:
+    """One stakeholder for the game-theoretic read."""
+
+    role: str
+    detail: str
+
+
+@dataclass
+class Act1Evidence:
+    """Deterministic evidence bundle for the Acte I framing."""
+
+    # Le texte
+    metadata: Dict[str, str] = field(default_factory=dict)
+    genre: str = ""
+    genre_source: str = ""  # transparency: which field supplied the genre
+    # Les enjeux
+    stakes: List[str] = field(default_factory=list)
+    rhetorical_register: str = ""
+    discursive_arena: str = ""
+    has_stakes: bool = False
+    # Spectre attendu (derived from taxonomy common_contexts)
+    expected_spectrum: List[ExpectedFamily] = field(default_factory=list)
+    spectrum_general: bool = False  # True when genre unknown → full taxonomy
+    spectrum_available: bool = True  # False when taxonomy could not load
+    # Game-theoretic
+    stakeholders: List[StakeholderInfo] = field(default_factory=list)
+    arg_count: int = 0
+
+
+@dataclass
+class Act1Result:
+    """Outcome of :func:`build_act1_framing`.
+
+    ``status`` is ``"woven"`` | ``"unavailable"`` | ``"empty_state"``.
+    ``gate_verdict`` is the honest §4 self-check.
+    """
+
+    narrative: str
+    status: str
+    gate_verdict: Optional[GateVerdict] = None
+    degraded: Dict[str, str] = field(default_factory=dict)
+
+
+# --- taxonomy loader (minimal, file-disjoint) --------------------------------
+
+
+_families_cache: Optional[List[Dict[str, Any]]] = None
+
+
+def _load_families() -> List[Dict[str, Any]]:
+    """Load the fallacy families from the taxonomy YAML (cached, fail-loud).
+
+    Returns a list of ``{family, name_fr, common_contexts, severity_weight}``
+    dicts, or an empty list if the file is unavailable (the caller reports the
+    spectrum as unavailable — anti-pendule: never fabricate families).
+    """
+    global _families_cache
+    if _families_cache is not None:
+        return _families_cache
+    try:
+        with open(_FALLACY_FAMILIES_PATH, "r", encoding="utf-8") as f:
+            raw = yaml.safe_load(f) or []
+    except (OSError, yaml.YAMLError) as exc:
+        logger.warning(
+            "Acte I: fallacy families taxonomy unavailable (%s) — expected "
+            "spectrum will be reported as indisponible (fail-loud).",
+            exc,
+        )
+        _families_cache = []
+        return _families_cache
+    families: List[Dict[str, Any]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        fid = entry.get("family")
+        if not fid:
+            continue
+        families.append(
+            {
+                "family": str(fid),
+                "name_fr": str(entry.get("name_fr", fid)),
+                "common_contexts": [
+                    str(c).lower() for c in (entry.get("common_contexts") or [])
+                ],
+                "severity_weight": float(entry.get("severity_weight", 0.5)),
+            }
+        )
+    _families_cache = families
+    return _families_cache
+
+
+def reset_taxonomy_cache() -> None:
+    """Reset the families cache (test hook)."""
+    global _families_cache
+    _families_cache = None
+
+
+# --- deterministic evidence builder (no LLM) ---------------------------------
+
+
+def _truncate(text: Any, cap: int) -> str:
+    if not text:
+        return ""
+    s = str(text).strip()
+    return s if len(s) <= cap else s[:cap].rstrip() + " […]"
+
+
+def _derive_genre(state: Any) -> Tuple[str, str]:
+    """Derive the discourse genre (the concrete discursive domain) from the state.
+
+    The arena is preferred over the register because the taxonomy
+    ``common_contexts`` encode *domains* (politique, marketing, scientifique…),
+    not Aristotelian registers (délibératif, polémique) — a register alone never
+    narrows the expected spectrum. The register is still surfaced separately in
+    the framing (``evidence.rhetorical_register`` → stakes_block), so no signal
+    is lost. Returns (genre_lowercased, source_label); unknown →
+    (``_GENRE_UNKNOWN``, "").
+    """
+    stakes = getattr(state, "stakes_and_stakeholders", {}) or {}
+    if isinstance(stakes, dict):
+        arena = str(stakes.get("discursive_arena", "") or "").strip()
+        if arena:
+            return arena.lower(), "discursive_arena"
+        register = str(stakes.get("rhetorical_register", "") or "").strip()
+        if register:
+            return register.lower(), "rhetorical_register"
+    metadata = getattr(state, "source_metadata", {}) or {}
+    if isinstance(metadata, dict):
+        for key in ("genre", "register", "type", "arena", "context"):
+            val = str(metadata.get(key, "") or "").strip()
+            if val:
+                return val.lower(), f"source_metadata.{key}"
+    return _GENRE_UNKNOWN, ""
+
+
+def _derive_expected_spectrum(
+    families: List[Dict[str, Any]], genre: str
+) -> Tuple[List[ExpectedFamily], bool]:
+    """Derive the expected spectrum by matching genre → ``common_contexts``.
+
+    A family is expected when its ``common_contexts`` contains the genre (or the
+    genre contains a context — bidirectional substring, FR). When the genre is
+    unknown, returns the FULL taxonomy (general watch-list) with
+    ``spectrum_general=True`` (honest: "genre non renseigné — spectre général").
+    """
+    if not families:
+        return [], False
+    if genre == _GENRE_UNKNOWN or not genre:
+        # General watch-list: all families, sorted by severity (most severe
+        # first) so the framing foregrounds the highest-stakes watch.
+        ordered = sorted(families, key=lambda f: f["severity_weight"], reverse=True)
+        return [
+            ExpectedFamily(
+                family_id=f["family"],
+                name_fr=f["name_fr"],
+                matched_contexts=[],
+                severity_weight=f["severity_weight"],
+            )
+            for f in ordered
+        ], True
+    matches: List[ExpectedFamily] = []
+    for f in families:
+        contexts = f["common_contexts"]
+        hit = [c for c in contexts if c and (c in genre or genre in c)]
+        if hit:
+            matches.append(
+                ExpectedFamily(
+                    family_id=f["family"],
+                    name_fr=f["name_fr"],
+                    matched_contexts=hit,
+                    severity_weight=f["severity_weight"],
+                )
+            )
+    # If the genre matched nothing, fall back to the general watch-list
+    # (honest: the genre is too specific to narrow the spectrum).
+    if not matches:
+        ordered = sorted(families, key=lambda f: f["severity_weight"], reverse=True)
+        return [
+            ExpectedFamily(
+                family_id=f["family"],
+                name_fr=f["name_fr"],
+                matched_contexts=[],
+                severity_weight=f["severity_weight"],
+            )
+            for f in ordered
+        ], True
+    matches.sort(key=lambda m: m.severity_weight, reverse=True)
+    return matches, False
+
+
+def build_act1_evidence(state: Any) -> Act1Evidence:
+    """Build the deterministic Acte I framing evidence from a shared state.
+
+    No LLM, no JVM — pure state + taxonomy extraction. Privacy: corpus-derived
+    fields (stakes, stakeholders) are truncated; metadata stays opaque.
+    """
+    metadata = getattr(state, "source_metadata", {}) or {}
+    if not isinstance(metadata, dict):
+        metadata = {}
+    metadata_view = {
+        str(k): _truncate(v, _META_CAP) for k, v in metadata.items() if v
+    }
+
+    stakes_obj = getattr(state, "stakes_and_stakeholders", {}) or {}
+    has_stakes = isinstance(stakes_obj, dict) and bool(
+        stakes_obj.get("stakes") or stakes_obj.get("stakeholders")
+    )
+    register = ""
+    arena = ""
+    stakes_list: List[str] = []
+    stakeholders: List[StakeholderInfo] = []
+    if isinstance(stakes_obj, dict):
+        register = str(stakes_obj.get("rhetorical_register", "") or "").strip()
+        arena = str(stakes_obj.get("discursive_arena", "") or "").strip()
+        for s in stakes_obj.get("stakes", []) or []:
+            if isinstance(s, dict):
+                desc = s.get("description") or s.get("stake_type") or ""
+                if desc:
+                    stakes_list.append(_truncate(desc, _STAKE_CAP))
+            elif isinstance(s, str) and s:
+                stakes_list.append(_truncate(s, _STAKE_CAP))
+        for sh in stakes_obj.get("stakeholders", []) or []:
+            if isinstance(sh, dict):
+                role = str(sh.get("role") or sh.get("name") or sh.get("id") or "")
+                interest = (
+                    sh.get("interest")
+                    or sh.get("description")
+                    or sh.get("stake")
+                    or ""
+                )
+                if role or interest:
+                    stakeholders.append(
+                        StakeholderInfo(
+                            role=str(role),
+                            detail=_truncate(interest, _STAKEHOLDER_CAP),
+                        )
+                    )
+
+    genre, genre_source = _derive_genre(state)
+    families = _load_families()
+    spectrum_available = bool(families)
+    expected_spectrum, spectrum_general = _derive_expected_spectrum(families, genre)
+
+    args = getattr(state, "identified_arguments", {}) or {}
+    arg_count = len(args) if isinstance(args, dict) else 0
+
+    return Act1Evidence(
+        metadata=metadata_view,
+        genre=genre,
+        genre_source=genre_source,
+        stakes=stakes_list,
+        rhetorical_register=register,
+        discursive_arena=arena,
+        has_stakes=has_stakes,
+        expected_spectrum=expected_spectrum,
+        spectrum_general=spectrum_general,
+        spectrum_available=spectrum_available,
+        stakeholders=stakeholders,
+        arg_count=arg_count,
+    )
+
+
+# --- the conducted prompt (spec §4 weaving rule, no template) ----------------
+
+_OPAQUE_ID_DIRECTIVE = (
+    "DISCIPLINE D'IDENTIFIANTS OPAQUES (FB-34) — OBLIGATOIRE :\n"
+    "- Désigne le locuteur, l'arène, l'époque par des IDs opaques (Speaker_A,\n"
+    "  era_A, State_Q…), JAMAIS par un nom réel, une date réelle ou un lieu.\n"
+    "- Ne reproduis JAMAIS de passage verbatim du texte source : paraphrase le\n"
+    "  cadre en une phrase qui dit quelque chose.\n"
+    "- Les familles de sophismes (autorité, peur, généralisation…) sont des\n"
+    "  constantes de taxonomie : tu peux les nommer comme ancrage."
+)
+
+_WEAVING_RULE = (
+    "RÈGLE DE TISSAGE (spec §4) — le contrat anti-énumération :\n"
+    "- L'Acte I est le SEUL acte qui peut ANTICIPER (spec §1.1) : tu dis ce\n"
+    "  qu'un auditeur averti doit guetter, avant toute détection.\n"
+    "- CHAQUE famille du spectre attendu doit être ancrée : dis POURQUOI elle\n"
+    "  est attendue pour CE genre de discours (le contexte qui la rend probable).\n"
+    "- INTERDIT : une ligne « nom + score isolé », ex. « ad verecundiam (0.8) ».\n"
+    "  Ne produis JAMAIS de score entre parenthèses isolé. Le spectre est une\n"
+    "  anticipation, pas un tableau de scores.\n"
+    "- INTERDIT : numéroter en « Sophisme 1: » / « Argument 2: ». Rédige des\n"
+    "  paragraphes thématiques en prose."
+)
+
+_FAIL_LOUD_INSTRUCTION = (
+    "HONNÊTETÉ (anti-pendule #1019/#369) :\n"
+    "- Si une métadonnée manque, DIS-LE explicitement (« registre non renseigné »),\n"
+    "  ne l'invente JAMAIS.\n"
+    "- Le spectre est soit dérivé du genre, soit général (genre inconnu) — la\n"
+    "  note ci-dessous dit lequel. Ne prétends pas une dérivation que tu n'as pas."
+)
+
+
+def build_act1_prompt(evidence: Act1Evidence) -> str:
+    """Build the §4-compliant LLM-conducted prompt for the Acte I framing.
+
+    The prompt varies with the evidence (hence with the corpus) — it is not a
+    static template (#1108/#405).
+    """
+    # --- Le texte (metadata) ---
+    if evidence.metadata:
+        meta_block = "\n".join(
+            f"  - {k} : {v}" for k, v in evidence.metadata.items()
+        )
+    else:
+        meta_block = "  (aucune métadonnée renseignée — contexte limité au texte analysé)"
+
+    # --- Les enjeux ---
+    if evidence.has_stakes:
+        stakes_lines = [f"  - {_truncate(s, _STAKE_CAP)}" for s in evidence.stakes] or [
+            "  - (enjeux présents mais non décrits)"
+        ]
+        stakes_block = "\n".join(stakes_lines)
+        if evidence.rhetorical_register:
+            stakes_block += f"\n  Registre rhétorique : {evidence.rhetorical_register}"
+        if evidence.discursive_arena:
+            stakes_block += f"\n  Arène discursive : {evidence.discursive_arena}"
+    else:
+        stakes_block = "  (enjeux non extraits — cadrage limité au microscope interne)"
+
+    # --- Spectre attendu (derived) ---
+    if not evidence.spectrum_available:
+        spectrum_block = (
+            "  (taxonomie non chargée — spectre anticipé indisponible ; lire "
+            "l'Acte II sans filet d'attente)"
+        )
+        spectrum_note = "Spectre : INDISPONIBLE (taxonomie non chargée)."
+    elif evidence.spectrum_general:
+        spectrum_block = "\n".join(
+            f"  - {f.name_fr} (sévérité {f.severity_weight:.1f})"
+            for f in evidence.expected_spectrum
+        )
+        spectrum_note = (
+            "Spectre : GÉNÉRAL (genre non renseigné → toutes les familles, "
+            "ordre de sévérité). Dis-le honnêtement : on ne sait pas quel "
+            "genre c'est, donc on guette large."
+        )
+    else:
+        spectrum_block = "\n".join(
+            f"  - {f.name_fr} — contexte(s) attendu(s) : {', '.join(f.matched_contexts)}"
+            for f in evidence.expected_spectrum
+        )
+        spectrum_note = (
+            f"Spectre : DÉRIVÉ du genre « {evidence.genre} » (source : "
+            f"{evidence.genre_source}). Ces familles sont attendues POUR CE "
+            f"genre — ancre chacune sur le contexte qui la rend probable."
+        )
+
+    # --- Game-theoretic ---
+    if evidence.stakeholders:
+        gt_block = "\n".join(
+            f"  - {_truncate(sh.role, _STAKEHOLDER_CAP)}"
+            + (f" : {sh.detail}" if sh.detail else "")
+            for sh in evidence.stakeholders
+        )
+    else:
+        gt_block = "  (parties engagées non extraites — cadrage stratégique limité)"
+    gt_note = (
+        f"Inventaire argumentatif : {evidence.arg_count} argument(s) extrait(s)."
+    )
+
+    return (
+        "Tu es l'auteur de l'ACTE I d'un rapport de restitution argumentative —\n"
+        "la MISE EN SITUATION, tout le cadrage AVANT d'entrer dans le texte pour\n"
+        "rendre l'analyse (Acte II) lisible. Quatre battements en prose :\n"
+        "1. Le texte (genre, locuteur, canal, contexte) ; 2. Les enjeux (ce qui\n"
+        "se joue, pour qui, quelle asymétrie) ; 3. Le spectre des sophismes\n"
+        "attendus pour ce genre (anticipation dérivée de la taxonomie) ;\n"
+        "4. La lecture game-theoretic (joueurs, intérêts, coups attendus).\n\n"
+        f"{_OPAQUE_ID_DIRECTIVE}\n\n"
+        f"{_WEAVING_RULE}\n\n"
+        f"{_FAIL_LOUD_INSTRUCTION}\n\n"
+        "DONNÉES VERIFIÉES DANS LE STATE :\n\n"
+        f"[LE TEXTE — métadonnées]\n{meta_block}\n\n"
+        f"[LES ENJEUX]\n{stakes_block}\n\n"
+        f"[SPECTRE ATTENDU — dérivation taxonomie]\n{spectrum_note}\n"
+        f"{spectrum_block}\n\n"
+        f"[LECTURE GAME-THEORETIC]\n{gt_block}\n{gt_note}\n\n"
+        "CONSIGNE DE RÉDACTION :\n"
+        "- Rédige 4 paragraphes thématiques (un par battement), en prose lisible,\n"
+        "  pas une liste de champs.\n"
+        "- Pour le spectre, ancre chaque famille sur le contexte qui la rend\n"
+        "  probable pour ce genre (ex. « dans un discours politique, l'appel à\n"
+        "  l'autorité et l'attaque personnelle sont à guetter car… »).\n"
+        "- Le récit doit VARIER selon le contenu réel ci-dessus : pas de prose\n"
+        "  générique recyclable.\n"
+        "- Rédige en français, markdown léger (titres thématiques en ###). "
+        "300-600 mots selon la richesse réelle.\n"
+    )
+
+
+# --- LLM-conducted weaving (fail-loud) ---------------------------------------
+
+
+async def weave_act1_framing(
+    evidence: Act1Evidence, llm_callable: LlmCallable
+) -> str:
+    """Conduct the Acte I framing via the LLM (fail-loud, #1108)."""
+    prompt = build_act1_prompt(evidence)
+    try:
+        raw = await llm_callable(prompt)
+    except Exception as exc:  # noqa: BLE001 — surface, don't fabricate
+        logger.warning("Acte I LLM weaving failed (fail-loud): %s", exc)
+        return ""
+    if not raw:
+        return ""
+    return str(raw).strip()
+
+
+# --- orchestrator ------------------------------------------------------------
+
+
+async def build_act1_framing(
+    state: Any, llm_callable: Optional[LlmCallable] = None
+) -> Act1Result:
+    """Build the Acte I framing narrative for ``state``.
+
+    Deterministic evidence is always built. The narrative is LLM-conducted only
+    when ``llm_callable`` is provided; otherwise fail-loud (``unavailable``,
+    empty narrative) — the renderer reports the gap honestly (#1108).
+
+    A §4 self-check (``ReadabilityGate``) is attached to every woven result so
+    the verdict is auditable; it never fabricates a pass.
+    """
+    evidence = build_act1_evidence(state)
+
+    # Acte I can be produced even with empty metadata (framing degrades to
+    # "contexte limité au texte") — but not without an LLM to conduct it.
+    if llm_callable is None:
+        return Act1Result(
+            narrative="",
+            status="unavailable",
+            degraded={
+                "act1_framing": (
+                    "Cadrage non conduit — aucun LLM injecté pour l'Acte I "
+                    "(fail-loud, #1108)."
+                )
+            },
+        )
+
+    narrative = await weave_act1_framing(evidence, llm_callable)
+    if not narrative:
+        return Act1Result(
+            narrative="",
+            status="unavailable",
+            degraded={
+                "act1_framing": (
+                    "Cadrage indisponible — le LLM n'a rien produit (fail-loud, "
+                    "#1108)."
+                )
+            },
+        )
+
+    gate = ReadabilityGate()
+    verdict = gate.check_body(narrative)
+    degraded: Dict[str, str] = {}
+    if verdict.band != "PASS":
+        degraded["act1_framing_gate"] = (
+            f"Self-check §4 = {verdict.band}: " + "; ".join(verdict.reasons[:3])
+        )
+    if not evidence.has_stakes:
+        degraded["act1_framing"] = (
+            "Enjeux non extraits (stakes_and_stakeholders vide) — cadrage "
+            "limité au microscope interne, fail-loud."
+        )
+    if not evidence.spectrum_available:
+        degraded["act1_framing_spectrum"] = (
+            "Spectre attendu indisponible (taxonomie non chargée) — lire "
+            "l'Acte II sans filet d'attente."
+        )
+
+    return Act1Result(
+        narrative=narrative, status="woven", gate_verdict=verdict, degraded=degraded
+    )

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
@@ -31,9 +31,11 @@ class TestSpectacularWorkflowDAG:
         # #1115: the template `narrative_synthesis` phase was REMOVED from the
         # spectacular workflow (determinization residue per #1109 §5). The count
         # reflects the real phase set (#504 solvers, #506 KB/tweety, #507
-        # belief_revision, #508 synthesis, #534 deep_synthesis, ...).
+        # belief_revision, #508 synthesis, #534 deep_synthesis, ...) PLUS the
+        # two restitution acts wired onto the spectacular DAG: act1_framing
+        # (R2 #1136) and act2_narrative (R3 #1137) — the 3-act narrative.
         wf = build_spectacular_workflow()
-        assert len(wf.phases) == 28
+        assert len(wf.phases) == 30
 
     def test_all_expected_phases_present(self):
         wf = build_spectacular_workflow()
@@ -67,6 +69,9 @@ class TestSpectacularWorkflowDAG:
             "belief_revision",
             "synthesis",
             "deep_synthesis",
+            # Restitution acts (Epic #1134): R2 framing + R3 narrative.
+            "act1_framing",
+            "act2_narrative",
         }
         assert expected == phase_names
 

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act1_framing_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act1_framing_plugin.py
@@ -1,0 +1,368 @@
+"""Tests for the Acte I generator — mise en situation / framing (R2 #1136).
+
+Pins the spec §1.1 contract (4 framing beats, before the microscope; the only
+act that may anticipate) and the §4 weaving contract. The load-bearing DoD for
+the expected spectrum: it is **derived** from the taxonomy ``common_contexts``
+matching the discourse genre — never hardcoded.
+
+Deterministic — no JVM, no LLM service, no network: the LLM is an injectable
+async stub and the state is a ``SimpleNamespace``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from argumentation_analysis.reporting.restitution.act1_framing_plugin import (
+    Act1Result,
+    _derive_expected_spectrum,
+    _derive_genre,
+    _load_families,
+    build_act1_evidence,
+    build_act1_framing,
+    build_act1_prompt,
+    reset_taxonomy_cache,
+    weave_act1_framing,
+)
+from argumentation_analysis.reporting.restitution.readability_gate import (
+    ReadabilityGate,
+)
+
+
+# --- state stubs -------------------------------------------------------------
+
+
+def _state(**fields: object) -> SimpleNamespace:
+    base = dict(
+        source_metadata={},
+        stakes_and_stakeholders={
+            "stakes": [],
+            "stakeholders": [],
+            "rhetorical_register": "",
+            "discursive_arena": "",
+        },
+        identified_arguments={},
+    )
+    base.update(fields)
+    return SimpleNamespace(**base)
+
+
+def _political_state() -> SimpleNamespace:
+    return _state(
+        source_metadata={
+            "genre": "discours politique",
+            "speaker_role": "locuteur en autorité",
+            "channel": "arène publique",
+        },
+        stakes_and_stakeholders={
+            "rhetorical_register": "délibératif",
+            "discursive_arena": "politique",
+            "stakes": [
+                {"stake_type": "décision", "description": "Mobiliser l'auditoire sur une décision controversée."},
+            ],
+            "stakeholders": [
+                {"role": "locuteur", "interest": "Faire adopter la décision."},
+                {"role": "adversaire", "interest": "Bloquer la décision."},
+            ],
+        },
+        identified_arguments={"arg_1": "thèse", "arg_2": "support"},
+    )
+
+
+# --- async LLM stubs ---------------------------------------------------------
+
+
+def _stub_llm(return_value: str) -> object:
+    async def _call(_prompt: str) -> str:
+        return return_value
+
+    return _call
+
+
+def _raising_llm(exc: BaseException) -> object:
+    async def _call(_prompt: str) -> str:
+        raise exc
+
+    return _call
+
+
+# A §4-compliant woven Acte I (4 thematic beats, families anchored to the
+# genre, no isolated score, no dump heading). Must PASS the readability gate.
+_WOVEN_FRAMING = (
+    "### Le texte\n\n"
+    "Le discours analysé (source doc_A) est un propos politique prononcé par "
+    "un locuteur en position d'autorité dans une arène publique. Le registre "
+    "délibératif borne ce qu'on peut attendre de la suite.\n\n"
+    "### Les enjeux\n\n"
+    "Ce qui se joue est l'adoption d'une décision controversée; l'asymétrie "
+    "d'information joue en faveur du locuteur, qui dispose de cadres que "
+    "l'auditoire ne peut vérifier immédiatement.\n\n"
+    "### Le spectre attendu\n\n"
+    "Pour un discours politique, un auditeur averti doit guetter l'appel à "
+    "l'autorité et l'attaque personnelle, typiques de l'arène où la "
+    "disqualification prime sur le raisonnement. L'appel à la peur y est aussi "
+    "probable, car l'émotion fait levier sur une décision controversée. C'est "
+    "une anticipation, non une détection : l'Acte II dira ce qui a été "
+    "réellement trouvé.\n\n"
+    "### La lecture game-theoretic\n\n"
+    "Les joueurs sont le locuteur, l'auditoire cible et un adversaire implicite; "
+    "leurs intérêts divergent sur la décision, et le coup attendu du locuteur "
+    "est la disqualification de l'adversaire. L'information asymétrique est son "
+    "atout principal."
+)
+
+# An enumeration (bare refs + dump headings) — must NOT pass the gate.
+_ENUMERATION = (
+    "Argument 1: Speaker_A\n"
+    "Sophisme 1: ad verecundiam (0.8)\n"
+    "Sophisme 2: ad populum (0.7)\n"
+)
+
+
+# ============================================================================
+# spectrum derivation (load-bearing DoD: derived, not hardcoded)
+# ============================================================================
+
+
+class TestSpectrumDerivation:
+    def test_political_genre_matches_four_families(self):
+        families = _load_families()
+        spectrum, general = _derive_expected_spectrum(families, "politique")
+        ids = {f.family_id for f in spectrum}
+        assert general is False
+        # All four families whose common_contexts include "politique".
+        assert ids == {
+            "authority_popularity",
+            "emotional_appeals",
+            "diversion_attack",
+            "false_dilemma_simplification",
+        }
+
+    def test_unknown_genre_falls_back_to_general_full_taxonomy(self):
+        families = _load_families()
+        spectrum, general = _derive_expected_spectrum(families, "__unknown__")
+        assert general is True
+        assert len(spectrum) == len(families)  # full watch-list
+        # ordered by severity descending
+        weights = [f.severity_weight for f in spectrum]
+        assert weights == sorted(weights, reverse=True)
+
+    def test_specific_genre_matching_nothing_falls_back_to_general(self):
+        families = _load_families()
+        spectrum, general = _derive_expected_spectrum(
+            families, "quantique_inédit_genre"
+        )
+        assert general is True
+        assert len(spectrum) == len(families)
+
+    def test_matched_spectrum_ordered_by_severity(self):
+        families = _load_families()
+        spectrum, _ = _derive_expected_spectrum(families, "scientifique")
+        weights = [f.severity_weight for f in spectrum]
+        assert weights == sorted(weights, reverse=True)
+
+
+class TestGenreDerivation:
+    def test_arena_takes_precedence(self):
+        # The arena (concrete domain) wins over the register (Aristotelian mode)
+        # because taxonomy common_contexts encode domains — a register alone
+        # never narrows the expected spectrum.
+        state = _state(
+            stakes_and_stakeholders={
+                "rhetorical_register": "Polémique",
+                "discursive_arena": "marketing",
+            }
+        )
+        genre, src = _derive_genre(state)
+        assert genre == "marketing"
+        assert src == "discursive_arena"
+
+    def test_register_used_when_arena_absent(self):
+        state = _state(
+            stakes_and_stakeholders={"rhetorical_register": "Délibératif", "discursive_arena": ""}
+        )
+        genre, src = _derive_genre(state)
+        assert genre == "délibératif"
+        assert src == "rhetorical_register"
+
+    def test_metadata_fallback(self):
+        state = _state(
+            source_metadata={"genre": "Plaidoyer"},
+            stakes_and_stakeholders={"rhetorical_register": "", "discursive_arena": ""},
+        )
+        genre, src = _derive_genre(state)
+        assert genre == "plaidoyer"
+        assert "source_metadata" in src
+
+    def test_unknown_when_nothing_present(self):
+        genre, src = _derive_genre(_state())
+        assert genre == "__unknown__"
+        assert src == ""
+
+
+# ============================================================================
+# build_act1_evidence — deterministic framing bundle
+# ============================================================================
+
+
+class TestBuildEvidence:
+    def test_metadata_is_opaque_view(self):
+        ev = build_act1_evidence(_political_state())
+        assert ev.metadata["speaker_role"] == "locuteur en autorité"
+        assert ev.genre in ("politique", "délibératif")
+
+    def test_stakes_and_stakeholders_populated(self):
+        ev = build_act1_evidence(_political_state())
+        assert ev.has_stakes is True
+        assert ev.stakeholders[0].role == "locuteur"
+        assert ev.arg_count == 2
+
+    def test_long_stake_truncated(self):
+        long_stake = "y" * 500
+        state = _state(
+            stakes_and_stakeholders={
+                "rhetorical_register": "politique",
+                "stakes": [{"description": long_stake}],
+                "stakeholders": [],
+            }
+        )
+        ev = build_act1_evidence(state)
+        assert ev.stakes[0].endswith("[…]")
+        assert len(ev.stakes[0]) <= 205
+
+    def test_no_stakes_flag(self):
+        ev = build_act1_evidence(_state())
+        assert ev.has_stakes is False
+
+    def test_spectrum_derived_not_general_for_known_genre(self):
+        ev = build_act1_evidence(_political_state())
+        assert ev.spectrum_available is True
+        assert ev.spectrum_general is False
+        assert any(f.family_id == "authority_popularity" for f in ev.expected_spectrum)
+
+
+class TestPrivacy:
+    def test_prompt_carries_directives(self):
+        ev = build_act1_evidence(_political_state())
+        prompt = build_act1_prompt(ev)
+        assert "OPAQUES" in prompt  # FB-34 directive
+        assert "TISSAGE" in prompt  # §4 weaving rule
+        assert "HONNÊTETÉ" in prompt  # fail-loud instruction
+
+    def test_long_metadata_truncated_in_prompt(self):
+        state = _state(source_metadata={"genre": "x" * 500})
+        ev = build_act1_evidence(state)
+        prompt = build_act1_prompt(ev)
+        assert "x" * 500 not in prompt
+
+
+# ============================================================================
+# weave_act1_framing — fail-loud
+# ============================================================================
+
+
+class TestWeaveFailLoud:
+    def test_llm_error_returns_empty(self):
+        ev = build_act1_evidence(_political_state())
+        out = asyncio.get_event_loop().run_until_complete(
+            weave_act1_framing(ev, _raising_llm(RuntimeError("boom")))  # type: ignore[arg-type]
+        )
+        assert out == ""
+
+    def test_llm_empty_returns_empty(self):
+        ev = build_act1_evidence(_political_state())
+        out = asyncio.get_event_loop().run_until_complete(
+            weave_act1_framing(ev, _stub_llm(""))  # type: ignore[arg-type]
+        )
+        assert out == ""
+
+
+# ============================================================================
+# build_act1_framing — orchestrator + §4 self-check
+# ============================================================================
+
+
+class TestBuildFraming:
+    def test_no_llm_is_fail_loud_unavailable(self):
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act1_framing(_political_state(), llm_callable=None)
+        )
+        assert result.status == "unavailable"
+        assert result.narrative == ""
+        assert "act1_framing" in result.degraded
+
+    def test_woven_framing_passes_gate_self_check(self):
+        """DoD: the conducted framing passes our own §4 gate."""
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act1_framing(
+                _political_state(), llm_callable=_stub_llm(_WOVEN_FRAMING)  # type: ignore[arg-type]
+            )
+        )
+        assert result.status == "woven"
+        assert result.narrative == _WOVEN_FRAMING
+        assert result.gate_verdict is not None
+        assert result.gate_verdict.band == "PASS", result.gate_verdict.reasons
+
+    def test_enumeration_is_detected_honestly(self):
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act1_framing(
+                _political_state(), llm_callable=_stub_llm(_ENUMERATION)  # type: ignore[arg-type]
+            )
+        )
+        assert result.status == "woven"
+        assert result.gate_verdict is not None
+        assert result.gate_verdict.band == "FAIL"
+        assert result.degraded
+
+    def test_no_stakes_recorded_as_degraded(self):
+        state = _political_state()
+        state.stakes_and_stakeholders = {
+            "stakes": [],
+            "stakeholders": [],
+            "rhetorical_register": "",
+            "discursive_arena": "",
+        }
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act1_framing(state, llm_callable=_stub_llm(_WOVEN_FRAMING))  # type: ignore[arg-type]
+        )
+        assert any("enjeux" in v.lower() for v in result.degraded.values())
+
+
+# ============================================================================
+# The woven fixture passes the gate independently (belt + braces)
+# ============================================================================
+
+
+class TestWovenFixtureIsGateCompliant:
+    def test_woven_framing_passes_gate_directly(self):
+        gate = ReadabilityGate()
+        verdict = gate.check_body(_WOVEN_FRAMING)
+        assert verdict.passed, verdict.reasons
+
+    def test_enumeration_fails_gate_directly(self):
+        gate = ReadabilityGate()
+        verdict = gate.check_body(_ENUMERATION)
+        assert not verdict.passed
+
+
+# ============================================================================
+# DoD (d): state.act1_framing is consumed by the R6 renderer end-to-end.
+# ============================================================================
+
+
+class TestConsumedByRenderer:
+    def test_state_act1_flows_to_renderer(self):
+        from argumentation_analysis.reporting.restitution.acts import RestitutionActs
+        from argumentation_analysis.reporting.restitution.renderer import (
+            render_restitution_report,
+        )
+
+        state = SimpleNamespace(act1_framing=_WOVEN_FRAMING)
+        acts = RestitutionActs(source_id="doc_A", act1_framing=state.act1_framing)
+        report = render_restitution_report(acts)
+        assert _WOVEN_FRAMING.splitlines()[0] in report.markdown
+        # act2/act3 are missing → reported honestly, not silently dropped.
+        assert "indisponible" in report.markdown.lower() or "acte" in report.markdown.lower()


### PR DESCRIPTION
## Summary

Epic **#1134 (Restitution)** / Track **R2 #1136**. Generates **Acte I — mise en situation**: the framing produced *before* the microscope, so the Acte II analysis (R3, merged) is legible. Four LLM-conducted beats per spec §1.1:

1. **Le texte** — genre, speaker role, channel, context (opaque metadata).
2. **Les enjeux** — stakes, stakeholders, asymmetry.
3. **Le spectre attendu** — the fallacies an informed listener should watch for given *this* genre. **Anticipation, not detection.** **Derived** by walking the taxonomy: families whose `common_contexts` match the discourse genre. Unknown genre → honest general watch-list.
4. **La lecture game-theoretic** — players, interests, expected moves.

Acte I is the ONLY act that may anticipate (spec §1.1). Every framework citation still gets a narrative anchor — the module self-checks with `ReadabilityGate` (woven fixture **PASS**, enumeration **FAIL**).

Mirrors the R3 act-plugin pattern (`act2_narrative_plugin`); R4 (Acte III) will mirror in turn.

## DoD proven

- **(a) Spectre dérivé, pas codé en dur** — load-bearing: `fallacy_families.yaml` `common_contexts` matched against the genre. Political genre → 4 derived families (`emotional_appeals`, `authority_popularity`, `false_dilemma_simplification`, `diversion_attack`); unknown genre → full taxonomy severity-ordered. Tested in `TestSpectrumDerivation` (4 tests).
- **(b) Passes our own §4 gate** — woven 4-beat fixture PASSES `ReadabilityGate`; bare-ref enumeration (`Sophisme 1: ad verecundiam (0.8)`) is detected FAIL. Self-check attached to every woven result.
- **(c) LLM-conducted, fail-loud** — no template (#1108/#405); the framing varies with the corpus. Absent LLM → empty + `status=unavailable` + explicit degraded reason; the renderer reports the gap honestly (#1019/#369). Missing metadata is *named* ("contexte non renseigné"), never invented.
- **(d) Consumed by R6 end-to-end** — `state.act1_framing` → `_write_act1_framing_to_state` → renderer populates `RestitutionActs.act1_framing`. Tested in `TestConsumedByRenderer`.

## Design decisions (anti-pendule — single source of truth)

- **Genre derivation prefers `discursive_arena` over `rhetorical_register`**: taxonomy `common_contexts` encode *domains* (politique, marketing, scientifique…), not Aristotelian registers (délibératif, polémique) — a register alone never narrows the spectrum. The register is still surfaced separately in the framing (`evidence.rhetorical_register`), no signal lost.
- **Taxonomy loaded file-disjoint** from the SK `plugin_framework` (heavy JVM deps) → restitution package stays dependency-free; loader fails-loud (empty → spectrum indisponible).

## Privacy HARD

Opaque IDs only (`Speaker_A`, `era_A`, `State_Q`); prompt carries the `OPAQUE_ID_DIRECTIVE` (FB-34); corpus-derived fields (stakes/stakeholders) truncated before entering the prompt; **argument text is never surfaced** (only the count). Taxonomy families are constants (safe to surface).

## Files changed (8)

| File | Change |
|------|--------|
| `reporting/restitution/act1_framing_plugin.py` | **NEW** — evidence + prompt + weave + orchestrator (569 LOC) |
| `tests/.../test_act1_framing_plugin.py` | **NEW** — 24 tests |
| `core/shared_state.py` | +`act1_framing: str` field |
| `orchestration/invoke_callables.py` | +`_invoke_act1_framing` (mypy-strict clean) |
| `orchestration/state_writers.py` | +`_write_act1_framing_to_state` + dict entry |
| `orchestration/registry_setup.py` | +`act1_framing_service` |
| `orchestration/workflows.py` | +`act1_framing` phase (depends_on extract+stakes) |
| `tests/.../test_spectacular_workflow_dag.py` | 28→30 phases (see below) |

All production code is **append-only** (1103 insertions, 2 deletions = the DAG count assertion).

## Test realignment (fixes R3 staleness)

`test_spectacular_workflow_dag.py` asserted 28 phases. R3 (#1147) added `act2_narrative` to the spectacular DAG **without bumping the count** — the test was already stale on `main`. This PR adds `act1_framing` and realigns the assertion to the real DAG: **30 phases** (28 base + `act1_framing` + `act2_narrative`).

## Validation

- `mypy --strict` on plugin + `invoke_callables.py` → **clean** (the CI gate).
- `test_act1_framing_plugin.py` → **24/24**.
- Full restitution suite → **100/100** (no R3/R6 regression).
- `test_spectacular_workflow_dag.py` → **16/16**.
- **0 LLM spend** (wiring + deterministic tests only).

Closes #1136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)