### PR TITLE
fix(logic): #1227 normalize modal predicate names to MlParser grammar (FP-15 follow-up)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -5753,9 +5753,7 @@ async def _invoke_modal_logic(
     # ``formulas`` path (tests, pre-typed KBs) stays as-is — never re-declare
     # atoms an existing KB already declared (MlParser rejects duplicates).
     nl_out = context.get("phase_nl_to_logic_output") or {}
-    nl_translations = (
-        nl_out.get("translations", []) if isinstance(nl_out, dict) else []
-    )
+    nl_translations = nl_out.get("translations", []) if isinstance(nl_out, dict) else []
     nl_formulas = [
         str(t["formula"])
         for t in nl_translations
@@ -5787,13 +5785,65 @@ async def _invoke_modal_logic(
             )
         # FP-11 #1214: declare type(prop) for each atomic predicate the modal
         # parser will reference (connectives/keywords are not atoms).
+        # #1227: MlParser predicate identifiers must match ``[a-zA-Z][a-zA-Z0-9]*``
+        # — NO underscores (stricter than Tweety PL, whose grammar is
+        # ``[a-zA-Z_][a-zA-Z0-9_]*`` and which ``PLFormulaSanitizer`` targets).
+        # Real ``nl_to_logic`` extraction emits COMPOUND atoms with underscores
+        # (e.g. ``heavy_rain``); the sanitizer only symbolizes atoms it deems
+        # NL-like (>30 chars / punctuation / accents), so a short compound atom
+        # passes through underscored and ``type(heavy_rain)`` raises
+        # ``ParserException: Illegal characters in predicate definition``. Subtract
+        # the illegal chars: map every MlParser-illegal atom to a fresh legal
+        # symbol (``mp1, mp2, ...``), applied CONSISTENTLY to both the
+        # declarations and the formula bodies so the KB stays sound (no two
+        # distinct atoms collapse to one symbol). Already-legal atoms are kept
+        # verbatim — minimal change, anti-pendule.
         _keyword_atoms = {
-            "forall", "exists", "true", "false", "type", "prop",
-            "and", "or", "not", "implies",
+            "forall",
+            "exists",
+            "true",
+            "false",
+            "type",
+            "prop",
+            "and",
+            "or",
+            "not",
+            "implies",
         }
+        _atom_re = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+        _mlparser_legal_re = re.compile(r"^[a-zA-Z][a-zA-Z0-9]*$")
+        # Reserve the already-legal atom names so generated ``mpN`` symbols never
+        # collide with a real atom that is already MlParser-legal.
+        _legal_atoms = {
+            tok
+            for f in kb_formulas
+            for tok in _atom_re.findall(str(f))
+            if tok not in _keyword_atoms and _mlparser_legal_re.match(tok)
+        }
+        _atom_symbol: Dict[str, str] = {}
+        _symbol_counter = 0
+
+        def _legal_symbol(atom: str) -> str:
+            """Map a modal atom to an MlParser-legal identifier (memoized)."""
+            nonlocal _symbol_counter
+            if atom in _keyword_atoms or _mlparser_legal_re.match(atom):
+                return atom
+            if atom not in _atom_symbol:
+                _symbol_counter += 1
+                candidate = f"mp{_symbol_counter}"
+                while candidate in _legal_atoms:
+                    _symbol_counter += 1
+                    candidate = f"mp{_symbol_counter}"
+                _atom_symbol[atom] = candidate
+            return _atom_symbol[atom]
+
+        kb_formulas = [
+            _atom_re.sub(lambda m: _legal_symbol(m.group(0)), str(f))
+            for f in kb_formulas
+        ]
         _seen_atoms: Dict[str, None] = {}
         for f in kb_formulas:
-            for tok in re.findall(r"[A-Za-z_][A-Za-z0-9_]*", str(f)):
+            for tok in _atom_re.findall(str(f)):
                 if tok not in _keyword_atoms and tok not in _seen_atoms:
                     _seen_atoms[tok] = None
         _declarations = [f"type({atom})" for atom in _seen_atoms]

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_invoke_modal_logic_reaches_solver.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_invoke_modal_logic_reaches_solver.py
@@ -123,6 +123,48 @@ class TestInvokeModalLogicReachesSolver:
         )
         assert result.get("solver") == "tweety"
 
+    async def test_nl_translations_compound_atoms_decide_true(self, jvm, tweety_solver):
+        """#1227: a modal KB built from nl_to_logic translations whose atoms are
+        COMPOUND (underscored, e.g. ``heavy_rain``) must still reach
+        SimpleMlReasoner and decide. The pre-#1227 nl-path declared
+        ``type(heavy_rain)`` verbatim — but MlParser's predicate grammar is
+        ``[a-zA-Z][a-zA-Z0-9]*`` (no underscores, stricter than Tweety PL), so it
+        raised ``ParserException`` → ``valid=None`` (degraded) on every real
+        corpus. The #1225 tests above use simple atoms (``rain``/``wet``) and so
+        MISS this gap; this test guards it. The fix symbolizes illegal atoms to
+        legal ``mpN`` identifiers consistently across declarations and bodies."""
+        result = await _invoke_modal_logic(
+            "ignored raw corpus",
+            {"phase_nl_to_logic_output": NL_COMPOUND_CONSISTENT_OUT},
+        )
+        assert result.get("valid") is True, (
+            f"#1227 REGRESSION: a consistent KB with compound (underscored) atoms "
+            f"must decide True; got valid={result.get('valid')!r}, "
+            f"solver={result.get('solver')!r}, message={result.get('message')!r}. "
+            f"A None means a compound atom leaked into type(...) and MlParser "
+            f"rejected the underscore."
+        )
+        assert result.get("solver") == "tweety"
+
+    async def test_nl_translations_compound_atoms_decide_false(
+        self, jvm, tweety_solver
+    ):
+        """#1227: an inconsistent KB whose atoms are compound (underscored) must
+        decide False — proving the symbol map is applied CONSISTENTLY (a single
+        compound atom ``heavy_rain`` and its negation ``!heavy_rain`` must map to
+        the SAME ``mpN`` symbol, else the contradiction would be lost and the KB
+        would look spuriously consistent)."""
+        result = await _invoke_modal_logic(
+            "ignored raw corpus",
+            {"phase_nl_to_logic_output": NL_COMPOUND_INCONSISTENT_OUT},
+        )
+        assert result.get("valid") is False, (
+            f"#1227 REGRESSION: an inconsistent KB with compound atoms must decide "
+            f"False (consistent symbolization preserves the contradiction); got "
+            f"valid={result.get('valid')!r}, message={result.get('message')!r}."
+        )
+        assert result.get("solver") == "tweety"
+
 
 # #1224 — nl_to_logic translation output (the shape _invoke_nl_to_logic returns).
 # The spectacular pipeline builds the modal KB from these translations (mirroring
@@ -141,6 +183,30 @@ NL_INCONSISTENT_OUT = {
     "translations": [
         {"formula": "rain", "is_valid": True, "logic_type": "propositional"},
         {"formula": "!rain", "is_valid": True, "logic_type": "propositional"},
+    ],
+    "valid_count": 2,
+}
+
+# #1227 — nl_to_logic translations whose atoms are COMPOUND (underscored), the
+# shape real extraction emits (PLFormulaSanitizer leaves short compound atoms
+# underscored; MlParser's [a-zA-Z][a-zA-Z0-9]* grammar then rejects them). Pre-fix
+# these gave valid=None (degraded) on every corpus; the fix symbolizes them to
+# legal mpN identifiers. Privacy HARD: synthetic atoms only, 0 corpus.
+NL_COMPOUND_CONSISTENT_OUT = {
+    "translations": [
+        {
+            "formula": "heavy_rain => wet_ground",
+            "is_valid": True,
+            "logic_type": "propositional",
+        },
+        {"formula": "heavy_rain", "is_valid": True, "logic_type": "propositional"},
+    ],
+    "valid_count": 2,
+}
+NL_COMPOUND_INCONSISTENT_OUT = {
+    "translations": [
+        {"formula": "heavy_rain", "is_valid": True, "logic_type": "propositional"},
+        {"formula": "!heavy_rain", "is_valid": True, "logic_type": "propositional"},
     ],
     "valid_count": 2,
 }


### PR DESCRIPTION
## Context

Modal-track next notch, surfaced by **FP-15 #1226** (formal-richness matrix re-run post-#1225). After #1225 made `_invoke_modal_logic` build the modal KB from `nl_to_logic` translations (fixing the FP-14 raw-corpus parse failures), the modal cell stayed `degraded` (`valid=None`, `verdict="tweety"`) on all 3 corpora for a **new, distinct cause**: `MlParser` rejects the **compound predicate names** real extraction emits.

## Root cause

`MlParser`'s predicate grammar is `[a-zA-Z][a-zA-Z0-9]*` — **no underscores** — stricter than Tweety PL's `[a-zA-Z_][a-zA-Z0-9_]*` (which `PLFormulaSanitizer` targets). Real `nl_to_logic` extraction produces compound atoms with underscores (e.g. `heavy_rain`). The sanitizer only symbolizes atoms it deems NL-like (>30 chars / punctuation / accents), so a short compound atom passes through underscored, and `type(heavy_rain)` raises `ParserException: Illegal characters in predicate definition`.

## Fix (anti-pendule — subtract the illegal chars)

In the nl-path of `_invoke_modal_logic`, map every MlParser-illegal atom to a fresh legal symbol (`mp1, mp2, ...`), applied **consistently** to both the `type(...)` declarations and the formula bodies so the KB stays sound (no two distinct atoms collapse to one symbol → no spurious consistency). Already-legal atoms are kept verbatim (minimal change). The direct-formulas path (hand-written KBs, tests) is untouched.

This is option 2 (symbolize) from the issue, not option 1 (strip underscores) — strip risks collisions; symbolize with a name→symbol map removes that risk, mirroring PL/FOL.

## Verify-the-verification (FP-13 lesson — runtime, not classifier)

Live-JVM probe confirmed **both** the bug and the fix:

| KB (synthetic compound atoms) | pre-fix | post-fix |
|---|---|---|
| `heavy_rain => wet_ground, heavy_rain` (consistent) | `valid=None` (ParserException) | `valid=True` solver=tweety |
| `heavy_rain, !heavy_rain` (inconsistent) | `valid=None` (ParserException) | `valid=False` solver=tweety |

Two new integration tests guard compound-atom KBs — the #1225 tests used simple atoms (`rain`/`wet`) and **missed** this gap. The inconsistent-compound test specifically proves the symbol map is applied consistently (the atom and its negation map to the same `mpN`, preserving the contradiction).

## Validation

- `mypy --strict argumentation_analysis/orchestration/invoke_callables.py` → **clean** (CI gate).
- **6/6** modal integration tests (4 existing #1219/#1224 + 2 new #1227) pass.
- **3** unit nl-kb + **5** fp11 roundtrip tests pass — no regression (`test_direct_formulas_path_unchanged` confirms the direct path is untouched).
- `black` clean.

## Privacy HARD

Synthetic atoms only (`heavy_rain`/`wet_ground`), 0 corpus token. Diff scanned for entity leaks (lesson R463 — prose ParserException can leak corpus): clean.

## Modal track

`#1219` solver gap → `#1224`/`#1225` KB-source → FP-15 #1226 (measurement, surfaced this) → **#1227 predicate-name normalization** (this PR). The modal cell should move `degraded` → `real-verdict` on the next matrix re-run.

Closes #1227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)