### PR TITLE
fix(logic): FP-10 #1208 persist real PySAT model into PL state snapshot

### DIFF
--- a/argumentation_analysis/agents/core/logic/pl_handler.py
+++ b/argumentation_analysis/agents/core/logic/pl_handler.py
@@ -208,6 +208,27 @@ class PLHandler:
         )
         return bool(is_consistent), msg
 
+    def check_consistency_detailed(
+        self, belief_set: str
+    ) -> Tuple[bool, Optional[dict], str]:
+        """Return the PL consistency verdict WITH the real PySAT model.
+
+        #1208 (FP-10): mirrors ``check_consistency`` but does not drop the
+        solver witness. ``TweetyBridge.check_consistency_detailed`` dispatches
+        here so the invoke-callable can persist the genuine SAT model instead
+        of fabricating one. Returns ``(is_consistent, named_model, message)``.
+        """
+        if self._sat_available():
+            return self.pl_check_consistency_detailed(belief_set)
+        # Tweety fallback (no PySAT): no structured model to return.
+        is_consistent = self.pl_check_consistency_tweety(belief_set)
+        msg = (
+            "PL knowledge base is consistent."
+            if is_consistent
+            else "PL knowledge base entails a contradiction."
+        )
+        return bool(is_consistent), None, msg
+
     def pl_check_consistency(
         self, knowledge_base_str: str, constants: Optional[List[str]] = None
     ) -> bool:
@@ -432,21 +453,48 @@ class PLHandler:
 
     def pl_check_consistency_sat(self, knowledge_base_str: str) -> bool:
         """Check PL consistency using PySAT instead of Tweety."""
+        is_consistent, _model, _msg = self.pl_check_consistency_detailed(
+            knowledge_base_str
+        )
+        return is_consistent
+
+    def pl_check_consistency_detailed(
+        self, knowledge_base_str: str
+    ) -> Tuple[bool, Optional[dict], str]:
+        """Check PL consistency via PySAT and return the real SAT model.
+
+        #1208 (FP-10): ``pl_check_consistency_sat`` returned only the boolean
+        verdict, dropping the model that ``SATHandler.solve_formulas`` had
+        already computed. The invoke-callable then fabricated a placeholder
+        ``{p1: True, p2: True}`` model, so the persisted state carried a real
+        decision (sat/unsat) with a fake witness — a silent loss of the real
+        solver output (same failure class as a buried solver, #1019).
+
+        This exposes the already-computed named model so callers persist the
+        genuine PySAT witness. Returns ``(is_consistent, named_model_or_None,
+        message)``. ``named_model`` maps proposition-name -> bool (True/False
+        assignment); None when UNSAT.
+        """
         formula_strings = [
             f.strip().rstrip("%")
             for f in knowledge_base_str.split("\n")
             if f.strip() and f.strip() != "```"
         ]
         if not formula_strings:
-            return True
-        # Normalize formulas for SAT handler
+            return True, {}, "Empty knowledge base is consistent."
         normalized = [self._normalize_formula(f) for f in formula_strings]
         handler = self._get_sat_handler()
-        is_consistent, msg = handler.check_consistency(
+        is_sat, named_model, stats = handler.solve_formulas(
             normalized, settings.pysat_solver
         )
+        is_consistent = bool(is_sat)
+        msg = (
+            f"Consistent (SAT). Model: {named_model}"
+            if is_consistent
+            else f"Inconsistent (UNSAT). Solver: {stats.get('solver')}"
+        )
         logger.info(f"PySAT consistency check: {msg}")
-        return is_consistent
+        return is_consistent, named_model, msg
 
     def pl_query_sat(self, knowledge_base_str: str, query_formula_str: str) -> bool:
         """Check PL entailment using PySAT instead of Tweety."""

--- a/argumentation_analysis/agents/core/logic/tweety_bridge.py
+++ b/argumentation_analysis/agents/core/logic/tweety_bridge.py
@@ -303,6 +303,24 @@ class TweetyBridge:
         else:
             return False, f"Unknown logic type: {logic_type}"
 
+    def check_consistency_detailed(
+        self, belief_set: str, logic_type: str = "propositional"
+    ) -> Tuple[bool, Optional[dict], str]:
+        """Consistency verdict that also returns the real solver witness.
+
+        #1208 (FP-10): the plain ``check_consistency`` returns only ``(bool,
+        str)`` and the message string is where the SAT model was buried (and
+        then dropped by the caller). This returns the structured named model
+        so the PL invoke-callable persists the genuine PySAT assignment
+        instead of fabricating ``{p1: True, p2: True}`` (silent loss of a
+        real decision, #1019). Currently supported for propositional logic;
+        other logic types fall back to ``(bool, None, msg)``.
+        """
+        if logic_type == "propositional":
+            return self.pl_handler.check_consistency_detailed(belief_set)
+        is_consistent, msg = self.check_consistency(belief_set, logic_type)
+        return is_consistent, None, msg
+
     async def wait_for_jvm(self, timeout: int = 30) -> None:
         """Attend de manière asynchrone que la JVM soit prête."""
         if TweetyInitializer.is_jvm_ready():

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -810,10 +810,20 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         satisfiable: bool,
         model: Optional[Dict[str, bool]] = None,
         arg_id: Optional[str] = None,
+        axiom_count: Optional[int] = None,
+        query_count: Optional[int] = None,
+        message: Optional[str] = None,
     ) -> str:
-        """Add a propositional logic analysis result."""
+        """Add a propositional logic analysis result.
+
+        #1208 (FP-10): the real PySAT verdict (satisfiable + genuine model)
+        is persisted here. ``axiom_count``/``query_count``/``message`` are
+        optional provenance fields so downstream consumers (restitution, the
+        measurement matrix) can confirm the entry carries a real solver
+        decision, not a hollow counter.
+        """
         pl_id = self._generate_id("pl", self.propositional_analysis_results)
-        entry = {
+        entry: Dict[str, Any] = {
             "id": pl_id,
             "formulas": formulas,
             "satisfiable": satisfiable,
@@ -821,6 +831,12 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         }
         if arg_id:
             entry["arg_id"] = arg_id
+        if axiom_count is not None:
+            entry["axiom_count"] = axiom_count
+        if query_count is not None:
+            entry["query_count"] = query_count
+        if message:
+            entry["message"] = message
         self.propositional_analysis_results.append(entry)
         state_logger.info(f"PL analysis added: {pl_id} (satisfiable={satisfiable})")
         return pl_id
@@ -1096,6 +1112,16 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
                     "bipolar_result_count": len(self.bipolar_results),
                     "fol_analysis_count": len(self.fol_analysis_results),
                     "propositional_analysis_count": len(
+                        self.propositional_analysis_results
+                    ),
+                    # #1208 (FP-10): expose the real PL entries (verdict +
+                    # genuine PySAT model + counts) in the summarized snapshot
+                    # too, not just the counter. The state IS the contract;
+                    # a count alone hides whether the verdict is real or a
+                    # fabricated placeholder. This list is already in the
+                    # state object — surfacing it subtracts the masking, it
+                    # does not add a counterweight.
+                    "propositional_analysis_results": list(
                         self.propositional_analysis_results
                     ),
                     "modal_analysis_count": len(self.modal_analysis_results),

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -5100,14 +5100,26 @@ async def _invoke_propositional_logic(
 
         bridge = TweetyBridge()
         belief_set_str = "\n".join(str(f) for f in formulas)
-        is_consistent, msg = await asyncio.to_thread(
-            bridge.check_consistency, belief_set_str, "propositional"
+        # #1208 (FP-10): use the detailed consistency API so the REAL PySAT
+        # model (named proposition -> bool assignment) is persisted, not the
+        # fabricated ``{p1: True, ...}`` placeholder that silently dropped the
+        # solver witness. Also exposes the axiom/query counts the state
+        # contract expects.
+        is_consistent, sat_model, msg = await asyncio.to_thread(
+            bridge.check_consistency_detailed, belief_set_str, "propositional"
         )
         pl_metrics["post_tweety"] = len(formulas)
+        # Fallback model only when PySAT returned no structured witness (e.g.
+        # Tweety-fallback path or UNSAT). Empty dict is honest for UNSAT.
+        persisted_model = (
+            sat_model if isinstance(sat_model, dict) else {}
+        )
         return {
             "formulas": formulas,
             "satisfiable": bool(is_consistent),
-            "model": {f"p{i+1}": True for i in range(len(args))},
+            "model": persisted_model,
+            "axiom_count": len(formulas),
+            "query_count": 0,  # PL consistency is a satisfiability check (no entailment query)
             "message": msg,
             "logic_type": "propositional",
             "argument_mapping": argument_mapping

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -693,7 +693,12 @@ def _write_fact_extraction_to_state(
 
 
 def _write_propositional_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
-    """Write propositional logic analysis results to UnifiedAnalysisState."""
+    """Write propositional logic analysis results to UnifiedAnalysisState.
+
+    #1208 (FP-10): forward the real PySAT model + axiom/query counts so the
+    persisted entry carries a genuine solver witness (not a fabricated
+    ``{p1: True}`` placeholder).
+    """
     if not output or not isinstance(output, dict):
         return
     formulas = output.get("formulas", [])
@@ -703,7 +708,16 @@ def _write_propositional_to_state(output: Any, state: Any, ctx: dict[str, Any]) 
         formulas = []
     if not isinstance(model, dict):
         model = {}
-    state.add_propositional_analysis_result(formulas, bool(satisfiable), model)
+    kwargs: dict[str, Any] = {}
+    if "axiom_count" in output:
+        kwargs["axiom_count"] = output["axiom_count"]
+    if "query_count" in output:
+        kwargs["query_count"] = output["query_count"]
+    if output.get("message"):
+        kwargs["message"] = output["message"]
+    state.add_propositional_analysis_result(
+        formulas, bool(satisfiable), model, **kwargs
+    )
 
 
 def _write_fol_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/scripts/run_fp5_formal_matrix.py
+++ b/scripts/run_fp5_formal_matrix.py
@@ -101,7 +101,7 @@ CORPORA = [("A", 11, 900), ("C", 2, 900), ("B", 3, 1800)]
 # state_count_key is the UnifiedAnalysisState snapshot counter for that capability.
 CAPABILITIES = [
     # ── Formal logic layer (the FP-3 focus) ──
-    ("pl", "propositional_analysis", "propositional_analysis_count"),
+    ("pl", "propositional_logic", "propositional_analysis_count"),
     ("fol", "fol", "fol_analysis_count"),
     ("modal", "modal", "modal_analysis_count"),
     ("kb_to_tweety", "kb_to_tweety", "atomic_propositions_count"),

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_fp10_pl_persistence.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_fp10_pl_persistence.py
@@ -1,0 +1,144 @@
+"""FP-10 #1208 — PL verdict persists into the state snapshot (persistence contract).
+
+The PL/PySAT handler decided correctly (real sat/unsat + model), but the
+invoke-callable fabricated a placeholder model ``{p1: True, p2: True}`` and the
+summarized state snapshot exposed only a counter — dropping the real solver
+witness before it reached ``UnifiedAnalysisState`` (same failure class as a
+buried solver, #1019). The FP-5 matrix therefore classed PL ``absent`` even on
+corpora where PySAT decided.
+
+These tests pin the persistence contract (#1208 DoD): the real PySAT model +
+verdict + axiom/query counts must land in the state snapshot. They run without
+a JVM — the contract is the state plumbing, not the solver binary.
+"""
+
+import pytest
+
+
+def test_state_writer_persists_real_model_not_placeholder():
+    """The PL state writer must forward the real PySAT model + counts.
+
+    #1208: before the fix, ``_invoke_propositional_logic`` returned a
+    fabricated ``{p1: True, ...}`` model regardless of the solver result. The
+    state writer then persisted that fake witness, so a real UNSAT could be
+    recorded with a "model" attached. The writer must now persist the genuine
+    model + axiom/query counts the handler produced.
+    """
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+    from argumentation_analysis.orchestration.state_writers import (
+        _write_propositional_to_state,
+    )
+
+    state = UnifiedAnalysisState("test")
+    output = {
+        "formulas": ["is_mortal && foreign_threat"],
+        "satisfiable": True,
+        "model": {"is_mortal": True, "foreign_threat": True},
+        "axiom_count": 2,
+        "query_count": 0,
+        "message": "Consistent (SAT). Model: {...}",
+        "logic_type": "propositional",
+    }
+    _write_propositional_to_state(output, state, {})
+
+    assert len(state.propositional_analysis_results) == 1
+    entry = state.propositional_analysis_results[0]
+    # The real named model must be preserved — NOT a {p1: True} placeholder.
+    assert entry["model"] == {"is_mortal": True, "foreign_threat": True}
+    assert entry["satisfiable"] is True
+    assert entry["axiom_count"] == 2
+    assert entry["query_count"] == 0
+    assert entry["message"].startswith("Consistent (SAT)")
+
+
+def test_state_writer_persists_unsat_with_empty_model():
+    """An UNSAT verdict must persist an empty model, never a fabricated witness.
+
+    #1208/#1019: the old code attached ``{p1: True}`` even to inconsistent KBs
+    (it derived the placeholder from ``len(args)``, not the solver). An UNSAT
+    result must carry an empty model so the witness is honest.
+    """
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+    from argumentation_analysis.orchestration.state_writers import (
+        _write_propositional_to_state,
+    )
+
+    state = UnifiedAnalysisState("test")
+    output = {
+        "formulas": ["claim", "!claim"],
+        "satisfiable": False,
+        "model": {},  # UNSAT — no model
+        "axiom_count": 2,
+        "query_count": 0,
+        "message": "Inconsistent (UNSAT).",
+    }
+    _write_propositional_to_state(output, state, {})
+
+    entry = state.propositional_analysis_results[0]
+    assert entry["satisfiable"] is False
+    assert entry["model"] == {}
+
+
+def test_summarized_snapshot_exposes_pl_results_not_just_count():
+    """``get_state_snapshot(summarize=True)`` must expose the real PL entries.
+
+    #1208: the summarized snapshot only exposed ``propositional_analysis_count``
+    (an integer), hiding whether the persisted verdict was real or a fabricated
+    placeholder. The state IS the contract — surfacing the list (which already
+    lives in the state object) subtracts the masking; it does not add a
+    counterweight.
+    """
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+    state = UnifiedAnalysisState("test")
+    state.add_propositional_analysis_result(
+        ["a && b"], True, {"a": True, "b": True}, axiom_count=1, query_count=0
+    )
+    snap = state.get_state_snapshot(summarize=True)
+
+    # Count is still there (backward compat).
+    assert snap["propositional_analysis_count"] == 1
+    # The real entries are now exposed — not just the counter.
+    results = snap["propositional_analysis_results"]
+    assert len(results) == 1
+    assert results[0]["satisfiable"] is True
+    assert results[0]["model"] == {"a": True, "b": True}
+
+
+@pytest.mark.jpype
+def test_check_consistency_detailed_returns_real_pysat_model():
+    """PLHandler.check_consistency_detailed returns the genuine SAT model.
+
+    #1208: the wired PL path must return ``(is_consistent, named_model, msg)``
+    where ``named_model`` is the real PySAT assignment (not None, not a
+    fabricated ``{p1}`` dict). Requires a JVM (TweetyBridge construction) and
+    PySAT.
+    """
+    try:
+        from argumentation_analysis.agents.core.logic.tweety_bridge import (
+            TweetyBridge,
+        )
+        from argumentation_analysis.agents.core.logic.sat_handler import (
+            PYSAT_AVAILABLE,
+        )
+    except ImportError:
+        pytest.skip("TweetyBridge / sat_handler not importable")
+    if not PYSAT_AVAILABLE:
+        pytest.skip("PySAT not installed")
+
+    bridge = TweetyBridge()
+    # SAT: a && b, a => c  (model must assign a, b, c)
+    is_c, model, _msg = bridge.check_consistency_detailed(
+        "alpha && beta\nalpha => gamma", "propositional"
+    )
+    assert is_c is True
+    assert isinstance(model, dict)
+    assert model.get("alpha") is True
+    assert model.get("beta") is True
+
+    # UNSAT: claim, !claim
+    is_c2, model2, _msg2 = bridge.check_consistency_detailed(
+        "claim\n!claim", "propositional"
+    )
+    assert is_c2 is False
+    assert not model2  # None or empty — never a fabricated witness

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_fp10_pl_persistence.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_fp10_pl_persistence.py
@@ -30,11 +30,16 @@ def test_state_writer_persists_real_model_not_placeholder():
     )
 
     state = UnifiedAnalysisState("test")
+    # Two formulas → axiom_count == len(formulas) (the invoke-callable contract).
+    # #1208 review feedback (Hermes po-2026): keep the test's axiom_count
+    # consistent with the number of formulas so it reflects the real emitted
+    # value, not an arbitrary hardcoded integer that masks the semantics.
+    formulas = ["is_mortal && foreign_threat", "is_mortal => danger"]
     output = {
-        "formulas": ["is_mortal && foreign_threat"],
+        "formulas": formulas,
         "satisfiable": True,
-        "model": {"is_mortal": True, "foreign_threat": True},
-        "axiom_count": 2,
+        "model": {"is_mortal": True, "foreign_threat": True, "danger": True},
+        "axiom_count": len(formulas),
         "query_count": 0,
         "message": "Consistent (SAT). Model: {...}",
         "logic_type": "propositional",
@@ -44,9 +49,13 @@ def test_state_writer_persists_real_model_not_placeholder():
     assert len(state.propositional_analysis_results) == 1
     entry = state.propositional_analysis_results[0]
     # The real named model must be preserved — NOT a {p1: True} placeholder.
-    assert entry["model"] == {"is_mortal": True, "foreign_threat": True}
+    assert entry["model"] == {
+        "is_mortal": True,
+        "foreign_threat": True,
+        "danger": True,
+    }
     assert entry["satisfiable"] is True
-    assert entry["axiom_count"] == 2
+    assert entry["axiom_count"] == len(formulas)
     assert entry["query_count"] == 0
     assert entry["message"].startswith("Consistent (SAT)")
 
@@ -64,11 +73,12 @@ def test_state_writer_persists_unsat_with_empty_model():
     )
 
     state = UnifiedAnalysisState("test")
+    formulas = ["claim", "!claim"]
     output = {
-        "formulas": ["claim", "!claim"],
+        "formulas": formulas,
         "satisfiable": False,
         "model": {},  # UNSAT — no model
-        "axiom_count": 2,
+        "axiom_count": len(formulas),
         "query_count": 0,
         "message": "Inconsistent (UNSAT).",
     }


### PR DESCRIPTION
## Summary

Closes #1208 (Epic #1191 depth-parity, surfaced by FP-5 matrix #1207).

PL/PySAT **decided correctly** (6 real decisions with explicit models in the FP-5 run log: `Consistent (SAT). Model: {…}`) but the verdict was **dropped before the state snapshot** — so downstream consumers (restitution, the FP-5 matrix) saw PL as `absent` on every corpus. Same failure class as a buried solver (#1019): a real decision silently discarded before it reaches `UnifiedAnalysisState`.

## Root cause (3-layer plumbing gap)

1. **`PLHandler.pl_check_consistency_sat`** returned only the boolean verdict, dropping the named model `SATHandler.solve_formulas` had already computed.
2. **`_invoke_propositional_logic`** (`invoke_callables.py:5110`) built a **fabricated placeholder** model `{p1: True, p2: True, ...}` from `len(args)` instead of persisting the genuine PySAT witness.
3. **`get_state_snapshot(summarize=True)`** exposed only `propositional_analysis_count` (an integer), masking whether the persisted verdict was real or a placeholder.

## Fix (anti-pendule: expose data already computed, no counterweight)

- `PLHandler.check_consistency_detailed` / `pl_check_consistency_detailed` → returns `(is_consistent, named_model, msg)` — the real PySAT assignment (`None` on UNSAT).
- `TweetyBridge.check_consistency_detailed` dispatches to it (other logic types fall back to `(bool, None, msg)`).
- `_invoke_propositional_logic` uses the detailed API: persists the **real model** + `axiom_count`/`query_count` (no fabricated placeholder).
- `add_propositional_analysis_result` accepts `axiom_count`/`query_count`/`message` provenance (backward-compatible kwargs).
- `_write_propositional_to_state` forwards the real model + counts.
- `get_state_snapshot(summarize=True)` exposes `propositional_analysis_results` (the list already lives in the state object — surfacing it subtracts the masking).

## Firsthand verification (real PySAT, cadical195)

- **SAT KB** (`is_mortal && foreign_threat`, `is_mortal => danger`) → `consistent=True`, real model `{is_mortal: True, foreign_threat: True, danger: True}` (not None, not fabricated).
- **UNSAT KB** (`claim`, `!claim`) → `consistent=False`, model `None` (no fake witness).

## DoD #1208

- [x] Root-cause cited `file:line` (`invoke_callables.py:5110` fabricated model).
- [x] PL verdicts (sat/unsat + model + counts) persist into state snapshot.
- [x] Verified firsthand on real PySAT + 4 contract tests green.
- [x] FP-5 classifier classes PL `real-verdict` (no classifier change needed — fixing persistence + the runner phase-name typo `propositional_analysis`→`propositional_logic` is sufficient).

## Tests

- New: `test_fp10_pl_persistence.py` (4 tests: real-model persistence, UNSAT-empty-model, snapshot-exposes-results, real-PySAT-detailed-API).
- No regression: 92 (regression suite + shared_state) + 69 (formal verification + mute capabilities) + 334 (logic + golden) pass.
- 4 pre-existing failures (`test_1178_handler_fixes`, `test_eprover_spass_integration` — EProver/SPASS/CL/Social handlers, **untouched by this PR**) confirmed on clean `main` via `git stash` baseline.

## Privacy HARD

Opaque IDs only (`pl_1`, `doc_A`). No `raw_text`/`full_text` in state or PR. `evaluation/results/` gitignored.

## Anti-pendule / anti-theater (#1019)

- Did NOT fabricate counts to green the cell — persisted the **real** decided values.
- Did NOT make the classifier read the log — the state IS the contract; fixed persistence, not the probe.
- The fix exposes solver output that was already computed and dropped — pure subtraction of the plumbing gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)