### PR TITLE
docs(integration): replace fabricated RhetoricalAnalysisSystem facade with real entry points

### DIFF
--- a/docs/technical/integration_outils.md
+++ b/docs/technical/integration_outils.md
@@ -1,65 +1,61 @@
 # Guide d'Intégration des Outils Rhétorique
 
-## Intégration dans des Projets Existants
+> ⚠️ **Note de véracité (2026-06-30).** Les versions précédentes de ce guide décrivaient une
+> façade `RhetoricalAnalysisSystem` (`system.configure_tool(...)`, `system.create_pipeline([...])`,
+> `pipeline.analyze(...)`) ainsi qu'une dépendance `mermaid` et un paquet `argumentation-analysis`
+> installable par pip. **Aucun de ces éléments n'existe dans le code** (vérifié : pas de classe
+> `RhetoricalAnalysisSystem`, pas de paquet publié, pas de dépendance `mermaid`). Le vrai système
+> suit l'**architecture Lego** (`CapabilityRegistry` + `UnifiedPipeline` + `WorkflowDSL` +
+> `AgentFactory`) documentée dans `CLAUDE.md` et `docs/architecture/INTEGRATION_STRATEGY.md`.
+> Les exemples ci-dessous sont ancrés sur les **vrais** points d'entrée du dépôt.
 
-### Architecture de Base
-```mermaid
-graph TD
-    A[Projet Existant] --> B[Module d'Analyse]
-    B --> C[Outils Rhétoriques]
-    C --> D[Évaluateur de Cohérence]
-    C --> E[Détecteur de Sophismes]
-    C --> F[Analyseur Complexe]
-```
+## Points d'entrée réels
 
-### Étapes d'Intégration
-1. **Installation** : `pip install argumentation-analysis`
-2. **Importation** : 
-   ```python
-   from argumentation_analysis import RhetoricalAnalysisSystem
-   ```
-3. **Configuration** :
-   ```python
-   system = RhetoricalAnalysisSystem()
-   system.configure_tool("coherence_evaluator", {"threshold": 0.7})
-   ```
-4. **Utilisation dans un Pipeline** :
-   ```python
-   pipeline = system.create_pipeline([
-       "coherence_evaluator",
-       "contextual_fallacy_detector"
-   ])
-   results = pipeline.analyze(user_input)
-   ```
+| Usage | Point d'entrée | Statut |
+|---|---|---|
+| API REST (recommandé) | `api/main.py` (FastAPI, `uvicorn api.main:app`) | réel |
+| CLI multi-modes | `argumentation_analysis/run_orchestration.py` (`--mode pipeline\|conversational`, `--workflow light\|standard\|full`) | réel |
+| Appel programmatique | `argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis` (async) | réel |
 
-## Intégration avec des Frameworks
-### Flask
+## Exemple programmatique (`run_unified_analysis`)
+
 ```python
-@app.route('/analyze', methods=['POST'])
-def analyze():
-    text = request.json['text']
-    results = pipeline.analyze(text)
-    return jsonify(results.visualization)
+import asyncio
+from argumentation_analysis.orchestration.unified_pipeline import run_unified_analysis
+
+async def main():
+    result = await run_unified_analysis(
+        text="Argumentation à analyser.",
+        workflow_name="standard",   # "light" | "standard" | "full"
+    )
+    print(result)   # Dict[str, Any]
+
+asyncio.run(main())
 ```
 
-### FastAPI
-```python
-@app.post("/analyze")
-async def analyze_text(text: str):
-    results = pipeline.analyze(text)
-    return {"visualization": results.visualization}
-```
+`run_unified_analysis` crée un `CapabilityRegistry` (via `setup_registry()`) si aucun n'est fourni, exécute un workflow pré-construit, et retourne un `Dict[str, Any]`. Voir la signature complète dans `argumentation_analysis/orchestration/unified_pipeline.py`.
 
-## Gestion des Dépendances
+## Installation
+
+Ce dépôt n'est **pas** un paquet pip publié. C'est un projet local (Python 3.10+) :
+1. Cloner le dépôt.
+2. Activer un environnement Conda (`projet-is-roo-new` ou `projet-is`) — voir `CLAUDE.md`.
+3. Copier `.env.example` en `.env` et renseigner les clés API.
+
+## Déploiement (FastAPI)
+
+L'application REST réelle est `api/main.py` :
+
 ```bash
-# Requirements.txt
-argumentation-analysis>=1.2.0
-mermaid>=10.3.0
+uvicorn api.main:app --reload --port 8000
 ```
 
-## Déploiement
 ```dockerfile
-FROM python:3.9
+FROM python:3.10
 COPY . /app
+WORKDIR /app
 RUN pip install -r requirements.txt
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+Pour les routes disponibles, voir `api/main.py` (7 routeurs, 25+ routes).

--- a/docs/technical/outils_analyse_rhetorique.md
+++ b/docs/technical/outils_analyse_rhetorique.md
@@ -1,7 +1,14 @@
-# Documentation des Outils d'Analyse Rhétorique Améliorés
+# Documentation des Outils d'Analyse Rhétorique
+
+> ⚠️ **Note de véracité (2026-06-30).** L'exemple précédent utilisait une façade
+> `RhetoricalAnalysisSystem` (`system.configure_tool(...)`, `system.create_pipeline([...])`,
+> `pipeline.analyze(...)`). **Cette classe n'existe pas dans le code** (vérifié). Le vrai point
+> d'entrée programmatique est `run_unified_analysis` (async,
+> `argumentation_analysis.orchestration.unified_pipeline`). Les paramètres par outil documentés
+> ci-après renvoient aux docs par classe, corrigés contre le code (#1307/#1308/#1309).
 
 ## Vue d'Ensemble
-Les outils d'analyse rhétorique améliorés offrent une infrastructure modulaire pour l'analyse argumentative, intégrant trois couches d'abstraction :
+Les outils d'analyse rhétorique offrent une infrastructure modulaire pour l'analyse argumentative, organisée selon l'architecture Lego (`CapabilityRegistry` + `UnifiedPipeline` + `WorkflowDSL` + `AgentFactory`).
 
 ```mermaid
 graph TD
@@ -16,60 +23,45 @@ graph TD
 3. **Analyse de complexité logique** : Étude des structures argumentatives complexes
 4. **Visualisation des résultats** : Représentation graphique des analyses
 
-## Exemple d'Utilisation
+## Exemple d'Utilisation (`run_unified_analysis`)
+
 ```python
-from argumentation_analysis import RhetoricalAnalysisSystem
+import asyncio
+from argumentation_analysis.orchestration.unified_pipeline import run_unified_analysis
 
-# Initialisation du système
-system = RhetoricalAnalysisSystem()
+async def main():
+    result = await run_unified_analysis(
+        text="Argumentation complexe à analyser.",
+        workflow_name="standard",   # "light" | "standard" | "full"
+    )
+    print(result)   # Dict[str, Any] : résultats d'analyse agrégés
 
-# Configuration des outils
-system.configure_tool("coherence_evaluator", {
-    "threshold": 0.7,
-    "explanations": True
-})
-
-# Création d'un pipeline
-pipeline = system.create_pipeline([
-    "coherence_evaluator",
-    "contextual_fallacy_detector",
-    "enhanced_complex_fallacy_analyzer"
-])
-
-# Exécution de l'analyse
-results = pipeline.analyze(text="Argumentation complexe à analyser")
-print(results.visualization)
+asyncio.run(main())
 ```
 
-## Paramètres Clés
-| Outil | Paramètres | Valeurs par défaut |
-|-------|------------|-------------------|
-| `coherence_evaluator` | `threshold`, `explanations` | 0.65, False |
-| `contextual_fallacy_detector` | `sensitivity`, `context_window` | 0.8, 100 |
-| `enhanced_complex_fallacy_analyzer` | `depth`, `strict_mode` | 3, False |
+## Outils par classe (API vérifiée contre le code)
 
-## Résultats Attendus
-- Score de cohérence entre 0 et 1
-- Liste des sophismes détectés avec leur type et position
-- Représentation graphique au format Mermaid
-- Suggestions de réécriture pour les textes problématiques
+Voir les documents dédiés dans `docs/technical/` :
 
-## Améliorations par Rapport aux Limitations Initiales
-1. **Gestion des contextes complexes** : Nouveau système de fenêtrage contextuel
-2. **Performance optimisée** : Architecture asynchrone pour les analyses parallèles
-3. **Extensibilité** : API standardisée pour l'ajout de nouveaux critères
-4. **Robustesse** : Mécanismes de validation des extraits d'arguments
+| Outil | Classe réelle | Doc |
+|---|---|---|
+| Évaluateur de cohérence | `ArgumentCoherenceEvaluator` | `argument_coherence_evaluator.md` |
+| Détecteur de sophismes contextuels | `ContextualFallacyDetector` | `contextual_fallacy_detector.md` |
+| Analyseur de sophismes complexes | `EnhancedComplexFallacyAnalyzer` | `complex_fallacy_analyzer.md` |
+| Visualiseur de résultats | `RhetoricalResultVisualizer` | `visualizer.md` |
 
-## Structure des Fichiers
+> Note : `coherence_evaluator.md` est un redirect (l'ancien nom `CoherenceEvaluator` n'existe pas).
+
+## Résultats
+`run_unified_analysis` retourne un `Dict[str, Any]` agrégeant les sorties des phases du workflow (cohérence, sophismes, structure, etc.). Pour une restitution lisible, voir le paramètre `render_restitution=True` de `run_unified_analysis` (rapport 3-actes).
+
+## Structure des Fichiers (docs par outil)
+
 ```
-docs/outils/
-├── coherence_evaluator.md
+docs/technical/
+├── argument_coherence_evaluator.md
 ├── contextual_fallacy_detector.md
 ├── complex_fallacy_analyzer.md
+├── enhanced_complex_fallacy_analyzer.md
 └── visualizer.md
 ```
-
-## Prochaines Étapes
-1. Créer les documents spécifiques pour chaque outil dans `docs/outils/`
-2. Ajouter des diagrammes détaillés pour chaque composant
-3. Documenter les cas d'utilisation avancés


### PR DESCRIPTION
## What

Two overview/integration docs described a **top-level facade that does not exist** and a **published pip package that was never published**. This was the last zombie from the R503/R504 doc-staleness sweep — unlike the per-class zombies (#1307/#1308/#1309, which had clean class swaps), this one had **no 1:1 real class**, so the examples are now anchored on the **real pipeline entry point**.

Verified against the repo: no class `RhetoricalAnalysisSystem` (grep: zero definitions), no `configure_tool`/`create_pipeline`/`pipeline.analyze` API, no `mermaid` dependency, no `argumentation-analysis` PyPI package, no `docs/outils/` directory.

## Real entry points (all verified present)

| Usage | Entry point |
|---|---|
| API REST | `api/main.py` (FastAPI, `uvicorn api.main:app`) |
| CLI | `argumentation_analysis/run_orchestration.py` |
| Programmatic | `argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis` (async) |

## Changes (2 files)

**`integration_outils.md`** — honesty header; real entry-point table; example rewritten to `run_unified_analysis(text, workflow_name)` (verified signature at `orchestration/unified_pipeline.py:55`); installation = local project (Python 3.10+, conda, not pip-installable); Docker `python:3.9`→`3.10` + real `uvicorn api.main:app`; dropped fabricated Flask/FastAPI `pipeline.analyze` examples + fake `mermaid` dep + the `argumentiation-analysis` typo.

**`outils_analyse_rhetorique.md`** — honesty header; example rewritten to `run_unified_analysis`; the fabricated "Paramètres Clés" table (which cross-referenced the `threshold`/`sensitivity`/`depth` params now corrected in #1307/#1308/#1309) replaced by a table pointing to the **real** per-class docs + real class names; fake `docs/outils/` structure → real `docs/technical/` paths.

## Why not a class swap

`RhetoricalAnalysisSystem` was a facade (`configure_tool`, `create_pipeline`) with no single real equivalent — the real system is the Lego architecture (`CapabilityRegistry` + `UnifiedPipeline` + `WorkflowDSL`). Forcing a fake class swap would re-fabricate. Anchoring on the real `run_unified_analysis` pipeline entry is the honest fix (anti-pendule: subtract the fabrication, point to what's verified).

## CI

Docs-only. mypy strict gate (`ci.yml:43`, 8 `argumentation_analysis` files) untouched. Markdown-lint warnings are IDE-only, not in CI.

Refs: closes the doc-staleness sweep started in R503/R504. Companion to #1306 (typo), #1307 (coherence), #1308 (fallacy), #1309 (visualizer). Worker po-2025, no self-merge — awaiting coordinator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)