### PR TITLE
test(ra8): force handler import failure in all fail-loud tests (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/test_ra8_anti_theater.py
+++ b/tests/unit/argumentation_analysis/test_ra8_anti_theater.py
@@ -53,7 +53,6 @@ from argumentation_analysis.orchestration.invoke_callables import (
     _invoke_propositional_logic,
 )
 
-
 # ---------------------------------------------------------------------------
 # Test data fixtures
 # ---------------------------------------------------------------------------
@@ -96,113 +95,186 @@ _CTX = {
 class TestRankingFailLoud:
     def test_raises_runtime_error(self):
         """When ranking handler import fails, must raise RuntimeError."""
-        with patch.dict(sys.modules, {
-            "argumentation_analysis.agents.core.logic.ranking_handler": None,
-        }):
+        with patch.dict(
+            sys.modules,
+            {
+                "argumentation_analysis.agents.core.logic.ranking_handler": None,
+            },
+        ):
             with pytest.raises(RuntimeError, match="Ranking semantics"):
                 _run(_invoke_ranking(_INPUT, _CTX))
 
 
 class TestBipolarFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="Bipolar analysis"):
-            _run(_invoke_bipolar(_INPUT, _CTX))
+        # Force the handler import to fail (JVM-unavailable scenario) — on a
+        # JVM-available machine (CI/agent) the real handler would run and never
+        # fail-loud, so we mock it to fail exactly as the file docstring says.
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.bipolar_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="Bipolar analysis"):
+                _run(_invoke_bipolar(_INPUT, _CTX))
 
 
 class TestABAFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="ABA reasoning"):
-            _run(_invoke_aba(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.aba_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="ABA reasoning"):
+                _run(_invoke_aba(_INPUT, _CTX))
 
 
 class TestADFFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="ADF reasoning"):
-            _run(_invoke_adf(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.adf_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="ADF reasoning"):
+                _run(_invoke_adf(_INPUT, _CTX))
 
 
 class TestASPICFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="ASPIC\\+"):
-            _run(_invoke_aspic(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.aspic_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="ASPIC\\+"):
+                _run(_invoke_aspic(_INPUT, _CTX))
 
 
 class TestBeliefRevisionFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="Belief revision"):
-            _run(_invoke_belief_revision(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.belief_revision_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="Belief revision"):
+                _run(_invoke_belief_revision(_INPUT, _CTX))
 
 
 class TestProbabilisticFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="Probabilistic"):
-            _run(_invoke_probabilistic(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.probabilistic_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="Probabilistic"):
+                _run(_invoke_probabilistic(_INPUT, _CTX))
 
 
 class TestDialogueFailLoud:
     def test_raises_runtime_error(self):
         """When dialogue handler import fails, must raise RuntimeError."""
-        with patch.dict(sys.modules, {
-            "argumentation_analysis.agents.core.logic.dialogue_handler": None,
-        }):
+        with patch.dict(
+            sys.modules,
+            {
+                "argumentation_analysis.agents.core.logic.dialogue_handler": None,
+            },
+        ):
             with pytest.raises(RuntimeError, match="Dialogue protocol"):
                 _run(_invoke_dialogue(_INPUT, _CTX))
 
 
 class TestDLFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="Description Logic"):
-            _run(_invoke_dl(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.dl_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="Description Logic"):
+                _run(_invoke_dl(_INPUT, _CTX))
 
 
 class TestCLFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="Conditional Logic"):
-            _run(_invoke_cl(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.cl_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="Conditional Logic"):
+                _run(_invoke_cl(_INPUT, _CTX))
 
 
 class TestSetAFFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="SetAF"):
-            _run(_invoke_setaf(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.setaf_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="SetAF"):
+                _run(_invoke_setaf(_INPUT, _CTX))
 
 
 class TestWeightedFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="Weighted AF"):
-            _run(_invoke_weighted(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.weighted_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="Weighted AF"):
+                _run(_invoke_weighted(_INPUT, _CTX))
 
 
 class TestSocialFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="Social argumentation"):
-            _run(_invoke_social(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.social_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="Social argumentation"):
+                _run(_invoke_social(_INPUT, _CTX))
 
 
 class TestEAFFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="Epistemic AF"):
-            _run(_invoke_eaf(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.eaf_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="Epistemic AF"):
+                _run(_invoke_eaf(_INPUT, _CTX))
 
 
 class TestDeLPFailLoud:
     def test_raises_runtime_error(self):
-        with pytest.raises(RuntimeError, match="DeLP"):
-            _run(_invoke_delp(_INPUT, _CTX))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.delp_handler": None},
+        ):
+            with pytest.raises(RuntimeError, match="DeLP"):
+                _run(_invoke_delp(_INPUT, _CTX))
 
 
 class TestPLFailLoud:
     """PL handler: when all Tweety solvers fail, must raise RuntimeError."""
 
     def test_raises_runtime_error(self):
-        """When Tweety cannot parse any formula, PL must fail-loud."""
-        # Use unparseable formulas to trigger the "all formulas failed" path
+        """When Tweety/PySAT is unavailable, PL must fail-loud.
+
+        The old input ``$$UNPARSEABLE$$`` no longer reaches the fail-loud path:
+        the #537 PL sanitizer legitimately salvages it into the valid atom
+        ``__UNPARSEABLE__``, which PySAT then decides SAT — a real solver
+        verdict, not theater. To exercise the actual "all Tweety solvers
+        failed" contract (invoke_callables L5390) we force the TweetyBridge
+        import to fail (JVM/Tweety-unavailable scenario), matching the
+        sys.modules pattern the other fail-loud tests use.
+        """
         ctx_bad = {
             "arguments": ["arg1", "arg2"],
-            "formulas": ["$$UNPARSEABLE$$"],
+            "formulas": ["p & q"],
         }
-        with pytest.raises(RuntimeError, match="Propositional logic"):
-            _run(_invoke_propositional_logic("test input", ctx_bad))
+        with patch.dict(
+            sys.modules,
+            {"argumentation_analysis.agents.core.logic.tweety_bridge": None},
+        ):
+            with pytest.raises(RuntimeError, match="Propositional logic"):
+                _run(_invoke_propositional_logic("test input", ctx_bad))
 
 
 # ---------------------------------------------------------------------------
@@ -256,9 +328,12 @@ class TestStateWriterGuard:
 
         mock_state = MagicMock()
         # Invoke raises RuntimeError (as it does now when JVM unavailable)
-        with patch.dict(sys.modules, {
-            "argumentation_analysis.agents.core.logic.aba_handler": None,
-        }):
+        with patch.dict(
+            sys.modules,
+            {
+                "argumentation_analysis.agents.core.logic.aba_handler": None,
+            },
+        ):
             with pytest.raises(RuntimeError):
                 _run(_invoke_aba(_INPUT, _CTX))
         # Writer was never called because invoke raised before producing output


### PR DESCRIPTION
## Track ATT-1 (Epic #1355) / gate #1336 — (b) test_ra8_anti_theater (11 F on CI)

Coord dispatch R537/R538 priority (b).

### Root cause (firsthand): env-dependent fail-loud tests

The RA-8 #1053 tests assert each Tweety handler raises `RuntimeError` when the
formal reasoner is unavailable — no fabricated Python fallback (#1019). 13 of
the 16 fail-loud tests **did not** patch `sys.modules` to force the handler
import to fail; they relied on the handler failing *ambiently*. That only holds
in a partial environment. On a JVM-available machine (CI/agent) the real handler
runs and never fails-loud, so the assertion fails. The file docstring already
warns this ("we must mock them to fail to test the fallback path") — `Ranking`
and `Dialogue` do it; the other 13 forgot.

Evidence:
- Local run (partial env): **7 failed** (bipolar, aba, adf, aspic,
  belief_revision, probabilistic, PL).
- Authoritative CI junit (run 28582260688): **11 failed**. The extra 4 are
  among {dl, cl, setaf, weighted, social, eaf, delp} — they pass locally *by
  accident* (handler fails in this partial env) but fail on CI's fuller env.

Fix: force the handler import to fail (`sys.modules[<handler>] = None`) in all
16 fail-loud tests, matching the `Ranking`/`Dialogue` pattern. Deterministic on
any env → a superset of the 11 CI failures.

### PL — distinct stale case (no prod bug)

`TestPLFailLoud` used `"$$UNPARSEABLE$$"` to reach the "all Tweety solvers
failed" path. That input no longer reaches it: the #537 PL sanitizer
legitimately salvages it into the valid atom `__UNPARSEABLE__`, which PySAT
decides SAT — a **real** solver verdict, not theater. The test now forces the
`TweetyBridge` import to fail to exercise the actual fail-loud path
(`invoke_callables.py` L5390). Prod is untouched — it already fails loud there.

### Anti-pendule / DoD

No skip/xfail, no prod change. Handler module names verified firsthand against
`invoke_callables.py`. File: **12 passed / 7 failed → 19 passed**, all
deterministic. Privacy: no dataset content. Refs #1336, #1355 (ATT-1), #1053,
#1019.
