### PR TITLE
fix(orchestration): wrap _invoke_sat constructor for PySAT-absent degraded result (#1336)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3475,9 +3475,31 @@ async def _invoke_sat(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
     """Invoke SAT solver handler (#86)."""
     from argumentation_analysis.agents.core.logic.sat_handler import SATHandler
 
-    handler = SATHandler(context.get("solver", "cadical195"))
     formulas = context.get("formulas", [input_text] if input_text else [])
     mode = context.get("sat_mode", "solve")  # solve, maxsat, mus
+    try:
+        handler = SATHandler(context.get("solver", "cadical195"))
+    except RuntimeError as exc:
+        # PySAT (python-sat) is an OPTIONAL backend and is not provisioned in
+        # every environment — e.g. the CI env provisions via environment.yml,
+        # which does not list python-sat (it is absent from both environment.yml
+        # and requirements.txt). SATHandler.__init__ fails loud with a
+        # RuntimeError when PYSAT_AVAILABLE is False (#1019). Surface that gap
+        # as a structured degraded result at the orchestration boundary —
+        # honest-degraded, not a raw crash — mirroring the MUS branch below and
+        # every other _invoke_* on solver-absence. The test contract
+        # (test_sat_solve / test_sat_mus_mode) anticipates ``error`` / ``mode``
+        # keys, never an exception escaping the boundary. Same outlier class as
+        # the MUS wrap landed in #1360, one level up (construction, not call).
+        logger.warning("SAT backend unavailable (PySAT not installed): %s", exc)
+        return {
+            "mode": mode,
+            "satisfiable": None,
+            "model": None,
+            "mus_count": 0,
+            "error": str(exc),
+            "statistics": {"handler": "SATHandler", "backend": "pysat-unavailable"},
+        }
     if mode == "mus":
         try:
             mus_list = await asyncio.to_thread(handler.find_mus, formulas)


### PR DESCRIPTION
## Context

Tail #1336 — `external_solvers` cluster (3 résiduels flagged by coord R542). This PR fixes **2 of 3** (TestInvokeSAT). The 3rd (TestSafeFloatEnv::test_valid_numeric_string) is collection-order pollution, deferred — see below.

## Root cause (firsthand via CI junit run `28636216633` at main `981b0c2b`, post-#1360)

`TestInvokeSAT::test_sat_solve` and `test_sat_mus_mode` fail on CI with:
```
RuntimeError: PySAT is not installed. Run: pip install python-sat
```

- **PySAT (python-sat) is OPTIONAL**, absent from BOTH `environment.yml` and `requirements.txt` (only a local undocumented `pysat 1.9.dev2`). CI provisions via `environment.yml` → PySAT absent on runners.
- `SATHandler.__init__` (`sat_handler.py:57-59`) fails loud (`#1019`) when `PYSAT_AVAILABLE` is False. This raises at `_invoke_sat` **construction** (L3478) — **BEFORE** the MUS `try/except` landed by **#1360** (which wraps only the `find_mus` *call*).
- **#1360 is NOT a regression** — it correctly wrapped the MUS call, but the construction-time crash escaped the boundary. po-2025's local env had PySAT → construction succeeded → only the z3/MARCO `find_mus` call raised → #1360's wrap caught it → tests passed locally. CI lacks PySAT → construction raises → both tests crash before the MUS branch.

## Fix (anti-pendule: source = truth, not skip/xfail)

Wrap `SATHandler(...)` construction in `try/except RuntimeError`. On absence, return a structured **degraded dict** (`mode`, `satisfiable=None`, `error`, `statistics`) — consistent with the MUS branch below and every other `_invoke_*` on solver-absence (`#1019`). The test contract (`test_sat_solve`: ``satisfiable in result or error in result``; `test_sat_mus_mode`: ``mode in result``) anticipates keys, never an exception escaping the boundary. Same outlier class as the MUS wrap (#1360), one level up (construction, not call).

## Verification
- **Probe under simulated PySAT absence** (`SATHandler` mocked to raise): both contracts held — SOLVE returns `satisfiable`+`error`, MUS returns `mode`+`error`.
- **Local run** (PySAT present, normal path): `TestInvokeSAT` 2 passed (no regression).
- **mypy strict** `invoke_callables.py`: exit 0 (edited range clean).

## Deferred (1 of 3)
`TestSafeFloatEnv::test_valid_numeric_string` (`assert 10.0 == 42.5`) — **collection-order pollution**. Passes in isolation AND in the full `test_external_solvers.py` file (22 passed locally). Polluter lives in another file (mutates `os.environ` / `_safe_float_env` in a way that survives). Needs full-suite bisection (~13k tests, costly) — same class as `camembert_invoke`. Not rushed; documented for the next round.

Co-Authored-By: Claude-Code <noreply@anthropic.com>