### PR TITLE
test(pl-2pass): align explicit-formulas assertion with PLFormulaSanitizer (#537)

### DIFF
--- a/tests/unit/argumentation_analysis/test_pl_2pass_pipeline.py
+++ b/tests/unit/argumentation_analysis/test_pl_2pass_pipeline.py
@@ -259,7 +259,7 @@ class TestBackwardCompat:
         assert "p => q" in result["formulas"]
 
     def test_explicit_formulas_context_still_works(self):
-        """When context already has formulas, use them directly."""
+        """When context already has formulas, use them (sanitized for Tweety)."""
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_propositional_logic,
         )
@@ -273,7 +273,13 @@ class TestBackwardCompat:
         )
 
         assert result is not None
-        assert "a & b" in result["formulas"]
+        # PLFormulaSanitizer (#537) normalizes formulas for Tweety: the PL AND
+        # operator is "&&" (not "&"), so "a & b" -> "a && b". Already-valid
+        # operators like "=>" are preserved (so "a => c" survives as-is). The
+        # sibling test_existing_translations_path_still_works passes because
+        # "p => q" has no operator needing normalization.
+        assert "a && b" in result["formulas"]  # sanitized "&" -> "&&" (#537)
+        assert "a => c" in result["formulas"]  # valid operator, preserved
 
     def test_no_state_object_graceful(self):
         """Should work even without _state_object in context."""


### PR DESCRIPTION
## Context — #1336 tail (continuing per coord R550 SUITE, "sonde 1×1")

Probed the PL half of the 2pass cluster. `test_explicit_formulas_context_still_works` reproduced locally — stale-contract, fixable firsthand.

## Verdict par échec (firsthand)

**Stale-contract: the test encodes the pre-sanitizer contract.**

`test_explicit_formulas_context_still_works` sets `ctx["formulas"] = ["a & b", "a => c"]` and asserts:
```python
assert "a & b" in result["formulas"]
```

But `_invoke_propositional_logic` runs **every** formula (2-pass-generated AND upstream `ctx["formulas"]`, unioned at `invoke_callables.py:5267`) through `PLFormulaSanitizer.sanitize_batch` (`invoke_callables.py:5325-5333`, #537 "Sanitize formulas for Tweety compatibility") before returning. The PL AND operator in Tweety is `&&` (not `&`), so `"a & b"` → `"a && b"`. `"a => c"` is preserved (`=>` is already valid).

Reproduced firsthand: `assert 'a & b' in ['a && b', 'a => c']` → AssertionError, with log `PLFormulaSanitizer: 2/2 formulas sanitized, 0 skipped`.

## Not a bug — the sanitizer is deliberate and documented

- `invoke_callables.py:5318` comment: *"Sanitize formulas for Tweety compatibility (#537)"*.
- `#537` sanitizer is the single source of truth for PL formula normalization.
- The sibling `test_existing_translations_path_still_works` (same class) **passes** because its input `"p => q"` has no operator needing normalization — confirming the sanitizer only rewrites non-Tweety operators.

The 2pass test was written before the sanitizer was wired as a mandatory post-step and never updated.

## Fix — pure test alignment (anti-pendule)

Prod #537 sanitizer is the truth; the expected formula follows. `"a & b"` → `"a && b"`, with a comment documenting #537 (and explaining why the sibling test passes) to prevent a future mis-realignment back to `"a & b"`. Also asserts `"a => c"` is preserved (the other input formula), which strengthens the test.

## Verification

```
test_pl_2pass_pipeline.py: 1F -> 19P  (firsthand, 0 regression on 18 siblings)
```

## FOL half of the 2pass cluster — DEFERRED (bug prod, not stale-contract)

`test_pass2_formulas_use_shared_predicates` (FOL) also reproduced locally but is a **bug prod, not a stale-contract**:
- `assert 0 > 0` → `result["formulas"]` is empty.
- Logs: `JPype JException parsing FOL formula 'Argues(socrates)': ParserException: Constant 'socrates' has not been declared.` (same for `plato`).
- The Pass 2 prompt (`invoke_callables.py:5607-5620`) asks the LLM for bare formula strings (`"Argues(socrates)"`) using ONLY the provided signature — the mock `pass2_data = {"formulas": ["Argues(socrates)", "Disagrees(plato)"]}` reflects that contract faithfully. So the mock is NOT stale.
- The signature's constants (`sig_data["constants"]`, extracted Pass 1) are stored in `state.fol_shared_signature` and passed to the LLM, but are **NOT declared in the Tweety belief set used by per-formula isolation** → Tweety rejects every formula → 0 survivors.
- `git blame`: the FOL path was recently reworked by `9df8f39c` (#1278 NL→FOL vivant-ou-fail-loud) and `c4c3cfb1` (#560/#561 CoordinatedLogicPlugin 2-pass).

This needs a prod fix (inject `sig_data` constants/sorts/predicates into the isolation belief set), which is non-trivial and deserves a dedicated round — **deferred per coord rule** (don't bundle behavioral/bug with clean stale-contracts). Filed for the next round.

## Files changed
- `tests/unit/argumentation_analysis/test_pl_2pass_pipeline.py` — explicit-formulas assertion `"a & b"` → `"a && b"` (PLFormulaSanitizer #537), assert `"a => c"` preserved.

## Lane note
Targets `argumentation_analysis/orchestration/invoke_callables.py` PL path (#537 sanitizer contract) — NOT `conversational_orchestrator.py`, `logic_agent_plugin.py`, or `nl_to_logic_plugin.py`/`NLToLogicTranslator` (po-2025's lanes). No merge collision.

## Privacy
Opaque test corpus names only. No source content.
