### PR TITLE
test(counter_argument): align statistical_counter test with honest placeholder (#1336, R536)

### DIFF
--- a/tests/unit/argumentation_analysis/agents/core/counter_argument/test_strategies_extended.py
+++ b/tests/unit/argumentation_analysis/agents/core/counter_argument/test_strategies_extended.py
@@ -397,7 +397,9 @@ class TestHelperGenerators:
     def test_statistical_counter(self, strategies):
         arg = _make_arg()
         result = strategies._generate_statistical_counter(arg)
-        assert "15%" in result
+        # Prod returns an honest "[template/placeholder]" (no fabricated data);
+        # assert the honest marker instead of the stale fabricated "15%".
+        assert "[template/placeholder]" in result
 
     def test_fallback_direct_refutation(self, strategies):
         arg = _make_arg()


### PR DESCRIPTION
## Context

Gate-completion #1336, agents/core cluster (counter_argument). 1 CI failure: `TestHelperGenerators::test_statistical_counter` — `assert "15%" in result`.

## Root cause — honesty pass (same family as #1352)

Prod `_generate_statistical_counter` was given an honesty pass. Its docstring is explicit:
> *"Generate a statistical counter-argument template (**no fabricated data**) ... a schematic placeholder that frames the statistical challenge **without inventing specific numbers** — actual data would be needed."*

It now returns `"[template/placeholder] a statistical counter would challenge ... the strength of this objection depends on actual data"`. The test still asserted the stale fabricated `"15%"`.

## Fix (source = truth)

```python
# was: assert "15%" in result
assert "[template/placeholder]" in result   # honest marker, no fabricated data
```

Same anti-pendule family as #1352 (conflict_resolution #971 placeholder): prod deliberately stopped fabricating a value; the test asserted a removed value. Not théâtre.

## Validation

`pytest test_strategies_extended.py → 57 passed`, no regression. black clean.

## Out of scope (reported, not fixed)

`test_check_consistency_uses_eprover_when_wired` (1F, logic/eprover_spass_integration): `assert is_consistent is True` gets `None`. This is a #1196 EPROVER-wiring contract test — the failure is either a real prod bug in `check_consistency` (EPROVER path returns None instead of bool) or a stale mock contract. Needs #1196 owner diagnosis; risky to touch blind (logic-agent JPype wiring). Reported for separate treatment.

Dispatched R536 (worker myia-po-2023, agents/core cluster). Gate-completion #1336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude-Code <noreply@anthropic.com>
