### PR TITLE
docs(readme): fix 18 broken internal links in docs/ index (post-#33 reorg)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,24 +9,23 @@ La documentation est organisée en plusieurs sections thématiques :
 ### [Architecture](./architecture/README.md)
 Documentation de l'architecture du système d'analyse argumentative, incluant l'architecture hiérarchique à trois niveaux, les systèmes de communication entre agents, et l'analyse des orchestrations agentiques Sherlock/Watson.
 
-### [Audit](./audit/README.md)
-Documentation relative aux audits du projet et de la documentation.
+### [Audit](./reports/README.md)
+Documentation relative aux audits du projet et de la documentation (regroupée sous `reports/` après la réorganisation des dossiers de docs).
 
-### [Composants](./composants/README.md)
+### [Composants](./architecture/interactions_composants.md)
 Description détaillée des différents composants qui constituent le système d'analyse argumentative, leur fonctionnement et leurs interactions.
 
 ### [Guides](./guides/README.md)
 Guides d'utilisation et tutoriels pour vous aider à comprendre et à utiliser efficacement le système d'analyse argumentative, incluant les patterns d'orchestration des modes.
 
-<!-- TODO: Le fichier docs/images/README.md est actuellement vide. Évaluer s'il doit être peuplé (par ex. avec une liste/catégorisation des images) ou si le lien dans cette section devrait pointer directement vers le dossier ./images/ ou si l'entrée "Images" devrait être supprimée si ce dossier n'est pas destiné à être navigué via un README. -->
-### [Images](./images/README.md)
-Diagrammes et schémas illustrant l'architecture et les concepts du système d'analyse argumentative.
+### [Images](./media/README.md)
+Diagrammes et schémas illustrant l'architecture et les concepts du système d'analyse argumentative (dossier `media/` après la réorganisation).
 
 ### [Intégration](./integration/README.md)
 Documentation des processus d'intégration et de validation du système d'analyse argumentative, incluant les guides d'intégration et les procédures de validation.
 
-<!-- TODO: Vérifier la distinction et la pertinence des contenus entre le répertoire [Outils](./outils/README.md) (documentation détaillée, fonctionnement, utilisation) et le document [Outils d'Analyse Rhétorique](./outils_analyse_rhetorique.md) (présentation). S'assurer que les titres et descriptions reflètent clairement cette distinction et qu'il n'y a pas de chevauchement excessif. -->
-### [Outils](./outils/README.md)
+<!-- TODO: Vérifier la distinction et la pertinence des contenus entre le répertoire [Outils](./technical/README.md) (documentation détaillée, fonctionnement, utilisation) et le document [Outils d'Analyse Rhétorique](./technical/outils_analyse_rhetorique.md) (présentation). S'assurer que les titres et descriptions reflètent clairement cette distinction et qu'il n'y a pas de chevauchement excessif. -->
+### [Outils](./technical/README.md)
 Documentation des outils d'analyse rhétorique disponibles dans le système, leur fonctionnement, leur utilisation et leurs dernières fonctionnalités.
 
 ### [Projets](./projets/README.md)
@@ -37,16 +36,16 @@ Documentation de référence pour les API du système d'analyse argumentative.
 
 ## Documents Principaux
 
-### [Conventions d'Importation](./conventions_importation.md)
+### [Conventions d'Importation](./guides/conventions_importation.md)
 Documentation des conventions d'importation et des mécanismes de redirection utilisés dans le projet.
 
-### [Structure du Projet](./structure_projet.md)
+### [Structure du Projet](./technical/structure_projet.md)
 Description détaillée de la structure du projet, incluant l'organisation des dossiers et des fichiers.
 
-### [Analyse de l'Architecture d'Orchestration](./analyse_architecture_orchestration.md)
+### [Analyse de l'Architecture d'Orchestration](./architecture/analyse_architecture_orchestration.md)
 Analyse approfondie de l'architecture d'orchestration du système.
 
-### [Architecture Hiérarchique à Trois Niveaux](./architecture_hierarchique_trois_niveaux.md)
+### [Architecture Hiérarchique à Trois Niveaux](./architecture/ARCHITECTURE_HIERARCHIQUE_3_NIVEAUX.md)
 Description détaillée de l'architecture hiérarchique à trois niveaux qui structure le système.
 
 ### [Système de Communication entre Agents](./architecture/communication_agents.md)
@@ -58,22 +57,22 @@ Analyse complète des flux d'orchestration dans les conversations agentiques ent
 ### [Conception du Système de Communication Multi-Canal](./integration/conception_systeme_communication_multi_canal.md)
 Présentation de la conception du système de communication multi-canal pour les agents.
 
-### [Outils d'Analyse Rhétorique](./outils_analyse_rhetorique.md)
+### [Outils d'Analyse Rhétorique](./technical/outils_analyse_rhetorique.md)
 Présentation des outils d'analyse rhétorique disponibles dans le système.
 
-### [API des Outils Rhétoriques](./api_outils_rhetorique.md)
+### [API des Outils Rhétoriques](./technical/api_outils.md)
 Documentation de l'API des outils d'analyse rhétorique.
 
-### [Extraits Chiffrés](./extraits_chiffres.md)
-Documentation détaillée sur le système d'extraits chiffrés utilisé pour l'analyse rhétorique, incluant la structure du fichier, les mécanismes de chiffrement et les outils de manipulation.
+### [Extraits Chiffrés](../CLAUDE.md)
+Règles de gestion et discipline de confidentialité du corpus chiffré utilisé pour l'analyse (section « Dataset Privacy Discipline » de CLAUDE.md — le contenu détaillé a été consolidé dans le canon du dépôt).
 
 ### [Intégration des Outils Rhétoriques](./integration/integration_outils_rhetorique.md)
 Guide pour l'intégration des outils d'analyse rhétorique dans le système.
 
-### [Validation de l'Intégration](./validation_integration.md)
+### [Validation de l'Intégration](./integration/validation_integration.md)
 Procédures et critères pour valider l'intégration du système.
 
-### [Liste de Vérification pour le Déploiement](./liste_verification_deploiement.md)
+### [Liste de Vérification pour le Déploiement](./integration/liste_verification_deploiement.md)
 Liste exhaustive des points à vérifier avant le déploiement du système.
 
 ### [Guide des Patterns d'Orchestration](./guides/GUIDE_PATTERNS_ORCHESTRATION_MODES.md)
@@ -83,11 +82,11 @@ Guide complet des patterns d'orchestration utilisés dans le projet, incluant 5 
 
 Si vous débutez avec le système d'analyse argumentative, nous vous recommandons de suivre ces étapes :
 
-1. Consultez la [Structure du Projet](./structure_projet.md) pour comprendre l'organisation générale
+1. Consultez la [Structure du Projet](./technical/structure_projet.md) pour comprendre l'organisation générale
 2. Explorez l'[Architecture](./architecture/README.md) pour comprendre les principes de conception
 3. Suivez les [Guides](./guides/README.md) pour apprendre à utiliser le système
-4. Consultez la documentation des [Outils](./outils/README.md) pour comprendre les fonctionnalités disponibles
-5. Familiarisez-vous avec le [système d'extraits chiffrés](./extraits_chiffres.md) pour comprendre comment les contenus sensibles sont gérés
+4. Consultez la documentation des [Outils](./technical/README.md) pour comprendre les fonctionnalités disponibles
+5. Familiarisez-vous avec le [système d'extraits chiffrés](../CLAUDE.md) pour comprendre comment les contenus sensibles sont gérés
 
 ## Contribution à la Documentation
 


### PR DESCRIPTION
## What

`docs/README.md` — the docs directory index (auto-rendered by GitHub when browsing `docs/`) — had **all 18 of its internal links broken**. They referenced the pre-reorg flat structure; **PR #33 (2026-02-24, reorganize docs/ 53→17 dirs)** moved/renamed targets but this index was never updated.

## Changes (every target verified to exist — verify-before-assert)

| Link | Was (broken) | Now (verified) | Reason |
|------|------|------|--------|
| Outils d'Analyse Rhétorique | `./outils_analyse_rhetorique.md` | `./technical/outils_analyse_rhetorique.md` | moved |
| Conventions d'Importation | `./conventions_importation.md` | `./guides/conventions_importation.md` | moved |
| Structure du Projet (×2) | `./structure_projet.md` | `./technical/structure_projet.md` | moved |
| Analyse Archi. Orchestration | `./analyse_architecture_orchestration.md` | `./architecture/…` | moved |
| Architecture Hiérarchique 3 Niveaux | `./architecture_hierarchique_trois_niveaux.md` | `./architecture/ARCHITECTURE_HIERARCHIQUE_3_NIVEAUX.md` | **renamed** |
| API des Outils Rhétoriques | `./api_outils_rhetorique.md` | `./technical/api_outils.md` | **renamed** |
| Validation de l'Intégration | `./validation_integration.md` | `./integration/validation_integration.md` | moved |
| Liste Vérification Déploiement | `./liste_verification_deploiement.md` | `./integration/…` | moved |
| Audit | `./audit/README.md` | `./reports/README.md` | dir deleted → content in reports/ |
| Composants | `./composants/README.md` | `./architecture/interactions_composants.md` | dir deleted → content moved |
| Images | `./images/README.md` | `./media/README.md` | dir renamed (stale TODO resolved) |
| Outils (×3) | `./outils/README.md` | `./technical/README.md` | dir deleted → content in technical/ |
| Extraits Chiffrés (×2) | `./extraits_chiffres.md` | `../CLAUDE.md` | file gone → topic consolidated in CLAUDE.md "Dataset Privacy Discipline" (description softened to match — anti-pendule) |

## Verification
Linkcheck (relative-link resolver, `:line`-suffix stripped) confirms `docs/README.md`: **18 broken → 0**.

## Scope / out of scope
- This PR fixes ONLY the docs index (highest reader value).
- **Broader gisement**: 1581 broken internal links across 147 files repo-wide — but mostly `docs/_archived/` + `docs/archives/` (frozen historical snapshots, intentionally not touched) + design docs referencing refactored code paths (judgment-heavy). That larger sweep is **coord-gated** (scale + per-path verification) and tracked in a follow-up issue.
- Docs-only, no code change. mypy gate unaffected.

Co-Authored-By: GLM-5.2 <noreply@z.ai>