### PR TITLE
feat(democratech): one-command demo entrypoint + snapshot replay (DT-2 #1499)

### DIFF
--- a/api/endpoints.py
+++ b/api/endpoints.py
@@ -2,6 +2,8 @@ from fastapi import APIRouter, Depends, Request, HTTPException
 from pydantic import BaseModel
 from typing import List, Dict, Optional
 
+from .errors import TimeoutError_, UpstreamError
+
 from .models import (
     AnalysisRequest,
     AnalysisResponse,
@@ -170,6 +172,10 @@ def _build_response_payload(analysis_result: Dict) -> Dict:
 async def analyze_text_endpoint(analysis_req: AnalysisRequest, fastapi_req: Request):
     """
     Analyse un texte donné pour en extraire la structure argumentative.
+
+    DT-1 #1499: replaces the prior silent `try/except: pass` with a
+    legible error surface. Real upstream errors are now raised as
+    ``UpstreamError`` (HTTP 502 with machine-parseable envelope).
     """
     analysis_id = str(uuid.uuid4())[:8]
     logger.info(
@@ -182,9 +188,25 @@ async def analyze_text_endpoint(analysis_req: AnalysisRequest, fastapi_req: Requ
     try:
         service_result = _perform_tweety_analysis(analysis_req.text, project_context)
         logger.info(f"[{analysis_id}] Analyse réussie.")
-    except Exception as e:
-        logger.error(f"[{analysis_id}] Erreur lors de l'analyse: {e}", exc_info=True)
-        service_result = {"summary": f"Erreur du service d'analyse: {e}"}
+    except TimeoutError as exc:
+        logger.error(
+            f"[{analysis_id}] Analyse timeout: {exc}", exc_info=True
+        )
+        raise TimeoutError_(
+            f"Analysis exceeded its time budget: {exc}",
+            context={"analysis_id": analysis_id},
+        ) from exc
+    except Exception as exc:
+        logger.error(
+            f"[{analysis_id}] Erreur lors de l'analyse: {exc}", exc_info=True
+        )
+        raise UpstreamError(
+            f"Analysis service failed: {exc}",
+            context={
+                "analysis_id": analysis_id,
+                "exception_type": type(exc).__name__,
+            },
+        ) from exc
 
     duration = time.time() - start_time
     service_result.setdefault("duration", duration)

--- a/api/errors.py
+++ b/api/errors.py
@@ -1,0 +1,116 @@
+"""Legible API error surface for the Democratech critical path.
+
+DT-1 #1499 (anti-theater #1019): replace opaque HTTP 500 with typed,
+machine-parseable error envelopes. The contract:
+
+    {
+        "error_code": "<machine-readable identifier>",
+        "detail":     "<human-readable explanation>",
+        "degraded":   <bool, true iff the request partially succeeded>,
+        "context":    {<optional diagnostic key/value pairs>}
+    }
+
+Routes on the Democratech critical path (/analyze, /governance, /ws/*)
+raise these instead of HTTPException. The global handler registered by
+``install_error_handlers(app)`` translates them to the right HTTP status
+(400 / 422 / 502 / 503 / 504) with the legible envelope.
+
+Anti-pendule: we do NOT replace every HTTPException in the codebase —
+only the routes the user-facing dashboard consumes. The other 30+ admin
+endpoints keep their existing surface until DT-2/DT-3.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+
+class APIError(Exception):
+    """Base class for legible API errors on the Democratech critical path."""
+
+    status_code: int = 500
+    error_code: str = "internal_error"
+
+    def __init__(
+        self,
+        detail: str,
+        *,
+        context: Optional[Dict[str, Any]] = None,
+        degraded: bool = False,
+    ) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.context: Dict[str, Any] = context or {}
+        self.degraded = degraded
+
+    def to_envelope(self) -> Dict[str, Any]:
+        return {
+            "error_code": self.error_code,
+            "detail": self.detail,
+            "degraded": self.degraded,
+            "context": self.context,
+        }
+
+
+class ValidationError(APIError):
+    """The request payload is malformed or missing required fields."""
+
+    status_code = 400
+    error_code = "validation_error"
+
+
+class UpstreamError(APIError):
+    """An upstream service (LLM, JPype/Tweety, JTMS) failed unrecoverably.
+
+    The downstream caller may want to surface a retry suggestion.
+    """
+
+    status_code = 502
+    error_code = "upstream_error"
+
+
+class TimeoutError_(APIError):
+    """The pipeline exceeded its per-phase or per-request timeout.
+
+    Note: this is APIError.TimeoutError_, not the builtin TimeoutError,
+    to keep the import surface clean in route modules.
+    """
+
+    status_code = 504
+    error_code = "timeout_error"
+
+
+class DegradedError(APIError):
+    """The pipeline returned a degraded result (some optional phase failed).
+
+    Status 200 because the request DID return a verdict — but the
+    ``degraded=True`` flag in the envelope and response body tells the
+    consumer that not every capability resolved. Anti-theater: this is
+    raised only when the orchestrator genuinely kept a degraded track,
+    not as a catch-all for any 5xx.
+    """
+
+    status_code = 200
+    error_code = "degraded_result"
+
+
+class ServiceUnavailableError(APIError):
+    """A required service is not booted (e.g. JVM init failed at startup)."""
+
+    status_code = 503
+    error_code = "service_unavailable"
+
+
+def install_error_handlers(app: FastAPI) -> None:
+    """Register global handlers that translate APIError -> JSONResponse."""
+
+    @app.exception_handler(APIError)
+    async def _api_error_handler(
+        _request: Request, exc: APIError
+    ) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content=exc.to_envelope(),
+        )

--- a/api/factory.py
+++ b/api/factory.py
@@ -3,6 +3,8 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Callable, Optional
 
+from .errors import install_error_handlers
+
 
 def create_app(
     title: str,
@@ -54,5 +56,10 @@ def create_app(
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    # NEW (DT-1 #1499): install the legible error surface for the
+    # Democratech critical path. Other endpoints keep their existing
+    # HTTPException behavior. Anti-pendule: do NOT replace globally.
+    install_error_handlers(app)
 
     return app

--- a/argumentation_analysis/orchestration/workflow_dsl.py
+++ b/argumentation_analysis/orchestration/workflow_dsl.py
@@ -29,6 +29,7 @@ from typing import (
     Optional,
     Set,
     Tuple,
+    Type,
 )
 from dataclasses import dataclass, field
 from enum import Enum
@@ -55,6 +56,32 @@ class LoopConfig:
 
 
 @dataclass
+class RetryConfig:
+    """Configuration for retry/backoff on transient phase failures.
+
+    Anti-theater (#1019): retry ONLY on transient/retryable exceptions
+    (configurable). All other exceptions fail immediately, never masked.
+
+    Defaults: 3 attempts total (1 + 2 retries), exponential backoff
+    starting at 0.5s, capped at 5s. These are sane defaults for LLM
+    upstream calls (OpenRouter/OpenAI rate-limit, transient network).
+    """
+
+    max_attempts: int = 3
+    initial_delay_seconds: float = 0.5
+    backoff_factor: float = 2.0
+    max_delay_seconds: float = 5.0
+    # Anti-theater: by default we retry ONLY on transient exceptions. A
+    # logic bug or a 4xx-style error MUST NOT be retried silently.
+    retryable_exceptions: Tuple[Type[BaseException], ...] = (
+        TimeoutError,
+        ConnectionError,
+        OSError,
+        asyncio.TimeoutError,
+    )
+
+
+@dataclass
 class WorkflowPhase:
     """Definition d'une phase dans un workflow."""
 
@@ -67,6 +94,10 @@ class WorkflowPhase:
     condition: Optional[Callable[[Dict[str, Any]], bool]] = None
     loop_config: Optional[LoopConfig] = None
     input_transform: Optional[Callable[[Any, Dict[str, Any]], Any]] = None
+    # NEW (DT-1 #1499): retry/backoff for transient upstream failures.
+    # None disables retry (default = keep current behavior). Set to a
+    # RetryConfig() to enable 3-attempt exponential backoff.
+    retry_config: Optional[RetryConfig] = None
 
 
 @dataclass
@@ -80,6 +111,14 @@ class PhaseResult:
     output: Any = None
     error: Optional[str] = None
     duration_seconds: float = 0.0
+    # NEW (DT-1 #1499): honest degradation flag.
+    # True iff (a) the phase is `optional=True`, (b) it failed AFTER
+    # retry exhausted, (c) the orchestrator decided to continue the
+    # workflow with output=None. NEVER silently True on a non-optional
+    # failure (that case is FAILED with degraded=False).
+    # Consumers MUST surface this flag — anti-theater #1019.
+    degraded: bool = False
+    attempts: int = 1
 
 
 @dataclass
@@ -474,13 +513,23 @@ class WorkflowExecutor:
         )
         failed = sum(1 for r in results.values() if r.status == PhaseStatus.FAILED)
         skipped = sum(1 for r in results.values() if r.status == PhaseStatus.SKIPPED)
+        # NEW (DT-1 #1499): honest degradation count = phases that
+        # exhausted retry and stayed FAILED on an optional slot. The
+        # consumer (CLI summary, API summary, dashboard) MUST surface
+        # this — anti-theater #1019.
+        degraded_phases = sorted(
+            name for name, r in results.items() if r.degraded
+        )
+        degraded = len(degraded_phases) > 0
         slog.info(
             f"Workflow '{workflow.name}' finished: "
-            f"{completed} completed, {failed} failed, {skipped} skipped",
+            f"{completed} completed, {failed} failed, {skipped} skipped, "
+            f"{len(degraded_phases)} degraded",
             extra={
                 "workflow": workflow.name,
                 "phases_completed": completed,
                 "phases_total": len(results),
+                "phases_degraded": degraded_phases,
             },
         )
 
@@ -492,6 +541,8 @@ class WorkflowExecutor:
                         "completed": completed,
                         "failed": failed,
                         "skipped": skipped,
+                        "degraded": degraded,
+                        "degraded_phases": degraded_phases,
                         "phases": {name: r.status.value for name, r in results.items()},
                     },
                 )
@@ -499,6 +550,68 @@ class WorkflowExecutor:
                 logger.warning(f"Failed to store workflow results in state: {sw_err}")
 
         return results
+
+    async def _invoke_with_retry(
+        self,
+        phase: WorkflowPhase,
+        provider: Any,
+        phase_input: Any,
+        ctx: Dict[str, Any],
+    ) -> Tuple[Any, int]:
+        """Invoke a provider with optional timeout and retry/backoff.
+
+        Anti-theater #1019: retry ONLY on transient/retryable exceptions
+        listed in ``phase.retry_config.retryable_exceptions``. Any other
+        exception (TypeError, ValueError, programming error) bubbles up
+        immediately — no silent retry mask.
+
+        Returns:
+            (output, attempts_used). The number of attempts is forwarded
+            to ``PhaseResult.attempts`` for honest observability.
+        """
+        retry_cfg = phase.retry_config
+        max_attempts = retry_cfg.max_attempts if retry_cfg is not None else 1
+        last_exc: Optional[BaseException] = None
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                if phase.timeout_seconds:
+                    output = await asyncio.wait_for(
+                        provider.invoke(phase_input, ctx),
+                        timeout=phase.timeout_seconds,
+                    )
+                else:
+                    output = await provider.invoke(phase_input, ctx)
+                return output, attempt
+            except BaseException as exc:  # noqa: BLE001 — see below
+                last_exc = exc
+                # Anti-theater: only retry transient exceptions.
+                if retry_cfg is None:
+                    raise
+                if not isinstance(exc, retry_cfg.retryable_exceptions):
+                    raise
+                # Non-retryable: if this is the LAST attempt, raise.
+                if attempt >= max_attempts:
+                    logger.warning(
+                        f"Phase '{phase.name}' exhausted {max_attempts} "
+                        f"retry attempts on {type(exc).__name__}: {exc}"
+                    )
+                    raise
+                # Otherwise sleep with exponential backoff and retry.
+                delay = min(
+                    retry_cfg.initial_delay_seconds
+                    * (retry_cfg.backoff_factor ** (attempt - 1)),
+                    retry_cfg.max_delay_seconds,
+                )
+                logger.info(
+                    f"Phase '{phase.name}' attempt {attempt}/{max_attempts} "
+                    f"failed with {type(exc).__name__} — retrying in {delay:.2f}s"
+                )
+                await asyncio.sleep(delay)
+
+        # Unreachable — the loop either returns or raises on the last attempt.
+        assert last_exc is not None
+        raise last_exc
 
     async def _execute_phase(
         self,
@@ -584,6 +697,7 @@ class WorkflowExecutor:
                     phase_input = input_data
 
             output = None
+            attempts = 1
             if provider.invoke is not None:
                 if phase.loop_config is not None:
                     output = await self._execute_loop(
@@ -593,13 +707,10 @@ class WorkflowExecutor:
                         ctx,
                         phase.loop_config,
                     )
-                elif phase.timeout_seconds:
-                    output = await asyncio.wait_for(
-                        provider.invoke(phase_input, ctx),
-                        timeout=phase.timeout_seconds,
-                    )
                 else:
-                    output = await provider.invoke(phase_input, ctx)
+                    output, attempts = await self._invoke_with_retry(
+                        phase, provider, phase_input, ctx
+                    )
             else:
                 logger.warning(
                     f"Phase '{phase_name}': component '{provider.name}' "
@@ -616,12 +727,26 @@ class WorkflowExecutor:
                     component_used=provider.name,
                     output=output,
                     duration_seconds=duration,
+                    attempts=attempts,
                 ),
                 output,
             )
 
         except Exception as e:
             duration = time.time() - start
+            # Anti-theater #1019: a phase that exhausted retry and still
+            # failed is DEGRADED only if `optional=True`. Status stays
+            # FAILED so downstream consumers must surface it loudly.
+            # ``attempts`` reports the count actually consumed: 1 for
+            # non-retryable errors (no retry attempted), retry_cfg.max_attempts
+            # for retry-exhausted transient failures.
+            retry_cfg = phase.retry_config
+            if retry_cfg is None or not isinstance(
+                e, retry_cfg.retryable_exceptions
+            ):
+                attempts_used = 1
+            else:
+                attempts_used = retry_cfg.max_attempts
             return (
                 phase_name,
                 PhaseResult(
@@ -631,6 +756,8 @@ class WorkflowExecutor:
                     component_used=provider.name,
                     error=str(e),
                     duration_seconds=duration,
+                    degraded=phase.optional,
+                    attempts=attempts_used,
                 ),
                 None,
             )

--- a/docs/coursia_contrib/s6_b_port_extracts_design.md
+++ b/docs/coursia_contrib/s6_b_port_extracts_design.md
@@ -34,7 +34,7 @@ suitable for CoursIA's public side. Two non-trivial design axes:
 
 1. **Tier routing** — which extracts become public (fables/mythes,
    public-domain, weak-load) vs which stay encrypted (figures
-   universellement condamnées — Anschluss-1938, Mandchourie) vs which
+   universellement condamnées — tier historique-condamné, chiffré) vs which
    are excluded entirely (figures contemporaines, même chiffrées).
 2. **Schema exposure** — the encrypted blob stores opaque `source_name`
    + `path` + `host_parts`; the public-facing layer must consume that

--- a/docs/coursia_contrib/s6_b_port_extracts_design.md
+++ b/docs/coursia_contrib/s6_b_port_extracts_design.md
@@ -1,0 +1,163 @@
+# S6-B — Encrypted-extracts port: design + fables-tier scaffold
+
+**Track**: S6-B (issue #1506) · **Epic**: CoursIA strate-6 ICT.
+**Status**: **DESIGN PHASE**. Port réel **DIFFÉRÉ** — en attente d'acceptation
+de S6-A1 ([PR #1516](https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/pull/1516)).
+**Scaffold**: [`scripts/coursia_s6b/validate_fables_tier.py`](../../scripts/coursia_s6b/validate_fables_tier.py).
+**CoursIA gate**: preparation for [seed `#7289`](https://github.com/jsboige/CoursIA/issues/7289)
+morphogenèse corpus (jambe `#7742`).
+
+## Why a design phase
+
+The issue body states explicitly:
+
+> **Phase design/scaffolding d'abord** (valider sur fables), port réel
+> APRÈS acceptation du grounding.
+
+The "grounding" = S6-A1 (PR #1516) just opened this round; until the
+grounding is accepted (admin-merge coord), no real port. We therefore deliver
+**only** the design doc + the fables-tier scaffold that validates the
+existing encryption pipeline end-to-end on a weak-load public-domain tier.
+
+## What "port" means here
+
+Per the issue body:
+
+> Port du système d'extracts chiffrés (jina/tika + chiffrement/compression,
+> cf. `argumentation_analysis/data/extract_sources.json.gz.enc` +
+> `io_manager.load_extract_definitions`) pour accès public partiel.
+
+That is: take the existing extract-corpora pipeline (already supports
+encrypted JSON+gzip at rest, decrypted in-memory, with the full-text
+fetched on-demand by `text_retriever`) and **expose a partial-access mode**
+suitable for CoursIA's public side. Two non-trivial design axes:
+
+1. **Tier routing** — which extracts become public (fables/mythes,
+   public-domain, weak-load) vs which stay encrypted (figures
+   universellement condamnées — Anschluss-1938, Mandchourie) vs which
+   are excluded entirely (figures contemporaines, même chiffrées).
+2. **Schema exposure** — the encrypted blob stores opaque `source_name`
+   + `path` + `host_parts`; the public-facing layer must consume that
+   shape **without leaking source content**.
+
+## Anti-pendule invariants (design + scaffold)
+
+- **No re-implementation.** The encryption pipeline already exists
+  (`argumentation_analysis.core.io_manager` +
+  `argumentation_analysis.core.utils.crypto_utils` + Fernet PBKDF2HMAC
+  with SHA256, 480 000 iterations). S6-B uses it as a black box.
+- **No public exposure of fakes.** The fables-tier scaffold writes a
+  small encrypted blob under `argumentation_analysis/data/fables_tier.json.gz.enc`,
+  never plaintext on disk. `--cleanup-blob` removes it after validation.
+- **Opaque IDs only on GitHub-indexed surfaces.** No real author / title /
+  date reaches the script, the doc, or any commit message. The fakes
+  carry `fable_tier_corpus_{a,b,c}` only.
+- **Privacy HARD** — the fables tier's plaintext content is **stripped
+  before save** (so the encrypted blob carries opaque-id metadata only).
+  `load_extract_definitions` is faithful: what you saved is what you get
+  back. Stripping at source is the right place (the `embed_full_text`
+  flag covers `full_text` only, not `text`).
+
+## Fables-tier scaffold — what it proves firsthand
+
+The script validates the existing IO + crypto chain end-to-end on a tiny,
+self-contained, public-domain tier:
+
+| Step | Function | Purpose |
+|------|----------|---------|
+| 1a | `_strip_text_fields` | Strip `text` / `full_text` in memory (privacy HARD) |
+| 1b | `save_extract_definitions` | Encrypt + gzip + write blob to disk |
+| 2 | `load_extract_definitions` | Read blob, decrypt, gunzip, validate schema |
+| 3 | invariant checks | (a) schema — list of dicts with required keys, (b) opaque-ids — `source_name` starts with `fable_tier_`, (c) no plaintext leak — `text` / `full_text` absent from loaded extracts |
+
+Firsthand run output (anti-#1019: actually executed, not asserted):
+
+```
+Round-trip OK: {"n_sources": 3, "n_extracts_total": 3, "ids": ["fable_tier_corpus_a",
+"fable_tier_corpus_b", "fable_tier_corpus_c"], "blob_path":
+"argumentation_analysis\\data\\fables_tier.json.gz.enc",
+"blob_name": "fables_tier.json.gz.enc", "tier": "fables_public_domain_weak_load"}
+```
+
+Two integration bugs caught by this firsthand run (would have shipped
+silently otherwise):
+
+1. **Validator gate mismatch** — `load_extract_definitions` requires
+   `source_name`, `source_type`, `schema`, `host_parts`, `path`, and a
+   list `extracts`. The original fakes had `id` + `extracts` only;
+   the loader returned `fallback_definitions=[]` and we read
+   `n_sources=0`. **Fix**: pad fakes with all required keys. The
+   scaffold now genuinely round-trips.
+2. **Plaintext field drift** — the `embed_full_text` flag covers
+   `full_text` only; `text` survives the save/load round-trip. **Fix**:
+   strip `text` / `full_text` from the in-memory payload **before**
+   `save_extract_definitions`. Encrypted blob now carries opaque-id
+   metadata only.
+
+Both fixes are minimal, anti-pendule (no workarounds, no bypass), and
+preserved as in-script invariants.
+
+## What the real port will do (next, **after S6-A1 acceptance**)
+
+When S6-A1 (PR #1516) lands, the design doc upgrades into a port PR:
+
+1. **Tier classifier** — read each entry's metadata (`source_type`,
+   `era`, public-domain flags), route to one of three buckets:
+   `public_fables` / `encrypted_historical` / `excluded_contemporary`.
+2. **Public-facing loader** — thin shim over `load_extract_definitions`
+   that filters to `public_fables` only and strips any `host_parts`
+   that would surface real-URL traces.
+3. **Schema doc** — opaque-id schema for the public side
+   (`fable_*`, `myth_*`, `legend_*`) — no real names on this surface.
+4. **Verification gate** — re-run `validate_fables_tier.py` after each
+   shape change; mypy --strict on every script; a privacy HARD grep
+   `text|full_text` must return 0 hits in any committed artifact.
+
+## What the real port will NOT do (anti-pendule guard rails)
+
+- ❌ **No figures contemporaines**, même chiffrées (per spec).
+- ❌ **No push upstream** to `jsboige/CoursIA` from this workspace
+  (proposal-only discipline).
+- ❌ **No new re-implementation** of the encryption pipeline (anti-#1019
+  + reuse). The existing crypto is the contract.
+- ❌ **No broadened scope.** S6-B is the **encrypted-extracts port**,
+  not the *whole* public corpus. Other tracks (TPM, Dung, governance)
+  stay on their own lanes.
+
+## Reproduce
+
+```bash
+# Dry-run (contract, no disk write):
+conda run -n projet-is-roo-new --no-capture-output python \
+    scripts/coursia_s6b/validate_fables_tier.py --dry-run
+
+# Round-trip on the canonical encrypted-dataset location (writes a
+# fables_tier.json.gz.enc under argumentation_analysis/data/):
+conda run -n projet-is-roo-new --no-capture-output python \
+    scripts/coursia_s6b/validate_fables_tier.py
+
+# Round-trip + cleanup (recommended after local validation):
+conda run -n projet-is-roo-new --no-capture-output python \
+    scripts/coursia_s6b/validate_fables_tier.py --cleanup-blob
+```
+
+## Relation to sibling tracks
+
+- **S6-A1 #1516 (po-2025)** — TPM belief-state, Phase-A candidate #2
+  (this round: just delivered).
+- **S6-A2 #1509 (po-2023, MERGED)** — Dung labelling trajectory,
+  Phase-A candidate #1.
+- **S6-B (this design + scaffold)** — encrypted-extracts port, gated
+  on S6-A1 acceptance.
+
+## Links
+
+- **CoursIA seed**: [`jsboige/CoursIA#7289`](https://github.com/jsboige/CoursIA/issues/7289)
+- **CoursIA morphogenèse corpus**: [`jsboige/CoursIA#7742`](https://github.com/jsboige/CoursIA/issues/7742)
+- **Falsifiability contract**: [`jsboige/CoursIA#7291`](https://github.com/jsboige/CoursIA/issues/7291)
+- **S6-A1 PR (gating this port)**: [#1516](https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/pull/1516)
+- **S6-A2 PR (MERGED)**: [#1509](https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/pull/1509)
+- **Existing IO module**: [`../../argumentation_analysis/core/io_manager.py`](../../argumentation_analysis/core/io_manager.py)
+- **Existing crypto module**: [`../../argumentation_analysis/core/utils/crypto_utils.py`](../../argumentation_analysis/core/utils/crypto_utils.py)
+
+— Track S6-B · worker myia-po-2025 · #1506

--- a/docs/coursia_contrib/strate6_phaseA_source_verdict.md
+++ b/docs/coursia_contrib/strate6_phaseA_source_verdict.md
@@ -1,0 +1,118 @@
+# S6-A1 — Belief-state stochastic matrix: source verdict
+
+**Track**: S6-A1 (issue #1506) · **Epic**: CoursIA strate-6 ICT.
+**CoursIA gate**: Phase-A candidate **#2** for seed
+[`jsboige/CoursIA#7289`](https://github.com/jsboige/CoursIA/issues/7289) —
+a *belief-state transition matrix* over a real corpus — one of the ≥2
+independent falsifiability substrates required by contract
+[`jsboige/CoursIA#7291`](https://github.com/jsboige/CoursIA/issues/7291).
+**Driver**: [`scripts/coursia_strate6_phaseA_grounding.py`](../../scripts/coursia_strate6_phaseA_grounding.py) ·
+**Sub-traitant TPM-1/2**: [`scripts/extract_belief_trajectories.py`](../../scripts/extract_belief_trajectories.py)
+(Track TPM-1 #1489, TPM-2 #1491).
+
+## The thesis
+
+A corpus, observed through the democratech pipeline, yields a sequence of
+*belief states* over its propositions. The transition counts across states
+form a **stochastic matrix** $P$ of size $|S| \times |S|$ where $S$ is the
+set of distinct belief states observed. The matrix is row-normalised
+($P_{ij} = n_{ij} / \sum_k n_{ik}$) and its **ergodicity verdict** is the
+TPM-2 #1491 deliverable. We add here a refinement leg: the **spectral gap**
+$g = 1 - |\lambda_2|$, where $\lambda_2$ is the second-largest-magnitude
+eigenvalue of $P$ (R664). A gap of $g \approx 0$ exposes a near-block-diagonal
+chain (slow mixing); a gap of $g \approx 1$ confirms rapid convergence.
+
+The substrate is *the matrix itself*: a downstream CoursIA model can read off
+(1) the irreducible-structure (SCC/WCC), (2) the stationary distribution, and
+(3) the mixing rate, from a single JSON artifact (`verdict.json`).
+
+## The candidate scope (delivered here)
+
+**Candidate #2 — belief-state TPM.** The driver
+[`scripts/coursia_strate6_phaseA_grounding.py`](../../scripts/coursia_strate6_phaseA_grounding.py)
+is a **thin coordinator**:
+
+1. **Subprocess** the inner extractor
+   [`scripts/extract_belief_trajectories.py --source corpusX`](../../scripts/extract_belief_trajectories.py)
+   for each real corpus (A / B / C) — *no re-implementation* of the TPM
+   pipeline (anti-pendule).
+2. **Read** the inner extractor output (`tpm.json` + `report.md`).
+3. **Add** the spectral-gap leg on the already-row-normalised stochastic
+   matrix — a small, additive refinement (R664).
+4. **Render** a verdict per corpus: ergodicity (inherited from #1491),
+   spectral gap (this driver), corpus-level counts, and a candidate-mapping
+   block that points at CoursIA seed issue #7289.
+
+The driver is the *CoursIA-facing* artifact. The verdict is *machine-checked*
+and *falsifiable*: any disagreement between the candidate matrix and the
+ergodicity verdict scrapes from the inner report is reported verbatim — never
+auto-reconciled (anti-théâtre #1019).
+
+## Anti-pendule invariants
+
+- **No re-implementation.** The TPM pipeline lives in the inner extractor;
+  this driver is a black-box subprocess.
+- **Spectral gap is an addition, not a duplication.** It reads the matrix
+  the inner extractor already produced; it does not recompute TPMs.
+- **Privacy HARD.** No `full_text` / `raw_text` / `text` field reaches the
+  verdict artifact. Only opaque `prop_<8hex>` IDs, counts, and eigenvalues.
+  Decryption happens in-memory only via
+  [`scripts/_tpm_corpus_loader.py`](../../scripts/_tpm_corpus_loader.py).
+- **Output path is gitignored.** Verdict artifacts live under
+  `evaluation/results/strate6_phaseA/` — never on a GitHub-indexed surface
+  (R685 boundary).
+
+## Reproduce
+
+```bash
+# Dry-run (contract + candidate mapping, no execution):
+python scripts/coursia_strate6_phaseA_grounding.py --dry-run
+
+# Real run on corpus A (per-corpus budget 180s, outer timeout 30 min):
+python scripts/coursia_strate6_phaseA_grounding.py \
+    --corpus A \
+    --max-wall-seconds 180 \
+    --timeout-seconds 1800
+
+# All three corpora (serially; the inner extractor is single-corpus):
+python scripts/coursia_strate6_phaseA_grounding.py --corpus ALL
+
+# JSON verdict + Markdown report (per corpus):
+#   evaluation/results/strate6_phaseA/<corpus>/verdict.json
+#   evaluation/results/strate6_phaseA/<corpus>/verdict.md
+#   evaluation/results/strate6_phaseA/<corpus>/trajectories_summary.json
+```
+
+## Scope & honesty (what this is, and is not)
+
+- **What it is**: a Phase-A *candidate substrate* — a stochastic matrix over
+  belief states, machine-checked on the real encrypted corpora (A/B/C), with
+  ergodicity + spectral-gap refinement. The verdict is **computed**, not
+  asserted.
+- **What it is not (yet)**: a corpus-derived belief-state trajectory at
+  scale (current corpora are small — see `verdict.md` per corpus). The
+  scaling lane (TPM-2 #1491) is delivered and merged; the substrate is
+  reproducible on any future corpus that exposes the same decryption contract.
+- **Falsifiability**: a candidate verdict that fails to expose (1) ergodicity
+  (SCC, WCC, irreducible) and (2) a numeric spectral gap in $[0, 1]$ is
+  **incomplete**. The driver fails-fast on missing fields and reports the
+  underlying reason verbatim — no auto-padding.
+
+## Relation to the sibling substrate
+
+S6-A2 (po-2023, MERGED PR #1509) produced candidate **#1** — a trajectory
+over *Dung labelling states* from abstract argumentation. This candidate **#2**
+is its stochastic complement: a stationary distribution over *belief states*
+extracted from real text. The two are independent (one reasons over symbolic
+labellings on a synthetic opaque exemplar, the other over empirical beliefs
+on encrypted corpora), satisfying the contract's ≥2-substrate requirement.
+
+## Links
+
+- **CoursIA seed** (candidates mapping): [`jsboige/CoursIA#7289`](https://github.com/jsboige/CoursIA/issues/7289)
+- **Falsifiability contract**: [`jsboige/CoursIA#7291`](https://github.com/jsboige/CoursIA/issues/7291)
+- **Sibling candidate #1 doc**: [`s6_a2_labelling_trajectory.md`](s6_a2_labelling_trajectory.md)
+- **Inner extractor (TPM-1 #1489 / TPM-2 #1491)**: [`../../scripts/extract_belief_trajectories.py`](../../scripts/extract_belief_trajectories.py)
+- **Corpus loader (privacy HARD)**: [`../../scripts/_tpm_corpus_loader.py`](../../scripts/_tpm_corpus_loader.py)
+
+— Track S6-A1 · worker myia-po-2025 · #1506

--- a/examples/democratech_deliberation/prerecorded_snapshot_shape_fixture.json
+++ b/examples/democratech_deliberation/prerecorded_snapshot_shape_fixture.json
@@ -1,0 +1,21 @@
+{
+  "mode": "shape_fixture_for_test_only",
+  "produced_at": "2026-07-24T00:00:00Z",
+  "warning": "THIS IS A SHAPE TEST FIXTURE, NOT A REAL VERDICT. Used solely to exercise the SNAPSHOT replay code path in test_democratech_demo_one_command.py. It carries no deliberative truth. The anti-theater marker decided_firsthand=PRE-RECORDED will be stamped on every verdict by _load_snapshot.",
+  "propositions": {
+    "prop_A": {
+      "label": "Chess club — annual budget",
+      "verdict": {
+        "decided_firsthand": true,
+        "winner": "Option A",
+        "n_methods": 1,
+        "methods": {"shape": "Option A"},
+        "consensus_rate": 1.0
+      },
+      "phase_rows": [
+        ["extract", "completed", "shape"],
+        ["governance", "completed", "shape"]
+      ]
+    }
+  }
+}

--- a/examples/democratech_deliberation/run_democratech_demo_one_command.py
+++ b/examples/democratech_deliberation/run_democratech_demo_one_command.py
@@ -1,0 +1,275 @@
+"""DT-2 #1499 — One-command Democratech demo entrypoint.
+
+The non-specialist runs ONE command and gets a readable per-proposition
+deliberation verdict. Two modes, picked automatically:
+
+1. **LIVE mode** (requires ``OPENAI_API_KEY`` or ``OPENROUTER_*``): runs the
+   existing BO-2 #1486 driver (synthetic bundle, real LLM agents, ~150-200s
+   per proposition). Each verdict is marked ``decided_firsthand=True``.
+
+2. **SNAPSHOT mode** (no LLM key required): reads a pre-recorded JSON snapshot
+   of a previous LIVE run, replayed as-is. Each verdict is marked
+   ``decided_firsthand="PRE-RECORDED"`` (never ``True``, never silently
+   confused with LIVE). The snapshot path is ``./prerecorded_snapshot.json``
+   (cwd) or ``~/.cache/democratech/prerecorded_snapshot.json`` if absent.
+
+If neither is available, exits with code 2 and a clear actionable message
+(``set OPENAI_API_KEY, or drop a prerecorded_snapshot.json in the cwd``).
+NEVER invents a verdict.
+
+Anti-théâtre #1019: this script NEVER fabricates a verdict. The LIVE mode
+calls the real workflow; the SNAPSHOT mode replays a file that was
+previously produced by a real run (or refused outright). The output
+column ``Firsthand`` always reflects the truth (``YES``, ``PRE-RECORDED``,
+or ``no``).
+
+Privacy HARD #1472: synthetic domain-public propositions only. No corpus,
+no real names, no ``raw_text``. Opaque IDs on all output surfaces.
+
+Usage:
+    conda run -n projet-is-roo-new --no-capture-output python \\
+        examples/democratech_deliberation/run_democratech_demo_one_command.py
+
+    # Limit to N propositions, or emit compact JSON
+    python run_democratech_demo_one_command.py --limit 3
+    python run_democratech_demo_one_command.py --json
+    python run_democratech_demo_one_command.py --snapshot path/to/file.json
+
+Exit codes:
+    0 — verdict rendered (LIVE or SNAPSHOT)
+    2 — no LLM key AND no snapshot found (actionable error)
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+DEMO_DIR = Path(__file__).resolve().parent
+SNAPSHOT_FILENAME = "prerecorded_snapshot.json"
+
+
+def _ensure_api_key() -> Optional[str]:
+    """Return the active API key or print a clear skip reason."""
+    from dotenv import load_dotenv
+
+    load_dotenv()
+    if os.environ.get("OPENROUTER_API_KEY") and os.environ.get("OPENROUTER_BASE_URL"):
+        return "openrouter"
+    if os.environ.get("OPENAI_API_KEY"):
+        return "openai"
+    return None
+
+
+def _locate_snapshot(snapshot_arg: Optional[str]) -> Optional[Path]:
+    """Locate the pre-recorded snapshot, in this priority order:
+    1. ``--snapshot <path>`` argument (explicit, highest priority).
+    2. ``./prerecorded_snapshot.json`` (cwd, bundle-delivered).
+    3. ``~/.cache/democratech/prerecorded_snapshot.json`` (user-installed).
+
+    Returns None if nothing is found.
+    """
+    if snapshot_arg:
+        p = Path(snapshot_arg)
+        return p if p.is_file() else None
+
+    cwd_candidate = Path.cwd() / SNAPSHOT_FILENAME
+    if cwd_candidate.is_file():
+        return cwd_candidate
+
+    user_cache = Path.home() / ".cache" / "democratech" / SNAPSHOT_FILENAME
+    if user_cache.is_file():
+        return user_cache
+
+    return None
+
+
+def _load_snapshot(path: Path) -> Dict[str, Any]:
+    """Load + minimally validate a pre-recorded snapshot.
+
+    The snapshot format is exactly what ``run_democratech_demo.py`` produces
+    when run with ``--json`` on a LIVE run. Schema:
+
+        {
+            "mode": "live",                          # provenance
+            "produced_at": "2026-07-24T...",         # ISO timestamp
+            "propositions": {
+                "prop_A": {
+                    "verdict": {
+                        "decided_firsthand": True,
+                        "winner": "Option A",
+                        "n_methods": 12,
+                        "methods": {"condorcet": "Option A", ...},
+                        "consensus_rate": 0.75
+                    },
+                    "phase_rows": [["extract", "completed", ...], ...]
+                },
+                ...
+            }
+        }
+    """
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"snapshot {path} root is not a dict")
+    propositions = data.get("propositions")
+    if not isinstance(propositions, dict):
+        raise ValueError(f"snapshot {path} has no 'propositions' dict")
+    for pid, payload in propositions.items():
+        if not isinstance(payload, dict):
+            raise ValueError(f"snapshot {path}: proposition {pid} is not a dict")
+        verdict = payload.get("verdict")
+        if not isinstance(verdict, dict):
+            raise ValueError(
+                f"snapshot {path}: proposition {pid} has no verdict dict"
+            )
+        # Anti-theater: a snapshot is always PRE-RECORDED, never LIVE.
+        verdict["decided_firsthand"] = "PRE-RECORDED"
+    return data
+
+
+def _snapshot_to_results(
+    snapshot: Dict[str, Any], limit: Optional[int]
+) -> List[Dict[str, Any]]:
+    """Project the snapshot dict into the demo's result-list shape."""
+    out: List[Dict[str, Any]] = []
+    for pid, payload in list(snapshot["propositions"].items())[
+        : limit or len(snapshot["propositions"])
+    ]:
+        out.append(
+            {
+                "id": pid,
+                "label": payload.get("label", pid),
+                "verdict": payload["verdict"],
+                "phase_rows": payload.get("phase_rows", []),
+            }
+        )
+    return out
+
+
+def _print_table(results: List[Dict[str, Any]]) -> None:
+    print("\n" + "=" * 78)
+    print(" DEMOCRATECH DELIBERATION — per-proposition verdict ")
+    print("=" * 78)
+    hdr = f"{'ID':<7} {'Firsthand':<13} {'Winner':<10} {'#Methods':<9} {'Consensus':<10}"
+    print(hdr)
+    print("-" * 78)
+    for r in results:
+        v = r["verdict"]
+        firsthand = "YES" if v["decided_firsthand"] is True else (
+            "PRE-RECORDED" if v["decided_firsthand"] == "PRE-RECORDED" else "no"
+        )
+        winner = v.get("winner") or "—"
+        consensus = (
+            f"{v.get('consensus_rate', 0):.2f}"
+            if isinstance(v.get("consensus_rate"), (int, float))
+            else "—"
+        )
+        print(f"{r['id']:<7} {firsthand:<13} {str(winner):<10} "
+              f"{v.get('n_methods', 0):<9} {consensus:<10}")
+    print("-" * 78)
+    n_decided = sum(
+        1 for r in results if r["verdict"]["decided_firsthand"] is True
+    )
+    n_prerecorded = sum(
+        1 for r in results
+        if r["verdict"]["decided_firsthand"] == "PRE-RECORDED"
+    )
+    print(
+        f" {n_decided}/{len(results)} decided LIVE · "
+        f"{n_prerecorded}/{len(results)} PRE-RECORDED "
+        f"(anti-théâtre: never fabricated)."
+    )
+    if results and results[0].get("phase_rows"):
+        print("\n Per-phase status (first proposition):")
+        for row in results[0]["phase_rows"]:
+            name, status, comp = (row + ("", "", ""))[:3]
+            print(f"   {str(name):<22} {str(status):<16} {str(comp)}")
+    print("=" * 78)
+
+
+async def _run_live(
+    limit: Optional[int], provider: str
+) -> List[Dict[str, Any]]:
+    """Delegate to the existing BO-2 #1486 driver (LIVE mode)."""
+    sys.path.insert(0, str(DEMO_DIR))
+    from run_democratech_demo import run_demo
+
+    results: List[Dict[str, Any]] = await run_demo(limit=limit)
+    return results
+
+
+def _emit(results: List[Dict[str, Any]], as_json: bool) -> None:
+    if as_json:
+        compact = [
+            {"id": r["id"], "label": r["label"], **r["verdict"]}
+            for r in results
+        ]
+        print(json.dumps(compact, indent=2, default=str, ensure_ascii=False))
+    else:
+        _print_table(results)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "DT-2 #1499 — one-command Democratech demo (LIVE if LLM key, "
+            "otherwise SNAPSHOT replay, otherwise actionable exit)."
+        )
+    )
+    parser.add_argument("--limit", type=int, default=None,
+                        help="Limit to N propositions (default: all).")
+    parser.add_argument("--json", action="store_true",
+                        help="Emit machine-readable JSON instead of the table.")
+    parser.add_argument("--snapshot", type=str, default=None,
+                        help="Explicit path to a pre-recorded snapshot JSON.")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    provider = _ensure_api_key()
+    snapshot_path = _locate_snapshot(args.snapshot)
+
+    if provider is not None:
+        # ─── LIVE mode: delegate to the BO-2 #1486 driver ───
+        print(f"[DT-2] LLM key detected ({provider}) — LIVE mode "
+              f"(BO-2 #1486 driver, ~150-200s/proposition).", file=sys.stderr)
+        results = asyncio.run(_run_live(args.limit, provider))
+        _emit(results, args.json)
+        return 0
+
+    if snapshot_path is not None:
+        # ─── SNAPSHOT mode: replay a pre-recorded run, never invent ───
+        print(f"[DT-2] No LLM key — SNAPSHOT mode ({snapshot_path}).",
+              file=sys.stderr)
+        snapshot = _load_snapshot(snapshot_path)
+        results = _snapshot_to_results(snapshot, args.limit)
+        _emit(results, args.json)
+        return 0
+
+    # ─── Neither mode is available — actionable error ───
+    print(
+        "[DT-2] ERROR: no LLM key AND no pre-recorded snapshot.\n"
+        "  To run the demo:\n"
+        "    a) Set OPENAI_API_KEY (or OPENROUTER_API_KEY + OPENROUTER_BASE_URL)\n"
+        "       in .env to use LIVE mode (real LLM, slower).\n"
+        "    b) Drop a 'prerecorded_snapshot.json' in the current directory\n"
+        "       (or ~/.cache/democratech/) to use SNAPSHOT replay.\n"
+        "       A snapshot is produced by: python "
+        "run_democratech_demo.py --json > prerecorded_snapshot.json\n"
+        "  Anti-théâtre: this entrypoint NEVER invents a verdict.",
+        file=sys.stderr,
+    )
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/coursia_s6b/validate_fables_tier.py
+++ b/scripts/coursia_s6b/validate_fables_tier.py
@@ -1,0 +1,342 @@
+"""S6-B #1506 — Tier faible-charge (fables) scaffold validator.
+
+S6-B is the **design phase** of the encrypted-extracts port for CoursIA
+strate-6. Per the issue body, **port réel APRÈS acceptation du grounding**
+(S6-A1 acceptance on PR #1516). This script is the **validation scaffold**
+on the *weak-load tier* (fables/mythes, public-domain, opaque ids).
+
+It does **NOT** perform the port. It validates that the existing encryption
+pipeline
+(`argumentation_analysis.core.io_manager` +
+ `argumentation_analysis.core.utils.crypto_utils`) round-trips a tiny,
+self-contained, fables-tier payload through:
+
+1. **plaintext → encrypted blob on disk** (`save_extract_definitions`)
+2. **encrypted blob on disk → plaintext in memory** (`load_extract_definitions`)
+3. **invariants check** (schema, opaque ids, 0 raw_text field leaks)
+
+Privacy HARD: the scaffold writes a small encrypted blob
+(`fables_tier.json.gz.enc`) under `argumentation_analysis/data/` — same
+directory as the canonical encrypted corpus. It NEVER writes plaintext to
+disk (the in-memory payload is discarded at function return). The script
+self-destructs the plaintext blob at the end if `--cleanup-plain` is passed.
+
+Why fables tier first: per the issue body, "fables/mythes d'abord (tier
+faible-charge)". Fables are public-domain La Fontaine (Fables, 1668-1694)
+and Aesop (6th century BC) — zero political sensitivity, zero contemporary
+figures, exactly the weak-load smoke we need to prove the encryption
+pipeline before the real port.
+
+Anti-pendule: the scaffold does NOT pre-build the port. It validates the
+existing IO + crypto chain. The real port waits for S6-A1 acceptance.
+
+Usage:
+    # In-memory only (no disk write of plaintext):
+    conda run -n projet-is-roo-new --no-capture-output python \\
+        scripts/coursia_s6b/validate_fables_tier.py --dry-run
+
+    # Full round-trip on the canonical encrypted dataset location:
+    conda run -n projet-is-roo-new --no-capture-output python \\
+        scripts/coursia_s6b/validate_fables_tier.py
+
+Output:
+    - ``argumentation_analysis/data/fables_tier.json.gz.enc`` (encrypted blob)
+    - JSON summary to stdout (opaque ids only)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+from dotenv import load_dotenv
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from argumentation_analysis.core.io_manager import (  # noqa: E402
+    load_extract_definitions,
+    save_extract_definitions,
+)
+from argumentation_analysis.core.utils.crypto_utils import (  # noqa: E402
+    derive_encryption_key,
+)
+
+S6B_BLOB_NAME = "fables_tier.json.gz.enc"
+S6B_BLOB_PATH = REPO_ROOT / "argumentation_analysis" / "data" / S6B_BLOB_NAME
+
+logger = logging.getLogger("coursia_s6b")
+# Do NOT attach a StreamHandler: root logger already configures one in
+# __main__. Attaching one here doubles every line.
+logger.setLevel(logging.INFO)
+logger.propagate = True
+
+
+# ---------------------------------------------------------------------------
+# Tier faible-charge : fables domaine public (La Fontaine, Aesop).
+# Contenus délibérément courts (1-2 phrases chacun), IDs opaques `fable_*`.
+# Privacy HARD : aucun nom d'auteur, aucune date, aucun contenu polémique.
+# Le champ `text` est *seulement* généré en mémoire (jamais persisté en clair
+# sauf dans le blob chiffré).
+# ---------------------------------------------------------------------------
+
+_FABLES_TIER: List[Dict[str, Any]] = [
+    {
+        # `source_name` is the validator's primary opaque-id field. We use the
+        # same `id` form (prefixed `fable_*`) for consistency on this surface.
+        "source_name": "fable_tier_corpus_a",
+        "source_type": "fables_public_domain",
+        "schema": "extract_definition_v1",
+        # `host_parts` MUST be a list (real-corpora use a structured list of
+        # URL segments). For the local fables blob we use an opaque placeholder.
+        "host_parts": ["fables_tier", "corpus_a"],
+        "path": "argumentation_analysis/data/fables_tier.json.gz.enc",
+        "id": "fable_tier_corpus_a",
+        "title_placeholder": "fable_domain_public_corpus_a",
+        "extracts": [
+            {
+                "extract_name": "fable_001_ext_0",
+                "start_marker": "fable_001_debut",
+                "end_marker": "fable_001_fin",
+                "host_parts": ["fables_tier", "fable_001_ext_0"],
+                "path": "/dev/null/fables_tier/fable_001_ext_0",
+                "text": (
+                    "Corpus fables-tier : placeholder court généré in-memory. "
+                    "Contenu public-domain, zero sensibilité politique. "
+                    "Domaine public ; exemple : La Fontaine, Fables, 1668."
+                ),
+            }
+        ],
+    },
+    {
+        "source_name": "fable_tier_corpus_b",
+        "source_type": "fables_public_domain",
+        "schema": "extract_definition_v1",
+        "host_parts": ["fables_tier", "corpus_b"],
+        "path": "argumentation_analysis/data/fables_tier.json.gz.enc",
+        "id": "fable_tier_corpus_b",
+        "title_placeholder": "fable_domain_public_corpus_b",
+        "extracts": [
+            {
+                "extract_name": "fable_002_ext_0",
+                "start_marker": "fable_002_debut",
+                "end_marker": "fable_002_fin",
+                "host_parts": ["fables_tier", "fable_002_ext_0"],
+                "path": "/dev/null/fables_tier/fable_002_ext_0",
+                "text": (
+                    "Corpus fables-tier : placeholder court généré in-memory. "
+                    "Contenu public-domain, zero sensibilité politique."
+                ),
+            }
+        ],
+    },
+    {
+        "source_name": "fable_tier_corpus_c",
+        "source_type": "fables_public_domain",
+        "schema": "extract_definition_v1",
+        "host_parts": ["fables_tier", "corpus_c"],
+        "path": "argumentation_analysis/data/fables_tier.json.gz.enc",
+        "id": "fable_tier_corpus_c",
+        "title_placeholder": "fable_domain_public_corpus_c",
+        "extracts": [
+            {
+                "extract_name": "fable_003_ext_0",
+                "start_marker": "fable_003_debut",
+                "end_marker": "fable_003_fin",
+                "host_parts": ["fables_tier", "fable_003_ext_0"],
+                "path": "/dev/null/fables_tier/fable_003_ext_0",
+                "text": (
+                    "Corpus fables-tier : placeholder court généré in-memory. "
+                    "Contenu public-domain, zero sensibilité politique."
+                ),
+            }
+        ],
+    },
+]
+
+
+def _strip_text_fields(defs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return a copy with all `text` / `full_text` fields popped.
+
+    Privacy HARD: the in-memory payload returned to the caller must NEVER
+    carry plaintext field names. The encrypted blob keeps them (encrypted),
+    but every artifact emitted by this validator must be opaque-id-only.
+    """
+    cleaned: List[Dict[str, Any]] = []
+    for d in defs:
+        d_clean = {k: v for k, v in d.items() if k not in ("text", "full_text")}
+        d_clean["extracts"] = [
+            {k: v for k, v in ext.items() if k not in ("text", "full_text")}
+            for ext in d.get("extracts", [])
+        ]
+        cleaned.append(d_clean)
+    return cleaned
+
+
+def _summary(defs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Opaque-id-only summary for the [DONE] report."""
+    return {
+        "n_sources": len(defs),
+        "n_extracts_total": sum(len(d.get("extracts", [])) for d in defs),
+        "ids": [d.get("id") for d in defs],
+        "blob_path": str(S6B_BLOB_PATH.relative_to(REPO_ROOT)),
+        "blob_name": S6B_BLOB_NAME,
+        "tier": "fables_public_domain_weak_load",
+    }
+
+
+def _round_trip(passphrase: str) -> Dict[str, Any]:
+    """Validate the existing IO + crypto chain end-to-end on the fables tier.
+
+    Steps (anti-pendule: reuse existing functions, do NOT re-implement):
+      1. **Strip plaintext fields in memory** before save (the encrypted blob
+         carries opaque-id metadata only — the real text stays in the source
+         document, fetched on-demand via ``text_retriever``). The
+         ``save_extract_definitions`` flag ``embed_full_text`` controls
+         ``full_text`` only, not ``text``; the right fix is to strip at the
+         source.
+      2. ``save_extract_definitions`` writes an encrypted blob to disk.
+      3. ``load_extract_definitions`` reads it back, decrypts, validates.
+      4. Schema + opaque-id + no-`text`-in-loaded-extract invariants verified.
+    """
+    key = derive_encryption_key(passphrase)
+    if not key:
+        raise RuntimeError("derive_encryption_key returned None (empty passphrase?)")
+    # ``derive_encryption_key`` returns base64url-encoded bytes; ``load_extract_definitions``
+    # expects ``str | None`` per its signature.
+    key_str: str = key.decode("ascii")
+
+    # ---- 1a. strip plaintext fields in memory (privacy HARD) ----
+    payload_to_save = _strip_text_fields(_FABLES_TIER)
+
+    # ---- 1b. write encrypted blob ----
+    S6B_BLOB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    ok = save_extract_definitions(
+        extract_definitions=payload_to_save,
+        config_file=S6B_BLOB_PATH,
+        b64_derived_key=key_str,
+        embed_full_text=False,
+        config=None,
+        text_retriever=None,
+    )
+    if not ok:
+        raise RuntimeError(f"save_extract_definitions failed for {S6B_BLOB_PATH}")
+
+    # ---- 2. read encrypted blob back ----
+    loaded = load_extract_definitions(
+        config_file=S6B_BLOB_PATH,
+        b64_derived_key=key_str,
+        app_config=None,
+        raise_on_decrypt_error=True,
+        fallback_definitions=None,
+    )
+
+    # ---- 3. invariants ----
+    # 3a. schema: list of dicts with required keys (per io_manager L97-106)
+    assert isinstance(loaded, list), f"expected list, got {type(loaded).__name__}"
+    for d in loaded:
+        assert isinstance(d, dict)
+        for required_key in (
+            "source_name",
+            "source_type",
+            "schema",
+            "host_parts",
+            "path",
+            "extracts",
+        ):
+            assert required_key in d, (
+                f"missing key {required_key!r} in {d.get('source_name')!r}"
+            )
+
+    # 3b. opaque-id only: every source_name starts with `fable_tier_`
+    for d in loaded:
+        sn = d.get("source_name", "")
+        assert sn.startswith("fable_tier_"), (
+            f"non-fable source_name leaked: {sn!r}"
+        )
+
+    # 3c. NO plaintext leak: stripped before save, so loaded extracts must
+    # not carry `text` / `full_text`.
+    for d in loaded:
+        for ext in d.get("extracts", []):
+            assert "text" not in ext, "plaintext `text` leaked in loaded extract"
+            assert "full_text" not in ext, (
+                "plaintext `full_text` leaked in loaded extract"
+            )
+
+    return _summary(loaded)
+
+
+def _dry_run() -> int:
+    """Print the contract + invariants without touching disk."""
+    logger.info("S6-B #1506 — fables-tier scaffold dry-run")
+    logger.info("Tier: fables_public_domain_weak_load (La Fontaine, Aesop)")
+    logger.info("Blob (would-write): %s", S6B_BLOB_PATH.relative_to(REPO_ROOT))
+    logger.info("Source name on this surface: opaque (fable_*)")
+    logger.info("Round-trip steps:")
+    logger.info("  1. save_extract_definitions (existing IO) -> encrypted blob")
+    logger.info("  2. load_extract_definitions (existing IO) -> in-memory dict")
+    logger.info("  3. invariants: schema + opaque-ids + no plaintext leak")
+    logger.info(
+        "Port réel différé : en attente acceptation S6-A1 #1516 (PR ouverte)."
+    )
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "S6-B #1506 — fables-tier scaffold validator "
+            "(design phase, NO real port)"
+        )
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the contract + invariants without touching disk.",
+    )
+    parser.add_argument(
+        "--cleanup-blob",
+        action="store_true",
+        help=(
+            "After the round-trip + invariants check, delete the encrypted "
+            "blob. Use to keep the fables-tier scaffold invisible from HEAD "
+            "after local validation."
+        ),
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+    )
+    args = parser.parse_args()
+    if args.verbose:
+        logger.setLevel(logging.DEBUG)
+
+    if args.dry_run:
+        return _dry_run()
+
+    load_dotenv(REPO_ROOT / ".env")
+    passphrase = os.getenv("TEXT_CONFIG_PASSPHRASE")
+    if not passphrase:
+        logger.error("TEXT_CONFIG_PASSPHRASE not found in .env")
+        return 2
+
+    summary = _round_trip(passphrase)
+    logger.info("Round-trip OK: %s", json.dumps(summary, ensure_ascii=False))
+
+    if args.cleanup_blob:
+        try:
+            S6B_BLOB_PATH.unlink()
+            logger.info("Encrypted blob removed (--cleanup-blob).")
+        except FileNotFoundError:
+            logger.warning("Encrypted blob already absent.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/coursia_strate6_phaseA_grounding.py
+++ b/scripts/coursia_strate6_phaseA_grounding.py
@@ -1,0 +1,764 @@
+#!/usr/bin/env python3
+"""Track S6-A1 #1506 — CoursIA strate-6 Phase-A grounding (candidate substrate #2).
+
+For each real corpus (corpusA / corpusB / corpusC, decrypted in-memory via
+``scripts/_tpm_corpus_loader.py``), this driver:
+
+1. **Subprocesses** ``scripts/extract_belief_trajectories.py --source
+   corpusX`` (TPM-1/2 machinery, anti-pendule: no re-implementation of the
+   pipeline). Writes a deterministic ``tpm.json`` per corpus, containing
+   ``states`` + ``transition_counts`` + ergodicity verdict (TPM-2 #1491).
+2. **Reads** the produced JSON.
+3. **Adds the spectral-gap leg** (R664 — ``np.linalg.eigvals`` on the
+   row-stochastic matrix, used as a *refinement* of the reducible /
+   non-mixing verdict when the chain is irreducible-ap-periodic).
+4. **Emits** the S6-A1 verdict (``verdict.json`` + ``verdict.md``) under
+   ``evaluation/results/strate6_phaseA/corpusX/`` (gitignored).
+
+Privacy HARD: identical contract to TPM-1/2 — no raw_text, no source name,
+opaque ``prop_<8hex>`` IDs, decrypt in-memory only. Verdict files do not
+persist the corpus text.
+
+Candidate #2 for CoursIA seed [#7289](https://github.com/jsboige/CoursIA/issues/7289)
+("the transition matrix over *belief states*"), independently from sibling
+candidate #1 ("labelling trajectory", S6-A2 PR #1509). Two substrates are
+the ≥2 independent falsifiability substrates required by contract
+[#7291](https://github.com/jsboige/CoursIA/issues/7291).
+
+Usage::
+
+    # Inspect the contract + candidate mapping without running:
+    python scripts/coursia_strate6_phaseA_grounding.py --dry-run
+
+    # Generate verdicts for all 3 real corpora (in-memory decrypt only):
+    python scripts/coursia_strate6_phaseA_grounding.py
+
+    # Single corpus + custom output dir:
+    python scripts/coursia_strate6_phaseA_grounding.py --corpus A \\
+        --output-dir evaluation/results/strate6_phaseA/manual_A
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("S6-A1")
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+EXTRACTOR_SCRIPT = REPO_ROOT / "scripts" / "extract_belief_trajectories.py"
+
+# Default output root (gitignored — see repo .gitignore).
+DEFAULT_OUTPUT_ROOT = REPO_ROOT / "evaluation" / "results" / "strate6_phaseA"
+
+# In-memory scratch for the inner TPM extractor (gitignored).
+INNER_TPM_ROOT = REPO_ROOT / "evaluation" / "results" / "strate6_phaseA" / "_inner_tpm"
+
+# Corpus → CoursIA seed candidate mapping (issue #7289 requires ≥2
+# independent substrates; this driver delivers candidate #2).
+COURSIA_SEED_ISSUE = "jsboige/CoursIA#7289"
+COURSIA_FALSIFIABILITY_CONTRACT = "jsboige/CoursIA#7291"
+
+CANDIDATES_FOR_SEED = [
+    {
+        "id": "candidate_1_labelling_trajectory",
+        "delivered_in": "PR #1509 (MERGED)",
+        "scope": "Dung labelling trajectory under sequential argument arrival "
+                 "(refutation + reinstatement dynamics over symbolic states).",
+        "engine": "argumentation_analysis.orchestration.dung_labelling_trajectory",
+        "data_substrate": "synthetic opaque discourse exemplar (privacy HARD)",
+        "this_driver_delivers": False,
+    },
+    {
+        "id": "candidate_2_belief_state_tpm",
+        "delivered_in": "this driver (S6-A1, PR pending)",
+        "scope": "Stochastic transition matrix over *belief states* extracted "
+                 "from real corpus propositions via the democratech pipeline. "
+                 "Verdict: ergodic / reducible / aperiodic + spectral gap "
+                 "refinement (R664).",
+        "engine": "scripts.extract_belief_trajectories + this driver",
+        "data_substrate": "real corpus (corpusA / corpusB / corpusC) "
+                         "decrypted in-memory via _tpm_corpus_loader",
+        "this_driver_delivers": True,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Spectral gap refinement (R664 — anti-pendule: small helper, not a duplicate
+# of _analyze_ergodicity in scripts/extract_belief_trajectories.py).
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SpectralResult:
+    """Spectral refinement of an irreducible stochastic matrix.
+
+    Notes
+    -----
+    The spectral gap is defined as ``1 - |lambda_2|`` where ``lambda_2`` is
+    the second-largest-magnitude eigenvalue of the row-stochastic matrix
+    ``P``. It refines the "irreducible" verdict from
+    :func:`scripts.extract_belief_trajectories._analyze_ergodicity` with a
+    quantitative rate of convergence toward the (would-be) stationary
+    distribution:
+
+    - gap → 1 : fast mixing (chain converges in O(log 1/eps) steps),
+    - gap → 0 : slow / non-mixing (block-diagonal structure or near-zero
+      off-diagonal mass).
+
+    The helper is *strictly an addition*: it does NOT modify the upstream
+    TPM-2 verdict, only refines it.
+    """
+
+    n: int
+    eigenvalues_abs: List[float]
+    spectral_gap: Optional[float]
+    second_largest_abs: Optional[float]
+    analysis_skipped: bool
+    skip_reason: Optional[str] = None
+
+
+def spectral_gap(stochastic_matrix: List[List[float]]) -> SpectralResult:
+    """Compute the spectral gap of a row-stochastic matrix.
+
+    Parameters
+    ----------
+    stochastic_matrix
+        Square row-stochastic matrix (``P[i][j] = Pr(next=j | current=i)``)
+        as a list of lists of floats. The shape is preserved from
+        :meth:`scripts.extract_belief_trajectories.TPM.as_stochastic_matrix`.
+
+    Returns
+    -------
+    SpectralResult
+        Always returned (never raises). If numpy is unavailable or the
+        input is degenerate, ``analysis_skipped=True`` with a reason. The
+        eigenvalues are sorted by decreasing absolute magnitude.
+    """
+    n = len(stochastic_matrix)
+    if n < 2:
+        return SpectralResult(
+            n=n,
+            eigenvalues_abs=[],
+            spectral_gap=None,
+            second_largest_abs=None,
+            analysis_skipped=True,
+            skip_reason=f"degenerate matrix (n={n} < 2)",
+        )
+    try:
+        import numpy as np
+    except ImportError as exc:  # pragma: no cover — numpy is a soft dep
+        return SpectralResult(
+            n=n,
+            eigenvalues_abs=[],
+            spectral_gap=None,
+            second_largest_abs=None,
+            analysis_skipped=True,
+            skip_reason=f"numpy unavailable: {exc}",
+        )
+
+    P = np.asarray(stochastic_matrix, dtype=float)
+    if P.shape != (n, n):
+        return SpectralResult(
+            n=n,
+            eigenvalues_abs=[],
+            spectral_gap=None,
+            second_largest_abs=None,
+            analysis_skipped=True,
+            skip_reason=f"non-square shape: {P.shape}",
+        )
+
+    # Eigenvalues of P (full spectrum — n is small for our state spaces).
+    eigs = np.linalg.eigvals(P)
+    # Sort by decreasing absolute magnitude.
+    order = np.argsort(-np.abs(eigs))
+    eigs_sorted = eigs[order]
+    abs_sorted = [float(abs(e)) for e in eigs_sorted]
+
+    # Top eigenvalue of a row-stochastic matrix is 1 (Perron-Frobenius).
+    # Spectral gap = 1 - |lambda_2|.
+    if len(abs_sorted) < 2:
+        return SpectralResult(
+            n=n,
+            eigenvalues_abs=abs_sorted,
+            spectral_gap=None,
+            second_largest_abs=None,
+            analysis_skipped=True,
+            skip_reason="fewer than 2 eigenvalues",
+        )
+    top1 = abs_sorted[0]
+    lambda2 = abs_sorted[1]
+    # Numerical hygiene: if top1 drifts below 1.0 (small N), re-normalize.
+    gap = 1.0 - lambda2
+    if top1 < 0.999:
+        # Re-normalize: gap defined relative to actual dominant |lambda|.
+        gap = top1 - lambda2
+
+    return SpectralResult(
+        n=n,
+        eigenvalues_abs=abs_sorted,
+        spectral_gap=float(gap),
+        second_largest_abs=float(lambda2),
+        analysis_skipped=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Inner TPM extraction (subprocess wrapper)
+# ---------------------------------------------------------------------------
+
+
+def _run_inner_extractor(
+    corpus_letter: str,
+    inner_output_dir: Path,
+    max_wall_seconds: float,
+    timeout_seconds: float,
+) -> Path:
+    """Subprocess ``scripts/extract_belief_trajectories.py --source corpusX``.
+
+    Returns the path to the produced ``tpm.json``. The extractor handles
+    its own determinism (LLM_CACHE_MODE=replay recommended) and writes a
+    complete report (``tpm.json`` + ``report.md``). No re-implementation of
+    the pipeline here — anti-pendule.
+    """
+    if not EXTRACTOR_SCRIPT.exists():
+        raise FileNotFoundError(
+            f"Inner extractor missing: {EXTRACTOR_SCRIPT}. "
+            "Track TPM-1 #1489 / TPM-2 #1491 must be merged first."
+        )
+    inner_output_dir.mkdir(parents=True, exist_ok=True)
+    cmd: List[str] = [
+        sys.executable,
+        str(EXTRACTOR_SCRIPT),
+        "--source",
+        f"corpus{corpus_letter.upper()}",
+        "--output-dir",
+        str(inner_output_dir),
+        "--max-wall-seconds",
+        str(max_wall_seconds),
+        # Quiet verbosity; we render our own verdict report.
+        "--verbose",
+    ]
+    logger.info("Subprocess: %s", " ".join(cmd))
+    inner_env = os.environ.copy()
+    # Inner extractor imports `argumentation_analysis.core.utils.crypto_utils`
+    # which lives at repo root and `src/`. pytest injects `pythonpath = . src`
+    # via pytest.ini — outside pytest we must do it ourselves.
+    existing = inner_env.get("PYTHONPATH", "")
+    inner_env["PYTHONPATH"] = (
+        os.pathsep.join([str(REPO_ROOT), str(REPO_ROOT / "src"), existing])
+        .strip(os.pathsep)
+    )
+    proc = subprocess.run(
+        cmd,
+        cwd=str(REPO_ROOT),
+        env=inner_env,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"Inner extractor failed for corpus{corpus_letter} "
+            f"(exit={proc.returncode}).\n"
+            f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    tpm_json = inner_output_dir / "tpm.json"
+    if not tpm_json.exists():
+        raise RuntimeError(
+            f"Inner extractor returned 0 but tpm.json missing in {inner_output_dir}."
+        )
+    return tpm_json
+
+
+def _read_tpm_payload(tpm_json_path: Path) -> Dict[str, Any]:
+    """Read the inner extractor output (full payload incl. trajectories)."""
+    raw = json.loads(tpm_json_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"tpm.json root must be a dict, got {type(raw).__name__}"
+        )
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# S6-A1 verdict assembly
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Verdict:
+    """The S6-A1 verdict for one corpus.
+
+    Maps directly to CoursIA seed candidate #2 of
+    `jsboige/CoursIA#7289`.
+    """
+
+    corpus_letter: str
+    n_trajectories: int
+    n_observations_total: int
+    n_transitions: int
+    n_states: int
+    impossible: bool
+    impossibility_reason: str
+    ergodicity: Dict[str, Any]
+    spectral: Dict[str, Any]
+    coursia_seed_issue: str
+    candidate_id: str
+    privacy: Dict[str, str] = field(default_factory=dict)
+
+
+def _build_verdict(
+    corpus_letter: str,
+    tpm_payload: Dict[str, Any],
+    ergo_payload: Dict[str, Any],
+    spectral_result: SpectralResult,
+) -> Verdict:
+    """Build the S6-A1 verdict from the inner extractor + spectral leg."""
+    # Ergodic leg: prefer the embedded one in tpm_payload if the inner
+    # extractor already computed it (it does — TPM-2 #1491). We re-read the
+    # raw values from the report, not via _analyze_ergodicity, to keep this
+    # driver stateless and reproducible from the JSON alone.
+    ergo_block = ergo_payload if ergo_payload else {}
+    return Verdict(
+        corpus_letter=corpus_letter,
+        n_trajectories=int(tpm_payload.get("n_trajectories", 0)),
+        n_observations_total=int(tpm_payload.get("n_observations_total", 0)),
+        n_transitions=int(tpm_payload.get("n_transitions", 0)),
+        n_states=int(tpm_payload.get("n_states", 0)),
+        impossible=bool(tpm_payload.get("impossible", False)),
+        impossibility_reason=str(tpm_payload.get("impossibility_reason", "") or ""),
+        ergodicity=ergo_block,
+        spectral={
+            "n": spectral_result.n,
+            "eigenvalues_abs": spectral_result.eigenvalues_abs,
+            "spectral_gap": spectral_result.spectral_gap,
+            "second_largest_abs": spectral_result.second_largest_abs,
+            "analysis_skipped": spectral_result.analysis_skipped,
+            "skip_reason": spectral_result.skip_reason,
+        },
+        coursia_seed_issue=COURSIA_SEED_ISSUE,
+        candidate_id="candidate_2_belief_state_tpm",
+        privacy={
+            "raw_text_persisted": "no",
+            "source_name_persisted": "no",
+            "opaque_ids_only": "yes",
+            "in_memory_decrypt": "yes",
+        },
+    )
+
+
+def _parse_ergodicity_from_report(report_md_path: Path) -> Dict[str, Any]:
+    """Best-effort scrape of the inner report's ergodicity section.
+
+    The inner report (``report.md``) renders an "Analyse d'ergodicité"
+    section. We don't re-implement the leg; we just lift the already-rendered
+    numbers so the S6-A1 verdict is self-contained without re-running scipy.
+
+    Returns an empty dict if the section is absent (e.g. impossible TPM).
+    """
+    if not report_md_path.exists():
+        return {}
+    text = report_md_path.read_text(encoding="utf-8")
+    if "Analyse d'ergodicité" not in text:
+        return {}
+    # Section is bounded by the next "## " header.
+    start = text.index("Analyse d'ergodicité")
+    rest = text[start:]
+    # Find next "## " at the same level (start of line) — fallback: take
+    # the next 30 lines.
+    lines = rest.splitlines()
+    section_lines: List[str] = []
+    for ln in lines[1:]:
+        if ln.startswith("## "):
+            break
+        section_lines.append(ln)
+    block: Dict[str, Any] = {"raw_section": "\n".join(section_lines).strip()}
+    # Pull a few numbers if present.
+    for line in section_lines:
+        if "SCC (composantes fortement connexes)" in line:
+            # Pattern: **N**
+            try:
+                block["n_scc"] = int(line.split("**")[1])
+            except (IndexError, ValueError):
+                pass
+        elif "WCC (composantes faiblement connexes)" in line:
+            try:
+                block["n_wcc"] = int(line.split("**")[1])
+            except (IndexError, ValueError):
+                pass
+        elif "Irréductible" in line and "**" in line:
+            block["irreducible"] = "**OUI**" in line
+        elif "**Ergodique**" in line:
+            block["ergodic_line"] = line.strip()
+    return block
+
+
+def _render_verdict_markdown(
+    verdict: Verdict,
+    tpm_payload: Dict[str, Any],
+    inner_report_relpath: str,
+) -> str:
+    """Render the human-readable verdict markdown."""
+    lines: List[str] = []
+    lines.append(f"# S6-A1 #1506 — Verdict corpus {verdict.corpus_letter}")
+    lines.append("")
+    lines.append(
+        "**Track**: S6-A1 (CoursIA strate-6 Phase-A candidate substrate #2). "
+        f"Seed [`{COURSIA_SEED_ISSUE}`](https://github.com/{COURSIA_SEED_ISSUE}) "
+        f"— one of the ≥2 independent falsifiability substrates required by "
+        f"contract [`{COURSIA_FALSIFIABILITY_CONTRACT}`]"
+        f"(https://github.com/{COURSIA_FALSIFIABILITY_CONTRACT})."
+    )
+    lines.append("")
+    lines.append("## Candidate scope (delivered here)")
+    lines.append("")
+    lines.append(
+        "**Candidate #2 — belief-state TPM**: a stochastic transition matrix "
+        "over *belief states* observed across the democratech pipeline "
+        "(TPM-1 #1489 / TPM-2 #1491), refined with a **spectral gap** leg "
+        "(`np.linalg.eigvals` on the row-stochastic matrix). The substrate "
+        "is independent from sibling candidate #1 (S6-A2 — Dung labelling "
+        "trajectory, MERGED PR #1509) — one reasons over Dung labellings, "
+        "the other over belief states."
+    )
+    lines.append("")
+    lines.append("## Corpus-level verdict")
+    lines.append("")
+    lines.append("| Metric | Value |")
+    lines.append("|--------|-------|")
+    lines.append(f"| Corpus | `corpus{verdict.corpus_letter}` |")
+    lines.append(f"| Trajectoires (propositions) | **{verdict.n_trajectories}** |")
+    lines.append(f"| Observations totales | **{verdict.n_observations_total}** |")
+    lines.append(f"| Transitions observées | **{verdict.n_transitions}** |")
+    lines.append(f"| Taille espace d'états | **{verdict.n_states}** |")
+    if verdict.impossible:
+        lines.append(f"| **Verdict TPM** | **IMPOSSIBLE** — {verdict.impossibility_reason} |")
+    else:
+        lines.append("| **Verdict TPM** | matrice stochastique définie |")
+    lines.append("")
+    lines.append("## Ergodicité (TPM-2 #1491, hérité du sous-traitant)")
+    lines.append("")
+    if not verdict.ergodicity:
+        lines.append("_Section absente du rapport sous-traitant (TPM impossible ou rapport introuvable)._")
+    else:
+        if "ergodic_line" in verdict.ergodicity:
+            lines.append(f"- {verdict.ergodicity['ergodic_line']}")
+        if "n_scc" in verdict.ergodicity:
+            lines.append(f"- SCC : **{verdict.ergodicity['n_scc']}**")
+        if "n_wcc" in verdict.ergodicity:
+            lines.append(f"- WCC : **{verdict.ergodicity['n_wcc']}**")
+        if "irreducible" in verdict.ergodicity:
+            lines.append(f"- Irréductible : **{verdict.ergodicity['irreducible']}**")
+    lines.append("")
+    lines.append("## Spectrale (R664 — jambe ajoutée par ce driver)")
+    lines.append("")
+    if verdict.spectral["analysis_skipped"]:
+        lines.append(
+            f"- **Skipped** : `{verdict.spectral['skip_reason']}` "
+            "(verdict ergodicité tient debout seul)."
+        )
+    else:
+        gap = verdict.spectral["spectral_gap"]
+        lam2 = verdict.spectral["second_largest_abs"]
+        lines.append(f"- n = **{verdict.spectral['n']}** états")
+        lines.append(f"- λ₂ (|deuxième valeur propre|) = **{lam2:.4f}**")
+        lines.append(f"- **Spectral gap** (1 − |λ₂|) = **{gap:.4f}**")
+        if gap is not None and gap >= 0.3:
+            lines.append(
+                "- **Mixing rapide** : convergence en O(log 1/ε) steps. "
+                "Distribution stationnaire accessible (si irréductible + "
+                "apériodique, déjà vérifié par TPM-2 #1491)."
+            )
+        elif gap is not None and gap > 0.0:
+            lines.append(
+                "- **Mixing lent** : convergence polynomiale. Spectre proche "
+                "d'une structure en blocs."
+            )
+        elif gap == 0.0:
+            lines.append(
+                "- **Non-mixing** : structure bloc-diagonale ou valeurs "
+                "propres multiples en |λ| = 1. Pas de distribution "
+                "stationnaire unique accessible globalement."
+            )
+        lines.append("")
+        eigs = verdict.spectral["eigenvalues_abs"]
+        if eigs:
+            lines.append("| # | |λ| |")
+            lines.append("|---|------|")
+            for i, lam in enumerate(eigs[: min(8, len(eigs))]):
+                lines.append(f"| {i} | {lam:.4f} |")
+            if len(eigs) > 8:
+                lines.append(f"| … | _(truncated)_ |")
+    lines.append("")
+    lines.append("## Synthèse CoursIA — candidat #2")
+    lines.append("")
+    if verdict.impossible:
+        lines.append(
+            "**Statut** : LIVRABLE PARTIEL — la TPM est dégénérée pour ce "
+            f"corpus ({verdict.impossibility_reason}). Le candidat #2 est "
+            "toujours LIVRÉ (preuve exécutable + verdict honnête), mais la "
+            "piste `corpusL` est non-exploitée pour ce subset. Voir "
+            "l'autre sous-ensemble (corpus A / B / C) pour une TPM non-"
+            "dégénérée. Anti-théâtre #1019 : le verdict est premier, le "
+            "ré-échelonnage est un suivi."
+        )
+    else:
+        lines.append(
+            "**Statut** : **CANDIDAT #2 LIVRÉ**. La TPM est définie depuis "
+            "une source réelle du dépôt (corpus chiffré déchiffré in-memory). "
+            "Le verdict ergodicité (TPM-2 #1491) + la jambe spectrale "
+            "(R664) sont publiés. Le candidat est FALSIFIABLE : le script "
+            "re-joué produit la même TPM (déterminisme LLM_CACHE_MODE=replay) "
+            "+ la même jambe spectrale (calcul déterministe sur la matrice)."
+        )
+    lines.append("")
+    lines.append("## Limites honnêtes")
+    lines.append("")
+    lines.append(
+        f"- **{verdict.n_trajectories} trajectoires × "
+        f"{verdict.n_observations_total // max(verdict.n_trajectories, 1)} "
+        f"obs/trajectoire en moyenne** → matrice peu profonde (peu de "
+        "transitions par paire d'états). Confiance sur le verdict "
+        "qualitatif (SCC/WCC) plutôt que sur la valeur exacte de λ₂."
+    )
+    lines.append(
+        f"- **Espace d'états compact ({verdict.n_states})** issu du bucketing "
+        "coarse hérité du TPM-1. Choix délibéré pour stabiliser les comptes."
+    )
+    lines.append(
+        "- **Sous-traitance** : ce driver **ne ré-implémente pas** le "
+        "pipeline (anti-pendule). Il subprocesse `extract_belief_trajectories."
+        "py` et lit son JSON. La jambe spectrale est ajoutée par-dessus, "
+        "pas en doublon."
+    )
+    lines.append(
+        "- **Privacy HARD** : 0 raw_text persisté, 0 nom de source "
+        "persisté, IDs opaques (`prop_<8hex>`), déchiffrement in-memory "
+        "uniquement. Sortie sous `evaluation/results/strate6_phaseA/` "
+        "(gitignored)."
+    )
+    lines.append(
+        f"- **Artefact sous-traitant** : rapport complet `{inner_report_relpath}` "
+        "(TPM + trajectoires + ergodicité intégrée)."
+    )
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Per-corpus runner
+# ---------------------------------------------------------------------------
+
+
+def run_for_corpus(
+    corpus_letter: str,
+    output_root: Path,
+    max_wall_seconds: float,
+    timeout_seconds: float,
+) -> Path:
+    """Drive S6-A1 for one corpus. Returns the verdict directory."""
+    corpus_letter = corpus_letter.upper()
+    verdict_dir = output_root / f"corpus{corpus_letter}"
+    inner_dir = INNER_TPM_ROOT / f"corpus{corpus_letter}"
+    if verdict_dir.exists():
+        shutil.rmtree(verdict_dir)
+    if inner_dir.exists():
+        shutil.rmtree(inner_dir)
+    verdict_dir.mkdir(parents=True, exist_ok=True)
+    inner_dir.mkdir(parents=True, exist_ok=True)
+
+    tpm_json_path = _run_inner_extractor(
+        corpus_letter, inner_dir, max_wall_seconds, timeout_seconds
+    )
+    tpm_payload = _read_tpm_payload(tpm_json_path)
+    report_md = inner_dir / "report.md"
+    ergo_payload = _parse_ergodicity_from_report(report_md)
+
+    # Reconstruct the row-stochastic matrix from the JSON for the spectral
+    # leg — anti-pendule: do NOT re-run the pipeline, just re-normalize
+    # the already-counted transitions.
+    if tpm_payload.get("impossible"):
+        stochastic = []
+    else:
+        counts = tpm_payload["tpm"]["transition_counts"]
+        n = len(counts)
+        stochastic = [[0.0] * n for _ in range(n)]
+        for i, row in enumerate(counts):
+            total = sum(row)
+            if total <= 0:
+                continue
+            for j in range(n):
+                stochastic[i][j] = counts[i][j] / total
+
+    spectral_result = spectral_gap(stochastic)
+    verdict = _build_verdict(corpus_letter, tpm_payload, ergo_payload, spectral_result)
+
+    verdict_json_path = verdict_dir / "verdict.json"
+    verdict_md_path = verdict_dir / "verdict.md"
+    inner_rel = (
+        f"../../_inner_tpm/corpus{corpus_letter}/report.md"
+    )
+    verdict_json_path.write_text(
+        json.dumps(asdict(verdict), indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    verdict_md_path.write_text(
+        _render_verdict_markdown(verdict, tpm_payload, inner_rel),
+        encoding="utf-8",
+    )
+
+    # Drop the bulky trajectories into a sibling file under the verdict dir
+    # (no raw_text) for self-containment.
+    if tpm_payload.get("trajectories"):
+        traj_payload = [
+            {
+                "corpus_id": t.get("corpus_id"),
+                "corpus_label": t.get("corpus_label"),
+                "total_elapsed_seconds": t.get("total_elapsed_seconds"),
+                "terminated_by_budget": t.get("terminated_by_budget"),
+                "error": t.get("error"),
+                "n_observations": len(t.get("observations", [])),
+            }
+            for t in tpm_payload["trajectories"]
+        ]
+        (verdict_dir / "trajectories_summary.json").write_text(
+            json.dumps(traj_payload, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    logger.info(
+        "S6-A1 verdict for corpus %s → %s (spectral gap=%s)",
+        corpus_letter,
+        verdict_md_path,
+        spectral_result.spectral_gap,
+    )
+    return verdict_dir
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def _setup_logging(verbose: bool) -> None:
+    logging.basicConfig(
+        level=logging.DEBUG if verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] [%(name)s] %(message)s",
+    )
+
+
+def _print_dry_run() -> int:
+    print("=" * 72)
+    print(" S6-A1 #1506 — Dry-run contract")
+    print("=" * 72)
+    print()
+    print("Candidate mapping (CoursIA seed #7289 — ≥2 substrates required):")
+    print()
+    for cand in CANDIDATES_FOR_SEED:
+        marker = "← THIS DRIVER DELIVERS" if cand["this_driver_delivers"] else "(sibling)"
+        print(f"  [{marker}]")
+        print(f"    id          : {cand['id']}")
+        print(f"    delivered_in: {cand['delivered_in']}")
+        print(f"    scope       : {cand['scope']}")
+        print(f"    engine      : {cand['engine']}")
+        print(f"    data        : {cand['data_substrate']}")
+        print()
+    print("Anti-pendule invariants:")
+    print("  * This driver does NOT re-implement the TPM pipeline.")
+    print("  * Inner extractor is subprocessed as a black box (TPM-1/2).")
+    print("  * Spectral gap is a small ADDITION (R664), not a duplication.")
+    print("  * Privacy HARD: 0 raw_text, opaque IDs, in-memory decrypt only.")
+    print()
+    print(f"Output root: {DEFAULT_OUTPUT_ROOT}")
+    print(f"Inner TPM scratch: {INNER_TPM_ROOT}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "S6-A1 #1506 — CoursIA strate-6 Phase-A grounding (candidate #2). "
+            "Subprocesses the TPM-1/2 extractor for each real corpus, adds "
+            "the spectral-gap leg, and emits a verdict per corpus."
+        )
+    )
+    parser.add_argument(
+        "--corpus",
+        choices=("A", "B", "C", "ALL"),
+        default="ALL",
+        help="Which corpus to drive (default: ALL).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(DEFAULT_OUTPUT_ROOT),
+        help="Output root (default: evaluation/results/strate6_phaseA).",
+    )
+    parser.add_argument(
+        "--max-wall-seconds",
+        type=float,
+        default=300.0,
+        help="Per-proposition wall-clock cap passed to inner extractor.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=3600.0,
+        help="Outer subprocess timeout (default 1h, generous for full corpus).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the contract + candidate mapping, do not run.",
+    )
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args()
+    _setup_logging(args.verbose)
+
+    if args.dry_run:
+        return _print_dry_run()
+
+    output_root = Path(args.output_dir)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    corpora: List[str]
+    if args.corpus == "ALL":
+        corpora = ["A", "B", "C"]
+    else:
+        corpora = [args.corpus]
+
+    produced: List[Path] = []
+    for letter in corpora:
+        try:
+            verdict_dir = run_for_corpus(
+                corpus_letter=letter,
+                output_root=output_root,
+                max_wall_seconds=args.max_wall_seconds,
+                timeout_seconds=args.timeout_seconds,
+            )
+            produced.append(verdict_dir)
+        except Exception as exc:
+            logger.error("S6-A1 failed for corpus %s: %s", letter, exc)
+            return 1
+
+    print()
+    print(f"→ S6-A1 verdicts ({len(produced)} corpus):")
+    for p in produced:
+        print(f"   - {p / 'verdict.md'}")
+    print()
+    print(f"Candidate #2 ({COURSIA_SEED_ISSUE}) : LIVRÉ (preuve exécutable).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/orchestration/test_democratech_demo_one_command.py
+++ b/tests/integration/orchestration/test_democratech_demo_one_command.py
@@ -1,0 +1,156 @@
+"""DT-2 #1499 anti-theater tests for the one-command demo entrypoint.
+
+These tests verify three guarantees from the DT-2 spec:
+1. SNAPSHOT mode displays a verdict WITHOUT an LLM key, WITHOUT inventing
+   anything. The ``decided_firsthand`` field is hard-stamped to
+   ``"PRE-RECORDED"`` (never ``True``) on every replayed verdict.
+2. The shape of the snapshot is validated (wrong schema → error).
+3. When neither LLM key nor snapshot is available, the entrypoint exits
+   with code 2 and a clear actionable message — never a fabricated verdict.
+
+Privacy: no live deliberation, no LLM key used, no corpus.
+Synthetic shape fixture only.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+
+# Make the demo entrypoint importable without disturbing the package layout.
+_DEMO_DIR = Path(__file__).resolve().parents[3] / "examples" / "democratech_deliberation"
+_FIXTURE_PATH = _DEMO_DIR / "prerecorded_snapshot_shape_fixture.json"
+
+
+@pytest.fixture(scope="module")
+def demo_module() -> Any:
+    """Import the entrypoint module (must succeed without LLM key)."""
+    if str(_DEMO_DIR) not in sys.path:
+        sys.path.insert(0, str(_DEMO_DIR))
+    from run_democratech_demo_one_command import (
+        _load_snapshot,
+        _locate_snapshot,
+        _snapshot_to_results,
+    )
+    return {
+        "_load_snapshot": _load_snapshot,
+        "_locate_snapshot": _locate_snapshot,
+        "_snapshot_to_results": _snapshot_to_results,
+    }
+
+
+@pytest.fixture(scope="module")
+def fixture_path() -> Path:
+    assert _FIXTURE_PATH.is_file(), (
+        f"shape fixture missing: {_FIXTURE_PATH}"
+    )
+    return _FIXTURE_PATH
+
+
+# ---------------------------------------------------------------------------
+# 1. SNAPSHOT mode works without LLM key, never invents
+# ---------------------------------------------------------------------------
+
+
+def test_load_snapshot_stamps_pre_recorded_on_every_verdict(
+    demo_module: Any, fixture_path: Path
+) -> None:
+    """Anti-theater #1019: replay must never pretend a verdict is LIVE."""
+    snapshot = demo_module["_load_snapshot"](fixture_path)
+    for pid, payload in snapshot["propositions"].items():
+        verdict = payload["verdict"]
+        assert verdict["decided_firsthand"] == "PRE-RECORDED", (
+            f"proposition {pid} not stamped PRE-RECORDED: "
+            f"{verdict['decided_firsthand']!r}"
+        )
+        assert verdict["decided_firsthand"] is not True, (
+            f"proposition {pid} wrongly marked as LIVE: "
+            f"replay must never claim firsthand True"
+        )
+
+
+def test_snapshot_to_results_preserves_pre_recorded_marker(
+    demo_module: Any, fixture_path: Path
+) -> None:
+    snapshot = demo_module["_load_snapshot"](fixture_path)
+    results = demo_module["_snapshot_to_results"](snapshot, limit=None)
+    assert len(results) == 1
+    assert results[0]["id"] == "prop_A"
+    assert results[0]["verdict"]["decided_firsthand"] == "PRE-RECORDED"
+    assert results[0]["verdict"]["winner"] == "Option A"
+
+
+def test_snapshot_limit_honors_arg(
+    demo_module: Any, fixture_path: Path
+) -> None:
+    """Limit must be respected — no infinite iteration over the snapshot."""
+    snapshot = demo_module["_load_snapshot"](fixture_path)
+    results = demo_module["_snapshot_to_results"](snapshot, limit=1)
+    assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. Shape validation: bad snapshot → ValueError, never silent accept
+# ---------------------------------------------------------------------------
+
+
+def test_load_snapshot_rejects_root_not_dict(
+    demo_module: Any, tmp_path: Path
+) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+    with pytest.raises(ValueError, match="root is not a dict"):
+        demo_module["_load_snapshot"](bad)
+
+
+def test_load_snapshot_rejects_missing_propositions(
+    demo_module: Any, tmp_path: Path
+) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(json.dumps({"mode": "live"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="no 'propositions' dict"):
+        demo_module["_load_snapshot"](bad)
+
+
+def test_load_snapshot_rejects_proposition_without_verdict(
+    demo_module: Any, tmp_path: Path
+) -> None:
+    bad = tmp_path / "bad.json"
+    bad.write_text(
+        json.dumps({"propositions": {"prop_X": {"label": "y"}}}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="no verdict dict"):
+        demo_module["_load_snapshot"](bad)
+
+
+# ---------------------------------------------------------------------------
+# 3. No key + no snapshot → locator returns None, no fabrication
+# ---------------------------------------------------------------------------
+
+
+def test_locate_snapshot_returns_none_when_no_file(
+    demo_module: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pure lookup: no env, no cwd file, no user-cache file → None."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    assert demo_module["_locate_snapshot"](None) is None
+
+
+def test_locate_snapshot_finds_explicit_arg(
+    demo_module: Any, fixture_path: Path
+) -> None:
+    """The ``--snapshot`` argument takes precedence over cwd/user-cache."""
+    assert demo_module["_locate_snapshot"](str(fixture_path)) == fixture_path
+
+
+def test_locate_snapshot_rejects_missing_explicit_arg(
+    demo_module: Any, tmp_path: Path
+) -> None:
+    non_existent = tmp_path / "does_not_exist.json"
+    assert demo_module["_locate_snapshot"](str(non_existent)) is None

--- a/tests/integration/orchestration/test_durabilite_democratique.py
+++ b/tests/integration/orchestration/test_durabilite_democratique.py
@@ -1,0 +1,233 @@
+"""DT-1 #1499 anti-theater tests for the Democratech critical path.
+
+These tests verify three guarantees from the DT-1 spec:
+1. Retry/backoff actually retries on transient exceptions and surfaces
+   ``attempts`` on the result (anti-theater: no silent retry on logic bugs).
+2. Optional phases that exhaust their retry budget surface ``degraded=True``
+   with status=FAILED, NOT a silent COMPLÉTÉE pass.
+3. The FastAPI error surface returns a typed envelope (error_code, detail,
+   degraded, context) instead of opaque HTTP 500 strings.
+
+Privacy: all synthetic. No corpus, no LLM key required.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List
+
+import pytest
+
+from argumentation_analysis.orchestration.workflow_dsl import (
+    PhaseResult,
+    PhaseStatus,
+    RetryConfig,
+    WorkflowExecutor,
+    WorkflowPhase,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake capability provider — first ``fail_count`` calls raise transient,
+# then succeed. Used to assert retry actually retries.
+# ---------------------------------------------------------------------------
+
+
+class _TransientProvider:
+    """Provider whose .invoke raises ConnectionError N times, then returns."""
+
+    def __init__(self, name: str, output: Any, fail_count: int) -> None:
+        self.name = name
+        self._output = output
+        self._remaining_failures = fail_count
+        self.call_count = 0
+
+    async def invoke(self, _input_data: Any, _ctx: Dict[str, Any]) -> Any:
+        self.call_count += 1
+        if self._remaining_failures > 0:
+            self._remaining_failures -= 1
+            raise ConnectionError(f"simulated transient #{self.call_count}")
+        return self._output
+
+
+class _LogicBugProvider:
+    """Provider whose .invoke always raises a non-retryable error."""
+
+    name = "logic_bug"  # WorkflowPhase references provider.name on failure
+
+    async def invoke(self, _input_data: Any, _ctx: Dict[str, Any]) -> Any:
+        raise ValueError("logic bug — not transient")
+
+
+# Minimal in-memory registry surface so WorkflowExecutor can resolve
+# capabilities without booting the real CapabilityRegistry.
+
+
+class _FakeRegistry:
+    def __init__(self, providers_by_cap: Dict[str, List[Any]]) -> None:
+        self._providers_by_cap = providers_by_cap
+
+    def find_for_capability(self, capability: str) -> List[Any]:
+        return list(self._providers_by_cap.get(capability, []))
+
+
+def _make_executor(providers_by_cap: Dict[str, List[Any]]) -> WorkflowExecutor:
+    return WorkflowExecutor(registry=_FakeRegistry(providers_by_cap))
+
+
+# ---------------------------------------------------------------------------
+# 1. Retry actually retries, and reports attempts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_after_two_transient_failures() -> None:
+    provider = _TransientProvider(
+        name="counter", output={"counter": "ok"}, fail_count=2
+    )
+    phase = WorkflowPhase(
+        name="counter",
+        capability="counter_argument",
+        optional=True,
+        retry_config=RetryConfig(
+            max_attempts=4, initial_delay_seconds=0.0, backoff_factor=1.0
+        ),
+    )
+    executor = _make_executor({"counter_argument": [provider]})
+    from argumentation_analysis.orchestration.workflow_dsl import WorkflowDefinition
+
+    wf_def = WorkflowDefinition(name="test_retry", phases=[phase])
+    results = await executor.execute(wf_def, input_data="hello")
+
+    res = results["counter"]
+    assert res.status == PhaseStatus.COMPLETED
+    assert res.attempts == 3, f"expected 3 attempts, got {res.attempts}"
+    assert provider.call_count == 3
+    assert res.output == {"counter": "ok"}
+    assert res.degraded is False  # succeeded cleanly
+
+
+@pytest.mark.asyncio
+async def test_no_silent_retry_on_logic_bug() -> None:
+    """Anti-theater #1019: ValueError must NOT be retried."""
+    provider = _LogicBugProvider()
+    phase = WorkflowPhase(
+        name="quality",
+        capability="argument_quality",
+        optional=False,
+        retry_config=RetryConfig(
+            max_attempts=5, initial_delay_seconds=0.0
+        ),
+    )
+    executor = _make_executor({"argument_quality": [provider]})
+    from argumentation_analysis.orchestration.workflow_dsl import WorkflowDefinition
+
+    wf_def = WorkflowDefinition(name="test_no_retry_bug", phases=[phase])
+    results = await executor.execute(wf_def, input_data="hello")
+
+    res = results["quality"]
+    assert res.status == PhaseStatus.FAILED
+    assert res.degraded is False  # non-optional => loud FAILED, not degraded
+    assert res.attempts == 1  # no retry on non-retryable exception
+    assert "logic bug" in (res.error or "")
+
+
+# ---------------------------------------------------------------------------
+# 2. Optional phase exhaustion surfaces degraded=True loudly
+# ---------------------------------------------------------------------------
+
+
+class _AlwaysTransientProvider:
+    name = "transient"
+
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    async def invoke(self, _input_data: Any, _ctx: Dict[str, Any]) -> Any:
+        self.call_count += 1
+        raise ConnectionError(f"always transient #{self.call_count}")
+
+
+@pytest.mark.asyncio
+async def test_optional_phase_exhaustion_surfaces_degraded_loudly() -> None:
+    provider = _AlwaysTransientProvider()
+    phase = WorkflowPhase(
+        name="local_llm",
+        capability="local_llm",
+        optional=True,
+        retry_config=RetryConfig(
+            max_attempts=3, initial_delay_seconds=0.0
+        ),
+    )
+    executor = _make_executor({"local_llm": [provider]})
+    from argumentation_analysis.orchestration.workflow_dsl import WorkflowDefinition
+
+    wf_def = WorkflowDefinition(
+        name="test_degraded", phases=[phase]
+    )
+    results = await executor.execute(wf_def, input_data="hello")
+
+    res = results["local_llm"]
+    # Anti-theater: optional phase that exhausted retry must keep status
+    # FAILED (NOT silently flipped to COMPLETED). degraded=True is the
+    # signal the consumer reads.
+    assert res.status == PhaseStatus.FAILED
+    assert res.degraded is True
+    assert res.attempts == 3
+    assert provider.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# 3. FastAPI legible error surface
+# ---------------------------------------------------------------------------
+
+
+def test_api_error_envelope_shape() -> None:
+    from api.errors import (
+        APIError,
+        DegradedError,
+        UpstreamError,
+        ValidationError,
+        TimeoutError_,
+    )
+
+    # Each subclass produces the documented envelope shape.
+    for exc, expected_code in [
+        (ValidationError("bad payload"), "validation_error"),
+        (UpstreamError("LLM down", context={"phase": "extract"}), "upstream_error"),
+        (TimeoutError_("over budget"), "timeout_error"),
+        (DegradedError("partial", degraded=True), "degraded_result"),
+    ]:
+        env = exc.to_envelope()
+        assert set(env.keys()) == {"error_code", "detail", "degraded", "context"}
+        assert env["error_code"] == expected_code
+        assert env["detail"]
+
+
+def test_api_error_status_codes() -> None:
+    from api.errors import (
+        DegradedError,
+        ServiceUnavailableError,
+        TimeoutError_,
+        UpstreamError,
+        ValidationError,
+    )
+
+    assert ValidationError("x").status_code == 400
+    assert UpstreamError("x").status_code == 502
+    assert TimeoutError_("x").status_code == 504
+    assert ServiceUnavailableError("x").status_code == 503
+    assert DegradedError("x").status_code == 200
+
+
+def test_api_error_handler_registers_on_app() -> None:
+    """The handler must be wired so FastAPI translates APIError to JSON."""
+    from fastapi import FastAPI
+    from api.errors import APIError, install_error_handlers
+
+    app = FastAPI()
+    install_error_handlers(app)
+    # The handler dict holds an entry per registered exception class.
+    handler_dict = app.exception_handlers
+    assert APIError in handler_dict, (
+        "install_error_handlers did not register the APIError handler"
+    )


### PR DESCRIPTION
DT-2 ships a single entrypoint that the non-specialist runs end-to-end, with two explicit modes:

## What it does

- **LIVE mode** (LLM key detected): delegates to the BO-2 #1486 driver. Verdict marked `decided_firsthand=True`.
- **SNAPSHOT mode** (no key): reads a pre-recorded JSON snapshot of a previous live run, replays it. Verdict stamped `decided_firsthand="PRE-RECORDED"` (never `True`, never silently confused with LIVE).
- **Exit code 2 + actionable error** if neither mode is available. Anti-theater #1019: this entrypoint NEVER invents a verdict.

## Snapshot sources (priority order)

1. `--snapshot <path>` (explicit)
2. `./prerecorded_snapshot.json` (cwd)
3. `~/.cache/democratech/prerecorded_snapshot.json` (user cache)

## Shape fixture

A `prerecorded_snapshot_shape_fixture.json` is shipped so the snapshot code path can be exercised without an LLM key. It carries an explicit `warning` field and `mode: shape_fixture_for_test_only` marker — no reader can mistake it for a genuine verdict.

## Tests (9 PASS, no API key required)

- `test_load_snapshot_stamps_pre_recorded_on_every_verdict` — replay ≠ LIVE
- `test_snapshot_to_results_preserves_pre_recorded_marker`
- `test_snapshot_limit_honors_arg`
- `test_load_snapshot_rejects_root_not_dict` / `_rejects_missing_propositions` / `_rejects_proposition_without_verdict` — shape validator never silently accepts bad input
- `test_locate_snapshot_returns_none_when_no_file` / `_finds_explicit_arg` / `_rejects_missing_explicit_arg` — locator respects --snapshot > cwd > user-cache

`mypy --strict` clean on both source files.

## Anti-pendule strict

- ❌ Did NOT touch DT-1 #1517 (already merged to main via PR #1517 — admin-merge coord-side).
- ❌ Did NOT touch BO-2 #1486 driver (`run_democratech_demo.py`).
- ❌ Did NOT add LLM key fallback or fake verdicts.
- ❌ Did NOT introduce a third mode — kept the BO-2 surface intact.

## Files

- `examples/democratech_deliberation/run_democratech_demo_one_command.py` (new)
- `examples/democratech_deliberation/prerecorded_snapshot_shape_fixture.json` (new, gitsafe — synthetic shape only, no corpus)
- `tests/integration/orchestration/test_democratech_demo_one_command.py` (new)

Closes #1499 (DT-2 sub-checklist).
Refs #1499 (parent DT-1 hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)