### PR TITLE
fix(test): cross_reference_graph mock — correct fallacy key (target_arg_id → target_argument_id)

### DIFF
--- a/tests/unit/argumentation_analysis/reporting/test_cross_reference_graph.py
+++ b/tests/unit/argumentation_analysis/reporting/test_cross_reference_graph.py
@@ -21,8 +21,8 @@ def _make_mock_state():
         "arg_2": {"text": "Third argument about health"},
     }
     state.identified_fallacies = {
-        "fal_0": {"fallacy_type": "ad_hominem", "target_arg_id": "arg_0"},
-        "fal_1": {"fallacy_type": "straw_man", "target_arg_id": "arg_1"},
+        "fal_0": {"fallacy_type": "ad_hominem", "target_argument_id": "arg_0"},
+        "fal_1": {"fallacy_type": "straw_man", "target_argument_id": "arg_1"},
     }
     state.jtms_beliefs = {
         "jtms_0": {"name": "climate_is_real", "valid": True, "justifications": []},


### PR DESCRIPTION
## Problem

`test_builds_edges_for_all_types` was failing because `_make_mock_state()` used `"target_arg_id"` as the dict key for the fallacy target, while `build_from_state()` checks for `"target_argument_id"` (the canonical schema key). The key mismatch meant the `ARGUMENT_FALLACY` edge was never created, causing the assertion to fail.

## Root cause

Key inconsistency in the test fixture — not in production code. The canonical schema is `"target_argument_id"` everywhere:
- `shared_state.py:43` — field documented as `target_argument_id?` in the fallacy dict
- `deep_synthesis_agent.py:420` — reads `fdata.get("target_argument_id")`
- `rhetorical_result_visualizer.py:100` — reads `fallacy.get("target_argument_id")`
- `cross_reference_graph.py:177` — checks `"target_argument_id" in f_data`

## Fix

`_make_mock_state()` in `test_cross_reference_graph.py`: `"target_arg_id"` → `"target_argument_id"` (2 occurrences).

## Validation

17/17 tests pass (was 16 passed, 1 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)