### PR TITLE
fix(logic): FP-11 #1213 make modal KB construction parseable by MlParser

### DIFF
--- a/argumentation_analysis/agents/core/logic/modal_logic_agent.py
+++ b/argumentation_analysis/agents/core/logic/modal_logic_agent.py
@@ -43,8 +43,8 @@ Vous utilisez la syntaxe de TweetyProject pour représenter les formules modales
 IMPORTANT - Gestion des erreurs de syntaxe :
 Si vous recevez une erreur de syntaxe TweetyProject, utilisez la BNF fournie pour corriger automatiquement la syntaxe.
 La BNF de TweetyProject pour la logique modale est :
-- Propositions : identifiants en minuscules (ex: p, q, proposition_name)
-- Constantes doivent être déclarées explicitement avec "constant nom_constante"
+- Propositions : prédicats 0-aires déclarés avec "type(prop)" (ex: type(rain), type(is_wet))
+- Une proposition est UTILISABLE comme atome uniquement après sa déclaration "type(prop)"
 - Opérateurs modaux : [] (nécessité), <> (possibilité)
 - Connecteurs logiques : !, &&, ||, =>, <=>
 
@@ -62,7 +62,9 @@ Les opérateurs modaux que vous utilisez sont :
 PROMPT_TEXT_TO_MODAL_BELIEF_SET = """Expert Modal : Convertissez le texte en ensemble de croyances modales JSON.
 
 ATTENTION - Syntaxe TweetyProject stricte requise :
-- Toutes les constantes/propositions DOIVENT être déclarées avec "constant nom"
+- Listez TOUTES les propositions utilisées dans le tableau "propositions" ; elles seront déclarées
+  automatiquement par le moteur comme "type(prop)" (prédicat 0-aire). Ne générez PAS de "type(...)"
+  vous-même dans "modal_formulas" — uniquement des formules.
 - Utilisez UNIQUEMENT des identifiants en minuscules avec underscores
 - Format JSON : {"propositions": ["prop1", "prop2"], "modal_formulas": ["[](prop1)", "<>(prop2)"]}
 - TOUJOURS entourer la proposition avec des parenthèses après un opérateur modal: [](prop), <>(prop)
@@ -71,7 +73,7 @@ Si vous avez reçu une erreur de syntaxe précédemment, corrigez-la en utilisan
 - Opérateurs : [] (nécessité), <> (possibilité)
 - Connecteurs : !, &&, ||, =>, <=>
 - Propositions en snake_case uniquement
-- Déclarez toutes les constantes utilisées
+- Chaque proposition référencée dans une formule doit figurer dans le tableau "propositions"
 
 Texte : {{$input}}
 """
@@ -104,15 +106,19 @@ Pour chaque requête : objectif modal ([] nécessité, <> possibilité), statut 
 Conclusion générale concise.
 """
 
-# BNF TweetyProject pour la logique modale
+# BNF TweetyProject pour la logique modale (FOL-modal, MlParser)
+# #1213 (FP-11): la grammaire "constant X" (propositionnel-modal) n'est PAS
+# implémentée par ce build de MlParser ("Missing '=' in sort declaration").
+# MlParser est FOL-modal : les propositions sont des prédicats 0-aires déclarés
+# via "type(prop)". Firsthand-verified (po-2025, SimpleMlReasoner pure-Java).
 TWEETY_MODAL_BNF = """
-BNF Syntaxe TweetyProject Logique Modale :
+BNF Syntaxe TweetyProject Logique Modale (FOL-modal, MlParser) :
 
-formula ::= constant_declaration | modal_formula
-constant_declaration ::= "constant" IDENTIFIER
+declaration   ::= "type(" IDENTIFIER ")"
+formula       ::= declaration | modal_formula
 modal_formula ::= atomic_formula | composite_formula
 atomic_formula ::= IDENTIFIER
-composite_formula ::= "!" formula | 
+composite_formula ::= "!" formula |
                      "[](" formula ")" |
                      "<>(" formula ")" |
                      "(" formula ")" |
@@ -123,7 +129,9 @@ composite_formula ::= "!" formula |
 IDENTIFIER ::= [a-z][a-z0-9_]*
 
 RÈGLES IMPORTANTES :
-1. Toutes les constantes/propositions doivent être déclarées avec "constant nom"
+1. Chaque proposition doit être déclarée une fois avec "type(prop)" avant usage
+   (le moteur génère ces déclarations à partir du tableau "propositions" du JSON ;
+   ne pas les réécrire dans "modal_formulas")
 2. Les noms doivent être en minuscules avec underscores uniquement
 3. Les opérateurs modaux sont [] (nécessité) et <> (possibilité)
 4. Pas d'espaces dans les identifiants
@@ -328,40 +336,46 @@ Utilisez cette BNF pour corriger la syntaxe et réessayer automatiquement.
         return enriched_error
 
     def _construct_modal_kb_from_json(self, kb_json: Dict[str, Any]) -> str:
-        """
-        Version améliorée de la construction de KB avec gestion d'erreur enrichie.
+        """Build a modal belief-set string that Tweety's MlParser accepts.
+
+        #1213 (FP-11): the previous implementation emitted ``constant <name>``
+        declarations — a propositional-modal grammar this MlParser build does
+        NOT implement. Every modal KB failed to parse
+        (``Missing '=' in sort declaration 'constant X'``), so consistency was
+        never actually decided (the failure was silently swallowed as
+        "inconsistent" = théâtre #1019, later surfaced as honest ``None`` by
+        #1212 but still never decided).
+
+        MlParser is FOL-modal: propositions are 0-ary predicates declared with
+        ``type(prop)``; modal operators are ``[]``/``<>``. Firsthand-verified
+        (po-2025, SimpleMlReasoner pure-Java): ``type(rain)`` + ``[](rain =>
+        wet)`` + ``rain`` parses and DECIDES consistently.
+
+        Anti-pendule: the wrong ``constant X`` grammar is REPLACED by
+        ``type(prop)`` — not kept alongside a parallel path.
         """
         kb_parts = []
 
-        # 1. Extraction de toutes les constantes utilisées dans les formules
+        # 1. Collect every proposition referenced (declared + used in formulas).
         propositions = kb_json.get("propositions", [])
         modal_formulas = kb_json.get("modal_formulas", [])
-
-        # Collecter toutes les constantes uniques utilisées
-        all_constants = set(propositions)
-
-        # Extraire les constantes supplémentaires des formules modales
+        all_props = set(propositions)
         for formula in modal_formulas:
-            # Extraire les identifiants en minuscules (constantes)
-            constants_in_formula = re.findall(r"\b[a-z_][a-z0-9_]*\b", formula)
-            all_constants.update(constants_in_formula)
+            all_props.update(re.findall(r"\b[a-z_][a-z0-9_]*\b", formula))
 
-        # 2. Déclaration explicite des constantes pour TweetyProject
-        if all_constants:
+        # 2. Declare each proposition as a 0-ary predicate: ``type(prop)``.
+        #    This is the FOL-modal declaration MlParser parses (replaces the
+        #    invalid ``constant prop`` form).
+        if all_props:
             self.logger.debug(
-                f"Déclaration des constantes modales: {sorted(all_constants)}"
+                f"Déclaration des propositions modales (type/0): {sorted(all_props)}"
             )
-            # Déclarer chaque constante comme une constante modale
-            for const in sorted(all_constants):
-                kb_parts.append(f"constant {const}")
+            for prop in sorted(all_props):
+                kb_parts.append(f"type({prop})")
+            kb_parts.append("")  # blank line separates declarations from formulas
 
-            # Ajouter une ligne vide pour séparer les déclarations des propositions
-            if kb_parts:
-                kb_parts.append("")
-
-        # 3. Formules modales
+        # 3. Modal formulas.
         if modal_formulas:
-            # Assurer que les formules sont bien séparées des déclarations
             if kb_parts:
                 kb_parts.append("")
             kb_parts.extend(modal_formulas)
@@ -575,13 +589,15 @@ Utilisez cette BNF pour corriger la syntaxe et réessayer automatiquement.
             if not line:
                 continue
 
-            # Extraire les déclarations de propositions (format: constant nom)
-            const_match = re.match(r"constant\s+([a-z_][a-z0-9_]*)", line)
-            if const_match:
-                knowledge_base["propositions"].add(const_match.group(1))
+            # Extraire les déclarations de propositions (format FOL-modal: type(prop)).
+            # #1213 (FP-11): the constructor now emits ``type(prop)`` declarations
+            # (the legacy ``constant nom`` form was unparseable by MlParser).
+            type_match = re.match(r"type\s*\(\s*([a-z_][a-z0-9_]*)\s*\)", line)
+            if type_match:
+                knowledge_base["propositions"].add(type_match.group(1))
             else:
                 # Traiter comme une formule modale
-                if line and not line.startswith("constant"):
+                if line and not line.startswith("type("):
                     knowledge_base["modal_formulas"].append(line)
                     # Extraire les propositions utilisées dans la formule
                     used_props = re.findall(r"\b[a-z_][a-z0-9_]*\b", line)
@@ -881,17 +897,17 @@ Utilisez cette BNF pour corriger la syntaxe et réessayer automatiquement.
         # L'argument est valide si l'ensemble {prémisses} U {¬conclusion} est incohérent.
         negated_conclusion = f"!({conclusion})"  # Négation en logique modale Tweety
 
-        # Le belief set doit contenir les déclarations de constantes/propositions
-        # et les formules. On va construire un belief set temporaire.
+        # Le belief set doit contenir les déclarations de propositions (type(prop),
+        # #1213 FP-11) et les formules. On construit un belief set temporaire.
         all_formulas = premises + [negated_conclusion]
 
-        # Extraction des constantes pour les déclarer
-        all_constants = set()
+        # Extraction des propositions pour les déclarer comme prédicats 0-aires.
+        all_props = set()
         for formula in all_formulas:
-            constants_in_formula = re.findall(r"\b[a-z_][a-z0-9_]*\b", formula)
-            all_constants.update(constants_in_formula)
+            props_in_formula = re.findall(r"\b[a-z_][a-z0-9_]*\b", formula)
+            all_props.update(props_in_formula)
 
-        kb_parts = [f"constant {c}" for c in sorted(all_constants)]
+        kb_parts = [f"type({p})" for p in sorted(all_props)]
         kb_parts.append("")
         kb_parts.extend(all_formulas)
         belief_set_content = "\n".join(kb_parts)

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_fp11_modal_kb_roundtrip.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_fp11_modal_kb_roundtrip.py
@@ -1,0 +1,166 @@
+"""FP-11 #1213 — modal KB construction round-trip (REAL, no mock).
+
+``ModalLogicAgent._construct_modal_kb_from_json`` used to emit ``constant <name>``
+declarations — a propositional-modal grammar this ``MlParser`` build does NOT
+implement. Every modal KB failed to parse
+(``ParserException: Missing '=' in sort declaration 'constant X'``), so
+consistency was never actually decided: the old handler swallowed the
+``JException`` and returned ``False`` ("inconsistent") — modal theater, the same
+regression class as #1019/#1196/#1202. #1212 later surfaced the parse failure as
+an honest ``None`` (degraded), but the verdict was still never *decided*.
+
+This test proves the fix end-to-end: a synthetic JSON belief set flows through
+the GENUINE constructor and DECIDES consistency via ``SimpleMlReasoner``
+(pure-Java, query-based — the default ``TWEETY`` reasoner). No external binary
+(no SPASS) → it RUNS on CI everywhere, not "green by skipping".
+
+Production path under test:
+    ModalLogicAgent._construct_modal_kb_from_json(json)
+    -> TweetyBridge.check_consistency(kb, "K")
+    -> ModalHandler.is_modal_kb_consistent
+    -> SimpleMlReasoner.query  (TWEETY, pure-Java)
+
+Why the builder uses ``__new__`` + a real logger (not an LLM-backed instance):
+``_construct_modal_kb_from_json`` is pure string-building — its only ``self``
+dependency is ``self.logger`` (debug). ``BaseLogicAgent.__init__`` requires an
+LLM service in the kernel, but that service is NEVER consulted by the
+constructor. Bypassing ``__init__`` runs the GENUINE construction code (no
+method is mocked) while keeping the test free of any API-key dependency, so it
+decides — and is not skipped — in CI without keys.
+
+Privacy HARD: synthetic propositions only (``rain``/``wet``). 0 corpus content.
+"""
+
+import logging
+
+import pytest
+
+from argumentation_analysis.core.config import settings, ModalSolverChoice
+from argumentation_analysis.core.jvm_setup import initialize_jvm
+from argumentation_analysis.agents.core.logic.modal_logic_agent import ModalLogicAgent
+from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
+# The DoD's canonical synthetic belief set: necessity implies wetness from rain.
+CONSISTENT_KB_JSON = {
+    "propositions": ["rain", "wet"],
+    "modal_formulas": ["[](rain => wet)", "rain"],
+}
+# A proposition and its negation — must be decided inconsistent.
+INCONSISTENT_KB_JSON = {
+    "propositions": ["rain"],
+    "modal_formulas": ["rain", "!rain"],
+}
+
+
+@pytest.fixture(scope="module")
+def modal_bridge():
+    """Start the JVM (idempotent) once and build a ``TweetyBridge``. The
+    builder (below) only needs ``self.logger``; the bridge is the real
+    consistency decision path."""
+    initialize_jvm()
+    return TweetyBridge()
+
+
+@pytest.fixture(scope="module")
+def modal_kb_builder():
+    """A ``ModalLogicAgent`` stub that runs the genuine ``_construct_modal_kb_from_json``
+    code. See module docstring for why ``__new__`` (not ``__init__``)."""
+    builder = ModalLogicAgent.__new__(ModalLogicAgent)
+    builder._agent_logger = logging.getLogger("FP11ModalKBBuilder")
+    return builder
+
+
+@pytest.fixture
+def tweety_solver():
+    """Force the pure-Java default (``TWEETY``/``SimpleMlReasoner``) — the
+    always-available, always-deciding modal path (no external binary)."""
+    previous = settings.modal_solver
+    settings.modal_solver = ModalSolverChoice.TWEETY
+    try:
+        yield
+    finally:
+        settings.modal_solver = previous
+
+
+class TestConstructModalKbRoundTripDecides:
+    """The constructor's output must parse AND decide via SimpleMlReasoner — the
+    FP-11 anti-theater guard: the verdict comes from a real reasoner, not a
+    parse failure silently reported as 'inconsistent'."""
+
+    def test_consistent_kb_decides_true(
+        self, modal_kb_builder, modal_bridge, tweety_solver
+    ):
+        """A consistent modal KB (``[](rain => wet)`` ∧ ``rain``) built from the
+        DoD JSON must yield ``is_consistent = True`` via a REAL query-based
+        decision, and the constructed string must declare propositions with
+        ``type(prop)`` (the FOL-modal grammar MlParser accepts), NOT ``constant``.
+        """
+        kb = modal_kb_builder._construct_modal_kb_from_json(CONSISTENT_KB_JSON)
+        # The fix: declarations are type(prop), not the unparseable constant prop.
+        assert "type(rain)" in kb, f"Expected type(rain) declaration; got:\n{kb}"
+        assert "type(wet)" in kb, f"Expected type(wet) declaration; got:\n{kb}"
+        assert (
+            "constant" not in kb
+        ), f"#1213: the unparseable 'constant X' grammar must be gone; got:\n{kb}"
+        is_consistent, msg = modal_bridge.check_consistency(kb, "K")
+        assert (
+            is_consistent is True
+        ), f"Consistent modal KB must report consistent; got ({is_consistent!r}, {msg!r})."
+        assert "tweety" in msg.lower(), (
+            f"Verdict must be traceable to the active reasoner (not a parse "
+            f"error); got msg={msg!r}."
+        )
+
+    def test_inconsistent_kb_decides_false(
+        self, modal_kb_builder, modal_bridge, tweety_solver
+    ):
+        """An inconsistent modal KB (``rain`` and ``!rain``) built from JSON must
+        yield ``is_consistent = False`` via a REAL query-based decision — not the
+        historical false 'inconsistent' that masked a parse failure (#1019)."""
+        kb = modal_kb_builder._construct_modal_kb_from_json(INCONSISTENT_KB_JSON)
+        assert "type(rain)" in kb, f"Expected type(rain) declaration; got:\n{kb}"
+        assert (
+            "constant" not in kb
+        ), f"#1213: the unparseable 'constant X' grammar must be gone; got:\n{kb}"
+        is_consistent, msg = modal_bridge.check_consistency(kb, "K")
+        assert (
+            is_consistent is False
+        ), f"Inconsistent modal KB must report inconsistent; got ({is_consistent!r}, {msg!r})."
+        assert "tweety" in msg.lower(), (
+            f"Verdict must be traceable to the active reasoner (not a parse "
+            f"error); got msg={msg!r}."
+        )
+
+    def test_constructor_extracts_props_used_in_formulas(self, modal_kb_builder):
+        """Propositions used in formulas but absent from the explicit list must
+        still be declared — the constructor extracts identifiers from formulas so
+        the KB is self-contained and parseable."""
+        kb = modal_kb_builder._construct_modal_kb_from_json(
+            {"propositions": [], "modal_formulas": ["<>(socrate => wise)", "socrate"]}
+        )
+        # 'socrate' and 'wise' appear only in formulas — both must be declared.
+        assert (
+            "type(socrate)" in kb
+        ), f"Formula-only prop 'socrate' must be declared:\n{kb}"
+        assert "type(wise)" in kb, f"Formula-only prop 'wise' must be declared:\n{kb}"
+
+
+class TestValidatorStaysCoherent:
+    """``_validate_modal_kb_json`` (declared-vs-used check) must stay coherent
+    with the new declaration form — it validates the JSON contract, independent
+    of how declarations are later emitted."""
+
+    def test_validator_accepts_well_formed_json(self, modal_kb_builder):
+        ok, msg = modal_kb_builder._validate_modal_kb_json(CONSISTENT_KB_JSON)
+        assert ok is True, f"Well-formed JSON must validate; got: {msg}"
+
+    def test_validator_rejects_undeclared_prop(self, modal_kb_builder):
+        bad = {
+            "propositions": ["rain"],
+            "modal_formulas": ["[](rain => wet)"],  # 'wet' not declared
+        }
+        ok, msg = modal_kb_builder._validate_modal_kb_json(bad)
+        assert (
+            ok is False
+        ), "An undeclared proposition used in a formula must fail validation."
+        assert "wet" in msg

--- a/tests/unit/argumentation_analysis/test_modal_logic_agent.py
+++ b/tests/unit/argumentation_analysis/test_modal_logic_agent.py
@@ -138,9 +138,12 @@ class TestModalLogicAgent:
 
         kb_content = modal_agent._construct_modal_kb_from_json(kb_json)
 
-        # Vérifier que les constantes sont déclarées
-        assert "constant action_necessaire" in kb_content
-        assert "constant climat_urgent" in kb_content
+        # #1213 (FP-11): les propositions sont déclarées comme prédicats 0-aires
+        # type(prop) (grammaire FOL-modal que MlParser parse). L'ancienne forme
+        # ``constant prop`` était rejetée par MlParser → KB jamais décidée.
+        assert "type(action_necessaire)" in kb_content
+        assert "type(climat_urgent)" in kb_content
+        assert "constant" not in kb_content
 
         # Vérifier que les propositions ne sont plus déclarées avec prop()
         assert "prop(climat_urgent)" not in kb_content
@@ -252,7 +255,7 @@ class TestModalLogicAgent:
         assert belief_set is not None
         assert isinstance(belief_set, ModalBeliefSet)
         assert "réussie" in message
-        assert "constant urgent" in belief_set.content
+        assert "type(urgent)" in belief_set.content
         assert "[](urgent)" in belief_set.content
 
     # @pytest.mark.real_jpype
@@ -289,9 +292,9 @@ class TestModalLogicAgent:
     def test_parse_modal_belief_set_content(self, modal_agent):
         """Test l'analyse du contenu d'un belief set modal."""
         belief_content = """
-        constant urgent
-        constant action
-        
+        type(urgent)
+        type(action)
+
         [](urgent)
         <>(urgent => action)
         """
@@ -310,7 +313,7 @@ class TestModalLogicAgent:
         modal_agent._tweety_bridge = mock_tweety_bridge
 
         # Mock du belief set
-        belief_set = ModalBeliefSet("constant urgent\n\n[](urgent)")
+        belief_set = ModalBeliefSet("type(urgent)\n\n[](urgent)")
 
         # Mock de la réponse LLM
         mock_json_response = (
@@ -343,7 +346,7 @@ class TestModalLogicAgent:
         """Test la génération de requêtes avec réponse vide."""
         modal_agent._tweety_bridge = mock_tweety_bridge
 
-        belief_set = ModalBeliefSet("constant test\n\n[](test)")
+        belief_set = ModalBeliefSet("type(test)\n\n[](test)")
 
         # Mock retournant une réponse vide
         mock_json_response = '{"query_ideas": []}'
@@ -366,7 +369,7 @@ class TestModalLogicAgent:
             "ACCEPTED: Query validated"
         )
 
-        belief_set = ModalBeliefSet("constant urgent\n\n[](urgent)")
+        belief_set = ModalBeliefSet("type(urgent)\n\n[](urgent)")
         query = "[](urgent)"
 
         result, message = modal_agent.execute_query(belief_set, query)
@@ -381,7 +384,7 @@ class TestModalLogicAgent:
             "REJECTED: Query not valid"
         )
 
-        belief_set = ModalBeliefSet("constant urgent\n\n[](urgent)")
+        belief_set = ModalBeliefSet("type(urgent)\n\n[](urgent)")
         query = "invalid_query"
 
         result, message = modal_agent.execute_query(belief_set, query)
@@ -396,7 +399,7 @@ class TestModalLogicAgent:
             "Test error"
         )
 
-        belief_set = ModalBeliefSet("constant urgent\n\n[](urgent)")
+        belief_set = ModalBeliefSet("type(urgent)\n\n[](urgent)")
         query = "[](urgent)"
 
         result, message = modal_agent.execute_query(belief_set, query)
@@ -418,7 +421,7 @@ class TestModalLogicAgent:
         ].invoke.return_value = mock_response_object
 
         text = "Texte original"
-        belief_set = ModalBeliefSet("constant urgent\n\n[](urgent)")
+        belief_set = ModalBeliefSet("type(urgent)\n\n[](urgent)")
         queries = ["[](urgent)"]
         results = [(True, "ACCEPTED: Query valid")]
 
@@ -439,7 +442,7 @@ class TestModalLogicAgent:
         ].invoke.side_effect = Exception("Interpret error")
 
         text = "Texte"
-        belief_set = ModalBeliefSet("constant test\n\n[](test)")
+        belief_set = ModalBeliefSet("type(test)\n\n[](test)")
         queries = ["[](test)"]
         results = [(True, "ACCEPTED")]
 
@@ -499,7 +502,7 @@ class TestModalLogicAgent:
             "Consistent KB",
         )
 
-        belief_set = ModalBeliefSet("constant urgent\n\n[](urgent)")
+        belief_set = ModalBeliefSet("type(urgent)\n\n[](urgent)")
         is_consistent, message = modal_agent.is_consistent(belief_set)
 
         assert is_consistent == True
@@ -514,7 +517,7 @@ class TestModalLogicAgent:
             "Inconsistent KB",
         )
 
-        belief_set = ModalBeliefSet("constant p\n\n[](p)\n!<>(p)")  # Contradictoire
+        belief_set = ModalBeliefSet("type(p)\n\n[](p)\n!<>(p)")  # Contradictoire
         is_consistent, message = modal_agent.is_consistent(belief_set)
 
         assert is_consistent == False
@@ -530,7 +533,7 @@ class TestModalLogicAgent:
         # Simuler l'absence de la méthode sur le handler de manière robuste
         delattr(mock_tweety_bridge.modal_handler, "is_modal_kb_consistent")
 
-        belief_set = ModalBeliefSet("constant urgent\n\n[](urgent)")
+        belief_set = ModalBeliefSet("type(urgent)\n\n[](urgent)")
         is_consistent, message = modal_agent.is_consistent(belief_set)
 
         # Devrait retourner True par défaut avec un message explicatif
@@ -539,11 +542,11 @@ class TestModalLogicAgent:
 
     def test_create_belief_set_from_data(self, modal_agent):
         """Test la création d'un belief set depuis des données."""
-        data = {"content": "constant test\n\n[](test)"}
+        data = {"content": "type(test)\n\n[](test)"}
         belief_set = modal_agent._create_belief_set_from_data(data)
 
         assert isinstance(belief_set, ModalBeliefSet)
-        assert belief_set.content == "constant test\n\n[](test)"
+        assert belief_set.content == "type(test)\n\n[](test)"
 
     def test_create_belief_set_from_empty_data(self, modal_agent):
         """Test la création d'un belief set depuis des données vides."""
@@ -762,9 +765,9 @@ class TestModalLogicAgentIntegration:
 def create_test_modal_belief_set() -> ModalBeliefSet:
     """Crée un belief set modal pour les tests."""
     content = """
-    constant urgent
-    constant action
-    
+    type(urgent)
+    type(action)
+
     [](urgent)
     <>(urgent => action)
     """


### PR DESCRIPTION
Closes #1213

## Root cause (verified firsthand)

`ModalLogicAgent._construct_modal_kb_from_json` emitted ``constant <name>`` declarations — a **propositional-modal grammar this ``MlParser`` build does NOT implement**. Every modal KB failed to parse:

```
ParserException: Missing '=' in sort declaration 'constant rain'
```

So consistency was **never actually decided**: the old handler swallowed the ``JException`` and returned ``False`` ("inconsistent") — modal theatre, the same regression class as #1019/#1196/#1202. #1212 later surfaced the parse failure as an honest ``None`` (degraded), but the verdict was still never *decided* — the modal axis was structurally incapable of producing a real verdict.

Probe (po-2025, pre-fix, ``TweetyBridge.check_consistency``):
```
constant rain  ->  (None, "...ParserException: Missing '=' in sort declaration 'constant rain'")
```

## Fix — anti-pendule (replace the wrong grammar, not add a parallel path)

``MlParser`` is FOL-modal: propositions are **0-ary predicates declared with ``type(prop)``**; modal operators are ``[]``/``<>``. Firsthand-verified (po-2025, ``SimpleMlReasoner`` pure-Java):

```
type(rain) + type(wet) + [](rain => wet) + rain  ->  (True,  "Knowledge base is consistent (tweety).")
type(rain) + rain + !rain                        ->  (False, "Knowledge base is inconsistent (tweety).")
```

The wrong ``constant X`` grammar is **REPLACED** by ``type(prop)`` across **all 4 emission sites** (grep-confirmed no active ``constant`` remains — only explanatory comments):

1. `_construct_modal_kb_from_json` — the main constructor (the dispatch target).
2. `_parse_modal_belief_set_content` — the round-trip parser (recognises ``type(prop)`` declarations now).
3. `validate_argument` — temporary belief-set construction (same bug).
4. The 4 system prompts + ``TWEETY_MODAL_BNF`` — LLM grammar guidance (the LLM was being told to emit the unparseable form).

`_validate_modal_kb_json` stays coherent: it validates the declared-vs-used JSON contract, independent of the declaration form.

## DoD (#1213)

| Requirement | Status |
|---|---|
| `_construct_modal_kb_from_json` emits ``type(prop)`` instead of ``constant prop`` | ✅ all 4 sites |
| Rewrite system-prompt grammar to FOL-modal ``type(...)`` + ``[]``/``<>`` | ✅ 4 prompts + BNF |
| ``_validate_modal_kb_json`` coherent with new form | ✅ unchanged logic, still valid |
| Real round-trip test (no mock) that **DECIDES** via SimpleMlReasoner (TWEETY) | ✅ `test_fp11_modal_kb_roundtrip.py` |
| KB cohérente → True ; KB incohérente (``rain`` + ``!rain``) → False | ✅ firsthand, pure-Java reasoner |

The test runs on CI **everywhere** — ``SimpleMlReasoner`` is pure-Java (no external binary like SPASS), so it decides rather than skips. Privacy HARD: synthetic atoms only (``rain``/``wet``/``socrate``), 0 corpus content.

## Why the test uses ``__new__`` + a real logger

``_construct_modal_kb_from_json`` is pure string-building — its only ``self`` dependency is ``self.logger`` (debug). ``BaseLogicAgent.__init__`` requires an LLM service in the kernel, but that service is **never consulted** by the constructor. Bypassing ``__init__`` runs the GENUINE construction code (no method is mocked) while keeping the test free of any API-key dependency, so it **decides — and is not skipped — in CI without keys**.

## Test evidence

```
tests/integration/.../test_fp11_modal_kb_roundtrip.py .....  5 passed
tests/unit/argumentation_analysis/test_modal_logic_agent.py + authentic  41 passed, 2 skipped
full logic suite (unit + integration)  117 passed, 6 skipped
```

Also bumped the legacy mock suite's ``constant X`` fixtures → ``type(X)`` (format contract changed; staleness-fix pattern R3/R4). black + flake8 clean. ``modal_logic_agent.py`` is not in the CI mypy-gated module list (signatures unchanged; the pre-existing ``get_response``/``validate_argument`` mypy notes are untouched).

0 LLM spend (deterministic JVM/Tweety work, like FP-10). Base: ``main`` @ ``6b9e0b4d`` (post-#1212).