### PR TITLE
fix(restitution): #1276 Acte III jargon-leak guardrail (follow-up #1297)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -897,8 +897,11 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
     gv = evidence.governance_verdict
     if gv is not None:
         deliberation_lines.append(
-            f"  - GOUVERNANCE : méthode « {gv.method} » — l'option {gv.winner} "
-            "sort gagnante du vote social-choice. (options opaques, FB-34.)"
+            f"  - GOUVERNANCE : sous la méthode interne « {gv.method} », l'option "
+            f"d'identifiant interne « {gv.winner} » sort gagnante du vote "
+            "social-choice. DÉCRIS-la par son rôle dans la prose (p.ex. "
+            "« l'argument arrivé en tête »), ne recopie PAS l'identifiant "
+            "technique brut ni le nom de méthode snake_case. (options opaques, FB-34.)"
         )
     if evidence.debate_exchanges:
         for i, ex in enumerate(evidence.debate_exchanges, start=1):
@@ -965,6 +968,14 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         "  au service du jugement du lecteur, jamais en sous-section isolée.\n"
         "- Respecte STRICTEMENT le plafond de claim de la bande : ne formule rien\n"
         "  au-delà de ce qu'elle autorise.\n"
+        "- JARGON INTERNE INTERDIT dans la prose : ne recopie JAMAIS un\n"
+        "  identifiant technique brut — token snake_case (agent_1, social_choice,\n"
+        "  modal_kb…), nom d'agent numéroté, ou nom de méthode/modèle interne.\n"
+        "  Ils sont opaques pour le lecteur non-technicien à qui ce récit\n"
+        "  s'adresse. Décris-les par leur RÔLE en français courant (« l'argument\n"
+        "  arrivé en tête », « la méthode de vote employée »). L'opacité des\n"
+        "  sources (FB-34) reste préservée : décrire par rôle ne\n"
+        "  déanonymise aucune source.\n"
         "- La conclusion doit VARIER selon le contenu réel ci-dessus : pas de\n"
         "  prose générique recyclable.\n"
         "- Rédige en français, markdown léger. 300-600 mots selon la richesse.\n"

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -302,6 +302,37 @@ class TestBuildEvidence:
         assert "DÉLIBÉRATION COLLECTIVE" in prompt
         assert "opt_X" in prompt
 
+    def test_governance_jargon_leak_guarded(self):
+        """Regression for po-2023 finding R487 (Acte III half) — the conclusion
+        prose leaked raw internal identifiers (« agent_1 » / « social_choice »).
+
+        The Acte III prompt mirrors the Acte II guardrail: the governance data
+        line must flag its identifiers as INTERNAL and instruct a role-based
+        description, and the CONSIGNE must carry the general anti-jargon
+        guardrail. (Without this fix the Acte III leak survived the Acte II-only
+        fix — surfaced by the R488 validation re-run.) FB-34 source-opacity is
+        orthogonal — describing by role deanonymises nothing.
+        """
+        state = _state(
+            governance_decisions=[
+                {
+                    "method": "social_choice",
+                    "winner": "agent_1",
+                    "scores": {"agent_1": 0.9},
+                }
+            ],
+        )
+        ev = build_act3_evidence(state)
+        prompt = build_act3_prompt(ev)
+        # Data line flags the id as internal and instructs role-based prose.
+        assert "identifiant interne" in prompt.lower()
+        assert "rôle" in prompt.lower()
+        # CONSIGNE carries the general anti-jargon guardrail.
+        assert "JARGON INTERNE INTERDIT" in prompt
+        assert "snake_case" in prompt
+        # FB-34 source-opacity explicitly preserved.
+        assert "déanonymise aucune source" in prompt.lower()
+
     def test_debate_scheme_grounding_g8(self):
         """G8 (#1184): a scheme-grounded exchange surfaces scheme + CQ.
 


### PR DESCRIPTION
## Contexte

Follow-up de #1297 (mergé `c0e8c67f`). Le **re-run capstone de validation** end-to-end demandé après #1297 a révélé que le fix du **Finding C** (jargon interne) du worker po-2023 ne couvrait que **Acte II** (`build_act2_prompt`). **Acte III** (`build_act3_prompt`) injectait encore la data-line gouvernance brute (`gv.winner`/`gv.method` en `snake_case`) sans consigne anti-jargon.

C'est un **risque latent non-déterministe** : le run Opus de validation a décrit la gouvernance par son rôle de lui-même (renders 3/3 propres), mais un autre modèle / une autre température pourrait recopier l'identifiant technique brut dans la prose lecteur.

## Fix (prompt-layer, anti-pendule #1019 — suppression du risque)

`act3_conclusion_plugin.py` :
- data-line gouvernance relabelée « méthode interne » / « identifiant interne » + instruction explicite « **DÉCRIS-la par son rôle** (p.ex. « l'argument arrivé en tête »), ne recopie PAS l'identifiant `snake_case` brut »
- CONSIGNE : ajout de la puce « **JARGON INTERNE INTERDIT** » ; opacité des sources (FB-34) préservée — décrire par rôle ne déanonymise aucune source
- Acte III n'a **PAS** le bug Tweety-priming d'Acte II (son instruction de verdict est équilibrée consistante/inconsistante) → **seul** le fix jargon est requis ici

## Validation

- `test_governance_jargon_leak_guarded` (classe `TestBuildEvidence`) — assertions : `identifiant interne`, `rôle`, `JARGON INTERNE INTERDIT`, `snake_case`, opacité sources préservée
- **4 passed**, mypy strict clean
- **End-to-end** : renders R488 des 3 corpora capstone — 0 leak jargon, prose gouvernance par rôle, (in)consistance cohérente avec l'annexe tri-state

## Files changed

| File | Type | Reason |
|---|---|---|
| `argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py` | other (prompt builder) | guardrail anti-jargon Acte III (parité avec Acte II #1297) |
| `tests/unit/.../test_act3_conclusion_plugin.py` | test | régression `test_governance_jargon_leak_guarded` |

Refs #1276 #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)