### PR TITLE
fix(docs): correct systemic 'argumentiation' typo across docs + 5 maintenance scripts

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -20,7 +20,7 @@ Le fichier `pytest.ini` définit les paramètres par défaut pour l'exécution d
 pytest
 
 # Exécuter les tests avec des options supplémentaires
-pytest -v --cov=argumentiation_analysis
+pytest -v --cov=argumentation_analysis
 ```
 
 ### Dépendances de Test

--- a/docs/guides/guide_developpeur.md
+++ b/docs/guides/guide_developpeur.md
@@ -404,8 +404,8 @@ middleware.add_routing_rule(
 Voici un exemple complet de création d'un nouveau canal de communication pour la gestion des alertes :
 
 ```python
-from argumentiation_analysis.core.communication.channel_interface import Channel
-from argumentiation_analysis.core.communication.message import MessagePriority
+from argumentation_analysis.core.communication.channel_interface import Channel
+from argumentation_analysis.core.communication.message import MessagePriority
 import threading
 import time
 import logging
@@ -841,7 +841,7 @@ Voici un exemple complet de création d'un nouvel adaptateur pour un agent de vi
 
 ```python
 from argumentation_analysis.core.communication.message import Message, MessageType, MessagePriority, AgentLevel # Assurez-vous que Message est importé si utilisé dans l'exemple VisualizationAdapter
-from argumentiation_analysis.core.communication.message import MessageType, MessagePriority, AgentLevel
+from argumentation_analysis.core.communication.message import MessageType, MessagePriority, AgentLevel
 import logging
 
 class VisualizationAdapter:
@@ -1635,8 +1635,8 @@ Voici un exemple complet de création d'un nouveau protocole de communication po
 
 ```python
 # Note: L'import de ProtocolInterface est supprimé car elle n'existe pas.
-# from argumentiation_analysis.core.communication.protocol_interface import ProtocolInterface
-from argumentiation_analysis.core.communication.message import MessageType, Message
+# from argumentation_analysis.core.communication.protocol_interface import ProtocolInterface
+from argumentation_analysis.core.communication.message import MessageType, Message
 import threading
 import time
 import uuid

--- a/docs/guides/tutorials/01_getting_started/01_introduction.md
+++ b/docs/guides/tutorials/01_getting_started/01_introduction.md
@@ -9,13 +9,13 @@ Apprendre à installer, configurer et exécuter une analyse rhétorique de base
 
 ## Installation
 ```bash
-cd argumentiation_analysis
+cd argumentation_analysis
 pip install -r requirements.txt
 ```
 
 ## Structure du projet
 ```
-argumentiation_analysis/
+argumentation_analysis/
 ├── orchestration/
 │   └── hierarchical/  # Architecture à trois niveaux
 ├── agents/            # Agents spécialisés
@@ -27,7 +27,7 @@ argumentiation_analysis/
 
 ## Premier exemple d'analyse
 ```python
-from argumentiation_analysis.examples.run_hierarchical_orchestration import HierarchicalOrchestrator
+from argumentation_analysis.examples.run_hierarchical_orchestration import HierarchicalOrchestrator
 
 async def main():
     orchestrator = HierarchicalOrchestrator()

--- a/docs/guides/tutorials/01_getting_started/02_simple_analysis.md
+++ b/docs/guides/tutorials/01_getting_started/02_simple_analysis.md
@@ -19,7 +19,7 @@ texte = """
 
 ## Configuration de l'analyse
 ```python
-from argumentiation_analysis.orchestration.hierarchical.strategic.planner import StrategicPlanner
+from argumentation_analysis.orchestration.hierarchical.strategic.planner import StrategicPlanner
 
 config = {
     "objectives": [
@@ -41,7 +41,7 @@ planner = StrategicPlanner(config)
 
 ## Exécution de l'analyse
 ```python
-from argumentiation_analysis.examples.run_hierarchical_orchestration import HierarchicalOrchestrator
+from argumentation_analysis.examples.run_hierarchical_orchestration import HierarchicalOrchestrator
 
 async def main():
     orchestrator = HierarchicalOrchestrator()

--- a/docs/guides/tutorials/01_getting_started/03_complex_analysis.md
+++ b/docs/guides/tutorials/01_getting_started/03_complex_analysis.md
@@ -11,8 +11,8 @@ Apprendre à analyser des discours avec structures imbriquées, arguments multip
 
 ## Configuration avancée
 ```python
-from argumentiation_analysis.orchestration.hierarchical.strategic.planner import StrategicPlanner
-from argumentiation_analysis.orchestration.hierarchical.tactical.resolver import TacticalResolver
+from argumentation_analysis.orchestration.hierarchical.strategic.planner import StrategicPlanner
+from argumentation_analysis.orchestration.hierarchical.tactical.resolver import TacticalResolver
 
 config = {
     "objectives": [
@@ -43,8 +43,8 @@ resolver = TacticalResolver(planner)
 
 ## Utilisation des outils spécialisés
 ```python
-from argumentiation_analysis.utils.taxonomy_loader import load_fallacy_taxonomy
-from argumentiation_analysis.services.definition_service import DefinitionService
+from argumentation_analysis.utils.taxonomy_loader import load_fallacy_taxonomy
+from argumentation_analysis.services.definition_service import DefinitionService
 
 async def analyze_complex_discourse(text):
     # Initialisation des services

--- a/docs/guides/tutorials/02_extending_the_system/01_adding_an_agent.md
+++ b/docs/guides/tutorials/02_extending_the_system/01_adding_an_agent.md
@@ -22,7 +22,7 @@ class BaseAgent:
 ## Implémentation d'un agent de détection de biais
 ```python
 # agents/bias_detector_agent.py
-from argumentiation_analysis.orchestration.hierarchical.operational.adapters.base_agent import BaseAgent
+from argumentation_analysis.orchestration.hierarchical.operational.adapters.base_agent import BaseAgent
 
 class BiasDetectorAgent(BaseAgent):
     def __init__(self, config):
@@ -55,7 +55,7 @@ class BiasDetectorAgent(BaseAgent):
 ## Intégration dans le système
 ```python
 # Mise à jour du registre d'agents
-from argumentiation_analysis.orchestration.hierarchical.strategic.planner import register_agent
+from argumentation_analysis.orchestration.hierarchical.strategic.planner import register_agent
 
 register_agent("bias_detector", BiasDetectorAgent)
 

--- a/docs/guides/tutorials/02_extending_the_system/02_extending_tools.md
+++ b/docs/guides/tutorials/02_extending_the_system/02_extending_tools.md
@@ -6,7 +6,7 @@ Apprendre à étendre les fonctionnalités des outils d'analyse existants pour a
 ## Identification des besoins
 ```python
 # Analyse des limitations actuelles
-from argumentiation_analysis.tests.tools.test_rhetorical_tools_integration import analyze_tool_coverage
+from argumentation_analysis.tests.tools.test_rhetorical_tools_integration import analyze_tool_coverage
 
 coverage_report = analyze_tool_coverage()
 print(f"Couverture actuelle: {coverage_report['coverage_percent']:.1f}%")
@@ -54,7 +54,7 @@ class ContextualFallacyAnalyzer:
 ## Implémentation et intégration
 ```python
 # Intégration dans le pipeline d'analyse
-from argumentiation_analysis.orchestration.hierarchical.tactical.resolver import TacticalResolver
+from argumentation_analysis.orchestration.hierarchical.tactical.resolver import TacticalResolver
 
 class EnhancedResolver(TacticalResolver):
     def __init__(self):
@@ -76,7 +76,7 @@ class EnhancedResolver(TacticalResolver):
 ```python
 # Tests de performance et de précision
 import time
-from argumentiation_analysis.tests.tools.test_rhetorical_tools_performance import run_benchmark
+from argumentation_analysis.tests.tools.test_rhetorical_tools_performance import run_benchmark
 
 def evaluate_extension():
     # Mesure des performances

--- a/docs/integration/README_cleanup_obsolete_files.md
+++ b/docs/integration/README_cleanup_obsolete_files.md
@@ -17,14 +17,14 @@ Suite à la refactorisation du code et à la migration des fonctionnalités vers
 Les fichiers obsolètes identifiés sont :
 
 1. Scripts d'extraction refactorisés :
-   - `argumentiation_analysis/utils/extract_repair/repair_extract_markers.py`
-   - `argumentiation_analysis/utils/extract_repair/verify_extracts.py`
-   - `argumentiation_analysis/utils/extract_repair/fix_missing_first_letter.py`
-   - `argumentiation_analysis/utils/extract_repair/verify_extracts_with_llm.py`
-   - `argumentiation_analysis/utils/extract_repair/repair_extract_markers.ipynb`
+   - `argumentation_analysis/utils/extract_repair/repair_extract_markers.py`
+   - `argumentation_analysis/utils/extract_repair/verify_extracts.py`
+   - `argumentation_analysis/utils/extract_repair/fix_missing_first_letter.py`
+   - `argumentation_analysis/utils/extract_repair/verify_extracts_with_llm.py`
+   - `argumentation_analysis/utils/extract_repair/repair_extract_markers.ipynb`
 
 2. Utilitaires remplacés par des services :
-   - `argumentiation_analysis/ui/extract_utils.py`
+   - `argumentation_analysis/ui/extract_utils.py`
 
 ## Utilisation
 
@@ -109,7 +109,7 @@ _archives/
   └── backup_YYYYMMDD_HHMMSS/
       ├── metadata.json
       ├── rapport_suppression_YYYYMMDD_HHMMSS.md
-      └── argumentiation_analysis/
+      └── argumentation_analysis/
           ├── ui/
           │   └── extract_utils.py
           └── utils/

--- a/docs/integration/integration_complete.md
+++ b/docs/integration/integration_complete.md
@@ -54,9 +54,9 @@ La fusion a ajouté plus de 150 fichiers au projet, principalement des composant
 
 2. **Utilisation des canaux de communication appropriés** : Choisir le type de canal adapté au besoin de communication entre agents. Consulter `docs/guide_developpeur_systeme_communication.md` pour des conseils détaillés.
 
-3. **Extension des outils d'analyse rhétorique** : Pour ajouter de nouveaux outils d'analyse, suivre les modèles existants dans `argumentiation_analysis/agents/tools/analysis/` et s'assurer de créer les tests correspondants.
+3. **Extension des outils d'analyse rhétorique** : Pour ajouter de nouveaux outils d'analyse, suivre les modèles existants dans `argumentation_analysis/agents/tools/analysis/` et s'assurer de créer les tests correspondants.
 
-4. **Tests d'intégration** : Lors de modifications importantes, exécuter les tests d'intégration pour s'assurer que tous les composants fonctionnent correctement ensemble. Les scripts de test se trouvent dans `argumentiation_analysis/tests/`.
+4. **Tests d'intégration** : Lors de modifications importantes, exécuter les tests d'intégration pour s'assurer que tous les composants fonctionnent correctement ensemble. Les scripts de test se trouvent dans `argumentation_analysis/tests/`.
 
 5. **Documentation** : Maintenir la documentation à jour lors de l'ajout ou de la modification de fonctionnalités. Suivre le format existant pour assurer la cohérence.
 

--- a/docs/integration/integration_outils_rhetorique.md
+++ b/docs/integration/integration_outils_rhetorique.md
@@ -13,10 +13,10 @@ graph TD
 ```
 
 ### Étapes d'Intégration
-1. **Installation** : `pip install argumentiation-analysis`
+1. **Installation** : `pip install argumentation-analysis`
 2. **Importation** : 
    ```python
-   from argumentiation_analysis import RhetoricalAnalysisSystem
+   from argumentation_analysis import RhetoricalAnalysisSystem
    ```
 3. **Configuration** :
    ```python
@@ -53,7 +53,7 @@ async def analyze_text(text: str):
 ## Gestion des Dépendances
 ```bash
 # Requirements.txt
-argumentiation-analysis>=1.2.0
+argumentation-analysis>=1.2.0
 mermaid>=10.3.0
 ```
 

--- a/docs/integration/liste_verification_deploiement.md
+++ b/docs/integration/liste_verification_deploiement.md
@@ -1,13 +1,13 @@
-# Liste de vérification pour le déploiement du projet "argumentiation_analysis"
+# Liste de vérification pour le déploiement du projet "argumentation_analysis"
 
 ## Introduction
 
-Ce document présente une liste de vérification complète pour s'assurer que le projet "argumentiation_analysis" est prêt à être déployé pour les étudiants de l'EPITA. Cette liste couvre tous les aspects essentiels du projet, de la structure aux dépendances, en passant par la documentation et les tests.
+Ce document présente une liste de vérification complète pour s'assurer que le projet "argumentation_analysis" est prêt à être déployé pour les étudiants de l'EPITA. Cette liste couvre tous les aspects essentiels du projet, de la structure aux dépendances, en passant par la documentation et les tests.
 
 ## 1. Vérification de la structure du projet
 
 - [ ] Vérifier que tous les dossiers principaux sont présents et correctement organisés :
-  - `argumentiation_analysis/` (dossier principal)
+  - `argumentation_analysis/` (dossier principal)
   - `agents/` (agents spécialistes)
   - `config/` (fichiers de configuration)
   - `core/` (composants fondamentaux)
@@ -35,12 +35,12 @@ Ce document présente une liste de vérification complète pour s'assurer que le
 
 - [ ] Exécuter tous les tests unitaires et vérifier qu'ils passent :
   ```bash
-  python -m argumentiation_analysis.tests.run_tests
+  python -m argumentation_analysis.tests.run_tests
   ```
 
 - [ ] Vérifier la couverture des tests :
   ```bash
-  python -m argumentiation_analysis.tests.run_coverage
+  python -m argumentation_analysis.tests.run_coverage
   ```
 
 - [ ] S'assurer que les tests couvrent tous les composants principaux :
@@ -191,4 +191,4 @@ Ce document présente une liste de vérification complète pour s'assurer que le
 
 ## Conclusion
 
-Cette liste de vérification couvre les aspects essentiels à vérifier avant le déploiement du projet "argumentiation_analysis" pour les étudiants de l'EPITA. En suivant cette liste, vous vous assurez que le projet est prêt à être utilisé et que les étudiants pourront travailler efficacement sur leurs projets pendant le mois qui leur est alloué.
+Cette liste de vérification couvre les aspects essentiels à vérifier avant le déploiement du projet "argumentation_analysis" pour les étudiants de l'EPITA. En suivant cette liste, vous vous assurez que le projet est prêt à être utilisé et que les étudiants pourront travailler efficacement sur leurs projets pendant le mois qui leur est alloué.

--- a/docs/integration/plan_integration.md
+++ b/docs/integration/plan_integration.md
@@ -6,11 +6,11 @@
 Le projet est un système d'orchestration agentique d'analyse rhétorique organisé en plusieurs composantes :
 
 1. **Outils d'analyse rhétorique** :
-   - Nouveaux outils dans `argumentiation_analysis/agents/tools/analysis/new/`
-   - Outils améliorés dans `argumentiation_analysis/agents/tools/analysis/enhanced/`
+   - Nouveaux outils dans `argumentation_analysis/agents/tools/analysis/new/`
+   - Outils améliorés dans `argumentation_analysis/agents/tools/analysis/enhanced/`
 
 2. **Adaptateurs d'agents** :
-   - Adaptateurs dans `argumentiation_analysis/orchestration/hierarchical/operational/adapters/`
+   - Adaptateurs dans `argumentation_analysis/orchestration/hierarchical/operational/adapters/`
 
 3. **Scripts utilitaires** :
    - Scripts de correction à la racine du projet (`fix_encoding.py`, `check_syntax.py`, `fix_docstrings.py`, `fix_indentation.py`)
@@ -46,26 +46,26 @@ Ces fichiers ont été sauvegardés dans `_archives/backup_20250506_151107/` ava
 ### Étape 2 : Intégration des outils d'analyse rhétorique
 1. Intégrer les nouveaux outils d'analyse :
    ```bash
-   git checkout sauvegarde-modifications-locales -- argumentiation_analysis/agents/tools/analysis/new/
+   git checkout sauvegarde-modifications-locales -- argumentation_analysis/agents/tools/analysis/new/
    ```
 2. Intégrer les outils améliorés :
    ```bash
-   git checkout sauvegarde-modifications-locales -- argumentiation_analysis/agents/tools/analysis/enhanced/
+   git checkout sauvegarde-modifications-locales -- argumentation_analysis/agents/tools/analysis/enhanced/
    ```
 3. Vérifier la syntaxe et les imports des fichiers intégrés :
    ```bash
-   python check_syntax.py argumentiation_analysis/agents/tools/analysis/new/
-   python check_syntax.py argumentiation_analysis/agents/tools/analysis/enhanced/
+   python check_syntax.py argumentation_analysis/agents/tools/analysis/new/
+   python check_syntax.py argumentation_analysis/agents/tools/analysis/enhanced/
    ```
 
 ### Étape 3 : Intégration des adaptateurs d'agents
 1. Intégrer les adaptateurs d'agents :
    ```bash
-   git checkout sauvegarde-modifications-locales -- argumentiation_analysis/orchestration/hierarchical/operational/adapters/
+   git checkout sauvegarde-modifications-locales -- argumentation_analysis/orchestration/hierarchical/operational/adapters/
    ```
 2. Vérifier la syntaxe et les imports des adaptateurs :
    ```bash
-   python check_syntax.py argumentiation_analysis/orchestration/hierarchical/operational/adapters/
+   python check_syntax.py argumentation_analysis/orchestration/hierarchical/operational/adapters/
    ```
 
 ### Étape 4 : Intégration des scripts utilitaires
@@ -84,11 +84,11 @@ Ces fichiers ont été sauvegardés dans `_archives/backup_20250506_151107/` ava
 ### Étape 5 : Tests et validation
 1. Exécuter les tests unitaires pour les outils d'analyse :
    ```bash
-   python -m argumentiation_analysis.tests.tools.run_rhetorical_tools_tests
+   python -m argumentation_analysis.tests.tools.run_rhetorical_tools_tests
    ```
 2. Exécuter les tests d'intégration pour les adaptateurs :
    ```bash
-   python -m argumentiation_analysis.tests.test_operational_agents_integration
+   python -m argumentation_analysis.tests.test_operational_agents_integration
    ```
 3. Vérifier que les scripts utilitaires fonctionnent sur des exemples simples
 
@@ -96,11 +96,11 @@ Ces fichiers ont été sauvegardés dans `_archives/backup_20250506_151107/` ava
 1. Préparer les commits par composante :
    ```bash
    # Commit pour les outils d'analyse
-   git add argumentiation_analysis/agents/tools/analysis/
+   git add argumentation_analysis/agents/tools/analysis/
    git commit -m "Intégration des nouveaux outils d'analyse rhétorique et améliorations des outils existants"
    
    # Commit pour les adaptateurs d'agents
-   git add argumentiation_analysis/orchestration/hierarchical/operational/adapters/
+   git add argumentation_analysis/orchestration/hierarchical/operational/adapters/
    git commit -m "Intégration des adaptateurs d'agents pour l'architecture hiérarchique"
    
    # Commit pour les scripts utilitaires

--- a/docs/integration/validation_integration.md
+++ b/docs/integration/validation_integration.md
@@ -115,7 +115,7 @@ Performance globale : Amélioration de 18% par rapport à la version précédent
 ### Utilisation des nouveaux outils d'analyse rhétorique
 1. **Détecteur de sophismes contextuels** : Utilisez cette fonctionnalité pour analyser des discours complexes où le contexte joue un rôle important dans l'identification des sophismes.
    ```python
-   from argumentiation_analysis.agents.tools.analysis.new.contextual_fallacy_detector import ContextualFallacyDetector
+   from argumentation_analysis.agents.tools.analysis.new.contextual_fallacy_detector import ContextualFallacyDetector
    
    detector = ContextualFallacyDetector()
    results = detector.analyze(text, context_info)
@@ -123,7 +123,7 @@ Performance globale : Amélioration de 18% par rapport à la version précédent
 
 2. **Visualiseur de structure d'arguments** : Utilisez cet outil pour générer des représentations visuelles des structures argumentatives.
    ```python
-   from argumentiation_analysis.agents.tools.analysis.new.argument_structure_visualizer import ArgumentStructureVisualizer
+   from argumentation_analysis.agents.tools.analysis.new.argument_structure_visualizer import ArgumentStructureVisualizer
    
    visualizer = ArgumentStructureVisualizer()
    visualization = visualizer.visualize(argument_data)
@@ -132,7 +132,7 @@ Performance globale : Amélioration de 18% par rapport à la version précédent
 
 3. **Évaluateur de cohérence d'arguments** : Utilisez cette fonctionnalité pour évaluer la cohérence logique entre différentes parties d'un argument.
    ```python
-   from argumentiation_analysis.agents.tools.analysis.new.argument_coherence_evaluator import ArgumentCoherenceEvaluator
+   from argumentation_analysis.agents.tools.analysis.new.argument_coherence_evaluator import ArgumentCoherenceEvaluator
    
    evaluator = ArgumentCoherenceEvaluator()
    coherence_score = evaluator.evaluate(argument)
@@ -141,7 +141,7 @@ Performance globale : Amélioration de 18% par rapport à la version précédent
 ### Utilisation du système de communication amélioré
 1. **Configuration des canaux de communication** :
    ```python
-   from argumentiation_analysis.core.communication.hierarchical_channel import HierarchicalChannel
+   from argumentation_analysis.core.communication.hierarchical_channel import HierarchicalChannel
    
    channel = HierarchicalChannel(
        name="strategic_tactical",
@@ -152,7 +152,7 @@ Performance globale : Amélioration de 18% par rapport à la version précédent
 
 2. **Utilisation des adaptateurs d'agents** :
    ```python
-   from argumentiation_analysis.orchestration.hierarchical.operational.adapters.pl_agent_adapter import PLAgentAdapter
+   from argumentation_analysis.orchestration.hierarchical.operational.adapters.pl_agent_adapter import PLAgentAdapter
    
    adapter = PLAgentAdapter(agent_config)
    result = adapter.process_request(request_data)
@@ -161,22 +161,22 @@ Performance globale : Amélioration de 18% par rapport à la version précédent
 ### Utilisation des scripts utilitaires
 1. **Correction des problèmes d'encodage** :
    ```bash
-   python fix_encoding.py --directory ./argumentiation_analysis --recursive
+   python fix_encoding.py --directory ./argumentation_analysis --recursive
    ```
 
 2. **Vérification de la syntaxe** :
    ```bash
-   python check_syntax.py --file ./argumentiation_analysis/agents/tools/analysis/new/contextual_fallacy_detector.py
+   python check_syntax.py --file ./argumentation_analysis/agents/tools/analysis/new/contextual_fallacy_detector.py
    ```
 
 3. **Normalisation des docstrings** :
    ```bash
-   python fix_docstrings.py --directory ./argumentiation_analysis/agents/tools --recursive
+   python fix_docstrings.py --directory ./argumentation_analysis/agents/tools --recursive
    ```
 
 4. **Correction des problèmes d'indentation** :
    ```bash
-   python fix_indentation.py --directory ./argumentiation_analysis --recursive
+   python fix_indentation.py --directory ./argumentation_analysis --recursive
    ```
 
 ## Prochaines étapes après l'intégration

--- a/docs/projets/message_annonce_etudiants.md
+++ b/docs/projets/message_annonce_etudiants.md
@@ -1,10 +1,10 @@
-# Annonce du projet "argumentiation_analysis" pour les étudiants de l'EPITA
+# Annonce du projet "argumentation_analysis" pour les étudiants de l'EPITA
 
 ## Présentation du projet
 
 Chers étudiants de l'EPITA,
 
-Nous avons le plaisir de vous annoncer le lancement du projet **"argumentiation_analysis"**, une opportunité exceptionnelle de mettre en pratique vos connaissances en intelligence symbolique dans un contexte concret et innovant.
+Nous avons le plaisir de vous annoncer le lancement du projet **"argumentation_analysis"**, une opportunité exceptionnelle de mettre en pratique vos connaissances en intelligence symbolique dans un contexte concret et innovant.
 
 Ce projet s'articule autour d'un **Système d'Orchestration Agentique d'Analyse Rhétorique**, une plateforme avancée qui utilise plusieurs agents IA spécialisés collaborant pour analyser des textes argumentatifs sous différents angles. Cette architecture multi-agents combine :
 
@@ -170,7 +170,7 @@ Pour commencer à travailler sur le projet, suivez ces étapes :
 
 ## Conclusion
 
-Le projet "argumentiation_analysis" représente une opportunité unique de mettre en pratique vos connaissances en intelligence symbolique dans un contexte concret et innovant. En combinant des approches symboliques traditionnelles avec des techniques modernes basées sur les LLMs, vous explorerez les frontières de l'analyse argumentative automatisée.
+Le projet "argumentation_analysis" représente une opportunité unique de mettre en pratique vos connaissances en intelligence symbolique dans un contexte concret et innovant. En combinant des approches symboliques traditionnelles avec des techniques modernes basées sur les LLMs, vous explorerez les frontières de l'analyse argumentative automatisée.
 
 Nous sommes impatients de découvrir vos contributions à ce projet passionnant et restons à votre disposition pour vous accompagner tout au long de ce mois de développement.
 

--- a/docs/technical/api_outils.md
+++ b/docs/technical/api_outils.md
@@ -88,7 +88,7 @@ class LLMValidator:
 
 ## Exemple d'API Utilisation
 ```python
-from argumentiation_analysis import RhetoricalAnalysisSystem
+from argumentation_analysis import RhetoricalAnalysisSystem
 
 system = RhetoricalAnalysisSystem()
 system.configure_tool("coherence_evaluator", {"threshold": 0.7})
@@ -102,7 +102,7 @@ visualization = MermaidVisualizer().generate(results)
 
 ## Structure des Répertoires
 ```
-argumentiation_analysis/
+argumentation_analysis/
 ├── orchestration/
 │   ├── strategic/
 │   │   ├── planner.py

--- a/docs/technical/argument_coherence_evaluator.md
+++ b/docs/technical/argument_coherence_evaluator.md
@@ -5,7 +5,7 @@
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import ArgumentCoherenceEvaluator
+from argumentation_analysis.tools import ArgumentCoherenceEvaluator
 
 evaluator = ArgumentCoherenceEvaluator()
 result = evaluator.analyze(text="Tous les chats sont des mammifères. Les mammifères sont des vertébrés. Donc, les chats sont des vertébrés.")

--- a/docs/technical/coherence_evaluator.md
+++ b/docs/technical/coherence_evaluator.md
@@ -5,7 +5,7 @@
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import CoherenceEvaluator
+from argumentation_analysis.tools import CoherenceEvaluator
 
 evaluator = CoherenceEvaluator(threshold=0.7, explanations=True)
 result = evaluator.analyze(text="Texte à analyser")

--- a/docs/technical/complex_fallacy_analyzer.md
+++ b/docs/technical/complex_fallacy_analyzer.md
@@ -5,7 +5,7 @@ Analyse les structures argumentatives complexes et identifie les erreurs logique
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import EnhancedComplexFallacyAnalyzer
+from argumentation_analysis.tools import EnhancedComplexFallacyAnalyzer
 
 analyzer = EnhancedComplexFallacyAnalyzer(depth=3, strict_mode=False)
 result = analyzer.analyze(text="Texte à analyser")

--- a/docs/technical/contextual_fallacy_detector.md
+++ b/docs/technical/contextual_fallacy_detector.md
@@ -5,7 +5,7 @@ Identifie les erreurs rhétoriques dans leur contexte, en analysant les relation
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import ContextualFallacyDetector
+from argumentation_analysis.tools import ContextualFallacyDetector
 
 detector = ContextualFallacyDetector(sensitivity=0.8, context_window=100)
 result = detector.analyze(text="Texte à analyser")

--- a/docs/technical/developpement_outils.md
+++ b/docs/technical/developpement_outils.md
@@ -14,7 +14,7 @@ graph TD
 
 ### Ajouter un Critère de Cohérence
 ```python
-from argumentiation_analysis.tools import CoherenceEvaluator
+from argumentation_analysis.tools import CoherenceEvaluator
 
 class CustomCoherenceCriterion:
     def evaluate(self, segment1, segment2):
@@ -30,7 +30,7 @@ evaluator.add_criterion(CustomCoherenceCriterion())
 
 ### Créer un Nouveau Type de Sophisme
 ```python
-from argumentiation_analysis.tools import ContextualFallacyDetector
+from argumentation_analysis.tools import ContextualFallacyDetector
 
 class CustomFallacyPlugin:
     def detect(self, context):
@@ -48,7 +48,7 @@ detector.register_detector(CustomFallacyPlugin())
 
 ### Structure de Base
 ```python
-from argumentiation_analysis.core import BaseRhetoricalTool
+from argumentation_analysis.core import BaseRhetoricalTool
 
 class MyNewTool(BaseRhetoricalTool):
     def __init__(self, param1, param2):
@@ -62,7 +62,7 @@ class MyNewTool(BaseRhetoricalTool):
         return RhetoricalResults(results)
 
 # Enregistrement de l'outil
-from argumentiation_analysis.registry import tool_registry
+from argumentation_analysis.registry import tool_registry
 tool_registry.register("my_new_tool", MyNewTool)
 ```
 
@@ -86,7 +86,7 @@ graph LR
 
 ## Structure de Répertoire
 ```
-argumentiation_analysis/
+argumentation_analysis/
 ├── tools/
 │   ├── __init__.py
 │   ├── coherence.py

--- a/docs/technical/enhanced_complex_fallacy_analyzer.md
+++ b/docs/technical/enhanced_complex_fallacy_analyzer.md
@@ -5,7 +5,7 @@ Analyse les structures argumentatives complexes pour détecter les sophismes imb
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import EnhancedComplexFallacyAnalyzer
+from argumentation_analysis.tools import EnhancedComplexFallacyAnalyzer
 
 analyzer = EnhancedComplexFallacyAnalyzer()
 result = analyzer.analyze(text="""

--- a/docs/technical/integration_outils.md
+++ b/docs/technical/integration_outils.md
@@ -13,10 +13,10 @@ graph TD
 ```
 
 ### Étapes d'Intégration
-1. **Installation** : `pip install argumentiation-analysis`
+1. **Installation** : `pip install argumentation-analysis`
 2. **Importation** : 
    ```python
-   from argumentiation_analysis import RhetoricalAnalysisSystem
+   from argumentation_analysis import RhetoricalAnalysisSystem
    ```
 3. **Configuration** :
    ```python
@@ -53,7 +53,7 @@ async def analyze_text(text: str):
 ## Gestion des Dépendances
 ```bash
 # Requirements.txt
-argumentiation-analysis>=1.2.0
+argumentation-analysis>=1.2.0
 mermaid>=10.3.0
 ```
 

--- a/docs/technical/outils_analyse_rhetorique.md
+++ b/docs/technical/outils_analyse_rhetorique.md
@@ -18,7 +18,7 @@ graph TD
 
 ## Exemple d'Utilisation
 ```python
-from argumentiation_analysis import RhetoricalAnalysisSystem
+from argumentation_analysis import RhetoricalAnalysisSystem
 
 # Initialisation du système
 system = RhetoricalAnalysisSystem()

--- a/docs/technical/outils_reference/argument_coherence_evaluator.md
+++ b/docs/technical/outils_reference/argument_coherence_evaluator.md
@@ -5,7 +5,7 @@
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import ArgumentCoherenceEvaluator
+from argumentation_analysis.tools import ArgumentCoherenceEvaluator
 
 evaluator = ArgumentCoherenceEvaluator()
 result = evaluator.analyze(text="Tous les chats sont des mammifères. Les mammifères sont des vertébrés. Donc, les chats sont des vertébrés.")

--- a/docs/technical/outils_reference/coherence_evaluator.md
+++ b/docs/technical/outils_reference/coherence_evaluator.md
@@ -5,7 +5,7 @@
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import CoherenceEvaluator
+from argumentation_analysis.tools import CoherenceEvaluator
 
 evaluator = CoherenceEvaluator(threshold=0.7, explanations=True)
 result = evaluator.analyze(text="Texte à analyser")

--- a/docs/technical/outils_reference/complex_fallacy_analyzer.md
+++ b/docs/technical/outils_reference/complex_fallacy_analyzer.md
@@ -5,7 +5,7 @@ Analyse les structures argumentatives complexes et identifie les erreurs logique
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import EnhancedComplexFallacyAnalyzer
+from argumentation_analysis.tools import EnhancedComplexFallacyAnalyzer
 
 analyzer = EnhancedComplexFallacyAnalyzer(depth=3, strict_mode=False)
 result = analyzer.analyze(text="Texte à analyser")

--- a/docs/technical/outils_reference/contextual_fallacy_detector.md
+++ b/docs/technical/outils_reference/contextual_fallacy_detector.md
@@ -5,7 +5,7 @@ Identifie les erreurs rhétoriques dans leur contexte, en analysant les relation
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import ContextualFallacyDetector
+from argumentation_analysis.tools import ContextualFallacyDetector
 
 detector = ContextualFallacyDetector(sensitivity=0.8, context_window=100)
 result = detector.analyze(text="Texte à analyser")

--- a/docs/technical/outils_reference/enhanced_complex_fallacy_analyzer.md
+++ b/docs/technical/outils_reference/enhanced_complex_fallacy_analyzer.md
@@ -5,7 +5,7 @@ Analyse les structures argumentatives complexes pour détecter les sophismes imb
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import EnhancedComplexFallacyAnalyzer
+from argumentation_analysis.tools import EnhancedComplexFallacyAnalyzer
 
 analyzer = EnhancedComplexFallacyAnalyzer()
 result = analyzer.analyze(text="""

--- a/docs/technical/outils_reference/visualizer.md
+++ b/docs/technical/outils_reference/visualizer.md
@@ -5,7 +5,7 @@ Génère des représentations graphiques des analyses argumentatives pour une me
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import RhetoricalVisualizer
+from argumentation_analysis.tools import RhetoricalVisualizer
 
 visualizer = RhetoricalVisualizer(style="mermaid", detail_level=2)
 result = visualizer.generate(analysis_results)

--- a/docs/technical/visualizer.md
+++ b/docs/technical/visualizer.md
@@ -5,7 +5,7 @@ Génère des représentations graphiques des analyses argumentatives pour une me
 
 ## Utilisation
 ```python
-from argumentiation_analysis.tools import RhetoricalVisualizer
+from argumentation_analysis.tools import RhetoricalVisualizer
 
 visualizer = RhetoricalVisualizer(style="mermaid", detail_level=2)
 result = visualizer.generate(analysis_results)

--- a/scripts/maintenance/cleanup/cleanup_obsolete_files.py
+++ b/scripts/maintenance/cleanup/cleanup_obsolete_files.py
@@ -46,13 +46,13 @@ logger = logging.getLogger(__name__)
 # Liste des fichiers obsolètes à supprimer
 OBSOLETE_FILES = [
     # Scripts d'extraction refactorisés
-    "argumentiation_analysis/utils/extract_repair/repair_extract_markers.py",
-    "argumentiation_analysis/utils/extract_repair/verify_extracts.py",
-    "argumentiation_analysis/utils/extract_repair/fix_missing_first_letter.py",
-    "argumentiation_analysis/utils/extract_repair/verify_extracts_with_llm.py",
-    "argumentiation_analysis/utils/extract_repair/repair_extract_markers.ipynb",
+    "argumentation_analysis/utils/extract_repair/repair_extract_markers.py",
+    "argumentation_analysis/utils/extract_repair/verify_extracts.py",
+    "argumentation_analysis/utils/extract_repair/fix_missing_first_letter.py",
+    "argumentation_analysis/utils/extract_repair/verify_extracts_with_llm.py",
+    "argumentation_analysis/utils/extract_repair/repair_extract_markers.ipynb",
     # Utilitaires remplacés par des services
-    "argumentiation_analysis/ui/extract_utils.py",
+    "argumentation_analysis/ui/extract_utils.py",
 ]
 
 # Répertoire d'archives

--- a/scripts/maintenance/cleanup/cleanup_repository.py
+++ b/scripts/maintenance/cleanup/cleanup_repository.py
@@ -83,8 +83,8 @@ def main():
     print("\n=== Gestion des fichiers de configuration ===")
 
     # Création d'un fichier .env.example comme modèle
-    env_path = base_path / "argumentiation_analysis" / ".env"
-    env_example_path = base_path / "argumentiation_analysis" / ".env.example"
+    env_path = base_path / "argumentation_analysis" / ".env"
+    env_example_path = base_path / "argumentation_analysis" / ".env.example"
 
     print(f"Vérification du fichier .env à: {env_path}")
 
@@ -117,19 +117,19 @@ TEXT_CONFIG_PASSPHRASE="votre-phrase-secrète"
     else:
         print(f"Fichier .env non trouvé à {env_path}")
 
-    # Chemin absolu vers le dossier argumentiation_analysis
+    # Chemin absolu vers le dossier argumentation_analysis
     # Comme nous sommes déjà dans le répertoire de travail actuel, nous devons remonter
-    # si nous sommes dans un sous-répertoire de argumentiation_analysis
-    if "argumentiation_analysis" in str(base_path):
-        # Si nous sommes dans un sous-répertoire de argumentiation_analysis
+    # si nous sommes dans un sous-répertoire de argumentation_analysis
+    if "argumentation_analysis" in str(base_path):
+        # Si nous sommes dans un sous-répertoire de argumentation_analysis
         parts = base_path.parts
-        idx = parts.index("argumentiation_analysis")
+        idx = parts.index("argumentation_analysis")
         arg_analysis_path = Path(*parts[: idx + 1])
     else:
         # Si nous sommes à la racine du projet
-        arg_analysis_path = base_path / "argumentiation_analysis"
+        arg_analysis_path = base_path / "argumentation_analysis"
 
-    print(f"Chemin vers argumentiation_analysis: {arg_analysis_path}")
+    print(f"Chemin vers argumentation_analysis: {arg_analysis_path}")
 
     # Suppression du dossier config vide
     config_path = arg_analysis_path / "config"

--- a/scripts/maintenance/tools/fix_project_structure.py
+++ b/scripts/maintenance/tools/fix_project_structure.py
@@ -99,11 +99,11 @@ def main():
     # Créer les répertoires nécessaires
     logging.info("\n=== Création des répertoires nécessaires ===")
     directories = [
-        project_dir / "argumentiation_analysis" / "libs",
-        project_dir / "argumentiation_analysis" / "libs" / "native",
-        project_dir / "argumentiation_analysis" / "tests" / "resources" / "libs",
+        project_dir / "argumentation_analysis" / "libs",
+        project_dir / "argumentation_analysis" / "libs" / "native",
+        project_dir / "argumentation_analysis" / "tests" / "resources" / "libs",
         project_dir
-        / "argumentiation_analysis"
+        / "argumentation_analysis"
         / "tests"
         / "resources"
         / "libs"
@@ -120,16 +120,16 @@ def main():
     # Créer les fichiers .gitkeep
     logging.info("\n=== Création des fichiers .gitkeep ===")
     gitkeep_files = [
-        project_dir / "argumentiation_analysis" / "libs" / ".gitkeep",
-        project_dir / "argumentiation_analysis" / "libs" / "native" / ".gitkeep",
+        project_dir / "argumentation_analysis" / "libs" / ".gitkeep",
+        project_dir / "argumentation_analysis" / "libs" / "native" / ".gitkeep",
         project_dir
-        / "argumentiation_analysis"
+        / "argumentation_analysis"
         / "tests"
         / "resources"
         / "libs"
         / ".gitkeep",
         project_dir
-        / "argumentiation_analysis"
+        / "argumentation_analysis"
         / "tests"
         / "resources"
         / "libs"
@@ -206,7 +206,7 @@ def main():
     else:
         logging.info("Toutes les étapes ont été exécutées.")
         logging.info("Pour tester les modifications, exécutez les tests unitaires:")
-        logging.info("  cd argumentiation_analysis/tests")
+        logging.info("  cd argumentation_analysis/tests")
         logging.info("  python run_tests.py")
 
     return 0

--- a/scripts/maintenance/tools/update_imports.py
+++ b/scripts/maintenance/tools/update_imports.py
@@ -185,7 +185,7 @@ def main():
     parser.add_argument(
         "--dir",
         type=str,
-        default="argumentiation_analysis",
+        default="argumentation_analysis",
         help="Répertoire à analyser",
     )
     parser.add_argument(

--- a/scripts/maintenance/tools/update_paths.py
+++ b/scripts/maintenance/tools/update_paths.py
@@ -215,7 +215,7 @@ def main():
     parser.add_argument(
         "--dir",
         type=str,
-        default="argumentiation_analysis",
+        default="argumentation_analysis",
         help="Répertoire à analyser",
     )
     parser.add_argument(


### PR DESCRIPTION
## What

Corrects the systemic `argumentiation` → `argumentation` typo **repo-wide**: 30 doc files + 5 maintenance scripts (~112 occurrences). The first pass (17 files) was incomplete; a second pass found a duplicate doc set under `docs/technical/outils_reference/` plus 4 more scripts.

## Functional impact — 5 maintenance scripts (silent no-ops)

In every script the typo named a **non-existent** path (`argumentiation_analysis/`), so the script silently operated on nothing:

| Script | What broke |
|---|---|
| `cleanup_obsolete_files.py` | `OBSOLETE_FILES` (6 paths) never matched → cleanup never removed them |
| `cleanup_repository.py` | `.env` detection + `argumentation_analysis` path resolution targeted the typo |
| `fix_project_structure.py` | `libs/` scaffolding created/checked the wrong tree |
| `update_imports.py` | `--dir` default scan directory = non-existent → found nothing by default |
| `update_paths.py` | same `--dir` default bug |

The import/path migration scripts use the **correct** `argumentation_analysis` as their replacement target throughout `IMPORT_PATTERNS`; only the `--dir` default was wrong. **None are typo-migration scripts** (none search for `argumentiation` as a pattern), so correcting the typo is unambiguously safe — verified by reading each script's replacement logic.

## Pedagogical impact — docs

The typo appeared in instructional paths students copy verbatim (`cd argumentiation_analysis`, `from argumentiation_analysis...`), across `docs/guides`, `docs/integration`, `docs/technical` (+ `outils_reference/`), `docs/projets`, `config/`.

## Excluded per policy

`docs/archives/`, `archived_root/`, and generated/dated reports (`extracted_summaries*.json`, `cartographie_documentation_2025-06-03.md`) — frozen/generated surfaces.

## Method & CI

Byte-level replacement (both ASCII) preserves UTF-8 + CRLF exactly: **112 insertions / 112 deletions**, pure 1:1, verified 0 residual in active files. mypy strict gate (`ci.yml:43`) is scoped to 8 files in `argumentation_analysis/core|orchestration|agents` — untouched. Pre-existing mypy errors in the maintenance scripts are out of scope.

## Caveat

Fixing the typo makes `cleanup_obsolete_files.py` correctly **target** what it claims — it does **not** delete `extract_utils.py` (listed as obsolete but still carrying active TODOs). Running the cleanup is a separate, coordinator-scoped decision requiring origin-check + a `## Files removed and why` section per the Cleanup Gate policy.

A follow-up PR will rewrite the evaluator doc **APIs** (the 4 `*_coherence_evaluator.md` / `coherence_evaluator.md` docs document a wrong method/constructor/return) — distinct from this mechanical typo fix.

Refs: discovery during R503 doc-staleness reconnaissance. Consolidation mandate (worker po-2025, no self-merge — awaiting coordinator review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)