### PR TITLE
fix(hierarchical): thread the corpus S→T→O in delegation mode (Track CC #1531)

### DIFF
--- a/argumentation_analysis/core/communication/strategic_adapter.py
+++ b/argumentation_analysis/core/communication/strategic_adapter.py
@@ -138,9 +138,49 @@ class StrategicAdapter:
             metadata=message.metadata,
         )
 
-        self.logger.info(
-            f"Objective {objective_type} broadcasted to {len(recipients)} agents"
+        # CC #1531: ``publish`` ne retourne QUE les abonnés du topic. Le fan-out
+        # C2 #1500 vers les ``global_handlers`` du middleware livre réellement le
+        # broadcast sans jamais apparaître dans ce compteur — le lire seul
+        # SOUS-rapporte une livraison qui a bien eu lieu. On compte donc les deux
+        # chemins de livraison que ``publish`` emprunte effectivement.
+        #
+        # ⚠ ``initialize_protocols`` enregistre son propre
+        # ``_debug_message_handler`` comme handler global (middleware.py:525), et
+        # ``publish`` déclenche cette initialisation paresseuse : compter la
+        # liste brute donnerait TOUJOURS ≥1 et éteindrait définitivement
+        # l'alerte ci-dessous. On l'exclut — un handler de debug n'est pas un
+        # destinataire (anti-pendule : ne pas fabriquer l'évidence qui fait
+        # taire la mesure).
+        own_debug = getattr(self.middleware, "_debug_message_handler", None)
+        listeners = len(
+            [
+                handler
+                for handler in (getattr(self.middleware, "global_handlers", None) or [])
+                if handler != own_debug
+            ]
         )
+        if recipients or listeners:
+            self.logger.info(
+                f"Objective {objective_type} broadcasted to {len(recipients)} "
+                f"topic subscriber(s) + {listeners} global listener(s)"
+            )
+        else:
+            # CC #1531 (reclassé depuis le DoD-2 de l'Epic #1500) : publier sur
+            # un topic sans abonné est un no-op TOTAL — le ``message`` construit
+            # ci-dessus n'est jamais émis sur le canal, seul ``publish`` l'est.
+            # Aucun composant de production ne s'abonne à ``objectives.*``
+            # (le tier tactique s'abonne au canal HIERARCHICAL, pas à ces
+            # topics), donc l'appelant reçoit un message_id comme si quelque
+            # chose avait été délivré. Le signaler au lieu de l'enterrer en INFO.
+            #
+            # Anti-pendule : NE PAS inventer un abonné pour faire monter le
+            # compteur à 1, et NE PAS se mettre à émettre ``message`` sur le
+            # canal ici (ce serait changer la sémantique de livraison hors
+            # périmètre). C'est la VISIBILITÉ du no-op qui est en jeu.
+            self.logger.warning(
+                f"Objective {objective_type} published on topic {topic_id!r} with "
+                f"NO subscriber — nothing was delivered (no-op broadcast)."
+            )
         return message.id
 
     def receive_report(

--- a/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
+++ b/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
@@ -170,7 +170,30 @@ def make_registry_operational_executor(
         # text. Pass the textual payload (``description``) as the position the
         # signatures actually declare, and keep the structured fields in the
         # context so providers that need them can still find them.
-        textual_input = command.get("description", "") or ""
+        #
+        # CC #1531: ce qui est passé en position 1 doit être le CORPUS, pas le
+        # libellé de la tâche. ``description`` est une étiquette de ~30
+        # caractères ("Extraire les segments...") — les runs de délégation
+        # montraient ``source_length: 28`` et un agent répondant honnêtement
+        # « aucun texte fourni », pendant que la chaîne concluait au succès.
+        # Le corpus arrive par ``text_extracts`` (voir
+        # ``TacticalOperationalInterface._determine_relevant_extracts``).
+        corpus_text = "\n\n".join(
+            str(extract.get("content", "")).strip()
+            for extract in input_data["text_extracts"]
+            if isinstance(extract, dict) and str(extract.get("content", "")).strip()
+        )
+        if not corpus_text:
+            # Fail loud plutôt qu'analyser un libellé : sans corpus la tâche ne
+            # peut rien produire, et un ``completed`` ici remonterait en
+            # success_rate=1.0 puis en « performance globale élevée » (#1019).
+            return {
+                **base,
+                "status": "failed",
+                "reason": "insufficient_input",
+                "capability": chosen,
+            }
+        textual_input = corpus_text
         bridge_context = {
             **(command.get("context") or {}),
             "input_data": input_data,
@@ -294,6 +317,12 @@ class DelegationOrchestrator:
         self.logger.info("M3 strategic tier produced %d objective(s).", len(objectives))
 
         # --- T: tactical decomposition -------------------------------------
+        # CC #1531: propager le corpus S→T. La décomposition ne transporte que
+        # les objectifs; sans ce fil le tier tactique n'a AUCUN accès au texte
+        # et l'interface T→O fabriquait un extrait factice. C'est le côté
+        # écriture de la chaîne écriture→lecture consommée par
+        # ``TacticalOperationalInterface._determine_relevant_extracts``.
+        self.tactical_coordinator.state.set_raw_text(text)
         decomposition = self.tactical_coordinator.process_strategic_objectives(
             objectives
         )

--- a/argumentation_analysis/orchestration/hierarchical/interfaces/tactical_operational.py
+++ b/argumentation_analysis/orchestration/hierarchical/interfaces/tactical_operational.py
@@ -285,11 +285,33 @@ class TacticalOperationalInterface:
     def _determine_relevant_extracts(
         self, task: Dict[str, Any]
     ) -> List[Dict[str, Any]]:
+        """Retourne les extraits de texte que l'agent opérationnel doit analyser.
+
+        CC #1531: cette méthode retournait un extrait CODÉ EN DUR
+        (``"Extrait à analyser..."``). Les adaptateurs opérationnels lisent tous
+        ``task["text_extracts"]`` pour construire le texte qu'ils soumettent au
+        LLM — ils recevaient donc un placeholder au lieu du corpus, et l'agent
+        répondait honnêtement « aucun texte fourni » pendant que la chaîne
+        concluait au succès.
+
+        Le corpus descend maintenant par ``TacticalState.raw_text``. En son
+        absence on retourne une liste **vide** plutôt qu'un extrait fabriqué :
+        l'exécuteur opérationnel échoue alors bruyamment en
+        ``insufficient_input`` (anti-#1019 — pas de contenu inventé).
+        """
+        raw_text = getattr(self.tactical_state, "raw_text", None)
+        if not raw_text:
+            self.logger.warning(
+                "Aucun texte source au niveau tactique pour la tâche %s — "
+                "aucun extrait transmis (échec bruyant en aval).",
+                task.get("id", "unknown"),
+            )
+            return []
         return [
             {
                 "id": f"extract-{uuid.uuid4().hex[:8]}",
                 "source": "raw_text",
-                "content": "Extrait à analyser...",
+                "content": raw_text,
             }
         ]
 

--- a/argumentation_analysis/orchestration/hierarchical/tactical/state.py
+++ b/argumentation_analysis/orchestration/hierarchical/tactical/state.py
@@ -23,6 +23,13 @@ class TacticalState:
         # Objectifs reçus du niveau stratégique
         self.assigned_objectives: List[Dict[str, Any]] = []
 
+        # Texte source à analyser, propagé depuis le niveau stratégique.
+        # CC #1531: le tier tactique n'avait aucun canal pour le corpus — seuls
+        # les objectifs descendaient. L'interface T→O fabriquait donc un extrait
+        # factice, et les agents opérationnels analysaient un libellé de tâche.
+        # Symétrique de ``StrategicState.raw_text`` (state.py:23).
+        self.raw_text: Optional[str] = None
+
         # Tâches décomposées
         self.tasks: Dict[str, List[Dict[str, Any]]] = {
             "pending": [],
@@ -70,6 +77,15 @@ class TacticalState:
 
         # Journal des actions tactiques
         self.tactical_actions_log: List[Dict[str, Any]] = []
+
+    def set_raw_text(self, text: str) -> None:
+        """
+        Définit le texte source à analyser au niveau tactique.
+
+        Args:
+            text: Le texte à analyser
+        """
+        self.raw_text = text
 
     def add_assigned_objective(self, objective: Dict[str, Any]) -> None:
         """

--- a/tests/orchestration/hierarchical/test_delegation_decides_firsthand_1471_R648.py
+++ b/tests/orchestration/hierarchical/test_delegation_decides_firsthand_1471_R648.py
@@ -137,6 +137,20 @@ class TestDelegationModeDecidesFirsthand:
                     "description": "Extraire segments pertinents",
                     "required_capabilities": ["text_extraction"],
                     "context": {},
+                    # CC #1531: le corpus voyage par ``text_extracts`` ; sans
+                    # lui l'exécuteur échoue en ``insufficient_input`` AVANT
+                    # d'invoquer. Le routage legacy→registry testé ici est
+                    # décidé en amont de cette garde : l'assertion est intacte.
+                    "text_extracts": [
+                        {
+                            "id": "x1",
+                            "content": (
+                                "Tous les experts le disent, donc c'est vrai. "
+                                "Et si vous n'êtes pas d'accord, c'est que vous "
+                                "ne comprenez rien au sujet."
+                            ),
+                        }
+                    ],
                 }
             )
         )
@@ -197,6 +211,12 @@ class TestDelegationModeDictStrSignatureBridge:
                 "description": "Le texte d'entrée est ici.",
                 "required_capabilities": ["spy_signature_bridge"],
                 "context": {"phase": "spy"},
+                # CC #1531: le corpus voyage par ``text_extracts``, et c'est
+                # LUI qui doit arriver en position 1 — pas la ``description``
+                # (un libellé de tâche). La garantie str-pas-dict de R648 est
+                # inchangée ; l'assertion ajoutée plus bas fixe l'identité du
+                # texte transmis.
+                "text_extracts": [{"id": "x1", "content": "CORPUS_MARK_spy_opaque"}],
             }
         )
 
@@ -204,6 +224,10 @@ class TestDelegationModeDictStrSignatureBridge:
         assert captured["input_text_type"] == "str", (
             f"provider received {captured['input_text_type']} — the "
             f"dict/str mismatch has regressed"
+        )
+        assert captured["input_text_value"] == "CORPUS_MARK_spy_opaque", (
+            f"provider received {captured['input_text_value']!r} at position 1 "
+            f"— the CORPUS must be analysed, not the task label (CC #1531)"
         )
         assert captured[
             "context_has_input_data"

--- a/tests/unit/argumentation_analysis/core/communication/test_broadcast_bus_fix_1500.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_broadcast_bus_fix_1500.py
@@ -110,13 +110,43 @@ class TestFixBBroadcastReachesListener:
         assert msg.content["objective_type"] == "analysis"
         assert msg.metadata.get("topic") == "objectives.analysis"
 
-    def test_broadcast_without_listener_is_honest_zero(self) -> None:
+    def test_broadcast_without_listener_is_honest_zero(
+        self, caplog: logging.Logger
+    ) -> None:
         # Anti-#1019: with no listener, the broadcast reaches nobody — nothing
         # fabricated, no crash. The path runs cleanly.
+        #
+        # CC #1531 (item reclassé depuis le DoD-2 de #1500): "reaches nobody"
+        # must be VISIBLE. Publishing on a topic with no subscriber is a total
+        # no-op — the ``Message`` built in ``broadcast_objective`` is never
+        # emitted on any channel — yet the caller still gets a message id back.
+        # That silence is what made a broken-looking "broadcasted to 0 agents"
+        # indistinguishable from a working bus. It is now a WARNING.
         mw = create_default_middleware()
-        StrategicAdapter("strategic_alpha", mw).broadcast_objective(
-            "analysis", {"goal": "opaque"}
+        with caplog.at_level(
+            logging.WARNING, logger="StrategicAdapter.strategic_alpha"
+        ):
+            StrategicAdapter("strategic_alpha", mw).broadcast_objective(
+                "analysis", {"goal": "opaque"}
+            )
+        assert "NO subscriber" in caplog.text, (
+            "a no-op broadcast must be surfaced, not buried in an INFO line "
+            f"— got: {caplog.text!r}"
         )
+
+    def test_broadcast_with_listener_emits_no_no_subscriber_warning(
+        self, caplog: logging.Logger
+    ) -> None:
+        """The CC #1531 warning must not become noise on the healthy path."""
+        mw = create_default_middleware()
+        mw.register_global_handler(lambda m: None)
+        with caplog.at_level(
+            logging.WARNING, logger="StrategicAdapter.strategic_alpha"
+        ):
+            StrategicAdapter("strategic_alpha", mw).broadcast_objective(
+                "analysis", {"goal": "opaque"}
+            )
+        assert "NO subscriber" not in caplog.text
 
 
 class TestNoChannelNotFoundOnBroadcastPath:

--- a/tests/unit/argumentation_analysis/test_tactical_operational_interface.py
+++ b/tests/unit/argumentation_analysis/test_tactical_operational_interface.py
@@ -209,23 +209,45 @@ class TestTacticalOperationalInterface(unittest.TestCase):
         self.assertIn("fallacy_pattern_matching", technique_names)
 
     def test_determine_relevant_extracts(self):
-        """Teste la détermination des extraits de texte pertinents."""
-        # Définir une tâche fictive
+        """Teste la détermination des extraits de texte pertinents.
+
+        CC #1531 : ce test validait auparavant le comportement de STUB — la
+        méthode retournait un extrait codé en dur (``"Extrait à analyser..."``)
+        et l'assertion ``len(result) > 0`` passait sans qu'aucun texte source
+        n'existe. Le contrat est désormais : l'extrait porte le corpus réel,
+        propagé par ``TacticalState.raw_text``.
+        """
         task = {
             "description": "Extraire les segments de texte contenant des arguments potentiels",
             "objective_id": "obj-1",
         }
+        corpus = "CORPUS_MARK_opaque — texte source à analyser."
+        # L'état tactique est un ``MagicMock(spec=TacticalState)`` : appeler
+        # ``set_raw_text`` n'écrirait rien (méthode mockée), on pose donc
+        # directement l'attribut que l'interface lit.
+        self.interface.tactical_state.raw_text = corpus
 
-        # Appeler la méthode à tester
         result = self.interface._determine_relevant_extracts(task)
 
-        # Vérifier le résultat
         self.assertIsInstance(result, list)
         self.assertTrue(len(result) > 0)
         self.assertIn("id", result[0])
         self.assertIn("source", result[0])
         self.assertIn("content", result[0])
-        # La clé 'relevance' n'est plus garantie
+        # Le contenu est le corpus, pas un placeholder.
+        self.assertEqual(result[0]["content"], corpus)
+
+    def test_determine_relevant_extracts_without_source_text(self):
+        """Sans texte source, aucun extrait fabriqué (anti-#1019).
+
+        Retourner une liste vide fait échouer bruyamment le tier opérationnel
+        (``insufficient_input``) au lieu de lui faire analyser un placeholder.
+        """
+        task = {"description": "Analyser", "objective_id": "obj-1"}
+
+        result = self.interface._determine_relevant_extracts(task)
+
+        self.assertEqual(result, [])
 
     def test_determine_execution_parameters(self):
         """Teste la détermination des paramètres d'exécution."""

--- a/tests/unit/orchestration/test_hierarchical_delegation.py
+++ b/tests/unit/orchestration/test_hierarchical_delegation.py
@@ -230,6 +230,7 @@ async def test_registry_executor_invokes_real_provider_with_intent():
 
     async def fake_invoke(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
         captured["input_text_type"] = type(input_text).__name__
+        captured["input_text"] = input_text
         captured["intent_in_input_data"] = (
             isinstance(context, dict)
             and "input_data" in context
@@ -249,6 +250,11 @@ async def test_registry_executor_invokes_real_provider_with_intent():
             "description": "Some tactical description for the provider.",
             "required_capabilities": ["fallacy_detection"],
             "strategic_objective_description": "INTENT_MARK_opaque",
+            # CC #1531: le corpus voyage par ``text_extracts``. Le fixture est
+            # antérieur à ce contrat (il ne portait qu'une ``description``), ce
+            # qui est exactement le défaut corrigé — les assertions R648
+            # ci-dessous sont conservées telles quelles.
+            "text_extracts": [{"id": "x1", "content": "CORPUS_MARK_opaque"}],
         }
     )
     assert result["status"] == "completed"
@@ -261,6 +267,10 @@ async def test_registry_executor_invokes_real_provider_with_intent():
         "intent_in_input_data"
     ], "strategic NL intent must reach the provider via context['input_data']"
     assert result["outputs"]["echo"] == "INTENT_MARK_opaque"
+    assert captured["input_text"] == "CORPUS_MARK_opaque", (
+        "the provider must receive the CORPUS at position 1, not the task label "
+        f"— got {captured['input_text']!r} (CC #1531)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -290,3 +300,118 @@ async def test_run_hierarchical_analysis_delegation_mode_dispatches():
             strategic_manager=_FakeStrategicManager(objectives),
             middleware=MagicMock(),
         )
+
+
+# ---------------------------------------------------------------------------
+# CC #1531 — le CORPUS doit atteindre le tier opérationnel
+# ---------------------------------------------------------------------------
+
+# Marqueur distinct de STRATEGIC_MARKER : celui-ci suit le *texte à analyser*,
+# pas l'intention stratégique. Les deux chaînes sont indépendantes et le test
+# ci-dessous échouerait si l'une était confondue avec l'autre.
+CORPUS_MARKER = "UNIQUE_CORPUS_omega77_opaque"
+
+
+async def test_corpus_reaches_the_operational_command():
+    """Chaîne écriture→lecture pour le TEXTE lui-même, pas seulement l'intention.
+
+    CC #1531 : le tier tactique n'avait aucun canal pour le corpus.
+    ``_determine_relevant_extracts`` retournait un extrait codé en dur et chaque
+    agent opérationnel analysait un libellé de tâche d'une trentaine de
+    caractères (``source_length: 28`` observé en run réel), pendant que la
+    chaîne concluait « performance globale élevée ».
+    """
+    objectives = [{"id": "obj-1", "description": STRATEGIC_MARKER, "priority": "high"}]
+    captured = []
+
+    async def stub_executor(command):
+        captured.append(command)
+        return {
+            "task_id": command.get("tactical_task_id"),
+            "objective_id": command.get("objective_id"),
+            "status": "completed",
+            "outputs": {"ok": True},
+        }
+
+    orchestrator = DelegationOrchestrator(
+        strategic_manager=_FakeStrategicManager(objectives),
+        operational_executor=stub_executor,
+        middleware=MagicMock(),
+    )
+    await orchestrator.analyze(CORPUS_MARKER)
+
+    assert captured, "aucune commande opérationnelle produite"
+    for command in captured:
+        contents = [
+            extract.get("content") for extract in command.get("text_extracts", [])
+        ]
+        assert CORPUS_MARKER in contents, (
+            f"le corpus n'a pas atteint la commande {command.get('id')} — "
+            f"extraits reçus : {contents!r}"
+        )
+        assert (
+            "Extrait à analyser..." not in contents
+        ), "le placeholder codé en dur est revenu (régression CC #1531)"
+
+
+async def test_executor_fails_loud_without_corpus():
+    """Sans corpus, l'exécuteur échoue honnêtement au lieu de valider du vide."""
+
+    async def fake_invoke(input_text, context):
+        raise AssertionError(
+            "le provider ne doit pas être invoqué sans corpus (CC #1531)"
+        )
+
+    registry = _FakeRegistry(
+        {"fallacy_detection": [_FakeProvider("informal_v1", fake_invoke)]}
+    )
+    executor = make_registry_operational_executor(registry)
+    result = await executor(
+        {
+            "tactical_task_id": "t1",
+            "objective_id": "obj-1",
+            "description": "Détecter les sophismes",  # libellé seul : insuffisant
+            "required_capabilities": ["fallacy_detection"],
+            "text_extracts": [],
+        }
+    )
+
+    assert result["status"] == "failed"
+    assert result["reason"] == "insufficient_input"
+
+
+async def test_starved_run_does_not_report_success_to_the_strategic_tier():
+    """L'ENTRÉE du verdict ne ment plus.
+
+    Anti-pendule : on ne touche ni ``_compute_decides`` ni
+    ``_formulate_conclusion``. On prouve que ce qui les alimente est honnête —
+    une chaîne privée de corpus remonte ``success_rate == 0.0``, et non 1.0.
+    Auparavant chaque tâche était comptée ``completed`` (le provider répondait
+    « aucun texte fourni ») ⇒ 1.0 ⇒ « performance globale élevée ».
+    """
+    objectives = [{"id": "obj-1", "description": STRATEGIC_MARKER, "priority": "high"}]
+
+    async def fake_invoke(input_text, context):
+        return {"unreachable": True}
+
+    registry = _FakeRegistry(
+        {
+            cap: [_FakeProvider(f"prov_{cap}", fake_invoke)]
+            for cap in ("fallacy_detection", "fact_extraction", "argument_parsing")
+        }
+    )
+    orchestrator = DelegationOrchestrator(
+        strategic_manager=_FakeStrategicManager(objectives),
+        operational_executor=make_registry_operational_executor(registry),
+        middleware=MagicMock(),
+    )
+    # Corpus vide : le tier tactique n'a rien à transmettre.
+    result = await orchestrator.analyze("")
+
+    assert all(
+        r["status"] == "failed" for r in result["operational_results"]
+    ), f"une tâche sans corpus a été comptée réussie : {result['operational_results']!r}"
+    eval_input = orchestrator.strategic_manager.eval_calls[0]
+    assert all(
+        v["success_rate"] == 0.0 for v in eval_input.values()
+    ), f"le tier stratégique a reçu un taux de succès fabriqué : {eval_input!r}"


### PR DESCRIPTION
Track **CC #1531** (Epic #1500). Le mode `hierarchical_delegation` concluait « Analyse réussie avec une performance globale élevée. » (`success_rate` 1.0) sur une analyse qui n'avait rien produit.

Le verdict n'était pas le défaut — c'est son **entrée** qui mentait.

## Cause racine : le corpus n'atteignait jamais le tier opérationnel

Deux canaux, tous deux coupés :

1. **`TacticalOperationalInterface._determine_relevant_extracts` retournait un extrait CODÉ EN DUR** — littéralement `"Extrait à analyser..."`. Or *tous* les adaptateurs opérationnels (`extract_agent_adapter:153`, `informal_agent_adapter:138`, `pl_agent_adapter:166`, `rhetorical_tools_adapter:132`) lisent `task["text_extracts"]` pour construire ce qu'ils soumettent. Ils recevaient donc un placeholder. En amont, `TacticalState` n'avait **aucun champ** pour le corpus : le texte était posé sur `StrategicState.raw_text` puis abandonné à la frontière S→T.
2. **L'exécuteur passait `command["description"]`** — un libellé de tâche d'une trentaine de caractères — en `input_text` du provider. Les runs montraient `source_length: 28`, et l'agent répondait honnêtement « aucun texte fourni » pendant que la chaîne concluait au succès.

## Le fix — dans le sens de la conception existante

- `TacticalState` gagne `raw_text` + `set_raw_text`, **symétrique de `StrategicState.raw_text`** qui existait déjà un étage au-dessus. Ce n'est pas une nouvelle couche, c'est le câblage manquant.
- `DelegationOrchestrator.analyze` propage le texte S→T (il le tenait déjà en paramètre et le laissait tomber après le tier stratégique).
- `_determine_relevant_extracts` sert le corpus réel — et retourne `[]` plutôt qu'un extrait fabriqué quand il n'y en a pas.
- L'exécuteur prend son `input_text` dans `text_extracts` et **échoue bruyamment** en `reason="insufficient_input"` au lieu d'analyser un libellé.

## Visibilité du broadcast no-op (item reclassé ici depuis le DoD-2 de #1500)

Publier sur un topic sans abonné ne livrait rien alors que l'appelant récupérait un `message_id` — le `Message` construit dans `broadcast_objective` n'est **jamais** émis sur un canal. C'est désormais un WARNING.

Le compteur est calculé honnêtement : `publish()` ne retourne que les abonnés du topic, donc le fan-out C2 vers les `global_handlers` est compté aussi — **moins** le `_debug_message_handler` que le middleware s'enregistre à lui-même (`middleware.py:525`, via l'init paresseuse déclenchée par `publish`). Sans cette exclusion le compteur vaudrait toujours ≥ 1 et l'alerte serait éteinte pour toujours. C'est un garde-fou que le test « chemin sain » a attrapé en cours de route, pas une précaution théorique.

## Anti-pendule

- `_compute_decides` **non touché** (Track CA #1529) : le mensonge était en amont.
- `_formulate_conclusion` **non touché** : un mode muet serait faux dans l'autre sens.
- **Aucun abonné inventé** pour faire monter un compteur à 1 ; aucune émission de `message` ajoutée sur le canal (ce serait changer la sémantique de livraison hors périmètre).
- Aucune hiérarchie refondue.

## Vérification firsthand

Run délégation sur un corpus synthétique de **404 caractères** :

```
operational tasks: 5
  - task-obj-1-1: status=completed capability=fact_extraction      source_length=[404]
  - task-obj-1-2: status=completed capability=argument_parsing
  - task-obj-2-1: status=completed capability=fallacy_detection
  - task-obj-3-1: status=completed capability=propositional_logic
  - task-obj-4-1: status=completed capability=argument_quality
```

`source_length` **404 = longueur exacte du corpus** (contre 28 avant). 5/5 tâches via de vrais providers du registry.

Tests : `430 passed` sur `core/communication/`, `30 passed` sur la surface délégation + interface T→O, `4 passed` sur les gardes firsthand R648. `black` + `flake8` propres.

## ⚠ Ce que cette PR ne corrige PAS — et une correction de mon propre diagnostic

En vérifiant le résultat dans le harness, la ligne `hierarchical_delegation` affiche **toujours** `0.0% fill / 0 sophismes / 0 arguments / 0-0 phases` — alors que les 5 tâches s'exécutent bel et bien sur le corpus complet.

Ce n'est pas un reliquat de la famine : `run_hierarchical_delegation_mode` lit `result["summary"]` et `result["capabilities_used"]`, **deux clés que `DelegationOrchestrator.analyze` ne retourne pas** (il retourne `mode`, `objectives`, `tasks_created`, `operational_results`, `evaluation`, `conclusion`). Les compteurs à zéro sont donc des **champs non lus**, pas des mesures. Et `Decides ✅` vient de la simple présence de `conclusion`.

Donc mon constat de R709 — « `Decides ✅` sur 0 argument / 0 sophisme » — **confondait deux défauts** : une vraie famine de texte (corrigée ici, prouvée firsthand) et un trou de *reporting* côté harness (toujours là). Le mapping correct existe pourtant : `tasks_created` et le `status` de chaque `operational_results` portent l'information.

Ce second défaut vit dans `scripts/compare_orchestration_modes.py`, **lane sérialisée de po-2023** (CB #1528 puis chiffrage C3) — je n'y touche pas pour ne pas collisionner. Reporté sur #1531 et transmis à po-2023.

Refs #1531 #1500
