### PR TITLE
test(metrics): align track_mm keys + formalagent FOL-default wording (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/test_fol_solver_selector.py
+++ b/tests/unit/argumentation_analysis/test_fol_solver_selector.py
@@ -141,11 +141,17 @@ class TestSettingsSolverBugFix:
         assert "fol_solver" not in field_names, "fol_solver should not exist"
 
     def test_solver_enum_values(self):
-        """SolverChoice enum should have tweety/prover9/eprover."""
+        """SolverChoice enum should have tweety/prover9/eprover/mace4.
+
+        FP-19 #1243 added Mace4 (LADR model-finder) as a selectable FOL backend
+        — a SEMI-decision procedure for satisfiability (proves CONSISTENT by
+        exhibiting a finite model), the sound complement to the refutation
+        provers EProver/Prover9 (which prove INCONSISTENT).
+        """
         from argumentation_analysis.core.config import SolverChoice
 
         values = {s.value for s in SolverChoice}
-        assert values == {"tweety", "prover9", "eprover"}
+        assert values == {"tweety", "prover9", "eprover", "mace4"}
 
     def test_settings_default_solver_is_eprover(self):
         """Default settings.solver should be SolverChoice.EPROVER (#939)."""
@@ -225,6 +231,14 @@ class TestExternalFOLSolverConsumer:
 
         TweetyBridge and FOLLogicAgent are imported locally inside the function,
         so we must patch their source modules, not invoke_callables.
+
+        Hermicity (#982): _invoke_external_fol_solver gates the eprover branch
+        on `shutil.which("eprover")` — the EProver binary is NOT on PATH in CI
+        (external bundled solver, not installed on runners). Without mocking
+        that probe the function falls through to the TweetyBridge path and the
+        routing-under-test never executes. We mock shutil.which to simulate a
+        present EProver binary so the test exercises the eprover branch
+        deterministically, independent of the runner's PATH.
         """
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_external_fol_solver,
@@ -242,6 +256,9 @@ class TestExternalFOLSolverConsumer:
         mock_bridge.check_consistency = MagicMock(return_value=(True, "consistent"))
 
         with patch(
+            "argumentation_analysis.orchestration.invoke_callables.shutil.which",
+            return_value="/usr/local/bin/eprover",
+        ), patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             return_value=mock_bridge,
         ), patch(
@@ -294,7 +311,17 @@ class TestExternalFOLSolverConsumer:
         assert result.get("solver") in ("prover9", "tweety_fallback", "tweety")
 
     async def test_default_eprover_uses_eprover_branch(self):
-        """When context has no fol_solver, default eprover path should be used (#939)."""
+        """When context has no fol_solver, default eprover path should be used (#939).
+
+        Hermicity (#982, #900): two probes must be mocked here. (1) The EProver
+        binary gate `shutil.which("eprover")` — CI runners lack the bundled
+        external solver. (2) The settings fallback: with no context override the
+        function reads `str(settings.solver)`, which reflects the real .env /
+        pydantic-settings defaults (tweety on many envs) and would route away
+        from eprover regardless of the binary probe. We force settings.solver to
+        the #939 default ("eprover") so the test exercises the default-eprover
+        routing deterministically, independent of runner config.
+        """
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_external_fol_solver,
         )
@@ -309,7 +336,16 @@ class TestExternalFOLSolverConsumer:
         mock_bridge = MagicMock()
         mock_bridge.check_consistency = MagicMock(return_value=(True, "OK"))
 
+        mock_settings = MagicMock()
+        mock_settings.solver = "eprover"
+
         with patch(
+            "argumentation_analysis.orchestration.invoke_callables.shutil.which",
+            return_value="/usr/local/bin/eprover",
+        ), patch(
+            "argumentation_analysis.core.config.settings",
+            mock_settings,
+        ), patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             return_value=mock_bridge,
         ), patch(
@@ -320,8 +356,8 @@ class TestExternalFOLSolverConsumer:
             })
             result = await _invoke_external_fol_solver("test formula", context)
 
-        # Default eprover path → eprover (or tweety_fallback if eprover unavailable)
-        assert result.get("solver") in ("eprover", "tweety_fallback")
+        # Default eprover path → eprover (binary present + settings default via mock)
+        assert result.get("solver") == "eprover"
         assert result.get("logic_type") == "first_order"
 
     async def test_no_context_falls_back_gracefully(self):

--- a/tests/unit/argumentation_analysis/test_formalagent_fol_default.py
+++ b/tests/unit/argumentation_analysis/test_formalagent_fol_default.py
@@ -13,15 +13,29 @@ import pytest
 class TestFormalAgentFOLDefault:
 
     def test_fol_is_default_translation(self):
-        """FormalAgent should start with FOL, not PL."""
+        """FormalAgent should start with FOL, not PL.
+
+        Post-CONV-C (#1345) the ETAPE 1 wording evolved from the single-shot
+        "commence par translate_to_fol" to a 2-pass coordinated flow that builds
+        a shared signature first. The FOL-default INTENT is preserved: FOL
+        formulas are generated BEFORE PL in ETAPE 1 (generate_fol_formulas
+        precedes generate_pl_formulas), and translate_to_fol remains the
+        no-shared-inventory fallback. We assert the current primary FOL path +
+        the fallback rather than the retired word-level phrase.
+        """
         from argumentation_analysis.orchestration.conversational_orchestrator import (
             AGENT_CONFIG,
         )
 
         instructions = AGENT_CONFIG["FormalAgent"]["instructions"]
-        # ETAPE 1 should say "commence par translate_to_fol"
+        # FOL is generated first in the 2-pass coordinated ETAPE 1 (#1345)
+        assert "generate_fol_formulas_with_shared_signature" in instructions
+        # translate_to_fol remains the fallback when no shared inventory exists
         assert "translate_to_fol" in instructions
-        assert "commence par translate_to_fol" in instructions
+        # FOL generation must appear before PL generation (FOL is the default)
+        assert instructions.index("generate_fol_formulas") < instructions.index(
+            "generate_pl_formulas"
+        )
 
     def test_pl_is_fallback(self):
         """PL should be listed as fallback when FOL fails."""

--- a/tests/unit/argumentation_analysis/test_track_mm_formal_recall.py
+++ b/tests/unit/argumentation_analysis/test_track_mm_formal_recall.py
@@ -89,6 +89,7 @@ class TestPLMetricsPresent:
             "post_sanitize",
             "post_tweety",
             "wide_net_extras",
+            "isolation_survivors",
         }
         assert expected_keys == set(metrics.keys())
 
@@ -189,6 +190,8 @@ class TestFOLMetricsPresent:
             "pass2_candidates",
             "fallback_nl",
             "template",
+            "pre_sanitize",
+            "post_sanitize",
             "pre_tweety",
             "post_tweety",
             "isolation_survivors",


### PR DESCRIPTION
Tail #1336 — 3 stale-contract fixes (test→prod alignment, anti-pendule compliant: no skip/xfail). Confirmed firsthand via CI junit run \`28645078770\` (main \`75d31420\`).

## \`test_track_mm_formal_recall\` — 2 set-exact metrics contracts (2F → 0)
The PL/FOL pipeline metrics dicts gained keys as instrumentation matured, but the two \`*_metrics_all_keys\` tests asserted **exact** sets. The prod initializers are the source of truth (\`invoke_callables.py:5033\` pl_metrics, \`:5458\` fol_metrics); tests now mirror them:
- **PL**: add \`isolation_survivors\` (set at :5396). 9 → 10 keys.
- **FOL**: add \`pre_sanitize\` (:5752) + \`post_sanitize\` (:5778), the FOL counterparts of the PL sanitize counters. 9 → 11 keys.

## \`test_formalagent_fol_default::test_fol_is_default_translation\` — prompt rewrite (1F → 0)
The ETAPE 1 wording retired the exact phrase \`"commence par translate_to_fol"\` when CONV-C (#1345) restructured FormalAgent into a 2-pass coordinated flow. **The FOL-default INTENT is preserved**: FOL formulas are generated BEFORE PL in ETAPE 1, with \`translate_to_fol\` kept as the no-shared-inventory fallback. The assertion now checks the current primary FOL path (\`generate_fol_formulas_with_shared_signature\`), the fallback (\`translate_to_fol\`), AND that FOL generation precedes PL generation (ordinal check) — a **stricter** capture of "FOL is default" than the retired word match.

## Deferred (documented, NOT aligned blind — anti-pendule)
- \`test_fol_rationale_present\`: asserts the prompt explains WHY FOL is default (\`"logique par defaut"\` + \`"predicats/relations"\`). That rationale was **dropped by the #1345 rewrite**. Restoring it is an agent-behavior change (prompt engineering) outside pure test-debt → **flagged for coord decision** (restore rationale vs accept loss), not aligned blind.
- \`test_template_counter\` (track_mm, 3rd fail): \`RuntimeError: all Tweety solvers failed for 9 formulas\` on the template fallback path. **Potential prod gap** (template formulas rejected by Tweety) — needs JVM-up investigation, not a blind skip.

## Verification
3 targeted tests pass locally, 0 regression.

Co-Authored-By: Claude-Code <noreply@anthropic.com>