### PR TITLE
feat(report): FP-17 #1236 honest-absent surfacing for structured-arg + translator scoping gate

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -419,6 +419,16 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         self.dialogue_results: List[Dict[str, Any]] = []
         self.probabilistic_results: List[Dict[str, Any]] = []
         self.bipolar_results: List[Dict[str, Any]] = []
+        # Structured-argumentation honest-absent status (FP-17 #1236). The
+        # formalisms ASPIC+/ABA/SETAF/weighted/bipolar require a text→structured
+        # translator (defeasible rules, assumptions+contraries, collective
+        # attacks, weights, support-relations) that is NOT wired — the
+        # translation-gap diagnosed in FP-4 (#1201). On real corpora they run on
+        # auto-shaped synthetic input, so an empty extension list means "never
+        # genuinely fed structured input", NOT "evaluated, found nothing". This
+        # map records that distinction per capability so the snapshot/report can
+        # surface it instead of a silent [] (#1019). Keyed by capability name.
+        self.structured_arg_status: Dict[str, Dict[str, Any]] = {}
         # Logic agent analysis results (#71 formal verification)
         self.fol_analysis_results: List[Dict[str, Any]] = []
         self.fol_signature: List[str] = []  # Pre-declared sorts/types (#348)
@@ -781,6 +791,42 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         state_logger.info(f"Bipolar result added: {bp_id} (type: {framework_type})")
         return bp_id
 
+    def add_structured_arg_status(
+        self,
+        capability: str,
+        status: str,
+        degraded: bool,
+        reason: str,
+        extension_count: int = 0,
+    ) -> None:
+        """Record the honest-absent status of a structured-arg capability (FP-17 #1236).
+
+        ``status`` is one of:
+
+        - ``"absent_no_translator"`` — the capability ran on auto-shaped
+          synthetic input because no text→structured translator is wired
+          (translation-gap FP-4 #1201). Its empty/degenerate extension list is
+          **not** a genuine evaluation of the source. ``degraded`` is ``True``.
+        - ``"evaluated"`` — genuine structured input (defeasible rules,
+          assumptions+contraries, collective attacks, weights, supports) was
+          supplied via context, so the framework reflects real structure.
+
+        This only *labels* what happened; it never fabricates extensions
+        (#1019). Keyed by ``capability`` (last write wins — one status per
+        capability per run).
+        """
+        self.structured_arg_status[capability] = {
+            "capability": capability,
+            "status": status,
+            "degraded": degraded,
+            "reason": reason,
+            "extension_count": extension_count,
+        }
+        state_logger.info(
+            f"Structured-arg status: {capability} = {status} "
+            f"(degraded={degraded}, extensions={extension_count})"
+        )
+
     def add_fol_analysis_result(
         self,
         formulas: List[str],
@@ -1110,6 +1156,11 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
                     "dialogue_result_count": len(self.dialogue_results),
                     "probabilistic_result_count": len(self.probabilistic_results),
                     "bipolar_result_count": len(self.bipolar_results),
+                    # FP-17 (#1236): surface the FULL honest-absent map even in
+                    # the summarized snapshot — a count would re-hide the very
+                    # distinction (absent_no_translator vs evaluated) this field
+                    # exists to expose (#1019). The map is small (≤5 entries).
+                    "structured_arg_status": dict(self.structured_arg_status),
                     "fol_analysis_count": len(self.fol_analysis_results),
                     "propositional_analysis_count": len(
                         self.propositional_analysis_results
@@ -1155,6 +1206,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
                     "dialogue_results": self.dialogue_results,
                     "probabilistic_results": self.probabilistic_results,
                     "bipolar_results": self.bipolar_results,
+                    "structured_arg_status": self.structured_arg_status,
                     "fol_analysis_results": self.fol_analysis_results,
                     "propositional_analysis_results": self.propositional_analysis_results,
                     "modal_analysis_results": self.modal_analysis_results,

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -8,9 +8,106 @@ Split from unified_pipeline.py (#310).
 """
 
 import logging
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Tuple
 
 logger = logging.getLogger("UnifiedPipeline")
+
+
+# FP-17 (#1236): the structured-argumentation formalisms below have NO
+# text→structured translator wired (translation-gap, FP-4 #1201). On real
+# corpora the pipeline feeds them AUTO-SHAPED synthetic input (rules / attacks /
+# supports derived from the bare argument graph), so an empty extension list
+# means "never genuinely evaluated", NOT "evaluated, found nothing". A
+# capability is genuinely fed structured input only when the caller supplies the
+# formalism-specific artifact via context — the keys below (a future,
+# user/coord-gated translator would populate them). Until then the honest status
+# is "absent_no_translator", surfaced explicitly, never a silent [] (#1019).
+_STRUCTURED_ARG_INPUT_KEYS: Dict[str, Tuple[str, ...]] = {
+    "aspic_plus_reasoning": ("strict_rules", "defeasible_rules"),
+    "aba_reasoning": ("contraries",),
+    "setaf_reasoning": ("set_attacks",),
+    "weighted_argumentation": ("weighted_attacks",),
+    "bipolar_argumentation": ("supports",),
+}
+
+# Per-formalism reason string explaining what extraction is missing. Kept in the
+# state so a reader sees *why* the axis is absent, not just that it is.
+_STRUCTURED_ARG_ABSENT_REASON: Dict[str, str] = {
+    "aspic_plus_reasoning": (
+        "ASPIC+ not genuinely evaluated: no translator extracts defeasible/"
+        "strict rules + preferences from the source. Ran on auto-shaped "
+        "synthetic rules — not fabricated, but not a genuine ASPIC+ analysis "
+        "of the text."
+    ),
+    "aba_reasoning": (
+        "ABA not genuinely evaluated: no translator extracts assumptions + "
+        "their contraries from the source. Ran on auto-shaped synthetic rules "
+        "without genuine contraries."
+    ),
+    "setaf_reasoning": (
+        "SetAF not genuinely evaluated: no translator extracts collective "
+        "(joint) attacks from the source. Ran on auto-shaped synthetic "
+        "pairwise attacks lifted to singletons."
+    ),
+    "weighted_argumentation": (
+        "Weighted AF not genuinely evaluated: no translator extracts attack "
+        "weights from the source. Ran on auto-shaped synthetic attacks with "
+        "neutral placeholder weights."
+    ),
+    "bipolar_argumentation": (
+        "Bipolar AF not genuinely evaluated: no translator extracts support "
+        "relations from the source. Ran on auto-shaped synthetic attacks with "
+        "no genuine supports."
+    ),
+}
+
+
+def _record_structured_arg_status(
+    state: Any, capability: str, output: Any, ctx: dict[str, Any]
+) -> None:
+    """Surface the honest-absent status of a structured-arg capability (FP-17 #1236).
+
+    Records ``status="absent_no_translator"`` (+ ``degraded=True``) when the
+    context carried no genuine formalism-specific structured input — the
+    translation-gap reality (FP-4 #1201) — or ``status="evaluated"`` when it
+    did. Only labels what happened; never fabricates extensions (#1019).
+    No-op on states that predate ``add_structured_arg_status`` (defensive).
+    """
+    recorder = getattr(state, "add_structured_arg_status", None)
+    if not callable(recorder):
+        return
+    keys = _STRUCTURED_ARG_INPUT_KEYS.get(capability, ())
+    has_genuine_input = any(ctx.get(k) for k in keys)
+    # Extension/support count from the handler output, 0-safe.
+    ext_count = 0
+    if isinstance(output, dict):
+        exts = output.get("extensions")
+        if exts is None:
+            exts = output.get("supports")
+        if isinstance(exts, list):
+            ext_count = len(exts)
+    if has_genuine_input:
+        recorder(
+            capability,
+            "evaluated",
+            False,
+            "Genuine structured input supplied via context; framework "
+            "evaluated on real structured artifacts.",
+            ext_count,
+        )
+    else:
+        recorder(
+            capability,
+            "absent_no_translator",
+            True,
+            _STRUCTURED_ARG_ABSENT_REASON.get(
+                capability,
+                "No text→structured translator wired; ran on auto-shaped "
+                "synthetic input (translation-gap FP-4 #1201).",
+            ),
+            ext_count,
+        )
+
 
 __all__ = [
     "_write_quality_to_state",
@@ -460,9 +557,7 @@ def _write_hierarchical_fallacy_to_state(
             if _source_arg_id and _source_arg_id in state.identified_arguments:
                 target_arg_id = _source_arg_id
         if not target_arg_id:
-            target_arg_id = _resolve_target_arg_id(
-                state, f.get("target_argument", "")
-            )
+            target_arg_id = _resolve_target_arg_id(state, f.get("target_argument", ""))
         if not target_arg_id:
             target_arg_id = _resolve_target_arg_id(
                 state, f.get("problematic_quote", "")
@@ -550,6 +645,7 @@ def _write_ranking_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> Non
 
 def _write_aspic_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write ASPIC+ analysis results to UnifiedAnalysisState."""
+    _record_structured_arg_status(state, "aspic_plus_reasoning", output, ctx)
     if not output or not isinstance(output, dict):
         return
     reasoner_type = str(output.get("reasoner_type", "simple"))
@@ -605,6 +701,7 @@ def _write_probabilistic_to_state(output: Any, state: Any, ctx: dict[str, Any]) 
 
 def _write_bipolar_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write bipolar argumentation results to UnifiedAnalysisState."""
+    _record_structured_arg_status(state, "bipolar_argumentation", output, ctx)
     if not output or not isinstance(output, dict):
         return
     fw_type = str(output.get("framework_type", "necessity"))
@@ -619,6 +716,7 @@ def _write_bipolar_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> Non
 
 def _write_aba_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write ABA reasoning results to UnifiedAnalysisState (stored as Dung framework)."""
+    _record_structured_arg_status(state, "aba_reasoning", output, ctx)
     if not output or not isinstance(output, dict):
         return
     assumptions = output.get("assumptions", [])
@@ -737,7 +835,10 @@ def _write_fol_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     # Preserve None (unverified) vs True (consistent) vs False (inconsistent).
     # bool(None) == False would silently conflate "unknown" with "inconsistent" (#1019).
     state.add_fol_analysis_result(
-        formulas, consistent if consistent is not None else None, inferences, float(confidence)
+        formulas,
+        consistent if consistent is not None else None,
+        inferences,
+        float(confidence),
     )
     # Store FOL signature metadata (#348)
     fol_signature = output.get("fol_signature", [])
@@ -886,6 +987,7 @@ def _write_sat_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
 
 def _write_setaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write SetAF results to UnifiedAnalysisState (#87)."""
+    _record_structured_arg_status(state, "setaf_reasoning", output, ctx)
     if not output or not isinstance(output, dict):
         return
     state.add_dung_framework(
@@ -898,6 +1000,7 @@ def _write_setaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
 
 def _write_weighted_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write Weighted AF results to UnifiedAnalysisState (#87)."""
+    _record_structured_arg_status(state, "weighted_argumentation", output, ctx)
     if not output or not isinstance(output, dict):
         return
     state.add_dung_framework(
@@ -1055,9 +1158,7 @@ def _write_act2_narrative_to_state(
         state.act2_narrative = narrative
 
 
-def _write_act1_framing_to_state(
-    output: Any, state: Any, ctx: dict[str, Any]
-) -> None:
+def _write_act1_framing_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write the Acte I framing narrative to UnifiedAnalysisState (#1136).
 
     Populates ``state.act1_framing`` — the key the R6 renderer consumes for

--- a/argumentation_analysis/reporting/restitution/appendix.py
+++ b/argumentation_analysis/reporting/restitution/appendix.py
@@ -89,6 +89,27 @@ def _provenance_counts(state: Mapping[str, Any]) -> Dict[str, Any]:
     counts["axe_dung"] = "disponible" if _g("dung_frameworks") else "indisponible"
     counts["axe_aspic"] = "disponible" if _g("aspic_results") else "indisponible"
 
+    # Structured-argumentation honesty (FP-17 #1236). ASPIC+/ABA/SETAF/weighted/
+    # bipolar have no text→structured translator wired (translation-gap FP-4
+    # #1201), so an empty extension list is NOT "evaluated, empty" — it is
+    # "never genuinely fed structured input". Surface that per-capability status
+    # explicitly so the bare ``axe_aspic = disponible`` above is not misread as
+    # a real structured-arg analysis of the source (#1019: no silent []).
+    sa_status = _g("structured_arg_status")
+    if isinstance(sa_status, Mapping) and sa_status:
+        parts = []
+        for cap, info in sa_status.items():
+            st = info.get("status", "?") if isinstance(info, Mapping) else "?"
+            label = (
+                "absent (aucun traducteur structuré)"
+                if st == "absent_no_translator"
+                else str(st)
+            )
+            parts.append(f"{cap}={label}")
+        counts["arg_structuree"] = "; ".join(parts)
+    else:
+        counts["arg_structuree"] = "indisponible"
+
     counts["synthese_narrative"] = (
         "présente" if _g("narrative_synthesis") else "absente"
     )

--- a/argumentation_analysis/reporting/restitution/state_adapter.py
+++ b/argumentation_analysis/reporting/restitution/state_adapter.py
@@ -28,6 +28,7 @@ _STATE_KEYS = (
     "modal_analysis_results",
     "dung_frameworks",
     "aspic_results",
+    "structured_arg_status",
     "narrative_synthesis",
     "formal_synthesis_reports",
     "stakes_and_stakeholders",

--- a/docs/architecture/STRUCTURED_ARG_TRANSLATOR_SCOPING.md
+++ b/docs/architecture/STRUCTURED_ARG_TRANSLATOR_SCOPING.md
@@ -1,0 +1,173 @@
+# Structured-Argumentation Translator — Scoping & Go/No-Go Gate (FP-17 #1236)
+
+**Status:** scoping only — the translator is **NOT built**. This document converts
+the structured-argumentation blind-spot (Epic #1191) into a *decidable* user/coord
+gate. It is the companion to the honest-absent surfacing delivered in the same
+track (#1236): the report and state snapshot now label these axes
+`absent_no_translator` instead of emitting a silent empty list.
+
+**Parent:** Epic #1191 (formal depth-parity). **Predecessor diagnostic:** FP-4
+(#1201, MERGED). **Anti-pendule (#1019):** honest-absent is the correct output
+until the gate is decided — we do **not** fabricate extensions to manufacture
+"parity".
+
+---
+
+## 1. The gap, precisely
+
+FP-4 (#1201) root-caused why **ASPIC+ / ABA / SETAF / weighted / bipolar** produce
+**0 extensions** on real corpora while Dung-core yields genuine ones:
+
+> The handlers and orchestrator shapers are correctly wired and **fail-loud**
+> (FP-2 #1193). But the pipeline **never feeds them genuine structured input** —
+> defeasible rules, assumptions+contraries, collective attacks, attack weights,
+> support relations are never extracted from the text. The handlers run real
+> Tweety on **auto-shaped synthetic input** derived from the bare argument graph,
+> which collapses to a trivial framework → empty/degenerate result.
+
+This is a **translation-gap**, not a reasoner bug. Dung-core works because a binary
+attack graph *can* be auto-shaped from pairwise argument relations; the richer
+formalisms need structure that simply is not in the argument graph.
+
+What `_extract_arguments_from_context` + the `_*_from_context` shapers produce today
+(see `orchestration/invoke_callables.py`) is the synthetic stand-in. The genuine
+input each handler *expects* already exists as a context key (a future translator
+would populate it):
+
+| Formalism | Capability | Genuine-input context key | Auto-shaped stand-in today |
+|---|---|---|---|
+| ASPIC+ | `aspic_plus_reasoning` | `strict_rules`, `defeasible_rules` | rules synthesised from claims/args (`_invoke_aspic`) |
+| ABA | `aba_reasoning` | `contraries` (+ assumptions) | rules from arg graph, `contraries=None` (`_invoke_aba`) |
+| SetAF | `setaf_reasoning` | `set_attacks` (collective/joint) | pairwise attacks lifted to singletons (`_setaf_attacks_from_pairs`) |
+| Weighted | `weighted_argumentation` | `weighted_attacks` (s,t,w triples) | pairwise attacks at neutral weight 0.5 (`_weighted_attacks_from_pairs`) |
+| Bipolar | `bipolar_argumentation` | `supports` | `supports=[]` (`_invoke_bipolar`) |
+
+The honest-absent surfacing (#1236) keys off exactly these context keys: when none
+is present, the capability is `absent_no_translator`; when a caller (or a future
+translator) supplies them, the status flips to `evaluated` automatically — no
+further wiring needed.
+
+---
+
+## 2. Per-formalism input contract & extraction requirements
+
+For each formalism: **(a)** the handler's existing input contract (what it already
+accepts), and **(b)** what a text→structured translator would have to extract to
+make the extensions genuine. Examples use opaque IDs only (`doc_A`, `arg_1`).
+
+### 2.1 ASPIC+ (`aspic_plus_reasoning`)
+- **Contract:** strict rules + defeasible rules as `{head, body:[...]}` dicts over
+  PL atoms; an optional preference order over defeasible rules.
+- **Extraction needed:**
+  1. **Strict rules** — entailments the author treats as indefeasible
+     ("by definition", "necessarily").
+  2. **Defeasible rules** — typical/presumptive inferences ("generally",
+     "usually", "tends to").
+  3. **Preferences** — which rule wins when two conflict (priority cues:
+     "more importantly", "but above all").
+- **Why auto-shaping fails:** synthesising strict rules from extracted claims gives
+  rules with no real defeat relation → grounded extension = all of it, no genuine
+  ASPIC+ dialectic.
+
+### 2.2 ABA (`aba_reasoning`)
+- **Contract:** a set of assumptions, inference rules `{head, body}`, and a
+  `contraries` map (assumption → its contrary literal).
+- **Extraction needed:**
+  1. **Assumptions** — defeasible premises taken for granted.
+  2. **Contraries** — what would defeat each assumption (the crux; without it ABA
+     degenerates to flat inference).
+  3. **Rules** linking assumptions to conclusions.
+- **Why auto-shaping fails:** `contraries=None` ⇒ no assumption can be attacked ⇒
+  every assumption-set is trivially "admissible".
+
+### 2.3 SetAF (`setaf_reasoning`)
+- **Contract:** arguments + **collective** attacks `{attackers:[...], target}` where
+  a *set* of arguments jointly attacks a target (no single one suffices).
+- **Extraction needed:** identify joint-attack structure — "X and Y *together*
+  refute Z". Pairwise extraction cannot represent this.
+- **Why auto-shaping fails:** lifting pairwise attacks to singleton sets makes SetAF
+  collapse to ordinary Dung — the collective semantics never engages.
+
+### 2.4 Weighted AF (`weighted_argumentation`)
+- **Contract:** arguments + weighted attacks `(source, target, weight)` + an
+  inconsistency budget γ.
+- **Extraction needed:** a **strength/confidence** per attack (hedging cues, evidence
+  quality) and a defensible γ.
+- **Why auto-shaping fails:** a uniform 0.5 weight (no fabricated confidence, #1019)
+  carries no information → weighted semantics ≡ unweighted.
+
+### 2.5 Bipolar AF (`bipolar_argumentation`)
+- **Contract:** arguments + attacks + **supports** `(supporter, supported)`, under a
+  chosen support interpretation (necessity / deductive / evidential).
+- **Extraction needed:** **support relations** — "X backs Y", "this reinforces" —
+  distinct from attacks, plus the intended support semantics.
+- **Why auto-shaping fails:** `supports=[]` ⇒ the bipolar layer is inert; result ≡
+  the underlying Dung framework.
+
+---
+
+## 3. Phased plan (only if the gate says GO)
+
+Each phase is independently shippable and independently honest (a partial translator
+upgrades *some* axes from `absent_no_translator` to `evaluated`; the rest stay
+honestly absent).
+
+- **Phase 0 — harness (no LLM).** A `StructuredArgInput` contract object + a
+  pass-through that lets a caller inject genuine structured input via the existing
+  context keys. Lets tests drive `evaluated` paths with hand-authored synthetic
+  structure. *This is the seam #1236 already targets — the status flips for free.*
+- **Phase 1 — bipolar + weighted (lowest extraction cost).** Support-cue and
+  hedging-cue extraction (deterministic lexicon first, LLM-assisted second). These
+  need one new relation/scalar each, no rule algebra.
+- **Phase 2 — ABA (assumptions + contraries).** Contrary extraction is the unit of
+  value; reuse the fallacy/claim layer for assumptions.
+- **Phase 3 — ASPIC+ (strict/defeasible + preferences).** Largest surface: a
+  rule-mining pass over claims with strict/defeasible classification + preference
+  cues.
+- **Phase 4 — SetAF (collective attacks).** Hardest extraction (joint-attack
+  detection); lowest expected corpus frequency — sequence last.
+
+Cross-cutting: every phase keeps the per-backend / per-axis honesty invariant
+(#1019) — a translator that is *uncertain* must yield `absent`/`degraded`, never a
+fabricated rule. Privacy: translator I/O is opaque-ID-only; raw structured artifacts
+derived from corpus stay gitignored under `evaluation/results/`.
+
+---
+
+## 4. Go/No-Go question for the user
+
+> **Do we build the text→structured-argument translator (Section 3), and if so, how
+> far?** Options:
+>
+> - **No-Go (status quo):** keep all five axes `absent_no_translator`. Honest, zero
+>   new LLM cost, no risk of fabricated structure. The report already says so.
+> - **Go — Phase 0 only:** ship the injection harness so genuine structured input
+>   *can* be supplied (by tests, or by an external caller) and is then genuinely
+>   evaluated — without committing to extraction.
+> - **Go — Phases 0–N:** build extraction up to a chosen formalism, accepting the
+>   per-phase LLM cost and the extraction-quality risk (mitigated by the #1019
+>   honest-uncertain rule).
+>
+> Default recommendation absent a decision: **No-Go**, because honest-absent is a
+> correct and complete answer to "is this axis genuine?" — and the surfacing in
+> #1236 makes that answer visible. The translator is value-add, not a correctness
+> fix.
+
+---
+
+## 5. What #1236 delivered (this track, non-gated)
+
+- `UnifiedAnalysisState.structured_arg_status` + `add_structured_arg_status()` —
+  per-capability `{status, degraded, reason, extension_count}`, in the state
+  snapshot (summarized **and** full).
+- `state_writers._record_structured_arg_status()` wired into the five structured-arg
+  writers — labels `absent_no_translator` (degraded) vs `evaluated` from the genuine
+  context keys in §1.
+- The restitution appendix (`reporting/restitution/appendix.py`) surfaces an
+  `arg_structuree` line: `aspic_plus_reasoning=absent (aucun traducteur structuré); …`
+  — so a reader can tell "absent (no translator)" from "evaluated, empty". No silent
+  `[]` (#1019).
+- This scoping doc.
+
+Out of scope (unchanged): the translator itself, and the modal/FOL invoke callables
+(serialization — `invoke_callables.py` is held by FP-19/FP-20).

--- a/tests/unit/argumentation_analysis/orchestration/test_structured_arg_honest_absent.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_structured_arg_honest_absent.py
@@ -1,0 +1,191 @@
+"""FP-17 (#1236) — honest-absent surfacing for structured-arg capabilities.
+
+ASPIC+/ABA/SETAF/weighted/bipolar have no text→structured translator wired
+(translation-gap FP-4 #1201). On real corpora they run on auto-shaped synthetic
+input, so an empty extension list means "never genuinely fed structured input",
+NOT "evaluated, found nothing". These tests pin the contract that the state
+writers + restitution appendix surface that distinction explicitly — never a
+silent ``[]`` (#1019).
+
+No JVM, no LLM. Synthetic atoms only (privacy HARD — no corpus tokens).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.orchestration.state_writers import (
+    _record_structured_arg_status,
+    _write_aba_to_state,
+    _write_aspic_to_state,
+    _write_bipolar_to_state,
+    _write_setaf_to_state,
+    _write_weighted_to_state,
+)
+from argumentation_analysis.reporting.restitution.appendix import (
+    _provenance_counts,
+    render_appendix,
+)
+from argumentation_analysis.reporting.restitution.state_adapter import (
+    state_to_appendix_mapping,
+)
+
+# (capability, writer) pairs — the five formalisms in scope for #1236.
+_WRITERS = [
+    ("aspic_plus_reasoning", _write_aspic_to_state),
+    ("aba_reasoning", _write_aba_to_state),
+    ("setaf_reasoning", _write_setaf_to_state),
+    ("weighted_argumentation", _write_weighted_to_state),
+    ("bipolar_argumentation", _write_bipolar_to_state),
+]
+
+# A genuine-structured-input context per capability (a future translator would
+# populate these keys). Presence of any flips the status to "evaluated".
+_GENUINE_CTX: Dict[str, Dict[str, Any]] = {
+    "aspic_plus_reasoning": {"strict_rules": [{"head": "h", "body": ["b"]}]},
+    "aba_reasoning": {"contraries": {"a": "not_a"}},
+    "setaf_reasoning": {"set_attacks": [{"attackers": ["a", "b"], "target": "c"}]},
+    "weighted_argumentation": {"weighted_attacks": [("a", "b", 0.9)]},
+    "bipolar_argumentation": {"supports": [["a", "b"]]},
+}
+
+
+def _new_state() -> UnifiedAnalysisState:
+    return UnifiedAnalysisState("synthetic structured-arg probe")
+
+
+class TestHonestAbsentEmitted:
+    """Each structured-arg writer records absent_no_translator with no translator."""
+
+    @pytest.mark.parametrize("capability,writer", _WRITERS)
+    def test_empty_output_records_absent_no_translator(self, capability, writer):
+        state = _new_state()
+        # output={} → the writer early-returns, but the status MUST already be
+        # recorded (no silent []): a capability that ran and produced nothing is
+        # labelled, not dropped.
+        writer({}, state, {})
+        assert capability in state.structured_arg_status
+        entry = state.structured_arg_status[capability]
+        assert entry["status"] == "absent_no_translator"
+        assert entry["degraded"] is True
+        assert isinstance(entry["reason"], str) and entry["reason"]
+
+    @pytest.mark.parametrize("capability,writer", _WRITERS)
+    def test_no_genuine_input_is_absent_even_with_a_result(self, capability, writer):
+        # Even when auto-shaped input yields a non-empty result, the absence of
+        # genuine structured input means the verdict is NOT a genuine analysis.
+        state = _new_state()
+        output = {
+            "reasoner_type": "simple",
+            "framework_type": "necessity",
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "assumptions": ["a"],
+            "supports": [],
+            "extensions": [["a"]],
+            "statistics": {},
+        }
+        writer(output, state, {})
+        assert state.structured_arg_status[capability]["status"] == (
+            "absent_no_translator"
+        )
+
+
+class TestGenuineInputFlipsToEvaluated:
+    """Genuine structured input via context flips the status to evaluated."""
+
+    @pytest.mark.parametrize("capability,writer", _WRITERS)
+    def test_genuine_context_marks_evaluated(self, capability, writer):
+        state = _new_state()
+        ctx = _GENUINE_CTX[capability]
+        output = {
+            "reasoner_type": "simple",
+            "framework_type": "necessity",
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "assumptions": ["a"],
+            "supports": ctx.get("supports", []),
+            "extensions": [["a"]],
+            "statistics": {},
+        }
+        writer(output, state, ctx)
+        entry = state.structured_arg_status[capability]
+        assert entry["status"] == "evaluated"
+        assert entry["degraded"] is False
+
+
+class TestRecordHelperDirectly:
+    def test_extension_count_is_zero_safe(self):
+        state = _new_state()
+        _record_structured_arg_status(state, "aspic_plus_reasoning", None, {})
+        assert (
+            state.structured_arg_status["aspic_plus_reasoning"]["extension_count"] == 0
+        )
+
+    def test_supports_counted_when_extensions_absent(self):
+        state = _new_state()
+        _record_structured_arg_status(
+            state,
+            "bipolar_argumentation",
+            {"supports": [["a", "b"], ["b", "c"]]},
+            {"supports": [["a", "b"]]},
+        )
+        entry = state.structured_arg_status["bipolar_argumentation"]
+        assert entry["status"] == "evaluated"
+        assert entry["extension_count"] == 2
+
+    def test_no_op_on_state_without_recorder(self):
+        # Defensive: a plain object lacking the recorder must not raise.
+        _record_structured_arg_status(object(), "aspic_plus_reasoning", {}, {})
+
+
+class TestSnapshotSurfacesStatus:
+    def test_full_snapshot_includes_status(self):
+        state = _new_state()
+        _write_bipolar_to_state({}, state, {})
+        snap = state.get_state_snapshot(summarize=False)
+        assert "structured_arg_status" in snap
+        assert snap["structured_arg_status"]["bipolar_argumentation"]["status"] == (
+            "absent_no_translator"
+        )
+
+    def test_summarized_snapshot_keeps_full_status_not_a_count(self):
+        state = _new_state()
+        _write_aspic_to_state({}, state, {})
+        snap = state.get_state_snapshot(summarize=True)
+        # The full map is kept even in the summary — a bare count would re-hide
+        # the absent_no_translator distinction this field exists to expose.
+        assert isinstance(snap["structured_arg_status"], dict)
+        assert snap["structured_arg_status"]["aspic_plus_reasoning"]["status"] == (
+            "absent_no_translator"
+        )
+
+
+class TestAppendixSurfacesHonestAbsent:
+    def test_appendix_shows_absent_no_silent_empty(self):
+        state = _new_state()
+        for _cap, writer in _WRITERS:
+            writer({}, state, {})
+        mapping = state_to_appendix_mapping(state)
+        assert "structured_arg_status" in mapping
+
+        counts = _provenance_counts(mapping)
+        assert "arg_structuree" in counts
+        line = counts["arg_structuree"]
+        # No silent [] — the reader sees "absent (no translator)" per capability.
+        assert "absent" in line
+        for cap, _writer in _WRITERS:
+            assert cap in line
+
+        rendered = render_appendix(mapping)
+        assert "arg_structuree" in rendered
+        assert "absent" in rendered
+
+    def test_appendix_indisponible_when_no_structured_arg_run(self):
+        state = _new_state()
+        counts = _provenance_counts(state_to_appendix_mapping(state))
+        # Nothing ran → honest "indisponible", still not a silent empty list.
+        assert counts["arg_structuree"] == "indisponible"


### PR DESCRIPTION
## What & why — #1236 (Epic #1191 formal depth-parity)

The five structured-argumentation formalisms — **ASPIC+ / ABA / SETAF / weighted / bipolar** — have **no text→structured translator wired** (translation-gap root-caused in FP-4 #1201, MERGED). On real corpora their handlers run on *auto-shaped synthetic input* derived from the bare argument graph, so an empty extension list means **"never genuinely fed structured input"** — *not* "evaluated, found nothing". Today that surfaces as a silent `[]`, indistinguishable from a genuine empty result.

This PR makes the distinction **explicit** (anti-théâtre #1019) and converts the translator into a **decidable go/no-go gate** — without building it.

## Scope discipline

- **State/report layer ONLY.** Does **not** touch `invoke_callables.py` (held by FP-19 #1245 / FP-20 #1244 serialization).
- **Does not build the translator** and **does not fabricate extensions** (anti-pendule): honest-absent *is* the correct output until the gate is decided.

## Changes

| File | Gated (mypy strict)? | Change |
|---|---|---|
| `core/shared_state.py` | ✅ | `structured_arg_status` field + `add_structured_arg_status()`; surfaced in the snapshot (**summarized keeps the FULL map, not a count** — a count would re-hide the very distinction the field exposes) and full. |
| `orchestration/state_writers.py` | ✅ | `_record_structured_arg_status()` wired into the 5 structured-arg writers. Status = `absent_no_translator` (degraded) vs `evaluated`, decided from the **genuine formalism-specific context keys** (`strict_rules`/`defeasible_rules`, `contraries`, `set_attacks`, `weighted_attacks`, `supports`). A future gated translator that populates those keys flips the status to `evaluated` **for free** — no further wiring. |
| `reporting/restitution/appendix.py` | — | renders an `arg_structuree` line (`aspic_plus_reasoning=absent (aucun traducteur structuré); …`). |
| `reporting/restitution/state_adapter.py` | — | exposes `structured_arg_status` to the appendix. |
| `docs/architecture/STRUCTURED_ARG_TRANSLATOR_SCOPING.md` | — | NEW. Per-formalism input contract + extraction requirements + phased plan + **go/no-go question** (default reco: No-Go). |
| `tests/.../test_structured_arg_honest_absent.py` | — | NEW. 22 tests. |

Status recorded at the **top** of each writer (before the early-return guard) so even empty/`None` output is labelled, never silently dropped.

## Validation

- **22 new tests** (state writers + snapshot + appendix), non-mocked, no JVM/LLM, **synthetic atoms only** (privacy HARD — no corpus tokens). Green.
- **mypy strict** on the gated files (`shared_state.py`, `state_writers.py`): clean.
- **black** + **flake8**: clean.
- The 3 pre-existing `test_unified_pipeline.py` failures (`_invoke_propositional_logic_error`, `_invoke_dung_extensions_error`, `_invoke_hierarchical_fallacy_success`) were verified to fail identically on clean `origin/main` `05ea4555` (no FP-17, no FP-19) — **pre-existing, not a regression**, and untouched here (they exercise `invoke_callables.py`).

## Not closing anything

References #1236. Does **not** close #1204 (that is FP-19 #1245).

🤖 Generated with [Claude Code](https://claude.com/claude-code)