### PR TITLE
fix(tweety): #1168 E1b — correct wrong Tweety class names + sanitize PL inputs (revive quality/prob/aspic/belief_revision)

### DIFF
--- a/argumentation_analysis/agents/core/logic/aspic_handler.py
+++ b/argumentation_analysis/agents/core/logic/aspic_handler.py
@@ -104,8 +104,18 @@ class ASPICHandler:
             else:
                 reasoner = self.SimpleAspicReasoner(self.SimplePreferredReasoner())
 
-            # Get extensions
-            extensions = reasoner.getModels(theory)
+            # Get extensions. SimpleAspicReasoner does NOT expose getModels
+            # directly; it translates the ASPIC+ theory into a Dung framework
+            # via getDungTheory(theory, invertable), and the underlying Dung
+            # reasoner (SimplePreferredReasoner, passed to the ctor above)
+            # computes the extensions on that DungTheory. The 2nd arg is an
+            # Invertable — a PL formula-type signature; a Proposition instance
+            # is the PL Invertable (verified empirically). (Prior code called
+            # reasoner.getModels(theory) → AttributeError on every real run.)
+            inv = self.Proposition("aspic_pl_formula")
+            dung_theory = reasoner.getDungTheory(theory, inv)
+            dung_reasoner = self.SimplePreferredReasoner()
+            extensions = dung_reasoner.getModels(dung_theory)
 
             ext_list = []
             for ext in extensions:

--- a/argumentation_analysis/agents/core/logic/belief_revision_handler.py
+++ b/argumentation_analysis/agents/core/logic/belief_revision_handler.py
@@ -36,15 +36,23 @@ class BeliefRevisionHandler:
             "org.tweetyproject.logics.pl.syntax.Proposition"
         )
         self.PlNegation = jpype.JClass("org.tweetyproject.logics.pl.syntax.Negation")
-        # Revision operators
-        self.DalalRevision = jpype.JClass(
-            "org.tweetyproject.beliefdynamics.revops.DalalRevision"
-        )
+        # Revision operators. NB: a prior revision referenced a fabricated
+        # ``org.tweetyproject.beliefdynamics.revops.DalalRevision`` class here
+        # — that class does NOT exist in Tweety 1.28 (there is no ``revops``
+        # package at all). The lookup crashed __init__ on every real run → the
+        # ``belief_revision`` phase FAILED, and because it is the FIRST
+        # revision operator loaded, the 4 valid operators below were never
+        # reached. A second, deeper bug was hidden behind it: the prior code
+        # constructed ``KernelContractionOperator(RandomIncision())`` but that
+        # ctor requires (IncisionFunction, KernelProvider) — 2 args, not 1.
+        # The self-contained ctor is
+        # ``org.tweetyproject.beliefdynamics.operators.RandomKernelContractionOperator``
+        # (no-arg: wires its own incision + kernel provider), so we use that.
+        # Tweety exposes no distance-based ``DalalRevision`` operator class;
+        # the ``dalal`` method maps to the same Levi pattern as ``levi``. See
+        # ``revise()`` below.
         self.KernelContraction = jpype.JClass(
-            "org.tweetyproject.beliefdynamics.kernels.KernelContractionOperator"
-        )
-        self.RandomIncision = jpype.JClass(
-            "org.tweetyproject.beliefdynamics.kernels.RandomIncisionFunction"
+            "org.tweetyproject.beliefdynamics.operators.RandomKernelContractionOperator"
         )
         self.DefaultExpansion = jpype.JClass(
             "org.tweetyproject.beliefdynamics.DefaultMultipleBaseExpansionOperator"
@@ -83,12 +91,15 @@ class BeliefRevisionHandler:
             parser = self.PlParser()
             new_formula = parser.parseFormula(new_belief)
 
-            if method == "levi":
-                contraction = self.KernelContraction(self.RandomIncision())
-                expansion = self.DefaultExpansion()
-                operator = self.LeviRevision(contraction, expansion)
-            else:
-                operator = self.DalalRevision()
+            # Both ``dalal`` and ``levi`` methods use the Levi pattern
+            # (contraction + expansion) — the only AGM revision operator
+            # family Tweety 1.28 exposes. ``dalal`` has no dedicated Tweety
+            # class (see __init__ note), so it maps to the same path. We do
+            # NOT fabricate a DalalRevision class. RandomKernelContractionOperator
+            # is no-arg (self-contained incision + kernel provider).
+            contraction = self.KernelContraction()
+            expansion = self.DefaultExpansion()
+            operator = self.LeviRevision(contraction, expansion)
 
             revised = operator.revise(bs, new_formula)
 
@@ -127,7 +138,7 @@ class BeliefRevisionHandler:
             parser = self.PlParser()
             formula = parser.parseFormula(formula_to_remove)
 
-            contraction = self.KernelContraction(self.RandomIncision())
+            contraction = self.KernelContraction()
             contracted = contraction.contract(bs, formula)
 
             contracted_formulas = [str(f) for f in contracted]

--- a/argumentation_analysis/agents/core/logic/probabilistic_handler.py
+++ b/argumentation_analysis/agents/core/logic/probabilistic_handler.py
@@ -23,9 +23,16 @@ class ProbabilisticHandler:
         self.Probability = jpype.JClass(
             "org.tweetyproject.math.probability.Probability"
         )
-        self.SubgraphProbReasoner = jpype.JClass(
-            "org.tweetyproject.arg.prob.reasoner.ProbabilisticReasoner"
-        )
+        # NB: a prior revision referenced a fabricated
+        # ``org.tweetyproject.arg.prob.reasoner.ProbabilisticReasoner`` class
+        # here — that class does NOT exist in Tweety 1.28 (the real reasoners
+        # are SimplePafReasoner / MonteCarloPafReasoner). The attribute was
+        # dead code: never read by any method (the acceptance computation
+        # uses org.tweetyproject.arg.dung.reasoner.SimpleGroundedReasoner at
+        # runtime, loaded lazily in _compute_acceptance_probabilities). The
+        # fabricated JClass lookup crashed __init__ on every real run → the
+        # ``probabilistic`` phase FAILED. Removed (anti-pendule: subtract the
+        # bug, do not replace it with another speculative class).
 
     def analyze_probabilistic_framework(
         self,

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -2823,6 +2823,33 @@ async def _invoke_adf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
         )
 
 
+def _pl_atom(text: str, prefix: str = "p") -> str:
+    """Sanitize free text into a valid propositional-logic atom.
+
+    Tweety's ``PlParser.parseFormula`` rejects atoms containing anything
+    outside ``[A-Za-z0-9_]`` (e.g. ``Unknown object teleprompteranecdote``
+    when raw corpus text leaked into a belief set / ASPIC rule). Upstream
+    pipeline data (extracted arguments, fallacy types) is free-form text —
+    it must be reduced to a stable alphanumeric atom before PL parsing.
+
+    The mapping is lossy by design (PL atoms are opaque labels, not
+    semantics): we keep up to 24 leading alnum chars of the text, lowercased,
+    non-alnum collapsed to ``_``. A short hash suffix disambiguates distinct
+    inputs that collapse to the same prefix (avoids false collisions that
+    would merge distinct beliefs). Deterministic (no Math.random).
+    """
+    import re as _re
+    import hashlib as _hashlib
+
+    if not text:
+        return f"{prefix}_0"
+    cleaned = _re.sub(r"[^A-Za-z0-9]+", "_", str(text)).strip("_").lower()[:24]
+    if not cleaned:
+        cleaned = "x"
+    digest = _hashlib.md5(str(text).encode("utf-8")).hexdigest()[:6]
+    return f"{prefix}_{cleaned}_{digest}"
+
+
 def _python_aspic_fallback(
     args: List[str],
     strict: List[str],
@@ -2859,7 +2886,11 @@ async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict[str, A
     strict = context.get("strict_rules")
     if not strict:
         strict = []
-        # Strict rules: factual claims that are uncontested
+        # Strict rules: factual claims support conclusions. The ASPIC handler
+        # expects dicts {head, body} with PL-atom heads/bodies (not raw rule
+        # strings — the handler builds StrictRule/DefeasibleRule itself).
+        # Atoms are sanitized via _pl_atom (Tweety's Proposition rejects
+        # non-alphanumeric names).
         extract_output = context.get("phase_extract_output", {})
         claims = (
             extract_output.get("claims", []) if isinstance(extract_output, dict) else []
@@ -2868,24 +2899,46 @@ async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict[str, A
             text = (
                 claim.get("text", str(claim)) if isinstance(claim, dict) else str(claim)
             )
-            strict.append(f"claim_{i+1}({text[:40]}) -> supported_{i+1}")
-        # If claims feed into arguments
+            strict.append(
+                {"head": f"supported_{i+1}", "body": [_pl_atom(text, prefix="claim")]}
+            )
+        # If claims feed into arguments, chain them.
         if len(args) >= 2:
-            strict.append(f"supported_1, supported_2 -> argument_chain")
+            strict.append(
+                {"head": "argument_chain", "body": ["supported_1", "supported_2"]}
+            )
 
     defeasible = context.get("defeasible_rules")
     if not defeasible:
         defeasible = []
-        # Defeasible rules: arguments that could be undermined
+        # Defeasible rules: arguments that could be undermined.
         for i, arg in enumerate(args[:4]):
-            defeasible.append(f"{arg[:40]} => plausible_conclusion_{i+1}")
-        # Fallacy-based defeat: if a fallacy targets an argument, it's defeasible
+            defeasible.append(
+                {
+                    "head": f"plausible_conclusion_{i+1}",
+                    "body": [_pl_atom(arg, prefix="arg")],
+                    "name": f"def_arg_{i+1}",
+                }
+            )
+        # Fallacy-based defeat: a detected fallacy undermines an argument.
         for j, f in enumerate(fallacies[:3]):
             if isinstance(f, dict):
                 ft = str(f.get("type", f.get("fallacy_type", "unknown")))
-                defeasible.append(f"detected({ft[:30]}) => undermined_{j+1}")
+                defeasible.append(
+                    {
+                        "head": f"undermined_{j+1}",
+                        "body": [_pl_atom(ft, prefix="fallacy")],
+                        "name": f"defeater_{j+1}",
+                    }
+                )
 
-    axioms = context.get("axioms")
+    axioms_raw = context.get("axioms")
+    # Sanitize axioms too (list of proposition names).
+    axioms = None
+    if axioms_raw:
+        axioms = [
+            _pl_atom(a, prefix="ax") for a in axioms_raw if isinstance(a, str)
+        ]
 
     try:
         from argumentation_analysis.agents.core.logic.aspic_handler import ASPICHandler
@@ -2941,8 +2994,19 @@ async def _invoke_belief_revision(
             BeliefRevisionHandler,
         )
 
+        # Sanitize free-form beliefs/new_belief into valid PL atoms.
+        # Upstream data (extracted args, fallacy types, LLM counter-arguments)
+        # is free text — Tweety's PlParser rejects non-alphanumeric atoms
+        # (ParserException: Unknown object ...). Reduce to stable atoms.
+        safe_beliefs = [_pl_atom(b) for b in beliefs if b and isinstance(b, str)]
+        safe_new_belief = _pl_atom(new_belief, prefix="n")
+        if not safe_beliefs:
+            safe_beliefs = [_pl_atom("initial_belief", prefix="b")]
+
         handler = BeliefRevisionHandler()  # type: ignore[no-untyped-call]
-        return await asyncio.to_thread(handler.revise, beliefs, new_belief, method)
+        return await asyncio.to_thread(
+            handler.revise, safe_beliefs, safe_new_belief, method
+        )
     except Exception as e:
         raise RuntimeError(
             f"Belief revision ({method}) unavailable: JVM/Tweety required ({e}). "

--- a/tests/fixtures/integration_fixtures.py
+++ b/tests/fixtures/integration_fixtures.py
@@ -321,7 +321,12 @@ def tweety_logics_classes(tweety_classpath_initializer, jvm_session):
             "org.tweetyproject.beliefdynamics.RevisionOperator", loader=loader_to_use
         ),  # Interface
         "DalalRevision": JClass(
-            "org.tweetyproject.beliefdynamics.revops.DalalRevision",
+            # Corrected #1168 E1b: org.tweetyproject.beliefdynamics.revops
+            # does not exist in Tweety 1.28. Tweety exposes no distance-based
+            # DalalRevision operator; the self-contained contraction operator
+            # is RandomKernelContractionOperator. Kept under the ``DalalRevision``
+            # key for fixture-consumer backward-compat, but points to a real class.
+            "org.tweetyproject.beliefdynamics.operators.RandomKernelContractionOperator",
             loader=loader_to_use,
         ),
         # Other useful classes
@@ -511,7 +516,10 @@ def belief_revision_classes(tweety_classpath_initializer, jvm_session):
         }
         revision_ops = {
             "KernelContractionOperator": jpype_instance.JClass(
-                "org.tweetyproject.beliefdynamics.kernels.KernelContractionOperator",
+                # Corrected #1168 E1b: the 2-arg kernels ctor needs
+                # (IncisionFunction, KernelProvider); the self-contained
+                # operator lives in the operators package (no-arg ctor).
+                "org.tweetyproject.beliefdynamics.operators.RandomKernelContractionOperator",
                 loader=loader_to_use,
             ),
             "RandomIncisionFunction": jpype_instance.JClass(

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_track_a_handlers.py
@@ -462,10 +462,22 @@ class TestBeliefRevisionHandler:
     def test_init_loads_revision_classes(self):
         handler, _, registry = self._make_handler()
         assert "org.tweetyproject.logics.pl.syntax.PlBeliefSet" in registry
-        assert "org.tweetyproject.beliefdynamics.revops.DalalRevision" in registry
+        # Contract (corrected #1168 E1b): the prior code referenced a fabricated
+        # ``org.tweetyproject.beliefdynamics.revops.DalalRevision`` (no such
+        # package/class in Tweety 1.28) and the 2-arg KernelContractionOperator
+        # ctor. The self-contained revision operator is
+        # RandomKernelContractionOperator (operators pkg, no-arg ctor).
         assert (
-            "org.tweetyproject.beliefdynamics.kernels.KernelContractionOperator"
+            "org.tweetyproject.beliefdynamics.operators.RandomKernelContractionOperator"
             in registry
+        )
+        assert (
+            "org.tweetyproject.beliefdynamics.LeviMultipleBaseRevisionOperator"
+            in registry
+        )
+        # The fabricated DalalRevision / revops package must NOT be loaded.
+        assert (
+            "org.tweetyproject.beliefdynamics.revops.DalalRevision" not in registry
         )
 
     def test_revise_dalal(self):
@@ -478,9 +490,15 @@ class TestBeliefRevisionHandler:
             )
         )
 
-        dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
-        if dalal:
-            dalal.return_value.revise.return_value = mock_revised
+        # Contract (corrected #1168 E1b): both ``dalal`` and ``levi`` methods
+        # now use the Levi pattern (RandomKernelContractionOperator +
+        # DefaultExpansion + LeviMultipleBaseRevisionOperator). The fabricated
+        # DalalRevision class is gone; we mock the Levi operator's revise().
+        levi = registry.get(
+            "org.tweetyproject.beliefdynamics.LeviMultipleBaseRevisionOperator"
+        )
+        if levi:
+            levi.return_value.revise.return_value = mock_revised
 
         result = handler.revise(
             belief_set=["a", "b"],
@@ -506,8 +524,11 @@ class TestBeliefRevisionHandler:
         mock_contracted = MagicMock()
         mock_contracted.__iter__ = MagicMock(return_value=iter([]))
 
+        # Contract (corrected #1168 E1b): self.KernelContraction now holds
+        # RandomKernelContractionOperator (no-arg, self-contained) instead of
+        # the 2-arg kernels.KernelContractionOperator.
         kernel = registry.get(
-            "org.tweetyproject.beliefdynamics.kernels.KernelContractionOperator"
+            "org.tweetyproject.beliefdynamics.operators.RandomKernelContractionOperator"
         )
         if kernel:
             kernel.return_value.contract.return_value = mock_contracted
@@ -527,9 +548,15 @@ class TestBeliefRevisionHandler:
                 [MagicMock(__str__=lambda s: "a"), MagicMock(__str__=lambda s: "b")]
             )
         )
-        dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
-        if dalal:
-            dalal.return_value.revise.return_value = mock_revised
+        # Contract (corrected #1168 E1b): both ``dalal`` and ``levi`` methods
+        # now use the Levi pattern (RandomKernelContractionOperator +
+        # DefaultExpansion + LeviMultipleBaseRevisionOperator). The fabricated
+        # DalalRevision class is gone; we mock the Levi operator's revise().
+        levi = registry.get(
+            "org.tweetyproject.beliefdynamics.LeviMultipleBaseRevisionOperator"
+        )
+        if levi:
+            levi.return_value.revise.return_value = mock_revised
 
         result = handler.revise(["a"], "b", method="dalal")
         assert "statistics" in result
@@ -540,8 +567,11 @@ class TestBeliefRevisionHandler:
         handler, _, registry = self._make_handler()
         mock_contracted = MagicMock()
         mock_contracted.__iter__ = MagicMock(return_value=iter([]))
+        # Contract (corrected #1168 E1b): self.KernelContraction now holds
+        # RandomKernelContractionOperator (no-arg, self-contained) instead of
+        # the 2-arg kernels.KernelContractionOperator.
         kernel = registry.get(
-            "org.tweetyproject.beliefdynamics.kernels.KernelContractionOperator"
+            "org.tweetyproject.beliefdynamics.operators.RandomKernelContractionOperator"
         )
         if kernel:
             kernel.return_value.contract.return_value = mock_contracted
@@ -556,9 +586,15 @@ class TestBeliefRevisionHandler:
         mock_revised.__iter__ = MagicMock(
             return_value=iter([MagicMock(__str__=lambda s: "!a")])
         )
-        dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
-        if dalal:
-            dalal.return_value.revise.return_value = mock_revised
+        # Contract (corrected #1168 E1b): both ``dalal`` and ``levi`` methods
+        # now use the Levi pattern (RandomKernelContractionOperator +
+        # DefaultExpansion + LeviMultipleBaseRevisionOperator). The fabricated
+        # DalalRevision class is gone; we mock the Levi operator's revise().
+        levi = registry.get(
+            "org.tweetyproject.beliefdynamics.LeviMultipleBaseRevisionOperator"
+        )
+        if levi:
+            levi.return_value.revise.return_value = mock_revised
 
         result = handler.revise(["a"], "!a", method="dalal")
         assert result["new_belief"] == "!a"
@@ -569,9 +605,15 @@ class TestBeliefRevisionHandler:
         mock_revised.__iter__ = MagicMock(
             return_value=iter([MagicMock(__str__=lambda s: "p")])
         )
-        dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
-        if dalal:
-            dalal.return_value.revise.return_value = mock_revised
+        # Contract (corrected #1168 E1b): both ``dalal`` and ``levi`` methods
+        # now use the Levi pattern (RandomKernelContractionOperator +
+        # DefaultExpansion + LeviMultipleBaseRevisionOperator). The fabricated
+        # DalalRevision class is gone; we mock the Levi operator's revise().
+        levi = registry.get(
+            "org.tweetyproject.beliefdynamics.LeviMultipleBaseRevisionOperator"
+        )
+        if levi:
+            levi.return_value.revise.return_value = mock_revised
 
         result = handler.revise([], "p", method="dalal")
         assert result["statistics"]["original_size"] == 0
@@ -581,8 +623,11 @@ class TestBeliefRevisionHandler:
         handler, _, registry = self._make_handler()
         mock_contracted = MagicMock()
         mock_contracted.__iter__ = MagicMock(return_value=iter([]))
+        # Contract (corrected #1168 E1b): self.KernelContraction now holds
+        # RandomKernelContractionOperator (no-arg, self-contained) instead of
+        # the 2-arg kernels.KernelContractionOperator.
         kernel = registry.get(
-            "org.tweetyproject.beliefdynamics.kernels.KernelContractionOperator"
+            "org.tweetyproject.beliefdynamics.operators.RandomKernelContractionOperator"
         )
         if kernel:
             kernel.return_value.contract.return_value = mock_contracted
@@ -598,9 +643,15 @@ class TestBeliefRevisionHandler:
         mock_revised_dalal.__iter__ = MagicMock(
             return_value=iter([MagicMock(__str__=lambda s: "a")])
         )
-        dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
-        if dalal:
-            dalal.return_value.revise.return_value = mock_revised_dalal
+        # Contract (corrected #1168 E1b): both ``dalal`` and ``levi`` methods
+        # now use the Levi pattern (RandomKernelContractionOperator +
+        # DefaultExpansion + LeviMultipleBaseRevisionOperator). The fabricated
+        # DalalRevision class is gone; we mock the Levi operator's revise().
+        levi = registry.get(
+            "org.tweetyproject.beliefdynamics.LeviMultipleBaseRevisionOperator"
+        )
+        if levi:
+            levi.return_value.revise.return_value = mock_revised_dalal
 
         result_d = handler.revise(["a", "b"], "c", method="dalal")
         result_l = handler.revise(["a", "b"], "c", method="levi")
@@ -620,9 +671,15 @@ class TestBeliefRevisionHandler:
                 ]
             )
         )
-        dalal = registry.get("org.tweetyproject.beliefdynamics.revops.DalalRevision")
-        if dalal:
-            dalal.return_value.revise.return_value = mock_revised
+        # Contract (corrected #1168 E1b): both ``dalal`` and ``levi`` methods
+        # now use the Levi pattern (RandomKernelContractionOperator +
+        # DefaultExpansion + LeviMultipleBaseRevisionOperator). The fabricated
+        # DalalRevision class is gone; we mock the Levi operator's revise().
+        levi = registry.get(
+            "org.tweetyproject.beliefdynamics.LeviMultipleBaseRevisionOperator"
+        )
+        if levi:
+            levi.return_value.revise.return_value = mock_revised
 
         result = handler.revise(["a"], "b", method="dalal")
         assert result["revised"] == sorted(result["revised"])


### PR DESCRIPTION
## Summary

Closes #1168 — Track E1 (Env/classpath) of Epic #1165 (#1134 culmination relaunch).

Revives the 4 phases that FAILED on every `spectacular`+`full` run: **`quality`, `probabilistic`, `aspic_analysis`, `belief_revision`**. All 4 now reach `status=completed` with non-trivial output.

## Coordinator diagnosis correction (verify-the-verification)

The R440 dispatch diagnosed this as *"JARs missing from classpath → extend classpath"*. **That diagnosis was wrong.** Empirical verification (zipfile inspection of `org.tweetyproject.tweety-full-1.28-with-dependencies.jar`) confirms the uber-jar **already contains all required classes** (arg/prob=30, arg/aspic=31, beliefdynamics=70 `.class` entries), and `jvm_setup.py` loads that uber-jar into the classpath. Extending the classpath (the literal dispatch instruction) would have been the pendulum — adding JARs that were already loaded. The real root cause was **wrong class names + wrong method calls** in the handler files, plus a 2nd-layer contract bug in the invokeables. Code = truth.

## Two fix layers

### Layer 1 — corrected fabricated Tweety class names (commit `6b5aabc4`)

All in `argumentation_analysis/agents/core/logic/`:

1. **`probabilistic_handler.py`** — `jpype.JClass("org.tweetyproject.arg.prob.reasoner.ProbabilisticReasoner")` was **fabricated** (no such class). The attribute was dead code — never read by any method (acceptance uses `SimpleGroundedReasoner` at runtime). The JClass lookup crashed `__init__` → phase FAILED. **Fix (anti-pendule subtraction):** removed the dead attribute.
2. **`belief_revision_handler.py`** — `org.tweetyproject.beliefdynamics.revops.DalalRevision` was **fabricated** (no `revops` package). This masked a deeper bug: the code built `KernelContractionOperator(RandomIncision())` but that ctor needs `(IncisionFunction, KernelProvider)` — 2 args, not 1. **Fix:** `RandomKernelContractionOperator` (no-arg, self-contained). Both `dalal` and `levi` methods use the Levi pattern (Tweety exposes no distance-based Dalal revision operator class — documented, not fabricated).
3. **`aspic_handler.py`** — `reasoner.getModels(theory)` but `SimpleAspicReasoner` has no `getModels`. Correct API: `reasoner.getDungTheory(theory, invertable)` → `DungTheory`, then `SimplePreferredReasoner().getModels(dung_theory)`. The 2nd arg is an `Invertable` (PL formula-type signature) = a `Proposition` instance.

### Layer 2 — sanitize PL atoms + fix aspic rule schema (commit `e64ecd70`)

Revealed after the handler fix (same cascade pattern — one crash masks the next). First DoD run: `quality`+`probabilistic` PASS, but `belief_revision`+`aspic_analysis` STILL FAILED with `ParserException: Unknown object <raw-corpus-atom>`. The **invokeables** fed raw corpus text (extracted args, fallacy types) into `PlParser.parseFormula()`, which rejects non-`[A-Za-z0-9_]` atoms. Plus `_invoke_aspic` built rules as strings but the handler contract expects `{head, body}` dicts.

- **`invoke_callables.py`** (mypy-strict CI-gated, stays clean): new `_pl_atom(text, prefix="p")` helper — deterministic lossy mapping (`re.sub(r"[^A-Za-z0-9]+", "_", ...).lower()[:24]` + 6-char md5 suffix). Sanitizes all PL atoms in both `_invoke_belief_revision` (`beliefs`, `new_belief`) and `_invoke_aspic` (axioms + strict/defeasible rules built as proper dicts).
- **`test_track_a_handlers.py`**: tests encoded the broken contract (mocked the fabricated classes). Repointed to `RandomKernelContractionOperator` + `LeviMultipleBaseRevisionOperator`.
- **`integration_fixtures.py`**: fixture entries repointed to `operators.RandomKernelContractionOperator` (backward-compat key names retained).

## DoD — proven by direct run

`spectacular`+`full` smoke run, opaque id `e1_smoke` (doc_A), TIMEOUT=1200s:

| Phase | Status | Non-trivial |
|-------|--------|-------------|
| `quality` | ✅ completed | True |
| `probabilistic` | ✅ completed | True |
| `aspic_analysis` | ✅ completed | True |
| `belief_revision` | ✅ completed | True |

**Verdict: ALL PASS (COMPLETED, 586.1s)** — 31/31 phases completed, 0 failed, 0 skipped. The full spectacular pipeline now runs end-to-end on the corpus with every previously-failing phase producing real output.

**E1a** (quality deps) was already satisfied — `textstat` + `fr_core_news_sm` load via the existing `_neutralize_faulty_torch()` helper (#1095/R401). No work needed.

## Validation gates

- `mypy --strict` on `invoke_callables.py` (the CI-gated file touched): **clean, no issues**.
- `test_track_a_handlers.py`: **44 passed**.
- 0 LLM spend (env/classpath track, deterministic JVM work).

## Privacy

Opaque ID `e1_smoke` only. No corpus content, raw text, or source identifiers in this PR. The local validation harness (`scripts/run_e1_phase_status_check.py`) is untracked — not committed (validation artifact, privacy HARD).

## Files removed and why

None. This PR is purely additive/corrective (212 insert / 55 delet across 6 files, no deletions).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
