### PR TITLE
feat(counter-arg): G6 #1180 surface ValidationResult from 5-criteria eval

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -506,8 +506,16 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         strategy: str,
         score: float,
         target_arg_id: Optional[str] = None,
+        validation: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """Add a counter-argument result."""
+        """Add a counter-argument result.
+
+        G6 (#1180): ``validation`` carries the populated ``ValidationResult``
+        verdict (is_valid_attack / original_survives / counter_succeeds /
+        logical_consistency / formal_representation) so the restitution report
+        (Acte II/III) can cite counter-argument *validity*, not just existence.
+        Stored only when non-empty (honest — never fabricated).
+        """
         ca_id = self._generate_id("ca", self.counter_arguments)
         entry = {
             "id": ca_id,
@@ -518,6 +526,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         }
         if target_arg_id:
             entry["target_arg_id"] = target_arg_id
+        if validation:
+            entry["validation"] = validation
         self.counter_arguments.append(entry)
         state_logger.info(f"Counter-argument added: {ca_id} (strategy: {strategy})")
         return ca_id

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -1201,6 +1201,60 @@ async def _invoke_counter_argument(
     return result
 
 
+def _build_counter_argument_validation(
+    overall_score: float,
+    logical_strength: float,
+) -> Dict[str, Any]:
+    """Populate a counter-argument ``validation`` dict (G6 #1180, Epic #1165).
+
+    The unified ``ValidationResult`` (``counter_argument/definitions.py:94``)
+    was defined + exported but never populated in the pipeline — the 4 boolean
+    fields (``is_valid_attack``/``original_survives``/``counter_succeeds``/
+    ``logical_consistency``) came, in the original student deliverable
+    (``counter_agent/logic/tweety_bridge.py``), from a Dung-theory attack
+    graph built per counter-argument. That formal bridge was dropped during
+    the #35 unification (β audit gap G6).
+
+    Anti-pendule / fail-loud (#1019): we do NOT fabricate a formal Dung
+    verdict here. We surface the *already-computed* 5-criteria evaluation
+    (the evaluator's real output) into the validation shape, with thresholds
+    derived from the original student fallback
+    (``tweety_bridge._fallback_validation``), which itself mapped strength
+    labels → booleans. The unified evaluator produces a continuous
+    ``overall_score`` ∈ [0,1] (weighted sum of 5 criteria, each ∈ [0,1]),
+    a richer signal than the student's categorical strength — so we map the
+    score onto the boolean fields with documented thresholds, and we label
+    ``formal_representation`` honestly as a heuristic (NOT a Tweety check):
+
+      - ``counter_succeeds``: overall_score ≥ 0.5 (the counter lands).
+      - ``original_survives``: overall_score < 0.6 (the original still holds
+        below a strong counter). Asymmetric vs ``counter_succeeds`` by design:
+        a mid-range counter both lands and leaves the original partially
+        standing (a real dynamic in argumentation).
+      - ``is_valid_attack``: counter_succeeds AND logical_strength ≥ 0.4
+        (a landing counter that is also internally coherent).
+      - ``logical_consistency``: logical_strength ≥ 0.4 (the counter's own
+        internal logic is coherent — not a cross-argument Dung check).
+
+    Returns a plain dict (not the dataclass) so it serializes into the state
+    entry without an import dependency at write time.
+    """
+    counter_succeeds = overall_score >= 0.5
+    original_survives = overall_score < 0.6
+    is_valid_attack = counter_succeeds and logical_strength >= 0.4
+    logical_consistency = logical_strength >= 0.4
+    return {
+        "is_valid_attack": is_valid_attack,
+        "original_survives": original_survives,
+        "counter_succeeds": counter_succeeds,
+        "logical_consistency": logical_consistency,
+        "formal_representation": (
+            "heuristic (5-criteria weighted score; not a Tweety/Dung "
+            "formal verification)"
+        ),
+    }
+
+
 def _evaluate_counter_arguments(
     llm_counters: List[Dict[str, Any]], input_text: str
 ) -> List[Dict[str, Any]]:
@@ -1208,6 +1262,12 @@ def _evaluate_counter_arguments(
 
     Wraps each LLM-generated dict into proper Argument/CounterArgument dataclass
     objects, runs the 5-criteria evaluator, and attaches the evaluation_score.
+
+    G6 (#1180): also populates a ``validation`` dict (``ValidationResult`` shape)
+    from the already-computed evaluation, so the counter-argument *validity*
+    verdict reaches the state and the restitution report can cite it — not
+    just that counter-arguments exist. Surface-only (no fabricated formal
+    signal); see ``_build_counter_argument_validation``.
     """
     try:
         from argumentation_analysis.agents.core.counter_argument.evaluator import (
@@ -1277,6 +1337,14 @@ def _evaluate_counter_arguments(
                 "clarity": round(evaluation.clarity, 3),
                 "recommendations": evaluation.recommendations,
             }
+            # G6 (#1180): surface the validation verdict from the computed
+            # evaluation. Anti-pendule: built from the real overall_score +
+            # logical_strength, never fabricated. Fail-loud: if this branch
+            # runs, evaluation succeeded; the validation dict is always set.
+            ca_dict["validation"] = _build_counter_argument_validation(
+                float(evaluation.overall_score),
+                float(evaluation.logical_strength),
+            )
         except Exception as e:
             logger.debug(f"Counter-argument evaluation skipped: {e}")
     return llm_counters

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -158,9 +158,20 @@ def _write_counter_argument_to_state(
                 score = float(evaluation["overall_score"])
             else:
                 score = strength_map.get(str(llm_ca.get("strength", "")).lower(), 0.5)
+            # G6 (#1180): persist the validation verdict (ValidationResult shape)
+            # when the evaluator populated it. Surface-only — absent if the
+            # evaluator did not run (no fabrication).
+            validation = llm_ca.get("validation")
+            if not isinstance(validation, dict):
+                validation = None
             arg_id = _resolve_target_arg_id(state, target)
             state.add_counter_argument(
-                target, counter_text, strategy_name, score, target_arg_id=arg_id
+                target,
+                counter_text,
+                strategy_name,
+                score,
+                target_arg_id=arg_id,
+                validation=validation,
             )
         return
 
@@ -171,9 +182,17 @@ def _write_counter_argument_to_state(
         counter_text = str(llm_ca.get("counter_argument", ""))
         strategy_name = str(llm_ca.get("strategy_used", "unknown"))
         score = strength_map.get(str(llm_ca.get("strength", "")).lower(), 0.5)
+        validation = llm_ca.get("validation")
+        if not isinstance(validation, dict):
+            validation = None
         arg_id = _resolve_target_arg_id(state, target)
         state.add_counter_argument(
-            target, counter_text, strategy_name, score, target_arg_id=arg_id
+            target,
+            counter_text,
+            strategy_name,
+            score,
+            target_arg_id=arg_id,
+            validation=validation,
         )
         return
 

--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -76,6 +76,10 @@ class CounterEvidence:
     strategy: str
     target_arg_id: str
     snippet: str
+    # G6 (#1180): validation verdict (ValidationResult shape) so the narrative
+    # can cite counter-argument *validity*. None when the evaluator did not run.
+    is_valid_attack: Optional[bool] = None
+    counter_succeeds: Optional[bool] = None
 
 
 @dataclass
@@ -306,11 +310,23 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
         tid = ca.get("target_arg_id") or ""
         if not tid:
             continue
+        validation = ca.get("validation")
+        is_valid_attack = None
+        counter_succeeds = None
+        if isinstance(validation, dict):
+            iva = validation.get("is_valid_attack")
+            if isinstance(iva, bool):
+                is_valid_attack = iva
+            cs = validation.get("counter_succeeds")
+            if isinstance(cs, bool):
+                counter_succeeds = cs
         counter_by_arg.setdefault(tid, []).append(
             CounterEvidence(
                 strategy=str(ca.get("strategy", "")),
                 target_arg_id=str(tid),
                 snippet=_truncate(ca.get("counter_content", ""), _COUNTER_CAP),
+                is_valid_attack=is_valid_attack,
+                counter_succeeds=counter_succeeds,
             )
         )
 

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -112,6 +112,11 @@ class CounterStrategy:
     strategy: str
     target_arg_id: str
     snippet: str
+    # G6 (#1180): the validation verdict (ValidationResult shape) so the
+    # narrative can cite counter-argument *validity*, not just existence.
+    # None when the evaluator did not run (honest absence, not fabricated).
+    is_valid_attack: Optional[bool] = None
+    counter_succeeds: Optional[bool] = None
 
 
 @dataclass
@@ -501,11 +506,24 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
         content = ca.get("counter_content") or ""
         if not (tid or content):
             continue
+        # G6 (#1180): surface the validation verdict (absent → None, honest).
+        validation = ca.get("validation")
+        is_valid = None
+        succeeds = None
+        if isinstance(validation, dict):
+            _iv = validation.get("is_valid_attack")
+            _cs = validation.get("counter_succeeds")
+            if isinstance(_iv, bool):
+                is_valid = _iv
+            if isinstance(_cs, bool):
+                succeeds = _cs
         counter_strategies.append(
             CounterStrategy(
                 strategy=str(ca.get("strategy", "")),
                 target_arg_id=str(tid),
                 snippet=_truncate(content, _COUNTER_CAP),
+                is_valid_attack=is_valid,
+                counter_succeeds=succeeds,
             )
         )
 

--- a/tests/unit/argumentation_analysis/orchestration/test_counter_argument_caps_gg.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_counter_argument_caps_gg.py
@@ -465,3 +465,73 @@ class TestYYCounterArgumentFloor:
             f"YY #730 floor: 24 expected, got {result['added']} (must be ≥19 to "
             "beat 0-shot=18 on corpus_C)"
         )
+
+
+class TestG6CounterArgumentValidation:
+    """G6 (#1180): surface counter-argument validity from the 5-criteria eval.
+
+    ``_build_counter_argument_validation`` maps the evaluator's already-computed
+    overall_score + logical_strength onto the ``ValidationResult`` shape with
+    documented thresholds (no fabricated formal/Dung signal — anti-pendule #1019).
+    """
+
+    def test_high_score_lands_and_is_valid(self):
+        v = mod._build_counter_argument_validation(0.8, 0.7)
+        assert v["counter_succeeds"] is True
+        assert v["is_valid_attack"] is True
+        assert v["logical_consistency"] is True
+        # original_survives is the asymmetric partner (a strong counter lowers it)
+        assert v["original_survives"] is False
+        assert "heuristic" in v["formal_representation"]
+
+    def test_low_score_fails_and_original_survives(self):
+        v = mod._build_counter_argument_validation(0.2, 0.1)
+        assert v["counter_succeeds"] is False
+        assert v["is_valid_attack"] is False
+        assert v["logical_consistency"] is False
+        assert v["original_survives"] is True
+
+    def test_mid_score_asymmetry(self):
+        """A mid-range counter (0.55) both lands AND leaves the original standing."""
+        v = mod._build_counter_argument_validation(0.55, 0.3)
+        assert v["counter_succeeds"] is True
+        assert v["original_survives"] is True
+        # logical_strength below 0.4 ⇒ not a coherent/valid attack
+        assert v["is_valid_attack"] is False
+
+    def test_validation_populated_in_evaluate_loop(self):
+        """``_evaluate_counter_arguments`` attaches validation when eval succeeds.
+
+        We mock the evaluator so the 5-criteria math runs through the real
+        population path (not a fabricated signal). Fail-loud: if the evaluator
+        returns an object, validation is ALWAYS set.
+        """
+        fake_eval = MagicMock()
+        fake_eval.overall_score = 0.75
+        fake_eval.logical_strength = 0.6
+        fake_eval.relevance = 0.5
+        fake_eval.persuasiveness = 0.5
+        fake_eval.originality = 0.5
+        fake_eval.clarity = 0.5
+        fake_eval.recommendations = []
+        fake_evaluator = MagicMock()
+        fake_evaluator.evaluate.return_value = fake_eval
+        with patch(
+            "argumentation_analysis.agents.core.counter_argument.evaluator.CounterArgumentEvaluator",
+            return_value=fake_evaluator,
+        ):
+            out = mod._evaluate_counter_arguments(
+                [
+                    {
+                        "counter_argument": "contredit la thèse par un exemple.",
+                        "strategy_used": "counter-example",
+                        "target_argument": "la thèse X",
+                        "strength": "strong",
+                    }
+                ],
+                "la thèse X",
+            )
+        assert out and out[0].get("validation") is not None
+        assert out[0]["validation"]["counter_succeeds"] is True
+        assert out[0]["validation"]["is_valid_attack"] is True
+

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -198,6 +198,45 @@ class TestBuildEvidence:
         assert len(ev.counter_strategies) == 1
         assert ev.counter_strategies[0].strategy == "contre-exemple"
 
+    def test_counter_validation_surfaced_g6(self):
+        """G6 (#1180): validation verdict (from 5-criteria eval) reaches Acte III."""
+        state = _state(
+            counter_arguments=[
+                {
+                    "target_arg_id": "arg_1",
+                    "strategy": "contre-exemple",
+                    "counter_content": "Attaque la thèse, pas la personne.",
+                    "validation": {
+                        "is_valid_attack": True,
+                        "counter_succeeds": True,
+                        "original_survives": False,
+                        "logical_consistency": True,
+                    },
+                }
+            ]
+        )
+        ev = build_act3_evidence(state)
+        assert len(ev.counter_strategies) == 1
+        cs = ev.counter_strategies[0]
+        assert cs.is_valid_attack is True
+        assert cs.counter_succeeds is True
+
+    def test_counter_validation_absent_is_none_g6(self):
+        """When the evaluator did not run, validation stays None (no #1019 fabrication)."""
+        state = _state(
+            counter_arguments=[
+                {
+                    "target_arg_id": "arg_1",
+                    "strategy": "contre-exemple",
+                    "counter_content": "Attaque la thèse.",
+                }
+            ]
+        )
+        ev = build_act3_evidence(state)
+        cs = ev.counter_strategies[0]
+        assert cs.is_valid_attack is None
+        assert cs.counter_succeeds is None
+
     def test_quality_strengths_collected(self):
         ev = build_act3_evidence(_rich_state())
         virtues = {s.virtue for s in ev.quality_strengths}


### PR DESCRIPTION
## What

Track **G6 #1180** (R442 dispatch, Epic #1165 Culmination). The unified `ValidationResult` (`counter_argument/definitions.py:94`) was defined + exported but **never populated** in the pipeline. Its 4 boolean fields originally came (student deliverable `2.3.3-generation-contre-argument/counter_agent/logic/tweety_bridge.py`) from a Dung-theory attack graph built per counter-argument — a formal bridge dropped during the #35 unification (β fidelity-audit gap G6). This left a developed capability *debranched* from the restitution report.

## Anti-pendule / fail-loud (#1019)

We do **NOT** fabricate a formal Dung verdict. We surface the **already-computed** 5-criteria evaluation into the validation shape, with thresholds derived from the original student fallback (`tweety_bridge._fallback_validation`, which itself mapped strength labels → booleans). `formal_representation` is honestly labelled `"heuristic (5-criteria weighted score; not a Tweety/Dung formal verification)"`.

Thresholds (documented in `_build_counter_argument_validation`):
- `counter_succeeds` = overall_score ≥ 0.5
- `original_survives` = overall_score < 0.6 *(asymmetric by design — a mid-range counter both lands and leaves the original standing)*
- `is_valid_attack` = counter_succeeds AND logical_strength ≥ 0.4
- `logical_consistency` = logical_strength ≥ 0.4

## Plumbing (file:line)

| Layer | File | Change |
|---|---|---|
| Populate | `invoke_callables.py:1204` | `_build_counter_argument_validation(overall_score, logical_strength)` helper |
| Populate | `invoke_callables.py:1344` | set `ca_dict["validation"]` in `_evaluate_counter_arguments` (only after evaluator succeeds → fail-loud) |
| Persist | `shared_state.py` `add_counter_argument` | optional `validation` kwarg (entry set only when truthy) |
| Persist | `state_writers.py` `_write_counter_argument_to_state` | passes `validation` on multi-CA + single-CA paths |
| Surface | `act2_narrative_plugin.py` `CounterEvidence` | +`is_valid_attack`/`counter_succeeds` Optional[bool], populated from `ca["validation"]` |
| Surface | `act3_conclusion_plugin.py` `CounterStrategy` | same fields, isinstance-guarded |

The restitution report can now cite counter-argument **validity**, not just existence (DoD: "Acte II/III peut référencer la validité counter-arg").

## Fail-loud

`validation` is set **only** inside the `try` block after `evaluator.evaluate()` succeeds. If the evaluator does not run (import error / exception), the key is absent and the restitution fields stay `None` (honest "evaluator did not run") — no degraded consumer, no fabricated signal.

## Tests

- `_build_counter_argument_validation` thresholds: high (lands + valid), low (fails + survives), mid (asymmetry: lands AND survives, but low logical_strength ⇒ not valid).
- `_evaluate_counter_arguments` populates `validation` through the real path (mocked evaluator).
- act3: validation surfaced; absent-validation → `None` (no fabrication).
- 205 restitution + workflow_state tests green; 95 act2/shared_state/caps tests green.
- mypy --strict clean on all 5 source files.

## Files removed and why

None — additive feature.

Part of Epic #1165 (Culmination). Collision-safe vs po-2025's workflows.py + logic-handler work this round (disjoint scope: counter_argument/ + counter-arg blocks only).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>