### PR TITLE
docs(att-5): Phase 2 linkcheck reroute in projets/ #1315

### DIFF
--- a/docs/projets/ACCUEIL_ETUDIANTS_SYNTHESE.md
+++ b/docs/projets/ACCUEIL_ETUDIANTS_SYNTHESE.md
@@ -14,10 +14,10 @@ Le projet "argumentation_analysis" consiste à développer et améliorer un **Sy
 
 **Livrables attendus :**
 1.  Code source de votre implémentation.
-    *   Par exemple, pour comprendre comment interagir avec une API, consultez [cet exemple d'intégration](examples/logic_agents/api_integration_example.py:0) ou pour une démonstration simple, voyez [ce script de démonstration](examples/scripts_demonstration/demo_tweety_interaction_simple.py:0).
+    *   Par exemple, pour comprendre comment interagir avec une API, consultez cet exemple d'intégration ou pour une démonstration simple, voyez [ce script de démonstration](../../examples/02_core_system_demos/scripts_demonstration/demo_tweety_interaction_simple.py:0).
 2.  Documentation détaillée.
 3.  Tests unitaires et d'intégration.
-    *   Pour des exemples de tests, référez-vous à [ce test unitaire](tests/unit/project_core/utils/test_file_utils.py:0) ou à [ce test d'intégration](tests/integration/test_logic_agents_integration.py:0). Le répertoire [`tests/integration/jpype_tweety/`](tests/integration/jpype_tweety/) contient également des tests d'intégration spécifiques.
+    *   Pour des exemples de tests, référez-vous à [ce test unitaire](../../tests/unit/argumentation_analysis/utils/core_utils/test_file_utils.py:0) ou à [ce test d'intégration](../../tests/integration/test_logic_agents_integration.py:0). Le répertoire [`tests/integration/jpype_tweety/`](../../tests/integration/jpype_tweety/) contient également des tests d'intégration spécifiques.
 4.  Rapport final.
 
 Pour tous les détails (objectifs pédagogiques, modalités, évaluation), consultez impérativement :

--- a/docs/projets/sujets/2.5.3_Developpement_Serveur_MCP_Analyse_Argumentative.md
+++ b/docs/projets/sujets/2.5.3_Developpement_Serveur_MCP_Analyse_Argumentative.md
@@ -507,7 +507,7 @@ graph TB
 
 **Note sur l'intégration avec le système d'analyse argumentative :**
 
-Pour l'intégration de votre serveur MCP en Python avec les capacités d'analyse argumentative du projet, il est **recommandé de privilégier l'interfaçage direct avec les composants Python sous-jacents** du système d'analyse. Bien qu'une API web soit en cours de développement ([`libs/web_api`](libs/web_api)), une intégration directe avec les bibliothèques Python offrira potentiellement plus de flexibilité, de performance et un couplage plus fin pour les fonctionnalités avancées que vous pourriez développer. Discutez de cette approche avec votre tuteur pour valider la meilleure stratégie en fonction de l'évolution de l'API web et de vos besoins spécifiques.
+Pour l'intégration de votre serveur MCP en Python avec les capacités d'analyse argumentative du projet, il est **recommandé de privilégier l'interfaçage direct avec les composants Python sous-jacents** du système d'analyse. Bien qu'une API web soit en cours de développement ([`libs/web_api`](../../../argumentation_analysis/services/web_api)), une intégration directe avec les bibliothèques Python offrira potentiellement plus de flexibilité, de performance et un couplage plus fin pour les fonctionnalités avancées que vous pourriez développer. Discutez de cette approche avec votre tuteur pour valider la meilleure stratégie en fonction de l'évolution de l'API web et de vos besoins spécifiques.
 ### 3.2 Intégration avec TweetyProject via JPype
 
 #### 3.2.1 Bridge TweetyProject optimisé

--- a/docs/projets/sujets/aide/GUIDE_INTEGRATION_PROJETS.md
+++ b/docs/projets/sujets/aide/GUIDE_INTEGRATION_PROJETS.md
@@ -51,11 +51,11 @@ Le système est composé de plusieurs couches :
 
 Pour mieux comprendre comment ces composants interagissent, vous pouvez consulter les ressources suivantes :
 
-*   **Scripts d'intégration d'API :** Un exemple concret d'appel à l'API pour utiliser les fonctionnalités du moteur d'analyse se trouve dans [`examples/logic_agents/api_integration_example.py`](examples/logic_agents/api_integration_example.py:0).
-*   **Tests d'intégration :** Les tests d'intégration pour les agents logiques, qui illustrent leurs interactions avec le reste du système, sont disponibles dans [`tests/integration/test_logic_agents_integration.py`](tests/integration/test_logic_agents_integration.py:0). Pour l'intégration spécifique avec TweetyProject via JPype, référez-vous au répertoire [`tests/integration/jpype_tweety/`](tests/integration/jpype_tweety/).
-*   **Scripts de démonstration :** Des scripts montrant l'utilisation combinée de plusieurs modules sont disponibles dans le répertoire [`examples/scripts_demonstration/`](examples/scripts_demonstration/).
-*   **Notebooks illustratifs :** Un tutoriel sous forme de notebook, illustrant un flux d'intégration typique avec l'API et les agents logiques, est disponible ici : [`examples/notebooks/api_logic_tutorial.ipynb`](examples/notebooks/api_logic_tutorial.ipynb:0).
-*   **Test de l'API Web :** Un script de test dédié pour l'API web, montrant comment interroger ses différents endpoints, se trouve dans [`libs/web_api/test_api.py`](libs/web_api/test_api.py:0).
+*   **Scripts d'intégration d'API :** Un exemple concret d'appel à l'API pour utiliser les fonctionnalités du moteur d'analyse se trouve dans `examples/logic_agents/api_integration_example.py`.
+*   **Tests d'intégration :** Les tests d'intégration pour les agents logiques, qui illustrent leurs interactions avec le reste du système, sont disponibles dans [`tests/integration/test_logic_agents_integration.py`](../../../../tests/integration/test_logic_agents_integration.py:0). Pour l'intégration spécifique avec TweetyProject via JPype, référez-vous au répertoire [`tests/integration/jpype_tweety/`](../../../../tests/integration/jpype_tweety/).
+*   **Scripts de démonstration :** Des scripts montrant l'utilisation combinée de plusieurs modules sont disponibles dans le répertoire [`examples/scripts_demonstration/`](../../../../examples/02_core_system_demos/scripts_demonstration/).
+*   **Notebooks illustratifs :** Un tutoriel sous forme de notebook, illustrant un flux d'intégration typique avec l'API et les agents logiques, est disponible ici : `examples/notebooks/api_logic_tutorial.ipynb`.
+*   **Test de l'API Web :** Un script de test dédié pour l'API web, montrant comment interroger ses différents endpoints, se trouve dans `libs/web_api/test_api.py`.
 
 ## Guide pour le projet Interface Web
 
@@ -261,7 +261,7 @@ Développer une interface web moderne et intuitive qui permet aux utilisateurs d
 - **Exemples de code** : Consultez `docs/projets/sujets/aide/interface-web/exemples-react/` pour des composants prêts à l'emploi
 - **Guide de démarrage rapide** : `docs/projets/sujets/aide/interface-web/DEMARRAGE_RAPIDE.md`
 - **Documentation de l'API** : Accessible via `http://localhost:5000/api/endpoints` une fois l'API démarrée
-*   **Exemples d'intégration API pour le frontend :** Bien que le guide se concentre sur React, les principes d'appel à l'API sont similaires pour d'autres frameworks. Pour un exemple Python d'appel à l'API, voir [`examples/logic_agents/api_integration_example.py`](examples/logic_agents/api_integration_example.py:0). Les tests d'intégration comme [`tests/integration/test_logic_agents_integration.py`](tests/integration/test_logic_agents_integration.py:0) peuvent aussi vous donner des idées sur les flux de données.
+*   **Exemples d'intégration API pour le frontend :** Bien que le guide se concentre sur React, les principes d'appel à l'API sont similaires pour d'autres frameworks. Pour un exemple Python d'appel à l'API, voir `examples/logic_agents/api_integration_example.py`. Les tests d'intégration comme [`tests/integration/test_logic_agents_integration.py`](../../../../tests/integration/test_logic_agents_integration.py:0) peuvent aussi vous donner des idées sur les flux de données.
 
 ### Fonctionnalités à implémenter
 
@@ -635,8 +635,8 @@ Développer un serveur MCP (Model Context Protocol) qui expose les fonctionnalit
 - **Documentation MCP** : [Model Context Protocol](https://github.com/anthropics/anthropic-cookbook/tree/main/model_context_protocol)
 - **Exemples d'intégration** : `docs/projets/sujets/2.5.3_Developpement_Serveur_MCP_Analyse_Argumentative.md`
 - **Documentation TweetyProject** : [TweetyProject](https://tweetyproject.org/doc/)
-*   **Exemples d'utilisation des agents logiques :** Pour comprendre comment interagir avec le moteur d'analyse que votre serveur MCP exposera, consultez le guide [`docs/guides/utilisation_agents_logiques.md`](docs/guides/utilisation_agents_logiques.md:0).
-*   **Tests d'intégration du moteur :** Les fichiers dans [`tests/integration/`](tests/integration/) (par exemple, [`tests/integration/test_logic_agents_integration.py`](tests/integration/test_logic_agents_integration.py:0)) montrent comment les composants du moteur sont testés ensemble.
+*   **Exemples d'utilisation des agents logiques :** Pour comprendre comment interagir avec le moteur d'analyse que votre serveur MCP exposera, consultez le guide [`docs/guides/utilisation_agents_logiques.md`](../../../guides/utilisation_agents_logiques.md:0).
+*   **Tests d'intégration du moteur :** Les fichiers dans [`tests/integration/`](../../../../tests/integration/) (par exemple, [`tests/integration/test_logic_agents_integration.py`](../../../../tests/integration/test_logic_agents_integration.py:0)) montrent comment les composants du moteur sont testés ensemble.
 
 ### Fonctionnalités à implémenter
 
@@ -701,11 +701,11 @@ L'API web expose les fonctionnalités suivantes :
 
 ### Guides et Exemples Complémentaires
 
-*   **Guide du développeur :** Pour une vue d'ensemble plus large des pratiques de développement et de l'architecture, consultez le [`docs/guides/guide_developpeur.md`](docs/guides/guide_developpeur.md:0).
-*   **Utilisation des agents logiques :** Un guide détaillé sur l'utilisation directe des agents logiques est disponible : [`docs/guides/utilisation_agents_logiques.md`](docs/guides/utilisation_agents_logiques.md:0).
-*   **Exemple d'intégration API :** Un script Python illustrant l'appel à l'API se trouve dans [`examples/logic_agents/api_integration_example.py`](examples/logic_agents/api_integration_example.py:0).
-*   **Notebook tutoriel :** Pour un exemple interactif d'utilisation de l'API et des agents, voir [`examples/notebooks/api_logic_tutorial.ipynb`](examples/notebooks/api_logic_tutorial.ipynb:0).
-*   **Script de test de l'API :** Pour voir comment tester les différents endpoints de l'API, référez-vous à [`libs/web_api/test_api.py`](libs/web_api/test_api.py:0).
+*   **Guide du développeur :** Pour une vue d'ensemble plus large des pratiques de développement et de l'architecture, consultez le [`docs/guides/guide_developpeur.md`](../../../guides/guide_developpeur.md:0).
+*   **Utilisation des agents logiques :** Un guide détaillé sur l'utilisation directe des agents logiques est disponible : [`docs/guides/utilisation_agents_logiques.md`](../../../guides/utilisation_agents_logiques.md:0).
+*   **Exemple d'intégration API :** Un script Python illustrant l'appel à l'API se trouve dans `examples/logic_agents/api_integration_example.py`.
+*   **Notebook tutoriel :** Pour un exemple interactif d'utilisation de l'API et des agents, voir `examples/notebooks/api_logic_tutorial.ipynb`.
+*   **Script de test de l'API :** Pour voir comment tester les différents endpoints de l'API, référez-vous à `libs/web_api/test_api.py`.
 
 ## Processus de développement
 
@@ -725,7 +725,7 @@ L'API web expose les fonctionnalités suivantes :
    - Tester chaque composant individuellement
    - Effectuer des tests d'intégration
    - Valider les fonctionnalités avec des cas d'utilisation réels
-    *   Consultez les tests d'intégration existants dans [`tests/integration/`](tests/integration/) pour des exemples, notamment [`tests/integration/test_logic_agents_integration.py`](tests/integration/test_logic_agents_integration.py:0) et le répertoire [`tests/integration/jpype_tweety/`](tests/integration/jpype_tweety/).
+    *   Consultez les tests d'intégration existants dans [`tests/integration/`](../../../../tests/integration/) pour des exemples, notamment [`tests/integration/test_logic_agents_integration.py`](../../../../tests/integration/test_logic_agents_integration.py:0) et le répertoire [`tests/integration/jpype_tweety/`](../../../../tests/integration/jpype_tweety/).
 
 4. **Documentation**
    - Documenter le code

--- a/docs/projets/sujets/aide/PRESENTATION_KICKOFF.md
+++ b/docs/projets/sujets/aide/PRESENTATION_KICKOFF.md
@@ -154,15 +154,15 @@ L'Intelligence Symbolique combine les approches symboliques traditionnelles de l
 Pour vous aider à démarrer et à comprendre comment interagir avec les différents composants du projet, voici quelques ressources clés :
 
 *   **Scripts de démonstration :**
-    *   Pour une illustration simple des interactions de base avec le système, consultez le script [`demo_tweety_interaction_simple.py`](../../../../examples/scripts_demonstration/demo_tweety_interaction_simple.py) dans le dossier [`examples/scripts_demonstration/`](../../../../examples/scripts_demonstration/).
+    *   Pour une illustration simple des interactions de base avec le système, consultez le script [`demo_tweety_interaction_simple.py`](../../../../examples/02_core_system_demos/scripts_demonstration/demo_tweety_interaction_simple.py) dans le dossier [`examples/scripts_demonstration/`](../../../../examples/02_core_system_demos/scripts_demonstration/).
 *   **Notebooks Jupyter :**
-    *   Un tutoriel interactif sur l'utilisation de l'API logique est disponible sous forme de notebook Jupyter : [`api_logic_tutorial.ipynb`](../../../../examples/notebooks/api_logic_tutorial.ipynb).
+    *   Un tutoriel interactif sur l'utilisation de l'API logique est disponible sous forme de notebook Jupyter : `api_logic_tutorial.ipynb`.
 *   **Exemples d'intégration API :**
-    *   Un exemple concret d'intégration avec l'API pour les agents logiques se trouve ici : [`api_integration_example.py`](../../../../examples/logic_agents/api_integration_example.py).
+    *   Un exemple concret d'intégration avec l'API pour les agents logiques se trouve ici : `api_integration_example.py`.
 *   **Script de test de l'API :**
-    *   Pour voir comment l'API peut être testée et utilisée, référez-vous au script [`test_api.py`](../../../../libs/web_api/test_api.py). Cela peut vous donner des idées pour vos propres tests et interactions.
+    *   Pour voir comment l'API peut être testée et utilisée, référez-vous au script `test_api.py`. Cela peut vous donner des idées pour vos propres tests et interactions.
 *   **Guides Généraux Importants :**
-    *   Le document principal pour démarrer avec les projets étudiants : [`README_PROJETS_ETUDIANTS.md`](../../../README_PROJETS_ETUDIANTS.md).
+    *   Le document principal pour démarrer avec les projets étudiants : `README_PROJETS_ETUDIANTS.md`.
     *   Un guide d'utilisation général du système : [`guide_utilisation.md`](../../../guides/guide_utilisation.md).
     *   Pour ceux qui travaillent sur l'interface web, le guide de démarrage rapide est essentiel : [`DEMARRAGE_RAPIDE.md`](./interface-web/DEMARRAGE_RAPIDE.md).
 

--- a/docs/projets/sujets/aide/README.md
+++ b/docs/projets/sujets/aide/README.md
@@ -131,18 +131,18 @@ Les ressources d'aide doivent être :
 ## 📚 Relation avec la Documentation Principale
 
 Ces ressources d'aide sont conçues pour être un complément pratique aux documentations principales du projet. Pour une compréhension approfondie des concepts, de l'architecture et des bonnes pratiques, veuillez consulter en priorité :
-- Le **[Portail des Guides Officiels](../../guides/README.md)**
-- La **[Documentation d'Architecture](../../architecture/README.md)**
-- La **[Documentation des Composants](../../composants/README.md)**
+- Le **[Portail des Guides Officiels](../../../guides/README.md)**
+- La **[Documentation d'Architecture](../../../architecture/README.md)**
+- La **[Documentation des Composants](../../../technical/README.md)**
 
 ### Complémentarité des Ressources
 
 | Type de Documentation | Objectif | Exemple |
 |----------------------|----------|---------|
-| **[Portail des Guides](../../guides/README.md)** (`docs/guides/`) | Expliquer les concepts, fournir des tutoriels et bonnes pratiques | Guide Interface Web complet |
+| **[Portail des Guides](../../../guides/README.md)** (`docs/guides/`) | Expliquer les concepts, fournir des tutoriels et bonnes pratiques | Guide Interface Web complet |
 | **Ressources d'aide** (`docs/projets/sujets/aide/`) | Fournir du code prêt à l'emploi | Composants React fonctionnels |
 | **API et services** (`services/`) | Exposer les fonctionnalités | API REST Flask |
-| **Documentation Technique** | Documenter l'architecture et les composants | [Architecture Globale](../../architecture/architecture_globale.md), [Composants Clés](../../composants/README.md) |
+| **Documentation Technique** | Documenter l'architecture et les composants | [Architecture Globale](../../../architecture/architecture_globale.md), [Composants Clés](../../../technical/README.md) |
 
 ### Parcours de Développement Recommandé
 
@@ -156,9 +156,9 @@ Ces ressources d'aide sont conçues pour être un complément pratique aux docum
 
 ### Ressources de Support
 
-- **Portail des Guides Officiels** : [`docs/guides/README.md`](../../guides/README.md) - **Source principale d'information recommandée.**
-- **Documentation d'Architecture** : [`docs/architecture/README.md`](../../architecture/README.md)
-- **Documentation des Composants** : [`docs/composants/README.md`](../../composants/README.md)
+- **Portail des Guides Officiels** : [`docs/guides/README.md`](../../../guides/README.md) - **Source principale d'information recommandée.**
+- **Documentation d'Architecture** : [`docs/architecture/README.md`](../../../architecture/README.md)
+- **Documentation des Composants** : [`docs/composants/README.md`](../../../technical/README.md)
 - **Issues GitHub** : Pour signaler des problèmes ou demander des fonctionnalités
 - **Discussions** : Pour poser des questions générales
 - **Pull Requests** : Pour contribuer des améliorations

--- a/docs/projets/sujets/aide/interface-web/DEMARRAGE_RAPIDE.md
+++ b/docs/projets/sujets/aide/interface-web/DEMARRAGE_RAPIDE.md
@@ -21,7 +21,7 @@ Pour une configuration plus automatisée de votre environnement de développemen
 # Depuis la racine du projet (par exemple, c:/dev/2025-Epita-Intelligence-Symbolique)
 ./setup_project_env.ps1
 ```
-Ce script vous aidera à configurer Conda, le JDK portable et d'autres aspects essentiels. Ce script est crucial pour configurer correctement l'environnement, y compris les aspects liés à Java nécessaires au [Moteur de Raisonnement](../../../../../docs/composants/reasoning_engine.md:1) et au [Pont Tweety](../../../../../docs/composants/tweety_bridge.md:1). Pour plus de détails sur la gestion de la JVM et la configuration de l'environnement de développement, consultez le [Guide du Développeur](../../../../../docs/guides/guide_developpeur.md:1).
+Ce script vous aidera à configurer Conda, le JDK portable et d'autres aspects essentiels. Ce script est crucial pour configurer correctement l'environnement, y compris les aspects liés à Java nécessaires au [Moteur de Raisonnement](../../../../technical/reasoning_engine.md:1) et au [Pont Tweety](../../../../technical/tweety_bridge.md:1). Pour plus de détails sur la gestion de la JVM et la configuration de l'environnement de développement, consultez le [Guide du Développeur](../../../../../docs/guides/guide_developpeur.md:1).
 
 **Important :** Si le script `setup_project_env.ps1` a configuré un environnement Conda (par exemple, `epita-env`), assurez-vous de l'activer dans votre terminal avant de poursuivre avec les commandes `pip` et `python` :
 ```bash
@@ -63,7 +63,7 @@ python start_api.py
 # OU méthode alternative (depuis services/web_api/)
 python app.py
 ```
-Pour comprendre le fonctionnement interne de l'API, ses différentes routes et options de configuration, consultez la documentation de l'[API Web](../../../../../docs/composants/api_web.md:1) et le guide d'[Intégration de l'API Web](../../../../../docs/guides/integration_api_web.md:1).
+Pour comprendre le fonctionnement interne de l'API, ses différentes routes et options de configuration, consultez la documentation de l'[API Web](../../../../technical/api_web.md:1) et le guide d'[Intégration de l'API Web](../../../../../docs/guides/integration_api_web.md:1).
 
 #### ☐ 5. Test de l'API
 ```bash
@@ -81,7 +81,7 @@ Vous pouvez également tester l'API de manière plus complète en exécutant le 
 # Assurez-vous que l'API est démarrée et que votre environnement est activé
 python libs/web_api/test_api.py
 ```
-Ce script effectue une série de tests sur les différents points d'accès de l'API. Consultez le fichier [`libs/web_api/test_api.py`](../../../../../libs/web_api/test_api.py) pour plus de détails. Ce script de test est un bon exemple d'interaction avec les différents *endpoints* décrits dans la documentation de l'[API Web](../../../../../docs/composants/api_web.md:1).
+Ce script effectue une série de tests sur les différents points d'accès de l'API. Consultez le fichier `libs/web_api/test_api.py` pour plus de détails. Ce script de test est un bon exemple d'interaction avec les différents *endpoints* décrits dans la documentation de l'[API Web](../../../../technical/api_web.md:1).
 
 **✅ Résultat attendu :** L'API répond avec un JSON contenant `"success": true` pour le test de santé, et une analyse pour le test d'analyse.
 
@@ -114,7 +114,7 @@ La gestion CORS est un aspect important de la sécurité et de la communication 
 
 #### ☐ 8. Création du service API
 Créez `src/services/api.js` dans votre projet React :
-Ce service encapsule la logique d'appel à l'API. Les *endpoints* `/api/analyze` et `/api/health` sont documentés en détail dans la documentation de l'[API Web](../../../../../docs/composants/api_web.md:1). Les options passées à `/api/analyze` (comme `detect_fallacies`) sont également décrites dans cette documentation.
+Ce service encapsule la logique d'appel à l'API. Les *endpoints* `/api/analyze` et `/api/health` sont documentés en détail dans la documentation de l'[API Web](../../../../technical/api_web.md:1). Les options passées à `/api/analyze` (comme `detect_fallacies`) sont également décrites dans cette documentation.
 ```javascript
 const API_BASE_URL = 'http://localhost:5000';
 
@@ -153,7 +153,7 @@ export const checkAPIHealth = async () => {
 
 #### ☐ 9. Composant de test simple
 Remplacez le contenu de `src/App.js` :
-Cet exemple montre comment appeler le service `api.js` et afficher les résultats. La structure des données retournées par l'API (par exemple, `result.overall_quality`, `result.fallacies`) est définie dans la documentation de l'[API Web](../../../../../docs/composants/api_web.md:1).
+Cet exemple montre comment appeler le service `api.js` et afficher les résultats. La structure des données retournées par l'API (par exemple, `result.overall_quality`, `result.fallacies`) est définie dans la documentation de l'[API Web](../../../../technical/api_web.md:1).
 ```jsx
 import React, { useState, useEffect } from 'react';
 import { analyzeText, checkAPIHealth } from './services/api';
@@ -352,7 +352,7 @@ npm start
 
 **✅ Résultat attendu :** L'interface affiche les résultats d'analyse. Si des sophismes sont détectés par l'API, ils devraient apparaître.
 
-Pour des tests plus automatisés et approfondis de l'API elle-même, vous pouvez réutiliser le script [`libs/web_api/test_api.py`](../../../../../libs/web_api/test_api.py) mentionné précédemment. Ce script est un outil précieux pour valider le bon fonctionnement de votre backend. Assurez-vous de comprendre son utilisation en consultant la documentation de l'[API Web](../../../../../docs/composants/api_web.md:1) et le [Guide du Développeur](../../../../../docs/guides/guide_developpeur.md:1) pour les bonnes pratiques de test.
+Pour des tests plus automatisés et approfondis de l'API elle-même, vous pouvez réutiliser le script `libs/web_api/test_api.py` mentionné précédemment. Ce script est un outil précieux pour valider le bon fonctionnement de votre backend. Assurez-vous de comprendre son utilisation en consultant la documentation de l'[API Web](../../../../technical/api_web.md:1) et le [Guide du Développeur](../../../../../docs/guides/guide_developpeur.md:1) pour les bonnes pratiques de test.
 
 ## 🎯 Objectifs de validation
 
@@ -412,7 +412,7 @@ Consultez le [Guide du Développeur](../../../../../docs/guides/guide_developpeu
 
 Une fois cette checklist terminée, consultez :
 
-1.  **Documentation de l'[API Web (Composant)](../../../../../docs/composants/api_web.md:1)** - Description détaillée du composant API, de ses routes et de ses options.
+1.  **Documentation de l'[API Web (Composant)](../../../../technical/api_web.md:1)** - Description détaillée du composant API, de ses routes et de ses options.
 2.  **[Guide d'Intégration de l'API Web](../../../../../docs/guides/integration_api_web.md:1)** - Comment utiliser et intégrer l'API plus en profondeur.
 3.  **[Exemples React avancés](./exemples-react/)** (`./exemples-react/`) - Pour des composants et des fonctionnalités React plus élaborés.
 4.  **[Guide de Troubleshooting général](./TROUBLESHOOTING.md)** (`./TROUBLESHOOTING.md`) - Solutions aux problèmes courants non spécifiques à ce démarrage rapide.

--- a/docs/projets/sujets/aide/interface-web/GUIDE_UTILISATION_API.md
+++ b/docs/projets/sujets/aide/interface-web/GUIDE_UTILISATION_API.md
@@ -15,7 +15,7 @@
 
 ## Introduction
 
-L'API d'Analyse Argumentative vous permet d'intégrer facilement les fonctionnalités d'analyse de textes argumentatifs dans votre interface web. Cette API expose plusieurs services principaux, détaillés dans la documentation du composant [`API Web`](../../../../composants/api_web.md:1) et le [`Guide d'Intégration de l'API Web`](../../../../guides/integration_api_web.md:1). Les services incluent typiquement :
+L'API d'Analyse Argumentative vous permet d'intégrer facilement les fonctionnalités d'analyse de textes argumentatifs dans votre interface web. Cette API expose plusieurs services principaux, détaillés dans la documentation du composant [`API Web`](../../../../technical/api_web.md:1) et le [`Guide d'Intégration de l'API Web`](../../../../guides/integration_api_web.md:1). Les services incluent typiquement :
 
 -   **Analyse complète** : Par exemple, détection de sophismes combinée à une analyse de structure.
 -   **Validation d'arguments** : Vérification de la logique d'un argument.
@@ -53,7 +53,7 @@ L'API Web est un composant du projet principal. Ses dépendances sont gérées d
     ```
     Consultez le [`Guide Développeur`](../../../../guides/guide_developpeur.md:1) pour les instructions d'installation détaillées.
 
-L'API elle-même se trouve dans le répertoire [`libs/web_api/`](../../../../../libs/web_api/:0).
+L'API elle-même se trouve dans le répertoire [`libs/web_api/`](../../../../../argumentation_analysis/services/web_api/:0).
 
 ### Variables d'environnement
 
@@ -70,7 +70,7 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:3001
 # Logging
 LOG_LEVEL=INFO
 ```
-Pour plus de détails sur la configuration, référez-vous au [`README de l'API Web`](../../../../../libs/web_api/README.md:0).
+Pour plus de détails sur la configuration, référez-vous au [`README de l'API Web`](../../../../../argumentation_analysis/services/web_api/README.md:0).
 
 ## Démarrage de l'API
 
@@ -89,7 +89,7 @@ python app.py
 # Exemple avec options personnalisées (si supporté par app.py ou start_api.py)
 # python app.py --port 8080 --debug --host 0.0.0.0
 ```
-Consultez le [`README de l'API Web`](../../../../../libs/web_api/README.md:0) pour les commandes de démarrage exactes et les options disponibles.
+Consultez le [`README de l'API Web`](../../../../../argumentation_analysis/services/web_api/README.md:0) pour les commandes de démarrage exactes et les options disponibles.
 
 ### Vérification du démarrage
 
@@ -114,7 +114,7 @@ Réponse attendue (la version et les services peuvent varier) :
 
 ## Endpoints Disponibles
 
-La liste exhaustive et les détails des endpoints sont disponibles dans la documentation du composant [`API Web`](../../../../composants/api_web.md:1) et le [`Guide d'Intégration de l'API Web`](../../../../guides/integration_api_web.md:1). Voici un aperçu des endpoints courants :
+La liste exhaustive et les détails des endpoints sont disponibles dans la documentation du composant [`API Web`](../../../../technical/api_web.md:1) et le [`Guide d'Intégration de l'API Web`](../../../../guides/integration_api_web.md:1). Voici un aperçu des endpoints courants :
 
 ### 🔍 Health Check
 -   **URL** : `GET /api/health`
@@ -154,7 +154,7 @@ La liste exhaustive et les détails des endpoints sont disponibles dans la docum
       "argument_type": "deductive" 
     }
     ```
-    Pour un exemple de test de cet endpoint, consultez la fonction [`test_validate_endpoint`](../../../../../libs/web_api/test_api.py:74) dans le script [`libs/web_api/test_api.py`](../../../../../libs/web_api/test_api.py:0).
+    Pour un exemple de test de cet endpoint, consultez la fonction `test_validate_endpoint` dans le script `libs/web_api/test_api.py`.
 
 ### 🚫 Détection de Sophismes
 -   **URL** : `POST /api/fallacies`
@@ -172,7 +172,7 @@ La liste exhaustive et les détails des endpoints sont disponibles dans la docum
       }
     }
     ```
-    Pour un exemple de test de cet endpoint, consultez la fonction [`test_fallacies_endpoint`](../../../../../libs/web_api/test_api.py:109) dans le script [`libs/web_api/test_api.py`](../../../../../libs/web_api/test_api.py:0).
+    Pour un exemple de test de cet endpoint, consultez la fonction `test_fallacies_endpoint` dans le script `libs/web_api/test_api.py`.
 
 ### 🕸️ Framework de Dung
 -   **URL** : `POST /api/framework`
@@ -200,10 +200,10 @@ La liste exhaustive et les détails des endpoints sont disponibles dans la docum
       }
     }
     ```
-    Pour un exemple de test de cet endpoint, consultez la fonction [`test_framework_endpoint`](../../../../../libs/web_api/test_api.py:143) dans le script [`libs/web_api/test_api.py`](../../../../../libs/web_api/test_api.py:0).
+    Pour un exemple de test de cet endpoint, consultez la fonction `test_framework_endpoint` dans le script `libs/web_api/test_api.py`.
 
 ### 📋 Liste des Endpoints (Documentation)
--   **URL** : `GET /api/endpoints` (ou un endpoint similaire, vérifiez la documentation de l'[`API Web`](../../../../composants/api_web.md:1))
+-   **URL** : `GET /api/endpoints` (ou un endpoint similaire, vérifiez la documentation de l'[`API Web`](../../../../technical/api_web.md:1))
 -   **Description** : Fournit une documentation (souvent au format OpenAPI/Swagger) de tous les endpoints disponibles.
 
 ## Exemples d'Utilisation
@@ -271,8 +271,8 @@ print(f"Sophismes détectés: {result.get('fallacy_count', 'N/A')}") # Utiliser 
 
 ### Inspiration pour Clients API Avancés
 Bien que ciblant une API pour agents logiques, les exemples suivants peuvent inspirer la création de clients API plus robustes :
--   Script Python d'intégration : [`examples/logic_agents/api_integration_example.py`](../../../../../examples/logic_agents/api_integration_example.py:0)
--   Tutoriel interactif Jupyter Notebook : [`examples/notebooks/api_logic_tutorial.ipynb`](../../../../../examples/notebooks/api_logic_tutorial.ipynb:0)
+-   Script Python d'intégration : `examples/logic_agents/api_integration_example.py`
+-   Tutoriel interactif Jupyter Notebook : `examples/notebooks/api_logic_tutorial.ipynb`
     (Voir aussi le [`Guide d'utilisation des agents logiques`](../../../../guides/utilisation_agents_logiques.md:1) pour le contexte de ces exemples.)
 
 ## Intégration avec React
@@ -368,7 +368,7 @@ export const useArgumentationAPI = () => {
 ```
 
 ### Composant React d'exemple (Concept)
-Le composant `ArgumentAnalyzer.jsx` fourni précédemment est un bon point de départ. Assurez-vous que les champs de `analysis` (ex: `overall_quality`, `fallacy_count`, `fallacies`, `argument_structure`) correspondent à la réponse réelle de votre API, telle que définie dans la documentation du composant [`API Web`](../../../../composants/api_web.md:1).
+Le composant `ArgumentAnalyzer.jsx` fourni précédemment est un bon point de départ. Assurez-vous que les champs de `analysis` (ex: `overall_quality`, `fallacy_count`, `fallacies`, `argument_structure`) correspondent à la réponse réelle de votre API, telle que définie dans la documentation du composant [`API Web`](../../../../technical/api_web.md:1).
 
 Consultez les exemples complets dans [`docs/projets/sujets/aide/interface-web/exemples-react/`](./exemples-react/README.md:0).
 
@@ -464,7 +464,7 @@ Consultez le [`Guide Développeur`](../../../../guides/guide_developpeur.md:1) p
       });
     });
     ```
--   Pour des exemples de tests d'intégration Python pour l'API elle-même, consultez [`libs/web_api/test_api.py`](../../../../../libs/web_api/test_api.py:0).
+-   Pour des exemples de tests d'intégration Python pour l'API elle-même, consultez `libs/web_api/test_api.py`.
 
 ### 6. Monitoring et Logging
 -   Utilisez des outils de logging côté client (ex: Sentry, LogRocket) pour capturer les erreurs en production.
@@ -473,12 +473,12 @@ Consultez le [`Guide Développeur`](../../../../guides/guide_developpeur.md:1) p
 ## Support et Ressources
 
 -   **Portail des Guides Officiels** : [`docs/guides/README.md`](../../../../guides/README.md:1) (point d'entrée principal pour la documentation).
--   **Documentation de l'API Web (Composant)** : [`docs/composants/api_web.md`](../../../../composants/api_web.md:1) (détails techniques de l'API).
+-   **Documentation de l'API Web (Composant)** : [`docs/composants/api_web.md`](../../../../technical/api_web.md:1) (détails techniques de l'API).
 -   **Guide d'Intégration de l'API Web** : [`docs/guides/integration_api_web.md`](../../../../guides/integration_api_web.md:1).
 -   **Guide Développeur Général** : [`docs/guides/guide_developpeur.md`](../../../../guides/guide_developpeur.md:1).
--   **README de l'API Web (Code)** : [`libs/web_api/README.md`](../../../../../libs/web_api/README.md:0) (informations spécifiques au code de l'API).
+-   **README de l'API Web (Code)** : [`libs/web_api/README.md`](../../../../../argumentation_analysis/services/web_api/README.md:0) (informations spécifiques au code de l'API).
 -   **Exemples de code React** : [`docs/projets/sujets/aide/interface-web/exemples-react/`](./exemples-react/README.md:0).
--   **Tests d'API en Python** : [`libs/web_api/test_api.py`](../../../../../libs/web_api/test_api.py:0).
+-   **Tests d'API en Python** : `libs/web_api/test_api.py`.
 -   **Autres guides pertinents** :
     -   [`Guide d'utilisation des agents logiques`](../../../../guides/utilisation_agents_logiques.md:1)
     -   Consultez le portail des guides pour d'autres logiques formelles si nécessaire.
@@ -487,7 +487,7 @@ Consultez le [`Guide Développeur`](../../../../guides/guide_developpeur.md:1) p
 
 ## Changelog
 
--   **vX.Y.Z** : (Consultez le changelog principal du projet ou le [`README de l'API Web`](../../../../../libs/web_api/README.md:0) pour les versions).
+-   **vX.Y.Z** : (Consultez le changelog principal du projet ou le [`README de l'API Web`](../../../../../argumentation_analysis/services/web_api/README.md:0) pour les versions).
 -   Ce document est régulièrement mis à jour pour refléter les évolutions de l'API et des bonnes pratiques.
 
 ---

--- a/docs/projets/sujets/aide/interface-web/TROUBLESHOOTING.md
+++ b/docs/projets/sujets/aide/interface-web/TROUBLESHOOTING.md
@@ -3,7 +3,7 @@
 **Note Importante :** Ce guide de dépannage est un complément aux documentations principales du projet. Pour une compréhension approfondie de l'architecture, des composants et des procédures de développement, veuillez consulter :
 *   Le portail des guides : [`docs/guides/README.md`](../../../../guides/README.md:1)
 *   La documentation d'architecture globale : [`docs/architecture/architecture_globale.md`](../../../../architecture/architecture_globale.md:1)
-*   La documentation des composants : [`docs/composants/`](../../../../composants/)
+*   La documentation des composants : [`docs/composants/`](../../../../technical/)
 
 ## 📋 Table des matières
 
@@ -127,7 +127,7 @@ netstat -an | grep :5000
    // Exemple : s'assurer que l'URL et le port correspondent à ceux de l'API
    const API_URL = 'http://localhost:5000'; // ou le port que vous utilisez
    ```
-   Consultez la documentation de l'[`API Web`](../../../../composants/api_web.md:1) pour les détails des endpoints.
+   Consultez la documentation de l'[`API Web`](../../../../technical/api_web.md:1) pour les détails des endpoints.
 
 3. **Vérifier le firewall**
    Assurez-vous que votre pare-feu autorise les connexions sur le port utilisé par l'API.
@@ -263,7 +263,7 @@ def handle_preflight():
 
 ## Erreurs de dépendances
 
-Consultez le [`Guide du Développeur`](../../../../guides/guide_developpeur.md:1) et la documentation sur la [`Structure du Projet`](../../../../composants/structure_projet.md:1) pour comprendre comment les modules sont organisés.
+Consultez le [`Guide du Développeur`](../../../../guides/guide_developpeur.md:1) et la documentation sur la [`Structure du Projet`](../../../../technical/structure_projet.md:1) pour comprendre comment les modules sont organisés.
 
 ### ❌ Erreur : "No module named 'argumentation_analysis'"
 
@@ -304,7 +304,7 @@ pip install -e .
    python start_api.py --debug
    ```
 3. **Installer les dépendances manquantes :** Si des dépendances spécifiques sont nécessaires pour ces modules (ex: bibliothèques C++, modèles de ML lourds), assurez-vous qu'elles sont installées conformément au [`Guide du Développeur`](../../../../guides/guide_developpeur.md:1).
-4. **Consulter la documentation des composants** comme [`Agents Spécialistes`](../../../../composants/agents_specialistes.md:1) ou [`Moteur de Raisonnement`](../../../../composants/reasoning_engine.md:1) pour comprendre les capacités attendues.
+4. **Consulter la documentation des composants** comme [`Agents Spécialistes`](../../../../technical/agents_specialistes.md:1) ou [`Moteur de Raisonnement`](../../../../technical/reasoning_engine.md:1) pour comprendre les capacités attendues.
 
 ### ❌ Erreur : Conflits de versions de dépendances
 
@@ -387,7 +387,7 @@ Vérifiez attentivement les chemins relatifs et absolus dans vos instructions `i
 
 ## Erreurs d'analyse
 
-Ces erreurs proviennent de l'API lorsqu'elle traite une requête d'analyse. Consultez la documentation de l'[`API Web`](../../../../composants/api_web.md:1) pour les formats de requête et de réponse attendus.
+Ces erreurs proviennent de l'API lorsqu'elle traite une requête d'analyse. Consultez la documentation de l'[`API Web`](../../../../technical/api_web.md:1) pour les formats de requête et de réponse attendus.
 
 ### ❌ Erreur : "Données invalides" (souvent une réponse HTTP 400 Bad Request)
 
@@ -412,7 +412,7 @@ console.log('Données envoyées à /api/analyze:', JSON.stringify(requestData, n
 **Solutions :**
 1. **Vérifier que le champ `text` n'est pas vide ou manquant.**
 2. **Vérifier que le corps de la requête est un JSON valide.**
-3. **Vérifier que les champs et les types de données correspondent à ce qui est attendu par l'API** (voir la documentation de l'[`API Web`](../../../../composants/api_web.md:1)).
+3. **Vérifier que les champs et les types de données correspondent à ce qui est attendu par l'API** (voir la documentation de l'[`API Web`](../../../../technical/api_web.md:1)).
 4. **Vérifier les `options` d'analyse :** Assurez-vous que les options envoyées sont valides et correctement formatées.
 
 ### ❌ Erreur : "Erreur interne du serveur" (souvent une réponse HTTP 500 Internal Server Error)
@@ -463,7 +463,7 @@ Measure-Command { Invoke-RestMethod -Uri http://localhost:5000/api/analyze -Meth
    ```
 3. **Redémarrer l'API :** Parfois, cela peut aider si des ressources sont bloquées.
 4. **Vérifier les logs de l'API en mode debug** pour voir si une étape spécifique de l'analyse prend beaucoup de temps.
-5. **Consulter la documentation des composants** (ex: [`Moteur de Raisonnement`](../../../../composants/reasoning_engine.md:1)) pour comprendre les implications de performance de certaines fonctionnalités.
+5. **Consulter la documentation des composants** (ex: [`Moteur de Raisonnement`](../../../../technical/reasoning_engine.md:1)) pour comprendre les implications de performance de certaines fonctionnalités.
 
 ### ❌ Interface React lente ou peu réactive
 
@@ -618,7 +618,7 @@ python diagnostic.py 2>&1 | tee diagnostic_api.log
 
 ### 🧪 Script de test complet de l'API
 
-Pour un ensemble de tests plus exhaustifs couvrant plusieurs endpoints de l'API (health check, analyse, validation, etc.) avec des charges utiles prédéfinies, utilisez le script [`libs/web_api/test_api.py`](../../../../../libs/web_api/test_api.py) (le chemin peut varier, vérifiez sa localisation actuelle dans le projet). Ce script est généralement plus détaillé que le diagnostic rapide.
+Pour un ensemble de tests plus exhaustifs couvrant plusieurs endpoints de l'API (health check, analyse, validation, etc.) avec des charges utiles prédéfinies, utilisez le script `libs/web_api/test_api.py` (le chemin peut varier, vérifiez sa localisation actuelle dans le projet). Ce script est généralement plus détaillé que le diagnostic rapide.
 Consultez le [`Guide du Développeur`](../../../../guides/guide_developpeur.md:1) pour des instructions sur l'exécution des suites de tests complètes.
 
 ```bash

--- a/docs/projets/sujets/aide/interface-web/exemples-react/README.md
+++ b/docs/projets/sujets/aide/interface-web/exemples-react/README.md
@@ -121,7 +121,7 @@ import FrameworkBuilder from './FrameworkBuilder';
 **Hook React personnalisé** pour interagir avec l'API d'argumentation.
 
 **Fonctionnalités :**
-- Gestion complète de tous les endpoints (voir la [documentation de l'API Web](../../../../composants/api_web.md) pour le détail des endpoints)
+- Gestion complète de tous les endpoints (voir la [documentation de l'API Web](../../../../../technical/api_web.md) pour le détail des endpoints)
 - États de chargement et gestion d'erreurs
 - Cache des résultats (si configuré et applicable)
 - Configuration flexible
@@ -319,8 +319,8 @@ Tous les composants utilisent des variables CSS pour faciliter la personnalisati
 La configuration de l'API se fait principalement dans le hook [`useArgumentationAPI.js`](#useargumentationapijs-hook). Il est crucial de s'assurer que l'URL de base (`baseURL`) pointe vers votre instance de l'API d'argumentation.
 
 Pour une compréhension détaillée des endpoints disponibles et des options de configuration avancées, référez-vous à :
-- **Documentation de l'API Web :** [`../../../../composants/api_web.md`](../../../../composants/api_web.md)
-- **Guide d'Intégration de l'API Web :** [`../../../../guides/integration_api_web.md`](../../../../guides/integration_api_web.md)
+- **Documentation de l'API Web :** [`../../../../composants/api_web.md`](../../../../../technical/api_web.md)
+- **Guide d'Intégration de l'API Web :** [`../../../../guides/integration_api_web.md`](../../../../../guides/integration_api_web.md)
 
 ```javascript
 // Dans useArgumentationAPI.js
@@ -353,7 +353,7 @@ const API_CONFIG = {
 
 3.  **Erreurs de validation des données :**
     - Utilisez les fonctions de validation fournies dans [`utils/validators.js`](#validatorsjs) avant d'envoyer des données à l'API.
-    - Consultez la [documentation de l'API Web](../../../../composants/api_web.md) pour les formats de données attendus par chaque endpoint.
+    - Consultez la [documentation de l'API Web](../../../../../technical/api_web.md) pour les formats de données attendus par chaque endpoint.
 
 ### Logs de débogage
 Pour activer des logs plus détaillés dans la console lors des interactions avec l'API (si le hook `useArgumentationAPI.js` le supporte) :
@@ -367,11 +367,11 @@ localStorage.setItem('DEBUG_API', 'true');
 
 Pour une compréhension approfondie de l'API Web et du système global, veuillez consulter :
 
-- **Documentation de l'API Web (Composant) :** [`../../../../composants/api_web.md`](../../../../composants/api_web.md) - Description détaillée du composant API Web, son architecture et ses endpoints.
-- **Guide d'Intégration de l'API Web :** [`../../../../guides/integration_api_web.md`](../../../../guides/integration_api_web.md) - Instructions pas à pas pour intégrer l'API Web dans vos applications.
-- **Guide du Développeur :** [`../../../../guides/guide_developpeur.md`](../../../../guides/guide_developpeur.md) - Informations générales pour les développeurs contribuant au projet.
-- **Portail des Guides :** [`../../../../guides/README.md`](../../../../guides/README.md) - Point d'entrée vers tous les guides techniques et d'utilisation.
-- **Architecture Globale :** [`../../../../architecture/architecture_globale.md`](../../../../architecture/architecture_globale.md) - Vue d'ensemble de l'architecture du système (pour contexte).
+- **Documentation de l'API Web (Composant) :** [`../../../../composants/api_web.md`](../../../../../technical/api_web.md) - Description détaillée du composant API Web, son architecture et ses endpoints.
+- **Guide d'Intégration de l'API Web :** [`../../../../guides/integration_api_web.md`](../../../../../guides/integration_api_web.md) - Instructions pas à pas pour intégrer l'API Web dans vos applications.
+- **Guide du Développeur :** [`../../../../guides/guide_developpeur.md`](../../../../../guides/guide_developpeur.md) - Informations générales pour les développeurs contribuant au projet.
+- **Portail des Guides :** [`../../../../guides/README.md`](../../../../../guides/README.md) - Point d'entrée vers tous les guides techniques et d'utilisation.
+- **Architecture Globale :** [`../../../../architecture/architecture_globale.md`](../../../../../architecture/architecture_globale.md) - Vue d'ensemble de l'architecture du système (pour contexte).
 
 Les anciens liens spécifiques à ce dossier d'exemples ont été remplacés ou complétés par les références ci-dessus, qui sont plus actuelles et centralisées au sein de la documentation globale du projet.
 

--- a/docs/projets/sujets/sujet_1.1.5_formules_booleennes_quantifiees.md
+++ b/docs/projets/sujets/sujet_1.1.5_formules_booleennes_quantifiees.md
@@ -122,7 +122,7 @@
     *   Rappeler l'importance de démarrer et d'arrêter correctement la JVM via `jpype` pour éviter les fuites de ressources ou les erreurs.
     *   Typiquement, `jpype.startJVM()` au début et `jpype.shutdownJVM()` à la fin, si l'application n'est pas un simple script.
 *   **Référence aux tests unitaires existants :**
-    *   Le fichier [`tests/integration/jpype_tweety/test_qbf.py`](tests/integration/jpype_tweety/test_qbf.py) contient des exemples concrets d'utilisation des fonctionnalités QBF de TweetyProject via `jpype`.
+    *   Le fichier [`tests/integration/jpype_tweety/test_qbf.py`](../../../tests/integration/jpype_tweety/test_qbf.py) contient des exemples concrets d'utilisation des fonctionnalités QBF de TweetyProject via `jpype`.
     *   Encourager les étudiants à étudier ce fichier pour comprendre comment interagir avec les classes Java, instancier des formules, et potentiellement appeler des solveurs.
 
 ## 5. Tests Unitaires et Validation
@@ -168,8 +168,8 @@
 
 *   **Documentation TweetyProject :** Commencer par se familiariser en profondeur avec la section QBF de la documentation de TweetyProject.
 *   **Étude des exemples existants :**
-    *   Analyser attentivement les exemples de code et les tests unitaires fournis dans le projet, notamment dans le répertoire [`tests/integration/jpype_tweety/`](tests/integration/jpype_tweety/).
-    *   Le fichier [`tests/integration/jpype_tweety/test_qbf.py`](tests/integration/jpype_tweety/test_qbf.py) est une ressource clé.
+    *   Analyser attentivement les exemples de code et les tests unitaires fournis dans le projet, notamment dans le répertoire [`tests/integration/jpype_tweety/`](../../../tests/integration/jpype_tweety/).
+    *   Le fichier [`tests/integration/jpype_tweety/test_qbf.py`](../../../tests/integration/jpype_tweety/test_qbf.py) est une ressource clé.
 *   **Approche itérative :**
     *   Commencer par implémenter les fonctionnalités de base (ex: instanciation d'une formule simple, appel à un solveur pour une formule triviale).
     *   Ajouter progressivement des fonctionnalités plus complexes et les tests correspondants.

--- a/docs/projets/sujets_projets_detailles.md
+++ b/docs/projets/sujets_projets_detailles.md
@@ -4,7 +4,7 @@ Les sujets proposés ci-dessous couvrent différents aspects de l'IA symbolique,
 
 Plusieurs projets proposés s'appuient sur **TweetyProject**, une bibliothèque Java open-source pour l'intelligence artificielle symbolique. TweetyProject offre un ensemble riche de modules pour la représentation de connaissances et l'argumentation computationnelle, permettant aux étudiants de travailler avec des formalismes logiques variés (propositionnelle, premier ordre, description, modale) et des frameworks d'argumentation (Dung, ASPIC+, ABA, etc.) sans avoir à les implémenter de zéro. L'utilisation de TweetyProject via JPype permet de combiner la puissance des implémentations Java avec la flexibilité de Python pour le prototypage rapide et l'expérimentation.
 
-> **Note**: Pour une présentation alternative des projets organisée par niveau de difficulté plutôt que par domaine technique, consultez le document [Sujets de Projets](./sujets_projets.md) qui présente les projets selon quatre catégories: projets d'initiation, d'extension, d'application et de recherche.
+> **Note**: Pour une présentation alternative des projets organisée par niveau de difficulté plutôt que par domaine technique, consultez le document Sujets de Projets qui présente les projets selon quatre catégories: projets d'initiation, d'extension, d'application et de recherche.
 
 ## Organisation des Sujets
 


### PR DESCRIPTION
## Summary

ATT-5 Phase 2 (issue #1315): fix broken internal markdown links across **`docs/projets/`** — 11 files, 75 balanced link edits, **0 files deleted**.

Sixth Phase 2 PR. Disjoint file set (#1413 arch / #1414 guides / #1415 technical / #1416 reference / #1417 integration) → independent merge order. This completes the reader-facing canonical subset per #1315 (reports/ is explicitly SKIP — semi-historical mission reports).

## Method

- All targets verified via `git ls-files` (verify-before-assert — R563/R568 lesson).
- `projets/` spans **4 sub-depths** (2/3/4/5/6-deep) → per-file exact ops with empirically-computed correct relative paths.
- Single-link-scoped regex + `]\(target(?=[:#)])` lookahead.

## Key distinction (lossless vs removed)

| Target | Status | Action |
|--------|--------|--------|
| `examples/logic_agents/*`, `examples/notebooks/*` | **0 tracked** (removed) | DELINK |
| `examples/scripts_demonstration/*` | **MOVED** → `examples/02_core_system_demos/scripts_demonstration/` (tracked) | **REROUTE** (lossless) |
| `libs/web_api/test_api.py` | **0 tracked** (removed) | DELINK |
| `libs/web_api/` + `README.md` | canonical → `argumentation_analysis/services/web_api/` | REROUTE |
| `docs/composants/*` | renamed → `docs/technical/*` | REROUTE |
| `README_PROJETS_ETUDIANTS.md` | **0 tracked** (aspirational) | DELINK |

## Operations (92 substitutions)

- **DELINK** (~30): removed targets → plain text
- **REROUTE** (~50): moved targets to canonical tracked home; composants→technical; libs/web_api→services/web_api; scripts_demonstration→02_core_system_demos
- **PREFIX depth** (~12): bare repo-relative paths get correct `../../` per sub-depth; exemples-react (6-deep) `../../../../X`→`../../../../../X`; aide/README (4-deep) `../../X`→`../../../X`

## Result

```
projets/ linkcheck:  107 broken  →  0 real broken
```

The **15 remaining hits are all false-positives**, left untouched:
- `sujets/2.5.6` (5): Python code-block calls `[category](ai_system)`, `[bias_type](target_system, target_belief)`, etc. — function invocations
- `exemples_tweety*.md` (6): modal logic formulas in string lists `[](q && r)`, `[](!p)` — typographic
- `sujets/2.5.3` (2): Python `[Argument](arg_name)`, `[handler](tool_args)`
- `sujets/2.1.6` (1): Python `[strategy](conflict)`
- `sujets/3.1.1` (1): webpack regex `[\/](d3|cytoscape)`

## Note

Some link TEXT labels (code-spans) still show old paths (e.g. `` `../../../../composants/api_web.md` ``) while the href is corrected — text is illustrative, href is what linkcheck validates. Left as-is (anti-pendulum: not scope-creeping into label rewrites).

## Verification

- `git diff --stat docs/projets/` → 11 files, 75 insertions / 75 deletions (balanced).
- Spot-checked: README reroute (PRE absorbed REP) ✓, composants→technical ✓, test_api DELINK plain text ✓, depth fixes resolve to tracked files ✓, no mangling.

## Cleanup Gate

N/A — markdown link **syntax only**, no files removed.

Refs #1315.

🤖 Generated with [Claude Code](https://claude.com/claude-code)