### PR TITLE
fix(api): serialize deliberation results JSON-safe — genuine verdict reachable via HTTP (BO-2 #1472)

### DIFF
--- a/api/proposal_endpoints.py
+++ b/api/proposal_endpoints.py
@@ -34,6 +34,7 @@ from .proposal_service import (
     ProposalStore,
     get_proposal_store,
     run_deliberation_workflow,
+    sanitize_workflow_result,
 )
 
 logger = logging.getLogger(__name__)
@@ -275,18 +276,14 @@ async def run_custom_workflow(request: CustomWorkflowRequest):
                 context=context or None,
             )
 
-        if isinstance(result, dict):
-            return WorkflowResult(
-                workflow=request.workflow, status="completed", results=result
-            )
-        if hasattr(result, "dict"):
-            return WorkflowResult(
-                workflow=request.workflow, status="completed", results=result.dict()
-            )
+        # Coerce to a JSON-safe dict: pipeline/orchestrator results carry the
+        # live unified_state object + PhaseResult dataclasses, which break
+        # FastAPI response serialization (500, empty body). The genuine
+        # analysis payload survives; unified_state is dropped (BO-2 #1472).
         return WorkflowResult(
             workflow=request.workflow,
             status="completed",
-            results={"raw": str(result)},
+            results=sanitize_workflow_result(result),
         )
     except Exception as e:
         logger.error(f"Custom workflow failed: {e}")

--- a/api/proposal_service.py
+++ b/api/proposal_service.py
@@ -5,10 +5,12 @@ Uses an in-memory dict (no persistence) — suitable for demo/dev.
 """
 
 import asyncio
+import dataclasses
 import logging
 import uuid
-from datetime import datetime
-from typing import Dict, List, Optional
+from datetime import date, datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional, cast
 
 from .proposal_models import (
     DeliberationStatus,
@@ -21,6 +23,64 @@ from .proposal_models import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# ──── JSON sanitization for API responses ────
+
+
+def _jsonable(obj: Any, _depth: int = 0, _max_depth: int = 12) -> Any:
+    """Best-effort conversion of an arbitrary value to JSON-safe primitives.
+
+    Preserves the genuine analysis payload (nested dicts / lists / primitives —
+    e.g. ``governance_decided_firsthand``, ``governance_verdict``,
+    ``capabilities_*``, per-phase ``output``) while coercing dataclasses
+    (``PhaseResult``), pydantic models, enums and datetimes. Anything else
+    falls back to ``str()``. Depth-guarded so a stray cyclic object cannot
+    cause runaway recursion.
+    """
+    if obj is None or isinstance(obj, (str, int, float, bool)):
+        return obj
+    if _depth >= _max_depth:
+        return str(obj)
+    if isinstance(obj, Enum):
+        return obj.value
+    if isinstance(obj, (datetime, date)):
+        return obj.isoformat()
+    if isinstance(obj, dict):
+        return {str(k): _jsonable(v, _depth + 1) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple, set)):
+        return [_jsonable(v, _depth + 1) for v in obj]
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return {
+            f.name: _jsonable(getattr(obj, f.name), _depth + 1)
+            for f in dataclasses.fields(obj)
+        }
+    for attr in ("model_dump", "dict"):
+        method = getattr(obj, attr, None)
+        if callable(method):
+            try:
+                return _jsonable(method(), _depth + 1)
+            except Exception:  # noqa: BLE001 — best-effort serialization
+                pass
+    return str(obj)
+
+
+def sanitize_workflow_result(result: Any) -> Dict[str, Any]:
+    """Coerce a pipeline/orchestrator result into a JSON-serializable dict.
+
+    ``run_unified_analysis`` returns a dict carrying the live
+    ``unified_state`` object and ``phases`` as ``PhaseResult`` dataclasses —
+    neither is JSON-serializable, so returning it verbatim through a FastAPI
+    ``response_model`` (``DeliberationStatusResponse.results`` /
+    ``WorkflowResult.results``) raises at encode time and the client gets a
+    500 with an empty body (BO-2 #1472). This drops ``unified_state``
+    (redundant with the JSON-safe ``state_snapshot``) and converts everything
+    else to primitives while preserving the genuine verdict markers.
+    """
+    if not isinstance(result, dict):
+        return {"raw_result": _jsonable(result)}
+    safe = {k: v for k, v in result.items() if k != "unified_state"}
+    return cast(Dict[str, Any], _jsonable(safe))
 
 
 class ProposalStore:
@@ -171,12 +231,11 @@ async def _run_pipeline(text: str, workflow: str, options: Dict) -> Dict:
         )
 
         result = await run_unified_analysis(text, workflow_name=workflow)
-        # Extract serializable results
-        if hasattr(result, "dict"):
-            return result.dict()
-        if isinstance(result, dict):
-            return result
-        return {"raw_result": str(result)}
+        # Coerce to a JSON-safe dict: the raw result carries the live
+        # unified_state object + PhaseResult dataclasses, which break FastAPI
+        # response serialization (500 with empty body). The genuine verdict
+        # markers survive; unified_state is dropped (BO-2 #1472).
+        return sanitize_workflow_result(result)
     except ImportError:
         logger.warning("UnifiedPipeline not available, using stub results")
         return {

--- a/tests/integration/api/test_deliberation_genuine_verdict.py
+++ b/tests/integration/api/test_deliberation_genuine_verdict.py
@@ -1,0 +1,103 @@
+"""BO-2 #1472 DoD #1 at the API boundary: the deliberation HTTP flow decides
+the governance verdict firsthand with real LLM agents (no mock), and the
+genuine verdict is retrievable through the JSON endpoints.
+
+Existing coverage stopped at ``202/queued`` (``test_proposal_api.py``) or mocked
+the pipeline (``test_workflow_endpoint_success``) — nothing proved that hitting
+the real endpoints produces (and returns) a genuine governance decision. This
+closes that gap end-to-end:
+
+    POST /api/propose  →  POST /api/deliberate (democratech)  →  GET status
+
+Privacy HARD: synthetic domain-public chess-club budget proposition only — no
+corpus, no real names. Marked requires_api+slow: skips without a key / on the
+fast per-push gate. FastAPI BackgroundTasks run synchronously under TestClient,
+so POST /deliberate blocks until the real workflow (~150-200s) completes.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.proposal_service import ProposalStore, get_proposal_store
+
+
+PROPOSITION = (
+    "Le club d'echecs dispose d'un budget participatif de 2000 euros. "
+    "Trois options divergentes s'affrontent. "
+    "Option A : organiser un tournoi inter-villes avec buffet et prix pour 2000 "
+    "euros, ce qui augmentera la visibilite du club et recrutera de nouveaux membres. "
+    "Option B : investir les 2000 euros en materiel pedagogique, echiquiers neufs, "
+    "horloges et supports de cours, car les echiquiers actuels sont uses. "
+    "Option C : un format hybride, 1000 euros pour un tournoi reduit et 1000 euros "
+    "pour le materiel pedagogique, equilibre entre visibilite et pedagogie."
+)
+
+
+@pytest.fixture(autouse=True)
+def fresh_store():
+    import api.proposal_service as svc
+
+    svc._store = ProposalStore()
+    yield
+    svc._store = None
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.mark.requires_api
+@pytest.mark.slow
+class TestDeliberationGenuineVerdictViaAPI:
+    @pytest.mark.asyncio
+    async def test_deliberation_decides_governance_firsthand_via_http(self, client):
+        # 1. Submit a synthetic multi-option proposal.
+        create = client.post(
+            "/api/propose",
+            json={"text": PROPOSITION, "author": "src0_ext0", "tags": ["budget"]},
+        )
+        assert create.status_code == 201
+        pid = create.json()["id"]
+
+        # 2. Launch deliberation. BackgroundTasks run synchronously under
+        #    TestClient, so this blocks until the real workflow completes.
+        start = client.post(
+            "/api/deliberate",
+            json={"proposal_id": pid, "workflow": "democratech"},
+        )
+        assert start.status_code == 202
+        delib_id = start.json()["id"]
+
+        # 3. Store-level proof: the workflow decided the verdict firsthand
+        #    through the full HTTP POST path (not a direct function call).
+        store = get_proposal_store()
+        delib = store.get_deliberation(delib_id)
+        assert delib is not None
+        assert delib.status.value == "completed", f"error={delib.error!r}"
+        gov = delib.results["phases"]["democratic_vote"]
+        gov_output = gov.output if hasattr(gov, "output") else gov["output"]
+        assert gov_output["governance_decided_firsthand"] is True, (
+            f"governance must decide firsthand with a live key "
+            f"(verdict={gov_output.get('governance_verdict')!r})"
+        )
+        assert gov_output["degraded"] is False
+        assert "governance_simulation" not in delib.results.get(
+            "capabilities_degraded", []
+        )
+
+        # 4. HTTP-level proof: the genuine verdict is retrievable as JSON —
+        #    the status endpoint no longer 500s on unserializable internals.
+        status = client.get(f"/api/deliberate/{delib_id}/status")
+        assert status.status_code == 200, status.text
+        body = status.json()
+        assert body["status"] == "completed"
+        http_gov = body["results"]["phases"]["democratic_vote"]["output"]
+        assert http_gov["governance_decided_firsthand"] is True
+        assert "unified_state" not in body["results"]
+
+        # 5. Proposal transitions to DECIDED and exposes its analysis.
+        detail = client.get(f"/api/proposals/{pid}")
+        assert detail.status_code == 200
+        assert detail.json()["status"] == "decided"

--- a/tests/unit/api/test_deliberation_serialization.py
+++ b/tests/unit/api/test_deliberation_serialization.py
@@ -1,0 +1,197 @@
+"""BO-2 #1472 — deliberation result JSON serialization (anti-theatre).
+
+A completed deliberation carries the genuine governance verdict, but the raw
+``run_unified_analysis`` result embeds the live ``unified_state`` object and
+``PhaseResult`` dataclasses. Returning it verbatim through FastAPI's
+``response_model`` raises at encode time → the ``GET /deliberate/{id}/status``
+and ``GET /proposals/{id}`` endpoints answered 500 with an empty body for every
+real deliberation (the verdict decided firsthand but was unreachable by the
+client — theatre #1019 at the API boundary).
+
+These tests exercise the ``sanitize_workflow_result`` fix and the endpoint
+regression WITHOUT a live LLM (the pipeline is mocked to return a raw result
+mirroring the real shape observed via a live-key probe), so they guard the fix
+on the fast CI gate. The genuine end-to-end proof (real LLM) lives in
+``tests/integration/api/test_deliberation_genuine_verdict.py`` (requires_api+slow).
+"""
+
+import json
+
+import pytest
+from unittest.mock import AsyncMock, patch
+from fastapi.testclient import TestClient
+
+from api.main import app
+from api.proposal_service import (
+    ProposalStore,
+    sanitize_workflow_result,
+)
+from argumentation_analysis.orchestration.workflow_dsl import PhaseResult, PhaseStatus
+
+
+class _FakeUnifiedState:
+    """Stand-in for the live UnifiedAnalysisState stored under
+    ``result['unified_state']``. Holds a self-cycle and a bare object() —
+    exactly the shape that makes FastAPI's jsonable_encoder raise, so the
+    test reproduces the real 500, not a strawman."""
+
+    def __init__(self):
+        self.self_ref = self  # cyclic reference
+        self.opaque = object()  # non-JSON-serializable attribute
+
+
+def _real_shape_raw_result() -> dict:
+    """A raw ``run_unified_analysis`` result mirroring the shape observed on a
+    live-key probe (keys, PhaseResult dataclasses, unified_state object)."""
+    gov_phase = PhaseResult(
+        phase_name="democratic_vote",
+        status=PhaseStatus.COMPLETED,
+        capability="governance_simulation",
+        output={
+            "governance_decided_firsthand": True,
+            "degraded": False,
+            "governance_verdict": {
+                "degraded": False,
+                "condorcet_winner": "arg_1",
+                "winners_per_method": {"borda": "arg_1", "copeland": "arg_1"},
+            },
+        },
+        error=None,
+    )
+    extract_phase = PhaseResult(
+        phase_name="extract",
+        status=PhaseStatus.COMPLETED,
+        capability="fact_extraction",
+        output={"arguments": ["arg_1", "arg_2", "arg_3"]},
+        error=None,
+    )
+    return {
+        "workflow_name": "democratech",
+        "phases": {"extract": extract_phase, "democratic_vote": gov_phase},
+        "summary": {"completed": 10, "failed": 0, "skipped": 0, "total": 10},
+        "capabilities_used": ["fact_extraction", "governance_simulation"],
+        "capabilities_degraded": [],
+        "capabilities_missing": [],
+        "state_snapshot": {"argument_count": 6, "governance_decision_count": 1},
+        "unified_state": _FakeUnifiedState(),
+    }
+
+
+# ──── sanitize_workflow_result unit tests ────
+
+
+class TestSanitizeWorkflowResult:
+    def test_output_is_json_serializable(self):
+        safe = sanitize_workflow_result(_real_shape_raw_result())
+        # Must not raise — the whole point of the fix.
+        json.dumps(safe)
+
+    def test_drops_unified_state(self):
+        safe = sanitize_workflow_result(_real_shape_raw_result())
+        assert "unified_state" not in safe
+
+    def test_preserves_genuine_verdict(self):
+        safe = sanitize_workflow_result(_real_shape_raw_result())
+        gov = safe["phases"]["democratic_vote"]["output"]
+        assert gov["governance_decided_firsthand"] is True
+        assert gov["degraded"] is False
+        assert gov["governance_verdict"]["condorcet_winner"] == "arg_1"
+
+    def test_preserves_capabilities_and_snapshot(self):
+        safe = sanitize_workflow_result(_real_shape_raw_result())
+        assert "governance_simulation" in safe["capabilities_used"]
+        assert safe["capabilities_degraded"] == []
+        assert safe["state_snapshot"]["argument_count"] == 6
+
+    def test_phase_result_status_enum_coerced(self):
+        safe = sanitize_workflow_result(_real_shape_raw_result())
+        # PhaseStatus enum → its value (str), not a bare enum member.
+        assert safe["phases"]["democratic_vote"]["status"] == PhaseStatus.COMPLETED.value
+
+    def test_non_dict_input_wrapped(self):
+        safe = sanitize_workflow_result("just a string")
+        assert safe == {"raw_result": "just a string"}
+
+    def test_empty_dict(self):
+        assert sanitize_workflow_result({}) == {}
+
+
+# ──── Endpoint regression (no LLM — pipeline mocked) ────
+
+
+@pytest.fixture(autouse=True)
+def fresh_store():
+    import api.proposal_service as svc
+
+    svc._store = ProposalStore()
+    yield
+    svc._store = None
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestDeliberationStatusSerialization:
+    """The status/detail endpoints must return 200 with the genuine verdict for
+    a completed deliberation — not 500 on unserializable internals (BO-2 #1472).
+
+    TestClient runs FastAPI BackgroundTasks synchronously, so after POST
+    /deliberate returns, the (mocked) deliberation has already completed and its
+    results are stored sanitized via the real run_deliberation_workflow path.
+    """
+
+    def test_status_endpoint_serializes_completed_deliberation(self, client):
+        raw = _real_shape_raw_result()
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            new=AsyncMock(return_value=raw),
+        ):
+            pid = client.post(
+                "/api/propose",
+                json={"text": "Synthetic multi-option proposal text", "author": "src0"},
+            ).json()["id"]
+
+            delib = client.post(
+                "/api/deliberate",
+                json={"proposal_id": pid, "workflow": "democratech"},
+            ).json()
+
+            resp = client.get(f"/api/deliberate/{delib['id']}/status")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "completed"
+        gov = body["results"]["phases"]["democratic_vote"]["output"]
+        assert gov["governance_decided_firsthand"] is True
+        assert "unified_state" not in body["results"]
+
+    def test_proposal_detail_serializes_analysis_results(self, client):
+        raw = _real_shape_raw_result()
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            new=AsyncMock(return_value=raw),
+        ):
+            pid = client.post(
+                "/api/propose",
+                json={"text": "Another synthetic proposal body here", "author": "src0"},
+            ).json()["id"]
+
+            client.post(
+                "/api/deliberate",
+                json={"proposal_id": pid, "workflow": "democratech"},
+            )
+
+            resp = client.get(f"/api/proposals/{pid}")
+
+        assert resp.status_code == 200, resp.text
+        detail = resp.json()
+        assert detail["status"] == "decided"
+        assert detail["analysis_results"] is not None
+        assert (
+            detail["analysis_results"]["phases"]["democratic_vote"]["output"][
+                "governance_decided_firsthand"
+            ]
+            is True
+        )


### PR DESCRIPTION
## Context — BO-2 #1472 follow-up (API serialization)

PR #1477 (merged) made the `democratech` workflow **decide** the governance verdict firsthand with real LLM agents (extract phase + capability cable fix). An empirical HTTP probe on the live API then revealed the **last mile** was broken: the verdict *was* decided, but the client could not retrieve it.

## The bug — theatre #1019 at the API boundary

`run_unified_analysis` returns a dict embedding:
- `unified_state` — the live `UnifiedAnalysisState` object (self-cyclic reference + bare `object()`)
- `phases` — `PhaseResult` dataclasses

Neither is JSON-serializable. Returning that dict through FastAPI's `response_model` (`DeliberationStatusResponse.results` / `WorkflowResult.results`) **raises at encode time**, so:

```
GET /api/deliberate/{id}/status  →  500 (empty body)
GET /api/proposals/{id}          →  500 (empty body)
```

…for *every* real deliberation. The governance verdict was decided firsthand but **unreachable by the client** — green at the store layer, 500 at the HTTP layer.

Probe evidence (live key, before this fix):
```
delib.status: COMPLETED | governance_decided_firsthand: True | condorcet_winner: arg_1
GET /api/deliberate/{id}/status → status_code: 500 | JSONDecodeError
```

## The fix — additive, 2 seams

`sanitize_workflow_result()` (api/proposal_service.py):
1. **Drops** `unified_state` (redundant with the already-JSON-safe `state_snapshot`).
2. **Coerces** the rest via a depth-guarded `_jsonable()` — handles `Enum`, `datetime`/`date`, dataclasses (`PhaseResult`), pydantic models (`model_dump`/`dict`), falls back to `str()`. Depth-guarded so a stray cycle cannot recurse forever.

Preserves the genuine verdict markers verbatim: `governance_decided_firsthand`, `governance_verdict`, `capabilities_used/degraded/missing`, `state_snapshot`.

Applied in **both** call sites that return pipeline results through a response_model:
- `_run_pipeline` (POST /deliberate → GET /status, GET /proposals/{id})
- `run_custom_workflow` (POST /workflow/custom — same latent bug, masked by a mock in its existing test)

## Proof firsthand (live LLM, no mock)

`tests/integration/api/test_deliberation_genuine_verdict.py` (`requires_api` + `slow`, **passed in 170s**):

```
democratech: 10 completed, 0 failed, 0 skipped
democratic_vote via governance_agent (14.59s, real LLM)
  → Governance decision added: gov_1 (social_choice: arg_1)
POST /propose → POST /deliberate → GET /status = 200  (was 500)
  results.phases.democratic_vote.output.governance_decided_firsthand = True
  "unified_state" not in results
proposal.status = decided
```

Synthetic chess-club budget proposition only — no corpus, no real names.

## Test coverage

| File | Marker | Purpose |
|------|--------|---------|
| `tests/unit/api/test_deliberation_serialization.py` | — (fast gate) | 9 tests, no key. Guards the fix via a raw result **mirroring the live shape** (self-cyclic `unified_state` + `object()` + `PhaseResult` dataclasses) — not a strawman. Endpoint regression via mocked pipeline. |
| `tests/integration/api/test_deliberation_genuine_verdict.py` | `requires_api` + `slow` | E2E real: full HTTP path decides + returns the genuine verdict. |

## mypy

Net **zero new errors** (stash-verified: 20 pre-existing → 19 with this change; the 19 are pre-existing untyped route handlers in `api/` not in the CI mypy scope). The 2 annotations on `sanitize_workflow_result` are typed (`Dict[str, Any]` + `cast`).

## Scope

Anti-théâtre only: the genuine verdict decided by #1477 is now **reachable** via HTTP. BO-2 #1472 remains OPEN — the WebSocket channels and the synthetic demo scenario are separate follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)