### PR TITLE
fix(att-3): restitution polish — famille-inconnu leak + Dung opaque-ID wall (#1421)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from .readability_gate import GateVerdict, ReadabilityGate
@@ -56,6 +57,73 @@ _DEBATE_MAX_EXCHANGES = 6
 # content — safe to surface). The reserved theme for arguments no fallacy
 # targets — the claims that hold.
 _SOUTIENS_THEME = "soutiens"
+
+# Honest label for a fallacy the LLM named but that resolves to no taxonomy node
+# (#1421-1). ``inconnu`` read as a bug; ``hors taxonomie`` says the truth — the
+# LLM named a fallacy absent from our tree — without inventing a family.
+_HORS_TAXONOMIE = "hors taxonomie"
+
+# Lazy cache: lowercase fallacy name (``nom_vulgarisé`` / ``text_fr``) → ``Famille``
+# from the taxonomy CSV. Used ONLY to reconcile LLM-named fallacies whose
+# ``family`` arrived empty (defect #1421-1) — never to override an explicit one.
+_TAXONOMY_NAME_TO_FAMILY: Optional[Dict[str, str]] = None
+
+
+def _load_name_to_family() -> Dict[str, str]:
+    """Lazy-load a name→family map from the taxonomy CSV (lightweight, no JVM).
+
+    Maps every ``nom_vulgarisé`` and ``text_fr`` (lowercased) to its ``Famille``.
+    Failure to load is non-fatal: the reconciler then falls back to
+    ``hors taxonomie`` (honest absence), never a fabricated family (#1019).
+    """
+    global _TAXONOMY_NAME_TO_FAMILY
+    if _TAXONOMY_NAME_TO_FAMILY is not None:
+        return _TAXONOMY_NAME_TO_FAMILY
+    mapping: Dict[str, str] = {}
+    try:
+        import csv
+
+        csv_path = (
+            Path(__file__).resolve().parents[2] / "data" / "taxonomy_full.csv"
+        )
+        if csv_path.is_file():
+            with csv_path.open(newline="", encoding="utf-8") as fh:
+                for row in csv.DictReader(fh):
+                    famille = (row.get("Famille") or "").strip()
+                    if not famille:
+                        continue
+                    for key in ("nom_vulgarisé", "text_fr"):
+                        name = (row.get(key) or "").strip().lower()
+                        if name and name not in mapping:
+                            mapping[name] = famille
+    except Exception as exc:  # noqa: BLE001 — non-fatal, honest-absent fallback
+        logger.debug("taxonomy name→family map unavailable: %s", exc)
+    _TAXONOMY_NAME_TO_FAMILY = mapping
+    return mapping
+
+
+def _reconcile_family(fdata: Dict[str, Any]) -> str:
+    """Resolve a fallacy's family, honest about gaps (#1421-1).
+
+    Order: explicit non-empty ``family`` → name→taxonomy match on ``type`` →
+    ``hors taxonomie``. Never invents a family; ``hors taxonomie`` labels the
+    real gap (the LLM named a fallacy absent from our tree), unlike ``inconnu``
+    which reads as a bug. Anti-pendulum #1019: the label is surfaced, not hidden.
+    """
+    fam = str(fdata.get("family", "") or "").strip()
+    if fam and fam.lower() != "inconnu":
+        return fam
+    name = str(fdata.get("type", "") or "").strip().lower()
+    if name:
+        mapping = _load_name_to_family()
+        # exact then substring: ``type`` may be « ad hominem circonstanciel »
+        # while the CSV holds « ad hominem ».
+        if name in mapping:
+            return mapping[name]
+        for csv_name, famille in mapping.items():
+            if csv_name and (name in csv_name or csv_name in name):
+                return famille
+    return _HORS_TAXONOMIE
 
 
 # --- evidence dataclasses ----------------------------------------------------
@@ -487,7 +555,7 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
         fallacy_by_arg.setdefault(tid, []).append(
             FallacyEvidence(
                 fallacy_id=str(_fid),
-                family=str(fdata.get("family", "inconnu")),
+                family=_reconcile_family(fdata),
                 type=str(fdata.get("type", "inconnu")),
                 taxonomy_path=str(fdata.get("taxonomy_path", "")),
                 justification=_truncate(
@@ -534,7 +602,7 @@ def build_act2_evidence(state: Any) -> Act2Evidence:
         flist = fallacy_by_arg.get(arg_id, [])
         if flist:
             families = sorted({f.family for f in flist if f.family})
-            key = families[0] if families else "inconnu"
+            key = families[0] if families else _HORS_TAXONOMIE
         else:
             key = _SOUTIENS_THEME
         movement_key_by_arg[arg_id] = key
@@ -902,13 +970,32 @@ def _collect_formal_findings(state: Any) -> List[FormalFinding]:
             f"extension {dung_trace.semantics_label} : {n_acc} retenu(s), "
             f"{n_rej} rejeté(s) (absents de l'extension acceptée)."
         )
-        accepted_preview = ", ".join(sorted(dung_trace.accepted_members)[:6]) or "—"
-        attacks_preview = "; ".join(f"{p[0]}→{p[1]}" for p in dung_trace.sample_attacks)
+        # #1421-2: render the Dung detail with OPAQUE arg_ids only (FB-34). The
+        # upstream usually stores opaque ids in ``accepted_members``, but real
+        # corpora can leak full position descriptions there — keep only canonical
+        # arg_ids (from ``identified_arguments``) so the detail never dumps
+        # position text. ``rejected_args`` already maps opaque arg_id → label.
+        # The verdict carries the counts; the detail carries the IDs + attacks.
+        known_arg_ids = set(
+            getattr(state, "identified_arguments", {}) or {}
+        )
+        accepted_opaque = sorted(
+            m for m in dung_trace.accepted_members if m in known_arg_ids
+        )[:6]
+        rejected_opaque = sorted(dung_trace.rejected_args.keys())[:4]
+        attacks_opaque = "; ".join(
+            f"{p[0]}→{p[1]}" for p in dung_trace.sample_attacks
+        )
+        detail_parts = [
+            f"extension {dung_trace.semantics_label}",
+            f"acceptés [{', '.join(accepted_opaque) or '—'}]",
+        ]
+        if rejected_opaque:
+            detail_parts.append(f"rejetés [{', '.join(rejected_opaque)}]")
+        detail_parts.append(f"attaques clés : {attacks_opaque or '—'}")
         detail = (
             f"cadre abstrait de Dung bâti à partir des arguments extraits "
-            f"(PAS un oracle externe indépendant) — acceptés: [{accepted_preview}] ; "
-            f"attaques échantillonnées: {attacks_preview or '—'} ; "
-            f"sémantique(s): {', '.join(sems)}."
+            f"(PAS un oracle externe indépendant) — {' ; '.join(detail_parts)}."
         )
         findings.append(FormalFinding(kind="dung", verdict=verdict, detail=detail))
 

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
@@ -905,3 +905,125 @@ class TestGovernanceJargonLeakRegression:
         prompt = build_act2_prompt(ev)
         assert "fb-34" in prompt.lower()
         assert "déanonymise aucune source" in prompt.lower()
+
+
+# ============================================================================
+# ATT-3 restitution polish — #1421 (famille-inconnu leak + Dung opaque-ID wall)
+# ============================================================================
+
+
+class TestAtt3RestitutionPolish1421:
+    """Defect 1 (famille inconnu) + Defect 2 (Dung opaque-ID wall) — #1421."""
+
+    def test_reconcile_family_keeps_explicit_family(self):
+        """An explicit non-empty family is never overridden."""
+        from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+            _reconcile_family,
+        )
+
+        assert _reconcile_family({"family": "ad hominem", "type": "x"}) == "ad hominem"
+
+    def test_reconcile_family_resolvable_name_uses_taxonomy(self):
+        """An empty family with a name present in the taxonomy CSV recovers its
+        family (option 1 — reconcile by name, fixes the cause)."""
+        from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+            _reconcile_family,
+        )
+
+        # « généralisation hâtive » is a taxonomy node under « Insuffisance ».
+        fam = _reconcile_family({"family": "", "type": "généralisation hâtive"})
+        assert fam  # resolvable → real family, NOT hors taxonomie
+        assert fam.lower() != "inconnu"
+
+    def test_reconcile_family_unresolvable_labels_hors_taxonomie(self):
+        """An empty family with a name absent from the taxonomy is labelled
+        « hors taxonomie » (the honest gap), NEVER « inconnu » (#1421-1)."""
+        from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+            _HORS_TAXONOMIE,
+            _reconcile_family,
+        )
+
+        fam = _reconcile_family({"family": "", "type": "Sophisme totalement inventé 42"})
+        assert fam == _HORS_TAXONOMIE
+        assert fam.lower() != "inconnu"
+
+    def test_reconcile_family_legacy_inconnu_is_reconciled(self):
+        """A legacy ``family == "inconnu"`` is treated as empty and reconciled
+        (not propagated as the buggy label)."""
+        from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+            _HORS_TAXONOMIE,
+            _reconcile_family,
+        )
+
+        fam = _reconcile_family({"family": "inconnu", "type": "inexistant"})
+        assert fam == _HORS_TAXONOMIE  # unresolvable → honest label
+
+    def test_evidence_no_famille_inconnu_in_rendered_families(self):
+        """End-to-end: an unresolved LLM-named fallacy surfaces « hors taxonomie »
+        in the built evidence, never « inconnu »."""
+        state = _state(
+            identified_arguments={"arg_1": "Un argument attaqué."},
+            identified_fallacies={
+                "fl_1": {
+                    "target_argument_id": "arg_1",
+                    "family": "",  # unresolved → was « inconnu », now « hors taxonomie »
+                    "type": "Sophisme bidon inexistant",
+                    "taxonomy_path": "",
+                    "justification": "Justification.",
+                }
+            },
+        )
+        ev = build_act2_evidence(state)
+        families = {
+            f.family for mvt in ev.movements for arg in mvt.arguments for f in arg.fallacies
+        }
+        assert "inconnu" not in families
+        assert any(f.lower() == "hors taxonomie" for f in families)
+        # The movement theme itself is the honest label, not « inconnu ».
+        themes = {mvt.theme for mvt in ev.movements}
+        assert "inconnu" not in themes
+
+    def test_dung_detail_no_position_text_leak(self):
+        """Defect 2: when ``accepted_members`` leaks full position descriptions
+        (real-corpus case), the rendered Dung detail must NOT echo any position
+        text — only opaque arg_ids + counts + key attacks (FB-34, #1421-2)."""
+        from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+            _collect_formal_findings,
+        )
+
+        leak_text = "Position text one (long description that should NOT appear)."
+        state = _state(
+            identified_arguments={
+                "arg_1": leak_text,
+                "arg_2": "Position text two.",
+            },
+            dung_frameworks={
+                "fw_1": {
+                    "name": "verification_preferred",
+                    "arguments": ["arg_1", "arg_2"],
+                    "attacks": [["arg_2", "arg_1"]],
+                    # LEAK: descriptions instead of opaque ids
+                    "extensions": {"all_members": [leak_text, "Position text two."]},
+                }
+            },
+        )
+        findings = _collect_formal_findings(state)
+        dung = next((f for f in findings if f.kind == "dung"), None)
+        assert dung is not None
+        # No position text leaks into the detail.
+        assert "Position text" not in dung.detail
+        assert "should NOT appear" not in dung.detail
+        # Opaque rejected ids + attacks are still surfaced.
+        assert "arg_" in dung.detail
+
+    def test_dung_detail_renders_opaque_ids_when_clean(self):
+        """When ``accepted_members`` stores canonical opaque ids (nominal case),
+        the detail lists them — the fix must not regress the clean path."""
+        ev = build_act2_evidence(_rich_state())
+        dung = next((f for f in ev.formal_findings if f.kind == "dung"), None)
+        assert dung is not None
+        # arg_2 is accepted in _rich_state; it must appear (opaque id rendered).
+        assert "arg_2" in dung.detail
+        # The honest framing is preserved.
+        assert "oracle externe" in dung.detail.lower()
+


### PR DESCRIPTION
## What & why

ATT-3 restitution polish, dispatched by coord R564 (issue #1421). Two reader-facing rendering defects in `reporting/restitution/act2_narrative_plugin.py`, both judged firsthand by ai-01 on the 3 real corpus texts (gate=PASS ×3, but readability/honesty degraded).

### Défaut 1 — `(famille inconnu)` leak (:490, :537)
LLM-named fallacies that resolve to no taxonomy node arrived with `family=""` → defaulted to `"inconnu"`, surfacing 4× (corpus_A) / 1× (corpus_B) in the Acte II prose as `« <name> » (famille inconnu)` — which reads as a bug.

**Fix (option 1, preferred):** reconcile the family by matching the fallacy `type` (FR name) against the taxonomy CSV (`nom_vulgarisé`/`text_fr` → `Famille`) via a lazy-cached module-level mapper `_load_name_to_family()`. When unresolvable, label honestly **`hors taxonomie`** (the LLM named a fallacy absent from our tree) instead of `inconnu`. The honest label is surfaced, never hidden — no default family invented, no fallacy masked (anti-pendulum #1019).

### Défaut 2 — Dung opaque-ID wall (:905)
The Dung finding detail dumped `accepted_members` verbatim. The upstream usually stores opaque arg_ids there, but real corpora leak full position descriptions → a wall of text + an FB-34 breach (arg content instead of opaque id).

**Fix:** keep only canonical arg_ids (from `identified_arguments`) when rendering the detail; `rejected_args.keys()` (already opaque) + `sample_attacks` are listed alongside. When `accepted_members` leaks position text, the detail shows the opaque rejected ids + key attacks — never the position text.

## Anti-pendule (#1019)
Both fixes repair the **cause** (unresolved family; opaque-id discipline) without hiding honest gaps or inventing data. No label censored, no `xfail`, no position-text truncation that would preserve the FB-34 entorse. The label `inconnu` is gone because the gap is now correctly characterized, not because it was hidden.

## Verification
- `pytest test_act2_narrative_plugin.py` → **59 passed** (7 new tests for #1421)
- `pytest reporting/restitution/` → **256 passed**, 0 regression
- `mypy --strict act2_narrative_plugin.py` → **Success, no issues**
- Functional probe: family reconcile (resolvable → CSV family, unresolvable → `hors taxonomie`); Dung detail with leaked position text → **no position text in detail**, opaque ids + attacks rendered
- Final verification on real corpora = **ai-01-local** (non-délégable — `run_full_judgment.py` + firsthand judgment, gitignored artifacts)

## Files
- `argumentation_analysis/reporting/restitution/act2_narrative_plugin.py` (+101/-7) — `_HORS_TAXONOMIE` const, `_load_name_to_family()` lazy mapper, `_reconcile_family()` helper, Dung detail opaque-id normalization
- `tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py` (+122) — `TestAtt3RestitutionPolish1421` (7 tests)

Disjoint from po-2023 lanes (TR-2 = `orchestration/`). No deletion, no plaintext, privacy-opaque preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)