### PR TITLE
feat(orchestration): wire compare_all_axes as selectable capability (I6 #1437 PR2)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -155,6 +155,7 @@ __all__ = [
     "_python_dung_fallback",
     "_compare_dung_backends",
     "compare_all_axes",
+    "_invoke_multi_axis_compare",
     "_invoke_formal_synthesis",
     "_invoke_narrative_synthesis",
     "_invoke_text_to_kb",
@@ -7326,6 +7327,95 @@ async def compare_all_axes(
             "axes_run": list(report_axes.keys()),
             "any_disagreement": any_disagree,
         },
+    }
+
+
+async def _invoke_multi_axis_compare(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Pipeline-selectable wrapper over :func:`compare_all_axes` (I6 #1437 PR2).
+
+    Exposes the unified multi-axis comparison as a SELECTABLE pipeline
+    capability, mirroring how ``_invoke_dung_extensions`` wires
+    ``dung_mode=compare`` (I5 #1434). The handler extracts per-axis inputs from
+    the context and routes to :func:`compare_all_axes`; it never re-implements
+    it and never invents a cross-axis translation (each axis keeps its own input
+    shape, per #1438).
+
+    Per-axis inputs are read from ``context["multi_axis"]`` (a dict):
+
+    * ``axes``            — optional explicit subset of {"fol","dung","sophism"}.
+      Defaults to every axis whose input was supplied.
+    * ``fol_belief_set``  — FOL belief set (string or Java object) for the fol
+      axis. If absent, the fol axis is reported available=False (honest-absent).
+    * ``dung_arguments`` / ``dung_attacks`` — explicit Dung arguments/attacks.
+      If absent, derived from upstream extraction via the same helpers
+      ``_invoke_dung_extensions`` uses (``_extract_arguments_from_context`` /
+      ``_generate_attacks_from_args``).
+    * ``sophism_candidates`` / ``sophism_span_text_for`` — candidates + bridge
+      span-text accessor. If absent, the sophism axis is honest-absent.
+    * ``sophism_kwargs``  — extra kwargs forwarded to the sophism comparator
+      (classifier / cq_evaluator / solver / semantics / conflict_policy).
+    * ``*_compare_fn``    — injected per-axis comparators (DI; for JVM/LLM-free
+      tests).
+
+    The default behaviour when ``context["multi_axis"]`` is absent or empty is
+    honest-absent: the report lists no decided axis and returns
+    ``agreement=None`` (NEVER a fabricated agreement — anti-théâtre #1019).
+
+    Returns ``{semantics: "multi_axis_compare", comparison: <uniform report>,
+    note: <anti-pendule statement>}``.
+    """
+    cfg = context.get("multi_axis") or {}
+
+    # Dung inputs are derived from upstream extraction ONLY when the caller
+    # explicitly opted into the dung axis (listed in cfg["axes"] or supplied an
+    # explicit dung input). We do NOT auto-activate dung from any input text —
+    # that would run an axis the caller did not ask for (anti-pendule: a
+    # capability must be selectable, not imposed).
+    dung_arguments = cfg.get("dung_arguments")
+    dung_attacks = cfg.get("dung_attacks")
+    explicit_axes = cfg.get("axes")
+    wants_dung = (
+        (explicit_axes is not None and "dung" in explicit_axes)
+        or dung_arguments is not None
+        or dung_attacks is not None
+        or cfg.get("dung_compare_fn") is not None
+    )
+    if wants_dung and dung_arguments is None and dung_attacks is None:
+        _args = _extract_arguments_from_context(input_text, context)
+        if _args:
+            dung_arguments = _args
+            dung_attacks = _generate_attacks_from_args(_args, context)
+
+    comparison = await compare_all_axes(
+        axes=cfg.get("axes"),
+        fol_belief_set=cfg.get("fol_belief_set"),
+        fol_compare_fn=cfg.get("fol_compare_fn"),
+        dung_arguments=dung_arguments,
+        dung_attacks=dung_attacks,
+        dung_compare_fn=cfg.get("dung_compare_fn"),
+        sophism_candidates=cfg.get("sophism_candidates"),
+        sophism_span_text_for=cfg.get("sophism_span_text_for"),
+        sophism_compare_fn=cfg.get("sophism_compare_fn"),
+        sophism_kwargs=cfg.get("sophism_kwargs"),
+    )
+
+    logger.info(
+        "Multi-axis comparison run (%d axis/axes) — any_disagreement=%s",
+        len(comparison["overall"]["axes_run"]),
+        comparison["overall"]["any_disagreement"],
+    )
+
+    return {
+        "semantics": "multi_axis_compare",
+        "comparison": comparison,
+        "note": (
+            "I6 #1437: unified multi-axis comparison. Disagreements are surfaced "
+            "per axis and NEVER auto-reconciled (anti-pendule #1019); an axis or "
+            "backend that cannot run is reported available=False (fail-loud), "
+            "never omitted."
+        ),
     }
 
 

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -32,6 +32,7 @@ from argumentation_analysis.orchestration.invoke_callables import (
     _invoke_fol_reasoning,
     _invoke_modal_logic,
     _invoke_dung_extensions,
+    _invoke_multi_axis_compare,
     _invoke_formal_synthesis,
     _invoke_nl_to_logic,
     _invoke_sat,
@@ -466,6 +467,12 @@ def setup_registry(
             _invoke_dung_extensions,
         ),
         (
+            "multi_axis_compare_service",
+            ["multi_axis_compare"],
+            "Unified multi-axis comparison (fol/dung/sophism) via compare_all_axes",
+            _invoke_multi_axis_compare,
+        ),
+        (
             "formal_synthesis_service",
             ["formal_synthesis"],
             "Aggregate formal analysis into unified report",
@@ -727,7 +734,11 @@ def setup_registry(
         registry.register_service(
             name="ai_shield_service",
             service_class=type("AIShieldService", (), {}),
-            capabilities=["input_validation", "output_filtering", "adversarial_protection"],
+            capabilities=[
+                "input_validation",
+                "output_filtering",
+                "adversarial_protection",
+            ],
             metadata={
                 "description": "AI Shield — adversarial protection for LLM pipeline (injection, jailbreak, bias, leak detection)",
                 "presets": ["basic", "advanced", "output_only", "strict"],

--- a/tests/unit/argumentation_analysis/orchestration/test_compare_all_axes.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_compare_all_axes.py
@@ -18,6 +18,7 @@ import pytest
 
 from argumentation_analysis.orchestration.invoke_callables import (
     compare_all_axes,
+    _invoke_multi_axis_compare,
     _normalize_dung_payload,
     _normalize_fol_payload,
     _normalize_sophism_payload,
@@ -356,3 +357,109 @@ class TestNormalizers:
             assert out["available"] is False
             assert out["agreement"] is None
             assert out["disagreements"] == []
+
+
+# -- I6 PR2: pipeline-selectable handler wiring ------------------------------
+
+
+class TestMultiAxisCompareHandler:
+    """_invoke_multi_axis_compare wraps compare_all_axes and exposes it as a
+    pipeline-selectable capability. Inputs are read from context["multi_axis"];
+    DI comparators keep it JVM/LLM-free."""
+
+    async def test_handler_routes_to_comparison_with_uniform_shape(self):
+        ctx = {
+            "multi_axis": {
+                "fol_belief_set": "dummy",
+                "fol_compare_fn": _fol_fake({"e": True}, True, []),
+                "sophism_candidates": ["c0"],
+                "sophism_span_text_for": lambda c: "x",
+                "sophism_compare_fn": _sophism_fake([], honest_absent=False),
+            }
+        }
+        out = await _invoke_multi_axis_compare("source text", ctx)
+        assert out["semantics"] == "multi_axis_compare"
+        assert out["comparison"]["overall"]["axes_run"] == ["fol", "sophism"]
+        assert "NEVER auto-reconciled" in out["note"]
+
+    async def test_handler_dung_inputs_derived_from_upstream(self):
+        # dung axis explicitly selected, no explicit dung_arguments → derived
+        # from phase_extract_output via the same helpers _invoke_dung_extensions
+        # uses.
+        ctx = {
+            "phase_extract_output": {"arguments": ["s0", "s1"]},
+            "multi_axis": {
+                "axes": ["dung"],
+                "dung_compare_fn": _dung_fake(
+                    {
+                        "grounded": {
+                            "agreement": True,
+                            "decided": ["a"],
+                            "disagreement": [],
+                        }
+                    },
+                    True,
+                ),
+            },
+        }
+        out = await _invoke_multi_axis_compare("source text", ctx)
+        # The dung axis ran (inputs derived) and the fake comparator was called.
+        assert out["comparison"]["overall"]["axes_run"] == ["dung"]
+        assert out["comparison"]["axes"]["dung"]["available"] is True
+
+    async def test_handler_explicit_axes_filter(self):
+        ctx = {
+            "multi_axis": {
+                "axes": ["fol"],
+                "fol_belief_set": "dummy",
+                "fol_compare_fn": _fol_fake({"e": True, "p": True}, True, []),
+                "sophism_candidates": ["c0"],  # supplied but filtered out
+                "sophism_span_text_for": lambda c: "x",
+                "sophism_compare_fn": _sophism_fake([], honest_absent=False),
+            }
+        }
+        out = await _invoke_multi_axis_compare("source text", ctx)
+        assert out["comparison"]["overall"]["axes_run"] == ["fol"]
+
+    async def test_handler_empty_config_is_honest_absent(self):
+        # No multi_axis cfg, no upstream extraction → no axis decided → NOT a
+        # fabricated agreement (anti-théâtre #1019).
+        out = await _invoke_multi_axis_compare("source text", {})
+        assert out["semantics"] == "multi_axis_compare"
+        assert out["comparison"]["overall"]["axes_run"] == []
+        assert out["comparison"]["overall"]["any_disagreement"] is False
+
+    async def test_handler_surfaces_disagreement_not_reconciled(self):
+        ctx = {
+            "multi_axis": {
+                "fol_belief_set": "dummy",
+                "fol_compare_fn": _fol_fake(
+                    {"e": True, "p": False}, False, ["NOT reconciled: e vs p"]
+                ),
+            }
+        }
+        out = await _invoke_multi_axis_compare("source text", ctx)
+        fol = out["comparison"]["axes"]["fol"]
+        assert fol["agreement"] is False
+        assert any("NOT reconciled" in d for d in fol["disagreements"])
+        assert out["comparison"]["overall"]["any_disagreement"] is True
+
+    async def test_capability_registered_selectable(self):
+        # The handler must be registered under the multi_axis_compare capability
+        # so a workflow phase can select it (I6 PR2 DoD). We verify the wiring
+        # statically (the service tuple names the capability + handler) rather
+        # than building the full registry, which would instantiate JVM agents.
+        import inspect
+
+        from argumentation_analysis.orchestration import registry_setup
+
+        src = inspect.getsource(registry_setup)
+        # The capability string and the handler are both wired in the source.
+        assert "multi_axis_compare" in src
+        assert "_invoke_multi_axis_compare" in src
+        # And the handler is importable from the module (the import the tuple uses).
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_multi_axis_compare as _h,
+        )
+
+        assert callable(_h)


### PR DESCRIPTION
## What

Last PR of the **I6 #1437 lane** — exposes the unified multi-axis comparison harness (PR1 #1438) as a **pipeline-SELECTABLE capability**. This closes the NORTH-STAR: the 3 comparison axes (`fol` / `dung` / `sophism`) are now reachable from a single selectable point.

Builds on PR1 (`compare_all_axes` router + uniform-shape aggregator, #1438 `3fc1e3d2`). Mirrors how `_invoke_dung_extensions` wires `dung_mode=compare` (I5 #1434).

## Changes

### `invoke_callables.py` — `_invoke_multi_axis_compare(input_text, context)`
- Wraps `compare_all_axes`. Reads per-axis inputs from `context["multi_axis"]` and routes to the harness; **never re-implements it** and **never invents a cross-axis translation** (each axis keeps its own input shape, per #1438).
- **Dung inputs derived from upstream extraction ONLY when the caller opted into the dung axis** (listed in `cfg["axes"]`, or explicit `dung_arguments`/`dung_attacks`/`dung_compare_fn` supplied). We do **NOT** auto-activate dung from any input text — a capability must be *selectable*, not *imposed* (anti-pendule).
- **Default = honest-absent**: no cfg + no upstream → no decided axis → `agreement=None` (**NEVER** a fabricated agreement — anti-théâtre #1019).
- Returns `{semantics:"multi_axis_compare", comparison, note}` with an explicit anti-pendule statement.

### `registry_setup.py` — capability registration
- `multi_axis_compare_service` under capability `["multi_axis_compare"]`. **Selectable** — NOT forced into core/extension presets.

### `tests/test_compare_all_axes.py` — +6 wiring tests (21 total)
- `test_handler_routes_to_comparison_with_uniform_shape`
- `test_handler_dung_inputs_derived_from_upstream` (`axes:["dung"]`)
- `test_handler_explicit_axes_filter`
- `test_handler_empty_config_is_honest_absent` (no fabricated agreement)
- `test_handler_surfaces_disagreement_not_reconciled`
- `test_capability_registered_selectable` (static `inspect.getsource` check — JVM-free, no `setup_registry()` which would instantiate JVM agents)

## DoD checklist (coord dispatch msg-v3d5v0)

- [x] `compare_all_axes` reachable as a selectable capability (`multi_axis_compare`)
- [x] Synthetic JVM/LLM-free DI tests (fakes mirror the NATIVE comparator shapes — lesson I5 PR3 applied)
- [x] mypy strict clean (`invoke_callables` + `registry_setup`) + black clean
- [x] Gate `state_writers.py` OUT of diff ; sanctuary `abs_arg_dung/` OUT of diff

## Validation

| Check | Result |
|-------|--------|
| mypy strict (2 gate files) | ✅ clean |
| black | ✅ clean |
| I6 tests | ✅ 21 passed |
| dung/multi_axis neighbors | ✅ 104 passed, 0 regression |
| sophism neighbors | ✅ 85 passed, 1 skipped, 0 regression |
| gate + sanctuary | ✅ OUT of diff (3 files only) |

## Anti-théâtre invariants (lane)

- **Disagreements surfaced per axis, NEVER auto-reconciled** (a disagreement is a result, not a bug to mask — #1019).
- **Unavailable axis/backend = `available=False` fail-loud**, never silently omitted.
- **Honest-absent (no genuine evaluation) = `agreement=None`**, not a fabricated `True`.
- **No invented cross-axis translation** — each axis keeps its own input shape.

This is additive and opt-in (a new selectable capability); the default pipeline path is unchanged (not a pendulum swing).

Closes #1437.

🤖 Generated with [Claude Code](https://claude.com/claude-code)