### PR TITLE
feat(logic): Epic #1258 Track 2 #1260 — intuitive logic symbols (lift p1/mp1 castration)

### DIFF
--- a/argumentation_analysis/agents/core/logic/modal_logic_agent.py
+++ b/argumentation_analysis/agents/core/logic/modal_logic_agent.py
@@ -65,8 +65,8 @@ ATTENTION - Syntaxe TweetyProject stricte requise :
 - Listez TOUTES les propositions utilisées dans le tableau "propositions" ; elles seront déclarées
   automatiquement par le moteur comme "type(prop)" (prédicat 0-aire). Ne générez PAS de "type(...)"
   vous-même dans "modal_formulas" — uniquement des formules.
-- Utilisez UNIQUEMENT des identifiants en minuscules avec underscores
-- Format JSON : {"propositions": ["prop1", "prop2"], "modal_formulas": ["[](prop1)", "<>(prop2)"]}
+- Utilisez UNIQUEMENT des identifiants en minuscules avec underscores (noms lisibles et porteurs de sens, ex. "climate_action" plutôt que "prop1")
+- Format JSON : {"propositions": ["climate_action", "energy_transition"], "modal_formulas": ["[](climate_action)", "<>(energy_transition)"]}
 - TOUJOURS entourer la proposition avec des parenthèses après un opérateur modal: [](prop), <>(prop)
 
 Si vous avez reçu une erreur de syntaxe précédemment, corrigez-la en utilisant la BNF TweetyProject :

--- a/argumentation_analysis/agents/core/logic/pl_formula_sanitizer.py
+++ b/argumentation_analysis/agents/core/logic/pl_formula_sanitizer.py
@@ -1,10 +1,20 @@
 """PL Formula Sanitizer for Tweety-compatible syntax (#537).
 
 Sits between LLM output and TweetyBridge.parse_pl_formula(). Handles:
-- Verbose proposition names (NL fragments) → atomic symbols (p, q, r, ...)
+- Normalisation of illegal tokens (accents/punctuation/spaces) into
+  snake_case atoms that **preserve the LLM-chosen meaning**.
 - Syntax validation against Tweety PL grammar before JPype submission
 - Graceful fallback: log warning and skip invalid formulas instead of raising
 - Symbol mapping storage for round-trip interpretation
+
+Epic #1258 Track 2 (#1260): the sanitizer used to collapse ANY atom longer
+than 30 chars (or NL-like) into opaque ``p, q, r`` — destroying the readable
+names the LLM produced. The collapse is now **subtracted**: a readable,
+parser-legal atom (``renewable_essential``) survives untouched regardless of
+length. Only tokens that would fail the Tweety grammar (accents, punctuation,
+embedded spaces) are normalised into a meaning-preserving snake_case atom;
+``symbol_mapping`` records those renames so Track 3 can opacify at export.
+The LLM names — this never generates a name.
 
 Tweety PL BNF (simplified):
     FORMULA ::= PROPOSITION | "(" FORMULA ")" | FORMULA "=>" FORMULA
@@ -64,17 +74,25 @@ class PLFormulaSanitizer:
         sanitizer = PLFormulaSanitizer()
         result = sanitizer.sanitize_batch(["rain && (rain => wet)", "verbose NL claim"])
         for f in result.sanitized_formulas:
-            print(f)  # "p && (p => q)"
-        print(result.symbol_mapping)  # {"p": "rain", "q": "wet"}
+            print(f)  # "rain && (rain => wet)" — readable atoms survive (#1260)
+        print(result.symbol_mapping)  # {"verbose_nl_claim": "verbose NL claim"}
     """
 
     def __init__(self, max_prop_length: int = 30):
+        # #1260: ``max_prop_length`` is retained for backward-compat but no
+        # longer caps readable atoms into ``p,q,r``. It is *not* read in the
+        # hot path — see ``_needs_normalization``. Kept (not deleted) only so
+        # existing call-sites passing it keep working.
         self._max_prop_length = max_prop_length
         self._symbol_counter = 0
         self._label_to_symbol: Dict[str, str] = {}
 
     def _next_symbol(self) -> str:
-        """Generate the next atomic symbol: p, q, r, s, t, u, v, w, x, y, z, p2, q2, ..."""
+        """Generate the next atomic symbol: p, q, r, s, t, u, v, w, x, y, z, p2, q2, ...
+
+        Retained for any future opt-in opaque-symbolisation, but #1260 stops
+        calling it for readable atoms — see ``_normalize_atom``.
+        """
         idx = self._symbol_counter
         # 11 letters: p(0), q(1), r(2), s(3), t(4), u(5), v(6), w(7), x(8), y(9), z(10)
         base = idx % 11
@@ -84,16 +102,48 @@ class PLFormulaSanitizer:
         self._symbol_counter += 1
         return symbol
 
+    def _needs_normalization(self, token: str) -> bool:
+        """Return True only if ``token`` would FAIL the Tweety proposition grammar.
+
+        #1260 (anti-pendule): previously an atom longer than 30 chars *or*
+        containing any NL marker was collapsed to ``p,q,r``. That destroyed
+        readable LLM-chosen atoms (``renewable_essential`` is perfectly legal
+        yet was >30c-readable). The cap is **subtracted**: a token needs
+        normalisation iff it is NOT already a valid ``PROPOSITION``. A long
+        but legal atom survives untouched.
+        """
+        return not _PROP_RE.match(token)
+
     def _is_nl_like(self, token: str) -> bool:
-        """Check if a token looks like NL text rather than a proposition name."""
-        if len(token) > self._max_prop_length:
-            return True
-        if _NL_TOKEN_RE.search(token):
-            return True
-        # Mixed language with accented chars
-        if re.search(r"[àâäéèêëïîôùûüÿçœæÀÂÄÉÈÊËÏÎÔÙÛÜŸÇŒÆ]", token):
-            return True
-        return False
+        """Backward-compatible alias for :meth:`_needs_normalization`.
+
+        #1260: the name is kept (callers + tests reference it) but the
+        semantics narrowed to "illegal for Tweety", not "looks like prose".
+        A readable long atom is no longer "NL-like" in the collapse sense.
+        """
+        return self._needs_normalization(token)
+
+    def _normalize_atom(self, atom: str) -> str:
+        """Normalise an illegal atom into a meaning-preserving snake_case atom.
+
+        #1260: replaces the old ``_map_label`` collapse to ``p,q,r``. The
+        transformation is lossy only in the syntactic sense (accents dropped,
+        non-alnum → ``_``) — the semantic stem of the LLM-chosen name is
+        preserved (``l``é``conomie_est_forte`` → ``l_e_conomie_est_forte``),
+        never replaced by an opaque letter. First alnum chars retained
+        (truncated to keep atoms reasonable); a short hash disambiguates
+        distinct inputs collapsing to the same stem. Deterministic.
+        """
+        if not atom:
+            return "x"
+        import hashlib as _hashlib
+
+        # Collapse runs of non-alnum to a single underscore, lowercase.
+        cleaned = re.sub(r"[^A-Za-z0-9]+", "_", atom).strip("_").lower()[:24]
+        if not cleaned:
+            cleaned = "x"
+        digest = _hashlib.md5(atom.encode("utf-8")).hexdigest()[:6]
+        return f"{cleaned}_{digest}"
 
     def _extract_propositions(self, formula: str) -> List[str]:
         """Extract proposition tokens from a normalized formula string."""
@@ -109,11 +159,17 @@ class PLFormulaSanitizer:
         return props
 
     def _map_label(self, label: str) -> str:
-        """Map a proposition label to an atomic symbol. Reuses existing mappings."""
+        """Map an illegal proposition label to a meaning-preserving atom.
+
+        #1260: previously produced opaque ``p,q,r``. Now normalises the label
+        into a readable snake_case atom (:meth:`_normalize_atom`) and records
+        the mapping in ``symbol_mapping`` (readable_atom → original NL) so
+        Track 3 can opacify at export. Reuses existing mappings for stability.
+        """
         label_lower = label.lower()
         if label_lower in self._label_to_symbol:
             return self._label_to_symbol[label_lower]
-        symbol = self._next_symbol()
+        symbol = self._normalize_atom(label)
         self._label_to_symbol[label_lower] = symbol
         return symbol
 

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -5117,11 +5117,13 @@ async def _invoke_propositional_logic(
                     logger.debug(f"NL-to-logic PL translation unavailable: {e}")
 
         if not formulas:
-            # Final fallback: template-based variables
-            prop_vars = [f"p{i+1}" for i in range(len(args))]
+            # Final fallback: meaning-preserving readable atoms (#1260).
+            # Previously opaque p1,p2 — now derive a readable slug per argument
+            # via the existing _pl_atom() so the belief set stays interpretable.
+            prop_vars = [_pl_atom(a) for a in args]
             formulas = list(prop_vars)
             pl_metrics["template"] = len(prop_vars)
-            argument_mapping = {f"p{i+1}": a[:60] for i, a in enumerate(args)}
+            argument_mapping = {prop_vars[i]: a[:60] for i, a in enumerate(args)}
             fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
             fallacies = (
                 fallacy_output.get("fallacies", [])
@@ -5187,9 +5189,7 @@ async def _invoke_propositional_logic(
         pl_backend_comparison: Optional[Dict[str, Any]] = None
         if context.get("compare_backends") and bridge is not None:
             try:
-                pl_backend_comparison = await bridge.compare_pl_backends(
-                    belief_set_str
-                )
+                pl_backend_comparison = await bridge.compare_pl_backends(belief_set_str)
                 logger.info(
                     "PL backend comparison: agreement=%s, decided=%s",
                     pl_backend_comparison.get("agreement"),
@@ -5207,8 +5207,7 @@ async def _invoke_propositional_logic(
             "query_count": 0,  # PL consistency is a satisfiability check (no entailment query)
             "message": msg,
             "logic_type": "propositional",
-            "argument_mapping": argument_mapping
-            or {f"p{i+1}": a[:60] for i, a in enumerate(args)},
+            "argument_mapping": argument_mapping or {_pl_atom(a): a[:60] for a in args},
             "pl_metrics": pl_metrics,
             **(
                 {"pl_backend_comparison": pl_backend_comparison}
@@ -5245,10 +5244,10 @@ async def _invoke_propositional_logic(
             return {
                 "formulas": valid_formulas,
                 "satisfiable": True,
-                "model": {f"p{i+1}": True for i in range(len(args))},
+                "model": {_pl_atom(a): True for a in args},
                 "logic_type": "propositional",
                 "argument_mapping": argument_mapping
-                or {f"p{i+1}": a[:60] for i, a in enumerate(args)},
+                or {_pl_atom(a): a[:60] for a in args},
                 "isolation_retry": True,
                 "rejected_count": len(formulas) - len(valid_formulas),
                 "pl_metrics": pl_metrics,
@@ -5912,7 +5911,7 @@ async def _invoke_modal_logic(
         }
         _atom_re = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
         _mlparser_legal_re = re.compile(r"^[a-zA-Z][a-zA-Z0-9]*$")
-        # Reserve the already-legal atom names so generated ``mpN`` symbols never
+        # Reserve the already-legal atom names so normalised symbols never
         # collide with a real atom that is already MlParser-legal.
         _legal_atoms = {
             tok
@@ -5921,19 +5920,33 @@ async def _invoke_modal_logic(
             if tok not in _keyword_atoms and _mlparser_legal_re.match(tok)
         }
         _atom_symbol: Dict[str, str] = {}
-        _symbol_counter = 0
 
         def _legal_symbol(atom: str) -> str:
-            """Map a modal atom to an MlParser-legal identifier (memoized)."""
-            nonlocal _symbol_counter
+            """Map a modal atom to an MlParser-legal identifier (memoized).
+
+            #1260 (anti-pendule): previously collapsed any underscored atom to
+            opaque ``mp1, mp2``. Now transforms to a meaning-preserving
+            camelCase identifier (``heavy_rain`` → ``heavyRain``), which is
+            accepted by ``MlParser`` (it forbids underscores but allows
+            alphanumeric camelCase). The semantic stem survives. Only fallback
+            to a generic ``mpN`` if normalisation yields an empty/illegal stem.
+            """
             if atom in _keyword_atoms or _mlparser_legal_re.match(atom):
                 return atom
             if atom not in _atom_symbol:
-                _symbol_counter += 1
-                candidate = f"mp{_symbol_counter}"
-                while candidate in _legal_atoms:
-                    _symbol_counter += 1
-                    candidate = f"mp{_symbol_counter}"
+                # underscore/camelCase transform: split on non-alnum, PascalCase.
+                parts = [p for p in re.split(r"[^A-Za-z0-9]+", atom) if p]
+                candidate = "".join(p[:1].upper() + p[1:] for p in parts) or "mpAtom"
+                if not _mlparser_legal_re.match(candidate) or candidate in _legal_atoms:
+                    # Rare: degenerate stem or collision — disambiguate, but
+                    # keep the readable stem as the base (not a bare mpN).
+                    base = (
+                        candidate if _mlparser_legal_re.match(candidate) else "MpAtom"
+                    )
+                    suffix = 1
+                    while f"{base}{suffix}" in _legal_atoms:
+                        suffix += 1
+                    candidate = f"{base}{suffix}"
                 _atom_symbol[atom] = candidate
             return _atom_symbol[atom]
 

--- a/argumentation_analysis/services/nl_to_logic.py
+++ b/argumentation_analysis/services/nl_to_logic.py
@@ -792,14 +792,23 @@ class NLToLogicTranslator:
         sentences = [s.strip() for s in sentences if len(s.strip()) > 10]
 
         if logic_type == "propositional":
-            variables = {}
-            for i, sent in enumerate(sentences[:5]):
-                var_name = f"p{i + 1}"
+            # #1260: derive a readable atom per sentence (was opaque p1,p2).
+            # Keeps up to 20 alnum chars of the sentence as the atom stem so the
+            # belief set stays interpretable; index suffix disambiguates.
+            variables: Dict[str, str] = {}
+            for sent in sentences[:5]:
+                stem = re.sub(r"[^A-Za-z0-9]+", "_", sent).strip("_").lower()[:20]
+                stem = stem or "claim"
+                idx = len(variables) + 1
+                var_name = stem
+                while var_name in variables:
+                    idx += 1
+                    var_name = f"{stem}_{idx}"
                 variables[var_name] = sent[:80]
 
             if len(variables) >= 2:
                 var_names = list(variables.keys())
-                # Simple implication chain: p1 => p2 => ... => pN
+                # Implication chain: stem_a => stem_b => ... => stemN
                 implications = [
                     f"{var_names[i]} => {var_names[i+1]}"
                     for i in range(len(var_names) - 1)
@@ -808,8 +817,13 @@ class NLToLogicTranslator:
             elif variables:
                 formula = list(variables.keys())[0]
             else:
-                formula = "p1"
-                variables = {"p1": text[:80]}
+                # Degenerate: no sentences long enough — single readable atom.
+                stem = (
+                    re.sub(r"[^A-Za-z0-9]+", "_", text).strip("_").lower()[:20]
+                    or "claim"
+                )
+                formula = stem
+                variables = {stem: text[:80]}
 
             return TranslationResult(
                 original_text=text,

--- a/tests/unit/argumentation_analysis/test_pl_formula_sanitizer.py
+++ b/tests/unit/argumentation_analysis/test_pl_formula_sanitizer.py
@@ -99,14 +99,22 @@ class TestNLDetection:
 
 
 class TestSymbolMapping:
-    """Test NL→atomic symbol mapping."""
+    """Test illegal-token → meaning-preserving atom mapping (#1260).
 
-    def test_basic_mapping(self):
+    #1260 (anti-pendule): previously NL-like labels collapsed to opaque
+    ``p,q,r``. They now normalise into a readable snake_case atom that
+    preserves the LLM-chosen meaning. Assertions check stability + that the
+    output is a readable stem (never an opaque single letter).
+    """
+
+    def test_basic_mapping_is_readable(self):
         s = PLFormulaSanitizer()
         sym1 = s._map_label("it is raining")
         sym2 = s._map_label("the ground is wet")
-        assert sym1 == "p"
-        assert sym2 == "q"
+        # Readable stem preserved, never an opaque "p"/"q".
+        assert "rain" in sym1 or "it_is_rain" in sym1
+        assert "wet" in sym2 or "ground_is_wet" in sym2
+        assert sym1 != "p" and sym2 != "q"
 
     def test_reuse_mapping(self):
         s = PLFormulaSanitizer()
@@ -114,28 +122,28 @@ class TestSymbolMapping:
         sym2 = s._map_label("rain")
         assert sym1 == sym2
 
-    def test_symbol_exhaustion(self):
+    def test_distinct_labels_distinct_symbols(self):
         s = PLFormulaSanitizer()
         symbols = [s._map_label(f"label_{i}") for i in range(30)]
-        assert symbols[0] == "p"
-        assert symbols[10] == "z"
-        assert symbols[11] == "p2"
-        assert symbols[12] == "q2"
+        # #1260: 30 distinct labels → 30 distinct readable atoms (no collision,
+        # hash disambiguates). None should be an opaque single letter.
         assert len(set(symbols)) == 30
+        assert all(not (len(sym) == 1 and sym.isalpha()) for sym in symbols)
 
     def test_case_insensitive_reuse(self):
         s = PLFormulaSanitizer()
         s._map_label("Rain")
         sym2 = s._map_label("rain")
-        assert sym2 == "p"
+        # Case-insensitive: same readable atom reused.
+        assert "rain" in sym2
 
     def test_reverse_mapping(self):
         s = PLFormulaSanitizer()
         s._map_label("it is raining")
         s._map_label("the ground is wet")
         rev = s.reverse_mapping()
-        assert rev["p"] == "it is raining"
-        assert rev["q"] == "the ground is wet"
+        # symbol → original NL label. Values preserved.
+        assert set(rev.values()) == {"it is raining", "the ground is wet"}
 
 
 class TestFormulaValidation:
@@ -274,17 +282,24 @@ class TestBatchSanitization:
         assert result.total_sanitized == 3
         assert len(result.skipped_formulas) == 2
 
-    def test_nl_formulas_mapped(self):
+    def test_readable_atoms_survive_unmapped(self):
+        # #1260 (DoD): long but LEGAL snake_case atoms must survive untouched.
+        # Previously these exceeded max_prop_length and were collapsed to p,q,r.
         s = PLFormulaSanitizer(max_prop_length=20)
-        # Long proposition names that exceed max_prop_length → mapped to atomic symbols
         formulas = [
             "national_sovereignty_requires && foreign_powers_threaten",
             "cooperation_yields_outcomes => defend_borders_against",
         ]
         result = s.sanitize_batch(formulas)
         assert result.total_sanitized == 2
-        # Long names should be mapped to p, q, r, s
-        assert len(result.symbol_mapping) >= 2
+        # Readable atoms survive verbatim → NO mapping needed (they were never
+        # illegal). symbol_mapping is empty for an all-legal batch.
+        assert result.symbol_mapping == {}
+        # The sanitized formulas still carry the readable names.
+        joined = " ".join(result.sanitized_formulas)
+        assert "national_sovereignty_requires" in joined
+        assert "foreign_powers_threaten" in joined
+        assert "p" != result.sanitized_formulas[0].split()[0]
 
     def test_symbol_mapping_populated(self):
         s = PLFormulaSanitizer()
@@ -308,6 +323,46 @@ class TestBatchSanitization:
         assert isinstance(result.sanitized_formulas, list)
         assert isinstance(result.symbol_mapping, dict)
         assert isinstance(result.skipped_formulas, list)
+
+
+class TestTrack2IntuitiveSymbols:
+    """Epic #1258 Track 2 (#1260) — readable atoms survive, illegal → readable."""
+
+    def test_illegal_atom_becomes_readable_snake_case(self):
+        # DoD: an illegal atom (spaces/accent) normalises to a meaning-preserving
+        # snake_case atom, NOT an opaque p/q/r. The stem carries the sense.
+        s = PLFormulaSanitizer()
+        result = s.sanitize_batch(["leconomie est forte => les marches montent"])
+        assert result.total_sanitized == 1
+        # The mapping records the readable normalised atom → original NL.
+        for atom in result.symbol_mapping.keys():
+            # Readable stem present, never a bare opaque letter.
+            assert len(atom) > 1
+            assert atom[0].isalpha()
+
+    def test_no_opaque_single_letter_atoms_produced(self):
+        # DoD: across a mixed batch, no atom should be an opaque p/q/r.
+        s = PLFormulaSanitizer()
+        result = s.sanitize_batch(
+            [
+                "renewable_essential => climate_stable",
+                "leconomie croit && foreign_powers_retreat",
+            ]
+        )
+        assert result.total_sanitized == 2
+        tokens = " ".join(result.sanitized_formulas).split()
+        atoms = [t for t in tokens if t not in {"=>", "<=>", "&&", "||", "!", "(", ")"}]
+        # Every atom is readable (length > 1, alnum/underscore).
+        for a in atoms:
+            assert len(a) > 1, f"opaque single-letter atom produced: {a}"
+
+    def test_long_legal_atom_survives_regardless_of_cap(self):
+        # DoD: the 30-char cap no longer collapses a legal readable atom.
+        s = PLFormulaSanitizer(max_prop_length=5)
+        result = s.sanitize_batch(["national_sovereignty_requires_immediate"])
+        assert result.total_sanitized == 1
+        assert result.sanitized_formulas[0] == "national_sovereignty_requires_immediate"
+        assert result.symbol_mapping == {}
 
 
 class TestEdgeCases:


### PR DESCRIPTION
## Track 2 — Intuitive logic symbols: lift the p1/mp1 castration (subtraction)

Closes #1260. Rebased on Track 1 #1264 (now merged, main `21c0fdf4`). Lane: po-2025, logic plumbing — disjoint functions from T1/T3/T4.

### What

The logic prompts already ask the LLM for readable names (`renewable_essential`, `heavy_rain`, `Homme(X)`), and FOL preserves them end-to-end. But three downstream mechanisms collapsed them into opaque `p1`/`mp1`. This PR **subtracts** the castration so the LLM-chosen atoms survive. The LLM names — no name generator is built (user mandate: "let the LLMs name, they're good at it"). `arg_N` stays the stable internal key (not re-keyed).

### Three sites — all subtractions

**1. PL sanitizer** (`pl_formula_sanitizer.py`):
- `_needs_normalization` (was `_is_nl_like`): returns True only if a token **fails** the Tweety proposition grammar, not if it's merely long. A readable, parser-legal atom survives untouched regardless of length.
- `_normalize_atom` (was `_map_label`→`_next_symbol`): an illegal token (accents/punctuation/spaces) normalises to a **meaning-preserving snake_case atom** (`leconomie est forte` → `leconomie_est_forte_<hash>`), never collapsed to `p,q,r`. The `p,q,r` counter is dead code now (kept for back-compat opt-in).
- `symbol_mapping` is preserved (records the renames) so Track 3 #1263 opacifies at export.

**2. Modal** (`invoke_callables.py::_legal_symbol`): underscored atom → camelCase preserving the sense (`heavy_rain` → `heavyRain`), which is accepted by `MlParser` (forbids underscores but allows alphanumeric camelCase). The `mp1,mp2` counter collapse is removed; a generic `mpN` only as a rare degenerate-stem fallback.

**3. Fallbacks**: `p1,p2` → the existing readable slug `_pl_atom(arg)` / per-sentence stem:
- `invoke_callables.py` PL template + isolation-retry paths (3 sites)
- `services/nl_to_logic.py` heuristic translator

**4. Modal prompt example** (`modal_logic_agent.py`): `prop1,prop2` → `climate_action, energy_transition` (light nudge).

### DoD mapping

- [x] Readable legal atoms survive (`renewable_essential`, `heavyRain`) instead of `p1`/`mp1`.
- [x] Tweety still parses (PL grammar respected; modal camelCase is `MlParser`-legal) — no `ParserException` introduced.
- [x] `symbol_mapping` preserved for Track 3 opacification.
- [x] Sanitizer tests adapted: `p,q,r`/`mp_N` assertions → "readable atom survives". 3 new DoD tests (`TestTrack2IntuitiveSymbols`): illegal→readable, no opaque single-letter atom produced, long legal atom survives regardless of cap.

### Validation

- **72/72** green (`test_pl_formula_sanitizer` + `test_track_vv_formula_survival`); **931/931** with services (incl. `nl_to_logic`).
- **mypy** clean on the 3 Track-2 source files. `nl_to_logic.py:328` + `:400` are **pre-existing errors on main** (verified via `git stash` baseline on `21c0fdf4`) — out of scope.
- **black** + **flake8** clean.

### Anti-pendule

Pure subtraction: lifted the caps/collapses, added no counterweight, built no name generator. FOL was already name-preserving (untouched). `arg_N` internal key unchanged (user decision).

### Privacy HARD

Readable atoms may be nominative → OK in working state + gitignored artefacts; `symbol_mapping` retained so Track 3 #1263 opacifies at export. Opaque IDs only in commit/PR/dashboard.

---
Dispatched by ai-01 (R472). Lane: po-2025. Epic #1258 now at 3/5 (T3+T1 merged, T2 here, T4 po-2023 pending).
