### PR TITLE
fix(interface_web): make package regular to fix CI import shadowing (#1336)

### DIFF
--- a/interface_web/__init__.py
+++ b/interface_web/__init__.py
@@ -1,0 +1,11 @@
+"""interface_web — frontend-only Starlette proxy package (issue #844).
+
+This ``__init__.py`` makes ``interface_web`` a regular package rather than an
+implicit namespace package. A regular package resolves deterministically from
+the first matching ``sys.path`` entry, which prevents a name collision with
+``tests/unit/interface_web/`` (the dashboard test package) from shadowing this
+package's modules — notably ``interface_web.app`` — under certain import
+environments (e.g. when ``jpype.imports`` is active). See #1336.
+"""
+
+__version__ = "3.1.0"


### PR DESCRIPTION
Part of #1336 (api/ cluster, dispatched R533). Fixes **31 FAIL/ERROR** in the `interface_web.app` shadowing cluster — all sharing one root error: `ModuleNotFoundError: No module named 'interface_web.app'`.

## Root cause

`interface_web/` was an implicit **namespace package** (no `__init__.py`). A regular package `tests/unit/interface_web/` (dashboard test package, empty `__init__.py`) collides on the name. Per Python import rules, a **regular package found anywhere on sys.path terminates and overrides an earlier namespace portion** — so when `tests/unit` reaches sys.path (which happens under the real-JVM + `jpype.imports` + full-collection CI environment), `interface_web` resolves to the test package (which has no `app.py`) and `interface_web.app` fails.

Mechanism verified locally: `PYTHONPATH` with `tests/unit` prepended reproduces the **exact** `ModuleNotFoundError`.

## Fix (anti-pendule: explicit package declaration, not a counterweight)

Add `interface_web/__init__.py`. A regular package resolves deterministically from the first sys.path entry (cwd / repo-root), making the test collision benign. This is the correct state for a production package dir — the bug was the missing `__init__.py` leaving it a fragile namespace package.

## Scope (CI run `28582260688` junit)

| Root cause | Tests | File(s) |
|---|---|---|
| **SHADOWING (this PR)** | **31** | `test_starlette_proxy.py` (17), `test_interface_web_starlette.py` (~12), `test_dashboard.py` (2) |
| JTMS routes (SEPARATE) | 1 | `test_jtms_import_guard.py::test_app_with_jtms_has_jtms_routes` — env-specific import of `argumentation_analysis.api.jtms_endpoints`, out of scope |

## Verification

These are pure `interface_web.app` structural tests (no JVM exercise); run locally with `--disable-jvm-session` so they **run** instead of being skipped by the autouse `jvm_session` fixture:
- R533 DoD pair (`test_starlette_proxy.py` + `test_interface_web_starlette.py`): **29 passed / 0 failed**
- + `test_dashboard.py`: **43 passed / 0 failed**
- No regression: `from interface_web.app import app, routes, dashboard_endpoint, ws_proxy, FASTAPI_BASE_URL` resolves correctly (routes=4, FASTAPI_BASE_URL=`http://127.0.0.1:8095`).

## Honesty caveat

The exact CI trigger (why `tests/unit` lands on sys.path) was **not reproducible locally** — the real JVM cannot start here (`java.dll` locked by a zombie process). The shadowing mechanism is confirmed, the fix resolves it against that mechanism, and there is no regression, but final confirmation is the CI run on this PR.

## Files changed

| File | Type | Reason |
|---|---|---|
| `interface_web/__init__.py` (new) | package marker | Makes `interface_web` a regular package so it is not shadowed by `tests/unit/interface_web/` |

Co-Authored-By: Claude <noreply@anthropic.com>