### PR TITLE
fix(testing): move environment import below shebang in 6 scripts

### DIFF
--- a/scripts/testing/debug_test_crypto_cycle.py
+++ b/scripts/testing/debug_test_crypto_cycle.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 # scripts/debug_test_crypto_cycle.py
+import argumentation_analysis.core.environment
 import base64
 import sys
 import os

--- a/scripts/testing/get_test_metrics.py
+++ b/scripts/testing/get_test_metrics.py
@@ -1,9 +1,8 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 """
 Script pour obtenir des métriques rapides des tests sans blocage.
 """
+import argumentation_analysis.core.environment
 
 import subprocess
 import sys

--- a/scripts/testing/investigation_playwright_async.py
+++ b/scripts/testing/investigation_playwright_async.py
@@ -1,10 +1,9 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 """
 Script Python Asynchrone - Investigation Playwright Textes Variés
 Alternative non bloquante au script PowerShell
 """
+import argumentation_analysis.core.environment
 
 import asyncio
 import json

--- a/scripts/testing/run_tests_alternative.py
+++ b/scripts/testing/run_tests_alternative.py
@@ -1,9 +1,8 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 """
 Runner de test alternatif à pytest
 """
+import argumentation_analysis.core.environment
 
 import sys
 import os

--- a/scripts/testing/simple_test_runner.py
+++ b/scripts/testing/simple_test_runner.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Script simple pour exécuter les tests embed_all_sources.

--- a/scripts/testing/validate_embed_tests.py
+++ b/scripts/testing/validate_embed_tests.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Script de validation des tests embed_all_sources - Version simplifiée et robuste.


### PR DESCRIPTION
Found via runtime-import scan (R517 dig). The auto_env migration `fd5bf726` bulk-prepended `import argumentation_analysis.core.environment` to L1 of entry-point scripts, pushing the shebang to L2/L3 — corrupting the shebang convention. Same defect class as the one that helped kill `run_embed_tests.py` (#1317/#1319).

## Root cause
`fd5bf726` "Migrate auto_env" prepended the env import at L1 instead of inserting it after the standard header (`shebang` → `coding cookie` → `docstring`). The goal (auto-activate conda early) is preserved by placing the import immediately after the header — the module self-executes on import either way, and the shebang/coding-cookie are just comments to the interpreter.

## Scope (6 scripts, pure reorder, +6/-12)
| File | Before | After |
|---|---|---|
| `debug_test_crypto_cycle.py` | env import L1, comment L3 | comment L1, env import L2 |
| `get_test_metrics.py` | env L1, shebang L3 | shebang L1, env L3 |
| `investigation_playwright_async.py` | env L1, shebang L3 | shebang L1, env L4 |
| `run_tests_alternative.py` | env L1, shebang L3 | shebang L1, env L3 |
| `simple_test_runner.py` | env L1, shebang L3 | shebang L1, env L3 |
| `validate_embed_tests.py` | env L1, shebang L3 | shebang L1, env L3 |

## Verification (firsthand, leçons R512/R515)
- **`py_compile` on all 6** → all compile (not assumed, verified).
- Environment auto-activation still loads early: the import is now the **first import** in each file, before any project import — the module's documented behavior ("s'auto-exécute à l'import") is preserved.
- `run_pytest.py` (same folder) already has the correct `#!/usr/bin/env python3` header at L1 → confirms this is the repo convention; the 6 affected scripts were the outliers from the bulk prepend.
- **Excluded `run_embed_tests.py`** — handled by #1319 (deletion, not reorder). The two PRs are disjoint (different files).
- mypy strict CI gate (8 core files) **unaffected** — all scripts are outside that scope; no production code touched, only header comments moved.

## Why this is a real defect (not cosmetic)
- The shebang on L2 is never honored by the OS (shebang must be the first 2 bytes). The scripts are `100644` (not +x), so they're invoked via `python script.py` today → no functional break *now*. But the corrupted header is a latent trap: if anyone ever `chmod +x` and runs `./script.py` on Unix, the shebang silently fails. Fixing restores correctness before it bites.

No arbitration needed — worker-scope mechanical fix, verifiably correct, composes with #1319 (disjoint files).

Co-Authored-By: GLM-5.2 <noreply@z.ai>