### PR TITLE
fix(democratech): governance decides E2E firsthand — extract phase + cable fix (BO-2 #1472 cont.)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -1826,6 +1826,27 @@ def _aggregate_governance_votes(
     }
 
 
+def _resolve_phase_output(context: Dict[str, Any], *keys: str) -> Dict[str, Any]:
+    """Resolve a phase output dict by trying multiple context keys in order.
+
+    Different workflows name the same logical phase differently — e.g. the
+    ``democratech`` workflow names its quality phase ``quality_baseline`` and
+    its debate phase ``adversarial_debate``, while the canonical context keys
+    most callables read are ``phase_quality_output`` / ``phase_debate_output``.
+    Without this fallback, a workflow whose phase names don't match the
+    canonical keys feeds governance an empty upstream → the verdict is
+    *always* degraded (BO-2 #1472: ``democratech`` reported an empty
+    governance verdict even with a live LLM key, because governance read
+    ``phase_quality_output`` while the populated key was
+    ``phase_quality_baseline_output``). Returns the first non-empty dict.
+    """
+    for key in keys:
+        value = context.get(key)
+        if isinstance(value, dict) and value:
+            return value
+    return {}
+
+
 async def _invoke_governance(
     input_text: str, context: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -1836,13 +1857,33 @@ async def _invoke_governance(
     methods_json = plugin.list_governance_methods()
     available_methods = json.loads(methods_json)
 
-    # (#289) Build positions from upstream phases (extract, debate, counter, quality, fallacy, jtms)
-    extract_output = context.get("phase_extract_output", {})
-    debate_output = context.get("phase_debate_output", {})
-    counter_output = context.get("phase_counter_output", {})
-    quality_output = context.get("phase_quality_output", {})
-    fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
-    jtms_output = context.get("phase_jtms_output", {})
+    # (#289) Build positions from upstream phases (extract, debate, counter,
+    # quality, fallacy, jtms). BO-2 #1472: resolve via canonical key first,
+    # then the democratech phase-name variants — otherwise a workflow whose
+    # phase names differ from the canonical keys (democratech: quality_baseline,
+    # adversarial_debate, counter_arguments, fallacy_detection, belief_tracking)
+    # feeds governance an empty upstream and the verdict is always degraded.
+    extract_output = _resolve_phase_output(context, "phase_extract_output")
+    debate_output = _resolve_phase_output(
+        context, "phase_debate_output", "phase_adversarial_debate_output"
+    )
+    counter_output = _resolve_phase_output(
+        context, "phase_counter_output", "phase_counter_arguments_output"
+    )
+    quality_output = _resolve_phase_output(
+        context,
+        "phase_quality_output",
+        "phase_quality_baseline_output",
+        "phase_quality_recheck_output",
+    )
+    fallacy_output = _resolve_phase_output(
+        context,
+        "phase_hierarchical_fallacy_output",
+        "phase_fallacy_detection_output",
+    )
+    jtms_output = _resolve_phase_output(
+        context, "phase_jtms_output", "phase_belief_tracking_output"
+    )
 
     arguments = extract_output.get("arguments", [])
     claims = extract_output.get("claims", [])

--- a/argumentation_analysis/workflows/democratech.py
+++ b/argumentation_analysis/workflows/democratech.py
@@ -1,19 +1,23 @@
 """
 Democratech workflow: democratic deliberation pipeline.
 
-A 9-phase pipeline that takes a proposition and subjects it to multi-agent
+A 10-phase pipeline that takes a proposition and subjects it to multi-agent
 argumentative analysis, producing a democratic decision with full audit trail.
 
 Phases:
-1. transcription          — Speech-to-text (optional, if audio input)
-2. quality_baseline       — 9-virtue argument quality evaluation
-3. fallacy_detection      — Neural fallacy detection (optional)
-4. counter_arguments      — Generate counter-arguments (5 strategies)
-5. adversarial_debate     — Multi-agent debate simulation
-6. belief_tracking        — JTMS belief maintenance (optional)
-7. democratic_vote        — Multi-method governance voting
-8. indexing               — Semantic indexing for future retrieval (optional)
-9. quality_recheck        — Re-evaluate quality if consensus is low (conditional)
+1. extract               — Argument extraction (the material the deliberation
+                           reasons about; without it the downstream quality →
+                           governance chain is starved and governance can never
+                           render a genuine verdict — BO-2 #1472)
+2. transcription          — Speech-to-text (optional, if audio input)
+3. quality_baseline       — 9-virtue argument quality evaluation (per-argument)
+4. fallacy_detection      — Neural fallacy detection (optional)
+5. counter_arguments      — Generate counter-arguments (5 strategies)
+6. adversarial_debate     — Multi-agent debate simulation
+7. belief_tracking        — JTMS belief maintenance (optional)
+8. democratic_vote        — Multi-method governance voting (12 methods)
+9. indexing               — Semantic indexing for future retrieval (optional)
+10. quality_recheck       — Re-evaluate quality if consensus is low (conditional)
 """
 
 import logging
@@ -54,7 +58,7 @@ def build_democratech_workflow(
             quality recheck phase. Below this, quality is reassessed.
 
     Returns:
-        A 9-phase WorkflowDefinition composing the full analysis stack.
+        A 10-phase WorkflowDefinition composing the full analysis stack.
     """
 
     def recheck_condition(ctx: Dict[str, Any]) -> bool:
@@ -62,57 +66,68 @@ def build_democratech_workflow(
 
     return (
         WorkflowBuilder("democratech")
-        # Phase 1: Optional transcription
+        # Phase 1: Argument extraction (BO-2 #1472) — the material the
+        # deliberation reasons about. Without this, quality scores only the
+        # raw text as a single argument and governance can never aggregate a
+        # collective choice (<2 options) → permanent degraded verdict = the
+        # theatre #1019 forbids. Mirrors the extract→quality wiring in the
+        # light/standard workflows.
+        .add_phase(
+            "extract",
+            capability="fact_extraction",
+        )
+        # Phase 2: Optional transcription
         .add_phase(
             "transcription",
             capability="speech_transcription",
             optional=True,
         )
-        # Phase 2: Quality baseline (required)
+        # Phase 3: Quality baseline (required, per-argument via extract)
         .add_phase(
             "quality_baseline",
             capability="argument_quality",
+            depends_on=["extract"],
         )
-        # Phase 3: Optional fallacy detection
+        # Phase 4: Optional fallacy detection
         .add_phase(
             "fallacy_detection",
             capability="neural_fallacy_detection",
             optional=True,
             depends_on=["quality_baseline"],
         )
-        # Phase 4: Generate counter-arguments
+        # Phase 5: Generate counter-arguments
         .add_phase(
             "counter_arguments",
             capability="counter_argument_generation",
             depends_on=["quality_baseline"],
         )
-        # Phase 5: Adversarial debate
+        # Phase 6: Adversarial debate
         .add_phase(
             "adversarial_debate",
             capability="adversarial_debate",
             depends_on=["counter_arguments"],
         )
-        # Phase 6: Optional belief tracking
+        # Phase 7: Optional belief tracking
         .add_phase(
             "belief_tracking",
             capability="belief_maintenance",
             optional=True,
             depends_on=["adversarial_debate"],
         )
-        # Phase 7: Democratic vote
+        # Phase 8: Democratic vote
         .add_phase(
             "democratic_vote",
             capability="governance_simulation",
             depends_on=["adversarial_debate"],
         )
-        # Phase 8: Optional semantic indexing
+        # Phase 9: Optional semantic indexing
         .add_phase(
             "indexing",
             capability="semantic_indexing",
             optional=True,
             depends_on=["democratic_vote"],
         )
-        # Phase 9: Conditional quality recheck
+        # Phase 10: Conditional quality recheck
         .add_phase(
             "quality_recheck",
             capability="argument_quality",

--- a/tests/unit/argumentation_analysis/workflows/test_democratech.py
+++ b/tests/unit/argumentation_analysis/workflows/test_democratech.py
@@ -32,11 +32,14 @@ class TestBuildDemocratechWorkflow:
 
     def test_phase_count(self):
         wf = build_democratech_workflow()
-        assert len(wf.phases) == 9
+        # BO-2 #1472: 10 phases — extract prepended so quality→governance has
+        # argument material to reason over (was 9; governance never decided).
+        assert len(wf.phases) == 10
 
     def test_required_capabilities(self):
         wf = build_democratech_workflow()
         caps = wf.get_required_capabilities()
+        assert "fact_extraction" in caps
         assert "argument_quality" in caps
         assert "counter_argument_generation" in caps
         assert "adversarial_debate" in caps
@@ -54,6 +57,7 @@ class TestBuildDemocratechWorkflow:
     def test_required_phases(self):
         wf = build_democratech_workflow()
         required_names = {p.name for p in wf.phases if not p.optional}
+        assert "extract" in required_names
         assert "quality_baseline" in required_names
         assert "counter_arguments" in required_names
         assert "adversarial_debate" in required_names
@@ -64,6 +68,8 @@ class TestBuildDemocratechWorkflow:
         order = wf.get_execution_order()
         # Flatten to a flat list
         flat = [phase for level in order for phase in level]
+        # BO-2 #1472: extract feeds quality_baseline (the material to reason over)
+        assert flat.index("extract") < flat.index("quality_baseline")
         assert flat.index("quality_baseline") < flat.index("counter_arguments")
         assert flat.index("counter_arguments") < flat.index("adversarial_debate")
         assert flat.index("adversarial_debate") < flat.index("democratic_vote")
@@ -143,6 +149,7 @@ class TestDemocratechExecution:
     @pytest.mark.asyncio
     async def test_execute_full_pipeline(self):
         registry = _make_registry(
+            "fact_extraction",
             "speech_transcription",
             "argument_quality",
             "neural_fallacy_detection",
@@ -156,6 +163,7 @@ class TestDemocratechExecution:
         executor = WorkflowExecutor(registry)
         results = await executor.execute(wf, "Test proposition")
 
+        assert results["extract"].status == PhaseStatus.COMPLETED
         assert results["quality_baseline"].status == PhaseStatus.COMPLETED
         assert results["counter_arguments"].status == PhaseStatus.COMPLETED
         assert results["adversarial_debate"].status == PhaseStatus.COMPLETED
@@ -164,6 +172,7 @@ class TestDemocratechExecution:
     @pytest.mark.asyncio
     async def test_execute_missing_optional_capabilities(self):
         registry = _make_registry(
+            "fact_extraction",
             "argument_quality",
             "counter_argument_generation",
             "adversarial_debate",
@@ -173,7 +182,8 @@ class TestDemocratechExecution:
         executor = WorkflowExecutor(registry)
         results = await executor.execute(wf, "Test proposition")
 
-        # Required phases complete
+        # Required phases complete (extract is required since BO-2 #1472)
+        assert results["extract"].status == PhaseStatus.COMPLETED
         assert results["quality_baseline"].status == PhaseStatus.COMPLETED
         assert results["democratic_vote"].status == PhaseStatus.COMPLETED
         # Optional phases skipped
@@ -185,6 +195,7 @@ class TestDemocratechExecution:
         """Low consensus triggers quality recheck."""
         low_consensus = AsyncMock(return_value={"consensus": 0.3, "method": "majority"})
         registry = _make_registry(
+            "fact_extraction",
             "counter_argument_generation",
             "adversarial_debate",
         )
@@ -217,6 +228,7 @@ class TestDemocratechExecution:
             return_value={"consensus": 0.95, "method": "condorcet"}
         )
         registry = _make_registry(
+            "fact_extraction",
             "counter_argument_generation",
             "adversarial_debate",
         )
@@ -250,6 +262,12 @@ class TestDemocratechExecution:
             return {"captured": True}
 
         registry = CapabilityRegistry()
+        registry.register(
+            "extract",
+            ComponentType.AGENT,
+            capabilities=["fact_extraction"],
+            invoke=AsyncMock(return_value={"arguments": [{"text": "an argument"}]}),
+        )
         quality_invoke = AsyncMock(return_value={"note_finale": 7.5})
         registry.register(
             "quality",
@@ -317,3 +335,107 @@ class TestRunDeliberation:
             # Verify threshold is 0.5
             ctx = {"phase_democratic_vote_output": {"consensus": 0.4}}
             assert recheck.condition(ctx) is True
+
+
+# --- Governance cabling tests (BO-2 #1472) ---
+
+
+class TestGovernanceCabling:
+    """BO-2 #1472: governance must resolve democratech's phase-name variants.
+
+    The democratech workflow names its phases ``quality_baseline`` /
+    ``adversarial_debate`` / ``counter_arguments`` / ``fallacy_detection`` /
+    ``belief_tracking``, but the canonical context keys governance historically
+    read were ``phase_quality_output`` / ``phase_debate_output`` / etc. Without
+    the multi-key fallback, governance received an empty upstream and rendered
+    a permanently-degraded verdict — the theatre #1019 forbids.
+    """
+
+    def test_resolve_phase_output_canonical_key(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _resolve_phase_output,
+        )
+
+        ctx = {"phase_quality_output": {"note_finale": 7.0}}
+        assert _resolve_phase_output(ctx, "phase_quality_output") == {"note_finale": 7.0}
+
+    def test_resolve_phase_output_democratech_fallback(self):
+        """The crux: governance finds quality under the democratech phase name."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _resolve_phase_output,
+        )
+
+        ctx = {"phase_quality_baseline_output": {"per_argument_scores": {"arg_1": {}}}}
+        out = _resolve_phase_output(
+            ctx, "phase_quality_output", "phase_quality_baseline_output"
+        )
+        assert out == {"per_argument_scores": {"arg_1": {}}}
+
+    def test_resolve_phase_output_prefers_first_non_empty(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _resolve_phase_output,
+        )
+
+        ctx = {
+            "phase_quality_output": {},  # present but empty
+            "phase_quality_baseline_output": {"note_finale": 8.0},
+        }
+        out = _resolve_phase_output(
+            ctx, "phase_quality_output", "phase_quality_baseline_output"
+        )
+        assert out == {"note_finale": 8.0}
+
+    def test_resolve_phase_output_empty_when_absent(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _resolve_phase_output,
+        )
+
+        assert _resolve_phase_output({}, "phase_quality_output") == {}
+
+    def test_resolve_phase_output_ignores_non_dict(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _resolve_phase_output,
+        )
+
+        ctx = {"phase_quality_output": "not a dict"}
+        assert _resolve_phase_output(ctx, "phase_quality_output") == {}
+
+
+@pytest.mark.requires_api
+@pytest.mark.slow
+class TestDemocratechE2EGenuineFirsthand:
+    """BO-2 #1472 DoD #1: the democratech workflow decides E2E firsthand with
+    real LLM agents (no mock), rendering a genuine governance verdict.
+
+    Runs the real workflow with a live LLM key on a synthetic multi-option
+    proposition (privacy HARD: domain-public chess-club budget). With the
+    extract phase + governance cabling fixes, governance must receive >=2
+    evaluated arguments and decide firsthand (12-method formal aggregation).
+    Marked requires_api+slow: skips without a key / on the fast CI gate.
+    """
+
+    @pytest.mark.asyncio
+    async def test_governance_decides_firsthand_on_multi_option_proposition(self):
+        from argumentation_analysis.workflows.democratech import run_deliberation
+
+        proposition = (
+            "Le club d'echecs dispose d'un budget participatif de 2000 euros. "
+            "Option A : tournoi inter-villes a 2000 euros pour la visibilite et "
+            "le recrutement de nouveaux membres. "
+            "Option B : materiel pedagogique (echiquiers, horloges, supports) car "
+            "les debutants manquent de supports. "
+            "Option C : format hybride 1000 tournoi + 1000 materiel."
+        )
+        result = await run_deliberation(proposition, consensus_threshold=0.7)
+        phases = result.get("phases", {})
+        gov = phases.get("democratic_vote")
+        assert gov is not None, "democratic_vote phase must run"
+        assert isinstance(gov.output, dict)
+        # DoD #1 crux: a genuine firsthand decision, not a degraded/empty verdict.
+        assert gov.output.get("governance_decided_firsthand") is True, (
+            f"governance must decide firsthand with a live LLM key on multi-option "
+            f"material (got verdict={gov.output.get('governance_verdict')!r})"
+        )
+        # Honnête anti-théâtre: a decided verdict is NOT marked degraded.
+        assert gov.output.get("degraded") is False
+        assert "governance_simulation" not in result.get("capabilities_degraded", [])


### PR DESCRIPTION
## What

BO-2 #1472 **continuation** — the democratech workflow now **decides E2E firsthand with real LLM agents** (DoD #1). PR #1475 was the anti-théâtre *foundation* (rollup surfaces degraded honestly); this PR fixes the two compounding bugs that made the verdict permanently degraded even with a live key.

## Root cause (firsthand, live key)

`bo2_e2e_genuine.py` probe with a live LLM key showed `governance_decided_firsthand: False`, reason `"fewer than 2 evaluated arguments"`. Two compounding bugs:

**Bug 1 — câblage.** `_invoke_governance` read `phase_quality_output` / `phase_debate_output` / `phase_counter_output` / `phase_hierarchical_fallacy_output` / `phase_jtms_output`, but democratech names its phases `quality_baseline` / `adversarial_debate` / `counter_arguments` / `fallacy_detection` / `belief_tracking`. Every upstream key mismatched → governance received an empty context → could never derive a preference profile.

**Bug 2 — missing extraction.** `_invoke_quality_evaluator` scores individual arguments from `phase_extract_output.arguments`; without an extract phase it fell back to scoring the raw text as ONE argument → even after the câblage fix, governance saw <2 options.

Both = the theatre #1019 forbids: a "deliberation" that can never decide, masked as a successful run.

## Fix — two surgical seams (additive)

**A.** `_resolve_phase_output(context, *keys)` helper — resolves a phase output by canonical key first, then democratech variants. `_invoke_governance` resolves quality/debate/counter/fallacy/jtms this way. No-op for workflows using canonical names.

**B.** Prepend an `extract` phase (`fact_extraction`) to `build_democratech_workflow`, `quality_baseline` depends on it — mirroring the light/standard wiring. Workflow is now **10 phases** (was 9; the 9-phase version was structurally broken).

## Firsthand proof (no injection, live key, synthetic 3-option chess-club budget)

```
argument_count: 10 (extract)  · quality_scores_count: 8
governance_decided_firsthand: True  · degraded: False
12 voting methods decide (Condorcet winner arg_1, unanimous, inter_method_disagreement=False)
capabilities_degraded: []  · 10/10 phases completed
```

**DoD #1 met**: the workflow decides E2E firsthand with real LLM agents, rendering a genuine governance verdict.

## Validation

- **5 unit tests** for `_resolve_phase_output` (canonical, democratech fallback, first-non-empty, empty, non-dict).
- Existing democratech tests updated for the 10-phase contract (extract required, deps, registries).
- **1 integration test** (`requires_api`+`slow`) runs the real workflow firsthand, asserts `governance_decided_firsthand=True` on a multi-option proposition — **PASSES firsthand (146s)**.
- mypy strict: **0 new errors** (1 pre-existing on `run_deliberation` signature, stash-verified). 27 democratech unit pass, 8 governance/rollup pass — **0 regressions**.

## Honest scope / collatéral

- **Out of scope (tracked):** `fallacy_workflow_plugin` one-shot fallback targets model `qwen3.5-35b-a3b` (404 on OpenAI endpoint); `neural_fallacy_detection` still produces output via another path. Config debt, separate PR.
- **Remaining BO-2 DoD (follow-up):** 9 API endpoints + 3 WebSocket integration tests, React dashboard validation.
- **Then BO-3 #1473** (replay cache determinism).

## Collision awareness

`invoke_callables.py` is shared with po-2023's BO-1 lane (PR #1476, `_invoke_hierarchical_fallacy_per_argument` ~L4444/L4791). My changes are in `_resolve_phase_output` (~L1829) + `_invoke_governance` — **disjoint functions**. Rebased on main `35dc22ec`.

Privacy: synthetic domain-public text only (chess-club participatory budget). No corpus, no `raw_text`, no real names.

Refs #1472 · Epic #1470.
