### PR TITLE
test(orchestration): hermeticize fact-extraction empty-text test (#1510 sibling)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -918,7 +918,9 @@ class TestInvokeCallables:
         assert "extraction_method" in result
         assert result["conflict_count"] == 0
 
-    async def test_invoke_governance_emits_degraded_canon_when_verdict_empty_bo2_1472(self):
+    async def test_invoke_governance_emits_degraded_canon_when_verdict_empty_bo2_1472(
+        self,
+    ):
         """BO-2 #1472 — _invoke_governance emits the codebase-standard
         ``degraded`` canon at the top level when the formal aggregation
         cannot decide (no derivable preferences — e.g. sparse upstream / no
@@ -1061,12 +1063,25 @@ class TestInvokeCallables:
         assert isinstance(result.get("fallacies", []), list)
 
     async def test_invoke_fact_extraction_empty(self):
-        """_invoke_fact_extraction handles empty text."""
+        """_invoke_fact_extraction handles empty text (heuristic fallback)."""
+        # #1510 sibling — same pytest-dotenv flake class as
+        # test_invoke_fact_extraction_short_text: in CI, real API keys leak into
+        # os.environ via pytest-dotenv (.env sessionstart load), so empty input
+        # is routed to the LLM whose claim_count is nondeterministic (usually 0,
+        # occasionally a hallucinated claim) instead of the deterministic
+        # heuristic fallback (0 claims, no sentences > 20 chars). Force the
+        # no-client path by patching _get_openai_client so the test exercises
+        # the heuristic path it asserts (soustraction of the leaky dependency).
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_fact_extraction,
         )
 
-        result = await _invoke_fact_extraction("", {})
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(None, ""),
+        ):
+            result = await _invoke_fact_extraction("", {})
+        assert result["extraction_method"] == "heuristic"
         assert result["claim_count"] == 0
 
     async def test_invoke_propositional_logic_success(self):


### PR DESCRIPTION
## Summary
Fixes the **sibling** of #1510 — `test_invoke_fact_extraction_empty` intermittently fails the same way as the short-text flake fixed in **PR #1514**. This is the second of the *"Floater Fact: two brothers (`_short_text` / `fact_extraction`)"* noted on the workspace dashboard.

## Root cause (firsthand)
`_invoke_fact_extraction("", {})` takes the **LLM path** whenever `_get_openai_client()` returns a client. In CI, real API keys leak into `os.environ` via **pytest-dotenv** (`.env` sessionstart load), so empty input is routed to the LLM whose `claim_count` is nondeterministic (usually 0, occasionally a hallucinated claim) instead of the deterministic **heuristic fallback** (0 claims — no sentences > 20 chars). The test asserted `claim_count == 0` without controlling which path runs.

A probe confirmed the mechanism (identical empty input `""`):
| condition | claim_count | extraction_method | test |
|---|---|---|---|
| no client (no key) | 0 | heuristic | ✅ passes |
| client available (leak) | 0 or 1 (nondeterministic) | llm | ❌ flaky |

This is **exactly** the #1514 mechanism, on the empty-input variant.

## Fix (anti-pendule — soustraction, not a retry)
Force the no-client path by **patching `_get_openai_client` → `(None, "")`**, isolating the heuristic fallback the test intends to exercise. `delenv` is insufficient (pytest-dotenv reloads the key faster than a function-scoped delenv can hold). Added `assert extraction_method == "heuristic"` so any future leak fails **loudly/diagnostically** instead of as a `claim_count` flake. Mirrors the #1514 fix exactly.

Test-only. Production code (`_invoke_fact_extraction`, `_get_openai_client`) unchanged — the bug was the test's implicit, uncontrolled dependency on `os.environ`.

## Drive-by
`black` reformatted one **pre-existing, unrelated** governance test (`test_invoke_governance_emits_degraded_canon_when_verdict_empty_bo2_1472`, L918, BO-2 #1472 already merged) in the same file. Pure whitespace (line-break on a long signature), no behavior change. Documented for transparency; the file is now black-clean.

## Validation (projet-is)
- Target + the robust sibling (`test_invoke_fact_extraction`, path-tolerant) + the reformatted governance test: **3 passed**.
- `black` clean.
- JVM/LLM-free; privacy HARD (synthetic `""` input, 0 corpus, 0 raw_text).

Relates to #1510 (does not auto-close — #1510 tracks the short-text instance, already fixed by #1514; this PR addresses the empty-text sibling).
