### PR TITLE
docs(fallacy): fix ContextualFallacyDetector + EnhancedComplexFallacyAnalyzer API accuracy

### DIFF
--- a/docs/technical/complex_fallacy_analyzer.md
+++ b/docs/technical/complex_fallacy_analyzer.md
@@ -1,50 +1,35 @@
-# Analyseur de Sophismes Complexes
+# Analyseur de sophismes complexes (`EnhancedComplexFallacyAnalyzer`)
 
 ## Objectif
-Analyse les structures argumentatives complexes et identifie les erreurs logiques imbriquées.
+Analyse la structure globale d'un ensemble d'arguments : identifie les patrons structurels de chaque argument, les relations (support, contradiction) entre arguments, puis évalue la cohérence globale et les vulnérabilités potentielles.
+
+## Chemin d'import
+```python
+from argumentation_analysis.plugins.analysis_tools.logic.complex_fallacy_analyzer import EnhancedComplexFallacyAnalyzer
+```
 
 ## Utilisation
 ```python
-from argumentation_analysis.tools import EnhancedComplexFallacyAnalyzer
+from argumentation_analysis.plugins.analysis_tools.logic.complex_fallacy_analyzer import EnhancedComplexFallacyAnalyzer
 
-analyzer = EnhancedComplexFallacyAnalyzer(depth=3, strict_mode=False)
-result = analyzer.analyze(text="Texte à analyser")
-print(result.complex_fallacies)  # Liste des sophismes imbriqués
-print(result.dependency_tree)  # Arbre des dépendances logiques
+# La construction requiert un détecteur de sophismes (AbstractFallacyDetector) injecté.
+analyzer = EnhancedComplexFallacyAnalyzer(fallacy_detector=mon_detecteur)
+result = analyzer.analyze_argument_structure(
+    arguments=["Argument 1.", "Argument 2.", "Argument 3."],
+    context="général",  # optionnel
+)
+print(result)  # Dict[str, Any] : structures, relations, cohérence, vulnérabilités
 ```
 
-## Paramètres
-| Paramètre | Type | Description | Valeur par défaut |
-|-----------|------|-------------|-------------------|
-| `depth` | int | Profondeur d'analyse des structures | 2 |
-| `strict_mode` | bool | Mode strict pour détection rigoureuse | False |
-| `language_model` | str | Modèle LLM à utiliser | "default" |
+## Constructeur
+`EnhancedComplexFallacyAnalyzer(fallacy_detector: AbstractFallacyDetector)` — un détecteur de sophismes **requis**.
 
-## Résultats
-- Arbre des dépendances logiques
-- Liste des sophismes imbriqués avec niveaux
-- Score de complexité logique
-- Suggestions de simplification
+## Méthodes principales
+- `analyze_argument_structure(arguments: list[str], context: str = "général") -> dict`
+- `detect_composite_fallacies(...)`
+- `analyze_inter_argument_coherence(...)`
 
-## Exemple de Diagramme
-```mermaid
-graph TD
-    A[Argument principal] --> B[Argument secondaire 1]
-    A --> C[Argument secondaire 2]
-    B --> D[Sophisme de type X]
-    C --> E[Sophisme de type Y]
-    D --> F[Sous-sophisme de type Z]
-    classDef complex fill:#ffcc99,stroke:#000;
-    classDef simple fill:#cce5ff,stroke:#000;
-    class D,E,F complex
-```
+## Résultat
+`Dict[str, Any]` riche : structures identifiées, relations entre arguments, évaluation de cohérence, vulnérabilités potentielles. Source de vérité : `argumentation_analysis/plugins/analysis_tools/logic/complex_fallacy_analyzer.py`.
 
-## Extension
-Pour ajouter un nouveau niveau d'analyse :
-```python
-class CustomDepthAnalyzer:
-    def analyze_depth(self, structure):
-        # Implémentation personnalisée
-        return depth_score, explanations
-
-analyzer.add_depth_analyzer(CustomDepthAnalyzer())
+> Note : ce document et `enhanced_complex_fallacy_analyzer.md` décrivent la même classe (`EnhancedComplexFallacyAnalyzer`).

--- a/docs/technical/contextual_fallacy_detector.md
+++ b/docs/technical/contextual_fallacy_detector.md
@@ -1,48 +1,32 @@
-# Détecteur de Sophismes Contextuels
+# Détecteur de sophismes contextuels (`ContextualFallacyDetector`)
 
 ## Objectif
-Identifie les erreurs rhétoriques dans leur contexte, en analysant les relations sémantiques entre les arguments.
+Détecte les sophismes contextuels dans un argument : pour chaque sophisme de la base de règles, recherche ses marqueurs dans le texte, calcule une gravité selon le contexte, et signale le sophisme si sa gravité dépasse 0.5.
+
+## Chemin d'import
+```python
+from argumentation_analysis.agents.tools.analysis.new.contextual_fallacy_detector import ContextualFallacyDetector
+```
 
 ## Utilisation
 ```python
-from argumentation_analysis.tools import ContextualFallacyDetector
+from argumentation_analysis.agents.tools.analysis.new.contextual_fallacy_detector import ContextualFallacyDetector
 
-detector = ContextualFallacyDetector(sensitivity=0.8, context_window=100)
-result = detector.analyze(text="Texte à analyser")
-print(result.fallacies)  # Liste des sophismes détectés
-print(result.context_map)  # Cartographie des relations contextuelles
+detector = ContextualFallacyDetector()
+result = detector.detect_contextual_fallacies(
+    argument="Cet argument...",
+    context_description="Débat parlementaire sur l'énergie",
+    # contextual_factors={"audience": "experts"},  # optionnel ; inféré depuis la description sinon
+)
+print(result)  # Dict[str, Any] : sophismes détectés pour cet argument
 ```
 
-## Paramètres
-| Paramètre | Type | Description | Valeur par défaut |
-|-----------|------|-------------|-------------------|
-| `sensitivity` | float | Niveau de sensibilité à la détection | 0.7 |
-| `context_window` | int | Taille de la fenêtre contextuelle | 80 |
-| `language_model` | str | Modèle LLM à utiliser | "default" |
+## Constructeur
+`ContextualFallacyDetector()` — aucun paramètre.
 
-## Résultats
-- Liste des sophismes avec type, position et gravité
-- Cartographie visuelle des relations contextuelles
-- Exemples de reformulation suggérés
+## Méthodes principales
+- `detect_contextual_fallacies(argument: str, context_description: str, contextual_factors: dict | None = None) -> dict` — un seul argument.
+- `detect_multiple_contextual_fallacies(...)` — plusieurs arguments.
 
-## Exemple de Diagramme
-```mermaid
-graph TD
-    A[Argument 1] -->|Fallacieux| B[Argument 2]
-    B -->|Valide| C[Argument 3]
-    C -->|Ambigu| D[Argument 4]
-    classDef fallacy fill:#ff9999,stroke:#000;
-    classDef valid fill:#cce5ff,stroke:#000;
-    class A fallacy
-    class D fallacy
-```
-
-## Extension
-Pour ajouter un nouveau type de sophisme :
-```python
-class CustomFallacyDetector:
-    def detect(self, context):
-        # Implémentation personnalisée
-        return fallacy_type, confidence
-
-detector.register_detector(CustomFallacyDetector())
+## Résultat
+`Dict[str, Any]` contenant la liste des sophismes détectés pour l'argument (gravité > 0.5). Source de vérité : `argumentation_analysis/agents/tools/analysis/new/contextual_fallacy_detector.py`.

--- a/docs/technical/enhanced_complex_fallacy_analyzer.md
+++ b/docs/technical/enhanced_complex_fallacy_analyzer.md
@@ -1,47 +1,35 @@
-# Analyseur de sophismes complexes
+# Analyseur de sophismes complexes (`EnhancedComplexFallacyAnalyzer`)
 
 ## Objectif
-Analyse les structures argumentatives complexes pour détecter les sophismes imbriqués et les contradictions multiples.
+Analyse la structure globale d'un ensemble d'arguments : identifie les patrons structurels de chaque argument, les relations (support, contradiction) entre arguments, puis évalue la cohérence globale et les vulnérabilités potentielles.
+
+## Chemin d'import
+```python
+from argumentation_analysis.plugins.analysis_tools.logic.complex_fallacy_analyzer import EnhancedComplexFallacyAnalyzer
+```
 
 ## Utilisation
 ```python
-from argumentation_analysis.tools import EnhancedComplexFallacyAnalyzer
+from argumentation_analysis.plugins.analysis_tools.logic.complex_fallacy_analyzer import EnhancedComplexFallacyAnalyzer
 
-analyzer = EnhancedComplexFallacyAnalyzer()
-result = analyzer.analyze(text="""
-1. Les énergies renouvelables sont coûteuses.
-2. Pourtant, les pays développés investissent massivement dedans.
-3. Donc, les pays développés sont irresponsables financièrement.
-4. Cependant, les énergies renouvelables réduisent les émissions.
-""")
-print(result.fallacy_tree)  # Structure hiérarchique des sophismes
+# La construction requiert un détecteur de sophismes (AbstractFallacyDetector) injecté.
+analyzer = EnhancedComplexFallacyAnalyzer(fallacy_detector=mon_detecteur)
+result = analyzer.analyze_argument_structure(
+    arguments=["Argument 1.", "Argument 2.", "Argument 3."],
+    context="général",  # optionnel
+)
+print(result)  # Dict[str, Any] : structures, relations, cohérence, vulnérabilités
 ```
 
-## Paramètres
-- `text` (str): Texte à analyser
-- `analysis_depth` (int, optional): Profondeur d'analyse (1-5, défaut: 3)
-- `explanations` (bool, optional): Activer les explications détaillées (défaut: False)
-- `visualization` (bool, optional): Générer une visualisation (défaut: False)
+## Constructeur
+`EnhancedComplexFallacyAnalyzer(fallacy_detector: AbstractFallacyDetector)` — un détecteur de sophismes **requis**.
 
-## Résultats
-Retourne un objet contenant:
-- `fallacy_tree` (dict): Structure hiérarchique des sophismes détectés
-- `confidence_matrix` (list): Matrice de confiance entre les arguments
-- `suggestions` (list): Recommandations pour clarifier la structure
-- `visualization_url` (str): Lien vers la visualisation générée
+## Méthodes principales
+- `analyze_argument_structure(arguments: list[str], context: str = "général") -> dict`
+- `detect_composite_fallacies(...)`
+- `analyze_inter_argument_coherence(...)`
 
-## Personnalisation
-Pour ajouter un nouveau type d'analyse:
-```python
-class CustomComplexFallacyChecker:
-    def analyze(self, argument_graph):
-        # Implémentation personnalisée
-        return fallacy_tree, confidence_scores
-```
+## Résultat
+`Dict[str, Any]` riche : structures identifiées, relations entre arguments, évaluation de cohérence, vulnérabilités potentielles. Source de vérité : `argumentation_analysis/plugins/analysis_tools/logic/complex_fallacy_analyzer.py`.
 
-```mermaid
-graph TD
-    A[Texte d'entrée] --> B[Construction du graphe d'arguments]
-    B --> C[Détection des cycles et contradictions]
-    C --> D[Analyse des relations imbriquées]
-    D --> E[Rapport structuré]
+> Note : ce document et `complex_fallacy_analyzer.md` décrivent la même classe (`EnhancedComplexFallacyAnalyzer`).

--- a/docs/technical/outils_reference/complex_fallacy_analyzer.md
+++ b/docs/technical/outils_reference/complex_fallacy_analyzer.md
@@ -1,50 +1,35 @@
-# Analyseur de Sophismes Complexes
+# Analyseur de sophismes complexes (`EnhancedComplexFallacyAnalyzer`)
 
 ## Objectif
-Analyse les structures argumentatives complexes et identifie les erreurs logiques imbriquées.
+Analyse la structure globale d'un ensemble d'arguments : identifie les patrons structurels de chaque argument, les relations (support, contradiction) entre arguments, puis évalue la cohérence globale et les vulnérabilités potentielles.
+
+## Chemin d'import
+```python
+from argumentation_analysis.plugins.analysis_tools.logic.complex_fallacy_analyzer import EnhancedComplexFallacyAnalyzer
+```
 
 ## Utilisation
 ```python
-from argumentation_analysis.tools import EnhancedComplexFallacyAnalyzer
+from argumentation_analysis.plugins.analysis_tools.logic.complex_fallacy_analyzer import EnhancedComplexFallacyAnalyzer
 
-analyzer = EnhancedComplexFallacyAnalyzer(depth=3, strict_mode=False)
-result = analyzer.analyze(text="Texte à analyser")
-print(result.complex_fallacies)  # Liste des sophismes imbriqués
-print(result.dependency_tree)  # Arbre des dépendances logiques
+# La construction requiert un détecteur de sophismes (AbstractFallacyDetector) injecté.
+analyzer = EnhancedComplexFallacyAnalyzer(fallacy_detector=mon_detecteur)
+result = analyzer.analyze_argument_structure(
+    arguments=["Argument 1.", "Argument 2.", "Argument 3."],
+    context="général",  # optionnel
+)
+print(result)  # Dict[str, Any] : structures, relations, cohérence, vulnérabilités
 ```
 
-## Paramètres
-| Paramètre | Type | Description | Valeur par défaut |
-|-----------|------|-------------|-------------------|
-| `depth` | int | Profondeur d'analyse des structures | 2 |
-| `strict_mode` | bool | Mode strict pour détection rigoureuse | False |
-| `language_model` | str | Modèle LLM à utiliser | "default" |
+## Constructeur
+`EnhancedComplexFallacyAnalyzer(fallacy_detector: AbstractFallacyDetector)` — un détecteur de sophismes **requis**.
 
-## Résultats
-- Arbre des dépendances logiques
-- Liste des sophismes imbriqués avec niveaux
-- Score de complexité logique
-- Suggestions de simplification
+## Méthodes principales
+- `analyze_argument_structure(arguments: list[str], context: str = "général") -> dict`
+- `detect_composite_fallacies(...)`
+- `analyze_inter_argument_coherence(...)`
 
-## Exemple de Diagramme
-```mermaid
-graph TD
-    A[Argument principal] --> B[Argument secondaire 1]
-    A --> C[Argument secondaire 2]
-    B --> D[Sophisme de type X]
-    C --> E[Sophisme de type Y]
-    D --> F[Sous-sophisme de type Z]
-    classDef complex fill:#ffcc99,stroke:#000;
-    classDef simple fill:#cce5ff,stroke:#000;
-    class D,E,F complex
-```
+## Résultat
+`Dict[str, Any]` riche : structures identifiées, relations entre arguments, évaluation de cohérence, vulnérabilités potentielles. Source de vérité : `argumentation_analysis/plugins/analysis_tools/logic/complex_fallacy_analyzer.py`.
 
-## Extension
-Pour ajouter un nouveau niveau d'analyse :
-```python
-class CustomDepthAnalyzer:
-    def analyze_depth(self, structure):
-        # Implémentation personnalisée
-        return depth_score, explanations
-
-analyzer.add_depth_analyzer(CustomDepthAnalyzer())
+> Note : ce document et `enhanced_complex_fallacy_analyzer.md` décrivent la même classe (`EnhancedComplexFallacyAnalyzer`).

--- a/docs/technical/outils_reference/contextual_fallacy_detector.md
+++ b/docs/technical/outils_reference/contextual_fallacy_detector.md
@@ -1,48 +1,32 @@
-# Détecteur de Sophismes Contextuels
+# Détecteur de sophismes contextuels (`ContextualFallacyDetector`)
 
 ## Objectif
-Identifie les erreurs rhétoriques dans leur contexte, en analysant les relations sémantiques entre les arguments.
+Détecte les sophismes contextuels dans un argument : pour chaque sophisme de la base de règles, recherche ses marqueurs dans le texte, calcule une gravité selon le contexte, et signale le sophisme si sa gravité dépasse 0.5.
+
+## Chemin d'import
+```python
+from argumentation_analysis.agents.tools.analysis.new.contextual_fallacy_detector import ContextualFallacyDetector
+```
 
 ## Utilisation
 ```python
-from argumentation_analysis.tools import ContextualFallacyDetector
+from argumentation_analysis.agents.tools.analysis.new.contextual_fallacy_detector import ContextualFallacyDetector
 
-detector = ContextualFallacyDetector(sensitivity=0.8, context_window=100)
-result = detector.analyze(text="Texte à analyser")
-print(result.fallacies)  # Liste des sophismes détectés
-print(result.context_map)  # Cartographie des relations contextuelles
+detector = ContextualFallacyDetector()
+result = detector.detect_contextual_fallacies(
+    argument="Cet argument...",
+    context_description="Débat parlementaire sur l'énergie",
+    # contextual_factors={"audience": "experts"},  # optionnel ; inféré depuis la description sinon
+)
+print(result)  # Dict[str, Any] : sophismes détectés pour cet argument
 ```
 
-## Paramètres
-| Paramètre | Type | Description | Valeur par défaut |
-|-----------|------|-------------|-------------------|
-| `sensitivity` | float | Niveau de sensibilité à la détection | 0.7 |
-| `context_window` | int | Taille de la fenêtre contextuelle | 80 |
-| `language_model` | str | Modèle LLM à utiliser | "default" |
+## Constructeur
+`ContextualFallacyDetector()` — aucun paramètre.
 
-## Résultats
-- Liste des sophismes avec type, position et gravité
-- Cartographie visuelle des relations contextuelles
-- Exemples de reformulation suggérés
+## Méthodes principales
+- `detect_contextual_fallacies(argument: str, context_description: str, contextual_factors: dict | None = None) -> dict` — un seul argument.
+- `detect_multiple_contextual_fallacies(...)` — plusieurs arguments.
 
-## Exemple de Diagramme
-```mermaid
-graph TD
-    A[Argument 1] -->|Fallacieux| B[Argument 2]
-    B -->|Valide| C[Argument 3]
-    C -->|Ambigu| D[Argument 4]
-    classDef fallacy fill:#ff9999,stroke:#000;
-    classDef valid fill:#cce5ff,stroke:#000;
-    class A fallacy
-    class D fallacy
-```
-
-## Extension
-Pour ajouter un nouveau type de sophisme :
-```python
-class CustomFallacyDetector:
-    def detect(self, context):
-        # Implémentation personnalisée
-        return fallacy_type, confidence
-
-detector.register_detector(CustomFallacyDetector())
+## Résultat
+`Dict[str, Any]` contenant la liste des sophismes détectés pour l'argument (gravité > 0.5). Source de vérité : `argumentation_analysis/agents/tools/analysis/new/contextual_fallacy_detector.py`.

--- a/docs/technical/outils_reference/enhanced_complex_fallacy_analyzer.md
+++ b/docs/technical/outils_reference/enhanced_complex_fallacy_analyzer.md
@@ -1,47 +1,35 @@
-# Analyseur de sophismes complexes
+# Analyseur de sophismes complexes (`EnhancedComplexFallacyAnalyzer`)
 
 ## Objectif
-Analyse les structures argumentatives complexes pour détecter les sophismes imbriqués et les contradictions multiples.
+Analyse la structure globale d'un ensemble d'arguments : identifie les patrons structurels de chaque argument, les relations (support, contradiction) entre arguments, puis évalue la cohérence globale et les vulnérabilités potentielles.
+
+## Chemin d'import
+```python
+from argumentation_analysis.plugins.analysis_tools.logic.complex_fallacy_analyzer import EnhancedComplexFallacyAnalyzer
+```
 
 ## Utilisation
 ```python
-from argumentation_analysis.tools import EnhancedComplexFallacyAnalyzer
+from argumentation_analysis.plugins.analysis_tools.logic.complex_fallacy_analyzer import EnhancedComplexFallacyAnalyzer
 
-analyzer = EnhancedComplexFallacyAnalyzer()
-result = analyzer.analyze(text="""
-1. Les énergies renouvelables sont coûteuses.
-2. Pourtant, les pays développés investissent massivement dedans.
-3. Donc, les pays développés sont irresponsables financièrement.
-4. Cependant, les énergies renouvelables réduisent les émissions.
-""")
-print(result.fallacy_tree)  # Structure hiérarchique des sophismes
+# La construction requiert un détecteur de sophismes (AbstractFallacyDetector) injecté.
+analyzer = EnhancedComplexFallacyAnalyzer(fallacy_detector=mon_detecteur)
+result = analyzer.analyze_argument_structure(
+    arguments=["Argument 1.", "Argument 2.", "Argument 3."],
+    context="général",  # optionnel
+)
+print(result)  # Dict[str, Any] : structures, relations, cohérence, vulnérabilités
 ```
 
-## Paramètres
-- `text` (str): Texte à analyser
-- `analysis_depth` (int, optional): Profondeur d'analyse (1-5, défaut: 3)
-- `explanations` (bool, optional): Activer les explications détaillées (défaut: False)
-- `visualization` (bool, optional): Générer une visualisation (défaut: False)
+## Constructeur
+`EnhancedComplexFallacyAnalyzer(fallacy_detector: AbstractFallacyDetector)` — un détecteur de sophismes **requis**.
 
-## Résultats
-Retourne un objet contenant:
-- `fallacy_tree` (dict): Structure hiérarchique des sophismes détectés
-- `confidence_matrix` (list): Matrice de confiance entre les arguments
-- `suggestions` (list): Recommandations pour clarifier la structure
-- `visualization_url` (str): Lien vers la visualisation générée
+## Méthodes principales
+- `analyze_argument_structure(arguments: list[str], context: str = "général") -> dict`
+- `detect_composite_fallacies(...)`
+- `analyze_inter_argument_coherence(...)`
 
-## Personnalisation
-Pour ajouter un nouveau type d'analyse:
-```python
-class CustomComplexFallacyChecker:
-    def analyze(self, argument_graph):
-        # Implémentation personnalisée
-        return fallacy_tree, confidence_scores
-```
+## Résultat
+`Dict[str, Any]` riche : structures identifiées, relations entre arguments, évaluation de cohérence, vulnérabilités potentielles. Source de vérité : `argumentation_analysis/plugins/analysis_tools/logic/complex_fallacy_analyzer.py`.
 
-```mermaid
-graph TD
-    A[Texte d'entrée] --> B[Construction du graphe d'arguments]
-    B --> C[Détection des cycles et contradictions]
-    C --> D[Analyse des relations imbriquées]
-    D --> E[Rapport structuré]
+> Note : ce document et `complex_fallacy_analyzer.md` décrivent la même classe (`EnhancedComplexFallacyAnalyzer`).


### PR DESCRIPTION
## What

Same fabricated-API pattern as the coherence-evaluator docs (#1307): these fallacy-analyzer docs described an API that matches the code on **no point**. Rewritten to the verified real API.

## API corrections

**`ContextualFallacyDetector`** — `argumentation_analysis/agents/tools/analysis/new/contextual_fallacy_detector.py`

| Doc (was) | Reality |
|---|---|
| `argumentation_analysis.tools` (dead) | `argumentation_analysis.agents.tools.analysis.new` |
| `analyze(text=...)` | `detect_contextual_fallacies(argument, context_description, contextual_factors=None)` |
| `__init__(sensitivity=0.8, context_window=100)` | `__init__()` — no args |
| `result.fallacies` / `result.context_map` (object) | `Dict[str, Any]` (fallacies with severity > 0.5) |
| `register_detector()` | no such API |

**`EnhancedComplexFallacyAnalyzer`** — `argumentation_analysis/plugins/analysis_tools/logic/complex_fallacy_analyzer.py`

| Doc (was) | Reality |
|---|---|
| `argumentation_analysis.tools` (dead) | `argumentation_analysis.plugins.analysis_tools.logic.complex_fallacy_analyzer` |
| `analyze(text=...)` | `analyze_argument_structure(arguments, context="général")` |
| `__init__(depth=3, strict_mode=False)` / no-arg | `__init__(fallacy_detector: AbstractFallacyDetector)` — a detector is **required** |
| `result.complex_fallacies` / `dependency_tree` (object) | `Dict[str, Any]` (structures, relations, coherence, vulnerabilities) |
| `add_depth_analyzer()` | no such API |

## Files (6 — ×2 duplicate dirs `docs/technical/` + `outils_reference/`)

- `contextual_fallacy_detector.md`: real import path, no-arg ctor, `detect_contextual_fallacies`, dict return.
- `complex_fallacy_analyzer.md` + `enhanced_complex_fallacy_analyzer.md`: both import `EnhancedComplexFallacyAnalyzer` — rewritten to the real plugin path, required-detector ctor, `analyze_argument_structure`, dict return. Cross-note added that the two docs describe the **same class** (dedup is coordinator-scoped).

## NOT touched here — zombie classes (next sweep)

These docs reference classes that **do not exist anywhere** in the code (grep: zero `.py` definitions), same as the `CoherenceEvaluator` zombie retired in #1307:
- `visualizer.md` → `RhetoricalVisualizer` (real neighbors: `RhetoricalResultVisualizer`, `EnhancedRhetoricalResultVisualizer`, `ArgumentStructureVisualizer`)
- `integration_outils.md` + `outils_analyse_rhetorique.md` → `RhetoricalAnalysisSystem` (no `*AnalysisSystem` class exists)

These need deeper doc↔class matching (which real class, if any, corresponds to the doc's intent) → queued for a follow-up PR. Flagged here for visibility.

## CI

Docs-only. mypy strict gate (`ci.yml:43`, 8 `argumentation_analysis` files) untouched. Markdown-lint warnings (MD022/MD031/MD032) are IDE-only, not in CI, and match the surrounding docs' compact style.

Refs: R503/R504 doc-staleness reconnaissance (consolidation mandate). Companion to #1306 (typo) + #1307 (coherence evaluator). Worker po-2025, no self-merge — awaiting coordinator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)