### PR TITLE
fix(logic): #1205 SPASS modal ctor wiring (1-arg path) + real test (sibling of eprover fix)

### DIFF
--- a/argumentation_analysis/agents/core/logic/modal_handler.py
+++ b/argumentation_analysis/agents/core/logic/modal_handler.py
@@ -8,6 +8,30 @@ from argumentation_analysis.core.config import settings, ModalSolverChoice
 logger = logging.getLogger(__name__)
 
 
+def _get_spass_path() -> "str | None":
+    """Return the detected SPASS binary path, or None if not wired.
+
+    Reads the module-level registry populated by
+    ``jvm_setup._configure_external_tools``. Centralised here (mirroring
+    ``fol_handler._get_eprover_path``) so the Modal handler does not duplicate
+    the detection logic and the wiring is testable in isolation (#1205).
+
+    #1205: the previous ``_get_spass_reasoner`` called ``SPASSMlReasoner()`` with
+    no argument — but in Tweety 1.28+/1.29 the only constructors are
+    ``SPASSMlReasoner(String)`` and ``SPASSMlReasoner(String, Shell)`` (verified
+    via ``javap`` on the bundled jar). The no-arg call raised a Java
+    construction error, swallowed by the surrounding ``except`` → SPASS was
+    never wired, yet the pipeline reported it as the configured modal solver
+    (formal theater, same class as the EProver regression #1196/#1202).
+    """
+    try:
+        from argumentation_analysis.core.jvm_setup import EXTERNAL_TOOL_PATHS
+
+        return EXTERNAL_TOOL_PATHS.get("spass")
+    except Exception:  # pragma: no cover - import guard
+        return None
+
+
 class ModalHandler:
     """
     Handles Modal Logic operations using TweetyProject.
@@ -34,14 +58,41 @@ class ModalHandler:
             )
 
     def _get_spass_reasoner(self):
-        """Lazy-load SPASSMlReasoner if available."""
+        """Lazy-load SPASSMlReasoner, wired with the detected binary path.
+
+        #1205 (anti-theater #1019): the previous implementation called
+        ``SPASSMlReasoner()`` with no argument — but Tweety 1.28+/1.29 only
+        exposes ``SPASSMlReasoner(String)`` / ``SPASSMlReasoner(String, Shell)``
+        (verified via ``javap``), so the construction raised and the bare
+        ``except`` swallowed it into a generic ``RuntimeError``. The detected
+        SPASS path (``EXTERNAL_TOOL_PATHS['spass']``) was never passed to the
+        constructor — mirroring the EProver regression #1196/#1202.
+
+        Now reads the registered path and instantiates
+        ``SPASSMlReasoner(JString(path))`` (1-arg ctor). If the path is unset
+        (binary absent), this raises ``RuntimeError`` **fail-loud** — it does
+        NOT silently fall back to ``SimpleMlReasoner``: a missing SPASS binary
+        must surface as an honest "could not decide" (``None``/degraded), never
+        as a fabricated verdict.
+        """
         if self._spass_reasoner is None:
+            spass_path = _get_spass_path()
+            if spass_path is None:
+                raise RuntimeError(
+                    "SPASS binary not detected (EXTERNAL_TOOL_PATHS['spass'] "
+                    "unset) — modal axis cannot decide via SPASS. Install "
+                    "SPASS under ext_tools/spass/ or use a non-SPASS modal "
+                    "solver (anti-theater #1019: no silent fallback)."
+                )
             try:
                 SPASSMlReasoner = jpype.JClass(
                     "org.tweetyproject.logics.ml.reasoner.SPASSMlReasoner"
                 )
-                self._spass_reasoner = SPASSMlReasoner()
-                logger.info("SPASSMlReasoner loaded successfully.")
+                JString = jpype.JClass("java.lang.String")
+                self._spass_reasoner = SPASSMlReasoner(JString(spass_path))
+                logger.info(
+                    f"SPASSMlReasoner loaded successfully (binary: {spass_path})."
+                )
             except Exception as e:
                 logger.warning(f"Failed to load SPASSMlReasoner: {e}")
                 raise RuntimeError(f"SPASS reasoner not available: {e}") from e

--- a/argumentation_analysis/agents/core/logic/modal_handler.py
+++ b/argumentation_analysis/agents/core/logic/modal_handler.py
@@ -167,41 +167,112 @@ class ModalHandler:
             logger.error(error_msg, exc_info=True)
             return f"FUNC_ERROR: {error_msg}"
 
-    def is_modal_kb_consistent(self, belief_set_content: str) -> Tuple[bool, str]:
+    def _build_contradiction_probe(self, belief_set):
+        """Build a ground contradiction ``atom && !atom`` over the KB signature.
+
+        Tweety modal reasoners (``SimpleMlReasoner`` / ``SPASSMlReasoner``)
+        expose ``query(beliefSet, formula)`` but **NOT** ``isConsistent`` (#1205,
+        verified firsthand via ``javap`` and ``getMethods()`` introspection — the
+        only methods are ``query``/``queryProof``). A modal KB is inconsistent
+        iff it entails a contradiction (an inconsistent KB has no models, so it
+        entails every formula over its signature, including ``atom && !atom``;
+        a consistent KB has a model that satisfies the atom one way, so it does
+        NOT entail the contradiction).
+
+        Returns the parsed contradiction formula, or ``None`` when the signature
+        has no predicates (an empty / modal-constant-only KB is trivially
+        consistent). Raises ``RuntimeError`` when a ground atom cannot be built
+        (n-ary predicate with no declared constants) — surfaced as honest
+        "undecidable" rather than a fabricated verdict (#1019).
+        """
+        signature = belief_set.getSignature()
+        predicates = list(signature.getPredicates())
+        if not predicates:
+            return None
+        predicate = predicates[0]
+        name = str(predicate.getName())
+        arity = int(predicate.getArity())
+        if arity == 0:
+            atom = name
+        else:
+            constants = list(signature.getConstants())
+            if not constants:
+                raise RuntimeError(
+                    f"Cannot build a ground contradiction probe: predicate "
+                    f"'{name}' has arity {arity} but the signature declares no "
+                    f"constants — modal consistency is undecidable via query here."
+                )
+            constant = str(constants[0].get())
+            atom = f"{name}(" + ",".join([constant] * arity) + ")"
+        return self._modal_parser.parseFormula(f"{atom} && !{atom}")
+
+    def is_modal_kb_consistent(
+        self, belief_set_content: str
+    ) -> Tuple[Optional[bool], str]:
         """
         Checks if a modal logic knowledge base is consistent.
-        Uses the configured reasoner (SimpleMlReasoner or SPASSMlReasoner).
+
+        Uses the configured reasoner (``SimpleMlReasoner`` or
+        ``SPASSMlReasoner``) via **query-based consistency** (#1205): the KB is
+        inconsistent iff it entails a contradiction (see
+        ``_build_contradiction_probe``). The previous implementation called
+        ``reasoner.isConsistent(belief_set)`` — a method that exists on NO
+        Tweety modal reasoner — so it never decided; the failure was masked by
+        fully-mocked unit tests (formal theater, modal side of #1196/#1202).
+
+        Returns ``(True/False, msg)`` on a real decision and ``(None, msg)``
+        when consistency cannot be determined — a malformed KB, or a reasoner
+        that cannot run (e.g. the SPASS binary is absent or not a runnable CLI
+        build). Honest ``None`` (no silent fallback to another reasoner, no
+        fabricated verdict) per the anti-theater contract (#1019/#961).
         """
+        solver_name = settings.modal_solver.value
         reasoner = self._get_active_reasoner()
-        logger.debug(
-            f"Checking modal KB consistency with {settings.modal_solver.value}."
-        )
+        logger.debug(f"Checking modal KB consistency with {solver_name}.")
+
         try:
             StringReader = jpype.JClass("java.io.StringReader")
-            belief_set_reader = StringReader(belief_set_content)
-            belief_set = self._modal_parser.parseBeliefBase(belief_set_reader)
-
-            is_consistent = reasoner.isConsistent(belief_set)
-
-            message = (
-                "Knowledge base is consistent."
-                if is_consistent
-                else "Knowledge base is inconsistent."
+            belief_set = self._modal_parser.parseBeliefBase(
+                StringReader(belief_set_content)
             )
-            return bool(is_consistent), message
+        except Exception as e:  # parse failure → undetermined, not "inconsistent"
+            error_msg = (
+                f"Modal KB parse error (consistency undetermined, {solver_name}): {e}"
+            )
+            logger.error(error_msg)
+            return None, error_msg
+
+        try:
+            contradiction = self._build_contradiction_probe(belief_set)
+            if contradiction is None:
+                return True, (
+                    f"Knowledge base is consistent (no predicates, {solver_name})."
+                )
+            entails_contradiction = reasoner.query(belief_set, contradiction)
+            is_consistent = not bool(entails_contradiction)
+            message = (
+                f"Knowledge base is consistent ({solver_name})."
+                if is_consistent
+                else f"Knowledge base is inconsistent ({solver_name})."
+            )
+            return is_consistent, message
 
         except jpype.JException as e:
-            if "no method found" in str(e).lower():
-                logger.warning(
-                    "The 'isConsistent' method is not available on the ModalReasoner. "
-                    "Reporting unverified status instead of assuming consistent (#961)."
-                )
-                return None, "Consistency check unavailable: method not found on reasoner."
-
-            error_msg = f"Error checking modal KB consistency: {e.getMessage()}"
-            logger.error(error_msg, exc_info=True)
-            return False, error_msg
+            # e.g. the SPASS binary cannot launch (wrong build / elevation) →
+            # honest "could not decide" (None), NOT False and NOT a fallback.
+            error_msg = (
+                f"Modal consistency could not be decided via {solver_name} "
+                f"(reasoner unavailable): {e.getMessage()}"
+            )
+            logger.warning(error_msg)
+            return None, error_msg
+        except RuntimeError as e:
+            error_msg = f"Modal consistency undecidable ({solver_name}): {e}"
+            logger.warning(error_msg)
+            return None, error_msg
         except Exception as e:
-            error_msg = f"An unexpected error occurred during consistency check: {e}"
+            error_msg = (
+                f"Unexpected error during modal consistency check ({solver_name}): {e}"
+            )
             logger.error(error_msg, exc_info=True)
-            return False, error_msg
+            return None, error_msg

--- a/argumentation_analysis/core/config.py
+++ b/argumentation_analysis/core/config.py
@@ -41,10 +41,17 @@ class ArgAnalysisSettings(BaseSettings):
 
     #
     # Le choix du solveur pour la logique modale.
-    # 'spass' (défaut) utilise SPASSMlReasoner — robust (#939).
-    # 'tweety' fallback — SimpleMlReasoner, last resort only.
+    # 'tweety' (défaut) utilise SimpleMlReasoner (pure-Java) — query-based
+    #   consistency DÉCIDE réellement, aucun binaire externe requis (#1205,
+    #   firsthand-vérifié). C'est le défaut honnête.
+    # 'spass' utilise SPASSMlReasoner (binaire externe) — disponible mais exige
+    #   un build CLI exécutable de SPASS ; le binaire vendoré actuel est un build
+    #   GUI/élévation (CreateProcess err740), donc SPASS reste fail-loud None
+    #   tant qu'un vrai CLI n'est pas fourni (anti-théâtre #1019, pas de fallback
+    #   silencieux). L'ancien défaut 'spass' (#939) n'a jamais décidé :
+    #   SPASSMlReasoner n'expose pas isConsistent + binaire non exécutable.
     #
-    modal_solver: ModalSolverChoice = ModalSolverChoice.SPASS
+    modal_solver: ModalSolverChoice = ModalSolverChoice.TWEETY
 
     #
     # Le choix du solveur pour la logique propositionnelle.

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
@@ -1,0 +1,134 @@
+"""Real (non-mocked) SPASS modal integration test — #1205.
+
+The SPASS modal reasoner had the SAME no-arg constructor bug that EProver had
+pre-#1202 (#1205): ``_get_spass_reasoner`` called ``SPASSMlReasoner()`` with no
+argument, but Tweety 1.28+/1.29 only exposes ``SPASSMlReasoner(String)`` /
+``SPASSMlReasoner(String, Shell)`` (verified via ``javap`` on the bundled jar).
+The construction error was swallowed by a bare ``except``, so SPASS was never
+wired, yet the pipeline reported it as the configured modal solver (formal
+theater, modal side of the #1196/#1202 regression class).
+
+This file closes that hole with ONE non-mocked, skip-if-binary-absent
+integration test that runs the REAL SPASS binary through the production path
+(``TweetyBridge.check_consistency(bs, "K")`` → ``ModalHandler.is_modal_kb_consistent``
+→ ``SPASSMlReasoner(path).isConsistent``) and asserts a real consistency verdict.
+
+Modeled on FP-8's real-EProver test (``test_eprover_real.py``, #1210).
+
+Anti-théâtre contract (#1019): the test must **EXECUTE** the binary where it is
+present — it must NOT be "green by skipping everywhere". On machines WITHOUT the
+SPASS binary (po-2023, fresh clones) it skips cleanly; on machines WITH it
+(ai-01) it must pass GREEN. A skip-everywhere outcome = re-théâtre and defeats
+the regression guard.
+
+DoD (#1205 R458 dispatch):
+- [x] Skips cleanly where the binary is absent (verified on po-2023)
+- [x] NO mock of binary, reasoner, or settings
+- [x] ai-01 runs it firsthand before merge (binary present there) — must pass GREEN
+
+Privacy HARD: synthetic atoms only (``Mortal(socrate)``-style), 0 corpus.
+"""
+
+import pytest
+
+from argumentation_analysis.core.config import settings, ModalSolverChoice
+from argumentation_analysis.core.jvm_setup import EXTERNAL_TOOL_PATHS, initialize_jvm
+
+# The production path under test.
+from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
+
+def _spass_binary_present() -> bool:
+    """True iff the SPASS binary path is registered in the module-level
+    ``EXTERNAL_TOOL_PATHS`` registry populated by ``jvm_setup`` at startup."""
+    return bool(EXTERNAL_TOOL_PATHS.get("spass"))
+
+
+# Skip if the binary is absent — this test cannot execute the solver otherwise.
+# (The JVM-started check is handled by the ``jvm_session`` autouse fixture in
+# conftest, which skips JVM-dependent tests when the JVM failed to start.)
+pytestmark = pytest.mark.skipif(
+    not _spass_binary_present(),
+    reason="SPASS binary not registered (EXTERNAL_TOOL_PATHS['spass'] unset) — "
+    "install SPASS under ext_tools/spass/ to run this real integration test.",
+)
+
+
+@pytest.fixture
+def spass_solver():
+    """Force ``settings.modal_solver = SPASS`` for the duration of the test,
+    then restore the previous value. This is a REAL runtime config change (not
+    a mock of ``settings``): the SPASS binary and the Tweety JVM both execute
+    for real. Without this, the default modal solver (TWEETY/SimpleMlReasoner)
+    would be dispatched and the SPASS path would never be exercised.
+
+    Under SPASS, ``_get_active_reasoner`` returns ``_get_spass_reasoner()``,
+    which (post-#1205) builds the REAL ``SPASSMlReasoner(path)`` — so reaching
+    a verdict at all proves SPASS was invoked (not the SimpleMl fallback)."""
+    previous = settings.modal_solver
+    settings.modal_solver = ModalSolverChoice.SPASS
+    try:
+        yield
+    finally:
+        settings.modal_solver = previous
+
+
+@pytest.fixture(scope="module")
+def modal_bridge():
+    """Start the JVM (idempotent) and build a ``TweetyBridge`` once for the
+    module. ``check_consistency(.., "K")`` routes to ``ModalHandler``
+    (``is_modal_kb_consistent``), the production entry point for modal
+    consistency."""
+    initialize_jvm()
+    return TweetyBridge()
+
+
+class TestRealSpassConsistency:
+    """Real-binary SPASS modal consistency verdicts, end-to-end through the
+    production ``TweetyBridge.check_consistency`` → ``ModalHandler`` path."""
+
+    def test_inconsistent_kb_reports_inconsistent_via_spass(
+        self, modal_bridge, spass_solver
+    ):
+        """An inconsistent modal KB must yield ``is_consistent = False`` via the
+        REAL SPASS binary.
+
+        The KB reaches ``SPASSMlReasoner(path).isConsistent`` only because
+        ``settings.modal_solver == SPASS`` forces ``_get_active_reasoner`` to
+        ``_get_spass_reasoner()``, which (post-#1205) builds the real reasoner
+        with the registered binary path. Pre-#1205 this raised a swallowed
+        construction error (no-arg ctor) and degraded silently; here, reaching
+        a boolean verdict at all is the regression guard.
+
+        KB (modal logic, contradiction): ``Mortal(socrate)`` together with its
+        negation ``!Mortal(socrate)`` — a direct contradiction. Syntax may need
+        a firsthand tweak per the MlParser declaration rules (ai-01 to confirm
+        on the real binary, as for the FOL case in #1210).
+        """
+        inconsistent_kb = "Mortal(socrate)\n!Mortal(socrate)\n"
+        is_consistent, msg = modal_bridge.check_consistency(
+            inconsistent_kb, "K"
+        )
+        assert is_consistent is False, (
+            f"Inconsistent modal KB must report inconsistent; "
+            f"got ({is_consistent!r}, {msg!r})."
+        )
+
+    def test_consistent_kb_reports_consistent_via_spass(
+        self, modal_bridge, spass_solver
+    ):
+        """A consistent modal KB must yield ``is_consistent = True`` via the
+        REAL SPASS binary.
+
+        KB (modal logic, no contradiction): ``[](Mortal(socrate))`` —
+        "necessarily Mortal(socrate)" — a single non-contradictory modal
+        formula (Tweety modal syntax: ``[]`` = necessity operator).
+        """
+        consistent_kb = "[](Mortal(socrate))\n"
+        is_consistent, msg = modal_bridge.check_consistency(
+            consistent_kb, "K"
+        )
+        assert is_consistent is True, (
+            f"Consistent modal KB must report consistent; "
+            f"got ({is_consistent!r}, {msg!r})."
+        )

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
@@ -1,32 +1,34 @@
-"""Real (non-mocked) SPASS modal integration test — #1205.
+"""Real (non-mocked) modal consistency integration test — #1205 / #1212.
 
-The SPASS modal reasoner had the SAME no-arg constructor bug that EProver had
-pre-#1202 (#1205): ``_get_spass_reasoner`` called ``SPASSMlReasoner()`` with no
-argument, but Tweety 1.28+/1.29 only exposes ``SPASSMlReasoner(String)`` /
-``SPASSMlReasoner(String, Shell)`` (verified via ``javap`` on the bundled jar).
-The construction error was swallowed by a bare ``except``, so SPASS was never
-wired, yet the pipeline reported it as the configured modal solver (formal
-theater, modal side of the #1196/#1202 regression class).
+Two firsthand findings (ai-01, 2026-06-21) reshaped this test from po-2023's
+original SPASS-forced draft:
 
-This file closes that hole with ONE non-mocked, skip-if-binary-absent
-integration test that runs the REAL SPASS binary through the production path
-(``TweetyBridge.check_consistency(bs, "K")`` → ``ModalHandler.is_modal_kb_consistent``
-→ ``SPASSMlReasoner(path).isConsistent``) and asserts a real consistency verdict.
+1. **No modal reasoner exposes ``isConsistent``.** Both ``SimpleMlReasoner`` and
+   ``SPASSMlReasoner`` only expose ``query``/``queryProof`` (verified via
+   ``getMethods()``). ``ModalHandler.is_modal_kb_consistent`` called the
+   non-existent ``isConsistent`` → it never decided; fully-mocked unit tests
+   masked it (formal theater, modal side of the #1196/#1202 regression class).
+   Fixed (#1205): query-based consistency (KB inconsistent iff it entails a
+   contradiction ``atom && !atom``).
 
-Modeled on FP-8's real-EProver test (``test_eprover_real.py``, #1210).
+2. **The vendored ``SPASS.exe`` cannot run here.** It is a GUI/elevation build
+   (``CreateProcess error=740``, ``isInstalled()==False``), not a runnable CLI
+   theorem prover. So a SPASS-forced verdict is impossible on ai-01 — forcing
+   it and asserting a boolean would be re-theater (it would in fact return the
+   honest ``None``).
 
-Anti-théâtre contract (#1019): the test must **EXECUTE** the binary where it is
-present — it must NOT be "green by skipping everywhere". On machines WITHOUT the
-SPASS binary (po-2023, fresh clones) it skips cleanly; on machines WITH it
-(ai-01) it must pass GREEN. A skip-everywhere outcome = re-théâtre and defeats
-the regression guard.
+So the **real anti-theater guard** is the DEFAULT modal reasoner
+(``SimpleMlReasoner``, pure-Java, query-based): it DECIDES consistency with NO
+external binary, hence it RUNS on CI everywhere — not "green by skipping". The
+SPASS-specific test is gated on ``isInstalled()`` and skips honestly where SPASS
+is not a runnable CLI build (ai-01's GUI binary), so it never green-by-skips a
+claim it cannot back.
 
-DoD (#1205 R458 dispatch):
-- [x] Skips cleanly where the binary is absent (verified on po-2023)
-- [x] NO mock of binary, reasoner, or settings
-- [x] ai-01 runs it firsthand before merge (binary present there) — must pass GREEN
+Production path under test:
+``TweetyBridge.check_consistency(bs, "K")`` → ``ModalHandler.is_modal_kb_consistent``
+→ active reasoner ``.query(beliefSet, contradiction)``.
 
-Privacy HARD: synthetic atoms only (``Mortal(socrate)``-style), 0 corpus.
+Privacy HARD: synthetic propositions only (``Rain``/``Wet``), 0 corpus.
 """
 
 import pytest
@@ -37,40 +39,37 @@ from argumentation_analysis.core.jvm_setup import EXTERNAL_TOOL_PATHS, initializ
 # The production path under test.
 from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
 
-
-def _spass_binary_present() -> bool:
-    """True iff the SPASS binary path is registered in the module-level
-    ``EXTERNAL_TOOL_PATHS`` registry populated by ``jvm_setup`` at startup."""
-    return bool(EXTERNAL_TOOL_PATHS.get("spass"))
-
-
-# Skip if the binary is absent — this test cannot execute the solver otherwise.
-# (The JVM-started check is handled by the ``jvm_session`` autouse fixture in
-# conftest, which skips JVM-dependent tests when the JVM failed to start.)
-pytestmark = pytest.mark.skipif(
-    not _spass_binary_present(),
-    reason="SPASS binary not registered (EXTERNAL_TOOL_PATHS['spass'] unset) — "
-    "install SPASS under ext_tools/spass/ to run this real integration test.",
-)
+# Valid Tweety MlParser syntax (firsthand-verified): predicates are declared with
+# ``type(Pred)`` (0-ary propositions here); modal operators are ``[]``/``<>``.
+# An inconsistent KB: a proposition and its negation.
+INCONSISTENT_KB = "type(Rain)\n\nRain\n!Rain\n"
+# A consistent modal KB exercising the necessity operator: []( Rain => Wet ) and Rain.
+CONSISTENT_KB = "type(Rain)\ntype(Wet)\n\n[](Rain => Wet)\nRain\n"
 
 
-@pytest.fixture
-def spass_solver():
-    """Force ``settings.modal_solver = SPASS`` for the duration of the test,
-    then restore the previous value. This is a REAL runtime config change (not
-    a mock of ``settings``): the SPASS binary and the Tweety JVM both execute
-    for real. Without this, the default modal solver (TWEETY/SimpleMlReasoner)
-    would be dispatched and the SPASS path would never be exercised.
+def _spass_runnable() -> bool:
+    """True iff the SPASS binary is registered AND actually launchable.
 
-    Under SPASS, ``_get_active_reasoner`` returns ``_get_spass_reasoner()``,
-    which (post-#1205) builds the REAL ``SPASSMlReasoner(path)`` — so reaching
-    a verdict at all proves SPASS was invoked (not the SimpleMl fallback)."""
-    previous = settings.modal_solver
-    settings.modal_solver = ModalSolverChoice.SPASS
+    ``EXTERNAL_TOOL_PATHS['spass']`` being set is NOT enough: the vendored
+    ``SPASS.exe`` on ai-01 is a GUI/elevation build that fails to launch
+    (``CreateProcess error=740``). Tweety's ``SPASSMlReasoner.isInstalled()``
+    probes the actual binary, so it is the honest gate for the SPASS test.
+    """
+    path = EXTERNAL_TOOL_PATHS.get("spass")
+    if not path:
+        return False
     try:
-        yield
-    finally:
-        settings.modal_solver = previous
+        import jpype
+
+        if not jpype.isJVMStarted():
+            return False
+        SPASSMlReasoner = jpype.JClass(
+            "org.tweetyproject.logics.ml.reasoner.SPASSMlReasoner"
+        )
+        JString = jpype.JClass("java.lang.String")
+        return bool(SPASSMlReasoner(JString(path)).isInstalled())
+    except Exception:
+        return False
 
 
 @pytest.fixture(scope="module")
@@ -83,52 +82,94 @@ def modal_bridge():
     return TweetyBridge()
 
 
-class TestRealSpassConsistency:
-    """Real-binary SPASS modal consistency verdicts, end-to-end through the
-    production ``TweetyBridge.check_consistency`` → ``ModalHandler`` path."""
+class TestModalConsistencyDecidesViaDefault:
+    """Real, non-mocked modal consistency via the DEFAULT reasoner
+    (``SimpleMlReasoner``, pure-Java, query-based). No external binary → this
+    RUNS on CI everywhere (the anti-theater guard for the #1205 regression).
+    """
 
-    def test_inconsistent_kb_reports_inconsistent_via_spass(
-        self, modal_bridge, spass_solver
-    ):
-        """An inconsistent modal KB must yield ``is_consistent = False`` via the
-        REAL SPASS binary.
+    @pytest.fixture
+    def tweety_solver(self):
+        """Force the pure-Java default (``TWEETY``/``SimpleMlReasoner``) for the
+        test. This reasoner decides consistency via ``query`` with no external
+        binary — the honest, always-available modal path."""
+        previous = settings.modal_solver
+        settings.modal_solver = ModalSolverChoice.TWEETY
+        try:
+            yield
+        finally:
+            settings.modal_solver = previous
 
-        The KB reaches ``SPASSMlReasoner(path).isConsistent`` only because
-        ``settings.modal_solver == SPASS`` forces ``_get_active_reasoner`` to
-        ``_get_spass_reasoner()``, which (post-#1205) builds the real reasoner
-        with the registered binary path. Pre-#1205 this raised a swallowed
-        construction error (no-arg ctor) and degraded silently; here, reaching
-        a boolean verdict at all is the regression guard.
-
-        KB (modal logic, contradiction): ``Mortal(socrate)`` together with its
-        negation ``!Mortal(socrate)`` — a direct contradiction. Syntax may need
-        a firsthand tweak per the MlParser declaration rules (ai-01 to confirm
-        on the real binary, as for the FOL case in #1210).
-        """
-        inconsistent_kb = "Mortal(socrate)\n!Mortal(socrate)\n"
-        is_consistent, msg = modal_bridge.check_consistency(
-            inconsistent_kb, "K"
-        )
+    def test_inconsistent_kb_reports_inconsistent(self, modal_bridge, tweety_solver):
+        """An inconsistent modal KB (``Rain`` and ``!Rain``) must yield
+        ``is_consistent = False`` via a REAL query-based decision (not a parse
+        error: the message must name the solver, proving the verdict came from
+        the reasoner)."""
+        is_consistent, msg = modal_bridge.check_consistency(INCONSISTENT_KB, "K")
         assert is_consistent is False, (
             f"Inconsistent modal KB must report inconsistent; "
             f"got ({is_consistent!r}, {msg!r})."
         )
-
-    def test_consistent_kb_reports_consistent_via_spass(
-        self, modal_bridge, spass_solver
-    ):
-        """A consistent modal KB must yield ``is_consistent = True`` via the
-        REAL SPASS binary.
-
-        KB (modal logic, no contradiction): ``[](Mortal(socrate))`` —
-        "necessarily Mortal(socrate)" — a single non-contradictory modal
-        formula (Tweety modal syntax: ``[]`` = necessity operator).
-        """
-        consistent_kb = "[](Mortal(socrate))\n"
-        is_consistent, msg = modal_bridge.check_consistency(
-            consistent_kb, "K"
+        assert "tweety" in msg.lower(), (
+            f"Verdict must be traceable to the active reasoner (not a parse "
+            f"error); got msg={msg!r}."
         )
+
+    def test_consistent_kb_reports_consistent(self, modal_bridge, tweety_solver):
+        """A consistent modal KB (``[](Rain => Wet)`` ∧ ``Rain``, exercising the
+        necessity operator) must yield ``is_consistent = True`` via a REAL
+        query-based decision."""
+        is_consistent, msg = modal_bridge.check_consistency(CONSISTENT_KB, "K")
         assert is_consistent is True, (
             f"Consistent modal KB must report consistent; "
             f"got ({is_consistent!r}, {msg!r})."
         )
+        assert (
+            "tweety" in msg.lower()
+        ), f"Verdict must be traceable to the active reasoner; got msg={msg!r}."
+
+
+@pytest.mark.skipif(
+    not _spass_runnable(),
+    reason="SPASS not runnable (binary unregistered, or not a launchable CLI "
+    "build — the vendored SPASS.exe is a GUI/elevation build, err740). "
+    "Honest skip: we do not green-by-skip a SPASS verdict we cannot produce.",
+)
+class TestRealSpassConsistency:
+    """Real-binary SPASS modal consistency — runs ONLY where SPASS is a
+    launchable CLI build. Where present (a proper CLI SPASS), it must DECIDE the
+    same verdicts as the default reasoner; the construction uses the 1-arg
+    ``SPASSMlReasoner(path)`` ctor fixed in #1205."""
+
+    @pytest.fixture
+    def spass_solver(self):
+        previous = settings.modal_solver
+        settings.modal_solver = ModalSolverChoice.SPASS
+        try:
+            yield
+        finally:
+            settings.modal_solver = previous
+
+    def test_inconsistent_kb_reports_inconsistent_via_spass(
+        self, modal_bridge, spass_solver
+    ):
+        is_consistent, msg = modal_bridge.check_consistency(INCONSISTENT_KB, "K")
+        assert is_consistent is False, (
+            f"Inconsistent modal KB must report inconsistent via SPASS; "
+            f"got ({is_consistent!r}, {msg!r})."
+        )
+        assert (
+            "spass" in msg.lower()
+        ), f"Verdict must be traceable to the SPASS reasoner; got msg={msg!r}."
+
+    def test_consistent_kb_reports_consistent_via_spass(
+        self, modal_bridge, spass_solver
+    ):
+        is_consistent, msg = modal_bridge.check_consistency(CONSISTENT_KB, "K")
+        assert is_consistent is True, (
+            f"Consistent modal KB must report consistent via SPASS; "
+            f"got ({is_consistent!r}, {msg!r})."
+        )
+        assert (
+            "spass" in msg.lower()
+        ), f"Verdict must be traceable to the SPASS reasoner; got msg={msg!r}."

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
@@ -397,15 +397,21 @@ class TestModalHandlerSPASS:
             "argumentation_analysis.agents.core.logic.modal_handler.settings"
         ) as mock_settings, patch(
             "argumentation_analysis.agents.core.logic.modal_handler.jpype"
-        ) as mock_jpype:
+        ) as mock_jpype, patch(
+            "argumentation_analysis.agents.core.logic.modal_handler._get_spass_path",
+            return_value="/registered/spass.exe",
+        ):
             mock_settings.modal_solver = ModalSolverChoice.SPASS
             mock_spass = MagicMock()
-            mock_jpype.JClass.return_value = lambda: mock_spass
+            # #1205: SPASSMlReasoner is built as SPASSMlReasoner(JString(path))
+            # (1-arg ctor). JClass is called twice: for JString and for the
+            # reasoner class. Both return a factory accepting the path arg.
+            mock_jpype.JClass.return_value = lambda *args, **kwargs: mock_spass
 
             handler = ModalHandler(mock_initializer)
             reasoner = handler._get_active_reasoner()
 
-            mock_jpype.JClass.assert_called_with(
+            mock_jpype.JClass.assert_any_call(
                 "org.tweetyproject.logics.ml.reasoner.SPASSMlReasoner"
             )
 
@@ -414,22 +420,49 @@ class TestModalHandlerSPASS:
             "argumentation_analysis.agents.core.logic.modal_handler.settings"
         ) as mock_settings, patch(
             "argumentation_analysis.agents.core.logic.modal_handler.jpype"
-        ) as mock_jpype:
+        ) as mock_jpype, patch(
+            "argumentation_analysis.agents.core.logic.modal_handler._get_spass_path",
+            return_value="/registered/spass.exe",
+        ):
             mock_settings.modal_solver = ModalSolverChoice.SPASS
             mock_spass = MagicMock()
-            mock_jpype.JClass.return_value = lambda: mock_spass
+            mock_jpype.JClass.return_value = lambda *args, **kwargs: mock_spass
 
             handler = ModalHandler(mock_initializer)
             r1 = handler._get_spass_reasoner()
             r2 = handler._get_spass_reasoner()
             assert r1 is r2  # Same instance
 
-    def test_spass_unavailable_raises(self, mock_initializer):
+    def test_spass_unavailable_raises_when_binary_absent(self, mock_initializer):
+        """#1205: when no SPASS binary is registered, _get_spass_reasoner must
+        raise RuntimeError fail-loud (anti-theater #1019) — NOT silently fall
+        back to SimpleMlReasoner. The previous code swallowed the no-arg ctor
+        error into a generic RuntimeError; now the fail-loud path is explicit
+        on the missing binary path."""
+        with patch(
+            "argumentation_analysis.agents.core.logic.modal_handler.settings"
+        ) as mock_settings, patch(
+            "argumentation_analysis.agents.core.logic.modal_handler._get_spass_path",
+            return_value=None,
+        ):
+            mock_settings.modal_solver = ModalSolverChoice.SPASS
+
+            handler = ModalHandler(mock_initializer)
+            with pytest.raises(RuntimeError, match="SPASS binary not detected"):
+                handler._get_active_reasoner()
+
+    def test_spass_construction_error_raises(self, mock_initializer):
+        """#1205: if the binary is registered but SPASSMlReasoner construction
+        fails (e.g. the binary is present but broken), the error must still
+        surface as RuntimeError — never a silent fallback."""
         with patch(
             "argumentation_analysis.agents.core.logic.modal_handler.settings"
         ) as mock_settings, patch(
             "argumentation_analysis.agents.core.logic.modal_handler.jpype"
-        ) as mock_jpype:
+        ) as mock_jpype, patch(
+            "argumentation_analysis.agents.core.logic.modal_handler._get_spass_path",
+            return_value="/registered/spass.exe",
+        ):
             mock_settings.modal_solver = ModalSolverChoice.SPASS
             mock_jpype.JClass.side_effect = Exception("Class not found")
 
@@ -442,7 +475,10 @@ class TestModalHandlerSPASS:
             "argumentation_analysis.agents.core.logic.modal_handler.settings"
         ) as mock_settings, patch(
             "argumentation_analysis.agents.core.logic.modal_handler.jpype"
-        ) as mock_jpype:
+        ) as mock_jpype, patch(
+            "argumentation_analysis.agents.core.logic.modal_handler._get_spass_path",
+            return_value="/registered/spass.exe",
+        ):
             mock_settings.modal_solver = ModalSolverChoice.SPASS
 
             # Setup SPASS reasoner mock
@@ -477,7 +513,10 @@ class TestModalHandlerSPASS:
             "argumentation_analysis.agents.core.logic.modal_handler.settings"
         ) as mock_settings, patch(
             "argumentation_analysis.agents.core.logic.modal_handler.jpype"
-        ) as mock_jpype:
+        ) as mock_jpype, patch(
+            "argumentation_analysis.agents.core.logic.modal_handler._get_spass_path",
+            return_value="/registered/spass.exe",
+        ):
             mock_settings.modal_solver = ModalSolverChoice.SPASS
 
             mock_spass_instance = MagicMock()

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
@@ -282,7 +282,10 @@ class TestEProverWiringContract:
 
         def fake_jclass(name):
             if name.endswith("EFOLReasoner"):
-                return lambda path: mock_reasoner.__setattr__("_path", path) or mock_reasoner
+                return (
+                    lambda path: mock_reasoner.__setattr__("_path", path)
+                    or mock_reasoner
+                )
             if name == "java.lang.String":
                 return lambda s: s
             return MagicMock()
@@ -519,8 +522,11 @@ class TestModalHandlerSPASS:
         ):
             mock_settings.modal_solver = ModalSolverChoice.SPASS
 
+            # #1205: modal reasoners expose query(), NOT isConsistent. The
+            # handler now decides consistency via query(beliefSet, atom&&!atom):
+            # query == False (contradiction NOT entailed) => consistent.
             mock_spass_instance = MagicMock()
-            mock_spass_instance.isConsistent.return_value = True
+            mock_spass_instance.query.return_value = False
             mock_spass_cls = MagicMock(return_value=mock_spass_instance)
 
             def jclass_side_effect(class_name):
@@ -531,14 +537,28 @@ class TestModalHandlerSPASS:
                 return MagicMock()
 
             mock_jpype.JClass.side_effect = jclass_side_effect
+            # is_modal_kb_consistent catches jpype.JException; give the patched
+            # jpype module a real exception class so the except clause is valid.
+            mock_jpype.JException = Exception
+
+            # Signature with one 0-ary predicate so _build_contradiction_probe
+            # builds a ground contradiction probe.
+            mock_pred = MagicMock()
+            mock_pred.getName.return_value = "Rain"
+            mock_pred.getArity.return_value = 0
+            mock_belief_set = MagicMock()
+            mock_belief_set.getSignature.return_value.getPredicates.return_value = [
+                mock_pred
+            ]
 
             mock_parser = mock_initializer.get_modal_parser()
-            mock_parser.parseBeliefBase.return_value = MagicMock()
+            mock_parser.parseBeliefBase.return_value = mock_belief_set
 
             handler = ModalHandler(mock_initializer)
-            is_consistent, msg = handler.is_modal_kb_consistent("p || []q")
+            is_consistent, msg = handler.is_modal_kb_consistent("Rain")
 
             assert is_consistent is True
+            mock_spass_instance.query.assert_called_once()
             assert "consistent" in msg.lower()
 
 


### PR DESCRIPTION
## Summary

Implements the **R458 dispatch** from ai-01 on **#1205** (FP-9, L2): fix the SPASS modal reasoner no-arg constructor bug (sibling of the EProver regression #1202) + add a real non-mocked integration test.

The SPASS modal reasoner had the **exact same bug** EProver had pre-#1202: `_get_spass_reasoner` called `SPASSMlReasoner()` with no argument, but Tweety 1.28+/1.29 only exposes `SPASSMlReasoner(String)` / `SPASSMlReasoner(String, Shell)` (**verified via `javap`** on the bundled jar, both 1.28 and 1.29). The construction error was swallowed by a bare `except` → SPASS was never wired, yet the pipeline reported it as the configured modal solver (formal theater, modal side of the #1196/#1202 regression class).

## Fix (mirror of the EProver consumer in `fol_handler.py`)

- New `_get_spass_path()` module-level helper reads `EXTERNAL_TOOL_PATHS['spass']` (mirrors `_get_eprover_path`).
- `_get_spass_reasoner` reads the registered path and builds `SPASSMlReasoner(JString(path))` (1-arg ctor).
- **Fail-loud** `RuntimeError` if the path is unset (anti-theater #1019): a missing SPASS binary surfaces as an honest "cannot decide", NOT a silent fallback to `SimpleMlReasoner`.

## Real test (`test_spass_real.py`, new)

Skip-if-binary-absent, modeled on #1210's real-EProver test. Runs the REAL SPASS binary through the production path (`TweetyBridge.check_consistency(bs, "K")` → `ModalHandler.is_modal_kb_consistent` → `SPASSMlReasoner(path).isConsistent`). **Skips cleanly on po-2023** (no binary); ai-01 (binary present) runs it firsthand before merge. Anti-théâtre: EXECUTES the binary where present, NOT "green by skipping everywhere".

## Unit tests adapted

The 5 existing SPASS tests in `test_eprover_spass_integration.py` mocked the no-arg ctor; now mock `_get_spass_path` + the 1-arg ctor. Added 2 fail-loud contract tests: (a) binary absent → `RuntimeError("SPASS binary not detected")`; (b) construction error → `RuntimeError`, no silent fallback.

## Verification

- **7/7 `TestModalHandlerSPASS` pass** (5 adapted + 2 new fail-loud contracts).
- `test_spass_real.py` skips cleanly on po-2023: `2 skipped`, reason `"SPASS binary not registered (EXTERNAL_TOOL_PATHS['spass'] unset)"` — right cause (no binary), not an import error.
- **0 regression**: the only 2 failures (`test_settings_default_values`, `test_fol_query_dispatches_to_eprover`) are pre-existing — confirmed identical on clean main via `git stash`.
- **mypy**: 0 new errors on `modal_handler.py` (8 pre-existing, file not in CI-gated modules).

## DoD (#1205 R458)

- [x] `_get_spass_reasoner` passes the path to `SPASSMlReasoner(path)`, fail-loud if unset.
- [x] No silent fallback to `SimpleMlReasoner` (SPASS unavailable → honest `RuntimeError`/`None`, no fabricated verdict).
- [x] Real test added, modeled on #1210, skips cleanly on po-2023.
- [ ] **ai-01 runs it firsthand on the SPASS binary** (`ext_tools/spass/SPASS.exe`, present there) before merge — the modal KB syntax may need a firsthand tweak per MlParser declaration rules (as the FOL syntax did in #1210).

## File-disjoint

3 files only: `modal_handler.py` (fix) + `test_eprover_spass_integration.py` (adapted unit tests) + `test_spass_real.py` (new real test). No overlap with #1211 (FP-10 PL persistence, po-2025's lane).

Privacy HARD: synthetic atoms only (`Mortal(socrate)`-style), 0 corpus.

🤖 Worker po-2023