### PR TITLE
fix(conv-b): repair the Dung deciding kernel_function contract (#1333)

### DIFF
--- a/argumentation_analysis/plugins/tweety_logic_plugin.py
+++ b/argumentation_analysis/plugins/tweety_logic_plugin.py
@@ -102,12 +102,22 @@ class TweetyLogicPlugin:
     def analyze_dung_framework(self, input: str) -> str:
         params = _parse_json_or_default(input, {"arguments": [], "attacks": []})
         from argumentation_analysis.agents.core.logic.af_handler import AFHandler
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
 
-        handler = AFHandler()
+        # CONV-B #1333 (po-2025): AFHandler requires an ``initializer_instance``
+        # (af_handler.py:38) and exposes ``analyze_dung_framework`` -- NOT
+        # ``compute_extensions``. Same dead-cable bug class as the modal decider
+        # (#1371): the previous call constructed the handler with no args
+        # (TypeError) and invoked a nonexistent method (AttributeError), so the
+        # FormalAgent's prescribed ETAPE 3 (Dung analysis) crashed at call time.
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        handler = AFHandler(initializer)
         args = params.get("arguments", [])
         attacks = params.get("attacks", [])
         semantics = params.get("semantics", "preferred")
-        result = handler.compute_extensions(args, attacks, semantics)
+        result = handler.analyze_dung_framework(args, attacks, semantics)
         return json.dumps(result, default=str)
 
     # ── Propositional Logic ───────────────────────────────────────────

--- a/tests/unit/argumentation_analysis/plugins/test_conv_b_kernel_deciders.py
+++ b/tests/unit/argumentation_analysis/plugins/test_conv_b_kernel_deciders.py
@@ -138,3 +138,27 @@ class TestConvBKernelDeciders:
         assert (
             isinstance(solver, str) and solver
         ), f"modal verdict must name its solver (genuine-solver #1019): {result}"
+
+    def test_dung_decider_produces_extensions(self, plugin: TweetyLogicPlugin):
+        """CONV-B #1333 (po-2025): the Dung decider (FormalAgent ETAPE 3) must
+        produce extensions, not crash. Same dead-cable bug class as the modal
+        decider (#1371): ``AFHandler()`` missing ``initializer_instance`` +
+        nonexistent ``compute_extensions`` method. The repaired contract
+        constructs ``AFHandler(TweetyInitializer())`` and calls
+        ``analyze_dung_framework``.
+        """
+        # A trivially grounded framework: one argument, no attacks -> the
+        # argument is in every extension under preferred semantics.
+        result = _parsed(
+            plugin.analyze_dung_framework(
+                '{"arguments": ["a"], "attacks": [], "semantics": "preferred"}'
+            )
+        )
+        assert isinstance(
+            result, dict
+        ), f"Dung decider must return a JSON object, got {type(result).__name__}: {result}"
+        assert (
+            result.get("error") != "JVM not available"
+        ), "Dung decider unreachable (JVM short-circuit)"
+        # The repaired contract returns {semantics, extensions, statistics}.
+        assert "extensions" in result, f"Dung decider produced no extensions: {result}"


### PR DESCRIPTION
## What

Follow-up to #1371 on the same CONV-B #1333 track. `analyze_dung_framework` is the FormalAgent's prescribed **ETAPE 3** (`conversational_orchestrator.py:273-279`) — on the same critical tool-call path as the 3 deciders fixed in #1371. It had the **same dead-cable bug class** as the modal decider:

- `AFHandler()` constructed with **no `initializer_instance`** (`af_handler.py:38` requires it) → `TypeError`
- call to **nonexistent `compute_extensions`** (`AFHandler` exposes `analyze_dung_framework`) → `AttributeError`

Same lesson **R319-R321**: registration + instructions != working cable. The FormalAgent's ETAPE 3 crashed at call time, so Dung analysis never produced a verdict via tool-call.

## Fix

Construct `AFHandler(TweetyInitializer())` and call `analyze_dung_framework`. The handler is fail-loud (`RuntimeError` on Java exception, no fabricated extensions — anti-theater #1019).

## Validation

- **4 tests green** (JVM up): the new `test_dung_decider_produces_extensions` asserts a real `{semantics, extensions, statistics}` verdict on a trivially-grounded framework (1 arg, no attacks → in every preferred extension).
- **mypy strict 41 → 39** on the plugin (0 new errors; the fix removes 2 pre-existing).
- **black** clean.

## Scope / Does NOT close CONV-B

CONV-B #1333 DoD #1 requires a verdict produced **via tool-call in an `AgentGroupChat`**. This PR removes a **4th dead cable** on the FormalAgent's tool path (after the 3 deciders in #1371). The **residual gap** for DoD #1 is in the **orchestrator**, not the plugin: the full scoping (VERIFIED firsthand) is posted on issue #1333 (comment issuecomment-4874781510) — the deciders sit at the *last, conditional* step of a 4-stage cascade capped by `maximum_auto_invoke_attempts=5`, so the budget is exhausted before ETAPE 2/3 are reached, and the deterministic post-processor backstop bypasses the plugin entirely.

**Arch decision pending coordinator**: raise `maximum_auto_invoke_attempts` (option i-a, minimal) vs foreground a decider turn (i-b) vs split FormalAgent (ii). This PR stays in the plugin scope (no orchestrator changes, no budget/budget-radius risk).

Refs: #1333 #1371 #1019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)