### PR TITLE
docs(att-5): fix 3 #1410 findings (consolidation-narrative + quickstart) #1315

### DIFF
--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -85,7 +85,7 @@ R: Si vous rencontrez des conflits, essayez d'installer les dépendances dans ce
 
 R: Pour une utilisation rapide, suivez ces étapes :
 1. Installez le package : `pip install -e .`
-2. Exécutez l'analyse sur un exemple : `python scripts/run_analysis.py --file examples/exemple_sophisme.txt`. Pour d'autres exemples de scripts prêts à l'emploi, explorez le répertoire [`scripts/`](../../scripts/) (l'ancien sous-dossier `examples/scripts_demonstration/` a été consolidé). Si vous souhaitez utiliser l'interface web, consultez le guide de démarrage rapide : [`docs/projets/sujets/aide/interface-web/DEMARRAGE_RAPIDE.md`](../projets/sujets/aide/interface-web/DEMARRAGE_RAPIDE.md).
+2. Exécutez l'analyse sur un exemple : `python argumentation_analysis/run_orchestration.py --file examples/scenarios/philosophy.txt`. Pour d'autres exemples de scripts prêts à l'emploi, explorez le répertoire [`scripts/`](../../scripts/). Si vous souhaitez utiliser l'interface web, consultez le guide de démarrage rapide : [`docs/projets/sujets/aide/interface-web/DEMARRAGE_RAPIDE.md`](../projets/sujets/aide/interface-web/DEMARRAGE_RAPIDE.md).
 3. Consultez les résultats dans le dossier `results/`
 
 **Q: Comment utiliser l'API web ?**
@@ -180,7 +180,7 @@ R: Les résultats sont stockés dans plusieurs formats :
 - Markdown pour la lisibilité humaine
 - Base de données (optionnel) pour la persistance
 - Visualisations graphiques pour la présentation
-Vous pouvez trouver des exemples de ces formats de sortie dans le répertoire `examples/test_data/results/` (si disponible) ou générés par les scripts dans [`scripts/`](../../scripts/) (l'ancien sous-dossier `examples/scripts_demonstration/` a été consolidé).
+Vous pouvez trouver des exemples de ces formats de sortie dans le répertoire `examples/test_data/results/` (si disponible) ou générés par les scripts dans [`scripts/`](../../scripts/) et [`examples/scripts_demonstration/`](../../examples/scripts_demonstration/).
 
 ### Extension du système
 
@@ -266,7 +266,7 @@ R: En cas de problèmes de compatibilité :
 
 R: Vous pouvez contribuer de plusieurs façons :
 1. Corriger des bugs et soumettre des pull requests
-2. Ajouter de nouveaux exemples (scripts, notebooks, données de test) dans les sous-répertoires de [`examples/`](../../examples) tels que `examples/notebooks/`. (Les anciens sous-dossiers `examples/logic_agents/`, `examples/scripts_demonstration/` et `examples/test_data/` ont été consolidés dans `examples/` ou `scripts/`.)
+2. Ajouter de nouveaux exemples (scripts, notebooks, données de test) dans les sous-répertoires de [`examples/`](../../examples) tels que `examples/notebooks/` et [`examples/scripts_demonstration/`](../../examples/scripts_demonstration/). (Les anciens sous-dossiers `examples/logic_agents/` et `examples/test_data/` ont été consolidés.)
 3. Améliorer la documentation
 4. Proposer de nouvelles fonctionnalités via les issues GitHub
 

--- a/docs/guides/FAQ.md
+++ b/docs/guides/FAQ.md
@@ -180,7 +180,7 @@ R: Les résultats sont stockés dans plusieurs formats :
 - Markdown pour la lisibilité humaine
 - Base de données (optionnel) pour la persistance
 - Visualisations graphiques pour la présentation
-Vous pouvez trouver des exemples de ces formats de sortie dans le répertoire `examples/test_data/results/` (si disponible) ou générés par les scripts dans [`scripts/`](../../scripts/) et [`examples/scripts_demonstration/`](../../examples/scripts_demonstration/).
+Vous pouvez trouver des exemples de ces formats de sortie dans le répertoire `examples/test_data/results/` (si disponible) ou générés par les scripts dans [`scripts/`](../../scripts/) et [`examples/02_core_system_demos/scripts_demonstration/`](../../examples/02_core_system_demos/scripts_demonstration/).
 
 ### Extension du système
 
@@ -266,7 +266,7 @@ R: En cas de problèmes de compatibilité :
 
 R: Vous pouvez contribuer de plusieurs façons :
 1. Corriger des bugs et soumettre des pull requests
-2. Ajouter de nouveaux exemples (scripts, notebooks, données de test) dans les sous-répertoires de [`examples/`](../../examples) tels que `examples/notebooks/` et [`examples/scripts_demonstration/`](../../examples/scripts_demonstration/). (Les anciens sous-dossiers `examples/logic_agents/` et `examples/test_data/` ont été consolidés.)
+2. Ajouter de nouveaux exemples (scripts, notebooks, données de test) dans les sous-répertoires de [`examples/`](../../examples) tels que `examples/notebooks/` et [`examples/02_core_system_demos/scripts_demonstration/`](../../examples/02_core_system_demos/scripts_demonstration/). (Les anciens sous-dossiers `examples/logic_agents/` et `examples/test_data/` ont été consolidés.)
 3. Améliorer la documentation
 4. Proposer de nouvelles fonctionnalités via les issues GitHub
 

--- a/docs/projets/ACCOMPAGNEMENT_ETUDIANTS.md
+++ b/docs/projets/ACCOMPAGNEMENT_ETUDIANTS.md
@@ -6,7 +6,7 @@ Ce document a pour but de centraliser les informations utiles, les conseils, les
 
 ## 1. Points d'Attention Généraux
 
-*   **Configuration de l'environnement** : Assurez-vous d'avoir correctement configuré votre environnement Python, Java (JDK 11+), et JPype. Le notebook Tweety (Partie 1) — situé dans le dossier du cours `D:/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Tweety/` — détaille les étapes. Pour des exemples de scripts d'initialisation, voir le répertoire [`scripts/`](../../scripts/) (les anciens sous-dossiers `scripts/execution/` et `scripts/testing/` ont été consolidés dans `scripts/`).
+*   **Configuration de l'environnement** : Assurez-vous d'avoir correctement configuré votre environnement Python, Java (JDK 11+), et JPype. Le notebook Tweety (Partie 1) — situé dans le dossier du cours `D:/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Tweety/` — détaille les étapes. Pour des exemples de scripts d'initialisation, voir le répertoire [`scripts/`](../../scripts/) (l'ancien sous-dossier `scripts/execution/` a été consolidé dans `scripts/` ; [`scripts/testing/`](../../scripts/testing/) reste disponible séparément).
 *   **Utilisation de TweetyProject** : De nombreux sujets s'appuient sur TweetyProject. Familiarisez-vous avec :
     *   Le notebook principal : Tweety (voir `D:/CoursIA/MyIA.AI.Notebooks/SymbolicAI/Tweety/`)
     *   Les exemples de code par projet : [`exemples_tweety_par_projet.md`](./exemples_tweety_par_projet.md)

--- a/docs/projets/README.md
+++ b/docs/projets/README.md
@@ -40,7 +40,7 @@ Pour une vue d'ensemble de tous les sujets avec leur structure standardisée :
 
 De nombreuses ressources sont à votre disposition pour vous aider à démarrer :
 
-- **Exemples de scripts** : [`../../examples/`](../../examples/) (les anciens sous-dossiers `examples/logic_agents/` et `examples/scripts_demonstration/` ont été consolidés)
+- **Exemples de scripts** : [`../../examples/`](../../examples/) et [`../../examples/scripts_demonstration/`](../../examples/scripts_demonstration/) (l'ancien sous-dossier `examples/logic_agents/` a été consolidé)
 - **Notebooks Jupyter didactiques** : [`../../examples/notebooks/`](../../examples/notebooks/)
 - **Tests unitaires** : [`../../tests/unit/`](../../tests/unit/)
 - **Tests d'intégration** : [`../../tests/integration/`](../../tests/integration/)

--- a/docs/projets/README.md
+++ b/docs/projets/README.md
@@ -40,7 +40,7 @@ Pour une vue d'ensemble de tous les sujets avec leur structure standardisée :
 
 De nombreuses ressources sont à votre disposition pour vous aider à démarrer :
 
-- **Exemples de scripts** : [`../../examples/`](../../examples/) et [`../../examples/scripts_demonstration/`](../../examples/scripts_demonstration/) (l'ancien sous-dossier `examples/logic_agents/` a été consolidé)
+- **Exemples de scripts** : [`../../examples/`](../../examples/) et [`../../examples/02_core_system_demos/scripts_demonstration/`](../../examples/02_core_system_demos/scripts_demonstration/) (l'ancien sous-dossier `examples/logic_agents/` a été consolidé)
 - **Notebooks Jupyter didactiques** : [`../../examples/notebooks/`](../../examples/notebooks/)
 - **Tests unitaires** : [`../../tests/unit/`](../../tests/unit/)
 - **Tests d'intégration** : [`../../tests/integration/`](../../tests/integration/)


### PR DESCRIPTION
Follow-up to #1410 (ATT-5 Phase 1, merged f27059ab). Fixes the 3 non-blocking findings from the po-2023 cross-machine review of #1410. Dispatched by coord R562 RE-ENGAGE.

Findings fixed (verify-before-assert firsthand):
1. scripts/testing/ claimed consolidated but still exists (32 files) — only scripts/execution/ removed. Link scripts/testing/ directly.
2. examples/scripts_demonstration/ claimed consolidated but still exists (6 files, load-bearing: pipeline imports it). Link it; only logic_agents/ + test_data/ consolidated.
3. FAQ quickstart pointed to non-existent scripts/run_analysis.py + exemple_sophisme.txt — rerouted to real CLI argumentation_analysis/run_orchestration.py --file examples/scenarios/philosophy.txt.

Verification: 7/7 newly-cited paths exist; 3 retired consolidated-dirs confirmed gone; run_orchestration.py has real --file/--text argparse CLI.

Rules: anti-pendule (suppressed false claims), anti-théâtre #1019 (no invented scripts), privacy (neutral example file). md-only diff (5±5, 3 files). Disjoint from po-2025 ATT-5 Phase 2 (architecture/*).

po-2023 — dispatched R562 RE-ENGAGE. Machine identity on workspace dashboard.