### PR TITLE
test(governance): align conflict_resolution tests with #971 None placeholder (#1336, R536)

### DIFF
--- a/tests/unit/argumentation_analysis/agents/core/governance/test_conflict_resolution.py
+++ b/tests/unit/argumentation_analysis/agents/core/governance/test_conflict_resolution.py
@@ -75,18 +75,18 @@ class TestResolveConflict:
     def test_collaborative_strategy(self, conflict):
         result = resolve_conflict(conflict, "collaborative")
         assert result["resolution_type"] == "collaborative"
-        assert result["success_probability"] == 0.8
+        assert result["success_probability"] is None  # None until #971
         assert result["agents"] == ["A", "B"]
 
     def test_competitive_strategy(self, conflict):
         result = resolve_conflict(conflict, "competitive")
         assert result["resolution_type"] == "competitive"
-        assert result["success_probability"] == 0.5
+        assert result["success_probability"] is None  # None until #971
 
     def test_compromise_strategy(self, conflict):
         result = resolve_conflict(conflict, "compromise")
         assert result["resolution_type"] == "compromise"
-        assert result["success_probability"] == 0.7
+        assert result["success_probability"] is None  # None until #971
 
     def test_default_strategy(self, conflict):
         result = resolve_conflict(conflict)
@@ -113,19 +113,19 @@ class TestMediationStrategies:
     def test_collaborative_mediation(self, conflict):
         result = collaborative_mediation(conflict)
         assert result["resolution_type"] == "collaborative"
-        assert result["success_probability"] == 0.8
+        assert result["success_probability"] is None  # None until #971
         assert "common ground" in result["details"]
 
     def test_competitive_mediation(self, conflict):
         result = competitive_mediation(conflict)
         assert result["resolution_type"] == "competitive"
-        assert result["success_probability"] == 0.5
+        assert result["success_probability"] is None  # None until #971
         assert "compete" in result["details"]
 
     def test_compromise_mediation(self, conflict):
         result = compromise_mediation(conflict)
         assert result["resolution_type"] == "compromise"
-        assert result["success_probability"] == 0.7
+        assert result["success_probability"] is None  # None until #971
         assert "middle ground" in result["details"]
 
     def test_all_results_have_agents(self, conflict):
@@ -147,6 +147,10 @@ class TestMediationStrategies:
             assert isinstance(result["details"], str)
             assert len(result["details"]) > 0
 
+    @pytest.mark.xfail(
+        reason="#971: success_probability is a None placeholder until measurement "
+        "is implemented; ordering is undefined in the interim."
+    )
     def test_success_probability_ordering(self, conflict):
         collab = collaborative_mediation(conflict)["success_probability"]
         comp = competitive_mediation(conflict)["success_probability"]

--- a/tests/unit/argumentation_analysis/agents/core/governance/test_governance.py
+++ b/tests/unit/argumentation_analysis/agents/core/governance/test_governance.py
@@ -516,7 +516,7 @@ class TestConflictResolution:
         conflict = {"agents": ["alice", "bob"], "conflict_level": 1.0}
         resolution = resolve_conflict(conflict, strategy="collaborative")
         assert resolution["resolution_type"] == "collaborative"
-        assert resolution["success_probability"] == 0.8
+        assert resolution["success_probability"] is None  # None until #971
 
     def test_resolve_competitive(self):
         """Competitive mediation has lower success."""
@@ -527,7 +527,7 @@ class TestConflictResolution:
         conflict = {"agents": ["alice", "bob"], "conflict_level": 1.0}
         resolution = resolve_conflict(conflict, strategy="competitive")
         assert resolution["resolution_type"] == "competitive"
-        assert resolution["success_probability"] == 0.5
+        assert resolution["success_probability"] is None  # None until #971
 
     def test_resolve_compromise(self):
         """Compromise mediation returns expected format."""
@@ -538,7 +538,7 @@ class TestConflictResolution:
         conflict = {"agents": ["alice", "bob"], "conflict_level": 1.0}
         resolution = resolve_conflict(conflict, strategy="compromise")
         assert resolution["resolution_type"] == "compromise"
-        assert resolution["success_probability"] == 0.7
+        assert resolution["success_probability"] is None  # None until #971
 
 
 class TestSimulation:


### PR DESCRIPTION
## Context

Gate-completion #1336, agents/core cluster. The authoritative CI tally (run `28615348489`) shows **10 failures** in conflict_resolution tests (test_conflict_resolution 7F + test_governance TestConflictResolution 3F). All share one root cause.

## Root cause

Prod `argumentation_analysis/agents/core/governance/conflict_resolution.py` **deliberately** returns:
```python
"success_probability": None,  # Not measured — placeholder (#971)
```
This was an **honesty pass** (#971) that replaced the old fabricated values (0.8/0.5/0.7). The tests still asserted the stale fabricated values → `assert None == 0.8` → fail.

## Fix (source = truth, anti-pendule)

Same pattern as #1348/#1350: align the stale test contract with the current honest prod behavior.

| Change | Count |
|---|---|
| `== 0.8/0.5/0.7` → `is None  # None until #971` | 9 assertions |
| `test_success_probability_ordering` → `@pytest.mark.xfail(reason="#971: ...")` | 1 test |

- The 9 simple assertions keep their `resolution_type`/`agents`/`details` checks (those still hold) — only the stale `success_probability` value is corrected.
- The ordering test (`collab > compr > comp`) is meaningless with None placeholders → `xfail(reason="#971")`. This **preserves the spec**: when #971 implements real measurement and restores the 0.8>0.7>0.5 ordering, the test xpasses → signals #971 is complete.

## Not théâtre

The code is **not broken** — it intentionally returns None (honest placeholder, tracked by #971). The tests asserted a value the honesty pass deliberately removed. This is stale-contract triage, not marker-hiding. When #971 lands real measurement, its PR updates these assertions back to real values (standard co-evolution).

## Validation

```
pytest test_conflict_resolution.py test_governance.py --disable-jvm-session -q
→ 66 passed, 1 xfailed in 15.05s   # the xfail = the ordering test, expected
```
black clean. Single-cluster change, zero collision with other agents/core PRs (#1351 = ai_model_id, separate).

Dispatched R536 (worker myia-po-2023, agents/core cluster). Gate-completion #1336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
