### PR TITLE
fix(tpm): unblock TPM-2 real-corpus run — 2 loader shape bugs + ergodicity verdict (#1491)

### DIFF
--- a/scripts/_tpm_corpus_loader.py
+++ b/scripts/_tpm_corpus_loader.py
@@ -103,12 +103,22 @@ def load_corpus_propositions(corpus_id: str) -> Dict[str, Dict[str, str]]:
         raw_id = str(d.get("id", ""))
         if not raw_id:
             continue
-        text = str(d.get("text", "")).strip()
+        # The encrypted dataset stores the document under ``full_text`` (the
+        # extracts also carry ``extract_text``); it has no bare ``text`` key.
+        # Map onto the single ``text`` field the pipeline consumes. This maps
+        # into the IN-MEMORY dict only — the extractor persists LIGHT
+        # aggregates, never the text (privacy HARD #1491).
+        text = str(d.get("full_text", "") or d.get("text", "")).strip()
         if not text:
             continue
         opaque = "prop_" + hashlib.sha256(raw_id.encode("utf-8")).hexdigest()[:8]
         out[opaque] = {
             "text": text,
+            # ``label`` is read by the run loop and PERSISTED as ``corpus_label``
+            # in tpm.json — it MUST stay opaque for the real corpus. The real
+            # source name lives only in ``_source_label`` (internal grouping,
+            # never persisted by the extractor). Privacy HARD #1491.
+            "label": f"corpus{corpus_id.upper()} · {opaque}",
             "_source_label": str(d.get("source_name", "unknown"))[:32],
         }
     if not out:

--- a/scripts/extract_belief_trajectories.py
+++ b/scripts/extract_belief_trajectories.py
@@ -875,6 +875,15 @@ def _render_markdown_report(
                 "- **Ergodique** : **NON** — irréductible mais périodique "
                 "(gcd return-period > 1)."
             )
+        elif ergo.irreducible:
+            # Irreducible (1 SCC) but aperiodicity undetermined (aperiodic is
+            # None — mixed self-loop evidence on small N). Do NOT claim
+            # "réductible" here: that contradicts the 1-SCC verdict just above.
+            lines.append(
+                "- **Ergodique** : **indéterminé** — irréductible (1 SCC) mais "
+                "apériodicité indéterminée sur N petit ; ergodicité non "
+                "conclue (pas de distribution stationnaire garantie)."
+            )
         else:
             lines.append(
                 "- **Ergodique** : **NON** — réductible (≥2 SCC), "

--- a/tests/scripts/test_extract_belief_trajectories_1491.py
+++ b/tests/scripts/test_extract_belief_trajectories_1491.py
@@ -209,11 +209,20 @@ class TestCorpusLoaderContract:
         something other than ``ImportError`` on the helper module).
         """
         loader = _load_corpus_loader_module()
-        # Calling without TEXT_CONFIG_PASSPHRASE must raise EnvironmentError,
-        # NOT ImportError — that would mean the loader references a symbol
-        # that does not exist in crypto_utils / io_manager.
-        with pytest.raises((EnvironmentError, FileNotFoundError)):
+        # The R672 invariant is: calling the loader must NOT raise ImportError
+        # (that would mean it references a symbol absent from crypto_utils /
+        # io_manager). It may legitimately raise EnvironmentError (no
+        # passphrase) / FileNotFoundError (no dataset), OR succeed when the
+        # secret is present — all three prove the import graph resolves. Do
+        # not assert the missing-passphrase path specifically: that makes the
+        # test env-fragile (it breaks the moment TEXT_CONFIG_PASSPHRASE is set,
+        # e.g. alongside the real-decrypt regression below).
+        try:
             loader.load_corpus_definitions("A")
+        except ImportError as exc:  # pragma: no cover — the regression we guard
+            pytest.fail(f"Loader import graph broken (R672 regression): {exc}")
+        except (EnvironmentError, FileNotFoundError, ValueError):
+            pass  # expected when the secret / dataset is absent
 
     def test_corpus_loader_rejects_unknown_id(self) -> None:
         loader = _load_corpus_loader_module()
@@ -221,11 +230,18 @@ class TestCorpusLoaderContract:
             loader.load_corpus_definitions("Z")
 
     def test_opaque_id_format(self) -> None:
-        """Opaque IDs must start with ``prop_`` and be 13 chars (prop_ + 8 hex)."""
+        """Opaque IDs must start with ``prop_`` and be 13 chars (prop_ + 8 hex).
+
+        The fixture uses ``full_text`` — the REAL dataset field (there is NO
+        bare ``text`` key). The earlier fixture used ``text``, which masked the
+        shape bug that shipped in #1492 (loader filtered on a non-existent
+        field → 0 props from the real corpus). Keep this fixture aligned with
+        the real schema.
+        """
         loader = _load_corpus_loader_module()
         fake_defs = [
-            {"id": "src0_ext0", "text": "Hello world.", "source_name": "Dictator X"},
-            {"id": "src0_ext1", "text": "Another text.", "source_name": "Politician Y"},
+            {"id": "src0_ext0", "full_text": "Hello world.", "source_name": "Dictator X"},
+            {"id": "src0_ext1", "full_text": "Another text.", "source_name": "Politician Y"},
         ]
         loader.load_corpus_definitions = lambda cid: fake_defs  # type: ignore[assignment]
         props = loader.load_corpus_propositions("A")
@@ -236,8 +252,16 @@ class TestCorpusLoaderContract:
             # The OPAQUE proposition ID must NEVER contain the source name.
             assert "Dictator" not in pid
             assert "Politician" not in pid
-            # Text is the only field exposed to the pipeline.
-            assert "text" in meta
+            # The run loop reads BOTH ``text`` and ``label`` — a missing
+            # ``label`` KeyErrors on the first real proposition (2nd shape bug
+            # that shipped in #1492).
+            assert "text" in meta and meta["text"]
+            assert "label" in meta
+            # ``label`` is persisted as ``corpus_label`` → must stay opaque
+            # (no source name), and reference the opaque prop id.
+            assert "Dictator" not in meta["label"]
+            assert "Politician" not in meta["label"]
+            assert pid in meta["label"]
 
     def test_empty_corpus_raises(self) -> None:
         loader = _load_corpus_loader_module()
@@ -347,3 +371,71 @@ class TestCLIContract:
         )
         assert result.returncode != 0
         assert "invalid choice" in result.stderr.lower() or "argument" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# Real-decrypt regression — the shape-bug guard the dry-run tests lacked
+# ---------------------------------------------------------------------------
+
+
+import os  # noqa: E402  (local to the gated test below)
+
+_ENC_PATH = (
+    REPO_ROOT / "argumentation_analysis" / "data" / "extract_sources.json.gz.enc"
+)
+_HAS_SECRET = bool(os.environ.get("TEXT_CONFIG_PASSPHRASE")) and _ENC_PATH.exists()
+
+
+@pytest.mark.skipif(
+    not _HAS_SECRET,
+    reason="TEXT_CONFIG_PASSPHRASE not set or encrypted dataset absent — "
+    "real-decrypt regression skips gracefully (CI without the secret).",
+)
+class TestCorpusLoaderRealDecrypt:
+    """Decrypt the REAL corpus and assert the loader yields usable props.
+
+    This is the guard that was missing when #1492 shipped: every prior test
+    either mocked ``load_corpus_definitions`` with the wrong schema (a bare
+    ``text`` key the real dataset never had) or stopped at ``--dry-run``
+    (which returns before the run loop). As a result, TWO shape bugs reached
+    ``main`` green:
+
+    1. The loader filtered on ``d.get("text")`` → 0 props from the real
+       corpus (real field is ``full_text``).
+    2. The run loop reads ``meta["label"]`` → KeyError on the first real prop
+       (loader returned only ``_source_label``).
+
+    This test exercises the true decrypt path with real data and asserts the
+    exact shape the run loop consumes — ``text`` (non-empty) + ``label``
+    (opaque). It prints NO text (privacy HARD): it asserts on lengths and
+    prefixes only.
+    """
+
+    def test_real_corpus_yields_props_with_run_loop_shape(self) -> None:
+        loader = _load_corpus_loader_module()
+        props = loader.load_corpus_propositions("A")
+        assert props, "Real corpus A produced 0 propositions (shape regression)."
+        for pid, meta in props.items():
+            # Opaque ID on every surface.
+            assert pid.startswith("prop_") and len(pid) == 13
+            # The run loop reads BOTH keys — both must exist and be usable.
+            assert meta.get("text"), f"{pid}: empty/absent text (full_text mapping regression)."
+            assert meta.get("label"), f"{pid}: absent label (run-loop KeyError regression)."
+            # Persisted ``corpus_label`` must stay opaque: it references the
+            # opaque id and never the internal source name.
+            assert pid in meta["label"]
+            assert meta["label"] != meta.get("_source_label", "")
+
+    def test_real_corpus_no_source_name_in_persisted_label(self) -> None:
+        """The persisted ``label`` must not equal the internal source name."""
+        loader = _load_corpus_loader_module()
+        props = loader.load_corpus_propositions("A")
+        for _pid, meta in props.items():
+            src = meta.get("_source_label", "")
+            # _source_label is internal grouping only; label (persisted) must
+            # not carry it verbatim.
+            if src and src != "unknown":
+                assert src not in meta["label"], (
+                    "Privacy HARD: internal source name leaked into the "
+                    "persisted opaque label."
+                )

--- a/tests/scripts/test_extract_belief_trajectories_1491.py
+++ b/tests/scripts/test_extract_belief_trajectories_1491.py
@@ -159,6 +159,45 @@ class TestErgodicityAnalysis:
         assert ergo.ergodic is False
         assert ergo.stationary is None
 
+    def test_irreducible_aperiodic_unknown_verdict_not_contradictory(self) -> None:
+        """Real-corpus regression: a 1-SCC chain whose aperiodicity is
+        undetermined (aperiodic is None on small N) must NOT be rendered as
+        ``réductible (≥2 SCC)`` — that contradicts the 1-SCC / irréductible
+        verdict printed two lines above. Observed firsthand on corpus A
+        (--limit 1): the report claimed both ``Irréductible: True`` and
+        ``réductible (≥2 SCC)``. The verdict must be internally consistent.
+        """
+        mod = _load_script_module()
+        # Exact transition structure observed on the real corpus A single
+        # trajectory (opaque count data — no privacy concern): 1 SCC, 1 WCC,
+        # irreducible=True, aperiodic=None.
+        counts = [
+            [2, 1, 0, 0],
+            [0, 2, 0, 1],
+            [0, 0, 0, 1],
+            [0, 0, 1, 1],
+        ]
+        states = [f"completed:s{i}" for i in range(4)]
+        tpm = mod.TPM(
+            states=states,
+            transition_counts=counts,
+            n_transitions=9,
+            n_trajectories=1,
+            n_observations_total=10,
+        )
+        ergo = mod._analyze_ergodicity(tpm)
+        if ergo.analysis_skipped:
+            pytest.skip("scipy absent — ergodicity path not exercised.")
+        # Precondition: this is precisely the irreducible-but-undetermined case.
+        assert ergo.irreducible is True
+        assert ergo.aperiodic is None
+        report = mod._render_markdown_report(
+            [], tpm, "corpusA (real encrypted dataset)", pathlib.Path(".")
+        )
+        # The contradiction guard: never claim reducibility for a 1-SCC chain.
+        assert "réductible (≥2 SCC)" not in report
+        assert "indéterminé" in report
+
     def test_disconnected_two_wcc(self) -> None:
         """4 states, no transitions at all → 4 SCCs, multiple WCCs possible."""
         mod = _load_script_module()


### PR DESCRIPTION
## Contexte

Coordinator (ai-01) firsthand follow-up on TPM-2 (#1491, merged in #1492). After merging, I produced the central deliverable of #1491 — a **real-corpus TPM** — firsthand in the canonical env (`projet-is-roo-new`, Py 3.10), the only node that can decrypt + run. Doing so surfaced **two loader shape bugs** that blocked any real-corpus run, plus a self-contradictory ergodicity verdict. All three are fixed and guarded here.

Why the workers couldn't catch these: every prior test either mocked `load_corpus_definitions` with a `text` key **the real dataset never had**, or stopped at `--dry-run` (returns before the run loop). CI stayed green because it never decrypts. This is the "mocked tests hide real-shape bugs" failure mode po-2025 flagged.

## Bugs fixed (all found firsthand on a real decrypt+run)

1. **Loader filtered on a non-existent field.** `load_corpus_propositions` filtered on `d.get("text")`, but the encrypted definitions carry the document under `full_text` (extracts also carry `extract_text`); there is no bare `text` key → **0/18 defs passed** → `ValueError: Corpus A produced 0 propositions`. Fix: map `full_text` onto the single `text` field the pipeline consumes.

2. **Run loop KeyError on the first real prop.** The run loop reads `meta["label"]` (persisted as `corpus_label` in `tpm.json`), but the loader returned only `_source_label` → `KeyError`. Fix: emit an **opaque** `label` (`corpus<A> · prop_<hash>`); the real source name stays in the internal-only `_source_label`, never persisted (privacy HARD).

3. **Self-contradictory ergodicity verdict.** The real run's report claimed both `Irréductible: True (1 SCC)` **and** `Ergodique: NON — réductible (≥2 SCC)`. On small N the aperiodicity heuristic returns `None`, so an irreducible chain fell into the hardcoded-"reducible" branch. Fix: a dedicated `elif ergo.irreducible:` branch → `Ergodique: indéterminé — irréductible (1 SCC) mais apériodicité indéterminée sur N petit`.

## Tests added (the guards that were missing)

- `TestCorpusLoaderRealDecrypt` — **real-decrypt regression** (gated on `TEXT_CONFIG_PASSPHRASE`, skips cleanly on CI without the secret). Exercises the true schema and asserts the exact `text`+`label` shape the run loop consumes. This is the guard #1492 lacked.
- `test_irreducible_aperiodic_unknown_verdict_not_contradictory` — reproduces the exact real-corpus transition structure (1 SCC, aperiodic None) and asserts the rendered verdict never says "réductible (≥2 SCC)" for a 1-SCC chain. Deterministic, no LLM.
- Aligned the `test_opaque_id_format` fixture to the real `full_text` schema (was `text`, which masked bug #1) and made `test_loader_import_graph_resolves` env-agnostic.

`19 passed` in the canonical env, both with and without the secret.

## Firsthand deliverable (the point of #1491)

Real democratech run on **corpus A, `--limit 1`** (one real proposition, 10-phase trajectory): **10/10 phases OK, 212.6s**, genuine outputs at each stage — formal governance verdict (12 methods, 15 conflicts), LLM debate (`source=llm`, real winner), JTMS beliefs. Produced a **4-state, 9-transition TPM** with an honest ergodicity verdict (1 SCC, aperiodicity indeterminate on N=1 → ergodicity not concluded). Artifacts under gitignored `evaluation/results/` with opaque IDs.

**Privacy audit (firsthand):** grepped the persisted `tpm.json` + `report.md` — **0 real names, 0 `full_text`/`raw_text`/`extract_text`, 0 verbatim**. States are count-bucket labels (`completed:args6+:fall0:ctr1+:bel6+:votearg_1:low`); `corpus_label` is `corpusA · prop_<hash>`. The privacy contract holds end-to-end.

## Scope / notes

- 3 files modified, none added, none deleted (no Cleanup-Gate section needed).
- `scripts/` is excluded from CI's (informational, non-blocking) black check; the loader was already non-black on main, so edits match the surrounding style rather than churning pre-existing lines.
- Scaling to all 4 corpus-A props (denser ergodicity verdict) + replay-cache determinism cross-check are honest follow-ups, not blockers for the #1491 deliverable.

Refs #1491 #1470.

🤖 Coordinator ai-01
