### PR TITLE
feat(informal): selectable Dung-arbitration stage + Walton-Krabbe policy (I1 #1501 PR1)

### DIFF
--- a/argumentation_analysis/agents/core/informal/dung_arbitration_stage.py
+++ b/argumentation_analysis/agents/core/informal/dung_arbitration_stage.py
@@ -1,0 +1,227 @@
+"""Selecteable Dung-arbitration stage for sophism detection (Track I1 #1501).
+
+A PRODUCTION STAGE — distinct from #1429's ``compare_sophism_backends`` comparison
+harness. When ``dung_arbitration`` is enabled, the Dung grounded extension
+arbitrates between sophism candidates and ALTERS the detection verdict:
+candidates defeated by a defended Walton-Krabbe refutation are eliminated (false
+positives filtered; surviving candidates reinstated). Off by default
+(backward-compat): the detector output is unchanged until the stage is selected.
+
+Anti-fabrication (#1019 / anti-théâtre)
+---------------------------------------
+The stage never invents an attack. It mechanically turns DECLARED Walton-Krabbe
+antagonistic relations (``SpeechAct.REFUTE`` / ``CHALLENGE`` from
+``debate/protocols.py``, produced by the DebateAgent protocol in PR2/PR3) into
+Dung attack edges, then lets the grounded extension decide which candidates
+survive. With no declared refutations and no same-span rivalry, the enabled stage
+is honest-absent: output == input (no fabricated arbitration, no cosmetic flag).
+
+JVM/LLM-free by design
+----------------------
+Reuses ``neuro_symbolic_arbitrator.arbitrate`` + the pure-python grounded solver
+so PR1 is unit-testable with synthetic opaque atoms — no JVM, no LLM. Inject
+``make_dung_agent_solver()`` for real JVM-backed grounded semantics (PR2/PR3).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional, Sequence
+
+from argumentation_analysis.agents.core.debate.protocols import SpeechAct
+from argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator import (
+    ArbitrationResult,
+    ConflictPolicy,
+    SophismCandidate,
+    arbitrate,
+    default_conflict_policy,
+)
+
+#: Walton-Krabbe speech acts that, when declared from A to B, yield a Dung attack
+#: A → B. REFUTE and CHALLENGE are the antagonistic moves in the Walton-Krabbe
+#: taxonomy (protocols.py); CONCEDE / SUPPORT / UNDERSTAND are cooperative and do
+#: NOT attack. The DebateAgent producer (PR2/PR3) filters its declared relations
+#: to these acts before feeding them to the stage.
+WALTON_KRABBE_ATTACKING_ACTS: frozenset[SpeechAct] = frozenset(
+    {SpeechAct.REFUTE, SpeechAct.CHALLENGE}
+)
+
+# Declared Walton-Krabbe relations: for each candidate id, the ids it
+# REFUTE/CHALLENGE. Produced by the DebateAgent protocol (PR2/PR3); PR1 passes
+# them explicitly to keep the stage JVM/LLM-free and deterministic.
+WaltonKrabbeRelations = dict[str, frozenset[str]]
+
+
+def walton_krabbe_conflict_policy(
+    relations: WaltonKrabbeRelations,
+) -> ConflictPolicy:
+    """ConflictPolicy turning DECLARED Walton-Krabbe refutations into attacks.
+
+    Each declared antagonistic relation (A refutes/challenges B) becomes a Dung
+    attack edge (A → B): A is the challenger argument, B the targeted candidate.
+    The grounded extension then defeats B exactly when A is itself defended
+    (unattacked) — a genuine refutation. This is the candidate-vs-candidate attack
+    dimension the #1501 dispatch asks for (DebateAgent as attack source between
+    candidates), distinct from #1429's same-span-rival policy and its synthetic
+    critical-question challenger.
+
+    Unknown ids, self-loops and cooperative acts are ignored. Returning an empty
+    set is always legitimate (honest-absent). The policy never touches critical
+    questions (those stay in ``neuro_symbolic_arbitrator.build_dung_framework``).
+    """
+
+    def _policy(candidates: Sequence[SophismCandidate]) -> set[tuple[str, str]]:
+        known = {c.candidate_id for c in candidates}
+        attacks: set[tuple[str, str]] = set()
+        for challenger, targets in relations.items():
+            if challenger not in known:
+                continue
+            for target in targets:
+                if target in known and target != challenger:
+                    attacks.add((challenger, target))
+        return attacks
+
+    return _policy
+
+
+def combine_conflict_policies(*policies: ConflictPolicy) -> ConflictPolicy:
+    """Union several ConflictPolicies into one (attacks deduped by set semantics)."""
+
+    def _combined(candidates: Sequence[SophismCandidate]) -> set[tuple[str, str]]:
+        attacks: set[tuple[str, str]] = set()
+        for policy in policies:
+            attacks |= policy(candidates)
+        return attacks
+
+    return _combined
+
+
+@dataclass(frozen=True)
+class ArbitrationVerdict:
+    """Formal, traceable outcome of the selectable ``dung_arbitration`` stage.
+
+    The detection pipeline reads ``surviving_ids`` as the arbitrated set of
+    fallacies to report; ``eliminated_ids`` carries a machine-checkable reason for
+    each dropped candidate, so the verdict is auditable rather than an opaque score
+    (#1501 DoD #4). ``enabled=False`` ⇒ passthrough: ``surviving_ids`` == all input
+    ids, ``honest_absent=True``, no arbitration performed.
+    """
+
+    enabled: bool
+    surviving_ids: frozenset[str]
+    eliminated_ids: dict[str, str]
+    attacks: frozenset[tuple[str, str]]
+    honest_absent: bool
+    input_count: int
+    surviving_count: int
+
+
+def arbitrate_detections(
+    candidates: Sequence[SophismCandidate],
+    *,
+    dung_arbitration: bool,
+    walton_krabbe_relations: Optional[WaltonKrabbeRelations] = None,
+    conflict_policy: Optional[ConflictPolicy] = None,
+    semantics: str = "grounded",
+    solver: Optional[Callable] = None,
+) -> ArbitrationVerdict:
+    """Selecteable Dung-arbitration stage over sophism candidates (#1501).
+
+    ``dung_arbitration=False`` (default OFF, backward-compat): passthrough — the
+    verdict keeps EVERY candidate, performs no arbitration. The detector output is
+    unchanged, so wiring the stage off is transparent.
+
+    ``dung_arbitration=True``: build the Dung AF from (a) the base conflict policy
+    (default: #1429's same-span rivalry) UNION (b) declared Walton-Krabbe
+    refutations, then let the grounded extension decide which candidates survive.
+    Candidates defeated by a defended refutation are eliminated (false-positive
+    filtering); the verdict differs from the off-baseline exactly when the symbolic
+    layer has something genuine to arbitrate (anti-#1019).
+
+    Args:
+        candidates: Sophism candidates as opaque Dung atoms.
+        dung_arbitration: Stage selector — OFF by default.
+        walton_krabbe_relations: Declared REFUTE/CHALLENGE relations (DebateAgent
+            output in PR2/PR3). Each becomes a candidate-vs-candidate attack.
+        conflict_policy: Base conflict derivation (default: #1429's
+            ``default_conflict_policy``). Pass a no-op returning ``set()`` to
+            arbitrate on Walton-Krabbe refutations alone.
+        semantics: Extension semantics label forwarded to ``arbitrate`` (grounded).
+        solver: Injected Dung solver (default: pure-python grounded; inject
+            ``make_dung_agent_solver()`` for real JVM-backed semantics).
+
+    Returns:
+        The formal :class:`ArbitrationVerdict`. When the stage is off OR no attacks
+        arise, ``honest_absent`` is True and ``surviving_ids`` == all input ids —
+        the stage never fabricates a verdict change.
+    """
+
+    candidate_ids = frozenset(c.candidate_id for c in candidates)
+
+    if not dung_arbitration:
+        return ArbitrationVerdict(
+            enabled=False,
+            surviving_ids=candidate_ids,
+            eliminated_ids={},
+            attacks=frozenset(),
+            honest_absent=True,
+            input_count=len(candidate_ids),
+            surviving_count=len(candidate_ids),
+        )
+
+    base_policy = conflict_policy or default_conflict_policy
+    if walton_krabbe_relations:
+        combined = combine_conflict_policies(
+            base_policy, walton_krabbe_conflict_policy(walton_krabbe_relations)
+        )
+    else:
+        combined = base_policy
+
+    result: ArbitrationResult = arbitrate(
+        candidates,
+        solver=solver,
+        semantics=semantics,
+        conflict_policy=combined,
+    )
+
+    surviving = result.arbitrated_ids
+    eliminated = dict(result.rejected)
+    _annotate_walton_krabbe_eliminations(
+        eliminated, surviving, result.attacks, walton_krabbe_relations
+    )
+
+    return ArbitrationVerdict(
+        enabled=True,
+        surviving_ids=surviving,
+        eliminated_ids=eliminated,
+        attacks=result.attacks,
+        honest_absent=result.honest_absent,
+        input_count=result.neural_count,
+        surviving_count=result.arbitrated_count,
+    )
+
+
+def _annotate_walton_krabbe_eliminations(
+    eliminated: dict[str, str],
+    surviving: frozenset[str],
+    attacks: frozenset[tuple[str, str]],
+    relations: Optional[WaltonKrabbeRelations],
+) -> None:
+    """Refine elimination reasons with the Walton-Krabbe dimension (traceability).
+
+    A candidate eliminated by a DECLARED refuter that itself survived (a genuine,
+    defended refutation) is labelled ``defeated_by_walton_krabbe_refutation``
+    rather than the generic ``defeated_by_rival_candidate``. Mutates ``eliminated``
+    in place. No-op when no relations were declared.
+    """
+
+    if not relations:
+        return
+    refuters = set(relations.keys())
+    attackers_of: dict[str, set[str]] = {}
+    for src, tgt in attacks:
+        attackers_of.setdefault(tgt, set()).add(src)
+    for cid in list(eliminated):
+        wk_attackers = attackers_of.get(cid, set()) & refuters
+        if wk_attackers & surviving:
+            eliminated[cid] = "defeated_by_walton_krabbe_refutation"

--- a/tests/unit/argumentation_analysis/agents/core/informal/test_dung_arbitration_stage.py
+++ b/tests/unit/argumentation_analysis/agents/core/informal/test_dung_arbitration_stage.py
@@ -1,0 +1,172 @@
+"""Unit tests for the selectable dung_arbitration stage (Track I1 #1501, PR1).
+
+JVM/LLM-free: the stage reuses ``neuro_symbolic_arbitrator.arbitrate`` with the
+pure-python grounded solver, so every test runs on synthetic opaque atoms. The
+anti-#1019 contract is asserted explicitly — the stage CHANGES the verdict when
+enabled and there is something genuine to arbitrate, and is transparent
+(output == input) otherwise.
+"""
+
+from __future__ import annotations
+
+from argumentation_analysis.agents.core.debate.protocols import SpeechAct
+from argumentation_analysis.agents.core.informal.dung_arbitration_stage import (
+    WALTON_KRABBE_ATTACKING_ACTS,
+    arbitrate_detections,
+    combine_conflict_policies,
+    walton_krabbe_conflict_policy,
+)
+from argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator import (
+    SophismCandidate,
+)
+
+
+def _cand(
+    cid: str, family: str = "f", span: str = "s", conf: float = 0.5
+) -> SophismCandidate:
+    return SophismCandidate(
+        candidate_id=cid, family=family, span_id=span, confidence=conf
+    )
+
+
+class TestWaltonKrabbeConflictPolicy:
+    def test_declared_refutation_becomes_attack(self) -> None:
+        cands = [_cand("a"), _cand("b")]
+        policy = walton_krabbe_conflict_policy({"a": frozenset({"b"})})
+        assert policy(cands) == {("a", "b")}
+
+    def test_unknown_challenger_ignored(self) -> None:
+        cands = [_cand("a")]  # challenger 'b' absent
+        policy = walton_krabbe_conflict_policy({"b": frozenset({"a"})})
+        assert policy(cands) == set()
+
+    def test_self_loop_ignored(self) -> None:
+        cands = [_cand("a")]
+        policy = walton_krabbe_conflict_policy({"a": frozenset({"a"})})
+        assert policy(cands) == set()
+
+    def test_unknown_target_ignored(self) -> None:
+        cands = [_cand("a")]
+        policy = walton_krabbe_conflict_policy({"a": frozenset({"ghost"})})
+        assert policy(cands) == set()
+
+    def test_empty_relations_is_honest_absent(self) -> None:
+        cands = [_cand("a"), _cand("b")]
+        policy = walton_krabbe_conflict_policy({})
+        assert policy(cands) == set()
+
+
+class TestCombineConflictPolicies:
+    def test_union_of_attacks(self) -> None:
+        cands = [_cand("a"), _cand("b"), _cand("c")]
+        p1 = walton_krabbe_conflict_policy({"a": frozenset({"b"})})
+        p2 = walton_krabbe_conflict_policy({"c": frozenset({"b"})})
+        combined = combine_conflict_policies(p1, p2)
+        assert combined(cands) == {("a", "b"), ("c", "b")}
+
+
+class TestArbitrateDetectionsSelector:
+    def test_off_is_passthrough_backward_compat(self) -> None:
+        cands = [_cand("s0"), _cand("s1")]
+        verdict = arbitrate_detections(cands, dung_arbitration=False)
+        assert verdict.enabled is False
+        assert verdict.surviving_ids == frozenset({"s0", "s1"})
+        assert verdict.eliminated_ids == {}
+        assert verdict.attacks == frozenset()
+        assert verdict.honest_absent is True
+        assert verdict.surviving_count == verdict.input_count == 2
+
+    def test_on_no_attacks_is_honest_absent_transparent(self) -> None:
+        # Different spans, no declared refutations → no attacks → output == input.
+        cands = [_cand("s0", span="x"), _cand("s1", span="y")]
+        verdict = arbitrate_detections(cands, dung_arbitration=True)
+        assert verdict.enabled is True
+        assert verdict.surviving_ids == frozenset({"s0", "s1"})
+        assert verdict.honest_absent is True
+        assert verdict.eliminated_ids == {}
+
+
+class TestVerdictChangeAntiTheatre:
+    """DoD #2/#3: the stage MUST change the verdict on a genuine case (anti-#1019)."""
+
+    def test_walton_krabbe_refutation_filters_candidate(self) -> None:
+        # s0 is refuted by a surviving refuter r0 on a different span. Under
+        # grounded, r0 is unattacked → accepted; s0 is defeated (FP filtered).
+        cands = [
+            _cand("s0", family="appeal_to_authority", span="span_a", conf=0.9),
+            _cand("r0", family="counter_example", span="span_b", conf=0.95),
+        ]
+        relations = {"r0": frozenset({"s0"})}
+
+        off = arbitrate_detections(cands, dung_arbitration=False)
+        on = arbitrate_detections(
+            cands, dung_arbitration=True, walton_krabbe_relations=relations
+        )
+
+        # Verdict CHANGES: s0 survives off, eliminated on.
+        assert "s0" in off.surviving_ids
+        assert "s0" not in on.surviving_ids
+        assert on.eliminated_ids["s0"] == "defeated_by_walton_krabbe_refutation"
+        # The refuter survives (defended argument reinstated).
+        assert "r0" in on.surviving_ids
+        assert on.honest_absent is False
+        assert ("r0", "s0") in on.attacks
+
+    def test_fp_filter_scenario_concrete(self) -> None:
+        # A hasty-generalization false positive (fp) is refuted by a surviving
+        # empirical counter-argument (cnt). The stage filters the FP.
+        cands = [
+            _cand("fp", family="hasty_generalization", span="span_x", conf=0.7),
+            _cand("cnt", family="empirical_evidence", span="span_y", conf=0.95),
+        ]
+        relations = {"cnt": frozenset({"fp"})}
+        on = arbitrate_detections(
+            cands, dung_arbitration=True, walton_krabbe_relations=relations
+        )
+        off = arbitrate_detections(cands, dung_arbitration=False)
+        assert off.surviving_ids == frozenset({"fp", "cnt"})
+        assert on.surviving_ids == frozenset({"cnt"})
+        assert on.eliminated_ids["fp"] == "defeated_by_walton_krabbe_refutation"
+
+    def test_mutual_refutation_eliminates_both(self) -> None:
+        # s0 ↔ r0 mutual refutation (Walton-Krabbe tie) → grounded = ∅, both out.
+        cands = [_cand("s0", span="a"), _cand("r0", span="b")]
+        relations = {"s0": frozenset({"r0"}), "r0": frozenset({"s0"})}
+        on = arbitrate_detections(
+            cands, dung_arbitration=True, walton_krabbe_relations=relations
+        )
+        assert on.surviving_ids == frozenset()
+        assert set(on.eliminated_ids) == {"s0", "r0"}
+        assert on.honest_absent is False
+
+    def test_refuter_defeated_does_not_eliminate_target(self) -> None:
+        # Genuine grounded semantics, not blind attack-counting. Chain:
+        #   defender → refuter → target
+        # defender (unattacked) is in; refuter is attacked by defender (in) → out;
+        # target's only attacker (refuter) is counter-attacked by defender (in) →
+        # target is DEFENDED and survives. The refuter does not eliminate it.
+        cands = [
+            _cand("target", span="a"),
+            _cand("refuter", span="b"),
+            _cand("defender", span="c"),
+        ]
+        relations = {
+            "refuter": frozenset({"target"}),
+            "defender": frozenset({"refuter"}),
+        }
+        on = arbitrate_detections(
+            cands, dung_arbitration=True, walton_krabbe_relations=relations
+        )
+        assert "defender" in on.surviving_ids
+        assert "target" in on.surviving_ids
+        assert "refuter" not in on.surviving_ids
+
+
+class TestAttackingActsContract:
+    def test_attacking_acts_are_refute_and_challenge(self) -> None:
+        assert WALTON_KRABBE_ATTACKING_ACTS == frozenset(
+            {SpeechAct.REFUTE, SpeechAct.CHALLENGE}
+        )
+        # Cooperative acts are excluded (they never yield an attack).
+        assert SpeechAct.CONCEDE not in WALTON_KRABBE_ATTACKING_ACTS
+        assert SpeechAct.SUPPORT not in WALTON_KRABBE_ATTACKING_ACTS


### PR DESCRIPTION
## Track I1 #1501 — PR1: selectable `dung_arbitration` stage + Walton-Krabbe policy

Epic #1498 · lane po-2023. First PR of a multi-PR increment delivering #1501.

### Scope decision (verified, not assumed)
- **#1429 (CLOSED)** delivered `neuro_symbolic_arbitrator.compare_sophism_backends` — a **bilateral comparison harness** (neural vs neuro-symbolic), wired into `compare_all_axes` (I6 #1437).
- **#1501** asks for a distinct artifact: a **selectable production stage** that **alters the detection verdict** (filter a FP / reinstate a candidate), with **Walton-Krabbe (`debate/protocols.py`) as the candidate-vs-candidate attack source**, and a verdict **traceable in state**.
- Grep confirms no `dung_arbitration` flag/stage exists anywhere. This is a new increment, **not** a rewrite of #1429.

### What PR1 delivers
- `dung_arbitration_stage.py`:
  - `arbitrate_detections(candidates, *, dung_arbitration, ...)` — the selectable stage. `False` (default) = passthrough (output == input, backward-compat); `True` = the grounded extension decides which candidates survive.
  - `walton_krabbe_conflict_policy(relations)` — derives candidate-vs-candidate Dung attacks from declared `SpeechAct.REFUTE`/`CHALLENGE` relations (the DebateAgent-as-attack-source dimension; PR2/PR3 wires DebateAgent to produce them).
  - `ArbitrationVerdict` — formal, traceable outcome (surviving_ids, eliminated_ids with machine-checkable reasons, attacks, honest_absent).
- Reuses `neuro_symbolic_arbitrator.arbitrate()` + the pure-python grounded solver (anti-duplication: no Dung semantics reimplemented — I5 owns the solver).

### DoD mapping (#1501)
| DoD | PR1 | PR2 (next) |
|---|---|---|
| selectable flag, default OFF | ✅ | — |
| verdict changed on ≥1 synthetic case | ✅ (4 cases) | — |
| test calls the real consumer | ✅ unit (stage → arbitrate → grounded solver) | ✅ integration (wired phase) |
| formal verdict traceable in state | (verdict dataclass ready) | ✅ `_write_dung_arbitration_to_state` |

### Anti-theatre #1019 (verified firsthand, JVM/LLM-free)
13 unit tests PASS. The stage CHANGES the verdict on four Walton-Krabbe cases:
- a refuted candidate is filtered (survives when OFF, eliminated when ON);
- a hasty-generalization FP filtered by a surviving empirical counter-argument;
- mutual refutation eliminates both (grounded extension = ∅);
- a defended target survives (genuine grounded defense, not blind attack-counting).

And it is transparent when there is nothing genuine to arbitrate (honest-absent: enabled output == disabled output).

### Up next (PR2)
Rule-vs-ML candidate producer (`TaxonomySophismDetector` + LLM detector → `SophismCandidate`), `_write_dung_arbitration_to_state` (verdict → `UnifiedAnalysisState`), flag plumbing into the detection config, and an integration test through the wired phase. PR3 (conditional): honest-degraded real-corpus run / DebateAgent-produced refutations.

### Privacy
Synthetic opaque atoms only; no corpus touched, no `raw_text`, no source names. Commit and PR messages are opaque.

🤖 Worker myia-po-2023 — I1 #1501 PR1
