### PR TITLE
test(arch): fix collection-order torch pollution + ai_model_id in arch compliance (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/agents/core/quality/test_quality_virtue_detectors.py
+++ b/tests/unit/argumentation_analysis/agents/core/quality/test_quality_virtue_detectors.py
@@ -247,10 +247,33 @@ class TestNeutralizeFaultyTorch:
     "the bug shipped because nothing asserted the dispatch".
     """
 
+    # Sentinel for "torch was absent from sys.modules before this test". A bare
+    # ``object()`` instance — distinct from None (which the neutraliser itself
+    # plants as a sentinel) and from any real torch module object.
+    _TORCH_ABSENT = object()
+
+    def setup_method(self) -> None:
+        # Snapshot torch's pre-test state and isolate each test by popping
+        # torch (the tests below assert on torch's absence/sentinel and expect
+        # a clean slate at entry). The snapshot is restored in teardown.
+        self._torch_before = sys.modules.get("torch", self._TORCH_ABSENT)
+        sys.modules.pop("torch", None)
+
     def teardown_method(self) -> None:
         # Restore module-global state between tests.
         qe._TORCH_NEUTRALIZED = False
-        sys.modules.pop("torch", None)
+        # Restore torch to its pre-test state instead of leaving it popped. The
+        # old teardown did a blind pop and never restored — so once this class
+        # had run, sys.modules["torch"] was gone for the rest of the session,
+        # and the next ``import torch`` (transitive, e.g. via french_fallacy_plugin
+        # in test_architecture_compliance) re-imported torch from scratch and hit
+        # the DLL fault (#882) on affected envs. That blind pop was the
+        # collection-order pollution root cause (gate #1336 tail). Restoring the
+        # snapshot keeps a healthy session-start torch available downstream.
+        if self._torch_before is self._TORCH_ABSENT:
+            sys.modules.pop("torch", None)
+        else:
+            sys.modules["torch"] = self._torch_before
 
     def _patched_import(self, behaviour):
         """Return a fake ``__import__`` that applies ``behaviour`` for torch."""

--- a/tests/unit/argumentation_analysis/test_architecture_compliance.py
+++ b/tests/unit/argumentation_analysis/test_architecture_compliance.py
@@ -27,7 +27,13 @@ from semantic_kernel.functions import kernel_function
 def mock_kernel():
     """Kernel with mock OpenAI service for agent tests."""
     kernel = Kernel()
-    service = OpenAIChatCompletion(service_id="default", api_key="test-key")
+    # ai_model_id is required by Semantic Kernel >= 1.40 (CI env). Established
+    # passing pattern (PR #1351 fixed the same omission in test_counter_argument
+    # / test_debate); test_architecture_compliance was missed. The value is
+    # arbitrary — the service is never called, only constructed.
+    service = OpenAIChatCompletion(
+        service_id="default", api_key="test-key", ai_model_id="gpt-4"
+    )
     kernel.add_service(service)
     return kernel
 


### PR DESCRIPTION
Gate #1336 tail dispatch R541. Fixes TestBaseAgentCompliance cluster (4 F+E CI). 2 root causes confirmed firsthand via bisection: (1) TestNeutralizeFaultyTorch teardown blind-popped torch -> destroyed healthy session-start torch -> next import torch (transitive via french_fallacy_plugin) re-imported from scratch -> DLL fault #882. Fix: setup snapshot+pop, teardown restore (pattern #1356). (2) mock_kernel built OpenAIChatCompletion without ai_model_id (SK>=1.40 required) — same family as #1351, arch file was missed. Both needed together. Local bisection: 1 failed -> 20 passed. Test-only, 0 prod. Non-colliding.