### PR TITLE
test(deep-synthesis): align deps set with spectacular DAG (drop narrative_synthesis) (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/test_deep_synthesis_wiring.py
+++ b/tests/unit/argumentation_analysis/test_deep_synthesis_wiring.py
@@ -87,9 +87,13 @@ class TestDAGOrdering:
 
         wf = build_spectacular_workflow()
         ds_phase = next(p for p in wf.phases if p.name == "deep_synthesis")
+        # The spectacular workflow has no ``narrative_synthesis`` phase — its
+        # narrative output is produced via the ``act1_framing`` /
+        # ``act2_narrative`` / ``act3_conclusion`` phases. deep_synthesis
+        # depends on synthesis + belief_revision + stakes (the validated DAG
+        # edges; all three exist as spectacular phases).
         assert set(ds_phase.depends_on) == {
             "synthesis",
-            "narrative_synthesis",
             "belief_revision",
             "stakes",
         }


### PR DESCRIPTION
## Context — #1336 tail (continuing per coord R549 SUITE)

Probed the remaining ~11 unprobed failures for clusters. `test_deep_synthesis_depends_on_correct_phases` reproduced locally — stale-contract, fixable firsthand.

## Verdict par échec (firsthand)

**Stale-contract: the test references a phase that doesn't exist in the spectacular workflow.**

`test_deep_synthesis_depends_on_correct_phases` asserts:
```python
assert set(ds_phase.depends_on) == {
    "synthesis", "narrative_synthesis", "belief_revision", "stakes",
}
```

But `build_spectacular_workflow()` (40 phases, confirmed firsthand) has **no `narrative_synthesis` phase**. Its narrative output is produced via the `act1_framing` / `act2_narrative` / `act3_conclusion` phases. The real `deep_synthesis.depends_on` is `{synthesis, belief_revision, stakes}` — all three are valid spectacular phases. The test encoded a contract from before the narrative phases were restructured.

## Fix — pure test alignment (anti-pendule)

The prod DAG is the truth; the expected set follows. Drop `narrative_synthesis` from the expected set.

## Verification

```
test_deep_synthesis_depends_on_correct_phases: 1F -> 1P  (firsthand)
```

## Batch-probe intel (this round)

Probed 4 other failures locally:
- **`test_fol_2pass_pipeline::test_pass2_formulas_use_shared_predicates`** + **`test_pl_2pass_pipeline::test_explicit_formulas_context_still_works`** (cluster 2pass, 2F): reproduce locally but are **behavioral, not stale-contract**. PL: prod normalizes `&`→`&&` (Tweety format, `invoke_callables.py:5176` + `#705` "do NOT short-circuit the 2-pass"), test expects `a & b` preserved. FOL: mock returns 2 formulas but result is empty (mock-contract drift). These need deeper prod investigation (distinguish stale vs bug) — **deferred to a dedicated round** per coord guidance ("don't bundle non-deterministic with clean stale-contract").
- **`test_parallel_fallacy_workflow_578::test_parses_json_array_response`** (1F): `assert '2' in ['2_1_1', '175']` — PK format mismatch. Likely stale but needs PK-generation logic review. Deferred.

## Files changed
- `tests/unit/argumentation_analysis/test_deep_synthesis_wiring.py` — drop `narrative_synthesis` from deep_synthesis deps expectation.

## Lane note
Targets `argumentation_analysis/orchestration/workflows.py` (spectacular DAG) — NOT `conversational_orchestrator.py`, `logic_agent_plugin.py`, or `nl_to_logic_plugin.py`/`NLToLogicTranslator` (po-2025's lanes). No merge collision.

## Privacy
Opaque phase names only. No source content.
