### PR TITLE
fix(logic): #1204 extend EProver delivery-contract sentinel to the SYNC check_consistency path

### DIFF
--- a/argumentation_analysis/agents/core/logic/fol_handler.py
+++ b/argumentation_analysis/agents/core/logic/fol_handler.py
@@ -675,8 +675,39 @@ class FOLHandler:
                         EFOLReasoner = jpype.JClass(
                             "org.tweetyproject.logics.fol.reasoner.EFOLReasoner"
                         )
+                        # use_eprover already implies eprover_path is not None
+                        # (set above); narrow for the typed sentinel call below.
+                        assert eprover_path is not None
                         reasoner = EFOLReasoner(JString(eprover_path))
                         solver_name = "EProver"
+                        # #1204/#1232: this SYNC path is what
+                        # ``TweetyBridge.check_consistency`` and the #1210 real-
+                        # eprover test actually call. The #1232 sentinel guard
+                        # was wired only into the ASYNC
+                        # ``_fol_check_consistency_with_eprover`` — so on a
+                        # platform with a broken Tweety->E delivery contract
+                        # (Linux argc=0, firsthand #1204) this path STILL
+                        # fabricated "consistent" on an inconsistent KB (#1019).
+                        # Apply the SAME sentinel here: if the known-inconsistent
+                        # {P(a),!P(a)} is not detected, eprover cannot be trusted
+                        # on this platform — fall back to the in-JVM
+                        # SimpleFolReasoner, which decides correctly, instead of
+                        # serving a fabricated verdict.
+                        if not _eprover_delivery_is_reliable(
+                            reasoner, eprover_path
+                        ):
+                            if self._initializer_instance is not None:
+                                reasoner = self._initializer_instance.get_reasoner(
+                                    "SimpleFolReasoner"
+                                )
+                                solver_name = "SimpleFolReasoner"
+                            else:
+                                return (
+                                    None,
+                                    "Degraded: EProver delivery contract broken "
+                                    "(#1204) and no in-JVM reasoner available; "
+                                    "no consistency verdict.",
+                                )
                     else:
                         reasoner = self._initializer_instance.get_reasoner(
                             "SimpleFolReasoner"

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_eprover_real.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_eprover_real.py
@@ -105,9 +105,18 @@ class TestRealEProverConsistency:
         assert (
             is_consistent is False
         ), f"Inconsistent KB must report inconsistent; got ({is_consistent!r}, {msg!r})."
-        assert (
-            "EProver" in msg
-        ), f"Verdict must be traceable to the EProver solver; got msg={msg!r}."
+        # Platform-honest (#1204/#1232): the verdict must be traceable to a real
+        # reasoner. On platforms where the Tweety->E delivery contract holds
+        # (Windows, E 2.0) eprover decides directly and the message names
+        # ``EProver``. On platforms where the contract is broken (Linux argc=0,
+        # firsthand #1204) the sentinel guard trips and the check falls back to
+        # the in-JVM ``SimpleFolReasoner`` — which decides correctly. Either
+        # named reasoner is an honest decision; a fabricated verdict would have
+        # already been caught by the ``is_consistent is False`` invariant above.
+        assert ("EProver" in msg) or ("SimpleFolReasoner" in msg), (
+            "Verdict must be traceable to a real reasoner (eprover, or the "
+            f"#1204 in-JVM fallback); got msg={msg!r}."
+        )
 
     def test_consistent_kb_reports_consistent_via_eprover(
         self, fol_bridge, eprover_solver
@@ -132,6 +141,10 @@ class TestRealEProverConsistency:
         assert (
             is_consistent is True
         ), f"Consistent KB must report consistent; got ({is_consistent!r}, {msg!r})."
-        assert (
-            "EProver" in msg
-        ), f"Verdict must be traceable to the EProver solver; got msg={msg!r}."
+        # Platform-honest (#1204/#1232): eprover names ``EProver`` where the
+        # delivery contract holds; the in-JVM ``SimpleFolReasoner`` fallback
+        # names itself where the sentinel guard trips. Both are real decisions.
+        assert ("EProver" in msg) or ("SimpleFolReasoner" in msg), (
+            "Verdict must be traceable to a real reasoner (eprover, or the "
+            f"#1204 in-JVM fallback); got msg={msg!r}."
+        )


### PR DESCRIPTION
## Summary

**Closes the #1204 L4 Tweety→EProver delivery-contract DoD on the Linux side.**

#1232 added the anti-théâtre sentinel `_eprover_delivery_is_reliable` (`{P(a),!P(a)}` must be reported inconsistent before any eprover verdict is trusted) — but wired it into the **async** `fol_check_consistency` only. The production `TweetyBridge.check_consistency` and the #1210 real-eprover integration test both call the **sync** `FOLHandler.check_consistency`, which had **no guard**.

**Firsthand WSL/E-3.3.5 verification on guarded main `93152fd5`** found the sync path *still fabricates*: an inconsistent KB `{P(a), ¬P(a)}` returned `(True, 'FOL consistency check (EProver): consistent')` — the #1204 fabrication (Tweety `EFOLReasoner` execs eprover argc=0 → E proves the empty theory `Satisfiable`). The `is_consistent is False` assertion in the #1210 test was the only thing catching it.

## Fix (anti-pendule — extend the existing guard, no relabeling)

- `fol_handler.py` sync `check_consistency`: run the **same** sentinel before trusting eprover; on trip → fall back to the in-JVM `SimpleFolReasoner` (decides correctly), else degraded `None`. This mirrors what #1232 did for the async path.
- `test_eprover_real.py` (#1210): keep the `is_consistent is False`/`True` invariants (these caught the fabrication); soften **only** the solver-name assertion to accept `EProver` **or** the `SimpleFolReasoner` fallback — platform-honest. A fabricated verdict is still caught by the verdict invariant.

## Verification (firsthand, both platforms)

| Platform | Delivery | Path taken | Result |
|---|---|---|---|
| Windows (E 2.0 Turzum) | reliable | eprover decides directly | **2 passed** (`(EProver)` msg) |
| WSL/E-3.3.5 (argc=0) | broken | sentinel trips → SimpleFolReasoner fallback | **2 passed** (`(SimpleFolReasoner)` msg, honest `False`) |

- mypy strict: **0 new errors** (30 pre-existing `no-untyped-def` baseline unchanged).
- Privacy: synthetic atoms only (`Mortal(socrate)`), no corpus.

## Files changed and why

| File | Type | Reason |
|---|---|---|
| `argumentation_analysis/agents/core/logic/fol_handler.py` | code | Wire the #1232 sentinel into the sync consistency path; fall back to in-JVM reasoner on broken delivery |
| `tests/integration/.../test_eprover_real.py` | test | Platform-honest assertion: keep verdict invariant, accept eprover-or-fallback solver name |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
