### PR TITLE
test(logic): model #1204 EProver delivery sentinel in check_consistency wiring test (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
@@ -275,6 +275,17 @@ class TestEProverWiringContract:
     verdict).
     """
 
+    @pytest.fixture(autouse=True)
+    def _clear_eprover_delivery_cache(self):
+        """The #1204 delivery self-check memoises per-path reliability in a
+        module global; clear it around each contract test so the sentinel is
+        exercised firsthand rather than inheriting a verdict cached elsewhere."""
+        from argumentation_analysis.agents.core.logic import fol_handler
+
+        fol_handler._EPROVER_DELIVERY_RELIABLE.clear()
+        yield
+        fol_handler._EPROVER_DELIVERY_RELIABLE.clear()
+
     def test_eprover_path_read_from_registry_on_query(self, mock_belief_set):
         """_fol_query_with_eprover must pass the registered path to EFOLReasoner."""
         mock_reasoner = MagicMock()
@@ -312,7 +323,19 @@ class TestEProverWiringContract:
         is EPROVER and the binary path is registered (#1196: previously it
         hardcoded SimpleFolReasoner regardless of settings)."""
         mock_reasoner = MagicMock()
-        mock_reasoner.query.return_value = False  # bottom not entailed => consistent
+
+        # The #1204/#1232 delivery self-check probes the SAME reasoner with a
+        # known-inconsistent sentinel {P(a),!P(a)} and requires it to be
+        # reported inconsistent (query -> True) before trusting EProver. Only
+        # the real belief set is the consistent KB (bottom not entailed ->
+        # False). A single return_value cannot model both phases, so key on the
+        # belief-set argument.
+        def _query_side_effect(belief_set, _formula):
+            if belief_set is mock_belief_set:
+                return False  # real KB: bottom not entailed => consistent
+            return True  # sentinel KB: inconsistent => delivery trusted
+
+        mock_reasoner.query.side_effect = _query_side_effect
         mock_parser_instance = MagicMock()
         mock_parser_instance.parseFormula.return_value = "bottom_formula"
         mock_parser_factory = MagicMock(return_value=mock_parser_instance)


### PR DESCRIPTION
## Track ATT-1 (Epic #1355) / gate #1336 — diagnostic (a) eprover-None

Coord dispatch R537/R538 priority (a): diagnose why `check_consistency` returns
`None` on the EPROVER path in `test_check_consistency_uses_eprover_when_wired`.
**Diagnostic before fix, verdict reported even if not fixed.**

### Verdict: stale is the TEST, prod is correct (no prod bug)

`check_consistency` was hardened by the #1204/#1232 anti-theater delivery
self-check: before trusting an EProver verdict, it probes the **same**
`EFOLReasoner` with a known-inconsistent sentinel `{P(a),!P(a)}` and requires
it to be reported inconsistent (`query -> True`). If not, the Tweety→E delivery
contract is broken on this platform → fall back to the in-JVM reasoner, or (no
initializer) return degraded `(None, ...)` **with a logged ERROR**.

The test predates that guard. It wired a single `mock_reasoner.query.return_value
= False`, so the sentinel probe (which expects `True`) also received `False` →
prod correctly judged EProver unreliable and degraded. Runtime proof (captured
log on the failing run):

```
EProver sentinel self-check FAILED: known-inconsistent {P(a),!P(a)} was not
reported inconsistent ... falling back to the in-JVM reasoner.
```

So the `None` is **not** the "silent solver disconnect / RED BUILD" the mandate
guards against (#1196/#1245/R467). It is the #1019 fail-loud degraded verdict
**working as designed** — logged, honest, non-fabricated. The truth is in prod;
the test's single-value mock cannot model the two-phase (sentinel-probe →
actual-query) flow.

### Fix (test-only, anti-pendule — no skip/xfail, no prod change)

- `mock_reasoner.query` gets a `side_effect` keyed on the belief-set argument:
  `True` for the sentinel KB (delivery trusted), `False` for the real KB
  (bottom not entailed ⇒ consistent). Faithfully models both phases.
- Autouse fixture clears the module-global `_EPROVER_DELIVERY_RELIABLE` cache
  around each contract test so the sentinel runs firsthand (no cross-test
  coupling via the per-path memo).

### Validation (env `projet-is`, SK 1.34)

- `TestEProverWiringContract`: **2 passed / 1 failed → 3 passed**
- Whole file `test_eprover_spass_integration.py`: **30 passed / 0 failed**
- `black --check`: clean

DoD: root cause identified firsthand, prod untouched (correct as-is), 0 new
broken. Privacy: no dataset content. Refs #1336, #1355 (ATT-1), #1196, #1204.
