### PR TITLE
fix(scripts): move environment import below shebang in 37 scripts

### DIFF
--- a/scripts/apps/sherlock_watson/validation_point1_simple.py
+++ b/scripts/apps/sherlock_watson/validation_point1_simple.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 VALIDATION POINT 1/5 : DEMOS CLUEDO/EINSTEIN SHERLOCK-WATSON-MORIARTY AVEC VRAIS LLMS
 

--- a/scripts/maintenance/migration/migrate_to_unified.py
+++ b/scripts/maintenance/migration/migrate_to_unified.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """
 Script de migration vers le système Enhanced PM Orchestration v2.0 unifié
 Aide à passer des anciens scripts éparpillés au nouveau système consolidé.

--- a/scripts/maintenance/tools/recovered/validate_oracle_coverage.py
+++ b/scripts/maintenance/tools/recovered/validate_oracle_coverage.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """Script de validation de la couverture Oracle Enhanced v2.1.0"""
 
 import subprocess

--- a/scripts/orchestration/orchestrate_complex_analysis.py
+++ b/scripts/orchestration/orchestrate_complex_analysis.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Orchestrateur d'analyse complexe multi-agents avec génération de rapport Markdown.
 """

--- a/scripts/orchestration/orchestrate_webapp_detached.py
+++ b/scripts/orchestration/orchestrate_webapp_detached.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """
 Orchestrateur webapp détaché - utilise les outils de haut niveau existants
 Démarre backend/frontend en arrière-plan et retourne immédiatement le contrôle

--- a/scripts/orchestration/orchestrate_with_existing_tools.py
+++ b/scripts/orchestration/orchestrate_with_existing_tools.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Orchestration complexe multi-agents utilisant les outils de reporting existants.
 SANS emojis Unicode pour éviter les problèmes d'encodage.

--- a/scripts/orchestration/run_extract_repair.py
+++ b/scripts/orchestration/run_extract_repair.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Script d'exécution pour la réparation des extraits

--- a/scripts/orchestration/run_verify_extracts.py
+++ b/scripts/orchestration/run_verify_extracts.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Script d'exécution pour la vérification des extraits

--- a/scripts/orchestration/select_extract.py
+++ b/scripts/orchestration/select_extract.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Utilitaire simple pour sélectionner des extraits du corpus.
 Usage: python select_extract.py [--random] [--index N] [--list]

--- a/scripts/reporting/compare_rhetorical_agents.py
+++ b/scripts/reporting/compare_rhetorical_agents.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Script pour comparer les performances des différents agents spécialistes d'analyse rhétorique.
 Ce script utilise les utilitaires de argumentation_analysis.utils.reporting_utils.

--- a/scripts/reporting/compare_rhetorical_agents_simple.py
+++ b/scripts/reporting/compare_rhetorical_agents_simple.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Script pour comparer les performances des différents agents spécialistes d'analyse rhétorique.

--- a/scripts/reporting/generate_comprehensive_report.py
+++ b/scripts/reporting/generate_comprehensive_report.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Script pour générer un rapport d'analyse complet qui synthétise tous les résultats des tests précédents.

--- a/scripts/reporting/generate_coverage_report.py
+++ b/scripts/reporting/generate_coverage_report.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Script pour générer un rapport textuel sur la couverture des tests.

--- a/scripts/reporting/generate_rhetorical_analysis_summaries.py
+++ b/scripts/reporting/generate_rhetorical_analysis_summaries.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Script pour générer des synthèses des analyses rhétoriques avec des extraits concrets.

--- a/scripts/reporting/initialize_coverage_history.py
+++ b/scripts/reporting/initialize_coverage_history.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Script pour initialiser l'historique de couverture des tests.

--- a/scripts/reporting/visualize_test_coverage.py
+++ b/scripts/reporting/visualize_test_coverage.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Script pour visualiser l'évolution de la couverture des tests au fil du temps.

--- a/scripts/tools/debugging/debug_jvm.py
+++ b/scripts/tools/debugging/debug_jvm.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """Script de diagnostic JVM pour identifier le problème d'initialisation"""
 
 import os

--- a/scripts/utils/unified_utilities.py
+++ b/scripts/utils/unified_utilities.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Système d'Utilitaires Unifiés
 =============================

--- a/scripts/validation/core.py
+++ b/scripts/validation/core.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Core components for the Unified Validation System.
 """

--- a/scripts/validation/debug_minimal_test.py
+++ b/scripts/validation/debug_minimal_test.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """
 Test minimal pour diagnostiquer le blocage JTMS
 """

--- a/scripts/validation/diagnose_backend.py
+++ b/scripts/validation/diagnose_backend.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """
 Diagnostic complet du backend - vérifie processus, ports, logs
 """

--- a/scripts/validation/orchestration_validation.py
+++ b/scripts/validation/orchestration_validation.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Script de validation complète de l'API Orchestration

--- a/scripts/validation/test_api.py
+++ b/scripts/validation/test_api.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 import requests
 import json

--- a/scripts/validation/test_importation_consolidee.py
+++ b/scripts/validation/test_importation_consolidee.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """
 Test d'importation consolidée du système universel récupéré
 Valide l'intégrité et la cohérence des 553 fichiers Python récupérés

--- a/scripts/validation/test_performance_systeme.py
+++ b/scripts/validation/test_performance_systeme.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """
 Phase 4 - Mesure de performance système complet
 """

--- a/scripts/validation/test_robustesse_systeme.py
+++ b/scripts/validation/test_robustesse_systeme.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """
 Phase 4 - Test de robustesse et gestion d'erreurs
 """

--- a/scripts/validation/test_system_stability.py
+++ b/scripts/validation/test_system_stability.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """Test de stabilité du système récupéré sur 3 exécutions"""
 
 import time

--- a/scripts/validation/test_unified_system.py
+++ b/scripts/validation/test_unified_system.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Test simple du système d'analyse rhétorique unifié
 =================================================

--- a/scripts/validation/test_validation_environnement.py
+++ b/scripts/validation/test_validation_environnement.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """
 Phase 4 - Validation configuration et environnement
 """

--- a/scripts/validation/test_web_api_direct.py
+++ b/scripts/validation/test_web_api_direct.py
@@ -1,6 +1,5 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
+import argumentation_analysis.core.environment
 """
 Test direct de l'API web pour diagnostiquer pourquoi la détection de sophismes
 ne fonctionne pas via l'interface web malgré nos corrections.

--- a/scripts/validation/validators/authenticity_validator.py
+++ b/scripts/validation/validators/authenticity_validator.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Validator for system component authenticity.
 """

--- a/scripts/validation/validators/ecosystem_validator.py
+++ b/scripts/validation/validators/ecosystem_validator.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Validator for the complete system ecosystem.
 """

--- a/scripts/validation/validators/epita_diagnostic_validator.py
+++ b/scripts/validation/validators/epita_diagnostic_validator.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 
 """
 Validateur pour le Diagnostic complet de la démo Épita et de ses composants illustrés

--- a/scripts/validation/validators/integration_validator.py
+++ b/scripts/validation/validators/integration_validator.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Validator for system integration between components.
 """

--- a/scripts/validation/validators/orchestration_validator.py
+++ b/scripts/validation/validators/orchestration_validator.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Validator for unified orchestrators.
 """

--- a/scripts/validation/validators/performance_validator.py
+++ b/scripts/validation/validators/performance_validator.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Validator for system performance.
 """

--- a/scripts/validation/validators/simple_validator.py
+++ b/scripts/validation/validators/simple_validator.py
@@ -1,7 +1,6 @@
-import argumentation_analysis.core.environment
-
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import argumentation_analysis.core.environment
 """
 Validator for a simplified, quick system check.
 """


### PR DESCRIPTION
Bulk extension of #1322 (6 files in scripts/testing/) to the rest of scripts/. Same defect class, same mechanical fix, verified safe.

## Root cause
The auto_env migration `fd5bf726` bulk-prepended `import argumentation_analysis.core.environment` to L1 of entry-point scripts across all of scripts/, pushing the shebang (and coding cookie) to L2-L3 — corrupting the shebang (must be the first bytes for the OS to honor it on Unix).

## Scope: 37 scripts (verified uniform, mechanical reorder)
Folders: scripts/apps/, scripts/maintenance/, scripts/orchestration/, scripts/reporting/, scripts/tools/, scripts/utils/, scripts/validation/.

Transform per file (env import stays the FIRST STATEMENT — faithful to original):
`[env_import, "", shebang, coding?, rest...] -> [shebang, coding?, env_import, rest...]`

## Method — verify-before-assert FIRST (key safety step)
A read-only scan confirmed uniformity: 54 files have env-import on L1, but only **37 match the uniform pattern** (L1 env, L2 blank, L3 shebang). The other **17 are non-uniform** (no shebang at all, env import correctly first → no defect) → **left untouched**. A naive bulk script would have mangled the 17.

## Verification (firsthand, not assumed)
- py_compile on all 37 → **37/37 OK**.
- Sanity: env import is the first STATEMENT in all 37 after reorder (0 warnings) → auto-env still loads before any project import.
- Shebangs preserved (26x python3, 11x python); +37/-74 = 1 blank line removed per file, pure header reorder, no logic/line-ending churn.
- mypy strict CI gate (8 core files) unaffected — scripts outside scope.

## Disjunction (composes cleanly)
- scripts/testing/ (6 files) → #1322 (separate PR)
- run_embed_tests.py → #1319 (deletion)
- This PR → the other 37

All three PRs touch disjoint files → merge in any order.

## Severity (honest)
Low-but-systemic: scripts are 100644 (invoked via python), so L2 shebang isn't a functional break today, but it's a latent trap (chmod +x + ./script on Unix → shebang ignored) and a convention inconsistency. Preventive, verified safe.

Co-Authored-By: GLM-5.2 <noreply@z.ai>