### PR TITLE
fix(modal): #1234 activate SPASS for modal logic — Tweety↔SPASS EML→eml delivery-contract adapter

### DIFF
--- a/argumentation_analysis/core/jvm_setup.py
+++ b/argumentation_analysis/core/jvm_setup.py
@@ -712,8 +712,25 @@ def _configure_external_tools():
             if clingo_path.exists():
                 tools_found["clingo"] = str(clingo_path.parent.resolve())
 
-    # SPASS — Modal logic theorem prover
+    # SPASS — Modal logic theorem prover.
+    # #1234: Tweety 1.29's SPASSMlReasoner emits the DFG special-formulae logic
+    # token as ``EML`` (uppercase); SPASS 3.9's parser requires ``eml``
+    # (lowercase) → "got 'EML', expected special type (eml)", SPASS aborts and
+    # the modal axis cannot decide. This is a Tweety↔SPASS delivery-contract
+    # version mismatch — the modal analogue of the eprover #1204 regression.
+    # The EML→eml adapter (scripts/solvers/spass_eml_adapter.sh) rewrites only
+    # that keyword case in the DFG temp file and forwards to the real SPASS,
+    # which performs ALL modal reasoning (EML→FOL translation + saturation).
+    # Prefer the adapter when present so Tweety's DFG is accepted; otherwise
+    # register the raw binary (modal SPASS then fails honestly on the EML
+    # mismatch — #1019, no fabrication).
+    adapter_name = (
+        "spass_eml_adapter.bat"
+        if platform.system() == "Windows"
+        else "spass_eml_adapter.sh"
+    )
     for candidate in [
+        str(EXT_TOOLS_DIR / f"spass/{adapter_name}"),
         shutil.which("SPASS"),
         str(EXT_TOOLS_DIR / f"spass/SPASS{exe_suffix}"),
     ]:

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -137,11 +137,11 @@ def filter_formal_extensions(
     workflow.phases = [
         p
         for p in workflow.phases
-        if p.capability not in _ALL_EXTENSION_CAPS
-        or p.capability in allowed_caps
+        if p.capability not in _ALL_EXTENSION_CAPS or p.capability in allowed_caps
     ]
     logger.info(f"formal_extension={filter_spec}: keeping {sorted(requested)}")
     return workflow
+
 
 # --- Pre-built workflow definitions ---
 
@@ -756,7 +756,18 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             capability="modal_logic",
             depends_on=["nl_to_logic"],
             optional=True,
-            timeout_seconds=180,
+            # #1234: align the modal ceiling with pl(420)/fol(600). #705 raised
+            # those two but left modal at 180, so a decidable modal KB (or the
+            # 2-pass nl_to_logic generator feeding it) could be timed out → the
+            # phase failed (the "error" matrix cell) instead of deciding. The
+            # OOM itself is fixed by ACTIVATING SPASS (the SOTA modal prover):
+            # SimpleMlReasoner enumerates Kripke models and OOMs at ~12 atoms
+            # (FP-16 #1231), whereas SPASS decides by saturation without that
+            # explosion (see scripts/solvers/spass_eml_adapter.sh). This ceiling
+            # bump is the secondary alignment (anti-pendule: it does NOT exist to
+            # "let an OOM finish" — an OOM is exponential and never finishes — only
+            # to give a genuinely-decidable phase the same room pl/fol already got).
+            timeout_seconds=420,
         )
         # L2c — external solver routing: FOL→EProver/Prover9 (#504)
         .add_phase(

--- a/docs/reports/FP_MODAL_SPASS_ACTIVATION_1234.md
+++ b/docs/reports/FP_MODAL_SPASS_ACTIVATION_1234.md
@@ -1,0 +1,118 @@
+# Modal axis — SPASS was never genuinely activated (régression #1234)
+
+**Date**: 2026-06-23 · **Machine**: po-2025 (WSL2 fol-linux stack) · **Issue**: #1234
+**Class**: anti-théâtre #1019 / delivery-contract regression (modal analogue of eprover #1204)
+
+## TL;DR
+
+The modal-logic axis advertised SPASS (a SOTA modal theorem prover) as its
+external solver, but **SPASS was never genuinely running**. The axis silently
+fell back to `SimpleMlReasoner` (pure-Java, naive Kripke enumeration), which
+**OOMs at ~12 atoms** — so real KBs never decided (`valid=None`). Three layers,
+all firsthand-verified:
+
+1. **Default never selected SPASS.** `config.modal_solver` defaults to `TWEETY`,
+   not `SPASS`. The modal axis ran `SimpleMlReasoner` everywhere.
+2. **The vendored binary was never a CLI prover, and was deleted.** The shipped
+   `SPASS.exe` was a GUI/elevation InstallShield build (`requireAdministrator`
+   manifest → `CreateProcess error=740`, `isInstalled()==False`) — verified
+   firsthand from its PE manifest. It was deleted in the cleanup-gate commit
+   `f1234b58` ("Nettoyer l'index Git", 426 files) together with the Tweety
+   notebooks and `_archives/Argument_Analysis/ext_tools`.
+3. **Even a freshly-built SPASS 3.9 CLI cannot be driven by Tweety 1.29 without
+   a delivery-contract fix.** See below — this is the actual blocker, and the
+   modal twin of the eprover #1204/#1196 regression class.
+
+## The delivery-contract regression (the real blocker)
+
+A genuine SPASS 3.9 CLI built from source (WSL, `scripts/setup/build_spass_modal.sh`)
+**works standalone** (UNSAT→"Proof found", SAT→"Completion found"). But driving
+it through `ModalHandler` → Tweety `SPASSMlReasoner.query` throws
+*"SPASS returned no result which can be interpreted"*.
+
+Captured firsthand (logging wrapper around the real binary), the exact Tweety
+invocation `SPASS -PGiven=0 -PProblem=0 <tmp>.dfg` fails at parse time:
+
+```
+In file <tmp>.dfg at line 14, column 33: got 'EML', expected special type (eml)
+```
+
+**Root cause**: Tweety 1.29's `SPASSMlReasoner` emits the DFG special-formulae
+logic token in **uppercase** —
+
+```
+list_of_special_formulae(axioms,EML).
+```
+
+— but **SPASS 3.9's DFG parser requires it lowercase** (`eml`; see
+`dfgparser.c: dfg_parse_special_type_isEml`, token `T_eml`). SPASS aborts before
+reasoning. It is a Tweety↔SPASS **version mismatch**, not a reasoning failure —
+exactly analogous to the Tweety↔E argc=0 delivery-contract regression (#1204).
+
+## Fix — activate SPASS, no contournement
+
+The SOTA prover does **100%** of the modal reasoning (EML→FOL translation +
+saturation). We repair **only** the interface keyword case, at the delivery
+boundary, mirroring the #1204 sentinel pattern:
+
+- **`scripts/solvers/spass_eml_adapter.sh`** — rewrites `list_of_special_formulae(X,EML)`
+  → `(X,eml)` in the DFG temp file Tweety passes as a file argument, then `exec`s
+  the real SPASS unchanged. Relocatable (`$SPASS_REAL_BIN` or sibling `./SPASS`).
+- **`argumentation_analysis/core/jvm_setup.py`** — SPASS detection now *prefers*
+  the adapter (`ext_tools/spass/spass_eml_adapter.sh`) when present, so Tweety
+  invokes it transparently as `EXTERNAL_TOOL_PATHS['spass']`. If only the raw
+  binary is present, modal SPASS fails **honestly** on the EML mismatch (`None`,
+  no fabrication, #1019).
+- **`scripts/setup/build_spass_modal.sh`** — reproducible SPASS 3.9 source build
+  (`spass39.tgz`; gcc+make+flex+bison, conda-forge userspace, sudo-free) +
+  adapter install into the gitignored `ext_tools/spass/`.
+- **`argumentation_analysis/orchestration/workflows.py`** — modal phase ceiling
+  180→420 s (parity with pl/fol, #705). Secondary; the OOM itself is fixed by
+  SPASS (saturation, no enumeration), not by more time.
+
+### Rejected: the PySAT routing contournement
+
+An earlier #1234 draft routed 0-modal-operator translations to PL/PySAT. Though
+mathematically sound for a no-□/◇ KB, it **routes around** the modal solver
+instead of activating it — rejected per the directive *"pas de contournement,
+tous les outils SOTA doivent être activés."* Reverted.
+
+## Firsthand proof (production `ModalHandler`, WSL fol-linux, SPASS via adapter)
+
+Detection registered the adapter; `ModalHandler` loaded `SPASSMlReasoner` with
+it; **all cases decided via SPASS**, traceable to `(spass)`:
+
+| KB (synthetic atoms only) | `SimpleMlReasoner` (TWEETY) | SPASS (adapter) |
+|---|---|---|
+| inconsistent `Rain, !Rain` | False | **False** ✓ |
+| consistent `[](Rain⇒Wet), Rain` | True | **True** ✓ |
+| **12-atom propositional chain** | **OOM → None** | **True** ✓ (no OOM) |
+| **12-atom modal `[](aᵢ⇒aᵢ₊₁)` + `<>(a1)`** | **OOM → None** | **True** ✓ (no OOM) |
+
+The two 12-atom KBs are the FP-16 #1231 OOM cases. SPASS decides them; the
+default reasoner cannot. Encoded as the gated
+`tests/integration/.../test_spass_real.py::TestRealSpassConsistency`
+(`test_multi_atom_kb_decides_via_spass_without_oom`), which skips honestly where
+SPASS is not a runnable CLI build (e.g. Windows CI with no binary).
+
+## Reproducibility
+
+- Build: `bash scripts/setup/build_spass_modal.sh` (needs `spass39.tgz` from the
+  official SPASS distribution; flex/bison/make/gcc).
+- Run: set `modal_solver=spass` (`MODAL_SOLVER=spass`); detection wires the
+  adapter; the gated real test asserts the verdicts above.
+- Bases: branch `fix/1234-modal-reasoner-oom-routing` off main `ce6c5474`.
+
+## Follow-ups (coordinator-gated)
+
+- **Windows SPASS CLI build** (Cygwin/MSVC) + `.bat` adapter — the canonical
+  pipeline runs on Windows, where no SPASS CLI yet exists; until then modal-SPASS
+  is honest-degraded (`None`) there, decided only on the Linux/WSL stack.
+- **Binary vendoring policy** — whether to vendor a prebuilt SPASS under
+  `ext_tools/` (as eprover.exe is), or keep build-from-source only.
+
+## Related
+
+- #1204 (Tweety↔E delivery contract, sync+async sentinel) — the FOL twin.
+- #1219/#1221 (modal pipeline reaches SimpleMlReasoner), #1231/FP-16 (modal OOM).
+- #1019 (anti-théâtre invariant) — the family this fix belongs to.

--- a/scripts/setup/build_spass_modal.sh
+++ b/scripts/setup/build_spass_modal.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------
+# Build & install SPASS 3.9 (SOTA modal theorem prover) for the modal axis (#1234)
+# ---------------------------------------------------------------------------
+# Reproducible Linux/WSL build of the real SPASS CLI, plus the Tweety<->SPASS
+# DFG delivery-contract adapter (scripts/solvers/spass_eml_adapter.sh).
+#
+# WHY this exists (the "énorme régression" reported 2026-06-23):
+#   * The modal axis defaulted to TWEETY/SimpleMlReasoner (pure-Java, naive
+#     Kripke enumeration) which OOMs at ~12 atoms (FP-16 #1231) — so real KBs
+#     never decided (valid=None).
+#   * The vendored SPASS.exe was a GUI/elevation InstallShield build (err740,
+#     requireAdministrator) — never a runnable CLI — and was deleted in the
+#     cleanup-gate commit f1234b58 together with the Tweety notebooks.
+#   * SPASS was therefore never genuinely activated for modal logic.
+#
+# This script rebuilds SPASS from source and wires the EML->eml adapter so the
+# real SOTA prover decides modal consistency (incl. the multi-atom KBs that OOM
+# SimpleMlReasoner) — verified firsthand via the production ModalHandler.
+#
+# Firsthand build environment (po-2025 / WSL2, sudo-free):
+#   gcc + make from the distro; flex 2.6.4 + bison 3.8.2 from conda-forge
+#   (`conda install -n base -c conda-forge flex bison make`). Source tarball
+#   spass39.tgz (554633 bytes) from the official SPASS distribution.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+BUILD_DIR="${SPASS_BUILD_DIR:-$HOME/spass_build}"
+SRC_TGZ="${SPASS_SRC_TGZ:-$BUILD_DIR/spass39.tgz}"
+# Detection looks under PROJ_ROOT/ext_tools (settings.jvm.ext_tools_dir); this
+# dir is gitignored except the vendored EProver, so the binary is NOT committed.
+DEST_DIR="${SPASS_DEST_DIR:-$REPO_ROOT/ext_tools/spass}"
+ADAPTER_SRC="$REPO_ROOT/scripts/solvers/spass_eml_adapter.sh"
+
+echo "== SPASS 3.9 build for modal logic (#1234) =="
+echo "  build dir : $BUILD_DIR"
+echo "  source    : $SRC_TGZ"
+echo "  install to: $DEST_DIR"
+
+# 1. Toolchain check (do NOT auto-install; report what is missing).
+missing=""
+for tool in gcc make flex bison; do
+  command -v "$tool" >/dev/null 2>&1 || missing="$missing $tool"
+done
+if [ -n "$missing" ]; then
+  echo "ERROR: missing build tools:$missing" >&2
+  echo "  apt:   sudo apt-get install build-essential flex bison" >&2
+  echo "  conda: conda install -n base -c conda-forge flex bison make  (sudo-free)" >&2
+  exit 1
+fi
+
+# 2. Obtain the source (spass39.tgz from the official SPASS distribution).
+mkdir -p "$BUILD_DIR"
+if [ ! -f "$SRC_TGZ" ]; then
+  echo "ERROR: SPASS source tarball not found at $SRC_TGZ" >&2
+  echo "  Download spass39.tgz from the official SPASS distribution" >&2
+  echo "  (https://www.spass-prover.org/) and place it there, or set SPASS_SRC_TGZ." >&2
+  exit 1
+fi
+
+# 3. Extract (the tarball expands flat — analyze.c, approx.c, ... at top level).
+cd "$BUILD_DIR"
+tar xzf "$SRC_TGZ"
+
+# 4. Build the CLI binary.
+make SPASS
+test -x "$BUILD_DIR/SPASS" || { echo "ERROR: SPASS build produced no binary" >&2; exit 1; }
+echo "Built: $("$BUILD_DIR/SPASS" 2>&1 | grep -i version | head -1 || echo "$BUILD_DIR/SPASS")"
+
+# 5. Install binary + adapter side by side (detection registers the adapter).
+mkdir -p "$DEST_DIR"
+cp -f "$BUILD_DIR/SPASS" "$DEST_DIR/SPASS"
+cp -f "$ADAPTER_SRC" "$DEST_DIR/spass_eml_adapter.sh"
+chmod +x "$DEST_DIR/SPASS" "$DEST_DIR/spass_eml_adapter.sh"
+
+echo "== Installed =="
+echo "  real binary : $DEST_DIR/SPASS"
+echo "  adapter     : $DEST_DIR/spass_eml_adapter.sh  (registered as EXTERNAL_TOOL_PATHS['spass'])"
+echo
+echo "Set modal_solver=spass (config.py / MODAL_SOLVER=spass) to route the modal"
+echo "axis through SPASS. Verify: tests/integration/.../test_spass_real.py"

--- a/scripts/solvers/spass_eml_adapter.sh
+++ b/scripts/solvers/spass_eml_adapter.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------
+# Tweety <-> SPASS DFG delivery-contract adapter (#1234)
+# ---------------------------------------------------------------------------
+# Modal analogue of the eprover #1204 delivery-contract sentinel.
+#
+# PROBLEM (firsthand-diagnosed, 2026-06-23):
+#   Tweety 1.29's SPASSMlReasoner translates a modal KB to DFG and writes the
+#   special-formulae logic token in UPPERCASE:
+#       list_of_special_formulae(axioms,EML).
+#   SPASS 3.9's DFG parser requires the token in LOWERCASE and aborts with:
+#       "got 'EML', expected special type (eml)"  (exit 1)
+#   so SPASSMlReasoner.query throws "SPASS returned no result which can be
+#   interpreted" and the modal axis cannot decide. This is a Tweety<->SPASS
+#   version mismatch, NOT a reasoning failure.
+#
+# FIX (no contournement — the real SOTA prover does ALL the work):
+#   Rewrite ONLY the keyword case in the DFG temp file Tweety passes as a file
+#   argument, then exec the real SPASS unchanged. SPASS still performs the full
+#   EML->FOL translation + saturation; this only repairs the interface token.
+#
+# WIRING:
+#   Detection (argumentation_analysis/core/jvm_setup.py) registers THIS script
+#   as EXTERNAL_TOOL_PATHS['spass'] when it is present next to the real binary,
+#   so Tweety invokes the adapter transparently. The real SPASS binary must sit
+#   beside this script as ./SPASS (override with $SPASS_REAL_BIN).
+#
+# Build the real SPASS: scripts/setup/build_spass_modal.sh
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REAL="${SPASS_REAL_BIN:-$HERE/SPASS}"
+
+if [ ! -x "$REAL" ]; then
+  echo "spass_eml_adapter: real SPASS binary not found/executable at '$REAL'" >&2
+  echo "  set SPASS_REAL_BIN or place the binary beside this adapter as ./SPASS" >&2
+  exit 127
+fi
+
+# Repair the DFG keyword case in every file argument (Tweety passes exactly one
+# DFG temp file). Match only the special-formulae logic token to stay surgical.
+for a in "$@"; do
+  if [ -f "$a" ]; then
+    sed -i 's/list_of_special_formulae(\([a-zA-Z_]*\),EML)/list_of_special_formulae(\1,eml)/g' "$a"
+  fi
+done
+
+exec "$REAL" "$@"

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
@@ -17,6 +17,21 @@ original SPASS-forced draft:
    it and asserting a boolean would be re-theater (it would in fact return the
    honest ``None``).
 
+A third firsthand finding (po-2025 / WSL, 2026-06-23, #1234) added the
+``TestRealSpassConsistency`` multi-atom case and the EML→eml adapter:
+
+3. **A genuine SPASS CLI built from source DOES decide modal logic — once the
+   Tweety↔SPASS DFG delivery contract is repaired.** Tweety 1.29 emits the DFG
+   special-formulae logic token as ``EML`` (uppercase); SPASS 3.9's parser
+   requires ``eml`` (lowercase) → "got 'EML', expected special type (eml)",
+   SPASS aborts, ``query`` throws "SPASS returned no result which can be
+   interpreted" (modal analogue of the eprover #1204 regression). The
+   ``spass_eml_adapter.sh`` adapter (registered as
+   ``EXTERNAL_TOOL_PATHS['spass']``) rewrites only that keyword case and
+   forwards to the real SPASS, which then DECIDES — including the 12-atom KB
+   that OOMs ``SimpleMlReasoner`` (``MULTI_ATOM_MODAL_KB`` below). Build:
+   ``scripts/setup/build_spass_modal.sh``.
+
 So the **real anti-theater guard** is the DEFAULT modal reasoner
 (``SimpleMlReasoner``, pure-Java, query-based): it DECIDES consistency with NO
 external binary, hence it RUNS on CI everywhere — not "green by skipping". The
@@ -45,6 +60,23 @@ from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
 INCONSISTENT_KB = "type(Rain)\n\nRain\n!Rain\n"
 # A consistent modal KB exercising the necessity operator: []( Rain => Wet ) and Rain.
 CONSISTENT_KB = "type(Rain)\ntype(Wet)\n\n[](Rain => Wet)\nRain\n"
+
+# A 12-atom genuinely-modal KB — a necessity chain []( a_i => a_{i+1} ) plus a
+# possibility <>( a1 ). This is the #1234 / FP-16 scaling case: ``SimpleMlReasoner``
+# enumerates Kripke models and OOMs (``java.lang.OutOfMemoryError``) at this atom
+# count, so it CANNOT decide it. SPASS decides it by saturation (no enumeration),
+# which is exactly why activating SPASS — not routing around the modal solver — is
+# the fix. Privacy HARD: synthetic atoms only.
+_MULTI_ATOMS = [f"a{i}" for i in range(1, 13)]
+MULTI_ATOM_MODAL_KB = (
+    "\n".join(f"type({a})" for a in _MULTI_ATOMS)
+    + "\n\n"
+    + "\n".join(
+        f"[]({_MULTI_ATOMS[i]} => {_MULTI_ATOMS[i + 1]})"
+        for i in range(len(_MULTI_ATOMS) - 1)
+    )
+    + f"\n<>({_MULTI_ATOMS[0]})\n"
+)
 
 
 def _spass_runnable() -> bool:
@@ -169,6 +201,29 @@ class TestRealSpassConsistency:
         assert is_consistent is True, (
             f"Consistent modal KB must report consistent via SPASS; "
             f"got ({is_consistent!r}, {msg!r})."
+        )
+        assert (
+            "spass" in msg.lower()
+        ), f"Verdict must be traceable to the SPASS reasoner; got msg={msg!r}."
+
+    def test_multi_atom_kb_decides_via_spass_without_oom(
+        self, modal_bridge, spass_solver
+    ):
+        """The #1234 / FP-16 win: a 12-atom genuinely-modal KB that OOMs
+        ``SimpleMlReasoner`` (naive Kripke enumeration) must DECIDE via SPASS
+        (saturation, no enumeration). Firsthand-verified (2026-06-23) via the
+        production ModalHandler under the WSL fol-linux stack: SPASS returns a
+        real boolean verdict here where the default reasoner cannot. The KB is
+        satisfiable (a reflexive single-world model satisfies the chain and the
+        diamond), so the genuine verdict is ``consistent``."""
+        is_consistent, msg = modal_bridge.check_consistency(MULTI_ATOM_MODAL_KB, "K")
+        assert is_consistent is not None, (
+            f"A 12-atom modal KB that OOMs SimpleMlReasoner must still DECIDE via "
+            f"SPASS (no enumeration); got ({is_consistent!r}, {msg!r})."
+        )
+        assert is_consistent is True, (
+            f"The necessity-chain + diamond KB is satisfiable; SPASS must report "
+            f"consistent. got ({is_consistent!r}, {msg!r})."
         )
         assert (
             "spass" in msg.lower()


### PR DESCRIPTION
Closes #1234.

## The régression (firsthand-verified, po-2025 / WSL fol-linux)

The modal axis advertised SPASS (SOTA modal prover) but **never genuinely ran it**. It silently fell back to `SimpleMlReasoner` (pure-Java, naive Kripke enumeration), which **OOMs at ~12 atoms** (FP-16 #1231) — so real KBs never decided (`valid=None`). Three layers:

1. **`config.modal_solver` defaults to `TWEETY`, not `SPASS`.** Modal ran `SimpleMlReasoner` everywhere.
2. **The vendored `SPASS.exe` was a GUI/elevation InstallShield build** (`requireAdministrator` manifest → `CreateProcess err740`, `isInstalled()==False`) — never a CLI prover. Deleted in cleanup-gate `f1234b58` ("Nettoyer l'index Git") with the Tweety notebooks + `ext_tools`.
3. **A freshly-built SPASS 3.9 CLI cannot be driven by Tweety 1.29.** Tweety emits the DFG token `EML` (uppercase); SPASS 3.9 requires `eml` (lowercase):
   ```
   In file <tmp>.dfg at line 14, column 33: got 'EML', expected special type (eml)
   ```
   SPASS aborts before reasoning → `query` throws *"SPASS returned no result which can be interpreted"*. A Tweety↔SPASS **version mismatch** — the modal analogue of the eprover #1204/#1196 delivery-contract regression.

## Fix — activate SPASS, no contournement

SPASS does **100%** of the modal reasoning (EML→FOL translation + saturation); we repair **only** the interface keyword case at the delivery boundary (mirroring the #1204 sentinel).

- **`scripts/solvers/spass_eml_adapter.sh`** — rewrites `list_of_special_formulae(X,EML)`→`(X,eml)` in the DFG temp file, then `exec`s the real SPASS (relocatable: `$SPASS_REAL_BIN` or sibling `./SPASS`).
- **`argumentation_analysis/core/jvm_setup.py`** — SPASS detection now *prefers* the adapter (registered as `EXTERNAL_TOOL_PATHS['spass']`); raw binary only → modal SPASS fails **honestly** on the EML mismatch (`None`, no fabrication, #1019).
- **`scripts/setup/build_spass_modal.sh`** — reproducible SPASS 3.9 source build (`spass39.tgz`; gcc+make+flex+bison, conda-forge userspace, sudo-free) + install into gitignored `ext_tools/spass/`.
- **`argumentation_analysis/orchestration/workflows.py`** — modal phase ceiling 180→420 s (pl/fol parity, #705). Secondary; the OOM is fixed by SPASS (saturation), not by more time.

### Rejected: the PySAT-routing draft
An earlier #1234 draft routed 0-modal-operator translations to PL/PySAT. Mathematically sound for a no-□/◇ KB, but it **routes around** the modal solver — rejected per *"pas de contournement, tous les outils SOTA doivent être activés."* Reverted.

## Firsthand proof (production `ModalHandler`, SPASS via adapter)

| KB (synthetic atoms only) | SimpleMlReasoner (TWEETY) | SPASS (adapter) |
|---|---|---|
| inconsistent `Rain, !Rain` | False | **False** ✓ |
| consistent `[](Rain⇒Wet), Rain` | True | **True** ✓ |
| **12-atom propositional chain** | **OOM → None** | **True** ✓ |
| **12-atom modal `[](aᵢ⇒aᵢ₊₁)` + `<>(a1)`** | **OOM → None** | **True** ✓ |

The two 12-atom KBs are the FP-16 OOM cases — SPASS decides them, `SimpleMlReasoner` cannot. Encoded as gated `tests/integration/.../test_spass_real.py::TestRealSpassConsistency::test_multi_atom_kb_decides_via_spass_without_oom` (skips honestly where SPASS is not a runnable CLI build, e.g. Windows CI without a binary).

Also firsthand-verified: detection (the new jvm_setup code) registers the adapter from `ext_tools/spass/`, `ModalHandler` loads `SPASSMlReasoner` with it, all verdicts traceable to `(spass)`.

## Notes
- CI **mypy strict** green (8 covered files).
- No file deletions → no cleanup-gate table needed.
- Full write-up: `docs/reports/FP_MODAL_SPASS_ACTIVATION_1234.md`.

## Follow-ups (coordinator-gated)
- **Windows SPASS CLI build** (Cygwin/MSVC) + `.bat` adapter — the canonical pipeline runs on Windows, where no SPASS CLI yet exists; until then modal-SPASS is honest-degraded (`None`) there, decided only on the Linux/WSL stack.
- **Binary vendoring policy** — vendor a prebuilt SPASS under `ext_tools/` (as `eprover.exe` is) vs build-from-source only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)