### PR TITLE
test(camembert): isolate camembert tier with enable_self_hosted_llm=False (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/test_camembert_integration.py
+++ b/tests/unit/argumentation_analysis/test_camembert_integration.py
@@ -174,6 +174,7 @@ class TestFrenchFallacyAdapterCamemBERT:
             enable_symbolic=False,
             enable_nli=False,
             enable_llm=False,
+            enable_self_hosted_llm=False,
             enable_camembert=True,
         )
         assert adapter._camembert is not None
@@ -203,6 +204,7 @@ class TestFrenchFallacyAdapterCamemBERT:
             enable_symbolic=False,
             enable_nli=False,
             enable_llm=False,
+            enable_self_hosted_llm=False,
             enable_camembert=True,
         )
         # Mock CamemBERT as available
@@ -223,6 +225,7 @@ class TestFrenchFallacyAdapterCamemBERT:
             enable_symbolic=False,
             enable_nli=False,
             enable_llm=False,
+            enable_self_hosted_llm=False,
             enable_camembert=True,
         )
 
@@ -251,6 +254,7 @@ class TestFrenchFallacyAdapterCamemBERT:
             enable_symbolic=False,
             enable_nli=False,
             enable_llm=False,
+            enable_self_hosted_llm=False,
             enable_camembert=True,
         )
         # CamemBERT unavailable (no model)
@@ -272,6 +276,7 @@ class TestFrenchFallacyAdapterCamemBERT:
             enable_symbolic=False,
             enable_nli=False,
             enable_llm=False,
+            enable_self_hosted_llm=False,
             enable_camembert=True,
             camembert_model_path="/custom/model/path",
         )
@@ -287,6 +292,7 @@ class TestFrenchFallacyAdapterCamemBERT:
             enable_symbolic=False,
             enable_nli=False,
             enable_llm=False,
+            enable_self_hosted_llm=False,
             enable_camembert=True,
             camembert_threshold=0.7,
         )
@@ -303,6 +309,7 @@ class TestFrenchFallacyAdapterCamemBERT:
             enable_symbolic=True,
             enable_nli=False,
             enable_llm=False,
+            enable_self_hosted_llm=False,
             enable_camembert=True,
         )
 

--- a/tests/unit/argumentation_analysis/test_llm_fallacy_detector.py
+++ b/tests/unit/argumentation_analysis/test_llm_fallacy_detector.py
@@ -199,5 +199,5 @@ class TestFrenchFallacyAdapterDefaults:
             FrenchFallacyAdapter,
         )
 
-        adapter = FrenchFallacyAdapter(enable_camembert=True)
+        adapter = FrenchFallacyAdapter(enable_camembert=True, enable_self_hosted_llm=False)
         assert adapter._camembert is not None


### PR DESCRIPTION
Gate #1336 cluster camembert (8F). Root cause: FrenchFallacyAdapter(enable_camembert=True) without enable_self_hosted_llm=False -> _camembert=None (prod #297 condition L1413). 8 stale tests fixed test-only (0 prod, sanctuaire 2.3.2 compliant). test_camembert_integration 7F/10P->17 passed; test_llm_fallacy_detector 1F/9P->10 passed. test_camembert_invoke 2F=pollution (pass in isolation)->separate hunt. Non-colliding.