### PR TITLE
fix(logic): #1204 sentinel guard for Tweety→EProver delivery contract (anti-théâtre)

### DIFF
--- a/argumentation_analysis/agents/core/logic/fol_handler.py
+++ b/argumentation_analysis/agents/core/logic/fol_handler.py
@@ -28,6 +28,61 @@ def _get_eprover_path() -> "str | None":
         return None
 
 
+# Cache: eprover binary path -> bool (delivery contract verified on this platform).
+# The sentinel is a one-off subprocess per binary, not per-query overhead.
+_EPROVER_DELIVERY_RELIABLE: "dict[str, bool]" = {}
+
+
+def _eprover_delivery_is_reliable(reasoner, eprover_path: str) -> bool:
+    """Anti-théâtre sentinel guard for the Tweety->EProver delivery contract (#1019, #1204).
+
+    Tweety's ``EFOLReasoner`` builds the command ``<eprover> --auto-schedule
+    --tptp3-format <file>`` and runs it through ``NativeShell`` via
+    ``Runtime.exec(String)`` (the fragile, non-portable single-String overload
+    that re-tokenises on whitespace). On some platform/E-version combinations
+    (firsthand-observed on Linux with E 3.x, #1204) the problem file never
+    reaches the binary — E reads empty input, proves the *empty* theory
+    ``Satisfiable`` and a genuinely **inconsistent** KB is reported *consistent*.
+    That is a fabricated verdict, exactly the failure #1019 forbids.
+
+    Before trusting any eprover verdict, run a known-inconsistent sentinel
+    ``{P(a), !P(a)}`` through the SAME reasoner. If the contradiction is not
+    detected, the delivery is broken here and eprover must not be trusted — the
+    caller raises so ``fol_check_consistency`` falls back to the in-JVM Tweety
+    reasoner instead of serving a fabricated answer. Result cached per path.
+
+    Returns True iff the sentinel is correctly reported inconsistent.
+    """
+    cached = _EPROVER_DELIVERY_RELIABLE.get(eprover_path)
+    if cached is not None:
+        return cached
+    reliable = False
+    try:
+        FolParser = jpype.JClass("org.tweetyproject.logics.fol.parser.FolParser")
+        sentinel = FolParser().parseBeliefBase(
+            "human = {a}\ntype(P(human))\n\nP(a)\n!P(a)\n"
+        )
+        probe_parser = FolParser()
+        probe_parser.setSignature(sentinel.getMinimalSignature())
+        contradiction = probe_parser.parseFormula("-")
+        # query returns True iff the KB entails the contradiction (= inconsistent).
+        reliable = bool(reasoner.query(sentinel, contradiction))
+    except Exception as e:  # parser/JVM hiccup -> unreliable, fail loud
+        logger.error(
+            f"EProver sentinel self-check raised ({e}); treating eprover as unreliable."
+        )
+        reliable = False
+    _EPROVER_DELIVERY_RELIABLE[eprover_path] = reliable
+    if not reliable:
+        logger.error(
+            "EProver sentinel self-check FAILED: known-inconsistent {P(a),!P(a)} "
+            "was not reported inconsistent — the problem is not reaching the solver "
+            "on this platform (Tweety<->E delivery contract broken, #1204). EProver "
+            "verdicts cannot be trusted here; falling back to the in-JVM reasoner."
+        )
+    return reliable
+
+
 class FOLHandler:
     """
     Handles First-Order Logic (FOL) operations using either TweetyProject or Prover9,
@@ -290,7 +345,9 @@ class FOLHandler:
                 self.logger.warning(
                     f"Prover9 unavailable ({e}), falling back to Tweety FOL reasoner"
                 )
-                return await self._fol_check_consistency_with_tweety_fallback(belief_set)
+                return await self._fol_check_consistency_with_tweety_fallback(
+                    belief_set
+                )
         elif settings.solver == SolverChoice.EPROVER:
             try:
                 return await self._fol_check_consistency_with_eprover(belief_set)
@@ -298,7 +355,9 @@ class FOLHandler:
                 self.logger.warning(
                     f"EProver unavailable ({e}), falling back to Tweety FOL reasoner"
                 )
-                return await self._fol_check_consistency_with_tweety_fallback(belief_set)
+                return await self._fol_check_consistency_with_tweety_fallback(
+                    belief_set
+                )
         else:
             return await self._fol_check_consistency_with_tweety(belief_set)
 
@@ -413,6 +472,17 @@ class FOLHandler:
             )
             reasoner = EFOLReasoner(JString(eprover_path))
 
+            # #1204 anti-théâtre guard: verify the Tweety->E delivery contract
+            # actually carries the problem to the binary on this platform before
+            # trusting any verdict. A broken contract silently returns
+            # "consistent" on an inconsistent KB (fabrication, #1019).
+            if not _eprover_delivery_is_reliable(reasoner, eprover_path):
+                raise RuntimeError(
+                    "EProver delivery contract broken on this platform "
+                    "(sentinel {P(a),!P(a)} not reported inconsistent, #1204) — "
+                    "refusing to serve a possibly-fabricated FOL verdict."
+                )
+
             # Check consistency by querying the bottom/contradiction symbol "-"
             local_parser = jpype.JClass(
                 "org.tweetyproject.logics.fol.parser.FolParser"
@@ -444,7 +514,10 @@ class FOLHandler:
 
         if settings.solver == SolverChoice.PROVER9:
             try:
-                return self._fol_query_with_prover9(belief_set, query_formula_str), False
+                return (
+                    self._fol_query_with_prover9(belief_set, query_formula_str),
+                    False,
+                )
             except RuntimeError as e:
                 logger.warning(
                     f"Prover9 unavailable ({e}), falling back to Tweety FOL query"
@@ -452,7 +525,10 @@ class FOLHandler:
                 return self._fol_query_with_tweety(belief_set, query_formula_str), True
         elif settings.solver == SolverChoice.EPROVER:
             try:
-                return self._fol_query_with_eprover(belief_set, query_formula_str), False
+                return (
+                    self._fol_query_with_eprover(belief_set, query_formula_str),
+                    False,
+                )
             except RuntimeError as e:
                 logger.warning(
                     f"EProver unavailable ({e}), falling back to Tweety FOL query"

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_fol_handler.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_fol_handler.py
@@ -31,6 +31,7 @@ class TestFOLSolverFallback:
             mock_settings.solver.value = "eprover"
             # Force tweety path for constructor
             from argumentation_analysis.core.config import SolverChoice
+
             mock_settings.solver = SolverChoice.TWEETY
             handler = FOLHandler(initializer_instance=mock_initializer)
             # Now override to eprover for test
@@ -71,7 +72,9 @@ class TestFOLSolverFallback:
         assert len(result) == 3
         is_consistent, msg, solver_fallback = result
         assert is_consistent is True
-        assert solver_fallback is True, "solver_fallback flag must be True when degraded"
+        assert (
+            solver_fallback is True
+        ), "solver_fallback flag must be True when degraded"
         assert "Tweety" in msg
 
     @pytest.mark.asyncio
@@ -150,7 +153,9 @@ class TestFOLSolverFallback:
         # Result is (entailed, solver_fallback)
         entailed, solver_fallback = result
         assert entailed is True
-        assert solver_fallback is True, "solver_fallback must be True on query degradation"
+        assert (
+            solver_fallback is True
+        ), "solver_fallback must be True on query degradation"
 
     def test_eprover_present_no_query_fallback(self, handler):
         """When eprover is available, query returns (entailed, False)."""
@@ -171,7 +176,9 @@ class TestFOLSolverFallback:
 
         entailed, solver_fallback = result
         assert entailed is True
-        assert solver_fallback is False, "solver_fallback must be False when eprover works"
+        assert (
+            solver_fallback is False
+        ), "solver_fallback must be False when eprover works"
 
     @pytest.mark.asyncio
     async def test_both_solvers_absent_raises(self, handler):
@@ -197,7 +204,9 @@ class TestFOLSolverFallback:
                 ):
                     belief_set = MagicMock()
                     belief_set.size.return_value = 2
-                    with pytest.raises(RuntimeError, match="FOL consistency check failed"):
+                    with pytest.raises(
+                        RuntimeError, match="FOL consistency check failed"
+                    ):
                         await handler.fol_check_consistency(belief_set)
 
 
@@ -237,17 +246,17 @@ class TestFOLCheckConsistencyFailLoud:
         # initializer present but get_reasoner raises (simulates a Tweety
         # internal failure on the contradiction query).
         handler._initializer_instance = MagicMock()
-        handler._initializer_instance.get_reasoner.side_effect = RuntimeError(
-            "boom"
-        )
+        handler._initializer_instance.get_reasoner.side_effect = RuntimeError("boom")
 
-        with patch.object(handler, "create_belief_set_from_string", return_value=java_bs):
+        with patch.object(
+            handler, "create_belief_set_from_string", return_value=java_bs
+        ):
             result = handler.check_consistency(java_bs)
 
         is_consistent, msg = result
-        assert is_consistent is None, (
-            "Degraded check must return None, not fabricate a True verdict"
-        )
+        assert (
+            is_consistent is None
+        ), "Degraded check must return None, not fabricate a True verdict"
         assert "degraded" in msg.lower() or "no consistency verdict" in msg.lower()
 
     def test_no_initializer_returns_degraded_not_true(self, handler):
@@ -256,7 +265,9 @@ class TestFOLCheckConsistencyFailLoud:
         java_bs = MagicMock()
         java_bs.size.return_value = 3
 
-        with patch.object(handler, "create_belief_set_from_string", return_value=java_bs):
+        with patch.object(
+            handler, "create_belief_set_from_string", return_value=java_bs
+        ):
             result = handler.check_consistency(java_bs)
 
         is_consistent, msg = result
@@ -322,7 +333,9 @@ class TestTweetyBridgeModalDispatch:
             "Tweety Result (SimpleMlReasoner): Modal Query 'p' is ACCEPTED (True)."
         )
         with patch.object(
-            TweetyBridge, "modal_handler", new_callable=lambda: property(lambda self: mock_modal)
+            TweetyBridge,
+            "modal_handler",
+            new_callable=lambda: property(lambda self: mock_modal),
         ):
             bridge = TweetyBridge.__new__(TweetyBridge)  # bypass JVM __init__
             accepted, msg = bridge.execute_modal_query("kb", "p", logic_type="K")
@@ -339,9 +352,87 @@ class TestTweetyBridgeModalDispatch:
         mock_modal = MagicMock()
         mock_modal.is_modal_kb_consistent.return_value = (True, "ok")
         with patch.object(
-            TweetyBridge, "modal_handler", new_callable=lambda: property(lambda self: mock_modal)
+            TweetyBridge,
+            "modal_handler",
+            new_callable=lambda: property(lambda self: mock_modal),
         ):
             bridge = TweetyBridge.__new__(TweetyBridge)
             result = bridge.check_consistency("kb", "S5")
         mock_modal.is_modal_kb_consistent.assert_called_once_with("kb")
         assert result == (True, "ok")
+
+
+# ──── #1204 anti-théâtre: EProver delivery-contract sentinel guard ────
+
+
+class TestEProverDeliverySentinelGuard:
+    """#1204 / #1019: Tweety's ``EFOLReasoner`` ships the problem to the binary
+    via ``Runtime.exec(String)`` — on some platform/E-version combos (Linux,
+    E 3.x) the file never reaches the solver, E proves the *empty* theory
+    ``Satisfiable`` and a genuinely **inconsistent** KB is reported *consistent*
+    (a fabricated verdict, #1019). ``_eprover_delivery_is_reliable`` runs a
+    known-inconsistent sentinel ``{P(a),!P(a)}`` through the SAME reasoner and
+    refuses to trust eprover when the contradiction is not detected, so the
+    caller falls back to the in-JVM reasoner instead of fabricating."""
+
+    def _clear_cache(self):
+        from argumentation_analysis.agents.core.logic import fol_handler
+
+        fol_handler._EPROVER_DELIVERY_RELIABLE.clear()
+
+    def test_reliable_when_sentinel_reported_inconsistent(self):
+        """Sentinel correctly detected inconsistent (query truthy) → reliable."""
+        from argumentation_analysis.agents.core.logic import fol_handler
+
+        self._clear_cache()
+        reasoner = MagicMock()
+        reasoner.query.return_value = True  # contradiction entailed = inconsistent
+        with patch.object(fol_handler.jpype, "JClass", return_value=MagicMock()):
+            assert (
+                fol_handler._eprover_delivery_is_reliable(reasoner, "/path/eprover")
+                is True
+            )
+
+    def test_unreliable_when_sentinel_not_inconsistent(self):
+        """Broken delivery: sentinel reported consistent (query falsy) → unreliable.
+        This is the exact Linux/E-3.x fabrication the guard must catch."""
+        from argumentation_analysis.agents.core.logic import fol_handler
+
+        self._clear_cache()
+        reasoner = MagicMock()
+        reasoner.query.return_value = (
+            False  # contradiction NOT entailed = fabricated "consistent"
+        )
+        with patch.object(fol_handler.jpype, "JClass", return_value=MagicMock()):
+            assert (
+                fol_handler._eprover_delivery_is_reliable(reasoner, "/path/eprover")
+                is False
+            )
+
+    def test_unreliable_when_sentinel_raises(self):
+        """A parser/JVM hiccup during the self-check → fail-loud unreliable, never trust."""
+        from argumentation_analysis.agents.core.logic import fol_handler
+
+        self._clear_cache()
+        reasoner = MagicMock()
+        reasoner.query.side_effect = RuntimeError("JVM boom")
+        with patch.object(fol_handler.jpype, "JClass", return_value=MagicMock()):
+            assert (
+                fol_handler._eprover_delivery_is_reliable(reasoner, "/path/eprover")
+                is False
+            )
+
+    def test_result_is_cached_per_path(self):
+        """The sentinel is a one-off per binary path; the verdict is cached so the
+        reasoner is probed only once (not per query)."""
+        from argumentation_analysis.agents.core.logic import fol_handler
+
+        self._clear_cache()
+        reasoner = MagicMock()
+        reasoner.query.return_value = True
+        with patch.object(fol_handler.jpype, "JClass", return_value=MagicMock()):
+            fol_handler._eprover_delivery_is_reliable(reasoner, "/path/eprover")
+            # second call must NOT re-probe (cache hit)
+            fol_handler._eprover_delivery_is_reliable(reasoner, "/path/eprover")
+        assert reasoner.query.call_count == 1
+        assert fol_handler._EPROVER_DELIVERY_RELIABLE["/path/eprover"] is True


### PR DESCRIPTION
## Problem (#1204, #1019)

Tweety's `EFOLReasoner` ships the FOL problem to the binary via
`Runtime.exec(String)` — the fragile single-String overload that re-tokenises on
whitespace. On some platform/E-version combos (firsthand: Linux + E 3.x) the
problem file never reaches the solver: **E reads empty input, proves the empty
theory `Satisfiable`, and a genuinely inconsistent KB is reported `consistent`.**
That is a fabricated verdict — the FOL axis silently "decides" with no reasoning,
exactly the théâtre #1019 forbids. Works on Windows / E 2.0; fabricates on
Linux / E 3.x.

## Diagnosis (firsthand)

- Decompiled `EFOLReasoner` bytecode from **both** the 1.28 and 1.29 jars
  (`javap -c -p -v`) → **identical** (same `--auto-schedule` recipe, same
  `Runtime.exec(String)` delivery, same proof-marker parsing). **A Tweety
  version bump does NOT fix this** — the defect is in the exec delivery, not the
  reasoner version. So the fix is platform-agnostic and patches no JAR.

## Fix

Before trusting any eprover verdict, run a known-inconsistent sentinel
`{P(a),!P(a)}` through the **same** reasoner (`_eprover_delivery_is_reliable`,
cached per binary path = one probe, not per-query). If the contradiction is not
detected, the delivery is broken on this platform →
`_fol_check_consistency_with_eprover` raises → the **existing** RuntimeError
fallback engages the in-JVM `SimpleFolReasoner` instead of fabricating.

## Verification (firsthand, Windows / E 2.0)

| Scenario | Result |
|---|---|
| Sentinel reliable (real E 2.0) | inconsistent KB → `(False, inconsistent)`, consistent KB → `(True, consistent)` — **no regression**, eprover stays active |
| Broken delivery simulated (sentinel forced to fail) | verdict stays honest `inconsistent` via fallback — **never fabricated `consistent`** |

4 new unit tests: reliable / broken-delivery / self-check-raises / cache-per-path.
Full `test_fol_handler.py` suite: **17 passed**. black-clean.

## Still to verify (dispatched)

The **trip path on real Linux/E-3.x** (sentinel actually fails → fallback) can
only be firsthand-confirmed on a Linux box with E 3.x. Dispatched to a worker
with that environment. The Windows path is fully verified here.

Epic #1191 (formal depth-parity blind-spot elimination). Refs #1204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)