### PR TITLE
fix(hierarchical): productivity predicate discounts partial production, not zeroes it (#1550)

### DIFF
--- a/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
+++ b/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
@@ -98,6 +98,47 @@ def _degradation_reasons(outputs: Any) -> List[str]:
     return reasons
 
 
+def _task_productivity(result: Dict[str, Any]) -> float:
+    """Per-task productivity weight: 1.0 clean, 0.5 produced-but-partial, 0.0 none.
+
+    #1550 (mirror of CC #1531 item 1): item 1 made the rate count production
+       rather than execution — closing a real false positive (``success_rate``
+    1.0 on empty tasks). But its discriminant was binary: a task that produced a
+    REAL artifact AND honestly flagged a partial degradation (``degraded``) fell
+    in the same bucket as a task that produced nothing. The real production was
+    erased by the partial-degradation admission — a verdict of void on real
+    production, the mirror image of the original defect.
+
+    The discriminant here is the PRESENCE of a substantive artifact (a non-empty
+    list in ``outputs``) among self-declared degradation:
+
+    * not degraded → **1.0**. A clean run that honestly finds zero fallacies on
+      a clean corpus is a success that found nothing (``test_empty_output_
+      without_self_report_still_counts`` pins this — emptiness is not failure).
+    * degraded + a non-empty artifact → **0.5**. The task produced real analysis
+      AND admitted a partial gap; ``degraded`` is a discount, not a zero.
+    * degraded + no artifact (or no outputs) → **0.0**. A self-declared
+      non-analysis (item 1's ``status: unavailable`` / empty ``total_fallacies``
+      forms) stays closed.
+
+    Justification in one line (DoD #3): ``degraded`` discounts a task that
+    produced; only the ABSENCE of production zeroes it. The rejected alternative
+    — reading only ``outputs.status in _DEGRADED_OUTPUT_STATUSES`` — does not
+    survive the item-1 guard's task shape (a degraded result with no ``outputs``
+    field must still read 0.0, which a status-only check would miss).
+    """
+    if result.get("status") != "completed":
+        return 0.0
+    if not result.get("degraded"):
+        return 1.0
+    outputs = result.get("outputs")
+    if isinstance(outputs, dict) and any(
+        isinstance(v, list) and v for v in outputs.values()
+    ):
+        return 0.5
+    return 0.0
+
+
 class DelegationError(RuntimeError):
     """Raised when the 3-tier delegation chain cannot proceed honestly.
 
@@ -436,10 +477,13 @@ class DelegationOrchestrator:
                 )
             elif result.get("status") == "failed":
                 reasons.append(f"{label}: {result.get('reason', 'failed')}")
-        produced_anything = any(
-            r.get("status") == "completed" and not r.get("degraded")
-            for r in operational_results
-        )
+        # #1550: ``produced_anything`` uses the SAME productivity predicate as
+        # the per-objective rate above (``_task_productivity``), so a run where
+        # every task produced real analysis but each flagged a partial gap is
+        # still a verdict, not a degrade. The previous binary form
+        # (``completed and not degraded``) was the same mirror defect at the
+        # verdict level — coherent predicate, two consumers.
+        produced_anything = any(_task_productivity(r) > 0 for r in operational_results)
         degraded = bool(operational_results) and not produced_anything
 
         conclusion = final.get("conclusion")
@@ -497,11 +541,7 @@ class DelegationOrchestrator:
             if not results:
                 success_rate = 0.0
             else:
-                productive = sum(
-                    1
-                    for r in results
-                    if r.get("status") == "completed" and not r.get("degraded")
-                )
+                productive = sum(_task_productivity(r) for r in results)
                 success_rate = productive / len(results)
             eval_input[oid] = {"success_rate": success_rate}
         return eval_input

--- a/tests/orchestration/hierarchical/test_delegation_decides_firsthand_1471_R648.py
+++ b/tests/orchestration/hierarchical/test_delegation_decides_firsthand_1471_R648.py
@@ -49,8 +49,15 @@ class TestDelegationModeDecidesFirsthand:
     """
 
     @pytest.mark.asyncio
+    @pytest.mark.requires_api
     async def test_delegation_mode_decides_end_to_end_with_real_agents(self) -> None:
         """5/5 operational tasks complete; conclusion is a graded verdict.
+
+        #1550 (DoD #5): this test makes REAL LLM calls (≈184 s measured) — it
+        must declare that dependency. Declaring is NOT excluding: the real path
+        still runs when a key is present, and CI (``tests/unit/`` only) never
+        collected it regardless. The marker protects a future CI scope widening
+        and makes the LLM cost honest. A ``skip`` would satisfy none of that.
 
         Honnête-partiel: this assumes the test environment has a populated
         ``setup_registry()`` (i.e. ``include_optional=True``). The

--- a/tests/unit/orchestration/test_productivity_predicate_1550.py
+++ b/tests/unit/orchestration/test_productivity_predicate_1550.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+"""Tests for #1550 — the productivity predicate mirror-error fix.
+
+CC #1531 item 1 (PR #1545) made the per-objective ``success_rate`` count
+production rather than execution — closing a real false positive (1.0 on empty
+tasks). But its discriminant was binary: ``completed and not degraded``. A task
+that produced a REAL artifact AND honestly flagged a partial degradation
+(``degraded``) fell in the same bucket as a task that produced nothing. Real
+production was erased by the partial-degradation admission — a verdict of void
+on production, the mirror image of the original defect.
+
+Firsthand (coordinator R722, ``results/task-obj-2-1_results.json``): obj-2
+returned ``outputs.fallacies`` with 6 items (taxonomy depth 5),
+``completion_status: completed``, ``degraded: True`` (a secondary per-argument
+lift step skipped for want of extractable arguments). The task DID detect
+fallacies — yet scored 0.0.
+
+The fix (``_task_productivity``): ``degraded`` discounts a task that produced
+(0.5); only the ABSENCE of a substantive artifact zeroes it (0.0); a clean run
+is 1.0 even on an empty corpus.
+
+These tests are sync and LLM-free. They live in a dedicated module WITHOUT
+``pytestmark = pytest.mark.asyncio`` so the sync functions do not inherit an
+asyncio mark they cannot satisfy (lesson R722). The 0.5 case is the mutation
+guard: the pre-fix binary predicate could only emit 0.0 or 1.0, so asserting
+0.5 proves the new discount path — a test that would still pass under the old
+predicate proves nothing (DoD #4).
+"""
+
+from argumentation_analysis.orchestration.hierarchical.delegation_orchestrator import (
+    DelegationOrchestrator,
+    _task_productivity,
+)
+
+# ``_aggregate_results_by_objective`` is a @staticmethod on DelegationOrchestrator
+# — the site #1550 targets (the per-objective success_rate).
+_aggregate_results_by_objective = DelegationOrchestrator._aggregate_results_by_objective
+
+
+# ── Unit: _task_productivity — three cases, three distinct scores ──────────
+
+
+def test_clean_production_is_full():
+    """A non-degraded completed task scores 1.0 — even with empty findings."""
+    assert (
+        _task_productivity({"status": "completed", "outputs": {"fallacies": []}}) == 1.0
+    )
+
+
+def test_degraded_with_artifact_is_half_the_mutation_guard():
+    """A degraded task that STILL produced a substantive artifact scores 0.5.
+
+    This is the obj-2 shape (firsthand): ``degraded: True`` AND a non-empty
+    ``fallacies`` list. Pre-fix this scored 0.0 (``completed and not degraded``
+    → False); the 0.5 assertion is the mutation discriminator — the binary
+    predicate could never emit it.
+    """
+    result = {
+        "status": "completed",
+        "degraded": True,
+        "degradation_reasons": ["degraded"],
+        "outputs": {
+            "fallacies": [{"taxonomy_pk": "1389", "taxonomy_path": "7.3.2.3.3"}],
+            "degraded": True,
+            "last_error": "per-argument fallacy lift skipped",
+        },
+    }
+    assert _task_productivity(result) == 0.5
+
+
+def test_degraded_without_artifact_is_zero_item1_case_stays_closed():
+    """A self-declared non-analysis with no artifact scores 0.0.
+
+    The three item-1 forms (``degraded`` flag with empty output, ``status:
+    unavailable``, ``extraction_status: failed``) all stay 0.0 — the mirror fix
+    must not re-open the false positive item 1 closed.
+    """
+    # degraded flag, no substantive artifact (a scalar count, not a collection)
+    assert (
+        _task_productivity(
+            {"status": "completed", "degraded": True, "outputs": {"total_fallacies": 0}}
+        )
+        == 0.0
+    )
+    # status: unavailable — self-declared non-analysis
+    assert (
+        _task_productivity(
+            {
+                "status": "completed",
+                "degraded": True,
+                "outputs": {"status": "unavailable"},
+            }
+        )
+        == 0.0
+    )
+    # no outputs at all (the test_degraded_run_does_not_conclude_success shape)
+    assert (
+        _task_productivity(
+            {
+                "status": "completed",
+                "degraded": True,
+                "degradation_reasons": ["degraded"],
+            }
+        )
+        == 0.0
+    )
+
+
+def test_three_scores_are_distinct():
+    """DoD #4: the three situations yield three distinct scores."""
+    scores = {
+        "clean": _task_productivity(
+            {"status": "completed", "outputs": {"fallacies": []}}
+        ),
+        "partial": _task_productivity(
+            {
+                "status": "completed",
+                "degraded": True,
+                "outputs": {"fallacies": [{"x": 1}]},
+            }
+        ),
+        "void": _task_productivity(
+            {"status": "completed", "degraded": True, "outputs": {"total_fallacies": 0}}
+        ),
+    }
+    assert scores == {"clean": 1.0, "partial": 0.5, "void": 0.0}, scores
+    assert len(set(scores.values())) == 3, "scores are not three distinct values"
+
+
+def test_failed_execution_is_zero():
+    """A task that did not complete scores 0.0 regardless of outputs."""
+    assert (
+        _task_productivity({"status": "failed", "outputs": {"fallacies": [1]}}) == 0.0
+    )
+
+
+# ── Integration: the per-objective rate (the site #1550 targets) ───────────
+
+
+def _obj_result(oid, **kwargs):
+    base = {"objective_id": oid, "status": "completed", "capability": "stub"}
+    base.update(kwargs)
+    return base
+
+
+def test_aggregate_obj2_partial_production_scores_above_zero():
+    """DoD #1: obj-2 (degraded + real fallacies) rates > 0.
+
+    Reproduces the firsthand obj-2 shape on the REAL aggregation path
+    (``_aggregate_results_by_objective``) — the exact site #1550 targets. No
+    LLM run: the artifact shape is the one captured in
+    ``results/task-obj-2-1_results.json``.
+    """
+    objectives = [{"id": "obj-2", "description": "Détecter les sophismes"}]
+    results = [
+        _obj_result(
+            "obj-2",
+            degraded=True,
+            degradation_reasons=["degraded"],
+            outputs={
+                "fallacies": [{"taxonomy_pk": "1389"}],
+                "degraded": True,
+                "last_error": "per-argument fallacy lift skipped",
+            },
+        )
+    ]
+    rate = _aggregate_results_by_objective(objectives, results)
+    assert rate["obj-2"]["success_rate"] == 0.5, rate
+    assert rate["obj-2"]["success_rate"] > 0, "obj-2 produced → must not be zero"
+
+
+def test_aggregate_item1_void_case_stays_zero():
+    """DoD #2: the item-1 void case (degraded, no artifact) stays 0.0."""
+    objectives = [{"id": "obj-1", "description": "Détecter les sophismes"}]
+    results = [
+        _obj_result(
+            "obj-1",
+            degraded=True,
+            degradation_reasons=["status=unavailable"],
+            outputs={"status": "unavailable"},
+        )
+    ]
+    rate = _aggregate_results_by_objective(objectives, results)
+    assert rate["obj-1"]["success_rate"] == 0.0, rate
+
+
+def test_aggregate_mixed_objective_averages_partial_and_full():
+    """An objective with one partial (0.5) and one clean (1.0) task rates 0.75.
+
+    The rate is an honest average of per-task productivities, so a partially
+    degraded objective that still produced reads between 0 and 1 — not the 0.0
+    the binary predicate forced, nor a fabricated 1.0.
+    """
+    objectives = [{"id": "obj-x", "description": "mixed"}]
+    results = [
+        _obj_result(
+            "obj-x",
+            degraded=True,
+            outputs={"fallacies": [{"a": 1}]},
+        ),
+        _obj_result("obj-x", outputs={"fallacies": []}),
+    ]
+    rate = _aggregate_results_by_objective(objectives, results)
+    assert rate["obj-x"]["success_rate"] == 0.75, rate


### PR DESCRIPTION
## #1550 — productivity predicate: discount partial production, don't zero it

Mirror of CC #1531 item 1 (PR #1545). Item 1 fixed a real false positive — the per-objective `success_rate` counted *execution* (`status == "completed"`) rather than *production*, so a provider announcing its own unavailability (`status: "unavailable"`) rolled up into "performance globale élevée". PR #1545 closed it.

But item 1's discriminant was binary: `completed and not degraded`. That swung the pendulum to the **mirror error**: a task that produced a REAL artifact AND honestly flagged a partial degradation (`degraded: True`) fell in the same bucket as a task that produced nothing. Real production was erased by the partial-degradation admission.

### Firsthand evidence (no LLM re-run)

`results/task-obj-2-1_results.json` (local, gitignored): obj-2 returned
`outputs.fallacies` with **6 items** (taxonomy depth 5),
`completion_status: completed`, `degraded: True` (a secondary per-argument
fallacy-lift step skipped for want of extractable arguments). The task **DID
detect fallacies** — yet scored `0.0` under the binary predicate.

This was originally misread (R722) as LLM non-determinism. The coordinator's
firsthand measurement proved obj-2 produced real analysis; the root cause is the
binary predicate, not the model.

### Fix — `_task_productivity` (delegation_orchestrator.py)

A single productivity predicate with a 3-valued discriminant on **artifact
presence** among self-declared degradation:

| Situation | Score | Rationale |
|-----------|-------|-----------|
| not degraded | **1.0** | a clean run that honestly finds zero fallacies on a clean corpus is a success that found nothing |
| degraded + non-empty artifact | **0.5** | the task produced real analysis AND admitted a partial gap; `degraded` is a *discount*, not a zero |
| degraded + no artifact (or no outputs) | **0.0** | a self-declared non-analysis (item-1's `status: unavailable` / empty `total_fallacies` forms) stays closed |
| status != completed | **0.0** | failed execution is zero regardless of outputs |

One line (DoD #3): **`degraded` discounts a task that produced; only the
ABSENCE of production zeroes it.**

Applied at **both consumers** so the two read the same predicate:
- per-objective rate (`_aggregate_results_by_objective`): `success_rate = sum(_task_productivity) / n`
- global degraded verdict: `produced_anything = any(_task_productivity(r) > 0 ...)`

The rejected alternative — reading only `outputs.status in _DEGRADED_OUTPUT_STATUSES` — does not survive the item-1 guard's task shape (a degraded result with no `outputs` field must still read 0.0, which a status-only check would miss).

### Anti-pendule

The void case (item 1's `status: unavailable`, empty `total_fallacies`, no
outputs) **stays 0.0** — the mirror fix must not re-open the false positive item
1 closed. The three item-1 contract guards stay green:

- `test_degraded_run_does_not_conclude_success` → 0.0
- `test_empty_output_without_self_report_still_counts` → 1.0 (emptiness ≠ failure)
- `test_partial_degradation_still_emits_a_verdict` → partial + clean → honest mix

### DoD

| # | Item | Status |
|---|------|--------|
| 1 | obj-2 (degraded + real fallacies) rates > 0 on the real aggregation path | ✅ `test_aggregate_obj2_partial_production_scores_above_zero` (0.5) |
| 2 | item-1 void case stays 0.0 | ✅ `test_aggregate_item1_void_case_stays_zero` + 3 unit guards |
| 3 | one-line justification documented | ✅ docstring + PR |
| 4 | three situations → three distinct scores (mutation guard) | ✅ `test_three_scores_are_distinct` — the 0.5 case could not be emitted by the binary predicate |
| 5 | LLM dependency declared honestly | ✅ `requires_api` on the e2e test (declaring ≠ excluding) |

8 sync LLM-free tests in a dedicated module (`tests/unit/orchestration/test_productivity_predicate_1550.py`). 18 delegation non-regression tests green. mypy 0 / black clean.

### Test-wiring note (lesson R722)

The sync tests live in a dedicated module **without** `pytestmark = pytest.mark.asyncio` so they do not inherit an asyncio mark they cannot satisfy. The 0.5 case is the mutation discriminator — a test that would still pass under the old binary predicate (which could only emit 0.0/1.0) proves nothing.

### Files

- `argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py` — `_task_productivity` helper + 2 call sites
- `tests/unit/orchestration/test_productivity_predicate_1550.py` — new, 8 tests
- `tests/orchestration/hierarchical/test_delegation_decides_firsthand_1471_R648.py` — `requires_api` on e2e (DoD #5)

No files removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
