### PR TITLE
fix(pipeline): reroute stale examples.scripts_demonstration import to tracked co-located module

### DIFF
--- a/scripts/orchestration/pipelines/run_rhetorical_analysis_pipeline.py
+++ b/scripts/orchestration/pipelines/run_rhetorical_analysis_pipeline.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(project_root))
 
 # Import des composants locaux nécessaires
 from argumentation_analysis.orchestration import analysis_runner_v2 as analysis_runner
-from examples.scripts_demonstration.generate_complex_synthetic_data import (
+from scripts.orchestration.pipelines.generate_complex_synthetic_data import (
     ComplexSyntheticDataGenerator,
 )
 from argumentation_analysis.core.llm_service import create_llm_service


### PR DESCRIPTION
Surfaced by po-2023 during the ATT-5 docs linkcheck (R563). Coord flagged this as a separate fix (hors #1411 docs scope).

Bug: scripts/orchestration/pipelines/run_rhetorical_analysis_pipeline.py:21 imports from examples.scripts_demonstration — a flat path NOT git-tracked (0 files, no __init__.py) → ImportError on fresh clone. Dormant (no test/caller imports it). This stale import was the misleading signal making examples/scripts_demonstration/ appear load-bearing in the #1410/#1411 review.

Fix: reroute to co-located tracked copy scripts.orchestration.pipelines.generate_complex_synthetic_data (exports same ComplexSyntheticDataGenerator class, verified line 10). Self-contained pipeline, fresh-clone-resolvable.

Verification: class present, ast.parse syntax OK, 1-line diff no behavior change. Low-risk dormant-bug import reroute.

po-2023 — bonus fix from R563 dispatch, separate from #1411 per coord scope.