### PR TITLE
fix(debate): honest debate_quality resolution, no 0/5 theater (GE-5 #1467)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -1388,6 +1388,40 @@ def _evaluate_counter_arguments(
     return llm_counters
 
 
+def _resolve_debate_quality(
+    base_scores: Dict[str, Any],
+    llm_debate: Optional[Dict[str, Any]],
+) -> Tuple[Optional[float], str]:
+    """Resolve an honest debate_quality value (GE-5 #1467, anti-théâtre #1019).
+
+    Returns (value, source) where:
+        - value ∈ [0.0, 5.0] or None
+        - source ∈ {"llm", "heuristic", "unscored"}
+
+    Order of preference (most to least authoritative):
+        1. LLM-reported debate_quality ∈ [1, 5] (int or float).
+           The LLM is asked to produce an integer 1-5 score; we accept any
+           value within that range as authoritative.
+        2. Plugin heuristic `persuasiveness` ∈ [0, 1] (always computed by
+           DebatePlugin.analyze_argument_quality). Multiplied by 5 to map
+           into the same scale. Honest about its origin.
+        3. None (unscored). The downstream trace must display "—/5", never "0/5".
+
+    Anti-théâtre rationale: returning 0 here is a lie — it implies the
+    debate ran and the score is genuinely 0, when in fact no measurement
+    was taken. Distinguishing "LLM scored 1/5" from "no score available"
+    matters for the corpus_A "qualité 0/5" diagnostic.
+    """
+    if isinstance(llm_debate, dict):
+        raw_q = llm_debate.get("debate_quality")
+        if isinstance(raw_q, (int, float)) and 1 <= raw_q <= 5:
+            return float(raw_q), "llm"
+    persu = base_scores.get("persuasiveness")
+    if isinstance(persu, (int, float)) and 0.0 <= float(persu) <= 1.0:
+        return float(persu) * 5.0, "heuristic"
+    return None, "unscored"
+
+
 async def _invoke_debate_analysis(
     input_text: str, context: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -1397,6 +1431,32 @@ async def _invoke_debate_analysis(
     plugin = DebatePlugin()  # type: ignore[no-untyped-call]
     scores_json = plugin.analyze_argument_quality(input_text)
     base_scores = json.loads(scores_json)
+
+    # GE-5 #1467 — honest degraded branch: if upstream extraction yielded no
+    # arguments, there is nothing to debate. Mirror the SetAF corpus-A/C
+    # honest-degraded pattern (anti-théâtre #1019, no fabricated debate).
+    extract_output = context.get("phase_extract_output", {}) or {}
+    raw_arguments = (
+        extract_output.get("arguments", []) if isinstance(extract_output, dict) else []
+    )
+    if not raw_arguments:
+        base_scores["debate_degraded"] = True
+        base_scores["debate_degraded_reason"] = "no_arguments_upstream"
+        base_scores["debate_quality"] = None
+        base_scores["debate_quality_source"] = "unscored"
+        _state = context.get("_state_object")
+        if _state is not None:
+            _state.add_trace_entry(
+                phase="debate",
+                agent="DebateAgent",
+                reacts_to=["counter", "quality", "jtms"],
+                summary=(
+                    "Débat NON TENU — aucun argument extrait en amont "
+                    "(degraded=True, raison=no_arguments_upstream). "
+                    "Pas de verdict fabriqué."
+                ),
+            )
+        return base_scores  # type: ignore[no-any-return]
 
     # Enrich with LLM-based adversarial debate assessment
     try:
@@ -1561,19 +1621,41 @@ async def _invoke_debate_analysis(
     except Exception as e:
         logger.warning(f"LLM debate assessment failed: {e}")
 
+    # GE-5 #1467 — resolve debate_quality HONESTLY. The previous contract
+    # returned 0/5 whenever the LLM path failed (rate-limit, JSON parse, missing
+    # field) — that is THEATER (no real measurement, but reported as 0/5).
+    # New contract:
+    #   - LLM said it  → use it (source="llm")
+    #   - LLM absent/failed but plugin heuristic ran  → derive from
+    #     base_scores["persuasiveness"] (∈ [0,1]) × 5 (source="heuristic")
+    #   - nothing usable → None (source="unscored")
+    # Stored as `debate_quality` (rounded int in [0,5] or None) +
+    # `debate_quality_source` (string). Anti-théâtre: never silently 0.
+    _quality_value, _quality_source = _resolve_debate_quality(
+        base_scores, base_scores.get("llm_debate_assessment")
+    )
+    base_scores["debate_quality"] = _quality_value
+    base_scores["debate_quality_source"] = _quality_source
+
     # Trace entry for debate analysis specialist
     _state = context.get("_state_object")
     if _state is not None and base_scores:
         _winner = base_scores.get("winner", "indéterminé")
-        _quality = base_scores.get("debate_quality", 0)
-        _completed = (
-            "oui" if base_scores.get("llm_debate_assessment") else "heuristique"
+        # GE-5 #1467 — honest rendering: None displayed as "—/5", not "0/5".
+        _quality_str = (
+            f"{int(round(_quality_value))}/5"
+            if isinstance(_quality_value, (int, float))
+            else "—/5"
         )
         _state.add_trace_entry(
             phase="debate",
             agent="DebateAgent",
             reacts_to=["counter", "quality", "jtms"],
-            summary=f"Débat complété ({_completed}) — vainqueur: {_winner}, qualité: {_quality}/5. Évaluation adversariale multi-agent.",
+            summary=(
+                f"Débat complété (source={_quality_source}) — "
+                f"vainqueur: {_winner}, qualité: {_quality_str}. "
+                f"Évaluation adversariale multi-agent."
+            ),
         )
     return base_scores  # type: ignore[no-any-return]
 
@@ -1605,8 +1687,12 @@ def _derive_governance_profile(
         else {}
     )
     if not isinstance(per_arg, dict) or len(per_arg) < 2:
-        return [], [], [], False, (
-            "fewer than 2 evaluated arguments — no collective choice possible"
+        return (
+            [],
+            [],
+            [],
+            False,
+            ("fewer than 2 evaluated arguments — no collective choice possible"),
         )
 
     options = sorted(per_arg.keys())
@@ -1623,8 +1709,12 @@ def _derive_governance_profile(
                 virtue_to_scores.setdefault(virtue, []).append((float(score), arg_id))
 
     if not virtue_to_scores:
-        return [], [], [], False, (
-            "no per-virtue scores available — cannot derive ordered preferences"
+        return (
+            [],
+            [],
+            [],
+            False,
+            ("no per-virtue scores available — cannot derive ordered preferences"),
         )
 
     agents: List[Any] = []
@@ -1646,8 +1736,12 @@ def _derive_governance_profile(
     if not agents:
         return [], [], [], False, "no elector produced a full ordering"
 
-    return options, ballots, agents, True, (
-        f"{len(agents)} electors derived from {len(virtue_to_scores)} virtues"
+    return (
+        options,
+        ballots,
+        agents,
+        True,
+        (f"{len(agents)} electors derived from {len(virtue_to_scores)} virtues"),
     )
 
 
@@ -7625,11 +7719,7 @@ async def _invoke_multi_axis_compare(
         or sophism_compare_fn is not None
     )
     sophism_kwargs: Optional[Dict[str, Any]] = cfg.get("sophism_kwargs")
-    if (
-        wants_sophism
-        and sophism_candidates is None
-        and sophism_compare_fn is None
-    ):
+    if wants_sophism and sophism_candidates is None and sophism_compare_fn is None:
         from argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator import (
             llm_neural_detect_async,
         )

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -597,6 +597,7 @@ class TestRealInvocationViaUnifiedAnalysis:
 class TestStateViaRunUnifiedAnalysis:
     """Real-invocation tests: call run_unified_analysis end-to-end (CI tally
     run 28582260688: ~68s). Marked `slow` for the per-push gate (#1336, R535)."""
+
     @pytest.mark.asyncio
     async def test_state_returned_by_default(self):
         """run_unified_analysis returns unified_state and state_snapshot by default."""
@@ -713,6 +714,125 @@ class TestInvokeCallables:
             result = await _invoke_debate_analysis("Some debate text", {})
         assert result["score"] == 7
         assert result["winner"] == "pro"
+
+    async def test_invoke_debate_analysis_no_args_upstream_is_degraded_1467(self):
+        """GE-5 #1467: if upstream extraction yielded no arguments, debate is
+        honestly degraded — NO debate_quality is fabricated, the call short-
+        circuits BEFORE any LLM call.
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_debate_analysis,
+        )
+
+        mock_plugin = MagicMock()
+        mock_plugin.analyze_argument_quality.return_value = (
+            '{"persuasiveness": 0.7, "logical_coherence": 0.6}'
+        )
+        with patch(
+            "argumentation_analysis.agents.core.debate.debate_agent.DebatePlugin",
+            return_value=mock_plugin,
+        ):
+            # No phase_extract_output → empty arguments upstream → degraded.
+            result = await _invoke_debate_analysis(
+                "Topic", {"phase_extract_output": {"arguments": []}}
+            )
+        assert result["debate_degraded"] is True
+        assert result["debate_degraded_reason"] == "no_arguments_upstream"
+        # Crucial anti-théâtre invariant: debate_quality is None, NOT 0,
+        # and the source is "unscored" (no measurement was taken).
+        assert result["debate_quality"] is None
+        assert result["debate_quality_source"] == "unscored"
+
+    async def test_invoke_debate_analysis_llm_quality_is_honored_1467(self):
+        """GE-5 #1467: when the LLM path returns a valid debate_quality ∈ [1,5],
+        that value is hoisted into base_scores (source=llm). The previous bug
+        dropped the field entirely, defaulting to 0/5 (THEATER).
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_debate_analysis,
+        )
+
+        mock_plugin = MagicMock()
+        mock_plugin.analyze_argument_quality.return_value = (
+            '{"persuasiveness": 0.7, "logical_coherence": 0.6}'
+        )
+
+        class _Msg:
+            content = (
+                '{"winner": "Agent B", "debate_quality": 3, '
+                '"key_exchanges": [], "new_insights": [], "reasoning": "ok"}'
+            )
+
+        class _Choice:
+            message = _Msg()
+
+        class _Resp:
+            choices = [_Choice()]
+
+        class _Completions:
+            async def create(self, *args, **kwargs):
+                return _Resp()
+
+        class _Chat:
+            completions = _Completions()
+
+        class _Client:
+            chat = _Chat()
+
+        from argumentation_analysis.orchestration import invoke_callables as ic
+
+        with patch(
+            "argumentation_analysis.agents.core.debate.debate_agent.DebatePlugin",
+            return_value=mock_plugin,
+        ), patch.object(ic, "_get_openai_client", return_value=(_Client(), "fake")):
+            result = await _invoke_debate_analysis(
+                "Topic", {"phase_extract_output": {"arguments": ["A1"]}}
+            )
+        # LLM-reported value (3) wins over the heuristic (0.7*5=3.5 → round 4).
+        assert result["debate_quality"] == 3.0
+        assert result["debate_quality_source"] == "llm"
+        assert result["winner"] == "Agent B"
+
+    async def test_invoke_debate_analysis_llm_fail_falls_back_to_heuristic_1467(self):
+        """GE-5 #1467: when the LLM path fails (exception), the trace MUST
+        show a genuine measurement from the plugin heuristic, NOT 0/5.
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_debate_analysis,
+        )
+
+        mock_plugin = MagicMock()
+        mock_plugin.analyze_argument_quality.return_value = (
+            '{"persuasiveness": 0.6, "logical_coherence": 0.5, '
+            '"evidence_quality": 0.4, "relevance_score": 0.7, '
+            '"emotional_appeal": 0.2, "fact_check_score": 0.5, '
+            '"novelty_score": 0.6, "readability_score": 0.8}'
+        )
+
+        class _Completions:
+            async def create(self, *args, **kwargs):
+                raise RuntimeError("LLM call failed (401 unauthorized)")
+
+        class _Chat:
+            completions = _Completions()
+
+        class _Client:
+            chat = _Chat()
+
+        from argumentation_analysis.orchestration import invoke_callables as ic
+
+        with patch(
+            "argumentation_analysis.agents.core.debate.debate_agent.DebatePlugin",
+            return_value=mock_plugin,
+        ), patch.object(ic, "_get_openai_client", return_value=(_Client(), "fake")):
+            result = await _invoke_debate_analysis(
+                "Topic", {"phase_extract_output": {"arguments": ["A1"]}}
+            )
+        # Heuristic derivation: 0.6 * 5 = 3.0. NOT 0 (that was the old bug).
+        assert result["debate_quality"] == 3.0
+        assert result["debate_quality_source"] == "heuristic"
+        # Anti-théâtre: no LLM assessment in result (it failed).
+        assert "llm_debate_assessment" not in result
 
     async def test_invoke_governance(self):
         """_invoke_governance calls GovernancePlugin and returns enriched result."""


### PR DESCRIPTION
## Constat (probe GE-5 #1467, firsthand)

Sur corpus_A, le run ATT-3 a rapporté `qualité: 0/5` pour la phase débat. Hypothèse ATT-3: « soit transcript mince, soit scoring cassé ». Ma probe révèle que **c'est le scoring qui était cassé** — le plugin heuristique (persuasiveness) tournait toujours mais n'était jamais hoisté dans base_scores, et le trace tombait sur `.get('debate_quality', 0)`. Théâtre: un score plancher SANS diagnostic.

## Probe matrix (firsthand, 4 cas)

| Cas | Avant (THEATER) | Après (honnête) |
|-----|-----------------|-----------------|
| LLM full JSON | `qualité: 0/5` | `qualité: 3/5` source=llm |
| LLM missing field | `qualité: 0/5` | `qualité: 3/5` source=heuristic |
| LLM FAIL (401/rate-limit) | `qualité: 0/5` heuristique | `qualité: 3/5` source=heuristic |
| LLM bad JSON | `qualité: 0/5` heuristique | `qualité: 3/5` source=heuristic |

Plus aucun `0/5` trompeur. Le débat plugin tourne toujours, le score est **vraiment** ~3/5 sur corpus_A (pas mince du tout).

## Fix (anti-théâtre #1019)

1. **Helper `_resolve_debate_quality(base_scores, llm_debate)`** :
   - LLM `debate_quality` ∈ [1,5] → use as-is (source=llm)
   - sinon plugin `persuasiveness` × 5 (source=heuristic) — exploite enfin l'info gaspillée
   - sinon None (source=unscored) — JAMAIS 0
2. **Hoist** `llm_debate_assessment['debate_quality']` dans `base_scores` (le bug architectural : L1558-1560 n'insérait QUE winner, pas debate_quality).
3. **Trace** affiche `None → '—/5'` (plus jamais `0/5` mensonger), avec le **source** explicite (`source=llm` / `source=heuristic` / `source=unscored`).
4. **Nouveau honest-degraded branch** : si `phase_extract_output.arguments` vide → short-circuit AVANT tout LLM call avec `debate_degraded=True` + raison = `no_arguments_upstream`. Mirror du pattern SetAF corpus-A/C.

## Diagnostic impact sur #1448

Le constat ATT-3 « débat qualité 0/5 sur corpus_A » se précisait en « soit transcript mince, soit scoring cassé ». Avec ce fix, **l'atténuation sur corpus_A est confirmée honnête-décidée** (~3/5 heuristic). Le débat plugin tourne et décide sur corpus_A — pas un 0 factice, pas un miracle LLM non-déterministe non plus. Les futurs runs maintiendront la trace `source=heuristic` si l'LLM échoue, ce qui distingue un débat LLM-rated d'un débat heuristique-rated.

## Tests

3 nouveaux dans `tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py` :
- `test_invoke_debate_analysis_no_args_upstream_is_degraded_1467` : vide arguments → degraded=True, debate_quality=None, source=unscored.
- `test_invoke_debate_analysis_llm_quality_is_honored_1467` : LLM retourne {debate_quality: 3} → hoisté source=llm.
- `test_invoke_debate_analysis_llm_fail_falls_back_to_heuristic_1467` : LLM raise → persuasiveness × 5 = source=heuristic, PAS 0.

Plus test existant `test_invoke_debate_analysis` toujours valide (mock contours le helper via son propre contrat).

**Validation** : 4/4 tests debate (164/164 orchestration). mypy --strict 0 err. black propre.

Refs #1467 #1448.
