### PR TITLE
feat(restitution): #1259 deanonymize working state + thread real source_metadata (Epic #1258 Track 1)

### DIFF
--- a/argumentation_analysis/agents/core/political/stakes_extractor.py
+++ b/argumentation_analysis/agents/core/political/stakes_extractor.py
@@ -26,7 +26,7 @@ EXTRACTION_PROMPT = (
     '   - "evidence_indices": list of integers referencing argument positions '
     "(0-based) that support this stake identification\n\n"
     '2. "stakeholders": List of objects, each with:\n'
-    '   - "name": pseudonymised (Speaker_A, Authority_X, Group_Y, Public_Z, etc.)\n'
+    "   - \"name\": {name_instruction}\n"
     '   - "role": who they are in this discourse (speaker, opponent, audience, '
     "authority, institution, group)\n"
     '   - "stance": one of for, against, ambivalent, uncommitted\n'
@@ -54,6 +54,7 @@ class StakesExtractor:
         raw_text: str = "",
         llm_client: Optional[Any] = None,
         determinism_params: Optional[Dict[str, Any]] = None,
+        deanonymized: bool = True,
     ) -> Dict[str, Any]:
         """Extract stakes, stakeholders, register, and arena from discourse.
 
@@ -92,6 +93,16 @@ class StakesExtractor:
 
         excerpt = (raw_text or "")[:3000]
 
+        # Epic #1258 / Track 1 #1259 — when the working state is deanonymized,
+        # instruct the LLM to emit REAL stakeholder names (from source metadata);
+        # otherwise restore the pseudonymisation discipline verbatim.
+        name_instruction = (
+            "the real name/label (the actual speaker, party, institution or public "
+            "named in the source metadata above)"
+            if deanonymized
+            else "pseudonymised (Speaker_A, Authority_X, Group_Y, Public_Z, etc.)"
+        )
+
         prompt = EXTRACTION_PROMPT.format(
             arguments_block=arguments_block,
             speaker=source_metadata.get("speaker", "unknown"),
@@ -101,6 +112,7 @@ class StakesExtractor:
                 "era", source_metadata.get("date_or_year", "unknown")
             ),
             language=source_metadata.get("language", "unknown"),
+            name_instruction=name_instruction,
             excerpt=excerpt,
         )
 

--- a/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
+++ b/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
@@ -65,7 +65,6 @@ class DeepSynthesisAgent(BaseAgent):
     )
 
     SYSTEM_PROMPT: ClassVar[str] = (
-        f"{OPAQUE_ID_DIRECTIVE}"
         "You are an intelligence analyst producing a political-rhetorical "
         "briefing on a discourse. Your output is structured into exactly 6 "
         "numbered sections (8-12 paragraphs total). Each section heading must "
@@ -124,7 +123,6 @@ class DeepSynthesisAgent(BaseAgent):
     # receives an intelligence briefing of verified artifacts (never raw
     # text) and must anchor every insight in [artifact:...] citations.
     GROUNDED_SYNTHESIS_PROMPT: ClassVar[str] = (
-        f"{OPAQUE_ID_DIRECTIVE}"
         "You are an intelligence analyst writing the grounded transversal "
         "synthesis of a rhetorical-analysis run. You receive an ARTIFACT "
         "BRIEFING: a list of verified analysis artifacts, each prefixed by a "
@@ -194,16 +192,31 @@ class DeepSynthesisAgent(BaseAgent):
     )
 
     _llm_service_id: Optional[str] = PrivateAttr(default=None)
+    # Epic #1258 / Track 1 #1259 — when False, the opaque-ID discipline is
+    # restored (directive prepended to every synthesis prompt); when True (default
+    # for CLI/local), the directive is dropped so the briefing may name the real
+    # speaker/arena. The export BOUNDARY guard is Track 3 sanitize_state.
+    _deanonymized: bool = PrivateAttr(default=True)
 
     def __init__(
         self,
         kernel: Kernel,
         agent_name: str = "DeepSynthesisAgent",
         service_id: Optional[str] = None,
+        deanonymized: bool = True,
         **kwargs,
     ):
-        super().__init__(kernel, agent_name, self.SYSTEM_PROMPT, **kwargs)
+        # Epic #1258 / Track 1 #1259 — conditionally prepend the opaque-ID
+        # directive to the system prompt. The directive dominates the model's
+        # attention (FB-32 sharpening), so it is first when present.
+        system_prompt = (
+            self.SYSTEM_PROMPT
+            if deanonymized
+            else self.OPAQUE_ID_DIRECTIVE + self.SYSTEM_PROMPT
+        )
+        super().__init__(kernel, agent_name, system_prompt, **kwargs)
         self._llm_service_id = service_id
+        self._deanonymized = bool(deanonymized)
 
     # ------------------------------------------------------------------
     # BaseAgent abstract implementations
@@ -1268,8 +1281,15 @@ class DeepSynthesisAgent(BaseAgent):
         if briefing.count("\n") < 1:
             return ""
         try:
+            # Epic #1258 / Track 1 #1259 — prepend the opaque-ID directive only
+            # when the agent runs in opaque mode (deanonymized=False).
+            _opaque_guard = (
+                ""
+                if getattr(self, "_deanonymized", True)
+                else self.OPAQUE_ID_DIRECTIVE
+            )
             prompt = (
-                f"{self.GROUNDED_SYNTHESIS_PROMPT}\n\n{briefing}\n\n"
+                f"{_opaque_guard}{self.GROUNDED_SYNTHESIS_PROMPT}\n\n{briefing}\n\n"
                 "Write the 4-section grounded transversal synthesis now."
             )
             settings = self.kernel.get_prompt_execution_settings_from_service_id(
@@ -1525,8 +1545,15 @@ class DeepSynthesisAgent(BaseAgent):
             else:
                 convergence_section += "  No cross-method convergence.\n"
 
+            # Epic #1258 / Track 1 #1259 — prepend the opaque-ID directive only
+            # when the agent runs in opaque mode (deanonymized=False).
+            _opaque_guard = (
+                ""
+                if getattr(self, "_deanonymized", True)
+                else DeepSynthesisAgent.OPAQUE_ID_DIRECTIVE
+            )
             prompt = (
-                f"{DeepSynthesisAgent.OPAQUE_ID_DIRECTIVE}"
+                f"{_opaque_guard}"
                 "Produce the 6-section political-rhetorical briefing as specified "
                 "in your system prompt. Use the data blocks below. Each section "
                 "heading must be '## N. Title' on its own line. 8-12 paragraphs "

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -465,6 +465,15 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         self.act3_conclusion: str = ""
         # PP #715: source-level metadata for qualitative synthesis
         self.source_metadata: Dict[str, str] = {}
+        # Epic #1258 / Track 1 #1259 — déanonymisation du pipeline de travail.
+        # True (default for CLI/local) = the working state carries REAL source
+        # metadata (speaker, arena, stakes); prompt builders DROP the opaque-ID
+        # directives so the readable restitution names the real speaker/arena.
+        # False restores the opaque-ID discipline verbatim (the git/dashboard/API
+        # export paths run opaque; the export BOUNDARY guard is Track 3
+        # sanitize_state, NOT this flag). Threaded via state because the build_*
+        # prompt builders cannot see ``context`` (#1259).
+        self.deanonymized: bool = True
         # PL 2-pass pipeline: shared atom inventory (#547)
         self.atomic_propositions: Dict[str, List[str]] = {}
         # FOL 2-pass pipeline: shared signature per source (#544)
@@ -485,6 +494,24 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         # RA-4 #1049: Strategic NL journaling bridge
         self.strategic_objectives: List[Dict[str, Any]] = []
         self.strategic_decisions_log: List[Dict[str, Any]] = []
+
+    def set_source_metadata(self, metadata: Dict[str, str]) -> None:
+        """Populate source-level metadata (Epic #1258 / Track 1 #1259).
+
+        Replaces the in-memory ``source_metadata`` map with the supplied dict
+        (real speaker/arena/epoch for CLI/local runs). This is the working-state
+        metadata consumed by the qualitative synthesis + restitution prompts;
+        the export boundary (git/dashboard/API) is sanitized separately by
+        Track 3 ``sanitize_state``. No ``raw_text``/``full_text`` is stored —
+        only short metadata fields (privacy HARD).
+        """
+        if not isinstance(metadata, dict):
+            state_logger.warning("set_source_metadata ignored non-dict: %r", type(metadata))
+            return
+        # Defensive: never accept raw_text/full_text keys (privacy HARD).
+        _FORBIDDEN = {"raw_text", "full_text", "full_text_segment", "raw_text_snippet"}
+        cleaned = {k: v for k, v in metadata.items() if k not in _FORBIDDEN}
+        self.source_metadata = cleaned
 
     def add_trace_entry(
         self,

--- a/argumentation_analysis/orchestration/hierarchical/strategic/manager.py
+++ b/argumentation_analysis/orchestration/hierarchical/strategic/manager.py
@@ -335,12 +335,25 @@ class StrategicManager:
 
         text_preview = text[:2000]
 
+        # Epic #1258 / Track 1 #1259 — the opaque-ID discipline (lines below) is
+        # dropped when the working state is deanonymized, so strategic objectives
+        # may reference the real speaker/arena (the export boundary guard is
+        # Track 3 sanitize_state, not this prompt).
+        _deanonymized = bool(getattr(self.state, "deanonymized", True))
+        _opaque_rules = (
+            ""
+            if _deanonymized
+            else (
+                "- Décris la STRUCTURE argumentative, jamais le nom de l'auteur ou des citations directes\n"
+                "- Utilise des identifiants opaques (ex: 'Source_A', 'Argument_principal_1')\n"
+            )
+        )
+
         prompt = (
             "Tu es un analyste rhétorique stratégique. À partir du texte ci-dessous, "
             "génère 3 à 6 objectifs d'analyse stratégique.\n\n"
             "RÈGLES IMPÉRATIVES :\n"
-            "- Décris la STRUCTURE argumentative, jamais le nom de l'auteur ou des citations directes\n"
-            "- Utilise des identifiants opaques (ex: 'Source_A', 'Argument_principal_1')\n"
+            f"{_opaque_rules}"
             "- Chaque objectif doit être un JSON object avec clés: id, description, priority\n"
             "- id au format 'obj-N', priority parmi 'high', 'medium', 'low'\n"
             "- Retourne UNIQUEMENT un tableau JSON valide, sans markdown\n\n"

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -7350,7 +7350,11 @@ async def _invoke_deep_synthesis(
             # kernel (the de-castrated path was correct but never wired — last
             # structural castration site, same class as FB-30/FB-31). Anti-pendule:
             # activate the existing path, no counterweight.
-            agent = DeepSynthesisAgent(kernel=kernel, service_id="default")
+            agent = DeepSynthesisAgent(
+                kernel=kernel,
+                service_id="default",
+                deanonymized=bool(getattr(state, "deanonymized", True)),
+            )
             source_meta = context.get("source_metadata", {})
             report = await agent.synthesize(state, source_metadata=source_meta)
         except (ValueError, Exception) as agent_err:
@@ -7481,6 +7485,7 @@ async def _invoke_stakes_extractor(
         raw_text=raw_text,
         llm_client=llm_client,
         determinism_params=determinism_params,
+        deanonymized=bool(getattr(state, "deanonymized", True)),
     )
 
     # Write to state

--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -63,6 +63,8 @@ async def run_unified_analysis(
     checkpoint_callback: Optional[Any] = None,
     resume_from: Optional[set] = None,
     render_restitution: bool = False,
+    deanonymized: bool = True,
+    source_metadata: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """
     Run a unified analysis pipeline on input text.
@@ -87,6 +89,16 @@ async def run_unified_analysis(
               it replaces the unreadable dimensional dump as the default report a
               reader meets first. Honest on non-spectacular states (missing acts
               are named, not fabricated — #1019/#369).
+        deanonymized: Epic #1258 / Track 1 #1259. If True (default for CLI/local),
+              the working state carries REAL source metadata and the restitution
+              prompt builders DROP the opaque-ID directives, so the readable report
+              names the real speaker/arena. If False, the opaque-ID discipline is
+              restored verbatim (git/dashboard/API paths). The export BOUNDARY
+              guard (sanitize_state) is Track 3, orthogonal to this flag.
+        source_metadata: Epic #1258 / Track 1 #1259. Optional dict of real
+              source-level metadata (speaker, arena, epoch...) threaded into
+              ``state.source_metadata``. Only short metadata fields — no
+              ``raw_text``/``full_text`` (privacy HARD).
 
     Returns:
         Dict with keys:
@@ -114,6 +126,23 @@ async def run_unified_analysis(
                 "Could not import UnifiedAnalysisState; state tracking disabled"
             )
             state = None
+
+    # Epic #1258 / Track 1 #1259 — thread the deanonymization switch + real
+    # source metadata onto the working state. Threaded via ``state`` because the
+    # ``build_actN_*`` / stakes / strategic prompt builders cannot see ``context``
+    # (#1259). Applied to both the freshly-created state and any externally
+    # provided state. ``getattr`` fallback keeps the defaults safe if a caller
+    # passes a minimal state object lacking the attribute.
+    if state is not None:
+        try:
+            state.deanonymized = bool(deanonymized)
+            if source_metadata is not None:
+                if hasattr(state, "set_source_metadata"):
+                    state.set_source_metadata(source_metadata)
+                else:
+                    state.source_metadata = dict(source_metadata)
+        except Exception as e:
+            logger.warning("Failed to thread deanonymized/source_metadata: %s", e)
 
     if custom_workflow is not None:
         workflow = custom_workflow

--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -498,6 +498,9 @@ def build_convergent_synthesis(state: Any) -> Dict[str, Any]:
         "convergent_verdicts": verdicts,
         "emergent_insights": insights,
         "conclusion": conclusion,
+        # Epic #1258 / Track 1 #1259 — thread the deanonymization flag so
+        # _build_prose_prompt can drop the opaque-ID rule when True.
+        "deanonymized": bool(getattr(state, "deanonymized", True)),
     }
 
 
@@ -515,6 +518,11 @@ _PROSE_INSTRUCTIONS = (
     "concordance (e.g. 'the argument combines X AND Y AND Z, making its weakness "
     "structural rather than circumstantial'). "
     "(6) Maximum 400 words. "
+)
+
+# Epic #1258 / Track 1 #1259 — item (7) split out so it can be dropped when the
+# working state is deanonymized (real names allowed in the prose).
+_PROSE_OPAQUE_RULE = (
     "(7) OPAQUE-ID DISCIPLINE (FB-34 #1118): refer to the source/speaker/states "
     "ONLY by opaque labels (Speaker_A, State_Q, arg_1, doc_A) — never emit a real "
     "name, leader, country, party, or date. Characterize the argumentation "
@@ -538,8 +546,14 @@ def _build_prose_prompt(synthesis_result: Dict[str, Any]) -> str:
     else:
         evidence_block = "(no convergent arguments detected)"
 
+    # Epic #1258 / Track 1 #1259 — drop the opaque-ID rule when deanonymized.
+    deanonymized = bool(synthesis_result.get("deanonymized", True))
+    instructions = _PROSE_INSTRUCTIONS + (
+        "" if deanonymized else _PROSE_OPAQUE_RULE
+    )
+
     return (
-        f"{_PROSE_INSTRUCTIONS}\n\n"
+        f"{instructions}\n\n"
         f"## Convergence Evidence\n{evidence_block}\n\n"
         f"## Structural Conclusion\n{conclusion}\n\n"
         f"Write the analytical prose report:"

--- a/argumentation_analysis/reporting/restitution/act1_framing_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act1_framing_plugin.py
@@ -122,6 +122,9 @@ class Act1Evidence:
     # as virtuous, the spectrum framing shifts from "what to watch for" to
     # "what could derail but doesn't" (anticipation that did not materialise).
     virtuous_mode: Optional[VirtuousModeAssessment] = None
+    # Epic #1258 / Track 1 #1259 — when True, build_act1_prompt DROPS the
+    # opaque-ID directive so the readable restitution names the real speaker/arena.
+    deanonymized: bool = True
 
 
 @dataclass
@@ -360,6 +363,7 @@ def build_act1_evidence(state: Any) -> Act1Evidence:
         stakeholders=stakeholders,
         arg_count=arg_count,
         virtuous_mode=virtuous_mode,
+        deanonymized=bool(getattr(state, "deanonymized", True)),
     )
 
 
@@ -488,6 +492,8 @@ def build_act1_prompt(evidence: Act1Evidence) -> str:
         f"Inventaire argumentatif : {evidence.arg_count} argument(s) extrait(s)."
     )
 
+    opaque_block = f"{_OPAQUE_ID_DIRECTIVE}\n\n" if not evidence.deanonymized else ""
+
     return (
         "Tu es l'auteur de l'ACTE I d'un rapport de restitution argumentative —\n"
         "la MISE EN SITUATION, tout le cadrage AVANT d'entrer dans le texte pour\n"
@@ -496,7 +502,7 @@ def build_act1_prompt(evidence: Act1Evidence) -> str:
         "se joue, pour qui, quelle asymétrie) ; 3. Le spectre des sophismes\n"
         "attendus pour ce genre (anticipation dérivée de la taxonomie) ;\n"
         "4. La lecture game-theoretic (joueurs, intérêts, coups attendus).\n\n"
-        f"{_OPAQUE_ID_DIRECTIVE}\n\n"
+        f"{opaque_block}"
         f"{_WEAVING_RULE}\n\n"
         f"{_FAIL_LOUD_INSTRUCTION}\n\n"
         f"{virtuous_section}"

--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -178,6 +178,9 @@ class Act2Evidence:
     # as virtuous, the narrative leads with WHY THE ARGUMENTATION HOLDS (the
     # soutiens movement becomes the centrepiece; formal tenue is the proof).
     virtuous_mode: Optional[VirtuousModeAssessment] = None
+    # Epic #1258 / Track 1 #1259 — when True, build_act2_prompt DROPS the
+    # opaque-ID directive so the readable restitution names the real argument.
+    deanonymized: bool = True
 
 
 @dataclass
@@ -463,6 +466,7 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
         virtuous_mode=virtuous_mode,
         governance_verdict=governance_verdict,
         debate_exchanges=debate_exchanges,
+        deanonymized=bool(getattr(state, "deanonymized", True)),
     )
 
 
@@ -800,11 +804,13 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
         "ne fabrique jamais de profil de vertus."
     )
 
+    opaque_block = f"{_OPAQUE_ID_DIRECTIVE}\n\n" if not evidence.deanonymized else ""
+
     return (
         "Tu es l'auteur de l'ACTE II d'un rapport de restitution argumentative.\n"
         "Le récit suit le FIL ARGUMENTATIF (thèse → soutiens → dérapages), découpé\n"
         "par MOUVEMENT argumentatif, PAS par dimension analytique.\n\n"
-        f"{_OPAQUE_ID_DIRECTIVE}\n\n"
+        f"{opaque_block}"
         f"{_WEAVING_RULE}\n\n"
         f"{virtuous_section}"
         "DONNÉES VERIFIÉES DANS LE STATE (ne citer que celles-ci) :\n\n"

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -199,6 +199,9 @@ class Act3Evidence:
     # state characterises the text as virtuous (zero fallacies + non-trivial
     # quality/formal axis). None until build_act3_evidence populates it.
     virtuous_mode: Optional[VirtuousModeAssessment] = None
+    # Epic #1258 / Track 1 #1259 — when True, build_act3_prompt DROPS the
+    # opaque-ID directive so the readable conclusion names the real stakes.
+    deanonymized: bool = True
 
 
 @dataclass
@@ -677,6 +680,7 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
         virtuous_mode=virtuous_mode,
         governance_verdict=governance_verdict,
         debate_exchanges=debate_exchanges,
+        deanonymized=bool(getattr(state, "deanonymized", True)),
     )
 
 
@@ -880,6 +884,8 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         else "  (aucune délibération governance/débat non-triviale — ne la fabrique pas)"
     )
 
+    opaque_block = f"{_OPAQUE_ID_DIRECTIVE}\n\n" if not evidence.deanonymized else ""
+
     return (
         "Tu es l'auteur de l'ACTE III d'un rapport de restitution argumentative\n"
         "— la CONCLUSION ACTIONNABLE : ce que le lecteur FAIT de l'analyse.\n"
@@ -888,7 +894,7 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         "2. Appréciations (forces ET faiblesses du discours, équilibré) ;\n"
         "3. Que faire : comment CONTRER, les POINTS FAIBLES À VISER, à quoi\n"
         "   S'ATTENDRE ENSUITE (retour au cadrage game-theoretic de l'Acte I).\n\n"
-        f"{_OPAQUE_ID_DIRECTIVE}\n\n"
+        f"{opaque_block}"
         f"{_WEAVING_RULE}\n\n"
         f"{_FAIL_LOUD_INSTRUCTION}\n\n"
         f"{virtuous_section}"

--- a/scripts/run_fb34_opaqueness_check.py
+++ b/scripts/run_fb34_opaqueness_check.py
@@ -115,6 +115,12 @@ async def run_one_corpus(label: str) -> dict:
         # leak grep needs. A per-corpus hard timeout below is the safety net.
         result = await run_unified_analysis(
             text=text, workflow_name="standard",
+            # Epic #1258 / Track 1 #1259 — explicitly opt into the OPAQUE path:
+            # this script verifies the opaque-ID discipline holds (0 leaks), so
+            # the working state must run deanonymized=False (the default is now
+            # True for CLI/local readability). The export boundary guard is
+            # Track 3; here we exercise the opaque prompts on purpose.
+            deanonymized=False,
         )
         if isinstance(result, dict):
             s = result.get("unified_state", result.get("state"))
@@ -145,7 +151,9 @@ async def run_one_corpus(label: str) -> dict:
         llm = create_llm_service(service_id="default")
         if llm:
             kernel.add_service(llm)
-        agent = DeepSynthesisAgent(kernel=kernel, service_id="default")
+        agent = DeepSynthesisAgent(
+            kernel=kernel, service_id="default", deanonymized=False
+        )
         # Build a fresh report to feed the grounded path
         fresh = DeepSynthesisReport()
         fresh.source_overview = DeepSynthesisAgent._build_source_overview(

--- a/scripts/run_fb37_capstone.py
+++ b/scripts/run_fb37_capstone.py
@@ -114,6 +114,35 @@ def load_corpus_text(label: str, idx: int) -> str:
     return text
 
 
+def load_corpus_metadata(label: str, idx: int) -> dict:
+    """Epic #1258 / Track 1 #1259 — extract the non-text source metadata already
+    loaded by ``load_extract_definitions``, threaded into ``state.source_metadata``
+    so the deanonymized restitution names the real speaker/arena/era. Only SHORT
+    scalar fields are kept — never ``full_text``/``raw_text``/``extracts``
+    (privacy HARD). The export boundary guard is Track 3 ``sanitize_state``.
+    """
+    from argumentation_analysis.core.utils.crypto_utils import derive_encryption_key
+    from argumentation_analysis.core.io_manager import load_extract_definitions
+
+    key = derive_encryption_key(os.environ["TEXT_CONFIG_PASSPHRASE"])
+    defs = load_extract_definitions(DATASET_PATH, key)
+    if idx >= len(defs):
+        return {}
+    src = defs[idx]
+    _NON_META = {
+        "full_text", "raw_text", "extract_text",
+        "full_text_segment", "raw_text_snippet",
+        "extracts", "segments",
+    }
+    meta: dict = {}
+    for k, v in src.items():
+        if k in _NON_META:
+            continue
+        if isinstance(v, (str, int, float)) and str(v).strip():
+            meta[k] = str(v)
+    return meta
+
+
 def _phase_status(result: dict, name: str) -> str:
     phases = result.get("phases", {})
     pr = phases.get(name)
@@ -190,6 +219,7 @@ async def run_one(label: str, idx: int, timeout: int, corpus_texts: dict) -> dic
     from argumentation_analysis.orchestration.unified_pipeline import run_unified_analysis
 
     text = load_corpus_text(label, idx)
+    source_meta = load_corpus_metadata(label, idx)  # Epic #1258: real source meta
     corpus_texts[label] = text  # keep for per-corpus leak audit
     print(f"[FB-37] doc_{label}: {len(text)} chars | spectacular+full | ceiling {timeout}s")
 
@@ -202,6 +232,11 @@ async def run_one(label: str, idx: int, timeout: int, corpus_texts: dict) -> dic
                 text,
                 workflow_name="spectacular",
                 context={"fallacy_tier": "full"},
+                # Epic #1258 / Track 1 #1259 — thread the real source metadata so
+                # the readable restitution names the real speaker/arena. Default
+                # deanonymized=True drops the opaque-ID prompts. The readable
+                # artifact stays gitignored under evaluation/results/fb37/.
+                source_metadata=source_meta,
             ),
             timeout=float(timeout),
         )

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act1_framing_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act1_framing_plugin.py
@@ -245,12 +245,19 @@ class TestBuildEvidence:
 
 
 class TestPrivacy:
-    def test_prompt_carries_directives(self):
-        ev = build_act1_evidence(_political_state())
+    @pytest.mark.parametrize("deanonymized,expect_opaque", [(True, False), (False, True)])
+    def test_opaque_directive_gated_by_deanonymized(self, deanonymized, expect_opaque):
+        # Epic #1258 / Track 1 #1259 — the opaque-ID directive is present only
+        # when the working state is NOT deanonymized (False restores it
+        # verbatim; True drops it so the readable restitution names the real
+        # speaker). The weaving rule + fail-loud instruction are always present.
+        state = _political_state()
+        state.deanonymized = deanonymized
+        ev = build_act1_evidence(state)
         prompt = build_act1_prompt(ev)
-        assert "OPAQUES" in prompt  # FB-34 directive
-        assert "TISSAGE" in prompt  # §4 weaving rule
-        assert "HONNÊTETÉ" in prompt  # fail-loud instruction
+        assert ("OPAQUES" in prompt) == expect_opaque  # FB-34 directive
+        assert "TISSAGE" in prompt  # §4 weaving rule (always)
+        assert "HONNÊTETÉ" in prompt  # fail-loud instruction (always)
 
     def test_long_metadata_truncated_in_prompt(self):
         state = _state(source_metadata={"genre": "x" * 500})

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
@@ -412,11 +412,16 @@ class TestPrivacy:
         assert long_desc not in prompt
         assert "[…]" in prompt
 
-    def test_prompt_carries_opaque_id_directive_and_weaving_rule(self):
-        ev = build_act2_evidence(_rich_state())
+    @pytest.mark.parametrize("deanonymized,expect_opaque", [(True, False), (False, True)])
+    def test_opaque_directive_gated_by_deanonymized(self, deanonymized, expect_opaque):
+        # Epic #1258 / Track 1 #1259 — opaque-ID directive present only when
+        # NOT deanonymized; weaving rule always present.
+        state = _rich_state()
+        state.deanonymized = deanonymized
+        ev = build_act2_evidence(state)
         prompt = build_act2_prompt(ev)
-        assert "OPAQUES" in prompt  # FB-34 directive heading
-        assert "TISSAGE" in prompt  # §4 weaving rule heading
+        assert ("OPAQUES" in prompt) == expect_opaque  # FB-34 directive heading
+        assert "TISSAGE" in prompt  # §4 weaving rule heading (always)
         assert "spec §4" in prompt
 
 

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -442,12 +442,17 @@ class TestPrivacy:
         assert long_just not in prompt
         assert "[…]" in prompt
 
-    def test_prompt_carries_directives(self):
-        ev = build_act3_evidence(_rich_state())
+    @pytest.mark.parametrize("deanonymized,expect_opaque", [(True, False), (False, True)])
+    def test_opaque_directive_gated_by_deanonymized(self, deanonymized, expect_opaque):
+        # Epic #1258 / Track 1 #1259 — opaque-ID directive present only when
+        # NOT deanonymized; weaving rule + fail-loud always present.
+        state = _rich_state()
+        state.deanonymized = deanonymized
+        ev = build_act3_evidence(state)
         prompt = build_act3_prompt(ev)
-        assert "OPAQUES" in prompt  # FB-34 directive heading
-        assert "TISSAGE" in prompt  # §4 weaving rule heading
-        assert "HONNÊTETÉ" in prompt  # fail-loud instruction heading
+        assert ("OPAQUES" in prompt) == expect_opaque  # FB-34 directive heading
+        assert "TISSAGE" in prompt  # §4 weaving rule heading (always)
+        assert "HONNÊTETÉ" in prompt  # fail-loud instruction heading (always)
         assert "spec §4" in prompt
 
     def test_prompt_carries_verdict_band(self):


### PR DESCRIPTION
## Epic #1258 Track 1 — #1259: Déanonymiser le pipeline de travail + source_metadata réel

The readable 3-act restitution report was **anonymized/decontextualized**: the FB-34 #1118 opaque-ID discipline was baked into every LLM synthesis prompt, so even a local run produced a briefing that named `Speaker_A` / `State_Q` instead of the real speaker/arena/era. This track flips the **working state** to deanonymized-by-default and threads REAL source metadata, so the readable artifact is contextualized — while the **export boundary** stays opaque (Track 3, separate scope).

### Deliverables (per #1259 body)

1. **`deanonymized` switch on state** (default `True` for CLI/local) — `UnifiedAnalysisState.deanonymized` + `run_unified_analysis(deanonymized=)`.
2. **Conditional opaque-directive gating** across 6 prompt sites — directive **dropped** when `True`, **restored verbatim** when `False`.
3. **`source_metadata` setter + plumbing** — `set_source_metadata()` (privacy-HARD key reject) + `run_unified_analysis(source_metadata=)` + capstone runner populates real short-scalar metadata.

### Anti-pendule

The fix **subtracts conditionally** — it never adds a "use the real name" directive. `False` restores the FB-34 opaque prompts byte-for-byte; `True` simply omits the opaque block. The LLM stays the only producer; we only relax the vocabulary constraint when the working state is allowed to be real.

### Privacy HARD (preserved)

- `set_source_metadata()` and `load_corpus_metadata()` **reject** `raw_text`/`full_text`/`full_text_segment`/`raw_text_snippet`/`extracts`/`segments` — only short scalars are kept.
- **Export boundary** (git/dashboard/API) stays opaque via Track 3 `sanitize_state` (po-2025 scope, #1260). This PR makes the *working* state real; the *committed/shared* artifact stays gitignored under `evaluation/results/` and opaque at the boundary. ⚠️ **Track 3 must merge before this default reaches any shared surface.**

### Files (15)

**Foundation:** `core/shared_state.py`, `orchestration/unified_pipeline.py`
**Prompt gating (conditional subtract):** `reporting/restitution/act{1,2,3}_*.py`, `orchestration/hierarchical/strategic/manager.py`, `agents/core/political/stakes_extractor.py`, `plugins/narrative_synthesis_plugin.py`, `agents/core/synthesis/deep_synthesis_agent.py`
**Threading:** `orchestration/invoke_callables.py`
**Scripts:** `scripts/run_fb34_opaqueness_check.py` (opts into opaque — verifies the guard), `scripts/run_fb37_capstone.py` (`load_corpus_metadata`)
**Tests:** `test_act{1,2,3}_*_plugin.py` (TestPrivacy parametrized by `deanonymized`)

### Verification

- **115 passed** (act1/2/3 plugins + stakes_extractor), deep_synthesis `_llm_synthesis` stub tests **green** (2 fixed: `getattr(self, "_deanonymized", True)` fallback for stub state).
- **CI-exact mypy** (`--config-file pyproject.toml`) on the 2 CI-gated edited files (`shared_state.py` + `invoke_callables.py`): **Success — 0 issues**. `deep_synthesis_agent.py` is NOT in the CI mypy list (its 9 pre-existing errors are non-gated).
- **8 unrelated test failures** (propositional_logic/dung/hierarchical_fallacy/standard_workflow/DAG) confirmed **pre-existing on `origin/main`** via `git stash` baseline — out of scope.
- black/flake8 are `continue-on-error` in CI (informational, non-blocking); `black`/`flake8` absent from the local env.

### DoD checklist (#1259)

- [x] Working state deanonymized by default (CLI/local)
- [x] No opaque directive injected when `deanonymized=True`
- [x] `deanonymized=False` restores opaque directives verbatim (FB-34 path intact)
- [x] `source_metadata` setter + `run_unified_analysis(source_metadata=)`
- [x] stakes_extractor emits real stakeholders when deanonymized
- [x] Tests act1/2/3 parametrized by `deanonymized`
- [x] mypy strict clean on gated files (real CI gate)
- [ ] Real run → Acte I names real speaker (requires LLM + corpus; out of unit-test scope — exercised by FB-37 capstone runner)

Closes #1259. Refs #1258. Blocked-on-merge-order: Track 3 (#1260 export boundary) should land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
