### PR TITLE
feat(orchestration): text→structured weighted-AF translator (TR-2 #1425)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3674,6 +3674,23 @@ async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict[str
     args = context.get("arguments") or _extract_arguments_from_context(
         input_text, context
     )
+    # Genuine weighted attacks: if the caller did not supply them, try to
+    # derive them from the text (validated by id). Never overrides a caller's
+    # explicit set; empty/failed derivation leaves the key unset so the handler
+    # honestly falls back to auto-shaped pairwise attacks with neutral weight.
+    if not context.get("weighted_attacks"):
+        try:
+            from argumentation_analysis.orchestration.structured_arg_translator import (
+                translate_to_weighted_attacks,
+            )
+
+            derived_attacks = await translate_to_weighted_attacks(input_text, args)
+            if derived_attacks:
+                context["weighted_attacks"] = derived_attacks
+        except Exception as e:
+            logger.info(
+                "Weighted translator unavailable (%s); absent_no_translator.", e
+            )
     # Weighted attacks come as (source, target, weight) triples. Upstream may
     # provide them directly, else shape from the canonical pairwise graph with
     # neutral weight 0.5 (#1019: no fabricated confidence).

--- a/argumentation_analysis/orchestration/structured_arg_translator.py
+++ b/argumentation_analysis/orchestration/structured_arg_translator.py
@@ -154,6 +154,21 @@ async def _llm_extract_relations(
             '{"attacks": [{"attackers": ["argN"], "target": "argM", '
             '"rationale": "one short sentence"}]}'
         )
+    elif relation_kind == "weighted_attacks":
+        task = (
+            "Identify WEIGHTED ATTACKS among these arguments: a weighted attack "
+            "is a pair (source, target) where the source argument attacks the "
+            "target, together with a WEIGHT in [0.0, 1.0] expressing how strongly "
+            "the source defeats the target (1.0 = total defeat, 0.0 = negligible). "
+            "Cite source AND target by id; every id must be present in the "
+            "inventory. Report an attack ONLY when the text genuinely presents "
+            "the source as undermining the target — do NOT connect unrelated "
+            "arguments."
+        )
+        shape = (
+            '{"attacks": [{"source": "argN", "target": "argM", "weight": 0.8, '
+            '"rationale": "one short sentence"}]}'
+        )
     else:
         raise ValueError(f"unknown relation_kind: {relation_kind!r}")
 
@@ -361,6 +376,51 @@ def _validate_setaf_attacks(
     return out
 
 
+def _validate_weighted_attacks(
+    data: Dict[str, Any], arg_by_id: Dict[str, str]
+) -> List[Tuple[str, str, float]]:
+    """Validate LLM weighted-attack proposals against the real inventory.
+
+    A weighted attack is a ``(source, target, weight)`` triple: the source and
+    target ids must both be in the inventory and distinct (self-attack is not
+    genuine), and the weight must be a number in ``[0, 1]``. A triple citing any
+    unknown id is dropped (anti-théâtre #1019); a non-numeric weight is dropped
+    (no fabricated confidence). Weights outside ``[0, 1]`` are CLAMPED — the
+    attack relation is genuine, only the magnitude needs sanitising to the valid
+    range. Ids are re-mapped to canonical argument text. Returns
+    ``(source_text, target_text, weight)`` tuples. Dedup on ``(source, target)``
+    keeps the first weight seen.
+    """
+    raw = data.get("attacks", []) if isinstance(data, dict) else []
+    if not isinstance(raw, list):
+        return []
+    seen: set[Tuple[str, str]] = set()
+    out: List[Tuple[str, str, float]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        src_id = str(item.get("source", "")).strip()
+        tgt_id = str(item.get("target", "")).strip()
+        if src_id not in arg_by_id or tgt_id not in arg_by_id:
+            continue  # fabricated / malformed → dropped (anti-théâtre)
+        if src_id == tgt_id:
+            continue  # self-attack is not a genuine relation
+        try:
+            w = float(item.get("weight", 0.5))
+        except (TypeError, ValueError):
+            continue  # non-numeric weight → dropped (no fabricated confidence)
+        # Clamp to the valid [0, 1] range — the relation is genuine, the
+        # magnitude is sanitised rather than invented or discarded.
+        w = max(0.0, min(1.0, w))
+        src, tgt = arg_by_id[src_id], arg_by_id[tgt_id]
+        key = (src, tgt)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append((src, tgt, w))
+    return out
+
+
 async def translate_to_bipolar_supports(
     input_text: str, arguments: List[str]
 ) -> List[List[str]]:
@@ -493,14 +553,49 @@ async def translate_to_setaf_attacks(
     return attacks
 
 
+async def translate_to_weighted_attacks(
+    input_text: str, arguments: List[str]
+) -> List[Tuple[str, str, float]]:
+    """Derive genuine weighted attacks from the text + arguments.
+
+    Returns a list of ``(source, target, weight)`` triples (canonical argument
+    texts, weight clamped to ``[0, 1]``), validated against the real inventory.
+    Empty list when the LLM finds no genuine weighted attacks OR no API key is
+    configured — the caller then stays ``absent_no_translator`` (honest absence,
+    anti-théâtre #1019). The gate ``_STRUCTURED_ARG_INPUT_KEYS[
+    'weighted_argumentation']`` accepts ``weighted_attacks``; the gate itself is
+    never modified.
+    """
+    arg_by_id, _ = _build_inventory(arguments)
+    if not arg_by_id:
+        return []
+    try:
+        data = await _llm_extract_relations(input_text, arguments, "weighted_attacks")
+    except Exception as e:  # network / parse / budget — never fatal to the run
+        logger.info(
+            "Weighted attacks translator failed (%s) — staying absent_no_translator.",
+            e,
+        )
+        return []
+    attacks = _validate_weighted_attacks(data, arg_by_id)
+    if attacks:
+        logger.info(
+            "Weighted translator: derived %d genuine weighted attack(s) from text.",
+            len(attacks),
+        )
+    return attacks
+
+
 __all__ = [
     "translate_to_bipolar_supports",
     "translate_to_aba_contraries",
     "translate_to_aspic_rules",
     "translate_to_setaf_attacks",
+    "translate_to_weighted_attacks",
     "_build_inventory",
     "_validate_supports",
     "_validate_contraries",
     "_validate_aspic_rules",
     "_validate_setaf_attacks",
+    "_validate_weighted_attacks",
 ]

--- a/tests/unit/argumentation_analysis/orchestration/test_structured_arg_translator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_structured_arg_translator.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import sys
 import types
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
@@ -25,10 +25,12 @@ from argumentation_analysis.orchestration.structured_arg_translator import (
     _validate_contraries,
     _validate_setaf_attacks,
     _validate_supports,
+    _validate_weighted_attacks,
     translate_to_aba_contraries,
     translate_to_aspic_rules,
     translate_to_bipolar_supports,
     translate_to_setaf_attacks,
+    translate_to_weighted_attacks,
 )
 
 
@@ -791,3 +793,210 @@ class TestSetafHandlerWiring:
         await _invoke_setaf("text", ctx)
         # Nothing genuine → context key stays unset → gate keeps absent_no_translator.
         assert "set_attacks" not in ctx
+
+
+# -- Weighted argumentation (source, target, weight) -------------------------
+
+
+class TestValidateWeightedAttacks:
+    def test_keeps_valid_attack_with_weight(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [
+            {"source": "arg1", "target": "arg2", "weight": 0.8, "rationale": "r"},
+        ]}
+        out = _validate_weighted_attacks(data, arg_by_id)
+        assert out == [("Alpha", "Beta", 0.8)]
+
+    def test_drops_attack_with_unknown_source(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [{"source": "arg9", "target": "arg2", "weight": 0.5}]}
+        assert _validate_weighted_attacks(data, arg_by_id) == []
+
+    def test_drops_attack_with_unknown_target(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [{"source": "arg1", "target": "arg9", "weight": 0.5}]}
+        assert _validate_weighted_attacks(data, arg_by_id) == []
+
+    def test_drops_self_attack(self):
+        arg_by_id = {"arg1": "Alpha"}
+        data = {"attacks": [{"source": "arg1", "target": "arg1", "weight": 0.5}]}
+        assert _validate_weighted_attacks(data, arg_by_id) == []
+
+    def test_clamps_weight_above_one(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [{"source": "arg1", "target": "arg2", "weight": 1.5}]}
+        out = _validate_weighted_attacks(data, arg_by_id)
+        assert out == [("Alpha", "Beta", 1.0)]
+
+    def test_clamps_weight_below_zero(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [{"source": "arg1", "target": "arg2", "weight": -0.3}]}
+        out = _validate_weighted_attacks(data, arg_by_id)
+        assert out == [("Alpha", "Beta", 0.0)]
+
+    def test_drops_non_numeric_weight(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [
+            {"source": "arg1", "target": "arg2", "weight": "high"},  # non-numeric
+        ]}
+        assert _validate_weighted_attacks(data, arg_by_id) == []
+
+    def test_dedups_identical_attacks_keeps_first_weight(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        data = {"attacks": [
+            {"source": "arg1", "target": "arg2", "weight": 0.9},
+            {"source": "arg1", "target": "arg2", "weight": 0.1},  # dup → dropped
+        ]}
+        out = _validate_weighted_attacks(data, arg_by_id)
+        assert out == [("Alpha", "Beta", 0.9)]
+
+    def test_empty_or_malformed_returns_empty(self):
+        arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
+        assert _validate_weighted_attacks({}, arg_by_id) == []
+        assert _validate_weighted_attacks({"attacks": []}, arg_by_id) == []
+        assert _validate_weighted_attacks({"attacks": "nope"}, arg_by_id) == []
+        assert _validate_weighted_attacks(
+            {"attacks": [{"source": 1, "target": "arg1", "weight": 0.5}]},  # type: ignore[dict-item]
+            arg_by_id,
+        ) == []
+
+
+class TestWeightedTranslator:
+    async def test_empty_llm_output_returns_empty(self, monkeypatch):
+        _patch_llm(monkeypatch, {"attacks": []})
+        out = await translate_to_weighted_attacks("some text", ["a", "b"])
+        assert out == []
+
+    async def test_no_inventory_returns_empty(self, monkeypatch):
+        _patch_llm(monkeypatch, {"attacks": [
+            {"source": "arg1", "target": "arg2", "weight": 0.5},
+        ]})
+        out = await translate_to_weighted_attacks("text", [])
+        assert out == []
+
+    async def test_only_fabricated_attacks_dropped(self, monkeypatch):
+        _patch_llm(monkeypatch, {"attacks": [
+            {"source": "arg8", "target": "arg9", "weight": 0.5},  # unknown ids
+        ]})
+        out = await translate_to_weighted_attacks("text", ["a", "b"])
+        assert out == []
+
+    async def test_returns_validated_triples_with_real_weights(self, monkeypatch):
+        _patch_llm(monkeypatch, {"attacks": [
+            {"source": "arg1", "target": "arg2", "weight": 0.7},
+            {"source": "arg1", "target": "arg9", "weight": 0.5},  # dropped (unknown)
+            {"source": "arg2", "target": "arg1", "weight": 2.0},  # clamped to 1.0
+        ]})
+        out = await translate_to_weighted_attacks("text", ["Alpha", "Beta"])
+        assert out == [("Alpha", "Beta", 0.7), ("Beta", "Alpha", 1.0)]
+
+
+def _inject_fake_weighted_module(monkeypatch, payload):
+    """Inject fake WeightedHandler + TweetyInitializer so _invoke_weighted runs w/o JVM."""
+    fake_handler = types.ModuleType(
+        "argumentation_analysis.agents.core.logic.weighted_handler"
+    )
+
+    class _FakeWeightedHandler:
+        def __init__(self, initializer: Any) -> None:
+            self.initializer = initializer
+
+        def analyze_weighted_framework(self, args, attacks, semantics="grounded"):
+            return payload
+
+    fake_handler.WeightedHandler = _FakeWeightedHandler  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "argumentation_analysis.agents.core.logic.weighted_handler",
+        fake_handler,
+    )
+
+    fake_init = types.ModuleType(
+        "argumentation_analysis.agents.core.logic.tweety_initializer"
+    )
+
+    class _FakeTweetyInitializer:
+        pass
+
+    fake_init.TweetyInitializer = _FakeTweetyInitializer  # type: ignore[attr-defined]
+    monkeypatch.setitem(
+        sys.modules,
+        "argumentation_analysis.agents.core.logic.tweety_initializer",
+        fake_init,
+    )
+
+
+class TestWeightedHandlerWiring:
+    """The lazy translator call inside _invoke_weighted must persist genuine
+    weighted attacks into ``context`` so _record_structured_arg_status labels the
+    axis ``evaluated`` — and must stay absent when nothing genuine is derived."""
+
+    async def test_translates_and_persists_weighted_attacks(self, monkeypatch):
+        _inject_fake_weighted_module(monkeypatch, {"extensions": []})
+        genuine: List[Tuple[str, str, float]] = [("Alpha", "Beta", 0.8)]
+
+        async def _fake_attacks(text, args):
+            return genuine
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_weighted_attacks",
+            _fake_attacks,
+        )
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_weighted,
+        )
+
+        ctx: Dict[str, Any] = {
+            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
+        }
+        await _invoke_weighted("source text", ctx)
+        assert ctx.get("weighted_attacks") == genuine
+
+    async def test_does_not_override_caller_supplied_attacks(self, monkeypatch):
+        called = {"n": 0}
+
+        async def _fake_attacks(text, args):
+            called["n"] += 1
+            return [("x", "y", 0.5)]
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_weighted_attacks",
+            _fake_attacks,
+        )
+        _inject_fake_weighted_module(monkeypatch, {"extensions": []})
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_weighted,
+        )
+
+        genuine: List[Tuple[str, str, float]] = [("Alpha", "Beta", 0.9)]
+        ctx: Dict[str, Any] = {
+            "phase_extract_output": {"arguments": ["Alpha", "Beta"]},
+            "weighted_attacks": genuine,
+        }
+        await _invoke_weighted("text", ctx)
+        assert ctx["weighted_attacks"] is genuine  # unchanged
+        assert called["n"] == 0  # translator never invoked
+
+    async def test_honest_absent_when_translator_returns_empty(self, monkeypatch):
+        _inject_fake_weighted_module(monkeypatch, {"extensions": []})
+
+        async def _fake_attacks(text, args):
+            return []
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_weighted_attacks",
+            _fake_attacks,
+        )
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_weighted,
+        )
+
+        ctx: Dict[str, Any] = {
+            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
+        }
+        await _invoke_weighted("text", ctx)
+        # Nothing genuine → context key stays unset → gate keeps absent_no_translator.
+        assert "weighted_attacks" not in ctx


### PR DESCRIPTION
## Summary

Third and **last** PR of the **TR-2 lane** (#1425, NORTH-STAR parametric integration), following #1427 (ASPIC+) and the SetAF PR: extend the text→structured translator to **weighted argumentation frameworks**. An LLM derives genuine **weighted attacks** — `(source, target, weight)` triples where the weight in `[0,1]` expresses how strongly the source defeats the target — from the real source text + already-extracted arguments, validated against the real inventory. Converts `weighted_argumentation` from `absent_no_translator` → `evaluated` when the text yields genuine weighted attacks.

**This completes the TR-2 lane: all 5 structured-arg formalisms (bipolar, ABA, ASPIC+, SetAF, weighted) now admit genuine text-derived input.**

## Changes

**`structured_arg_translator.py`**
- `_llm_extract_relations` gains a `"weighted_attacks"` branch (weighted-attack prompt + JSON shape `{"attacks":[{"source":"argN","target":"argM","weight":0.8}]}`).
- `_validate_weighted_attacks(data, arg_by_id)`: drops a triple citing any unknown id (source **or** target), drops self-attacks, drops **non-numeric weights** (no fabricated confidence, anti-théâtre #1019), **CLAMPS** out-of-range weights to `[0,1]` (the attack relation is genuine; only the magnitude needs sanitising — clamping is not fabrication, dropping the whole genuine attack over a `1.2` would be the pendulum), re-maps ids → canonical argument text, dedups on `(source, target)` keeping the first weight seen.
- `translate_to_weighted_attacks`: mirrors `translate_to_setaf_attacks`; empty / failed LLM → `[]` (honest absence).

**`invoke_callables.py`**
- `_invoke_weighted` calls the translator **lazily**, only when the caller supplied no `weighted_attacks`, and persists genuine triples into `context["weighted_attacks"]` — the existing `isinstance(list|tuple) and len>=3` path then feeds them to `analyze_weighted_framework`, and `_record_structured_arg_status` labels the axis `evaluated` via the existing `has_genuine_input` path. Caller-supplied attacks are never overridden.

## Anti-théâtre HARD (#1019)

- Triples citing ids absent from the real inventory (or with non-numeric weights) are **DROPPED**; if nothing valid remains the formalism **stays `absent_no_translator`** — an honest absence, never a fabricated evaluation.
- The honest-absent gate (`_STRUCTURED_ARG_INPUT_KEYS` / `_record_structured_arg_status` in `state_writers.py`) is **NOT modified** — `state_writers.py` is not in the diff. This PR only feeds the gate genuine input.
- No fabrication of attacks or confidence: the code only drops or clamps, never invents.

## Validation (firsthand)

- **mypy strict** CI gate (incl. `invoke_callables.py`): `Success: no issues found in 2 source files`.
- **Tests**: 16 new (no JVM / no real LLM, synthetic opaque atoms) — validation drops fabricated/self/unknown-id triples and non-numeric weights, clamps out-of-range weights (above→1.0, below→0.0), dedups keeping the first weight; translator honest-absent on empty/failed LLM; handler wiring persists genuine triples, never overrides caller, stays absent when empty. **75 pass** in the translator file, 0 regressions.
- **Probe** (gitignored scratchpad, opaque synthetic args): genuine derived weighted attack → gate flips to `evaluated` (degraded=False, n=2); empty derivation → stays `absent_no_translator` (degraded=True); real no-key LLM call → honest-absent.

End-to-end confirmation on the 3 real corpora remains coord-local (ai-01), as for the rest of the lane.

Closes #1425 (weighted axis — lane complete: 5/5 formalisms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
