### PR TITLE
test(conv-b): align formalagent-shared-state instruction tests with 2-pass rewrite (#560/#561, #1336)

### DIFF
--- a/tests/unit/argumentation_analysis/test_formalagent_shared_state.py
+++ b/tests/unit/argumentation_analysis/test_formalagent_shared_state.py
@@ -78,7 +78,12 @@ class TestFormalAgentInstructions:
         )
 
         formal_instructions = AGENT_CONFIG["FormalAgent"]["instructions"]
-        assert "atomes partages" in formal_instructions
+        # CONV-B #1336 (#560/#561 follow-up): the 2-pass CoordinatedLogicPlugin
+        # rewrite dropped the bare phrase "atomes partages" -- the shared
+        # inventory is now named "atomes PL partages" / "signature FOL partagee"
+        # (ETAPE 0). Assert the shared concept + the inter-argument coherence
+        # usage it enables (ETAPE 0 step 5).
+        assert "partages" in formal_instructions
         assert "coherence inter-arguments" in formal_instructions
 
     def test_formal_agent_instructions_preserve_existing_etapes(self):
@@ -102,7 +107,13 @@ class TestFormalAgentInstructions:
         )
 
         formal_instructions = AGENT_CONFIG["FormalAgent"]["instructions"]
-        assert "inclus-les" in formal_instructions or "guide" in formal_instructions
+        # CONV-B #1336 (#560/#561 follow-up): the 2-pass rewrite replaced the
+        # prose "inclus-les" with an explicit generator call that takes the
+        # shared atoms as a parameter (ETAPE 1 step 3:
+        # generate_pl_formulas_with_shared_atoms(..., shared_atoms=atoms_json)).
+        # Asserting the parameter name is a STRICTER inclusion check than the
+        # vague "guide"/"inclus-les" prose.
+        assert "shared_atoms" in formal_instructions
 
 
 class TestEndToEndSharedStateFlow:


### PR DESCRIPTION
## What

Aligns 2 stale-contract assertions in `TestFormalAgentInstructions` (`test_formalagent_shared_state.py`) with the current FormalAgent instructions. Flagged by po-2023 R549 as po-2025's lane (impacted area = FormalAgent instructions, my #1382 lane). Tally 31 -> 29 expected (2 F resolved).

## Why (firsthand, verified)

Both assertions failed on clean main `273080a0`:

- `test_formal_agent_instructions_mention_shared_atoms_usage` asserted `"atomes partages"` (exact substring). The instructions say `"atomes PL partages"` / `"signature FOL partagee"` (ETAPE 0) -- the bare phrase is absent.
- `test_formal_agent_instructions_guide_atom_inclusion` asserted `"inclus-les" or "guide"`. Neither is present.

**Not a regression from #1382.** Git pickaxe (`git log -S "atomes partages"`, `git log -S "inclus-les"`) traces both phrases to commits `6eb350a2` (#545) and `c4c3cfb1` (#560/#561). The #1382 diff does NOT touch these phrases -- they were dropped by the 2-pass CoordinatedLogicPlugin rewrite (#560/#561), which replaced the prose with explicit generator calls. po-2023's attribution to #1382 was a correlation (the tests sit in the failing tally alongside the recent merge), not the cause.

## Fix

Same doctrine as #1383 / #1386 / #1387 (stale test contract, prod evolved -> align test to prod, anti-pendule). The tested intent is unchanged and still served by ETAPE 0/1:

- `mention_shared_atoms_usage`: assert `"partages"` (covers "atomes PL partages" + "signature FOL partagee") + keep `"coherence inter-arguments"` (ETAPE 0 step 5, still present).
- `guide_atom_inclusion`: ETAPE 1 step 3 now passes shared atoms as a parameter (`generate_pl_formulas_with_shared_atoms(..., shared_atoms=atoms_json)`). Assert `"shared_atoms"` -- a STRICTER inclusion check than the vague "guide"/"inclus-les" prose.

## Validation

10P (was 8P+2F). `black --check` clean. Diff +13 -2 (2 assertions + explanatory comments only).

## Scope

Test-only, 1 file. No orchestrator change, no behavior change. Different files from #1386 (logic_agent_plugin) -> no collision.

## Relation to DoD #1 / #1336

Does NOT touch DoD #1 (CONV-B #1333, awaiting coord's strict-vs-substantial reading of the R538 proof-run verdict). This is an ATT-1 (#1336 CI-debt) tally fix: 2 of the 31 F+E resolved.

## Privacy

Opaque IDs only; no source names or dataset content.
