### PR TITLE
feat(restitution): post-render prose↔annexe cross-check (#1316, approach A)

### DIFF
--- a/argumentation_analysis/reporting/restitution/factual_consistency_check.py
+++ b/argumentation_analysis/reporting/restitution/factual_consistency_check.py
@@ -1,0 +1,184 @@
+"""Deterministic post-render factual cross-check of prose vs appendix (#1316).
+
+Complements the *structural* readability gate (``readability_gate.py``, which
+enforces the weaving rule of spec §4) with a *factual* check: does the rendered
+narrative cite a formal framework as the authority for a verdict the formal data
+does not actually support?
+
+## The gap this closes
+
+The honesty guarantee of the restitution report rests on two pillars:
+
+1. **Prompt discipline** — ``#1297`` removed the Tweety-priming phrasing from the
+   Acte II ``CONSIGNE`` and added an ``INTERDIT`` guardrail, pinned by the
+   regression test ``TestTweetyInconsistanceGapRegression``.
+2. **The LLM obeying that guardrail** — untested, because LLM output is
+   non-deterministic by nature.
+
+The regression test asserts on the *prompt contract* (deterministic) only; it
+cannot see the rendered prose. The structural readability gate checks presence
+and weaving — it deliberately treats « le solveur Tweety confirme
+l'inconsistance » as *woven* (the verb ``confirme`` anchors it), so it passes a
+sentence whose factual claim contradicts the appendix.
+
+Empirically (R485 artifacts, base ``976aea28``), all 3 restitutions **PASSED**
+the readability gate despite Acte II claiming *« le solveur Tweety confirme
+l'inconsistance »* on every corpus while the appendix reported
+``inconsistantes: 0`` everywhere — the contradiction ``#1297`` later fixed at
+the prompt level. **This module is the post-render detector for the residual
+class of bug** (*prose theatre*): prose invoking a formal authority in a
+direction the formal data does not support.
+
+## Approach (#1316 option A — narrow, deterministic, defense-in-depth)
+
+After render, scan the Acte II narrative body: if a line cites a **formal
+authority** (Tweety, Dung, ASPIC, SPASS, EProver, PySAT, … or the generic
+« solveur »/« solver ») **and** asserts an inconsistency
+(``inconsist*`` / ``insatisfais*``), then the appendix's formal-axis aggregates
+must actually support an inconsistency (``inconsistantes > 0``,
+``insatisfiables > 0``, or a decided ``consistante: False``). If none does, the
+claim is unsupported → the report is flagged **FAIL** with an auditable reason.
+
+The check is heuristic and cheap. It never needs LLM determinism and survives
+model swaps. It composes with the ``#1297`` prompt guardrail as defense in
+depth: the prompt *inhibits* the theatre, this module *detects* any that leaks
+through. Symmetric guards (Dung, score-qualité conflation) are possible but out
+of scope here — this targets the empirical failure mode (#1276 / po-2023 R487).
+
+Honesty contract (#1019): the check only ever *reports*; when the appendix data
+is absent (``state is None``) or no authority-backed inconsistency claim is
+present, it returns ``PASS`` silently rather than manufacturing a verdict.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, List, Mapping, Optional
+
+from .appendix import _provenance_counts
+from .readability_gate import GateVerdict
+
+# Formal frameworks / external solvers that, when cited in the narrative, turn a
+# bare "inconsistance" mention into an authority-backed formal claim. Mirrors the
+# spirit of readability_gate._FRAMEWORK_SOLVERS but keeps to the formal-inference
+# authorities (FOL/PL/modal), plus the generic "solveur"/"solver" wording the
+# report prose actually uses (« le solveur Tweety … »).
+_FORMAL_AUTHORITIES = (
+    "tweety",
+    "tweetyproject",
+    "dung",
+    "aspic",
+    "spass",
+    "eprover",
+    "e prover",
+    "pysat",
+    "mace4",
+    "prover9",
+    "solveur",  # generic FR — « le solveur X confirme l'inconsistance »
+    "solver",  # generic EN
+)
+
+# A claim of formal inconsistency. Matches the report's own vocabulary
+# (« inconsistantes », « insatisfaisables »). Intentionally excludes the generic
+# « invalide » (too noisy — used for informal invalidation too) to keep the
+# detector narrow to the *formal-inconsistency* theatre class.
+_INCONSISTENCE_RE = re.compile(r"inconsist|insatisfais", re.IGNORECASE)
+
+
+def _axis_supports_inconsistance(axis: Any) -> bool:
+    """Does a formal-axis status (from ``_provenance_counts``) record a decided
+    inconsistency?
+
+    Covers every axis shape :func:`appendix._fol_axis_status` /
+    :func:`_pl_axis_status` / :func:`_modal_axis_status` emit:
+
+    * FOL / modal-list: ``{"inconsistantes": n, …}``
+    * PL: ``{"insatisfiables": n, …}``
+    * modal-mapping: ``{"consistante": False}``
+
+    A *degraded* axis (``None`` verdict) never counts — it is unverified, not
+    inconsistent (#1019: ``None`` is never collapsed to a decided ``False``).
+    A string status ("indisponible", "disponible") means the axis did not decide
+    an inconsistency, so it does not support an inconsistency claim.
+    """
+    if isinstance(axis, Mapping):
+        if axis.get("inconsistantes"):
+            return True
+        if axis.get("insatisfiables"):
+            return True
+        if axis.get("consistante") is False:
+            return True
+    return False
+
+
+def _axes_support_inconsistance(state: Mapping[str, Any]) -> bool:
+    """Does ANY formal axis in the appendix support a decided inconsistency?"""
+    counts = _provenance_counts(state)
+    return any(
+        _axis_supports_inconsistance(counts.get(k))
+        for k in ("axe_fol", "axe_pl", "axe_modale")
+    )
+
+
+def _unsupported_authority_claims(body: str, *, supported: bool) -> List[str]:
+    """Authority-backed inconsistency claims in ``body`` that the data refutes.
+
+    When ``supported`` is True (the appendix records a decided inconsistency
+    somewhere), authority-backed inconsistency claims are legitimate and an empty
+    list is returned — no theatre. When ``supported`` is False, every line that
+    cites a formal authority AND asserts an inconsistency is unsupported theatre
+    and is returned (stripped) for an auditable reason.
+    """
+    if supported:
+        return []
+    claims: List[str] = []
+    for line in body.splitlines():
+        low = line.lower()
+        if not _INCONSISTENCE_RE.search(low):
+            continue
+        if any(auth in low for auth in _FORMAL_AUTHORITIES):
+            stripped = line.strip()
+            if stripped and stripped not in claims:
+                claims.append(stripped)
+    return claims
+
+
+def check_factual_consistency(
+    body: str,
+    state: Optional[Mapping[str, Any]],
+) -> GateVerdict:
+    """Deterministic post-render cross-check of prose vs appendix (#1316, opt A).
+
+    Args:
+        body: the rendered narrative body (the 3 acts concatenated, *excluding*
+            the folded appendix). This is the surface where prose theatre lives.
+        state: the shared-state mapping the appendix was rendered from (the
+            source of truth for formal verdicts). ``None`` when the renderer was
+            called without a state — in that case the check is skipped (PASS),
+            honestly, rather than inventing a verdict from missing data.
+
+    Returns:
+        A :class:`~.readability_gate.GateVerdict` — ``FAIL`` with an auditable
+        reason when the prose cites a formal authority for an inconsistency the
+        appendix does not record (prose theatre); ``PASS`` otherwise. Mergeable
+        with the structural readability verdict via ``GateVerdict.merge``.
+    """
+    if state is None:
+        return GateVerdict(band="PASS")
+
+    supported = _axes_support_inconsistance(state)
+    claims = _unsupported_authority_claims(body, supported=supported)
+    if not claims:
+        return GateVerdict(band="PASS")
+
+    preview = claims[0][:100]
+    return GateVerdict(
+        band="FAIL",
+        reasons=[
+            f"Prose theatre (#1316) — {len(claims)} affirmation(s) du récit "
+            f"cite(nt) un cadre formel (Tweety/Dung/ASPIC/…) comme autorité "
+            f"d'une inconsistance que l'annexe ne soutient pas (axes formels : "
+            f"inconsistance décidée = {supported}). La prose contredit les "
+            f"données de provenance. Ex : « {preview} »."
+        ],
+    )

--- a/argumentation_analysis/reporting/restitution/renderer.py
+++ b/argumentation_analysis/reporting/restitution/renderer.py
@@ -30,6 +30,7 @@ from typing import Any, Mapping, Optional
 
 from .acts import ACT_TITLES, RestitutionActs
 from .appendix import render_appendix
+from .factual_consistency_check import check_factual_consistency
 from .readability_gate import GateVerdict, ReadabilityGate
 
 # Minimum substantive length for an act body, below which we treat it as
@@ -132,6 +133,13 @@ class RestitutionReportRenderer:
         verdict = self.gate.check(acts)
         if thin_notes:
             verdict = verdict.merge(GateVerdict(band="WARN", reasons=thin_notes))
+
+        # factual cross-check of rendered prose vs appendix (#1316, opt A):
+        # detect prose theatre — a formal authority cited for an inconsistency
+        # the appendix data does not support. Composes with the structural gate
+        # as defense-in-depth with the #1297 prompt guardrail. Skipped honestly
+        # (PASS) when no state was provided (no source of truth to check against).
+        verdict = verdict.merge(check_factual_consistency(body, state))
 
         # assemble the final document
         doc = self._assemble(acts, body, verdict, state, include_full_state_json)

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_factual_consistency_check.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_factual_consistency_check.py
@@ -1,0 +1,240 @@
+"""Tests for the post-render factual prose↔annexe cross-check (#1316, option A).
+
+Pins the detector that closes the residual testability gap of the Tweety
+inconsistency regression (#1297, po-2023 finding R487): the ``#1297`` fix pins
+the *prompt* contract; this detector pins the *rendered prose*. It flags
+*prose theatre* — a formal authority cited in the narrative as the source of an
+inconsistency the appendix's formal-axis aggregates do not record.
+
+All deterministic — no LLM, no JVM. The state is a plain dict (the renderer's
+``state: Mapping`` contract); the body is a hand-written prose string.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from argumentation_analysis.reporting.restitution.factual_consistency_check import (
+    check_factual_consistency,
+)
+from argumentation_analysis.reporting.restitution.readability_gate import GateVerdict
+
+# --- state builders -----------------------------------------------------------
+
+
+def _fol_all_consistent_state() -> Dict[str, Any]:
+    """State where every FOL theory is consistent (0 inconsistantes) — the exact
+    configuration under which the R485 artifacts claimed « Tweety confirme
+    l'inconsistance » (the theatre)."""
+    return {
+        "fol_analysis_results": [
+            {"consistent": True, "message": None},
+            {"consistent": True, "message": None},
+        ],
+        "propositional_analysis_results": [],
+        "modal_analysis_results": [],
+    }
+
+
+def _fol_with_inconsistance_state() -> Dict[str, Any]:
+    """State where FOL actually records an inconsistency (1 inconsistante)."""
+    return {
+        "fol_analysis_results": [
+            {"consistent": True, "message": None},
+            {"consistent": False, "message": "unsatisfiable"},
+        ],
+    }
+
+
+def _modal_inconsistent_mapping_state() -> Dict[str, Any]:
+    """State where the modal axis (mapping shape) decided consistante=False."""
+    return {
+        "fol_analysis_results": [],
+        "modal_analysis_results": {"valid": False},
+    }
+
+
+def _pl_insatisfiable_state() -> Dict[str, Any]:
+    """State where the PL axis records an insatisfiable inference."""
+    return {
+        "fol_analysis_results": [],
+        "modal_analysis_results": [],
+        "propositional_analysis_results": [{"satisfiable": False}],
+    }
+
+
+def _fol_degraded_state() -> Dict[str, Any]:
+    """State where every FOL theory degraded (consistent=None) — unverified, not
+    inconsistent (#1019: None must not support an inconsistance claim)."""
+    return {
+        "fol_analysis_results": [{"consistent": None, "message": "parse-fail"}],
+    }
+
+
+# --- detection ---------------------------------------------------------------
+
+
+def test_passes_when_no_inconsistance_claim_in_prose():
+    verdict = check_factual_consistency(
+        "L'analyse montre que l'argument repose sur une causalité non démontrée.",
+        _fol_all_consistent_state(),
+    )
+    assert verdict.band == "PASS"
+
+
+def test_flags_theatre_when_prose_claims_unsupported_inconsistance():
+    """The canonical R485 bug: prose says « solveur Tweety confirme
+    l'inconsistance » while the appendix records 0 inconsistantes."""
+    verdict = check_factual_consistency(
+        "Le solveur Tweety confirme l'inconsistance de cette inférence, "
+        "ce qui invalide la thèse centrale.",
+        _fol_all_consistent_state(),
+    )
+    assert verdict.band == "FAIL"
+    assert any("Prose theatre" in r for r in verdict.reasons)
+    assert any("#1316" in r for r in verdict.reasons)
+
+
+def test_passes_when_inconsistance_claim_is_supported_by_fol():
+    """Same prose wording, but FOL genuinely records an inconsistency → not
+    theatre."""
+    verdict = check_factual_consistency(
+        "Le solveur Tweety confirme l'inconsistance de cette inférence.",
+        _fol_with_inconsistance_state(),
+    )
+    assert verdict.band == "PASS"
+
+
+def test_passes_when_inconsistance_claim_supported_by_modal_mapping():
+    verdict = check_factual_consistency(
+        "Le solveur révèle l'inconsistance de la théorie modale.",
+        _modal_inconsistent_mapping_state(),
+    )
+    assert verdict.band == "PASS"
+
+
+def test_passes_when_inconsistance_claim_supported_by_pl():
+    verdict = check_factual_consistency(
+        "Le solveur détecte une inférence insatisfaisable.",
+        _pl_insatisfiable_state(),
+    )
+    assert verdict.band == "PASS"
+
+
+def test_degraded_axis_does_not_support_inconsistance_claim():
+    """A degraded axis (None) is unverified — it must NOT legitimise an
+    inconsistency claim (anti None→False collapse, #1019)."""
+    verdict = check_factual_consistency(
+        "Le solveur Tweety confirme l'inconsistance de l'inférence.",
+        _fol_degraded_state(),
+    )
+    assert verdict.band == "FAIL"
+
+
+def test_detects_each_formal_authority_wording():
+    """The detector must catch every authority wording the report prose uses,
+    not just 'Tweety'."""
+    state = _fol_all_consistent_state()
+    for prose in (
+        "Dung isole l'inconsistance du graphe.",
+        "ASPIC+ démontre l'inconsistance de l'argument.",
+        "SPASS prouve l'insatisfaisabilité de la théorie.",
+        "le solveur confirme l'inconsistance.",
+    ):
+        verdict = check_factual_consistency(prose, state)
+        assert verdict.band == "FAIL", f"undetected theatre: {prose!r}"
+
+
+def test_ignores_inconsistance_mention_without_authority():
+    """An informal « cet argument est inconsistant » (no formal authority cited)
+    is a rhetorical judgement, not formal theatre — must not be flagged."""
+    verdict = check_factual_consistency(
+        "Cet argument est inconsistant dans sa propre logique interne.",
+        _fol_all_consistent_state(),
+    )
+    assert verdict.band == "PASS"
+
+
+# --- robustness --------------------------------------------------------------
+
+
+def test_skips_silently_when_state_is_none():
+    """No state → no source of truth → check is skipped honestly (PASS), never
+    manufactures a verdict from missing data (#1019)."""
+    verdict = check_factual_consistency(
+        "Le solveur Tweety confirme l'inconsistance.", None
+    )
+    assert verdict.band == "PASS"
+
+
+def test_returns_a_mergeable_gate_verdict():
+    """The check yields a GateVerdict that merges correctly with the structural
+    gate (the renderer relies on GateVerdict.merge)."""
+    fail = check_factual_consistency(
+        "Le solveur Tweety confirme l'inconsistance.",
+        _fol_all_consistent_state(),
+    )
+    merged = GateVerdict(band="PASS").merge(fail)
+    assert merged.band == "FAIL"
+    assert merged.reasons  # reasons carried through the merge
+
+
+# --- renderer integration ----------------------------------------------------
+
+
+def test_renderer_flags_prose_theatre_in_final_verdict():
+    """End-to-end: a rendered report whose Acte II prose commits theatre receives
+    a FAIL verdict, even though every act is present and well-woven (the
+    structural gate alone would PASS it — the R485 failure mode)."""
+    from argumentation_analysis.reporting.restitution.acts import RestitutionActs
+    from argumentation_analysis.reporting.restitution.renderer import (
+        render_restitution_report,
+    )
+
+    acts = RestitutionActs(
+        source_id="corpus_test",
+        act1_framing=(
+            "Mise en situation substantielle : le locuteur défend une thèse "
+            "historique devant un auditoire varié, dans un contexte tendu."
+        ),
+        act2_narrative=(
+            "L'argument central ne tient pas. En effet, le solveur Tweety "
+            "confirme l'inconsistance de cette inférence, ce qui ruine la "
+            "démonstration. Un mouvement ad hominem achève de le défaire."
+        ),
+        act3_conclusion=(
+            "Le lecteur doit donc soupeser ces failles : la thèse ne résiste "
+            "pas à l'examen formel, et l'appel à l'émotion reste à surveiller."
+        ),
+    )
+    report = render_restitution_report(acts, state=_fol_all_consistent_state())
+    assert report.verdict.band == "FAIL"
+    assert any("Prose theatre" in r for r in report.verdict.reasons)
+
+
+def test_renderer_passes_clean_prose_with_consistent_state():
+    """Symmetric control: the same well-woven acts, with prose that does NOT
+    claim an unsupported inconsistency, pass the full verdict."""
+    from argumentation_analysis.reporting.restitution.acts import RestitutionActs
+    from argumentation_analysis.reporting.restitution.renderer import (
+        render_restitution_report,
+    )
+
+    acts = RestitutionActs(
+        source_id="corpus_test",
+        act1_framing=(
+            "Mise en situation substantielle : le locuteur défend une thèse "
+            "historique devant un auditoire varié, dans un contexte tendu."
+        ),
+        act2_narrative=(
+            "L'argument central repose sur une analogie historique que les "
+            "cadres formels n'invalident pas, mais que l'analyse rhétorique "
+            "fragilise par un mouvement ad hominem."
+        ),
+        act3_conclusion=(
+            "Le lecteur garde donc une lecture critique : la forme tient, le "
+            "fond demande à être contre-argumenté."
+        ),
+    )
+    report = render_restitution_report(acts, state=_fol_all_consistent_state())
+    assert report.verdict.passed is True


### PR DESCRIPTION
## Summary

Closes #1316 (approach A — coordinator dispatch R514). Adds a **deterministic post-render factual-consistency detector** that closes the residual testability gap of the Tweety inconsistency regression (#1297):

- **#1297** pins the *prompt* contract (removed the priming phrasing + added the `INTERDIT` guardrail + regression test `TestTweetyInconsistanceGapRegression`).
- **This PR** pins the *rendered prose*. It flags **"prose theatre"** — a formal authority (Tweety/Dung/ASPIC/SPASS/EProver/PySAT, or the generic « solveur ») cited in the narrative as the source of an inconsistency the appendix's formal-axis aggregates do not record (`inconsistantes` / `insatisfiables` / `consistante: False`).

**Empirical failure mode** (R485 artifacts, base `976aea28`): all 3 restitutions **PASSED** the structural readability gate despite Acte II claiming *« le solveur Tweety confirme l'inconsistance »* on every corpus while the appendix reported `inconsistantes: 0` everywhere — the contradiction #1297 later fixed at the prompt level. The structural gate treats « Tweety confirme l'inconsistance » as *woven* (the verb `confirme` anchors it), so it cannot catch it. This module is the post-render detector for the residual class.

## Files changed

| File | Type | Role | Δ |
|---|---|---|---|
| `argumentation_analysis/reporting/restitution/factual_consistency_check.py` | new | The detector (`check_factual_consistency`) — scans prose for authority-backed `inconsist*`/`insatisfais*` claims, cross-checks vs appendix via `_provenance_counts` | +184 |
| `argumentation_analysis/reporting/restitution/renderer.py` | modified | Wires the check into `render()` via `GateVerdict.merge` (1 import + 1 merge call + comment) | +8 |
| `tests/unit/argumentation_analysis/reporting/restitution/test_factual_consistency_check.py` | new | 12 tests: red on R485 contradiction, green on honest render + every axis-supports case + robustness + end-to-end renderer | +240 |

## DoD checklist (dispatch R514)

- [x] Cross-check déterministe post-render implémenté (prose `inconsist*` ⇒ annexe cohérente, sinon FAIL)
- [x] Test rouge sur la contradiction R485 (`test_flags_theatre_when_prose_claims_unsupported_inconsistance` + end-to-end `test_renderer_flags_prose_theatre_in_final_verdict`)
- [x] Test vert sur rendu honnête (`test_renderer_passes_clean_prose_with_consistent_state`)
- [x] CI verte (mypy N/A — restitution hors scope 8 fichiers core ; voir validation ci-dessous)
- [x] 1 PR ciblée

## Anti-pendule (explicit)

- **Composes with #1297, does NOT replace it.** The prompt guardrail inhibits the theatre; this check detects any that leaks through. Defense in depth.
- **NOT a gate refactor (option B).** Targets only the formal-inconsistency theatre class. The structural readability gate (`readability_gate.py`) is untouched.
- Reuses `appendix._provenance_counts` (DRY) — never recomputes axis verdicts, so it cannot drift from the appendix.
- Honesty contract (#1019): a degraded axis (`None`) never collapses to `False` — it does not legitimise an inconsistency claim. `state=None` → skip silently (PASS), never manufactures a verdict from missing data.

## Privacy HARD

Opaque-only. The detector scans prose for substrings (`inconsist*`, authority names) and reads the appendix's aggregate counts — it handles **no corpus content** (`raw_text`/snippets are already stripped by `appendix._strip_leak_keys` upstream). No corpus name, no source content in the code, the tests, or this PR body. The R485 rendered prose that exhibited the bug stays local gitignored.

## Validation (firsthand, this round)

- **New tests:** 12/12 PASS (`pytest test_factual_consistency_check.py -v`)
- **Full restitution suite:** 241/241 PASS — **no regression** from the `renderer.py` wiring (`pytest tests/unit/argumentation_analysis/reporting/restitution/ -q`)
- **black:** clean (1 trivial reformat applied)
- **mypy:** N/A — `reporting/restitution/` is not in the 8-file CI mypy scope (`.github/workflows/ci.yml` line 43)

## Note

The detector + tests + renderer wiring were found pre-written in the working tree (uncommitted, from a prior interrupted session) and are shipped here after **verify-before-assert validation** (tests run green firsthand, not trusted on read). No duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)