### PR TITLE
fix(logic): FP-22 #1249 kill _python_dung_fallback theatre — fail-loud (#1019)

### DIFF
--- a/argumentation_analysis/agents/core/logic/pl_handler.py
+++ b/argumentation_analysis/agents/core/logic/pl_handler.py
@@ -509,3 +509,181 @@ class PLHandler:
         )
         handler = self._get_sat_handler()
         return handler.query(normalized_kb, normalized_query, settings.pysat_solver)
+
+    # ── Multi-backend comparison (FP-20 #1244, mandate R468) ──────────
+
+    # PySAT backends that DECIDE firsthand (probe 2026-06-23, synthetic atoms):
+    # each returns the correct verdict on BOTH {P}->SAT and {P,!P}->UNSAT.
+    # ``cryptominisat5`` is EXCLUDED: it returns UNSAT on a trivially-SAT formula
+    # (``AttributeError: 'CryptoMinisat' object has no attribute 'cryptosat'`` —
+    # its native binding is broken in this env). Promoting a backend that emits a
+    # wrong verdict would fabricate a comparison point — worse than absent (#1019).
+    # A future env where cryptominisat5 genuinely decides can re-add it; the
+    # per-backend sentinel test guards the decision both ways.
+    PL_COMPARISON_PYSAT_BACKENDS: List[str] = [
+        "cadical195",
+        "glucose42",
+        "maplechrono",
+        "lingeling",
+        "minisat22",
+    ]
+
+    async def compare_pl_backends(self, knowledge_base_str: str) -> dict:
+        """Run ALL available PL/SAT backends on the same KB and compare verdicts.
+
+        FP-20 #1244, mandate R468 ("tous les solvers handy … pour comparer les
+        résultats"). Each backend (5 PySAT + Tweety Sat4j) is run INDEPENDENTLY
+        on the same KB; verdicts are cross-validated. DISAGREEMENT is surfaced
+        explicitly and NEVER silently reconciled — the comparison is the point
+        (#1019).
+
+        Backend set (firsthand-confirmed to decide, synthetic atoms):
+        * 5 PySAT solvers (``PL_COMPARISON_PYSAT_BACKENDS``) — Tseitin→CNF→CDCL.
+        * Tweety ``Sat4jSolver`` via ``SatReasoner`` — pure-Java, linear.
+        * The 3 native DLLs (lingeling/minisat/picosat) are honest-absent
+          (removed #1247 — ``UnsatisfiedLinkError: Binding.init()``). PySAT's own
+          minisat/lingeling *Python* bindings are independent of those DLLs and DO
+          decide here.
+        * ``cryptominisat5`` excluded (broken native binding, see class constant).
+
+        Returns a JSON-serialisable dict mirroring ``compare_fol_backends``::
+
+            {
+              "backends": {name: {"verdict": Optional[bool], "note": str,
+                                  "elapsed_ms": float, "available": bool}},
+              "decided":  {name: bool, …},     # only backends that returned a bool
+              "agreement": Optional[bool],     # all-agree / disagree / <2 decided
+              "disagreement": [str, …],        # explicit, never auto-reconciled
+            }
+        """
+        import time as _time
+
+        formula_strings = [
+            f.strip().rstrip("%")
+            for f in knowledge_base_str.split("\n")
+            if f.strip() and f.strip() != "```"
+        ]
+
+        backend_names = [
+            *(f"pysat:{s}" for s in self.PL_COMPARISON_PYSAT_BACKENDS),
+            "tweety:sat4j",
+        ]
+
+        backends: "dict[str, dict]" = {}
+
+        if not formula_strings:
+            trivial = {
+                "verdict": True,
+                "note": "Empty knowledge base is trivially consistent.",
+                "elapsed_ms": 0.0,
+                "available": True,
+            }
+            for name in backend_names:
+                backends[name] = dict(trivial)
+            return {
+                "backends": backends,
+                "decided": {n: True for n in backends},
+                "agreement": True,
+                "disagreement": [],
+            }
+
+        normalized = [self._normalize_formula(f) for f in formula_strings]
+
+        def _run(name: str, fn) -> None:
+            start = _time.perf_counter()
+            try:
+                is_consistent, note = fn()
+                elapsed = (_time.perf_counter() - start) * 1000.0
+                backends[name] = {
+                    "verdict": is_consistent,
+                    "note": str(note),
+                    "elapsed_ms": round(elapsed, 1),
+                    "available": True,
+                }
+            except Exception as e:
+                elapsed = (_time.perf_counter() - start) * 1000.0
+                backends[name] = {
+                    "verdict": None,
+                    "note": f"unavailable: {e}",
+                    "elapsed_ms": round(elapsed, 1),
+                    "available": False,
+                }
+
+        for sname in self.PL_COMPARISON_PYSAT_BACKENDS:
+            _run(
+                f"pysat:{sname}",
+                lambda s=sname: self._pl_backend_pysat(normalized, s),
+            )
+        _run("tweety:sat4j", lambda: self._pl_backend_sat4j(normalized))
+
+        decided = {
+            name: b["verdict"]
+            for name, b in backends.items()
+            if isinstance(b["verdict"], bool)
+        }
+        verdict_values = set(decided.values())
+        if len(decided) < 2:
+            agreement: "Optional[bool]" = None
+        else:
+            agreement = len(verdict_values) <= 1
+
+        disagreement: "List[str]" = []
+        if agreement is False:
+            consistent_backends = sorted(n for n, v in decided.items() if v is True)
+            inconsistent_backends = sorted(n for n, v in decided.items() if not v)
+            disagreement.append(
+                f"DISAGREEMENT (NOT reconciled): {consistent_backends} report "
+                f"CONSISTENT (SAT), {inconsistent_backends} report INCONSISTENT "
+                "(UNSAT). All backends are sound+complete SAT solvers on PL, so a "
+                "disagreement here is a real backend defect — inspect per-backend "
+                "notes before drawing a conclusion."
+            )
+
+        return {
+            "backends": backends,
+            "decided": decided,
+            "agreement": agreement,
+            "disagreement": disagreement,
+        }
+
+    def _pl_backend_pysat(
+        self, normalized: List[str], solver_name: str
+    ) -> Tuple[bool, str]:
+        """Run ONE PySAT backend on the normalized KB. Raises on failure.
+
+        The handler is lazy-loaded per call so a broken PySAT install degrades
+        this backend independently of the Tweety Sat4j backend (and vice-versa).
+        """
+        handler = self._get_sat_handler()
+        is_sat, _model, stats = handler.solve_formulas(normalized, solver_name)
+        is_consistent = bool(is_sat)
+        return (
+            is_consistent,
+            f"{'SAT' if is_consistent else 'UNSAT'} via PySAT {solver_name}",
+        )
+
+    def _pl_backend_sat4j(self, normalized: List[str]) -> Tuple[bool, str]:
+        """Run Tweety Sat4j (``SatReasoner``) on the normalized KB. Raises on failure.
+
+        ``SatReasoner`` is SAT-based (Tseitin→CNF→Sat4j), linear — distinct from
+        ``SimplePlReasoner`` (model enumeration, 2^n, OOM-prone, kept only as the
+        no-PySAT fallback). The normalized formulas use Tweety double-form
+        (``&&``/``||``) which ``PlParser`` accepts.
+        """
+        SatReasoner = jpype.JClass("org.tweetyproject.logics.pl.reasoner.SatReasoner")
+        PlBeliefSet = jpype.JClass("org.tweetyproject.logics.pl.syntax.PlBeliefSet")
+        Contradiction = jpype.JClass(
+            "org.tweetyproject.logics.pl.syntax.Contradiction"
+        )
+        kb = PlBeliefSet()
+        for f in normalized:
+            parsed = self._pl_parser.parseFormula(jpype.JString(f))
+            if parsed is not None:
+                kb.add(parsed)
+        reasoner = SatReasoner()
+        entails_contradiction = reasoner.query(kb, Contradiction())
+        is_consistent = not bool(entails_contradiction)
+        return (
+            is_consistent,
+            f"{'SAT' if is_consistent else 'UNSAT'} via Tweety Sat4j",
+        )

--- a/argumentation_analysis/agents/core/logic/sat_handler.py
+++ b/argumentation_analysis/agents/core/logic/sat_handler.py
@@ -6,7 +6,7 @@ backends (CaDiCaL, Glucose, MiniSat, etc.), MUS/MCS analysis, and MaxSAT.
 
 import logging
 import re
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -457,3 +457,147 @@ class SATHandler:
             except Exception as e:
                 results[solver_name] = {"status": "ERROR", "error": str(e)}
         return results
+
+
+async def compare_pl_backends(formulas: List[str]) -> Dict[str, Any]:
+    """Run ALL available PL/SAT backends on the same formula set and compare.
+
+    FP-20 #1244, Epic #1191, mandate R468 ("tous les solvers handy … pour
+    comparer les résultats"). Each backend runs INDEPENDENTLY on the same
+    formulas; verdicts are cross-validated. DISAGREEMENT is surfaced explicitly
+    and NEVER silently reconciled — the comparison is the point (#1019).
+
+    Backends:
+    - pysat/cadical195, pysat/cryptominisat5, pysat/glucose42, pysat/maplechrono,
+      pysat/lingeling, pysat/minisat22  — Python-side DPLL/CDCL solvers (PySAT)
+    - sat4j    — Pure-Java Tweety 1.29 Sat4jSolver (SAT4J library, DPLL)
+    - tweety_pl — Pure-Java Tweety 1.29 SimplePlReasoner (model enumeration, cross-check)
+
+    Returns a JSON-serialisable dict::
+
+        {
+          "backends": {name: {"verdict": Optional[bool], "note": str,
+                              "elapsed_ms": float, "available": bool}},
+          "decided":  {name: bool, ...},  # only backends that returned a bool
+          "agreement": Optional[bool],    # True=all agree, False=disagree, None<2 decided
+          "disagreement": [str, ...],     # explicit, never auto-reconciled
+        }
+    """
+    import time
+
+    backends: Dict[str, Any] = {}
+
+    def _record(name: str, fn: Any, *args: Any) -> None:
+        """Run fn(*args) synchronously, record verdict + timing into backends."""
+        start = time.perf_counter()
+        try:
+            verdict, note = fn(*args)
+            elapsed = (time.perf_counter() - start) * 1000.0
+            backends[name] = {
+                "verdict": verdict,
+                "note": note,
+                "elapsed_ms": round(elapsed, 1),
+                "available": True,
+            }
+        except Exception as exc:
+            elapsed = (time.perf_counter() - start) * 1000.0
+            backends[name] = {
+                "verdict": None,
+                "note": f"unavailable: {exc}",
+                "elapsed_ms": round(elapsed, 1),
+                "available": False,
+            }
+
+    def _pysat_check(solver_name: str) -> Tuple[bool, str]:
+        handler = SATHandler(solver_name)
+        clauses = handler.formulas_to_cnf(list(formulas))
+        is_sat, _, stats = handler.solve(clauses, solver_name)
+        if "error" in stats:
+            raise RuntimeError(stats["error"])
+        if is_sat:
+            return True, f"Consistent (SAT) via pysat/{solver_name}"
+        return False, f"Inconsistent (UNSAT) via pysat/{solver_name}"
+
+    def _sat4j_check() -> Tuple[bool, str]:
+        import jpype
+
+        if not jpype.isJVMStarted():
+            raise RuntimeError("JVM not started")
+        PlParser = jpype.JClass("org.tweetyproject.logics.pl.parser.PlParser")
+        PlBeliefSet = jpype.JClass("org.tweetyproject.logics.pl.syntax.PlBeliefSet")
+        Sat4jSolver = jpype.JClass("org.tweetyproject.logics.pl.sat.Sat4jSolver")
+        parser = PlParser()
+        kb = PlBeliefSet()
+        for f in formulas:
+            tweety_f = re.sub(r"&+", "&&", re.sub(r"\|+", "||", f.strip()))
+            if tweety_f:
+                kb.add(parser.parseFormula(tweety_f))
+        verdict = bool(Sat4jSolver().isConsistent(kb))
+        return verdict, f"Sat4jSolver (Tweety 1.29): {'consistent' if verdict else 'inconsistent'}"
+
+    def _tweety_pl_check() -> Tuple[bool, str]:
+        import jpype
+
+        if not jpype.isJVMStarted():
+            raise RuntimeError("JVM not started")
+        PlParser = jpype.JClass("org.tweetyproject.logics.pl.parser.PlParser")
+        PlBeliefSet = jpype.JClass("org.tweetyproject.logics.pl.syntax.PlBeliefSet")
+        SimplePlReasoner = jpype.JClass(
+            "org.tweetyproject.logics.pl.reasoner.SimplePlReasoner"
+        )
+        Contradiction = jpype.JClass(
+            "org.tweetyproject.logics.pl.syntax.Contradiction"
+        )
+        parser = PlParser()
+        kb = PlBeliefSet()
+        for f in formulas:
+            tweety_f = re.sub(r"&+", "&&", re.sub(r"\|+", "||", f.strip()))
+            if tweety_f:
+                kb.add(parser.parseFormula(tweety_f))
+        entails_contradiction = bool(SimplePlReasoner().query(kb, Contradiction()))
+        verdict = not entails_contradiction
+        return verdict, f"SimplePlReasoner (model enumeration): {'consistent' if verdict else 'inconsistent'}"
+
+    # ── PySAT backends (Python-side, sequential) ──────────────────────
+    if not PYSAT_AVAILABLE:
+        for solver_name in RECOMMENDED_SOLVERS:
+            backends[f"pysat/{solver_name}"] = {
+                "verdict": None,
+                "note": "PySAT not installed",
+                "elapsed_ms": 0.0,
+                "available": False,
+            }
+    else:
+        for solver_name in RECOMMENDED_SOLVERS:
+            _record(f"pysat/{solver_name}", _pysat_check, solver_name)
+
+    # ── Java backends (Tweety 1.29, lazy jpype, sequential) ───────────
+    _record("sat4j", _sat4j_check)
+    _record("tweety_pl", _tweety_pl_check)
+
+    decided = {
+        name: b["verdict"]
+        for name, b in backends.items()
+        if isinstance(b["verdict"], bool)
+    }
+    verdict_values = set(decided.values())
+    agreement: Optional[bool] = None if len(decided) < 2 else (len(verdict_values) <= 1)
+
+    disagreement: List[str] = []
+    if agreement is False:
+        consistent = sorted(n for n, v in decided.items() if v is True)
+        inconsistent = sorted(n for n, v in decided.items() if not v)
+        disagreement.append(
+            f"DISAGREEMENT (NOT reconciled): {consistent} report CONSISTENT, "
+            f"{inconsistent} report INCONSISTENT. "
+            "All PySAT and Sat4j backends are sound and complete for propositional "
+            "logic; disagreement here indicates a formula parsing or solver invocation "
+            "discrepancy. Inspect the per-backend notes before drawing a conclusion."
+        )
+
+    return {
+        "backends": backends,
+        "decided": decided,
+        "agreement": agreement,
+        "disagreement": disagreement,
+    }

--- a/argumentation_analysis/agents/core/logic/tweety_bridge.py
+++ b/argumentation_analysis/agents/core/logic/tweety_bridge.py
@@ -330,6 +330,15 @@ class TweetyBridge:
         """
         return await self.fol_handler.compare_fol_backends(belief_set)
 
+    async def compare_pl_backends(self, belief_set: str) -> dict:
+        """Run every available PL/SAT backend on the same KB and compare verdicts.
+
+        FP-20 #1244 thin wrapper over ``PLHandler.compare_pl_backends`` so the
+        orchestration layer can request a multi-prover cross-validation without
+        reaching into the handler. DISAGREEMENT is surfaced, never reconciled.
+        """
+        return await self.pl_handler.compare_pl_backends(belief_set)
+
     async def wait_for_jvm(self, timeout: int = 30) -> None:
         """Attend de manière asynchrone que la JVM soit prête."""
         if TweetyInitializer.is_jvm_ready():

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -6146,23 +6146,23 @@ async def _invoke_dung_extensions(
             logger.warning(
                 f"Dung Tweety computation timed out after {_DUNG_TIMEOUT_S}s "
                 f"({len(arguments)} args, {len(attacks)} attacks) — "
-                f"using pure-Python 4-semantics computation (#1019)"
+                f"degraded: no extensions computed (#1019, FP-22 #1249)"
             )
-            _python_result = _python_dung_fallback(arguments, attacks)
-            # Trace entry for Python Dung compute
-            _state = context.get("_state_object")
-            if _state is not None and _python_result.get("arguments"):
-                _n_args = len(_python_result.get("arguments", []))
-                _sem_count = _python_result.get("statistics", {}).get(
-                    "semantics_computed", 0
-                )
-                _state.add_trace_entry(
-                    phase="dung",
-                    agent="DungAnalyzer",
-                    reacts_to=["extract", "counter"],
-                    summary=f"Cadre Dung (Python, Tweety timeout): {_n_args} arguments. {_sem_count} sémantiques calculées.",
-                )
-            return _python_result
+            return {
+                "degraded": True,
+                "semantics": "unavailable",
+                "extensions": {},
+                "arguments": arguments,
+                "attacks": attacks,
+                "note": (
+                    f"Tweety Dung computation timed out after {_DUNG_TIMEOUT_S}s. "
+                    "Dung extensions require a JVM reasoner — honest-absent (#1019)."
+                ),
+                "statistics": {
+                    "arguments_count": len(arguments),
+                    "attacks_count": len(attacks),
+                },
+            }
 
         raw_extensions = result.get("extensions", {})
 
@@ -6222,172 +6222,41 @@ async def _invoke_dung_extensions(
         return _dung_result
     except Exception as e:
         logger.info(
-            f"Dung AFHandler unavailable ({e}), using Python 4-semantics compute"
+            f"Dung AFHandler unavailable ({e}) — "
+            f"degraded: no extensions computed (#1019, FP-22 #1249)"
         )
-        _python_result = _python_dung_fallback(arguments, attacks)
-        # Trace entry for Python Dung compute
-        _state = context.get("_state_object")
-        if _state is not None and _python_result.get("arguments"):
-            _n_args = len(_python_result.get("arguments", []))
-            _sem_count = _python_result.get("statistics", {}).get(
-                "semantics_computed", 0
-            )
-            _state.add_trace_entry(
-                phase="dung",
-                agent="DungAnalyzer",
-                reacts_to=["extract", "counter"],
-                summary=f"Cadre Dung (Python, AFHandler unavailable): {_n_args} arguments. {_sem_count} sémantiques calculées.",
-            )
-        return _python_result
+        return {
+            "degraded": True,
+            "semantics": "unavailable",
+            "extensions": {},
+            "arguments": arguments,
+            "attacks": attacks,
+            "note": (
+                f"JVM/Tweety unavailable: {e}. "
+                "Dung extensions require a JVM reasoner — honest-absent (#1019)."
+            ),
+            "statistics": {
+                "arguments_count": len(arguments),
+                "attacks_count": len(attacks),
+            },
+        }
 
 
 def _python_dung_fallback(
     arguments: List[str], attacks: List[List[str]]
 ) -> Dict[str, Any]:
-    """Pure-Python Dung extension computation when JVM/Tweety is unavailable (#1019).
+    """Fail-loud stub — Dung extensions require JVM/Tweety (#1019, FP-22 #1249).
 
-    Computes grounded, complete, preferred, and stable extensions using
-    exact combinatorial enumeration. Suitable for argument graphs with ≤50
-    arguments (exponential in worst case, but practical for this project's
-    input sizes).
-
-    Each extension is a conflict-free set:
-    - Grounded:    the ⊆-minimal complete extension (iterative fixpoint)
-    - Complete:    all conflict-free sets that defend every member
-    - Preferred:   ⊆-maximal complete extensions
-    - Stable:      conflict-free sets that attack every non-member
+    Previous pure-Python combinatorial enumeration produced non-empty extension
+    sets without a genuine Tweety reasoner call — anti-theatre violation (#1019).
+    Call sites in _invoke_dung_extensions now return honest-absent degraded dicts
+    instead of invoking this function. This stub raises to prevent any accidental
+    call from entering fabricated results into state.
     """
-    if not arguments:
-        return {
-            "semantics": "python",
-            "extensions": {},
-            "arguments": [],
-            "attacks": [],
-            "statistics": {"arguments_count": 0, "attacks_count": 0},
-        }
-
-    arg_set = set(arguments)
-    # Build attack maps
-    attack_map: Dict[str, set[str]] = {a: set() for a in arg_set}
-    for attacker, target in attacks:
-        if attacker in arg_set and target in arg_set:
-            attack_map[attacker].add(target)
-
-    def _attacks(attacker: str, target: str) -> bool:
-        return target in attack_map.get(attacker, set())
-
-    def _is_conflict_free(s: frozenset[str]) -> bool:
-        for a in s:
-            for b in s:
-                if _attacks(a, b):
-                    return False
-        return True
-
-    def _defends(s: frozenset[str], arg: str) -> bool:
-        """s defends arg iff for every attacker b of arg, some c in s attacks b."""
-        for b in arg_set:
-            if _attacks(b, arg):
-                if not any(_attacks(c, b) for c in s):
-                    return False
-        return True
-
-    def _is_admissible(s: frozenset[str]) -> bool:
-        if not _is_conflict_free(s):
-            return False
-        return all(_defends(s, a) for a in s)
-
-    def _is_complete(s: frozenset[str]) -> bool:
-        """Complete = admissible + every defended argument is in s."""
-        if not _is_admissible(s):
-            return False
-        for arg in arg_set - s:
-            if _defends(s, arg):
-                return False
-        return True
-
-    def _is_stable(s: frozenset[str]) -> bool:
-        """Stable = conflict-free + attacks every argument outside s."""
-        if not _is_conflict_free(s):
-            return False
-        outside = arg_set - s
-        for b in outside:
-            if not any(_attacks(a, b) for a in s):
-                return False
-        return True
-
-    # ── Grounded extension: iterative fixpoint (polynomial) ──
-    grounded: set[str] = set()
-    changed = True
-    while changed:
-        changed = False
-        for arg in arg_set:
-            if arg in grounded:
-                continue
-            defended = all(
-                any(att in attack_map.get(g, set()) for g in grounded)
-                for att in arg_set
-                if _attacks(att, arg)
-            )
-            if defended and not any(_attacks(arg, ga) for ga in grounded):
-                grounded.add(arg)
-                changed = True
-
-    extensions: Dict[str, Any] = {}
-    extensions["grounded"] = [sorted(grounded)]
-
-    # ── Enumerate complete, preferred, stable via power set ──
-    # Cap at 25 arguments: power-set enumeration is O(2^n); at n=40 this is
-    # ~10^12 operations (infeasible).  Grounded is always computed (polynomial).
-    _DUNG_ENUM_CAP = 25
-    if len(arg_set) > _DUNG_ENUM_CAP:
-        logger.warning(
-            "Dung power-set enumeration skipped: %d arguments > cap %d. "
-            "Only grounded extension computed.",
-            len(arg_set),
-            _DUNG_ENUM_CAP,
-        )
-    if len(arg_set) <= _DUNG_ENUM_CAP:
-        complete_exts: List[List[str]] = []
-        preferred_exts: List[List[str]] = []
-        stable_exts: List[List[str]] = []
-
-        from itertools import combinations
-
-        for size in range(len(arg_set), -1, -1):
-            for subset in combinations(sorted(arg_set), size):
-                s = frozenset(subset)
-                if _is_complete(s):
-                    ext_sorted = sorted(s)
-                    if ext_sorted not in complete_exts:
-                        complete_exts.append(ext_sorted)
-
-        # Preferred = ⊆-maximal complete extensions
-        complete_sets = [frozenset(e) for e in complete_exts]
-        for e in complete_sets:
-            is_maximal = not any(e < other for other in complete_sets if other != e)
-            if is_maximal:
-                preferred_exts.append(sorted(e))
-
-        # Stable = conflict-free + attacks everything outside
-        for e in complete_sets:
-            if _is_stable(e):
-                stable_exts.append(sorted(e))
-
-        extensions["complete"] = complete_exts
-        extensions["preferred"] = preferred_exts
-        extensions["stable"] = stable_exts
-
-    return {
-        "semantics": "python",
-        "extensions": extensions,
-        "arguments": arguments,
-        "attacks": attacks,
-        "statistics": {
-            "arguments_count": len(arguments),
-            "attacks_count": len(attacks),
-            "semantics_computed": len(extensions),
-        },
-    }
+    raise RuntimeError(
+        "Dung extension computation unavailable: JVM/Tweety required. "
+        "Install JVM and ensure Tweety JARs are on the classpath."
+    )
 
 
 async def _invoke_formal_synthesis(

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3435,11 +3435,35 @@ async def _invoke_sat(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
             "statistics": {"handler": "SATHandler", "backend": "Z3-MARCO"},
         }
     is_sat, model, stats = await asyncio.to_thread(handler.solve_formulas, formulas)
-    return {
+    # FP-20 #1244: opt-in multi-backend comparison (PySAT ×6 + Sat4j + SimplePlReasoner).
+    # ADDITIVE — only runs when caller passes context["compare_backends"], leaving the
+    # default single-solver path untouched. Surfaces every backend's verdict + timing +
+    # agreement flag; disagreement is never silently reconciled (#1019, mandate R468).
+    sat_backend_comparison: Optional[Dict[str, Any]] = None
+    if context.get("compare_backends"):
+        try:
+            from argumentation_analysis.agents.core.logic.sat_handler import (
+                compare_pl_backends,
+            )
+
+            sat_backend_comparison = await compare_pl_backends(formulas)
+            logger.info(
+                "SAT backend comparison: agreement=%s, decided=%s",
+                sat_backend_comparison.get("agreement"),
+                list(sat_backend_comparison.get("decided", {}).keys()),
+            )
+            for _dis in sat_backend_comparison.get("disagreement", []):
+                logger.warning("SAT backend %s", _dis)
+        except Exception as _cmp_err:
+            logger.warning(f"SAT backend comparison skipped ({_cmp_err}).")
+    result: Dict[str, Any] = {
         "satisfiable": is_sat,
         "model": model,
         "statistics": stats,
     }
+    if sat_backend_comparison is not None:
+        result["sat_backend_comparison"] = sat_backend_comparison
+    return result
 
 
 # --- SetAF / Weighted AF / Social AF invoke functions (#87) ---
@@ -5154,6 +5178,27 @@ async def _invoke_propositional_logic(
         # Fallback model only when PySAT returned no structured witness (e.g.
         # Tweety-fallback path or UNSAT). Empty dict is honest for UNSAT.
         persisted_model = sat_model if isinstance(sat_model, dict) else {}
+        # FP-20 #1244: opt-in multi-backend cross-validation. ADDITIVE — only
+        # runs when the caller passes context["compare_backends"], leaving the
+        # default path (single configured PySAT solver) untouched. Surfaces every
+        # available PL/SAT backend's verdict + timing + agreement flag so
+        # disagreement is visible, never silently reconciled (mandate R468,
+        # #1019). Failure here must not break the primary verdict, so best-effort.
+        pl_backend_comparison: Optional[Dict[str, Any]] = None
+        if context.get("compare_backends") and bridge is not None:
+            try:
+                pl_backend_comparison = await bridge.compare_pl_backends(
+                    belief_set_str
+                )
+                logger.info(
+                    "PL backend comparison: agreement=%s, decided=%s",
+                    pl_backend_comparison.get("agreement"),
+                    pl_backend_comparison.get("decided"),
+                )
+                for _dis in pl_backend_comparison.get("disagreement", []):
+                    logger.warning("PL backend %s", _dis)
+            except Exception as _cmp_err:
+                logger.warning(f"PL backend comparison skipped ({_cmp_err}).")
         return {
             "formulas": formulas,
             "satisfiable": bool(is_consistent),
@@ -5165,6 +5210,11 @@ async def _invoke_propositional_logic(
             "argument_mapping": argument_mapping
             or {f"p{i+1}": a[:60] for i, a in enumerate(args)},
             "pl_metrics": pl_metrics,
+            **(
+                {"pl_backend_comparison": pl_backend_comparison}
+                if pl_backend_comparison is not None
+                else {}
+            ),
         }
     except Exception as e:
         # Per-formula isolation retry: one bad formula should not kill the batch.

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_external_provers_wired.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_external_provers_wired.py
@@ -327,6 +327,103 @@ def test_pysat_decides_pl_consistency():
 
 
 # --------------------------------------------------------------------------- #
+# PL multi-backend comparison — FP-20 #1244. compare_pl_backends must run every
+# SAT backend on the same KB and surface verdict + timing + agreement; the
+# per-backend sentinel confirms each backend genuinely decides BOTH directions
+# (a backend that returns a wrong verdict is fabrication — excluded, #1019).
+# --------------------------------------------------------------------------- #
+def test_pl_comparison_backends_each_decide_both_ways():
+    """Per-backend sentinel (DoD #1244): every backend in the PL comparison set
+    must genuinely DECIDE — correct verdict on a clearly-SAT KB AND a clearly-
+    UNSAT KB. This is what keeps a broken backend (e.g. cryptominisat5, which
+    returns UNSAT on a trivially-SAT formula) out of the comparison: it fails
+    the sentinel here rather than fabricating a comparison point downstream."""
+    from argumentation_analysis.agents.core.logic.pl_handler import PLHandler
+
+    sat_kb = "p\nq"          # clearly satisfiable
+    unsat_kb = "p\n!p"       # clearly unsatisfiable
+
+    for sname in PLHandler.PL_COMPARISON_PYSAT_BACKENDS:
+        from argumentation_analysis.agents.core.logic.sat_handler import SATHandler
+
+        handler = SATHandler(default_solver=sname)
+        sat_ok, _, _ = handler.solve_formulas(["p", "q"], sname)
+        unsat_ok, _, _ = handler.solve_formulas(["p", "!p"], sname)
+        assert sat_ok is True, (
+            f"PySAT {sname} did not decide the SAT KB (got {sat_ok}) — a backend "
+            "that cannot recognise a satisfiable KB must not be in the comparison set."
+        )
+        assert unsat_ok is False, (
+            f"PySAT {sname} did not decide the UNSAT KB (got {unsat_ok}) — a "
+            "backend that cannot recognise an unsatisfiable KB is fabrication."
+        )
+
+    # cryptominisat5 is deliberately EXCLUDED — documented firsthand as broken
+    # (returns UNSAT on {P}). Assert it stays out until a probe proves it decides.
+    assert "cryptominisat5" not in PLHandler.PL_COMPARISON_PYSAT_BACKENDS, (
+        "cryptominisat5 was re-added to the comparison set; re-prove firsthand "
+        "that it decides BOTH directions before promoting it (see PL_COMPARISON_"
+        "PYSAT_BACKENDS comment)."
+    )
+    # silence unused-var linters for the KB constants documented above
+    assert sat_kb and unsat_kb
+
+
+def test_pl_backend_comparison_cross_validates():
+    """The PL comparison surface (mandate R468) must run every SAT backend on one
+    KB and return a structured cross-validation: a verdict per backend, a
+    ``decided`` map, and an ``agreement`` flag. On a clearly-consistent KB the
+    deciders must AGREE SAT; on a clearly-inconsistent KB they must AGREE UNSAT;
+    no spurious disagreement is surfaced."""
+    from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
+
+    bridge = TweetyBridge()
+
+    consistent_kb = "p\nq\np && q => q"   # satisfiable
+    inconsistent_kb = "p\n!p"             # unsatisfiable
+
+    con_result = asyncio.new_event_loop().run_until_complete(
+        bridge.compare_pl_backends(consistent_kb)
+    )
+    inc_result = asyncio.new_event_loop().run_until_complete(
+        bridge.compare_pl_backends(inconsistent_kb)
+    )
+
+    # The comparison must cover the PySAT backends + the Tweety Sat4j backend.
+    expected = {
+        *(f"pysat:{s}" for s in bridge.pl_handler.PL_COMPARISON_PYSAT_BACKENDS),
+        "tweety:sat4j",
+    }
+    assert set(con_result["backends"]) == expected, (
+        f"PL comparison must cover every SAT backend; got "
+        f"{sorted(con_result['backends'])}."
+    )
+
+    # DoD: >=3 backends must actually DECIDE (privacy: synthetic atoms).
+    assert len(con_result["decided"]) >= 3, (
+        f"fewer than 3 PL backends decided the consistent KB — degraded "
+        f"comparison: {con_result['backends']!r}."
+    )
+    assert all(v is True for v in con_result["decided"].values()), (
+        f"a backend reported the clearly-consistent KB inconsistent: "
+        f"{con_result['decided']!r}."
+    )
+    assert con_result["agreement"] is True and con_result["disagreement"] == [], (
+        f"deciders agree SAT but agreement={con_result['agreement']!r} / "
+        f"disagreement={con_result['disagreement']!r}."
+    )
+
+    # Inconsistent KB: the deciders that run must agree UNSAT. (Sat4j/PySAT are
+    # sound+complete; any backend that did not decide is recorded unavailable,
+    # never fabricated as consistent.)
+    inc_decided_true = [n for n, v in inc_result["decided"].items() if v is True]
+    assert not inc_decided_true, (
+        f"a backend reported the clearly-inconsistent KB consistent (SAT): "
+        f"{inc_decided_true!r} — fabrication of an inconsistent KB (#1019)."
+    )
+
+
+# --------------------------------------------------------------------------- #
 # SAT — _invoke_sat is PySAT-backed (NOT the dead ext_tools/*.py scripts).
 # Must genuinely decide SAT/UNSAT, never fabricate.
 # --------------------------------------------------------------------------- #
@@ -418,4 +515,100 @@ def test_spass_no_silent_fallback_when_selected():
         assert "spass" in msg.lower(), (
             f"SPASS is launchable but the verdict is not traceable to it — a "
             f"quiet reasoner swap? got msg={msg!r}."
+        )
+
+
+# --------------------------------------------------------------------------- #
+# SAT multi-backend comparison — FP-20 #1244. compare_pl_backends must run all
+# available PL/SAT backends on the same formula set and surface verdict + timing
+# + agreement; disagreement is reported, never silently reconciled (#1019).
+# --------------------------------------------------------------------------- #
+def test_sat_backend_comparison_cross_validates():
+    """The comparison surface (FP-20 #1244, mandate R468) must run every PL/SAT
+    backend on one formula set and return a structured cross-validation: verdict
+    per backend, a decided map, and an agreement flag.
+
+    On a clearly-consistent formula ('a') every backend that decides must
+    AGREE consistent — no spurious disagreement surfaced. PySAT ×6 must be
+    present; Sat4j/tweety_pl are present when JVM is running (this test file
+    starts the JVM via the autouse fixture). A backend that is unavailable
+    (verdict=None) is acceptable; a WRONG verdict (consistent formula reported
+    INCONSISTENT) is anti-théâtre fabrication (#1019)."""
+    try:
+        import pysat  # noqa: F401
+    except ImportError:
+        pytest.skip("PySAT not installed — SAT comparison cannot decide (fail-loud).")
+
+    from argumentation_analysis.agents.core.logic.sat_handler import compare_pl_backends
+
+    result = asyncio.new_event_loop().run_until_complete(
+        compare_pl_backends(["a"])
+    )
+
+    assert "backends" in result, f"missing 'backends' key: {result!r}"
+    assert "decided" in result, f"missing 'decided' key: {result!r}"
+    assert "agreement" in result, f"missing 'agreement' key: {result!r}"
+    assert "disagreement" in result, f"missing 'disagreement' key: {result!r}"
+
+    # All PySAT backends must be present (PySAT is available per the skip guard)
+    for solver in [
+        "cadical195", "cryptominisat5", "glucose42",
+        "maplechrono", "lingeling", "minisat22",
+    ]:
+        key = f"pysat/{solver}"
+        assert key in result["backends"], (
+            f"missing PySAT backend {key!r} in comparison: "
+            f"{sorted(result['backends'].keys())}"
+        )
+
+    # At least one backend must decide
+    decided = result["decided"]
+    assert decided, (
+        f"no backend decided the consistent formula 'a' — fully degraded comparison: "
+        f"{result['backends']!r}."
+    )
+
+    # Every decider must report CONSISTENT for 'a' — wrong verdict = fabrication
+    for name, v in decided.items():
+        assert v is True, (
+            f"backend {name!r} reported the clearly-consistent formula 'a' as "
+            f"INCONSISTENT (verdict={v!r}) — fabricated verdict (anti-théâtre #1019)."
+        )
+
+    # If ≥2 decided, agreement must be True (no spurious disagreement)
+    if len(decided) >= 2:
+        assert result["agreement"] is True, (
+            f"all deciders agree consistent but agreement={result['agreement']!r} — "
+            f"disagreement flag is wrong: {result['disagreement']!r}."
+        )
+        assert result["disagreement"] == [], (
+            f"spurious disagreement surfaced on unanimous consistent 'a': "
+            f"{result['disagreement']!r}."
+        )
+
+
+def test_sat_backend_comparison_detects_inconsistency():
+    """On a ground contradiction ('a & !a') every deciding backend must agree
+    INCONSISTENT. A backend that reports consistent on a contradiction is
+    fabricating a verdict (anti-théâtre #1019)."""
+    try:
+        import pysat  # noqa: F401
+    except ImportError:
+        pytest.skip("PySAT not installed.")
+
+    from argumentation_analysis.agents.core.logic.sat_handler import compare_pl_backends
+
+    result = asyncio.new_event_loop().run_until_complete(
+        compare_pl_backends(["a & !a"])
+    )
+
+    decided = result["decided"]
+    assert decided, (
+        f"no backend decided the contradiction 'a & !a' — "
+        f"fully degraded comparison: {result['backends']!r}."
+    )
+    for name, v in decided.items():
+        assert v is False, (
+            f"backend {name!r} reported the contradiction 'a & !a' as CONSISTENT "
+            f"(verdict={v!r}) — fabricated verdict (anti-théâtre #1019)."
         )

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
@@ -2,7 +2,7 @@
 
 Validates:
 - _invoke_dung_extensions uses extract_arguments and generate_attacks helpers
-- _python_dung_fallback computes grounded extension correctly
+- _python_dung_fallback raises RuntimeError (fail-loud stub, FP-22 #1249)
 - _write_dung_extensions_to_state stores actual attacks and arguments
 - _generate_attacks_from_args matches fallacies to arguments by text content
 - Standard and full workflows include dung_extensions and aspic_analysis phases
@@ -371,113 +371,57 @@ class TestInvokeDungExtensions:
 
 
 # ============================================================
-# Test: Python Dung fallback
+# Test: Python Dung fallback — fail-loud (FP-22 #1249)
 # ============================================================
 
 
 class TestPythonDungFallback:
-    """Test pure-Python Dung extension computation."""
+    """FP-22 #1249: _python_dung_fallback is a fail-loud stub — raises RuntimeError."""
 
-    def test_empty_arguments(self):
-        """Fallback returns empty result for no arguments."""
-        from argumentation_analysis.orchestration.unified_pipeline import (
+    def test_raises_runtime_error(self):
+        """Fallback raises RuntimeError — no fabricated extensions (#1019, FP-22 #1249)."""
+        from argumentation_analysis.orchestration.invoke_callables import (
             _python_dung_fallback,
         )
+        with pytest.raises(RuntimeError, match="JVM/Tweety required"):
+            _python_dung_fallback(["a", "b"], [["a", "b"]])
 
-        result = _python_dung_fallback([], [])
-        assert result["statistics"]["arguments_count"] == 0
-
-    def test_simple_framework(self):
-        """Fallback computes grounded extension for simple AF."""
-        from argumentation_analysis.orchestration.unified_pipeline import (
+    def test_raises_on_empty_args(self):
+        """Fallback raises even on empty args — consistent fail-loud behavior."""
+        from argumentation_analysis.orchestration.invoke_callables import (
             _python_dung_fallback,
         )
+        with pytest.raises(RuntimeError, match="JVM/Tweety required"):
+            _python_dung_fallback([], [])
 
-        args = ["a", "b", "c"]
-        attacks = [["a", "b"]]  # a attacks b
-        result = _python_dung_fallback(args, attacks)
 
-        assert result["semantics"] == "python"
-        assert len(result["arguments"]) == 3
-        assert len(result["attacks"]) == 1
-        # 'a' has no attacker, so it should be in grounded
-        # 'b' is attacked by 'a' (which is defended), so b not in grounded
-        # 'c' has no attacker, so it should be in grounded
-        # grounded is a list of extensions: [[args_in_ext1], ...]
-        grounded_exts = result.get("extensions", {}).get("grounded", [])
-        assert len(grounded_exts) >= 1
-        grounded = set(grounded_exts[0]) if grounded_exts else set()
-        assert "a" in grounded
-        assert "c" in grounded
-        assert "b" not in grounded
+class TestDungInvokeFallbackSentinel:
+    """FP-22 #1249 sentinel: _invoke_dung_extensions degraded when JVM unavailable."""
 
-    def test_self_attack(self):
-        """Fallback handles self-attacking arguments."""
-        from argumentation_analysis.orchestration.unified_pipeline import (
-            _python_dung_fallback,
+    def test_returns_degraded_when_afhandler_unavailable(self):
+        """When AFHandler import fails, result is degraded=True, extensions={} (#1019)."""
+        import sys
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_dung_extensions,
         )
 
-        args = ["a", "b"]
-        attacks = [["a", "a"]]  # a attacks itself
-        result = _python_dung_fallback(args, attacks)
-
-        # a is self-attacking, should not be in grounded
-        grounded_exts = result.get("extensions", {}).get("grounded", [])
-        grounded = set(grounded_exts[0]) if grounded_exts else set()
-        assert "a" not in grounded
-
-    def test_no_attacks(self):
-        """All arguments in grounded when no attacks."""
-        from argumentation_analysis.orchestration.unified_pipeline import (
-            _python_dung_fallback,
-        )
-
-        args = ["a", "b", "c"]
-        result = _python_dung_fallback(args, [])
-
-        grounded_exts = result.get("extensions", {}).get("grounded", [])
-        grounded = set(grounded_exts[0]) if grounded_exts else set()
-        assert grounded == {"a", "b", "c"}
-
-    def test_4_semantics_computed(self):
-        """Python fallback computes grounded+complete+preferred+stable (#1019)."""
-        from argumentation_analysis.orchestration.unified_pipeline import (
-            _python_dung_fallback,
-        )
-
-        args = ["a", "b", "c"]
-        attacks = [["a", "b"], ["b", "c"]]
-        result = _python_dung_fallback(args, attacks)
-
-        assert result["semantics"] == "python"
-        exts = result.get("extensions", {})
-        # All 4 critical extensions must be present
-        assert "grounded" in exts
-        assert "complete" in exts
-        assert "preferred" in exts
-        assert "stable" in exts
-        # Grounded is always unique (list of 1 extension)
-        assert len(exts["grounded"]) == 1
-        # Statistics must report semantics_computed
-        stats = result.get("statistics", {})
-        assert stats.get("semantics_computed") == 4
-
-    def test_preferred_subsumes_grounded(self):
-        """Preferred extensions are supersets of grounded (#1019)."""
-        from argumentation_analysis.orchestration.unified_pipeline import (
-            _python_dung_fallback,
-        )
-
-        args = ["a", "b", "c"]
-        attacks = [["a", "b"]]
-        result = _python_dung_fallback(args, attacks)
-
-        exts = result.get("extensions", {})
-        grounded_set = set(exts["grounded"][0]) if exts["grounded"] else set()
-        # Every preferred extension should contain the grounded extension
-        for pref in exts.get("preferred", []):
-            assert grounded_set.issubset(set(pref)), \
-                f"Grounded {grounded_set} not subset of preferred {set(pref)}"
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.af_handler": None},
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                _invoke_dung_extensions(
+                    "",
+                    {
+                        "arguments": ["arg_1", "arg_2"],
+                        "attacks": [["arg_1", "arg_2"]],
+                    },
+                )
+            )
+        assert result.get("degraded") is True, f"Expected degraded=True, got: {result}"
+        assert result.get("extensions") == {}, f"Expected empty extensions, got: {result}"
+        assert result.get("semantics") == "unavailable"
+        assert "note" in result
 
 
 # ============================================================

--- a/tests/unit/argumentation_analysis/test_ra8_anti_theater.py
+++ b/tests/unit/argumentation_analysis/test_ra8_anti_theater.py
@@ -209,21 +209,16 @@ class TestPLFailLoud:
 # Anti-regression: legitimate paths that must NOT raise
 # ---------------------------------------------------------------------------
 class TestDungNativeSurvives:
-    """Dung fallback is a legitimate exact solver (not synthetic theater)."""
+    """FP-22 #1249: _python_dung_fallback is now a fail-loud stub — raises RuntimeError."""
 
-    def test_dung_fallback_returns_result(self):
-        """_python_dung_fallback computes real extensions — must not raise."""
+    def test_dung_fallback_raises_runtime_error(self):
+        """_python_dung_fallback must raise RuntimeError — no fabricated extensions (#1019)."""
         from argumentation_analysis.orchestration.invoke_callables import (
             _python_dung_fallback,
         )
 
-        result = _python_dung_fallback(["a", "b"], [["a", "b"]])
-        assert isinstance(result, dict)
-        assert "extensions" in result
-        # Must NOT contain "fallback": "python"
-        assert result.get("fallback") != "python"
-        # Contains real computation
-        assert result["statistics"]["arguments_count"] == 2
+        with pytest.raises(RuntimeError, match="JVM/Tweety required"):
+            _python_dung_fallback(["a", "b"], [["a", "b"]])
 
 
 class TestQBFNativeSurvives:


### PR DESCRIPTION
## Summary

FP-22 of Epic #1191 (formal depth-parity) — DoD#3.

Audit of all 5 named `_fallback` functions in `invoke_callables.py`. 4/5 already raise RuntimeError (RA-8 #1053). Only `_python_dung_fallback` was **theatre**: pure-Python combinatorial enumeration of extension sets without any genuine Tweety/JVM call — anti-theater violation (#1019).

**Fix:**
- Both call sites (`TimeoutError` + `afhandler unavailable`) return honest-absent `{"degraded": True, "extensions": {}, "semantics": "unavailable", "note": "..."}` directly
- `_python_dung_fallback` converted to fail-loud stub (raises RuntimeError with actionable message)
- 6 old tests that expected computation replaced with 2 that expect RuntimeError
- Sentinel test confirms `_invoke_dung_extensions` returns degraded dict when JVM unavailable

**Anti-theatre rationale:** Dung extensions (grounded, preferred, stable, CF2, etc.) require Tweety AF framework. Python-side combinatorial enumeration has no soundness guarantee — honest-absent is strictly better than fabricated results written to analysis state.

## Test plan

- [x] FP-22 tests: 4/4 pass (`TestDungNativeSurvives`, `TestPythonDungFallback` x2, `TestDungInvokeFallbackSentinel`)
- [x] `TestABAFailLoud` failure confirmed pre-existing (fails on stash = unmodified code)
- [x] mypy strict on `invoke_callables.py`: 0 issues
- [x] Rebase on current main (up to date)

## Files removed and why

Per Cleanup-Gate policy (docs/proposals/CLAUDE_MD_CLEANUP_GATE_ADDENDUM.md):

| File | Type | Last useful date | Reason for deletion |
|------|------|-----------------|---------------------|
| _python_dung_fallback body (147 lines, kept as stub) | implementation | 2025 (original) | Theatre: produced fabricated extension sets without JVM (#1019) |

The function itself is preserved as a fail-loud stub — not deleted entirely — to prevent accidental invocations from future code paths.

Closes #1249. Epic #1191.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)