### PR TITLE
fix(conversational): guard growth re-prompt loops against an expired deadline (CB #1528 item 4)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -2022,6 +2022,23 @@ async def _run_phase(
                 speaking_agent = _find_agent_by_name(agents, msg_entry["agent"])
                 if speaking_agent is not None:
                     for rp in range(growth_re_prompt_limit):
+                        # CB #1528 item 4: a re-prompt is a fresh LLM invocation
+                        # and the turn's first agent.invoke may have consumed the
+                        # whole budget already. Re-check the deadline BEFORE each
+                        # re-prompt (the entry-of-phase check at L1896 only guards
+                        # entering the phase; the group-chat path is the live one
+                        # since CD #1534, so this is an active post-cap LLM site).
+                        # The intra-invocation case (a single invoke that never
+                        # yields) is item 5, not item 4 — this guard catches the
+                        # inter-re-prompt case.
+                        if deadline is not None and time.time() >= deadline:
+                            logger.info(
+                                f"  [{phase_name}] Wall-clock deadline atteinte "
+                                f"avant le growth re-prompt {rp + 1}/"
+                                f"{growth_re_prompt_limit} (group-chat path) ; "
+                                f"re-prompts restants annulés."
+                            )
+                            break
                         logger.info(
                             f"  [{phase_name}] Growth re-prompt {rp + 1}/"
                             f"{growth_re_prompt_limit} (group-chat path)"
@@ -2185,6 +2202,19 @@ async def _run_phase(
                 fp_after = _get_growth_fingerprint(state)
                 if not _validate_state_growth(fp_before, fp_after, phase_name):
                     for rp in range(growth_re_prompt_limit):
+                        # CB #1528 item 4: same deadline guard as the group-chat
+                        # re-prompt loop above (symmetric). The round-robin path's
+                        # re-prompt is also a fresh LLM invocation that must not
+                        # fire after the wall-clock budget is exhausted. Mirrors
+                        # the entry-of-phase check (L1896) inside the loop.
+                        if deadline is not None and time.time() >= deadline:
+                            logger.info(
+                                f"  [{phase_name}] Wall-clock deadline atteinte "
+                                f"avant le growth re-prompt {rp + 1}/"
+                                f"{growth_re_prompt_limit} (round-robin path) ; "
+                                f"re-prompts restants annulés."
+                            )
+                            break
                         logger.info(
                             f"  [{phase_name}] Growth re-prompt {rp + 1}/{growth_re_prompt_limit}"
                         )

--- a/tests/unit/argumentation_analysis/orchestration/test_cf1538_growth_validation_groupchat.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_cf1538_growth_validation_groupchat.py
@@ -30,6 +30,8 @@ see the PR body / dashboard [DONE].
 from __future__ import annotations
 
 import asyncio
+import time
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -302,3 +304,111 @@ class TestCF1538NonRegression:
         assert _find_agent_by_name([a], "Unknown") is None
         assert _find_agent_by_name([a], None) is None
         assert _find_agent_by_name([], "Anybody") is None
+
+
+# ---------------------------------------------------------------------------
+# CB #1528 item 4 — deadline guard inside the group-chat re-prompt loop.
+# The coord's R717 comment on #1528 formally split the track: item 3
+# (``#1544``) guards the entry of the phase + the awaited spectacular stages;
+# item 4 is the control *inside* the two growth re-prompt loops (group-chat +
+# round-robin). The group-chat loop lives here (CF #1538); the round-robin
+# loop is covered in test_growth_validation_hook_597.py. A re-prompt is a
+# fresh ``speaking_agent.invoke`` LLM call — after the turn's first invoke
+# consumed budget, the deadline may have expired, so each re-prompt must
+# re-check ``deadline`` before firing (the entry-of-phase check at L1896 only
+# guards entering the phase). The intra-invocation case (a single invoke that
+# never yields) is item 5, not item 4.
+# ---------------------------------------------------------------------------
+
+
+class TestCB1528Item4GroupChatDeadlineGuard:
+    def test_reprompt_cancelled_when_deadline_expired(self, caplog):
+        """CB #1528 item 4 (group-chat path): when ``deadline`` has expired by
+        re-prompt time, the loop MUST ``break`` before invoking the speaking
+        agent — no post-cap LLM call. The group-chat path is the live one since
+        CD #1534, so this is an active post-cap LLM site, not dead code.
+
+        Isolating item 4 from the entry-of-phase check (L1896) requires the
+        clock to read ``< deadline`` at phase entry AND at the between-turn
+        check (L1996), but ``>= deadline`` at the re-prompt guard. The mocked
+        ``chat.invoke()`` is instant, so we advance a fake clock between those
+        sites: the first ``time.time()`` calls return ``entry_time`` (entry +
+        between-turn checks pass), subsequent calls return ``post_turn_time``
+        (the re-prompt guard fires). Asserts both the no-invoke contract and
+        the loud skip log.
+        """
+        agent = _make_speaking_agent()
+        state = _empty_growth_state()
+        fake_chat = _FakeGroupChat(agents=[agent])
+        entry_time = 1000.0
+        post_turn_time = entry_time + 10000.0
+        deadline = entry_time + 1.0  # future at entry, expired by re-prompt
+        call_count = [0]
+
+        def fake_time():
+            call_count[0] += 1
+            # Call order in _run_phase for one mocked turn: (1) entry check
+            # L1896, (2) one call during turn processing, (3) between-turn
+            # check L1996 — all three must see entry_time (< deadline) so the
+            # turn completes and reaches growth validation. The re-prompt guard
+            # L2025 is the next call → sees post_turn_time (>= deadline) → fires.
+            return entry_time if call_count[0] <= 3 else post_turn_time
+
+        with caplog.at_level(logging.INFO, logger="ConversationalOrchestrator"):
+            with patch(_GC_PATCH, return_value=fake_chat):
+                with patch(
+                    "argumentation_analysis.orchestration.conversational_orchestrator.time.time",
+                    side_effect=fake_time,
+                ):
+                    asyncio.run(
+                        _run_phase(
+                            agents=[agent],
+                            initial_prompt="extract",
+                            max_turns=2,
+                            phase_name="Extraction & Detection",
+                            state=state,
+                            enable_growth_validation=True,
+                            growth_re_prompt_limit=2,
+                            deadline=deadline,
+                        )
+                    )
+        assert len(agent.invoke_calls) == 0, (
+            "speaking_agent.invoke called despite the deadline being expired at "
+            "re-prompt time — the CB #1528 item 4 deadline guard did not fire on "
+            "the group-chat re-prompt path (a post-cap LLM call leaked through)"
+        )
+        # Loud skip: the cancellation is logged (anti-silent-fail, #1019).
+        assert any(
+            "deadline atteinte" in rec.message and "group-chat path" in rec.message
+            for rec in caplog.records
+        ), "no deadline-skip log emitted on the group-chat path (CB #1528 item 4)"
+
+    def test_reprompt_fires_when_deadline_in_future(self):
+        """Symmetric guard: a deadline comfortably in the future does NOT block
+        the re-prompt — the item-4 guard must not regress the CF #1538 re-prompt
+        contract (a zero-growth turn still triggers a re-prompt when budget
+        remains). Confirms the guard is conditional, not unconditional.
+        """
+        agent = _make_speaking_agent()
+        state = _empty_growth_state()
+        fake_chat = _FakeGroupChat(agents=[agent])
+        # deadline 1h in the future → guard does not fire.
+        future_deadline = time.time() + 3600.0
+        with patch(_GC_PATCH, return_value=fake_chat):
+            asyncio.run(
+                _run_phase(
+                    agents=[agent],
+                    initial_prompt="extract",
+                    max_turns=2,
+                    phase_name="Extraction & Detection",
+                    state=state,
+                    enable_growth_validation=True,
+                    growth_re_prompt_limit=2,
+                    deadline=future_deadline,
+                )
+            )
+        assert len(agent.invoke_calls) >= 1, (
+            "speaking_agent.invoke NOT called despite deadline being in the "
+            "future — the CB #1528 item 4 guard over-fired and cancelled a "
+            "legitimate re-prompt (regression of the CF #1538 contract)"
+        )

--- a/tests/unit/argumentation_analysis/orchestration/test_growth_validation_hook_597.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_growth_validation_hook_597.py
@@ -7,7 +7,10 @@ Verifies:
 - enable_growth_validation=False disables re-prompting
 - Telemetry re_prompt_count appears in messages
 """
+
 import asyncio
+import time
+import logging
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -265,6 +268,86 @@ class TestRunPhaseGrowthHook:
 
         # Growth happened via re-prompt
         assert len(mock_state.identified_arguments) == 1
+
+
+class TestCB1528Item4RoundRobinDeadlineGuard:
+    """CB #1528 item 4 (round-robin path): the growth re-prompt loop on the
+    round-robin path (the fallback path) must also re-check ``deadline`` before
+    each re-prompt — symmetric to the group-chat loop covered in
+    test_cf1538_growth_validation_groupchat.py. A re-prompt is a fresh
+    ``agent.invoke`` LLM call that must not fire after the wall-clock budget is
+    exhausted. The intra-invocation case is item 5, not item 4.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reprompt_cancelled_when_deadline_expired(self, caplog):
+        # Empty-growth state: every fingerprint collection empty → no growth →
+        # the growth-validation block enters the re-prompt loop (the trigger).
+        state = MagicMock()
+        state.identified_arguments = {}
+        state.identified_fallacies = {}
+        state.counter_arguments = []
+        state.jtms_beliefs = {}
+        state.dung_frameworks = {}
+        state.aspic_results = []
+        state.belief_revision_results = []
+        state.nl_to_logic_translations = []
+        state.fol_analysis_results = []
+        state.propositional_analysis_results = []
+        state.modal_analysis_results = []
+        state._next_agent_designated = None
+        state.final_conclusion = None
+
+        # Noop agent: returns content, never modifies state (keeps triggering
+        # the re-prompt loop). Each invoke() call returns a fresh AsyncIterator.
+        agent = MagicMock()
+        agent.name = "MockAgent"
+        response = MagicMock()
+        response.content = "no findings registered"
+        agent.invoke = MagicMock(side_effect=lambda hist: AsyncIterator([response]))
+
+        entry_time = 1000.0
+        post_turn_time = entry_time + 10000.0
+        deadline = entry_time + 1.0  # future at entry, expired by re-prompt
+        call_count = [0]
+
+        def fake_time():
+            call_count[0] += 1
+            # Round-robin path order: (1) entry check, (2-3) setup, (4) the
+            # "avant tour 1" start-of-turn check — all must pass → entry_time.
+            # The re-prompt guard is the next call → post_turn_time → fires.
+            return entry_time if call_count[0] <= 4 else post_turn_time
+
+        with caplog.at_level(logging.INFO, logger="ConversationalOrchestrator"):
+            with patch(
+                "argumentation_analysis.orchestration.conversational_orchestrator.AgentGroupChat",
+                create=True,
+                side_effect=ImportError("disabled for test"),
+            ):
+                with patch(
+                    "argumentation_analysis.orchestration.conversational_orchestrator.time.time",
+                    side_effect=fake_time,
+                ):
+                    await _run_phase(
+                        [agent],
+                        "Test prompt",
+                        max_turns=2,
+                        phase_name="Extraction & Detection",
+                        state=state,
+                        enable_growth_validation=True,
+                        growth_re_prompt_limit=2,
+                        deadline=deadline,
+                    )
+        # Loud skip on the round-robin path: the guard fired and cancelled the
+        # re-prompt rather than silently leaking a post-cap LLM call (#1019).
+        assert any(
+            "deadline atteinte" in rec.message and "round-robin path" in rec.message
+            for rec in caplog.records
+        ), (
+            "no deadline-skip log emitted on the round-robin re-prompt path — "
+            "the CB #1528 item 4 guard is not wired on this path (asymmetry vs "
+            "the group-chat path)"
+        )
 
 
 class AsyncIterator:


### PR DESCRIPTION
## CB #1528 — item 4: deadline guard inside the growth re-prompt loops

Closes the item-4 gap on the CB #1528 track. Item 3 (#1544, merged) added the
`_budget_allows(stage)` predicate on the awaited spectacular stages + the
entry-of-phase + group-chat-construction deadline checks. **Item 4 is the
control *inside* the two growth-validation re-prompt loops** — a re-prompt is a
fresh `speaking_agent.invoke` LLM call, and the turn's first invoke may have
consumed the whole wall-clock budget already, so each re-prompt must re-check
`deadline` before firing.

The coord's R717 comment on #1528 formally split the track: *"Reste sur le
track : item 4 (contrôle intra-boucle de re-prompt) et item 5"*. This PR is
item 4. Item 5 (intra-invocation: a single invoke that never yields) is out of
scope — "chiffré plutôt que soupçonné".

### The gap (verified firsthand on main `d9c49942`)

```
$ grep -n "for rp in range(growth_re_prompt_limit)" argumentation_analysis/orchestration/conversational_orchestrator.py
2024:                    for rp in range(growth_re_prompt_limit):     # group-chat path
2187:                    for rp in range(growth_re_prompt_limit):     # round-robin path
```

Neither loop checked `deadline` before re-prompting. The entry-of-phase check
(L1896) and the between-turn check (L1996) only guard *reaching* the loop, not
the loop's own re-prompts. A turn that ran the first `invoke` near the cap, then
hit zero-growth, would re-prompt *after* the cap — a post-cap LLM call
(anti-#1019).

### The fix (subtract, symmetric)

Add a guard at the top of **both** loops, mirroring the entry-of-phase idiom:

```python
for rp in range(growth_re_prompt_limit):
    if deadline is not None and time.time() >= deadline:
        logger.info(
            f"  [{phase_name}] Wall-clock deadline atteinte "
            f"avant le growth re-prompt {rp + 1}/{growth_re_prompt_limit} "
            f"(group-chat path) ; re-prompts restants annulés."
        )
        break
    ...  # existing re-prompt invoke
```

The round-robin loop gets the identical guard with `"(round-robin path)"` in the
log. The group-chat path is the live one since CD #1534; the round-robin guard
keeps the two paths symmetric (no asymmetry that could hide a future regression,
cf. the CB #1528 round-robin/group-chat parity tests).

Loud INFO log on cancellation (anti-silent-fail #1019): the skip is named and
the path is identified.

### DoD (LLM-free, deterministic, firsthand green)

```
$ pytest test_growth_validation_hook_597.py test_cf1538_growth_validation_groupchat.py \
        test_cb1528_postcap_budget.py --disable-jvm-session -q
======================= 39 passed, 4 warnings in 1.84s =======================
```

New tests:
- `TestCB1528Item4GroupChatDeadlineGuard` (2 tests):
  - `test_reprompt_cancelled_when_deadline_expired`: fake clock advances past the
    deadline at re-prompt time (entry + between-turn checks still see pre-cap
    time) → `agent.invoke` NOT called (0 post-cap LLM calls) + loud log
    "deadline atteinte" + "group-chat path".
  - `test_reprompt_fires_when_deadline_in_future`: deadline 1h ahead → re-prompt
    still fires (guard is conditional, not unconditional — does not regress the
    CF #1538 re-prompt contract).
- `TestCB1528Item4RoundRobinDeadlineGuard` (1 test): symmetric — round-robin
  path (forced via `AgentGroupChat` construction failure), guard fires and logs
  "round-robin path".

Firsthand log proof (round-robin path, from the passing test run):
```
[Extraction & Detection] Turn 1: MockAgent
[Extraction & Detection] Wall-clock deadline atteinte avant le growth re-prompt 1/2 (round-robin path) ; re-prompts restants annulés.
[Extraction & Detection] Wall-clock deadline atteint avant tour 2 — sortie propre (verdict partiel).
```

### Non-regression

Budget/wall-clock/executor contracts stay green (87 passed):
```
$ pytest test_conversational_wall_clock_c1.py test_conversational_llm_budget.py \
          test_conversational_sk_budget.py test_fail_loud_downstream_1019.py \
          test_conversational_executor.py test_ce1537_execution_path.py -q
======================= 87 passed, 4 warnings in 1.92s =======================
```

CF #1538 (growth re-prompt on the group-chat path) and CD #1534 (AgentGroupChat
construction) contracts are untouched. C1 #1500 (wall-clock cap inside
`run_conversational_analysis`) untouched.

### Files changed
- `argumentation_analysis/orchestration/conversational_orchestrator.py` — 2 guards (+30 lines, both re-prompt loops).
- `tests/unit/argumentation_analysis/orchestration/test_cf1538_growth_validation_groupchat.py` — +1 class, 2 tests (+110 lines).
- `tests/unit/argumentation_analysis/orchestration/test_growth_validation_hook_597.py` — +1 class, 1 test (+83 lines).

No deletions. No `requires_api` markers (tests are JVM/LLM-free and deterministic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
