### PR TITLE
test(logic): #1204 real non-mocked EProver integration test (skip-if-binary-absent)

### DIFF
--- a/tests/integration/argumentation_analysis/agents/core/logic/test_eprover_real.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_eprover_real.py
@@ -87,23 +87,27 @@ class TestRealEProverConsistency:
         must identify the EProver solver (so the verdict is traceable to a real
         decision, not a degraded fallback).
 
-        KB (Tweety FOL syntax): ``Mortal(socrate)`` together with its negation
-        ``!Mortal(socrate)`` — a direct contradiction.
+        KB (Tweety native FOL syntax — sort + predicate declarations are
+        mandatory): a one-element sort ``human = {socrate}``, the predicate type
+        ``type(Mortal(human))``, then ``Mortal(socrate)`` together with its
+        negation ``!Mortal(socrate)`` — a direct contradiction.
         """
         inconsistent_kb = (
-            "type Human\n"
+            "human = {socrate}\n"
+            "type(Mortal(human))\n"
+            "\n"
             "Mortal(socrate)\n"
             "!Mortal(socrate)\n"
         )
         is_consistent, msg = fol_bridge.check_consistency(
             inconsistent_kb, "first_order"
         )
-        assert is_consistent is False, (
-            f"Inconsistent KB must report inconsistent; got ({is_consistent!r}, {msg!r})."
-        )
-        assert "EProver" in msg, (
-            f"Verdict must be traceable to the EProver solver; got msg={msg!r}."
-        )
+        assert (
+            is_consistent is False
+        ), f"Inconsistent KB must report inconsistent; got ({is_consistent!r}, {msg!r})."
+        assert (
+            "EProver" in msg
+        ), f"Verdict must be traceable to the EProver solver; got msg={msg!r}."
 
     def test_consistent_kb_reports_consistent_via_eprover(
         self, fol_bridge, eprover_solver
@@ -111,19 +115,23 @@ class TestRealEProverConsistency:
         """A consistent FOL KB must yield ``is_consistent = True`` via the REAL
         EProver binary.
 
-        KB (Tweety FOL syntax): ``∀x(Human(x) → Mortal(x))`` +
-        ``Human(socrate)`` + ``Mortal(socrate)`` — the classic syllogism, no
-        contradiction.
+        KB (Tweety native FOL syntax — sort + predicate declarations are
+        mandatory): ``∀x(Human(x) → Mortal(x))`` + ``Human(socrate)`` +
+        ``Mortal(socrate)`` — the classic syllogism, no contradiction.
         """
         consistent_kb = (
-            "type Human\n"
-            "forall x: (Human(x) => Mortal(x)).\n"
-            "Human(socrate).\n"
-            "Mortal(socrate).\n"
+            "human = {socrate}\n"
+            "type(Human(human))\n"
+            "type(Mortal(human))\n"
+            "\n"
+            "forall X: (Human(X) => Mortal(X))\n"
+            "Human(socrate)\n"
+            "Mortal(socrate)\n"
         )
-        is_consistent, msg = fol_bridge.check_consistency(
-            consistent_kb, "first_order"
-        )
-        assert is_consistent is True, (
-            f"Consistent KB must report consistent; got ({is_consistent!r}, {msg!r})."
-        )
+        is_consistent, msg = fol_bridge.check_consistency(consistent_kb, "first_order")
+        assert (
+            is_consistent is True
+        ), f"Consistent KB must report consistent; got ({is_consistent!r}, {msg!r})."
+        assert (
+            "EProver" in msg
+        ), f"Verdict must be traceable to the EProver solver; got msg={msg!r}."

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_eprover_real.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_eprover_real.py
@@ -1,0 +1,129 @@
+"""Real (non-mocked) EProver integration test — #1204.
+
+The EProver 3-layer regression (#1204) stayed hidden across FP-3 because the
+existing ``test_eprover_spass_integration`` is **100% mocked**: it patches
+``_get_eprover_path`` / ``jpype`` / ``settings`` and asserts Python *dispatch*,
+never running the binary. This file closes that hole with ONE non-mocked,
+skip-if-binary-absent integration test that runs the REAL EProver binary
+through the production path (``TweetyBridge.check_consistency(bs, "first_order")``
+→ ``FOLHandler.check_consistency`` → ``EFOLReasoner(path)``) and asserts a real
+consistency verdict.
+
+Modeled on FP-8's real-Prover9 test (``test_real_binary_inconsistent_kb_emits_theorem_proved``
+in ``tests/unit/argumentation_analysis/core/test_prover9_runner.py``).
+
+Anti-théâtre contract (#1019): the test must **EXECUTE** the binary where it is
+present — it must NOT be "green by skipping everywhere". On machines WITHOUT the
+EProver binary (po-2023, fresh clones) it skips cleanly; on machines WITH it
+(ai-01, po-2025) it must pass GREEN. A skip-everywhere outcome = re-théâtre and
+defeats the regression guard.
+
+DoD (#1204 R455 dispatch):
+- [x] Skips cleanly where the binary is absent (verified on po-2023)
+- [x] NO mock of binary, reasoner, or settings
+- [x] ai-01 runs it firsthand before merge (binary present there) — must pass GREEN
+
+Privacy HARD: synthetic atoms only (``Mortal(socrate)``), 0 corpus.
+"""
+
+import pytest
+
+from argumentation_analysis.core.config import settings, SolverChoice
+from argumentation_analysis.core.jvm_setup import EXTERNAL_TOOL_PATHS, initialize_jvm
+
+# The production path under test.
+from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
+
+def _eprover_binary_present() -> bool:
+    """True iff the EProver binary path is registered in the module-level
+    ``EXTERNAL_TOOL_PATHS`` registry populated by ``jvm_setup`` at startup."""
+    return bool(EXTERNAL_TOOL_PATHS.get("eprover"))
+
+
+# Skip if the binary is absent — this test cannot execute the solver otherwise.
+# (The JVM-started check is handled by the ``jvm_session`` autouse fixture in
+# conftest, which skips JVM-dependent tests when the JVM failed to start.)
+pytestmark = pytest.mark.skipif(
+    not _eprover_binary_present(),
+    reason="EProver binary not registered (EXTERNAL_TOOL_PATHS['eprover'] unset) — "
+    "install EProver under ext_tools/EProver/ to run this real integration test.",
+)
+
+
+@pytest.fixture
+def eprover_solver():
+    """Force ``settings.solver = EPROVER`` for the duration of the test, then
+    restore the previous value. This is a REAL runtime config change (not a
+    mock of ``settings``): the EProver binary and the Tweety JVM both execute
+    for real. Without this, the default solver (TWEETY/PROVER9) would be
+    dispatched and the EProver path would never be exercised."""
+    previous = settings.solver
+    settings.solver = SolverChoice.EPROVER
+    try:
+        yield
+    finally:
+        settings.solver = previous
+
+
+@pytest.fixture(scope="module")
+def fol_bridge():
+    """Start the JVM (idempotent) and build a ``TweetyBridge`` once for the
+    module. ``check_consistency(.., "first_order")`` is the production entry
+    point (path B in the #1202 cross-verification table)."""
+    initialize_jvm()
+    return TweetyBridge()
+
+
+class TestRealEProverConsistency:
+    """Real-binary EProver consistency verdicts, end-to-end through the
+    production ``TweetyBridge.check_consistency`` path."""
+
+    def test_inconsistent_kb_reports_inconsistent_via_eprover(
+        self, fol_bridge, eprover_solver
+    ):
+        """An inconsistent FOL KB (``P(a)`` and ``¬P(a)``) must yield
+        ``is_consistent = False`` via the REAL EProver binary, and the message
+        must identify the EProver solver (so the verdict is traceable to a real
+        decision, not a degraded fallback).
+
+        KB (Tweety FOL syntax): ``Mortal(socrate)`` together with its negation
+        ``!Mortal(socrate)`` — a direct contradiction.
+        """
+        inconsistent_kb = (
+            "type Human\n"
+            "Mortal(socrate)\n"
+            "!Mortal(socrate)\n"
+        )
+        is_consistent, msg = fol_bridge.check_consistency(
+            inconsistent_kb, "first_order"
+        )
+        assert is_consistent is False, (
+            f"Inconsistent KB must report inconsistent; got ({is_consistent!r}, {msg!r})."
+        )
+        assert "EProver" in msg, (
+            f"Verdict must be traceable to the EProver solver; got msg={msg!r}."
+        )
+
+    def test_consistent_kb_reports_consistent_via_eprover(
+        self, fol_bridge, eprover_solver
+    ):
+        """A consistent FOL KB must yield ``is_consistent = True`` via the REAL
+        EProver binary.
+
+        KB (Tweety FOL syntax): ``∀x(Human(x) → Mortal(x))`` +
+        ``Human(socrate)`` + ``Mortal(socrate)`` — the classic syllogism, no
+        contradiction.
+        """
+        consistent_kb = (
+            "type Human\n"
+            "forall x: (Human(x) => Mortal(x)).\n"
+            "Human(socrate).\n"
+            "Mortal(socrate).\n"
+        )
+        is_consistent, msg = fol_bridge.check_consistency(
+            consistent_kb, "first_order"
+        )
+        assert is_consistent is True, (
+            f"Consistent KB must report consistent; got ({is_consistent!r}, {msg!r})."
+        )


### PR DESCRIPTION
## Summary

Implements the R455 dispatch item from ai-01 on **#1204**: the missing **real non-mocked EProver integration test**.

The EProver 3-layer regression stayed hidden across FP-3 because `test_eprover_spass_integration` is 100% mocked (patches `_get_eprover_path`/`jpype`/`settings`, asserts Python dispatch, never runs the binary). This PR adds ONE non-mocked, skip-if-binary-absent test that runs the REAL EProver binary through the **production path** (`TweetyBridge.check_consistency(bs, "first_order")` → `FOLHandler.check_consistency` → `EFOLReasoner(path)`) and asserts a real consistency verdict.

## What it tests

| Case | KB | Expected verdict |
|------|-----|------------------|
| Inconsistent | `Mortal(socrate)` + `!Mortal(socrate)` | `(False, msg containing "EProver")` |
| Consistent | `∀x(Human(x) → Mortal(x))` + `Human(socrate)` + `Mortal(socrate)` | `(True, ...)` |

## DoD checklist (R455 dispatch)

- [x] **Skips cleanly where binary absent** — verified on po-2023 (my machine): `2 skipped`, reason `"EProver binary not registered (EXTERNAL_TOOL_PATHS['eprover'] unset) — install EProver under ext_tools/EProver/"`. Skip is for the RIGHT cause (binary absent), not an import error.
- [x] **NO mock of binary, reasoner, or settings** — `settings.solver = EPROVER` is a real runtime config change (restored in the fixture's `finally`), not a mock. The EProver binary and Tweety JVM both execute for real.
- [ ] **ai-01 runs it firsthand before merge** — ai-01 has the binary (`E 2.0 Turzum`); must pass GREEN there. The consistent-KB FOL syntax may need a firsthand tweak (Tweety FolParser signature declarations) — ai-01 to confirm/adjust on the real binary.

## Anti-théâtre contract (#1019)

The test **EXECUTES** the binary where present (ai-01, po-2025) — it is NOT "green by skipping everywhere". A skip-everywhere outcome = re-théâtre and would defeat the regression guard. On po-2023 (no binary) it skips; on machines with the binary it runs the real solver.

## File-disjoint

New file only: `tests/integration/argumentation_analysis/agents/core/logic/test_eprover_real.py` (+129). No code change — no overlap with any other open PR.

## Notes

- mypy strict: the 2 fixture functions lack type annotations, matching the repo convention (no test fixtures are mypy-annotated; CI mypy gate checks only the 8 core modules in `pyproject.toml`, not tests). Verified against `test_eprover_spass_integration.py` which uses the same unannotated-fixture style.
- Modeled on FP-8's real-Prover9 test (`test_real_binary_inconsistent_kb_emits_theorem_proved`).

🤖 Worker po-2023