### PR TITLE
test(parallel-578): align wide-net PK assertion with FB-19 deep index

### DIFF
--- a/tests/unit/argumentation_analysis/test_parallel_fallacy_workflow_578.py
+++ b/tests/unit/argumentation_analysis/test_parallel_fallacy_workflow_578.py
@@ -79,8 +79,13 @@ class TestWideNetCandidates:
         result = asyncio.get_event_loop().run_until_complete(
             plugin._wide_net_candidates("Some argument text here")
         )
-        assert "2" in result  # Ad hominem PK
-        assert "175" in result  # Manipulation mentale PK
+        # FB-19 (#1107): _wide_net_candidates tries the deep index (depth 2-3)
+        # BEFORE falling back to root PKs (see test_fb19_beam_descent.py
+        # TestWideNetDeepMapping). "Ad hominem abusif" is a depth-3 leaf
+        # (PK 2_1_1) → deep index returns the leaf, not the root "2".
+        # "Manipulation mentale" has no deep match → root fallback PK 175.
+        assert "2_1_1" in result  # Ad hominem abusif → deep leaf PK
+        assert "175" in result  # Manipulation mentale root PK (deep miss → root)
 
     def test_handles_empty_response(self):
         plugin = _make_plugin()


### PR DESCRIPTION
## Context — #1336 tail (continuing per coord R550 SUITE)

Probed parallel_578. `test_parses_json_array_response` reproduced locally — stale-contract, fixable firsthand.

## Verdict par échec (firsthand)

**Stale-contract: the test encodes the pre-FB-19 root-PK contract.**

`test_parses_json_array_response` asserts:
```python
assert "2" in result  # Ad hominem PK
assert "175" in result  # Manipulation mentale PK
```

But `_wide_net_candidates` uses the FB-19 (#1107) **deep index first** (depth 2-3) before falling back to root PKs. The LLM mock returns `"fallacy_name": "Ad hominem abusif"`, which is a depth-3 leaf (`PK=2_1_1`, `parent_PK=2_1` → `2`). `_map_fallacy_to_deep_pk` (`fallacy_workflow_plugin.py:488`) returns the deepest matching PK via direct match in the deep index → `2_1_1`. `"Manipulation mentale"` has no deep match → root fallback `175`.

Reproduced firsthand: `assert '2' in ['2_1_1', '175']` → AssertionError. Real result = `['2_1_1', '175']` (correct FB-19 behavior).

## This is the documented contract — not a regression

`test_fb19_beam_descent.py::TestWideNetDeepMapping` confirms the prod behavior is intentional and already tested:
- `test_wide_net_uses_deep_index` (L201): *"Wide-net should try deep index before root index."*
- `test_wide_net_deep_pk_preferred_over_root` (L223): *"When deep index matches, PK should be at depth ≥ 2."*

The `_wide_net_candidates` docstring (`fallacy_workflow_plugin.py:510-517`) states explicitly: *"Returns list of PKs (depth 1-3 via deep index)... Tries deep index first (depth 2-3), falls back to root PKs. This gives the agentic navigation a 2-3 level head start."*

The 578 test was written before FB-19 landed and never updated.

## Fix — pure test alignment (anti-pendule)

Prod FB-19 deep-index-first is the truth; the expected PK follows. `2` → `2_1_1`, with a comment documenting FB-19 (and pointing at the sibling contract test) to prevent a future mis-realignment back to the root PK.

## Verification

```
test_parallel_fallacy_workflow_578.py: 1F -> 11P  (firsthand, 0 regression on 10 siblings)
```

## Files changed
- `tests/unit/argumentation_analysis/test_parallel_fallacy_workflow_578.py` — wide-net PK assertion `2` → `2_1_1` (FB-19 deep index).

## Lane note
Targets `argumentation_analysis/plugins/fallacy_workflow_plugin.py` (FB-19 wide-net mapping contract) — NOT `conversational_orchestrator.py`, `logic_agent_plugin.py`, or `nl_to_logic_plugin.py`/`NLToLogicTranslator` (po-2025's lanes). No merge collision.

## Privacy
Opaque PKs only. No source content.
