### PR TITLE
ci(env): add pyfakefs to environment.yml — fixes plugin_loader fs fixture (#1336, R536)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -89,3 +89,4 @@ dependencies:
     - tiktoken
     - hypothesis  # #1303: property tests (tests/property/) — CI collection breaks without it
     - pytest-timeout  # CI hang guard: --timeout=900 in ci.yml converts a hung test into a stack-dumped failure
+    - pyfakefs>=5.0.0  # #1336: provides the `fs` fixture for test_plugin_loader.py — CI errors "fixture 'fs' not found" without it


### PR DESCRIPTION
## Context

Gate-completion #1336, agents/core cluster. 3 CI errors in `test_plugin_loader.py`: `fixture 'fs' not found`.

## Root cause — CI env provisioning gap (not a code bug)

`test_plugin_loader.py` uses the pyfakefs **`fs` fixture** (`@pytest.fixture def plugin_test_env(fs):`). pyfakefs is declared in `requirements.txt` (line 29), but **CI provisions its conda env from `environment.yml`** (`.github/workflows/ci.yml` L30: `environment-file: environment.yml`), NOT `requirements.txt`. pyfakefs is absent from `environment.yml` → the runner never installs it → the `pytest11` entry-point that registers the `fs` fixture is absent → `fixture 'fs' not found`.

The 3 tests are **correct** (they use pyfakefs as designed). Validated locally where pyfakefs 5.9.2 is installed: **3 passed**.

## Fix — root, not masking

Add `pyfakefs>=5.0.0` to `environment.yml`'s pip section, matching the `requirements.txt` declaration. This is the **exact precedent** of the `hypothesis` line directly above (line 90: *"#1303: property tests — CI collection breaks without it"*) — a test dep CI needs to avoid errors.

```yaml
- pyfakefs>=5.0.0  # #1336: provides the fs fixture for test_plugin_loader.py — CI errors without it
```

**1-line infra change, 0 test/production code touched.** Not théâtre: the tests legitimately need pyfakefs; this brings CI into alignment with the dev-env declaration.

## Validation

Locally (pyfakefs present): `pytest test_plugin_loader.py → 3 passed`. Final confirmation = CI run installs pyfakefs from the updated environment.yml and the `fs` fixture registers.

Dispatched R536 (worker myia-po-2023, agents/core cluster). Gate-completion #1336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
