### PR TITLE
chore(synthesis): opportunistic polish — 3 non-blocking Hermes concerns on D1 #1172

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -4091,6 +4091,11 @@ async def _invoke_hierarchical_fallacy_per_argument(
                     return
                 # Verbatim span: cap to keep the quote a tight anchor (privacy +
                 # match precision — the writer matches on desc[:60] prefixes).
+                # NB: the field name ``problematic_quote`` matches the
+                # IdentifiedFallacy schema, but here it is NOT the exact
+                # fallacious phrase — it is a match anchor (the argument's
+                # leading text) used by the writer for ID resolution only, and
+                # is never persisted into the narrated report.
                 quote_span = arg_text.strip()[:200]
                 for f in fallacies:
                     if not isinstance(f, dict):

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -938,6 +938,16 @@ def _write_deep_synthesis_to_state(
         trace for downstream consumers).
     Empty/unavailable results are left as the empty default so the gap is
     reported honestly (fail-loud, #1108/#1019 — never fabricate here).
+
+    Workflow disjointness (double-writer note): both this writer and
+    ``_write_narrative_synthesis_to_state`` (the ``full`` path) set
+    ``state.narrative_synthesis``. They are never active in the same run —
+    ``narrative_synthesis`` was removed from the ``spectacular`` workflow
+    (#1119, replaced by this ``deep_synthesis`` successor), while ``full``
+    keeps the sequential ``narrative_synthesis`` phase. So at most one writer
+    fires per workflow. No execution guard is added: the disjointness lives
+    in the workflow phase sets, and a guard here would duplicate that
+    contract (anti-pendule).
     """
     if not output or not isinstance(output, dict):
         return
@@ -953,7 +963,12 @@ def _write_deep_synthesis_to_state(
             if isinstance(existing, dict):
                 existing["deep_synthesis_value_gates"] = value_gates
         except Exception:  # noqa: BLE001 — non-fatal: state may lock the attr
-            pass
+            # Side-channel only (narrative_synthesis is the headline and is
+            # already set above); trace at debug so a state-lock regression
+            # stays diagnosable rather than silently swallowed.
+            logger.debug(
+                "deep_synthesis value_gates persistence skipped", exc_info=True
+            )
 
 
 def _write_act2_narrative_to_state(


### PR DESCRIPTION
## chore(synthesis): opportunistic polish — 3 non-blocking Hermes concerns on D1 #1172

Addresses the 3 non-blocking review concerns Hermes raised on the merged D1 keystone (PR #1172, commit `b2aadfed`). Cosmetic/diagnostic only — **zero behavior change**, no new guards (anti-pendule).

### Concern 1 — `problematic_quote` field semantics (`invoke_callables.py`)
The field name matches the `IdentifiedFallacy` Pydantic schema, but the value attached by `_enrich_fallacies` is a **match anchor** (the argument's leading text, used by the writer for ID resolution), **not** the exact fallacious phrase. It is never persisted into the narrated report. Added an inline comment at the assignment site so a downstream reader of the intermediate dict isn't misled. **No rename** — renaming would diverge from the schema field name.

### Concern 2 — `except Exception: pass` on value_gates (`state_writers.py`)
Was silently swallowing any state-attr error on the value_gates side-channel persistence. Replaced `pass` with `logger.debug(..., exc_info=True)` so a state-lock regression stays diagnosable. Non-fatal — `narrative_synthesis` (the headline) is set above and is unaffected.

### Concern 3 — double-writer on `state.narrative_synthesis`
`_write_narrative_synthesis` (full path) and `_write_deep_synthesis` (spectacular) both set `state.narrative_synthesis`. They are **workflow-disjoint** (`narrative_synthesis` was removed from spectacular in #1119). Documented the disjointness in the `_write_deep_synthesis` docstring instead of adding an execution guard — the disjointness lives in the workflow phase sets and a guard here would duplicate that contract (anti-pendule).

### Validation
- **mypy strict clean** on both modified files.
- **195 synthesis + restitution tests pass** (no regression).
- Zero behavior change — comment + docstring + debug-log only.

### Scope
Touches `invoke_callables.py` (comment only, ~line 4094) + `state_writers.py` (docstring + 1 debug-log). Disjoint from po-2025's W1 lane (W1 wires dormant reasoners / `_pl_atom` helper; this PR only adds comments to the D1 enrichment block). References #1172 (merged).

Opportunistic — this was flagged by Hermes as "transmis à po-2023 pour polish opportuniste" (R441). Worker idle otherwise (T1 #1174 + β #1175 await admin merge; R1 #1171 gated).
