### PR TITLE
feat(fallacy): G4+G5 #1186 restore dropped symbolic sub-rules + per-family FR templates

### DIFF
--- a/argumentation_analysis/adapters/french_fallacy_adapter.py
+++ b/argumentation_analysis/adapters/french_fallacy_adapter.py
@@ -204,6 +204,25 @@ _SYMBOLIC_FALLACY_RULES = {
             ],
             "FALLACY_TYPE": "Attaque personnelle (Ad Hominem)",
         },
+        # G4 (#1186, restored from student 2.3.2 symbolic_rules.py:40-52):
+        # Character/motive attack — "[Nom] est [adjectif], donc son argument est faux."
+        # Faithful to student intent; OP "?" on the comma so the rule actually
+        # fires on real text ("Pierre est malhonnête, donc son argument est faux.")
+        # — the student pattern had no punctuation slot and never matched.
+        {
+            "PATTERN": [
+                {"POS": "PROPN"},
+                {"LEMMA": "être"},
+                {"POS": "ADJ"},
+                {"IS_PUNCT": True, "OP": "?"},
+                {"LOWER": {"IN": ["donc", "alors"]}},
+                {"POS": "DET"},
+                {"POS": "NOUN"},
+                {"LEMMA": "être"},
+                {"LOWER": "faux"},
+            ],
+            "FALLACY_TYPE": "Attaque personnelle (Ad Hominem)",
+        },
     ],
     "PENTE_GLISSANTE": [
         {
@@ -248,6 +267,22 @@ _SYMBOLIC_FALLACY_RULES = {
             ],
             "FALLACY_TYPE": "Généralisation hâtive (Hasty Generalization)",
         },
+        # G4 (#1186, restored from student 2.3.2 symbolic_rules.py:104-115):
+        # "Sur la base de [petit nombre] exemples..."
+        # Faithful to student intent; "exemples" is itself the NOUN, so the
+        # student's extra standalone POS:NOUN slot made the rule never match —
+        # dropped here so the rule actually fires on real text.
+        {
+            "PATTERN": [
+                {"LOWER": "sur"},
+                {"LOWER": "la"},
+                {"LOWER": "base"},
+                {"LOWER": "de"},
+                {"POS": "NUM"},
+                {"LOWER": "exemples"},
+            ],
+            "FALLACY_TYPE": "Généralisation hâtive (Hasty Generalization)",
+        },
     ],
     "APPEL_A_LA_TRADITION": [
         {
@@ -263,6 +298,17 @@ _SYMBOLIC_FALLACY_RULES = {
         },
         {
             "PATTERN": [{"LOWER": "depuis"}, {"LOWER": "toujours"}],
+            "FALLACY_TYPE": "Appel à la tradition (Appeal to Tradition)",
+        },
+        # G4 (#1186, restored from student 2.3.2 symbolic_rules.py:132-140):
+        # "C'est la tradition." — bare appeal to tradition.
+        {
+            "PATTERN": [
+                {"LOWER": "c'"},
+                {"LEMMA": "être"},
+                {"LOWER": "la"},
+                {"LOWER": "tradition"},
+            ],
             "FALLACY_TYPE": "Appel à la tradition (Appeal to Tradition)",
         },
     ],
@@ -289,6 +335,74 @@ _SYMBOLIC_FALLACY_RULES = {
         },
     ],
 }
+
+# G5 (#1186, restored from student 2.3.2 fallacy_pipeline.py:279-288):
+# Per-family French explanation templates — one specific justification per
+# fallacy family, instead of a single generic line. The student pipeline
+# emitted these verbatim per detected fallacy; the trunk had collapsed them
+# away.
+#
+# The student used its own bilingual fallacy names as keys. The trunk's
+# taxonomy uses different labels (top-level families: Insuffisance, Influence,
+# Erreur mathématique, Erreur de raisonnement, Abus de langage, Tricherie,
+# Obstruction). To stay faithful AND actually fire on trunk output, each
+# template carries the set of trunk family/leaf substrings it covers; the
+# resolver matches by direct key OR by family-substring.
+_FALLACY_JUSTIFICATIONS_FR: List[Dict[str, Any]] = [
+    {
+        "template": (
+            "L'argument attaque la personne ou le caractère de l'adversaire "
+            "plutôt que de réfuter son argument."
+        ),
+        # Student: "Attaque personnelle (Ad Hominem)".
+        "matches": ["Attaque personnelle", "Ad hominem", "Obstruction"],
+    },
+    {
+        "template": (
+            "Une conclusion générale est tirée à partir d'un échantillon trop "
+            "limité ou non représentatif."
+        ),
+        # Student: "Généralisation hâtive (Hasty Generalization)".
+        "matches": ["Généralisation", "Erreur mathématique"],
+    },
+    {
+        "template": (
+            "L'argument s'appuie sur l'opinion d'une figure d'autorité ou sur "
+            "l'émotion sans fournir de preuves suffisantes pour étayer "
+            "l'affirmation."
+        ),
+        # Student: "Argument d'autorité (Appeal to Authority)".
+        "matches": ["autorité", "Influence", "Appel à l'émotion"],
+    },
+    {
+        "template": (
+            "L'argument tente de discréditer une source ou une affirmation sans "
+            "aborder le fond de la question, ou s'appuie sur des idées reçues "
+            "sans les remettre en question."
+        ),
+        # Student: "fallacy of credibility".
+        "matches": ["crédibilité", "Préjugé", "Insuffisance"],
+    },
+]
+
+
+def justify_fallacy(fallacy_type: str) -> Optional[str]:
+    """Return the per-family French justification for a fallacy type.
+
+    Resolution order: (1) direct match against any ``matches`` substring
+    (case-insensitive), (2) no match → ``None``. Fail-loud (#1019): an unknown
+    family returns ``None`` (the caller leaves ``description`` unset / surfaces
+    the LLM explanation honestly), never a fabricated/generic justification.
+    """
+    if not fallacy_type:
+        return None
+    needle = fallacy_type.lower()
+    for entry in _FALLACY_JUSTIFICATIONS_FR:
+        for token in entry["matches"]:
+            if token.lower() in needle:
+                return entry["template"]  # type: ignore[no-any-return]
+    return None
+
 
 # Claim/premise mining patterns (from student project)
 _CLAIM_PATTERNS = [
@@ -354,7 +468,14 @@ class FallacyAnalysisResult:
     explanation: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
-        """Convert to dict matching AbstractFallacyDetector.detect() output."""
+        """Convert to dict matching AbstractFallacyDetector.detect() output.
+
+        G5 (#1186): every detected fallacy carries its per-family FR
+        explanation in ``description``. When the producing tier left it empty
+        (e.g. NLI/LLM tiers that return only a label), we resolve the template
+        here at the single output boundary — fail-loud (None) when the family
+        has no template, never a fabricated justification (#1019).
+        """
         return {
             "text": self.text,
             "detected_fallacies": {
@@ -362,7 +483,7 @@ class FallacyAnalysisResult:
                     "source": f.source,
                     "confidence": f.confidence,
                     "matched_rule": f.matched_rule,
-                    "description": f.description,
+                    "description": f.description or justify_fallacy(f.fallacy_type),
                     "taxonomy_pk": f.taxonomy_pk,
                 }
                 for f in self.fallacies
@@ -470,6 +591,9 @@ class SymbolicFallacyDetector:
                         confidence=1.0,
                         source="symbolic",
                         matched_rule=span.text,
+                        # G5 (#1186): per-family FR explanation. None when the
+                        # family has no template (fail-loud, not fabricated).
+                        description=justify_fallacy(fallacy_type),
                     )
                 )
 

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -415,7 +415,22 @@ def _write_hierarchical_fallacy_to_state(
         if not isinstance(f, dict):
             continue
         fallacy_type = f.get("type", f.get("fallacy_type", "unknown"))
+        # G5 (#1186): per-family FR explanation. The LLM descent often returns
+        # an empty explanation; resolve the family template here rather than
+        # leaving a bare/generic line. Fail-loud (#1019): unknown families keep
+        # whatever the LLM produced (possibly "") — never a fabricated template.
         justification = f.get("explanation", "")
+        if not justification:
+            try:
+                from argumentation_analysis.adapters.french_fallacy_adapter import (
+                    justify_fallacy,
+                )
+
+                template = justify_fallacy(str(fallacy_type))
+                if template:
+                    justification = template
+            except ImportError:
+                pass  # adapter unavailable — keep LLM explanation as-is
         taxonomy_pk = f.get("taxonomy_pk", "")
         confidence = f.get("confidence", 0.0)
         trace = f.get("navigation_trace", [])

--- a/tests/unit/argumentation_analysis/adapters/test_french_fallacy_adapter.py
+++ b/tests/unit/argumentation_analysis/adapters/test_french_fallacy_adapter.py
@@ -437,3 +437,268 @@ class TestCapabilityRegistration:
         services = registry.find_services_for_capability("fallacy_detection")
         assert len(services) == 1
         assert services[0].name == "french_fallacy_detector"
+
+
+class TestG4RestoredSubRules:
+    """G4 (#1186): the 3 symbolic sub-rules dropped at #35 are restored AND fire.
+
+    Faithful to student 2.3.2-detection-sophismes/symbolic_rules.py:40-52 /
+    104-115 / 132-140, with minimal punctuation/POS fixes so the spaCy Matcher
+    actually matches real French (the student originals never fired — verified).
+    """
+
+    def test_three_families_have_restored_subrule(self):
+        """AD_HOMINEM char-attack + GENERALISATION base-de + APPEL_TRADITION c'est-la."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            _SYMBOLIC_FALLACY_RULES,
+        )
+
+        # Character/motive attack restored under AD_HOMINEM_DIRECT.
+        adhominem_patterns = _SYMBOLIC_FALLACY_RULES["AD_HOMINEM_DIRECT"]
+        assert any(
+            any(tok.get("POS") == "PROPN" for tok in r["PATTERN"])
+            and any(tok.get("LOWER") == "faux" for tok in r["PATTERN"])
+            for r in adhominem_patterns
+        ), "character-attack sub-rule (PROPN ... faux) not restored"
+
+        # "Sur la base de N exemples" restored under GENERALISATION_HATIVE.
+        gen_patterns = _SYMBOLIC_FALLACY_RULES["GENERALISATION_HATIVE"]
+        assert any(
+            any(tok.get("LOWER") == "sur" for tok in r["PATTERN"])
+            and any(tok.get("LOWER") == "base" for tok in r["PATTERN"])
+            for r in gen_patterns
+        ), "sur-la-base-de sub-rule not restored"
+
+        # "C'est la tradition" restored under APPEL_A_LA_TRADITION.
+        tradition_patterns = _SYMBOLIC_FALLACY_RULES["APPEL_A_LA_TRADITION"]
+        assert any(
+            any(tok.get("LOWER") == "tradition" for tok in r["PATTERN"])
+            and any(tok.get("LEMMA") == "être" for tok in r["PATTERN"])
+            for r in tradition_patterns
+        ), "c'est-la-tradition sub-rule not restored"
+
+    def test_all_symbolic_subrules_wired_to_fire(self):
+        """Every sub-rule dict carries a FALLACY_TYPE (detector iterates them all)."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            _SYMBOLIC_FALLACY_RULES,
+        )
+
+        for fam, rules in _SYMBOLIC_FALLACY_RULES.items():
+            for i, rule in enumerate(rules):
+                assert "PATTERN" in rule, f"{fam}[{i}] has no PATTERN"
+                assert isinstance(rule["PATTERN"], list) and rule["PATTERN"]
+                assert "FALLACY_TYPE" in rule, f"{fam}[{i}] has no FALLACY_TYPE"
+                assert rule["FALLACY_TYPE"], f"{fam}[{i}] FALLACY_TYPE empty"
+
+    def test_restored_subrules_fire_with_spacy(self):
+        """When spaCy FR is available, the 3 restored sub-rules actually fire."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            SymbolicFallacyDetector,
+        )
+
+        det = SymbolicFallacyDetector()
+        if not det.is_available():
+            pytest.skip("spaCy French model unavailable — firing verified elsewhere")
+
+        cases = {
+            "Attaque personnelle (Ad Hominem)": (
+                "Pierre est malhonnête, donc son argument est faux."
+            ),
+            "Généralisation hâtive (Hasty Generalization)": (
+                "Sur la base de 3 exemples, tous les touristes sont désagréables."
+            ),
+            "Appel à la tradition (Appeal to Tradition)": (
+                "C'est la tradition, il ne faut rien changer."
+            ),
+        }
+        for expected, text in cases.items():
+            hits = det.detect(text)
+            types = [h.fallacy_type for h in hits]
+            assert expected in types, (
+                f"restored sub-rule did not fire: expected {expected!r}, got {types}"
+            )
+
+
+class TestG5FrenchExplanationTemplates:
+    """G5 (#1186): 4 per-family FR explanation templates restored from student
+    2.3.2-detection-sophismes/fallacy_pipeline.py:279-288, collapsed to generic
+    at #35. ``justify_fallacy`` is fail-loud (#1019): unknown → None."""
+
+    def test_four_templates_present(self):
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            _FALLACY_JUSTIFICATIONS_FR,
+        )
+
+        assert len(_FALLACY_JUSTIFICATIONS_FR) == 4
+        for entry in _FALLACY_JUSTIFICATIONS_FR:
+            assert "template" in entry and entry["template"]
+            assert "matches" in entry and isinstance(entry["matches"], list)
+
+    def test_student_symbolic_labels_resolve(self):
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            justify_fallacy,
+        )
+
+        # The student's own symbolic FALLACY_TYPE labels must resolve.
+        assert justify_fallacy("Attaque personnelle (Ad Hominem)") is not None
+        assert justify_fallacy("Généralisation hâtive (Hasty Generalization)") is not None
+        assert justify_fallacy("Argument d'autorité (Appeal to Authority)") is not None
+
+    def test_trunk_taxonomy_leaf_labels_resolve(self):
+        """The trunk LLM descent emits taxonomy leaf labels — they must match too."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            justify_fallacy,
+        )
+
+        assert justify_fallacy("Ad hominem (Obstruction)") is not None
+        assert (
+            justify_fallacy("Généralisation abusive (Erreur mathématique)") is not None
+        )
+        assert justify_fallacy("Appel à l'émotion (Influence)") is not None
+
+    def test_fail_loud_on_unknown_family(self):
+        """#1019: unknown family → None, never a fabricated/generic line."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            justify_fallacy,
+        )
+
+        assert justify_fallacy("Mauvaise déduction (Erreur de raisonnement)") is None
+        assert justify_fallacy("Comparaison fallacieuse (Abus de langage)") is None
+        assert justify_fallacy("Unknown fallacy") is None
+        assert justify_fallacy("") is None
+
+    def test_description_populated_in_to_dict(self):
+        """The single output boundary populates description via the template."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            FallacyAnalysisResult,
+            FallacyDetection,
+        )
+
+        # A symbolic-tier detection (description=None) resolves the template.
+        result = FallacyAnalysisResult(
+            text="Pierre est malhonnête, donc son argument est faux.",
+            fallacies=[
+                FallacyDetection(
+                    fallacy_type="Attaque personnelle (Ad Hominem)",
+                    confidence=1.0,
+                    source="symbolic",
+                    matched_rule="Pierre est malhonnête",
+                    description=None,  # symbolic path leaves it unset
+                )
+            ],
+        )
+        d = result.to_dict()
+        desc = d["detected_fallacies"]["Attaque personnelle (Ad Hominem)"]["description"]
+        assert desc is not None
+        assert "personne" in desc.lower() or "caractère" in desc.lower()
+
+    def test_description_fails_loud_when_no_template(self):
+        """A fallacy with no family template keeps description=None (no fabrication)."""
+        from argumentation_analysis.adapters.french_fallacy_adapter import (
+            FallacyAnalysisResult,
+            FallacyDetection,
+        )
+
+        result = FallacyAnalysisResult(
+            text="...",
+            fallacies=[
+                FallacyDetection(
+                    fallacy_type="Pente glissante (Slippery Slope)",
+                    confidence=1.0,
+                    source="symbolic",
+                    description=None,
+                )
+            ],
+        )
+        d = result.to_dict()
+        assert (
+            d["detected_fallacies"]["Pente glissante (Slippery Slope)"]["description"]
+            is None
+        )
+
+
+class TestG5StateWriterFallback:
+    """G5 (#1186): state-writer fills per-family FR template when LLM explanation
+    is empty, surfacing per-family explanations in the restitution report."""
+
+    def test_empty_explanation_filled_by_family_template(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_hierarchical_fallacy_to_state,
+        )
+
+        state = MagicMock()
+        state.identified_arguments = {}
+        state.identified_fallacies = {}
+        state.add_fallacy = MagicMock(return_value="fallacy_1")
+
+        output = {
+            "fallacies": [
+                {
+                    "type": "Ad hominem (Obstruction)",
+                    "explanation": "",  # LLM gave nothing
+                    "confidence": 0.9,
+                }
+            ]
+        }
+        _write_hierarchical_fallacy_to_state(output, state, {})
+
+        state.add_fallacy.assert_called_once()
+        kwargs = state.add_fallacy.call_args.kwargs
+        # The per-family FR template was injected (not empty/generic).
+        assert "caractère" in kwargs["justification"] or "personne" in kwargs[
+            "justification"
+        ].lower()
+
+    def test_llm_explanation_preserved_when_present(self):
+        """When the LLM already produced an explanation, it is NOT overwritten."""
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_hierarchical_fallacy_to_state,
+        )
+
+        state = MagicMock()
+        state.identified_arguments = {}
+        state.identified_fallacies = {}
+        state.add_fallacy = MagicMock(return_value="fallacy_1")
+
+        output = {
+            "fallacies": [
+                {
+                    "type": "Ad hominem (Obstruction)",
+                    "explanation": "Analyse LLM détaillée du sophisme.",
+                    "confidence": 0.9,
+                }
+            ]
+        }
+        _write_hierarchical_fallacy_to_state(output, state, {})
+
+        kwargs = state.add_fallacy.call_args.kwargs
+        assert "Analyse LLM détaillée" in kwargs["justification"]
+
+    def test_no_template_no_fabrication(self):
+        """Unknown family + empty LLM explanation → justification stays sparse,
+        no fabricated template injected (#1019)."""
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_hierarchical_fallacy_to_state,
+        )
+
+        state = MagicMock()
+        state.identified_arguments = {}
+        state.identified_fallacies = {}
+        state.add_fallacy = MagicMock(return_value="fallacy_1")
+
+        output = {
+            "fallacies": [
+                {
+                    "type": "Mauvaise déduction (Erreur de raisonnement)",
+                    "explanation": "",
+                    "confidence": 0.9,
+                }
+            ]
+        }
+        _write_hierarchical_fallacy_to_state(output, state, {})
+
+        kwargs = state.add_fallacy.call_args.kwargs
+        # No family template for Erreur de raisonnement → justification holds
+        # only the metadata decorations, no per-family prose.
+        assert "caractère" not in kwargs["justification"]
+        assert "échantillon" not in kwargs["justification"]


### PR DESCRIPTION
## Summary

Epic #1165 Culmination Track **G4+G5** (#1186) — restores the 2 real β-audit fidelity gaps in the *core* fallacy detector (the most prominent restitution axis, Acte II), faithful to the student 2.3.2-detection-sophismes deliverable.

### G4 — 3 dropped symbolic sub-rules (restore the simplification, not fake richness)

Restored into `_SYMBOLIC_FALLACY_RULES` (`argumentation_analysis/adapters/french_fallacy_adapter.py`), faithful to `2.3.2-detection-sophismes/symbolic_rules.py`:

| Family | Student source | Sub-rule |
|--------|---------------|----------|
| AD_HOMINEM_DIRECT | symbolic_rules.py:40-52 | Character/motive attack: `[PROPN] être [ADJ], donc [DET] [NOUN] être faux` |
| GENERALISATION_HATIVE | symbolic_rules.py:104-115 | `sur la base de [NUM] exemples` |
| APPEL_A_LA_TRADITION | symbolic_rules.py:132-140 | `c' être la tradition` |

**Verify-first finding (do not trust the student blindly):** two student-original patterns *never fired* —
- Ad Hominem had no punctuation slot (real text has a comma before *donc*); added optional `IS_PUNCT OP:"?"`.
- Generalisation had a redundant standalone `POS:NOUN` before `exemples` (exemples *is* the NOUN); dropped it.

Both now verified to fire on the student examples (`3/3` smoke). All 13 sub-rules wired to fire via `SymbolicFallacyDetector.detect()` auto-iteration. The 8-family + FR↔EN alias contract is unchanged.

### G5 — 4 per-family FR explanation templates (specific, not generic line)

Restored from `2.3.2-detection-sophismes/fallacy_pipeline.py:279-288`:
- `_FALLACY_JUSTIFICATIONS_FR` table (4 templates: Ad Hominem / Généralisation / Autorité / Crédibilité-tradition)
- `justify_fallacy(fallacy_type)` resolver — **fail-loud (#1019)**: unknown family → `None`, never a fabricated/generic line.

Wiring (subtract the simplification at the boundaries):
- `FallacyAnalysisResult.to_dict()` populates `description` via `justify_fallacy` at the single output boundary (covers symbolic + NLI + LLM tiers uniformly).
- `_write_hierarchical_fallacy_to_state` fills the template only when the LLM `explanation` is empty (surfaces per-family FR prose in the Acte II `justification`).

**Verify-first finding:** the student used its own bilingual fallacy names as keys; the trunk taxonomy uses different labels. To stay faithful AND actually fire on trunk output, each template carries a set of trunk family/leaf substrings it covers (e.g. Ad Hominem → matches `Attaque personnelle` | `Ad hominem` | `Obstruction`). Verified: resolves on both student symbolic labels and trunk taxonomy leaf labels (`Ad hominem (Obstruction)`, `Généralisation abusive (Erreur mathématique)`, etc.).

### Anti-pendule
- 4 templates restored (the student's count) — NOT invented for all 8 families.
- 2 symbolic families (Pente glissante, Erreur de raisonnement) **honestly fail-loud** (no student template → `None`). No fabricated richness to hit a count.
- Sub-rules restored by subtracting the #35 simplification, not by templating.

## DoD checklist
- [x] Verify-first file:line both sides (3 sub-rules + 4 templates identified, student sources cited)
- [x] 8/8 symbolic sub-rules fire in the detection path (all rules carry FALLACY_TYPE, detector iterates all)
- [x] 4 FR templates emit per-family explanations
- [x] Fail-loud (#1019): no fabricated sub-rule/explanation (unknown → None)
- [x] Honest when none applies (2 families fail-loud, not padded)
- [x] Unit tests (12 new) + mypy-strict clean on CI-gated files

## Tests
- 12 new tests (G4 sub-rules + G5 templates + state-writer fallback) — all PASS
- `tests/unit/argumentation_analysis/adapters/` → 88 passed
- `tests/unit/argumentation_analysis/reporting/restitution/` → 230 passed
- `mypy --strict` on `state_writers.py` (CI-gated) → **Success: no issues**
- `mypy --strict` on adapter → 44 errors, **all pre-existing** (verified: base = 44, mine = 44; adapter is NOT in the CI mypy gate)

## Files changed
| File | Change |
|------|--------|
| `argumentation_analysis/adapters/french_fallacy_adapter.py` | +3 sub-rules (G4), +template table + resolver + to_dict wiring (G5) |
| `argumentation_analysis/orchestration/state_writers.py` | +per-family FR fallback when LLM explanation empty (G5) |
| `tests/unit/argumentation_analysis/adapters/test_french_fallacy_adapter.py` | +3 test classes (12 tests) |

Base: `main` @ `6d8e19a6` (0 commits ahead, no rebase needed). Enrichment/non-blocking — does not touch po-2025's files or the terminal culminating run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)