### PR TITLE
test(config): align fol_solver_selector with mace4 enum + hermetic eprover routing (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/test_fol_solver_selector.py
+++ b/tests/unit/argumentation_analysis/test_fol_solver_selector.py
@@ -141,11 +141,17 @@ class TestSettingsSolverBugFix:
         assert "fol_solver" not in field_names, "fol_solver should not exist"
 
     def test_solver_enum_values(self):
-        """SolverChoice enum should have tweety/prover9/eprover."""
+        """SolverChoice enum should have tweety/prover9/eprover/mace4.
+
+        FP-19 #1243 added Mace4 (LADR model-finder) as a selectable FOL backend
+        — a SEMI-decision procedure for satisfiability (proves CONSISTENT by
+        exhibiting a finite model), the sound complement to the refutation
+        provers EProver/Prover9 (which prove INCONSISTENT).
+        """
         from argumentation_analysis.core.config import SolverChoice
 
         values = {s.value for s in SolverChoice}
-        assert values == {"tweety", "prover9", "eprover"}
+        assert values == {"tweety", "prover9", "eprover", "mace4"}
 
     def test_settings_default_solver_is_eprover(self):
         """Default settings.solver should be SolverChoice.EPROVER (#939)."""
@@ -225,6 +231,14 @@ class TestExternalFOLSolverConsumer:
 
         TweetyBridge and FOLLogicAgent are imported locally inside the function,
         so we must patch their source modules, not invoke_callables.
+
+        Hermicity (#982): _invoke_external_fol_solver gates the eprover branch
+        on `shutil.which("eprover")` — the EProver binary is NOT on PATH in CI
+        (external bundled solver, not installed on runners). Without mocking
+        that probe the function falls through to the TweetyBridge path and the
+        routing-under-test never executes. We mock shutil.which to simulate a
+        present EProver binary so the test exercises the eprover branch
+        deterministically, independent of the runner's PATH.
         """
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_external_fol_solver,
@@ -242,6 +256,9 @@ class TestExternalFOLSolverConsumer:
         mock_bridge.check_consistency = MagicMock(return_value=(True, "consistent"))
 
         with patch(
+            "argumentation_analysis.orchestration.invoke_callables.shutil.which",
+            return_value="/usr/local/bin/eprover",
+        ), patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             return_value=mock_bridge,
         ), patch(
@@ -294,7 +311,17 @@ class TestExternalFOLSolverConsumer:
         assert result.get("solver") in ("prover9", "tweety_fallback", "tweety")
 
     async def test_default_eprover_uses_eprover_branch(self):
-        """When context has no fol_solver, default eprover path should be used (#939)."""
+        """When context has no fol_solver, default eprover path should be used (#939).
+
+        Hermicity (#982, #900): two probes must be mocked here. (1) The EProver
+        binary gate `shutil.which("eprover")` — CI runners lack the bundled
+        external solver. (2) The settings fallback: with no context override the
+        function reads `str(settings.solver)`, which reflects the real .env /
+        pydantic-settings defaults (tweety on many envs) and would route away
+        from eprover regardless of the binary probe. We force settings.solver to
+        the #939 default ("eprover") so the test exercises the default-eprover
+        routing deterministically, independent of runner config.
+        """
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_external_fol_solver,
         )
@@ -309,7 +336,16 @@ class TestExternalFOLSolverConsumer:
         mock_bridge = MagicMock()
         mock_bridge.check_consistency = MagicMock(return_value=(True, "OK"))
 
+        mock_settings = MagicMock()
+        mock_settings.solver = "eprover"
+
         with patch(
+            "argumentation_analysis.orchestration.invoke_callables.shutil.which",
+            return_value="/usr/local/bin/eprover",
+        ), patch(
+            "argumentation_analysis.core.config.settings",
+            mock_settings,
+        ), patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             return_value=mock_bridge,
         ), patch(
@@ -320,8 +356,8 @@ class TestExternalFOLSolverConsumer:
             })
             result = await _invoke_external_fol_solver("test formula", context)
 
-        # Default eprover path → eprover (or tweety_fallback if eprover unavailable)
-        assert result.get("solver") in ("eprover", "tweety_fallback")
+        # Default eprover path → eprover (binary present + settings default via mock)
+        assert result.get("solver") == "eprover"
         assert result.get("logic_type") == "first_order"
 
     async def test_no_context_falls_back_gracefully(self):


### PR DESCRIPTION
Tail #1336 — \`test_fol_solver_selector\` cluster (3F → 0). All stale-contract / hermeticity (test→prod alignment, anti-pendule compliant: no skip/xfail). Confirmed firsthand via CI junit run \`28636216633\`.

## \`test_solver_enum_values\` — stale-contract (FP-19 #1243)
\`SolverChoice\` gained a 4th member \`MACE4 = "mace4"\` (FP-19 #1243: Mace4 LADR model-finder — a SEMI-decision procedure for satisfiability, proves CONSISTENT by exhibiting a finite model; the sound complement to EProver/Prover9 which prove INCONSISTENT). Test still asserted the 3-value set. Aligned to the 4-value set.

## \`test_context_eprover_routes_to_eprover_branch\` + \`test_default_eprover_uses_eprover_branch\` — hermeticity (#982, #900)
Both failed on CI with \`assert 'tweety' == 'eprover'\`. **Root cause is NOT a prod bug** — the eprover branch in \`_invoke_external_fol_solver\` is gated on \`shutil.which("eprover")\` (\`invoke_callables.py:7385\`), and the EProver binary is a **bundled external solver NOT installed on CI runners**. So \`eprover_available=False\` → eprover branch (L7388) skipped → falls through to TweetyBridge (L7461, \`solver="tweety"\`). The tests mocked \`TweetyBridge\` + \`FOLLogicAgent\` but **not the binary probe** → they only passed on envs where EProver happens to be on PATH.

**Fix**: mock \`shutil.which\` to simulate a present EProver binary → exercises the eprover routing branch deterministically, independent of runner PATH. For \`test_default_eprover_uses_eprover_branch\`, additionally mock \`settings.solver="eprover"\` (#939 default) — without it, the no-context path reads the real pydantic-settings default (tweety on many envs) and routes away from eprover regardless of the binary probe.

**Prod routing is correct and unchanged**: route to EProver ONLY when the binary is available (#982 genuine-solver gate, #1019 anti-theater — never claim an external verdict without the real solver).

## Verification
Full file **23 passed** locally (was 20P+3F), 0 regression.

Co-Authored-By: Claude-Code <noreply@anthropic.com>