### PR TITLE
fix(ci): the anti-skip-storm guard could never fire — its total was always 0 (#1556)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,10 +136,19 @@ jobs:
           
           if (Test-Path pytest_report.xml) {
             [xml]$xml = Get-Content pytest_report.xml
-            $total = [int]$xml.testsuites.tests
-            $errors = [int]$xml.testsuites.errors
-            $failures = [int]$xml.testsuites.failures
-            $skipped = [int]$xml.testsuites.skipped
+            # #1556: pytest porte les compteurs sur <testsuite>, pas sur la
+            # racine <testsuites>. Lire la racine renvoyait '' donc 0 à TOUS les
+            # runs — d'où un "Passed: 0 / 0" affiché aussi bien sur 13161 tests
+            # passés que sur une suite entièrement sautée, ce qui a rendu le
+            # skip storm de fd07420f invisible.
+            $suites = @($xml.testsuites.testsuite)
+            $total = 0; $errors = 0; $failures = 0; $skipped = 0
+            foreach ($s in $suites) {
+              $total    += [int]$s.tests
+              $errors   += [int]$s.errors
+              $failures += [int]$s.failures
+              $skipped  += [int]$s.skipped
+            }
             $passed = $total - $errors - $failures - $skipped
             
             Write-Host "✅ Passed:  $passed / $total"
@@ -177,16 +186,31 @@ jobs:
             exit 0
           }
           [xml]$xml = Get-Content pytest_report.xml
-          $total = [int]$xml.testsuites.tests
+          # #1556: les compteurs sont sur <testsuite>, pas sur la racine
+          # <testsuites>. Lire la racine donnait $total = 0 à tous les runs, ce
+          # qui rendait la branche "exit 1" ci-dessous INATTEIGNABLE par
+          # construction : le run 30360430769 a compté 13202 skips JVM sur un
+          # total lu à 0, puis a imprimé son message de succès.
+          $total = 0
+          foreach ($s in @($xml.testsuites.testsuite)) { $total += [int]$s.tests }
           $content = Get-Content pytest_report.xml -Raw
           $jvmSignature = "JVM n'est pas réellement démarrée"
           # Count <skipped message="...signature..."> occurrences (scoped to
           # skip messages, so a signature mention in test names / stdout cannot
           # inflate the count).
           $jvmSkipCount = ([regex]::Matches($content, 'message="[^"]*' + [regex]::Escape($jvmSignature))).Count
-          $pct = if ($total -gt 0) { [math]::Round(100 * $jvmSkipCount / $total) } else { 0 }
+          # Un rapport présent dont le total est nul n'est pas un succès : soit
+          # la suite n'a rien exécuté, soit le parse est cassé. Les deux doivent
+          # être bruyants — c'est très exactement le trou par lequel #1556 est
+          # passé inaperçu (le garde se désarmait lui-même en silence).
+          if ($total -le 0) {
+            Write-Host "❌ FAIL-LOUD: pytest_report.xml présent mais total illisible ou nul ($total)."
+            Write-Host "   Le run n'a décidé de rien — un badge vert ici serait du théâtre (#1556, #1385, #1019)."
+            exit 1
+          }
+          $pct = [math]::Round(100 * $jvmSkipCount / $total)
           Write-Host "🔍 JVM-startup guard: $jvmSkipCount / $total tests ($pct%) skipped with JVM-not-started signature."
-          if ($total -gt 0 -and ($jvmSkipCount / $total) -gt 0.5) {
+          if (($jvmSkipCount / $total) -gt 0.5) {
             Write-Host "❌ FAIL-LOUD: $jvmSkipCount tests ($pct%) were skipped because the JVM did not start."
             Write-Host "   The run decided nothing — a green badge here would be theater (#1385, #1019)."
             Write-Host "   Likely cause: transient Temurin/JVM-setup flake on the runner. Re-run; if it persists, JVM init is broken on CI (urgent)."


### PR DESCRIPTION
Ferme #1556.

Le garde anti-théâtre ajouté par #1385 pour attraper les skip storms JVM **ne pouvait pas se déclencher**. Sa condition de tir est gardée par un total qui vaut `0` à tous les runs.

## Le défaut

`pytest` porte ses compteurs sur `<testsuite>`, pas sur la racine `<testsuites>` :

```xml
<testsuites name="pytest tests">
  <testsuite name="pytest" errors="0" failures="0" skipped="1" tests="2" ...>
```

Les deux étapes lisaient la racine. Mesuré :

```
$xml.testsuites.tests            -> ''   as int: 0
$xml.testsuites.testsuite.tests  -> '2'  as int: 2
```

Conséquence sur le garde :

```powershell
if ($total -gt 0 -and ($jvmSkipCount / $total) -gt 0.5) { exit 1 }
```

`$total -gt 0` toujours faux ⇒ branche `exit 1` **inatteignable par construction**.

## La preuve d'impact

Run [30360430769](https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/actions/runs/30360430769) — `main` `fd07420f`, conclusion **success** :

```
======= 13448 skipped, 298 deselected, 10 warnings in 77.86s ========
✅ Passed:  0 / 0
🔍 JVM-startup guard: 13202 / 0 tests (0%) skipped with JVM-not-started signature.
✅ JVM-startup guard OK — JVM-dependent tests ran (or skipped for legitimate non-JVM reasons).
```

**13202 / 0.** 77 secondes au lieu des ~27 minutes habituelles, zéro test exécuté, badge vert. La cause amont est visible dans le même log — un plantage natif au chargement de torch (`Windows fatal exception: code 0xc0000138`) qui empêche ensuite la JVM de démarrer. C'est le flake d'environnement connu ; ce qui est nouveau, c'est que le garde écrit pour le rendre bruyant est resté muet.

Le `Passed: 0 / 0` est la même cause, et c'est **pourquoi personne ne l'a vu** : il affiche `0 / 0` aussi bien sur les runs à 13 161 tests passés que sur celui-ci à 0.

## Portée — le gate n'est pas vacué en permanence

Trois runs verts antérieurs vérifiés (`a84dd58f`, `00ab8102`, `efb76eda`) ont bien exécuté la suite : 13 161–13 164 passés en 1 500–2 100 s. Le gate décide réellement **quand l'environnement du runner tient**. Il devient vacué exactement dans le cas que le garde devait couvrir.

## Le correctif

1. Lire les compteurs sur `<testsuite>` et les sommer, dans les **deux** étapes.
2. Traiter « rapport présent mais total illisible ou nul » comme un échec bruyant plutôt qu'un passage silencieux — c'est le trou par lequel le garde se désarmait lui-même.

## Vérification

Garde exécuté contre des rapports synthétiques :

| Scénario | Avant | Après |
|---|---|---|
| 13202 skips JVM / 13448 tests (le cas réel) | `13202 / 0 (0%)` → **OK** | `13202 / 13448 (98%)` → **exit 1** |
| 4000 / 13430 (30 %) | OK | `(30%)` → pass — seuil ciblé préservé |
| Run sain 13430 tests, 0 signature | OK | `0 / 13430 (0%)` → pass |
| Rapport présent, total 0 | OK | **exit 1** |

## Anti-pendule

**Pas** élargi à un taux de skip brut. Le commentaire d'origine dit explicitement que le garde vise la signature JVM « NOT the raw skip rate, so legitimate skips (orphan-model, build-absent, requires_api) never trip it » — cette décision reste bonne. Seule l'arithmétique était fausse, seule l'arithmétique change.

## ⚠ Fichier sous discipline — à relire humainement

Ce diff touche `.github/workflows/ci.yml`, que ma propre discipline de merge classe en zone protégée (non-mergeable sans relecture). Je l'ouvre en PR et **je ne la merge pas moi-même** : c'est au coordinateur humain de trancher.

## Note

Même famille que les défauts que l'Epic #1500 ferme en ce moment : une métrique dont le nom survit à ce qu'elle calcule (#1531), un garde placé là où il ne peut pas mordre, un champ jamais lu correctement (#1019). Ici, dans le garde anti-théâtre lui-même.

🤖 Coordinator ai-01 — R725
