### PR TITLE
fix(deps): pin mcp to the 1.x line — 2.0.0 drops mcp.server.fastmcp and aborts CI collection

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -82,7 +82,7 @@ dependencies:
     - tenacity
     - pybreaker
     - pytest-dotenv
-    - mcp
+    - mcp>=1.26,<2  # PIN: mcp 2.0.0 (sorti le 2026-07-28) supprime `mcp.server.fastmcp`, importé par argumentation_analysis/services/mcp_server/main.py → 3 erreurs de COLLECTION dans tests/unit/services/test_mcp_server_v2/, qui avortent toute la suite. Non épinglé, la CI a résolu 2.0.0 le jour de sa sortie et a bloqué toutes les PRs. Migration vers l'API 2.x = ticket séparé.
     - blis
     - JPype1>=1.5.0
     - pytest-benchmark

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,6 +15,6 @@ psutil
 unidecode
 pytest-playwright
 matplotlib
-mcp
+mcp>=1.26,<2  # voir environment.yml : mcp 2.0.0 supprime `mcp.server.fastmcp`
 hypothesis
 pytest-timeout


### PR DESCRIPTION
`mcp` était non épinglé dans `environment.yml` et `requirements-test.txt`. **`mcp 2.0.0` est sorti aujourd'hui** et supprime `mcp.server.fastmcp`, importé par `argumentation_analysis/services/mcp_server/main.py`. La CI a résolu 2.0.0 le jour même :

```
Downloading mcp-2.0.0-py3-none-any.whl (349 kB)
...
E   ModuleNotFoundError: No module named 'mcp.server.fastmcp'
ERROR tests/unit/services/test_mcp_server_v2/test_conversation_tools.py
ERROR tests/unit/services/test_mcp_server_v2/test_main_v2.py
ERROR tests/unit/services/test_mcp_server_v2/test_session_manager.py
!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!
=============== 298 deselected, 9 warnings, 3 errors in 47.57s ================
```

Une erreur de **collection** avorte la suite entière : ceci bloquait **toutes les PRs ouvertes**, pas seulement celle qui l'a fait apparaître (#1554, dont le diff ne touche ni les dépendances ni ces modules).

## Le pin

`>=1.26,<2` — la ligne contre laquelle le code est écrit et que fait tourner l'environnement de dev. Vérifié firsthand :

```
installed 1.26.0 -> satisfies >=1.26,<2 : True
mcp.server.fastmcp importable: True
```

Les deux fichiers sont corrigés : `environment.yml` (utilisé par la CI) et `requirements-test.txt` (même entrée nue, même dérive à venir sinon).

## Ce que ce PR ne fait pas

Il ne migre pas vers l'API 2.x. C'est du travail réel qui mérite son propre ticket — ici on restaure le gate, on ne réécrit pas le serveur MCP.

## Famille

Même classe de dérive que `pyfakefs` (#1353), `hypothesis` (#1303) et `diskcache` (#1336) : une dépendance non épinglée qui se résout silencieusement vers quelque chose contre quoi le code n'a jamais été écrit. La différence ici est le rayon de souffle — une erreur de collection, donc zéro test exécuté sur toutes les branches.

🤖 Coordinator ai-01 — R725
