### PR TITLE
fix(api): cable deliberation WS streaming — client receives genuine verdict (BO-2 #1472)

### DIFF
--- a/api/proposal_service.py
+++ b/api/proposal_service.py
@@ -10,7 +10,7 @@ import logging
 import uuid
 from datetime import date, datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, cast
+from typing import Any, Awaitable, Callable, Dict, List, Optional, cast
 
 from .proposal_models import (
     DeliberationStatus,
@@ -208,6 +208,15 @@ async def run_deliberation_workflow(
     proposal_id = store.get_deliberation(delib_id).proposal_id
     store.update_status(proposal_id, ProposalStatus.ANALYZING)
 
+    # Stream lifecycle/verdict to any WS client subscribed to this deliberation.
+    # The session_id IS the delib_id (POST /deliberate returns it before the
+    # client connects to /ws/deliberation/{delib_id}). Broadcasting is best-effort:
+    # _send_to_session no-ops when nobody is connected, and WS failures must never
+    # break the deliberation itself (BO-2 #1472 WS last-mile — the routes + manager
+    # existed but NOTHING in the execution path ever emitted, so a connected client
+    # received only pongs: theatre #1019 at the WS boundary).
+    await _broadcast_ws(delib_id, lambda m: m.broadcast_status(delib_id, "running", workflow))
+
     try:
         # Try to run via UnifiedPipeline
         results = await _run_pipeline(proposal_text, workflow, options)
@@ -217,10 +226,67 @@ async def run_deliberation_workflow(
         store.set_analysis_results(proposal_id, results)
         store.update_status(proposal_id, ProposalStatus.DECIDED)
         logger.info(f"Deliberation {delib_id} completed successfully")
+        await _broadcast_ws_deliberation_result(delib_id, proposal_id, results)
+        await _broadcast_ws(
+            delib_id, lambda m: m.broadcast_status(delib_id, "completed")
+        )
     except Exception as e:
         logger.error(f"Deliberation {delib_id} failed: {e}")
         store.update_deliberation(delib_id, DeliberationStatus.FAILED, error=str(e))
         store.update_status(proposal_id, ProposalStatus.PENDING)
+        await _broadcast_ws(delib_id, lambda m: m.broadcast_error(delib_id, str(e)))
+        await _broadcast_ws(
+            delib_id, lambda m: m.broadcast_status(delib_id, "failed")
+        )
+
+
+async def _broadcast_ws(
+    delib_id: str, emit: Callable[[Any], Awaitable[None]]
+) -> None:
+    """Best-effort broadcast to the WS session for ``delib_id``.
+
+    Swallows any error: a streaming glitch must never propagate into the
+    deliberation's own success/failure state. ``emit`` receives the manager.
+    """
+    try:
+        from argumentation_analysis.services.websocket_manager import (
+            get_websocket_manager,
+        )
+
+        await emit(get_websocket_manager())
+    except Exception as e:  # noqa: BLE001 — streaming is best-effort
+        logger.warning(f"WS broadcast failed for deliberation {delib_id}: {e}")
+
+
+async def _broadcast_ws_deliberation_result(
+    delib_id: str, proposal_id: str, results: Dict[str, Any]
+) -> None:
+    """Extract the governance verdict from sanitized results and broadcast it.
+
+    ``results`` is already JSON-safe (``sanitize_workflow_result``), so the
+    democratic_vote phase output is a plain dict. A missing/degraded verdict is
+    broadcast honestly (``decided_firsthand=False``) rather than fabricated.
+    """
+    gov_output = (
+        results.get("phases", {})
+        .get("democratic_vote", {})
+        .get("output", {})
+    )
+    verdict = gov_output.get("governance_verdict") or {}
+    await _broadcast_ws(
+        delib_id,
+        lambda m: m.broadcast_deliberation_result(
+            delib_id,
+            proposal_id,
+            winner=verdict.get("condorcet_winner"),
+            decided_firsthand=bool(gov_output.get("governance_decided_firsthand", False)),
+            degraded=bool(gov_output.get("degraded", False)),
+            summary={
+                "governance_verdict": verdict,
+                "capabilities_degraded": results.get("capabilities_degraded", []),
+            },
+        ),
+    )
 
 
 async def _run_pipeline(text: str, workflow: str, options: Dict) -> Dict:

--- a/argumentation_analysis/services/websocket_manager.py
+++ b/argumentation_analysis/services/websocket_manager.py
@@ -167,6 +167,36 @@ class AnalysisWebSocketManager:
             },
         )
 
+    async def broadcast_deliberation_result(
+        self,
+        session_id: str,
+        proposal_id: str,
+        winner: Optional[str],
+        decided_firsthand: bool,
+        degraded: bool = False,
+        summary: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Broadcast a terminal deliberation verdict (governance decision).
+
+        Distinct from ``broadcast_vote_update`` (a single voter's ballot): this
+        carries the aggregated governance verdict emitted by the
+        ``democratic_vote`` phase — the ``condorcet_winner`` plus the genuine
+        marker, so a WS client learns *both* that the deliberation resolved and
+        whether it decided firsthand (BO-2 #1472 WS last-mile).
+        """
+        await self._send_to_session(
+            session_id,
+            {
+                "type": "deliberation_result",
+                "proposal_id": proposal_id,
+                "winner": winner,
+                "governance_decided_firsthand": decided_firsthand,
+                "degraded": degraded,
+                "summary": _safe_serialize(summary or {}),
+                "timestamp": time.time(),
+            },
+        )
+
     async def broadcast_status(self, session_id: str, status: str, detail: str = ""):
         """Broadcast a generic status message."""
         await self._send_to_session(

--- a/tests/integration/api/test_websocket_deliberation_genuine.py
+++ b/tests/integration/api/test_websocket_deliberation_genuine.py
@@ -1,0 +1,102 @@
+"""BO-2 #1472 DoD #2 — WebSocket last-mile GENUINE proof (real LLM, no mock).
+
+Companion to ``tests/unit/api/test_websocket_deliberation_cable.py`` (fast gate,
+mocked pipeline) and to the HTTP genuine test
+``tests/integration/api/test_deliberation_genuine_verdict.py`` (#1481). This
+closes the WS last-mile: a client subscribed to ``/ws/deliberation/{delib_id}``
+receives the genuine governance verdict — decided firsthand by real LLM agents —
+not only pongs.
+
+Before the cable (grep-confirmed): ``AnalysisWebSocketManager.broadcast_*`` were
+called only in tests; the production execution path never emitted, so a connected
+client saw only ping/pong (theatre #1019 at the WS boundary, same family as the
+HTTP serialization 500 fixed in #1481).
+
+Anti-theatre HARD: this test runs the REAL pipeline (no mock) on a synthetic
+domain-public chess-club budget proposition, so the broadcast ``winner`` and
+``governance_decided_firsthand`` are the genuine LLM-decided verdict.
+
+Note on the WS transport: a ``_FakeSocket`` registered in the real manager's
+connection set is the capture point. ``_send_to_session`` calls ``ws.send_json``
+on it identically to a live socket (the cable is manager-side), and the genuine
+proof is that the *real* pipeline verdict reaches it. The HTTP POST -> WS
+concurrent flow is unreachable under FastAPI TestClient (BackgroundTasks run
+synchronously), so ``run_deliberation_workflow`` is awaited directly with a
+pre-registered socket.
+"""
+
+import pytest
+from starlette.websockets import WebSocketState
+
+from api.proposal_service import ProposalStore, run_deliberation_workflow
+from argumentation_analysis.services.websocket_manager import AnalysisWebSocketManager
+
+
+PROPOSITION = (
+    "Le club d'echecs dispose d'un budget participatif de 2000 euros. "
+    "Trois options divergentes s'affrontent. "
+    "Option A : organiser un tournoi inter-villes avec buffet et prix pour 2000 "
+    "euros, ce qui augmentera la visibilite du club et recrutera de nouveaux membres. "
+    "Option B : investir les 2000 euros en materiel pedagogique, echiquiers neufs, "
+    "horloges et supports de cours, car les echiquiers actuels sont uses. "
+    "Option C : un format hybride, 1000 euros pour un tournoi reduit et 1000 euros "
+    "pour le materiel pedagogique, equilibre entre visibilite et pedagogie."
+)
+
+
+class _FakeSocket:
+    def __init__(self):
+        self.client_state = WebSocketState.CONNECTED
+        self.received: list[dict] = []
+
+    async def send_json(self, message):
+        self.received.append(message)
+
+
+@pytest.mark.requires_api
+@pytest.mark.slow
+class TestWebSocketDeliberationGenuineVerdict:
+    @pytest.mark.asyncio
+    async def test_ws_client_receives_genuine_governance_verdict(self, monkeypatch):
+        # Isolated store + fresh manager.
+        store = ProposalStore()
+        manager = AnalysisWebSocketManager()
+        import argumentation_analysis.services.websocket_manager as wsm
+
+        monkeypatch.setattr(wsm, "_manager", manager)
+
+        proposal = store.create_proposal(
+            type(
+                "P",
+                (),
+                {"text": PROPOSITION, "author": "src0_ext0", "title": None, "tags": ["budget"]},
+            )()
+        )
+        delib = store.create_deliberation(proposal.id, "democratech")
+
+        # Subscribe a client to this deliberation's session (= delib_id) BEFORE
+        # running the workflow, as a real browser would after POST /deliberate.
+        sock = _FakeSocket()
+        manager._connections[delib.id] = {sock}
+
+        # REAL pipeline — no mock. Blocks ~150-200s with a live key.
+        await run_deliberation_workflow(
+            store, delib.id, proposal.text, "democratech", {}
+        )
+
+        # 1. The deliberation decided firsthand at the store level.
+        d = store.get_deliberation(delib.id)
+        assert d is not None
+        assert d.status.value == "completed", f"error={d.error!r}"
+
+        # 2. The subscribed WS client received the lifecycle + the GENUINE verdict.
+        types = [m["type"] for m in sock.received]
+        assert types[0] == "status" and sock.received[0]["status"] == "running"
+        assert "deliberation_result" in types, f"no verdict broadcast: {types}"
+        result_ev = next(m for m in sock.received if m["type"] == "deliberation_result")
+        # Genuine markers — decided firsthand by real LLM agents, not fabricated.
+        assert result_ev["governance_decided_firsthand"] is True, result_ev
+        assert result_ev["degraded"] is False, result_ev
+        assert result_ev["winner"] is not None, result_ev
+        assert result_ev["proposal_id"] == proposal.id
+        assert types[-1] == "status" and sock.received[-1]["status"] == "completed"

--- a/tests/unit/api/test_websocket_deliberation_cable.py
+++ b/tests/unit/api/test_websocket_deliberation_cable.py
@@ -1,0 +1,224 @@
+"""BO-2 #1472 DoD — WebSocket last-mile cable (anti-theatre), fast-gate guard.
+
+Empirical SDDD probe (grep) found that ``AnalysisWebSocketManager.broadcast_*``
+helpers were called **only in tests** — ``get_websocket_manager()`` was reached
+in production solely from ``api/websocket_routes.py`` (connect/disconnect). So a
+client connected to ``/ws/deliberation/{id}`` received only pongs: the streaming
+surface existed but NOTHING in the execution path ever emitted. Theatre #1019 at
+the WS boundary — the same family of latent bug as the HTTP serialization 500
+fixed in #1481 (verdict decided but unreachable).
+
+This module guards the cable added in ``run_deliberation_workflow`` (lifecycle
+``running``/``completed``/``failed`` + terminal ``deliberation_result`` carrying
+the governance verdict) on the **fast per-push gate**, with the pipeline mocked
+to a realistic sanitized-result shape. The genuine end-to-end proof (real LLM,
+real verdict broadcast) lives in
+``tests/integration/api/test_websocket_deliberation_genuine.py`` (requires_api+slow).
+
+A ``FakeSocket`` registered in the real manager's connection set stands in for a
+connected client: ``_send_to_session`` calls ``ws.send_json`` on it exactly as on
+a live socket, so capturing on it proves the manager actually broadcast.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from starlette.websockets import WebSocketState
+
+from api.proposal_service import ProposalStore, run_deliberation_workflow
+from argumentation_analysis.orchestration.workflow_dsl import PhaseResult, PhaseStatus
+from argumentation_analysis.services.websocket_manager import (
+    AnalysisWebSocketManager,
+    get_websocket_manager,
+)
+
+
+class _FakeSocket:
+    """Stand-in for a connected WebSocket. Captures every broadcast."""
+
+    def __init__(self):
+        self.client_state = WebSocketState.CONNECTED
+        self.received: list[dict] = []
+
+    async def send_json(self, message):
+        self.received.append(message)
+
+
+def _sanitized_result_shape() -> dict:
+    """A sanitized ``run_unified_analysis`` result (post ``sanitize_workflow_result``).
+
+    Mirrors the live shape: phases as dicts (PhaseResult coerced), genuine
+    governance verdict. NOT a strawman — ``run_deliberation_workflow`` extracts
+    the verdict from ``phases.democratic_vote.output`` exactly this way.
+    """
+    gov = PhaseResult(
+        phase_name="democratic_vote",
+        status=PhaseStatus.COMPLETED,
+        capability="governance_simulation",
+        output={
+            "governance_decided_firsthand": True,
+            "degraded": False,
+            "governance_verdict": {
+                "degraded": False,
+                "condorcet_winner": "arg_1",
+                "winners_per_method": {"borda": "arg_1", "copeland": "arg_1"},
+            },
+        },
+        error=None,
+    )
+    extract = PhaseResult(
+        phase_name="extract",
+        status=PhaseStatus.COMPLETED,
+        capability="fact_extraction",
+        output={"arguments": ["arg_1", "arg_2"]},
+        error=None,
+    )
+    return {
+        "workflow_name": "democratech",
+        "phases": {"extract": extract, "democratic_vote": gov},
+        "summary": {"completed": 10, "failed": 0, "skipped": 0, "total": 10},
+        "capabilities_used": ["fact_extraction", "governance_simulation"],
+        "capabilities_degraded": [],
+        "capabilities_missing": [],
+        "state_snapshot": {"argument_count": 6, "governance_decision_count": 1},
+    }
+
+
+@pytest.fixture
+def fresh_store_and_manager(monkeypatch):
+    """Isolated store + fresh manager so tests don't leak connections."""
+    import api.proposal_service as svc
+
+    monkeypatch.setattr(svc, "_store", ProposalStore())
+    fresh_manager = AnalysisWebSocketManager()
+    import argumentation_analysis.services.websocket_manager as wsm
+
+    monkeypatch.setattr(wsm, "_manager", fresh_manager)
+    yield svc._store, fresh_manager
+
+
+class TestWSCableBroadcastsLifecycleAndVerdict:
+    """A connected client receives running -> verdict -> completed (the cable)."""
+
+    @pytest.mark.asyncio
+    async def test_completed_deliberation_streams_verdict_to_ws_client(
+        self, fresh_store_and_manager
+    ):
+        store, manager = fresh_store_and_manager
+        proposal = store.create_proposal(
+            type(
+                "P",
+                (),
+                {
+                    "text": "Synthetic 3-option budget proposal",
+                    "author": "src0",
+                    "title": None,
+                    "tags": [],
+                },
+            )()
+        )
+        delib = store.create_deliberation(proposal.id, "democratech")
+
+        sock = _FakeSocket()
+        manager._connections[delib.id] = {sock}
+
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            new=AsyncMock(return_value=_sanitized_result_shape()),
+        ):
+            await run_deliberation_workflow(
+                store, delib.id, proposal.text, "democratech", {}
+            )
+
+        types = [m["type"] for m in sock.received]
+        # Lifecycle opened with running, closed with completed.
+        assert types[0] == "status" and sock.received[0]["status"] == "running"
+        assert sock.received[0]["detail"] == "democratech"
+        assert types[-1] == "status" and sock.received[-1]["status"] == "completed"
+        # The genuine verdict was broadcast.
+        assert "deliberation_result" in types
+        result_ev = next(m for m in sock.received if m["type"] == "deliberation_result")
+        assert result_ev["proposal_id"] == proposal.id
+        assert result_ev["winner"] == "arg_1"
+        assert result_ev["governance_decided_firsthand"] is True
+        assert result_ev["degraded"] is False
+        # Store transitioned too (the cable did not break the deliberation).
+        assert store.get_deliberation(delib.id).status.value == "completed"
+
+    @pytest.mark.asyncio
+    async def test_failed_deliberation_streams_error_to_ws_client(
+        self, fresh_store_and_manager
+    ):
+        store, manager = fresh_store_and_manager
+        proposal = store.create_proposal(
+            type(
+                "P",
+                (),
+                {
+                    "text": "Synthetic failing proposal",
+                    "author": "src0",
+                    "title": None,
+                    "tags": [],
+                },
+            )()
+        )
+        delib = store.create_deliberation(proposal.id, "democratech")
+
+        sock = _FakeSocket()
+        manager._connections[delib.id] = {sock}
+
+        # Patch _run_pipeline (not run_unified_analysis): the real _run_pipeline
+        # swallows all exceptions and returns an error-stub, which would be treated
+        # as a *completed* deliberation. To exercise run_deliberation_workflow's own
+        # except branch (-> FAILED + error broadcast) we make _run_pipeline raise.
+        with patch(
+            "api.proposal_service._run_pipeline",
+            new=AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            await run_deliberation_workflow(
+                store, delib.id, proposal.text, "democratech", {}
+            )
+
+        types = [m["type"] for m in sock.received]
+        assert types[0] == "status" and sock.received[0]["status"] == "running"
+        assert "error" in types
+        err_ev = next(m for m in sock.received if m["type"] == "error")
+        assert "boom" in err_ev["error"]
+        assert types[-1] == "status" and sock.received[-1]["status"] == "failed"
+        assert store.get_deliberation(delib.id).status.value == "failed"
+
+    @pytest.mark.asyncio
+    async def test_broadcast_noop_when_no_client_connected(
+        self, fresh_store_and_manager
+    ):
+        """No client registered -> deliberation still completes, nothing raised.
+
+        Guards the best-effort contract: WS must never break a headless
+        deliberation (e.g. POST /deliberate with no WS subscriber).
+        """
+        store, manager = fresh_store_and_manager
+        proposal = store.create_proposal(
+            type(
+                "P",
+                (),
+                {
+                    "text": "Headless deliberation, no WS client",
+                    "author": "src0",
+                    "title": None,
+                    "tags": [],
+                },
+            )()
+        )
+        delib = store.create_deliberation(proposal.id, "democratech")
+        # Deliberately do NOT register any socket.
+
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            new=AsyncMock(return_value=_sanitized_result_shape()),
+        ):
+            await run_deliberation_workflow(
+                store, delib.id, proposal.text, "democratech", {}
+            )  # must not raise
+
+        assert store.get_deliberation(delib.id).status.value == "completed"
+        assert manager.get_active_sessions() == []


### PR DESCRIPTION
## Context — BO-2 #1472 WS last-mile (theatre discovery)

Follows #1481 (HTTP serialization). An SDDD grep probe surfaced a **second theatre** at the WS boundary: `AnalysisWebSocketManager.broadcast_*` helpers were called **only in tests** — `get_websocket_manager()` was reached in production solely from `api/websocket_routes.py` for `connect`/`disconnect`. So a client connected to `/ws/deliberation/{id}` received **only pongs**: the streaming surface existed, but NOTHING in the execution path ever emitted. Same family of latent bug as #1481 (verdict decided but unreachable) — `grep` proof:

```
broadcast_phase_result|broadcast_vote_update|...  →  only in test_websocket_manager.py
get_websocket_manager()                            →  only in api/websocket_routes.py (connect/disconnect)
```

## The fix — additive cable (anti-pendule)

Wire `run_deliberation_workflow` → the real WS manager so a subscribed client gets the lifecycle + the terminal governance verdict:

| Event | When | Carrier |
|-------|------|---------|
| `status: running` | workflow start | `broadcast_status` |
| `deliberation_result` | on COMPLETED | **new** `broadcast_deliberation_result` (winner / `governance_decided_firsthand` / degraded + capabilities summary) |
| `status: completed` | on success | `broadcast_status` |
| `error` + `status: failed` | on failure | `broadcast_error` + `broadcast_status` |

- `broadcast_deliberation_result` is **distinct** from `broadcast_vote_update` (a single voter's ballot): it carries the **aggregated** governance verdict emitted by `democratic_vote` (the `condorcet_winner` + the genuine marker).
- Two best-effort helpers (`_broadcast_ws` / `_broadcast_ws_deliberation_result`): **no-op when nobody is connected**, and WS failures never propagate into the deliberation's own success/failure. `session_id` IS `delib_id` (POST /deliberate returns it before the client connects to `/ws/deliberation/{delib_id}`).
- The verdict is extracted from the already-sanitized results (`phases.democratic_vote.output`), so a missing/degraded verdict is broadcast **honestly** (`decided_firsthand=False`) rather than fabricated.

**Honest scope note**: this streams lifecycle + terminal verdict, not per-phase events in real time — that would require instrumenting `unified_pipeline` (out of this lane). It is the minimum that makes the WS surface non-theatrical.

## Proof firsthand (live LLM, no mock)

`tests/integration/api/test_websocket_deliberation_genuine.py` (`requires_api` + `slow`, **passed**):

```
democratech: 10 completed, 0 failed, 0 skipped
democratic_vote via governance_agent (16.28s, real LLM)
  → Governance decision added: gov_1 (social_choice: arg_1)
WS client (FakeSocket registered for delib_id) received:
  status:running → deliberation_result(winner=arg_1, governance_decided_firsthand=True, degraded=False) → status:completed
```

The `qwen3.5-35b-a3b` 404 + torch `fbgemm.dll` warnings are known collateral (neural fallacy/quality tiers degrade honestly, #882/FB-25) — governance still decides firsthand via the 9-virtue electorate (GE-4).

## Test coverage

| File | Marker | Purpose |
|------|--------|---------|
| `tests/unit/api/test_websocket_deliberation_cable.py` | fast gate (no key) | 3 tests: completed lifecycle + verdict broadcast / failed lifecycle + error broadcast / **no-op-when-headless** (WS must never break a deliberation with no subscriber) |
| `tests/integration/api/test_websocket_deliberation_genuine.py` | `requires_api` + `slow` | real LLM → genuine verdict reaches the WS client |

A `_FakeSocket` registered in the real manager's connection set is the capture point: `_send_to_session` calls `ws.send_json` on it identically to a live socket. The genuine proof is that the *real* pipeline verdict reaches it. (The HTTP POST → WS-concurrent flow is unreachable under FastAPI TestClient — BackgroundTasks run synchronously — so `run_deliberation_workflow` is awaited with a pre-registered socket.)

## mypy

Net **zero new errors** (stash-verified: 22 pre-existing → 22 with this change). The 3 new helpers are annotated (`-> None`, `emit: Callable[[Any], Awaitable[None]]`, `Dict[str, Any]`).

## Scope

Lane po-2025 (`api/` + `services/websocket_manager` + tests) — 0 collision with po-2023 (BO-4 orchestration). BO-2 #1472 residual: synthetic demo scenario + React dashboard (frontend scope to frame with coord/user).

🤖 Generated with [Claude Code](https://claude.com/claude-code)