### PR TITLE
fix(restitution): #1151 §3(b) stakes extractor argument schema

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -6857,8 +6857,23 @@ async def _invoke_stakes_extractor(
 
     extractor = StakesExtractor()
 
-    # Gather arguments from state
-    arguments = list(getattr(state, "identified_arguments", []) or [])
+    # Gather arguments from state.
+    # Writer schema (shared_state.add_argument): identified_arguments is a
+    # dict {arg_id: description}. StakesExtractor.extract expects a list of
+    # argument dicts with a "text"/"description" key. The previous
+    # ``list(dict)`` passed bare arg_id keys (strings), which crashed
+    # ``arg.get("text", ...)`` inside extract on real (LLM-on) runs — masked
+    # by unit tests that mock LLM=None (extract short-circuits before the
+    # loop). Audit #1151 §3(b). Convert the dict-of-strings into the
+    # list-of-dicts the consumer's contract specifies (anti-pendule: feed the
+    # consumer what it asked for, no counterweight).
+    raw_args = getattr(state, "identified_arguments", {}) or {}
+    if isinstance(raw_args, dict):
+        arguments = [
+            {"text": desc} for desc in raw_args.values() if isinstance(desc, str)
+        ]
+    else:  # defensive: already a sequence of argument dicts (legacy/fixture)
+        arguments = list(raw_args)
 
     # Source metadata
     source_metadata = getattr(state, "source_metadata", {})

--- a/tests/unit/argumentation_analysis/orchestration/test_mute_capabilities_b02.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_mute_capabilities_b02.py
@@ -129,9 +129,10 @@ class TestInvokeStakesExtractor:
         """Stakes extractor runs on a populated state (LLM=None, fallback path)."""
         invoke = self._get_invoke()
         state = UnifiedAnalysisState("Test speech about economic reform.")
-        state.identified_arguments = [
-            {"id": "arg_1", "text": "We must reform the tax system."},
-        ]
+        # Real writer schema (shared_state.add_argument): dict {arg_id: desc}.
+        state.identified_arguments = {
+            "arg_1": "We must reform the tax system.",
+        }
         result = asyncio.get_event_loop().run_until_complete(
             invoke("", {"_state_object": state, "source_metadata": {}})
         )
@@ -147,12 +148,60 @@ class TestInvokeStakesExtractor:
         """Results are written to state.stakes_and_stakeholders."""
         invoke = self._get_invoke()
         state = UnifiedAnalysisState("Test speech about policy.")
-        state.identified_arguments = [{"id": "a1", "text": "Policy argument"}]
+        # Real writer schema: dict {arg_id: description}.
+        state.identified_arguments = {"a1": "Policy argument"}
         asyncio.get_event_loop().run_until_complete(
             invoke("", {"_state_object": state, "source_metadata": {}})
         )
         # state.stakes_and_stakeholders should be populated (even if empty)
         assert hasattr(state, "stakes_and_stakeholders")
+
+    @patch(
+        "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+        return_value=None,
+    )
+    def test_dict_arguments_passed_as_list_of_dicts(self, mock_client):
+        """Audit #1151 §3(b): identified_arguments is {arg_id: description}
+        (writer schema). StakesExtractor.extract must receive a list of dicts
+        with a 'text' key — not bare arg_id keys (which crashed extract's
+        ``arg.get("text")`` on real LLM-on runs). This pins the contract by
+        capturing what extract receives, bypassing the LLM=None short-circuit
+        that previously masked the bug."""
+        invoke = self._get_invoke()
+        state = UnifiedAnalysisState("Test speech about reform.")
+        state.identified_arguments = {
+            "arg_1": "We must reform the tax system.",
+            "arg_2": "Reform will reduce inequality.",
+        }
+        captured = {}
+
+        class _StubExtractor:
+            def extract(self, **kwargs):
+                captured.update(kwargs)
+                return {
+                    "stakes": [],
+                    "stakeholders": [],
+                    "rhetorical_register": "",
+                    "discursive_arena": "",
+                }
+
+        with patch(
+            "argumentation_analysis.agents.core.political.stakes_extractor"
+            ".StakesExtractor",
+            return_value=_StubExtractor(),
+        ):
+            asyncio.get_event_loop().run_until_complete(
+                invoke("", {"_state_object": state, "source_metadata": {}})
+            )
+        args = captured.get("arguments", [])
+        # Contract: extract receives a list of dicts each with "text".
+        assert isinstance(args, list), args
+        assert all(isinstance(a, dict) and "text" in a for a in args), args
+        texts = [a["text"] for a in args]
+        assert "We must reform the tax system." in texts
+        assert "Reform will reduce inequality." in texts
+        # No bare arg_id keys leak through.
+        assert "arg_1" not in texts and "arg_2" not in texts
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`_invoke_stakes_extractor` read `list(getattr(state, "identified_arguments", []))`. Since `identified_arguments` is a **dict** `{arg_id: description}` (writer schema, [shared_state.py:103](argumentation_analysis/core/shared_state.py#L103)), `list(dict)` passed **bare arg_id keys** (strings) to `StakesExtractor.extract` — which expects `List[Dict]` with a `"text"`/`"description"` key and calls `arg.get("text", ...)` on each. On real (LLM-on) runs that's an **AttributeError** crashing stakes extraction.

## Why it was invisible

Unit tests mock `LLM=None`; `extract` short-circuits to an empty result **before** the arguments loop — so the crash never fired in tests, only in real runs. Same *"fixture encodes the consumer's expected contract, not the writer's real schema"* pattern as Finding A/C/D (#1154).

This is **§3(b)** from po-2023's audit #1151 — assigned to po-2025's lane (R432) and folded here as promised.

## Fix (anti-pendule)

Convert the dict-of-strings into the list-of-dicts the consumer's contract specifies, at the single call site — feed the consumer what it asked for, no counterweight. Defensive fallback for a sequence-of-dicts (legacy/fixture) preserved.

```python
raw_args = getattr(state, "identified_arguments", {}) or {}
if isinstance(raw_args, dict):
    arguments = [{"text": desc} for desc in raw_args.values() if isinstance(desc, str)]
else:  # defensive: already a sequence of argument dicts (legacy/fixture)
    arguments = list(raw_args)
```

## Tests

- Realigned the 2 stakes fixtures to the writer schema (`{arg_id: desc}`).
- **Added `test_dict_arguments_passed_as_list_of_dicts`**: pins the contract by capturing what `extract` receives (bypasses the LLM=None short-circuit that masked the bug) — asserts a list of dicts each with `"text"`, real descriptions present, no bare arg_id keys leaking.

## Validation

- **mypy strict** (`invoke_callables.py` = CI-gated): **Success, 0 issues**
- mute_capabilities + stakes tests: **26 passed**
- Restitution suite: **134 passed** (0 regression)
- **0 LLM spend**

Refs #1151. File-disjoint from #1154 (act2) and R5-v2 (act plugins) — `invoke_callables.py` is po-2025's infra lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)