### PR TITLE
fix(registry): per-argument sub-step no longer shadows the complete fallacy path (#1553)

### DIFF
--- a/argumentation_analysis/orchestration/hierarchical/hierarchy_bridge.py
+++ b/argumentation_analysis/orchestration/hierarchical/hierarchy_bridge.py
@@ -67,7 +67,18 @@ class RegistryBackedOperationalRegistry:
     def find_for_capability(self, capability: str) -> Optional[ComponentRegistration]:
         """Find the best component providing a capability.
 
-        Returns the first registered provider (any type) or None.
+        Returns a single provider (any type) or ``None`` if none is registered.
+
+        #1553: the underlying ``CapabilityRegistry`` indexes capabilities as a
+        ``Dict[str, Set[str]]`` and does NOT guarantee registration order — so
+        when several providers share a capability, ``providers[0]`` is
+        arbitrary (depends on ``hash()``, salted per-process). This bridge and
+        the DSL consume capabilities whose providers were curated to be unique
+        (e.g. ``hierarchical_fallacy_detection`` resolves to exactly one
+        complete path since #1553), which makes ``providers[0]`` deterministic
+        *for those*. Do NOT assume determinism for a capability with multiple
+        registered providers — register a deterministic selector or collapse
+        the providers first.
         """
         providers = self._registry.find_for_capability(capability)
         return providers[0] if providers else None

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -278,18 +278,39 @@ def setup_registry(
                 FallacyWorkflowPlugin,
             )
 
+            # #1553: this service is an ENRICHMENT sub-step, NOT a terminal
+            # detection provider. Its own contract (invoke_callables.py:4893-4922)
+            # states it runs AFTER the wide-net descent and that "the wide-net
+            # result is retained by the caller" — the complete path calls it
+            # directly at invoke_callables.py:4506 and merges via
+            # ``_merge_fallacy_results``. Declaring ``hierarchical_fallacy_detection``
+            # (or ``fallacy_detection``) here let it be RESOLVED as a terminal
+            # provider: with no caller, the wide-net result it assumes already
+            # ran is absent, and it returns ``fallacies: []`` + ``degraded`` —
+            # a silent loss. Because ``_capability_index`` is a ``Dict[str,
+            # Set[str]]`` and consumers take ``providers[0]`` believing it is
+            # "first registered" (hierarchy_bridge.py:67-73), the winner between
+            # this sub-step and ``hierarchical_fallacy_detector`` depended on
+            # ``hash()``, salted per-process — intermittent between runs (3/5),
+            # stable inside one. The fix is subtractive: the sub-step keeps its
+            # REAL capability (``per_argument_fallacy_detection``) and ceases to
+            # shadow the complete path. Not deleted — still invoked directly by
+            # the complete path; just no longer selectable as a terminal
+            # detection provider. Anti-pendule: tri the index was rejected (it
+            # would stabilize the winner on an arbitrary — alphabetic — order,
+            # i.e. work for a wrong reason).
             registry.register_service(
                 name="hierarchical_fallacy_per_argument",
                 service_class=FallacyWorkflowPlugin,
                 capabilities=[
-                    "hierarchical_fallacy_detection",
                     "per_argument_fallacy_detection",
-                    "fallacy_detection",
                 ],
                 metadata={
                     "description": (
                         "Parallel per-argument hierarchical fallacy detection. "
-                        "Runs FallacyWorkflowPlugin on each argument via asyncio.gather (#578 tier 3)"
+                        "Runs FallacyWorkflowPlugin on each argument via asyncio.gather (#578 tier 3). "
+                        "Enrichment sub-step of _invoke_hierarchical_fallacy (invoked directly, "
+                        "NOT a terminal detection provider — #1553)."
                     )
                 },
                 invoke=_invoke_hierarchical_fallacy_per_argument,

--- a/tests/unit/orchestration/test_shared_capability_provider_selection_1553.py
+++ b/tests/unit/orchestration/test_shared_capability_provider_selection_1553.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+"""Tests for #1553 — the shared-capability provider-selection defect.
+
+Two services declared the SAME capability ``hierarchical_fallacy_detection``:
+the complete path (``hierarchical_fallacy_detector`` → wide-net + merge) and a
+per-argument enrichment SUB-STEP (``hierarchical_fallacy_per_argument``) whose
+own contract says it runs AFTER the wide-net descent and that "the wide-net
+result is retained by the caller". Invoked as a terminal provider, that
+sub-step has no caller to retain anything — it returns ``fallacies: []`` +
+``degraded`` (a silent loss, score 0.0).
+
+The mechanism (established firsthand by the coordinator, R724, and re-verified
+here): ``_capability_index`` is a ``Dict[str, Set[str]]``
+(capability_registry.py:84); ``find_for_capability`` iterates the set as-is
+(:295-296); consumers take ``providers[0]`` believing it is "first registered"
+(hierarchy_bridge.py:67-73). The iteration order of a ``set`` of strings
+depends on ``hash()``, which CPython salts per-process — so the winner between
+the two providers was a coin flip at process start. Intermittent BETWEEN runs
+(3/5), stable INSIDE one. That is the tell that pointed at the process, not
+the business logic.
+
+The fix is SUBTRACTIVE (anti-pendule): the sub-step ceases to declare
+``hierarchical_fallacy_detection`` (and ``fallacy_detection``, same structural
+defect — it is no kind of terminal detection provider). It keeps its REAL
+capability ``per_argument_fallacy_detection``. It is not deleted: the complete
+path still calls it directly at invoke_callables.py:4506. Tri the index was
+rejected: it would stabilize the winner on an arbitrary (alphabetic) order —
+the complete path would win by luck, not by design, and the sub-step would
+still shadow other consumers of ``fallacy_detection``.
+
+These tests are sync and LLM-free. They prove the selection is now
+deterministic BY CONSTRUCTION (exactly one provider for
+``hierarchical_fallacy_detection`` → the ``providers[0]`` coin flip has only
+one face). The mutation guards assert what the pre-fix registration shape
+would have failed (two providers) and what must survive (the real capability
+is preserved).
+
+They live in a dedicated module WITHOUT ``pytestmark = pytest.mark.asyncio``
+so the sync functions do not inherit an asyncio mark they cannot satisfy
+(lesson R722).
+"""
+
+from argumentation_analysis.core.capability_registry import (
+    CapabilityRegistry,
+    ComponentType,
+)
+from argumentation_analysis.orchestration.registry_setup import setup_registry
+
+# ── DoD #1 — the mechanism, measured (not hypothesized) ────────────────────
+
+
+def test_capability_index_is_a_set_so_order_is_not_guaranteed():
+    """The defect carrier: ``_capability_index`` stores a ``Set[str]``, whose
+    iteration order depends on ``hash()`` (salted per-process). This is the
+    structural fact that made ``providers[0]`` a coin flip when two providers
+    shared a capability. Establishing it here (measurement, not hypothesis) is
+    DoD #1.
+    """
+    registry = setup_registry(include_optional=True)
+    index = registry._capability_index  # noqa: SLF001 — structural assertion
+    # The index maps capability -> set of provider names (a Set, not a list).
+    assert isinstance(index["hierarchical_fallacy_detection"], set)
+
+
+def test_per_process_salt_is_the_variable_neutralized():
+    """The intermittence was BETWEEN processes (stable inside one). The fix
+    removes the second provider, so the set cardinality is 1 and there is no
+    coin to flip regardless of ``PYTHONHASHSEED``. Asserting cardinality 1 here
+    IS the reproductibility guarantee (DoD #2) — established structurally
+    rather than by 5 LLM runs whose variance would be the model, not the
+    selection.
+    """
+    registry = setup_registry(include_optional=True)
+    providers = registry._capability_index[  # noqa: SLF001
+        "hierarchical_fallacy_detection"
+    ]
+    assert len(providers) == 1, (
+        f"hierarchical_fallacy_detection has {len(providers)} providers "
+        f"({sorted(providers)}) — must be exactly 1 to be deterministic; "
+        f"the shared-capability defect (#1553) is not closed"
+    )
+
+
+# ── DoD #3 — the sub-step can no longer be a terminal provider ─────────────
+
+
+def test_only_the_complete_path_provides_hierarchical_fallacy_detection():
+    """After the fix, ``find_for_capability('hierarchical_fallacy_detection')``
+    returns exactly one provider: ``hierarchical_fallacy_detector`` (the
+    complete wide-net + merge path). The per-argument sub-step no longer
+    shadows it.
+    """
+    registry = setup_registry(include_optional=True)
+    providers = registry.find_for_capability("hierarchical_fallacy_detection")
+    names = [p.name for p in providers]
+    assert names == ["hierarchical_fallacy_detector"], names
+
+
+def test_sub_step_no_longer_declares_terminal_detection_capabilities():
+    """Mutation guard: the per-argument sub-step must NOT declare
+    ``hierarchical_fallacy_detection`` nor ``fallacy_detection`` — those are
+    terminal-detection capabilities, and it is an enrichment sub-step. The
+    pre-fix registration declared both; this assertion would have failed then.
+    """
+    registry = setup_registry(include_optional=True)
+    for terminal_cap in (
+        "hierarchical_fallacy_detection",
+        "fallacy_detection",
+    ):
+        providers = registry.find_for_capability(terminal_cap)
+        names = [p.name for p in providers]
+        assert "hierarchical_fallacy_per_argument" not in names, (
+            f"sub-step still declares terminal capability {terminal_cap!r} — "
+            f"#1553 regression (it would shadow the complete path again)"
+        )
+
+
+def test_sub_step_keeps_its_real_capability():
+    """Anti-pendule guard: the sub-step is NOT deleted — it keeps its REAL
+    capability ``per_argument_fallacy_detection``. The complete path still
+    invokes it directly (invoke_callables.py:4506) for the recall lift. The
+    defect was the SHARING of the terminal capability, not the sub-step's
+    existence.
+    """
+    registry = setup_registry(include_optional=True)
+    providers = registry.find_for_capability("per_argument_fallacy_detection")
+    names = [p.name for p in providers]
+    assert "hierarchical_fallacy_per_argument" in names, (
+        "sub-step lost per_argument_fallacy_detection — the fix deleted the "
+        "sub-step instead of subtracting the shared capability (anti-pendule)"
+    )
+
+
+def test_resolution_is_invariant_under_hash_seed_by_construction():
+    """DoD #2 (reproductibility) read as a structural property: with exactly
+    one provider, resolving N times in the same process trivially yields the
+    same provider every time — but the point is to assert the absence of the
+    second face of the coin, not to re-run an LLM 5 times. Simulating the
+    pre-fix shape (two providers) shows the non-determinism the fix removes.
+    """
+    # Post-fix real registry: one provider, deterministic by construction.
+    registry = setup_registry(include_optional=True)
+    resolved = [
+        registry.find_for_capability("hierarchical_fallacy_detection")[0].name
+        for _ in range(8)
+    ]
+    assert all(name == "hierarchical_fallacy_detector" for name in resolved)
+
+    # The pre-fix shape, reproduced on a throwaway registry: two providers
+    # under the same capability. find_for_capability returns BOTH (order not
+    # guaranteed); consumers taking [0] would see either. This is the
+    # variable the subtractive fix removes — documented, not re-introduced.
+    twin = CapabilityRegistry()
+    twin.register(
+        name="complete_path",
+        component_type=ComponentType.SERVICE,
+        capabilities=["hierarchical_fallacy_detection"],
+    )
+    twin.register(
+        name="enrichment_sub_step",
+        component_type=ComponentType.SERVICE,
+        capabilities=["hierarchical_fallacy_detection"],
+    )
+    twin_providers = twin.find_for_capability("hierarchical_fallacy_detection")
+    assert len(twin_providers) == 2, (
+        "expected the pre-fix shape (2 providers sharing the capability) to "
+        "reproduce the non-determinism carrier — if this fails, the registry "
+        "changed and the test's premise needs revisiting"
+    )


### PR DESCRIPTION
## #1553 — the per-argument sub-step stops shadowing the complete fallacy path

Two services declared the **same** capability `hierarchical_fallacy_detection`:
the complete path (`hierarchical_fallacy_detector` → wide-net + merge) and a
per-argument **enrichment sub-step** (`hierarchical_fallacy_per_argument`). The
delegation e2e test was intermittent **3/5** on the same commit (3 green, 2
red); `obj-2` scored 0.5 or 0.0 depending on which provider won.

### Mechanism — established firsthand (DoD #1)

Verified here against the source, matching the coordinator's R724 measurement:

- `_capability_index` is a `Dict[str, Set[str]]` (`capability_registry.py:84`)
- `find_for_capability` iterates the set as-is (`:295-296`)
- consumers take `providers[0]` believing it is "first registered" (`hierarchy_bridge.py:67-73`)
- the iteration order of a `set` of strings depends on `hash()`, **salted per-process**

→ the winner between the two providers was a coin flip at process start. The tell: stability **inside** a run vs intermittence **between** runs — pointing at the process, not the business logic. 8 processes with the same two names: 5/3, consistent with 3 green / 2 red.

The sub-step's **own contract** confirms it is not a terminal provider (`invoke_callables.py:4893-4922`):

> "this per-argument pass is invoked AFTER the wide-net 'llm' descent already ran (its results are merged by the caller at the `_merge_fallacy_results` site) … the wide-net result is retained by the caller"

The complete path calls it **directly** at `invoke_callables.py:4506` and merges via `_merge_fallacy_results`. Invoked as a terminal provider, it has no caller to retain anything — it returns `fallacies: []` + `degraded` → score 0.0. A correct contract for a sub-step, a silent loss for a terminal provider.

### Fix — subtractive (anti-pendule)

The sub-step **ceases to declare** `hierarchical_fallacy_detection` **and** `fallacy_detection` (same structural defect — it is no kind of terminal detection provider). It **keeps** its REAL capability `per_argument_fallacy_detection`. It is **not deleted**: the complete path still invokes it directly for the recall lift; it is just no longer selectable as a terminal detection provider.

**Rejected** — tri the index: it would stabilize the winner on an arbitrary (alphabetic) order. `hierarchical_fallacy_detector` < `hierarchical_fallacy_per_argument` → the complete path would win **by luck, not by design**, and the sub-step would still shadow other consumers of `fallacy_detection`. The coordinator's R724 note: "rendre la résolution déterministe est nécessaire mais ne suffit pas."

The `find_for_capability` docstring (`hierarchy_bridge.py:67-73`) no longer claims "first registered" (a guarantee the registry never provided). It documents the residual non-determinism for capabilities that DO have multiple providers, so the defect stays visible instead of masked by a false promise.

### Reproducibility (DoD #2) is now structural

With exactly **one** provider for `hierarchical_fallacy_detection`, `providers[0]` is deterministic regardless of `PYTHONHASHSEED` — the coin has one face. Asserted at the registry level (set cardinality 1), not by 5 LLM runs whose variance would be the model, not the selection.

### Anti-pendule

- The sub-step is **preserved** — it carries `per_argument_fallacy_detection`, and the complete path still calls it directly (`invoke_callables.py:4506`).
- The defect was the **sharing** of the terminal capability, not the sub-step's existence.
- No refactor of capability resolution (tri rejected; `workflow_dsl.py:686` `providers[0]` left in place — with one provider it is deterministic by construction).

### DoD

| # | Item | Status |
|---|------|--------|
| 1 | mechanism established + written (measurement, not hypothesis) | ✅ docstring + PR + test_capability_index_is_a_set… |
| 2 | 5 consecutive runs, same verdict on obj-2 | ✅ structural — set cardinality 1 ⇒ deterministic by construction (test_per_process_salt_is_the_variable_neutralized) |
| 3 | sub-step can no longer be selected as terminal provider of `hierarchical_fallacy_detection` | ✅ it no longer declares it (test_sub_step_no_longer_declares_terminal_detection_capabilities) |
| 4 | no fabricated result — empty `fallacies` + honest `degraded` stays the right answer when the complete path finds nothing | ✅ the complete path's own contract (unchanged) already does this; the fix only stops the sub-step from being the one that answers |

### Files

- `argumentation_analysis/orchestration/registry_setup.py` — sub-step keeps only `per_argument_fallacy_detection`; comment documents the #1553 reasoning
- `argumentation_analysis/orchestration/hierarchical/hierarchy_bridge.py` — `find_for_capability` docstring corrected (no more false "first registered" promise)
- `tests/unit/orchestration/test_shared_capability_provider_selection_1553.py` — new, 6 LLM-free tests (mutation guard: pre-fix the sub-step appeared in `find_for_capability('hierarchical_fallacy_detection')`)

No files removed (Consolider ≠ Archiver). The sub-step is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
