### PR TITLE
feat(restitution): SV #1182 surface governance + debate into Acte II/III

### DIFF
--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -47,6 +47,10 @@ LlmCallable = Callable[[str], Awaitable[str]]
 _DESC_CAP = 220
 _JUSTIFICATION_CAP = 200
 _COUNTER_CAP = 200
+# SV (#1182): truncation + count caps for governance/debate evidence (privacy
+# + prompt-budget discipline; the LLM paraphrases, never echoes).
+_DEBATE_CAP = 220
+_DEBATE_MAX_EXCHANGES = 6
 
 # Fallacy families form the mouvement theme (taxonomy constants, not source
 # content — safe to surface). The reserved theme for arguments no fallacy
@@ -115,12 +119,46 @@ class FormalFinding:
 
 
 @dataclass
+class GovernanceVerdict:
+    """A governance voting decision (7-method social-choice layer), verified-in-state.
+
+    SV (#1182): the spectacular pipeline runs a governance phase (7 voting methods,
+    Copeland winner, consensus) but it was invisible in the report — the same
+    debranching G6 fixed for counter-argument validity. ``scores`` maps opaque
+    option IDs → Copeland/influence score (privacy: opaque keys, never party names).
+    """
+
+    method: str
+    winner: str
+    scores: Dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class DebateExchange:
+    """One Walton-Krabbe adversarial-debate exchange (point vs rebuttal).
+
+    SV (#1182): the debate phase produces key exchanges. NB (gap β G8): the
+    schemes-engine (student ``ArgumentationEngine`` 10 schemes) was dropped in the
+    #35 unification → exchanges can be sparse. We surface what exists honestly
+    and never fabricate a rich debate (#1019). G8 is a separate follow-up.
+    """
+
+    point: str
+    rebuttal: str
+
+
+@dataclass
 class Act2Evidence:
     """Deterministic evidence bundle for the Acte II narrative."""
 
     movements: List[MovementEvidence] = field(default_factory=list)
     formal_findings: List[FormalFinding] = field(default_factory=list)
     quality_axis_available: bool = True
+    # SV (#1182): governance voting verdict + adversarial-debate exchanges,
+    # surfaced so the narrative can cite them. Empty/None when the phases did
+    # not produce non-trivial output (honest absence, not fabricated).
+    governance_verdict: Optional[GovernanceVerdict] = None
+    debate_exchanges: List[DebateExchange] = field(default_factory=list)
     args_total: int = 0
     fallacies_total: int = 0
     # Note (a) (#1153): fallacies whose target_argument_id could not be
@@ -403,6 +441,10 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
 
     formal_findings = _collect_formal_findings(state)
     virtuous_mode = detect_virtuous_mode(state)
+    # SV (#1182): surface governance verdict + debate exchanges (debranched
+    # capabilities — same fix shape as G6 for counter-arg validity).
+    governance_verdict = _collect_governance(state)
+    debate_exchanges = _collect_debate(state)
 
     return Act2Evidence(
         movements=ordered,
@@ -412,7 +454,80 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
         fallacies_total=fallacies_total,
         unattributed_fallacies=unattributed_fallacies,
         virtuous_mode=virtuous_mode,
+        governance_verdict=governance_verdict,
+        debate_exchanges=debate_exchanges,
     )
+
+
+def _collect_governance(state: Any) -> Optional[GovernanceVerdict]:
+    """Collect the governance voting verdict (SV #1182, spec §1.2.4 social-choice).
+
+    Reads ``state.governance_decisions`` (written by
+    ``state_writers._write_governance_to_state``). Each entry carries the
+    recommended voting ``method``, the ``winner`` (Copeland / recommended
+    resolution), and per-option ``scores``. We surface the LAST decision (the
+    terminal aggregation) — fail-loud: return ``None`` when the list is empty
+    or carries no non-trivial winner/scores (no fabricated verdict, #1019).
+
+    Privacy: option keys are kept as-is (opaque IDs from the pipeline). The
+    writer already scrubs source names; we never echo raw option labels.
+    """
+    decisions = getattr(state, "governance_decisions", []) or []
+    if not isinstance(decisions, list):
+        return None
+    chosen: Optional[GovernanceVerdict] = None
+    for d in decisions:
+        if not isinstance(d, dict):
+            continue
+        method = str(d.get("method", "")).strip()
+        winner = str(d.get("winner", "")).strip()
+        raw_scores = d.get("scores", {}) or {}
+        scores: Dict[str, float] = {}
+        if isinstance(raw_scores, dict):
+            for k, v in raw_scores.items():
+                try:
+                    scores[str(k)] = float(v)
+                except (TypeError, ValueError):
+                    continue
+        # Trivial / placeholder winners ("N/A", empty) carry no verdict.
+        if not method or not winner or winner == "N/A":
+            continue
+        chosen = GovernanceVerdict(method=method, winner=winner, scores=scores)
+    return chosen
+
+
+def _collect_debate(state: Any) -> List[DebateExchange]:
+    """Collect adversarial-debate key exchanges (SV #1182, spec §1.2.4).
+
+    Reads ``state.debate_transcripts`` (written by
+    ``state_writers._write_debate_to_state``). Each transcript carries a list of
+    ``exchanges`` (point + rebuttal). Gap β G8: the schemes-engine was dropped in
+    #35 unification → exchanges can be sparse; we surface ONLY the real, non-empty
+    ones and never invent exchanges (#1019). Capped to keep the prompt budget sane.
+    """
+    transcripts = getattr(state, "debate_transcripts", []) or []
+    if not isinstance(transcripts, list):
+        return []
+    out: List[DebateExchange] = []
+    for t in transcripts:
+        if not isinstance(t, dict):
+            continue
+        exchanges = t.get("exchanges", []) or []
+        if not isinstance(exchanges, list):
+            continue
+        for ex in exchanges:
+            if not isinstance(ex, dict):
+                continue
+            point = _truncate(ex.get("point", ""), _DEBATE_CAP)
+            rebuttal = _truncate(ex.get("rebuttal", ""), _DEBATE_CAP)
+            # Fail-loud: skip empty exchanges (no point AND no rebuttal) — they
+            # would read as fabricated debate matter (#1019).
+            if not point and not rebuttal:
+                continue
+            out.append(DebateExchange(point=point, rebuttal=rebuttal))
+            if len(out) >= _DEBATE_MAX_EXCHANGES:
+                return out
+    return out
 
 
 def _pl_verdict(result: Dict[str, Any]) -> Optional[bool]:
@@ -622,6 +737,32 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
             for f in evidence.formal_findings
         )
 
+    # --- SV (#1182): délibération collective (governance + debate) ---
+    # Both capabilities were completing in the 40 phases but invisible in the
+    # report. We surface what exists — honestly sparse when the schemes-engine
+    # gap (β G8) left debate thin. Each citation must bind to a narrative beat
+    # (spec §4 anti-énumération); never a bare score/label line.
+    deliberation_lines: List[str] = []
+    gv = evidence.governance_verdict
+    if gv is not None:
+        deliberation_lines.append(
+            f"  - GOUVERNANCE : sous la méthode « {gv.method} », l'option "
+            f"{gv.winner} sort gagnante du vote social-choice. "
+            "(noms d'options maintenus opaques — discipline FB-34.)"
+        )
+    if evidence.debate_exchanges:
+        for i, ex in enumerate(evidence.debate_exchanges, start=1):
+            deliberation_lines.append(
+                f"  - DÉBAT (échange {i}) : position « {ex.point} » / "
+                f"réplique « {ex.rebuttal} »."
+            )
+    deliberation_block = (
+        "\n".join(deliberation_lines)
+        if deliberation_lines
+        else "  (aucune délibération governance/débat non-triviale dans le state — "
+        "ne la fabrique pas, note l'absence honnêtement si tu l'évoques)"
+    )
+
     quality_note = (
         "L'axe qualité est disponible : tisse les vertus comme CARACTÈRE."
         if evidence.quality_axis_available
@@ -640,6 +781,10 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
         f"{chr(10).join(blocks)}\n\n"
         f"TENUE FORMELLE (ancres vérifiées, à tisser comme PREUVE d'un battement) :\n"
         f"{formal_block}\n\n"
+        f"DÉLIBÉRATION COLLECTIVE (governance + débat, à tisser dans le récit — "
+        f"le verdict de gouvernance ou un échange de débat peut appuyer un "
+        f"battement, jamais une sous-section isolée) :\n"
+        f"{deliberation_block}\n\n"
         f"{quality_note}\n\n"
         "CONSIGNE DE RÉDACTION :\n"
         "- Pour chaque mouvement, écris un paragraphe qui tisse en UN battement : "

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -64,6 +64,9 @@ LlmCallable = Callable[[str], Awaitable[str]]
 _JUSTIFICATION_CAP = 200
 _COUNTER_CAP = 200
 _SYNTHESIS_CAP = 400
+# SV (#1182): caps for governance/debate evidence (privacy + prompt budget).
+_DEBATE_CAP = 200
+_DEBATE_MAX_EXCHANGES = 4
 
 # Verdict bands (adapted from #1008 §2.1 to the restitution coverage model).
 _BAND_EXCEEDED = "EXCEEDED"
@@ -120,6 +123,27 @@ class CounterStrategy:
 
 
 @dataclass
+class GovernanceVerdict:
+    """A governance voting decision (SV #1182), verified-in-state.
+
+    ``scores`` maps opaque option IDs → Copeland/influence score. Privacy: the
+    keys are opaque (no party/option names).
+    """
+
+    method: str
+    winner: str
+    scores: Dict[str, float] = field(default_factory=dict)
+
+
+@dataclass
+class DebateExchange:
+    """One adversarial-debate exchange (SV #1182). Gap β G8: can be sparse."""
+
+    point: str
+    rebuttal: str
+
+
+@dataclass
 class QualityStrength:
     """A virtue where the discourse scores well (a strength to acknowledge)."""
 
@@ -159,6 +183,11 @@ class Act3Evidence:
     verdict: Optional[VerdictBand] = None
     narrative_synthesis_available: bool = False
     gates: Dict[str, bool] = field(default_factory=dict)
+    # SV (#1182): governance verdict + debate exchanges, surfaced so the
+    # conclusion can cite collective deliberation. None/empty when the phases
+    # produced no non-trivial output (honest absence, not fabricated).
+    governance_verdict: Optional[GovernanceVerdict] = None
+    debate_exchanges: List[DebateExchange] = field(default_factory=list)
     # DERIVED virtuous flag (spec §5.1) — drives virtue-first titling when the
     # state characterises the text as virtuous (zero fallacies + non-trivial
     # quality/formal axis). None until build_act3_evidence populates it.
@@ -402,6 +431,65 @@ def _collect_quality_strengths(quality: Dict[str, Any]) -> List[QualityStrength]
     ]
 
 
+def _collect_governance(state: Any) -> Optional[GovernanceVerdict]:
+    """Collect the governance voting verdict (SV #1182).
+
+    Reads ``state.governance_decisions``; surfaces the LAST non-trivial decision.
+    Fail-loud: ``None`` when empty or winner is a placeholder ("N/A"/empty) —
+    no fabricated verdict (#1019). Privacy: option keys stay opaque.
+    """
+    decisions = getattr(state, "governance_decisions", []) or []
+    if not isinstance(decisions, list):
+        return None
+    chosen: Optional[GovernanceVerdict] = None
+    for d in decisions:
+        if not isinstance(d, dict):
+            continue
+        method = str(d.get("method", "")).strip()
+        winner = str(d.get("winner", "")).strip()
+        if not method or not winner or winner == "N/A":
+            continue
+        raw_scores = d.get("scores", {}) or {}
+        scores: Dict[str, float] = {}
+        if isinstance(raw_scores, dict):
+            for k, v in raw_scores.items():
+                try:
+                    scores[str(k)] = float(v)
+                except (TypeError, ValueError):
+                    continue
+        chosen = GovernanceVerdict(method=method, winner=winner, scores=scores)
+    return chosen
+
+
+def _collect_debate(state: Any) -> List[DebateExchange]:
+    """Collect adversarial-debate exchanges (SV #1182). Gap β G8: can be sparse.
+
+    Reads ``state.debate_transcripts``; surfaces ONLY non-empty exchanges
+    (fail-loud: empty point+rebuttal would read as fabricated matter, #1019).
+    """
+    transcripts = getattr(state, "debate_transcripts", []) or []
+    if not isinstance(transcripts, list):
+        return []
+    out: List[DebateExchange] = []
+    for t in transcripts:
+        if not isinstance(t, dict):
+            continue
+        exchanges = t.get("exchanges", []) or []
+        if not isinstance(exchanges, list):
+            continue
+        for ex in exchanges:
+            if not isinstance(ex, dict):
+                continue
+            point = _truncate(ex.get("point", ""), _DEBATE_CAP)
+            rebuttal = _truncate(ex.get("rebuttal", ""), _DEBATE_CAP)
+            if not point and not rebuttal:
+                continue
+            out.append(DebateExchange(point=point, rebuttal=rebuttal))
+            if len(out) >= _DEBATE_MAX_EXCHANGES:
+                return out
+    return out
+
+
 def _compute_verdict_band(
     axes_nontrivial: List[str],
 ) -> VerdictBand:
@@ -534,6 +622,11 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
         narrative_synthesis and isinstance(narrative_synthesis, str) and narrative_synthesis.strip()
     )
 
+    # SV (#1182): surface governance verdict + debate exchanges (debranched
+    # capabilities — same fix shape as G6 for counter-arg validity).
+    governance_verdict = _collect_governance(state)
+    debate_exchanges = _collect_debate(state)
+
     # G1–G4 (#1008 §3.2). G3 passes once a band is computable (always, given the
     # deterministic scorer); G4 is structural (we only surface real-in-state
     # fields). The orchestrator emits the honest fallback when any gate fails.
@@ -559,6 +652,8 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
         narrative_synthesis_available=narrative_synthesis_available,
         gates=gates,
         virtuous_mode=virtuous_mode,
+        governance_verdict=governance_verdict,
+        debate_exchanges=debate_exchanges,
     )
 
 
@@ -736,6 +831,26 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         "localisées."
     )
 
+    # --- SV (#1182): délibération collective (governance + debate) ---
+    deliberation_lines: List[str] = []
+    gv = evidence.governance_verdict
+    if gv is not None:
+        deliberation_lines.append(
+            f"  - GOUVERNANCE : méthode « {gv.method} » — l'option {gv.winner} "
+            "sort gagnante du vote social-choice. (options opaques, FB-34.)"
+        )
+    if evidence.debate_exchanges:
+        for i, ex in enumerate(evidence.debate_exchanges, start=1):
+            deliberation_lines.append(
+                f"  - DÉBAT (échange {i}) : position « {ex.point} » / "
+                f"réplique « {ex.rebuttal} »."
+            )
+    deliberation_block = (
+        "\n".join(deliberation_lines)
+        if deliberation_lines
+        else "  (aucune délibération governance/débat non-triviale — ne la fabrique pas)"
+    )
+
     return (
         "Tu es l'auteur de l'ACTE III d'un rapport de restitution argumentative\n"
         "— la CONCLUSION ACTIONNABLE : ce que le lecteur FAIT de l'analyse.\n"
@@ -754,6 +869,7 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         f"[APPRÉCIATIONS — faiblesses localisées]\n{weaknesses_lines}\n\n"
         f"[QUE FAIRE — comment contrer]\n{counters_lines}\n\n"
         f"[QUE FAIRE — points faibles à viser]\n{target_lines}\n\n"
+        f"[DÉLIBÉRATION COLLECTIVE — governance + débat]\n{deliberation_block}\n\n"
         f"{what_next_block}\n\n"
         "CONSIGNE DE RÉDACTION :\n"
         f"{consigne_virtue}"

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
@@ -44,6 +44,8 @@ def _state(**fields: object) -> SimpleNamespace:
         fol_analysis_results=[],
         propositional_analysis_results=[],
         modal_analysis_results=[],
+        governance_decisions=[],
+        debate_transcripts=[],
     )
     base.update(fields)
     return SimpleNamespace(**base)
@@ -314,6 +316,54 @@ class TestReaderWriterContracts:
         ev = build_act2_evidence(state)
         arg1 = next(a for m in ev.movements for a in m.arguments if a.arg_id == "arg_1")
         assert arg1.dung_rejected == "stable"
+
+    def test_governance_and_debate_surfaced_sv(self):
+        """SV (#1182): governance verdict + debate exchange reach Acte II."""
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            governance_decisions=[
+                {"method": "copeland", "winner": "opt_X", "scores": {"opt_X": 0.9}}
+            ],
+            debate_transcripts=[
+                {
+                    "topic": "t",
+                    "exchanges": [{"point": "position A", "rebuttal": "réplique B"}],
+                    "winner": "pro",
+                }
+            ],
+        )
+        ev = build_act2_evidence(state)
+        assert ev.governance_verdict is not None
+        assert ev.governance_verdict.winner == "opt_X"
+        assert len(ev.debate_exchanges) == 1
+        assert ev.debate_exchanges[0].rebuttal == "réplique B"
+
+    def test_governance_trivial_and_empty_debate_fail_loud_sv(self):
+        """SV fail-loud: N/A winner → None; empty exchange → [] (#1019)."""
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            governance_decisions=[{"method": "majority", "winner": "N/A", "scores": {}}],
+            debate_transcripts=[{"exchanges": [{"point": "", "rebuttal": ""}]}],
+        )
+        ev = build_act2_evidence(state)
+        assert ev.governance_verdict is None
+        assert ev.debate_exchanges == []
+
+    def test_deliberation_block_in_prompt_sv(self):
+        """SV: the deliberation block reaches the Acte II conducted prompt."""
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            governance_decisions=[
+                {"method": "copeland", "winner": "opt_X", "scores": {"opt_X": 0.9}}
+            ],
+            debate_transcripts=[
+                {"topic": "t", "exchanges": [{"point": "p", "rebuttal": "r"}]}
+            ],
+        )
+        ev = build_act2_evidence(state)
+        prompt = build_act2_prompt(ev)
+        assert "DÉLIBÉRATION COLLECTIVE" in prompt
+        assert "opt_X" in prompt
 
     def test_note_a_unresolved_fallacy_traced_not_dropped(self):
         # A fallacy with no target_argument_id must be counted apart, not lost.

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -52,6 +52,8 @@ def _state(**fields: object) -> SimpleNamespace:
         propositional_analysis_results=[],
         modal_analysis_results=[],
         narrative_synthesis="",
+        governance_decisions=[],
+        debate_transcripts=[],
     )
     base.update(fields)
     return SimpleNamespace(**base)
@@ -236,6 +238,49 @@ class TestBuildEvidence:
         cs = ev.counter_strategies[0]
         assert cs.is_valid_attack is None
         assert cs.counter_succeeds is None
+
+    def test_governance_and_debate_surfaced_sv(self):
+        """SV (#1182): governance verdict + debate exchange reach Acte III."""
+        state = _state(
+            governance_decisions=[
+                {"method": "copeland", "winner": "opt_X", "scores": {"opt_X": 0.9}}
+            ],
+            debate_transcripts=[
+                {
+                    "topic": "t",
+                    "exchanges": [{"point": "la thèse P", "rebuttal": "or Q"}],
+                    "winner": "pro",
+                }
+            ],
+        )
+        ev = build_act3_evidence(state)
+        assert ev.governance_verdict is not None
+        assert ev.governance_verdict.winner == "opt_X"
+        assert ev.governance_verdict.method == "copeland"
+        assert len(ev.debate_exchanges) == 1
+        assert ev.debate_exchanges[0].point == "la thèse P"
+
+    def test_governance_trivial_winner_is_none_sv(self):
+        """SV fail-loud: a placeholder 'N/A' winner carries no verdict (#1019)."""
+        state = _state(
+            governance_decisions=[{"method": "majority", "winner": "N/A", "scores": {}}],
+            debate_transcripts=[{"exchanges": [{"point": "", "rebuttal": ""}]}],
+        )
+        ev = build_act3_evidence(state)
+        assert ev.governance_verdict is None
+        assert ev.debate_exchanges == []
+
+    def test_deliberation_block_in_prompt_sv(self):
+        """SV: the deliberation block reaches the conducted prompt."""
+        state = _state(
+            governance_decisions=[
+                {"method": "copeland", "winner": "opt_X", "scores": {"opt_X": 0.9}}
+            ],
+        )
+        ev = build_act3_evidence(state)
+        prompt = build_act3_prompt(ev)
+        assert "DÉLIBÉRATION COLLECTIVE" in prompt
+        assert "opt_X" in prompt
 
     def test_quality_strengths_collected(self):
         ev = build_act3_evidence(_rich_state())


### PR DESCRIPTION
## What

Track **SV #1182** (R443 dispatch, Epic #1165 Culmination). The spectacular pipeline runs **governance** (7 voting methods, Copeland winner, consensus) and **adversarial-debate** (Walton-Krabbe) phases — both complete in the 40-phase set — but they were **invisible** in the restitution report (`grep -niE "debate|governance|vote" act2/act3 plugins` = 0 content hits, verified independently per FB-39). Same debranching G6 #1180 fixed for counter-argument validity.

This serves the R440 mandate: « toutes les capacités développées proprement digérées et intégrées dans le rapport final ».

## Anti-pendule / fail-loud (#1019)

We surface **ONLY real-in-state** output and never fabricate deliberation matter.

- **GovernanceVerdict** (`method`/`winner`/`scores`): surfaces the LAST non-trivial `governance_decisions` entry; a placeholder winner `"N/A"`/empty → `None` (no fabricated verdict). Privacy: option keys stay opaque (FB-34).
- **DebateExchange** (`point`/`rebuttal`): surfaces **ONLY non-empty** exchanges; empty point+rebuttal → skipped. **Gap β G8** (the schemes-engine `ArgumentationEngine` 10 schemes was dropped in #35 unification → debate can be sparse) is surfaced honestly — G8 is a separate follow-up, **not invented here**.

## Plumbing (mirror G6, file:line)

| File | Change |
|---|---|
| `act2_narrative_plugin.py` | `GovernanceVerdict` + `DebateExchange` dataclasses; `Act2Evidence` fields; `_collect_governance()` + `_collect_debate()` readers (fail-loud guards); `DÉLIBÉRATION COLLECTIVE` prompt block |
| `act3_conclusion_plugin.py` | mirror dataclasses + `Act3Evidence` fields + readers; `[DÉLIBÉRATION COLLECTIVE]` prompt block |

State sources (verified): `state.governance_decisions` (writer `state_writers._write_governance_to_state`) + `state.debate_transcripts` (writer `_write_debate_to_state`).

## DoD

- [x] Acte II/III cite governance verdict + debate exchange (opaque) when non-trivial, not just phase completion.
- [x] Sparse debate surfaced honestly (β G8 noted) — no invented rich debate (#1019).
- [x] Fail-loud on empty phase (`N/A` winner → None; empty exchange → []).
- [x] ReadabilityGate §4: each citation bound to a narrative beat, never a bare score/label line.
- [x] mypy --strict clean on both files.
- [x] 73 act2+act3 tests green (6 new SV tests).

## Privacy HARD

Opaque option IDs (`opt_X`, never party/source names). Corpus-derived fields truncated (caps). No raw_text. No student dirs / `.github/` / `.claude/rules/*` touched.

## Files removed and why

None — additive feature.

Part of Epic #1165 (Culmination). Collision-safe vs po-2025 this round (po-2025 = logic handlers; me = `reporting/restitution` only).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>