### PR TITLE
docs(comparison): depth-parity trade-off documented with firsthand chiffres (C3 #1500)

### DIFF
--- a/docs/reports/ORCHESTRATION_MODE_DEPTH_PARITY.md
+++ b/docs/reports/ORCHESTRATION_MODE_DEPTH_PARITY.md
@@ -1,0 +1,72 @@
+# Orchestration Mode Depth-Parity — Trade-off Documented (C3 #1500)
+
+**Track C3 of #1500** (Epic: rigorous apples-to-apples comparison of the 4 orchestration modes). Generated from firsthand structural introspection (po-2023, env `projet-is`).
+
+## TL;DR
+
+The 4 orchestration modes are **comparable in interface** (all produce a verdict on the same synthetic input) but **NOT in work-perimeter**. They occupy three different depth dimensions. This asymmetry is a **deliberate design trade-off, not a defect**: aligning the catalogue would be a pendulum swing the project rejects (anti-#1019). This document makes the trade-off explicit and firsthand-chiffred — the honest C3 deliverable.
+
+## The depth asymmetry (firsthand chiffres)
+
+| Mode | Depth dimension | Count | Nature |
+|------|-----------------|-------|--------|
+| `pipeline_light` | workflow phases (DAG) | 3 | breadth |
+| `pipeline_standard` | workflow phases (DAG) | 15 | breadth |
+| `pipeline_full` | workflow phases (DAG) | 17 | breadth |
+| `hierarchical_bridge` | strategic objectives (default axes) | 4 | delegation |
+| `hierarchical_delegation` | strategic objectives (LLM-derived) | variable | delegation (3-tier depth) |
+| `conversational` | dialogue macro-phases (multi-turn) | 3 | dialogue-depth |
+| `conversation_deterministic` | dialogue macro-phases (deterministic) | 3 | dialogue-depth (no LLM) |
+
+The pipeline breadth chiffres are **verified firsthand** by introspecting the real workflow builders (`build_light_workflow` / `build_standard_workflow` / `build_full_workflow` in [`argumentation_analysis/orchestration/workflows.py`](../../argumentation_analysis/orchestration/workflows.py)) — not hand-written constants. The hierarchical `4` is the documented M2-bridge default ([`delegation_orchestrator.py`](../../argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py) — "the M2 bridge would inject 4 default objectives"). The conversational `3` is the macro-phase count (informal → formal → synthesis).
+
+## Three depth dimensions, not one common scale
+
+The modes do **not** share a single depth axis. The `depth_dimension` column names what each count measures:
+
+- **Pipeline = breadth.** A wide capability catalogue (registry exposes ~50 capabilities; the workflows exercise a subset per workflow). Each phase is shallow-per-capability. The verdict is the aggregation of many per-capability micro-verdicts by `WorkflowExecutor`.
+- **Hierarchical = delegation.** A narrow set of strategic objectives (4 default axes for the bridge; LLM-derived for the delegation tier), decomposed through the Strategic → Tactical → Operational chain. Depth comes from the 3-tier decomposition, not from capability count.
+- **Conversational = dialogue-depth.** Few macro-phases, but each is a deep multi-agent `AgentGroupChat` dialogue (unbounded turn count — bounded in wall-time by C1 #1500). Depth comes from turn-level exchange, not from phase count.
+
+## Why "align the catalogue" is rejected (anti-pendule, anti-#1019)
+
+The R653 reframe of the parent Epic falsified the idea that a mode was "dormant" — all 4 modes are already `--mode`-selectable. The depth asymmetry is the *next* layer of honesty: even with all modes selectable, they are not comparable in work-perimeter.
+
+Two alignment strategies were considered and **rejected**:
+
+1. **Gut pipeline's breadth** to match hierarchical/conversational (e.g. trim `standard` from 15 to ~4 phases). Rejected: the pipeline's breadth is its purpose — it is the "full analysis" surface. Trimming it destroys capability (pendulum subtract).
+2. **Inflate hierarchical/conversational** to match pipeline's phase count (e.g. fabricate 15 "phases" inside the hierarchical chain). Rejected: this is exactly the theatre #1019 forbids — cosmetic phases that look comparable but do no genuine work (pendulum add).
+
+Both swings move the problem to the other extreme. The equilibrium is reached by **documenting the trade-off** (this doc + the `--depth-parity` report section), not by adding a counterweight.
+
+## Reproducing the chiffres
+
+The depth-parity table is generated deterministically (JVM/LLM-free) by the orchestration-mode harness:
+
+```bash
+# Print ONLY the depth-parity trade-off section (fast, no mode runs):
+python scripts/compare_orchestration_modes.py --depth-parity
+
+# The depth-parity section is also appended to EVERY full comparison report:
+python scripts/compare_orchestration_modes.py --output report.md
+```
+
+The underlying functions are `compute_depth_parity()` and `render_depth_parity_section()` in [`scripts/compare_orchestration_modes.py`](../../scripts/compare_orchestration_modes.py). The chiffres are re-introspected on every call — if a workflow gains or loses a phase, the table and the unit tests ([`test_depth_parity_1500.py`](../../tests/unit/argumentation_analysis/orchestration/test_depth_parity_1500.py)) update/surface the drift (no silent staleness).
+
+## What this means for the mode comparison
+
+- The modes ARE comparable on: **termination** (C1 bounds conversational), **broadcast delivery** (C2 repairs the shared bus), and **decision** (does the mode emit a verdict). These are the Trade-off Summary columns of the harness report.
+- The modes are NOT comparable on: **work-perimeter depth**. The depth-parity section makes this explicit so a reader of the comparison report does not mistake "pipeline ran 15 phases" for "pipeline is 5× better than hierarchical" — the phases measure a different dimension than the objectives/turns.
+
+## Discipline
+
+- **Privacy HARD**: the chiffres are structural (phase/objective/macro-phase counts), not corpus-derived. No corpus names, no raw text — the comparison runs on synthetic opaque IDs (`corpus_A/B/C`).
+- **Anti-pendule**: reuses the existing workflow builders + the documented hierarchical/conversational constants; no new mode, no catalogue inflation/deflation.
+- **Anti-#1019**: the verdict makes the asymmetry explicit as a deliberate trade-off; nothing is faked into parity.
+
+## References
+
+- Parent Epic: #1500 (rigorous 4-mode comparison). Track C3 = this document.
+- Harness: BO-4 #1480 (`scripts/compare_orchestration_modes.py`).
+- R653 firsthand mode-comparison (the asymmetry observation).
+- Related tracks: C1 (bounded conversational termination), C2 (shared broadcast bus).

--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -161,6 +161,151 @@ class ModeResult:
         return asdict(self)
 
 
+# ── Depth-parity trade-off (C3 #1500) ─────────────────────────────────────
+#
+# The 4 modes are comparable in INTERFACE (all produce a verdict on the
+# same synthetic input) but NOT in work-perimeter. R653 surfaced the
+# asymmetry firsthand: pipeline = breadth (workflow DAG phase count),
+# hierarchical = delegation (4 default objectives / 3-tier), conversational
+# = dialogue-depth (3 macro-phases, multi-turn). Aligning them would be a
+# pendulum (gut pipeline's catalogue OR inflate hierarchical/conversational
+# artificially — both anti-#1019). C3 documents the trade-off instead.
+#
+# Structural chiffres verified firsthand (po-2023, build_*_workflow
+# introspection): pipeline light=3 / standard=15 / full=17 phases
+# (workflow_dsl.py add_phase); hierarchical bridge = 4 default objectives
+# (delegation_orchestrator.py:291); conversational = 3 macro-phases
+# (informal → formal → synthesis, AgentGroupChat).
+
+
+@dataclass
+class DepthParityRow:
+    """One row of the C3 #1500 structural depth-per-mode trade-off table.
+
+    The modes do NOT share a single depth axis — ``depth_dimension`` names
+    what kind of depth the count measures (workflow phases / objectives /
+    dialogue macro-phases), so the counts are honest labels, not a false
+    common scale.
+    """
+
+    mode: str
+    depth_dimension: str
+    depth_count: int
+    nature: str
+    verdict_dimension: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def compute_depth_parity() -> List[DepthParityRow]:
+    """Deterministic structural depth-per-mode (C3 #1500).
+
+    JVM/LLM-free: introspects the pure workflow builders (light/standard/
+    full) for the pipeline breadth axis, and uses the documented structural
+    constants for the hierarchical (delegation) and conversational
+    (dialogue-depth) axes. Returns the depth asymmetry the mode-comparison
+    surfaces — DOCUMENTED as a deliberate trade-off (anti-pendule, anti-#1019:
+    aligning would fabricate parity where there is none).
+    """
+    from argumentation_analysis.orchestration.workflows import (
+        build_full_workflow,
+        build_light_workflow,
+        build_standard_workflow,
+    )
+
+    rows: List[DepthParityRow] = []
+    for mode_name, builder in (
+        ("pipeline_light", build_light_workflow),
+        ("pipeline_standard", build_standard_workflow),
+        ("pipeline_full", build_full_workflow),
+    ):
+        workflow = builder()
+        rows.append(
+            DepthParityRow(
+                mode=mode_name,
+                depth_dimension="workflow phases (DAG)",
+                depth_count=len(workflow.phases),
+                nature="breadth",
+                verdict_dimension="per-capability verdicts aggregated by WorkflowExecutor",
+            )
+        )
+    rows.append(
+        DepthParityRow(
+            mode="hierarchical_bridge",
+            depth_dimension="strategic objectives (default axes)",
+            depth_count=4,
+            nature="delegation",
+            verdict_dimension="objectives_to_workflow -> WorkflowExecutor",
+        )
+    )
+    rows.append(
+        DepthParityRow(
+            mode="hierarchical_delegation",
+            depth_dimension="strategic objectives (LLM-derived)",
+            depth_count=0,  # variable: strategic tier produces N objectives per input
+            nature="delegation (3-tier depth)",
+            verdict_dimension="Strategic -> Tactical -> Operational chain",
+        )
+    )
+    rows.append(
+        DepthParityRow(
+            mode="conversational",
+            depth_dimension="dialogue macro-phases (multi-turn)",
+            depth_count=3,
+            nature="dialogue-depth",
+            verdict_dimension="AgentGroupChat synthesis",
+        )
+    )
+    rows.append(
+        DepthParityRow(
+            mode="conversation_deterministic",
+            depth_dimension="dialogue macro-phases (deterministic)",
+            depth_count=3,
+            nature="dialogue-depth (no LLM)",
+            verdict_dimension="ConversationOrchestrator synthesis",
+        )
+    )
+    return rows
+
+
+_DEPTH_PARITY_TRADEOFF_VERDICT = (
+    "The 4 modes are comparable in interface (all produce a verdict on the "
+    "same synthetic input) but NOT in work-perimeter. They occupy three "
+    "different depth dimensions: pipeline = breadth (a wide capability "
+    "catalogue, shallow per-capability), hierarchical = delegation (few "
+    "objectives, multi-tier decomposition), conversational = dialogue-depth "
+    "(few macro-phases, deep multi-turn). This asymmetry is a DELIBERATE "
+    "design trade-off, not a defect: aligning the catalogue would mean "
+    "gutting pipeline's breadth or artificially inflating hierarchical/"
+    "conversational — both pendulum swings the project rejects (anti-#1019). "
+    "Making the trade-off explicit and firsthand-chiffred (this section) is "
+    "the honest C3 deliverable."
+)
+
+
+def render_depth_parity_section() -> str:
+    """Render the C3 #1500 depth-parity trade-off section (markdown)."""
+    rows = compute_depth_parity()
+    lines = [
+        "## Depth-Parity Trade-off (C3 #1500)",
+        "",
+        "Structural depth per mode — firsthand chiffres (JVM/LLM-free,",
+        "deterministic workflow introspection). The modes do NOT share a",
+        "single depth axis; ``depth_dimension`` names what each count measures.",
+        "",
+        "| Mode | Depth dimension | Count | Nature |",
+        "|------|-----------------|-------|--------|",
+    ]
+    for r in rows:
+        count = str(r.depth_count) if r.depth_count > 0 else "variable (LLM-derived)"
+        lines.append(f"| {r.mode} | {r.depth_dimension} | {count} | {r.nature} |")
+    lines.append("")
+    lines.append(_DEPTH_PARITY_TRADEOFF_VERDICT)
+    lines.append("")
+    return "\n".join(lines)
+
+
 # ── Mode runners ─────────────────────────────────────────────────────────
 
 
@@ -382,18 +527,18 @@ async def run_hierarchical_bridge_mode(text: str, corpus_id: str) -> ModeResult:
         duration_seconds=round(duration, 2),
         phases_completed=phases_completed,
         phases_total=phases_total,
-        capabilities_used=result.get("capabilities_used", [])
-        if isinstance(result, dict)
-        else [],
+        capabilities_used=(
+            result.get("capabilities_used", []) if isinstance(result, dict) else []
+        ),
         decides=decides,
         scope_of_work=(
             "Strategic planning -> objectives_to_workflow -> "
             "WorkflowExecutor (Lego/DAG, 4 axes)"
         ),
         extra_metrics={
-            "objectives_count": len(result.get("objectives", []))
-            if isinstance(result, dict)
-            else 0,
+            "objectives_count": (
+                len(result.get("objectives", [])) if isinstance(result, dict) else 0
+            ),
         },
     )
 
@@ -459,18 +604,18 @@ async def run_hierarchical_delegation_mode(text: str, corpus_id: str) -> ModeRes
         duration_seconds=round(duration, 2),
         phases_completed=phases_completed,
         phases_total=phases_total,
-        capabilities_used=result.get("capabilities_used", [])
-        if isinstance(result, dict)
-        else [],
+        capabilities_used=(
+            result.get("capabilities_used", []) if isinstance(result, dict) else []
+        ),
         decides=decides,
         scope_of_work=(
             "Strategic -> Tactical -> Operational (3-tier, "
             "5 tasks via CapabilityRegistry)"
         ),
         extra_metrics={
-            "objectives_count": len(result.get("objectives", []))
-            if isinstance(result, dict)
-            else 0,
+            "objectives_count": (
+                len(result.get("objectives", [])) if isinstance(result, dict) else 0
+            ),
         },
     )
 
@@ -591,6 +736,11 @@ def generate_report(
         )
 
     lines.append("")
+
+    # Depth-parity trade-off (C3 #1500): structural depth per mode, surfaced
+    # on EVERY report so the mode-comparison makes the work-perimeter
+    # asymmetry explicit (not buried in capabilities_used lists).
+    lines.append(render_depth_parity_section())
 
     # Legacy detail table (preserves backward-compat for readers of
     # the previous report format).
@@ -814,7 +964,20 @@ def main():
             f"(terminated_by_budget=True), never as success=True."
         ),
     )
+    parser.add_argument(
+        "--depth-parity",
+        action="store_true",
+        help=(
+            "Print ONLY the C3 #1500 depth-parity trade-off section and exit "
+            "(deterministic workflow introspection — no mode runs, no LLM, no "
+            "JVM). Surfaces the structural depth asymmetry across the 4 modes."
+        ),
+    )
     args = parser.parse_args()
+
+    if args.depth_parity:
+        print(render_depth_parity_section())
+        return
 
     asyncio.run(
         run_all(

--- a/tests/unit/argumentation_analysis/orchestration/test_depth_parity_1500.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_depth_parity_1500.py
@@ -1,0 +1,124 @@
+# tests/unit/argumentation_analysis/orchestration/test_depth_parity_1500.py
+"""Track C3 of #1500 — depth-parity trade-off (documented, firsthand-chiffred).
+
+The 4 orchestration modes are comparable in interface (all produce a
+verdict on the same synthetic input) but NOT in work-perimeter. R653
+surfaced the asymmetry firsthand: pipeline = breadth (workflow DAG phase
+count), hierarchical = delegation (4 default objectives / 3-tier),
+conversational = dialogue-depth (3 macro-phases, multi-turn).
+
+Aligning the catalogue would be a pendulum (gut pipeline's breadth OR
+inflate hierarchical/conversational artificially — both anti-#1019). The
+honest C3 deliverable is to DOCUMENT the trade-off with firsthand chiffres,
+which ``compute_depth_parity`` + ``render_depth_parity_section`` do.
+
+These tests are JVM/LLM-free: they introspect the pure workflow builders
+(light/standard/full) deterministically and assert the structural chiffres
+match the real workflow phase counts (verify-before-assert — re-introspect
+in the test, never trust a hand-written constant).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# ``scripts/`` is not a package; add it to sys.path so the harness module
+# (which lives at scripts/compare_orchestration_modes.py) is importable.
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+_SCRIPTS_DIR = str(_PROJECT_ROOT / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import compare_orchestration_modes as harness  # noqa: E402
+from argumentation_analysis.orchestration.workflows import (  # noqa: E402
+    build_full_workflow,
+    build_light_workflow,
+    build_standard_workflow,
+)
+
+
+class TestComputeDepthParity:
+    """``compute_depth_parity`` returns one row per comparable mode with the
+    correct structural depth axis (breadth / delegation / dialogue-depth).
+    """
+
+    def test_returns_all_comparable_modes(self) -> None:
+        rows = harness.compute_depth_parity()
+        modes = {r.mode for r in rows}
+        # The three depth dimensions, each represented.
+        assert "pipeline_standard" in modes  # breadth
+        assert "hierarchical_bridge" in modes  # delegation
+        assert "conversational" in modes  # dialogue-depth
+
+    def test_pipeline_breadth_matches_real_workflow_phase_counts(self) -> None:
+        # Verify-before-assert: re-introspect the real builders, do NOT trust
+        # the hand-written chiffres. If a workflow gains/loses a phase, this
+        # test forces the depth-parity table to be updated (no silent drift).
+        rows = {r.mode: r for r in harness.compute_depth_parity()}
+        assert rows["pipeline_light"].depth_count == len(build_light_workflow().phases)
+        assert rows["pipeline_standard"].depth_count == len(
+            build_standard_workflow().phases
+        )
+        assert rows["pipeline_full"].depth_count == len(build_full_workflow().phases)
+
+    def test_pipeline_breadth_is_the_widest_dimension(self) -> None:
+        # The firsthand R653 observation: pipeline exercises a far wider
+        # capability catalogue than the other modes. Standard alone must be
+        # wider than the hierarchical default objectives and the conversational
+        # macro-phases.
+        rows = {r.mode: r for r in harness.compute_depth_parity()}
+        pipeline = rows["pipeline_standard"].depth_count
+        hierarchical = rows["hierarchical_bridge"].depth_count
+        conversational = rows["conversational"].depth_count
+        assert pipeline > hierarchical
+        assert pipeline > conversational
+
+    def test_hierarchical_bridge_has_four_default_objectives(self) -> None:
+        # delegation_orchestrator.py:291 documents the M2 bridge injects 4
+        # default objectives (the delegation tier refuses to fabricate —
+        # anti-#1019). This is the documented structural constant.
+        rows = {r.mode: r for r in harness.compute_depth_parity()}
+        assert rows["hierarchical_bridge"].depth_count == 4
+        assert rows["hierarchical_bridge"].nature == "delegation"
+
+    def test_conversational_is_dialogue_depth_not_breadth(self) -> None:
+        rows = {r.mode: r for r in harness.compute_depth_parity()}
+        assert rows["conversational"].nature == "dialogue-depth"
+        assert rows["conversational"].depth_count == 3  # 3 macro-phases
+
+    def test_modes_do_not_share_a_single_depth_axis(self) -> None:
+        # The honest point: the depth_dimension labels DIFFER across modes —
+        # they are not comparable on one common scale. This is the trade-off.
+        rows = harness.compute_depth_parity()
+        dimensions = {r.depth_dimension for r in rows}
+        assert len(dimensions) > 1  # at least breadth + delegation + dialogue
+
+
+class TestRenderDepthParitySection:
+    """``render_depth_parity_section`` produces the documented trade-off."""
+
+    def test_section_has_title_and_table_header(self) -> None:
+        section = harness.render_depth_parity_section()
+        assert "## Depth-Parity Trade-off (C3 #1500)" in section
+        assert "| Mode | Depth dimension | Count | Nature |" in section
+
+    def test_section_states_the_trade_off_is_deliberate(self) -> None:
+        # Anti-#1019: the verdict must make explicit that the asymmetry is a
+        # deliberate design trade-off, not a defect to "fix" by aligning.
+        section = harness.render_depth_parity_section()
+        assert "DELIBERATE design trade-off" in section
+        assert "anti-#1019" in section
+
+    def test_section_contains_firsthand_chiffres(self) -> None:
+        section = harness.render_depth_parity_section()
+        # The pipeline breadth chiffres (verified firsthand above).
+        assert (
+            f"| pipeline_standard | workflow phases (DAG) | {len(build_standard_workflow().phases)} |"
+            in section
+        )
+        # The hierarchical delegation constant.
+        assert (
+            "| hierarchical_bridge | strategic objectives (default axes) | 4 |"
+            in section
+        )


### PR DESCRIPTION
## C3 #1500 — Depth-parity trade-off documented with firsthand chiffres

Track **C3** of #1500 (Epic: rigorous apples-to-apples comparison of the 4 orchestration modes). The DoD offers two paths — *align the catalogue* OR *document the trade-off*. This PR delivers the **documented trade-off**, because aligning would be a pendulum swing.

### The asymmetry (firsthand, R653)

The 4 modes are comparable in **interface** (all produce a verdict on the same synthetic input) but **NOT in work-perimeter**. They occupy three different depth dimensions:

- **Pipeline = breadth** — a wide capability catalogue (workflow DAG: light=3 / standard=15 / full=17 phases).
- **Hierarchical = delegation** — 4 default strategic objectives (bridge) / LLM-derived (delegation), decomposed through the Strategic → Tactical → Operational chain.
- **Conversational = dialogue-depth** — 3 macro-phases of deep multi-turn `AgentGroupChat` dialogue.

### Why not "align the catalogue" (anti-pendule, anti-#1019)

Two alignment strategies were considered and **rejected**:

1. **Gut pipeline's breadth** (trim standard 15→~4) — destroys capability (pendulum subtract).
2. **Inflate hierarchical/conversational** to ~15 phases — cosmetic phases that look comparable but do no genuine work (pendulum add = theatre #1019 forbids).

The equilibrium is reached by **documenting the trade-off**, not by adding a counterweight.

### Deliverable

| File | Change |
|------|--------|
| `scripts/compare_orchestration_modes.py` | `compute_depth_parity()` (deterministic, JVM/LLM-free introspection of the real workflow builders + documented structural constants) + `render_depth_parity_section()` surfaced on EVERY comparison report + standalone `--depth-parity` CLI flag |
| `docs/reports/ORCHESTRATION_MODE_DEPTH_PARITY.md` | The trade-off doc: firsthand chiffres, 3-dimensions-not-one reasoning, rejection of both alignment swings |
| `tests/unit/.../test_depth_parity_1500.py` | 9 tests — verify-before-assert, breadth-is-widest, 4-objective documented constant, verdict states DELIBERATE trade-off + anti-#1019 |

No files deleted.

### Firsthand chiffres (verified by introspecting the real builders)

```
| pipeline_standard         | workflow phases (DAG)         | 15       | breadth            |
| pipeline_full             | workflow phases (DAG)         | 17       | breadth            |
| hierarchical_bridge       | strategic objectives (default)| 4       | delegation         |
| hierarchical_delegation   | strategic objectives (LLM)    | variable | delegation (3-tier)|
| conversational            | dialogue macro-phases         | 3        | dialogue-depth     |
```

The pipeline counts are re-introspected on every call — if a workflow gains/loses a phase, the table + the unit tests surface the drift (no silent staleness).

### Validation (po-2023, env `projet-is`)

- `pytest tests/unit/argumentation_analysis/orchestration/test_depth_parity_1500.py` → **9 passed** (4.6s)
- `python scripts/compare_orchestration_modes.py --depth-parity` → renders the table firsthand (deterministic, no mode runs)
- `black` → formatted clean (2 files)
- JVM/LLM-free: pure workflow introspection.

### Discipline

- **Anti-pendule**: reuses the existing workflow builders + documented structural constants; no new mode, no catalogue inflation/deflation.
- **Anti-#1019**: the verdict makes the asymmetry explicit as a **deliberate design trade-off**; nothing is faked into parity.
- **Privacy HARD**: structural chiffres only (phase/objective/macro-phase counts), not corpus-derived. No corpus names, no raw text.
- **Lane-disjoint** from C1 (po-2025 conversational runner): this PR touches only the comparison harness + a doc — it does **not** modify the conversational runner.

Partially addresses #1500 (track C3). With C2 (PR #1512, the shared broadcast bus) and C1 (po-2025, bounded conversational termination), the Epic's 4 modes become honestly comparable: bounded termination, genuine broadcast delivery, and an explicit depth-parity trade-off.
