### PR TITLE
fix(scripts): replace bare open(.env) with load_dotenv in fp5 matrix runner (#1336)

### DIFF
--- a/scripts/run_fp5_formal_matrix.py
+++ b/scripts/run_fp5_formal_matrix.py
@@ -31,11 +31,13 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
-for line in open(ROOT / ".env", encoding="utf-8"):
-    line = line.strip()
-    if line and not line.startswith("#") and "=" in line:
-        k, _, v = line.partition("=")
-        os.environ.setdefault(k.strip(), v.strip())
+# Load .env if present (local dev). No-op when absent (CI provisions secrets via
+# env, no .env file) — use load_dotenv (project-wide convention, ~10 scripts)
+# instead of a bare open() that raised FileNotFoundError at module import and
+# broke the 5 unit tests importing _classify_capability (gate #1336).
+from dotenv import load_dotenv
+
+load_dotenv(ROOT / ".env")
 
 # Privacy HARD — redact any substring of any corpus.
 _REDACT_CHUNKS: "list[str]" = []


### PR DESCRIPTION
Gate #1336 cluster fp5 (5F). Root cause: scripts/run_fp5_formal_matrix.py:34 did bare open(ROOT/'.env') at module top-level -> FileNotFoundError on CI (no .env, keys=secrets) -> 5 unit tests crash importing _classify_capability. Fix: load_dotenv (project convention ~10 scripts, no-op if absent). 5 passed with .env absent (CI sim) AND present. mypy 0 on changed lines. Non-colliding.