### PR TITLE
fix(tests): no-api-key cluster robust to collection-order pollution (option B) (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/test_collaborative_debate.py
+++ b/tests/unit/argumentation_analysis/test_collaborative_debate.py
@@ -295,17 +295,15 @@ class TestInvokeCollaborativeAnalysis:
         """Without API key, should use heuristic fallback."""
         context = {"phase_extract_output": {"arguments": [{"text": "Test argument"}]}}
 
-        # Blank BOTH providers so the toggle (now honored via resolve_chat_endpoint,
-        # #1079) resolves to no key → heuristic fallback. Robust to --allow-dotenv
-        # or OS env carrying OPENROUTER_*.
-        with patch.dict(
-            "os.environ",
-            {
-                "OPENAI_API_KEY": "",
-                "OPENROUTER_API_KEY": "",
-                "OPENROUTER_BASE_URL": "",
-            },
-            clear=False,
+        # ATT-1 #1336: collection-order pollution — patching os.environ is not
+        # enough in the full suite (a prior test leaks a mock/state that re-
+        # exposes the client). Make this robust by patching the canonical
+        # resolver (option B, approved coord R558) → api_key="" hermetically,
+        # regardless of ambient env / leaked mocks. The resolver is imported
+        # lazily inside _invoke_collaborative_analysis, so patch at its source.
+        with patch(
+            "argumentation_analysis.core.llm_service.resolve_chat_endpoint",
+            return_value=("", "", ""),
         ):
             result = await _invoke_collaborative_analysis("test text", context)
 

--- a/tests/unit/argumentation_analysis/test_llm_fallacy_detector.py
+++ b/tests/unit/argumentation_analysis/test_llm_fallacy_detector.py
@@ -32,8 +32,16 @@ class TestLLMFallacyDetector:
     def test_is_not_available_without_api_key(self):
         """Detector unavailable without OPENAI_API_KEY."""
         detector = self._make_detector()
-        with patch.dict("os.environ", {}, clear=True):
-            detector._available = None
+        # ATT-1 #1336: collection-order pollution — a prior test in the full
+        # suite leaks a mock/state such that, even with clear=True, the LLM
+        # client resolves as available. Make this test robust by patching the
+        # canonical resolver (option B, approved coord R558) so api_key is ""
+        # hermetically, regardless of ambient env / leaked mocks.
+        with patch(
+            "argumentation_analysis.core.llm_service.resolve_chat_endpoint",
+            return_value=("", "", ""),
+        ):
+            detector._available = None  # reset cache
             assert not detector.is_available()
 
     async def test_detect_async_parses_response(self):

--- a/tests/unit/argumentation_analysis/test_nl_to_logic.py
+++ b/tests/unit/argumentation_analysis/test_nl_to_logic.py
@@ -144,22 +144,25 @@ class TestNLToLogicTranslator:
     async def test_translate_no_api_key_uses_heuristic(self):
         """Without API key, translate falls back to heuristic."""
         translator = self._make_translator()
-        # ATT-1 #1336: isolate BOTH API channels. The prod translator
-        # (_translate_with_llm) checks OpenRouter FIRST, then OpenAI; patching
-        # only OPENAI_API_KEY with clear=False leaks OPENROUTER_API_KEY from the
-        # real .env, routing to the LLM path (high confidence) instead of the
-        # heuristic. Hermétique isolation = patch both channels.
-        with patch.dict(
-            "os.environ",
-            {"OPENAI_API_KEY": "", "OPENROUTER_API_KEY": ""},
-            clear=False,
-        ):
+        # ATT-1 #1336: collection-order pollution — patching os.environ is not
+        # enough in the full suite (a prior test leaks a mock/state that re-
+        # exposes an api_key, routing to the LLM path). Make this robust by
+        # patching the AsyncOpenAI constructor to raise (option B, approved
+        # coord R558): translate() catches and falls back to heuristic, so this
+        # tests the "LLM unavailable → heuristic" intent hermetically,
+        # independent of ambient env / leaked mocks.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no key")):
             result = await translator.translate(
                 "All men are mortal. Socrates is a man. Therefore Socrates is mortal.",
                 logic_type="propositional",
             )
         assert result.is_valid is True
-        assert result.confidence <= 0.3  # heuristic confidence
+        # Heuristic markers (#1019 anti-théâtre): the heuristic path sets
+        # confidence=0.3 and a "Heuristic translation (no LLM)" message. Assert
+        # both so a silent LLM-path leak (confidence=0.7+, LLM message) fails
+        # loud rather than passing on the wrong branch.
+        assert result.confidence == 0.3
+        assert "Heuristic" in result.validation_message
 
     @pytest.mark.asyncio
     async def test_translate_with_mock_llm(self):
@@ -374,12 +377,11 @@ class TestNLToLogicPipelineIntegration:
                 ],
             },
         }
-        # ATT-1 #1336: isolate BOTH API channels (see test_translate_no_api_key_uses_heuristic).
-        with patch.dict(
-            "os.environ",
-            {"OPENAI_API_KEY": "", "OPENROUTER_API_KEY": ""},
-            clear=False,
-        ):
+        # ATT-1 #1336: collection-order pollution — patching os.environ is not
+        # enough in the full suite (see test_translate_no_api_key_uses_heuristic).
+        # Patch the AsyncOpenAI constructor (option B, coord R558) so the LLM
+        # path fails hermetically → translate() catches → heuristic.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no key")):
             result = await _invoke_nl_to_logic("test input text", context)
 
         assert "translations" in result


### PR DESCRIPTION
## What

Closes the 4/21 ATT-1 no-key cluster. Option **(B)** — approved coord R558, endorsed po-2026/Hermes.

## Root cause (firsthand, re-diagnosed R559 — corrects PR #1400's premise)

The 4 tests are STILL RED on PR #1400's own merge run (28730466099) — #1400 was ineffective. **NOT env-hermeticity** (the #1400 premise):

- Tests PASS in isolation (1 test) AND as a pair (37/37 across both files).
- `LLMFallacyDetector::test_is_not_available_without_api_key` uses `clear=True` (empties ALL os.environ) → STILL returns `is_available()=True` on CI → leak is NOT os.environ.
- Minimal repro (`patch.dict` + `resolve_chat_endpoint`) returns `api_key=''` correctly in isolation.

**=> Collection-order pollution** (dashboard-known pattern). A prior test in the full suite leaves a leaked mock/state (`resolve_chat_endpoint` / `_get_openai_client` / `openai.AsyncOpenAI` or torch/asyncio) that re-exposes the client → LLM path taken. Evidence: CI result for `test_translate_no_api_key_uses_heuristic` had `confidence=0.9`, `formula='(p && q) => r'`, `validation_message='Valid propositional formula (Tweety)'`, `attempts=1` (heuristic would be `0.3 / attempts=0 / 'Heuristic translation (no LLM)'`).

## Fix — option (B): neutralize the LLM path hermetically at the construct point

| Test | Patch | Why this form |
|------|-------|---------------|
| `test_translate_no_api_key_uses_heuristic` | `openai.AsyncOpenAI` → raise | `translate()` has `try/except Exception → heuristic`; raise is caught cleanly |
| `test_invoke_nl_to_logic_heuristic` | `openai.AsyncOpenAI` → raise | same catch path |
| `test_is_not_available_without_api_key` | `resolve_chat_endpoint` → `("","","")` | `is_available()` has NO try/except — constructor-raise would crash; resolver-patch returns `api_key=""` → client None → False |
| `test_no_api_key_uses_fallback` | `resolve_chat_endpoint` → `("","","")` | `_invoke_collaborative_analysis` branches on `api_key` → `fallback_heuristic` |

Asserts strengthened (#1019 anti-théâtre): `test_translate_no_api_key_uses_heuristic` now asserts the real heuristic markers (confidence==0.3 + \"Heuristic\" in validation_message) so a silent LLM-path leak fails loud instead of passing on the wrong branch.

## Validation

```
4/4 target tests PASS with CI env reproduced (OPENAI+OPENROUTER keys set = simulating pollution)
60/60 PASS across the 3 full files (0 regression): test_nl_to_logic, test_llm_fallacy_detector, test_collaborative_debate
```

The fix is hermetic by construction — patches the construct/resolver, not env, so it survives the collection-order pollution that defeated #1400.

## Scope

Test-only. Anti-pendule: removes fragile ambient-env dependence; does NOT weaken the \"LLM unavailable → fallback\" contract (asserts real heuristic markers, not just absence-of-LLM). Option (A) source-polluter hunt routed to po-2023 backlog (unblocks the family at the root, separate effort).

## ATT-1 #1336 context

Closes 4 of the ~17 RED on main. Separate from env-read (SafeFloat/Budget, ~2) — those are collection-order too but option (B) \"patch constructor\" does not apply (no LLM constructor); investigated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)