### PR TITLE
docs(att-5): Phase 2 linkcheck reroute in guides/ #1315

### DIFF
--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -17,7 +17,7 @@ La documentation est organisée selon une structure hiérarchique à trois nivea
 - **Niveau 2** : Sous-catégories ou thèmes spécifiques
 - **Niveau 3** : Documents individuels
 
-Pour plus de détails sur la structure, consultez le fichier [docs/STRUCTURE.md](docs/STRUCTURE.md).
+Pour plus de détails sur la structure, consultez le fichier docs/STRUCTURE.md.
 
 ## Conventions de Nommage
 
@@ -89,4 +89,4 @@ La documentation doit être révisée régulièrement pour :
 
 - [Guide de syntaxe Markdown](https://www.markdownguide.org/basic-syntax/)
 - [Mermaid pour les diagrammes](https://mermaid-js.github.io/mermaid/#/)
-- [Documentation sur les conventions du projet](./guides/conventions_importation.md)
+- [Documentation sur les conventions du projet](./conventions_importation.md)

--- a/docs/guides/GETTING_STARTED.md
+++ b/docs/guides/GETTING_STARTED.md
@@ -98,7 +98,7 @@ Le cycle de vie d'une analyse argumentative suit les étapes suivantes :
         ```
         Ce script va :
         *   Vérifier la présence de Conda.
-        *   Créer ou mettre à jour l'environnement Conda `projet-is` à partir du fichier [`environment.yml`](environment.yml:1). Cet environnement inclut Python 3.10, Clingo, JPype1, et toutes les autres dépendances.
+        *   Créer ou mettre à jour l'environnement Conda `projet-is` à partir du fichier [`environment.yml`](../../environment.yml:1). Cet environnement inclut Python 3.10, Clingo, JPype1, et toutes les autres dépendances.
         *   Gérer l'installation d'un JDK portable (pour JPype) si nécessaire.
         *   Créer et configurer un fichier `.env` à la racine du projet pour les variables d'environnement (comme `JAVA_HOME`, et les emplacements pour les clés API).
         *   Vous demander de confirmer la suppression d'anciens répertoires `venv` s'ils sont détectés.

--- a/docs/guides/GUIDE_DEMARRAGE_RAPIDE_PROJET_EPITA.md
+++ b/docs/guides/GUIDE_DEMARRAGE_RAPIDE_PROJET_EPITA.md
@@ -377,7 +377,7 @@ python -m pytest tests/unit/ -v --timeout=300 -m "not slow"
 
 ### 🏗️ Pour Développeurs
 - **[Architecture Système](../architecture/README.md)** : Documentation technique détaillée
-- **[Guide des Composants](../composants/README.md)** : Modules réutilisables
+- **[Guide des Composants](../technical/README.md)** : Modules réutilisables
 - **[Patterns d'Orchestration](GUIDE_PATTERNS_ORCHESTRATION_MODES.md)** : Bonnes pratiques
 
 ### 🔬 Pour Chercheurs

--- a/docs/guides/GUIDE_INSTALLATION_ETUDIANTS.md
+++ b/docs/guides/GUIDE_INSTALLATION_ETUDIANTS.md
@@ -25,9 +25,9 @@ Avant de commencer, assurez-vous d'avoir les éléments suivants installés sur 
 
 ## 2. Configuration Initiale de l'Environnement avec `setup_project_env.ps1`
 
-Le script [`setup_project_env.ps1`](setup_project_env.ps1:1) est conçu pour automatiser la configuration complète de votre environnement Conda. Il effectuera les actions suivantes :
+Le script [`setup_project_env.ps1`](../../setup_project_env.ps1:1) est conçu pour automatiser la configuration complète de votre environnement Conda. Il effectuera les actions suivantes :
 *   Vérification de l'installation de Conda.
-*   Création ou mise à jour de l'environnement Conda nommé `projet-is` à partir du fichier [`environment.yml`](environment.yml:1). Cet environnement inclura Python 3.10, Clingo, JPype1, et toutes les autres dépendances listées.
+*   Création ou mise à jour de l'environnement Conda nommé `projet-is` à partir du fichier [`environment.yml`](../../environment.yml:1). Cet environnement inclura Python 3.10, Clingo, JPype1, et toutes les autres dépendances listées.
 *   Téléchargement et configuration du JDK portable (Java Development Kit 17), si non géré par Conda.
 *   Configuration du fichier `.env` avec les chemins nécessaires (comme `JAVA_HOME`).
 *   Demande de confirmation pour supprimer les anciens répertoires `venv` s'ils existent.
@@ -71,7 +71,7 @@ Chaque fois que vous souhaitez travailler sur le projet, vous devez activer l'en
     python --version     # Devrait afficher Python 3.10.x
     conda list           # Pour voir les paquets installés dans l'environnement Conda
     ```
-    Le script [`activate_project_env.ps1`](activate_project_env.ps1:1) a été simplifié et sert maintenant principalement de rappel pour la commande `conda activate projet-is`. Vous pouvez toujours l'exécuter pour voir ce rappel :
+    Le script [`activate_project_env.ps1`](../../activate_project_env.ps1:1) a été simplifié et sert maintenant principalement de rappel pour la commande `conda activate projet-is`. Vous pouvez toujours l'exécuter pour voir ce rappel :
     ```powershell
     .\activate_project_env.ps1
     ```
@@ -80,7 +80,7 @@ Chaque fois que vous souhaitez travailler sur le projet, vous devez activer l'en
 
 ## 4. Vérification de l'Installation de JPype avec `check_jpype_env.py`
 
-Après avoir activé votre environnement avec `.\activate_project_env.ps1`, vous pouvez utiliser le script [`check_jpype_env.py`](check_jpype_env.py:1) pour effectuer un diagnostic de base de votre configuration JPype.
+Après avoir activé votre environnement avec `.\activate_project_env.ps1`, vous pouvez utiliser le script `check_jpype_env.py` pour effectuer un diagnostic de base de votre configuration JPype.
 
 **Étapes :**
 
@@ -121,7 +121,7 @@ Ce script est la première étape recommandée pour tester votre installation. I
 
 ### 5.2. Script de Démonstration Complet (Optionnel - Pour aller plus loin) : `scripts/demonstration_epita.py`
 
-Le script [`scripts/demonstration_epita.py`](scripts/demonstration_epita.py:1) est une démonstration plus exhaustive des capacités du projet. Il illustre des interactions avancées avec les services réels du projet, tels que l'analyse de texte via des LLMs et le déchiffrement de données.
+Le script [`scripts/demonstration_epita.py`](../../examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py:1) est une démonstration plus exhaustive des capacités du projet. Il illustre des interactions avancées avec les services réels du projet, tels que l'analyse de texte via des LLMs et le déchiffrement de données.
 
 **Prérequis Important : Configuration du Fichier `.env`**
 
@@ -136,7 +136,7 @@ Pour un fonctionnement complet de ce script, notamment l'utilisation des service
 *   **Fichier d'exemple :** Un fichier nommé `.env.example` peut exister (ou devrait être créé s'il n'est pas présent) dans le répertoire `argumentation_analysis`. Ce fichier sert de modèle et liste les variables d'environnement attendues. Copiez-le sous le nom `.env` et remplissez-le avec vos propres valeurs.
 
 **Ce que ce script démontre :**
-*   L'initialisation et l'utilisation du module de bootstrap ([`project_core/bootstrap.py`](project_core/bootstrap.py:1)) pour charger la configuration et les services.
+*   L'initialisation et l'utilisation du module de bootstrap ([`project_core/bootstrap.py`](../../argumentation_analysis/core/bootstrap.py:1)) pour charger la configuration et les services.
 *   L'interaction avec des services réels (LLM, déchiffrement, analyse logique) plutôt que des mocks internes pour ses fonctionnalités principales.
 *   Des opérations logiques complexes via Tweety (satisfiabilité, calcul de modèles).
 *   Des exemples d'analyse de sophismes et d'autres fonctionnalités avancées du projet en utilisant les données et services configurés.
@@ -161,7 +161,7 @@ Pour un fonctionnement complet de ce script, notamment l'utilisation des service
 
 ## 6. Dépannage des Problèmes JPype Courants
 
-Cette section vous aidera à diagnostiquer et résoudre les problèmes fréquents rencontrés avec JPype, **principalement si le script [`check_jpype_env.py`](check_jpype_env.py:1) signale des erreurs après avoir utilisé les scripts d'installation et d'activation.**
+Cette section vous aidera à diagnostiquer et résoudre les problèmes fréquents rencontrés avec JPype, **principalement si le script `check_jpype_env.py` signale des erreurs après avoir utilisé les scripts d'installation et d'activation.**
 
 ### 6.1. Problèmes liés à `jpype.config` et au Démarrage de la JVM
 
@@ -184,7 +184,7 @@ Cette section vous aidera à diagnostiquer et résoudre les problèmes fréquent
     *   **Cause potentielle :** Fichiers JAR non trouvés, `CLASSPATH` incorrect. Source fréquente de `java.lang.ClassNotFoundException`. Le script `activate_project_env.ps1` devrait configurer le `CLASSPATH` nécessaire pour Tweety si les JARs sont dans `libs/tweety_jars`.
     *   **Diagnostic/Solution :**
         1.  **Vérifier le `CLASSPATH` :** Après `.\activate_project_env.ps1`, exécutez `echo $env:CLASSPATH`. Il devrait inclure le chemin vers `libs/tweety_jars/*` si ce dossier existe et contient des JARs.
-        2.  **Afficher le `CLASSPATH` réel utilisé par Java :** Dans un script Python (comme [`check_jpype_env.py`](check_jpype_env.py:1) ou un script de test) après le démarrage de la JVM :
+        2.  **Afficher le `CLASSPATH` réel utilisé par Java :** Dans un script Python (comme `check_jpype_env.py` ou un script de test) après le démarrage de la JVM :
             ```python
             import jpype
             if jpype.isJVMStarted():
@@ -216,6 +216,6 @@ Cette section vous aidera à diagnostiquer et résoudre les problèmes fréquent
 
 ### 6.3. Script de Vérification `check_jpype_env.py` pour Auto-Diagnostic
 
-Référez-vous à la Section 4 pour l'utilisation du script [`check_jpype_env.py`](check_jpype_env.py:1). Ce script est votre premier outil de diagnostic. Il vérifie `JAVA_HOME`, le chemin de la JVM, tente de démarrer la JVM et d'accéder à une classe Java simple.
+Référez-vous à la Section 4 pour l'utilisation du script `check_jpype_env.py`. Ce script est votre premier outil de diagnostic. Il vérifie `JAVA_HOME`, le chemin de la JVM, tente de démarrer la JVM et d'accéder à une classe Java simple.
 
 Félicitations, votre environnement de développement devrait être prêt ! Si vous rencontrez d'autres problèmes, n'hésitez pas à demander de l'aide en fournissant les messages d'erreur complets que vous obtenez.

--- a/docs/guides/PLAN_REORGANISATION_DOCUMENTATION.md
+++ b/docs/guides/PLAN_REORGANISATION_DOCUMENTATION.md
@@ -347,20 +347,20 @@ Le nouveau fichier `README.md` du répertoire `projets/` servira d'index princip
 ## Filtrage par Niveau de Difficulté
 
 ### Niveau ⭐⭐ (Accessible)
-- [Documentation et transfert de connaissances](./developpement_systeme.md#214-documentation-et-transfert-de-connaissances)
+- [Documentation et transfert de connaissances](../projets/developpement_systeme.md#214-documentation-et-transfert-de-connaissances)
 
 ### Niveau ⭐⭐⭐ (Intermédiaire)
-- [Taxonomie des schémas argumentatifs](./fondements_theoriques.md#131-taxonomie-des-schémas-argumentatifs)
-- [Classification des sophismes](./fondements_theoriques.md#132-classification-des-sophismes)
-- [Ontologie de l'argumentation](./fondements_theoriques.md#133-ontologie-de-largumentation)
+- [Taxonomie des schémas argumentatifs](../projets/fondements_theoriques.md#131-taxonomie-des-schémas-argumentatifs)
+- [Classification des sophismes](../projets/fondements_theoriques.md#132-classification-des-sophismes)
+- [Ontologie de l'argumentation](../projets/fondements_theoriques.md#133-ontologie-de-largumentation)
 
 ### Niveau ⭐⭐⭐⭐ (Avancé)
-- [Formules booléennes quantifiées (QBF)](./fondements_theoriques.md#115-formules-booléennes-quantifiées-qbf)
-- [Argumentation basée sur les hypothèses (ABA)](./fondements_theoriques.md#124-argumentation-basée-sur-les-hypothèses-aba)
+- [Formules booléennes quantifiées (QBF)](../projets/fondements_theoriques.md#115-formules-booléennes-quantifiées-qbf)
+- [Argumentation basée sur les hypothèses (ABA)](../projets/fondements_theoriques.md#124-argumentation-basée-sur-les-hypothèses-aba)
 
 ### Niveau ⭐⭐⭐⭐⭐ (Très avancé)
-- [ArgumentuMind: Système cognitif de compréhension argumentative](./lutte_desinformation.md#argumentumind-système-cognitif-de-compréhension-argumentative)
-- [ArgumentuShield: Système de protection cognitive contre la désinformation](./lutte_desinformation.md#argumentushield-système-de-protection-cognitive-contre-la-désinformation)
+- ArgumentuMind: Système cognitif de compréhension argumentative
+- ArgumentuShield: Système de protection cognitive contre la désinformation
 ```
 
 Cette approche permettra de conserver toutes les informations utiles des vues actuelles tout en éliminant les redondances et en améliorant la navigation.

--- a/docs/guides/PROPOSITION_REORG_TESTS.md
+++ b/docs/guides/PROPOSITION_REORG_TESTS.md
@@ -3,7 +3,7 @@
 Ce document propose une nouvelle structure pour le répertoire `tests/` afin d'améliorer la clarté, la maintenabilité et la distinction entre les différents types de tests (unitaires, intégration avec mocks, intégration réelle JVM).
 
 &gt; **Note sur l'État d'Implémentation**
-&gt; Bien que la réorganisation complète des répertoires décrite ici n'ait pas encore été mise en œuvre, des étapes cruciales de stabilisation ont été accomplies, notamment l'isolation des tests JVM via des marqueurs `pytest`. Pour plus de détails sur ces travaux, consultez le [Rapport de Refactoring : Serveur MCP, Stabilisation des Tests et CI](./refactoring/refactoring_mcp_et_stabilisation_ci.md).
+&gt; Bien que la réorganisation complète des répertoires décrite ici n'ait pas encore été mise en œuvre, des étapes cruciales de stabilisation ont été accomplies, notamment l'isolation des tests JVM via des marqueurs `pytest`. Pour plus de détails sur ces travaux, consultez le Rapport de Refactoring : Serveur MCP, Stabilisation des Tests et CI.
 ## Structure Actuelle (Observée)
 
 Le répertoire `tests/` contient actuellement une structure assez plate avec des sous-répertoires thématiques (`agents/`, `functional/`, `integration/`, `mocks/`, etc.), mais la distinction entre les tests unitaires et les tests d'intégration, en particulier ceux qui dépendent de la JVM réelle, n'est pas toujours explicite au premier coup d'œil.

--- a/docs/guides/RUNNERS_ET_VALIDATION_WEB.md
+++ b/docs/guides/RUNNERS_ET_VALIDATION_WEB.md
@@ -212,10 +212,10 @@ jobs:
 
 ## 📚 **Références**
 
-- [Guide de Démarrage Rapide](guides/GUIDE_DEMARRAGE_RAPIDE_PROJET_EPITA.md)
-- [Architecture Hiérarchique](ARCHITECTURE_HIERARCHIQUE_3_NIVEAUX.md)
+- [Guide de Démarrage Rapide](./GUIDE_DEMARRAGE_RAPIDE_PROJET_EPITA.md)
+- [Architecture Hiérarchique](../architecture/ARCHITECTURE_HIERARCHIQUE_3_NIVEAUX.md)
 - [Composants React](COMPOSANTS_REACT_SOPHISTIQUES.md)
-- [Tests Playwright](../tests_playwright/README.md)
+- Tests Playwright
 
 ---
 

--- a/docs/guides/RUN_VALIDATION.md
+++ b/docs/guides/RUN_VALIDATION.md
@@ -62,9 +62,9 @@ python scripts/webapp/unified_web_orchestrator.py --integration --visible
 
 ## 📚 **Documentation Complète**
 
-- **[Guide Runners Complet](docs/RUNNERS_ET_VALIDATION_WEB.md)**
-- **[Guide Démarrage Rapide](docs/guides/GUIDE_DEMARRAGE_RAPIDE_PROJET_EPITA.md)**
-- **[Architecture 3 Niveaux](docs/architecture/ARCHITECTURE_HIERARCHIQUE_3_NIVEAUX.md)**
+- **[Guide Runners Complet](./RUNNERS_ET_VALIDATION_WEB.md)**
+- **[Guide Démarrage Rapide](./GUIDE_DEMARRAGE_RAPIDE_PROJET_EPITA.md)**
+- **[Architecture 3 Niveaux](../architecture/ARCHITECTURE_HIERARCHIQUE_3_NIVEAUX.md)**
 
 ---
 

--- a/docs/guides/TROUBLESHOOTING.md
+++ b/docs/guides/TROUBLESHOOTING.md
@@ -32,9 +32,9 @@ Avant de plonger dans des problèmes spécifiques, plusieurs scripts et ensemble
 *   **Tests Généraux :** Le répertoire [`scripts/testing/`](../../scripts/testing/) contient divers scripts pour tester différentes fonctionnalités du projet.
 *   **Tests Unitaires :** Pour isoler des problèmes au niveau des modules, exécutez les tests situés dans [`tests/unit/`](../../tests/unit/).
 *   **Tests d'Intégration :** Si vous suspectez des problèmes d'interaction entre différents composants, les tests dans [`tests/integration/`](../../tests/integration/) peuvent être utiles.
-*   **Test de l'API :** Pour les problèmes spécifiques à l'API web, le script [`libs/web_api/test_api.py`](../../libs/web_api/test_api.py) permet de vérifier son bon fonctionnement.
+*   **Test de l'API :** Pour les problèmes spécifiques à l'API web, le script `libs/web_api/test_api.py` permet de vérifier son bon fonctionnement.
 
-Consultez également la [FAQ générale de développement](projets/sujets/aide/FAQ_DEVELOPPEMENT.md) pour des réponses aux questions fréquentes.
+Consultez également la [FAQ générale de développement](../projets/sujets/aide/FAQ_DEVELOPPEMENT.md) pour des réponses aux questions fréquentes.
 
 ## Problèmes d'Installation
 
@@ -250,7 +250,7 @@ Consultez également la [FAQ générale de développement](projets/sujets/aide/F
 
 ## Problèmes d'API
 
-Pour tout problème lié à l'API, il est fortement recommandé d'exécuter le script de test dédié [`libs/web_api/test_api.py`](../../libs/web_api/test_api.py) qui peut aider à identifier la source du problème (connexion, routes, réponses attendues, etc.).
+Pour tout problème lié à l'API, il est fortement recommandé d'exécuter le script de test dédié `libs/web_api/test_api.py` qui peut aider à identifier la source du problème (connexion, routes, réponses attendues, etc.).
 
 ### Erreurs de connexion
 
@@ -596,8 +596,8 @@ Cette erreur se produit lorsque le système manque de mémoire pour traiter de g
 ---
 
 Si vous rencontrez un problème qui n'est pas couvert dans ce guide, veuillez consulter les ressources suivantes :
-*   La [FAQ générale de développement](projets/sujets/aide/FAQ_DEVELOPPEMENT.md).
-*   Pour les problèmes spécifiques à l'interface web, consultez le [guide de dépannage de l'interface web](projets/sujets/aide/interface-web/TROUBLESHOOTING.md).
+*   La [FAQ générale de développement](../projets/sujets/aide/FAQ_DEVELOPPEMENT.md).
+*   Pour les problèmes spécifiques à l'interface web, consultez le [guide de dépannage de l'interface web](../projets/sujets/aide/interface-web/TROUBLESHOOTING.md).
 
 Si le problème persiste, ouvrez une issue sur le dépôt GitHub du projet avec une description détaillée du problème, les étapes pour le reproduire, et les logs pertinents.
 

--- a/docs/guides/UNIFIED_AUTHENTIC_SYSTEM.md
+++ b/docs/guides/UNIFIED_AUTHENTIC_SYSTEM.md
@@ -14,7 +14,7 @@ Le **Système Unifié Authentique** est une refactorisation majeure du système 
 
 ### 1. Configuration Dynamique Unifiée
 
-Le fichier [`config/unified_config.py`](../config/unified_config.py) centralise tous les paramètres configurables :
+Le fichier [`config/unified_config.py`](../../config/unified_config.py) centralise tous les paramètres configurables :
 
 ```python
 from config.unified_config import UnifiedConfig, LogicType, MockLevel
@@ -34,7 +34,7 @@ config = UnifiedConfig(
 
 ### 2. Agent FOL/PL de Substitution
 
-Le nouvel agent [`FOLLogicAgent`](../argumentation_analysis/agents/core/logic/fol_logic_agent.py) remplace l'agent Modal défaillant :
+Le nouvel agent [`FOLLogicAgent`](../../argumentation_analysis/agents/core/logic/fol_logic_agent.py) remplace l'agent Modal défaillant :
 
 ```python
 from argumentation_analysis.agents.core.logic.fol_logic_agent import FOLLogicAgent
@@ -51,7 +51,7 @@ print(f"Cohérence: {result.consistency_check}")
 
 ### 3. Élimination Automatique des Mocks
 
-Le système de détection [`mock_elimination.py`](../scripts/validation/mock_elimination.py) identifie et élimine tous les mocks :
+Le système de détection [`mock_elimination.py`](../../tests/unit/argumentation_analysis/test_mock_elimination.py) identifie et élimine tous les mocks :
 
 ```python
 from scripts.validation.mock_elimination import MockDetector

--- a/docs/guides/WEB_APPLICATION_GUIDE.md
+++ b/docs/guides/WEB_APPLICATION_GUIDE.md
@@ -179,9 +179,9 @@ Test-NetConnection localhost -Port 3000
 
 ## 📚 Documentation Supplémentaire
 
-- **[Guide Installation](../GUIDE_INSTALLATION_ETUDIANTS.md)** : Configuration initiale
+- **[Guide Installation](./GUIDE_INSTALLATION_ETUDIANTS.md)** : Configuration initiale
 - **[Tests Fonctionnels](testing/functional_tests.md)** : Documentation des tests
-- **[API Documentation](../argumentation_analysis/services/web_api/README.md)** : Référence API détaillée
+- **[API Documentation](../../argumentation_analysis/services/web_api/README.md)** : Référence API détaillée
 
 ## 🤝 Contribution
 

--- a/docs/guides/analyse_impact_guides_sur_projets_etudiants.md
+++ b/docs/guides/analyse_impact_guides_sur_projets_etudiants.md
@@ -4,75 +4,75 @@ Ce document analyse l'impact potentiel des récentes mises à jour des guides du
 
 ## Méthodologie
 
-Pour chaque document étudiant identifié dans [`docs/projets/`](docs/projets/), nous avons examiné son contenu et déterminé quels guides récemment mis à jour pourraient apporter des informations utiles ou des clarifications pertinentes.
+Pour chaque document étudiant identifié dans [`docs/projets/`](../projets/), nous avons examiné son contenu et déterminé quels guides récemment mis à jour pourraient apporter des informations utiles ou des clarifications pertinentes.
 
 ## Analyse par Document Étudiant
 
-### 1. [`docs/projets/sujets/aide/interface-web/exemples-react/README.md`](docs/projets/sujets/aide/interface-web/exemples-react/README.md)
+### 1. [`docs/projets/sujets/aide/interface-web/exemples-react/README.md`](../projets/sujets/aide/interface-web/exemples-react/README.md)
 
 *   **Contenu principal :** Présentation des composants React pour l'API d'argumentation, guide de démarrage rapide, structure des fichiers, installation, configuration, exemples d'utilisation, personnalisation et dépannage.
 *   **Guides pertinents :**
-    *   [`docs/guides/guide_utilisation.md`](docs/guides/guide_utilisation.md): La section sur l'utilisation de l'API (nouvellement ajoutée ou mise à jour) est directement pertinente pour comprendre comment les composants React interagissent avec le backend.
-    *   [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md): Fournit des détails techniques sur l'API que les développeurs des composants React doivent connaître.
-    *   [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md): Peut offrir un contexte plus large sur l'architecture du système global, utile pour l'intégration.
-    *   [`docs/guides/conventions_importation.md`](docs/guides/conventions_importation.md): Bien que ce guide concerne le backend Python, comprendre les conventions peut aider à anticiper la structure des réponses de l'API ou la logique métier sous-jacente.
+    *   [`docs/guides/guide_utilisation.md`](guide_utilisation.md): La section sur l'utilisation de l'API (nouvellement ajoutée ou mise à jour) est directement pertinente pour comprendre comment les composants React interagissent avec le backend.
+    *   [`docs/guides/integration_api_web.md`](integration_api_web.md): Fournit des détails techniques sur l'API que les développeurs des composants React doivent connaître.
+    *   [`docs/guides/guide_developpeur.md`](guide_developpeur.md): Peut offrir un contexte plus large sur l'architecture du système global, utile pour l'intégration.
+    *   [`docs/guides/conventions_importation.md`](conventions_importation.md): Bien que ce guide concerne le backend Python, comprendre les conventions peut aider à anticiper la structure des réponses de l'API ou la logique métier sous-jacente.
 
-### 2. [`docs/projets/sujets/aide/interface-web/DEMARRAGE_RAPIDE.md`](docs/projets/sujets/aide/interface-web/DEMARRAGE_RAPIDE.md)
+### 2. [`docs/projets/sujets/aide/interface-web/DEMARRAGE_RAPIDE.md`](../projets/sujets/aide/interface-web/DEMARRAGE_RAPIDE.md)
 
 *   **Contenu principal :** Checklist pour la préparation de l'environnement, démarrage de l'API, configuration React, et premier composant.
 *   **Guides pertinents :**
-    *   [`docs/guides/guide_utilisation.md`](docs/guides/guide_utilisation.md): La section sur l'API est cruciale pour comprendre ce que l'interface React va consommer.
-    *   [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md): Essentiel pour la configuration des appels API depuis React.
-    *   [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md): Utile pour comprendre l'environnement de développement global du projet.
+    *   [`docs/guides/guide_utilisation.md`](guide_utilisation.md): La section sur l'API est cruciale pour comprendre ce que l'interface React va consommer.
+    *   [`docs/guides/integration_api_web.md`](integration_api_web.md): Essentiel pour la configuration des appels API depuis React.
+    *   [`docs/guides/guide_developpeur.md`](guide_developpeur.md): Utile pour comprendre l'environnement de développement global du projet.
 
-### 3. [`docs/projets/sujets/aide/interface-web/GUIDE_UTILISATION_API.md`](docs/projets/sujets/aide/interface-web/GUIDE_UTILISATION_API.md)
+### 3. [`docs/projets/sujets/aide/interface-web/GUIDE_UTILISATION_API.md`](../projets/sujets/aide/interface-web/GUIDE_UTILISATION_API.md)
 
 *   **Contenu principal :** Documentation détaillée de l'API d'Analyse Argumentative (endpoints, requêtes, réponses).
 *   **Guides pertinents :**
-    *   [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md): Ce guide mis à jour est la référence principale et devrait être aligné avec ce document étudiant. Les mises à jour de ce guide (par exemple, nouveaux endpoints, modifications des schémas de requête/réponse) impactent directement la documentation étudiante.
-    *   [`docs/guides/guide_utilisation.md`](docs/guides/guide_utilisation.md): La section API de ce guide doit être cohérente.
-    *   [`docs/guides/utilisation_agents_logiques.md`](docs/guides/utilisation_agents_logiques.md): Si l'API expose des fonctionnalités des agents logiques, ce guide peut fournir un contexte sur leur fonctionnement.
-    *   Les guides sur les logiques spécifiques ([`exemples_logique_propositionnelle.md`](docs/guides/exemples_logique_propositionnelle.md), [`exemples_logique_premier_ordre.md`](docs/guides/exemples_logique_premier_ordre.md), [`exemples_logique_modale.md`](docs/guides/exemples_logique_modale.md)) peuvent être utiles si l'API permet de spécifier ou d'interagir avec ces logiques.
+    *   [`docs/guides/integration_api_web.md`](integration_api_web.md): Ce guide mis à jour est la référence principale et devrait être aligné avec ce document étudiant. Les mises à jour de ce guide (par exemple, nouveaux endpoints, modifications des schémas de requête/réponse) impactent directement la documentation étudiante.
+    *   [`docs/guides/guide_utilisation.md`](guide_utilisation.md): La section API de ce guide doit être cohérente.
+    *   [`docs/guides/utilisation_agents_logiques.md`](utilisation_agents_logiques.md): Si l'API expose des fonctionnalités des agents logiques, ce guide peut fournir un contexte sur leur fonctionnement.
+    *   Les guides sur les logiques spécifiques ([`exemples_logique_propositionnelle.md`](exemples_logique_propositionnelle.md), [`exemples_logique_premier_ordre.md`](exemples_logique_premier_ordre.md), [`exemples_logique_modale.md`](exemples_logique_modale.md)) peuvent être utiles si l'API permet de spécifier ou d'interagir avec ces logiques.
 
-### 4. [`docs/projets/sujets/aide/interface-web/TROUBLESHOOTING.md`](docs/projets/sujets/aide/interface-web/TROUBLESHOOTING.md)
+### 4. [`docs/projets/sujets/aide/interface-web/TROUBLESHOOTING.md`](../projets/sujets/aide/interface-web/TROUBLESHOOTING.md)
 
 *   **Contenu principal :** Guide de dépannage pour les problèmes de démarrage de l'API, erreurs de connexion, CORS, dépendances, React, erreurs d'analyse.
 *   **Guides pertinents :**
-    *   [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md): Les problèmes d'intégration API sont souvent une source d'erreurs.
-    *   [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md): Peut contenir des informations sur la configuration de l'environnement de développement qui sont pertinentes pour le dépannage.
+    *   [`docs/guides/integration_api_web.md`](integration_api_web.md): Les problèmes d'intégration API sont souvent une source d'erreurs.
+    *   [`docs/guides/guide_developpeur.md`](guide_developpeur.md): Peut contenir des informations sur la configuration de l'environnement de développement qui sont pertinentes pour le dépannage.
 
-### 5. [`docs/projets/sujets/aide/FAQ_DEVELOPPEMENT.md`](docs/projets/sujets/aide/FAQ_DEVELOPPEMENT.md)
+### 5. [`docs/projets/sujets/aide/FAQ_DEVELOPPEMENT.md`](../projets/sujets/aide/FAQ_DEVELOPPEMENT.md)
 
 *   **Contenu principal :** FAQ sur la documentation, l'API Web, le moteur d'analyse, l'interface web, les tests, le déploiement, et la contribution.
 *   **Guides pertinents :**
     *   Tous les guides mis à jour sont potentiellement pertinents car la FAQ couvre l'ensemble du projet.
-    *   [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md): Particulièrement pertinent pour les sections sur l'architecture, les tests, le déploiement et les conventions.
-    *   [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md): Pour les questions relatives à l'API.
-    *   [`docs/guides/utilisation_agents_logiques.md`](docs/guides/utilisation_agents_logiques.md): Pour les questions sur le moteur d'analyse.
-    *   [`docs/guides/conventions_importation.md`](docs/guides/conventions_importation.md): Pour les questions sur la structure du code backend.
+    *   [`docs/guides/guide_developpeur.md`](guide_developpeur.md): Particulièrement pertinent pour les sections sur l'architecture, les tests, le déploiement et les conventions.
+    *   [`docs/guides/integration_api_web.md`](integration_api_web.md): Pour les questions relatives à l'API.
+    *   [`docs/guides/utilisation_agents_logiques.md`](utilisation_agents_logiques.md): Pour les questions sur le moteur d'analyse.
+    *   [`docs/guides/conventions_importation.md`](conventions_importation.md): Pour les questions sur la structure du code backend.
     *   Les guides sur les logiques spécifiques pour les questions relatives à leur utilisation.
 
-### 6. [`docs/projets/sujets/aide/GUIDE_INTEGRATION_PROJETS.md`](docs/projets/sujets/aide/GUIDE_INTEGRATION_PROJETS.md)
+### 6. [`docs/projets/sujets/aide/GUIDE_INTEGRATION_PROJETS.md`](../projets/sujets/aide/GUIDE_INTEGRATION_PROJETS.md)
 
 *   **Contenu principal :** Guide pour l'intégration des projets étudiants, vue d'ensemble, architecture, guide pour l'interface web et le serveur MCP.
 *   **Guides pertinents :**
-    *   [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md): Fournit le contexte architectural global.
-    *   [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md): Essentiel pour le projet Interface Web.
-    *   [`docs/guides/utilisation_agents_logiques.md`](docs/guides/utilisation_agents_logiques.md): Pertinent pour le projet Serveur MCP s'il expose les fonctionnalités des agents.
+    *   [`docs/guides/guide_developpeur.md`](guide_developpeur.md): Fournit le contexte architectural global.
+    *   [`docs/guides/integration_api_web.md`](integration_api_web.md): Essentiel pour le projet Interface Web.
+    *   [`docs/guides/utilisation_agents_logiques.md`](utilisation_agents_logiques.md): Pertinent pour le projet Serveur MCP s'il expose les fonctionnalités des agents.
     *   Les guides sur les logiques spécifiques si le serveur MCP doit interagir avec elles.
 
-### 7. [`docs/projets/sujets/aide/PRESENTATION_KICKOFF.md`](docs/projets/sujets/aide/PRESENTATION_KICKOFF.md)
+### 7. [`docs/projets/sujets/aide/PRESENTATION_KICKOFF.md`](../projets/sujets/aide/PRESENTATION_KICKOFF.md)
 
 *   **Contenu principal :** Présentation initiale des projets, architecture, objectifs.
 *   **Guides pertinents :**
-    *   [`docs/guides/README.md`](docs/guides/README.md): Le portail des guides mis à jour peut servir de référence actualisée.
-    *   [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md): Pour une vue d'ensemble de l'architecture actuelle.
+    *   [`docs/guides/README.md`](README.md): Le portail des guides mis à jour peut servir de référence actualisée.
+    *   [`docs/guides/guide_developpeur.md`](guide_developpeur.md): Pour une vue d'ensemble de l'architecture actuelle.
 
-### 8. [`docs/projets/sujets/aide/README.md`](docs/projets/sujets/aide/README.md)
+### 8. [`docs/projets/sujets/aide/README.md`](../projets/sujets/aide/README.md)
 
 *   **Contenu principal :** Présentation des ressources d'aide par sujet, structure des ressources.
 *   **Guides pertinents :**
-    *   [`docs/guides/README.md`](docs/guides/README.md): Ce document étudiant devrait pointer vers le portail des guides officiels mis à jour.
+    *   [`docs/guides/README.md`](README.md): Ce document étudiant devrait pointer vers le portail des guides officiels mis à jour.
 
 ### 9. Documents de projets spécifiques (ex: `docs/projets/1.2.7_Argumentation_Dialogique.md`, etc.)
 
@@ -93,108 +93,108 @@ Pour chaque document étudiant identifié dans [`docs/projets/`](docs/projets/),
     *   `docs/projets/sujet_2.3.5_agent_evaluation_qualite.md`
 *   **Impact potentiel (si ces fichiers existaient et traitaient de leurs sujets nominaux) :**
     *   **Pour les projets liés à la logique et à l'argumentation formelle :**
-        *   [`docs/guides/exemples_logique_propositionnelle.md`](docs/guides/exemples_logique_propositionnelle.md)
-        *   [`docs/guides/exemples_logique_premier_ordre.md`](docs/guides/exemples_logique_premier_ordre.md)
-        *   [`docs/guides/exemples_logique_modale.md`](docs/guides/exemples_logique_modale.md)
-        *   [`docs/guides/utilisation_agents_logiques.md`](docs/guides/utilisation_agents_logiques.md)
+        *   [`docs/guides/exemples_logique_propositionnelle.md`](exemples_logique_propositionnelle.md)
+        *   [`docs/guides/exemples_logique_premier_ordre.md`](exemples_logique_premier_ordre.md)
+        *   [`docs/guides/exemples_logique_modale.md`](exemples_logique_modale.md)
+        *   [`docs/guides/utilisation_agents_logiques.md`](utilisation_agents_logiques.md)
     *   **Pour les projets liés au développement de l'API ou du serveur MCP :**
-        *   [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md)
-        *   [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md)
+        *   [`docs/guides/integration_api_web.md`](integration_api_web.md)
+        *   [`docs/guides/guide_developpeur.md`](guide_developpeur.md)
     *   **Pour les projets liés à l'interface web :**
-        *   [`docs/guides/guide_utilisation.md`](docs/guides/guide_utilisation.md) (section API)
-        *   [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md)
+        *   [`docs/guides/guide_utilisation.md`](guide_utilisation.md) (section API)
+        *   [`docs/guides/integration_api_web.md`](integration_api_web.md)
     *   **Pour tous les projets :**
-        *   [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md) (pour l'architecture, les conventions)
-        *   [`docs/guides/conventions_importation.md`](docs/guides/conventions_importation.md) (pour comprendre la structure du backend)
+        *   [`docs/guides/guide_developpeur.md`](guide_developpeur.md) (pour l'architecture, les conventions)
+        *   [`docs/guides/conventions_importation.md`](conventions_importation.md) (pour comprendre la structure du backend)
 
-### 10. [`docs/projets/README.md`](docs/projets/README.md)
+### 10. [`docs/projets/README.md`](../projets/README.md)
 
 *   **Contenu principal :** Vue d'ensemble des projets étudiants, structure, catégories, filtrage, ressources.
 *   **Guides pertinents :**
-    *   [`docs/guides/README.md`](docs/guides/README.md): Le portail des guides mis à jour est la référence principale.
+    *   [`docs/guides/README.md`](README.md): Le portail des guides mis à jour est la référence principale.
     *   Tous les guides spécifiques peuvent être référencés ici pour orienter les étudiants.
 
-### 11. [`docs/projets/ACCOMPAGNEMENT_ETUDIANTS.md`](docs/projets/ACCOMPAGNEMENT_ETUDIANTS.md)
+### 11. [`docs/projets/ACCOMPAGNEMENT_ETUDIANTS.md`](../projets/ACCOMPAGNEMENT_ETUDIANTS.md)
 
 *   **Contenu principal :** Points d'attention généraux, problèmes connus, bonnes pratiques, liens utiles.
 *   **Guides pertinents :**
     *   Tous les guides mis à jour sont pertinents car ce document vise à aider les étudiants de manière globale.
     *   Les guides sur les logiques, l'utilisation des agents, l'API, et le développement sont particulièrement importants.
 
-### 12. [`docs/projets/ACCUEIL_ETUDIANTS_SYNTHESE.md`](docs/projets/ACCUEIL_ETUDIANTS_SYNTHESE.md)
+### 12. [`docs/projets/ACCUEIL_ETUDIANTS_SYNTHESE.md`](../projets/ACCUEIL_ETUDIANTS_SYNTHESE.md)
 
 *   **Contenu principal :** Synthèse pour démarrer rapidement, objectifs, choix de sujet, ressources, calendrier.
 *   **Guides pertinents :**
-    *   [`docs/guides/README.md`](docs/guides/README.md): Pour un accès centralisé aux guides.
-    *   [`docs/guides/guide_utilisation.md`](docs/guides/guide_utilisation.md): Pour comprendre le fonctionnement général.
-    *   [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md): Pour les aspects techniques.
+    *   [`docs/guides/README.md`](README.md): Pour un accès centralisé aux guides.
+    *   [`docs/guides/guide_utilisation.md`](guide_utilisation.md): Pour comprendre le fonctionnement général.
+    *   [`docs/guides/guide_developpeur.md`](guide_developpeur.md): Pour les aspects techniques.
 
-### 13. [`docs/projets/developpement_systeme.md`](docs/projets/developpement_systeme.md)
+### 13. [`docs/projets/developpement_systeme.md`](../projets/developpement_systeme.md)
 
 *   **Contenu principal :** Projets axés sur l'architecture, l'orchestration, les composants techniques.
 *   **Guides pertinents :**
-    *   [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md): Très pertinent pour l'architecture et les conventions.
-    *   [`docs/guides/conventions_importation.md`](docs/guides/conventions_importation.md): Utile pour comprendre la structure du code.
-    *   [`docs/guides/utilisation_agents_logiques.md`](docs/guides/utilisation_agents_logiques.md): Pour les projets impliquant des agents.
-    *   [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md): Si les projets de système interagissent avec ou exposent des API.
+    *   [`docs/guides/guide_developpeur.md`](guide_developpeur.md): Très pertinent pour l'architecture et les conventions.
+    *   [`docs/guides/conventions_importation.md`](conventions_importation.md): Utile pour comprendre la structure du code.
+    *   [`docs/guides/utilisation_agents_logiques.md`](utilisation_agents_logiques.md): Pour les projets impliquant des agents.
+    *   [`docs/guides/integration_api_web.md`](integration_api_web.md): Si les projets de système interagissent avec ou exposent des API.
 
-### 14. [`docs/projets/exemples_tweety_par_projet.md`](docs/projets/exemples_tweety_par_projet.md) et [`docs/projets/exemples_tweety.md`](docs/projets/exemples_tweety.md)
+### 14. [`docs/projets/exemples_tweety_par_projet.md`](../projets/exemples_tweety_par_projet.md) et [`docs/projets/exemples_tweety.md`](../projets/exemples_tweety.md)
 
 *   **Contenu principal :** Exemples de code TweetyProject.
 *   **Guides pertinents :**
-    *   [`docs/guides/exemples_logique_propositionnelle.md`](docs/guides/exemples_logique_propositionnelle.md)
-    *   [`docs/guides/exemples_logique_premier_ordre.md`](docs/guides/exemples_logique_premier_ordre.md)
-    *   [`docs/guides/exemples_logique_modale.md`](docs/guides/exemples_logique_modale.md)
-    *   [`docs/guides/utilisation_agents_logiques.md`](docs/guides/utilisation_agents_logiques.md): Ces guides expliquent les concepts logiques que TweetyProject implémente.
+    *   [`docs/guides/exemples_logique_propositionnelle.md`](exemples_logique_propositionnelle.md)
+    *   [`docs/guides/exemples_logique_premier_ordre.md`](exemples_logique_premier_ordre.md)
+    *   [`docs/guides/exemples_logique_modale.md`](exemples_logique_modale.md)
+    *   [`docs/guides/utilisation_agents_logiques.md`](utilisation_agents_logiques.md): Ces guides expliquent les concepts logiques que TweetyProject implémente.
 
-### 15. [`docs/projets/experience_utilisateur.md`](docs/projets/experience_utilisateur.md)
+### 15. [`docs/projets/experience_utilisateur.md`](../projets/experience_utilisateur.md)
 
 *   **Contenu principal :** Projets orientés interfaces, visualisations, cas d'usage.
 *   **Guides pertinents :**
-    *   [`docs/guides/guide_utilisation.md`](docs/guides/guide_utilisation.md): Pour comprendre comment les utilisateurs finaux interagissent avec le système.
-    *   [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md): Si les projets d'UX consomment l'API.
+    *   [`docs/guides/guide_utilisation.md`](guide_utilisation.md): Pour comprendre comment les utilisateurs finaux interagissent avec le système.
+    *   [`docs/guides/integration_api_web.md`](integration_api_web.md): Si les projets d'UX consomment l'API.
 
-### 16. [`docs/projets/fondements_theoriques.md`](docs/projets/fondements_theoriques.md)
+### 16. [`docs/projets/fondements_theoriques.md`](../projets/fondements_theoriques.md)
 
 *   **Contenu principal :** Projets sur les aspects formels, logiques, théoriques de l'argumentation.
 *   **Guides pertinents :**
-    *   [`docs/guides/exemples_logique_propositionnelle.md`](docs/guides/exemples_logique_propositionnelle.md)
-    *   [`docs/guides/exemples_logique_premier_ordre.md`](docs/guides/exemples_logique_premier_ordre.md)
-    *   [`docs/guides/exemples_logique_modale.md`](docs/guides/exemples_logique_modale.md)
-    *   [`docs/guides/utilisation_agents_logiques.md`](docs/guides/utilisation_agents_logiques.md)
+    *   [`docs/guides/exemples_logique_propositionnelle.md`](exemples_logique_propositionnelle.md)
+    *   [`docs/guides/exemples_logique_premier_ordre.md`](exemples_logique_premier_ordre.md)
+    *   [`docs/guides/exemples_logique_modale.md`](exemples_logique_modale.md)
+    *   [`docs/guides/utilisation_agents_logiques.md`](utilisation_agents_logiques.md)
 
-### 17. [`docs/projets/matrice_interdependances.md`](docs/projets/matrice_interdependances.md)
+### 17. [`docs/projets/matrice_interdependances.md`](../projets/matrice_interdependances.md)
 
 *   **Contenu principal :** Relations et dépendances entre projets.
 *   **Guides pertinents :**
-    *   [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md): Pour comprendre l'architecture qui sous-tend ces interdépendances.
+    *   [`docs/guides/guide_developpeur.md`](guide_developpeur.md): Pour comprendre l'architecture qui sous-tend ces interdépendances.
 
-### 18. [`docs/projets/message_annonce_etudiants.md`](docs/projets/message_annonce_etudiants.md)
+### 18. [`docs/projets/message_annonce_etudiants.md`](../projets/message_annonce_etudiants.md)
 
 *   **Contenu principal :** Annonce du projet, objectifs, modalités, évaluation, calendrier.
 *   **Guides pertinents :**
-    *   [`docs/guides/README.md`](docs/guides/README.md): Pour orienter les étudiants vers la documentation pertinente.
+    *   [`docs/guides/README.md`](README.md): Pour orienter les étudiants vers la documentation pertinente.
 
-### 19. [`docs/projets/modeles_affaires_ia.md`](docs/projets/modeles_affaires_ia.md)
+### 19. [`docs/projets/modeles_affaires_ia.md`](../projets/modeles_affaires_ia.md)
 
 *   **Contenu principal :** Modèles d'affaires et cas d'usage commerciaux.
 *   **Guides pertinents :**
-    *   [`docs/guides/guide_utilisation.md`](docs/guides/guide_utilisation.md): Pour comprendre les fonctionnalités qui pourraient être monétisées.
-    *   [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md): Si l'API est un produit commercialisable.
+    *   [`docs/guides/guide_utilisation.md`](guide_utilisation.md): Pour comprendre les fonctionnalités qui pourraient être monétisées.
+    *   [`docs/guides/integration_api_web.md`](integration_api_web.md): Si l'API est un produit commercialisable.
 
-### 20. [`docs/projets/SUIVI_PROJETS_ETUDIANTS.md`](docs/projets/SUIVI_PROJETS_ETUDIANTS.md)
+### 20. [`docs/projets/SUIVI_PROJETS_ETUDIANTS.md`](../projets/SUIVI_PROJETS_ETUDIANTS.md)
 
 *   **Contenu principal :** Suivi de l'avancement des projets.
 *   **Guides pertinents :**
     *   Tous les guides peuvent être utiles pour aider les étudiants à débloquer des situations ou à trouver des informations.
 
-### 21. [`docs/projets/sujets_projets_detailles.md`](docs/projets/sujets_projets_detailles.md)
+### 21. [`docs/projets/sujets_projets_detailles.md`](../projets/sujets_projets_detailles.md)
 
 *   **Contenu principal :** Description détaillée des sujets de projets.
 *   **Guides pertinents :**
     *   Chaque sujet détaillé devrait idéalement pointer vers les guides techniques pertinents (logique, API, développement, etc.). Les guides mis à jour peuvent enrichir ces références.
 
-### 22. [`docs/projets/SYNTHESE_THEMATIQUE_PROJETS.md`](docs/projets/SYNTHESE_THEMATIQUE_PROJETS.md)
+### 22. [`docs/projets/SYNTHESE_THEMATIQUE_PROJETS.md`](../projets/SYNTHESE_THEMATIQUE_PROJETS.md)
 
 *   **Contenu principal :** Synthèse thématique des projets.
 *   **Guides pertinents :**
@@ -202,7 +202,7 @@ Pour chaque document étudiant identifié dans [`docs/projets/`](docs/projets/),
 
 ## Conclusion Générale de l'Analyse d'Impact
 
-Les guides récemment mis à jour, en particulier [`docs/guides/integration_api_web.md`](docs/guides/integration_api_web.md), [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md), [`docs/guides/utilisation_agents_logiques.md`](docs/guides/utilisation_agents_logiques.md) et les guides sur les logiques spécifiques, ont un impact significatif sur la majorité de la documentation des projets étudiants.
+Les guides récemment mis à jour, en particulier [`docs/guides/integration_api_web.md`](integration_api_web.md), [`docs/guides/guide_developpeur.md`](guide_developpeur.md), [`docs/guides/utilisation_agents_logiques.md`](utilisation_agents_logiques.md) et les guides sur les logiques spécifiques, ont un impact significatif sur la majorité de la documentation des projets étudiants.
 
 **Actions recommandées (non demandées dans la tâche, mais logiques) :**
 *   Mettre à jour les liens et références dans les documents étudiants pour pointer vers les versions les plus récentes des guides.

--- a/docs/guides/authenticity_validation_guide.md
+++ b/docs/guides/authenticity_validation_guide.md
@@ -381,9 +381,9 @@ def pre_commit_authenticity_check():
 
 ### Documentation Technique
 
-- [Configuration Unifiée](../config/unified_config.py)
-- [Tests d'Authenticité](../tests/unit/authentication/)
-- [Scripts CLI](../scripts/)
+- [Configuration Unifiée](../../config/unified_config.py)
+- [Tests d'Authenticité](../../tests/unit/authentication/)
+- [Scripts CLI](../../scripts/)
 
 ### Standards de Qualité
 

--- a/docs/guides/exemples_logique_modale.md
+++ b/docs/guides/exemples_logique_modale.md
@@ -110,7 +110,7 @@ Résultat: True - Tweety Result: Modal Query '<>(somme_angles_triangle_180)' is 
 ```
 L'argument est valide. Puisque la somme des angles d'un triangle est nécessairement égale à 180 degrés ([](somme_angles_triangle_180)), elle est vraie (somme_angles_triangle_180). Et puisqu'elle est vraie, elle est possiblement vraie (<>(somme_angles_triangle_180)).
 
-Pour voir cet exemple en action, consultez la fonction `process_necessity_possibility_example` dans [le script d'exemples de logique modale](../../examples/logic_agents/modal_logic_example.py:91).
+Pour voir cet exemple en action, consultez la fonction `process_necessity_possibility_example` dans le script d'exemples de logique modale.
 ```
 
 ### Exemple 2: Raisonnement épistémique
@@ -159,7 +159,7 @@ Résultat: True - Tweety Result: Modal Query 'K(alice, obtention_diplome)' is AC
 ```
 L'argument est valide. Puisqu'Alice sait que si elle réussit son examen, elle obtiendra son diplôme, et qu'elle sait qu'elle a réussi son examen, elle sait logiquement qu'elle obtiendra son diplôme. Cela illustre la propriété de clôture sous implication de la connaissance.
 
-Pour un exemple de code illustrant ce type de raisonnement, référez-vous à la fonction `process_epistemic_example` dans [le script d'exemples de logique modale](../../examples/logic_agents/modal_logic_example.py:143).
+Pour un exemple de code illustrant ce type de raisonnement, référez-vous à la fonction `process_epistemic_example` dans le script d'exemples de logique modale.
 ```
 
 ### Exemple 3: Raisonnement déontique
@@ -208,7 +208,7 @@ Résultat: False - Tweety Result: Modal Query '!circuler_librement => !respecter
 ```
 L'argument n'est pas valide. Le fait qu'il soit permis de circuler librement si on respecte la loi n'implique pas que si on ne circule pas librement, alors on ne respecte pas la loi. La permission de faire quelque chose n'implique pas l'obligation de le faire. C'est une erreur de raisonnement connue sous le nom de "négation de l'antécédent".
 
-Le code correspondant à cet exemple se trouve dans la fonction `process_deontic_example` du [script d'exemples de logique modale](../../examples/logic_agents/modal_logic_example.py:174).
+Le code correspondant à cet exemple se trouve dans la fonction `process_deontic_example` du script d'exemples de logique modale.
 ```
 
 ## Exemples intermédiaires
@@ -259,7 +259,7 @@ Résultat: True - Tweety Result: Modal Query 'F(routes_mouillees)' is ACCEPTED (
 ```
 L'argument est valide. Puisqu'il pleuvra demain (F(pluie)) et que s'il pleut, les routes seront mouillées (pluie => routes_mouillees), il s'ensuit que les routes seront mouillées demain (F(routes_mouillees)).
 
-Bien qu'il n'y ait pas de fonction dédiée pour cet exemple spécifique dans [`modal_logic_example.py`](../../examples/logic_agents/modal_logic_example.py:0), les principes de conversion de texte et d'exécution de requêtes modales sont illustrés par les autres fonctions du script.
+Bien qu'il n'y ait pas de fonction dédiée pour cet exemple spécifique dans `modal_logic_example.py`, les principes de conversion de texte et d'exécution de requêtes modales sont illustrés par les autres fonctions du script.
 ```
 
 ### Exemple 5: Croyances et connaissances
@@ -311,7 +311,7 @@ Résultat: True - Tweety Result: Modal Query '!K(jean, terre_plate)' is ACCEPTED
 ```
 L'argument est valide. Si Jean savait que la Terre est plate, alors la Terre serait plate (par la propriété de véracité de la connaissance). Or, la Terre n'est pas plate. Donc, Jean ne sait pas que la Terre est plate, même s'il le croit.
 
-Bien qu'il n'y ait pas de fonction dédiée pour cet exemple spécifique dans [`modal_logic_example.py`](../../examples/logic_agents/modal_logic_example.py:0), les principes de conversion de texte et d'exécution de requêtes modales sont illustrés par les autres fonctions du script.
+Bien qu'il n'y ait pas de fonction dédiée pour cet exemple spécifique dans `modal_logic_example.py`, les principes de conversion de texte et d'exécution de requêtes modales sont illustrés par les autres fonctions du script.
 ```
 
 ## Exemples avancés
@@ -362,7 +362,7 @@ Résultat: True - Tweety Result: Modal Query '<>([](P(sauver_vie)))' is ACCEPTED
 ```
 L'argument est valide. Puisqu'il est possible que sauver une vie soit obligatoire (<>(O(sauver_vie))), et que si une action est obligatoire, alors il est nécessaire qu'elle soit permise (O(a) => [](P(a))), il s'ensuit qu'il est possible qu'il soit nécessaire que sauver une vie soit permis (<>([](P(sauver_vie)))).
 
-Vous pouvez retrouver une implémentation de cet exemple complexe dans la fonction `process_complex_example` du [script d'exemples de logique modale](../../examples/logic_agents/modal_logic_example.py:210).
+Vous pouvez retrouver une implémentation de cet exemple complexe dans la fonction `process_complex_example` du script d'exemples de logique modale.
 ```
 
 ### Exemple 7: Paradoxes modaux
@@ -418,7 +418,7 @@ L'ensemble de croyances est incohérent. Le paradoxe vient de la combinaison des
 
 Cette combinaison mène à une contradiction dans certains systèmes modaux, illustrant les subtilités et les défis de la logique modale.
 
-Bien qu'il n'y ait pas de fonction dédiée pour cet exemple spécifique dans [`modal_logic_example.py`](../../examples/logic_agents/modal_logic_example.py:0), les principes de conversion de texte et d'exécution de requêtes modales, y compris la vérification de la cohérence (bien que la requête ici soit formulée pour tester une conséquence spécifique qui se révèle fausse, indiquant l'incohérence), sont illustrés par les autres fonctions du script.
+Bien qu'il n'y ait pas de fonction dédiée pour cet exemple spécifique dans `modal_logic_example.py`, les principes de conversion de texte et d'exécution de requêtes modales, y compris la vérification de la cohérence (bien que la requête ici soit formulée pour tester une conséquence spécifique qui se révèle fausse, indiquant l'incohérence), sont illustrés par les autres fonctions du script.
 ```
 
 ## Cas d'utilisation réels

--- a/docs/guides/exemples_logique_premier_ordre.md
+++ b/docs/guides/exemples_logique_premier_ordre.md
@@ -50,11 +50,11 @@ Notre système utilise la syntaxe de TweetyProject pour la logique du premier or
 | Égalité | `=` | Identité | `pere(pere(x)) = grand_pere(x)` |
 
 Pour voir ces concepts en action et des exemples d'utilisation de l'agent de logique du premier ordre avec la syntaxe décrite, consultez le script suivant :
-- Code source : [`examples/logic_agents/first_order_logic_example.py`](../../examples/logic_agents/first_order_logic_example.py)
+- Code source : `examples/logic_agents/first_order_logic_example.py`
 
 ## Exemples de base
 
-Les exemples qui suivent (Syllogisme, Quantificateurs mixtes, Relations) sont illustrés par des implémentations concrètes dans le script [`first_order_logic_example.py`](../../examples/logic_agents/first_order_logic_example.py). Vous y trouverez notamment les fonctions `process_syllogism_example`, `process_quantifiers_example`, et `process_relations_example` qui correspondent aux Exemples 1, 2 et 3 ci-dessous.
+Les exemples qui suivent (Syllogisme, Quantificateurs mixtes, Relations) sont illustrés par des implémentations concrètes dans le script `first_order_logic_example.py`. Vous y trouverez notamment les fonctions `process_syllogism_example`, `process_quantifiers_example`, et `process_relations_example` qui correspondent aux Exemples 1, 2 et 3 ci-dessous.
 
 ### Exemple 1: Syllogisme catégorique
 
@@ -308,7 +308,7 @@ L'argument est valide. Alice est la mère de Bob, donc elle est son parent. Bob 
 
 ## Exemples avancés
 
-L'Exemple 6 ("Analyse d'un argument complexe") présenté ci-dessous est également implémenté dans la fonction `process_complex_example` du script [`first_order_logic_example.py`](../../examples/logic_agents/first_order_logic_example.py).
+L'Exemple 6 ("Analyse d'un argument complexe") présenté ci-dessous est également implémenté dans la fonction `process_complex_example` du script `first_order_logic_example.py`.
 
 ### Exemple 6: Analyse d'un argument complexe
 
@@ -540,7 +540,7 @@ L'argument est valide. Puisque l'accusé est une personne qui a commis un crime 
 - [Guide d'utilisation des agents logiques](utilisation_agents_logiques.md)
 - [Exemples de logique propositionnelle](exemples_logique_propositionnelle.md)
 - [Exemples de logique modale](exemples_logique_modale.md)
-- [Tutoriel interactif sur les agents logiques](../../examples/notebooks/logic_agents_tutorial.ipynb)
+- Tutoriel interactif sur les agents logiques
 - [Documentation de TweetyProject sur la logique du premier ordre](http://tweetyproject.org/doc/first-order-logic.html)
-- Script d'exemples complets pour l'agent de Logique du Premier Ordre : [`examples/logic_agents/first_order_logic_example.py`](../../examples/logic_agents/first_order_logic_example.py)
-- Tutoriel interactif via API (incluant une section LPO) : [`examples/notebooks/api_logic_tutorial.ipynb`](../../examples/notebooks/api_logic_tutorial.ipynb) (voir section 4.2)
+- Script d'exemples complets pour l'agent de Logique du Premier Ordre : `examples/logic_agents/first_order_logic_example.py`
+- Tutoriel interactif via API (incluant une section LPO) : `examples/notebooks/api_logic_tutorial.ipynb` (voir section 4.2)

--- a/docs/guides/exemples_logique_propositionnelle.md
+++ b/docs/guides/exemples_logique_propositionnelle.md
@@ -22,7 +22,7 @@
 
 ## Introduction
 
-Pour une implémentation complète des exemples présentés dans ce guide, vous pouvez consulter le script Python suivant : [`examples/logic_agents/propositional_logic_example.py`](../../examples/logic_agents/propositional_logic_example.py:0). Ce script montre comment initialiser l'agent, convertir du texte, exécuter des requêtes et interpréter les résultats pour divers scénarios de logique propositionnelle.
+Pour une implémentation complète des exemples présentés dans ce guide, vous pouvez consulter le script Python suivant : `examples/logic_agents/propositional_logic_example.py`. Ce script montre comment initialiser l'agent, convertir du texte, exécuter des requêtes et interpréter les résultats pour divers scénarios de logique propositionnelle.
 
 La logique propositionnelle est le type de logique le plus fondamental, permettant de représenter et d'analyser des propositions simples et leurs relations. Ce document présente des exemples concrets d'utilisation de la logique propositionnelle avec notre système d'agents logiques.
 
@@ -50,7 +50,7 @@ Les variables propositionnelles sont généralement représentées par des lettr
 
 ### Exemple 1: Modus Ponens
 
-*Le code complet pour cet exemple est disponible dans [`examples/logic_agents/propositional_logic_example.py`](../../examples/logic_agents/propositional_logic_example.py:91).* 
+*Le code complet pour cet exemple est disponible dans `examples/logic_agents/propositional_logic_example.py`.* 
 
 
 Le Modus Ponens est une règle d'inférence fondamentale: si on a "si P alors Q" et "P", on peut conclure "Q".
@@ -108,7 +108,7 @@ L'argument est valide selon le Modus Ponens. Puisque nous savons que "si le ciel
 
 ### Exemple 2: Modus Tollens
 
-*Le code complet pour cet exemple est disponible dans [`examples/logic_agents/propositional_logic_example.py`](../../examples/logic_agents/propositional_logic_example.py:132).* 
+*Le code complet pour cet exemple est disponible dans `examples/logic_agents/propositional_logic_example.py`.* 
 
 
 Le Modus Tollens est une autre règle d'inférence: si on a "si P alors Q" et "non Q", on peut conclure "non P".
@@ -154,12 +154,12 @@ Résultat: True - Tweety Result: Query '!mammifere' is ACCEPTED (True).
 **Interprétation:**
 ```
 L'argument est valide selon le Modus Tollens. Puisque nous savons que "si un animal est un mammifère, alors il a des poils" et que "ce reptile n'a pas de poils", nous pouvons logiquement conclure que "ce reptile n'est pas un mammifère".
-Le script [`examples/logic_agents/propositional_logic_example.py`](../../examples/logic_agents/propositional_logic_example.py:163) exécute également une requête pour "mammifere", qui retourne `False`, renforçant la conclusion.
+Le script `examples/logic_agents/propositional_logic_example.py` exécute également une requête pour "mammifere", qui retourne `False`, renforçant la conclusion.
 ```
 
 ### Exemple 3: Syllogisme hypothétique
 
-*Bien qu'un exemple explicitement nommé "syllogisme hypothétique" ne soit pas présent dans [`examples/logic_agents/propositional_logic_example.py`](../../examples/logic_agents/propositional_logic_example.py:0), le principe du raisonnement chaîné est illustré dans des exemples plus complexes, comme l'analyse d'argument complexe (voir Exemple 6).*
+*Bien qu'un exemple explicitement nommé "syllogisme hypothétique" ne soit pas présent dans `examples/logic_agents/propositional_logic_example.py`, le principe du raisonnement chaîné est illustré dans des exemples plus complexes, comme l'analyse d'argument complexe (voir Exemple 6).*
 
 Le syllogisme hypothétique combine des implications: si on a "si P alors Q" et "si Q alors R", on peut conclure "si P alors R".
 
@@ -210,7 +210,7 @@ L'argument est valide selon le syllogisme hypothétique. Puisque nous savons que
 
 ### Exemple 4: Raisonnement par cas
 
-*Le script [`examples/logic_agents/propositional_logic_example.py`](../../examples/logic_agents/propositional_logic_example.py:0) ne contient pas d'exemple explicitement nommé "raisonnement par cas". Cependant, la logique sous-jacente peut être construite en utilisant les fonctionnalités de l'agent.*
+*Le script `examples/logic_agents/propositional_logic_example.py` ne contient pas d'exemple explicitement nommé "raisonnement par cas". Cependant, la logique sous-jacente peut être construite en utilisant les fonctionnalités de l'agent.*
 
 Le raisonnement par cas consiste à examiner toutes les possibilités et à montrer que la même conclusion s'ensuit dans chaque cas.
 
@@ -262,7 +262,7 @@ L'argument est valide selon le raisonnement par cas. Puisque nous savons qu'"il 
 
 ### Exemple 5: Réduction à l'absurde
 
-*Le code complet pour un exemple de détection de contradiction, qui utilise un raisonnement similaire, est disponible dans [`examples/logic_agents/propositional_logic_example.py`](../../examples/logic_agents/propositional_logic_example.py:212).* 
+*Le code complet pour un exemple de détection de contradiction, qui utilise un raisonnement similaire, est disponible dans `examples/logic_agents/propositional_logic_example.py`.* 
 
 
 La réduction à l'absurde consiste à montrer qu'une hypothèse mène à une contradiction, prouvant ainsi que l'hypothèse est fausse.
@@ -315,7 +315,7 @@ L'argument est valide selon la réduction à l'absurde. Si nous supposons que "t
 
 ### Exemple 6: Analyse d'un argument complexe
 
-*Le code complet pour cet exemple est disponible dans [`examples/logic_agents/propositional_logic_example.py`](../../examples/logic_agents/propositional_logic_example.py:168).* 
+*Le code complet pour cet exemple est disponible dans `examples/logic_agents/propositional_logic_example.py`.* 
 
 
 Analysons un argument plus complexe avec plusieurs prémisses et des relations logiques imbriquées.
@@ -380,7 +380,7 @@ Cela crée une contradiction. Par conséquent, notre supposition que le projet e
 
 ### Exemple 7: Détection de contradictions
 
-*Le code complet pour cet exemple est disponible dans [`examples/logic_agents/propositional_logic_example.py`](../../examples/logic_agents/propositional_logic_example.py:212).* 
+*Le code complet pour cet exemple est disponible dans `examples/logic_agents/propositional_logic_example.py`.* 
 
 
 Utilisons la logique propositionnelle pour détecter des contradictions dans un ensemble d'affirmations.
@@ -434,7 +434,7 @@ alice_reussite: True - Tweety Result: Query 'alice_reussite' is ACCEPTED (True).
 
 **Interprétation:**
 ```
-L'ensemble de croyances est incohérent (contradictoire). D'une part, nous pouvons dériver qu'Alice a réussi son examen (car elle étudie régulièrement et tous les étudiants qui étudient régulièrement réussissent). D'autre part, nous avons l'affirmation directe qu'Alice n'a pas réussi son examen. Ces deux conclusions (`alice_reussite` est VRAI et `!alice_reussite` est VRAI) sont contradictoires, ce qui indique qu'au moins une des prémisses doit être fausse. Le script [`examples/logic_agents/propositional_logic_example.py`](../../examples/logic_agents/propositional_logic_example.py:250) confirme cela en montrant que la requête `alice_reussite && !alice_reussite` est ACCEPTED (True) pour cet ensemble de croyances.
+L'ensemble de croyances est incohérent (contradictoire). D'une part, nous pouvons dériver qu'Alice a réussi son examen (car elle étudie régulièrement et tous les étudiants qui étudient régulièrement réussissent). D'autre part, nous avons l'affirmation directe qu'Alice n'a pas réussi son examen. Ces deux conclusions (`alice_reussite` est VRAI et `!alice_reussite` est VRAI) sont contradictoires, ce qui indique qu'au moins une des prémisses doit être fausse. Le script `examples/logic_agents/propositional_logic_example.py` confirme cela en montrant que la requête `alice_reussite && !alice_reussite` est ACCEPTED (True) pour cet ensemble de croyances.
 ```
 
 ## Cas d'utilisation réels
@@ -573,8 +573,8 @@ L'ensemble de croyances est contradictoire. D'une part, nous pouvons conclure qu
 - [Guide d'utilisation des agents logiques](utilisation_agents_logiques.md)
 - [Exemples de logique du premier ordre](exemples_logique_premier_ordre.md)
 - [Exemples de logique modale](exemples_logique_modale.md)
-- [Tutoriel interactif sur les agents logiques](../../examples/notebooks/logic_agents_tutorial.ipynb)
+- Tutoriel interactif sur les agents logiques
 - [Documentation de TweetyProject sur la logique propositionnelle](http://tweetyproject.org/doc/propositional-logic.html)
-- [Script d'exemples complets de logique propositionnelle](../../examples/logic_agents/propositional_logic_example.py)
-- [Tests d'intégration pour les opérations logiques (JPype/Tweety)](../tests/integration/jpype_tweety/test_logic_operations.py)
-- [Tutoriel interactif sur l'API logique (Notebook)](../../examples/notebooks/api_logic_tutorial.ipynb) (Note: se concentre sur une API Web, mais peut illustrer des concepts)
+- Script d'exemples complets de logique propositionnelle
+- [Tests d'intégration pour les opérations logiques (JPype/Tweety)](../../tests/integration/jpype_tweety/test_logic_operations.py)
+- Tutoriel interactif sur l'API logique (Notebook) (Note: se concentre sur une API Web, mais peut illustrer des concepts)

--- a/docs/guides/guide_developpeur.md
+++ b/docs/guides/guide_developpeur.md
@@ -114,11 +114,11 @@ Le système de communication multi-canal est organisé autour des classes princi
 Les principales classes et leurs responsabilités sont :
 
 1. **MessageMiddleware** : Composant central qui gère les canaux, les protocoles et le routage des messages.
-2. **Channel** : Classe de base abstraite que tous les canaux de communication doivent implémenter. Définie dans [`argumentation_analysis/core/communication/channel_interface.py`](argumentation_analysis/core/communication/channel_interface.py:30).
+2. **Channel** : Classe de base abstraite que tous les canaux de communication doivent implémenter. Définie dans [`argumentation_analysis/core/communication/channel_interface.py`](../../argumentation_analysis/core/communication/channel_interface.py:30).
 3. **Canaux spécifiques** (HierarchicalChannel, CollaborationChannel, etc.) : Implémentations concrètes des canaux.
-4. **Protocoles de communication** : Il n'existe pas d'interface formelle `ProtocolInterface`. Les protocoles comme `RequestResponseProtocol` (défini dans [`argumentation_analysis/core/communication/request_response.py`](argumentation_analysis/core/communication/request_response.py:25)) et `PublishSubscribeProtocol` (défini dans [`argumentation_analysis/core/communication/pub_sub.py`](argumentation_analysis/core/communication/pub_sub.py:235)) sont implémentés directement.
+4. **Protocoles de communication** : Il n'existe pas d'interface formelle `ProtocolInterface`. Les protocoles comme `RequestResponseProtocol` (défini dans [`argumentation_analysis/core/communication/request_response.py`](../../argumentation_analysis/core/communication/request_response.py:25)) et `PublishSubscribeProtocol` (défini dans [`argumentation_analysis/core/communication/pub_sub.py`](../../argumentation_analysis/core/communication/pub_sub.py:235)) sont implémentés directement.
 5. **Protocoles spécifiques** (RequestResponse, PublishSubscribe, etc.) : Implémentations concrètes des protocoles.
-6. **Adaptateurs d'agents** : Il n'existe pas de classe de base formelle `AgentAdapter`. Les adaptateurs spécifiques comme `StrategicAdapter` (défini dans [`argumentation_analysis/core/communication/strategic_adapter.py`](argumentation_analysis/core/communication/strategic_adapter.py:23)), `TacticalAdapter` (défini dans [`argumentation_analysis/core/communication/tactical_adapter.py`](argumentation_analysis/core/communication/tactical_adapter.py:23)), et `OperationalAdapter` (défini dans [`argumentation_analysis/core/communication/operational_adapter.py`](argumentation_analysis/core/communication/operational_adapter.py:22)) sont implémentés directement. Chaque adaptateur interagit avec le `MessageMiddleware`.
+6. **Adaptateurs d'agents** : Il n'existe pas de classe de base formelle `AgentAdapter`. Les adaptateurs spécifiques comme `StrategicAdapter` (défini dans [`argumentation_analysis/core/communication/strategic_adapter.py`](../../argumentation_analysis/core/communication/strategic_adapter.py:23)), `TacticalAdapter` (défini dans [`argumentation_analysis/core/communication/tactical_adapter.py`](../../argumentation_analysis/core/communication/tactical_adapter.py:23)), et `OperationalAdapter` (défini dans [`argumentation_analysis/core/communication/operational_adapter.py`](../../argumentation_analysis/core/communication/operational_adapter.py:22)) sont implémentés directement. Chaque adaptateur interagit avec le `MessageMiddleware`.
 7. **Adaptateurs spécifiques** (StrategicAdapter, TacticalAdapter, etc.) : Implémentations concrètes des adaptateurs.
 8. **Message** : Classe de base pour tous les types de messages.
 9. **Types de messages spécifiques** (CommandMessage, InformationMessage, etc.) : Implémentations concrètes des messages.
@@ -213,7 +213,7 @@ La structure typique d'un canal comprend :
 
 ### Interface à implémenter
 
-Tous les canaux de communication doivent hériter de la classe abstraite `Channel` (définie dans [`argumentation_analysis/core/communication/channel_interface.py`](argumentation_analysis/core/communication/channel_interface.py:30)) qui définit les méthodes requises pour interagir avec le middleware. Voici les principales méthodes de cette classe :
+Tous les canaux de communication doivent hériter de la classe abstraite `Channel` (définie dans [`argumentation_analysis/core/communication/channel_interface.py`](../../argumentation_analysis/core/communication/channel_interface.py:30)) qui définit les méthodes requises pour interagir avec le middleware. Voici les principales méthodes de cette classe :
 
 ```python
 class Channel(abc.ABC):
@@ -705,7 +705,7 @@ Il est crucial de tester vos implémentations de canaux. Vous pouvez vous inspir
 - Le fonctionnement des abonnements et des filtres.
 - La gestion des erreurs.
 
-Par exemple, consultez les tests unitaires pour les composants principaux dans [`tests/unit/project_core/`](tests/unit/project_core/) pour des idées sur la structure des tests.
+Par exemple, consultez les tests unitaires pour les composants principaux dans [`tests/unit/project_core/`](../../tests/unit/project_core/) pour des idées sur la structure des tests.
 
 ## Comment créer de nouveaux adaptateurs
 
@@ -723,12 +723,12 @@ La structure typique d'un adaptateur comprend :
 
 ### Interface à implémenter
 
-Il n'existe pas de classe de base `AgentAdapter` formelle à étendre. Chaque adaptateur spécifique (par exemple, `StrategicAdapter` dans [`argumentation_analysis/core/communication/strategic_adapter.py`](argumentation_analysis/core/communication/strategic_adapter.py:23), `TacticalAdapter` dans [`argumentation_analysis/core/communication/tactical_adapter.py`](argumentation_analysis/core/communication/tactical_adapter.py:23), et `OperationalAdapter` dans [`argumentation_analysis/core/communication/operational_adapter.py`](argumentation_analysis/core/communication/operational_adapter.py:22)) est une classe distincte.
+Il n'existe pas de classe de base `AgentAdapter` formelle à étendre. Chaque adaptateur spécifique (par exemple, `StrategicAdapter` dans [`argumentation_analysis/core/communication/strategic_adapter.py`](../../argumentation_analysis/core/communication/strategic_adapter.py:23), `TacticalAdapter` dans [`argumentation_analysis/core/communication/tactical_adapter.py`](../../argumentation_analysis/core/communication/tactical_adapter.py:23), et `OperationalAdapter` dans [`argumentation_analysis/core/communication/operational_adapter.py`](../../argumentation_analysis/core/communication/operational_adapter.py:22)) est une classe distincte.
 
 Lors de la création d'un nouvel adaptateur, vous devriez vous inspirer de ces implémentations existantes. Typiquement, un adaptateur :
 - Prend un `agent_id` et une instance du `MessageMiddleware` dans son constructeur.
 - Initialise un logger spécifique.
-- Implémente une méthode `_get_agent_level()` qui retourne la valeur appropriée de l'énumération `AgentLevel` (définie dans [`argumentation_analysis/core/communication/message.py`](argumentation_analysis/core/communication/message.py:38)).
+- Implémente une méthode `_get_agent_level()` qui retourne la valeur appropriée de l'énumération `AgentLevel` (définie dans [`argumentation_analysis/core/communication/message.py`](../../argumentation_analysis/core/communication/message.py:38)).
 - Fournit des méthodes spécifiques pour envoyer et recevoir des types de messages pertinents pour le niveau de l'agent qu'il sert. Ces méthodes construisent des objets `Message` et utilisent le `MessageMiddleware` pour les envoyer ou les recevoir. Par exemple, une méthode `send_message` générique pourrait ressembler à ceci (adapté des adaptateurs existants) :
   ```python
   # Dans votre classe d'adaptateur spécifique:
@@ -754,7 +754,7 @@ Lors de la création d'un nouvel adaptateur, vous devriez vous inspirer de ces i
   ```
 - Peut inclure des méthodes pour s'abonner à des sujets via le `MessageMiddleware`.
 
-Le `MessageMiddleware` possède une méthode `get_adapter(self, agent_id: str, level: AgentLevel)` (patchée via [`argumentation_analysis/core/communication/middleware_patch.py`](argumentation_analysis/core/communication/middleware_patch.py:8)) qui peut instancier l'adaptateur approprié en fonction du niveau de l'agent.
+Le `MessageMiddleware` possède une méthode `get_adapter(self, agent_id: str, level: AgentLevel)` (patchée via [`argumentation_analysis/core/communication/middleware_patch.py`](../../argumentation_analysis/core/communication/middleware_patch.py:8)) qui peut instancier l'adaptateur approprié en fonction du niveau de l'agent.
 
 ### Traduction des messages
 
@@ -1088,7 +1088,7 @@ Les adaptateurs doivent être testés pour s'assurer qu'ils traduisent correctem
 - Vérifiez la création correcte des messages sortants.
 - Assurez-vous que les messages entrants sont correctement interprétés.
 
-Vous trouverez des exemples de tests d'adaptateurs dans le répertoire [`tests/unit/argumentation_analysis/`](tests/unit/argumentation_analysis/) ou en examinant les tests des modules principaux.
+Vous trouverez des exemples de tests d'adaptateurs dans le répertoire [`tests/unit/argumentation_analysis/`](../../tests/unit/argumentation_analysis/) ou en examinant les tests des modules principaux.
 
 ## Bonnes pratiques de développement
 
@@ -1235,7 +1235,7 @@ class TestStrategicAdapter(unittest.TestCase):
         self.assertEqual(message.priority, MessagePriority.HIGH)
 ```
 
-Pour un exemple concret de test unitaire, vous pouvez examiner [`tests/unit/argumentation_analysis/utils/core_utils/test_file_utils.py`](tests/unit/argumentation_analysis/utils/core_utils/test_file_utils.py:0) qui teste les utilitaires de fichiers.
+Pour un exemple concret de test unitaire, vous pouvez examiner [`tests/unit/argumentation_analysis/utils/core_utils/test_file_utils.py`](../../tests/unit/argumentation_analysis/utils/core_utils/test_file_utils.py:0) qui teste les utilitaires de fichiers.
 
 #### 2. Tests d'intégration
 
@@ -1541,7 +1541,7 @@ La structure typique d'un protocole comprend :
 
 ### Structure d'un protocole
 
-Bien qu'il n'y ait pas d'interface `ProtocolInterface` formelle à implémenter, les protocoles existants comme `RequestResponseProtocol` ([`argumentation_analysis/core/communication/request_response.py`](argumentation_analysis/core/communication/request_response.py:25)) et `PublishSubscribeProtocol` ([`argumentation_analysis/core/communication/pub_sub.py`](argumentation_analysis/core/communication/pub_sub.py:235)) suivent une structure similaire. Un nouveau protocole devrait typiquement :
+Bien qu'il n'y ait pas d'interface `ProtocolInterface` formelle à implémenter, les protocoles existants comme `RequestResponseProtocol` ([`argumentation_analysis/core/communication/request_response.py`](../../argumentation_analysis/core/communication/request_response.py:25)) et `PublishSubscribeProtocol` ([`argumentation_analysis/core/communication/pub_sub.py`](../../argumentation_analysis/core/communication/pub_sub.py:235)) suivent une structure similaire. Un nouveau protocole devrait typiquement :
 
 - Prendre le `MessageMiddleware` en argument de son constructeur.
 - Posséder une méthode pour initialiser le protocole (si nécessaire).
@@ -1549,7 +1549,7 @@ Bien qu'il n'y ait pas d'interface `ProtocolInterface` formelle à implémenter,
 - Définir une méthode pour obtenir son nom (par exemple, `get_protocol_name()`).
 - Définir une méthode pour lister les types de messages qu'il supporte (par exemple, `get_supported_message_types()`).
 
-Le middleware ([`argumentation_analysis/core/communication/middleware.py`](argumentation_analysis/core/communication/middleware.py:19)) instancie et utilise ces protocoles.
+Le middleware ([`argumentation_analysis/core/communication/middleware.py`](../../argumentation_analysis/core/communication/middleware.py:19)) instancie et utilise ces protocoles.
 
 ### Gestion des échanges
 

--- a/docs/guides/guide_utilisation.md
+++ b/docs/guides/guide_utilisation.md
@@ -9,13 +9,13 @@ Bienvenue dans le guide d'utilisation du système d'analyse argumentative. Ce do
 Avant toute chose, assurez-vous d'avoir correctement configuré votre environnement de développement. Des scripts sont fournis pour faciliter cette étape :
 
 *   Pour un environnement PowerShell : exécutez le script [`setup_project_env.ps1`](../../setup_project_env.ps1:0).
-*   Pour un environnement Bash (Linux/macOS) : exécutez le script [`setup_project_env.sh`](../../setup_project_env.sh:0).
+*   Pour un environnement Bash (Linux/macOS) : exécutez le script [`setup_project_env.sh`](../../scripts/setup/setup_project_env.sh:0).
 
 Ces scripts installeront les dépendances nécessaires et configureront les variables d'environnement.
 
 ## 2. Utilisation du Service d'Analyse Argumentative via l'API
 
-Le moyen principal d'interagir avec le système pour analyser un texte est d'utiliser son API Web. Cette section décrit comment soumettre un texte et interpréter les résultats. Pour une documentation exhaustive de l'API, veuillez consulter le document [`docs/composants/api_web.md`](../composants/api_web.md:1).
+Le moyen principal d'interagir avec le système pour analyser un texte est d'utiliser son API Web. Cette section décrit comment soumettre un texte et interpréter les résultats. Pour une documentation exhaustive de l'API, veuillez consulter le document [`docs/composants/api_web.md`](../technical/api_web.md:1).
 
 ### Soumettre un Texte pour Analyse Complète
 
@@ -49,7 +49,7 @@ Le corps de la requête doit être au format JSON et contenir le texte à analys
     *   `evaluate_coherence` (boolean) : Activer ou désactiver l'évaluation de la cohérence.
     *   `include_context` (boolean) : Inclure plus de contexte pour les éléments détectés.
     *   `severity_threshold` (float) : Seuil de sévérité pour la détection (par exemple, pour les sophismes).
-    Pour une liste complète et détaillée des options, référez-vous à la section sur l'endpoint `/api/analyze` dans la [documentation de l'API Web](../composants/api_web.md:58).
+    Pour une liste complète et détaillée des options, référez-vous à la section sur l'endpoint `/api/analyze` dans la [documentation de l'API Web](../technical/api_web.md:58).
 
 #### Exemple avec `curl`
 
@@ -125,24 +125,24 @@ Si une erreur survient (par exemple, une requête malformée ou une erreur inter
 
 Si vous êtes un développeur souhaitant comprendre les composants internes du système ou contribuer au projet, plusieurs exemples sont à votre disposition.
 
-*   **Scripts de démonstration :** Le répertoire [`examples/scripts_demonstration/`](../../examples/scripts_demonstration/) contient des scripts Python simples illustrant des interactions spécifiques. Par exemple, le script [`demo_tweety_interaction_simple.py`](../../examples/scripts_demonstration/demo_tweety_interaction_simple.py:0) montre une utilisation basique de la librairie Tweety.
-*   **Notebooks Jupyter :** Pour une approche plus interactive et didactique, consultez les notebooks disponibles dans [`examples/notebooks/`](../../examples/notebooks/). Le notebook [`api_logic_tutorial.ipynb`](../../examples/notebooks/api_logic_tutorial.ipynb:0) constitue un excellent point de départ pour comprendre l'utilisation de l'API logique.
+*   **Scripts de démonstration :** Le répertoire `examples/scripts_demonstration/` contient des scripts Python simples illustrant des interactions spécifiques. Par exemple, le script `demo_tweety_interaction_simple.py` montre une utilisation basique de la librairie Tweety.
+*   **Notebooks Jupyter :** Pour une approche plus interactive et didactique, consultez les notebooks disponibles dans [`examples/notebooks/`](../../examples/notebooks/). Le notebook `api_logic_tutorial.ipynb` constitue un excellent point de départ pour comprendre l'utilisation de l'API logique.
 
 ## 4. Intégration d'API et Agents Logiques (pour Développeurs)
 
 Le projet explore l'intégration avec des API externes et l'utilisation d'agents logiques.
 
-*   Des exemples concrets d'intégration d'API et de mise en œuvre d'agents logiques se trouvent dans le répertoire [`examples/logic_agents/`](../../examples/logic_agents/). Le script [`api_integration_example.py`](../../examples/logic_agents/api_integration_example.py:0) illustre un cas d'usage typique.
+*   Des exemples concrets d'intégration d'API et de mise en œuvre d'agents logiques se trouvent dans le répertoire `examples/logic_agents/`. Le script `api_integration_example.py` illustre un cas d'usage typique.
 
 ## 5. Utilisation des Données de Test (pour Développeurs)
 
 Un ensemble de données d'exemple est fourni pour vous permettre de tester et d'expérimenter avec le projet sans avoir à créer vos propres données initiales.
 
-*   Vous trouverez ces données dans le répertoire [`examples/test_data/`](../../examples/test_data/). N'hésitez pas à les explorer et à les utiliser avec les différents scripts et notebooks.
+*   Vous trouverez ces données dans le répertoire `examples/test_data/`. N'hésitez pas à les explorer et à les utiliser avec les différents scripts et notebooks.
 
 ## 6. Exécution de Scripts Spécifiques (pour Développeurs)
 
-Le répertoire [`scripts/execution/`](../../scripts/execution/) contient des scripts plus avancés pour des tâches spécifiques, comme l'analyse rhétorique ou des workflows complets.
+Le répertoire `scripts/execution/` contient des scripts plus avancés pour des tâches spécifiques, comme l'analyse rhétorique ou des workflows complets.
 
 *   Parcourez ce répertoire pour découvrir des exemples d'utilisation plus complexes et des chaînes de traitement de données.
 
@@ -151,14 +151,14 @@ Le répertoire [`scripts/execution/`](../../scripts/execution/) contient des scr
 Il est crucial de pouvoir vérifier l'intégrité et le bon fonctionnement du code. Plusieurs niveaux de tests sont disponibles.
 
 *   **Scripts de test dédiés :** Le répertoire [`scripts/testing/`](../../scripts/testing/) contient des scripts pour lancer des suites de tests spécifiques ou des simulations.
-*   **Tests Unitaires :** Les tests unitaires, qui vérifient des composants isolés du code, sont situés dans [`tests/unit/`](../../tests/unit/). Un exemple typique est [`tests/unit/project_core/utils/test_file_utils.py`](../../tests/unit/project_core/utils/test_file_utils.py:0), qui teste les utilitaires de gestion de fichiers.
-*   **Tests d'Intégration :** Les tests d'intégration, qui vérifient l'interaction entre plusieurs composants, se trouvent dans [`tests/integration/`](../../tests/integration/). Vous pouvez consulter [`tests/integration/test_logic_agents_integration.py`](../tests/integration/test_logic_agents_integration.py:0) pour un exemple d'intégration d'agents logiques, ou le répertoire [`tests/integration/jpype_tweety/`](../../tests/integration/jpype_tweety/) pour les tests spécifiques à l'intégration JPype/Tweety.
+*   **Tests Unitaires :** Les tests unitaires, qui vérifient des composants isolés du code, sont situés dans [`tests/unit/`](../../tests/unit/). Un exemple typique est [`tests/unit/project_core/utils/test_file_utils.py`](../../tests/unit/argumentation_analysis/utils/core_utils/test_file_utils.py:0), qui teste les utilitaires de gestion de fichiers.
+*   **Tests d'Intégration :** Les tests d'intégration, qui vérifient l'interaction entre plusieurs composants, se trouvent dans [`tests/integration/`](../../tests/integration/). Vous pouvez consulter [`tests/integration/test_logic_agents_integration.py`](../../tests/integration/test_logic_agents_integration.py:0) pour un exemple d'intégration d'agents logiques, ou le répertoire [`tests/integration/jpype_tweety/`](../../tests/integration/jpype_tweety/) pour les tests spécifiques à l'intégration JPype/Tweety.
 
 ## Conclusion
 
 Ce guide vous a présenté comment utiliser le service d'analyse argumentative via son API, ainsi que les principales façons d'explorer les ressources du projet pour les développeurs. Pour une utilisation directe du service d'analyse, référez-vous à la section sur l'API (Section 2). Pour approfondir votre compréhension des mécanismes internes ou développer des fonctionnalités, les exemples et scripts décrits dans les sections suivantes restent à votre disposition.
 
-N'hésitez pas à consulter la documentation complète de l'API ([`docs/composants/api_web.md`](../composants/api_web.md:1)) et les README spécifiques à chaque module pour plus de détails.
+N'hésitez pas à consulter la documentation complète de l'API ([`docs/composants/api_web.md`](../technical/api_web.md:1)) et les README spécifiques à chaque module pour plus de détails.
 
 Bonne exploration !
 

--- a/docs/guides/integration_api_web.md
+++ b/docs/guides/integration_api_web.md
@@ -418,9 +418,9 @@ En cas d'erreur, l'API renvoie un objet JSON avec les informations suivantes:
 
 ## Ressources supplémentaires
 
-- [Description technique de l'API Web](../composants/api_web.md)
+- [Description technique de l'API Web](../technical/api_web.md)
 - [Guide d'utilisation des agents logiques](utilisation_agents_logiques.md)
 - [Exemples de logique propositionnelle](exemples_logique_propositionnelle.md)
 - [Exemples de logique du premier ordre](exemples_logique_premier_ordre.md)
 - [Exemples de logique modale](exemples_logique_modale.md)
-- [Exemple d'intégration avec l'API Web](../../examples/logic_agents/api_integration_example.py)
+- Exemple d'intégration avec l'API Web

--- a/docs/guides/java_integration_handbook.md
+++ b/docs/guides/java_integration_handbook.md
@@ -14,7 +14,7 @@ L'architecture actuelle repose sur des principes clés pour assurer la résilien
 Pour les erreurs spécifiques et leur résolution, consultez les guides dédiés :
 
 *   **Crash JVM (Access Violation) au Démarrage des Tests :** Causé par une mauvaise détection des sessions E2E.
-    *   **Solution :** [Résolution du Crash JVM dû à la détection E2E](../troubleshooting/jpype_e2e_detection_crash.md)
+    *   **Solution :** [Résolution du Crash JVM dû à la détection E2E](./jpype_e2e_detection_crash.md)
 
 *   **Modularité des solveurs logiques** grâce à un sélecteur (`FOLHandler` refactorisé) permettant de basculer entre `tweety` (basé sur Java) et `prover9` (exécutable externe) via une variable d'environnement.
 
@@ -101,7 +101,7 @@ Ce contexte historique montre que la gestion du cycle de vie de la JVM est extr�
 *   **Cause Racine 2 (Erreur de Chemin)** : Quatre tests échouaient systématiquement avec le code d'erreur 4 de `pytest` ("file or directory not found"). L'enquête a montré qu'une faute de frappe s'était glissée dans le nom du fichier de test (`authentic_components.py` au lieu de `test_authentic_components.py`).
 *   **Solution** :
     1.  Correction de l'assignation dans `FOLLogicAgent` pour utiliser l'attribut interne `_tweety_bridge` au lieu de la propriété publique.
-    2.  Correction de la faute de frappe dans les fichiers [`tests_jvm.txt`](maintenance/tests_jvm.txt:1) (utilisé par le script d'isolation) pour pointer vers le bon fichier de test.
+    2.  Correction de la faute de frappe dans les fichiers `tests_jvm.txt` (utilisé par le script d'isolation) pour pointer vers le bon fichier de test.
     3.  Ces corrections, combinées au refactoring précédent qui a introduit l'injection de dépendance pour `TweetyBridge` via une fixture `pytest`, ont permis de rendre la suite de tests `jvm_test` entièrement fonctionnelle.
 
 ### Phase 6 : Stabilisation des Tests End-to-End (Début Août 2025)

--- a/docs/guides/java_testing_action_plan.md
+++ b/docs/guides/java_testing_action_plan.md
@@ -3,7 +3,7 @@
 Ce document détaille la stratégie et les étapes pour corriger la suite de tests E2E et assurer une isolation robuste des tests dépendants de la JVM.
 
 &gt; **Note sur l'Implémentation**
-&gt; Ce document décrit le plan d'action initial. Pour un rapport complet sur l'implémentation finale de cette stratégie ainsi que sur le refactoring plus large du serveur MCP et de la CI, veuillez consulter le [Rapport de Refactoring : Serveur MCP, Stabilisation des Tests et CI](./refactoring/refactoring_mcp_et_stabilisation_ci.md).
+&gt; Ce document décrit le plan d'action initial. Pour un rapport complet sur l'implémentation finale de cette stratégie ainsi que sur le refactoring plus large du serveur MCP et de la CI, veuillez consulter le Rapport de Refactoring : Serveur MCP, Stabilisation des Tests et CI.
 ## 1. Stratégie Générale
 
 La stratégie repose sur l'isolation des tests basés sur la JVM du reste de la suite de tests en utilisant les marqueurs `pytest`. Cela nous permettra de contrôler précisément quand et comment la JVM est démarrée et d'éviter les conflits avec d'autres bibliothèques ou plugins.

--- a/docs/guides/jpype_e2e_detection_crash.md
+++ b/docs/guides/jpype_e2e_detection_crash.md
@@ -18,7 +18,7 @@ L'enquête a révélé que le crash n'était pas directement dû à `jpype` ou �
 
 Le correctif a consisté à remplacer la détection par chaîne de caractères par une méthode plus robuste et spécifique à `pytest`, qui vérifie la présence explicite du marqueur `@pytest.mark.e2e`.
 
-**Fichier modifié :** [`tests/conftest.py`](tests/conftest.py:1)
+**Fichier modifié :** [`tests/conftest.py`](../../tests/conftest.py:1)
 
 ```python
 # Ligne 251

--- a/docs/guides/mcp_implementation_guide.md
+++ b/docs/guides/mcp_implementation_guide.md
@@ -19,7 +19,7 @@ Cette approche consiste à recréer la structure de base de la bibliothèque `mc
 
 2.  **Définir la structure de la classe `FastMCP` :**
 
-    Le fichier [`libs/mcp/server/fastmcp.py`](libs/mcp/server/fastmcp.py) doit contenir la classe `FastMCP`. En se basant sur son utilisation dans `services/mcp_server/main.py`, la classe devra implémenter les méthodes suivantes :
+    Le fichier [`libs/mcp/server/fastmcp.py`](../../libs/mcp/server/fastmcp.py) doit contenir la classe `FastMCP`. En se basant sur son utilisation dans `services/mcp_server/main.py`, la classe devra implémenter les méthodes suivantes :
     *   `__init__(self, ...)`: Pour l'initialisation.
     *   `tool(self, ...)`: Pour décorer et enregistrer de nouveaux outils.
     *   `run(self, ...)`: Pour démarrer le serveur et écouter les requêtes.

--- a/docs/guides/mcp_integration_guide_for_students.md
+++ b/docs/guides/mcp_integration_guide_for_students.md
@@ -10,7 +10,7 @@ L'objectif de ce document est de vous fournir un retour constructif et un plan d
 
 Votre serveur MCP est bien conçu, mais il repose sur une hypothèse architecturale qui n'est plus d'actualité.
 
-**Le point clé :** Votre code dans [`mcp/main.py`](mcp/main.py:8) tente de contacter une API web à l'adresse `http://localhost:5000/api`.
+**Le point clé :** Votre code dans `mcp/main.py` tente de contacter une API web à l'adresse `http://localhost:5000/api`.
 
 ```python
 # mcp/main.py:8
@@ -23,7 +23,7 @@ Cette approche était valable avec l'ancienne architecture du projet. Cependant,
 
 Le projet n'expose plus une multitude de services sur des ports différents. À la place, nous avons un **point d'entrée unique** :
 
-- **[`project_core/webapp_from_scripts/unified_web_orchestrator.py`](project_core/webapp_from_scripts/unified_web_orchestrator.py)**
+- **[`project_core/webapp_from_scripts/unified_web_orchestrator.py`](../../scripts/apps/webapp/unified_web_orchestrator.py)**
 
 Cet orchestrateur est maintenant responsable du cycle de vie de toutes les applications et services. Il utilise une classe centrale, le `ServiceManager`, pour démarrer, arrêter et communiquer avec les différents composants, y compris les vôtres.
 
@@ -38,7 +38,7 @@ Voici un plan étape par étape pour aligner votre serveur MCP avec la nouvelle 
 Votre `main.py` ne doit plus être un simple "proxy" HTTP. Il doit devenir un véritable service qui utilise directement les fonctionnalités d'analyse du projet.
 
 **Action :**
-Modifiez les fonctions dans [`mcp/main.py`](mcp/main.py) pour qu'elles importent et appellent les classes et fonctions d'analyse du projet. Inspirez-vous de la manière dont le `ServiceManager` communique avec les autres services. Vous devrez probablement importer des éléments depuis `argumentation_analysis` ou `project_core`.
+Modifiez les fonctions dans `mcp/main.py` pour qu'elles importent et appellent les classes et fonctions d'analyse du projet. Inspirez-vous de la manière dont le `ServiceManager` communique avec les autres services. Vous devrez probablement importer des éléments depuis `argumentation_analysis` ou `project_core`.
 
 *Exemple (conceptuel) :*
 ```python
@@ -57,7 +57,7 @@ return result
 
 ### Étape 2 : Intégrer le lancement à l'Orchestrateur
 
-L'[`UnifiedWebOrchestrator`](project_core/webapp_from_scripts/unified_web_orchestrator.py) doit connaître votre serveur MCP pour le lancer en tant que sous-processus.
+L'[`UnifiedWebOrchestrator`](../../scripts/apps/webapp/unified_web_orchestrator.py) doit connaître votre serveur MCP pour le lancer en tant que sous-processus.
 
 **Action :**
 Identifiez dans le script de l'orchestrateur l'endroit où les autres services sont démarrés et ajoutez le code nécessaire pour lancer votre serveur. La commande sera probablement similaire à celle que vous avez définie dans votre `README.md` : `uv run mcp/main.py`.

--- a/docs/guides/standards_documentation.md
+++ b/docs/guides/standards_documentation.md
@@ -202,7 +202,7 @@ Liens vers d'autres documents pertinents :
 
 ## Exemple d'Application
 
-Un exemple complet d'application de cette structure est disponible dans le README du module [scripts](../scripts/README.md).
+Un exemple complet d'application de cette structure est disponible dans le README du module [scripts](../../scripts/README.md).
 
 ## Validation
 

--- a/docs/guides/testing/functional_tests.md
+++ b/docs/guides/testing/functional_tests.md
@@ -328,10 +328,10 @@ fi
 
 ## 📚 Documentation Associée
 
-- **[Guide Application Web](../docs/WEB_APPLICATION_GUIDE.md)** : Guide utilisateur complet
-- **[API Backend](../argumentation_analysis/services/web_api/README.md)** : Documentation API
-- **[Frontend React](../services/web_api/interface-web-argumentative/README.md)** : Documentation frontend
-- **[Script d'Exécution](../scripts/run_all_and_test.ps1)** : Pipeline automatisé
+- **[Guide Application Web](../WEB_APPLICATION_GUIDE.md)** : Guide utilisateur complet
+- **[API Backend](../../../argumentation_analysis/services/web_api/README.md)** : Documentation API
+- **[Frontend React](../../../services/web_api/interface-web-argumentative/README.md)** : Documentation frontend
+- **Script d'Exécution** : Pipeline automatisé
 
 ## 🤝 Maintenance et Évolution
 

--- a/docs/guides/testing/unified_config_tests.md
+++ b/docs/guides/testing/unified_config_tests.md
@@ -35,7 +35,7 @@ tests/
 
 ## 🧪 Tests unitaires détaillés
 
-### [`test_unified_config.py`](unit/config/test_unified_config.py)
+### [`test_unified_config.py`](../../../tests/unit/config/test_unified_config.py)
 
 **Couverture :** Configuration principale, énumérations, validation
 
@@ -80,7 +80,7 @@ def test_get_agent_classes()              # Mapping agents → classes
 
 ## 🖥️ Tests CLI
 
-### [`test_configuration_cli.py`](unit/scripts/test_configuration_cli.py)
+### [`test_configuration_cli.py`](../../../tests/unit/argumentation_analysis/test_configuration_cli.py)
 
 **Couverture :** Interface CLI, conversion arguments, validation
 
@@ -132,7 +132,7 @@ python scripts/main/analyze_text.py \
 
 ## 🔗 Tests d'intégration
 
-### [`test_unified_config_integration.py`](unit/integration/test_unified_config_integration.py)
+### [`test_unified_config_integration.py`](../../../tests/unit/integration/test_unified_config_integration.py)
 
 **Couverture :** Pipeline complet, presets, compatibilité
 
@@ -159,7 +159,7 @@ def test_configuration_validation_comprehensive()   # Validation complète
 
 ## 💻 Tests PowerShell CLI
 
-### [`test_unified_config_cli.ps1`](scripts/test_unified_config_cli.ps1)
+### [`test_unified_config_cli.ps1`](../../../tests/scripts/test_unified_config_cli.ps1)
 
 **Couverture :** CLI système, intégration Windows, validation bout-en-bout
 
@@ -191,7 +191,7 @@ python analyze_text.py --source-type simple --format json --output test.json
 
 ## 🚀 Orchestrateur de tests
 
-### [`run_unified_config_tests.py`](run_unified_config_tests.py)
+### `run_unified_config_tests.py`
 
 **Couverture :** Automatisation complète, rapports, métriques
 

--- a/docs/guides/tutorials/01_getting_started/README.md
+++ b/docs/guides/tutorials/01_getting_started/README.md
@@ -123,15 +123,15 @@ python -c "from argumentation_analysis.core.environment import ensure_env; ensur
 
 ### Pendant les Tutoriels
 
-- **[Démonstrations](../../demos/showcases/)** : Voir des exemples fonctionnels
-- **[Exemples](../../examples/)** : Code réutilisable
-- **[Documentation](../../docs/)** : Référence complète
+- **Démonstrations** : Voir des exemples fonctionnels
+- **[Exemples](../../../../examples/)** : Code réutilisable
+- **[Documentation](../../../../docs/)** : Référence complète
 
 ### Après les Tutoriels
 
 - **[Extending the System](../02_extending_the_system/)** : Niveau avancé
-- **[Plugins](../../examples/04_plugins/)** : Développement de plugins
-- **[Integration](../../demos/integration/)** : Tests d'intégration
+- **[Plugins](../../../../examples/04_plugins/)** : Développement de plugins
+- **Integration** : Tests d'intégration
 
 ## Conseils pour Réussir
 
@@ -172,10 +172,10 @@ Prochaine étape
 
 ### Besoin d'Aide ?
 
-1. **Consultez la [FAQ](../../docs/FAQ.md)** : Réponses aux questions fréquentes
-2. **Explorez les [démos](../../demos/)** : Voir le système en action
-3. **Testez les [exemples](../../examples/)** : Code prêt à l'emploi
-4. **Lisez la [documentation](../../docs/)** : Référence complète
+1. **Consultez la [FAQ](../../../../docs/guides/FAQ.md)** : Réponses aux questions fréquentes
+2. **Explorez les démos** : Voir le système en action
+3. **Testez les [exemples](../../../../examples/)** : Code prêt à l'emploi
+4. **Lisez la [documentation](../../../../docs/)** : Référence complète
 
 ### Feedback
 

--- a/docs/guides/tutorials/02_extending_the_system/README.md
+++ b/docs/guides/tutorials/02_extending_the_system/README.md
@@ -179,21 +179,21 @@ class EmotionalToneAnalyzer:
 
 ### Documentation Technique
 
-- **[Architecture du Système](../../docs/architecture/)** : Schémas et diagrammes
-- **[API Reference](../../docs/api/)** : Documentation des classes et méthodes
-- **[Design Patterns](../../docs/patterns/)** : Patterns utilisés dans le projet
+- **[Architecture du Système](../../../../docs/architecture/)** : Schémas et diagrammes
+- **API Reference** : Documentation des classes et méthodes
+- **Design Patterns** : Patterns utilisés dans le projet
 
 ### Exemples de Code
 
-- **[Plugins](../../examples/04_plugins/)** : Exemples de plugins fonctionnels
-- **[Core System Demos](../../examples/02_core_system_demos/)** : Démos système central
-- **[Tests](../../tests/)** : Suite de tests pour inspiration
+- **[Plugins](../../../../examples/04_plugins/)** : Exemples de plugins fonctionnels
+- **[Core System Demos](../../../../examples/02_core_system_demos/)** : Démos système central
+- **[Tests](../../../../tests/)** : Suite de tests pour inspiration
 
 ### Outils de Développement
 
-- **[Debugging Tools](../../demos/debugging/)** : Outils de débogage
-- **[Validation Tools](../../demos/validation/)** : Scripts de validation
-- **[Integration Tests](../../demos/integration/)** : Tests d'intégration
+- **Debugging Tools** : Outils de débogage
+- **Validation Tools** : Scripts de validation
+- **Integration Tests** : Tests d'intégration
 
 ## Bonnes Pratiques
 

--- a/docs/guides/tutorials/README.md
+++ b/docs/guides/tutorials/README.md
@@ -37,8 +37,8 @@ tutorials/
 | Tutoriel | Titre | Contenu Clé |
 |----------|-------|-------------|
 | **[01](./01_getting_started/01_introduction.md)** | Introduction | Présentation du système, architecture générale, concepts de base |
-| **[02](./01_getting_started/02_installation.md)** | Installation | Configuration de l'environnement, installation des dépendances, vérification |
-| **[03](./01_getting_started/03_first_steps.md)** | Premiers Pas | Première analyse, utilisation de l'API, interprétation des résultats |
+| **02** | Installation | Configuration de l'environnement, installation des dépendances, vérification |
+| **03** | Premiers Pas | Première analyse, utilisation de l'API, interprétation des résultats |
 
 **📖 [Documentation détaillée](./01_getting_started/README.md)**
 
@@ -59,8 +59,8 @@ tutorials/
 
 | Tutoriel | Titre | Contenu Clé |
 |----------|-------|-------------|
-| **[01](./02_extending_the_system/01_creating_plugins.md)** | Création de Plugins | Architecture des plugins, développement, intégration, bonnes pratiques |
-| **[02](./02_extending_the_system/02_custom_analyzers.md)** | Analyseurs Personnalisés | Création d'analyseurs spécialisés, extension de la taxonomie des sophismes |
+| **01** | Création de Plugins | Architecture des plugins, développement, intégration, bonnes pratiques |
+| **02** | Analyseurs Personnalisés | Création d'analyseurs spécialisés, extension de la taxonomie des sophismes |
 
 **📖 [Documentation détaillée](./02_extending_the_system/README.md)**
 
@@ -135,10 +135,10 @@ Niveau 2: Extending the System
 
 ## 🔗 Ressources Connexes
 
-- **[Démonstrations](../demos/README.md)** : Exemples fonctionnels complets du système
-- **[Exemples](../examples/README.md)** : Code réutilisable et patterns d'implémentation
-- **[Documentation](../docs/)** : Documentation technique complète et référence API
-- **[Plugins](../plugins/)** : Collection de plugins existants
+- **Démonstrations** : Exemples fonctionnels complets du système
+- **[Exemples](../../../examples/README.md)** : Code réutilisable et patterns d'implémentation
+- **[Documentation](../../../docs/)** : Documentation technique complète et référence API
+- **Plugins** : Collection de plugins existants
 
 ## 💡 Créer un Nouveau Tutoriel
 
@@ -205,9 +205,9 @@ ensure_env()
 
 Si vous rencontrez des difficultés en suivant ces tutoriels :
 
-1. **Consultez la [documentation technique](../docs/README.md)** pour des informations supplémentaires
-2. **Explorez les [exemples pratiques](../examples/README.md)** pour voir des implémentations concrètes
-3. **Testez les [démonstrations](../demos/README.md)** pour valider votre environnement
+1. **Consultez la [documentation technique](../../../docs/README.md)** pour des informations supplémentaires
+2. **Explorez les [exemples pratiques](../../../examples/README.md)** pour voir des implémentations concrètes
+3. **Testez les démonstrations** pour valider votre environnement
 4. **Vérifiez les problèmes connus** dans les issues GitHub du projet
 
 ## 🏆 Certification

--- a/docs/guides/utilisation_agents_logiques.md
+++ b/docs/guides/utilisation_agents_logiques.md
@@ -84,7 +84,7 @@ Le système d'agents logiques est composé des éléments suivants:
 1. **`BaseLogicAgent`**: Classe abstraite **unifiée** ([`argumentation_analysis/agents/core/abc/agent_bases.py`](../../argumentation_analysis/agents/core/abc/agent_bases.py:159)) définissant l'interface commune à tous les agents logiques. Suite à un refactoring, elle intègre désormais à la fois les capacités de raisonnement formel et la logique d'orchestration de tâches (précédemment dans `AbstractLogicAgent`, qui a été supprimé).
 2. **Agents spécifiques**: Implémentations concrètes héritant de `BaseLogicAgent`:
    - [`PropositionalLogicAgent`](../../argumentation_analysis/agents/core/logic/propositional_logic_agent.py:35): Pour la logique propositionnelle
-   - [`FirstOrderLogicAgent`](../../argumentation_analysis/agents/core/logic/first_order_logic_agent.py:131): Pour la logique du premier ordre
+   - [`FirstOrderLogicAgent`](../../argumentation_analysis/agents/core/logic/fol_logic_agent.py:131): Pour la logique du premier ordre
    - [`ModalLogicAgent`](../../argumentation_analysis/agents/core/logic/modal_logic_agent.py:138): Pour la logique modale
 3. **`LogicAgentFactory`**: Factory ([`argumentation_analysis/agents/core/logic/logic_factory.py`](../../argumentation_analysis/agents/core/logic/logic_factory.py:20)) pour créer les agents appropriés selon le type de logique.
 4. **`BeliefSet`**: Représentation des ensembles de croyances ([`argumentation_analysis/agents/core/logic/belief_set.py`](../../argumentation_analysis/agents/core/logic/belief_set.py)).
@@ -128,7 +128,7 @@ llm_service_id = "default" # Assurez-vous que ce service est configuré dans vot
 agent = LogicAgentFactory.create_agent("propositional", kernel, llm_service_id)
 ```
 
-Pour un exemple complet d'initialisation et d'utilisation programmatique d'un agent logique, consultez les scripts disponibles dans le répertoire [`examples/logic_agents/`](../../examples/logic_agents/). Le script [`demo_tweety_interaction_simple.py`](../../examples/scripts_demonstration/demo_tweety_interaction_simple.py:0) peut également offrir un contexte d'utilisation, bien qu'il soit plus orienté vers une démonstration d'interaction globale.
+Pour un exemple complet d'initialisation et d'utilisation programmatique d'un agent logique, consultez les scripts disponibles dans le répertoire `examples/logic_agents/`. Le script `demo_tweety_interaction_simple.py` peut également offrir un contexte d'utilisation, bien qu'il soit plus orienté vers une démonstration d'interaction globale.
 
 ### Conversion de texte en ensemble de croyances
 
@@ -191,7 +191,7 @@ interpretation = agent.interpret_results(text, belief_set, queries, results_for_
 print(f"Interprétation: {interpretation}")
 ```
 
-Des exemples illustrant l'ensemble de ce flux de travail (de la conversion du texte à l'interprétation des résultats) sont disponibles dans le répertoire [`examples/logic_agents/`](../../examples/logic_agents/).
+Des exemples illustrant l'ensemble de ce flux de travail (de la conversion du texte à l'interprétation des résultats) sont disponibles dans le répertoire `examples/logic_agents/`.
 
 ## Intégration avec d'autres composants
 
@@ -230,10 +230,10 @@ Les agents logiques sont exposés via l'API Web, permettant leur utilisation à 
 - Endpoint `/api/logic/belief-set`: Convertit un texte en ensemble de croyances
 - Endpoint `/api/logic/query`: Exécute une requête sur un ensemble de croyances
 - Endpoint `/api/logic/generate-queries`: Génère des requêtes pertinentes
-- Endpoint `/api/logic/interpret`: Interprète les résultats des requêtes (Note: Cet endpoint n'est actuellement pas implémenté dans [`libs/web_api/routes/logic_routes.py`](../../libs/web_api/routes/logic_routes.py)).
+- Endpoint `/api/logic/interpret`: Interprète les résultats des requêtes (Note: Cet endpoint n'est actuellement pas implémenté dans [`libs/web_api/routes/logic_routes.py`](../../argumentation_analysis/services/web_api/routes/logic_routes.py)).
 
-Pour un exemple concret d'intégration et d'utilisation de ces endpoints API, référez-vous au script [`api_integration_example.py`](../../examples/logic_agents/api_integration_example.py).
-De plus, des tests d'intégration pour les agents logiques, y compris leur interaction via l'API, sont disponibles dans [`tests/integration/test_logic_agents_integration.py`](../tests/integration/test_logic_agents_integration.py).
+Pour un exemple concret d'intégration et d'utilisation de ces endpoints API, référez-vous au script `api_integration_example.py`.
+De plus, des tests d'intégration pour les agents logiques, y compris leur interaction via l'API, sont disponibles dans [`tests/integration/test_logic_agents_integration.py`](../../tests/integration/test_logic_agents_integration.py).
 
 ## Bonnes pratiques
 
@@ -291,19 +291,19 @@ logging.basicConfig(level=logging.DEBUG)
 - [Exemples de logique modale](exemples_logique_modale.md)
 - [Guide d'intégration avec l'API Web](integration_api_web.md)
 - [Documentation de TweetyProject](http://tweetyproject.org/doc/)
-- [Tutoriel interactif sur les agents logiques](../../examples/notebooks/logic_agents_tutorial.ipynb)
+- Tutoriel interactif sur les agents logiques
 - **Exemples de scripts pour agents logiques**:
-    - Le répertoire [`examples/logic_agents/`](../../examples/logic_agents/) contient divers scripts illustrant l'utilisation des agents logiques.
-    - Le script [`api_integration_example.py`](../../examples/logic_agents/api_integration_example.py) montre comment interagir avec les agents logiques via l'API.
-    - Certains scripts dans [`examples/scripts_demonstration/`](../../examples/scripts_demonstration/) peuvent également offrir des contextes d'utilisation pertinents (ex: [`demo_tweety_interaction_simple.py`](../../examples/scripts_demonstration/demo_tweety_interaction_simple.py)).
+    - Le répertoire `examples/logic_agents/` contient divers scripts illustrant l'utilisation des agents logiques.
+    - Le script `api_integration_example.py` montre comment interagir avec les agents logiques via l'API.
+    - Certains scripts dans `examples/scripts_demonstration/` peuvent également offrir des contextes d'utilisation pertinents (ex: `demo_tweety_interaction_simple.py`).
 - **Notebooks Jupyter supplémentaires**:
-    - En complément du tutoriel `logic_agents_tutorial.ipynb` déjà listé, le notebook [`api_logic_tutorial.ipynb`](../../examples/notebooks/api_logic_tutorial.ipynb) peut offrir des exemples d'utilisation de l'API des agents logiques (vérifiez sa disponibilité et pertinence exacte pour votre besoin).
+    - En complément du tutoriel `logic_agents_tutorial.ipynb` déjà listé, le notebook `api_logic_tutorial.ipynb` peut offrir des exemples d'utilisation de l'API des agents logiques (vérifiez sa disponibilité et pertinence exacte pour votre besoin).
 - **Tests d'intégration**:
     - Pour comprendre comment les agents logiques sont testés et pour voir des exemples d'utilisation dans des scénarios d'intégration, consultez :
-        - Le fichier de test principal : [`tests/integration/test_logic_agents_integration.py`](../tests/integration/test_logic_agents_integration.py).
+        - Le fichier de test principal : [`tests/integration/test_logic_agents_integration.py`](../../tests/integration/test_logic_agents_integration.py).
         - Le répertoire [`tests/integration/jpype_tweety/`](../../tests/integration/jpype_tweety/) pour des tests spécifiques à l'intégration avec TweetyProject via JPype, qui est un composant clé.
 - **Données d'exemple**:
-    - Les données utilisées par les exemples ou les tests des agents logiques peuvent se trouver dans le répertoire [`examples/test_data/`](../../examples/test_data/). Il est recommandé d'explorer ce répertoire pour trouver des fichiers de données spécifiques si vous travaillez sur des exemples ou reproduisez des tests.
+    - Les données utilisées par les exemples ou les tests des agents logiques peuvent se trouver dans le répertoire `examples/test_data/`. Il est recommandé d'explorer ce répertoire pour trouver des fichiers de données spécifiques si vous travaillez sur des exemples ou reproduisez des tests.
 
 
 


### PR DESCRIPTION
## Summary

ATT-5 Phase 2 (issue #1315): fix broken internal markdown links across **`docs/guides/`** — 31 files, 232 balanced link edits (net-zero line count), **0 files deleted**.

Sister PR to #1413 (Phase 2 architecture/). Disjoint file set → independent merge order, no conflict risk.

## Method

- All reroute targets **verified via `git ls-files`** (verify-before-assert — R563/R568 lesson: trust git tracking, not working tree).
- **Single-link-scoped regex** (`[^\]]+`, not non-greedy `.+?`) — avoids R568 multi-link-per-line mangling.
- Linkcheck run **in-place** on the real docs tree (never on a scratchpad copy — false positives).

## Operations

| Op | Description | Count |
|----|-------------|-------|
| **DELINK** | links to genuinely-removed targets → plain text (examples/logic_agents/*, examples/scripts_demonstration/*, examples/notebooks/*, removed refactoring dirs, check_jpype_env.py, maintenance/tests_jvm.txt) | ~40 |
| **REPLACE** | stale path → canonical tracked location (libs/web_api/routes→services/web_api, composants/→technical/, setup_project_env.sh→scripts/setup/, project_core/bootstrap.py→argumentation_analysis/core/bootstrap.py, first_order_logic_agent.py→fol_logic_agent.py, etc.) | ~95 |
| **PREFIX** | depth correction (tutorials/01,02 are **4-deep** → `../../../../`; TROUBLESHOOTING projets links are **1-deep** → `../projets/`) | ~14 |
| **analyse_impact** | 83 bare repo-relative paths (`docs/guides/*`, `docs/projets/*`) that **double-prefixed** from within docs/guides/ → relative (`./`, `../`) | 83 |

## Result

```
guides/ linkcheck:  269 broken  →  0 real broken
```

The **22 remaining linkcheck hits are all false-positives**, deliberately left untouched (link syntax, not broken references):
- `exemples_logique_modale.md` (17): FOL/modal/predicate notation `[p](p)`, `[P(a)](P(a))`, `[realite(dieu](realite(dieu))`, `[somme_angles_triangle_180](...)` — typographic logic formulas, not links.
- `standards_documentation.md` (2): placeholder examples `lien/vers/document1.md`.
- `CHANGELOG.md` (1): glob placeholder `.*`.
- `UNIFIED_SYSTEM_GUIDE.md` (1): Python code ref `**kwargs`.
- `utilisation_agents_logiques.md` (1): implication formula `p => q`.

## Verification

- `git diff --stat docs/guides/` → 31 files, 232 insertions / 232 deletions (balanced).
- Spot-checked corrected lines: tutorials 4-deep resolves to repo root ✓, TROUBLESHOOTING `../projets/` resolves to `docs/projets/` ✓, analyse_impact `../projets/` + `./` resolve correctly ✓, no markdown mangling.

## Cleanup Gate

N/A — markdown link **syntax only**, no files removed.

Refs #1315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)