### PR TITLE
test(workflows): hermeticize fact-extraction short-text test (#1510)

### DIFF
--- a/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
+++ b/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
@@ -276,12 +276,27 @@ class TestInvokeCallables:
 
     @pytest.mark.asyncio
     async def test_invoke_fact_extraction_short_text(self):
+        # #1510 — hermeticity: exercise the no-client heuristic fallback ("Hi." < 20 chars
+        # => claim_count 0). _invoke_fact_extraction takes the LLM path whenever
+        # _get_openai_client() returns a client. When real API keys are in
+        # os.environ (pytest-dotenv .env load, or a shell/fixture leak), "Hi."
+        # is routed to the LLM whose claim_count is nondeterministic (usually 0,
+        # occasionally 1) => spurious CI red on unrelated PRs. delenv is
+        # insufficient (.env keys leak back faster than a function-scoped delenv
+        # can hold); force the no-client path by patching _get_openai_client so
+        # the test deterministically exercises the heuristic fallback under test
+        # (soustraction of the leaky env/client dependency, not a retry/rerun).
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_fact_extraction,
         )
 
-        result = await _invoke_fact_extraction("Hi.", {})
-        assert result["claim_count"] == 0  # Too short
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(None, ""),
+        ):
+            result = await _invoke_fact_extraction("Hi.", {})
+        assert result["extraction_method"] == "heuristic"
+        assert result["claim_count"] == 0  # Too short (< 20 chars heuristic threshold)
 
     @pytest.mark.asyncio
     async def test_invoke_propositional_logic_error_fallback(self):


### PR DESCRIPTION
## Summary
Fixes #1510 — `test_invoke_fact_extraction_short_text` intermittently fails (`claim_count 1` vs `0` for `"Hi."`) in full-suite CI, causing spurious reds on **unrelated** PRs (e.g. #1508, which only touched `dung_arbitration`). Re-runs were green.

## Root cause (firsthand)
`_invoke_fact_extraction("Hi.", {})` takes the **LLM path** whenever `_get_openai_client()` returns a client, and the **heuristic path** ("Too short" < 20 chars → `claim_count 0`) only when no client. The test implicitly assumed the no-client path. But real API keys leak into `os.environ` via **pytest-dotenv** (`.env` sessionstart load) faster than a function-scoped `delenv` fixture can hold, so `"Hi."` is routed to the nondeterministic LLM (usually 0 claims, occasionally 1) → flake.

A probe confirmed the mechanism (identical input `"Hi."`):
| condition | claim_count | extraction_method | test |
|---|---|---|---|
| no client (no key) | 0 | heuristic | ✅ passes |
| client available (leak) | 0 or 1 (nondeterministic) | llm | ❌ flaky |

## Fix (anti-pendule — soustraction, not a retry)
Force the no-client path directly by **patching `_get_openai_client` → `(None, "")`**. `delenv` was tried first but is circumvented by the `.env` reload (pytest-dotenv reloads faster than a function-scoped delenv can hold); patching short-circuits all env/cache leakage. Added `assert extraction_method == "heuristic"` so any future leak fails **loudly/diagnostically** instead of as a `claim_count` flake.

This is a one-test, test-only change. The production code (`_invoke_fact_extraction`, `_get_openai_client`) is unchanged — the bug was the test's implicit, uncontrolled dependency on `os.environ`.

## Validation (projet-is)
- **Under simulated leak** (`OPENAI_API_KEY=sk-fake`): test now **PASSES** via heuristic. (Before the fix it `FAILED` with `extraction_method='llm'` — this reproduction is what proved `delenv` insufficient.)
- `test_formal_verification.py` full: **53 passed**.
- `black` clean.
- JVM/LLM-free; privacy HARD (synthetic `"Hi."` input, 0 corpus, 0 raw_text).

Closes #1510.
