### PR TITLE
test(logic-agent-plugin): align FOL/modal consistency tests with #1380 routing (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/plugins/test_logic_agent_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_logic_agent_plugin.py
@@ -267,8 +267,12 @@ class TestFOLMethods:
             result = json.loads(plugin.check_fol_consistency("forall X: p(X)"))
 
         assert result["is_consistent"] is True
+        # CONV-B #1333 (#1380): the plugin now routes FOL through
+        # ``logic_type="first_order"`` (the code TweetyBridge.check_consistency
+        # actually dispatches to FOLHandler). The old "fol" code fell to the
+        # else-branch and returned a fabricated "Unknown logic type: fol".
         bridge.check_consistency.assert_called_once_with(
-            "forall X: p(X)", logic_type="fol"
+            "forall X: p(X)", logic_type="first_order"
         )
 
 
@@ -322,7 +326,11 @@ class TestModalMethods:
         assert result["logic_type"] == "T"
         bridge.check_consistency.assert_called_once()
         call_kwargs = bridge.check_consistency.call_args
-        assert "modal_t" in call_kwargs[1]["logic_type"]
+        # CONV-B #1333 (#1380): the plugin now forwards the BARE modal logic
+        # code ("T") -- TweetyBridge.check_consistency routes ["K","T","S4","S5"]
+        # directly. The old f"modal_{logic_type.lower()}" (e.g. "modal_t") fell
+        # to the else-branch and returned a fabricated "Unknown logic type".
+        assert call_kwargs[1]["logic_type"] == "T"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context — #1336 tail (CI debt triage)

While cross-verifying po-2025's PR #1382 (CONV-B DoD #1), its CI run (`28666401216`) showed 2 failures in `test_logic_agent_plugin.py` that are **NOT present in the #1381 baseline**:
- `TestFOLMethods::test_check_fol_consistency`
- `TestModalMethods::test_check_modal_consistency`

## Verdict par échec (firsthand)

**Pre-existing on main `e92f76cf` — NOT caused by #1382.**

I ran both tests on clean main (this branch's base) — they fail identically. They are a **stale-contract** left by **#1380** (merged today), which deliberately changed the `logic_type` codes `LogicAgentPlugin` forwards to `TweetyBridge.check_consistency`:

| Method | Old code (buggy) | New code (#1380) | Why |
|--------|------------------|------------------|-----|
| `check_fol_consistency` | `logic_type="fol"` | `logic_type="first_order"` | TweetyBridge routes `"first_order"` to FOLHandler; `"fol"` fell to the else-branch → fabricated `"Unknown logic type: fol"` |
| `check_modal_consistency` | `f"modal_{lt}"` (e.g. `"modal_t"`) | bare `"T"`/`"S5"` | TweetyBridge routes bare codes `["K","T","S4","S5"]`; `"modal_t"` fell to the else-branch → fabricated `"Unknown logic type: modal_t"` |

Prod source-of-truth (`logic_agent_plugin.py:211-216` and `295-306`) carries explicit `# CONV-B #1333` comments confirming the bare codes are the deliberate contract. The two plugin tests still asserted the old (buggy) codes.

#1382 only edits `conversational_orchestrator.py` instruction text (and one assertion in `test_formalagent_fol_default.py`) — it does **not** touch `test_logic_agent_plugin.py`, so these 2 failures are independent of it. **#1382 is clean** (0 new failures) and clear to merge.

## Fix — pure test alignment (anti-pendule)

The fix was in prod (#1380); the tests follow. Two minimal assertion updates, no prod change:

- `test_check_fol_consistency`: `logic_type="fol"` → `logic_type="first_order"`
- `test_check_modal_consistency`: `assert "modal_t" in ...` → `assert call_kwargs[1]["logic_type"] == "T"`

## Verification

```
tests/unit/argumentation_analysis/plugins/test_logic_agent_plugin.py
  BEFORE: 29 passed, 2 failed
  AFTER:  31 passed
```
No regressions (full file green).

## Files changed
- `tests/unit/argumentation_analysis/plugins/test_logic_agent_plugin.py` — 2 stale assertions aligned to #1380's deliberate routing contract.

## Lane note (transparency)

This test file is adjacent to po-2025's `LogicAgentPlugin` feature area. po-2025's open PR #1382 touches a different file (`conversational_orchestrator.py`), so there is no merge collision. Flagging here so @myia-po-2025 can review/object — if the bare-code contract is intended to change again, this is trivial to revert.

## Privacy
Opaque IDs only. No source content.
