### PR TITLE
feat(orchestration): bounded wall-clock termination for conversational mode (C1 #1500)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -24,6 +24,7 @@ import logging
 import os
 import re
 import time
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 import semantic_kernel as sk
@@ -49,6 +50,41 @@ from argumentation_analysis.orchestration.trace_analyzer import (
 )
 
 logger = logging.getLogger("ConversationalOrchestrator")
+
+
+@dataclass
+class WallClockBudget:
+    """Wall-clock deadline for a conversational run (C1 #1500).
+
+    The turn-count cap (CONV-C #1334 ``max_total_turns``) bounds the NUMBER
+    of agent turns, but on a real LLM each turn is a slow round-trip — so a
+    turn-bounded run can still exceed 600s wall-clock (the R653 firsthand
+    finding that motivated this Epic). This budget bounds WALL-CLOCK time.
+
+    When exhausted, the run exits CLEANLY between turns: the partial state
+    accumulated so far IS the verdict. This is the anti-#1019 point — a real
+    bounded verdict at the bound, not a ``return None`` nor a coroutine
+    killed mid-flight by an external ``asyncio.wait_for`` (which would lose
+    the partial state and report ``decides=False``).
+    """
+
+    max_seconds: Optional[float]
+    start: float
+
+    @property
+    def active(self) -> bool:
+        """True iff a wall-clock bound was requested."""
+        return self.max_seconds is not None
+
+    @property
+    def deadline(self) -> Optional[float]:
+        """Absolute wall-clock deadline, or None when inactive."""
+        return (self.start + self.max_seconds) if self.active else None
+
+    def is_exhausted(self, now: float) -> bool:
+        """True iff the bound is active and ``now`` has reached the deadline."""
+        deadline = self.deadline
+        return deadline is not None and now >= deadline
 
 
 def _detect_language(text: str) -> str:
@@ -542,6 +578,7 @@ async def run_conversational_analysis(
     source_metadata: Optional[Dict[str, str]] = None,
     selector_context: Optional[Dict[str, Any]] = None,
     max_total_turns: Optional[int] = None,
+    max_wall_seconds: Optional[float] = None,
     render_restitution: bool = False,
 ) -> Dict[str, Any]:
     """Run a full conversational analysis on the input text.
@@ -574,6 +611,14 @@ async def run_conversational_analysis(
             (not adjusted at runtime); hitting it appends a ``CapBreachRecord``
             and ends the run with status ``BUDGET_EXHAUSTED`` (#708 fail-loud).
             None defaults to the sum of the three macro-phase caps.
+        max_wall_seconds: C1 #1500 — wall-clock budget in seconds. When set,
+            the run checks elapsed time before each phase and before each agent
+            turn; on exhaustion it records a ``CapBreachRecord(cap_kind=
+            "wall_clock")`` and exits CLEANLY, returning the partial state as a
+            REAL verdict (status ``WALL_CLOCK_BOUNDED``) — anti-#1019: a vrai
+            verdict at the bound, not a killed coroutine / ``return None``.
+            None (default) leaves the run wall-clock-unbounded (turn-cap only),
+            preserving the prior behaviour for callers that do not opt in.
         render_restitution: CONV-D #1335 — if True, generate the 3-act
             restitution report from the completed state and attach it under
             ``result["restitution_report"]``. The conversational path does not
@@ -612,6 +657,7 @@ async def run_conversational_analysis(
             source_metadata=source_metadata,
             selector_context=selector_context,
             max_total_turns=max_total_turns,
+            max_wall_seconds=max_wall_seconds,
             render_restitution=render_restitution,
         )
 
@@ -723,10 +769,17 @@ async def _run_conversational_analysis_inner(
     source_metadata: Optional[Dict[str, str]] = None,
     selector_context: Optional[Dict[str, Any]] = None,
     max_total_turns: Optional[int] = None,
+    max_wall_seconds: Optional[float] = None,
     render_restitution: bool = False,
 ) -> Dict[str, Any]:
     """Inner implementation of run_conversational_analysis, already inside llm_budget_scope."""
     start_time = time.time()
+
+    # C1 #1500: wall-clock budget. Checked before each phase (coarse) and
+    # threaded as an absolute deadline into _run_phase (per-turn, fine). On
+    # exhaustion the run exits cleanly and the partial state becomes the
+    # verdict — anti-#1019 (real bounded verdict, not a killed coroutine).
+    wall = WallClockBudget(max_seconds=max_wall_seconds, start=start_time)
 
     # CONV-C #1334 §6: pipeline-global tour cap. Default = sum of every phase
     # cap (3 macro + conditional Re-Analysis), derived from the per-phase config
@@ -743,6 +796,7 @@ async def _run_conversational_analysis_inner(
         )
     turns_used = 0
     budget_exhausted = False
+    wall_clock_bounded = False
 
     # 0b. Env var override for growth validation (#597)
     _env_growth = os.environ.get("ENABLE_GROWTH_VALIDATION", "").lower()
@@ -909,6 +963,30 @@ async def _run_conversational_analysis_inner(
             )
             break
 
+        # C1 #1500: wall-clock budget — stop once the deadline is reached.
+        # Distinct from the turn-count cap above: this bounds ELAPSED time so
+        # the mode terminates in a comparable timeframe on a real (slow) LLM.
+        # Breach is recorded (CapBreachRecord cap_kind="wall_clock") and the
+        # run ends with status WALL_CLOCK_BOUNDED; the partial state built
+        # after the loop IS the verdict (anti-#1019 — real, not faked/None).
+        if wall.is_exhausted(time.time()):
+            wall_clock_bounded = True
+            if hasattr(state, "record_cap_breach"):
+                state.record_cap_breach(
+                    cap_kind="wall_clock",
+                    turn=turns_used,
+                    detail=(
+                        f"wall-clock budget {max_wall_seconds:g}s atteint "
+                        f"avant phase '{phase_cfg['name']}'"
+                    ),
+                )
+            logger.warning(
+                f"[C1] Wall-clock budget atteint ({max_wall_seconds:g}s) — "
+                f"phase '{phase_cfg['name']}' et les suivantes sont sautées "
+                f"(verdict partiel honnête)."
+            )
+            break
+
         phase_name = phase_cfg["name"]
         phase_agent_names = phase_cfg["agents"]
         phase_agents = [
@@ -945,6 +1023,7 @@ async def _run_conversational_analysis_inner(
             enable_growth_validation=enable_growth_validation,
             growth_re_prompt_limit=growth_re_prompt_limit,
             reprompt_extractor=reprompt_extractor,
+            deadline=wall.deadline,
         )
         conversation_log.extend(phase_log)
 
@@ -1073,6 +1152,7 @@ async def _run_conversational_analysis_inner(
                         enable_growth_validation=enable_growth_validation,
                         growth_re_prompt_limit=growth_re_prompt_limit,
                         reprompt_extractor=reprompt_extractor,
+                        deadline=wall.deadline,
                     )
                     conversation_log.extend(phase_log)
 
@@ -1367,11 +1447,17 @@ async def _run_conversational_analysis_inner(
         "unified_state": state,
         "trace_report": trace_report,
         "reprompt_traces": reprompt_extractor.to_dict() if reprompt_extractor else None,
-        # CONV-C #1334 §6: pipeline-global budget accounting + fail-loud status.
+        # CONV-C #1334 §6 + C1 #1500: budget accounting + fail-loud status.
+        # wall_clock_bounded is surfaced so downstream readers (BO-4 harness,
+        # reports) can distinguish a real PARTIAL verdict reached at the
+        # wall-clock bound from a clean completion — both are successes (a
+        # verdict was produced), the flag is the honest nuance (anti-#1019).
         "budget": {
             "max_total_turns": max_total_turns,
             "turns_used": turns_used,
             "exhausted": budget_exhausted,
+            "max_wall_seconds": max_wall_seconds,
+            "wall_clock_bounded": wall_clock_bounded,
             "deliberation_turn_count": sum(
                 1
                 for r in getattr(state, "deliberation_trace", [])
@@ -1383,7 +1469,11 @@ async def _run_conversational_analysis_inner(
                 if r.get("record_type") == "cap_breach"
             ],
         },
-        "status": "BUDGET_EXHAUSTED" if budget_exhausted else "COMPLETED",
+        "status": (
+            "WALL_CLOCK_BOUNDED"
+            if wall_clock_bounded
+            else ("BUDGET_EXHAUSTED" if budget_exhausted else "COMPLETED")
+        ),
         "summary": {
             "completed": len(phase_configs),
             "failed": 0,
@@ -1665,6 +1755,7 @@ async def _run_phase(
     enable_growth_validation: bool = True,
     growth_re_prompt_limit: int = 2,
     reprompt_extractor=None,
+    deadline: Optional[float] = None,
 ) -> List[Dict[str, Any]]:
     """Run a single conversational phase with a set of agents.
 
@@ -1676,6 +1767,10 @@ async def _run_phase(
     compares a state fingerprint before/after.  If no growth occurred, the
     agent is re-prompted with explicit function-call feedback up to
     ``growth_re_prompt_limit`` times per turn.
+
+    ``deadline`` (C1 #1500) is an absolute wall-clock timestamp; when set, the
+    phase checks it before each agent turn and exits cleanly when passed, so a
+    wall-clock-bounded run preserves the partial state as the verdict.
     """
     messages: List[Dict[str, Any]] = []
     total_re_prompts = 0
@@ -1737,6 +1832,16 @@ async def _run_phase(
             if _check_convergence(state, phase_name, messages):
                 break
             if turn >= max_turns:
+                break
+
+            # C1 #1500: wall-clock deadline — exit cleanly between turns so the
+            # partial state accumulated so far is preserved as the verdict
+            # (anti-#1019: real bounded verdict, not a killed coroutine).
+            if deadline is not None and time.time() >= deadline:
+                logger.info(
+                    f"  [{phase_name}] Wall-clock deadline atteint au tour "
+                    f"{turn} — sortie propre (verdict partiel)."
+                )
                 break
 
             # Growth validation hook (AgentGroupChat path)
@@ -1816,6 +1921,15 @@ async def _run_phase(
     # Fallback: round-robin invocation with PM designation support
     # In SK 1.40, ChatCompletionAgent.invoke() returns an AsyncGenerator
     for turn in range(1, max_turns + 1):
+        # C1 #1500: wall-clock deadline — check before invoking the next agent
+        # so a bounded run exits cleanly between turns (partial state = verdict).
+        if deadline is not None and time.time() >= deadline:
+            logger.info(
+                f"  [{phase_name}] Wall-clock deadline atteint avant tour "
+                f"{turn} — sortie propre (verdict partiel)."
+            )
+            break
+
         agent = _select_next_agent(state, agents, turn)
         try:
             fp_before = _get_growth_fingerprint(state)

--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -73,6 +73,20 @@ for _name in ("httpx", "openai", "semantic_kernel", "urllib3"):
 DEFAULT_CONVERSATIONAL_WALL_SECONDS = 180.0
 
 
+def _conversational_safety_net_timeout(max_wall_seconds: float) -> float:
+    """C1 #1500: safety-net timeout wrapping the internally-bounded call.
+
+    The wall-clock bound is enforced INSIDE ``run_conversational_analysis``
+    (clean exit between turns → real partial verdict, anti-#1019). This outer
+    ``asyncio.wait_for`` only catches a single in-flight LLM round-trip that
+    overshoots the between-turn check. The headroom is the larger of 20 % of
+    the budget or 30 s, so the internal bound reliably fires first; if the
+    safety net ever fires the verdict is still an honest partial
+    (``terminated_by_budget=True``, never faked into success).
+    """
+    return max(max_wall_seconds * 1.2, max_wall_seconds + 30.0)
+
+
 # ── Benchmark texts (opaque IDs, no raw content in reports) ──────────────
 
 BENCHMARK_TEXTS = {
@@ -351,13 +365,25 @@ async def run_conversational_mode(
 ) -> ModeResult:
     """Run conversational orchestrator (AgentGroupChat multi-agent).
 
-    Bounded by ``max_wall_seconds`` (default 180s — pre-R653 the
-    conversational mode was unbounded and ran >600s on a 643-octet
-    input). On timeout, the verdict is PARTIAL HONNÊTE: ``success=False``
-    but ``terminates=True`` (we DID terminate, we did not crash), and
-    ``terminated_by_budget=True`` so downstream readers can distinguish
-    a budget breach from a real failure. Anti-pendule #1019 — we never
-    fake ``success=True`` to fill the trade-off table.
+    C1 #1500: the wall-clock bound is enforced INTERNALLY by
+    ``run_conversational_analysis(max_wall_seconds=...)`` — when the deadline
+    is reached the orchestrator exits cleanly between turns and the PARTIAL
+    state accumulated so far IS the verdict (a real bounded verdict,
+    anti-#1019 — not a ``return None`` nor a coroutine killed by
+    ``asyncio.wait_for`` that would lose the partial state).
+
+    ``asyncio.wait_for`` is retained only as a safety net at a headroom margin
+    (see ``_conversational_safety_net_timeout``); the internal bound is
+    expected to fire first.
+
+    Outcomes:
+      * Internal bound fired (common on a real LLM): ``success=True``,
+        ``terminates=True``, ``decides=True`` (real partial verdict), with
+        ``extra_metrics["wall_clock_bounded"]=True`` as the honest nuance.
+      * Safety-net timeout (rare — single in-flight call hung past the
+        between-turn check): ``success=False``, ``terminates=True``,
+        ``terminated_by_budget=True`` (honest partial, never faked into
+        success — anti-#1019).
     """
     from argumentation_analysis.orchestration.conversational_orchestrator import (
         run_conversational_analysis,
@@ -368,17 +394,18 @@ async def run_conversational_mode(
         f"wall-time-bounded at {max_wall_seconds:g}s)"
     )
     start = time.time()
+    safety_net = _conversational_safety_net_timeout(max_wall_seconds)
     try:
         result = await asyncio.wait_for(
-            run_conversational_analysis(text=text),
-            timeout=max_wall_seconds,
+            run_conversational_analysis(text=text, max_wall_seconds=max_wall_seconds),
+            timeout=safety_net,
         )
     except asyncio.TimeoutError:
         duration = time.time() - start
         logger.warning(
-            f"Conversational mode on {corpus_id} hit the "
-            f"{max_wall_seconds:g}s budget after {duration:.2f}s — "
-            "recording partial verdict (terminated_by_budget=True)."
+            f"Conversational mode on {corpus_id} hit the {safety_net:g}s "
+            f"safety-net (internal {max_wall_seconds:g}s bound did not exit "
+            f"in time) after {duration:.2f}s — recording honest partial."
         )
         return ModeResult(
             mode="conversational",
@@ -387,7 +414,7 @@ async def run_conversational_mode(
             terminates=True,
             terminated_by_budget=True,
             duration_seconds=round(duration, 2),
-            error=f"Budget breached (>={max_wall_seconds:g}s)",
+            error=f"Safety-net timeout (>={safety_net:g}s)",
             scope_of_work=scope,
         )
     except Exception as exc:
@@ -403,11 +430,26 @@ async def run_conversational_mode(
         )
     duration = time.time() - start
 
+    budget = result.get("budget", {}) if isinstance(result, dict) else {}
+    wall_clock_bounded = bool(budget.get("wall_clock_bounded", False))
+
     state = result.get("state_snapshot", {})
     total_fields = len(state) if state else 1
     non_empty = sum(
         1 for v in (state or {}).values() if v and v not in ([], {}, "", None, 0)
     )
+
+    planned_phases = result.get("phases", []) if isinstance(result, dict) else []
+    conv_log = result.get("conversation_log", []) if isinstance(result, dict) else []
+    # Honest phase count: only planned macro-phases that actually produced an
+    # agent message. A phase skipped by the wall-clock bound does NOT count
+    # (anti-théâtre #1019 — no inflated phases_completed for an empty partial).
+    phases_ran = {
+        m.get("phase")
+        for m in conv_log
+        if isinstance(m, dict) and m.get("phase") in planned_phases
+    }
+    total_messages = result.get("total_messages", 0) if isinstance(result, dict) else 0
 
     return ModeResult(
         mode="conversational",
@@ -417,14 +459,20 @@ async def run_conversational_mode(
         duration_seconds=round(duration, 2),
         state_fill_rate=round(non_empty / max(total_fields, 1), 3),
         fallacy_count=result.get("extra_metrics", {}).get("fallacy_count", 0),
-        phases_completed=len(result.get("phases", [])),
-        phases_total=len(result.get("phases", [])),
+        phases_completed=len(phases_ran),
+        phases_total=len(planned_phases),
         capabilities_used=result.get("capabilities_used", []),
-        decides=bool(result.get("phases")),
+        # C1 #1500: a real verdict — partial state reached at the bound counts.
+        # ``decides`` reflects whether any agent actually produced a message,
+        # honest on both clean completion and wall-clock-bounded partial.
+        decides=total_messages > 0,
+        terminated_by_budget=False,
         scope_of_work=scope,
         extra_metrics={
-            "total_messages": result.get("total_messages", 0),
+            "total_messages": total_messages,
             "duration_seconds_raw": result.get("duration_seconds", 0),
+            "wall_clock_bounded": wall_clock_bounded,
+            "conversational_status": result.get("status"),
         },
     )
 
@@ -696,8 +744,12 @@ def generate_report(
         Mode | Corpus | Terminates | Wall-Time | Decides | Phases | Scope
 
     Status legend:
-      ✅ terminates=True, success=True
-      ⏱ terminates=True, terminated_by_budget=True (honest partial)
+      ✅ terminates=True, success=True (clean completion)
+      ✅⏱ bounded — success on a wall-clock-bounded PARTIAL verdict (C1 #1500):
+            the conversational mode exited cleanly at the bound and the partial
+            state IS the verdict (real, comparable — not a killed coroutine).
+      ⏱ terminates=True, terminated_by_budget=True (honest partial — safety-net
+            timeout fired, no verdict produced)
       ❌ terminates=False (real failure / exception)
     """
     lines = [
@@ -723,6 +775,8 @@ def generate_report(
     for r in sorted(results, key=lambda x: (x.mode, x.corpus_id)):
         if r.terminated_by_budget:
             status = "⏱ budget"
+        elif r.extra_metrics.get("wall_clock_bounded"):
+            status = "✅⏱ bounded"
         elif r.terminates and r.success:
             status = "✅"
         else:

--- a/tests/scripts/test_compare_orchestration_modes_1480.py
+++ b/tests/scripts/test_compare_orchestration_modes_1480.py
@@ -33,6 +33,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -182,6 +183,180 @@ class TestConversationalWallBudget:
         assert "Budget breached" in (result.error or "")
         # Surface the patched runner to silence the linter about real_runner.
         _ = real_runner
+
+
+class TestConversationalInternalBound:
+    """C1 #1500 — the wall-clock bound is enforced INTERNALLY by
+    ``run_conversational_analysis``; the harness maps the resulting partial
+    verdict to ``success=True`` / ``decides=True`` (a REAL verdict at the
+    bound, anti-#1019), keeping ``asyncio.wait_for`` only as a safety net.
+
+    Distinct from ``TestConversationalWallBudget`` above, which covers the
+    safety-net-fires contract via a stub runner. These tests exercise the real
+    ``run_conversational_mode`` with the inner runner patched.
+    """
+
+    def test_safety_net_timeout_math(self) -> None:
+        """The safety net gives 20 % headroom for large budgets, 30 s min for
+        small ones — so the internal bound reliably fires first."""
+        mod = _load_harness_module()
+        # 20 % headroom dominates for large budgets.
+        assert mod._conversational_safety_net_timeout(180.0) == 216.0
+        # 30 s minimum headroom dominates for small budgets.
+        assert mod._conversational_safety_net_timeout(10.0) == 40.0
+        assert mod._conversational_safety_net_timeout(60.0) == 90.0
+
+    def test_internal_bound_maps_to_real_partial_verdict(self) -> None:
+        mod = _load_harness_module()
+        fake_result = {
+            "phases": [
+                "Extraction & Detection",
+                "Formal Analysis & Quality",
+                "Synthesis & Debate",
+            ],
+            "conversation_log": [
+                {
+                    "phase": "Extraction & Detection",
+                    "turn": 1,
+                    "agent": "ExtractAgent",
+                    "content": "partial",
+                },
+            ],
+            "total_messages": 1,
+            "state_snapshot": {"identified_arguments": ["arg_0"]},
+            "budget": {"wall_clock_bounded": True},
+            "capabilities_used": ["fact_extraction"],
+            "status": "WALL_CLOCK_BOUNDED",
+            "duration_seconds": 30.0,
+        }
+
+        async def fake_run(**kwargs):
+            return fake_result
+
+        async def _drive():
+            with patch(
+                "argumentation_analysis.orchestration.conversational_orchestrator"
+                ".run_conversational_analysis",
+                side_effect=fake_run,
+            ):
+                return await mod.run_conversational_mode(
+                    "text", "corpus_A", max_wall_seconds=30.0
+                )
+
+        result = asyncio.run(_drive())
+
+        # The partial state reached at the bound IS a real verdict (anti-#1019).
+        assert result.success is True
+        assert result.terminates is True
+        assert result.decides is True
+        assert result.terminated_by_budget is False
+        assert result.extra_metrics["wall_clock_bounded"] is True
+        assert result.extra_metrics["conversational_status"] == "WALL_CLOCK_BOUNDED"
+        # Honest phase count: only 1 of 3 planned phases produced a message.
+        assert result.phases_completed == 1
+        assert result.phases_total == 3
+
+    def test_clean_completion_not_marked_bounded(self) -> None:
+        """A run that completes within the bound is not flagged bounded."""
+        mod = _load_harness_module()
+        fake_result = {
+            "phases": [
+                "Extraction & Detection",
+                "Formal Analysis & Quality",
+                "Synthesis & Debate",
+            ],
+            "conversation_log": [
+                {
+                    "phase": "Extraction & Detection",
+                    "turn": 1,
+                    "agent": "ExtractAgent",
+                    "content": "x",
+                },
+                {
+                    "phase": "Formal Analysis & Quality",
+                    "turn": 1,
+                    "agent": "FormalAgent",
+                    "content": "y",
+                },
+                {
+                    "phase": "Synthesis & Debate",
+                    "turn": 1,
+                    "agent": "DebateAgent",
+                    "content": "z",
+                },
+            ],
+            "total_messages": 3,
+            "state_snapshot": {"identified_arguments": ["arg_0"]},
+            "budget": {"wall_clock_bounded": False},
+            "capabilities_used": ["fact_extraction"],
+            "status": "COMPLETED",
+            "duration_seconds": 12.0,
+        }
+
+        async def fake_run(**kwargs):
+            return fake_result
+
+        async def _drive():
+            with patch(
+                "argumentation_analysis.orchestration.conversational_orchestrator"
+                ".run_conversational_analysis",
+                side_effect=fake_run,
+            ):
+                return await mod.run_conversational_mode(
+                    "text", "corpus_A", max_wall_seconds=30.0
+                )
+
+        result = asyncio.run(_drive())
+
+        assert result.success is True
+        assert result.decides is True
+        assert result.extra_metrics["wall_clock_bounded"] is False
+        assert result.phases_completed == 3
+
+    def test_safety_net_timeout_is_honest_partial(self) -> None:
+        """When the safety-net ``asyncio.wait_for`` DOES fire (a single
+        in-flight call hung past the between-turn check), the verdict is an
+        honest partial — never faked into success (anti-#1019)."""
+        mod = _load_harness_module()
+
+        async def fake_wait_for(coro, timeout=None):
+            coro.close()  # avoid 'coroutine never awaited' warning
+            raise asyncio.TimeoutError()
+
+        async def _drive():
+            with patch.object(asyncio, "wait_for", fake_wait_for):
+                return await mod.run_conversational_mode(
+                    "text", "corpus_A", max_wall_seconds=30.0
+                )
+
+        result = asyncio.run(_drive())
+
+        assert result.success is False
+        assert result.terminates is True
+        assert result.terminated_by_budget is True
+        assert "Safety-net timeout" in (result.error or "")
+
+    def test_report_marks_bounded_verdict_distinctly(self) -> None:
+        """The trade-off table distinguishes a bounded partial verdict (✅⏱)
+        from a clean completion (✅) and a safety-net breach (⏱ budget)."""
+        mod = _load_harness_module()
+        report = mod.generate_report(
+            [
+                mod.ModeResult(
+                    mode="conversational",
+                    corpus_id="corpus_A",
+                    success=True,
+                    terminates=True,
+                    decides=True,
+                    duration_seconds=180.0,
+                    phases_completed=2,
+                    phases_total=3,
+                    scope_of_work="AgentGroupChat (bounded)",
+                    extra_metrics={"wall_clock_bounded": True},
+                ),
+            ]
+        )
+        assert "✅⏱ bounded" in report
 
 
 class TestReportFormat:

--- a/tests/unit/argumentation_analysis/orchestration/test_conversational_orchestrator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversational_orchestrator.py
@@ -603,6 +603,7 @@ class TestRunConversationalAnalysis:
             enable_growth_validation=True,
             growth_re_prompt_limit=2,
             reprompt_extractor=None,
+            deadline=None,
         ):
             phase_names_seen.append(phase_name)
             return [

--- a/tests/unit/argumentation_analysis/orchestration/test_conversational_wall_clock_c1.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversational_wall_clock_c1.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+"""Tests for C1 #1500 — wall-clock bounded termination of the conversational mode.
+
+The conversational mode was turn-bounded (CONV-C #1334 ``max_total_turns``)
+but WALL-CLOCK-unbounded: on a real (slow) LLM each turn is a round-trip, so
+a turn-bounded run could still exceed 600s (the R653 firsthand finding that
+motivated Epic #1500). C1 adds an internal ``max_wall_seconds`` budget that,
+on exhaustion, exits the phase loop CLEANLY between turns — the partial state
+accumulated so far IS the verdict (anti-#1019: a real bounded verdict, not a
+``return None`` nor a coroutine killed by an external ``asyncio.wait_for``).
+
+These tests are deterministic and LLM-free:
+
+* ``WallClockBudget`` — pure unit tests of the deadline helper.
+* ``run_conversational_analysis`` — param forwarding (mirrors the
+  ``test_conversational_llm_budget`` pattern: patches ``_run_conversational_
+  analysis_inner`` so no kernel/LLM is built).
+* ``_run_phase`` — the per-turn deadline check breaks the round-robin loop
+  before the first agent is invoked (AgentGroupChat is forced to raise so the
+  fallback path runs — no real SK chat, no LLM).
+
+The harness-side contract (internal bound → real partial verdict) is covered
+in ``tests/scripts/test_compare_orchestration_modes_1480.py``.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── WallClockBudget (pure unit) ───────────────────────────────────────────
+
+
+class TestWallClockBudget:
+    """The deadline helper is the crux of C1 — test it in isolation."""
+
+    def test_inactive_when_max_seconds_is_none(self) -> None:
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            WallClockBudget,
+        )
+
+        budget = WallClockBudget(max_seconds=None, start=1000.0)
+        assert budget.active is False
+        assert budget.deadline is None
+        # Never exhausted when inactive — the run stays wall-clock-unbounded.
+        assert budget.is_exhausted(now=9999.0) is False
+
+    def test_active_when_max_seconds_set(self) -> None:
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            WallClockBudget,
+        )
+
+        budget = WallClockBudget(max_seconds=10.0, start=1000.0)
+        assert budget.active is True
+        assert budget.deadline == 1010.0
+
+    def test_is_exhausted_false_before_deadline(self) -> None:
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            WallClockBudget,
+        )
+
+        budget = WallClockBudget(max_seconds=10.0, start=1000.0)
+        assert budget.is_exhausted(now=1000.0) is False
+        assert budget.is_exhausted(now=1005.0) is False
+        assert budget.is_exhausted(now=1009.99) is False
+
+    def test_is_exhausted_true_at_and_after_deadline(self) -> None:
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            WallClockBudget,
+        )
+
+        budget = WallClockBudget(max_seconds=10.0, start=1000.0)
+        assert budget.is_exhausted(now=1010.0) is True  # boundary: at deadline
+        assert budget.is_exhausted(now=1010.001) is True
+        assert budget.is_exhausted(now=9999.0) is True
+
+
+# ── run_conversational_analysis forwards max_wall_seconds ────────────────
+
+
+class TestRunConversationalForwardsWallClock:
+    """The outer wrapper must forward ``max_wall_seconds`` to the inner run."""
+
+    @pytest.mark.asyncio
+    async def test_max_wall_seconds_forwarded_to_inner(self) -> None:
+        captured: dict = {}
+
+        async def _mock_inner(**kwargs):
+            captured.update(kwargs)
+            return {
+                "state_snapshot": {},
+                "conversation_log": [],
+                "budget": {"wall_clock_bounded": False},
+            }
+
+        with patch(
+            "argumentation_analysis.orchestration.conversational_orchestrator"
+            "._run_conversational_analysis_inner",
+            side_effect=_mock_inner,
+        ):
+            from argumentation_analysis.orchestration.conversational_orchestrator import (
+                run_conversational_analysis,
+            )
+
+            await run_conversational_analysis("test text", max_wall_seconds=42.0)
+
+        assert captured.get("max_wall_seconds") == 42.0, (
+            "C1 regression: run_conversational_analysis did not forward "
+            "max_wall_seconds to _run_conversational_analysis_inner."
+        )
+
+    @pytest.mark.asyncio
+    async def test_max_wall_seconds_defaults_to_none(self) -> None:
+        """Default None preserves the prior wall-clock-unbounded behaviour
+        (turn-cap only) for callers that do not opt in (anti-pendule)."""
+        captured: dict = {}
+
+        async def _mock_inner(**kwargs):
+            captured.update(kwargs)
+            return {
+                "state_snapshot": {},
+                "conversation_log": [],
+                "budget": {"wall_clock_bounded": False},
+            }
+
+        with patch(
+            "argumentation_analysis.orchestration.conversational_orchestrator"
+            "._run_conversational_analysis_inner",
+            side_effect=_mock_inner,
+        ):
+            from argumentation_analysis.orchestration.conversational_orchestrator import (
+                run_conversational_analysis,
+            )
+
+            await run_conversational_analysis("test text")
+
+        assert captured.get("max_wall_seconds") is None
+
+
+# ── _run_phase per-turn deadline ──────────────────────────────────────────
+
+
+class TestRunPhaseDeadline:
+    """The per-turn deadline check lets a bounded phase exit cleanly between
+    turns, preserving the partial conversation as the verdict (anti-#1019)."""
+
+    @pytest.mark.asyncio
+    async def test_deadline_in_past_breaks_before_first_turn(self) -> None:
+        from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_phase,
+        )
+
+        state = RhetoricalAnalysisState("test text")
+        fake_agent = MagicMock()
+        fake_agent.name = "FakeAgent"
+
+        # Force the round-robin fallback by making the SK AgentGroupChat raise
+        # on construction — no real SK chat, no LLM call.
+        with patch(
+            "semantic_kernel.agents.group_chat.agent_group_chat.AgentGroupChat",
+            side_effect=RuntimeError("force round-robin for test"),
+        ):
+            # deadline already in the past → must break before turn 1.
+            messages = await _run_phase(
+                [fake_agent],
+                "initial prompt",
+                max_turns=5,
+                phase_name="Extraction & Detection",
+                state=state,
+                enable_growth_validation=False,
+                deadline=time.time(),
+            )
+
+        assert messages == [], (
+            "C1 regression: with a past deadline, _run_phase should run ZERO "
+            f"turns (clean between-turn exit), got {len(messages)} message(s)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_deadline_runs_as_before(self) -> None:
+        """With deadline=None the phase behaves exactly as before C1 — the
+        round-robin loop runs at least one turn (anti-pendule: the bound is
+        opt-in, not an always-on truncation)."""
+        from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_phase,
+        )
+
+        state = RhetoricalAnalysisState("test text")
+        fake_agent = MagicMock()
+        fake_agent.name = "FakeAgent"
+
+        # Stub invoke() so round-robin yields one fast message, then the
+        # max_turns=1 cap ends the loop (deterministic, no LLM).
+        async def fake_invoke(chat_history):
+            msg = MagicMock()
+            msg.content = "stub response"
+            yield msg
+
+        fake_agent.invoke = fake_invoke
+
+        with patch(
+            "semantic_kernel.agents.group_chat.agent_group_chat.AgentGroupChat",
+            side_effect=RuntimeError("force round-robin for test"),
+        ):
+            messages = await _run_phase(
+                [fake_agent],
+                "initial prompt",
+                max_turns=1,
+                phase_name="Extraction & Detection",
+                state=state,
+                enable_growth_validation=False,
+                deadline=None,
+            )
+
+        assert len(messages) == 1, (
+            "C1 regression: with deadline=None and max_turns=1, _run_phase "
+            f"should run exactly 1 turn, got {len(messages)}."
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## C1 #1500 — Bounded wall-clock termination for the conversational mode

Closes the **C1** track of Epic #1500 (the last one — C2 #1512 + C3 #1513 are merged). Unblocks DoD-4: the coord can constate firsthand a bounded 4-mode comparison via `scripts/compare_orchestration_modes.py`.

### The gap (anti-#1019)

The conversational mode was **turn**-bounded (CONV-C #1334 `max_total_turns`) but **wall-clock**-unbounded: on a real LLM each turn is a round-trip, so it could exceed 600s (the R653 firsthand finding). The BO-4 harness already wrapped the call in `asyncio.wait_for`, but on breach the coroutine was **killed** — the partial state accumulated so far was **lost** and the run reported `decides=False`. The other 3 modes terminate bounded AND decide; the conversational mode was the odd one out (either it completed, or it produced nothing).

### The fix — the partial state IS the verdict

C1 moves the wall-clock bound **inside** `run_conversational_analysis`. When the deadline is reached, the orchestrator exits **cleanly between turns** (a per-turn check in `_run_phase`, on both the AgentGroupChat and round-robin paths) and the partial state becomes a **real verdict** — never a `return None` nor a killed coroutine.

| Surface | Behaviour |
|---|---|
| `run_conversational_analysis(max_wall_seconds=X)` | Per-phase + per-turn deadline check; on exhaustion records a `CapBreachRecord(cap_kind="wall_clock")`, breaks, returns `status="WALL_CLOCK_BOUNDED"` + `budget.wall_clock_bounded=True`. Default `None` = unbounded (opt-in, anti-pendule). |
| Harness `run_conversational_mode` | Passes `max_wall_seconds` **into** the orchestrator → real partial verdict (`success=True`, `decides=True`, `wall_clock_bounded` flag). `asyncio.wait_for` kept only as a **safety net** at `max(1.2×, +30s)` margin; if it ever fires (a single in-flight call hung past the between-turn check) the verdict is still an honest partial (`terminated_by_budget=True`, never faked into success). |
| Report trade-off table | New `✅⏱ bounded` marker distinguishes a bounded partial verdict from a clean `✅` and a safety-net `⏱ budget`. Honest `phases_completed` (only planned phases that produced a message). |

### Tests — deterministic, LLM-free (13 new, 90 total green)

- `test_conversational_wall_clock_c1.py`: `WallClockBudget` pure unit (active/inactive, deadline boundary), `max_wall_seconds` param forwarding, `_run_phase` per-turn deadline break (forces the round-robin path so no real SK chat / no LLM).
- `test_compare_orchestration_modes_1480.py` `TestConversationalInternalBound`: safety-net timeout math, internal-bound → real partial verdict, clean completion not flagged, safety-net honest partial, report marker.
- `test_conversational_orchestrator.py`: the `tracking_run_phase` wrapper accepts the new `deadline` kwarg.

### Anti-pendule checklist
- [x] The bound is **opt-in** (`max_wall_seconds=None` default preserves the prior wall-clock-unbounded behaviour for callers that don't opt in).
- [x] Bounding ≠ disabling: the mode still runs its full 3-phase depth when not bounded; nothing is gutted.
- [x] No `return None` disguised as "bounded" — the partial state at the bound is a real verdict with real phases/messages.
- [x] `terminated_by_budget=True ⟹ success=False` contract preserved (now only the rare safety-net case).

### Validation
`black` clean, `py_compile` clean. `pytest` (po-2023, `projet-is`, `--disable-jvm-session`): **90 passed**, 0 failed across `test_conversational_wall_clock_c1`, `test_conversational_orchestrator`, `test_conversational_llm_budget`, `test_conversational_sk_budget`, `test_depth_parity_1500`, `test_compare_orchestration_modes_1480`, `test_compare_orchestration_modes`.

DoD-4 (coord firsthand): `python scripts/compare_orchestration_modes.py --modes conversational --max-wall-seconds 60` — the conversational row should now show `✅⏱ bounded` / `Decides ✅` (a real partial verdict) instead of `⏱ budget` / `Decides —`.

Refs: #1500 (Epic, C1 track), R653 firsthand mode-comparison, BO-4 #1480 harness, CONV-C #1334 (turn cap). Dispatched R703 (po-2023, C1 primary).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
