### PR TITLE
fix(orchestration): make conversational AgentGroupChat actually construct (#1534)

### DIFF
--- a/argumentation_analysis/core/strategies.py
+++ b/argumentation_analysis/core/strategies.py
@@ -1,5 +1,6 @@
 ﻿# core/strategies.py
-# CORRECTIF COMPATIBILITÉ: Utilisation du module de compatibilité
+# CD #1534: inherit the REAL Semantic Kernel strategy bases so our strategy
+# instances are accepted by AgentGroupChat's Pydantic validator.
 from semantic_kernel.contents import ChatMessageContent
 
 # from semantic_kernel.contents import AuthorRole
@@ -7,15 +8,28 @@ from semantic_kernel.contents import ChatMessageContent
 from typing import List, Dict, TYPE_CHECKING, Optional  # Ajout de Optional
 import logging
 from pydantic import PrivateAttr
-from argumentation_analysis.orchestration.base import (
+
+# CD #1534 (anti-#1019): AgentGroupChat.selection_strategy is type-annotated to
+# SK's SelectionStrategy, so its Pydantic validator (model_type) only accepts
+# real SK subclasses. The previous import pointed at
+# argumentation_analysis.orchestration.base, whose SelectionStrategy /
+# TerminationStrategy are a LOCAL BaseModel+ABC stub with no link to SK — so SK
+# silently rejected our instances and the conversational mode fell back to
+# round-robin forever (the failure was logged as a WARNING, then masked).
+# SK's bases expose the SAME abstract signatures as the stub —
+#   SelectionStrategy.next(self, agents, history) -> Agent
+#   TerminationStrategy.should_terminate(self, agent, history) -> bool
+# — verified firsthand on SK 1.34.0 — so no method-body change is required, only
+# the base class. The cluedo strategies (CyclicSelectionStrategy /
+# OracleTerminationStrategy in orchestration/strategies.py) still use the local
+# stub; they are never passed to AgentGroupChat and are deliberately left
+# untouched (anti-pendule: the stub has other consumers).
+from semantic_kernel.agents.strategies.selection.selection_strategy import (
     SelectionStrategy,
+)
+from semantic_kernel.agents.strategies.termination.termination_strategy import (
     TerminationStrategy,
 )
-
-# L'import de 'argumentation_analysis.orchestration.base.SelectionStrategy' et
-# 'argumentation_analysis.orchestration.base.TerminationStrategy' est omis
-# car ces noms sont maintenant fournis par 'argumentation_analysis.utils.semantic_kernel_compatibility'.
-# Les classes de stratégies ci-dessous hériteront donc des versions du module de compatibilité.
 
 # Importer la classe d'état
 from .shared_state import RhetoricalAnalysisState

--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -1779,6 +1779,9 @@ async def _run_phase(
 
     # Try SK native AgentGroupChat first
     try:
+        _chat_constructed = (
+            False  # CD #1534: distinguish construction vs invoke failure
+        )
         from semantic_kernel.agents.group_chat.agent_group_chat import (
             AgentGroupChat,
         )
@@ -1800,10 +1803,24 @@ async def _run_phase(
                     "DelegatingSelectionStrategy unavailable, using SK default selection"
                 )
 
+        # CD #1534 (anti-#1019): a failure on the AgentGroupChat path must be
+        # VISIBLE, never silent. Pre-CD, a construction failure logged WARNING
+        # and silently delivered round-robin — the mode advertised AgentGroupChat
+        # and shipped something else (the #1019 "fake success" failure).
+        # _chat_constructed distinguishes a construction failure (ERROR — the mode
+        # is fundamentally broken) from a runtime invoke error (WARNING — mid-
+        # execution degrade); both fall back to round-robin so a transient error
+        # does not abort the phase. A hard raise on construction failure was
+        # considered but rejected: it breaks the merged C1 contract
+        # (test_deadline_in_past_breaks_before_first_turn injects a raising
+        # AgentGroupChat to force round-robin) — migrating it is scope-creep
+        # beyond CD #1534. ERROR (not WARNING) makes a construction regression
+        # surface in log monitoring; that is the "loud" DoD #3 requires.
         chat = AgentGroupChat(
             agents=agents,
             selection_strategy=selection,
         )
+        _chat_constructed = True
         # Add initial prompt to the group chat
         await chat.add_chat_message(
             chat_history.messages[-1] if chat_history.messages else initial_prompt
@@ -1812,7 +1829,6 @@ async def _run_phase(
         async for response in chat.invoke():
             _bump_sk_budget()
             turn += 1
-            fp_before = _get_growth_fingerprint(state)
             msg_entry = {
                 "phase": phase_name,
                 "turn": turn,
@@ -1844,61 +1860,19 @@ async def _run_phase(
                 )
                 break
 
-            # Growth validation hook (AgentGroupChat path)
-            if enable_growth_validation:
-                fp_after = _get_growth_fingerprint(state)
-                if not _validate_state_growth(fp_before, fp_after, phase_name):
-                    for rp in range(growth_re_prompt_limit):
-                        logger.info(
-                            f"  [{phase_name}] Growth re-prompt {rp + 1}/{growth_re_prompt_limit}"
-                        )
-                        await chat.add_chat_message(_RE_PROMPT_FEEDBACK)
-                        async for rp_response in chat.invoke():
-                            _bump_sk_budget()
-                            msg_entry = {
-                                "phase": phase_name,
-                                "turn": turn,
-                                "agent": getattr(
-                                    rp_response,
-                                    "name",
-                                    getattr(rp_response, "role", "?"),
-                                ),
-                                "content": str(
-                                    getattr(rp_response, "content", rp_response)
-                                ),
-                                "re_prompt": rp + 1,
-                            }
-                            messages.append(msg_entry)
-                            total_re_prompts += 1
-                        fp_after = _get_growth_fingerprint(state)
-                        # Record re-prompt trace (#609)
-                        if reprompt_extractor is not None:
-                            rp_outcome = (
-                                "ok"
-                                if _validate_state_growth(
-                                    fp_before, fp_after, phase_name
-                                )
-                                else (
-                                    "reran"
-                                    if rp + 1 < growth_re_prompt_limit
-                                    else "gave_up"
-                                )
-                            )
-                            reprompt_extractor.record(
-                                phase_name=phase_name,
-                                turn=turn,
-                                attempt_idx=rp + 1,
-                                fingerprint_before=fp_before,
-                                fingerprint_after=fp_after,
-                                outcome=rp_outcome,
-                                agent_name=getattr(
-                                    rp_response,
-                                    "name",
-                                    getattr(rp_response, "role", "?"),
-                                ),
-                            )
-                        if _validate_state_growth(fp_before, fp_after, phase_name):
-                            break
+            # CD #1534: the growth-validation re-prompt is INTENTIONALLY ABSENT
+            # on the AgentGroupChat path (it lives only on the round-robin path
+            # below). SK's AgentChat._is_active flag
+            # (semantic_kernel/agents/group_chat/agent_chat.py:41-46) forbids
+            # chat.add_chat_message() and a nested chat.invoke() while the outer
+            # chat.invoke() generator is suspended — doing either inside this
+            # loop raised "Unable to proceed while another agent is active."
+            # That bug was masked pre-CD (construction failed -> round-robin
+            # fallback, which never touched chat.invoke). Re-prompting an agent
+            # mid-group-chat would require agent.invoke(chat.history) directly
+            # (bypassing _is_active); that is a #597 follow-up, deliberately out
+            # of scope here. The group chat's own selection + termination
+            # strategies already drive multi-turn progression.
 
         if total_re_prompts > 0:
             messages.append(
@@ -1912,11 +1886,24 @@ async def _run_phase(
         return messages
 
     except ImportError:
+        # SK not installed in this environment — round-robin is the legitimate
+        # degraded path (not a masked failure). INFO, not WARNING.
         logger.info("SK AgentGroupChat not importable, using round-robin fallback")
     except Exception as e:
-        logger.warning(
-            f"SK AgentGroupChat failed ({type(e).__name__}: {e}), using round-robin fallback"
-        )
+        # CD #1534 (anti-#1019): construction failure is LOUD (ERROR), runtime
+        # invoke error is a degrade (WARNING); both fall back to round-robin so
+        # a transient error does not abort the phase. See the pre-construction
+        # comment above for the raise-vs-log rationale.
+        if not _chat_constructed:
+            logger.error(
+                f"SK AgentGroupChat CONSTRUCTION failed ({type(e).__name__}: {e}); "
+                f"falling back to round-robin but surfacing LOUD (anti-#1019, CD #1534)."
+            )
+        else:
+            logger.warning(
+                f"SK AgentGroupChat runtime error ({type(e).__name__}: {e}), "
+                f"using round-robin fallback"
+            )
 
     # Fallback: round-robin invocation with PM designation support
     # In SK 1.40, ChatCompletionAgent.invoke() returns an AsyncGenerator

--- a/tests/unit/argumentation_analysis/test_strategies_real.py
+++ b/tests/unit/argumentation_analysis/test_strategies_real.py
@@ -327,3 +327,141 @@ class TestRealStrategiesIntegration:
         assert turn == 8, "La conversation doit se terminer exactement au 8ème tour"
 
         print("[OK] INTÉGRATION COMPLÈTE : Toutes les stratégies fonctionnent ensemble")
+
+
+class TestCD1534AgentGroupChatConstruction:
+    """CD #1534 — AgentGroupChat must ACCEPT our strategy instances.
+
+    Pre-CD #1534, core/strategies.py imported SelectionStrategy/TerminationStrategy
+    from the LOCAL orchestration.base stub (BaseModel+ABC), not from Semantic Kernel.
+    AgentGroupChat.selection_strategy is type-annotated to SK's SelectionStrategy, so
+    Pydantic's model_type validator rejected our instances -> the conversational mode
+    caught the ValidationError, logged a WARNING, and silently fell back to round-robin
+    forever (anti-#1019 violation: a construction failure disguised as a working mode).
+
+    These tests lock the fix: our strategies MUST be real SK subclasses so
+    AgentGroupChat construction succeeds. If a future change re-points the import at
+    a non-SK base, these tests fail LOUD instead of the mode silently degrading.
+    """
+
+    def test_delegating_selection_is_real_sk_selection(
+        self, delegating_selection_fixture
+    ):
+        """DelegatingSelectionStrategy must inherit SK's real SelectionStrategy."""
+        from semantic_kernel.agents.strategies.selection.selection_strategy import (
+            SelectionStrategy as SKSelection,
+        )
+
+        strategy = delegating_selection_fixture["strategy"]
+        assert isinstance(
+            strategy, SKSelection
+        ), "DelegatingSelectionStrategy must be a real SK SelectionStrategy (CD #1534)"
+
+    def test_simple_termination_is_real_sk_termination(
+        self, simple_termination_fixture
+    ):
+        """SimpleTerminationStrategy must inherit SK's real TerminationStrategy."""
+        from semantic_kernel.agents.strategies.termination.termination_strategy import (
+            TerminationStrategy as SKTermination,
+        )
+
+        assert isinstance(
+            simple_termination_fixture["strategy"], SKTermination
+        ), "SimpleTerminationStrategy must be a real SK TerminationStrategy (CD #1534)"
+
+    def test_agent_group_chat_accepts_our_selection_strategy(
+        self, delegating_selection_fixture
+    ):
+        """AgentGroupChat(selection_strategy=<our instance>) must construct.
+
+        This is the exact gate that failed pre-CD #1534 (model_type ValidationError).
+        Empty agents list: we validate only the selection_strategy field, which is
+        the field that rejected our stub-subclass.
+        """
+        from semantic_kernel.agents.group_chat.agent_group_chat import AgentGroupChat
+
+        strategy = delegating_selection_fixture["strategy"]
+        # Must NOT raise. Pre-CD #1534 this raised:
+        #   ValidationError: Input should be a valid dictionary or instance of SelectionStrategy
+        chat = AgentGroupChat(agents=[], selection_strategy=strategy)
+        assert chat is not None
+        print("[OK] AgentGroupChat accepte DelegatingSelectionStrategy (CD #1534)")
+
+    def test_agent_group_chat_rejects_stub_subclass(self):
+        """Regression guard: a non-SK subclass is still rejected.
+
+        Ensures the gate is real (not accidentally widened) — a stub BaseModel+ABC
+        subclass must STILL be rejected by AgentGroupChat's validator.
+        """
+        from abc import ABC
+        from pydantic import BaseModel
+        from semantic_kernel.agents.group_chat.agent_group_chat import AgentGroupChat
+
+        class StubSelection(BaseModel, ABC):
+            class Config:
+                arbitrary_types_allowed = True
+
+        class FakeStubStrategy(StubSelection):
+            async def next(self, agents, history):
+                return agents[0] if agents else None
+
+        with pytest.raises(Exception):
+            AgentGroupChat(agents=[], selection_strategy=FakeStubStrategy())
+
+    def test_run_phase_logs_loud_on_construction_failure(self, caplog):
+        """CD #1534 DoD #3: a construction failure must surface as an ERROR log
+        (loud), NOT a silent WARNING. We inject a raising AgentGroupChat at its
+        source; _run_phase must emit an ERROR naming the construction failure
+        (anti-#1019). It may still fall back to round-robin (preserving the
+        merged C1 contract that injects a failing AgentGroupChat to force the
+        round-robin path), but the ERROR must be visible — that visibility is
+        the "loud" of DoD #3. A hard raise was rejected as scope-creep.
+        """
+        import logging
+        from unittest.mock import MagicMock, patch
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_phase,
+        )
+
+        fake_agent = MagicMock()
+        fake_agent.name = "FakeAgent"
+        fake_state = MagicMock()
+
+        async def run():
+            await _run_phase(
+                [fake_agent],
+                "CD #1534 loud-failure probe",
+                max_turns=1,
+                phase_name="Extraction & Detection",
+                state=fake_state,
+                enable_growth_validation=False,
+            )
+
+        # Patch AgentGroupChat AT ITS SOURCE so the local
+        # `from ...agent_group_chat import AgentGroupChat` in _run_phase resolves
+        # to a mock whose construction raises. This is the construction-failure
+        # path that must surface LOUD (ERROR), not silently fall back.
+        with patch(
+            "semantic_kernel.agents.group_chat.agent_group_chat.AgentGroupChat",
+            side_effect=RuntimeError("construction boom (CD #1534 test)"),
+        ):
+            with caplog.at_level(
+                logging.ERROR,
+                logger="argumentation_analysis.orchestration.conversational_orchestrator",
+            ):
+                try:
+                    asyncio.run(run())
+                except Exception:
+                    # The round-robin fallback may itself raise on the MagicMock
+                    # agent (no real invoke/get_response) — that is orthogonal to
+                    # the construction-failure ERROR we assert here. We care only
+                    # that the ERROR was emitted BEFORE the fallback ran.
+                    pass
+
+        error_msgs = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any(
+            "CONSTRUCTION failed" in m and "CD #1534" in m for m in error_msgs
+        ), f"Expected ERROR log naming construction failure, got: {error_msgs}"
+        print(
+            "[OK] _run_phase logs ERROR loud on construction failure (CD #1534 DoD #3)"
+        )


### PR DESCRIPTION
Closes #1534

## Root cause (verified firsthand, not re-diagnosed)

The conversational mode advertised SK's `AgentGroupChat` but silently delivered round-robin. `argumentation_analysis/core/strategies.py` imported `SelectionStrategy` / `TerminationStrategy` from the **local** `orchestration.base` stub (`BaseModel` + `ABC`), not from Semantic Kernel. `AgentGroupChat.selection_strategy` is a Pydantic `model_type`-validated field bound to SK's `SelectionStrategy`, so it **rejected** our stub-subclass instances with a `ValidationError`. The construction failure was caught in `conversational_orchestrator._run_phase`, logged at **WARNING**, and the mode fell back to round-robin indefinitely — the **#1019 "fake success" failure** (a broken mode disguised as a working one).

Coord R710 verified the causal chain; this PR implements the fix without re-diagnosing.

## Fixes (anti-pendule: subtract, don't counterweight)

**1. `core/strategies.py` — re-point the import at SK's real bases.** SK 1.34.0 signatures are identical to the local stub (abstract methods empty), so this is a **base-class swap only** — no method-body change. The lying comment claiming the stub was necessary is replaced with an accurate explanation. **Cluedo strategies (`CyclicSelectionStrategy`, `OracleTerminationStrategy`) stay on the local stub** — they are never passed to `AgentGroupChat`, so touching them is out of scope (DoD #4).

**2. `conversational_orchestrator.py` — remove the untested growth re-prompt on the `AgentGroupChat` path.** That block did `chat.add_chat_message()` + a nested `invoke()` inside the `async for response in chat.invoke():` loop, which violates SK's `AgentChat._is_active` constraint (`agent_chat.py:41-46`) and raised `"Unable to proceed while another agent is active."` The bug was **masked pre-CD** by the round-robin fallback. The growth re-prompt now lives **only** on the round-robin path; re-prompting an agent mid-group-chat would require `agent.invoke(chat.history)` directly and is a #597 follow-up, deliberately out of scope.

**3. `conversational_orchestrator.py` — make a construction failure LOUD (anti-#1019, DoD #3).** `_chat_constructed` distinguishes a **construction** failure (ERROR — the mode is fundamentally broken) from a **runtime invoke** error (WARNING — mid-execution degrade). A hard `raise` on construction was **considered but rejected as scope-creep**: it breaks the merged C1 contract (`test_deadline_in_past_breaks_before_first_turn` injects a raising `AgentGroupChat` to force round-robin). **ERROR (not WARNING)** makes a construction regression surface in log monitoring; that visibility is the "loud" DoD #3 requires. Migrating to a hard raise is a coord-décidé follow-up.

## DoD checklist (all verified firsthand)

- [x] **#1 — `AgentGroupChat` constructs.** 5 new tests in `TestCD1534AgentGroupChatConstruction`: `isinstance(SK base)` for both strategies + `AgentGroupChat(agents=[], selection_strategy=<ours>)` constructs + regression guard (a non-SK stub-subclass is still rejected by the validator).
- [x] **#2 — `--modes conversational` completes cleanly.** Real multi-phase run (Turns 1-5 + Phase 2 multi-agent) exits at the C1 wall-clock deadline, no `_is_active` crash after the growth-path removal.
- [x] **#3 — construction failure is LOUD, not silent.** `test_run_phase_logs_loud_on_construction_failure` (caplog) injects a raising `AgentGroupChat` at its source and asserts an ERROR-level log naming the construction failure. Pre-CD this was a silent WARNING.
- [x] **#4 — no cluedo / cyclic / oracle regression.** Cluedo strategies untouched (local stub); `test_groupchat_turn_strategy` green.
- [x] **#5 — lying comment fixed.** `core/strategies.py:15-18` replaced with an accurate explanation of stub-vs-SK.

## Test results

```
tests/unit/argumentation_analysis/test_strategies_real.py            (DoD #1, #3)
tests/unit/argumentation_analysis/orchestration/test_conversational_wall_clock_c1.py  (C1 contract — Fix 2)
tests/unit/argumentation_analysis/orchestration/test_growth_validation_hook_597.py    (growth — Fix 3)
tests/unit/argumentation_analysis/orchestration/test_groupchat_turn_strategy.py       (cluedo — DoD #4)
tests/unit/argumentation_analysis/orchestration/test_conversational_orchestrator.py   (DoD #2)
tests/unit/argumentation_analysis/orchestration/test_conversational_executor.py
tests/unit/argumentation_analysis/orchestration/test_conversational_sk_budget.py
→ 160 passed total, black clean.
```

## Anti-pendule / scope notes

- Did **not** entrench round-robin by deleting the `AgentGroupChat` attempt — it is now the real primary path.
- Did **not** just muzzle the warning — construction failure is now ERROR (visible), not WARNING (silent).
- Did **not** re-point the import blindly — verified SK 1.34.0 signatures identical to the stub, and audited all consumers (`CyclicSelectionStrategy`, `OracleTerminationStrategy`, `orchestration/strategies.py`, `cluedo_orchestrator.py`) before touching only `core/strategies.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
