### PR TITLE
feat(orchestration): wire dung_mode=compare into _invoke_dung_extensions (I5 #1430)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -6463,12 +6463,45 @@ async def _invoke_dung_extensions(
     #908: If ``context["dung_provider_hint"]`` is set to
     ``"abs_arg_dung_student"``, delegates to the student Dung provider
     instead of the native AFHandler.
+
+    I5 #1430: If ``context["dung_mode"]`` is set to ``"compare"``, runs EVERY
+    available backend on the same AF and surfaces per-semantics agreement /
+    disagreement (never auto-reconciled, anti-pendule #1019). Backends that
+    cannot run are reported ``unavailable`` (fail-loud), never omitted. See
+    :func:`_compare_dung_backends`.
     """
     # 1. Extract arguments from upstream phases
     arguments = _extract_arguments_from_context(input_text, context)
 
     # 2. Build attack relations from fallacies and counter-arguments
     attacks = _generate_attacks_from_args(arguments, context)
+
+    # I5 #1430: compare mode — run every available backend on the same AF and
+    # surface agreement / disagreement (never auto-reconciled). Short-circuits
+    # the single-backend selection below; a backend that cannot run is reported
+    # ``unavailable`` (fail-loud) inside the comparison payload.
+    dung_mode = context.get("dung_mode")
+    if dung_mode == "compare":
+        comparison = await _compare_dung_backends(arguments, attacks)
+        logger.info(
+            "Dung extensions computed in compare mode (%d backend(s)) — "
+            "overall_agreement=%s",
+            comparison["statistics"]["backends_count"],
+            comparison["comparison"]["overall_agreement"],
+        )
+        return {
+            "semantics": "multi_compare",
+            "comparison": comparison["comparison"],
+            "backends": comparison["backends"],
+            "arguments": arguments,
+            "attacks": attacks,
+            "statistics": comparison["statistics"],
+            "note": (
+                "I5 #1430: multi-backend comparison. Disagreements are surfaced "
+                "per-semantics and NEVER auto-reconciled (anti-pendule #1019); "
+                "unavailable backends are reported, never omitted."
+            ),
+        }
 
     # #908: Provider selection — delegate to student provider if hinted
     provider_hint = context.get("dung_provider_hint")

--- a/tests/unit/argumentation_analysis/orchestration/test_compare_dung_backends.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_compare_dung_backends.py
@@ -205,3 +205,110 @@ class TestStructure:
             "A",
             "B",
         ]
+
+
+# -- wiring into _invoke_dung_extensions (I5 PR2) ----------------------------
+
+
+class TestDungCompareWiring:
+    """dung_mode="compare" routes _invoke_dung_extensions through the
+    multi-backend comparison, surfacing agreement (never reconciled) without a
+    JVM — the real backends are monkeypatched to deterministic fakes."""
+
+    async def test_compare_mode_routes_to_comparison(self, monkeypatch):
+        from argumentation_analysis.orchestration import invoke_callables as ic
+
+        # Monkeypatch the real comparison fn → deterministic fake (no JVM).
+        fake_comparison = {
+            "backends": {
+                "tweety": {"extensions": {"grounded": [["a", "b"]]}, "available": True},
+                "student": {"extensions": {"grounded": [["a"]]}, "available": True},
+            },
+            "comparison": {
+                "semantics": ["grounded"],
+                "per_semantics": {
+                    "grounded": {
+                        "agreement": False,
+                        "decided": ["tweety", "student"],
+                        "disagreement": ["tweety vs student"],
+                    }
+                },
+                "overall_agreement": False,
+            },
+            "statistics": {"arguments_count": 2, "attacks_count": 1, "backends_count": 2},
+        }
+
+        async def _fake_compare(arguments, attacks, **kwargs):
+            return fake_comparison
+
+        monkeypatch.setattr(ic, "_compare_dung_backends", _fake_compare)
+
+        ctx = {
+            "phase_extract_output": {"arguments": ["a", "b"]},
+            "dung_mode": "compare",
+        }
+        out = await ic._invoke_dung_extensions("source text", ctx)
+
+        assert out["semantics"] == "multi_compare"
+        assert out["comparison"]["overall_agreement"] is False
+        assert out["statistics"]["backends_count"] == 2
+        # Disagreement surfaced verbatim, never reconciled.
+        assert out["comparison"]["per_semantics"]["grounded"]["disagreement"] == [
+            "tweety vs student"
+        ]
+        assert "NEVER auto-reconciled" in out["note"]
+
+    async def test_default_mode_does_not_compare(self, monkeypatch):
+        # Without dung_mode="compare", the comparison fn is NEVER invoked.
+        from argumentation_analysis.orchestration import invoke_callables as ic
+
+        called = {"n": 0}
+
+        async def _fake_compare(arguments, attacks, **kwargs):
+            called["n"] += 1
+            return {}
+
+        monkeypatch.setattr(ic, "_compare_dung_backends", _fake_compare)
+        # Monkeypatch the native AFHandler path so no JVM is needed: make the
+        # try-block raise → degraded honest-absent return (the real fallback).
+        monkeypatch.setattr(
+            ic.asyncio, "to_thread", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("no JVM"))
+        )
+
+        ctx = {"phase_extract_output": {"arguments": ["a", "b"]}}
+        out = await ic._invoke_dung_extensions("source text", ctx)
+
+        assert called["n"] == 0  # compare fn never invoked (default mode)
+        assert out["semantics"] == "unavailable"  # degraded honest-absent (no JVM)
+
+    async def test_compare_mode_available_backend_unavailable_reported(self, monkeypatch):
+        # Even in compare mode, an unavailable backend is reported, not omitted.
+        from argumentation_analysis.orchestration import invoke_callables as ic
+
+        fake_comparison = {
+            "backends": {
+                "tweety": {"extensions": {}, "available": False, "note": "no JVM"},
+                "student": {"extensions": {}, "available": False, "note": "no JVM"},
+            },
+            "comparison": {
+                "semantics": ["grounded"],
+                "per_semantics": {"grounded": {"agreement": None, "decided": [], "disagreement": []}},
+                "overall_agreement": None,
+            },
+            "statistics": {"arguments_count": 1, "attacks_count": 0, "backends_count": 2},
+        }
+
+        async def _fake_compare(arguments, attacks, **kwargs):
+            return fake_comparison
+
+        monkeypatch.setattr(ic, "_compare_dung_backends", _fake_compare)
+
+        ctx = {
+            "phase_extract_output": {"arguments": ["a"]},
+            "dung_mode": "compare",
+        }
+        out = await ic._invoke_dung_extensions("source text", ctx)
+        # Both backends reported unavailable (fail-loud), agreement indeterminate.
+        assert out["backends"]["tweety"]["available"] is False
+        assert out["backends"]["student"]["available"] is False
+        assert out["comparison"]["overall_agreement"] is None


### PR DESCRIPTION
feat(orchestration): wire dung_mode=compare into _invoke_dung_extensions (I5 #1430)

Second PR of the I5 lane (#1430): make the multi-backend Dung comparison
(PR1 #1432, merged) SELECTABLE in the pipeline, aligned with the NORTH-STAR
parametric integration. _invoke_dung_extensions gains a ``compare`` mode
alongside the existing single-backend hint selection.

invoke_callables.py:
- When ``context["dung_mode"] == "compare"``, _invoke_dung_extensions
  short-circuits the single-backend selection and runs
  _compare_dung_backends over the same AF (arguments + attacks already built).
  The returned payload is shaped {semantics: "multi_compare", comparison,
  backends, arguments, attacks, statistics, note}. The note states explicitly
  that disagreements are NEVER auto-reconciled (anti-pendule #1019) and
  unavailable backends are reported, never omitted.

This keeps the existing default path unchanged: a caller that does NOT set
dung_mode continues through the hint-based single-backend selection (Tweety
AFHandler or DungStudentProvider), then the honest-absent degraded return.
The compare mode is opt-in via the context key, mirroring how the other axes
admit genuine parametric input (NORTH-STAR).

Anti-pendule / anti-théâtre #1019 (DoD): the comparison payload surfaces
disagreement per-semantics verbatim and NEVER reconciles it; a backend that
cannot run is reported available=False (fail-loud), never silently dropped.
The single-backend default path is NOT modified (no pendulum — additive
opt-in mode only). abs_arg_dung/ sanctuary and state_writers.py gate are NOT
in the diff.

Tests (3 new wiring, no JVM / no real LLM): dung_mode="compare" routes through
the comparison and returns the multi_compare shape with disagreement surfaced
verbatim (real backends monkeypatched to deterministic fakes); default mode
(without the key) NEVER invokes the comparison fn (degraded honest-absent
return when JVM is absent); an unavailable backend in compare mode is reported
not omitted (agreement None). 20 pass in the file (17 PR1 + 3 wiring).

This is PR2 of 3. PR3 probes a real corpus (opaque IDs) + synthesis report.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
