### PR TITLE
fix(harness): uniform _compute_decides for all modes (Track CA #1529, R706 item 1)

### DIFF
--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -137,8 +137,22 @@ class ModeResult:
                             ``False`` if the runner crashed mid-flight.
         wall_time_seconds  — measured wall-clock (matches duration_seconds,
                             kept as a separate column for the report).
-        decides            — bool: did the mode emit a decision (verdict,
-                            classification, or governance outcome)?
+        decides            — Optional[bool]: did the mode produce at least one
+                            usable VERDICT ARTIFACT? Computed UNIFORMLY for
+                            every mode by :func:`_compute_decides` (Track CA
+                            #1529) — never hand-set per runner. A mode decides
+                            iff it left behind any of: a non-empty shared state
+                            (``state_fill_rate > 0``), an extracted argument or
+                            fallacy, an agent dialogue message, a mode-specific
+                            conclusion/synthesis (``extra_metrics["verdict_artifact"]``),
+                            or a completed workflow phase. ``None`` = not yet
+                            computed (a runner that bypassed the helper);
+                            ``False`` = computed "no artifact" (e.g. a
+                            conversational run cut at the safety-net with 0/0
+                            phases — honestly ``—``, anti-#1019: "I checked,
+                            nothing" is not "indeterminate"). A budget breach
+                            that still produced partial artifacts honestly
+                            decides ``True`` (the partial state IS the verdict).
         terminated_by_budget — bool: True iff the run hit the wall-clock
                             budget and was killed by asyncio.wait_for.
                             Treated as a HONEST PARTIAL verdict (anti-pendule
@@ -167,12 +181,57 @@ class ModeResult:
     extra_metrics: Dict[str, Any] = field(default_factory=dict)
     # Trade-off columns (BO-4 #1480):
     terminates: bool = True
-    decides: bool = False
+    # Track CA #1529: default is None ("not computed"), NOT False ("no"). A
+    # runner that forgets the uniform helper shows `—` (indeterminate) rather
+    # than asserting a false "no". run_all computes the real value for every
+    # result via _compute_decides before the report is rendered.
+    decides: Optional[bool] = None
     terminated_by_budget: bool = False
     scope_of_work: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
+
+
+def _compute_decides(result: ModeResult) -> bool:
+    """The ONE uniform definition of whether a mode *decided* (Track CA #1529).
+
+    A mode decides iff it produced at least one usable **verdict artifact**.
+    The signals are read off the common ``ModeResult`` fields every runner
+    populates — so the same definition applies to pipeline / conversational /
+    hierarchical alike, and no runner hand-sets ``decides`` on a local
+    criterion (the BO-4 #1480 defect: three runners, three ad-hoc
+    definitions, plus a misleading ``False`` default that painted the
+    hardest-working mode — pipeline 15/15 phases — as ``Decides —``).
+
+    Order is irrelevant (short-circuit on the first artifact found):
+
+    * ``state_fill_rate > 0`` — the shared analysis state was populated.
+    * ``argument_count > 0`` or ``fallacy_count > 0`` — extracted artifacts.
+    * ``extra_metrics["total_messages"] > 0`` — agent dialogue (conversational).
+    * ``extra_metrics["verdict_artifact"]`` — a mode-specific conclusion /
+      synthesis / strategic decision (e.g. hierarchical_bridge emits a
+      ``conclusion`` without filling the shared state — documented as a
+      legitimate decide, per DoD-4 #1529).
+    * ``phases_completed > 0`` — a completed workflow phase emits its phase's
+      artifact by definition.
+
+    Anti-#1019 / anti-pendule: returning ``True`` everywhere would destroy the
+    column's discriminating power. The non-regression test is that a genuinely
+    sterile run (conversational cut at the safety-net: 0/0 phases, 0 % fill,
+    0 messages) stays ``False`` → ``—``.
+    """
+    if result.state_fill_rate > 0:
+        return True
+    if result.argument_count > 0 or result.fallacy_count > 0:
+        return True
+    if result.extra_metrics.get("total_messages", 0) > 0:
+        return True
+    if result.extra_metrics.get("verdict_artifact"):
+        return True
+    if result.phases_completed > 0:
+        return True
+    return False
 
 
 # ── Depth-parity trade-off (C3 #1500) ─────────────────────────────────────
@@ -462,10 +521,8 @@ async def run_conversational_mode(
         phases_completed=len(phases_ran),
         phases_total=len(planned_phases),
         capabilities_used=result.get("capabilities_used", []),
-        # C1 #1500: a real verdict — partial state reached at the bound counts.
-        # ``decides`` reflects whether any agent actually produced a message,
-        # honest on both clean completion and wall-clock-bounded partial.
-        decides=total_messages > 0,
+        # Track CA #1529: `decides` is no longer hand-set here — run_all
+        # computes it uniformly from phases_completed + total_messages below.
         terminated_by_budget=False,
         scope_of_work=scope,
         extra_metrics={
@@ -500,7 +557,7 @@ async def run_conversation_deterministic_mode(text: str, corpus_id: str) -> Mode
         fallacy_count=conv_state.get("state", {}).get("fallacies_detected", 0),
         phases_completed=3,  # informal + fol + synthesis
         phases_total=3,
-        decides=True,
+        # Track CA #1529: `decides` computed uniformly (phases_completed=3 → True).
         scope_of_work=("ConversationOrchestrator(mode=demo, SimulatedAgent, no LLM)"),
         extra_metrics={
             "messages_count": conv_state.get("messages_count", 0),
@@ -556,16 +613,24 @@ async def run_hierarchical_bridge_mode(text: str, corpus_id: str) -> ModeResult:
     phases_completed = summary.get("completed", 0)
     phases_total = summary.get("total", 0)
     # Bridge mode DÉCIDE firsthand via real agents when the registry is
-    # populated: it returns a `conclusion` (R644). Treat presence of
-    # `conclusion` as `decides=True`.
-    decides = bool(
-        isinstance(result, dict)
-        and (
+    # populated: it returns a `conclusion` (R644). Track CA #1529: we no longer
+    # hand-set `decides` — instead we stash the mode-specific verdict artifact
+    # (conclusion / strategic_decision / governance-decoded-firsthand flag)
+    # into the uniform `extra_metrics["verdict_artifact"]` channel, and run_all
+    # computes `decides` uniformly via `_compute_decides`. This documents that a
+    # strategic conclusion counts as deciding EVEN WITHOUT shared-state fill
+    # (the DoD-4 #1529 case: bridge 0.0 % fill but Decides ✅ is legitimate).
+    verdict_artifact = None
+    if isinstance(result, dict):
+        verdict_artifact = (
             result.get("conclusion")
             or result.get("strategic_decision")
-            or result.get("governance_decided_firsthand") is True
+            or (
+                "governance_decided_firsthand"
+                if result.get("governance_decided_firsthand") is True
+                else None
+            )
         )
-    )
 
     return ModeResult(
         mode="hierarchical_bridge",
@@ -578,7 +643,6 @@ async def run_hierarchical_bridge_mode(text: str, corpus_id: str) -> ModeResult:
         capabilities_used=(
             result.get("capabilities_used", []) if isinstance(result, dict) else []
         ),
-        decides=decides,
         scope_of_work=(
             "Strategic planning -> objectives_to_workflow -> "
             "WorkflowExecutor (Lego/DAG, 4 axes)"
@@ -587,6 +651,7 @@ async def run_hierarchical_bridge_mode(text: str, corpus_id: str) -> ModeResult:
             "objectives_count": (
                 len(result.get("objectives", [])) if isinstance(result, dict) else 0
             ),
+            "verdict_artifact": verdict_artifact,
         },
     )
 
@@ -633,16 +698,20 @@ async def run_hierarchical_delegation_mode(text: str, corpus_id: str) -> ModeRes
     summary = result.get("summary", {}) if isinstance(result, dict) else {}
     phases_completed = summary.get("completed", 0)
     phases_total = summary.get("total", 0)
-    # Delegation mode DÉCIDE firsthand on hierarchical_fallacy (R648).
-    decides = bool(
-        isinstance(result, dict)
-        and (
+    # Delegation mode DÉCIDE firsthand on hierarchical_fallacy (R648). Track CA
+    # #1529: `decides` is computed uniformly by run_all via `_compute_decides`
+    # — from phases_completed (above) and the stashed verdict artifact below.
+    verdict_artifact = None
+    if isinstance(result, dict):
+        verdict_artifact = (
             result.get("conclusion")
             or result.get("strategic_decision")
-            or result.get("broadcasted_to_zero_agents") is False
-            or phases_completed > 0
+            or (
+                "broadcasted_to_nonzero_agents"
+                if result.get("broadcasted_to_zero_agents") is False
+                else None
+            )
         )
-    )
 
     return ModeResult(
         mode="hierarchical_delegation",
@@ -655,7 +724,6 @@ async def run_hierarchical_delegation_mode(text: str, corpus_id: str) -> ModeRes
         capabilities_used=(
             result.get("capabilities_used", []) if isinstance(result, dict) else []
         ),
-        decides=decides,
         scope_of_work=(
             "Strategic -> Tactical -> Operational (3-tier, "
             "5 tasks via CapabilityRegistry)"
@@ -664,6 +732,7 @@ async def run_hierarchical_delegation_mode(text: str, corpus_id: str) -> ModeRes
             "objectives_count": (
                 len(result.get("objectives", [])) if isinstance(result, dict) else 0
             ),
+            "verdict_artifact": verdict_artifact,
         },
     )
 
@@ -955,6 +1024,15 @@ async def run_all(
                     )
                 )
                 logger.error(f"  → {mode} on {corpus_id}: EXCEPTION {e}")
+
+    # Track CA #1529: compute `decides` UNIFORMLY for every mode from the
+    # common ModeResult fields — the single source of truth, so no runner can
+    # hand-set it on a local criterion. A budget breach that still produced
+    # partial artifacts honestly decides True (the partial state IS the
+    # verdict, anti-#1019); a genuinely sterile run (conversational cut at the
+    # safety-net: 0/0 phases, 0 % fill) stays False → `—`.
+    for r in results:
+        r.decides = _compute_decides(r)
 
     # Generate report
     report = generate_report(results)

--- a/tests/scripts/test_compare_orchestration_modes_1480.py
+++ b/tests/scripts/test_compare_orchestration_modes_1480.py
@@ -136,7 +136,10 @@ class TestModeResultColumns:
         mod = _load_harness_module()
         result = mod.ModeResult(mode="x", corpus_id="y", success=True)
         assert result.terminates is True
-        assert result.decides is False
+        # Track CA #1529: the default is now None ("not computed"), NOT False
+        # ("no") — a runner that bypasses the uniform _compute_decides helper
+        # surfaces as indeterminate, not as a false "no verdict".
+        assert result.decides is None
         assert result.terminated_by_budget is False
         assert result.scope_of_work == ""
 
@@ -248,7 +251,13 @@ class TestConversationalInternalBound:
         # The partial state reached at the bound IS a real verdict (anti-#1019).
         assert result.success is True
         assert result.terminates is True
-        assert result.decides is True
+        # Track CA #1529: `decides` is now computed UNIFORMLY by run_all (not
+        # hand-set by the runner), so a direct runner call leaves it None. The
+        # partial-verdict-is-real contract is verified via the uniform helper:
+        # the fields the runner populated (1 message, 1/3 phases, non-empty
+        # state) DO constitute a decision.
+        assert result.decides is None
+        assert mod._compute_decides(result) is True
         assert result.terminated_by_budget is False
         assert result.extra_metrics["wall_clock_bounded"] is True
         assert result.extra_metrics["conversational_status"] == "WALL_CLOCK_BOUNDED"
@@ -309,7 +318,8 @@ class TestConversationalInternalBound:
         result = asyncio.run(_drive())
 
         assert result.success is True
-        assert result.decides is True
+        # Track CA #1529: decides computed uniformly (3 messages, 3/3 phases → True).
+        assert mod._compute_decides(result) is True
         assert result.extra_metrics["wall_clock_bounded"] is False
         assert result.phases_completed == 3
 
@@ -457,6 +467,182 @@ class TestCliDryRun:
         assert (
             "--max-wall-seconds" in result.stdout
         ), "BO-4 regression: --max-wall-seconds CLI flag is missing."
+
+
+class TestComputeDecidesCA:
+    """Track CA #1529 — ``decides`` computed UNIFORMLY for every mode.
+
+    The BO-4 #1480 defect: ``ModeResult.decides`` defaulted to ``False`` and
+    each runner hand-set it on a different local criterion (conversational:
+    ``total_messages > 0``; hierarchical: a ``conclusion``; pipeline: never →
+    the misleading ``False`` default). Result: ``pipeline_standard`` with
+    15/15 phases and 51.2 % state fill was painted ``Decides —``. CA #1529
+    replaces this with ONE definition (:func:`_compute_decides`) applied in a
+    single ``run_all`` pass, and changes the default to ``None``.
+
+    These tests are deterministic and LLM/JVM-free — they build ``ModeResult``
+    instances directly and exercise the helper + the ``run_all`` normalization.
+    """
+
+    def _harness(self):
+        return _load_harness_module()
+
+    def test_sterile_run_decides_false(self) -> None:
+        """Anti-pendule guard: a run that produced nothing stays False → `—`.
+        This is the non-regression test the coord emphasized — a fix that
+        turns every mode green is wrong."""
+        mod = self._harness()
+        sterile = mod.ModeResult(
+            mode="conversational",
+            corpus_id="corpus_A",
+            success=False,
+            terminates=True,
+            terminated_by_budget=True,  # cut at the safety-net
+            error="Safety-net timeout (>=60s)",
+        )
+        assert mod._compute_decides(sterile) is False, (
+            "CA #1529 regression: a genuinely sterile run (0/0 phases, 0 % "
+            "fill, 0 messages) must decide False, not True."
+        )
+
+    def test_state_fill_decides_true(self) -> None:
+        mod = self._harness()
+        filled = mod.ModeResult(
+            mode="pipeline_standard",
+            corpus_id="corpus_A",
+            success=True,
+            state_fill_rate=0.512,
+        )
+        assert mod._compute_decides(filled) is True
+
+    def test_extracted_artifacts_decide_true(self) -> None:
+        mod = self._harness()
+        for kwargs in ({"argument_count": 3}, {"fallacy_count": 2}):
+            r = mod.ModeResult(mode="x", corpus_id="y", success=True, **kwargs)
+            assert mod._compute_decides(r) is True, (
+                f"CA #1529 regression: extracted artifacts ({kwargs}) must "
+                "count as deciding."
+            )
+
+    def test_agent_messages_decide_true(self) -> None:
+        mod = self._harness()
+        r = mod.ModeResult(
+            mode="conversational",
+            corpus_id="corpus_A",
+            success=True,
+            extra_metrics={"total_messages": 5},
+        )
+        assert mod._compute_decides(r) is True
+
+    def test_verdict_artifact_decides_true_without_fill(self) -> None:
+        """DoD-4 #1529: hierarchical_bridge emits a strategic ``conclusion``
+        without filling the shared state (0.0 % fill) — that is a LEGITIMATE
+        decide, documented via the uniform ``verdict_artifact`` channel."""
+        mod = self._harness()
+        r = mod.ModeResult(
+            mode="hierarchical_bridge",
+            corpus_id="corpus_A",
+            success=True,
+            state_fill_rate=0.0,
+            extra_metrics={"verdict_artifact": "strategic conclusion text"},
+        )
+        assert mod._compute_decides(r) is True, (
+            "CA #1529 regression: a mode-specific conclusion (verdict_artifact) "
+            "must count as deciding even at 0 % shared-state fill."
+        )
+
+    def test_phases_completed_decides_true(self) -> None:
+        """A completed workflow phase emits its phase's artifact by definition
+        — so ``phases_completed > 0`` decides True even at 0 % fill."""
+        mod = self._harness()
+        r = mod.ModeResult(
+            mode="x",
+            corpus_id="y",
+            success=True,
+            phases_completed=4,
+        )
+        assert mod._compute_decides(r) is True
+
+    def test_pipeline_bug_reproduction_now_decides_true(self) -> None:
+        """The coord's firsthand DoD-4 bug (R706): pipeline_standard completing
+        15/15 phases, 51.2 % fill, 14 capabilities was shown ``Decides —``
+        because run_pipeline_mode never set decides. The uniform helper must
+        now compute True."""
+        mod = self._harness()
+        pipeline_like = mod.ModeResult(
+            mode="pipeline_standard",
+            corpus_id="corpus_A",
+            success=True,
+            duration_seconds=320.75,
+            state_fill_rate=0.512,
+            phases_completed=15,
+            phases_total=15,
+            capabilities_used=[f"cap_{i}" for i in range(14)],
+        )
+        assert mod._compute_decides(pipeline_like) is True, (
+            "CA #1529 NOT-fixed: pipeline with 15/15 phases and 51.2 % fill "
+            "must decide True (the BO-4 false-negative the coord caught firsthand)."
+        )
+
+    def test_conversational_safety_net_stays_false(self) -> None:
+        """The coord's non-regression guard verbatim: the conversational run
+        cut at the safety-net (0/0 phases, 0 % fill) must HONESTLY stay False.
+        If CA turned it green, CA would be theater."""
+        mod = self._harness()
+        safety_net = mod.ModeResult(
+            mode="conversational",
+            corpus_id="corpus_A",
+            success=False,
+            terminates=True,
+            terminated_by_budget=True,
+            duration_seconds=60.01,
+            phases_completed=0,
+            phases_total=0,
+            state_fill_rate=0.0,
+            error="Safety-net timeout (>=30s)",
+            extra_metrics={"total_messages": 0},
+        )
+        assert mod._compute_decides(safety_net) is False
+
+    def test_run_all_computes_decides_uniformly(self) -> None:
+        """``run_all`` is the single point that computes ``decides`` for every
+        result via the uniform helper — regardless of what the runners return.
+        A deciding stub (phases>0) → True; a sterile stub → False; neither
+        hand-sets ``decides``."""
+        mod = self._harness()
+
+        async def stub_deciding(text, cid):
+            return mod.ModeResult(
+                mode="stub_deciding",
+                corpus_id=cid,
+                success=True,
+                phases_completed=2,
+            )
+
+        async def stub_sterile(text, cid):
+            return mod.ModeResult(mode="stub_sterile", corpus_id=cid, success=True)
+
+        real_runners = dict(mod.MODE_RUNNERS)
+        mod.MODE_RUNNERS.clear()
+        mod.MODE_RUNNERS["stub_deciding"] = stub_deciding
+        mod.MODE_RUNNERS["stub_sterile"] = stub_sterile
+        try:
+            results = asyncio.run(
+                mod.run_all(
+                    modes=["stub_deciding", "stub_sterile"], corpora=["corpus_A"]
+                )
+            )
+        finally:
+            mod.MODE_RUNNERS.clear()
+            mod.MODE_RUNNERS.update(real_runners)
+
+        by_mode = {r.mode: r for r in results}
+        assert (
+            by_mode["stub_deciding"].decides is True
+        ), "CA #1529: run_all did not compute decides=True for the deciding stub."
+        assert (
+            by_mode["stub_sterile"].decides is False
+        ), "CA #1529: run_all did not compute decides=False for the sterile stub."
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Track CA #1529 — uniform `decides` for all 4 modes

Item 1 of dispatch R706 (po-2023, **blocking** — unblocks DoD-1/DoD-4 of Epic #1500). Closes the BO-4 #1480 defect the coord caught firsthand at DoD-4 (R706): `pipeline_standard` completing **15/15 phases at 51.2 % state fill** was shown **`Decides —`**, while `hierarchical_bridge` at **0.0 % fill** showed `Decides ✅`.

### Root cause (verified in code, not supposed)

`ModeResult.decides` was **not a computed metric** — it was a field posed **ad hoc per runner** with a misleading default:

```python
decides: bool = False   # ← the default
```

- `run_pipeline_mode` — **never set `decides`** → took the `False` default → `—`.
- `run_conversational_mode` — `total_messages > 0` (C1).
- `run_hierarchical_bridge_mode` / `_delegation` — a `conclusion`.

Three definitions for a column whose purpose is to **compare**. Structurally non-comparable since BO-4 #1480 — not a C1 regression.

### The fix — ONE definition, computed uniformly

| Change | What |
|---|---|
| `ModeResult.decides` default | `False` → **`None`** (indeterminate ≠ "no" — anti-#1019: "I didn't check" is not "I checked, nothing"). |
| `_compute_decides(result)` (new) | A mode decides iff it produced ≥1 **verdict artifact**: non-empty state, an extracted arg/fallacy, an agent message, a mode-specific conclusion (`extra_metrics["verdict_artifact"]`), **or** a completed workflow phase. |
| `run_all` | Computes `decides` for every result in a **single pass** — runners no longer hand-set it. |
| Bridge/delegation | Stash their strategic `conclusion` into the uniform `verdict_artifact` channel (instead of hand-computing `decides`). |

### DoD-4 cases resolved

- ✅ **`pipeline_standard` 15/15 + 51.2 % fill → `Decides ✅`** (via `state_fill_rate > 0` / `phases_completed > 0`). The coord's firsthand bug, reproduced + fixed deterministically in `test_pipeline_bug_reproduction_now_decides_true`.
- ✅ **Conversational cut at safety-net (0/0 phases, 0 % fill) → honestly stays `—`** (`test_conversational_safety_net_stays_false`). **The anti-pendule guard: if CA turned this green, CA would be theater.**
- ✅ **`hierarchical_bridge` 0.0 % fill + `Decides ✅` → legitimate, documented** — it emits a strategic `conclusion` (`verdict_artifact`) without filling the shared state. Not "corrected" away; the uniform definition captures it.

### Anti-pendule

- Scope = **one definition + one helper + the misleading-default removal**. No harness rewrite.
- The C1 safety-net refactor (`_conversational_safety_net_timeout`) is **untouched** (the CA branch is off `ce5e6df7`, C1 intact).
- A budget breach that produced partial artifacts honestly decides `True` (partial state IS the verdict); one that produced nothing honestly decides `False`.

### Tests (deterministic, LLM/JVM-free) — 39 green on po-2023

- **9 new** in `TestComputeDecidesCA`: `_compute_decides` unit cases (state fill / extracted artifacts / messages / verdict_artifact / phases / **sterile→False guard** / **pipeline-bug reproduction** / run_all uniform computation).
- **2 adapted** C1 `TestConversationalInternalBound` asserts: `decides` is now computed in `run_all`, so direct runner calls are verified via `mod._compute_decides(result)` (the partial-verdict-is-real contract is preserved — same intent, uniform channel).
- 28 existing BO-4 / C1 / depth-parity tests unchanged and green.

`black` clean, `py_compile` clean (`projet-is`, `--disable-jvm-session`).

### Privacy

Synthetic harness input (`corpus_A/B/C`), opaque IDs, zero encrypted corpus, zero `raw_text`.

### Files changed

| File | Type | Role |
|---|---|---|
| `scripts/compare_orchestration_modes.py` | fix (harness) | Uniform `_compute_decides` + `None` default + run_all normalization + runner cleanup |
| `tests/scripts/test_compare_orchestration_modes_1480.py` | test | 9 new CA tests + 2 C1 asserts adapted + default-None test |

Refs: dispatch R706 · #1529 (this track) · #1528 (CB, next) · Epic #1500 (DoD-1/DoD-4) · BO-4 #1480 (origin of the column) · C1 #1526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
