### PR TITLE
fix(orchestration): heal external_solvers cluster — stale modal tests + SAT MUS fail-loud (#1336)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3479,7 +3479,24 @@ async def _invoke_sat(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
     formulas = context.get("formulas", [input_text] if input_text else [])
     mode = context.get("sat_mode", "solve")  # solve, maxsat, mus
     if mode == "mus":
-        mus_list = await asyncio.to_thread(handler.find_mus, formulas)
+        try:
+            mus_list = await asyncio.to_thread(handler.find_mus, formulas)
+        except RuntimeError as exc:
+            # MUS extraction requires z3-solver (MARCO). z3 is an OPTIONAL
+            # backend and may be absent from the environment; SATHandler.find_mus
+            # fails loud with a RuntimeError in that case. Surface the gap as a
+            # structured degraded result rather than letting the exception escape
+            # the orchestration boundary — honest-degraded, not silent, and not a
+            # raw crash either (#1019). Every other _invoke_* callable returns a
+            # dict on solver-absence; the MUS branch was the outlier.
+            logger.warning("SAT MUS mode unavailable: %s", exc)
+            return {
+                "mode": "mus",
+                "mus_count": 0,
+                "mus_subsets": [],
+                "error": str(exc),
+                "statistics": {"handler": "SATHandler", "backend": "Z3-MARCO"},
+            }
         return {
             "mode": "mus",
             "mus_count": len(mus_list),

--- a/tests/unit/argumentation_analysis/orchestration/test_external_solvers.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_external_solvers.py
@@ -147,11 +147,20 @@ class TestInvokeModalWithSPASS:
         )
         return _invoke_modal_logic
 
+    # #1279 (2ccb1de3): a modal KB is supplied through ``context['formulas']``
+    # (the direct/hand-written-KB channel). Raw text with no nl_to_logic
+    # translation and no direct formulas is honestly marked
+    # ``unavailable:no-translation`` — the pre-#1279 ``[input_text]`` raw-parse
+    # fallback was removed as the #1224 trap (never feed raw prose to MlParser,
+    # #1019). These tests pass the formula via context, matching the already-
+    # passing ``test_formulas_from_context``; the modality-detection assertions
+    # are unchanged.
+
     def test_default_tweety_routing(self):
-        """Without modal_solver context, uses TweetyBridge or heuristic."""
+        """Default routing (no explicit modal_solver) detects necessity."""
         invoke = self._get_invoke()
         result = asyncio.get_event_loop().run_until_complete(
-            invoke("[](p -> q)", {})
+            invoke("[](p -> q)", {"formulas": ["[](p -> q)"]})
         )
         assert "modalities" in result
         assert "necessity" in result["modalities"]
@@ -160,7 +169,7 @@ class TestInvokeModalWithSPASS:
         """Detects [] as necessity modality."""
         invoke = self._get_invoke()
         result = asyncio.get_event_loop().run_until_complete(
-            invoke("[](p)", {})
+            invoke("[](p)", {"formulas": ["[](p)"]})
         )
         assert "necessity" in result["modalities"]
 
@@ -168,7 +177,7 @@ class TestInvokeModalWithSPASS:
         """Detects <> as possibility modality."""
         invoke = self._get_invoke()
         result = asyncio.get_event_loop().run_until_complete(
-            invoke("<>(p)", {})
+            invoke("<>(p)", {"formulas": ["<>(p)"]})
         )
         assert "possibility" in result["modalities"]
 


### PR DESCRIPTION
## Contexte

Reliquat #1336 (ATT-1, CI verte honnête). Cluster **external_solvers** = 4 F reproductibles **en isolation** (pas de la pollution collection-order) : `18 passed / 4 failed` → `22 passed / 0 failed`. Non-colliding avec le dispatch #4 de po-2023 (ra8 / llm_enrich / unified_pipeline / starlette).

Deux causes racines distinctes, deux traitements différents (anti-théâtre : test stale aligné vs vrai gap prod corrigé).

## ① 3 tests modaux STALE — pré-#1279 (test-only)

`TestInvokeModalWithSPASS::{test_default_tweety_routing, test_necessity_modality_detected, test_possibility_modality_detected}` passaient la formule modale **en texte brut avec contexte vide** (`invoke("[](p)", {})`) et attendaient la détection de modalité.

**Preuve git** : ce contrat = le fallback `[input_text]` que **#1279 (`2ccb1de3`, PR #1288) a délibérément supprimé** — le piège #1224 (ne jamais parser de la prose brute au MlParser, #1019). Le code de prod retourne désormais `unavailable:no-translation` à cette frontière, ce qui est **correct et intentionnel**. Le fichier de test est antérieur de plusieurs mois (PR #495).

**Fix** : aligner les 3 tests sur le canal direct-KB `context["formulas"]` — exactement le pattern du test frère **déjà passant** `test_formulas_from_context`. Les assertions sur la détection de modalité (`necessity`/`possibility`) sont **inchangées** : c'est leur intention, préservée.

## ② SAT MUS — vrai gap prod (fail-loud à la frontière)

`TestInvokeSAT::test_sat_mus_mode` : `_invoke_sat` (mode `mus`) appelait `SATHandler.find_mus` sans garde. `find_mus` **fail-loud correctement** (`RuntimeError("Z3 not installed")`) quand z3-solver (backend MARCO **optionnel**) est absent — mais l'exception **s'échappait de la frontière d'orchestration** au lieu de retourner un dict structuré.

**Fix** (prod) : envelopper la branche MUS pour retourner un dict dégradé structuré (`mus_count=0` + champ `error`), comme **tous les autres `_invoke_*`** le font sur solveur-absent. Honest-degraded, pas de crash brut (#1019). La branche MUS était l'exception.

## Files changed

| File | Type | Reason |
|------|------|--------|
| `tests/.../orchestration/test_external_solvers.py` | test | Align 3 stale pre-#1279 modal tests to the `context["formulas"]` channel |
| `argumentation_analysis/orchestration/invoke_callables.py` | prod | `_invoke_sat` MUS branch: structured fail-loud on optional z3 absence |

## Validation

- `test_external_solvers.py` : **22 passed / 0 failed** (`--disable-jvm-session`, isolation).
- `mypy --strict invoke_callables.py` = **0 erreurs**.
- Mes lignes ajoutées black-clean (la dette black pré-existante d'autres méthodes du fichier n'est **pas** touchée — hors-scope, continue-on-error).

## Notes

- `mergeStateStatus` sera BLOCKED (artefact red-main #1336, gate suite-entière) → admin-merge après vérif firsthand.
- Aucun nom de source, IDs opaques uniquement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)