### PR TITLE
docs(att-5): Phase 2 linkcheck reroute in integration/ #1315

### DIFF
--- a/docs/integration/MIGRATION_WEBAPP.md
+++ b/docs/integration/MIGRATION_WEBAPP.md
@@ -370,9 +370,9 @@ frontend:
 ## Ressources et liens utiles
 
 ### Documentation
-- [Configuration Guide](config/README.md)
-- [UnifiedWebOrchestrator API](docs/api/unified_web_orchestrator.md)
-- [Troubleshooting Guide](docs/troubleshooting.md)
+- [Configuration Guide](../../config/README.md)
+- UnifiedWebOrchestrator API
+- [Troubleshooting Guide](../guides/TROUBLESHOOTING.md)
 
 ### Scripts utiles
 - **Validation environnement** : `python -c "import scripts.webapp.unified_web_orchestrator; print('✅ Import OK')"`
@@ -380,8 +380,8 @@ frontend:
 - **Diagnostic complet** : `python start_webapp.py --verbose --no-conda`
 
 ### Support
-- **Issues GitHub** : [Créer un ticket](../../issues)
-- **Documentation équipe** : [Wiki interne](../../wiki)
+- **Issues GitHub** : Créer un ticket
+- **Documentation équipe** : Wiki interne
 - **Contact** : equipe-dev@projet-is.fr
 
 ---

--- a/docs/integration/epita_demo_map.md
+++ b/docs/integration/epita_demo_map.md
@@ -8,19 +8,19 @@ Ce document cartographie l'architecture et les composants de la démonstration E
 
 ### 2.1. Orchestrateur de Validation
 
-- **Script**: [`demos/validation_complete_epita.py`](demos/validation_complete_epita.py:0)
+- **Script**: [`demos/validation_complete_epita.py`](../../examples/03_demos_overflow/validation/validation_complete_epita.py:0)
 - **Rôle**: Ce script est le point d'entrée pour lancer une validation complète et rigoureuse de la démonstration. Il exécute une série de tests, collecte des métriques et génère des rapports de certification.
 
 ### 2.2. Script de Démonstration
 
-- **Script**: [`examples/scripts_demonstration/demonstration_epita.py`](examples/scripts_demonstration/demonstration_epita.py:0)
+- **Script**: [`examples/scripts_demonstration/demonstration_epita.py`](../../examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py:0)
 - **Rôle**: C'est le cœur de la démo. Il met en scène des scénarios d'analyse, invoque les agents d'argumentation et affiche les résultats.
 
 ## 3. Modules et Dépendances
 
 ### 3.1. Analyse de l'Argumentation
 
-- **Répertoire**: [`argumentation_analysis/`](argumentation_analysis/)
+- **Répertoire**: [`argumentation_analysis/`](../../argumentation_analysis/)
 - **Description**: Ce module central fournit toutes les capacités d'analyse. Il est structuré en plusieurs sous-modules clés :
     - `agents/core/logic/`: Contient les agents responsables de l'analyse logique formelle (logique propositionnelle, premier ordre, modale).
     - `agents/core/informal/`: Contient les agents pour la détection de sophismes et l'analyse de la rhétorique.
@@ -29,15 +29,15 @@ Ce document cartographie l'architecture et les composants de la démonstration E
 
 ### 3.2. Modules de la Démonstration
 
-- **Répertoire**: [`examples/scripts_demonstration/modules/`](examples/scripts_demonstration/modules/)
+- **Répertoire**: [`examples/scripts_demonstration/modules/`](../../examples/02_core_system_demos/scripts_demonstration/modules/)
 - **Description**: Ces modules sont spécifiques à la démonstration EPITA et contiennent des scénarios de test, des configurations et des données d'exemple.
 
 ## 4. Flux d'Exécution
 
-1.  L'utilisateur lance [`demos/validation_complete_epita.py`](demos/validation_complete_epita.py:0) avec des paramètres optionnels (mode, complexité).
+1.  L'utilisateur lance [`demos/validation_complete_epita.py`](../../examples/03_demos_overflow/validation/validation_complete_epita.py:0) avec des paramètres optionnels (mode, complexité).
 2.  Le script configure l'environnement et les chemins nécessaires.
-3.  Il exécute le script [`examples/scripts_demonstration/demonstration_epita.py`](examples/scripts_demonstration/demonstration_epita.py:0) avec différents arguments pour tester sa robustesse.
-4.  Il valide l'importation et la syntaxe des modules dans [`examples/scripts_demonstration/modules/`](examples/scripts_demonstration/modules/).
+3.  Il exécute le script [`examples/scripts_demonstration/demonstration_epita.py`](../../examples/02_core_system_demos/scripts_demonstration/demonstration_epita.py:0) avec différents arguments pour tester sa robustesse.
+4.  Il valide l'importation et la syntaxe des modules dans [`examples/scripts_demonstration/modules/`](../../examples/02_core_system_demos/scripts_demonstration/modules/).
 5.  Des tests synthétiques peuvent être générés et soumis aux agents d'analyse pour évaluer leur précision.
 6.  Les résultats, les temps d'exécution et les scores d'authenticité sont collectés.
 7.  Un rapport de validation final est généré, certifiant le niveau de fiabilité de la démonstration.

--- a/docs/integration/logical_reasoning_demos_map.md
+++ b/docs/integration/logical_reasoning_demos_map.md
@@ -1,6 +1,6 @@
 # Cartographie des Démonstrations de Raisonnement Logique
 
-Ce document détaille l'architecture et les interactions des composants impliqués dans les démonstrations de raisonnement logique (Cluedo & Einstein), principalement orchestrées par le script [`agents_logiques_production.py`](../../examples/Sherlock_Watson/agents_logiques_production.py).
+Ce document détaille l'architecture et les interactions des composants impliqués dans les démonstrations de raisonnement logique (Cluedo & Einstein), principalement orchestrées par le script [`agents_logiques_production.py`](../../examples/01_logic_and_riddles/Sherlock_Watson/agents_logiques_production.py).
 
 ## 1. Vue d'ensemble de l'Architecture
 
@@ -16,22 +16,22 @@ Le système est conçu autour d'un modèle d'orchestration d'agents, où un scri
 
 C'est le point d'entrée et le chef d'orchestre. Ses responsabilités incluent :
 
-- **Parsing des arguments** : La fonction [`main()`](../../examples/Sherlock_Watson/agents_logiques_production.py:670) utilise `argparse` pour accepter un fichier de scénario via l'argument `--scenario`.
-- **Chargement des scénarios** : La fonction [`load_scenarios()`](../../examples/Sherlock_Watson/agents_logiques_production.py:535) lit les fichiers JSON qui décrivent les tâches à exécuter.
-- **Initialisation** : La classe [`ProductionAgentOrchestrator`](../../examples/Sherlock_Watson/agents_logiques_production.py:408) est instanciée pour gérer le cycle de vie des agents.
-- **Création des Agents** : Le script crée des instances de [`ProductionLogicalAgent`](../../examples/Sherlock_Watson/agents_logiques_production.py:301), notamment :
+- **Parsing des arguments** : La fonction [`main()`](../../examples/01_logic_and_riddles/Sherlock_Watson/agents_logiques_production.py:670) utilise `argparse` pour accepter un fichier de scénario via l'argument `--scenario`.
+- **Chargement des scénarios** : La fonction [`load_scenarios()`](../../examples/01_logic_and_riddles/Sherlock_Watson/agents_logiques_production.py:535) lit les fichiers JSON qui décrivent les tâches à exécuter.
+- **Initialisation** : La classe [`ProductionAgentOrchestrator`](../../examples/01_logic_and_riddles/Sherlock_Watson/agents_logiques_production.py:408) est instanciée pour gérer le cycle de vie des agents.
+- **Création des Agents** : Le script crée des instances de [`ProductionLogicalAgent`](../../examples/01_logic_and_riddles/Sherlock_Watson/agents_logiques_production.py:301), notamment :
     - `sherlock` (Raisonnement déductif)
     - `watson` (Raisonnement inductif)
     - `moriarty` (Raisonnement contradictoire / adversaire)
-- **Exécution du Scénario** : La fonction [`run_production_agents_demo()`](../../examples/Sherlock_Watson/agents_logiques_production.py:549) exécute les différentes étapes définies dans le fichier de scénario (tests de données, dialogues, débats).
+- **Exécution du Scénario** : La fonction [`run_production_agents_demo()`](../../examples/01_logic_and_riddles/Sherlock_Watson/agents_logiques_production.py:549) exécute les différentes étapes définies dans le fichier de scénario (tests de données, dialogues, débats).
 
 ### 2.2. Les Agents Logiques (`ProductionLogicalAgent`)
 
 Chaque agent est une entité autonome capable d'analyse.
 
-- **Traitement interne** : Chaque agent utilise une instance de [`ProductionCustomDataProcessor`](../../examples/Sherlock_Watson/agents_logiques_production.py:94) pour l'analyse du langage naturel. Ce processeur identifie les propositions, détecte les sophismes et analyse la logique modale à l'aide d'expressions régulières.
+- **Traitement interne** : Chaque agent utilise une instance de [`ProductionCustomDataProcessor`](../../examples/01_logic_and_riddles/Sherlock_Watson/agents_logiques_production.py:94) pour l'analyse du langage naturel. Ce processeur identifie les propositions, détecte les sophismes et analyse la logique modale à l'aide d'expressions régulières.
 - **Base de connaissances** : Les agents maintiennent une base de connaissances et une mémoire de leurs conversations pour conserver le contexte.
-- **Communication** : La méthode [`communicate_with_agent()`](../../examples/Sherlock_Watson/agents_logiques_production.py:366) permet aux agents d'échanger des messages, qui sont à leur tour analysés.
+- **Communication** : La méthode [`communicate_with_agent()`](../../examples/01_logic_and_riddles/Sherlock_Watson/agents_logiques_production.py:366) permet aux agents d'échanger des messages, qui sont à leur tour analysés.
 
 ### 2.3. Les Fichiers de Scénario (JSON)
 
@@ -40,11 +40,11 @@ Ces fichiers sont le moteur des démonstrations. Ils décrivent une séquence d'
 - `name` : Le nom du scénario.
 - `custom_data_test` : Une tâche de traitement de texte pour un agent spécifique.
 - `dialogue_test` : Un échange de messages entre deux agents.
-- `debate_test` : Un débat structuré sur un sujet, orchestré par [`orchestrate_logical_debate()`](../../examples/Sherlock_Watson/agents_logiques_production.py:434).
+- `debate_test` : Un débat structuré sur un sujet, orchestré par [`orchestrate_logical_debate()`](../../examples/01_logic_and_riddles/Sherlock_Watson/agents_logiques_production.py:434).
 
 ## 3. Flux d'Interaction
 
-1.  Un utilisateur lance [`agents_logiques_production.py`](../../examples/Sherlock_Watson/agents_logiques_production.py) en spécifiant un fichier de scénario (`--scenario cluedo_scenario.json`).
+1.  Un utilisateur lance [`agents_logiques_production.py`](../../examples/01_logic_and_riddles/Sherlock_Watson/agents_logiques_production.py) en spécifiant un fichier de scénario (`--scenario cluedo_scenario.json`).
 2.  L'**Orchestrateur** charge le JSON, initialise et crée les agents `sherlock`, `watson`, et `moriarty`.
 3.  L'Orchestrateur lit les tâches dans le scénario (ex: un débat sur le coupable dans le Cluedo).
 4.  Il appelle les méthodes appropriées sur les agents (ex: `process_argument` ou `communicate_with_agent`).


### PR DESCRIPTION
## Summary

ATT-5 Phase 2 (issue #1315): fix broken internal markdown links across **`docs/integration/`** — 3 files, 22 balanced link edits, **0 files deleted**.

Fifth Phase 2 PR. Disjoint file set (#1413 arch / #1414 guides / #1415 technical / #1416 reference) → independent merge order.

## Method

- All targets verified via `git ls-files` (verify-before-assert — R563/R568 lesson).
- Single-link-scoped regex + `]\(target(?=[:#)])` lookahead, linkcheck in-place.

## Operations

| Op | Description | Count |
|----|-------------|-------|
| **PREFIX** | `examples/Sherlock_Watson/` flat → `examples/01_logic_and_riddles/Sherlock_Watson/` (canonical tracked home, 10 links in logical_reasoning_demos_map.md) | 10 |
| **PREFIX depth** | bare repo-relative from 2-deep `integration/`: `demos/validation_complete_epita.py` → `../../examples/03_demos_overflow/validation/`; `examples/scripts_demonstration/` flat non-tracked → `../../examples/02_core_system_demos/scripts_demonstration/` (canonical per #1411/#1412 context); `argumentation_analysis/` → `../../` | 7 |
| **REPLACE** | `config/README.md` → `../../config/README.md` (bare, root-tracked); `docs/troubleshooting.md` → `../guides/TROUBLESHOOTING.md` (sibling docs/ subdir) | 3 |
| **DELINK** | `docs/api/unified_web_orchestrator.md` (0 tracked); `../../issues` + `../../wiki` (GitHub endpoints, not local paths — anti-pendule: no arbitrary URL fabricated) | 3 |

## Result

```
integration/ linkcheck:  26 broken  →  0 real broken
```

The **4 remaining linkcheck hits are false-positives**: Python code-block calls `rule["condition"](message)`, `rule["recipients"](message)`, `handler_info["handler"](error, context)` — function invocations inside fenced ```python blocks in conception_systeme_communication_multi_canal.md, not markdown links. Left untouched.

## Verification

- `git diff --stat docs/integration/` → 3 files, 22 insertions / 22 deletions (balanced).
- Spot-checked: PRE flat→01_logic_and_riddles resolves ✓, bare→`../../` resolves ✓, DELINK preserves plain text ("UnifiedWebOrchestrator API", "Créer un ticket", "Wiki interne") ✓, no mangling.

## Cleanup Gate

N/A — markdown link **syntax only**, no files removed.

Refs #1315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)