### PR TITLE
fix(env): #1295 deterministic multi-.env loading — root wins + divergence warn

### DIFF
--- a/project_core/managers/environment_manager.py
+++ b/project_core/managers/environment_manager.py
@@ -1,30 +1,114 @@
 # -*- coding: utf-8 -*-
 """
 Manages environment variables for the project.
+Loads root .env deterministically (override=True so root wins over sub-.env files).
+Warns when secondary .env files carry a different OPENAI_API_KEY.
 """
 
+import logging
 import os
-from dotenv import load_dotenv, find_dotenv
+from pathlib import Path
+from typing import Optional
+
+from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
+
+# Secondary .env paths relative to repo root — parsed for divergence detection only,
+# never loaded into os.environ.
+_SECONDARY_ENV_RELPATHS = [
+    "argumentation_analysis/.env",
+    "config/.env",
+]
+
+# Variables whose divergence across .env files causes a silent 401.
+_SENSITIVE_VARS = ["OPENAI_API_KEY", "OPENROUTER_API_KEY"]
+
+
+def _mask(val: str) -> str:
+    """Mask a secret for log output: first 8 chars + last 4 chars."""
+    if len(val) <= 8:
+        return "***"
+    return f"{val[:8]}...{val[-4:]}"
+
+
+def _find_repo_root() -> Optional[Path]:
+    """Walk up from this file to find the repo root via pyproject.toml sentinel."""
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    return None
 
 
 class EnvironmentManager:
     """
     Handles loading and retrieving environment variables.
-    It now tracks if a .env file was found and loaded.
+
+    Loading order (deterministic):
+    1. Root .env (located via pyproject.toml sentinel) — loaded with override=True so it
+       always wins, even if a sub-.env was previously imported.
+    2. Secondary .env files (argumentation_analysis/.env, config/.env) are NOT loaded;
+       they are only parsed to detect divergence and emit a WARNING.
+    3. Fallback: find_dotenv() legacy behaviour when no root .env is found.
     """
 
-    def __init__(self, override=False):
-        # find_dotenv() searches for the .env file (useful for scripts deep in the hierarchy)
-        # It returns the path to the file, or an empty string if not found.
-        self.dotenv_path = find_dotenv()
+    def __init__(self, override: bool = False) -> None:
+        self.dotenv_path: str = ""
+        self.dotenv_loaded: bool = False
 
-        # load_dotenv() returns True if it found and loaded a file.
-        self.dotenv_loaded = load_dotenv(
-            dotenv_path=self.dotenv_path or None, override=override
-        )
+        repo_root = _find_repo_root()
+        root_env: Optional[Path] = (repo_root / ".env") if repo_root is not None else None
 
-    def get_variable(self, name: str, default=None):
-        """
-        Retrieves an environment variable.
-        """
+        if root_env is not None and root_env.exists():
+            self.dotenv_path = str(root_env)
+            # override=True: root .env is canonical; beats any value already in os.environ
+            # (e.g. from a sub-.env loaded earlier via first-import-wins).
+            self.dotenv_loaded = load_dotenv(dotenv_path=str(root_env), override=True)
+            if repo_root is not None:
+                self._check_secondary_divergence(repo_root)
+        else:
+            # No root .env found — fall back to legacy find_dotenv behaviour.
+            from dotenv import find_dotenv  # local import to avoid unconditional dep
+
+            self.dotenv_path = find_dotenv()
+            self.dotenv_loaded = load_dotenv(
+                dotenv_path=self.dotenv_path or None, override=override
+            )
+
+    def _check_secondary_divergence(self, repo_root: Path) -> None:
+        """Parse secondary .env files and warn on OPENAI_API_KEY divergence."""
+        canonical: dict[str, str] = {
+            var: os.getenv(var, "") for var in _SENSITIVE_VARS
+        }
+        for rel in _SECONDARY_ENV_RELPATHS:
+            secondary = repo_root / rel
+            if not secondary.exists():
+                continue
+            secondary_vals: dict[str, str] = {}
+            try:
+                with open(secondary, encoding="utf-8", errors="replace") as fh:
+                    for line in fh:
+                        stripped = line.strip()
+                        if not stripped or stripped.startswith("#") or "=" not in stripped:
+                            continue
+                        k, _, v = stripped.partition("=")
+                        k = k.strip()
+                        if k in _SENSITIVE_VARS:
+                            secondary_vals[k] = v.strip().strip('"').strip("'")
+            except OSError:
+                continue
+            for var, sec_val in secondary_vals.items():
+                canon_val = canonical.get(var, "")
+                if sec_val and canon_val and sec_val != canon_val:
+                    logger.warning(
+                        "[EnvironmentManager] %s divergence: root .env=%s but %s=%s"
+                        " — root value retained. Update or remove the stale key.",
+                        var,
+                        _mask(canon_val),
+                        rel,
+                        _mask(sec_val),
+                    )
+
+    def get_variable(self, name: str, default: Optional[str] = None) -> Optional[str]:
+        """Retrieves an environment variable."""
         return os.getenv(name, default)

--- a/tests/unit/project_core/managers/test_dotenv_loading.py
+++ b/tests/unit/project_core/managers/test_dotenv_loading.py
@@ -1,0 +1,147 @@
+"""Tests for deterministic multi-.env loading in EnvironmentManager (#1295).
+
+Verifies:
+  - root .env always wins (override=True) even when OPENAI_API_KEY is pre-set in os.environ
+  - divergence WARNING is emitted when a secondary .env carries a different key
+  - no WARNING when secondary .env has the same key as root
+"""
+import logging
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_env(path: Path, key: str, value: str) -> None:
+    path.write_text(f'{key}="{value}"\n', encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Module alias for patching
+# ---------------------------------------------------------------------------
+import project_core.managers.environment_manager as _em_mod
+from project_core.managers.environment_manager import EnvironmentManager
+
+
+class TestDotenvLoadingDeterministic:
+    """Root .env override behaviour."""
+
+    def test_root_env_overrides_pre_existing_env_var(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Root .env (override=True) must replace a stale value set by a prior sub-.env."""
+        root_env = tmp_path / ".env"
+        _write_env(root_env, "OPENAI_API_KEY", "sk-root-VALID")
+
+        # Simulate a dead key already present in os.environ (first-import-wins scenario)
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-dead-STALE")
+
+        with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path):
+            EnvironmentManager()
+
+        assert os.environ.get("OPENAI_API_KEY") == "sk-root-VALID", (
+            "Root .env should have overridden the stale value via override=True"
+        )
+
+    def test_dotenv_path_points_to_root_env(self, tmp_path: Path) -> None:
+        """dotenv_path attribute must reflect the root .env location."""
+        root_env = tmp_path / ".env"
+        root_env.write_text("DUMMY=1\n", encoding="utf-8")
+
+        with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path):
+            mgr = EnvironmentManager()
+
+        assert mgr.dotenv_path == str(root_env)
+        assert mgr.dotenv_loaded is True
+
+
+class TestDotenvDivergenceWarning:
+    """Secondary .env divergence detection."""
+
+    def test_warning_emitted_on_key_divergence(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """WARNING must be logged when secondary .env carries a different OPENAI_API_KEY."""
+        root_env = tmp_path / ".env"
+        _write_env(root_env, "OPENAI_API_KEY", "sk-root-AAAA")
+
+        secondary_dir = tmp_path / "argumentation_analysis"
+        secondary_dir.mkdir()
+        _write_env(secondary_dir / ".env", "OPENAI_API_KEY", "sk-dead-ZZZZ")
+
+        with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path), \
+             patch.object(_em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]):
+            with caplog.at_level(
+                logging.WARNING, logger="project_core.managers.environment_manager"
+            ):
+                EnvironmentManager()
+
+        assert any(
+            "divergence" in record.message
+            for record in caplog.records
+        ), "Expected a WARNING containing 'divergence' for mismatched keys"
+
+    def test_no_warning_when_keys_identical(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No WARNING should be emitted when secondary .env key matches root."""
+        root_env = tmp_path / ".env"
+        _write_env(root_env, "OPENAI_API_KEY", "sk-same-BBBB")
+
+        secondary_dir = tmp_path / "argumentation_analysis"
+        secondary_dir.mkdir()
+        _write_env(secondary_dir / ".env", "OPENAI_API_KEY", "sk-same-BBBB")
+
+        with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path), \
+             patch.object(_em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]):
+            with caplog.at_level(
+                logging.WARNING, logger="project_core.managers.environment_manager"
+            ):
+                EnvironmentManager()
+
+        assert not any(
+            "divergence" in record.message
+            for record in caplog.records
+        ), "No WARNING should be emitted when secondary key matches root"
+
+    def test_warning_masks_key_values(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """WARNING log must not contain the full key — only masked prefix/suffix."""
+        root_env = tmp_path / ".env"
+        _write_env(root_env, "OPENAI_API_KEY", "sk-proj-LONGROOT12345")
+
+        secondary_dir = tmp_path / "argumentation_analysis"
+        secondary_dir.mkdir()
+        _write_env(secondary_dir / ".env", "OPENAI_API_KEY", "sk-proj-LONGSECONDARY9")
+
+        with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path), \
+             patch.object(_em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]):
+            with caplog.at_level(
+                logging.WARNING, logger="project_core.managers.environment_manager"
+            ):
+                EnvironmentManager()
+
+        for record in caplog.records:
+            assert "LONGROOT12345" not in record.message, "Full root key must not appear in log"
+            assert "LONGSECONDARY9" not in record.message, "Full secondary key must not appear in log"
+
+    def test_no_warning_when_secondary_absent(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """No WARNING when secondary .env does not exist."""
+        root_env = tmp_path / ".env"
+        _write_env(root_env, "OPENAI_API_KEY", "sk-root-CCCC")
+
+        with patch.object(_em_mod, "_find_repo_root", return_value=tmp_path), \
+             patch.object(_em_mod, "_SECONDARY_ENV_RELPATHS", ["argumentation_analysis/.env"]):
+            with caplog.at_level(
+                logging.WARNING, logger="project_core.managers.environment_manager"
+            ):
+                EnvironmentManager()
+
+        assert not any(
+            "divergence" in record.message
+            for record in caplog.records
+        ), "No WARNING when there is no secondary .env to diverge from"


### PR DESCRIPTION
## Problem

The project has 3 `.env` files with **different** `OPENAI_API_KEY` values:
- `./env` (root) → valid key `sk-proj-bxha...PEgA`
- `argumentation_analysis/.env` + `config/.env` → dead key `sk-proj-dMc...XSAA` (causes 401)

`EnvironmentManager` used `find_dotenv()` with `override=False`, so whichever sub-`.env` was first-imported by the process won, silently pinning the dead key → silent 401 on all LLM call-sites.

## Fix

**`project_core/managers/environment_manager.py`** — three changes:

1. **Deterministic root detection** via `pyproject.toml` sentinel (walks up from `__file__`).
2. **Load root `.env` with `override=True`** — root always wins, regardless of any prior env var state.
3. **Divergence detection** — secondary `.env` files are parsed (never loaded) and a `WARNING` is emitted when their `OPENAI_API_KEY` differs from the root value. Keys are masked (`sk-proj-xxxx...YYYY`) — no secret in logs.

Secondary `.env` files are NOT deleted or rewritten (anti-pendule: they may serve other local services).

## Tests

6 new tests in `tests/unit/project_core/managers/test_dotenv_loading.py`:
- `test_root_env_overrides_pre_existing_env_var` — override=True proof
- `test_dotenv_path_points_to_root_env` — attribute reflects root .env path
- `test_warning_emitted_on_key_divergence` — divergence WARNING on mismatch
- `test_no_warning_when_keys_identical` — no noise when keys match
- `test_warning_masks_key_values` — full key never appears in log
- `test_no_warning_when_secondary_absent` — no spurious WARNING

## Validation

```
mypy project_core/managers/environment_manager.py --strict  → no issues
pytest tests/unit/project_core/managers/test_dotenv_loading.py -v -s → 6/6 PASSED
```

## Anti-pendule checklist (#1019)

- [x] Does NOT delete sub-.env files
- [x] Does NOT fail-HARD on single key (only warns on divergence)
- [x] Does NOT touch pythonpath
- [x] Fail-loud via WARNING (not silent fallback, not hard crash)
- [x] No key values in logs (masked)

Closes #1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>