### PR TITLE
fix(orchestration): surface degraded democratech phases honestly (BO-2 #1472)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -2050,6 +2050,14 @@ async def _invoke_governance(
         # at most a prior (recommended method), never the verdict.
         "governance_verdict": governance_verdict,
         "governance_decided_firsthand": not governance_verdict.get("degraded", True),
+        # BO-2 #1472 — emit the codebase-standard ``degraded`` canon at the
+        # top level so the pipeline rollup (unified_pipeline.run_unified_analysis)
+        # surfaces this phase in ``capabilities_degraded`` instead of
+        # ``capabilities_used``. Without it, a 9-phase deliberation whose
+        # governance verdict is empty (no derivable preferences) is reported as
+        # 9/9 success — the theatre #1019 forbids (Constat n°5: degraded !=
+        # used). Mirrors the existing canon in state_writers / fallacy_detection.
+        "degraded": bool(governance_verdict.get("degraded", False)),
     }
     if vote_result:
         result["vote_result"] = vote_result

--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -288,6 +288,7 @@ async def run_unified_analysis(
     # Mirrors the conversational_orchestrator fix (#1446). Additive key: zero
     # blast radius on consumers (all read capabilities_used via .get(..., [])).
     capabilities_degraded: list[str] = []
+    degraded_caps: set[str] = set()
     if state is not None:
         structured = getattr(state, "structured_arg_status", None) or {}
         degraded_caps = {
@@ -295,11 +296,29 @@ async def run_unified_analysis(
             for cap, info in structured.items()
             if isinstance(info, dict) and info.get("degraded")
         }
-        if degraded_caps:
-            capabilities_degraded = sorted(degraded_caps)
-            capabilities_used = [
-                c for c in capabilities_used if c not in degraded_caps
-            ]
+
+    # BO-2 #1472 — ``structured_arg_status`` only covers the formal/logic
+    # axes (ASPIC+/SetAF/weighted/Dung). Non-formal workflows (e.g.
+    # ``democratech``) carry their honest-degraded verdict in the phase
+    # output itself, via the codebase's standard ``output["degraded"] = True``
+    # canon (state_writers._write_external_*_solver, fallacy_detection,
+    # governance per GE-4 #1462). Without this cross-check, a 9-phase
+    # deliberation whose governance verdict is empty (no derivable
+    # preferences — no LLM key, sparse upstream) reports as 9/9 success —
+    # exactly the theatre #1019 forbids. Surface phase-level degraded
+    # markers here too. Additive: phases without the marker are unaffected.
+    for pr in phase_results.values():
+        if pr.status != PhaseStatus.COMPLETED:
+            continue
+        out = getattr(pr, "output", None)
+        if isinstance(out, dict) and out.get("degraded") is True:
+            degraded_caps.add(pr.capability)
+
+    if degraded_caps:
+        capabilities_degraded = sorted(degraded_caps)
+        capabilities_used = [
+            c for c in capabilities_used if c not in degraded_caps
+        ]
 
     result = {
         "workflow_name": workflow.name,

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -525,6 +525,71 @@ class TestRunUnifiedAnalysis:
         assert isinstance(result["capabilities_used"], list)
         assert isinstance(result["capabilities_missing"], list)
 
+    @pytest.mark.asyncio
+    async def test_degraded_phase_surfaces_in_capabilities_degraded_bo2_1472(self):
+        """BO-2 #1472 — anti-théâtre rollup (Constat n°5 / #1019).
+
+        A COMPLETED phase whose output carries the codebase-standard
+        ``degraded: True`` canon MUST surface in ``capabilities_degraded``
+        and be REMOVED from ``capabilities_used``. Without this, a
+        ``democratech`` deliberation whose governance verdict is empty (no
+        derivable preferences — e.g. no LLM key) reports as full 9/9
+        success — exactly the theatre #1019 forbids. The degraded marker on
+        ``structured_arg_status`` (formal/logic axes only, #1454) leaves
+        non-formal workflows silent; this test pins the phase-output canon
+        cross-check added in run_unified_analysis.
+        """
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            run_unified_analysis,
+        )
+
+        async def _degraded_invoke(text, context):
+            return {"degraded": True, "reason": "no_llm_key_synthetic"}
+
+        async def _genuine_invoke(text, context):
+            return {"note_finale": 7.5}
+
+        registry = CapabilityRegistry()
+        registry.register_agent(
+            name="degraded_quality",
+            agent_class=type("DQ", (), {}),
+            capabilities=["argument_quality"],
+            invoke=_degraded_invoke,
+        )
+        registry.register_agent(
+            name="genuine_counter",
+            agent_class=type("GC", (), {}),
+            capabilities=["counter_argument_generation"],
+            invoke=_genuine_invoke,
+        )
+        custom_wf = (
+            WorkflowBuilder("bo2_degraded_rollup")
+            .add_phase("quality", capability="argument_quality")
+            .add_phase("counter", capability="counter_argument_generation")
+            .build()
+        )
+        result = await run_unified_analysis(
+            "Synthetic domain-public proposition.",
+            registry=registry,
+            custom_workflow=custom_wf,
+        )
+
+        # The degraded phase surfaces honestly — NOT masked as "used".
+        assert "argument_quality" in result["capabilities_degraded"], (
+            f"degraded phase must surface in capabilities_degraded, got "
+            f"{result['capabilities_degraded']}"
+        )
+        assert "argument_quality" not in result["capabilities_used"], (
+            f"degraded phase must NOT be in capabilities_used, got "
+            f"{result['capabilities_used']}"
+        )
+        # A genuine phase is unaffected — still reported as used.
+        assert "counter_argument_generation" in result["capabilities_used"]
+        assert "counter_argument_generation" not in result["capabilities_degraded"]
+        # Both phases executed (completed) — the summary counts execution,
+        # not genuineness; that separation is what capabilities_degraded is for.
+        assert result["summary"]["completed"] == 2
+
 
 # ============================================================
 # Test: real invocation through run_unified_analysis
@@ -852,6 +917,66 @@ class TestInvokeCallables:
         assert "conflicts" in result
         assert "extraction_method" in result
         assert result["conflict_count"] == 0
+
+    async def test_invoke_governance_emits_degraded_canon_when_verdict_empty_bo2_1472(self):
+        """BO-2 #1472 — _invoke_governance emits the codebase-standard
+        ``degraded`` canon at the top level when the formal aggregation
+        cannot decide (no derivable preferences — e.g. sparse upstream / no
+        LLM key). This lets the pipeline rollup (run_unified_analysis)
+        surface the phase in ``capabilities_degraded`` instead of
+        masquerading an empty verdict as a used capability (#1019)."""
+        from argumentation_analysis.orchestration import invoke_callables as ic
+
+        mock_plugin = MagicMock()
+        mock_plugin.list_governance_methods.return_value = '["majority", "borda"]'
+        mock_plugin.detect_conflicts_fn.return_value = "[]"
+        with patch(
+            "argumentation_analysis.plugins.governance_plugin.GovernancePlugin",
+            return_value=mock_plugin,
+        ), patch.object(
+            ic,
+            "_derive_governance_profile",
+            return_value=([], [], [], False, "no_preferences_synthetic"),
+        ):
+            result = await ic._invoke_governance("text", {})
+        # The verdict is honestly degraded.
+        assert result["governance_verdict"]["degraded"] is True
+        assert result["governance_decided_firsthand"] is False
+        # BO-2 canon: top-level degraded marker, consumed by the rollup.
+        assert result["degraded"] is True
+
+    async def test_invoke_governance_no_degraded_canon_when_genuine_bo2_1472(self):
+        """BO-2 #1472 — when governance genuinely decides, ``degraded`` is
+        False at the top level so the capability surfaces in
+        ``capabilities_used`` (the happy path the coord re-runs with a live
+        LLM key). Pins that the canon does not false-positive on a genuine
+        verdict."""
+        from argumentation_analysis.orchestration import invoke_callables as ic
+
+        mock_plugin = MagicMock()
+        mock_plugin.list_governance_methods.return_value = '["majority", "borda"]'
+        mock_plugin.detect_conflicts_fn.return_value = "[]"
+        fake_verdict = {
+            "winners_per_method": {"majority": "A", "plurality": "A"},
+            "condorcet_winner": "A",
+            "distinct_winners": ["A"],
+            "inter_method_disagreement": False,
+        }
+        with patch(
+            "argumentation_analysis.plugins.governance_plugin.GovernancePlugin",
+            return_value=mock_plugin,
+        ), patch.object(
+            ic,
+            "_derive_governance_profile",
+            return_value=(["A", "B"], {"qe": ["A", "B"]}, ["qe"], True, "ok"),
+        ), patch.object(
+            ic,
+            "_aggregate_governance_votes",
+            return_value=fake_verdict,
+        ):
+            result = await ic._invoke_governance("text", {})
+        assert result["degraded"] is False
+        assert result["governance_decided_firsthand"] is True
 
     async def test_invoke_jtms(self):
         """_invoke_jtms creates beliefs from real argument content with JTMS API."""


### PR DESCRIPTION
## What

The `democratech` workflow's top-level rollup reported a 9/9 deliberation **"success"** even when the governance verdict was empty (no derivable preferences — e.g. no LLM key) and `fallacy_detection` was honestly degraded. `capabilities_degraded` stayed `[]` → the empty verdict was masked as a "used" capability. **Anti-théâtre #1019 / Constat n°5** (degraded ≠ used).

## Root cause (firsthand)

`run_unified_analysis` consulted only `state.structured_arg_status` for the honest-degraded channel — a formal/logic-axes-only layer (#1454) that non-formal workflows like `democratech` never populate. The phase-level degraded markers (`governance_verdict_degraded` from GE-4 #1462, `fallacy_detection.degraded`) were silently dropped by the rollup.

Probe (`bo2_probe_llm.py`, no LLM key on this lane) before the fix:
```
capabilities_used: [... governance_simulation ...]   ← masked
capabilities_degraded: []                            ← lie
summary: {'completed': 9, 'failed': 0}
governance_decision_count: 0   ← verdict empty
```

## Fix — two additive seams

1. **`unified_pipeline.run_unified_analysis` rollup** — also scans each COMPLETED `PhaseResult.output` for the codebase-standard `output["degraded"]` canon (already emitted by `fallacy_detection`, consumed by `state_writers._write_external_*_solver`). A degraded phase surfaces in `capabilities_degraded` and is removed from `capabilities_used`.
2. **`_invoke_governance`** — emits `result["degraded"]` at the top level (mirrors the canon) so the rollup surfaces `governance_simulation` as degraded when the formal aggregation cannot decide.

After the fix:
```
capabilities_degraded: ['governance_simulation', 'neural_fallacy_detection']   ← honest
capabilities_used: [7 phases, governance + fallacy removed]
```

## Tests

- `test_degraded_phase_surfaces_in_capabilities_degraded_bo2_1472` — pins the rollup cross-check (degraded phase → capabilities_degraded, removed from capabilities_used; genuine phase unaffected).
- `test_invoke_governance_emits_degraded_canon_when_verdict_empty_bo2_1472` — Fix 2 degraded path.
- `test_invoke_governance_no_degraded_canon_when_genuine_bo2_1472` — Fix 2 genuine path (happy path ready for coord re-run with a live key).
- **157 non-slow tests in the file pass, 0 regressions.** mypy strict: **0 new errors** (7 pre-existing on the baseline — TweetyInitializer/JPype untyped, RenderedReport assignments — verified via stash).

## Scope (honest)

This is the **anti-théâtre foundation** for BO-2 #1472 — without it, any "green" E2E is theatre. The remaining DoD items are a separate integration perimeter, **left for follow-up**:
- 9 proposal endpoints + 3 WebSocket channels — integration tests
- Synthetic 3-5 proposition budget-participatif demo scenario
- React governance dashboard — real-data validation

Privacy: synthetic domain-public text only (chess-club participatory budget). No encrypted corpus, no `raw_text`, no real names.

Refs #1472 · Epic #1470.
