### PR TITLE
feat(orchestration): text→structured ASPIC+ translator (TR-2 #1425)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3223,6 +3223,29 @@ async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict[str, A
     """
     args = _extract_arguments_from_context(input_text, context)
 
+    # TR-2 #1425: when the caller supplied no genuine defeasible rules, derive
+    # them from the real text + extracted arguments (mirror TR-1 bipolar/ABA).
+    # The translator validates each premise→conclusion link against the real
+    # argument inventory — rules citing unknown ids are dropped, so an empty
+    # result keeps the honest absent_no_translator status (anti-théâtre #1019).
+    # Persisting into ``context["defeasible_rules"]`` lets
+    # _record_structured_arg_status label the axis "evaluated" via the existing
+    # has_genuine_input path. Caller-supplied rules are never overridden, and the
+    # honest-absent gate is not modified.
+    if not context.get("defeasible_rules"):
+        try:
+            from argumentation_analysis.orchestration.structured_arg_translator import (
+                translate_to_aspic_rules,
+            )
+
+            derived_rules = await translate_to_aspic_rules(input_text, args)
+            if derived_rules:
+                context["defeasible_rules"] = derived_rules
+        except Exception as e:
+            logger.info(
+                "ASPIC+ translator unavailable (%s); absent_no_translator.", e
+            )
+
     # Build meaningful rules from upstream data
     fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
     fallacies = (

--- a/argumentation_analysis/orchestration/structured_arg_translator.py
+++ b/argumentation_analysis/orchestration/structured_arg_translator.py
@@ -36,7 +36,7 @@ gitignored state artifacts.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple
 
 logger = logging.getLogger("UnifiedPipeline")
 
@@ -114,7 +114,7 @@ async def _llm_extract_relations(
             '{"supports": [{"source": "argN", "target": "argM", '
             '"rationale": "one short sentence"}]}'
         )
-    else:  # contraries
+    elif relation_kind == "contraries":
         task = (
             "Identify ASSUMPTIONS and their CONTRARIES among these arguments: an "
             "assumption is a premise taken on faith (arguable), and its contrary "
@@ -126,6 +126,21 @@ async def _llm_extract_relations(
             '{"contraries": [{"assumption": "argN", "contrary": "defeating sentence", '
             '"rationale": "one short sentence"}]}'
         )
+    elif relation_kind == "aspic_rules":
+        task = (
+            "Identify DEFEASIBLE INFERENCE rules among these arguments: a rule is "
+            "(premises, conclusion) where the premise argument(s) defeasibly lead "
+            "to — justify — the conclusion argument. Cite premises AND conclusion "
+            "by id; every id must be present in the inventory. Report a rule ONLY "
+            "when the text genuinely presents the premises as reasons for the "
+            "conclusion — do NOT connect unrelated arguments."
+        )
+        shape = (
+            '{"rules": [{"premises": ["argN"], "conclusion": "argM", '
+            '"rationale": "one short sentence"}]}'
+        )
+    else:
+        raise ValueError(f"unknown relation_kind: {relation_kind!r}")
 
     system_content = (
         "You are an expert in formal argumentation theory. "
@@ -214,6 +229,67 @@ def _validate_contraries(
     return out
 
 
+def _validate_aspic_rules(
+    data: Dict[str, Any],
+    arg_by_id: Dict[str, str],
+    atom_fn: Callable[..., str],
+) -> List[Dict[str, Any]]:
+    """Validate LLM defeasible-rule proposals against the real inventory.
+
+    A genuine defeasible rule links real arguments: the conclusion id **and every
+    premise id** must be in the inventory (a rule citing any absent id is a
+    fabricated relation → the whole rule is dropped, anti-théâtre #1019), and at
+    least one premise must remain after removing any premise equal to the
+    conclusion (a rule concluding one of its own premises is vacuous).
+
+    Ids are mapped to canonical argument text, then to stable PL atoms via
+    ``atom_fn``. All argument atoms share the ``arg`` prefix so that an argument
+    used as a conclusion of one rule and as a premise of another maps to the SAME
+    atom — genuine ASPIC+ rule chaining. Returns handler-shaped
+    ``{head, body, name}`` dicts. Dedup on ``(head, frozenset(body))``.
+    """
+    raw = data.get("rules", []) if isinstance(data, dict) else []
+    if not isinstance(raw, list):
+        return []
+    seen: set[Tuple[str, frozenset[str]]] = set()
+    out: List[Dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        premises = item.get("premises", [])
+        if isinstance(premises, str):
+            premises = [premises]
+        if not isinstance(premises, list):
+            continue
+        concl_id = str(item.get("conclusion", "")).strip()
+        prem_ids = [str(p).strip() for p in premises]
+        # Every cited id must be real — a rule citing any unknown id is dropped
+        # wholesale (never salvaged into a partly-fabricated rule).
+        if concl_id not in arg_by_id:
+            continue
+        if not prem_ids or any(pid not in arg_by_id for pid in prem_ids):
+            continue
+        prem_ids = [pid for pid in prem_ids if pid != concl_id]
+        if not prem_ids:
+            continue  # only premise was the conclusion itself → vacuous
+        head_atom = atom_fn(arg_by_id[concl_id], prefix="arg")
+        body_atoms: List[str] = []
+        body_seen: set[str] = set()
+        for pid in prem_ids:
+            a = atom_fn(arg_by_id[pid], prefix="arg")
+            if a not in body_seen:
+                body_seen.add(a)
+                body_atoms.append(a)
+        key = (head_atom, frozenset(body_atoms))
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(
+            {"head": head_atom, "body": body_atoms, "name": f"def_rule_{len(out) + 1}"}
+        )
+    return out
+
+
 async def translate_to_bipolar_supports(
     input_text: str, arguments: List[str]
 ) -> List[List[str]]:
@@ -273,10 +349,53 @@ async def translate_to_aba_contraries(
     return contraries
 
 
+async def translate_to_aspic_rules(
+    input_text: str, arguments: List[str]
+) -> List[Dict[str, Any]]:
+    """Derive genuine ASPIC+ defeasible inference rules from the text + arguments.
+
+    Returns a list of handler-shaped ``{head, body, name}`` rule dicts with
+    PL-atom heads/bodies, validated against the real inventory. Empty list when
+    the LLM finds no genuine rules OR no API key is configured — the caller then
+    stays ``absent_no_translator`` (honest absence, anti-théâtre #1019).
+
+    Only **defeasible** rules are derived: natural-language argumentation is
+    defeasible, and strict rules / preference orderings are not reliably
+    extractable from prose (they stay auto-shaped, honestly not a genuine strict
+    layer). Feeding genuine defeasible rules is sufficient to flip the
+    honest-absent gate to ``evaluated`` — ``_STRUCTURED_ARG_INPUT_KEYS[
+    'aspic_plus_reasoning']`` accepts ``defeasible_rules``. The gate itself is
+    never modified.
+    """
+    arg_by_id, _ = _build_inventory(arguments)
+    if not arg_by_id:
+        return []
+    try:
+        data = await _llm_extract_relations(input_text, arguments, "aspic_rules")
+    except Exception as e:  # network / parse / budget — never fatal to the run
+        logger.info(
+            "ASPIC+ rules translator failed (%s) — staying absent_no_translator.",
+            e,
+        )
+        return []
+    # _pl_atom lives in invoke_callables (lazy import — no module-load cycle).
+    from argumentation_analysis.orchestration.invoke_callables import _pl_atom
+
+    rules = _validate_aspic_rules(data, arg_by_id, _pl_atom)
+    if rules:
+        logger.info(
+            "ASPIC+ translator: derived %d genuine defeasible rule(s) from text.",
+            len(rules),
+        )
+    return rules
+
+
 __all__ = [
     "translate_to_bipolar_supports",
     "translate_to_aba_contraries",
+    "translate_to_aspic_rules",
     "_build_inventory",
     "_validate_supports",
     "_validate_contraries",
+    "_validate_aspic_rules",
 ]

--- a/tests/unit/argumentation_analysis/orchestration/test_structured_arg_translator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_structured_arg_translator.py
@@ -21,11 +21,18 @@ import pytest
 
 from argumentation_analysis.orchestration.structured_arg_translator import (
     _build_inventory,
+    _validate_aspic_rules,
     _validate_contraries,
     _validate_supports,
     translate_to_aba_contraries,
+    translate_to_aspic_rules,
     translate_to_bipolar_supports,
 )
+
+
+def _atom(text: str, prefix: str = "arg") -> str:
+    """Trivial deterministic atom_fn for validation tests (no _pl_atom import)."""
+    return f"{prefix}:{text}"
 
 
 # -- _build_inventory --------------------------------------------------------
@@ -341,3 +348,220 @@ class TestHandlerWiringPersistsToContext:
         ctx: Dict[str, Any] = {"arguments": ["Alpha", "Beta"]}
         await _invoke_bipolar("text", ctx)
         assert "supports" not in ctx
+
+
+# -- TR-2 #1425: ASPIC+ defeasible-rule translator ---------------------------
+
+
+class TestValidateAspicRules:
+    def test_keeps_valid_rule_mapped_to_atoms(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta", "arg3": "Gamma"}
+        data = {"rules": [
+            {"premises": ["arg1", "arg2"], "conclusion": "arg3", "rationale": "r"},
+        ]}
+        out = _validate_aspic_rules(data, arg_by_id, _atom)
+        assert out == [
+            {
+                "head": "arg:Gamma",
+                "body": ["arg:Alpha", "arg:Beta"],
+                "name": "def_rule_1",
+            }
+        ]
+
+    def test_drops_rule_with_unknown_premise(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"rules": [
+            {"premises": ["arg1", "arg9"], "conclusion": "arg2"},  # arg9 unknown
+        ]}
+        assert _validate_aspic_rules(data, arg_by_id, _atom) == []
+
+    def test_drops_rule_with_unknown_conclusion(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"rules": [
+            {"premises": ["arg1"], "conclusion": "arg9"},  # unknown conclusion
+        ]}
+        assert _validate_aspic_rules(data, arg_by_id, _atom) == []
+
+    def test_drops_rule_with_no_premises(self):
+        arg_by_id = {"arg1": "Alpha"}
+        data = {"rules": [{"premises": [], "conclusion": "arg1"}]}
+        assert _validate_aspic_rules(data, arg_by_id, _atom) == []
+
+    def test_removes_conclusion_from_premises_keeps_rest(self):
+        arg_by_id = {"arg1": "Alpha", "arg3": "Gamma"}
+        data = {"rules": [
+            {"premises": ["arg1", "arg3"], "conclusion": "arg3"},  # arg3 dropped
+        ]}
+        out = _validate_aspic_rules(data, arg_by_id, _atom)
+        assert out == [
+            {"head": "arg:Gamma", "body": ["arg:Alpha"], "name": "def_rule_1"}
+        ]
+
+    def test_drops_self_only_rule(self):
+        arg_by_id = {"arg3": "Gamma"}
+        data = {"rules": [{"premises": ["arg3"], "conclusion": "arg3"}]}
+        assert _validate_aspic_rules(data, arg_by_id, _atom) == []
+
+    def test_dedups_identical_rules(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"rules": [
+            {"premises": ["arg1"], "conclusion": "arg2"},
+            {"premises": ["arg1"], "conclusion": "arg2"},
+        ]}
+        out = _validate_aspic_rules(data, arg_by_id, _atom)
+        assert out == [
+            {"head": "arg:Beta", "body": ["arg:Alpha"], "name": "def_rule_1"}
+        ]
+
+    def test_dedups_repeated_body_atoms(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"rules": [
+            {"premises": ["arg1", "arg1"], "conclusion": "arg2"},
+        ]}
+        out = _validate_aspic_rules(data, arg_by_id, _atom)
+        assert out[0]["body"] == ["arg:Alpha"]
+
+    def test_premises_as_string_normalized(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"rules": [{"premises": "arg1", "conclusion": "arg2"}]}
+        out = _validate_aspic_rules(data, arg_by_id, _atom)
+        assert out == [
+            {"head": "arg:Beta", "body": ["arg:Alpha"], "name": "def_rule_1"}
+        ]
+
+    def test_empty_or_malformed_returns_empty(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        assert _validate_aspic_rules({}, arg_by_id, _atom) == []
+        assert _validate_aspic_rules({"rules": []}, arg_by_id, _atom) == []
+        assert _validate_aspic_rules({"rules": "nope"}, arg_by_id, _atom) == []
+        assert _validate_aspic_rules(
+            {"rules": [{"premises": 1, "conclusion": "arg1"}]},  # type: ignore[dict-item]
+            arg_by_id,
+            _atom,
+        ) == []
+
+
+class TestAspicTranslator:
+    async def test_empty_llm_output_returns_empty(self, monkeypatch):
+        _patch_llm(monkeypatch, {"rules": []})
+        out = await translate_to_aspic_rules("some text", ["a", "b"])
+        assert out == []
+
+    async def test_no_inventory_returns_empty(self, monkeypatch):
+        _patch_llm(monkeypatch, {"rules": [
+            {"premises": ["arg1"], "conclusion": "arg2"},
+        ]})
+        out = await translate_to_aspic_rules("text", [])
+        assert out == []
+
+    async def test_only_fabricated_rules_dropped(self, monkeypatch):
+        _patch_llm(monkeypatch, {"rules": [
+            {"premises": ["arg8"], "conclusion": "arg9"},   # unknown ids
+            {"premises": ["phantom"], "conclusion": "ghost"},
+        ]})
+        out = await translate_to_aspic_rules("text", ["a", "b"])
+        assert out == []
+
+    async def test_returns_validated_rules_with_real_atoms(self, monkeypatch):
+        # Uses the real _pl_atom; assert head/body are the deterministic atoms
+        # for the cited canonical argument texts.
+        from argumentation_analysis.orchestration.invoke_callables import _pl_atom
+
+        _patch_llm(monkeypatch, {"rules": [
+            {"premises": ["arg1", "arg2"], "conclusion": "arg3"},
+            {"premises": ["arg1"], "conclusion": "arg9"},  # dropped (unknown)
+        ]})
+        out = await translate_to_aspic_rules("text", ["Alpha", "Beta", "Gamma"])
+        assert len(out) == 1
+        assert out[0]["head"] == _pl_atom("Gamma", prefix="arg")
+        assert out[0]["body"] == [
+            _pl_atom("Alpha", prefix="arg"),
+            _pl_atom("Beta", prefix="arg"),
+        ]
+        assert out[0]["name"] == "def_rule_1"
+
+
+def _inject_fake_aspic_module(monkeypatch, payload):
+    """Inject a fake ASPICHandler so _invoke_aspic runs without a JVM."""
+    fake = types.ModuleType("argumentation_analysis.agents.core.logic.aspic_handler")
+
+    class _FakeASPICHandler:
+        def analyze_aspic_framework(self, strict, defeasible, axioms=None):
+            return payload
+
+    fake.ASPICHandler = _FakeASPICHandler  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "argumentation_analysis.agents.core.logic.aspic_handler",
+        fake,
+    )
+
+
+class TestAspicHandlerWiring:
+    """The lazy translator call inside _invoke_aspic must persist genuine
+    defeasible rules into ``context`` so _record_structured_arg_status labels the
+    axis ``evaluated`` — and must stay absent when nothing genuine is derived."""
+
+    async def test_translates_and_persists_defeasible_rules(self, monkeypatch):
+        _inject_fake_aspic_module(monkeypatch, {"extensions": []})
+        genuine = [{"head": "arg:h", "body": ["arg:b"], "name": "def_rule_1"}]
+
+        async def _fake_rules(text, args):
+            return genuine
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_aspic_rules",
+            _fake_rules,
+        )
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_aspic
+
+        ctx: Dict[str, Any] = {
+            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
+        }
+        await _invoke_aspic("source text", ctx)
+        assert ctx.get("defeasible_rules") == genuine
+
+    async def test_does_not_override_caller_supplied_rules(self, monkeypatch):
+        called = {"n": 0}
+
+        async def _fake_rules(text, args):
+            called["n"] += 1
+            return [{"head": "arg:x", "body": ["arg:y"], "name": "should_not_be_used"}]
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_aspic_rules",
+            _fake_rules,
+        )
+        _inject_fake_aspic_module(monkeypatch, {"extensions": []})
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_aspic
+
+        genuine = [{"head": "arg:real", "body": ["arg:prem"], "name": "def_rule_1"}]
+        ctx: Dict[str, Any] = {
+            "phase_extract_output": {"arguments": ["Alpha", "Beta"]},
+            "defeasible_rules": genuine,
+        }
+        await _invoke_aspic("text", ctx)
+        assert ctx["defeasible_rules"] is genuine  # unchanged
+        assert called["n"] == 0  # translator never invoked
+
+    async def test_honest_absent_when_translator_returns_empty(self, monkeypatch):
+        _inject_fake_aspic_module(monkeypatch, {"extensions": []})
+
+        async def _fake_rules(text, args):
+            return []
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_aspic_rules",
+            _fake_rules,
+        )
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_aspic
+
+        ctx: Dict[str, Any] = {
+            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
+        }
+        await _invoke_aspic("text", ctx)
+        # Nothing genuine → context key stays unset → gate keeps absent_no_translator.
+        assert "defeasible_rules" not in ctx


### PR DESCRIPTION
## Summary

First PR of the **TR-2 lane** (#1425, NORTH-STAR parametric integration): extend the TR-1 text→structured translator to **ASPIC+**. An LLM derives genuine **defeasible inference rules** (premises→conclusion, cited by id) from the real source text + already-extracted arguments, validated against the real inventory. Converts `aspic_plus_reasoning` from `absent_no_translator` → `evaluated` when the text yields genuine rules.

Mirrors the TR-1 pattern exactly (bipolar/ABA, #1419 → #1422 merged). **SetAF and weighted stay `absent_no_translator`** (handlers untouched) — they are the next two serial PRs of this lane.

> Lane reassigned to po-2025 by user arbitrage (po-2023 stalled ~30h with no TR-2 branch; coordinator silent). The 3 formalisms share the same 2 files, so the "1 PR per formalism" DoD is serialization by design (parallel = conflict).

## Changes

**`structured_arg_translator.py`**
- `_llm_extract_relations` gains an `"aspic_rules"` branch (defeasible-rule prompt + JSON shape `{"rules":[{"premises":["argN"],"conclusion":"argM"}]}`).
- `_validate_aspic_rules(data, arg_by_id, atom_fn)`: drops any rule citing an unknown id (conclusion **or** premise), drops self-only / empty-premise rules, maps ids → canonical text → stable PL atoms. All argument atoms share the `arg` prefix, so a conclusion of one rule and the same argument used as a premise of another map to the **same atom** = genuine ASPIC+ rule chaining. Dedups on `(head, frozenset(body))`.
- `translate_to_aspic_rules`: mirrors `translate_to_bipolar_supports`; empty / failed LLM → `[]` (honest absence). Only **defeasible** rules are derived (NL argumentation is defeasible; strict rules / preference orderings are not reliably extractable from prose and stay auto-shaped — honestly not a genuine strict layer).

**`invoke_callables.py`**
- `_invoke_aspic` calls the translator **lazily**, only when the caller supplied no `defeasible_rules`, and persists genuine rules into `context["defeasible_rules"]` so `_record_structured_arg_status` labels the axis `evaluated` via the existing `has_genuine_input` path. Caller-supplied rules are never overridden.

## Anti-théâtre HARD (#1019)

- Rules citing ids absent from the real inventory are **DROPPED**; if nothing valid remains the formalism **stays `absent_no_translator`** — an honest absence, never a fabricated evaluation.
- The honest-absent gate (`_STRUCTURED_ARG_INPUT_KEYS` / `_record_structured_arg_status` in `state_writers.py`) is **NOT modified** — `state_writers.py` is not in the diff. This PR only feeds the gate genuine input.
- No fabrication of rules/preferences: the code only drops, never invents.

## Validation (firsthand)

- **mypy strict** CI gate (8 core files incl. `invoke_callables.py`): `Success: no issues found in 8 source files`.
- **Tests**: 17 new (no JVM / no real LLM, synthetic opaque atoms) — validation drops fabricated/self/unknown-id rules + dedups; translator honest-absent on empty/failed LLM; handler wiring persists genuine rules, never overrides caller, stays absent when empty. **41 pass** in the translator file; **82 pass** across honest-absent + anti-theater + translator suites, 0 regressions.
- **Probe** (gitignored scratchpad, opaque synthetic args): genuine derived rule → gate flips to `evaluated` (degraded=False); empty derivation → stays `absent_no_translator` (degraded=True); a real (failing 401) LLM call is caught → honest-absent — proving the graceful-degradation contract on a real call.

End-to-end confirmation on the 3 real corpora in the spectacular snapshot remains coord-local (ai-01), as for TR-1.

Closes part of #1425 (ASPIC+ axis).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
