### PR TITLE
fix(modal): normalize sort-name identifiers amont de parseBeliefBase (#1326)

### DIFF
--- a/argumentation_analysis/agents/core/logic/modal_handler.py
+++ b/argumentation_analysis/agents/core/logic/modal_handler.py
@@ -2,6 +2,7 @@ import jpype
 import logging
 from typing import Optional, Tuple
 
+from .modal_kb_identifier_normalizer import ModalIdentifierNormalizer
 from .tweety_initializer import TweetyInitializer
 from argumentation_analysis.core.config import settings, ModalSolverChoice
 
@@ -104,6 +105,34 @@ class ModalHandler:
             return self._get_spass_reasoner()
         return self._modal_reasoner
 
+    @staticmethod
+    def _normalize_for_parse(belief_set_content: str) -> str:
+        """Normalize modal KB identifiers so ``MlParser`` accepts them (#1326).
+
+        ``MlParser`` forbids underscores/separators in predicate declarations
+        (``[a-zA-Z][a-zA-Z0-9]*``), but producers such as the spectacular-path
+        ``_construct_modal_kb_from_json`` and LLM-generated identifiers emit
+        underscored multi-word atoms (``joke_teleprompter``) — which raised
+        ``ParserException: Illegal characters in predicate definition`` so the
+        KB never parsed and consistency was never decided (R519: 3/3 modal axes
+        undecided). Applied here, *amont* de ``parseBeliefBase``, it protects
+        every caller regardless of upstream producer (defense-in-depth).
+
+        Idempotent on already-legal atoms: the nl path pre-sanitizes via
+        ``invoke_callables._legal_symbol`` and the second pass is a no-op.
+        Anti-pendule: normalizes sort-name SYNTAX only (PascalCase stem
+        survives), no heuristic masking a parse-fail (#1019 fail-loud).
+        """
+        normalized, reverse = ModalIdentifierNormalizer().normalize_belief_set(
+            belief_set_content
+        )
+        if reverse:
+            logger.debug(
+                "Modal KB identifiers normalized for MlParser (#1326): %s",
+                reverse,
+            )
+        return normalized
+
     def validate_modal_formula(self, formula_str: str) -> Tuple[bool, str]:
         """
         Validates the syntax of a modal logic formula by attempting to parse it.
@@ -138,6 +167,20 @@ class ModalHandler:
         logger.debug(f"Executing modal query '{query_string}' with {reasoner_name}")
         try:
             StringReader = jpype.JClass("java.io.StringReader")
+
+            # #1326: normalize identifiers amont de parseBeliefBase so
+            # underscored atoms (joke_teleprompter) become MlParser-legal
+            # (JokeTeleprompter). One shared normalizer maps belief-set and
+            # query atoms consistently so query names match the KB signature.
+            normalizer = ModalIdentifierNormalizer()
+            belief_set_content, _bs_rev = normalizer.normalize_belief_set(
+                belief_set_content
+            )
+            query_string, _q_rev = normalizer.normalize_belief_set(query_string)
+            if _bs_rev:
+                logger.debug(
+                    "Modal query KB identifiers normalized (#1326): %s", _bs_rev
+                )
 
             # Parse belief set
             belief_set_reader = StringReader(belief_set_content)
@@ -229,6 +272,12 @@ class ModalHandler:
         solver_name = settings.modal_solver.value
         reasoner = self._get_active_reasoner()
         logger.debug(f"Checking modal KB consistency with {solver_name}.")
+
+        # #1326: normalize identifiers amont de parseBeliefBase so underscored
+        # atoms (joke_teleprompter) become MlParser-legal (JokeTeleprompter) and
+        # the configured solver actually receives a parseable belief set to
+        # DECIDE — rather than degrading to None on a ParserException.
+        belief_set_content = self._normalize_for_parse(belief_set_content)
 
         try:
             StringReader = jpype.JClass("java.io.StringReader")

--- a/argumentation_analysis/agents/core/logic/modal_kb_identifier_normalizer.py
+++ b/argumentation_analysis/agents/core/logic/modal_kb_identifier_normalizer.py
@@ -1,0 +1,114 @@
+"""Modal KB identifier normalization (#1326, builds on #1260/#1230).
+
+Tweety's ``MlParser`` grammar is *stricter* than the propositional parser: a
+predicate/sort declaration must match ``[a-zA-Z][a-zA-Z0-9]*`` — underscores and
+other separators are rejected with::
+
+    ParserException: Illegal characters in predicate definition 'joke_teleprompter';
+                      declaration must conform to [a-z,A-Z]([a-z,A-Z,0-9])*
+
+Several modal-KB producers emit underscored multi-word atoms (LLM-generated
+identifiers such as ``joke_teleprompter``, the spectacular-path
+``_construct_modal_kb_from_json``). Such a KB never parses, so consistency is
+never decided and the modal axis degrades to honest ``None`` (the R519
+firsthand-reproduced failure: 3/3 modal axes undecided).
+
+This module maps every MlParser-illegal atom to a fresh legal identifier and is
+applied at the parse point (``ModalHandler``, immediately *amont* de
+``parseBeliefBase``) so EVERY caller is protected regardless of upstream
+producer — defense-in-depth. The transform:
+
+* PascalCase join on non-alphanumeric splits: ``joke_teleprompter`` →
+  ``JokeTeleprompter`` (the semantic stem survives, only the separators drop).
+* generic ``MpAtomN`` fallback when the stem is empty/illegal.
+* applied **consistently** to declarations and bodies, and the collision set
+  tracks *generated* candidates too — so two distinct source atoms that
+  PascalCase to the same stem (``heavy_rain`` vs ``heavy-rain``) are
+  disambiguated instead of collapsed. That soundness guard was absent from the
+  original inline #1260 closure.
+
+Anti-pendule: this normalizes the **syntax** of the sort-name for Tweety only;
+it does not neutralize semantic content or variance. No heuristic masks a
+parse-fail — a genuinely malformed KB is still rejected and the handler returns
+honest ``None`` (#1019 fail-loud). It is idempotent on already-legal atoms, so a
+caller that pre-sanitizes (the nl path via ``invoke_callables._legal_symbol``)
+is unaffected by the second pass here.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Iterable, Tuple
+
+# Reserved words of the modal grammar — must never be treated as atoms.
+_KEYWORDS = frozenset(
+    {
+        "forall",
+        "exists",
+        "true",
+        "false",
+        "type",
+        "prop",
+        "and",
+        "or",
+        "not",
+        "implies",
+    }
+)
+
+# A modal atom token (mirrors ``invoke_callables._atom_re`` / #1260): any
+# identifier-shaped run including underscores, so ``joke_teleprompter`` is
+# captured as ONE token rather than split around the underscore.
+_ATOM_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+# The MlParser declaration grammar (firsthand-confirmed via the ParserException
+# message reproduced in #1326): first letter alphabetic, rest alphanumeric, NO
+# underscores/separators.
+_LEGAL_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9]*$")
+
+
+class ModalIdentifierNormalizer:
+    """Sound, memoized mapping of modal atoms to MlParser-legal identifiers.
+
+    ``reserved`` pre-seeds the collision set (e.g. atoms already legal in the
+    KB) so a generated symbol never shadows a real atom. Generated candidates
+    are also added to the collision set, so two distinct source atoms that
+    PascalCase to the same stem are disambiguated rather than collapsed — the
+    soundness guard missing from the original inline #1260 closure.
+    """
+
+    def __init__(self, reserved: Iterable[str] = ()) -> None:
+        self._reserved: set[str] = set(reserved)
+        self._forward: Dict[str, str] = {}
+
+    def legalize(self, atom: str) -> str:
+        """Return an MlParser-legal identifier for ``atom`` (memoized)."""
+        if atom in _KEYWORDS or _LEGAL_RE.match(atom):
+            return atom
+        cached = self._forward.get(atom)
+        if cached is not None:
+            return cached
+        parts = [p for p in re.split(r"[^A-Za-z0-9]+", atom) if p]
+        candidate = "".join(p[:1].upper() + p[1:] for p in parts) or "MpAtom"
+        if not _LEGAL_RE.match(candidate) or candidate in self._reserved:
+            # Rare: degenerate stem or collision — disambiguate, but keep the
+            # readable stem as the base (not a bare MpAtomN).
+            base = candidate if _LEGAL_RE.match(candidate) else "MpAtom"
+            suffix = 1
+            while f"{base}{suffix}" in self._reserved:
+                suffix += 1
+            candidate = f"{base}{suffix}"
+        self._reserved.add(candidate)
+        self._forward[atom] = candidate
+        return candidate
+
+    def normalize_belief_set(self, content: str) -> Tuple[str, Dict[str, str]]:
+        """Normalize every atom in a modal belief-set string.
+
+        Returns ``(normalized_content, reverse_map)`` where ``reverse_map`` is
+        ``{normalized: original}`` for readability/traceability. Atoms already
+        legal are absent from the map (they pass through verbatim).
+        """
+        normalized = _ATOM_RE.sub(lambda m: self.legalize(m.group(0)), content)
+        reverse = {v: k for k, v in self._forward.items()}
+        return normalized, reverse

--- a/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
+++ b/tests/integration/argumentation_analysis/agents/core/logic/test_spass_real.py
@@ -228,3 +228,105 @@ class TestRealSpassConsistency:
         assert (
             "spass" in msg.lower()
         ), f"Verdict must be traceable to the SPASS reasoner; got msg={msg!r}."
+
+
+# ---------------------------------------------------------------------------
+# #1326 — modal sort-name normalization (amont de parseBeliefBase).
+# ---------------------------------------------------------------------------
+# R519 firsthand: a modal KB whose predicate names contain underscores
+# (``type(heavy_rain)``) raised ``ParserException: Illegal characters in
+# predicate definition`` → ``is_modal_kb_consistent`` returned ``(None,
+# "...parse error...")`` → the axis degraded, never decided. Several producers
+# (spectacular-path ``_construct_modal_kb_from_json``, LLM identifiers) emit
+# such names. ``ModalHandler`` now normalizes identifiers to MlParser-legal
+# PascalCase immediately before ``parseBeliefBase`` (#1326, defense-in-depth).
+#
+# The anti-theater guard: a KB that USED to parse-fail must now DECIDE via a
+# REAL reasoner (verdict traceable to the solver name in ``msg``, not a parse
+# error). Privacy HARD: weather-domain synthetic atoms only (no corpus).
+UNDERSCORED_CONSISTENT_KB = (
+    "type(heavy_rain)\ntype(wet_ground)\n\n"
+    "[](heavy_rain => wet_ground)\nheavy_rain\n"
+)
+UNDERSCORED_INCONSISTENT_KB = "type(heavy_rain)\n\nheavy_rain\n!heavy_rain\n"
+
+
+class TestUnderscoredKbDecidesViaDefault:
+    """The #1326 fix, decided by the DEFAULT pure-Java reasoner (runs on CI
+    everywhere — the anti-theater guard). Before #1326 these KBs returned
+    ``(None, parse error)``; they must now return a definite boolean."""
+
+    @pytest.fixture
+    def tweety_solver(self):
+        previous = settings.modal_solver
+        settings.modal_solver = ModalSolverChoice.TWEETY
+        try:
+            yield
+        finally:
+            settings.modal_solver = previous
+
+    def test_underscored_consistent_kb_decides_true(self, modal_bridge, tweety_solver):
+        """A consistent KB with underscored atoms must DECIDE ``True`` via a real
+        query (not a parse error). Proves the normalization lets the reasoner
+        actually receive and decide the belief set."""
+        is_consistent, msg = modal_bridge.check_consistency(
+            UNDERSCORED_CONSISTENT_KB, "K"
+        )
+        assert is_consistent is True, (
+            f"Underscored consistent KB must decide True after #1326 "
+            f"normalization; got ({is_consistent!r}, {msg!r})."
+        )
+        assert "tweety" in msg.lower() and "parse" not in msg.lower(), (
+            f"Verdict must come from the reasoner, not a parse error; "
+            f"got msg={msg!r}."
+        )
+
+    def test_underscored_inconsistent_kb_decides_false(self, modal_bridge, tweety_solver):
+        """An inconsistent KB (``heavy_rain`` ∧ ``!heavy_rain``) must DECIDE
+        ``False``. This proves the symbol map is SOUND: both occurrences of
+        ``heavy_rain`` map to the SAME normalized symbol, so the reasoner sees
+        the contradiction. An inconsistent map would map them to two different
+        atoms and wrongly report consistent."""
+        is_consistent, msg = modal_bridge.check_consistency(
+            UNDERSCORED_INCONSISTENT_KB, "K"
+        )
+        assert is_consistent is False, (
+            f"Underscored inconsistent KB must decide False (sound symbol map); "
+            f"got ({is_consistent!r}, {msg!r})."
+        )
+        assert "tweety" in msg.lower() and "parse" not in msg.lower(), (
+            f"Verdict must come from the reasoner, not a parse error; "
+            f"got msg={msg!r}."
+        )
+
+
+@pytest.mark.skipif(
+    not _spass_runnable(),
+    reason="SPASS not runnable — the SPASS DECIDES-firsthand variant of the "
+    "#1326 guard runs only where SPASS is a launchable CLI build.",
+)
+class TestUnderscoredKbDecidesViaSpass:
+    """The #1326 fix decided firsthand by SPASS (the coord DoD: genuine solver,
+    no theater fallback). The normalized belief set must reach SPASS and DECIDE."""
+
+    @pytest.fixture
+    def spass_solver(self):
+        previous = settings.modal_solver
+        settings.modal_solver = ModalSolverChoice.SPASS
+        try:
+            yield
+        finally:
+            settings.modal_solver = previous
+
+    def test_underscored_kb_decides_via_spass(self, modal_bridge, spass_solver):
+        is_consistent, msg = modal_bridge.check_consistency(
+            UNDERSCORED_CONSISTENT_KB, "K"
+        )
+        assert is_consistent is True, (
+            f"Underscored consistent KB must decide True via SPASS; "
+            f"got ({is_consistent!r}, {msg!r})."
+        )
+        assert "spass" in msg.lower() and "parse" not in msg.lower(), (
+            f"Verdict must come from SPASS, not a parse error; got msg={msg!r}."
+        )
+

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_modal_kb_identifier_normalizer.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_modal_kb_identifier_normalizer.py
@@ -1,0 +1,120 @@
+"""Unit tests for ``ModalIdentifierNormalizer`` (#1326) — no JVM, runs in CI.
+
+Root cause (#1326, firsthand-reproduced): Tweety ``MlParser`` rejects
+underscored predicate declarations with ``ParserException: Illegal characters
+in predicate definition 'joke_teleprompter'; declaration must conform to
+[a-z,A-Z]([a-z,A-Z,0-9])*``. Producers like the spectacular-path
+``_construct_modal_kb_from_json`` emit raw ``type(joke_teleprompter)``, so the
+KB never parsed and consistency was never decided (R519: 3/3 modal axes
+undecided → axis degraded to honest ``None``). The normalizer maps such atoms
+to MlParser-legal PascalCase identifiers, applied at the parse point in
+``ModalHandler`` (defense-in-depth).
+
+These tests guard the transform itself; the end-to-end real-solver decision is
+covered by the integration test ``test_spass_real.TestUnderscoredKbDecides``.
+"""
+
+import pytest
+
+from argumentation_analysis.agents.core.logic.modal_kb_identifier_normalizer import (
+    ModalIdentifierNormalizer,
+)
+
+
+class TestLegalize:
+    """The per-atom transform (#1260 camelCase logic, #1326 collision guard)."""
+
+    def test_underscored_atom_becomes_pascalcase(self):
+        n = ModalIdentifierNormalizer()
+        assert n.legalize("joke_teleprompter") == "JokeTeleprompter"
+        assert n.legalize("heavy_rain") == "HeavyRain"
+
+    def test_already_legal_atom_passes_through(self):
+        n = ModalIdentifierNormalizer()
+        # Idempotency: the nl path pre-sanitizes; the second pass is a no-op.
+        assert n.legalize("Rain") == "Rain"
+        assert n.legalize("JokeTeleprompter") == "JokeTeleprompter"
+        assert n.legalize("a1") == "a1"
+
+    def test_modal_keywords_are_preserved(self):
+        n = ModalIdentifierNormalizer()
+        for kw in ("type", "forall", "exists", "true", "false", "implies", "and"):
+            assert n.legalize(kw) == kw
+
+    def test_legalize_is_memoized(self):
+        n = ModalIdentifierNormalizer()
+        first = n.legalize("heavy_rain")
+        second = n.legalize("heavy_rain")
+        assert first == second == "HeavyRain"
+
+
+class TestSoundness:
+    """The map must be sound — no two distinct atoms collapse to one symbol."""
+
+    def test_atom_and_its_negation_share_a_symbol(self):
+        """The contradiction ``heavy_rain`` ∧ ``!heavy_rain`` must be detectable:
+        both occurrences map to the SAME symbol, so a reasoner sees
+        ``HeavyRain ∧ !HeavyRain`` (inconsistent), not two unrelated atoms."""
+        n = ModalIdentifierNormalizer()
+        kb = "type(heavy_rain)\n\nheavy_rain\n!heavy_rain\n"
+        normalized, _ = n.normalize_belief_set(kb)
+        # Both heavy_rain occurrences became the same symbol.
+        assert normalized.count("HeavyRain") == 3  # type(...) + atom + negation
+        assert "heavy_rain" not in normalized
+
+    def test_distinct_separator_variants_do_not_collapse(self):
+        """Soundness guard absent from the original #1260 inline closure: two
+        atoms that PascalCase to the same stem (``heavy_rain`` vs ``heavy-rain``)
+        must be DISAMBIGUATED, not collapsed. Collapsing distinct atoms would
+        fabricate a contradiction (or hide one) — a #1019 theater risk."""
+        n = ModalIdentifierNormalizer()
+        a = n.legalize("heavy_rain")
+        b = n.legalize("heavy-rain")
+        assert a != b, (
+            f"Distinct source atoms must map to distinct symbols; got {a!r}=={b!r}."
+        )
+        assert a == "HeavyRain"
+        assert b == "HeavyRain1"
+
+    def test_degenerate_atom_falls_back_to_mpatom(self):
+        n = ModalIdentifierNormalizer()
+        # Only separators → empty stem → MpAtom fallback.
+        assert n.legalize("___") == "MpAtom"
+
+
+class TestNormalizeBeliefSet:
+    """Whole-KB normalization + reverse map for readability."""
+
+    def test_declarations_and_body_normalized_consistently(self):
+        n = ModalIdentifierNormalizer()
+        kb = (
+            "type(heavy_rain)\ntype(wet_ground)\n\n"
+            "[](heavy_rain => wet_ground)\nheavy_rain\n"
+        )
+        normalized, reverse = n.normalize_belief_set(kb)
+        assert "type(HeavyRain)" in normalized
+        assert "type(WetGround)" in normalized
+        assert "[](HeavyRain => WetGround)" in normalized
+        assert "HeavyRain\n" in normalized
+        assert reverse == {"HeavyRain": "heavy_rain", "WetGround": "wet_ground"}
+
+    def test_already_legal_kb_is_unchanged(self):
+        n = ModalIdentifierNormalizer()
+        kb = "type(Rain)\ntype(Wet)\n\n[](Rain => Wet)\nRain\n"
+        normalized, reverse = n.normalize_belief_set(kb)
+        assert normalized == kb
+        assert reverse == {}
+
+    def test_type_keyword_not_mangled(self):
+        """The ``type`` declaration keyword must survive normalization."""
+        n = ModalIdentifierNormalizer()
+        normalized, _ = n.normalize_belief_set("type(heavy_rain)\nheavy_rain\n")
+        assert normalized.startswith("type(")
+        assert normalized == "type(HeavyRain)\nHeavyRain\n"
+
+    def test_reserved_seeds_prevent_collision_with_real_atom(self):
+        """A generated symbol must never shadow a pre-existing legal atom."""
+        # Pre-existing legal atom "HeavyRain" in the KB.
+        n = ModalIdentifierNormalizer(reserved={"HeavyRain"})
+        # An underscored atom that would PascalCase to HeavyRain must disambiguate.
+        assert n.legalize("heavy_rain") == "HeavyRain1"


### PR DESCRIPTION
## What

Modal consistency never **decided** on corpus renders whose LLM-generated proposition names contain underscores (R519: 3/3 modal axes undecided → honest `None`). Root cause: Tweety `MlParser` forbids underscores in predicate declarations (`Illegal characters in predicate definition 'joke_teleprompter'; declaration must conform to [a-z,A-Z]([a-z,A-Z,0-9])*`), but the spectacular-path `_construct_modal_kb_from_json` emits raw `type(joke_teleprompter)` with **no sanitizer**. The KB never parsed, so the configured solver (TWEETY or SPASS) never received a belief set to decide.

## Fix (anti-pendule: parse-layer, defense-in-depth)

Normalize identifiers to MlParser-legal PascalCase (`joke_teleprompter` → `JokeTeleprompter`) **at the parse point** in `ModalHandler` — immediately *amont* de `parseBeliefBase`, in both `is_modal_kb_consistent` and `execute_modal_query`. This covers the ModalHandler path AND the TweetyBridge fallback that delegates to it (the \"2 chemins\" of dispatch R516/#1326).

- New shared module `modal_kb_identifier_normalizer.py` — reuses the proven #1260 camelCase/`mpN` transform, **adds a collision guard** that the original inline #1260 closure lacked: two distinct source atoms that PascalCase to the same stem (`heavy_rain` vs `heavy-rain`) are now disambiguated instead of collapsed (a soundness bug — collapsing distinct atoms would fabricate/hide a contradiction, #1019 theater risk).
- Normalizes sort-name **SYNTAX** only — the semantic stem survives in the PascalCase form. No heuristic masks a parse-fail: a genuinely malformed KB is still rejected, handler returns honest `None`.
- Idempotent on already-legal atoms → the nl path (`invoke_callables._legal_symbol`, #1260) pre-sanitizes and the second pass here is a no-op.
- Reverse map (`{normalized: original}`) returned for readability/traceability, logged at DEBUG.

## Firsthand DoD evidence (verify-before-assert)

Probe + integration tests run against the **real** JVM + reasoners (no mocks):

1. **Parse-fail reproduced**: `type(joke_teleprompter)` → `valid=None`, exact `ParserException`.
2. **Normalization makes it parse + decide**: `JokeTeleprompter` → `valid=True`.
3. **Symbol map is SOUND**: inconsistent KB (`heavy_rain` ∧ `!heavy_rain`) → `valid=False`. Both occurrences map to the SAME symbol, so the contradiction is detected (an inconsistent map would wrongly report consistent).
4. **SPASS DECIDES firsthand**: SPASS installed + launchable, decides the normalized consistent KB `valid=True`. Verdict réel, pas theater-fallback.

## Bisect — regression vs LLM non-determinism (with proof)

**NOT a regression.** `modal_logic_agent.py` and `modal_handler.py` are **byte-identical** R483 (`2ccb1de3`, modal 3/3 decided) → R519 (`0fcc595a`, modal 3/3 parse-fail); `_construct_modal_kb_from_json` untouched since 2025-06-06 (`01461e8d`). The vulnerability is **pre-existing** (spectacular path always emitted raw `type(prop)`). The difference between runs is **LLM output non-determinism**: R483 generated MlParser-legal names (or routed through the nl-path `_legal_symbol` sanitizer #1260); R519 generated underscored multi-word atoms that hit the unsanitized spectacular path. The same underscored KB would parse-fail in R483 too. The fix closes the latent gap so both runs decide regardless of LLM naming.

## Tests

- `tests/unit/.../test_modal_kb_identifier_normalizer.py` — 11 no-JVM tests: PascalCase transform, idempotency, keyword preservation, memoization, soundness (negation shares symbol), collision guard (the #1260 fix), mpN fallback, reverse map, reserved seeding.
- `tests/integration/.../test_spass_real.py` — 3 new guards: underscored consistent KB DECIDES `True` (TWEETY), underscored inconsistent KB DECIDES `False` (sound map), SPASS DECIDES firsthand (gated on `_spass_runnable()`, **ran not skipped** here). All assert the verdict is traceable to the solver name in `msg` and is NOT a parse error.
- Existing `test_invoke_modal_logic_reaches_solver.py` + `test_fp11_modal_kb_roundtrip.py` (11 tests) PASS — no regression on the nl path.

## Validation

- mypy `--strict`: **0 new errors** (new module clean; `modal_handler.py` has 9 pre-existing untyped-call errors unchanged, outside the narrow CI mypy scope).
- Privacy HARD: synthetic weather-domain atoms only (`heavy_rain`, `wet_ground`); opaque corpus IDs (corpus_A/B/C) in this PR; no raw_text.

Closes #1326. Dispatch R516 task 2.