### PR TITLE
test(api): fix jtms route-introspection for FastAPI 0.138 _IncludedRouter (#1336)

### DIFF
--- a/tests/unit/api/test_jtms_import_guard.py
+++ b/tests/unit/api/test_jtms_import_guard.py
@@ -96,11 +96,22 @@ class TestGuardRuntimeBehavior:
     """Verify guard logic using constructed test apps."""
 
     def test_app_with_jtms_has_jtms_routes(self):
-        """When JTMS available, app has /api/v1/jtms routes."""
+        """When JTMS available, app has /api/v1/jtms routes.
+
+        Resolves served paths via ``app.openapi()["paths"]`` rather than
+        iterating ``app.routes``. Since FastAPI 0.138, ``include_router`` no
+        longer flattens the sub-router's routes into ``app.routes`` — it
+        registers a single deferred ``_IncludedRouter`` entry, so
+        ``[r.path for r in app.routes]`` sees only FastAPI's default routes
+        (openapi/docs/redoc) and misses every jtms route even though they ARE
+        served (verified: the production app exposes 17 ``/api/v1/jtms`` paths
+        via its OpenAPI schema and responds 200 to them). The OpenAPI schema
+        is the authoritative enumeration of what the app actually publishes.
+        """
         app = _make_test_app_with_guard(jtms_available=True)
-        routes = [r.path for r in app.routes if hasattr(r, "path")]
-        jtms = [r for r in routes if "/jtms" in r]
-        assert len(jtms) > 0, f"No JTMS routes in {len(routes)} routes"
+        served_paths = list(app.openapi().get("paths", {}).keys())
+        jtms = [p for p in served_paths if "/jtms" in p]
+        assert len(jtms) > 0, f"No JTMS routes served (got {len(served_paths)} paths: {served_paths})"
 
     def test_app_without_jtms_has_no_jtms_routes(self):
         """When JTMS unavailable, app has no /api/v1/jtms routes."""


### PR DESCRIPTION
Part of #1336 (api/ cluster). Fixes **1 real CI failure** reported in the R533 dispatch as out-of-scope: `test_jtms_import_guard.py::test_app_with_jtms_has_jtms_routes`.

## Root cause (CI run `28582260688` junit + reproduced locally)

Failed with `AssertionError: No JTMS routes in 5 routes` — a **real assertion**, not an import error. Since **FastAPI 0.138**, `include_router` no longer flattens the sub-router's routes into `app.routes`; it registers a single **deferred `_IncludedRouter`** entry. So `[r.path for r in app.routes]` sees only FastAPI's default routes (`/openapi.json`, `/docs`, `/redoc`) and misses every jtms route, even though they ARE served.

Verified:
- Production `api.main` **serves 17 `/api/v1/jtms` paths** via its OpenAPI schema and responds to them.
- A minimal `APIRouter` with 2 routes (`/foo`, `/bar`) is invisible via `app.routes` but **served (200)** via TestClient and present in `app.openapi()["paths"]`.

The route list was always correct at runtime — only the **test's introspection API** was stale.

## Fix (anti-pendule: convert the contract toward the authoritative truth, not a skip)

Enumerate served paths via `app.openapi()["paths"]` — the schema FastAPI actually publishes — instead of iterating the `app.routes` attribute. **No production code changed**; the test now measures what it claims to (the app publishes jtms routes).

## Verification

Run locally with `--disable-jvm-session` (so the runtime tests run instead of being skipped by the autouse `jvm_session` fixture; these construct their own FastAPI app and do not exercise the JVM): **11 passed / 0 failed** (7 source-structure + 4 runtime). Production `api.main` shows the same 17 jtms paths through the `openapi()` lens (no regression, consistent truth source).

## Disjoint from #1346

#1346 (merged) fixed the `interface_web.app` namespace-package shadowing (31 ModuleNotFoundError). This PR fixes a **separate** root cause (FastAPI 0.138 route-introspection) in a disjoint file (`test_jtms_import_guard.py`). Both are part of the api/ cluster DoD.

## Files changed

| File | Type | Reason |
|---|---|---|
| `tests/unit/api/test_jtms_import_guard.py` | test | Convert stale `app.routes` introspection to authoritative `app.openapi()["paths"]` (FastAPI 0.138 `_IncludedRouter`) |

Co-Authored-By: Claude <noreply@anthropic.com>