### PR TITLE
fix(orchestration): normalize student Dung backend payload (I5 PR3 #1430)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -6818,8 +6818,28 @@ async def _default_student_dung_backend(
                 "note": f"unavailable: {result.get('error', 'student provider')}",
                 "elapsed_ms": round(elapsed, 1),
             }
+        # Normalize the student payload to the {sem: [[args]]} contract the
+        # comparison expects. ``compute_extensions`` returns per-semantics
+        # extensions nested under ``all_extensions`` (each value a
+        # ``{extensions:[[args]], count, sizes, all_members}`` wrapper); the
+        # top-level ``extensions`` is only the DEFAULT set, also wrapped. Reading
+        # the wrapper raw makes _normalize_extensions extract [] → a SPURIOUS
+        # disagreement even when both backends compute the same set (PR3
+        # firsthand probe, anti-théâtre #1019).
+        normalized: Dict[str, List[List[str]]] = {}
+        all_ext = result.get("all_extensions")
+        if isinstance(all_ext, dict):
+            for _sem, _payload in all_ext.items():
+                if isinstance(_payload, dict):
+                    _exts = _payload.get("extensions", [])
+                elif isinstance(_payload, list):
+                    _exts = _payload
+                else:
+                    _exts = []
+                if isinstance(_exts, list):
+                    normalized[_sem] = [e for e in _exts if isinstance(e, list)]
         return {
-            "extensions": result.get("extensions", {}),
+            "extensions": normalized,
             "available": True,
             "note": "abs_arg_dung_student",
             "elapsed_ms": round(elapsed, 1),

--- a/tests/unit/argumentation_analysis/orchestration/test_compare_dung_backends.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_compare_dung_backends.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List
 
 from argumentation_analysis.orchestration.invoke_callables import (
     _compare_dung_backends,
+    _default_student_dung_backend,
     _extensions_key,
     _normalize_extensions,
     _pairs,
@@ -312,3 +313,132 @@ class TestDungCompareWiring:
         assert out["backends"]["tweety"]["available"] is False
         assert out["backends"]["student"]["available"] is False
         assert out["comparison"]["overall_agreement"] is None
+
+
+# -- PR3 regression: student backend shape normalization ---------------------
+#
+# PR3 firsthand probing (real JVM, both backends) caught a spurious-disagreement
+# bug: DungStudentProvider.compute_extensions returns per-semantics extensions
+# nested under ``all_extensions`` (each value a ``{extensions, count, sizes,
+# all_members}`` wrapper), and the top-level ``extensions`` is only the DEFAULT
+# set, also wrapped. _default_student_dung_backend used to read that wrapper raw,
+# so _normalize_extensions extracted [] → a FALSE disagreement even when both
+# backends compute the identical extension set. These tests lock the fix using
+# the REAL observed shape (not an injected fake with the hoped-for shape).
+
+
+_STUDENT_REAL_SHAPE = {
+    "provider": "abs_arg_dung_student",
+    "semantics": "multi",
+    "extensions": {  # default-semantics wrapper (NOT the per-semantics dict)
+        "extensions": [["arg0", "arg2"]],
+        "count": 1,
+        "sizes": [2],
+        "all_members": ["arg0", "arg2"],
+    },
+    "all_extensions": {  # the actual per-semantics payload
+        sem: {
+            "extensions": [["arg0", "arg2"]],
+            "count": 1,
+            "sizes": [2],
+            "all_members": ["arg0", "arg2"],
+        }
+        for sem in ("grounded", "preferred", "stable", "complete")
+    },
+}
+
+
+class TestStudentBackendNormalization:
+    """The student backend must normalize the all_extensions wrapper into the
+    {sem: [[args]]} contract, or the comparison reads a spurious disagreement."""
+
+    async def test_backend_returns_per_semantics_dict(self, monkeypatch):
+        from argumentation_analysis.adapters import dung_student_provider as dsp
+
+        class _FakeProvider:
+            async def compute_extensions(self, arguments, attacks):
+                return _STUDENT_REAL_SHAPE
+
+        monkeypatch.setattr(dsp, "DungStudentProvider", _FakeProvider)
+
+        out = await _default_student_dung_backend(
+            ["arg0", "arg1", "arg2"], [["arg0", "arg1"], ["arg1", "arg2"]]
+        )
+        assert out["available"] is True
+        # Per-semantics dict extracted, not the raw wrapper.
+        assert out["extensions"]["grounded"] == [["arg0", "arg2"]]
+        assert out["extensions"]["preferred"] == [["arg0", "arg2"]]
+        assert out["extensions"]["stable"] == [["arg0", "arg2"]]
+        assert out["extensions"]["complete"] == [["arg0", "arg2"]]
+        # Wrapper keys must NOT leak into the per-semantics dict.
+        assert "count" not in out["extensions"]
+        assert "all_members" not in out["extensions"]
+
+    async def test_normalization_yields_genuine_agreement(self, monkeypatch):
+        """With the fix, two backends computing the SAME set AGREE — the
+        spurious disagreement is gone (anti-théâtre #1019)."""
+        from argumentation_analysis.adapters import dung_student_provider as dsp
+
+        ext_set = [["arg0", "arg2"]]
+
+        class _FakeProvider:
+            async def compute_extensions(self, arguments, attacks):
+                shape = {
+                    "extensions": {"extensions": ext_set, "count": 1,
+                                   "sizes": [2], "all_members": ["arg0", "arg2"]},
+                    "all_extensions": {
+                        sem: {"extensions": ext_set, "count": 1, "sizes": [2],
+                              "all_members": ["arg0", "arg2"]}
+                        for sem in ("grounded", "preferred", "stable", "complete")
+                    },
+                }
+                return shape
+
+        monkeypatch.setattr(dsp, "DungStudentProvider", _FakeProvider)
+
+        tweety = _backend(
+            {sem: ext_set for sem in ("grounded", "preferred", "stable", "complete")}
+        )
+        r = await _compare_dung_backends(
+            ["arg0", "arg1", "arg2"], [["arg0", "arg1"], ["arg1", "arg2"]],
+            backends={"tweety": tweety,
+                      "abs_arg_dung_student": _default_student_dung_backend},
+        )
+        # BEFORE the fix this was False (spurious); AFTER it is True (genuine).
+        assert r["comparison"]["overall_agreement"] is True
+        assert r["comparison"]["per_semantics"]["grounded"]["agreement"] is True
+        assert r["comparison"]["per_semantics"]["grounded"]["disagreement"] == []
+
+    async def test_real_disagreement_still_surfaced_with_student_normalized(
+        self, monkeypatch
+    ):
+        """Normalization does not mask a GENUINE disagreement: when the student
+        computes a different set than Tweety, it is still surfaced verbatim."""
+        from argumentation_analysis.adapters import dung_student_provider as dsp
+
+        class _FakeProvider:
+            async def compute_extensions(self, arguments, attacks):
+                return {
+                    "extensions": {"extensions": [["arg0"]], "count": 1,
+                                   "sizes": [1], "all_members": ["arg0"]},
+                    "all_extensions": {
+                        sem: {"extensions": [["arg0"]], "count": 1, "sizes": [1],
+                              "all_members": ["arg0"]}
+                        for sem in ("grounded", "preferred", "stable", "complete")
+                    },
+                }
+
+        monkeypatch.setattr(dsp, "DungStudentProvider", _FakeProvider)
+
+        tweety = _backend(
+            {sem: [["arg0", "arg2"]] for sem in
+             ("grounded", "preferred", "stable", "complete")}
+        )
+        r = await _compare_dung_backends(
+            ["arg0", "arg1", "arg2"], [["arg0", "arg1"], ["arg1", "arg2"]],
+            backends={"tweety": tweety,
+                      "abs_arg_dung_student": _default_student_dung_backend},
+        )
+        per = r["comparison"]["per_semantics"]["grounded"]
+        assert per["agreement"] is False  # genuine disagreement, not masked
+        assert len(per["disagreement"]) == 1


### PR DESCRIPTION
## Summary

I5 #1430 — **PR3 of 3** (closes the lane). A firsthand probe of `_compare_dung_backends` with the **real backends** (Tweety `AFHandler` + `DungStudentProvider`, JVM up on po-2025) caught a **spurious-disagreement bug** in PR1's `_default_student_dung_backend`, and the fix is validated in both directions.

## The bug (PR3 probe-caught)

`DungStudentProvider.compute_extensions` returns per-semantics extensions **nested under `all_extensions`** (each value a `{extensions:[[args]], count, sizes, all_members}` wrapper); the top-level `extensions` is only the **default** set, also wrapped. PR1's backend read that wrapper raw and passed it as the per-semantics dict, so `_normalize_extensions` extracted `[]` for every semantics → a **FALSE disagreement** even when both backends compute the identical set.

The 20 PR1/PR2 unit tests missed it because they inject **fakes with the hoped-for `{sem:[[args]]}` shape**, not the real one. This is exactly the theater firsthand probing is meant to catch.

## The fix

`_default_student_dung_backend` now builds the `{sem: [[args]]}` contract from `result["all_extensions"]` (each value unwrapped from its `{extensions,...}` wrapper). The student library (sanctuary `abs_arg_dung/`, #893) is **not modified** — outer adapter fix only.

## Firsthand validation (real backends, JVM up)

7 opaque synthetic AF topologies (chain, mutual cycle, odd 3-cycle, independent set, star, chain-5, two-defenders):

| semantics | agreement | note |
|---|---|---|
| grounded | 7/7 (100%) | |
| stable | 7/7 (100%) | |
| complete | 7/7 (100%) | |
| preferred | 6/7 (86%) | 1 **genuine** divergence (see below) |

Anti-théâtre confirmed **in both directions**:
- **Spurious disagreement gone**: chain/cycle/star/chain-5 AFs now show `overall_agreement=True` where both backends compute the same set (was spuriously `False`).
- **Genuine disagreement still surfaced verbatim**: on a 3-cycle (s0→s1→s2→s0), `preferred`: Tweety `{∅}` vs student `{{s0},{s1},{s2}}`. By standard Dung semantics each node is attacked by an undefended-against attacker → no singleton is admissible → preferred = {∅} (Tweety correct; student diverges). The comparison surfaces this engine divergence **verbatim, never reconciled** — which is what a multi-backend comparison exists for.

Unavailable backends still reported `available=False` (fail-loud), never omitted.

## Tests

3 new JVM-free regression tests (monkeypatch `DungStudentProvider` with the **real observed shape**): backend returns the per-semantics dict with no wrapper leakage; two backends computing the same set now AGREE (was spuriously `False`); a genuine disagreement is still surfaced. **23 pass** in the file; dung/structured-arg neighbours (**78**) unaffected. mypy strict on `invoke_callables.py` clean.

## Out of scope (NOT in diff)

- `state_writers.py` gate — unchanged (honest-absent contract).
- `abs_arg_dung/` sanctuary — unchanged (#893).
- `_invoke_dung_extensions` native path — unchanged.

PR1 (#1432, merged `ad2f03cf`) = compare fn. PR2 (#1434, merged `81c5d2b4`) = wiring. **PR3 = this** (probe-caught fix + regression tests). Closes I5.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
