### PR TITLE
fix(att-1): stabilize fol_inconsistent floater via deterministic formula injection (#1355)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -908,7 +908,19 @@ class TestInvokeCallables:
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             return_value=mock_bridge,
         ):
-            result = await _invoke_fol_reasoning("text", {})
+            # Inject a real FOL formula via the upstream ``formulas`` context
+            # channel so the test exercises the bridge-inconsistent contract
+            # deterministically. Without this, the trivial ``"text"`` input is
+            # too short to trigger the 2-pass generator (len <= 100 gate) and
+            # falls back to ``NLToLogicTranslator`` — a real, non-mocked LLM
+            # call that intermittently yields an empty belief set, which the
+            # fail-loud guard returns as ``consistent=None`` (#1278/#1019),
+            # surfacing as a flaky ``assert None is False``. Supplying the
+            # formula upstream makes ``NLToLogicTranslator`` unreachable, so
+            # the mocked bridge decides the verdict every run.
+            result = await _invoke_fol_reasoning(
+                "text", {"formulas": ["forall X: P(X)"]}
+            )
         assert result["consistent"] is False
         assert result["confidence"] == 0.4
 


### PR DESCRIPTION
## What & why

`test_invoke_fol_reasoning_inconsistent` is a rotating ATT-1 floater: it **FAILED in main run `28886613831`** (`assert None is False`) but **PASSED in #1420 GREEN run `28893501286`** — classic LLM non-determinism, not a regression.

### Root cause (characterized firsthand)
The test fed the trivial NL input `"text"` to `_invoke_fol_reasoning` while mocking **only** `TweetyBridge`. Trace:
- `"text"` (4 chars) is below the `len > 100` gate (`invoke_callables.py:5530`) → 2-pass generator skipped.
- Falls back to `NLToLogicTranslator.translate_batch(["argument_placeholder"])` (`invoke_callables.py:5682`) — a **real, non-mocked LLM call**.
- When that call intermittently produces no valid formula, `formulas` stays empty → the fail-loud guard returns `consistent=None` (`invoke_callables.py:5736`, #1278/#1019) → `assert None is False` fails.

The production guard is **correct** (#1278/#1019 fail-loud on empty belief set). The defect is a **non-hermetic test input**.

## Fix (anti-pendulum #1019)

Inject a real FOL formula via the upstream `context["formulas"]` channel (union at `invoke_callables.py:5463`). With formulas non-empty, the `NLToLogicTranslator` fallback (`:5676 if not formulas`) is unreachable and the empty-belief-set early-return (`:5736`) is skipped → the **mocked bridge decides the verdict every run**. The test now deterministically exercises the bridge-inconsistent contract (`consistent=False`, `confidence=0.4`) with zero LLM dependency.

No code change — test-only. No assertion weakened, no skip/xfly added.

## Verification
- Targeted: `test_invoke_fol_reasoning_inconsistent` + `test_invoke_fol_reasoning_success` → **2/2 pass**
- Regression guard: full `TestInvokeCallables` → **27/27 pass, 0 regressions**
- mypy strict: N/A (test file, outside the 8-file CI gate scope)

## Related
- Epic #1355 (ATT-1 floater stabilization). Sibling floaters fixed in #1420 (run_cell, request_response dual-clock race, cluedo); residual `test_invoke_fact_extraction_short_text` documented in #1423.
- Read-body-before-action: full `_invoke_fol_reasoning` impl + both sibling tests + `_extract_arguments_from_context` read before fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)