### PR TITLE
feat(informal): neuro-symbolic sophism arbitrator + LLM cq_evaluator (I1 #1429 PR2+PR3)

### DIFF
--- a/argumentation_analysis/agents/core/informal/neuro_symbolic_arbitrator.py
+++ b/argumentation_analysis/agents/core/informal/neuro_symbolic_arbitrator.py
@@ -46,7 +46,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field, replace
-from typing import Callable, Optional, Protocol, Sequence, runtime_checkable
+from typing import Any, Callable, Optional, Protocol, Sequence, runtime_checkable
 
 from argumentation_analysis.agents.core.debate.argumentation_schemes import (
     ArgumentationScheme,
@@ -571,3 +571,163 @@ def compare_sophism_backends(
         eliminated_ids=neural_ids - result.arbitrated_ids,
         span_coverage=coverage,
     )
+
+
+# --------------------------------------------------------------------------- #
+# PR3 — Real LLM cq_evaluator (production wiring of the bridge)               #
+# --------------------------------------------------------------------------- #
+#
+# PR2 keeps the bridge honest-absent by default: the default evaluator declares
+# ZERO unsatisfied critical questions. PR3 supplies a real evaluator that asks
+# the LLM (OpenAI / OpenRouter via ``invoke_callables`` helpers) which of a
+# candidate's scheme's canonical Walton critical questions are genuinely
+# unsatisfied for that span.
+#
+# The mirror is exact of the TR-1/TR-2 structured_arg_translator pattern:
+#   * lazy import of invoke_callables helpers (avoids any module-load cycle),
+#   * no API key ⇒ returns () so the call fails-soft to honest-absent,
+#   * JSON-mode response parsed by ``_parse_json_from_llm``,
+#   * validations: ``failed`` keys must be MEMBERS of the scheme's canonical
+#     critical_questions (the bridge re-validates against the same canonical
+#     set, so this is double-belt-and-braces anti-fabrication).
+#
+# Exposed as :func:`make_llm_cq_evaluator` returning a ``CQEvaluator``-compatible
+# async-callable. The CQEvaluator protocol is sync today — PR3 keeps the sync
+# shape (the bridge does NOT await), wrapping the async LLM call synchronously
+# via ``asyncio.run`` from the probe side, mirroring how ``compare_sophism_backends``
+# is called from synchronous PR3 probe code.
+
+# Async signature of the LLM-backed CQ evaluator. The synchronous CQEvaluator
+# used by :func:`walton_cq_bridge` is the production entry point; the async form
+# lets the probe ``await`` it once per candidate without spinning a thread.
+AsyncCQEvaluator = Callable[[str, ArgumentationScheme, SophismCandidate], "Any"]
+
+
+async def _llm_cq_evaluator_async(
+    span_text: str, scheme: ArgumentationScheme, candidate: SophismCandidate
+) -> Sequence[str]:
+    """Ask the LLM which canonical critical questions this span genuinely fails.
+
+    Mirrors :func:`_llm_extract_relations` (TR-1/TR-2 pattern): lazy imports,
+    no-API-key honest-absent, JSON-mode parse, fail-soft exception handling.
+    Validates against the scheme's canonical CQ set as a defence-in-depth guard
+    on top of the bridge's same check.
+
+    Returns an empty tuple on any failure path — the bridge's anti-fabrication
+    posture means a failure to evaluate MUST stay transparent, not invent CQ
+    failures. PR3 probe surfaces the failure mode (key missing, parse, etc.) via
+    the caller's own logging.
+    """
+
+    # Lazy import: invoke_callables imports the informal modules lazily from the
+    # handlers, so importing its helpers here is safe at call time (no cycle).
+    from argumentation_analysis.orchestration.invoke_callables import (
+        _get_determinism_params,
+        _get_openai_client,
+        _guarded_chat_completion,
+        _parse_json_from_llm,
+    )
+
+    canonical_cqs = list(scheme.critical_questions)
+    if not canonical_cqs:
+        return ()
+
+    client, model_id = _get_openai_client()
+    if client is None:
+        logger.info("LLM cq_evaluator: no API key configured — staying honest-absent.")
+        return ()
+
+    canonical_list = "; ".join(f"- {q}" for q in canonical_cqs)
+    system_content = (
+        "You are an expert in Walton-style argumentation schemes. "
+        "For the given passage and its classified argumentation scheme, decide "
+        "which of the scheme's canonical critical questions are GENUINELY "
+        "unsatisfied by the passage — i.e. which CQ, if asked of the passage, "
+        "would expose a real weakness. Report a CQ ONLY when the passage "
+        "genuinely fails to satisfy it. If none are genuinely unsatisfied, "
+        "return an empty list. Do NOT invent failures. "
+        f"Candidate id: {candidate.candidate_id} (opaque, ignore its meaning). "
+        f"Canonical critical questions of scheme « {scheme.label} »: "
+        f"{canonical_list}. "
+        "Respond with ONLY a JSON object of shape: "
+        '{"failed": ["verbatim CQ text 1", ...]}'
+    )
+    user_content = (
+        f"Scheme key: {scheme.key}\n"
+        f"Passage (the candidate's evidence span):\n{span_text[:3000]}\n\n"
+        "Return the JSON."
+    )
+
+    det_params = _get_determinism_params()
+    llm_kwargs: dict[str, Any] = dict(det_params)
+    llm_kwargs["response_format"] = {"type": "json_object"}
+    try:
+        response = await _guarded_chat_completion(
+            client,
+            model=model_id,
+            messages=[
+                {"role": "system", "content": system_content},
+                {"role": "user", "content": user_content},
+            ],
+            **llm_kwargs,
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-soft: any LLM error → honest-absent
+        logger.info("LLM cq_evaluator: call failed (%s); staying honest-absent.", exc)
+        return ()
+
+    raw = response.choices[0].message.content or ""
+    try:
+        data = _parse_json_from_llm(raw)
+    except Exception as exc:  # noqa: BLE001
+        logger.info("LLM cq_evaluator: parse failed (%s); staying honest-absent.", exc)
+        return ()
+
+    declared = data.get("failed") if isinstance(data, dict) else None
+    if not isinstance(declared, list):
+        return ()
+    canonical_set = set(canonical_cqs)
+    return tuple(q for q in declared if isinstance(q, str) and q in canonical_set)
+
+
+def make_llm_cq_evaluator() -> CQEvaluator:
+    """Build a synchronous ``CQEvaluator`` wrapping the async LLM-backed one.
+
+    The bridge's :func:`walton_cq_bridge` consumes a sync callable. The returned
+    ``CQEvaluator`` runs the async LLM call to completion via
+    ``asyncio.run`` — safe from the PR3 probe (sync entry point that runs once
+    per candidate). If called from an already-running event loop (e.g. inside
+    another async context), the call fails soft: returns () so the bridge stays
+    honest-absent for that candidate rather than crashing the run.
+
+    Lazy-imports the async helper so importing this module stays LLM-free (no
+    network calls at import time, no module-load cycle with ``invoke_callables``).
+    """
+
+    def _sync(
+        span_text: str, scheme: ArgumentationScheme, candidate: SophismCandidate
+    ) -> Sequence[str]:
+        try:
+            import asyncio
+
+            asyncio.get_running_loop()
+        except RuntimeError:
+            # No running loop — safe to drive the async helper synchronously.
+            try:
+                return asyncio.run(
+                    _llm_cq_evaluator_async(span_text, scheme, candidate)
+                )
+            except Exception as exc:  # noqa: BLE001 — fail-soft
+                logger.info(
+                    "LLM cq_evaluator (sync wrapper): run failed (%s); "
+                    "staying honest-absent.",
+                    exc,
+                )
+                return ()
+        # Already inside an event loop — cannot asyncio.run. Fail soft.
+        logger.info(
+            "LLM cq_evaluator: sync wrapper called from a running loop; "
+            "staying honest-absent. Use _llm_cq_evaluator_async directly."
+        )
+        return ()
+
+    return _sync

--- a/argumentation_analysis/agents/core/informal/neuro_symbolic_arbitrator.py
+++ b/argumentation_analysis/agents/core/informal/neuro_symbolic_arbitrator.py
@@ -45,8 +45,13 @@ for production use in PR2/PR3. This mirrors the ``compare_*_backends`` DI idiom.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Callable, Optional, Protocol, Sequence, runtime_checkable
+
+from argumentation_analysis.agents.core.debate.argumentation_schemes import (
+    ArgumentationScheme,
+    classify_scheme,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -390,4 +395,179 @@ def arbitrate(
         honest_absent=honest_absent,
         neural_count=len(candidate_ids),
         arbitrated_count=len(arbitrated_ids),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# PR2 — Walton critical-question bridge + neural/neuro-symbolic comparison    #
+# --------------------------------------------------------------------------- #
+#
+# The arbitrator consumes ``failed_critical_questions`` as an opaque declared
+# signal (PR1). PR2 wires the NEURAL→SYMBOLIC bridge that produces that
+# declaration honestly: for each candidate, classify the argumentation scheme of
+# its evidence span (``classify_scheme``), then ask an injected evaluator which
+# of that scheme's *canonical* Walton critical questions are genuinely
+# unsatisfied. The bridge only ever propagates questions that are members of the
+# classified scheme's canonical set — an evaluator can never inject a question
+# the scheme does not actually ask. This is the hard anti-fabrication guard.
+#
+# The default evaluator declares ZERO unsatisfied questions (honest-absent), so
+# without a genuine evaluator (LLM, wired in PR3) the bridge is a no-op and the
+# neuro-symbolic pipeline coincides exactly with the neural one. This keeps PR2
+# JVM/LLM-free and unit-testable while PR3 supplies the real evaluation.
+
+# Classifies a span's text to its Walton argumentation scheme (or None). DI so
+# tests can inject a deterministic classifier; default is the real
+# ``argumentation_schemes.classify_scheme``.
+SchemeClassifier = Callable[[str], Optional[ArgumentationScheme]]
+
+# Given a span, its scheme, and the candidate under test, returns the critical
+# questions the passage genuinely fails to satisfy. The contract is honesty: the
+# caller (the bridge) validates the result against the scheme's canonical CQs,
+# but the evaluator itself must not fabricate failures — return an empty sequence
+# when none are genuinely unsatisfied.
+CQEvaluator = Callable[[str, ArgumentationScheme, SophismCandidate], Sequence[str]]
+
+
+def default_cq_evaluator(
+    span_text: str,
+    scheme: ArgumentationScheme,
+    candidate: SophismCandidate,
+) -> Sequence[str]:
+    """Declare ZERO unsatisfied critical questions.
+
+    Honest-absent by construction: without a genuine evaluator (LLM in PR3), the
+    bridge must not invent any critical-question failure. The neuro-symbolic
+    pipeline therefore coincides with the neural one until a real evaluator is
+    injected — the anti-théâtre guarantee.
+    """
+
+    return ()
+
+
+def walton_cq_bridge(
+    candidates: Sequence[SophismCandidate],
+    *,
+    span_text_for: Callable[[SophismCandidate], str],
+    classifier: Optional[SchemeClassifier] = None,
+    cq_evaluator: Optional[CQEvaluator] = None,
+) -> tuple[list[SophismCandidate], dict[str, str]]:
+    """Enrich candidates with their unsatisfied Walton critical questions.
+
+    For each candidate, classifies the argumentation scheme of its evidence span
+    (``span_text_for``), then asks ``cq_evaluator`` which of that scheme's
+    canonical critical questions are genuinely unsatisfied. Returns new
+    ``SophismCandidate`` instances with ``failed_critical_questions`` set to the
+    validated subset.
+
+    Anti-fabrication: only critical questions that are MEMBERS of the classified
+    scheme's canonical ``critical_questions`` are propagated — an evaluator can
+    never inject a question the scheme does not actually ask. When no scheme is
+    classified for a span (``classify_scheme`` returns ``None``), the candidate is
+    returned unchanged with no declared CQ.
+
+    Args:
+        candidates: Raw neural candidates.
+        span_text_for: Yields the evidence-span text for a candidate. Supplied by
+            the upstream caller that holds the real text + segmentation (PR3).
+        classifier: Scheme classifier (default: ``classify_scheme``).
+        cq_evaluator: CQ evaluator (default: :func:`default_cq_evaluator` —
+            declares nothing, honest-absent).
+
+    Returns:
+        ``(enriched_candidates, span_coverage)`` where ``span_coverage`` maps each
+        candidate id to the classified scheme key (``""`` when no scheme matched)
+        — useful for PR3's synthesis report.
+    """
+
+    cls = classifier or classify_scheme
+    evaluator = cq_evaluator or default_cq_evaluator
+
+    enriched: list[SophismCandidate] = []
+    coverage: dict[str, str] = {}
+    for cand in candidates:
+        span_text = span_text_for(cand)
+        scheme = cls(span_text)
+        coverage[cand.candidate_id] = scheme.key if scheme is not None else ""
+
+        failed: tuple[str, ...] = ()
+        if scheme is not None:
+            canonical = set(scheme.critical_questions)
+            declared = evaluator(span_text, scheme, cand)
+            # Hard anti-fabrication guard: keep only declared questions that are
+            # genuine members of THIS scheme's canonical critical questions.
+            failed = tuple(q for q in declared if q in canonical)
+
+        enriched.append(replace(cand, failed_critical_questions=failed))
+
+    return enriched, coverage
+
+
+@dataclass(frozen=True)
+class SophismComparison:
+    """Side-by-side neural vs neuro-symbolic outcome (NORTH-STAR comparable).
+
+    ``neural_ids`` is the raw detector output (all candidates kept);
+    ``neuro_symbolic_ids`` is the set that survives Dung arbitrage after the
+    Walton CQ bridge. ``eliminated_ids`` = ``neural_ids - neuro_symbolic_ids``
+    (the candidates the symbolic layer rejected), and ``arbitrated`` carries the
+    full diagnostics (rejected reasons, attacks, challengers) so PR3 can render a
+    detailed comparison report. ``span_coverage`` maps each candidate id to the
+    Walton scheme key classified on its span (``""`` if none).
+    """
+
+    neural_ids: frozenset[str]
+    neuro_symbolic_ids: frozenset[str]
+    arbitrated: ArbitrationResult
+    eliminated_ids: frozenset[str]
+    span_coverage: dict[str, str]
+
+
+def compare_sophism_backends(
+    candidates: Sequence[SophismCandidate],
+    *,
+    span_text_for: Callable[[SophismCandidate], str],
+    classifier: Optional[SchemeClassifier] = None,
+    cq_evaluator: Optional[CQEvaluator] = None,
+    solver: Optional[DungSolver] = None,
+    semantics: str = "grounded",
+    conflict_policy: Optional[ConflictPolicy] = None,
+) -> SophismComparison:
+    """Compare the neural-only and neuro-symbolic pipelines on the same batch.
+
+    **Neural** = all candidates kept (raw detector output). **Neuro-symbolic** =
+    candidates enriched by :func:`walton_cq_bridge` then arbitrated under Dung
+    semantics via :func:`arbitrate`. The comparison surfaces exactly which
+    candidates the symbolic layer eliminates and why (through the embedded
+    :class:`ArbitrationResult`), realising the NORTH-STAR
+    "selectable/comparable" requirement.
+
+    With the default evaluator (no genuine CQ evaluation), the bridge declares no
+    failures and the two pipelines coincide — the symbolic layer is transparent
+    until there is something genuine to arbitrate. Inject ``cq_evaluator`` (PR3
+    wires a real LLM evaluator) and/or ``solver`` to exercise real defeats.
+
+    Args mirror :func:`arbitrate` plus the bridge's ``span_text_for`` /
+    ``classifier`` / ``cq_evaluator``.
+    """
+
+    neural_ids = frozenset(c.candidate_id for c in candidates)
+    enriched, coverage = walton_cq_bridge(
+        candidates,
+        span_text_for=span_text_for,
+        classifier=classifier,
+        cq_evaluator=cq_evaluator,
+    )
+    result = arbitrate(
+        enriched,
+        solver=solver,
+        semantics=semantics,
+        conflict_policy=conflict_policy,
+    )
+    return SophismComparison(
+        neural_ids=neural_ids,
+        neuro_symbolic_ids=result.arbitrated_ids,
+        arbitrated=result,
+        eliminated_ids=neural_ids - result.arbitrated_ids,
+        span_coverage=coverage,
     )

--- a/tests/unit/argumentation_analysis/agents/core/informal/test_neuro_symbolic_arbitrator.py
+++ b/tests/unit/argumentation_analysis/agents/core/informal/test_neuro_symbolic_arbitrator.py
@@ -19,13 +19,19 @@ import pytest
 from argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator import (
     ArbitrationResult,
     SophismCandidate,
+    SophismComparison,
     _CQ_CHALLENGER_PREFIX,
     _grounded_extension_pure,
     arbitrate,
     build_dung_framework,
+    compare_sophism_backends,
     default_conflict_policy,
     make_dung_agent_solver,
     pure_python_solver,
+    walton_cq_bridge,
+)
+from argumentation_analysis.agents.core.debate.argumentation_schemes import (
+    classify_scheme,
 )
 
 
@@ -220,6 +226,117 @@ class TestArbitrate:
             a.startswith(_CQ_CHALLENGER_PREFIX) and b == "s0" for a, b in res.attacks
         )
         assert ("s0", "s1") in res.attacks
+
+
+class TestWaltonCqBridge:
+    # A span that deterministically matches the expert_opinion scheme keyword set
+    # ["expert", "domaine"] so tests get a real scheme with real CQs.
+    _EXPERT_SPAN = "Selon un expert du domaine, la mesure est efficace."
+
+    def test_no_scheme_leaves_candidate_unchanged(self) -> None:
+        enriched, coverage = walton_cq_bridge(
+            [_cand("s0")], span_text_for=lambda c: "zzzzz"
+        )
+        assert enriched[0].failed_critical_questions == ()
+        assert coverage == {"s0": ""}
+
+    def test_default_evaluator_is_honest_absent(self) -> None:
+        enriched, coverage = walton_cq_bridge(
+            [_cand("s0")], span_text_for=lambda c: self._EXPERT_SPAN
+        )
+        # Default evaluator declares nothing → no CQ, but the scheme is recorded.
+        assert enriched[0].failed_critical_questions == ()
+        assert coverage == {"s0": "expert_opinion"}
+
+    def test_canonical_cq_is_propagated(self) -> None:
+        scheme = classify_scheme(self._EXPERT_SPAN)
+        assert scheme is not None
+        canonical_cq = scheme.critical_questions[0]
+
+        def ev(_t: str, _s: object, _c: SophismCandidate) -> tuple[str, ...]:
+            return (canonical_cq,)
+
+        enriched, _ = walton_cq_bridge(
+            [_cand("s0")], span_text_for=lambda c: self._EXPERT_SPAN, cq_evaluator=ev
+        )
+        assert canonical_cq in enriched[0].failed_critical_questions
+
+    def test_non_canonical_cq_is_dropped_anti_fabrication(self) -> None:
+        def ev(_t: str, _s: object, _c: SophismCandidate) -> tuple[str, ...]:
+            # A question the expert_opinion scheme never asks — must be dropped.
+            return ("Cette question n'existe dans aucun scheme Walton",)
+
+        enriched, _ = walton_cq_bridge(
+            [_cand("s0")], span_text_for=lambda c: self._EXPERT_SPAN, cq_evaluator=ev
+        )
+        assert enriched[0].failed_critical_questions == ()
+
+    def test_injected_classifier_is_used(self) -> None:
+        from argumentation_analysis.agents.core.debate.argumentation_schemes import (
+            ArgumentationScheme,
+        )
+
+        fake = ArgumentationScheme(
+            key="fake_scheme",
+            label="Fake",
+            premises_pattern=[],
+            conclusion_pattern="",
+            strength=1.0,
+            critical_questions=["FAKE_Q"],
+        )
+
+        def fake_cls(_text: str) -> ArgumentationScheme:
+            return fake
+
+        def ev(_t: str, _s: object, _c: SophismCandidate) -> tuple[str, ...]:
+            return ("FAKE_Q",)
+
+        enriched, coverage = walton_cq_bridge(
+            [_cand("s0")],
+            span_text_for=lambda c: "x",
+            classifier=fake_cls,
+            cq_evaluator=ev,
+        )
+        assert coverage == {"s0": "fake_scheme"}
+        assert enriched[0].failed_critical_questions == ("FAKE_Q",)
+
+
+class TestCompareSophismBackends:
+    def test_honest_absent_neural_equals_neuro_symbolic(self) -> None:
+        cands = [_cand("s0", span="x"), _cand("s1", span="y")]
+        cmp = compare_sophism_backends(cands, span_text_for=lambda c: "zzzzz")
+        assert isinstance(cmp, SophismComparison)
+        assert cmp.neural_ids == frozenset({"s0", "s1"})
+        assert cmp.neuro_symbolic_ids == cmp.neural_ids
+        assert cmp.eliminated_ids == frozenset()
+        assert cmp.arbitrated.honest_absent is True
+
+    def test_cq_defeat_surfaces_in_delta(self) -> None:
+        # One candidate fails a canonical CQ (eliminated), the other does not.
+        scheme = classify_scheme("Selon un expert du domaine cela fonctionne.")
+        assert scheme is not None
+        canonical_cq = scheme.critical_questions[0]
+
+        def ev(_t: str, _s: object, c: SophismCandidate) -> tuple[str, ...]:
+            return (canonical_cq,) if c.candidate_id == "s0" else ()
+
+        cands = [_cand("s0", span="x"), _cand("s1", span="y")]
+        cmp = compare_sophism_backends(
+            cands,
+            span_text_for=lambda c: "Selon un expert du domaine cela fonctionne.",
+            cq_evaluator=ev,
+        )
+        assert cmp.eliminated_ids == frozenset({"s0"})
+        assert cmp.neuro_symbolic_ids == frozenset({"s1"})
+        assert cmp.neural_ids - cmp.neuro_symbolic_ids == cmp.eliminated_ids
+        assert cmp.arbitrated.honest_absent is False
+
+    def test_coverage_reports_classified_scheme_keys(self) -> None:
+        cmp = compare_sophism_backends(
+            [_cand("s0")],
+            span_text_for=lambda c: "Selon un expert du domaine la chose est vraie.",
+        )
+        assert cmp.span_coverage == {"s0": "expert_opinion"}
 
 
 class TestDungAgentSolverAdapter:

--- a/tests/unit/argumentation_analysis/agents/core/informal/test_neuro_symbolic_arbitrator.py
+++ b/tests/unit/argumentation_analysis/agents/core/informal/test_neuro_symbolic_arbitrator.py
@@ -22,11 +22,13 @@ from argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator impor
     SophismComparison,
     _CQ_CHALLENGER_PREFIX,
     _grounded_extension_pure,
+    _llm_cq_evaluator_async,
     arbitrate,
     build_dung_framework,
     compare_sophism_backends,
     default_conflict_policy,
     make_dung_agent_solver,
+    make_llm_cq_evaluator,
     pure_python_solver,
     walton_cq_bridge,
 )
@@ -337,6 +339,110 @@ class TestCompareSophismBackends:
             span_text_for=lambda c: "Selon un expert du domaine la chose est vraie.",
         )
         assert cmp.span_coverage == {"s0": "expert_opinion"}
+
+
+class TestLlmCqEvaluator:
+    """PR3 — production wiring of the LLM-backed CQ evaluator.
+
+    These tests are JVM/LLM-free by design: they cover the fail-soft paths (no
+    API key, no running loop, invalid input) and the lazy-import contract. The
+    genuine LLM path is exercised end-to-end by the PR3 probe (scratchpad,
+    gitignored) on real-corpus text.
+    """
+
+    _EXPERT_SPAN = "Selon un expert du domaine, la mesure est efficace."
+
+    def test_factory_returns_callable(self) -> None:
+        ev = make_llm_cq_evaluator()
+        assert callable(ev)
+
+    @pytest.mark.asyncio
+    async def test_async_helper_returns_empty_when_no_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No API key configured ⇒ async helper returns () (honest-absent)."""
+
+        def _no_client() -> tuple[object, str]:
+            return None, ""
+
+        monkeypatch.setattr(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            _no_client,
+        )
+        scheme = classify_scheme(self._EXPERT_SPAN)
+        assert scheme is not None
+        out = await _llm_cq_evaluator_async(self._EXPERT_SPAN, scheme, _cand("s0"))
+        assert out == ()
+
+    @pytest.mark.asyncio
+    async def test_async_helper_validates_against_canonical(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """LLM response that declares a non-canonical CQ is dropped (anti-fab)."""
+
+        import json
+
+        scheme = classify_scheme(self._EXPERT_SPAN)
+        assert scheme is not None
+        canonical = scheme.critical_questions[0]
+        declared_non_canonical = "Question jamais posée par aucun schème Walton"
+        # json.dumps produces strictly valid JSON (escapes the French apostrophe
+        # and any other specials). repr() would emit Python-style single quotes
+        # that _parse_json_from_llm rejects, masking the anti-fabrication path.
+        payload = json.dumps({"failed": [canonical, declared_non_canonical]})
+
+        # Fake LLM plumbing: a stub client + a guarded completion that returns
+        # the canned JSON, plus the real parse_json_from_llm.
+
+        class _Msg:
+            def __init__(self, content: str) -> None:
+                self.content = content
+
+        class _Choice:
+            def __init__(self, content: str) -> None:
+                self.message = _Msg(content)
+
+        class _Resp:
+            def __init__(self, content: str) -> None:
+                self.choices = [_Choice(content)]
+
+        async def _fake_completion(*_a: object, **_k: object) -> _Resp:
+            return _Resp(payload)
+
+        def _fake_client() -> tuple[object, str]:
+            return object(), "fake-model"
+
+        import argumentation_analysis.orchestration.invoke_callables as ic
+
+        monkeypatch.setattr(ic, "_get_openai_client", _fake_client)
+        monkeypatch.setattr(ic, "_guarded_chat_completion", _fake_completion)
+        monkeypatch.setattr(ic, "_get_determinism_params", lambda: {})
+
+        out = await _llm_cq_evaluator_async(self._EXPERT_SPAN, scheme, _cand("s0"))
+        assert canonical in out
+        assert declared_non_canonical not in out
+        # The bridge re-validates too, but this is the helper's own defence.
+        assert all(q in scheme.critical_questions for q in out)
+
+    def test_sync_wrapper_fails_soft_when_no_api_key(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ev = make_llm_cq_evaluator()
+        scheme = classify_scheme(self._EXPERT_SPAN)
+        assert scheme is not None
+        # Force the no-key path: stub the async helper directly to mirror the
+        # "no client" behaviour end-to-end.
+        import asyncio
+
+        async def _empty(*_a: object, **_k: object) -> tuple[str, ...]:
+            return ()
+
+        monkeypatch.setattr(
+            "argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator._llm_cq_evaluator_async",
+            _empty,
+        )
+        # Sync path (no running loop): the wrapper awaits the async helper.
+        assert ev(self._EXPERT_SPAN, scheme, _cand("s0")) == ()
 
 
 class TestDungAgentSolverAdapter:


### PR DESCRIPTION
## Track I1 #1429 — PR2/3 (NORTH-STAR selectable/comparable, lane po-2023)

Builds on merged PR1 #1433 (the Dung arbitrator). PR2 wires the **neural→symbolic bridge** that produces the arbitrator's declared input, and exposes the **side-by-side neural vs neuro-symbolic comparison** mandated by the NORTH-STAR "selectable/comparable" requirement.

### 1. `walton_cq_bridge` — the neural→CQ bridge
For each candidate, classifies the argumentation scheme of its evidence span (`argumentation_schemes.classify_scheme` — deterministic, no LLM/JVM), then asks an **injected** `cq_evaluator` which of that scheme's *canonical* Walton critical questions are genuinely unsatisfied. The candidate's `failed_critical_questions` is set to that validated subset.

**Hard anti-fabrication guard:** only critical questions that are MEMBERS of the classified scheme's canonical `critical_questions` are propagated — an evaluator can never inject a question the scheme does not actually ask. When no scheme matches a span, the candidate is returned unchanged.

**Default evaluator = honest-absent:** `default_cq_evaluator` declares ZERO unsatisfied questions. So without a genuine evaluator (LLM, wired in PR3), the bridge is a no-op and neuro-symbolic == neural — the anti-théâtre guarantee holds.

### 2. `compare_sophism_backends` — neural vs neuro-symbolic
Renders **neural-only** (all candidates kept) vs **neuro-symbolic** (bridge → arbitrate) on the same batch, surfacing exactly which candidates the symbolic layer eliminates and why (through the embedded `ArbitrationResult`). Returns a `SophismComparison` (`neural_ids`, `neuro_symbolic_ids`, `eliminated_ids`, `arbitrated`, `span_coverage`). Mirrors the `compare_*_backends` NORTH-STAR idiom.

### DI throughout (JVM/LLM-free tests)
`span_text_for`, `classifier`, `cq_evaluator`, `solver` all injectable — tests use synthetic opaque atoms + a real `classify_scheme` (pure-python) + deterministic injected evaluators. **No JVM, no LLM.**

### DoD (PR2 scope)
- [x] Pont neural→CQ Walton via `argumentation_schemes.classify_scheme` + `critical_questions`
- [x] Mode sélectionnable/comparable `neural|neuro-symbolic` (façon `compare_dung_backends`/`compare_fol_backends`)
- [x] Anti-théâtre : aucune CQ fabriquée — garde « membre du schème canonique » + default evaluator honest-absent
- [x] Tests synthétiques (pas de JVM/LLM)

### Validation
- `mypy --config-file pyproject.toml` : **Success**
- `black` : clean
- `pytest` : **29 passed, 1 skipped** (21 PR1 + 8 PR2 : bridge no-scheme / honest-absent-default / canonical-CQ-propagation / **non-canonical-dropped** / injected-classifier ; comparison honest-absent-equality / CQ-defeat-delta / coverage). 1 skip = JVM-gated.

### Lane disjointness
NO file under `orchestration/` touched. `debate/argumentation_schemes.py` is consumed **read-only**. Diff = 2 files (`neuro_symbolic_arbitrator.py` +182, its test +117), both in `agents/core/informal/`.

### Next (deep-queue)
- **PR3** — real-corpus probe: wire a genuine LLM `cq_evaluator` (pattern TR-1/TR-2), run `compare_sophism_backends` on ≥1 corpus (opaque IDs), synthesis report (neural count vs arbitrated count, which Walton CQs decided).

Refs #1429. Closes nothing yet (PR2 of 3).