### PR TITLE
feat(informal): genuinely-reachable neural tier for sophism comparison (GE-3 #1456)

### DIFF
--- a/argumentation_analysis/agents/core/informal/neuro_symbolic_arbitrator.py
+++ b/argumentation_analysis/agents/core/informal/neuro_symbolic_arbitrator.py
@@ -44,6 +44,7 @@ for production use in PR2/PR3. This mirrors the ``compare_*_backends`` DI idiom.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from dataclasses import dataclass, field, replace
 from typing import Any, Callable, Optional, Protocol, Sequence, runtime_checkable
@@ -521,6 +522,7 @@ class SophismComparison:
     arbitrated: ArbitrationResult
     eliminated_ids: frozenset[str]
     span_coverage: dict[str, str]
+    neural_reachable: bool = True
 
 
 def compare_sophism_backends(
@@ -532,6 +534,7 @@ def compare_sophism_backends(
     solver: Optional[DungSolver] = None,
     semantics: str = "grounded",
     conflict_policy: Optional[ConflictPolicy] = None,
+    neural_reachable: bool = True,
 ) -> SophismComparison:
     """Compare the neural-only and neuro-symbolic pipelines on the same batch.
 
@@ -549,6 +552,13 @@ def compare_sophism_backends(
 
     Args mirror :func:`arbitrate` plus the bridge's ``span_text_for`` /
     ``classifier`` / ``cq_evaluator``.
+
+    ``neural_reachable`` (GE-3 #1456) records whether the NEURAL tier genuinely
+    decided. When ``False`` (no LLM configured / detection failed) the comparison
+    is unilateral theatre — the caller MUST surface it as ``degraded``, never as a
+    genuine comparison (anti-théâtre #1019). A reachable tier that detected zero
+    fallacies stays ``True``: an empty-but-reachable neural verdict is an honest
+    negative, not a degraded failure.
     """
 
     neural_ids = frozenset(c.candidate_id for c in candidates)
@@ -570,6 +580,7 @@ def compare_sophism_backends(
         arbitrated=result,
         eliminated_ids=neural_ids - result.arbitrated_ids,
         span_coverage=coverage,
+        neural_reachable=neural_reachable,
     )
 
 
@@ -687,6 +698,154 @@ async def _llm_cq_evaluator_async(
         return ()
     canonical_set = set(canonical_cqs)
     return tuple(q for q in declared if isinstance(q, str) and q in canonical_set)
+
+
+# --------------------------------------------------------------------------- #
+# GE-3 (#1456, Epic #1448) — genuinely-reachable NEURAL tier                   #
+# --------------------------------------------------------------------------- #
+#
+# ``compare_sophism_backends`` is bilateral only when the NEURAL side genuinely
+# decides. The cluster's existing neural entry point (``_invoke_camembert_fallacy``)
+# depends on the SELF_HOSTED_LLM_* endpoint, which is not configured here → it
+# returns ``status="unavailable"`` and the axis stays honest-absent (constat C3:
+# the "comparison" is unilateral theatre). This detector routes through
+# ``_get_openai_client()`` (the configured OpenAI/OpenRouter client) so the neural
+# tier is reachable wherever the main LLM is — exactly like ``_llm_cq_evaluator``
+# does for the symbolic CQ side (PR3).
+
+
+async def llm_neural_detect_async(
+    input_text: str, *, max_candidates: int = 25
+) -> "tuple[list[SophismCandidate], Callable[[SophismCandidate], str], bool]":
+    """LLM-backed neural sophism detection producing genuine ``SophismCandidate``s.
+
+    Asks the configured LLM to detect the fallacies genuinely present in the
+    text, then maps each to an opaque candidate. Mirrors ``_llm_cq_evaluator``
+    (PR3): lazy imports, no-API-key honest-absent, JSON-mode, fail-soft.
+
+    Returns ``(candidates, span_text_for, reachable)``:
+
+    * ``candidates`` — ``SophismCandidate`` list (opaque ids ``s0..sN``, family
+      from the LLM label, span_id from a deterministic hash of the span text so
+      two detections on the same span with rival families are declared rivals
+      under :func:`default_conflict_policy`, confidence clamped to ``[0, 1]``);
+    * ``span_text_for`` — accessor feeding the Walton-CQ bridge;
+    * ``reachable`` — ``False`` when no key is configured OR the call/parse
+      failed (the axis MUST then surface as ``degraded``, never as a genuine
+      comparison — anti-théâtre #1019). ``True`` when the LLM genuinely ran
+      (even if it returned zero fallacies: a reachable negative is honest, not
+      degraded — see :func:`compare_sophism_backends` semantics).
+    """
+
+    # Lazy import (same no-cycle rationale as the CQ evaluator above).
+    from argumentation_analysis.orchestration.invoke_callables import (
+        _get_determinism_params,
+        _get_openai_client,
+        _guarded_chat_completion,
+        _parse_json_from_llm,
+    )
+
+    client, model_id = _get_openai_client()
+    if client is None:
+        logger.info(
+            "LLM neural detect: no API key configured — neural tier "
+            "unreachable (degraded, #1456)."
+        )
+        return [], lambda c: "", False
+
+    system_content = (
+        "You are an expert at detecting informal fallacies in argumentative text. "
+        "Identify the GENUINE fallacies present — report a fallacy ONLY when the "
+        "passage really commits it. Do NOT invent fallacies. For each one give: "
+        "a short family label (e.g. ad_hominem, straw_man, appeal_to_authority, "
+        "false_dilemma, hasty_generalization, slippery_slope, circular_reasoning, "
+        "equivocation, appeal_to_emotion, red_herring), the exact span text that "
+        "commits it (verbatim, <= 400 chars), and a confidence in [0,1]. "
+        "Respond with ONLY a JSON object of shape: "
+        '{"fallacies": [{"family": "...", "span_text": "...", "confidence": 0.0}]}'
+    )
+    user_content = (
+        f"Analyse the following text for fallacies:\n\n{input_text[:8000]}\n\n"
+        "Return the JSON."
+    )
+
+    det_params = _get_determinism_params()
+    llm_kwargs: dict[str, Any] = dict(det_params)
+    llm_kwargs["response_format"] = {"type": "json_object"}
+    try:
+        response = await _guarded_chat_completion(
+            client,
+            model=model_id,
+            messages=[
+                {"role": "system", "content": system_content},
+                {"role": "user", "content": user_content},
+            ],
+            **llm_kwargs,
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-soft: any LLM error → degraded
+        logger.info(
+            "LLM neural detect: call failed (%s); neural tier unreachable "
+            "(degraded, #1456).",
+            exc,
+        )
+        return [], lambda c: "", False
+
+    raw = response.choices[0].message.content or ""
+    try:
+        data = _parse_json_from_llm(raw)
+    except Exception as exc:  # noqa: BLE001
+        logger.info(
+            "LLM neural detect: parse failed (%s); neural tier unreachable "
+            "(degraded, #1456).",
+            exc,
+        )
+        return [], lambda c: "", False
+
+    raw_fallacies = data.get("fallacies") if isinstance(data, dict) else None
+    if not isinstance(raw_fallacies, list):
+        # Reachable, but nothing structured to detect — a reachable negative.
+        return [], lambda c: "", True
+
+    span_by_id: dict[str, str] = {}
+    candidates: list[SophismCandidate] = []
+    seen_ids: set[str] = set()
+    for i, f in enumerate(raw_fallacies[:max_candidates]):
+        if not isinstance(f, dict):
+            continue
+        family = str(f.get("family", "unknown")).strip() or "unknown"
+        span_text = str(f.get("span_text", "")).strip()[:400]
+        if not span_text:
+            continue
+        try:
+            confidence = float(f.get("confidence", 0.5))
+        except (TypeError, ValueError):
+            confidence = 0.5
+        confidence = max(0.0, min(1.0, confidence))
+        # Deterministic, opaque span anchor: same span text ⇒ same span_id, so
+        # rival-family detections on one passage are declared conflicts.
+        span_id = "span_" + hashlib.md5(span_text.encode("utf-8")).hexdigest()[:8]
+        cid = f"s{i}"
+        while cid in seen_ids:  # defensive: never collide with a challenger id
+            cid = f"s{i}_{len(seen_ids)}"
+        seen_ids.add(cid)
+        span_by_id[cid] = span_text
+        candidates.append(
+            SophismCandidate(
+                candidate_id=cid,
+                family=family,
+                span_id=span_id,
+                confidence=confidence,
+            )
+        )
+
+    def span_text_for(c: SophismCandidate) -> str:
+        return span_by_id.get(c.candidate_id, "")
+
+    logger.info(
+        "LLM neural detect: %d genuine candidate(s); neural tier reachable (#1456).",
+        len(candidates),
+    )
+    return candidates, span_text_for, True
 
 
 def make_llm_cq_evaluator() -> CQEvaluator:

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -7050,6 +7050,7 @@ async def _default_sophism_axis(
         "eliminated_ids": getattr(res, "eliminated_ids", frozenset()),
         "arbitrated": getattr(res, "arbitrated", None),
         "span_coverage": getattr(res, "span_coverage", None),
+        "neural_reachable": getattr(res, "neural_reachable", True),
     }
 
 
@@ -7147,6 +7148,35 @@ def _normalize_sophism_payload(payload: Any) -> Dict[str, Any]:
     neural = payload.get("neural_ids", frozenset()) or frozenset()
     neuro = payload.get("neuro_symbolic_ids", frozenset()) or frozenset()
     eliminated = payload.get("eliminated_ids", frozenset()) or frozenset()
+    # GE-3 (#1456): neural_reachable records whether the NEURAL tier genuinely
+    # decided. When False (no LLM configured / detection failed) the comparison
+    # is unilateral theatre — the axis is NOT genuinely available as a
+    # comparison, agreement is indeterminate, and the neural backend is
+    # unavailable with a proven cause (fail-loud #1019, anti-théâtre). A
+    # reachable tier that detected zero fallacies stays reachable: an
+    # empty-but-reachable verdict is an honest negative, not a degraded failure.
+    neural_reachable = payload.get("neural_reachable", True)
+    if not neural_reachable:
+        return {
+            "available": False,
+            "agreement": None,
+            "disagreements": [],
+            "backends": {
+                "neural": {
+                    "available": False,
+                    "note": (
+                        "neural tier unreachable (no LLM configured / detection "
+                        "failed) — comparison NOT run (degraded, #1456)"
+                    ),
+                },
+                "neuro_symbolic": {"available": False},
+            },
+            "timings_ms": {},
+            "note": (
+                "sophism axis degraded: neural tier did not decide — no genuine "
+                "comparison (anti-théâtre #1019)"
+            ),
+        }
     # honest-absent = the symbolic layer had no genuine signal (arbitrated is
     # None or its honest_absent flag is True) → agreement indeterminate, not a
     # fabricated agreement.
@@ -7168,7 +7198,7 @@ def _normalize_sophism_payload(payload: Any) -> Dict[str, Any]:
         "neuro_symbolic": {"available": not honest_absent},
     }
     return {
-        "available": True,  # the axis ran (the neural backend always exists)
+        "available": True,  # the axis ran with a reachable neural tier
         "agreement": agreement,
         "disagreements": disagreements,
         "backends": backends,
@@ -7388,6 +7418,39 @@ async def _invoke_multi_axis_compare(
             dung_arguments = _args
             dung_attacks = _generate_attacks_from_args(_args, context)
 
+    # GE-3 (#1456): the sophism axis is genuinely bilateral only when the NEURAL
+    # tier decides. When the caller opted into the sophism axis but supplied no
+    # explicit candidates (and no test-injected comparator), auto-derive them
+    # from a genuine LLM neural detection — mirroring how the dung axis auto-
+    # derives from upstream extraction. The tier is reachable wherever the main
+    # LLM is (it routes through ``_get_openai_client``); if no key is configured
+    # or the call fails, ``neural_reachable=False`` propagates through the
+    # sophism kwargs so the axis surfaces as ``degraded`` (never as a fake
+    # comparison — anti-théâtre #1019).
+    sophism_candidates = cfg.get("sophism_candidates")
+    sophism_span_text_for = cfg.get("sophism_span_text_for")
+    sophism_compare_fn = cfg.get("sophism_compare_fn")
+    wants_sophism = (
+        (explicit_axes is not None and "sophism" in explicit_axes)
+        or sophism_candidates is not None
+        or sophism_compare_fn is not None
+    )
+    sophism_kwargs: Optional[Dict[str, Any]] = cfg.get("sophism_kwargs")
+    if (
+        wants_sophism
+        and sophism_candidates is None
+        and sophism_compare_fn is None
+    ):
+        from argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator import (
+            llm_neural_detect_async,
+        )
+
+        sophism_candidates, sophism_span_text_for, _neural_reachable = (
+            await llm_neural_detect_async(input_text)
+        )
+        sophism_kwargs = dict(sophism_kwargs or {})
+        sophism_kwargs["neural_reachable"] = _neural_reachable
+
     comparison = await compare_all_axes(
         axes=cfg.get("axes"),
         fol_belief_set=cfg.get("fol_belief_set"),
@@ -7395,10 +7458,10 @@ async def _invoke_multi_axis_compare(
         dung_arguments=dung_arguments,
         dung_attacks=dung_attacks,
         dung_compare_fn=cfg.get("dung_compare_fn"),
-        sophism_candidates=cfg.get("sophism_candidates"),
-        sophism_span_text_for=cfg.get("sophism_span_text_for"),
-        sophism_compare_fn=cfg.get("sophism_compare_fn"),
-        sophism_kwargs=cfg.get("sophism_kwargs"),
+        sophism_candidates=sophism_candidates,
+        sophism_span_text_for=sophism_span_text_for,
+        sophism_compare_fn=sophism_compare_fn,
+        sophism_kwargs=sophism_kwargs,
     )
 
     logger.info(

--- a/tests/unit/argumentation_analysis/agents/core/informal/test_neuro_symbolic_arbitrator.py
+++ b/tests/unit/argumentation_analysis/agents/core/informal/test_neuro_symbolic_arbitrator.py
@@ -341,6 +341,52 @@ class TestCompareSophismBackends:
         assert cmp.span_coverage == {"s0": "expert_opinion"}
 
 
+class TestGE3NeuralReachable:
+    """GE-3 (#1456) — the neural_reachable flag distinguishes a genuine bilateral
+    comparison from unilateral theatre. A reachable tier that decided ⇒
+    neural_reachable=True (the genuine case). An unreachable tier ⇒ False, which
+    the downstream normalizer must turn into ``degraded`` (never a fake agreement).
+    Pure-python, JVM/LLM-free."""
+
+    def test_neural_reachable_defaults_true(self) -> None:
+        cmp = compare_sophism_backends(
+            [_cand("s0")], span_text_for=lambda c: "x"
+        )
+        assert cmp.neural_reachable is True
+
+    def test_neural_unreachable_propagates_to_comparison(self) -> None:
+        cmp = compare_sophism_backends(
+            [_cand("s0")], span_text_for=lambda c: "x", neural_reachable=False
+        )
+        assert cmp.neural_reachable is False
+        # Neural tier absent ⇒ no genuine decision; ids are empty by contract
+        # (the caller passes [] when unreachable), but the FLAG is the signal.
+        assert cmp.neural_ids == frozenset({"s0"})  # input echoed verbatim
+
+    def test_two_tiers_decide_genuine_comparison(self) -> None:
+        """DoD #1456 (a): both tiers decide ⇒ agreement is computed (not None)
+        and reflects the genuine symbolic elimination. The neural tier accepts
+        both candidates; the symbolic layer eliminates s0 (failed canonical CQ).
+        This is a real bilateral comparison, reachable=True throughout."""
+        scheme = classify_scheme("Selon un expert du domaine cela fonctionne.")
+        assert scheme is not None
+        canonical_cq = scheme.critical_questions[0]
+
+        def ev(_t: str, _s: object, c: SophismCandidate) -> tuple[str, ...]:
+            return (canonical_cq,) if c.candidate_id == "s0" else ()
+
+        cmp = compare_sophism_backends(
+            [_cand("s0", span="x"), _cand("s1", span="y")],
+            span_text_for=lambda c: "Selon un expert du domaine cela fonctionne.",
+            cq_evaluator=ev,
+            neural_reachable=True,
+        )
+        assert cmp.neural_reachable is True
+        assert cmp.eliminated_ids == frozenset({"s0"})  # symbolic disagreed
+        assert cmp.neuro_symbolic_ids == frozenset({"s1"})
+        assert cmp.arbitrated.honest_absent is False  # genuine arbitrage ran
+
+
 class TestLlmCqEvaluator:
     """PR3 — production wiring of the LLM-backed CQ evaluator.
 

--- a/tests/unit/argumentation_analysis/orchestration/test_compare_all_axes.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_compare_all_axes.py
@@ -463,3 +463,129 @@ class TestMultiAxisCompareHandler:
         )
 
         assert callable(_h)
+
+
+# -- GE-3 #1456: genuinely-reachable neural tier for the sophism axis ----------
+
+
+class TestGE3NeuralTier:
+    """GE-3 (#1456, Epic #1448). The sophism axis is genuinely bilateral only
+    when the NEURAL tier decides. These tests pin the honest-degraded contract:
+    neural unreachable ⇒ axis available=False (degraded, never a fake agreement);
+    neural reachable ⇒ axis runs with the derived candidates. No JVM, no real
+    LLM (the detector is monkeypatched)."""
+
+    _NEURAL_DETECT_PATH = (
+        "argumentation_analysis.agents.core.informal."
+        "neuro_symbolic_arbitrator.llm_neural_detect_async"
+    )
+
+    def test_normalize_neural_unreachable_is_degraded(self) -> None:
+        """A sophism payload with neural_reachable=False surfaces as available=False
+        with a proven degraded cause — NOT as a vacuous agreement (anti-théâtre)."""
+        out = _normalize_sophism_payload(
+            {
+                "neural_ids": frozenset(),
+                "neuro_symbolic_ids": frozenset(),
+                "eliminated_ids": frozenset(),
+                "arbitrated": {"honest_absent": True},
+                "span_coverage": {},
+                "neural_reachable": False,
+            }
+        )
+        assert out["available"] is False
+        assert out["agreement"] is None
+        assert out["backends"]["neural"]["available"] is False
+        assert "degraded" in out["note"]
+
+    def test_normalize_reachable_with_genuine_split_reports_disagreement(
+        self,
+    ) -> None:
+        """Reachable tier + a genuine symbolic elimination ⇒ available=True and
+        agreement=False (a real, unreconciled bilateral disagreement)."""
+        out = _normalize_sophism_payload(
+            {
+                "neural_ids": frozenset({"s0", "s1"}),
+                "neuro_symbolic_ids": frozenset({"s1"}),
+                "eliminated_ids": frozenset({"s0"}),
+                "arbitrated": {"honest_absent": False},
+                "span_coverage": {"s0": "expert_opinion"},
+                "neural_reachable": True,
+            }
+        )
+        assert out["available"] is True
+        assert out["agreement"] is False
+        assert out["disagreements"] == ["eliminated: s0"]
+
+    async def test_handler_auto_derives_sophism_from_llm(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DoD #1456 (a): caller opts into the sophism axis without explicit
+        candidates ⇒ the handler auto-derives them from the (mocked) reachable
+        neural tier and the axis genuinely runs (available=True)."""
+        from argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator import (
+            SophismCandidate,
+        )
+
+        async def _fake_detect(text: str):
+            cands = [
+                SophismCandidate("s0", "ad_hominem", "span_a", 0.9),
+                SophismCandidate("s1", "straw_man", "span_b", 0.7),
+            ]
+            return cands, lambda c: "passage text", True
+
+        monkeypatch.setattr(self._NEURAL_DETECT_PATH, _fake_detect)
+
+        ctx = {"multi_axis": {"axes": ["sophism"]}}
+        out = await _invoke_multi_axis_compare("source text", ctx)
+        ax = out["comparison"]["axes"]["sophism"]
+        assert ax["available"] is True
+        assert ax["backends"]["neural"]["available"] is True
+
+    async def test_handler_neural_unreachable_is_degraded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """DoD #1456 (b): neural tier genuinely unavailable (no key / call failed)
+        ⇒ the sophism axis is degraded (available=False), NEVER presented as a
+        genuine comparison (anti-théâtre #1019)."""
+        from argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator import (
+            SophismCandidate,
+        )
+
+        async def _fake_unreachable(text: str):
+            return [], lambda c: "", False
+
+        monkeypatch.setattr(self._NEURAL_DETECT_PATH, _fake_unreachable)
+
+        ctx = {"multi_axis": {"axes": ["sophism"]}}
+        out = await _invoke_multi_axis_compare("source text", ctx)
+        ax = out["comparison"]["axes"]["sophism"]
+        assert ax["available"] is False  # degraded, NOT a fake comparison
+        assert ax["agreement"] is None
+        assert ax["backends"]["neural"]["available"] is False
+        assert "degraded" in ax.get("note", "")
+
+    async def test_handler_explicit_candidates_skip_auto_derivation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the caller supplies explicit candidates, auto-derivation is NOT
+        triggered (the detector must not be called) — anti-pendule: don't run an
+        LLM call the caller did not ask for."""
+
+        async def _boom(text: str):
+            raise AssertionError("auto-derivation must not run when candidates given")
+
+        monkeypatch.setattr(self._NEURAL_DETECT_PATH, _boom)
+
+        ctx = {
+            "multi_axis": {
+                "axes": ["sophism"],
+                "sophism_candidates": ["c0"],
+                "sophism_span_text_for": lambda c: "x",
+                "sophism_compare_fn": _sophism_fake([], honest_absent=True),
+            }
+        }
+        out = await _invoke_multi_axis_compare("source text", ctx)
+        ax = out["comparison"]["axes"]["sophism"]
+        assert ax["available"] is True  # injected comparator ran, no LLM call
+


### PR DESCRIPTION
## Track GE-3 #1456 — neuro-symbolic sophism comparison: genuinely-reachable neural tier

Closes #1456 (Track GE-3, Epic #1448). The constat firsthand ATT-3 (C3): `compare_sophism_backends` was **unilateral theatre** — the neural tier was unavailable, so the "comparison" only ever ran the symbolic side and presented it as compared. This PR makes the tier genuinely reachable and surfaces honest-`degraded` when it cannot decide.

### Root cause (located firsthand)

- The cluster's neural entry point `_invoke_camembert_fallacy` depends on `SELF_HOSTED_LLM_*`, which is not configured here → returns `status="unavailable"`.
- `compare_sophism_backends` ran only when `context["multi_axis"]["sophism_candidates"]` was supplied, and **nothing ever populated it** → the sophism axis stayed honest-absent (never genuinely bilateral).
- `_normalize_sophism_payload` hardcoded `available=True` / `backends.neural.available=True` — it had no path to report the neural tier as genuinely absent.

### Changes (2 source + 2 test, +399/-5)

**`neuro_symbolic_arbitrator.py`**
- `llm_neural_detect_async(text)` — genuinely-reachable neural tier. Routes through `_get_openai_client()` (the configured OpenAI/OpenRouter client — **not** the dead self-hosted endpoint), so the tier is reachable wherever the main LLM is. Mirrors the PR3 `_llm_cq_evaluator` pattern: lazy imports, no-API-key → honest-absent, JSON-mode, fail-soft. Returns `(candidates, span_text_for, reachable)`; `reachable=False` on no-key/call/parse failure.
- `SophismComparison.neural_reachable: bool = True` (additive field) + `compare_sophism_backends(..., neural_reachable=True)` param — propagates whether the neural tier genuinely decided. A reachable tier that detected zero fallacies stays `True` (honest negative ≠ degraded failure).

**`invoke_callables.py`**
- `_normalize_sophism_payload` — honors `neural_reachable`. When `False` → `available=False`, `agreement=None`, `backends.neural.available=False` with a proven degraded cause (fail-loud #1019). Removes the hardcoded `available=True`.
- `_invoke_multi_axis_compare` — **auto-derives** sophism candidates from the LLM neural detection when the caller opts into the sophism axis without explicit candidates (mirrors how the dung axis auto-derives from upstream extraction). Propagates `neural_reachable` through `sophism_kwargs`. Explicit candidates / injected `sophism_compare_fn` skip auto-derivation (anti-pendule: no LLM call the caller didn't ask for).

### DoD

- [x] **Two tiers decide → agreement computed** — `test_two_tiers_decide_genuine_comparison` (neural accepts both; symbolic eliminates s0 via a failed canonical Walton CQ → genuine bilateral disagreement).
- [x] **Neural unavailable → honest degraded** — `_normalize_sophism_payload` + `test_handler_neural_unreachable_is_degraded` (available=False, agreement=None, proven cause, never a fake comparison).
- [x] **Agreement never auto-reconciled** — the eliminated set is surfaced verbatim (I5 pattern); disagreement = disagreement.
- [x] **Firsthand** — probe (`scratchpad/ge3_firsthand_probe.py`, synthetic public-domain text, NOT the corpus) confirms: the wiring reaches the configured LLM and, on this machine, the call fails (401 invalid key / connection error) → `reachable=False` → degraded is the **honest, proven** outcome (anti-théâtre: the happy-path "neural decides" requires a valid LLM credential — an infra precondition, not a code defect; ready for the coordinator to validate on a corpus re-run when credentials are healthy).

### Validation

- `mypy --strict` on both source files: **0 errors** (was 1 lambda-inference error, fixed via a typed named closure).
- `pytest test_neuro_symbolic_arbitrator.py test_compare_all_axes.py`: **62 passed, 1 skipped** (pre-existing). 8 new GE-3 tests (3 arbitrator + 5 harness), all green.
- No regression: existing sophism/harness behavior preserved (explicit candidates, injected comparators, honest-absent default).

Refs #1456 #1448 #1019.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
