### PR TITLE
chore(privacy): gitignore spectacular run-artifacts (trace_arg/fallacy/reanalysis)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,15 @@ scripts/_write_c03_report.py
 scripts/run_baselines.py
 docs/reports/spectacular_perf_bench.md
 docs/reports/spectacular_vs_baseline.md
+
+# === Run-artifacts leak guard (#1396 R547) ===
+# The spectacular conversational runner dumps per-arg/per-fallacy trace files
+# at repo root during a run (trace_arg_*, trace_fallacy_*, reanalysis_arg_*).
+# These contain corpus-derived content (privacy: never commit). They have
+# leaked as untracked-root files repeatedly (R543, R544, R547). Gitignore the
+# pattern so runs never surface them in `git status`. Move existing ones to a
+# gitignored scratchpad before/after runs.
+/trace_arg_*
+/trace_fallacy_*
+/reanalysis_arg_*
+


### PR DESCRIPTION
## What

Permanent gitignore guard for the spectacular conversational runner's run-artifacts (`trace_arg_*`, `trace_fallacy_*`, `reanalysis_arg_*`), which dump at repo root during a run.

## Why

These files contain corpus-derived content (privacy: never commit per CLAUDE.md "Dataset Privacy Discipline"). They leaked as untracked-root files in **3 consecutive proof-runs** (R543, R544, R547) before being caught by `git status` — a recurring manual-cleanup footgun.

The guard makes runs never surface them in `git status` in the first place. Existing files should be moved to a gitignored scratchpad before/after runs (not committed).

## Scope

`.gitignore` only (+12 lines). No code change.

## Checklist

- [x] Pattern verified via `git check-ignore trace_arg_TEST`
- [x] No tracked files match the new pattern (`git ls-files` clean)
- [x] mypy gate unchanged (no `.py` touched)

Co-Authored-By: Claude-Code <noreply@anthropic.com>