### PR TITLE
feat(conv-c): de-templatised PM prompt + designation backfill + pipeline cap (#1334 phase 3/3)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -367,8 +367,12 @@ class RhetoricalAnalysisState:
                 "next_agent_designated": self._next_agent_designated,
                 # CONV-C #1334: deliberation trace (count only in the summary;
                 # full records via the non-summarized snapshot / direct field).
-                "deliberation_turn_count": len(
-                    getattr(self, "deliberation_trace", [])
+                # cap_breach markers are NOT designations — excluded from the
+                # count so the metric reflects PM conduction turns only.
+                "deliberation_turn_count": sum(
+                    1
+                    for r in getattr(self, "deliberation_trace", [])
+                    if r.get("record_type") != "cap_breach"
                 ),
             }
         else:
@@ -601,6 +605,85 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "jtms_belief_count": len(getattr(self, "jtms_beliefs", {})),
             "conclusion_present": self.final_conclusion is not None,
         }
+
+    def backfill_last_designation_for(self, agent: str) -> bool:
+        """Close the most recent open DesignationRecord when its agent returns.
+
+        CONV-C #1334 phase 3 (design doc §7.3). The conversational ``_run_phase``
+        calls this after each turn with the name of the agent that just spoke.
+        The record is closed **only** when ``agent`` matches the record's
+        ``designated_agent`` — i.e. the designated specialist has actually
+        returned (not the PM speaking its own freshly-opened record, nor a
+        round-robin interloper). ``fingerprint_after`` reuses
+        :meth:`_designation_fingerprint` so before/after are directly comparable,
+        making the "conditioned on intermediate results" judgement inspectable
+        without a new measurement path.
+
+        Returns:
+            True if a record was closed, False otherwise (no open record, or the
+            open record is for a different agent and is left open).
+        """
+        for record in reversed(self.deliberation_trace):
+            if record.get("record_type") == "cap_breach":
+                continue  # audit marker, not a designation
+            if record.get("state_fingerprint_after") is None:
+                if record.get("designated_agent") != agent:
+                    return False  # open record exists, but for another agent
+                fp_after = self._designation_fingerprint()
+                record["state_fingerprint_after"] = fp_after
+                record["delta_summary"] = self._designation_delta_summary(
+                    record.get("state_fingerprint_before") or {}, fp_after
+                )
+                return True
+        return False
+
+    @staticmethod
+    def _designation_delta_summary(
+        before: Dict[str, Any], after: Dict[str, Any]
+    ) -> str:
+        """One-line human-readable delta between two designation fingerprints."""
+        parts: List[str] = []
+        for key in (
+            "argument_count",
+            "fallacy_count",
+            "belief_set_count",
+            "counter_argument_count",
+            "jtms_belief_count",
+        ):
+            delta = int(after.get(key, 0)) - int(before.get(key, 0))
+            if delta:
+                sign = "+" if delta > 0 else ""
+                parts.append(f"{key.removesuffix('_count')}{sign}{delta}")
+        if after.get("conclusion_present") and not before.get(
+            "conclusion_present"
+        ):
+            parts.append("conclusion_set")
+        return ", ".join(parts) if parts else "no_growth"
+
+    def record_cap_breach(self, cap_kind: str, turn: int, detail: str = "") -> None:
+        """Append a CapBreachRecord to the deliberation trace (§6 fail-loud).
+
+        CONV-C #1334. When a pipeline-global or per-phase turn cap is hit, the
+        breach is recorded as a structured entry — not a silent truncation — so
+        the #708 anti-runaway audit and CONV-D can see the run ended on a cap,
+        not on convergence. Marked ``record_type="cap_breach"`` to distinguish
+        from a DesignationRecord (and excluded from the designation count).
+        """
+        self.deliberation_trace.append(
+            {
+                "record_type": "cap_breach",
+                "cap_kind": cap_kind,
+                "turn": turn,
+                "detail": detail,
+                "state_fingerprint_before": self._designation_fingerprint(),
+            }
+        )
+        state_logger.warning(
+            "[CONV-C] Cap dur atteint tour %s (%s): %s",
+            turn,
+            cap_kind,
+            detail,
+        )
 
     def set_source_metadata(self, metadata: Dict[str, str]) -> None:
         """Populate source-level metadata (Epic #1258 / Track 1 #1259).

--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -161,30 +161,37 @@ AGENT_CONFIG = {
     "ProjectManager": {
         "speciality": "project_manager",
         "instructions": (
-            "Tu es le chef de projet d'analyse argumentative. Tu coordonnes l'equipe "
-            "d'agents specialises. A chaque tour :\n"
-            "1. Lis l'etat courant via get_current_state_snapshot()\n"
-            "2. Identifie ce qui manque (arguments? sophismes? formalisation? qualite? JTMS?)\n"
-            "3. Designe l'agent suivant via designate_next_agent(nom_exact)\n"
-            "4. Formule une question precise pour cet agent\n\n"
-            "EXTRACTION GATE (#595) — AVANT toute autre action :\n"
-            "- Verifie state.identified_arguments dans le snapshot. Si la liste est VIDE, "
-            "designe ExtractAgent en priorite ABSOLUE et demande-lui d'extraire TOUS les arguments.\n"
-            "- Ne passe PAS a InformalAgent, FormalAgent ou autre agent tant que identified_arguments est vide.\n"
-            "- Extraire des arguments est plus important que creer des croyances JTMS.\n"
-            "- Le minimum acceptable est 3 arguments sur un texte de >5000 mots.\n\n"
-            "CROSS-KB ENRICHMENT (#208-I) — tu dois diriger les synergies entre agents :\n"
-            "- Apres ExtractAgent : demande-lui d'abord de verifier que identified_arguments est rempli. "
-            "ENSUITE seulement, demande de creer des croyances JTMS (jtms_create_belief)\n"
-            "- Apres InformalAgent : demande a QualityAgent de TENIR COMPTE des sophismes detectes "
-            "en utilisant evaluate_with_cross_kb_context() avec les sophismes en contexte\n"
-            "- Apres QualityAgent : demande a CounterAgent de CIBLER les arguments faibles (score < 5/9)\n"
-            "- Apres FormalAgent : signale aux autres si des INCONSISTANCES logiques ont ete trouvees\n"
-            "- Apres DebateAgent : demande a GovernanceAgent d'evaluer le CONSENSUS avec "
-            "detect_conflicts() puis social_choice_vote() si des positions divergent\n"
-            "- Si JTMS retracte une croyance (jtms_check_consistency), signale-le et demande re-evaluation\n\n"
-            "CONVERGENCE : Quand tous les aspects sont couverts et que le consensus est evalue, "
-            "appelle set_final_conclusion() avec ta synthese. Cela signalera la fin de la phase."
+            "Tu es le chef de projet. Tu conduis l'analyse pour produire un ETAT RICHE "
+            "(couverture de toutes les dimensions pertinentes du texte), pas pour suivre un script. "
+            "Aucune sequence n'est imposee : c'est a toi de juger, a chaque tour, qui doit parler.\n\n"
+            "A CHAQUE TOUR :\n"
+            "1. Lis l'etat courant via get_current_state_snapshot().\n"
+            "2. Decide, en fonction de ce qui manque ou de ce qu'un resultat intermediaire "
+            "t'apprend, quel specialiste doit parler ensuite — ET POURQUOI.\n"
+            "3. Enregistre ta decision via record_designation(agent, motivation, trigger). "
+            "La motivation est OBLIGATOIRE : 1-2 phrases sur ce qui te fait convoquer cet agent "
+            "MAINTENANT (ex. 'InformalAgent a trouve une contradiction sur arg_3, je convoque "
+            "FormalAgent pour la formaliser'). trigger parmi : initial, deepening, synergy, convergence.\n"
+            "4. Designe l'agent via designate_next_agent(nom_exact) et pose-lui une question precise.\n\n"
+            "CARTE DES CAPACITES — ces synergies existent, c'est a toi d'en juger l'opportunite "
+            "(personne ne te l'impose) :\n"
+            "- ExtractAgent — extrait les arguments (add_identified_argument). [Fait : les "
+            "specialistes travaillent sur l'etat partage ; tant que l'extraction n'a rien "
+            "enregistre, l'etat est vide et rien d'autre n'a de substrate.]\n"
+            "- InformalAgent — sophismes (run_guided_analysis, add_identified_fallacy).\n"
+            "- FormalAgent — coherence logique (inconsistances signalees).\n"
+            "- QualityAgent — peut evaluer EN CONTEXTE les sophismes detectes "
+            "(evaluate_with_cross_kb_context).\n"
+            "- CounterAgent — peut cibler les arguments faibles.\n"
+            "- DebateAgent — positions adversariales ; GovernanceAgent — consensus, conflits, "
+            "vote (detect_conflicts, social_choice_vote).\n"
+            "- JTMS — croyances et retractations (jtms_create_belief, jtms_check_consistency) ; "
+            "une retractation peut invalider un fil.\n\n"
+            "BUDGET : tu as au plus {budget_turns} tours (pipeline-global) pour couvrir "
+            "l'analyse. La couverture prime sur l'epuisement du budget, mais le budget est DUR — "
+            "si tu l'atteins sans converger, le depassement est tracé (pas silencieux).\n\n"
+            "CONVERGENCE : quand l'etat est suffisamment couvert (dimensions pertinentes remplies, "
+            "consensus evalue si des positions divergent), appelle set_final_conclusion() avec ta synthese."
         ),
     },
     "ExtractAgent": {
@@ -389,6 +396,7 @@ def create_conversational_agents(
     llm_service_id: str,
     agent_names: Optional[List[str]] = None,
     agent_state_class: Optional[Dict[str, type]] = None,
+    pm_budget_turns: Optional[int] = None,
 ) -> List[ChatCompletionAgent]:
     """Create agents with specialized plugins for conversational mode.
 
@@ -408,6 +416,9 @@ def create_conversational_agents(
         agent_state_class: Optional mapping of agent_name → phase-scoped state
             plugin class (#605). When provided, the mapped agent gets the
             scoped class instead of the full StateManagerPlugin.
+        pm_budget_turns: CONV-C #1334 — pipeline-global tour budget surfaced to
+            the PM as the ``{budget_turns}`` placeholder in its instructions
+            (design doc §6). None falls back to a conservative default.
     """
     from argumentation_analysis.agents.factory import get_plugin_instances
 
@@ -436,11 +447,19 @@ def create_conversational_agents(
             state_plugin_class=state_cls,
         )
 
+        # CONV-C #1334: the PM instructions carry a {budget_turns} placeholder
+        # (design doc §5/§6) surfacing the pipeline-global cap to the conductor.
+        # Format it once at build time; non-PM agents have no placeholder.
+        instructions = config["instructions"]
+        if name == "ProjectManager":
+            budget = pm_budget_turns if pm_budget_turns else 30
+            instructions = instructions.format(budget_turns=budget)
+
         agent = ChatCompletionAgent(
             kernel=kernel,
             service=llm_service,
             name=name,
-            instructions=config["instructions"],
+            instructions=instructions,
             plugins=plugins,
             function_choice_behavior=FunctionChoiceBehavior.Auto(
                 auto_invoke_kernel_functions=True,
@@ -473,6 +492,7 @@ async def run_conversational_analysis(
     enable_reprompt_tracing: bool = False,
     source_metadata: Optional[Dict[str, str]] = None,
     selector_context: Optional[Dict[str, Any]] = None,
+    max_total_turns: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Run a full conversational analysis on the input text.
 
@@ -498,6 +518,12 @@ async def run_conversational_analysis(
             only see StateManagerPlugin functions relevant to their phase (#605).
         enable_reprompt_tracing: If True, capture structured RepromptTrace
             records from growth validation re-prompt events (#609).
+        max_total_turns: CONV-C #1334 — pipeline-global tour budget (design doc
+            §6). When set, the sum of turns across phases is capped and surfaced
+            to the PM as its ``{budget_turns}``. The cap is a fixed contract
+            (not adjusted at runtime); hitting it appends a ``CapBreachRecord``
+            and ends the run with status ``BUDGET_EXHAUSTED`` (#708 fail-loud).
+            None defaults to the sum of the three macro-phase caps.
 
     Returns dict with state snapshot, conversation history, and metrics.
     """
@@ -529,6 +555,7 @@ async def run_conversational_analysis(
             enable_reprompt_tracing=enable_reprompt_tracing,
             source_metadata=source_metadata,
             selector_context=selector_context,
+            max_total_turns=max_total_turns,
         )
 
 
@@ -547,9 +574,26 @@ async def _run_conversational_analysis_inner(
     enable_reprompt_tracing: bool = False,
     source_metadata: Optional[Dict[str, str]] = None,
     selector_context: Optional[Dict[str, Any]] = None,
+    max_total_turns: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Inner implementation of run_conversational_analysis, already inside llm_budget_scope."""
     start_time = time.time()
+
+    # CONV-C #1334 §6: pipeline-global tour cap. Default = sum of every phase
+    # cap (3 macro + conditional Re-Analysis), derived from the per-phase config
+    # so the default never binds (the cap only constrains when a caller sets a
+    # smaller explicit budget). The cap is a fixed contract surfaced to the PM
+    # and enforced across phases; breach is recorded (CapBreachRecord) and ends
+    # the run fail-loud.
+    if max_total_turns is None:
+        max_total_turns = (
+            extraction_max_turns
+            + formal_max_turns
+            + synthesis_max_turns
+            + reanalysis_max_turns
+        )
+    turns_used = 0
+    budget_exhausted = False
 
     # 0b. Env var override for growth validation (#597)
     _env_growth = os.environ.get("ENABLE_GROWTH_VALIDATION", "").lower()
@@ -618,6 +662,7 @@ async def _run_conversational_analysis_inner(
         "conversational_llm",
         agent_names,
         agent_state_class=agent_state_class,
+        pm_budget_turns=max_total_turns,
     )
     agent_by_name = {a.name: a for a in all_agents}
 
@@ -694,6 +739,27 @@ async def _run_conversational_analysis_inner(
     ]
 
     for phase_cfg in phase_configs:
+        # CONV-C #1334 §6: pipeline-global cap — stop once the budget is spent.
+        # The cap is a fixed contract; hitting it ends the run fail-loud
+        # (CapBreachRecord + BUDGET_EXHAUSTED status), not a silent truncation.
+        if turns_used >= max_total_turns:
+            budget_exhausted = True
+            if hasattr(state, "record_cap_breach"):
+                state.record_cap_breach(
+                    cap_kind="pipeline_global",
+                    turn=turns_used,
+                    detail=(
+                        f"budget {max_total_turns} atteint avant phase "
+                        f"'{phase_cfg['name']}'"
+                    ),
+                )
+            logger.warning(
+                f"[CONV-C] Budget pipeline-global atteint ({turns_used}/"
+                f"{max_total_turns}) — phase '{phase_cfg['name']}' et les "
+                f"suivantes sont sautées."
+            )
+            break
+
         phase_name = phase_cfg["name"]
         phase_agent_names = phase_cfg["agents"]
         phase_agents = [
@@ -704,12 +770,15 @@ async def _run_conversational_analysis_inner(
             logger.warning(f"No agents available for phase '{phase_name}', skipping")
             continue
 
-        # Per-phase turn limit (falls back to global max_turns_per_phase)
+        # Per-phase turn limit (falls back to global max_turns_per_phase),
+        # further clamped to the remaining pipeline-global budget (§6).
         phase_max_turns = phase_cfg.get("max_turns", max_turns_per_phase)
+        remaining = max_total_turns - turns_used
+        effective_max_turns = min(phase_max_turns, remaining)
 
         logger.info(
             f"=== Phase: {phase_name} ({len(phase_agents)} agents, "
-            f"max {phase_max_turns} turns) ==="
+            f"max {effective_max_turns} turns) ==="
         )
 
         # Trace: capture state before phase
@@ -721,7 +790,7 @@ async def _run_conversational_analysis_inner(
         phase_log = await _run_phase(
             phase_agents,
             phase_cfg["initial_prompt"],
-            max_turns=phase_max_turns,
+            max_turns=effective_max_turns,
             phase_name=phase_name,
             state=state,
             enable_growth_validation=enable_growth_validation,
@@ -729,6 +798,14 @@ async def _run_conversational_analysis_inner(
             reprompt_extractor=reprompt_extractor,
         )
         conversation_log.extend(phase_log)
+
+        # CONV-C #1334 §6: accumulate turns consumed (highest turn index in the
+        # phase) against the pipeline-global budget.
+        phase_turns = max(
+            (m.get("turn", 0) for m in phase_log if isinstance(m.get("turn"), int)),
+            default=0,
+        )
+        turns_used += phase_turns
 
         # Conflict resolution (#214): detect and resolve conflicts between agents
         conflict_resolutions = await _resolve_phase_conflicts(
@@ -776,7 +853,9 @@ async def _run_conversational_analysis_inner(
     # re-evaluated, arguments missing fallacy analysis), add an extra phase
     # to re-analyze using informal + quality + governance agents.
     reanalysis_added = False
-    if hasattr(state, "get_enrichment_summary"):
+    # CONV-C #1334 §6: skip the conditional Re-Analysis phase if the
+    # pipeline-global budget is already exhausted (the run ended fail-loud).
+    if not budget_exhausted and hasattr(state, "get_enrichment_summary"):
         try:
             enrichment = state.get_enrichment_summary()
             needs_reanalysis = _should_add_reanalysis_phase(enrichment, state)
@@ -821,6 +900,12 @@ async def _run_conversational_analysis_inner(
                         f"max {reanalysis_cfg['max_turns']} turns) ==="
                     )
 
+                    # CONV-C #1334 §6: clamp Re-Analysis to remaining budget.
+                    remaining = max(0, max_total_turns - turns_used)
+                    reanalysis_effective = max(
+                        1, min(reanalysis_cfg["max_turns"], remaining)
+                    )
+
                     try:
                         trace.begin_phase(
                             phase_name, state.get_state_snapshot(summarize=False)
@@ -831,7 +916,7 @@ async def _run_conversational_analysis_inner(
                     phase_log = await _run_phase(
                         reanalysis_agents,
                         reanalysis_cfg["initial_prompt"],
-                        max_turns=reanalysis_cfg["max_turns"],
+                        max_turns=reanalysis_effective,
                         phase_name=phase_name,
                         state=state,
                         enable_growth_validation=enable_growth_validation,
@@ -839,6 +924,15 @@ async def _run_conversational_analysis_inner(
                         reprompt_extractor=reprompt_extractor,
                     )
                     conversation_log.extend(phase_log)
+
+                    turns_used += max(
+                        (
+                            m.get("turn", 0)
+                            for m in phase_log
+                            if isinstance(m.get("turn"), int)
+                        ),
+                        default=0,
+                    )
 
                     # Trace recording
                     for msg in phase_log:
@@ -1119,6 +1213,23 @@ async def _run_conversational_analysis_inner(
         "unified_state": state,
         "trace_report": trace_report,
         "reprompt_traces": reprompt_extractor.to_dict() if reprompt_extractor else None,
+        # CONV-C #1334 §6: pipeline-global budget accounting + fail-loud status.
+        "budget": {
+            "max_total_turns": max_total_turns,
+            "turns_used": turns_used,
+            "exhausted": budget_exhausted,
+            "deliberation_turn_count": sum(
+                1
+                for r in getattr(state, "deliberation_trace", [])
+                if r.get("record_type") != "cap_breach"
+            ),
+            "cap_breaches": [
+                r
+                for r in getattr(state, "deliberation_trace", [])
+                if r.get("record_type") == "cap_breach"
+            ],
+        },
+        "status": "BUDGET_EXHAUSTED" if budget_exhausted else "COMPLETED",
         "summary": {
             "completed": len(phase_configs),
             "failed": 0,
@@ -1273,6 +1384,25 @@ def _get_growth_fingerprint(state: Any) -> tuple[int, ...]:
     )
 
 
+def _backfill_designation_if_present(state: Any, agent: Optional[str]) -> None:
+    """CONV-C #1334 §7.3: close the open DesignationRecord when its agent returns.
+
+    Thin guard around ``state.backfill_last_designation_for`` so ``_run_phase``
+    callers don't branch on state type: a no-op for base
+    ``RhetoricalAnalysisState`` (no deliberation trace) or when ``agent`` is
+    None. The matching logic (designated_agent == agent) lives on the state.
+    """
+    if agent is None:
+        return
+    backfill = getattr(state, "backfill_last_designation_for", None)
+    if backfill is None:
+        return
+    try:
+        backfill(agent)
+    except Exception:
+        logger.debug("backfill_last_designation_for failed", exc_info=True)
+
+
 # Phases where state growth is expected (Extraction, Fallacy, Re-Analysis).
 _GROWTH_EXPECTING_PATTERNS = (
     "xtraction",
@@ -1412,6 +1542,12 @@ async def _run_phase(
             messages.append(msg_entry)
             logger.info(f"  [{phase_name}] Turn {turn}: {msg_entry['agent']}")
 
+            # CONV-C #1334 §7.3: close the open DesignationRecord when its
+            # designated agent returns (no-op if the PM spoke or no record is
+            # open). Pairs each motivated designation with the state delta it
+            # produced, without a new measurement path.
+            _backfill_designation_if_present(state, msg_entry["agent"])
+
             # Convergence check
             if _check_convergence(state, phase_name, messages):
                 break
@@ -1526,6 +1662,10 @@ async def _run_phase(
                 }
             )
             logger.info(f"  [{phase_name}] Turn {turn}: {agent.name}")
+
+            # CONV-C #1334 §7.3: close the open DesignationRecord when its
+            # designated agent returns (mirrors the AgentGroupChat path).
+            _backfill_designation_if_present(state, agent.name)
 
             # Convergence check after each turn
             if _check_convergence(state, phase_name, messages):

--- a/tests/unit/argumentation_analysis/test_conv_c_pm_conduction_1334.py
+++ b/tests/unit/argumentation_analysis/test_conv_c_pm_conduction_1334.py
@@ -1,0 +1,199 @@
+"""Tests for CONV-C PM conduction — phase 3 (#1334, Epic #1331).
+
+Covers the three phase-3 deliverables on the conversational spine:
+
+1. **De-templatised PM prompt (§5)** — the EXTRACTION-GATE (#595) and CROSS-KB
+   ENRICHMENT (#208-I) sequence recipes are *subtracted* (anti-pendule: the fix
+   removes the hard-coded sequence, it does not add a counterweight rule); the
+   prompt now states mission + per-turn loop + capability map + motivated-
+   designation requirement + budget.
+2. **Designation backfill (§7.3)** — when the designated agent returns, its open
+   ``DesignationRecord`` is closed with ``state_fingerprint_after`` + a delta
+   summary, pairing each motivated designation with the state growth it produced.
+3. **Pipeline-global cap (§6)** — a ``CapBreachRecord`` is appended on breach
+   (fail-loud, #708) and excluded from the designation count.
+
+Design doc: docs/architecture/CONV_C_PM_ECLAIRE.md (PR #1340; phase 3 of #1334).
+"""
+
+import pytest
+
+from argumentation_analysis.core.shared_state import (
+    RhetoricalAnalysisState,
+    UnifiedAnalysisState,
+)
+from argumentation_analysis.orchestration.conversational_orchestrator import (
+    AGENT_CONFIG,
+    _backfill_designation_if_present,
+)
+
+# ---------------------------------------------------------------------------
+# 1. PM prompt rewrite (§5) — subtraction + addition
+# ---------------------------------------------------------------------------
+
+
+def test_pm_prompt_subtracts_extraction_gate_and_cross_kb():
+    """The templatised #595 / #208-I recipes are gone (anti-pendule: subtract)."""
+    instr = AGENT_CONFIG["ProjectManager"]["instructions"]
+    assert "EXTRACTION GATE" not in instr
+    assert "CROSS-KB ENRICHMENT" not in instr
+    # the surviving #595 form: an enunciated fact, not a gate to obey
+    assert "[Fait :" in instr
+
+
+def test_pm_prompt_requires_motivated_designation():
+    """record_designation + mandatory motivation = the CONV-C core requirement."""
+    instr = AGENT_CONFIG["ProjectManager"]["instructions"]
+    assert "record_designation(agent, motivation, trigger)" in instr
+    assert "OBLIGATOIRE" in instr
+    assert "designate_next_agent(nom_exact)" in instr
+    # capability map present (PM reasons about synergies, none imposed)
+    assert "CARTE DES CAPACITES" in instr
+
+
+def test_pm_prompt_surfaces_budget_placeholder():
+    """The pipeline-global cap is surfaced as {budget_turns} (filled at build)."""
+    assert "{budget_turns}" in AGENT_CONFIG["ProjectManager"]["instructions"]
+
+
+def test_pm_prompt_budget_placeholder_formats_cleanly():
+    """The template formats without stray braces for any budget value."""
+    instr = AGENT_CONFIG["ProjectManager"]["instructions"]
+    filled = instr.format(budget_turns=25)
+    assert "{budget_turns}" not in filled
+    assert "25 tours" in filled
+    # no other brace placeholders leak
+    assert "{" not in filled
+    assert "}" not in filled
+
+
+def test_non_pm_agents_have_no_budget_placeholder():
+    """Only the PM carries {budget_turns} — formatting others must be safe."""
+    for name, cfg in AGENT_CONFIG.items():
+        if name == "ProjectManager":
+            continue
+        assert "{budget_turns}" not in cfg["instructions"], name
+
+
+# ---------------------------------------------------------------------------
+# 2. Designation backfill (§7.3) — delta paired to the returning agent
+# ---------------------------------------------------------------------------
+
+
+def test_backfill_closes_record_when_designated_agent_returns():
+    """The open record is closed with fingerprint_after + delta on return."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    state.record_designation("FormalAgent", "contradiction arg_3", "deepening")
+    assert state.deliberation_trace[0]["state_fingerprint_after"] is None
+    # simulate FormalAgent's contribution growing the state
+    state.add_identified_arguments(["premisses: P conclusion: Q"])
+    closed = state.backfill_last_designation_for("FormalAgent")
+    assert closed is True
+    rec = state.deliberation_trace[0]
+    assert rec["state_fingerprint_after"] is not None
+    assert rec["state_fingerprint_after"]["argument_count"] == 1
+    assert "argument+1" in rec["delta_summary"]
+
+
+def test_backfill_does_not_close_on_pm_or_wrong_agent():
+    """PM speaking (or a different specialist) leaves the record open."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    state.record_designation("FormalAgent", "x", "deepening")
+    # the PM itself speaks -> must NOT close (else it closes its own record)
+    assert state.backfill_last_designation_for("ProjectManager") is False
+    assert state.deliberation_trace[0]["state_fingerprint_after"] is None
+    # a different specialist (round-robin interloper) -> must NOT close
+    assert state.backfill_last_designation_for("InformalAgent") is False
+    assert state.deliberation_trace[0]["state_fingerprint_after"] is None
+    # the designated agent -> closes
+    assert state.backfill_last_designation_for("FormalAgent") is True
+
+
+def test_backfill_no_op_when_no_open_record():
+    """No record / none open -> False, no crash."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    assert state.backfill_last_designation_for("FormalAgent") is False
+    state.record_designation("FormalAgent", "x", "deepening")
+    assert state.backfill_last_designation_for("FormalAgent") is True
+    # now closed -> a second call finds nothing open
+    assert state.backfill_last_designation_for("FormalAgent") is False
+
+
+def test_backfill_skips_cap_breach_marker_to_reach_open_designation():
+    """A cap_breach marker between the open record and the scan is skipped."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    state.record_designation("FormalAgent", "x", "deepening")
+    # FormalAgent never returned; budget then hits -> cap_breach appended after
+    state.record_cap_breach("pipeline_global", 10, "budget atteint")
+    # reversed scan meets the cap_breach first; it must be skipped so the still-
+    # open designation is reachable (not mistaken for an open record).
+    assert state.backfill_last_designation_for("FormalAgent") is True
+    assert state.deliberation_trace[0]["state_fingerprint_after"] is not None
+
+
+def test_delta_summary_reports_growth_and_no_growth():
+    """Delta lists grown dimensions; 'no_growth' when nothing changed.
+
+    The delta window is designation -> agent return: the agent's contribution
+    lands AFTER record_designation (captured in fingerprint_before) and BEFORE
+    backfill (captured in fingerprint_after).
+    """
+    state = UnifiedAnalysisState("Some text to analyse.")
+    # designation 1: ExtractAgent adds nothing during its turn -> no_growth
+    state.record_designation("ExtractAgent", "etat vide", "initial")
+    state.backfill_last_designation_for("ExtractAgent")
+    assert state.deliberation_trace[0]["delta_summary"] == "no_growth"
+    # designation 2: ExtractAgent again, this time it extracts 2 args
+    state.record_designation(
+        "ExtractAgent", "reprendre, extraire les args", "deepening"
+    )
+    state.add_identified_arguments(["a: prem b: conc", "c: prem d: conc"])
+    state.backfill_last_designation_for("ExtractAgent")
+    assert "argument+2" in state.deliberation_trace[1]["delta_summary"]
+
+
+def test_backfill_helper_noop_on_base_state_and_none():
+    """_backfill_designation_if_present must not raise on state without trace."""
+    base = RhetoricalAnalysisState("Some text to analyse.")
+    _backfill_designation_if_present(base, "FormalAgent")  # no trace -> no-op
+    _backfill_designation_if_present(None, "FormalAgent")  # type: ignore[arg-type]
+    _backfill_designation_if_present(base, None)
+    # and it actually closes on a Unified state
+    u = UnifiedAnalysisState("Some text to analyse.")
+    u.record_designation("FormalAgent", "x", "deepening")
+    _backfill_designation_if_present(u, "FormalAgent")
+    assert u.deliberation_trace[0]["state_fingerprint_after"] is not None
+
+
+# ---------------------------------------------------------------------------
+# 3. Pipeline-global cap (§6) — CapBreachRecord, fail-loud, count exclusion
+# ---------------------------------------------------------------------------
+
+
+def test_record_cap_breach_appends_marker_excluded_from_count():
+    """A cap breach is recorded but not counted as a designation turn."""
+    state = UnifiedAnalysisState("Some text to analyse.")
+    state.record_designation("ExtractAgent", "x", "initial")
+    assert state.get_state_snapshot(summarize=True)["deliberation_turn_count"] == 1
+    state.record_cap_breach("pipeline_global", 12, "budget atteint")
+    # count unchanged: the breach is a marker, not a designation
+    assert state.get_state_snapshot(summarize=True)["deliberation_turn_count"] == 1
+    breaches = [
+        r for r in state.deliberation_trace if r.get("record_type") == "cap_breach"
+    ]
+    assert len(breaches) == 1
+    assert breaches[0]["cap_kind"] == "pipeline_global"
+    assert breaches[0]["turn"] == 12
+
+
+def test_cap_breach_record_serializes_with_trace():
+    """The cap_breach marker survives to_json (CONV-D / audit read the trace)."""
+    import json
+
+    state = UnifiedAnalysisState("Some text to analyse.")
+    state.record_designation("ExtractAgent", "x", "initial")
+    state.record_cap_breach("pipeline_global", 8, "detail")
+    payload = json.loads(state.to_json(indent=None))
+    trace = payload["deliberation_trace"]
+    assert any(r.get("record_type") == "cap_breach" for r in trace)
+    assert any(r.get("designated_agent") == "ExtractAgent" for r in trace)


### PR DESCRIPTION
Phase 3/3 of CONV-C « PM éclairé » (#1334, Epic #1331). Design doc: PR #1340. Phase 2 (trace plumbing) merged in #1344 (`ad9350fd`).

## What

Three deliverables on the conversational spine, anti-pendule discipline (fix by subtraction, not counterweight):

### 1. PM prompt rewrite (§5) — SUBTRACT
Removed the hard-coded sequence recipes from `AGENT_CONFIG["ProjectManager"]` (`conversational_orchestrator.py`):
- **EXTRACTION-GATE (#595)** — the "AVANT toute autre action, vérifie identified_arguments…" gate
- **CROSS-KB ENRICHMENT (#208-I)** — the "Apres ExtractAgent… Apres InformalAgent…" sequence script

Replaced with: mission (produire un ETAT RICHE, pas suivre un script) + per-turn loop (lire → décider ET POURQUOI → `record_designation(agent, motivation, trigger)` → `designate_next_agent(nom_exact)`) + **CARTE DES CAPACITÉS** (synergies exist, PM judges their opportunity — none imposed) + budget. `#595` survives as an enunciated `[Fait : …]` fact the PM reasons about, **not** a gate it obeys.

### 2. Designation backfill (§7.3) — ADD measurement
`UnifiedAnalysisState.backfill_last_designation_for(agent)` closes the open `DesignationRecord` with `state_fingerprint_after` + a delta summary **when its designated agent returns** (not on PM/wrong-agent turns). `_run_phase` calls it after each turn (both AgentGroupChat and round-robin paths) via the `_backfill_designation_if_present` guard. Pairs each motivated designation with the state growth it produced — reuses `_designation_fingerprint`, no new measurement path.

### 3. Pipeline-global cap (§6) — ADD backstop
`max_total_turns` across phases (default = sum of per-phase caps, so the default never binds). Surfaced to the PM as the `{budget_turns}` placeholder (filled at agent-build time). On breach: `CapBreachRecord` appended to `deliberation_trace` (fail-loud, #708), remaining phases skipped, run ends `status = "BUDGET_EXHAUSTED"`. `cap_breach` markers are excluded from the designation count. Result dict surfaces a `budget` block (`turns_used`, `exhausted`, `cap_breaches`).

## Anti-pendule
The fix **removes** the templatisation (#595/#208-I recipes); it does **not** add counterweight rules. The capability map gives the PM *information* (synergies exist); it does not *prescribe* sequence. The protection is empirical visibility (CONV-A baseline → delta on the same harness), per design doc §8.

## Tests
- **13 new** in `test_conv_c_pm_conduction_1334.py`: prompt subtraction (EXTRACTION-GATE/CROSS-KB gone, `[Fait :` survives), `record_designation`/`designate_next_agent`/`CARTE DES CAPACITES` present, `{budget_turns}` formats cleanly (no stray braces), non-PM agents have no placeholder, backfill close/no-close (PM + wrong-agent leave open)/skip-cap_breach/delta (growth + no_growth), `_backfill_designation_if_present` no-op on base state, cap breach appended + excluded from count + serializes.
- **8 phase-2** trace tests still green.
- **mypy strict** `shared_state.py` (CI scope) = 0 issues.
- black: my additions clean (3 pre-existing hunks on `_run_parent_harness_fallback` are on origin/main already; black/flake8 = continue-on-error).

## Pre-existing (NOT a regression)
`test_formalagent_shared_state.py::TestFormalAgentInstructions` (2 tests) fail — verified **identical on origin/main** (stash test). This PR touches the **PM** prompt only, not FormalAgent. Per #1336 triage discipline, PRs are judged on introduced vs pre-existing failures.

## Demonstrative run
A bounded run (`max_total_turns=4`, short synthetic text) exhibiting motivated designations + deltas + cap breach is being captured; trace summary will be appended in a comment.

Co-Authored-By: Claude-Code <noreply@anthropic.com>