### PR TITLE
fix(orchestration): wire LLM replay-cache into the direct path — deterministic governance verdict (BO-3 #1473)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -460,12 +460,24 @@ async def _guarded_chat_completion(client: Any, **kwargs: Any) -> Any:
                 f"({budget.count} > {budget.ceiling}) in a single analysis run "
                 f"— runaway guard (issue #708)."
             )
+    # Cache-aware dispatch (BO-3 #1473): route the direct OpenAI call through
+    # the raw LLM cache. In record mode the response is persisted; in replay
+    # mode a miss raises LLMCacheMiss (fail-loud — never a silent live call);
+    # in off mode it passes through unchanged. This single seam covers EVERY
+    # direct-path phase (extract/governance/quality/fallacy/counter-arg), so a
+    # replay run is deterministic for these phases. SK-native agent calls
+    # (ChatCompletionAgent/AgentGroupChat) bypass this funnel and are cached at
+    # the service level (create_llm_service) — separate follow-up.
+    from argumentation_analysis.services.llm_cache import (
+        cached_raw_chat_completion,
+    )
+
     if _LLM_CALL_TIMEOUT_S > 0:
         return await asyncio.wait_for(
-            client.chat.completions.create(**kwargs),
+            cached_raw_chat_completion(client, **kwargs),
             timeout=_LLM_CALL_TIMEOUT_S,
         )
-    return await client.chat.completions.create(**kwargs)
+    return await cached_raw_chat_completion(client, **kwargs)
 
 
 # --- Invoke callables for registered components ---

--- a/argumentation_analysis/services/llm_cache.py
+++ b/argumentation_analysis/services/llm_cache.py
@@ -16,7 +16,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
@@ -240,3 +240,145 @@ class CachedChatCompletion(ChatCompletionClientBase):
         if self._cache is not None:
             self._cache.close()
             self._cache = None
+
+
+# ──── Raw-path cache (direct OpenAI calls via _guarded_chat_completion) ────
+#
+# CachedChatCompletion above wraps the SK service (kernel/agents path). But the
+# direct path — ``_guarded_chat_completion`` → ``client.chat.completions.create``
+# (extract/governance/quality/fallacy/counter-arg) — never touches an SK service,
+# so it needs its own cache at the raw OpenAI-kwargs level. Both share the same
+# diskcache backend + CACHE_DIR so a single record run seeds every call site,
+# and a single replay run replays every call site (BO-3 #1473, determinism DoD).
+
+_RAW_CACHE_KEY_FIELDS = (
+    "temperature",
+    "max_tokens",
+    "top_p",
+    "presence_penalty",
+    "frequency_penalty",
+    "response_format",
+    "tool_choice",
+    "tools",
+)
+
+
+def compute_raw_cache_key(**kwargs: Any) -> str:
+    """SHA-256 over the deterministic part of a raw chat.completions.create call.
+
+    The cache key captures the fields that affect the LLM output: model,
+    messages, and the deterministic sampling/tooling kwargs. Non-deterministic
+    kwargs (e.g. ``user``, ``seed`` if unset) are ignored. The ``client`` is
+    NOT part of the key (two clients with the same provider → same answer).
+    Takes the full ``client.chat.completions.create`` kwargs and extracts the
+    relevant fields itself, so callers never risk a double-arg collision.
+    """
+    key_data: Dict[str, Any] = {
+        "model": kwargs.get("model"),
+        "messages": kwargs.get("messages", []),
+    }
+    for field in _RAW_CACHE_KEY_FIELDS:
+        if field in kwargs and kwargs[field] is not None:
+            key_data[field] = kwargs[field]
+    raw = json.dumps(key_data, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _serialize_chat_completion(response: Any) -> Dict[str, Any]:
+    """Serialize an OpenAI ChatCompletion to a JSON-safe dict (diskcache-storable).
+
+    Uses pydantic ``model_dump`` (OpenAI v1+ SDK). The dict round-trips via
+    ``ChatCompletion.model_validate`` (probed firsthand: content + tool_calls +
+    JSON-string all survive).
+    """
+    if hasattr(response, "model_dump"):
+        return cast(Dict[str, Any], response.model_dump())
+    # Fallback: already a dict-like.
+    return {"_fallback": str(response)}
+
+
+def _deserialize_chat_completion(data: Any) -> Any:
+    """Reconstruct an OpenAI ChatCompletion from a cached dict."""
+    if isinstance(data, dict) and "_fallback" in data:
+        return data["_fallback"]
+    from openai.types.chat import ChatCompletion
+
+    return ChatCompletion.model_validate(data)
+
+
+# Module-level singleton diskcache for the raw path (shared with CACHE_DIR).
+_raw_cache: Any = None
+_raw_cache_dir: Optional[str] = None
+
+
+def get_raw_cache(cache_dir: Optional[Path] = None) -> Any:
+    """Return the shared raw-path diskcache, or None when caching is off.
+
+    Lazily initialized so importing the module never opens a cache. Reuses one
+    diskcache across calls within a process; a different ``cache_dir`` re-opens.
+    """
+    mode = get_cache_mode()
+    if mode == OFF:
+        return None
+    env_cache_dir: Optional[str] = os.getenv("LLM_CACHE_DIR")
+    target = str(cache_dir or env_cache_dir or CACHE_DIR)
+    global _raw_cache, _raw_cache_dir
+    if _raw_cache is None or _raw_cache_dir != target:
+        Path(target).mkdir(parents=True, exist_ok=True)
+        try:
+            import diskcache
+
+            _raw_cache = diskcache.Cache(target)
+            _raw_cache_dir = target
+        except ImportError:
+            logger.warning("diskcache not installed, raw cache disabled")
+            return None
+    return _raw_cache
+
+
+def reset_raw_cache() -> None:
+    """Close + drop the module-level raw cache singleton (test isolation)."""
+    global _raw_cache, _raw_cache_dir
+    if _raw_cache is not None:
+        try:
+            _raw_cache.close()
+        except Exception:  # noqa: BLE001 — best-effort teardown
+            pass
+    _raw_cache = None
+    _raw_cache_dir = None
+
+
+async def cached_raw_chat_completion(client: Any, **kwargs: Any) -> Any:
+    """Cache-aware wrapper for ``client.chat.completions.create(**kwargs)``.
+
+    Mirrors ``CachedChatCompletion`` but for the direct (non-SK) path. In replay
+    mode a miss raises ``LLMCacheMiss`` (fail-loud — never a silent live call,
+    BO-3 #1473 anti-theatre); in record mode a miss calls the API and caches the
+    response; in off mode it passes through. The cache key is computed from the
+    deterministic kwargs only (see ``compute_raw_cache_key``).
+    """
+    mode = get_cache_mode()
+    if mode == OFF:
+        return await client.chat.completions.create(**kwargs)
+    cache = get_raw_cache()
+    if cache is None:  # diskcache unavailable
+        return await client.chat.completions.create(**kwargs)
+    key = compute_raw_cache_key(**kwargs)
+    if mode == REPLAY:
+        cached = cache.get(key)
+        if cached is None:
+            raise LLMCacheMiss(
+                f"Raw cache miss in replay mode for key {key[:16]}... "
+                f"Record fixtures first with LLM_CACHE_MODE=record"
+            )
+        logger.debug("Raw cache HIT (replay): %s...", key[:16])
+        return _deserialize_chat_completion(cached)
+    # RECORD mode
+    cached = cache.get(key)
+    if cached is not None:
+        logger.debug("Raw cache HIT (record): %s...", key[:16])
+        return _deserialize_chat_completion(cached)
+    logger.debug("Raw cache MISS (record): %s..., calling API", key[:16])
+    response = await client.chat.completions.create(**kwargs)
+    cache.set(key, _serialize_chat_completion(response))
+    return response

--- a/tests/integration/orchestration/test_replay_cache_determinism.py
+++ b/tests/integration/orchestration/test_replay_cache_determinism.py
@@ -1,0 +1,167 @@
+"""BO-3 #1473 DoD #1 at the pipeline level: a ``democratech`` run is
+DETERMINISTICALLY REPRODUCIBLE. Recording one live run, then replaying the
+same input against the cache, yields an IDENTICAL governance verdict decided
+firsthand on BOTH runs — proven firsthand, not asserted.
+
+This is the 3rd axis of Epic #1470 (reproducibility). It complements the unit
+tests in ``test_llm_cache.py`` (which prove the cache mechanics in isolation)
+by proving the property END-TO-END through ``run_unified_analysis``: every
+direct-path phase (extract/quality/counter/fallacy/debate/governance) routes
+through ``_guarded_chat_completion`` → ``cached_raw_chat_completion``, so a
+replay run reuses the recorded responses instead of hitting the API.
+
+Two DoDs:
+  #1 (determinism firsthand): record → replay → identical governance verdict
+     (winner + winners_per_method + governance_decided_firsthand) AND identical
+     per-phase decisional output (wall-clock fields stripped — they measure
+     time, not the decision, and are never reproducible by construction).
+  #2 (fail-loud on miss, at the cache layer): a replay miss raises
+     ``LLMCacheMiss`` and NEVER silently calls the API — covered in
+     ``test_llm_cache.py::test_replay_mode_miss_raises_fail_loud`` (calls == 0).
+
+Privacy HARD: synthetic domain-public chess-club budget proposition only — no
+corpus, no real names. Marked ``requires_api``+``slow``: skips without a key
+and on the fast per-push gate (the record leg needs a real LLM, ~3-5 calls).
+
+NOTE on the JTMS wall-clock field: ``belief_tracking`` embeds
+``creation_timestamp`` (set to ``datetime.now()`` at extended_belief.py:32) in
+its output. That field is wall-clock by construction, so it can NEVER match
+between two real runs — cache or no cache (the phase makes no LLM call). The
+decisional hash below strips wall-clock keys so it measures decisional
+determinism (what the cache must reproduce), not wall-time.
+"""
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+
+import pytest
+
+
+PROPOSITION = (
+    "Le club d'echecs dispose d'un budget participatif de 2000 euros. "
+    "Trois options divergentes s'affrontent. "
+    "Option A : organiser un tournoi inter-villes avec buffet et prix pour 2000 "
+    "euros, ce qui augmentera la visibilite du club. "
+    "Option B : investir les 2000 euros en materiel pedagogique, echiquiers neufs. "
+    "Option C : un format hybride, 1000 euros tournoi reduit et 1000 euros materiel."
+)
+
+# Wall-clock fields are never reproducible between two real runs (they measure
+# time, not the decision). The cache cannot and should not make them equal, so
+# they are stripped from the decisional hash.
+_WALLCLOCK_KEYS = {"creation_timestamp", "timestamp", "created_at", "modified_at"}
+
+
+def _strip_wallclock(obj):
+    if isinstance(obj, dict):
+        return {k: _strip_wallclock(v) for k, v in obj.items() if k not in _WALLCLOCK_KEYS}
+    if isinstance(obj, list):
+        return [_strip_wallclock(v) for v in obj]
+    return obj
+
+
+def _decisional_hash(obj) -> str:
+    """Deterministic SHA-256[:12] of a JSON-able object (wall-clock stripped)."""
+    cleaned = _strip_wallclock(obj)
+    raw = json.dumps(cleaned, sort_keys=True, ensure_ascii=False, default=str)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()[:12]
+
+
+def _phase_output(phase_val):
+    if phase_val is None:
+        return {}
+    if hasattr(phase_val, "output"):
+        return phase_val.output or {}
+    if isinstance(phase_val, dict):
+        return phase_val.get("output") or phase_val
+    return {}
+
+
+async def _run_democratech(cache_dir, mode):
+    """Run the democratech workflow with the cache pointed at ``cache_dir``.
+
+    ``LLM_CACHE_MODE``/``LLM_CACHE_DIR`` are set + the raw-cache singleton is
+    reset so each run sees a fresh view of the cache backend.
+    """
+    os.environ["LLM_CACHE_MODE"] = mode
+    os.environ["LLM_CACHE_DIR"] = cache_dir
+    from argumentation_analysis.services import llm_cache as lc
+    lc.reset_raw_cache()
+    from argumentation_analysis.orchestration.unified_pipeline import (
+        run_unified_analysis,
+    )
+    return await run_unified_analysis(PROPOSITION, workflow_name="democratech")
+
+
+def _governance_verdict(result):
+    phases = result.get("phases", {}) if isinstance(result, dict) else {}
+    gov = phases.get("democratic_vote", {})
+    out = _phase_output(gov)
+    verdict = out.get("governance_verdict") or {}
+    return {
+        "winner": verdict.get("condorcet_winner"),
+        "firsthand": out.get("governance_decided_firsthand"),
+        "methods": dict(verdict.get("winners_per_method", {})),
+    }
+
+
+def _phase_hashes(result):
+    phases = result.get("phases", {}) if isinstance(result, dict) else {}
+    return {name: _decisional_hash(_phase_output(val)) for name, val in phases.items()}
+
+
+@pytest.mark.requires_api
+@pytest.mark.slow
+class TestReplayCacheDeterminism:
+    """DoD #1: record → replay → identical governance verdict + per-phase output."""
+
+    @pytest.mark.asyncio
+    async def test_record_then_replay_yields_identical_governance_verdict(self, tmp_path):
+        cache_dir = str(tmp_path / "llm_cache")
+        try:
+            record_result = await _run_democratech(cache_dir, "record")
+            replay_result = await _run_democratech(cache_dir, "replay")
+
+            rec_verdict = _governance_verdict(record_result)
+            rep_verdict = _governance_verdict(replay_result)
+
+            # The record run itself must decide firsthand (else the proposition
+            # or invocation is the problem, not the cache).
+            assert rec_verdict["firsthand"] is True, (
+                f"RECORD governance not firsthand (firsthand="
+                f"{rec_verdict['firsthand']}). Proposition/invocation issue."
+            )
+            # DoD #1: identical governance verdict, decided firsthand on both.
+            assert rep_verdict["firsthand"] is True, (
+                "REPLAY governance not firsthand — replay diverged from record"
+            )
+            assert rec_verdict["winner"] == rep_verdict["winner"], (
+                f"winner differs: {rec_verdict['winner']} vs {rep_verdict['winner']}"
+            )
+            assert rec_verdict["methods"] == rep_verdict["methods"], (
+                "winners_per_method differs between record and replay"
+            )
+            assert rec_verdict["methods"], "expected ≥1 voting method decided"
+
+            # DoD #1 (per-phase): every phase's decisional output is identical
+            # (wall-clock stripped). A divergence here would be a REAL cache bug,
+            # not a cosmetic timestamp — this is the core anti-théâtre guarantee.
+            rec_hashes = _phase_hashes(record_result)
+            rep_hashes = _phase_hashes(replay_result)
+            diverged = {
+                name: (rec_hashes[name], rep_hashes.get(name))
+                for name in rec_hashes
+                if rec_hashes[name] != rep_hashes.get(name)
+            }
+            assert not diverged, (
+                f"phases diverged decisionally between record and replay "
+                f"(not wall-clock — real cache miss): {diverged}"
+            )
+        finally:
+            os.environ.pop("LLM_CACHE_MODE", None)
+            os.environ.pop("LLM_CACHE_DIR", None)
+            from argumentation_analysis.services import llm_cache as lc
+            lc.reset_raw_cache()

--- a/tests/unit/argumentation_analysis/services/test_llm_cache.py
+++ b/tests/unit/argumentation_analysis/services/test_llm_cache.py
@@ -19,7 +19,11 @@ from argumentation_analysis.services.llm_cache import (
     CachedChatCompletion,
     LLMCacheMiss,
     compute_cache_key,
+    compute_raw_cache_key,
+    cached_raw_chat_completion,
     get_cache_mode,
+    get_raw_cache,
+    reset_raw_cache,
     _serialize_messages,
     _serialize_response,
     _deserialize_response,
@@ -381,3 +385,190 @@ class TestCachedChatCompletion:
         cached = CachedChatCompletion(inner, cache_dir=cache_tmpdir, mode=RECORD)
         cached.close()
         cached.close()  # should not raise
+
+
+# --- Raw-path cache (direct OpenAI calls via _guarded_chat_completion) ---
+# BO-3 #1473: the CachedChatCompletion class above wraps the SK service, but the
+# direct path (_guarded_chat_completion -> client.chat.completions.create) needs
+# its own cache at the raw-kwargs level. These guard that cache on the fast gate.
+
+
+class FakeRawClient:
+    """Stand-in for an AsyncOpenAI client. Counts chat.completions.create calls."""
+
+    def __init__(self, response=None):
+        from openai.types.chat import ChatCompletion, ChatCompletionMessage
+        from openai.types.chat.chat_completion import Choice
+
+        self._response = response or ChatCompletion(
+            id="chatcmpl-x",
+            object="chat.completion",
+            created=1700000000,
+            model="gpt-5-mini",
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(role="assistant", content="live"),
+                    finish_reason="stop",
+                )
+            ],
+        )
+        self.calls = 0
+
+        async def _create(**kwargs):
+            self.calls += 1
+            return self._response
+
+        self.chat = type("C", (), {})()
+        self.chat.completions = type("P", (), {})()
+        self.chat.completions.create = _create
+
+
+@pytest.fixture
+def isolated_raw_cache(cache_tmpdir, monkeypatch):
+    """Point the raw cache at a tmpdir + reset the singleton for isolation."""
+    monkeypatch.setenv("LLM_CACHE_DIR", str(cache_tmpdir))
+    reset_raw_cache()
+    yield cache_tmpdir
+    reset_raw_cache()
+
+
+class TestComputeRawCacheKey:
+    def test_deterministic(self):
+        kw = {"model": "gpt-5-mini", "messages": [{"role": "user", "content": "hi"}]}
+        assert compute_raw_cache_key(**kw) == compute_raw_cache_key(**kw)
+
+    def test_different_messages_different_key(self):
+        k1 = compute_raw_cache_key(model="m", messages=[{"role": "user", "content": "a"}])
+        k2 = compute_raw_cache_key(model="m", messages=[{"role": "user", "content": "b"}])
+        assert k1 != k2
+
+    def test_different_model_different_key(self):
+        msgs = [{"role": "user", "content": "x"}]
+        assert compute_raw_cache_key(model="a", messages=msgs) != compute_raw_cache_key(
+            model="b", messages=msgs
+        )
+
+    def test_temperature_affects_key(self):
+        msgs = [{"role": "user", "content": "x"}]
+        k1 = compute_raw_cache_key(model="m", messages=msgs, temperature=0.0)
+        k2 = compute_raw_cache_key(model="m", messages=msgs, temperature=1.0)
+        assert k1 != k2
+
+    def test_non_deterministic_fields_ignored(self):
+        msgs = [{"role": "user", "content": "x"}]
+        # `user` (per-request user id) must NOT fragment the key.
+        k1 = compute_raw_cache_key(model="m", messages=msgs, user="alice")
+        k2 = compute_raw_cache_key(model="m", messages=msgs, user="bob")
+        assert k1 == k2
+
+
+class TestCachedRawChatCompletion:
+    @pytest.mark.asyncio
+    async def test_off_mode_passthrough(self, isolated_raw_cache):
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "off"}):
+            reset_raw_cache()
+            client = FakeRawClient()
+            r = await cached_raw_chat_completion(
+                client, model="m", messages=[{"role": "user", "content": "q"}]
+            )
+            assert r.choices[0].message.content == "live"
+            assert client.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_record_mode_caches_then_hits(self, isolated_raw_cache):
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "record"}):
+            reset_raw_cache()
+            client = FakeRawClient()
+            kw = {"model": "m", "messages": [{"role": "user", "content": "q"}]}
+            r1 = await cached_raw_chat_completion(client, **kw)
+            r2 = await cached_raw_chat_completion(client, **kw)
+            assert r1.choices[0].message.content == "live"
+            assert r2.choices[0].message.content == "live"
+            assert client.calls == 1  # second call served from cache
+
+    @pytest.mark.asyncio
+    async def test_replay_mode_hit_no_live_call(self, isolated_raw_cache):
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "record"}):
+            reset_raw_cache()
+            recorder = FakeRawClient()
+            kw = {"model": "m", "messages": [{"role": "user", "content": "q"}]}
+            await cached_raw_chat_completion(recorder, **kw)
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "replay"}):
+            reset_raw_cache()
+            replayer = FakeRawClient()
+            r = await cached_raw_chat_completion(replayer, **kw)
+            assert r.choices[0].message.content == "live"  # served from cache
+            assert replayer.calls == 0  # NO live call in replay
+
+    @pytest.mark.asyncio
+    async def test_replay_mode_miss_raises_fail_loud(self, isolated_raw_cache):
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "replay"}):
+            reset_raw_cache()
+            client = FakeRawClient()
+            with pytest.raises(LLMCacheMiss, match="Raw cache miss in replay mode"):
+                await cached_raw_chat_completion(
+                    client,
+                    model="m",
+                    messages=[{"role": "user", "content": "never seen"}],
+                )
+            assert client.calls == 0  # fail-loud: must NOT silently call the API
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_roundtrip(self, isolated_raw_cache):
+        """Function-calling responses (tool_calls) must survive the cache."""
+        from openai.types.chat import ChatCompletion, ChatCompletionMessage
+        from openai.types.chat.chat_completion import Choice
+
+        tc_response = ChatCompletion(
+            id="chatcmpl-tc",
+            object="chat.completion",
+            created=1700000000,
+            model="gpt-5-mini",
+            choices=[
+                Choice(
+                    index=0,
+                    message=ChatCompletionMessage(
+                        role="assistant",
+                        content=None,
+                        tool_calls=[
+                            {
+                                "id": "call_1",
+                                "type": "function",
+                                "function": {"name": "extract", "arguments": '{"x":1}'},
+                            }
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+        )
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "record"}):
+            reset_raw_cache()
+            recorder = FakeRawClient(response=tc_response)
+            kw = {"model": "m", "messages": [{"role": "user", "content": "call tool"}]}
+            await cached_raw_chat_completion(recorder, **kw)
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "replay"}):
+            reset_raw_cache()
+            replayer = FakeRawClient()
+            r = await cached_raw_chat_completion(replayer, **kw)
+            assert r.choices[0].message.tool_calls[0].function.name == "extract"
+            assert replayer.calls == 0
+
+
+class TestGetRawCache:
+    def test_off_returns_none(self, isolated_raw_cache):
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "off"}):
+            reset_raw_cache()
+            assert get_raw_cache() is None
+
+    def test_record_returns_cache(self, isolated_raw_cache):
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "record"}):
+            reset_raw_cache()
+            cache = get_raw_cache()
+            assert cache is not None
+
+    def test_singleton_reused(self, isolated_raw_cache):
+        with patch.dict(os.environ, {"LLM_CACHE_MODE": "record"}):
+            reset_raw_cache()
+            assert get_raw_cache() is get_raw_cache()


### PR DESCRIPTION
## Summary

Closes the **3rd axis of Epic #1470** (reproducibility, BO-3 #1473 DoD #1).

The `llm_cache` module existed with `CachedChatCompletion` + record/replay/off modes but was **never instantiated in production** — unit-tested in isolation, unwired. A `replay` toggle that wraps nothing gives **false reproducibility** (anti-théâtre #1019). This wires the raw-path cache into `_guarded_chat_completion` (the single funnel for every direct-path LLM call: extract/quality/counter/fallacy/debate/governance).

## Changes

- `argumentation_analysis/services/llm_cache.py` (+144): raw-path cache — `compute_raw_cache_key` (sha256 over deterministic kwargs only; non-deterministic fields like `user` id ignored so equivalent calls share a key), `cached_raw_chat_completion` (record/replay/off; replay miss → `LLMCacheMiss`), `get_raw_cache`/`reset_raw_cache` (shared singleton diskcache), ChatCompletion serialize/deserialize (`model_dump`/`model_validate`).
- `argumentation_analysis/orchestration/invoke_callables.py` (+13): 2 call sites `client.chat.completions.create(**kwargs)` → `cached_raw_chat_completion(client, **kwargs)`. **off = passthrough no-op** (default; no behavior change).
- `tests/unit/argumentation_analysis/services/test_llm_cache.py` (+191): 13 tests covering cache mechanics + **fail-loud contract** (`replay miss raises LLMCacheMiss AND inner.calls == 0`) + tool_calls roundtrip + non-deterministic-field-ignored.
- `tests/integration/orchestration/test_replay_cache_determinism.py` (new): DoD #1 firsthand proof.

## DoD #1 — Determinism PROVEN firsthand (not asserted)

`test_replay_cache_determinism.py` (`requires_api`+`slow`, **PASSED 188s**): records a live `democratech` run, then replays the same input against the cache → **IDENTICAL governance verdict decided firsthand on BOTH runs** (winner `arg_1`, 12 voting methods identical, `governance_decided_firsthand=True ×2`) AND identical per-phase decisional output. Only **5 live LLM calls** total, all served from cache on replay → zero new API calls.

DoD #2 (fail-loud on miss): covered by `test_replay_mode_miss_raises_fail_loud` — a replay miss raises `LLMCacheMiss` and **never silently calls the API** (`calls == 0`).

## Scope (PR1, honest)

**Direct path only** — covers the governance verdict, the core of DoD #1. **PR2 follow-up**: SK-native `create_llm_service` path (`ChatCompletionAgent`/`AgentGroupChat`) + profiling + batch + monitoring. The SK path feeds phases outside the democratech governance chain, so PR1 alone satisfies the DoD. (This matches the coordinator's R658 framing: "PR1 = direct path = core of DoD #1; don't over-scope.")

## Residual documented (not masked)

`belief_tracking`'s **decisional** output matches, but its RAW output embeds `creation_timestamp` (`datetime.now()` at `extended_belief.py:32`) — wall-clock by construction, **never reproducible** between two real runs (the phase makes no LLM call, so the cache cannot and should not equalize it). The decisional hash strips wall-clock fields to measure what the cache must reproduce. This is reported transparently, not hidden.

## Validation

- ✅ Integration test PASSED 188s (live LLM, no mock)
- ✅ 45 unit tests pass (13 new + existing)
- ✅ mypy strict **net zero** (stash-verified 10→10)
- ✅ Privacy HARD: synthetic chess-club proposition only, no corpus; cache artifacts gitignored
- ✅ No collision with po-2023 BO-4 (disjoint `invoke_callables.py` regions: this = L439/463, BO-4 = L4444+)

Awaiting coordinator admin merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>