### PR TITLE
fix(logic): #1224 build modal KB from nl_to_logic translations, not raw corpus

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -5739,9 +5739,78 @@ async def _invoke_modal_logic(
     ``TweetyBridge.execute_modal_query`` then to an honest ``unavailable``
     report (#961) — no heuristic that fabricates a verdict.
     """
-    formulas = context.get("formulas", [input_text])
-    if not isinstance(formulas, list):
-        formulas = [str(formulas)]
+    # #1224: build the modal KB from the nl_to_logic translations (as PL/FOL
+    # do), NOT from the raw corpus. The spectacular DAG executor never populates
+    # ``context["formulas"]`` (``_store_phase_result`` sets only
+    # ``phase_*_output``/``_result`` and does not merge output keys), so the
+    # prior ``context.get("formulas", [input_text])`` fallback fed ``MlParser``
+    # the raw corpus paragraph → ``ParserException`` on URL fragments /
+    # prose-as-sort-declarations → ``valid=None`` (degraded) on every corpus.
+    # When nl_to_logic produced formulas, mirror PL: keep the valid ones,
+    # sanitize them to clean propositional atoms (``PLFormulaSanitizer``,
+    # #537), and declare ``type(<atom>)`` per FP-11 #1214 so the modal parser
+    # (an extension of FOL) accepts the KB. The hand-written-KB / direct
+    # ``formulas`` path (tests, pre-typed KBs) stays as-is — never re-declare
+    # atoms an existing KB already declared (MlParser rejects duplicates).
+    nl_out = context.get("phase_nl_to_logic_output") or {}
+    nl_translations = (
+        nl_out.get("translations", []) if isinstance(nl_out, dict) else []
+    )
+    nl_formulas = [
+        str(t["formula"])
+        for t in nl_translations
+        if isinstance(t, dict) and t.get("is_valid") and t.get("formula")
+    ]
+
+    if nl_formulas:
+        # Real-pipeline path (#1224): the modal KB comes from nl_to_logic.
+        # Sanitize to clean propositional atoms, then declare type(prop) per
+        # atom so MlParser accepts the KB. Fail-loud: if the sanitized KB still
+        # does not parse, ``is_modal_kb_consistent`` honestly returns
+        # ``(None, "parse error")`` → degraded, never a fabricated verdict
+        # (#1019). nl_to_logic formulas never carry ``type(...)`` so there is
+        # no duplicate-declaration risk here.
+        formulas = nl_formulas
+        kb_formulas: List[str] = list(nl_formulas)
+        try:
+            from argumentation_analysis.agents.core.logic.pl_formula_sanitizer import (
+                PLFormulaSanitizer,
+            )
+
+            sanitizer = PLFormulaSanitizer()
+            san_result = sanitizer.sanitize_batch(nl_formulas)
+            if san_result.sanitized_formulas:
+                kb_formulas = san_result.sanitized_formulas
+        except Exception as san_err:
+            logger.debug(
+                f"Modal sanitizer unavailable ({san_err}), using raw nl formulas"
+            )
+        # FP-11 #1214: declare type(prop) for each atomic predicate the modal
+        # parser will reference (connectives/keywords are not atoms).
+        _keyword_atoms = {
+            "forall", "exists", "true", "false", "type", "prop",
+            "and", "or", "not", "implies",
+        }
+        _seen_atoms: Dict[str, None] = {}
+        for f in kb_formulas:
+            for tok in re.findall(r"[A-Za-z_][A-Za-z0-9_]*", str(f)):
+                if tok not in _keyword_atoms and tok not in _seen_atoms:
+                    _seen_atoms[tok] = None
+        _declarations = [f"type({atom})" for atom in _seen_atoms]
+        belief_set_str = "\n".join(_declarations + [str(f) for f in kb_formulas])
+    else:
+        # Direct-formulas / hand-written-KB path (tests, pre-typed KBs like
+        # ``type(rain), [](rain => wet), rain``): use the formulas verbatim so
+        # existing declarations/modal operators are not duplicated. Falls back
+        # to ``[input_text]`` only when neither path yields formulas — the parse
+        # below then fail-louds to ``degraded`` if that content is raw corpus.
+        formulas = context.get("formulas", [input_text])
+        if not isinstance(formulas, list):
+            formulas = [str(formulas)]
+        belief_set_str = "\n".join(str(f) for f in formulas)
+
+    # Modality detection runs on the source formulas: modal operators ([]/<>)
+    # live in the untranslated input, not in sanitized propositional atoms.
     modalities = []
     for f in formulas:
         f_str = str(f)
@@ -5750,7 +5819,6 @@ async def _invoke_modal_logic(
         if "<>" in f_str or "possibly" in f_str.lower():
             modalities.append("possibility")
     modalities = list(set(modalities)) or ["none_detected"]
-    belief_set_str = "\n".join(str(f) for f in formulas)
 
     # Primary: ModalHandler.is_modal_kb_consistent (#1212 query-based
     # consistency) via the CONFIGURED solver (default TWEETY = SimpleMlReasoner).

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_invoke_modal_logic_reaches_solver.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_invoke_modal_logic_reaches_solver.py
@@ -93,3 +93,54 @@ class TestInvokeModalLogicReachesSolver:
         assert (
             result.get("solver") == "tweety"
         ), f"solver must be 'tweety', got {result.get('solver')!r}."
+
+    async def test_nl_translations_consistent_decides_true(self, jvm, tweety_solver):
+        """#1224: a modal KB built from nl_to_logic translations (sanitized to
+        propositional atoms + type(prop) declarations) reaches SimpleMlReasoner
+        and decides True — NOT the raw-corpus ``valid=None`` of the pre-#1224
+        pipeline. ``input_text`` is ignored when translations are present."""
+        result = await _invoke_modal_logic(
+            "ignored raw corpus", {"phase_nl_to_logic_output": NL_CONSISTENT_OUT}
+        )
+        assert result.get("valid") is True, (
+            f"#1224 REGRESSION: a consistent nl_to_logic-derived KB must decide "
+            f"True via SimpleMlReasoner; got valid={result.get('valid')!r}, "
+            f"solver={result.get('solver')!r}, message={result.get('message')!r}. "
+            f"A None means the nl→modal-KB translation is still malformed."
+        )
+        assert result.get("solver") == "tweety"
+
+    async def test_nl_translations_inconsistent_decides_false(self, jvm, tweety_solver):
+        """#1224: an inconsistent nl_to_logic-derived KB decides False — a real
+        rejection on sanitized translations, not a fabricated one."""
+        result = await _invoke_modal_logic(
+            "ignored raw corpus", {"phase_nl_to_logic_output": NL_INCONSISTENT_OUT}
+        )
+        assert result.get("valid") is False, (
+            f"#1224 REGRESSION: an inconsistent nl_to_logic-derived KB must "
+            f"decide False via SimpleMlReasoner; got valid={result.get('valid')!r}, "
+            f"message={result.get('message')!r}."
+        )
+        assert result.get("solver") == "tweety"
+
+
+# #1224 — nl_to_logic translation output (the shape _invoke_nl_to_logic returns).
+# The spectacular pipeline builds the modal KB from these translations (mirroring
+# PL/FOL), NOT from the raw corpus. These prove the fix end-to-end: a KB derived
+# from nl_to_logic formulas (sanitized to propositional atoms + type(prop)
+# declarations) reaches SimpleMlReasoner and DECIDES — the pre-#1224 pipeline
+# fed MlParser the raw corpus and got valid=None (degraded) on every corpus.
+NL_CONSISTENT_OUT = {
+    "translations": [
+        {"formula": "rain => wet", "is_valid": True, "logic_type": "propositional"},
+        {"formula": "rain", "is_valid": True, "logic_type": "propositional"},
+    ],
+    "valid_count": 2,
+}
+NL_INCONSISTENT_OUT = {
+    "translations": [
+        {"formula": "rain", "is_valid": True, "logic_type": "propositional"},
+        {"formula": "!rain", "is_valid": True, "logic_type": "propositional"},
+    ],
+    "valid_count": 2,
+}

--- a/tests/unit/argumentation_analysis/orchestration/test_invoke_modal_logic_nl_kb.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_invoke_modal_logic_nl_kb.py
@@ -1,0 +1,103 @@
+"""#1224 — the modal KB must be built from ``nl_to_logic`` translations, not
+the raw corpus.
+
+``_invoke_modal_logic`` previously read ``context.get("formulas", [input_text])``.
+The spectacular DAG executor never populates ``context["formulas"]``
+(``_store_phase_result`` sets only ``phase_*_output``/``_result``), so the modal
+phase fell back to ``[input_text]`` — the **raw corpus paragraph**. ``MlParser``
+then raised ``ParserException`` on URL fragments / prose-as-sort-declarations
+and ``is_modal_kb_consistent`` honestly returned ``(None, "parse error")`` →
+the modal cell was ``degraded`` on every corpus.
+
+The fix mirrors PL/FOL: when ``phase_nl_to_logic_output`` carries valid
+translations, the KB is built from those (sanitized to propositional atoms +
+``type(prop)`` declarations per FP-11 #1214), never from the raw corpus. The
+direct ``{"formulas": ...}`` path (hand-written, pre-typed KBs) is left as-is
+so existing ``type(...)`` declarations are not duplicated.
+
+These are STRUCTURAL tests (no JVM): they patch the solver route
+(``asyncio.to_thread``, same pattern as ``test_value_gates``) and assert the KB
+*source*. The real-decision proof lives in the integration test
+``test_invoke_modal_logic_reaches_solver`` (added ``test_nl_translations_*``).
+"""
+
+from unittest.mock import patch
+
+from argumentation_analysis.orchestration.invoke_callables import _invoke_modal_logic
+
+# Sentinel distinct from any logic token — must never appear in the KB source.
+_RAW_CORPUS = "RAW UNPARSED CORPUS PARAGRAPH with a url http://x/y?s=2.25"
+
+
+class TestInvokeModalLogicNLKB:
+    """#1224: the modal KB source follows the nl_to_logic translations."""
+
+    async def test_kb_source_is_nl_translations_not_raw_corpus(self):
+        """When ``phase_nl_to_logic_output`` has valid translations, the modal
+        formulas come from THOSE — the raw ``[input_text]`` corpus must not
+        leak (the #1224 bug that fed MlParser URL fragments / prose)."""
+        nl_out = {
+            "translations": [
+                {"formula": "rain => wet", "is_valid": True, "logic_type": "propositional"},
+                {"formula": "rain", "is_valid": True, "logic_type": "propositional"},
+                {"formula": "", "is_valid": False, "logic_type": "propositional"},
+            ],
+            "valid_count": 2,
+        }
+        # Patch the solver route so the real KB-building runs but no JVM call
+        # is made (the KB source is decided before the solver is reached).
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("stop solver route"),
+        ):
+            result = await _invoke_modal_logic(
+                _RAW_CORPUS, {"phase_nl_to_logic_output": nl_out}
+            )
+
+        formulas = result.get("formulas", [])
+        # The raw corpus MUST NOT be the KB source anymore (#1224).
+        assert _RAW_CORPUS not in formulas, (
+            f"#1224 REGRESSION: the raw corpus leaked into the modal KB source "
+            f"({formulas!r}). The KB must be built from nl_to_logic translations."
+        )
+        assert all(_RAW_CORPUS not in str(f) for f in formulas)
+        # The valid translations ARE the source; the invalid one is dropped.
+        assert "rain => wet" in formulas
+        assert "rain" in formulas
+        assert "" not in formulas
+
+    async def test_invalid_translations_fall_through_honestly(self):
+        """When nl_to_logic produced NO valid formula, the KB must NOT be empty
+        (which would crash) — it falls to the formulas/``[input_text]`` path and
+        the solver then fail-louds honestly (``valid=None``), never a fabricated
+        verdict (#1019)."""
+        nl_out = {"translations": [
+            {"formula": "", "is_valid": False},
+        ], "valid_count": 0}
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("stop solver route"),
+        ):
+            result = await _invoke_modal_logic(
+                _RAW_CORPUS, {"phase_nl_to_logic_output": nl_out}
+            )
+        # No valid translations → falls to [input_text]; solver route patched →
+        # honest unavailable. Crucially: NOT valid=True (no fabricated verdict).
+        assert result.get("valid") is not True
+        assert result.get("solver") == "unavailable"
+
+    async def test_direct_formulas_path_unchanged(self):
+        """Regression guard: the direct ``{"formulas": ...}`` path (hand-written
+        KBs with existing ``type(...)`` declarations, as the reaches-solver
+        integration tests pass them) must be UNCHANGED — no duplicate
+        declarations injected that MlParser would reject."""
+        hand_written = ["type(rain)", "type(wet)", "[](rain => wet)", "rain"]
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=RuntimeError("stop solver route"),
+        ):
+            result = await _invoke_modal_logic("ignored", {"formulas": hand_written})
+        assert result.get("formulas") == hand_written, (
+            "The direct-formulas path must pass hand-written KBs through verbatim "
+            "(no re-sanitization / duplicate type declarations)."
+        )


### PR DESCRIPTION
## Summary

Closes #1224. The modal phase built its KB from the **raw corpus** instead of the
`nl_to_logic` translations, so `MlParser` choked on URL fragments / prose and
`is_modal_kb_consistent` returned `valid=None` (degraded) on every corpus. This
PR makes `_invoke_modal_logic` read `phase_nl_to_logic_output` (as PL/FOL already
do), sanitize, and declare `type(prop)` so the modal parser accepts the KB —
modal now **decides** (`valid=True`/`False`) on real-pipeline input.

## Root cause (confirmed read-only, then fixed)

`_invoke_modal_logic` read `context.get("formulas", [input_text])`
([invoke_callables.py:5742](argumentation_analysis/orchestration/invoke_callables.py#L5742)).
But the spectacular DAG executor never populates `context["formulas"]`:
`_store_phase_result` ([workflow_dsl.py:651-653](argumentation_analysis/orchestration/workflow_dsl.py#L651-L653))
stores only `phase_*_output`/`_result` and does not merge output keys. And
`_invoke_nl_to_logic` returns `translations` (no `formulas` key). So the fallback
`[input_text]` = the **raw corpus paragraph** → `MlParser.parseBeliefBase` raised
`ParserException` (URL fragment `<url-fragment>` as predicate; prose
`<proper-noun-fragment>` / `<prose-greeting-fragment>` as sort declarations).

PL and FOL avoid this — they read `phase_nl_to_logic_output`
([5246](argumentation_analysis/orchestration/invoke_callables.py#L5246)/[4845](argumentation_analysis/orchestration/invoke_callables.py#L4845)),
extract `[t.formula for t in valid]`, and sanitize. **Modal was the only logic
phase taking the raw-corpus fallback.**

## Fix (anti-pendule: mirror PL/FOL, no new infra)

When `phase_nl_to_logic_output` carries valid translations:
1. Extract `[t["formula"] for t in translations if is_valid]`.
2. Sanitize to clean propositional atoms (`PLFormulaSanitizer`, #537).
3. Declare `type(<atom>)` per unique atom (FP-11 #1214 MlParser contract).
4. Join → modal KB → `is_modal_kb_consistent` decides.

The **direct `{"formulas": ...}` path (hand-written, pre-typed KBs) is unchanged**
— existing `type(...)` declarations are not duplicated (MlParser rejects dupes).
Fail-loud: if the KB still doesn't parse, `(None, "parse error")` → `degraded`,
never a fabricated verdict (#1019).

## Verification (verify-the-verification — real runtime, not classifier)

| Evidence | Result |
| --- | --- |
| Integration `test_nl_translations_consistent_decides_true` (real JVM) | `valid=True`, solver=`tweety` ✅ |
| Integration `test_nl_translations_inconsistent_decides_false` (real JVM) | `valid=False` ✅ |
| Unit: KB source follows translations, not raw corpus | ✅ |
| Unit: invalid-only translations fall through honestly (no fabricated True) | ✅ |
| Unit: direct `{"formulas":...}` path unchanged (regression guard) | ✅ |
| Existing `#1219` hand-written-KB integration tests | 4/4 ✅ |
| Existing modal unit tests (`-k modal`, 3 files) | 14 passed ✅ |
| `mypy --strict invoke_callables.py` | clean ✅ |

This moves the modal depth-parity track forward: the cell should transition
`degraded` → `real-verdict` on a re-run FP-5 matrix (out of scope here; tracked
in #1222/#1223). It is independent of the FP-14 classifier fix (#1223) —
different files, clean rebase on `883fd770`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

