### PR TITLE
test(sherlock): point scenarios tests at archived doc path (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/test_sherlock_scenarios.py
+++ b/tests/unit/argumentation_analysis/test_sherlock_scenarios.py
@@ -66,7 +66,11 @@ class TestScenarioRunner:
     def test_scenarios_doc_exists(self):
         from pathlib import Path
 
-        path = Path("docs/sherlock/scenarios.md")
+        # PR #449 archived docs/sherlock/scenarios.md to docs/archives/.
+        # The scenario doc still exists (and still uses opaque IDs — see
+        # TestScenarioPrivacy); only its path moved. Update the assertion to
+        # the live location so the existence + privacy coverage is preserved.
+        path = Path("docs/archives/sherlock/scenarios.md")
         assert path.exists()
 
     def test_scenario_definitions_valid(self):
@@ -146,7 +150,9 @@ class TestScenarioPrivacy:
         """Scenarios doc uses only opaque IDs."""
         from pathlib import Path
 
-        content = Path("docs/sherlock/scenarios.md").read_text(encoding="utf-8")
+        # PR #449 archived docs/sherlock/scenarios.md to docs/archives/.
+        # The privacy coverage (opaque IDs, no plaintext leak) is unchanged.
+        content = Path("docs/archives/sherlock/scenarios.md").read_text(encoding="utf-8")
         assert "doc_A" in content
         assert "doc_B" in content
         assert "doc_C" in content


### PR DESCRIPTION
Tail #1336 — \`test_sherlock_scenarios\` cluster (2F → 0). Stale-contract path fix (anti-pendule compliant: coverage preserved, no skip/xfail). Confirmed firsthand via CI junit run \`28645078770\` + git history.

## Root cause
Both failing tests reference \`docs/sherlock/scenarios.md\`:
- \`TestScenarioRunner::test_scenarios_doc_exists\` — \`assert path.exists()\`
- \`TestScenarioPrivacy::test_no_plaintext_in_docs\` — \`read_text()\`

That path no longer exists: **PR #449** (commit \`e016e59b\`, *"chore(docs): archive stale documentation"*) moved the file to \`docs/archives/sherlock/scenarios.md\`. The file itself is **intact** (verified: opaque IDs \`doc_A\`/\`doc_B\`/\`doc_C\` present ×7, **0 plaintext leak** — \`"discours complet"\`/\`"texte integral"\` absent). Only the path the tests hardcode is stale.

## Fix
Align both tests to the live location \`docs/archives/sherlock/scenarios.md\`. The coverage they provide is **unchanged**: the existence check and the privacy scrub (opaque IDs, no plaintext) still run against the real file content.

## Verification
Full \`test_sherlock_scenarios.py\` = **7 passed** (was 5P+2F), no regression.

Co-Authored-By: Claude-Code <noreply@anthropic.com>