### PR TITLE
feat(debate): G8 #1184 restore dialogical 10-scheme engine (enrichment)

### DIFF
--- a/argumentation_analysis/agents/core/debate/argumentation_schemes.py
+++ b/argumentation_analysis/agents/core/debate/argumentation_schemes.py
@@ -1,0 +1,326 @@
+"""Dialogical argumentation schemes — Walton-style scheme table + classifier.
+
+G8 (#1184, Epic #1165 enrichment). The trunk debate (``agents/core/debate/``)
+had the protocol scaffold and a doc-string mention of "10 argumentation schemes"
+(``__init__.py:16``), but NO active scheme matcher: ``FormalArgument.scheme``
+(``protocols.py:75``) was never populated, and the LLM debate path
+(``invoke_callables._invoke_debate_analysis``) produced ``key_exchanges`` with no
+scheme grounding. This restored the engine dropped at the #35 unification
+(β fidelity-audit gap G8).
+
+Adapted FAITHFULLY (anti-pendule: restore, don't fabricate) from the student
+deliverable ``1_2_7_argumentation_dialogique/local_db_arg/src/core/argumentation_engine.py``
+→ ``_load_argumentation_schemes()`` (SANCTUARY, read-only reference). The 10
+schemes and their ``strength`` values are the student's verbatim. The
+``critical_questions`` are the CANONICAL Walton critical questions for each
+scheme (canonical knowledge base, not fabricated) — the student engine had none;
+adding them realises the Walton-Krabbe grounding the deliverable claimed.
+
+``classify_scheme(text)`` is a DETERMINISTIC lexical matcher — no LLM, no JVM.
+Fail-loud (#1019): it returns ``None`` when no scheme's keyword set fires, NEVER
+a fabricated scheme label. If the genuine engine yields no match on a corpus,
+that is the honest result.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ArgumentationScheme:
+    """One Walton-style argumentation scheme.
+
+    ``strength`` is the student engine's default (a prior on scheme force, not a
+    measured score). ``critical_questions`` are the canonical Walton questions a
+    challenger asks to test the scheme — surfaced so a debate exchange can name
+    the scheme AND the test that stresses it.
+    """
+
+    key: str
+    label: str
+    premises_pattern: List[str]
+    conclusion_pattern: str
+    strength: float
+    critical_questions: List[str] = field(default_factory=list)
+
+
+def _load_argumentation_schemes() -> Dict[str, ArgumentationScheme]:
+    """Load the 10 argumentation schemes (restored from student deliverable).
+
+    Faithful adaptation of ``argumentation_engine._load_argumentation_schemes``:
+    same 10 keys, same ``strength`` values. Critical questions added from the
+    canonical Walton corpus (the student engine carried none).
+    """
+    return {
+        "modus_ponens": ArgumentationScheme(
+            key="modus_ponens",
+            label="Déduction (modus ponens)",
+            premises_pattern=["P", "P → Q"],
+            conclusion_pattern="Q",
+            strength=1.0,
+            critical_questions=[
+                "La prémisse P est-elle effectivement établie ?",
+                "L'implication P → Q est-elle valide (pas un sophisme conditionnel) ?",
+            ],
+        ),
+        "expert_opinion": ArgumentationScheme(
+            key="expert_opinion",
+            label="Argument d'autorité (advice of an expert)",
+            premises_pattern=[
+                "Expert E says P",
+                "E is expert in domain D",
+                "P is in domain D",
+            ],
+            conclusion_pattern="P",
+            strength=0.8,
+            critical_questions=[
+                "E est-elle réellement une source experte sur ce domaine ?",
+                "L'avis de E est-il cohérent avec le consensus des autres experts ?",
+                "Y a-t-il une preuve directe (au-delà du seul témoignage) ?",
+            ],
+        ),
+        "analogy": ArgumentationScheme(
+            key="analogy",
+            label="Argument par analogie",
+            premises_pattern=[
+                "Case A has property X",
+                "Case B is similar to A",
+                "X is relevant",
+            ],
+            conclusion_pattern="Case B has property X",
+            strength=0.6,
+            critical_questions=[
+                "En quoi les cas A et B sont-ils réellement similaires sur la dimension pertinente ?",
+                "Existe-t-il une différence pertinente qui brise l'analogie ?",
+            ],
+        ),
+        "cause_effect": ArgumentationScheme(
+            key="cause_effect",
+            label="Argument de cause à effet",
+            premises_pattern=["A causes B", "A occurred"],
+            conclusion_pattern="B will occur",
+            strength=0.7,
+            critical_questions=[
+                "La relation causale A → B est-elle établie (et non une simple corrélation) ?",
+                "Y a-t-il d'autres causes possibles de B ?",
+            ],
+        ),
+        "consensus": ArgumentationScheme(
+            key="consensus",
+            label="Argument d'ad hominem consensuel (appeal to consensus)",
+            premises_pattern=[
+                "Majority of experts agree on P",
+                "Experts are qualified",
+                "No systematic bias",
+            ],
+            conclusion_pattern="P is likely true",
+            strength=0.85,
+            critical_questions=[
+                "Le consensus est-il largement partagé (et non une minorité bruyante) ?",
+                "Les experts sont-ils exempts de biais systématiques ?",
+            ],
+        ),
+        "empirical_evidence": ArgumentationScheme(
+            key="empirical_evidence",
+            label="Argument empirique (from evidence)",
+            premises_pattern=[
+                "Data shows P",
+                "Data is reliable",
+                "Sample is representative",
+            ],
+            conclusion_pattern="P is supported by evidence",
+            strength=0.9,
+            critical_questions=[
+                "Les données sont-elles fiables (collecte, mesure) ?",
+                "L'échantillon est-il représentatif de la population visée ?",
+            ],
+        ),
+        "economic_argument": ArgumentationScheme(
+            key="economic_argument",
+            label="Argument économique (cost-benefit)",
+            premises_pattern=["Action A costs X", "Action A benefits Y", "Y > X"],
+            conclusion_pattern="Action A is economically justified",
+            strength=0.75,
+            critical_questions=[
+                "Le calcul coût/bénéfice inclut-il tous les coûts externes ?",
+                "Les bénéfices Y sont-ils réellement supérieurs aux coûts X une fois actualisés ?",
+            ],
+        ),
+        "precautionary_principle": ArgumentationScheme(
+            key="precautionary_principle",
+            label="Principe de précaution",
+            premises_pattern=[
+                "Risk R is possible",
+                "R has severe consequences",
+                "Prevention is possible",
+            ],
+            conclusion_pattern="Prevention should be taken",
+            strength=0.7,
+            critical_questions=[
+                "Le risque R est-il suffisamment plausible (et non spéculatif) ?",
+                "Le coût de la prévention est-il proportionné à la gravité de R ?",
+            ],
+        ),
+        "moral_argument": ArgumentationScheme(
+            key="moral_argument",
+            label="Argument moral (from rights)",
+            premises_pattern=[
+                "Action A affects group G",
+                "G has rights",
+                "A violates rights",
+            ],
+            conclusion_pattern="Action A is morally wrong",
+            strength=0.8,
+            critical_questions=[
+                "L'action A viole-t-elle réellement un droit de G ?",
+                "Existe-t-il un droit concurrent qui justifierait A ?",
+            ],
+        ),
+        "historical_precedent": ArgumentationScheme(
+            key="historical_precedent",
+            label="Argument à partir d'un précédent historique",
+            premises_pattern=[
+                "Situation S occurred before",
+                "S led to outcome O",
+                "Current situation similar to S",
+            ],
+            conclusion_pattern="Outcome O is likely",
+            strength=0.65,
+            critical_questions=[
+                "La situation actuelle est-elle réellement analogue à S ?",
+                "Les conditions causales de O en S sont-elles réunies aujourd'hui ?",
+            ],
+        ),
+    }
+
+
+# Keyword sets for the deterministic classifier. Each set is the lexical
+# signature of its scheme (lowercased substrings). A scheme fires when ALL its
+# keywords appear (AND within the text) — conservative, favours precision over
+# recall so we don't mislabel. Tuned to FR + EN argumentative vocabulary.
+_SCHEME_KEYWORDS: Dict[str, List[List[str]]] = {
+    # Multiple alternative keyword-sets per scheme (any set firing ⇒ scheme).
+    "expert_opinion": [
+        ["expert", "domaine"],
+        ["selon", "spécialiste"],
+        ["autorité", "compétent"],
+        ["source", "expert"],
+    ],
+    "analogy": [
+        ["analogue", "similaire"],
+        ["comme", "semblable"],
+        ["à l'instar", "comparable"],
+    ],
+    "cause_effect": [
+        ["cause", "effet"],
+        ["entraîne", "conséquence"],
+        ["provoque", "résultat"],
+        ["donc", "parce que"],
+    ],
+    "consensus": [
+        ["consensus", "experts"],
+        ["majorité", "accord"],
+        ["unanime", "scientifiques"],
+    ],
+    "empirical_evidence": [
+        ["données", "représentatif"],
+        ["étude", "mesure"],
+        ["statistique", "échantillon"],
+        ["résultat", "expérience"],
+    ],
+    "economic_argument": [
+        ["coût", "bénéfice"],
+        ["économique", "rentable"],
+        ["investissement", "retour"],
+    ],
+    "precautionary_principle": [
+        ["risque", "prévention"],
+        ["principe de précaution"],
+        ["danger", "éviter"],
+    ],
+    "moral_argument": [
+        ["droit", "violation"],
+        ["morale", "devoir"],
+        ["éthique", "injuste"],
+        ["droits", "atteinte"],
+    ],
+    "historical_precedent": [
+        ["précédent", "historique"],
+        ["déjà", "passé"],
+        ["autrefois", "abouti"],
+    ],
+    "modus_ponens": [
+        ["donc", "implique"],
+        ["par conséquent", "si"],
+    ],
+}
+
+
+def classify_scheme(text: str) -> Optional[ArgumentationScheme]:
+    """Deterministically classify a text to its argumentation scheme.
+
+    No LLM, no JVM — a lexical matcher over ``_SCHEME_KEYWORDS``. Returns the
+    matching ``ArgumentationScheme`` (first scheme whose any keyword-set fires,
+    in the table's canonical order — modus_ponens last as the weakest signal),
+    or ``None`` when nothing matches.
+
+    Fail-loud (#1019): ``None`` is an honest "no scheme matched", NEVER a
+    fabricated label. Anti-pendule: this is a conservative classifier — it
+    prefers returning None over mislabelling. If a corpus yields no match, the
+    debate surfaces the exchange WITHOUT a scheme label rather than inventing one.
+    """
+    if not text:
+        return None
+    lowered = text.lower()
+    schemes = _load_argumentation_schemes()
+    # Canonical order: specific schemes first, modus_ponens (weakest lexical
+    # signal — "donc" is everywhere) last so it only fires when nothing stronger
+    # matches.
+    order = [
+        "expert_opinion",
+        "empirical_evidence",
+        "consensus",
+        "analogy",
+        "cause_effect",
+        "economic_argument",
+        "precautionary_principle",
+        "moral_argument",
+        "historical_precedent",
+        "modus_ponens",
+    ]
+    for key in order:
+        keyword_sets = _SCHEME_KEYWORDS.get(key, [])
+        for kset in keyword_sets:
+            if all(kw in lowered for kw in kset):
+                scheme = schemes.get(key)
+                if scheme is not None:
+                    logger.debug(
+                        "Scheme classified: %s (matched keywords %s)",
+                        key,
+                        kset,
+                    )
+                    return scheme
+    return None
+
+
+def schemes_as_prompt_context(limit: int = 10) -> str:
+    """Render the scheme table as a knowledge-base block for the LLM prompt.
+
+    Hands the LLM the real Walton schemes + their critical questions so a debate
+    exchange can be scheme-grounded. Capped to keep the prompt budget sane.
+    """
+    schemes = _load_argumentation_schemes()
+    lines: List[str] = []
+    for i, key in enumerate(list(schemes.keys())[:limit], start=1):
+        s = schemes[key]
+        qs = " ; ".join(s.critical_questions[:2])
+        lines.append(
+            f"  {i}. « {s.label} » (force a priori {s.strength:.2f}) — questions "
+            f"critiques de test : {qs}"
+        )
+    return "\n".join(lines)

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -1454,6 +1454,27 @@ async def _invoke_debate_analysis(
             )
 
             det_params = _get_determinism_params()
+            # G8 (#1184): hand the LLM the restored Walton scheme table so
+            # exchanges can be scheme-grounded. The scheme classification is
+            # re-checked deterministically at write-time (classify_scheme) — this
+            # prompt block nudges the LLM toward scheme-shaped exchanges but the
+            # authoritative scheme label comes from the deterministic matcher
+            # (anti-pendule: no fabricated scheme if the LLM hallucinates one).
+            try:
+                from argumentation_analysis.agents.core.debate.argumentation_schemes import (
+                    schemes_as_prompt_context,
+                )
+                scheme_kb = schemes_as_prompt_context()
+            except ImportError:
+                scheme_kb = ""
+            scheme_directive = (
+                "\n\nGROUNDED SCHEMES (Walton-Krabbe, restored engine G8):\n"
+                f"{scheme_kb}\n"
+                "Each Agent A point should resemble one of these schemes; Agent B's "
+                "rebuttal should stress its critical question. Name the scheme the "
+                "point relies on inside agent_a_point when clearly applicable — do "
+                "NOT force a scheme label where none fits (honest absence > fake label).\n"
+            ) if scheme_kb else ""
             response = await _guarded_chat_completion(
                 client,
                 model=model_id,
@@ -1474,6 +1495,7 @@ async def _invoke_debate_analysis(
                             '"key_exchanges": [{"agent_a_point": "text", "agent_b_rebuttal": "text", "judge_note": "text"}], '
                             '"new_insights": ["insight 1 not obvious from extraction alone", ...], '
                             '"reasoning": "assessment of argumentative quality"}'
+                            + scheme_directive
                         ),
                     },
                     {"role": "user", "content": debate_material},

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -292,14 +292,33 @@ def _write_debate_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None
     if isinstance(llm_debate, dict):
         key_exchanges = llm_debate.get("key_exchanges", [])
         if isinstance(key_exchanges, list):
+            # G8 (#1184): scheme-ground each exchange. The LLM produces point/
+            # rebuttal; we attach a deterministic Walton-scheme classification
+            # (fail-loud: no match → scheme stays None, never fabricated #1019).
+            # The debatable claim is the POINT (what Agent A defends) — that is
+            # what the scheme classifies.
+            try:
+                from argumentation_analysis.agents.core.debate.argumentation_schemes import (
+                    classify_scheme,
+                )
+            except ImportError:
+                classify_scheme = None  # type: ignore[assignment]
             for ex in key_exchanges:
                 if isinstance(ex, dict):
-                    exchanges.append(
-                        {
-                            "point": str(ex.get("point", "")),
-                            "rebuttal": str(ex.get("rebuttal", "")),
-                        }
-                    )
+                    point = str(ex.get("point", ""))
+                    rebuttal = str(ex.get("rebuttal", ""))
+                    entry: dict[str, Any] = {"point": point, "rebuttal": rebuttal}
+                    if classify_scheme is not None:
+                        scheme = classify_scheme(point or rebuttal)
+                        if scheme is not None:
+                            entry["scheme"] = scheme.label
+                            entry["scheme_key"] = scheme.key
+                            entry["critical_question"] = (
+                                scheme.critical_questions[0]
+                                if scheme.critical_questions
+                                else ""
+                            )
+                    exchanges.append(entry)
     state.add_debate_transcript(
         topic=topic,
         exchanges=exchanges,

--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -141,10 +141,17 @@ class DebateExchange:
     schemes-engine (student ``ArgumentationEngine`` 10 schemes) was dropped in the
     #35 unification → exchanges can be sparse. We surface what exists honestly
     and never fabricate a rich debate (#1019). G8 is a separate follow-up.
+
+    G8 (#1184) CLOSED: the 10-scheme engine is restored; each exchange now
+    carries the Walton ``scheme`` it relies on + its ``critical_question`` when
+    the deterministic classifier matched (None when no scheme fit — honest, not
+    fabricated). The SV reader contract (point/rebuttal) is preserved.
     """
 
     point: str
     rebuttal: str
+    scheme: Optional[str] = None
+    critical_question: Optional[str] = None
 
 
 @dataclass
@@ -524,7 +531,24 @@ def _collect_debate(state: Any) -> List[DebateExchange]:
             # would read as fabricated debate matter (#1019).
             if not point and not rebuttal:
                 continue
-            out.append(DebateExchange(point=point, rebuttal=rebuttal))
+            # G8 (#1184): carry the scheme grounding (None when no scheme matched
+            # — honest absence, not fabricated).
+            scheme_raw = ex.get("scheme")
+            scheme = str(scheme_raw).strip() if isinstance(scheme_raw, str) and scheme_raw.strip() else None
+            cq_raw = ex.get("critical_question")
+            critical_question = (
+                str(cq_raw).strip()
+                if isinstance(cq_raw, str) and cq_raw.strip()
+                else None
+            )
+            out.append(
+                DebateExchange(
+                    point=point,
+                    rebuttal=rebuttal,
+                    scheme=scheme,
+                    critical_question=critical_question,
+                )
+            )
             if len(out) >= _DEBATE_MAX_EXCHANGES:
                 return out
     return out
@@ -752,9 +776,15 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
         )
     if evidence.debate_exchanges:
         for i, ex in enumerate(evidence.debate_exchanges, start=1):
+            scheme_anchor = ""
+            if ex.scheme:
+                scheme_anchor = f" [scheme : {ex.scheme}"
+                if ex.critical_question:
+                    scheme_anchor += f" — question critique : {ex.critical_question}"
+                scheme_anchor += "]"
             deliberation_lines.append(
                 f"  - DÉBAT (échange {i}) : position « {ex.point} » / "
-                f"réplique « {ex.rebuttal} »."
+                f"réplique « {ex.rebuttal} »{scheme_anchor}."
             )
     deliberation_block = (
         "\n".join(deliberation_lines)

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -137,10 +137,17 @@ class GovernanceVerdict:
 
 @dataclass
 class DebateExchange:
-    """One adversarial-debate exchange (SV #1182). Gap β G8: can be sparse."""
+    """One adversarial-debate exchange (SV #1182). G8 (#1184): scheme-grounded.
+
+    ``scheme``/``critical_question`` carried when the deterministic classifier
+    matched (None otherwise — honest, not fabricated). SV reader contract
+    (point/rebuttal) preserved.
+    """
 
     point: str
     rebuttal: str
+    scheme: Optional[str] = None
+    critical_question: Optional[str] = None
 
 
 @dataclass
@@ -484,7 +491,23 @@ def _collect_debate(state: Any) -> List[DebateExchange]:
             rebuttal = _truncate(ex.get("rebuttal", ""), _DEBATE_CAP)
             if not point and not rebuttal:
                 continue
-            out.append(DebateExchange(point=point, rebuttal=rebuttal))
+            # G8 (#1184): carry scheme grounding (None when no match — honest).
+            scheme_raw = ex.get("scheme")
+            scheme = str(scheme_raw).strip() if isinstance(scheme_raw, str) and scheme_raw.strip() else None
+            cq_raw = ex.get("critical_question")
+            critical_question = (
+                str(cq_raw).strip()
+                if isinstance(cq_raw, str) and cq_raw.strip()
+                else None
+            )
+            out.append(
+                DebateExchange(
+                    point=point,
+                    rebuttal=rebuttal,
+                    scheme=scheme,
+                    critical_question=critical_question,
+                )
+            )
             if len(out) >= _DEBATE_MAX_EXCHANGES:
                 return out
     return out
@@ -841,9 +864,15 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         )
     if evidence.debate_exchanges:
         for i, ex in enumerate(evidence.debate_exchanges, start=1):
+            scheme_anchor = ""
+            if ex.scheme:
+                scheme_anchor = f" [scheme : {ex.scheme}"
+                if ex.critical_question:
+                    scheme_anchor += f" — question critique : {ex.critical_question}"
+                scheme_anchor += "]"
             deliberation_lines.append(
                 f"  - DÉBAT (échange {i}) : position « {ex.point} » / "
-                f"réplique « {ex.rebuttal} »."
+                f"réplique « {ex.rebuttal} »{scheme_anchor}."
             )
     deliberation_block = (
         "\n".join(deliberation_lines)

--- a/tests/unit/argumentation_analysis/agents/core/debate/test_argumentation_schemes.py
+++ b/tests/unit/argumentation_analysis/agents/core/debate/test_argumentation_schemes.py
@@ -1,0 +1,96 @@
+"""Tests for the restored 10-scheme dialogical engine (G8 #1184, Epic #1165).
+
+The trunk debate had no active scheme matcher (``FormalArgument.scheme`` was
+never populated). G8 restores the engine adapted faithfully from the student
+deliverable ``argumentation_engine._load_argumentation_schemes``, adding the
+canonical Walton critical questions. ``classify_scheme`` is a DETERMINISTIC
+lexical matcher that fails loud (None) when no scheme fits — never a fabricated
+label (#1019).
+"""
+
+from __future__ import annotations
+
+from argumentation_analysis.agents.core.debate.argumentation_schemes import (
+    ArgumentationScheme,
+    _load_argumentation_schemes,
+    classify_scheme,
+    schemes_as_prompt_context,
+)
+
+
+class TestSchemeTable:
+    def test_ten_schemes_loaded(self):
+        schemes = _load_argumentation_schemes()
+        assert len(schemes) == 10
+
+    def test_student_keys_preserved(self):
+        """The 10 scheme keys match the student deliverable verbatim."""
+        schemes = _load_argumentation_schemes()
+        expected = {
+            "modus_ponens",
+            "expert_opinion",
+            "analogy",
+            "cause_effect",
+            "consensus",
+            "empirical_evidence",
+            "economic_argument",
+            "precautionary_principle",
+            "moral_argument",
+            "historical_precedent",
+        }
+        assert set(schemes.keys()) == expected
+
+    def test_each_scheme_has_critical_questions(self):
+        """G8 addition: every scheme carries canonical Walton critical questions."""
+        schemes = _load_argumentation_schemes()
+        for key, s in schemes.items():
+            assert isinstance(s, ArgumentationScheme)
+            assert len(s.critical_questions) >= 1, f"{key} has no critical question"
+
+    def test_strength_values_are_students(self):
+        """Faithful restoration: strength values are the student engine's."""
+        schemes = _load_argumentation_schemes()
+        assert schemes["modus_ponens"].strength == 1.0
+        assert schemes["empirical_evidence"].strength == 0.9
+        assert schemes["consensus"].strength == 0.85
+
+
+class TestClassifyScheme:
+    def test_expert_opinion_matched(self):
+        s = classify_scheme("Selon un expert du domaine, la thèse tient.")
+        assert s is not None
+        assert s.key == "expert_opinion"
+
+    def test_economic_argument_matched(self):
+        s = classify_scheme("Le coût est élevé mais le bénéfice est plus grand.")
+        assert s is not None
+        assert s.key == "economic_argument"
+
+    def test_empirical_evidence_matched(self):
+        s = classify_scheme("Les données montrent P sur un échantillon représentatif.")
+        assert s is not None
+        assert s.key == "empirical_evidence"
+
+    def test_no_match_returns_none_fail_loud(self):
+        """Fail-loud (#1019): neutral text yields None, never a fabricated label."""
+        assert classify_scheme("Le ciel est bleu aujourd'hui.") is None
+
+    def test_empty_returns_none(self):
+        assert classify_scheme("") is None
+        assert classify_scheme(None) is None  # type: ignore[arg-type]
+
+    def test_no_fabricated_scheme_label(self):
+        """Anti-pendule: the matcher never invents a scheme that isn't in the table."""
+        s = classify_scheme("Selon un expert du domaine.")
+        if s is not None:
+            table = _load_argumentation_schemes()
+            assert s.key in table
+
+
+class TestPromptContext:
+    def test_renders_all_schemes_with_questions(self):
+        ctx = schemes_as_prompt_context()
+        assert "expert" in ctx.lower()
+        assert "question" in ctx.lower()
+        # 10 numbered lines
+        assert ctx.count("\n") >= 9

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -282,6 +282,33 @@ class TestBuildEvidence:
         assert "DÉLIBÉRATION COLLECTIVE" in prompt
         assert "opt_X" in prompt
 
+    def test_debate_scheme_grounding_g8(self):
+        """G8 (#1184): a scheme-grounded exchange surfaces scheme + CQ.
+
+        SV reader contract (point/rebuttal) intact; scheme/critical_question
+        extend it optionally. None when no scheme matched (fail-loud, #1019).
+        """
+        state = _state(
+            debate_transcripts=[
+                {
+                    "topic": "t",
+                    "exchanges": [
+                        {
+                            "point": "Selon un expert du domaine, P tient.",
+                            "rebuttal": "mais hors domaine",
+                            "scheme": "Argument d'autorité (advice of an expert)",
+                            "critical_question": "E est-elle experte ?",
+                        }
+                    ],
+                }
+            ]
+        )
+        ev = build_act3_evidence(state)
+        ex = ev.debate_exchanges[0]
+        assert ex.point == "Selon un expert du domaine, P tient."
+        assert ex.scheme == "Argument d'autorité (advice of an expert)"
+        assert ex.critical_question == "E est-elle experte ?"
+
     def test_quality_strengths_collected(self):
         ev = build_act3_evidence(_rich_state())
         virtues = {s.virtue for s in ev.quality_strengths}


### PR DESCRIPTION
## What

Track **G8 #1184** (R444 dispatch, Epic #1165 enrichment, non-blocking). SV #1183 surfaced debate exchanges into Acte II/III but **honestly sparse** — because the 10-scheme `ArgumentationEngine` was dropped at the #35 unification (β fidelity-audit gap G8). This **restores the engine** so debate is genuinely scheme-grounded (each exchange names its Walton scheme + critical question), and SV's surfacing then renders it rich instead of sparse.

## Verify-first (DoD, file:line both sides)

- **Trunk has NO active engine**: `FormalArgument.scheme: Optional[str] = None` (`protocols.py:75`) is never populated. `__init__.py:16` docstring claims "10 argumentation schemes" — unimplemented.
- **Student has it**: `1_2_7_argumentation_dialogique/local_db_arg/src/core/argumentation_engine.py:_load_argumentation_schemes()` → 10-scheme table (SANCTUARY, read-only ref).

## Anti-pendule / fail-loud (#1019)

Restore the dropped engine — do **NOT** template fake richness. If the genuine engine yields no match on a corpus, the debate surfaces the exchange **WITHOUT** a scheme label rather than inventing one.

## New module: `agents/core/debate/argumentation_schemes.py`

- `_load_argumentation_schemes()`: **10 schemes adapted FAITHFULLY** from the student engine — same keys (`modus_ponens`, `expert_opinion`, `analogy`, `cause_effect`, `consensus`, `empirical_evidence`, `economic_argument`, `precautionary_principle`, `moral_argument`, `historical_precedent`), same `strength` values. The `critical_questions` are the **canonical Walton critical questions** added per scheme (canonical KB, not fabricated; the student engine had none).
- `classify_scheme(text)`: **DETERMINISTIC** lexical matcher (no LLM, no JVM). Returns matching scheme (specific-first order; `modus_ponens` last as weakest signal) or `None`. **Fail-loud: `None` is honest "no scheme matched", never a fabricated label.**
- `schemes_as_prompt_context()`: renders the table as a KB block for the LLM.

## Wiring (file:line)

| File | Change |
|---|---|
| `state_writers._write_debate_to_state` | scheme-grounds each `key_exchange` at write-time via `classify_scheme(point)`; stores `scheme`/`scheme_key`/`critical_question` (None when no match) |
| `invoke_callables._invoke_debate_analysis` | hands the LLM the restored scheme table (source shaping); authoritative label still from deterministic matcher |
| `act2`/`act3` `DebateExchange` | +`scheme`/`critical_question` Optional fields — **SV reader contract (point/rebuttal) PRESERVED**, extends richness, breaks no schema. Prompt blocks anchor `[scheme + CQ]` when present |

## DoD (#1184)

- [x] Verify-first `file:line` both sides (trunk no engine / student has it).
- [x] Trunk debate produces scheme-grounded exchanges (Walton scheme + critical question per exchange), restored from the student engine.
- [x] Fail-loud: no scheme match → scheme stays `None` (#1019), never fabricated.
- [x] SV `DebateExchange` reader contract intact (point/rebuttal unchanged; scheme/critical_question optional).
- [x] mypy --strict clean on all 5 source files.
- [x] 209 debate tests + 85 scheme/restitution tests green (10 new scheme tests + 1 G8 surfacing test).

## Privacy HARD

Opaque IDs in surfaced debate content. No student dirs / `.github/` / `.claude/rules/*` edited. File-disjoint from po-2025's terminal R1 run (it reads debate, doesn't edit it).

## Files removed and why

None — additive feature (1 new module + 1 new test file).

Part of Epic #1165 (enrichment, non-blocking). G8 dispatch #1184 (R444).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>