### PR TITLE
docs(profiling): 5-prop demo bundle record→replay profiling (BO-3 #1473 residual)

### DIFF
--- a/docs/reports/spectacular_profiling.md
+++ b/docs/reports/spectacular_profiling.md
@@ -205,6 +205,99 @@ The test prints the per-phase record-vs-replay table and the `CacheStats` totals
 
 ---
 
+## Demo Bundle Profiling (5 propositions, BO-3 #1473 residual / dispatch R660)
+
+The PR3 batch test above used 3 synthetic propositions. This section profiles the
+**full 5-proposition demo bundle** (`examples/democratech_deliberation/synthetic_proposals.py`,
+merged #1486) through the same record→replay harness — extending the determinism
+proof to the demoable bundle and isolating the per-phase residual honestly.
+
+### Bundle results (record vs replay, 5 synthetic domain-public propositions)
+
+| Metric | Record leg | Replay leg |
+|--------|-----------:|-----------:|
+| Live API calls (`CacheStats.live`) | **25** | **0** ✅ |
+| Cache hits | 5 | 30 |
+| Cache misses (`miss_replay`) | 0 | 0 |
+| Decided firsthand | 5/5 | 5/5 |
+| Wall-clock total | 745.62 s | 179.62 s |
+| Replay as % of record | — | **24.1%** |
+
+**DoD T2 firsthand-proven** (not asserted): the whole 5-prop replay batch made
+**zero live API calls** (`CacheStats.live == 0`, proven via the shared counter),
+zero cache misses, and every proposition decided firsthand with an identical
+verdict (winner `arg_1`, 12 voting methods) on both legs.
+
+### Per-proposition wall-clock
+
+| Proposition | Record (s) | Replay (s) | Replay % |
+|-------------|-----------:|-----------:|---------:|
+| prop_A (chess club) | 134.22 | 36.00 | 26.8% |
+| prop_B (library) | 163.73 | 36.23 | 22.1% |
+| prop_C (sports assoc) | 157.13 | 35.82 | 22.8% |
+| prop_D (park) | 149.33 | 35.54 | 23.8% |
+| prop_E (music school) | 141.22 | 36.03 | 25.5% |
+
+### Per-phase breakdown (prop_A, representative)
+
+| Phase | Record (s) | Replay (s) | LLM-bound? |
+|-------|-----------:|-----------:|:----------:|
+| extract | 27.98 | 0.06 | yes → collapses |
+| quality_baseline | 39.04 | 0.52 | yes → collapses |
+| counter_arguments | 16.19 | 0.07 | yes → collapses |
+| adversarial_debate | 29.77 | 0.04 | yes → collapses |
+| democratic_vote | 18.44 | 0.04 | yes → collapses |
+| fallacy_detection | 0.19 | **32.78** | **no (neural-tier, uncached — see below)** |
+| indexing | 2.04 | 2.03 | no (~constant) |
+| belief_tracking | 0.00 | 0.00 | no |
+| quality_recheck | 0.30 | 0.45 | partial |
+| transcription | 0.00 | 0.00 | no |
+
+Every LLM-bound phase routed through `_guarded_chat_completion` (direct) or
+`CachedChatCompletion` (SK) **collapses** at replay (record → sub-0.1 s), matching
+the PR3 finding.
+
+### Residual wall-clock floor (documented honestly, not masked)
+
+The bundle replay is **24.1%** of record — higher than the PR3 batch's 1.6%. The
+floor is **not** a cache defect; it is a per-proposition orchestration + uncached
+neural-tier cost that the cache does not (and should not) absorb:
+
+- **`fallacy_detection` = 32.78 s at replay** (vs 0.19 s at record). The neural
+  fallacy tier (`self_hosted_fallacy_detector`) uses its **own** OpenAI client and
+  is **not** routed through `_guarded_chat_completion`, so it is outside both
+  cache layers. On this run the configured neural model (`qwen3.5-35b-a3b`) 404s
+  and the tier retries to timeout (visible in the log as `NotFoundError` /
+  `APITimeoutError` on the fallacy wide-net). At *record* this phase happened to
+  fail fast (0.19 s heuristic fallback); at *replay* the same timeout path
+  re-executes every time. This is the dominant residual — **~33 s × 5 = ~165 s
+  of the 180 s replay total is uncached neural-tier timeout, not LLM work**.
+- **`indexing` ≈ 2.0 s** (semantic index build, non-LLM, ~constant per prop).
+- **Registry build + torch import** (~1–2 s per prop): the standalone driver
+  re-instantiates the `CapabilityRegistry` (37 services) per proposition.
+
+Strip the neural-tier timeout and the per-prop replay floor drops to ~3 s
+(indexing + orchestration) → bundle replay would be ~3–4% of record, consistent
+with the PR3 batch. The determinism invariant (`live == 0` at replay) is
+unaffected: the neural tier makes no *LLM chat* call that the cache must cover.
+
+### Reproducing the bundle profiling run
+
+```bash
+# Requires a working LLM key in .env (OpenRouter preferred). The standalone
+# driver reuses the cache harness from test_replay_cache_profiling_batch.py over
+# the 5 demo propositions, isolated to a scratch cache_dir.
+LLM_CACHE_MODE=record python <driver>   # seeds the cache (live, ~12 min)
+LLM_CACHE_MODE=replay python <driver>   # replays (0 live call, ~3 min)
+```
+
+Provider-routing note: an early pipeline import can inject stale env vars (a
+dead `OPENAI_API_KEY`, empty `OPENROUTER_*`) before the driver's `load_dotenv`;
+the driver must call `load_dotenv(.env, override=True)` so `create_llm_service`
+routes to the working OpenRouter key (else 401 on api.openai.com).
+
+---
+
 View the pyinstrument flame graph: `open .profiling/spectacular_pyinstrument.html`
 View cProfile interactively: `snakeviz .profiling/spectacular_cprofile.prof`
 


### PR DESCRIPTION
## BO-3 #1473 residual / dispatch R660 — 5-prop demo bundle profiling

Extends `docs/reports/spectacular_profiling.md` with the **demo bundle** profiling
(T2 of dispatch R660). Profiles the full 5-proposition demo bundle (#1486) through
the same record→replay harness as the PR3 3-prop batch test.

**Base:** `d7d2d7f1` (main). Doc-only (+93 lines, 1 file).

### Results — firsthand-proven (live OpenRouter, no mock)

5 synthetic domain-public propositions (opaque IDs `prop_A..prop_E`):

| Metric | Record | Replay |
|--------|-------:|-------:|
| Live API calls (`CacheStats.live`) | 25 | **0** ✅ |
| Cache hits / `miss_replay` | 5 / 0 | 30 / 0 |
| Decided firsthand | 5/5 | 5/5 |
| Wall-clock total | 745.62 s | 179.62 s |
| Replay % of record | — | **24.1%** |

Every LLM-bound phase collapses at replay (extract 28s→0.06s, debate 30s→0.04s,
governance 18s→0.04s, quality 39s→0.5s, counter 16s→0.07s). Identical verdict on
both legs (winner `arg_1`, 12 voting methods).

### Residual floor — documented honestly, not masked

The bundle replay is 24.1% (vs the PR3 batch's 1.6%). The floor is **not** a cache
defect — it is per-prop orchestration + an **uncached neural tier** the cache does
not (should not) absorb:

- `fallacy_detection` = **32.78 s at replay** (vs 0.19 s at record). The neural
  fallacy tier (`self_hosted_fallacy_detector`) uses its **own** OpenAI client,
  outside both cache layers (`_guarded_chat_completion` direct + `CachedChatCompletion`
  SK). The configured neural model (`qwen3.5-35b-a3b`) 404s and retries to timeout.
  **~33 s × 5 = ~165 s of the 180 s replay total is uncached neural-tier timeout,
  not LLM work.**
- `indexing` ≈ 2 s/prop (semantic index build, non-LLM).
- Registry build + torch import ≈ 1–2 s/prop (standalone driver re-instantiates
  the 37-service registry per prop).

Strip the neural-tier timeout and the per-prop replay floor drops to ~3 s → bundle
replay ~3–4% of record, consistent with PR3. The **determinism invariant
(`live == 0` at replay) is unaffected**: the neural tier makes no *LLM chat* call
that the cache must cover.

### Scope (honest)

- **Anti-pendule:** DOC extension profiling the already-merged demo + cache layers
  (#1483/#1484/#1485/#1486). No pipeline change, no React (React = DEFERRED, user
  decision).
- **Privacy HARD:** profiling artifacts land under the gitignored
  `argumentation_analysis/evaluation/results/democratech_demo/` tree (table + JSON).
  Only aggregate numbers + opaque IDs in this report.
- **T1 (readable demo table) delivered** as a gitignored artifact alongside
  (5/5 firsthand, winner `arg_1` ×5, 12 methods ×5) — material for course/soutenance
  demo, not committed (dataset-privacy discipline).

Refs #1473 (residual). Closes the T2 of dispatch R660.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
