### PR TITLE
test(fallacy-tier): give per-arg fail-loud test an extractable-args input (#1123, #1336)

### DIFF
--- a/tests/unit/argumentation_analysis/test_fallacy_tier_selector.py
+++ b/tests/unit/argumentation_analysis/test_fallacy_tier_selector.py
@@ -124,13 +124,28 @@ class TestFallacyTierDispatch:
             _invoke_hierarchical_fallacy_per_argument,
         )
 
+        # FB-36 (#1123): _invoke_hierarchical_fallacy_per_argument extracts
+        # arguments first and SKIPS the per-argument pass (returns a degraded
+        # verdict, no LLM call) when no arguments are extractable. A single
+        # short string like "Some text" produces no arguments, so it never
+        # reaches create_llm_service and the fail-loud RuntimeError never
+        # fires. Provide a 2-paragraph input (each >20 chars, \n\n-separated)
+        # so _extract_arguments_for_parallel Source 3 yields args and the
+        # harness proceeds to the LLM call where the patched ValueError is
+        # re-raised as PER_ARG_FALLACY_UNAVAILABLE.
+        text = (
+            "First argument paragraph long enough to be extracted by the "
+            "paragraph-break heuristic.\n\n"
+            "Second argument paragraph also long enough for extraction."
+        )
+
         with patch(
             "argumentation_analysis.core.llm_service.create_llm_service",
             side_effect=ValueError("No API key configured"),
         ):
             with pytest.raises(RuntimeError, match="PER_ARG_FALLACY_UNAVAILABLE"):
                 await _invoke_hierarchical_fallacy_per_argument(
-                    "Some text", {"fallacy_tier": "llm"}
+                    text, {"fallacy_tier": "llm"}
                 )
 
 


### PR DESCRIPTION
## Context — #1336 tail (CI debt triage, per coord R547 dispatch)

Pulled the authoritative 31 F+E from the valid real run `28674970192` (main `273080a0`, 36min, JVM up). Probed which reproduce **locally** (actionable) vs CI-only (defer). `test_perarg_tier_fail_loud_on_missing_api_key` reproduced locally — fixable firsthand.

## Verdict par échec (firsthand)

**Stale test input, not a prod regression.**

`test_perarg_tier_fail_loud_on_missing_api_key` asserts that `_invoke_hierarchical_fallacy_per_argument` raises `RuntimeError(PER_ARG_FALLACY_UNAVAILABLE)` when `create_llm_service` is unavailable (RA-1 #1046, anti-theater #1019).

It failed because its input `"Some text"` produced **no extractable arguments**. FB-36 (#1123) added an intentional guard to `_invoke_hierarchical_fallacy_per_argument` (`invoke_callables.py:4458`): `_extract_arguments_for_parallel` must return ≥1 argument before the harness reaches `create_llm_service` (`:4499`). With no state args, no `phase_extract_output`, and no `\n\n` paragraph breaks, extraction yields nothing → the guard returns a degraded verdict (wide-net result retained by the caller) → the fail-loud `RuntimeError` never fires.

**The guard is correct** — it prevents the infinite-recursion hang (the doc_A spectacular+full >2h hang, ruled out by FB-35/#1123) when the per-arg pass is invoked after the wide-net descent with no splittable input.

## Fix — test input alignment (anti-pendule)

The prod FB-36 guard is correct; the test must exercise the real fail-loud path. Provide a 2-paragraph input (each >20 chars, `\n\n`-separated) so `_extract_arguments_for_parallel` Source 3 (paragraph-break heuristic, `invoke_callables.py:4738`) yields arguments, the harness proceeds to `create_llm_service`, and the patched `ValueError` is re-raised as `PER_ARG_FALLACY_UNAVAILABLE`. No skip/xfail; no prod change.

## Verification

```
tests/unit/argumentation_analysis/test_fallacy_tier_selector.py
  BEFORE: 19 passed, 1 failed
  AFTER:  20 passed
```

The sibling `test_llm_tier_fail_loud_on_missing_api_key` (a different function, `_invoke_hierarchical_fallacy`, which reaches the LLM call without arg extraction) already passed and is untouched.

## Batch-probe results (prioritization intel)

Also probed 5 other 31-list failures locally — 4 passed locally (CI-only, defer): `test_collaborative_debate::test_no_api_key_uses_fallback`, `test_llm_fallacy_detector::test_is_not_available_without_api_key`, `test_nl_to_logic::test_translate_no_api_key_uses_heuristic`, `test_external_solvers::test_valid_numeric_string` (os.environ trio, CI-only). 1 reproduced but is **po-2025's lane**: `test_formalagent_shared_state` (both tests assert on `conversational_orchestrator.AGENT_CONFIG` instructions, affected by #1382 — flagged for po-2025).

## Files changed
- `tests/unit/argumentation_analysis/test_fallacy_tier_selector.py` — 1 stale test input aligned to the FB-36 #1123 extractable-args guard.

## Lane note
Test targets `invoke_callables.py::_invoke_hierarchical_fallacy_per_argument` — NOT `conversational_orchestrator.py` or `logic_agent_plugin.py` (po-2025's lane). No merge collision.

## Privacy
Opaque, synthetic input. No source content.
