### PR TITLE
test(orchestration): align 2 stale phase-count assertions (spectacular 23->40, standard 14->15) (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_pipeline_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_pipeline_wiring.py
@@ -101,9 +101,11 @@ class TestWorkflowFormalPhases:
 
         wf = build_standard_workflow()
         # extract, neural_detect, hierarchical_fallacy, nl_to_logic, pl, fol,
-        # dung_extensions, aspic_analysis, quality, counter, jtms, governance, debate,
-        # local_llm = 14 phases (#835 A-10)
-        assert len(wf.phases) == 14
+        # dung_extensions, aspic_analysis, quality, counter, jtms, governance,
+        # debate, narrative_synthesis, local_llm = 15 phases (#835 A-10 +
+        # narrative_synthesis). The build now emits 15 (narrative_synthesis was
+        # added after this count was last updated).
+        assert len(wf.phases) == 15
 
 
 # ============================================================

--- a/tests/unit/argumentation_analysis/orchestration/test_text_kb_spectacular_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_text_kb_spectacular_wiring.py
@@ -63,7 +63,12 @@ class TestSpectacularWorkflowPhases:
         )
 
         wf = build_spectacular_workflow()
-        assert len(wf.phases) == 23
+        # #1179 (#1178) wired the 4 dormant-reasoner handlers into spectacular,
+        # taking the phase count from 23 (the 3 text-to-kb phases of #506 atop
+        # the original 20) to 40. Sibling tests (test_spectacular_regression_suite,
+        # test_belief_revision_spectacular, test_external_solver_spectacular,
+        # test_spectacular_workflow_dag) already assert 40; this one was missed.
+        assert len(wf.phases) == 40
 
 
 class TestInvokeCallables:


### PR DESCRIPTION
## Context — #1336 tail (CI debt triage, per coord R548 SUITE dispatch)

Coord R548 SUITE answered my ASK: next target = the ~17 unprobed failures, prioritizing "what unblocks the most F at once (e.g. a shared conftest/fixture)." I batch-probed the orchestration cluster locally — found a **stale-contract pair sharing one root cause** (workflow phase-count drift).

## Verdict par échec (firsthand)

Two workflow-wiring tests encode outdated phase counts:

1. **`test_text_kb_spectacular_wiring.py::test_spectacular_phase_count`** — asserts `len(wf.phases) == 23`, prod builds **40**.
2. **`test_pipeline_wiring.py::test_standard_workflow_phase_count`** — asserts `len(wf.phases) == 14`, prod builds **15**.

**Root cause: stale-contract drift, not a prod regression.**

- Spectacular: PR #1179 (#1178 — "fix 4 dormant-reasoner handlers + wire into spectacular") raised the count from 23 (the 3 text-to-kb phases of #506 atop the original 20) to **40**. **Four sibling tests already assert 40** — `test_spectacular_regression_suite:356+684`, `test_belief_revision_spectacular:31`, `test_external_solver_spectacular:48`, `test_spectacular_workflow_dag:41` — this one was missed.
- Standard: `build_standard_workflow()` now emits **15** phases. Confirmed firsthand — the build logs `Built workflow 'standard_analysis' with 15 phases` and the phase list = the test's enumerated 14 (`extract, neural_detect, hierarchical_fallacy, nl_to_logic, pl, fol, dung_extensions, aspic_analysis, quality, counter, jtms, governance, debate, local_llm`) **+ `narrative_synthesis`**.

## Fix — pure stale-contract alignment (anti-pendule)

The prod `build_*_workflow()` is the truth; the test counts follow:
- `test_spectacular_phase_count`: 23 → **40** (comment cites #1179)
- `test_standard_workflow_phase_count`: 14 → **15** (comment adds `narrative_synthesis`)

No skip/xfail, no prod change.

## Verification

```
Targeted tests (the 2 failures): 2P+0F  (were 2F)
```
Firsthand. (The slow sibling tests in the same files are unrelated; the full-file run hit a 2.5min budget on JVM startup, so I ran only the 2 targets.)

## Batch-probe intel (prioritization)

Also probed 3 other 31-list failures locally — all **PASS locally = CI-only, defer**: `test_dashboard` (×2), `test_llm_budget_guard_ll_bis::test_env_override`. No mass-unblock there (CI env divergence, likely secrets/JVM-on-CI). The phase-count pair was the only reproducible cluster.

## Files changed
- `tests/unit/argumentation_analysis/orchestration/test_text_kb_spectacular_wiring.py` — spectacular phase count 23→40.
- `tests/unit/argumentation_analysis/orchestration/test_pipeline_wiring.py` — standard phase count 14→15.

## Lane note
Both target `argumentation_analysis/orchestration/{workflows,unified_pipeline}.py` build contracts — NOT `conversational_orchestrator.py` or `logic_agent_plugin.py` (po-2025's lane). No merge collision.

## Privacy
Opaque phase names only. No source content.
