### PR TITLE
docs(visualizer): fix RhetoricalResultVisualizer API (RhetoricalVisualizer zombie)

### DIFF
--- a/docs/technical/outils_reference/visualizer.md
+++ b/docs/technical/outils_reference/visualizer.md
@@ -1,43 +1,34 @@
-# Visualiseur de Résultats Rhétoriques
+# Visualiseur de résultats rhétoriques (`RhetoricalResultVisualizer`)
 
 ## Objectif
-Génère des représentations graphiques des analyses argumentatives pour une meilleure compréhension visuelle.
+Génère des visualisations (graphes d'arguments, distributions de sophismes, cartes de chaleur, rapport HTML) à partir de l'état d'analyse rhétorique (`state`).
+
+> Note : la classe réelle est **`RhetoricalResultVisualizer`** (le nom `RhetoricalVisualizer` utilisé précédemment dans ce document n'existe pas dans le code).
+
+## Chemin d'import
+```python
+from argumentation_analysis.agents.tools.analysis.rhetorical_result_visualizer import RhetoricalResultVisualizer
+```
 
 ## Utilisation
 ```python
-from argumentation_analysis.tools import RhetoricalVisualizer
+from argumentation_analysis.agents.tools.analysis.rhetorical_result_visualizer import RhetoricalResultVisualizer
 
-visualizer = RhetoricalVisualizer(style="mermaid", detail_level=2)
-result = visualizer.generate(analysis_results)
-print(result.mermaid_code)  # Code Mermaid pour intégration
+visualizer = RhetoricalResultVisualizer()
+mermaid_graph = visualizer.generate_argument_graph(state)   # str : code Mermaid
+all_viz = visualizer.generate_all_visualizations(state)     # Dict[str, str]
+html = visualizer.generate_html_report(state)               # str : rapport HTML
 ```
 
-## Paramètres
-| Paramètre | Type | Description | Valeur par défaut |
-|-----------|------|-------------|-------------------|
-| `style` | str | Format de visualisation (mermaid, svg, etc.) | "mermaid" |
-| `detail_level` | int | Niveau de détail des diagrammes | 1 |
-| `theme` | str | Thème visuel | "default" |
+## Constructeur
+`RhetoricalResultVisualizer()` — aucun paramètre.
 
-## Exemple de Sortie
-```mermaid
-graph TD
-    A[Argument Principal] --> B[Argument 1]
-    A --> C[Argument 2]
-    B --> D[Sophisme de type X]
-    C --> E[Sophisme de type Y]
-    D --> F[Segment incohérent]
-    classDef fallacy fill:#ff4d4d,stroke:#000;
-    classDef valid fill:#90ee90,stroke:#000;
-    class D,E,F fallacy
-```
+## Méthodes principales (toutes prennent un `state: dict`)
+- `generate_argument_graph(state) -> str` — graphe Mermaid des arguments.
+- `generate_fallacy_distribution(state) -> str` — distribution des sophismes.
+- `generate_argument_quality_heatmap(state) -> str` — carte de chaleur de qualité.
+- `generate_all_visualizations(state) -> dict[str, str]` — toutes les visualisations.
+- `generate_html_report(state) -> str` — rapport HTML agrégé.
 
-## Extension
-Pour ajouter un nouveau format de visualisation :
-```python
-class CustomVisualizer:
-    def generate(self, results):
-        # Implémentation personnalisée
-        return visualization_data
-
-visualizer.register_format("custom", CustomVisualizer())
+## Résultat
+Chaque générateur retourne une chaîne (ou un dict de chaînes pour `generate_all_visualizations`). Source de vérité : `argumentation_analysis/agents/tools/analysis/rhetorical_result_visualizer.py`.

--- a/docs/technical/visualizer.md
+++ b/docs/technical/visualizer.md
@@ -1,43 +1,34 @@
-# Visualiseur de Résultats Rhétoriques
+# Visualiseur de résultats rhétoriques (`RhetoricalResultVisualizer`)
 
 ## Objectif
-Génère des représentations graphiques des analyses argumentatives pour une meilleure compréhension visuelle.
+Génère des visualisations (graphes d'arguments, distributions de sophismes, cartes de chaleur, rapport HTML) à partir de l'état d'analyse rhétorique (`state`).
+
+> Note : la classe réelle est **`RhetoricalResultVisualizer`** (le nom `RhetoricalVisualizer` utilisé précédemment dans ce document n'existe pas dans le code).
+
+## Chemin d'import
+```python
+from argumentation_analysis.agents.tools.analysis.rhetorical_result_visualizer import RhetoricalResultVisualizer
+```
 
 ## Utilisation
 ```python
-from argumentation_analysis.tools import RhetoricalVisualizer
+from argumentation_analysis.agents.tools.analysis.rhetorical_result_visualizer import RhetoricalResultVisualizer
 
-visualizer = RhetoricalVisualizer(style="mermaid", detail_level=2)
-result = visualizer.generate(analysis_results)
-print(result.mermaid_code)  # Code Mermaid pour intégration
+visualizer = RhetoricalResultVisualizer()
+mermaid_graph = visualizer.generate_argument_graph(state)   # str : code Mermaid
+all_viz = visualizer.generate_all_visualizations(state)     # Dict[str, str]
+html = visualizer.generate_html_report(state)               # str : rapport HTML
 ```
 
-## Paramètres
-| Paramètre | Type | Description | Valeur par défaut |
-|-----------|------|-------------|-------------------|
-| `style` | str | Format de visualisation (mermaid, svg, etc.) | "mermaid" |
-| `detail_level` | int | Niveau de détail des diagrammes | 1 |
-| `theme` | str | Thème visuel | "default" |
+## Constructeur
+`RhetoricalResultVisualizer()` — aucun paramètre.
 
-## Exemple de Sortie
-```mermaid
-graph TD
-    A[Argument Principal] --> B[Argument 1]
-    A --> C[Argument 2]
-    B --> D[Sophisme de type X]
-    C --> E[Sophisme de type Y]
-    D --> F[Segment incohérent]
-    classDef fallacy fill:#ff4d4d,stroke:#000;
-    classDef valid fill:#90ee90,stroke:#000;
-    class D,E,F fallacy
-```
+## Méthodes principales (toutes prennent un `state: dict`)
+- `generate_argument_graph(state) -> str` — graphe Mermaid des arguments.
+- `generate_fallacy_distribution(state) -> str` — distribution des sophismes.
+- `generate_argument_quality_heatmap(state) -> str` — carte de chaleur de qualité.
+- `generate_all_visualizations(state) -> dict[str, str]` — toutes les visualisations.
+- `generate_html_report(state) -> str` — rapport HTML agrégé.
 
-## Extension
-Pour ajouter un nouveau format de visualisation :
-```python
-class CustomVisualizer:
-    def generate(self, results):
-        # Implémentation personnalisée
-        return visualization_data
-
-visualizer.register_format("custom", CustomVisualizer())
+## Résultat
+Chaque générateur retourne une chaîne (ou un dict de chaînes pour `generate_all_visualizations`). Source de vérité : `argumentation_analysis/agents/tools/analysis/rhetorical_result_visualizer.py`.


### PR DESCRIPTION
## What

`visualizer.md` documented a class **`RhetoricalVisualizer` that does not exist** (grep: zero `.py` definitions) — same zombie pattern as `CoherenceEvaluator` (#1307). The doc's title "Visualiseur de **Résultats** Rhétoriques" + intent map cleanly to the real **`RhetoricalResultVisualizer`**. Rewritten to the verified API.

Verified against `argumentation_analysis/agents/tools/analysis/rhetorical_result_visualizer.py` (exported in `analysis/__init__.py`):

| Doc (was) | Reality |
|---|---|
| `argumentation_analysis.tools` (dead) | `argumentation_analysis.agents.tools.analysis.rhetorical_result_visualizer` |
| `RhetoricalVisualizer` | `RhetoricalResultVisualizer` |
| `generate(analysis_results)` | `generate_argument_graph(state)` / `generate_fallacy_distribution(state)` / `generate_argument_quality_heatmap(state)` / `generate_all_visualizations(state)` / `generate_html_report(state)` |
| `__init__(style=, detail_level=, theme=)` | `__init__()` — no args |
| `result.mermaid_code` (object) | `str` / `Dict[str, str]` |
| `register_format()` | no such API |

## Files (2 — duplicate dirs `docs/technical/` + `outils_reference/`)

Rewritten to the real class, no-arg ctor, the 5 `generate_*` methods (all take a `state: dict`), `str`/`dict` returns. Note added that `RhetoricalVisualizer` was a non-existent alias.

## Remaining zombie (NOT touched here — queued)

`integration_outils.md` + `outils_analyse_rhetorique.md` reference **`RhetoricalAnalysisSystem`**, also non-existent (no `*AnalysisSystem` class exists). Unlike the visualizer, this one has **no clean 1:1 real equivalent** — it likely refers to the overall analysis pipeline/orchestrator rather than a single class. Needs a deeper decision (redirect to the pipeline entry point? mark historical?) → separate follow-up.

## CI

Docs-only. mypy strict gate (`ci.yml:43`, 8 `argumentation_analysis` files) untouched. Markdown-lint warnings are IDE-only, not in CI, matching surrounding docs' compact style.

Refs: R503/R504 doc-staleness reconnaissance (consolidation mandate). Companion to #1306 (typo), #1307 (coherence), #1308 (fallacy). Worker po-2025, no self-merge — awaiting coordinator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)