### PR TITLE
fix(modal): hoist SPASS routing to shared ModalHandler layer (#1339)

### DIFF
--- a/argumentation_analysis/agents/core/logic/modal_handler.py
+++ b/argumentation_analysis/agents/core/logic/modal_handler.py
@@ -99,9 +99,43 @@ class ModalHandler:
                 raise RuntimeError(f"SPASS reasoner not available: {e}") from e
         return self._spass_reasoner
 
-    def _get_active_reasoner(self):
-        """Returns the active reasoner based on configuration."""
+    def _resolve_active_solver_choice(self) -> ModalSolverChoice:
+        """Resolve which modal solver is actually in effect (#1339).
+
+        The "prefer the vendored SPASS binary when available" upgrade used to
+        live ONLY at the pipeline site
+        (``invoke_callables._invoke_modal_logic``), which applied it by mutating
+        the global ``settings.modal_solver`` before driving the handler. Direct
+        callers of the shared handler — notably the conversational path
+        ``ModalLogicAgent`` → ``TweetyBridge.modal_handler.is_modal_kb_consistent``
+        (CONV-B) — bypass that site and silently got the OOM-prone
+        ``SimpleMlReasoner`` default (FP-16 #1231). Hoisting the resolution here
+        gives every caller the same routing to the solver that DÉCIDE.
+
+        Anti-pendule (#1279): an explicit ``SPASS`` choice is honored directly;
+        the default ``TWEETY`` is upgraded to ``SPASS`` only when (a) the prefer
+        flag is set and (b) a vendored SPASS binary is detected. ``TWEETY`` with
+        the prefer flag off stays ``TWEETY`` — the explicit opt-out the #1219
+        regression pins. This *routes* to the capable solver rather than catching
+        an OOM and reporting degraded.
+        """
         if settings.modal_solver == ModalSolverChoice.SPASS:
+            return ModalSolverChoice.SPASS
+        if (
+            settings.modal_solver == ModalSolverChoice.TWEETY
+            and bool(settings.modal_prefer_spass_when_available)
+            and _get_spass_path() is not None
+        ):
+            return ModalSolverChoice.SPASS
+        return settings.modal_solver
+
+    def _get_active_reasoner(self):
+        """Returns the active reasoner based on the resolved solver choice.
+
+        #1339: resolution is centralised in ``_resolve_active_solver_choice`` so
+        the pipeline AND direct (conversational) callers share the same routing.
+        """
+        if self._resolve_active_solver_choice() == ModalSolverChoice.SPASS:
             return self._get_spass_reasoner()
         return self._modal_reasoner
 
@@ -269,7 +303,10 @@ class ModalHandler:
         build). Honest ``None`` (no silent fallback to another reasoner, no
         fabricated verdict) per the anti-theater contract (#1019/#961).
         """
-        solver_name = settings.modal_solver.value
+        # #1339: report the RESOLVED solver (SPASS when auto-routed), not the
+        # raw ``settings.modal_solver`` — otherwise a conversational call that
+        # auto-upgrades to SPASS would still label its verdict "tweety".
+        solver_name = self._resolve_active_solver_choice().value
         reasoner = self._get_active_reasoner()
         logger.debug(f"Checking modal KB consistency with {solver_name}.")
 

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py
@@ -412,11 +412,74 @@ class TestModalHandlerSPASS:
         return init
 
     def test_default_reasoner_is_tweety(self, mock_initializer):
+        """Default TWEETY stays SimpleMlReasoner when no SPASS binary is wired.
+
+        #1339: the resolution now auto-upgrades TWEETY→SPASS when a vendored
+        SPASS is detected, so this test pins the *SPASS-absent* case explicitly
+        (``_get_spass_path`` → None) rather than relying on the ambient env.
+        """
         with patch(
             "argumentation_analysis.agents.core.logic.modal_handler.settings"
-        ) as mock_settings:
+        ) as mock_settings, patch(
+            "argumentation_analysis.agents.core.logic.modal_handler._get_spass_path",
+            return_value=None,
+        ):
             mock_settings.modal_solver = ModalSolverChoice.TWEETY
+            mock_settings.modal_prefer_spass_when_available = True
             handler = ModalHandler(mock_initializer)
+            reasoner = handler._get_active_reasoner()
+            assert reasoner == mock_initializer.get_modal_reasoner()
+            assert (
+                handler._resolve_active_solver_choice() == ModalSolverChoice.TWEETY
+            )
+
+    def test_default_tweety_auto_upgrades_to_spass_when_available(self, mock_initializer):
+        """#1339: with the prefer flag set (default) and a vendored SPASS binary
+        detected, the default TWEETY resolves to SPASS at the *shared handler*
+        layer — so direct/conversational callers (CONV-B) get the solver that
+        DÉCIDE, not the OOM-prone SimpleMlReasoner. Mirrors the pipeline routing
+        that previously lived only in ``_invoke_modal_logic``."""
+        with patch(
+            "argumentation_analysis.agents.core.logic.modal_handler.settings"
+        ) as mock_settings, patch(
+            "argumentation_analysis.agents.core.logic.modal_handler.jpype"
+        ) as mock_jpype, patch(
+            "argumentation_analysis.agents.core.logic.modal_handler._get_spass_path",
+            return_value="/registered/spass.exe",
+        ):
+            mock_settings.modal_solver = ModalSolverChoice.TWEETY
+            mock_settings.modal_prefer_spass_when_available = True
+            mock_spass = MagicMock()
+            mock_jpype.JClass.return_value = lambda *args, **kwargs: mock_spass
+
+            handler = ModalHandler(mock_initializer)
+            assert (
+                handler._resolve_active_solver_choice() == ModalSolverChoice.SPASS
+            )
+            reasoner = handler._get_active_reasoner()
+            # Routed to the lazily-loaded SPASS reasoner, NOT the tweety default.
+            assert reasoner is not mock_initializer.get_modal_reasoner()
+            mock_jpype.JClass.assert_any_call(
+                "org.tweetyproject.logics.ml.reasoner.SPASSMlReasoner"
+            )
+
+    def test_prefer_flag_off_keeps_tweety_even_when_spass_available(self, mock_initializer):
+        """#1339 anti-pendule (#1219): the explicit opt-out
+        ``modal_prefer_spass_when_available=False`` keeps SimpleMlReasoner even
+        when a vendored SPASS is detected — the resolution never overrides an
+        opt-out."""
+        with patch(
+            "argumentation_analysis.agents.core.logic.modal_handler.settings"
+        ) as mock_settings, patch(
+            "argumentation_analysis.agents.core.logic.modal_handler._get_spass_path",
+            return_value="/registered/spass.exe",
+        ):
+            mock_settings.modal_solver = ModalSolverChoice.TWEETY
+            mock_settings.modal_prefer_spass_when_available = False
+            handler = ModalHandler(mock_initializer)
+            assert (
+                handler._resolve_active_solver_choice() == ModalSolverChoice.TWEETY
+            )
             reasoner = handler._get_active_reasoner()
             assert reasoner == mock_initializer.get_modal_reasoner()
 


### PR DESCRIPTION
## Problem (#1339)

The `modal_prefer_spass_when_available` resolution (Track C #1279) was consumed at **exactly one site** — `orchestration/invoke_callables.py:6207`, the pipeline's `_invoke_modal_logic` — which applied it by **mutating the global** `settings.modal_solver` before driving the handler. Every other entry point resolved the default `TWEETY` → OOM-prone `SimpleMlReasoner` (FP-16 #1231):

- direct `ModalHandler` construction (probes, scripts, tests),
- **the conversational `ModalLogicAgent` modal tool-calls** — `TweetyBridge.modal_handler.is_modal_kb_consistent(...)` (the CONV-B #1333 path). As-is, in-conversation modal consistency checks hang/OOM on real corpus KBs, sinking CONV-B's DoD (solvers must DECIDE in the dialogue).

Found by po-2025 EDGE-4 post-merge probe (R525): a direct `ModalHandler.is_modal_kb_consistent` probe **hung**, while the pipeline on the same KB routed to SPASS and decided.

## Fix

Hoist the resolution into **`ModalHandler._resolve_active_solver_choice()`** — the single source of truth used by both:
- `_get_active_reasoner()` (reasoner **selection**), and
- `is_modal_kb_consistent()` (solver_name **reporting** — so an auto-routed call labels its verdict `spass`, not `tweety`).

Every caller — pipeline AND conversational — now routes to the solver that DÉCIDE.

**Anti-pendule (#1279), per the issue's fix direction:** an explicit `SPASS` choice is honored directly; the default `TWEETY` is upgraded to `SPASS` only under (prefer flag **+** detected vendored binary); `TWEETY` with the prefer flag off stays `TWEETY` (the #1219 opt-out). We *subtract* the OOM-prone default routing — no `try/except` stacked on the OOM.

**Pipeline site intentionally left unchanged.** Its own `"solver"` report reads `settings.modal_solver` directly, and the #1279 routing tests (`test_track_c_modal_spass_1279.py`) pin the mutation+restore behavior. On that path the handler resolves to the already-mutated explicit `SPASS`, so behavior is identical — the mutation is now redundant for reasoner selection but still feeds the pipeline's own report. Removing it would break the #1279 contract; a follow-up could simplify it once the report is sourced from the handler.

## DoD (#1339)

- [x] A direct `ModalHandler` consistency call resolves to **SPASS** when the vendored binary is present (no hang), on the same code path the conversational agent uses — proven by `test_default_tweety_auto_upgrades_to_spass_when_available` (routing) + the existing real-JVM `test_invoke_modal_logic_reaches_solver` integration exercises `_get_active_reasoner`.
- [x] Explicit `modal_solver='tweety'` (prefer flag off) still forces `SimpleMlReasoner` — `test_prefer_flag_off_keeps_tweety_even_when_spass_available` + `test_default_reasoner_is_tweety` (now deterministic).
- [x] `_invoke_modal_logic` behavior unchanged — `test_track_c_modal_spass_1279.py` (routing + restore + opt-out) all green.

## Tests

`tests/unit/argumentation_analysis/agents/core/logic/test_eprover_spass_integration.py`:
- `test_default_reasoner_is_tweety` — made deterministic (pins `_get_spass_path`→None, the SPASS-absent case).
- **+** `test_default_tweety_auto_upgrades_to_spass_when_available` — the #1339 win (shared-layer auto-route).
- **+** `test_prefer_flag_off_keeps_tweety_even_when_spass_available` — opt-out honored at the handler.

**Validation:** modal + Track C #1279 tests green (39 passed). mypy strict on `modal_handler.py`: 0 new errors (baseline 9 = current 9, in-place; file not in the strict gate). The 1 remaining failure in the file (`TestEProverWiringContract::test_check_consistency_uses_eprover_when_wired`) is **pre-existing on origin/main** (verified in-place, orthogonal FOL/EProver test — not touched by this change).

Prereq of **CONV-B #1333**. Refs: #1279 (Track C routing), #1231 (FP-16 OOM), #1239/#1242 (SPASS native), Epic #1331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)