### PR TITLE
fix(conversational): the wall-clock cap must cancel, not just schedule (CB #1528 item 3)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -1084,6 +1084,33 @@ async def _run_conversational_analysis_inner(
         except Exception:
             trace.end_phase(phase_name)
 
+    # CB #1528 item 3 (C1 #1500): ONE shared predicate for every stage that
+    # runs after the phase loop. Before this, ``wall_clock_bounded`` was set at
+    # the breach and then read ONLY to build the result dict — it gated
+    # nothing. The cap therefore behaved as a scheduling decision ("do not
+    # start the next PHASE") while the run kept issuing LLM round-trips for the
+    # conditional Re-Analysis phase and the five ``spectacular`` stages below,
+    # until an external safety-net cut the coroutine and discarded the state it
+    # had just populated (firsthand: arguments and counter-arguments written
+    # seconds before the cut, reported as an empty row).
+    #
+    # Anti-pendule: these stages are NOT removed — they carry the analytical
+    # value of the mode. They are SKIPPED once the budget is spent, which is
+    # what "verdict partiel honnête" already means everywhere else here. And
+    # no second budget mechanism is introduced: ``wall`` is the one authority.
+    def _budget_allows(stage: str) -> bool:
+        nonlocal wall_clock_bounded
+        if not wall.is_exhausted(time.time()):
+            return True
+        # The loop may have finished all phases and the deadline passed only
+        # during post-processing: record the bound so the result stays honest.
+        wall_clock_bounded = True
+        logger.info(
+            f"[C1] Wall-clock budget épuisé ({max_wall_seconds:g}s) — étage "
+            f"post-boucle '{stage}' sauté (verdict partiel honnête)."
+        )
+        return False
+
     # 5b. Conditional Phase 4: Re-Analysis (#305)
     # If the enrichment summary shows gaps (e.g., JTMS retracted beliefs not
     # re-evaluated, arguments missing fallacy analysis), add an extra phase
@@ -1091,7 +1118,14 @@ async def _run_conversational_analysis_inner(
     reanalysis_added = False
     # CONV-C #1334 §6: skip the conditional Re-Analysis phase if the
     # pipeline-global budget is already exhausted (the run ended fail-loud).
-    if not budget_exhausted and hasattr(state, "get_enrichment_summary"):
+    # CB #1528 item 3: ``budget_exhausted`` is the TURN-COUNT flag; the
+    # wall-clock bound is a distinct budget and was not consulted here, so a
+    # run stopped by the clock still ran a whole extra 4-agent phase.
+    if (
+        not budget_exhausted
+        and hasattr(state, "get_enrichment_summary")
+        and _budget_allows("Re-Analysis")
+    ):
         try:
             enrichment = state.get_enrichment_summary()
             needs_reanalysis = _should_add_reanalysis_phase(enrichment, state)
@@ -1194,6 +1228,14 @@ async def _run_conversational_analysis_inner(
     # 5b-2. Dung framework construction (#564)
     # Build Dung AF from identified_arguments + counter_arguments/fallacies
     # after all conversational phases have populated the state.
+    #
+    # CB #1528 item 3 — the next four stages (Dung, modal, ASPIC, belief
+    # revision) are deliberately NOT gated by ``_budget_allows``. They are
+    # synchronous (no ``await``, no kernel/agent/LLM call — checked by AST)
+    # and only re-read state the conversation has already populated, so they
+    # cost milliseconds and cannot push the run past its deadline. Gating them
+    # would strip content from an honest partial verdict for no time saved.
+    # What the budget must cut is what still SPENDS it: the awaited stages.
     dung_result = None
     if spectacular and hasattr(state, "dung_frameworks") and not state.dung_frameworks:
         try:
@@ -1273,7 +1315,12 @@ async def _run_conversational_analysis_inner(
     # collaborative path matches the sequential path's coverage.
     n_args = len(getattr(state, "identified_arguments", []) or [])
     n_cas = len(getattr(state, "counter_arguments", []) or [])
-    if spectacular and n_args and n_cas < n_args:
+    if (
+        spectacular
+        and n_args
+        and n_cas < n_args
+        and _budget_allows("counter_arguments")
+    ):
         try:
             from argumentation_analysis.orchestration.invoke_callables import (
                 _generate_counter_arguments_from_state,
@@ -1303,6 +1350,7 @@ async def _run_conversational_analysis_inner(
         and hasattr(state, "propositional_analysis_results")
         and not state.propositional_analysis_results
         and not getattr(state, "fol_analysis_results", None)
+        and _budget_allows("formal_logic_enrichment")
     ):
         try:
             from argumentation_analysis.orchestration.invoke_callables import (
@@ -1331,7 +1379,12 @@ async def _run_conversational_analysis_inner(
     # 9-virtue evaluator over every identified argument so the collaborative path
     # always has quality scores. Gated on under-production — fills gaps only.
     n_quality = len(getattr(state, "argument_quality_scores", {}) or {})
-    if spectacular and n_args and n_quality < n_args:
+    if (
+        spectacular
+        and n_args
+        and n_quality < n_args
+        and _budget_allows("quality_sweep")
+    ):
         try:
             from argumentation_analysis.orchestration.invoke_callables import (
                 _run_quality_sweep_from_state,
@@ -1350,7 +1403,7 @@ async def _run_conversational_analysis_inner(
             logger.warning(f"Quality sweep post-processing failed: {e}")
 
     # 5b-10. Stakes & Stakeholders extraction (Track TT #723)
-    if spectacular:
+    if spectacular and _budget_allows("stakes_extraction"):
         try:
             from argumentation_analysis.orchestration.invoke_callables import (
                 _invoke_stakes_extractor,
@@ -1385,7 +1438,7 @@ async def _run_conversational_analysis_inner(
     # Run DeepSynthesisAgent on the accumulated state to produce a 9-section
     # grounded markdown report. Appended as terminal step after all agents.
     deep_synthesis_result = None
-    if spectacular:
+    if spectacular and _budget_allows("deep_synthesis"):
         try:
             from argumentation_analysis.orchestration.invoke_callables import (
                 _invoke_deep_synthesis,
@@ -1447,11 +1500,20 @@ async def _run_conversational_analysis_inner(
         # (construction failure, runtime error, or SK unavailable) downgrades to
         # "round_robin_fallback" so the comparison harness cannot read a fallback
         # run as a genuine group-chat run (anti-#1019).
+        # CB #1528 item 3: when NO phase ran (the wall-clock deadline was
+        # already past at entry, e.g. a budget smaller than the agent setup),
+        # there is no path to report. Claiming "round_robin_fallback" here
+        # would assert a branch that never executed — the CE defect itself.
+        # ``None`` renders as "—" in the harness table, like every other mode
+        # that records no path.
         "execution_path": (
-            "agent_group_chat"
-            if phase_execution_paths
-            and all(p == "agent_group_chat" for p in phase_execution_paths)
-            else "round_robin_fallback"
+            None
+            if not phase_execution_paths
+            else (
+                "agent_group_chat"
+                if all(p == "agent_group_chat" for p in phase_execution_paths)
+                else "round_robin_fallback"
+            )
         ),
         "conversation_log": conversation_log,
         "total_messages": len(conversation_log),
@@ -1820,6 +1882,24 @@ async def _run_phase(
     """
     messages: List[Dict[str, Any]] = []
     total_re_prompts = 0
+
+    # C1 #1500 / CB #1528 item 3: check the deadline BEFORE entering either
+    # execution path. The round-robin loop already checks before invoking the
+    # next agent, but the AgentGroupChat path invoked ``chat.invoke()``
+    # unconditionally and only checked *after* the first response had come
+    # back — so a phase entered with an already-expired deadline still burned
+    # one full multi-agent turn. Since CD #1534 the group-chat path is the
+    # live one, and the existing regression test does NOT cover it: it injects
+    # a raising AgentGroupChat precisely to force the round-robin fallback.
+    # No path is recorded here on purpose: nothing ran, and asserting a path
+    # that did not execute is the CE #1537 residual defect.
+    if deadline is not None and time.time() >= deadline:
+        logger.info(
+            f"  [{phase_name}] Wall-clock deadline déjà atteint à l'entrée de "
+            f"la phase — aucun tour entamé (verdict partiel honnête)."
+        )
+        return messages
+
     chat_history = ChatHistory()
     chat_history.add_user_message(initial_prompt)
 

--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -20,7 +20,7 @@ Usage:
     python scripts/compare_orchestration_modes.py \\
         --modes pipeline hierarchical_bridge hierarchical_delegation
 
-    # Bound conversational wall-clock (default 180s)
+    # Bound the wall-clock of every mode (default 180s)
     python scripts/compare_orchestration_modes.py \\
         --modes conversational --max-wall-seconds 60
 
@@ -65,12 +65,17 @@ logger = logging.getLogger("orchestration_mode_harness")
 for _name in ("httpx", "openai", "semantic_kernel", "urllib3"):
     logging.getLogger(_name).setLevel(logging.WARNING)
 
-# Default conversational wall-time budget (seconds). Pre-R653, the
+# Default wall-time budget (seconds) for EVERY mode. Pre-R653, the
 # conversational mode was unbounded and ran >600s on 643-octet input;
 # 180s is a reasonable budget that lets a real run reach the Synthesis
 # phase on a short corpus without making the harness itself a CI
 # bottleneck. Overridable via --max-wall-seconds.
-DEFAULT_CONVERSATIONAL_WALL_SECONDS = 180.0
+#
+# CB #1528 item 3: the name used to carry a "conversational" qualifier and
+# the CLI help still said "for the conversational mode". That was drift:
+# since CB the budget is threaded to every runner (see ``run_comparison``),
+# and the conversational mode is simply the one that used to overshoot it.
+DEFAULT_WALL_SECONDS = 180.0
 
 
 def _conversational_safety_net_timeout(max_wall_seconds: float) -> float:
@@ -262,8 +267,10 @@ def _compute_decides(result: ModeResult) -> bool:
 
     Anti-#1019 / anti-pendule: returning ``True`` everywhere would destroy the
     column's discriminating power. The non-regression test is that a genuinely
-    sterile run (conversational cut at the safety-net: 0/0 phases, 0 % fill,
-    0 messages) stays ``False`` → ``—``.
+    sterile run stays ``False`` → ``—``: 0/0 phases, 0 messages, and NO state
+    written at all (``state_fill_rate is None`` since Track CG #1540 — the
+    safety-net branch builds its ``ModeResult`` without those fields, so the
+    old "0 % fill" wording here described a measurement that never happens).
 
     Track CG #1540: ``state_fill_rate`` / ``argument_count`` / ``fallacy_count``
     are now Optional (None = "not written", e.g. hierarchical modes that decide
@@ -651,7 +658,7 @@ async def run_pipeline_mode(
 async def run_conversational_mode(
     text: str,
     corpus_id: str,
-    max_wall_seconds: float = DEFAULT_CONVERSATIONAL_WALL_SECONDS,
+    max_wall_seconds: float = DEFAULT_WALL_SECONDS,
 ) -> ModeResult:
     """Run conversational orchestrator (AgentGroupChat multi-agent).
 
@@ -741,6 +748,26 @@ async def run_conversational_mode(
     }
     total_messages = result.get("total_messages", 0) if isinstance(result, dict) else 0
 
+    # CB #1528 item 3: the counts are MEASURED from the state snapshot the
+    # orchestrator returns. ``result["extra_metrics"]`` is a key it NEVER
+    # emits, so reading ``.get("extra_metrics", {}).get("fallacy_count", 0)``
+    # manufactured a 0 indistinguishable from an observed 0 (leçon #1531), and
+    # ``argument_count`` was not read at all — a populated state rendered "—"
+    # in the Args column. The snapshot is the non-summarized one (raw attribute
+    # names, ``identified_arguments`` / ``identified_fallacies``), NOT the
+    # summarized ``*_count`` shape. Absent key → None ("not written", Track CG
+    # #1540), never a fabricated 0.
+    snapshot = state if isinstance(state, dict) else {}
+
+    def _snapshot_count(key: str) -> Optional[int]:
+        value = snapshot.get(key)
+        if value is None:
+            return None
+        try:
+            return len(value)
+        except TypeError:
+            return None
+
     return ModeResult(
         mode="conversational",
         corpus_id=corpus_id,
@@ -748,7 +775,8 @@ async def run_conversational_mode(
         terminates=True,
         duration_seconds=round(duration, 2),
         state_fill_rate=round(non_empty / max(total_fields, 1), 3),
-        fallacy_count=result.get("extra_metrics", {}).get("fallacy_count", 0),
+        fallacy_count=_snapshot_count("identified_fallacies"),
+        argument_count=_snapshot_count("identified_arguments"),
         phases_completed=len(phases_ran),
         phases_total=len(planned_phases),
         capabilities_used=result.get("capabilities_used", []),
@@ -1318,7 +1346,7 @@ async def run_all(
     corpora: Optional[List[str]] = None,
     output_file: Optional[str] = None,
     dry_run: bool = False,
-    max_wall_seconds: float = DEFAULT_CONVERSATIONAL_WALL_SECONDS,
+    max_wall_seconds: float = DEFAULT_WALL_SECONDS,
 ) -> List[ModeResult]:
     """Run selected modes on selected corpora.
 
@@ -1412,8 +1440,8 @@ async def run_all(
     # common ModeResult fields — the single source of truth, so no runner can
     # hand-set it on a local criterion. A budget breach that still produced
     # partial artifacts honestly decides True (the partial state IS the
-    # verdict, anti-#1019); a genuinely sterile run (conversational cut at the
-    # safety-net: 0/0 phases, 0 % fill) stays False → `—`.
+    # verdict, anti-#1019); a genuinely sterile run (cut at the safety-net:
+    # 0/0 phases, no state written) stays False → `—`.
     for r in results:
         r.decides = _compute_decides(r)
 
@@ -1471,10 +1499,10 @@ def main():
     parser.add_argument(
         "--max-wall-seconds",
         type=float,
-        default=DEFAULT_CONVERSATIONAL_WALL_SECONDS,
+        default=DEFAULT_WALL_SECONDS,
         help=(
-            f"Wall-clock budget for the conversational mode in seconds "
-            f"(default {DEFAULT_CONVERSATIONAL_WALL_SECONDS:g}). "
+            f"Wall-clock budget in seconds, applied to EVERY mode "
+            f"(default {DEFAULT_WALL_SECONDS:g}). "
             f"On breach, the verdict is recorded as PARTIAL HONNÊTE "
             f"(terminated_by_budget=True), never as success=True."
         ),

--- a/tests/scripts/test_compare_orchestration_modes_1480.py
+++ b/tests/scripts/test_compare_orchestration_modes_1480.py
@@ -370,6 +370,88 @@ class TestConversationalInternalBound:
         assert "✅⏱ bounded" in report
 
 
+class TestCB1528CountsComeFromTheSnapshot:
+    """CB #1528 item 3 — the Args/Fallacies columns must be MEASURED.
+
+    The runner read ``result["extra_metrics"]["fallacy_count"]``, a key the
+    conversational orchestrator never emits, so the default ``0`` was a
+    fabricated zero indistinguishable from an observed one (leçon #1531);
+    ``argument_count`` was not read at all, so a populated state rendered
+    ``—``. Both are measured from the state snapshot, which this runner
+    receives NON-summarized: raw attribute names (``identified_arguments``),
+    not the summarized ``*_count`` shape — the same shape the pre-existing
+    ``test_internal_bound_maps_to_real_partial_verdict`` fixture uses.
+    """
+
+    @staticmethod
+    def _fake_result(**snapshot_extra):
+        snapshot = {
+            "identified_arguments": {"arg_0": "a", "arg_1": "b", "arg_2": "c"},
+            "identified_fallacies": {"f_0": "x", "f_1": "y"},
+        }
+        snapshot.update(snapshot_extra)
+        return {
+            "phases": ["Extraction & Detection"],
+            "conversation_log": [
+                {"phase": "Extraction & Detection", "turn": 1, "content": "x"}
+            ],
+            "total_messages": 1,
+            "state_snapshot": snapshot,
+            "budget": {"wall_clock_bounded": True},
+            "status": "WALL_CLOCK_BOUNDED",
+            "duration_seconds": 30.0,
+        }
+
+    def _run(self, fake_result):
+        mod = _load_harness_module()
+
+        async def fake_run(**kwargs):
+            return fake_result
+
+        async def _drive():
+            with patch(
+                "argumentation_analysis.orchestration.conversational_orchestrator"
+                ".run_conversational_analysis",
+                side_effect=fake_run,
+            ):
+                return await mod.run_conversational_mode(
+                    "text", "corpus_A", max_wall_seconds=30.0
+                )
+
+        return asyncio.run(_drive())
+
+    def test_counts_are_read_from_the_state_snapshot(self) -> None:
+        result = self._run(self._fake_result())
+        assert result.argument_count == 3, (
+            "CB #1528 item 3 regression: argument_count is not read from the "
+            f"state snapshot (got {result.argument_count!r}) — a populated "
+            "state renders '—' in the Args column."
+        )
+        assert result.fallacy_count == 2, (
+            "CB #1528 item 3 regression: fallacy_count is not read from the "
+            f"state snapshot (got {result.fallacy_count!r})."
+        )
+
+    def test_absent_counts_stay_none_never_a_fabricated_zero(self) -> None:
+        """Track CG #1540: absent ≠ measured. A snapshot without the keys must
+        leave the columns unwritten (``None`` → ``—``), not report ``0``."""
+        fake = self._fake_result()
+        fake["state_snapshot"] = {"some_other_field": 1}
+        result = self._run(fake)
+        assert result.argument_count is None
+        assert result.fallacy_count is None, (
+            "A snapshot with no fallacy_count must render '—', not a 0 that "
+            "reads as 'measured, none found'."
+        )
+
+    def test_measured_zero_stays_zero(self) -> None:
+        """Anti-pendule: a real 0 must survive as 0, not be turned into ``—``."""
+        fake = self._fake_result(identified_arguments={}, identified_fallacies={})
+        result = self._run(fake)
+        assert result.argument_count == 0
+        assert result.fallacy_count == 0
+
+
 class TestReportFormat:
     """The trade-off table is generated with the BO-4 columns."""
 

--- a/tests/unit/argumentation_analysis/orchestration/test_cb1528_postcap_budget.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_cb1528_postcap_budget.py
@@ -1,0 +1,343 @@
+# -*- coding: utf-8 -*-
+"""Tests for CB #1528 item 3 — the wall-clock cap must CANCEL, not just schedule.
+
+Firsthand measurement recorded on #1528 (R715/R716): ``wall_clock_bounded`` was
+set at the breach and then read ONLY to build the result dict — no ``if`` ever
+consulted it. So the cap decided "do not start the next PHASE" and the run kept
+going: a whole conditional Re-Analysis phase (4 agents, guarded by the distinct
+TURN-COUNT flag) plus five ``spectacular`` LLM stages, ~16 round-trips past the
+deadline, until an external safety-net cut the coroutine and discarded the state
+it had just populated (arguments and counter-arguments written seconds before
+the cut, reported as an empty row).
+
+Two defects, two kinds of test here:
+
+* **Behavioural** — ``_run_phase`` entered with an already-expired deadline used
+  to burn one full multi-agent turn on the ``AgentGroupChat`` path, because that
+  path invoked ``chat.invoke()`` unconditionally and only checked the deadline
+  *after* the first response. The round-robin path had the check; the group-chat
+  path did not. The pre-existing regression test
+  (``test_deadline_in_past_breaks_before_first_turn``) injects a raising
+  ``AgentGroupChat`` precisely to force the round-robin fallback, so it does NOT
+  cover the path that has been live since CD #1534. These tests do.
+
+* **Structural** — the post-loop stages are now gated by one shared
+  ``_budget_allows`` predicate. That gating is not reachable without a real LLM
+  run, so it is pinned as a WIRING GUARD (same family as
+  ``test_external_provers_wired.py``): the guard proves the call sites are still
+  attached to the budget, and the behaviour they protect is measured firsthand
+  in the bounded run recorded on #1528. A new post-loop stage added without the
+  predicate re-opens the exact defect this item closed, silently.
+
+Anti-pendule: none of these stages is removed — they carry the analytical value
+of the mode. They are SKIPPED once the budget is spent, which is what "verdict
+partiel honnête" already means everywhere else in this module.
+
+All tests are deterministic and LLM-free.
+"""
+
+from __future__ import annotations
+
+import ast
+import time
+from pathlib import Path
+from typing import List, Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ORCHESTRATOR_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "argumentation_analysis"
+    / "orchestration"
+    / "conversational_orchestrator.py"
+)
+
+
+# ── Behavioural: the group-chat path checks the deadline BEFORE turn 1 ────
+
+
+class TestGroupChatPreFirstTurnDeadline:
+    """A phase entered past its deadline must run ZERO turns on BOTH paths."""
+
+    @pytest.mark.asyncio
+    async def test_past_deadline_never_constructs_group_chat(self) -> None:
+        """The live (CD #1534) path: AgentGroupChat must not even be built.
+
+        Asserting on the mock rather than on the message list is the point —
+        an empty list would also be produced by a chat that ran and returned
+        nothing. Here we assert the LLM path was never entered at all.
+        """
+        from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_phase,
+        )
+
+        state = RhetoricalAnalysisState("test text")
+        fake_agent = MagicMock()
+        fake_agent.name = "FakeAgent"
+
+        # NOT raising: unlike the pre-existing C1 test, we let the group-chat
+        # path be available so that reaching it would be observable.
+        chat_cls = MagicMock(name="AgentGroupChat")
+
+        with patch(
+            "semantic_kernel.agents.group_chat.agent_group_chat.AgentGroupChat",
+            chat_cls,
+        ):
+            messages = await _run_phase(
+                [fake_agent],
+                "initial prompt",
+                max_turns=5,
+                phase_name="Extraction & Detection",
+                state=state,
+                enable_growth_validation=False,
+                deadline=time.time() - 1.0,
+            )
+
+        assert chat_cls.call_count == 0, (
+            "CB #1528 item 3 regression: _run_phase entered with an expired "
+            "deadline constructed an AgentGroupChat — the group-chat path used "
+            "to burn one full multi-agent turn before checking the deadline."
+        )
+        assert messages == [], (
+            f"Expected zero turns past the deadline, got {len(messages)} " "message(s)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_past_deadline_records_no_execution_path(self) -> None:
+        """Nothing ran, so no execution path may be claimed (CE #1537).
+
+        Recording a path here would re-introduce the CE defect: a value
+        asserted for a branch that never executed.
+        """
+        from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_phase,
+        )
+
+        state = RhetoricalAnalysisState("test text")
+        fake_agent = MagicMock()
+        fake_agent.name = "FakeAgent"
+        recorder: List[str] = []
+
+        with patch(
+            "semantic_kernel.agents.group_chat.agent_group_chat.AgentGroupChat",
+            MagicMock(name="AgentGroupChat"),
+        ):
+            await _run_phase(
+                [fake_agent],
+                "initial prompt",
+                max_turns=5,
+                phase_name="Extraction & Detection",
+                state=state,
+                enable_growth_validation=False,
+                deadline=time.time() - 1.0,
+                execution_path_recorder=recorder,
+            )
+
+        assert recorder == [], (
+            "CB #1528 item 3: no execution path may be recorded when the "
+            f"deadline aborted the phase before any turn — got {recorder}."
+        )
+
+    @pytest.mark.asyncio
+    async def test_future_deadline_still_runs_a_turn(self) -> None:
+        """Anti-pendule: the pre-entry check is a BOUND, not a truncation.
+
+        With a deadline comfortably ahead, the phase must behave exactly as
+        before — one turn under ``max_turns=1``.
+        """
+        from argumentation_analysis.core.shared_state import RhetoricalAnalysisState
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_phase,
+        )
+
+        state = RhetoricalAnalysisState("test text")
+        fake_agent = MagicMock()
+        fake_agent.name = "FakeAgent"
+
+        async def fake_invoke(chat_history):
+            msg = MagicMock()
+            msg.content = "stub response"
+            yield msg
+
+        fake_agent.invoke = fake_invoke
+
+        with patch(
+            "semantic_kernel.agents.group_chat.agent_group_chat.AgentGroupChat",
+            side_effect=RuntimeError("force round-robin for test"),
+        ):
+            messages = await _run_phase(
+                [fake_agent],
+                "initial prompt",
+                max_turns=1,
+                phase_name="Extraction & Detection",
+                state=state,
+                enable_growth_validation=False,
+                deadline=time.time() + 3600.0,
+            )
+
+        assert len(messages) == 1, (
+            "Anti-pendule regression: a deadline in the future must not "
+            f"suppress the phase — expected 1 turn, got {len(messages)}."
+        )
+
+
+# ── Structural wiring guard: post-loop stages consult the budget ─────────
+
+
+def _module_ast() -> ast.Module:
+    return ast.parse(ORCHESTRATOR_PATH.read_text(encoding="utf-8"))
+
+
+def _guard_test_source_for_call(callee: str) -> Optional[str]:
+    """Source of the ``if`` test whose body calls ``callee``.
+
+    ``ast.walk`` is breadth-first, so the first matching ``If`` is the
+    outermost one containing the call — which for these top-level post-loop
+    stages is exactly their guard.
+    """
+    for node in ast.walk(_module_ast()):
+        if not isinstance(node, ast.If):
+            continue
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Call) and getattr(sub.func, "id", None) == callee:
+                return ast.unparse(node.test)
+    return None
+
+
+class TestPostLoopStagesAreBudgetGated:
+    """Every post-loop LLM stage must be attached to the ONE shared predicate."""
+
+    # The five ``spectacular`` stages measured on #1528 as running past the cap.
+    POST_LOOP_LLM_STAGES = [
+        "_generate_counter_arguments_from_state",
+        "_run_formal_logic_from_state",
+        "_run_quality_sweep_from_state",
+        "_invoke_stakes_extractor",
+        "_invoke_deep_synthesis",
+    ]
+
+    @pytest.mark.parametrize("callee", POST_LOOP_LLM_STAGES)
+    def test_stage_guard_consults_budget(self, callee: str) -> None:
+        guard = _guard_test_source_for_call(callee)
+        assert guard is not None, (
+            f"{callee} is no longer called from an `if` in the orchestrator — "
+            "update this guard so the budget wiring stays checked."
+        )
+        assert "_budget_allows" in guard, (
+            f"CB #1528 item 3 regression: the post-loop stage `{callee}` runs "
+            f"under `if {guard}` — it does not consult the wall-clock budget. "
+            "Past the cap this stage issues LLM round-trips that the external "
+            "safety-net then cuts, discarding the state just populated."
+        )
+
+    def test_reanalysis_phase_consults_wall_clock_not_only_turn_count(self) -> None:
+        """The conditional Re-Analysis phase is a WHOLE extra 4-agent phase.
+
+        It was guarded by ``budget_exhausted`` — the turn-count flag from
+        CONV-C #1334 — which is a different budget from the wall clock.
+        """
+        guard = _guard_test_source_for_call("_should_add_reanalysis_phase")
+        assert guard is not None, (
+            "Re-Analysis is no longer gated by an `if` calling "
+            "_should_add_reanalysis_phase — update this guard."
+        )
+        assert "_budget_allows" in guard, (
+            f"CB #1528 item 3 regression: Re-Analysis runs under `if {guard}` "
+            "— the turn-count flag alone let a wall-clock-stopped run start a "
+            "whole extra 4-agent phase."
+        )
+
+    def test_budget_predicate_is_defined_once_in_the_inner_run(self) -> None:
+        """One predicate, not five copies, and not a second budget mechanism."""
+        definitions = [
+            node
+            for node in ast.walk(_module_ast())
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "_budget_allows"
+        ]
+        assert len(definitions) == 1, (
+            f"Expected exactly one `_budget_allows` definition, found "
+            f"{len(definitions)} — the item asked for ONE shared predicate."
+        )
+
+    def test_predicate_asks_the_budget_not_the_reporting_flag(self) -> None:
+        """``wall_clock_bounded`` is a REPORTING flag; ``wall`` is the authority.
+
+        The original defect was a flag that gated nothing. Re-implementing the
+        gate on that same flag would rebuild the defect with an `if` in front
+        of it, so the predicate must ask ``wall.is_exhausted``.
+        """
+        definition = next(
+            node
+            for node in ast.walk(_module_ast())
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "_budget_allows"
+        )
+        body = ast.unparse(definition)
+        assert "wall.is_exhausted" in body, (
+            "`_budget_allows` must consult the WallClockBudget itself, not the "
+            "`wall_clock_bounded` reporting flag."
+        )
+
+
+class TestSynchronousStagesStayExemptForTheStatedReason:
+    """Four post-loop stages are ungated *because* they spend no wall clock.
+
+    Dung / modal / ASPIC / belief-revision re-read state the conversation has
+    already populated. Gating them would strip content from an honest partial
+    verdict and save no time. That exemption is only sound while they stay
+    synchronous — so pin the reason, not the decision: if one of them ever
+    becomes awaited (or starts calling a kernel/agent/LLM), this fails and the
+    gating question has to be answered again rather than silently inherited.
+    """
+
+    SYNC_STAGES = [
+        "_build_dung_framework_from_state",
+        "_detect_and_run_modal_analysis",
+        "_build_aspic_from_state",
+        "_run_belief_revision_from_state",
+    ]
+
+    _LLM_HINTS = ("openai", "completion", "kernel", "llm", "asyncio")
+
+    @pytest.mark.parametrize("name", SYNC_STAGES)
+    def test_stage_spends_no_wall_clock(self, name: str) -> None:
+        definition = next(
+            (
+                node
+                for node in ast.walk(_module_ast())
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == name
+            ),
+            None,
+        )
+        assert definition is not None, f"{name} disappeared — update this guard."
+
+        assert not isinstance(definition, ast.AsyncFunctionDef), (
+            f"`{name}` became async. It is one of the four post-loop stages left "
+            "ungated by `_budget_allows` on the grounds that it spends no wall "
+            "clock — re-examine whether it now needs the budget guard."
+        )
+
+        awaits = [n for n in ast.walk(definition) if isinstance(n, ast.Await)]
+        assert not awaits, f"`{name}` now awaits — see the message above."
+
+        calls = {
+            ast.unparse(n.func).lower()
+            for n in ast.walk(definition)
+            if isinstance(n, ast.Call)
+        }
+        suspicious = sorted(
+            c for c in calls if any(hint in c for hint in self._LLM_HINTS)
+        )
+        assert not suspicious, (
+            f"`{name}` now calls {suspicious} — it may issue LLM round-trips, "
+            "which would invalidate its exemption from the budget guard."
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Problème

`wall_clock_bounded` était posé à la brèche et **relu uniquement pour construire le dict de résultat** — aucun `if` ne le consultait. Même famille que « `degraded=True` sans consommateur » (anti-#1019) : un drapeau de reporting qui ne garde rien.

Conséquence mesurée : le cap signifiait « ne pas démarrer la **phase** suivante », pendant que la fonction continuait à dépenser du budget — une phase Re-Analysis conditionnelle entière (4 agents, gardée par le drapeau de *tours*, pas par l'horloge) puis cinq étages `spectacular` awaités. Le filet externe coupait la coroutine et **jetait l'état qu'elle venait de peupler** (constat R715 : 3 arguments extraits et des contre-arguments ajoutés 6 s avant la coupure, ligne rendue `— | 0/0 | —`).

## Ce que fait cette PR (item 3 de #1528, dans l'ordre publié)

1. **Un seul prédicat partagé** `_budget_allows(stage)`, branché sur `wall.is_exhausted()` — l'autorité qui existait déjà, pas un second mécanisme de budget. Il garde la phase Re-Analysis (qui ne consultait que le compteur de tours de CONV-C #1334) et les **cinq étages awaités** : `counter_arguments`, `formal_logic_enrichment`, `quality_sweep`, `stakes_extraction`, `deep_synthesis`.

2. **Contrôle avant le premier tour sur le chemin group-chat**, symétrique de celui du round-robin. Le round-robin vérifiait avant d'invoquer l'agent suivant ; le chemin `AgentGroupChat` — le chemin **vivant** depuis CD #1534 — invoquait sans condition et ne vérifiait qu'**après** la première réponse. Le test C1 existant ne couvrait pas ce chemin : il injecte un `AgentGroupChat` qui lève, précisément pour forcer le repli round-robin. Le nouveau test vise le chemin vivant, avec un mock **non-levant**, et assert que la classe n'est **jamais construite**.

3. **Aucun `execution_path` rapporté quand rien n'a tourné.** Avec le retour anticipé, la liste des chemins peut être vide ; l'agrégation d'origine aurait alors annoncé `round_robin_fallback` — soit exactement le défaut résiduel de CE #1537. Elle rend `None`, donc `—` comme tout mode qui n'enregistre pas de chemin.

### Correction d'un périmètre que j'avais publié incomplet

J'avais listé **cinq** étages `spectacular` sur #1528. Il y en a neuf. Les quatre autres — Dung, modal, ASPIC, révision de croyances — restent **délibérément non gardés** : `def` et non `async def`, aucun `await`, aucun appel kernel/agent/LLM (vérifié par AST, pas par lecture). Ils relisent un état déjà peuplé et coûtent des millisecondes ; les garder retirerait du contenu d'un verdict partiel honnête **sans économiser de temps**. Ce que le budget doit couper, c'est ce qui le **dépense**.

Un test épingle cette **raison** plutôt que la décision : si l'un d'eux devient awaité ou se met à appeler un kernel, il échoue et la question du gating doit être re-posée au lieu d'être héritée en silence.

### Anti-pendule

On ne **supprime** ni les étages post-boucle ni `spectacular` : ils produisent le contenu qui fait la valeur du mode. On les **saute quand le budget est épuisé**. Et le prédicat interroge `wall.is_exhausted`, pas `wall_clock_bounded` — ré-implémenter le garde sur le drapeau défectueux reconstruirait le défaut avec un `if` devant (test dédié).

## Deux défauts de mesure trouvés en validant

Ils ne sont pas cosmétiques : c'est par eux que la table de comparaison ment.

- **Zéro fabriqué.** `run_conversational_mode` lisait `result["extra_metrics"]["fallacy_count"]` — clé que l'orchestrateur **n'émet jamais** — donc le `0` par défaut était une valeur inventée, indiscernable d'un zéro observé ; `argument_count` n'était pas lu du tout. Les deux sont désormais **mesurés** depuis le snapshot d'état, absent → `None` (Track CG #1540), jamais un `0` fabriqué.
  *Note de méthode :* j'ai d'abord câblé ces compteurs sur `argument_count`/`fallacy_count`, clés bien présentes dans `shared_state.py` — mais **dans la branche `summarize=True` seulement**. Le chemin en service passe par `summarize=False` (`identified_arguments` / `identified_fallacies`). Le run suivant a rendu `—` partout : c'est la **re-mesure après correctif**, pas la relecture, qui l'a dit.
- **Dérive de doc** : `--max-wall-seconds` s'annonçait « for *the conversational mode* » alors qu'il borne **tous** les modes (constante renommée en conséquence) ; deux docstrings décrivaient la ligne du filet comme « 0 % fill » là où CG laisse ces champs à `None`.

## Preuve firsthand (bornée, 3 corpus)

Avant : **aucune** ligne conversationnelle peuplée — le filet coupait, la ligne rendait `—`.

Après, sur un run borné : la ligne sort **proprement au cap**, `1/3` phases, `AgentGroupChat`, `Decides ✅`, taux de remplissage et compteurs **mesurés** (`1` argument, `4` sophismes, `0.157`), les six lignes de skip journalisées dans la même seconde.

**Résidu, mesuré et non extrapolé.** Sur d'autres corpus le filet se déclenche encore, et la cause n'est pas celle que cette PR traite : la **première invocation d'agent elle-même ne rend jamais la main**. Sur deux corpus, `Invoking agent ProjectManager` est journalisé au démarrage, **aucune ligne `Turn 1:` n'apparaît jamais**, et **12 aller-retours LLM** s'enchaînent à l'intérieur de cette unique invocation jusqu'au filet. Aucun contrôle *entre les tours* — y compris celui ajouté ici — ne peut se déclencher à l'intérieur d'un tour qui ne se termine pas. Le palier de 30 s du filet avait été dimensionné pour « un seul aller-retour LLM en vol » ; l'hypothèse ne tient pas pour un agent à function-calling.

Cette borne-là est **intra-invocation** (timeout par requête dérivé du budget restant, ou `wait_for` sur chaque `__anext__`) : elle relève de l'item 5 de #1528, pas de l'item 3. Elle est maintenant chiffrée plutôt que soupçonnée.

## Tests

17 tests, tous sans LLM :
- 3 comportementaux sur le chemin de la deadline — **vérifiés par mutation** : en neutralisant le contrôle d'entrée, les deux assertions échouent avec leur message prévu, puis la ligne a été restaurée à l'identique ;
- 7 gardes AST sur le câblage du budget (les six sites + « un seul prédicat » + « il interroge le budget, pas le drapeau ») ;
- 4 épinglant la raison de l'exemption des étages synchrones ;
- 3 sur les compteurs mesurés depuis le snapshot.

`black` + `flake8` propres sur les quatre fichiers.

## Fichiers

| Fichier | Rôle |
|---|---|
| `argumentation_analysis/orchestration/conversational_orchestrator.py` | prédicat partagé, 6 sites gardés, contrôle d'entrée group-chat, agrégation `execution_path` honnête |
| `scripts/compare_orchestration_modes.py` | compteurs mesurés depuis le snapshot, dérive de doc |
| `tests/unit/.../test_cb1528_postcap_budget.py` | nouveau — 14 tests |
| `tests/scripts/test_compare_orchestration_modes_1480.py` | +3 tests sur les compteurs |

Refs #1528, #1500
