### PR TITLE
fix(orchestration): point main_orchestrator entry at AnalysisRunnerV2

### DIFF
--- a/argumentation_analysis/main_orchestrator.py
+++ b/argumentation_analysis/main_orchestrator.py
@@ -207,12 +207,23 @@ async def main():
             "\n[LAUNCH] Lancement de l'analyse collaborative (peut prendre du temps)... "
         )
         # Importer les dépendances nécessaires
-        from argumentation_analysis.orchestration.analysis_runner import AnalysisRunner
+        # Note : AnalysisRunnerV2 est l'entry point canonique — l'ancien
+        # module `analysis_runner.AnalysisRunner` a été supprimé et son
+        # `try/except ImportError` masquait silencieusement l'échec.
+        from argumentation_analysis.orchestration.analysis_runner_v2 import (
+            AnalysisRunnerV2,
+        )
 
         try:
             # Exécuter la fonction d'analyse en passant le texte et le service LLM
-            runner = AnalysisRunner()
-            await runner.run_analysis_async(
+            runner = AnalysisRunnerV2()
+            # NOTE: `llm_service` est typé `ChatCompletionClientBase` ici
+            # (create_llm_service peut retourner un MockChatCompletion), alors
+            # que run_analysis attend `OpenAIChatCompletion | AzureChatCompletion
+            # | None`. Le build mocké fonctionne via duck-typing ; le type strict
+            # est assoupli localement pour ne pas refactorer analysis_runner_v2
+            # dans cette PR — bug latent à traiter séparément.
+            await runner.run_analysis(  # type: ignore[arg-type]
                 text_content=texte_pour_analyse, llm_service=llm_service
             )
 

--- a/tests/unit/argumentation_analysis/orchestration/test_main_orchestrator_import.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_main_orchestrator_import.py
@@ -1,0 +1,97 @@
+# tests/unit/argumentation_analysis/orchestration/test_main_orchestrator_import.py
+"""Regression tests for the main_orchestrator entry point import path.
+
+Background
+----------
+The top-level orchestrator script (`argumentation_analysis/main_orchestrator.py`)
+used to import `from argumentation_analysis.orchestration.analysis_runner import
+AnalysisRunner`. The legacy `analysis_runner` module was removed, leaving a
+broken import that was silently swallowed by a `try/except ImportError`. This
+masked a real entry-point failure: launching the CLI without `--mock-llm` and
+without an upstream service would reach L210 and never actually execute the
+analysis pipeline.
+
+These tests guard against regression to the legacy path AND verify the V2
+substitute (`AnalysisRunnerV2`) is reachable and exposes the async `run_analysis`
+method with the kwargs the orchestrator passes.
+"""
+
+from __future__ import annotations
+
+import inspect
+import importlib
+
+import pytest
+
+
+# The legacy module must stay gone — guard against resurrection.
+def test_legacy_analysis_runner_module_remains_absent() -> None:
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("argumentation_analysis.orchestration.analysis_runner")
+
+
+# The canonical V2 entry point must be importable from the path the
+# orchestrator now uses.
+def test_analysis_runner_v2_importable() -> None:
+    mod = importlib.import_module(
+        "argumentation_analysis.orchestration.analysis_runner_v2"
+    )
+    assert hasattr(mod, "AnalysisRunnerV2"), (
+        "AnalysisRunnerV2 must be importable from analysis_runner_v2"
+    )
+
+
+# The orchestrator's call site uses `await runner.run_analysis(...)` with
+# kwargs text_content + llm_service. Verify the signature matches — if the
+# V2 contract drifts again, this test catches it before runtime.
+def test_analysis_runner_v2_run_analysis_signature() -> None:
+    from argumentation_analysis.orchestration.analysis_runner_v2 import (
+        AnalysisRunnerV2,
+    )
+
+    method = getattr(AnalysisRunnerV2, "run_analysis", None)
+    assert method is not None, "AnalysisRunnerV2.run_analysis must exist"
+    sig = inspect.signature(method)
+    params = sig.parameters
+    assert "text_content" in params, (
+        "run_analysis must accept 'text_content' kwarg (see main_orchestrator.py L221)"
+    )
+    assert "llm_service" in params, (
+        "run_analysis must accept 'llm_service' kwarg"
+    )
+    assert inspect.iscoroutinefunction(method), (
+        "run_analysis must be async — main_orchestrator awaits it"
+    )
+
+
+# The orchestrator module itself must be importable. This catches any
+# top-level syntax/import regression in the main_orchestrator.py module.
+def test_main_orchestrator_module_importable() -> None:
+    # Use a spec import to avoid running the module's top-level side effects.
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "argumentation_analysis.main_orchestrator",
+        "argumentation_analysis/main_orchestrator.py",
+    )
+    assert spec is not None, "main_orchestrator.py must have a valid module spec"
+
+    # Static AST scan: the legacy import path must NOT appear in source.
+    import ast
+
+    with open("argumentation_analysis/main_orchestrator.py", "r", encoding="utf-8") as fh:
+        tree = ast.parse(fh.read(), filename="main_orchestrator.py")
+
+    legacy_imports: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            for alias in node.names:
+                full = f"{module}.{alias.name}" if module else alias.name
+                if "analysis_runner" in module and "v2" not in module:
+                    legacy_imports.append(full)
+
+    assert not legacy_imports, (
+        f"Legacy non-v2 analysis_runner import(s) still present: {legacy_imports}. "
+        "Use 'analysis_runner_v2.AnalysisRunnerV2' instead."
+    )


### PR DESCRIPTION
## Summary

The legacy `analysis_runner` module was removed but the import in `argumentation_analysis/main_orchestrator.py:210` was left behind, with a `try/except ImportError` silently swallowing the failure. The orchestrator entry point thus never reached the actual analysis pipeline.

Migrate to the canonical V2 entry point (`AnalysisRunnerV2` / `run_analysis`), which is already the pattern used by `argumentation_analysis/analytics/text_analyzer.py:52`.

## Changes

- `argumentation_analysis/main_orchestrator.py` (L208–226): swap the dead import for `analysis_runner_v2.AnalysisRunnerV2` and call `run_analysis` (async, renamed from `run_analysis_async`)
- `tests/unit/argumentation_analysis/orchestration/test_main_orchestrator_import.py` (new): narrow regression test that
  - guards against the legacy module being reinstated
  - verifies the V2 import path is reachable
  - asserts `run_analysis` signature matches the kwargs the call site passes (`text_content`, `llm_service`) and that it is awaitable
  - AST-scans `main_orchestrator.py` to block any resurrection of the legacy non-v2 import

## Latent type bug (not addressed here, documented)

A latent type-narrowing gap exists between `ChatCompletionClientBase` (what `create_llm_service` can return, including mocks) and the `OpenAIChatCompletion | AzureChatCompletion | None` union expected by `AnalysisRunnerV2.run_analysis`. The duck-typed mock path works at runtime; widening `AnalysisRunnerV2.run_analysis` to accept the broader base is a separate change. The call site is annotated with a localised `type: ignore[arg-type]` and a NOTE comment for the next dev.

## Why this PR scope is narrow

Other latent references to the legacy module were found but kept out of scope:
- `speech-to-text/services/fallacy_detector.py:58` — same dead import, but lives in a root-level non-canonical module; deserves its own audit pass
- `docs/architecture/analyse_architecture_orchestration.md` / `docs/architecture/architecture_restauration_orchestration.md` — stale docs referencing the gone module
- `docs/reference/orchestration/analysis_runner.md` + 6 references in `docs/reference/orchestration/README.md` — zombie doc

These are bookkeeping follow-ups, not coupled to the code fix.

## Validation

- 4/4 new tests PASSED (`test_main_orchestrator_import.py`)
- 1/1 existing `test_analysis_runner.py` PASSED (no regression on V2)
- mypy --strict clean on the new test file
- Smoke import: `from argumentation_analysis.orchestration.analysis_runner_v2 import AnalysisRunnerV2` OK
- Convention: no Dart/code en-anglais drift; français respecté dans le code source, anglais dans le diff body

## Risk

Low. The change replaces a path that could not have succeeded (broken import) with one that mirrors a working caller (`text_analyzer.py`). The latent type-narrowing gap is blocked at runtime only by duck typing on the mock path; the NOTE comment captures the limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)