### PR TITLE
feat(orchestration): compare_dung_backends multi-backend comparison (I5 #1430)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -13,8 +13,9 @@ import json
 import logging
 import os
 import re
+import time
 from contextlib import contextmanager
-from typing import Dict, Any, Iterator, Optional, List, Tuple
+from typing import Dict, Any, Awaitable, Callable, Iterator, Optional, List, Tuple
 
 logger = logging.getLogger("UnifiedPipeline")
 
@@ -152,6 +153,7 @@ __all__ = [
     "_invoke_modal_logic",
     "_invoke_dung_extensions",
     "_python_dung_fallback",
+    "_compare_dung_backends",
     "_invoke_formal_synthesis",
     "_invoke_narrative_synthesis",
     "_invoke_text_to_kb",
@@ -6658,6 +6660,263 @@ def _python_dung_fallback(
         "Dung extension computation unavailable: JVM/Tweety required. "
         "Install JVM and ensure Tweety JARs are on the classpath."
     )
+
+
+# --- I5 #1430: multi-backend Dung comparison (pattern compare_fol_backends) ---
+#
+# The Dung axis already selects a backend by hint (student vs Tweety) but the
+# outputs are never COMPARED. ``_compare_dung_backends`` runs every available
+# backend on the SAME abstract framework and surfaces agreement / disagreement
+# PER SEMANTICS. Disagreement is NEVER auto-reconciled — it is the result
+# (anti-pendule #1019, mirroring the FOL multi-prover frame #1243). A backend
+# that cannot run (no JVM / library missing) is reported ``unavailable``
+# (fail-loud), never silently omitted (DoD #1019).
+
+# Semantics common to both the student library (4) and the native engine
+# (subset of 11) — the only ones a cross-backend verdict is meaningful for.
+_COMPARE_DUNG_SEMANTICS: Tuple[str, ...] = (
+    "grounded",
+    "preferred",
+    "stable",
+    "complete",
+)
+
+# A backend fn: (arguments, attacks) -> {"extensions": {sem: [[arg,...],...]},
+# "available": bool, "note": str}. Fakes injected for unit tests (no JVM).
+_DungBackendFn = Callable[
+    [List[str], List[List[str]]], Awaitable[Dict[str, Any]]
+]
+
+
+def _normalize_extensions(
+    raw: Any, semantics: Tuple[str, ...]
+) -> List[List[str]]:
+    """Coerce a backend's per-semantics extension payload to a flat list.
+
+    Tolerates the two producer shapes (``analyze_multi_semantics`` returns
+    ``{sem: [[args]] | {"error": ...}}``; ``compute_extensions`` returns
+    ``{"extensions": {sem: [...]}}``). Drops error / non-list entries so a
+    failed semantics is treated as "no extension decided" (honest-absent), not
+    a fabricated empty agreement.
+    """
+    if isinstance(raw, dict):
+        # compute_extensions nests under "extensions".
+        candidate = raw.get("extensions", raw)
+    else:
+        candidate = raw
+    if not isinstance(candidate, dict):
+        return []
+    flat: List[List[str]] = []
+    for sem in semantics:
+        val = candidate.get(sem)
+        if isinstance(val, list):
+            flat.extend(v for v in val if isinstance(v, list))
+    return flat
+
+
+def _extensions_key(extensions: List[List[str]]) -> frozenset[frozenset[str]]:
+    """Order-independent canonical key for a set of extensions.
+
+    A Dung extension SET is compared as a set of sets, so ``[[a,b],[c]]`` and
+    ``[[c],[b,a]]`` are equal (genuine agreement), independent of listing order.
+    """
+    return frozenset(frozenset(ext) for ext in extensions)
+
+
+async def _default_tweety_dung_backend(
+    arguments: List[str], attacks: List[List[str]]
+) -> Dict[str, Any]:
+    """Native AFHandler (Tweety) as a comparison backend (lazy import)."""
+    start = time.perf_counter()
+    try:
+        from argumentation_analysis.agents.core.logic.af_handler import (
+            AFHandler,
+            SEMANTICS_REASONERS,
+        )
+        from argumentation_analysis.agents.core.logic.tweety_initializer import (
+            TweetyInitializer,
+        )
+
+        initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
+        handler = AFHandler(initializer)
+        sem_list = [s for s in _COMPARE_DUNG_SEMANTICS if s in SEMANTICS_REASONERS]
+        result = await asyncio.to_thread(
+            handler.analyze_multi_semantics, arguments, attacks, sem_list
+        )
+        elapsed = (time.perf_counter() - start) * 1000.0
+        return {
+            "extensions": result.get("extensions", {}),
+            "available": True,
+            "note": "tweety AFHandler",
+            "elapsed_ms": round(elapsed, 1),
+        }
+    except Exception as e:
+        elapsed = (time.perf_counter() - start) * 1000.0
+        return {
+            "extensions": {},
+            "available": False,
+            "note": f"unavailable: {e}",
+            "elapsed_ms": round(elapsed, 1),
+        }
+
+
+async def _default_student_dung_backend(
+    arguments: List[str], attacks: List[List[str]]
+) -> Dict[str, Any]:
+    """abs_arg_dung student provider as a comparison backend (lazy import).
+
+    The student library is a SANCTUARY (never modified, #893); this only wraps
+    its public ``compute_extensions`` adapter from the outside.
+    """
+    start = time.perf_counter()
+    try:
+        from argumentation_analysis.adapters.dung_student_provider import (
+            DungStudentProvider,
+        )
+
+        provider = DungStudentProvider()  # type: ignore[no-untyped-call]
+        _typed_attacks = [(a[0], a[1]) for a in attacks if len(a) >= 2]
+        result = await provider.compute_extensions(arguments, _typed_attacks)
+        elapsed = (time.perf_counter() - start) * 1000.0
+        if result.get("status") == "unavailable":
+            return {
+                "extensions": {},
+                "available": False,
+                "note": f"unavailable: {result.get('error', 'student provider')}",
+                "elapsed_ms": round(elapsed, 1),
+            }
+        return {
+            "extensions": result.get("extensions", {}),
+            "available": True,
+            "note": "abs_arg_dung_student",
+            "elapsed_ms": round(elapsed, 1),
+        }
+    except Exception as e:
+        elapsed = (time.perf_counter() - start) * 1000.0
+        return {
+            "extensions": {},
+            "available": False,
+            "note": f"unavailable: {e}",
+            "elapsed_ms": round(elapsed, 1),
+        }
+
+
+async def _compare_dung_backends(
+    arguments: List[str],
+    attacks: List[List[str]],
+    *,
+    backends: Optional[Dict[str, _DungBackendFn]] = None,
+    semantics: Optional[Tuple[str, ...]] = None,
+) -> Dict[str, Any]:
+    """Run every available Dung backend on the same AF and compare (I5 #1430).
+
+    Mirrors :meth:`compare_fol_backends` (fol_handler.py:963): each backend
+    reasons INDEPENDENTLY over the same framework and the per-semantics
+    agreement is surfaced, **never auto-reconciled**. A backend that cannot run
+    is reported ``available=False`` (fail-loud), never silently dropped.
+
+    ``backends`` defaults to the two real providers (Tweety ``AFHandler`` +
+    student ``DungStudentProvider``); inject fakes (``{name: async_fn}``) for
+    JVM-free unit tests. Each backend fn returns ``{"extensions": {sem: [...]},
+    "available": bool, "note": str}``.
+
+    Returns::
+
+        {
+          "backends": {name: {"extensions": {sem: [[args]]}, "available": bool,
+                              "note": str, "elapsed_ms": float}},
+          "comparison": {
+            "semantics": [sem, ...],
+            "per_semantics": {sem: {"agreement": Optional[bool],
+                                    "decided": [name, ...],
+                                    "disagreement": [str, ...]}},
+            "overall_agreement": Optional[bool],   # None if <2 backends decided
+          },
+          "statistics": {"arguments_count", "attacks_count", "backends_count"},
+        }
+    """
+    sem_tuple = semantics if semantics is not None else _COMPARE_DUNG_SEMANTICS
+
+    if backends is None:
+        backends = {
+            "tweety": _default_tweety_dung_backend,
+            "abs_arg_dung_student": _default_student_dung_backend,
+        }
+
+    backend_results: Dict[str, Dict[str, Any]] = {}
+    for name, fn in backends.items():
+        try:
+            res = await fn(arguments, attacks)
+        except Exception as e:  # a buggy backend never poisons the comparison
+            res = {"extensions": {}, "available": False, "note": f"unavailable: {e}"}
+        backend_results[name] = {
+            "extensions": res.get("extensions", {}),
+            "available": bool(res.get("available", False)),
+            "note": str(res.get("note", "")),
+            "elapsed_ms": float(res.get("elapsed_ms", 0.0)),
+        }
+
+    # Per-semantics agreement over the decided backends.
+    per_sem: Dict[str, Dict[str, Any]] = {}
+    any_disagree = False
+    any_decided_pair = False
+    for sem in sem_tuple:
+        keys_by_backend: Dict[str, frozenset[frozenset[str]]] = {}
+        for name, res in backend_results.items():
+            if not res["available"]:
+                continue
+            ext = _normalize_extensions({"extensions": res["extensions"]}, (sem,))
+            keys_by_backend[name] = _extensions_key(ext)
+        decided = list(keys_by_backend.keys())
+        distinct = set(keys_by_backend.values())
+        if len(decided) >= 2:
+            any_decided_pair = True
+        if len(decided) < 2:
+            agreement: Optional[bool] = None
+            disagreement: List[str] = []
+        elif len(distinct) == 1:
+            agreement = True
+            disagreement = []
+        else:
+            agreement = False
+            any_disagree = True
+            disagreement = [
+                f"{a}: {sorted(sorted(e) for e in keys_by_backend[a])} vs "
+                f"{b}: {sorted(sorted(e) for e in keys_by_backend[b])}"
+                for a, b in _pairs(decided)
+                if keys_by_backend[a] != keys_by_backend[b]
+            ]
+        per_sem[sem] = {
+            "agreement": agreement,
+            "decided": decided,
+            "disagreement": disagreement,
+        }
+
+    if not any_decided_pair:
+        overall: Optional[bool] = None
+    elif any_disagree:
+        overall = False
+    else:
+        overall = True
+
+    return {
+        "backends": backend_results,
+        "comparison": {
+            "semantics": list(sem_tuple),
+            "per_semantics": per_sem,
+            "overall_agreement": overall,
+        },
+        "statistics": {
+            "arguments_count": len(arguments),
+            "attacks_count": len(attacks),
+            "backends_count": len(backend_results),
+        },
+    }
+
+
+def _pairs(items: List[str]) -> List[Tuple[str, str]]:
+    """Yield unordered pairs for cross-backend disagreement notes."""
+    return [(items[i], items[j]) for i in range(len(items)) for j in range(i + 1, len(items))]
 
 
 async def _invoke_formal_synthesis(

--- a/tests/unit/argumentation_analysis/orchestration/test_compare_dung_backends.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_compare_dung_backends.py
@@ -1,0 +1,207 @@
+"""I5 #1430 — compare_dung_backends multi-backend Dung comparison unit tests.
+
+Mirrors the anti-théâtre contract of the FOL multi-prover frame (#1243):
+- DISAGREEMENT between backends is surfaced, NEVER auto-reconciled (a
+  disagreement is a result, not a bug to mask).
+- A backend that cannot run is reported ``available=False`` (fail-loud), never
+  silently omitted.
+- Extension SETS compare order-independently (a Dung extension is a set).
+
+No JVM, no real LLM, synthetic opaque AFs only (privacy HARD — no corpus tokens).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from argumentation_analysis.orchestration.invoke_callables import (
+    _compare_dung_backends,
+    _extensions_key,
+    _normalize_extensions,
+    _pairs,
+)
+
+
+# -- helpers ------------------------------------------------------------------
+
+
+def _backend(
+    extensions: Dict[str, List[List[str]]], available: bool = True, note: str = ""
+):
+    """Build an injected fake backend callable returning a fixed payload."""
+
+    async def _fn(arguments: List[str], attacks: List[List[str]]) -> Dict[str, Any]:
+        return {"extensions": extensions, "available": available, "note": note}
+
+    return _fn
+
+
+# -- _normalize_extensions / _extensions_key / _pairs -------------------------
+
+
+class TestHelpers:
+    def test_normalize_extensions_flat_dict(self):
+        raw = {"grounded": [["a", "b"]], "preferred": [["a"], ["b"]]}
+        out = _normalize_extensions(raw, ("grounded",))
+        assert out == [["a", "b"]]
+
+    def test_normalize_extensions_nested_under_extensions(self):
+        raw = {"extensions": {"grounded": [["a"]]}}
+        assert _normalize_extensions(raw, ("grounded",)) == [["a"]]
+
+    def test_normalize_extensions_drops_error_and_nonlist(self):
+        raw = {"grounded": {"error": "boom"}, "preferred": "nope", "stable": [["c"]]}
+        assert _normalize_extensions(raw, ("grounded", "preferred", "stable")) == [
+            ["c"]
+        ]
+
+    def test_normalize_extensions_bad_shape_returns_empty(self):
+        assert _normalize_extensions("nope", ("grounded",)) == []
+        assert _normalize_extensions(42, ("grounded",)) == []
+
+    def test_extensions_key_order_independent(self):
+        assert _extensions_key([["a", "b"]]) == _extensions_key([["b", "a"]])
+        assert _extensions_key([["a"], ["b"]]) == _extensions_key([["b"], ["a"]])
+
+    def test_pairs_unordered(self):
+        assert _pairs(["a", "b", "c"]) == [("a", "b"), ("a", "c"), ("b", "c")]
+        assert _pairs([]) == []
+        assert _pairs(["solo"]) == []
+
+
+# -- agreement ----------------------------------------------------------------
+
+
+class TestAgreement:
+    async def test_full_agreement_order_independent(self):
+        # Both backends agree on grounded/preferred despite different listing order.
+        be1 = _backend({"grounded": [["a", "b"]], "preferred": [["a", "b"]]})
+        be2 = _backend({"grounded": [["b", "a"]], "preferred": [["b", "a"]]})
+        r = await _compare_dung_backends(
+            ["a", "b"], [["a", "b"]], backends={"A": be1, "B": be2}
+        )
+        assert r["comparison"]["per_semantics"]["grounded"]["agreement"] is True
+        assert r["comparison"]["per_semantics"]["preferred"]["agreement"] is True
+        assert r["comparison"]["overall_agreement"] is True
+        assert r["comparison"]["per_semantics"]["grounded"]["disagreement"] == []
+
+    async def test_disagreement_surfaced_never_reconciled(self):
+        # Grounded extension differs between backends → disagreement listed verbatim.
+        be1 = _backend({"grounded": [["a", "b"]]})
+        be2 = _backend({"grounded": [["a"]]})  # smaller extension
+        r = await _compare_dung_backends(
+            ["a", "b"], [["a", "b"]], backends={"A": be1, "B": be2}
+        )
+        per = r["comparison"]["per_semantics"]["grounded"]
+        assert per["agreement"] is False
+        assert len(per["disagreement"]) == 1
+        assert "A" in per["disagreement"][0] and "B" in per["disagreement"][0]
+        assert r["comparison"]["overall_agreement"] is False
+
+    async def test_mixed_agreement_per_semantics(self):
+        # Agree on grounded, disagree on preferred → overall False (any disagree).
+        be1 = _backend({"grounded": [["a"]], "preferred": [["a", "b"]]})
+        be2 = _backend({"grounded": [["a"]], "preferred": [["a"]]})
+        r = await _compare_dung_backends(
+            ["a", "b"], [["a", "b"]], backends={"A": be1, "B": be2}
+        )
+        assert r["comparison"]["per_semantics"]["grounded"]["agreement"] is True
+        assert r["comparison"]["per_semantics"]["preferred"]["agreement"] is False
+        assert r["comparison"]["overall_agreement"] is False
+
+    async def test_three_backends_pairwise_disagreement(self):
+        be1 = _backend({"grounded": [["a", "b"]]})
+        be2 = _backend({"grounded": [["a", "b"]]})
+        be3 = _backend({"grounded": [["a"]]})
+        r = await _compare_dung_backends(
+            ["a", "b"], [["a", "b"]], backends={"A": be1, "B": be2, "C": be3}
+        )
+        per = r["comparison"]["per_semantics"]["grounded"]
+        assert per["agreement"] is False
+        # A↔C and B↔C differ (2 disagree notes), A↔B agrees.
+        assert len(per["disagreement"]) == 2
+
+
+# -- unavailable / fail-loud --------------------------------------------------
+
+
+class TestUnavailableFailLoud:
+    async def test_unavailable_backend_reported_not_omitted(self):
+        # Backend B cannot run → available=False, kept in the report, agreement None.
+        be1 = _backend({"grounded": [["a", "b"]]})
+        be2 = _backend({}, available=False, note="unavailable: JVM down")
+        r = await _compare_dung_backends(
+            ["a", "b"], [["a", "b"]], backends={"A": be1, "B": be2}
+        )
+        assert r["backends"]["B"]["available"] is False
+        assert "JVM down" in r["backends"]["B"]["note"]
+        assert r["backends"]["B"] in r["backends"].values()  # NOT omitted
+        # Only one decided backend → agreement indeterminate.
+        assert r["comparison"]["per_semantics"]["grounded"]["agreement"] is None
+        assert r["comparison"]["overall_agreement"] is None
+
+    async def test_all_unavailable_overall_none(self):
+        be1 = _backend({}, available=False)
+        be2 = _backend({}, available=False)
+        r = await _compare_dung_backends(
+            ["a", "b"], [["a", "b"]], backends={"A": be1, "B": be2}
+        )
+        assert r["comparison"]["overall_agreement"] is None
+        assert r["statistics"]["backends_count"] == 2
+
+    async def test_backend_exception_caught_as_unavailable(self):
+        # A buggy backend (raises) must NOT poison the comparison.
+
+        async def _boom(arguments, attacks):
+            raise RuntimeError("backend exploded")
+
+        be_ok = _backend({"grounded": [["a"]]})
+        r = await _compare_dung_backends(
+            ["a", "b"], [["a", "b"]], backends={"ok": be_ok, "boom": _boom}
+        )
+        assert r["backends"]["boom"]["available"] is False
+        assert "exploded" in r["backends"]["boom"]["note"]
+
+
+# -- structure / statistics ---------------------------------------------------
+
+
+class TestStructure:
+    async def test_default_semantics_are_the_four_common(self):
+        be = _backend({"grounded": [["a"]]})
+        r = await _compare_dung_backends(["a"], [], backends={"A": be})
+        assert r["comparison"]["semantics"] == [
+            "grounded",
+            "preferred",
+            "stable",
+            "complete",
+        ]
+
+    async def test_custom_semantics(self):
+        be1 = _backend({"only_sem": [["a"]]})
+        be2 = _backend({"only_sem": [["a"]]})
+        r = await _compare_dung_backends(
+            ["a"], [], backends={"A": be1, "B": be2}, semantics=("only_sem",)
+        )
+        assert r["comparison"]["semantics"] == ["only_sem"]
+        assert r["comparison"]["per_semantics"]["only_sem"]["agreement"] is True
+
+    async def test_statistics_counts(self):
+        be = _backend({"grounded": [["a", "b"]]})
+        r = await _compare_dung_backends(
+            ["a", "b", "c"], [["a", "b"], ["b", "c"]], backends={"A": be, "B": be}
+        )
+        assert r["statistics"]["arguments_count"] == 3
+        assert r["statistics"]["attacks_count"] == 2
+        assert r["statistics"]["backends_count"] == 2
+
+    async def test_per_semantics_decided_lists_backends(self):
+        be1 = _backend({"grounded": [["a"]]})
+        be2 = _backend({"grounded": [["a"]]})
+        r = await _compare_dung_backends(
+            ["a"], [], backends={"A": be1, "B": be2}
+        )
+        assert sorted(r["comparison"]["per_semantics"]["grounded"]["decided"]) == [
+            "A",
+            "B",
+        ]


### PR DESCRIPTION
feat(orchestration): compare_dung_backends multi-backend comparison (I5 #1430)

First PR of the I5 lane (#1430, NORTH-STAR parametric integration, queued
after the TR-2 lane completed): make the Dung axis SELECTABLE AND COMPARABLE,
mirroring the FOL multi-prover frame (compare_fol_backends, fol_handler.py:963).

Today the Dung backend is chosen by hint (student vs Tweety vs fallback) but
the outputs are never COMPARED. _compare_dung_backends runs every available
backend on the SAME abstract framework and surfaces agreement / disagreement
PER SEMANTICS.

invoke_callables.py:
- _compare_dung_backends(arguments, attacks, *, backends=None, semantics=None):
  orchestrates each backend independently over the same AF. Default backends =
  native AFHandler (Tweety, lazy import) + DungStudentProvider (student, lazy
  import). backends={name: async_fn} is injectable for JVM-free unit tests
  (each fn returns {extensions, available, note}).
- _default_tweety_dung_backend / _default_student_dung_backend: lazy-imported
  real backends, each timed with time.perf_counter and wrapped so a failure
  becomes available=False (fail-loud) rather than a thrown comparison.
- _normalize_extensions / _extensions_key / _pairs: pure helpers — coerce the
  two producer shapes (analyze_multi_semantics vs compute_extensions), compare
  extension SETS order-independently (frozenset of frozensets), and enumerate
  unordered backend pairs for disagreement notes.

Output: {backends: {name: {extensions, available, note, elapsed_ms}},
comparison: {semantics, per_semantics: {sem: {agreement, decided,
disagreement}}, overall_agreement}, statistics}. agreement per semantics is
True (all decided backends equal), False (>=2 differ, disagreement listed
verbatim), or None (<2 decided).

Anti-pendule #1019 (DoD): DISAGREEMENT is NEVER auto-reconciled — it is the
result, not a bug to mask (mirrors the FOL frame #1243). A backend that cannot
run is reported available=False (fail-loud), never silently omitted. A buggy
backend (raises) is caught as unavailable so it cannot poison the comparison.
abs_arg_dung/ is a SANCTUARY (not in the diff, #893) — only its public adapter
is wrapped from the outside. state_writers.py is untouched (unrelated to this
axis).

Tests (17 new, no JVM / no real LLM, synthetic opaque AFs): helpers normalize
both shapes and drop error/non-list entries, compare order-independently;
agreement is order-invariant, disagreement is surfaced verbatim and never
reconciled, mixed per-semantics agreement yields overall False; unavailable
backends are reported not omitted (agreement None), exceptions are caught as
unavailable; structure + statistics + custom/default semantics. 17 pass.

This is PR1 of 3 (compare fn + synthetic tests). PR2 wires a `compare` mode
into _invoke_dung_extensions (fail-loud, honest-absent). PR3 probes a real
corpus (opaque IDs).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
