### PR TITLE
feat(dung): AIF-attacks -> Dung labelling substrate (#1520)

### DIFF
--- a/abs_arg_dung/aif_adapter.py
+++ b/abs_arg_dung/aif_adapter.py
@@ -1,0 +1,278 @@
+"""AIF-attacks → Dung-framework adapter.
+
+Background
+----------
+The Argument Interchange Format (AIF) is the standard interchange model for
+argumentation structures. It distinguishes three families of attack relations
+between abstract arguments:
+
+- ``undercut`` (U-): attacks the *inference link* between premises and conclusion.
+- ``undermine`` (UM-): attacks a *premise* of an argument.
+- ``rebut`` (R-): attacks the *conclusion* of an argument.
+
+Dung's abstract framework is strictly binary: every attack is a directed edge
+``(source, target)`` with no semantic enrichment. The reduction from AIF to
+Dung is therefore a *projection*: each AIF relation becomes a flat Dung
+attack. The information loss is structural — Dung **cannot** distinguish
+``undercut`` from ``undermine`` from ``rebut`` once projected.
+
+This adapter provides:
+
+* :func:`aif_attacks_to_dung_af` — pure projection (deterministic, JVM-free).
+* :func:`verify_aif_to_dung` — runs the projection through both backends
+  (``backend_python`` and the Tweety-backed ``DungAgent``) and compares
+  the resulting grounded / complete / stable labellings.
+
+Why this lives here
+-------------------
+The AIF relation space is a *new input* for our Dung backend — a north-star
+capability on the path to a richer argumentation model. The adapter sits
+next to the core backends so the comparison script can pick it up the same
+way it picks up the ICCMA parser or the synthetic generators.
+
+Anti-pendule
+------------
+The adapter is purely mechanical — no semantic interpretation of AIF
+relations survives the projection. Disagreement between backends on the
+projected framework is **never** reconciled (I5 / #1502 invariant); it is
+reported verbatim. If a backend is unavailable (no JVM), the report carries
+``available=False`` and the comparison degrades honestly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, List, NamedTuple, Sequence, Tuple
+
+# Reuse the canonical Framework type used by the ICCMA parser.
+from .backends.generators import Attack, Framework
+
+# Backend report shape — same as ``scripts/compare_dung_backends.BackendReport``.
+# We import the runtime types lazily inside ``_run_python`` / ``_try_run_tweety``
+# to avoid a hard dependency on the JVM at import time.
+BackendReport = dict[str, Any]
+VerifyResult = dict[str, Any]
+
+# AIF relation kinds. Keep the set closed: extending it requires updating
+# :func:`aif_attacks_to_dung_af` and the tests.
+AIF_KIND_UNDERCUT = "undercut"
+AIF_KIND_UNDERMINE = "undermine"
+AIF_KIND_REBUT = "rebut"
+
+AIF_KINDS = frozenset({AIF_KIND_UNDERCUT, AIF_KIND_UNDERMINE, AIF_KIND_REBUT})
+
+
+class AIFAttack(NamedTuple):
+    """A single AIF attack relation.
+
+    Attributes
+    ----------
+    source:
+        Identifier of the attacking argument.
+    target:
+        Identifier of the argument under attack.
+    kind:
+        One of ``"undercut"``, ``"undermine"``, ``"rebut"``.
+    """
+
+    source: str
+    target: str
+    kind: str
+
+
+def _validate_kind(kind: str) -> None:
+    if kind not in AIF_KINDS:
+        raise ValueError(
+            f"Unknown AIF attack kind: {kind!r}. "
+            f"Expected one of {sorted(AIF_KINDS)}."
+        )
+
+
+def aif_attacks_to_dung_af(
+    arguments: Sequence[str],
+    aif_attacks: Iterable[AIFAttack],
+) -> Framework:
+    """Project AIF attacks onto a flat Dung framework.
+
+    Every AIF relation is reduced to a directed edge ``(source, target)``.
+    The ``kind`` field is preserved for traceability but does not influence
+    the resulting framework's structure — Dung is strictly binary.
+
+    Parameters
+    ----------
+    arguments:
+        Identifiers of the arguments participating in the framework. The
+        order is preserved on output for determinism.
+    aif_attacks:
+        Iterable of :class:`AIFAttack` triples. Duplicates (same source,
+        target, kind) are silently de-duplicated.
+
+    Returns
+    -------
+    ``(sorted_arguments, sorted_attacks)`` — the canonical Dung framework
+    shape consumed by :func:`abs_arg_dung.backends.backend_python` and the
+    ICCMA parser pathways.
+    """
+    argument_set = set(arguments)
+    seen: set[Tuple[str, str, str]] = set()
+    attack_set: set[Tuple[str, str]] = set()
+
+    for aif in aif_attacks:
+        _validate_kind(aif.kind)
+        if aif.source == aif.target:
+            # Self-attacks are well-defined in Dung (the argument is then
+            # never in any admissible set). We preserve them rather than
+            # silently dropping them — silent drops are a classic
+            # anti-#1019 trap.
+            pass
+        # Register any argument that appears in an attack edge. The
+        # ``arguments`` list is the *primary* declaration, but we also
+        # accept implicit declarations via attack edges — this matches
+        # the behaviour of the ICCMA parser and keeps the adapter
+        # permissive without losing information.
+        argument_set.add(aif.source)
+        argument_set.add(aif.target)
+        key = (aif.source, aif.target, aif.kind)
+        if key in seen:
+            continue
+        seen.add(key)
+        attack_set.add((aif.source, aif.target))
+
+    return (sorted(argument_set), sorted(attack_set))
+
+
+# ---------------------------------------------------------------------------
+# Backend verification (mirrors scripts/compare_dung_backends.py pattern)
+# ---------------------------------------------------------------------------
+
+
+def _run_python(args: List[str], atts: List[Attack]) -> BackendReport:
+    """Run the pure-Python backend and return its report."""
+    from .backends import backend_python
+
+    # ``_BackendResult`` is a TypedDict which mypy treats as a distinct
+    # nominal type; wrap into a plain dict so the declared
+    # ``BackendReport`` (used by callers / verification) matches.
+    result = backend_python(args, atts)
+    return dict(result)
+
+
+def _try_run_tweety(
+    args: List[str], atts: List[Attack]
+) -> Tuple[bool, BackendReport | None]:
+    """Run the Tweety backend (JVM-dependent). Returns ``(ok, report)``.
+
+    If the JVM bridge is unavailable, returns ``(False, None)`` and the
+    comparison degrades honestly to pure-Python only. The caller is
+    responsible for reporting this in the final output.
+    """
+    try:
+        from abs_arg_dung.agent import DungAgent  # sanctuary #893
+        from argumentation_analysis.core.jvm_setup import initialize_jvm
+    except Exception:
+        return False, None
+
+    try:
+        if not initialize_jvm():
+            return False, {
+                "backend": "tweety",
+                "available": False,
+                "note": "JVM unavailable (initialize_jvm returned False)",
+            }
+        agent = DungAgent()  # type: ignore[no-untyped-call]
+        for a in args:
+            agent.add_argument(a)
+        for src, tgt in atts:
+            agent.add_attack(src, tgt)
+        return True, {
+            "backend": "tweety",
+            "available": True,
+            "note": "abs_arg_dung.DungAgent via JPype (Tweety 1.28)",
+            "extensions": {
+                "grounded": [sorted(agent.get_grounded_extension())],
+                "complete": [sorted(ext) for ext in agent.get_complete_extensions()],
+                "stable": [sorted(ext) for ext in agent.get_stable_extensions()],
+            },
+            "elapsed_ms": 0.0,
+        }
+    except Exception as exc:  # pragma: no cover — JVM-dependent
+        return False, {
+            "backend": "tweety",
+            "available": False,
+            "note": f"error: {exc}",
+        }
+
+
+def _extensions_match(a: BackendReport, b: BackendReport) -> bool:
+    """Compare two backend reports semantic-by-semantic.
+
+    A disagreement is reported by the caller (the verification summary);
+    this helper never silently coerces one side to the other.
+    """
+    for key in ("grounded", "complete", "stable"):
+        ext_a = a.get("extensions", {}).get(key, [])
+        ext_b = b.get("extensions", {}).get(key, [])
+        if sorted(ext_a) != sorted(ext_b):
+            return False
+    return True
+
+
+def verify_aif_to_dung(
+    arguments: Sequence[str],
+    aif_attacks: Iterable[AIFAttack],
+) -> VerifyResult:
+    """Project AIF attacks onto Dung and verify both backends agree.
+
+    Returns a summary dict with the following keys:
+
+    - ``framework``: the projected ``(arguments, attacks)`` tuple.
+    - ``backend_python``: the pure-Python backend report.
+    - ``backend_tweety``: the Tweety backend report (or ``None`` if JVM
+      unavailable).
+    - ``agree``: True iff both backends ran successfully and produced
+      identical extension sets. When Tweety is unavailable, ``agree`` is
+      ``None`` (indeterminate — not the same as False).
+    - ``disagreements``: list of human-readable disagreement strings,
+      empty when both backends agree.
+    """
+    args, atts = aif_attacks_to_dung_af(arguments, aif_attacks)
+
+    py_report = _run_python(args, atts)
+    tweety_ok, tweety_report = _try_run_tweety(args, atts)
+
+    disagreements: List[str] = []
+    agree: bool | None
+
+    if not tweety_ok or tweety_report is None:
+        # Degraded mode: pure-Python only. Honest reporting.
+        agree = None
+    else:
+        agree = _extensions_match(py_report, tweety_report)
+        if not agree:
+            for key in ("grounded", "complete", "stable"):
+                py_ext = py_report.get("extensions", {}).get(key, [])
+                tw_ext = tweety_report.get("extensions", {}).get(key, [])
+                if sorted(py_ext) != sorted(tw_ext):
+                    disagreements.append(
+                        f"{key}: python={sorted(py_ext)} vs tweety={sorted(tw_ext)}"
+                    )
+
+    return {
+        "framework": (args, atts),
+        "backend_python": py_report,
+        "backend_tweety": tweety_report,
+        "agree": agree,
+        "disagreements": disagreements,
+    }
+
+
+__all__ = [
+    "AIFAttack",
+    "AIF_KIND_UNDERCUT",
+    "AIF_KIND_UNDERMINE",
+    "AIF_KIND_REBUT",
+    "AIF_KINDS",
+    "aif_attacks_to_dung_af",
+    "verify_aif_to_dung",
+    "Framework",
+    "Attack",
+]

--- a/scripts/aif_dung_demo.py
+++ b/scripts/aif_dung_demo.py
@@ -1,0 +1,103 @@
+"""AIF → Dung adapter demo.
+
+M1 #1520 — self-contained demo of the AIF-attacks → Dung-labelling
+substrate. Runs three synthetic AIF scenarios through the adapter and
+prints a per-scenario summary of the verification vs both backends.
+
+Usage::
+
+    PYTHONPATH=. python scripts/aif_dung_demo.py
+
+Privacy: all examples are synthetic, with opaque IDs (``arg_A``…).
+No encrypted corpus, no raw text.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+from abs_arg_dung.aif_adapter import (
+    AIF_KIND_REBUT,
+    AIF_KIND_UNDERCUT,
+    AIF_KIND_UNDERMINE,
+    AIFAttack,
+    verify_aif_to_dung,
+)
+
+
+def _scn_nixon() -> tuple[str, list[str], list[AIFAttack]]:
+    """Nixon Diamond via three undermines (mutual attack)."""
+    args = ["arg_A", "arg_B", "arg_C"]
+    attacks = [
+        AIFAttack("arg_A", "arg_B", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_B", "arg_C", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_C", "arg_A", AIF_KIND_UNDERMINE),
+    ]
+    return ("nixon_diamond_aif", args, attacks)
+
+
+def _scn_rebut_chain() -> tuple[str, list[str], list[AIFAttack]]:
+    """Linear rebut chain: A→B→C→D (each rebuts the next)."""
+    args = ["arg_A", "arg_B", "arg_C", "arg_D"]
+    attacks = [
+        AIFAttack("arg_A", "arg_B", AIF_KIND_REBUT),
+        AIFAttack("arg_B", "arg_C", AIF_KIND_REBUT),
+        AIFAttack("arg_C", "arg_D", AIF_KIND_REBUT),
+    ]
+    return ("rebut_chain", args, attacks)
+
+
+def _scn_mixed_undercut_undermine_rebut() -> tuple[str, list[str], list[AIFAttack]]:
+    """Mixed-kind fan-in: A and B both attack C, A undercuts B."""
+    args = ["arg_A", "arg_B", "arg_C"]
+    attacks = [
+        AIFAttack("arg_A", "arg_C", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_B", "arg_C", AIF_KIND_REBUT),
+        AIFAttack("arg_A", "arg_B", AIF_KIND_UNDERCUT),
+    ]
+    return ("mixed_fan_in", args, attacks)
+
+
+def _summarise(summary: dict[str, Any]) -> dict[str, Any]:
+    """Build a JSON-friendly summary stripped of the full extension dumps."""
+    py = summary["backend_python"]
+    tw = summary["backend_tweety"]
+    return {
+        "framework": {
+            "args": summary["framework"][0],
+            "attacks": [list(a) for a in summary["framework"][1]],
+        },
+        "backend_python": {
+            "available": py["available"],
+            "grounded": py["extensions"]["grounded"],
+            "complete": py["extensions"]["complete"],
+            "stable": py["extensions"]["stable"],
+            "elapsed_ms": py["elapsed_ms"],
+        },
+        "backend_tweety_present": tw is not None,
+        "backend_tweety_available": (tw or {}).get("available", False),
+        "backend_tweety_note": (tw or {}).get("note", ""),
+        "agree": summary["agree"],
+        "disagreements": summary["disagreements"],
+    }
+
+
+def main() -> int:
+    scenarios: List[tuple[str, list[str], list[AIFAttack]]] = [
+        _scn_nixon(),
+        _scn_rebut_chain(),
+        _scn_mixed_undercut_undermine_rebut(),
+    ]
+
+    out: dict[str, Any] = {"scenarios": []}
+    for name, args, attacks in scenarios:
+        summary = verify_aif_to_dung(args, attacks)
+        out["scenarios"].append({"name": name, **_summarise(summary)})
+
+    print(json.dumps(out, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/abs_arg_dung/test_aif_adapter.py
+++ b/tests/unit/abs_arg_dung/test_aif_adapter.py
@@ -1,0 +1,180 @@
+# tests/unit/abs_arg_dung/test_aif_adapter.py
+"""Unit tests for the AIF → Dung adapter.
+
+These tests cover:
+
+1. Pure projection (``aif_attacks_to_dung_af``):
+   - the Nixon Diamond via AIF relations
+   - the AIF "all-three-kinds" mixed attack pattern
+   - duplicate-attack de-duplication
+   - implicit-argument auto-registration (mirrors ICCMA parser)
+   - unknown-kind rejection
+   - self-attack preservation (anti-#1019: silent drops forbidden)
+
+2. Backend verification (``verify_aif_to_dung``):
+   - the projection is reachable through ``verify_aif_to_dung``
+   - the pure-Python backend always runs and reports an ``available=True``
+     ``backend_python`` slot
+   - the Tweety backend is either available (and agrees) or honestly
+     degraded (no fabricated verdict)
+   - disagreements are reported verbatim, never reconciled (I5 / #1502)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from abs_arg_dung.aif_adapter import (
+    AIF_KIND_REBUT,
+    AIF_KIND_UNDERCUT,
+    AIF_KIND_UNDERMINE,
+    AIFAttack,
+    aif_attacks_to_dung_af,
+    verify_aif_to_dung,
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure projection
+# ---------------------------------------------------------------------------
+
+
+def test_nixon_diamond_via_aif_undermines() -> None:
+    """A→B→C→A (each via undermine) is the canonical AIF reduction of
+    the Nixon Diamond. The projection must produce the three-edge
+    cycle and recover the same grounded extension the Dung backend
+    would deliver on the flat framework."""
+    args = ["arg_A", "arg_B", "arg_C"]
+    attacks = [
+        AIFAttack("arg_A", "arg_B", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_B", "arg_C", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_C", "arg_A", AIF_KIND_UNDERMINE),
+    ]
+    proj_args, proj_atts = aif_attacks_to_dung_af(args, attacks)
+    assert proj_args == ["arg_A", "arg_B", "arg_C"]
+    assert proj_atts == [
+        ("arg_A", "arg_B"),
+        ("arg_B", "arg_C"),
+        ("arg_C", "arg_A"),
+    ]
+
+
+def test_mixed_aif_kinds_collapse_to_binary() -> None:
+    """The three AIF kinds must collapse to the same flat edge in Dung.
+
+    The information loss is structural — the projection preserves the
+    *fact* of attack but not the *kind*. Verifies that mixing kinds
+    targeting the same pair does not produce duplicate Dung edges.
+    """
+    attacks = [
+        AIFAttack("arg_A", "arg_B", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_A", "arg_B", AIF_KIND_REBUT),
+        AIFAttack("arg_A", "arg_B", AIF_KIND_UNDERCUT),
+    ]
+    _, proj_atts = aif_attacks_to_dung_af(["arg_A", "arg_B"], attacks)
+    assert proj_atts == [("arg_A", "arg_B")]
+
+
+def test_duplicate_aif_attacks_dedup() -> None:
+    """Two identical AIF attacks must not produce two Dung edges."""
+    attacks = [
+        AIFAttack("arg_A", "arg_B", AIF_KIND_REBUT),
+        AIFAttack("arg_A", "arg_B", AIF_KIND_REBUT),
+    ]
+    _, proj_atts = aif_attacks_to_dung_af(["arg_A", "arg_B"], attacks)
+    assert proj_atts == [("arg_A", "arg_B")]
+
+
+def test_implicit_argument_autoregistered() -> None:
+    """Arguments appearing only in attack edges must be auto-registered
+    (mirrors the ICCMA parser behaviour)."""
+    _, proj_atts = aif_attacks_to_dung_af(
+        ["arg_A"],
+        [AIFAttack("arg_A", "arg_B", AIF_KIND_REBUT)],
+    )
+    assert proj_atts == [("arg_A", "arg_B")]
+
+
+def test_unknown_aif_kind_rejected() -> None:
+    with pytest.raises(ValueError, match="Unknown AIF attack kind"):
+        aif_attacks_to_dung_af(
+            ["arg_A", "arg_B"],
+            [AIFAttack("arg_A", "arg_B", "doxelclash")],
+        )
+
+
+def test_self_attack_preserved() -> None:
+    """Self-attacks are semantically meaningful in Dung (an argument
+    that attacks itself is in no admissible set). They must NOT be
+    silently dropped — silent drops are a classic anti-#1019 trap."""
+    attacks = [AIFAttack("arg_A", "arg_A", AIF_KIND_REBUT)]
+    _, proj_atts = aif_attacks_to_dung_af(["arg_A"], attacks)
+    assert proj_atts == [("arg_A", "arg_A")]
+
+
+# ---------------------------------------------------------------------------
+# Backend verification
+# ---------------------------------------------------------------------------
+
+
+def test_verify_aif_to_dung_nixon_returns_python_report() -> None:
+    """``verify_aif_to_dung`` must run the pure-Python backend and
+    expose its report. The Tweety slot is either populated (and agrees)
+    or empty (honest degradation). Never a fabricated verdict."""
+    args = ["arg_A", "arg_B", "arg_C"]
+    attacks = [
+        AIFAttack("arg_A", "arg_B", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_B", "arg_C", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_C", "arg_A", AIF_KIND_UNDERMINE),
+    ]
+    summary = verify_aif_to_dung(args, attacks)
+
+    py = summary["backend_python"]
+    assert py["backend"] == "python"
+    assert py["available"] is True
+    assert "grounded" in py["extensions"]
+
+    # Grounded extension of the Nixon Diamond is empty (mutual attack
+    # cycle, no argument is acceptable). Cross-check with the documented
+    # Dung semantics.
+    assert py["extensions"]["grounded"] == [[]]
+
+    # ``agree`` is either True (Tweety ran + agreed) or None (Tweety
+    # unavailable / JVM not initialised). It must NEVER be False-with-fake
+    # agreement: if Tweety is unavailable the comparison is indeterminate.
+    assert summary["agree"] in (True, None)
+    if summary["agree"] is True:
+        assert summary["disagreements"] == []
+
+
+def test_verify_aif_to_dung_empty_attack_set() -> None:
+    """Empty AIF attack list with two isolated arguments: every argument
+    is acceptable, grounded = full set."""
+    args = ["arg_A", "arg_B"]
+    summary = verify_aif_to_dung(args, [])
+
+    py = summary["backend_python"]
+    assert sorted(py["extensions"]["grounded"][0]) == ["arg_A", "arg_B"]
+
+
+def test_verify_aif_to_dung_reports_disagreements_verbatim() -> None:
+    """If the two backends ever disagree, the disagreement strings
+    must be returned to the caller — never silently reconciled.
+    I5 / #1502 invariant."""
+    args = ["arg_A", "arg_B", "arg_C", "arg_D"]
+    attacks = [
+        AIFAttack("arg_A", "arg_B", AIF_KIND_REBUT),
+        AIFAttack("arg_C", "arg_B", AIF_KIND_REBUT),
+        AIFAttack("arg_D", "arg_A", AIF_KIND_REBUT),
+    ]
+    summary = verify_aif_to_dung(args, attacks)
+    # ``disagreements`` is always a list — empty if they agree, populated
+    # if they diverge.
+    assert isinstance(summary["disagreements"], list)
+    if summary["agree"] is False:
+        # Disagreements must surface a human-readable hint per divergent
+        # semantic.
+        assert len(summary["disagreements"]) >= 1
+        for d in summary["disagreements"]:
+            assert ":" in d
+            assert "python=" in d and "tweety=" in d


### PR DESCRIPTION
Resolves #1520 (M1 of the mix-c dispatch from coord).

## What

AIF (Argument Interchange Format) distinguishes three attack relations:
- **undercut** — attacks the inference link
- **undermine** — attacks a premise
- **rebut** — attacks a conclusion

Dung is strictly binary: every attack is a directed edge `(src, tgt)`
with no semantic enrichment. This PR adds a **projection** layer that
reduces AIF relations onto a flat Dung framework, then runs both the
pure-Python backend and the Tweety/JPype backend against it.

## Why

`abs_arg_dung` is the substrate for everything in the EPITA tech-debt
track. Adding an AIF input is the natural next step toward a richer
argumentation model — the kind field is preserved for traceability but
does not influence the resulting framework's structure (Dung cannot
distinguish `undercut` from `undermine` from `rebut` once projected).

## Deliverables

- `abs_arg_dung/aif_adapter.py` — projection + dual-backend verification
- `tests/unit/abs_arg_dung/test_aif_adapter.py` — 9 tests
- `scripts/aif_dung_demo.py` — 3 synthetic scenarios end-to-end

## Anti-pendule / invariants

- **I5 / #1502**: backend disagreements NEVER auto-reconciled. The
  `disagreements` field in the summary is verbatim, never coerced.
- **Degraded-honest**: when Tweety/JVM is unavailable, `agree=None`
  (indeterminate), `available=False`, JVM error in `note`. Never
  fabricate a verdict.
- **Self-attacks preserved**: anti-#1019 silent-drop trap avoided.
- **All examples opaque**: `arg_A`, `arg_B`, … — no corpus / raw_text.

## Verification

- mypy --strict clean on `abs_arg_dung/aif_adapter.py`.
- 9/9 new tests PASS + 82 prior Dung tests PASS (0 regressions).
- End-to-end demo: 3 scenarios, both backends available, `agree=true`,
  `disagreements=[]`. Nixon Diamond grounded=`[[]]` (cross-checked
  against `compute_grounded` direct call).
