### PR TITLE
fix(communication): shared broadcast bus delivers to listeners (C2 #1500)

### DIFF
--- a/argumentation_analysis/core/communication/pub_sub.py
+++ b/argumentation_analysis/core/communication/pub_sub.py
@@ -279,7 +279,9 @@ class PublishSubscribeProtocol:
 
         # Démarrer le thread de nettoyage des messages expirés
         self.running = True
-        self._stop_event = threading.Event()  # Rend l'attente du cleanup interruptible par shutdown()
+        self._stop_event = (
+            threading.Event()
+        )  # Rend l'attente du cleanup interruptible par shutdown()
         self.cleanup_thread = threading.Thread(target=self._cleanup_expired_messages)
         self.cleanup_thread.daemon = True
         self.cleanup_thread.start()
@@ -380,11 +382,21 @@ class PublishSubscribeProtocol:
             metadata={"topic": topic_id, "ttl": ttl or topic.ttl, **(metadata or {})},
         )
 
-        # Publier le message sur le topic
+        # Publier le message sur le topic (livraison aux abonnés du topic)
         recipients = topic.publish_message(message)
 
-        # Envoyer le message via le middleware
-        self.middleware.send_message(message)
+        # C2 #1500 — fan-out du broadcast aux listeners globaux du middleware.
+        # ``send_message`` était mort pour les broadcasts : le message porte
+        # ``recipient=None`` (broadcast), or les canaux HIERARCHICAL et DATA le
+        # rejettent tous deux ("has no recipient") ; et quand le canal DATA
+        # n'est pas enregistré (middleware shared hand-built, Sites main_orchest-
+        # rator / service_manager avant Fix A) on logge en boucle
+        # "Channel not found: data" — d'où le défaut R653 « broadcasts atteignant
+        # 0 agent ». On livre donc aux ``global_handlers`` du middleware (le
+        # mécanisme "listen to all messages") : un agent qui s'enregistre comme
+        # listener reçoit réellement le broadcast (anti-#1019 : livraison
+        # genuine, pas un masquage try/except ; et plus de send_message mort).
+        self.middleware._handle_message(message)
 
         return recipients
 

--- a/argumentation_analysis/orchestration/engine/main_orchestrator.py
+++ b/argumentation_analysis/orchestration/engine/main_orchestrator.py
@@ -43,6 +43,7 @@ try:
     from argumentation_analysis.orchestration.conversation_orchestrator import (
         ConversationOrchestrator,
     )
+
     # RealLLMOrchestrator and LogiqueComplexeOrchestrator removed (#885)
 except ImportError as e:
     logger.error(
@@ -1184,9 +1185,8 @@ if __name__ == "__main__":
     from argumentation_analysis.orchestration.hierarchical.operational.manager import (
         OperationalManager,
     )
-    from argumentation_analysis.core.communication.middleware import MessageMiddleware
-    from argumentation_analysis.core.communication.hierarchical_channel import (
-        HierarchicalChannel,
+    from argumentation_analysis.core.communication.middleware import (
+        create_default_middleware,
     )
 
     logging.basicConfig(
@@ -1214,8 +1214,11 @@ if __name__ == "__main__":
             OpenAIChatCompletion(service_id="chat_completion", api_key=api_key)
         )
 
-        shared_middleware = MessageMiddleware()
-        shared_middleware.register_channel(HierarchicalChannel("hierarchical_channel"))
+        # C2 #1500: shared middleware wired with BOTH channels via the
+        # single-source-of-truth factory (mirror of the PR #1479 / R652 fix).
+        # The previous hand-built HierarchicalChannel-only bus dropped every
+        # PUBLICATION broadcast on the unregistered DATA channel.
+        shared_middleware = create_default_middleware()
         strategic_manager = StrategicManager(middleware=shared_middleware)
         tactical_coordinator = TacticalCoordinator(middleware=shared_middleware)
         operational_manager = OperationalManager(middleware=shared_middleware)

--- a/argumentation_analysis/orchestration/service_manager.py
+++ b/argumentation_analysis/orchestration/service_manager.py
@@ -103,7 +103,7 @@ try:
         MessagePriority,
         MessageType,
         AgentLevel,
-        HierarchicalChannel,  # Importer la classe concrète du canal
+        create_default_middleware,  # C2 #1500: factory wiring HIERARCHICAL + DATA
     )
 except ImportError as e:
     logging.error(
@@ -115,7 +115,7 @@ except ImportError as e:
     MessageMiddleware = (
         None  # Pour éviter des NameError plus loin si on continue malgré tout
     )
-    HierarchicalChannel = None  # Idem
+    create_default_middleware = None  # C2 #1500 idem
     # Les autres (Message, ChannelType, etc.) causeront des NameError s'ils sont utilisés.
 
 
@@ -208,7 +208,9 @@ class OrchestrationServiceManager:
         # Orchestrateurs spécialisés
         self.cluedo_orchestrator: Optional[CluedoOrchestrator] = None
         self.conversation_orchestrator: Optional[ConversationOrchestrator] = None
-        self.llm_orchestrator: Optional[Any] = None  # Removed RealLLMOrchestrator (#885)
+        self.llm_orchestrator: Optional[Any] = (
+            None  # Removed RealLLMOrchestrator (#885)
+        )
         self.fact_checking_orchestrator: Optional[FactCheckingOrchestrator] = None
 
         # Middleware de communication
@@ -385,31 +387,20 @@ class OrchestrationServiceManager:
 
         if (
             settings.service_manager.enable_communication_middleware
-            and MessageMiddleware
+            and create_default_middleware
         ):
-            self.middleware = MessageMiddleware()
-            self.logger.info("Middleware de communication instancié.")
-
-            # Enregistrer les canaux nécessaires
-            if HierarchicalChannel:
-                try:
-                    hierarchical_channel_id = (
-                        settings.service_manager.hierarchical_channel_id
-                    )
-                    hc = HierarchicalChannel(channel_id=hierarchical_channel_id)
-                    self.middleware.register_channel(hc)
-                    self.logger.info(
-                        f"Canal HIERARCHICAL '{hierarchical_channel_id}' enregistré dans le middleware."
-                    )
-                except Exception as e_chan:
-                    self.logger.error(
-                        f"Échec de l'enregistrement du HierarchicalChannel: {e_chan}",
-                        exc_info=True,
-                    )
-            else:
-                self.logger.error(
-                    "Classe HierarchicalChannel non disponible pour enregistrement."
-                )
+            # C2 #1500: shared middleware wired with BOTH channels (HIERARCHICAL
+            # + DATA) via the single-source-of-truth factory, mirroring the
+            # PR #1479 / R652 fix. The previous hand-built HierarchicalChannel-
+            # only bus dropped every PUBLICATION broadcast on the unregistered
+            # DATA channel ("Channel not found: data"). Channel lookups are by
+            # type, so the conventional IDs (hierarchical_main / data_main)
+            # replace the configured hierarchical_channel_id harmlessly.
+            self.middleware = create_default_middleware()
+            self.logger.info(
+                "Middleware de communication instancié (HIERARCHICAL + DATA "
+                "via create_default_middleware)."
+            )
         else:
             self.logger.warning(
                 "Middleware de communication désactivé ou non disponible."

--- a/tests/unit/argumentation_analysis/core/communication/test_broadcast_bus_fix_1500.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_broadcast_bus_fix_1500.py
@@ -1,0 +1,133 @@
+# tests/unit/argumentation_analysis/core/communication/test_broadcast_bus_fix_1500.py
+"""Track C2 of #1500 — shared-middleware broadcast bus hole fix.
+
+Reproduces the R653 defect firsthand and asserts the fix. The defect: a shared
+``MessageMiddleware`` built with only the HIERARCHICAL channel (as
+``main_orchestrator.main()`` and ``service_manager.initialize_middleware`` did
+before this track) dropped every ``PUBLICATION`` broadcast — ``determine_channel``
+routes a PUBLICATION to the DATA channel, which was unregistered, so
+``send_message`` logged ``Channel not found: data`` and returned False. Worse,
+the ``publish()`` path's ``send_message`` was *dead* for broadcasts anyway: the
+broadcast message carries ``recipient=None``, and both HIERARCHICAL and DATA
+channels reject a recipient-less message ("has no recipient"). Result
+(coordinator R653): "broadcasted to 0 agents", hierarchical-wide.
+
+The fix has two parts, both asserted here:
+
+* **Fix A** — the two shared-middleware integration sites now use
+  :func:`create_default_middleware` (single source of truth, mirror of the
+  PR #1479 / R652 delegation-path fix), so the shared bus registers BOTH
+  HIERARCHICAL and DATA.
+* **Fix B** — ``publish()`` fans the broadcast out to the middleware's
+  ``global_handlers`` (the "listen to all messages" mechanism) instead of the
+  dead ``send_message``. A registered listener therefore receives the broadcast
+  firsthand (DoD bullet 1, anti-#1019: genuine delivery, not a cosmetic flag),
+  and no ``Channel not found`` is emitted on the broadcast path (DoD bullet 2).
+
+JVM/LLM-free: pure communication-module machinery on synthetic opaque content.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from argumentation_analysis.core.communication.channel_interface import ChannelType
+from argumentation_analysis.core.communication.hierarchical_channel import (
+    HierarchicalChannel,
+)
+from argumentation_analysis.core.communication.message import (
+    AgentLevel,
+    Message,
+    MessagePriority,
+    MessageType,
+)
+from argumentation_analysis.core.communication.middleware import (
+    MessageMiddleware,
+    create_default_middleware,
+)
+from argumentation_analysis.core.communication.strategic_adapter import (
+    StrategicAdapter,
+)
+
+
+class TestFixADefaultMiddlewareWiresBothChannels:
+    """Fix A — ``create_default_middleware`` is the single source of truth for
+    the shared bus channel set (HIERARCHICAL + DATA), mirroring PR #1479/R652.
+    """
+
+    def test_registers_hierarchical_and_data(self) -> None:
+        mw = create_default_middleware()
+        assert mw.get_channel(ChannelType.HIERARCHICAL) is not None
+        assert mw.get_channel(ChannelType.DATA) is not None
+
+
+class TestDefectReproductionR653:
+    """The R653 defect mechanism, reproduced firsthand: a PUBLICATION routed to
+    the DATA channel on a HIERARCHICAL-only (pre-fix shared) middleware logs
+    ``Channel not found: data`` and the send returns False. This is the
+    "before" the fix addresses.
+    """
+
+    def test_hierarchical_only_middleware_drops_publication(
+        self, caplog: logging.Logger
+    ) -> None:
+        # Pre-fix shared-middleware setup: HIERARCHICAL channel only.
+        mw = MessageMiddleware()
+        mw.register_channel(HierarchicalChannel("hierarchical_channel"))
+        publication = Message(
+            message_type=MessageType.PUBLICATION,
+            sender="strategic_alpha",
+            sender_level=AgentLevel.STRATEGIC,
+            content={},
+            recipient=None,
+            channel=None,
+            priority=MessagePriority.NORMAL,
+        )
+        with caplog.at_level(logging.ERROR, logger="MessageMiddleware"):
+            delivered = mw.send_message(publication)
+        # The defect: DATA channel unregistered → "Channel not found: data".
+        assert delivered is False
+        assert "Channel not found: data" in caplog.text
+
+
+class TestFixBBroadcastReachesListener:
+    """Fix B — ``publish()`` fans the broadcast out to the middleware's global
+    handlers so a registered listener (the tactical tier's natural broadcast
+    reception) receives it firsthand. DoD bullet 1.
+    """
+
+    def test_broadcast_reaches_registered_listener_firsthand(self) -> None:
+        mw = create_default_middleware()
+        received: list[Message] = []
+        mw.register_global_handler(lambda m: received.append(m))
+        strategic = StrategicAdapter("strategic_alpha", mw)
+
+        strategic.broadcast_objective("analysis", {"goal": "opaque"})
+
+        # DoD bullet 1 — firsthand reception, not just channel registration.
+        assert len(received) == 1
+        msg = received[0]
+        assert msg.content["objective_type"] == "analysis"
+        assert msg.metadata.get("topic") == "objectives.analysis"
+
+    def test_broadcast_without_listener_is_honest_zero(self) -> None:
+        # Anti-#1019: with no listener, the broadcast reaches nobody — nothing
+        # fabricated, no crash. The path runs cleanly.
+        mw = create_default_middleware()
+        StrategicAdapter("strategic_alpha", mw).broadcast_objective(
+            "analysis", {"goal": "opaque"}
+        )
+
+
+class TestNoChannelNotFoundOnBroadcastPath:
+    """DoD bullet 2 — the broadcast path emits no ``Channel not found`` once the
+    shared middleware is wired with both channels and ``publish`` fans out via
+    handlers (no dead ``send_message`` to hit the missing DATA channel).
+    """
+
+    def test_broadcast_emits_no_channel_not_found(self, caplog: logging.Logger) -> None:
+        mw = create_default_middleware()
+        strategic = StrategicAdapter("strategic_alpha", mw)
+        with caplog.at_level(logging.ERROR, logger="MessageMiddleware"):
+            strategic.broadcast_objective("analysis", {"goal": "opaque"})
+        assert "Channel not found" not in caplog.text

--- a/tests/unit/argumentation_analysis/core/communication/test_pub_sub.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_pub_sub.py
@@ -356,7 +356,12 @@ class TestProtocolPublish:
         proto = PublishSubscribeProtocol(mw)
         proto.publish("t1", "sender", AgentLevel.OPERATIONAL, {"data": "test"})
         assert "t1" in proto.topics
-        mw.send_message.assert_called_once()
+        # C2 #1500: publish fans the broadcast out to the middleware's global
+        # handlers (genuine delivery) instead of the dead ``send_message``,
+        # which could never deliver a ``recipient=None`` broadcast. The old
+        # ``mw.send_message.assert_called_once()`` pinned that dead call.
+        mw._handle_message.assert_called_once()
+        mw.send_message.assert_not_called()
         proto.shutdown()
 
     def test_publish_returns_recipients(self):

--- a/tests/unit/argumentation_analysis/orchestration/test_service_manager.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_service_manager.py
@@ -488,60 +488,60 @@ class TestInitializeMiddleware:
             await manager.initialize_middleware()
             assert manager.middleware is None
 
-    async def test_middleware_success_with_channel(self, manager):
-        mock_settings = MagicMock()
-        mock_settings.service_manager.enable_communication_middleware = True
-        mock_settings.service_manager.hierarchical_channel_id = "test_channel"
-
-        mock_mw_class = MagicMock()
-        mock_mw_instance = MagicMock()
-        mock_mw_class.return_value = mock_mw_instance
-
-        mock_hc_class = MagicMock()
-        mock_hc_instance = MagicMock()
-        mock_hc_class.return_value = mock_hc_instance
-
-        with patch(f"{SM_MODULE}.settings", mock_settings), patch(
-            f"{SM_MODULE}.MessageMiddleware", mock_mw_class
-        ), patch(f"{SM_MODULE}.HierarchicalChannel", mock_hc_class):
-            await manager.initialize_middleware()
-            assert manager.middleware is mock_mw_instance
-            mock_mw_instance.register_channel.assert_called_once_with(mock_hc_instance)
-
-    async def test_middleware_no_hierarchical_channel_class(self, manager):
+    async def test_middleware_created_via_factory(self, manager):
+        """C2 #1500 — ``initialize_middleware`` wires the shared bus via the
+        single-source-of-truth factory ``create_default_middleware`` (not a
+        hand-built ``MessageMiddleware`` + ``register_channel``). Replaces the
+        pre-fix ``test_middleware_success_with_channel`` which pinned the dead
+        hand-built contract.
+        """
         mock_settings = MagicMock()
         mock_settings.service_manager.enable_communication_middleware = True
 
-        mock_mw_class = MagicMock()
-        mock_mw_instance = MagicMock()
-        mock_mw_class.return_value = mock_mw_instance
-
+        mock_factory_instance = MagicMock()
         with patch(f"{SM_MODULE}.settings", mock_settings), patch(
-            f"{SM_MODULE}.MessageMiddleware", mock_mw_class
-        ), patch(f"{SM_MODULE}.HierarchicalChannel", None):
+            f"{SM_MODULE}.create_default_middleware", return_value=mock_factory_instance
+        ) as mock_factory:
             await manager.initialize_middleware()
-            assert manager.middleware is mock_mw_instance
-            # No channel registered since HierarchicalChannel is None
-            mock_mw_instance.register_channel.assert_not_called()
+            assert manager.middleware is mock_factory_instance
+            mock_factory.assert_called_once_with()
 
-    async def test_middleware_channel_registration_error(self, manager):
+    async def test_middleware_factory_unavailable_fallback(self, manager):
+        """C2 #1500 — honest-degraded: when the communication import failed at
+        module load (``create_default_middleware is None``), the middleware
+        stays ``None`` with a logged warning, no crash. Replaces the pre-fix
+        ``test_middleware_no_hierarchical_channel_class`` which pinned the dead
+        ``HierarchicalChannel is None`` contract.
+        """
         mock_settings = MagicMock()
         mock_settings.service_manager.enable_communication_middleware = True
-        mock_settings.service_manager.hierarchical_channel_id = "test_channel"
-
-        mock_mw_class = MagicMock()
-        mock_mw_instance = MagicMock()
-        mock_mw_class.return_value = mock_mw_instance
-        mock_mw_instance.register_channel.side_effect = RuntimeError("channel error")
-
-        mock_hc_class = MagicMock()
 
         with patch(f"{SM_MODULE}.settings", mock_settings), patch(
-            f"{SM_MODULE}.MessageMiddleware", mock_mw_class
-        ), patch(f"{SM_MODULE}.HierarchicalChannel", mock_hc_class):
-            # Should not raise, error is logged
+            f"{SM_MODULE}.create_default_middleware", None
+        ):
             await manager.initialize_middleware()
-            assert manager.middleware is mock_mw_instance
+            assert manager.middleware is None
+
+    async def test_middleware_factory_registers_both_channels(self, manager):
+        """C2 #1500 — the shared bus wires BOTH HIERARCHICAL and DATA (the
+        core of the fix: a PUBLICATION routed to DATA was dropped pre-fix on a
+        HIERARCHICAL-only bus). Firsthand assertion on the real factory output,
+        mirroring ``test_broadcast_bus_fix_1500.py``. Replaces the pre-fix
+        ``test_middleware_channel_registration_error`` which pinned the dead
+        per-channel ``register_channel`` error-handling contract.
+        """
+        from argumentation_analysis.core.communication.channel_interface import (
+            ChannelType,
+        )
+
+        mock_settings = MagicMock()
+        mock_settings.service_manager.enable_communication_middleware = True
+
+        with patch(f"{SM_MODULE}.settings", mock_settings):
+            await manager.initialize_middleware()
+            assert manager.middleware is not None
+            assert manager.middleware.get_channel(ChannelType.HIERARCHICAL) is not None
+            assert manager.middleware.get_channel(ChannelType.DATA) is not None
 
 
 # ========================================================================
@@ -632,9 +632,7 @@ class TestInitializeSpecializedOrchestrators:
 
         with patch(f"{SM_MODULE}.CluedoOrchestrator", mock_cluedo), patch(
             f"{SM_MODULE}.ConversationOrchestrator", mock_conversation
-        ), patch(
-            f"{SM_MODULE}.FactCheckingOrchestrator", None
-        ):
+        ), patch(f"{SM_MODULE}.FactCheckingOrchestrator", None):
             await manager._initialize_specialized_orchestrators()
             assert manager.cluedo_orchestrator is not None
             assert manager.conversation_orchestrator is not None
@@ -647,9 +645,7 @@ class TestInitializeSpecializedOrchestrators:
     async def test_all_none_when_classes_none(self, manager):
         with patch(f"{SM_MODULE}.CluedoOrchestrator", None), patch(
             f"{SM_MODULE}.ConversationOrchestrator", None
-        ), patch(
-            f"{SM_MODULE}.FactCheckingOrchestrator", None
-        ):
+        ), patch(f"{SM_MODULE}.FactCheckingOrchestrator", None):
             await manager._initialize_specialized_orchestrators()
             assert manager.cluedo_orchestrator is None
             assert manager.conversation_orchestrator is None
@@ -866,8 +862,7 @@ class TestSelectOrchestrator:
 
     def test_modal_type(self, manager):
         assert (
-            manager._select_orchestrator("modal")
-            is manager.fact_checking_orchestrator
+            manager._select_orchestrator("modal") is manager.fact_checking_orchestrator
         )
 
     def test_propositional_type(self, manager):


### PR DESCRIPTION
## C2 #1500 — Shared-middleware broadcast bus delivers to listeners

Track **C2** of #1500 (Epic: rigorous apples-to-apples comparison of the 4 orchestration modes). Fixes the shared-broadcast-bus hole: a broadcast reached **0 agents** hierarchical-wide (coordinator verdict R653).

### Defect (reproduced firsthand)

The shared `MessageMiddleware` built at the two integration sites was hand-wired with only the HIERARCHICAL channel:

- `determine_channel` routes a `PUBLICATION` → `ChannelType.DATA` (unregistered) → `"Channel not found: data"` + silent `False`.
- Worse, `publish()`'s `send_message` was **dead for broadcasts regardless of channels**: the broadcast message carries `recipient=None`, and both `HierarchicalChannel` and `DataChannel` reject a recipient-less message ("has no recipient").

Net: every broadcast was dropped — coordinator measured "broadcasted to 0 agents", hierarchical-wide.

### Fix A — single source of truth for the shared bus

Both integration sites now use `create_default_middleware()` (the PR #1479 / R652 factory), which registers **both** `HIERARCHICAL` and `DATA`. Kills the `"Channel not found: data"` noise on the shared path.

### Fix B — genuine delivery via `global_handlers`

`PublishSubscribeProtocol.publish()` fans the broadcast out to the middleware's `global_handlers` (the "listen to all messages" mechanism, via `_handle_message`) instead of the dead `send_message`. A registered listener receives the broadcast firsthand — genuine delivery, not a cosmetic flag (anti-#1019).

### DoD (track C2)

- [x] **Bullet 1** — a broadcast reaches ≥1 agent firsthand: the test asserts **reception** (`test_broadcast_reaches_registered_listener_firsthand`), not just channel registration.
- [x] **Bullet 2** — no more `"Channel not found"` on the shared path: reproduced before (`test_hierarchical_only_middleware_drops_publication`: `send_message` returns `False` + `"Channel not found: data"` in caplog) and asserted absent after (`test_broadcast_emits_no_channel_not_found`).

### Files changed

| File | Change |
|------|--------|
| `orchestration/engine/main_orchestrator.py` | Fix A: `main()` shared bus → `create_default_middleware()` |
| `orchestration/service_manager.py` | Fix A: `initialize_middleware()` → `create_default_middleware()` |
| `core/communication/pub_sub.py` | Fix B: `publish()` fans out to `global_handlers` via `_handle_message` |
| `tests/.../test_broadcast_bus_fix_1500.py` | New: 5 tests — defect repro + both fixes (JVM/LLM-free) |
| `tests/.../test_pub_sub.py` | Regression: pin the new genuine-delivery contract (was the dead `send_message`) |

No files deleted.

### Validation (po-2023, env `projet-is`)

- `pytest tests/unit/argumentation_analysis/core/communication/` → **429 passed**
- `pytest tests/orchestration/hierarchical/` (excl. slow R652 subprocess) → **exit 0**
- `black` → formatted clean
- mypy `--strict` → **0 real defects on edited lines** (131 pre-existing errors in untyped modules; the two lint notes on edited lines mirror the existing optional-import `= None` idiom at the sibling `MessageMiddleware = None` fallback).

### Discipline

- **JVM/LLM-free**: pure communication-module machinery on synthetic opaque content.
- **Privacy HARD**: no corpus names, no raw text, opaque IDs only.
- **Anti-pendule**: reuses `create_default_middleware()` + the `global_handlers` fan-out mechanism; no new channel type, no counterweight.
- **Anti-#1019**: the stage changes the outcome (`0 → ≥1` delivered) on the synthetic case — not cosmetic.

Partially addresses #1500 (track C2). Track C3 (depth-parity / documented trade-off, reusing `compare_orchestration_modes.py`) follows in a separate PR, lane-disjoint from C1 (po-2025 conversational runner).
