### PR TITLE
fix(logic): R467 harden Prover9 (timeout) + extend external-prover guard to 7 contracts

### DIFF
--- a/argumentation_analysis/core/prover9_runner.py
+++ b/argumentation_analysis/core/prover9_runner.py
@@ -46,14 +46,29 @@ def run_prover9(input_content: str) -> str:
         temp_input_path_quoted = f'"{temp_input_path}"'
         command_str = f"{executable_path_quoted} -f {temp_input_path_quoted}"
 
-        process = subprocess.run(
-            command_str,
-            capture_output=True,
-            text=True,
-            cwd=str(PROVER9_BIN_DIR),
-            encoding="cp1252",
-            shell=True,
-        )
+        # R467: a hard timeout is mandatory. ``subprocess.run`` with no timeout
+        # hangs the whole pipeline indefinitely if Prover9 deadlocks (the
+        # prover9.bat wrapper itself documents a no-args deadlock). An infinite
+        # hang is a *silent* failure — anti-théâtre #1019 demands it surface.
+        # A genuine consistency check on a small KB returns in well under 1s;
+        # 60s is a generous ceiling. A timeout is re-raised as RuntimeError so
+        # the caller falls back to the Tweety reasoner (honest, labelled) instead
+        # of blocking forever.
+        try:
+            process = subprocess.run(
+                command_str,
+                capture_output=True,
+                text=True,
+                cwd=str(PROVER9_BIN_DIR),
+                encoding="cp1252",
+                shell=True,
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired as e:
+            raise RuntimeError(
+                f"Prover9 timed out after {e.timeout}s (deadlock or runaway "
+                "search) — surfacing instead of hanging the pipeline."
+            ) from e
         # FP-8 verify-the-verification: Prover9's exit code is SEMANTIC, not a
         # success/failure signal. Exit 2 with "SEARCH FAILED" is the NORMAL
         # outcome for a consistency check on a CONSISTENT KB (no proof of $F
@@ -67,8 +82,7 @@ def run_prover9(input_content: str) -> str:
         stdout = process.stdout
         if "Fatal error" in stdout:
             raise RuntimeError(
-                "Prover9 reported a fatal error (likely malformed input):\n"
-                f"{stdout}"
+                "Prover9 reported a fatal error (likely malformed input):\n" f"{stdout}"
             )
         return stdout
     finally:

--- a/scripts/verify_all_external_solvers_live.py
+++ b/scripts/verify_all_external_solvers_live.py
@@ -1,0 +1,128 @@
+"""Firsthand, NO-MOCKS sweep of EVERY external solver path — not just Clingo
+(R467 follow-up: "tu as vérifié tous les autres composants externes?").
+
+For each external-binary path we run a known-INCONSISTENT and known-CONSISTENT
+synthetic KB through the production code and print exactly what it does:
+a real verdict (True/False), an honest None/raise (cannot decide), or — the
+thing we hunt — a FABRICATED verdict from a silent fallback (theatre #1019).
+
+Covers: EProver (FOL default), Prover9 (FOL alt), the Tweety FOL fallback that
+both fall back to, PySAT (PL), SAT handler (_invoke_sat), Clingo (ASP).
+Modal/SPASS is po-2025's — probed read-only for completeness.
+
+Synthetic atoms only — no corpus.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+from argumentation_analysis.core.jvm_setup import initialize_jvm, EXTERNAL_TOOL_PATHS
+from argumentation_analysis.core.config import settings, SolverChoice
+from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
+FOL_INC = "Mortal = {socrate}\ntype(Human(Mortal))\nHuman(socrate)\n!Human(socrate)"
+FOL_CON = "Mortal = {socrate}\ntype(Human(Mortal))\nHuman(socrate)"
+
+
+def line(label, verdict, detail=""):
+    print(f"  {label:<34} verdict={verdict!r:>7}  | {detail[:90]}")
+
+
+def fol_under(bridge, solver_choice):
+    prev = settings.solver
+    settings.solver = solver_choice
+    try:
+        vi, mi = bridge.check_consistency(FOL_INC, "first_order")
+        vc, mc = bridge.check_consistency(FOL_CON, "first_order")
+        line(f"FOL[{solver_choice.value}] INCONSISTENT", vi, mi)
+        line(f"FOL[{solver_choice.value}] CONSISTENT", vc, mc)
+        # Honest contract: inconsistent KB must NOT come back True.
+        if vi is True:
+            print(
+                "    >>> THEATRE: a contradiction was reported CONSISTENT (fabrication)."
+            )
+        elif vi is False:
+            print("    >>> OK: contradiction decided inconsistent.")
+        else:
+            print("    >>> fail-loud (None) — honest, no fabrication.")
+    except Exception as e:  # noqa: BLE001
+        print(
+            f"    FOL[{solver_choice.value}] raised {type(e).__name__}: {str(e)[:120]}"
+        )
+    finally:
+        settings.solver = prev
+
+
+def main():
+    initialize_jvm()
+    print("\n=== External binary inventory (firsthand) ===")
+    for k in ("eprover", "spass", "clingo"):
+        print(f"  EXTERNAL_TOOL_PATHS[{k:8}] = {EXTERNAL_TOOL_PATHS.get(k)}")
+    p9 = Path("libs/prover9/bin/prover9.bat")
+    print(f"  prover9.bat present       = {p9.is_file()}  ({p9})")
+    try:
+        import pysat  # noqa
+
+        print("  pysat package             = present")
+    except ImportError:
+        print("  pysat package             = ABSENT")
+    try:
+        import clingo  # noqa
+
+        print("  clingo python package     = present")
+    except ImportError:
+        print("  clingo python package     = ABSENT")
+
+    bridge = TweetyBridge()
+
+    print("\n=== FOL — EProver (default) ===")
+    fol_under(bridge, SolverChoice.EPROVER)
+
+    print("\n=== FOL — Prover9 (alt; binary absent => fallback path) ===")
+    fol_under(bridge, SolverChoice.PROVER9)
+
+    print("\n=== FOL — Tweety fallback (the path both fall back to) ===")
+    fol_under(bridge, SolverChoice.TWEETY)
+
+    print("\n=== PL — PySAT (production path) ===")
+    try:
+        vi, mi = bridge.check_consistency("a\n!a", "propositional")
+        vc, mc = bridge.check_consistency("a\nb", "propositional")
+        line("PL INCONSISTENT", vi, mi)
+        line("PL CONSISTENT", vc, mc)
+    except Exception as e:  # noqa: BLE001
+        print(f"  PL raised {type(e).__name__}: {str(e)[:120]}")
+
+    print("\n=== SAT — _invoke_sat (PySAT-backed) ===")
+    try:
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_sat
+
+        loop = asyncio.new_event_loop()
+        res = loop.run_until_complete(_invoke_sat("a & !a", {}))
+        print(f"  _invoke_sat('a & !a') -> {str(res)[:160]}")
+    except Exception as e:  # noqa: BLE001
+        print(f"  _invoke_sat raised {type(e).__name__}: {str(e)[:120]}")
+
+    print("\n=== ASP — Clingo (already fixed; re-confirm genuine) ===")
+    try:
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_asp_reasoning,
+        )
+
+        loop = asyncio.new_event_loop()
+        res = loop.run_until_complete(_invoke_asp_reasoning("a.\nb :- a.", {}))
+        sets = [set(m) for m in res.get("answer_sets", [])]
+        print(
+            f"  ASP solver={res.get('solver')!r}  sets={sets}  "
+            f"{'OK' if {'a','b'} in sets else 'SUSPECT'}"
+        )
+    except Exception as e:  # noqa: BLE001
+        print(f"  ASP raised {type(e).__name__}: {str(e)[:120]}")
+
+    print("\nDONE.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_prover9_live.py
+++ b/scripts/verify_prover9_live.py
@@ -1,0 +1,42 @@
+"""Firsthand: Prover9 is fully installed (prover9.exe + cygwin1.dll) yet
+selecting SolverChoice.PROVER9 silently yields SimpleFolReasoner. Surface the
+raw reason (R467 — a present external binary should DECIDE, or we must know why
+it doesn't). Synthetic atoms only."""
+
+import sys
+from argumentation_analysis.core.jvm_setup import initialize_jvm
+
+
+def main():
+    initialize_jvm()
+    import argumentation_analysis.core.prover9_runner as pr
+
+    print(f"PROVER9_EXECUTABLE = {pr.PROVER9_EXECUTABLE}")
+    print(f"  exists = {pr.PROVER9_EXECUTABLE.is_file()}")
+
+    # Minimal inconsistent KB in Prover9 syntax: Human(socrate) & -Human(socrate)
+    p9_input = (
+        "formulas(assumptions).\n"
+        "Human(socrate).\n"
+        "-Human(socrate).\n"
+        "end_of_list.\n\n"
+        "formulas(goals).\n"
+        "$F.\n"
+        "end_of_list."
+    )
+    try:
+        out = pr.run_prover9(p9_input)
+        print("--- prover9 raw output (first 700 chars) ---")
+        print(out[:700])
+        print(
+            f"--- 'THEOREM PROVED' present? {'THEOREM PROVED' in out} "
+            f"(=> inconsistent if present)"
+        )
+    except Exception as e:  # noqa: BLE001
+        print(f"PROVER9 RAISED: {type(e).__name__}")
+        print(str(e)[:600])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_external_provers_wired.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_external_provers_wired.py
@@ -123,6 +123,77 @@ def test_eprover_decides_inconsistent_when_binary_present():
 
 
 # --------------------------------------------------------------------------- #
+# Prover9 / FOL (alt) — the binary is fully installed (prover9.exe + cygwin1.dll
+# + mace4.exe under libs/prover9/bin/). R467 sweep firsthand-confirmed it
+# genuinely DECIDES standalone ("THEOREM PROVED" on a contradiction in ~0.00s).
+# Two guards: (1) the binary still decides when fed real Prover9 syntax — so an
+# archived/broken install becomes a red build, the EProver #1204 failure mode in
+# the Prover9 dimension; (2) selecting PROVER9 through the production bridge must
+# yield the CORRECT verdict (the Tweety->Prover9 syntax gap routes it to an
+# honest SimpleFolReasoner fallback — that is fine; a FABRICATED verdict is not).
+# --------------------------------------------------------------------------- #
+def test_prover9_binary_genuinely_decides():
+    """Firsthand: the installed Prover9 binary must DECIDE an inconsistent KB
+    (fed in real Prover9 syntax). 'THEOREM PROVED' on {Human(socrate),
+    -Human(socrate)} |- $F means it genuinely refuted the KB. If the binary is
+    archived/broken later, this goes red instead of a silent month-late hand
+    discovery (the #1204 / R467 pattern)."""
+    from argumentation_analysis.core import prover9_runner
+
+    if not prover9_runner.PROVER9_EXECUTABLE.is_file():
+        pytest.skip("Prover9 binary not installed — cannot test the FOL alt solver.")
+
+    p9_input = (
+        "formulas(assumptions).\n"
+        "Human(socrate).\n"
+        "-Human(socrate).\n"
+        "end_of_list.\n\n"
+        "formulas(goals).\n"
+        "$F.\n"
+        "end_of_list."
+    )
+    out = prover9_runner.run_prover9(p9_input)
+    assert "THEOREM PROVED" in out, (
+        "Prover9 binary is installed but did NOT prove $F from a contradiction — "
+        f"it no longer decides (silent disconnect). Raw tail:\n{out[-400:]!r}"
+    )
+
+
+def test_prover9_selection_yields_correct_verdict_never_fabricated():
+    """Selecting SolverChoice.PROVER9 must produce the CORRECT verdict on an
+    inconsistent FOL KB. The Tweety->Prover9 syntax-translation gap means the
+    binary path raises 'Fatal error' and the bridge falls back to the Tweety
+    SimpleFolReasoner — an HONEST, labelled fallback. The invariant: the
+    contradiction is reported inconsistent (False), or fails loud (None); it is
+    NEVER fabricated as consistent (True). A timeout (added R467) turns a hang
+    into a fast honest fallback rather than blocking the pipeline."""
+    from argumentation_analysis.core import prover9_runner
+
+    if not EXTERNAL_TOOL_PATHS.get("eprover") and not (
+        prover9_runner.PROVER9_EXECUTABLE.is_file()
+    ):
+        pytest.skip("No FOL backend present — cannot test PROVER9 selection.")
+
+    from argumentation_analysis.core.config import settings, SolverChoice
+    from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
+    prev = settings.solver
+    settings.solver = SolverChoice.PROVER9
+    try:
+        bridge = TweetyBridge()
+        kb = "Mortal = {socrate}\ntype(Human(Mortal))\nHuman(socrate)\n!Human(socrate)"
+        verdict, msg = bridge.check_consistency(kb, "first_order")
+    finally:
+        settings.solver = prev
+
+    assert verdict in (False, None), (
+        f"PROVER9-selected FOL reported a contradiction as CONSISTENT "
+        f"(verdict={verdict!r}) — a fabricated verdict (anti-théâtre #1019). "
+        f"Honest outcomes are inconsistent (False) or fail-loud (None). msg={msg!r}"
+    )
+
+
+# --------------------------------------------------------------------------- #
 # PySAT / PL — must decide via PySAT, not the Tweety fallback.
 # --------------------------------------------------------------------------- #
 def test_pysat_decides_pl_consistency():
@@ -134,6 +205,34 @@ def test_pysat_decides_pl_consistency():
     assert (
         inc is False and con is True
     ), f"PL consistency wrong: inconsistent->{inc}, consistent->{con}"
+
+
+# --------------------------------------------------------------------------- #
+# SAT — _invoke_sat is PySAT-backed (NOT the dead ext_tools/*.py scripts).
+# Must genuinely decide SAT/UNSAT, never fabricate.
+# --------------------------------------------------------------------------- #
+def test_sat_decided_by_pysat():
+    """_invoke_sat routes through SATHandler -> pysat.solvers.Solver (genuine).
+    'a & !a' is UNSAT; 'a' is SAT. If PySAT is uninstalled the handler raises
+    (fail-loud) rather than fabricating — so we surface that as a skip, never a
+    green pass on a dead solver."""
+    try:
+        import pysat  # noqa: F401
+    except ImportError:
+        pytest.skip("PySAT not installed — SAT handler cannot decide (fail-loud).")
+
+    from argumentation_analysis.orchestration.invoke_callables import _invoke_sat
+
+    loop = asyncio.new_event_loop()
+    unsat = loop.run_until_complete(_invoke_sat("a & !a", {}))
+    sat = loop.run_until_complete(_invoke_sat("a", {}))
+    assert unsat.get("satisfiable") is False, (
+        f"contradiction 'a & !a' reported satisfiable={unsat.get('satisfiable')!r} "
+        f"— PySAT disconnect or fabrication (#1019)."
+    )
+    assert (
+        sat.get("satisfiable") is True
+    ), f"'a' reported satisfiable={sat.get('satisfiable')!r} — expected True."
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Context

Continuation of #1238 (Clingo reconnect). The R467 mandate asked to verify **every** external solver firsthand — *"tu as vérifié tous les autres composants externes et pas simplement Clingo?"*. This PR closes that sweep.

**Firsthand external-solver matrix (synthetic atoms only, no corpus):**

| Solver | Path | Verdict |
|--------|------|---------|
| EProver | FOL default | ✅ decides (inconsistent on contradiction) |
| Prover9 | FOL alt (non-default) | binary ✅ decides standalone; selection → Tweety-syntax gap → **honest** SimpleFolReasoner fallback |
| SimpleFolReasoner | Tweety fallback | ✅ decides small KB |
| PySAT | PL + SAT | ✅ decides SAT/UNSAT |
| Clingo | ASP | ✅ genuine (Python binding, #1238) |
| SPASS | modal | po-2025 owns the re-wire — untouched |

**No new #1019 theatre found.** Two genuine (non-theatre) Prover9 findings addressed:

1. **`run_prover9()` had no subprocess timeout** — a deadlocked `prover9.bat` hung the pipeline indefinitely (witnessed firsthand). Added `timeout=60` + `TimeoutExpired → RuntimeError`, so a hang becomes a fast **honest** fallback instead of an infinite block.
2. **Tweety→Prover9 syntax gap** is an *honest* fallback (non-default solver, labelled), so it's locked in as a **contract**, not silently "fixed".

## Guard extended (4 → 7 tests, all pass firsthand)

- `test_prover9_binary_genuinely_decides` — the installed binary still proves `\$F` from a contradiction; an archived/broken install → red build (the #1204 pattern in the Prover9 dimension).
- `test_prover9_selection_yields_correct_verdict_never_fabricated` — PROVER9 selection yields inconsistent (`False`) or fail-loud (`None`), **never** fabricated consistent (`True`).
- `test_sat_decided_by_pysat` — `_invoke_sat` decides via genuine PySAT (not the dead `ext_tools` scripts), skips fail-loud if PySAT absent.

\`\`\`
7 passed in ~2s
\`\`\`

## Files

| File | Type | Reason |
|------|------|--------|
| `argumentation_analysis/core/prover9_runner.py` | source | add subprocess `timeout=60` + honest `TimeoutExpired` surfacing |
| `tests/.../test_external_provers_wired.py` | test | +3 guard contracts (Prover9 ×2, SAT) |
| `scripts/verify_all_external_solvers_live.py` | diagnostic | firsthand no-mocks sweep of all external paths |
| `scripts/verify_prover9_live.py` | diagnostic | focused Prover9 probe |

No files removed. Synthetic atoms only — no corpus, no plaintext.

🤖 Coordinator ai-01 — R467