### PR TITLE
fix(governance): #1273 consensus_rate handles dict-shaped votes

### DIFF
--- a/argumentation_analysis/agents/core/governance/metrics.py
+++ b/argumentation_analysis/agents/core/governance/metrics.py
@@ -10,13 +10,38 @@ import numpy as np
 
 
 def consensus_rate(results):
-    """Fraction of agents voting for the winner."""
+    """Fraction of agents voting for the winner.
+
+    Handles three ``votes`` shapes the governance plugin's LLM-generated
+    JSON can take (#1273): a sequential list (``["A", "A", "B"]``), a
+    per-option tally map (``{"A": 2, "B": 1}``), or a per-agent vote map
+    (``{"agent_1": "A", "agent_2": "B"}``). The plugin calls this without a
+    try/except wrapper, so a dict must not raise ``AttributeError`` on
+    ``.count()``. Dicts are disambiguated by whether ``winner`` is a key
+    (tally map) or a value (per-agent map). Returns 0.0 on missing/empty.
+    """
     if not results or "votes" not in results or "winner" not in results:
         return 0.0
     votes = results["votes"]
     winner = results["winner"]
     if not votes or winner is None:
         return 0.0
+
+    def _tally(value: Any) -> float:
+        # Normalize a tally entry to a scalar vote count: a number stays,
+        # a (pos, neg)/list sums its numeric items, anything else is 0.
+        if isinstance(value, (list, tuple)):
+            return float(sum(v for v in value if isinstance(v, (int, float))))
+        return float(value) if isinstance(value, (int, float)) else 0.0
+
+    if isinstance(votes, dict):
+        if winner in votes:
+            # Per-option tally map {option: count}: winner's share of total.
+            total = sum(_tally(v) for v in votes.values())
+            return _tally(votes.get(winner, 0)) / total if total else 0.0
+        # Per-agent vote map {agent: choice}: fraction of agents who picked
+        # the winner.
+        return sum(1 for v in votes.values() if v == winner) / len(votes)
     return votes.count(winner) / len(votes)
 
 

--- a/tests/unit/argumentation_analysis/agents/core/governance/test_governance_metrics.py
+++ b/tests/unit/argumentation_analysis/agents/core/governance/test_governance_metrics.py
@@ -40,6 +40,31 @@ class TestConsensusRate:
     def test_winner_not_in_votes(self):
         assert consensus_rate({"votes": ["A", "B"], "winner": "C"}) == 0.0
 
+    # ── dict-shaped votes (LLM-generated tally maps, #1273) ──
+
+    def test_dict_tally_unanimous(self):
+        # Per-option tally map {option: count}; all votes for the winner.
+        assert consensus_rate({"votes": {"A": 3, "B": 0}, "winner": "A"}) == 1.0
+
+    def test_dict_tally_majority(self):
+        r = consensus_rate({"votes": {"A": 2, "B": 1}, "winner": "A"})
+        assert r == pytest.approx(2 / 3)
+
+    def test_dict_tally_winner_not_present(self):
+        # Winner absent from the tally → 0 of total → 0.0, no crash.
+        assert consensus_rate({"votes": {"A": 2, "B": 1}, "winner": "C"}) == 0.0
+
+    def test_dict_per_agent_vote_map(self):
+        # Per-agent map {agent: choice}; winner is a value, not a key.
+        # 2 of 3 agents picked "A" → 2/3.
+        r = consensus_rate(
+            {"votes": {"agent_1": "A", "agent_2": "A", "agent_3": "B"}, "winner": "A"}
+        )
+        assert r == pytest.approx(2 / 3)
+
+    def test_dict_tally_empty(self):
+        assert consensus_rate({"votes": {}, "winner": "A"}) == 0.0
+
 
 # ── gini ──
 


### PR DESCRIPTION
## What

`consensus_rate()` called `.count()` on `votes`, which raises `AttributeError` when `votes` is a `dict`. The governance plugin feeds this **LLM-generated JSON** (a `results_json` string with `'votes'` + `'winner'` keys) **without a try/except wrapper** (`governance_plugin.py:85`, unlike its siblings `fairness_index`/`satisfaction` which ARE wrapped), so the exception propagated → SK caught it → ~204 log lines per capstone run + silently degraded the metric to 0.0.

Discovered firsthand during Capstone #1269 (corpus_A spectacular run). Filed as #1273.

## Root cause (verified firsthand)

`governance_plugin.compute_consensus_metrics` → `results = json.loads(results_json)` → `consensus_rate(results)`. The LLM variably emits `votes` as:
- a **list** `["A","A","B"]` (handled — `.count()` works), OR
- a **dict** — two real shapes:
  - per-option tally map `{"A": 2, "B": 1}` (winner is a **key**)
  - per-agent vote map `{"agent_1": "A", "agent_2": "B"}` (winner is a **value**)

The dict path hit `votes.count(winner)` → `'dict' object has no attribute 'count'`.

## Fix

Anti-pendule (minimal, single function): discriminate the dict shape by whether `winner` is a key (tally map → winner's share of total) or a value (per-agent map → fraction of agents who picked the winner). List path unchanged. A nested `_tally` normalizes scalar/list/tuple tally entries so `sum(values)` never TypeErrors.

```python
if isinstance(votes, dict):
    if winner in votes:                      # per-option tally map
        total = sum(_tally(v) for v in votes.values())
        return _tally(votes.get(winner, 0)) / total if total else 0.0
    return sum(1 for v in votes.values() if v == winner) / len(votes)  # per-agent map
return votes.count(winner) / len(votes)      # list (unchanged)
```

## Validation

- `tests/unit/.../test_governance_metrics.py`: **47/47 pass** (5 new dict cases: tally unanimous/majority/winner-absent, per-agent map, empty).
- `tests/unit/.../test_governance_plugin.py`: **15/15 pass** (caller unaffected).
- Issue #1273 repro `consensus_rate({'votes': {'a':1,'b':2}, 'winner':'b'})` → `0.667` (was crash).
- mypy: this file is **not** in the CI strict gate (`ci.yml:43` checks 8 core-orchestration files only); error count unchanged at the pre-existing 19 (whole file untyped), 0 new.

## Scope

Governance lane (`agents/core/governance/metrics.py`). Out of rehumanization scope — a latent bug surfaced by the capstone runs, not a regression from Epic #1258.

Closes #1273.