### PR TITLE
fix(scripts): remove duplicate environment imports in 2 scripts

### DIFF
--- a/scripts/maintenance/tools/correct_source_paths.py
+++ b/scripts/maintenance/tools/correct_source_paths.py
@@ -1,5 +1,4 @@
 import argumentation_analysis.core.environment
-import argumentation_analysis.core.environment
 import json
 import logging
 from pathlib import Path

--- a/scripts/orchestration/orchestrate_webapp_detached.py
+++ b/scripts/orchestration/orchestrate_webapp_detached.py
@@ -18,7 +18,6 @@ project_root = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(project_root))
 
 # --- Imports du projet (après configuration du path) ---
-import argumentation_analysis.core.environment  # Import déplacé ici
 from project_core.service_manager import InfrastructureServiceManager, ServiceConfig
 
 


### PR DESCRIPTION
## Summary

Continuation of the auto-env migration cleanup (`fd5bf726`). The shebang reorder sweep (#1322 testing/, #1323 bulk) noted one bonus finding — a duplicate env-import in `correct_source_paths.py` — left unbundled to keep those PRs focused. This PR closes that finding **and** extends the scan repo-wide: a second duplicate surfaced in `orchestrate_webapp_detached.py`.

`import argumentation_analysis.core.environment` auto-executes the module on first import (activates conda / sets up the path). A second identical import is a no-op — pure dead code. Same artifact family as #1322/#1323.

## Changes

| File | Before | After |
|------|--------|-------|
| `scripts/maintenance/tools/correct_source_paths.py` | identical import on L1 **and** L2 | keep one (L1) |
| `scripts/orchestration/orchestrate_webapp_detached.py` | L2 (correct, first statement after shebang) **+** L21 stale `# Import déplacé ici` (original never removed) | keep early L2, drop L21 |

## Verification (firsthand)

- **py_compile both OK** — no syntax regression.
- **1 env-import per file** (was 2) — auto-env still runs once, as the first statement.
- **2 deletions, 0 logic changed** — pure dead-code removal.
- For `orchestrate_webapp_detached.py`: kept the **early** import (L2, right after shebang = the convention #1322/#1323 restored), dropped the redundant "moved here" copy that ran after `sys.path` config.
- Scan was repo-wide (`grep -c` over `scripts/`): exactly these 2 files have count > 1; no others.

## Scope

Scripts are outside the 8-file mypy-strict CI gate, so no type-check impact. Docs/scripts-only, disjoint from all open PRs.

Co-Authored-By: Claude <noreply@anthropic.com>