### PR TITLE
docs(technical): mark test_failure_analysis.md as historical snapshot

### DIFF
--- a/docs/technical/test_failure_analysis.md
+++ b/docs/technical/test_failure_analysis.md
@@ -1,5 +1,12 @@
 # Rapport d'Analyse des Échecs de Tests `pytest`
 
+> ⚠️ **Historical snapshot — 2025-07-23.** This captured the test-suite state right after the
+> `jpype`/`opentelemetry` JVM-crash workaround (Total: 2433 tests, 135 failed). The suite has
+> since grown to 14000+ collected tests and the failure profile has changed entirely. Kept for
+> provenance, **not** as a description of the present test status. For current test statistics
+> see `KNOWN_ISSUES.md` (Test Statistics); for the still-active OpenTelemetry workaround see
+> `tests/conftest.py` and `opentelemetry_workaround.md`.
+
 Ce document présente une analyse détaillée des résultats de la suite de tests exécutée après avoir contourné le crash fatal de la JVM.
 
 ## 1. Résumé Quantitatif


### PR DESCRIPTION
## Summary

Marks `docs/technical/test_failure_analysis.md` (2025-07-23) as a **historical snapshot**. The report captured the test-suite state right after the `jpype`/`opentelemetry` JVM-crash workaround (Total: **2433 tests, 135 failed**). The suite has since grown to **14000+ collected tests** with a completely different failure profile, so the numbers describe a past state. A reader landing on the doc could mistake it for current status.

## Change

Adds a "Historical snapshot" header (after the H1) pointing to present sources:
- `KNOWN_ISSUES.md` (Test Statistics) for current numbers
- `tests/conftest.py` + `opentelemetry_workaround.md` for the **still-active** OpenTelemetry workaround

## Why mark, not delete (anti-pendule + Cleanup Gate)

The doc is kept for provenance — the post-workaround failure breakdown remains useful historical context. Deleting it would violate the Cleanup Gate ("design docs kept being silently deleted as cleanup"). Marking adds clarity without losing anything, and is reversible.

## Isolation verified

Only external references to this doc are in `docs/archives/` (already archived). No canonical doc references it — safe to mark without cascade.

## Scope

This PR is intentionally focal. The interconnected `docs/architecture/` 2025-06 analysis set (`current_state_analysis.md`, `reorganization_proposal.md`, etc. — referenced 7–18× by each other) needs a broader coherent audit and is left for a separate pass.

## Validation

Docs-only, no code change. No tests/mypy affected.

**No self-merge** — per mandate, awaits coordinator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
