### PR TITLE
feat(demo): democratech deliberation demo bundle — synthetic propositions (BO-2 #1472 residual)

### DIFF
--- a/examples/democratech_deliberation/README.md
+++ b/examples/democratech_deliberation/README.md
@@ -1,0 +1,45 @@
+# Democratech Deliberation Demo (BO-2 #1472)
+
+A bundle-able demo of the `democratech` workflow: runs a multi-agent citizen
+deliberation E2E over a set of **synthetic, domain-public** propositions and
+prints a readable per-proposition verdict (winner, voting methods, consensus).
+
+## What it demonstrates
+
+The `democratech` workflow decides **firsthand with real LLM agents** (no mock) —
+the 3rd north-star axis of Epic #1470. Each proposition is subjected to the full
+10-phase deliberation (extract → quality → counter-arguments → adversarial
+debate → democratic vote), and the governance phase renders a genuine collective
+choice via 12 voting methods (majority, Borda, Condorcet, approval, STV, …).
+
+## Run
+
+```bash
+conda run -n projet-is-roo-new --no-capture-output \
+  python examples/democratech_deliberation/run_democratech_demo.py
+
+# Limit to 3 propositions, or emit compact JSON
+python run_democratech_demo.py --limit 3
+python run_democratech_demo.py --json
+```
+
+Requires an LLM key (`OPENAI_API_KEY` or `OPENROUTER_API_KEY` + `OPENROUTER_BASE_URL`).
+
+## Output
+
+A table: per proposition — `Firsthand` (decided with real agents), `Winner`
+(Condorcet), `#Methods` (how many voting methods agreed), `Consensus`. A
+per-phase honesty row shows which phases ran or were honestly degraded.
+
+## Privacy HARD
+
+Every proposition is **synthetic and domain-public** (chess club, library,
+sports association, park, music school — generic participatory-budget models).
+**No corpus, no real names, no `raw_text`.** Opaque IDs (`prop_A`..`prop_E`) on
+all output. See `synthetic_proposals.py`.
+
+## Anti-théâtre
+
+The `Firsthand` column is the truth flag: a proposition that fails to decide is
+reported as `no`, never fabricated. The demo reports honest-partial results
+(N/5 decide) as-is.

--- a/examples/democratech_deliberation/run_democratech_demo.py
+++ b/examples/democratech_deliberation/run_democratech_demo.py
@@ -1,0 +1,181 @@
+"""Democratech deliberation demo driver (BO-2 #1472 residual).
+
+Runs the ``democratech`` workflow E2E over the bundle of synthetic domain-public
+propositions (``synthetic_proposals.py``) and prints a READABLE per-proposition
+verdict — winner, voting methods, consensus, honest-degraded flags. Bundle-able
+as course / soutenance demo material.
+
+Privacy HARD (#1472): every proposition is synthetic + domain-public. No corpus,
+no real names, no ``raw_text``. Opaque IDs (prop_A..prop_E) on all output.
+
+Anti-théâtre (#1019): the demo runs the workflow with REAL agents (no mock) and
+reports each verdict's ``governance_decided_firsthand`` flag — a proposition
+that fails to decide is reported as such, never fabricated.
+
+Usage:
+    conda run -n projet-is-roo-new --no-capture-output \\
+        python examples/democratech_deliberation/run_democratech_demo.py
+
+    # Limit to N propositions (default: all 5)
+    python run_democratech_demo.py --limit 3
+
+    # JSON output (machine-readable) instead of the readable table
+    python run_democratech_demo.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def _ensure_api_key() -> Optional[str]:
+    """Return the active API key or print a clear skip reason."""
+    from dotenv import load_dotenv
+
+    load_dotenv()
+    if os.environ.get("OPENROUTER_API_KEY") and os.environ.get("OPENROUTER_BASE_URL"):
+        return "openrouter"
+    if os.environ.get("OPENAI_API_KEY"):
+        return "openai"
+    return None
+
+
+def _phase_output(phase_val: Any) -> Dict[str, Any]:
+    if phase_val is None:
+        return {}
+    if hasattr(phase_val, "output"):
+        return phase_val.output or {}
+    if isinstance(phase_val, dict):
+        return phase_val.get("output") or phase_val
+    return {}
+
+
+def _extract_verdict(result: Dict[str, Any]) -> Dict[str, Any]:
+    """Pull the governance verdict + honest-degraded flags from a run result."""
+    phases = result.get("phases", {}) if isinstance(result, dict) else {}
+    gov = _phase_output(phases.get("democratic_vote", {}))
+    verdict = gov.get("governance_verdict") or {}
+    methods = dict(verdict.get("winners_per_method", {}))
+    return {
+        "decided_firsthand": bool(gov.get("governance_decided_firsthand")),
+        "winner": verdict.get("condorcet_winner"),
+        "n_methods": len(methods),
+        "methods": methods,
+        "consensus_rate": gov.get("consensus_rate"),
+        "component_used": gov.get("component_used"),
+    }
+
+
+def _phase_status_table(result: Dict[str, Any]) -> List[Tuple[str, str, bool]]:
+    """phase name → (status, component, degraded) for the per-phase honesty row."""
+    phases = result.get("phases", {}) if isinstance(result, dict) else {}
+    rows = []
+    for name in sorted(phases):
+        val = phases[name]
+        status = getattr(val, "status", None)
+        status_str = getattr(status, "value", str(status)) if status else "?"
+        out = _phase_output(val)
+        degraded = bool(out.get("degraded") or out.get(f"{name}_degraded"))
+        comp = getattr(val, "component_used", None) or out.get("component_used") or "-"
+        rows.append((name, f"{status_str}{'/DEGRADED' if degraded else ''}", comp))
+    return rows
+
+
+async def run_one(pid: str, text: str) -> Dict[str, Any]:
+    """Run democratech on one proposition; return {verdict, phase_rows}."""
+    from argumentation_analysis.workflows.democratech import run_deliberation
+
+    result = await run_deliberation(text)
+    return {
+        "id": pid,
+        "verdict": _extract_verdict(result),
+        "phase_rows": _phase_status_table(result),
+    }
+
+
+async def run_demo(limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    from synthetic_proposals import get_propositions
+
+    props = get_propositions()
+    items = list(props.items())[: (limit or len(props))]
+    results = []
+    for pid, meta in items:
+        print(f"\n→ Deliberating {pid} ({meta['label']}) …", flush=True)
+        res = await run_one(pid, meta["text"])
+        res["label"] = meta["label"]
+        results.append(res)
+    return results
+
+
+def _print_table(results: List[Dict[str, Any]]) -> None:
+    print("\n" + "=" * 78)
+    print(" DEMOCRATECH DELIBERATION — per-proposition verdict ")
+    print("=" * 78)
+    hdr = f"{'ID':<7} {'Firsthand':<10} {'Winner':<10} {'#Methods':<9} {'Consensus':<10}"
+    print(hdr)
+    print("-" * 78)
+    for r in results:
+        v = r["verdict"]
+        firsthand = "YES" if v["decided_firsthand"] else "no"
+        winner = v["winner"] or "—"
+        consensus = (
+            f"{v['consensus_rate']:.2f}"
+            if isinstance(v["consensus_rate"], (int, float))
+            else "—"
+        )
+        print(f"{r['id']:<7} {firsthand:<10} {str(winner):<10} "
+              f"{v['n_methods']:<9} {consensus:<10}")
+    print("-" * 78)
+    n_decided = sum(1 for r in results if r["verdict"]["decided_firsthand"])
+    print(f" {n_decided}/{len(results)} propositions decided firsthand "
+          f"(anti-théâtre: undecided ones reported, never fabricated).")
+    # Per-phase honesty row for the first proposition (representative).
+    if results and results[0]["phase_rows"]:
+        print("\n Per-phase status (first proposition, honest-degraded shown):")
+        for name, status, comp in results[0]["phase_rows"]:
+            print(f"   {name:<22} {status:<16} {comp}")
+    print("=" * 78)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Democratech deliberation demo.")
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Limit to N propositions (default: all 5).")
+    parser.add_argument("--json", action="store_true",
+                        help="Emit machine-readable JSON instead of the table.")
+    args = parser.parse_args()
+
+    provider = _ensure_api_key()
+    if not provider:
+        print("No LLM API key found (OPENAI_API_KEY or OPENROUTER_*). "
+              "The demo needs a real LLM to deliberate. Skipping.",
+              file=sys.stderr)
+        return 2
+
+    # Make the examples package importable for `from synthetic_proposals import …`.
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    results = asyncio.run(run_demo(limit=args.limit))
+
+    if args.json:
+        # Strip the verbose phase_rows + methods for a compact JSON view.
+        compact = [
+            {
+                "id": r["id"],
+                "label": r["label"],
+                **r["verdict"],
+            }
+            for r in results
+        ]
+        print(json.dumps(compact, indent=2, default=str, ensure_ascii=False))
+    else:
+        _print_table(results)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/democratech_deliberation/synthetic_proposals.py
+++ b/examples/democratech_deliberation/synthetic_proposals.py
@@ -1,0 +1,75 @@
+"""Synthetic domain-public deliberation propositions (BO-2 #1472 demo).
+
+Bundle of 5 citizen-deliberation propositions for the ``democratech`` demo. All
+are **synthetic, domain-public, generic** participatory-budget scenarios — no
+real names, no corpus, no politically sensitive content (privacy HARD, #1472).
+
+Each proposition frames 3 divergent options so the governance phase has ≥2
+choices to aggregate (governance needs ≥2 to render a genuine verdict — BO-2
+#1472). The option wording is deliberately varied across propositions so the
+LLM produces distinct extractions → distinct cache keys (also used by the BO-3
+#1473 replay-cache batch test).
+
+IDs are opaque (prop_A..prop_E) for any GitHub-indexed surface.
+"""
+
+from typing import Dict
+
+
+# (opaque_id, human_label_for_display_only, proposition_text)
+SYNTHETIC_PROPOSITIONS = (
+    (
+        "prop_A",
+        "Chess club — annual budget",
+        "Le club d'echecs dispose d'un budget participatif annuel de 2000 euros. "
+        "Trois options divergentes s'affrontent. "
+        "Option A : organiser un tournoi inter-villes avec buffet et prix pour 2000 "
+        "euros, augmentant la visibilite du club. "
+        "Option B : investir les 2000 euros en materiel pedagogique et echiquiers neufs. "
+        "Option C : un format hybride, 1000 euros tournoi reduit et 1000 euros materiel.",
+    ),
+    (
+        "prop_B",
+        "Neighborhood library — exceptional grant",
+        "La bibliotheque de quartier beneficie d'une subvention exceptionnelle de "
+        "3000 euros. Trois usages sont en concurrence. "
+        "Option A : elargir le fonds de livres jeunesse. "
+        "Option B : creer un espace numerique avec des ordinateurs en libre acces. "
+        "Option C : repartir la somme, moitie fonds livre, moitie espace numerique.",
+    ),
+    (
+        "prop_C",
+        "Sports association — subsidy allocation",
+        "L'association sportive municipale dispose de 1500 euros de subvention a "
+        "allouer. Trois pistes sont proposees. "
+        "Option A : acheter des equipements collectifs (ballons, filets, vestiaires). "
+        "Option B : financer des stages de formation pour les entraineurs benevoles. "
+        "Option C : repartir equitablement entre equipement et formation.",
+    ),
+    (
+        "prop_D",
+        "District park — improvement budget",
+        "Le comite de quartier a 2500 euros pour amenager un parc local. "
+        "Trois options sont debattues. "
+        "Option A : installer des jeux pour enfants et des bancs. "
+        "Option B : planter une voie verdoyante et un potager partage. "
+        "Option C : moitie jeux, moitie verdurisation.",
+    ),
+    (
+        "prop_E",
+        "Music school — equipment fund",
+        "L'ecole de musique associative a leve 1800 euros. Trois projets "
+        "concurrents emergent. "
+        "Option A : renouveler les instruments d'etude (pianos, guitares). "
+        "Option B : financer des bourses pour les eleves en difficulte. "
+        "Option C : repartir entre instruments et bourses.",
+    ),
+)
+
+
+def get_propositions() -> Dict[str, Dict[str, str]]:
+    """Return the bundle as ``{opaque_id: {label, text}}`` for the demo driver."""
+    return {
+        pid: {"label": label, "text": text}
+        for pid, label, text in SYNTHETIC_PROPOSITIONS
+    }

--- a/tests/integration/orchestration/test_democratech_demo.py
+++ b/tests/integration/orchestration/test_democratech_demo.py
@@ -1,0 +1,69 @@
+"""BO-2 #1472 residual DoD: the democratech demo renders a FIRSTHAND verdict per
+proposition, with a readable output — proven firsthand, not asserted.
+
+The demo bundle (``examples/democratech_deliberation/``) runs the ``democratech``
+workflow E2E over synthetic domain-public propositions and prints a per-prop
+verdict. This test exercises the demo's own driver on 2 propositions to prove:
+  - each proposition DECIDES firsthand (real agents, ``governance_decided_firsthand``);
+  - the verdict is readable (winner + ≥1 voting method + consensus);
+  - the table renderer does not crash on real output.
+
+Privacy HARD: synthetic domain-public propositions only (no corpus). Marked
+``requires_api``+``slow``: the workflow needs a real LLM per proposition.
+"""
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _demo_on_path(monkeypatch):
+    """Make the examples package importable so the driver's intra-package import resolves."""
+    import pathlib
+
+    demo_dir = pathlib.Path(__file__).resolve().parents[3] / "examples" / "democratech_deliberation"
+    monkeypatch.syspath_prepend(str(demo_dir))
+    yield
+
+
+@pytest.mark.requires_api
+@pytest.mark.slow
+class TestDemocratechDemo:
+    """DoD: demo renders a firsthand, readable verdict per proposition."""
+
+    @pytest.mark.asyncio
+    async def test_demo_renders_firsthand_verdict_per_prop(self):
+        # Import after syspath_prepend.
+        from run_democratech_demo import _print_table, run_demo
+
+        # 2 propositions = enough to prove "per prop" while staying within the
+        # slow timeout (~150s/prop live).
+        results = await run_demo(limit=2)
+
+        assert len(results) == 2, "demo should process the 2 requested propositions"
+
+        for r in results:
+            v = r["verdict"]
+            assert v["decided_firsthand"] is True, (
+                f"{r['id']} did not decide firsthand — demo must render a genuine "
+                f"verdict (anti-théâtre #1019), not a fabricated one"
+            )
+            assert v["winner"] is not None, f"{r['id']}: no winner rendered"
+            assert v["n_methods"] >= 1, f"{r['id']}: 0 voting methods decided"
+            assert v["methods"], f"{r['id']}: empty winners_per_method"
+
+        # The readable table renderer must not crash on real output.
+        _print_table(results)
+
+    def test_synthetic_propositions_are_domain_public(self):
+        """Privacy HARD: fixtures contain no real-name / corpus markers."""
+        from synthetic_proposals import SYNTHETIC_PROPOSITIONS
+
+        forbidden = ("raw_text", "discours", "source_quote")  # corpus-field markers
+        assert len(SYNTHETIC_PROPOSITIONS) >= 3, "demo needs ≥3 propositions"
+        for pid, label, text in SYNTHETIC_PROPOSITIONS:
+            assert pid.startswith("prop_"), f"non-opaque id: {pid}"
+            low = (text or "").lower()
+            for marker in forbidden:
+                assert marker not in low, f"{pid}: forbidden marker {marker!r}"


### PR DESCRIPTION
## BO-2 #1472 residual — democratech deliberation demo (synthetic bundle)

Closes the residual demo DoD of #1472. **Base:** `b604c90e`.

BO-2 core is DONE (decide #1477 → serialize/HTTP #1481 → stream/WS #1482). The remaining residual (per coord R657/R659 dispatch) is the **lightweight synthetic demo scenario** — a bundle-able driver that runs `democratech` E2E over domain-public propositions and renders a readable per-prop verdict. The React dashboard stays **DEFERRED** (frontend, cadrage user).

### Deliverable — `examples/democratech_deliberation/`

| File | Role |
|------|------|
| `synthetic_proposals.py` | 5 domain-public propositions (chess club, library, sports assoc, park, music school — generic participatory-budget models, opaque IDs) |
| `run_democratech_demo.py` | Standalone driver: loops over the bundle, runs `run_deliberation`, prints a readable per-prop table (Firsthand / Winner / #Methods / Consensus) + honest per-phase status |
| `README.md` | Usage + privacy HARD note |

### Anti-pendule

The demo is a **driver**, not a pipeline rebuild — it calls the existing `run_deliberation` convenience wrapper. No new orchestration logic.

### Firsthand proof (no mock)

- **Integration** (`test_democratech_demo.py`, `requires_api`+`slow`): runs the demo driver on **2 propositions** → each decides **firsthand** (`governance_decided_firsthand=True`), renders a winner + ≥1 voting method + consensus; the table renderer does not crash on real output.
- **Privacy unit test** (no key): fixtures are domain-public (opaque `prop_*` IDs, no `raw_text`/corpus markers), ≥3 propositions.

### DoD #1472 mapping (residual)

| DoD item | Status |
|---|---|
| Workflow democratech decided E2E firsthand | ✅ #1477 (core) |
| 9 endpoints + 3 WS tested in integration | ✅ #1481 (HTTP) + #1482 (WS) |
| **Synthetic demo scenario (3-5 props)** | ✅ **this PR** — 5 propositions, driver + E2E |
| Honest-degraded if a phase doesn't carry material | ✅ per-phase status row |
| React dashboard displays real data | ⏳ **DEFERRED** (cadrage user, per coord R657) |

### Scope (honest)

- **Lane:** `examples/democratech_deliberation/` + 1 integration test → po-2025 (0 collision: PR3 touches `services/llm_cache.py`+tests+doc; BO-4 touches orchestration harness).
- **Privacy HARD:** 5 synthetic domain-public propositions, 0 corpus, 0 `raw_text`, opaque IDs on all output.
- **Budget:** E2E test uses 2 propositions (live LLM, ~10-15 calls/prop); the full 5-prop bundle is demoable via the standalone script.

Closes the residual of #1472 (demo scenario). React dashboard deferred. Refs #1470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
