### PR TITLE
fix(core): wire LLM replay-cache into the SK-native path (BO-3 #1473, PR2)

### DIFF
--- a/argumentation_analysis/core/llm_service.py
+++ b/argumentation_analysis/core/llm_service.py
@@ -169,7 +169,10 @@ def create_llm_service(
         )
 
     resilient_client = get_resilient_async_client()
-    llm_instance = None
+    # Typed as the SK base so the authentic OpenAI/Azure instance, and the
+    # cache wrapper (CachedChatCompletion) added below in record/replay mode,
+    # are all valid assignments (BO-3 #1473 PR2).
+    llm_instance: Union[ChatCompletionClientBase, None] = None
 
     try:
         if service_type == "OpenAIChatCompletion":
@@ -223,6 +226,34 @@ def create_llm_service(
 
     if not llm_instance:
         raise RuntimeError("La configuration du service LLM a échoué silencieusement.")
+
+    # Cache-aware SK-service wrapping (BO-3 #1473, PR2 — SK-native path):
+    # wrap the freshly built service with CachedChatCompletion so SK-native agent
+    # calls (ChatCompletionAgent.invoke / AgentGroupChat.invoke — the
+    # conversational & cluedo orchestration modes, which reach the OpenAI API
+    # through the kernel service and BYPASS the direct-path funnel
+    # ``_guarded_chat_completion`` wired in PR1) are replayed from the same disk
+    # cache. Inert in off mode (no wrapping, zero behavior change); record
+    # persists the response, replay raises ``LLMCacheMiss`` on a miss (fail-loud
+    # — never a silent live call, anti-théâtre #1019). Mirrors
+    # ``_guarded_chat_completion`` (PR1, direct path). Both layers share
+    # CACHE_DIR, so one record run seeds every call site and one replay run
+    # replays every call site (BO-3 determinism DoD).
+    #
+    # CachedChatCompletion overrides get_chat_message_contents (plural); the
+    # singular variant delegates to it via ``self`` (SK base class, line 190),
+    # so both non-streaming entry points are intercepted. Streaming is out of
+    # scope (same boundary as the direct path).
+    from argumentation_analysis.services.llm_cache import (
+        OFF,
+        CachedChatCompletion,
+        get_cache_mode,
+    )
+
+    cache_mode = get_cache_mode()
+    if cache_mode != OFF:
+        llm_instance = CachedChatCompletion(inner=llm_instance, mode=cache_mode)
+        logger.info(f"Service LLM SK wrappé avec cache (mode={cache_mode}).")
 
     return llm_instance
 

--- a/tests/integration/orchestration/test_replay_cache_sk_path.py
+++ b/tests/integration/orchestration/test_replay_cache_sk_path.py
@@ -1,0 +1,162 @@
+"""BO-3 #1473 PR2 DoD: the SK-NATIVE path is deterministic and replayed from
+cache — proven firsthand, not asserted.
+
+PR1 wired the DIRECT path (``_get_openai_client`` → ``_guarded_chat_completion``
+→ ``cached_raw_chat_completion``), which every ``democratech`` phase uses
+(including ``adversarial_debate`` — it calls ``_get_openai_client``, not the SK
+service; that is why PR1's pipeline test already showed identical per-phase
+output). PR2 wires the SK-NATIVE path: ``create_llm_service`` wraps its returned
+service with ``CachedChatCompletion``, so SK-native calls
+(``ChatCompletionAgent.invoke`` / ``AgentGroupChat.invoke`` — the conversational
+& cluedo orchestration modes) are replayed from the same disk cache.
+
+This test proves the property END-TO-END through a real SK kernel call
+(``kernel.invoke`` on a prompt function — the same ``service.get_chat_message_contents``
+path the agents use, confirmed in SK 1.40: ``ChatCompletionAgent._invoke_internal``
+→ ``chat_completion_service.get_chat_message_contents``):
+
+  #1 (determinism firsthand): record a call → replay the SAME call → the live
+     ``AsyncCompletions.create`` is invoked 0 times on replay and the response is
+     IDENTICAL.
+  #2 (fail-loud on miss): a replay call with an UNSEEN prompt raises and makes 0
+     live call (never a silent live fallback — anti-théâtre #1019).
+
+Privacy HARD: synthetic probe strings only — no corpus, no real names. Marked
+``requires_api``+``slow``: the record leg needs a real LLM.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def _counting_create(monkeypatch):
+    """Patch ``AsyncCompletions.create`` at the class level to count live calls.
+
+    SK's OpenAI handler calls ``self.client.chat.completions.create(...)`` (open_ai
+    handler L88); patching the class intercepts every AsyncOpenAI instance in the
+    process for the duration of the test (restored on teardown).
+    """
+    from openai.resources.chat.completions import AsyncCompletions
+
+    live = {"n": 0}
+    original = AsyncCompletions.create
+
+    async def _counting(self, *args, **kwargs):
+        live["n"] += 1
+        return await original(self, *args, **kwargs)
+
+    monkeypatch.setattr(AsyncCompletions, "create", _counting)
+    return live
+
+
+@pytest.mark.requires_api
+@pytest.mark.slow
+class TestReplayCacheSKPath:
+    """DoD: SK-native kernel call record → replay → 0 live call + identical."""
+
+    @pytest.mark.asyncio
+    async def test_sk_path_record_then_replay_zero_live_call(
+        self, tmp_path, monkeypatch, _counting_create
+    ):
+        # Point the SK cache at a tmp dir. CachedChatCompletion reads the
+        # module-global CACHE_DIR at construction, so patch it (create_llm_service
+        # does not pass cache_dir explicitly).
+        from argumentation_analysis.services import llm_cache as lc
+
+        monkeypatch.setattr(lc, "CACHE_DIR", tmp_path / "sk_cache")
+        monkeypatch.setenv("LLM_CACHE_MODE", "record")
+        lc.reset_raw_cache()
+
+        from semantic_kernel.functions import KernelArguments
+        from semantic_kernel.kernel import Kernel
+
+        from argumentation_analysis.core.llm_service import create_llm_service
+
+        PROMPT = (
+            "Respond with EXACTLY this token and nothing else: SK_PROBE_OK\n\n"
+            "Context: {{$input}}"
+        )
+        INPUT = "deterministic-cache-probe"
+
+        def _build_kernel():
+            kernel = Kernel()
+            svc = create_llm_service(service_id="sk_probe", force_authentic=True)
+            kernel.add_service(svc)
+            kernel.add_function(
+                function_name="probe",
+                plugin_name="probe",
+                prompt=PROMPT,
+            )
+            return kernel
+
+        def _invoke(kernel):
+            return kernel.invoke(
+                kernel.get_function("probe", "probe"),
+                KernelArguments(input=INPUT),
+            )
+
+        # --- RECORD leg ---
+        record_kernel = _build_kernel()
+        record_result = await _invoke(record_kernel)
+        record_text = str(record_result).strip()
+        assert record_text, "record leg produced an empty response"
+        assert _counting_create["n"] >= 1, (
+            "record leg made 0 live API calls — the SK path did not reach the API"
+        )
+        record_live = _counting_create["n"]
+
+        # --- REPLAY leg (same input → same cache key → 0 live call) ---
+        monkeypatch.setenv("LLM_CACHE_MODE", "replay")
+        _counting_create["n"] = 0
+        replay_kernel = _build_kernel()
+        replay_result = await _invoke(replay_kernel)
+        replay_text = str(replay_result).strip()
+
+        assert _counting_create["n"] == 0, (
+            f"replay made {_counting_create['n']} live API call(s) — the cache "
+            "did NOT intercept the SK-native path (anti-théâtre #1019: a silent "
+            "live fallback is exactly the theater this test forbids)"
+        )
+        assert replay_text == record_text, (
+            f"replay diverged from record (record={record_text!r}, "
+            f"replay={replay_text!r}) — cache returned a different response"
+        )
+        # sanity: the record leg did hit the API (else the 0-on-replay is trivial)
+        assert record_live >= 1
+
+    @pytest.mark.asyncio
+    async def test_sk_path_replay_miss_fails_loud(
+        self, tmp_path, monkeypatch, _counting_create
+    ):
+        """DoD #2: an unseen prompt in replay raises and makes 0 live call."""
+        from argumentation_analysis.services import llm_cache as lc
+
+        monkeypatch.setattr(lc, "CACHE_DIR", tmp_path / "sk_cache_miss")
+        monkeypatch.setenv("LLM_CACHE_MODE", "replay")
+        lc.reset_raw_cache()
+
+        from semantic_kernel.functions import KernelArguments
+        from semantic_kernel.kernel import Kernel
+
+        from argumentation_analysis.core.llm_service import create_llm_service
+
+        kernel = Kernel()
+        svc = create_llm_service(service_id="sk_probe", force_authentic=True)
+        kernel.add_service(svc)
+        kernel.add_function(
+            function_name="probe",
+            plugin_name="probe",
+            prompt="Respond with EXACTLY this token: MISS_PROBE\n\nInput: {{$input}}",
+        )
+
+        _counting_create["n"] = 0
+        # An unseen prompt in replay must NOT silently call the API.
+        with pytest.raises(Exception):  # LLMCacheMiss, possibly SK-wrapped
+            await kernel.invoke(
+                kernel.get_function("probe", "probe"),
+                KernelArguments(input="never-seen-before-miss-probe"),
+            )
+        assert _counting_create["n"] == 0, (
+            "replay miss silently called the API — must fail-loud instead "
+            "(anti-théâtre #1019)"
+        )

--- a/tests/unit/argumentation_analysis/core/test_llm_service_cache_wrapping.py
+++ b/tests/unit/argumentation_analysis/core/test_llm_service_cache_wrapping.py
@@ -1,0 +1,100 @@
+"""BO-3 #1473 PR2 (SK-path wiring) — unit tests, no network.
+
+``create_llm_service`` is the canonical factory for every SK-native chat service
+(the conversational ``AgentGroupChat`` / ``ChatCompletionAgent`` path, the cluedo
+orchestrator, the CLI). PR2 wraps its returned service with
+``CachedChatCompletion`` so SK-native calls are replayed from the same disk cache
+as the direct path (PR1, ``_guarded_chat_completion``). These tests assert the
+wiring CONTRACT with ``OpenAIChatCompletion`` patched out (no API key needed):
+
+- off mode  → service returned UNWRAPPED (zero behavior change)
+- record    → wrapped with CachedChatCompletion(mode=record)
+- replay    → wrapped with CachedChatCompletion(mode=replay)
+- mock path → NOT wrapped (mocks are deterministic by nature; they return early)
+
+The end-to-end live proof (record → replay → 0 live API call, identical output,
+fail-loud on miss) lives in
+``tests/integration/orchestration/test_replay_cache_sk_path.py``.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from argumentation_analysis.services.llm_cache import (
+    OFF,
+    RECORD,
+    REPLAY,
+    CachedChatCompletion,
+)
+
+
+@pytest.fixture(autouse=True)
+def _cache_env(monkeypatch):
+    """Isolate LLM_CACHE_* + provider env per test; reset the raw-cache singleton."""
+    monkeypatch.delenv("LLM_CACHE_MODE", raising=False)
+    monkeypatch.delenv("LLM_CACHE_DIR", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-not-used")
+    monkeypatch.delenv("OPENROUTER_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    from argumentation_analysis.services import llm_cache as lc
+
+    lc.reset_raw_cache()
+    yield
+    lc.reset_raw_cache()
+
+
+class _FakeOpenAIChatCompletion:
+    """Stand-in for the real SK service; only construction matters here."""
+
+    def __init__(self, *args, **kwargs):
+        self.service_id = kwargs.get("service_id")
+        self.ai_model_id = kwargs.get("ai_model_id")
+
+
+def _build(monkeypatch, tmp_path, mode):
+    """Build an authentic service with OpenAIChatCompletion patched (no network)."""
+    monkeypatch.setenv("LLM_CACHE_MODE", mode)
+    monkeypatch.setenv("LLM_CACHE_DIR", str(tmp_path / "sk_cache"))
+    with patch(
+        "argumentation_analysis.core.llm_service.OpenAIChatCompletion",
+        _FakeOpenAIChatCompletion,
+    ):
+        from argumentation_analysis.core.llm_service import create_llm_service
+
+        return create_llm_service(
+            service_id="test", model_id="gpt-test", force_authentic=True
+        )
+
+
+def test_off_mode_no_wrapping(monkeypatch, tmp_path):
+    service = _build(monkeypatch, tmp_path, OFF)
+    assert not isinstance(service, CachedChatCompletion), (
+        "off mode must NOT wrap the SK service (zero behavior change)"
+    )
+
+
+def test_record_mode_wraps(monkeypatch, tmp_path):
+    service = _build(monkeypatch, tmp_path, RECORD)
+    assert isinstance(service, CachedChatCompletion), (
+        "record mode must wrap the SK service with CachedChatCompletion (PR2)"
+    )
+    assert service.mode == RECORD
+
+
+def test_replay_mode_wraps(monkeypatch, tmp_path):
+    service = _build(monkeypatch, tmp_path, REPLAY)
+    assert isinstance(service, CachedChatCompletion)
+    assert service.mode == REPLAY
+
+
+def test_mock_path_not_wrapped(monkeypatch):
+    """Test-env mock branch returns early → never wrapped."""
+    monkeypatch.setenv("LLM_CACHE_MODE", REPLAY)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-fake-not-used")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "unit::test::mock_path (call)")
+    from argumentation_analysis.core.llm_service import create_llm_service
+
+    service = create_llm_service(service_id="test", model_id="m")
+    assert not isinstance(service, CachedChatCompletion)


### PR DESCRIPTION
## BO-3 #1473 — PR2: wire LLM replay-cache into the SK-native path

Follow-up to #1483 (PR1, direct path). **Base:** `c9476dec`.

### Context (anti-théâtre #1019 — 4th latent theatre layer)

`llm_cache.py` ships two cache layers. PR1 wired the **direct** layer (`_guarded_chat_completion` → `cached_raw_chat_completion`) — the path every `democratech` phase uses (including `adversarial_debate`, which calls `_get_openai_client`, **not** the SK service). That is why #1483's pipeline test already showed identical per-phase output.

The **SK-native** layer (`CachedChatCompletion`) existed with 20 passing unit tests but, like the raw layer before PR1, was **never instantiated in production** — testé en isolation, déconnecté. SK-native calls (`ChatCompletionAgent.invoke` / `AgentGroupChat.invoke` — the conversational & cluedo orchestration modes) reach the OpenAI API through the kernel service and **bypass** the direct funnel. A cache covering only half the LLM paths is a latent theatre. This PR closes that gap.

### Fix (additive, no-op in `off`, fail-loud on miss)

`create_llm_service` (the canonical SK-service factory) wraps its returned service with `CachedChatCompletion` when `LLM_CACHE_MODE != off`:

- `off` (default) → no wrapping, **zero behavior change**
- `record` → persists the SK response
- `replay` → cache miss raises `LLMCacheMiss` (never a silent live call)

Mirrors PR1's `_guarded_chat_completion`. Both layers share `CACHE_DIR`, so one record run seeds every call site and one replay run replays every call site. `CachedChatCompletion` overrides `get_chat_message_contents` (plural); the singular variant delegates via `self` (SK base L190), so both **non-streaming** entry points are intercepted. Streaming is out of scope (same boundary as the direct path).

### DoD #1473 mapping

| DoD item | Status |
|---|---|
| `LLM_CACHE_MODE=replay` deterministic (2 runs identical) | ✅ PR1 (#1483) — direct path |
| miss = explicit error, not silent API fallback | ✅ PR1 + this PR (both layers fail-loud) |
| Profiling documented | ⏳ follow-up (scindable) |
| Batch multi-source (≥2 sources) | ⏳ follow-up (scindable) |
| Monitoring: timing/phase + hit/miss | ⏳ follow-up (scindable) |

Profiling/batch/monitoring split as PR3 if this lands (anti-hoarding, coord's call).

### Firsthand proof (no mock)

- **4 unit tests** (`test_llm_service_cache_wrapping.py`, no key, fast gate): `create_llm_service` wraps in `record`/`replay`, returns the raw service unwrapped in `off`, and never wraps the test-env mock path.
- **Integration** (`test_replay_cache_sk_path.py`, `requires_api`+`slow`, **PASSED**): a real SK `kernel.invoke` →
  - record→replay of the same prompt = **0 live `AsyncCompletions.create` call** + **identical response** (replay 0.69 ms vs record 3.67 s)
  - a replay miss on an unseen prompt → `LLMCacheMiss`, **0 live call**

### Scope (honest)

`democratech` is **already fully deterministic via PR1** — its `adversarial_debate` phase uses the direct path. PR2 covers the **SK-native** path consumed by the conversational & cluedo orchestration modes (directly relevant to **BO-4** comparability, po-2023).

- **Lane:** `core/llm_service.py` + tests → po-2025 (0 collision with BO-4 orchestration regions).
- **mypy:** `llm_service.py` is **not** in the strict 8-file CI gate; local mypy 11→10 (annotation fix also clears a pre-existing assignment error).
- **Pre-existing failures:** 3 stale tests in `test_llm_service_extended.py` (model substitution / env drift) — confirmed failing on `c9476dec` without this change.
- **Privacy HARD:** synthetic probe strings only, 0 corpus, cache gitignored.

Closes part of #1473 (SK-native determinism + fail-loud). Refs #1470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
