### PR TITLE
test(logic): FP-7 #1199 restore green main — PL fallback tests to fail-loud

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_dag_formal_logic_union_ll.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dag_formal_logic_union_ll.py
@@ -23,6 +23,8 @@ API, no JVM), that:
 
 from unittest.mock import patch
 
+import pytest
+
 import argumentation_analysis.orchestration.invoke_callables as mod
 
 _LONG_TEXT = "This is a sufficiently long source text for the formal phase. " * 8
@@ -34,6 +36,12 @@ class TestDagPlUnionsAndDoesNotShortCircuit:
     """#705: upstream PL formulas no longer skip the 2-pass; they are unioned."""
 
     async def test_upstream_formulas_still_reach_2pass(self):
+        """FP-7 #1199: PL now fails loud (RuntimeError) when all Tweety solvers
+        fail (FP-3 #1192/#1019), but the 2-pass generator is STILL reached before
+        the solver step — preserving the #705 regression guard against
+        short-circuiting. The graceful Python fallback was the theater removed
+        by FP-3; we assert fail-loud + 2-pass-reached instead.
+        """
         calls = {"client": 0}
 
         def _fake_client():
@@ -43,19 +51,20 @@ class TestDagPlUnionsAndDoesNotShortCircuit:
         with patch.object(
             mod, "_get_openai_client", side_effect=_fake_client
         ), patch(_BRIDGE, side_effect=RuntimeError("no JVM")):
-            out = await mod._invoke_propositional_logic(
-                _LONG_TEXT, {"formulas": ["a", "b"]}
-            )
+            with pytest.raises(RuntimeError, match="Tweety solvers failed"):
+                await mod._invoke_propositional_logic(
+                    _LONG_TEXT, {"formulas": ["a", "b"]}
+                )
 
         # Regression: before #705 the upstream branch short-circuited and the
-        # generator was never reached — calls["client"] would be 0.
+        # generator was never reached — calls["client"] would be 0. The raise
+        # happens AFTER the 2-pass, so the client was still called.
         assert calls["client"] >= 1
-        # Upstream formulas are unioned into the output, not dropped.
-        assert "a" in out["formulas"] and "b" in out["formulas"]
-        # JVM mocked away → graceful Python fallback, never a raise.
-        assert out.get("fallback") == "python"
 
     async def test_upstream_nl_to_logic_translations_reach_2pass(self):
+        """FP-7 #1199: same fail-loud + 2-pass-reached contract for the
+        nl_to_logic upstream branch (#705).
+        """
         calls = {"client": 0}
 
         def _fake_client():
@@ -78,16 +87,22 @@ class TestDagPlUnionsAndDoesNotShortCircuit:
         with patch.object(
             mod, "_get_openai_client", side_effect=_fake_client
         ), patch(_BRIDGE, side_effect=RuntimeError("no JVM")):
-            out = await mod._invoke_propositional_logic(_LONG_TEXT, context)
+            with pytest.raises(RuntimeError, match="Tweety solvers failed"):
+                await mod._invoke_propositional_logic(_LONG_TEXT, context)
 
+        # The 2-pass generator was reached before the solver raised.
         assert calls["client"] >= 1
-        assert "p" in out["formulas"]
 
 
 class TestDagFolUnionsAndDoesNotShortCircuit:
     """#705: upstream FOL formulas no longer skip the 2-pass; they are unioned."""
 
     async def test_upstream_formulas_still_reach_2pass(self):
+        """FP-7 #1199: FOL reports honest absence (tri-state ``consistent=None``,
+        ``solver="none"``) instead of the removed ``fallback="python"`` theater
+        (FP-3 #1192/#1019). The #705 regression guard (2-pass reached, upstream
+        formulas unioned) is preserved on the honest fail-loud return path.
+        """
         calls = {"client": 0}
 
         def _fake_client():
@@ -101,15 +116,23 @@ class TestDagFolUnionsAndDoesNotShortCircuit:
                 _LONG_TEXT, {"formulas": ["P(a)", "Q(b)"]}
             )
 
+        # Regression: before #705 the upstream branch short-circuited and the
+        # generator was never reached — calls["client"] would be 0.
         assert calls["client"] >= 1
+        # Upstream formulas are unioned into the output, not dropped.
         assert "P(a)" in out["formulas"] and "Q(b)" in out["formulas"]
-        assert out.get("fallback") == "python"
+        # FP-3/#1019: no fabricated verdict — honest tri-state None + solver none.
+        assert out.get("consistent") is None
+        assert out.get("solver") == "none"
 
 
 class TestConversationalPathUnchanged:
     """No upstream formulas → 2-pass still runs (HH conversational behaviour)."""
 
     async def test_pl_no_upstream_reaches_2pass(self):
+        """FP-7 #1199: conversational path (no upstream) still reaches the 2-pass
+        generator, then fails loud on Tweety absence (FP-3 #1192/#1019).
+        """
         calls = {"client": 0}
 
         def _fake_client():
@@ -119,7 +142,8 @@ class TestConversationalPathUnchanged:
         with patch.object(
             mod, "_get_openai_client", side_effect=_fake_client
         ), patch(_BRIDGE, side_effect=RuntimeError("no JVM")):
-            out = await mod._invoke_propositional_logic(_LONG_TEXT, {})
+            with pytest.raises(RuntimeError, match="Tweety solvers failed"):
+                await mod._invoke_propositional_logic(_LONG_TEXT, {})
 
+        # The 2-pass generator was reached before the solver raised.
         assert calls["client"] >= 1
-        assert isinstance(out, dict) and "formulas" in out

--- a/tests/unit/argumentation_analysis/orchestration/test_formal_logic_conversational_hh.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_formal_logic_conversational_hh.py
@@ -20,6 +20,8 @@ baseline on the formal axis. These tests verify, with mocked invoke callables
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 import argumentation_analysis.orchestration.invoke_callables as mod
 
 
@@ -163,17 +165,23 @@ class TestRunFormalLogicFromState:
 class TestExceptBlockHardening:
     """A TweetyBridge construction failure must degrade, not raise (#697 HH)."""
 
-    async def test_pl_bridge_failure_degrades_to_python_fallback(self):
+    async def test_pl_bridge_failure_raises_fail_loud(self):
+        """FP-7 #1199 / #1019: a TweetyBridge failure must FAIL LOUD.
+
+        Previously (pre-FP-3) this asserted ``out["fallback"] == "python"`` — a
+        graceful Python fallback that fabricated a result on Tweety failure.
+        FP-3 (#1192/#1019) removed that theater: when all Tweety solvers fail
+        (here the bridge cannot even be constructed), ``_invoke_propositional_logic``
+        now raises ``RuntimeError`` rather than degrading silently. This test
+        asserts that fail-loud behaviour (R369 / anti-théâtre).
+        """
         context = {"formulas": ["p1", "p2"]}
         with patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             side_effect=RuntimeError("no JVM"),
         ):
-            out = await mod._invoke_propositional_logic("text", context)
-        # No exception bubbled; we still get a usable result dict.
-        assert isinstance(out, dict)
-        assert "formulas" in out
-        assert out.get("fallback") == "python"
+            with pytest.raises(RuntimeError, match="Tweety solvers failed"):
+                await mod._invoke_propositional_logic("text", context)
 
     async def test_fol_bridge_failure_degrades_to_python_fallback(self):
         context = {"formulas": ["P(a)", "Q(b)"]}


### PR DESCRIPTION
## FP-7 — restore green main (obsolete fallback-asserting PL tests → fail-loud)

Parent: Epic **#1191**. Dispatch: R451 (ai-01). Issue: #1199. Base: main `72586016` (post-FP-3). **Tests-only** (no prod change).

## Problem
5 PL tests were **red on main** `72586016` (reproduced before fixing). They asserted the graceful Python fallback (`out["fallback"] == "python"`) that **FP-3 (#1192/#1019) removed**: `_invoke_propositional_logic` now raises `RuntimeError` when all Tweety solvers fail (fail-loud, R369) instead of fabricating a Python result.

## Fix (anti-pendule, R405 subtraction — never reintroduce the fallback)
- `test_pl_bridge_failure_degrades_to_python_fallback` → renamed **`test_pl_bridge_failure_raises_fail_loud`**: asserts `pytest.raises(RuntimeError, match="Tweety solvers failed")`.
- 4 DAG `test_*_reach_2pass` tests (#705 regression guards): the **#705 intent is preserved** — the 2-pass generator (`_get_openai_client`) is still reached before the solver step. Wrapped in `pytest.raises` + assert `calls["client"] >= 1` was reached **before** the raise.
  - PL tests: raise = fail-loud (FP-3).
  - FOL test: asserts honest tri-state (`consistent is None`, `solver == "none"`) instead of the removed `fallback == "python"`.

## Validation
- **14 passed** (5 restored green + 9 already green in the 2 files). Verified.
- The 5 target tests reproduced red on `72586016` before the fix (verify > memo).

## Findings surfaced (DoD bonus — flagged for coordinator)
1. **CI selection gap**: FP-3 #1195 showed green though these 5 were red. `automated-tests` is **NOT** `continue-on-error` (only lint/format are). Likely the **JVM-present CI env masked** the bridge-failure path these mock-only tests exercise (they `patch(_BRIDGE, side_effect=RuntimeError)`). Recommend a dedicated **no-JVM CI lane** or a mock-bridge CI subset so fail-loud paths are exercised in CI.
2. **`test_fol_ignores_propositional_translations`** (`test_nl_to_logic_wiring.py:250`) is **flaky / env-dependent**: it fails on **clean main** too (asserts `'Asserted(arg1)'` but the real Tweety parser yields `'exists X: (Argument(X))'` on a constant-empty parse, depending on JVM state). **Not a regression** — verified by stashing FP-7 and re-running on `72586016`. Needs its bridge mocked. Flagged, **not fixed here** (out of FP-7 scope; this PR only touches the 2 target files).

## Privacy / anti-pendule
Tests only, opaque atoms (`p1`, `Asserted(arg1)`, `P(a)`), no corpus content. Fix = assertion subtraction (fail-loud), never a fallback reintroduction.

🤖 Worker po-2023
