### PR TITLE
test(logic): fix stale assertion in test_fol_query_dispatches_to_eprover

### DIFF
--- a/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
@@ -99,7 +99,9 @@ class TestFOLHandlerEProverDispatch:
             mock_eprover.assert_called_once_with(mock_belief_set, "query(a)")
             mock_tweety.assert_not_called()
             mock_prover9.assert_not_called()
-            assert result is True
+            # fol_query returns (result, used_tweety_fallback); the eprover path
+            # returns the prover verdict + False (no Tweety fallback was used).
+            assert result == (True, False)
 
     @pytest.mark.parametrize(
         "solver,expected_method",


### PR DESCRIPTION
## Summary
`FOLHandler.fol_query` returns a tuple `(result, used_tweety_fallback)`. The eprover dispatch path returns `(verdict, False)`. The unit test `test_fol_query_dispatches_to_eprover` still asserted the old bare-bool shape (`assert result is True`) and failed `assert (True, False) is True` on clean main — a **stale test**, not a code regression.

The eprover dispatch itself is correct: `mock_eprover.assert_called_once_with(...)` passes; only the return-shape assertion was outdated.

## Fix
`assert result is True` → `assert result == (True, False)` (with a clarifying comment).

## Verification
- `test_eprover_spass_integration.py`: **30/30 pass** (was 1 failed).
- black + flake8 clean.

This is the pre-existing FOL failure flagged during #1216 validation (po-2023's lane was down; confirmed independently by po-2025 via `git stash` on clean main `1e379fd5`). Coordinator self-pickup — test-only, no production code change.

🤖 Coordinator ai-01