### PR TITLE
docs(accuracy): finish rhetorical-system facade sweep (#1311)

### DIFF
--- a/docs/integration/integration_outils_rhetorique.md
+++ b/docs/integration/integration_outils_rhetorique.md
@@ -1,65 +1,76 @@
 # Guide d'Intégration des Outils Rhétorique
 
+> Les points d'entrée réels sont `run_unified_analysis` (async), l'API REST
+> `api/main.py` et le CLI `run_orchestration.py`. L'ancienne classe
+> `RhetoricalAnalysisSystem` (`configure_tool` / `create_pipeline`) n'existe pas
+> dans le code.
+
 ## Intégration dans des Projets Existants
 
 ### Architecture de Base
+
 ```mermaid
 graph TD
-    A[Projet Existant] --> B[Module d'Analyse]
-    B --> C[Outils Rhétoriques]
-    C --> D[Évaluateur de Cohérence]
-    C --> E[Détecteur de Sophismes]
-    C --> F[Analyseur Complexe]
+    A[Projet Existant] --> B[run_unified_analysis]
+    B --> C[Détection de sophismes]
+    B --> D[Logique formelle FOL/Modal/PL]
+    B --> E[Évaluation qualité / gouvernance]
 ```
 
 ### Étapes d'Intégration
-1. **Installation** : `pip install argumentation-analysis`
-2. **Importation** : 
+
+1. **Environnement** : activer l'environnement Conda (`projet-is-roo-new`) et
+   renseigner les clés API dans `.env` (voir `CLAUDE.md`, section Build & Environment).
+2. **Appel principal** :
+
    ```python
-   from argumentation_analysis import RhetoricalAnalysisSystem
-   ```
-3. **Configuration** :
-   ```python
-   system = RhetoricalAnalysisSystem()
-   system.configure_tool("coherence_evaluator", {"threshold": 0.7})
-   ```
-4. **Utilisation dans un Pipeline** :
-   ```python
-   pipeline = system.create_pipeline([
-       "coherence_evaluator",
-       "contextual_fallacy_detector"
-   ])
-   results = pipeline.analyze(user_input)
+   import asyncio
+   from argumentation_analysis.orchestration.unified_pipeline import run_unified_analysis
+
+   async def analyze(text: str):
+       return await run_unified_analysis(text, workflow_name="standard")
+
+   results = asyncio.run(analyze("Texte à analyser"))
    ```
 
+3. **Choix du workflow** : `light` | `standard` | `full` (paramètre `workflow_name`).
+
 ## Intégration avec des Frameworks
+
 ### Flask
+
 ```python
+import asyncio
+from argumentation_analysis.orchestration.unified_pipeline import run_unified_analysis
+
 @app.route('/analyze', methods=['POST'])
 def analyze():
     text = request.json['text']
-    results = pipeline.analyze(text)
-    return jsonify(results.visualization)
+    results = asyncio.run(run_unified_analysis(text))
+    return jsonify(results)
 ```
 
 ### FastAPI
+
 ```python
+from argumentation_analysis.orchestration.unified_pipeline import run_unified_analysis
+
 @app.post("/analyze")
 async def analyze_text(text: str):
-    results = pipeline.analyze(text)
-    return {"visualization": results.visualization}
+    return await run_unified_analysis(text)
 ```
 
-## Gestion des Dépendances
-```bash
-# Requirements.txt
-argumentation-analysis>=1.2.0
-mermaid>=10.3.0
-```
+## Dépendances
+
+L'environnement complet est défini par Conda (`projet-is-roo-new`) et le fichier
+`.env` (clés API OpenAI / OpenRouter). Il n'y a pas de paquet pip
+`argumentation-analysis` à installer ; le projet s'exécute depuis le dépôt.
+Voir `CLAUDE.md` (section Build & Environment).
 
 ## Déploiement
-```dockerfile
-FROM python:3.9
-COPY . /app
-RUN pip install -r requirements.txt
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+Point d'entrée REST recommandé :
+
+```bash
+uvicorn api.main:app --reload --port 8000
+```

--- a/docs/technical/api_outils.md
+++ b/docs/technical/api_outils.md
@@ -1,119 +1,102 @@
-# Référence API - Outils d'Analyse Rhétorique
+# Référence API — Analyse Rhétorique
 
-## Architecture Modulaire
-```mermaid
-classDiagram
-    class RhetoricalAnalysisSystem {
-        +configure_tool(tool_name, params)
-        +create_pipeline(tools_list)
-        +analyze(text)
-    }
-    
-    class StrategicLayer {
-        +plan_analysis(text)
-        +allocate_tools(pipeline)
-    }
-    
-    class TacticalLayer {
-        +coordinate_tools()
-        +resolve_conflicts(results)
-    }
-    
-    class OperationalLayer {
-        +execute_tool(tool, text)
-        +format_results(data)
-    }
-    
-    StrategicLayer <|--> RhetoricalAnalysisSystem
-    TacticalLayer <|--> StrategicLayer
-    OperationalLayer <|--> TacticalLayer
+> ⚠️ **Note d'exactitude.** Les versions précédentes de cette page décrivaient une
+> classe `RhetoricalAnalysisSystem` (`configure_tool` / `create_pipeline` / `analyze`)
+> ainsi que des modules `tools/`, `BaseRhetoricalTool`, `RhetoricalResults`,
+> `StrategicLayer`, `TacticalLayer`, `OperationalLayer`, `MermaidVisualizer`,
+> `LLMValidator`, etc. **Aucun de ces éléments n'existe dans le code.**
+> Cette page documente les vrais points d'entrée. Le code source reste la source
+> de vérité (`argumentation_analysis/`).
+
+## Hiérarchie d'agents (3 tiers)
+
+```text
+Strategic   → Orchestrators (workflows multi-étapes)
+Tactical    → Coordinators (interactions entre agents)
+Operational → Base agents (Sherlock, Watson, FOL, Modal, PL, détection de sophismes)
 ```
 
-## Modules Principaux
+Source : `argumentation_analysis/agents/core/`, `docs/architecture/`.
 
-### Module Core
+## Point d'entrée principal — `run_unified_analysis`
+
 ```python
-class BaseRhetoricalTool:
-    def analyze(self, text: str) -> RhetoricalResults:
-        pass
+import asyncio
+from argumentation_analysis.orchestration.unified_pipeline import run_unified_analysis
 
-class RhetoricalResults:
-    def __init__(self, score: float, explanations: List[str], visualization: str):
-        self.score = score
-        self.explanations = explanations
-        self.visualization = visualization
+async def main():
+    results = await run_unified_analysis(
+        text="Texte à analyser",
+        workflow_name="standard",   # "light" | "standard" | "full"
+    )
+    print(results)
+
+asyncio.run(main())
 ```
 
-### Module Strategic
+Signature vérifiée dans `argumentation_analysis/orchestration/unified_pipeline.py` :
+
 ```python
-class StrategicPlanner:
-    def create_analysis_plan(self, text: str) -> AnalysisPlan:
-        """Génère un plan d'analyse basé sur la structure du texte"""
-        
-class AnalysisPlan:
-    def __init__(self, steps: List[AnalysisStep]):
-        self.steps = steps
+async def run_unified_analysis(
+    text: str,
+    workflow_name: str = "standard",
+    registry: Optional[CapabilityRegistry] = None,
+    custom_workflow: Optional[WorkflowDefinition] = None,
+    ...
+) -> Dict[str, Any]
 ```
 
-### Module Tactical
+## Architecture Lego — `CapabilityRegistry`
+
+Le registre central câble agents, plugins et services. `UnifiedPipeline.setup_registry()`
+enregistre automatiquement tous les composants.
+
 ```python
-class TacticalResolver:
-    def resolve_tool_chain(self, plan: AnalysisPlan) -> List[ToolExecution]:
-        """Crée une chaîne d'exécution des outils"""
-        
-class ToolExecution:
-    def __init__(self, tool_name: str, parameters: Dict[str, Any]):
-        self.tool_name = tool_name
-        self.parameters = parameters
+from argumentation_analysis.core.capability_registry import CapabilityRegistry
+
+registry = CapabilityRegistry()
+registry.register_agent(name="my_agent", agent_class=MyAgent)
+registry.register_plugin(name="my_plugin", plugin_class=MyPlugin)
+registry.register_service(name="my_service", service_class=MyService)
+
+# Recherche par capacité (find_*_for_capability)
+agent = registry.find_agent_for_capability("...")
 ```
 
-### Module Operational
+Source : `argumentation_analysis/core/capability_registry.py`.
+
+## Écrire un nouvel outil / plugin
+
+Le mécanisme d'extension réel est un **plugin Semantic Kernel** (méthode décorée
+`@kernel_function`) enregistré dans `CapabilityRegistry`. Il n'existe pas de
+classe de base `BaseRhetoricalTool` ni de `tool_registry`.
+
 ```python
-class MermaidVisualizer:
-    def generate(self, results: RhetoricalResults) -> str:
-        """Convertit les résultats en diagramme Mermaid"""
-        
-class LLMValidator:
-    def validate_extracts(self, text: str) -> ValidationReport:
-        """Valide les extraits avec un modèle LLM"""
+from semantic_kernel.functions import kernel_function
+from argumentation_analysis.core.capability_registry import CapabilityRegistry
+
+class MyToolPlugin:
+    @kernel_function(description="Analyse personnalisée")
+    def analyze(self, text: str) -> dict:
+        return {"score": 0.8, "details": "..."}
+
+registry = CapabilityRegistry()
+registry.register_plugin(name="my_tool", plugin_class=MyToolPlugin)
 ```
 
-## Améliorations Techniques
-| Limitation Initiale | Solution Implémentée |
-|---------------------|---------------------|
-| Gestion des contextes | Fenêtrage contextuel dynamique |
-| Performance | Exécution asynchrone des outils |
-| Extensibilité | Système de plug-ins modulaire |
-| Robustesse | Validation des extraits avec LLM |
+Voir aussi les plugins existants : `argumentation_analysis/plugins/`
+(`quality_scoring_plugin.py`, `french_fallacy_plugin.py`, `governance_plugin.py`).
 
-## Exemple d'API Utilisation
-```python
-from argumentation_analysis import RhetoricalAnalysisSystem
+## Autres points d'entrée
 
-system = RhetoricalAnalysisSystem()
-system.configure_tool("coherence_evaluator", {"threshold": 0.7})
+| Point d'entrée | Localisation | Usage |
+|----------------|--------------|-------|
+| API REST FastAPI | `api/main.py` | 7 routers, 25+ routes, WebSocket streaming |
+| CLI multi-mode | `argumentation_analysis/run_orchestration.py` | `--mode pipeline\|conversational\|legacy` |
+| Web UI Starlette | `interface_web/app.py` | Frontend React + API d'analyse |
 
-plan = StrategicPlanner().create_analysis_plan("Texte à analyser")
-executions = TacticalResolver().resolve_tool_chain(plan)
+## Workflows pré-construits
 
-results = OperationalLayer().execute_tool_chain(executions)
-visualization = MermaidVisualizer().generate(results)
-```
-
-## Structure des Répertoires
-```
-argumentation_analysis/
-├── orchestration/
-│   ├── strategic/
-│   │   ├── planner.py
-│   │   └── allocator.py
-│   ├── tactical/
-│   │   ├── coordinator.py
-│   │   └── resolver.py
-│   └── operational/
-│       ├── adapters/
-│       └── manager.py
-└── tools/
-    ├── coherence.py
-    ├── fallacy.py
-    └── visualizer.py
+`UnifiedPipeline` expose 3 workflows : `light`, `standard`, `full`
+(plus `collaborative`), construits déclarativement via `WorkflowDSL`
+(`argumentation_analysis/orchestration/workflow_dsl.py`).

--- a/docs/technical/developpement_outils.md
+++ b/docs/technical/developpement_outils.md
@@ -29,41 +29,71 @@ evaluator.add_criterion(CustomCoherenceCriterion())
 ```
 
 ### Créer un Nouveau Type de Sophisme
+
+Il n'existe pas d'API `register_detector()` de type plug-in. Deux voies réelles :
+
+**1. Sous-classer un détecteur existant** et surcharger sa logique de règles :
+
 ```python
-from argumentation_analysis.tools import ContextualFallacyDetector
+from argumentation_analysis.agents.tools.analysis.new.contextual_fallacy_detector import ContextualFallacyDetector
+
+class CustomFallacyDetector(ContextualFallacyDetector):
+    def detect_contextual_fallacies(self, argument, context_description, contextual_factors=None):
+        # Règle personnalisée, puis complétion par la détection de base
+        result = super().detect_contextual_fallacies(argument, context_description, contextual_factors)
+        # ...ajouter ou modifier les détections dans result...
+        return result
+
+detector = CustomFallacyDetector()
+result = detector.detect_contextual_fallacies(
+    argument="Argument à analyser",
+    context_description="Contexte du débat",
+)
+```
+
+**2. Exposer la détection comme un plugin Semantic Kernel** (méthode recommandée
+pour l'intégration au registre) via `@kernel_function`, puis l'enregistrer :
+
+```python
+from semantic_kernel.functions import kernel_function
+from argumentation_analysis.core.capability_registry import CapabilityRegistry
 
 class CustomFallacyPlugin:
-    def detect(self, context):
+    @kernel_function(description="Détecte un sophisme personnalisé")
+    def detect(self, argument: str) -> dict:
         # Logique de détection personnalisée
-        if self._is_fallacious(context):
-            return "custom_fallacy", 0.95
-        return None, 0.0
+        return {"fallacy": "custom_fallacy", "confidence": 0.95}
 
-# Enregistrement du plugin
-detector = ContextualFallacyDetector()
-detector.register_detector(CustomFallacyPlugin())
+registry = CapabilityRegistry()
+registry.register_plugin(name="custom_fallacy", plugin_class=CustomFallacyPlugin)
 ```
 
 ## Créer un Nouvel Outil
 
 ### Structure de Base
-```python
-from argumentation_analysis.core import BaseRhetoricalTool
 
-class MyNewTool(BaseRhetoricalTool):
+> Les classes `BaseRhetoricalTool` / `RhetoricalResults` et le `tool_registry`
+> décrits dans les versions précédentes n'existent pas dans le code. Le mécanisme
+> d'extension réel est l'architecture Lego : un plugin Semantic Kernel
+> (`@kernel_function`) enregistré dans `CapabilityRegistry`.
+
+```python
+from semantic_kernel.functions import kernel_function
+from argumentation_analysis.core.capability_registry import CapabilityRegistry
+
+class MyNewToolPlugin:
     def __init__(self, param1, param2):
-        super().__init__()
         self.param1 = param1
         self.param2 = param2
 
-    def analyze(self, text):
+    @kernel_function(description="Analyse personnalisée")
+    def analyze(self, text: str) -> dict:
         # Implémentation de l'analyse
-        results = self._process(text)
-        return RhetoricalResults(results)
+        return {"score": 0.8, "details": "..."}
 
-# Enregistrement de l'outil
-from argumentation_analysis.registry import tool_registry
-tool_registry.register("my_new_tool", MyNewTool)
+# Enregistrement dans le registre (Lego architecture)
+registry = CapabilityRegistry()
+registry.register_plugin(name="my_new_tool", plugin_class=MyNewToolPlugin)
 ```
 
 ## Bonnes Pratiques
@@ -85,13 +115,12 @@ graph LR
 ```
 
 ## Structure de Répertoire
-```
+
+```text
 argumentation_analysis/
-├── tools/
-│   ├── __init__.py
-│   ├── coherence.py
-│   ├── fallacy.py
-│   └── custom_tool.py  ← Nouvel outil
-└── tests/
-    └── tools/
-        └── test_custom_tool.py  ← Tests associés
+├── agents/                     # BaseAgent + agents (logic, extract, informal, synthesis…)
+│   └── tools/analysis/new/     # Évaluateurs/détecteurs (coherence, fallacy…)
+├── core/                       # CapabilityRegistry, communication, llm_service, jvm_setup
+├── orchestration/              # unified_pipeline, workflow_dsl, hierarchical/
+└── plugins/                    # plugins SK (quality, fallacy, governance)
+```


### PR DESCRIPTION
## What

Completes the doc-staleness sweep that **#1310** started. PR #1310 fixed the `RhetoricalAnalysisSystem` facade in 2 docs but missed 2 sibling docs + 1 extension-API file. This PR fixes the remaining instances — all **verified against source** before rewriting (anti-pendule / verify-before-assert, no new fabrications introduced).

## Files changed (3)

### `docs/technical/api_outils.md` — full rewrite
The entire page described a fabricated API. Removed:
- `RhetoricalAnalysisSystem` class (`configure_tool` / `create_pipeline` / `analyze`)
- Zombie classes: `BaseRhetoricalTool`, `RhetoricalResults`, `StrategicLayer`, `TacticalLayer`, `OperationalLayer`, `MermaidVisualizer`, `LLMValidator`
- Fabricated `tools/` module tree

Replaced with verified real entry points:
- `run_unified_analysis(text, workflow_name, ...)` — signature checked at `orchestration/unified_pipeline.py:55`
- `CapabilityRegistry.register_agent/register_plugin/register_service` — checked at `core/capability_registry.py:163/181/199`
- `@kernel_function` plugin pattern — import checked at `plugins/quality_scoring_plugin.py:14`
- Real entry-point table (`api/main.py`, `run_orchestration.py`, `interface_web/app.py`)

### `docs/integration/integration_outils_rhetorique.md`
- Facade `RhetoricalAnalysisSystem` → real `run_unified_analysis` (async)
- Flask/FastAPI examples: fabricated `pipeline.analyze()` → `run_unified_analysis`
- Deps: removed nonexistent pip pkg `argumentation-analysis` → honest Conda env + `.env`
- Deploy: fabricated dockerfile → real `uvicorn api.main:app`

### `docs/technical/developpement_outils.md` (3 sections — #1307's coherence block left untouched)
- **Créer un Nouveau Type de Sophisme**: fabricated `register_detector()` → real paths (subclass `ContextualFallacyDetector.detect_contextual_fallacies` OR `@kernel_function` plugin). Verified `detect_contextual_fallacies(self, argument, ...)` at `contextual_fallacy_detector.py:291`; grep confirmed no `register`/`plugin`/`add_` mechanism exists.
- **Créer un Nouvel Outil**: fabricated `BaseRhetoricalTool` / `RhetoricalResults` / `tool_registry.register()` → real `@kernel_function` plugin + `CapabilityRegistry.register_plugin()`.
- **Structure de Répertoire**: typo `argumentiation_analysis` + fabricated `tools/coherence.py`/`fallacy.py` → real `argumentation_analysis/` structure.

## Verification
Every replaced API was grep-confirmed in source before rewriting. Post-edit grep of the 3 files confirms **no remaining** `RhetoricalAnalysisSystem` / `register_detector` / `BaseRhetoricalTool` / `tool_registry` / `argumentiation` typo in the edited regions (the only residual `argumentiation`/`CoherenceEvaluator` match is in #1307's region of `developpement_outils.md`, which this PR deliberately does not touch).

## Merge notes for coord
- **Disjoint from #1307**: edits to `developpement_outils.md` avoid the CoherenceEvaluator block (lines 15-29) that #1307 owns → clean 3-way merge.
- **Expected conflict with #1306** (repo-wide typo PR) on the 3 files: #1306 changes the `argumentiation`→`argumentation` token on lines this PR fully rewrites. Resolve by taking **this PR's version** (supersedes the typo-only edits with correct content).
- Doc-only, no code, no tests → no CI risk. markdown-lint warnings are pre-existing / IDE-only (not CI-gated; only mypy strict gates CI per #1303).

## Related
- Completes scope of #1310 (facade sweep)
- Coordinates with #1306 (typo), #1307 (coherence block)