### PR TITLE
fix(scripts): repair f-string SyntaxError in documentation_system/interactive_guide.py

### DIFF
--- a/scripts/documentation_system/interactive_guide.py
+++ b/scripts/documentation_system/interactive_guide.py
@@ -194,7 +194,7 @@ class InteractiveDocumentationGuide:
                         <div class="entry-item">
                             <h4>{entry['name']}</h4>
                             <span class="badge badge-{entry['category']}">{entry['category']}</span>
-                            <p>{entry.get('docstring', 'Module d\'entrée du système')[:120]}...</p>
+                            <p>{entry.get("docstring", "Module d'entrée du système")[:120]}...</p>
                         </div>'''
 
         html_content += """


### PR DESCRIPTION
## What

`scripts/documentation_system/interactive_guide.py` did **not compile** — `SyntaxError: f-string expression part cannot include a backslash`. The whole interactive documentation generator was unrunnable.

## Root cause

Line 197, inside an `f'''...'''` block:
```
<p>{entry.get('docstring', 'Module d\'entrée du système')[:120]}...</p>
```
The `\'` (backslash-escaped apostrophe) sits **inside the f-string expression part** `{...}`, which Python < 3.12 forbids. The module docstring claimed "VERSION CORRIGÉE sans problèmes de f-string" but this one site was missed.

## Fix (anti-pendule: minimal quoting change)

Switch the `.get()` string args to double quotes so the apostrophe in "d'entrée" needs no backslash:
```
<p>{entry.get("docstring", "Module d'entrée du système")[:120]}...</p>
```
No logic change. The apostrophe is now a literal inside a double-quoted string.

## Why fix, not delete

Unlike #1317 (`run_embed_tests.py` — irrecoverable: `import *` inside a function + dead import target), this is a real, functional documentation generator (Flask + static-HTML fallback). The SyntaxError is the only blocker; a one-char-class fix makes it runnable. Same dead-script **family** as #1317/#1322/#1323/#1325 (found via the same `py_compile` sweep), but the recoverable branch.

## Validation

- `python -m py_compile scripts/documentation_system/interactive_guide.py` -> **OK** (was SyntaxError).
- Full `scripts/` + `argumentation_analysis/` `py_compile` sweep -> **0 broken** (was 1).
- Disjoint from open PRs (#1327 modal logic/, #1328 docs/tutorials/).

Found during R522 active-dig recon (no-idle mandate).

Co-Authored-By: Claude-Code <noreply@anthropic.com>