### PR TITLE
fix(run-orchestration): bootstrap sys.path before first package import (#1336)

### DIFF
--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -27,14 +27,30 @@ Exemples :
     python argumentation_analysis/run_orchestration.py --text "Mon argument" --mode conversational
 """
 
+import sys
+from pathlib import Path
+
+# Bootstrap sys.path BEFORE any ``argumentation_analysis.*`` import (#883, #1336).
+# When executed as ``python argumentation_analysis/run_orchestration.py``,
+# sys.path[0] is the script directory (argumentation_analysis/), so the
+# ``argumentation_analysis`` package itself is unresolvable until the project
+# root is added. This MUST precede the dll_guard import below, otherwise the
+# bare-subprocess invocation (no PYTHONPATH, no editable install — the CI
+# condition) fails at the first line with ModuleNotFoundError. This is the
+# root cause the test_run_orchestration subprocess tests assert against.
+current_dir = Path(__file__).parent
+project_root = current_dir.parent
+if str(current_dir) not in sys.path:
+    sys.path.append(str(current_dir))
+if str(project_root) not in sys.path:
+    sys.path.append(str(project_root))
+
 import argumentation_analysis.core.dll_guard  # noqa: F401 — must load before jpype (#1019)
 
-import sys
 import json
 import asyncio
 import argparse
 import logging
-from pathlib import Path
 from typing import Any, Dict, Optional
 
 # Ensure .env is loaded BEFORE any other import that might need API keys
@@ -44,14 +60,6 @@ try:
     load_dotenv()
 except ImportError:
     pass
-
-# Ajouter les répertoires au chemin de recherche des modules
-current_dir = Path(__file__).parent
-project_root = current_dir.parent
-if str(current_dir) not in sys.path:
-    sys.path.append(str(current_dir))
-if str(project_root) not in sys.path:
-    sys.path.append(str(project_root))
 
 
 def setup_logging(verbose: bool = False) -> None:


### PR DESCRIPTION
Part of #1336 tail (Epic #1355 ATT-1). Tally: 2F resolved (`test_help_flag_works`, `test_list_workflows_no_import_error`).

## Context
The CI tests `test_help_flag_works` and `test_list_workflows_no_import_error` execute the CLI as a bare subprocess `python argumentation_analysis/run_orchestration.py --help`. On CI this exits 1 with `ModuleNotFoundError: No module named 'argumentation_analysis'` — the exact #883 failure mode the tests guard against.

## Verdict par échec (firsthand) — prod bug (not test-périmé)
**Root cause:** `run_orchestration.py` had `import argumentation_analysis.core.dll_guard` (L30) BEFORE the #883 sys.path bootstrap (L48) that adds the project root. When run as a bare subprocess (`sys.path[0]` = script dir, no PYTHONPATH, no editable install — the CI condition), the import fails at the first line before the bootstrap can run.

**Proof (CI condition reproduced locally):** masked on dev machines by the editable install (`__editable__.argumentation_analysis_project-0.1.0.pth` + MetaPathFinder). Reproduced the true CI condition by disabling that finder + clearing project root from `sys.path` + clearing `sys.modules` cache:
- OLD_ORDER → `ModuleNotFoundError: No module named 'argumentation_analysis'` (exact CI error)
- FIXED_ORDER → `dll_guard imported OK`

## Change
Relocate the sys.path bootstrap (pure `sys.path.append`) to precede the `dll_guard` import. `dll_guard` still loads before `jpype` (#1019 unchanged). No test changes; the tests assert correct behavior (#883 intent) and now pass on CI.

## No masking
No skip/xfail. black clean. mypy: 2 pre-existing errors on `main()`/call (L258/L756 → L266/L764 after +8-line shift) unrelated, not introduced here (clean-cache diff verified). HORS `conversational_orchestrator.py`.

Co-Authored-By: Claude <noreply@anthropic.com>