### PR TITLE
test(orchestration): retarget llm_enrich patches to invoke_callables namespace (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_llm_enrich_quality.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_llm_enrich_quality.py
@@ -13,12 +13,21 @@ class TestLlmEnrichQuality:
     """Tests for _llm_enrich_quality function."""
 
     async def test_returns_none_when_no_api_key(self):
-        """LLM enrichment returns None gracefully when OPENAI_API_KEY is absent."""
+        """LLM enrichment returns None gracefully when no API key is available.
+
+        Patch _get_openai_client to return its documented no-key sentinel
+        ``(None, "")`` rather than clearing os.environ: on CI (which provisions
+        a real key via secrets) the env-clear did not prevent a live client, so
+        the enrichment made a real LLM call instead of the no-key short-circuit.
+        """
         from argumentation_analysis.orchestration.unified_pipeline import (
             _llm_enrich_quality,
         )
 
-        with patch.dict("os.environ", {}, clear=True):
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(None, ""),
+        ):
             result = await _llm_enrich_quality(
                 {"arg_1": {"note_finale": 5.0, "scores_par_vertu": {"clarity": 6.0}}},
                 [{"text": "Some argument"}],
@@ -32,7 +41,7 @@ class TestLlmEnrichQuality:
         )
 
         with patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(MagicMock(), "gpt-5-mini"),
         ):
             result = await _llm_enrich_quality({}, [])
@@ -45,7 +54,7 @@ class TestLlmEnrichQuality:
         )
 
         with patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(MagicMock(), "gpt-5-mini"),
         ):
             result = await _llm_enrich_quality(
@@ -85,7 +94,7 @@ class TestLlmEnrichQuality:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         with patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(mock_client, "gpt-5-mini"),
         ):
             result = await _llm_enrich_quality(
@@ -122,7 +131,7 @@ class TestLlmEnrichQuality:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         with patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(mock_client, "gpt-5-mini"),
         ):
             result = await _llm_enrich_quality(
@@ -145,7 +154,7 @@ class TestLlmEnrichQuality:
         )
 
         with patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(mock_client, "gpt-5-mini"),
         ):
             result = await _llm_enrich_quality(
@@ -181,7 +190,7 @@ class TestLlmEnrichQuality:
         raw_args = [{"text": f"Argument {i}"} for i in range(1, 8)]
 
         with patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(mock_client, "gpt-5-mini"),
         ):
             await _llm_enrich_quality(heuristic, raw_args)
@@ -212,7 +221,7 @@ class TestLlmEnrichQuality:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         with patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(mock_client, "test-model"),
         ) as mock_get:
             await _llm_enrich_quality(
@@ -249,7 +258,7 @@ class TestInvokeQualityWithLlmEnrichment:
             "argumentation_analysis.agents.core.quality.quality_evaluator.ArgumentQualityEvaluator",
             return_value=mock_evaluator,
         ), patch(
-            "argumentation_analysis.orchestration.unified_pipeline._llm_enrich_quality",
+            "argumentation_analysis.orchestration.invoke_callables._llm_enrich_quality",
             return_value=enrichment_data,
         ):
             context = {
@@ -278,7 +287,7 @@ class TestInvokeQualityWithLlmEnrichment:
             "argumentation_analysis.agents.core.quality.quality_evaluator.ArgumentQualityEvaluator",
             return_value=mock_evaluator,
         ), patch(
-            "argumentation_analysis.orchestration.unified_pipeline._llm_enrich_quality",
+            "argumentation_analysis.orchestration.invoke_callables._llm_enrich_quality",
             return_value=None,
         ):
             context = {
@@ -317,7 +326,7 @@ class TestLlmEnrichQualityWithFallacies:
         ]
 
         with patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(mock_client, "gpt-5-mini"),
         ):
             await _llm_enrich_quality(
@@ -349,7 +358,7 @@ class TestLlmEnrichQualityWithFallacies:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         with patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(mock_client, "gpt-5-mini"),
         ):
             await _llm_enrich_quality(
@@ -390,7 +399,7 @@ class TestLlmEnrichQualityWithFallacies:
             "argumentation_analysis.agents.core.quality.quality_evaluator.ArgumentQualityEvaluator",
             return_value=mock_evaluator,
         ), patch(
-            "argumentation_analysis.orchestration.unified_pipeline._llm_enrich_quality",
+            "argumentation_analysis.orchestration.invoke_callables._llm_enrich_quality",
             return_value=enrichment_data,
         ):
             context = {
@@ -424,7 +433,7 @@ class TestLlmEnrichQualityWithFallacies:
             "argumentation_analysis.agents.core.quality.quality_evaluator.ArgumentQualityEvaluator",
             return_value=mock_evaluator,
         ), patch(
-            "argumentation_analysis.orchestration.unified_pipeline._llm_enrich_quality",
+            "argumentation_analysis.orchestration.invoke_callables._llm_enrich_quality",
             return_value=None,
         ):
             context = {


### PR DESCRIPTION
## Track ATT-1 (Epic #1355) / gate #1336 — (c) part 1: llm_enrich_quality (10 F on CI)

### Root cause (firsthand): patch target wrong namespace (same as #1350)

`_get_openai_client` (invoke_callables L245), `_invoke_quality_evaluator` (L471)
and `_llm_enrich_quality` (L618) are all **defined in `invoke_callables`**.
`unified_pipeline` only re-exports them via `from invoke_callables import *`
(L38). These functions call each other by bare name, resolved against
`invoke_callables.__dict__` — never the `unified_pipeline` alias. So patching
`unified_pipeline._get_openai_client` / `unified_pipeline._llm_enrich_quality`
was a **no-op**.

CI evidence (junit run 28582260688 — CI has a real key via secrets, so the real
client ran and made real LLM calls):
- `caps_at_4 / fallacy_context / no_fallacy`: `'NoneType' object has no attribute
  'kwargs'` (mock's `call_args` is None — mock never used)
- `uses_get_openai_client`: `Expected '_get_openai_client' ... Called 0 times`
- `successful / includes / omits / merged / not_merged / returns_none_on_exception`:
  real LLM output compared to fixtures

### Fix (test-only, no prod change)

- Retarget all 13 patches `unified_pipeline.*` → `invoke_callables.*`
  (9 `_get_openai_client`, 4 `_llm_enrich_quality`).
- `test_returns_none_when_no_api_key` relied on `patch.dict(os.environ, {},
  clear=True)`, which did not stop the client on CI (the key survives the clear).
  It now patches `_get_openai_client` to its documented no-key sentinel
  `(None, "")` — deterministic, matches the function's contract.

### DoD

Root cause firsthand, prod untouched, anti-pendule (retarget, no skip). File:
**10 failed / 8 passed (73s real network) → 18 passed (2.6s, no network)** — the
runtime drop is direct proof the mock now applies. Privacy: no dataset content.
Refs #1336, #1355 (ATT-1), #1350 (same pattern), #208-F, #290.
