### PR TITLE
fix(tests): point aspic/dung idempotency guard tests at _inner body (#956, #1336)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_sprint5_hygiene_591.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_sprint5_hygiene_591.py
@@ -96,7 +96,13 @@ class TestDungIdempotency:
         """conversational_orchestrator must skip Dung if dung_frameworks is non-empty."""
         from argumentation_analysis.orchestration import conversational_orchestrator
 
-        source = inspect.getsource(conversational_orchestrator.run_conversational_analysis)
+        # The spectacular post-processing (Dung/ASPIC/Modal hooks) lives in the
+        # _run_conversational_analysis_inner body — run_conversational_analysis
+        # is now a thin wrapper that delegates to it. Inspect the body that
+        # actually holds the guard so the assertion survives the extraction.
+        source = inspect.getsource(
+            conversational_orchestrator._run_conversational_analysis_inner
+        )
         # Check that the guard 'not state.dung_frameworks' appears in the Dung block
         assert "not state.dung_frameworks" in source, (
             "Dung hook should have idempotency guard checking "
@@ -111,7 +117,12 @@ class TestAspicIdempotency:
         """conversational_orchestrator must skip ASPIC if aspic_results is non-empty."""
         from argumentation_analysis.orchestration import conversational_orchestrator
 
-        source = inspect.getsource(conversational_orchestrator.run_conversational_analysis)
+        # See test_conversational_orchestrator_dung_guard: the guard moved into
+        # _run_conversational_analysis_inner when the body was extracted from
+        # the (now wrapper) run_conversational_analysis.
+        source = inspect.getsource(
+            conversational_orchestrator._run_conversational_analysis_inner
+        )
         assert "not state.aspic_results" in source, (
             "ASPIC hook should have idempotency guard checking "
             "'not state.aspic_results' before invocation"


### PR DESCRIPTION
## What

Two of the 21 ATT-1 main-RED failures are stale hygiene tests, not guard regressions:

- `TestDungIdempotency::test_conversational_orchestrator_dung_guard`
- `TestAspicIdempotency::test_conversational_orchestrator_aspic_guard`

Both do `inspect.getsource(run_conversational_analysis)` and assert `'not state.dung_frameworks'` / `'not state.aspic_results'` is present.

## Root cause (verified firsthand)

Commit `eec7339d` (#950/#956) extracted the body of `run_conversational_analysis` into `_run_conversational_analysis_inner`, leaving the outer function as a thin wrapper (`return await _run_conversational_analysis_inner(...)` at line 71). The Dung/ASPIC idempotency guards moved **with** the body — they are live and functional at:

- `conversational_orchestrator.py:1020` → `if spectacular and hasattr(state, "dung_frameworks") and not state.dung_frameworks:`
- `conversational_orchestrator.py:1056` → `if spectacular and hasattr(state, "aspic_results") and not state.aspic_results:`

The tests kept inspecting the outer wrapper's source, so they have been RED on CI since #956. The guards never regressed — the test pointed at the wrong function.

## Fix

Point `inspect.getsource` at `_run_conversational_analysis_inner` (where the spectacular post-processing + guards actually live). Intent preserved: still asserts the idempotency guard is present before Dung/ASPIC invocation. Comment explains why so a future reader doesn't "fix" it back.

## Validation

```
tests/unit/argumentation_analysis/orchestration/test_sprint5_hygiene_591.py
5 passed, 0 failed  (incl. both corrected guard tests)
```

## Scope

Test-only. No prod change. Anti-pendule: not weakening — pointing the test at where the guard provably lives after a legitimate refactor.

## ATT-1 #1336 context

This closes 2 of the 21 RED on main. The remaining no-api-key cluster (4 tests) is a separate test-ordering-pollution issue — escalated to coordinator separately (not addressed here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)