### PR TITLE
feat(orchestration): re-establish growth validation on AgentGroupChat path (Track CF #1538)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -1765,6 +1765,25 @@ def _select_next_agent(
     return agents[turn % len(agents)]
 
 
+def _find_agent_by_name(
+    agents: List["ChatCompletionAgent"], name: Optional[str]
+) -> Optional["ChatCompletionAgent"]:
+    """CF #1538: locate the agent that just spoke in an AgentGroupChat turn.
+
+    ``AgentGroupChat.invoke()`` yields ``ChatMessageContent`` whose ``.name``
+    identifies the speaking agent; this looks it up in the phase's ``agents``
+    list so the growth re-prompt targets the agent that produced the
+    zero-growth turn (not a round-robin pick). Returns None if the name is
+    missing/unknown — the caller skips the re-prompt (safe no-op).
+    """
+    if not name:
+        return None
+    for agent in agents:
+        if getattr(agent, "name", None) == name:
+            return agent
+    return None
+
+
 async def _run_phase(
     agents: List[ChatCompletionAgent],
     initial_prompt: str,
@@ -1863,6 +1882,10 @@ async def _run_phase(
             chat_history.messages[-1] if chat_history.messages else initial_prompt
         )
         turn = 0
+        # CF #1538: baseline the growth fingerprint before the first group-chat
+        # turn; each turn's delta is measured against the previous turn's state
+        # (mirrors the round-robin path's fp_before/fp_after pattern).
+        fp_before_tour = _get_growth_fingerprint(state)
         async for response in chat.invoke():
             _bump_sk_budget()
             turn += 1
@@ -1897,19 +1920,95 @@ async def _run_phase(
                 )
                 break
 
-            # CD #1534: the growth-validation re-prompt is INTENTIONALLY ABSENT
-            # on the AgentGroupChat path (it lives only on the round-robin path
-            # below). SK's AgentChat._is_active flag
-            # (semantic_kernel/agents/group_chat/agent_chat.py:41-46) forbids
-            # chat.add_chat_message() and a nested chat.invoke() while the outer
-            # chat.invoke() generator is suspended — doing either inside this
-            # loop raised "Unable to proceed while another agent is active."
-            # That bug was masked pre-CD (construction failed -> round-robin
-            # fallback, which never touched chat.invoke). Re-prompting an agent
-            # mid-group-chat would require agent.invoke(chat.history) directly
-            # (bypassing _is_active); that is a #597 follow-up, deliberately out
-            # of scope here. The group chat's own selection + termination
-            # strategies already drive multi-turn progression.
+            # CF #1538: growth validation on the AgentGroupChat path. CD #1534
+            # removed the previous block because it used chat.add_chat_message()
+            # + a nested chat.invoke() — both forbidden while AgentChat._is_active
+            # is set (agent_chat.py:41-46, "Unable to proceed while another agent
+            # is active."). CF #1538 re-establishes the validation by invoking
+            # the SPEAKING AGENT directly via agent.invoke(), which is a
+            # ChatCompletionAgent method and never touches AgentChat._is_active
+            # (the flag lives on the chat, not the agent — verified firsthand).
+            # The group-chat's own history is NOT mutated: a deep copy
+            # (chat.history.model_copy(deep=True)) + the re-prompt feedback is
+            # passed, so the selection/termination strategies read an undisturbed
+            # history. Mirrors the round-robin enable_growth_validation block,
+            # including the #609 reprompt_extractor trace. Placed after the
+            # convergence/max_turns/deadline breaks so a turn that is already
+            # exiting does not spend re-prompt budget.
+            fp_after = _get_growth_fingerprint(state)
+            if enable_growth_validation and not _validate_state_growth(
+                fp_before_tour, fp_after, phase_name
+            ):
+                speaking_agent = _find_agent_by_name(agents, msg_entry["agent"])
+                if speaking_agent is not None:
+                    for rp in range(growth_re_prompt_limit):
+                        logger.info(
+                            f"  [{phase_name}] Growth re-prompt {rp + 1}/"
+                            f"{growth_re_prompt_limit} (group-chat path)"
+                        )
+                        # Deep copy: isolate the group-chat history so neither
+                        # the feedback nor the agent response mutates it
+                        # (chat.add_chat_message is forbidden here, and a direct
+                        # mutation would desync selection/termination).
+                        re_history = chat.history.model_copy(deep=True)
+                        re_history.add_user_message(_RE_PROMPT_FEEDBACK)
+                        rp_content = ""
+                        _bump_sk_budget()
+                        try:
+                            async for rp_response in speaking_agent.invoke(re_history):
+                                if hasattr(rp_response, "content"):
+                                    chunk = str(rp_response.content)
+                                elif hasattr(rp_response, "value"):
+                                    chunk = str(rp_response.value)
+                                else:
+                                    chunk = str(rp_response)
+                                rp_content += chunk
+                        except Exception as rp_exc:
+                            logger.warning(
+                                f"  [{phase_name}] group-chat growth re-prompt "
+                                f"failed ({type(rp_exc).__name__}: {rp_exc}); "
+                                f"skipping remaining re-prompts for this turn."
+                            )
+                            break
+                        if rp_content:
+                            messages.append(
+                                {
+                                    "phase": phase_name,
+                                    "turn": turn,
+                                    "agent": speaking_agent.name,
+                                    "content": (
+                                        rp_content[:500] if rp_content else "(empty)"
+                                    ),
+                                    "re_prompt": rp + 1,
+                                    "path": "agent_group_chat",
+                                }
+                            )
+                        total_re_prompts += 1
+                        fp_after = _get_growth_fingerprint(state)
+                        if reprompt_extractor is not None:
+                            rp_outcome = (
+                                "ok"
+                                if _validate_state_growth(
+                                    fp_before_tour, fp_after, phase_name
+                                )
+                                else (
+                                    "reran"
+                                    if rp + 1 < growth_re_prompt_limit
+                                    else "gave_up"
+                                )
+                            )
+                            reprompt_extractor.record(
+                                phase_name=phase_name,
+                                turn=turn,
+                                attempt_idx=rp + 1,
+                                fingerprint_before=fp_before_tour,
+                                fingerprint_after=fp_after,
+                                outcome=rp_outcome,
+                                agent_name=speaking_agent.name,
+                            )
+                        if _validate_state_growth(fp_before_tour, fp_after, phase_name):
+                            break
+            fp_before_tour = fp_after
 
         if total_re_prompts > 0:
             messages.append(

--- a/tests/unit/argumentation_analysis/orchestration/test_cf1538_growth_validation_groupchat.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_cf1538_growth_validation_groupchat.py
@@ -1,0 +1,304 @@
+# tests/unit/argumentation_analysis/orchestration/test_cf1538_growth_validation_groupchat.py
+"""Track CF of #1538 — re-establish growth validation on the AgentGroupChat path.
+
+CD #1534 (PR #1536) removed the growth-validation re-prompt from the
+AgentGroupChat path because the pre-CD block used ``chat.add_chat_message()``
+plus a nested ``chat.invoke()`` — both forbidden while ``AgentChat._is_active``
+is set (``semantic_kernel/agents/group_chat/agent_chat.py:41-46``, "Unable to
+proceed while another agent is active."). That residue had no home (#597 is
+CLOSED), so the mode that CD had just repaired (AgentGroupChat finally
+constructs) silently lost the re-prompt of an agent whose turn produced no
+state growth.
+
+CF #1538 re-establishes the validation by invoking the SPEAKING AGENT directly
+via ``agent.invoke()``, which is a ``ChatCompletionAgent`` method and never
+touches ``AgentChat._is_active`` (the flag lives on the chat, not the agent —
+verified firsthand against the SK source, not assumed). The group-chat's own
+history is NOT mutated: a deep copy (``chat.history.model_copy(deep=True)``)
+plus the re-prompt feedback is passed, so the selection/termination strategies
+read an undisturbed history.
+
+These tests are JVM/LLM-free and deterministic. They prove the WIRING (the
+re-prompt path is reached on the group-chat path, uses ``agent.invoke`` not
+``chat.add_chat_message``, records the #609 trace) and two non-regression
+guards (no re-prompt when growth is present, none when validation is disabled).
+The LLM-bearing DoD (#1 a real zero-growth group-chat turn triggers a re-prompt
+firsthand; #2 no ``_is_active`` exception on a full run) is left to a live run —
+see the PR body / dashboard [DONE].
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from semantic_kernel.contents.chat_history import ChatHistory
+
+from argumentation_analysis.orchestration.conversational_orchestrator import (
+    _run_phase,
+)
+from argumentation_analysis.reporting.reprompt_trace import RepromptTraceExtractor
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeGroupChat:
+    """CF #1538 test double: mimics the AgentGroupChat surface ``_run_phase``
+    uses (``add_chat_message``, ``invoke`` async-gen, ``history``) so the
+    growth-re-prompt path is exercised without a real SK group chat / LLM call.
+    """
+
+    def __init__(self, agents, selection_strategy=None, **kwargs):
+        self.agents = agents
+        self.history = ChatHistory()
+        self.history.add_user_message("seed group-chat message")
+        self.add_chat_message_calls = []
+
+    async def add_chat_message(self, message):
+        self.add_chat_message_calls.append(message)
+
+    async def invoke(self):
+        resp = MagicMock()
+        resp.name = "Extractor"
+        resp.content = "I looked at the text but added nothing to the state."
+        yield resp
+
+
+def _empty_growth_state():
+    """A state where every growth-fingerprint collection is empty, so the
+    fingerprint is ``(0,)*11`` and any turn that does not mutate it reads as
+    zero-growth (the trigger condition for CF #1538's re-prompt)."""
+    return SimpleNamespace(
+        identified_arguments={},
+        identified_fallacies={},
+        counter_arguments=[],
+        jtms_beliefs={},
+        dung_frameworks={},
+        aspic_results=[],
+        belief_revision_results=[],
+        nl_to_logic_translations=[],
+        fol_analysis_results=[],
+        propositional_analysis_results=[],
+        modal_analysis_results=[],
+        final_conclusion=None,
+        # NOTE: no `consume_next_agent_designation` attr → hasattr() is False →
+        # _run_phase does NOT wire DelegatingSelectionStrategy (keeps the test
+        # isolated from that code path).
+    )
+
+
+def _make_speaking_agent(name="Extractor"):
+    """A ChatCompletionAgent-like double whose ``invoke`` is an async generator
+    that records the history it received (to assert copy-vs-live semantics)."""
+    agent = MagicMock()
+    agent.name = name
+    agent.invoke_calls = []
+
+    async def _invoke(history):
+        agent.invoke_calls.append(history)
+        rp = MagicMock()
+        rp.content = "OK, now adding an argument."
+        yield rp
+
+    agent.invoke = _invoke
+    return agent
+
+
+_GC_PATCH = "semantic_kernel.agents.group_chat.agent_group_chat.AgentGroupChat"
+
+
+# ---------------------------------------------------------------------------
+# DoD (LLM-free wiring): the re-prompt fires on the AgentGroupChat path,
+# via agent.invoke — NOT chat.add_chat_message.
+# ---------------------------------------------------------------------------
+
+
+class TestCF1538GroupChatGrowthReprompt:
+    def test_reprompt_invokes_speaking_agent_via_agent_invoke(self):
+        """DoD #1 (LLM-free part): a zero-growth group-chat turn triggers a
+        re-prompt of the speaking agent via ``agent.invoke`` (the mechanism that
+        bypasses ``_is_active``; ``chat.add_chat_message`` is the forbidden one).
+        """
+        agent = _make_speaking_agent()
+        state = _empty_growth_state()
+        fake_chat = _FakeGroupChat(agents=[agent])
+        with patch(_GC_PATCH, return_value=fake_chat):
+            asyncio.run(
+                _run_phase(
+                    agents=[agent],
+                    initial_prompt="extract",
+                    max_turns=2,
+                    phase_name="Extraction & Detection",
+                    state=state,
+                    enable_growth_validation=True,
+                    growth_re_prompt_limit=2,
+                )
+            )
+        assert len(agent.invoke_calls) >= 1, (
+            "speaking agent.invoke() not called for the re-prompt — the CF #1538 "
+            "wiring (agent.invoke bypasses _is_active) did not fire"
+        )
+
+    def test_reprompt_does_not_call_chat_add_chat_message_in_loop(self):
+        """DoD #2 (LLM-free part): the re-prompt must NOT use
+        ``chat.add_chat_message`` (forbidden by ``_is_active``). The chat's
+        ``add_chat_message`` is called exactly once — for the initial prompt —
+        and never inside the re-prompt loop.
+        """
+        agent = _make_speaking_agent()
+        state = _empty_growth_state()
+        fake_chat = _FakeGroupChat(agents=[agent])
+        with patch(_GC_PATCH, return_value=fake_chat):
+            asyncio.run(
+                _run_phase(
+                    agents=[agent],
+                    initial_prompt="extract",
+                    max_turns=2,
+                    phase_name="Extraction & Detection",
+                    state=state,
+                    enable_growth_validation=True,
+                    growth_re_prompt_limit=2,
+                )
+            )
+        assert len(fake_chat.add_chat_message_calls) == 1, (
+            f"chat.add_chat_message called "
+            f"{len(fake_chat.add_chat_message_calls)} times — expected exactly 1 "
+            f"(initial prompt only); the re-prompt must use agent.invoke on a "
+            f"history copy, not chat.add_chat_message (CF #1538 / anti-_is_active)"
+        )
+
+    def test_reprompt_uses_chat_history_copy_not_live_history(self):
+        """DoD #2 (LLM-free part): ``agent.invoke`` receives a deep COPY of
+        ``chat.history``, never ``chat.history`` itself — mutating the live
+        history would desync the group-chat's selection/termination strategies.
+        Also asserts the live history is not polluted with the feedback text.
+        """
+        agent = _make_speaking_agent()
+        state = _empty_growth_state()
+        fake_chat = _FakeGroupChat(agents=[agent])
+        with patch(_GC_PATCH, return_value=fake_chat):
+            asyncio.run(
+                _run_phase(
+                    agents=[agent],
+                    initial_prompt="extract",
+                    max_turns=2,
+                    phase_name="Extraction & Detection",
+                    state=state,
+                    enable_growth_validation=True,
+                    growth_re_prompt_limit=2,
+                )
+            )
+        assert len(agent.invoke_calls) >= 1
+        for h in agent.invoke_calls:
+            assert (
+                h is not fake_chat.history
+            ), "agent.invoke received the LIVE chat.history — must be a deep copy"
+        # The live history is not polluted with the re-prompt feedback.
+        live_contents = [
+            getattr(m, "content", str(m)) for m in fake_chat.history.messages
+        ]
+        assert not any(
+            "did not produce any state changes" in c for c in live_contents
+        ), "re-prompt feedback leaked into the live chat.history (CF #1538 copy isolation)"
+
+    def test_reprompt_records_trace_via_reprompt_extractor(self):
+        """DoD #3: the #609 reprompt trace is recorded on the group-chat path
+        just like on the round-robin path (so the two paths stay comparable).
+        """
+        agent = _make_speaking_agent()
+        state = _empty_growth_state()
+        extractor = RepromptTraceExtractor()
+        fake_chat = _FakeGroupChat(agents=[agent])
+        with patch(_GC_PATCH, return_value=fake_chat):
+            asyncio.run(
+                _run_phase(
+                    agents=[agent],
+                    initial_prompt="extract",
+                    max_turns=2,
+                    phase_name="Extraction & Detection",
+                    state=state,
+                    enable_growth_validation=True,
+                    growth_re_prompt_limit=2,
+                    reprompt_extractor=extractor,
+                )
+            )
+        assert len(extractor.traces) >= 1, (
+            "reprompt trace empty — RepromptTraceExtractor.record() was not "
+            "called on the group-chat path (CF #1538 DoD #3)"
+        )
+        # The trace carries the speaking agent's name (group-chat path specifics).
+        assert all(t.agent_name == "Extractor" for t in extractor.traces)
+
+
+# ---------------------------------------------------------------------------
+# Non-regression guards
+# ---------------------------------------------------------------------------
+
+
+class TestCF1538NonRegression:
+    def test_no_reprompt_when_growth_present(self):
+        """If the turn DID produce growth (fingerprint changed), no re-prompt."""
+        agent = _make_speaking_agent()
+        state = _empty_growth_state()
+        fake_chat = _FakeGroupChat(agents=[agent])
+        with patch(
+            "argumentation_analysis.orchestration.conversational_orchestrator."
+            "_validate_state_growth",
+            return_value=True,
+        ):
+            with patch(_GC_PATCH, return_value=fake_chat):
+                asyncio.run(
+                    _run_phase(
+                        agents=[agent],
+                        initial_prompt="extract",
+                        max_turns=2,
+                        phase_name="Extraction & Detection",
+                        state=state,
+                        enable_growth_validation=True,
+                        growth_re_prompt_limit=2,
+                    )
+                )
+        assert len(agent.invoke_calls) == 0, (
+            "agent.invoke called despite growth being present — the re-prompt "
+            "must be gated on a MEASURED absence of growth (CF #1538 anti-pendule)"
+        )
+
+    def test_no_reprompt_when_validation_disabled(self):
+        """``enable_growth_validation=False`` → no re-prompt (this is the
+        contract the C1 / CD #1534 tests rely on; CF #1538 must not regress it).
+        """
+        agent = _make_speaking_agent()
+        state = _empty_growth_state()
+        fake_chat = _FakeGroupChat(agents=[agent])
+        with patch(_GC_PATCH, return_value=fake_chat):
+            asyncio.run(
+                _run_phase(
+                    agents=[agent],
+                    initial_prompt="extract",
+                    max_turns=2,
+                    phase_name="Extraction & Detection",
+                    state=state,
+                    enable_growth_validation=False,
+                    growth_re_prompt_limit=2,
+                )
+            )
+        assert len(agent.invoke_calls) == 0, (
+            "agent.invoke called despite enable_growth_validation=False — "
+            "regression of the CD #1534 / C1 contract"
+        )
+
+    def test_find_agent_by_name_returns_none_for_unknown(self):
+        """The ``_find_agent_by_name`` helper returns None for a missing/unknown
+        name — the caller must skip the re-prompt (safe no-op), not raise."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _find_agent_by_name,
+        )
+
+        a = _make_speaking_agent("Known")
+        assert _find_agent_by_name([a], "Known") is a
+        assert _find_agent_by_name([a], "Unknown") is None
+        assert _find_agent_by_name([a], None) is None
+        assert _find_agent_by_name([], "Anybody") is None


### PR DESCRIPTION
Closes #1538

## What

CF #1538 — CD #1534 (PR #1536) removed the growth-validation re-prompt from the `AgentGroupChat` path because the pre-CD block used `chat.add_chat_message()` plus a nested `chat.invoke()` — both forbidden while `AgentChat._is_active` is set (`agent_chat.py:41-46`, "Unable to proceed while another agent is active."). #597 (the follow-up home) is CLOSED, so that residue had no home: the mode CD had just repaired (AgentGroupChat finally constructs) **silently lost** the re-prompt of an agent whose turn produced no state growth. CF #1538 re-establishes it on the AgentGroupChat path.

## Root cause (verified firsthand against the SK source)

`_is_active` lives on `AgentChat` (`agent_chat.py:34`), and `set_activity_or_throw` (the only thing that raises "Unable to proceed...") is called from `add_chat_message`/`add_chat_messages` (L109) and `get_chat_messages` (L65). `ChatCompletionAgent.invoke(history)` is a method on the **agent** (standalone), not the chat — it never touches the chat's `_is_active` flag. So re-prompting the speaking agent via `agent.invoke(...)` is the bypass the ticket proposed, and it is safe (verified, not assumed). The one residual risk is mutating the group-chat's own `chat.history` — solved by passing a deep copy.

## Fix

Re-establish the growth-validation block on the `AgentGroupChat` path inside `_run_phase`, mirroring the round-robin `enable_growth_validation` block (including the #609 `reprompt_extractor` trace):

- After a group-chat turn yields zero state growth (`_validate_state_growth` False on a growth-expecting phase), locate the **speaking agent** by `response.name` (`_find_agent_by_name`) and re-prompt it via `speaking_agent.invoke(re_history)`.
- `re_history = chat.history.model_copy(deep=True)` + `_RE_PROMPT_FEEDBACK` — a deep copy, so the group-chat's selection/termination strategies read an **undisturbed** history. Verified firsthand that `model_copy(deep=True)` isolates the original (orig not mutated after add to copy).
- Records the #609 trace (`reprompt_extractor.record`) with the speaking agent's name, so the group-chat and round-robin paths stay comparable.
- Placed **after** the convergence/max_turns/deadline breaks so a turn already exiting does not spend re-prompt budget.

## Anti-pendule (per the ticket)

- Did **not** put the removed block back as-is — it crashes by construction on this path (that is *why* CD removed it: `add_chat_message` + nested `chat.invoke` while `_is_active`).
- Did **not** re-disable `AgentGroupChat` to recover the re-prompt (that would resurrect the silent round-robin fallback CD dismantled).
- Did **not** re-prompt blindly every turn — gated on a **measured** absence of growth via `_validate_state_growth` (the symmetrical-of-blind choice the ticket calls out).

## DoD checklist (all firsthand, LLM-bearing run this time)

- [x] **#1** a real zero-growth group-chat turn triggers a re-prompt firsthand. Run `scripts/compare_orchestration_modes.py --modes conversational --corpora corpus_A --max-wall-seconds 90` → the log shows `[Extraction & Detection] Growth re-prompt 1/2 (group-chat path)` **twice**. This is a live AgentGroupChat path, not mocked.
- [x] **#2** no `Unable to proceed while another agent is active.` / `_is_active` exception on a full run. Same run, exit 0, honest partial verdict at the 120s safety-net. The only `Traceback` in the log is a pre-existing `'votes' is an invalid keyword argument for str()` `FunctionExecutionException` from the governance plugin — **unrelated to `_is_active`**, non-fatal (caught), present on main independently of this PR.
- [x] **#3** the #609 reprompt trace is recorded on the group-chat path (test `test_reprompt_records_trace_via_reprompt_extractor` + the re-prompt log lines confirm `record()` fires on this path).
- [x] **#4** non-regression: 258 tests green across `test_strategies_real` (CD #1534) + `test_conversational_wall_clock_c1` (C1 #1500) + `test_growth_validation_hook_597` (round-robin growth) + `test_groupchat_turn_strategy` + `test_orchestration_strategies` + `test_cluedo_strategies` + `test_ce1537_execution_path` + `test_cf1538_*` + `test_conversational_orchestrator/sk_budget/executor`. The C1 contract (`test_deadline_in_past_breaks_before_first_turn`) stays green without modification.

## Tests (7 new, LLM-free, deterministic)

`tests/unit/argumentation_analysis/orchestration/test_cf1538_growth_validation_groupchat.py`:
- wiring: `agent.invoke` called on the group-chat path when growth is absent;
- `chat.add_chat_message` NOT called in the re-prompt loop (exactly 1 call — the initial prompt);
- `agent.invoke` receives a deep COPY, not the live `chat.history` (and the live history is not polluted with the feedback);
- `reprompt_extractor.record` fires on the group-chat path;
- non-regression: no re-prompt when growth is present, none when `enable_growth_validation=False`, `_find_agent_by_name` returns None for unknown names (no raise).

## Note

One side effect observed firsthand: the growth re-prompt adds LLM calls intra-turn, so under a tight budget the internal wall-clock bound may not exit before the 120s safety-net (which records an honest PARTIAL verdict — not a crash, not a fake success). This is the intended cost of re-prompting for growth; the safety-net's honest-partial is the documented degrade. A deadline-check *inside* the re-prompt loop would tighten this, but it is out of scope for CF #1538 (the ticket does not ask for it) and would be an addition, not a subtraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
