### PR TITLE
docs(testing): remove 5 phantom scripts from scripts/testing/README.md

### DIFF
--- a/scripts/testing/README.md
+++ b/scripts/testing/README.md
@@ -8,11 +8,7 @@ Ce répertoire contient des scripts spécifiques pour des scénarios de test, de
 - **`get_test_metrics.py`**: Calcule et affiche des métriques sur l'exécution des tests (potentiellement à partir de rapports JUnit/XML).
 - **`run_all_embed_tests.py`** / **`run_embed_tests.py`**: Scripts pour exécuter des tests spécifiques liés à l'embarquement de données ou de modèles.
 - **`run_tests_alternative.py`**: Un autre script pour lancer des tests, potentiellement avec une configuration ou un périmètre différent.
-- **`simple_test_runner.py`** / **`test_runner_simple.py`**: Runners de test simplifiés pour des exécutions rapides ou ciblées.
-- **`simulation_agent_informel.py`** : Script de simulation pour tester le comportement des agents informels dans différents contextes d'analyse.
-- **`test_agent_informel.py`** : Script de test pour valider le fonctionnement des agents informels et leur capacité à analyser des arguments.
-- **`test_fallacy_adapter.py`**: Script dédié au test de l'adaptateur de sophismes, vérifiant sa capacité à interfacer correctement avec les logiques de détection de sophismes.
-- **`test_rhetorical_analysis.py`**: Script pour tester les fonctionnalités d'analyse rhétorique, potentiellement en exécutant des analyses sur des exemples de textes et en validant les sorties.
+- **`simple_test_runner.py`**: Runner de test simplifié pour des exécutions rapides ou ciblées.
 - **`validate_embed_tests.py`**: Valide les résultats des tests d'embarquement.
 
 ## Utilisation


### PR DESCRIPTION
Spawned while executing #1319: the same README documents **5 more non-existent scripts** beyond the L9 bullet #1319 fixes. All confirmed deleted, not moved.

## Summary

`scripts/testing/README.md` was never updated after two consolidated cleanups (`89e150f1` "Remove obsolete demo and diagnostic scripts ... scripts/testing folders" + `a75a150f` Phase C), so it advertised 5 deleted scripts as functional test helpers. This is the same doc-accuracy defect as the L9 bullet, in the same file — found via verify-before-assert while doing #1319.

## Verification (firsthand, verify-before-assert)

| Script (README L11-15) | In `scripts/testing/`? | Git history |
|---|---|---|
| `test_runner_simple.py` | ABSENT | deleted by `a75a150f` Phase C |
| `simulation_agent_informel.py` | ABSENT | deleted by `89e150f1` |
| `test_agent_informel.py` | ABSENT | deleted by `89e150f1` |
| `test_fallacy_adapter.py` | ABSENT | deleted by `89e150f1` |
| `test_rhetorical_analysis.py` | ABSENT | deleted by `89e150f1` |

- **Not moved**: none of the 5 exist anywhere in the repo (`git ls-files '**/<name>.py'` = empty for all). `test_rhetorical_analysis.py` has a namesake at `tests/unit/argumentation_analysis/mocks/` — but that is a pytest mock module, a homonym, not a relocation of the script.
- `simple_test_runner.py` (the surviving half of the L11 bullet) is **kept** and reworded to singular ("Runner", since its pair `test_runner_simple.py` is gone).

## Scope & disjunction

- Touches **L11-L15 only**. **Disjoint from #1319** (L9 bullet). The two PRs compose cleanly (different line ranges of the same file) — whichever merges first, the other rebases trivially.
- **No file deletion** (docs-only edit). Pre-existing markdownlint warnings (MD030 `1.  ` in Bonnes Pratiques section, MD047 trailing newline — both present on `origin/main`) are **out of scope** and left untouched (markdownlint is not a CI gate; only mypy strict is, and no `.py` is touched).

Refs: #1319 (L9 bullet, the paired fix), #1294 (removed the tests/scripts phantom namespace). Worker-scope doc-accuracy, no arbitration needed.

Co-Authored-By: GLM-5.2 <noreply@z.ai>