### PR TITLE
docs(fp5): FP-16 #1231 re-run matrix post-#1230; modal residual = SimpleMlReasoner OOM, not grammar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,8 @@ playwright-timeout-screenshot-*.png
 results/
 traces/
 text_cache/
+# Scratch run logs (may contain corpus-derived plaintext — never track). #1231
+.cache/
 data/
 !data/.gitkeep
 !data/extract_sources.json.gz.enc

--- a/docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md
+++ b/docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md
@@ -1,11 +1,12 @@
 # FP-5 #1196 — Multi-corpus formal-richness matrix (post FP-10/11/12 + classifier fix)
 
-**Track**: FP-5 #1196 / FP-13 #1218 / FP-14 #1222 / FP-15 #1226 (Epic #1191 depth-parity) ·
+**Track**: FP-5 #1196 / FP-13 #1218 / FP-14 #1222 / FP-15 #1226 / FP-16 #1231 (Epic #1191 depth-parity) ·
 **Type**: measurement matrix · **Author**: po-2025 · **Date**: 2026-06-22 ·
-**Base**: `b118f2da` (post FP-10/11/12 + #1219 modal-pipeline-solver fix +
-#1224/#1225 NL→modal-KB-source fix) + FP-14 modal-cell classifier correction.
-The FP-13/FP-14 bodies are preserved as provenance; the **FP-15 Update** section
-supersedes the modal findings.
+**Base**: `8c6714f2` (post FP-10/11/12 + #1219 modal-pipeline-solver fix +
+#1224/#1225 NL→modal-KB-source fix + **#1227/#1230 modal predicate-name
+normalization**) + FP-14 modal-cell classifier correction.
+The FP-13/FP-14/FP-15 bodies are preserved as provenance; the **FP-16 Update**
+section supersedes the modal findings.
 
 > Aggregate-only. Counts/classes/verdicts only — no corpus content. Opaque IDs
 > (`doc_A/B/C`). Raw JSON metrics stay local under gitignored
@@ -46,6 +47,118 @@ degraded-by-default on axes the corpus supports. The two `empty` cells (DeLP,
 modal) are honest-absent — the corpus has no defeasible program (DeLP) / no
 solver is loaded in the pipeline environment (modal). Neither is dressed as
 decided.
+
+## FP-16 Update (2026-06-22, base `8c6714f2` post-#1227/#1230 predicate-name normalization)
+
+**Status: #1230 (predicate-name normalization, the FP-15 residual) is MERGED, and
+the re-run confirms it is upstream-correct — the modal KB now PARSES cleanly. Modal
+still does NOT reach a real verdict, but the residual has moved OFF the parser
+entirely onto the *reasoner* layer: `SimpleMlReasoner.query` raises
+`java.lang.OutOfMemoryError` on the real KB.** `modal_fabricated_true: False` × 3
+(DoD met — no verdict dressed as decided). **This finding supersedes the
+earlier-drafted "MlParser tokenizer mismatch" hypothesis, which the firsthand
+verification REFUTED** (see "Verify-the-verification" below): the constructed KB
+parses with **zero** MlParser-illegal constructs.
+
+### Matrix re-run (3 corpora, base `8c6714f2`)
+
+| corpus | pipeline verdict | modal class | `modal_valid` | `modal_solver` | `modal_fabricated_true` |
+| --- | --- | --- | --- | --- | --- |
+| doc_A (hard) | COMPLETED (563.6s) | **error** (modal phase FAILED — phase timeout) | None | None | **False** |
+| doc_C (standard) | TIMED_OUT_900s | **absent** (pipeline never reached modal) | None | None | **False** |
+| doc_B (large/stress) | hung past 1800s ceiling → killed | n/a (never reached modal) | None | None | **False** |
+
+Only **doc_A reaches the modal phase**; doc_C/doc_B time out *upstream* of modal
+(a pipeline-throughput blocker, orthogonal to the modal layer — see note). So the
+modal residual is characterized on **doc_A**, the corpus that exercises the modal KB.
+
+> **doc_B hang (process-hygiene finding).** `asyncio.wait_for(timeout=1800)` cancels
+> the *await* but cannot interrupt an in-flight blocking JPype/JVM call, so doc_B ran
+> ~63 min past its ceiling without producing output and had to be killed. The harness
+> now supports `FP16_CORPORA=A` to re-run a single corpus without re-triggering this
+> hang; a hard per-corpus subprocess kill is the proper fix (follow-up). The same
+> mechanism explains doc_A's `status=failed` (below): an in-thread JVM call that
+> over-runs the phase ceiling cannot be cancelled, so the phase is marked FAILED.
+
+### Verify-the-verification — the residual is the REASONER, not the parser
+
+The first draft of this section blamed an "MlParser *tokenizer* mismatch" (URL /
+multi-word atoms reaching the parser). **Firsthand replay refuted it.** Replaying
+the real `nl_to_logic` translations through a verbatim copy of #1230's KB
+construction and the **live `MlParser`** shows the KB **parses** —
+`parseBeliefBase` → `org.tweetyproject.logics.ml.syntax.MlBeliefSet`, with
+**`distinct_illegal_constructs = 0`**. The URL/prose ParserExceptions in the draft
+were stale observations from a *pre-#1230 / raw-corpus* path, not this run. #1230
+genuinely closed the grammar layer.
+
+Driving the next step manually pins the real cause (privacy: classes/counts only,
+never corpus tokens):
+
+| step | observed |
+| --- | --- |
+| `parseBeliefBase(belief_set)` | OK → `MlBeliefSet` (KB is well-formed) |
+| `_build_contradiction_probe` | OK → `org.tweetyproject.logics.fol.syntax.Conjunction` |
+| `reasoner.query(belief_set, contradiction)` | **raises `java.lang.OutOfMemoryError`** |
+| `is_modal_kb_consistent` (full) | returns honest `(None, "could not be decided … reasoner unavailable")` — the OOM is caught, never fabricated |
+
+`SimpleMlReasoner` decides consistency by **naive Kripke-model enumeration**. Its
+memory scales (hyper-)exponentially in the number of atomic propositions. Synthetic
+control KBs confirm the threshold: a 2-atom propositional KB and a small genuinely
+modal KB (`[](rain => wet)`) both **decide** in <1s (`valid=True/False`); the real
+doc_A KB (12 atom declarations) **OOMs**. The #1225/#1230 integration tests passed
+precisely because they used tiny KBs (`rain`, `wet`) below this threshold.
+
+### Modal cell — full residual characterization by TYPE (anti-loop deliverable)
+
+The DoD asks, if modal still cannot decide, for the FULL remaining MlParser-illegal
+set enumerated by TYPE. **That set is empty** — the residual is no longer at the
+parser. Reported instead is the construct profile of the KB the reasoner OOMs on,
+classified by logical-construct TYPE (privacy: presence-counts only, no tokens):
+
+- **MlParser-illegal constructs:** `0` (grammar layer closed by #1227/#1230).
+- **Modal operators (`[]` / `<>`):** `0` — the `nl_to_logic` translations are all
+  `logic_type=propositional`. The modal phase is asked to decide a purely
+  propositional KB via the modal reasoner.
+- **Boolean-connective profile (per-formula presence):** implication ×1,
+  equivalence ×1, negation ×1, conjunction ×3, disjunction ×1, atom-only ×2
+  (6 formulas, 12 atoms). No quantifiers.
+- **Reasoner outcome:** `java.lang.OutOfMemoryError` from `SimpleMlReasoner.query`
+  → honest `valid=None`. In-pipeline the OOM-thrash over-runs the **180s** modal
+  phase ceiling → `status=failed` (the `error` cell).
+
+### Two distinct, both-honest residuals — neither is grammar
+
+1. **Reasoner blow-up (primary).** `SimpleMlReasoner` cannot decide a ~12-atom KB
+   without exhausting memory. Raising the timeout would not help (it OOMs, it does
+   not merely run long). Two viable fixes, neither applied here (out of scope for a
+   measurement PR): route 0-modal-operator (purely propositional) translations to
+   the PL/PySAT path that already DECIDES (`real-verdict`) instead of the modal
+   reasoner; and/or use a real modal prover (SPASS CLI) in place of the naive
+   enumerator.
+2. **Phase-timeout asymmetry (secondary).** The spectacular `modal` phase keeps
+   `timeout_seconds=180`, while the #705 fix that raised `pl`→420s and `fol`→600s
+   ("180s ceiling timed the phase out → failed_phases") was **never applied to
+   modal**. So even a deciding modal reasoner has a third the budget of `pl`/`fol`.
+   This converts the reasoner's honest `None` (degraded) into a `status=failed`
+   (`error`) cell under load.
+
+**Filed follow-up (#1231 → new issue):** route non-modal translations away from
+`SimpleMlReasoner`, and align the modal phase ceiling with `pl`/`fol`. Distinct from
+#1219 (solver reached), #1224/#1225 (KB source) and #1227/#1230 (predicate-name
+grammar) — this is the reasoner-scalability layer.
+
+### Modal track progression
+
+`#1219` solver gap (closed, FP-14) → `#1224/#1225` KB source (closed) → `#1227/#1230`
+predicate-name grammar (closed, FP-15) → **FP-16 measurement**: KB now parses
+cleanly; non-verdict for a *new, deeper* cause = `SimpleMlReasoner` OOM on real
+(propositional, multi-atom) KBs, plus a `180s` modal-phase ceiling never aligned
+with `pl`/`fol`. Each notch is independently verifiable in the run log; none is
+dressed as decided (`modal_fabricated_true: False` × 3). The convergent pattern
+holds — and this round it also corrected a drafted hypothesis the firsthand replay
+refuted (parser → reasoner), rather than shipping the plausible-but-wrong cause.
+
+---
 
 ## FP-15 Update (2026-06-22, base `b118f2da` post-#1225 NL→modal-KB-source fix)
 

--- a/docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md
+++ b/docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md
@@ -142,7 +142,7 @@ classified by logical-construct TYPE (privacy: presence-counts only, no tokens):
    This converts the reasoner's honest `None` (degraded) into a `status=failed`
    (`error`) cell under load.
 
-**Filed follow-up (#1231 → new issue):** route non-modal translations away from
+**Filed follow-up (#1234):** route non-modal translations away from
 `SimpleMlReasoner`, and align the modal phase ceiling with `pl`/`fol`. Distinct from
 #1219 (solver reached), #1224/#1225 (KB source) and #1227/#1230 (predicate-name
 grammar) — this is the reasoner-scalability layer.

--- a/scripts/run_fp16_modal_enum.py
+++ b/scripts/run_fp16_modal_enum.py
@@ -1,0 +1,409 @@
+"""FP-16 #1231 — re-run formal matrix post-#1230 + enumerate ALL remaining
+MlParser-illegal modal constructs in one diagnostic pass (Epic #1191).
+
+#1230 (main ``b5023ca8``) normalizes MlParser-illegal predicate names: every
+atom not matching the predicate grammar ``[a-zA-Z][a-zA-Z0-9]*`` is mapped to a
+fresh legal ``mpN`` symbol, consistently across ``type(...)`` declarations and
+formula bodies. This harness measures whether the modal cell finally moves
+``degraded``/``error`` → ``real-verdict`` on the 3 real corpora end-to-end — and
+if it still degrades, breaks the one-residual-per-round loop by enumerating the
+FULL remaining illegal set at once (scope step 3 of the issue).
+
+How the anti-loop enumeration works: ``MlParser.parseBeliefBase`` raises on the
+FIRST illegal construct and ``is_modal_kb_consistent`` catches it → ``valid=None``
+— so a plain re-run only ever surfaces ONE rejection per corpus. To get the whole
+set, this harness:
+  1. runs the real spectacular+full pipeline per corpus (the DoD matrix re-run),
+  2. takes the modal phase output's real ``formulas`` (the ``nl_to_logic``
+     translations the pipeline actually built its KB from),
+  3. replays them through a VERBATIM copy of the #1230 KB-construction logic
+     (kept byte-aligned with ``_invoke_modal_logic``'s nl-path),
+  4. validates the resulting belief base against the LIVE ``MlParser`` — first the
+     whole KB (matching the pipeline's ``valid``), then each ``type(...)``
+     declaration and each formula INDIVIDUALLY — so every rejection is captured,
+     not just the first the parser hit.
+
+Privacy HARD (R463 lesson — sharp): ParserException / "Illegal characters"
+excerpts echo raw corpus tokens verbatim — a leak BY CONSTRUCTION. This harness
+NEVER emits a real token: each illegal construct is classified by *type*
+(leading-digit / accented / underscore / multi-word / other-punctuation /
+reserved-token) with the real token held only in-memory. The corpus redact-filter
+from the FP-5 runner is reused over all stdout/logging. Raw per-construct dumps
+(if any) stay gitignored under ``evaluation/results/fp5/``.
+
+Anti-pendule: do NOT relabel ``degraded`` as ``real-verdict`` without a captured
+solver verdict; do NOT skip-everywhere. If modal still can't decide, the FULL
+enumerated residual set IS the deliverable.
+"""
+
+import os
+import re
+import sys
+import json
+import asyncio
+import time
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+# Reuse the FP-5 runner's redact infra, classifier, CAPABILITIES, CORPORA and
+# corpus loader — the matrix half of this harness IS the FP-5 matrix, so importing
+# guarantees identical classification. (Importing also installs the redact stream
+# + .env load as a module side effect — intended.)
+import run_fp5_formal_matrix as fp5  # noqa: E402
+
+RESULTS_DIR = fp5.RESULTS_DIR
+
+# ── #1230 KB construction — VERBATIM copy of _invoke_modal_logic's nl-path ──
+# Kept byte-aligned with argumentation_analysis/orchestration/invoke_callables.py
+# (~5763-5850). The enumeration is only faithful if this matches production; any
+# drift here would measure a different KB than the pipeline builds.
+_KEYWORD_ATOMS = {
+    "forall",
+    "exists",
+    "true",
+    "false",
+    "type",
+    "prop",
+    "and",
+    "or",
+    "not",
+    "implies",
+}
+_ATOM_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_MLPARSER_LEGAL_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9]*$")
+
+
+def _build_modal_kb_1230(nl_formulas: "list[str]") -> "tuple[str, list[str], list[str]]":
+    """Reproduce the #1230 nl-path: sanitize → map illegal atoms to mpN →
+    declare type(atom). Returns (belief_set_str, declarations, kb_formulas)."""
+    kb_formulas: "list[str]" = list(nl_formulas)
+    try:
+        from argumentation_analysis.agents.core.logic.pl_formula_sanitizer import (
+            PLFormulaSanitizer,
+        )
+
+        sanitizer = PLFormulaSanitizer()
+        san_result = sanitizer.sanitize_batch(nl_formulas)
+        if san_result.sanitized_formulas:
+            kb_formulas = san_result.sanitized_formulas
+    except Exception:
+        pass
+
+    _legal_atoms = {
+        tok
+        for f in kb_formulas
+        for tok in _ATOM_RE.findall(str(f))
+        if tok not in _KEYWORD_ATOMS and _MLPARSER_LEGAL_RE.match(tok)
+    }
+    _atom_symbol: "dict[str, str]" = {}
+    _symbol_counter = 0
+
+    def _legal_symbol(atom: str) -> str:
+        nonlocal _symbol_counter
+        if atom in _KEYWORD_ATOMS or _MLPARSER_LEGAL_RE.match(atom):
+            return atom
+        if atom not in _atom_symbol:
+            _symbol_counter += 1
+            candidate = f"mp{_symbol_counter}"
+            while candidate in _legal_atoms:
+                _symbol_counter += 1
+                candidate = f"mp{_symbol_counter}"
+            _atom_symbol[atom] = candidate
+        return _atom_symbol[atom]
+
+    kb_formulas = [
+        _ATOM_RE.sub(lambda m: _legal_symbol(m.group(0)), str(f)) for f in kb_formulas
+    ]
+    _seen: "dict[str, None]" = {}
+    for f in kb_formulas:
+        for tok in _ATOM_RE.findall(str(f)):
+            if tok not in _KEYWORD_ATOMS and tok not in _seen:
+                _seen[tok] = None
+    declarations = [f"type({atom})" for atom in _seen]
+    belief_set_str = "\n".join(declarations + [str(f) for f in kb_formulas])
+    return belief_set_str, declarations, kb_formulas
+
+
+# ── Construct classification (opaque — never emits a real token) ──
+_TWEETY_RESERVED = _KEYWORD_ATOMS | {"type"}
+
+
+def _classify_construct(tok: str) -> str:
+    """Classify an MlParser-illegal token by construct TYPE (privacy: the token
+    itself is never returned/logged, only its class)."""
+    if _MLPARSER_LEGAL_RE.match(tok):
+        return "legal"
+    if tok and tok[0].isdigit():
+        return "leading-digit"
+    if any(ord(c) > 127 for c in tok):
+        return "accented/non-ascii"
+    if "_" in tok:
+        return "underscore"  # should be 0 post-#1230
+    if any(c.isspace() for c in tok):
+        return "multi-word"
+    if tok in _TWEETY_RESERVED:
+        return "reserved-token"
+    return "other-punctuation"
+
+
+def _illegal_tokens_in(text: str) -> "list[str]":
+    """All whitespace/operator-delimited tokens in a formula body that are NOT
+    MlParser-legal predicate identifiers (and not pure modal/logical operators)."""
+    # split on operators + parens + whitespace; keep word-ish chunks
+    raw = re.split(r"[\s()\[\]<>!&|=>~,;]+", text)
+    bad = []
+    for t in raw:
+        t = t.strip()
+        if not t or t in _KEYWORD_ATOMS:
+            continue
+        if _MLPARSER_LEGAL_RE.match(t):
+            continue
+        bad.append(t)
+    return bad
+
+
+def _enumerate_modal_rejections(
+    nl_formulas: "list[str]", modal_parser, jpype_mod
+) -> dict:
+    """Replay the #1230 KB through the live MlParser; enumerate EVERY remaining
+    illegal construct.
+
+    Two complementary signals:
+      * ``kb_parses`` — the AUTHORITATIVE decidability signal: does the full
+        constructed belief base parse? This matches the pipeline's modal
+        ``valid`` non-None-ness (same formulas, same #1230 construction, same
+        ``parseBeliefBase``). True ⇒ modal decides.
+      * ``illegal_by_type`` — a STATIC scan of the constructed KB for any
+        predicate-position token that violates the MlParser grammar
+        ``[a-zA-Z][a-zA-Z0-9]*`` after the #1230 mpN-substitution. When #1230
+        fully covers the corpus this is empty and agrees with ``kb_parses=True``;
+        when a residual class survives (a construct ``_atom_re`` never captured —
+        accents, leading digits, stray punctuation), ``kb_parses=False`` and this
+        lists the FULL residual set by type — the anti-loop deliverable.
+
+    A lone ``type(...)`` line is NOT a valid standalone belief base (MlParser
+    needs formulas too), so we do NOT test declarations individually (that gave
+    false "bad declaration" positives). The whole-KB parse + static token scan is
+    both correct and faithful. No raw token ever leaves this function — only
+    construct *types*.
+    """
+    belief_set_str, declarations, kb_formulas = _build_modal_kb_1230(nl_formulas)
+    StringReader = jpype_mod.JClass("java.io.StringReader")
+
+    whole_parses = True
+    parse_error_class = None
+    try:
+        modal_parser.parseBeliefBase(StringReader(belief_set_str))
+    except Exception as e:  # privacy: class name only — the message echoes tokens
+        whole_parses = False
+        parse_error_class = type(e).__name__
+
+    # Static residual scan over the CONSTRUCTED KB (post #1230 substitution).
+    distinct_illegal: "set[str]" = set()  # in-memory only, never emitted
+    for decl in declarations:
+        m = re.match(r"^type\((.+)\)$", decl)
+        if m and not _MLPARSER_LEGAL_RE.match(m.group(1)):
+            distinct_illegal.add(m.group(1))
+    for f in kb_formulas:
+        for tok in _illegal_tokens_in(str(f)):
+            distinct_illegal.add(tok)
+
+    type_counts: "dict[str, int]" = {}
+    for tok in distinct_illegal:
+        cls = _classify_construct(tok)
+        type_counts[cls] = type_counts.get(cls, 0) + 1
+
+    return {
+        "kb_parses": whole_parses,
+        "parse_error_class": parse_error_class,
+        "n_declarations": len(declarations),
+        "n_formulas": len(kb_formulas),
+        "distinct_illegal_constructs": len(distinct_illegal),
+        "illegal_by_type": type_counts,  # opaque: construct-type → count
+    }
+
+
+async def run_corpus(label: str, idx: int, timeout: int, corpus_texts: dict) -> dict:
+    """Run the spectacular+full pipeline (DoD matrix re-run), classify all cells
+    with the FP-5 classifier, and run the modal anti-loop enumeration."""
+    from argumentation_analysis.orchestration.unified_pipeline import (
+        run_unified_analysis,
+    )
+
+    text = fp5.load_corpus_text(label, idx)
+    corpus_texts[label] = text
+    print(
+        f"[FP-16] doc_{label}: {len(text)} chars | spectacular+full | ceiling {timeout}s"
+    )
+
+    t0 = time.time()
+    verdict = "UNKNOWN"
+    result: dict = {}
+    try:
+        result = await asyncio.wait_for(
+            run_unified_analysis(
+                text, workflow_name="spectacular", context={"fallacy_tier": "full"}
+            ),
+            timeout=float(timeout),
+        )
+        verdict = "COMPLETED"
+    except asyncio.TimeoutError:
+        verdict = f"TIMED_OUT_{timeout}s"
+        print(f"[FP-16] doc_{label} TIMED OUT after {timeout}s.")
+    except Exception as exc:
+        verdict = f"ERROR:{type(exc).__name__}"
+        print(f"[FP-16] doc_{label} {verdict}: {fp5._redact(str(exc))[:160]}")
+    elapsed = time.time() - t0
+
+    # Matrix cells via the SAME classifier as FP-5 (identical classification).
+    matrix = {}
+    for cap, phase, count_key in fp5.CAPABILITIES:
+        cls, ev = fp5._classify_capability(result, phase, count_key)
+        matrix[cap] = {"class": cls, "evidence": ev}
+
+    # Modal cell verdict shape (from the real pipeline output).
+    modal_pr = fp5._phase(result, "modal")
+    modal_out = getattr(modal_pr, "output", None) if modal_pr else None
+    modal_valid = modal_out.get("valid") if isinstance(modal_out, dict) else None
+    modal_solver = modal_out.get("solver") if isinstance(modal_out, dict) else None
+    modal_fabricated_true = bool(
+        isinstance(modal_out, dict) and modal_out.get("valid") is True
+    )
+
+    # Anti-loop enumeration: replay the REAL modal formulas through #1230 + live MlParser.
+    enum: dict = {"ran": False, "reason": "no modal formulas"}
+    # Source the KB-input formulas the SAME way production does (#1224, invoke_callables
+    # ~5755-5761): the valid ``nl_to_logic`` translations. These exist even when the
+    # modal PHASE itself failed (``status=failed``) before exposing its own
+    # ``formulas`` — which is precisely the FP-16 case (modal raises on a URL /
+    # prose construct). The old path read ``modal_out["formulas"]`` only, so the
+    # enumeration never ran on the very corpora where modal can't decide.
+    nl_formulas = []
+    nl_pr = fp5._phase(result, "nl_to_logic")
+    nl_out = getattr(nl_pr, "output", None) if nl_pr else None
+    if isinstance(nl_out, dict):
+        nl_formulas = [
+            str(t["formula"])
+            for t in (nl_out.get("translations") or [])
+            if isinstance(t, dict) and t.get("is_valid") and t.get("formula")
+        ]
+    if not nl_formulas and isinstance(modal_out, dict):
+        # Fallback: a modal phase that DID expose formulas (direct-KB / older path).
+        nl_formulas = [str(f) for f in (modal_out.get("formulas") or []) if str(f).strip()]
+    if nl_formulas:
+        try:
+            import jpype
+            from argumentation_analysis.core.jvm_setup import initialize_jvm
+            from argumentation_analysis.agents.core.logic.tweety_initializer import (
+                TweetyInitializer,
+            )
+
+            initialize_jvm()
+            initz = TweetyInitializer()
+            initz.initialize_modal_components()
+            modal_parser = initz.get_modal_parser()
+            if modal_parser is not None:
+                enum = _enumerate_modal_rejections(nl_formulas, modal_parser, jpype)
+                enum["ran"] = True
+            else:
+                enum = {"ran": False, "reason": "modal parser None"}
+        except Exception as exc:
+            enum = {"ran": False, "reason": f"{type(exc).__name__}: {fp5._redact(str(exc))[:120]}"}
+
+    metrics = {
+        "corpus": f"doc_{label}",
+        "verdict": verdict,
+        "elapsed_s": round(elapsed, 1),
+        "modal_class": matrix["modal"]["class"],
+        "modal_valid": modal_valid,
+        "modal_solver": modal_solver,
+        "modal_fabricated_true": modal_fabricated_true,
+        "modal_enumeration": enum,
+        "matrix": matrix,
+    }
+
+    ts = time.strftime("%Y%m%dT%H%M%S")
+    raw_out = RESULTS_DIR / f"fp16_doc{label}_{ts}.json"
+    try:
+        with open(raw_out, "w", encoding="utf-8") as f:
+            json.dump(
+                {"metrics": metrics, "state_snapshot": result.get("state_snapshot")},
+                f,
+                indent=2,
+                ensure_ascii=False,
+                default=str,
+            )
+        print(f"[FP-16] doc_{label} raw saved -> {raw_out.name} (gitignored)")
+    except Exception as exc:
+        print(f"[FP-16] doc_{label} raw save failed: {type(exc).__name__}")
+
+    tally: "dict[str, int]" = {}
+    for row in matrix.values():
+        tally[row["class"]] = tally.get(row["class"], 0) + 1
+    print(
+        f"[FP-16] doc_{label} DONE: {verdict} ({metrics['elapsed_s']}s) | "
+        f"modal={metrics['modal_class']} valid={modal_valid} solver={modal_solver} | "
+        f"enum={enum.get('illegal_by_type') if enum.get('ran') else enum.get('reason')} | "
+        f"classes={tally}"
+    )
+    return metrics
+
+
+async def amain() -> None:
+    print("=" * 72)
+    print("[FP-16] #1231 modal matrix re-run + illegal-construct enumeration")
+    print("=" * 72)
+    corpus_texts: dict = {}
+    all_metrics = []
+    # ``FP16_CORPORA=A`` (comma-separated labels) restricts the run. The modal
+    # construct enumeration only needs corpora where the pipeline actually REACHES
+    # the modal phase; doc_C/doc_B time out upstream of modal (modal=absent), so
+    # re-running just doc_A captures the modal-illegal set without paying their
+    # ceilings — and avoids doc_B's JPype hang (asyncio.wait_for can't cancel an
+    # in-flight JVM call). Empty/unset = all 3 (the full matrix).
+    _only = {c.strip().upper() for c in os.environ.get("FP16_CORPORA", "").split(",") if c.strip()}
+    corpora = [c for c in fp5.CORPORA if (not _only or c[0].upper() in _only)]
+    if _only:
+        print(f"[FP-16] corpus filter FP16_CORPORA={sorted(_only)} -> running {[c[0] for c in corpora]}")
+    for label, idx, timeout in corpora:
+        try:
+            m = await run_corpus(label, idx, timeout, corpus_texts)
+        except Exception as exc:
+            m = {
+                "corpus": f"doc_{label}",
+                "verdict": f"FATAL:{type(exc).__name__}",
+                "error": fp5._redact(str(exc))[:200],
+            }
+            print(f"[FP-16] doc_{label} FATAL: {fp5._redact(str(exc))[:160]}")
+        all_metrics.append(m)
+
+    agg = RESULTS_DIR / f"fp16_matrix_{time.strftime('%Y%m%dT%H%M%S')}.json"
+    with open(agg, "w", encoding="utf-8") as f:
+        json.dump(all_metrics, f, indent=2, ensure_ascii=False, default=str)
+    print(f"\n[FP-16] aggregate saved -> {agg.name} (gitignored)")
+
+    print("\n" + "=" * 72)
+    print("[FP-16] MODAL SUMMARY (post-#1230)")
+    print("=" * 72)
+    for m in all_metrics:
+        e = m.get("modal_enumeration", {})
+        print(
+            f"  {m.get('corpus')}: class={m.get('modal_class')} "
+            f"valid={m.get('modal_valid')} solver={m.get('modal_solver')} "
+            f"fabricated_true={m.get('modal_fabricated_true')}"
+        )
+        if e.get("ran"):
+            print(
+                f"      KB_parses={e.get('kb_parses')} parse_error={e.get('parse_error_class')} "
+                f"decls={e.get('n_declarations')} formulas={e.get('n_formulas')} "
+                f"distinct_illegal={e.get('distinct_illegal_constructs')} "
+                f"by_type={e.get('illegal_by_type')}"
+            )
+        else:
+            print(f"      enumeration not run: {e.get('reason')}")
+
+
+if __name__ == "__main__":
+    asyncio.run(amain())


### PR DESCRIPTION
## FP-16 #1231 — re-run formal-richness matrix post-#1227/#1230 (Epic #1191)

Re-run of `scripts/run_fp5_formal_matrix.py` (spectacular+full) on the 3 corpora after #1227/#1230 (modal predicate-name normalization). **Report + harness only** — no production code change.

### Key finding (verify-the-verification)

**#1230 is upstream-correct: the modal KB now PARSES cleanly** — `parseBeliefBase → MlBeliefSet`, **0 MlParser-illegal constructs**. The grammar layer is genuinely closed.

The earlier-drafted root cause ("MlParser *tokenizer* mismatch" on URL/multi-word atoms) was **REFUTED by firsthand replay** — those ParserExceptions were stale pre-#1230 raw-corpus observations. Driving the reasoner manually pins the real residual:

| step | observed |
| --- | --- |
| `parseBeliefBase` | OK → `MlBeliefSet` |
| `_build_contradiction_probe` | OK → `Conjunction` |
| `reasoner.query(...)` | **`java.lang.OutOfMemoryError`** |
| `is_modal_kb_consistent` | honest `(None, …)` — OOM caught, never fabricated |

`SimpleMlReasoner` decides by naive Kripke-model enumeration; memory scales (hyper-)exponentially in atom count. The `nl_to_logic` translations carry **0 modal operators** (all propositional) but ~12 atoms → OOM. Synthetic 2-atom KBs decide in <1s; the real 12-atom KB OOMs. The #1225/#1230 unit tests passed only because they used tiny KBs below the threshold.

### Matrix (base `8c6714f2`)

| corpus | verdict | modal class | `modal_fabricated_true` |
| --- | --- | --- | --- |
| doc_A | COMPLETED (563.6s) | error (phase FAILED — 180s ceiling) | **False** |
| doc_C | TIMED_OUT_900s | absent (upstream throughput) | **False** |
| doc_B | hung → killed | n/a | **False** |

`modal_fabricated_true: False` ×3 — DoD met, no verdict dressed as decided.

### Two distinct honest residuals (neither is grammar)

1. **Reasoner OOM (primary).** `SimpleMlReasoner` can't decide a ~12-atom KB without exhausting memory. Fix direction (out of scope here): route 0-modal-operator (propositional) translations to the PL/PySAT path that already DECIDES, and/or use SPASS instead of the naive enumerator.
2. **Phase-timeout asymmetry (secondary).** `modal` keeps `timeout_seconds=180` while the #705 fix raised `pl`→420 / `fol`→600. Never applied to modal → OOM-thrash → `status=failed`.

### DoD

- [x] Matrix re-run, 3 corpora, base post-#1230
- [x] Modal line updated — full residual enumeration: **MlParser-illegal set = ∅** (grammar closed); reasoner residual = `OutOfMemoryError`, characterized by construct TYPE
- [x] `modal_fabricated_true` False ×3 (verified)
- [x] Report committed (`docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md`)
- [ ] Follow-up issue (reasoner-scalability + timeout alignment) — to file

### Files
- `docs/reports/FP5_FORMAL_RICHNESS_MATRIX.md` — FP-16 Update section (supersedes the drafted tokenizer hypothesis)
- `scripts/run_fp16_modal_enum.py` — matrix re-run + parser-illegal enumeration harness (proves grammar closed)
- `.gitignore` — `.cache/` (scratch run logs may contain corpus-derived plaintext)

### Privacy
Opaque IDs (`doc_A/B/C`), construct TYPES + Java class names + counts only — no corpus tokens. Raw JSON stays gitignored under `evaluation/results/fp5/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)