### PR TITLE
feat(logic): #1279 modal routed to vendored SPASS (fail-loud, no OOM->degraded)

### DIFF
--- a/argumentation_analysis/core/config.py
+++ b/argumentation_analysis/core/config.py
@@ -50,15 +50,28 @@ class ArgAnalysisSettings(BaseSettings):
     # Le choix du solveur pour la logique modale.
     # 'tweety' (défaut) utilise SimpleMlReasoner (pure-Java) — query-based
     #   consistency DÉCIDE réellement, aucun binaire externe requis (#1205,
-    #   firsthand-vérifié). C'est le défaut honnête.
-    # 'spass' utilise SPASSMlReasoner (binaire externe) — disponible mais exige
-    #   un build CLI exécutable de SPASS ; le binaire vendoré actuel est un build
-    #   GUI/élévation (CreateProcess err740), donc SPASS reste fail-loud None
-    #   tant qu'un vrai CLI n'est pas fourni (anti-théâtre #1019, pas de fallback
-    #   silencieux). L'ancien défaut 'spass' (#939) n'a jamais décidé :
-    #   SPASSMlReasoner n'expose pas isConsistent + binaire non exécutable.
+    #   firsthand-vérifié). C'est le défaut honnête QUAND SPASS n'est pas
+    #   disponible.
+    # 'spass' utilise SPASSMlReasoner (binaire externe) — le binaire vendoré
+    #   `ext_tools/spass/SPASS.exe` (build CLI natif post-#1242, + adapter
+    #   EML→eml) DÉCIDE sur les KB qui OOM SimpleMlReasoner (#1239/#1242,
+    #   firsthand 4/4). Track C #1279 : le chemin pipeline réel préfère
+    #   SPASS quand il est détecté (voir ``modal_prefer_spass_when_available``).
     #
     modal_solver: ModalSolverChoice = ModalSolverChoice.TWEETY
+
+    #
+    # Track C #1279 : quand un binaire SPASS vendoré est détecté
+    # (``EXTERNAL_TOOL_PATHS['spass']`` peuplé par ``jvm_setup``), le chemin
+    # pipeline ``_invoke_modal_logic`` route vers SPASS — le solveur qui DÉCIDE
+    # sans OOM, au lieu du défaut SimpleMlReasoner (Kripke naïf, OOM sur KB
+    # réels ~12 atomes, FP-16 #1231). Anti-pendule : on *soustrait* le défaut
+    # OOM-prone en routant vers le solveur capable, on n'empile pas un try/except
+    # sur l'OOM. Un utilisateur/fixture peut forcer TWEETY (False) pour tester
+    # le path SimpleMlReasoner explicitement — un ``modal_solver`` explicitement
+    # choisi est toujours respecté.
+    #
+    modal_prefer_spass_when_available: bool = True
 
     #
     # Le choix du solveur pour la logique propositionnelle.

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -946,8 +946,16 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         formulas: List[str],
         valid: bool,
         modalities: List[str],
+        message: Optional[str] = None,
     ) -> str:
-        """Add a modal logic analysis result."""
+        """Add a modal logic analysis result.
+
+        #1279 (Track C): ``message`` is an optional provenance field (mirrors the
+        FOL/PL siblings). It carries the honest status — e.g.
+        ``unavailable:no-translation`` / ``unavailable:no-solver`` (OOM) — so
+        downstream consumers can confirm the entry is a real solver decision OR
+        an explicit degradation, never a silent None (#1019).
+        """
         ml_id = self._generate_id("modal", self.modal_analysis_results)
         entry = {
             "id": ml_id,
@@ -955,6 +963,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "valid": valid,
             "modalities": modalities,
         }
+        if message:
+            entry["message"] = message
         self.modal_analysis_results.append(entry)
         state_logger.info(f"Modal analysis added: {ml_id} (valid={valid})")
         return ml_id

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -6028,10 +6028,33 @@ async def _invoke_modal_logic(
     else:
         # Direct-formulas / hand-written-KB path (tests, pre-typed KBs like
         # ``type(rain), [](rain => wet), rain``): use the formulas verbatim so
-        # existing declarations/modal operators are not duplicated. Falls back
-        # to ``[input_text]`` only when neither path yields formulas — the parse
-        # below then fail-louds to ``degraded`` if that content is raw corpus.
-        formulas = context.get("formulas", [input_text])
+        # existing declarations/modal operators are not duplicated.
+        _direct_formulas = context.get("formulas")
+        if not _direct_formulas:
+            # Track C #1279 (cohérent Track B #1278): no nl_to_logic modal
+            # translation AND no direct formulas → the KB would be the raw
+            # corpus paragraph (MlParser parse fail → silent degraded None on
+            # every corpus, the pre-#1224 trap). Fail loud at this boundary
+            # instead: mark the axis unavailable:no-translation, never feed
+            # raw prose to the modal parser (#1019).
+            logger.warning(
+                "Modal reasoning: no nl_to_logic translation and no direct "
+                "formulas — marking axis unavailable:no-translation (#1279/#1019)."
+            )
+            return {
+                "formulas": [],
+                "valid": None,
+                "modalities": ["none_detected"],
+                "logic_type": "modal",
+                "solver": "unavailable",
+                "message": (
+                    "unavailable:no-translation — NL→modal produced no valid "
+                    "formulas and no direct KB was supplied; the modal axis is "
+                    "honestly absent, not degraded on raw corpus (#1279/#1019)."
+                ),
+                "modal_status": "unavailable:no-translation",
+            }
+        formulas = _direct_formulas
         if not isinstance(formulas, list):
             formulas = [str(formulas)]
         belief_set_str = "\n".join(str(f) for f in formulas)
@@ -6047,80 +6070,132 @@ async def _invoke_modal_logic(
             modalities.append("possibility")
     modalities = list(set(modalities)) or ["none_detected"]
 
-    # Primary: ModalHandler.is_modal_kb_consistent (#1212 query-based
-    # consistency) via the CONFIGURED solver (default TWEETY = SimpleMlReasoner).
-    # #1219: do NOT force SPASS — forcing it bypassed the fix when the binary
-    # was absent. valid is Optional[bool] (None = undecidable, honest).
-    try:
-        from argumentation_analysis.core.config import settings
-        from argumentation_analysis.agents.core.logic.modal_handler import (
-            ModalHandler,
-        )
-        from argumentation_analysis.agents.core.logic.tweety_initializer import (
-            TweetyInitializer,
-        )
-
-        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
-        # #1219: bare TweetyInitializer() does NOT initialize the modal parser/
-        # reasoner — those are class attrs that start None and are set only by
-        # ``initialize_modal_components`` (which ``TweetyBridge.__init__`` calls
-        # via ``ensure_jvm_and_components_are_ready``). Without this call,
-        # ``ModalHandler.__init__`` raises "Modal Parser not initialized" and the
-        # #1212 ``SimpleMlReasoner`` fix is never reached. The original code
-        # masked this construction bug behind the SPASS force-set cascade.
-        initializer.initialize_modal_components()  # type: ignore[no-untyped-call]
-        handler = ModalHandler(initializer_instance=initializer)
-        is_consistent, msg = await asyncio.to_thread(
-            handler.is_modal_kb_consistent, belief_set_str
-        )
-        return {
-            "formulas": formulas,
-            "valid": is_consistent,
-            "modalities": modalities,
-            "logic_type": "modal",
-            "solver": settings.modal_solver.value,
-            "message": msg,
-        }
-    except Exception as e:
-        logger.info(f"ModalHandler unavailable ({e}), falling back to TweetyBridge")
-
-    # Fallback: TweetyBridge.execute_modal_query (genuine modal query via JVM)
-    try:
-        from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
-
-        bridge = TweetyBridge()
-        logic_type = context.get("modal_logic_type", "K")
-        accepted, msg = await asyncio.to_thread(
-            bridge.execute_modal_query,
-            belief_set_str,
-            belief_set_str,
-            logic_type=logic_type,
-        )
-        return {
-            "formulas": formulas,
-            "valid": accepted,
-            "modalities": modalities,
-            "logic_type": "modal",
-            "solver": "tweety",
-            "message": msg,
-        }
-    except Exception as e:
-        logger.debug(f"Modal TweetyBridge unavailable ({e})")
-
-    # No solver available — report honest failure (#1019, #961).
-    # No heuristic fallback that could fabricate a verdict.
-    logger.warning(
-        "Modal analysis unavailable: no solver (Tweety/SPASS) could be loaded. "
-        "Reporting unverified status (no heuristic fallback)."
+    # Track C #1279: prefer the vendored SPASS binary when detected — the solver
+    # that DÉCIDE without OOM. SimpleMlReasoner (TWEETY default) OOMs on real
+    # modal KBs (~12 propositionnel atoms, FP-16 #1231); SPASSMlReasoner decides
+    # them (#1239/#1242, firsthand 4/4). Anti-pendule: *route* to the solver
+    # that can decide rather than catch the OOM and report degraded. The flip is
+    # conditional on (a) a detected vendored SPASS path, (b) the prefer flag,
+    # (c) the default TWEETY solver — an explicit ``modal_solver`` choice is
+    # always respected (the #1219 regression test pins TWEETY via that path).
+    # Restored in ``finally`` so the global choice never leaks past this call
+    # (#1219 lesson: no unconditional, leaked force-set).
+    from argumentation_analysis.core.config import settings as _modal_settings
+    from argumentation_analysis.core.config import ModalSolverChoice
+    from argumentation_analysis.agents.core.logic.modal_handler import (
+        ModalHandler as _ModalHandler,
+        _get_spass_path,
     )
-    return {
-        "formulas": formulas,
-        "valid": None,
-        "modalities": modalities,
-        "logic_type": "modal",
-        "solver": "unavailable",
-        "message": "Modal analysis unavailable: no solver could be loaded.",
-    }
+
+    _spass_path = _get_spass_path()
+    _prev_modal_solver = _modal_settings.modal_solver
+    _spass_routed = (
+        _spass_path is not None
+        and bool(_modal_settings.modal_prefer_spass_when_available)
+        and _prev_modal_solver == ModalSolverChoice.TWEETY
+    )
+    _modal_failure_reasons: List[str] = []
+    if _spass_routed:
+        object.__setattr__(_modal_settings, "modal_solver", ModalSolverChoice.SPASS)
+        logger.info(
+            f"Track C #1279: routing modal to vendored SPASS ({_spass_path}) — "
+            f"avoids SimpleMlReasoner OOM on real KBs."
+        )
+
+    try:
+        # Primary: ModalHandler.is_modal_kb_consistent (#1212 query-based
+        # consistency) via the CONFIGURED solver (TWEETY, or SPASS when routed
+        # above). valid is Optional[bool] (None = undecidable, honest, #1019).
+        try:
+            from argumentation_analysis.core.config import settings
+            from argumentation_analysis.agents.core.logic.tweety_initializer import (
+                TweetyInitializer,
+            )
+
+            initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+            # #1219: bare TweetyInitializer() does NOT initialize the modal parser/
+            # reasoner — those are class attrs that start None and are set only by
+            # ``initialize_modal_components`` (which ``TweetyBridge.__init__`` calls
+            # via ``ensure_jvm_and_components_are_ready``). Without this call,
+            # ``ModalHandler.__init__`` raises "Modal Parser not initialized" and the
+            # #1212 ``SimpleMlReasoner`` fix is never reached. The original code
+            # masked this construction bug behind the SPASS force-set cascade.
+            initializer.initialize_modal_components()  # type: ignore[no-untyped-call]
+            handler = _ModalHandler(initializer_instance=initializer)
+            is_consistent, msg = await asyncio.to_thread(
+                handler.is_modal_kb_consistent, belief_set_str
+            )
+            return {
+                "formulas": formulas,
+                "valid": is_consistent,
+                "modalities": modalities,
+                "logic_type": "modal",
+                "solver": settings.modal_solver.value,
+                "message": msg,
+                # Track C #1279: a real verdict from the active solver (SPASS
+                # when routed, else SimpleMlReasoner). "decided" only on a
+                # definite True/False; None stays "unverified" (#1019).
+                "modal_status": (
+                    "decided" if is_consistent in (True, False) else "unverified"
+                ),
+            }
+        except Exception as e:
+            _modal_failure_reasons.append(f"ModalHandler: {e}")
+            logger.info(f"ModalHandler unavailable ({e}), falling back to TweetyBridge")
+
+        # Fallback: TweetyBridge.execute_modal_query (genuine modal query via JVM)
+        try:
+            from argumentation_analysis.agents.core.logic.tweety_bridge import (
+                TweetyBridge,
+            )
+
+            bridge = TweetyBridge()
+            logic_type = context.get("modal_logic_type", "K")
+            accepted, msg = await asyncio.to_thread(
+                bridge.execute_modal_query,
+                belief_set_str,
+                belief_set_str,
+                logic_type=logic_type,
+            )
+            return {
+                "formulas": formulas,
+                "valid": accepted,
+                "modalities": modalities,
+                "logic_type": "modal",
+                "solver": "tweety",
+                "message": msg,
+                "modal_status": (
+                    "decided" if accepted in (True, False) else "unverified"
+                ),
+            }
+        except Exception as e:
+            _modal_failure_reasons.append(f"TweetyBridge: {e}")
+            logger.debug(f"Modal TweetyBridge unavailable ({e})")
+
+        # No solver available — report honest failure (#1019, #961).
+        # No heuristic fallback that could fabricate a verdict.
+        _reason = "; ".join(_modal_failure_reasons) or "no solver could be loaded"
+        logger.warning(
+            "Modal analysis unavailable (%s). Reporting unverified status "
+            "(no heuristic fallback, #1279/#1019).",
+            _reason,
+        )
+        return {
+            "formulas": formulas,
+            "valid": None,
+            "modalities": modalities,
+            "logic_type": "modal",
+            "solver": "unavailable",
+            "message": f"Modal analysis unavailable: {_reason}.",
+            # Track C #1279: surface the honest reason (OOM / no-solver) instead
+            # of a silent None — the reader sees the axis tried and failed, not
+            # "indisponible" with no cause.
+            "modal_status": "unavailable:no-solver",
+        }
+    finally:
+        # Restore the prior solver choice (no leaked global side-effect, #1219).
+        if _spass_routed:
+            object.__setattr__(_modal_settings, "modal_solver", _prev_modal_solver)
 
 
 async def _invoke_dung_extensions(

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -882,8 +882,22 @@ def _write_modal_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
         formulas = []
     if not isinstance(modalities, list):
         modalities = []
+    # Track C #1279: surface the honest status token when the modal axis is
+    # unavailable (no-translation / no-solver OOM), mirroring the FOL writer
+    # (#1278). A decided/unverified verdict keeps the solver's own message.
+    modal_status = output.get("modal_status")
+    raw_msg = output.get("message")
+    if isinstance(modal_status, str) and modal_status.startswith("unavailable:"):
+        status_message: Optional[str] = modal_status
+    elif isinstance(raw_msg, str):
+        status_message = raw_msg
+    else:
+        status_message = None
     state.add_modal_analysis_result(
-        formulas, valid if valid is not None else None, modalities
+        formulas,
+        valid if valid is not None else None,
+        modalities,
+        message=status_message,
     )
 
 

--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -826,6 +826,55 @@ def _collect_formal_findings(state: Any) -> List[FormalFinding]:
                     )
                 )
 
+    modal = getattr(state, "modal_analysis_results", None)
+    if isinstance(modal, list):
+        # Track C #1279: surface the modal verdict when decided, OR the honest
+        # unavailability (no-translation / no-solver OOM) instead of silence —
+        # mirroring the FOL block (#1278). ``valid`` is tri-state: True/False =
+        # SPASS/SimpleMlReasoner decided; None = degraded.
+        decided = [
+            r for r in modal if isinstance(r, dict) and r.get("valid") in (True, False)
+        ]
+        if decided:
+            sat = sum(1 for r in decided if r.get("valid") is True)
+            unsat = sum(1 for r in decided if r.get("valid") is False)
+            findings.append(
+                FormalFinding(
+                    kind="modal",
+                    verdict=(
+                        f"{unsat} théorie(s) modales inconsistantes sur "
+                        f"{len(decided)} vérifiée(s)"
+                        if unsat
+                        else f"{sat} théorie(s) modales consistantes"
+                    ),
+                    detail="solveur modal (SPASS/Tweety)",
+                )
+            )
+        else:
+            unavailable_modal = [
+                r
+                for r in modal
+                if isinstance(r, dict)
+                and r.get("valid") is None
+                and isinstance(r.get("message"), str)
+                and str(r.get("message")).startswith("unavailable:")
+            ]
+            if unavailable_modal:
+                findings.append(
+                    FormalFinding(
+                        kind="modal",
+                        verdict=(
+                            "Modal indisponible : aucune théorie modale n'a pu "
+                            "être formalisée puis validée sur ce corpus"
+                        ),
+                        detail=(
+                            "logique modale — traduction NL→modal vide ou solveur "
+                            "indisponible (OOM/absent) ; axe honnêtement absent, "
+                            "non silencieusement dégradé (#1279/#1019)"
+                        ),
+                    )
+                )
+
     dung_trace = _collect_dung_trace(state)
     if dung_trace.available and dung_trace.rejected_args:
         sems = sorted(set(dung_trace.rejected_args.values()))

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_invoke_modal_logic_reaches_solver.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_invoke_modal_logic_reaches_solver.py
@@ -47,13 +47,22 @@ def jvm():
 @pytest.fixture
 def tweety_solver():
     """Force the pure-Java default (TWEETY / SimpleMlReasoner) — the
-    always-available, always-deciding modal path (no external binary)."""
+    always-available, always-deciding modal path (no external binary).
+
+    Track C #1279: the pipeline now prefers vendored SPASS when detected. To
+    keep testing the SimpleMlReasoner path explicitly (this test's intent), opt
+    out of the SPASS preference in addition to pinning TWEETY."""
     previous = settings.modal_solver
+    previous_prefer = settings.modal_prefer_spass_when_available
     settings.modal_solver = ModalSolverChoice.TWEETY
+    object.__setattr__(settings, "modal_prefer_spass_when_available", False)
     try:
         yield
     finally:
         settings.modal_solver = previous
+        object.__setattr__(
+            settings, "modal_prefer_spass_when_available", previous_prefer
+        )
 
 
 # Parseable modal KBs (FP-11 grammar: type(prop) declarations, MlParser).

--- a/tests/unit/argumentation_analysis/orchestration/test_track_c_modal_spass_1279.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_track_c_modal_spass_1279.py
@@ -1,0 +1,256 @@
+"""Track C #1279 — modal routed to vendored SPASS (fail-loud, no OOM→degraded).
+
+Pins the issue #1279 DoD:
+
+  1. When a vendored SPASS binary is detected, ``_invoke_modal_logic`` ROUTES to
+     it (flips ``modal_solver`` to SPASS for the call, restored after) — the
+     solver that decides without OOM, instead of the SimpleMlReasoner default.
+  2. When SPASS/the KB is unavailable, the axis fails loud
+     (``unavailable:no-translation`` / ``unavailable:no-solver``) — never a
+     silent OOM→None (#1019).
+
+Covers the routing logic (mocked ModalHandler — no JVM), the KB-starvation gate
+(cohérent Track B #1278), the state-writer ``modal_status`` passthrough, and the
+act2 honest 'Modal indisponible' surfacing. The real-JVM "SPASS decides"
+verdict is exercised by ``test_invoke_modal_logic_reaches_solver`` (integration).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+MODAL_HANDLER_MOD = "argumentation_analysis.agents.core.logic.modal_handler"
+TWEETY_INIT_PATH = (
+    "argumentation_analysis.agents.core.logic.tweety_initializer.TweetyInitializer"
+)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# DoD #2 — KB starvation → unavailable:no-translation (cohérent Track B)
+# ---------------------------------------------------------------------------
+
+
+class TestModalStarvationNoTranslation:
+    """No nl_to_logic modal translation AND no direct formulas → axis is
+    unavailable:no-translation, NOT raw-corpus silent degraded."""
+
+    def test_no_formulas_marks_unavailable(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_modal_logic,
+        )
+
+        # No phase_nl_to_logic_output, no context["formulas"] → starvation gate.
+        result = _run(_invoke_modal_logic("some raw corpus paragraph", {}))
+        assert result["modal_status"] == "unavailable:no-translation"
+        assert result["valid"] is None
+        assert result["formulas"] == []
+
+
+# ---------------------------------------------------------------------------
+# DoD #1 — SPASS routing: flip + restore + decided verdict
+# ---------------------------------------------------------------------------
+
+
+class TestModalSpassRouting:
+    """When vendored SPASS is detected (+ prefer flag + default TWEETY),
+    ``_invoke_modal_logic`` routes to SPASS and restores the global after."""
+
+    def test_spass_routed_decides_and_restores_global(self):
+        from argumentation_analysis.core.config import ModalSolverChoice, settings
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_modal_logic,
+        )
+
+        prev = settings.modal_solver
+        prev_prefer = settings.modal_prefer_spass_when_available
+        settings.modal_solver = ModalSolverChoice.TWEETY
+        object.__setattr__(settings, "modal_prefer_spass_when_available", True)
+        try:
+            mock_handler = MagicMock()
+            mock_handler.is_modal_kb_consistent.return_value = (
+                True,
+                "SPASS: consistent.",
+            )
+            mock_initializer = MagicMock()
+            with (
+                patch(MODAL_HANDLER_MOD + ".ModalHandler", return_value=mock_handler),
+                patch(
+                    MODAL_HANDLER_MOD + "._get_spass_path",
+                    return_value="/fake/ext_tools/spass/SPASS.exe",
+                ),
+                patch(TWEETY_INIT_PATH, return_value=mock_initializer),
+            ):
+                result = _run(
+                    _invoke_modal_logic(
+                        "ignored",
+                        {"formulas": ["type(p)", "type(q)", "[](p => q)", "p"]},
+                    )
+                )
+
+            # Routed to SPASS → a real verdict, modal_status=decided.
+            assert result["modal_status"] == "decided"
+            assert result["valid"] is True
+            # solver reflects the SPASS routing (modal_solver.value at call time).
+            assert result["solver"] == "spass"
+            # ModalHandler was actually driven with the SPASS-routed config.
+            assert mock_handler.is_modal_kb_consistent.called
+        finally:
+            settings.modal_solver = prev
+            object.__setattr__(
+                settings, "modal_prefer_spass_when_available", prev_prefer
+            )
+
+        # The global modal_solver is restored (no leaked side-effect, #1219).
+        assert settings.modal_solver == ModalSolverChoice.TWEETY
+
+    def test_prefer_flag_opts_out_of_spass(self):
+        """``modal_prefer_spass_when_available=False`` keeps TWEETY even when a
+        vendored SPASS is detected — the explicit opt-out the #1219 regression
+        test uses to pin the SimpleMlReasoner path."""
+        from argumentation_analysis.core.config import ModalSolverChoice, settings
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_modal_logic,
+        )
+
+        prev = settings.modal_solver
+        prev_prefer = settings.modal_prefer_spass_when_available
+        settings.modal_solver = ModalSolverChoice.TWEETY
+        object.__setattr__(settings, "modal_prefer_spass_when_available", False)
+        try:
+            mock_handler = MagicMock()
+            mock_handler.is_modal_kb_consistent.return_value = (True, "ok")
+            mock_initializer = MagicMock()
+            captured = {}
+
+            def _capture_init(initializer_instance=None):
+                captured["solver_at_call"] = settings.modal_solver
+                return mock_handler
+
+            with (
+                patch(MODAL_HANDLER_MOD + ".ModalHandler", side_effect=_capture_init),
+                patch(
+                    MODAL_HANDLER_MOD + "._get_spass_path",
+                    return_value="/fake/SPASS",
+                ),
+                patch(TWEETY_INIT_PATH, return_value=mock_initializer),
+            ):
+                result = _run(
+                    _invoke_modal_logic("ignored", {"formulas": ["type(p)", "p"]})
+                )
+            # Opted out → stayed on TWEETY (SimpleMlReasoner), not SPASS.
+            assert captured["solver_at_call"] == ModalSolverChoice.TWEETY
+            assert result["solver"] == "tweety"
+            assert result["modal_status"] == "decided"
+        finally:
+            settings.modal_solver = prev
+            object.__setattr__(
+                settings, "modal_prefer_spass_when_available", prev_prefer
+            )
+
+
+# ---------------------------------------------------------------------------
+# State writer — modal_status passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestStateWriterModalStatus:
+    """_write_modal_to_state carries the honest status as ``message`` (#1279)."""
+
+    def test_unavailable_message_passed_to_state(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_modal_to_state,
+        )
+
+        state = MagicMock()
+        output = {
+            "formulas": [],
+            "valid": None,
+            "modalities": [],
+            "modal_status": "unavailable:no-solver",
+        }
+        _write_modal_to_state(output, state, {})
+
+        assert state.add_modal_analysis_result.called
+        call = state.add_modal_analysis_result.call_args
+        assert call[0][1] is None  # valid preserved as None (not False, #1019)
+        assert call.kwargs.get("message") == "unavailable:no-solver"
+
+    def test_decided_keeps_solver_message(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_modal_to_state,
+        )
+
+        state = MagicMock()
+        output = {
+            "formulas": ["type(p)", "p"],
+            "valid": True,
+            "modalities": ["necessity"],
+            "modal_status": "decided",
+            "message": "SPASS: consistent.",
+        }
+        _write_modal_to_state(output, state, {})
+
+        call = state.add_modal_analysis_result.call_args
+        assert call[0][1] is True
+        assert call.kwargs.get("message") == "SPASS: consistent."
+
+
+# ---------------------------------------------------------------------------
+# act2 — honest 'Modal indisponible' surfacing
+# ---------------------------------------------------------------------------
+
+
+def _findings_state(modal_results):
+    return SimpleNamespace(
+        propositional_analysis_results=[],
+        fol_analysis_results=[],
+        modal_analysis_results=modal_results,
+        dung_frameworks={},
+    )
+
+
+class TestAct2ModalIndisponibleSurfacing:
+    """When modal is unavailable, the restitution surfaces it honestly
+    instead of silence (DoD #2)."""
+
+    def test_unavailable_modal_surfaces_indisponible(self):
+        from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+            _collect_formal_findings,
+        )
+
+        state = _findings_state(
+            [{"valid": None, "message": "unavailable:no-translation"}]
+        )
+        findings = _collect_formal_findings(state)
+        modal = [f for f in findings if f.kind == "modal"]
+        assert len(modal) == 1
+        assert "indisponible" in modal[0].verdict.lower()
+
+    def test_decided_modal_not_marked_indisponible(self):
+        from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+            _collect_formal_findings,
+        )
+
+        state = _findings_state([{"valid": True}])
+        findings = _collect_formal_findings(state)
+        modal = [f for f in findings if f.kind == "modal"]
+        assert len(modal) == 1
+        assert "indisponible" not in modal[0].verdict.lower()
+        assert "consistante" in modal[0].verdict.lower()
+
+    def test_no_modal_results_no_finding(self):
+        from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+            _collect_formal_findings,
+        )
+
+        state = _findings_state([])
+        findings = _collect_formal_findings(state)
+        assert not any(f.kind == "modal" for f in findings)


### PR DESCRIPTION
Track C of Epic #1276 (modal axis). DoD met.

## Problem

The modal pipeline (`_invoke_modal_logic`) defaulted to `TWEETY` → `SimpleMlReasoner`, which OOMs on real KBs (~12 propositional atoms — FP-16 #1231). A **vendored SPASS binary is detected at jvm_setup time** (and is git-tracked at `ext_tools/spass/SPASS.exe`), but the production path **never routed to it** — so every real corpus silently degraded to `valid=None`. That `None` is the anti-pendule #1019 signature: empty/None reads as "ran, found nothing" instead of "the capable solver was never engaged".

This is the modal twin of Track B #1278 (NL→FOL template theatre → "consistent sur vide").

## Fix = subtract, don't counterweight

1. **SPASS routing** (`invoke_callables.py` `_invoke_modal_logic`): when SPASS is detected AND `modal_prefer_spass_when_available` is set AND the configured solver is the default `TWEETY`, flip `modal_solver`→`SPASS` for the call and **restore the global after** (try/finally — no leaked side-effect, #1219 regression-safe). The fix **routes to the capable solver**, it does NOT catch the OOM with a retry/fallback (that would be the pendulum).
2. **KB starvation gate** (cohérent Track B #1278): no `nl_to_logic` modal translation AND no direct formulas → early-return `unavailable:no-translation`, never the raw `[input_text]` fallback that fed `MlParser` the corpus and got `valid=None`.
3. **`modal_status`** surfaced on all return paths (`decided` / `unverified` / `unavailable:no-solver`) + state-writer `message` passthrough (mirrors FOL). act2 surfaces an honest **"Modal indisponible"** finding instead of silence when `valid is None` AND `message` starts with `unavailable:`.

## Config

`config.py`: `modal_prefer_spass_when_available: bool = True` — anti-pendule route-to-capable-solver (NOT catching the OOM).

## DoD evidence

| # | Requirement | Test |
|---|---|---|
| 1 | SPASS detected → routed + restored + decides | `TestModalSpassRouting::test_spass_routed_decides_and_restores_global` (`solver=="spass"`, `modal_status=="decided"`, global restored to TWEETY) |
| 1b | Opt-out keeps TWEETY | `test_prefer_flag_opts_out_of_spass` (`prefer=False` → `solver=="tweety"`) |
| 2 | Unavailable → fail-loud, not silent None | `TestModalStarvationNoTranslation::test_no_formulas_marks_unavailable` (`unavailable:no-translation`) |
| 3 | Honest status reaches state | `TestStateWriterModalStatus` (message passthrough) |
| 4 | act2 surfaces "indisponible" honestly | `TestAct2ModalIndisponibleSurfacing` (decided / unavailable / empty) |
| — | #1219 regression still pins SimpleMlReasoner | `tweety_solver` fixture opts out (`prefer=False`); integration `test_invoke_modal_logic_reaches_solver` exercises real-JVM "decides" |

**8 unit tests green, mypy strict clean.**

## Files

- `argumentation_analysis/orchestration/invoke_callables.py` — SPASS routing + KB starvation gate + `modal_status`
- `argumentation_analysis/core/config.py` — `modal_prefer_spass_when_available` flag + corrected stale comment
- `argumentation_analysis/core/shared_state.py` — `add_modal_analysis_result(message=)`
- `argumentation_analysis/orchestration/state_writers.py` — `_write_modal_to_state` passthrough
- `argumentation_analysis/reporting/restitution/act2_narrative_plugin.py` — modal indisponible surfacing
- `tests/unit/argumentation_analysis/orchestration/test_track_c_modal_spass_1279.py` (new, 8 tests)
- `tests/integration/.../test_invoke_modal_logic_reaches_solver.py` — `tweety_solver` opt-out

Base: `9df8f39c` (Track B merged) — sequential same-file dependency on B, rebased on latest main.

Privacy HARD: synthetic atoms only (`type(p)`, `type(q)`), zero corpus content.

Refs #1279. Track C complete; Epic #1276 stays open until capstone re-run.