### PR TITLE
fix(logic): #1278 NL→FOL vivant-ou-fail-loud (kill template théâtre, gate empty KB)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -877,8 +877,17 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         inferences: List[str],
         confidence: float = 0.0,
         arg_id: Optional[str] = None,
+        message: Optional[str] = None,
     ) -> str:
-        """Add a first-order logic analysis result."""
+        """Add a first-order logic analysis result.
+
+        #1278 (Track B): ``message`` is an optional provenance field (mirrors the
+        PL sibling's ``message``). It carries the honest status — e.g.
+        ``unavailable:no-translation`` / ``unavailable:parse-fail`` — so downstream
+        consumers (restitution, measurement matrix) can confirm the entry is a
+        real solver decision OR an explicit degradation, never a silent
+        "trivially consistent sur vide" (#1019).
+        """
         fol_id = self._generate_id("fol", self.fol_analysis_results)
         entry = {
             "id": fol_id,
@@ -889,6 +898,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         }
         if arg_id:
             entry["arg_id"] = arg_id
+        if message:
+            entry["message"] = message
         self.fol_analysis_results.append(entry)
         state_logger.info(f"FOL analysis added: {fol_id} (consistent={consistent})")
         return fol_id

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -5540,25 +5540,16 @@ async def _invoke_fol_reasoning(
                 except Exception as e:
                     logger.debug(f"NL-to-logic FOL translation unavailable: {e}")
 
-        if not formulas:
-            # Final fallback: template-based FOL predicates
-            formulas = []
-            fol_metrics["template"] = len(args)
-            for i in range(len(args)):
-                formulas.append(f"Asserted(arg{i+1})")
-            fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
-            fallacies = (
-                fallacy_output.get("fallacies", [])
-                if isinstance(fallacy_output, dict)
-                else []
-            )
-            for j, f in enumerate(fallacies):
-                if isinstance(f, dict):
-                    target_idx = min(j, len(args) - 1) if args else 0
-                    formulas.append(f"Undermines(fallacy{j+1}, arg{target_idx+1})")
-                    formulas.append(f"Fallacious(arg{target_idx+1})")
-            if fallacies:
-                formulas.append("forall X: (Fallacious(X) -> !FullySupported(X))")
+        # Track B #1278 (anti-théâtre #1019): the template fabrication fallback
+        # that lived here (Asserted(argN), Undermines(fallacyN, argM),
+        # Fallacious(argM), ``forall X: Fallacious(X)->!FullySupported(X)``) is
+        # REMOVED. Those predicates are not translated from the source — they
+        # are fabricated to make the FOL axis "look alive". Downstream they
+        # produced a "consistent" verdict on meaningless formulas (or, when no
+        # arguments were extracted, an empty belief set that
+        # fol_handler.check_consistency reports as "trivially consistent sur
+        # vide"), masking NL→FOL starvation as a confident result. The honest
+        # fail-loud early-return below now handles the no-translation case.
 
     if not isinstance(formulas, list):
         formulas = [str(formulas)]
@@ -5574,6 +5565,41 @@ async def _invoke_fol_reasoning(
             inferences.append(
                 f"Argument undermined by {f.get('type', f.get('fallacy_type', 'unknown'))} fallacy"
             )
+
+    # Track B #1278: gate fol_handler.py:830 from the caller. When NO real FOL
+    # formula was translated from the source arguments, do NOT hand an empty
+    # belief set to the prover — check_consistency treats the empty theory as
+    # "trivially consistent" (mathematically sound; see
+    # test_empty_belief_set_still_consistent), which downstream reads as a
+    # confident "FOL consistent" verdict on a corpus the pipeline failed to
+    # formalize. Fail loud: mark the axis unavailable with the honest reason.
+    # (#1019; coordinator R479: gate the empty case — do not fabricate FOL nor
+    # over-engineer the NL→FOL prompt.)
+    if not formulas:
+        logger.warning(
+            "FOL reasoning: no formulas translated from %d argument(s) — "
+            "marking axis unavailable:no-translation (not 'trivially "
+            "consistent sur vide', #1278/#1019).",
+            len(args),
+        )
+        return {
+            "formulas": [],
+            "fol_signature": [],
+            "fol_metadata": {},
+            "consistent": None,
+            "inferences": inferences,
+            "confidence": 0.0,
+            "message": (
+                "unavailable:no-translation — NL→FOL produced no valid "
+                "formulas from the source arguments; the belief set is empty "
+                "and is NOT reported as 'trivially consistent' (#1278/#1019)."
+            ),
+            "fol_status": "unavailable:no-translation",
+            "logic_type": "first_order",
+            "argument_count": len(args),
+            "fol_metrics": fol_metrics,
+            **({"strategic_objective_ids": _strat_ids_fol} if _strat_ids_fol else {}),
+        }
 
     # Bind bridge outside the try so the except isolation loop can reference it
     # even if TweetyBridge import/construction itself raises (#697 Track HH).
@@ -5660,6 +5686,12 @@ async def _invoke_fol_reasoning(
                 else (0.0 if is_consistent is None else 0.4)
             ),
             "message": msg,
+            # Track B #1278: real formulas reached the prover. "decided" only
+            # when the prover returned a definite True/False; None stays
+            # "unverified" (degraded), never fabricated (#1019).
+            "fol_status": (
+                "decided" if is_consistent in (True, False) else "unverified"
+            ),
             "logic_type": "first_order",
             "argument_count": len(args),
             "fol_metrics": fol_metrics,
@@ -5738,6 +5770,11 @@ async def _invoke_fol_reasoning(
                     else (0.0 if iso_consistent is None else 0.4)
                 ),
                 "message": iso_msg,
+                # Track B #1278: real formulas survived per-formula isolation;
+                # "decided" only on a definite prover verdict (#1019).
+                "fol_status": (
+                    "decided" if iso_consistent in (True, False) else "unverified"
+                ),
                 "logic_type": "first_order",
                 "argument_count": len(args),
                 "isolation_retry": True,
@@ -5772,9 +5809,15 @@ async def _invoke_fol_reasoning(
             "consistent": None,
             "inferences": inferences,
             "confidence": 0.0,
+            "message": (
+                "unavailable:parse-fail — NL→FOL produced formulas but none "
+                "parsed into a verifiable belief set; no consistency verdict "
+                "(#1278/#1019)."
+            ),
             "logic_type": "first_order",
             "argument_count": len(args),
             "solver": "none",
+            "fol_status": "unavailable:parse-fail",
             "diagnostic": str(tweety_err),
             "fol_metrics": fol_metrics,
             **({"strategic_objective_ids": _strat_ids_fol} if _strat_ids_fol else {}),

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -843,11 +843,24 @@ def _write_fol_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
         confidence = 0.0
     # Preserve None (unverified) vs True (consistent) vs False (inconsistent).
     # bool(None) == False would silently conflate "unknown" with "inconsistent" (#1019).
+    fol_status = output.get("fol_status")
+    raw_msg = output.get("message")
+    # Track B #1278: surface the honest status token when the FOL axis is
+    # unavailable (no-translation / parse-fail), so the restitution can mark
+    # it honestly instead of silence or a fabricated "consistent" finding
+    # (#1019). Decided/unverified keep the prover's own message.
+    if isinstance(fol_status, str) and fol_status.startswith("unavailable:"):
+        status_message: Optional[str] = fol_status
+    elif isinstance(raw_msg, str):
+        status_message = raw_msg
+    else:
+        status_message = None
     state.add_fol_analysis_result(
         formulas,
         consistent if consistent is not None else None,
         inferences,
         float(confidence),
+        message=status_message,
     )
     # Store FOL signature metadata (#348)
     fol_signature = output.get("fol_signature", [])

--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -794,6 +794,37 @@ def _collect_formal_findings(state: Any) -> List[FormalFinding]:
                     detail="solveur Tweety (logique du premier ordre)",
                 )
             )
+        else:
+            # Track B #1278: no decided FOL verdict — surface the honest
+            # unavailability instead of silence. An entry with consistent=None
+            # and message "unavailable:<raison>" means the pipeline tried but
+            # could not formalize the source (no translation / parse-fail).
+            # The reader must see that the axis is honestly absent, never a
+            # "trivially consistent sur vide" fabrication (#1019).
+            unavailable = [
+                r
+                for r in fol
+                if isinstance(r, dict)
+                and r.get("consistent") is None
+                and isinstance(r.get("message"), str)
+                and str(r.get("message")).startswith("unavailable:")
+            ]
+            if unavailable:
+                findings.append(
+                    FormalFinding(
+                        kind="fol",
+                        verdict=(
+                            "FOL indisponible : aucune théorie du premier ordre "
+                            "n'a pu être formalisée puis validée sur ce corpus"
+                        ),
+                        detail=(
+                            "logique du premier ordre — la traduction NL→FOL n'a "
+                            "produit aucune formule analysable (belief set vide ou "
+                            "non parsable) ; axe honnêtement absent, non « consistant "
+                            "sur vide » (#1278/#1019)"
+                        ),
+                    )
+                )
 
     dung_trace = _collect_dung_trace(state)
     if dung_trace.available and dung_trace.rejected_args:

--- a/tests/unit/argumentation_analysis/orchestration/test_nl_to_logic_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_nl_to_logic_wiring.py
@@ -1,6 +1,9 @@
 """Tests for NL-to-logic wiring in PL and FOL pipeline phases (#208-H).
 
-Verifies the 3-tier fallback: upstream translations → on-the-fly translator → templates.
+FOL contract (Track B #1278): upstream translations → on-the-fly translator →
+FAIL LOUD (``unavailable:no-translation``). The template fabrication fallback
+(Asserted(argN)) was removed — it masked NL→FOL starvation as a confident
+"consistent" verdict (#1019).
 """
 
 import pytest
@@ -234,21 +237,32 @@ class TestFOLReasoningNLWiring:
         assert "Human(socrates)" in result["formulas"]
         assert "Mortal(socrates)" in result["formulas"]
 
-    async def test_fol_falls_back_to_templates(self):
-        """FOL phase generates Asserted(argN) templates when no translations available."""
+    async def test_fol_unavailable_when_no_translation(self):
+        """Track B #1278: no FOL translation → axis is unavailable:no-translation.
+
+        Never 'trivially consistent sur vide', never fabricated Asserted(argN)
+        templates (#1019). The NL translator is forced unavailable so the path
+        is deterministic regardless of API-key presence.
+        """
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_fol_reasoning,
         )
 
         context = _make_context_with_args(["Arg one", "Arg two"])
-        result = await _invoke_fol_reasoning("text", context)
+        with patch.dict(
+            "sys.modules", {"argumentation_analysis.services.nl_to_logic": None}
+        ):
+            result = await _invoke_fol_reasoning("text", context)
 
         assert result["logic_type"] == "first_order"
-        assert "Asserted(arg1)" in result["formulas"]
-        assert "Asserted(arg2)" in result["formulas"]
+        assert result["formulas"] == []
+        assert result["consistent"] is None
+        assert result["fol_status"] == "unavailable:no-translation"
+        assert "Asserted(arg1)" not in result.get("formulas", [])
 
     async def test_fol_ignores_propositional_translations(self):
-        """FOL phase only uses translations with logic_type='fol'."""
+        """FOL phase only uses translations with logic_type='fol'; a purely
+        propositional translation yields no FOL formula → unavailable (#1278)."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_fol_reasoning,
         )
@@ -268,12 +282,17 @@ class TestFOLReasoningNLWiring:
                 }
             },
         )
-
-        result = await _invoke_fol_reasoning("text", context)
-        assert "Asserted(arg1)" in result["formulas"]
+        with patch.dict(
+            "sys.modules", {"argumentation_analysis.services.nl_to_logic": None}
+        ):
+            result = await _invoke_fol_reasoning("text", context)
+        assert result["fol_status"] == "unavailable:no-translation"
+        assert result["formulas"] == []
+        assert "Asserted(arg1)" not in result.get("formulas", [])
 
     async def test_fol_nl_translator_import_failure(self):
-        """FOL phase gracefully falls back when NLToLogicTranslator import fails."""
+        """FOL phase fails loud when NLToLogicTranslator import fails — axis
+        marked unavailable:no-translation, not fabricated templates (#1278)."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_fol_reasoning,
         )
@@ -286,4 +305,6 @@ class TestFOLReasoningNLWiring:
             result = await _invoke_fol_reasoning("text", context)
 
         assert result["logic_type"] == "first_order"
-        assert "Asserted(arg1)" in result["formulas"]
+        assert result["fol_status"] == "unavailable:no-translation"
+        assert result["consistent"] is None
+        assert "Asserted(arg1)" not in result.get("formulas", [])

--- a/tests/unit/argumentation_analysis/orchestration/test_track_b_fol_fail_loud_1278.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_track_b_fol_fail_loud_1278.py
@@ -1,0 +1,247 @@
+"""Track B #1278 — NL→FOL vivant-ou-fail-loud contract tests.
+
+Pins the two acceptable outcomes (issue #1278 DoD, coordinator R479):
+
+  1. ``decided``     — a real formula reaches the prover, which returns a
+                       definite verdict (True/False).
+  2. ``unavailable`` — no real formula could be translated from the source →
+                       fail loud with a reason (``no-translation`` / ``parse-
+                       fail``), NEVER 'trivially consistent sur vide' nor
+                       fabricated ``Asserted(argN)`` templates (#1019).
+
+Covers every ``_invoke_fol_reasoning`` return path, the ``_write_fol_to_state``
+message passthrough, and the act2 honest 'FOL indisponible' surfacing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+TWEETY_BRIDGE_PATH = (
+    "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge"
+)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _ctx_with_fol_formula(formula: str) -> dict:
+    """Context carrying one upstream FOL formula (logic_type-agnostic injection
+    via context['formulas'], unioned into the belief set)."""
+    return {
+        "phase_extract_output": {"arguments": [{"text": "some argument"}]},
+        "formulas": [formula],
+        "_state_object": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# DoD #1 — decided: real formula + prover verdict
+# ---------------------------------------------------------------------------
+
+
+class TestFolDecidedOnRealFormulas:
+    """A real FOL formula reaches the prover → fol_status='decided'."""
+
+    def test_decided_consistent(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fol_reasoning,
+        )
+
+        context = _ctx_with_fol_formula("forall X: (Human(X) => Mortal(X))")
+        mock_bridge = MagicMock()
+        mock_bridge.check_consistency.return_value = (
+            True,
+            "FOL consistency check: consistent.",
+        )
+        with patch(TWEETY_BRIDGE_PATH, return_value=mock_bridge):
+            result = _run(_invoke_fol_reasoning("text", context))
+
+        assert result["fol_status"] == "decided"
+        assert result["consistent"] is True
+        assert any("Human" in f for f in result["formulas"])
+        # No fabricated template predicate leaked in.
+        assert not any(f.startswith("Asserted(arg") for f in result["formulas"])
+
+    def test_decided_inconsistent(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fol_reasoning,
+        )
+
+        context = _ctx_with_fol_formula("forall X: (P(X) && !P(X))")
+        mock_bridge = MagicMock()
+        mock_bridge.check_consistency.return_value = (
+            False,
+            "FOL consistency check: inconsistent.",
+        )
+        with patch(TWEETY_BRIDGE_PATH, return_value=mock_bridge):
+            result = _run(_invoke_fol_reasoning("text", context))
+
+        assert result["fol_status"] == "decided"
+        assert result["consistent"] is False
+
+
+# ---------------------------------------------------------------------------
+# DoD #2 — unavailable:no-translation
+# ---------------------------------------------------------------------------
+
+
+class TestFolUnavailableNoTranslation:
+    """No formula translated → unavailable:no-translation (not 'trivially
+    consistent sur vide', not fabricated templates)."""
+
+    def test_no_formulas_marks_unavailable(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fol_reasoning,
+        )
+
+        context = {
+            "phase_extract_output": {"arguments": [{"text": "an argument"}]},
+            "_state_object": None,
+        }
+        # Force the no-translation path deterministically (no LLM, no on-the-fly
+        # NL translator) regardless of API-key presence.
+        with patch.dict(
+            "sys.modules", {"argumentation_analysis.services.nl_to_logic": None}
+        ):
+            result = _run(_invoke_fol_reasoning("text", context))
+
+        assert result["fol_status"] == "unavailable:no-translation"
+        assert result["consistent"] is None
+        assert result["formulas"] == []
+        assert result["confidence"] == 0.0
+        assert not any(f.startswith("Asserted(arg") for f in result.get("formulas", []))
+
+
+# ---------------------------------------------------------------------------
+# DoD #2 (variant) — unavailable:parse-fail
+# ---------------------------------------------------------------------------
+
+
+class TestFolUnavailableParseFail:
+    """Formulas were produced but none parse into a verifiable belief set."""
+
+    def test_all_formulas_rejected_by_solver(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fol_reasoning,
+        )
+
+        context = _ctx_with_fol_formula("garbage ((( not a formula")
+        mock_bridge = MagicMock()
+        # The combined check AND every per-formula isolation check reject.
+        mock_bridge.check_consistency.side_effect = Exception("Tweety parse error")
+        with patch(TWEETY_BRIDGE_PATH, return_value=mock_bridge):
+            result = _run(_invoke_fol_reasoning("text", context))
+
+        assert result["fol_status"] == "unavailable:parse-fail"
+        assert result["consistent"] is None
+        assert result["confidence"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# State writer — unavailable token surfaces on the entry
+# ---------------------------------------------------------------------------
+
+
+class TestStateWriterSurfacesUnavailable:
+    """_write_fol_to_state carries the honest status as ``message`` (#1278)."""
+
+    def test_unavailable_message_passed_to_state(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_fol_to_state,
+        )
+
+        state = MagicMock()
+        output = {
+            "formulas": [],
+            "consistent": None,
+            "fol_status": "unavailable:no-translation",
+            "inferences": [],
+            "confidence": 0.0,
+        }
+        _write_fol_to_state(output, state, {})
+
+        assert state.add_fol_analysis_result.called
+        call = state.add_fol_analysis_result.call_args
+        # consistent preserved as None (not coerced to False, #1019).
+        assert call[0][1] is None
+        # message kwarg carries the unavailable token.
+        assert call.kwargs.get("message") == "unavailable:no-translation"
+
+    def test_decided_keeps_solver_message(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_fol_to_state,
+        )
+
+        state = MagicMock()
+        output = {
+            "formulas": ["forall X: (Human(X) => Mortal(X))"],
+            "consistent": True,
+            "fol_status": "decided",
+            "message": "FOL consistency check: consistent.",
+            "inferences": [],
+            "confidence": 0.8,
+        }
+        _write_fol_to_state(output, state, {})
+
+        call = state.add_fol_analysis_result.call_args
+        assert call[0][1] is True
+        assert call.kwargs.get("message") == "FOL consistency check: consistent."
+
+
+# ---------------------------------------------------------------------------
+# act2 — honest 'FOL indisponible' surfacing
+# ---------------------------------------------------------------------------
+
+
+def _findings_state(fol_results):
+    return SimpleNamespace(
+        propositional_analysis_results=[],
+        fol_analysis_results=fol_results,
+        dung_frameworks={},
+    )
+
+
+class TestAct2FolIndisponibleSurfacing:
+    """When FOL is unavailable, the restitution surfaces it honestly instead of
+    silence (DoD #2: 'marquer l'axe FOL unavailable: <raison>')."""
+
+    def test_unavailable_fol_surfaces_indisponible(self):
+        from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+            _collect_formal_findings,
+        )
+
+        state = _findings_state(
+            [{"consistent": None, "message": "unavailable:no-translation"}]
+        )
+        findings = _collect_formal_findings(state)
+        fol_findings = [f for f in findings if f.kind == "fol"]
+        assert len(fol_findings) == 1
+        assert "indisponible" in fol_findings[0].verdict.lower()
+
+    def test_decided_fol_not_marked_indisponible(self):
+        from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+            _collect_formal_findings,
+        )
+
+        state = _findings_state([{"consistent": True}])
+        findings = _collect_formal_findings(state)
+        fol_findings = [f for f in findings if f.kind == "fol"]
+        assert len(fol_findings) == 1
+        assert "indisponible" not in fol_findings[0].verdict.lower()
+        # French restitution wording for a consistent FOL theory.
+        assert "consistante" in fol_findings[0].verdict.lower()
+
+    def test_no_fol_results_no_indisponible_finding(self):
+        from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+            _collect_formal_findings,
+        )
+
+        state = _findings_state([])
+        findings = _collect_formal_findings(state)
+        assert not any(f.kind == "fol" for f in findings)


### PR DESCRIPTION
**Epic** : #1276 (Track B) · **Issue** : #1278 · **Worker** : po-2025 · **Base** : main \`092a5450\` · pas de self-merge (R450), à la review firsthand du coordinateur.

## Contexte
FOL « indisponible 3/3 » sur le capstone. Les provers (EProver/Prover9/Mace4) **décident déjà** sur les fixtures `test_external_provers_wired.py` — le goulot n'est pas le solveur, c'est ce qui le nourrit : un belief set **vide ou fabriqué**.

## Root cause (firsthand)
Quand la traduction NL→FOL ne produit rien, `_invoke_fol_reasoning` retombait sur une **fabrication de templates** — `Asserted(argN)`, `Undermines(fallacyN, argM)`, `Fallacious(...)` — des prédicats non traduits depuis la source, fabriqués pour faire « vivant » l'axe FOL. Et quand aucun argument n'était extrait, le belief set vide faisait que `fol_handler.py:830` retournait « trivially consistent sur vide », masquant la starvation en verdict « consistent » confiant (#1019).

## Fix (anti-pendule = soustraction + fail-loud, pas sur-ingénierie du prompt — coord R479)
- **SUPPRESSION** du fallback template entièrement.
- **GATE** `fol_handler.py:830` côté caller : quand aucune formule réelle n'est traduite, retour anticipé `consistent=None` + `fol_status="unavailable:no-translation"` (jamais de belief set vide au prover).
- **`fol_status`** (`decided` | `unavailable:no-translation` | `unavailable:parse-fail` | `unverified`) ajouté à chaque chemin de retour de `_invoke_fol_reasoning`.
- **Surfacing** : `add_fol_analysis_result` gagne un `message` optionnel (miroir du sibling PL), `_write_fol_to_state` le propage, et act2 surface un finding honnête « FOL indisponible » au lieu du silence quand l'axe est indisponible.

L'oracle `fol_handler` reste mathématiquement correct (théorie vide = consistant — `test_empty_belief_set_still_consistent` passe toujours) ; le gate vit à la frontière du caller qui connaît le contexte de traduction.

## DoD #1278
- [x] Chemin `decided` prouvé sur une formule réelle (verdict prover mocké firsthand).
- [x] Chemin indisponible fail-loud avec raison ; **jamais** « consistent sur vide ».
- [x] Test reproduisant les deux cas (+ parse-fail).

## Tests
- `test_nl_to_logic_wiring` : les 3 tests FOL « falls back to templates » réécrits vers le contrat fail-loud (formules vides + `unavailable:no-translation`).
- Nouveau `test_track_b_fol_fail_loud_1278` : chemins decided / no-translation / parse-fail + passage du message par le state-writer + surfacing act2 indisponible (decided→non-indisponible, zéro résultat→zéro finding).

## Validation
- `black` vert (6 fichiers) ; `mypy` strict 0 issues (4 fichiers source).
- act2 **43/43** ; Track B + FOL wiring verts.
- 6 échecs non-liés (2 PL env-JVM, 2 Dung fail-loud stub test-debt, 2 assertions exact-key metrics périmées) **vérifiés pré-existants sur clean main** (git stash).

## Scope / collision
`invoke_callables.py` (FOL uniquement — `#1285` a touché la fonction camembert adjacente, base rebased sur `092a5450`, 0 conflit) + `shared_state.py`/`state_writers.py`/`act2_narrative_plugin.py` (couche FOL/state/restitution). 0 collision Track C #1279 (modal, fichier disjoint côté handlers). Ne ferme **pas** #1191 (modal = Track C).

🤖 Worker po-2025 — Track B livrée, prêt pour Track C #1279.

Co-Authored-By: Claude-Code <noreply@anthropic.com>