### PR TITLE
feat(democratech): run-story + .env.example demo bloc (DT-3 #1499)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,31 @@ CONDA_ENV_NAME="projet-is-roo-new"
 # Utilisé par Playwright, peut être laissé par défaut.
 FRONTEND_URL="http://localhost:3000"
 BACKEND_URL="http://localhost:8000"
+
+# --- Democratech demo (DT-2 #1499 / DT-3 #1499) ---
+# The one-command entrypoint (examples/democratech_deliberation/run_democratech_demo_one_command.py)
+# picks its mode automatically:
+#
+#   - LIVE mode (real LLM agents, ~150-200 s/proposition):
+#       requires OPENAI_API_KEY below, OR (OPENROUTER_API_KEY + OPENROUTER_BASE_URL)
+#       from the "Clés API" section above. Verdict marked decided_firsthand=True.
+#
+#   - SNAPSHOT mode (replay of a pre-recorded run, <1 s):
+#       if no LLM key is set, the entrypoint looks for a snapshot JSON at:
+#         1. --snapshot <path> (explicit CLI override)
+#         2. ./prerecorded_snapshot.json (cwd)
+#         3. ~/.cache/democratech/prerecorded_snapshot.json (user cache)
+#       Verdict marked decided_firsthand="PRE-RECORDED" (never True).
+#       To generate a snapshot from a successful LIVE run:
+#         python examples/democratech_deliberation/run_democratech_demo.py --json \
+#           > prerecorded_snapshot.json
+#
+#   - Exit 2 if neither mode is available. The entrypoint NEVER invents a verdict.
+#
+# Required for the LIVE mode (already documented above — same vars):
+#   OPENAI_API_KEY=sk-...
+#   OPENROUTER_API_KEY=sk-or-v1-...   (alternative, set with OPENROUTER_BASE_URL)
+#   OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+#
+# Demo propositions are synthetic, domain-public (chess club, library, ...).
+# No corpus, no `raw_text`, opaque IDs (prop_A..prop_E) on all output.

--- a/examples/democratech_deliberation/README.md
+++ b/examples/democratech_deliberation/README.md
@@ -12,7 +12,67 @@ the 3rd north-star axis of Epic #1470. Each proposition is subjected to the full
 debate → democratic vote), and the governance phase renders a genuine collective
 choice via 12 voting methods (majority, Borda, Condorcet, approval, STV, …).
 
-## Run
+## "Lancer en 3 commandes" — DT-3 #1499 run-story
+
+The non-specialist runs **one command** and gets a readable verdict. The
+entrypoint `run_democratech_demo_one_command.py` selects the mode automatically:
+
+1. **Backend health-check** (optional, but recommended):
+
+    ```bash
+    conda run -n projet-is-roo-new --no-capture-output \
+      uvicorn api.main:app --port 8000 &
+    curl -s http://localhost:8000/health
+    # → {"status":"healthy",...}
+    ```
+
+2. **Run the demo (LIVE if LLM key, else SNAPSHOT replay)**:
+
+    ```bash
+    conda run -n projet-is-roo-new --no-capture-output \
+      python examples/democratech_deliberation/run_democratech_demo_one_command.py
+    ```
+
+3. **Inspect the verdict** (table on stdout, or `--json` for machine-readable):
+
+    ```bash
+    python examples/democratech_deliberation/run_democratech_demo_one_command.py --json
+    ```
+
+### Two modes, picked automatically
+
+| Mode | Trigger | Verdict marker | Speed |
+|------|---------|----------------|-------|
+| **LIVE** | `OPENAI_API_KEY` (or `OPENROUTER_API_KEY` + `OPENROUTER_BASE_URL`) set | `decided_firsthand=True` | ~150-200 s/proposition |
+| **SNAPSHOT** | snapshot JSON found (`--snapshot <path>` > `./prerecorded_snapshot.json` > `~/.cache/democratech/prerecorded_snapshot.json`) | `decided_firsthand="PRE-RECORDED"` | <1 s |
+| **Exit 2** | neither | (no verdict) | n/a |
+
+To generate a snapshot from a successful LIVE run for later replay:
+
+```bash
+python examples/democratech_deliberation/run_democratech_demo.py --json \
+  > prerecorded_snapshot.json
+```
+
+### Dashboard React (BO-2b #1493)
+
+The web dashboard at `services/web_api/interface-web-argumentative/` consumes a
+real `democratech` run via 8 wired FastAPI endpoints. To reproduce the E2E
+proof offline (no LLM/JVM/browser):
+
+```bash
+python scripts/proof_bo2b_dashboard_e2e.py
+python scripts/render_bo2b_dashboard_static.py
+# → evaluation/results/bo2b_dashboard_proof/dashboard_snapshot.html
+```
+
+See `services/web_api/interface-web-argumentative/README.md` (section
+"Dashboard de Gouvernance (BO-2b #1493)") for full endpoint map.
+
+## Run (legacy driver)
+
+The original BO-2 #1486 driver is still available for users who want explicit
+command-line flags:
 
 ```bash
 conda run -n projet-is-roo-new --no-capture-output \
@@ -27,9 +87,9 @@ Requires an LLM key (`OPENAI_API_KEY` or `OPENROUTER_API_KEY` + `OPENROUTER_BASE
 
 ## Output
 
-A table: per proposition — `Firsthand` (decided with real agents), `Winner`
-(Condorcet), `#Methods` (how many voting methods agreed), `Consensus`. A
-per-phase honesty row shows which phases ran or were honestly degraded.
+A table: per proposition — `Firsthand` (decided LIVE / PRE-RECORDED / no),
+`Winner` (Condorcet), `#Methods` (how many voting methods agreed), `Consensus`.
+A per-phase honesty row shows which phases ran or were honestly degraded.
 
 ## Privacy HARD
 
@@ -42,4 +102,7 @@ all output. See `synthetic_proposals.py`.
 
 The `Firsthand` column is the truth flag: a proposition that fails to decide is
 reported as `no`, never fabricated. The demo reports honest-partial results
-(N/5 decide) as-is.
+(N/5 decide) as-is. SNAPSHOT mode replays a previously-recorded verdict marked
+`PRE-RECORDED` (never `True`, never silently confused with LIVE). The entrypoint
+exits with code 2 if neither an LLM key nor a snapshot is available — never
+fabricates a verdict.


### PR DESCRIPTION
DT-3 documents the non-specialist run path for the Democratech product that DT-1 (hardening) + DT-2 (one-command entrypoint) brought to deliverable territory. **No new code, no refactor — purely configuration + documentation.**

## What's in this PR

### `examples/democratech_deliberation/README.md` — new "Lancer en 3 commandes" section

- Step-by-step 3-command sequence (health-check → one-command demo → verdict inspection)
- 2-mode table (LIVE vs SNAPSHOT) with verdict markers and speeds
- Snapshot generation recipe (`run_democratech_demo.py --json > prerecorded_snapshot.json`)
- Cross-reference to BO-2b #1493 dashboard React run-story
- Legacy BO-2 #1486 driver section preserved untouched

### `.env.example` — new "Democratech demo" block

- Documents the env-var contract for the auto-detected mode (LIVE triggers on `OPENAI_API_KEY` or `OPENROUTER_*`; SNAPSHOT on `--snapshot` / cwd / user-cache JSON)
- Explicit anti-théâtre note: the entrypoint never invents a verdict and exits 2 with an actionable message if neither mode is available
- Reuses the existing OPENAI/OpenRouter vars (no duplicate declarations)

## Anti-pendule strict (additive only)

- ❌ Zero new Python code
- ❌ Zero refactor of `run_democratech_demo_one_command.py` (DT-2 #1499)
- ❌ Health-check `/api/health` already shipped (`api/main.py:108`) — only documented, not duplicated
- ❌ BO-2b #1493 dashboard React run-story already shipped — only cross-referenced, not duplicated

## Validation

- **15/15 tests anti-régression PASS** (DT-1 + DT-2, no `.py` touched)
- mypy N/A (no Python changes)
- 96 insertions, 5 deletions across 2 files

## Epic #1499 DoD status

DT-3 closes the last open item of the Epic #1499 DoD:
- ✅ Un non-spécialiste lance la démo E2E (1 commande) → `run_democratech_demo_one_command.py` (DT-2)
- ✅ Chemin critique durci, ≥1 phase dégradation honnête → DT-1 (`RetryConfig` + `degraded` flag + API errors)
- ✅ **Run-story documentée + reproductible ; dashboard React affiche un run réel → DT-3 (this PR) + BO-2b #1493**
- 🟡 Coord constate la démo firsthand → out of band (admin-merge + post-merge demo)

Refs #1499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)