### PR TITLE
test(agents/core): add ai_model_id to OpenAIChatCompletion fixtures — SK 1.40 (#1336, R536)

### DIFF
--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_counter_argument.py
@@ -20,7 +20,9 @@ from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 def mock_kernel():
     """Create a kernel with a test LLM service (fake API key)."""
     kernel = Kernel()
-    service = OpenAIChatCompletion(service_id="default", api_key="test-key")
+    service = OpenAIChatCompletion(
+        service_id="default", ai_model_id="gpt-4", api_key="test-key"
+    )
     kernel.add_service(service)
     return kernel
 
@@ -539,7 +541,9 @@ class TestCounterArgumentAgent:
 
         # Create kernel with test service
         self.kernel = Kernel()
-        service = OpenAIChatCompletion(service_id="default", api_key="test-key")
+        service = OpenAIChatCompletion(
+            service_id="default", ai_model_id="gpt-4", api_key="test-key"
+        )
         self.kernel.add_service(service)
 
     def _create_agent(self, **kwargs):

--- a/tests/unit/argumentation_analysis/agents/core/debate/test_debate.py
+++ b/tests/unit/argumentation_analysis/agents/core/debate/test_debate.py
@@ -31,7 +31,9 @@ from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
 def mock_kernel():
     """Create a Kernel with a mock OpenAI service for testing."""
     kernel = Kernel()
-    service = OpenAIChatCompletion(service_id="default", api_key="test-key")
+    service = OpenAIChatCompletion(
+        service_id="default", ai_model_id="gpt-4", api_key="test-key"
+    )
     kernel.add_service(service)
     return kernel
 
@@ -811,7 +813,9 @@ class TestDebateAgent:
 
         self.AgentClass = DebateAgent
         self.kernel = Kernel()
-        service = OpenAIChatCompletion(service_id="default", api_key="test-key")
+        service = OpenAIChatCompletion(
+            service_id="default", ai_model_id="gpt-4", api_key="test-key"
+        )
         self.kernel.add_service(service)
 
     def _create_agent(self, **kwargs):
@@ -963,7 +967,9 @@ class TestDebateModerator:
     def setup_method(self):
         """Set up kernel for agent creation."""
         self.kernel = Kernel()
-        service = OpenAIChatCompletion(service_id="default", api_key="test-key")
+        service = OpenAIChatCompletion(
+            service_id="default", ai_model_id="gpt-4", api_key="test-key"
+        )
         self.kernel.add_service(service)
 
     def test_moderator_creation(self):


### PR DESCRIPTION
## Context

Gate-completion #1336, dispatched R536 item #3 (`agents/core/` 39 F+E, reassigned from po-2025 — down). The authoritative CI tally (run `28615348489` junit) shows **24 of 27 errors in `agents/core/` share a single root cause**: `ServiceInitializationError: The OpenAI model ID is required.`

## Root cause

`test_counter_argument.py` (10E) and `test_debate.py` (14E) both construct the test LLM service as:
```python
OpenAIChatCompletion(service_id="default", api_key="test-key")  # no ai_model_id
```
On **SK ≥ 1.40** (CI env), `ai_model_id` is **required** → `ServiceInitializationError` at fixture/setup → whole test class errors. On SK 1.34 (my local `projet-is`) it's optional, so I cannot reproduce the failure locally — but the CI error message is unambiguous (`ai_model_id = None` → raise).

## Fix (anti-pendule: align with established pattern)

The **sibling tests in the same directory already pass** with the working pattern:
```python
OpenAIChatCompletion(service_id="default", ai_model_id="gpt-4", api_key="test-key")  # test_extract_agent.py:42, test_oracle:57
```
This PR adds `ai_model_id="gpt-4"` to the 5 stale sites (2 in counter_argument, 3 in debate), bringing them in line with the established convention. **Version-skew debt correction, not a logic change. 0 production code touched.**

| File | Sites | Errors resolved |
|---|---|---|
| `test_counter_argument.py` | L23 (setup_method), L542 | 10 (TestCounterArgumentAgent) |
| `test_debate.py` | L34 (fixture), L814, L966 | 14 (TestDebateAgent + Moderator + Capabilities + BaseAgentInterface) |

## Validation

```
pytest test_counter_argument.py test_debate.py --disable-jvm-session -q  (projet-is, SK 1.34)
→ 118 passed in 6.48s   # ai_model_id accepted as optional on 1.34; required on 1.40
```
No regression — `ai_model_id` is accepted on both SK 1.34 (optional) and SK 1.40 (required). **Final confirmation = CI run** (I cannot reproduce the SK 1.40 env locally — `projet-is-roo-new` absent on this machine).

## Out of scope (reported, separate clusters)

- **`conflict_resolution` (10F)** — `success_probability` returns `None` vs tests expecting 0.8/0.5/0.7. Prod code `conflict_resolution.py:40/49/58` deliberately sets `None  # Not measured — placeholder (#971)`. This is a **design decision** (update tests to None vs implement #971 measurement) — not mechanical triage. Reported for separate treatment.
- **`plugin_loader` (3E)** — `fixture 'fs' not found` (pyfakefs missing/not enabled in CI). Separate dependency issue.
- **`eprover_spass_integration` (1F) + `strategies_extended` (1F)** — misc assertion failures, separate.

Dispatched R536 (worker myia-po-2023, reassigned from po-2025 down). Gate-completion #1336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
