### PR TITLE
feat(dung): labelling trajectory under sequential arrival (S6-A2 #1506)

### DIFF
--- a/argumentation_analysis/orchestration/dung_labelling_trajectory.py
+++ b/argumentation_analysis/orchestration/dung_labelling_trajectory.py
@@ -1,0 +1,296 @@
+"""Dung labelling trajectory under sequential argument arrival (Track S6-A2 #1506).
+
+A CoursIA strate-6 **Phase-A candidate substrate (#1)** — "the discourse as a
+substrate": a discourse that delivers arguments one by one induces a
+**trajectory of labelling states** (in / out / undec) under grounded semantics.
+This module computes that trajectory by consuming the existing
+:mod:`abs_arg_dung.backends` grounded reasoner; it implements **no** Dung
+semantics of its own (anti-pendule: reuse, don't reimplement — I5/po-2025 owns
+the backend in ``abs_arg_dung/backends/**``).
+
+Concept
+-------
+A *labelling* of an argumentation framework (AF) under a semantics is a total
+function ``L: Args -> {in, out, undec}``. From the unique grounded extension
+``G`` (computed by :func:`abs_arg_dung.backends.compute_grounded`):
+
+* ``in    = G``                              — accepted (defended) arguments
+* ``out   = { x : some g in G attacks x }``  — rejected by an accepted argument
+* ``undec = Args \\ (in ∪ out)``             — undecided (typically cycles)
+
+A *trajectory* fixes an arrival order over the arguments (the discourse's
+rhetorical sequencing) and, for each prefix ``k``, restricts the AF to the
+arguments arrived so far and records the grounded labelling. The sequence of
+labellings is the substrate: it shows how each argument's status **evolves** as
+the discourse unfolds — an argument accepted early may be refuted (in -> out)
+when a later attacker arrives; an undecided argument may be reinstated (undec ->
+in) when a defender lands.
+
+JVM-free by design
+------------------
+The trajectory reuses the pure-Python ``compute_grounded`` so it is fully
+unit-testable with synthetic opaque atoms and no JVM, no LLM. The CLI
+(:mod:`scripts.labelling_trajectory`) adds an optional Tweety cross-check on the
+full AF (honest degradation if the JVM is unavailable), reusing the
+:mod:`scripts.compare_dung_backends` pattern.
+
+Privacy HARD (S6)
+-----------------
+The bundled exemplar (:func:`build_discourse_exemplar`) is a **structurally
+realistic synthetic AF with opaque ids** (``prop_*`` / ``arg_*`` tokens), NOT a
+decrypted corpus. The substrate demonstrated here is the *trajectory-of-labellings
+concept*; a corpus-derived AF would be a heavier follow-up (text -> arguments ->
+attacks extraction), out of scope for this Phase-A *candidate*. Zero ``raw_text``,
+zero source names, zero corpus access.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+# Reuse the existing grounded reasoner (collision-safe: import, do NOT modify
+# the backend subpackage — I5/po-2025 owns abs_arg_dung/backends/**).
+from abs_arg_dung.backends import compute_grounded
+
+Attack = Tuple[str, str]
+LabellingMap = Dict[str, str]  # arg_id -> "in" | "out" | "undec"
+
+
+@dataclass(frozen=True)
+class Labelling:
+    """A grounded labelling of one (sub-)framework.
+
+    Attributes:
+        arguments: The arguments present in this (sub-)framework, in arrival
+            order. Kept so callers can render the labelling in discourse order.
+        in_args: Accepted (grounded) arguments.
+        out_args: Arguments attacked by some accepted argument.
+        undec_args: The remaining arguments (neither in nor out).
+    """
+
+    arguments: Tuple[str, ...]
+    in_args: frozenset[str]
+    out_args: frozenset[str]
+    undec_args: frozenset[str]
+
+    def as_map(self) -> LabellingMap:
+        """Return the labelling as ``{arg_id: "in"|"out"|"undec"}``."""
+        m: LabellingMap = {}
+        for a in self.in_args:
+            m[a] = "in"
+        for a in self.out_args:
+            m[a] = "out"
+        for a in self.undec_args:
+            m[a] = "undec"
+        return m
+
+
+def labelling_from_grounded(
+    arguments: Sequence[str], attacks: Iterable[Attack]
+) -> Labelling:
+    """Compute the grounded labelling of an AF.
+
+    ``in`` = the unique grounded extension (via
+    :func:`abs_arg_dung.backends.compute_grounded`); ``out`` = arguments attacked
+    by some ``in`` argument; ``undec`` = the rest. Deterministic (the grounded
+    extension is unique). Unknown attack endpoints are ignored, matching the
+    backend's own defensive handling.
+    """
+
+    arg_tuple = tuple(arguments)
+    arg_set = set(arg_tuple)
+    attack_set = {(s, t) for s, t in attacks if s in arg_set and t in arg_set}
+
+    grounded = set(compute_grounded(list(arg_tuple), list(attack_set)))
+    out_args = {t for (s, t) in attack_set if s in grounded}
+    # in and out are disjoint by grounded's definition (a grounded argument
+    # cannot be attacked by another grounded argument), but we guard anyway.
+    out_args -= grounded
+    undec_args = arg_set - grounded - out_args
+    return Labelling(
+        arguments=arg_tuple,
+        in_args=frozenset(grounded),
+        out_args=frozenset(out_args),
+        undec_args=frozenset(undec_args),
+    )
+
+
+@dataclass(frozen=True)
+class TrajectoryStep:
+    """One step of the labelling trajectory: the labelling after ``k`` arrivals.
+
+    Attributes:
+        step: 1-based index of the arrival count (``step == k`` means the first
+            ``k`` arguments of the arrival order have landed).
+        arrived: The arguments arrived so far, in arrival order.
+        labelling: The grounded labelling of the sub-framework restricted to
+            ``arrived``.
+    """
+
+    step: int
+    arrived: Tuple[str, ...]
+    labelling: Labelling
+
+
+def labelling_trajectory(
+    arguments: Sequence[str],
+    attacks: Iterable[Attack],
+    arrival_order: Sequence[str],
+) -> List[TrajectoryStep]:
+    """Compute the labelling trajectory under sequential argument arrival.
+
+    For each ``k`` in ``1..len(arrival_order)``, restricts the AF to the first
+    ``k`` arrived arguments (keeping only attacks whose both endpoints have
+    arrived) and records the grounded labelling. The returned list is the
+    trajectory — a sequence of labelling states showing how each argument's
+    status evolves as the discourse unfolds.
+
+    Args:
+        arguments: All arguments of the full AF (used to validate the arrival
+            order is a permutation; the trajectory itself only ever touches the
+            arrived subset).
+        attacks: Attack relation of the full AF.
+        arrival_order: A permutation of ``arguments`` — the rhetorical order in
+            which the discourse delivers them.
+
+    Returns:
+        The trajectory, one :class:`TrajectoryStep` per prefix length.
+
+    Raises:
+        ValueError: If ``arrival_order`` is not a permutation of ``arguments``
+            (defensive — a mismatched order would silently produce a misleading
+            trajectory).
+    """
+
+    full = set(arguments)
+    if set(arrival_order) != full:
+        raise ValueError(
+            "arrival_order must be a permutation of arguments: "
+            f"missing={full - set(arrival_order)}, "
+            f"extra={set(arrival_order) - full}"
+        )
+    attack_list = list(attacks)
+
+    steps: List[TrajectoryStep] = []
+    arrived: List[str] = []
+    for k, arg in enumerate(arrival_order, start=1):
+        arrived.append(arg)
+        arrived_set = set(arrived)
+        prefix_attacks = [
+            (s, t) for (s, t) in attack_list if s in arrived_set and t in arrived_set
+        ]
+        lab = labelling_from_grounded(tuple(arrived), prefix_attacks)
+        steps.append(TrajectoryStep(step=k, arrived=tuple(arrived), labelling=lab))
+    return steps
+
+
+def label_transitions(
+    trajectory: Sequence[TrajectoryStep],
+) -> Dict[str, Tuple[str, ...]]:
+    """Per-argument label sequence across the trajectory (after its first arrival).
+
+    Returns ``{arg_id: (label_at_step_of_arrival, ..., label_at_final_step)}``.
+    An argument's sequence starts at the step where it arrives (its label before
+    arrival is undefined). Useful to surface the dynamics (in -> out, undec ->
+    in) that make the trajectory a non-trivial substrate.
+    """
+
+    transitions: Dict[str, Tuple[str, ...]] = {}
+    for step in trajectory:
+        m = step.labelling.as_map()
+        for arg, label in m.items():
+            transitions.setdefault(arg, ())
+            if arg in step.arrived:
+                transitions[arg] = (*transitions[arg], label)
+    return transitions
+
+
+def render_trajectory(trajectory: Sequence[TrajectoryStep]) -> str:
+    """Human-readable table of the trajectory (step | arrived | in/out/undec)."""
+
+    lines = ["step | arrived            | in          | out         | undec"]
+    lines.append("-----+-------------------+-------------+-------------+------")
+    for step in trajectory:
+        lab = step.labelling
+        lines.append(
+            f" {step.step:>2} | {','.join(step.arrived):<17} | "
+            f"{','.join(sorted(lab.in_args)) or '-':<11} | "
+            f"{','.join(sorted(lab.out_args)) or '-':<11} | "
+            f"{','.join(sorted(lab.undec_args)) or '-'}"
+        )
+    return "\n".join(lines)
+
+
+# --------------------------------------------------------------------------- #
+# Structural exemplar (opaque ids, privacy HARD)                              #
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class DiscourseExemplar:
+    """A structurally-realistic synthetic AF with opaque ids (privacy HARD).
+
+    The exemplar is NOT a decrypted corpus: it is a hand-crafted framework
+    designed to exhibit the full labelling-trajectory dynamics (an argument
+    accepted then refuted; an undecided argument reinstated by a defender). The
+    substrate is the trajectory *concept*; this instance makes it concrete and
+    falsifiable for the CoursIA Phase-A candidate #1.
+    """
+
+    arguments: Tuple[str, ...]
+    attacks: Tuple[Attack, ...]
+    arrival_order: Tuple[str, ...]
+    notes: Tuple[str, ...] = field(default_factory=tuple)
+
+
+def build_discourse_exemplar() -> DiscourseExemplar:
+    """Build the canonical S6-A2 discourse exemplar (opaque ids, deterministic).
+
+    Structure (opaque ``prop_*`` ids — no source content, privacy HARD):
+
+    * ``prop_thesis`` — an unattacked opening claim (the discourse's thesis).
+    * ``prop_counter`` — an attacker that later refutes the thesis.
+    * ``prop_cycle_a`` / ``prop_cycle_b`` — a mutual-attack pair (a 2-cycle),
+      undecided in isolation.
+    * ``prop_defender`` — an unattacked late argument that attacks the cycle,
+      reinstating one member of the pair.
+
+    Arrival order is chosen so the trajectory shows three genuine dynamics:
+    acceptance (``prop_thesis`` in), refutation (``prop_thesis`` in -> out when
+    ``prop_counter`` lands), and reinstatement (a cycle member undec -> in when
+    ``prop_defender`` lands). Returned ids are opaque; ``notes`` describe the
+    intended dynamics without any source-revealing content.
+    """
+
+    arguments = (
+        "prop_thesis",
+        "prop_counter",
+        "prop_cycle_a",
+        "prop_cycle_b",
+        "prop_defender",
+    )
+    attacks = (
+        # The counter refutes the thesis (delivered AFTER the thesis).
+        ("prop_counter", "prop_thesis"),
+        # A mutual-attack 2-cycle: undecided in isolation.
+        ("prop_cycle_a", "prop_cycle_b"),
+        ("prop_cycle_b", "prop_cycle_a"),
+        # A defender (unattacked) attacks one cycle member; under grounded this
+        # defends the OTHER member of the pair (reinstatement: undec -> in).
+        ("prop_defender", "prop_cycle_a"),
+    )
+    arrival_order = (
+        "prop_thesis",  # step 1: thesis accepted (in).
+        "prop_cycle_a",  # step 2: cycle half arrives, alone -> in (unattacked).
+        "prop_cycle_b",  # step 3: cycle completes -> both undec.
+        "prop_counter",  # step 4: thesis refuted (in -> out).
+        "prop_defender",  # step 5: defender lands -> cycle_b reinstated (undec -> in).
+    )
+    notes = (
+        "Structural exemplar only — opaque ids, no source content (privacy HARD).",
+        "Dynamics demonstrated: acceptance, refutation (in->out), reinstatement (undec->in).",
+    )
+    return DiscourseExemplar(
+        arguments=arguments, attacks=attacks, arrival_order=arrival_order, notes=notes
+    )

--- a/docs/coursia_contrib/s6_a2_labelling_trajectory.md
+++ b/docs/coursia_contrib/s6_a2_labelling_trajectory.md
@@ -1,0 +1,97 @@
+# S6-A2 — Discourse as a substrate: Dung labelling trajectory
+
+**Track**: S6-A2 (issue #1506) · **Epic**: CoursIA strate-6 ICT.
+**CoursIA gate**: Phase-A candidate **#1** for seed
+[`jsboige/CoursIA#7289`](https://github.com/jsboige/CoursIA/issues/7289) —
+"the discourse as a substrate" — one of the ≥2 independent falsifiability
+substrates required by contract [`jsboige/CoursIA#7291`](https://github.com/jsboige/CoursIA/issues/7291).
+**Engine**: [`argumentation_analysis/orchestration/dung_labelling_trajectory.py`](../../argumentation_analysis/orchestration/dung_labelling_trajectory.py) ·
+**CLI**: [`scripts/labelling_trajectory.py`](../../scripts/labelling_trajectory.py).
+
+## The thesis
+
+A discourse does not arrive all at once — it delivers arguments one by one, in a
+rhetorical order. Under Dung's grounded semantics, each prefix of the arrival
+sequence induces a **labelling** of the arguments seen so far:
+
+- **in** — accepted (defended) arguments,
+- **out** — arguments attacked by some accepted argument,
+- **undec** — the rest (typically cycles, undecided in isolation).
+
+The sequence of labellings across the arrival is a **trajectory of states**. As
+the discourse unfolds, an argument's status *evolves*: a claim accepted early is
+**refuted** (`in → out`) when a later attacker lands; a cycle member that was
+**undecided** is **reinstated** (`undec → in`) when a defender arrives. This
+trajectory is the substrate: it turns a static abstract argumentation framework
+into a *process* that a downstream model (e.g. a belief-state transition matrix,
+the sibling S6-A1 substrate) can read off.
+
+## The canonical exemplar
+
+A structurally-realistic synthetic framework with **opaque ids** (privacy HARD)
+exhibiting all three dynamics:
+
+| step | arrived | in | out | undec |
+|-----:|---------|----|----|-------|
+| 1 | `prop_thesis` | `prop_thesis` | — | — |
+| 2 | …`prop_cycle_a` | +`prop_cycle_a` | — | — |
+| 3 | …`prop_cycle_b` | `prop_thesis` | — | `prop_cycle_a, prop_cycle_b` |
+| 4 | …`prop_counter` | `prop_counter` | `prop_thesis` | `prop_cycle_a, prop_cycle_b` |
+| 5 | …`prop_defender` | `prop_counter, prop_defender, prop_cycle_b` | `prop_thesis, prop_cycle_a` | — |
+
+Dynamics, verified firsthand (`pytest tests/unit/argumentation_analysis/orchestration/test_dung_labelling_trajectory.py`):
+
+- **Refutation**: `prop_thesis` `in` (steps 1–3) → `out` (step 4) when
+  `prop_counter` lands and is itself accepted.
+- **Reinstatement**: `prop_cycle_b` `undec` (steps 3–4) → `in` (step 5) when
+  `prop_defender` attacks `prop_cycle_a`, thereby defending `prop_cycle_b`.
+
+## Reproduce
+
+```bash
+# Render the trajectory table + transitions
+python scripts/labelling_trajectory.py --exemplar discourse
+
+# Cross-check the native grounded extension against Tweety on the full AF
+# (honest degradation if the JVM is unavailable)
+python scripts/labelling_trajectory.py --exemplar discourse --cross-check-tweety
+
+# JSON export
+python scripts/labelling_trajectory.py --json trajectory.json
+```
+
+## Backends & anti-théâtre
+
+The trajectory reuses the pure-Python
+[`abs_arg_dung.backends.compute_grounded`](../../abs_arg_dung/backends/native.py)
+reasoner (the I5 #1502 multi-backend comparison's native side, with the direction
+inversion fixed on `main`). No Dung semantics are reimplemented here
+(anti-pendule). The CLI offers an optional native-vs-Tweety grounded cross-check
+on the full AF: the two backends must agree, or the disagreement is reported
+verbatim — never auto-reconciled (anti-théâtre #1019). If the JVM is unavailable,
+the trajectory (computed JVM-free) still stands; the cross-check degrades
+honestly.
+
+## Scope & honesty (what this is, and is not)
+
+- **What it is**: a Phase-A *candidate substrate* — the trajectory-of-labellings
+  concept, made executable and falsifiable on a structural exemplar.
+- **What it is not (yet)**: a corpus-derived AF. Deriving an AF from a real
+  discourse requires the text → arguments → attacks extraction pipeline and is
+  privacy-sensitive; it is a deliberate follow-up, out of scope for this
+  candidate. The exemplar uses **opaque `prop_*` ids** with **no source content**
+  and **no corpus access** — privacy HARD.
+- **Falsifiability**: the trajectory is deterministic and machine-checked. If
+  grounded semantics on the exemplar did not produce the refutation/reinstatement
+  dynamics above, the substrate would be falsified — it is not asserted, it is
+  computed.
+
+## Relation to the sibling substrate
+
+S6-A1 (po-2025) produces candidate **#2** — a transition matrix over *belief
+states* extracted from a real source. This candidate **#1** is its symbolic
+complement: a trajectory over *labelling states* from abstract argumentation. The
+two are independent (one reasons over belief states, the other over Dung
+labellings), satisfying the contract's ≥2-substrate requirement.
+
+— Track S6-A2 · worker myia-po-2023 · #1506

--- a/scripts/labelling_trajectory.py
+++ b/scripts/labelling_trajectory.py
@@ -1,0 +1,180 @@
+"""Standalone CLI: Dung labelling trajectory under sequential argument arrival.
+
+Track S6-A2 (#1506) — CoursIA strate-6 Phase-A candidate substrate #1: "the
+discourse as a substrate". A discourse delivers arguments one by one; under
+grounded semantics each prefix induces a labelling (in/out/undec). This CLI
+renders the resulting **trajectory of labelling states** and, optionally,
+cross-checks the native Python backend against Tweety on the full AF (honest
+degradation if the JVM is unavailable).
+
+Privacy: touches ONLY synthetic frameworks with opaque ids. Never reads the
+encrypted corpus. See the engine docstring in
+:mod:`argumentation_analysis.orchestration.dung_labelling_trajectory`.
+
+Usage::
+
+    # Default: the canonical opaque discourse exemplar (acceptance/refutation/reinstatement)
+    python scripts/labelling_trajectory.py --exemplar discourse
+
+    # Cross-check the native grounded extension against Tweety on the full AF
+    python scripts/labelling_trajectory.py --exemplar discourse --cross-check-tweety
+
+    # Write the trajectory as JSON
+    python scripts/labelling_trajectory.py --json trajectory.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+# Ensure the project root is on sys.path so the engine + backends resolve.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from argumentation_analysis.orchestration.dung_labelling_trajectory import (  # noqa: E402
+    DiscourseExemplar,
+    build_discourse_exemplar,
+    label_transitions,
+    labelling_trajectory,
+    render_trajectory,
+)
+
+
+def _trajectory_to_jsonable(exemplar: DiscourseExemplar) -> Dict[str, Any]:
+    trajectory = labelling_trajectory(
+        exemplar.arguments, exemplar.attacks, exemplar.arrival_order
+    )
+    return {
+        "arguments": list(exemplar.arguments),
+        "attacks": [list(a) for a in exemplar.attacks],
+        "arrival_order": list(exemplar.arrival_order),
+        "trajectory": [
+            {
+                "step": s.step,
+                "arrived": list(s.arrived),
+                "in": sorted(s.labelling.in_args),
+                "out": sorted(s.labelling.out_args),
+                "undec": sorted(s.labelling.undec_args),
+            }
+            for s in trajectory
+        ],
+        "transitions": {
+            arg: list(seq) for arg, seq in sorted(label_transitions(trajectory).items())
+        },
+    }
+
+
+def _try_tweety_grounded(
+    args: List[str], atts: List[Tuple[str, str]]
+) -> Tuple[bool, List[str] | None, str]:
+    """Native-vs-Tweety grounded cross-check on the full AF (honest degradation).
+
+    Mirrors ``scripts.compare_dung_backends._try_run_tweety``: lazy-imports the
+    sanctuary ``DungAgent`` + idempotent ``initialize_jvm``; returns
+    ``(available, grounded_extension_or_None, note)``. If the JVM/Tweety is
+    unavailable, the trajectory (computed with the pure-Python backend) still
+    stands — the cross-check is a validation, not a dependency.
+    """
+
+    try:
+        from abs_arg_dung.agent import DungAgent  # sanctuary #893
+        from argumentation_analysis.core.jvm_setup import initialize_jvm
+    except Exception as exc:  # noqa: BLE001 — optional dependency
+        return False, None, f"Tweety import unavailable: {exc}"
+    try:
+        if not initialize_jvm():
+            return False, None, "JVM unavailable (initialize_jvm returned False)"
+        agent = DungAgent()  # type: ignore[no-untyped-call]
+        for a in args:
+            agent.add_argument(a)
+        for src, tgt in atts:
+            agent.add_attack(src, tgt)
+        ext = sorted(agent.get_grounded_extension())  # type: ignore[no-untyped-call]
+        return True, ext, "abs_arg_dung.DungAgent via JPype (Tweety 1.28)"
+    except Exception as exc:  # noqa: BLE001 — JVM-dependent, pragma: no cover
+        return False, None, f"error: {exc}"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Dung labelling trajectory under sequential argument arrival "
+            "(S6-A2 #1506 — CoursIA Phase-A candidate substrate #1). "
+            "Touches only synthetic opaque-id frameworks."
+        ),
+    )
+    p.add_argument(
+        "--exemplar",
+        choices=["discourse"],
+        default="discourse",
+        help="Which exemplar AF to run (only 'discourse' for now).",
+    )
+    p.add_argument(
+        "--cross-check-tweety",
+        action="store_true",
+        help="Cross-check the native grounded extension against Tweety on the "
+        "full AF (honest degradation if the JVM is unavailable).",
+    )
+    p.add_argument(
+        "--json",
+        type=str,
+        default=None,
+        help="Write the full trajectory (steps + transitions) as JSON to this path.",
+    )
+    return p
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    exemplar = build_discourse_exemplar()
+
+    trajectory = labelling_trajectory(
+        exemplar.arguments, exemplar.attacks, exemplar.arrival_order
+    )
+
+    print("=== S6-A2 labelling trajectory (opaque discourse exemplar) ===")
+    for note in exemplar.notes:
+        print(f"# {note}")
+    print()
+    print(render_trajectory(trajectory))
+
+    print("\n--- label transitions (per argument, from its arrival) ---")
+    for arg, seq in sorted(label_transitions(trajectory).items()):
+        print(f"  {arg:<16}: {' -> '.join(seq)}")
+
+    if args.cross_check_tweety:
+        from abs_arg_dung.backends import compute_grounded
+
+        native = sorted(
+            compute_grounded(list(exemplar.arguments), list(exemplar.attacks))
+        )
+        ok, tweety_ext, note = _try_tweety_grounded(
+            list(exemplar.arguments), list(exemplar.attacks)
+        )
+        print("\n--- native ≡ Tweety grounded cross-check (full AF) ---")
+        print(f"  native (python): {native}")
+        if ok and tweety_ext is not None:
+            agree = set(native) == set(tweety_ext)
+            print(f"  tweety:          {tweety_ext}")
+            print(f"  agree: {agree}   ({note})")
+        else:
+            print(f"  tweety: UNAVAILABLE — {note}")
+            print(
+                "  (trajectory computed with the pure-Python backend; "
+                "cross-check degraded, anti-théâtre #1019)"
+            )
+
+    if args.json:
+        payload = _trajectory_to_jsonable(exemplar)
+        Path(args.json).write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"\nWritten: {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_labelling_trajectory.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_labelling_trajectory.py
@@ -1,0 +1,145 @@
+"""Unit tests for the Dung labelling trajectory (Track S6-A2 #1506).
+
+JVM/LLM-free: the engine reuses ``abs_arg_dung.backends.compute_grounded`` (pure
+Python), so every test runs on synthetic opaque atoms. The tests assert the
+trajectory DYNAMICS firsthand (acceptance, refutation in->out, reinstatement
+undec->in) — the non-trivial behaviour that makes the trajectory a genuine
+strate-6 substrate rather than a flat list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from argumentation_analysis.orchestration.dung_labelling_trajectory import (
+    build_discourse_exemplar,
+    label_transitions,
+    labelling_from_grounded,
+    labelling_trajectory,
+    render_trajectory,
+)
+
+
+class TestLabellingFromGrounded:
+    def test_single_unattacked_argument_is_in(self) -> None:
+        lab = labelling_from_grounded(["a"], [])
+        assert lab.in_args == frozenset({"a"})
+        assert lab.out_args == frozenset()
+        assert lab.undec_args == frozenset()
+
+    def test_chain_grounds_alternating(self) -> None:
+        # a -> b -> c: grounded = {a, c}; b is out.
+        lab = labelling_from_grounded(["a", "b", "c"], [("a", "b"), ("b", "c")])
+        assert lab.in_args == frozenset({"a", "c"})
+        assert lab.out_args == frozenset({"b"})
+        assert lab.undec_args == frozenset()
+
+    def test_mutual_attack_cycle_is_all_undec(self) -> None:
+        # a <-> b: grounded = {}; both undecided (no unattacked seed).
+        lab = labelling_from_grounded(["a", "b"], [("a", "b"), ("b", "a")])
+        assert lab.in_args == frozenset()
+        assert lab.out_args == frozenset()
+        assert lab.undec_args == frozenset({"a", "b"})
+
+    def test_unknown_attack_endpoints_ignored(self) -> None:
+        # Attacks referencing args not in the set are dropped (defensive).
+        lab = labelling_from_grounded(["a"], [("a", "ghost"), ("ghost", "a")])
+        assert lab.in_args == frozenset({"a"})
+
+    def test_as_map_covers_every_argument(self) -> None:
+        lab = labelling_from_grounded(["a", "b", "c"], [("a", "b")])
+        m = lab.as_map()
+        assert set(m) == {"a", "b", "c"}
+        assert m["a"] == "in"
+        assert m["b"] == "out"
+        # c is isolated (unattacked) -> trivially acceptable -> in the grounded
+        # extension, NOT undecided.
+        assert m["c"] == "in"
+
+
+class TestLabellingTrajectory:
+    def test_trajectory_length_equals_arrival_count(self) -> None:
+        args = ["a", "b", "c"]
+        atts = [("a", "b")]
+        traj = labelling_trajectory(args, atts, ["a", "b", "c"])
+        assert len(traj) == 3
+        assert [s.step for s in traj] == [1, 2, 3]
+
+    def test_refutation_dynamic_in_to_out(self) -> None:
+        # Thesis accepted at step 1; refuted (in -> out) when the counter lands.
+        args = ["prop_thesis", "prop_counter"]
+        atts = [("prop_counter", "prop_thesis")]
+        traj = labelling_trajectory(args, atts, ["prop_thesis", "prop_counter"])
+        assert traj[0].labelling.in_args == frozenset({"prop_thesis"})
+        assert "prop_thesis" in traj[0].labelling.in_args
+        # After the counter arrives, the thesis is out (counter in, defends nothing
+        # else; thesis attacked by the accepted counter).
+        assert traj[1].labelling.in_args == frozenset({"prop_counter"})
+        assert traj[1].labelling.out_args == frozenset({"prop_thesis"})
+
+    def test_prefix_only_keeps_arrived_attacks(self) -> None:
+        # An attack whose target has not arrived yet must not affect the prefix.
+        args = ["a", "b"]
+        atts = [("b", "a")]  # b refutes a, but a arrives first.
+        traj = labelling_trajectory(args, atts, ["a", "b"])
+        # Step 1: only {a}, no attack within prefix -> a in.
+        assert traj[0].labelling.in_args == frozenset({"a"})
+        # Step 2: b arrives, attacks a; b unattacked -> in, a out.
+        assert traj[1].labelling.in_args == frozenset({"b"})
+        assert traj[1].labelling.out_args == frozenset({"a"})
+
+    def test_arrival_order_not_a_permutation_raises(self) -> None:
+        with pytest.raises(ValueError, match="permutation"):
+            labelling_trajectory(["a", "b"], [], ["a", "c"])
+
+    def test_deterministic_repeat(self) -> None:
+        args = ["a", "b", "c"]
+        atts = [("a", "b"), ("b", "c")]
+        t1 = labelling_trajectory(args, atts, ["a", "b", "c"])
+        t2 = labelling_trajectory(args, atts, ["a", "b", "c"])
+        assert [s.labelling for s in t1] == [s.labelling for s in t2]
+
+
+class TestLabelTransitions:
+    def test_transitions_start_at_arrival(self) -> None:
+        traj = labelling_trajectory(["a", "b"], [("b", "a")], ["a", "b"])
+        tr = label_transitions(traj)
+        # a arrives step1 (in), then out step2 -> (in, out).
+        assert tr["a"] == ("in", "out")
+        # b arrives step2 (in) -> (in,).
+        assert tr["b"] == ("in",)
+
+
+class TestDiscourseExemplar:
+    """The canonical S6-A2 exemplar: acceptance + refutation + reinstatement."""
+
+    def test_exemplar_uses_opaque_ids_no_raw_text(self) -> None:
+        ex = build_discourse_exemplar()
+        # Privacy HARD: opaque prop_* tokens, never source content.
+        for a in ex.arguments:
+            assert a.startswith("prop_"), f"non-opaque id leaked: {a!r}"
+
+    def test_exemplar_trajectory_shows_full_dynamics(self) -> None:
+        ex = build_discourse_exemplar()
+        traj = labelling_trajectory(ex.arguments, ex.attacks, ex.arrival_order)
+        tr = label_transitions(traj)
+
+        # Refutation: thesis accepted early, refuted (in -> out) when the
+        # counter lands (step 4).
+        assert tr["prop_thesis"][0] == "in"  # accepted at arrival
+        assert tr["prop_thesis"][-1] == "out"  # refuted by the end
+
+        # Reinstatement: a cycle member is undecided, then reinstated (undec ->
+        # in) when the defender lands (step 5).
+        assert tr["prop_cycle_b"][0] == "undec"  # undecided on arrival (cycle)
+        assert tr["prop_cycle_b"][-1] == "in"  # reinstated by the defender
+
+        # The defender, once landed, is accepted (unattacked seed).
+        assert tr["prop_defender"] == ("in",)
+
+    def test_render_trajectory_is_non_empty(self) -> None:
+        ex = build_discourse_exemplar()
+        traj = labelling_trajectory(ex.arguments, ex.attacks, ex.arrival_order)
+        rendered = render_trajectory(traj)
+        assert "step" in rendered
+        assert rendered.count("\n") >= len(ex.arguments)


### PR DESCRIPTION
## S6-A2 (#1506) — Discourse as a substrate: Dung labelling trajectory

CoursIA strate-6 Phase-A **candidate substrate #1** — "the discourse as a substrate"
(seed [`CoursIA#7289`](https://github.com/jsboige/CoursIA/issues/7289)). One of
the ≥2 independent falsifiability substrates required by contract
[`CoursIA#7291`](https://github.com/jsboige/CoursIA/issues/7291); the sibling
candidate #2 (S6-A1, po-2025) is a belief-state transition matrix.

### The thesis
A discourse delivers arguments one by one. Under grounded semantics, each prefix
of the arrival induces a **labelling** (in/out/undec). The sequence of labellings
is a **trajectory of states**: an argument accepted early is **refuted**
(`in → out`) when a later attacker lands; a cycle member **undecided** is
**reinstated** (`undec → in`) when a defender arrives. The trajectory turns a
static AF into a *process* — the substrate.

### What this PR delivers
- **Engine** [`dung_labelling_trajectory.py`](argumentation_analysis/orchestration/dung_labelling_trajectory.py) — `Labelling`, `labelling_from_grounded`, `TrajectoryStep`, `labelling_trajectory`, `label_transitions`, `render_trajectory`, `build_discourse_exemplar`. Pure-stdlib, JVM/LLM-free. **Reuses** `abs_arg_dung.backends.compute_grounded` (anti-pendule: no Dung semantics reimplemented; I5 owns the backend, the #1502 direction fix is on `main` → gate lifted).
- **CLI** [`scripts/labelling_trajectory.py`](scripts/labelling_trajectory.py) — trajectory table + transitions, optional **native-vs-Tweety grounded cross-check** on the full AF (honest degradation if JVM unavailable, anti-théâtre #1019), JSON export.
- **Doc** [`docs/coursia_contrib/s6_a2_labelling_trajectory.md`](docs/coursia_contrib/s6_a2_labelling_trajectory.md) — links to #7289 candidate #1, thesis, exemplar dynamics, backends, scope.
- **Tests** 14 JVM/LLM-free unit tests asserting the dynamics firsthand.

### DoD (#1506 S6-A2, verified firsthand)
| DoD | Status |
|---|---|
| script executable producing a labelling trajectory | ✅ CLI renders the full trajectory |
| trajectory on ≥1 AF | ✅ opaque discourse exemplar (5 args, 4 attacks) |
| labellings DECIDE via backend (native ≡ Tweety) | ✅ trajectory computed via `compute_grounded`; optional native-vs-Tweety cross-check |
| opaque ids | ✅ `prop_*` tokens |
| short doc linking to #7289 candidate #1 | ✅ `docs/coursia_contrib/s6_a2_labelling_trajectory.md` |

Trajectory smoke run (dynamics confirmed, not asserted):
```
prop_thesis  : in -> in -> in -> out -> out      # refutation at step 4
prop_cycle_b : undec -> undec -> in              # reinstatement at step 5
prop_cycle_a : in -> undec -> undec -> out
prop_defender: in
prop_counter : in -> in
```

### Validation
- `black` ✅ · `mypy --strict` ✅ (engine, 0 issues) · `pytest` ✅ 14/14 (JVM/LLM-free).

### Scope & honesty (anti-théâtre)
- The substrate is the **trajectory-of-labellings concept**, made executable and falsifiable on a **structural exemplar**. It is **not** a corpus-derived AF — deriving an AF from a real discourse needs the text→arguments→attacks pipeline and is privacy-sensitive; that is a deliberate follow-up, out of scope for this Phase-A *candidate*.
- **Privacy HARD**: opaque `prop_*` ids, **no source content, no corpus access, no raw_text**.
- Falsifiability: the trajectory is deterministic and machine-checked. The refutation/reinstatement dynamics are **computed** by grounded semantics, not asserted.

Awaits coord admin-merge (shared account blocks self-merge).

🤖 Worker myia-po-2023 — S6-A2 #1506
