### PR TITLE
fix(tpm): directed SCC for ergodicity verdict (TPM-2 #1491)

### DIFF
--- a/scripts/extract_belief_trajectories.py
+++ b/scripts/extract_belief_trajectories.py
@@ -571,13 +571,14 @@ def _analyze_ergodicity(tpm: TPM) -> ErgodicityResult:
     n = len(tpm.states)
     counts = np.asarray(tpm.transition_counts, dtype=float)
     # Connected components on the BINARY support (any non-zero transition
-    # counts as a graph edge — direction-agnostic for connectivity).
+    # counts as a directed graph edge). ``directed=True`` is REQUIRED for
+    # ``connection="strong"``: with ``directed=False`` scipy ignores the
+    # ``connection`` argument and computes WEAK components for both calls,
+    # so ``n_scc`` silently measured WCC (TPM-2 #1491 ergodicity bug).
     support = (counts > 0).astype(int)
-    # Symmetrize so weakly-connected components capture both directions.
-    symmetric = np.maximum(support, support.T)
-    graph = csr_matrix(symmetric)
-    n_scc, scc_labels = connected_components(graph, directed=False, connection="strong")
-    n_wcc, wcc_labels = connected_components(graph, directed=False, connection="weak")
+    graph = csr_matrix(support)
+    n_scc, scc_labels = connected_components(graph, directed=True, connection="strong")
+    n_wcc, wcc_labels = connected_components(graph, directed=True, connection="weak")
 
     irreducible = n_scc == 1
     # Aperiodicity check: gcd of return-periods to each state. With limited
@@ -863,7 +864,7 @@ def _render_markdown_report(
     else:
         lines.append(f"- SCC (composantes fortement connexes) : **{ergo.n_scc}**")
         lines.append(f"- WCC (composantes faiblement connexes) : **{ergo.n_wcc}**")
-        lines.append(f"- Irréductible : **{ergo.irreducible}** (1 SCC = chaîne irréductible)")
+        lines.append(f"- Irréductible : **{ergo.irreducible}** ({ergo.n_scc} SCC)")
         lines.append(
             f"- Apériodique : **{ergo.aperiodic}** "
             "(heuristique self-loop : None = évidence mixte sur N petit)."

--- a/tests/scripts/test_extract_belief_trajectories_1491.py
+++ b/tests/scripts/test_extract_belief_trajectories_1491.py
@@ -205,6 +205,32 @@ class TestErgodicityAnalysis:
         # ...and never simultaneously claimed irreducible.
         assert "Irréductible : **True**" not in report
 
+    def test_directed_path_wcc1_scc_reducible(self) -> None:
+        """Minimal directed-path regression (coord DoD #2): a pure forward
+        chain ``0→1→2→3`` with no return edges is WEAKLY connected (1 WCC)
+        but has 4 SCCs (no mutual reachability). The pre-fix code (symmetrize
+        + ``directed=False``) computed n_scc = WCC = 1 → ``irreducible=True``
+        (wrong). This test would have caught the ergodicity bug: the verdict
+        must say reducible.
+        """
+        mod = _load_script_module()
+        # 0→1→2→3, no self-loops, no return edges.
+        counts = [
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1],
+            [0, 0, 0, 0],
+        ]
+        tpm = _fake_tpm(["s0", "s1", "s2", "s3"], counts)
+        ergo = mod._analyze_ergodicity(tpm)
+        if ergo.analysis_skipped:
+            pytest.skip("scipy absent — ergodicity path not exercised.")
+        # Weakly connected (1 WCC) but 4 SCC → reducible.
+        assert ergo.n_wcc == 1
+        assert ergo.n_scc == 4
+        assert ergo.irreducible is False
+        assert ergo.ergodic is False
+
     def test_irreducible_aperiodic_unknown_verdict_not_contradictory(self) -> None:
         """A GENUINELY irreducible (1 SCC) chain whose aperiodicity is
         undetermined (aperiodic is None on small N) must NOT be rendered as

--- a/tests/scripts/test_extract_belief_trajectories_1491.py
+++ b/tests/scripts/test_extract_belief_trajectories_1491.py
@@ -159,18 +159,21 @@ class TestErgodicityAnalysis:
         assert ergo.ergodic is False
         assert ergo.stationary is None
 
-    def test_irreducible_aperiodic_unknown_verdict_not_contradictory(self) -> None:
-        """Real-corpus regression: a 1-SCC chain whose aperiodicity is
-        undetermined (aperiodic is None on small N) must NOT be rendered as
-        ``réductible (≥2 SCC)`` — that contradicts the 1-SCC / irréductible
-        verdict printed two lines above. Observed firsthand on corpus A
-        (--limit 1): the report claimed both ``Irréductible: True`` and
-        ``réductible (≥2 SCC)``. The verdict must be internally consistent.
+    def test_corpusa_single_trajectory_reducible_regression(self) -> None:
+        """Real-corpus regression (TPM-2 #1491 ergodicity bug): the corpus A
+        single-trajectory transition structure is REDUCIBLE (3 SCC), not
+        irreducible. Previously the symmetrized + ``directed=False`` SCC
+        computation reported ``n_scc=1`` / ``irreducible=True`` because
+        ``directed=False`` makes scipy ignore ``connection="strong"`` and
+        compute weak components — so ``n_scc`` silently measured WCC. The
+        directed-SCC fix must classify this honestly as reducible, and the
+        rendered report must stay internally consistent (never claim both
+        ``Irréductible: True`` and ``réductible``).
         """
         mod = _load_script_module()
-        # Exact transition structure observed on the real corpus A single
-        # trajectory (opaque count data — no privacy concern): 1 SCC, 1 WCC,
-        # irreducible=True, aperiodic=None.
+        # Exact transition structure observed on corpus A single trajectory
+        # (opaque count data — no privacy concern). TRUE directed SCC = 3:
+        # {s0} (no inbound edge), {s1} (only s0→s1), {s2,s3} (s2→s3, s3→s2).
         counts = [
             [2, 1, 0, 0],
             [0, 2, 0, 1],
@@ -188,7 +191,50 @@ class TestErgodicityAnalysis:
         ergo = mod._analyze_ergodicity(tpm)
         if ergo.analysis_skipped:
             pytest.skip("scipy absent — ergodicity path not exercised.")
+        # Honest verdict: 3 SCC, reducible.
+        assert ergo.n_scc == 3
+        assert ergo.n_wcc == 1
+        assert ergo.irreducible is False
+        assert ergo.aperiodic is None  # mixed self-loop evidence (s2 has none)
+        assert ergo.ergodic is False
+        report = mod._render_markdown_report(
+            [], tpm, "corpusA (real encrypted dataset)", pathlib.Path(".")
+        )
+        # Consistency guard: a reducible chain is rendered as reducible...
+        assert "réductible" in report
+        # ...and never simultaneously claimed irreducible.
+        assert "Irréductible : **True**" not in report
+
+    def test_irreducible_aperiodic_unknown_verdict_not_contradictory(self) -> None:
+        """A GENUINELY irreducible (1 SCC) chain whose aperiodicity is
+        undetermined (aperiodic is None on small N) must NOT be rendered as
+        ``réductible (≥2 SCC)`` — that contradicts the 1-SCC / irréductible
+        verdict printed above. Preserves the original contradiction guard
+        (TPM-2 #1491) using a matrix that is truly 1 SCC under directed
+        strong connectivity, with mixed self-loop evidence → aperiodic=None.
+        """
+        mod = _load_script_module()
+        # 3 states in a bidirectional chain s0↔s1↔s2 → genuinely 1 SCC
+        # (all mutually reachable). Self-loops on s0 and s2 only →
+        # aperiodic_states=[1,0,1] → mixed → aperiodic=None.
+        counts = [
+            [1, 1, 0],
+            [1, 0, 1],
+            [0, 1, 1],
+        ]
+        states = [f"completed:s{i}" for i in range(3)]
+        tpm = mod.TPM(
+            states=states,
+            transition_counts=counts,
+            n_transitions=6,
+            n_trajectories=1,
+            n_observations_total=6,
+        )
+        ergo = mod._analyze_ergodicity(tpm)
+        if ergo.analysis_skipped:
+            pytest.skip("scipy absent — ergodicity path not exercised.")
         # Precondition: this is precisely the irreducible-but-undetermined case.
+        assert ergo.n_scc == 1
         assert ergo.irreducible is True
         assert ergo.aperiodic is None
         report = mod._render_markdown_report(


### PR DESCRIPTION
## Fix: directed SCC for ergodicity verdict (TPM-2 #1491)

`_analyze_ergodicity` reported `irreducible=True` on corpus A and C, but those
chains are genuinely **reducible (3 SCC)**. Root cause + anti-pendule fix.

### Root cause (firsthand, main `b1eedfd9`)

`scripts/extract_belief_trajectories.py::_analyze_ergodicity` (L575-580):

```python
symmetric = np.maximum(support, support.T)   # symmetrized → loses direction
graph = csr_matrix(symmetric)
n_scc = connected_components(graph, directed=False, connection="strong")[0]
```

With `directed=False`, scipy **ignores** the `connection` argument and computes
WEAK components for both calls. So `n_scc` silently measured WCC, yielding
`irreducible=True` on any weakly-connected chain.

**scipy doc**: "`connection` — Ignored if directed == False."

### Fix (anti-pendule: removal, not counterweight)

- Drop the symmetrization.
- Pass `directed=True` for both SCC (`connection="strong"`) and WCC
  (`connection="weak"`).
- Render the irreducible line with the actual `n_scc` (was hardcoded
  `"(1 SCC = chaîne irréductible)"`).

### Test split (the regression test encoded the bug)

`test_irreducible_aperiodic_unknown_verdict_not_contradictory` asserted
`irreducible=True` on a corpus-A single-trajectory matrix that is **truly 3-SCC
reducible** under directed strong connectivity. The test was built from the
buggy output and pinned the bug as expected behavior. Split into:

- `test_corpusa_single_trajectory_reducible_regression` — corpus-A structure,
  asserts `n_scc==3`, `irreducible=False`, report renders "réductible", never
  "Irréductible : **True**".
- `test_irreducible_aperiodic_unknown_verdict_not_contradictory` — a
  genuinely-irreducible (1 SCC) bidirectional chain with mixed self-loop
  evidence (`aperiodic=None`), preserves the "indéterminé" rendering branch and
  the contradiction guard.

### Firsthand verification (po-2025 dense lane measure, R660)

Independent directed-SCC recompute (scipy) on 3 real-corpus TPMs vs the buggy
embedded verdict — divergence reported verbatim (I5, never auto-reconciled):

| Corpus | States | SCC (directed recompute) | WCC | Buggy embedded `irreducible` | True |
|--------|--------|--------------------------|-----|------------------------------|------|
| corpusA | 4 | 3 | 1 | True ❌ | False |
| corpusB | 8 | 6 | 2 | False ✅ (by luck: 2 WCC) | False |
| corpusC | 4 | 3 | 1 | True ❌ | False |

The bug agrees **by chance** when WCC>1, diverges when WCC=1. My recompute was
cross-checked against the raw transition-count table in `report.md` itself
(`0→{0,1}`, `1→{1,3}`, `2↔3` → SCC={0},{1},{2,3}=3).

### Falsifiable answer to #1490/#1491

Does the chain become irreducible (→ well-defined stationary) on a rich corpus,
or does the "reducible/indeterminate" bound hold at scale? **Answer: the bound
HOLDS.** All 3 real-corpus TPMs are reducible/non-ergodic. corpusB (richest, 8
states) is block-diagonal (2 WCC = 2 isolated basins by args bucket). No global
stationary distribution is guaranteed — only per-terminal-SCC locals.

Determinism replay A==B bit-for-bit: PASS on all 3 corpora
(states/counts/n_transitions/n_obs/impossible identical).

### Validation

```
pytest tests/scripts/test_extract_belief_trajectories_1491.py --noconftest -q
20 passed in 21.15s
```

mypy strict on `scripts/extract_belief_trajectories.py`: 0 new errors (13
pre-existing on this out-of-CI-gate file, unchanged by this PR).

### Privacy

0 `full_text`/`raw_text`/`source_name` in artifacts, opaque IDs
(`corpusA · prop_<8hex>`), state labels are structural buckets only. Fix is in
`scripts/` + `tests/`, zero blast radius on core.

Refs #1491
