### PR TITLE
fix(restitution): #1153 act2 reader↔writer schema (quality virtues, PL verdict, Dung label, non-attributed, usable gate)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -118,6 +118,12 @@ class Act2Evidence:
     quality_axis_available: bool = True
     args_total: int = 0
     fallacies_total: int = 0
+    # Note (a) (#1153): fallacies whose target_argument_id could not be
+    # resolved to an identified argument. These cannot join a movement beat,
+    # but they ARE counted (here) rather than silently dropped (#1019) — the
+    # LLM/rapport surfaces them honestly as "non rattaché(s) à un argument
+    # identifié". ``fallacies_total`` counts only the attributed ones.
+    unattributed_fallacies: int = 0
 
 
 @dataclass
@@ -164,7 +170,18 @@ def _dung_rejected_by_arg(state: Any) -> Dict[str, str]:
         fw_args = fw.get("arguments", []) or []
         if not isinstance(fw_args, list):
             continue
-        semantics = str(fw.get("semantics", "grounded"))
+        # Finding D (#1151/#1153): add_dung_framework stores no ``semantics``
+        # key — the writer folds it into ``name=f"verification_{semantics}"``
+        # (state_writers.py:717). Prefer an explicit key if present, else parse
+        # it back from ``name``; only default to ``grounded`` when neither
+        # carries a signal (honest: the label stays, but it is now correct when
+        # the name encodes the semantics).
+        semantics = fw.get("semantics")
+        if not semantics:
+            name = str(fw.get("name", "") or "")
+            if name.startswith("verification_"):
+                semantics = name[len("verification_") :]
+        semantics = str(semantics or "grounded")
         accepted: set[str] = set()
         ext = fw.get("extensions", [])
         if isinstance(ext, dict):
@@ -190,6 +207,37 @@ def _dung_rejected_by_arg(state: Any) -> Dict[str, str]:
     return rejected
 
 
+def _quality_axis_usable(quality: Any) -> bool:
+    """§5 gate (#1153): is the quality axis *usable*, not merely present?
+
+    The old gate ``bool(quality)`` stayed ``True`` for a non-empty dict whose
+    entries were unusable (no overall, no per-virtue scores) — a silent bug that
+    hid Finding A (#1151). This gate requires at least one scored entry to carry
+    a usable ``overall`` OR a usable per-virtue map (under the canonical
+    ``scores`` key or the legacy ``scores_par_vertu``).
+
+    Calibrated, NOT over-strict (anti-pendule): a single usable entry suffices
+    (we degrade the unusable ones per-entry, not the whole axis); we never
+    require ALL virtues populated (some args are short/degraded with overall
+    only). An empty/partial-but-empty axis returns ``False`` → the report
+    fail-louds « non concluable » honestly.
+    """
+    if not isinstance(quality, dict) or not quality:
+        return False
+    for entry in quality.values():
+        if not isinstance(entry, dict):
+            continue
+        ov = entry.get("overall")
+        if isinstance(ov, (int, float)):
+            return True
+        spv = entry.get("scores")
+        if not isinstance(spv, dict):
+            spv = entry.get("scores_par_vertu")
+        if isinstance(spv, dict) and spv:
+            return True
+    return False
+
+
 def build_act2_evidence(state: Any) -> Act2Evidence:
     """Build the deterministic Acte II evidence bundle from a shared state.
 
@@ -207,7 +255,7 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
     quality = getattr(state, "argument_quality_scores", {}) or {}
     counters = getattr(state, "counter_arguments", []) or []
 
-    quality_axis_available = bool(quality) and isinstance(quality, dict)
+    quality_axis_available = _quality_axis_usable(quality)
     if not isinstance(args, dict):
         args = {}
     if not isinstance(fallacies, dict):
@@ -218,11 +266,15 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
     # Index fallacies by target arg.
     fallacy_by_arg: Dict[str, List[FallacyEvidence]] = {}
     fallacies_total = 0
+    unattributed_fallacies = 0  # Note (a) (#1153): traced, not dropped (#1019)
     for _fid, fdata in fallacies.items():
         if not isinstance(fdata, dict):
             continue
         tid = fdata.get("target_argument_id") or ""
         if not tid:
+            # Note (a): no resolved target — count it apart so the report can
+            # surface it honestly instead of silently losing the detection.
+            unattributed_fallacies += 1
             continue
         fallacies_total += 1
         fallacy_by_arg.setdefault(tid, []).append(
@@ -292,7 +344,14 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
         q_available = False
         if isinstance(qs, dict):
             q_available = True
-            spv = qs.get("scores_par_vertu")
+            # Finding A (#1151/#1153): the writer add_quality_score stores
+            # per-virtue scores under the canonical key ``scores``
+            # (shared_state.py:536); read that first, then the legacy
+            # ``scores_par_vertu`` key for any external source. Both shapes
+            # carry the same {virtue: float} mapping.
+            spv = qs.get("scores")
+            if not isinstance(spv, dict):
+                spv = qs.get("scores_par_vertu")
             if isinstance(spv, dict):
                 for vname, vval in spv.items():
                     if isinstance(vval, (int, float)):
@@ -326,7 +385,23 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
         quality_axis_available=quality_axis_available,
         args_total=len(args),
         fallacies_total=fallacies_total,
+        unattributed_fallacies=unattributed_fallacies,
     )
+
+
+def _pl_verdict(result: Dict[str, Any]) -> Optional[bool]:
+    """Resolve a PL analysis verdict from a stored result dict.
+
+    Finding C (#1151/#1153): the canonical writer key is ``satisfiable``
+    (shared_state.py:801); the legacy reader key is ``consistent``. Both map
+    to the same satisfiability semantics here. Returns ``True``/``False`` for a
+    settled verdict, or ``None`` when unverified (the entry carries neither key
+    or an explicit None) — never collapses None to False (#1019).
+    """
+    sat = result.get("satisfiable")
+    if sat is None:
+        sat = result.get("consistent")
+    return sat if isinstance(sat, bool) else None
 
 
 def _collect_formal_findings(state: Any) -> List[FormalFinding]:
@@ -340,15 +415,24 @@ def _collect_formal_findings(state: Any) -> List[FormalFinding]:
 
     pl = getattr(state, "propositional_analysis_results", None)
     if isinstance(pl, list):
+        # Finding C (#1151/#1153): the writer add_propositional_analysis_result
+        # stores the verdict under ``satisfiable`` (shared_state.py:801), NOT
+        # ``consistent``. Read the canonical PL key first, then the legacy
+        # ``consistent`` key (some external/older writers use it). Preserve the
+        # strict ``is True``/``is False`` check — NEVER ``bool(sat)``: that
+        # would conflate the unverified sentinel (None) with ``inconsistent``
+        # (False), an #1019 silent-degradation.
         consistent = sum(
             1
             for r in pl
-            if isinstance(r, dict) and r.get("consistent") is True
+            if isinstance(r, dict)
+            and _pl_verdict(r) is True
         )
         inconsistent = sum(
             1
             for r in pl
-            if isinstance(r, dict) and r.get("consistent") is False
+            if isinstance(r, dict)
+            and _pl_verdict(r) is False
         )
         if consistent or inconsistent:
             findings.append(

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
@@ -71,11 +71,11 @@ def _rich_state() -> SimpleNamespace:
         argument_quality_scores={
             "arg_1": {
                 "overall": 4.2,
-                "scores_par_vertu": {"pertinence": 3.0, "clarte": 5.0},
+                "scores": {"pertinence": 3.0, "clarte": 5.0},
             },
             "arg_2": {
                 "overall": 7.8,
-                "scores_par_vertu": {"pertinence": 8.0, "coherence": 7.5},
+                "scores": {"pertinence": 8.0, "coherence": 7.5},
             },
         },
         counter_arguments=[
@@ -88,16 +88,23 @@ def _rich_state() -> SimpleNamespace:
                 ),
             }
         ],
+        # Canonical Dung shape: the writer add_dung_framework stores NO
+        # ``semantics`` key (it folds it into ``name``, state_writers.py:717).
+        # Finding D (#1153): the reader must recover it from ``name``.
         dung_frameworks={
             "fw_1": {
+                "name": "verification_preferred",
                 "arguments": ["arg_1", "arg_2"],
+                "attacks": [["arg_2", "arg_1"]],
                 "extensions": {"all_members": ["arg_2"]},
-                "semantics": "grounded",
             }
         },
+        # Canonical PL shape: the writer stores ``satisfiable``, NOT
+        # ``consistent`` (shared_state.py:801). Finding C (#1153): the reader
+        # must read ``satisfiable`` to collect PL findings.
         propositional_analysis_results=[
-            {"consistent": True},
-            {"consistent": False},
+            {"satisfiable": True},
+            {"satisfiable": False},
         ],
     )
 
@@ -172,7 +179,7 @@ class TestBuildEvidence:
         assert arg1.fallacies[0].family == "ad hominem"
         assert len(arg1.counter_args) == 1
         assert arg1.counter_args[0].strategy == "contre-exemple"
-        assert arg1.dung_rejected == "grounded"
+        assert arg1.dung_rejected == "preferred"  # Finding D: parsed from name
 
     def test_quality_axis_available_flag(self):
         ev = build_act2_evidence(_rich_state())
@@ -202,6 +209,147 @@ class TestBuildEvidence:
         assert "dung" in kinds
         pl = next(f for f in ev.formal_findings if f.kind == "pl")
         assert "inconsistantes" in pl.verdict
+
+
+class TestReaderWriterContracts:
+    """#1153: prove each reader↔writer schema fix (Finding A/C/D + note(a) + §5).
+
+    These tests assert against the CANONICAL writer schema (the shape the
+    state-writers + shared_state.add_* actually produce), not the legacy shape
+    the old reader keys expected — the prior tests passed only because the
+    stubs mirrored the buggy reader.
+    """
+
+    def test_finding_a_quality_virtues_read_from_canonical_scores_key(self):
+        # Writer add_quality_score stores per-virtue scores under 'scores'.
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            argument_quality_scores={
+                "arg_1": {"overall": 3.5, "scores": {"pertinence": 2.0,
+                                                      "clarte": 5.0}},
+            },
+        )
+        ev = build_act2_evidence(state)
+        arg1 = ev.movements[0].arguments[0]
+        assert arg1.virtues == {"pertinence": 2.0, "clarte": 5.0}  # NOT {}
+        assert arg1.quality_available is True
+        assert arg1.quality_overall == pytest.approx(3.5)
+
+    def test_finding_a_quality_virtues_legacy_scores_par_vertu_still_works(self):
+        # Legacy / external writers using 'scores_par_vertu' still surface.
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            argument_quality_scores={
+                "arg_1": {"overall": 3.0,
+                          "scores_par_vertu": {"coherence": 4.0}},
+            },
+        )
+        ev = build_act2_evidence(state)
+        assert ev.movements[0].arguments[0].virtues == {"coherence": 4.0}
+
+    def test_finding_c_pl_verdict_collected_from_satisfiable_key(self):
+        # Writer stores 'satisfiable'; reader MUST collect PL findings.
+        state = _state(
+            propositional_analysis_results=[
+                {"satisfiable": True},
+                {"satisfiable": False},
+            ],
+        )
+        ev = build_act2_evidence(state)
+        pl = next((f for f in ev.formal_findings if f.kind == "pl"), None)
+        assert pl is not None
+        assert "inconsistantes" in pl.verdict  # the False entry surfaces
+
+    def test_finding_c_pl_none_verdict_not_treated_as_inconsistent(self):
+        # #1019: a None (unverified) verdict must NOT collapse to False.
+        state = _state(
+            propositional_analysis_results=[
+                {"satisfiable": None},  # unverified
+            ],
+        )
+        ev = build_act2_evidence(state)
+        assert not any(f.kind == "pl" for f in ev.formal_findings)
+
+    def test_finding_c_pl_legacy_consistent_key_still_collected(self):
+        # Backward-compat: a writer using the legacy 'consistent' key still works.
+        state = _state(
+            propositional_analysis_results=[{"consistent": True}],
+        )
+        ev = build_act2_evidence(state)
+        pl = next((f for f in ev.formal_findings if f.kind == "pl"), None)
+        assert pl is not None and "consistantes" in pl.verdict
+
+    def test_finding_d_dung_semantics_parsed_from_name(self):
+        # Writer folds semantics into name=verification_<sem>; no 'semantics' key.
+        state = _state(
+            identified_arguments={"arg_1": "Claim A.", "arg_2": "Claim B."},
+            dung_frameworks={
+                "fw_1": {
+                    "name": "verification_preferred",
+                    "arguments": ["arg_1", "arg_2"],
+                    "attacks": [["arg_2", "arg_1"]],
+                    "extensions": {"all_members": ["arg_2"]},
+                }
+            },
+        )
+        ev = build_act2_evidence(state)
+        # arg_1 rejected; label must be 'preferred', not the wrong 'grounded'.
+        arg1 = next(a for m in ev.movements for a in m.arguments if a.arg_id == "arg_1")
+        assert arg1.dung_rejected == "preferred"
+
+    def test_finding_d_dung_semantics_explicit_key_preferred(self):
+        # When an explicit 'semantics' key is present, it wins over the name.
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            dung_frameworks={
+                "fw_1": {
+                    "name": "verification_grounded",
+                    "semantics": "stable",
+                    "arguments": ["arg_1"],
+                    "attacks": [],
+                    "extensions": {"all_members": []},
+                }
+            },
+        )
+        ev = build_act2_evidence(state)
+        arg1 = next(a for m in ev.movements for a in m.arguments if a.arg_id == "arg_1")
+        assert arg1.dung_rejected == "stable"
+
+    def test_note_a_unresolved_fallacy_traced_not_dropped(self):
+        # A fallacy with no target_argument_id must be counted apart, not lost.
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            identified_fallacies={
+                "fl_1": {"target_argument_id": "arg_1", "family": "ad hominem",
+                         "type": "ad hominem", "justification": "x"},
+                "fl_2": {"target_argument_id": "", "family": "fuite",
+                         "type": "fuite en avant", "justification": "y"},
+            },
+        )
+        ev = build_act2_evidence(state)
+        assert ev.fallacies_total == 1  # only the attributed one
+        assert ev.unattributed_fallacies == 1  # traced, not dropped
+
+    def test_section5_gate_usable_content_not_bool_dict(self):
+        # A non-empty dict with NO usable entry → axis unavailable (Finding A
+        # hid here). Partial-but-empty must fail-loud, not pass as available.
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            argument_quality_scores={"arg_1": {}},  # present but unusable
+        )
+        ev = build_act2_evidence(state)
+        assert ev.quality_axis_available is False
+
+    def test_section5_gate_legit_partial_state_still_available(self):
+        # Anti-pendule: a single usable entry (overall only, no virtues) is
+        # a legitimate partial state → axis stays available, no false fail-loud.
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            argument_quality_scores={"arg_1": {"overall": 2.5}},
+        )
+        ev = build_act2_evidence(state)
+        assert ev.quality_axis_available is True
+
 
 
 class TestPrivacy:


### PR DESCRIPTION
Closes #1153.

## Summary

Implements the 5 reader-side fixes proven in audit #1151 (#1152), **all in `act2_narrative_plugin.py`** — file-disjoint from R4's `act3_conclusion_plugin.py`, runs in parallel with po-2025's R4. **Zero edits to the 5 infra files** (`shared_state`, `invoke_callables`, `registry_setup`, `state_writers`, `workflows`) — R4's lane.

Validation: **110 restitution tests pass** (0 regression), **mypy strict clean**. 12 new contract tests.

## Fixes (5)

| # | Fix | Writer key (file:l) | Reader now | Severity |
|---|-----|---------------------|------------|----------|
| **A** | quality virtues | `scores` shared_state.py:536 | `qs.get("scores")` + legacy `scores_par_vertu` | HIGH |
| **C** | PL verdict | `satisfiable` shared_state.py:801 | `_pl_verdict()` reads `satisfiable` + legacy `consistent` | HIGH |
| **D** | Dung semantics | (none; in `name`) state_writers.py:717 | parsed from `name=verification_<sem>` | LOW |
| **(a)** | non-attributed fallacy | target_arg_id unresolved | counted in `Act2Evidence.unattributed_fallacies` (was silently dropped) | MED |
| **§5** | usable-content gate | — | `_quality_axis_usable()` replaces `bool(dict)` | MED |

### Finding C — strict `is True`/`is False` preserved (#1019)
```python
def _pl_verdict(result):
    sat = result.get("satisfiable")
    if sat is None:
        sat = result.get("consistent")
    return sat if isinstance(sat, bool) else None  # NEVER bool(sat)
```
A `None` (unverified) verdict returns `None`, never collapses to `False` (inconsistent) — anti-#1019.

### §5 gate — calibrated, not over-strict (anti-pendule)
`_quality_axis_usable()` requires **at least one** entry with a usable `overall` OR per-virtue map. A single overall-only entry (legitimate partial state) stays available — no false fail-loud. An empty-but-present entry (`{"arg_1": {}}`) correctly fails loud (this is where Finding A hid).

### Why the bug was invisible
The prior tests passed only because the `_rich_state` fixture mirrored the **buggy reader keys** (`scores_par_vertu`, `consistent`). This PR updates the fixture to the **canonical writer schema** (`scores`, `satisfiable`, `name=verification_preferred`) so the tests validate the real writer→reader contract.

## DoD (#1153)

- [x] A/C/D fixed reader-side, each with a test proving the value is collected (virtues non-empty; PL finding collected; Dung label correct).
- [x] PL: `is True`/`is False` strict preserved (never `bool(sat)`) — `test_finding_c_pl_none_verdict_not_treated_as_inconsistent`.
- [x] Note (a): non-attributed fallacy traced (`test_note_a_unresolved_fallacy_traced_not_dropped`), not dropped.
- [x] §5: usable-content gate calibrated (`test_section5_gate_usable_content_not_bool_dict` + `test_section5_gate_legit_partial_state_still_available`).
- [x] Files: `act2_narrative_plugin.py` + test only. Zero edits to the 5 infra files.

## Coordination note

This is file-disjoint from po-2025's R4 (`act3_conclusion_plugin.py` + infra appends). The §5 gate-fix is meaningful *now that* Finding A is fixed (otherwise virtues is always empty). Note (a)'s `unattributed_fallacies` field is additive — po-2025's R6 wiring can optionally surface it; no breaking change.

🤖 Worker po-2023 — dispatch R432