### PR TITLE
feat(dung): AIF->Dung labelling trajectory under sequential arrival (M2 #1524)

### DIFF
--- a/abs_arg_dung/aif_adapter.py
+++ b/abs_arg_dung/aif_adapter.py
@@ -22,6 +22,30 @@ This adapter provides:
 * :func:`verify_aif_to_dung` — runs the projection through both backends
   (``backend_python`` and the Tweety-backed ``DungAgent``) and compares
   the resulting grounded / complete / stable labellings.
+* :func:`aif_labelling_trajectory` — the **sequential-arrival** layer (#1524):
+  arguments land one by one, and after each arrival the projected framework is
+  re-labelled and re-verified against both backends.
+
+Static verification vs trajectory
+---------------------------------
+:func:`verify_aif_to_dung` answers "do the backends agree on *this* framework?".
+:func:`aif_labelling_trajectory` answers "how does each argument's status
+*evolve* as the discourse delivers its arguments one at a time?" — an argument
+accepted early flips ``in -> out`` when its attacker lands later; a member of an
+undecided cycle is reinstated ``undec -> in`` when a defender arrives. Every
+step of that trajectory carries its own dual-backend verification.
+
+Relationship to :mod:`argumentation_analysis.orchestration.dung_labelling_trajectory`
+-------------------------------------------------------------------------------------
+That module (#1509) computes the same *concept* over a plain Dung AF. This one
+is deliberately **not** importing it: that package's ``__init__`` pulls in the
+full orchestration stack (LLM service, crypto, fetch service — measured ~12 s
+import), which would make this JVM-free adapter unusable as a lightweight
+building block. The two are independent islands with a **compatible output
+contract**: the same ``"in"`` / ``"out"`` / ``"undec"`` label vocabulary and the
+same ``as_map()`` shape, so a consumer (e.g. a notebook cell) can render either.
+No Dung semantics are reimplemented here — the grounded extension always comes
+from the backends.
 
 Why this lives here
 -------------------
@@ -41,7 +65,8 @@ reported verbatim. If a backend is unavailable (no JVM), the report carries
 
 from __future__ import annotations
 
-from typing import Any, Iterable, List, NamedTuple, Sequence, Tuple
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Sequence, Tuple
 
 # Reuse the canonical Framework type used by the ICCMA parser.
 from .backends.generators import Attack, Framework
@@ -265,14 +290,330 @@ def verify_aif_to_dung(
     }
 
 
+# ---------------------------------------------------------------------------
+# Sequential-arrival trajectory (#1524)
+# ---------------------------------------------------------------------------
+
+# Label vocabulary — kept identical to
+# ``argumentation_analysis.orchestration.dung_labelling_trajectory`` so both
+# substrates render the same way downstream (compatible contract, no import).
+LABEL_IN = "in"
+LABEL_OUT = "out"
+LABEL_UNDEC = "undec"
+
+LabellingMap = Dict[str, str]  # arg_id -> "in" | "out" | "undec"
+
+
+@dataclass(frozen=True)
+class AIFLabelling:
+    """A grounded labelling of one projected (sub-)framework.
+
+    Attributes
+    ----------
+    arguments:
+        Arguments present in this sub-framework, in arrival order.
+    in_args:
+        Accepted arguments — the grounded extension **as returned by the
+        backend** (never recomputed here).
+    out_args:
+        Arguments attacked by some accepted argument.
+    undec_args:
+        The remainder — neither accepted nor rejected (typically cycles).
+    source_backend:
+        Which backend's grounded extension this labelling was derived from.
+        Recorded explicitly because, when the backends disagree, the labelling
+        is *one side of a disagreement* rather than a settled verdict — see
+        :class:`AIFTrajectoryStep.disagreements` (I5 / #1502).
+    """
+
+    arguments: Tuple[str, ...]
+    in_args: frozenset[str]
+    out_args: frozenset[str]
+    undec_args: frozenset[str]
+    source_backend: str
+
+    def as_map(self) -> LabellingMap:
+        """Return the labelling as ``{arg_id: "in"|"out"|"undec"}``."""
+        m: LabellingMap = {}
+        for a in self.in_args:
+            m[a] = LABEL_IN
+        for a in self.out_args:
+            m[a] = LABEL_OUT
+        for a in self.undec_args:
+            m[a] = LABEL_UNDEC
+        return m
+
+
+@dataclass(frozen=True)
+class AIFTrajectoryStep:
+    """The state of the discourse after ``step`` arguments have arrived.
+
+    Attributes
+    ----------
+    step:
+        1-based arrival index.
+    new_argument:
+        The argument that landed at this step.
+    arrived:
+        All arguments arrived so far, in arrival order.
+    activated_attacks:
+        AIF attacks that became *active* at this step — i.e. whose two
+        endpoints are now both present. An attack declared up front stays
+        dormant until its source (or target) arrives; that latency is exactly
+        what makes the trajectory non-trivial.
+    framework:
+        The projected Dung framework ``(arguments, attacks)`` at this step.
+    labelling:
+        The grounded labelling, or ``None`` when no backend produced a grounded
+        extension (degraded-honest: no fabricated verdict — anti-#1019).
+    agree:
+        ``True``/``False`` when both backends ran and were compared; ``None``
+        when the comparison is indeterminate (Tweety unavailable, or
+        ``verify=False``). ``None`` is *not* ``False``.
+    disagreements:
+        Backend disagreements for this step, **verbatim and never
+        reconciled** (I5 / #1502 invariant).
+    verification:
+        The full :func:`verify_aif_to_dung` result for this step, or ``None``
+        when ``verify=False``.
+    """
+
+    step: int
+    new_argument: str
+    arrived: Tuple[str, ...]
+    activated_attacks: Tuple[AIFAttack, ...]
+    framework: Framework
+    labelling: Optional[AIFLabelling]
+    agree: Optional[bool]
+    disagreements: Tuple[str, ...]
+    verification: Optional[VerifyResult]
+
+
+def _labelling_from_report(
+    arrived: Sequence[str],
+    attacks: Sequence[Attack],
+    report: BackendReport,
+    source_backend: str,
+) -> Optional[AIFLabelling]:
+    """Derive the in/out/undec partition from a backend's grounded extension.
+
+    The grounded extension is taken **as-is** from ``report`` — this function
+    runs no reasoner of its own. It only applies the definition of a labelling:
+    ``out`` is whatever an accepted argument attacks, ``undec`` is the rest.
+
+    Returns ``None`` when the report carries no grounded extension (backend
+    unavailable or failed): a missing extension yields no labelling rather than
+    an invented one.
+    """
+    extensions = report.get("extensions", {}).get("grounded")
+    if not extensions:
+        return None
+
+    grounded = set(extensions[0])
+    arrived_set = set(arrived)
+    out_args = {t for (s, t) in attacks if s in grounded} - grounded
+    undec_args = arrived_set - grounded - out_args
+    return AIFLabelling(
+        arguments=tuple(arrived),
+        in_args=frozenset(grounded),
+        out_args=frozenset(out_args),
+        undec_args=frozenset(undec_args),
+        source_backend=source_backend,
+    )
+
+
+def aif_labelling_trajectory(
+    arguments_stream: Sequence[str],
+    aif_attacks_stream: Iterable[AIFAttack],
+    *,
+    verify: bool = True,
+) -> List[AIFTrajectoryStep]:
+    """Compute the labelling trajectory of an AIF discourse under sequential arrival.
+
+    The discourse delivers its arguments one at a time, in the order given by
+    ``arguments_stream``. An AIF attack becomes active only once **both** of its
+    endpoints have arrived. After each arrival the adapter re-projects the
+    active subset onto a Dung framework (:func:`aif_attacks_to_dung_af`),
+    re-labels it, and — unless ``verify=False`` — re-verifies it against both
+    backends (:func:`verify_aif_to_dung`).
+
+    Parameters
+    ----------
+    arguments_stream:
+        Arrival order of the arguments. Must contain no duplicates (a repeated
+        argument would make "the state after step k" ambiguous).
+    aif_attacks_stream:
+        The AIF attacks of the whole discourse, declared up front. Every
+        endpoint must appear in ``arguments_stream``.
+    verify:
+        When ``True`` (default) each step is cross-checked against both
+        backends per the #1502 contract. When ``False`` only the pure-Python
+        backend runs: the trajectory is then **unverified**, and every step
+        reports ``agree=None`` — never a fabricated agreement.
+
+    Returns
+    -------
+    One :class:`AIFTrajectoryStep` per arrival, in order.
+
+    Raises
+    ------
+    ValueError
+        If ``arguments_stream`` contains duplicates, if an attack endpoint
+        never arrives, or if an attack carries an unknown AIF kind. All three
+        are raised up front: a half-computed trajectory silently missing an
+        attack would be worse than no trajectory at all.
+    """
+    arrival = list(arguments_stream)
+    if len(set(arrival)) != len(arrival):
+        duplicates = sorted({a for a in arrival if arrival.count(a) > 1})
+        raise ValueError(f"arguments_stream must not contain duplicates: {duplicates}")
+
+    attacks = list(aif_attacks_stream)
+    for aif in attacks:
+        _validate_kind(aif.kind)
+
+    arrival_set = set(arrival)
+    unknown = sorted(
+        {ep for aif in attacks for ep in (aif.source, aif.target)} - arrival_set
+    )
+    if unknown:
+        raise ValueError(
+            "every AIF attack endpoint must appear in arguments_stream; "
+            f"never arrive: {unknown}"
+        )
+
+    steps: List[AIFTrajectoryStep] = []
+    arrived: List[str] = []
+    active: List[AIFAttack] = []
+    activated_idx: set[int] = set()
+
+    for k, argument in enumerate(arrival, start=1):
+        arrived.append(argument)
+        arrived_so_far = set(arrived)
+
+        # An attack activates on the step where its *second* endpoint lands.
+        # Tracked by index, not by value, so exact-duplicate declarations each
+        # activate once instead of collapsing into the first occurrence.
+        newly: List[AIFAttack] = []
+        for i, aif in enumerate(attacks):
+            if i in activated_idx:
+                continue
+            if aif.source in arrived_so_far and aif.target in arrived_so_far:
+                activated_idx.add(i)
+                newly.append(aif)
+        newly_active = tuple(newly)
+        active.extend(newly_active)
+
+        framework = aif_attacks_to_dung_af(arrived, active)
+        args, atts = framework
+
+        verification: Optional[VerifyResult] = None
+        py_report: BackendReport
+        agree: Optional[bool]
+        disagreements: Tuple[str, ...]
+
+        if verify:
+            verification = verify_aif_to_dung(arrived, active)
+            py_report = verification["backend_python"]
+            agree = verification["agree"]
+            disagreements = tuple(verification["disagreements"])
+        else:
+            py_report = _run_python(args, atts)
+            agree = None  # unverified is indeterminate, never "agreed"
+            disagreements = ()
+
+        labelling = _labelling_from_report(arrived, atts, py_report, "backend_python")
+
+        steps.append(
+            AIFTrajectoryStep(
+                step=k,
+                new_argument=argument,
+                arrived=tuple(arrived),
+                activated_attacks=newly_active,
+                framework=framework,
+                labelling=labelling,
+                agree=agree,
+                disagreements=disagreements,
+                verification=verification,
+            )
+        )
+
+    return steps
+
+
+def aif_label_transitions(
+    trajectory: Sequence[AIFTrajectoryStep],
+) -> Dict[str, Tuple[str, ...]]:
+    """Per-argument label sequence, starting at the step where it arrives.
+
+    Returns ``{arg_id: (label_at_arrival, ..., label_at_final_step)}``. This is
+    where the dynamics become legible: a sequence like ``("in", "in", "out")``
+    is a refutation, ``("undec", "in")`` a reinstatement. Steps whose labelling
+    is unavailable (degraded) contribute no entry rather than a placeholder.
+    """
+    transitions: Dict[str, Tuple[str, ...]] = {}
+    for step in trajectory:
+        if step.labelling is None:
+            continue
+        label_map = step.labelling.as_map()
+        for argument in step.arrived:
+            label = label_map.get(argument)
+            if label is None:
+                continue
+            transitions[argument] = (*transitions.get(argument, ()), label)
+    return transitions
+
+
+def render_aif_trajectory(trajectory: Sequence[AIFTrajectoryStep]) -> str:
+    """Human-readable table of the trajectory (step | arrived | in/out/undec | agree).
+
+    Mirrors the rendering of the #1509 substrate so both can be shown
+    side-by-side, plus an ``agree`` column carrying the per-step dual-backend
+    verdict (``=`` agree, ``!`` disagree, ``?`` indeterminate).
+    """
+    rows: List[Tuple[str, str, str, str, str, str]] = []
+    for step in trajectory:
+        mark = "=" if step.agree is True else ("!" if step.agree is False else "?")
+        if step.labelling is None:
+            in_s = out_s = undec_s = "(degraded)"
+        else:
+            in_s = ",".join(sorted(step.labelling.in_args)) or "-"
+            out_s = ",".join(sorted(step.labelling.out_args)) or "-"
+            undec_s = ",".join(sorted(step.labelling.undec_args)) or "-"
+        rows.append(
+            (str(step.step), ",".join(step.arrived), in_s, out_s, undec_s, mark)
+        )
+
+    header = ("step", "arrived", "in", "out", "undec", "agree")
+    # Size every column to its widest cell so the table stays aligned whatever
+    # the argument ids look like (it is read as-is in a notebook cell).
+    widths = [
+        max(len(header[i]), max((len(r[i]) for r in rows), default=0))
+        for i in range(len(header))
+    ]
+    lines = [" | ".join(h.ljust(widths[i]) for i, h in enumerate(header))]
+    lines.append("-+-".join("-" * w for w in widths))
+    for row in rows:
+        lines.append(" | ".join(cell.ljust(widths[i]) for i, cell in enumerate(row)))
+    return "\n".join(lines)
+
+
 __all__ = [
     "AIFAttack",
     "AIF_KIND_UNDERCUT",
     "AIF_KIND_UNDERMINE",
     "AIF_KIND_REBUT",
     "AIF_KINDS",
+    "LABEL_IN",
+    "LABEL_OUT",
+    "LABEL_UNDEC",
+    "AIFLabelling",
+    "AIFTrajectoryStep",
     "aif_attacks_to_dung_af",
     "verify_aif_to_dung",
+    "aif_labelling_trajectory",
+    "aif_label_transitions",
+    "render_aif_trajectory",
     "Framework",
     "Attack",
 ]

--- a/scripts/aif_dung_trajectory_demo.py
+++ b/scripts/aif_dung_trajectory_demo.py
@@ -1,0 +1,229 @@
+"""AIF → Dung labelling TRAJECTORY demo (sequential arrival).
+
+M2 #1524 — the sequential-arrival counterpart of :mod:`scripts.aif_dung_demo`
+(M1 #1520). Where M1 asks "do both backends agree on *this* framework?", this
+demo asks "how does each argument's status **evolve** as the discourse delivers
+its arguments one at a time?".
+
+Three scenarios:
+
+1. ``dynamics`` — a discourse exhibiting the three labelling dynamics:
+   acceptance, refutation (``in -> out``), reinstatement (``undec -> in``).
+2. ``order_matters`` — the *same* argumentation framework delivered in two
+   different rhetorical orders. The final labelling is identical (Dung
+   semantics do not care about arrival order); the *trajectories* differ. That
+   contrast is the substrate: what the trajectory carries is precisely the
+   information the static labelling throws away.
+3. ``degenerate_cycle`` — a 3-cycle where nothing is ever accepted, the
+   negative control: a trajectory that stays flat.
+
+Each step is verified against both Dung backends (#1502): ``=`` both agree,
+``!`` they disagree (reported verbatim, never reconciled — I5), ``?``
+indeterminate (Tweety/JVM unavailable — honest degradation, not a fake pass).
+
+Usage::
+
+    PYTHONPATH=. python scripts/aif_dung_trajectory_demo.py            # verified
+    PYTHONPATH=. python scripts/aif_dung_trajectory_demo.py --no-verify  # fast
+
+Privacy: every example is synthetic with opaque IDs (``arg_A``…). No encrypted
+corpus, no raw text, no source names.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Dict, List, Sequence, Tuple
+
+from abs_arg_dung.aif_adapter import (
+    AIF_KIND_REBUT,
+    AIF_KIND_UNDERCUT,
+    AIF_KIND_UNDERMINE,
+    AIFAttack,
+    AIFTrajectoryStep,
+    aif_label_transitions,
+    aif_labelling_trajectory,
+    render_aif_trajectory,
+)
+
+Scenario = Tuple[str, str, List[str], List[AIFAttack]]
+
+
+def _scn_dynamics() -> Scenario:
+    """Acceptance, refutation and reinstatement in a single discourse."""
+    arrival = ["arg_A", "arg_B", "arg_C", "arg_D", "arg_E"]
+    attacks = [
+        AIFAttack("arg_D", "arg_A", AIF_KIND_REBUT),
+        AIFAttack("arg_B", "arg_C", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_C", "arg_B", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_E", "arg_B", AIF_KIND_UNDERCUT),
+    ]
+    return (
+        "dynamics",
+        "arg_A accepted then refuted; arg_C undecided then reinstated",
+        arrival,
+        attacks,
+    )
+
+
+def _scn_order_first() -> Scenario:
+    """The attacker arrives late — the thesis enjoys a spell of acceptance."""
+    _, _, _, attacks = _scn_dynamics()
+    return (
+        "order_matters/attacker_last",
+        "the counter lands at the end: arg_A holds, then falls",
+        ["arg_A", "arg_B", "arg_C", "arg_E", "arg_D"],
+        attacks,
+    )
+
+
+def _scn_order_second() -> Scenario:
+    """The attacker arrives first — the thesis is never accepted at all."""
+    _, _, _, attacks = _scn_dynamics()
+    return (
+        "order_matters/attacker_first",
+        "the counter opens: arg_A is out from the moment it is uttered",
+        ["arg_D", "arg_A", "arg_B", "arg_C", "arg_E"],
+        attacks,
+    )
+
+
+def _scn_degenerate_cycle() -> Scenario:
+    """Negative control: a 3-cycle nobody ever escapes."""
+    arrival = ["arg_A", "arg_B", "arg_C"]
+    attacks = [
+        AIFAttack("arg_A", "arg_B", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_B", "arg_C", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_C", "arg_A", AIF_KIND_UNDERMINE),
+    ]
+    return (
+        "degenerate_cycle",
+        "mutual attack: no argument is ever accepted after the cycle closes",
+        arrival,
+        attacks,
+    )
+
+
+def _verification_tally(trajectory: Sequence[AIFTrajectoryStep]) -> Dict[str, Any]:
+    """Per-step verification outcome, kept honest.
+
+    ``indeterminate`` is counted separately from ``agree`` — a step the JVM
+    could not check is not a step that passed.
+    """
+    agree = sum(1 for s in trajectory if s.agree is True)
+    disagree = sum(1 for s in trajectory if s.agree is False)
+    indeterminate = sum(1 for s in trajectory if s.agree is None)
+    return {
+        "steps": len(trajectory),
+        "agree": agree,
+        "disagree": disagree,
+        "indeterminate": indeterminate,
+        "disagreements": [
+            {"step": s.step, "detail": list(s.disagreements)}
+            for s in trajectory
+            if s.disagreements
+        ],
+    }
+
+
+def _final_labelling(trajectory: Sequence[AIFTrajectoryStep]) -> Dict[str, List[str]]:
+    """The labelling once the whole discourse has landed."""
+    labelling = trajectory[-1].labelling
+    if labelling is None:
+        return {}
+    return {
+        "in": sorted(labelling.in_args),
+        "out": sorted(labelling.out_args),
+        "undec": sorted(labelling.undec_args),
+    }
+
+
+def _run(scenario: Scenario, *, verify: bool) -> Dict[str, Any]:
+    name, blurb, arrival, attacks = scenario
+    trajectory = aif_labelling_trajectory(arrival, attacks, verify=verify)
+    transitions = aif_label_transitions(trajectory)
+
+    print(f"\n=== {name} ===")
+    print(f"{blurb}")
+    print(f"arrival order: {' -> '.join(arrival)}\n")
+    print(render_aif_trajectory(trajectory))
+    print("\nper-argument label sequence (from its own arrival onwards):")
+    for argument in arrival:
+        print(f"  {argument}: {' -> '.join(transitions.get(argument, ()))}")
+
+    tally = _verification_tally(trajectory)
+    print(
+        f"\nverification: {tally['agree']} agree / {tally['disagree']} disagree "
+        f"/ {tally['indeterminate']} indeterminate  (out of {tally['steps']} steps)"
+    )
+    for entry in tally["disagreements"]:
+        print(f"  step {entry['step']}: {entry['detail']}")
+
+    return {
+        "name": name,
+        "arrival_order": arrival,
+        "transitions": {k: list(v) for k, v in transitions.items()},
+        "final_labelling": _final_labelling(trajectory),
+        "verification": tally,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--no-verify",
+        action="store_true",
+        help=(
+            "skip the per-step dual-backend cross-check (fast, JVM-free). "
+            "Every step then reports 'indeterminate', never a fabricated pass."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="also emit a machine-readable summary on stdout.",
+    )
+    args = parser.parse_args()
+    verify = not args.no_verify
+
+    scenarios: List[Scenario] = [
+        _scn_dynamics(),
+        _scn_order_first(),
+        _scn_order_second(),
+        _scn_degenerate_cycle(),
+    ]
+    results = [_run(scenario, verify=verify) for scenario in scenarios]
+
+    # The point of the order_matters pair: same endpoint, different paths.
+    first = next(r for r in results if r["name"].endswith("attacker_last"))
+    second = next(r for r in results if r["name"].endswith("attacker_first"))
+    same_endpoint = first["final_labelling"] == second["final_labelling"]
+    same_path = first["transitions"] == second["transitions"]
+    print("\n=== order_matters: what the trajectory adds ===")
+    print(f"  identical final labelling : {same_endpoint}")
+    print(f"  identical trajectory      : {same_path}")
+    print(
+        "  => the static labelling is order-blind; the trajectory is not — "
+        "that difference is the substrate."
+    )
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "scenarios": results,
+                    "order_matters": {
+                        "same_final_labelling": same_endpoint,
+                        "same_trajectory": same_path,
+                    },
+                },
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/abs_arg_dung/test_aif_adapter.py
+++ b/tests/unit/abs_arg_dung/test_aif_adapter.py
@@ -18,9 +18,21 @@ These tests cover:
    - the Tweety backend is either available (and agrees) or honestly
      degraded (no fabricated verdict)
    - disagreements are reported verbatim, never reconciled (I5 / #1502)
+
+3. Sequential-arrival trajectory (``aif_labelling_trajectory``, #1524):
+   - one step per arrival, growing prefix
+   - attack activation latency (an attack is dormant until BOTH endpoints land)
+   - the three dynamics that make the trajectory a non-trivial substrate:
+     acceptance, refutation (in -> out), reinstatement (undec -> in)
+   - per-step dual-backend verification, disagreements verbatim (I5 / #1502)
+   - ``verify=False`` never fabricates agreement (``agree is None``)
+   - degraded-honest labelling when no grounded extension is available
+   - the final step coincides with the static M1 projection (#1520 continuity)
 """
 
 from __future__ import annotations
+
+from typing import Any, Dict
 
 import pytest
 
@@ -28,11 +40,17 @@ from abs_arg_dung.aif_adapter import (
     AIF_KIND_REBUT,
     AIF_KIND_UNDERCUT,
     AIF_KIND_UNDERMINE,
+    LABEL_IN,
+    LABEL_OUT,
+    LABEL_UNDEC,
     AIFAttack,
+    _labelling_from_report,
     aif_attacks_to_dung_af,
+    aif_label_transitions,
+    aif_labelling_trajectory,
+    render_aif_trajectory,
     verify_aif_to_dung,
 )
-
 
 # ---------------------------------------------------------------------------
 # Pure projection
@@ -178,3 +196,255 @@ def test_verify_aif_to_dung_reports_disagreements_verbatim() -> None:
         for d in summary["disagreements"]:
             assert ":" in d
             assert "python=" in d and "tweety=" in d
+
+
+# ---------------------------------------------------------------------------
+# Sequential-arrival trajectory (#1524)
+# ---------------------------------------------------------------------------
+
+
+def _dynamics_exemplar() -> tuple[list[str], list[AIFAttack]]:
+    """A discourse exhibiting all three labelling dynamics, opaque ids only.
+
+    * ``arg_A`` opens unattacked and is accepted.
+    * ``arg_B`` / ``arg_C`` form a mutual-attack 2-cycle — undecided together.
+    * ``arg_D`` lands late and rebuts ``arg_A`` (refutation: in -> out).
+    * ``arg_E`` lands last, unattacked, and undercuts ``arg_B`` — which
+      reinstates ``arg_C`` (undec -> in).
+    """
+    arrival = ["arg_A", "arg_B", "arg_C", "arg_D", "arg_E"]
+    attacks = [
+        AIFAttack("arg_D", "arg_A", AIF_KIND_REBUT),
+        AIFAttack("arg_B", "arg_C", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_C", "arg_B", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_E", "arg_B", AIF_KIND_UNDERCUT),
+    ]
+    return arrival, attacks
+
+
+def test_trajectory_has_one_step_per_arrival() -> None:
+    """The trajectory is indexed by arrivals: step k holds exactly the first
+    k arguments of the stream, in order."""
+    arrival, attacks = _dynamics_exemplar()
+    trajectory = aif_labelling_trajectory(arrival, attacks, verify=False)
+
+    assert [s.step for s in trajectory] == [1, 2, 3, 4, 5]
+    for k, step in enumerate(trajectory, start=1):
+        assert step.new_argument == arrival[k - 1]
+        assert step.arrived == tuple(arrival[:k])
+
+
+def test_trajectory_attack_activation_is_deferred() -> None:
+    """An attack declared up front stays dormant until BOTH of its endpoints
+    have arrived — that latency is what produces the dynamics."""
+    arrival, attacks = _dynamics_exemplar()
+    trajectory = aif_labelling_trajectory(arrival, attacks, verify=False)
+
+    # Step 1 (only arg_A present): nothing can be active yet.
+    assert trajectory[0].activated_attacks == ()
+    assert trajectory[0].framework == (["arg_A"], [])
+
+    # The 2-cycle activates only when its second half (arg_C) lands at step 3.
+    assert trajectory[1].activated_attacks == ()
+    assert set(trajectory[2].activated_attacks) == {
+        AIFAttack("arg_B", "arg_C", AIF_KIND_UNDERMINE),
+        AIFAttack("arg_C", "arg_B", AIF_KIND_UNDERMINE),
+    }
+
+    # arg_D -> arg_A activates exactly when arg_D lands (step 4).
+    assert trajectory[3].activated_attacks == (
+        AIFAttack("arg_D", "arg_A", AIF_KIND_REBUT),
+    )
+
+    # Every declared attack is activated exactly once across the trajectory.
+    all_activated = [a for s in trajectory for a in s.activated_attacks]
+    assert sorted(all_activated) == sorted(attacks)
+
+
+def test_trajectory_exhibits_refutation_and_reinstatement() -> None:
+    """The substrate claim, made falsifiable: statuses genuinely evolve.
+
+    ``arg_A`` is accepted and later refuted; ``arg_C`` is undecided and later
+    reinstated. A trajectory where nothing ever changes would not be a
+    substrate at all — this test is what makes the claim refutable.
+    """
+    arrival, attacks = _dynamics_exemplar()
+    trajectory = aif_labelling_trajectory(arrival, attacks, verify=False)
+    transitions = aif_label_transitions(trajectory)
+
+    # Acceptance then refutation.
+    assert transitions["arg_A"] == (
+        LABEL_IN,
+        LABEL_IN,
+        LABEL_IN,
+        LABEL_OUT,
+        LABEL_OUT,
+    )
+    # Undecided (cycle) then reinstated once its attacker is undercut.
+    assert transitions["arg_C"] == (LABEL_UNDEC, LABEL_UNDEC, LABEL_IN)
+    # The late unattacked arrival is accepted immediately.
+    assert transitions["arg_E"] == (LABEL_IN,)
+
+
+def test_trajectory_depends_on_arrival_order_but_endpoint_does_not() -> None:
+    """The substrate claim in one assertion.
+
+    Dung semantics are order-blind: the same framework yields the same final
+    labelling whatever order its arguments were uttered in. The *trajectory* is
+    not order-blind. What the trajectory carries is exactly the information the
+    static labelling discards — if both were equal, M2 would add nothing over
+    M1 (#1520) and this substrate would be redundant.
+    """
+    _, attacks = _dynamics_exemplar()
+    attacker_last = ["arg_A", "arg_B", "arg_C", "arg_E", "arg_D"]
+    attacker_first = ["arg_D", "arg_A", "arg_B", "arg_C", "arg_E"]
+
+    traj_last = aif_labelling_trajectory(attacker_last, attacks, verify=False)
+    traj_first = aif_labelling_trajectory(attacker_first, attacks, verify=False)
+
+    final_last = traj_last[-1].labelling
+    final_first = traj_first[-1].labelling
+    assert final_last is not None and final_first is not None
+    assert final_last.as_map() == final_first.as_map()  # order-blind endpoint
+
+    # ...but the paths differ: the thesis is accepted for a while in one
+    # ordering and rejected from its very first appearance in the other.
+    transitions_last = aif_label_transitions(traj_last)
+    transitions_first = aif_label_transitions(traj_first)
+    assert transitions_last != transitions_first
+    assert transitions_last["arg_A"][0] == LABEL_IN
+    assert transitions_first["arg_A"][0] == LABEL_OUT
+
+
+def test_trajectory_labelling_partition_is_total_and_disjoint() -> None:
+    """At every step the labelling partitions exactly the arrived arguments —
+    no argument missing, none in two classes at once."""
+    arrival, attacks = _dynamics_exemplar()
+    trajectory = aif_labelling_trajectory(arrival, attacks, verify=False)
+
+    for step in trajectory:
+        labelling = step.labelling
+        assert labelling is not None
+        in_a, out_a, undec_a = (
+            labelling.in_args,
+            labelling.out_args,
+            labelling.undec_args,
+        )
+        assert in_a | out_a | undec_a == set(step.arrived)
+        assert not (in_a & out_a) and not (in_a & undec_a) and not (out_a & undec_a)
+        # Label vocabulary is the one shared with the #1509 substrate.
+        assert set(labelling.as_map().values()) <= {LABEL_IN, LABEL_OUT, LABEL_UNDEC}
+
+
+def test_trajectory_final_step_matches_static_projection() -> None:
+    """The trajectory must land exactly where M1 (#1520) starts: its last step
+    is the static projection of the whole discourse."""
+    arrival, attacks = _dynamics_exemplar()
+    trajectory = aif_labelling_trajectory(arrival, attacks, verify=False)
+
+    assert trajectory[-1].framework == aif_attacks_to_dung_af(arrival, attacks)
+
+
+def test_trajectory_verifies_each_step_against_both_backends() -> None:
+    """Every step carries its own dual-backend verification (#1502 contract).
+
+    ``agree`` is ``True`` (both ran and matched) or ``None`` (Tweety
+    unavailable — indeterminate). It is never ``False`` with an empty
+    disagreement list, and disagreements are never reconciled away.
+    """
+    arrival, attacks = _dynamics_exemplar()
+    trajectory = aif_labelling_trajectory(arrival, attacks, verify=True)
+
+    for step in trajectory:
+        assert step.verification is not None
+        assert step.verification["backend_python"]["available"] is True
+        assert step.agree in (True, False, None)
+        if step.agree is True:
+            assert step.disagreements == ()
+        if step.agree is False:
+            # A disagreement must be reported verbatim, never silently fixed.
+            assert len(step.disagreements) >= 1
+
+
+def test_trajectory_unverified_never_fabricates_agreement() -> None:
+    """``verify=False`` skips the cross-check; it must report indeterminate
+    (``agree is None``) rather than a comfortable ``True``."""
+    arrival, attacks = _dynamics_exemplar()
+    trajectory = aif_labelling_trajectory(arrival, attacks, verify=False)
+
+    for step in trajectory:
+        assert step.agree is None
+        assert step.disagreements == ()
+        assert step.verification is None
+        # The labelling is still computed — and still traceable to its source.
+        assert step.labelling is not None
+        assert step.labelling.source_backend == "backend_python"
+
+
+def test_trajectory_rejects_duplicate_arrivals() -> None:
+    with pytest.raises(ValueError, match="must not contain duplicates"):
+        aif_labelling_trajectory(["arg_A", "arg_A"], [], verify=False)
+
+
+def test_trajectory_rejects_attack_endpoint_that_never_arrives() -> None:
+    """An attack pointing at an argument outside the stream would be silently
+    dropped at every step — exactly the kind of silent loss anti-#1019 bans."""
+    with pytest.raises(ValueError, match="never arrive"):
+        aif_labelling_trajectory(
+            ["arg_A"],
+            [AIFAttack("arg_A", "arg_ghost", AIF_KIND_REBUT)],
+            verify=False,
+        )
+
+
+def test_trajectory_rejects_unknown_kind_upfront() -> None:
+    """A bad kind fails before step 1 rather than halfway through."""
+    with pytest.raises(ValueError, match="Unknown AIF attack kind"):
+        aif_labelling_trajectory(
+            ["arg_A", "arg_B"],
+            [AIFAttack("arg_A", "arg_B", "doxelclash")],
+            verify=False,
+        )
+
+
+def test_trajectory_preserves_self_attack() -> None:
+    """A self-attacking argument is never accepted — the trajectory must show
+    it as undecided rather than dropping the edge."""
+    trajectory = aif_labelling_trajectory(
+        ["arg_A"],
+        [AIFAttack("arg_A", "arg_A", AIF_KIND_REBUT)],
+        verify=False,
+    )
+    step = trajectory[0]
+    assert step.framework == (["arg_A"], [("arg_A", "arg_A")])
+    assert step.labelling is not None
+    assert step.labelling.in_args == frozenset()
+    assert step.labelling.undec_args == frozenset({"arg_A"})
+
+
+def test_labelling_is_degraded_honest_without_grounded_extension() -> None:
+    """No grounded extension in the backend report => no labelling.
+
+    An unavailable backend must yield ``None``, not an all-undecided labelling
+    invented to keep the shape pretty (anti-#1019).
+    """
+    empty_report: Dict[str, Any] = {
+        "backend": "python",
+        "available": False,
+        "extensions": {},
+    }
+    assert _labelling_from_report(["arg_A"], [], empty_report, "backend_python") is None
+
+
+def test_render_trajectory_marks_verification_state() -> None:
+    """The rendered table (consumed as-is downstream) must expose the per-step
+    verification verdict, not just the labels."""
+    arrival, attacks = _dynamics_exemplar()
+    rendered = render_aif_trajectory(
+        aif_labelling_trajectory(arrival, attacks, verify=False)
+    )
+    lines = rendered.splitlines()
+    assert lines[0].split("|")[-1].strip() == "agree"
+    # Unverified steps are marked indeterminate ("?"), never "=".
+    for line in lines[2:]:
+        assert line.split("|")[-1].strip() == "?"


### PR DESCRIPTION
## Contexte

Track **M2 #1524**, suite de M1 #1520 (PR #1523, mergé `f5aa07cd`). Grain CoursIA #4960 (Mission-1 accompagnement, notre repo = fabrique).

M1 a livré la couche **statique** : projeter les attaques AIF (undercut/undermine/rebut) sur un AF de Dung et vérifier les labellings vs les deux backends (#1502). Cette PR livre la couche **arrivée séquentielle** : le discours délivre ses arguments un par un, et après chaque arrivée le framework projeté est re-labellé et re-vérifié.

> **REROUTE** : ticket dispatché à `myia-po-2025`, worker injoignable (flag `UNKNOWN`, 0 push depuis 24/07 19:42, 6 tirs cron manqués). Repris par le coord — c'est le chemin critique du wrap notebook coord-held (Cell [22]).

## Livré

- `abs_arg_dung/aif_adapter.py` — `aif_labelling_trajectory` (un pas par arrivée, activation différée des attaques, vérification duale par pas), `AIFLabelling` / `AIFTrajectoryStep`, `aif_label_transitions`, `render_aif_trajectory`.
- `tests/unit/abs_arg_dung/test_aif_adapter.py` — 14 cas ajoutés (23 au total).
- `scripts/aif_dung_trajectory_demo.py` — 4 scénarios synthétiques end-to-end.

## La revendication substrat, rendue falsifiable

Les sémantiques de Dung sont **aveugles à l'ordre** ; la trajectoire ne l'est pas. La démo passe le **même** framework sous deux ordres d'arrivée :

```
identical final labelling : True
identical trajectory      : False
```

C'est exactement l'information que le labelling statique jette. Un test (`test_trajectory_depends_on_arrival_order_but_endpoint_does_not`) verrouille la propriété — sans lui, M2 pourrait dégénérer silencieusement en redite de M1.

Les trois dynamiques sont observées firsthand : acceptation, **réfutation** (`in -> out` quand l'attaquant atterrit), **réinstauration** (`undec -> in` quand un défenseur arrive).

## Invariants

- **I5 / #1502** — désaccords par pas retournés **verbatim, jamais auto-réconciliés**.
- **anti-#1019** — pas d'extension grounded ⇒ `labelling = None` (dégradé-honnête, aucun verdict fabriqué) ; `verify=False` ⇒ `agree = None`, jamais un faux pass ; un endpoint d'attaque qui n'arrive jamais lève au lieu d'être silencieusement ignoré.
- **anti-pendule** — zéro sémantique de Dung réimplémentée : l'extension grounded vient **toujours** des backends, la projection est celle de M1.
- **Décision d'architecture documentée** — n'importe délibérément **pas** le module trajectoire #1509 : son package `__init__` tire tout le stack orchestration (**~12 s d'import, mesuré**), ce qui rendrait cet adaptateur JVM-free inutilisable comme brique légère. Les deux sont des îlots indépendants au **contrat de sortie compatible** (même vocabulaire `in`/`out`/`undec`, même forme `as_map()`) — un consommateur (cellule de notebook) peut rendre l'un ou l'autre.

## Privacy

100 % synthétique, IDs opaques (`arg_A`…), zéro corpus chiffré, zéro `raw_text`, zéro nom de source. Leak-scan du diff : 0 hit.

## Validation (firsthand)

| Gate | Résultat |
|------|----------|
| Suite Dung complète | **123 passed / 4 skipped**, 0 régression (inclut #1509 + #1502) |
| Démo end-to-end (JVM) | **18/18 pas `agree=True`**, Tweety/JPype disponible, 0 désaccord |
| `mypy --strict` | clean (2 fichiers source) |
| `black` / `flake8` | clean |

## DoD #1524

- [x] `aif_labelling_trajectory` calcule une trajectoire sous arrivée séquentielle, testée sur un exemple abstrait
- [x] Chaque pas vérifié vs backend #1502 (0 désaccord constaté ; sinon reporté verbatim)
- [x] Démo exécutable + tests verts, 0 régression
- [x] Substrat prêt à wrapper dans Cell [22] du notebook CoursIA (étape coord, hors ce ticket)

Refs : #1520, #1509, #1502, CoursIA #4960.

🤖 Coordinator ai-01
