### PR TITLE
fix(logic): FP-12 #1215 make DL/DeLP/CF2 actually decide

### DIFF
--- a/argumentation_analysis/agents/core/logic/af_handler.py
+++ b/argumentation_analysis/agents/core/logic/af_handler.py
@@ -7,7 +7,12 @@ from .tweety_initializer import TweetyInitializer
 logger = logging.getLogger(__name__)
 
 
-# Mapping from semantics name to Tweety reasoner class path
+# Mapping from semantics name to Tweety reasoner class path.
+# #1215 (FP-12): ``cf2`` removed — ``CF2Reasoner`` is NOT shipped in the vendored
+# Tweety build (introspected firsthand: the FQN raises ClassNotFoundException in
+# both 1.28 and 1.29; no SimpleCF2Reasoner / prover.* variant exists either).
+# Advertising it as supported while the class is absent was a false promise;
+# honest gate-out instead of a silent {"error": ...} dressed as a result.
 SEMANTICS_REASONERS = {
     "preferred": "org.tweetyproject.arg.dung.reasoner.SimplePreferredReasoner",
     "grounded": "org.tweetyproject.arg.dung.reasoner.SimpleGroundedReasoner",
@@ -17,7 +22,6 @@ SEMANTICS_REASONERS = {
     "conflict_free": "org.tweetyproject.arg.dung.reasoner.SimpleConflictFreeReasoner",
     "semi_stable": "org.tweetyproject.arg.dung.reasoner.SimpleSemiStableReasoner",
     "stage": "org.tweetyproject.arg.dung.reasoner.SimpleStageReasoner",
-    "cf2": "org.tweetyproject.arg.dung.reasoner.CF2Reasoner",
     "ideal": "org.tweetyproject.arg.dung.reasoner.SimpleIdealReasoner",
     "naive": "org.tweetyproject.arg.dung.reasoner.SimpleNaiveReasoner",
 }
@@ -27,7 +31,8 @@ class AFHandler:
     """
     Handles Abstract Argumentation Framework (AF) operations using TweetyProject.
     Supports multiple Dung semantics: preferred, grounded, stable, complete,
-    admissible, conflict-free, semi-stable, stage, CF2, ideal, naive.
+    admissible, conflict-free, semi-stable, stage, ideal, naive.
+    (CF2 is NOT shipped in the vendored Tweety build — see SEMANTICS_REASONERS.)
     """
 
     def __init__(self, initializer_instance: TweetyInitializer):
@@ -124,8 +129,8 @@ class AFHandler:
             arguments: A list of argument names.
             attacks: A list of attacks [source, target].
             semantics: The semantics to use. Supported: preferred, grounded, stable,
-                      complete, admissible, conflict_free, semi_stable, stage, cf2,
-                      ideal, naive.
+                      complete, admissible, conflict_free, semi_stable, stage,
+                      ideal, naive. (cf2 is NOT available in the vendored build.)
 
         Returns:
             Dict with keys: semantics, extensions, statistics.

--- a/argumentation_analysis/agents/core/logic/dl_handler.py
+++ b/argumentation_analysis/agents/core/logic/dl_handler.py
@@ -53,6 +53,8 @@ class DLHandler:
             self._RoleAssertion = jpype.JClass(f"{dl_pkg}.RoleAssertion")
             self._DlBeliefSet = jpype.JClass(f"{dl_pkg}.DlBeliefSet")
             self._DlSignature = jpype.JClass(f"{dl_pkg}.DlSignature")
+            # Bottom concept for consistency checking (bottom-entailment, #1215).
+            self._BottomConcept = jpype.JClass(f"{dl_pkg}.BottomConcept")
 
             self._DlParser = jpype.JClass("org.tweetyproject.logics.dl.parser.DlParser")
             self._NaiveDlReasoner = jpype.JClass(
@@ -156,21 +158,44 @@ class DLHandler:
 
     # ── Reasoning ────────────────────────────────────────────────────
 
-    def is_consistent(self, kb) -> Tuple[bool, str]:
-        """Check if a DL knowledge base is consistent."""
+    def is_consistent(self, kb) -> Tuple[Optional[bool], str]:
+        """Check if a DL knowledge base is consistent via bottom-entailment.
+
+        #1215 (FP-12): the previous implementation computed
+        ``reasoner.query(kb, AtomicConcept("⊤"))`` and then **ignored the
+        result**, unconditionally returning ``(True, "consistent")`` — DL
+        consistency was never actually decided (hardcoded-True theater, the same
+        #1019 regression class as the modal/DL/DeLP family). Querying ``⊤``
+        cannot distinguish consistent from inconsistent anyway (a consistent KB
+        entails ⊤ trivially, but so does an inconsistent one which entails
+        everything).
+
+        ``NaiveDlReasoner`` exposes only ``query`` (no ``isConsistent`` — same gap
+        as the modal reasoners, #1212). The deciding procedure is
+        **bottom-entailment**: a KB is consistent iff it does NOT entail ⊥. We
+        assert ``(witness: ⊥)`` and ask whether the KB entails it — an
+        inconsistent KB entails everything (incl. ⊥), a consistent one does not.
+        Firsthand-verified (po-2025): consistent KB → ``query(witness:⊥)=False``
+        → ``True``; KB with ``john:human`` ∧ ``john:¬human`` → ``True`` → ``False``.
+
+        Returns ``(None, msg)`` on a reasoner exception — fail-loud degraded
+        (#1019), never a fabricated ``False`` disguised as "inconsistent".
+        """
         reasoner = self._get_reasoner()
         try:
-            result = reasoner.query(kb, self._AtomicConcept("⊤"))
-            # NaiveDlReasoner.query returns true if kb entails the query
-            # An inconsistent KB entails everything
+            witness = self._Individual("_consistency_witness")
+            bottom_assertion = self._ConceptAssertion(witness, self._BottomConcept())
+            entails_bottom = bool(reasoner.query(kb, bottom_assertion))
+            if entails_bottom:
+                return False, "Knowledge base is inconsistent (entails ⊥)."
             return True, "Knowledge base is consistent."
         except jpype.JException as e:
             error_msg = f"DL consistency check error: {e.getMessage()}"
             logger.error(error_msg)
-            return False, error_msg
+            return None, error_msg
         except Exception as e:
             logger.error(f"Unexpected DL error: {e}")
-            return False, str(e)
+            return None, str(e)
 
     def query_concept(self, kb, individual_name: str, concept_name: str) -> bool:
         """Check if an individual is an instance of a concept."""

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3619,10 +3619,28 @@ async def _invoke_eaf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
 
 
 async def _invoke_delp(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
-    """Invoke DeLP handler (#89) with JVM fallback."""
-    program_text = context.get("program", input_text[:500])
+    """Invoke DeLP handler (#89) with JVM fallback.
+
+    #1215 (FP-12): requires an explicit ``program`` in context. Never feeds raw
+    text to ``DelpParser`` — DeLP syntax (facts / strict rules / defeasible
+    rules) is not prose; the old ``input_text[:500]`` default guaranteed a parse
+    failure AND leaked corpus text into the parser (correctness + privacy).
+    Honest-absent when no program is supplied, not a fake parse.
+    """
+    program_text = context.get("program")
     queries = context.get("queries", [])
     criterion = context.get("criterion", "generalized_specificity")
+
+    if not program_text:
+        return {
+            "status": "unavailable",
+            "message": (
+                "DeLP analysis requires an explicit 'program' in context "
+                "(DeLP syntax: 'fact.', 'head <- body.' strict, "
+                "'head -< body.' defeasible). Raw text is not a valid program."
+            ),
+            "queries": queries,
+        }
 
     try:
         from argumentation_analysis.agents.core.logic.delp_handler import DeLPHandler
@@ -5111,9 +5129,7 @@ async def _invoke_propositional_logic(
         pl_metrics["post_tweety"] = len(formulas)
         # Fallback model only when PySAT returned no structured witness (e.g.
         # Tweety-fallback path or UNSAT). Empty dict is honest for UNSAT.
-        persisted_model = (
-            sat_model if isinstance(sat_model, dict) else {}
-        )
+        persisted_model = sat_model if isinstance(sat_model, dict) else {}
         return {
             "formulas": formulas,
             "satisfiable": bool(is_consistent),
@@ -5790,9 +5806,9 @@ async def _invoke_dung_extensions(
     """Invoke Dung framework extension computation via AFHandler (JVM required).
 
     Builds attack graph from extracted arguments and detected fallacies,
-    then computes all 11 Dung semantics via Tweety: grounded, preferred,
-    stable, complete, admissible, conflict_free, semi_stable, stage, cf2,
-    ideal, naive.
+    then computes all available Dung semantics via Tweety: grounded, preferred,
+    stable, complete, admissible, conflict_free, semi_stable, stage, ideal,
+    naive. (cf2 is NOT shipped in the vendored Tweety build — #1215.)
     Falls back to pure-Python computation when JVM is unavailable.
 
     #908: If ``context["dung_provider_hint"]`` is set to

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_fp12_dl_delp_cf2.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_fp12_dl_delp_cf2.py
@@ -1,0 +1,155 @@
+"""FP-12 #1215 — DL/DeLP/CF2 wiring: DECIDE or honest fail-loud (REAL, no mock).
+
+Three reasoners that *seemed* wired but never actually decided (the #1019
+theater family, sibling of the modal/DL/DeLP bugs):
+
+1. **DL ``is_consistent`` hardcoded True** — ``dl_handler`` computed
+   ``reasoner.query(kb, ⊤)`` then ignored the result and unconditionally
+   returned ``(True, "consistent")``. Worse than "degraded": a fabricated
+   verdict. ``NaiveDlReasoner`` exposes only ``query`` (no ``isConsistent``,
+   same gap as the modal reasoners #1212), so the deciding procedure is
+   **bottom-entailment**: a KB is consistent iff it does NOT entail ⊥. Assert
+   ``(witness: ⊥)`` and query — an inconsistent KB entails everything (incl. ⊥),
+   a consistent one does not. Firsthand-verified (po-2025).
+
+2. **DeLP fed raw prose to ``DelpParser``** — ``_invoke_delp`` defaulted
+   ``program_text`` to ``input_text[:500]`` when no program was in context.
+   DeLP syntax (facts / strict / defeasible rules) is not prose → guaranteed
+   parse failure AND a corpus-text leak into the parser (privacy). Fix is
+   subtraction: drop the raw-text default, fail-loud ``unavailable``.
+
+3. **CF2 announced but class absent** — ``CF2Reasoner`` is NOT shipped in the
+   vendored Tweety build (introspected firsthand: the FQN raises
+   ClassNotFoundException in both 1.28 and 1.29; no SimpleCF2Reasoner /
+   prover.* variant). Advertising cf2 as supported while the class is absent
+   was a false promise. Honest gate-out: cf2 is removed from
+   ``SEMANTICS_REASONERS`` → ``_get_reasoner("cf2")`` raises ``ValueError``
+   (not a silent empty result dressed as "decided").
+
+Privacy HARD: synthetic atoms only (``human``/``john``). 0 corpus content.
+"""
+
+import pytest
+
+from argumentation_analysis.core.jvm_setup import initialize_jvm
+
+
+@pytest.fixture(scope="module")
+def tweety_bridge():
+    """Start the JVM (idempotent) once and build a ``TweetyBridge`` whose
+    initializer has all Tweety components loaded (DLHandler/AFHandler require
+    ``is_jvm_ready()`` = JVM started AND classes loaded)."""
+    initialize_jvm()
+    from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
+    return TweetyBridge()
+
+
+class TestDLDecidesViaBottomEntailment:
+    """DL ``is_consistent`` must DECIDE via the real NaiveDlReasoner — the
+    hardcoded-True theater is gone; the verdict comes from bottom-entailment."""
+
+    def test_consistent_kb_decides_true(self, tweety_bridge):
+        from argumentation_analysis.agents.core.logic.dl_handler import DLHandler
+
+        handler = DLHandler(tweety_bridge.initializer)
+        # KB: john is human (no contradiction) -> consistent.
+        kb = handler._DlBeliefSet()
+        john = handler._Individual("john")
+        human = handler._AtomicConcept("human")
+        kb.add(handler._ConceptAssertion(john, human))
+
+        result, msg = handler.is_consistent(kb)
+        assert (
+            result is True
+        ), f"Consistent DL KB must decide True; got ({result!r}, {msg!r})."
+        assert "consistent" in msg.lower()
+
+    def test_inconsistent_kb_decides_false(self, tweety_bridge):
+        from argumentation_analysis.agents.core.logic.dl_handler import DLHandler
+
+        handler = DLHandler(tweety_bridge.initializer)
+        # KB: john is human AND john is ¬human -> john cannot be both -> inconsistent.
+        kb = handler._DlBeliefSet()
+        john = handler._Individual("john")
+        human = handler._AtomicConcept("human")
+        kb.add(handler._ConceptAssertion(john, human))
+        kb.add(handler._ConceptAssertion(john, handler._Complement(human)))
+
+        result, msg = handler.is_consistent(kb)
+        assert result is False, (
+            f"Inconsistent DL KB must decide False (previously hardcoded True); "
+            f"got ({result!r}, {msg!r})."
+        )
+        assert "inconsistent" in msg.lower()
+
+
+class TestDeLPNoRawTextFailLoud:
+    """DeLP must NOT feed raw text to DelpParser. No program -> honest
+    ``unavailable``, never a parse-failure-on-prose (correctness + privacy)."""
+
+    async def test_no_program_returns_unavailable(self):
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_delp
+
+        result = await _invoke_delp("some raw prose that is not a program", {})
+        assert (
+            result["status"] == "unavailable"
+        ), f"No program in context must fail-loud unavailable; got {result!r}."
+        assert "program" in result["message"].lower()
+
+    async def test_raw_text_never_reaches_parser(self):
+        """Privacy guard (#1215): the ``input_text[:500]`` default is gone — a
+        raw corpus-like input must NOT be forwarded to the parser; it must be
+        rejected upstream as ``unavailable``."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_delp
+
+        secret = "SECRET_CORPUS_LEAK_" + "x" * 200
+        result = await _invoke_delp(secret, {})
+        assert result["status"] == "unavailable"
+        # The raw input must not appear anywhere in the result (no leak).
+        assert "SECRET_CORPUS_LEAK" not in str(result)
+
+    async def test_explicit_program_is_forwarded(self):
+        """Sanity: when a program IS supplied, the callable proceeds past the
+        fail-loud guard (the handler may still raise on JVM issues, but the
+        raw-text default no longer interferes)."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_delp
+
+        # A minimal valid DeLP program (a strict fact). We only assert the
+        # guard did not short-circuit: result is NOT the "unavailable" dict.
+        try:
+            result = await _invoke_delp(
+                "", {"program": "bird(tweety).", "queries": ["bird(tweety)"]}
+            )
+        except RuntimeError:
+            # JVM unavailable in this env is acceptable — the point is the
+            # guard did not fire (which would return a dict, not raise).
+            return
+        assert result.get("status") != "unavailable" or "program" not in str(
+            result.get("message", "")
+        ), "An explicit program must not trigger the no-program fail-loud."
+
+
+class TestCF2HonestGateOut:
+    """CF2 is not shipped in the vendored Tweety build. The fix is honest
+    gate-out (removed from SEMANTICS_REASONERS), not a silent empty result."""
+
+    def test_cf2_not_advertised_as_supported(self):
+        from argumentation_analysis.agents.core.logic.af_handler import (
+            AFHandler,
+            SEMANTICS_REASONERS,
+        )
+
+        assert "cf2" not in SEMANTICS_REASONERS
+        assert "cf2" not in AFHandler.supported_semantics()
+        # The other 10 are still there.
+        assert len(SEMANTICS_REASONERS) == 10
+
+    def test_cf2_request_raises_valueerror(self, tweety_bridge):
+        """Asking for cf2 must fail loudly (ValueError), not silently produce
+        an empty result dressed as 'decided'."""
+        from argumentation_analysis.agents.core.logic.af_handler import AFHandler
+
+        handler = AFHandler(tweety_bridge.initializer)
+        with pytest.raises(ValueError, match="Unsupported semantics"):
+            handler._get_reasoner("cf2")

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_af_handler_extended.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_af_handler_extended.py
@@ -1,8 +1,9 @@
 """Tests for extended Dung semantics in AFHandler.
 
 Validates:
-- All 11 supported semantics (preferred, grounded, stable, complete, admissible,
-  conflict_free, semi_stable, stage, cf2, ideal, naive)
+- All 10 supported semantics (preferred, grounded, stable, complete, admissible,
+  conflict_free, semi_stable, stage, ideal, naive). cf2 is NOT shipped in the
+  vendored Tweety build (#1215).
 - Multi-semantics analysis
 - Convenience methods (get_grounded_extension)
 - Error handling (invalid semantics, unavailable reasoner)
@@ -79,6 +80,8 @@ class TestSupportedSemantics:
     """Tests for semantics enumeration."""
 
     def test_supported_semantics_list(self):
+        # #1215 (FP-12): cf2 is NOT shipped in the vendored Tweety build —
+        # honest gate-out (was advertised but the class is absent).
         expected = [
             "preferred",
             "grounded",
@@ -88,14 +91,14 @@ class TestSupportedSemantics:
             "conflict_free",
             "semi_stable",
             "stage",
-            "cf2",
             "ideal",
             "naive",
         ]
         assert AFHandler.supported_semantics() == expected
+        assert "cf2" not in AFHandler.supported_semantics()
 
     def test_semantics_reasoners_mapping(self):
-        assert len(SEMANTICS_REASONERS) == 11
+        assert len(SEMANTICS_REASONERS) == 10
         for sem, cls_path in SEMANTICS_REASONERS.items():
             assert "org.tweetyproject.arg.dung.reasoner" in cls_path
 
@@ -242,10 +245,10 @@ class TestMultiSemantics:
         result = handler.analyze_multi_semantics(
             arguments=["a"],
             attacks=[],
-            semantics_list=["grounded", "naive", "cf2"],
+            semantics_list=["grounded", "naive", "ideal"],
         )
 
-        assert set(result["extensions"].keys()) == {"grounded", "naive", "cf2"}
+        assert set(result["extensions"].keys()) == {"grounded", "naive", "ideal"}
 
     def test_partial_failure_continues(self, mock_initializer, mock_jpype):
         _, mock_reasoner_cls = mock_jpype

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_dl_handler.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_dl_handler.py
@@ -223,7 +223,8 @@ class TestConsistencyCheck:
     def test_consistent_kb(self, mock_initializer, mock_jpype):
         handler = DLHandler(mock_initializer)
         mock_reasoner = MagicMock()
-        mock_reasoner.query.return_value = True
+        # #1215: bottom-entailment — a consistent KB does NOT entail ⊥.
+        mock_reasoner.query.return_value = False
         handler._NaiveDlReasoner.return_value = mock_reasoner
 
         kb = MagicMock()
@@ -231,7 +232,19 @@ class TestConsistencyCheck:
         assert result is True
         assert "consistent" in msg.lower()
 
-    def test_jexception_returns_false(self, mock_initializer, mock_jpype):
+    def test_inconsistent_kb(self, mock_initializer, mock_jpype):
+        handler = DLHandler(mock_initializer)
+        mock_reasoner = MagicMock()
+        # #1215: an inconsistent KB entails ⊥ (it entails everything).
+        mock_reasoner.query.return_value = True
+        handler._NaiveDlReasoner.return_value = mock_reasoner
+
+        kb = MagicMock()
+        result, msg = handler.is_consistent(kb)
+        assert result is False
+        assert "inconsistent" in msg.lower()
+
+    def test_jexception_returns_none_degraded(self, mock_initializer, mock_jpype):
         jpype_mock, _ = mock_jpype
         handler = DLHandler(mock_initializer)
         mock_reasoner = MagicMock()
@@ -240,9 +253,10 @@ class TestConsistencyCheck:
 
         kb = MagicMock()
         result, msg = handler.is_consistent(kb)
-        assert result is False
+        # #1215: fail-loud None (degraded), not a fabricated False (anti-theater #1019).
+        assert result is None
 
-    def test_unexpected_error(self, mock_initializer, mock_jpype):
+    def test_unexpected_error_returns_none_degraded(self, mock_initializer, mock_jpype):
         handler = DLHandler(mock_initializer)
         mock_reasoner = MagicMock()
         mock_reasoner.query.side_effect = ValueError("unexpected")
@@ -250,7 +264,8 @@ class TestConsistencyCheck:
 
         kb = MagicMock()
         result, msg = handler.is_consistent(kb)
-        assert result is False
+        # #1215: fail-loud None, never a fabricated verdict.
+        assert result is None
 
 
 class TestConceptQuery:


### PR DESCRIPTION
## FP-12 #1215 — DL / DeLP / CF2: actually decide (bottom-entailment, fail-loud, honest gate-out)

Three reasoners that *seemed* wired but never actually decided — the same
**#1019 silent-theater regression family** as the modal/DL bugs in #1212/#1213.
Each one returned a verdict that was either hardcoded, fed garbage, or promised
a class that does not exist.

### Fix 1 — DL `is_consistent` (fabricated True → real bottom-entailment)

`dl_handler.is_consistent` computed `reasoner.query(kb, TopConcept)` and then
**ignored the result**, unconditionally returning `(True, "consistent")`.
Querying TopConcept cannot distinguish consistent from inconsistent anyway (a
consistent KB entails Top trivially, but so does an inconsistent one which
entails everything). This was worse than "degraded": a fabricated verdict.

`NaiveDlReasoner` exposes only `query` (no `isConsistent` — same gap as the
modal reasoners, #1212). The deciding procedure is **bottom-entailment**: a KB
is consistent iff it does **not** entail BottomConcept. Assert
`(witness: Bottom)` and ask whether the KB entails it.

**Firsthand-verified** against a real JVM (probe + integration test):
- consistent KB `(john:human)` → `query(witness:Bottom)=False` → **True**
- inconsistent KB `(john:human) ∧ (john:¬human)` → `query=True` → **False**

Returns `(None, msg)` on a reasoner exception — fail-loud degraded (#1019),
never a fabricated `False` disguised as "inconsistent". `is_consistent` is now
`Tuple[Optional[bool], str]`.

### Fix 2 — DeLP raw-prose default (parse-garbage + corpus leak → fail-loud)

`_invoke_delp` defaulted `program_text = context.get("program", input_text[:500])`.
DeLP syntax (`fact.`, `head <- body.` strict, `head -< body.` defeasible) is
**not prose** → guaranteed parse failure, **and** a corpus-text leak into the
parser (privacy violation). Fix is **subtraction**: drop the raw-text default;
when no program is in context, return `status="unavailable"` with the DeLP
syntax hint. The raw corpus string never reaches the parser (verified by the
privacy-guard test: a `SECRET_CORPUS_LEAK_*` input is rejected upstream and
appears nowhere in the result).

### Fix 3 — CF2 honest gate-out (false promise → removed)

`CF2Reasoner` is **NOT shipped** in the vendored Tweety build. Introspected
firsthand: the FQN raises `ClassNotFoundException` in both 1.28 and 1.29; no
`SimpleCF2Reasoner` / `prover.CF2Reasoner` / `prover.Prover` variant exists
either. Advertising cf2 as supported while the class is absent was a false
promise. Honest gate-out: cf2 is removed from `SEMANTICS_REASONERS` →
`_get_reasoner("cf2")` now raises `ValueError` (not a silent
`{"error": ...}` dressed as a result). The other 10 semantics are untouched.

---

## Design notes

- **Anti-pendule**: each fix *subtracts* the bug (the hardcoded `return True`,
  the raw-text default, the false-promise dict entry). No counterweight added.
- **Anti-theater #1019**: DL returns `Optional[bool]` — `None` = degraded,
  never a fabricated verdict. DeLP returns `unavailable`, never a parse-on-prose
  masquerading as "analyzed".
- **Privacy HARD**: the DeLP fix *removes* a raw-text path. Verified no
  `input_text` / `raw_text` reaches a parser or the state. Synthetic atoms only
  (`human`/`john`), 0 corpus content.

---

## DoD (from dispatch #1215)

- [x] **DL `is_consistent` → vrai bool** (synthetic consistent→True /
      inconsistent→False), result plus ignoré. **Test réel non-mocké.**
      → `TestDLDecidesViaBottomEntailment` (real `DLHandler` + real JVM):
      `test_consistent_kb_decides_true`, `test_inconsistent_kb_decides_false`.
- [x] **DeLP défaut raw-prose retiré** ; fail-loud si pas de programme.
      → `TestDeLPNoRawTextFailLoud` (3): no-program→`unavailable`; raw-corpus
      string never reaches parser (privacy guard); explicit program forwarded.
- [x] **CF2 FQN vérifié par introspection** : gaté honnêtement (class absente).
      **Test réel pour le chemin retenu.**
      → `TestCF2HonestGateOut` (2): cf2 not in `SEMANTICS_REASONERS` /
      `supported_semantics` (real import); `_get_reasoner("cf2")` raises
      `ValueError` (real `AFHandler` + real JVM).
- [x] **Chaque fix a un test qui DÉCIDE** (pas skip-partout — reasoners pure-Java
      Tweety). The DL + CF2 tests run the **real** `NaiveDlReasoner` /
      `AFHandler` against a real JVM (no skip, no mock). DeLP fail-loud is
      deterministic Python (the guard fires before any JVM call).

green-by-skip = re-théâtre: **non** — 5 of 7 tests exercise real Tweety classes.

---

## Validation

- **69 FP-12 tests pass** (new integration 7 + bumped DL/AF suites).
- **Full logic suite**: 337 passed, 43 skipped, **1 failed**
  (`test_fol_query_dispatches_to_eprover` — **pre-existing**, confirmed via
  `git stash` + run on clean main `1e379fd5` where the same test fails; not a
  regression of this PR).
- **mypy strict** on `invoke_callables.py` (CI-gated): clean.
- **black + flake8**: clean.
- **Spectacular DAG intact** (`test_spectacular_workflow_dag.py`): 16 passed —
  the phases (`description_logic`, `delp_reasoning`, `dung_extensions`) already
  exist; this PR only changes their *internal* behavior, not the workflow
  structure.

Closes #1215
