### PR TITLE
docs(coherence): fix ArgumentCoherenceEvaluator API accuracy + retire CoherenceEvaluator zombie

### DIFF
--- a/docs/technical/argument_coherence_evaluator.md
+++ b/docs/technical/argument_coherence_evaluator.md
@@ -1,32 +1,54 @@
-# Évaluateur de cohérence argumentative
+# Évaluateur de cohérence argumentative (`ArgumentCoherenceEvaluator`)
 
 ## Objectif
-Évalue la cohérence logique des arguments dans un texte en vérifiant l'alignement entre les prémisses et la conclusion.
+Évalue la cohérence d'un ensemble d'arguments selon cinq dimensions (logique, thématique, structurelle, rhétorique, épistémique) et produit un score global pondéré ainsi que des recommandations.
+
+> ⚠️ **Statut d'implémentation — simulation.** Le module est actuellement un squelette : les scores par dimension sont pré-définis et ne dérivent pas d'une analyse sémantique réelle. Il sert de cadre pour une future implémentation. Source de vérité : la docstring du module `argumentation_analysis/agents/tools/analysis/new/argument_coherence_evaluator.py`.
+
+## Chemin d'import
+```python
+from argumentation_analysis.agents.tools.analysis.new.argument_coherence_evaluator import ArgumentCoherenceEvaluator
+```
 
 ## Utilisation
 ```python
-from argumentation_analysis.tools import ArgumentCoherenceEvaluator
+from argumentation_analysis.agents.tools.analysis.new.argument_coherence_evaluator import ArgumentCoherenceEvaluator
 
 evaluator = ArgumentCoherenceEvaluator()
-result = evaluator.analyze(text="Tous les chats sont des mammifères. Les mammifères sont des vertébrés. Donc, les chats sont des vertébrés.")
-print(result.coherence_score)
+result = evaluator.evaluate_coherence(
+    arguments=[
+        "Tous les chats sont des mammifères.",
+        "Les mammifères sont des vertébrés.",
+        "Donc, les chats sont des vertébrés.",
+    ],
+    context="Déduction catégorique",  # optionnel
+)
+print(result["overall_coherence"])
 ```
 
-## Paramètres
-- `text` (str): Texte à analyser
-- `threshold` (float, optional): Seuil de cohérence minimal (défaut: 0.7)
-- `explanation` (bool, optional): Activer les explications détaillées (défaut: False)
+## Constructeur
+`ArgumentCoherenceEvaluator()` — aucun paramètre.
 
-## Résultats
-Retourne un objet contenant:
-- `coherence_score` (float): Note entre 0 et 1
-- `inconsistencies` (list): Liste des incohérences détectées
-- `suggestions` (list): Recommandations pour améliorer la cohérence
+## Méthode principale
+`evaluate_coherence(arguments: list[str], context: str | None = None) -> dict`
 
-## Personnalisation
-Pour ajouter un nouveau critère d'évaluation:
-```python
-class CustomCoherenceCriterion:
-    def evaluate(self, argument):
-        # Implémentation personnalisée
-        return score, feedback
+## Résultat (dictionnaire)
+| Clé | Type | Description |
+|-----|------|-------------|
+| `overall_coherence` | float | Score global (moyenne pondérée des 5 axes, 0–1) |
+| `coherence_evaluations` | dict | Scores détaillés par axe (`logique`, `thématique`, `structurelle`, `rhétorique`, `épistémique`) |
+| `recommendations` | list | Recommandations basées sur les points faibles identifiés |
+| `context` | str | Contexte utilisé (`"Analyse d'arguments"` par défaut) |
+| `timestamp` | str | Horodatage ISO 8601 de l'évaluation |
+
+## Axes d'évaluation (et pondérations)
+| Axe | Poids |
+|-----|-------|
+| logique | 0.30 |
+| thématique | 0.20 |
+| structurelle | 0.20 |
+| rhétorique | 0.15 |
+| épistémique | 0.15 |
+
+## Tests
+`tests/unit/argumentation_analysis/agents/tools/analysis/new/test_argument_coherence_evaluator.py`

--- a/docs/technical/coherence_evaluator.md
+++ b/docs/technical/coherence_evaluator.md
@@ -1,48 +1,15 @@
-# Évaluateur de Cohérence Argumentative
+# `CoherenceEvaluator` — classe renommée
 
-## Objectif
-Évalue la cohérence logique entre les arguments dans un texte, identifiant les ruptures de chaînage sémantique.
+> ⚠️ **Classe renommée.** `CoherenceEvaluator` n'existe plus dans le code. Elle a été
+> renommée en **`ArgumentCoherenceEvaluator`**. Ce fichier est conservé comme point de
+> redirection pour les éventuels liens entrants ; son contenu précédent décrivait une API
+> (`threshold=`, `explanations=`, `.analyze(text=...)`, `.score`, `add_criterion()`) qui ne
+> correspond à **aucune** classe présente dans le dépôt (vérifié : aucune définition de
+> `CoherenceEvaluator` dans le code source ; la classe réelle est `ArgumentCoherenceEvaluator`).
 
-## Utilisation
+➡️ Voir la documentation à jour : [argument_coherence_evaluator.md](argument_coherence_evaluator.md).
+
+## Chemin d'import correct
 ```python
-from argumentation_analysis.tools import CoherenceEvaluator
-
-evaluator = CoherenceEvaluator(threshold=0.7, explanations=True)
-result = evaluator.analyze(text="Texte à analyser")
-print(result.score)  # Score entre 0 et 1
-print(result.explanations)  # Liste des ruptures détectées
+from argumentation_analysis.agents.tools.analysis.new.argument_coherence_evaluator import ArgumentCoherenceEvaluator
 ```
-
-## Paramètres
-| Paramètre | Type | Description | Valeur par défaut |
-|-----------|------|-------------|-------------------|
-| `threshold` | float | Seuil de cohérence minimal | 0.65 |
-| `explanations` | bool | Activer les explications détaillées | False |
-| `language_model` | str | Modèle LLM à utiliser | "default" |
-
-## Résultats
-- Score de cohérence global
-- Liste des segments incohérents avec positions
-- Suggestions de réécriture
-- Diagramme de flux sémantique
-
-## Exemple de Diagramme
-```mermaid
-graph LR
-    A[Segment 1] -->|Score 0.85| B[Segment 2]
-    B -->|Score 0.42| C[Segment 3]
-    C -->|Score 0.90| D[Segment 4]
-    classDef lowCoherence fill:#ff4d4d,stroke:#000;
-    classDef normalCoherence fill:#90ee90,stroke:#000;
-    class B lowCoherence
-```
-
-## Extension
-Pour ajouter un critère de cohérence personnalisé :
-```python
-class CustomCoherenceCriterion:
-    def evaluate(self, segment1, segment2):
-        # Implémentation personnalisée
-        return score, explanation
-
-evaluator.add_criterion(CustomCoherenceCriterion())

--- a/docs/technical/developpement_outils.md
+++ b/docs/technical/developpement_outils.md
@@ -12,20 +12,20 @@ graph TD
 
 ## Étendre les Outils Existants
 
-### Ajouter un Critère de Cohérence
+### Étendre l'évaluateur de cohérence
 ```python
-from argumentation_analysis.tools import CoherenceEvaluator
+from argumentation_analysis.agents.tools.analysis.new.argument_coherence_evaluator import ArgumentCoherenceEvaluator
 
-class CustomCoherenceCriterion:
-    def evaluate(self, segment1, segment2):
+# ArgumentCoherenceEvaluator évalue 5 axes internes (logique, thématique,
+# structurelle, rhétorique, épistémique). Pour étendre l'évaluation, sous-classer
+# et surcharger l'une des méthodes _evaluate_*_coherence, ou ajouter un nouvel axe
+# dans coherence_types + la méthode _evaluate_* correspondante.
+# Note : il n'existe pas d'API publique add_criterion() ; l'évaluation est
+# actuellement simulée (scores pré-définis — voir la docstring du module).
+class CustomArgumentCoherenceEvaluator(ArgumentCoherenceEvaluator):
+    def _evaluate_logical_coherence(self, arguments, semantic_analysis):
         # Implémentation personnalisée
-        score = self._calculate_score(segment1, segment2)
-        explanation = self._generate_explanation(segment1, segment2)
-        return score, explanation
-
-# Enregistrement du critère
-evaluator = CoherenceEvaluator()
-evaluator.add_criterion(CustomCoherenceCriterion())
+        return super()._evaluate_logical_coherence(arguments, semantic_analysis)
 ```
 
 ### Créer un Nouveau Type de Sophisme

--- a/docs/technical/outils_reference/argument_coherence_evaluator.md
+++ b/docs/technical/outils_reference/argument_coherence_evaluator.md
@@ -1,32 +1,54 @@
-# Évaluateur de cohérence argumentative
+# Évaluateur de cohérence argumentative (`ArgumentCoherenceEvaluator`)
 
 ## Objectif
-Évalue la cohérence logique des arguments dans un texte en vérifiant l'alignement entre les prémisses et la conclusion.
+Évalue la cohérence d'un ensemble d'arguments selon cinq dimensions (logique, thématique, structurelle, rhétorique, épistémique) et produit un score global pondéré ainsi que des recommandations.
+
+> ⚠️ **Statut d'implémentation — simulation.** Le module est actuellement un squelette : les scores par dimension sont pré-définis et ne dérivent pas d'une analyse sémantique réelle. Il sert de cadre pour une future implémentation. Source de vérité : la docstring du module `argumentation_analysis/agents/tools/analysis/new/argument_coherence_evaluator.py`.
+
+## Chemin d'import
+```python
+from argumentation_analysis.agents.tools.analysis.new.argument_coherence_evaluator import ArgumentCoherenceEvaluator
+```
 
 ## Utilisation
 ```python
-from argumentation_analysis.tools import ArgumentCoherenceEvaluator
+from argumentation_analysis.agents.tools.analysis.new.argument_coherence_evaluator import ArgumentCoherenceEvaluator
 
 evaluator = ArgumentCoherenceEvaluator()
-result = evaluator.analyze(text="Tous les chats sont des mammifères. Les mammifères sont des vertébrés. Donc, les chats sont des vertébrés.")
-print(result.coherence_score)
+result = evaluator.evaluate_coherence(
+    arguments=[
+        "Tous les chats sont des mammifères.",
+        "Les mammifères sont des vertébrés.",
+        "Donc, les chats sont des vertébrés.",
+    ],
+    context="Déduction catégorique",  # optionnel
+)
+print(result["overall_coherence"])
 ```
 
-## Paramètres
-- `text` (str): Texte à analyser
-- `threshold` (float, optional): Seuil de cohérence minimal (défaut: 0.7)
-- `explanation` (bool, optional): Activer les explications détaillées (défaut: False)
+## Constructeur
+`ArgumentCoherenceEvaluator()` — aucun paramètre.
 
-## Résultats
-Retourne un objet contenant:
-- `coherence_score` (float): Note entre 0 et 1
-- `inconsistencies` (list): Liste des incohérences détectées
-- `suggestions` (list): Recommandations pour améliorer la cohérence
+## Méthode principale
+`evaluate_coherence(arguments: list[str], context: str | None = None) -> dict`
 
-## Personnalisation
-Pour ajouter un nouveau critère d'évaluation:
-```python
-class CustomCoherenceCriterion:
-    def evaluate(self, argument):
-        # Implémentation personnalisée
-        return score, feedback
+## Résultat (dictionnaire)
+| Clé | Type | Description |
+|-----|------|-------------|
+| `overall_coherence` | float | Score global (moyenne pondérée des 5 axes, 0–1) |
+| `coherence_evaluations` | dict | Scores détaillés par axe (`logique`, `thématique`, `structurelle`, `rhétorique`, `épistémique`) |
+| `recommendations` | list | Recommandations basées sur les points faibles identifiés |
+| `context` | str | Contexte utilisé (`"Analyse d'arguments"` par défaut) |
+| `timestamp` | str | Horodatage ISO 8601 de l'évaluation |
+
+## Axes d'évaluation (et pondérations)
+| Axe | Poids |
+|-----|-------|
+| logique | 0.30 |
+| thématique | 0.20 |
+| structurelle | 0.20 |
+| rhétorique | 0.15 |
+| épistémique | 0.15 |
+
+## Tests
+`tests/unit/argumentation_analysis/agents/tools/analysis/new/test_argument_coherence_evaluator.py`

--- a/docs/technical/outils_reference/coherence_evaluator.md
+++ b/docs/technical/outils_reference/coherence_evaluator.md
@@ -1,48 +1,15 @@
-# Évaluateur de Cohérence Argumentative
+# `CoherenceEvaluator` — classe renommée
 
-## Objectif
-Évalue la cohérence logique entre les arguments dans un texte, identifiant les ruptures de chaînage sémantique.
+> ⚠️ **Classe renommée.** `CoherenceEvaluator` n'existe plus dans le code. Elle a été
+> renommée en **`ArgumentCoherenceEvaluator`**. Ce fichier est conservé comme point de
+> redirection pour les éventuels liens entrants ; son contenu précédent décrivait une API
+> (`threshold=`, `explanations=`, `.analyze(text=...)`, `.score`, `add_criterion()`) qui ne
+> correspond à **aucune** classe présente dans le dépôt (vérifié : aucune définition de
+> `CoherenceEvaluator` dans le code source ; la classe réelle est `ArgumentCoherenceEvaluator`).
 
-## Utilisation
+➡️ Voir la documentation à jour : [argument_coherence_evaluator.md](argument_coherence_evaluator.md).
+
+## Chemin d'import correct
 ```python
-from argumentation_analysis.tools import CoherenceEvaluator
-
-evaluator = CoherenceEvaluator(threshold=0.7, explanations=True)
-result = evaluator.analyze(text="Texte à analyser")
-print(result.score)  # Score entre 0 et 1
-print(result.explanations)  # Liste des ruptures détectées
+from argumentation_analysis.agents.tools.analysis.new.argument_coherence_evaluator import ArgumentCoherenceEvaluator
 ```
-
-## Paramètres
-| Paramètre | Type | Description | Valeur par défaut |
-|-----------|------|-------------|-------------------|
-| `threshold` | float | Seuil de cohérence minimal | 0.65 |
-| `explanations` | bool | Activer les explications détaillées | False |
-| `language_model` | str | Modèle LLM à utiliser | "default" |
-
-## Résultats
-- Score de cohérence global
-- Liste des segments incohérents avec positions
-- Suggestions de réécriture
-- Diagramme de flux sémantique
-
-## Exemple de Diagramme
-```mermaid
-graph LR
-    A[Segment 1] -->|Score 0.85| B[Segment 2]
-    B -->|Score 0.42| C[Segment 3]
-    C -->|Score 0.90| D[Segment 4]
-    classDef lowCoherence fill:#ff4d4d,stroke:#000;
-    classDef normalCoherence fill:#90ee90,stroke:#000;
-    class B lowCoherence
-```
-
-## Extension
-Pour ajouter un critère de cohérence personnalisé :
-```python
-class CustomCoherenceCriterion:
-    def evaluate(self, segment1, segment2):
-        # Implémentation personnalisée
-        return score, explanation
-
-evaluator.add_criterion(CustomCoherenceCriterion())


### PR DESCRIPTION
## What

The coherence-evaluator docs described an API that does **not match the code** on any point. This rewrites them to the verified real API and retires a zombie class.

Verified against source: `argumentation_analysis/agents/tools/analysis/new/argument_coherence_evaluator.py` (grep: `ArgumentCoherenceEvaluator` is the only coherence-evaluator class; no `CoherenceEvaluator` exists).

## API corrections (every field was wrong)

| Doc (was) | Reality |
|---|---|
| `argumentation_analysis.tools` (dead path) | `argumentation_analysis.agents.tools.analysis.new` |
| `analyze(text=...)` | `evaluate_coherence(arguments, context=None)` |
| `__init__(threshold=, explanations=, language_model=)` | `__init__()` — no args |
| `result.coherence_score` (object attr) | `result["overall_coherence"]` (dict) |
| `add_criterion(...)` | no such API — 5 internal `_evaluate_*_coherence` axes |
| implied real semantic analysis | explicitly a **simulation** (predefined scores per module docstring) |

## Files (5)

- `argument_coherence_evaluator.md` (×2 — `docs/technical/` + `outils_reference/` duplicate): rewritten to real import path, constructor, method, dict return, the 5 weighted axes (logique 0.30, thématique/structurelle 0.20, rhétorique/épistémique 0.15), + the simulation honesty caveat.
- `coherence_evaluator.md` (×2): documented a class **`CoherenceEvaluator` that does not exist** (grep: zero definitions). Converted to a **redirect stub** → `argument_coherence_evaluator.md`. Anti-pendule: preserve inbound links + correct the record rather than silent delete (would need a `## Files removed and why` per the Cleanup Gate).
- `developpement_outils.md`: the "Ajouter un Critère" example fabricated `CoherenceEvaluator()` + `add_criterion()`. Rewritten to subclass the real class and override an internal axis method, with an explicit note that there is no public `add_criterion()` and evaluation is simulated.

## Flagged, NOT resolved here (coordinator-scoped / separate sweep)

1. **Duplicate dir**: `docs/technical/` and `docs/technical/outils_reference/` hold **byte-identical** copies of these files. Both fixed identically here. Dedup needs Cleanup Gate origin-check.
2. **Dead import path `argumentation_analysis.tools`** also appears in other docs (`complex_fallacy_analyzer.md`, `contextual_fallacy_detector.md`, `enhanced_complex_fallacy_analyzer.md`, `visualizer.md`, `integration_outils.md`, `outils_analyse_rhetorique.md`). Separate sweep — each needs its own verify-before-assert of the real class path.

## CI

Docs-only. mypy strict gate (`ci.yml:43`, 8 `argumentation_analysis` files) untouched. Markdown-lint warnings (MD022/MD058/MD060) are IDE-only, not in CI, and match the surrounding docs' compact style.

Refs: discovered during R503 doc-staleness reconnaissance (consolidation mandate). Companion to #1306 (mechanical typo fix). Worker po-2025, no self-merge — awaiting coordinator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)