### PR TITLE
ci(jvm-guard): fail-loud on JVM-startup skip storm (anti-fake-green #1385)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,40 @@ jobs:
           }
           Write-Host "═══════════════════════════════════════════════"
 
+      - name: Fail-loud guard — JVM-startup skip storm (#1385, anti-théâtre #1019)
+        # A JVM-startup failure on the runner makes an autouse conftest guard
+        # (tests/conftest.py:522) skip ~98% of the suite with the message
+        # "Saut du test car la JVM n'est pas réellement démarrée". With 0
+        # failures the job concludes "success" — a green badge from an infra
+        # failure that decided nothing (#1385). This guard fails the job
+        # honestly when that specific signature dominates. It is targeted to
+        # the JVM skip message, NOT the raw skip rate, so legitimate skips
+        # (orphan-model, build-absent, requires_api) never trip it.
+        if: always() && env.API_KEYS_CONFIGURED == 'true'
+        shell: pwsh
+        run: |
+          if (-not (Test-Path pytest_report.xml)) {
+            Write-Host "ℹ️ No pytest_report.xml — JVM-startup guard skipped (tests produced no report; failure already captured upstream)."
+            exit 0
+          }
+          [xml]$xml = Get-Content pytest_report.xml
+          $total = [int]$xml.testsuites.tests
+          $content = Get-Content pytest_report.xml -Raw
+          $jvmSignature = "JVM n'est pas réellement démarrée"
+          # Count <skipped message="...signature..."> occurrences (scoped to
+          # skip messages, so a signature mention in test names / stdout cannot
+          # inflate the count).
+          $jvmSkipCount = ([regex]::Matches($content, 'message="[^"]*' + [regex]::Escape($jvmSignature))).Count
+          $pct = if ($total -gt 0) { [math]::Round(100 * $jvmSkipCount / $total) } else { 0 }
+          Write-Host "🔍 JVM-startup guard: $jvmSkipCount / $total tests ($pct%) skipped with JVM-not-started signature."
+          if ($total -gt 0 -and ($jvmSkipCount / $total) -gt 0.5) {
+            Write-Host "❌ FAIL-LOUD: $jvmSkipCount tests ($pct%) were skipped because the JVM did not start."
+            Write-Host "   The run decided nothing — a green badge here would be theater (#1385, #1019)."
+            Write-Host "   Likely cause: transient Temurin/JVM-setup flake on the runner. Re-run; if it persists, JVM init is broken on CI (urgent)."
+            exit 1
+          }
+          Write-Host "✅ JVM-startup guard OK — JVM-dependent tests ran (or skipped for legitimate non-JVM reasons)."
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Context (#1385)

The main CI run [`28663783651`](https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/actions/runs/28663783651) reported **conclusion = success** but tested almost nothing: **12947 / 12947 tests skipped**, pytest wall-time 82s (a real run is ~36 min). Of those skips, **12672** carried the message `Saut du test car la JVM n'est pas réellement démarrée` (the autouse guard at `tests/conftest.py:522`). The JVM failed to start on the runner → ~98% silently skipped → 0 failures → green badge from an infra failure that decided nothing.

This is the anti-théâtre principle (#1019) applied to CI: a run that decides nothing must not report success.

**Authorization:** user arbitration 2026-07-04 lifted CI path protection for #1385 (this `.github/workflows/ci.yml` edit). Coordinator R557 routed this to po-2025 as self-pickup (po-2023 unreachable 6h+).

## Fix

Add a post-pytest step `Fail-loud guard — JVM-startup skip storm` that fails the job when the JVM-not-started skip signature dominates (>50% of collected tests).

**Targeted to the signature, NOT the raw skip rate** (dispatch R557 spec): legitimate skips (`orphan-model`, `build dir absent`, `requires_api`) never trip it — only the JVM-startup-failure signature does. This avoids false-positives on honest-absent skips.

Key properties:
- `if: always() && env.API_KEYS_CONFIGURED == 'true'` — fires even on fake-green, only when tests actually executed.
- Scoped regex on `message="...signature..."` — a signature mention in test names/stdout cannot inflate the count.
- Placed before `Upload test results` so the junit diagnostic is uploaded regardless of the guard's verdict.
- Clear remediation message (transient Temurin flake vs systemic JVM breakage).

## Validation (local, 3 synthetic junitxmls)

| Scenario | JVM skip ratio | Expected | Result |
|----------|---------------|----------|--------|
| Fake-green (JVM failed) | 60% | FAIL-LOUD | ✅ FAIL-LOUD |
| Healthy run | 0% | PASS | ✅ PASS |
| Build-absent (29 legit skips, 0 JVM) | 0% | PASS (no false-positive) | ✅ PASS |

## Files changed

| File | Type | Reason |
|------|------|--------|
| `.github/workflows/ci.yml` | config (CI) | Add fail-loud guard step (+34 lines, 0 deletions — strictly additive) |

No prod code, no test files. mypy gate unaffected (CI config out of the 8-file strict scope).

## Note on current CI state

CI is currently RED on all recent main runs (~20-22 F+E ATT-1 debt, known, mypy gate OK). The #1385 fake-green was transient (JVM now starts). The guard is **defensive** — it does not fix a current red, it prevents a future fake-green regression.

Closes #1385.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>