### PR TITLE
feat(conv-b): translate_to_modal tool + ETAPE wiring (#1391, #1333)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -273,15 +273,24 @@ AGENT_CONFIG = {
             "argument_text='...', shared_atoms=atoms_json)\n"
             "4. Si aucun inventaire partage n'existe (fallback) : utilise translate_to_fol "
             "puis translate_to_pl comme avant\n"
-            "5. Stock la traduction via add_nl_to_logic_translation(\n"
-            "   original_text='...', formula='...', logic_type='propositional'|'fol',\n"
+            "5. MODAL (#1391) : pour chaque argument cle qui exprime une modalite "
+            "(necessite/possibilite : 'doit', 'faut', 'peut', 'necessairement', "
+            "'possible', 'obligatoire'), appelle translate_to_modal(text='...') -> "
+            "belief set modal (declarations 'constant <atom>' + formules [] / <>). "
+            "Stock le resultat via add_nl_to_logic_translation(logic_type='modal'). "
+            "Si l'argument n'a aucune saveur modale, l'outil retourne un resultat "
+            "valide vide (honnête absent, #1019) -- NE fabrique PAS de contenu modal.\n"
+            "6. Stock la traduction via add_nl_to_logic_translation(\n"
+            "   original_text='...', formula='...', logic_type='propositional'|'fol'|'modal',\n"
             "   is_valid=True/False, variables=JSON. confidence=0.0-1.0)\n\n"
             "ETAPE 2 — Validation Tweety (OBLIGATOIRE et IMMEDIATE apres ETAPE 1, pas finale) :\n"
             "#1333 (a) Pour CHAQUE formule generee en ETAPE 1 (sans exception, pas seulement les valides) :\n"
-            "1. PL: appelle check_pl_consistency(belief_set=\"p => q\\np\")  (formules separees par \\n)\n"
-            "2. FOL: appelle check_fol_consistency(belief_set=\"forall X: (P(X))\")\n"
+            '1. PL: appelle check_pl_consistency(belief_set="p => q\\np")  (formules separees par \\n)\n'
+            '2. FOL: appelle check_fol_consistency(belief_set="forall X: (P(X))")\n'
             "3. Modal (possibilite/obligation): appelle check_modal_consistency(\n"
-            "   payload='{\"belief_set\": \"<>(p)\", \"logic_type\": \"S5\"}')  (K/T/S4/S5)\n"
+            '   payload=\'{"belief_set": "<belief_set_modal_de_translate_to_modal>", '
+            '"logic_type": "K"}\')  (K/T/S4/S5). #1391: passe le belief set modal '
+            "PRODUIT par translate_to_modal (ETAPE 1 step 5), ne le freehand pas.\n"
             "4. Si inconstistances: signalez au PM. NE PAS passer a ETAPE 3 tant que chaque formule n'a pas de verdict.\n\n"
             "ETAPE 3 — Analyse Dung (Argumentation Abstraite) :\n"
             "1. Construis un graphe d'attaque depuis les arguments et sophismes detectes\n"
@@ -848,7 +857,9 @@ async def _run_conversational_analysis_inner(
         # Parent harness (#578 tier 3): always fire on dense texts after Detection
         if "etection" in phase_name and len(text) > 5000:
             harness_log = await _run_parent_harness_fallback(
-                text, state, selector_context=selector_context,
+                text,
+                state,
+                selector_context=selector_context,
             )
             if harness_log:
                 conversation_log.append(harness_log)
@@ -1536,9 +1547,7 @@ async def _run_phase(
                     DelegatingSelectionStrategy,
                 )
 
-                selection = DelegatingSelectionStrategy(
-                    agents=agents, state=state
-                )
+                selection = DelegatingSelectionStrategy(agents=agents, state=state)
             except (ImportError, TypeError, ValueError):
                 logger.warning(
                     "DelegatingSelectionStrategy unavailable, using SK default selection"
@@ -1824,7 +1833,9 @@ def _extract_fallacy_type(fallacy_dict: Dict[str, Any]) -> str:
 
 
 async def _run_parent_harness_fallback(
-    text: str, state: Any, selector_context: Optional[Dict[str, Any]] = None,
+    text: str,
+    state: Any,
+    selector_context: Optional[Dict[str, Any]] = None,
 ) -> Optional[Dict[str, Any]]:
     """Invoke tier-3 parent harness on dense texts after Detection phase (#578, #600).
 

--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -276,7 +276,7 @@ AGENT_CONFIG = {
             "5. MODAL (#1391) : pour chaque argument cle qui exprime une modalite "
             "(necessite/possibilite : 'doit', 'faut', 'peut', 'necessairement', "
             "'possible', 'obligatoire'), appelle translate_to_modal(text='...') -> "
-            "belief set modal (declarations 'constant <atom>' + formules [] / <>). "
+            "belief set modal (declarations 'type(<atom>)' + formules [] / <>, #1327). "
             "Stock le resultat via add_nl_to_logic_translation(logic_type='modal'). "
             "Si l'argument n'a aucune saveur modale, l'outil retourne un resultat "
             "valide vide (honnête absent, #1019) -- NE fabrique PAS de contenu modal.\n"

--- a/argumentation_analysis/plugins/nl_to_logic_plugin.py
+++ b/argumentation_analysis/plugins/nl_to_logic_plugin.py
@@ -87,6 +87,40 @@ class NLToLogicPlugin:
         )
 
     @kernel_function(
+        name="translate_to_modal",
+        description=(
+            "Translate a natural language argument into modal logic (alethic "
+            "and deontic) using Tweety MlParser syntax. "
+            "Uses LLM with Tweety validation and retry loop. "
+            "Input: plain text argument that expresses necessity/possibility "
+            "(must, may, necessarily, possibly). "
+            "Returns JSON with 'formula' (a modal belief set: constant "
+            "declarations + [] / <> formulas), 'logic_type', 'is_valid', "
+            "'confidence'. Returns is_valid=true with empty formula when the "
+            "input carries no modal content (honest absent, #1391)."
+        ),
+    )
+    async def translate_to_modal(self, text: str) -> str:
+        """Translate NL text to modal logic (#1391, mirror of translate_to_fol)."""
+        from argumentation_analysis.services.nl_to_logic import NLToLogicTranslator
+
+        translator = NLToLogicTranslator(max_retries=3, logic_type="modal")
+        result = await translator.translate(text, logic_type="modal")
+
+        return json.dumps(
+            {
+                "original_text": result.original_text[:200],
+                "formula": result.formula,
+                "logic_type": result.logic_type,
+                "is_valid": result.is_valid,
+                "validation_message": result.validation_message,
+                "attempts": result.attempts,
+                "variables": result.variables,
+                "confidence": result.confidence,
+            }
+        )
+
+    @kernel_function(
         name="translate_batch_to_pl",
         description=(
             "Translate multiple NL arguments to propositional logic in batch. "

--- a/argumentation_analysis/services/nl_to_logic.py
+++ b/argumentation_analysis/services/nl_to_logic.py
@@ -84,6 +84,38 @@ def _extract_fol_metadata(parsed: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _build_modal_belief_set(constants: List[str], formulas: List[str]) -> str:
+    """Build a Tweety MlParser belief-set string for modal logic (#1391).
+
+    Format (firsthand-confirmed via test_modal_logic_agent.py:316
+    ``ModalBeliefSet("type(urgent)\\n\\n[](urgent)")`` and the SPASS track
+    test_track_c_modal_spass_1279 ``{"formulas": ["type(p)", "p"]}``):
+        type(<atom>)
+        <blank line>
+        <modal-formula using [] / <>
+
+    Each modal atom is declared with ``type(<atom>)`` (NOT ``constant <atom>``
+    -- that is the TweetyBridgeSK *simulation* format; the real MlParser
+    rejects it with "Missing '=' in sort declaration"). Atoms are de-duplicated
+    and limited to legal identifiers ``[A-Za-z][A-Za-z0-9]*``; the
+    ModalIdentifierNormalizer (#1326/#1327) PascalCases any residual illegal
+    atom at parse time (defense-in-depth).
+    """
+    legal = []
+    seen: set[str] = set()
+    for c in constants:
+        if isinstance(c, str) and re.match(r"^[A-Za-z][A-Za-z0-9]*$", c):
+            if c not in seen:
+                seen.add(c)
+                legal.append(c)
+    parts = [f"type({c})" for c in legal]
+    formula_lines = [f.strip() for f in formulas if isinstance(f, str) and f.strip()]
+    if formula_lines:
+        parts.append("")  # blank line separating declarations from formulas
+        parts.extend(formula_lines)
+    return "\n".join(parts)
+
+
 # ── Data classes ─────────────────────────────────────────────────────────
 
 
@@ -173,6 +205,47 @@ FOL_RETRY_PROMPT = (
     "Original text: {original}\n"
     "Previous (invalid) formulas: {formulas}\n\n"
     "Respond with ONLY a corrected JSON object."
+)
+
+# Modal logic (alethic/deontic). Tweety MlParser belief-set grammar:
+#   constant <atom>            (one declaration per modal atom)
+#   <modal-formula>            (using [] necessarily, <> possibly)
+# Atoms MUST match [a-zA-Z][a-zA-Z0-9]* -- no underscores (MlParser rejects
+# them; ModalIdentifierNormalizer PascalCases as defense-in-depth, but emit
+# clean identifiers). #1391 (CONV-B DoD #1 modal parity): mirrors translate_to_fol.
+MODAL_SYSTEM_PROMPT = (
+    "You are a formal logic expert. Translate natural language arguments "
+    "into modal logic (alethic and deontic) using Tweety MlParser syntax.\n\n"
+    "Modal operators:\n"
+    "- []  means NECESSARILY / MUST / OBLIGATORY (box)\n"
+    "- <>  means POSSIBLY / MIGHT / PERMITTED (diamond)\n\n"
+    "Rules:\n"
+    "- Atoms are simple alphanumeric identifiers, no underscores "
+    "(e.g. rain, peace, action)\n"
+    "- Each distinct atom must be declared as a constant\n"
+    "- Boolean operators: && (and), || (or), => (implies), ! (not), <=> (iff)\n"
+    "- Capture modalities: 'must/necessarily/obliged' -> [], "
+    "'may/possibly/permitted' -> <>\n"
+    "- If the text has NO modal flavor (no necessity/possibility), return "
+    "EMPTY formulas and an empty constants list.\n\n"
+    "Respond with ONLY a JSON object:\n"
+    '{"constants": ["action", "peace"], '
+    '"formulas": ["[](action => peace)", "<>peace"], '
+    '"confidence": 0.8}'
+)
+
+MODAL_RETRY_PROMPT = (
+    "Your previous modal translation was invalid. The validator returned:\n"
+    "Error: {error}\n\n"
+    "Common issues:\n"
+    "- Atom names must be [a-zA-Z][a-zA-Z0-9]* (NO underscores)\n"
+    "- Every atom used in a formula must appear in 'constants'\n"
+    "- Operators are [] and <> (not □ ◇ or 'box'/'diamond')\n"
+    "- Unmatched parentheses\n\n"
+    "Original text: {original}\n"
+    "Previous (invalid) formulas: {formulas}\n\n"
+    "Respond with ONLY a corrected JSON object. If the text has no modal "
+    "content, return empty constants and formulas."
 )
 
 
@@ -295,10 +368,14 @@ class NLToLogicTranslator:
         client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
         system_prompt = (
-            PL_SYSTEM_PROMPT if logic_type == "propositional" else FOL_SYSTEM_PROMPT
+            PL_SYSTEM_PROMPT
+            if logic_type == "propositional"
+            else FOL_SYSTEM_PROMPT if logic_type == "fol" else MODAL_SYSTEM_PROMPT
         )
         retry_template = (
-            PL_RETRY_PROMPT if logic_type == "propositional" else FOL_RETRY_PROMPT
+            PL_RETRY_PROMPT
+            if logic_type == "propositional"
+            else FOL_RETRY_PROMPT if logic_type == "fol" else MODAL_RETRY_PROMPT
         )
 
         last_error = ""
@@ -333,6 +410,31 @@ class NLToLogicTranslator:
                 if logic_type == "propositional":
                     formula = parsed.get("formula", "")
                     variables = parsed.get("variables", {})
+                    confidence = parsed.get("confidence", 0.7)
+                    last_formula = formula
+                    fol_metadata = None
+                elif logic_type == "modal":
+                    # #1391: build a modal belief set (constant declarations +
+                    # formulas) so the decider's parseBeliefBase accepts it.
+                    modal_constants = parsed.get("constants", []) or []
+                    modal_formulas = parsed.get("formulas", []) or []
+                    # Anti-théâtre #1019 (#1391): a modal-free input yields
+                    # EMPTY formulas. That is honest-absent, NOT a validation
+                    # failure -- do not retry into a fabricated verdict. Return
+                    # a valid empty result so the caller skips the modal decider.
+                    if not modal_formulas:
+                        return TranslationResult(
+                            original_text=text,
+                            formula="",
+                            logic_type="modal",
+                            is_valid=True,
+                            validation_message=("No modal content (honest absent)"),
+                            attempts=attempt,
+                            variables={},
+                            confidence=0.0,
+                        )
+                    formula = _build_modal_belief_set(modal_constants, modal_formulas)
+                    variables = {c: c for c in modal_constants}
                     confidence = parsed.get("confidence", 0.7)
                     last_formula = formula
                     fol_metadata = None
@@ -456,6 +558,24 @@ class NLToLogicTranslator:
                 return True, "Valid propositional formula (Tweety)"
             else:
                 return False, "Invalid propositional formula syntax"
+        elif logic_type == "modal":
+            # #1391: validate the FULL modal belief set the way the decider
+            # consumes it (parseBeliefBase). Use the ready SINGLETON
+            # (``get_instance``) -- a fresh ``TweetyBridge()`` lacks the fully
+            # initialized SPASS reasoner + modal parser signature and rejects
+            # even ``<>(p)`` with "Unknown object p". The singleton (same one
+            # ``check_modal_consistency`` uses) parses it fine (#1380).
+            #   (None, "Modal KB parse error...") -> invalid syntax -> retry
+            #   (True/False, ...)                -> parsed -> valid belief set
+            # The consistency value is decided again in ETAPE 2; here we only
+            # assert parse-ability (anti-theater: never false-green).
+            modal_bridge = TweetyBridge.get_instance()
+            verdict, dec_msg = await asyncio.to_thread(
+                modal_bridge.check_consistency, formula, "K"
+            )
+            if verdict is None:
+                return False, f"Modal belief set parse failed: {dec_msg}"
+            return True, f"Valid modal belief set (parsed, Tweety): {dec_msg}"
         else:
             # FOL: build signature from metadata and validate all formulas together
             fol_formulas = [f.strip() for f in formula.split(";") if f.strip()]
@@ -644,8 +764,43 @@ class NLToLogicTranslator:
         """Lightweight Python-based syntax validation (no JVM needed)."""
         if logic_type == "propositional":
             return self._validate_pl_python(formula)
+        elif logic_type == "modal":
+            return self._validate_modal_python(formula)
         else:
             return self._validate_fol_python(formula)
+
+    def _validate_modal_python(self, formula: str) -> Tuple[bool, str]:
+        """Basic modal belief-set syntax validation (no JVM needed).
+
+        Checks balanced parentheses and that each non-declaration line is
+        non-empty. The atom-identifier grammar ([a-zA-Z][a-zA-Z0-9]*) is
+        enforced by the ModalIdentifierNormalizer at parse time; here we only
+        catch gross syntax errors so the retry loop has a fallback when Tweety
+        is unavailable.
+        """
+        lines = [ln.strip() for ln in formula.split("\n") if ln.strip()]
+        if not lines:
+            return False, "Empty modal belief set"
+        formulas = [ln for ln in lines if not ln.startswith("constant ")]
+        if not formulas:
+            return False, "No modal formulas"
+        for f in formulas:
+            depth = 0
+            for ch in f:
+                if ch == "(":
+                    depth += 1
+                elif ch == ")":
+                    depth -= 1
+                if depth < 0:
+                    return False, f"Unmatched closing parenthesis in '{f}'"
+            if depth != 0:
+                return False, f"Unmatched parentheses in '{f}'"
+            # Modal formulas must carry a box/diamond or a boolean op/atom
+            if "[]" not in f and "<>" not in f and "=>" not in f and "&&" not in f:
+                # bare atom is legal (a declared constant) -- allow
+                if not re.match(r"^[A-Za-z][A-Za-z0-9]*$", f):
+                    return False, f"Invalid modal formula '{f}'"
+        return True, f"Valid modal formulas ({len(formulas)}, Python)"
 
     def _validate_pl_python(self, formula: str) -> Tuple[bool, str]:
         """Basic propositional logic syntax validation."""
@@ -790,6 +945,72 @@ class NLToLogicTranslator:
 
         sentences = re.split(r"[.!?;]", text)
         sentences = [s.strip() for s in sentences if len(s.strip()) > 10]
+
+        if logic_type == "modal":
+            # #1391: heuristic modal extraction. Detect necessity/possibility
+            # cues and emit a minimal modal belief set. If the text carries no
+            # modal cue, return an honest-absent empty result (#1019) rather
+            # than fabricating one.
+            text_lower = text.lower()
+            necessity_cues = (
+                "must",
+                "necessarily",
+                "obligatory",
+                "required",
+                "il faut",
+                "doit",
+                "doivent",
+                "obligatoire",
+            )
+            possibility_cues = (
+                "may",
+                "might",
+                "possibly",
+                "permitted",
+                "can",
+                "peut",
+                "peuvent",
+                "possible",
+                "permis",
+            )
+            has_nec = any(c in text_lower for c in necessity_cues)
+            has_pos = any(c in text_lower for c in possibility_cues)
+            if not (has_nec or has_pos):
+                return TranslationResult(
+                    original_text=text,
+                    formula="",
+                    logic_type="modal",
+                    is_valid=True,
+                    validation_message=("No modal content (heuristic, honest absent)"),
+                    attempts=0,
+                    variables={},
+                    confidence=0.0,
+                )
+            # Derive one atom from the longest sentence stem.
+            stems = []
+            for sent in sentences[:3]:
+                stem = re.sub(r"[^A-Za-z0-9]+", "", sent).strip()[:12]
+                stem = stem.capitalize() or "MpAtom"
+                stems.append(stem)
+            if not stems:
+                stems = ["MpAtom"]
+            constants = list(dict.fromkeys(stems))[:3]
+            formulas = []
+            if has_nec:
+                formulas.append(f"[]({constants[0]})")
+            if has_pos and len(constants) > 1:
+                formulas.append(f"<>({constants[-1]})")
+            belief_set = _build_modal_belief_set(constants, formulas)
+            return TranslationResult(
+                original_text=text,
+                formula=belief_set,
+                logic_type="modal",
+                is_valid=True,
+                validation_message="Heuristic modal translation (no LLM)",
+                attempts=0,
+                variables={c: c for c in constants},
+                confidence=0.2,
+            )
 
         if logic_type == "propositional":
             # #1260: derive a readable atom per sentence (was opaque p1,p2).

--- a/tests/unit/argumentation_analysis/plugins/test_nl_to_logic_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_nl_to_logic_plugin.py
@@ -24,6 +24,7 @@ class TestNLToLogicPlugin:
         plugin = NLToLogicPlugin()
         assert hasattr(plugin, "translate_to_pl")
         assert hasattr(plugin, "translate_to_fol")
+        assert hasattr(plugin, "translate_to_modal")
         assert hasattr(plugin, "translate_batch_to_pl")
         assert hasattr(plugin, "translate_batch_to_fol")
 
@@ -81,6 +82,64 @@ class TestNLToLogicPlugin:
         assert "forall" in result["formula"]
         assert result["logic_type"] == "fol"
         assert result["is_valid"] is True
+
+    @pytest.mark.asyncio
+    async def test_translate_to_modal_success(self):
+        """translate_to_modal returns JSON with a modal belief set (#1391)."""
+        plugin = NLToLogicPlugin()
+
+        mock_result = MagicMock()
+        mock_result.original_text = "Citizens must vote and may protest"
+        # #1391: a modal belief set = type(<atom>) declarations + [] / <> formulas
+        mock_result.formula = "type(vote)\ntype(protest)\n\n[](vote)\n<>(protest)"
+        mock_result.logic_type = "modal"
+        mock_result.is_valid = True
+        mock_result.validation_message = "Valid modal formulas (2, Tweety)"
+        mock_result.attempts = 1
+        mock_result.variables = {"vote": "vote", "protest": "protest"}
+        mock_result.confidence = 0.8
+
+        with patch(
+            "argumentation_analysis.services.nl_to_logic.NLToLogicTranslator"
+        ) as MockTranslator:
+            MockTranslator.return_value.translate = AsyncMock(return_value=mock_result)
+            result_str = await plugin.translate_to_modal(
+                "Citizens must vote and may protest"
+            )
+
+        result = json.loads(result_str)
+        assert result["logic_type"] == "modal"
+        assert result["is_valid"] is True
+        assert "type(vote)" in result["formula"]
+        assert "[](vote)" in result["formula"]
+        assert "<>(protest)" in result["formula"]
+
+    @pytest.mark.asyncio
+    async def test_translate_to_modal_honest_absent(self):
+        """Modal-free input -> valid empty result (honest absent, #1391/#1019)."""
+        plugin = NLToLogicPlugin()
+
+        mock_result = MagicMock()
+        mock_result.original_text = "The cat sat on the mat"
+        mock_result.formula = ""  # no modal content
+        mock_result.logic_type = "modal"
+        mock_result.is_valid = True  # valid-but-empty = honest absent
+        mock_result.validation_message = "No modal content (honest absent)"
+        mock_result.attempts = 1
+        mock_result.variables = {}
+        mock_result.confidence = 0.0
+
+        with patch(
+            "argumentation_analysis.services.nl_to_logic.NLToLogicTranslator"
+        ) as MockTranslator:
+            MockTranslator.return_value.translate = AsyncMock(return_value=mock_result)
+            result_str = await plugin.translate_to_modal("The cat sat on the mat")
+
+        result = json.loads(result_str)
+        assert result["is_valid"] is True
+        assert result["formula"] == ""
+        # Honest absent MUST NOT be a fabricated verdict -- empty + valid.
+        assert "absent" in result["validation_message"].lower()
 
     @pytest.mark.asyncio
     async def test_translate_to_pl_invalid_formula(self):

--- a/tests/unit/argumentation_analysis/plugins/test_translate_to_modal_antitheater.py
+++ b/tests/unit/argumentation_analysis/plugins/test_translate_to_modal_antitheater.py
@@ -1,0 +1,77 @@
+"""CONV-B #1391 anti-inerte guard — the REAL consumer of translate_to_modal's
+output (the ModalHandler parser via ``validate_modal_formula``) must accept the
+belief-set format the translator produces, and must reject malformed input.
+
+CONTEXT (#1391, builds on the R319-R321 lesson restated in #1380)
+-----------------------------------------------------------------
+The plugin method ``translate_to_modal`` wraps ``NLToLogicTranslator`` which
+validates each modal formula line via ``bridge.modal_handler.validate_modal_formula``
+(Tweety MlParser). A unit test that MOCKS the translator (see
+test_nl_to_logic_plugin.py) proves the wrapper plumbing but NOT that the belief
+set the translator emits actually parses in Tweety -- exactly the "registration
+!= wiring" gap that left CONV-B modal at 0 for the whole R530-R540 arc.
+
+This test calls the REAL validate path (``_validate_with_tweety`` with a live
+JVM/ModalHandler via ``tweety_bridge_fixture``) on a belief set built by the
+production ``_build_modal_belief_set`` helper. It fails loud if:
+  - a valid modal belief set ever stops parsing (format drift), or
+  - a malformed belief set ever parses (false-green theater).
+
+This is the guard the #1391 DoD requires ("appelle le VRAI consommateur").
+"""
+
+import pytest
+
+from argumentation_analysis.services.nl_to_logic import (
+    NLToLogicTranslator,
+    _build_modal_belief_set,
+)
+
+pytestmark = pytest.mark.tweety
+
+
+def test_build_modal_belief_set_format():
+    """The belief-set builder emits the type(<atom>) + formula format (#1391)."""
+    bs = _build_modal_belief_set(
+        ["vote", "protest", "vote"],  # duplicate -> de-duped
+        ["[](vote)", "<>(protest)"],
+    )
+    assert bs == "type(vote)\ntype(protest)\n\n[](vote)\n<>(protest)"
+
+
+def test_build_modal_belief_set_rejects_illegal_atoms():
+    """Illegal constant identifiers (underscores) are dropped by the builder."""
+    bs = _build_modal_belief_set(
+        ["action", "bad_atom"],  # "action" legal, "bad_atom" underscored -> filtered
+        ["[](action)"],
+    )
+    assert "type(action)" in bs
+    assert "bad_atom" not in bs  # filtered (normalizer is defense-in-depth)
+
+
+async def test_validate_with_tweety_accepts_valid_modal_belief_set(
+    tweety_bridge_fixture,
+):
+    """REAL consumer: a type()-declared modal belief set parses in Tweety.
+
+    Ground-truth format: ``type(<atom>)`` declarations (the real MlParser
+    grammar, firsthand-confirmed via test_modal_logic_agent.py:316 and the
+    SPASS track test_track_c_modal_spass_1279 -- NOT ``constant <atom>``
+    which is the TweetyBridgeSK simulation format the parser rejects).
+    Guards the translator's validate path against format drift.
+    """
+    translator = NLToLogicTranslator(max_retries=1, logic_type="modal")
+    bs = _build_modal_belief_set(["action"], ["[](action)"])
+    is_valid, msg = await translator._validate_with_tweety(bs, "modal")
+    assert is_valid is True, f"Valid modal belief set rejected: {msg}"
+
+
+async def test_validate_with_tweety_rejects_malformed_modal(
+    tweety_bridge_fixture,
+):
+    """REAL consumer: a malformed modal formula is rejected (anti-theater)."""
+    translator = NLToLogicTranslator(max_retries=1, logic_type="modal")
+    # Unbalanced parentheses -> MlParser must reject, never false-green.
+    bs = _build_modal_belief_set(["p"], ["[]((p"])
+    is_valid, msg = await translator._validate_with_tweety(bs, "modal")
+    assert is_valid is False, "Malformed modal formula parsed (false-green!)"


### PR DESCRIPTION
## Summary

Closes the **modal** leg of CONV-B DoD #1 (#1333) via Epic #1391: exposes modal-logic translation as a Semantic Kernel `@kernel_function` (`translate_to_modal`) so the FormalAgent can produce a modal verdict **BY tool-call** in `AgentGroupChat`. This completes the PL + FOL + **modal** triptych — modal was 0 across the whole R530-R540 arc (PL+FOL closed R538).

**Strategy (a)-tool only** (mirror of `translate_to_fol`), per coordinator R549 scope validation. No agent-decider (b), no prompt-fiddle.

## Root format discovered firsthand (R319-R321 lesson)

The real Tweety **MlParser** belief-set grammar is:

```
type(<atom>)

[](<formula>)
<>(<formula>)
```

Ground-truth firsthand-confirmed via `test_modal_logic_agent.py:316` (`ModalBeliefSet("type(urgent)\n\n[](urgent)")`) and the SPASS track test (`{"formulas": ["type(p)", "p"]}`). Two earlier guesses were the *simulation* formats the parser rejects:

| Wrong format | Parser error |
|---|---|
| `constant <atom>` | `Missing '=' in sort declaration` (TweetyBridgeSK sim format) |
| bare `<>(p)` | `Unknown object p` (no declaration) |

A **mocked** unit test passed for both wrong formats — proving plumbing but not wiring (the exact R319-R321 gap that left CONV-B modal at 0). Only the anti-inerte test calling the **REAL** consumer (live JVM → `check_consistency`) forced the correct grammar out.

## Anti-theater guarantees (#1019)

- **Honest-absent short-circuit**: modal-free input → `is_valid=True`, `formula=""`, message notes "absent". **Never** fabricates modal content to tick the box.
- **Parse-fail → None**: a malformed belief set returns `None` degraded, never a fabricated `is_consistent`.
- **Illegal atoms dropped** at build time; `ModalIdentifierNormalizer` (#1326/#1327) is defense-in-depth at parse point.

## Changes

| File | Change |
|---|---|
| `services/nl_to_logic.py` | `MODAL_*_PROMPT`, `_build_modal_belief_set` (module fn, `type()` grammar), modal branch w/ honest-absent, modal validation via singleton `TweetyBridge.get_instance()` + `check_consistency`, python fallback, heuristic fallback |
| `plugins/nl_to_logic_plugin.py` | `translate_to_modal` `@kernel_function` (mirror of FOL) |
| `orchestration/conversational_orchestrator.py` | ETAPE 1 step 5 (call + stock `logic_type='modal'`), ETAPE 2 step 3 (pass produced belief set, never freehand) |
| `tests/.../test_nl_to_logic_plugin.py` | +`translate_to_modal_success`, +`translate_to_modal_honest_absent` |
| `tests/.../test_translate_to_modal_antitheater.py` | **NEW**, `@pytest.mark.tweety` anti-inerte guard (format, illegal-atom reject, REAL validate accepts valid, REAL validate rejects `[]((p`) |

## Validation

- **17 modal tests green** (4 anti-inerte with live JVM + 13 plugin).
- **mypy strict**: no NEW errors (3 pre-existing on main, unchanged — confirmed by stash-compare).
- **black**: clean.

## DoD #1 status (per coord R549)

Code + guard landed. The **proof-run** (showing ≥1 real `check_modal_consistency` tool-call with `is_consistent` or degraded-null + SPASS solver named, on a modal-exposing input) is the coordinator's call to trigger — coord R549: *"Je clos DoD #1 au retour du proof-run modal."* This PR is the prerequisite for that run. Anti-inerte (the "appelle le VRAI consommateur" guard) is already covered by the new test.

No corpus content in this PR — code + tests only.

Co-Authored-By: Claude-Code <noreply@anthropic.com>