### PR TITLE
fix(test-infra): #1293 scripts namespace phantom + dead pytest config (collect exit 0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,7 +81,7 @@ pytest tests/ -m "belief_set" -v         # Logic belief set tests
 
 **Async mode**: `asyncio_mode = auto` — no need for `@pytest.mark.asyncio`.
 
-**Python path**: pytest resolves from `.`, `argumentation_analysis`, and `project_core` (configured in `pyproject.toml`).
+**Python path**: pytest config lives in **`pytest.ini`** (the single source of truth — `pythonpath = . src`; `argumentation_analysis` and `project_core` are reachable as subdirs of `.`). Do not assume `pyproject.toml`'s `[tool.pytest.ini_options]` applies: pytest discovers exactly one config file and `pytest.ini` wins, so any `[tool.pytest.ini_options]` section is dead/overridden (removed in #1293 to kill the drift).
 
 **DLL load order on Windows**: `conftest.py` imports torch/transformers BEFORE jpype to avoid `WinError 182` crashes. Do not reorder these imports.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,60 +20,15 @@ extend-exclude = '''
 )/
 '''
 
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = "-ra -q -p no:faulthandler"
-asyncio_mode = "auto"
-norecursedirs = [
-    ".git",
-    "venv",
-    "archived_scripts",
-    "libs",
-    "abs_arg_dung",
-    "examples",
-    "argumentation_analysis/services/web_api/tests",
-]
-pythonpath = [
-    ".",
-    "argumentation_analysis",
-    "project_core"
-]
-testpaths = [
-    "tests"
-]
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-    "integration: marks tests as integration tests",
-    "e2e: marks tests as end-to-end tests",
-    "api: marks tests related to the API",
-    "llm_light: Tests LLM légers (config/init, <30s, ~$0.01-0.05)",
-    "llm_integration: Tests intégration LLM complets (appels réels, >30s, ~$0.05-0.20)",
-    "llm_critical: Tests critiques stack 100% authentique (E2E, >60s, >$0.20)",
-    "real_jpype: marks tests that require a real JPype/JVM environment",
-    "no_jvm_session: marks tests that should not start the shared JVM session",
-    "phase5",
-    "informal",
-    "performance",
-    "comparison",
-    "user_experience",
-    "config",
-    "api_integration",
-    "use_real_numpy",
-    "validation",
-    "debuglog",
-    "use_mock_numpy",
-    "requires_tweety_jar",
-    "belief_set",
-    "propositional",
-    "first_order",
-    "modal",
-    "robustness",
-    "playwright",
-]
-log_cli = true
-log_cli_level = "INFO"
-log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
-log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+# NOTE (#1293): pytest configuration lives exclusively in `pytest.ini`.
+# A `[tool.pytest.ini_options]` section previously lived here but was DEAD —
+# pytest discovers exactly one config file and `pytest.ini` takes precedence
+# (pytest.ini > pyproject.toml > tox.ini > setup.cfg), so every key it held
+# (pythonpath, addopts, markers, log_cli, ...) was silently overridden. This
+# caused documented drift: CLAUDE.md cited pyproject's `pythonpath` as
+# authoritative while pytest.ini's `pythonpath = . src` was the live one.
+# Removed to establish a single source of truth (pytest.ini). Behavior-neutral:
+# pytest already ignored this section. `pythonpath` of pytest.ini is unchanged.
 
 [tool.poetry]
 name = "argumentation-analysis"

--- a/scripts/analysis/__init__.py
+++ b/scripts/analysis/__init__.py
@@ -1,0 +1,5 @@
+# This file makes the 'scripts/analysis' subdirectory a package, consistent with
+# sibling scripts/* subpackages (core, apps, setup, narrative_reporting, ...).
+# Removing the ambiguity around the top-level `scripts` package (issue #1293):
+# an explicit __init__ here ensures `scripts.analysis.*` resolves deterministically
+# against the repo-root `scripts/` package rather than a same-named shadow.

--- a/tests/scripts/__init__.py
+++ b/tests/scripts/__init__.py
@@ -1,1 +1,0 @@
-"""Tests module"""


### PR DESCRIPTION
## What

Closes #1293. `pytest tests/ --collect-only` aborted the full suite with **exit 2 (20 collection errors)**. This makes collection **exit 0** (14207 tests, 0 errors) without touching the `pythonpath` that CI depends on.

## Root cause (firsthand — corrected vs the issue hypothesis)

The issue hypothesized a 3-way collision between the `./scripts`, `argumentation_analysis/scripts`, and `project_core/scripts` directories. **Firsthand investigation found a different culprit.**

I instrumented the import system (`builtins.__import__` / `importlib.import_module` watcher plugins) to trace who rebinds `sys.modules['scripts']` in full-suite. It bound to **`tests/scripts/__init__.py`** — a **vestigial phantom package**:
- Added in mass-commit `865140b7` ("99 corrections __init__.py").
- Empty body (`"""Tests module"""`).
- **Zero importers** (no `from scripts import`, no `tests.scripts` reference).
- No test modules live under `tests/scripts/` (only a stray `.ps1`).

Mechanism: pytest's default `importmode=prepend` collects a test under `tests/scripts/`, inserts `tests/` on `sys.path`, and the bare `scripts` name gets bound to the phantom. The 5 repo-root test call sites (`from scripts.maintenance_manager`, `from scripts.run_capstone_c1`, etc.) then fail with `No module named 'scripts.X'` because the phantom has no such submodules. Confirmed reversible: setting aside the phantom dropped collection errors **20 → 16** (the 4 `scripts.*` errors gone).

## Fix (scoped, low-risk — option a-bounded per the issue)

1. **Remove `tests/scripts/__init__.py`** (the phantom root cause).
2. **Add `scripts/analysis/__init__.py`** for package consistency with sibling `scripts/*` subpackages (all of `core`, `apps`, `setup`, `narrative_reporting`, `validation`, `commit_analysis` have one). This was flagged as missing in the issue.
3. **Remove the dead `[tool.pytest.ini_options]` block** from `pyproject.toml`. pytest discovers exactly one config file; `pytest.ini` wins (precedence: pytest.ini > pyproject.toml > tox.ini > setup.cfg), so that entire section (pythonpath, addopts, markers, log_cli) was **silently overridden**. This is the documented drift: CLAUDE.md cited pyproject's `pythonpath` as authoritative while pytest.ini's `pythonpath = . src` was the live one. Removed to establish one source of truth. Replaced with an explanatory NOTE.
4. **Fix CLAUDE.md** to point at `pytest.ini` as the single source of truth.

`pythonpath` of pytest.ini is **unchanged** — CI depends on it.

## Files removed and why (cleanup gate)

| File | Type | Last useful date | Reason for deletion |
|------|------|------------------|---------------------|
| `tests/scripts/__init__.py` | test / config | never (vestigial) | Empty phantom package (mass-commit 865140b7). Zero importers, zero test modules under `tests/scripts/`. Root cause of the `scripts` namespace poisoning. Origin check: `865140b7` is a `refactor`/mass-correction commit, not a `feat` — low suspicion. |

## DoD (verified firsthand, `projet-is`)

- [x] `pytest tests/ --collect-only` → **exit 0** (14207 collected, 0 errors). Before: 20 errors / Interrupted.
- [x] Non-regression: `pytest tests/unit/scripts/ --disable-jvm-session` → **131 passed, 2 skipped** — includes the 4 colliders that previously failed to even collect.
- [x] `pythonpath` of pytest.ini **unchanged**.
- [x] Drift pytest.ini ↔ pyproject.toml ↔ CLAUDE.md **reconciled** (pytest.ini is the single source of truth).

## Out of scope (env drift, NOT code — flagged for honesty)

The 16 non-`scripts` collection errors were `ModuleNotFoundError: fastapi` / `hypothesis` on my **local** `projet-is` env (drifted). Both are present in `environment.yml` / transitive deps, so **CI is unaffected**. I installed them locally only to prove the full exit 0. No code change here touches fastapi/hypothesis.

## Anti-pendule

- ❌ Did NOT rename/remove any of the 3 real `scripts` dirs (would break repo-wide imports).
- ❌ Did NOT touch pytest.ini's `pythonpath` (option-a-unbounded = CI risk).
- ❌ Did NOT `--ignore` the 5 colliders (option c — masks the hole instead of fixing it).

Refs #1293.