### PR TITLE
fix(conv-b): route LogicAgentPlugin.validate_formula to the real Tweety codes (#1333)

### DIFF
--- a/argumentation_analysis/plugins/logic_agent_plugin.py
+++ b/argumentation_analysis/plugins/logic_agent_plugin.py
@@ -356,9 +356,13 @@ class LogicAgentPlugin:
             if logic_type == "propositional":
                 is_valid = bridge.validate_pl_formula(formula)
             elif logic_type == "fol":
-                is_valid, _ = bridge.check_consistency(formula, logic_type="fol")
+                # CONV-B #1333 (#1380 follow-up): bridge routes "first_order", not
+                # "fol" (else-branch fabricated "Unknown logic type: fol").
+                is_valid, _ = bridge.check_consistency(formula, logic_type="first_order")
             elif logic_type == "modal":
-                is_valid, _ = bridge.check_consistency(formula, logic_type="modal_k")
+                # CONV-B #1333 (#1380 follow-up): bridge routes BARE modal codes,
+                # not "modal_k" (else-branch fabricated verdict).
+                is_valid, _ = bridge.check_consistency(formula, logic_type="K")
             else:
                 return _error_json(f"Unknown logic_type: {logic_type}")
 

--- a/tests/unit/argumentation_analysis/plugins/test_logic_agent_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_logic_agent_plugin.py
@@ -372,7 +372,7 @@ class TestValidateFormula:
         assert result["is_valid"] is True
         assert result["logic_type"] == "fol"
         bridge.check_consistency.assert_called_once_with(
-            "forall X: p(X)", logic_type="fol"
+            "forall X: p(X)", logic_type="first_order"
         )
 
     def test_validate_modal(self, plugin_and_bridge):
@@ -387,7 +387,7 @@ class TestValidateFormula:
         assert result["is_valid"] is True
         assert result["logic_type"] == "modal"
         bridge.check_consistency.assert_called_once_with(
-            "[](a => b)", logic_type="modal_k"
+            "[](a => b)", logic_type="K"
         )
 
     def test_validate_invalid_formula_returns_false(self, plugin_and_bridge):


### PR DESCRIPTION
## What

Fixes the SAME routing bug #1380 fixed on the consistency deciders, this time on `LogicAgentPlugin.validate_formula` — the path the FormalAgent actually reached in the R535 corpus_A re-run.

## Why (firsthand, from the R535 trace)

The R535 corpus_A re-run (full DoD #1 stack on main) showed the FormalAgent invokes `LogicAgentPlugin-validate_formula` **x2** in conversation (it reaches LogicAgentPlugin but, with `check_*_consistency` still not called, it leans on validate). `validate_formula` had the **identical routing bug** #1380 fixed on the consistency deciders:

```python
elif logic_type == "fol":
    is_valid, _ = bridge.check_consistency(formula, logic_type="fol")      # else-branch!
elif logic_type == "modal":
    is_valid, _ = bridge.check_consistency(formula, logic_type="modal_k")  # else-branch!
```

`TweetyBridge.check_consistency` routes only `"first_order"` (FOL) and the bare codes `["K","T","S4","S5"]` (modal). Both `"fol"` and `"modal_k"` fall to the else-branch → fabricated `(False, "Unknown logic type: ...")`. So the FormalAgent's two conversational `validate_formula` calls silently returned `is_valid=False` **regardless of input** — an anti-theater violation (#1019): the LLM thinks it validated, but it got a fabricated "invalid".

This is the latent note I flagged on #1383 (cross-verify comment): `validate_formula:359` still routed the old codes. That path IS now exercised conversationally (x2 in the trace), so it's no longer theoretical.

## Fix

Route `"first_order"` (FOL) and bare `"K"` (modal) — consistent with #1380 and the `check_*_consistency` deciders. 2 stale test-contracts aligned (same class as #1383). **31 passed**, mypy strict `Success: no issues`.

## Scope

LogicAgentPlugin lane (I'm the #1380 owner). 1 prod method + 2 test assertions. No orchestrator, no behavior change beyond routing the correct codes.

## Relation to DoD #1

This does NOT close DoD #1 (the deciders must still be *invoked*, which strategy (a) #1382 — now merged — targets). But it removes a fabrication on the path the FormalAgent currently uses (validate), so when validate IS called it returns a real verdict. A separate DoD #1 proof-run is in flight on main `273080a0` (full stack #1380+#1378+#1382).

## Privacy

Opaque IDs only; no source names or dataset content.
