### PR TITLE
test(fol-2pass): unblock stillborn pass-2 test (text below 100-char gate) (#544)

### DIFF
--- a/tests/unit/argumentation_analysis/test_fol_2pass_pipeline.py
+++ b/tests/unit/argumentation_analysis/test_fol_2pass_pipeline.py
@@ -119,7 +119,14 @@ class TestFolTwoPassPipeline:
             _invoke_fol_reasoning,
         )
 
-        text = "Socrates argues about justice. Plato disagrees."
+        # Text must exceed the 100-char gate (invoke_callables.py:5530) so the
+        # 2-pass pipeline actually runs and consumes the pass-1 signature.
+        # The original 47-char text fell through to the NL fallback and never
+        # reached pass-2, leaving formulas empty — a stillborn test since #544.
+        text = (
+            "Socrates argues about justice in the city of Athens. "
+            "Plato disagrees and proposes a different theory of justice."
+        )
         state = UnifiedAnalysisState(text)
         ctx = _make_context(text, state)
 
@@ -146,6 +153,11 @@ class TestFolTwoPassPipeline:
         assert result is not None
         assert "formulas" in result
         assert len(result["formulas"]) > 0
+        # Honor the test name: pass-2 formulas must reference predicates drawn
+        # from the pass-1 shared signature (Argues/Disagrees), proving the
+        # signature is consumed by pass-2 — not ignored.
+        joined = " ".join(result["formulas"])
+        assert "Argues" in joined or "Disagrees" in joined
 
     def test_fallback_when_no_api_key(self):
         """Without API key, should fall back to template."""


### PR DESCRIPTION
## Root cause (firsthand)

`test_pass2_formulas_use_shared_predicates` has been red since its introduction in #544 (`afd62c60`). The 47-char text:

\`\`\`python
text = "Socrates argues about justice. Plato disagrees."  # 47 chars
\`\`\`

falls below the prod guard at `invoke_callables.py:5530`:

\`\`\`python
if client is not None and input_text and len(input_text) > 100:
    # ... 2-pass pipeline (pass-1 signature + pass-2 formulas) ...
\`\`\`

So the 2-pass branch **never runs**, the pass-1 + pass-2 mocks are never consumed, the code falls through to the NL-to-logic fallback (mock mismatch), and `formulas=[]` is returned → \`assert len(result["formulas"]) > 0\` fails with \`assert 0 > 0\`.

The captured JPype error (`Constant 'socrates' has not been declared`) is a red herring — it comes from the fallback path, not the 2-pass.

## The prod path is sound (coord hypothesis corrected)

The dispatch R557 hypothesis was *"pass-2 must consume fol_shared_signature from pass-1"*. The source shows pass-2 **already** consumes the shared signature — `invoke_callables.py:5619` injects it into the LLM prompt:

\`\`\`python
_prompt = (... f"Signature:\n{sig_json}")
\`\`\`

and `test_pass1_signature_stored_in_state` (long text, same mocks) passes, proving the 2-pass + signature storage work end-to-end. **0 prod change needed.**

## Fix (test-only, anti-pendule)

1. Lengthen the text above the 100-char gate so the 2-pass actually runs (the mocks' intended path).
2. Add an assertion that honors the test name: pass-2 formulas must reference predicates drawn from the pass-1 shared signature (\`Argues\`/\`Disagrees\`) — proving the signature is consumed, not ignored. This assertion would have caught a real regression if pass-2 ever stopped using the signature.

## Validation

- \`pytest tests/unit/argumentation_analysis/test_fol_2pass_pipeline.py\` → **12 passed**, 0 failed (was 11/12).
- Reproduced the fix firsthand: with text >100 chars, \`formulas = ['Argues(socrates)', 'Disagrees(plato)']\`, \`fol_status: decided\`.
- No prod files touched; no mypy impact (test file out of the 8-file strict gate).

## Files changed

| File | Type | Reason |
|------|------|--------|
| \`tests/unit/argumentation_analysis/test_fol_2pass_pipeline.py\` | test | Lengthen text above 100-char gate + assert shared-predicate usage |

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>