### PR TITLE
feat(harness): delegation depth-parity chiffrage + reader fold-in (Track C3 #1500, closes Epic)

### DIFF
--- a/docs/reports/ORCHESTRATION_MODE_DEPTH_PARITY.md
+++ b/docs/reports/ORCHESTRATION_MODE_DEPTH_PARITY.md
@@ -14,11 +14,13 @@ The 4 orchestration modes are **comparable in interface** (all produce a verdict
 | `pipeline_standard` | workflow phases (DAG) | 15 | breadth |
 | `pipeline_full` | workflow phases (DAG) | 17 | breadth |
 | `hierarchical_bridge` | strategic objectives (default axes) | 4 | delegation |
-| `hierarchical_delegation` | strategic objectives (LLM-derived) | variable | delegation (3-tier depth) |
+| `hierarchical_delegation` | strategic objectives (LLM-derived, measured) | 4–4 objectives → 5–5 tasks (n=3, corpus_A/B/C) | delegation (3-tier depth) |
 | `conversational` | dialogue macro-phases (multi-turn) | 3 | dialogue-depth |
 | `conversation_deterministic` | dialogue macro-phases (deterministic) | 3 | dialogue-depth (no LLM) |
 
 The pipeline breadth chiffres are **verified firsthand** by introspecting the real workflow builders (`build_light_workflow` / `build_standard_workflow` / `build_full_workflow` in [`argumentation_analysis/orchestration/workflows.py`](../../argumentation_analysis/orchestration/workflows.py)) — not hand-written constants. The hierarchical `4` is the documented M2-bridge default ([`delegation_orchestrator.py`](../../argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py) — "the M2 bridge would inject 4 default objectives"). The conversational `3` is the macro-phase count (informal → formal → synthesis).
+
+The `hierarchical_delegation` row is **not** a structural constant — its strategic tier is LLM-driven, so the objective/task count is a **firsthand-measured range** over ≥3 inputs (see [Delegation depth chiffrage](#delegation-depth-chiffrage-firsthand) below). It is injected into the deterministic render path as a constant + provenance (no LLM call at render time).
 
 ## Three depth dimensions, not one common scale
 
@@ -38,6 +40,20 @@ Two alignment strategies were considered and **rejected**:
 2. **Inflate hierarchical/conversational** to match pipeline's phase count (e.g. fabricate 15 "phases" inside the hierarchical chain). Rejected: this is exactly the theatre #1019 forbids — cosmetic phases that look comparable but do no genuine work (pendulum add).
 
 Both swings move the problem to the other extreme. The equilibrium is reached by **documenting the trade-off** (this doc + the `--depth-parity` report section), not by adding a counterweight.
+
+## Delegation depth chiffrage (firsthand)
+
+Unlike the pipeline's deterministic phase count (introspected statically), the delegation mode's strategic tier is **LLM-driven** — the objective/task count *could* vary per input. The chiffre is therefore a **measured range** over ≥3 benchmark corpora, not a structural constant. Firsthand R711 measurement (po-2023, env `projet-is`, post-CC #1531 corpus fix — so the operational tier received the real text):
+
+| Corpus | Objectives | Tasks | Completed | Failed | Success rate | Wall-time |
+|--------|-----------:|------:|----------:|-------:|-------------:|----------:|
+| `corpus_A` | 4 | 5 | 5 | 0 | 1.0 | 127.2s |
+| `corpus_B` | 4 | 5 | 5 | 0 | 1.0 | 109.5s |
+| `corpus_C` | 4 | 5 | 5 | 0 | 1.0 | 95.5s |
+
+**Result: a degenerate range `4–4` objectives → `5–5` tasks (n=3).** This is the honest finding, not a failed measurement: on these inputs the LLM-derived delegation tier goes **no deeper** than the 4 hardcoded bridge axes — it produced exactly them (obj-1 decomposes into 2 tasks, hence 5). The non-differentiation is itself the DoD-3 deliverable (the DoD allows "documented as a trade-off" over "aligned"). Written as the range `4–4` rather than the int `4` so a reader sees it is a *measured distribution* (that happens to be degenerate), not a structural constant disguised as a measurement.
+
+**Reader fold-in (coord R710 FINDING):** pre-C3, `run_hierarchical_delegation_mode` read `result["summary"]` and `result["capabilities_used"]` — two keys `DelegationOrchestrator.analyze` never emits — so the report line showed `0/0` phases and `0.0%` fill on a run where 5 tasks really executed. Those zeros were **unread fields, not measurements**. C3 reads the real keys (`tasks_created` → phase denominator; `operational_results[].status` → completed/failed numerator; `evaluation["overall_success_rate"]`), so the Phases column now reflects the work performed.
 
 ## Reproducing the chiffres
 

--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -285,9 +285,43 @@ class DepthParityRow:
     depth_count: int
     nature: str
     verdict_dimension: str
+    # C3 #1500: when the depth axis is LLM-derived (delegation), the count is a
+    # MEASURED RANGE over ≥3 inputs, not a structural constant. ``measured_range``
+    # carries the "min–max (n=K, provenance)" string rendered in place of a bare
+    # int. ``depth_count`` holds a representative int (max of range) so any
+    # downstream logic that reads the count still gets a usable value.
+    measured_range: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
+
+
+# C3 #1500 chiffrage — the delegation mode's strategic tier is LLM-driven, so
+# its objective/task count could in principle VARY per input (unlike the
+# pipeline's deterministic workflow phase count, which ``compute_depth_parity``
+# introspects statically). This constant holds the firsthand-MEASURED range over
+# ≥3 benchmark corpora. Injected as a constant + provenance so
+# ``render_depth_parity_section`` stays LLM-free at render time (coord R710
+# directive: inject a measured constant, do NOT call an LLM from the render
+# path). Re-measure after any change to the strategic/tactical tiers and update
+# the ranges; the depth-parity tests assert the SHAPE (a measured range with
+# provenance), not the exact digits.
+#
+# Firsthand result R711 (po-2023, env projet-is, post-CC #1531 corpus fix):
+# the range is DEGENERATE — all 3 corpora produced exactly 4 objectives
+# decomposed into 5 tasks (obj-1 splits into 2), 5/5 completed, rate 1.0. This
+# matches the coord's R709 datapoint and documents a NON-DIFFERENTIATION
+# finding: on these inputs the LLM-derived delegation tier goes NO DEEPER than
+# the 4 hardcoded bridge axes (it produced exactly them). Written as the range
+# ``4–4`` rather than the int ``4`` so a reader sees it is a measured
+# distribution (that happens to be degenerate), not a structural constant.
+DELEGATION_DEPTH_MEASURED = {
+    "objectives_range": "4–4",
+    "tasks_range": "5–5",
+    "n_runs": 3,
+    "inputs": "corpus_A/B/C",
+    "provenance": "firsthand R711, po-2023 projet-is",
+}
 
 
 def compute_depth_parity() -> List[DepthParityRow]:
@@ -334,10 +368,22 @@ def compute_depth_parity() -> List[DepthParityRow]:
     rows.append(
         DepthParityRow(
             mode="hierarchical_delegation",
-            depth_dimension="strategic objectives (LLM-derived)",
-            depth_count=0,  # variable: strategic tier produces N objectives per input
+            depth_dimension="strategic objectives (LLM-derived, measured)",
+            # Representative int (max of the measured objective range) so
+            # downstream logic reading depth_count gets a usable value; the
+            # honest per-input RANGE is carried by ``measured_range`` below.
+            depth_count=int(
+                DELEGATION_DEPTH_MEASURED["objectives_range"].split("–")[1]
+            ),
             nature="delegation (3-tier depth)",
             verdict_dimension="Strategic -> Tactical -> Operational chain",
+            measured_range=(
+                f"{DELEGATION_DEPTH_MEASURED['objectives_range']} objectives "
+                f"-> {DELEGATION_DEPTH_MEASURED['tasks_range']} tasks "
+                f"(n={DELEGATION_DEPTH_MEASURED['n_runs']}, "
+                f"{DELEGATION_DEPTH_MEASURED['inputs']}, "
+                f"{DELEGATION_DEPTH_MEASURED['provenance']})"
+            ),
         )
     )
     rows.append(
@@ -390,7 +436,12 @@ def render_depth_parity_section() -> str:
         "|------|-----------------|-------|--------|",
     ]
     for r in rows:
-        count = str(r.depth_count) if r.depth_count > 0 else "variable (LLM-derived)"
+        if r.measured_range:
+            count = r.measured_range
+        elif r.depth_count > 0:
+            count = str(r.depth_count)
+        else:
+            count = "variable (LLM-derived)"
         lines.append(f"| {r.mode} | {r.depth_dimension} | {count} | {r.nature} |")
     lines.append("")
     lines.append(_DEPTH_PARITY_TRADEOFF_VERDICT)
@@ -399,6 +450,36 @@ def render_depth_parity_section() -> str:
 
 
 # ── Mode runners ─────────────────────────────────────────────────────────
+
+
+def _planned_workflow_phase_count(workflow_name: str) -> int:
+    """C3 #1500: the PLANNED phase total for a workflow_name (deterministic).
+
+    Used at the pipeline budget-breach path so the Phases column reads
+    ``completed/planned`` (e.g. 8/15) instead of the nonsensical ``N/0`` the
+    pre-C3 breach path left. Same builders ``compute_depth_parity`` introspects
+    — read honestly, never fabricated. Returns 0 only if the builder is
+    unavailable (e.g. partial import), in which case the column falls back to
+    ``completed/0`` rather than inventing a number.
+    """
+    try:
+        from argumentation_analysis.orchestration.workflows import (
+            build_full_workflow,
+            build_light_workflow,
+            build_standard_workflow,
+        )
+
+        builders = {
+            "light": build_light_workflow,
+            "standard": build_standard_workflow,
+            "full": build_full_workflow,
+        }
+        builder = builders.get(workflow_name)
+        if builder is None:
+            return 0
+        return len(builder().phases)
+    except Exception:
+        return 0
 
 
 async def run_pipeline_mode(
@@ -487,6 +568,12 @@ async def run_pipeline_mode(
         non_empty = sum(
             1 for v in snapshot.values() if v and v not in ([], {}, "", None, 0)
         )
+        # C3 #1500 (coord R710 wart): set the PLANNED phase total at breach so
+        # the report's Phases column reads ``completed/planned`` (e.g. 8/15),
+        # not the nonsensical ``N/0`` left by the pre-C3 breach path. The
+        # planned total is deterministic for a given workflow_name (same builder
+        # ``compute_depth_parity`` introspects) — read honestly, not fabricated.
+        planned_total = _planned_workflow_phase_count(workflow_name)
         return ModeResult(
             mode=f"pipeline_{workflow_name}",
             corpus_id=corpus_id,
@@ -496,6 +583,7 @@ async def run_pipeline_mode(
             duration_seconds=round(duration, 2),
             state_fill_rate=round(non_empty / max(total_fields, 1), 3),
             phases_completed=last_completed[0],
+            phases_total=planned_total,
             # `decides` left None → _compute_decides in run_all. A partial
             # state (fill>0) or any completed phase ⇒ True (anti-#1019:
             # the partial state IS the verdict).
@@ -872,23 +960,50 @@ async def run_hierarchical_delegation_mode(
         )
     duration = time.time() - start
 
-    summary = result.get("summary", {}) if isinstance(result, dict) else {}
-    phases_completed = summary.get("completed", 0)
-    phases_total = summary.get("total", 0)
-    # Delegation mode DÉCIDE firsthand on hierarchical_fallacy (R648). Track CA
-    # #1529: `decides` is computed uniformly by run_all via `_compute_decides`
-    # — from phases_completed (above) and the stashed verdict artifact below.
+    # C3 #1500 fold-in (coord R710 FINDING): read the keys
+    # ``DelegationOrchestrator.analyze`` ACTUALLY emits (delegation_orchestrator.
+    # py:341-348) — ``objectives`` / ``tasks_created`` / ``operational_results``
+    # / ``evaluation`` / ``conclusion``. The previous reader read ``summary`` and
+    # ``capabilities_used``, two keys the mode NEVER emits, so the report line
+    # showed ``0/0`` phases + ``0.0%`` fill on a run where 5 tasks really
+    # executed. Those zeros were UNREAD FIELDS, not measurements. (Bridge mode
+    # IS correctly read — it emits ``summary`` via WorkflowExecutor,
+    # orchestrator.py:209.) Anti-pendule: the mode already has the data; we read
+    # it instead of fabricating a ``summary`` surface orchestrator-side.
+    objectives = result.get("objectives", []) if isinstance(result, dict) else []
+    tasks_created = result.get("tasks_created", 0) if isinstance(result, dict) else 0
+    operational_results = (
+        result.get("operational_results", []) if isinstance(result, dict) else []
+    )
+    evaluation = result.get("evaluation", {}) if isinstance(result, dict) else {}
+
+    # Phases column = the delegation depth axis DoD-3 asks for. Denominator =
+    # tactical task count (``tasks_created``); numerator = tasks that reached a
+    # completed state. Status values are ``completed`` / ``completed_with_issues``
+    # / ``failed`` (operational/adapters/rhetorical_tools_adapter.py:147 +
+    # delegation_orchestrator.py:213). ``completed_with_issues`` still produced
+    # output → counts as completed (anti-#1019: honest, not punitive).
+    def _count_status(results: List[Dict[str, Any]], prefix: str) -> int:
+        return sum(
+            1
+            for r in results
+            if isinstance(r, dict) and str(r.get("status", "")).startswith(prefix)
+        )
+
+    phases_total = tasks_created
+    phases_completed = _count_status(operational_results, "completed")
+    tasks_failed = _count_status(operational_results, "failed")
+
+    # Track CA #1529: ``decides`` is computed UNIFORMLY by run_all via
+    # ``_compute_decides``. Post-fold-in it keys on ``phases_completed > 0``
+    # (real completed operational tasks) — a genuine signal — in addition to
+    # the stashed verdict artifact (the strategic conclusion). NB (CC #1531):
+    # pre-CC-fix the conclusion was a false positive on starved input; post-CC
+    # (merged dd616d6f) the corpus reaches the operational tier, so the
+    # conclusion now reflects real work. ``_compute_decides`` is NOT touched.
     verdict_artifact = None
     if isinstance(result, dict):
-        verdict_artifact = (
-            result.get("conclusion")
-            or result.get("strategic_decision")
-            or (
-                "broadcasted_to_nonzero_agents"
-                if result.get("broadcasted_to_zero_agents") is False
-                else None
-            )
-        )
+        verdict_artifact = result.get("conclusion") or result.get("strategic_decision")
 
     return ModeResult(
         mode="hierarchical_delegation",
@@ -898,18 +1013,16 @@ async def run_hierarchical_delegation_mode(
         duration_seconds=round(duration, 2),
         phases_completed=phases_completed,
         phases_total=phases_total,
-        capabilities_used=(
-            result.get("capabilities_used", []) if isinstance(result, dict) else []
-        ),
-        scope_of_work=(
-            "Strategic -> Tactical -> Operational (3-tier, "
-            "5 tasks via CapabilityRegistry)"
-        ),
+        scope_of_work=scope,
         extra_metrics={
-            "objectives_count": (
-                len(result.get("objectives", [])) if isinstance(result, dict) else 0
-            ),
+            "objectives_count": len(objectives),
             "verdict_artifact": verdict_artifact,
+            # Honest signals (C3 #1500): the strategic tier's own evaluation of
+            # how much of the delegated work genuinely succeeded + the task
+            # status breakdown. Surfaced, not buried in a single 0/0.
+            "overall_success_rate": evaluation.get("overall_success_rate"),
+            "tasks_completed": phases_completed,
+            "tasks_failed": tasks_failed,
         },
     )
 

--- a/tests/scripts/test_compare_orchestration_modes_1480.py
+++ b/tests/scripts/test_compare_orchestration_modes_1480.py
@@ -958,5 +958,169 @@ class TestCBWallClockBudget1528:
         assert "| — |" in report
 
 
+class TestC3DelegationDepthParity1500:
+    """Track C3 #1500 — delegation depth-parity chiffrage + reader fold-in.
+
+    Two coupled fixes (coord R710 FINDING + DISPATCH):
+
+    * **Reader fold-in**: ``run_hierarchical_delegation_mode`` reads the keys
+      ``DelegationOrchestrator.analyze`` ACTUALLY emits (``tasks_created`` /
+      ``operational_results[].status`` / ``evaluation``), not the phantom
+      ``summary`` / ``capabilities_used`` (never emitted → the report line
+      showed ``0/0`` phases on a run where 5 tasks executed). Those zeros were
+      unread fields, not measurements.
+    * **Depth chiffrage**: the delegation depth axis is LLM-derived, so its
+      count is a MEASURED RANGE over ≥3 inputs (injected as a constant +
+      provenance, NOT an LLM call at render time).
+
+    Deterministic + LLM/JVM-free: the inner entry-point is patched with a fake
+    delegation result carrying the real return shape.
+    """
+
+    def _harness(self):
+        return _load_harness_module()
+
+    @staticmethod
+    def _fake_delegation_result():
+        """The real ``DelegationOrchestrator.analyze`` return shape (no
+        ``summary``, no ``capabilities_used`` — those are the phantom keys)."""
+        return {
+            "mode": "delegation",
+            "objectives": [
+                {"id": "obj-1"},
+                {"id": "obj-2"},
+                {"id": "obj-3"},
+                {"id": "obj-4"},
+            ],
+            "tasks_created": 5,
+            "operational_results": [
+                {
+                    "objective_id": "obj-1",
+                    "status": "completed",
+                    "outputs": {"arguments": ["a1"]},
+                },
+                {
+                    "objective_id": "obj-1",
+                    "status": "completed_with_issues",
+                    "outputs": {"fallacies": ["f1"]},
+                },
+                {"objective_id": "obj-2", "status": "completed", "outputs": {}},
+                {
+                    "objective_id": "obj-3",
+                    "status": "failed",
+                    "reason": "insufficient_input",
+                },
+                {"objective_id": "obj-4", "status": "completed", "outputs": {}},
+            ],
+            "evaluation": {"overall_success_rate": 0.8, "objectives_evaluated": 4},
+            "conclusion": "Analyse réussie.",
+        }
+
+    def test_delegation_reader_reads_real_keys(self) -> None:
+        """The reader maps ``tasks_created`` -> phases_total and counts
+        ``operational_results[].status`` -> phases_completed. A ``summary``
+        key is absent from the input; the counts must still be correct
+        (proving we do not rely on the phantom key)."""
+        mod = self._harness()
+        fake = self._fake_delegation_result()
+
+        async def fake_analyze(**kwargs):
+            return fake
+
+        async def _drive():
+            with patch(
+                "argumentation_analysis.orchestration.hierarchical.orchestrator"
+                ".run_hierarchical_analysis",
+                side_effect=fake_analyze,
+            ), patch(
+                "argumentation_analysis.orchestration.registry_setup" ".setup_registry",
+                return_value=None,
+            ):
+                return await mod.run_hierarchical_delegation_mode(
+                    "text", "corpus_A", max_wall_seconds=None
+                )
+
+        r = asyncio.run(_drive())
+        # phases_total <- tasks_created (5), NOT summary.total (absent).
+        assert r.phases_total == 5
+        # 4 completed (3 "completed" + 1 "completed_with_issues"), 1 failed.
+        assert r.phases_completed == 4
+        assert r.extra_metrics["tasks_failed"] == 1
+        # objectives_count is the DoD-3 depth axis (strategic tier).
+        assert r.extra_metrics["objectives_count"] == 4
+        # Honest evaluation signal surfaced, not buried.
+        assert r.extra_metrics["overall_success_rate"] == 0.8
+        # The verdict artifact (conclusion) is stashed for _compute_decides.
+        assert r.extra_metrics["verdict_artifact"] == "Analyse réussie."
+
+    def test_delegation_decides_from_real_completed_tasks(self) -> None:
+        """Post-fold-in, ``decides`` keys on ``phases_completed > 0`` (real
+        completed operational tasks), not just the conclusion. A run with
+        completed tasks decides True even before run_all normalizes it."""
+        mod = self._harness()
+        fake = self._fake_delegation_result()
+
+        async def fake_analyze(**kwargs):
+            return fake
+
+        async def _drive():
+            with patch(
+                "argumentation_analysis.orchestration.hierarchical.orchestrator"
+                ".run_hierarchical_analysis",
+                side_effect=fake_analyze,
+            ), patch(
+                "argumentation_analysis.orchestration.registry_setup" ".setup_registry",
+                return_value=None,
+            ):
+                return await mod.run_hierarchical_delegation_mode("text", "corpus_A")
+
+        r = asyncio.run(_drive())
+        # Direct runner call leaves decides=None (run_all computes it); verify
+        # via the uniform helper that the real signals => True.
+        assert r.decides is None
+        assert mod._compute_decides(r) is True
+
+    def test_depth_parity_delegation_row_carries_measured_range(self) -> None:
+        """The delegation depth-parity row carries a MEASURED RANGE with
+        provenance (not the old ``variable (LLM-derived)`` placeholder)."""
+        mod = self._harness()
+        rows = mod.compute_depth_parity()
+        delegation = next(r for r in rows if r.mode == "hierarchical_delegation")
+        assert delegation.measured_range is not None, (
+            "C3 regression: delegation row has no measured_range — the depth "
+            "axis must be a firsthand-measured range, not 'variable'."
+        )
+        # Provenance: range + n= + inputs, so a reader can audit the measure.
+        assert "objectives" in delegation.measured_range
+        assert "tasks" in delegation.measured_range
+        assert "n=" in delegation.measured_range
+        # depth_count is a usable int (max of the objective range).
+        assert delegation.depth_count > 0
+
+    def test_depth_parity_render_shows_range_not_variable(self) -> None:
+        """The rendered section shows the measured range, NOT the stale
+        ``variable (LLM-derived)`` string — and does so WITHOUT calling an
+        LLM (deterministic render from the injected constant)."""
+        mod = self._harness()
+        section = mod.render_depth_parity_section()
+        assert "variable (LLM-derived)" not in section, (
+            "C3 regression: the delegation cell still renders 'variable' — the "
+            "measured range must replace it."
+        )
+        delegation_line = next(
+            ln for ln in section.splitlines() if "hierarchical_delegation" in ln
+        )
+        assert "objectives" in delegation_line
+        assert "n=" in delegation_line
+
+    def test_depth_parity_render_is_deterministic(self) -> None:
+        """The render path is LLM-free — two calls produce identical output
+        (regression guard against accidental LLM/IO in the render)."""
+        mod = self._harness()
+        a = mod.render_depth_parity_section()
+        b = mod.render_depth_parity_section()
+        assert a == b
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Track C3 #1500 — delegation depth-parity chiffrage + reader fold-in (closes Epic #1500 DoD-3)

Coord R710 DISPATCH. Closes the **last blocker** of Epic #1500: the only non-chiffred cell of the depth-parity table was `hierarchical_delegation | variable`. The delegation mode's strategic tier is LLM-driven, so its objective/task count is a **measured range** over ≥3 inputs, not a structural constant. `variable` was not a chiffre.

### Two coupled fixes (coord R710 FINDING + DISPATCH)

**1. Reader fold-in** — `run_hierarchical_delegation_mode` read `result["summary"]` and `result["capabilities_used"]` — **two keys `DelegationOrchestrator.analyze` never emits** ([delegation_orchestrator.py:341-348](../blob/main/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py)). So the report line showed `0/0` phases + `0.0%` fill on a run where 5 tasks really executed. **Those zeros were unread fields, not measurements.** (Bridge IS correctly read — it emits `summary` via WorkflowExecutor, orchestrator.py:209.) Now reads the real keys:

| Field | Source key | Maps to |
|---|---|---|
| `phases_total` | `tasks_created` | tactical task count (the delegation depth axis) |
| `phases_completed` | `operational_results[].status` ∈ {`completed`, `completed_with_issues`} | tasks that reached a completed state |
| `tasks_failed` | `operational_results[].status` == `failed` | surfaced honestly |
| `overall_success_rate` | `evaluation["overall_success_rate"]` | strategic tier's own eval |

**Anti-pendule:** the mode already has the data; we read it instead of fabricating a `summary` surface orchestrator-side. Bridge reader untouched (correct as-is).

**2. Depth chiffrage** — firsthand-measured delegation depth on corpus_A/B/C (post-CC #1531 corpus fix, so the operational tier received the real text — `source_length=404` on a 404-char corpus, vs 28 before):

| Corpus | Objectives | Tasks | Completed | Failed | Rate | Wall-time |
|--------|-----------:|------:|----------:|-------:|-----:|----------:|
| `corpus_A` | 4 | 5 | 5 | 0 | 1.0 | 127.2s |
| `corpus_B` | 4 | 5 | 5 | 0 | 1.0 | 109.5s |
| `corpus_C` | 4 | 5 | 5 | 0 | 1.0 | 95.5s |

**Result: a degenerate range `4–4` objectives → `5–5` tasks (n=3).** This is the honest DoD-3 deliverable — a **non-differentiation finding**: on these inputs the LLM-derived delegation tier goes **no deeper** than the 4 hardcoded bridge axes (it produced exactly them; obj-1 decomposed into 2 tasks). Matches the coord's R709 datapoint. Written as the **range** `4–4` rather than the int `4` so a reader sees it is a *measured distribution* (that happens to be degenerate), not a structural constant disguised as a measurement.

Injected as a constant + provenance in `compute_depth_parity()` (`DELEGATION_DEPTH_MEASURED`), so `render_depth_parity_section()` stays **LLM-free at render** (coord R710 directive: inject a measured constant, do not call an LLM from the render path).

### Cosmetic fold-in (coord R710 wart, same file)

The pipeline budget-breach path left `phases_total` unset → the report read `N/0` (nonsensical fraction). Now sets the **planned** total via `_planned_workflow_phase_count()` (deterministic — same builders `compute_depth_parity` introspects) so it reads `completed/planned` (e.g. `8/15`).

### Anti-pendule

- `_compute_decides` (CA #1529) **untouched** — post-fold-in it keys on `phases_completed > 0` (real completed operational tasks) in addition to the stashed conclusion.
- C1 safety-net **untouched**. Hierarchical_bridge reader **untouched** (correct as-is).
- Degenerate range written honestly — **not** "fixed" to look more interesting by hunting for an input that moves the digit.

### Tests (deterministic, LLM/JVM-free) — 38 green on po-2023

5 new in `TestC3DelegationDepthParity1500`: reader reads real keys (`tasks_created`→phases, statuses→completed/failed, `overall_success_rate` surfaced); `decides` from real completed tasks; depth-parity delegation row carries `measured_range` + provenance; render shows range not `variable`; render is deterministic (no LLM/IO). 33 CA/CB/BO-4 unchanged + green; sibling file 6 green.

`black` clean, `py_compile` clean (`projet-is`, `--disable-jvm-session`).

### Privacy

Synthetic harness corpus (`corpus_A/B/C`), opaque IDs, zero encrypted corpus, zero `raw_text`.

### Files changed

| File | Type | Role |
|---|---|---|
| `scripts/compare_orchestration_modes.py` | feat (harness) | Delegation reader fold-in (real keys) + `DELEGATION_DEPTH_MEASURED` + `_planned_workflow_phase_count` (breach wart) |
| `docs/reports/ORCHESTRATION_MODE_DEPTH_PARITY.md` | docs | Measured range cell + firsthand chiffrage table + reader fold-in note |
| `tests/scripts/test_compare_orchestration_modes_1480.py` | test | 5 new C3 tests (key-mapping + measured-range render) |

Refs: coord R710 (FINDING + DISPATCH C3) · #1500 (Epic, DoD-3 — this closes it) · CC #1531 (corpus fix, makes the measure non-degenerate in content) · CB #1528 / CA #1529 (intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
