### PR TITLE
fix(tests): locale-independent shell-error + pkg_resources→importlib.metadata (ATT-1 tail) (#1336)

### DIFF
--- a/tests/unit/argumentation_analysis/utils/core_utils/test_system_utils.py
+++ b/tests/unit/argumentation_analysis/utils/core_utils/test_system_utils.py
@@ -189,19 +189,17 @@ def test_run_shell_command_with_work_dir(mock_subprocess_run, tmp_path):
 def test_run_shell_command_empty_command_string(caplog):
     """Teste le comportement avec une chaîne de commande vide."""
     # shlex.split('') -> []
-    # subprocess.run([]) lèvera probablement une exception (FileNotFoundError ou autre)
-    # car il n'y a pas de commande à exécuter.
+    # subprocess.run([]) lève OSError [WinError 87] sur Windows (commande vide),
+    # attrapée par le bloc `except Exception` générique → retourne -11.
     ret_code, out, err = run_shell_command("")
 
-    assert (
-        ret_code == -11
-    )  # OSError: [WinError 87] Paramètre incorrect est capturée par le except Exception générique
-    assert "Paramètre incorrect" in err  # Vérifie une partie du message de OSError
-    # Le log devrait indiquer une erreur générique car OSError est attrapée par le bloc Exception
-    assert (
-        "Une erreur inattendue est survenue lors de l'exécution de '': OSError - [WinError 87] Paramètre incorrect"
-        in caplog.text
-    )
-    # Les commentaires et assertions précédents supposaient un FileNotFoundError ou IndexError,
-    # mais c'est une OSError sur Windows pour une commande vide passée à subprocess.run,
-    # qui est ensuite attrapée par le bloc `except Exception`.
+    assert ret_code == -11  # OSError capturée par le except Exception générique
+    # ATT-1 #1336: le message OS est locale-dépendant (« Paramètre incorrect » en
+    # FR, « The parameter is incorrect » en en-US sur le runner CI). Le numéro
+    # [WinError 87] est stable cross-locale — asserter sur lui, pas sur le texte
+    # traduit. (précédemment : assert "Paramètre incorrect" → RED sur CI en-US)
+    assert "[WinError 87]" in err
+    # Le log prod préfixe en français (« Une erreur inattendue... ») — stable,
+    # contrairement au message OS traduit. Vérifier le préfixe + le code d'erreur.
+    assert "Une erreur inattendue est survenue lors de l'exécution de ''" in caplog.text
+    assert "[WinError 87]" in caplog.text

--- a/tests/unit/scripts/test_jpype_dependency_validator.py
+++ b/tests/unit/scripts/test_jpype_dependency_validator.py
@@ -85,18 +85,22 @@ class TestJPypeDependencyValidator:
 
     def test_environment_diagnostics(self):
         """Test 6: Diagnostics détaillés de l'environnement"""
-        import pkg_resources
+        # ATT-1 #1336: pkg_resources est déprécié/retiré dans setuptools récent
+        # (>=67 deprecated, retiré par défaut en 81+/82 → ModuleNotFoundError sur
+        # CI et localement). Migrer vers importlib.metadata (stdlib, Python 3.8+),
+        # replacement officiel pour parcourir les distributions installées.
+        from importlib.metadata import distributions
 
         # Rechercher tous les packages JPype
         jpype_packages = [
-            pkg
-            for pkg in pkg_resources.working_set
-            if "jpype" in pkg.project_name.lower()
+            dist
+            for dist in distributions()
+            if "jpype" in (dist.metadata.get("Name", "") or "").lower()
         ]
 
         print(f"\n📦 Packages JPype trouvés: {len(jpype_packages)}")
-        for pkg in jpype_packages:
-            print(f"   - {pkg.project_name} {pkg.version} ({pkg.location})")
+        for dist in jpype_packages:
+            print(f"   - {dist.metadata['Name']} {dist.version} ({dist.locate_file('')})")
 
         # Vérifier l'environnement Python
         print(f"\n🐍 Environnement Python:")


### PR DESCRIPTION
## What

Closes 2 ATT-1 main-RED tests, both test-only, root-caused firsthand.

### 1. test_run_shell_command_empty_command_string (test_system_utils.py:189)

Asserted the **OS-localized** message `'Paramètre incorrect'` (Windows FR). The CI runner is en-US → returns `'The parameter is incorrect'` → RED on CI, GREEN locally.

The error **number** `[WinError 87]` is stable cross-locale; assert on it instead. The prod log prefix `'Une erreur inattendue...'` is French (stable), so assert prefix + `[WinError 87]`.

### 2. TestJPypeDependencyValidator::test_environment_diagnostics (test_jpype_dependency_validator.py:86)

`import pkg_resources` → `ModuleNotFoundError` on setuptools 82+ (deprecated ≥67, removed by default recently). **Confirmed missing LOCALLY too** (not CI-only) — real debt, not flake:

```
$ python -c \"import pkg_resources\"
ModuleNotFoundError: No module named 'pkg_resources'
$ python -c \"import setuptools; print(setuptools.__version__)\"
82.0.1
```

Migrate to **importlib.metadata** (stdlib, Python 3.8+, official replacement): `distributions()` + `metadata['Name']`. Verified: finds jpype1 1.6.0.

## Validation

```
test_run_shell_command_empty_command_string: PASSED (FR locale; [WinError 87] stable → will pass en-US CI)
test_environment_diagnostics: PASSED (1 jpype1 1.6.0 found via importlib.metadata)
```

## Scope

Test-only. Anti-pendule: subtraction of locale-coupling and deprecated-dep, no contract weakened.

## ATT-1 #1336 context

2 of the ~17 RED on main. Part of the T3 \"ATT-1 tail\" sweep (dispatch R558). Separate from: no-key cluster (PR #1406, option B), npm-build (#1403 rebased), env-read (SafeFloat+Budget, collection-order pollution — deferred pending polluter identification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)