### PR TITLE
feat(detection): wire dung_arbitration producer + verdict-to-state plumbing (#1501 PR2)

### DIFF
--- a/argumentation_analysis/agents/core/informal/detection_candidate_bridge.py
+++ b/argumentation_analysis/agents/core/informal/detection_candidate_bridge.py
@@ -1,0 +1,165 @@
+"""Rule-vs-ML detection candidate bridge for the Dung-arbitration stage (I1 #1501 PR2).
+
+The arbitration stage (:mod:`dung_arbitration_stage`) consumes
+:class:`SophismCandidate` atoms. The neural/ML side already produces them
+(:func:`neuro_symbolic_arbitrator.llm_neural_detect_async`, from #1429 PR3). This
+module supplies the **rule side** and a combiner, so the stage can arbitrate
+across detector provenances (rule taxonomy vs ML) — the "rule-vs-ML" dimension
+the #1501 dispatch asks for.
+
+The bridge is a PURE transformer: it maps detection dicts (from
+:meth:`TaxonomySophismDetector.detect_sophisms_from_taxonomy`) to opaque
+:class:`SophismCandidate` atoms without interpreting their meaning, and combines
+several detector sources into one candidate batch with unique opaque ids. It
+implements no detection logic of its own (anti-pendule: reuse
+``TaxonomySophismDetector``, don't reimplement) and is JVM/LLM-free so it is
+unit-testable with synthetic atoms.
+
+Provenance, not a direct attack channel
+---------------------------------------
+Rule and ML detections generally do not share a textual span (the taxonomy
+detector is lexical over the whole passage, the ML detector returns span text),
+so cross-source rivalry is NOT derived from span overlap here. Cross-source
+disagreement surfaces through the declared Walton-Krabbe relations (the stage's
+:func:`walton_krabbe_conflict_policy`) and the same-span rivalry within a single
+source (the #1429 ``default_conflict_policy``). Provenance is recorded on each
+candidate so a downstream report can attribute each atom to its detector.
+
+Privacy HARD
+------------
+Callers MUST pass opaque family labels and opaque span anchors. The bridge never
+ingests source text directly — ``span_text_for`` is the caller's responsibility
+(the upstream that holds the real text + segmentation), matching #1429's
+``span_text_for`` contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Mapping, Sequence
+
+from argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator import (
+    SophismCandidate,
+)
+
+# Shape produced by TaxonomySophismDetector.detect_sophisms_from_taxonomy. Kept
+# as a loose Mapping (not a TypedDict) because the student detector is untyped
+# student code whose dict keys are not contractually frozen.
+TaxonomyDetection = Mapping[str, Any]
+
+
+def _opaque_span_id(family: str, detector: str) -> str:
+    """Deterministic opaque span anchor for a rule detection that has no text span.
+
+    The taxonomy detector is lexical over the whole passage (no span), so two
+    rule detections of the SAME family under the SAME detector collapse to one
+    span_id (a passage may legitimately surface the same fallacy twice is not
+    modelled at the rule level — same family ⇒ same anchor). Families from
+    different detectors stay distinct (detector is part of the hash input), so a
+    rule and an ML detection of the same family do NOT falsely collapse.
+    """
+
+    raw = f"{detector}::{family}".encode("utf-8")
+    return "span_" + hashlib.md5(raw).hexdigest()[:8]
+
+
+def _coerce_confidence(value: Any, default: float = 0.5) -> float:
+    """Clamp a detection confidence into [0, 1], defaulting on bad/missing input."""
+
+    try:
+        c = float(value)
+    except (TypeError, ValueError):
+        return default
+    if c != c:  # NaN
+        return default
+    return max(0.0, min(1.0, c))
+
+
+def taxonomy_detection_to_candidate(
+    detection: TaxonomyDetection,
+    *,
+    index: int,
+    detector: str = "rule_taxonomy",
+) -> SophismCandidate:
+    """Map ONE taxonomy detection dict to an opaque :class:`SophismCandidate`.
+
+    ``family`` is the detection's family/name (opaque label — the stage never
+    interprets it); ``confidence`` is clamped to ``[0, 1]`` (defaults to 0.5 if
+    missing or malformed); ``span_id`` is a deterministic opaque anchor derived
+    from ``(detector, family)`` (the rule detector carries no text span).
+
+    Args:
+        detection: One row of ``detect_sophisms_from_taxonomy`` output.
+        index: Position in the source batch — used to mint a unique opaque id.
+        detector: Provenance label embedded in the id and span anchor so a rule
+            detection never collides with an ML detection of the same family.
+    """
+
+    # Tolerant family lookup: the rule detector (TaxonomySophismDetector) emits
+    # ``famille``/``name``/``nom_vulgarise``; the ML/hierarchical phase emits
+    # ``family``/``fallacy_type``. One converter serves both provenances — the
+    # family is an opaque label the stage never interprets (#1501 rule-vs-ML).
+    family = (
+        str(
+            detection.get("famille")
+            or detection.get("family")
+            or detection.get("fallacy_type")
+            or detection.get("name")
+            or detection.get("nom_vulgarise")
+            or "unknown"
+        ).strip()
+        or "unknown"
+    )
+    confidence = _coerce_confidence(detection.get("confidence", 0.5))
+    return SophismCandidate(
+        candidate_id=f"{detector}_{index}",
+        family=family,
+        span_id=_opaque_span_id(family, detector),
+        confidence=confidence,
+    )
+
+
+def taxonomy_detections_to_candidates(
+    detections: Sequence[TaxonomyDetection],
+    *,
+    detector: str = "rule_taxonomy",
+) -> list[SophismCandidate]:
+    """Map a batch of taxonomy detections to opaque candidates (stable order)."""
+
+    return [
+        taxonomy_detection_to_candidate(d, index=i, detector=detector)
+        for i, d in enumerate(detections)
+    ]
+
+
+def combine_candidate_sources(
+    sources: Mapping[str, Sequence[SophismCandidate]],
+) -> list[SophismCandidate]:
+    """Union several detector outputs into one candidate batch (unique ids).
+
+    Each source key is a provenance label (e.g. ``"rule_taxonomy"``,
+    ``"ml_llm"``). Candidates keep their original ``candidate_id`` but are
+    prefixed with the source label when needed to guarantee global uniqueness
+    (defensive — ids that already include their source are left untouched).
+    Order is stable: sources in insertion order, candidates in source order.
+    """
+
+    seen: set[str] = set()
+    combined: list[SophismCandidate] = []
+    for source, cands in sources.items():
+        for i, cand in enumerate(cands):
+            cid = cand.candidate_id
+            if cid in seen:
+                cid = f"{source}_{i}_{cid}"
+                cand = SophismCandidate(
+                    candidate_id=cid,
+                    family=cand.family,
+                    span_id=cand.span_id,
+                    confidence=cand.confidence,
+                    failed_critical_questions=cand.failed_critical_questions,
+                )
+            if cid in seen:
+                continue
+            seen.add(cid)
+            combined.append(cand)
+    return combined

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -167,6 +167,7 @@ __all__ = [
     "_invoke_deep_synthesis",
     "_invoke_stakes_extractor",
     "_invoke_ai_shield",
+    "_invoke_dung_arbitration",
 ]
 
 
@@ -7701,6 +7702,83 @@ async def compare_all_axes(
             "axes_run": list(report_axes.keys()),
             "any_disagreement": any_disagree,
         },
+    }
+
+
+async def _invoke_dung_arbitration(
+    input_text: str, context: Dict[str, Any]
+) -> Dict[str, Any]:
+    """Pipeline-selectable Dung-arbitration stage over fallacy candidates (I1 #1501 PR2).
+
+    A PRODUCTION STAGE — distinct from ``_invoke_dung_extensions`` (which computes
+    extensions over the global argument AF) and from ``_invoke_multi_axis_compare``
+    (which runs the #1429 sophism-axis comparison harness). This stage consumes
+    sophism CANDIDATES, derives attacks from DECLARED Walton-Krabbe relations +
+    same-span rivalry, and lets the grounded extension decide which candidates
+    survive — ALTERING the detection verdict when ``dung_arbitration`` is selected.
+
+    Selectable (default OFF, backward-compat): gated by ``context["dung_arbitration"]``.
+    OFF ⇒ passthrough verdict (surviving == input). ON ⇒ grounded arbitration.
+
+    Rule-vs-ML provenance: candidates are collected from the rule taxonomy phase
+    (``phase_taxonomy_sophisms_output``) and the ML/hierarchical phase
+    (``phase_hierarchical_fallacy_output``), bridged to opaque ``SophismCandidate``
+    atoms. Provenance is preserved on each atom; cross-source disagreement surfaces
+    via declared Walton-Krabbe relations (``walton_krabbe_relations``) and same-span
+    rivalry, NOT span overlap (the rule detector carries no text span).
+
+    Honest-absent (anti-#1019): with no declared refutations and no same-span
+    rivalry, the enabled stage returns surviving == input (no fabricated attack).
+    """
+    # Lazy imports — mirror the camembert handler pattern to avoid churning the
+    # top-level import block of this large module.
+    from argumentation_analysis.agents.core.informal.detection_candidate_bridge import (
+        combine_candidate_sources,
+        taxonomy_detections_to_candidates,
+    )
+    from argumentation_analysis.agents.core.informal.dung_arbitration_stage import (
+        arbitrate_detections,
+    )
+
+    enabled = bool(context.get("dung_arbitration", False))
+
+    sources: Dict[str, List[Any]] = {}
+    rule_detections = context.get("phase_taxonomy_sophisms_output") or []
+    if rule_detections:
+        sources["rule_taxonomy"] = taxonomy_detections_to_candidates(rule_detections)
+    hierarchical = context.get("phase_hierarchical_fallacy_output") or {}
+    if isinstance(hierarchical, dict):
+        ml_fallacies = hierarchical.get("fallacies") or []
+        if ml_fallacies:
+            sources["ml_llm"] = taxonomy_detections_to_candidates(
+                ml_fallacies, detector="ml_llm"
+            )
+
+    candidates = combine_candidate_sources(sources) if sources else []
+
+    verdict = arbitrate_detections(
+        candidates,
+        dung_arbitration=enabled,
+        walton_krabbe_relations=context.get("walton_krabbe_relations"),
+    )
+
+    surviving = sorted(verdict.surviving_ids)
+    eliminated = {str(k): str(v) for k, v in verdict.eliminated_ids.items()}
+    attack_pairs = [[str(a), str(b)] for a, b in sorted(verdict.attacks)]
+
+    return {
+        "verdict": {
+            "enabled": verdict.enabled,
+            "surviving_ids": surviving,
+            "eliminated_ids": eliminated,
+            "attacks": attack_pairs,
+            "honest_absent": verdict.honest_absent,
+            "input_count": verdict.input_count,
+            "surviving_count": verdict.surviving_count,
+        },
+        "dung_arbitration": enabled,
+        "candidate_count": len(candidates),
+        "degraded": False,
     }
 
 

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -32,6 +32,7 @@ from argumentation_analysis.orchestration.invoke_callables import (
     _invoke_fol_reasoning,
     _invoke_modal_logic,
     _invoke_dung_extensions,
+    _invoke_dung_arbitration,
     _invoke_multi_axis_compare,
     _invoke_formal_synthesis,
     _invoke_nl_to_logic,
@@ -465,6 +466,12 @@ def setup_registry(
             ["dung_extensions"],
             "Dung AF extension computation via AFHandler",
             _invoke_dung_extensions,
+        ),
+        (
+            "dung_arbitration_service",
+            ["dung_arbitration"],
+            "Selectable Dung grounded arbitration over sophism candidates (Walton-Krabbe)",
+            _invoke_dung_arbitration,
         ),
         (
             "multi_axis_compare_service",

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -959,6 +959,67 @@ def _write_dung_extensions_to_state(
                 )
 
 
+def _write_dung_arbitration_to_state(
+    output: Any, state: Any, ctx: dict[str, Any]
+) -> None:
+    """Write the Dung-arbitration verdict to UnifiedAnalysisState (#1501 PR2, DoD #4).
+
+    The formal verdict (surviving / eliminated candidates + grounded attacks) is
+    stored as a Dung framework named ``dung_arbitration`` via the existing
+    ``add_dung_framework`` hook — the sibling pattern used by the SetAF/ABA/Dung
+    writers, where formalism-specifics are stuffed into the ``extensions`` dict.
+    A trace entry is added so the verdict is auditable in the analysis timeline.
+
+    Passthrough (``enabled=False``) and honest-absent verdicts are still recorded
+    (the stage RAN), but carry ``honest_absent=True`` so a downstream report can
+    tell "arbitration found nothing genuine to decide" from "arbitration altered
+    nothing because it was off".
+    """
+    if not output or not isinstance(output, dict):
+        return
+    verdict = output.get("verdict")
+    if not isinstance(verdict, dict):
+        return
+    surviving = verdict.get("surviving_ids") or []
+    eliminated = verdict.get("eliminated_ids") or {}
+    attacks = verdict.get("attacks") or []
+    # Opaque candidate ids are the AF's arguments; attacks are [src, tgt] pairs.
+    arguments = [str(c) for c in surviving] + [str(c) for c in eliminated]
+    attack_pairs = [
+        [str(pair[0]), str(pair[1])]
+        for pair in attacks
+        if isinstance(pair, (list, tuple)) and len(pair) >= 2
+    ]
+    state.add_dung_framework(
+        name="dung_arbitration",
+        arguments=arguments,
+        attacks=attack_pairs,
+        extensions={
+            "surviving_ids": [str(c) for c in surviving],
+            "eliminated_ids": {str(k): str(v) for k, v in eliminated.items()},
+            "honest_absent": bool(verdict.get("honest_absent", False)),
+            "enabled": bool(verdict.get("enabled", False)),
+            "input_count": int(verdict.get("input_count", 0)),
+            "surviving_count": int(verdict.get("surviving_count", 0)),
+        },
+    )
+    if verdict.get("enabled"):
+        state.add_trace_entry(
+            phase="dung_arbitration",
+            agent="DungArbitrationStage",
+            reacts_to=["hierarchical_fallacy"],
+            summary=(
+                f"Grounded arbitration: {len(surviving)} surviving, "
+                f"{len(eliminated)} eliminated"
+                + (
+                    " (honest-absent: no genuine attack)"
+                    if verdict.get("honest_absent")
+                    else ""
+                )
+            ),
+        )
+
+
 def _write_formal_synthesis_to_state(
     output: Any, state: Any, ctx: dict[str, Any]
 ) -> None:
@@ -1398,6 +1459,7 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "fol_reasoning": _write_fol_to_state,
     "modal_logic": _write_modal_to_state,
     "dung_extensions": _write_dung_extensions_to_state,
+    "dung_arbitration": _write_dung_arbitration_to_state,
     "formal_synthesis": _write_formal_synthesis_to_state,
     "hierarchical_fallacy_detection": _write_hierarchical_fallacy_to_state,
     "description_logic": _write_dl_to_state,

--- a/tests/unit/argumentation_analysis/agents/core/informal/test_detection_candidate_bridge.py
+++ b/tests/unit/argumentation_analysis/agents/core/informal/test_detection_candidate_bridge.py
@@ -1,0 +1,152 @@
+"""Unit tests for the rule-vs-ML detection candidate bridge (Track I1 #1501, PR2).
+
+JVM/LLM-free: the bridge is a pure transformer mapping detection dicts (from
+``TaxonomySophismDetector`` rule side, or the hierarchical/ML phase output) to
+opaque :class:`SophismCandidate` atoms, plus a multi-source combiner. Every test
+runs on synthetic opaque dicts — no detector, no JVM, no LLM.
+
+The contract asserted here is the rule-vs-ML provenance dimension (#1501): a
+rule detection and an ML detection of the SAME family stay distinct atoms
+(detector is part of the opaque id + span anchor), and the bridge is tolerant of
+both the taxonomy shape (``famille``/``name``) and the hierarchical/ML shape
+(``family``/``fallacy_type``).
+"""
+
+from __future__ import annotations
+
+from argumentation_analysis.agents.core.informal.detection_candidate_bridge import (
+    combine_candidate_sources,
+    taxonomy_detection_to_candidate,
+    taxonomy_detections_to_candidates,
+)
+from argumentation_analysis.agents.core.informal.neuro_symbolic_arbitrator import (
+    SophismCandidate,
+)
+
+
+class TestTaxonomyDetectionToCandidate:
+    def test_maps_rule_taxonomy_shape(self) -> None:
+        det = {"famille": "Ad Hominem", "confidence": 0.8, "name": "ad_hominem"}
+        cand = taxonomy_detection_to_candidate(det, index=2)
+        assert cand.family == "Ad Hominem"
+        assert cand.confidence == 0.8
+        # Default detector label + index baked into the opaque id.
+        assert cand.candidate_id == "rule_taxonomy_2"
+
+    def test_tolerates_hierarchical_ml_shape(self) -> None:
+        # The ML/hierarchical phase emits family/fallacy_type, not famille/name.
+        det = {"fallacy_type": "Straw Man", "confidence": 0.6}
+        cand = taxonomy_detection_to_candidate(det, index=0, detector="ml_llm")
+        assert cand.family == "Straw Man"
+        assert cand.confidence == 0.6
+        assert cand.candidate_id == "ml_llm_0"
+
+    def test_missing_family_defaults_opaque(self) -> None:
+        cand = taxonomy_detection_to_candidate({"confidence": 0.4}, index=1)
+        assert cand.family == "unknown"
+
+    def test_confidence_clamped_to_unit_interval(self) -> None:
+        assert (
+            taxonomy_detection_to_candidate(
+                {"famille": "f", "confidence": 1.5}, index=0
+            ).confidence
+            == 1.0
+        )
+        assert (
+            taxonomy_detection_to_candidate(
+                {"famille": "f", "confidence": -0.2}, index=0
+            ).confidence
+            == 0.0
+        )
+
+    def test_missing_or_bad_confidence_defaults_to_half(self) -> None:
+        assert (
+            taxonomy_detection_to_candidate({"famille": "f"}, index=0).confidence == 0.5
+        )
+        assert (
+            taxonomy_detection_to_candidate(
+                {"famille": "f", "confidence": "oops"}, index=0
+            ).confidence
+            == 0.5
+        )
+
+    def test_nan_confidence_defaults_to_half(self) -> None:
+        nan = float("nan")
+        assert (
+            taxonomy_detection_to_candidate(
+                {"famille": "f", "confidence": nan}, index=0
+            ).confidence
+            == 0.5
+        )
+
+    def test_span_id_deterministic_for_same_family_and_detector(self) -> None:
+        a = taxonomy_detection_to_candidate({"famille": "Slippery Slope"}, index=0)
+        b = taxonomy_detection_to_candidate({"famille": "Slippery Slope"}, index=1)
+        # Same (detector, family) ⇒ same opaque anchor (rule detections carry no span).
+        assert a.span_id == b.span_id
+        assert a.span_id.startswith("span_")
+
+    def test_rule_and_ml_of_same_family_do_not_collapse(self) -> None:
+        rule = taxonomy_detection_to_candidate(
+            {"famille": "Bandwagon"}, index=0, detector="rule_taxonomy"
+        )
+        ml = taxonomy_detection_to_candidate(
+            {"fallacy_type": "Bandwagon"}, index=0, detector="ml_llm"
+        )
+        # Provenance keeps the atoms distinct even for the same family label.
+        assert rule.span_id != ml.span_id
+        assert rule.candidate_id != ml.candidate_id
+        assert rule.family == ml.family == "Bandwagon"
+
+
+class TestTaxonomyDetectionsToCandidates:
+    def test_stable_order_and_unique_ids(self) -> None:
+        dets = [
+            {"famille": "A", "confidence": 0.9},
+            {"famille": "B", "confidence": 0.3},
+        ]
+        cands = taxonomy_detections_to_candidates(dets)
+        assert [c.candidate_id for c in cands] == ["rule_taxonomy_0", "rule_taxonomy_1"]
+        assert [c.family for c in cands] == ["A", "B"]
+
+    def test_empty_batch_returns_empty(self) -> None:
+        assert taxonomy_detections_to_candidates([]) == []
+
+
+class TestCombineCandidateSources:
+    def test_union_preserves_order_and_unique_ids(self) -> None:
+        rule = taxonomy_detections_to_candidates(
+            [{"famille": "A"}, {"famille": "B"}], detector="rule_taxonomy"
+        )
+        ml = taxonomy_detections_to_candidates(
+            [{"fallacy_type": "C"}], detector="ml_llm"
+        )
+        combined = combine_candidate_sources({"rule_taxonomy": rule, "ml_llm": ml})
+        assert [c.candidate_id for c in combined] == [
+            "rule_taxonomy_0",
+            "rule_taxonomy_1",
+            "ml_llm_0",
+        ]
+        assert {c.family for c in combined} == {"A", "B", "C"}
+
+    def test_cross_source_id_collision_is_disambiguated(self) -> None:
+        # Two sources craft ids that collide (same literal candidate_id) — the
+        # combiner must prefix to guarantee global uniqueness.
+        rule = [
+            SophismCandidate(
+                candidate_id="dup", family="A", span_id="s1", confidence=0.5
+            )
+        ]
+        ml = [
+            SophismCandidate(
+                candidate_id="dup", family="B", span_id="s2", confidence=0.5
+            )
+        ]
+        combined = combine_candidate_sources({"rule_taxonomy": rule, "ml_llm": ml})
+        assert len(combined) == 2
+        ids = {c.candidate_id for c in combined}
+        assert "dup" in ids  # first occurrence kept verbatim
+        assert len(ids) == 2  # second disambiguated, no loss
+
+    def test_empty_sources_returns_empty(self) -> None:
+        assert combine_candidate_sources({}) == []

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_arbitration_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_arbitration_wiring.py
@@ -1,0 +1,122 @@
+"""Integration test: real ``dung_arbitration`` consumer wiring (Track I1 #1501, PR2).
+
+DoD #3 reinforced — calls the REAL pipeline handler
+:func:`_invoke_dung_arbitration` and the REAL state writer
+:func:`_write_dung_arbitration_to_state` on synthetic opaque candidates (no LLM,
+no JVM, no pipeline spin), asserting the anti-#1019 contract end-to-end:
+
+* the stage is a transparent passthrough when ``dung_arbitration`` is OFF;
+* when ON, a DECLARED Walton-Krabbe refutation ALTERS the verdict — the targeted
+  candidate is eliminated (the verdict genuinely CHANGES, not a cosmetic flag);
+* when ON but nothing genuine is declared, the stage is honest-absent
+  (surviving == input, no fabricated attack);
+* the resulting verdict is traceable in ``UnifiedAnalysisState`` as a Dung
+  framework (DoD #4).
+"""
+
+from __future__ import annotations
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.orchestration.invoke_callables import (
+    _invoke_dung_arbitration,
+)
+from argumentation_analysis.orchestration.state_writers import (
+    _write_dung_arbitration_to_state,
+)
+
+
+def _ctx(*, enabled: bool, with_refutation: bool) -> dict:
+    """Build a synthetic pipeline context with two ML-detected candidates.
+
+    The bridge mints ``ml_llm_<index>`` ids in stable order, so candidate 0
+    (``ml_llm_0``) is declared to refute candidate 1 (``ml_llm_1``) when
+    ``with_refutation`` is set — a genuine unidirectional attack.
+    """
+    fallacies = [
+        {"fallacy_type": "appeal_to_authority", "confidence": 0.7},
+        {"fallacy_type": "hasty_generalization", "confidence": 0.6},
+    ]
+    ctx: dict = {
+        "dung_arbitration": enabled,
+        "phase_hierarchical_fallacy_output": {"fallacies": fallacies},
+    }
+    if with_refutation:
+        # WaltonKrabbeRelations = {challenger_id: frozenset({target_id})}.
+        ctx["walton_krabbe_relations"] = {"ml_llm_0": frozenset({"ml_llm_1"})}
+    return ctx
+
+
+class TestDungArbitrationWiring:
+    async def test_off_is_passthrough(self) -> None:
+        out = await _invoke_dung_arbitration(
+            "opaque_text", _ctx(enabled=False, with_refutation=True)
+        )
+        verdict = out["verdict"]
+        assert verdict["enabled"] is False
+        assert verdict["honest_absent"] is True
+        # OFF ⇒ surviving == input (no arbitration performed, backward-compat).
+        assert verdict["surviving_count"] == verdict["input_count"] == 2
+        assert verdict["eliminated_ids"] == {}
+
+    async def test_on_with_refutation_changes_verdict(self) -> None:
+        out_off = await _invoke_dung_arbitration(
+            "opaque_text", _ctx(enabled=False, with_refutation=True)
+        )
+        out_on = await _invoke_dung_arbitration(
+            "opaque_text", _ctx(enabled=True, with_refutation=True)
+        )
+        # The verdict CHANGES across the flag (#1019): OFF keeps both candidates,
+        # ON eliminates the one defeated by a defended Walton-Krabbe refutation.
+        assert out_off["verdict"]["surviving_count"] == 2
+        assert out_on["verdict"]["enabled"] is True
+        assert out_on["verdict"]["honest_absent"] is False
+        assert out_on["verdict"]["surviving_count"] == 1
+        assert "ml_llm_1" in out_on["verdict"]["eliminated_ids"]
+        # The attack edge (ml_llm_0 → ml_llm_1) is surfaced for auditability.
+        assert ["ml_llm_0", "ml_llm_1"] in out_on["verdict"]["attacks"]
+
+    async def test_on_without_refutation_is_honest_absent(self) -> None:
+        out = await _invoke_dung_arbitration(
+            "opaque_text", _ctx(enabled=True, with_refutation=False)
+        )
+        # No declared attack, no same-span rivalry ⇒ honest-absent: surviving == input.
+        assert out["verdict"]["enabled"] is True
+        assert out["verdict"]["honest_absent"] is True
+        assert out["verdict"]["surviving_count"] == out["verdict"]["input_count"] == 2
+        assert out["verdict"]["eliminated_ids"] == {}
+
+    async def test_writer_records_verdict_in_state(self) -> None:
+        out = await _invoke_dung_arbitration(
+            "opaque_text", _ctx(enabled=True, with_refutation=True)
+        )
+        state = UnifiedAnalysisState("opaque_text")
+        _write_dung_arbitration_to_state(out, state, {})
+        # DoD #4: the verdict is traceable as a Dung framework in the state.
+        arbitration = [
+            f for f in state.dung_frameworks.values() if f["name"] == "dung_arbitration"
+        ]
+        assert len(arbitration) == 1
+        ext = arbitration[0]["extensions"]
+        assert ext["enabled"] is True
+        assert ext["honest_absent"] is False
+        assert "ml_llm_1" in ext["eliminated_ids"]
+        assert ext["surviving_count"] == 1
+        assert ext["input_count"] == 2
+        # The AF's arguments/attacks are the opaque candidate ids / pairs.
+        assert "ml_llm_0" in arbitration[0]["arguments"]
+        assert ["ml_llm_0", "ml_llm_1"] in arbitration[0]["attacks"]
+
+    async def test_writer_handles_passthrough_verdict(self) -> None:
+        # A passthrough (OFF) verdict is still recorded — the stage RAN.
+        out = await _invoke_dung_arbitration(
+            "opaque_text", _ctx(enabled=False, with_refutation=True)
+        )
+        state = UnifiedAnalysisState("opaque_text")
+        _write_dung_arbitration_to_state(out, state, {})
+        arbitration = [
+            f for f in state.dung_frameworks.values() if f["name"] == "dung_arbitration"
+        ]
+        assert len(arbitration) == 1
+        ext = arbitration[0]["extensions"]
+        assert ext["enabled"] is False
+        assert ext["honest_absent"] is True


### PR DESCRIPTION
## I1 #1501 (PR2) — Dung-arbitration producer + verdict-to-state plumbing

Builds on PR1 (#1508, merged) — the selectable `arbitrate_detections` stage. PR2
makes that stage **consume real pipeline candidates** and **write a traceable
verdict to the analysis state**, satisfying the full #1501 DoD.

### What this PR adds

- **`detection_candidate_bridge.py`** — the rule-vs-ML candidate producer. Maps
  rule detections (`TaxonomySophismDetector`) and ML detections (hierarchical
  fallacy phase output) to opaque `SophismCandidate` atoms. Tolerant of both
  dict shapes (`famille`/`name` vs `family`/`fallacy_type`); provenance is baked
  into each atom so a rule detection and an ML detection of the same family stay
  distinct. Pure transformer, JVM/LLM-free.
- **`_invoke_dung_arbitration`** (`invoke_callables.py`) — the pipeline-selectable
  handler, gated by `context["dung_arbitration"]` (default **OFF**). Collects
  candidates from the rule+ML phase outputs, runs `arbitrate_detections` with
  declared Walton-Krabbe relations. Distinct from `_invoke_dung_extensions`
  (extensions over the global argument AF) and `_invoke_multi_axis_compare`
  (#1429 sophism-axis comparison harness) — no collision.
- **`_write_dung_arbitration_to_state`** (`state_writers.py`) — records the
  verdict as a Dung framework named `dung_arbitration` via the existing
  `add_dung_framework` hook (sibling SetAF/ABA pattern — **zero state-class
  changes**), plus a trace entry. Registered in `CAPABILITY_STATE_WRITERS`.
- **`registry_setup.py`** — registers the `dung_arbitration` capability → handler.

### DoD #1501 — all met, verified firsthand

| DoD | Status |
|---|---|
| selectable flag, default OFF | ✅ `context["dung_arbitration"]` gates the stage; OFF ⇒ passthrough |
| verdict CHANGES on a synthetic case (anti-#1019) | ✅ a declared Walton-Krabbe refutation eliminates the targeted candidate when ON; both kept when OFF |
| test calling the REAL consumer | ✅ `test_dung_arbitration_wiring.py` exercises the real handler + writer + `UnifiedAnalysisState` end-to-end |
| formal verdict traceable in state (DoD #4) | ✅ recorded as a Dung framework (`surviving_ids`, `eliminated_ids`+reasons, `attacks`, `honest_absent`) |

Wiring smoke run (synthetic opaque candidates, computed not asserted):
- OFF + declared refutation: `surviving_count=2` (passthrough)
- ON + declared refutation: `surviving_count=1`, `ml_llm_1` eliminated (verdict changed)
- ON + no genuine attack: `surviving_count=2` (honest-absent, no fabricated attack)

### Validation
- `black` ✅ · `mypy --strict` ✅ (bridge, 0 issues) · `pytest` ✅ **31/31** (bridge 13 + stage PR1 13 + wiring 5), JVM/LLM-free.

### Scope & honesty (anti-théâtre #1019)
- The stage never invents an attack — it turns DECLARED Walton-Krabbe
  refutations + same-span rivalry into Dung edges and lets grounded semantics
  decide. With no declared refutations and no rivalry, the enabled stage is
  honest-absent (surviving == input), not a cosmetic flag.
- Anti-pendule: reuses `arbitrate_detections` (PR1) + `add_dung_framework`
  (existing state hook); no Dung semantics reimplemented.
- **Privacy HARD**: opaque `ml_llm_*` candidate ids, generic fallacy-family
  labels, no source text, no corpus access.

Awaits coord admin-merge (shared account blocks self-merge).

🤖 Worker myia-po-2023 — I1 #1501 PR2
