### PR TITLE
test(scripts): make proof_bo2b_dashboard_e2e hermetic via --no-llm (4th #1510 brother, #1547)

### DIFF
--- a/api/proposal_service.py
+++ b/api/proposal_service.py
@@ -291,6 +291,21 @@ async def _broadcast_ws_deliberation_result(
 
 async def _run_pipeline(text: str, workflow: str, options: Dict) -> Dict:
     """Run the unified pipeline for analysis."""
+    # #1547: an explicit ``force_stub`` option short-circuits to the offline
+    # stub BEFORE importing/calling ``run_unified_analysis`` (the only LLM
+    # site in this flow). The stub already existed (ImportError/Exception
+    # branches below) but was only *suffered*; this makes it *demandable*
+    # from a CLI flag, so a proof script can run hermetically — zero LLM
+    # calls, no matter what ``load_dotenv`` re-reads from ``.env`` (the #1510
+    # leak vector). Anti-pendule: route to the existing stub rather than
+    # patch the LLM client globally (which would break the live API).
+    if options.get("force_stub"):
+        logger.info("Force-stub requested via options — skipping LLM pipeline")
+        return {
+            "workflow": workflow,
+            "text_excerpt": text[:200],
+            "note": "Pipeline skipped — force-stub requested (offline path)",
+        }
     try:
         from argumentation_analysis.orchestration.unified_pipeline import (
             run_unified_analysis,

--- a/scripts/proof_bo2b_dashboard_e2e.py
+++ b/scripts/proof_bo2b_dashboard_e2e.py
@@ -105,13 +105,18 @@ def _serialize_deliberation(d) -> Dict[str, Any]:
     }
 
 
-async def run_democratech_flow(store: ProposalStore) -> Dict[str, Any]:
+async def run_democratech_flow(store: ProposalStore, force_stub: bool = False) -> Dict[str, Any]:
     """Execute one full proposal→deliberate→vote cycle on the in-memory store.
 
     Returns a JSON-safe payload suitable for the React dashboard's initial
     state (proposal + deliberation + vote + analysis results). Mirrors what
     ``GET /api/proposals/{id}`` + ``GET /api/deliberate/{id}/status`` would
     return after a successful run.
+
+    ``force_stub`` routes ``_run_pipeline`` to the offline stub (no LLM call)
+    — #1547: makes the hermetic path demandable rather than relying on a
+    broken env. The stub branch is captured honestly via the ``STUB`` status
+    line below, not masqueraded as a real verdict (anti-théâtre #1019).
     """
     # 1. Create proposal (synthetic chess-club).
     proposal_in = ProposalCreate(
@@ -155,7 +160,7 @@ async def run_democratech_flow(store: ProposalStore) -> Dict[str, Any]:
         delib_id=delib_id,
         proposal_text=PROPOSITION,
         workflow="democratech",
-        options={},
+        options={"force_stub": force_stub},
     )
 
     # 5. Re-fetch enriched state.
@@ -212,6 +217,17 @@ def main() -> int:
         action="store_true",
         help="Suppress INFO logs.",
     )
+    parser.add_argument(
+        "--no-llm",
+        action="store_true",
+        help=(
+            "Force the offline stub path (no LLM call). Makes the script "
+            "hermetic — independent of OPENAI_API_KEY in the env or .env "
+            "(#1547). The stub branch is the same one used when the pipeline "
+            "is unavailable; this flag just makes it demandable. Honest: the "
+            "output reports STUB, not a fabricated verdict."
+        ),
+    )
     args = parser.parse_args()
 
     if not args.quiet:
@@ -221,7 +237,7 @@ def main() -> int:
 
     store = ProposalStore()
     t0 = time.monotonic()
-    payload = asyncio.run(run_democratech_flow(store))
+    payload = asyncio.run(run_democratech_flow(store, force_stub=args.no_llm))
     elapsed = time.monotonic() - t0
 
     # Honest status line (anti-théâtre #1019 — degraded is a VALID outcome).

--- a/tests/scripts/test_proof_bo2b_dashboard_1493.py
+++ b/tests/scripts/test_proof_bo2b_dashboard_1493.py
@@ -152,7 +152,12 @@ class TestProofRuntimeContract:
         from api.proposal_service import ProposalStore
 
         store = ProposalStore()
-        payload = asyncio.run(proof_mod.run_democratech_flow(store))
+        # #1547 sibling: force_stub keeps this hermetic (no LLM call). This
+        # test asserts the PAYLOAD SHAPE (keys, provenance, opaque IDs,
+        # votes), none of which depend on the LLM verdict — so the stub path
+        # preserves the contract. Without force_stub it bills a real LLM run
+        # (3-4 min) with no requires_api marker, same leak as the CLI test.
+        payload = asyncio.run(proof_mod.run_democratech_flow(store, force_stub=True))
 
         # Required keys (consumed by the React dashboard).
         assert "proposal" in payload
@@ -185,7 +190,8 @@ class TestProofRuntimeContract:
         from api.proposal_service import ProposalStore
 
         store = ProposalStore()
-        payload = asyncio.run(proof_mod.run_democratech_flow(store))
+        # #1547 sibling: hermetic — see test_run_democratech_flow_produces_payload.
+        payload = asyncio.run(proof_mod.run_democratech_flow(store, force_stub=True))
         out = tmp_path / "dashboard_data.json"
         out.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
         reloaded = json.loads(out.read_text(encoding="utf-8"))
@@ -294,7 +300,25 @@ class TestRenderContract:
 
 @pytest.mark.slow
 def test_proof_script_cli_runs(tmp_path: pathlib.Path) -> None:
-    """`python scripts/proof_bo2b_dashboard_e2e.py --output <tmp>` exits 0."""
+    """`--no-llm --output <tmp>` exits 0 on the hermetic stub path.
+
+    #1547: previously this test ran the script WITHOUT ``--no-llm``, branching
+    on the real LLM client whenever a key was present (``load_dotenv`` re-reads
+    ``.env``, so removing the env var is not enough). The real path takes 3-4
+    min (LLM latency, measured firsthand) and blew the 120 s subprocess borne
+    — a red that CI did not surface (no ``requires_api`` marker). Same leak
+    family as #1510 (Floater Fact / pytest-dotenv).
+
+    Fix = subtract the dependency (anti-pendule), not raise the borne: route
+    the script to the offline stub that already existed (``_run_pipeline``
+    ImportError/Exception branches) and make it *demandable* via ``--no-llm``.
+    The stub short-circuits BEFORE ``run_unified_analysis`` is even imported,
+    so zero LLM call is made regardless of any key in env or ``.env``.
+
+    The borne is justified by measurement, not guessed: the stub path runs in
+    ~7-9 s locally (startup + imports + serialize + write); 60 s leaves a ~6x
+    margin for slower CI Windows runners (torch/transformers cold import).
+    """
     out_path = tmp_path / "data.json"
     result = subprocess.run(
         [
@@ -303,10 +327,11 @@ def test_proof_script_cli_runs(tmp_path: pathlib.Path) -> None:
             "--output",
             str(out_path),
             "--quiet",
+            "--no-llm",
         ],
         capture_output=True,
         text=True,
-        timeout=120,
+        timeout=60,
         cwd=str(REPO_ROOT),
     )
     assert result.returncode == 0, (
@@ -317,3 +342,53 @@ def test_proof_script_cli_runs(tmp_path: pathlib.Path) -> None:
     payload = json.loads(out_path.read_text(encoding="utf-8"))
     assert payload["provenance"]["synthetic"] is True
     assert payload["proposal"]["author"].startswith("prop_")
+    # Fail-loud the hermeticity contract (anti-théâtre #1019): the stub marker
+    # proves the offline path was taken. If someone drops ``--no-llm`` from the
+    # command above, the real LLM path runs and this note is absent — the test
+    # turns red loud instead of silently billing LLM calls under the borne.
+    assert "force-stub" in payload["results"]["note"], (
+        "stub path not taken — `--no-llm` did not route to the offline stub; "
+        "the real LLM path may have run (hermeticity regression, #1547)"
+    )
+
+
+@pytest.mark.requires_api
+@pytest.mark.slow
+def test_proof_script_cli_real_llm_path(tmp_path: pathlib.Path) -> None:
+    """The real (non-stub) LLM path still exits 0 — kept for who has a key.
+
+    #1547 DoD #4: the hermetic test above covers the stub path; this test
+    guards the real path so it is not silently dropped. It is marked
+    ``requires_api`` (skipped without a key) AND ``slow`` (the real path takes
+    3-4 min, so it must not run in the default CI sweep). It does NOT assert
+    a specific verdict — the real path may DECIDED or DEGRADE honestly
+    depending on key quota / pipeline availability; we only assert it exits 0
+    and emits a payload of the expected shape.
+    """
+    out_path = tmp_path / "data.json"
+    # 300 s borne: the real path measures 178-259 s firsthand (#1547 body);
+    # 300 s leaves margin for LLM latency variance (±45 % measured between
+    # identical runs — network-shaped, not import-shaped).
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PROOF_SCRIPT),
+            "--output",
+            str(out_path),
+            "--quiet",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=300,
+        cwd=str(REPO_ROOT),
+    )
+    assert result.returncode == 0, (
+        f"proof script (real path) failed:\nSTDOUT:\n{result.stdout}\n"
+        f"STDERR:\n{result.stderr}"
+    )
+    assert out_path.exists()
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["provenance"]["synthetic"] is True
+    assert payload["proposal"]["author"].startswith("prop_")
+    # Real path: the force-stub note must be ABSENT (we did not pass --no-llm).
+    assert "force-stub" not in payload["results"].get("note", "")


### PR DESCRIPTION
## #1547 — make `proof_bo2b_dashboard_e2e.py` hermetic via `--no-llm`

Closes #1547 (4th instance of the #1510 Floater-Fact / pytest-dotenv leak family).

### The leak (constat coord, re-verified firsthand)

`test_proof_script_cli_runs` ran the proof script WITHOUT any offline flag. The
script flows `run_democratech_flow → run_deliberation_workflow → _run_pipeline
→ run_unified_analysis` — a real multi-agent LLM analysis (3-4 min, measured
firsthand: 178/210/259 s). Whenever a key is present it branches on the real
client, because `argumentation_analysis/core/llm_service.py:5` calls
`load_dotenv()` → the key is re-read from `.env` even if the env var is unset
(the #1510 vector). Under the 120 s subprocess borne this is a red CI did not
surface (no `requires_api` marker).

### The fix (subtract, anti-pendule — not raise the borne)

The offline stub already existed (`_run_pipeline` ImportError/Exception branches)
but was only *suffered*. This PR makes it **demandable**:

1. **`api/proposal_service.py::_run_pipeline`** — `if options.get("force_stub")`
   short-circuits to the stub BEFORE `run_unified_analysis` is even imported.
   Zero LLM call, regardless of any key in env or `.env`. Anti-pendule: routes
   to the existing stub rather than patching the LLM client globally (would
   break the live API). Default `options` unchanged → API callers
   (`proposal_endpoints.py:117` passes `request.options`, no `force_stub`) keep
   the real LLM path.
2. **`scripts/proof_bo2b_dashboard_e2e.py`** — new `--no-llm` CLI flag threads
   `force_stub` through `run_democratech_flow → run_deliberation_workflow`.
   Honest: the output reports `STUB` (not a fabricated verdict).

### DoD #1547 — all met, firsthand

- [x] **#1 hermetic, no LLM call regardless of key** — `--no-llm` + force_stub
  short-circuit + assertion on the `force-stub` note marker. Firsthand log:
  `Force-stub requested via options — skipping LLM pipeline` (run_unified_analysis
  not even imported). 7.17 s / 8.59 s measured.
- [x] **#2 borne justified by measurement** — 120→60 s. Stub path measured ~7-9 s
  locally; 60 s = ~6x margin for slower CI Windows runners. Documented in the
  test docstring (not guessed).
- [x] **#3 contract unchanged** — returncode 0, `provenance.synthetic is True`,
  `proposal.author` startswith `prop_`. All asserted + passing.
- [x] **#4 real path still covered** — new `test_proof_script_cli_real_llm_path`,
  marked `requires_api` + `slow` (does not run in default CI sweep). Asserts
  exit 0 + shape, NOT a specific verdict (DECIDED/DEGRADED both honest).
- [x] **#5 justification written** — this section (why not raise the borne: it
  treats an LLM dependency as a latency problem and leaves a test billing real
  calls every CI run).

### Siblings hermétisés (leçon R716 — grep all callers of the leaky path)

`test_run_democratech_flow_produces_payload` and `test_json_roundtrip` ALSO
called `run_democratech_flow(store)` without `force_stub` → real LLM run, no
`requires_api` marker (same leak, in-process not subprocess → no 120 s borne, so
they hung ~3-4 min rather than timed out). Both assert PAYLOAD SHAPE (keys,
provenance, opaque IDs, votes, JSON-serializable) — none of which depend on the
verdict → the stub path preserves the contract. Hermétisés in the same PR (same
trivial fix, same family).

### Validation

```
$ pytest tests/scripts/test_proof_bo2b_dashboard_1493.py -m "not requires_api" -q --disable-jvm-session
18 passed, 1 deselected in 3.98 s
$ pytest tests/integration/api/ -m "not requires_api" -q --disable-jvm-session
6 passed, 2 deselected   # API callers unaffected (default options → real path)
```

mypy: 0 error on the added guard (the L292 `Dict` type-arg warning is
pre-existing — it's the `_run_pipeline` signature, unchanged).

### Privacy HARD

Synthetic chess-club budget proposition (domain-public, already used in
`test_deliberation_genuine_verdict.py`). Opaque IDs (`prop_<8hex>`). No raw_text
/ full_text / verbatim from the encrypted corpus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
