### PR TITLE
test(config): align default-solver test with #940 (EPROVER, not TWEETY) (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/core/test_config.py
+++ b/tests/unit/argumentation_analysis/core/test_config.py
@@ -6,10 +6,11 @@ from unittest.mock import patch
 # ou utiliser importlib.reload pour forcer la relecture.
 
 
-def test_default_solver_is_tweety():
+def test_default_fol_solver_is_eprover():
     """
-    Vérifie que le solveur par défaut est 'tweety' lorsqu'aucune variable
-    d'environnement n'est définie.
+    Vérifie que le solveur FOL par défaut est 'eprover' lorsqu'aucune variable
+    d'environnement n'est définie (#940 : eprover est le défaut robust, tweety
+    est désormais un fallback de dernier recours seulement).
     """
     # S'assurer que la variable d'env n'est pas définie pour ce test
     with patch.dict(os.environ, {}, clear=True):
@@ -17,7 +18,7 @@ def test_default_solver_is_tweety():
 
         # Forcer la relecture du module pour prendre en compte l'environnement mocké
         importlib.reload(config)
-        assert config.settings.solver == config.SolverChoice.TWEETY
+        assert config.settings.solver == config.SolverChoice.EPROVER
 
 
 def test_solver_loads_from_environment_variable():


### PR DESCRIPTION
## Context — #1336 tail (CI debt triage)

Probing which baseline failures reproduce **locally** (actionable) vs CI-only (defer), `test_config.py::test_default_solver_is_tweety` failed locally — reproducible, fixable firsthand.

## Verdict par échec (firsthand)

**Stale-contract left by #940.**

PR #940 (commit `6756c038`, 2026-06-05 — "fix(pipeline): solver defaults — eprover for FOL, spass for modal") deliberately changed the default FOL solver from TWEETY to EPROVER. Prod source-of-truth (`config.py:41-47`):

```python
# 'eprover' (défaut) utilise EProver via Tweety's EFOLReasoner — robust (#939).
# 'prover9' utilise un appel à un processus externe Prover9.
# 'tweety' fallback — SimpleFolReasoner via JPype, last resort only.
solver: SolverChoice = SolverChoice.EPROVER
```

The test still asserted the old default (`SolverChoice.TWEETY`) and was even **named** `test_default_solver_is_tweety`, so it has failed every CI run since #940 landed ~2 months ago.

## Fix — pure test alignment (anti-pendule)

The fix was in prod (#940); the test follows. Minimal change:
- rename `test_default_solver_is_tweety` → `test_default_fol_solver_is_eprover`
- assertion `SolverChoice.TWEETY` → `SolverChoice.EPROVER`
- docstring updated to cite #940

No prod change. The sibling tests (`test_solver_loads_from_environment_variable`, `test_solver_enum_values`) are already correct and untouched.

## Verification

```
tests/unit/argumentation_analysis/core/test_config.py
  BEFORE: 2 passed, 1 failed
  AFTER:  3 passed
```

## Files changed
- `tests/unit/argumentation_analysis/core/test_config.py` — 1 stale test aligned to #940's deliberate EPROVER default.

## Privacy
Opaque IDs only. No source content.
