### PR TITLE
test(pl): #1287 structural atom check replaces stale p1/p2/p3 assertions

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_nl_to_logic_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_nl_to_logic_wiring.py
@@ -6,12 +6,25 @@ FAIL LOUD (``unavailable:no-translation``). The template fabrication fallback
 "consistent" verdict (#1019).
 """
 
+import re
+
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 TWEETY_BRIDGE_PATH = (
     "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge"
 )
+
+# A valid Tweety PlParser atom: lowercase letter then alnum/underscore (#1260
+# _pl_atom slug). Structural check — NOT an exact key — so the test does not
+# rot again when the slug scheme changes (#1287 anti-pendule: don't freeze a
+# new exact key that would be just as fragile as the old p1/p2/p3).
+_PL_ATOM_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+def _is_pl_atom(formula: str) -> bool:
+    """True if ``formula`` is a single valid PL atom (opaque label)."""
+    return bool(isinstance(formula, str) and _PL_ATOM_RE.match(formula))
 
 
 def _make_context_with_args(args_texts, extra=None):
@@ -104,18 +117,29 @@ class TestPropositionalLogicNLWiring:
         assert len(result["formulas"]) >= 1
 
     async def test_pl_falls_back_to_templates(self):
-        """PL phase generates p1, p2, ... templates when no translations available."""
+        """PL phase generates one valid atom per argument when no translations available.
+
+        #1260 changed the opaque ``p1,p2`` template to a meaning-preserving slug
+        via ``_pl_atom`` (e.g. ``p_arg_one_<hash>``). #1287 (anti-pendule): assert
+        the structural contract — one valid PL atom per argument, distinct —
+        instead of freezing an exact key that rots when the slug scheme changes.
+        """
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_propositional_logic,
         )
 
-        context = _make_context_with_args(["Arg one", "Arg two", "Arg three"])
+        args = ["Arg one", "Arg two", "Arg three"]
+        context = _make_context_with_args(args)
         result = await _invoke_propositional_logic("text", context)
 
         assert result["logic_type"] == "propositional"
-        assert "p1" in result["formulas"]
-        assert "p2" in result["formulas"]
-        assert "p3" in result["formulas"]
+        formulas = result["formulas"]
+        # One atom per argument (the template fallback covers every argument).
+        assert len(formulas) == len(args)
+        # Each is a valid PL atom; all distinct (the hash suffix disambiguates
+        # args that collapse to the same slug).
+        assert all(_is_pl_atom(f) for f in formulas), formulas
+        assert len(set(formulas)) == len(formulas), formulas
 
     async def test_pl_argument_mapping_from_translations(self):
         """argument_mapping is populated from NL-to-logic translations."""
@@ -152,7 +176,10 @@ class TestPropositionalLogicNLWiring:
         assert any("Original text" in v for v in mapping_values)
 
     async def test_pl_nl_translator_import_failure(self):
-        """PL phase gracefully falls back when NLToLogicTranslator import fails."""
+        """PL phase falls back to valid atoms when NLToLogicTranslator import fails.
+
+        #1287: structural check (valid PL atom) instead of the stale ``p1`` key.
+        """
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_propositional_logic,
         )
@@ -165,7 +192,9 @@ class TestPropositionalLogicNLWiring:
             result = await _invoke_propositional_logic("text", context)
 
         assert result["logic_type"] == "propositional"
-        assert "p1" in result["formulas"]
+        formulas = result["formulas"]
+        assert len(formulas) >= 1
+        assert all(_is_pl_atom(f) for f in formulas), formulas
 
 
 class TestFOLReasoningNLWiring:


### PR DESCRIPTION
## What

`#1287` (deep-queue DQ2, dispatched R483). Fix the 2 stale PL test-debt assertions that **my own FB-39 cross-verify surfaced** on Track B #1286.

## Root cause (firsthand, FB-39 #1286)

Epic #1258 Track 2 (#1260, intuitive logic symbols) intentionally replaced the opaque `p1,p2` template with a meaning-preserving slug via `_pl_atom()` (e.g. `p_arg_one_<hash>`) — a *good* change (readable atoms). But 2 tests in `test_nl_to_logic_wiring.py` still asserted the old exact keys `p1`/`p2`/`p3`, so they rotted.

The #1286 body mislabeled these as "2 PL env-JVM" failures. FB-39 firsthand proved they are **stale exact-key assertions** (JVM runs fine; `092a5450` parent fails too; Track B touched no PL file). Not a regression — cosmetic test-debt.

## Fix (anti-pendule #1287: don't freeze a new exact key)

Assert the **structural contract** instead of any exact key:
- `_is_pl_atom(formula)`: regex `^[a-z][a-z0-9_]*$` (the Tweety `PlParser` atom grammar — lowercase letter then alnum/underscore).
- `test_pl_falls_back_to_templates`: `len(formulas) == len(args)` + all valid atoms + all distinct (hash suffix disambiguates).
- `test_pl_nl_translator_import_failure`: `>= 1` + all valid atoms.

The test no longer breaks when the slug scheme changes again — it pins what the fallback *means* (one valid atom per argument), not the literal key.

## DoD #1287

- [x] 2 tests green.
- [x] `black` green.
- [x] `flake8` — not run (absent from env `projet-is`; continue-on-error per CLAUDE.md). mypy strict = only blocking gate, and it does **not** cover test files in CI (fixed file list = 8 source modules in `ci.yml`).

## Validation

- **Full `test_nl_to_logic_wiring.py` : 10 passed** (2 PL fixed + 0 FOL regression — the 5 FOL Track B tests still green).
- black clean. `_is_pl_atom` is properly typed (`str -> bool`).

## Scope / collision

Test file only — **disjoint from DQ1** (capstone, po-2025). No source change. 1 file, +36/-7.

## Privacy

None — test atoms only (`"Arg one"`, synthetic).

Closes #1287

— po-2023 (GLM-5.2/z.ai) · Epic #1276 deep-queue DQ2