### PR TITLE
fix(restitution): #1276 appendix surfaces modal/PL formal verdicts

### DIFF
--- a/argumentation_analysis/reporting/restitution/appendix.py
+++ b/argumentation_analysis/reporting/restitution/appendix.py
@@ -105,6 +105,94 @@ def _fol_axis_status(fol: Any) -> Any:
     return "indisponible"
 
 
+def _modal_axis_status(modal: Any) -> Any:
+    """Coarse Modal-axis status, mirroring :func:`_fol_axis_status`.
+
+    #1276 (po-2023 R487): the appendix reduced the modal axis to a bare
+    "disponible"/"indisponible" presence flag, so a genuinely *decided* modal
+    axis (``valid=True`` via SPASS — capstone 3/3) was under-reported as merely
+    "available", hiding formal work actually done while ``axe_fol`` surfaced its
+    verdict richly. Surface the real tri-state verdict instead. ``valid`` is
+    tri-state (True/False/None) — never collapse None→False (#1019/#1279). State
+    stores modal results either as a per-belief-set *list* (capstone shape, the
+    shape Acte II reads) or as an external-solver *Mapping* (SPASS path,
+    state_writers ``external_valid``); both are read here. ``valid=True`` =
+    consistante (aligned with Acte II's reader).
+    """
+    if isinstance(modal, Mapping):
+        v = modal.get("external_valid", modal.get("valid"))
+        if v is True or v is False:
+            return {"verdict": "décidé", "consistante": v}
+        if v is None and ("external_valid" in modal or "external_degraded" in modal):
+            return "indisponible (aucun verdict décidé — dégradé)"
+        return "disponible" if modal else "indisponible"
+    if isinstance(modal, list) and modal:
+        decided = [
+            r for r in modal if isinstance(r, dict) and r.get("valid") in (True, False)
+        ]
+        degraded = [
+            r for r in modal if isinstance(r, dict) and r.get("valid") is None
+        ]
+        if decided:
+            status: Dict[str, Any] = {
+                "verdict": "décidé",
+                "consistantes": sum(1 for r in decided if r.get("valid") is True),
+                "inconsistantes": sum(1 for r in decided if r.get("valid") is False),
+                "verifiees": len(decided),
+            }
+            if degraded:
+                status["degradees"] = len(degraded)
+            return status
+        return "indisponible (aucun verdict décidé — dégradé)"
+    return "indisponible"
+
+
+def _pl_verdict_of(result: Any) -> Optional[bool]:
+    """Strict PL satisfiability verdict, or ``None`` when unverified (#1019).
+
+    Canonical key is ``satisfiable`` (#1151 Finding C), with ``consistent`` as
+    the legacy fallback. ``None`` (unverified) is never collapsed to ``False``.
+    """
+    if not isinstance(result, dict):
+        return None
+    sat = result.get("satisfiable")
+    if sat is None:
+        sat = result.get("consistent")
+    return sat if isinstance(sat, bool) else None
+
+
+def _pl_axis_status(pl: Any) -> Any:
+    """Coarse PL-axis status, mirroring :func:`_fol_axis_status`.
+
+    #1276 (po-2023 R487): same under-reporting as the modal axis — a decided PL
+    axis (PySAT) was flattened to "disponible". Surface the satisfiability
+    verdict tri-state instead. ``satisfiable``/``consistent`` is tri-state;
+    ``None`` (unverified) is never collapsed to ``False`` (#1019).
+    """
+    if isinstance(pl, Mapping):
+        v = _pl_verdict_of(pl)
+        if v is True or v is False:
+            return {"verdict": "décidé", "satisfiable": v}
+        return "disponible" if pl else "indisponible"
+    if isinstance(pl, list) and pl:
+        decided = [r for r in pl if _pl_verdict_of(r) in (True, False)]
+        degraded = [
+            r for r in pl if isinstance(r, dict) and _pl_verdict_of(r) is None
+        ]
+        if decided:
+            status: Dict[str, Any] = {
+                "verdict": "décidé",
+                "satisfiables": sum(1 for r in decided if _pl_verdict_of(r) is True),
+                "insatisfiables": sum(1 for r in decided if _pl_verdict_of(r) is False),
+                "verifiees": len(decided),
+            }
+            if degraded:
+                status["degradees"] = len(degraded)
+            return status
+        return "indisponible (aucun verdict décidé — dégradé)"
+    return "indisponible"
+
+
 def _provenance_counts(state: Mapping[str, Any]) -> Dict[str, Any]:
     """Honest provenance summary: counts + verdict flags, no corpus content.
 
@@ -125,12 +213,8 @@ def _provenance_counts(state: Mapping[str, Any]) -> Dict[str, Any]:
 
     # formal axes — report presence + a coarse status, not the raw belief sets
     counts["axe_fol"] = _fol_axis_status(_g("fol_analysis_results"))
-    counts["axe_pl"] = (
-        "disponible" if _g("propositional_analysis_results") else "indisponible"
-    )
-    counts["axe_modale"] = (
-        "disponible" if _g("modal_analysis_results") else "indisponible"
-    )
+    counts["axe_pl"] = _pl_axis_status(_g("propositional_analysis_results"))
+    counts["axe_modale"] = _modal_axis_status(_g("modal_analysis_results"))
     counts["axe_dung"] = "disponible" if _g("dung_frameworks") else "indisponible"
     counts["axe_aspic"] = "disponible" if _g("aspic_results") else "indisponible"
 

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_appendix.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_appendix.py
@@ -11,6 +11,8 @@ import json
 
 from argumentation_analysis.reporting.restitution.appendix import (
     _fol_axis_status,
+    _modal_axis_status,
+    _pl_axis_status,
     _provenance_counts,
     _strip_leak_keys,
     render_appendix,
@@ -144,6 +146,86 @@ class TestFolAxisStatusListShape:
         # Back-compat: the old Mapping shape still produces the old summary.
         status = _fol_axis_status({"consistent": True, "formulas": ["a", "b"]})
         assert status == {"consistent": True, "formules": 2}
+
+
+class TestModalAxisStatus:
+    """#1276 (po-2023 R487): the modal axis was reduced to a binary presence flag
+    even when SPASS decided ``valid=True`` (capstone 3/3). The appendix must
+    surface the real tri-state verdict (decided / degraded / unavailable),
+    mirroring ``axe_fol`` — never collapse None→False (#1019/#1279).
+    """
+
+    def test_list_decided_surfaces_verdict(self):
+        # capstone shape: a decided modal theory (valid=True via SPASS)
+        modal = [{"valid": True, "message": None}]
+        status = _modal_axis_status(modal)
+        assert status["verdict"] == "décidé"
+        assert status["consistantes"] == 1
+        assert status["inconsistantes"] == 0
+        assert status["verifiees"] == 1
+        assert "degradees" not in status
+
+    def test_list_mixed_decided_and_degraded_surfaces_degradees(self):
+        modal = [
+            {"valid": True, "message": None},
+            {"valid": None, "message": "unavailable:no-translation"},
+        ]
+        status = _modal_axis_status(modal)
+        assert status["verifiees"] == 1
+        assert status["degradees"] == 1  # the degraded theory is visible, not dropped
+
+    def test_list_degraded_only_is_honest_unavailable(self):
+        # ran but could not decide — NOT a bare "indisponible" (axis never ran)
+        modal = [{"valid": None, "message": "unavailable:no-solver"}]
+        assert _modal_axis_status(modal) == "indisponible (aucun verdict décidé — dégradé)"
+
+    def test_external_solver_mapping_shape(self):
+        # SPASS external-solver path (state_writers external_valid)
+        status = _modal_axis_status({"external_solver": "spass", "external_valid": True})
+        assert status == {"verdict": "décidé", "consistante": True}
+
+    def test_empty_and_none_are_indisponible(self):
+        assert _modal_axis_status([]) == "indisponible"
+        assert _modal_axis_status(None) == "indisponible"
+
+
+class TestPlAxisStatus:
+    """#1276 (po-2023 R487): the PL axis was flattened to "disponible" even when
+    PySAT decided satisfiability. Surface the verdict tri-state, mirroring
+    ``axe_fol``. Canonical key ``satisfiable`` (#1151), legacy ``consistent``.
+    """
+
+    def test_list_decided_surfaces_verdict(self):
+        pl = [
+            {"satisfiable": True},
+            {"satisfiable": False},
+        ]
+        status = _pl_axis_status(pl)
+        assert status["verdict"] == "décidé"
+        assert status["satisfiables"] == 1
+        assert status["insatisfiables"] == 1
+        assert status["verifiees"] == 2
+        assert "degradees" not in status
+
+    def test_legacy_consistent_key_fallback(self):
+        pl = [{"consistent": True}]
+        status = _pl_axis_status(pl)
+        assert status["satisfiables"] == 1
+
+    def test_list_mixed_decided_and_degraded(self):
+        pl = [{"satisfiable": True}, {"satisfiable": None}]
+        status = _pl_axis_status(pl)
+        assert status["verifiees"] == 1
+        assert status["degradees"] == 1
+
+    def test_mapping_without_verdict_stays_disponible(self):
+        # back-compat: a non-empty mapping with no parseable verdict is still
+        # honestly "disponible" (data present), not a fabricated verdict
+        assert _pl_axis_status({"something": 1}) == "disponible"
+
+    def test_empty_and_none_are_indisponible(self):
+        assert _pl_axis_status([]) == "indisponible"
+        assert _pl_axis_status(None) == "indisponible"
 
 
 class TestLeakStripping:


### PR DESCRIPTION
## Context

Closes a deferred finding from the Epic #1276 (restitution honesty) 360° review: **the dimensional appendix under-reported the modal and PL formal axes.** While `axe_fol` surfaced a rich tri-state verdict (decided counts / degraded entries / honest "indisponible"), `axe_modale` and `axe_pl` were reduced to a binary `"disponible"`/`"indisponible"` *presence* flag — so a genuinely **decided** modal axis (`valid=True` via SPASS, capstone 3/3) read as merely "available", hiding the formal work actually performed.

## Fix

Deterministic appendix layer only — **not** the LLM prose (no over-templating / anti-pendule #1019 risk; the prose-citation half of the finding stays deferred by design). Mirrors the existing `_fol_axis_status`:

- **`_modal_axis_status`** — tri-state from the `valid` key (True/False/None). Handles both the per-belief-set **list** shape and the **external-solver Mapping** (SPASS `external_valid`). Never collapses `None`→`False` (#1019/#1279); degraded entries surfaced as `degradees`, kept out of decided counts.
- **`_pl_axis_status`** + `_pl_verdict_of` — same, from canonical `satisfiable` (#1151) with `consistent` legacy fallback.
- `axe_pl` / `axe_modale` wired to the new status functions.

## End-to-end proof (real capstone snapshots — verdict counts only, no corpus content)

| corpus | `axe_modale` before → after | `axe_pl` before → after |
|--------|------------------------------|--------------------------|
| corpus_A | disponible → **décidé, consistantes:1** | disponible → **décidé, satisfiables:3** |
| corpus_B | disponible → **décidé, consistantes:1** | disponible → **décidé, satisfiables:2, insatisfiables:1** |
| corpus_C | disponible → **décidé, consistantes:1** | disponible → **décidé, satisfiables:3** |

corpus_B's `insatisfiables:1` is a real PL inconsistency that the old flat "disponible" flag completely hid.

## Tests

- `TestModalAxisStatus` (5) + `TestPlAxisStatus` (5) — list decided / mixed decided+degraded / degraded-only honest-unavailable / external-solver mapping / empty-None.
- Existing `TestProvenanceCounts` unchanged (its synthetic Mapping inputs still produce "disponible"/"indisponible" by design).
- **23 passed**, **mypy strict clean**.

Refs #1276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)