### PR TITLE
test(workflows): hermeticize test_invoke_fact_extraction (#1510 brother-3, main-RED flake)

### DIFF
--- a/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
+++ b/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
@@ -262,14 +262,34 @@ class TestInvokeCallables:
 
     @pytest.mark.asyncio
     async def test_invoke_fact_extraction(self):
+        # #1510 brother-3 — same hermeticity gap as test_invoke_fact_extraction_short_text
+        # below: _invoke_fact_extraction takes the LLM path whenever
+        # _get_openai_client() returns a client. When real API keys leak into
+        # os.environ (pytest-dotenv .env load, or a shell/fixture leak), this
+        # substantive text is routed to the LLM, whose claim_count is
+        # nondeterministic — occasionally 0 (the model emits an empty claims
+        # array), which spursiously fails the ``assert claim_count >= 1`` on
+        # unrelated PRs (observed on main CI at 742bfea8 after CG #1541, which
+        # does not touch this code). Force the no-client path by patching
+        # _get_openai_client so the test deterministically exercises the
+        # heuristic fallback under test (soustraction of the leaky env/client
+        # dependency, same fix as _short_text — not a retry/rerun). The
+        # heuristic deterministically yields >=1 claim for any text with a
+        # sentence > 20 chars (here: 2 sentences qualify), so the contract
+        # assertion stays meaningful. The LLM extraction quality itself is
+        # covered by the requires_api suite.
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_fact_extraction,
         )
 
-        result = await _invoke_fact_extraction(
-            "This is a long claim about logic. Another important assertion here. A third point.",
-            {},
-        )
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(None, ""),
+        ):
+            result = await _invoke_fact_extraction(
+                "This is a long claim about logic. Another important assertion here. A third point.",
+                {},
+            )
         assert "claims" in result
         assert "claim_count" in result
         assert result["claim_count"] >= 1


### PR DESCRIPTION
Closes the #1510 long-text brother. Main-CI flake fix (main went RED at `742bfea8`).

## What

`test_invoke_fact_extraction` had the same hermeticity gap that `test_invoke_fact_extraction_short_text` closed in **#1510 (PR #1515)**. `_invoke_fact_extraction` takes the LLM path whenever `_get_openai_client()` returns a client. When real API keys leak into `os.environ` (pytest-dotenv `.env` load, or a shell/fixture leak), the substantive 3-sentence fixture text is routed to the LLM, whose `claim_count` is nondeterministic — occasionally `0` (the model emits an empty claims array), which spuriously fails `assert claim_count >= 1` on unrelated PRs.

## Symptom (firsthand, main CI)

Main went RED at `742bfea8` (run `30216228827`) right after **CG #1541 (PR #1541)** was merged:

```
FAILED tests/unit/argumentation_analysis/workflows/test_formal_verification.py::TestInvokeCallables::test_invoke_fact_extraction - assert 0 >= 1
```

## Root cause — flake, not a CG regression (verified)

CG #1541 touches **only** `scripts/compare_orchestration_modes.py` + `tests/.../test_cg1540_unwritten_vs_measured.py` (confirmed via `gh pr view 1541 --json files`). Zero contact with `_invoke_fact_extraction` / `unified_pipeline` / `invoke_callables`. The previous main run (`5a20b526`, CE merged) was green. So the failure is the **#1510 leaky-dependency flake** biting the long-text brother — the 3rd brother that the #1510 audit missed (it hermeticized `_short_text` but left `test_invoke_fact_extraction` exposed to the same LLM leak).

The heuristic fallback (`invoke_callables.py:5403-5404`) deterministically yields `claim_count == 2` for this fixture (two sentences exceed the 20-char threshold). So `assert 0 >= 1` *requires* the LLM path — i.e. an API key leaked into the CI env, routing the text to an LLM that nondeterministically returned 0 claims.

## Fix

Same soustraction as `_short_text`: patch `argumentation_analysis.orchestration.invoke_callables._get_openai_client` to return `(None, "")` so the test deterministically exercises the heuristic fallback under test, regardless of any env/client leak. The contract assertion (`claim_count >= 1`) stays meaningful — the heuristic is deterministic for this fixture. LLM extraction quality is covered by the `requires_api` suite.

## Anti-pendule (#1019)

- No retry / rerun / relaxation.
- No `@pytest.mark.flaky` / skip.
- The leaky env/client dependency is **subtracted** at the source — the test now pins the deterministic heuristic contract, which is what it was always meant to verify.

## Verification (firsthand, local)

`pytest tests/unit/argumentation_analysis/workflows/test_formal_verification.py::TestInvokeCallables -v --disable-jvm-session` → **8 passed** (including `test_invoke_fact_extraction` + `test_invoke_fact_extraction_short_text`). `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
