### PR TITLE
ci(env): add diskcache to environment.yml — fixes 5 test_llm_cache CI failures (#1336)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -90,3 +90,4 @@ dependencies:
     - hypothesis  # #1303: property tests (tests/property/) — CI collection breaks without it
     - pytest-timeout  # CI hang guard: --timeout=900 in ci.yml converts a hung test into a stack-dumped failure
     - pyfakefs>=5.0.0  # #1336: provides the `fs` fixture for test_plugin_loader.py — CI errors "fixture 'fs' not found" without it
+    - diskcache  # #1336: LLM response cache (llm_cache.py CachedChatCompletion). In requirements.txt but not environment.yml — CI provisions via environment.yml, so diskcache was absent on runners → CachedChatCompletion fell back to OFF mode, failing 5 test_llm_cache tests. Same drift class as pyfakefs (#1353) and hypothesis (#1303).


### PR DESCRIPTION
Gate #1336 tail. diskcache in requirements.txt but not environment.yml -> CI (provisions via env.yml) lacked diskcache -> CachedChatCompletion fell back to OFF -> 5 TestCachedChatCompletion fails (mode='replay' got 'off'). Reproduced firsthand (sys.modules['diskcache']=None). Same drift class as pyfakefs #1353 / hypothesis #1303. 1-line fix. Tally 68->63. Non-colliding.