### PR TITLE
FP-6 #1197 — FOL invoke-callable fail-loud: stop re-castrating None into a fabricated verdict

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -5560,20 +5560,24 @@ async def _invoke_fol_reasoning(
             # `None` (unverified), never a fabricated True.
             iso_consistent: Optional[bool] = None
             iso_msg = "combined consistency unverified"
-            try:
-                combined_bs = "\n".join(
-                    str(f) for f in fol_signature + [""] + valid_formulas
-                )
-                iso_consistent, iso_msg = await asyncio.to_thread(
-                    bridge.check_consistency, combined_bs, "first_order"
-                )
-            except Exception as iso_err:  # combined check failed → honest unverified
-                logger.warning(
-                    "FOL isolation: combined consistency check failed (%s) — "
-                    "reporting unverified (None), not fabricated True.",
-                    iso_err,
-                )
-                iso_consistent = None
+            # bridge is non-None whenever valid_formulas is non-empty (the loop
+            # above is guarded by `if bridge is not None`), but narrow explicitly
+            # for the type checker; None ⇒ stay unverified (never fabricate True).
+            if bridge is not None:
+                try:
+                    combined_bs = "\n".join(
+                        str(f) for f in fol_signature + [""] + valid_formulas
+                    )
+                    iso_consistent, iso_msg = await asyncio.to_thread(
+                        bridge.check_consistency, combined_bs, "first_order"
+                    )
+                except Exception as iso_err:  # combined check failed → unverified
+                    logger.warning(
+                        "FOL isolation: combined consistency check failed (%s) — "
+                        "reporting unverified (None), not fabricated True.",
+                        iso_err,
+                    )
+                    iso_consistent = None
             return {
                 "formulas": valid_formulas,
                 "fol_signature": fol_signature,

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -46,6 +46,7 @@ def _preflight_solver_check() -> None:
 # RA-4 #1049 item 3 — Strategic objective consumption by tactical callables
 # ---------------------------------------------------------------------------
 
+
 def _get_strategic_directives(context: Dict[str, Any]) -> Tuple[str, List[str]]:
     """Extract active strategic objectives from state and format as NL directives.
 
@@ -62,8 +63,10 @@ def _get_strategic_directives(context: Dict[str, Any]) -> Tuple[str, List[str]]:
         return "", []
 
     active = [
-        obj for obj in objectives
-        if isinstance(obj, dict) and obj.get("status", "active") in ("active", "in_progress")
+        obj
+        for obj in objectives
+        if isinstance(obj, dict)
+        and obj.get("status", "active") in ("active", "in_progress")
     ]
     if not active:
         return "", []
@@ -1464,17 +1467,22 @@ async def _invoke_debate_analysis(
                 from argumentation_analysis.agents.core.debate.argumentation_schemes import (
                     schemes_as_prompt_context,
                 )
+
                 scheme_kb = schemes_as_prompt_context()
             except ImportError:
                 scheme_kb = ""
             scheme_directive = (
-                "\n\nGROUNDED SCHEMES (Walton-Krabbe, restored engine G8):\n"
-                f"{scheme_kb}\n"
-                "Each Agent A point should resemble one of these schemes; Agent B's "
-                "rebuttal should stress its critical question. Name the scheme the "
-                "point relies on inside agent_a_point when clearly applicable — do "
-                "NOT force a scheme label where none fits (honest absence > fake label).\n"
-            ) if scheme_kb else ""
+                (
+                    "\n\nGROUNDED SCHEMES (Walton-Krabbe, restored engine G8):\n"
+                    f"{scheme_kb}\n"
+                    "Each Agent A point should resemble one of these schemes; Agent B's "
+                    "rebuttal should stress its critical question. Name the scheme the "
+                    "point relies on inside agent_a_point when clearly applicable — do "
+                    "NOT force a scheme label where none fits (honest absence > fake label).\n"
+                )
+                if scheme_kb
+                else ""
+            )
             response = await _guarded_chat_completion(
                 client,
                 model=model_id,
@@ -2403,7 +2411,9 @@ async def _invoke_camembert_fallacy(
 
         # RA-4 #1049 item 3: inject strategic directives into LLM prompt
         _strat_text_cam, _strat_ids_cam = _get_strategic_directives(context)
-        _effective_text_cam = f"{_strat_text_cam}\n\n{input_text}" if _strat_text_cam else input_text
+        _effective_text_cam = (
+            f"{_strat_text_cam}\n\n{input_text}" if _strat_text_cam else input_text
+        )
 
         # Bounded wide-net descent (#1087) — same backstop as the main path above:
         # the camembert wide-net is unbounded and explodes on dense corpora. The
@@ -2857,9 +2867,7 @@ def _eaf_beliefs_from_context(
             return {str(k): [str(x) for x in v] for k, v in beliefs_in.items()}
         # Float-valued (probability per arg): treat as a single agent's beliefs
         # above a neutral 0.5 threshold — no fabricated multi-agent structure.
-        believed = [
-            str(k) for k, v in beliefs_in.items() if float(v) >= 0.5
-        ]
+        believed = [str(k) for k, v in beliefs_in.items() if float(v) >= 0.5]
         if believed:
             return {"agent_0": believed}
     return None
@@ -3186,9 +3194,7 @@ async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict[str, A
     # Sanitize axioms too (list of proposition names).
     axioms = None
     if axioms_raw:
-        axioms = [
-            _pl_atom(a, prefix="ax") for a in axioms_raw if isinstance(a, str)
-        ]
+        axioms = [_pl_atom(a, prefix="ax") for a in axioms_raw if isinstance(a, str)]
 
     try:
         from argumentation_analysis.agents.core.logic.aspic_handler import ASPICHandler
@@ -3447,8 +3453,10 @@ async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict[str, A
     # SetAF attacks come as {attackers, target} dicts. Upstream may provide
     # them directly, else shape from the canonical pairwise attack graph.
     raw_attacks = context.get("set_attacks")
-    if isinstance(raw_attacks, list) and raw_attacks and isinstance(
-        raw_attacks[0], dict
+    if (
+        isinstance(raw_attacks, list)
+        and raw_attacks
+        and isinstance(raw_attacks[0], dict)
     ):
         attacks = raw_attacks
     else:
@@ -3481,9 +3489,12 @@ async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict[str
     # provide them directly, else shape from the canonical pairwise graph with
     # neutral weight 0.5 (#1019: no fabricated confidence).
     raw_attacks = context.get("weighted_attacks")
-    if isinstance(raw_attacks, list) and raw_attacks and isinstance(
-        raw_attacks[0], (list, tuple)
-    ) and len(raw_attacks[0]) >= 3:
+    if (
+        isinstance(raw_attacks, list)
+        and raw_attacks
+        and isinstance(raw_attacks[0], (list, tuple))
+        and len(raw_attacks[0]) >= 3
+    ):
         attacks = [
             (str(t[0]), str(t[1]), float(t[2]))
             for t in raw_attacks
@@ -3863,7 +3874,9 @@ async def _invoke_hierarchical_fallacy(
 
         # RA-4 #1049 item 3: inject strategic directives into LLM prompt
         _strat_text, _strat_ids = _get_strategic_directives(context)
-        _effective_text = f"{_strat_text}\n\n{input_text}" if _strat_text else input_text
+        _effective_text = (
+            f"{_strat_text}\n\n{input_text}" if _strat_text else input_text
+        )
 
         # Bounded wide-net descent (#1087). The wide-net ``run_guided_analysis``
         # on the FULL source text is unbounded here — on a dense corpus it explodes
@@ -4381,6 +4394,7 @@ async def _invoke_hierarchical_fallacy_per_argument(
                         f["target_argument"] = arg_id
                     if not f.get("problematic_quote") and quote_span:
                         f["problematic_quote"] = quote_span
+
             plugin = None
             try:
                 master_kernel = Kernel()
@@ -5485,13 +5499,23 @@ async def _invoke_fol_reasoning(
             bridge.check_consistency, belief_set_str, "first_order"
         )
         fol_metrics["post_tweety"] = len(formulas)
+        # FP-6 #1197: pass the handler's tri-state through unchanged. The handler
+        # (fol_handler.check_consistency, FP-3 #1192) returns None on reasoner OOM /
+        # failure = "could not compute". `bool(None)` would fabricate that into a
+        # definite `consistent: False` ("KB is inconsistent") — théâtre regrowing one
+        # layer above the handler (R405). None ⇒ unverified (confidence 0.0), True ⇒
+        # consistent (0.8), False ⇒ a real inconsistency verdict (0.4). (#1019 fail-loud)
         return {
             "formulas": formulas,
             "fol_signature": fol_signature,
             "fol_metadata": meta,
-            "consistent": bool(is_consistent),
+            "consistent": is_consistent,
             "inferences": inferences,
-            "confidence": 0.8 if is_consistent else 0.4,
+            "confidence": (
+                0.8
+                if is_consistent is True
+                else (0.0 if is_consistent is None else 0.4)
+            ),
             "message": msg,
             "logic_type": "first_order",
             "argument_count": len(args),
@@ -5528,19 +5552,50 @@ async def _invoke_fol_reasoning(
                 f"FOL per-formula isolation: {len(valid_formulas)}/{len(formulas)} "
                 f"formulas accepted by Tweety"
             )
+            # FP-6 #1197: the per-formula loop only proved each formula PARSES — it
+            # discarded the consistency verdicts. Hardcoding `consistent: True` here
+            # fabricated a consistency verdict out of parse-success (théâtre, R405 /
+            # #1019). Run a real combined consistency check on the survivors and pass
+            # the tri-state through; if the combined check itself fails/OOMs, that is
+            # `None` (unverified), never a fabricated True.
+            iso_consistent: Optional[bool] = None
+            iso_msg = "combined consistency unverified"
+            try:
+                combined_bs = "\n".join(
+                    str(f) for f in fol_signature + [""] + valid_formulas
+                )
+                iso_consistent, iso_msg = await asyncio.to_thread(
+                    bridge.check_consistency, combined_bs, "first_order"
+                )
+            except Exception as iso_err:  # combined check failed → honest unverified
+                logger.warning(
+                    "FOL isolation: combined consistency check failed (%s) — "
+                    "reporting unverified (None), not fabricated True.",
+                    iso_err,
+                )
+                iso_consistent = None
             return {
                 "formulas": valid_formulas,
                 "fol_signature": fol_signature,
                 "fol_metadata": meta,
-                "consistent": True,
+                "consistent": iso_consistent,
                 "inferences": inferences,
-                "confidence": 0.6,
+                "confidence": (
+                    0.6
+                    if iso_consistent is True
+                    else (0.0 if iso_consistent is None else 0.4)
+                ),
+                "message": iso_msg,
                 "logic_type": "first_order",
                 "argument_count": len(args),
                 "isolation_retry": True,
                 "rejected_count": len(formulas) - len(valid_formulas),
                 "fol_metrics": fol_metrics,
-                **({"strategic_objective_ids": _strat_ids_fol} if _strat_ids_fol else {}),
+                **(
+                    {"strategic_objective_ids": _strat_ids_fol}
+                    if _strat_ids_fol
+                    else {}
+                ),
             }
 
         # All formulas failed — no heuristic fallback (#1019)
@@ -5572,6 +5627,8 @@ async def _invoke_fol_reasoning(
             "fol_metrics": fol_metrics,
             **({"strategic_objective_ids": _strat_ids_fol} if _strat_ids_fol else {}),
         }
+
+
 async def _invoke_nl_to_logic(
     input_text: str, context: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -6295,9 +6352,7 @@ async def _invoke_act2_narrative(
         # Conducted LLM call bound to the resolved kernel/service.
         if not llm_service_id or kernel is None:
             return ""
-        settings = kernel.get_prompt_execution_settings_from_service_id(
-            llm_service_id
-        )
+        settings = kernel.get_prompt_execution_settings_from_service_id(llm_service_id)
         result = await kernel.invoke_prompt(
             function_name="act2_narrative_conducted",
             plugin_name="restitution",
@@ -6411,9 +6466,7 @@ async def _invoke_act1_framing(
     async def _llm(prompt: str) -> str:
         if not llm_service_id or kernel is None:
             return ""
-        settings = kernel.get_prompt_execution_settings_from_service_id(
-            llm_service_id
-        )
+        settings = kernel.get_prompt_execution_settings_from_service_id(llm_service_id)
         result = await kernel.invoke_prompt(
             function_name="act1_framing_conducted",
             plugin_name="restitution",
@@ -6513,9 +6566,7 @@ async def _invoke_act3_conclusion(
     async def _llm(prompt: str) -> str:
         if not llm_service_id or kernel is None:
             return ""
-        settings = kernel.get_prompt_execution_settings_from_service_id(
-            llm_service_id
-        )
+        settings = kernel.get_prompt_execution_settings_from_service_id(llm_service_id)
         result = await kernel.invoke_prompt(
             function_name="act3_conclusion_conducted",
             plugin_name="restitution",

--- a/tests/unit/argumentation_analysis/orchestration/test_fp6_fol_faillloud.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_fp6_fol_faillloud.py
@@ -1,0 +1,122 @@
+"""FP-6 #1197 — FOL invoke-callable must propagate the handler's fail-loud tri-state.
+
+FP-3 (#1192/#1195) made the FOL *handler* (``fol_handler.check_consistency``)
+return ``None`` on reasoner OOM / failure — an honest "could not compute". But the
+*invoke callable* ``_invoke_fol_reasoning`` re-castrated that honesty one layer up:
+
+  - main path:  ``"consistent": bool(is_consistent)`` → ``bool(None) == False``
+                fabricated a definite "KB is inconsistent" verdict (confidence 0.4);
+  - isolation:  hardcoded ``"consistent": True`` after only checking each formula
+                *parses* — never a consistency check on the combined KB.
+
+This is the R405 "determinization is structural" pattern: théâtre killed at the
+handler instantly regrows above it. These tests pin the tri-state contract so the
+fail-loud ``None`` reaches the state unchanged (and is never fabricated into a
+verdict). The LLM client is mocked away (no API) and the TweetyBridge is mocked
+(no JVM) — the formulas are injected via ``context["formulas"]`` (the DAG path).
+"""
+
+from unittest.mock import MagicMock, patch
+
+import argumentation_analysis.orchestration.invoke_callables as mod
+
+_LONG_TEXT = "This is a sufficiently long source text for the FOL formal phase. " * 8
+
+_BRIDGE = "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge"
+
+
+def _no_llm_client():
+    """Client unavailable → 2-pass generator is a no-op; KB comes from context."""
+    return (None, None)
+
+
+class TestFolFailLoudTriState:
+    """#1197: the handler's None/True/False tri-state must survive the invoke callable."""
+
+    async def test_handler_none_propagates_as_none_not_false(self):
+        """Reasoner returns None (OOM/degraded) ⇒ output consistent=None, confidence=0.0.
+
+        Regression: before FP-6, ``bool(None)`` fabricated ``consistent=False`` and
+        ``confidence=0.4`` — a reader would see "FOL decided the KB is inconsistent"
+        when in truth FOL could not compute a verdict.
+        """
+        bridge = MagicMock()
+        # The FP-3 handler returns (None, msg) when the reasoner OOMs / fails.
+        bridge.check_consistency.return_value = (None, "OutOfMemoryError → degraded")
+
+        with patch.object(mod, "_get_openai_client", side_effect=_no_llm_client), patch(
+            _BRIDGE, return_value=bridge
+        ):
+            out = await mod._invoke_fol_reasoning(
+                _LONG_TEXT,
+                {"formulas": ["Human(socrates)", "Mortal(socrates)"]},
+            )
+
+        assert out["consistent"] is None, "None must not be coerced to False"
+        assert out["confidence"] == 0.0, "unverified ⇒ confidence 0.0, not 0.4"
+
+    async def test_handler_true_maps_to_consistent_true(self):
+        """A real positive verdict is preserved (True ⇒ confidence 0.8)."""
+        bridge = MagicMock()
+        bridge.check_consistency.return_value = (True, "consistent")
+
+        with patch.object(mod, "_get_openai_client", side_effect=_no_llm_client), patch(
+            _BRIDGE, return_value=bridge
+        ):
+            out = await mod._invoke_fol_reasoning(
+                _LONG_TEXT,
+                {"formulas": ["Human(socrates)", "Mortal(socrates)"]},
+            )
+
+        assert out["consistent"] is True
+        assert out["confidence"] == 0.8
+
+    async def test_handler_false_is_a_real_inconsistency_verdict(self):
+        """A real negative verdict is preserved and distinguishable from None."""
+        bridge = MagicMock()
+        bridge.check_consistency.return_value = (False, "inconsistent")
+
+        with patch.object(mod, "_get_openai_client", side_effect=_no_llm_client), patch(
+            _BRIDGE, return_value=bridge
+        ):
+            out = await mod._invoke_fol_reasoning(
+                _LONG_TEXT,
+                {"formulas": ["P(a)", "!P(a)"]},
+            )
+
+        assert out["consistent"] is False
+        assert out["confidence"] == 0.4
+
+    async def test_isolation_retry_does_not_fabricate_true(self):
+        """When the batch check raises, the per-formula isolation path must run a real
+        combined consistency check — not hardcode ``consistent: True`` from parse-success.
+
+        Here the first batch ``check_consistency`` raises (forcing the isolation
+        branch); per-formula parse checks succeed; the combined re-check returns the
+        degraded ``None``. Output must be ``consistent=None``, never the old ``True``.
+        """
+        bridge = MagicMock()
+        calls = {"n": 0}
+
+        def _check(belief_set, logic_type):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                # First (batch) call raises → drives the except-isolation branch.
+                raise RuntimeError("batch parse failed")
+            # Per-formula parse checks + final combined re-check.
+            # Return the degraded tri-state for the combined re-check.
+            return (None, "combined degraded")
+
+        bridge.check_consistency.side_effect = _check
+
+        with patch.object(mod, "_get_openai_client", side_effect=_no_llm_client), patch(
+            _BRIDGE, return_value=bridge
+        ):
+            out = await mod._invoke_fol_reasoning(
+                _LONG_TEXT,
+                {"formulas": ["Human(socrates)", "Mortal(socrates)"]},
+            )
+
+        assert out.get("isolation_retry") is True, "expected the isolation branch"
+        assert out["consistent"] is None, "isolation must not fabricate True"
+        assert out["confidence"] == 0.0


### PR DESCRIPTION
Closes #1197. Sibling of FP-3 #1195. Epic #1191.

## Firsthand constat (the user's "constate par toi-même" mandate)
Re-ran corpus_A on the FP-3-fixed main `72586016`. PL now returns **real PySAT verdicts** (a ~30-atom KB that used to OOM now returns `satisfiable: True` with a model in ms). But the FOL section showed `consistent: False, confidence: 0.4` — while the **live log showed the reasoner OOM'd** and the FP-3 handler honestly returned `degraded (None)`. The honesty was destroyed downstream.

## Root cause — théâtre regrows above the handler (R405)
`_invoke_fol_reasoning` (`invoke_callables.py`) re-castrated the handler's tri-state:
- **main path**: `"consistent": bool(is_consistent)` → `bool(None) == False` fabricated a definite "KB is inconsistent" verdict (`confidence 0.4`).
- **isolation retry**: hardcoded `"consistent": True` after only checking each formula *parses* — never a consistency check on the combined KB.

## Fix (subtraction, #1019 fail-loud)
- Propagate the handler tri-state unchanged: `None` ⇒ unverified (confidence 0.0), `True` ⇒ 0.8, `False` ⇒ real inconsistency verdict (0.4). Mirrors the conversational path which already does `fol_out.get("consistent")`.
- Isolation retry now runs a **real combined consistency check** on the parseable survivors and propagates its tri-state; if that check itself OOMs/raises ⇒ `None` (unverified), never a fabricated `True`.

## Tests (LLM + JVM mocked, no API/no JVM)
- `None` (handler OOM) ⇒ `consistent=None, confidence=0.0` (regression: was `False/0.4`)
- `True` ⇒ `consistent=True, confidence=0.8`
- `False` ⇒ `consistent=False, confidence=0.4` (a real inconsistency, distinct from None)
- isolation branch ⇒ no fabricated `True`; combined re-check tri-state propagates
4 passed.

## Scope note — pre-existing red on main (NOT this PR)
While verifying, I found **5 pre-existing test failures on main `72586016`** (they fail with this PR's changes stashed): obsolete PL tests asserting the *old graceful Python fallback* that FP-3/#1019 deliberately removed (now a fail-loud `RuntimeError: ... JVM/Tweety required`). Tracked separately as FP-7 #1199 — out of scope here to keep this FOL fix focused.

## Privacy
Opaque IDs only. The firsthand report is gitignored local — no raw content in this PR.

🤖 Coordinator ai-01 (self-pickup: surgical fix root-caused firsthand; both workers busy on FP-4/FP-5)