### PR TITLE
fix(stakes): async contract + tuple unpack — unblock Acte I enjeux (#1269)

### DIFF
--- a/argumentation_analysis/agents/core/political/stakes_extractor.py
+++ b/argumentation_analysis/agents/core/political/stakes_extractor.py
@@ -12,9 +12,22 @@ Privacy: outputs pseudonymised references (Speaker_A, Group_X), never raw text.
 
 import json
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 logger = logging.getLogger("StakesExtractor")
+
+
+async def _default_chat_completion(client: Any, **kwargs: Any) -> Any:
+    """Default async LLM call: a direct ``chat.completions.create``.
+
+    The orchestrator (``_invoke_stakes_extractor``) injects the #708
+    budget-guarded variant (``_guarded_chat_completion``) so this specialist's
+    call is counted against the per-run runaway ceiling; unit tests inject
+    fakes. Keeping the call injectable lets the specialist stay decoupled from
+    the orchestration layer (no specialist imports the orchestrator) while
+    still funnelling through the circuit-breaker in production.
+    """
+    return await client.chat.completions.create(**kwargs)
 
 EXTRACTION_PROMPT = (
     "You are a political-rhetorical analyst. Analyse the following discourse excerpt "
@@ -47,7 +60,7 @@ EXTRACTION_PROMPT = (
 class StakesExtractor:
     """Lightweight specialist for stakes & stakeholders extraction."""
 
-    def extract(
+    async def extract(
         self,
         arguments: List[Dict[str, Any]],
         source_metadata: Dict[str, str],
@@ -55,6 +68,8 @@ class StakesExtractor:
         llm_client: Optional[Any] = None,
         determinism_params: Optional[Dict[str, Any]] = None,
         deanonymized: bool = True,
+        model_id: str = "",
+        llm_call: Optional[Callable[..., Awaitable[Any]]] = None,
     ) -> Dict[str, Any]:
         """Extract stakes, stakeholders, register, and arena from discourse.
 
@@ -63,9 +78,16 @@ class StakesExtractor:
                        'description' keys).
             source_metadata: Speaker, venue, topic, era, language.
             raw_text: Full discourse text (truncated to 3000 chars for prompt).
-            llm_client: OpenAI client with .chat.completions.create(). If None,
-                        returns empty result.
+            llm_client: Async OpenAI client whose ``chat.completions.create``
+                        is awaitable. If None, returns empty result.
             determinism_params: Optional temperature/seed for reproducibility.
+            model_id: Resolved model id to send (threaded from
+                      ``_get_openai_client`` by the orchestrator). Falls back to
+                      ``determinism_params["model"]`` then ``gpt-4o-mini``.
+            llm_call: Async callable ``(client, **kwargs) -> response``. Defaults
+                      to a direct ``await client.chat.completions.create``; the
+                      orchestrator injects ``_guarded_chat_completion`` (#708
+                      runaway guard).
 
         Returns:
             Dict matching UnifiedAnalysisState.stakes_and_stakeholders schema.
@@ -118,8 +140,10 @@ class StakesExtractor:
 
         try:
             params = determinism_params or {}
-            response = llm_client.chat.completions.create(
-                model=params.get("model", "gpt-4o-mini"),
+            call_fn = llm_call or _default_chat_completion
+            response = await call_fn(
+                llm_client,
+                model=model_id or params.get("model", "gpt-4o-mini"),
                 messages=[{"role": "user", "content": prompt}],
                 temperature=params.get("temperature", 0.3),
                 **({} if "seed" not in params else {"seed": params["seed"]}),

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -7479,12 +7479,19 @@ async def _invoke_stakes_extractor(
     if not source_metadata:
         source_metadata = context.get("source_metadata", {})
 
-    # Get LLM client
+    # Get LLM client + resolved model id. _get_openai_client() returns a
+    # (client, model_id) tuple — it MUST be unpacked (canonical pattern at
+    # l.602/848/1123/...). Previously this site assigned the whole tuple to
+    # ``client`` (a tuple is always truthy), then passed that tuple as
+    # ``llm_client`` → ``.chat`` AttributeError inside extract → swallowed by
+    # its broad ``except`` → empty stakes on every real (LLM-on) run. The bug
+    # was masked because unit tests exercised only the LLM=None short-circuit.
     llm_client = None
+    model_id = ""
     determinism_params = {}
     try:
-        client = _get_openai_client()
-        if client:
+        client, model_id = _get_openai_client()
+        if client is not None:
             llm_client = client
             determinism_params = _get_determinism_params()
     except Exception:
@@ -7492,12 +7499,17 @@ async def _invoke_stakes_extractor(
 
     raw_text = getattr(state, "raw_text", "") or input_text
 
-    result = extractor.extract(
+    # extract() is now async (it awaits the LLM call on an AsyncOpenAI client);
+    # thread the resolved model_id (not a hardcoded default) and route the call
+    # through _guarded_chat_completion (#708 per-run runaway guard).
+    result = await extractor.extract(
         arguments=arguments,
         source_metadata=source_metadata,
         raw_text=raw_text,
         llm_client=llm_client,
         determinism_params=determinism_params,
+        model_id=model_id,
+        llm_call=_guarded_chat_completion,
         deanonymized=bool(getattr(state, "deanonymized", True)),
     )
 

--- a/tests/unit/argumentation_analysis/orchestration/test_mute_capabilities_b02.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_mute_capabilities_b02.py
@@ -123,7 +123,7 @@ class TestInvokeStakesExtractor:
 
     @patch(
         "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
-        return_value=None,
+        return_value=(None, ""),
     )
     def test_extracts_stakes_with_mock_state(self, mock_client):
         """Stakes extractor runs on a populated state (LLM=None, fallback path)."""
@@ -142,7 +142,7 @@ class TestInvokeStakesExtractor:
 
     @patch(
         "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
-        return_value=None,
+        return_value=(None, ""),
     )
     def test_stakes_written_to_state(self, mock_client):
         """Results are written to state.stakes_and_stakeholders."""
@@ -158,7 +158,7 @@ class TestInvokeStakesExtractor:
 
     @patch(
         "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
-        return_value=None,
+        return_value=(None, ""),
     )
     def test_dict_arguments_passed_as_list_of_dicts(self, mock_client):
         """Audit #1151 §3(b): identified_arguments is {arg_id: description}
@@ -176,7 +176,7 @@ class TestInvokeStakesExtractor:
         captured = {}
 
         class _StubExtractor:
-            def extract(self, **kwargs):
+            async def extract(self, **kwargs):
                 captured.update(kwargs)
                 return {
                     "stakes": [],

--- a/tests/unit/argumentation_analysis/test_stakes_extractor.py
+++ b/tests/unit/argumentation_analysis/test_stakes_extractor.py
@@ -10,7 +10,7 @@ Covers:
 
 import json
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from argumentation_analysis.agents.core.political.stakes_extractor import (
     StakesExtractor,
@@ -24,14 +24,20 @@ from argumentation_analysis.core.shared_state import UnifiedAnalysisState
 
 
 def _mock_llm_client(response_dict: dict) -> MagicMock:
-    """Create a mock OpenAI client returning the given dict as JSON."""
+    """Create a mock async OpenAI client returning the given dict as JSON.
+
+    ``chat.completions.create`` is an AsyncMock: ``extract`` now awaits the
+    call (it runs on an AsyncOpenAI client in production). A plain MagicMock
+    return_value is not awaitable and would mask the real call path — which is
+    exactly how the original tuple-unpack bug hid for so long.
+    """
     content = json.dumps(response_dict)
     mock_choice = MagicMock()
     mock_choice.message.content = content
     mock_response = MagicMock()
     mock_response.choices = [mock_choice]
     client = MagicMock()
-    client.chat.completions.create.return_value = mock_response
+    client.chat.completions.create = AsyncMock(return_value=mock_response)
     return client
 
 
@@ -100,10 +106,10 @@ SAMPLE_LLM_RESPONSE = {
 class TestStakesExtractor:
     """StakesExtractor with mock LLM."""
 
-    def test_extract_with_valid_llm_response(self):
+    async def test_extract_with_valid_llm_response(self):
         client = _mock_llm_client(SAMPLE_LLM_RESPONSE)
         extractor = StakesExtractor()
-        result = extractor.extract(
+        result = await extractor.extract(
             arguments=SAMPLE_ARGUMENTS,
             source_metadata=SAMPLE_METADATA,
             raw_text="Full discourse text here...",
@@ -116,9 +122,9 @@ class TestStakesExtractor:
         assert result["rhetorical_register"] == "mobilization"
         assert result["discursive_arena"] == "parliamentary debate"
 
-    def test_extract_no_llm_client_returns_empty(self):
+    async def test_extract_no_llm_client_returns_empty(self):
         extractor = StakesExtractor()
-        result = extractor.extract(
+        result = await extractor.extract(
             arguments=SAMPLE_ARGUMENTS,
             source_metadata=SAMPLE_METADATA,
             llm_client=None,
@@ -128,16 +134,16 @@ class TestStakesExtractor:
         assert result["rhetorical_register"] == ""
         assert result["discursive_arena"] == ""
 
-    def test_extract_handles_malformed_json(self):
+    async def test_extract_handles_malformed_json(self):
         mock_choice = MagicMock()
         mock_choice.message.content = "NOT JSON AT ALL"
         mock_response = MagicMock()
         mock_response.choices = [mock_choice]
         client = MagicMock()
-        client.chat.completions.create.return_value = mock_response
+        client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         extractor = StakesExtractor()
-        result = extractor.extract(
+        result = await extractor.extract(
             arguments=SAMPLE_ARGUMENTS,
             source_metadata=SAMPLE_METADATA,
             llm_client=client,
@@ -145,7 +151,7 @@ class TestStakesExtractor:
         assert result["stakes"] == []
         assert result["rhetorical_register"] == ""
 
-    def test_extract_strips_markdown_fences(self):
+    async def test_extract_strips_markdown_fences(self):
         raw_json = json.dumps(SAMPLE_LLM_RESPONSE)
         fenced = f"```json\n{raw_json}\n```"
         mock_choice = MagicMock()
@@ -153,17 +159,17 @@ class TestStakesExtractor:
         mock_response = MagicMock()
         mock_response.choices = [mock_choice]
         client = MagicMock()
-        client.chat.completions.create.return_value = mock_response
+        client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         extractor = StakesExtractor()
-        result = extractor.extract(
+        result = await extractor.extract(
             arguments=SAMPLE_ARGUMENTS,
             source_metadata=SAMPLE_METADATA,
             llm_client=client,
         )
         assert len(result["stakes"]) == 3
 
-    def test_extract_caps_at_10_entries(self):
+    async def test_extract_caps_at_10_entries(self):
         large_response = {
             "stakes": [
                 {
@@ -187,7 +193,7 @@ class TestStakesExtractor:
         }
         client = _mock_llm_client(large_response)
         extractor = StakesExtractor()
-        result = extractor.extract(
+        result = await extractor.extract(
             arguments=SAMPLE_ARGUMENTS,
             source_metadata=SAMPLE_METADATA,
             llm_client=client,
@@ -195,10 +201,10 @@ class TestStakesExtractor:
         assert len(result["stakes"]) == 10
         assert len(result["stakeholders"]) == 10
 
-    def test_prompt_contains_arguments_and_metadata(self):
+    async def test_prompt_contains_arguments_and_metadata(self):
         client = _mock_llm_client(SAMPLE_LLM_RESPONSE)
         extractor = StakesExtractor()
-        extractor.extract(
+        await extractor.extract(
             arguments=SAMPLE_ARGUMENTS,
             source_metadata=SAMPLE_METADATA,
             raw_text="Test discourse",
@@ -209,6 +215,23 @@ class TestStakesExtractor:
         assert "[0] We must increase defence spending" in prompt
         assert "Speaker_A" in prompt
         assert "parliamentary debate" in prompt
+
+    async def test_extract_threads_resolved_model_id(self):
+        """The resolved model_id is sent, not the hardcoded gpt-4o-mini default.
+
+        Regression guard for the async-contract fix: the orchestrator threads
+        the model resolved by _get_openai_client through to the call.
+        """
+        client = _mock_llm_client(SAMPLE_LLM_RESPONSE)
+        extractor = StakesExtractor()
+        await extractor.extract(
+            arguments=SAMPLE_ARGUMENTS,
+            source_metadata=SAMPLE_METADATA,
+            llm_client=client,
+            model_id="resolved-fleet-model",
+        )
+        sent_model = client.chat.completions.create.call_args[1]["model"]
+        assert sent_model == "resolved-fleet-model"
 
 
 # ---------------------------------------------------------------------------
@@ -300,3 +323,56 @@ class TestDeepSynthesisStakesBlock:
             for k in ("stakes", "stakeholders", "rhetorical_register")
         )
         assert not has_data
+
+
+# ---------------------------------------------------------------------------
+# 4. Integration: _invoke_stakes_extractor with a REAL-shaped async client
+#    (the path that the original tuple-unpack bug silently broke)
+# ---------------------------------------------------------------------------
+
+
+class TestInvokeStakesExtractorIntegration:
+    """End-to-end _invoke_stakes_extractor with a mock AsyncOpenAI client.
+
+    This is the test the original bug lacked: it exercises the FULL production
+    path — _get_openai_client() tuple unpack → extract() → awaited
+    _guarded_chat_completion(client, model=model_id) — with a real-shaped async
+    client returning a well-formed response, and asserts stakes come back
+    NON-empty. Before the fix, _invoke_stakes_extractor passed the (client,
+    model_id) TUPLE as llm_client → '.tuple' object has no attribute 'chat' →
+    swallowed by extract's broad except → empty stakes. This test fails on that
+    code and passes on the fixed code.
+    """
+
+    async def test_invoke_returns_non_empty_stakes_with_mock_client(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_stakes_extractor,
+        )
+
+        mock_client = _mock_llm_client(SAMPLE_LLM_RESPONSE)
+        state = UnifiedAnalysisState(
+            "We must increase defence spending to protect our borders."
+        )
+        # Real writer schema: {arg_id: description}.
+        state.identified_arguments = {
+            "arg_1": "We must increase defence spending to protect our borders.",
+            "arg_2": "The economic cost is too high for ordinary citizens.",
+        }
+
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(mock_client, "resolved-fleet-model"),
+        ):
+            result = await _invoke_stakes_extractor(
+                "", {"_state_object": state, "source_metadata": SAMPLE_METADATA}
+            )
+
+        # The bug returned empty stakes (tuple-as-client crash, swallowed).
+        assert len(result["stakes"]) == 3, result
+        assert result["stakes"][0]["stake_type"] == "security"
+        assert len(result["stakeholders"]) == 3
+        # Resolved model_id was threaded to the actual LLM call (not gpt-4o-mini).
+        sent_model = mock_client.chat.completions.create.call_args[1]["model"]
+        assert sent_model == "resolved-fleet-model"
+        # State was written.
+        assert len(state.stakes_and_stakeholders["stakes"]) == 3


### PR DESCRIPTION
## What

Fixe le vide des enjeux du capstone #1269 (pointé par le user comme maillon faible bloquant la barre 360°). Deux bugs compounding sur le chemin LLM-on, jusqu'ici masqués car les tests unitaires n'exerçaient que le court-circuit LLM=None.

## Bugs (ai-01 firsthand-verified)

1. **Tuple unpack manquant** — invoke_callables.py `_invoke_stakes_extractor` (l.7486). `_get_openai_client()` retourne un Tuple (client, model_id). Ce caller assignait le tuple entier à `client` (un tuple est toujours truthy), puis passait ce tuple comme `llm_client` à extract -> `.chat` AttributeError -> avalé par le `except Exception` de extract -> dict vide -> enjeux vides 3/3 corpus. Les 8 autres callers déballent correctement (l.602/848/1123/1368/1612/4700/4929/5350). Site déjà connu pour des contract bugs (audit #1151 §3(b)).

2. **Async/sync mismatch** — stakes_extractor.py `extract()`. Méthode synchrone qui appelait `llm_client.chat.completions.create()` sans `await` sur un client AsyncOpenAI. L'unpack seul ne suffisait donc pas. + modèle hardcoded `gpt-4o-mini` au lieu du model_id résolu.

## Fix

- _invoke_stakes_extractor : unpack `client, model_id = _get_openai_client()` + guard `is not None` (pas truthy-check sur tuple).
- extract devient `async def extract` + `await` via un callable injecté `llm_call` (DI). Le spécialiste reste découplé de l'orchestration (aucun import du module orchestrateur — le layering reste orchestration -> specialist à sens unique). _invoke_stakes_extractor injecte `_guarded_chat_completion` (#708 runaway guard) ; les tests injectent des fakes. Le `model_id` résolu est threadé (drop du défaut gpt-4o-mini).

## Tests (DoD ai-01 satisfait)

Le test qui manquait : `TestInvokeStakesExtractorIntegration.test_invoke_returns_non_empty_stakes_with_mock_client` exerce le **chemin client réel** (mock AsyncOpenAI -> `_get_openai_client` tuple -> `extract` -> `_guarded_chat_completion(client, model=model_id)`) et asserte `stakes` non-vides + `model_id` threadé. **Ce test FAIL sur le code cassé et PASS sur le corrigé.**

- mock client -> AsyncMock (awaitable) ; 6 tests existants convertis en async/await.
- 16/16 pass (test_stakes_extractor.py + b02 TestInvokeStakesExtractor).

Repro (env projet-is, 0 API cost) :
```
python -m pytest tests/unit/argumentation_analysis/test_stakes_extractor.py \
  tests/unit/argumentation_analysis/orchestration/test_mute_capabilities_b02.py::TestInvokeStakesExtractor -v
-> 16 passed in 69s
```

## Scope (caveat)

Débloque la dimension **enjeux** du capstone. **Ne clôture pas #1191** (axes FOL indisponible 3/3, modal 2/3, ASPIC+/ABA/SETAF absents). #1258 (réhumanisation locuteur+citation+garde export) reste défendable à clore séparément. Chantier suivant = réveil des axes FOL/modal morts.

## Note

Pas de self-merge (R450). PR pour review firsthand ai-01 (body+diff+CI+repro) puis merge --admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
