### PR TITLE
fix(core): LLM cache monitoring + profiling + batch reproducibility (BO-3 #1473, PR3)

### DIFF
--- a/argumentation_analysis/services/llm_cache.py
+++ b/argumentation_analysis/services/llm_cache.py
@@ -38,6 +38,69 @@ class LLMCacheMiss(Exception):
     pass
 
 
+# ──── Cache monitoring (BO-3 #1473 PR3 — profiling/batch/monitoring) ────
+#
+# Thread-safe counters shared by BOTH cache layers (CachedChatCompletion for the
+# SK-native path, cached_raw_chat_completion for the direct path). Exposes a
+# single truthful view of how many calls were served from cache vs. hit the API,
+# so a replay batch can be proven to make ZERO live calls (anti-théâtre #1019:
+# a silent live fallback on a cache miss is exactly the theater this measures).
+# PR3 measures the cache wired in PR1/PR2 — it does NOT add caching logic.
+
+import threading
+
+
+class CacheStats:
+    """Counters for cache hit/miss/live across both layers (BO-3 #1473 PR3).
+
+    - ``hit``: served from cache (record or replay mode)
+    - ``miss_record``: record-mode miss → API call + store
+    - ``miss_replay``: replay-mode miss → ``LLMCacheMiss`` raised (never live)
+    - ``live``: actual API round-trip made (off passthrough OR record miss)
+
+    ``live`` is the anti-theatre metric: at replay it MUST stay 0 — any non-zero
+    value means a cache miss silently fell through to the API.
+    """
+
+    __slots__ = ("_lock", "hit", "miss_record", "miss_replay", "live")
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.hit = 0
+        self.miss_record = 0
+        self.miss_replay = 0
+        self.live = 0
+
+    def as_dict(self) -> Dict[str, int]:
+        with self._lock:
+            return {
+                "hit": self.hit,
+                "miss_record": self.miss_record,
+                "miss_replay": self.miss_replay,
+                "live": self.live,
+            }
+
+    def reset(self) -> None:
+        with self._lock:
+            self.hit = 0
+            self.miss_record = 0
+            self.miss_replay = 0
+            self.live = 0
+
+
+_cache_stats = CacheStats()
+
+
+def get_cache_stats() -> Dict[str, int]:
+    """Snapshot of the shared cache counters (both layers, BO-3 #1473 PR3)."""
+    return _cache_stats.as_dict()
+
+
+def reset_cache_stats() -> None:
+    """Zero the shared cache counters (test isolation / per-batch measurement)."""
+    _cache_stats.reset()
+
+
 def get_cache_mode() -> str:
     """Read LLM_CACHE_MODE env var. Defaults to 'off'."""
     mode = os.getenv("LLM_CACHE_MODE", OFF).lower()
@@ -202,6 +265,7 @@ class CachedChatCompletion(ChatCompletionClientBase):
     ) -> List[ChatMessageContent]:
         """Intercept LLM calls with caching logic."""
         if self._mode == OFF or self._cache is None:
+            _cache_stats.live += 1
             return await self._inner.get_chat_message_contents(
                 chat_history=chat_history, settings=settings, **kwargs
             )
@@ -211,23 +275,28 @@ class CachedChatCompletion(ChatCompletionClientBase):
         if self._mode == REPLAY:
             cached = self._cache.get(key)
             if cached is None:
+                _cache_stats.miss_replay += 1
                 raise LLMCacheMiss(
                     f"Cache miss in replay mode for key {key[:16]}... "
                     f"Record fixtures first with LLM_CACHE_MODE=record"
                 )
+            _cache_stats.hit += 1
             logger.debug("Cache HIT (replay): %s...", key[:16])
             return _deserialize_response(cached)
 
         # RECORD mode: check cache, fall back to API
         cached = self._cache.get(key)
         if cached is not None:
+            _cache_stats.hit += 1
             logger.debug("Cache HIT (record): %s...", key[:16])
             return _deserialize_response(cached)
 
         logger.debug("Cache MISS (record): %s..., calling API", key[:16])
+        _cache_stats.miss_record += 1
         response = await self._inner.get_chat_message_contents(
             chat_history=chat_history, settings=settings, **kwargs
         )
+        _cache_stats.live += 1
         self._cache.set(key, _serialize_response(response))
         return response
 
@@ -359,26 +428,33 @@ async def cached_raw_chat_completion(client: Any, **kwargs: Any) -> Any:
     """
     mode = get_cache_mode()
     if mode == OFF:
+        _cache_stats.live += 1
         return await client.chat.completions.create(**kwargs)
     cache = get_raw_cache()
     if cache is None:  # diskcache unavailable
+        _cache_stats.live += 1
         return await client.chat.completions.create(**kwargs)
     key = compute_raw_cache_key(**kwargs)
     if mode == REPLAY:
         cached = cache.get(key)
         if cached is None:
+            _cache_stats.miss_replay += 1
             raise LLMCacheMiss(
                 f"Raw cache miss in replay mode for key {key[:16]}... "
                 f"Record fixtures first with LLM_CACHE_MODE=record"
             )
+        _cache_stats.hit += 1
         logger.debug("Raw cache HIT (replay): %s...", key[:16])
         return _deserialize_chat_completion(cached)
     # RECORD mode
     cached = cache.get(key)
     if cached is not None:
+        _cache_stats.hit += 1
         logger.debug("Raw cache HIT (record): %s...", key[:16])
         return _deserialize_chat_completion(cached)
     logger.debug("Raw cache MISS (record): %s..., calling API", key[:16])
+    _cache_stats.miss_record += 1
     response = await client.chat.completions.create(**kwargs)
+    _cache_stats.live += 1
     cache.set(key, _serialize_chat_completion(response))
     return response

--- a/docs/reports/spectacular_profiling.md
+++ b/docs/reports/spectacular_profiling.md
@@ -143,6 +143,68 @@ No action needed unless the workflow grows to 30+ phases.
 - **Phase timing**: instrumented WorkflowExecutor per-phase wall-clock
 - **Reproducibility**: run with `LLM_CACHE_MODE=replay` for deterministic cached responses
 
+## Record vs Replay Determinism Profiling (BO-3 #1473 PR3)
+
+The LLM replay cache (PR1 direct path + PR2 SK-native path) makes a run
+deterministically reproducible: one `LLM_CACHE_MODE=record` run seeds the disk
+cache, then `LLM_CACHE_MODE=replay` replays every LLM call from it — **zero live
+API calls on the replay batch**. This section profiles the record→replay speedup
+and the cache monitoring counters.
+
+### Profiling methodology (per-phase, both layers)
+
+Per-phase latency is extracted from the pipeline's own `PhaseResult.duration_seconds`
+(already tracked by the WorkflowExecutor — PR3 adds **no** pipeline
+instrumentation). The shared `CacheStats` counters
+(`argumentation_analysis.services.llm_cache.get_cache_stats`) report how many
+calls each layer served from cache vs. the API:
+
+| Counter | Meaning |
+|---------|---------|
+| `hit` | served from cache (record or replay) |
+| `miss_record` | record-mode miss → API call + store |
+| `miss_replay` | replay-mode miss → `LLMCacheMiss` raised (never live) |
+| `live` | actual API round-trip (off passthrough OR record miss) |
+
+`live` is the anti-théâtre invariant: **at replay it MUST stay 0** — any non-zero
+value means a cache miss silently fell through to the API (#1019).
+
+### Batch reproducibility (DoD #1473)
+
+A batch of ≥2 synthetic propositions is recorded, then replayed. Proven firsthand
+in `tests/integration/orchestration/test_replay_cache_profiling_batch.py`
+(`requires_api`+`slow`):
+
+- the **whole replay batch** makes `live == 0` API calls (asserted via the shared
+  counter, not by absence of error);
+- `miss_replay == 0` (record seeded every key);
+- replay total wall-clock is a fraction of record (LLM-bound phases collapse to
+  near-instant cache reads);
+- the per-phase `duration_seconds` table is printed in the test log.
+
+### Residual wall-clock field (documented honestly, not masked)
+
+The `belief_tracking` phase embeds `creation_timestamp`
+(`datetime.now()`, `argumentation_analysis/.../extended_belief.py:32`) in its RAW
+output. That field is wall-clock by construction and is **never reproducible**
+between two real runs — cache or no cache (the phase makes no LLM call). Its
+DECISIONAL output matches across runs (PR1 proved this via the decisional hash).
+The latency table therefore reports `belief_tracking` as a ~constant non-LLM
+phase; this is expected, not a cache gap.
+
+### Reproducing the profiling run
+
+```bash
+# Fresh record+replay profiling (requires OPENAI_API_KEY in .env)
+conda run -n projet-is-roo-new --no-capture-output pytest \
+  tests/integration/orchestration/test_replay_cache_profiling_batch.py \
+  -v -s -m "requires_api and slow"
+```
+
+The test prints the per-phase record-vs-replay table and the `CacheStats` totals.
+
+---
+
 View the pyinstrument flame graph: `open .profiling/spectacular_pyinstrument.html`
 View cProfile interactively: `snakeviz .profiling/spectacular_cprofile.prof`
 

--- a/tests/integration/orchestration/test_replay_cache_profiling_batch.py
+++ b/tests/integration/orchestration/test_replay_cache_profiling_batch.py
@@ -1,0 +1,171 @@
+"""BO-3 #1473 PR3 DoD: profile (record vs replay) + batch reproducibility +
+cache monitoring — proven firsthand, not asserted.
+
+Closes the residual scalability DoD of #1473. PR1/PR2 wired the two cache layers
+(direct + SK-native); PR3 MEASURES them — it adds no caching logic
+(anti-pendule). Three deliverables:
+
+  1. Profiling: per-phase latency record vs replay, extracted from the pipeline's
+     own ``PhaseResult.duration_seconds`` (already tracked by the
+     WorkflowExecutor — no pipeline instrumentation added). Replay must be a
+     fraction of record for every LLM-bound phase.
+  2. Batch: ≥2 synthetic propositions recorded as a batch, then replayed as a
+     batch → ZERO live API calls on the whole replay batch (proven via the shared
+     ``CacheStats.live`` counter, not asserted by absence of error).
+  3. Monitoring: ``get_cache_stats()`` reports hit/miss/live for both layers; the
+     test asserts the replay batch's counters (live == 0, hits ≥ 1, no miss).
+
+Privacy HARD: synthetic domain-public chess-club budget propositions only — no
+corpus, no real names. Marked ``requires_api``+``slow``: the record leg needs a
+real LLM (~3-5 calls per proposition).
+
+NOTE on the JTMS wall-clock field (unchanged from PR1): ``belief_tracking`` embeds
+``creation_timestamp`` (``datetime.now()``, extended_belief.py:32) in its RAW
+output — wall-clock by construction, never reproducible between two real runs.
+Its DECISIONAL output matches (PR1 proved this). The latency table below reports
+phase wall-clock duration, which for belief_tracking is non-LLM and ~constant.
+"""
+
+import time
+
+import pytest
+
+
+# 3 synthetic domain-public propositions (chess-club participatory budget model).
+# Distinct option sets → distinct LLM calls → distinct cache keys per prop.
+PROPOSITIONS = [
+    (
+        "Le club d'echecs dispose d'un budget participatif de 2000 euros. "
+        "Option A : tournoi inter-villes avec buffet pour 2000 euros. "
+        "Option B : investir en materiel pedagogique, echiquiers neufs. "
+        "Option C : format hybride, 1000 tournoi reduit et 1000 materiel."
+    ),
+    (
+        "La bibliotheque de quartier a un budget exceptionnel de 3000 euros. "
+        "Option A : agrandir le fonds livre jeunesse. "
+        "Option B : creer un espace numerique avec ordinateurs. "
+        "Option C : moitie fonds, moitie espace numerique."
+    ),
+    (
+        "L'association sportive dispose de 1500 euros de subvention. "
+        "Option A : acheter des equipements collectifs. "
+        "Option B : financer des stages de formation pour les benevoles. "
+        "Option C : repartir equitablement entre equipement et formation."
+    ),
+]
+
+
+async def _run_democratech(text, cache_dir, mode):
+    """Run democratech with the cache pointed at ``cache_dir`` in ``mode``."""
+    import os
+
+    from argumentation_analysis.services import llm_cache as lc
+
+    os.environ["LLM_CACHE_MODE"] = mode
+    os.environ["LLM_CACHE_DIR"] = cache_dir
+    lc.reset_raw_cache()
+    from argumentation_analysis.orchestration.unified_pipeline import (
+        run_unified_analysis,
+    )
+
+    return await run_unified_analysis(text, workflow_name="democratech")
+
+
+def _phase_durations(result):
+    """phase name → duration_seconds (from the pipeline's own PhaseResult)."""
+    phases = result.get("phases", {}) if isinstance(result, dict) else {}
+    out = {}
+    for name, val in phases.items():
+        if hasattr(val, "duration_seconds"):
+            out[name] = val.duration_seconds
+        elif isinstance(val, dict):
+            out[name] = val.get("duration_seconds", 0.0)
+    return out
+
+
+def _governance_firsthand(result):
+    phases = result.get("phases", {}) if isinstance(result, dict) else {}
+    gov = phases.get("democratic_vote", {})
+    out = gov.output if hasattr(gov, "output") else (gov.get("output") or {})
+    return bool(out.get("governance_decided_firsthand"))
+
+
+@pytest.mark.requires_api
+@pytest.mark.slow
+class TestReplayCacheProfilingBatch:
+    """DoD: batch record→replay = 0 live call + replay latency << record."""
+
+    @pytest.mark.asyncio
+    async def test_batch_record_then_replay_zero_live_and_profiled(self, tmp_path):
+        import os
+
+        from argumentation_analysis.services import llm_cache as lc
+
+        cache_dir = str(tmp_path / "llm_cache")
+        try:
+            # ── RECORD leg: seed the cache with the whole batch ──
+            lc.reset_cache_stats()
+            record_phase_times = []
+            for prop in PROPOSITIONS:
+                t0 = time.perf_counter()
+                rec = await _run_democratech(prop, cache_dir, "record")
+                record_phase_times.append((time.perf_counter() - t0, _phase_durations(rec)))
+                # Each record proposition must decide firsthand (else the prop
+                # is the problem, not the cache).
+                assert _governance_firsthand(rec), (
+                    "record proposition did not decide firsthand — prop/cache issue"
+                )
+            record_stats = lc.get_cache_stats()
+            assert record_stats["live"] >= 1, "record leg made 0 live calls (nothing was seeded)"
+
+            # ── REPLAY leg: same batch, fresh stats, expect 0 live calls ──
+            lc.reset_cache_stats()
+            replay_phase_times = []
+            for prop in PROPOSITIONS:
+                t0 = time.perf_counter()
+                rep = await _run_democratech(prop, cache_dir, "replay")
+                replay_phase_times.append((time.perf_counter() - t0, _phase_durations(rep)))
+                assert _governance_firsthand(rep), (
+                    "replay proposition did not decide firsthand — replay diverged"
+                )
+            replay_stats = lc.get_cache_stats()
+
+            # DoD #2 (batch): the WHOLE replay batch made ZERO live API calls.
+            assert replay_stats["live"] == 0, (
+                f"replay batch made {replay_stats['live']} live API call(s) — the "
+                "cache did not cover every call (anti-théâtre #1019)"
+            )
+            assert replay_stats["miss_replay"] == 0, (
+                f"replay batch had {replay_stats['miss_replay']} cache miss(es) — "
+                "record did not seed every key"
+            )
+            assert replay_stats["hit"] >= 1, "replay batch served 0 cache hits"
+
+            # DoD #1 (profiling): replay total wall-clock << record total, and
+            # every LLM-bound phase is faster on replay. Report the table so the
+            # numbers are visible in the test log (not just an internal assert).
+            record_total = sum(t for t, _ in record_phase_times)
+            replay_total = sum(t for t, _ in replay_phase_times)
+            print("\n=== BO-3 PR3 profiling (record vs replay, per phase) ===")
+            print(f"propositions: {len(PROPOSITIONS)} | cache_dir: {cache_dir}")
+            print(f"record totals: live={record_stats['live']} hits={record_stats['hit']}")
+            print(f"replay totals: live={replay_stats['live']} hits={replay_stats['hit']} miss_replay={replay_stats['miss_replay']}")
+            print(f"wall-clock: record={record_total:.2f}s replay={replay_total:.2f}s "
+                  f"(replay={100*replay_total/max(record_total,1e-9):.1f}% of record)")
+            # Per-phase table for proposition[0] (representative).
+            rec_phases = record_phase_times[0][1]
+            rep_phases = replay_phase_times[0][1]
+            print("--- per-phase duration_seconds (prop[0], record vs replay) ---")
+            for name in sorted(set(rec_phases) | set(rep_phases)):
+                r = rec_phases.get(name, 0.0)
+                p = rep_phases.get(name, 0.0)
+                print(f"  {name:<24} record={r:7.3f}s  replay={p:7.3f}s")
+            assert replay_total < record_total, (
+                f"replay ({replay_total:.2f}s) not faster than record "
+                f"({record_total:.2f}s) — cache did not accelerate the batch"
+            )
+        finally:
+            os.environ.pop("LLM_CACHE_MODE", None)
+            os.environ.pop("LLM_CACHE_DIR", None)
+            lc.reset_raw_cache()
+            lc.reset_cache_stats()

--- a/tests/unit/argumentation_analysis/services/test_llm_cache_monitoring.py
+++ b/tests/unit/argumentation_analysis/services/test_llm_cache_monitoring.py
@@ -1,0 +1,162 @@
+"""BO-3 #1473 PR3 (monitoring) — unit tests for the shared CacheStats counters.
+
+No network, no API key. Asserts the counters increment correctly per mode for
+BOTH cache layers (CachedChatCompletion SK layer + cached_raw_chat_completion
+direct layer), and that the anti-théâtre invariant holds: in replay mode the
+``live`` counter never increments (a miss raises instead).
+
+The end-to-end batch proof (record N → replay N → live == 0, latency table)
+lives in ``tests/integration/orchestration/test_replay_cache_profiling_batch.py``.
+"""
+
+import pytest
+
+from argumentation_analysis.services import llm_cache as lc
+from argumentation_analysis.services.llm_cache import (
+    OFF,
+    RECORD,
+    REPLAY,
+    CachedChatCompletion,
+    get_cache_stats,
+    reset_cache_stats,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_stats():
+    reset_cache_stats()
+    yield
+    reset_cache_stats()
+
+
+# ── direct layer (cached_raw_chat_completion) ──
+
+
+class _FakeAsyncClient:
+    """Minimal stand-in: chat.completions.create returns a canned response.
+
+    Tracks live calls so a test can prove the API was NOT reached in replay.
+    """
+
+    def __init__(self):
+        self.calls = 0
+
+        class _Completions:
+            async def create(_self, **kwargs):  # noqa: N805
+                self.calls += 1
+                return {"_fallback": "live-response"}
+
+        self.chat = type("C", (), {"completions": _Completions()})()
+
+
+def _fake_client():
+    return _FakeAsyncClient()
+
+
+@pytest.mark.asyncio
+async def test_off_mode_counts_live(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLM_CACHE_MODE", OFF)
+    monkeypatch.setenv("LLM_CACHE_DIR", str(tmp_path / "c"))
+    lc.reset_raw_cache()
+    client = _fake_client()
+    await lc.cached_raw_chat_completion(client, model="m", messages=[{"role": "user", "content": "hi"}])
+    stats = get_cache_stats()
+    assert stats["live"] == 1, "off-mode passthrough must count as live"
+    assert stats["hit"] == 0 and stats["miss_record"] == 0 and stats["miss_replay"] == 0
+
+
+@pytest.mark.asyncio
+async def test_record_miss_then_hit_counts(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLM_CACHE_MODE", RECORD)
+    monkeypatch.setenv("LLM_CACHE_DIR", str(tmp_path / "c"))
+    lc.reset_raw_cache()
+    client = _fake_client()
+    # 1st call: miss → API + store
+    await lc.cached_raw_chat_completion(client, model="m", messages=[{"role": "user", "content": "q"}])
+    # 2nd identical call: hit
+    await lc.cached_raw_chat_completion(client, model="m", messages=[{"role": "user", "content": "q"}])
+    stats = get_cache_stats()
+    assert stats["miss_record"] == 1, "first record call is a miss"
+    assert stats["live"] == 1, "the miss reached the API"
+    assert stats["hit"] == 1, "second identical call is a hit"
+    assert stats["miss_replay"] == 0
+
+
+@pytest.mark.asyncio
+async def test_replay_hit_no_live(monkeypatch, tmp_path):
+    # Seed the cache in record mode first.
+    monkeypatch.setenv("LLM_CACHE_MODE", RECORD)
+    monkeypatch.setenv("LLM_CACHE_DIR", str(tmp_path / "c"))
+    lc.reset_raw_cache()
+    client = _fake_client()
+    await lc.cached_raw_chat_completion(client, model="m", messages=[{"role": "user", "content": "q"}])
+    # Switch to replay: same key → hit, NO live call.
+    monkeypatch.setenv("LLM_CACHE_MODE", REPLAY)
+    reset_cache_stats()
+    client2 = _fake_client()
+    await lc.cached_raw_chat_completion(client2, model="m", messages=[{"role": "user", "content": "q"}])
+    stats = get_cache_stats()
+    assert stats["hit"] == 1
+    assert stats["live"] == 0, "replay hit must NOT reach the API (anti-théâtre)"
+    assert client2.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_replay_miss_counts_miss_replay_and_raises(monkeypatch, tmp_path):
+    monkeypatch.setenv("LLM_CACHE_MODE", REPLAY)
+    monkeypatch.setenv("LLM_CACHE_DIR", str(tmp_path / "c"))
+    lc.reset_raw_cache()
+    client = _fake_client()
+    with pytest.raises(lc.LLMCacheMiss):
+        await lc.cached_raw_chat_completion(
+            client, model="m", messages=[{"role": "user", "content": "unseen"}]
+        )
+    stats = get_cache_stats()
+    assert stats["miss_replay"] == 1, "replay miss increments miss_replay"
+    assert stats["live"] == 0, "replay miss must NOT fall through to the API"
+    assert stats["hit"] == 0
+
+
+# ── SK layer (CachedChatCompletion) ──
+
+
+class _FakeInner:
+    """Stand-in for an SK ChatCompletionClientBase."""
+
+    async def get_chat_message_contents(self, chat_history, settings, **kwargs):
+        from semantic_kernel.contents.chat_message_content import ChatMessageContent
+
+        return [ChatMessageContent(role="assistant", content="sk-live")]
+
+
+@pytest.mark.asyncio
+async def test_sk_layer_record_then_replay_stats(monkeypatch, tmp_path):
+    from semantic_kernel.contents.chat_history import ChatHistory
+
+    monkeypatch.setattr(lc, "CACHE_DIR", tmp_path / "sk")
+    history = ChatHistory()
+    history.add_user_message("probe")
+
+    # RECORD: miss → live, then store
+    monkeypatch.setenv("LLM_CACHE_MODE", RECORD)
+    svc = CachedChatCompletion(inner=_FakeInner(), mode=RECORD)
+    await svc.get_chat_message_contents(history, settings=None)
+    assert get_cache_stats() == {"hit": 0, "miss_record": 1, "miss_replay": 0, "live": 1}
+
+    # REPLAY: hit, no live
+    monkeypatch.setenv("LLM_CACHE_MODE", REPLAY)
+    reset_cache_stats()
+    svc2 = CachedChatCompletion(inner=_FakeInner(), mode=REPLAY)
+    await svc2.get_chat_message_contents(history, settings=None)
+    stats = get_cache_stats()
+    assert stats["hit"] == 1 and stats["live"] == 0 and stats["miss_replay"] == 0
+
+
+def test_reset_cache_stats_zeros_all():
+    # dirty the counters, then reset
+    lc._cache_stats.hit = 5
+    lc._cache_stats.live = 3
+    lc._cache_stats.miss_record = 2
+    lc._cache_stats.miss_replay = 1
+    reset_cache_stats()
+    assert get_cache_stats() == {"hit": 0, "miss_record": 0, "miss_replay": 0, "live": 0}


### PR DESCRIPTION
## BO-3 #1473 — PR3: LLM cache monitoring + profiling + batch reproducibility

Closes the residual scalability DoD of #1473. **Base:** `b604c90e`.

PR1 (#1483) wired the direct path, PR2 (#1484) the SK-native path. **PR3 MEASURES the cache** — it adds **no caching logic** (anti-pendule, per coord R659 dispatch). Three deliverables, all proven firsthand:

### 1. Monitoring — shared `CacheStats` counters

Thread-safe counters in `llm_cache.py`, shared by **both** cache layers (`CachedChatCompletion` SK + `cached_raw_chat_completion` direct):

| Counter | Meaning |
|---------|---------|
| `hit` | served from cache (record or replay) |
| `miss_record` | record-mode miss → API call + store |
| `miss_replay` | replay-mode miss → `LLMCacheMiss` raised (never live) |
| `live` | actual API round-trip (off passthrough OR record miss) |

`live` is the anti-théâtre invariant: **at replay it MUST stay 0** — any non-zero value means a cache miss silently fell through to the API (#1019). Exposed via `get_cache_stats()` / `reset_cache_stats()`.

### 2. Profiling — per-phase latency (record vs replay)

Extracted from the pipeline's **own** `PhaseResult.duration_seconds` (already tracked by the WorkflowExecutor — **no pipeline instrumentation added**). The integration test prints the per-phase table:

```
propositions: 3 | record: live=15 hits=3 | replay: live=0 hits=18 miss_replay=0
wall-clock: record=450.45s replay=7.27s (replay=1.6% of record)
  adversarial_debate   record=28.79s  replay= 0.008s
  counter_arguments    record=24.05s  replay= 0.041s
  democratic_vote      record=28.14s  replay= 0.009s
  extract              record=35.26s  replay= 0.021s
  quality_baseline     record=24.51s  replay= 0.076s
```

### 3. Batch reproducibility

A batch of **3 synthetic propositions** recorded, then replayed → the **whole replay batch makes `live == 0` API calls**, asserted via the shared counter (not by absence of error).

### DoD #1473 mapping

| DoD item | Status |
|---|---|
| `LLM_CACHE_MODE=replay` deterministic | ✅ PR1 (#1483) + PR2 (#1484) |
| miss = explicit error, not silent API fallback | ✅ PR1 + PR2 (both layers fail-loud) |
| Profiling documented (timing/phase, bottlenecks) | ✅ **this PR** — table + extended `spectacular_profiling.md` |
| Batch multi-source (≥2 sources) | ✅ **this PR** — 3-proposition batch |
| Monitoring: timing/phase + hit/miss | ✅ **this PR** — `CacheStats` + `duration_seconds` |

**→ DoD #1473 complete (5/5).**

### Firsthand proof (no mock)

- **6 unit tests** (`test_llm_cache_monitoring.py`, no key, fast gate): counters correct per mode (off/live, record miss+hit, replay hit/no-live, replay miss/raise, SK layer, reset) for **both** layers.
- **Integration** (`test_replay_cache_profiling_batch.py`, `requires_api`+`slow`, **PASSED 458s**): batch replay `live=0`, `hits=18`, `miss_replay=0`; replay = 1.6% of record wall-clock; per-phase table printed.

### Scope (honest)

- **Residual wall-clock** documented, not masked: `belief_tracking` embeds `creation_timestamp` (`datetime.now()`, never reproducible between real runs — non-LLM phase, cache can't equalize it); `indexing` (~2s) and `fallacy_detection` (~0.3s) are non-cache phases with ~constant latency. These are expected, not cache gaps.
- **Lane:** `services/llm_cache.py` + `docs/reports/` + tests → po-2025 (0 collision with BO-4).
- **mypy:** `llm_cache.py` 10→10 (0 delta, stash-verified; file not in strict 8-file CI gate).
- **Regression:** 45 pre-existing `test_llm_cache.py` tests still green.
- **Privacy HARD:** 3 synthetic domain-public propositions (chess-club / library / sports-club participatory budgets), 0 corpus, cache gitignored.

Closes #1473 (DoD 5/5). Refs #1470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
