### PR TITLE
docs(att-5): Phase 2 linkcheck reroute in reference/ #1315

### DIFF
--- a/docs/reference/PLUGIN_GENEALOGY.md
+++ b/docs/reference/PLUGIN_GENEALOGY.md
@@ -31,7 +31,7 @@ L'agent a connu plusieurs itérations majeures, chacune introduisant une nouvell
 
 ## 3. Analyse des Anciens Workflows pour Coexistence
 
-### Comparaison du Workflow Parallèle : `4d7132cc` vs. [`DESIGN_PARALLEL_WORKFLOW.md`](maintenance/DESIGN_PARALLEL_WORKFLOW.md:1)
+### Comparaison du Workflow Parallèle : `4d7132cc` vs. [`DESIGN_PARALLEL_WORKFLOW.md`](../design/DESIGN_PARALLEL_WORKFLOW.md:1)
 
 La différence entre l'ancienne et la nouvelle approche parallèle est fondamentale et illustre une maturité croissante de la conception.
 

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -4,7 +4,7 @@ Cette section contient la documentation de référence pour les API du système 
 
 ## Documents Disponibles
 
-### [Référence API du Système de Communication](./reference_api.md)
+### Référence API du Système de Communication
 Documentation complète de l'API du système de communication entre agents.
 
 ### [API des Agents](./agents/README.md)
@@ -78,7 +78,7 @@ L'API du système suit les principes du versionnement sémantique (SemVer) :
 - **Changements mineurs** : Ajouts de fonctionnalités compatibles avec les versions précédentes
 - **Correctifs** : Corrections de bugs sans modification de l'API
 
-Pour plus d'informations sur les changements d'API, consultez le [CHANGELOG](../../CHANGELOG.md).
+Pour plus d'informations sur les changements d'API, consultez le CHANGELOG.
 
 ## Structure de la Documentation
 

--- a/docs/reference/agents/README.md
+++ b/docs/reference/agents/README.md
@@ -99,4 +99,4 @@ Les agents interagissent principalement via l'Agent PM, qui joue le rôle de coo
 ## Voir aussi
 
 - [API d'Orchestration](../orchestration/README.md)
-- [API du Système de Communication](../reference_api.md)
+- API du Système de Communication

--- a/docs/reference/orchestration/README.md
+++ b/docs/reference/orchestration/README.md
@@ -263,4 +263,4 @@ asyncio.run(main())
 ## Voir aussi
 
 - [API des Agents](../agents/README.md)
-- [API du Système de Communication](../reference_api.md)
+- API du Système de Communication

--- a/docs/reference/orchestration/hierarchical_architecture_api.md
+++ b/docs/reference/orchestration/hierarchical_architecture_api.md
@@ -620,4 +620,4 @@ print(f"Résultats: {results}")
 - [API du Niveau Tactique](./tactical_level_api.md)
 - [API du Niveau Opérationnel](./operational_level_api.md)
 - [API des Agents](../agents/README.md)
-- [API du Système de Communication](../reference_api.md)
+- API du Système de Communication


### PR DESCRIPTION
## Summary

ATT-5 Phase 2 (issue #1315): fix broken internal markdown links across **`docs/reference/`** — 5 files, 6 balanced link edits, **0 files deleted**.

Fourth Phase 2 PR. Disjoint file set (#1413 arch / #1414 guides / #1415 technical) → independent merge order.

## Method

- All targets verified via `git ls-files` (verify-before-assert — R563/R568 lesson).
- Single-link-scoped regex, linkcheck in-place on real docs tree.

## Operations

| Op | Description | Count |
|----|-------------|-------|
| **DELINK** | `reference_api.md` (5 links from README + 3 subdirs: never created, 0 tracked) → plain text; `../../CHANGELOG.md` (README L81: repo-root CHANGELOG.md gone, only `docs/guides/CHANGELOG.md` remains) → plain text | 6 |
| **REPLACE** | `maintenance/DESIGN_PARALLEL_WORKFLOW.md` → `../design/DESIGN_PARALLEL_WORKFLOW.md` (canonical home = `docs/design/`, restored by PR #582 anti-rogue-cleanup; reference/ is 2-deep so sibling docs/ subdir = `../design/`) | 1 |

## Result

```
reference/ linkcheck:  6 broken  →  0 broken
```

## Verification

- `git diff --stat docs/reference/` → 5 files, 6 insertions / 6 deletions (balanced).
- Spot-checked: DELINK preserves plain text ✓, DESIGN reroute `../design/` resolves to `docs/design/` ✓, no mangling.

## Cleanup Gate

N/A — markdown link **syntax only**, no files removed.

Refs #1315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)