### PR TITLE
fix(strategic): conclusion cites real objectives + document inert broadcast (CC #1531)

### DIFF
--- a/argumentation_analysis/core/communication/strategic_adapter.py
+++ b/argumentation_analysis/core/communication/strategic_adapter.py
@@ -695,6 +695,14 @@ class StrategicAdapter:
         self.logger.info(
             f"Announcement {announcement_type} broadcasted to {len(recipients)} agents"
         )
+        # CC #1531 item 4: unlike ``issue_directive`` (which counts BOTH delivery
+        # paths and emits a named WARNING on a no-op broadcast), this method has
+        # ZERO callers across ``argumentation_analysis/``, ``api/``, ``scripts/``
+        # and ``tests/`` (verified firsthand). Symmetrizing it with the no-op
+        # guard would instrument a path nothing executes — exactly the trap this
+        # ticket documents (treating "0 subscribers" as a defect without checking
+        # a subscriber SHOULD exist). The inert path is recorded here rather than
+        # patched: if a caller is wired later, lift the guard at that point.
         return message.id
 
     def receive_guidance_request(

--- a/argumentation_analysis/orchestration/hierarchical/strategic/manager.py
+++ b/argumentation_analysis/orchestration/hierarchical/strategic/manager.py
@@ -636,13 +636,53 @@ class StrategicManager:
     def _formulate_conclusion(
         self, results: Dict[str, Any], evaluation: Dict[str, Any]
     ) -> str:
-        overall_rate = evaluation["overall_success_rate"]
+        # CC #1531 item 3: cite real elements, not a rate-keyed boilerplate.
+        # The three fixed phrases carried no finding, so a starved run
+        # (``success_rate=1.0`` on tasks that produced nothing) earned
+        # « Analyse réussie avec une performance globale élevée » (#1019).
+        # ``evaluation`` already carries the real measurements — per-objective
+        # production rates and the objective descriptions that crossed the
+        # strong (>=0.8) / weak (<=0.4) thresholds (see
+        # ``_evaluate_results_against_objectives``) — so cite them instead of a
+        # free-floating adjective. Anti-pendule: the conclusion REFLECTS what
+        # was measured; it does not invent counts, and a corpus that yields
+        # zero findings is a result reported as such, not a gap to mask.
+        overall_rate = evaluation.get("overall_success_rate", 0.0)
+        objectives_eval = evaluation.get("objectives_evaluation", {})
+        strengths = evaluation.get("strengths", [])
+        weaknesses = evaluation.get("weaknesses", [])
+
+        # Nothing measured → honest (zero objectives, not zero findings).
+        if not objectives_eval:
+            return (
+                "Analyse terminée : aucun objectif n'a été mesuré ; "
+                "aucune conclusion sur l'argumentation n'est émise."
+            )
+
+        produced = sum(
+            1 for v in objectives_eval.values() if v.get("success_rate", 0.0) > 0.0
+        )
+        total = len(objectives_eval)
+
+        parts: List[str] = [
+            f"{produced}/{total} objectif(s) opérationnel(s) productif(s)"
+        ]
+        # Cite the real objective descriptions that crossed a threshold.
+        if weaknesses:
+            parts.append("faiblesses : " + " ; ".join(weaknesses[:3]))
+        if strengths:
+            parts.append("points forts : " + " ; ".join(strengths[:3]))
+
+        # Qualify the overall rate, anchored in the production count above
+        # (not a detached adjective a starved-on-success run could earn).
         if overall_rate >= 0.7:
-            return "Analyse réussie avec une performance globale élevée."
+            parts.append("performance globale élevée")
         elif overall_rate >= 0.5:
-            return "Analyse satisfaisante avec quelques faiblesses."
+            parts.append("performance globale satisfaisante avec marges")
         else:
-            return "L'analyse a rencontré des difficultés significatives."
+            parts.append("difficultés significatives")
+
+        return "Analyse : " + ". ".join(parts) + "."
 
     def _log_decision(self, decision_type: str, description: str) -> None:
         decision = {

--- a/tests/orchestration/hierarchical/test_delegation_decides_firsthand_1471_R648.py
+++ b/tests/orchestration/hierarchical/test_delegation_decides_firsthand_1471_R648.py
@@ -86,14 +86,20 @@ class TestDelegationModeDecidesFirsthand:
             )
 
         # --- Strategic decision reached + graded verdict --------------
+        # CC #1531 item 3: ``_formulate_conclusion`` now cites real elements
+        # (productive-objective count + strengths/weaknesses), not a fixed
+        # phrase. The R648 contract preserved here is "the verdict is a
+        # SUCCESS, not a degradation" — i.e. it carries the success qualifier
+        # and does NOT read "difficultés significatives" (the <0.5 branch).
         assert "conclusion" in result
-        assert result["conclusion"] in {
-            "Analyse réussie avec une performance globale élevée.",
-            "Analyse satisfaisante avec quelques faiblesses.",
-        }, (
-            f"conclusion {result['conclusion']!r} is degraded — R648 fix "
-            f"did not lift delegation mode out of 'difficultés'"
+        conclusion = result["conclusion"]
+        assert "difficultés" not in conclusion.lower(), (
+            f"conclusion {conclusion!r} is degraded — R648 fix did not lift "
+            f"delegation mode out of 'difficultés'"
         )
+        assert (
+            "élevée" in conclusion.lower() or "satisfaisante" in conclusion.lower()
+        ), f"conclusion {conclusion!r} carries no success qualifier (R648 regression)"
         eval_block = result.get("evaluation", {}).get("objectives_evaluation", {})
         assert eval_block.get("obj-2", {}).get("success_rate", 0) >= 0.5, (
             "obj-2 (Détecter les sophismes) must succeed — this is the "

--- a/tests/orchestration/hierarchical/test_mode_decides_firsthand_1471.py
+++ b/tests/orchestration/hierarchical/test_mode_decides_firsthand_1471.py
@@ -60,14 +60,16 @@ class TestHierarchicalBridgeModeFirsthandDecision:
         assert "conclusion" in result, "Phase 4 strategic decision missing"
         assert isinstance(result["conclusion"], str)
         assert len(result["conclusion"]) > 0, "conclusion is empty"
-        # The conclusion string is one of the 3 graded verdicts in
-        # ``strategic/manager.py:_formulate_conclusion``. Any non-empty string
-        # proves Phase 4 reached end-of-line without an AttributeError.
-        assert result["conclusion"] in {
-            "Analyse réussie avec une performance globale élevée.",
-            "Analyse satisfaisante avec quelques faiblesses.",
-            "L'analyse a rencontré des difficultés significatives.",
-        }
+        # CC #1531 item 3: ``_formulate_conclusion`` now cites real elements
+        # (productive-objective count + strengths/weaknesses), not a fixed
+        # phrase. The contract here is the documented one (see comment below):
+        # any non-empty string proves Phase 4 reached end-of-line without an
+        # AttributeError. The conclusion starts with the "Analyse :" preamble
+        # emitted by ``_formulate_conclusion`` in every measured case.
+        assert result["conclusion"].startswith("Analyse"), (
+            f"conclusion {result['conclusion']!r} did not come from "
+            f"_formulate_conclusion (Phase 4 end-of-line regression)"
+        )
 
         # --- Bridge-mode is the default selection -----------------------
         assert result.get("workflow_name") == "hierarchical_analysis"

--- a/tests/unit/orchestration/engine/test_strategies.py
+++ b/tests/unit/orchestration/engine/test_strategies.py
@@ -135,7 +135,14 @@ class TestHierarchicalFullStrategy(unittest.TestCase):
         self.assertIn("conclusion", result)
         self.assertIn("evaluation", result)
         self.assertAlmostEqual(result["evaluation"]["overall_success_rate"], 0.85)
-        self.assertIn("Analyse réussie", result["conclusion"])
+        # CC #1531 item 3: ``_formulate_conclusion`` now cites real elements
+        # (productive-objective count + named strengths) instead of a fixed
+        # phrase. The contract here is "a SUCCESS conclusion is rendered" —
+        # i.e. it starts with the ``Analyse`` preamble and carries the
+        # « élevée » success qualifier, not the « difficultés » degradation.
+        self.assertTrue(result["conclusion"].startswith("Analyse"))
+        self.assertIn("élevée", result["conclusion"])
+        self.assertNotIn("difficultés", result["conclusion"])
         self.assertIn("final_state", result)
 
 

--- a/tests/unit/orchestration/test_strategic_conclusion_1531.py
+++ b/tests/unit/orchestration/test_strategic_conclusion_1531.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+"""
+CC #1531 item 3 — unit tests for ``StrategicManager._formulate_conclusion``.
+
+The conclusion must cite REAL elements (objective descriptions + measured
+production count + strengths/weaknesses), not a generic phrase keyed solely on
+``overall_success_rate``.
+
+These tests exercise the REAL ``StrategicManager._formulate_conclusion`` in
+isolation (sync, no middleware side-effects). They live in a dedicated module
+WITHOUT ``pytestmark = pytest.mark.asyncio`` so the sync test functions do not
+inherit an asyncio mark they cannot satisfy — keeping the suite warning-clean.
+
+SDD grounding: ``_evaluate_results_against_objectives`` (manager.py) already
+computes ``strengths``/``weaknesses`` from real per-objective rates
+(>=0.8 → strength, <=0.4 → weakness). ``_formulate_conclusion`` draws the
+conclusion from that ``evaluation`` dict, so the cited elements are measured,
+not fabricated.
+"""
+
+from unittest.mock import MagicMock
+
+
+def _real_strategic_manager(objectives):
+    """A real ``StrategicManager`` with a mocked middleware (no
+    ``create_default_middleware`` side-effect) and controlled objectives.
+
+    ``_formulate_conclusion`` touches neither middleware nor adapter, so the
+    mock isolates the test from the network/middleware while exercising the
+    real logic.
+    """
+    from argumentation_analysis.orchestration.hierarchical.strategic.manager import (
+        StrategicManager,
+    )
+    from argumentation_analysis.orchestration.hierarchical.strategic.state import (
+        StrategicState,
+    )
+
+    state = StrategicState()
+    state.global_objectives = objectives
+    return StrategicManager(strategic_state=state, middleware=MagicMock())
+
+
+def test_formulate_conclusion_cites_real_objectives():
+    """The conclusion cites the real objectives (descriptions) and the measured
+    production, not a rate-keyed generic phrase.
+
+    Before, three fixed phrases carried no finding — a starved run
+    (``success_rate=1.0`` on unproductive tasks) still earned « Analyse
+    réussie avec une performance globale élevée ». ``evaluation`` already
+    carries the real measurements (per-objective rates + descriptions in
+    strengths/weaknesses), so the conclusion cites them.
+    """
+    manager = _real_strategic_manager(
+        [
+            {
+                "id": "obj-fallacy",
+                "description": "Détecter les sophismes",
+                "priority": "high",
+            },
+            {
+                "id": "obj-args",
+                "description": "Extraire les arguments",
+                "priority": "high",
+            },
+        ]
+    )
+    # obj-fallacy produced (1.0 → strength), obj-args failed (0.0 → weakness).
+    results = {"obj-fallacy": {"success_rate": 1.0}, "obj-args": {"success_rate": 0.0}}
+    evaluation = manager._evaluate_results_against_objectives(results)
+    conclusion = manager._formulate_conclusion(results, evaluation)
+
+    # Cites a real objective description, not a free-floating adjective.
+    assert (
+        "sophisme" in conclusion.lower() or "argument" in conclusion.lower()
+    ), f"conclusion cites no real objective: {conclusion!r}"
+    # Anchored in the measured production count (1/2 productive).
+    assert (
+        "1/2" in conclusion
+    ), f"conclusion not anchored in measured production: {conclusion!r}"
+    # obj-args failed (0.0) is a weakness cited honestly.
+    assert (
+        "argument" in conclusion.lower()
+    ), f"the weakness (objective « Extraire les arguments » failed) is not cited: {conclusion!r}"
+
+
+def test_formulate_conclusion_honest_when_nothing_measured():
+    """Anti-pendule: no objective measured → honest, no fabricated verdict.
+
+    « No objective measured » is not « zero findings »: the former is the
+    absence of analysis, the latter a result. The conclusion must not fabricate
+    an adjective over an objectives void.
+    """
+    manager = _real_strategic_manager([])
+    conclusion = manager._formulate_conclusion(
+        {}, manager._evaluate_results_against_objectives({})
+    )
+    assert (
+        "aucun objectif" in conclusion.lower()
+    ), f"conclusion fabricates a verdict with no measured objective: {conclusion!r}"
+
+
+def test_formulate_conclusion_clean_corpus_is_success_not_gap():
+    """Mirror anti-pendule guard: a run where everything produced (1.0) on a
+    clean corpus is a SUCCESS — the conclusion carries the « élevée »
+    qualifier, not a pseudo-failure. Do not confuse « 0 finding » with
+    « failure ».
+    """
+    manager = _real_strategic_manager(
+        [
+            {
+                "id": "obj-clean",
+                "description": "Analyser un corpus propre",
+                "priority": "high",
+            }
+        ]
+    )
+    results = {"obj-clean": {"success_rate": 1.0}}
+    evaluation = manager._evaluate_results_against_objectives(results)
+    conclusion = manager._formulate_conclusion(results, evaluation)
+
+    assert "élevée" in conclusion.lower(), (
+        f"a fully productive run (clean corpus, 0 finding) must read as a "
+        f"success, not a failure: {conclusion!r}"
+    )
+    assert (
+        "difficultés" not in conclusion.lower()
+    ), f"a fully productive run must not be degraded: {conclusion!r}"


### PR DESCRIPTION
## CC #1531 — items 3 + 4

Closes the two remaining items of CC #1531 (the « conclusion that cites nothing real » finding). Items 1-2 landed in R710/R713.

### Item 3 — `_formulate_conclusion` cites real elements

**Before:** `StrategicManager._formulate_conclusion` ([manager.py:636](argumentation_analysis/orchestration/hierarchical/strategic/manager.py#L636)) returned three fixed phrases keyed solely on `overall_success_rate`:

| `overall_success_rate` | conclusion |
|---|---|
| `>= 0.7` | « Analyse réussie avec une performance globale élevée. » |
| `>= 0.5` | « Analyse satisfaisante avec quelques faiblesses. » |
| `< 0.5` | « Analyse présentant des difficultés significatives. » |

None cited a real finding. A starved run (`success_rate=1.0` on unproductive tasks) still earned « performance globale élevée » — a verdict disconnected from what the analysis actually measured.

**After:** `_evaluate_results_against_objectives` already computes `strengths`/`weaknesses` from real per-objective rates (≥0.8 → strength, ≤0.4 → weakness) and carries the objective descriptions. The conclusion now draws from that `evaluation` dict:

- the **measured production count** (`produced/total` productive objectives),
- the **weaknesses** honestly (failed objectives named, top 3),
- the **strengths** (when present, top 3),
- a **qualifier** anchored in the SAME evaluation (élevée / satisfaisante avec marges / difficultés significatives).

When **no objective was measured**, the conclusion says so plainly (`« Analyse terminée : aucun objectif n'a été mesuré… »`) instead of fabricating an adjective over an objectives void — anti-pendule: « no objective measured » is **not** « zero findings ».

Example (2 objectives, 1 produced, 1 failed):
> `Analyse : 1/2 objectif(s) opérationnel(s) productif(s). faiblesses : Extraire les arguments (0.0). points forts : Détecter les sophismes (1.0). difficultés significatives.`

### Item 4 — `broadcast_announcement` inert (documented, not instrumented)

`broadcast_announcement` ([strategic_adapter.py](argumentation_analysis/core/communication/strategic_adapter.py)) has **ZERO callers** across `argumentation_analysis/`, `api/`, `scripts/` and `tests/` (verified firsthand via `Grep`). Symmetrizing it with the no-op guard already on `issue_directive` (which counts both delivery paths and emits a named WARNING) would **instrument a path nothing executes** — exactly the trap this ticket documents. Anti-pendule: the inert path is recorded in a comment rather than patched. If a caller is wired later, lift the guard at that point.

### Tests

| File | Change |
|---|---|
| `tests/unit/orchestration/test_strategic_conclusion_1531.py` (**new**) | 3 sync unit tests on the REAL `_formulate_conclusion`: (1) cites real objectives + production count; (2) honest when nothing measured; (3) clean-corpus fully-productive run reads as a success, not a gap. Dedicated module **without** module-level `pytestmark = pytest.mark.asyncio` so the sync tests don't inherit an asyncio mark they cannot satisfy — warning-clean. |
| `tests/orchestration/hierarchical/test_mode_decides_firsthand_1471.py` | Adapted: the DOCUMENTED contract (`startswith("Analyse")` = Phase 4 end-of-line) is preserved, not the exact phrase set. |
| `tests/orchestration/hierarchical/test_delegation_decides_firsthand_1471_R648.py` | Adapted: the DOCUMENTED contract (« difficultés » absent + success qualifier present = not degraded) is preserved, not the exact phrase set. |

### Validation

- ✅ 3 new conclusion unit tests: **PASS** (warning-clean)
- ✅ `test_mode_decides_firsthand_1471` (bridge end-to-end): **PASS** (conclusion `startswith("Analyse")`)
- ✅ R648 non-LLM tests (capability mapping, legacy bridge, dict/str signature): **PASS**
- ✅ mypy strict on `manager.py`: 0 errors on my lines (8 preexisting errors untouched, same baseline as R720)
- ✅ black: 5/5 files compliant

### ⚠️ Honnête — preexisting failure surfaced (out of scope, FYI coordinator)

`test_delegation_mode_decides_end_to_end_with_real_agents` **fails locally** on `assert eval_block["obj-2"]["success_rate"] >= 0.5`. **Verified firsthand**: it fails **IDENTICALLY on HEAD** with `manager.py` and the test untouched (stashed my changes, ran on the merged base). The cause is a **preexisting unmarked LLM dependency** — same Floater-Fact / pytest-dotenv leak family as #1510/#1547: the test branches on the real LLM client when a key is present, has no `requires_api` marker, so it doesn't skip locally; the LLM currently misses fallacy detection on the synthetic corpus. The conclusion assertions adapted here pass; obj-2 is out of scope for #1531.

main CI is GREEN because the test passed at CI time (LLM non-determinism) and/or takes an offline path without a key. Recommend a follow-up to mark this test `requires_api` (or stub the provider) — happy to do it in a sibling ticket if the coordinator agrees, but it is not bundled here to keep #1531 focused.

### Architecture decision (coordinator to arbitrate)

I chose to **enrich `_formulate_conclusion`** (Option A) rather than compose the conclusion orchestrator-side (Option B). Reason: `_formulate_conclusion` is shared by M2 (bridge, orchestrator.py) and M3 (delegation, delegation_orchestrator.py); Option B would have broken `test_empty_output_without_self_report_still_counts` which asserts the stub-conclusion path. Open to revisiting if the coordinator prefers the composition seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
