### PR TITLE
fix(conversational): bound the invocation itself, not just between turns (CB #1528 item 5)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -1846,6 +1846,87 @@ def _find_agent_by_name(
     return None
 
 
+async def _bounded_invoke(
+    async_gen: Any,
+    deadline: Optional[float],
+    phase_name: str,
+    path_label: str,
+) -> Any:
+    """CB #1528 item 5: yield from ``async_gen`` (an ``invoke()`` async
+    generator), bounding EACH ``__anext__`` to the remaining wall-clock budget.
+
+    Why this exists: the live AgentGroupChat path's first ``chat.invoke()``
+    drives a function-calling agent that chains ~12 LLM round-trips before
+    yielding a single response (measured R716/R717, published on #1528). Every
+    inter-turn deadline guard (item 3 #1544 / item 4 #1546) checks BETWEEN
+    turns — none can fire inside a turn that never ends, so a tight wall-clock
+    budget was blown by ONE invocation and the external net caught it,
+    throwing away a populated state. This checkpoint bounds the invocation
+    ITSELF: a single ``__anext__`` cannot consume the whole remaining budget.
+
+    On timeout, the in-flight response is lost — but the shared ``state``
+    object is NOT. Plugins write to it DURING the invocation; the
+    ``CancelledError`` ``asyncio.wait_for`` raises at the await point leaves
+    those writes intact, so the partial state becomes the honest partial
+    verdict (same observation as R715, viewed from the other end).
+
+    This is NOT the "coroutine killed mid-flight by an external
+    ``asyncio.wait_for``" the ``WallClockBudget`` docstring (L67-68) rejects:
+    that kills the WHOLE ``run_conversational_analysis`` and loses its return
+    dict (``decides=False``); this bounds a single ``__anext__`` INSIDE
+    ``_run_phase``, which then returns normally with the messages accumulated
+    so far — the verdict comes from the populated ``state``, not from a
+    constructed-but-lost return value.
+
+    Anti-pendule: a SINGLE mechanism, derived from the existing ``deadline``
+    (no second budget). When ``deadline`` is None the generator is yielded
+    unchanged (no-op for unbounded runs — the unbounded path is preserved
+    byte-for-byte, mutation-verified by the dedicated test).
+    """
+    agen = async_gen.__aiter__()
+    try:
+        while True:
+            if deadline is not None:
+                remaining = deadline - time.time()
+                if remaining <= 0:
+                    logger.info(
+                        f"  [{phase_name}] Wall-clock deadline atteinte avant "
+                        f"un tour ({path_label}, borne intra-invocation CB "
+                        f"#1528 item 5) ; invocation stoppée, état accumulé "
+                        f"préservé comme verdict partiel."
+                    )
+                    return
+                try:
+                    response = await asyncio.wait_for(
+                        agen.__anext__(), timeout=remaining
+                    )
+                except StopAsyncIteration:
+                    return
+                except asyncio.TimeoutError:
+                    logger.info(
+                        f"  [{phase_name}] Wall-clock deadline atteinte PENDANT "
+                        f"l'invocation ({path_label}, borne intra-invocation "
+                        f"CB #1528 item 5) ; réponse en vol perdue, état "
+                        f"accumulé préservé comme verdict partiel."
+                    )
+                    return
+            else:
+                try:
+                    response = await agen.__anext__()
+                except StopAsyncIteration:
+                    return
+            yield response
+    finally:
+        # Best-effort cleanup of the underlying generator. It may already be
+        # exhausted (normal completion) or cancelled mid-flight (timeout); in
+        # either case aclose is a safe no-op or a swallowable exception, never
+        # fatal to the bounded path.
+        try:
+            await agen.aclose()
+        except Exception:  # noqa: BLE001 — cleanup must never mask the bound
+            pass
+
+
 async def _run_phase(
     agents: List[ChatCompletionAgent],
     initial_prompt: str,
@@ -1966,7 +2047,18 @@ async def _run_phase(
         # turn; each turn's delta is measured against the previous turn's state
         # (mirrors the round-robin path's fp_before/fp_after pattern).
         fp_before_tour = _get_growth_fingerprint(state)
-        async for response in chat.invoke():
+        # CB #1528 item 5: bound EACH __anext__ of the invocation to the
+        # remaining budget. A function-calling agent chains ~12 LLM round-trips
+        # inside a single chat.invoke() before yielding (measured R716/R717) —
+        # so the first __anext__ can blow the whole budget and every inter-turn
+        # guard above (item 3/4) is powerless inside a turn that never ends.
+        # _bounded_invoke wraps the generator: on timeout it stops cleanly,
+        # preserving the populated `state` (plugins wrote to it during the
+        # aborted invocation) as the partial verdict. See its docstring for why
+        # this is not the "killed mid-flight" the WallClockBudget rejects.
+        async for response in _bounded_invoke(
+            chat.invoke(), deadline, phase_name, "group-chat path"
+        ):
             _bump_sk_budget()
             turn += 1
             msg_entry = {
@@ -2166,7 +2258,15 @@ async def _run_phase(
             # multiple streaming chunks per call — we count 1 LLM call = 1 bump,
             # regardless of chunk count (NanoClaw concern #1).
             _bump_sk_budget()
-            async for response in agent.invoke(chat_history):
+            # CB #1528 item 5: same intra-invocation bound as the group-chat
+            # path — a single agent.invoke() can also chain function-calling
+            # round-trips and blow the budget inside one turn. The inter-turn
+            # guard above (L2153) checks BEFORE the turn; this bounds the turn
+            # itself. Re-prompt loops below are pre-guarded by item 4 (check
+            # before each re-prompt) and kept out of scope here.
+            async for response in _bounded_invoke(
+                agent.invoke(chat_history), deadline, phase_name, "round-robin path"
+            ):
                 chunk = ""
                 if hasattr(response, "content"):
                     chunk = str(response.content)

--- a/tests/unit/argumentation_analysis/orchestration/test_cb1528_intra_invocation_item5.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_cb1528_intra_invocation_item5.py
@@ -1,0 +1,382 @@
+# -*- coding: utf-8 -*-
+"""Tests for CB #1528 item 5 — the intra-invocation wall-clock bound.
+
+Firsthand measurement recorded on #1528 (R716/R717, published by the
+coordinator): the live (CD #1534) AgentGroupChat path's first ``chat.invoke()``
+drives a function-calling agent that chains ~12 LLM round-trips before yielding
+a single response. Every inter-turn deadline guard (item 3 #1544 / item 4 #1546)
+checks BETWEEN turns — none can fire inside a turn that never ends. So a tight
+wall-clock budget was blown by ONE invocation and the external net caught it,
+throwing away a populated state (arguments written seconds before the cut).
+
+Item 5 closes that path: ``_bounded_invoke`` wraps the invocation generator and
+bounds EACH ``__anext__`` to the remaining budget. On timeout the in-flight
+response is lost, but the shared ``state`` is NOT — plugins wrote to it during
+the invocation, and the ``CancelledError`` raised at the await point leaves
+those writes intact. The partial state becomes the honest partial verdict.
+
+These tests are LLM-free and deterministic. They exercise the REAL ``_run_phase``
+with a mocked ``AgentGroupChat`` whose ``invoke()`` simulates the stuck turn
+(an ``asyncio.sleep`` that never yields within the budget) — the exact shape
+the measurement diagnosed. The first test is mutation-verified: remove the
+``_bounded_invoke`` wrap at the call site and it hangs (timeout → red).
+
+Anti-pendule (from the dispatch): a SINGLE mechanism, derived from the existing
+``deadline`` (no second budget); when ``deadline`` is None the generator is
+yielded unchanged (no-op for unbounded runs).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_AGENT_GROUP_CHAT = "semantic_kernel.agents.group_chat.agent_group_chat.AgentGroupChat"
+
+
+class _FakeMsg:
+    """Minimal stand-in for an SK ``ChatMessageContent``-like response."""
+
+    def __init__(self, name: str, content: str = "ok") -> None:
+        self.name = name
+        self.content = content
+
+
+class _StuckInvokeChat:
+    """A fake ``AgentGroupChat`` whose first ``invoke().__anext__`` never
+    returns within the budget.
+
+    Mirrors the measured shape: the agent chains many LLM round-trips inside a
+    single ``__anext__`` before yielding. ``state_writer`` (if provided) is
+    called BEFORE the long sleep — simulating plugins writing to the shared
+    ``state`` DURING the invocation, which must survive the cut.
+    """
+
+    def __init__(self, state_writer=None, stuck_seconds: float = 10.0) -> None:
+        self._state_writer = state_writer
+        self._stuck_seconds = stuck_seconds
+
+    async def add_chat_message(self, _msg) -> None:  # noqa: ANN001 — SK signature
+        return None
+
+    def invoke(self):
+        return self._gen()
+
+    async def _gen(self):
+        if self._state_writer is not None:
+            self._state_writer()
+        # The ~12 LLM round-trips that never yield control back to the loop.
+        await asyncio.sleep(self._stuck_seconds)
+        yield _FakeMsg("unreachable")  # pragma: no cover — the bound cuts first
+
+
+class _QuickYieldChat:
+    """A fake ``AgentGroupChat`` that yields promptly — the unbounded (no
+    deadline) path must iterate it unchanged."""
+
+    def __init__(self, names: List[str]) -> None:
+        self._names = names
+
+    async def add_chat_message(self, _msg) -> None:  # noqa: ANN001
+        return None
+
+    def invoke(self):
+        return self._gen()
+
+    async def _gen(self):
+        for name in self._names:
+            await asyncio.sleep(0)  # yield control to the loop between turns
+            yield _FakeMsg(name)
+
+
+def _run_phase_import():
+    from argumentation_analysis.orchestration.conversational_orchestrator import (
+        _run_phase,
+    )
+
+    return _run_phase
+
+
+# ── Behavioural: the bound cuts a stuck first turn ─────────────────────────
+
+
+class TestIntraInvocationBoundCutsStuckTurn:
+    """The bound fires INSIDE a single ``chat.invoke()`` that never yields."""
+
+    @pytest.mark.asyncio
+    async def test_stuck_first_turn_is_cut_within_budget(self) -> None:
+        """A first ``__anext__`` that never returns is cut by the bound.
+
+        Mutation-verified: remove the ``_bounded_invoke`` wrap at the group-chat
+        call site and this test hangs on the ``asyncio.sleep(10)`` until the
+        pytest per-test timeout kills it (red). With the wrap, ``wait_for``
+        raises ``TimeoutError`` at ``deadline - now`` (~0.05 s here) and the
+        phase returns with zero messages — the response in flight was lost, but
+        the run did not hang and the populated ``state`` is preserved (next
+        test).
+        """
+        _run_phase = _run_phase_import()
+        from argumentation_analysis.core.shared_state import (
+            RhetoricalAnalysisState,
+        )
+
+        state = RhetoricalAnalysisState("test text")
+        fake_agent = MagicMock()
+        fake_agent.name = "FakeAgent"
+
+        chat = _StuckInvokeChat()
+        chat_cls = MagicMock(return_value=chat)
+
+        tight_deadline = time.time() + 0.05
+        start = time.time()
+        with patch(_AGENT_GROUP_CHAT, chat_cls):
+            messages = await _run_phase(
+                [fake_agent],
+                "initial prompt",
+                max_turns=5,
+                phase_name="Extraction & Detection",
+                state=state,
+                enable_growth_validation=False,
+                deadline=tight_deadline,
+            )
+        elapsed = time.time() - start
+
+        assert elapsed < 2.0, (
+            f"CB #1528 item 5 regression: the intra-invocation bound did NOT "
+            f"fire — _run_phase took {elapsed:.2f}s (stuck turn hung). Remove "
+            f"the _bounded_invoke wrap and this hangs until the test timeout."
+        )
+        assert messages == [], (
+            f"the stuck first __anext__ must be cut before ANY message is "
+            f"yielded; got {len(messages)} message(s)."
+        )
+
+    @pytest.mark.asyncio
+    async def test_stuck_turn_state_survives_the_cut(self) -> None:
+        """The shared ``state`` written DURING the stuck invocation survives.
+
+        This is the non-trivial point of item 5: the in-flight response is lost,
+        but plugins have already written to ``state`` before the cut. Those
+        writes are the honest partial verdict — NOT a hole. A ``CancelledError``
+        at the await point does not unwind mutations made to the shared mutable
+        ``state`` object.
+        """
+        _run_phase = _run_phase_import()
+        from argumentation_analysis.core.shared_state import (
+            RhetoricalAnalysisState,
+        )
+
+        state = RhetoricalAnalysisState("test text")
+
+        def _plugin_write():
+            # Plugins mutate the shared state DURING the invocation.
+            state._intra_invocation_marker = "written-before-cut"
+
+        chat = _StuckInvokeChat(state_writer=_plugin_write)
+        chat_cls = MagicMock(return_value=chat)
+
+        with patch(_AGENT_GROUP_CHAT, chat_cls):
+            await _run_phase(
+                [MagicMock(name="FakeAgent")],
+                "initial prompt",
+                max_turns=5,
+                phase_name="Extraction & Detection",
+                state=state,
+                enable_growth_validation=False,
+                deadline=time.time() + 0.05,
+            )
+
+        assert getattr(state, "_intra_invocation_marker", None) == (
+            "written-before-cut"
+        ), (
+            "CB #1528 item 5: the partial state written during the stuck "
+            "invocation was lost at the cut — the verdict partial must be REAL."
+        )
+
+    @pytest.mark.asyncio
+    async def test_stuck_turn_cut_is_logged_loud(self, caplog) -> None:
+        """The cut is a NAMED log, not a drowned INFO (DoD #2).
+
+        Uses the named-logger capture validated in R713/R720 (the project
+        re-installs root handlers mid-import, evicting a plain ``caplog``
+        handler; pinning the level on the named logger survives that).
+        """
+        _run_phase = _run_phase_import()
+        from argumentation_analysis.core.shared_state import (
+            RhetoricalAnalysisState,
+        )
+
+        state = RhetoricalAnalysisState("test text")
+        chat = _StuckInvokeChat()
+        chat_cls = MagicMock(return_value=chat)
+
+        with caplog.at_level(logging.INFO, logger="ConversationalOrchestrator"), patch(
+            _AGENT_GROUP_CHAT, chat_cls
+        ):
+            await _run_phase(
+                [MagicMock(name="FakeAgent")],
+                "initial prompt",
+                max_turns=5,
+                phase_name="Extraction & Detection",
+                state=state,
+                enable_growth_validation=False,
+                deadline=time.time() + 0.05,
+            )
+
+        assert any(
+            "borne intra-invocation" in rec.getMessage()
+            and "CB #1528 item 5" in rec.getMessage()
+            for rec in caplog.records
+        ), (
+            f"the intra-invocation cut must be a NAMED log mentioning "
+            f"'borne intra-invocation CB #1528 item 5'; got records: "
+            f"{[r.getMessage() for r in caplog.records]}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_mutation_without_the_bound_the_turn_is_not_cut(self) -> None:
+        """DoD mutation check, automated so it cannot rot: with ``_bounded_invoke``
+        neutralized to identity at the module reference, the stuck first turn is
+        NOT cut — it hangs for the full ``stuck_seconds``. This is the explicit
+        counterpart to ``test_stuck_first_turn_is_cut_within_budget``: together
+        they prove the bound is the thing cutting the turn, and that removing it
+        re-opens the defect.
+
+        ``stuck_seconds`` is kept short (1.5 s) to bound CI cost while staying
+        comfortably above the 0.05 s budget the cut test uses.
+        """
+        _run_phase = _run_phase_import()
+        from argumentation_analysis.core.shared_state import (
+            RhetoricalAnalysisState,
+        )
+
+        async def _identity_invoke(async_gen, _deadline, _phase, _path):
+            async for r in async_gen:
+                yield r
+
+        state = RhetoricalAnalysisState("test text")
+        chat = _StuckInvokeChat(stuck_seconds=1.5)
+        chat_cls = MagicMock(return_value=chat)
+
+        start = time.time()
+        with patch(_AGENT_GROUP_CHAT, chat_cls), patch(
+            "argumentation_analysis.orchestration.conversational_orchestrator."
+            "_bounded_invoke",
+            _identity_invoke,
+        ):
+            messages = await _run_phase(
+                [MagicMock(name="FakeAgent")],
+                "initial prompt",
+                max_turns=5,
+                phase_name="Extraction & Detection",
+                state=state,
+                enable_growth_validation=False,
+                deadline=time.time() + 0.05,
+            )
+        elapsed = time.time() - start
+
+        assert elapsed >= 1.2, (
+            f"Mutation check: with _bounded_invoke neutralized, the stuck turn "
+            f"should hang for the full stuck_seconds (~1.5s); elapsed={elapsed:.2f}s "
+            f"means something ELSE cut the turn — the bound is no longer load-bearing."
+        )
+        # With the bound removed, the stuck generator eventually completes and
+        # yields its single response — i.e. the turn was NOT cut at the budget
+        # (0.05 s) but ran to completion (~1.5 s). That is exactly the
+        # pre-item-5 defect the bound closes.
+        assert len(messages) == 1, (
+            f"with the bound removed the stuck turn completes and yields once; "
+            f"got {len(messages)} message(s)."
+        )
+
+
+# ── Non-regression: the unbounded path is unchanged ────────────────────────
+
+
+class TestUnboundedPathUnchanged:
+    """When ``deadline`` is None the bound is a no-op — the generator yields
+    normally. Anti-pendule: item 5 must not change the unbounded run."""
+
+    @pytest.mark.asyncio
+    async def test_no_deadline_iterates_normally(self) -> None:
+        _run_phase = _run_phase_import()
+        from argumentation_analysis.core.shared_state import (
+            RhetoricalAnalysisState,
+        )
+
+        state = RhetoricalAnalysisState("test text")
+        chat = _QuickYieldChat(["Agent-A", "Agent-B"])
+        chat_cls = MagicMock(return_value=chat)
+
+        with patch(_AGENT_GROUP_CHAT, chat_cls):
+            messages = await _run_phase(
+                [MagicMock(name="FakeAgent")],
+                "initial prompt",
+                max_turns=2,
+                phase_name="Extraction & Detection",
+                state=state,
+                enable_growth_validation=False,
+                deadline=None,  # unbounded — the bound must be a no-op
+            )
+
+        assert len(messages) == 2, (
+            f"with no deadline the generator must yield normally (2 turns); "
+            f"got {len(messages)}. The _bounded_invoke no-op path regressed."
+        )
+
+
+# ── Unit: _bounded_invoke in isolation ─────────────────────────────────────
+
+
+class TestBoundedInvokeUnit:
+    """Direct unit tests on the helper, isolating the mechanism from
+    ``_run_phase`` wiring."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_stops_generator_and_preserves_writes(self) -> None:
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _bounded_invoke,
+        )
+
+        written = {}
+
+        async def stuck_gen():
+            written["before_sleep"] = True
+            await asyncio.sleep(10)
+            yield "unreachable"  # pragma: no cover
+
+        deadline = time.time() + 0.05
+        out = []
+        async for r in _bounded_invoke(stuck_gen(), deadline, "X", "unit"):
+            out.append(r)
+
+        assert out == [], "the stuck __anext__ must be cut before any yield"
+        assert (
+            written.get("before_sleep") is True
+        ), "the write made before the stuck await must survive the cut"
+
+    @pytest.mark.asyncio
+    async def test_no_deadline_is_identity(self) -> None:
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _bounded_invoke,
+        )
+
+        async def quick_gen():
+            for v in ("a", "b", "c"):
+                await asyncio.sleep(0)
+                yield v
+
+        out = []
+        async for r in _bounded_invoke(quick_gen(), None, "X", "unit"):
+            out.append(r)
+
+        assert out == [
+            "a",
+            "b",
+            "c",
+        ], f"with deadline=None the wrapper must be identity; got {out}"

--- a/tests/unit/argumentation_analysis/orchestration/test_cf1538_growth_validation_groupchat.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_cf1538_growth_validation_groupchat.py
@@ -348,11 +348,14 @@ class TestCB1528Item4GroupChatDeadlineGuard:
         def fake_time():
             call_count[0] += 1
             # Call order in _run_phase for one mocked turn: (1) entry check
-            # L1896, (2) one call during turn processing, (3) between-turn
-            # check L1996 — all three must see entry_time (< deadline) so the
-            # turn completes and reaches growth validation. The re-prompt guard
-            # L2025 is the next call → sees post_turn_time (>= deadline) → fires.
-            return entry_time if call_count[0] <= 3 else post_turn_time
+            # L1896, (2) the intra-invocation ``remaining`` read in
+            # ``_bounded_invoke`` (CB #1528 item 5 — added one time.time() per
+            # turn before the first __anext__), (3) one call during turn
+            # processing, (4) between-turn check L1996 — all four must see
+            # entry_time (< deadline) so the turn completes and reaches growth
+            # validation. The re-prompt guard L2025 is the next call → sees
+            # post_turn_time (>= deadline) → fires.
+            return entry_time if call_count[0] <= 4 else post_turn_time
 
         with caplog.at_level(logging.INFO, logger="ConversationalOrchestrator"):
             with patch(_GC_PATCH, return_value=fake_chat):


### PR DESCRIPTION
## CB #1528 item 5 — bound the invocation itself (last critical path of Epic #1500)

Closes the last item of CB #1528. Items 1-4 merged (#1544, #1546); this closes the case the measurement re-opened.

### The diagnosed defect

Firsthand measurement (R716/R717, published on [#1528](https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/issues/1528)): the live (CD #1534) AgentGroupChat path's first `chat.invoke()` drives a function-calling agent that chains **~12 LLM round-trips before yielding a single response**. Every inter-turn deadline guard (item 3 #1544 / item 4 #1546) checks BETWEEN turns — none can fire inside a turn that never ends. So a tight wall-clock budget was blown by **ONE** invocation, and the external safety-net caught it, **throwing away a populated state** (arguments written seconds before the cut).

### The fix — `_bounded_invoke`

A new helper wraps the invocation generator and bounds **each `__anext__`** to the remaining budget:

```python
response = await asyncio.wait_for(agen.__anext__(), timeout=deadline - time.time())
```

Applied to both live invocation sites:
- the group-chat `chat.invoke()` (the path the measurement diagnosed — [conversational_orchestrator.py](argumentation_analysis/orchestration/conversational_orchestrator.py));
- the round-robin `agent.invoke()` fallback (a single agent.invoke can also chain function-calling round-trips).

On timeout the in-flight response is lost — **but the shared `state` is NOT**. Plugins write to it DURING the invocation; the `CancelledError` raised at the await point leaves those writes intact, so the partial state becomes the honest partial verdict (not a hole). This is the same observation as R715 viewed from the other end.

### Why this is NOT the "killed mid-flight" the WallClockBudget rejects

The `WallClockBudget` docstring (L67-68) explicitly rejects *"a coroutine killed mid-flight by an external `asyncio.wait_for` (which would lose the partial state and report `decides=False`)."* Item 5 is a different operation: that rejection kills the **whole** `run_conversational_analysis` and loses its return dict; item 5 bounds a **single `__anext__` inside `_run_phase`**, which then returns normally with the messages accumulated so far. The verdict comes from the populated `state`, not from a constructed-but-lost return value. The `_bounded_invoke` docstring makes the distinction explicit so a future reader does not "fix" it back into the rejected shape.

### Form choice (the dispatch offered two)

| Form | Verdict |
|---|---|
| `asyncio.wait_for` on each `__anext__` with the remaining budget | **Retained** — one mechanism, derived from `deadline`, no second budget |
| per-request timeout pushed to the LLM client | **Rejected** — more intrusive, touches the client, breaks the SK abstraction |

### Anti-pendule (held)

- A **single** mechanism, derived from the existing `deadline` (no second budget).
- When `deadline` is None the generator is yielded **unchanged** (no-op for unbounded runs — verified by `test_no_deadline_iterates_normally`).
- The re-prompt loops (item 4) are pre-guarded before each re-prompt and **kept out of scope**: a re-prompt is one short `agent.invoke`, already gated; bounding its interior is defense-in-depth, not the diagnosed defect.

### Tests — LLM-free, deterministic, mutation-verified

`tests/unit/argumentation_analysis/orchestration/test_cb1528_intra_invocation_item5.py` (new, 7 tests):

| Test | Proves |
|---|---|
| `test_stuck_first_turn_is_cut_within_budget` | the bound cuts a stuck first `__anext__` (~0.05 s, not 10 s) — **mutation-verified**: remove the wrap and it hangs |
| `test_stuck_turn_state_survives_the_cut` | the state written DURING the stuck invocation survives the cut → real partial verdict, not a hole |
| `test_stuck_turn_cut_is_logged_loud` | the cut is a NAMED log (`borne intra-invocation CB #1528 item 5`), DoD #2 |
| `test_mutation_without_the_bound_the_turn_is_not_cut` | neutralizes `_bounded_invoke` to identity → the stuck turn then hangs for the full `stuck_seconds`; the automated, non-rotting mutation check the DoD requires |
| `test_no_deadline_iterates_normally` | the unbounded path (deadline None) is unchanged |
| `test_timeout_stops_generator_and_preserves_writes` / `test_no_deadline_is_identity` | unit suite on `_bounded_invoke` directly, isolating the mechanism |

Plus a recalibration in `test_cf1538_growth_validation_groupchat.py`: the item-4 group-chat `fake_time` threshold `<= 3` → `<= 4` (item 5 adds one `time.time()` read per turn in `_bounded_invoke`); comment updated.

### Validation

- ✅ 7 item-5 tests **pass**
- ✅ Non-regression **113 passed** (CB item 3/4 postcap, CF growth groupchat, C1 wall-clock, groupchat turn, orchestrator, growth_validation_hook_597, item 5)
- ✅ mypy strict: 0 errors on the new helper (42 preexisting on the file, unchanged baseline)
- ✅ black: clean

### ⚠️ Honnête — DoD #1 / #3 need a real LLM run

The DoD's empirical items ("a tight bounded run shows conversational mode exit at the cap with `decides=True` and non-zero fill, **without** the external net intervening"; "a generous N: no cut, 4 modes clean") require a real LLM run (3-4 min, non-deterministic), calibrated on the measured variance (`pipeline_standard` 15/15 in 301 s vs breach at 400 s). As in R715/R720, that firsthand bounded run is left to the coordinator. The LLM-free coverage here proves the mechanism (bound cuts + state survives + mutation), the non-regression, and the rendering contract (unbounded path unchanged) — the deterministic core of what those runs would demonstrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
