### PR TITLE
docs(att-5): Phase 2 linkcheck reroute in technical/ #1315

### DIFF
--- a/docs/technical/02_web_app.md
+++ b/docs/technical/02_web_app.md
@@ -8,7 +8,7 @@ L'application web constitue un point d'entrée majeur pour interagir avec les fo
 
 Après la phase de stabilisation, le lancement de l'application web et de ses dépendances a été consolidé en un **point d'entrée unique et fiable**.
 
--   **Orchestrateur Principal :** [`project_core/webapp_from_scripts/unified_web_orchestrator.py`](project_core/webapp_from_scripts/unified_web_orchestrator.py)
+-   **Orchestrateur Principal :** [`project_core/webapp_from_scripts/unified_web_orchestrator.py`](../../scripts/apps/webapp/unified_web_orchestrator.py)
 
 Toute interaction avec l'application (lancement, tests, etc.) **doit** passer par ce script. Il garantit que l'environnement est correctement configuré et que tous les composants (backend, frontend, tests) sont démarrés de manière cohérente.
 
@@ -42,9 +42,9 @@ Le composant central de l'architecture reste le `UnifiedWebOrchestrator`.
 
 ## 4. Architecture du Backend (Application Flask)
 
-Le backend est une application web standard basée sur Flask, dont le code source principal se trouve dans [`interface_web/app.py`](interface_web/app.py).
+Le backend est une application web standard basée sur Flask, dont le code source principal se trouve dans [`interface_web/app.py`](../../interface_web/app.py).
 
--   **Point d'Entrée d'Analyse :** La route `POST /analyze` ([`interface_web/app.py:174`](interface_web/app.py:174)) est le point d'entrée principal pour soumettre un texte et recevoir une analyse complète.
+-   **Point d'Entrée d'Analyse :** La route `POST /analyze` ([`interface_web/app.py:174`](../../interface_web/app.py:174)) est le point d'entrée principal pour soumettre un texte et recevoir une analyse complète.
 
 -   **Routes Principales :**
     -   `GET /`: Affiche la page d'accueil de l'application.
@@ -54,25 +54,25 @@ Le backend est une application web standard basée sur Flask, dont le code sourc
 
 -   **Intégration du Module JTMS :**
     -   L'application intègre des fonctionnalités spécifiques au **JTMS (Justification and Truth Maintenance System)** via un blueprint Flask.
-    -   Le blueprint, défini dans [`interface_web/routes/jtms_routes.py`](interface_web/routes/jtms_routes.py), est enregistré sous le préfixe d'URL `/jtms`.
+    -   Le blueprint, défini dans [`interface_web/routes/jtms_routes.py`](../../interface_web/routes/jtms_routes.py), est enregistré sous le préfixe d'URL `/jtms`.
 
 ## 5. Architecture du Frontend
 
 L'interface utilisateur est principalement rendue côté serveur, en utilisant le moteur de templates Jinja2 de Flask.
 
--   **Fichiers de Templates :** Situés dans le répertoire [`interface_web/templates/`](interface_web/templates/).
-    -   [`index.html`](interface_web/templates/index.html) est la page principale.
-    -   Des templates spécifiques comme [`jtms/dashboard.html`](interface_web/templates/jtms/dashboard.html) sont dédiés à l'interface JTMS.
+-   **Fichiers de Templates :** Situés dans le répertoire [`interface_web/templates/`](../../interface_web/templates/).
+    -   [`index.html`](../../interface_web/templates/index.html) est la page principale.
+    -   Des templates spécifiques comme [`jtms/dashboard.html`](../../interface_web/templates/jtms/dashboard.html) sont dédiés à l'interface JTMS.
 
--   **Fichiers Statiques :** Les ressources CSS et JavaScript sont servies depuis [`interface_web/static/`](interface_web/static/).
-    -   On note la présence de [`jtms_dashboard.js`](interface_web/static/js/jtms_dashboard.js), indiquant une logique d'interactivité côté client pour le tableau de bord JTMS, probablement pour gérer des communications en temps réel (WebSocket) ou des mises à jour dynamiques.
+-   **Fichiers Statiques :** Les ressources CSS et JavaScript sont servies depuis [`interface_web/static/`](../../interface_web/static/).
+    -   On note la présence de [`jtms_dashboard.js`](../../interface_web/static/js/jtms_dashboard.js), indiquant une logique d'interactivité côté client pour le tableau de bord JTMS, probablement pour gérer des communications en temps réel (WebSocket) ou des mises à jour dynamiques.
 
 ## 6. Points d'Intégration avec le Cœur du Projet
 
 Le lien crucial entre l'interface web (la façade) et les algorithmes d'analyse (le cerveau) est le **`ServiceManager`**.
 
 -   **Le Pont `ServiceManager` :**
-    -   Dans [`interface_web/app.py`](interface_web/app.py:108), une instance de `ServiceManager` est créée au démarrage de l'application.
+    -   Dans [`interface_web/app.py`](../../interface_web/app.py:108), une instance de `ServiceManager` est créée au démarrage de l'application.
     -   La route `/analyze` utilise cette instance pour appeler la méthode `analyze_text()`.
     -   C'est cet appel qui déclenche les pipelines d'analyse complexes (stratégique, tactique, opérationnel), en passant le texte fourni par l'utilisateur.
 

--- a/docs/technical/03_demo_epita.md
+++ b/docs/technical/03_demo_epita.md
@@ -35,7 +35,7 @@ L'architecture de la démo s'articule autour des composants clés suivants :
 Le bon fonctionnement de la démonstration dépend des éléments de configuration et des répertoires suivants :
 
 -   **Configuration Unifiée** :
-    -   [`config/unified_config.py`](config/unified_config.py:1) : Ce fichier est essentiel pour configurer le comportement du système, notamment pour s'assurer que de **vrais LLM** sont utilisés (`MockLevel.NONE`) et non des simulations.
+    -   [`config/unified_config.py`](../../config/unified_config.py:1) : Ce fichier est essentiel pour configurer le comportement du système, notamment pour s'assurer que de **vrais LLM** sont utilisés (`MockLevel.NONE`) et non des simulations.
 
 -   **Répertoires de Sortie** :
     -   `logs/` : Ce répertoire est utilisé pour stocker les logs détaillés de l'exécution de la session, y compris les traces complètes des interactions avec le LLM.

--- a/docs/technical/05_unit_tests.md
+++ b/docs/technical/05_unit_tests.md
@@ -35,10 +35,10 @@ Après une analyse approfondie, plusieurs actions de nettoyage ont été menées
 
 Les changements suivants ont été effectués :
 *   **Suppression du fichier de test d'adaptateur redondant :**
-    *   Le fichier [`tests/unit/orchestration/hierarchical/operational/adapters/test_extract_agent_adapter.py`](tests/unit/orchestration/hierarchical/operational/adapters/test_extract_agent_adapter.py) a été supprimé car il n'apportait pas de valeur ajoutée et ses tests étaient couverts par d'autres suites.
+    *   Le fichier [`tests/unit/orchestration/hierarchical/operational/adapters/test_extract_agent_adapter.py`](../../tests/orchestration/hierarchical/operational/adapters/test_extract_agent_adapter.py) a été supprimé car il n'apportait pas de valeur ajoutée et ses tests étaient couverts par d'autres suites.
 *   **Suppression d'un test E2E invalide :**
-    *   Le fichier [`tests/e2e/python/test_service_manager.py`](tests/e2e/python/test_service_manager.py) a été retiré, car il contenait des tests E2E qui n'étaient pas à leur place dans la structure de tests unitaires et étaient devenus inutiles.
+    *   Le fichier [`tests/e2e/python/test_service_manager.py`](../../tests/unit/argumentation_analysis/orchestration/test_service_manager.py) a été retiré, car il contenait des tests E2E qui n'étaient pas à leur place dans la structure de tests unitaires et étaient devenus inutiles.
 *   **Suppression d'une fonction de test non pertinente :**
-    *   La fonction `test_save_definitions_unencrypted` dans le fichier [`tests/ui/test_extract_definition_persistence.py`](tests/ui/test_extract_definition_persistence.py) a été supprimée. Cette fonction testait un comportement qui n'est plus d'actualité, à savoir la sauvegarde de définitions non chiffrées.
+    *   La fonction `test_save_definitions_unencrypted` dans le fichier [`tests/ui/test_extract_definition_persistence.py`](../../tests/ui/test_extract_definition_persistence.py) a été supprimée. Cette fonction testait un comportement qui n'est plus d'actualité, à savoir la sauvegarde de définitions non chiffrées.
 
 Suite à ces opérations de nettoyage, la suite de tests unitaires est désormais stable et s'exécute avec succès. Ce cycle de refactoring est maintenant terminé pour ce point d'entrée, marquant une étape importante dans la fiabilisation de notre base de code.

--- a/docs/technical/agent_management.md
+++ b/docs/technical/agent_management.md
@@ -24,7 +24,7 @@ Ce document décrit les mécanismes de gestion des agents au sein du système d'
 
 *   **Sources de configuration :**
     *   Paramètres des constructeurs (voir exemples dans [`agents_specialistes.md`](./agents_specialistes.md)).
-    *   Fichiers de configuration externes (ex: [`config/fallacies_taxonomy.json`](../../config/fallacies_taxonomy.json:1) pour `ContextualFallacyAnalyzer`).
+    *   Fichiers de configuration externes (ex: `config/fallacies_taxonomy.json` pour `ContextualFallacyAnalyzer`).
     *   (À compléter : y a-t-il un système de configuration centralisé pour les prompts, les modèles LLM par défaut/spécifiques ?).
 *   **Configuration des prompts et instructions système :**
     *   Localisation des prompts (généralement dans les répertoires des agents, ex: `argumentation_analysis/agents/core/informal/prompts/`).
@@ -32,7 +32,7 @@ Ce document décrit les mécanismes de gestion des agents au sein du système d'
 ## 5. Enregistrement et Intégration dans l'Orchestration
 
 *   **Orchestration Simple (`AgentGroupChat`) :**
-    *   Ajout des instances d'agents au `AgentGroupChat` (voir [`../../argumentation_analysis/orchestration/analysis_runner.py`](../../argumentation_analysis/orchestration/analysis_runner.py:1)).
+    *   Ajout des instances d'agents au `AgentGroupChat` (voir `../../argumentation_analysis/orchestration/analysis_runner.py`).
 *   **Architecture Hiérarchique :**
     *   Rôle de l'`OperationalManager` ([`../../argumentation_analysis/orchestration/hierarchical/operational/manager.py`](../../argumentation_analysis/orchestration/hierarchical/operational/manager.py:1)) pour la prise en charge des agents opérationnels.
     *   Utilisation des adaptateurs ([`../../argumentation_analysis/orchestration/hierarchical/operational/adapters/`](../../argumentation_analysis/orchestration/hierarchical/operational/adapters/:1)) pour intégrer les agents existants.

--- a/docs/technical/agents_specialistes.md
+++ b/docs/technical/agents_specialistes.md
@@ -144,7 +144,7 @@ else:
 
 ### 4. `RhetoricalResultAnalyzer`
 
-**Source :** [`../../argumentation_analysis/agents/tools/analysis/rhetorical_result_analyzer.py`](../../argumentation_analysis/agents/tools/analysis/rhetorical_result_analyzer.py)
+**Source :** [`../../argumentation_analysis/agents/tools/analysis/rhetorical_result_analyzer.py`](../../argumentation_analysis/plugins/analysis_tools/logic/rhetorical_result_analyzer.py)
 
 Analyse les résultats d'une analyse rhétorique pour en extraire des insights, des patterns ou des scores.
 
@@ -228,8 +228,8 @@ for viz_name, viz_path in saved_visualizations.items():
 ## Tests Associés
 
 Les tests pour ces outils, en particulier leurs versions "enhanced", peuvent être trouvés sous :
-- [`tests/agents/tools/analysis/enhanced/test_enhanced_contextual_fallacy_analyzer.py`](../../tests/agents/tools/analysis/enhanced/test_enhanced_contextual_fallacy_analyzer.py)
-- [`tests/agents/tools/analysis/enhanced/test_enhanced_fallacy_severity_evaluator.py`](../../tests/agents/tools/analysis/enhanced/test_enhanced_fallacy_severity_evaluator.py)
-- [`tests/agents/tools/analysis/enhanced/test_enhanced_complex_fallacy_analyzer.py`](../../tests/agents/tools/analysis/enhanced/test_enhanced_complex_fallacy_analyzer.py)
+- [`tests/agents/tools/analysis/enhanced/test_enhanced_contextual_fallacy_analyzer.py`](../../argumentation_analysis/plugins/analysis_tools/tests/test_enhanced_contextual_fallacy_analyzer.py)
+- [`tests/agents/tools/analysis/enhanced/test_enhanced_fallacy_severity_evaluator.py`](../../argumentation_analysis/plugins/analysis_tools/tests/test_enhanced_fallacy_severity_evaluator.py)
+- [`tests/agents/tools/analysis/enhanced/test_enhanced_complex_fallacy_analyzer.py`](../../argumentation_analysis/plugins/analysis_tools/tests/test_enhanced_complex_fallacy_analyzer.py)
 
 Il est recommandé de vérifier la couverture des tests pour les versions de base de `RhetoricalResultAnalyzer` et `RhetoricalResultVisualizer` et de les compléter si nécessaire.

--- a/docs/technical/e2e_test_orchestration.md
+++ b/docs/technical/e2e_test_orchestration.md
@@ -2,7 +2,7 @@
 
 **Date:** 2025-09-04
 **Auteur:** Roo
-**Contexte:** Ce document a été rédigé dans le cadre de la refonte visant à stabiliser l'exécution des tests E2E lancés via `run_tests.ps1`, conformément aux recommandations du document [`docs/testing_entrypoints_audit.md`](docs/reports/testing_entrypoints_audit.md).
+**Contexte:** Ce document a été rédigé dans le cadre de la refonte visant à stabiliser l'exécution des tests E2E lancés via `run_tests.ps1`, conformément aux recommandations du document `docs/testing_entrypoints_audit.md`.
 
 ## 1. Contexte : Résoudre l'Instabilité des Tests E2E
 
@@ -16,8 +16,8 @@ Pour pallier ce problème, un nouvel orchestrateur, plus léger et spécialisé,
 
 Le nouvel orchestrateur suit une philosophie simple : être un "chef d'orchestre" **asynchrone, non bloquant et résilient**. Il s'appuie entièrement sur la bibliothèque `asyncio` de Python pour gérer les processus et les entrées/sorties, ce qui constitue sa différence fondamentale avec l'approche `subprocess` synchrone de l'ancien runner.
 
--   **Fichier Clé** : [`scripts/orchestration/run_e2e_tests.py`](scripts/orchestration/run_e2e_tests.py)
--   **Point d'Entrée** : Le script est exclusivement invoqué par [`run_tests.ps1`](run_tests.ps1) lorsque l'option `-Type "e2e"` est utilisée.
+-   **Fichier Clé** : [`scripts/orchestration/run_e2e_tests.py`](../../scripts/orchestration/run_e2e_tests.py)
+-   **Point d'Entrée** : Le script est exclusivement invoqué par [`run_tests.ps1`](../../run_tests.ps1) lorsque l'option `-Type "e2e"` est utilisée.
 
 ### 2.2. Flux d'Exécution
 

--- a/docs/technical/ep2_web_applications.md
+++ b/docs/technical/ep2_web_applications.md
@@ -12,11 +12,11 @@ L'exploration du code a révélé un écosystème hétérogène composé de plus
 
 | Application / Service | Chemin d'accès | Framework / Technologie | Statut de Lancement |
 | :--- | :--- | :--- | :--- |
-| **Interface Web Principale** | [`interface_web/`](./interface_web) | **Starlette / React** | ✅ **Lancée avec succès** |
-| **Application Web Legacy (Simple)** | [`services/web_api/interface-simple/`](./services/web_api/interface-simple) | **Flask** | ✅ **Lancée avec succès** |
-| API REST Principale | [`api/`](./api) | **FastAPI** | ✅ **Lancée avec succès** |
-| Application Mobile | [`3.1.5_Interface_Mobile/`](./3.1.5_Interface_Mobile) | **Expo (React Native)** | ✅ **Lancée avec succès** |
-| Orchestrateur Unifié | [`scripts/apps/webapp/`](./scripts/apps/webapp) | Python (Script) | N/A |
+| **Interface Web Principale** | [`interface_web/`](../../interface_web) | **Starlette / React** | ✅ **Lancée avec succès** |
+| **Application Web Legacy (Simple)** | `services/web_api/interface-simple/` | **Flask** | ✅ **Lancée avec succès** |
+| API REST Principale | [`api/`](../../api) | **FastAPI** | ✅ **Lancée avec succès** |
+| Application Mobile | [`3.1.5_Interface_Mobile/`](../../3.1.5_Interface_Mobile) | **Expo (React Native)** | ✅ **Lancée avec succès** |
+| Orchestrateur Unifié | [`scripts/apps/webapp/`](../../scripts/apps/webapp) | Python (Script) | N/A |
 
 ---
 
@@ -26,9 +26,9 @@ C'est l'application la plus moderne et la plus intégrée du projet. Elle est g�
 
 ### 3.1. Architecture
 
--   **Backend**: Une application [Starlette](https://www.starlette.io/) située dans [`interface_web/app.py`](./interface_web/app.py) qui sert une API et les fichiers statiques du frontend.
+-   **Backend**: Une application [Starlette](https://www.starlette.io/) située dans [`interface_web/app.py`](../../interface_web/app.py) qui sert une API et les fichiers statiques du frontend.
 -   **Frontend**: Une application [React](https://reactjs.org/) (initialisée avec `create-react-app`) dont le code source se trouve dans `services/web_api/interface-web-argumentative/`. Les fichiers buildés sont servis par le backend Starlette.
--   **Orchestration**: Le script [`unified_web_orchestrator.py`](./scripts/apps/webapp/unified_web_orchestrator.py) gère le cycle de vie complet : activation de l'environnement, installation des dépendances, nettoyage des ports, lancement des serveurs backend et frontend, et surveillance de leur état.
+-   **Orchestration**: Le script [`unified_web_orchestrator.py`](../../scripts/apps/webapp/unified_web_orchestrator.py) gère le cycle de vie complet : activation de l'environnement, installation des dépendances, nettoyage des ports, lancement des serveurs backend et frontend, et surveillance de leur état.
 
 ### 3.2. Procédure de Lancement
 
@@ -49,13 +49,13 @@ Lors du premier lancement, deux problèmes ont été identifiés et corrigés :
 
 1.  **Erreur `TypeError` sur `ServiceManager`**:
     -   **Symptôme**: Le script échouait avec une erreur `TypeError: OrchestrationServiceManager.__init__() got an unexpected keyword argument 'config'`.
-    -   **Cause**: L'instanciation de `ServiceManager` dans [`interface_web/app.py`](./interface_web/app.py:165) utilisait un ancien format avec un paramètre `config`.
+    -   **Cause**: L'instanciation de `ServiceManager` dans [`interface_web/app.py`](../../interface_web/app.py:165) utilisait un ancien format avec un paramètre `config`.
     -   **Solution**: La ligne a été modifiée pour appeler `ServiceManager()` sans argument, conformément à sa nouvelle définition.
 
 2.  **Erreur `404 Not Found` sur le Health Check**:
     -   **Symptôme**: L'orchestrateur démarrait le backend puis l'arrêtait immédiatement car le health check sur `/api/health` échouait.
     -   **Cause**: L'application exposait un endpoint `/api/status` mais l'orchestrateur était configuré pour interroger `/api/health`.
-    -   **Solution**: Un alias a été ajouté dans [`interface_web/app.py`](./interface_web/app.py:186) pour que la route `/api/health` pointe vers le même endpoint que `/api/status`.
+    -   **Solution**: Un alias a été ajouté dans [`interface_web/app.py`](../../interface_web/app.py:186) pour que la route `/api/health` pointe vers le même endpoint que `/api/status`.
 
 Avec ces deux corrections, l'application est désormais stable et peut être lancée de manière fiable.
 
@@ -67,7 +67,7 @@ Une application Flask autonome a été découverte dans `services/web_api/interf
 
 ### 4.1. Architecture
 
-- **Backend**: Une application [Flask](https://flask.palletsprojects.com/) simple définie dans [`app.py`](./services/web_api/interface-simple/app.py).
+- **Backend**: Une application [Flask](https://flask.palletsprojects.com/) simple définie dans `app.py`.
 - **Dépendances**: L'application s'appuie sur le `ServiceManager` global du projet, ce qui indique une intégration avec l'écosystème d'analyse d'argumentation.
 
 ### 4.2. Procédure de Lancement
@@ -89,7 +89,7 @@ Un bug critique, identique à celui trouvé dans l'application Starlette, a ét�
 
 1.  **Erreur `TypeError` sur `ServiceManager`**:
     -   **Symptôme**: L'application ne démarrait pas, levant une `TypeError: OrchestrationServiceManager.__init__() got an unexpected keyword argument 'config'`.
-    -   **Cause**: L'instanciation de `ServiceManager` dans [`services/web_api/interface-simple/app.py`](./services/web_api/interface-simple/app.py) était obsolète.
+    -   **Cause**: L'instanciation de `ServiceManager` dans `services/web_api/interface-simple/app.py` était obsolète.
     -   **Solution**: L'appel a été corrigé pour utiliser `ServiceManager()`, sans argument, ce qui a résolu l'erreur et permis au serveur de démarrer.
 
 ---
@@ -100,7 +100,7 @@ Une API REST basée sur FastAPI a été identifiée dans le répertoire `api/`. 
 
 ### 5.1. Architecture
 
-- **Backend**: Une application [FastAPI](https://fastapi.tiangolo.com/) définie dans [`main_simple.py`](./api/main_simple.py). Le serveur est lancé via [Uvicorn](https://www.uvicorn.org/).
+- **Backend**: Une application [FastAPI](https://fastapi.tiangolo.com/) définie dans `main_simple.py`. Le serveur est lancé via [Uvicorn](https://www.uvicorn.org/).
 - **Intégration**: L'application est conçue pour être exécutée comme un module Python (`python -m api.main_simple`), ce qui assure que les imports relatifs au projet fonctionnent correctement.
 
 ### 5.2. Procédure de Lancement
@@ -129,9 +129,9 @@ Le projet inclut une application mobile développée avec Expo et React Native. 
 
 ### 6.1. Architecture
 
-- **Framework**: [Expo (React Native)](https://expo.dev/) utilisant TypeScript. Le code source est situé dans [`3.1.5_Interface_Mobile/`](./3.1.5_Interface_Mobile).
+- **Framework**: [Expo (React Native)](https://expo.dev/) utilisant TypeScript. Le code source est situé dans [`3.1.5_Interface_Mobile/`](../../3.1.5_Interface_Mobile).
 - **Environnement**: L'application est autonome et repose sur l'écosystème Node.js/NPM. Elle n'a pas de dépendance directe avec l'environnement Conda du projet.
-- **Gestion des dépendances**: Un fichier [`package.json`](./3.1.5_Interface_Mobile/package.json) définit les dépendances et les scripts de lancement.
+- **Gestion des dépendances**: Un fichier [`package.json`](../../3.1.5_Interface_Mobile/package.json) définit les dépendances et les scripts de lancement.
 
 ### 6.2. Procédure de Lancement (Mode Web)
 

--- a/docs/technical/reasoning_engine.md
+++ b/docs/technical/reasoning_engine.md
@@ -60,7 +60,7 @@ Les capacités de raisonnement sont principalement implémentées et orchestrée
 Certains outils d'analyse, bien que principalement axés sur d'autres aspects (comme les sophismes ou la rhétorique), peuvent intégrer des formes de raisonnement :
 
 *   **`ComplexFallacyAnalyzer`** ([`../../argumentation_analysis/agents/tools/analysis/complex_fallacy_analyzer.py`](../../argumentation_analysis/agents/tools/analysis/complex_fallacy_analyzer.py)) : Peut effectuer des inférences pour décomposer des arguments complexes ou identifier des contradictions implicites qui sous-tendent certains sophismes.
-*   **`RhetoricalResultAnalyzer`** ([`../../argumentation_analysis/agents/tools/analysis/rhetorical_result_analyzer.py`](../../argumentation_analysis/agents/tools/analysis/rhetorical_result_analyzer.py)) : Pourrait analyser la cohérence logique des stratégies rhétoriques employées ou inférer les intentions de l'orateur basées sur des patterns logiques.
+*   **`RhetoricalResultAnalyzer`** ([`../../argumentation_analysis/agents/tools/analysis/rhetorical_result_analyzer.py`](../../argumentation_analysis/plugins/analysis_tools/logic/rhetorical_result_analyzer.py)) : Pourrait analyser la cohérence logique des stratégies rhétoriques employées ou inférer les intentions de l'orateur basées sur des patterns logiques.
 
 La documentation spécifique de ces outils devrait détailler leurs capacités de raisonnement respectives.
 

--- a/docs/technical/structure_projet.md
+++ b/docs/technical/structure_projet.md
@@ -199,20 +199,20 @@ Avant que les textes ne soient soumis aux agents d'analyse principaux (comme `In
 
 ### 1. Normalisation de Base
 
-Des utilitaires de normalisation de texte sont disponibles dans [`argumentation_analysis/utils/core_utils/text_utils.py`](../../argumentation_analysis/utils/core_utils/text_utils.py:1). Ces fonctions permettent :
+Des utilitaires de normalisation de texte sont disponibles dans [`argumentation_analysis/utils/core_utils/text_utils.py`](../../argumentation_analysis/core/utils/text_utils.py:1). Ces fonctions permettent :
 
 *   **Conversion en Minuscules :** Uniformisation de la casse du texte.
 *   **Suppression des Accents :** Remplacement des caractères accentués par leurs équivalents non accentués (par exemple, "é" devient "e").
 *   **Suppression de la Ponctuation :** Retrait des signes de ponctuation standard. Une attention particulière est portée aux apostrophes pour tenter de conserver leur rôle linguistique lorsque c'est pertinent.
 *   **Normalisation des Espaces :** Remplacement des séquences d'espaces multiples (espaces, tabulations, sauts de ligne) par un seul espace, et suppression des espaces en début et fin de chaîne.
 
-La fonction principale pour ces opérations est `normalize_text(text: str)` ([`../../argumentation_analysis/utils/core_utils/text_utils.py:17`](../../argumentation_analysis/utils/core_utils/text_utils.py:17)).
+La fonction principale pour ces opérations est `normalize_text(text: str)` ([`../../argumentation_analysis/utils/core_utils/text_utils.py:17`](../../argumentation_analysis/core/utils/text_utils.py:17)).
 
 ### 2. Tokenisation
 
 Après la normalisation, le texte peut être segmenté en unités lexicales plus petites, appelées tokens (généralement des mots).
 
-*   La fonction `tokenize_text(text: str)` ([`../../argumentation_analysis/utils/core_utils/text_utils.py:85`](../../argumentation_analysis/utils/core_utils/text_utils.py:85)) effectue d'abord une normalisation du texte puis le divise en tokens en se basant sur les espaces.
+*   La fonction `tokenize_text(text: str)` ([`../../argumentation_analysis/utils/core_utils/text_utils.py:85`](../../argumentation_analysis/core/utils/text_utils.py:85)) effectue d'abord une normalisation du texte puis le divise en tokens en se basant sur les espaces.
 
 Ces tokens peuvent ensuite être utilisés pour des analyses statistiques, la création d'embeddings, ou d'autres traitements NLP.
 

--- a/docs/technical/synthese_collaboration.md
+++ b/docs/technical/synthese_collaboration.md
@@ -10,7 +10,7 @@ Le système utilise deux approches principales pour l'orchestration et la collab
 
 ### 1.1 Orchestration Simple via `AgentGroupChat`
 
-Ce mécanisme, principalement implémenté dans [`argumentation_analysis/orchestration/analysis_runner.py`](../../argumentation_analysis/orchestration/analysis_runner.py), s'appuie sur la fonctionnalité `AgentGroupChat` de la bibliothèque Semantic Kernel.
+Ce mécanisme, principalement implémenté dans `argumentation_analysis/orchestration/analysis_runner.py`, s'appuie sur la fonctionnalité `AgentGroupChat` de la bibliothèque Semantic Kernel.
 
 *   **Principes Clés** :
     *   **État Partagé Centralisé** : Une instance de `RhetoricalAnalysisState` (définie dans [`argumentation_analysis/core/shared_state.py`](../../argumentation_analysis/core/shared_state.py)) stocke toutes les informations pertinentes à l'analyse (texte initial, tâches, arguments identifiés, sophismes, `next_agent_to_act`, conclusion finale, etc.).
@@ -50,7 +50,7 @@ Une approche d'orchestration plus structurée et évoluée est implémentée dan
         *   **Adaptateurs d'Agents** ([`.../operational/adapters/`](../../argumentation_analysis/orchestration/hierarchical/operational/adapters/)) : Permettent d'intégrer les agents existants (PM, Informal, PL, Extract) dans ce niveau.
 
 *   **Communication Inter-Niveaux** :
-    *   L'architecture hiérarchique utilise un `MessageMiddleware` (probablement défini dans [`argumentation_analysis/core/communication.py`](../../argumentation_analysis/core/communication.py)) pour faciliter une communication structurée entre les niveaux.
+    *   L'architecture hiérarchique utilise un `MessageMiddleware` (probablement défini dans [`argumentation_analysis/core/communication.py`](../../argumentation_analysis/core/communication/middleware.py)) pour faciliter une communication structurée entre les niveaux.
     *   Des adaptateurs spécifiques (`StrategicAdapter`, `TacticalAdapter`, `OperationalAdapter`) gèrent l'envoi et la réception de messages (directives, rapports, requêtes de statut, résultats) entre les managers/coordinateurs de chaque niveau.
     *   Des interfaces dédiées comme `StrategicTacticalInterface` et `TacticalOperationalInterface` (définies dans [`.../interfaces/`](../../argumentation_analysis/orchestration/hierarchical/interfaces/)) formalisent les interactions.
 
@@ -115,4 +115,4 @@ Les agents spécialistes ([`ProjectManagerAgent`](../../argumentation_analysis/a
 
 ## 4. Conclusion
 
-Le système de collaboration des agents a évolué significativement avec l'introduction potentielle d'une architecture hiérarchique robuste en parallèle ou en remplacement d'une orchestration plus simple basée sur `AgentGroupChat`. La documentation actuelle, en particulier [`docs/composants/synthese_collaboration.md`](docs/composants/synthese_collaboration.md), nécessite une mise à jour majeure pour refléter fidèlement ces développements, en particulier l'architecture hiérarchique, ses composants, ses états distribués, et ses mécanismes de communication avancés. Cette actualisation permettra une meilleure compréhension du système et guidera plus efficacement les évolutions futures.
+Le système de collaboration des agents a évolué significativement avec l'introduction potentielle d'une architecture hiérarchique robuste en parallèle ou en remplacement d'une orchestration plus simple basée sur `AgentGroupChat`. La documentation actuelle, en particulier [`docs/composants/synthese_collaboration.md`](./synthese_collaboration.md), nécessite une mise à jour majeure pour refléter fidèlement ces développements, en particulier l'architecture hiérarchique, ses composants, ses états distribués, et ses mécanismes de communication avancés. Cette actualisation permettra une meilleure compréhension du système et guidera plus efficacement les évolutions futures.


### PR DESCRIPTION
## Summary

ATT-5 Phase 2 (issue #1315): fix broken internal markdown links across **`docs/technical/`** — 10 files, 44 balanced link edits, **0 files deleted**.

Third Phase 2 PR. Disjoint file set from #1413 (architecture/) and #1414 (guides/) → independent merge order, no conflict risk.

## Method

- All reroute targets **verified via `git ls-files`** (verify-before-assert — R563/R568 lesson: trust git tracking, not working tree).
- **Single-link-scoped regex** (`[^\]]+` text class + `]\(target(?=[:#)])` lookahead) — the lookahead makes each REP target-specific, preventing prefix collisions (e.g. `./api` dir-link never matches `./api/main_simple.py`).
- Linkcheck run **in-place** on the real docs tree.

## Operations

| Op | Description | Count |
|----|-------------|-------|
| **PREFIX** | depth correction — `docs/technical/` is **2-deep**, so bare repo-relative paths (`interface_web/*`, `api/`, `3.1.5_Interface_Mobile/`, `scripts/apps/webapp/*`, `tests/ui/*`, `scripts/orchestration/*`, `run_tests.ps1`, `config/unified_config.py`) and `./`-prefixed paths (ep2_web_applications) → `../../` (were resolving wrongly to `docs/technical/<x>`) | ~25 |
| **REPLACE** | module moves to canonical tracked location: `rhetorical_result_analyzer.py` (agents/tools/analysis → plugins/analysis_tools/logic/); enhanced test trio (tests/agents/tools/analysis/enhanced/ → argumentation_analysis/plugins/analysis_tools/tests/); `test_extract_agent_adapter` (tests/unit/orchestration → tests/orchestration); `test_service_manager` (tests/e2e/python → tests/unit/argumentation_analysis/orchestration); `text_utils.py` (utils/core_utils → core/utils); `communication.py` → `communication/middleware.py` (MessageMiddleware, precise file); `project_core/webapp_from_scripts` → `scripts/apps/webapp`; `docs/composants` self-ref → `./` (file moved to technical/) | ~12 |
| **DELINK** | genuinely-removed targets → plain text: `services/web_api/interface-simple/` (archived per CLAUDE.md), `api/main_simple.py`, `analysis_runner.py` (removed in arch cleanup), `config/fallacies_taxonomy.json` (replaced by csv/yaml elsewhere), `docs/reports/testing_entrypoints_audit.md` (moved to **frozen archives** — not linked in per #1315 frozen-archives rule) | ~7 |

## Result

```
technical/ linkcheck:  44 broken  →  0 broken
```

## Verification

- `git diff --stat docs/technical/` → 10 files, 44 insertions / 44 deletions (balanced).
- Spot-checked: ep2 `../../interface_web`/`../../api`/`../../3.1.5_Interface_Mobile` resolve to repo root ✓; interface-simple DELINKED to plain text ✓; enhanced tests rerouted to plugins/analysis_tools/tests/ ✓; communication.py → middleware.py ✓; no markdown mangling.

## Cleanup Gate

N/A — markdown link **syntax only**, no files removed.

Refs #1315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)