### PR TITLE
fix(logic): #1219 modal pipeline reaches SimpleMlReasoner (no more valid=None)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -5710,10 +5710,34 @@ async def _invoke_nl_to_logic(
 async def _invoke_modal_logic(
     input_text: str, context: Dict[str, Any]
 ) -> Dict[str, Any]:
-    """Invoke modal logic analysis via TweetyBridge or external SPASS solver.
+    """Invoke modal logic consistency via the configured Tweety reasoner.
 
-    Routes to SPASS when context["modal_solver"] == "spass" (#479).
-    Falls back to TweetyBridge or pure-Python heuristic.
+    Primary path: ``ModalHandler.is_modal_kb_consistent`` — the #1212
+    query-based consistency probe (the KB is inconsistent iff it entails a
+    ground contradiction), run with the **configured** modal solver. The
+    default ``settings.modal_solver`` is ``TWEETY`` → ``SimpleMlReasoner``
+    (pure Java, decides without any external binary — #1205, firsthand-
+    verified). SPASS remains opt-in via ``settings.modal_solver = SPASS``
+    (honored by ``ModalHandler._get_active_reasoner``), useful once a real
+    SPASS CLI build is vendored.
+
+    #1219 (anti-pendule): the previous implementation force-set
+    ``settings.modal_solver = SPASS`` *unconditionally* on every call. With
+    the SPASS binary absent (the current state), ``_get_active_reasoner``
+    raised ``RuntimeError`` *before* ``is_modal_kb_consistent`` could run,
+    so the #1212 ``SimpleMlReasoner`` fix — proven in unit tests
+    (``test_fp11_modal_kb_roundtrip``) — was **never reached in the
+    pipeline**: every spectacular ``modal`` phase fell through to the
+    no-solver path (``valid=None``). The force-set was the bug; subtracting
+    it lets the configured ``TWEETY`` default decide. ``ModalSolverChoice``
+    is no longer imported here (no per-call override → config is the single
+    source of truth, mirroring ``ModalHandler``'s own design).
+
+    ``valid`` is ``Optional[bool]``: a real ``True``/``False`` when the
+    solver decided, ``None`` when it could not (parse error, undecidable
+    signature) — honest, never fabricated (#1019). Falls back to
+    ``TweetyBridge.execute_modal_query`` then to an honest ``unavailable``
+    report (#961) — no heuristic that fabricates a verdict.
     """
     formulas = context.get("formulas", [input_text])
     if not isinstance(formulas, list):
@@ -5726,47 +5750,50 @@ async def _invoke_modal_logic(
         if "<>" in f_str or "possibly" in f_str.lower():
             modalities.append("possibility")
     modalities = list(set(modalities)) or ["none_detected"]
+    belief_set_str = "\n".join(str(f) for f in formulas)
 
-    modal_solver = context.get(
-        "modal_solver", "spass"
-    )  # #939: spass default, tweety is last resort
+    # Primary: ModalHandler.is_modal_kb_consistent (#1212 query-based
+    # consistency) via the CONFIGURED solver (default TWEETY = SimpleMlReasoner).
+    # #1219: do NOT force SPASS — forcing it bypassed the fix when the binary
+    # was absent. valid is Optional[bool] (None = undecidable, honest).
+    try:
+        from argumentation_analysis.core.config import settings
+        from argumentation_analysis.agents.core.logic.modal_handler import (
+            ModalHandler,
+        )
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
 
-    # SPASS routing (#479): set settings.modal_solver for this request
-    if modal_solver == "spass":
-        try:
-            from argumentation_analysis.core.config import settings, ModalSolverChoice
-            from argumentation_analysis.agents.core.logic.modal_handler import (
-                ModalHandler,
-            )
-            from argumentation_analysis.agents.core.logic.tweety_initializer import (
-                TweetyInitializer,
-            )
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        # #1219: bare TweetyInitializer() does NOT initialize the modal parser/
+        # reasoner — those are class attrs that start None and are set only by
+        # ``initialize_modal_components`` (which ``TweetyBridge.__init__`` calls
+        # via ``ensure_jvm_and_components_are_ready``). Without this call,
+        # ``ModalHandler.__init__`` raises "Modal Parser not initialized" and the
+        # #1212 ``SimpleMlReasoner`` fix is never reached. The original code
+        # masked this construction bug behind the SPASS force-set cascade.
+        initializer.initialize_modal_components()  # type: ignore[no-untyped-call]
+        handler = ModalHandler(initializer_instance=initializer)
+        is_consistent, msg = await asyncio.to_thread(
+            handler.is_modal_kb_consistent, belief_set_str
+        )
+        return {
+            "formulas": formulas,
+            "valid": is_consistent,
+            "modalities": modalities,
+            "logic_type": "modal",
+            "solver": settings.modal_solver.value,
+            "message": msg,
+        }
+    except Exception as e:
+        logger.info(f"ModalHandler unavailable ({e}), falling back to TweetyBridge")
 
-            if not settings.modal_solver == ModalSolverChoice.SPASS:
-                object.__setattr__(settings, "modal_solver", ModalSolverChoice.SPASS)
-            initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
-            handler = ModalHandler(initializer_instance=initializer)
-            belief_set_str = "\n".join(str(f) for f in formulas)
-            is_consistent, msg = await asyncio.to_thread(
-                handler.is_modal_kb_consistent, belief_set_str
-            )
-            return {
-                "formulas": formulas,
-                "valid": bool(is_consistent),
-                "modalities": modalities,
-                "logic_type": "modal",
-                "solver": "spass",
-                "message": msg,
-            }
-        except Exception as e:
-            logger.info(f"SPASS modal solver unavailable ({e}), falling back to Tweety")
-
-    # TweetyBridge routing
+    # Fallback: TweetyBridge.execute_modal_query (genuine modal query via JVM)
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
 
         bridge = TweetyBridge()
-        belief_set_str = "\n".join(str(f) for f in formulas)
         logic_type = context.get("modal_logic_type", "K")
         accepted, msg = await asyncio.to_thread(
             bridge.execute_modal_query,
@@ -5783,11 +5810,12 @@ async def _invoke_modal_logic(
             "message": msg,
         }
     except Exception as e:
-        logger.debug(f"Modal TweetyBridge unavailable ({e}), using heuristic")
+        logger.debug(f"Modal TweetyBridge unavailable ({e})")
 
-    # No solver available — report honest failure (#1019)
+    # No solver available — report honest failure (#1019, #961).
+    # No heuristic fallback that could fabricate a verdict.
     logger.warning(
-        "Modal analysis unavailable: no solver (SPASS/Tweety) could be loaded. "
+        "Modal analysis unavailable: no solver (Tweety/SPASS) could be loaded. "
         "Reporting unverified status (no heuristic fallback)."
     )
     return {

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_invoke_modal_logic_reaches_solver.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_invoke_modal_logic_reaches_solver.py
@@ -1,0 +1,95 @@
+"""Real (non-mocked) modal-pipeline integration test — #1219.
+
+The modal pipeline gap (#1219) stayed hidden because the existing modal unit
+tests are 100% mocked/patched: ``test_external_solvers`` asserts only the
+``modalities`` field; ``test_value_gates`` patches ``asyncio.to_thread`` so the
+real ``ModalHandler`` never runs. Neither proves the production path
+``_invoke_modal_logic`` actually reaches ``SimpleMlReasoner`` and returns a
+real verdict. This file closes that hole with ONE non-mocked integration test
+that runs the REAL ``_invoke_modal_logic`` (live JVM, configured TWEETY solver)
+and asserts a real consistency verdict (``valid`` is ``True``/``False``, NOT
+``None``).
+
+Anti-théâtre #1019: the test must EXECUTE the real reasoner — NOT be "green by
+skipping everywhere". Where the JVM is available (ai-01, po-2025, CI) it must
+pass GREEN; the ``jvm_session`` autouse fixture in conftest skips cleanly where
+the JVM cannot start. A skip-everywhere outcome = re-théâtre and defeats the
+regression guard.
+
+#1219 regression guard — this test FAILS if someone:
+  * reintroduces the unconditional ``settings.modal_solver = SPASS`` force-set
+    (routes to the absent SPASS binary → ``valid=None``); OR
+  * removes the ``initializer.initialize_modal_components()`` call (bare
+    ``TweetyInitializer`` leaves the modal parser None → ModalHandler raises
+    → ``valid=None``).
+Both bugs were surfaced by FP-13's matrix and fixed; this test prevents their
+return. Verify-the-verification (FP-13 lesson): trust the runtime path, not
+the patched unit tests.
+
+Privacy HARD: synthetic atoms only (``type(rain)``, ``type(wet)``), 0 corpus.
+"""
+
+import pytest
+
+from argumentation_analysis.core.config import ModalSolverChoice, settings
+from argumentation_analysis.core.jvm_setup import initialize_jvm
+from argumentation_analysis.orchestration.invoke_callables import _invoke_modal_logic
+
+
+@pytest.fixture(scope="module")
+def jvm():
+    """Start the JVM once (idempotent). The ``jvm_session`` autouse fixture in
+    conftest skips this module when the JVM cannot start."""
+    initialize_jvm()
+    return True
+
+
+@pytest.fixture
+def tweety_solver():
+    """Force the pure-Java default (TWEETY / SimpleMlReasoner) — the
+    always-available, always-deciding modal path (no external binary)."""
+    previous = settings.modal_solver
+    settings.modal_solver = ModalSolverChoice.TWEETY
+    try:
+        yield
+    finally:
+        settings.modal_solver = previous
+
+
+# Parseable modal KBs (FP-11 grammar: type(prop) declarations, MlParser).
+CONSISTENT_KB = ["type(rain)", "type(wet)", "[](rain => wet)", "rain"]
+INCONSISTENT_KB = ["type(rain)", "rain", "!rain"]
+
+
+class TestInvokeModalLogicReachesSolver:
+    """The pipeline ``modal`` phase must reach SimpleMlReasoner and decide —
+    not silently fall to ``valid=None`` (#1219)."""
+
+    async def test_consistent_kb_decides_true(self, jvm, tweety_solver):
+        """A consistent modal KB yields ``valid=True`` via the REAL pipeline
+        path (``_invoke_modal_logic`` → ``ModalHandler.is_modal_kb_consistent``
+        → ``SimpleMlReasoner``)."""
+        result = await _invoke_modal_logic("ignored", {"formulas": CONSISTENT_KB})
+        assert result.get("valid") is True, (
+            f"#1219 REGRESSION: consistent KB must decide True via "
+            f"SimpleMlReasoner; got valid={result.get('valid')!r}, "
+            f"solver={result.get('solver')!r}. A None verdict means the "
+            f"pipeline did not reach the solver (force-SPASS override or "
+            f"missing initialize_modal_components)."
+        )
+        assert result.get("solver") == "tweety", (
+            f"solver must be 'tweety' (SimpleMlReasoner reached), got "
+            f"{result.get('solver')!r}."
+        )
+
+    async def test_inconsistent_kb_decides_false(self, jvm, tweety_solver):
+        """An inconsistent modal KB yields ``valid=False`` via the REAL pipeline
+        path — a real rejection, not a fabricated one."""
+        result = await _invoke_modal_logic("ignored", {"formulas": INCONSISTENT_KB})
+        assert result.get("valid") is False, (
+            f"#1219 REGRESSION: inconsistent KB must decide False via "
+            f"SimpleMlReasoner; got valid={result.get('valid')!r}."
+        )
+        assert (
+            result.get("solver") == "tweety"
+        ), f"solver must be 'tweety', got {result.get('solver')!r}."

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -959,7 +959,16 @@ class TestInvokeCallables:
         assert result["modalities"] == ["none_detected"]
 
     async def test_invoke_modal_logic_error(self):
-        """_invoke_modal_logic returns error dict on exception."""
+        """_invoke_modal_logic handles undecidable input honestly (valid=None).
+
+        #1219 + #961/#1019: when the solver cannot decide (here: an unparseable
+        modal belief set, or a solver that cannot load), the result reports
+        ``valid=None`` — NEVER a fabricated ``valid=False`` nor an ``error`` dict.
+        This is the anti-théâtre invariant; the load-bearing unavailable-fallback
+        assertion lives in ``test_value_gates`` (patches ``asyncio.to_thread``).
+        Previously this test asserted the theater shape ``valid is False`` +
+        ``"error"``, which the #1097 hardening removed — aligned here.
+        """
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_modal_logic,
         )
@@ -969,8 +978,11 @@ class TestInvokeCallables:
             side_effect=Exception("fail"),
         ):
             result = await _invoke_modal_logic("text", {})
-        assert "error" in result
-        assert result["valid"] is False
+        assert result.get("valid") is None, (
+            f"Undecidable modal input must yield valid=None (honest, not "
+            f"fabricated), got {result.get('valid')!r}."
+        )
+        assert "modalities" in result
 
     async def test_invoke_dung_extensions_error(self):
         """_invoke_dung_extensions falls back to Python when handler unavailable."""


### PR DESCRIPTION
## Summary

Closes #1219 — the modal logic capability (fixed in unit tests by #1212/#1214)
was **never reached by the spectacular pipeline**: every `modal` phase returned
`valid=None` because `_invoke_modal_logic` could not load a solver. Surfaced by
FP-13 #1218's depth-parity matrix (modal cell = honest-empty, the théâtre
suspect the DoD required flagging).

## Root cause (two bugs, both masked by the SPASS cascade)

`_invoke_modal_logic` (the spectacular `modal` phase) had **two** construction
bugs that unit tests could not catch (they patch `asyncio.to_thread`, so the
real `ModalHandler` never runs):

1. **Unconditional SPASS force-set** — `object.__setattr__(settings,
   "modal_solver", ModalSolverChoice.SPASS)` ran on *every* call. With the SPASS
   binary absent, `_get_active_reasoner` raised `RuntimeError` *before*
   `is_modal_kb_consistent` could run → fell to the TweetyBridge fallback.
2. **Bare `TweetyInitializer()`** — does NOT initialize the modal parser/reasoner
   (class attrs start `None`; set only by `initialize_modal_components`, which
   `TweetyBridge.__init__` calls but a bare initializer does not). So
   `ModalHandler.__init__` raised "Modal Parser not initialized" → fell through.

Net: the #1212 `SimpleMlReasoner` query-based consistency fix (proven in
`test_fp11_modal_kb_roundtrip`) was unreachable in the pipeline. Modal always
landed on the no-solver path (`valid=None`).

## Fix (anti-pendule — subtraction of each bug)

- **Remove** the unconditional SPASS force-set + `if modal_solver == "spass"`
  gate. Use the **configured** solver (default `settings.modal_solver = TWEETY`
  → `SimpleMlReasoner`, pure Java, no external binary). SPASS remains opt-in via
  `settings.modal_solver = SPASS` (honored by `_get_active_reasoner`).
- **Add** `initializer.initialize_modal_components()` so `ModalHandler`
  constructs with a real modal parser/reasoner.
- `valid` is `Optional[bool]` (None = undecidable), never fabricated `False`
  (anti-théâtre #1019). The honest `unavailable` fallback (#961) is preserved.

## Verify-the-verification (FP-13 lesson — trust the runtime, not the patched tests)

The patched unit tests passed both before AND after the fix (they never run the
real reasoner). A real end-to-end call against a live JVM confirms the fix:

```
consistent KB   → valid=True   solver='tweety'  "Knowledge base is consistent (tweety)."
inconsistent KB → valid=False  solver='tweety'  "Knowledge base is inconsistent (tweety)."
```

Before the fix, both were `valid=None, solver='unavailable'`.

## Files

- `argumentation_analysis/orchestration/invoke_callables.py` — `_invoke_modal_logic`
  rewrite (remove force-SPASS + gate; add `initialize_modal_components`;
  `Optional[bool]` valid). **mypy strict clean** (CI-gated file).
- `tests/integration/.../test_invoke_modal_logic_reaches_solver.py` — **new**
  non-mocked regression test (skip-if-JVM-absent). Asserts the REAL pipeline
  reaches `SimpleMlReasoner` and decides. Fails if either bug returns.
- `tests/unit/.../test_unified_pipeline.py` — `test_invoke_modal_logic_error`
  was **pre-existing failing** (verified via stash): it asserted the theater
  shape `valid is False` + `"error"`, which #1097's hardening removed. Aligned
  to the honest `valid is None` contract (same staleness-fix pattern as #1217).

## Validation

- `mypy --strict invoke_callables.py` → Success: no issues.
- 25 modal unit tests PASS (incl. load-bearing `test_value_gates` #961/#1097).
- 2 new integration tests PASS (real JVM, real verdicts).
- black + flake8 clean.

## Scope / out-of-scope

This makes modal **decide** in the pipeline via the existing `SimpleMlReasoner`
(not an architectural change). Vendoring a real SPASS CLI build (for more
powerful modal reasoning) remains a separate, optional follow-up — not required
for the depth-parity Epic #1191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
