### PR TITLE
fix(fp5): FP-14 #1222 refresh depth-parity matrix post-#1221; modal solver gap resolved

### DIFF
--- a/docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md
+++ b/docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md
@@ -73,9 +73,9 @@ pre-#1221 that parser was never invoked). The remaining `valid=None` is a
 **different** problem: the corpus→modal-KB translation produces malformed
 grammar, so the parser rejects it:
 
-- doc_A: `Predicate 'http[…]s=2.25' has not been declared` (a URL fragment
+- doc_A: `Predicate '<url-fragment>' has not been declared` (a URL fragment
   leaked from upstream extraction as a predicate name).
-- doc_C: `Missing '=' in sort declaration '[…] Citizens of Russia, friends,'`
+- doc_C: `Missing '=' in sort declaration '<prose-greeting-fragment>'`
   (prose leaked as a sort declaration).
 
 `is_modal_kb_consistent` catches the parse failure and honestly returns
@@ -102,7 +102,7 @@ the parallel FOL fail-loud over-label (`is_consistent=None` + echoed `axioms`).
 
 | check | doc_A | doc_C | doc_B |
 | --- | --- | --- | --- |
-| `modal` class (post-fix) | **degraded** | **degraded** | **degraded** (parse error: sort decl `'Adolf Hitler'`) |
+| `modal` class (post-fix) | **degraded** | **degraded** | **degraded** (parse error: sort decl `'<proper-noun-fragment>'`) |
 | `modal_fabricated_true` | False | False | False |
 | `dl_fabricated_true` | True (pre-existing, genuine) | True | True |
 | phases completed | 40/40 | 40/40 | 39/40 (`act2_narrative` — non-formal, same transient LLM failure as FP-13) |

--- a/docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md
+++ b/docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md
@@ -1,9 +1,10 @@
 # FP-5 #1196 — Multi-corpus formal-richness matrix (post FP-10/11/12 + classifier fix)
 
-**Track**: FP-5 #1196 / FP-13 #1218 (Epic #1191 depth-parity) · **Type**:
-measurement matrix · **Author**: po-2025 · **Date**: 2026-06-21 · **Base**:
-`0a5a7a00` (post FP-10 #1211 / FP-11 #1214 / FP-12 #1216) + classifier fix
-(this PR).
+**Track**: FP-5 #1196 / FP-13 #1218 / FP-14 #1222 (Epic #1191 depth-parity) ·
+**Type**: measurement matrix · **Author**: po-2025 · **Date**: 2026-06-22 ·
+**Base**: `883fd770` (post FP-10/11/12 + #1219 modal-pipeline-solver fix) +
+modal-cell classifier correction (this PR). The FP-13 body below is preserved
+as provenance; the **FP-14 Update** section supersedes the modal findings.
 
 > Aggregate-only. Counts/classes/verdicts only — no corpus content. Opaque IDs
 > (`doc_A/B/C`). Raw JSON metrics stay local under gitignored
@@ -44,6 +45,81 @@ degraded-by-default on axes the corpus supports. The two `empty` cells (DeLP,
 modal) are honest-absent — the corpus has no defeasible program (DeLP) / no
 solver is loaded in the pipeline environment (modal). Neither is dressed as
 decided.
+
+## FP-14 Update (2026-06-22, base `883fd770` post-#1221 #1219-fix)
+
+**Status: #1219 RESOLVED at the pipeline level.** The modal follow-up flagged in
+the FP-13 body below ("modal `empty`, pipeline can't reach a solver") is fixed
+by #1219 (PR #1221, merged `883fd770`): `_invoke_modal_logic` no longer
+force-sets `SPASS` and now calls `initialize_modal_components()`, so the
+spectacular `modal` phase reaches `SimpleMlReasoner` (the configured `TWEETY`
+default). A fresh A/B/C re-run at `883fd770` confirms the solver is now reached —
+but surfaced a **new, distinct gap** (NL→modal-KB translation) and a **classifier
+over-label**, both addressed in this PR.
+
+### Modal cell — no longer `empty (no solver)`; now `degraded`
+
+| metric | pre-#1221 (FP-13) | post-#1221 (FP-14) |
+| --- | --- | --- |
+| `solver` evidence | `null` (`"unavailable"`) | **`"tweety"`** (SimpleMlReasoner reached) |
+| run log | no modal parser invocation | `MlParser.parseBeliefBase` runs, raises `ParserException` |
+| `valid` | `None` (solver never ran) | **`None`** (solver ran, **KB malformed**) |
+| honest class | `empty` (no solver) | **`degraded`** (solver ran, could not decide) |
+
+The #1219 pipeline gap is closed: the modal phase now exercises the real
+`MlParser`/`SimpleMlReasoner` (verified two ways: the matrix cell evidence
+`verdict:"tweety"`, and the run log where `MlParser.parseBeliefBase` raises —
+pre-#1221 that parser was never invoked). The remaining `valid=None` is a
+**different** problem: the corpus→modal-KB translation produces malformed
+grammar, so the parser rejects it:
+
+- doc_A: `Predicate 'http[…]s=2.25' has not been declared` (a URL fragment
+  leaked from upstream extraction as a predicate name).
+- doc_C: `Missing '=' in sort declaration '[…] Citizens of Russia, friends,'`
+  (prose leaked as a sort declaration).
+
+`is_modal_kb_consistent` catches the parse failure and honestly returns
+`(None, "Modal KB parse error (consistency undetermined, tweety)")` — no
+fabricated verdict (`modal_fabricated_true: False` × 3). **This is neither a
+clean `real-verdict` nor `honest-absent`** (the DoD's binary): the corpus *has*
+modal-ish content, but the NL→modal-KB translation cannot render it as valid
+`MlParser` grammar. The unit-test KBs (`type(rain)`, `[](rain => wet)`) parse
+and decide cleanly; real political-corpus extraction does not. Filed as a new
+follow-up (NL→modal-logic translation quality) — out of scope for this PR.
+
+### Classifier over-label corrected (this PR)
+
+The FP-13 classifier labeled this modal output `real-verdict`: `_output_repr`
+strips `valid=None` (falsy), and the remaining echoed keys (`formulas`,
+`modalities`, `solver`) satisfied the `has_output` gate — an undecidable modal
+disguised as decided (anti-théâtre #1019). **Fixed**: a verdict key
+(`is_consistent`/`consistent`/`valid`) present-but-`None` in the unstripped
+output → `degraded`. Pinned by 5 unit tests
+(`tests/unit/scripts/test_run_fp5_formal_matrix.py`). The same correction closes
+the parallel FOL fail-loud over-label (`is_consistent=None` + echoed `axioms`).
+
+### DoD re-check (post-#1221 re-run `b7osu9551`)
+
+| check | doc_A | doc_C | doc_B |
+| --- | --- | --- | --- |
+| `modal` class (post-fix) | **degraded** | **degraded** | **degraded** (parse error: sort decl `'Adolf Hitler'`) |
+| `modal_fabricated_true` | False | False | False |
+| `dl_fabricated_true` | True (pre-existing, genuine) | True | True |
+| phases completed | 40/40 | 40/40 | *run completing — modal verdict already confirmed* |
+
+`dl_fabricated_true: True` is **pre-existing and genuine** — DL bottom-entailment
+returns `consistent=True` per FP-12 #1216; #1221 touched modal only (not DL), so
+no fabrication was **introduced** by FP-14. Verified pre-existing across the two
+prior runs (`fp5_docA_20260621T231303.json`, `…T221436.json` both `true`). The
+flag records the *presence* of a True verdict, not fabrication.
+
+### Class tally (post-fix classifier, per corpus)
+
+21 `real-verdict` · 1 `degraded` (modal — solver reached, KB malformed) · 1
+`empty` (DeLP honest-absent). (Pre-fix the modal cell was mis-counted among the
+22 `real-verdict`; the DeLP `empty` is unchanged.)
+
+---
 
 ## Delta from #1196 (FP-13 #1218)
 
@@ -113,7 +189,7 @@ non-trivial structure) | `degraded` (fail-loud None verdict) | `empty`
 | --- | --- | --- | --- |
 | pl | **real-verdict (3)** | **real-verdict (3)** | **real-verdict (3)** |
 | fol | real-verdict (2) | real-verdict (2) | real-verdict (2) |
-| modal | **empty (no solver)** | **empty (no solver)** | **empty (no solver)** |
+| modal | **degraded** † | **degraded** † | **degraded** † |
 | kb_to_tweety | real-verdict (43) | real-verdict (25) | real-verdict (67) |
 | dung_extensions | real-verdict (16) | real-verdict (16) | real-verdict (16) |
 | aspic_analysis | real-verdict (1) | real-verdict (1) | real-verdict (1) |
@@ -135,8 +211,11 @@ non-trivial structure) | `degraded` (fail-loud None verdict) | `empty`
 | jtms | real-verdict (46) | real-verdict (45) | real-verdict (43) |
 | deep_synthesis | real-verdict (1) | real-verdict (1) | real-verdict (1) |
 
-**Class tally (per corpus)**: 21 `real-verdict` · 2 `empty` (DeLP honest-absent,
-modal no-solver) · 0 `degraded` · 0 `absent` · 0 `error`. CF2 is not a separate
+**Class tally (per corpus, post-FP-14 classifier)**: 21 `real-verdict` · 1
+`degraded` (modal †) · 1 `empty` (DeLP honest-absent) · 0 `absent` · 0 `error`.
+† modal = `degraded` post-#1221: the solver is now reached (`verdict:"tweety"`)
+but the corpus KB is malformed → `valid=None` (see **FP-14 Update** above). CF2
+is not a separate
 cell — it is a Dung-family semantic gated out by FP-12 (`CF2Reasoner` absent from
 the vendored Tweety build → `ValueError`, never a silent dressed-as-decided
 result).
@@ -221,10 +300,11 @@ completes a 3MB corpus bounded, with every formal cell real.
 - **PL, FOL, DL all have real decision procedures now** (PySAT, EProver,
   `NaiveDlReasoner` bottom-entailment). Before the FP-3/10/11/12 stack this layer
   was theatre (PL OOM, FOL fabricated, DL hardcoded True, DeLP parse-garbage).
-  **Modal is the exception**: the capability is fixed in unit tests
-  (`SimpleMlReasoner`, #1212/#1214) but the spectacular pipeline's
-  `_invoke_modal_logic` does not reach the deciding path (SPASS absent +
-  `TweetyBridge.execute_modal_query` raises) — filed as follow-up #1219.
+  **Modal now reaches its solver too** (FP-14/#1221): the pipeline gap (#1219)
+  is closed — `_invoke_modal_logic` exercises `SimpleMlReasoner`
+  (`verdict:"tweety"`). The remaining modal depth-gap is the NL→modal-KB
+  translation (corpus grammar malformed → `valid=None`), a *different* problem
+  from the solved solver gap — see **FP-14 Update** above.
 - **No fabricated verdicts anywhere** — `fol_fabricated_true: False` × 3,
   `modal_fabricated_true: False` × 3; `dl_fabricated_true: True` is a genuine
   bottom-entailment verdict (verified by the FP-12 real-JVM test). The
@@ -234,7 +314,15 @@ completes a 3MB corpus bounded, with every formal cell real.
   vendored build), modal is honest-absent (no solver in the pipeline env).
   None is dressed as decided.
 
-## New finding — modal pipeline solver gap (#1219, follow-up)
+## New finding — modal pipeline solver gap (#1219) — ✅ RESOLVED by #1221
+
+> **FP-14 (2026-06-22): RESOLVED.** #1219 was fixed by PR #1221 (merged
+> `883fd770`): `_invoke_modal_logic` no longer force-sets `SPASS` and now calls
+> `initialize_modal_components()`, so the spectacular `modal` phase reaches
+> `SimpleMlReasoner`. The post-#1221 re-run confirms it (`verdict:"tweety"`,
+> `MlParser.parseBeliefBase` runs). The remaining depth-gap is now a *different*
+> one — NL→modal-KB translation quality (corpus produces malformed grammar) —
+> see **FP-14 Update** above. The historical FP-13 finding is preserved below.
 
 The DoD asked to flag any new théâtre suspect. The re-run log surfaced one:
 **modal is honest-unverified in the spectacular pipeline, despite the capability

--- a/docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md
+++ b/docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md
@@ -105,7 +105,7 @@ the parallel FOL fail-loud over-label (`is_consistent=None` + echoed `axioms`).
 | `modal` class (post-fix) | **degraded** | **degraded** | **degraded** (parse error: sort decl `'Adolf Hitler'`) |
 | `modal_fabricated_true` | False | False | False |
 | `dl_fabricated_true` | True (pre-existing, genuine) | True | True |
-| phases completed | 40/40 | 40/40 | *run completing — modal verdict already confirmed* |
+| phases completed | 40/40 | 40/40 | 39/40 (`act2_narrative` — non-formal, same transient LLM failure as FP-13) |
 
 `dl_fabricated_true: True` is **pre-existing and genuine** — DL bottom-entailment
 returns `consistent=True` per FP-12 #1216; #1221 touched modal only (not DL), so

--- a/scripts/run_fp5_formal_matrix.py
+++ b/scripts/run_fp5_formal_matrix.py
@@ -250,6 +250,25 @@ def _classify_capability(result: dict, phase_name: str, count_key) -> tuple[str,
             or str(raw_out.get("solver", "")).lower() in _decl
         ):
             return "empty", evidence
+    # #1222 (FP-14): a verdict key that EXISTS in raw_out with value None means
+    # the solver RAN but could not decide (parse error, undecidable signature)
+    # — degraded, NOT real-verdict. ``_output_repr`` strips ``valid=None``
+    # (falsy), so the degraded branch below misses it when the dict also carries
+    # echoed input (formulas/modalities/solver) and mis-labels via ``has_output``.
+    # Surfaced by the post-#1219 matrix: modal now reaches SimpleMlReasoner
+    # (solver="tweety", not "unavailable") but the real-corpus KB is malformed
+    # → valid=None → over-labeled real-verdict. Read raw_out (unstripped). Must
+    # follow the honest-absent check above: solver="unavailable" + valid=None
+    # stays empty (solver never ran), while solver="tweety" + valid=None is
+    # degraded (solver ran, could not decide). A real verdict (True OR False) is
+    # untouched (``is None`` is False).
+    if isinstance(raw_out, dict) and isinstance(out, dict):
+        if any(
+            raw_out.get(_k) is None
+            for _k in ("is_consistent", "consistent", "valid")
+            if _k in raw_out
+        ):
+            return "degraded", evidence
     # degraded: fail-loud tri-state — NO decisive verdict (every verdict key is
     # None) AND no other real structure. #1218 (FP-13): verdict-aware — the old
     # ``any()`` over is_consistent/consistent/valid mis-fired when FOL returned

--- a/tests/unit/scripts/test_run_fp5_formal_matrix.py
+++ b/tests/unit/scripts/test_run_fp5_formal_matrix.py
@@ -1,0 +1,104 @@
+"""Tests for the FP-5 formal-richness matrix capability classifier.
+
+#1222 (FP-14): the depth-parity matrix refresh post-#1219 surfaced that the
+``modal`` cell was OVER-LABELED ``real-verdict``. The #1219 fix let the
+spectacular ``modal`` phase reach ``SimpleMlReasoner`` (``solver="tweety"``,
+no longer ``"unavailable"``), but on a real political-corpus KB the extracted
+formulas are malformed (URL fragments leak as predicates, prose leaks as sort
+declarations), so ``MlParser.parseBeliefBase`` raises ``ParserException`` and
+``is_modal_kb_consistent`` honestly returns ``(None, "parse error")``. The
+phase output dict is non-empty (echoed ``formulas``/``modalities``/``solver``
+keys), so ``_output_repr`` strips only ``valid=None`` (falsy) and the
+``has_output`` gate mis-labeled it ``real-verdict`` — an undecidable modal
+disguised as a decided one (anti-théâtre #1019).
+
+The fix: a verdict key (``is_consistent``/``consistent``/``valid``) that EXISTS
+in the unstripped ``raw_out`` with value ``None`` means the solver RAN but
+could not decide → ``degraded``, never ``real-verdict``. These tests pin that
+contract and guard the regression.
+"""
+
+from types import SimpleNamespace
+
+
+def _result(output: dict, count: int = 1, phase: str = "modal"):
+    """Build a minimal runner ``result`` dict for one phase (status=completed)."""
+    return {
+        "phases": {phase: SimpleNamespace(status="completed", output=output)},
+        "state_snapshot": {f"{phase}_analysis_count": count},
+    }
+
+
+class TestFp5ModalClassifierLabeling:
+    """The modal cell must be self-proving: ``real-verdict`` only when a real
+    verdict (True/False) was produced — never for ``valid=None``."""
+
+    def test_modal_valid_none_with_solver_is_degraded(self):
+        """#1222: modal reached the solver (solver='tweety', #1219 fixed) but
+        could not decide (valid=None, malformed corpus KB) → ``degraded``, NOT
+        ``real-verdict``. The echoed formulas/modalities must not mask the
+        missing verdict."""
+        from scripts.run_fp5_formal_matrix import _classify_capability
+
+        out = {
+            "valid": None,
+            "solver": "tweety",
+            "message": "Modal KB parse error (consistency undetermined, tweety)",
+            "formulas": ["type(rain)", "rain"],
+            "modalities": ["none_detected"],
+            "logic_type": "modal",
+        }
+        cls, ev = _classify_capability(_result(out), "modal", "modal_analysis_count")
+        assert cls == "degraded", (
+            f"#1222 REGRESSION: modal valid=None + solver='tweety' must be "
+            f"degraded (solver ran, no decision), got {cls!r}. A real-verdict "
+            f"label here is anti-théâtre #1019 (undecidable disguised as decided)."
+        )
+        # the evidence still records that the solver was reached (verdict=tweety)
+        assert ev["verdict"] == "tweety"
+
+    def test_modal_valid_true_is_real_verdict(self):
+        """A genuine modal verdict (valid=True) stays ``real-verdict`` — the
+        fix must not demote a real decision."""
+        from scripts.run_fp5_formal_matrix import _classify_capability
+
+        out = {"valid": True, "solver": "tweety", "message": "consistent"}
+        cls, _ = _classify_capability(_result(out), "modal", "modal_analysis_count")
+        assert cls == "real-verdict"
+
+    def test_modal_valid_false_is_real_verdict(self):
+        """A genuine modal rejection (valid=False) stays ``real-verdict`` — a
+        False verdict is a real decision, not degraded (the #1218 contract)."""
+        from scripts.run_fp5_formal_matrix import _classify_capability
+
+        out = {"valid": False, "solver": "tweety", "message": "inconsistent"}
+        cls, _ = _classify_capability(_result(out), "modal", "modal_analysis_count")
+        assert cls == "real-verdict"
+
+    def test_modal_solver_unavailable_valid_none_is_empty(self):
+        """The pre-#1219 shape (solver='unavailable', valid=None) stays
+        ``empty`` (honest-absent) — the solver never ran. The new degraded
+        check must not fire before the honest-absent check."""
+        from scripts.run_fp5_formal_matrix import _classify_capability
+
+        out = {"valid": None, "solver": "unavailable", "message": "no solver"}
+        cls, _ = _classify_capability(_result(out), "modal", "modal_analysis_count")
+        assert cls == "empty"
+
+    def test_fol_is_consistent_none_with_axioms_is_degraded(self):
+        """The same over-label affected FOL fail-loud: ``is_consistent=None``
+        plus echoed ``axioms`` was mis-labeled real-verdict. The fix corrects
+        it to ``degraded`` (no decisive verdict)."""
+        from scripts.run_fp5_formal_matrix import _classify_capability
+
+        out = {
+            "is_consistent": None,
+            "axioms": ["forall x P(x)"],
+            "message": "eprover unavailable",
+        }
+        result = {
+            "phases": {"fol": SimpleNamespace(status="completed", output=out)},
+            "state_snapshot": {"fol_analysis_count": 1},
+        }
+        cls, _ = _classify_capability(result, "fol", "fol_analysis_count")
+        assert cls == "degraded"


### PR DESCRIPTION
## Summary

Closes #1222 (FP-14) — refreshes the FP-5 formal-richness depth-parity matrix at
the post-#1221 base (`883fd770`) and confirms the #1219 modal-pipeline-solver
gap is **resolved**: the spectacular `modal` phase now reaches
`SimpleMlReasoner`. The refresh surfaced a **new, distinct gap**
(NL→modal-KB translation) and a **classifier over-label**, both addressed here.

## #1219 — RESOLVED at the pipeline level

`_invoke_modal_logic` (PR #1221, merged `883fd770`) no longer force-sets `SPASS`
and now calls `initialize_modal_components()`. The A/B/C re-run confirms the
solver is reached:

| | pre-#1221 (FP-13) | post-#1221 (FP-14) |
| --- | --- | --- |
| `solver` evidence | `null` (`"unavailable"`) | **`"tweety"`** (SimpleMlReasoner) |
| run log | no modal parser invocation | `MlParser.parseBeliefBase` runs (raises `ParserException`) |
| `valid` | `None` (solver never ran) | `None` (solver ran, **KB malformed**) |

Verified two ways (FP-13 lesson — trust the runtime, not the classifier): the
matrix cell `verdict:"tweety"` AND the run log where `MlParser.parseBeliefBase`
raises — pre-#1221 that parser was never invoked.

## Modal cell — `empty (no solver)` → `degraded`

The solver is reached, but `valid=None` because the corpus→modal-KB translation
produces malformed grammar (the parser rejects it):

- doc_A: `Predicate '<url-fragment>' has not been declared` (URL fragment as predicate).
- doc_C: `Missing '=' in sort declaration '<prose-greeting-fragment>'`.

`is_modal_kb_consistent` catches the parse failure and honestly returns
`(None, "Modal KB parse error (consistency undetermined, tweety)")`. This is
**neither a clean `real-verdict` nor `honest-absent`** (the DoD's binary): the
corpus has modal-ish content, but the NL→modal-KB translation can't render it as
valid `MlParser` grammar. The synthetic unit-test KBs (`type(rain)`,
`[](rain => wet)`) parse and decide cleanly; real political-corpus extraction
does not. **New follow-up** (NL→modal-logic translation quality) — out of scope here.

## Classifier over-label corrected (this PR)

The FP-13 classifier labeled this modal output `real-verdict`:
`_output_repr` strips `valid=None` (falsy), and the remaining echoed keys
(`formulas`, `modalities`, `solver`) satisfied the `has_output` gate — an
undecidable modal disguised as decided (anti-théâtre #1019). **Fixed**: a verdict
key (`is_consistent`/`consistent`/`valid`) present-but-`None` in the unstripped
output → `degraded`. The same correction closes the parallel FOL fail-loud
over-label (`is_consistent=None` + echoed `axioms`).

## DoD (#1222)

- [x] Matrix re-run A/B/C at post-#1221 base `883fd770`.
- [x] Modal cell no longer `empty`-due-to-pipeline-gap — solver reached (`"tweety"`).
- [x] Modal classed honestly: **`degraded`** (solver reached, KB malformed) —
      the evidence line (`verdict:"tweety"`, a string not a bool) distinguishes
      "solver ran, no decision" from a real verdict. Neither clean real-verdict
      nor honest-absent; the third state is documented + a follow-up filed.
- [x] `modal_fabricated_true: False` × 3 (valid=None, no fabricated True).
- [x] `fol_fabricated_true: False` × 3.
- [x] `dl_fabricated_true: True` × 3 — **pre-existing and genuine** (DL
      bottom-entailment `consistent=True` per FP-12 #1216; #1221 touched modal
      only; verified pre-existing across 2 prior runs). No fabrication
      **introduced** by FP-14.
- [x] Report updated; #1219 marked resolved; delta narrative (FP-14 Update section).

## Files

- `scripts/run_fp5_formal_matrix.py` — classifier: verdict key present-but-None
  → `degraded` (reads unstripped `raw_out`; follows the honest-absent check so
  `solver:"unavailable"`+None stays `empty`).
- `tests/unit/scripts/test_run_fp5_formal_matrix.py` — **new**, 5 tests pinning
  the modal/DL/FOL labeling contract (degraded for None-verdict, real-verdict
  for True/False, empty for solver-unavailable).
- `docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md` — FP-14 Update section (supersedes
  the FP-13 modal narrative, preserved as provenance); matrix modal row →
  `degraded`; class tally; #1219 section marked RESOLVED.

## Validation

- 5 new classifier unit tests PASS (`pytest tests/unit/scripts/test_run_fp5_formal_matrix.py`).
- black + flake8 clean on both files.
- Post-#1221 matrix re-run (`b7osu9551`): doc_A/C 40/40 phases; doc_B completing.
  Raw metrics gitignored under `evaluation/results/fp5/`.

## Scope / out-of-scope

The classifier correction is part of making the refreshed matrix honest (the
refresh surfaced the over-label on the very cell FP-14 is about). The NL→modal-KB
translation gap is a separate follow-up (not wired here). Vendoring a real SPASS
CLI build remains optional (SimpleMlReasoner already decides; not required for
Epic #1191).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

