### PR TITLE
feat(shared-state): CONV-C deliberation trace plumbing (#1334, phase 2/3)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -1,6 +1,6 @@
 # core/shared_state.py
 import json
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from typing import Dict, List, Any, Optional, cast
 import logging
 
@@ -28,6 +28,35 @@ class ArgumentProfile:
     counter_arguments: List[Dict[str, Any]] = field(default_factory=list)
     jtms_beliefs: List[Dict[str, Any]] = field(default_factory=list)
     formal_results: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class DesignationRecord:
+    """Trace d'une désignation motivée du PM conversationnel (CONV-C #1334).
+
+    Une structure commune servent trois consommateurs : (1) les métriques
+    CONV-A/C (conduite non-round-robin démontrable), (2) l'audit anti-runaway
+    #708 (cap respecté, fail-loud sur breach), (3) l'Acte II de CONV-D
+    (restitution de la délibération — ne doit narrer QUE des events tracés).
+
+    Attributes:
+        turn: Index du tour pipeline-global (auto si None : len(trace)+1).
+        designated_agent: Nom exact de l'agent convoqué (ex. "FormalAgent").
+        motivation: 1-2 phrases du PM sur POURQUOI maintenant (obligatoire).
+        trigger: "initial" | "deepening" | "synergy" | "convergence".
+        state_fingerprint_before: Empreinte de l'état avant l'appel (counts).
+        state_fingerprint_after: Empreinte après le retour de l'agent (backfill
+            par ``_run_phase``), None tant que l'agent n'a pas répondu.
+        delta_summary: Résumé humain du delta observé (backfill ``_run_phase``).
+    """
+
+    designated_agent: str
+    motivation: str
+    trigger: str
+    turn: Optional[int] = None
+    state_fingerprint_before: Optional[Dict[str, Any]] = None
+    state_fingerprint_after: Optional[Dict[str, Any]] = None
+    delta_summary: Optional[str] = None
 
 
 class RhetoricalAnalysisState:
@@ -336,6 +365,11 @@ class RhetoricalAnalysisState:
                 "tasks_answered": list(self.answers.keys()),
                 "conclusion_present": self.final_conclusion is not None,
                 "next_agent_designated": self._next_agent_designated,
+                # CONV-C #1334: deliberation trace (count only in the summary;
+                # full records via the non-summarized snapshot / direct field).
+                "deliberation_turn_count": len(
+                    getattr(self, "deliberation_trace", [])
+                ),
             }
         else:
             return cast(Dict[str, Any], json.loads(self.to_json(indent=None)))
@@ -494,6 +528,79 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         # RA-4 #1049: Strategic NL journaling bridge
         self.strategic_objectives: List[Dict[str, Any]] = []
         self.strategic_decisions_log: List[Dict[str, Any]] = []
+        # CONV-C #1334: deliberation trace of the conversational PM. Each
+        # DesignationRecord (agent designated + motivation + trigger + state
+        # fingerprint before/after + delta) is the shared material of (1) the
+        # CONV-A/C metrics (non-round-robin conduction), (2) the #708 anti-
+        # runaway audit, (3) CONV-D Act II. Appended by record_designation();
+        # the PM writes a record BEFORE designating (fingerprint_before), and
+        # the conversational _run_phase backfills fingerprint_after/delta when
+        # the designated agent returns. Stored as plain dicts (via asdict) so
+        # the trace serializes with the rest of __dict__ (to_json); the
+        # DesignationRecord dataclass is the typed constructor. One spine, no
+        # second state object.
+        self.deliberation_trace: List[Dict[str, Any]] = []
+
+    def record_designation(
+        self,
+        agent: str,
+        motivation: str,
+        trigger: str,
+        turn: Optional[int] = None,
+    ) -> int:
+        """Append a motivated PM designation record to the deliberation trace.
+
+        CONV-C #1334. The PM calls this (via the StateManagerPlugin
+        ``record_designation`` kernel function) BEFORE ``designate_next_agent``:
+        it captures the *why* of the designation and a fingerprint of the state
+        at the moment of the decision. ``fingerprint_after`` / ``delta_summary``
+        are backfilled by the conversational ``_run_phase`` when the designated
+        agent returns.
+
+        Args:
+            agent: Exact name of the designated agent (e.g. "FormalAgent").
+            motivation: 1-2 sentences on WHY now (obligatory; the central
+                CONV-C requirement — designations must be motivated, not
+                round-robin).
+            trigger: "initial" | "deepening" | "synergy" | "convergence".
+            turn: Pipeline-global turn index. Auto-derived (len(trace)+1) when
+                None, so the PM does not have to track it.
+
+        Returns:
+            The 1-based turn index assigned to this record (for log/audit).
+        """
+        if turn is None:
+            turn = len(self.deliberation_trace) + 1
+        record = DesignationRecord(
+            designated_agent=agent,
+            motivation=motivation,
+            trigger=trigger,
+            turn=turn,
+            state_fingerprint_before=self._designation_fingerprint(),
+        )
+        self.deliberation_trace.append(asdict(record))
+        state_logger.info(
+            f"[CONV-C] Désignation tracée tour {turn}: '{agent}' "
+            f"(trigger={trigger}) — {motivation[:80]}"
+        )
+        return turn
+
+    def _designation_fingerprint(self) -> Dict[str, Any]:
+        """Compact state fingerprint at a designation moment (for the trace).
+
+        Lightweight counts only — enough for the metrics (growth / coverage)
+        and the #708 audit, without the full snapshot payload.
+        """
+        return {
+            "argument_count": len(self.identified_arguments),
+            "fallacy_count": len(self.identified_fallacies),
+            "belief_set_count": len(self.belief_sets),
+            "counter_argument_count": len(
+                getattr(self, "counter_arguments", [])
+            ),
+            "jtms_belief_count": len(getattr(self, "jtms_beliefs", {})),
+            "conclusion_present": self.final_conclusion is not None,
+        }
 
     def set_source_metadata(self, metadata: Dict[str, str]) -> None:
         """Populate source-level metadata (Epic #1258 / Track 1 #1259).

--- a/argumentation_analysis/core/state_manager_plugin.py
+++ b/argumentation_analysis/core/state_manager_plugin.py
@@ -363,6 +363,55 @@ class StateManagerPlugin:
             )
             return f"FUNC_ERROR: Erreur désignation agent {agent_name}: {e}"
 
+    @kernel_function(
+        description=(
+            "Enregistre une désignation motivée dans la trace de délibération "
+            "(CONV-C #1334). À appeler AVANT designate_next_agent : capture le "
+            "POURQUOI de la désignation (motivation, 1-2 phrases) et le type de "
+            "déclencheur. La motivation est OBLIGATOIRE."
+        ),
+        name="record_designation",
+    )
+    def record_designation(
+        self,
+        agent: str,
+        motivation: str,
+        trigger: str,
+    ) -> str:
+        """Trace une désignation motivée du PM dans ``state.deliberation_trace``.
+
+        CONV-C #1334. Companion de ``designate_next_agent`` : cette fonction
+        écrit le *pourquoi* (matériau des métriques CONV-A/C, de l'audit #708,
+        et de l'Acte II de CONV-D), tandis que ``designate_next_agent`` écrit
+        le signal de sélection lu par ``DelegatingSelectionStrategy``. On garde
+        les deux séparées : la trace et le signal servent des lecteurs
+        différents et peuvent découpler (ex. un record d'audit seul).
+        """
+        self._logger.info(
+            f"Appel record_designation: agent='{agent}', trigger='{trigger}'"
+        )
+        try:
+            record_method = getattr(self._state, "record_designation", None)
+            if record_method is None:
+                return (
+                    "FUNC_ERROR: l'état n'expose pas record_designation "
+                    "(UnifiedAnalysisState requis pour CONV-C)."
+                )
+            turn = record_method(agent, motivation, trigger)
+            self._logger.info(
+                f" -> Désignation tracée tour {turn} pour '{agent}'."
+            )
+            return (
+                f"OK. Désignation tracée (tour {turn}, agent '{agent}', "
+                f"trigger '{trigger}')."
+            )
+        except Exception as e:
+            self._logger.error(
+                f"Erreur lors de l'enregistrement de la désignation: {e}",
+                exc_info=True,
+            )
+            return f"FUNC_ERROR: Erreur enregistrement désignation: {e}"
+
     # =========================================================================
     # JTMS Hub Integration (#214)
     # =========================================================================

--- a/tests/unit/argumentation_analysis/test_conv_c_deliberation_trace_1334.py
+++ b/tests/unit/argumentation_analysis/test_conv_c_deliberation_trace_1334.py
@@ -1,0 +1,122 @@
+"""Tests for the CONV-C deliberation trace (#1334, Epic #1331).
+
+Covers the ``record_designation`` plumbing on ``UnifiedAnalysisState`` +
+``StateManagerPlugin``: motivated PM designations are recorded in a
+``deliberation_trace`` of ``DesignationRecord`` (the shared material of the
+CONV-A/C metrics, the #708 anti-runaway audit, and CONV-D Act II).
+
+Design doc: docs/architecture/CONV_C_PM_ECLAIRE.md (PR #1340).
+"""
+
+import json
+
+import pytest
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.core.state_manager_plugin import StateManagerPlugin
+
+
+# ---------------------------------------------------------------------------
+# UnifiedAnalysisState.record_designation
+# ---------------------------------------------------------------------------
+
+
+def test_record_designation_appends_motivated_record():
+    """A designation is recorded with its motivation + trigger + fingerprint."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    turn = state.record_designation(
+        "FormalAgent",
+        "InformalAgent a trouve une contradiction sur arg_3",
+        "deepening",
+    )
+    assert turn == 1
+    assert len(state.deliberation_trace) == 1
+    record = state.deliberation_trace[0]
+    assert record["designated_agent"] == "FormalAgent"
+    assert "contradiction" in record["motivation"]
+    assert record["trigger"] == "deepening"
+    # fingerprint_before captured at the moment of the designation
+    assert record["state_fingerprint_before"] is not None
+    assert record["state_fingerprint_before"]["argument_count"] == 0
+    # after/delta left for _run_phase backfill until the agent returns
+    assert record["state_fingerprint_after"] is None
+    assert record["delta_summary"] is None
+
+
+def test_record_designation_auto_increments_turn():
+    """Turn auto-derives (len(trace)+1) so the PM does not track it."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    t1 = state.record_designation("ExtractAgent", "etat vide", "initial")
+    t2 = state.record_designation("InformalAgent", "extraire les sophismes", "deepening")
+    t3 = state.record_designation("QualityAgent", "evaluer la qualite", "synergy")
+    assert (t1, t2, t3) == (1, 2, 3)
+    assert len(state.deliberation_trace) == 3
+
+
+def test_record_designation_explicit_turn_respected():
+    """An explicit turn index is honored (pipeline-global accounting)."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    turn = state.record_designation("ExtractAgent", "x", "initial", turn=7)
+    assert turn == 7
+    assert state.deliberation_trace[0]["turn"] == 7
+
+
+def test_snapshot_exposes_deliberation_turn_count():
+    """The summarized snapshot surfaces the trace length (lightweight)."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    snap = state.get_state_snapshot(summarize=True)
+    assert snap["deliberation_turn_count"] == 0
+    state.record_designation("ExtractAgent", "x", "initial")
+    state.record_designation("InformalAgent", "y", "deepening")
+    snap = state.get_state_snapshot(summarize=True)
+    assert snap["deliberation_turn_count"] == 2
+
+
+def test_designation_fingerprint_reflects_state_growth():
+    """The fingerprint captures the state dimensions the PM reasons about."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    state.add_identified_arguments(["premisses: P conclusion: Q"])
+    state.record_designation("FormalAgent", "argument extrait, formaliser", "deepening")
+    fp = state.deliberation_trace[0]["state_fingerprint_before"]
+    assert fp is not None
+    assert fp["argument_count"] == 1
+
+
+def test_full_snapshot_serializes_deliberation_trace():
+    """The non-summarized snapshot carries the full trace (for CONV-D / audit)."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    state.record_designation("ExtractAgent", "raison initiale", "initial")
+    # to_json serializes __dict__ -> deliberation_trace included
+    payload = json.loads(state.to_json(indent=None))
+    assert "deliberation_trace" in payload
+    trace = payload["deliberation_trace"]
+    assert len(trace) == 1
+    assert trace[0]["designated_agent"] == "ExtractAgent"
+
+
+# ---------------------------------------------------------------------------
+# StateManagerPlugin.record_designation (kernel function companion)
+# ---------------------------------------------------------------------------
+
+
+def test_plugin_record_designation_delegates_to_state():
+    """The kernel function delegates to state.record_designation."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    plugin = StateManagerPlugin(state)
+    result = plugin.record_designation(
+        "InformalAgent", "arguments extraits, detecter sophismes", "deepening"
+    )
+    assert result.startswith("OK.")
+    assert len(state.deliberation_trace) == 1
+    assert state.deliberation_trace[0]["designated_agent"] == "InformalAgent"
+
+
+def test_plugin_record_designation_fails_loud_on_missing_method():
+    """A state without record_designation (base RhetoricalAnalysisState) fails loud."""
+    from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+
+    base_state = RhetoricalAnalysisState("Some text to analyse.")
+    plugin = StateManagerPlugin(base_state)  # type: ignore[arg-type]
+    result = plugin.record_designation("ExtractAgent", "x", "initial")
+    assert result.startswith("FUNC_ERROR")
+    assert "record_designation" in result


### PR DESCRIPTION
Implements the motivated-designation trace for the conversational PM — the **phase 2/3** follow-up to the design doc merged in #1340 (`docs/architecture/CONV_C_PM_ECLAIRE.md`). Epic #1331, track #1334.

## What this adds

The deliberation trace the PM was missing (the central gap diagnosed in #1340 §2.3). It is the **one structure for three consumers** (§4): (1) the CONV-A/C metrics — non-round-robin conduction demonstrable; (2) the #708 anti-runaway audit — cap respected; (3) CONV-D Act II — the restitution woven from real traced events (#1316 honesty cross-check extends here).

- **`DesignationRecord`** dataclass (`turn`, `designated_agent`, `motivation`, `trigger`, `state_fingerprint_before/after`, `delta_summary`) — the typed constructor.
- **`UnifiedAnalysisState.deliberation_trace`** (`List[Dict]`, `asdict`-serialized → carries through `to_json` like every other field). One spine, no second state object (§P5: no bridge to the dormant hierarchical state).
- **`UnifiedAnalysisState.record_designation(agent, motivation, trigger, turn=None)`** — appends a record with `fingerprint_before` captured at the decision moment; `turn` auto-derives (`len(trace)+1`) so the PM doesn't track it. `fingerprint_after`/`delta_summary` left for the `_run_phase` backfill (next phase).
- **`StateManagerPlugin.record_designation`** kernel function — the PM-facing entry point, called **before** `designate_next_agent`. Kept separate from the selection signal (different readers; may decouple). Fails loud on a state that lacks the method (base `RhetoricalAnalysisState`).
- `get_state_snapshot(summarize=True)` surfaces `deliberation_turn_count`.

## Anti-pendule

This **adds** the missing trace (real gap). The prompt rewrite (subtracting the EXTRACTION-GATE/CROSS-KB recipes per §5) lands in the next phase — separate concern.

## Validation

- **mypy --strict** (CI config) on `shared_state.py`: **0 issues** (shared_state is in the 8-file CI mypy scope).
- **8 new unit tests + 82 existing shared_state tests: 90 passed, 0 failed.**
- Smoke: end-to-end trace append + auto-turn-increment + fingerprint + snapshot count.

## DoD (#1340 §9)

- [x] `record_designation` kernel function + `deliberation_trace` field + snapshot exposure (§7.1–7.2)
- [ ] PM prompt rewrite per §5 (subtract EXTRACTION-GATE/CROSS-KB) — next phase
- [ ] `_run_phase` backfills `fingerprint_after` / `delta_summary` (§7.3) — next phase
- [ ] Pipeline-global tour cap + `CapBreachRecord` fail-loud (§6) — next phase
- [ ] Trace run demonstrating non-round-robin conduction — next phase

Refs: #1331 #1334 #1340 #1335 #708 #1019 #1313 #1316.

🤖 Generated with [Claude Code](https://claude.com/claude-code)