### PR TITLE
feat(restitution): #1139 R5 volet-2 — virtuous-text report mode (positive titling)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act1_framing_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act1_framing_plugin.py
@@ -42,9 +42,10 @@ import os
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from .readability_gate import GateVerdict, ReadabilityGate
+from .virtuous_identification import VirtuousModeAssessment, detect_virtuous_mode
 
 logger = logging.getLogger(__name__)
 
@@ -117,6 +118,10 @@ class Act1Evidence:
     # Game-theoretic
     stakeholders: List[StakeholderInfo] = field(default_factory=list)
     arg_count: int = 0
+    # DERIVED virtuous flag (spec §5.1) — when the state characterises the text
+    # as virtuous, the spectrum framing shifts from "what to watch for" to
+    # "what could derail but doesn't" (anticipation that did not materialise).
+    virtuous_mode: Optional[VirtuousModeAssessment] = None
 
 
 @dataclass
@@ -131,6 +136,9 @@ class Act1Result:
     status: str
     gate_verdict: Optional[GateVerdict] = None
     degraded: Dict[str, str] = field(default_factory=dict)
+    # True when the framing was conducted with the virtuous anticipation shift
+    # (spec §5): the spectrum is read as "what could derail but doesn't".
+    is_virtuous: bool = False
 
 
 # --- taxonomy loader (minimal, file-disjoint) --------------------------------
@@ -336,6 +344,8 @@ def build_act1_evidence(state: Any) -> Act1Evidence:
     args = getattr(state, "identified_arguments", {}) or {}
     arg_count = len(args) if isinstance(args, dict) else 0
 
+    virtuous_mode = detect_virtuous_mode(state)
+
     return Act1Evidence(
         metadata=metadata_view,
         genre=genre,
@@ -349,6 +359,7 @@ def build_act1_evidence(state: Any) -> Act1Evidence:
         spectrum_available=spectrum_available,
         stakeholders=stakeholders,
         arg_count=arg_count,
+        virtuous_mode=virtuous_mode,
     )
 
 
@@ -392,6 +403,29 @@ def build_act1_prompt(evidence: Act1Evidence) -> str:
     The prompt varies with the evidence (hence with the corpus) — it is not a
     static template (#1108/#405).
     """
+    # --- Mode vertueux (spec §5) — anticipation qui ne se concrétise pas ---
+    vm = evidence.virtuous_mode
+    is_virtuous = vm is not None and vm.is_virtuous
+    if is_virtuous:
+        virtuous_section = (
+            "MODE VIRTUEUX (spec §5) — ANTICIPATION QUI NE DÉRAPE PAS :\n"
+            "Ce texte est caractérisé comme vertueux par le pipeline (zéro\n"
+            "sophisme localisé + vertus mesurées). Le spectre ci-dessous reste ce\n"
+            "qu'un auditeur averti GUILLETAIT pour ce genre — mais le texte ne\n"
+            "dérape pas : l'anticipation ne s'est pas concrétisée. Cadre donc le\n"
+            "spectre comme « ce qui aurait pu déraper et ne dérape pas », en\n"
+            "honnêteté avec ce qui tient (vertus, robustesse formelle). Ne\n"
+            "fabrique JAMAIS de sophisme pour valider l'attente.\n"
+            f"Dérivation du flag : {vm.reasoning if vm is not None else ''}\n\n"
+        )
+        spectrum_coda = (
+            " Sur un texte vertueux, ces familles sont l'attente NON concrétisée "
+            "— dis ce qui aurait pu déraper et ne dérape pas."
+        )
+    else:
+        virtuous_section = ""
+        spectrum_coda = ""
+
     # --- Le texte (metadata) ---
     if evidence.metadata:
         meta_block = "\n".join(
@@ -465,10 +499,11 @@ def build_act1_prompt(evidence: Act1Evidence) -> str:
         f"{_OPAQUE_ID_DIRECTIVE}\n\n"
         f"{_WEAVING_RULE}\n\n"
         f"{_FAIL_LOUD_INSTRUCTION}\n\n"
+        f"{virtuous_section}"
         "DONNÉES VERIFIÉES DANS LE STATE :\n\n"
         f"[LE TEXTE — métadonnées]\n{meta_block}\n\n"
         f"[LES ENJEUX]\n{stakes_block}\n\n"
-        f"[SPECTRE ATTENDU — dérivation taxonomie]\n{spectrum_note}\n"
+        f"[SPECTRE ATTENDU — dérivation taxonomie]\n{spectrum_note}{spectrum_coda}\n"
         f"{spectrum_block}\n\n"
         f"[LECTURE GAME-THEORETIC]\n{gt_block}\n{gt_note}\n\n"
         "CONSIGNE DE RÉDACTION :\n"
@@ -563,7 +598,18 @@ async def build_act1_framing(
             "Spectre attendu indisponible (taxonomie non chargée) — lire "
             "l'Acte II sans filet d'attente."
         )
+    vm = evidence.virtuous_mode
+    is_virtuous = vm is not None and vm.is_virtuous
+    if vm is not None and vm.is_virtuous:
+        degraded["act1_virtuous_mode"] = (
+            "Mode vertueux (spec §5) — spectre lu comme anticipation qui ne "
+            "dérape pas. " + vm.reasoning
+        )
 
     return Act1Result(
-        narrative=narrative, status="woven", gate_verdict=verdict, degraded=degraded
+        narrative=narrative,
+        status="woven",
+        gate_verdict=verdict,
+        degraded=degraded,
+        is_virtuous=is_virtuous,
     )

--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from .readability_gate import GateVerdict, ReadabilityGate
+from .virtuous_identification import VirtuousModeAssessment, detect_virtuous_mode
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,10 @@ class Act2Evidence:
     # LLM/rapport surfaces them honestly as "non rattaché(s) à un argument
     # identifié". ``fallacies_total`` counts only the attributed ones.
     unattributed_fallacies: int = 0
+    # DERIVED virtuous flag (spec §5.1) — when the state characterises the text
+    # as virtuous, the narrative leads with WHY THE ARGUMENTATION HOLDS (the
+    # soutiens movement becomes the centrepiece; formal tenue is the proof).
+    virtuous_mode: Optional[VirtuousModeAssessment] = None
 
 
 @dataclass
@@ -139,6 +144,9 @@ class Act2Result:
     status: str
     gate_verdict: Optional[GateVerdict] = None
     degraded: Dict[str, str] = field(default_factory=dict)
+    # True when the narrative was conducted leading with why the argumentation
+    # holds (spec §5) — the virtuous reading.
+    is_virtuous: bool = False
 
 
 # --- deterministic evidence builder (no LLM) ---------------------------------
@@ -378,6 +386,7 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
         ordered.append(movements_by_key[_SOUTIENS_THEME])
 
     formal_findings = _collect_formal_findings(state)
+    virtuous_mode = detect_virtuous_mode(state)
 
     return Act2Evidence(
         movements=ordered,
@@ -386,6 +395,7 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
         args_total=len(args),
         fallacies_total=fallacies_total,
         unattributed_fallacies=unattributed_fallacies,
+        virtuous_mode=virtuous_mode,
     )
 
 
@@ -527,6 +537,24 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
     static template (#1108/#405). It instructs the LLM to weave each movement
     and to cite only the verified formal verdicts provided.
     """
+    # --- Mode vertueux (spec §5) — le récit mène avec pourquoi ça tient ---
+    vm = evidence.virtuous_mode
+    is_virtuous = vm is not None and vm.is_virtuous
+    if is_virtuous:
+        virtuous_section = (
+            "MODE VIRTUEUX (spec §5) — LE RÉCIT MÈNE AVEC POURQUOI ÇA TIENT :\n"
+            "Ce texte est caractérisé comme vertueux (zéro sophisme localisé +\n"
+            "vertus mesurées). Le mouvement des soutiens est le CENTRE du récit,\n"
+            "pas un résidu. Tisse d'abord ce qui tient : le caractère (vertus),\n"
+            "la cohérence, et — si le solveur a validé des inférences — la tenue\n"
+            "formelle comme PREUVE que l'argumentation ne dérape pas. Peu (aucun)\n"
+            "contre-argument ne mord : c'est le résultat honnête, ne le présente\n"
+            "pas comme un manque. Ne fabrique JAMAIS de dérapage pour équilibrer.\n"
+            f"Dérivation du flag : {vm.reasoning if vm is not None else ''}\n\n"
+        )
+    else:
+        virtuous_section = ""
+
     # --- movement data blocks (truncated, opaque) ---
     blocks: List[str] = []
     for mvt in evidence.movements:
@@ -591,6 +619,7 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
         "par MOUVEMENT argumentatif, PAS par dimension analytique.\n\n"
         f"{_OPAQUE_ID_DIRECTIVE}\n\n"
         f"{_WEAVING_RULE}\n\n"
+        f"{virtuous_section}"
         "DONNÉES VERIFIÉES DANS LE STATE (ne citer que celles-ci) :\n\n"
         f"{chr(10).join(blocks)}\n\n"
         f"TENUE FORMELLE (ancres vérifiées, à tisser comme PREUVE d'un battement) :\n"
@@ -705,7 +734,18 @@ async def build_act2_narrative(
             "Axe qualité non concluable ici (argument_quality_scores "
             "indisponible) — vertus tues, fail-loud."
         )
+    vm = evidence.virtuous_mode
+    is_virtuous = vm is not None and vm.is_virtuous
+    if vm is not None and vm.is_virtuous:
+        degraded["act2_virtuous_mode"] = (
+            "Mode vertueux (spec §5) — récit mené par pourquoi ça tient. "
+            + vm.reasoning
+        )
 
     return Act2Result(
-        narrative=narrative, status="woven", gate_verdict=verdict, degraded=degraded
+        narrative=narrative,
+        status="woven",
+        gate_verdict=verdict,
+        degraded=degraded,
+        is_virtuous=is_virtuous,
     )

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -52,6 +52,7 @@ from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from .readability_gate import GateVerdict, ReadabilityGate
+from .virtuous_identification import VirtuousModeAssessment, detect_virtuous_mode
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,10 @@ class Act3Evidence:
     verdict: Optional[VerdictBand] = None
     narrative_synthesis_available: bool = False
     gates: Dict[str, bool] = field(default_factory=dict)
+    # DERIVED virtuous flag (spec §5.1) — drives virtue-first titling when the
+    # state characterises the text as virtuous (zero fallacies + non-trivial
+    # quality/formal axis). None until build_act3_evidence populates it.
+    virtuous_mode: Optional[VirtuousModeAssessment] = None
 
 
 @dataclass
@@ -170,6 +175,9 @@ class Act3Result:
     status: str
     gate_verdict: Optional[GateVerdict] = None
     degraded: Dict[str, str] = field(default_factory=dict)
+    # True when the conclusion was conducted in virtuous mode (spec §5) — the
+    # headline titles on the measured virtues, not on the absence of fallacies.
+    is_virtuous: bool = False
 
 
 # --- deterministic evidence builder (no LLM) ---------------------------------
@@ -183,16 +191,31 @@ def _truncate(text: Any, cap: int) -> str:
     return s if len(s) <= cap else s[:cap].rstrip() + " […]"
 
 
+def _pl_verdict(result: Dict[str, Any]) -> Optional[bool]:
+    """Read a PL analysis verdict as a strict bool, or None when unverified.
+
+    Canonical PL key is ``satisfiable`` (shared_state.add_propositional_analysis_result,
+    #1151 Finding C); ``consistent`` is the legacy/FOL-shared key kept as a
+    fallback. Preserves the strict ``True``/``False``/``None`` semantics so an
+    unverified theory is never conflated with an inconsistent one (#1019) — do
+    NOT collapse to ``bool()``.
+    """
+    sat = result.get("satisfiable")
+    if sat is None:
+        sat = result.get("consistent")
+    return sat if isinstance(sat, bool) else None
+
+
 def _pl_inconsistent(state: Any) -> int:
-    """Count PL inferences the Tweety solver found inconsistent (real-in-state)."""
+    """Count PL inferences the Tweety solver found inconsistent (real-in-state).
+
+    Uses ``_pl_verdict`` (canonical ``satisfiable`` key) so the PL axis is read
+    the same way as the FOL axis and the virtuous-mode detector — #1151 C.
+    """
     pl = getattr(state, "propositional_analysis_results", None)
     if not isinstance(pl, list):
         return 0
-    return sum(
-        1
-        for r in pl
-        if isinstance(r, dict) and r.get("consistent") is False
-    )
+    return sum(1 for r in pl if isinstance(r, dict) and _pl_verdict(r) is False)
 
 
 def _fol_inconsistent(state: Any) -> int:
@@ -320,7 +343,12 @@ def _collect_quality_strengths(quality: Dict[str, Any]) -> List[QualityStrength]
     for _arg, qs in quality.items():
         if not isinstance(qs, dict):
             continue
-        spv = qs.get("scores_par_vertu")
+        # Canonical writer key is ``scores`` (shared_state.add_quality_score,
+        # #1150/#1151); ``scores_par_vertu`` is the legacy key kept as a
+        # fallback for any external source. Same {virtue: float} mapping.
+        spv = qs.get("scores")
+        if not isinstance(spv, dict):
+            spv = qs.get("scores_par_vertu")
         if not isinstance(spv, dict):
             continue
         for vname, vval in spv.items():
@@ -457,6 +485,7 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
     }
 
     verdict = _compute_verdict_band(axes_nontrivial)
+    virtuous_mode = detect_virtuous_mode(state)
 
     return Act3Evidence(
         args_total=args_total,
@@ -469,6 +498,7 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
         verdict=verdict,
         narrative_synthesis_available=narrative_synthesis_available,
         gates=gates,
+        virtuous_mode=virtuous_mode,
     )
 
 
@@ -572,6 +602,31 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
     else:
         synthesis_block = "Bande de verdict : NON CALCULABLE (gates G1–G4 non passés)."
 
+    # --- Mode vertueux (spec §5) — titre sur les vertus quand l'état le dit ---
+    vm = evidence.virtuous_mode
+    is_virtuous = vm is not None and vm.is_virtuous
+    if is_virtuous:
+        virtuous_section = (
+            "MODE VIRTUEUX (spec §5) — DÉCISION DE TITRE :\n"
+            "Le TITRE de l'Acte III porte sur ce qui TIENT : les vertus mesurées,\n"
+            "la robustesse formelle, la tenue des schemes. Le pipeline n'a localisé\n"
+            "AUCUN sophisme sur ce texte — ce n'est pas un manque à combler, c'est\n"
+            "le résultat honnête. Ne fabrique JAMAIS de sophisme ni de point faible\n"
+            "pour remplir un battement (anti-pendule #1019/#369). Si un battement\n"
+            "manque de matière faiblesse, titre sur la force qui le justifie.\n"
+            f"Dérivation du flag : {vm.reasoning if vm is not None else ''}\n\n"
+        )
+        consigne_virtue = (
+            "- MODE VIRTUEUX : ouvre la synthèse en caractérisant le discours par\n"
+            "  ses vertus (ce qui tient). L'appréciation mène avec les forces ; les\n"
+            "  faiblesses (si aucune localisée) s'effacent honnêtement. Le « que\n"
+            "  faire » devient « comment s'appuyer sur ce qui tient / le préserver »\n"
+            "  plutôt que « comment contrer ».\n"
+        )
+    else:
+        virtuous_section = ""
+        consigne_virtue = ""
+
     # --- Appréciations (forces + faiblesses) ---
     if evidence.quality_strengths:
         strengths_lines = "\n".join(
@@ -632,6 +687,7 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         f"{_OPAQUE_ID_DIRECTIVE}\n\n"
         f"{_WEAVING_RULE}\n\n"
         f"{_FAIL_LOUD_INSTRUCTION}\n\n"
+        f"{virtuous_section}"
         "DONNÉES VERIFIÉES DANS LE STATE (ne citer que celles-ci) :\n\n"
         f"[SYNTHÈSE HONNÊTE — verdict gated]\n{synthesis_block}\n\n"
         f"[APPRÉCIATIONS — forces (qualité)]\n{strengths_lines}\n\n"
@@ -640,6 +696,7 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         f"[QUE FAIRE — points faibles à viser]\n{target_lines}\n\n"
         f"{what_next_block}\n\n"
         "CONSIGNE DE RÉDACTION :\n"
+        f"{consigne_virtue}"
         "- Rédige 3 paragraphes thématiques (un par battement), en prose lisible,\n"
         "  pas une liste de champs. Titres thématiques en ###.\n"
         "- Le verdict formel (Tweety/Dung) appuie un battement : formule-le comme\n"
@@ -769,12 +826,26 @@ async def build_act3_conclusion(
             "Axe qualité non concluable ici (argument_quality_scores "
             "indisponible) — appréciations limitées aux faiblesses, fail-loud."
         )
-    if not evidence.weak_points:
-        degraded["act3_conclusion_virtuous"] = (
-            "Aucun point faible localisé — conclusion bascule en mode texte "
-            "vertueux (forces en titre)."
+    vm = evidence.virtuous_mode
+    is_virtuous = vm is not None and vm.is_virtuous
+    if vm is not None and vm.is_virtuous:
+        degraded["act3_virtuous_mode"] = (
+            "Mode vertueux (spec §5) — titre sur les vertus. " + vm.reasoning
+        )
+    elif not evidence.weak_points:
+        # Defensive: no weak points AND not flagged virtuous (an empty-ish run
+        # that still passed G1). Honest note — not a positive virtuous claim,
+        # since no non-trivial axis qualified the text as virtuous.
+        degraded["act3_conclusion"] = (
+            "Aucun point faible localisé et aucun axe vertueux non-trivial — "
+            "la conclusion titre sur les forces disponibles sans claim vertueux "
+            "non dérivé (fail-loud)."
         )
 
     return Act3Result(
-        narrative=narrative, status="woven", gate_verdict=verdict, degraded=degraded
+        narrative=narrative,
+        status="woven",
+        gate_verdict=verdict,
+        degraded=degraded,
+        is_virtuous=is_virtuous,
     )

--- a/argumentation_analysis/reporting/restitution/virtuous_identification.py
+++ b/argumentation_analysis/reporting/restitution/virtuous_identification.py
@@ -365,3 +365,196 @@ def render_inventory_report(inv: VirtuousInventory) -> str:
     )
     lines.append("")
     return "\n".join(lines)
+
+
+# ===========================================================================
+# volet-2 — DERIVED virtuous flag from pipeline output (spec §5.1)
+# ===========================================================================
+#
+# Volet-1 (``identify``) is the cheap lexical CANDIDATE screen over the
+# *dataset* — it narrows which entries are worth a pipeline run. Volet-2 is the
+# *report mode*: once a pipeline has run, the DERIVED flag says whether the
+# output characterises the text as virtuous. The two answer the same question
+# ("is this virtuous?") at different stages, with different inputs (dataset
+# definitions vs a run ``state``) — hence they live together in this module.
+#
+# Spec §5.1 is unambiguous: a corpus input is virtuous iff its PIPELINE OUTPUT
+# shows (a) a low/zero localized-fallacy count AND (b) a non-trivial formal or
+# quality axis. The flag is **derived, never asserted**. Spec §5 adds: the
+# virtuous variant is NOT a separate skeleton — it is the same 3 acts with the
+# emphasis shifted by what the state actually contains. ``detect_virtuous_mode``
+# is the single source of truth that each act consults to shift its emphasis.
+
+# Transparent, fixed thresholds (anti-pendule: no curve, no tuning).
+# A text is virtuous-titled iff it has ZERO localized fallacies AND a
+# non-trivial quality/formal axis. We do NOT title on virtue when a fallacy is
+# located — that would hide a real weakness behind a virtue headline. The
+# non-trivial-axis guard prevents an empty run (0 fallacies, 0 quality, 0
+# formal) from being misread as virtuous (spec §5.1: "so an empty run is not
+# misread as virtuous").
+_VIRTUOUS_MAX_LOCALIZED_FALLACIES = 0
+
+
+@dataclass
+class VirtuousModeAssessment:
+    """DERIVED virtuous-mode flag (spec §5.1) — from pipeline output, never asserted.
+
+    A corpus input is virtuous iff its pipeline output shows (a) zero localized
+    fallacies AND (b) a non-trivial **quality** axis — measured virtues the
+    evaluator scored > 0. The quality axis is the *title material*: Acte III
+    titles on the virtues (spec §5 / DoD #1139), which requires measured virtues
+    to title on. ``formal_holds`` (a PL/FOL theory the solver validated) is a
+    strengthening signal surfaced for the "why it holds" narrative (Acte II),
+    NOT a standalone titling qualifier — a formally-robust text with no measured
+    virtues is told via its formal tenue, not via a virtue title. This keeps the
+    flag aligned with the G2 non-triviality gate (quality is a G2 axis) and with
+    the DoD ("les vertus sont en titre").
+
+    The flag is **derived from state**, never from lexical evidence alone, and
+    never fabricated. It governs *emphasis* in the report (the acts title on the
+    virtues instead of on the absence of fallacies), per spec §5: "the same 3
+    acts with the emphasis shifted by what the state actually contains". It
+    never authorises fabricating a fallacy to fill a beat (anti-pendule
+    #1019/#369).
+    """
+
+    is_virtuous: bool
+    fallacy_count: int
+    quality_virtues_present: bool
+    formal_holds: bool
+    reasoning: str
+
+
+def _quality_virtue_names(state: Any) -> List[str]:
+    """Return the measured virtue names across all scored arguments.
+
+    Reads the canonical writer key ``scores`` (shared_state.add_quality_score,
+    #1150/#1151) with a ``scores_par_vertu`` legacy fallback. A virtue counts
+    when at least one argument scored it > 0. De-duplicated, order-preserving.
+    Empty when no usable per-virtue map is present.
+    """
+    quality = getattr(state, "argument_quality_scores", {}) or {}
+    if not isinstance(quality, dict):
+        return []
+    names: List[str] = []
+    for _arg, qs in quality.items():
+        if not isinstance(qs, dict):
+            continue
+        spv = qs.get("scores")
+        if not isinstance(spv, dict):
+            spv = qs.get("scores_par_vertu")
+        if not isinstance(spv, dict):
+            continue
+        for vname, vval in spv.items():
+            if isinstance(vval, (int, float)) and float(vval) > 0:
+                names.append(str(vname))
+    seen: set[str] = set()
+    unique: List[str] = []
+    for n in names:
+        if n not in seen:
+            seen.add(n)
+            unique.append(n)
+    return unique
+
+
+def _localized_fallacy_count(state: Any) -> int:
+    """Count fallacies located on an identified argument (target_argument_id set).
+
+    Unresolved fallacies (no target) are NOT counted — they do not characterize
+    the discourse as fallacy-laden (they may be a resolution gap). Mirrors the
+    ``fallacies_total`` definition used by the act plugins.
+    """
+    fallacies = getattr(state, "identified_fallacies", {}) or {}
+    if not isinstance(fallacies, dict):
+        return 0
+    return sum(
+        1
+        for _f, d in fallacies.items()
+        if isinstance(d, dict) and (d.get("target_argument_id") or "")
+    )
+
+
+def _formal_holds(state: Any) -> bool:
+    """True iff at least one formal theory was checked AND found consistent.
+
+    The POSITIVE formal signal (an inference the solver validated), not the
+    absence of formal results. Reads the canonical PL key ``satisfiable``
+    (#1151 Finding C) with a ``consistent`` fallback, and the FOL ``consistent``
+    key. A verdict of ``True`` counts; an absent verdict never does
+    (anti-pendule: never read absence of a verdict as success, #1019).
+    """
+    pl = getattr(state, "propositional_analysis_results", None)
+    if isinstance(pl, list):
+        for r in pl:
+            if isinstance(r, dict):
+                sat = r.get("satisfiable")
+                if sat is None:
+                    sat = r.get("consistent")
+                if sat is True:
+                    return True
+    fol = getattr(state, "fol_analysis_results", None)
+    if isinstance(fol, list):
+        for r in fol:
+            if isinstance(r, dict) and r.get("consistent") is True:
+                return True
+    return False
+
+
+def detect_virtuous_mode(state: Any) -> VirtuousModeAssessment:
+    """DERIVED virtuous-mode flag from pipeline output (spec §5.1).
+
+    The single source of truth for "is this text virtuous?" across the three
+    act plugins (Acte I anticipation, Acte II why-it-holds, Acte III virtue
+    titling). Operates on a shared ``state`` (pipeline output); never on lexical
+    evidence (that is volet-1's cheap screen, which only narrows candidates).
+
+    Returns a :class:`VirtuousModeAssessment`. ``reasoning`` is an opaque
+    one-line justification (counts + which axis qualifies) so each act can
+    surface it honestly — it carries no source name and no corpus text.
+
+    Anti-pendule: the flag is AND of two real signals (zero localized fallacies
+    AND a non-trivial axis). It never inflates: an empty run is explicitly
+    non-virtuous, and a single located fallacy disqualifies virtue-titling.
+    """
+    fallacy_count = _localized_fallacy_count(state)
+    virtues = _quality_virtue_names(state)
+    quality_present = bool(virtues)
+    formal_holds = _formal_holds(state)
+
+    low_fallacies = fallacy_count <= _VIRTUOUS_MAX_LOCALIZED_FALLACIES
+    # Quality drives the titling flag (the title material). formal_holds is a
+    # strengthening signal, not a standalone qualifier (see class docstring).
+    is_virtuous = low_fallacies and quality_present
+
+    if is_virtuous:
+        title_axes: List[str] = [f"vertus mesurées ({', '.join(sorted(virtues))})"]
+        if formal_holds:
+            title_axes.append("robustesse formelle (solveur valide les inférences)")
+        reasoning = (
+            "0 sophisme localisé + vertus mesurées ("
+            + "; ".join(title_axes)
+            + ") → mode vertueux (titre sur les vertus, spec §5)."
+        )
+    elif low_fallacies and formal_holds and not quality_present:
+        reasoning = (
+            "0 sophisme localisé + robustesse formelle validée, MAIS aucune "
+            "vertu mesurée (argument_quality_scores vide) → pas de titre vertueux "
+            "(pas de matière vertu) ; l'Acte II raconte la tenue formelle."
+        )
+    else:
+        reasons: List[str] = []
+        if not low_fallacies:
+            reasons.append(
+                f"{fallacy_count} sophisme(s) localisé(s) → ne titre pas sur les vertus"
+            )
+        if not quality_present:
+            reasons.append("aucune vertu mesurée (argument_quality_scores vide)")
+        reasoning = "Mode non-vertueux : " + " ; ".join(reasons) + "."
+
+    return VirtuousModeAssessment(
+        is_virtuous=is_virtuous,
+        fallacy_count=fallacy_count,
+        quality_virtues_present=quality_present,
+        formal_holds=formal_holds,
+        reasoning=reasoning,
+    )

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act1_framing_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act1_framing_plugin.py
@@ -366,3 +366,52 @@ class TestConsumedByRenderer:
         assert _WOVEN_FRAMING.splitlines()[0] in report.markdown
         # act2/act3 are missing → reported honestly, not silently dropped.
         assert "indisponible" in report.markdown.lower() or "acte" in report.markdown.lower()
+
+
+# ============================================================================
+# R5 volet-2 (#1139) — virtuous mode: Acte I anticipates "what could derail
+# but doesn't" (spec §5).
+# ============================================================================
+
+
+def _virtuous_state() -> SimpleNamespace:
+    """A virtuous text with framing: political genre + measured virtues, no fallacies."""
+    s = _political_state()
+    s.identified_fallacies = {}  # zero localized fallacies
+    s.argument_quality_scores = {
+        "arg_1": {"overall": 8.0, "scores": {"clarte": 8.0, "coherence": 8.0}},
+        "arg_2": {"overall": 7.5, "scores": {"pertinence": 7.5}},
+    }
+    return s
+
+
+class TestVirtuousMode:
+    def test_virtuous_state_flagged(self):
+        ev = build_act1_evidence(_virtuous_state())
+        assert ev.virtuous_mode is not None
+        assert ev.virtuous_mode.is_virtuous is True
+
+    def test_non_virtuous_state_not_flagged(self):
+        # _political_state has no quality scores → not virtuous (empty-run guard)
+        ev = build_act1_evidence(_political_state())
+        assert ev.virtuous_mode is not None
+        assert ev.virtuous_mode.is_virtuous is False
+
+    def test_prompt_shifts_to_anticipated_but_no_derailment(self):
+        ev = build_act1_evidence(_virtuous_state())
+        prompt = build_act1_prompt(ev)
+        assert "MODE VIRTUEUX" in prompt
+        assert "dérape pas" in prompt  # "ce qui aurait pu déraper et ne dérape pas"
+        # non-virtuous: no virtuous shift
+        ev2 = build_act1_evidence(_political_state())
+        assert "MODE VIRTUEUX" not in build_act1_prompt(ev2)
+
+    def test_virtuous_result_carries_positive_marker(self):
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act1_framing(
+                _virtuous_state(), llm_callable=_stub_llm(_WOVEN_FRAMING)  # type: ignore[arg-type]
+            )
+        )
+        assert result.is_virtuous is True
+        assert result.status == "woven"
+        assert "act1_virtuous_mode" in result.degraded

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
@@ -491,3 +491,64 @@ class TestConsumedByRenderer:
         assert _WOVEN_NARRATIVE.splitlines()[0] in report.markdown
         # act1/act3 are reported as missing (fail-loud), not silently dropped.
         assert "indisponible" in report.markdown.lower() or "acte" in report.markdown.lower()
+
+
+# ============================================================================
+# R5 volet-2 (#1139) — virtuous mode: Acte II narrates why the argumentation
+# holds (spec §5). The soutiens movement becomes the centrepiece.
+# ============================================================================
+
+
+def _virtuous_state() -> SimpleNamespace:
+    """A virtuous text: two clean arguments, no fallacies, measured virtues.
+
+    No attacks → both arguments form the 'soutiens' movement (what holds).
+    """
+    return _state(
+        identified_arguments={
+            "arg_1": "Un raisonnement causal étayé par des sources vérifiées.",
+            "arg_2": "Une conclusion qui suit logiquement ses prémisses.",
+        },
+        identified_fallacies={},  # zero localized fallacies
+        argument_quality_scores={
+            "arg_1": {"overall": 8.0, "scores": {"clarte": 8.0, "coherence": 8.5}},
+            "arg_2": {"overall": 7.5, "scores": {"coherence": 8.0, "pertinence": 7.0}},
+        },
+    )
+
+
+class TestVirtuousMode:
+    def test_virtuous_state_flagged(self):
+        ev = build_act2_evidence(_virtuous_state())
+        assert ev.virtuous_mode is not None
+        assert ev.virtuous_mode.is_virtuous is True
+        # no dérapages on a virtuous text — the single mouvement is the soutiens
+        assert ev.fallacies_total == 0
+        assert all(m.theme == "soutiens" for m in ev.movements)
+
+    def test_non_virtuous_state_not_flagged(self):
+        # _rich_state has a localized fallacy → not virtuous
+        ev = build_act2_evidence(_rich_state())
+        assert ev.virtuous_mode is not None
+        assert ev.virtuous_mode.is_virtuous is False
+
+    def test_prompt_leads_with_why_it_holds(self):
+        ev = build_act2_evidence(_virtuous_state())
+        prompt = build_act2_prompt(ev)
+        assert "MODE VIRTUEUX" in prompt
+        assert "tient" in prompt  # "pourquoi ça tient"
+        # non-virtuous: no virtuous lead
+        ev2 = build_act2_evidence(_rich_state())
+        assert "MODE VIRTUEUX" not in build_act2_prompt(ev2)
+
+    def test_virtuous_result_carries_positive_marker(self):
+        import asyncio
+
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act2_narrative(
+                _virtuous_state(), llm_callable=_stub_llm(_WOVEN_NARRATIVE)  # type: ignore[arg-type]
+            )
+        )
+        assert result.is_virtuous is True
+        assert result.status == "woven"
+        assert "act2_virtuous_mode" in result.degraded

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -84,11 +84,11 @@ def _rich_state() -> SimpleNamespace:
         argument_quality_scores={
             "arg_1": {
                 "overall": 4.2,
-                "scores_par_vertu": {"pertinence": 3.0, "clarte": 5.0},
+                "scores": {"pertinence": 3.0, "clarte": 5.0},
             },
             "arg_2": {
                 "overall": 7.8,
-                "scores_par_vertu": {"pertinence": 8.0, "coherence": 7.5},
+                "scores": {"pertinence": 8.0, "coherence": 7.5},
             },
         },
         counter_arguments=[
@@ -109,8 +109,8 @@ def _rich_state() -> SimpleNamespace:
             }
         },
         propositional_analysis_results=[
-            {"consistent": True},
-            {"consistent": False},
+            {"satisfiable": True},
+            {"satisfiable": False},
         ],
     )
 
@@ -442,3 +442,85 @@ class TestConsumedByRenderer:
         assert _WOVEN_CONCLUSION.splitlines()[0] in report.markdown
         # act1/act2 are reported as missing (fail-loud), not silently dropped.
         assert "indisponible" in report.markdown.lower() or "acte" in report.markdown.lower()
+
+
+# ============================================================================
+# R5 volet-2 (#1139) — virtuous mode: Acte III titles the virtues (spec §5).
+# ============================================================================
+
+
+def _virtuous_state() -> SimpleNamespace:
+    """A virtuous text: zero localized fallacies + measured quality virtues.
+
+    No fallacies, real per-virtue scores under the canonical ``scores`` key, a
+    PL inference the solver validated (formal robustness). The conclusion must
+    title on the virtues, not on the absence of fallacies (spec §5 / DoD #1139).
+    """
+    return _state(
+        identified_arguments={
+            "arg_1": "Un raisonnement causal étayé par des sources vérifiées.",
+            "arg_2": "Une conclusion qui suit logiquement ses prémisses.",
+        },
+        identified_fallacies={},  # zero localized fallacies — the honest result
+        argument_quality_scores={
+            "arg_1": {
+                "overall": 8.0,
+                "scores": {"clarte": 8.0, "coherence": 8.5, "pertinence": 7.5},
+            },
+            "arg_2": {
+                "overall": 7.5,
+                "scores": {"coherence": 8.0, "pertinence": 7.0},
+            },
+        },
+        propositional_analysis_results=[{"satisfiable": True}],  # inferences hold
+    )
+
+
+class TestVirtuousMode:
+    def test_virtuous_state_flagged(self):
+        ev = build_act3_evidence(_virtuous_state())
+        assert ev.virtuous_mode is not None
+        assert ev.virtuous_mode.is_virtuous is True
+        # no weak points on a virtuous text (nothing fabricated)
+        assert ev.weak_points == []
+
+    def test_non_virtuous_state_not_flagged(self):
+        # _rich_state has a localized fallacy → not virtuous (don't hide it)
+        ev = build_act3_evidence(_rich_state())
+        assert ev.virtuous_mode is not None
+        assert ev.virtuous_mode.is_virtuous is False
+
+    def test_prompt_titles_on_virtues_when_virtuous(self):
+        ev = build_act3_evidence(_virtuous_state())
+        prompt = build_act3_prompt(ev)
+        assert "MODE VIRTUEUX" in prompt
+        assert "TIENT" in prompt  # titles on what holds
+        # no fabrication instruction present when non-virtuous
+        ev2 = build_act3_evidence(_rich_state())
+        assert "MODE VIRTUEUX" not in build_act3_prompt(ev2)
+
+    def test_virtuous_result_carries_positive_marker(self):
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act3_conclusion(
+                _virtuous_state(), llm_callable=_stub_llm(_WOVEN_CONCLUSION)  # type: ignore[arg-type]
+            )
+        )
+        assert result.is_virtuous is True
+        assert result.status == "woven"
+        assert "act3_virtuous_mode" in result.degraded
+
+    def test_non_virtuous_result_no_virtuous_marker(self):
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act3_conclusion(
+                _rich_state(), llm_callable=_stub_llm(_WOVEN_CONCLUSION)  # type: ignore[arg-type]
+            )
+        )
+        assert result.is_virtuous is False
+        assert "act3_virtuous_mode" not in result.degraded
+
+    def test_no_fabricated_fallacy_in_virtuous_prompt(self):
+        # the virtuous prompt must NOT invent a weak point to fill a beat
+        ev = build_act3_evidence(_virtuous_state())
+        prompt = build_act3_prompt(ev)
+        assert "fabrique" in prompt.lower() or "ne fabrique" in prompt.lower()
+        assert ev.weak_points == []

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_virtuous_identification.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_virtuous_identification.py
@@ -12,13 +12,17 @@ pipeline run (spec §5.1). Tests assert that honest caveat is present.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from argumentation_analysis.reporting.restitution.virtuous_identification import (
     VirtuousCandidate,
     VirtuousInventory,
+    VirtuousModeAssessment,
     _extract_prose,
     _opaque_id,
+    detect_virtuous_mode,
     identify,
     render_inventory_report,
 )
@@ -210,3 +214,158 @@ class TestPrivacy:
         report = render_inventory_report(identify(defs))
         assert "pipeline" in report.lower()
         assert "unconfirmed" in report.lower() or "not assert" in report.lower()
+
+
+# ===========================================================================
+# volet-2 — DERIVED virtuous-mode flag from pipeline output (spec §5.1)
+# ===========================================================================
+#
+# ``detect_virtuous_mode`` reads a pipeline ``state`` (not the dataset). It is
+# the single source of truth the three act plugins consult to shift emphasis.
+# Deterministic: synthetic state stubs, no LLM/JVM/dataset.
+
+
+def _state(**fields: object) -> SimpleNamespace:
+    """A state stub with the virtuous-relevant fields defaulted empty."""
+    base = dict(
+        identified_arguments={},
+        identified_fallacies={},
+        argument_quality_scores={},
+        propositional_analysis_results=[],
+        fol_analysis_results=[],
+    )
+    base.update(fields)
+    return SimpleNamespace(**base)
+
+
+def _virtuous_state() -> SimpleNamespace:
+    """0 localized fallacies + measured quality virtues → virtuous (quality)."""
+    return _state(
+        identified_arguments={"arg_1": "Un raisonnement étayé et honnête."},
+        identified_fallacies={},  # zero localized fallacies
+        argument_quality_scores={
+            "arg_1": {
+                "overall": 7.5,
+                "scores": {"clarte": 8.0, "coherence": 7.0, "pertinence": 7.5},
+            }
+        },
+    )
+
+
+class TestDetectVirtuousMode:
+    def test_virtuous_zero_fallacies_plus_quality(self):
+        a = detect_virtuous_mode(_virtuous_state())
+        assert isinstance(a, VirtuousModeAssessment)
+        assert a.is_virtuous is True
+        assert a.fallacy_count == 0
+        assert a.quality_virtues_present is True
+
+    def test_virtuous_with_formal_bonus(self):
+        s = _virtuous_state()
+        s.propositional_analysis_results = [{"satisfiable": True}]  # PL holds
+        a = detect_virtuous_mode(s)
+        assert a.is_virtuous is True
+        assert a.formal_holds is True  # strengthening signal surfaced
+
+    def test_one_fallacy_disqualifies_virtue_titling(self):
+        # a located fallacy hides behind no virtue title (anti-pendule: honest)
+        s = _virtuous_state()
+        s.identified_fallacies = {
+            "fl_1": {"target_argument_id": "arg_1", "family": "ad hominem"}
+        }
+        a = detect_virtuous_mode(s)
+        assert a.is_virtuous is False
+        assert a.fallacy_count == 1
+        assert a.quality_virtues_present is True  # quality present, but overridden
+
+    def test_empty_run_not_misread_as_virtuous(self):
+        # 0 fallacies, 0 quality, 0 formal = empty run, NOT virtuous (spec §5.1)
+        a = detect_virtuous_mode(_state(identified_arguments={"arg_1": "x"}))
+        assert a.is_virtuous is False
+        assert a.quality_virtues_present is False
+
+    def test_formal_only_without_quality_not_virtue_titled(self):
+        # formally robust but no measured virtues → no virtue title material
+        s = _state(
+            identified_arguments={"arg_1": "x"},
+            propositional_analysis_results=[{"satisfiable": True}],
+        )
+        a = detect_virtuous_mode(s)
+        assert a.is_virtuous is False
+        assert a.formal_holds is True
+        assert a.quality_virtues_present is False
+        # reasoning honestly notes the formal robustness without claiming virtue
+        assert "formelle" in a.reasoning
+
+    def test_quality_canonical_scores_key(self):
+        # writer stores virtues under canonical 'scores' (Finding A, #1150)
+        s = _state(
+            identified_arguments={"arg_1": "x"},
+            argument_quality_scores={
+                "arg_1": {"overall": 6.0, "scores": {"clarte": 5.0}}
+            },
+        )
+        a = detect_virtuous_mode(s)
+        assert a.is_virtuous is True
+        assert a.quality_virtues_present is True
+
+    def test_quality_legacy_scores_par_vertu_fallback(self):
+        s = _state(
+            identified_arguments={"arg_1": "x"},
+            argument_quality_scores={
+                "arg_1": {"overall": 6.0, "scores_par_vertu": {"clarte": 5.0}}
+            },
+        )
+        assert detect_virtuous_mode(s).is_virtuous is True
+
+    def test_pl_canonical_satisfiable_key_for_formal_holds(self):
+        # writer stores PL verdict under canonical 'satisfiable' (Finding C)
+        s = _state(
+            identified_arguments={"arg_1": "x"},
+            propositional_analysis_results=[{"satisfiable": True}],
+            fol_analysis_results=[],
+        )
+        assert detect_virtuous_mode(s).formal_holds is True
+
+    def test_pl_legacy_consistent_fallback(self):
+        s = _state(
+            identified_arguments={"arg_1": "x"},
+            propositional_analysis_results=[{"consistent": True}],
+        )
+        assert detect_virtuous_mode(s).formal_holds is True
+
+    def test_fol_consistent_counts_as_formal_holds(self):
+        s = _state(
+            identified_arguments={"arg_1": "x"},
+            fol_analysis_results=[{"consistent": True}],
+        )
+        assert detect_virtuous_mode(s).formal_holds is True
+
+    def test_zero_virtue_score_not_counted(self):
+        # a virtue scored 0 is not "measured virtue" material
+        s = _state(
+            identified_arguments={"arg_1": "x"},
+            argument_quality_scores={"arg_1": {"overall": 0.0, "scores": {"clarte": 0.0}}},
+        )
+        assert detect_virtuous_mode(s).quality_virtues_present is False
+        assert detect_virtuous_mode(s).is_virtuous is False
+
+    def test_reasoning_carries_no_source_nor_prose(self):
+        # privacy HARD: reasoning is opaque counts + axis labels only
+        leak = "UNIQUE_LEAK_MARKER"
+        s = _state(
+            identified_arguments={"arg_1": leak},
+            identified_fallacies={},
+            argument_quality_scores={"arg_1": {"overall": 5.0, "scores": {"clarte": 5.0}}},
+        )
+        a = detect_virtuous_mode(s)
+        assert leak not in a.reasoning
+
+    def test_unresolved_fallacy_not_counted_as_localized(self):
+        # a fallacy with no target_argument_id is a resolution gap, not a
+        # characterization of the discourse as fallacy-laden
+        s = _virtuous_state()
+        s.identified_fallacies = {"fl_1": {"family": "ad hominem"}}  # no target
+        a = detect_virtuous_mode(s)
+        assert a.fallacy_count == 0
+        assert a.is_virtuous is True


### PR DESCRIPTION
## R5 volet-2 — mode texte vertueux (le positif en titre)

Epic **#1134** (Restitution), Track **R5 volet-2 #1139**. Dispatch coord **R433**. Closes #1139 (volet-2; end-to-end DoD reste gated sur le merge R6-final de po-2025 #1156).

**Mandate user** : « le moteur doit pouvoir tourner sur des textes vertueux — sur un texte vertueux, le positif est le titre. »

## Principe (spec §5)
La variante vertueuse n'est **pas un squelette séparé** — ce sont les 3 mêmes actes avec l'emphase décalée par ce que le state contient. Le générateur sélectionne l'emphasis depuis les données, ne l'invente jamais.

## Ce que fait cette PR

**`detect_virtuous_mode(state)`** (`virtuous_identification.py`) — source unique de vérité consultée par les 3 actes. Flag DERIVED (spec §5.1), jamais asserté :
- **Virtueux** = 0 sophisme localisé **ET** vertus qualité mesurées (>0) — la matière du titre.
- `formal_holds` (solveur valide une inférence) = signal de **renforcement**, pas qualificateur autonome (garde le flag aligné avec G2 + le DoD « les vertus sont en titre » ; un texte formellement robuste sans vertu mesurée est raconté via sa tenue formelle, pas titré sur des vertus absentes).
- **Anti-pendule** : un run vide (0 sophisme + 0 qualité + 0 formel) n'est **pas** lu comme vertueux (garde-fou spec §5.1) ; un seul sophisme localisé disqualifie le titrage vertueux ; rien n'est fabriqué.

**Actes** (consultent le flag, décalent l'emphase) :
- **Acte I** — anticipe « ce qui *pourrait* déraper mais ne dérape pas » (le spectre devient l'attente non concrétisée).
- **Acte II** — mène avec **pourquoi ça tient** (mouvement soutiens en centre, tenue formelle comme preuve, peu/aucun contre ne mord = résultat honnête).
- **Acte III** — **titre sur les vertus** (synthèse mène avec les forces, le « que faire » devient « comment s'appuyer sur ce qui tient »).

Chaque `Act*Result` gagne `is_virtuous` + un marqueur positif `actN_virtuous_mode`.

## Bonus cohérence (Finding A+C foldé dans act3)
`act3_conclusion_plugin.py` entre maintenant dans la lane R5 — j'y ai foldé les **mêmes fixes reader-side prouvés en #1151/#1153 pour act2** (ce fichier les avait aussi) :
- `_collect_quality_strengths` lit la clé canonique `scores` (+ fallback `scores_par_vertu`) — était `scores_par_vertu` → vertus act3 toujours vides en production (Finding A).
- `_pl_inconsistent` via un `_pl_verdict` local lisant `satisfiable` canonique (+ fallback `consistent`) — était `consistent` → verdicts PL manqués en production (Finding C).
- Fixture `_rich_state` du test act3 updatée aux clés canoniques pour **exercer réellement le fix** (les clés legacy restent couvertes par fallback + 1 test explicite).
- Nettoyage trivial : retrait d'un `# type: ignore[import-untyped]` mort sur `import yaml` (inutilisé sous `ignore_missing_imports=true` global).

## Collision guard (STRICT — parallèle à #1156)
**Mes fichiers** : `virtuous_identification.py`, `act1_framing_plugin.py`, `act2_narrative_plugin.py`, **`act3_conclusion_plugin.py`** (transféré à po-2023 pour R5, po-2025 est sur R6-final).
**Non touchés** (lane po-2025 #1156) : `renderer.py`, `acts.py`, `state_adapter.py`, `readability_gate.py`, `pipeline_adapter.py`, `unified_pipeline.py`.
**Contrat `RestitutionActs` INCHANGÉ** — le mode vertueux se décide dans les plugins, pas dans le contrat.

## DoD #1139
- [x] Détection vertueuse DERIVED (flag opaque depuis le state, jamais asserté).
- [x] Sur texte vertueux, Acte III titre sur les vertus ; **aucun sophisme fabriqué** pour remplir.
- [x] Acte I anticipe les non-dérapages ; Acte II raconte pourquoi ça tient.
- [x] **Aucune dégradation** sur les textes non-vertueux (non-régression : 134→161 tests verts, 0 casse).
- [ ] End-to-end « rapport vertueux complet » : **gated sur merge R6-final** #1156 (assemble act1+act2+act3 → renderer ; le mode vertueux se propage via les prompts conduits). Je peux enchaîner après merge des deux.

## Validation
- **mypy strict clean** sur les 4 fichiers source.
- **161 tests restitution verts** (134 existants + 27 nouveaux) : 14 policy-unit sur `detect_virtuous_mode` (canonical/legacy keys, empty-run guard, formal-only, privacy), + virtuous fixtures par acte (flag, prompt branch, result marker, no-fabrication).
- 0 LLM/JVM/dataset (state stubs déterministes).

## Privacy HARD
IDs opaques partout ; le détecteur ne lit que des counts et noms de vertus (constantes) ; `reasoning` opaque, aucun `raw_text`/source name (testé).

@ai-01 : review/merge. File-disjoint #1156 → merge parallèle. Cron `d2a469e8` :17 actif.

🤖 Worker po-2023 — R433/#1139 volet-2 livré