### PR TITLE
feat(restitution): R4 #1138 — Acte III actionable conclusion by gated verdict

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -445,6 +445,14 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         # the R6 renderer to populate RestitutionActs.act1_framing. Empty until
         # the act1_framing phase runs; the renderer reports the gap honestly.
         self.act1_framing: str = ""
+        # Restitution Acte III — actionable conclusion: gated verdict + balanced
+        # appréciations + que-faire (contrer / points faibles à viser / what-next
+        # game-theoretic). Epic #1134 / R4 #1138. LLM-conducted, gated on G1–G4
+        # (#1008 §3) + the verdict band (coverage-adapted from #1008 §2).
+        # Consumed by the R6 renderer to populate RestitutionActs.act3_conclusion.
+        # Empty until the act3_conclusion phase runs; the renderer reports the gap
+        # honestly.
+        self.act3_conclusion: str = ""
         # PP #715: source-level metadata for qualitative synthesis
         self.source_metadata: Dict[str, str] = {}
         # PL 2-pass pipeline: shared atom inventory (#547)

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -6062,6 +6062,108 @@ async def _invoke_act1_framing(
     }
 
 
+async def _invoke_act3_conclusion(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Invoke the Acte III conclusion generator (Epic #1134 / R4 #1138).
+
+    Builds the deterministic conclusion evidence (gated verdict band + balanced
+    appréciations + actionable que-faire: counters / structuring weak points /
+    game-theoretic what-next), then conducts it via the LLM (fail-loud, no
+    template — #1108/#405). Gated on G1–G4 (#1008 §3). The result populates
+    ``state.act3_conclusion``, the key the R6 renderer consumes for
+    ``RestitutionActs.act3_conclusion``.
+
+    Mirrors ``_invoke_act2_narrative`` / ``_invoke_act1_framing``: the LLM is
+    resolved into an async callable from a kernel + default service (FB-32
+    idiom). Absent service → fail-loud unavailable (anti-pendule #1019/#369).
+    """
+    from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+        Act3Result,
+        build_act3_conclusion,
+    )
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+    from argumentation_analysis.orchestration.state_writers import (
+        CAPABILITY_STATE_WRITERS,
+    )
+
+    state = context.get("_state_object") or context.get("unified_state")
+    if not isinstance(state, UnifiedAnalysisState):
+        state = UnifiedAnalysisState(input_text[:200])
+        populated = 0
+        for key, value in context.items():
+            if key.startswith("phase_") and key.endswith("_output"):
+                cap = key[len("phase_") : -len("_output")]
+                writer = CAPABILITY_STATE_WRITERS.get(cap)
+                if writer and isinstance(value, dict):
+                    try:
+                        writer(value, state, context)
+                        populated += 1
+                    except Exception:
+                        logger.warning(
+                            "State writer for '%s' failed during Acte III "
+                            "reconstruction",
+                            cap,
+                            exc_info=True,
+                        )
+        logger.info(
+            "Acte III: no UnifiedAnalysisState in context, reconstructed from "
+            "%d phase outputs",
+            populated,
+        )
+
+    llm_service_id: Optional[str] = None
+    kernel: Any = None
+    try:
+        from semantic_kernel import Kernel
+
+        kernel = Kernel()
+        try:
+            from argumentation_analysis.core.llm_service import create_llm_service
+
+            llm = create_llm_service(service_id="default")
+            if llm:
+                kernel.add_service(llm)
+                llm_service_id = "default"
+        except Exception:
+            llm_service_id = None
+    except Exception:
+        llm_service_id = None
+
+    async def _llm(prompt: str) -> str:
+        if not llm_service_id or kernel is None:
+            return ""
+        settings = kernel.get_prompt_execution_settings_from_service_id(
+            llm_service_id
+        )
+        result = await kernel.invoke_prompt(
+            function_name="act3_conclusion_conducted",
+            plugin_name="restitution",
+            prompt=prompt,
+            settings=settings,
+        )
+        return str(result) if result else ""
+
+    result: Act3Result = await build_act3_conclusion(
+        state, llm_callable=_llm if llm_service_id else None
+    )
+
+    gate_band = result.gate_verdict.band if result.gate_verdict is not None else None
+    if result.status != "woven":
+        logger.warning(
+            "Acte III conclusion status=%s (fail-loud). llm_service_id=%s.",
+            result.status,
+            llm_service_id,
+        )
+
+    return {
+        "act3_conclusion": result.narrative,
+        "status": result.status,
+        "gate_band": gate_band,
+        "degraded": result.degraded,
+    }
+
+
 def _count_referenced_fields(state: Any) -> int:
     """Count how many state fields have data (used as references in narrative)."""
     count = 0

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -59,6 +59,7 @@ from argumentation_analysis.orchestration.invoke_callables import (
     _invoke_narrative_synthesis,
     _invoke_act2_narrative,
     _invoke_act1_framing,
+    _invoke_act3_conclusion,
     _invoke_external_fol_solver,
     _invoke_external_modal_solver,
     _invoke_deep_synthesis,
@@ -587,6 +588,26 @@ def setup_registry(
         registered.append("act1_framing_service")
     except Exception as e:
         skipped.append(("act1_framing_service", str(e)))
+
+    # --- Acte III actionable conclusion service (#1138, Epic #1134) ---
+    try:
+        registry.register_service(
+            name="act3_conclusion_service",
+            service_class=type("act3_conclusion_service", (), {}),
+            capabilities=["act3_conclusion"],
+            metadata={
+                "description": (
+                    "Generate the Acte III actionable conclusion — gated verdict "
+                    "(G1-G4, band-adapted from #1008 §2), balanced appréciations, "
+                    "and que-faire (contrer / weak points / game-theoretic "
+                    "what-next). LLM-conducted, fail-loud. Consumed by R6."
+                )
+            },
+            invoke=_invoke_act3_conclusion,
+        )
+        registered.append("act3_conclusion_service")
+    except Exception as e:
+        skipped.append(("act3_conclusion_service", str(e)))
 
     # --- External solver routing services (#504) ---
     for name, caps, desc, invoke_fn in [

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -936,6 +936,23 @@ def _write_act1_framing_to_state(
         state.act1_framing = narrative
 
 
+def _write_act3_conclusion_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
+    """Write the Acte III actionable conclusion to UnifiedAnalysisState (#1138).
+
+    Populates ``state.act3_conclusion`` — the key the R6 renderer consumes for
+    ``RestitutionActs.act3_conclusion``. Empty/unavailable results are left as
+    the empty default so the renderer reports the gap honestly (fail-loud,
+    #1108/#1019 — never fabricate a conclusion here).
+    """
+    if not output or not isinstance(output, dict):
+        return
+    narrative = output.get("act3_conclusion", "")
+    if isinstance(narrative, str) and narrative:
+        state.act3_conclusion = narrative
+
+
 def _write_text_to_kb_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write TextToKB extraction results to UnifiedAnalysisState (#506)."""
     if not output or not isinstance(output, dict):
@@ -1115,6 +1132,7 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "narrative_synthesis": _write_narrative_synthesis_to_state,
     "act2_narrative": _write_act2_narrative_to_state,
     "act1_framing": _write_act1_framing_to_state,
+    "act3_conclusion": _write_act3_conclusion_to_state,
     "nl_extraction": _write_text_to_kb_to_state,
     "kb_to_tweety": _write_kb_to_tweety_to_state,
     "formal_result_interpretation": _write_tweety_interpretation_to_state,

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -956,6 +956,21 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             optional=False,
             timeout_seconds=180,
         )
+        # L12 — Acte III actionable conclusion (Epic #1134 / R4 #1138). The
+        # reader's payoff: gated verdict (G1–G4, #1008 §3 + band adapted from
+        # #1008 §2), balanced appréciations, and que-faire (contrer / weak
+        # points / game-theoretic what-next). LLM-conducted + fail-loud (no
+        # template — #1108/#405). Depends on act2_narrative so the conclusion
+        # closes the narrative (framing → récit → conclusion), making it the
+        # spectacular terminal phase. Robust: returns empty + status when the LLM
+        # is unavailable (never raises) — the renderer reports the gap honestly.
+        .add_phase(
+            "act3_conclusion",
+            capability="act3_conclusion",
+            depends_on=["act2_narrative"],
+            optional=False,
+            timeout_seconds=180,
+        )
         .build()
     )
 

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -1,0 +1,780 @@
+"""Acte III generator — actionable conclusion (the reader's payoff).
+
+Epic #1134 (Restitution) / Track R4 #1138. LLM-conducted, woven per spec §4.
+Consumed by the R6 renderer to populate ``RestitutionActs.act3_conclusion``.
+
+Design (spec §1.3 + §3 + §4 + §7, issue #1138, dispatch coord R428/R429):
+  - The conclusion hands back something *usable*. Three beats:
+    1. **Synthèse honnête** — the verdict, **gated** on the non-triviality gates
+       G1–G4 (#1008 §3) and on the verdict band (computed here, adapted from
+       #1008 §2 — see ``_compute_verdict_band``). No over-claim.
+    2. **Appréciations** — strengths **and** weaknesses of the discourse (both,
+       honestly, woven from the quality axis and the fallacy/formal findings).
+    3. **Que faire de l'analyse** — actionable: how to **counter** the arguments
+       (the generated counter-arguments), the **weak points to target** (the
+       structuring fallacies + the inferences Tweety invalidates + the attacks
+       Dung isolates as defeated), and **what to expect next** (the probable
+       follow-on moves — closing the loop on the Acte I game-theoretic framing).
+  - Every framework citation gets a narrative anchor (passes the §4 gate — this
+    module self-checks its own output with ``ReadabilityGate``).
+  - **LLM-conducted**: the conclusion VARIES by corpus (no template #1108/#405).
+    Fail-loud when no LLM is injected — empty string + explicit status; the
+    renderer reports the gap honestly (anti-pendule #1019/#369).
+
+Verdict band — honest adaptation of #1008 §2 to the restitution context:
+  #1008 §2.1 frames the bands as "pipeline vs external analyst" (MATCH+ count
+  over 10 yardstick dimensions). The restitution report has *no external
+  analyst to compare against* (spec §3: "what this discourse is, honestly").
+  We therefore compute the band from the **real analytical coverage** of the
+  run — how many analytical axes produced non-trivial content — so the band
+  governs *how strongly the discourse may be characterised*, never a fabricated
+  comparison. This is the scorer the spec §2 table attributes to
+  ``_compute_verdict()`` ("computed, not a state key").
+
+Privacy HARD: opaque IDs only (``arg_N``, fallacy families are taxonomy
+constants). The prompt carries the OPAQUE_ID_DIRECTIVE (FB-34). Corpus-derived
+fields (fallacy justifications, counter-content, synthesis snippets) are
+**truncated** before entering the prompt; the LLM is told to paraphrase, never
+echo verbatim — the final R6 scrub (spec §6) is the downstream guard.
+
+Testability: ``build_act3_evidence`` is deterministic (no LLM/JVM/API); the LLM
+is an injectable async callable ``Callable[[str], Awaitable[str]]`` (FB-29/38
+injectable-LLM pattern), so unit tests pass a stub and need no kernel.
+
+Mirrors the R3 act-plugin pattern (``act2_narrative_plugin``) — same 3 infra
+files, append-only.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from .readability_gate import GateVerdict, ReadabilityGate
+
+logger = logging.getLogger(__name__)
+
+# An async LLM callable: prompt in, completion text out (FB-29/38 injectable).
+LlmCallable = Callable[[str], Awaitable[str]]
+
+# Truncation caps for corpus-derived fields entering the prompt (privacy +
+# prompt-budget discipline). The LLM is told to paraphrase, not echo.
+_JUSTIFICATION_CAP = 200
+_COUNTER_CAP = 200
+_SYNTHESIS_CAP = 400
+
+# Verdict bands (adapted from #1008 §2.1 to the restitution coverage model).
+_BAND_EXCEEDED = "EXCEEDED"
+_BAND_MATCH = "MATCH"
+_BAND_PARTIAL = "PARTIAL"
+_BAND_BELOW = "BELOW"
+
+# The analytical axes whose non-trivial coverage earns the verdict band. Each is
+# real-in-state; we never fabricate an axis (G4).
+_AXIS_FALLACIES = "fallacies"
+_AXIS_QUALITY = "quality"
+_AXIS_COUNTERS = "counter_arguments"
+_AXIS_FORMAL_PL = "formal_pl"
+_AXIS_FORMAL_FOL = "formal_fol"
+_AXIS_DUNG = "dung"
+
+# Thresholds mapping coverage count → band (anti-pendule: transparent, fixed).
+# EXCEEDED needs formal depth (PL or FOL) AND quality (a characterised discourse)
+# on top of broad coverage — the "depth surpassing" spirit of #1008 §2.1.
+_EXCEEDED_MIN_AXES = 5
+_MATCH_MIN_AXES = 4
+_PARTIAL_MIN_AXES = 2
+
+
+# --- evidence dataclasses ----------------------------------------------------
+
+
+@dataclass
+class StructuringWeakPoint:
+    """A weak point the reader can target — a fallacy or a formal rejection.
+
+    ``source`` is one of ``"fallacy"`` / ``"pl"`` / ``"fol"`` / ``"dung"`` so the
+    LLM can anchor the citation to the framework that produced it (spec §4).
+    """
+
+    source: str
+    label: str  # human-readable: fallacy family/type, or a formal verdict line
+    target_arg_id: str
+    detail: str = ""
+
+
+@dataclass
+class CounterStrategy:
+    """A counter-argument the reader can use to push back."""
+
+    strategy: str
+    target_arg_id: str
+    snippet: str
+
+
+@dataclass
+class QualityStrength:
+    """A virtue where the discourse scores well (a strength to acknowledge)."""
+
+    virtue: str
+    score: float
+
+
+@dataclass
+class VerdictBand:
+    """The computed verdict band + the honest coverage that earned it.
+
+    Adapted from #1008 §2.1 to the restitution coverage model (no external
+    analyst): the band governs how strongly the discourse may be characterised.
+    """
+
+    band: str
+    nontrivial_axes: List[str] = field(default_factory=list)
+    missing_axes: List[str] = field(default_factory=list)
+    axes_count: int = 0
+
+
+@dataclass
+class Act3Evidence:
+    """Deterministic evidence bundle for the Acte III conclusion.
+
+    ``gates`` carries the G1–G4 statuses (#1008 §3.2) so the orchestrator can
+    emit the honest fallback wording when the conclusion must not render.
+    """
+
+    args_total: int = 0
+    fallacies_total: int = 0
+    counters_total: int = 0
+    quality_axis_available: bool = False
+    quality_strengths: List[QualityStrength] = field(default_factory=list)
+    weak_points: List[StructuringWeakPoint] = field(default_factory=list)
+    counter_strategies: List[CounterStrategy] = field(default_factory=list)
+    verdict: Optional[VerdictBand] = None
+    narrative_synthesis_available: bool = False
+    gates: Dict[str, bool] = field(default_factory=dict)
+
+
+@dataclass
+class Act3Result:
+    """Outcome of :func:`build_act3_conclusion`.
+
+    ``status`` is one of ``"woven"`` (LLM produced a conclusion), ``"unavailable"``
+    (no LLM injected or LLM failed — fail-loud, #1108), ``"empty_state"`` (G1
+    failed — no substrate), ``"gates_failed"`` (G1–G4 blocked the gated
+    synthesis — honest fallback wording). ``gate_verdict`` is the honest §4
+    self-check.
+    """
+
+    narrative: str
+    status: str
+    gate_verdict: Optional[GateVerdict] = None
+    degraded: Dict[str, str] = field(default_factory=dict)
+
+
+# --- deterministic evidence builder (no LLM) ---------------------------------
+
+
+def _truncate(text: Any, cap: int) -> str:
+    """Coerce to str and cap length (privacy + prompt budget)."""
+    if not text:
+        return ""
+    s = str(text).strip()
+    return s if len(s) <= cap else s[:cap].rstrip() + " […]"
+
+
+def _pl_inconsistent(state: Any) -> int:
+    """Count PL inferences the Tweety solver found inconsistent (real-in-state)."""
+    pl = getattr(state, "propositional_analysis_results", None)
+    if not isinstance(pl, list):
+        return 0
+    return sum(
+        1
+        for r in pl
+        if isinstance(r, dict) and r.get("consistent") is False
+    )
+
+
+def _fol_inconsistent(state: Any) -> int:
+    """Count FOL theories the Tweety solver found inconsistent (real-in-state)."""
+    fol = getattr(state, "fol_analysis_results", None)
+    if not isinstance(fol, list):
+        return 0
+    return sum(
+        1
+        for r in fol
+        if isinstance(r, dict) and r.get("consistent") is False
+    )
+
+
+def _dung_rejected_by_arg(state: Any) -> Dict[str, str]:
+    """Map arg_id → Dung semantics label for arguments a framework rejected.
+
+    A rejected argument is present in a framework's arguments but absent from
+    its accepted extension — the attack isolates it as defeated. Mirrors the
+    resolution in ``act2_narrative_plugin._dung_rejected_by_arg`` (kept local
+    here for file-disjointness — R4 establishes its own copy, same logic).
+    """
+    rejected: Dict[str, str] = {}
+    frameworks = getattr(state, "dung_frameworks", {}) or {}
+    if not isinstance(frameworks, dict):
+        return rejected
+    for _fid, fw in frameworks.items():
+        if not isinstance(fw, dict):
+            continue
+        fw_args = fw.get("arguments", []) or []
+        if not isinstance(fw_args, list):
+            continue
+        semantics = str(fw.get("semantics", "grounded"))
+        accepted: set[str] = set()
+        ext = fw.get("extensions", [])
+        if isinstance(ext, dict):
+            if "all_members" in ext:
+                accepted = set(ext.get("all_members", []) or [])
+            else:
+                for val in ext.values():
+                    if isinstance(val, list):
+                        for item in val:
+                            if isinstance(item, list):
+                                accepted.update(item)
+                            elif isinstance(item, str):
+                                accepted.add(item)
+        elif isinstance(ext, list):
+            for item in ext:
+                if isinstance(item, list):
+                    accepted.update(item)
+                elif isinstance(item, str):
+                    accepted.add(item)
+        for arg in fw_args:
+            if isinstance(arg, str) and arg not in accepted:
+                rejected.setdefault(arg, semantics)
+    return rejected
+
+
+def _collect_weak_points(
+    fallacies: Dict[str, Any],
+    dung_rejected: Dict[str, str],
+    pl_inc: int,
+    fol_inc: int,
+) -> List[StructuringWeakPoint]:
+    """Collect the structuring weak points the reader can target (real-in-state).
+
+    Each weak point is bound to (a) a located argument and (b) the concrete
+    verdict that flagged it — the spec §4 weaving anchors. We surface the
+    fallacies that *target* an argument, plus the formal rejections. Never
+    fabricate a weak point (G4, anti-pendule #1019/#369).
+    """
+    points: List[StructuringWeakPoint] = []
+    for _fid, fdata in fallacies.items():
+        if not isinstance(fdata, dict):
+            continue
+        tid = fdata.get("target_argument_id") or ""
+        if not tid:
+            continue
+        family = str(fdata.get("family", "inconnu"))
+        ftype = str(fdata.get("type", "inconnu"))
+        points.append(
+            StructuringWeakPoint(
+                source="fallacy",
+                label=f"{ftype} (famille {family})",
+                target_arg_id=str(tid),
+                detail=_truncate(fdata.get("justification", ""), _JUSTIFICATION_CAP),
+            )
+        )
+    for arg_id, semantics in dung_rejected.items():
+        points.append(
+            StructuringWeakPoint(
+                source="dung",
+                label=f"argument rejeté par le cadre de Dung (sémantique {semantics})",
+                target_arg_id=str(arg_id),
+            )
+        )
+    if pl_inc:
+        points.append(
+            StructuringWeakPoint(
+                source="pl",
+                label=f"{pl_inc} inférence(s) propositionnelle(s) inconsistantes (solveur Tweety)",
+                target_arg_id="—",
+            )
+        )
+    if fol_inc:
+        points.append(
+            StructuringWeakPoint(
+                source="fol",
+                label=f"{fol_inc} théorie(s) du premier ordre inconsistantes (solveur Tweety)",
+                target_arg_id="—",
+            )
+        )
+    return points
+
+
+def _collect_quality_strengths(quality: Dict[str, Any]) -> List[QualityStrength]:
+    """Surface the virtues where the discourse scores well (honest strengths).
+
+    A strength is a virtue with a non-zero score on at least one argument.
+    Aggregated as the max across arguments (the discourse's best tenue on that
+    virtue) — surfaced so the LLM can acknowledge what holds, not only what
+    breaks (the balanced "appréciations" beat, spec §1.3).
+    """
+    best: Dict[str, float] = {}
+    for _arg, qs in quality.items():
+        if not isinstance(qs, dict):
+            continue
+        spv = qs.get("scores_par_vertu")
+        if not isinstance(spv, dict):
+            continue
+        for vname, vval in spv.items():
+            if isinstance(vval, (int, float)) and vval > 0:
+                best[str(vname)] = max(best.get(str(vname), 0.0), float(vval))
+    return [
+        QualityStrength(virtue=k, score=v)
+        for k, v in sorted(best.items(), key=lambda kv: kv[1], reverse=True)
+    ]
+
+
+def _compute_verdict_band(
+    axes_nontrivial: List[str],
+) -> VerdictBand:
+    """Compute the verdict band from the real analytical coverage.
+
+    Honest adaptation of #1008 §2.1: the restitution report has no external
+    analyst to compare against, so the band governs *how strongly the discourse
+    may be characterised* based on how many analytical axes produced non-trivial
+    content. The thresholds are transparent and fixed (anti-pendule: no curve).
+
+    EXCEEDED needs formal depth (PL or FOL) AND the quality axis (a
+    characterised discourse) on top of broad coverage — the "depth surpassing"
+    spirit of #1008 §2.1, read as analytical depth rather than comparison.
+    """
+    all_axes = [
+        _AXIS_FALLACIES,
+        _AXIS_QUALITY,
+        _AXIS_COUNTERS,
+        _AXIS_FORMAL_PL,
+        _AXIS_FORMAL_FOL,
+        _AXIS_DUNG,
+    ]
+    present = set(axes_nontrivial)
+    missing = [a for a in all_axes if a not in present]
+    n = len(axes_nontrivial)
+    has_formal_depth = _AXIS_FORMAL_PL in present or _AXIS_FORMAL_FOL in present
+    has_quality = _AXIS_QUALITY in present
+
+    if n >= _EXCEEDED_MIN_AXES and has_formal_depth and has_quality:
+        band = _BAND_EXCEEDED
+    elif n >= _MATCH_MIN_AXES:
+        band = _BAND_MATCH
+    elif n >= _PARTIAL_MIN_AXES:
+        band = _BAND_PARTIAL
+    else:
+        band = _BAND_BELOW
+
+    return VerdictBand(
+        band=band,
+        nontrivial_axes=list(axes_nontrivial),
+        missing_axes=missing,
+        axes_count=n,
+    )
+
+
+def build_act3_evidence(state: Any) -> Act3Evidence:
+    """Build the deterministic Acte III evidence bundle from a shared state.
+
+    No LLM, no JVM — pure state extraction. Privacy: corpus-derived fields are
+    truncated; IDs stay opaque. The verdict band and the G1–G4 gate statuses are
+    computed here (deterministic) so the orchestrator can gate the synthesis
+    honestly.
+    """
+    args = getattr(state, "identified_arguments", {}) or {}
+    fallacies = getattr(state, "identified_fallacies", {}) or {}
+    quality = getattr(state, "argument_quality_scores", {}) or {}
+    counters = getattr(state, "counter_arguments", []) or []
+
+    if not isinstance(args, dict):
+        args = {}
+    if not isinstance(fallacies, dict):
+        fallacies = {}
+    if not isinstance(quality, dict):
+        quality = {}
+    if not isinstance(counters, list):
+        counters = []
+
+    args_total = len(args)
+    fallacies_total = sum(1 for _f, d in fallacies.items() if isinstance(d, dict) and (d.get("target_argument_id") or ""))
+    quality_axis_available = bool(quality)
+    counters_total = sum(1 for c in counters if isinstance(c, dict) and (c.get("target_arg_id") or c.get("counter_content")))
+    pl_inc = _pl_inconsistent(state)
+    fol_inc = _fol_inconsistent(state)
+    dung_rejected = _dung_rejected_by_arg(state)
+
+    # Non-trivial axes (real-in-state content), in a stable display order.
+    axes_nontrivial: List[str] = []
+    if fallacies_total:
+        axes_nontrivial.append(_AXIS_FALLACIES)
+    if quality_axis_available:
+        axes_nontrivial.append(_AXIS_QUALITY)
+    if counters_total:
+        axes_nontrivial.append(_AXIS_COUNTERS)
+    if pl_inc:
+        axes_nontrivial.append(_AXIS_FORMAL_PL)
+    if fol_inc:
+        axes_nontrivial.append(_AXIS_FORMAL_FOL)
+    if dung_rejected:
+        axes_nontrivial.append(_AXIS_DUNG)
+
+    weak_points = _collect_weak_points(fallacies, dung_rejected, pl_inc, fol_inc)
+    counter_strategies: List[CounterStrategy] = []
+    for ca in counters:
+        if not isinstance(ca, dict):
+            continue
+        tid = ca.get("target_arg_id") or ""
+        content = ca.get("counter_content") or ""
+        if not (tid or content):
+            continue
+        counter_strategies.append(
+            CounterStrategy(
+                strategy=str(ca.get("strategy", "")),
+                target_arg_id=str(tid),
+                snippet=_truncate(content, _COUNTER_CAP),
+            )
+        )
+
+    quality_strengths = _collect_quality_strengths(quality)
+
+    narrative_synthesis = getattr(state, "narrative_synthesis", None)
+    narrative_synthesis_available = bool(
+        narrative_synthesis and isinstance(narrative_synthesis, str) and narrative_synthesis.strip()
+    )
+
+    # G1–G4 (#1008 §3.2). G3 passes once a band is computable (always, given the
+    # deterministic scorer); G4 is structural (we only surface real-in-state
+    # fields). The orchestrator emits the honest fallback when any gate fails.
+    gates: Dict[str, bool] = {
+        "G1_arguments_extracted": args_total > 0,
+        "G2_one_dimension_nontrivial": len(axes_nontrivial) >= 1,
+        "G3_verdict_computed": True,
+        "G4_no_fabrication": True,
+    }
+
+    verdict = _compute_verdict_band(axes_nontrivial)
+
+    return Act3Evidence(
+        args_total=args_total,
+        fallacies_total=fallacies_total,
+        counters_total=counters_total,
+        quality_axis_available=quality_axis_available,
+        quality_strengths=quality_strengths,
+        weak_points=weak_points,
+        counter_strategies=counter_strategies,
+        verdict=verdict,
+        narrative_synthesis_available=narrative_synthesis_available,
+        gates=gates,
+    )
+
+
+# --- the conducted prompt (spec §4 weaving rule, no template) ----------------
+
+_OPAQUE_ID_DIRECTIVE = (
+    "DISCIPLINE D'IDENTIFIANTS OPAQUES (FB-34) — OBLIGATOIRE :\n"
+    "- Désigne chaque argument par son ID opaque (arg_1, arg_2…), JAMAIS par un\n"
+    "  nom de source, d'auteur, de lieu ou de date.\n"
+    "- Ne reproduis JAMAIS de passage verbatim du texte source : paraphrase la\n"
+    "  conclusion en une phrase qui dit quelque chose.\n"
+    "- Les familles de sophismes (ad hominem, ad verecundiam…) sont des\n"
+    "  constantes de taxonomie : tu peux les nommer comme ancrage."
+)
+
+_WEAVING_RULE = (
+    "RÈGLE DE TISSAGE (spec §4) — le contrat anti-énumération :\n"
+    "- CHAQUE citation d'un cadre (Tweety, Dung, taxonomie, vertus) DOIT être\n"
+    "  ancrée narrativement : liée à (a) un argument localisé ET (b) le verdict\n"
+    "  concret que ce cadre a produit.\n"
+    "- INTERDIT : une ligne « nom + score isolé », ex. « ad verecundiam (0.8) ».\n"
+    "  Ne produis JAMAIS de score entre parenthèses isolé comme (0.8) ou\n"
+    "  « score 0.8 ». Les vertus sont le CARACTÈRE du discours, pas un tableau\n"
+    "  de scores.\n"
+    "- INTERDIT : numéroter en « Sophisme 1: » / « Argument 2: ». Donne aux\n"
+    "  blocs des titres THÉMATIQUES en ### (ex. « Ce qui tient », « Ce qui\n"
+    "  dérape et comment le contrer », « Les coups suivants probables »).\n"
+    "- Le verdict formel appuie un battement narratif ; ce n'est jamais une\n"
+    "  sous-section isolée."
+)
+
+_FAIL_LOUD_INSTRUCTION = (
+    "HONNÊTETÉ (anti-pendule #1019/#369) :\n"
+    "- La bande de verdict ci-dessous gouverne la force de ta caractérisation.\n"
+    "  Ne formule JAMAIS un claim au-delà de ce que la bande autorise.\n"
+    "- Si un axe est manquant (liste fournie), DIS-LE explicitement (« l'axe\n"
+    "  qualité n'est pas concluable sur ce run »), ne le simule JAMAIS.\n"
+    "- Si aucun point faible n'est localisé (texte vertueux), titre sur les\n"
+    "  forces — la robustesse formelle, la tenue des schemes. Ne fabrique pas\n"
+    "  de sophisme pour remplir un bloc."
+)
+
+
+def _band_claim_ceiling(band: str) -> str:
+    """The allowed-claim ceiling per band (adapted from #1008 §2.2).
+
+    Restitution framing (#1008 absorbed, spec §3): the band governs *how
+    strongly the discourse may be characterised* — narrative, not a scorecard.
+    """
+    if band == _BAND_EXCEEDED:
+        return (
+            "Tu peux caractériser l'analyse comme APPROFONDIE et multi-axes : "
+            "elle couvre largement les dimensions (dont la profondeur formelle "
+            "vérifiée et le profil de qualité), et produit des verdicts "
+            "vérifiables qui vont au-delà d'une lecture de surface. Cite les "
+            "axes non-triviaux qui le justifient."
+        )
+    if band == _BAND_MATCH:
+        return (
+            "Tu peux caractériser l'analyse comme COMPLÈTE : elle couvre les "
+            "axes principaux du discours. Nomme les axes touchés et ceux qui "
+            "restent non-concluables, honnêtement."
+        )
+    if band == _BAND_PARTIAL:
+        return (
+            "Caractérise l'analyse comme PARTIELLE : elle touche certaines "
+            "dimensions mais en manque de clés. Diagnostic honnête : nomme ce "
+            "qui est couvert et ce qui manque (axes listés)."
+        )
+    # BELOW
+    return (
+        "Caractérise l'analyse comme MINIMALE : la couverture analytique est "
+        "réduite. Donne la liste honnête des axes non-concluables. Ne rejette "
+        "pas la responsabilité sur des facteurs externes (timeout, DLL) sans "
+        "reconnaître la responsabilité du pipeline dans la dégradation gracieuse."
+    )
+
+
+def build_act3_prompt(evidence: Act3Evidence) -> str:
+    """Build the §4-compliant LLM-conducted prompt for the Acte III conclusion.
+
+    The prompt varies with the evidence (hence with the corpus) — it is not a
+    static template (#1108/#405). It hands the LLM the gated verdict ceiling,
+    the real strengths/weaknesses, and the actionable material (counters +
+    structuring weak points), and instructs it to weave the three beats.
+    """
+    verdict = evidence.verdict
+
+    # --- Synthèse honnête (gated) ---
+    if verdict is not None:
+        axes_present = ", ".join(verdict.nontrivial_axes) or "aucun axe non-trivial"
+        axes_missing = ", ".join(verdict.missing_axes) or "aucun"
+        synthesis_block = (
+            f"Bande de verdict : {verdict.band} "
+            f"(couverture analytique : {verdict.axes_count} axe(s) non-trivial(aux) "
+            f"sur 6).\n"
+            f"  Axes touchés : {axes_present}.\n"
+            f"  Axes manquants / non-concluables : {axes_missing}.\n"
+            f"  Plafond de claim autorisé : {_band_claim_ceiling(verdict.band)}"
+        )
+    else:
+        synthesis_block = "Bande de verdict : NON CALCULABLE (gates G1–G4 non passés)."
+
+    # --- Appréciations (forces + faiblesses) ---
+    if evidence.quality_strengths:
+        strengths_lines = "\n".join(
+            f"  - {s.virtue} (meilleur score du discours : {s.score:.1f})"
+            for s in evidence.quality_strengths[:6]
+        )
+    else:
+        strengths_lines = (
+            "  (axe qualité non concluable — aucune vertu caractérisée à "
+            "acknowledger)"
+        )
+    if evidence.weak_points:
+        weaknesses_lines = "\n".join(
+            f"  - [{wp.source}] {wp.label} sur {wp.target_arg_id}"
+            + (f" : {wp.detail}" if wp.detail else "")
+            for wp in evidence.weak_points[:8]
+        )
+    else:
+        weaknesses_lines = (
+            "  (aucun point faible localisé — texte vertueux : titre sur la "
+            "robustesse formelle et la tenue des schemes)"
+        )
+
+    # --- Que faire (actionnable) ---
+    if evidence.counter_strategies:
+        counters_lines = "\n".join(
+            f"  - Pour contrer {cs.target_arg_id} ({cs.strategy}) : {cs.snippet}"
+            for cs in evidence.counter_strategies[:8]
+        )
+    else:
+        counters_lines = "  (aucun contre-argument généré — recommandations de contre limitées aux exceptions de scheme)"
+
+    target_lines = (
+        "\n".join(
+            f"  - {wp.label} sur {wp.target_arg_id} (ancre : {wp.source})"
+            for wp in evidence.weak_points if wp.source in ("fallacy", "pl", "fol", "dung")
+        )
+        or "  (aucun point faible structurel à viser identifié)"
+    )
+
+    what_next_block = (
+        "  À quoi s'attendre ensuite : referme la boucle sur le cadrage "
+        "game-theoretic de l'Acte I — les coups probables que l'orateur peut "
+        "jouer ensuite pour esquiver les faiblesses signalées (doubler la mise "
+        "sur l'autorité, glisser d'une attaque à une autre, amplification "
+        "émotive). Ne fabrique pas de coups : déduis-les des faiblesses "
+        "localisées."
+    )
+
+    return (
+        "Tu es l'auteur de l'ACTE III d'un rapport de restitution argumentative\n"
+        "— la CONCLUSION ACTIONNABLE : ce que le lecteur FAIT de l'analyse.\n"
+        "Trois battements en prose :\n"
+        "1. Synthèse honnête (verdict gated sur la bande — pas de sur-claim) ;\n"
+        "2. Appréciations (forces ET faiblesses du discours, équilibré) ;\n"
+        "3. Que faire : comment CONTRER, les POINTS FAIBLES À VISER, à quoi\n"
+        "   S'ATTENDRE ENSUITE (retour au cadrage game-theoretic de l'Acte I).\n\n"
+        f"{_OPAQUE_ID_DIRECTIVE}\n\n"
+        f"{_WEAVING_RULE}\n\n"
+        f"{_FAIL_LOUD_INSTRUCTION}\n\n"
+        "DONNÉES VERIFIÉES DANS LE STATE (ne citer que celles-ci) :\n\n"
+        f"[SYNTHÈSE HONNÊTE — verdict gated]\n{synthesis_block}\n\n"
+        f"[APPRÉCIATIONS — forces (qualité)]\n{strengths_lines}\n\n"
+        f"[APPRÉCIATIONS — faiblesses localisées]\n{weaknesses_lines}\n\n"
+        f"[QUE FAIRE — comment contrer]\n{counters_lines}\n\n"
+        f"[QUE FAIRE — points faibles à viser]\n{target_lines}\n\n"
+        f"{what_next_block}\n\n"
+        "CONSIGNE DE RÉDACTION :\n"
+        "- Rédige 3 paragraphes thématiques (un par battement), en prose lisible,\n"
+        "  pas une liste de champs. Titres thématiques en ###.\n"
+        "- Le verdict formel (Tweety/Dung) appuie un battement : formule-le comme\n"
+        "  « le solveur Tweety invalide cette inférence » ou « le cadre de Dung\n"
+        "  isole cette attaque comme défaillante » — jamais une sous-section\n"
+        "  isolée.\n"
+        "- Respecte STRICTEMENT le plafond de claim de la bande : ne formule rien\n"
+        "  au-delà de ce qu'elle autorise.\n"
+        "- La conclusion doit VARIER selon le contenu réel ci-dessus : pas de\n"
+        "  prose générique recyclable.\n"
+        "- Rédige en français, markdown léger. 300-600 mots selon la richesse.\n"
+    )
+
+
+# --- LLM-conducted weaving (fail-loud) ---------------------------------------
+
+
+async def weave_act3_conclusion(
+    evidence: Act3Evidence, llm_callable: LlmCallable
+) -> str:
+    """Conduct the Acte III conclusion via the LLM (fail-loud, #1108).
+
+    Returns the LLM-produced markdown, or an empty string if the LLM produced
+    nothing (the caller records the explicit ``unavailable`` status). No
+    template fallback — anti-pendule #1019/#369.
+    """
+    prompt = build_act3_prompt(evidence)
+    try:
+        raw = await llm_callable(prompt)
+    except Exception as exc:  # noqa: BLE001 — surface, don't fabricate
+        logger.warning("Acte III LLM weaving failed (fail-loud): %s", exc)
+        return ""
+    if not raw:
+        return ""
+    return str(raw).strip()
+
+
+# --- orchestrator ------------------------------------------------------------
+
+
+async def build_act3_conclusion(
+    state: Any, llm_callable: Optional[LlmCallable] = None
+) -> Act3Result:
+    """Build the Acte III actionable conclusion for ``state``.
+
+    Deterministic evidence is always built (including the gated verdict band and
+    the G1–G4 statuses). The conclusion is LLM-conducted only when
+    ``llm_callable`` is provided; otherwise the result is fail-loud
+    (``status="unavailable"``, empty narrative) — the renderer reports the gap
+    honestly, never a template (#1108).
+
+    G1–G4 (#1008 §3.2) gate the *gated synthesis* beat: on any gate failure the
+    LLM is still conducted for the *appreciations* and *que-faire* beats (those
+    do not require a comparative verdict), but the synthesis beat carries the
+    honest fallback wording. A §4 self-check (``ReadabilityGate``) is attached
+    to every woven result so the verdict is auditable; it never fabricates a
+    pass.
+    """
+    evidence = build_act3_evidence(state)
+
+    gates = evidence.gates
+    failed_gates = [g for g, ok in gates.items() if not ok]
+
+    if not gates["G1_arguments_extracted"]:
+        # No substrate at all — the whole conclusion is fail-loud.
+        return Act3Result(
+            narrative="",
+            status="empty_state",
+            degraded={
+                "act3_conclusion": (
+                    "Aucun argument extrait — l'Acte III n'a pas de substrat à "
+                    "conclure (G1 échoué : identified_arguments vide)."
+                )
+            },
+        )
+
+    if llm_callable is None:
+        return Act3Result(
+            narrative="",
+            status="unavailable",
+            degraded={
+                "act3_conclusion": (
+                    "Conclusion non conduite — aucun LLM injecté pour l'Acte III "
+                    "(fail-loud, #1108)."
+                )
+            },
+        )
+
+    # If a gate beyond G1 failed, flag it: the synthesis beat must carry the
+    # honest fallback, but we still conduct the LLM for the other beats and
+    # attach the gate status so nothing is silently weakened.
+    gate_note = ""
+    if failed_gates:
+        gate_note = (
+            f"Gates G1–G4 : {', '.join(failed_gates)} non passé(s). La synthèse "
+            "doit porter le wording de repli honnête (#1008 §3.3) — pas de "
+            "verdict comparatif."
+        )
+        # Re-flag the verdict as ungated so the prompt's synthesis beat degrades.
+        evidence.verdict = None
+
+    narrative = await weave_act3_conclusion(evidence, llm_callable)
+    if not narrative:
+        return Act3Result(
+            narrative="",
+            status="unavailable",
+            degraded={
+                "act3_conclusion": (
+                    "Conclusion indisponible — le LLM n'a rien produit "
+                    "(fail-loud, #1108)."
+                )
+            },
+        )
+
+    # §4 self-check (honest, never grades on a curve).
+    gate = ReadabilityGate()
+    verdict = gate.check_body(narrative)
+    degraded: Dict[str, str] = {}
+    if verdict.band != "PASS":
+        degraded["act3_conclusion_gate"] = (
+            f"Self-check §4 = {verdict.band}: " + "; ".join(verdict.reasons[:3])
+        )
+    if gate_note:
+        degraded["act3_conclusion_gates"] = gate_note
+    if not evidence.quality_axis_available:
+        degraded["act3_conclusion"] = (
+            "Axe qualité non concluable ici (argument_quality_scores "
+            "indisponible) — appréciations limitées aux faiblesses, fail-loud."
+        )
+    if not evidence.weak_points:
+        degraded["act3_conclusion_virtuous"] = (
+            "Aucun point faible localisé — conclusion bascule en mode texte "
+            "vertueux (forces en titre)."
+        )
+
+    return Act3Result(
+        narrative=narrative, status="woven", gate_verdict=verdict, degraded=degraded
+    )

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
@@ -330,13 +330,19 @@ class TestSpectacularWorkflowGolden:
         "belief_revision",
         "synthesis",
         "deep_synthesis",
+        # Restitution acts (Epic #1134): R2 framing + R3 narrative + R4 conclusion.
+        "act1_framing",
+        "act2_narrative",
+        "act3_conclusion",
     }
 
-    def test_phase_count_is_28(self):
+    def test_phase_count_is_31(self):
         # #1115: narrative_synthesis template phase removed from spectacular
-        # (determinization residue #1109 §5); count reflects real phase set.
+        # (determinization residue #1109 §5); count reflects real phase set PLUS
+        # the three restitution acts (R2 act1_framing #1136, R3 act2_narrative
+        # #1137, R4 act3_conclusion #1138) wired onto the spectacular DAG.
         wf = build_spectacular_workflow()
-        assert len(wf.phases) == 28
+        assert len(wf.phases) == 31
 
     def test_all_expected_phases_present(self):
         wf = build_spectacular_workflow()
@@ -352,13 +358,15 @@ class TestSpectacularWorkflowGolden:
         wf = build_spectacular_workflow()
         assert wf.validate() == []
 
-    def test_execution_order_has_8_levels(self):
+    def test_execution_order_has_10_levels(self):
         # #1115: DAG grew via #504/#506/#507/#508/#534 (solvers, KB/tweety,
-        # belief_revision, synthesis, deep_synthesis) — execution order is now
-        # 8 levels. Folded DAG test debt per ai-01 R407.
+        # belief_revision, synthesis, deep_synthesis) PLUS the three restitution
+        # acts: act1_framing (R2, depends on extract+stakes), act2_narrative
+        # (R3, depends on deep_synthesis) and act3_conclusion (R4, depends on
+        # act2_narrative — the terminal level). Execution order is now 10 levels.
         wf = build_spectacular_workflow()
         levels = wf.get_execution_order()
-        assert len(levels) == 8
+        assert len(levels) == 10
 
     def test_extract_is_sole_entry_point(self):
         wf = build_spectacular_workflow()
@@ -405,13 +413,14 @@ class TestSpectacularWorkflowGolden:
         assert "aspic_analysis" in synth.depends_on
         levels = wf.get_execution_order()
         # formal_synthesis runs in the formal-aggregation level (5 of 0..7); the
-        # terminal level is deep_synthesis (#534).
+        # terminal level is act3_conclusion (R4 #1138, depends on act2_narrative
+        # which depends on deep_synthesis #534).
         assert "formal_synthesis" in levels[5]
-        assert levels[-1] == ["deep_synthesis"]
+        assert levels[-1] == ["act3_conclusion"]
 
     @pytest.mark.asyncio
     async def test_all_phases_complete_or_optional_skipped(self):
-        # #1115: the spectacular workflow has 28 phases (was 16/17); exact-count
+        # #1115: the spectacular workflow has 31 phases (was 16/17); exact-count
         # asserts went stale as the DAG grew. Assert the load-bearing invariant
         # instead: no phase FAILED, and the non-optional phases all COMPLETED.
         wf = build_spectacular_workflow()
@@ -657,9 +666,9 @@ class TestWorkflowCatalogGolden:
         catalog = get_workflow_catalog()
         assert "spectacular" in catalog
         assert catalog["spectacular"].name == "spectacular_analysis"
-        # #1115: spectacular has 28 phases (narrative_synthesis template removed;
-        # DAG grew via #504/#506/#507/#508/#534).
-        assert len(catalog["spectacular"].phases) == 28
+        # #1115: spectacular has 31 phases (narrative_synthesis template removed;
+        # DAG grew via #504/#506/#507/#508/#534 + 3 restitution acts R2/R3/R4).
+        assert len(catalog["spectacular"].phases) == 31
 
     def test_catalog_includes_sherlock_modern(self):
         catalog = get_workflow_catalog()

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
@@ -32,10 +32,11 @@ class TestSpectacularWorkflowDAG:
         # spectacular workflow (determinization residue per #1109 §5). The count
         # reflects the real phase set (#504 solvers, #506 KB/tweety, #507
         # belief_revision, #508 synthesis, #534 deep_synthesis, ...) PLUS the
-        # two restitution acts wired onto the spectacular DAG: act1_framing
-        # (R2 #1136) and act2_narrative (R3 #1137) — the 3-act narrative.
+        # three restitution acts wired onto the spectacular DAG: act1_framing
+        # (R2 #1136), act2_narrative (R3 #1137) and act3_conclusion (R4 #1138)
+        # — the 3-act narrative.
         wf = build_spectacular_workflow()
-        assert len(wf.phases) == 30
+        assert len(wf.phases) == 31
 
     def test_all_expected_phases_present(self):
         wf = build_spectacular_workflow()
@@ -69,9 +70,10 @@ class TestSpectacularWorkflowDAG:
             "belief_revision",
             "synthesis",
             "deep_synthesis",
-            # Restitution acts (Epic #1134): R2 framing + R3 narrative.
+            # Restitution acts (Epic #1134): R2 framing + R3 narrative + R4 conclusion.
             "act1_framing",
             "act2_narrative",
+            "act3_conclusion",
         }
         assert expected == phase_names
 

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -1,0 +1,444 @@
+"""Tests for the Acte III generator — actionable conclusion (R4 #1138).
+
+Pins the spec §1.3 contract (gated verdict + balanced appréciations + que-faire)
+and the §4 weaving contract (LLM-conducted conclusion passes the readability
+gate; enumeration does not). The verdict band is computed from the real
+analytical coverage (adapted from #1008 §2) — EXCEEDED/MATCH/PARTIAL/BELOW
+govern how strongly the discourse may be characterised.
+
+The G1–G4 non-triviality gates (#1008 §3) gate the synthesis beat: on any gate
+failure the conclusion degrades honestly (no fabricated verdict).
+
+All deterministic — no JVM, no LLM service, no network: the LLM is an injectable
+async stub and the state is a ``SimpleNamespace`` (the plugin reads attributes
+via ``getattr``).
+
+Privacy HARD is asserted: corpus-derived fields are truncated before entering
+the prompt, and the prompt carries the opaque-ID directive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import List
+
+import pytest
+
+from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+    Act3Result,
+    build_act3_conclusion,
+    build_act3_evidence,
+    build_act3_prompt,
+    weave_act3_conclusion,
+)
+from argumentation_analysis.reporting.restitution.readability_gate import (
+    ReadabilityGate,
+)
+
+
+# --- state stubs -------------------------------------------------------------
+
+
+def _state(**fields: object) -> SimpleNamespace:
+    """Build a lightweight state stub with the Acte III-relevant fields."""
+    base = dict(
+        identified_arguments={},
+        identified_fallacies={},
+        argument_quality_scores={},
+        counter_arguments=[],
+        dung_frameworks={},
+        fol_analysis_results=[],
+        propositional_analysis_results=[],
+        modal_analysis_results=[],
+        narrative_synthesis="",
+    )
+    base.update(fields)
+    return SimpleNamespace(**base)
+
+
+def _rich_state() -> SimpleNamespace:
+    """A state with broad analytical coverage → verdict band EXCEEDED.
+
+    5 non-trivial axes: fallacies + quality + counters + formal_pl + dung.
+    Has formal depth (PL inconsistency) AND quality → EXCEEDED (≥5 axes + formal
+    + quality, per the band threshold).
+    """
+    return _state(
+        identified_arguments={
+            "arg_1": "Le locuteur disqualifie l'adversaire par une attaque personnelle.",
+            "arg_2": "Une revendication défendue par un raisonnement causal étayé.",
+        },
+        identified_fallacies={
+            "fl_1": {
+                "target_argument_id": "arg_1",
+                "family": "ad hominem",
+                "type": "ad hominem circonstanciel",
+                "taxonomy_path": "racine > sophismes de pertinence > ad hominem",
+                "justification": (
+                    "L'argument attaque la personne plutôt que la thèse, "
+                    "ce qui détache la conclusion des motifs."
+                ),
+            }
+        },
+        argument_quality_scores={
+            "arg_1": {
+                "overall": 4.2,
+                "scores_par_vertu": {"pertinence": 3.0, "clarte": 5.0},
+            },
+            "arg_2": {
+                "overall": 7.8,
+                "scores_par_vertu": {"pertinence": 8.0, "coherence": 7.5},
+            },
+        },
+        counter_arguments=[
+            {
+                "target_arg_id": "arg_1",
+                "strategy": "contre-exemple",
+                "counter_content": (
+                    "On peut attaquer la thèse sans attaquer la personne, ce qui "
+                    "montre que le procès personnel est superflu."
+                ),
+            }
+        ],
+        dung_frameworks={
+            "fw_1": {
+                "arguments": ["arg_1", "arg_2"],
+                "extensions": {"all_members": ["arg_2"]},
+                "semantics": "grounded",
+            }
+        },
+        propositional_analysis_results=[
+            {"consistent": True},
+            {"consistent": False},
+        ],
+    )
+
+
+# --- async LLM stubs ---------------------------------------------------------
+
+
+def _stub_llm(return_value: str) -> object:
+    """An async LLM callable stub returning a fixed conclusion."""
+
+    async def _call(_prompt: str) -> str:
+        return return_value
+
+    return _call
+
+
+def _raising_llm(exc: BaseException) -> object:
+    async def _call(_prompt: str) -> str:
+        raise exc
+
+    return _call
+
+
+# A §4-compliant woven conclusion (all framework refs anchored on a beat, no
+# isolated score, no dump heading). Must PASS the readability gate.
+_WOVEN_CONCLUSION = (
+    "### Synthèse honnête\n\n"
+    "L'analyse atteint une profondeur multi-axes: elle localise un dérapage, "
+    "caractérise le discours par ses vertus, et le solveur Tweety confirme "
+    "l'inconsistance d'une inférence sous-jacente. La couverture est large, la "
+    "caractérisation peut donc être assurée sans sur-claim.\n\n"
+    "### Ce qui tient et ce qui dérape\n\n"
+    "Le second mouvement tient: la vertu de pertinence éclaire un argument lié "
+    "à sa conclusion. Le premier dérape vers un ad hominem circonstanciel "
+    "(famille ad hominem), qui détache la conclusion des motifs. Le cadre de "
+    "Dung traduit cela mécaniquement: arg_1 est rejeté par la sémantique "
+    "grounded, ne survivant pas à l'attaque.\n\n"
+    "### Comment contrer et à quoi s'attendre\n\n"
+    "Un contre-exemple montre qu'on peut attaquer la thèse sans attaquer la "
+    "personne, isolant le procès personnel comme superflu. À attendre ensuite: "
+    "l'orateur peut doubler la mise sur l'autorité ou glisser d'une attaque à "
+    "une autre pour esquiver la faiblesse signalée."
+)
+
+# An enumeration (bare refs + dump headings) — must NOT pass the gate.
+_ENUMERATION = (
+    "Sophisme 1: ad hominem (0.8)\n"
+    "Sophisme 2: ad verecundiam (0.7)\n"
+    "Argument 1: quality 0.4\n"
+    "Verdict: Tweety 0.8\n"
+)
+
+
+# ============================================================================
+# build_act3_evidence — deterministic verdict + weak points
+# ============================================================================
+
+
+class TestBuildEvidence:
+    def test_rich_state_is_exceeded_band(self):
+        ev = build_act3_evidence(_rich_state())
+        assert ev.verdict is not None
+        assert ev.verdict.band == "EXCEEDED"
+        assert ev.verdict.axes_count == 5
+        assert "formal_pl" in ev.verdict.nontrivial_axes
+        assert "quality" in ev.verdict.nontrivial_axes
+
+    def test_counts_and_axes(self):
+        ev = build_act3_evidence(_rich_state())
+        assert ev.args_total == 2
+        assert ev.fallacies_total == 1
+        assert ev.counters_total == 1
+        assert ev.quality_axis_available is True
+
+    def test_weak_points_collect_fallacy_and_formal_and_dung(self):
+        ev = build_act3_evidence(_rich_state())
+        sources = {wp.source for wp in ev.weak_points}
+        # fallacy (ad hominem) + dung (arg_1 rejected) + pl (1 inconsistency).
+        assert "fallacy" in sources
+        assert "dung" in sources
+        assert "pl" in sources
+
+    def test_counter_strategies_collected(self):
+        ev = build_act3_evidence(_rich_state())
+        assert len(ev.counter_strategies) == 1
+        assert ev.counter_strategies[0].strategy == "contre-exemple"
+
+    def test_quality_strengths_collected(self):
+        ev = build_act3_evidence(_rich_state())
+        virtues = {s.virtue for s in ev.quality_strengths}
+        assert "pertinence" in virtues
+        assert "clarte" in virtues
+
+    def test_gates_pass_on_rich_state(self):
+        ev = build_act3_evidence(_rich_state())
+        assert ev.gates["G1_arguments_extracted"] is True
+        assert ev.gates["G2_one_dimension_nontrivial"] is True
+        assert ev.gates["G3_verdict_computed"] is True
+        assert ev.gates["G4_no_fabrication"] is True
+
+    def test_empty_state_g1_fails_and_below_band(self):
+        ev = build_act3_evidence(_state())
+        assert ev.gates["G1_arguments_extracted"] is False
+        assert ev.verdict is not None
+        assert ev.verdict.band == "BELOW"
+        assert ev.verdict.axes_count == 0
+
+    def test_match_band_without_formal_depth(self):
+        # 4 axes but no formal depth (no PL/FOL) → MATCH, not EXCEEDED.
+        state = _state(
+            identified_arguments={"arg_1": "un argument"},
+            identified_fallacies={
+                "fl_1": {
+                    "target_argument_id": "arg_1",
+                    "family": "ad hominem",
+                    "type": "ad hominem",
+                }
+            },
+            argument_quality_scores={"arg_1": {"scores_par_vertu": {"clarte": 5.0}}},
+            counter_arguments=[
+                {"target_arg_id": "arg_1", "strategy": "contre-exemple", "counter_content": "réponse"}
+            ],
+            dung_frameworks={
+                "fw_1": {"arguments": ["arg_1"], "extensions": {}, "semantics": "grounded"}
+            },
+        )
+        ev = build_act3_evidence(state)
+        assert ev.verdict is not None
+        assert ev.verdict.band == "MATCH"
+
+    def test_partial_band_with_two_axes(self):
+        state = _state(
+            identified_arguments={"arg_1": "un argument"},
+            identified_fallacies={
+                "fl_1": {
+                    "target_argument_id": "arg_1",
+                    "family": "ad hominem",
+                    "type": "ad hominem",
+                }
+            },
+            argument_quality_scores={"arg_1": {"scores_par_vertu": {"clarte": 5.0}}},
+        )
+        ev = build_act3_evidence(state)
+        assert ev.verdict is not None
+        assert ev.verdict.band == "PARTIAL"
+
+    def test_below_band_with_one_axis(self):
+        state = _state(
+            identified_arguments={"arg_1": "un argument"},
+            identified_fallacies={
+                "fl_1": {
+                    "target_argument_id": "arg_1",
+                    "family": "ad hominem",
+                    "type": "ad hominem",
+                }
+            },
+        )
+        ev = build_act3_evidence(state)
+        assert ev.verdict is not None
+        assert ev.verdict.band == "BELOW"
+
+
+class TestPrivacy:
+    def test_long_justification_truncated_in_prompt(self):
+        long_just = "x" * 500  # well over the _JUSTIFICATION_CAP
+        state = _state(
+            identified_arguments={"arg_1": "arg"},
+            identified_fallacies={
+                "fl_1": {
+                    "target_argument_id": "arg_1",
+                    "family": "ad hominem",
+                    "type": "ad hominem",
+                    "justification": long_just,
+                }
+            },
+        )
+        ev = build_act3_evidence(state)
+        prompt = build_act3_prompt(ev)
+        assert long_just not in prompt
+        assert "[…]" in prompt
+
+    def test_prompt_carries_directives(self):
+        ev = build_act3_evidence(_rich_state())
+        prompt = build_act3_prompt(ev)
+        assert "OPAQUES" in prompt  # FB-34 directive heading
+        assert "TISSAGE" in prompt  # §4 weaving rule heading
+        assert "HONNÊTETÉ" in prompt  # fail-loud instruction heading
+        assert "spec §4" in prompt
+
+    def test_prompt_carries_verdict_band(self):
+        ev = build_act3_evidence(_rich_state())
+        prompt = build_act3_prompt(ev)
+        assert "EXCEEDED" in prompt
+
+
+# ============================================================================
+# weave_act3_conclusion — fail-loud
+# ============================================================================
+
+
+class TestWeaveFailLoud:
+    def test_llm_error_returns_empty(self):
+        ev = build_act3_evidence(_rich_state())
+        out = asyncio.get_event_loop().run_until_complete(
+            weave_act3_conclusion(ev, _raising_llm(RuntimeError("boom")))  # type: ignore[arg-type]
+        )
+        assert out == ""
+
+    def test_llm_empty_returns_empty(self):
+        ev = build_act3_evidence(_rich_state())
+        out = asyncio.get_event_loop().run_until_complete(
+            weave_act3_conclusion(ev, _stub_llm(""))  # type: ignore[arg-type]
+        )
+        assert out == ""
+
+
+# ============================================================================
+# build_act3_conclusion — orchestrator + G1-G4 gates + §4 self-check
+# ============================================================================
+
+
+class TestBuildConclusion:
+    def test_no_llm_is_fail_loud_unavailable(self):
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act3_conclusion(_rich_state(), llm_callable=None)
+        )
+        assert result.status == "unavailable"
+        assert result.narrative == ""
+        assert "act3_conclusion" in result.degraded
+
+    def test_empty_state_is_fail_loud_empty_state(self):
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act3_conclusion(_state(), llm_callable=_stub_llm(_WOVEN_CONCLUSION))  # type: ignore[arg-type]
+        )
+        assert result.status == "empty_state"
+        assert result.narrative == ""
+        assert "G1" in result.degraded.get("act3_conclusion", "")
+
+    def test_woven_conclusion_passes_gate_self_check(self):
+        """DoD: the conducted conclusion passes our own §4 gate."""
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act3_conclusion(
+                _rich_state(), llm_callable=_stub_llm(_WOVEN_CONCLUSION)  # type: ignore[arg-type]
+            )
+        )
+        assert result.status == "woven"
+        assert result.narrative == _WOVEN_CONCLUSION
+        assert result.gate_verdict is not None
+        assert result.gate_verdict.band == "PASS", result.gate_verdict.reasons
+
+    def test_enumeration_is_detected_honestly(self):
+        """The self-check must NOT pass an enumeration (honest, no curve)."""
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act3_conclusion(
+                _rich_state(), llm_callable=_stub_llm(_ENUMERATION)  # type: ignore[arg-type]
+            )
+        )
+        assert result.status == "woven"  # LLM produced text, but…
+        assert result.gate_verdict is not None
+        assert result.gate_verdict.band == "FAIL"
+        assert result.degraded  # surfaced honestly
+
+    def test_quality_unavailable_recorded_as_degraded(self):
+        state = _rich_state()
+        state.argument_quality_scores = {}
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act3_conclusion(
+                state, llm_callable=_stub_llm(_WOVEN_CONCLUSION)  # type: ignore[arg-type]
+            )
+        )
+        assert any(
+            "qualité" in v.lower() or "qualit" in v.lower()
+            for v in result.degraded.values()
+        )
+
+    def test_g2_failure_flags_gate_note(self):
+        """G2 fails when no axis is non-trivial but args exist (vacuous)."""
+        state = _state(identified_arguments={"arg_1": "un argument sans analyse"})
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act3_conclusion(
+                state, llm_callable=_stub_llm(_WOVEN_CONCLUSION)  # type: ignore[arg-type]
+            )
+        )
+        # G1 passes (arg exists), G2 fails (no non-trivial axis) → gate note set,
+        # verdict nulled in the evidence so the synthesis beat degrades honestly.
+        assert result.status == "woven"
+        assert "act3_conclusion_gates" in result.degraded
+        assert "G2" in result.degraded["act3_conclusion_gates"]
+
+
+# ============================================================================
+# The woven fixture itself passes the gate independently (belt + braces)
+# ============================================================================
+
+
+class TestWovenFixtureIsGateCompliant:
+    def test_woven_conclusion_passes_gate_directly(self):
+        gate = ReadabilityGate()
+        verdict = gate.check_body(_WOVEN_CONCLUSION)
+        assert verdict.passed, verdict.reasons
+
+    def test_enumeration_fails_gate_directly(self):
+        gate = ReadabilityGate()
+        verdict = gate.check_body(_ENUMERATION)
+        assert not verdict.passed
+
+
+# ============================================================================
+# DoD (d): state.act3_conclusion is consumed by the R6 renderer end-to-end.
+# ============================================================================
+
+
+class TestConsumedByRenderer:
+    def test_state_act3_flows_to_renderer(self):
+        from argumentation_analysis.reporting.restitution.acts import (
+            RestitutionActs,
+        )
+        from argumentation_analysis.reporting.restitution.renderer import (
+            render_restitution_report,
+        )
+
+        # A state whose act3 phase has run (state_writer populated the key).
+        state = SimpleNamespace(act3_conclusion=_WOVEN_CONCLUSION)
+        # The 1-liner wiring: the act-builder maps state→RestitutionActs.
+        acts = RestitutionActs(source_id="doc_A", act3_conclusion=state.act3_conclusion)
+
+        report = render_restitution_report(acts)
+        # The woven act3 conclusion is rendered into the body verbatim.
+        assert _WOVEN_CONCLUSION.splitlines()[0] in report.markdown
+        # act1/act2 are reported as missing (fail-loud), not silently dropped.
+        assert "indisponible" in report.markdown.lower() or "acte" in report.markdown.lower()


### PR DESCRIPTION
**Epic #1134** (Restitution) — Track **R4 #1138**. Closes #1138. The reader's payoff — closes the triptyque (framing → récit → conclusion). Dispatch coord R428/R429 (cleared on base `18af612e`).

## What
`act3_conclusion` — the **actionable conclusion** generator (LLM-conducted, woven per spec §4). Three beats per spec §1.3 + #1138:
1. **Synthèse honnête** — verdict **gated** on G1–G4 (#1008 §3) + the verdict band (computed from real analytical coverage — adapted from #1008 §2 to the restitution context, which has **no external analyst**: the band governs *how strongly the discourse may be characterised*, never a fabricated comparison).
2. **Appréciations** — strengths **and** weaknesses (balanced: quality strengths + localized weak points).
3. **Que faire de l'analyse** — how to **counter** (counter_arguments + scheme exceptions) / **points faibles à viser** (structuring fallacies + Tweety-invalidated inferences + Dung-rejected attacks) / **à quoi s'attendre ensuite** (game-theoretic, returns to the Acte I framing).

Mirrors the R3/R2 act-plugin pattern (same 3 infra files, append-only).

## DoD (#1138) — all proven (24 tests)
- [x] The 3 beats produced (`_WOVEN_CONCLUSION` fixture, `test_woven_conclusion_passes_gate_self_check`).
- [x] **Verdict respects #1008 bands**; no claim beyond what the band authorizes (`_band_claim_ceiling`, band computed from real coverage: EXCEEDED ≥5 axes+formal+quality | MATCH ≥4 | PARTIAL 2–3 | BELOW 1).
- [x] **contrer / points faibles / what-next concrete + adossé au state** (`test_weak_points_collect_fallacy_and_formal_and_dung`, `test_counter_strategies_collected`).
- [x] **`act3_conclusion` key documented** + consumed by R6 end-to-end (`test_state_act3_flows_to_renderer`).
- [x] Self-check §4 PASS on woven fixture; enumeration detected FAIL (`test_enumeration_is_detected_honestly`).

## G1–G4 gates (#1008 §3)
On G2 failure (args exist but no non-trivial axis), the verdict is nulled and the synthesis beat carries the honest fallback wording — no fabricated verdict (`test_g2_failure_flags_gate_note`).

## Wiring (append-only — 0 deletions on infra)
`shared_state.act3_conclusion` + `invoke_callables._invoke_act3_conclusion` (mypy-strict, FB-32 `service_id="default"` idiom) + `state_writers._write_act3_conclusion_to_state` + dispatch map + `registry_setup` (import + service) + `workflows` (phase spectacular **LAST**, `depends_on=["act2_narrative"]` → framing→récit→conclusion, new terminal level).

## Fix staleness regression suite (5 tests RED on main, left stale by R2/R3)
Recurring lesson (#1136 already flagged it for R3). This PR aligns everything:
- `test_phase_count_is_28` → `31`, `EXPECTED_PHASES` + act1+act2+act3
- `test_execution_order_has_8_levels` → `10`
- `levels[-1]` `deep_synthesis` → `act3_conclusion`
- `test_catalog_includes_spectacular` 28 → 31
- DAG test 30 → 31 (+ act3_conclusion in expected set)

## Validation
- ✅ mypy strict clean (5 files = the CI gate)
- ✅ act3 24/24 · restitution 124/124 (0 regression) · DAG 16/16 · regression suite 47/47
- ✅ **0 LLM spend** (wiring + deterministic tests; real spectacular run is coord/user-gated)
- ✅ Privacy HARD: opaque IDs, corpus fields truncated, OPAQUE_ID_DIRECTIVE in prompt

## After R4 (gated on this merge)
The 2 last tracks open — `R6 wiring final` (1-liner assembling act1+act2+act3 → `RestitutionActs` → renderer, replacing `render_markdown`) + `R5 volet-2` (virtuous-text mode). I can chain them.

🤖 Worker po-2025 — R4 #1138