### PR TITLE
fix(tests): drop stale analyze_text/llm orchestrator test (#885, #1336)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_service_manager.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_service_manager.py
@@ -940,40 +940,6 @@ class TestRunSpecializedAnalysis:
             assert result["method"] == "fact_checking"
             assert result["request_id"] == "req-123"
 
-    async def test_analyze_text_interface(self, manager):
-        """Orchestrator with analyze_text method (legacy LLM interface)."""
-        mock_orch = MagicMock()
-        mock_orch.__class__.__name__ = "LLMOrchestrator"
-        # No analyze_with_fact_checking
-        del mock_orch.analyze_with_fact_checking
-
-        mock_result = MagicMock()
-        mock_result.request_id = "req-456"
-        mock_result.analysis_type = "llm"
-        mock_result.result = {"data": "llm_result"}
-        mock_result.confidence = 0.95
-        mock_result.processing_time = 2.0
-        mock_result.timestamp = datetime(2026, 1, 1)
-
-        mock_orch.analyze_text = AsyncMock(return_value=mock_result)
-
-        import sys
-
-        mock_llm_module = MagicMock()
-        mock_llm_module.LLMAnalysisRequest = MagicMock()
-
-        with patch.dict(
-            sys.modules,
-            {
-                "argumentation_analysis.orchestration.real_llm_orchestrator": mock_llm_module
-            },
-        ):
-            result = await manager._run_specialized_analysis(
-                mock_orch, "test text", "llm", {"context": "test"}
-            )
-            assert result["method"] == "real_llm"
-            assert result["request_id"] == "req-456"
-
     async def test_generic_analyze_interface(self, manager):
         """Orchestrator with generic analyze() method."""
         mock_orch = MagicMock()


### PR DESCRIPTION
## What

Closes 1 of the 21 ATT-1 main-RED failures:

- `TestRunSpecializedAnalysis::test_analyze_text_interface` — `Exception: Échec analyse orchestrateur: object MagicMock can't be used in 'await' expression`

## Root cause (verified firsthand)

`_run_specialized_analysis` (service_manager.py:599) **no longer has an `analyze_text` / `"llm"` branch** — it was removed in #885. The prod comment at line 634 is explicit:

```
# RealLLMOrchestrator branch removed (#885) — superseded by UnifiedPipeline
```

Current dispatch is `analyze_with_fact_checking` → `analyze` → `process` → raise.

The test mocked `mock_orch.analyze_text = AsyncMock(...)` (never called), then `del mock_orch.analyze_with_fact_checking`. With both removed, prod falls to `hasattr(orchestrator, "analyze")` — MagicMock auto-creates `analyze` as a plain `MagicMock` (not awaitable) → `await orchestrator.analyze(...)` → `TypeError: MagicMock can't be used in 'await'`. The test also asserted `result["method"] == "real_llm"`, a value prod can no longer return.

So the test has been RED since #885 and exercises a code path that no longer exists.

## Fix

Drop the stale test. Redundant — the current prod behavior is fully covered by the rest of `TestRunSpecializedAnalysis`:

| Test | Branch covered |
|------|----------------|
| `test_fact_checking_interface` | `analyze_with_fact_checking` ✓ |
| `test_generic_analyze_interface` | `analyze()` ✓ |
| `test_process_interface` | `process()` ✓ |
| `test_no_supported_method_raises` | raise ✓ |

## Validation

```
TestRunSpecializedAnalysis: 4 passed, 0 failed  (stale test removed)
```

## Scope

Test-only (deletion of 1 stale method). No prod change. Anti-pendule: removing a test that asserts a return value prod cannot produce and exercises a removed branch — not weakening coverage (the 4 surviving tests cover every live branch).

## ATT-1 #1336 context

This is 1 of the 21 RED on main. Separate from the no-api-key cluster (4 tests, collection-order pollution — escalated separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)