### PR TITLE
feat(orchestration): text→structured SetAF translator (TR-2 #1425)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3624,6 +3624,21 @@ async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict[str, A
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
     )
+    # Genuine SetAF joint-attacks: if the caller did not supply them, try to
+    # derive them from the text (validated by id). Never overrides a caller's
+    # explicit set; empty/failed derivation leaves the key unset so the handler
+    # honestly falls back to auto-shaped pairwise attacks.
+    if not context.get("set_attacks"):
+        try:
+            from argumentation_analysis.orchestration.structured_arg_translator import (
+                translate_to_setaf_attacks,
+            )
+
+            derived_attacks = await translate_to_setaf_attacks(input_text, args)
+            if derived_attacks:
+                context["set_attacks"] = derived_attacks
+        except Exception as e:
+            logger.info("SetAF translator unavailable (%s); absent_no_translator.", e)
     # SetAF attacks come as {attackers, target} dicts. Upstream may provide
     # them directly, else shape from the canonical pairwise attack graph.
     raw_attacks = context.get("set_attacks")

--- a/argumentation_analysis/orchestration/structured_arg_translator.py
+++ b/argumentation_analysis/orchestration/structured_arg_translator.py
@@ -139,6 +139,21 @@ async def _llm_extract_relations(
             '{"rules": [{"premises": ["argN"], "conclusion": "argM", '
             '"rationale": "one short sentence"}]}'
         )
+    elif relation_kind == "setaf_attacks":
+        task = (
+            "Identify SET (collective) ATTACKS among these arguments: a SetAF "
+            "attack is a SET of arguments that JOINTLY defeat a target argument "
+            "— no single attacker defeats it alone, but together they do (a "
+            "joint attack). Report an ordinary pairwise attack as a singleton "
+            "attacker set. Cite every attacker AND the target by id; every id "
+            "must be present in the inventory. Report an attack ONLY when the "
+            "text genuinely presents the attackers as undermining the target — "
+            "do NOT connect unrelated arguments."
+        )
+        shape = (
+            '{"attacks": [{"attackers": ["argN"], "target": "argM", '
+            '"rationale": "one short sentence"}]}'
+        )
     else:
         raise ValueError(f"unknown relation_kind: {relation_kind!r}")
 
@@ -290,6 +305,62 @@ def _validate_aspic_rules(
     return out
 
 
+def _validate_setaf_attacks(
+    data: Dict[str, Any], arg_by_id: Dict[str, str]
+) -> List[Dict[str, Any]]:
+    """Validate LLM SetAF joint-attack proposals against the real inventory.
+
+    A SetAF (Set Argumentation Framework) attack is collective: a SET of
+    arguments jointly attacks a target. The target id AND every attacker id must
+    be in the inventory — a joint-attack citing any absent id is dropped
+    wholesale (never salvaged into a partly-fabricated attack, anti-théâtre
+    #1019). The target is removed from the attacker set (self-attack is
+    vacuous), and the attack is dropped if no attacker remains. Ids are re-mapped
+    to canonical argument text so the framework connects real nodes. Returns
+    handler-shaped ``{attackers, target}`` dicts. Dedup on
+    ``(frozenset(attackers), target)``.
+    """
+    raw = data.get("attacks", []) if isinstance(data, dict) else []
+    if not isinstance(raw, list):
+        return []
+    seen: set[Tuple[frozenset[str], str]] = set()
+    out: List[Dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        attackers = item.get("attackers", [])
+        if isinstance(attackers, str):
+            attackers = [attackers]
+        if not isinstance(attackers, list):
+            continue
+        tgt_id = str(item.get("target", "")).strip()
+        atk_ids = [str(a).strip() for a in attackers]
+        # Target and every attacker must be real — any unknown id drops the
+        # whole joint-attack (never a partly-fabricated attacker set).
+        if tgt_id not in arg_by_id:
+            continue
+        if not atk_ids or any(aid not in arg_by_id for aid in atk_ids):
+            continue
+        atk_ids = [aid for aid in atk_ids if aid != tgt_id]
+        if not atk_ids:
+            continue  # only attacker was the target itself → vacuous self-attack
+        # Dedup attacker ids within the set (preserve first-seen order).
+        uniq_ids: List[str] = []
+        id_seen: set[str] = set()
+        for aid in atk_ids:
+            if aid not in id_seen:
+                id_seen.add(aid)
+                uniq_ids.append(aid)
+        atk_texts = [arg_by_id[aid] for aid in uniq_ids]
+        tgt_text = arg_by_id[tgt_id]
+        key = (frozenset(atk_texts), tgt_text)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append({"attackers": atk_texts, "target": tgt_text})
+    return out
+
+
 async def translate_to_bipolar_supports(
     input_text: str, arguments: List[str]
 ) -> List[List[str]]:
@@ -390,12 +461,46 @@ async def translate_to_aspic_rules(
     return rules
 
 
+async def translate_to_setaf_attacks(
+    input_text: str, arguments: List[str]
+) -> List[Dict[str, Any]]:
+    """Derive genuine SetAF joint attacks from the text + arguments.
+
+    Returns a list of handler-shaped ``{attackers, target}`` joint-attack dicts
+    (canonical argument texts), validated against the real inventory. Empty list
+    when the LLM finds no genuine joint attacks OR no API key is configured — the
+    caller then stays ``absent_no_translator`` (honest absence, anti-théâtre
+    #1019). The gate ``_STRUCTURED_ARG_INPUT_KEYS['setaf_reasoning']`` accepts
+    ``set_attacks``; the gate itself is never modified.
+    """
+    arg_by_id, _ = _build_inventory(arguments)
+    if not arg_by_id:
+        return []
+    try:
+        data = await _llm_extract_relations(input_text, arguments, "setaf_attacks")
+    except Exception as e:  # network / parse / budget — never fatal to the run
+        logger.info(
+            "SetAF attacks translator failed (%s) — staying absent_no_translator.",
+            e,
+        )
+        return []
+    attacks = _validate_setaf_attacks(data, arg_by_id)
+    if attacks:
+        logger.info(
+            "SetAF translator: derived %d genuine joint attack(s) from text.",
+            len(attacks),
+        )
+    return attacks
+
+
 __all__ = [
     "translate_to_bipolar_supports",
     "translate_to_aba_contraries",
     "translate_to_aspic_rules",
+    "translate_to_setaf_attacks",
     "_build_inventory",
     "_validate_supports",
     "_validate_contraries",
     "_validate_aspic_rules",
+    "_validate_setaf_attacks",
 ]

--- a/tests/unit/argumentation_analysis/orchestration/test_structured_arg_translator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_structured_arg_translator.py
@@ -23,10 +23,12 @@ from argumentation_analysis.orchestration.structured_arg_translator import (
     _build_inventory,
     _validate_aspic_rules,
     _validate_contraries,
+    _validate_setaf_attacks,
     _validate_supports,
     translate_to_aba_contraries,
     translate_to_aspic_rules,
     translate_to_bipolar_supports,
+    translate_to_setaf_attacks,
 )
 
 
@@ -565,3 +567,227 @@ class TestAspicHandlerWiring:
         await _invoke_aspic("text", ctx)
         # Nothing genuine → context key stays unset → gate keeps absent_no_translator.
         assert "defeasible_rules" not in ctx
+
+
+# -- SetAF (collective / joint attacks) --------------------------------------
+
+
+class TestValidateSetafAttacks:
+    def test_keeps_valid_joint_attack_mapped_to_text(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta", "arg3": "Gamma"}
+        data = {"attacks": [
+            {"attackers": ["arg1", "arg2"], "target": "arg3", "rationale": "r"},
+        ]}
+        out = _validate_setaf_attacks(data, arg_by_id)
+        assert out == [{"attackers": ["Alpha", "Beta"], "target": "Gamma"}]
+
+    def test_drops_attack_with_unknown_attacker(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [
+            {"attackers": ["arg1", "arg9"], "target": "arg2"},  # arg9 unknown
+        ]}
+        assert _validate_setaf_attacks(data, arg_by_id) == []
+
+    def test_drops_attack_with_unknown_target(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [
+            {"attackers": ["arg1"], "target": "arg9"},  # unknown target
+        ]}
+        assert _validate_setaf_attacks(data, arg_by_id) == []
+
+    def test_drops_attack_with_no_attackers(self):
+        arg_by_id = {"arg1": "Alpha"}
+        data = {"attacks": [{"attackers": [], "target": "arg1"}]}
+        assert _validate_setaf_attacks(data, arg_by_id) == []
+
+    def test_removes_target_from_attackers_keeps_rest(self):
+        arg_by_id = {"arg1": "Alpha", "arg3": "Gamma"}
+        data = {"attacks": [
+            {"attackers": ["arg1", "arg3"], "target": "arg3"},  # arg3 removed
+        ]}
+        out = _validate_setaf_attacks(data, arg_by_id)
+        assert out == [{"attackers": ["Alpha"], "target": "Gamma"}]
+
+    def test_drops_self_only_attack(self):
+        arg_by_id = {"arg3": "Gamma"}
+        data = {"attacks": [{"attackers": ["arg3"], "target": "arg3"}]}
+        assert _validate_setaf_attacks(data, arg_by_id) == []
+
+    def test_dedups_identical_attacks(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [
+            {"attackers": ["arg1"], "target": "arg2"},
+            {"attackers": ["arg1"], "target": "arg2"},
+        ]}
+        out = _validate_setaf_attacks(data, arg_by_id)
+        assert out == [{"attackers": ["Alpha"], "target": "Beta"}]
+
+    def test_dedups_repeated_attackers(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [
+            {"attackers": ["arg1", "arg1"], "target": "arg2"},
+        ]}
+        out = _validate_setaf_attacks(data, arg_by_id)
+        assert out[0]["attackers"] == ["Alpha"]
+
+    def test_dedups_attacker_order_independence(self):
+        # SetAF attacker set is a SET: {arg1,arg2} == {arg2,arg1} → one attack.
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta", "arg3": "Gamma"}
+        data = {"attacks": [
+            {"attackers": ["arg1", "arg2"], "target": "arg3"},
+            {"attackers": ["arg2", "arg1"], "target": "arg3"},
+        ]}
+        out = _validate_setaf_attacks(data, arg_by_id)
+        assert len(out) == 1
+
+    def test_attackers_as_string_normalized(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [{"attackers": "arg1", "target": "arg2"}]}
+        out = _validate_setaf_attacks(data, arg_by_id)
+        assert out == [{"attackers": ["Alpha"], "target": "Beta"}]
+
+    def test_empty_or_malformed_returns_empty(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        assert _validate_setaf_attacks({}, arg_by_id) == []
+        assert _validate_setaf_attacks({"attacks": []}, arg_by_id) == []
+        assert _validate_setaf_attacks({"attacks": "nope"}, arg_by_id) == []
+        assert _validate_setaf_attacks(
+            {"attacks": [{"attackers": 1, "target": "arg1"}]},  # type: ignore[dict-item]
+            arg_by_id,
+        ) == []
+
+
+class TestSetafTranslator:
+    async def test_empty_llm_output_returns_empty(self, monkeypatch):
+        _patch_llm(monkeypatch, {"attacks": []})
+        out = await translate_to_setaf_attacks("some text", ["a", "b"])
+        assert out == []
+
+    async def test_no_inventory_returns_empty(self, monkeypatch):
+        _patch_llm(monkeypatch, {"attacks": [
+            {"attackers": ["arg1"], "target": "arg2"},
+        ]})
+        out = await translate_to_setaf_attacks("text", [])
+        assert out == []
+
+    async def test_only_fabricated_attacks_dropped(self, monkeypatch):
+        _patch_llm(monkeypatch, {"attacks": [
+            {"attackers": ["arg8"], "target": "arg9"},   # unknown ids
+            {"attackers": ["phantom"], "target": "ghost"},
+        ]})
+        out = await translate_to_setaf_attacks("text", ["a", "b"])
+        assert out == []
+
+    async def test_returns_validated_attacks_with_real_texts(self, monkeypatch):
+        # SetAF attacks use canonical argument TEXTS (no PL-atom mapping).
+        _patch_llm(monkeypatch, {"attacks": [
+            {"attackers": ["arg1", "arg2"], "target": "arg3"},
+            {"attackers": ["arg1"], "target": "arg9"},  # dropped (unknown)
+        ]})
+        out = await translate_to_setaf_attacks("text", ["Alpha", "Beta", "Gamma"])
+        assert out == [{"attackers": ["Alpha", "Beta"], "target": "Gamma"}]
+
+
+def _inject_fake_setaf_module(monkeypatch, payload):
+    """Inject fake SetAFHandler + TweetyInitializer so _invoke_setaf runs w/o JVM."""
+    fake_handler = types.ModuleType(
+        "argumentation_analysis.agents.core.logic.setaf_handler"
+    )
+
+    class _FakeSetAFHandler:
+        def __init__(self, initializer: Any) -> None:
+            self.initializer = initializer
+
+        def analyze_setaf(self, args, attacks, semantics="grounded"):
+            return payload
+
+    fake_handler.SetAFHandler = _FakeSetAFHandler  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "argumentation_analysis.agents.core.logic.setaf_handler",
+        fake_handler,
+    )
+
+    fake_init = types.ModuleType(
+        "argumentation_analysis.agents.core.logic.tweety_initializer"
+    )
+
+    class _FakeTweetyInitializer:
+        pass
+
+    fake_init.TweetyInitializer = _FakeTweetyInitializer  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "argumentation_analysis.agents.core.logic.tweety_initializer",
+        fake_init,
+    )
+
+
+class TestSetafHandlerWiring:
+    """The lazy translator call inside _invoke_setaf must persist genuine joint
+    attacks into ``context`` so _record_structured_arg_status labels the axis
+    ``evaluated`` — and must stay absent when nothing genuine is derived."""
+
+    async def test_translates_and_persists_joint_attacks(self, monkeypatch):
+        _inject_fake_setaf_module(monkeypatch, {"extensions": []})
+        genuine = [{"attackers": ["Alpha"], "target": "Beta"}]
+
+        async def _fake_attacks(text, args):
+            return genuine
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_setaf_attacks",
+            _fake_attacks,
+        )
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_setaf
+
+        ctx: Dict[str, Any] = {
+            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
+        }
+        await _invoke_setaf("source text", ctx)
+        assert ctx.get("set_attacks") == genuine
+
+    async def test_does_not_override_caller_supplied_attacks(self, monkeypatch):
+        called = {"n": 0}
+
+        async def _fake_attacks(text, args):
+            called["n"] += 1
+            return [{"attackers": ["x"], "target": "should_not_be_used"}]
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_setaf_attacks",
+            _fake_attacks,
+        )
+        _inject_fake_setaf_module(monkeypatch, {"extensions": []})
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_setaf
+
+        genuine = [{"attackers": ["Alpha"], "target": "Beta"}]
+        ctx: Dict[str, Any] = {
+            "phase_extract_output": {"arguments": ["Alpha", "Beta"]},
+            "set_attacks": genuine,
+        }
+        await _invoke_setaf("text", ctx)
+        assert ctx["set_attacks"] is genuine  # unchanged
+        assert called["n"] == 0  # translator never invoked
+
+    async def test_honest_absent_when_translator_returns_empty(self, monkeypatch):
+        _inject_fake_setaf_module(monkeypatch, {"extensions": []})
+
+        async def _fake_attacks(text, args):
+            return []
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_setaf_attacks",
+            _fake_attacks,
+        )
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_setaf
+
+        ctx: Dict[str, Any] = {
+            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
+        }
+        await _invoke_setaf("text", ctx)
+        # Nothing genuine → context key stays unset → gate keeps absent_no_translator.
+        assert "set_attacks" not in ctx


### PR DESCRIPTION
## Summary

Second PR of the **TR-2 lane** (#1425, NORTH-STAR parametric integration), following #1427 (ASPIC+, merged): extend the text→structured translator to **SetAF** (Set Argumentation Frameworks). An LLM derives genuine **collective (joint) attacks** — a SET of arguments that together defeat a target — from the real source text + already-extracted arguments, validated against the real inventory. Converts `setaf_reasoning` from `absent_no_translator` → `evaluated` when the text yields genuine joint attacks.

Mirrors the TR-1/ASPIC+ pattern exactly. **weighted stays `absent_no_translator`** (handler untouched) — it is the last serial PR of this lane.

## Changes

**`structured_arg_translator.py`**
- `_llm_extract_relations` gains a `"setaf_attacks"` branch (joint-attack prompt + JSON shape `{"attacks":[{"attackers":["argN"],"target":"argM"}]}`; ordinary pairwise attacks surface as singleton attacker sets).
- `_validate_setaf_attacks(data, arg_by_id)`: drops a joint-attack citing any unknown id (target **or** any attacker — dropped wholesale, never salvaged into a partly-fabricated attacker set), removes the target from the attacker set (self-attack is vacuous) and drops the attack if no attacker remains, dedups attacker ids within a set, re-maps ids → canonical argument **text** (SetAF nodes are argument names), dedups on `(frozenset(attackers), target)` so attacker **order is irrelevant** (a set, not a list).
- `translate_to_setaf_attacks`: mirrors `translate_to_aspic_rules`; empty / failed LLM → `[]` (honest absence).

**`invoke_callables.py`**
- `_invoke_setaf` calls the translator **lazily**, only when the caller supplied no `set_attacks`, and persists genuine joint-attacks into `context["set_attacks"]` — the existing `isinstance(raw_attacks[0], dict)` path then feeds them to `analyze_setaf`, and `_record_structured_arg_status` labels the axis `evaluated` via the existing `has_genuine_input` path. Caller-supplied attacks are never overridden.

## Anti-théâtre HARD (#1019)

- Joint-attacks citing ids absent from the real inventory are **DROPPED**; if nothing valid remains the formalism **stays `absent_no_translator`** — an honest absence, never a fabricated evaluation.
- The honest-absent gate (`_STRUCTURED_ARG_INPUT_KEYS` / `_record_structured_arg_status` in `state_writers.py`) is **NOT modified** — `state_writers.py` is not in the diff. This PR only feeds the gate genuine input.
- No fabrication of attacks: the code only drops, never invents.

## Validation (firsthand)

- **mypy strict** CI gate (incl. `invoke_callables.py`): `Success: no issues found in 2 source files`.
- **Tests**: 18 new (no JVM / no real LLM, synthetic opaque atoms) — validation drops fabricated/self/unknown-id joint-attacks, removes the target from the attacker set, dedups identical AND order-permuted attacker sets; translator honest-absent on empty/failed LLM; handler wiring persists genuine attacks, never overrides caller, stays absent when empty. **59 pass** in the translator file, 0 regressions.
- **Probe** (gitignored scratchpad, opaque synthetic args): genuine derived joint-attack → gate flips to `evaluated` (degraded=False, n=2); empty derivation → stays `absent_no_translator` (degraded=True); real no-key LLM call → honest-absent.

End-to-end confirmation on the 3 real corpora remains coord-local (ai-01), as for TR-1/ASPIC+.

Closes part of #1425 (SetAF axis). Next and last: weighted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
