### PR TITLE
test(orchestration): align 5 stale-contract tests with fail-loud doctrine (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_fail_loud_downstream_1019.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_fail_loud_downstream_1019.py
@@ -294,34 +294,32 @@ class TestFormalSynthesisScoring:
 # ---------------------------------------------------------------------------
 
 
-class TestDungPowerSetCap:
-    """Python Dung fallback must skip power-set enumeration for >25 arguments."""
+class TestDungFallbackIsFailLoud:
+    """_python_dung_fallback is a fail-loud stub — pure-Python Dung extension
+    enumeration was removed as anti-theatre (#1019, FP-22 #1249): the previous
+    combinatorial power-set path produced non-empty extension sets without a
+    genuine Tweety reasoner call. The stub raises so no accidental call can
+    enter fabricated results into state. Call sites in _invoke_dung_extensions
+    return honest-absent degraded dicts instead. These tests lock the
+    anti-theatre fix (regression guard) — they replace the old cap-enumeration
+    tests, which asserted the now-excised fabricated behavior.
+    """
 
-    def test_large_argument_set_only_grounded(self):
-        """When >25 arguments, only grounded extension is computed (direct test)."""
+    def test_large_set_raises_fail_loud(self):
+        """For >25 arguments the stub raises (no fabricated extensions)."""
         from argumentation_analysis.orchestration.invoke_callables import (
             _python_dung_fallback,
         )
 
-        # Create 30 arguments — above the 25 cap
+        # 30 arguments — formerly above the 25 power-set cap.
         arguments = [f"arg_{i}" for i in range(30)]
         attacks = [[f"arg_{i}", f"arg_{i+1}"] for i in range(29)]
 
-        result = _python_dung_fallback(arguments, attacks)
+        with pytest.raises(RuntimeError, match="JVM/Tweety required"):
+            _python_dung_fallback(arguments, attacks)
 
-        # Grounded must be present
-        assert "grounded" in result.get("extensions", {}), (
-            "Grounded extension must always be computed"
-        )
-        # Complete/preferred/stable must NOT be present (cap exceeded)
-        exts = result.get("extensions", {})
-        for sem in ("complete", "preferred", "stable"):
-            assert sem not in exts, (
-                f"{sem} should not be computed for n=30 (>25 cap)"
-            )
-
-    def test_at_cap_computes_all_four(self):
-        """When exactly 25 arguments (at cap), all 4 semantics are computed."""
+    def test_at_cap_raises_fail_loud(self):
+        """Even at the old 25-arg cap, no pure-Python path remains — stub raises."""
         from argumentation_analysis.orchestration.invoke_callables import (
             _python_dung_fallback,
         )
@@ -329,13 +327,8 @@ class TestDungPowerSetCap:
         arguments = [f"arg_{i}" for i in range(25)]
         attacks = [[f"arg_{i}", f"arg_{i+1}"] for i in range(24)]
 
-        result = _python_dung_fallback(arguments, attacks)
-
-        exts = result.get("extensions", {})
-        assert "grounded" in exts
-        assert "complete" in exts
-        assert "preferred" in exts
-        assert "stable" in exts
+        with pytest.raises(RuntimeError, match="JVM/Tweety required"):
+            _python_dung_fallback(arguments, attacks)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/argumentation_analysis/orchestration/test_parent_harness_578.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_parent_harness_578.py
@@ -39,7 +39,7 @@ class TestExtractArgumentsForParallel:
         )
 
         context = {
-            "phase_extraction_output": {
+            "phase_extract_output": {
                 "arguments": [
                     {"text": "Argument one is a substantial text for testing purposes here"},
                     {"text": "Argument two is another substantial text for testing"},
@@ -137,14 +137,18 @@ class TestInvokeHierarchicalFallacyPerArgument:
 
     @pytest.mark.asyncio
     async def test_falls_back_to_single_when_no_args(self):
+        """No extractable arguments -> fail-loud skip (FB-36 #1123, anti-recursion).
+
+        The per-argument pass runs AFTER the wide-net descent (its results are
+        merged by the caller at _merge_fallacy_results), so re-entering
+        _invoke_hierarchical_fallacy here is redundant and -- with no splittable
+        input (no state args / no phase_extract_output / no paragraph breaks) --
+        infinite. The function returns a degraded per_argument_skipped_no_args
+        dict instead of recursing; the wide-net result is retained by the caller.
+        """
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_hierarchical_fallacy_per_argument,
         )
-
-        mock_single_result = {
-            "fallacies": [{"fallacy_type": "ad_hominem"}],
-            "exploration_method": "one_shot",
-        }
 
         with patch(
             "argumentation_analysis.orchestration.invoke_callables.os.path.isfile",
@@ -152,13 +156,11 @@ class TestInvokeHierarchicalFallacyPerArgument:
         ), patch(
             "argumentation_analysis.orchestration.invoke_callables._extract_arguments_for_parallel",
             return_value=[],
-        ), patch(
-            "argumentation_analysis.orchestration.invoke_callables._invoke_hierarchical_fallacy",
-            new_callable=AsyncMock,
-            return_value=mock_single_result,
         ):
             result = await _invoke_hierarchical_fallacy_per_argument("short text", {})
-            assert result["fallacies"][0]["fallacy_type"] == "ad_hominem"
+        assert result["exploration_method"] == "per_argument_skipped_no_args"
+        assert result["fallacies"] == []
+        assert result["degraded"] is True
 
     @pytest.mark.asyncio
     async def test_parallel_execution_with_mocked_plugin(self):
@@ -450,7 +452,16 @@ class TestInvokeHierarchicalFallacyPerArgument:
         assert result["fallacies"][0]["fallacy_type"] == "post_hoc"
 
     @pytest.mark.asyncio
-    async def test_no_api_key_returns_unavailable(self):
+    async def test_no_api_key_raises_fail_loud(self):
+        """No API key -> fail-loud RuntimeError (anti-theater #1019/#1046).
+
+        Returning an empty/unavailable dict here would read as "found nothing"
+        and silently starve every downstream layer (Dung/Modal/synthesis feed on
+        fallacies). The function raises PER_ARG_FALLACY_UNAVAILABLE so the caller
+        (wide-net merge) handles the gap explicitly. The no-key failure is
+        simulated at the create_llm_service injection point so the test is
+        hermetic (independent of the real .env / cached settings).
+        """
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_hierarchical_fallacy_per_argument,
         )
@@ -462,9 +473,10 @@ class TestInvokeHierarchicalFallacyPerArgument:
             "argumentation_analysis.orchestration.invoke_callables._extract_arguments_for_parallel",
             return_value=[("arg_1", "A long enough argument text for testing here")],
         ), patch(
-            "argumentation_analysis.orchestration.invoke_callables.os.environ",
-            {"OPENAI_API_KEY": "", "OPENAI_BASE_URL": "", "OPENAI_CHAT_MODEL_ID": ""},
+            "argumentation_analysis.core.llm_service.create_llm_service",
+            side_effect=RuntimeError(
+                "Aucune clé API LLM définie. Définissez OPENAI_API_KEY."
+            ),
         ):
-            result = await _invoke_hierarchical_fallacy_per_argument("text", {})
-            assert result["exploration_method"] == "unavailable"
-            assert result["fallacies"] == []
+            with pytest.raises(RuntimeError, match="PER_ARG_FALLACY_UNAVAILABLE"):
+                await _invoke_hierarchical_fallacy_per_argument("text", {})


### PR DESCRIPTION
Tail #1336 — two clusters, **all stale-contract** (test→prod alignment, anti-pendule compliant: locks the anti-theater fixes, no skip/xfail). Confirmed firsthand via CI junit run \`28636216633\`.

## \`test_fail_loud_downstream_1019.py\` — TestDungPowerSetCap (2F → 0)

\`_python_dung_fallback\` was converted to a **fail-loud RAISE stub** (FP-22 #1249, anti-theater #1019): the previous pure-Python combinatorial power-set enumeration produced non-empty extension sets **without a genuine Tweety reasoner call** — fabricated results. Call sites in \`_invoke_dung_extensions\` now return honest-absent degraded dicts; the stub is kept ONLY to raise on accidental re-entry (**no internal call sites remain** — verified via grep). The 2 tests still asserted the old cap-enumeration behavior (grounded present at n=30, all-four at n=25). Rewritten as **regression guards** asserting \`pytest.raises(RuntimeError, match="JVM/Tweety required")\`. Class renamed \`TestDungPowerSetCap\` → \`TestDungFallbackIsFailLoud\` (honest naming).

## \`test_parent_harness_578.py\` (3F → 0)

1. **test_extracts_from_extraction_output** — context key typo. Prod reads the canonical \`phase_extract_output\` (\`invoke_callables.py:4704\`, *"key matches phase_extract_output used by all other callables"*); the test used the non-existent \`phase_extraction_output\` → empty extraction. Fixed the key.
2. **test_falls_back_to_single_when_no_args** — FB-36 #1123 changed the no-args path from recursing into \`_invoke_hierarchical_fallacy\` (**infinite loop** on non-splittable input — the doc_A spectacular >2h hang) to a fail-loud degraded \`per_argument_skipped_no_args\` dict. Test still asserted the old single-text fallback → \`IndexError\` on empty fallacies. Rewritten to assert the degraded-skip contract.
3. **test_no_api_key_returns_unavailable → test_no_api_key_raises_fail_loud** — #1019/#1046 made the no-key path **RAISE** \`PER_ARG_FALLACY_UNAVAILABLE\` (returning an empty/unavailable dict would silently starve downstream layers). Test expected the graceful dict → \`RuntimeError\`. Rewritten to assert \`pytest.raises(RuntimeError, match="PER_ARG_FALLACY_UNAVAILABLE")\`; the no-key failure is injected hermetically at \`create_llm_service\` (independent of the real \`.env\` / cached settings).

## Verification
Both files run together = **33 passed** locally (parent_harness_578 14 + fail_loud_downstream_1019 19), no regression.

Co-Authored-By: Claude-Code <noreply@anthropic.com>