### PR TITLE
ci(slow-marking): exclude real-pipeline tests from per-push gate (#1336, R535)

### DIFF
--- a/tests/unit/api/test_api_endpoints.py
+++ b/tests/unit/api/test_api_endpoints.py
@@ -7,6 +7,7 @@ import os
     reason="Le test du worker JVM échoue actuellement en raison de problèmes de configuration de l'environnement."
 )
 @pytest.mark.no_jvm_session
+@pytest.mark.slow
 def test_api_endpoints_via_worker(run_in_jvm_subprocess):
     """
     Exécute les tests des endpoints de l'API via un script worker dans un sous-processus.

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -531,8 +531,12 @@ class TestRunUnifiedAnalysis:
 # ============================================================
 
 
+@pytest.mark.slow
 class TestRealInvocationViaUnifiedAnalysis:
-    """Test that run_unified_analysis produces real outputs (not None)."""
+    """Test that run_unified_analysis produces real outputs (not None).
+
+    Real-invocation tests: call run_unified_analysis end-to-end (CI tally
+    run 28582260688: ~142s). Marked `slow` for the per-push gate (#1336, R535)."""
 
     @pytest.mark.asyncio
     async def test_light_workflow_produces_quality_output(self):
@@ -589,7 +593,10 @@ class TestRealInvocationViaUnifiedAnalysis:
 # ============================================================
 
 
+@pytest.mark.slow
 class TestStateViaRunUnifiedAnalysis:
+    """Real-invocation tests: call run_unified_analysis end-to-end (CI tally
+    run 28582260688: ~68s). Marked `slow` for the per-push gate (#1336, R535)."""
     @pytest.mark.asyncio
     async def test_state_returned_by_default(self):
         """run_unified_analysis returns unified_state and state_snapshot by default."""
@@ -1873,8 +1880,12 @@ class TestAdditionalWorkflows:
 # ============================================================
 
 
+@pytest.mark.slow
 class TestRunUnifiedAnalysisEdgeCases:
-    """Test edge cases in run_unified_analysis."""
+    """Test edge cases in run_unified_analysis.
+
+    Real-invocation tests: call run_unified_analysis end-to-end (CI tally
+    run 28582260688: ~114s). Marked `slow` for the per-push gate (#1336, R535)."""
 
     async def test_run_with_auto_routing_fallback(self):
         """run_unified_analysis with workflow_name='auto' falls back to standard on error."""

--- a/tests/unit/argumentation_analysis/orchestration/test_workflow_robustness.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_workflow_robustness.py
@@ -29,6 +29,15 @@ from argumentation_analysis.orchestration.unified_pipeline import (
     reset_workflow_catalog,
 )
 
+# Every test in this module runs `run_unified_analysis` (a full orchestration
+# pipeline) against adversarial inputs, each under a 30s per-call timeout.
+# The CI tally (run 28582260688) shows this module alone accounts for ~3h of
+# the ~4h gate — these are integration-style robustness checks, not unit
+# tests. Marked `slow` at module level so the per-push gate
+# (`-m "not slow and not requires_api"`) excludes them; they still run in the
+# on-demand Extended Test Lane (#1336, R535).
+pytestmark = pytest.mark.slow
+
 # ============================================================
 # Fixtures
 # ============================================================

--- a/tests/unit/argumentation_analysis/test_sherlock_modern_orchestrator.py
+++ b/tests/unit/argumentation_analysis/test_sherlock_modern_orchestrator.py
@@ -35,8 +35,15 @@ SAMPLE_DISCOURSE = (
 )
 
 
+@pytest.mark.slow
 class TestSherlockModernOrchestrator:
-    """Tests for the main orchestrator class."""
+    """Tests for the main orchestrator class.
+
+    Instantiates the full SherlockModernOrchestrator and runs end-to-end
+    multi-agent investigations (~25 min / 13 tests, max ~155s each in the
+    CI tally run 28582260688). These are integration-style checks, not unit
+    tests; marked `slow` so the per-push gate excludes them (#1336, R535).
+    """
 
     def test_investigate_returns_result(self):
         orch = SherlockModernOrchestrator()


### PR DESCRIPTION
Gate-completion, dispatched R535 (TOP priority). The per-push gate (`tests/unit -m "not slow and not requires_api"`) ran **~4h** because it included integration-style tests launching full orchestration pipelines — not unit tests. Marked `slow` the real offenders, confirmed heavy by the authoritative CI tally (run `28582260688` junit). **Marker-only — no assertion/logic changed.**

## Top offenders marked (by aggregated CI time)

| File / class | Marker level | CI time | Why slow |
|---|---|---|---|
| `test_workflow_robustness.py` | **module** (`pytestmark`) | **~3h** (10 classes) | Every class runs `run_unified_analysis` on adversarial inputs under a 30s per-call timeout. THE big win. |
| `test_sherlock_modern_orchestrator.py::TestSherlockModernOrchestrator` | class | ~25 min (max ~155s/test) | End-to-end multi-agent investigations |
| `test_api_endpoints.py::test_api_endpoints_via_worker` | function | 300s | JVM subprocess spawn |
| `test_unified_pipeline.py::TestRealInvocationViaUnifiedAnalysis` | class | ~142s | Real `run_unified_analysis` |
| `test_unified_pipeline.py::TestRunUnifiedAnalysisEdgeCases` | class | ~114s | Real `run_unified_analysis` |
| `test_unified_pipeline.py::TestStateViaRunUnifiedAnalysis` | class | ~68s | Real `run_unified_analysis` |

## DoD #1 (R535) — met

- **Collection under `not slow and not requires_api`**: 12938 tests (297 deselected); **285 tests now marked slow**. The heavy pipeline tests move to the on-demand Extended Test Lane (`extended-tests.yml`, #1336).
- **Estimated gate time**: ~4h → **<1h** (`test_workflow_robustness` alone was ~75% of the runtime per the tally).
- **Each marker justified firsthand**: every marked test/class confirmed to run a full orchestration pipeline (not mocked).

## Anti-pendule (respected)

`slow` is legitimate **ONLY** for genuinely heavy tests. `test_hierarchical_fallacy_workflow` was on the candidate list (R535) but was **NOT** marked — its body is structure-assertions (build/depends/catalog/registry), not a real pipeline run; the 93s max was a single registry setup. Marking it would be over-marking. The smaller clusters (communication/router/realcomponent-integration, ~10 min cumulated) were also left unmarked: the gate is already <1h without them.

## Validation

- 4 marked files still collect cleanly (440 tests collected, no syntax error from edits).
- This PR is marker-only; the deferred `orchestration/` logic fix (dispatch #2, awaiting this merge) is separate.

Co-Authored-By: Claude <noreply@anthropic.com>