### PR TITLE
fix(communication): stop leaked PubSub/RequestResponse threads (#1341, partial)

### DIFF
--- a/argumentation_analysis/core/communication/pub_sub.py
+++ b/argumentation_analysis/core/communication/pub_sub.py
@@ -9,6 +9,7 @@ récepteurs et permet une communication one-to-many efficace.
 import uuid
 import threading
 import asyncio
+import weakref
 from typing import Dict, Any, Optional, Callable, List, Set
 from datetime import datetime, timedelta
 
@@ -261,6 +262,10 @@ class PublishSubscribeProtocol:
     publication de messages.
     """
 
+    # Registre faible des instances vivantes, pour le nettoyage des threads
+    # d'arrière-plan fuyants lors des tests (root cause du hang CI #1341).
+    _instances: "weakref.WeakSet[PublishSubscribeProtocol]" = weakref.WeakSet()
+
     def __init__(self, middleware):
         """
         Initialise le protocole de publication-abonnement.
@@ -274,9 +279,12 @@ class PublishSubscribeProtocol:
 
         # Démarrer le thread de nettoyage des messages expirés
         self.running = True
+        self._stop_event = threading.Event()  # Rend l'attente du cleanup interruptible par shutdown()
         self.cleanup_thread = threading.Thread(target=self._cleanup_expired_messages)
         self.cleanup_thread.daemon = True
         self.cleanup_thread.start()
+
+        PublishSubscribeProtocol._instances.add(self)
 
     def create_topic(
         self,
@@ -484,15 +492,32 @@ class PublishSubscribeProtocol:
                                 > now
                             ]
 
-                # Attendre avant le prochain nettoyage
-                threading.Event().wait(60)  # Nettoyer toutes les minutes
+                # Attendre avant le prochain nettoyage (interruptible par shutdown)
+                self._stop_event.wait(60)  # Nettoyer toutes les minutes
 
             except Exception as e:
                 print(f"Error in message cleanup: {e}")
-                threading.Event().wait(5)  # Attendre un peu en cas d'erreur
+                self._stop_event.wait(5)  # Attendre un peu en cas d'erreur
 
     def shutdown(self):
         """Arrête proprement le protocole."""
         self.running = False
+        self._stop_event.set()  # Réveille immédiatement le thread de cleanup
         if self.cleanup_thread.is_alive():
             self.cleanup_thread.join(timeout=2)
+
+    @classmethod
+    def shutdown_all(cls):
+        """Arrête toutes les instances vivantes (nettoyage test, #1341).
+
+        Les tests de communication créent des PublishSubscribeProtocol via
+        MessageMiddleware sans appeler shutdown() ; leurs threads cleanup
+        (daemon, attente 60s) fuient à travers la session et, sous la
+        réentrance nest_asyncio, bloquent la boucle asyncio des tests async
+        suivants. Ce balayage arrête les threads fuyants après chaque test.
+        """
+        for instance in list(cls._instances):
+            try:
+                instance.shutdown()
+            except Exception:
+                pass

--- a/argumentation_analysis/core/communication/request_response.py
+++ b/argumentation_analysis/core/communication/request_response.py
@@ -11,6 +11,7 @@ import time
 import threading
 import asyncio
 import logging
+import weakref
 from typing import Dict, Any, Optional, Callable, Tuple, List
 from datetime import datetime, timedelta
 
@@ -30,6 +31,10 @@ class RequestResponseProtocol:
     Ce protocole gère l'envoi de requêtes et la réception des réponses correspondantes,
     avec gestion des timeouts et des réessais.
     """
+
+    # Registre faible des instances vivantes, pour le nettoyage des threads
+    # d'arrière-plan fuyants lors des tests (root cause du hang CI #1341).
+    _instances: "weakref.WeakSet[RequestResponseProtocol]" = weakref.WeakSet()
 
     def __init__(self, middleware):
         """
@@ -61,6 +66,8 @@ class RequestResponseProtocol:
         self.timeout_thread = threading.Thread(target=self._monitor_timeouts)
         self.timeout_thread.daemon = True
         self.timeout_thread.start()
+
+        RequestResponseProtocol._instances.add(self)
 
     def send_request(
         self,
@@ -819,3 +826,18 @@ class RequestResponseProtocol:
             self.pending_requests.clear()
             self.early_responses.clear()
             self.early_responses_by_conversation.clear()
+
+    @classmethod
+    def shutdown_all(cls):
+        """Arrête toutes les instances vivantes (nettoyage test, #1341).
+
+        Les tests de communication créent des RequestResponseProtocol via
+        MessageMiddleware sans appeler shutdown() ; leurs threads timeout
+        (daemon) fuient à travers la session. Ce balayage les arrête après
+        chaque test, en complément de PublishSubscribeProtocol.shutdown_all().
+        """
+        for instance in list(cls._instances):
+            try:
+                instance.shutdown()
+            except Exception:
+                pass

--- a/tests/unit/argumentation_analysis/conftest.py
+++ b/tests/unit/argumentation_analysis/conftest.py
@@ -82,3 +82,39 @@ def mock_parse_args():
     """Fixture pour mocker la fonction `parse_args` d'argparse."""
     with patch("argparse.ArgumentParser.parse_args") as mock:
         yield mock
+
+
+@pytest.fixture(autouse=True)
+def _shutdown_leaked_communication_threads():
+    """Arrête les threads d'arrière-plan de communication fuyants après chaque test.
+
+    Root cause du hang CI (#1341) : les tests de communication créent des
+    MessageMiddleware (et donc des PublishSubscribeProtocol /
+    RequestResponseProtocol) sans appeler ``shutdown()``. Leurs threads
+    daemon (cleanup 60s pour pub_sub, monitor 0.1s pour request_response)
+    fuient à travers la session ; sous la réentrance ``nest_asyncio`` du
+    conftest global, ils bloquent la boucle asyncio des tests async suivants
+    → le job ``automated-tests`` hang >5h et ne complète jamais.
+
+    Ce balayage (O(instances vivantes), négligeable sur les ~14k tests où
+    la WeakSet est vide) arrête les threads fuyants après chaque test. Les
+    protocoles enregistrent leurs instances dans une WeakSet faible
+    (``shutdown_all``) ; la WeakSet auto-retire les instances GC-ées.
+    """
+    yield
+    try:
+        from argumentation_analysis.core.communication.pub_sub import (
+            PublishSubscribeProtocol,
+        )
+
+        PublishSubscribeProtocol.shutdown_all()
+    except Exception:
+        pass
+    try:
+        from argumentation_analysis.core.communication.request_response import (
+            RequestResponseProtocol,
+        )
+
+        RequestResponseProtocol.shutdown_all()
+    except Exception:
+        pass


### PR DESCRIPTION
First-round root-cause investigation of the CI `automated-tests` hang (**#1341**, >5h, never completes). Builds on po-2025's R525 diagnosis (asyncio inter-test pollution).

## What this PR fixes (verified firsthand)

**The thread-leak component.** `PublishSubscribeProtocol.__init__` launched a cleanup daemon whose 60s wait was **uninterruptible** — a fresh `threading.Event()` each loop iteration, so `shutdown() -> join(timeout=2)` could not stop it. Threads leaked across the session.

Fix:
- `shutdown()` now sets a persistent `_stop_event`; the wait returns immediately.
- `weakref` registry + `shutdown_all()` classmethod on both `PublishSubscribeProtocol` and `RequestResponseProtocol`.
- Autouse conftest fixture sweeps leaked instances after each test (O(instances), negligible on ~14k tests where the WeakSet is empty).

**Verification:**
- faulthandler dump confirms the 2 leaked `_cleanup_expired_messages` threads are **GONE** post-fix.
- No regression: the 3 comm files pass clean (`9 passed, 1 xfailed`).
- mypy: communication files are **out of CI scope** (the gate checks 8 specific core files).

## Necessary but NOT sufficient — deeper loop pollution remains

Post-fix, the canary **still hangs** — the main thread deadlocks in `nest_asyncio._run_once` -> `windows_events._poll` (IOCP), and a leaked `concurrent.futures.thread._worker` (ThreadPoolExecutor) persists. Correlates with `loop.run_in_executor` default executor (middleware.py:341) and `asyncio.run()`/`loop.run_until_complete()` in `test_communication_integration.py` under the global `nest_asyncio.apply()`.

Full diagnostic posted to #1341. **pytest-timeout (coord R521) already makes the hang fail-fast** -> the suite COMPLETES (unblocking #1336 triage) even before the full root-cause fix.

## Why ship the partial fix now

Genuine bug (`shutdown()` was broken — uninterruptible 60s wait), removes a verified pollution source, correct/safe/no-regression. Lets the deeper investigation continue on a clean base.

Refs: #1341 #1336 #1303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)