### PR TITLE
feat(informal): neuro-symbolic Dung arbitrator over neural sophism candidates (I1 #1429 PR1)

### DIFF
--- a/argumentation_analysis/agents/core/informal/neuro_symbolic_arbitrator.py
+++ b/argumentation_analysis/agents/core/informal/neuro_symbolic_arbitrator.py
@@ -1,0 +1,393 @@
+"""Neuro-symbolic sophism detection — Dung arbitrage over neural candidates.
+
+Track I1 (#1429, NORTH-STAR). This is a **symbolic arbitrage layer** built on top
+of the existing neural sophism detector (``taxonomy_sophism_detector.py``) and
+the existing abstract-argumentation solver (``abs_arg_dung/``). It does **not**
+re-implement detection, nor the Dung solver — it wires them together so that
+overlapping / mutually-exclusive neural candidates are arbitrated by Dung
+semantics, with attacks derived from unsatisfied Walton critical questions.
+
+Anti-fabrication posture (#1019 / anti-théâtre)
+-----------------------------------------------
+The arbitrator never invents a fallacy, a conflict, or a critical-question
+failure. It only **mechanically turns declared signals into attacks**:
+
+* A candidate declares the Walton critical questions it fails
+  (``failed_critical_questions``) — that declaration is the neural/LLM layer's
+  responsibility (bridge wired in PR2, exercised on real text in PR3). Each
+  declared failure becomes an unattacked *challenger* argument attacking the
+  candidate, so the candidate is defeated under grounded semantics exactly when
+  one of its critical questions is genuinely unsatisfied.
+* Two candidates anchored on the same evidence span with rival families are in
+  declared conflict (the issue's own example: one passage flagged as both *ad
+  hominem* and *straw man*). Resolution is mechanical: the strictly more
+  confident candidate attacks the less confident one (a tie yields a mutual
+  attack → both rejected under grounded).
+
+Honest-absent
+-------------
+If no candidate declares a failed critical question **and** no two candidates
+share a span with rival families, the attack set is empty. The accepted
+extension is then the full set of arguments, so the arbitrated output is
+identical to the raw neural output — the neuro-symbolic mode is **transparent**
+(== neural) when there is nothing genuine to arbitrate. This is mandated by the
+issue: no fabricated attacks to "make it symbolic".
+
+JVM-free by design (DI solver)
+------------------------------
+The Dung solver is an injected callable (``DungSolver`` protocol) so the core
+logic is unit-testable with synthetic opaque atoms and **no JVM, no LLM**. The
+default solver is a pure-python grounded-extension computation; a thin adapter
+(:func:`make_dung_agent_solver`) wraps the real ``abs_arg_dung.DungAgent`` (JVM)
+for production use in PR2/PR3. This mirrors the ``compare_*_backends`` DI idiom.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Protocol, Sequence, runtime_checkable
+
+logger = logging.getLogger(__name__)
+
+# Prefix for synthetic challenger arguments standing in for unsatisfied Walton
+# critical questions. Caller-supplied candidate ids MUST NOT start with this
+# prefix (a guard rejects collisions). Keeping these as first-class arguments
+# (rather than implicit attacks) makes the arbitration auditable: every defeat
+# traces back to a named critical question.
+_CQ_CHALLENGER_PREFIX = "__walton_cq__"
+
+
+@dataclass(frozen=True)
+class SophismCandidate:
+    """One neural sophism candidate, modelled as an opaque Dung argument.
+
+    The arbitrator treats ``candidate_id`` / ``family`` / ``span_id`` as opaque
+    atoms — it never interprets their meaning, only their declared relations
+    (failed critical questions, span overlap). This keeps the symbolic layer
+    decoupled from the detector's taxonomy internals and is what makes the unit
+    tests JVM/LLM-free.
+
+    Attributes:
+        candidate_id: Opaque, unique candidate identifier (e.g. ``"s0"``).
+            Must not start with ``__walton_cq__``.
+        family: Opaque family label (e.g. ``"ad_hominem"``). Used only to decide
+            rivalry between same-span candidates — never interpreted semantically.
+        span_id: Opaque evidence-span anchor. Two candidates sharing a span with
+            different families are in declared conflict.
+        confidence: Neural confidence in ``[0, 1]``. Breaks ties between rival
+            same-span candidates (higher attacks lower).
+        failed_critical_questions: Walton critical questions the passage fails to
+            satisfy for this candidate, as declared by the neural/LLM bridge. Each
+            becomes an unattacked challenger attacking this candidate.
+    """
+
+    candidate_id: str
+    family: str
+    span_id: str
+    confidence: float
+    failed_critical_questions: Sequence[str] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        if self.candidate_id.startswith(_CQ_CHALLENGER_PREFIX):
+            raise ValueError(
+                f"Candidate id {self.candidate_id!r} collides with the reserved "
+                f"challenger prefix {_CQ_CHALLENGER_PREFIX!r}."
+            )
+
+
+@dataclass(frozen=True)
+class ArbitrationResult:
+    """Outcome of arbitrating a batch of neural candidates under Dung semantics.
+
+    ``arbitrated_ids`` is the set of candidate ids that survive the chosen
+    semantics. When ``honest_absent`` is ``True`` there were no attacks at all,
+    so ``arbitrated_ids`` equals the full input set — the neuro-symbolic mode is
+    transparent (identical to neural). Diagnostics (``rejected`` with reasons,
+    ``attacks``, challenger map) give PR2/PR3 everything needed to render a
+    comparison and a real-corpus report.
+    """
+
+    semantics: str
+    arbitrated_ids: frozenset[str]
+    rejected: dict[str, str]
+    attacks: frozenset[tuple[str, str]]
+    challenger_for: dict[str, str]
+    honest_absent: bool
+    neural_count: int
+    arbitrated_count: int
+
+
+@runtime_checkable
+class DungSolver(Protocol):
+    """Callable contract for an injected Dung extension solver.
+
+    Returns one extension per element of the returned list (grounded ⇒ one
+    element, preferred ⇒ several). Arguments and attacks are opaque string ids.
+    Implementations must be pure with respect to ``(arguments, attacks)``.
+    """
+
+    def __call__(
+        self,
+        arguments: set[str],
+        attacks: set[tuple[str, str]],
+        *,
+        semantics: str,
+    ) -> list[set[str]]: ...
+
+
+# A conflict policy derives candidate-vs-candidate attack edges from declared
+# span overlaps. It must NOT touch critical questions (those are handled by
+# :func:`build_dung_framework`). Returning an empty set is always legitimate and
+# yields honest-absent behaviour for the conflict dimension.
+ConflictPolicy = Callable[[Sequence[SophismCandidate]], set[tuple[str, str]]]
+
+
+def default_conflict_policy(
+    candidates: Sequence[SophismCandidate],
+) -> set[tuple[str, str]]:
+    """Mechanical same-span / rival-family conflict derivation.
+
+    For each evidence span hosting candidates from **different** families, the
+    strictly more confident candidate attacks each less-confident rival; an exact
+    confidence tie yields a mutual attack between the rivals (both rejected under
+    grounded). No rivalry matrix is invented: "different family on the same span"
+    is the only conflict signal, matching the issue's own example.
+
+    Same-span candidates of the **same** family are not in conflict (a passage may
+    legitimately surface the same fallacy twice); they produce no edge.
+    """
+
+    by_span: dict[str, list[SophismCandidate]] = {}
+    for cand in candidates:
+        by_span.setdefault(cand.span_id, []).append(cand)
+
+    attacks: set[tuple[str, str]] = set()
+    for group in by_span.values():
+        # Pairs of candidates on the same span with different families.
+        for i, a in enumerate(group):
+            for b in group[i + 1 :]:
+                if a.family == b.family:
+                    continue
+                if a.confidence > b.confidence:
+                    attacks.add((a.candidate_id, b.candidate_id))
+                elif b.confidence > a.confidence:
+                    attacks.add((b.candidate_id, a.candidate_id))
+                else:
+                    # Exact tie — cannot rank; mutual attack (both fall under
+                    # grounded). Overridable by supplying another ConflictPolicy.
+                    attacks.add((a.candidate_id, b.candidate_id))
+                    attacks.add((b.candidate_id, a.candidate_id))
+    return attacks
+
+
+def build_dung_framework(
+    candidates: Sequence[SophismCandidate],
+    *,
+    conflict_policy: Optional[ConflictPolicy] = None,
+) -> tuple[set[str], set[tuple[str, str]], dict[str, str]]:
+    """Construct the abstract AF (arguments + attacks) for a candidate batch.
+
+    Combines two declared signal sources into one attack set:
+
+    1. **Critical-question challengers** — one unattacked synthetic argument per
+       distinct failed Walton CQ, attacking its candidate. The challenger id is
+       stable and mapped in the returned ``challenger_for`` dict (challenger →
+       candidate it attacks) for auditability.
+    2. **Conflict edges** — produced by ``conflict_policy`` (default:
+       :func:`default_conflict_policy`).
+
+    Returns ``(arguments, attacks, challenger_for)``.
+    """
+
+    policy = conflict_policy or default_conflict_policy
+    arguments: set[str] = {c.candidate_id for c in candidates}
+    attacks: set[tuple[str, str]] = set(policy(candidates))
+    challenger_for: dict[str, str] = {}
+
+    for cand in candidates:
+        # Dedup identical critical questions within a candidate so a repeated CQ
+        # yields a single challenger (one weakness, one attacker).
+        seen: set[str] = set()
+        for idx, question in enumerate(cand.failed_critical_questions):
+            if question in seen:
+                continue
+            seen.add(question)
+            challenger = f"{_CQ_CHALLENGER_PREFIX}{cand.candidate_id}__{idx}"
+            arguments.add(challenger)
+            attacks.add((challenger, cand.candidate_id))
+            challenger_for[challenger] = cand.candidate_id
+
+    return arguments, attacks, challenger_for
+
+
+def _grounded_extension_pure(
+    arguments: set[str], attacks: set[tuple[str, str]]
+) -> frozenset[str]:
+    """Least-fixed-point grounded extension in pure python (no JVM).
+
+    Iterates the grounded characteristic function from the empty set: an argument
+    is acceptable w.r.t. ``S`` iff every attacker of it is itself attacked by some
+    member of ``S``. Converges to the unique grounded extension. Deterministic
+    iteration order (sorted) keeps results stable across runs.
+    """
+
+    accepted: set[str] = set()
+    while True:
+        grew = False
+        for arg in sorted(arguments):
+            if arg in accepted:
+                continue
+            acceptable = True
+            for src, tgt in attacks:
+                if tgt != arg:
+                    continue
+                # `src` attacks `arg`; it must be counter-attacked by some member
+                # of the currently accepted set for `arg` to be defended.
+                if not any(
+                    defender in accepted and (defender, src) in attacks
+                    for defender in arguments
+                ):
+                    acceptable = False
+                    break
+            if acceptable:
+                accepted.add(arg)
+                grew = True
+        if not grew:
+            break
+    return frozenset(accepted)
+
+
+def pure_python_solver(
+    arguments: set[str],
+    attacks: set[tuple[str, str]],
+    *,
+    semantics: str,
+) -> list[set[str]]:
+    """Default injected solver — pure-python grounded extension only.
+
+    Supports ``semantics="grounded"`` (the conservative, single-extension choice
+    that best matches "accepted = survives arbitrage"). Other semantics raise
+    ``NotImplementedError`` rather than silently approximating: callers wanting
+    preferred/stable must inject the real ``abs_arg_dung`` solver via
+    :func:`make_dung_agent_solver` (PR2/PR3).
+    """
+
+    if semantics != "grounded":
+        raise NotImplementedError(
+            f"pure_python_solver supports only grounded semantics (got {semantics!r}); "
+            "inject make_dung_agent_solver() for preferred/stable/etc."
+        )
+    return [set(_grounded_extension_pure(arguments, attacks))]
+
+
+def make_dung_agent_solver() -> DungSolver:
+    """Build a ``DungSolver`` backed by the real ``abs_arg_dung.DungAgent`` (JVM).
+
+    Lazy-imports ``abs_arg_dung.agent`` so importing this module never requires
+    the JVM; the JVM is only touched when the returned solver is actually called
+    (mirroring ``DungAgent.__init__``'s contract). Used in PR2/PR3 production
+    wiring; PR1 unit tests inject ``pure_python_solver`` instead.
+    """
+
+    def solver(
+        arguments: set[str],
+        attacks: set[tuple[str, str]],
+        *,
+        semantics: str,
+    ) -> list[set[str]]:
+        # Local import: keep the module JVM-free at import time. ``abs_arg_dung``
+        # is untyped student code; under the project mypy config this module is
+        # not in the strict-override list, so the untyped call is accepted.
+        from abs_arg_dung.agent import DungAgent
+
+        agent = DungAgent()  # type: ignore[no-untyped-call]
+        for arg in sorted(arguments):
+            agent.add_argument(arg)
+        for src, tgt in sorted(attacks):
+            agent.add_attack(src, tgt)
+
+        if semantics == "grounded":
+            return [set(agent.get_grounded_extension())]
+        if semantics == "preferred":
+            return [set(ext) for ext in agent.get_preferred_extensions()]
+        if semantics == "stable":
+            return [set(ext) for ext in agent.get_stable_extensions()]
+        if semantics == "complete":
+            return [set(ext) for ext in agent.get_complete_extensions()]
+        if semantics == "ideal":
+            return [set(agent.get_ideal_extension())]
+        raise ValueError(
+            f"Unsupported semantics for abs_arg_dung solver: {semantics!r}"
+        )
+
+    return solver
+
+
+def arbitrate(
+    candidates: Sequence[SophismCandidate],
+    *,
+    solver: Optional[DungSolver] = None,
+    semantics: str = "grounded",
+    conflict_policy: Optional[ConflictPolicy] = None,
+) -> ArbitrationResult:
+    """Arbitrate neural candidates under Dung semantics.
+
+    Args:
+        candidates: Raw neural sophism candidates as opaque atoms.
+        solver: Injected Dung solver (default: pure-python grounded). Inject
+            :func:`make_dung_agent_solver` for real JVM-backed semantics.
+        semantics: Extension semantics label forwarded to ``solver``.
+        conflict_policy: Same-span conflict derivation (default:
+            :func:`default_conflict_policy`). Pass a no-op returning ``set()`` to
+            disable the conflict dimension and arbitrate on CQs alone.
+
+    Returns:
+        The arbitrated candidate set plus full diagnostics. When the framework
+        has no attacks (no failed CQ, no same-span rivalry) the result is
+        honest-absent: ``arbitrated_ids`` == all candidate ids and
+        ``honest_absent`` is ``True``.
+    """
+
+    chosen_solver = solver or pure_python_solver
+    arguments, attacks, challenger_for = build_dung_framework(
+        candidates, conflict_policy=conflict_policy
+    )
+
+    extensions = chosen_solver(arguments, attacks, semantics=semantics)
+    if not extensions:
+        accepted: set[str] = set()
+    elif len(extensions) == 1:
+        accepted = set(extensions[0])
+    else:
+        # Multi-extension semantics (e.g. preferred): a candidate "survives
+        # arbitration" only if it is skeptically accepted — present in EVERY
+        # extension. This is the conservative reading of "definitely accepted".
+        accepted = set(extensions[0])
+        for ext in extensions[1:]:
+            accepted &= set(ext)
+
+    candidate_ids = {c.candidate_id for c in candidates}
+    arbitrated_ids = frozenset(candidate_ids & accepted)
+
+    rejected: dict[str, str] = {}
+    for cand in candidates:
+        if cand.candidate_id in arbitrated_ids:
+            continue
+        if any(challenger_for.get(a) == cand.candidate_id for a, _ in attacks):
+            rejected[cand.candidate_id] = "defeated_by_unsatisfied_critical_question"
+        else:
+            rejected[cand.candidate_id] = "defeated_by_rival_candidate"
+
+    honest_absent = len(attacks) == 0
+
+    return ArbitrationResult(
+        semantics=semantics,
+        arbitrated_ids=arbitrated_ids,
+        rejected=rejected,
+        attacks=frozenset(attacks),
+        challenger_for=challenger_for,
+        honest_absent=honest_absent,
+        neural_count=len(candidate_ids),
+        arbitrated_count=len(arbitrated_ids),
+    )

--- a/tests/unit/argumentation_analysis/agents/core/informal/test_neuro_symbolic_arbitrator.py
+++ b/tests/unit/argumentation_analysis/agents/core/informal/test_neuro_symbolic_arbitrator.py
@@ -1,0 +1,241 @@
+"""Unit tests for the neuro-symbolic arbitrator (Track I1 #1429).
+
+Pure-python, JVM/LLM-free: synthetic opaque atoms (``s0``, ``family_a``,
+``span_0``) only. The default ``pure_python_solver`` (grounded) is exercised
+throughout; the real ``abs_arg_dung`` adapter is covered for its lazy-import /
+no-JVM contract without spinning up a JVM.
+
+These tests pin the two anti-fabrication guarantees of the module:
+
+* honest-absent — no declared signal ⇒ no attack ⇒ arbitrated == neural;
+* no invented defeats — every rejection traces to a declared failed Walton
+  critical question or a declared same-span rivalry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator import (
+    ArbitrationResult,
+    SophismCandidate,
+    _CQ_CHALLENGER_PREFIX,
+    _grounded_extension_pure,
+    arbitrate,
+    build_dung_framework,
+    default_conflict_policy,
+    make_dung_agent_solver,
+    pure_python_solver,
+)
+
+
+def _cand(
+    cid: str,
+    *,
+    family: str = "family_a",
+    span: str = "span_0",
+    confidence: float = 0.5,
+    cqs: tuple[str, ...] = (),
+) -> SophismCandidate:
+    """Compact opaque-atom builder for readable test fixtures."""
+
+    return SophismCandidate(
+        candidate_id=cid,
+        family=family,
+        span_id=span,
+        confidence=confidence,
+        failed_critical_questions=cqs,
+    )
+
+
+class TestBuildDungFramework:
+    def test_clean_batch_yields_no_attacks(self) -> None:
+        cands = [_cand("s0", span="span_0"), _cand("s1", span="span_1")]
+        args, attacks, challenger_for = build_dung_framework(cands)
+        assert args == {"s0", "s1"}
+        assert attacks == set()
+        assert challenger_for == {}
+
+    def test_failed_cq_creates_unattacked_challenger(self) -> None:
+        cands = [_cand("s0", cqs=("Is the expert really competent?",))]
+        args, attacks, challenger_for = build_dung_framework(cands)
+        assert len(challenger_for) == 1
+        challenger = next(iter(challenger_for))
+        assert challenger.startswith(_CQ_CHALLENGER_PREFIX)
+        assert challenger_for[challenger] == "s0"
+        assert (challenger, "s0") in attacks
+        # The challenger is unattacked (nothing attacks it).
+        assert not any(tgt == challenger for _, tgt in attacks)
+
+    def test_duplicate_critical_question_yields_single_challenger(self) -> None:
+        cands = [_cand("s0", cqs=("Q1", "Q1"))]
+        _, attacks, challenger_for = build_dung_framework(cands)
+        assert len(challenger_for) == 1
+        assert sum(1 for _, tgt in attacks if tgt == "s0") == 1
+
+    def test_same_span_different_family_directed_by_confidence(self) -> None:
+        cands = [
+            _cand("s0", family="ad_hominem", span="x", confidence=0.8),
+            _cand("s1", family="straw_man", span="x", confidence=0.4),
+        ]
+        attacks = default_conflict_policy(cands)
+        assert attacks == {("s0", "s1")}
+
+    def test_same_span_same_family_no_conflict(self) -> None:
+        cands = [
+            _cand("s0", family="ad_hominem", span="x", confidence=0.8),
+            _cand("s1", family="ad_hominem", span="x", confidence=0.4),
+        ]
+        assert default_conflict_policy(cands) == set()
+
+    def test_same_span_tie_yields_mutual_attack(self) -> None:
+        cands = [
+            _cand("s0", family="ad_hominem", span="x", confidence=0.5),
+            _cand("s1", family="straw_man", span="x", confidence=0.5),
+        ]
+        assert default_conflict_policy(cands) == {("s0", "s1"), ("s1", "s0")}
+
+    def test_distinct_spans_never_conflict(self) -> None:
+        cands = [
+            _cand("s0", family="a", span="x", confidence=0.9),
+            _cand("s1", family="b", span="y", confidence=0.1),
+        ]
+        assert default_conflict_policy(cands) == set()
+
+    def test_candidate_id_colliding_with_prefix_rejected(self) -> None:
+        with pytest.raises(ValueError, match="collides with the reserved"):
+            SophismCandidate(
+                candidate_id=_CQ_CHALLENGER_PREFIX + "s0",
+                family="a",
+                span_id="x",
+                confidence=0.5,
+            )
+
+
+class TestGroundedExtensionPure:
+    def test_no_attackers_all_accepted(self) -> None:
+        accepted = _grounded_extension_pure({"a", "b", "c"}, set())
+        assert accepted == frozenset({"a", "b", "c"})
+
+    def test_two_cycle_neither_accepted(self) -> None:
+        attacks = {("a", "b"), ("b", "a")}
+        assert _grounded_extension_pure({"a", "b"}, attacks) == frozenset()
+
+    def test_unattacked_attacker_defeats_target(self) -> None:
+        # c attacks b, nothing attacks c → b rejected, c and a accepted.
+        attacks = {("c", "b")}
+        assert _grounded_extension_pure({"a", "b", "c"}, attacks) == frozenset(
+            {"a", "c"}
+        )
+
+    def test_defender_reinstates_attacked_argument(self) -> None:
+        # c attacks b, a attacks c → a survives (unattacked), b is defended by a
+        # (reinstated), c is defeated by a. Grounded = {a, b}.
+        attacks = {("c", "b"), ("a", "c")}
+        assert _grounded_extension_pure({"a", "b", "c"}, attacks) == frozenset(
+            {"a", "b"}
+        )
+
+    def test_pure_solver_rejects_non_grounded_semantics(self) -> None:
+        with pytest.raises(NotImplementedError, match="only grounded"):
+            pure_python_solver({"a"}, set(), semantics="preferred")
+
+
+class TestArbitrate:
+    def test_honest_absent_keeps_all_candidates(self) -> None:
+        cands = [_cand("s0", span="x"), _cand("s1", span="y"), _cand("s2", span="z")]
+        res = arbitrate(cands)
+        assert isinstance(res, ArbitrationResult)
+        assert res.honest_absent is True
+        assert res.arbitrated_ids == frozenset({"s0", "s1", "s2"})
+        assert res.rejected == {}
+        assert res.neural_count == 3
+        assert res.arbitrated_count == 3
+
+    def test_candidate_with_failed_cq_is_rejected(self) -> None:
+        cands = [
+            _cand("s0", span="x", cqs=("Is the source independent?",)),
+            _cand("s1", span="y"),
+        ]
+        res = arbitrate(cands)
+        assert res.honest_absent is False
+        assert res.arbitrated_ids == frozenset({"s1"})
+        assert res.rejected == {"s0": "defeated_by_unsatisfied_critical_question"}
+
+    def test_rival_loser_rejected_winner_kept(self) -> None:
+        cands = [
+            _cand("s0", family="ad_hominem", span="x", confidence=0.9),
+            _cand("s1", family="straw_man", span="x", confidence=0.3),
+        ]
+        res = arbitrate(cands)
+        assert res.arbitrated_ids == frozenset({"s0"})
+        assert res.rejected == {"s1": "defeated_by_rival_candidate"}
+
+    def test_mixed_cq_and_rival_dimensions(self) -> None:
+        # s0 fails a CQ (rejected); s1 and s2 rival on span x, s1 wins.
+        cands = [
+            _cand("s0", span="y", cqs=("Q?",)),
+            _cand("s1", family="a", span="x", confidence=0.9),
+            _cand("s2", family="b", span="x", confidence=0.2),
+        ]
+        res = arbitrate(cands)
+        assert res.arbitrated_ids == frozenset({"s1"})
+        assert set(res.rejected) == {"s0", "s2"}
+
+    def test_custom_conflict_policy_can_disable_rivalry(self) -> None:
+        cands = [
+            _cand("s0", family="a", span="x", confidence=0.9),
+            _cand("s1", family="b", span="x", confidence=0.2),
+        ]
+        res = arbitrate(cands, conflict_policy=lambda _c: set())
+        # No rivalry, no CQ → honest-absent, both kept.
+        assert res.honest_absent is True
+        assert res.arbitrated_ids == frozenset({"s0", "s1"})
+
+    def test_injected_solver_with_multiple_extensions_is_skeptical(self) -> None:
+        # Custom solver returns 2 preferred extensions; only the candidate in
+        # BOTH survives the skeptical intersection.
+        cands = [_cand("s0"), _cand("s1")]
+
+        def two_ext(
+            arguments: set[str],
+            attacks: set[tuple[str, str]],
+            *,
+            semantics: str,
+        ) -> list[set[str]]:
+            return [{"s0", "s1"}, {"s0"}]
+
+        res = arbitrate(cands, solver=two_ext, semantics="preferred")
+        assert res.arbitrated_ids == frozenset({"s0"})
+        assert res.semantics == "preferred"
+
+    def test_attacks_recorded_on_result(self) -> None:
+        cands = [
+            _cand("s0", span="x", cqs=("Q?",)),
+            _cand("s1", family="b", span="x", confidence=0.1),
+        ]
+        res = arbitrate(cands)
+        # At least one challenger→s0 attack and the rivalry edge s0→s1.
+        assert any(
+            a.startswith(_CQ_CHALLENGER_PREFIX) and b == "s0" for a, b in res.attacks
+        )
+        assert ("s0", "s1") in res.attacks
+
+
+class TestDungAgentSolverAdapter:
+    def test_factory_does_not_touch_jvm_at_import(self) -> None:
+        # Building the solver closure must be cheap and JVM-free; only calling
+        # it (in PR2/PR3 with a live JVM) should touch jpype.
+        solver = make_dung_agent_solver()
+        assert callable(solver)
+
+    def test_solver_raises_without_jvm(self) -> None:
+        import jpype
+
+        if jpype.isJVMStarted():
+            pytest.skip(
+                "JVM already started in this process; cannot assert the no-JVM path"
+            )
+        solver = make_dung_agent_solver()
+        with pytest.raises(RuntimeError, match="La JVM doit être démarrée"):
+            solver({"a"}, set(), semantics="grounded")


### PR DESCRIPTION
## Track I1 #1429 — PR1/3 (NORTH-STAR, lane po-2023)

Dispatched by coordinator R593. A **symbolic arbitrage layer** on top of the existing neural detector (`taxonomy_sophism_detector.py`) and the existing Dung solver (`abs_arg_dung/`). It does **not** re-implement detection nor the solver.

### Mechanism
Neural sophism candidates → Dung AF → accepted extension = arbitrated set.
- Each candidate = an argument (opaque atom).
- An **unsatisfied Walton critical question** (declared by the candidate) → an unattacked *challenger* argument attacking that candidate → defeated under grounded exactly when a CQ is genuinely unsatisfied.
- **Same-span / rival-family** candidates (the issue's own example: one passage flagged as both *ad hominem* and *straw man*) → confidence-directed attack (strict winner attacks loser; exact tie ⇒ mutual attack).

### Anti-fabrication (#1019 / anti-théâtre)
The arbitrator **never invents** a fallacy, a conflict, or a CQ failure. It only mechanically turns **declared** signals into attacks. With no declared signal ⇒ empty attack set ⇒ grounded extension = all arguments ⇒ **neuro-symbolic == neural** (transparent, honest-absent). This is mandated by the issue.

### JVM-free by design (DI)
The Dung solver is an injected `DungSolver` callable (Protocol):
- `pure_python_solver` (grounded) = default, used by all unit tests — **no JVM, no LLM**.
- `make_dung_agent_solver()` = thin lazy adapter wrapping the real `abs_arg_dung.DungAgent` for PR2/PR3 production wiring (mirrors the `compare_*_backends` DI idiom).

### DoD (PR1 scope)
- [x] Arbitrage Dung fonctionnel (`arbitrate()` → `ArbitrationResult`)
- [x] Honest-absent quand pas de conflit genuine (no failed CQ + no same-span rivalry ⇒ arbitrated == neural)
- [x] Tests unitaires atomes opaques synthétiques, **pas de JVM/LLM requis** (21 pass, 1 skip JVM-gated)
- [x] Anti-théâtre : aucune attaque fabriquée — every rejection traces to a declared CQ or a declared rivalry
- [x] Composants existants réutilisés (detector output shape + `abs_arg_dung` solver), pas de ré-implémentation

### Validation
- `mypy --config-file pyproject.toml` : **Success** (module hors strict-override list ; `no-untyped-call` sur `DungAgent()` supprimé via l'idiome repo `# type: ignore[no-untyped-call]` — cf. `BipolarHandler()`/`ABAHandler()` dans invoke_callables)
- `black` : clean
- `pytest` : **21 passed, 1 skipped** (le skip = test du path no-JVM ; JVM démarrée dans ce process → skip légitime, s'exécute en CI sans JVM)

### Lane disjointness
NO file under `orchestration/` is touched (po-2025 TR-2/I5 lane). Only:
- `argumentation_analysis/agents/core/informal/neuro_symbolic_arbitrator.py` (new)
- `tests/unit/argumentation_analysis/agents/core/informal/test_neuro_symbolic_arbitrator.py` (new)

### Privacy
Synthetic opaque atoms only (`s0`, `family_a`, `span_0`); no corpus text in code/tests. PR3 (later) will probe real corpus with opaque IDs (`corpus_A`, `Speaker_A`).

### Next (deep-queue)
- **PR2** — selectable/comparable mode `neural|neuro-symbolic` (wire the neural→CQ bridge using `argumentation_schemes.py`, expose a `compare_sophism_backends`).
- **PR3** — real-corpus probe (opaque IDs) + synthesis report.

Closes nothing yet (PR1 of 3). Refs #1429.