### PR TITLE
fix(harness): les compteurs sophismes/arguments du pipeline n'ont jamais rien mesuré (#1560)

### DIFF
--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -639,14 +639,35 @@ async def run_pipeline_mode(
         1 for v in (snap or {}).values() if v and v not in ([], {}, "", None, 0)
     )
 
+    # #1560: the counts are MEASURED from the snapshot the pipeline returns.
+    # ``result["extra_metrics"]`` has NO producer anywhere in the package, so
+    # ``.get("extra_metrics", {}).get("fallacy_count", 0)`` returned its literal
+    # default on every run — a 0 indistinguishable from an observed 0 (leçon
+    # #1531). What gave it away was invariance: identical 0/0 before AND after
+    # #1553 changed the resolution the pipeline uses. Same phantom-key defect as
+    # the one already fixed for the conversational runner (CB #1528 item 3).
+    #
+    # ⚠ INVERSE polarity from that fix: ``unified_pipeline`` returns
+    # ``get_state_snapshot(summarize=True)``, whose shape carries ``fallacy_count``
+    # / ``argument_count`` FLAT at top level (shared_state.py:358-359) — NOT the
+    # raw ``identified_*`` collections the conversational runner reads. Copying
+    # that fix verbatim yields None everywhere while looking correct.
+    def _summarized_count(key: str) -> Optional[int]:
+        value = (snap or {}).get(key)
+        # Absent (or drifted to a non-count shape) → None → "—" (Track CG #1540).
+        # Never a fabricated 0.
+        if isinstance(value, bool) or not isinstance(value, int):
+            return None
+        return value
+
     return ModeResult(
         mode=f"pipeline_{workflow_name}",
         corpus_id=corpus_id,
         success=True,
         duration_seconds=round(duration, 2),
         state_fill_rate=round(non_empty / max(total_fields, 1), 3),
-        fallacy_count=result.get("extra_metrics", {}).get("fallacy_count", 0),
-        argument_count=result.get("extra_metrics", {}).get("argument_count", 0),
+        fallacy_count=_summarized_count("fallacy_count"),
+        argument_count=_summarized_count("argument_count"),
         phases_completed=summary.get("completed", 0),
         phases_total=summary.get("total", 0),
         capabilities_used=result.get("capabilities_used", []),

--- a/tests/scripts/test_compare_orchestration_modes_1480.py
+++ b/tests/scripts/test_compare_orchestration_modes_1480.py
@@ -452,6 +452,125 @@ class TestCB1528CountsComeFromTheSnapshot:
         assert result.fallacy_count == 0
 
 
+class Test1560PipelineCountsComeFromTheSnapshot:
+    """#1560 — the SAME phantom-key defect, in the pipeline runner.
+
+    ``run_pipeline_mode`` read ``result["extra_metrics"]["fallacy_count"]``.
+    ``extra_metrics`` has no producer anywhere in the package, so the call
+    returned its literal default ``0`` on every run — a fabricated zero
+    indistinguishable from an observed one (leçon #1531). It went unnoticed
+    because the twin call-site was fixed (CB #1528 item 3, class above)
+    WITHOUT grepping the pattern: a phantom key copied between sibling
+    runners is a motif, not an accident.
+
+    ⚠ INVERSE polarity from the conversational fix. ``unified_pipeline``
+    returns ``get_state_snapshot(summarize=True)``, whose shape carries
+    ``fallacy_count`` / ``argument_count`` FLAT at top level — NOT the raw
+    ``identified_*`` collections the conversational runner reads. Copying
+    that fix verbatim yields ``None`` everywhere while looking correct;
+    ``test_counts_are_read_from_the_summarized_snapshot`` is what catches it.
+    """
+
+    @staticmethod
+    def _fake_result(snapshot=None, **extra):
+        result = {
+            "summary": {"completed": 15, "total": 15},
+            "state_snapshot": (
+                {"fallacy_count": 2, "argument_count": 3}
+                if snapshot is None
+                else snapshot
+            ),
+            "capabilities_used": ["fact_extraction"],
+            "capabilities_missing": [],
+        }
+        result.update(extra)
+        return result
+
+    def _run(self, fake_result):
+        mod = _load_harness_module()
+
+        async def fake_run(**kwargs):
+            return fake_result
+
+        async def _drive():
+            with patch(
+                "argumentation_analysis.orchestration.unified_pipeline"
+                ".run_unified_analysis",
+                side_effect=fake_run,
+            ):
+                return await mod.run_pipeline_mode("text", "corpus_A", "standard")
+
+        return asyncio.run(_drive())
+
+    def test_counts_are_read_from_the_summarized_snapshot(self) -> None:
+        result = self._run(self._fake_result())
+        assert result.fallacy_count == 2, (
+            "#1560 regression: fallacy_count is not read from the summarized "
+            f"state snapshot (got {result.fallacy_count!r}). Reading the raw "
+            "``identified_*`` keys instead — the conversational shape — yields "
+            "None here."
+        )
+        assert result.argument_count == 3
+
+    def test_phantom_extra_metrics_is_never_consulted(self) -> None:
+        """The exact defect: a key with no producer must not drive the column.
+
+        If the reader still consults ``extra_metrics``, this returns 99 (or the
+        old fabricated 0). Only reading the snapshot gives ``None`` here.
+        """
+        fake = self._fake_result(
+            snapshot={"some_other_field": 1},
+            extra_metrics={"fallacy_count": 99, "argument_count": 99},
+        )
+        result = self._run(fake)
+        assert result.fallacy_count is None, (
+            "#1560 regression: the runner is still reading the phantom "
+            f"``extra_metrics`` key (got {result.fallacy_count!r})."
+        )
+        assert result.argument_count is None
+
+    def test_absent_counts_stay_none_never_a_fabricated_zero(self) -> None:
+        """Track CG #1540: absent ≠ measured. Unwritten renders ``—``, not 0."""
+        result = self._run(self._fake_result(snapshot={"some_other_field": 1}))
+        assert result.fallacy_count is None, (
+            "A snapshot with no fallacy_count must render '—', not a 0 that "
+            "reads as 'measured, none found'."
+        )
+        assert result.argument_count is None
+
+    def test_measured_zero_stays_zero(self) -> None:
+        """Anti-pendule: a real 0 must survive as 0, not be turned into ``—``."""
+        result = self._run(
+            self._fake_result(snapshot={"fallacy_count": 0, "argument_count": 0})
+        )
+        assert result.fallacy_count == 0
+        assert result.argument_count == 0
+
+    def test_null_snapshot_does_not_crash(self) -> None:
+        """``unified_pipeline`` sets ``state_snapshot = None`` when state
+        tracking is off — the key is PRESENT with a null value, so ``.get(...,
+        {})`` returns None, not the default. The reader must survive that."""
+        fake = self._fake_result()
+        fake["state_snapshot"] = None
+        result = self._run(fake)
+        assert result.fallacy_count is None
+        assert result.argument_count is None
+
+    def test_summarized_snapshot_really_carries_these_keys(self) -> None:
+        """Pin the CONSUMER-side contract this reader depends on.
+
+        The reader is correct only as long as ``get_state_snapshot(summarize=
+        True)`` exposes these two names at top level. If ``shared_state`` drifts,
+        the reader silently returns ``None`` and the columns go back to being
+        uninformative — so assert the contract rather than trust it.
+        """
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+        snapshot = UnifiedAnalysisState("x").get_state_snapshot(summarize=True)
+        assert "fallacy_count" in snapshot
+        assert "argument_count" in snapshot
+
+
 class TestReportFormat:
     """The trade-off table is generated with the BO-4 columns."""
 
@@ -842,10 +961,12 @@ class TestCBWallClockBudget1528:
         mod = self._harness()
         fake_result = {
             "summary": {"completed": 15, "total": 15},
-            "state_snapshot": {"identified_arguments": {"arg_1": "x"}},
+            # #1560: the pipeline's snapshot is the SUMMARIZED shape. This
+            # fixture used to also carry an ``extra_metrics`` key — which no
+            # orchestrator emits — encoding the phantom key as if it were real.
+            "state_snapshot": {"argument_count": 1, "fallacy_count": 2},
             "capabilities_used": ["fact_extraction"],
             "capabilities_missing": [],
-            "extra_metrics": {"fallacy_count": 2, "argument_count": 1},
         }
         captured: dict = {}
 


### PR DESCRIPTION
Ferme #1560.

## Le défaut

`run_pipeline_mode` lisait ses compteurs dans `result["extra_metrics"]`, une clé **sans aucun producteur** dans le dépôt (zéro occurrence en écriture dans `argumentation_analysis/`, `api/`, `interface_web/` — elle n'existe que comme champ du dataclass `ModeResult`, côté script). `.get("extra_metrics", {}).get("fallacy_count", 0)` rendait donc son **défaut littéral** à chaque run.

```python
snap = result.get("state_snapshot", {})                                    # L635 — la bonne source
state_fill_rate=round(non_empty / max(total_fields, 1), 3),                # L647 — lit snap ✅
fallacy_count=result.get("extra_metrics", {}).get("fallacy_count", 0),     # L648 ❌
argument_count=result.get("extra_metrics", {}).get("argument_count", 0),   # L649 ❌
```

Le taux de remplissage, lui, était bien mesuré : il lit `snap`, lié trois lignes plus haut. Les compteurs passaient par-dessus la variable déjà disponible pour aller chercher une clé fantôme.

## Ce qui l'a trahi

L'**invariance**. `pipeline_standard` rendait exactement `51,2 % de fill · 0 sophisme · 0 argument · 15/15 phases` **avant et après** que #1553 change la résolution de provider que ce mode utilise. J'ai d'abord lu ça comme « le correctif n'a pas d'effet » — c'est-à-dire comme un résultat négatif exploitable. Une colonne qui ne bouge d'aucun chiffre entre deux états différents du code n'est pas une mesure qui répond « aucun » ; c'est une mesure qui n'existe pas.

## Pourquoi le jumeau avait survécu

Ce défaut exact a été diagnostiqué et corrigé dans **le même fichier**, pour `run_conversational_mode` (CB #1528 item 3). Le commentaire qui l'explique est encore en place — **130 lignes sous** l'instance survivante. J'avais corrigé une instance et rapporté « deux défauts de mesure corrigés » sans chercher le call-site frère. Une clé fantôme naît d'un copier-coller entre runners : elle est structurellement plurielle.

## ⚠ Polarité inverse — pourquoi ce n'est pas un copier-coller du correctif connu

Le runner conversationnel lit les noms d'attributs **bruts** (`identified_fallacies`), corrects pour lui parce que son chemin passe par `get_state_snapshot(summarize=False)`.

Le pipeline est dans la polarité **inverse** : `unified_pipeline.py:344` renvoie `get_state_snapshot(summarize=True)`, dont la forme expose `fallacy_count` / `argument_count` **à plat au premier niveau** (`shared_state.py:358-359`). Recopier le correctif conversationnel rendrait `None` partout **en ayant l'air de l'appliquer**.

## Le correctif

Un lecteur dédié à la forme résumée :

- Clé absente — ou dérivée vers une forme non-comptable — ⇒ `None` ⇒ rendu `—` (Track CG #1540). **Jamais** un `0` fabriqué.
- Un `0` réellement mesuré survit comme `0` (anti-pendule : on ne remplace pas un faux zéro par un faux tiret).
- `state_snapshot` peut être **présent-mais-nul** (`unified_pipeline.py:346` quand le suivi d'état est coupé) : la clé existe, donc `.get(..., {})` rend `None` et non le défaut. Le lecteur y survit, et un test le pin.

## Tests — 56 verts sur les deux fichiers du harness

Nouvelle classe `Test1560PipelineCountsComeFromTheSnapshot`, calquée sur celle du jumeau conversationnel :

| Test | Ce qu'il attrape |
|---|---|
| `counts_are_read_from_the_summarized_snapshot` | le correctif naïf (lecture des clés brutes) — il rendrait `None` ici |
| `phantom_extra_metrics_is_never_consulted` | le défaut lui-même : `extra_metrics` gavé à 99, snapshot vide ⇒ doit rendre `None` |
| `absent_counts_stay_none_never_a_fabricated_zero` | la régression CG #1540 |
| `measured_zero_stays_zero` | le pendule inverse |
| `null_snapshot_does_not_crash` | `state_snapshot: None` |
| `summarized_snapshot_really_carries_these_keys` | le **contrat côté consommateur** : si `shared_state` dérive, le lecteur redevient muet en silence — donc on l'assère au lieu de lui faire confiance |

Nettoyé au passage : la fixture de `test_pipeline_unbounded_path_unchanged` alimentait elle aussi `extra_metrics`, encodant la clé fantôme comme si elle était réelle.

## Portée de la correction

`grep` du motif sur tout le fichier après correctif : plus aucune lecture de `extra_metrics` sur un résultat d'orchestrateur, quel que soit le runner. Les 4 occurrences restantes sont des **écritures** du champ homonyme du dataclass `ModeResult` (côté script, légitimes) et deux mentions en commentaire.

## Ce que ça ne fait pas

- **N'ajoute pas** l'écriture de `extra_metrics` côté orchestrateur pour satisfaire le lecteur — le snapshot porte déjà l'information, un canal parallèle dupliquerait la source de vérité.
- **Ne touche pas** aux colonnes `—` des modes hiérarchiques : là, rien n'est écrit du tout, c'est un **manque** et non une fabrication, et il relève de #1528 item 2 (en cours, po-2025).
- **Ne rouvre pas** #1553 : ce correctif rend simplement l'effet de #1553 sur le pipeline **observable** pour la première fois.

## Privacy

Entrée synthétique `corpus_A` du harness, IDs opaques, aucun corpus chiffré, aucun texte source.

Refs #1560, #1528 (item 3, l'instance jumelle), #1553, #1531, #1019, CG #1540.
