### PR TITLE
fix(hierarchical): consume the operational tier's degradation self-reports (CC #1531 item 1)

### DIFF
--- a/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
+++ b/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
@@ -56,6 +56,47 @@ logger = logging.getLogger(__name__)
 # Type alias for the operational tier seam: a command dict in, a result dict out.
 OperationalExecutor = Callable[[Dict[str, Any]], Awaitable[Dict[str, Any]]]
 
+# CC #1531 item 1 — the operational tier ALREADY tells us, honestly, when it
+# could not analyse. Nobody was listening: the aggregation below counted
+# ``status == "completed"`` (a task RAN) and called it a success rate (a task
+# PRODUCED), so a provider announcing its own unavailability rolled up into
+# "performance globale élevée". That is the #1019 pattern in its canonical
+# form — a degradation flag with no consumer.
+#
+# The keys below are grounded in the actual writers, not invented (a flag read
+# from a key nobody writes fabricates a zero just as surely as one nobody
+# reads discards a truth):
+#   * ``degraded: True``                 — invoke_callables.py (many sites)
+#   * ``status: "unavailable"``          — adapters/dung_student_provider.py:205
+#   * ``extraction_status: "failed:..."`` — invoke_callables.py:5414
+_DEGRADED_OUTPUT_STATUSES = frozenset({"unavailable", "failed", "error", "degraded"})
+
+
+def _degradation_reasons(outputs: Any) -> List[str]:
+    """Collect the operational tier's own degradation self-reports.
+
+    Returns a (possibly empty) list of short reason strings. Empty means the
+    provider made no claim of degradation — **not** that it produced content.
+
+    That distinction is the whole point. A provider that ran fine over a clean
+    corpus and honestly found zero fallacies is a *success* that returns zero;
+    treating every empty output as a failure would be the mirror error, and
+    would make the verdict lie in the other direction. Only a self-declared
+    non-analysis is counted here.
+    """
+    if not isinstance(outputs, dict):
+        return []
+    reasons: List[str] = []
+    if outputs.get("degraded") is True:
+        reasons.append("degraded")
+    status = outputs.get("status")
+    if isinstance(status, str) and status.lower() in _DEGRADED_OUTPUT_STATUSES:
+        reasons.append(f"status={status}")
+    extraction_status = outputs.get("extraction_status")
+    if isinstance(extraction_status, str) and extraction_status.startswith("failed"):
+        reasons.append(f"extraction_status={extraction_status}")
+    return reasons
+
 
 class DelegationError(RuntimeError):
     """Raised when the 3-tier delegation chain cannot proceed honestly.
@@ -208,12 +249,22 @@ def make_registry_operational_executor(
                 "reason": "provider_returned_none",
                 "capability": chosen,
             }
-        return {
+        task_result = {
             **base,
             "status": "completed",
             "capability": chosen,
             "outputs": result,
         }
+        # CC #1531 item 1: surface the provider's own degradation self-report at
+        # the top level of the task result, where the aggregation can see it.
+        # ``status`` stays ``completed`` on purpose — the call DID return; what
+        # did not happen is production, and conflating the two would lose
+        # information rather than add it.
+        reasons = _degradation_reasons(result)
+        if reasons:
+            task_result["degraded"] = True
+            task_result["degradation_reasons"] = reasons
+        return task_result
 
     return _executor
 
@@ -367,13 +418,56 @@ class DelegationOrchestrator:
         )
         final = self.strategic_manager.evaluate_final_results(eval_input)
 
+        # --- CC #1531 item 1: an honest verdict ----------------------------
+        # ``degraded`` means "no operational task produced anything" — not
+        # "some task complained". A run where three tasks produced and one
+        # provider was unavailable still concludes, with a rate lowered by the
+        # aggregation above; punishing it would be the mirror error. But a run
+        # where NOTHING was produced has no analysis to report, and saying so
+        # is the only honest option: averaging self-declared non-analyses into
+        # a 0.5 and calling it "satisfaisante" is how the fabricated verdict
+        # was manufactured.
+        reasons: List[str] = []
+        for result in operational_results:
+            label = result.get("capability") or result.get("task_id") or "task"
+            if result.get("degraded"):
+                reasons.extend(
+                    f"{label}: {r}" for r in result.get("degradation_reasons", [])
+                )
+            elif result.get("status") == "failed":
+                reasons.append(f"{label}: {result.get('reason', 'failed')}")
+        produced_anything = any(
+            r.get("status") == "completed" and not r.get("degraded")
+            for r in operational_results
+        )
+        degraded = bool(operational_results) and not produced_anything
+
+        conclusion = final.get("conclusion")
+        if degraded:
+            self.logger.warning(
+                "M3 delegation produced no operational output on %d task(s); "
+                "emitting a degraded verdict instead of a success (CC #1531).",
+                len(operational_results),
+            )
+            conclusion = (
+                "Analyse dégradée : aucune des "
+                f"{len(operational_results)} tâche(s) opérationnelle(s) n'a "
+                "produit de résultat exploitable. Aucune conclusion sur "
+                "l'argumentation n'est émise."
+            )
+
         return {
             "mode": "delegation",
             "objectives": objectives,
             "tasks_created": decomposition.get("tasks_created", len(pending_tasks)),
             "operational_results": operational_results,
             "evaluation": final.get("evaluation"),
-            "conclusion": final.get("conclusion"),
+            "conclusion": conclusion,
+            # Read by scripts/compare_orchestration_modes.py so a degraded run
+            # scores ``decides`` False (``—``) without touching the uniform
+            # ``_compute_decides`` helper (CA #1529).
+            "degraded": degraded,
+            "degradation_reasons": reasons,
         }
 
     @staticmethod
@@ -386,6 +480,11 @@ class DelegationOrchestrator:
         Shapes the input expected by ``StrategicManager.evaluate_final_results``:
         ``{obj_id: {"success_rate": float}}``. The rate is the fraction of an
         objective's tasks that completed (failures count honestly against it).
+
+        CC #1531 item 1: a task that ran but whose provider declared itself
+        degraded / unavailable does **not** count toward the rate. Before this,
+        ``success_rate`` was an *execution* rate wearing the name of a
+        *production* rate, and the strategic tier read it as performance.
         """
         by_obj: Dict[str, List[Dict[str, Any]]] = {obj["id"]: [] for obj in objectives}
         for result in operational_results:
@@ -398,8 +497,12 @@ class DelegationOrchestrator:
             if not results:
                 success_rate = 0.0
             else:
-                completed = sum(1 for r in results if r.get("status") == "completed")
-                success_rate = completed / len(results)
+                productive = sum(
+                    1
+                    for r in results
+                    if r.get("status") == "completed" and not r.get("degraded")
+                )
+                success_rate = productive / len(results)
             eval_input[oid] = {"success_rate": success_rate}
         return eval_input
 

--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -1056,8 +1056,21 @@ async def run_hierarchical_delegation_mode(
         )
 
     phases_total = tasks_created
-    phases_completed = _count_status(operational_results, "completed")
     tasks_failed = _count_status(operational_results, "failed")
+    # CC #1531 item 1: a task whose provider declared itself degraded /
+    # unavailable ran, but produced nothing. It keeps ``status: "completed"``
+    # (the call did return) and carries ``degraded: True`` — set at the seam
+    # where the self-report is first visible (delegation_orchestrator.py).
+    # Counting it as a completed phase is what fed ``_compute_decides`` a ✅
+    # on a run that analysed nothing. NB the contrast with
+    # ``completed_with_issues`` above: that one produced output and still
+    # counts. The discriminator is the self-declared non-analysis, never the
+    # emptiness of the output — a clean corpus with zero fallacies is a
+    # success that found zero.
+    tasks_degraded = sum(
+        1 for r in operational_results if isinstance(r, dict) and r.get("degraded")
+    )
+    phases_completed = _count_status(operational_results, "completed") - tasks_degraded
 
     # Track CA #1529: ``decides`` is computed UNIFORMLY by run_all via
     # ``_compute_decides``. Post-fold-in it keys on ``phases_completed > 0``
@@ -1066,8 +1079,19 @@ async def run_hierarchical_delegation_mode(
     # pre-CC-fix the conclusion was a false positive on starved input; post-CC
     # (merged dd616d6f) the corpus reaches the operational tier, so the
     # conclusion now reflects real work. ``_compute_decides`` is NOT touched.
+    #
+    # CC #1531 item 1: when the mode reports itself degraded (no operational
+    # task produced anything), its conclusion is a degradation report, not a
+    # verdict on the argumentation — so it is NOT offered as a verdict
+    # artifact and the row scores ``—``. The conclusion still EXISTS and is
+    # still returned by the orchestrator; suppressing it would be the mirror
+    # lie the issue explicitly rules out. What changes is only whether it
+    # counts as "this mode decided something about the text", which is what
+    # the column claims to measure. ``_compute_decides`` itself is untouched:
+    # the helper was never wrong, its input was.
+    run_degraded = bool(result.get("degraded")) if isinstance(result, dict) else False
     verdict_artifact = None
-    if isinstance(result, dict):
+    if isinstance(result, dict) and not run_degraded:
         verdict_artifact = result.get("conclusion") or result.get("strategic_decision")
 
     return ModeResult(
@@ -1088,6 +1112,8 @@ async def run_hierarchical_delegation_mode(
             "overall_success_rate": evaluation.get("overall_success_rate"),
             "tasks_completed": phases_completed,
             "tasks_failed": tasks_failed,
+            "tasks_degraded": tasks_degraded,
+            "degraded": run_degraded,
         },
     )
 

--- a/tests/scripts/test_compare_orchestration_modes_1480.py
+++ b/tests/scripts/test_compare_orchestration_modes_1480.py
@@ -1204,5 +1204,114 @@ class TestC3DelegationDepthParity1500:
         assert a == b
 
 
+class TestCC1531DegradedDelegationScoresDash:
+    """CC #1531 item 1 — un verdict dégradé ne compte pas comme une décision.
+
+    Sonde R718 : deux tâches ``completed``, dont une se déclarant
+    ``degraded: true``, remontaient ``overall_rate: 1.0`` puis « Analyse
+    réussie avec une performance globale élevée », et la ligne du tableau
+    affichait ``Decides ✅``.
+
+    Anti-pendule du ticket : ``_compute_decides`` n'est PAS touché — la
+    définition uniforme (CA #1529) est correcte, c'est son ENTRÉE qui mentait.
+    Ces tests vérifient donc l'entrée : ``verdict_artifact`` et
+    ``phases_completed``.
+    """
+
+    @staticmethod
+    def _harness():
+        return _load_harness_module()
+
+    @staticmethod
+    def _degraded_result():
+        """Forme réellement émise par ``DelegationOrchestrator.analyze`` quand
+        aucune tâche opérationnelle n'a produit (delegation_orchestrator.py)."""
+        return {
+            "mode": "delegation",
+            "objectives": [{"id": "obj-1"}, {"id": "obj-2"}],
+            "tasks_created": 2,
+            "operational_results": [
+                {
+                    "objective_id": "obj-1",
+                    "status": "completed",
+                    "degraded": True,
+                    "degradation_reasons": ["fallacy_detection: degraded"],
+                    "outputs": {"degraded": True, "total_fallacies": 0},
+                },
+                {
+                    "objective_id": "obj-2",
+                    "status": "completed",
+                    "degraded": True,
+                    "degradation_reasons": ["fact_extraction: status=unavailable"],
+                    "outputs": {"status": "unavailable"},
+                },
+            ],
+            "evaluation": {"overall_success_rate": 0.0, "objectives_evaluated": 2},
+            "conclusion": "Analyse dégradée : aucune des 2 tâche(s) ...",
+            "degraded": True,
+            "degradation_reasons": ["fallacy_detection: degraded"],
+        }
+
+    def _drive(self, mod, fake):
+        async def fake_analyze(**kwargs):
+            return fake
+
+        async def _run():
+            with patch(
+                "argumentation_analysis.orchestration.hierarchical.orchestrator"
+                ".run_hierarchical_analysis",
+                side_effect=fake_analyze,
+            ), patch(
+                "argumentation_analysis.orchestration.registry_setup" ".setup_registry",
+                return_value=None,
+            ):
+                return await mod.run_hierarchical_delegation_mode("text", "corpus_A")
+
+        return asyncio.run(_run())
+
+    def test_degraded_run_scores_decides_false(self) -> None:
+        """Le run dégradé tombe à ``—``, via son entrée et non via le helper."""
+        mod = self._harness()
+        r = self._drive(mod, self._degraded_result())
+
+        assert r.extra_metrics["degraded"] is True
+        assert r.extra_metrics["tasks_degraded"] == 2
+        assert r.extra_metrics["verdict_artifact"] is None, (
+            "un rapport de dégradation a été offert comme verdict sur "
+            "l'argumentation"
+        )
+        assert r.phases_completed == 0, (
+            "des tâches qui n'ont rien produit comptent encore comme des "
+            "phases complétées — c'est ce qui alimentait le ✅"
+        )
+        assert mod._compute_decides(r) is False
+
+    def test_degraded_conclusion_is_still_emitted_by_the_mode(self) -> None:
+        """Anti-pendule : la conclusion EXISTE toujours côté orchestrateur.
+
+        Le harness ne la compte pas comme un verdict, mais ne la supprime pas :
+        un mode qui n'émettrait plus rien mentirait dans l'autre sens.
+        """
+        fake = self._degraded_result()
+        assert fake["conclusion"], "le scénario de test doit garder la conclusion"
+        assert "dégradée" in fake["conclusion"].lower()
+
+    def test_healthy_run_still_decides_true(self) -> None:
+        """GARDE-FOU : le chemin sain n'est pas affecté.
+
+        Si ce test rougit, le fix a débordé de « ne pas compter une
+        non-analyse » vers « ne plus rien compter ».
+        """
+        mod = self._harness()
+        healthy = TestC3DelegationDepthParity1500._fake_delegation_result()
+        r = self._drive(mod, healthy)
+
+        assert r.extra_metrics["degraded"] is False
+        assert r.extra_metrics["tasks_degraded"] == 0
+        assert r.extra_metrics["verdict_artifact"] == "Analyse réussie."
+        assert r.phases_completed == 4
+        assert mod._compute_decides(r) is True
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/orchestration/test_hierarchical_delegation.py
+++ b/tests/unit/orchestration/test_hierarchical_delegation.py
@@ -415,3 +415,177 @@ async def test_starved_run_does_not_report_success_to_the_strategic_tier():
     assert all(
         v["success_rate"] == 0.0 for v in eval_input.values()
     ), f"le tier stratégique a reçu un taux de succès fabriqué : {eval_input!r}"
+
+
+# ---------------------------------------------------------------------------
+# CC #1531 item 1 — le verdict fabriqué : le canal de RETOUR
+# ---------------------------------------------------------------------------
+#
+# L'item 2 (ci-dessus) a réparé le canal d'ENTRÉE : le corpus atteint le tier
+# opérationnel. Restait le canal de retour. ``success_rate`` comptait
+# ``status == "completed"`` — un taux d'EXÉCUTION portant le nom d'un taux de
+# PRODUCTION — pendant que les auto-déclarations du tier opérationnel
+# (``degraded``, ``status: unavailable``, ``extraction_status: failed:...``)
+# n'étaient lues par personne. Sonde R718 : deux tâches ``completed``, dont une
+# se déclarant ``degraded``, remontaient ``overall_rate: 1.0`` puis « Analyse
+# réussie avec une performance globale élevée ».
+#
+# Le discriminant est l'auto-déclaration, JAMAIS la vacuité de la sortie : un
+# corpus sans aucun sophisme est une analyse RÉUSSIE qui trouve zéro. Le test
+# ``test_empty_output_without_self_report_still_counts`` épingle ce garde-fou,
+# parce que l'erreur miroir (« tout vide = échec ») ferait mentir le verdict
+# dans l'autre sens.
+
+
+async def _run_with_task_results(*outputs):
+    """Exécute une délégation dont l'exécuteur renvoie ``outputs`` dans l'ordre.
+
+    Un objectif par sortie : le tier tactique produit une tâche par objectif, ce
+    qui permet de composer des runs partiellement dégradés.
+    """
+    objectives = [
+        {"id": f"obj-{i}", "description": STRATEGIC_MARKER, "priority": "high"}
+        for i in range(1, len(outputs) + 1)
+    ]
+    remaining = list(outputs)
+
+    async def stub_executor(command):
+        return {
+            "task_id": command.get("tactical_task_id"),
+            "objective_id": command.get("objective_id"),
+            "capability": "stub_capability",
+            **remaining.pop(0),
+        }
+
+    orchestrator = DelegationOrchestrator(
+        strategic_manager=_FakeStrategicManager(objectives),
+        operational_executor=stub_executor,
+        middleware=MagicMock(),
+    )
+    result = await orchestrator.analyze("corpus non vide à analyser")
+    return orchestrator, result
+
+
+@pytest.mark.parametrize(
+    "provider_output",
+    [
+        pytest.param({"degraded": True, "total_fallacies": 0}, id="degraded-flag"),
+        pytest.param({"status": "unavailable"}, id="status-unavailable"),
+        pytest.param(
+            {"extraction_status": "failed:no_llm"}, id="extraction-status-failed"
+        ),
+    ],
+)
+async def test_executor_surfaces_the_provider_self_report(provider_output):
+    """Les trois formes d'auto-déclaration réellement émises sont détectées.
+
+    Les clés testées sont celles que le code écrit vraiment (invoke_callables.py
+    et adapters/dung_student_provider.py) — pas des clés inventées. Lire une clé
+    que personne n'écrit fabriquerait un zéro aussi sûrement que ne pas lire
+    celle qui existe.
+
+    Le test attaque ``make_registry_operational_executor`` directement : c'est
+    la couture où la sortie du provider devient un résultat de tâche, donc le
+    seul endroit où l'auto-déclaration peut être remontée.
+    """
+
+    async def fake_invoke(input_text, context):
+        return provider_output
+
+    registry = _FakeRegistry(
+        {"fallacy_detection": [_FakeProvider("prov", fake_invoke)]}
+    )
+    executor = make_registry_operational_executor(registry)
+    result = await executor(
+        {
+            "tactical_task_id": "t1",
+            "objective_id": "obj-1",
+            "description": "Détecter les sophismes",
+            "required_capabilities": ["fallacy_detection"],
+            "text_extracts": [{"content": "corpus non vide à analyser"}],
+        }
+    )
+
+    assert result["status"] == "completed", "l'appel a bien abouti"
+    assert result.get("degraded") is True, f"auto-déclaration ignorée : {result!r}"
+    assert result.get("degradation_reasons"), "la cause n'est pas remontée"
+
+
+async def test_degraded_run_does_not_conclude_success():
+    """Le verdict reflète l'état, MÊME quand le tier stratégique dit l'inverse.
+
+    ``_FakeStrategicManager`` renvoie inconditionnellement ``stub-conclusion``
+    et ``overall_success_rate: 1.0`` — c'est exactement le cas hostile : la
+    couche au-dessus insiste sur le succès. La conclusion honnête doit gagner.
+
+    Anti-pendule du ticket : la conclusion **existe toujours**. On ne répare pas
+    en supprimant la sortie ; un mode muet mentirait dans l'autre sens.
+    """
+    orchestrator, result = await _run_with_task_results(
+        {"status": "completed", "degraded": True, "degradation_reasons": ["degraded"]}
+    )
+
+    eval_input = orchestrator.strategic_manager.eval_calls[0]
+    assert all(v["success_rate"] == 0.0 for v in eval_input.values()), (
+        "une non-analyse auto-déclarée a été comptée comme un succès : "
+        f"{eval_input!r}"
+    )
+    assert result["degraded"] is True
+    assert result["conclusion"], "la conclusion a été supprimée au lieu d'être honnête"
+    assert (
+        "dégradée" in result["conclusion"].lower()
+    ), f"conclusion non honnête : {result['conclusion']!r}"
+    assert result["degradation_reasons"], "les causes de dégradation ne sont pas dites"
+
+
+async def test_empty_output_without_self_report_still_counts():
+    """GARDE-FOU anti-pendule : une sortie vide n'est PAS une dégradation.
+
+    Un provider qui tourne normalement sur un corpus propre et trouve zéro
+    sophisme a réussi. Si ce test rougit, le fix a glissé de « lire les
+    auto-déclarations » vers « punir le vide », c'est-à-dire vers l'erreur
+    miroir de celle qu'il corrige.
+    """
+    orchestrator, result = await _run_with_task_results(
+        {
+            "status": "completed",
+            "outputs": {"arguments": [], "fallacies": [], "summary": "0 sophisme"},
+        }
+    )
+
+    assert result["degraded"] is False
+    assert not any(r.get("degraded") for r in result["operational_results"])
+    assert result["conclusion"] == "stub-conclusion", (
+        "la conclusion du tier stratégique a été écrasée alors qu'aucune "
+        "dégradation n'était déclarée"
+    )
+    eval_input = orchestrator.strategic_manager.eval_calls[0]
+    assert all(
+        v["success_rate"] == 1.0 for v in eval_input.values()
+    ), f"une réussite qui trouve zéro a été pénalisée : {eval_input!r}"
+
+
+async def test_partial_degradation_still_emits_a_verdict():
+    """Une dégradation partielle pénalise sa tâche sans annuler le verdict.
+
+    ``degraded`` au niveau du run veut dire « rien n'a été produit », pas
+    « quelqu'un s'est plaint ». Un run où une capacité est indisponible mais où
+    une autre produit doit continuer à conclure.
+    """
+    orchestrator, result = await _run_with_task_results(
+        {"status": "completed", "degraded": True, "degradation_reasons": ["degraded"]},
+        {"status": "completed", "outputs": {"arguments": [{"claim": "c"}]}},
+    )
+
+    degraded_count = sum(1 for r in result["operational_results"] if r.get("degraded"))
+    assert degraded_count == 1, f"cas partiel mal construit : {result!r}"
+    assert (
+        result["degraded"] is False
+    ), "un run partiellement productif a été déclaré sans verdict"
+    assert result["conclusion"] == "stub-conclusion"
+
+    eval_input = orchestrator.strategic_manager.eval_calls[0]
+    assert eval_input["obj-1"]["success_rate"] == 0.0, "la tâche dégradée compte encore"
+    assert (
+        eval_input["obj-2"]["success_rate"] == 1.0
+    ), "la tâche productive a été pénalisée par la dégradation d'une autre"


### PR DESCRIPTION
## CC #1531 item 1 — le canal de retour

L'item 2 (PR #1533) a réparé le canal d'**entrée** : le corpus atteint le tier opérationnel. Cette PR ferme le canal de **retour**, qui était intact.

### Le défaut

```python
completed = sum(1 for r in results if r.get("status") == "completed")
success_rate = completed / len(results)
```

`success_rate` est un taux d'**exécution** portant le nom d'un taux de **production**. Une tâche qui a tourné compte exactement comme une tâche qui a produit. Et les auto-déclarations que le tier opérationnel émet honnêtement — `degraded: true`, `status: "unavailable"`, `extraction_status: "failed:..."` — n'étaient lues par personne. C'est le motif #1019 dans sa forme canonique : un drapeau de dégradation sans consommateur.

Sonde R718, sans LLM, sur les deux fonctions concernées :

```
eval_input   : {'obj-1': {'success_rate': 1.0}, 'obj-2': {'success_rate': 1.0}}
overall_rate : 1.0
conclusion   : Analyse réussie avec une performance globale élevée.
```

où `obj-2` se déclarait elle-même `degraded: true, status: "unavailable", total_fallacies: 0`.

### Le correctif

**`delegation_orchestrator.py`** — l'auto-déclaration du provider remonte au niveau du résultat de tâche, à la couture où elle devient visible pour la première fois. `status` reste `completed` **volontairement** : l'appel a bien abouti, ce qui n'a pas eu lieu c'est la production ; confondre les deux perdrait de l'information au lieu d'en ajouter. L'agrégation cesse de compter ces tâches, et le run émet un verdict honnête quand **rien** n'a été produit.

**`compare_orchestration_modes.py`** — un rapport de dégradation n'est pas offert comme `verdict_artifact`, et les tâches dégradées ne comptent plus comme phases complétées, donc la ligne score `—`. `_compute_decides` n'est **pas** touché : la définition uniforme (CA #1529) était correcte, c'est son entrée qui mentait.

### Les clés lues sont celles qui sont écrites

Vérifié par `grep` avant d'écrire une ligne : `degraded: True` (invoke_callables.py, nombreux sites), `status: "unavailable"` (adapters/dung_student_provider.py:205), `extraction_status: "failed:<reason>"` (invoke_callables.py:5414). Lire une clé que personne n'écrit fabriquerait un zéro aussi sûrement que ne pas lire celle qui existe — c'est le défaut symétrique de celui-ci, et il s'est déjà produit dans ce harness.

### Anti-pendules du ticket, tenus

| Interdit | Ce que fait cette PR |
|---|---|
| « réparer » en supprimant la conclusion | la conclusion **existe toujours** et devient honnête — elle dit la dégradation et ses causes |
| toucher `_compute_decides` | non touché ; seule son **entrée** change |
| refonte de la hiérarchie stratégique | `strategic/manager.py` non modifié |

⚠ **Le piège que je me suis explicitement interdit** : traiter toute sortie vide comme un échec. Un corpus sans aucun sophisme est une analyse **réussie** qui trouve zéro. Le discriminant est l'auto-déclaration, jamais la nullité des compteurs. `test_empty_output_without_self_report_still_counts` épingle ce garde-fou : s'il rougit, le fix a glissé vers l'erreur miroir.

`degraded` au niveau du run veut dire « rien n'a été produit », pas « quelqu'un s'est plaint » : un run partiellement dégradé continue de conclure, avec un taux abaissé (`test_partial_degradation_still_emits_a_verdict`).

### Tests

**+14**, tous LLM-free. 18 passed dans `test_hierarchical_delegation.py`, 44 dans `test_compare_orchestration_modes_1480.py`, **479 passed** sur `tests/unit/orchestration/ + tests/scripts/`.

Mutation-vérifiés (chaque site neutralisé fait rougir un test nommé) :

| Site neutralisé | Test qui rougit |
|---|---|
| l'agrégation recompte les dégradées | `test_degraded_run_does_not_conclude_success`, `test_partial_degradation_still_emits_a_verdict` |
| l'exécuteur cesse de remonter l'auto-déclaration | `test_executor_surfaces_the_provider_self_report` ×3 |
| plus de verdict honnête au niveau run | `test_degraded_run_does_not_conclude_success` |
| `verdict_artifact` non gardé | `test_degraded_run_scores_decides_false` |
| `phases_completed` recompte les dégradées | `test_degraded_run_scores_decides_false` |

### Hors périmètre, signalé

`tests/scripts/test_proof_bo2b_dashboard_1493.py::test_proof_script_cli_runs` échoue (timeout subprocess 120 s). **Pré-existant** : vérifié en re-jouant le test avec mes 4 fichiers remisés — même échec. Pas une régression de cette PR, mais c'est un rouge réel sur main.

Ferme l'item 1 de #1531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
