### PR TITLE
docs(technical): correct FOL Top/Bottom + add MlParser grammar gotchas (#1441)

### DIFF
--- a/docs/technical/tweety_bridge.md
+++ b/docs/technical/tweety_bridge.md
@@ -75,14 +75,15 @@ Il est crucial de respecter la syntaxe attendue par TweetyProject pour les formu
     *   XOR : `^^`
     *   Constantes : `true`, `false`
     *   Variables propositionnelles : `a, b, prop1, ...`
-*   **Logique du Premier Ordre :**
+*   **Logique du Premier Ordre (FOL) :** BNF officiel dans [`tweety_fol_bnf.md`](../../argumentation_analysis/agents/core/logic/tweety_fol_bnf.md).
     *   Quantificateurs : `forall X: (formula)`, `exists X: (formula)`
     *   Prédicats : `P(X,y)`
-    *   Connecteurs : similaires à PL.
-*   **Logique Modale :**
-    *   Opérateur de nécessité (Box) : `[]` ou `Box`
-    *   Opérateur de possibilité (Diamond) : `<>` ou `Diamond`
-    *   Connecteurs : similaires à PL.
+    *   Connecteurs : `&&`, `||`, `!`, `=>`, `<=>`, `==`, `/==`, `^^` (symboles identiques à PL).
+    *   **Constantes Top/Bottom : `+` / `-`** — et **NON** `true`/`false` hérités de PL. Un atome `T`/`F` (ou `true`/`false`) émis par un LLM lève `ParserException: Unrecognized formula type 'T'` et la formule est perdue. `fol_handler._sanitize_fol_bool_constants` (#1441 Bug B) mappe `T`→`+` / `F`→`-` (word-boundary ; `Table`, `T1`, `t` minuscule intacts) en amont du parse.
+*   **Logique Modale (ML) — `MlParser`, grammaire plus stricte que le `FolParser` :**
+    *   Opérateurs : nécessité `[]` (ou `Box`), possibilité `<>` (ou `Diamond`) ; connecteurs `&&`/`||`/`!`/`=>`/`<=>`.
+    *   **Pas de mot-clé `sort`** : les propositions se déclarent via `type(prop)` (un KB modal ne déclare pas les sortes à la mode FOL). Une ligne `sort (...)` lève `ParserException: Illegal characters / Missing '=' in sort definition` sur **tout** le KB. `ModalIdentifierNormalizer.strip_illegal_sort_declarations` (#1441 Bug A) supprime ces lignes en amont de `parseBeliefBase`.
+    *   **Identifiants stricts `[a-zA-Z][a-zA-Z0-9]*`** : les underscores et autres séparateurs sont rejetés (`joke_teleprompter` → `ParserException`). `ModalIdentifierNormalizer.legalize` (#1326) mappe ces atomes vers du PascalCase légal (`JokeTeleprompter`) en amont du parse, avec garde anti-collision.
 
 Les ensembles de croyances sont typiquement une liste de formules, chacune sur une nouvelle ligne. Les commentaires peuvent être introduits par `#`.
 


### PR DESCRIPTION
## Summary

SDDD bookend FIN of the **#1441** lane (sanitizer code merged in #1443 → main `19ff95a9`). While validating the two fixes against the reference docs, a firsthand doc gap surfaced in [`docs/technical/tweety_bridge.md`](docs/technical/tweety_bridge.md) §6.

## Doc gap 1 — FOL Top/Bottom (fed Bug B)

The FOL bullet said **"Connecteurs : similaires à PL"**, but §6's PL entry uses `true`/`false` while the FOL BNF ([`tweety_fol_bnf.md`](argumentation_analysis/agents/core/logic/tweety_fol_bnf.md)) uses **`+` / `-`** for Top/Bottom. The "similaires à PL" wording implied FOL inherited `true`/`false` — the exact misconception behind Bug B (an LLM-emitted `T` raises `ParserException: Unrecognized formula type 'T'`).

**Fixed:** states `+`/`-` explicitly, with a cross-ref to `tweety_fol_bnf.md` and the merged `fol_handler._sanitize_fol_bool_constants`.

## Doc gap 2 — Modal MlParser grammar (fed Bug A + #1326)

The Modal bullet listed only `[]` / `<>` operators and omitted the three firsthand-confirmed grammar facts that caused Bug A (#1441) and the underscore-id ParserException (#1326):

- **No `sort` keyword** — propositions are `type(prop)`; a `sort (...)` line raises on the whole KB → `ModalIdentifierNormalizer.strip_illegal_sort_declarations`.
- **Strict identifier rule `[a-zA-Z][a-zA-Z0-9]*`** — underscores rejected → `ModalIdentifierNormalizer.legalize`.

Added both with pointers to the merged code.

## Why this belongs here (bookend FIN)

The natural home for parser-grammar lessons is the bridge doc a practitioner reads *before* hitting the ParserException — not just commit messages. The 3 sanitization entry points are now documented at the bridge layer, alongside the BNF cross-ref.

## Verification

- **Docs-only** (+7/-6, one `.md`). No code change, no behavior change.
- All cited symbols verified present in merged code via `git grep` (`_sanitize_fol_bool_constants`, `strip_illegal_sort_declarations`, `legalize`).
- BNF cross-ref target is tracked (`git ls-files`).
- No issue closed (#1441 already closed by #1443); this is the autonomous bookend follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
