### PR TITLE
feat(harness): mode-agnostic --max-wall-seconds for all runners (Track CB #1528)

### DIFF
--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -87,6 +87,25 @@ def _conversational_safety_net_timeout(max_wall_seconds: float) -> float:
     return max(max_wall_seconds * 1.2, max_wall_seconds + 30.0)
 
 
+def _count_pending_async_tasks() -> int:
+    """CB #1528 guard (b): count asyncio tasks still pending (not done).
+
+    A mode killed by ``asyncio.wait_for`` should leave its cancelled coroutine
+    fully cleaned up. If this returns >0 immediately after a breached mode, the
+    cancellation leaked dangling work (e.g. in-flight HTTP sessions spawned by
+    the LLM client) that may inflate the NEXT mode's measured wall-time —
+    cross-mode contamination. The count is MEASURED and REPORTED (logged +
+    stashed in ``extra_metrics["pending_tasks_after_breach"]``), never masked
+    by a convenient mode ordering (coord R709 directive: measure, don't hide).
+    """
+    try:
+        current = asyncio.current_task()
+        return sum(1 for t in asyncio.all_tasks() if t is not current and not t.done())
+    except RuntimeError:
+        # No running loop (called outside a coroutine) → nothing to measure.
+        return 0
+
+
 # ── Benchmark texts (opaque IDs, no raw content in reports) ──────────────
 
 BENCHMARK_TEXTS = {
@@ -383,23 +402,113 @@ def render_depth_parity_section() -> str:
 
 
 async def run_pipeline_mode(
-    text: str, corpus_id: str, workflow_name: str = "standard"
+    text: str,
+    corpus_id: str,
+    workflow_name: str = "standard",
+    max_wall_seconds: Optional[float] = None,
 ) -> ModeResult:
-    """Run UnifiedPipeline (modern workflow engine)."""
+    """Run UnifiedPipeline (modern workflow engine).
+
+    CB #1528: when ``max_wall_seconds`` is set, the bound is enforced by
+    ``asyncio.wait_for`` AROUND ``run_unified_analysis`` — but the analysis
+    state is created HERE and passed BY REFERENCE, so a level torn
+    mid-``asyncio.gather`` by the cancellation still leaves behind the
+    completed levels' artifacts. State writers run per-phase only AFTER each
+    level's gather completes (workflow_dsl.py:498 → :788), so the partial
+    state is exactly the verdict of the levels that finished — anti-#1019 (a
+    real bounded verdict, not a killed coroutine that lost everything). The
+    recording ``checkpoint_callback`` counts COMPLETED phases at each level; a
+    torn level never reaches its checkpoint, so ``phases_completed`` cannot be
+    inflated by a half-finished level (coord R709 guard a).
+
+    ``max_wall_seconds=None`` (default) = unbounded — the original pre-CB
+    path. Bounding is opt-in (anti-pendule: bornant ≠ désactiver).
+    """
     from argumentation_analysis.orchestration.unified_pipeline import (
         run_unified_analysis,
     )
 
+    scope = "UnifiedPipeline DAG workflow"
     start = time.time()
-    result = await run_unified_analysis(text=text, workflow_name=workflow_name)
+
+    # CB #1528: state-reference trick + recording checkpoint (bound only).
+    state = None
+    last_completed = [0]
+    checkpoint_callback = None
+    if max_wall_seconds is not None:
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+        state = UnifiedAnalysisState(text)
+
+        def _record_completed(results, _ctx):
+            # Recording only — never raises, so the executor's
+            # ``except Exception`` checkpoint swallow (workflow_dsl.py:507)
+            # cannot silence it. Fires after each fully-gathered level, so
+            # ``last_completed[0]`` = COMPLETED phases from FINISHED levels
+            # only — a level torn mid-gather never reaches here (guard a).
+            try:
+                last_completed[0] = sum(
+                    1
+                    for r in results.values()
+                    if getattr(getattr(r, "status", None), "name", "") == "COMPLETED"
+                )
+            except Exception:
+                pass  # recording must never disturb the pipeline
+
+        checkpoint_callback = _record_completed
+
+    try:
+        if max_wall_seconds is not None:
+            result = await asyncio.wait_for(
+                run_unified_analysis(
+                    text=text,
+                    workflow_name=workflow_name,
+                    state=state,
+                    checkpoint_callback=checkpoint_callback,
+                ),
+                timeout=max_wall_seconds,
+            )
+        else:
+            result = await run_unified_analysis(text=text, workflow_name=workflow_name)
+    except asyncio.TimeoutError:
+        duration = time.time() - start
+        logger.warning(
+            f"pipeline_{workflow_name} on {corpus_id} hit the "
+            f"{max_wall_seconds:g}s wall-clock budget after {duration:.2f}s "
+            f"— recovering partial state from the state reference "
+            f"(completed levels only; torn level not counted)."
+        )
+        snapshot: Dict[str, Any] = {}
+        try:
+            snapshot = state.get_state_snapshot() or {}
+        except Exception:
+            snapshot = {}
+        total_fields = len(snapshot) if snapshot else 1
+        non_empty = sum(
+            1 for v in snapshot.values() if v and v not in ([], {}, "", None, 0)
+        )
+        return ModeResult(
+            mode=f"pipeline_{workflow_name}",
+            corpus_id=corpus_id,
+            success=False,
+            terminates=True,
+            terminated_by_budget=True,
+            duration_seconds=round(duration, 2),
+            state_fill_rate=round(non_empty / max(total_fields, 1), 3),
+            phases_completed=last_completed[0],
+            # `decides` left None → _compute_decides in run_all. A partial
+            # state (fill>0) or any completed phase ⇒ True (anti-#1019:
+            # the partial state IS the verdict).
+            scope_of_work=scope,
+        )
+
     duration = time.time() - start
-
     summary = result.get("summary", {})
-    state = result.get("state_snapshot", {})
+    snap = result.get("state_snapshot", {})
 
-    total_fields = len(state) if state else 1
+    total_fields = len(snap) if snap else 1
     non_empty = sum(
-        1 for v in (state or {}).values() if v and v not in ([], {}, "", None, 0)
+        1 for v in (snap or {}).values() if v and v not in ([], {}, "", None, 0)
     )
 
     return ModeResult(
@@ -414,6 +523,7 @@ async def run_pipeline_mode(
         phases_total=summary.get("total", 0),
         capabilities_used=result.get("capabilities_used", []),
         capabilities_missing=result.get("capabilities_missing", []),
+        scope_of_work=scope,
     )
 
 
@@ -534,8 +644,16 @@ async def run_conversational_mode(
     )
 
 
-async def run_conversation_deterministic_mode(text: str, corpus_id: str) -> ModeResult:
-    """Run ConversationOrchestrator in demo mode (SimulatedAgent, no LLM)."""
+async def run_conversation_deterministic_mode(
+    text: str, corpus_id: str, max_wall_seconds: Optional[float] = None
+) -> ModeResult:
+    """Run ConversationOrchestrator in demo mode (SimulatedAgent, no LLM).
+
+    CB #1528: ``max_wall_seconds`` is accepted for signature uniformity with
+    the other runners (so ``run_all`` can thread it to every mode) but is
+    IGNORED — this runner is deterministic and LLM-free, so it always
+    completes in milliseconds; bounding it would be dead code.
+    """
     from argumentation_analysis.orchestration.conversation_orchestrator import (
         ConversationOrchestrator,
     )
@@ -567,7 +685,9 @@ async def run_conversation_deterministic_mode(text: str, corpus_id: str) -> Mode
     )
 
 
-async def run_hierarchical_bridge_mode(text: str, corpus_id: str) -> ModeResult:
+async def run_hierarchical_bridge_mode(
+    text: str, corpus_id: str, max_wall_seconds: Optional[float] = None
+) -> ModeResult:
     """Run hierarchical analysis via the bridge mode (M2 default).
 
     The bridge mode short-circuits the 3-tier chain via
@@ -577,6 +697,12 @@ async def run_hierarchical_bridge_mode(text: str, corpus_id: str) -> ModeResult:
     populated ``CapabilityRegistry``, NOT the legacy ``HierarchicalOrchestrator().
     analyze()`` (which predates the registry and never distinguishes
     bridge vs delegation).
+
+    CB #1528: ``run_hierarchical_analysis`` exposes NO incremental state, so a
+    wall-clock breach cannot recover a partial verdict — the honest degrade is
+    a sterile ``terminated_by_budget=True`` result (``decides`` → False → ``—``
+    via ``_compute_decides``). This is the structural asymmetry with the
+    pipeline (state-reference trick): documented here, not papered over.
     """
     from argumentation_analysis.orchestration.hierarchical.orchestrator import (
         run_hierarchical_analysis,
@@ -585,13 +711,38 @@ async def run_hierarchical_bridge_mode(text: str, corpus_id: str) -> ModeResult:
         setup_registry,
     )
 
+    scope = (
+        "Strategic planning -> objectives_to_workflow -> "
+        "WorkflowExecutor (Lego/DAG, 4 axes)"
+    )
     start = time.time()
     registry = setup_registry(include_optional=True)
+    coro = run_hierarchical_analysis(
+        text=text,
+        capability_registry=registry,
+        mode="bridge",
+    )
     try:
-        result = await run_hierarchical_analysis(
-            text=text,
-            capability_registry=registry,
-            mode="bridge",
+        if max_wall_seconds is not None:
+            result = await asyncio.wait_for(coro, timeout=max_wall_seconds)
+        else:
+            result = await coro
+    except asyncio.TimeoutError:
+        duration = time.time() - start
+        logger.warning(
+            f"hierarchical_bridge on {corpus_id} hit the "
+            f"{max_wall_seconds:g}s budget after {duration:.2f}s — honest "
+            f"degrade (no incremental state exposed → sterile partial)."
+        )
+        return ModeResult(
+            mode="hierarchical_bridge",
+            corpus_id=corpus_id,
+            success=False,
+            terminates=True,
+            terminated_by_budget=True,
+            duration_seconds=round(duration, 2),
+            error=f"Wall-clock budget (>={max_wall_seconds:g}s)",
+            scope_of_work=scope,
         )
     except Exception as exc:
         duration = time.time() - start
@@ -602,10 +753,7 @@ async def run_hierarchical_bridge_mode(text: str, corpus_id: str) -> ModeResult:
             terminates=False,
             error=str(exc)[:200],
             duration_seconds=round(duration, 2),
-            scope_of_work=(
-                "Strategic planning -> objectives_to_workflow -> "
-                "WorkflowExecutor (Lego/DAG, 4 axes)"
-            ),
+            scope_of_work=scope,
         )
     duration = time.time() - start
 
@@ -656,13 +804,20 @@ async def run_hierarchical_bridge_mode(text: str, corpus_id: str) -> ModeResult:
     )
 
 
-async def run_hierarchical_delegation_mode(text: str, corpus_id: str) -> ModeResult:
+async def run_hierarchical_delegation_mode(
+    text: str, corpus_id: str, max_wall_seconds: Optional[float] = None
+) -> ModeResult:
     """Run hierarchical analysis via the delegation mode (M3, RA-10 #1069).
 
     True strategic -> tactical -> operational delegation driven by
     explicit sequential calls (5/5 tasks when the registry is fully
     populated, per R648+R649+R651+R652). Wired via
     ``run_hierarchical_analysis(..., mode="delegation")``.
+
+    CB #1528: same honest-degrade contract as bridge —
+    ``run_hierarchical_analysis`` exposes no incremental state, so a
+    wall-clock breach yields a sterile ``terminated_by_budget=True`` result
+    (``decides`` → False → ``—``).
     """
     from argumentation_analysis.orchestration.hierarchical.orchestrator import (
         run_hierarchical_analysis,
@@ -671,13 +826,38 @@ async def run_hierarchical_delegation_mode(text: str, corpus_id: str) -> ModeRes
         setup_registry,
     )
 
+    scope = (
+        "Strategic -> Tactical -> Operational (3-tier, "
+        "5 tasks via CapabilityRegistry)"
+    )
     start = time.time()
     registry = setup_registry(include_optional=True)
+    coro = run_hierarchical_analysis(
+        text=text,
+        capability_registry=registry,
+        mode="delegation",
+    )
     try:
-        result = await run_hierarchical_analysis(
-            text=text,
-            capability_registry=registry,
-            mode="delegation",
+        if max_wall_seconds is not None:
+            result = await asyncio.wait_for(coro, timeout=max_wall_seconds)
+        else:
+            result = await coro
+    except asyncio.TimeoutError:
+        duration = time.time() - start
+        logger.warning(
+            f"hierarchical_delegation on {corpus_id} hit the "
+            f"{max_wall_seconds:g}s budget after {duration:.2f}s — honest "
+            f"degrade (no incremental state exposed → sterile partial)."
+        )
+        return ModeResult(
+            mode="hierarchical_delegation",
+            corpus_id=corpus_id,
+            success=False,
+            terminates=True,
+            terminated_by_budget=True,
+            duration_seconds=round(duration, 2),
+            error=f"Wall-clock budget (>={max_wall_seconds:g}s)",
+            scope_of_work=scope,
         )
     except Exception as exc:
         duration = time.time() - start
@@ -688,10 +868,7 @@ async def run_hierarchical_delegation_mode(text: str, corpus_id: str) -> ModeRes
             terminates=False,
             error=str(exc)[:200],
             duration_seconds=round(duration, 2),
-            scope_of_work=(
-                "Strategic -> Tactical -> Operational (3-tier, "
-                "5 tasks via CapabilityRegistry)"
-            ),
+            scope_of_work=scope,
         )
     duration = time.time() - start
 
@@ -742,15 +919,18 @@ async def run_hierarchical_delegation_mode(text: str, corpus_id: str) -> ModeRes
 # TWO comparable sub-modes (bridge + delegation) — point the alias
 # at the bridge default for compatibility while documenting the
 # deprecation (the issue body of #1480 covers the full migration).
-async def run_hierarchical_mode(text: str, corpus_id: str) -> ModeResult:
+async def run_hierarchical_mode(
+    text: str, corpus_id: str, max_wall_seconds: Optional[float] = None
+) -> ModeResult:
     """Deprecated alias for ``run_hierarchical_bridge_mode``.
 
     Kept so that ``--modes hierarchical`` on an old caller does not
     silently break; the alias routes to bridge (the historical default).
     New code should request ``hierarchical_bridge`` or
-    ``hierarchical_delegation`` explicitly.
+    ``hierarchical_delegation`` explicitly. Forwards ``max_wall_seconds``
+    (CB #1528).
     """
-    return await run_hierarchical_bridge_mode(text, corpus_id)
+    return await run_hierarchical_bridge_mode(text, corpus_id, max_wall_seconds)
 
 
 # ── Mode registry ────────────────────────────────────────────────────────
@@ -762,10 +942,16 @@ async def run_hierarchical_mode(text: str, corpus_id: str) -> ModeResult:
 # for the comparative trade-off — cluedo is a Sherlock-Watson game, not
 # an argumentation-analysis mode comparable to the others.
 
-MODE_RUNNERS: Dict[str, Callable[[str, str], Awaitable[ModeResult]]] = {
-    "pipeline": lambda text, cid: run_pipeline_mode(text, cid, "standard"),
-    "pipeline_light": lambda text, cid: run_pipeline_mode(text, cid, "light"),
-    "pipeline_full": lambda text, cid: run_pipeline_mode(text, cid, "full"),
+MODE_RUNNERS: Dict[str, Callable[..., Awaitable[ModeResult]]] = {
+    "pipeline": lambda text, cid, max_wall_seconds=None: run_pipeline_mode(
+        text, cid, "standard", max_wall_seconds=max_wall_seconds
+    ),
+    "pipeline_light": lambda text, cid, max_wall_seconds=None: run_pipeline_mode(
+        text, cid, "light", max_wall_seconds=max_wall_seconds
+    ),
+    "pipeline_full": lambda text, cid, max_wall_seconds=None: run_pipeline_mode(
+        text, cid, "full", max_wall_seconds=max_wall_seconds
+    ),
     "conversational": run_conversational_mode,
     "conversation_deterministic": run_conversation_deterministic_mode,
     "hierarchical_bridge": run_hierarchical_bridge_mode,
@@ -820,6 +1006,11 @@ def generate_report(
       ⏱ terminates=True, terminated_by_budget=True (honest partial — safety-net
             timeout fired, no verdict produced)
       ❌ terminates=False (real failure / exception)
+
+    Decides column (CB #1528 folds-in): ``✅`` produced ≥1 verdict artifact,
+    ``—`` computed "no artifact" (e.g. a sterile safety-net cut), ``?``
+    indeterminate (a result that bypassed ``_compute_decides`` — should not
+    appear via ``run_all``, which normalizes every result).
     """
     lines = [
         f"# {title}",
@@ -850,7 +1041,18 @@ def generate_report(
             status = "✅"
         else:
             status = "❌"
-        decides = "✅" if r.decides else "—"
+        # CB #1528 folds-in: distinguish the 3 documented `decides` states.
+        # `run_all` normalizes every result via `_compute_decides` before
+        # reporting, so True/False are the common cases. A direct
+        # `generate_report` caller passing un-normalized results would have
+        # `decides=None` (indeterminate) — render `?`, NOT `—` (anti-#1019:
+        # "I didn't check" is not "I checked, nothing").
+        if r.decides is True:
+            decides = "✅"
+        elif r.decides is False:
+            decides = "—"
+        else:
+            decides = "?"
         scope = r.scope_of_work or MODE_SCOPE_DESCRIPTIONS.get(r.mode, "")
         lines.append(
             f"| {r.mode} | {r.corpus_id} | {status} | "
@@ -956,9 +1158,12 @@ async def run_all(
     """Run selected modes on selected corpora.
 
     Args:
-        max_wall_seconds: Wall-clock budget applied to the conversational
-            runner. Breach is recorded as a HONEST PARTIAL verdict
-            (``terminated_by_budget=True``) — never faked into success.
+        max_wall_seconds: Wall-clock budget (CB #1528) threaded to EVERY
+            runner — pipeline (state-reference trick → real partial verdict),
+            conversational (internal bound, C1 #1500), hierarchical (honest
+            degrade — no incremental state exposed → sterile ``—``). Breach is
+            recorded as a HONEST PARTIAL verdict (``terminated_by_budget=True``)
+            — never faked into success (anti-#1019).
     """
     if modes is None:
         modes = list(MODE_RUNNERS.keys())
@@ -972,7 +1177,7 @@ async def run_all(
             available = "available" if runner else "UNKNOWN"
             print(f"  {mode}: {available}")
         print(f"\nCorpora: {', '.join(corpora)}")
-        print(f"Conversational wall-time budget: {max_wall_seconds:g}s")
+        print(f"Wall-clock budget (all modes, CB #1528): {max_wall_seconds:g}s")
         return []
 
     # Load environment
@@ -999,15 +1204,28 @@ async def run_all(
 
             logger.info(f"Running {mode} on {corpus_id} ({len(text)} chars)...")
             try:
-                # The conversational runner needs the wall-time budget;
-                # pass it explicitly. All other runners ignore extra kwargs.
-                if mode == "conversational":
-                    result = await runner(text, corpus_id, max_wall_seconds)
-                else:
-                    result = await runner(text, corpus_id)
+                # CB #1528: the wall-clock budget is now threaded to EVERY
+                # runner (uniform signature ``runner(text, cid, max_wall_seconds=...)``).
+                # Pipeline applies the state-reference trick; conversational
+                # its internal bound (C1); hierarchical honest-degrades.
+                result = await runner(
+                    text, corpus_id, max_wall_seconds=max_wall_seconds
+                )
                 results.append(result)
                 if result.terminated_by_budget:
                     status = f"BUDGET BREACH ({result.duration_seconds:.2f}s)"
+                    # CB #1528 guard (b): measure cross-mode cancellation
+                    # contamination. A breached mode's `asyncio.wait_for`
+                    # cancels in-flight work; if it leaks dangling tasks they
+                    # can inflate the NEXT mode's wall-time. Measured +
+                    # reported, NOT masked by re-ordering (coord R709).
+                    pending = _count_pending_async_tasks()
+                    if pending:
+                        logger.warning(
+                            f"  → contamination risk: {pending} pending async "
+                            f"task(s) survived the {mode} breach on {corpus_id}"
+                        )
+                        result.extra_metrics["pending_tasks_after_breach"] = pending
                 elif result.success:
                     status = "OK"
                 else:

--- a/tests/scripts/test_compare_orchestration_modes_1480.py
+++ b/tests/scripts/test_compare_orchestration_modes_1480.py
@@ -33,6 +33,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -611,7 +612,10 @@ class TestComputeDecidesCA:
         hand-sets ``decides``."""
         mod = self._harness()
 
-        async def stub_deciding(text, cid):
+        # CB #1528: run_all now threads max_wall_seconds to EVERY runner, so
+        # the stubs accept (and ignore) the kwarg. Intent unchanged — this
+        # still verifies run_all computes `decides` uniformly.
+        async def stub_deciding(text, cid, max_wall_seconds=None):
             return mod.ModeResult(
                 mode="stub_deciding",
                 corpus_id=cid,
@@ -619,7 +623,7 @@ class TestComputeDecidesCA:
                 phases_completed=2,
             )
 
-        async def stub_sterile(text, cid):
+        async def stub_sterile(text, cid, max_wall_seconds=None):
             return mod.ModeResult(mode="stub_sterile", corpus_id=cid, success=True)
 
         real_runners = dict(mod.MODE_RUNNERS)
@@ -643,6 +647,315 @@ class TestComputeDecidesCA:
         assert (
             by_mode["stub_sterile"].decides is False
         ), "CA #1529: run_all did not compute decides=False for the sterile stub."
+
+
+class TestCBWallClockBudget1528:
+    """Track CB #1528 — mode-agnostic ``--max-wall-seconds``.
+
+    The bound is threaded to EVERY runner, not just conversational:
+    * pipeline applies the STATE-REFERENCE trick (``state=`` passed by
+      reference → completed levels survive ``asyncio.wait_for`` cancellation
+      → real partial verdict, anti-#1019);
+    * hierarchical honest-degrades (no incremental state exposed → sterile
+      ``terminated_by_budget=True`` → ``decides`` False → ``—``);
+    * conversational unchanged (C1 #1500 internal bound).
+
+    Coord R709 two guards: (a) a torn level must NOT inflate
+    ``phases_completed``; (b) cross-mode cancellation contamination is
+    MEASURED and reported, never masked by re-ordering.
+
+    Deterministic + LLM/JVM-free: the inner entry-points are patched.
+    """
+
+    def _harness(self):
+        return _load_harness_module()
+
+    @staticmethod
+    def _phase(status_name: str) -> SimpleNamespace:
+        """A fake PhaseResult whose ``.status.name`` is ``status_name``."""
+        return SimpleNamespace(status=SimpleNamespace(name=status_name))
+
+    def test_pipeline_budget_breach_recovers_partial_state(self) -> None:
+        """CB #1528 anti-#1019: a pipeline killed at the bound leaves a REAL
+        partial verdict — completed levels' state survives via the
+        state-reference trick, so ``decides`` is True (not a killed coroutine
+        that lost everything)."""
+        mod = self._harness()
+
+        async def fake_run(**kwargs):
+            # Level 0 completes: writes an argument to the shared state AND
+            # fires the checkpoint with 2 COMPLETED phases.
+            state = kwargs.get("state")
+            if state is not None and hasattr(state, "add_argument"):
+                state.add_argument("partial_argument_from_completed_level")
+            cb = kwargs.get("checkpoint_callback")
+            if cb is not None:
+                cb(
+                    {
+                        "p_extract": self._phase("COMPLETED"),
+                        "p_detect": self._phase("COMPLETED"),
+                    },
+                    {},
+                )
+            # Level 1 torn — hangs past the tiny budget.
+            await asyncio.sleep(5)
+
+        async def _drive():
+            with patch(
+                "argumentation_analysis.orchestration.unified_pipeline"
+                ".run_unified_analysis",
+                side_effect=fake_run,
+            ):
+                return await mod.run_pipeline_mode(
+                    "text", "corpus_A", "standard", max_wall_seconds=0.5
+                )
+
+        result = asyncio.run(_drive())
+
+        assert result.terminated_by_budget is True
+        assert result.success is False
+        assert result.terminates is True
+        # Partial state survived the cancellation → fill_rate > 0.
+        assert result.state_fill_rate > 0
+        # phases_completed == checkpoint count (2), NOT inflated by the torn level.
+        assert result.phases_completed == 2
+        # The partial state IS the verdict (anti-#1019).
+        assert mod._compute_decides(result) is True
+
+    def test_pipeline_torn_level_not_inflated(self) -> None:
+        """Coord R709 guard (a): a level torn mid-gather by the budget must
+        NOT count toward ``phases_completed``. The checkpoint fires only after
+        a full gather, so the torn level's in-flight phase never reaches it."""
+        mod = self._harness()
+
+        async def fake_run(**kwargs):
+            cb = kwargs.get("checkpoint_callback")
+            # Level 0 fully gathered (2 COMPLETED) → checkpoint fires with 2.
+            if cb is not None:
+                cb({"p1": self._phase("COMPLETED"), "p2": self._phase("COMPLETED")}, {})
+            # Level 1 torn mid-gather (1 RUNNING, never completes) → hangs
+            # before its own checkpoint could fire.
+            await asyncio.sleep(5)
+
+        async def _drive():
+            with patch(
+                "argumentation_analysis.orchestration.unified_pipeline"
+                ".run_unified_analysis",
+                side_effect=fake_run,
+            ):
+                return await mod.run_pipeline_mode(
+                    "text", "corpus_A", "standard", max_wall_seconds=0.5
+                )
+
+        result = asyncio.run(_drive())
+        assert result.phases_completed == 2, (
+            "Guard (a) regression: the torn level's in-flight phase leaked into "
+            "phases_completed. The checkpoint must count only COMPLETED phases "
+            "from fully-gathered levels."
+        )
+
+    def test_pipeline_unbounded_path_unchanged(self) -> None:
+        """``max_wall_seconds=None`` = original pre-CB path (no state-ref, no
+        checkpoint, no wait_for). Regression guard."""
+        mod = self._harness()
+        fake_result = {
+            "summary": {"completed": 15, "total": 15},
+            "state_snapshot": {"identified_arguments": {"arg_1": "x"}},
+            "capabilities_used": ["fact_extraction"],
+            "capabilities_missing": [],
+            "extra_metrics": {"fallacy_count": 2, "argument_count": 1},
+        }
+        captured: dict = {}
+
+        async def fake_run(**kwargs):
+            captured["state"] = kwargs.get("state")
+            captured["checkpoint_callback"] = kwargs.get("checkpoint_callback")
+            return fake_result
+
+        async def _drive():
+            with patch(
+                "argumentation_analysis.orchestration.unified_pipeline"
+                ".run_unified_analysis",
+                side_effect=fake_run,
+            ):
+                return await mod.run_pipeline_mode("text", "corpus_A", "standard")
+
+        result = asyncio.run(_drive())
+        # Unbounded → no state-reference, no checkpoint (bound is opt-in).
+        assert captured["state"] is None
+        assert captured["checkpoint_callback"] is None
+        assert result.success is True
+        assert result.terminated_by_budget is False
+        assert result.phases_completed == 15
+
+    def test_hierarchical_bridge_budget_breach_honest_degrade(self) -> None:
+        """CB #1528: hierarchical exposes no incremental state → a budget
+        breach honestly degrades to a sterile ``terminated_by_budget=True``
+        result (decides False → ``—``), NOT a faked success."""
+        mod = self._harness()
+
+        async def fake_hang(**kwargs):
+            await asyncio.sleep(5)
+
+        async def _drive():
+            with patch(
+                "argumentation_analysis.orchestration.hierarchical.orchestrator"
+                ".run_hierarchical_analysis",
+                side_effect=fake_hang,
+            ), patch(
+                "argumentation_analysis.orchestration.registry_setup" ".setup_registry",
+                return_value=None,
+            ):
+                return await mod.run_hierarchical_bridge_mode(
+                    "text", "corpus_A", max_wall_seconds=0.5
+                )
+
+        result = asyncio.run(_drive())
+        assert result.terminated_by_budget is True
+        assert result.success is False
+        assert result.terminates is True
+        # No partial state exposed → sterile → honestly decides False.
+        assert mod._compute_decides(result) is False
+
+    def test_hierarchical_delegation_budget_breach_honest_degrade(self) -> None:
+        """Same honest-degrade contract as bridge, for the delegation mode."""
+        mod = self._harness()
+
+        async def fake_hang(**kwargs):
+            await asyncio.sleep(5)
+
+        async def _drive():
+            with patch(
+                "argumentation_analysis.orchestration.hierarchical.orchestrator"
+                ".run_hierarchical_analysis",
+                side_effect=fake_hang,
+            ), patch(
+                "argumentation_analysis.orchestration.registry_setup" ".setup_registry",
+                return_value=None,
+            ):
+                return await mod.run_hierarchical_delegation_mode(
+                    "text", "corpus_A", max_wall_seconds=0.5
+                )
+
+        result = asyncio.run(_drive())
+        assert result.terminated_by_budget is True
+        assert result.success is False
+        assert mod._compute_decides(result) is False
+
+    def test_count_pending_async_tasks_detects_leak(self) -> None:
+        """Coord R709 guard (b): the contamination detector must surface
+        dangling tasks left by a cancelled coroutine (would inflate the next
+        mode's wall-time). Measured, not masked."""
+        mod = self._harness()
+
+        async def _drive():
+            before = mod._count_pending_async_tasks()
+            # Spawn a task that outlives the measurement (a "leaked" session).
+            leak = asyncio.ensure_future(asyncio.sleep(50))
+            await asyncio.sleep(0)  # let the scheduler start it
+            after = mod._count_pending_async_tasks()
+            leak.cancel()
+            try:
+                await leak
+            except asyncio.CancelledError:
+                pass
+            return before, after
+
+        before, after = asyncio.run(_drive())
+        assert after > before, (
+            "Guard (b) regression: _count_pending_async_tasks did not detect "
+            f"the leaked task (before={before}, after={after})."
+        )
+
+    def test_run_all_threads_max_wall_seconds_to_all_runners(self) -> None:
+        """CB #1528: ``run_all`` threads ``max_wall_seconds`` to EVERY runner
+        (not just conversational) via the uniform dispatch call."""
+        mod = self._harness()
+        received: dict = {}
+
+        async def fake_pipeline(
+            text, cid, workflow_name="standard", max_wall_seconds=None
+        ):
+            received[f"pipeline_{workflow_name}"] = max_wall_seconds
+            return mod.ModeResult(
+                mode=f"pipeline_{workflow_name}", corpus_id=cid, success=True
+            )
+
+        async def fake_bridge(text, cid, max_wall_seconds=None):
+            received["hierarchical_bridge"] = max_wall_seconds
+            return mod.ModeResult(
+                mode="hierarchical_bridge", corpus_id=cid, success=True
+            )
+
+        async def fake_conv(text, cid, max_wall_seconds=180.0):
+            received["conversational"] = max_wall_seconds
+            return mod.ModeResult(mode="conversational", corpus_id=cid, success=True)
+
+        async def fake_det(text, cid, max_wall_seconds=None):
+            received["conversation_deterministic"] = max_wall_seconds
+            return mod.ModeResult(
+                mode="conversation_deterministic",
+                corpus_id=cid,
+                success=True,
+                phases_completed=3,
+            )
+
+        fake_runners = {
+            "pipeline": fake_pipeline,
+            "hierarchical_bridge": fake_bridge,
+            "conversational": fake_conv,
+            "conversation_deterministic": fake_det,
+        }
+
+        async def _drive():
+            with patch.object(mod, "MODE_RUNNERS", fake_runners), patch(
+                "argumentation_analysis.core.jvm_setup.initialize_jvm",
+                return_value=None,
+            ):
+                return await mod.run_all(
+                    modes=[
+                        "pipeline",
+                        "hierarchical_bridge",
+                        "conversational",
+                        "conversation_deterministic",
+                    ],
+                    corpora=["corpus_A"],
+                    max_wall_seconds=42.0,
+                )
+
+        asyncio.run(_drive())
+        assert received == {
+            "pipeline_standard": 42.0,
+            "hierarchical_bridge": 42.0,
+            "conversational": 42.0,
+            "conversation_deterministic": 42.0,
+        }, f"run_all did not thread max_wall_seconds to all runners: {received}"
+
+    def test_generate_report_renders_none_decides_as_question(self) -> None:
+        """CB #1528 folds-in: ``decides=None`` (indeterminate) renders ``?``,
+        NOT ``—`` (anti-#1019: 'I didn't check' ≠ 'I checked, nothing')."""
+        mod = self._harness()
+        none_result = mod.ModeResult(
+            mode="pipeline_standard", corpus_id="corpus_A", success=True
+        )
+        none_result.decides = None  # bypassed _compute_decides
+        report = mod.generate_report([none_result])
+        assert (
+            "| ? |" in report
+        ), "CB #1528 folds-in regression: decides=None must render '?', not '—'."
+
+    def test_generate_report_decides_true_false_distinct(self) -> None:
+        """True → ``✅``, False → ``—`` (the common run_all-normalized cases)."""
+        mod = self._harness()
+        yes = mod.ModeResult(
+            mode="pipeline_standard", corpus_id="corpus_A", success=True
+        )
+        yes.decides = True
+        no = mod.ModeResult(mode="conversational", corpus_id="corpus_B", success=False)
+        no.decides = False
+        report = mod.generate_report([yes, no])
+        assert "| ✅ |" in report
+        assert "| — |" in report
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Track CB #1528 — mode-agnostic `--max-wall-seconds` for all runners

Item 2 of dispatch R706 (po-2023), unblocked by CA #1530 (merged `f738b267`). Closes the BO-4 #1480 asymmetry the coord flagged at DoD-4: `--max-wall-seconds` was honored by **1 of 4 modes** (conversational only) — pipeline / hierarchical_bridge / hierarchical_delegation ran **unbounded**, so the harness could not bound its own comparison subjects uniformly.

### Root cause

`run_all` specialized the dispatch — only `mode == "conversational"` received `max_wall_seconds`; every other runner was called as `runner(text, cid)` and the budget was silently dropped:

```python
if mode == "conversational":
    result = await runner(text, corpus_id, max_wall_seconds)
else:
    result = await runner(text, corpus_id)   # ← budget discarded
```

### The fix — thread the bound to EVERY runner, each with an HONEST contract

| Runner | Bound mechanism | Breach outcome |
|---|---|---|
| `pipeline_*` | **State-reference trick** — `UnifiedAnalysisState` created in the runner, passed BY REFERENCE into `run_unified_analysis(state=...)`, wrapped in `asyncio.wait_for` | Real partial verdict: completed levels survive in the referenced state (`state_fill_rate>0` / `phases_completed>0` → `decides=True` via CA's `_compute_decides`). Anti-#1019. |
| `hierarchical_bridge` / `_delegation` / alias | `asyncio.wait_for` + **honest degrade** | Sterile `terminated_by_budget=True` (`decides=False` → `—`). `run_hierarchical_analysis` exposes NO incremental state — the asymmetry with pipeline is documented, not papered over. |
| `conversational` | **Unchanged** (C1 #1500 internal bound) | Safety-net intact. |
| `conversation_deterministic` | accepts (ignores) the kwarg | Deterministic / LLM-free — bounding it is dead code. |

The state-reference trick works because state writers run **per-phase only after each level's `asyncio.gather`** completes (`workflow_dsl.py:498→:788`) — so a level torn mid-gather by cancellation leaves behind exactly the completed levels' artifacts.

### Coord R709 — two guards

**(a) A torn level must NOT inflate `phases_completed`.** A recording `checkpoint_callback` counts `COMPLETED` phases after each fully-gathered level; a level torn mid-gather never reaches its checkpoint, so the count cannot include half-finished work. The callback only **records** (never raises) → immune to the executor's `except Exception` swallow (`workflow_dsl.py:507`). **The coord-flagged sentinel-via-callback fallback was NOT shipped** — it fails silently (coord R709 read the swallow firsthand).

**(b) Cross-mode cancellation contamination is MEASURED, not masked.** `_count_pending_async_tasks()` logs + stashes `pending_tasks_after_breach` when a breached mode leaves dangling async work that could inflate the NEXT mode's wall-time. No convenient re-ordering (coord R709 directive: measure, don't hide).

### Folds-in

`generate_report` conflated `None`≡`False` (a result that bypassed `_compute_decides` rendered `—`). Now `True`→`✅`, `False`→`—`, `None`→`?` (anti-#1019: "I didn't check" is not "I checked, nothing").

### Anti-pendule

- Scope = **thread the bound + 2 guards + the None-render fix**. No harness rewrite.
- The CA uniform `_compute_decides` is **untouched** (CA gives DoD item 2 free — not re-coded).
- The C1 safety-net (`_conversational_safety_net_timeout`) is **untouched**.
- `max_wall_seconds=None` (default) = the original unbounded path; bounding is opt-in (bornant ≠ désactiver).

### Tests (deterministic, LLM/JVM-free) — 39 green on po-2023

- **9 new** in `TestCBWallClockBudget1528`: pipeline breach recovers partial state + `decides=True`; torn-level guard (a); unbounded-path regression; bridge/delegation honest-degrade; contamination detector guard (b); `run_all` threads the budget to all 4 runners; `None`→`?` / True-False distinct rendering.
- **1 CA stub adapted** (`stub_deciding`/`stub_sterile` now accept the uniform `max_wall_seconds` kwarg — intent unchanged).
- 24 existing BO-4 / C1 / CA tests unchanged and green. C1 safety-net intact.

`black` clean, `py_compile` clean (`projet-is`, `--disable-jvm-session`).

### Privacy

Synthetic harness input (`corpus_A/B/C`), opaque IDs, zero encrypted corpus, zero `raw_text`.

### Files changed

| File | Type | Role |
|---|---|---|
| `scripts/compare_orchestration_modes.py` | feat (harness) | Uniform `max_wall_seconds` threading + pipeline state-reference trick + hierarchical honest-degrade + 2 coord guards + None-render fix |
| `tests/scripts/test_compare_orchestration_modes_1480.py` | test | 9 new CB tests + 1 CA stub signature adaptation |

Refs: dispatch R706 · coord R709 (state-reference approved, sentinel fallback rejected) · #1528 (this track) · #1529 / #1530 (CA, merged) · Epic #1500 (DoD-2 substance) · BO-4 #1480 (the harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
