### PR TITLE
test(tweety-plugins): align ranking methods count with prod (7 -> 12) (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/plugins/test_tweety_plugins.py
+++ b/tests/unit/argumentation_analysis/plugins/test_tweety_plugins.py
@@ -21,7 +21,14 @@ class TestRankingPlugin:
             assert isinstance(result, list)
             assert "categorizer" in result
             assert "burden" in result
-            assert len(result) == 7
+            # RankingPlugin.list_ranking_methods returns
+            # RankingHandler.REASONERS.keys() — the handler now exposes 12
+            # formal ranking methods (categorizer, burden, discussion, counting,
+            # tuples, strategy, propagation, saf, counter_transitivity,
+            # probabilistic_ranking, iterated_graded_defense, serialisable).
+            # The count was 7 when Track A handlers were first added
+            # (7e8c2ce0); it grew as more reasoners were wired in.
+            assert len(result) == 12
 
     def test_rank_arguments_returns_json(self):
         mock_handler = MagicMock()


### PR DESCRIPTION
## Context — #1336 tail (CI debt triage, continuing per coord R548 SUITE)

Batch-probed the plugins cluster (calibration×2, workflow_plugin, tweety_plugins) locally. `test_list_ranking_methods` reproduced — fixable firsthand. (The other 3 are complex mock-driven 2-phase LLM-workflow tests — not trivial stale-contracts; deferred to a dedicated round.)

## Verdict par échec (firsthand)

**Stale-contract, not a prod regression.**

`test_list_ranking_methods` asserts `len(result) == 7`, but the prod `RankingPlugin.list_ranking_methods` returns `RankingHandler.REASONERS.keys()`, and the handler now exposes **12** formal ranking methods. The `ranking_plugin.py` module docstring (lines 3-6) states explicitly:

```
Wraps RankingHandler to expose 12 formal ranking methods
(categorizer, burden, discussion, counting, tuples, strategy, propagation,
saf, counter_transitivity, probabilistic_ranking, iterated_graded_defense,
serialisable) as @kernel_function methods for SK agent integration.
```

The count was 7 when Track A handlers were first added (`7e8c2ce0`) and grew as more reasoners were wired in; this test was not updated.

## Fix — pure stale-contract alignment (anti-pendule)

Prod `REASONERS.keys()` is the truth; the count follows. `7 → 12`. The name-presence assertions (`"categorizer"`, `"burden"`) are kept and still hold.

## Verification

```
test_list_ranking_methods: 1F -> 1P  (firsthand)
```

## Batch-probe intel (plugins cluster)

The other 3 plugins failures reproduce locally too, but they are **complex mock-driven 2-phase LLM-workflow tests** (`test_fallacy_workflow_calibration` simulates a two-phase hierarchical workflow with taxonomy navigation + auto-confirm; `test_one_shot_with_plain_text` is the one-shot fallback path). They fail on mock-contract drift with the evolved plugin, not a trivial count — fixing them well needs a focused round (and they may have non-deterministic elements). Not bundled here to keep this PR surgical.

## Files changed
- `tests/unit/argumentation_analysis/plugins/test_tweety_plugins.py` — ranking methods count 7→12.

## Lane note
Targets `argumentation_analysis/plugins/ranking_plugin.py` (a ranking handler contract) — NOT `conversational_orchestrator.py` or `logic_agent_plugin.py` (po-2025's lane). No merge collision.

## Privacy
Opaque method names only. No source content.
