### PR TITLE
feat(orchestration): honest capabilities_used rollup - degraded != used (Constat 5 #1355)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -24,7 +24,7 @@ import logging
 import os
 import re
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 import semantic_kernel as sk
 from semantic_kernel.agents import ChatCompletionAgent
@@ -614,6 +614,97 @@ async def run_conversational_analysis(
             max_total_turns=max_total_turns,
             render_restitution=render_restitution,
         )
+
+
+def _formal_axis_genuine(results: List[Any]) -> bool:
+    """True iff at least one result entry is a genuine reasoning artifact.
+
+    Constat n°5 (#1355): a formal axis (FOL/modal/PL) counts as *genuinely
+    used* only when an entry carries non-empty ``formulas`` (something was
+    actually formalized) AND bears no explicit ``unavailable:*`` degradation
+    token. Requiring non-empty formulas prevents an empty theory from reading
+    as a "trivially consistent" decision — the exact theatre #1019 forbids.
+    The ``unavailable:`` marker is the canonical honest-degradation signal
+    written by the FOL/modal writers (#1278/#1279: ``no-translation``,
+    ``parse-fail``, ``no-solver``).
+    """
+    for entry in results:
+        if not isinstance(entry, dict):
+            continue
+        message = entry.get("message")
+        if isinstance(message, str) and message.startswith("unavailable:"):
+            continue
+        if entry.get("formulas"):
+            return True
+    return False
+
+
+def _axis_produced_formulas(results: List[Any]) -> bool:
+    """True iff at least one entry carries non-empty formulas.
+
+    Distinct from :func:`_formal_axis_genuine`: NL→formal *translation*
+    succeeded whenever formulas exist on an axis, even if the solver later
+    degraded (e.g. modal ``unavailable:no-solver`` keeps the translated
+    formulas — invoke_callables.py:6429). This lets ``nl_to_logic_translation``
+    be reported genuine while ``modal_logic`` is reported degraded.
+    """
+    for entry in results:
+        if isinstance(entry, dict) and entry.get("formulas"):
+            return True
+    return False
+
+
+def _classify_formal_capabilities(
+    state: Any,
+) -> Tuple[Set[str], Set[str], Set[str]]:
+    """Split FormalAgent participation into honest used/degraded/missing sets.
+
+    Constat n°5 (#1355): the spectacular rollup previously declared every
+    formal capability as ``used`` the moment FormalAgent spoke — even when
+    FOL/modal were ``degraded=true`` (parse-fail, no-translation, solver OOM).
+    This crosses participation with the REAL per-axis decision status already
+    recorded in ``state`` (``fol/modal/propositional_analysis_results``),
+    mirroring the honest ``structured_arg_status`` layer but for the
+    ``fol_reasoning``/``modal_logic``/``propositional_logic``/
+    ``nl_to_logic_translation`` vocabulary.
+
+    Returns ``(used, degraded, missing)``:
+      * *used* — axis genuinely decided/produced (non-empty formulas, no
+        ``unavailable:*`` token).
+      * *degraded* — axis participated but every entry is a degradation.
+      * *missing* — FormalAgent participated but the axis left no entry.
+
+    Anti-théâtre #1019: a degraded axis is never reported as ``used``; an empty
+    theory is never reported as a genuine decision.
+    """
+    fol_res = list(getattr(state, "fol_analysis_results", []) or [])
+    modal_res = list(getattr(state, "modal_analysis_results", []) or [])
+    pl_res = list(getattr(state, "propositional_analysis_results", []) or [])
+    used: Set[str] = set()
+    degraded: Set[str] = set()
+    missing: Set[str] = set()
+    for cap, results in (
+        ("fol_reasoning", fol_res),
+        ("modal_logic", modal_res),
+        ("propositional_logic", pl_res),
+    ):
+        if _formal_axis_genuine(results):
+            used.add(cap)
+        elif results:
+            degraded.add(cap)
+        else:
+            missing.add(cap)
+    # nl_to_logic_translation is genuine iff translation produced formulas on
+    # ANY axis (distinct from the solver later degrading). If FormalAgent
+    # participated but produced no formulas anywhere, it degraded; if it left
+    # no formal entries at all, it is missing.
+    if any(_axis_produced_formulas(r) for r in (fol_res, modal_res, pl_res)):
+        used.add("nl_to_logic_translation")
+    elif fol_res or modal_res or pl_res:
+        degraded.add("nl_to_logic_translation")
+    else:
+        missing.add("nl_to_logic_translation")
+    return used, degraded, missing
 
 
 async def _run_conversational_analysis_inner(
@@ -1302,9 +1393,18 @@ async def _run_conversational_analysis_inner(
         },
     }
 
-    # Spectacular mode: add capability mapping from conversation log
+    # Spectacular mode: add capability mapping from conversation log.
+    # Constat n°5 (#1355): formal capabilities are crossed with the REAL
+    # per-axis decision status in ``state`` — a degraded axis (parse-fail,
+    # no-translation, solver OOM) is reported via ``capabilities_degraded``,
+    # NOT as ``used`` identical to a genuine decision (anti-théâtre #1019).
+    # ``capabilities_missing`` reflects axes that participated but left no
+    # entry, instead of a hardcoded empty list.
     if spectacular:
-        capabilities_used = set()
+        capabilities_used: Set[str] = set()
+        capabilities_degraded: Set[str] = set()
+        capabilities_missing: Set[str] = set()
+        formal_participated = False
         for msg in conversation_log:
             agent = msg.get("agent", "")
             if agent == "ExtractAgent":
@@ -1314,14 +1414,7 @@ async def _run_conversational_analysis_inner(
                     ["neural_fallacy_detection", "hierarchical_fallacy_detection"]
                 )
             elif agent == "FormalAgent":
-                capabilities_used.update(
-                    [
-                        "nl_to_logic_translation",
-                        "fol_reasoning",
-                        "modal_logic",
-                        "propositional_logic",
-                    ]
-                )
+                formal_participated = True
             elif agent == "QualityAgent":
                 capabilities_used.add("argument_quality")
             elif agent == "CounterAgent":
@@ -1330,8 +1423,15 @@ async def _run_conversational_analysis_inner(
                 capabilities_used.add("adversarial_debate")
             elif agent == "GovernanceAgent":
                 capabilities_used.add("governance_simulation")
-        result["capabilities_used"] = list(capabilities_used)
-        result["capabilities_missing"] = []
+        if formal_participated:
+            f_used, f_degraded, f_missing = _classify_formal_capabilities(state)
+            capabilities_used |= f_used
+            capabilities_degraded |= f_degraded
+            capabilities_missing |= f_missing
+        # Sorted for deterministic output (golden/compare snapshots, #1355).
+        result["capabilities_used"] = sorted(capabilities_used)
+        result["capabilities_degraded"] = sorted(capabilities_degraded)
+        result["capabilities_missing"] = sorted(capabilities_missing)
 
     logger.info(
         f"Conversational analysis complete: {len(conversation_log)} messages, "

--- a/tests/unit/argumentation_analysis/orchestration/test_conversational_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversational_spectacular.py
@@ -248,13 +248,149 @@ class TestSpectacularCapabilityMapping:
             result = await run_conversational_analysis("test text", spectacular=True)
 
         caps = result["capabilities_used"]
+        # Non-formal agents map purely from participation (no degradation
+        # concept) — these remain in capabilities_used.
         assert "fact_extraction" in caps
         assert "neural_fallacy_detection" in caps
-        assert "fol_reasoning" in caps
         assert "argument_quality" in caps
         assert "counter_argument_generation" in caps
         assert "adversarial_debate" in caps
         assert "governance_simulation" in caps
+        # Constat n°5 (#1355): FormalAgent participated here, but the mocked
+        # _run_phase populated NO formal result entries in state — so the
+        # formal axes are NOT reported as ``used`` (that was the bug). With
+        # empty formal state, they are ``missing`` (participated, no entry).
+        # The genuine-vs-degraded distinction is covered directly by
+        # TestConstat5FormalCapabilityHonesty below.
+        assert "fol_reasoning" not in caps
+        assert "modal_logic" not in caps
+        assert "propositional_logic" not in caps
+        assert "nl_to_logic_translation" not in caps
+        assert "fol_reasoning" in result["capabilities_missing"]
+        assert result["capabilities_degraded"] == [] or all(
+            c not in ("fol_reasoning", "modal_logic", "propositional_logic")
+            for c in result["capabilities_degraded"]
+        )
+
+
+class TestConstat5FormalCapabilityHonesty:
+    """Constat n°5 (#1355): degraded formal axes ≠ used — DI synthetic tests.
+
+    Proves the honest split without any JVM/LLM: ``_classify_formal_capabilities``
+    crosses FormalAgent participation with the REAL per-axis decision status
+    already recorded in state. A degraded axis (``unavailable:*`` token or empty
+    theory) is never reported as ``used`` (anti-théâtre #1019).
+    """
+
+    def _make_state(self) -> "UnifiedAnalysisState":
+        return UnifiedAnalysisState("corpus_A synthetic")
+
+    def test_degraded_fol_not_used(self):
+        """FOL degraded (no-translation) → fol_reasoning in degraded, not used."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _classify_formal_capabilities,
+        )
+
+        state = self._make_state()
+        state.add_fol_analysis_result(
+            [], None, [], 0.0, message="unavailable:no-translation — empty theory"
+        )
+        used, degraded, missing = _classify_formal_capabilities(state)
+        assert "fol_reasoning" not in used
+        assert "fol_reasoning" in degraded
+        assert "fol_reasoning" not in missing
+        # No formulas produced anywhere → nl_to_logic degraded (attempted, failed)
+        assert "nl_to_logic_translation" not in used
+        assert "nl_to_logic_translation" in degraded
+
+    def test_genuine_fol_is_used(self):
+        """FOL genuine decision → fol_reasoning + nl_to_logic_translation used."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _classify_formal_capabilities,
+        )
+
+        state = self._make_state()
+        state.add_fol_analysis_result(
+            ["forall x (P(x) -> Q(x))"], True, ["Q(x) derived"], 0.9
+        )
+        used, degraded, missing = _classify_formal_capabilities(state)
+        assert "fol_reasoning" in used
+        assert "fol_reasoning" not in degraded
+        assert "nl_to_logic_translation" in used
+
+    def test_modal_solver_oom_split_is_the_crux(self):
+        """modal unavailable:no-solver keeps formulas → modal degraded BUT
+        nl_to_logic_translation used (translation succeeded, solver failed).
+
+        This is the crux distinction: translation-success ≠ solver-success.
+        """
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _classify_formal_capabilities,
+        )
+
+        state = self._make_state()
+        # Formulas present (translation worked) but solver OOM'd.
+        state.add_modal_analysis_result(
+            ["[]p", "<>q"], None, [], message="unavailable:no-solver — SPASS OOM"
+        )
+        used, degraded, missing = _classify_formal_capabilities(state)
+        assert "modal_logic" not in used
+        assert "modal_logic" in degraded
+        # Translation DID produce formulas → nl_to_logic is genuine.
+        assert "nl_to_logic_translation" in used
+        assert "nl_to_logic_translation" not in degraded
+
+    def test_missing_when_no_entries(self):
+        """FormalAgent participated but no formal entries → all four missing."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _classify_formal_capabilities,
+        )
+
+        state = self._make_state()  # empty
+        used, degraded, missing = _classify_formal_capabilities(state)
+        assert used == set()
+        assert degraded == set()
+        assert missing == {
+            "fol_reasoning",
+            "modal_logic",
+            "propositional_logic",
+            "nl_to_logic_translation",
+        }
+
+    def test_mixed_fol_genuine_modal_degraded_per_axis(self):
+        """Per-axis independence: FOL genuine + modal degraded in one run."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _classify_formal_capabilities,
+        )
+
+        state = self._make_state()
+        state.add_fol_analysis_result(["forall x P(x)"], True, [], 0.8)
+        state.add_modal_analysis_result(
+            [], None, [], message="unavailable:no-translation — empty"
+        )
+        used, degraded, missing = _classify_formal_capabilities(state)
+        assert "fol_reasoning" in used
+        assert "modal_logic" in degraded
+        assert "modal_logic" not in used
+        assert "fol_reasoning" not in degraded
+        # FOL produced formulas → nl_to_logic used.
+        assert "nl_to_logic_translation" in used
+
+    def test_parse_fail_fol_is_degraded(self):
+        """FOL unavailable:parse-fail (formulas produced but unparseable)
+        → degraded. Verifies the unavailable:* prefix contract."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _formal_axis_genuine,
+        )
+
+        # Even if formulas leaked non-empty, the unavailable: prefix marks
+        # the axis degraded (the prover decided nothing).
+        assert not _formal_axis_genuine(
+            [{"formulas": ["forall x P(x)"], "message": "unavailable:parse-fail"}]
+        )
+        assert _formal_axis_genuine([{"formulas": ["forall x P(x)"], "message": None}])
+        # Empty theory with no degradation token is NOT genuine (#1019).
+        assert not _formal_axis_genuine([{"formulas": [], "message": None}])
 
 
 class TestUnifiedAnalysisStateFields:


### PR DESCRIPTION
## Constat n°5 (#1355) — `capabilities_used` honnête (degraded ≠ used)

Dispatched by coordinator ai-01 (R621). The spectacular rollup declared every formal capability as `used` the moment `FormalAgent` participated — even when FOL/modal were `degraded=true` (parse-fail, no-translation, solver OOM). It diverged from the honest `structured_arg_status` layer and over-declared.

### The bug — `conversational_orchestrator.py` spectacular rollup
- Formerly added `nl_to_logic_translation` / `fol_reasoning` / `modal_logic` / `propositional_logic` **unconditionally** on `FormalAgent` participation.
- `capabilities_missing = []` was hardcoded → never reflected what actually failed.

### Fix — cross participation with the REAL per-axis status already in `state`
| Bucket | Rule |
|--------|------|
| `capabilities_used` | axis has ≥1 entry with **non-empty formulas AND no `unavailable:*` token** (genuine decision/translation) |
| `capabilities_degraded` (NEW, additive) | axis participated but every entry is a degradation (`unavailable:*`) |
| `capabilities_missing` | `FormalAgent` participated but the axis left no entry |

**Crux distinction** (firsthand-verified `invoke_callables.py:6429`): modal `unavailable:no-solver` (SPASS OOM) keeps the translated formulas non-empty → `nl_to_logic_translation` stays `used` (translation succeeded) while `modal_logic` is `degraded` (solver failed). Translation-success ≠ solver-success.

### DoD (dispatch R621)
- [x] `capabilities_used` contains ONLY genuinely decided/produced capabilities
- [x] `capabilities_degraded` surfaces participated-but-degraded axes
- [x] `capabilities_missing` reflects reality (no more hardcoded `[]`)
- [x] Consumers `output_formatter` + `unified_text_analysis` (and the 4 others) not broken — additive key, `capabilities_used` stays `list[str]`
- [x] DI synthetic tests: degraded ≠ used, proven without real JVM/LLM
- [x] Anti-pendule (#1019) respected — no degraded→used masking, no key deletion, no forced verdict

### Anti-pendule
- A degraded axis is never reported as `used` (the inverse of the fix would be theatre).
- `capabilities_used` is corrected, not amputated — consumers depend on it.
- Honest-degraded is preserved as the correct signal when the solver decided nothing (cf. #1445 SetAF/weighted).

### Tests (6 new, DI / JVM-LLM-free)
`TestConstat5FormalCapabilityHonesty`: degraded-fol, genuine-fol, modal-OOM split (the crux), missing, mixed per-axis, `unavailable:parse-fail` prefix contract. Existing `test_capabilities_extracted_from_conversation` updated to the new honest semantics (FormalAgent + empty state → `missing`, not `used`).

### Verification
- `test_conversational_spectacular.py`: **15/15 PASS**
- Regression: `test_conversational_orchestrator` + `test_spectacular_regression_suite` + `test_mute_capabilities_b02`: **102 PASS**
- mypy: **0 new error** (42 pre-existing baseline unchanged; file is not in the strict gate)
- black + flake8: clean

### Privacy HARD
Opaque IDs only (`corpus_A synthetic`); no raw_text in state.

Base: `7151fb8e`. Closes nothing autonomously (Constat n°5 is a coordinator-tracked item under Epic #1355; awaiting coord review/merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
