### PR TITLE
fix(fallacy): #1275 wide-net self-hosted 404 fails loud + drop rot-prone model id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,12 @@ OPENAI_CHAT_MODEL_ID="gpt-5-mini"
 # Models may change over time; query /v1/models to discover current models.
 SELF_HOSTED_LLM_ENDPOINT="https://api.medium.text-generation-webui.myia.io/v1"
 SELF_HOSTED_LLM_API_KEY="your-key-here"
-SELF_HOSTED_LLM_MODEL="qwen3.5-35b-a3b"
+# Leave SELF_HOSTED_LLM_MODEL unset unless you actually run the endpoint above.
+# When unset, the self-hosted wide-net tier reports degraded (#1275) and the
+# main fallacy wide-net uses the central OPENROUTER/OPENAI model instead — no
+# rot-prone placeholder id shipped here. If you run the endpoint, set this to a
+# model IT serves (verify via GET {ENDPOINT}/models); a wrong id silently 404s.
+# SELF_HOSTED_LLM_MODEL="a-model-your-endpoint-actually-serves"
 SELF_HOSTED_LLM_MINI_ENDPOINT="https://api.mini.text-generation-webui.myia.io/v1"
 SELF_HOSTED_LLM_MINI_API_KEY="your-key-here"
 SELF_HOSTED_LLM_MINI_MODEL="omnicoder-9b"

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -2384,6 +2384,10 @@ async def _invoke_camembert_fallacy(
             "arguments": {},
             "tiers_used": ["none"],
             "status": "unavailable",
+            # Same degraded signal as the runtime-failure branch below (#1275):
+            # both "not configured" and "failed at runtime" are honest zeros.
+            "degraded": True,
+            "degradation_reason": ("Self-hosted LLM endpoint/model not configured"),
             "explanation": "Self-hosted LLM endpoint not configured",
             "total_fallacies": 0,
         }
@@ -2462,11 +2466,28 @@ async def _invoke_camembert_fallacy(
         return _ret
 
     except Exception as e:
-        logger.warning("Self-hosted LLM fallacy detection failed: %s", e)
+        logger.warning(
+            "Self-hosted LLM fallacy detection failed (model=%s, endpoint=%s): %s",
+            model_id,
+            endpoint,
+            e,
+        )
         return {
             "detected_fallacies": {},
             "arguments": {},
             "tiers_used": ["none"],
+            # Anti-théâtre #1019 (#1275): a runtime failure — e.g. the configured
+            # SELF_HOSTED_LLM_MODEL does not exist on the endpoint (404) — must
+            # NOT read downstream as "ran and found 0 fallacies". Surface a
+            # degraded status + reason, consistent with the not-configured
+            # branch above, so the empty result is honestly attributed instead
+            # of silently passing as a clean zero.
+            "status": "unavailable",
+            "degraded": True,
+            "degradation_reason": (
+                f"self-hosted LLM call failed (model={model_id!r}, "
+                f"endpoint={endpoint!r}): {e}"
+            ),
             "explanation": f"Self-hosted LLM unavailable: {e}",
             "total_fallacies": 0,
             "error": str(e),

--- a/tests/unit/argumentation_analysis/orchestration/test_camembert_invoke.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_camembert_invoke.py
@@ -131,6 +131,67 @@ class TestInvokeCamemBERTFallacy:
 
         assert result["tiers_used"] == ["none"]
 
+    async def test_invoke_camembert_runtime_failure_is_degraded(self):
+        """Anti-théâtre #1019 (#1275): a runtime failure (e.g. the configured
+        SELF_HOSTED_LLM_MODEL 404s on the endpoint) must surface as degraded,
+        NOT silently read as "ran and found 0 fallacies".
+
+        Endpoint+model are configured (so the not-configured gate passes), but
+        the plugin call raises — simulating the 404 observed in capstone #1269.
+        """
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_camembert_fallacy,
+        )
+
+        # Plugin call raises (model 404 / endpoint error surfaces here)
+        mock_plugin = MagicMock()
+        mock_plugin.run_guided_analysis = AsyncMock(
+            side_effect=RuntimeError("404 - model does not exist on endpoint")
+        )
+
+        env = {
+            "SELF_HOSTED_LLM_ENDPOINT": "http://localhost:5000/v1",
+            "SELF_HOSTED_LLM_MODEL": "qwen3.5-35b-a3b",
+        }
+
+        with patch.dict("os.environ", env, clear=True), patch(
+            "argumentation_analysis.orchestration.invoke_callables.FallacyWorkflowPlugin",
+            create=True,
+        ), patch("openai.AsyncOpenAI"), patch("semantic_kernel.kernel.Kernel"), patch(
+            "semantic_kernel.connectors.ai.open_ai.OpenAIChatCompletion"
+        ):
+            with patch.dict(
+                "sys.modules",
+                {
+                    "openai": MagicMock(AsyncOpenAI=MagicMock()),
+                    "semantic_kernel.kernel": MagicMock(Kernel=MagicMock()),
+                    "semantic_kernel.connectors.ai.open_ai": MagicMock(
+                        OpenAIChatCompletion=MagicMock()
+                    ),
+                    "argumentation_analysis.plugins.fallacy_workflow_plugin": MagicMock(
+                        FallacyWorkflowPlugin=MagicMock(return_value=mock_plugin)
+                    ),
+                },
+            ):
+                result = await _invoke_camembert_fallacy(
+                    "Argument ad hominem classique.", {}
+                )
+
+        # Honest zero: the run did NOT succeed, it degraded.
+        assert result["total_fallacies"] == 0
+        assert result["tiers_used"] == ["none"]
+        assert result["detected_fallacies"] == {}
+        # Anti-théâtre signal: downstream MUST be able to tell this apart from
+        # a successful run that genuinely found 0 fallacies.
+        assert result["status"] == "unavailable"
+        assert result["degraded"] is True
+        reason = result["degradation_reason"]
+        assert isinstance(reason, str) and reason
+        # Reason must attribute the failure to the configured model/endpoint
+        # (not a generic "failed") so the operator can fix the config.
+        assert "qwen3.5-35b-a3b" in reason
+        assert "localhost:5000" in reason
+
 
 class TestCamemBERTRegistryRegistration:
     """Tests for neural_fallacy_detection registration in setup_registry."""


### PR DESCRIPTION
## What

`#1275` (Epic #1276, lane po-2023 per coord R477 dispatch). The fallacy **wide-net Phase 1** self-hosted path silently degraded on a non-existent model id — anti-théâtre #1019.

## Root cause (firsthand)

`_invoke_camembert_fallacy` (`invoke_callables.py`) reads `SELF_HOSTED_LLM_MODEL` (default `""`). `.env.example` shipped a rot-prone `qwen3.5-35b-a3b` that 404s on the endpoint. The not-configured gate (`if not endpoint or not model_id`) **passed** (model truthy), the API 404'd, and the broad `except Exception` returned `{tiers_used:["none"], error}` **without** `status`/`degraded` → downstream read it as "ran and found 0 fallacies". Fired on all 3 capstone corpora.

Confirmed the 404 site is the self-hosted wide-net callable (`_invoke_camembert_fallacy`, wired at `registry_setup.py:242`, runs `plugin.run_guided_analysis` with one-shot fallback) — NOT the main wide-net (`_invoke_hierarchical_fallacy` resolves its model centrally via `create_llm_service`, doesn't touch `SELF_HOSTED_LLM_MODEL`). `qwen3.5-35b-a3b` exists only in `.env.example`.

## Fix (anti-pendule: surface honestly, no fallback chain)

| File | Change |
|------|--------|
| `invoke_callables.py` | Both degraded branches (not-configured **and** runtime-fail) now return `status="unavailable"`, `degraded=True`, `degradation_reason` naming the configured `model`+`endpoint`. A 404 is no longer indistinguishable from a genuine zero. Logging also carries model+endpoint. |
| `.env.example` | Drop the rot-prone `qwen3.5-35b-a3b` placeholder; leave `SELF_HOSTED_LLM_MODEL` commented out with guidance. When unset, the self-hosted tier reports degraded and the main wide-net uses the central `OPENROUTER`/`OPENAI` model — **no second rot-prone id** (per issue anti-pendule note). |
| `test_camembert_invoke.py` | New `test_invoke_camembert_runtime_failure_is_degraded`: exercises the 404 path (plugin raises) and asserts `status`/`degraded`/`degradation_reason` (with model+endpoint in the reason). The existing import-failure test only asserted `detected_fallacies=={}` — which passed even when the branch was silent; this locks the anti-théâtre signal. |

## DoD (#1275)

- [x] No reference to a non-existent model id remains; wide-net uses a valid/available model (or honestly degrades).
- [x] Smoke check: wide-net honestly logs degraded with reason (`status`/`degraded`/`degradation_reason`).
- [x] `black --check` green. (`flake8` absent from env `projet-is` — continue-on-error per CLAUDE.md; mypy strict = only blocking gate.)

## Validation

- **9 passed** `test_camembert_invoke.py` (incl. the new test). **28 passed** adjacent sweep (`test_camembert_workflow_wiring.py` + `test_self_hosted_llm_fallacy_detector.py`).
- **mypy strict** on `invoke_callables.py`: `Success: no issues found` (exit 0).

## Scope / collision

Self-hosted wide-net callable + `.env` template only. **0 collision** with Tracks B/C (FOL/modal, po-2025) — disjoint functions. No deletion (cleanup gate N/A).

## Privacy

Technical config only — no corpus content, opaque ids (`arg_N`-style unaffected).

— po-2023 (GLM-5.2/z.ai) · Epic #1276 lane po-2023