### PR TITLE
feat(restitution): Track E #1281 — de-theatralise governance (LLM origin surfaced)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -506,7 +506,9 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         only short metadata fields (privacy HARD).
         """
         if not isinstance(metadata, dict):
-            state_logger.warning("set_source_metadata ignored non-dict: %r", type(metadata))
+            state_logger.warning(
+                "set_source_metadata ignored non-dict: %r", type(metadata)
+            )
             return
         # Defensive: never accept raw_text/full_text keys (privacy HARD).
         _FORBIDDEN = {"raw_text", "full_text", "full_text_segment", "raw_text_snippet"}
@@ -630,9 +632,21 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         return df_id
 
     def add_governance_decision(
-        self, method: str, winner: str, scores: Dict[str, float]
+        self,
+        method: str,
+        winner: str,
+        scores: Dict[str, float],
+        extraction_method: Optional[str] = None,
     ) -> str:
-        """Add a governance voting decision."""
+        """Add a governance voting decision.
+
+        Track E #1281 — ``extraction_method`` carries the honest origin signal
+        (``"llm"`` | ``"heuristic"`` | ``None``) so the restitution can frame
+        the verdict correctly: an LLM-produced assessment is NOT a genuine
+        multi-agent deliberation, and must not be dressed as procedural
+        legitimacy. ``None`` preserves backward compat for callers that don't
+        supply it (the restitution then falls back to its prior framing).
+        """
         gd_id = self._generate_id("gov", self.governance_decisions)
         entry = {
             "id": gd_id,
@@ -640,6 +654,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "winner": winner,
             "scores": scores,
         }
+        if extraction_method:
+            entry["extraction_method"] = extraction_method
         self.governance_decisions.append(entry)
         state_logger.info(f"Governance decision added: {gd_id} ({method}: {winner})")
         return gd_id

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -475,10 +475,19 @@ def _write_governance_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> 
         if isinstance(resolutions, list) and resolutions:
             winner = str(resolutions[0].get("resolution_type", "N/A"))
 
+    # Track E #1281 — propagate the honest origin signal: an LLM-assessed
+    # verdict is not a genuine multi-agent deliberation, and the restitution
+    # must not dress it as procedural legitimacy. extraction_method is computed
+    # by _invoke_governance (invoke_callables.py:1746) as "llm" | "heuristic".
+    extraction_method = output.get("extraction_method")
+    if not isinstance(extraction_method, str):
+        extraction_method = None
+
     state.add_governance_decision(
         method=str(recommended),
         winner=winner,
         scores=scores,
+        extraction_method=extraction_method,
     )
 
 

--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -114,7 +114,9 @@ class FormalFinding:
     """A global formal-tenue anchor the LLM weaves as backing (verified-in-state)."""
 
     kind: str  # "pl" | "fol" | "dung"
-    verdict: str  # human-readable, e.g. "inconsistant (Tweety)", "rejet (Dung grounded)"
+    verdict: (
+        str  # human-readable, e.g. "inconsistant (Tweety)", "rejet (Dung grounded)"
+    )
     detail: str
 
 
@@ -126,11 +128,19 @@ class GovernanceVerdict:
     Copeland winner, consensus) but it was invisible in the report — the same
     debranching G6 fixed for counter-argument validity. ``scores`` maps opaque
     option IDs → Copeland/influence score (privacy: opaque keys, never party names).
+
+    Track E #1281 — ``extraction_method`` carries the honest origin signal so the
+    restitution can frame the verdict correctly. ``"llm"`` means the assessment was
+    produced by a SINGLE LLM call dressed as governance (NOT a genuine multi-agent
+    deliberation); the narrative must then present it as a model-assessed ranking,
+    not procedural legitimacy. ``None`` = origin not recorded (caller pre-#1281);
+    the prompt then falls back to its prior framing.
     """
 
     method: str
     winner: str
     scores: Dict[str, float] = field(default_factory=dict)
+    extraction_method: Optional[str] = None  # "llm" | "heuristic" | None
 
 
 @dataclass
@@ -503,7 +513,18 @@ def _collect_governance(state: Any) -> Optional[GovernanceVerdict]:
         # Trivial / placeholder winners ("N/A", empty) carry no verdict.
         if not method or not winner or winner == "N/A":
             continue
-        chosen = GovernanceVerdict(method=method, winner=winner, scores=scores)
+        # Track E #1281 — carry the honest origin signal so the prompt can frame
+        # an LLM-assessed verdict as model-assessed, not procedural legitimacy.
+        em_raw = d.get("extraction_method")
+        extraction_method = (
+            str(em_raw).strip() if isinstance(em_raw, str) and em_raw.strip() else None
+        )
+        chosen = GovernanceVerdict(
+            method=method,
+            winner=winner,
+            scores=scores,
+            extraction_method=extraction_method,
+        )
     return chosen
 
 
@@ -538,7 +559,11 @@ def _collect_debate(state: Any) -> List[DebateExchange]:
             # G8 (#1184): carry the scheme grounding (None when no scheme matched
             # — honest absence, not fabricated).
             scheme_raw = ex.get("scheme")
-            scheme = str(scheme_raw).strip() if isinstance(scheme_raw, str) and scheme_raw.strip() else None
+            scheme = (
+                str(scheme_raw).strip()
+                if isinstance(scheme_raw, str) and scheme_raw.strip()
+                else None
+            )
             cq_raw = ex.get("critical_question")
             critical_question = (
                 str(cq_raw).strip()
@@ -592,16 +617,10 @@ def _collect_formal_findings(state: Any) -> List[FormalFinding]:
         # would conflate the unverified sentinel (None) with ``inconsistent``
         # (False), an #1019 silent-degradation.
         consistent = sum(
-            1
-            for r in pl
-            if isinstance(r, dict)
-            and _pl_verdict(r) is True
+            1 for r in pl if isinstance(r, dict) and _pl_verdict(r) is True
         )
         inconsistent = sum(
-            1
-            for r in pl
-            if isinstance(r, dict)
-            and _pl_verdict(r) is False
+            1 for r in pl if isinstance(r, dict) and _pl_verdict(r) is False
         )
         if consistent or inconsistent:
             findings.append(
@@ -620,14 +639,10 @@ def _collect_formal_findings(state: Any) -> List[FormalFinding]:
     fol = getattr(state, "fol_analysis_results", None)
     if isinstance(fol, list):
         consistent = sum(
-            1
-            for r in fol
-            if isinstance(r, dict) and r.get("consistent") is True
+            1 for r in fol if isinstance(r, dict) and r.get("consistent") is True
         )
         inconsistent = sum(
-            1
-            for r in fol
-            if isinstance(r, dict) and r.get("consistent") is False
+            1 for r in fol if isinstance(r, dict) and r.get("consistent") is False
         )
         if consistent or inconsistent:
             findings.append(
@@ -718,11 +733,10 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
     blocks: List[str] = []
     for mvt in evidence.movements:
         is_soutiens = mvt.theme == _SOUTIENS_THEME
-        header = (
-            f"MOUVEMENT « {mvt.theme} » — "
-            + ("les soutiens qui tiennent (aucun sophisme localisé)"
-               if is_soutiens
-               else f"les arguments attaqués par la famille « {mvt.theme} »")
+        header = f"MOUVEMENT « {mvt.theme} » — " + (
+            "les soutiens qui tiennent (aucun sophisme localisé)"
+            if is_soutiens
+            else f"les arguments attaqués par la famille « {mvt.theme} »"
         )
         lines: List[str] = [header]
         for a in mvt.arguments:
@@ -747,9 +761,7 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
                     f"Justification : {fl.justification}"
                 )
             for ca in a.counter_args:
-                lines.append(
-                    f"      Contre-argument ({ca.strategy}) : {ca.snippet}"
-                )
+                lines.append(f"      Contre-argument ({ca.strategy}) : {ca.snippet}")
             if a.dung_rejected:
                 lines.append(
                     f"      Rejet formel : cadre de Dung isole cet argument "
@@ -770,13 +782,34 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
     # report. We surface what exists — honestly sparse when the schemes-engine
     # gap (β G8) left debate thin. Each citation must bind to a narrative beat
     # (spec §4 anti-énumération); never a bare score/label line.
+    # Track E #1281 — frame governance honestly. When extraction_method == "llm",
+    # the verdict is a SINGLE-LLM assessment dressed as a voting layer (NOT a
+    # genuine multi-agent deliberation); present it as a model-assessed ranking,
+    # never as procedural legitimacy / an independent social-choice verdict.
     deliberation_lines: List[str] = []
     gv = evidence.governance_verdict
     if gv is not None:
+        if gv.extraction_method == "llm":
+            gov_origin = (
+                "ATTENTION : ce verdict governance est une ÉVALUATION D'UN MODÈLE "
+                "(issue d'un seul appel LLM, pas d'une délibération multi-agent "
+                "réelle). Présente-le comme un classement évalué par le modèle, "
+                "PAS comme une caution de légitimité procédurale indépendante."
+            )
+            gov_lead = (
+                f"  - GOUVERNANCE (évaluation modèle) : l'analyste-LLM classe "
+                f"{gv.winner} en tête sous la méthode « {gv.method} ». "
+            )
+        else:
+            gov_origin = ""
+            gov_lead = (
+                f"  - GOUVERNANCE : sous la méthode « {gv.method} », l'option "
+                f"{gv.winner} sort gagnante du vote social-choice. "
+            )
+        if gov_origin:
+            deliberation_lines.append(gov_origin)
         deliberation_lines.append(
-            f"  - GOUVERNANCE : sous la méthode « {gv.method} », l'option "
-            f"{gv.winner} sort gagnante du vote social-choice. "
-            "(noms d'options maintenus opaques — discipline FB-34.)"
+            gov_lead + "(noms d'options maintenus opaques — discipline FB-34.)"
         )
     if evidence.debate_exchanges:
         for i, ex in enumerate(evidence.debate_exchanges, start=1):
@@ -926,8 +959,7 @@ async def build_act2_narrative(
     degraded: Dict[str, str] = {}
     if verdict.band != "PASS":
         degraded["act2_narrative_gate"] = (
-            f"Self-check §4 = {verdict.band}: "
-            + "; ".join(verdict.reasons[:3])
+            f"Self-check §4 = {verdict.band}: " + "; ".join(verdict.reasons[:3])
         )
     if not evidence.quality_axis_available:
         degraded["act2_narrative"] = (

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
@@ -29,7 +29,6 @@ from argumentation_analysis.reporting.restitution.readability_gate import (
     ReadabilityGate,
 )
 
-
 # --- state stubs -------------------------------------------------------------
 
 
@@ -227,8 +226,7 @@ class TestReaderWriterContracts:
         state = _state(
             identified_arguments={"arg_1": "Claim."},
             argument_quality_scores={
-                "arg_1": {"overall": 3.5, "scores": {"pertinence": 2.0,
-                                                      "clarte": 5.0}},
+                "arg_1": {"overall": 3.5, "scores": {"pertinence": 2.0, "clarte": 5.0}},
             },
         )
         ev = build_act2_evidence(state)
@@ -242,8 +240,7 @@ class TestReaderWriterContracts:
         state = _state(
             identified_arguments={"arg_1": "Claim."},
             argument_quality_scores={
-                "arg_1": {"overall": 3.0,
-                          "scores_par_vertu": {"coherence": 4.0}},
+                "arg_1": {"overall": 3.0, "scores_par_vertu": {"coherence": 4.0}},
             },
         )
         ev = build_act2_evidence(state)
@@ -342,12 +339,84 @@ class TestReaderWriterContracts:
         """SV fail-loud: N/A winner → None; empty exchange → [] (#1019)."""
         state = _state(
             identified_arguments={"arg_1": "Claim."},
-            governance_decisions=[{"method": "majority", "winner": "N/A", "scores": {}}],
+            governance_decisions=[
+                {"method": "majority", "winner": "N/A", "scores": {}}
+            ],
             debate_transcripts=[{"exchanges": [{"point": "", "rebuttal": ""}]}],
         )
         ev = build_act2_evidence(state)
         assert ev.governance_verdict is None
         assert ev.debate_exchanges == []
+
+    # --- Track E #1281 — de-theatralise governance (LLM origin surfaced) ---
+
+    def test_governance_carries_llm_extraction_method(self):
+        """Track E #1281 — the verdict carries the honest origin signal."""
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            governance_decisions=[
+                {
+                    "method": "copeland",
+                    "winner": "opt_X",
+                    "scores": {"opt_X": 0.9},
+                    "extraction_method": "llm",
+                }
+            ],
+        )
+        ev = build_act2_evidence(state)
+        assert ev.governance_verdict is not None
+        assert ev.governance_verdict.extraction_method == "llm"
+
+    def test_governance_extraction_method_none_preserves_legacy(self):
+        """Track E #1281 — backward compat: no extraction_method → None."""
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            governance_decisions=[
+                {"method": "copeland", "winner": "opt_X", "scores": {"opt_X": 0.9}}
+            ],
+        )
+        ev = build_act2_evidence(state)
+        assert ev.governance_verdict is not None
+        assert ev.governance_verdict.extraction_method is None
+
+    def test_prompt_reframes_llm_governance_as_model_assessment(self):
+        """Track E #1281 — when extraction_method == 'llm', the prompt frames
+        the verdict as a MODEL assessment, NOT procedural legitimacy. The old
+        'social-choice' wording must NOT appear for LLM-origin verdicts."""
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            governance_decisions=[
+                {
+                    "method": "copeland",
+                    "winner": "opt_X",
+                    "scores": {"opt_X": 0.9},
+                    "extraction_method": "llm",
+                }
+            ],
+        )
+        ev = build_act2_evidence(state)
+        prompt = build_act2_prompt(ev)
+        # Honest framing surfaced for the reader.
+        assert "évaluation d'un modèle" in prompt.lower()
+        assert "pas comme une caution de légitimité procédurale" in prompt.lower()
+        assert "évaluation modèle" in prompt.lower()
+        # The old theatrical wording must NOT survive for LLM-origin verdicts.
+        assert "vote social-choice" not in prompt.lower()
+
+    def test_prompt_keeps_social_choice_wording_when_origin_unknown(self):
+        """Track E #1281 — when extraction_method is None (legacy / non-LLM),
+        the prompt keeps its prior framing (no regression on the social-choice
+        path). Anti-pendule: we re-label the LLM path, not blanket-rewrite."""
+        state = _state(
+            identified_arguments={"arg_1": "Claim."},
+            governance_decisions=[
+                {"method": "copeland", "winner": "opt_X", "scores": {"opt_X": 0.9}}
+            ],
+        )
+        ev = build_act2_evidence(state)
+        prompt = build_act2_prompt(ev)
+        assert "social-choice" in prompt.lower()
+        assert "évaluation d'un modèle" not in prompt.lower()
 
     def test_deliberation_block_in_prompt_sv(self):
         """SV: the deliberation block reaches the Acte II conducted prompt."""
@@ -370,10 +439,18 @@ class TestReaderWriterContracts:
         state = _state(
             identified_arguments={"arg_1": "Claim."},
             identified_fallacies={
-                "fl_1": {"target_argument_id": "arg_1", "family": "ad hominem",
-                         "type": "ad hominem", "justification": "x"},
-                "fl_2": {"target_argument_id": "", "family": "fuite",
-                         "type": "fuite en avant", "justification": "y"},
+                "fl_1": {
+                    "target_argument_id": "arg_1",
+                    "family": "ad hominem",
+                    "type": "ad hominem",
+                    "justification": "x",
+                },
+                "fl_2": {
+                    "target_argument_id": "",
+                    "family": "fuite",
+                    "type": "fuite en avant",
+                    "justification": "y",
+                },
             },
         )
         ev = build_act2_evidence(state)
@@ -401,7 +478,6 @@ class TestReaderWriterContracts:
         assert ev.quality_axis_available is True
 
 
-
 class TestPrivacy:
     def test_long_description_truncated_in_prompt(self):
         long_desc = "x" * 500  # well over the _DESC_CAP
@@ -412,7 +488,9 @@ class TestPrivacy:
         assert long_desc not in prompt
         assert "[…]" in prompt
 
-    @pytest.mark.parametrize("deanonymized,expect_opaque", [(True, False), (False, True)])
+    @pytest.mark.parametrize(
+        "deanonymized,expect_opaque", [(True, False), (False, True)]
+    )
     def test_opaque_directive_gated_by_deanonymized(self, deanonymized, expect_opaque):
         # Epic #1258 / Track 1 #1259 — opaque-ID directive present only when
         # NOT deanonymized; weaving rule always present.
@@ -500,7 +578,10 @@ class TestBuildNarrative:
                 state, llm_callable=_stub_llm(_WOVEN_NARRATIVE)  # type: ignore[arg-type]
             )
         )
-        assert any("qualité" in v.lower() or "qualit" in v.lower() for v in result.degraded.values())
+        assert any(
+            "qualité" in v.lower() or "qualit" in v.lower()
+            for v in result.degraded.values()
+        )
 
 
 # ============================================================================
@@ -545,7 +626,10 @@ class TestConsumedByRenderer:
         # The woven act2 narrative is rendered into the body verbatim.
         assert _WOVEN_NARRATIVE.splitlines()[0] in report.markdown
         # act1/act3 are reported as missing (fail-loud), not silently dropped.
-        assert "indisponible" in report.markdown.lower() or "acte" in report.markdown.lower()
+        assert (
+            "indisponible" in report.markdown.lower()
+            or "acte" in report.markdown.lower()
+        )
 
 
 # ============================================================================


### PR DESCRIPTION
Epic #1276 Track E (#1281). Worker po-2023. Base main 9994f171. Commit 242bf28b.

Problem: restitution presented agent_based governance vote as procedural legitimacy, but it is a SINGLE LLM call (invoke_callables.py:1708) dressed as a voting layer. Signal existed internally (extraction_method:llm l.1746) but never propagated to state.

Fix (anti-pendule = reframe voie b; no fake deliberation):
- shared_state.add_governance_decision: optional extraction_method param (llm|heuristic|None), backward-compat.
- state_writers._write_governance_to_state: passes extraction_method through.
- act2 GovernanceVerdict.extraction_method + _collect_governance: carry signal.
- act2 prompt: extraction_method==llm reframes as MODEL assessment (not procedural legitimacy); legacy None keeps prior framing (no regression).

Scope: governance+state+restitution only. Disjoint from Track D #1283. No touch FOL/modal/Dung.

Validation: 40 passed (+4 Track E tests), mypy strict 0 issues, black green. Tests assert old 'vote social-choice' wording gone for LLM path, kept for None.

DoD: restitution no longer presents synthetic vote as independent legitimacy; LLM origin explicit; black/mypy green. Next: #1275.

Co-Authored-By: Claude-Code <noreply@anthropic.com>