### PR TITLE
fix(restitution): #1167 Track D1 — digestion keystone (fallacy attribution + deep_synthesis wiring + Dung/verdict)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -4002,7 +4002,40 @@ async def _invoke_hierarchical_fallacy_per_argument(
             section AND the convergence layer (fallacy is one of its inputs).
             The one-shot is a single taxonomy-mapped call, so it recovers
             recall cheaply when the API is slow.
+
+            D1a (#1167): enrich every emitted fallacy with the grounded arg
+            link so the state writer (_write_hierarchical_fallacy_to_state)
+            can attach it to arg_1..N. The plugin's IdentifiedFallacy model
+            has ``problematic_quote`` but the descent never populates it and
+            the confirm_fallacy tool emits no quote; without this enrichment
+            the fallacies arrive orphaned ({type, justification} only) and
+            the writer's text-match fallbacks cannot link them. We attach:
+              - ``target_argument`` = arg_id (a real id from state.identified_
+                arguments, or "arg_N" from the extract phase) — the writer
+                resolves it by direct ID match;
+              - ``problematic_quote`` = a verbatim span capped from the
+                argument text (privacy: stays in-memory in the state, results
+                are gitignored) — the writer's text-match fallback anchor.
+            This surfaces what the descent already grounded (which argument
+            it analyzed) — it does NOT fabricate family/target (anti-pendule).
             """
+
+            def _enrich_fallacies(res: Dict[str, Any]) -> None:
+                """Attach grounded arg link to each fallacy dict in-place."""
+                fallacies = res.get("fallacies")
+                if not isinstance(fallacies, list):
+                    return
+                # Verbatim span: cap to keep the quote a tight anchor (privacy +
+                # match precision — the writer matches on desc[:60] prefixes).
+                quote_span = arg_text.strip()[:200]
+                for f in fallacies:
+                    if not isinstance(f, dict):
+                        continue
+                    # Do not overwrite an explicit plugin-provided target.
+                    if not f.get("target_argument"):
+                        f["target_argument"] = arg_id
+                    if not f.get("problematic_quote") and quote_span:
+                        f["problematic_quote"] = quote_span
             plugin = None
             try:
                 master_kernel = Kernel()
@@ -4020,6 +4053,7 @@ async def _invoke_hierarchical_fallacy_per_argument(
                 )
                 result: Dict[str, Any] = json.loads(result_json)
                 result["source_arg_id"] = arg_id
+                _enrich_fallacies(result)
                 return result
             except asyncio.TimeoutError:
                 logger.warning(
@@ -4037,6 +4071,7 @@ async def _invoke_hierarchical_fallacy_per_argument(
                         oneshot: Dict[str, Any] = json.loads(oneshot_json)
                         oneshot["source_arg_id"] = arg_id
                         oneshot["timed_out_fallback"] = True
+                        _enrich_fallacies(oneshot)
                         return oneshot
                     except Exception as e:
                         logger.warning(

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -390,11 +390,26 @@ def _write_hierarchical_fallacy_to_state(
             full_justification += f" [confidence:{confidence:.2f}]"
         if trace:
             full_justification += f" [trace:{'>'.join(trace)}]"
-        # Resolve target argument: try target_argument first (if present),
-        # then problematic_quote (exact text from the source), then explanation.
-        target_arg_id = f.get("target_argument_id") or _resolve_target_arg_id(
-            state, f.get("target_argument", "")
-        )
+        # Resolve target argument. Resolution order (D1a #1167 — surface what
+        # the per-argument descent already grounded, do NOT invent a link):
+        #   1. ``target_argument_id`` — an explicit arg_id carried by the plugin.
+        #   2. ``source_arg_id`` — set by the per-argument harness
+        #      (_invoke_hierarchical_fallacy_per_argument) to the arg_id the
+        #      descent analyzed this fallacy against. It IS a real arg_id from
+        #      state.identified_arguments (or "arg_N" from the extract phase),
+        #      so it is the most reliable grounded link — the wide-net fallacies
+        #      arrive with no quote/target and were orphaned without this.
+        #   3. text-match fallbacks (target_argument / problematic_quote /
+        #      explanation) for wide-net fallacies without a source_arg_id.
+        target_arg_id = f.get("target_argument_id")
+        if not target_arg_id:
+            _source_arg_id = str(f.get("source_arg_id") or "")
+            if _source_arg_id and _source_arg_id in state.identified_arguments:
+                target_arg_id = _source_arg_id
+        if not target_arg_id:
+            target_arg_id = _resolve_target_arg_id(
+                state, f.get("target_argument", "")
+            )
         if not target_arg_id:
             target_arg_id = _resolve_target_arg_id(
                 state, f.get("problematic_quote", "")
@@ -902,6 +917,45 @@ def _write_narrative_synthesis_to_state(
         state.narrative_synthesis = narrative
 
 
+def _write_deep_synthesis_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
+    """Write the DeepSynthesisAgent grounded synthesis to UnifiedAnalysisState.
+
+    D1b (#1167 / Epic #1165): the spectacular workflow runs the
+    ``deep_synthesis`` phase (DeepSynthesisAgent, ~74s, LLM-conducted grounded
+    FB-18 synthesis with [artifact:] citations + value-gates) but no writer
+    existed in ``CAPABILITY_STATE_WRITERS`` — the output was dropped and
+    ``state.narrative_synthesis`` stayed empty, so Acte III (which reads it
+    via ``getattr(state, "narrative_synthesis", None)``) never saw the most
+    global component. This writer surfaces it.
+
+    The agent output (see ``_invoke_deep_synthesis``) carries:
+      - ``grounded_synthesis`` — the grounded FB-18 prose (the headline);
+      - ``value_gates`` — VG1-4 dict (persisted onto workflow_results when
+        present, the state has no dedicated attr);
+      - ``report`` — the full structured report (kept available on the state
+        trace for downstream consumers).
+    Empty/unavailable results are left as the empty default so the gap is
+    reported honestly (fail-loud, #1108/#1019 — never fabricate here).
+    """
+    if not output or not isinstance(output, dict):
+        return
+    grounded = output.get("grounded_synthesis", "")
+    if isinstance(grounded, str) and grounded.strip():
+        state.narrative_synthesis = grounded
+    # Persist the value-gates verdict where the state supports it. The state
+    # has no dedicated value_gates attr; workflow_results is the generic bag.
+    value_gates = output.get("value_gates")
+    if isinstance(value_gates, dict) and value_gates:
+        try:
+            existing = getattr(state, "workflow_results", None)
+            if isinstance(existing, dict):
+                existing["deep_synthesis_value_gates"] = value_gates
+        except Exception:  # noqa: BLE001 — non-fatal: state may lock the attr
+            pass
+
+
 def _write_act2_narrative_to_state(
     output: Any, state: Any, ctx: dict[str, Any]
 ) -> None:
@@ -1130,6 +1184,7 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "collaborative_analysis": _write_collaborative_analysis_to_state,
     "nl_to_logic_translation": _write_nl_to_logic_to_state,
     "narrative_synthesis": _write_narrative_synthesis_to_state,
+    "deep_synthesis": _write_deep_synthesis_to_state,
     "act2_narrative": _write_act2_narrative_to_state,
     "act1_framing": _write_act1_framing_to_state,
     "act3_conclusion": _write_act3_conclusion_to_state,

--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -494,7 +494,7 @@ def _collect_formal_findings(state: Any) -> List[FormalFinding]:
                     f"{len(dung_rejected)} argument(s) rejeté(s) par le cadre "
                     f"abstrait de Dung (sémantique: {', '.join(sems)})"
                 ),
-                detail="cadre de Dung — attaque défaillante isolée",
+                detail="cadre de Dung — argument rejeté (absent de l'extension acceptée)",
             )
         )
 
@@ -631,8 +631,11 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
         "(sophisme localisé + descente + contre-argument), et sa tenue formelle "
         "citée comme preuve.\n"
         "- Le verdict formel (Tweety/Dung) appuie le battement ; formule-le comme "
-        "« le solveur Tweety confirme l'inconsistance de cette inférence » ou "
-        "« le cadre de Dung isole cette attaque comme défaillante ».\n"
+        "« le solveur Tweety confirme l'inconsistance de cette inférence » "
+        "(théorie inconsistante), « le solveur Tweety confirme la cohérence de "
+        "cette inférence » (théorie consistante — un résultat formel aussi) ou "
+        "« le cadre de Dung isole cet argument comme rejeté/défaillant » "
+        "(argument absent de l'extension acceptée).\n"
         "- Si un mouvement n'a ni sophisme ni verdict formel (les soutiens), "
         "dis ce qui le tient (le caractère, la cohérence).\n"
         "- Le récit doit VARIER selon le contenu réel ci-dessus : pas de prose\n"

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -218,6 +218,25 @@ def _pl_inconsistent(state: Any) -> int:
     return sum(1 for r in pl if isinstance(r, dict) and _pl_verdict(r) is False)
 
 
+def _pl_verified(state: Any) -> int:
+    """Count PL theories the Tweety solver verified (any verdict, real-in-state).
+
+    D1c (#1167): a CONSISTENT PL theory (``satisfiable is True``) is a real
+    formal result, not a non-event — the solver ran and confirmed the
+    discourse's propositional structure holds. The formal axis must credit it
+    as non-trivial so a coherent text (no inconsistency) still surfaces a
+    formal finding (satisfiable IS a result). Counts True AND False verdicts;
+    unverified (None) theories are excluded — #1019 (never ``bool()`` a formal
+    verdict: None ≠ False).
+    """
+    pl = getattr(state, "propositional_analysis_results", None)
+    if not isinstance(pl, list):
+        return 0
+    return sum(
+        1 for r in pl if isinstance(r, dict) and _pl_verdict(r) is not None
+    )
+
+
 def _fol_inconsistent(state: Any) -> int:
     """Count FOL theories the Tweety solver found inconsistent (real-in-state)."""
     fol = getattr(state, "fol_analysis_results", None)
@@ -227,6 +246,24 @@ def _fol_inconsistent(state: Any) -> int:
         1
         for r in fol
         if isinstance(r, dict) and r.get("consistent") is False
+    )
+
+
+def _fol_verified(state: Any) -> int:
+    """Count FOL theories the Tweety solver verified (any verdict, real-in-state).
+
+    D1c (#1167): a CONSISTENT FOL theory (``consistent is True``) is a real
+    formal result — credit it so a coherent text surfaces a formal finding.
+    Counts True AND False verdicts; excludes unverified (None) — #1019.
+    """
+    fol = getattr(state, "fol_analysis_results", None)
+    if not isinstance(fol, list):
+        return 0
+    return sum(
+        1
+        for r in fol
+        if isinstance(r, dict)
+        and (r.get("consistent") is True or r.get("consistent") is False)
     )
 
 
@@ -433,6 +470,11 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
     counters_total = sum(1 for c in counters if isinstance(c, dict) and (c.get("target_arg_id") or c.get("counter_content")))
     pl_inc = _pl_inconsistent(state)
     fol_inc = _fol_inconsistent(state)
+    # D1c (#1167): a verified-consistent theory is a real formal result too —
+    # the formal axis credits ANY verified verdict (satisfiable/consistent True
+    # OR False), so a coherent text surfaces a non-trivial formal finding.
+    pl_verified = _pl_verified(state)
+    fol_verified = _fol_verified(state)
     dung_rejected = _dung_rejected_by_arg(state)
 
     # Non-trivial axes (real-in-state content), in a stable display order.
@@ -443,9 +485,9 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
         axes_nontrivial.append(_AXIS_QUALITY)
     if counters_total:
         axes_nontrivial.append(_AXIS_COUNTERS)
-    if pl_inc:
+    if pl_verified:
         axes_nontrivial.append(_AXIS_FORMAL_PL)
-    if fol_inc:
+    if fol_verified:
         axes_nontrivial.append(_AXIS_FORMAL_FOL)
     if dung_rejected:
         axes_nontrivial.append(_AXIS_DUNG)
@@ -700,9 +742,11 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         "- Rédige 3 paragraphes thématiques (un par battement), en prose lisible,\n"
         "  pas une liste de champs. Titres thématiques en ###.\n"
         "- Le verdict formel (Tweety/Dung) appuie un battement : formule-le comme\n"
-        "  « le solveur Tweety invalide cette inférence » ou « le cadre de Dung\n"
-        "  isole cette attaque comme défaillante » — jamais une sous-section\n"
-        "  isolée.\n"
+        "  « le solveur Tweety invalide cette inférence » (théorie inconsistante),\n"
+        "  « le solveur Tweety confirme la cohérence de cette inférence »\n"
+        "  (théorie consistante — un résultat formel aussi) ou « le cadre de Dung\n"
+        "  isole cet argument comme rejeté/défaillant » (argument absent de\n"
+        "  l'extension acceptée) — jamais une sous-section isolée.\n"
         "- Respecte STRICTEMENT le plafond de claim de la bande : ne formule rien\n"
         "  au-delà de ce qu'elle autorise.\n"
         "- La conclusion doit VARIER selon le contenu réel ci-dessus : pas de\n"

--- a/tests/unit/argumentation_analysis/orchestration/test_hierarchical_fallacy_writer.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_hierarchical_fallacy_writer.py
@@ -1,0 +1,155 @@
+"""Tests for the hierarchical-fallacy state writer — D1a (#1167 / Epic #1165).
+
+The spectacular run showed 25 orphan fallacies: the per-argument descent
+detected them but they landed in state as ``{type, justification}`` only — no
+family/taxonomy_path/target_argument_id — so Acte II could not narrate them.
+Root cause: the wide-net ``confirm_fallacy`` tool emits no quote/target, and
+while the per-argument harness attached ``source_arg_id`` (a real arg_id from
+``state.identified_arguments``) to each fallacy, the writer never used it — it
+only tried text-match fallbacks on empty fields.
+
+D1a fix (wiring, not invention): the writer resolves ``target_argument_id``
+from ``source_arg_id`` first (when it is a real arg_id in
+``identified_arguments``), and the per-argument harness enriches each fallacy
+with a grounded ``target_argument`` (= arg_id) + a verbatim
+``problematic_quote`` span. These tests pin both ends.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from argumentation_analysis.orchestration.state_writers import (
+    _write_hierarchical_fallacy_to_state,
+)
+
+
+class _FakeState:
+    """Minimal state stub mirroring add_fallacy's storage (shared_state.py:110).
+
+    Records each add_fallacy call exactly as the real state does: stores
+    family/taxonomy_path/target_argument_id only when non-empty.
+    """
+
+    def __init__(self) -> None:
+        self.identified_arguments = {
+            "arg_1": "Le locuteur attaque la personne plutôt que la thèse.",
+            "arg_2": "Un raisonnement causal étayé défend la revendication.",
+        }
+        self.identified_fallacies: dict = {}
+        self._counter = 0
+
+    def add_trace_entry(self, **kwargs):  # noqa: ANN003 — degraded marker path
+        pass
+
+    def add_fallacy(
+        self,
+        fallacy_type: str,
+        justification: str,
+        target_arg_id=None,
+        family: str = "",
+        taxonomy_path: str = "",
+    ) -> str:
+        self._counter += 1
+        fid = f"fallacy_{self._counter}"
+        entry = {"type": fallacy_type, "justification": justification}
+        if family:
+            entry["family"] = family
+        if taxonomy_path:
+            entry["taxonomy_path"] = taxonomy_path
+        if target_arg_id:
+            entry["target_argument_id"] = target_arg_id
+        self.identified_fallacies[fid] = entry
+        return fid
+
+
+def _state_with_args() -> _FakeState:
+    return _FakeState()
+
+
+def test_source_arg_id_resolves_to_target_argument_d1a():
+    """A fallacy carrying ``source_arg_id`` (set by the per-arg harness) links
+    to that arg_id even with NO target_argument / problematic_quote / family —
+    the orphan-fallacy case (D1a #1167)."""
+    state = _state_with_args()
+    output = {
+        "fallacies": [
+            {
+                "type": "ad hominem circonstanciel",
+                "explanation": "Attaque la personne.",
+                # The per-arg harness sets source_arg_id = the analyzed arg_id.
+                "source_arg_id": "arg_1",
+                # No target_argument / problematic_quote / family (wide-net emit).
+            }
+        ]
+    }
+    _write_hierarchical_fallacy_to_state(output, state, {})
+    assert len(state.identified_fallacies) == 1
+    entry = next(iter(state.identified_fallacies.values()))
+    assert entry["target_argument_id"] == "arg_1"
+
+
+def test_unknown_source_arg_id_falls_back_to_text_match_d1a():
+    """When source_arg_id is not a real arg_id (e.g. paragraph_1 fallback),
+    the writer falls back to text-match on target_argument/quote — does not
+    fabricate a link (anti-pendule)."""
+    state = _state_with_args()
+    output = {
+        "fallacies": [
+            {
+                "type": "ad hominem",
+                "explanation": "Attaque.",
+                "source_arg_id": "paragraph_1",  # not in identified_arguments
+                "target_argument": "Le locuteur attaque la personne plutôt que la thèse.",
+            }
+        ]
+    }
+    _write_hierarchical_fallacy_to_state(output, state, {})
+    entry = next(iter(state.identified_fallacies.values()))
+    assert entry["target_argument_id"] == "arg_1"  # matched via target_argument text
+
+
+def test_per_arg_enrichment_fields_consumed_by_writer_d1a():
+    """End-to-end of the D1a enrichment: a fallacy as emitted by the enriched
+    per-arg harness (target_argument = arg_id, problematic_quote = span) is
+    resolved by direct ID / quote match."""
+    state = _state_with_args()
+    output = {
+        "fallacies": [
+            {
+                "type": "appel à l'autorité",
+                "explanation": "Autorité invoquée sans expertise.",
+                "source_arg_id": "arg_2",
+                "target_argument": "arg_2",
+                "problematic_quote": "Un raisonnement causal étayé",
+                "family": "Appeal to Authority",
+                "taxonomy_path": "racine > autorité",
+            }
+        ]
+    }
+    _write_hierarchical_fallacy_to_state(output, state, {})
+    entry = next(iter(state.identified_fallacies.values()))
+    assert entry["target_argument_id"] == "arg_2"
+    assert entry["family"] == "Appeal to Authority"
+    assert entry["taxonomy_path"] == "racine > autorité"
+
+
+def test_no_target_link_when_nothing_matchable_d1a():
+    """A fallacy with no grounded link and no text-match is stored WITHOUT a
+    target_argument_id (honest — never fabricated). family/taxonomy_path still
+    surface what was computed."""
+    state = _state_with_args()
+    output = {
+        "fallacies": [
+            {
+                "type": "pente glissante",
+                "explanation": "Enchaînement non causalement étayé.",
+                "family": "Slippery Slope",
+                "taxonomy_path": "racine > causalité",
+            }
+        ]
+    }
+    _write_hierarchical_fallacy_to_state(output, state, {})
+    entry = next(iter(state.identified_fallacies.values()))
+    assert "target_argument_id" not in entry  # honest: no link
+    assert entry["family"] == "Slippery Slope"

--- a/tests/unit/argumentation_analysis/orchestration/test_narrative_synthesis_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_narrative_synthesis_spectacular.py
@@ -56,21 +56,24 @@ class TestNarrativeSynthesisRegistration:
         # MagicMock creates phantom attrs, so just verify no string was assigned
         assert not isinstance(getattr(state, "narrative_synthesis", ""), str)
 
-    def test_spectacular_has_narrative_synthesis_phase(self):
+    def test_spectacular_has_deep_synthesis_phase(self):
+        """Spectacular replaced ``narrative_synthesis`` with ``deep_synthesis``
+        (#1119 FB-33 — the template-prose narrative phase was removed; the
+        DeepSynthesisAgent grounded FB-18 synthesis is the spectacular
+        equivalent). D1b (#1167) wires its state writer. The spectacular
+        workflow must carry the deep_synthesis phase."""
         from argumentation_analysis.orchestration.workflows import (
             build_spectacular_workflow,
         )
 
         wf = build_spectacular_workflow()
         phase = {p.name: p for p in wf.phases}
-        assert "narrative_synthesis" in phase
-        assert phase["narrative_synthesis"].capability == "narrative_synthesis"
-        deps = phase["narrative_synthesis"].depends_on
-        assert "quality" in deps
-        assert "jtms" in deps
-        assert "atms" in deps
-        assert "dung_extensions" in deps
-        assert phase["narrative_synthesis"].optional is True
+        # narrative_synthesis was removed from spectacular in #1119.
+        assert "narrative_synthesis" not in phase
+        # deep_synthesis is its grounded successor (mandatory, not optional).
+        assert "deep_synthesis" in phase
+        assert phase["deep_synthesis"].capability == "deep_synthesis"
+        assert phase["deep_synthesis"].optional is False
 
     def test_full_has_narrative_synthesis_phase(self):
         """II #698: the sequential `full` path computes convergence in-run too.

--- a/tests/unit/argumentation_analysis/orchestration/test_synthesis_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_synthesis_spectacular.py
@@ -29,7 +29,65 @@ class TestSynthesisSpectacularPhase:
         )
 
         wf = build_spectacular_workflow()
-        assert len(wf.phases) == 21
+        # The workflow grew from 21 to 31 phases over #504/#506/#507/#508/#534/
+        # Epic #1134 (3 acts + deep_synthesis + stakes + kb pipeline + solvers).
+        # A fixed exact count is fragile test-debt; assert load-bearing invariants
+        # instead: the synthesis chain is present and the mandatory acts exist.
+        phase_names = {p.name for p in wf.phases}
+        assert "synthesis" in phase_names
+        assert "deep_synthesis" in phase_names
+        assert {"act1_framing", "act2_narrative", "act3_conclusion"} <= phase_names
+        assert len(wf.phases) >= 21  # never regresses below the original floor
+
+    def test_deep_synthesis_state_writer_registered(self):
+        """D1b (#1167): the deep_synthesis phase must have a state writer, else
+        the grounded FB-18 synthesis is dropped and state.narrative_synthesis
+        stays empty (Acte III never sees the most global component)."""
+        from argumentation_analysis.orchestration.state_writers import (
+            CAPABILITY_STATE_WRITERS,
+            _write_deep_synthesis_to_state,
+        )
+
+        assert "deep_synthesis" in CAPABILITY_STATE_WRITERS
+        assert (
+            CAPABILITY_STATE_WRITERS["deep_synthesis"]
+            is _write_deep_synthesis_to_state
+        )
+
+    def test_write_deep_synthesis_populates_narrative(self):
+        """D1b (#1167): _write_deep_synthesis_to_state persists grounded_synthesis
+        into state.narrative_synthesis (the field Acte III reads)."""
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_deep_synthesis_to_state,
+        )
+
+        state = MagicMock()
+        state.narrative_synthesis = ""
+        state.workflow_results = {}
+
+        _write_deep_synthesis_to_state(
+            {"grounded_synthesis": "Synthèse ancrée avec [artifact:arg_1]."},
+            state,
+            {},
+        )
+        assert (
+            state.narrative_synthesis
+            == "Synthèse ancrée avec [artifact:arg_1]."
+        )
+
+    def test_write_deep_synthesis_drops_empty_fail_loud(self):
+        """D1b (#1167): empty/unavailable grounded_synthesis is left as the empty
+        default — never fabricated (fail-loud, #1108/#1019)."""
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_deep_synthesis_to_state,
+        )
+
+        state = MagicMock()
+        state.narrative_synthesis = ""
+        _write_deep_synthesis_to_state({"grounded_synthesis": ""}, state, {})
+        assert state.narrative_synthesis == ""
+        _write_deep_synthesis_to_state({}, state, {})
+        assert state.narrative_synthesis == ""
 
     def test_analysis_synthesis_state_writer_registered(self):
         from argumentation_analysis.orchestration.state_writers import (

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -272,6 +272,45 @@ class TestBuildEvidence:
         assert ev.verdict is not None
         assert ev.verdict.band == "BELOW"
 
+    def test_consistent_pl_credits_formal_axis_d1c(self):
+        """D1c (#1167): a CONSISTENT PL theory (satisfiable True) is a real
+        formal result — the formal_pl axis must be credited so a coherent
+        text (no inconsistency) still surfaces a formal finding. satisfiable
+        IS a result."""
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            _pl_verified,
+        )
+
+        state = _state(
+            propositional_analysis_results=[{"satisfiable": True}]
+        )
+        assert _pl_verified(state) == 1
+        ev = build_act3_evidence(state)
+        assert "formal_pl" in ev.verdict.nontrivial_axes
+
+    def test_consistent_fol_credits_formal_axis_d1c(self):
+        """D1c (#1167): a CONSISTENT FOL theory credits the formal_fol axis."""
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            _fol_verified,
+        )
+
+        state = _state(fol_analysis_results=[{"consistent": True}])
+        assert _fol_verified(state) == 1
+        ev = build_act3_evidence(state)
+        assert "formal_fol" in ev.verdict.nontrivial_axes
+
+    def test_unverified_pl_does_not_credit_formal_axis_d1c(self):
+        """D1c (#1167): an unverified theory (None) is NOT a result — never
+        ``bool()`` a formal verdict (#1019: None ≠ False)."""
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            _pl_verified,
+        )
+
+        state = _state(
+            propositional_analysis_results=[{"satisfiable": None}]
+        )
+        assert _pl_verified(state) == 0
+
 
 class TestPrivacy:
     def test_long_justification_truncated_in_prompt(self):


### PR DESCRIPTION
Track **D1** of **Epic #1165** (relaunch #1134). Closes #1167.

## Problem
A direct `spectacular`+`full` run on doc_A (437s, LLM-conducted, healthy) showed **gate=PASS masks broken substance**: rich agentic output was produced then **disconnected** from the report. The diagnostic (grounded, do not re-derive) identified three interconnected losses. This track fixes the architectural heart by **wiring** (never template/invention — anti-pendule #1019/#369).

## D1a — Fallacy attribution (25 orphans → grounded targets)
The writer `_write_hierarchical_fallacy_to_state` was **correct** but received fallacies with empty `family`/`taxonomy_path`/`target` — observed state had 25 entries as `{type, justification}` only. Root cause:
- The wide-net `confirm_fallacy` tool emits no quote/target;
- The per-argument harness attached `source_arg_id` (a real arg_id) but the writer ignored it — it only tried text-match fallbacks on empty fields.

**Fix:**
- `_invoke_hierarchical_fallacy_per_argument` (invoke_callables.py) now enriches each fallacy with a grounded `target_argument` (= the analyzed arg_id) + a verbatim `problematic_quote` span (in-memory only — results are gitignored; privacy HARD).
- The writer resolves `target_argument_id` from `source_arg_id` **first** (when it is a real arg_id in `identified_arguments`), then the text-match fallbacks.

## D1b — deep_synthesis wiring (74s grounded synthesis was dropped)
No `deep_synthesis` key in `CAPABILITY_STATE_WRITERS` → the spectacular phase's grounded FB-18 synthesis + value_gates were never persisted; `state.narrative_synthesis` stayed empty (Acte III reads it, never saw the most global component). Added `_write_deep_synthesis_to_state` (persists `grounded_synthesis` → `state.narrative_synthesis` + value_gates onto `workflow_results`) and registered it. Fail-loud: empty results left as the empty default, never fabricated (#1108/#1019).

## D1c — Dung alignment + verdict band formal credit
- **Dung wording:** act2 said *"attaque défaillante"* (attack fails ⇒ arg holds) while `_dung_rejected_by_arg` returns **rejected arguments** (the arg is the defect). Aligned both acts' prompt wording + act2 detail on *"argument rejeté/défaillant (absent de l'extension acceptée)"* and added the consistent-verdict credit (*"le solveur confirme la cohérence"*).
- **Verdict band:** `_compute_verdict_band` only credited PL/FOL when **inconsistent**. A coherent text (`satisfiable=True`) surfaced no formal finding. Added `_pl_verified`/`_fol_verified` (count any verified verdict, True OR False; never `bool()` a formal verdict — None ≠ False, #1019); the formal axis now credits a consistent theory too (**satisfiable IS a result**).

## DoD
- [x] Fallacies carry family+taxonomy_path+target_argument_id; Acte II can narrate them (no longer "aucun sophisme localisé")
- [x] `narrative_synthesis` populated from grounded synthesis; the report references it
- [x] Dung wording coherent II↔III; verdict band credits a consistent formal verdict
- [x] Unit tests D1a/b/c (11 new); restitution gate still PASS (now on real substance)
- [x] mypy strict clean on all 4 modified source files

## Tests
- `+11` unit: D1a writer ×4 (`test_hierarchical_fallacy_writer.py`), D1b writer ×3 + phase ×1 (`test_synthesis_spectacular.py`), D1c verdict ×3 (`test_act3_conclusion_plugin.py`).
- Folded **2 pre-existing DAG test-debt items** (in lane — I touch the synthesis writers):
  - `test_spectacular_phase_count_with_synthesis` asserted `==21` but the workflow grew to 31 over #504..#1134 → replaced with load-bearing invariants (`synthesis`/`deep_synthesis`/3 acts present, floor `>=21`).
  - `test_spectacular_has_narrative_synthesis_phase` asserted a phase removed in #1119 → corrected to assert the `deep_synthesis` successor.
- **203 restitution/synthesis tests pass.** (Both folded items confirmed failing on clean `main f5565cf6` — pre-existing, not regressions.)

## Files
`invoke_callables.py` (per-arg enrichment), `state_writers.py` (fallacy target resolution + deep_synthesis writer + registry), `act2_narrative_plugin.py` + `act3_conclusion_plugin.py` (Dung wording + verified formal credit).

## Privacy HARD
`problematic_quote` stays in-memory in the state (results gitignored); opaque IDs only in this PR. No raw_text/source_name.

## Collision / sequencing
Touches `invoke_callables.py` — **W1 (#1169, po-2025)** is gated on this merge (per dispatch R440). I pass first. `state_writers.py`/act plugins are D1-only (file-disjoint from E1 po-2025 env/classpath lane).

🤖 Worker po-2023 — D1 #1167 delivered, awaiting next dispatch (T1 #1170 + β #1166).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>