### PR TITLE
fix(orchestration): register HIERARCHICAL+DATA channels on the delegation path (BO-1 #1471 R652)

### DIFF
--- a/argumentation_analysis/core/communication/__init__.py
+++ b/argumentation_analysis/core/communication/__init__.py
@@ -19,7 +19,7 @@ from .channel_interface import (
     ChannelType,
     LocalChannel,
 )  # Ajout de LocalChannel
-from .middleware import MessageMiddleware
+from .middleware import MessageMiddleware, create_default_middleware
 from .request_response import RequestResponseProtocol
 from .pub_sub import PublishSubscribeProtocol
 from .hierarchical_channel import HierarchicalChannel
@@ -41,6 +41,7 @@ __all__ = [
     "ChannelType",
     "LocalChannel",  # Ajout de LocalChannel
     "MessageMiddleware",
+    "create_default_middleware",
     "RequestResponseProtocol",
     "PublishSubscribeProtocol",
     "HierarchicalChannel",

--- a/argumentation_analysis/core/communication/middleware.py
+++ b/argumentation_analysis/core/communication/middleware.py
@@ -16,6 +16,56 @@ from .message import Message, MessageType, MessagePriority, AgentLevel
 from .channel_interface import Channel, ChannelType, ChannelException
 
 
+def create_default_middleware(
+    config: Optional[Dict[str, Any]] = None,
+) -> "MessageMiddleware":
+    """Return a :class:`MessageMiddleware` with the standard channel set wired.
+
+    BO-1 #1471 R652 (constat firsthand coord) : the delegation path used to
+    fall back to ``results/*.json`` file-drop because the per-tier
+    ``MessageMiddleware()`` instances were created without registering any
+    channel. ``send_message`` then logged ``Channel not found: hierarchical``
+    and the bus stayed silent.
+
+    This helper centralises the wiring of the two channels the hierarchical
+    orchestration actually uses (HIERARCHICAL + DATA, mirroring
+    :class:`~argumentation_analysis.core.communication.middleware.MessageMiddleware.determine_channel`).
+    It is the single source of truth — do not duplicate ``register_channel``
+    calls at the call site (anti-pendule: a future addition of e.g. a
+    FEEDBACK channel should not require touching every manager / coordinator
+    / adapter).
+
+    Args:
+        config: Optional configuration forwarded to the middleware constructor.
+
+    Returns:
+        A ``MessageMiddleware`` instance with HIERARCHICAL and DATA channels
+        registered. Both channels are constructed with the conventional IDs
+        ``hierarchical_main`` / ``data_main`` (matching
+        ``argumentation_analysis.config.settings``).
+    """
+    middleware = MessageMiddleware(config=config)
+
+    # Imports locaux pour éviter cycles et préserver le lazy-loading existant.
+    from .hierarchical_channel import HierarchicalChannel
+    from .data_channel import DataChannel
+
+    try:
+        middleware.register_channel(HierarchicalChannel(channel_id="hierarchical_main"))
+    except Exception as exc:  # noqa: BLE001 — surface, ne pas masquer
+        logging.getLogger("MessageMiddleware").error(
+            "Failed to register HierarchicalChannel: %s", exc
+        )
+    try:
+        middleware.register_channel(DataChannel(channel_id="data_main"))
+    except Exception as exc:  # noqa: BLE001 — surface, ne pas masquer
+        logging.getLogger("MessageMiddleware").error(
+            "Failed to register DataChannel: %s", exc
+        )
+
+    return middleware
+
+
 class MessageMiddleware:
     """
     Middleware de messagerie central pour le système de communication multi-canal.

--- a/argumentation_analysis/orchestration/hierarchical/interfaces/strategic_tactical.py
+++ b/argumentation_analysis/orchestration/hierarchical/interfaces/strategic_tactical.py
@@ -24,6 +24,7 @@ from argumentation_analysis.orchestration.hierarchical.tactical.state import (
 from argumentation_analysis.paths import DATA_DIR
 from argumentation_analysis.core.communication import (
     MessageMiddleware,
+    create_default_middleware,
     StrategicAdapter,
     TacticalAdapter,
     ChannelType,
@@ -74,7 +75,7 @@ class StrategicTacticalInterface:
         self.tactical_state = tactical_state or TacticalState()
         self.logger = logging.getLogger(__name__)
 
-        self.middleware = middleware or MessageMiddleware()
+        self.middleware = middleware or create_default_middleware()
         self.strategic_adapter = StrategicAdapter(
             agent_id="strategic_interface", middleware=self.middleware
         )

--- a/argumentation_analysis/orchestration/hierarchical/interfaces/tactical_operational.py
+++ b/argumentation_analysis/orchestration/hierarchical/interfaces/tactical_operational.py
@@ -27,6 +27,7 @@ from argumentation_analysis.orchestration.hierarchical.operational.state import 
 from argumentation_analysis.paths import DATA_DIR, RESULTS_DIR
 from argumentation_analysis.core.communication import (
     MessageMiddleware,
+    create_default_middleware,
     TacticalAdapter,
     OperationalAdapter,
     ChannelType,
@@ -75,7 +76,7 @@ class TacticalOperationalInterface:
         self.operational_state = operational_state
         self.logger = logging.getLogger(__name__)
 
-        self.middleware = middleware or MessageMiddleware()
+        self.middleware = middleware or create_default_middleware()
         self.tactical_adapter = TacticalAdapter(
             agent_id="tactical_interface", middleware=self.middleware
         )

--- a/argumentation_analysis/orchestration/hierarchical/operational/agent_interface.py
+++ b/argumentation_analysis/orchestration/hierarchical/operational/agent_interface.py
@@ -17,6 +17,7 @@ from argumentation_analysis.orchestration.hierarchical.operational.state import 
 from argumentation_analysis.paths import RESULTS_DIR
 from argumentation_analysis.core.communication import (
     MessageMiddleware,
+    create_default_middleware,
     OperationalAdapter,
     Message,
     ChannelType,
@@ -55,7 +56,7 @@ class OperationalAgent(ABC):
         self.logger = logging.getLogger(f"OperationalAgent.{name}")
 
         # Initialiser le middleware de communication
-        self.middleware = middleware if middleware else MessageMiddleware()
+        self.middleware = middleware if middleware else create_default_middleware()
 
         # Créer l'adaptateur opérationnel
         self.adapter = OperationalAdapter(agent_id=name, middleware=self.middleware)

--- a/argumentation_analysis/orchestration/hierarchical/operational/manager.py
+++ b/argumentation_analysis/orchestration/hierarchical/operational/manager.py
@@ -27,7 +27,10 @@ if TYPE_CHECKING:
     from argumentation_analysis.orchestration.hierarchical.interfaces.tactical_operational import (
         TacticalOperationalInterface,
     )
-from argumentation_analysis.core.communication.middleware import MessageMiddleware
+from argumentation_analysis.core.communication.middleware import (
+    MessageMiddleware,
+    create_default_middleware,
+)
 from argumentation_analysis.core.communication.operational_adapter import (
     OperationalAdapter,
 )
@@ -106,7 +109,7 @@ class OperationalManager:
         self.result_queue = asyncio.Queue()
         self.running = False
         self.worker_task = None
-        self.middleware = middleware or MessageMiddleware()
+        self.middleware = middleware or create_default_middleware()
         self.adapter = OperationalAdapter(
             agent_id="operational_manager", middleware=self.middleware
         )

--- a/argumentation_analysis/orchestration/hierarchical/strategic/manager.py
+++ b/argumentation_analysis/orchestration/hierarchical/strategic/manager.py
@@ -23,6 +23,7 @@ from argumentation_analysis.orchestration.hierarchical.strategic.state import (
 from argumentation_analysis.paths import DATA_DIR, RESULTS_DIR
 from argumentation_analysis.core.communication import (
     MessageMiddleware,
+    create_default_middleware,
     StrategicAdapter,
     MessagePriority,
     ChannelType,
@@ -84,7 +85,7 @@ class StrategicManager:
         """
         self.state = strategic_state or StrategicState()
         self.logger = logging.getLogger(__name__)
-        self.middleware = middleware or MessageMiddleware()
+        self.middleware = middleware or create_default_middleware()
         self.adapter = StrategicAdapter(
             agent_id="strategic_manager", middleware=self.middleware
         )
@@ -272,12 +273,15 @@ class StrategicManager:
                     )
                     objectives = self._fallback_objectives()
                 else:
-                    objectives = loop.run_until_complete(self._generate_llm_objectives())
+                    objectives = loop.run_until_complete(
+                        self._generate_llm_objectives()
+                    )
             except (json.JSONDecodeError, ValueError, TypeError, RuntimeError) as e:
                 # Narrowed catch: only LLM/parse/async errors, not blanket Exception.
                 self.logger.warning(
                     "LLM objective generation failed (%s: %s), using degraded fallback",
-                    type(e).__name__, e,
+                    type(e).__name__,
+                    e,
                 )
                 objectives = self._fallback_objectives()
             except Exception as e:
@@ -285,7 +289,8 @@ class StrategicManager:
                 self.logger.error(
                     "UNEXPECTED error in LLM objective generation (%s: %s), "
                     "using degraded fallback — investigate if persistent",
-                    type(e).__name__, e,
+                    type(e).__name__,
+                    e,
                 )
                 objectives = self._fallback_objectives()
         else:
@@ -372,16 +377,23 @@ class StrategicManager:
 
         try:
             from semantic_kernel.functions import KernelArguments
-            from semantic_kernel.prompt_template import PromptTemplateConfig, InputVariable
+            from semantic_kernel.prompt_template import (
+                PromptTemplateConfig,
+                InputVariable,
+            )
 
             # Use a simple invoke on the kernel with a direct prompt
             result = await self._kernel.invoke_prompt(
                 function_name="generate_objectives",
                 plugin_name="StrategicObjectiveGenerator",
                 prompt=prompt,
-                settings=self._kernel.get_service(self._llm_service_id).get_prompt_execution_settings()
-                if hasattr(self._kernel, "get_service")
-                else None,
+                settings=(
+                    self._kernel.get_service(
+                        self._llm_service_id
+                    ).get_prompt_execution_settings()
+                    if hasattr(self._kernel, "get_service")
+                    else None
+                ),
             )
 
             response_text = str(result).strip()
@@ -412,21 +424,24 @@ class StrategicManager:
             # Parse/validation errors — expected failure modes
             self.logger.warning(
                 "LLM objective generation failed (%s: %s), using degraded fallback",
-                type(e).__name__, e,
+                type(e).__name__,
+                e,
             )
             return self._fallback_objectives()
         except (ConnectionError, TimeoutError, asyncio.TimeoutError) as e:
             # Network/timeout errors — expected failure modes
             self.logger.warning(
                 "LLM objective generation network error (%s: %s), using degraded fallback",
-                type(e).__name__, e,
+                type(e).__name__,
+                e,
             )
             return self._fallback_objectives()
         except Exception as e:
             # Unexpected errors: fail-loud at ERROR level
             self.logger.error(
                 "UNEXPECTED error in _generate_llm_objectives (%s: %s) — investigate",
-                type(e).__name__, e,
+                type(e).__name__,
+                e,
             )
             return self._fallback_objectives()
 
@@ -444,18 +459,26 @@ class StrategicManager:
                 objectives = await self._generate_llm_objectives()
                 for obj in objectives:
                     self.state.add_global_objective(obj)
-            except (json.JSONDecodeError, ValueError, TypeError,
-                    ConnectionError, TimeoutError, asyncio.TimeoutError) as e:
+            except (
+                json.JSONDecodeError,
+                ValueError,
+                TypeError,
+                ConnectionError,
+                TimeoutError,
+                asyncio.TimeoutError,
+            ) as e:
                 self.logger.warning(
                     "LLM objectives failed in async path (%s: %s), using degraded fallback",
-                    type(e).__name__, e,
+                    type(e).__name__,
+                    e,
                 )
                 for obj in self._fallback_objectives():
                     self.state.add_global_objective(obj)
             except Exception as e:
                 self.logger.error(
                     "UNEXPECTED error in async LLM objectives (%s: %s) — investigate",
-                    type(e).__name__, e,
+                    type(e).__name__,
+                    e,
                 )
                 for obj in self._fallback_objectives():
                     self.state.add_global_objective(obj)
@@ -497,11 +520,12 @@ class StrategicManager:
         if self._unified_state is None:
             return
         try:
-            from argumentation_analysis.core.strategic_bridge import sync_strategic_to_unified
-            count = sync_strategic_to_unified(self.state, self._unified_state)
-            self.logger.info(
-                "Bridged %d objectives to UnifiedAnalysisState", count
+            from argumentation_analysis.core.strategic_bridge import (
+                sync_strategic_to_unified,
             )
+
+            count = sync_strategic_to_unified(self.state, self._unified_state)
+            self.logger.info("Bridged %d objectives to UnifiedAnalysisState", count)
         except Exception as e:
             self.logger.warning("Failed to bridge to UnifiedAnalysisState: %s", e)
 

--- a/argumentation_analysis/orchestration/hierarchical/tactical/coordinator.py
+++ b/argumentation_analysis/orchestration/hierarchical/tactical/coordinator.py
@@ -11,7 +11,10 @@ from argumentation_analysis.orchestration.hierarchical.tactical.state import (
     TacticalState,
 )
 from argumentation_analysis.paths import RESULTS_DIR
-from argumentation_analysis.core.communication.middleware import MessageMiddleware
+from argumentation_analysis.core.communication.middleware import (
+    MessageMiddleware,
+    create_default_middleware,
+)
 from argumentation_analysis.core.communication.tactical_adapter import TacticalAdapter
 from argumentation_analysis.core.communication.operational_adapter import (
     OperationalAdapter,
@@ -72,7 +75,7 @@ class TaskCoordinator:
         """
         self.state = tactical_state or TacticalState()
         self.logger = logging.getLogger(__name__)
-        self.middleware = middleware or MessageMiddleware()
+        self.middleware = middleware or create_default_middleware()
         self.adapter = TacticalAdapter(
             agent_id="tactical_coordinator", middleware=self.middleware
         )

--- a/tests/orchestration/hierarchical/test_channel_registration_1471_R652.py
+++ b/tests/orchestration/hierarchical/test_channel_registration_1471_R652.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+"""
+Integration test for BO-1 #1471 continuation (R652) — the CLI entry-point
+``argumentation_analysis/run_orchestration.py`` now creates a
+``MessageMiddleware`` with the standard channel set (HIERARCHICAL + DATA)
+registered, via the new :func:`create_default_middleware` factory.
+
+Before this fix the delegation path emitted 17 ``Channel not found`` errors
+per run (16× ``hierarchical`` + 1× ``data``) and the inter-tier results
+fell back to file-drop (``results/task-obj-*.json``) instead of the live
+bus. The R644/R648/R651 chain made the chain decide E2E — but the
+plumbing was still degraded. The R652 fix wires the channels at every
+``self.middleware = middleware or MessageMiddleware()`` site under
+``orchestration/hierarchical/``.
+
+Anti-pendule guard: a single helper centralises the channel set so a
+future addition (e.g. FEEDBACK) is a one-line change — no scattered
+``register_channel`` calls to forget at any of the 6 call sites.
+
+This test invokes the **real CLI** via ``subprocess.run`` (not the
+function directly) and asserts:
+
+1. The combined stdout/stderr contains **0 occurrences** of
+   ``Channel not found`` (the dispatch's primary DoD marker).
+2. The combined output contains at least one ``Channel registered:
+   hierarchical`` and one ``Channel registered: data`` (witness that
+   the helper wired the channels upstream).
+3. The run still completes 5/5 tasks with a graded conclusion (no
+   regression on the R648/R651 contract).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CLI_SCRIPT = REPO_ROOT / "argumentation_analysis" / "run_orchestration.py"
+
+SIMPLE_TEXT = "Le soleil brille. Il fait beau."
+
+# These exact substrings come from the BO-1 #1471 R652 dispatch's DoD
+# markers. They pin the contract that ``create_default_middleware``
+# registers BOTH channels.
+HIERARCHICAL_REGISTERED_MARKER = "Channel registered: hierarchical"
+DATA_REGISTERED_MARKER = "Channel registered: data"
+CHANNEL_NOT_FOUND_MARKER = "Channel not found"
+
+
+def _run_cli(*extra_args: str) -> subprocess.CompletedProcess[str]:
+    """Invoke the real CLI entry-point and return the CompletedProcess.
+
+    ``-u`` (unbuffered) so stdout/stderr flush in order, mirroring the
+    probe captured in the dispatch acknowledgment.
+    """
+    return subprocess.run(
+        [
+            sys.executable,
+            "-u",
+            str(CLI_SCRIPT),
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(REPO_ROOT),
+    )
+
+
+class TestChannelRegistration:
+    """The R652 fix wires HIERARCHICAL + DATA channels into the
+    ``MessageMiddleware`` used by the hierarchical orchestrator, so
+    the live bus is used instead of file-drop fallback. Anti-pendule:
+    centralised in :func:`create_default_middleware` (1 source of
+    truth) — no scattered ``register_channel`` calls.
+    """
+
+    def test_cli_delegation_mode_has_no_channel_not_found(self) -> None:
+        """The dispatch's primary DoD: ``--mode hierarchical
+        --hierarchical-mode delegation`` runs end-to-end with **zero**
+        ``Channel not found`` errors in the combined log.
+
+        Before the R652 fix this run emitted 17 such errors (16×
+        ``hierarchical`` + 1× ``data``).
+        """
+        result = _run_cli(
+            "--mode",
+            "hierarchical",
+            "--hierarchical-mode",
+            "delegation",
+            "--text",
+            SIMPLE_TEXT,
+        )
+        combined = result.stdout + result.stderr
+
+        occurrences = combined.count(CHANNEL_NOT_FOUND_MARKER)
+        assert occurrences == 0, (
+            "R652 regression: 'Channel not found' still appears "
+            f"{occurrences} time(s) on the CLI delegation path. "
+            "The HIERARCHICAL+DATA channels are not registered on the "
+            "per-tier MessageMiddleware instances.\n"
+            f"--- STDOUT (tail) ---\n{result.stdout[-2000:]}\n"
+            f"--- STDERR (tail) ---\n{result.stderr[-2000:]}"
+        )
+
+    def test_cli_delegation_mode_registers_both_channels(self) -> None:
+        """Witness that the helper actually wired the channels upstream
+        (positive control on the previous assertion). Both
+        ``hierarchical`` and ``data`` must appear in ``Channel
+        registered:`` log lines.
+        """
+        result = _run_cli(
+            "--mode",
+            "hierarchical",
+            "--hierarchical-mode",
+            "delegation",
+            "--text",
+            SIMPLE_TEXT,
+        )
+        combined = result.stdout + result.stderr
+
+        assert HIERARCHICAL_REGISTERED_MARKER in combined, (
+            "R652 regression: no 'Channel registered: hierarchical' "
+            "log line. create_default_middleware() did not wire the "
+            "HierarchicalChannel upstream.\n"
+            f"--- STDOUT (tail) ---\n{result.stdout[-2000:]}\n"
+            f"--- STDERR (tail) ---\n{result.stderr[-2000:]}"
+        )
+        assert DATA_REGISTERED_MARKER in combined, (
+            "R652 regression: no 'Channel registered: data' log "
+            "line. create_default_middleware() did not wire the "
+            "DataChannel upstream.\n"
+            f"--- STDOUT (tail) ---\n{result.stdout[-2000:]}\n"
+            f"--- STDERR (tail) ---\n{result.stderr[-2000:]}"
+        )
+
+    def test_cli_delegation_mode_still_completes_e2e(self) -> None:
+        """No regression on the R648/R651 contract: 5/5 tasks complete
+        and a graded conclusion is printed. The R652 plumbing fix must
+        not regress the decision chain.
+        """
+        result = _run_cli(
+            "--mode",
+            "hierarchical",
+            "--hierarchical-mode",
+            "delegation",
+            "--text",
+            SIMPLE_TEXT,
+        )
+        combined = result.stdout + result.stderr
+
+        assert "Tâches complétées" in combined, (
+            "R652 regression: the per-axis summary is missing. The "
+            "delegation chain did not reach the conclusion phase.\n"
+            f"--- STDOUT (tail) ---\n{result.stdout[-2000:]}\n"
+            f"--- STDERR (tail) ---\n{result.stderr[-2000:]}"
+        )
+        assert "Conclu" in combined and "performance" in combined, (
+            "R652 regression: the graded conclusion is missing. The "
+            "decision phase did not render.\n"
+            f"--- STDOUT (tail) ---\n{result.stdout[-2000:]}\n"
+            f"--- STDERR (tail) ---\n{result.stderr[-2000:]}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## R652 — Fix CLI delegation: register HIERARCHICAL+DATA channels (BO-1 #1471)

**Constat firsthand coord (R652)** : après le fix R651 (câblage registry CLI), le mode delegation **DÉCIDE firsthand E2E** — mais 17 `[ERROR] Channel not found` (16× `hierarchical` + 1× `data`) persistent. Cause-racine déterrée firsthand (verify-before-assert) : **les 6 `MessageMiddleware()` instanciés sur le chemin délégation n'appellent jamais `register_channel()`**. Le routage inter-tier retombe en file-drop fallback (`results/task-obj-*.json`) au lieu du bus vivant.

### Périmètre (surgical, additif, anti-pendule strict)

1. **`argumentation_analysis/core/communication/middleware.py`** — helper factory `create_default_middleware()` qui retourne `MessageMiddleware` avec HIERARCHICAL (`hierarchical_main`) + DATA (`data_main`) enregistrés par défaut. **Single source of truth** (anti-pendule : 1 future addition de canal = 1 seule modification).
2. **`argumentation_analysis/core/communication/__init__.py`** — export public du helper.
3. **6 sites `orchestration/hierarchical/`** où `self.middleware = middleware or MessageMiddleware()` → remplacés par `create_default_middleware()` :
   - `strategic/manager.py:87`
   - `tactical/coordinator.py:75`
   - `operational/manager.py:109`
   - `operational/agent_interface.py:58`
   - `interfaces/strategic_tactical.py:77`
   - `interfaces/tactical_operational.py:78`
   Le paramètre `middleware` explicite reste respecté (helper n'est utilisé QUE si le caller n'en passe pas).
4. **`tests/orchestration/hierarchical/test_channel_registration_1471_R652.py`** (NEW, 3 tests) — invoke le vrai CLI via `subprocess.run`, assert 0 `Channel not found` + présence des `Channel registered: hierarchical/data` + non-régression R648/R651.

### Anti-pendule (rejected alternatives)

| Alternative | Pourquoi rejetée |
|-------------|------------------|
| Scattered `register_channel` à chaque site (×6) | Exactement l'anti-pattern qui a créé le défaut |
| Helper privé local à un fichier | 6 duplications, anti-pendule à nouveau |
| Étendre le fix au résidu `broadcasted to 0 agents` (subscribers) | Out of scope strict du dispatch R652 (qui vise les canaux, pas les subscribers) |

### DoD dispatch R650 R652 ✓

| Critère | Status |
|---------|--------|
| Run firsthand delegation → 0 `Channel not found` dans le log | ✅ (était 17) |
| Résultats routés via bus (pas seulement file-drop fallback) | ✅ canaux registered |
| Mode décide toujours 5/5 + conclusion (pas de régression) | ✅ |
| Test intégration assert absence `Channel not found` | ✅ 3 tests subprocess |

### Validation

- **Probe firsthand** sur branche (texte simple + complexe) : `grep -c "Channel not found" probe.log` → **0** (vs 17 avant). 5/5 tâches via vrais providers.
- `pytest tests/orchestration/hierarchical/` → **26 passed** (23 R644+R648+R651 + 3 R652), 0 failed.
- mypy --strict scope CI (8 fichiers core orchestration) → **0 issue**.
- black → **clean**.

### Résidu honnête (out of scope, escalate)

`broadcasted to 0 agents` persiste — ce n'est PAS un défaut de canal (les canaux sont registered) mais un défaut de **subscriber** : aucun adapter ne s'abonne au canal HIERARCHICAL pour recevoir la décision stratégique. C'est un **deuxième défaut distinct** qui mérite son propre dispatch coord. Anti-pendule strict : ne pas étendre le scope sans coord approval.

Refs #1471 #1470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)