### PR TITLE
fix(communication): wire the strategic→tactical broadcast junction (#1555)

### DIFF
--- a/argumentation_analysis/core/communication/tactical_adapter.py
+++ b/argumentation_analysis/core/communication/tactical_adapter.py
@@ -658,6 +658,50 @@ class TacticalAdapter:
         )
         return subscription_id
 
+    def subscribe_to_directives(
+        self,
+        callback: Callable[[Message], None],
+        topic_id: str = "objectives.strategic_decision",
+        filter_criteria: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """S'abonne aux directives stratégiques diffusées par le manager.
+
+        #1555 (Track C2, Epic #1500) — la jonction publieur/abonné se fait sur
+        le **chemin topic** du middleware, pas sur le canal HIERARCHICAL. Le
+        manager stratégique émet via ``StrategicAdapter.broadcast_objective``
+        → ``middleware.publish(topic_id="objectives.<type>", ...)`` (topic
+        path). ``subscribe_to_operational_updates`` (le miroir obvious)
+        utilise ``get_channel(HIERARCHICAL).subscribe`` (channel path) — or
+        ``publish`` ne livre qu'aux topic subscribers + ``global_handlers``
+        (pub_sub.py:386/399, middleware.py:419-434), JAMAIS aux subscribers
+        d'un canal. Un miroir aveugle du canal laisserait le broadcast
+        atteindre 0 agent. On s'abonne donc au topic que le publieur utilise
+        vraiment (Option A du DoD item 4 de #1555).
+
+        Args:
+            callback: Fonction **synchrone** appelée à la réception —
+                ``Topic.publish_message`` invoque le callback sans ``await``
+                (pub_sub.py:121), un ``async def`` créerait une coroutine
+                jamais attendue et ne s'exécuterait jamais.
+            topic_id: Topic auquel s'abonner (``objectives.strategic_decision``
+                par défaut — le type émis par
+                ``StrategicManager.evaluate_final_results``).
+            filter_criteria: Critères de filtrage optionnels (``None`` =
+                accepte tous les messages du topic ; le nom du topic filtre
+                déjà par type d'objectif).
+
+        Returns:
+            Un identifiant d'abonnement.
+        """
+        subscription_id = self.middleware.subscribe(
+            topic_id=topic_id,
+            subscriber_id=self.agent_id,
+            callback=callback,
+            filter_criteria=filter_criteria,
+        )
+        self.logger.info(f"Subscribed to strategic directives on topic {topic_id!r}")
+        return subscription_id
+
     def send_status_update(
         self,
         update_type: str,

--- a/argumentation_analysis/orchestration/hierarchical/tactical/coordinator.py
+++ b/argumentation_analysis/orchestration/hierarchical/tactical/coordinator.py
@@ -10,7 +10,7 @@ import uuid
 from argumentation_analysis.orchestration.hierarchical.tactical.state import (
     TacticalState,
 )
-from argumentation_analysis.paths import RESULTS_DIR
+from argumentation_analysis.paths import RESULTS_DIR, DATA_DIR
 from argumentation_analysis.core.communication.middleware import (
     MessageMiddleware,
     create_default_middleware,
@@ -248,20 +248,35 @@ class TaskCoordinator:
         self.logger.info(f"Action Tactique: {action_type} - {description}")
 
     def _subscribe_to_strategic_directives(self) -> None:
-        async def handle_directive(message: Message) -> None:
-            directive_type = message.content.get("directive_type")
-            self.logger.info(f"Directive stratégique reçue : {directive_type}")
-            if directive_type == "new_strategic_plan":
-                objectives = message.content.get("objectives", [])
-                self.process_strategic_objectives(objectives)
-            elif directive_type == "strategic_adjustment":
-                self._apply_strategic_adjustments(message.content)
+        # #1555 (Track C2, Epic #1500) — le handler est désormais enregistré
+        # pour de vrai (plus de commentaire + log menteur). La signature est
+        # synchrone : ``Topic.publish_message`` appelle le callback sans
+        # ``await`` (pub_sub.py:121), un ``async def`` n'aurait jamais tourné.
+        def handle_directive(message: Message) -> None:
+            # Le publieur (``StrategicAdapter.broadcast_objective``) écrit la
+            # clé ``objective_type`` (pas ``directive_type`` — celle-là vient
+            # du point-à-point ``issue_directive``, un autre chemin).
+            objective_type = message.content.get("objective_type")
+            self.logger.info(f"Directive stratégique reçue : {objective_type}")
+            if objective_type == "strategic_decision":
+                # Le payload (decision_type/conclusion/evaluation) est niché
+                # sous la clé ``DATA_DIR`` (un Path) — lu de la même façon
+                # qu'écrit par le publieur (strategic_adapter.py:122). Le type
+                # ignore reflète ce couplage : ``content`` est typé
+                # ``Dict[str, Any]`` mais le publieur utilise le Path comme
+                # clé (défaut latent pré-existant, hors périmètre #1555).
+                payload = message.content.get(DATA_DIR, {}) or {}  # type: ignore[call-overload]
+                self._log_action(
+                    "strategic_decision_received",
+                    (
+                        f"decision_type={payload.get('decision_type', 'unknown')}; "
+                        f"conclusion={payload.get('conclusion', '')}"
+                    ),
+                )
 
-        # self.adapter.subscribe_to_directives(handle_directive)
-        self.logger.warning(
-            "Subscription to directives is currently disabled due to API changes."
+        self._directive_subscription_id = self.adapter.subscribe_to_directives(
+            handle_directive
         )
-        self.logger.info("Abonné aux directives stratégiques.")
 
     def _determine_appropriate_agent(
         self, required_capabilities: List[str]

--- a/tests/orchestration/tactical/test_tactical_coordinator_advanced.py
+++ b/tests/orchestration/tactical/test_tactical_coordinator_advanced.py
@@ -182,6 +182,18 @@ class AuthenticMiddleware:
             self.channels[channel_type] = AuthenticChannel(channel_type)
         return self.channels[channel_type]
 
+    def subscribe(self, topic_id, subscriber_id, callback=None, filter_criteria=None):
+        """S'abonne à un topic — interface du middleware réel (#1555).
+
+        Le double authentique se contente de renvoyer un id d'abonnement ; il
+        ne reproduit pas la livraison topic (les tests de réception firsthand
+        passent par le vrai ``create_default_middleware``). Présent pour que la
+        construction d'un ``TacticalCoordinator`` (qui appelle désormais
+        ``subscribe_to_directives``) ne lève pas.
+        """
+        logger.info(f"Abonnement authentique de {subscriber_id} au topic {topic_id}")
+        return f"sub-{subscriber_id}-{topic_id}"
+
     def publish(
         self, topic_id, sender, sender_level, content, priority=None, metadata=None
     ):

--- a/tests/orchestration/tactical/test_tactical_coordinator_coverage.py
+++ b/tests/orchestration/tactical/test_tactical_coordinator_coverage.py
@@ -297,6 +297,18 @@ class AuthenticMiddlewareExtended:
             logger.info(f"Canal authentique créé automatiquement: {channel_type}")
         return self.channels[channel_type]
 
+    def subscribe(self, topic_id, subscriber_id, callback=None, filter_criteria=None):
+        """S'abonne à un topic — interface du middleware réel (#1555).
+
+        Le double authentique renvoie un id d'abonnement sans reproduire la
+        livraison topic (les tests de réception firsthand utilisent le vrai
+        ``create_default_middleware``). Présent pour que la construction d'un
+        ``TacticalCoordinator`` (qui appelle désormais
+        ``subscribe_to_directives``) ne lève pas.
+        """
+        logger.info(f"Abonnement authentique de {subscriber_id} au topic {topic_id}")
+        return f"sub-{subscriber_id}-{topic_id}"
+
     def publish(
         self, topic_id, sender, sender_level, content, priority=None, metadata=None
     ):

--- a/tests/unit/argumentation_analysis/core/communication/test_strategic_broadcast_junction_1555.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_strategic_broadcast_junction_1555.py
@@ -1,0 +1,180 @@
+# tests/unit/argumentation_analysis/core/communication/test_strategic_broadcast_junction_1555.py
+"""Track C2 of #1500 — #1555: the strategic→tactical broadcast junction.
+
+``test_broadcast_bus_fix_1500.py`` established the *plumbing* (Fix B: ``publish``
+fans out to ``global_handlers`` so a registered listener receives the broadcast
+firsthand) and CC #1531 made the *hole* visible (the ``NO subscriber`` warning).
+Neither **closed** the hole for production: the tactical coordinator — the one
+tier meant to consume strategic decisions — never subscribed. Its
+``_subscribe_to_strategic_directives`` had the handler commented out, logged
+``"Abonné aux directives stratégiques."`` (affirming the subscription it just
+disabled), and called ``subscribe_to_directives`` — a method that did not exist.
+
+The mechanism (issue #1555, established firsthand on ``main``): three pieces.
+(1) The handler was commented (coordinator.py); (2) ``subscribe_to_directives``
+did not exist — the only subscription primitive is ``subscribe_to_operational_updates``
+(``tactical_adapter.py:623``), which uses the **channel** path
+(``get_channel(HIERARCHICAL).subscribe``); (3) the publisher emits on the
+**topic** path (``middleware.publish(topic_id="objectives.<type>")``), and these
+two paths do not meet. ``publish`` delivers to topic subscribers + ``global_handlers``
+(pub_sub.py:386/399, middleware.py:419-434) — NEVER to a channel's subscribers.
+
+So the fix is the junction of DoD item 4, **Option A**: the tactical tier
+subscribes to the topic ``objectives.strategic_decision`` via
+``middleware.subscribe`` (the topic path the publisher actually uses). The shape
+mirrors ``subscribe_to_operational_updates`` (adapter method, filter_criteria,
+returns a subscription id); the transport is the topic path, because a channel
+mirror would leave the broadcast reaching 0 agents. Option B (make the strategic
+tier emit on the channel) is rejected — it is exactly the delivery-semantics
+change forbidden by ``strategic_adapter.py:177-179``.
+
+These tests prove the production junction firsthand, LLM-free and JVM-free: a
+real ``TacticalCoordinator`` subscribes in its ``__init__``, a real
+``StrategicAdapter`` broadcasts on the same shared middleware, and the decision
+lands in tactical state (a genuine effect, anti-#1019 / anti-pendule: not a
+debug listener invented to bump a counter). The no-subscriber guard stays armed
+on topics nobody listens to (DoD bullet 3).
+
+Content uses opaque IDs only (corpus_A) — privacy discipline.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from argumentation_analysis.core.communication.message import MessagePriority
+from argumentation_analysis.core.communication.middleware import (
+    create_default_middleware,
+)
+from argumentation_analysis.core.communication.strategic_adapter import (
+    StrategicAdapter,
+)
+from argumentation_analysis.orchestration.hierarchical.tactical.coordinator import (
+    TacticalCoordinator,
+)
+from argumentation_analysis.orchestration.hierarchical.tactical.state import (
+    TacticalState,
+)
+
+# ── DoD bullet 1+2 — production reception, firsthand, same run ──────────────
+
+
+class TestStrategicDecisionReachesTacticalFirsthand:
+    """A real ``TacticalCoordinator`` receives a strategic broadcast and acts
+    on it (records the decision in tactical state). This is the closed hole:
+    not a debug listener, a production component that does something.
+    """
+
+    def test_tactical_coordinator_records_strategic_decision(self) -> None:
+        mw = create_default_middleware()
+        tactical_state = TacticalState()
+        # Construction subscribes the coordinator to the strategic_decision
+        # topic (via _subscribe_to_strategic_directives → subscribe_to_directives).
+        TacticalCoordinator(tactical_state=tactical_state, middleware=mw)
+        strategic = StrategicAdapter("strategic_manager", mw)
+
+        # Same shared middleware, same run: emission then reception.
+        strategic.broadcast_objective(
+            "strategic_decision",
+            {
+                "decision_type": "final_conclusion",
+                "conclusion": "corpus_A_coherent",
+                "evaluation": {"score": 0.8},
+            },
+            priority=MessagePriority.HIGH,
+        )
+
+        # Firsthand reception — a REAL effect on production state, not a flag.
+        received = [
+            a
+            for a in tactical_state.tactical_actions_log
+            if a.get("type") == "strategic_decision_received"
+        ]
+        assert len(received) == 1, (
+            f"expected the tactical coordinator to record the strategic "
+            f"decision firsthand; actions log = {tactical_state.tactical_actions_log!r}"
+        )
+        assert "corpus_A_coherent" in received[0]["description"]
+        assert "final_conclusion" in received[0]["description"]
+
+
+# ── DoD bullet 3 — the no-subscriber guard stays armed ──────────────────────
+
+
+class TestNoSubscriberGuardArmedAndScoped:
+    """The CC #1531 ``NO subscriber`` warning must NOT fire on the now-wired
+    ``strategic_decision`` path, and MUST still fire on a topic with nobody
+    listening. It must not be neutralized (DoD bullet 3).
+    """
+
+    def test_no_warning_when_tactical_subscribed(self, caplog: logging.Logger) -> None:
+        mw = create_default_middleware()
+        TacticalCoordinator(middleware=mw)
+        strategic = StrategicAdapter("strategic_manager", mw)
+        with caplog.at_level(
+            logging.WARNING, logger="StrategicAdapter.strategic_manager"
+        ):
+            strategic.broadcast_objective(
+                "strategic_decision", {"decision_type": "final_conclusion"}
+            )
+        assert "NO subscriber" not in caplog.text
+
+    def test_warning_still_fires_when_nobody_listens(
+        self, caplog: logging.Logger
+    ) -> None:
+        # A topic with NO production subscriber → the guard fires. Do not
+        # neutralize it.
+        mw = create_default_middleware()
+        with caplog.at_level(
+            logging.WARNING, logger="StrategicAdapter.strategic_manager"
+        ):
+            StrategicAdapter("strategic_manager", mw).broadcast_objective(
+                "global_strategy", {"goal": "opaque"}
+            )
+        assert "NO subscriber" in caplog.text
+
+
+# ── Anti-pendule — topic-scoped subscription, not a fabricated catch-all ─────
+
+
+class TestSubscriptionIsTopicScoped:
+    """The junction is a **topic** subscription (Option A), not a
+    ``register_global_handler`` invented to bump the reception counter. A
+    topic-scoped subscriber receives ``strategic_decision`` and ignores an
+    unrelated objective type — proving the scope is real, not a wildcard.
+    """
+
+    def test_tactical_ignores_unrelated_objective_type(self) -> None:
+        mw = create_default_middleware()
+        tactical_state = TacticalState()
+        TacticalCoordinator(tactical_state=tactical_state, middleware=mw)
+        strategic = StrategicAdapter("strategic_manager", mw)
+
+        # An objective type the coordinator did NOT subscribe to.
+        strategic.broadcast_objective("global_strategy", {"goal": "opaque"})
+
+        decisions = [
+            a
+            for a in tactical_state.tactical_actions_log
+            if a.get("type") == "strategic_decision_received"
+        ]
+        assert decisions == [], (
+            "a topic-scoped subscriber must not catch unrelated objective "
+            "types — that would be a global catch-all (the fabricated-counter "
+            "anti-pattern), not a topic junction"
+        )
+
+    def test_subscribe_to_directives_uses_topic_path(self) -> None:
+        """Mutation guard: the subscription lands on the topic the publisher
+        uses (``objectives.strategic_decision``), reachable via ``publish`` —
+        not stranded on a channel that ``publish`` never delivers to.
+        """
+        mw = create_default_middleware()
+        TacticalCoordinator(middleware=mw)
+        # The topic must exist and carry the tactical subscriber.
+        topic = mw.publish_subscribe.topics.get("objectives.strategic_decision")
+        assert topic is not None, (
+            "subscribe_to_directives must subscribe on the topic path — the "
+            "topic objectives.strategic_decision was not created"
+        )
+        assert topic.get_subscriber_count() >= 1


### PR DESCRIPTION
## #1555 — the strategic→tactical broadcast junction is wired (Track C2, Epic #1500)

The tactical coordinator — the one tier meant to consume strategic decisions —
never subscribed. Its `_subscribe_to_strategic_directives` had the handler
**commented out**, logged `"Abonné aux directives stratégiques."` (affirming the
subscription it just disabled), and called `subscribe_to_directives` — a method
that **did not exist**. CC #1531 made the hole visible (the `NO subscriber`
warning); this PR closes it for production.

### Mechanism — three pieces, established firsthand on `main`

1. The handler was commented (`tactical/coordinator.py`); the next line logged
   the subscription it just disabled.
2. `subscribe_to_directives` did not exist. The only subscription primitive was
   `subscribe_to_operational_updates` (`tactical_adapter.py:623`), which uses
   the **channel** path (`get_channel(HIERARCHICAL).subscribe`).
3. The publisher emits on the **topic** path
   (`middleware.publish(topic_id="objectives.<type>")`). These two paths are
   **disjoint**: `publish` delivers to topic subscribers + `global_handlers`
   (`pub_sub.py:386/399`, `middleware.py:419-434`) — **never** to a channel's
   subscribers. So even with the handler uncommented and the method written,
   publisher and subscriber would not meet. **This junction is the heart of the
   track**, not the commented line.

A note on the coordinator's hint ("mirror `subscribe_to_operational_updates`"):
mirroring its **shape** is right, but its **transport** (channel) is disjoint
from `broadcast_objective`'s topic path — a blind channel mirror leaves the
broadcast reaching 0 agents (DoD #2 fails). The mirror must use the topic path.

### Fix — Option A (DoD item 4)

The tactical tier subscribes to the topic `objectives.strategic_decision` via
`middleware.subscribe` (the topic path the publisher actually uses). New method
`TacticalAdapter.subscribe_to_directives(callback, topic_id=..., filter_criteria=...)`
mirrors `subscribe_to_operational_updates` (adapter method, filter_criteria,
returns a subscription id); the transport is the topic path.

**Option B rejected** (make the strategic tier emit on the channel) — it is
exactly the delivery-semantics change forbidden by the anti-pendule guard at
`strategic_adapter.py:177-179` ("NE PAS se mettre à émettre `message` sur le
canal ici"). **No middleware refactor.**

The handler is **synchronous**: `Topic.publish_message` calls the callback
without `await` (`pub_sub.py:121`), so the original `async def` handler would
have created a coroutine that never runs. It reads `objective_type` (the key
the publisher writes — **not** `directive_type`, which is the point-to-point
`issue_directive` path) and records the decision in tactical state via
`_log_action` — a **genuine effect** (anti-pendule: not a debug listener
invented to bump a counter, not a `register_global_handler` catch-all).

### Firsthand trace — emission + reception, same run (DoD #2)

Real `TacticalCoordinator` + `StrategicAdapter` on a shared
`create_default_middleware()`, LLM/JVM-free:

```
StrategicAdapter.strategic_manager : Objective strategic_decision broadcasted
  to 1 topic subscriber(s) + 0 global listener(s)   ← the NO-subscriber
                                                      warning does NOT fire
coordinator : Directive stratégique reçue : strategic_decision
coordinator : Action Tactique: strategic_decision_received
                - decision_type=final_conclusion; conclusion=corpus_A_coherent
                                                       ← state mutation, not a flag
```

`test_tactical_coordinator_records_strategic_decision` asserts the decision
lands in `tactical_state.tactical_actions_log`.

### The guard stays armed (DoD #3)

The CC #1531 warning no longer fires on `objectives.strategic_decision` (there
is now a real subscriber), but it **still fires** on a topic nobody listens to:

```
StrategicAdapter.strategic_manager : Objective global_strategy published on
  topic 'objectives.global_strategy' with NO subscriber — nothing was
  delivered (no-op broadcast).
```

It is **not neutralized** — covered by `test_warning_still_fires_when_nobody_listens`.

### Test doubles

The pre-#1555 `_subscribe_to_strategic_directives` was a no-op, so it tolerated
incomplete middleware fakes. The real subscription calls
`middleware.subscribe`, which the `AuthenticMiddleware` /
`AuthenticMiddlewareExtended` doubles in `tests/orchestration/tactical/` did
not implement — constructing a `TacticalCoordinator` with them crashed at
`AttributeError` (17 tests). They now implement `.subscribe` (the real
contract: returns a subscription id). The reception-firsthand tests use the
**real** `create_default_middleware`, not a double.

### DoD

| # | Item | Status |
|---|------|--------|
| 1 | production component really subscribed: handler registered (not commented), log no longer lies | ✅ handler wired; lying log removed; `subscribe_to_directives` implemented |
| 2 | broadcast reaches ≥1 agent firsthand — trace in PR | ✅ trace above; `test_tactical_coordinator_records_strategic_decision` |
| 3 | warning no longer fires on this path, still fires when nobody's there | ✅ `test_no_warning_when_tactical_subscribed` + `test_warning_still_fires_when_nobody_listens` |
| 4 | junction explicit, one option documented | ✅ Option A (topic path); Option B rejected (forbidden delivery-semantics change) |

### Anti-pendule

- The handler does something **real** (mutates tactical state), not a debug counter.
- The no-subscriber warning is **preserved** (still fires on empty topics).
- **No middleware refactor** — `subscribe_to_directives` mirrors the shape of
  `subscribe_to_operational_updates`, only the transport differs (topic vs channel).
- The subscription is **topic-scoped** (`objectives.strategic_decision`), not a
  `register_global_handler` catch-all — proven by
  `test_tactical_ignores_unrelated_objective_type`.

### Files

- `argumentation_analysis/core/communication/tactical_adapter.py` — new `subscribe_to_directives` (topic path)
- `argumentation_analysis/orchestration/hierarchical/tactical/coordinator.py` — handler wired (sync, reads `objective_type`, records in state); lying log removed
- `tests/unit/argumentation_analysis/core/communication/test_strategic_broadcast_junction_1555.py` — new, 5 LLM-free tests
- `tests/orchestration/tactical/test_tactical_coordinator_advanced.py` / `..._coverage.py` — `AuthenticMiddleware(Extended).subscribe` (real contract)

Validation: 5 new + 28 tactical/communication green; CI mypy gate (8 gated files) Success 0 issues; black clean.

Epic #1500. Closes #1555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
