### PR TITLE
docs(readme): fix Quick Start path drift + drop non-existent setup_project_env.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ cp .env.example .env
 
 # 3. Activate and test
 conda activate projet-is-roo-new
-python examples/scripts_demonstration/demonstration_epita.py --quick-start
+python examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py --quick-start
 ```
 
-Linux/macOS: use `setup_project_env.sh` instead.
+Linux/macOS: no `setup_project_env.sh` is provided — create the Conda env manually (`conda create -n projet-is-roo-new python=3.10`, then `pip install -r requirements.txt`) or adapt the `.ps1` script.
 
 ## Repository Map
 


### PR DESCRIPTION
## Context

README Quick Start (last touched 2026-05-11) had two verified drifts versus the current filesystem. A new user following the Quick Start verbatim hit `FileNotFoundError`.

## Drifts fixed

Both confirmed by path existence check (`[ -e path ]`):

1. **Quick Start demo path** (line 19): `examples/scripts_demonstration/demonstration_epita.py` → **`examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py`**. The `02_core_system_demos/` parent was added during the examples reorg but the README was not updated.
2. **`setup_project_env.sh`** (line 22): the README told Linux/macOS users to run `setup_project_env.sh`, but **only `setup_project_env.ps1` ships** (no `.sh` exists). Replaced with honest manual Conda steps rather than inventing a script (anti-pendule: subtract the false claim, don't fabricate a replacement).

## What was NOT changed

- All other README paths verified present (repo map, entry points, key components, student-project links, `tests/unit/api`, `tests/e2e`).
- Pre-existing markdown-lint warning (MD032 line 77) left untouched — out of scope, README is not CI-linted.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (running under GLM-5.2)