### PR TITLE
test(att-1): make no-api-key nl_to_logic tests hermetic (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/test_nl_to_logic.py
+++ b/tests/unit/argumentation_analysis/test_nl_to_logic.py
@@ -144,7 +144,16 @@ class TestNLToLogicTranslator:
     async def test_translate_no_api_key_uses_heuristic(self):
         """Without API key, translate falls back to heuristic."""
         translator = self._make_translator()
-        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+        # ATT-1 #1336: isolate BOTH API channels. The prod translator
+        # (_translate_with_llm) checks OpenRouter FIRST, then OpenAI; patching
+        # only OPENAI_API_KEY with clear=False leaks OPENROUTER_API_KEY from the
+        # real .env, routing to the LLM path (high confidence) instead of the
+        # heuristic. Hermétique isolation = patch both channels.
+        with patch.dict(
+            "os.environ",
+            {"OPENAI_API_KEY": "", "OPENROUTER_API_KEY": ""},
+            clear=False,
+        ):
             result = await translator.translate(
                 "All men are mortal. Socrates is a man. Therefore Socrates is mortal.",
                 logic_type="propositional",
@@ -365,7 +374,12 @@ class TestNLToLogicPipelineIntegration:
                 ],
             },
         }
-        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+        # ATT-1 #1336: isolate BOTH API channels (see test_translate_no_api_key_uses_heuristic).
+        with patch.dict(
+            "os.environ",
+            {"OPENAI_API_KEY": "", "OPENROUTER_API_KEY": ""},
+            clear=False,
+        ):
             result = await _invoke_nl_to_logic("test input text", context)
 
         assert "translations" in result


### PR DESCRIPTION
## Summary

Dispatch R556 T2 (ATT-1 no-api-key cluster, self-pickup). Firsthand investigation corrected the coordinator's hypothesis and produced a surgical test-isolation fix.

## Root cause (firsthand)

The 2 failing tests (`test_translate_no_api_key_uses_heuristic`, `test_invoke_nl_to_logic_heuristic`) failed **NOT** because #1019 removed a heuristic fallback — the fallback is intact (`nl_to_logic.py:372` returns `_translate_heuristic` when no API key). They failed because of **non-hermetic env isolation**:

`_translate_with_llm` checks OpenRouter **FIRST** (`OPENROUTER_BASE_URL` + `OPENROUTER_API_KEY`), then OpenAI. The tests used `patch.dict({"OPENAI_API_KEY": ""}, clear=False)` which preserves `OPENROUTER_API_KEY` from the real `.env`. With OpenRouter keys present in the ambient env, prod takes the LLM path → `confidence=0.95`, `method="llm"` → both assertions fail.

This is the **"Test Herméticité CI"** pattern (dashboard learned-patterns): patch.dict is ineffective if it only names one channel of a multi-channel env.

## Fix (anti-pendule, test-side)

Patch **both** API channels empty so the test exercises the heuristic path regardless of which keys live in the ambient env. No prod change, no fallback re-cabling (the prod is correct — it legitimately uses OpenRouter when OPENAI_API_KEY is absent). Subtraction of the test's non-hermeticity, not a counterweight.

## Validation firsthand
- `pytest tests/unit/argumentation_analysis/test_nl_to_logic.py` → **27 passed** (was 25/27; the 2 formerly-failing tests now pass).
- mypy strict on test file: 47 pre-existing errors (test files OUT of CI mypy gate, which covers exactly 8 core files). Edits only changed `patch.dict` contents — 0 new type errors.
- The other 2 cluster tests already pass (use `clear=True` or assert dict-shape only).

## Files changed
- `tests/unit/argumentation_analysis/test_nl_to_logic.py` — 2 tests made hermetic (isolate both OpenAI + OpenRouter channels).

## Cluster note
Part of ATT-1 tally reduction (#1336, ~22 F+E). Dispatch R556 T2. The coordinator's hypothesis ("fallback retiré par #1019") was partially incorrect for nl_to_logic — the fallback exists; the tests were non-hermetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)