### PR TITLE
feat(orchestration): governance genuine vote aggregation (GE-4 #1462)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -1578,6 +1578,160 @@ async def _invoke_debate_analysis(
     return base_scores  # type: ignore[no-any-return]
 
 
+def _derive_governance_profile(
+    quality_output: Dict[str, Any],
+) -> Tuple[List[str], List[List[str]], List[Any], bool, str]:
+    """Derive a multi-elector preference profile from upstream quality scores (GE-4 #1462).
+
+    HONEST derivation — no fabricated preferences. Each of the 9 argumentative
+    virtues is a real evaluation criterion, hence a legitimate *elector* whose
+    preference ranks the extracted arguments by its own score.
+
+    - Options = evaluated arguments (opaque ids ``arg_1``, ``arg_2``…).
+    - Electors = virtues present in ``scores_par_vertu`` across the arguments.
+    - Preference of elector *v* = arguments ordered by their score on *v* (desc).
+
+    Returns ``(options, ballots, agents, derivable, reason)``. ``derivable=False``
+    triggers the honest-degraded branch (<2 options or no virtue scores): the
+    material carries no orderable preferences, mirroring the SetAF branch-OR on
+    corpus A/C. Unanimous preferences are NOT degraded — they are reported
+    honestly as concordant (empty divergence), a genuine collective decision.
+    """
+    from argumentation_analysis.agents.core.governance.governance_agent import Agent
+
+    per_arg = (
+        quality_output.get("per_argument_scores", {})
+        if isinstance(quality_output, dict)
+        else {}
+    )
+    if not isinstance(per_arg, dict) or len(per_arg) < 2:
+        return [], [], [], False, (
+            "fewer than 2 evaluated arguments — no collective choice possible"
+        )
+
+    options = sorted(per_arg.keys())
+    virtue_to_scores: Dict[str, List[Tuple[float, str]]] = {}
+    for arg_id in options:
+        result = per_arg.get(arg_id)
+        if not isinstance(result, dict):
+            continue
+        scores = result.get("scores_par_vertu", {})
+        if not isinstance(scores, dict):
+            continue
+        for virtue, score in scores.items():
+            if isinstance(score, (int, float)):
+                virtue_to_scores.setdefault(virtue, []).append((float(score), arg_id))
+
+    if not virtue_to_scores:
+        return [], [], [], False, (
+            "no per-virtue scores available — cannot derive ordered preferences"
+        )
+
+    agents: List[Any] = []
+    ballots: List[List[str]] = []
+    for virtue in sorted(virtue_to_scores.keys()):
+        ranked = sorted(virtue_to_scores[virtue], key=lambda t: (-t[0], t[1]))
+        order = [arg_id for _, arg_id in ranked]
+        if len(order) < 2:
+            continue
+        agents.append(
+            Agent(
+                name=f"elector_{virtue}",
+                personality="stubborn",
+                preferences=list(order),
+            )
+        )
+        ballots.append(list(order))
+
+    if not agents:
+        return [], [], [], False, "no elector produced a full ordering"
+
+    return options, ballots, agents, True, (
+        f"{len(agents)} electors derived from {len(virtue_to_scores)} virtues"
+    )
+
+
+def _aggregate_governance_votes(
+    agents: List[Any], options: List[str], ballots: List[List[str]]
+) -> Dict[str, Any]:
+    """Run the 7 agent-based + 5 social-choice voting methods on the derived
+    profile (GE-4 #1462).
+
+    Returns the per-method winners and the **divergence set** (distinct winners
+    across methods) — reported verbatim, NEVER reconciled into a single number
+    (cf. multi-prover FOL / I5 anti-reconcile discipline).
+
+    Deterministic by construction: ``byzantine`` and ``raft`` are stochastic by
+    design (faulty-agent / leader-election models); they run under a fixed local
+    seed (RNG state snapshotted and restored) so the verdict is reproducible and
+    flagged ``stochastic_methods``.
+    """
+    import numpy as np
+
+    from argumentation_analysis.agents.core.governance.governance_methods import (
+        GOVERNANCE_METHODS,
+    )
+    from argumentation_analysis.agents.core.governance import social_choice as sc
+
+    stochastic_methods = ["byzantine", "raft"]
+    agent_context: Dict[str, Any] = {}
+    winners: Dict[str, Any] = {}
+
+    # 7 agent-based methods (byzantine/raft under a fixed local seed).
+    rng_state = np.random.get_state()
+    np.random.seed(42)
+    try:
+        for name, fn in GOVERNANCE_METHODS.items():
+            try:
+                winners[name] = fn(agents, options, agent_context)  # type: ignore[no-untyped-call]  # legacy governance_methods (GE-4 #1462)
+            except Exception as exc:  # noqa: BLE001 — fail-soft per method
+                winners[name] = None
+                logger.debug("governance method %s failed: %s", name, exc)
+    finally:
+        np.random.set_state(rng_state)
+
+    # 5 social-choice methods (operate on the preference ballots directly).
+    social_winners: Dict[str, Any] = {}
+    try:
+        social_winners["approval"] = sc.approval_voting(ballots, options)[0]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("approval voting skipped: %s", exc)
+    try:
+        stv_winners, _rounds = sc.stv(ballots, options, seats=1)
+        social_winners["stv"] = stv_winners[0] if stv_winners else None
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("stv skipped: %s", exc)
+    try:
+        social_winners["copeland"] = sc.copeland(ballots, options)[0]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("copeland skipped: %s", exc)
+    try:
+        social_winners["schulze"] = sc.schulze(ballots, options)[0]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("schulze skipped: %s", exc)
+    try:
+        social_winners["condorcet_winner"] = sc.condorcet_winner(ballots, options)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("condorcet_winner skipped: %s", exc)
+
+    winners.update(social_winners)
+
+    decided = {k: v for k, v in winners.items() if v is not None}
+    distinct_winners = sorted({str(v) for v in decided.values()})
+    n_decided = len(decided)
+    disagreement = len(distinct_winners) > 1
+
+    return {
+        "winners_per_method": winners,
+        "n_methods_decided": n_decided,
+        "distinct_winners": distinct_winners,
+        "inter_method_disagreement": disagreement,
+        "condorcet_winner": social_winners.get("condorcet_winner"),
+        "stochastic_methods": stochastic_methods,
+        "derivation": "formal-vote-aggregation (virtue electors)",
+    }
+
+
 async def _invoke_governance(
     input_text: str, context: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -1621,25 +1775,23 @@ async def _invoke_governance(
             resolutions.append(json.loads(resolution_json))
 
     # (#294) Auto-run social choice vote when we have enough positions
-    vote_result = None
-    if len(positions) >= 2:
-        try:
-            options = list(positions.keys())
-            # Build preference ballots: each agent ranks others based on position order
-            ballots = []
-            for agent in options:
-                pref = [a for a in options if a != agent] + [agent]
-                ballots.append(pref)
-            vote_input = json.dumps(
-                {
-                    "method": context.get("vote_method", "copeland"),
-                    "ballots": ballots,
-                    "options": options,
-                }
-            )
-            vote_result = json.loads(plugin.social_choice_vote(vote_input))
-        except Exception as e:
-            logger.debug(f"Social choice vote skipped: {e}")
+    # GE-4 #1462 — formal vote aggregation on HONESTLY derived preferences.
+    # The 9 quality virtues act as electors (real criteria, not fabricated).
+    # Verdict = the formal aggregation; the LLM assessment below is a prior only.
+    g_options, g_ballots, g_agents, g_derivable, g_reason = _derive_governance_profile(
+        quality_output
+    )
+    if g_derivable:
+        governance_verdict = _aggregate_governance_votes(g_agents, g_options, g_ballots)
+        governance_verdict["degraded"] = False
+        governance_verdict["derivation_reason"] = g_reason
+    else:
+        governance_verdict = {
+            "degraded": True,
+            "reason": g_reason,
+            "derivation": "formal-vote-aggregation (virtue electors)",
+        }
+        logger.debug("governance formal aggregation degraded: %s", g_reason)
 
     # Enrich with LLM-based governance and deliberation assessment
     llm_governance = None
@@ -1772,6 +1924,26 @@ async def _invoke_governance(
     except Exception as e:
         logger.warning(f"LLM governance assessment failed: {e}")
 
+    # GE-4 #1462 — reconstruct a backward-compatible, HONEST vote_result from
+    # the formal aggregation (per-method winners as the 'votes' list; the winner
+    # is the Condorcet winner if one exists, else the plurality winner). This
+    # supersedes the former fabricated self-deprecating ballots.
+    vote_result = None
+    if not governance_verdict.get("degraded"):
+        wpm = governance_verdict.get("winners_per_method", {})
+        winner = (
+            governance_verdict.get("condorcet_winner")
+            or wpm.get("majority")
+            or wpm.get("plurality")
+        )
+        votes = [v for v in wpm.values() if v is not None]
+        vote_result = {
+            "winner": winner,
+            "votes": votes,
+            "method": "formal-aggregation",
+            "results": governance_verdict,
+        }
+
     result = {
         "available_methods": available_methods,
         "positions": positions,
@@ -1779,6 +1951,11 @@ async def _invoke_governance(
         "resolutions": resolutions,
         "conflict_count": len(conflicts),
         "extraction_method": "llm" if llm_governance else "heuristic",
+        # GE-4 #1462 — the genuine verdict: a formal vote aggregation (or an
+        # honest-degraded marker). NOT LLM-scored; the LLM assessment below is
+        # at most a prior (recommended method), never the verdict.
+        "governance_verdict": governance_verdict,
+        "governance_decided_firsthand": not governance_verdict.get("degraded", True),
     }
     if vote_result:
         result["vote_result"] = vote_result
@@ -1795,6 +1972,8 @@ async def _invoke_governance(
         except Exception as e:
             logger.debug(f"Consensus metrics computation skipped: {e}")
     if llm_governance:
+        # GE-4 #1462: LLM assessment is a PRIOR (method recommendation /
+        # qualitative framing), explicitly not the governance verdict.
         result["llm_governance_assessment"] = llm_governance
         result["recommended_method"] = llm_governance.get("recommended_method")
         result["consensus_potential"] = llm_governance.get("consensus_potential")
@@ -1802,14 +1981,24 @@ async def _invoke_governance(
     _state = context.get("_state_object")
     if _state is not None and result.get("conflict_count", 0) > 0:
         _n_conflicts = result.get("conflict_count", 0)
-        _vote = result.get("vote_result", {})
-        _consensus = result.get("consensus_potential", "N/A")
-        _method = result.get("recommended_method", "copeland")
+        _decided = result.get("governance_decided_firsthand", False)
+        _verdict = result.get("governance_verdict", {})
+        _distinct = _verdict.get("distinct_winners", [])
+        _disagree = _verdict.get("inter_method_disagreement", False)
+        _verdict_kind = (
+            f"verdict formel ({len(_verdict.get('winners_per_method', {}))} méthodes, "
+            f"divergence={'oui' if _disagree else 'non'})"
+            if _decided
+            else f"verdict dégradé ({_verdict.get('reason', 'n/a')})"
+        )
         _state.add_trace_entry(
             phase="governance",
             agent="GovernanceModule",
             reacts_to=["quality", "hierarchical_fallacy", "jtms"],
-            summary=f"{_n_conflicts} conflits détectés — méthode: {_method}, consensus: {_consensus}. Vote social-choice appliqué.",
+            summary=(
+                f"{_n_conflicts} conflits détectés — {_verdict_kind}. "
+                f"Gagnants distincts: {_distinct}. (GE-4 #1462)"
+            ),
         )
     return result
 

--- a/tests/unit/argumentation_analysis/orchestration/test_auto_evaluate_governance.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_auto_evaluate_governance.py
@@ -149,7 +149,10 @@ class TestGovernanceAutoVote:
     """Tests for #294 — governance auto-triggers social_choice_vote."""
 
     async def test_governance_runs_vote_with_positions(self):
-        """Governance auto-runs Copeland vote when positions are available."""
+        """GE-4 #1462: governance produces a FORMAL vote aggregation
+        (governance_verdict) when the quality phase carries derivable
+        per-virtue preferences — superseding the former single mocked
+        social_choice_vote (#294)."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_governance,
         )
@@ -157,11 +160,8 @@ class TestGovernanceAutoVote:
         mock_plugin = MagicMock()
         mock_plugin.list_governance_methods.return_value = '["majority", "copeland"]'
         mock_plugin.detect_conflicts_fn.return_value = "[]"
-        mock_plugin.social_choice_vote.return_value = json.dumps(
-            {
-                "winner": "agent_1",
-                "copeland_scores": {"agent_1": 2, "agent_2": 1, "agent_3": 0},
-            }
+        mock_plugin.compute_consensus_metrics.return_value = json.dumps(
+            {"consensus_rate": 1.0}
         )
 
         with patch(
@@ -179,12 +179,25 @@ class TestGovernanceAutoVote:
                         {"text": "Arg 3"},
                     ]
                 },
+                "phase_quality_output": {
+                    "per_argument_scores": {
+                        "arg_1": {"scores_par_vertu": {"clarte": 9.0, "pertinence": 4.0, "structure": 3.0}},
+                        "arg_2": {"scores_par_vertu": {"clarte": 5.0, "pertinence": 8.0, "structure": 7.0}},
+                        "arg_3": {"scores_par_vertu": {"clarte": 2.0, "pertinence": 6.0, "structure": 5.0}},
+                    }
+                },
             }
             result = await _invoke_governance("Test", context)
 
-        assert "vote_result" in result
-        assert result["vote_result"]["winner"] == "agent_1"
-        mock_plugin.social_choice_vote.assert_called_once()
+        assert result["governance_decided_firsthand"] is True
+        verdict = result["governance_verdict"]
+        assert verdict["degraded"] is False
+        assert verdict["condorcet_winner"] == "arg_2"
+        assert verdict["n_methods_decided"] >= 3
+        # Backward-compat vote_result is reconstructed honestly from the verdict.
+        assert result["vote_result"]["winner"] == "arg_2"
+        # GE-4: the aggregation bypasses the plugin's social_choice_vote.
+        mock_plugin.social_choice_vote.assert_not_called()
 
     async def test_governance_no_vote_with_single_position(self):
         """Governance skips vote when less than 2 positions."""

--- a/tests/unit/argumentation_analysis/orchestration/test_governance_ge4_1462.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_governance_ge4_1462.py
@@ -1,0 +1,200 @@
+"""GE-4 #1462 — governance genuine vote aggregation tests.
+
+Anti-théâtre contract: governance must DECIDE firsthand via a FORMAL vote
+aggregation (>=3 of the 7 real methods + social-choice), NOT via an LLM-scored
+ranking. Inter-method divergence is surfaced verbatim, NEVER reconciled into a
+single number (cf. multi-prover FOL / I5 discipline). When the material carries
+no orderable preferences (<2 args, no virtue scores), the axis is
+honest-degraded (branch-OR, as SetAF on corpus A/C) — never a fake vote.
+
+No JVM, no real LLM, synthetic opaque inputs only (privacy HARD).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+from unittest.mock import patch
+
+import pytest
+
+from argumentation_analysis.orchestration.invoke_callables import (
+    _aggregate_governance_votes,
+    _derive_governance_profile,
+    _invoke_governance,
+)
+from argumentation_analysis.agents.core.governance.governance_agent import Agent
+
+
+def _no_llm() -> Tuple[None, str]:
+    """Stub for _get_openai_client: no LLM available (honest)."""
+    return None, ""
+
+
+# ---------------------------------------------------------------------------
+# _derive_governance_profile — honest derivation
+# ---------------------------------------------------------------------------
+
+
+def test_derive_profile_concordant_three_electors():
+    """3 args x 3 virtues -> arg_2 is the Condorcet winner (beats others on 2/3)."""
+    quality = {
+        "per_argument_scores": {
+            "arg_1": {"scores_par_vertu": {"clarte": 9.0, "pertinence": 4.0, "structure": 3.0}},
+            "arg_2": {"scores_par_vertu": {"clarte": 5.0, "pertinence": 8.0, "structure": 7.0}},
+            "arg_3": {"scores_par_vertu": {"clarte": 2.0, "pertinence": 6.0, "structure": 5.0}},
+        }
+    }
+    options, ballots, agents, derivable, reason = _derive_governance_profile(quality)
+    assert derivable is True
+    assert options == ["arg_1", "arg_2", "arg_3"]
+    assert len(agents) == 3   # one elector per virtue
+    # clarte ranks arg_1 first; pertinence + structure rank arg_2 first.
+    assert ballots[0][0] == "arg_1"   # clarte elector
+    assert ballots[1][0] == "arg_2"   # pertinence elector
+    assert ballots[2][0] == "arg_2"   # structure elector
+    assert "3 electors" in reason
+
+
+def test_derive_profile_degraded_single_argument():
+    """<2 evaluated arguments -> honest-degraded (no collective choice)."""
+    quality = {
+        "per_argument_scores": {
+            "arg_1": {"scores_par_vertu": {"clarte": 9.0}},
+        }
+    }
+    options, ballots, agents, derivable, reason = _derive_governance_profile(quality)
+    assert derivable is False
+    assert options == []
+    assert agents == []
+    assert "fewer than 2" in reason
+
+
+def test_derive_profile_degraded_no_virtue_scores():
+    """Per-arg results without scores_par_vertu -> honest-degraded."""
+    quality = {
+        "per_argument_scores": {
+            "arg_1": {"note_finale": 7.0},
+            "arg_2": {"note_finale": 5.0},
+        }
+    }
+    _options, _ballots, _agents, derivable, reason = _derive_governance_profile(quality)
+    assert derivable is False
+    assert "no per-virtue scores" in reason
+
+
+# ---------------------------------------------------------------------------
+# _aggregate_governance_votes — divergence never reconciled
+# ---------------------------------------------------------------------------
+
+
+def test_aggregate_divergence_plurality_vs_condorcet_never_reconciled():
+    """Plurality elects the Condorcet LOSER while Condorcet elects the winner:
+    inter-method divergence must be surfaced verbatim (distinct_winners holds
+    BOTH), never collapsed into a single number (#1019 / I5 anti-reconcile)."""
+    # 7 electors: 3 rank arg_1 first (-> plurality), 4 rank arg_2 above arg_1
+    # (-> arg_2 is the Condorcet winner, arg_1 the Condorcet loser).
+    agents: List[Any] = [
+        Agent("e1", "stubborn", ["arg_1", "arg_2", "arg_3"]),
+        Agent("e2", "stubborn", ["arg_1", "arg_3", "arg_2"]),
+        Agent("e3", "stubborn", ["arg_1", "arg_2", "arg_3"]),
+        Agent("e4", "stubborn", ["arg_2", "arg_1", "arg_3"]),
+        Agent("e5", "stubborn", ["arg_2", "arg_3", "arg_1"]),
+        Agent("e6", "stubborn", ["arg_3", "arg_2", "arg_1"]),
+        Agent("e7", "stubborn", ["arg_3", "arg_2", "arg_1"]),
+    ]
+    options = ["arg_1", "arg_2", "arg_3"]
+    ballots = [list(a.preferences) for a in agents]
+
+    verdict = _aggregate_governance_votes(agents, options, ballots)
+    wpm = verdict["winners_per_method"]
+
+    # Plurality/majority elect arg_1 (3 first-places); Condorcet elects arg_2.
+    assert wpm["majority"] == "arg_1"
+    assert verdict["condorcet_winner"] == "arg_2"
+    # Divergence surfaced verbatim — BOTH winners present, never reconciled.
+    assert verdict["inter_method_disagreement"] is True
+    assert "arg_1" in verdict["distinct_winners"]
+    assert "arg_2" in verdict["distinct_winners"]
+    # DoD: >=3 methods decided firsthand.
+    assert verdict["n_methods_decided"] >= 3
+
+
+def test_aggregate_concordant_profile_single_winner():
+    """UNANIMOUS profile (all electors share one ordering) -> empty divergence,
+    reported honestly (NOT degraded — concordance is a genuine collective
+    decision). Unanimity guarantees even the stochastic methods (byzantine with
+    0 faulty agents, raft with universal acceptance) elect the same option."""
+    agents = [
+        Agent("e1", "stubborn", ["arg_1", "arg_2", "arg_3"]),
+        Agent("e2", "stubborn", ["arg_1", "arg_2", "arg_3"]),
+        Agent("e3", "stubborn", ["arg_1", "arg_2", "arg_3"]),
+    ]
+    options = ["arg_1", "arg_2", "arg_3"]
+    ballots = [list(a.preferences) for a in agents]
+    verdict = _aggregate_governance_votes(agents, options, ballots)
+    assert verdict["condorcet_winner"] == "arg_1"
+    assert verdict["inter_method_disagreement"] is False
+    assert verdict["distinct_winners"] == ["arg_1"]
+    assert verdict["n_methods_decided"] >= 3
+
+
+# ---------------------------------------------------------------------------
+# _invoke_governance — end-to-end handler (DoD test guard)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handler_guard_governance_decides_firsthand_condorcet():
+    """DoD test guard: on a synthetic quality profile with a known Condorcet
+    winner, the handler decides FIRSTHAND via formal aggregation (no LLM)."""
+    quality = {
+        "per_argument_scores": {
+            "arg_1": {"scores_par_vertu": {"clarte": 9.0, "pertinence": 4.0, "structure": 3.0}},
+            "arg_2": {"scores_par_vertu": {"clarte": 5.0, "pertinence": 8.0, "structure": 7.0}},
+            "arg_3": {"scores_par_vertu": {"clarte": 2.0, "pertinence": 6.0, "structure": 5.0}},
+        }
+    }
+    context: Dict[str, Any] = {
+        "phase_extract_output": {"arguments": ["a", "b", "c"]},
+        "phase_quality_output": quality,
+        "_state_object": None,
+    }
+    with patch(
+        "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+        return_value=(None, ""),
+    ):
+        result = await _invoke_governance("synthetic neutral text", context)
+
+    assert result["governance_decided_firsthand"] is True
+    verdict = result["governance_verdict"]
+    assert verdict["degraded"] is False
+    assert verdict["condorcet_winner"] == "arg_2"
+    assert verdict["n_methods_decided"] >= 3
+    # The LLM assessment is NOT the verdict (absent here — no LLM).
+    assert "llm_governance_assessment" not in result
+    assert result["extraction_method"] == "heuristic"
+
+
+@pytest.mark.asyncio
+async def test_handler_degraded_when_single_argument():
+    """DoD: honest-degraded when <2 arguments (branch-OR, never a fake vote)."""
+    quality = {
+        "per_argument_scores": {
+            "arg_1": {"scores_par_vertu": {"clarte": 9.0, "pertinence": 4.0}},
+        }
+    }
+    context: Dict[str, Any] = {
+        "phase_extract_output": {"arguments": ["a"]},
+        "phase_quality_output": quality,
+        "_state_object": None,
+    }
+    with patch(
+        "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+        return_value=(None, ""),
+    ):
+        result = await _invoke_governance("synthetic neutral text", context)
+
+    assert result["governance_decided_firsthand"] is False
+    verdict = result["governance_verdict"]
+    assert verdict["degraded"] is True
+    assert "fewer than 2" in verdict["reason"]


### PR DESCRIPTION
## GE-4 #1462 — Governance genuine vote aggregation

Dispatch ai-01 (R634, HIGH). Replaces the **anti-théâtre** governance verdict (1 fabricated self-deprecating ballot → 1 method → LLM-dominated ranking) with a **formal 12-method aggregation** over a virtue-elector preference profile derived honestly from upstream quality scores.

### Root cause (firsthand-located)
`_invoke_governance` fabricated ballots (`pref = [a for a in options if a != agent] + [agent]` — every agent self-deprecates), ran a single method, then let an LLM assessment override the verdict. The "decision" was theatre: no genuine collective choice, no inter-method divergence surfaced.

### Fix (3 seams)
- **`_derive_governance_profile`** — each of the 9 argumentative virtues is a real evaluation criterion, hence a legitimate *elector*. Options = evaluated args; preference = args ranked by virtue score (desc). No fabricated preferences.
- **`_aggregate_governance_votes`** — runs the 7 agent-based methods (`majority`, `plurality`, `borda`, `condorcet`, `quadratic`, `byzantine`, `raft`) + 5 social-choice (`approval`, `stv`, `copeland`, `schulze`, `condorcet_winner`). Stochastic methods seeded (numpy seed 42, state saved/restored). **Inter-method divergence surfaced verbatim** (`distinct_winners`, `inter_method_disagreement`) — NEVER reconciled into a single number (I5 anti-reconcile discipline).
- **`_invoke_governance`** — `governance_verdict` (formel|dégradé) is the genuine decision; `governance_decided_firsthand = not degraded`. Backward-compat `vote_result` reconstructed honestly from the verdict (winner = Condorcet | majority | plurality; votes = per-method winners). LLM assessment demoted to a **prior** (`recommended_method`), never the verdict.

### Honest-degraded (branch-OR, anti-pendule #1019)
When `<2 evaluated args` or no `scores_par_vertu`, the profile is underivable → `degraded=True` with an honest reason. **Never** a fabricated vote. Same discipline as SetAF on corpus A/C.

### DoD (all met)
- ✅ Formal aggregation (≥3 methods) decided firsthand — `n_methods_decided >= 3`
- ✅ Inter-method divergence reported verbatim (plurality vs Condorcet test: BOTH winners present)
- ✅ `degraded=True` honest when preferences underivable
- ✅ Comparable/selectable (parametric, same return-shape contract)
- ✅ Test guard (7 GE-4 tests + adapted #294 regression)

### Validation
- `mypy --strict` : 0 errors (the true CI gate)
- 7/7 GE-4 tests pass · adapted #294 regression (`vote_result` contract) passes
- 27/27 `test_unified_pipeline` unit tests pass · 13/14 golden tests pass (1 integration test `run_unified_analysis` timeouts on a preexisting broken `qwen` LLM endpoint — confirmed preexisting via stash, unrelated to GE-4) · 140 state-writer tests pass
- Synthetic opaque inputs only, no corpus, no `raw_text` (privacy HARD)

### Files
- `argumentation_analysis/orchestration/invoke_callables.py` (+212/-23) — 2 helpers + `_invoke_governance` rewired
- `tests/unit/argumentation_analysis/orchestration/test_governance_ge4_1462.py` (new, 7 tests)
- `tests/unit/argumentation_analysis/orchestration/test_auto_evaluate_governance.py` (+19/-12) — adapted `#294` test to the new contract

Refs #1462
