### PR TITLE
fix(conv-b): raise FormalAgent auto-invoke cap to reach the deciding kernel_functions (#1333 DoD #1)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -469,7 +469,18 @@ def create_conversational_agents(
             plugins=plugins,
             function_choice_behavior=FunctionChoiceBehavior.Auto(
                 auto_invoke_kernel_functions=True,
-                maximum_auto_invoke_attempts=5,
+                # CONV-B #1333 DoD #1 (po-2025, dispatch R545): the FormalAgent's
+                # prescribed 4-stage cascade is ETAPE 0 (3 tool-calls: snapshot +
+                # extract_shared_pl_atoms + extract_shared_fol_signature) -> ETAPE 1
+                # (>=2: generate_fol_formulas + generate_pl_formulas + store) ->
+                # ETAPE 2 (up to 4 deciders: PL/FOL/modal/Dung). A cap of 5 starves
+                # the descent: the budget is exhausted at ETAPE 0+1 before the
+                # deciding kernel_functions (#1371/#1374) are ever reached mid-turn,
+                # so the FormalAgent answers from parametric knowledge instead of
+                # invoking a solver (the CONV-A #1332 "tagheur"). 12 covers the
+                # full cascade (3+3+4=10) with a small margin; a hard bound (not
+                # unlimited) still guards against a runaway tool-call loop.
+                maximum_auto_invoke_attempts=12,
             ),
         )
         agents.append(agent)


### PR DESCRIPTION
## What

**Item A of dispatch R544/R545 (DoD #1 of CONV-B #1333).** `maximum_auto_invoke_attempts` was **5**, which starves the FormalAgent's prescribed 4-stage cascade:

- **ETAPE 0**: 3 tool-calls (`get_current_state_snapshot` + `extract_shared_pl_atoms` + `extract_shared_fol_signature`)
- **ETAPE 1**: ≥2 tool-calls (`generate_fol_formulas_with_shared_signature` + `generate_pl_formulas_with_shared_atoms` + `add_nl_to_logic_translation`)
- **ETAPE 2**: the **deciding kernel_functions** (`check_propositional_consistency` / `check_fol_consistency` / `check_modal_satisfiability` / `analyze_dung_framework`, repaired in #1371/#1374)

ETAPE 0 + ETAPE 1 already exhaust the 5-attempt budget **before** ETAPE 2 is reached. The FormalAgent then answers consistency/satisfiability from **parametric knowledge** instead of invoking a solver — exactly the CONV-A #1332 *tagheur* (the verified scoping is on issue #1333, comment issuecomment-4874781510).

## Fix

Raise the cap to **12** = the full cascade (3 + 3 + 4) + small margin. **Dimensioned from the cascade, not a round number.** A hard bound (not unlimited) still guards against a runaway tool-call loop (dispatch R545 anti-pendule: *garde une borne*).

Coordinator R545 confirmed this is **doctrine-aligned subtraction** (lift a mechanical ceiling that starved the agent descent), not a workaround — `[[project_determinization_structural_drift]]`.

## Validation

- Module imports cleanly; **8 tests green** in `test_formalagent_fol_default.py` (instructions untouched).
- **Surgical diff** (+12 −1, only the FCB block + explanatory comment).

## Does NOT by itself close DoD #1

The bump alone is not the proof (dispatch R545: *le bump SEUL ne prouve rien*). A **smoke run capturing the tool-call trace** on corpus_A is the DoD evidence. That run is captured in a follow-up and reported on the issue/dashboard. This PR ships the fix; the trace ships the proof.

Refs: #1333 #1371 #1374 #1332 #1019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)