### PR TITLE
docs(tutorials): add dormant-Hierarchical notice banner (#1313, NOTICE decision)

### DIFF
--- a/docs/guides/tutorials/01_getting_started/01_introduction.md
+++ b/docs/guides/tutorials/01_getting_started/01_introduction.md
@@ -1,5 +1,15 @@
 # Tutoriel 1: Prise en main du système d'analyse rhétorique
 
+> **⚠️ Tutoriel en sommeil (mode Hiérarchique dormant).**
+> Ce tutoriel parcourt le mode d'orchestration **Hiérarchique**, actuellement
+> **dormant** (voir la table *Orchestration Modes* de `CLAUDE.md`). Le code de
+> référence reste présent à l'emplacement canonique
+> `argumentation_analysis/orchestration/hierarchical/` (expérimental, non branché
+> dans le pipeline actif). **Point d'entrée recommandé** aujourd'hui :
+> [`demonstration_epita.py`](../../../../examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py)
+> et `run_unified_analysis` (mode Pipeline actif). Les exemples d'imports
+> ci-dessous peuvent ne pas s'exécuter tels quels.
+
 ## Objectif
 Apprendre à installer, configurer et exécuter une analyse rhétorique de base
 

--- a/docs/guides/tutorials/01_getting_started/02_simple_analysis.md
+++ b/docs/guides/tutorials/01_getting_started/02_simple_analysis.md
@@ -1,5 +1,15 @@
 # Tutoriel 2: Analyse d'un discours simple
 
+> **⚠️ Tutoriel en sommeil (mode Hiérarchique dormant).**
+> Ce tutoriel parcourt le mode d'orchestration **Hiérarchique**, actuellement
+> **dormant** (voir la table *Orchestration Modes* de `CLAUDE.md`). Le code de
+> référence reste présent à l'emplacement canonique
+> `argumentation_analysis/orchestration/hierarchical/` (expérimental, non branché
+> dans le pipeline actif). **Point d'entrée recommandé** aujourd'hui :
+> [`demonstration_epita.py`](../../../../examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py)
+> et `run_unified_analysis` (mode Pipeline actif). Les exemples d'imports
+> ci-dessous peuvent ne pas s'exécuter tels quels.
+
 ## Objectif
 Apprendre à configurer et exécuter une analyse rhétorique complète sur un discours simple
 

--- a/docs/guides/tutorials/01_getting_started/03_complex_analysis.md
+++ b/docs/guides/tutorials/01_getting_started/03_complex_analysis.md
@@ -1,5 +1,15 @@
 # Tutoriel 3: Analyse d'un discours complexe
 
+> **⚠️ Tutoriel en sommeil (mode Hiérarchique dormant).**
+> Ce tutoriel parcourt le mode d'orchestration **Hiérarchique**, actuellement
+> **dormant** (voir la table *Orchestration Modes* de `CLAUDE.md`). Le code de
+> référence reste présent à l'emplacement canonique
+> `argumentation_analysis/orchestration/hierarchical/` (expérimental, non branché
+> dans le pipeline actif). **Point d'entrée recommandé** aujourd'hui :
+> [`demonstration_epita.py`](../../../../examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py)
+> et `run_unified_analysis` (mode Pipeline actif). Les exemples d'imports
+> ci-dessous peuvent ne pas s'exécuter tels quels.
+
 ## Objectif
 Apprendre à analyser des discours avec structures imbriquées, arguments multiples et sophismes complexes
 

--- a/docs/guides/tutorials/01_getting_started/README.md
+++ b/docs/guides/tutorials/01_getting_started/README.md
@@ -1,5 +1,16 @@
 # 📘 Getting Started
 
+> **⚠️ Documentation en sommeil (mode Hiérarchique dormant).**
+> Les tutoriels de cette section décrivent le mode d'orchestration
+> **Hiérarchique**, actuellement **dormant** (voir la table *Orchestration Modes*
+> de `CLAUDE.md`). Le code de référence reste présent à l'emplacement canonique
+> `argumentation_analysis/orchestration/hierarchical/` (expérimental, non branché
+> dans le pipeline actif) — ces tutoriels sont donc **en sommeil, pas cassés**.
+> **Point d'entrée recommandé** aujourd'hui :
+> [`demonstration_epita.py`](../../../../examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py)
+> et `run_unified_analysis` (mode Pipeline actif). Les exemples d'imports
+> ci-dessous peuvent ne pas s'exécuter tels quels.
+
 ## Description
 
 Ce répertoire contient les tutoriels d'introduction pour prendre en main le système d'analyse argumentative de l'Intelligence Symbolique EPITA. Ces tutoriels sont conçus pour les débutants et couvrent l'installation, la configuration, et les premières analyses.

--- a/docs/guides/tutorials/02_extending_the_system/01_adding_an_agent.md
+++ b/docs/guides/tutorials/02_extending_the_system/01_adding_an_agent.md
@@ -1,5 +1,15 @@
 # Tutoriel 4: Ajout d'un nouvel agent spécialiste
 
+> **⚠️ Tutoriel en sommeil (mode Hiérarchique dormant).**
+> Ce tutoriel parcourt le mode d'orchestration **Hiérarchique**, actuellement
+> **dormant** (voir la table *Orchestration Modes* de `CLAUDE.md`). Le code de
+> référence reste présent à l'emplacement canonique
+> `argumentation_analysis/orchestration/hierarchical/` (expérimental, non branché
+> dans le pipeline actif). **Point d'entrée recommandé** aujourd'hui :
+> [`demonstration_epita.py`](../../../../examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py)
+> et `run_unified_analysis` (mode Pipeline actif). Les exemples d'imports
+> ci-dessous peuvent ne pas s'exécuter tels quels.
+
 ## Objectif
 Apprendre à concevoir, implémenter et intégrer un nouvel agent dans l'architecture hiérarchique
 

--- a/docs/guides/tutorials/02_extending_the_system/02_extending_tools.md
+++ b/docs/guides/tutorials/02_extending_the_system/02_extending_tools.md
@@ -1,5 +1,15 @@
 # Tutoriel 5: Extension des outils d'analyse rhétorique
 
+> **⚠️ Tutoriel en sommeil (mode Hiérarchique dormant).**
+> Ce tutoriel parcourt le mode d'orchestration **Hiérarchique**, actuellement
+> **dormant** (voir la table *Orchestration Modes* de `CLAUDE.md`). Le code de
+> référence reste présent à l'emplacement canonique
+> `argumentation_analysis/orchestration/hierarchical/` (expérimental, non branché
+> dans le pipeline actif). **Point d'entrée recommandé** aujourd'hui :
+> [`demonstration_epita.py`](../../../../examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py)
+> et `run_unified_analysis` (mode Pipeline actif). Les exemples d'imports
+> ci-dessous peuvent ne pas s'exécuter tels quels.
+
 ## Objectif
 Apprendre à étendre les fonctionnalités des outils d'analyse existants pour améliorer la précision et les capacités du système
 

--- a/docs/guides/tutorials/02_extending_the_system/README.md
+++ b/docs/guides/tutorials/02_extending_the_system/README.md
@@ -1,5 +1,16 @@
 # 📗 Extending the System
 
+> **⚠️ Documentation en sommeil (mode Hiérarchique dormant).**
+> Les tutoriels de cette section décrivent le mode d'orchestration
+> **Hiérarchique**, actuellement **dormant** (voir la table *Orchestration Modes*
+> de `CLAUDE.md`). Le code de référence reste présent à l'emplacement canonique
+> `argumentation_analysis/orchestration/hierarchical/` (expérimental, non branché
+> dans le pipeline actif) — ces tutoriels sont donc **en sommeil, pas cassés**.
+> **Point d'entrée recommandé** aujourd'hui :
+> [`demonstration_epita.py`](../../../../examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py)
+> et `run_unified_analysis` (mode Pipeline actif). Les exemples d'imports
+> ci-dessous peuvent ne pas s'exécuter tels quels.
+
 ## Description
 
 Ce répertoire contient les tutoriels avancés pour étendre et personnaliser le système d'analyse argumentative. Ces tutoriels s'adressent aux développeurs qui souhaitent enrichir le système avec leurs propres agents, outils d'analyse, ou fonctionnalités personnalisées.

--- a/docs/guides/tutorials/README.md
+++ b/docs/guides/tutorials/README.md
@@ -1,5 +1,17 @@
 # 📚 Tutoriels
 
+> **⚠️ Documentation en sommeil (mode Hiérarchique dormant).**
+> Ces tutoriels décrivent le mode d'orchestration **Hiérarchique**, actuellement
+> **dormant** (voir la table *Orchestration Modes* de `CLAUDE.md`). Le code de
+> référence reste présent à l'emplacement canonique
+> `argumentation_analysis/orchestration/hierarchical/` (expérimental, non branché
+> dans le pipeline actif) — ces tutoriels sont donc **en sommeil, pas cassés**.
+>
+> **Point d'entrée recommandé** pour démarrer aujourd'hui :
+> [`examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py`](../../../examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py)
+> et la fonction `run_unified_analysis` (mode Pipeline actif).
+> Les exemples d'imports ci-dessous peuvent ne pas s'exécuter tels quels.
+
 ## 📋 Vue d'Ensemble
 
 Les tutoriels offrent des guides pas-à-pas pour apprendre à utiliser et étendre le système d'argumentation de l'Intelligence Symbolique EPITA. Ils sont organisés du niveau débutant au niveau avancé, avec une progression pédagogique claire.


### PR DESCRIPTION
## Summary

**Dispatched by coord ai-01 R516** — implements the **NOTICE decision** for #1313: an honest "dormant mode" banner at the top of all 8 files in `docs/guides/tutorials/**`. The tutorials describe the **dormant Hierarchical orchestration mode** using non-runnable imports; the coord arbitrated NOTICE over delete/rewrite because a dormant mode is a **recycling candidate, not dead weight** (north-star parametric).

## What it does

Adds a banner at the top of all 8 files (6 tutorials + root README + 2 subdir READMEs) that:
1. **Marks the Hierarchical mode as DORMANT**, linking the *Orchestration Modes* table in `CLAUDE.md`.
2. **Points to the active entry point**: `examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py` + `run_unified_analysis` (Pipeline mode).
3. **Contextualizes the non-runnable imports**: notes the canonical dormant location `argumentation_analysis/orchestration/hierarchical/` (experimental, not wired into the active pipeline) so the reader knows the tutorials are **experimental-dormant, not silently-broken**.

| File | Banner |
|------|--------|
| `tutorials/README.md` (root) | "Documentation en sommeil" |
| `tutorials/01_getting_started/README.md` | "Documentation en sommeil" |
| `tutorials/02_extending_the_system/README.md` | "Documentation en sommeil" |
| `tutorials/01_getting_started/01_introduction.md` | "Tutoriel en sommeil" |
| `tutorials/01_getting_started/02_simple_analysis.md` | "Tutoriel en sommeil" |
| `tutorials/01_getting_started/03_complex_analysis.md` | "Tutoriel en sommeil" |
| `tutorials/02_extending_the_system/01_adding_an_agent.md` | "Tutoriel en sommeil" |
| `tutorials/02_extending_the_system/02_extending_tools.md` | "Tutoriel en sommeil" |

## DoD (all met)

- [x] Banner in all 8 files, coherent text. Entry-point links verified to resolve **in-place** (`../../../examples/...` from root README, `../../../../examples/...` from subdirs — depth-aware, lesson R494 applied: never assume the relative path).
- [x] **No file deletion** (Cleanup-Gate-clean, fully reversible).
- [x] **No body rewrite** — pure insertion: 8 files, **+84 insertions, 0 deletions**. Anti-pendule respected: this is a banner + pointer, not a disguised rewrite.

## Anti-pendule / scope

The **preexisting broken links inside the 3 README bodies** (`../demos/`, `../../docs/`, `./01_getting_started/02_installation.md`, etc. — 11/9/9 across the 3 READMEs) are intentionally **OUT of scope**: touching them would be a body rewrite, which the NOTICE decision forbids. They remain as-is (candidates for a separate #1315-style link campaign, not this notice).

Docs-only; mypy gate unaffected (no code touched).

Refs #1313.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
