### PR TITLE
fix(hierarchical): recover a real partial verdict at wall-clock breach (CB #1528 item 2)

### DIFF
--- a/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
+++ b/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
@@ -386,11 +386,27 @@ class DelegationOrchestrator:
         else:
             self.operational_executor = _absent_operational_executor
 
-    async def analyze(self, text: str) -> Dict[str, Any]:
+    async def analyze(
+        self,
+        text: str,
+        checkpoint_callback: Optional[Callable[..., None]] = None,
+    ) -> Dict[str, Any]:
         """Run the full S→T→O delegation chain on ``text``.
 
         Returns a dict with the objectives, task count, per-task operational
         results, and the strategic evaluation/conclusion.
+
+        Args:
+            text: The argument text to analyze.
+            checkpoint_callback: Optional ``(operational_results, ctx)``
+                callable fired after each operational task completes (CB #1528
+                item 2). The T→O loop is strictly sequential, so the caller
+                sees exactly the tasks that finished. It exists so a
+                wall-clock-bounded caller can recover a REAL partial verdict
+                after an external ``asyncio.wait_for`` cancels the chain:
+                without it, everything the finished tasks produced dies with
+                the coroutine. Recording only — never load-bearing for the
+                chain itself.
 
         Raises:
             DelegationError: if the strategic tier yields no objectives or the
@@ -452,6 +468,18 @@ class DelegationOrchestrator:
                     command.get("id"),
                     exc,
                 )
+
+            # CB #1528 item 2: hand the caller what has been produced so far.
+            # Guarded like the pipeline's ``_record_completed`` — a recording
+            # hook must never be able to break the run it observes.
+            if checkpoint_callback is not None:
+                try:
+                    checkpoint_callback(
+                        list(operational_results),
+                        {"planned_tasks": len(pending_tasks)},
+                    )
+                except Exception as cb_err:  # noqa: BLE001
+                    self.logger.warning("Checkpoint callback failed: %s", cb_err)
 
         # --- O→T→S: aggregate + strategic evaluation -----------------------
         eval_input = self._aggregate_results_by_objective(
@@ -553,6 +581,7 @@ async def run_delegation_analysis(
     strategic_manager: Optional[StrategicManager] = None,
     operational_executor: Optional[OperationalExecutor] = None,
     middleware: Any = None,
+    checkpoint_callback: Optional[Callable[..., None]] = None,
     **kwargs: Any,
 ) -> Dict[str, Any]:
     """Convenience entry point for M3 delegation analysis.
@@ -560,6 +589,10 @@ async def run_delegation_analysis(
     Mirrors ``run_hierarchical_analysis`` (M2) so the two modes are symmetric
     selectable axes. Extra ``kwargs`` are accepted and ignored for signature
     compatibility with the M2 convenience function.
+
+    ``checkpoint_callback`` (CB #1528 item 2) is forwarded, not ignored: it is
+    the seam a wall-clock-bounded caller uses to recover a real partial
+    verdict when the chain is cancelled mid-flight.
     """
     orchestrator = DelegationOrchestrator(
         strategic_manager=strategic_manager,
@@ -567,4 +600,4 @@ async def run_delegation_analysis(
         capability_registry=capability_registry,
         middleware=middleware,
     )
-    return await orchestrator.analyze(text)
+    return await orchestrator.analyze(text, checkpoint_callback=checkpoint_callback)

--- a/argumentation_analysis/orchestration/hierarchical/orchestrator.py
+++ b/argumentation_analysis/orchestration/hierarchical/orchestrator.py
@@ -16,7 +16,7 @@ Created as part of Epic #208 / R311 — Hierarchical Mode Reactivation.
 
 import logging
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from argumentation_analysis.orchestration.hierarchical.strategic.manager import (
     StrategicManager,
@@ -73,12 +73,36 @@ class HierarchicalOrchestrator:
             logger.info("CapabilityRegistry created via setup_registry()")
         return self._registry
 
-    async def analyze(self, text: str, **kwargs: Any) -> Dict[str, Any]:
+    async def analyze(
+        self,
+        text: str,
+        state: Optional[Any] = None,
+        state_writers: Optional[Dict[str, Any]] = None,
+        checkpoint_callback: Optional[Callable[..., None]] = None,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
         """
         Run a full hierarchical analysis on the given text.
 
         Args:
             text: The argument text to analyze.
+            state: Optional analysis-state object passed BY REFERENCE to the
+                executor. CB #1528 item 2: the caller keeps the reference, so
+                a run torn by an external ``asyncio.wait_for`` still leaves
+                behind everything the completed phases wrote — the same
+                mechanism ``run_pipeline_mode`` already relies on. Without it
+                the breach yields a sterile result (state lost with the
+                cancelled coroutine).
+            state_writers: Capability-name → writer mapping (typically
+                ``CAPABILITY_STATE_WRITERS``). Only consulted when ``state``
+                is not None; each write is already guarded executor-side
+                (workflow_dsl.py:788).
+            checkpoint_callback: Optional ``(results, ctx)`` callable invoked
+                after each fully-gathered DAG level. The bridge workflow is a
+                strictly sequential chain (``objectives_to_workflow`` makes
+                every phase depend on the previous one), so this fires once
+                per completed phase — a torn phase never reaches it, so a
+                bounded caller cannot over-count.
             **kwargs: Additional context passed through to WorkflowExecutor.
 
         Returns:
@@ -141,11 +165,23 @@ class HierarchicalOrchestrator:
 
         # --- Phase 3: Execute via WorkflowExecutor ---
         logger.info("Phase 3: Executing workflow via WorkflowExecutor")
-        context = {"source": "hierarchical", **kwargs}
+        context = {
+            "source": "hierarchical",
+            # CB #1528 item 2: the PLANNED phase count travels in the context
+            # so a bounded caller's checkpoint callback can report
+            # ``completed/planned`` at breach instead of the nonsensical
+            # ``N/0`` (coord R710 wart). Read off the built WorkflowDefinition
+            # — measured, never fabricated.
+            "hierarchical_planned_phases": phase_count,
+            **kwargs,
+        }
         phase_results: Dict[str, PhaseResult] = await self._executor.execute(
             workflow,
             text,
             context=context,
+            state=state,
+            state_writers=state_writers,
+            checkpoint_callback=checkpoint_callback,
         )
 
         # Compute summary
@@ -225,6 +261,9 @@ async def run_hierarchical_analysis(
     text: str,
     capability_registry: Optional[CapabilityRegistry] = None,
     mode: str = "bridge",
+    state: Optional[Any] = None,
+    state_writers: Optional[Dict[str, Any]] = None,
+    checkpoint_callback: Optional[Callable[..., None]] = None,
     **kwargs: Any,
 ) -> Dict[str, Any]:
     """
@@ -240,6 +279,19 @@ async def run_hierarchical_analysis(
       on a degraded chain instead of falling back to hardcoded objectives.
 
     Used by ``run_orchestration.py --mode hierarchical --hierarchical-mode ...``.
+
+    CB #1528 item 2 — incremental-progress seam (opt-in, ``None`` = the
+    original behaviour): ``state`` / ``state_writers`` / ``checkpoint_callback``
+    let a wall-clock-bounded caller keep a reference to what the run produced
+    BEFORE it was cut. Both modes expose the seam, with the shape each one
+    actually has:
+
+    * ``bridge`` — all three, forwarded to ``WorkflowExecutor`` (DAG levels).
+    * ``delegation`` — ``checkpoint_callback`` only, fired per completed
+      operational task. This mode has no ``UnifiedAnalysisState`` surface, so
+      ``state`` / ``state_writers`` would have nothing to write into; they are
+      rejected rather than silently ignored (a caller that passes them is
+      expecting a fill rate it would never get).
     """
     if mode == "delegation":
         # Imported lazily to avoid a hard dependency cycle for the M2 path.
@@ -247,9 +299,17 @@ async def run_hierarchical_analysis(
             run_delegation_analysis,
         )
 
+        if state is not None or state_writers is not None:
+            raise ValueError(
+                "hierarchical mode='delegation' has no shared-state surface: "
+                "state/state_writers cannot be honoured. Use "
+                "checkpoint_callback (fired per completed operational task) "
+                "to observe incremental progress."
+            )
         return await run_delegation_analysis(
             text,
             capability_registry=capability_registry,
+            checkpoint_callback=checkpoint_callback,
             **kwargs,
         )
     if mode != "bridge":
@@ -260,4 +320,10 @@ async def run_hierarchical_analysis(
     orchestrator = HierarchicalOrchestrator(
         capability_registry=capability_registry,
     )
-    return await orchestrator.analyze(text, **kwargs)
+    return await orchestrator.analyze(
+        text,
+        state=state,
+        state_writers=state_writers,
+        checkpoint_callback=checkpoint_callback,
+        **kwargs,
+    )

--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -47,7 +47,7 @@ import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -235,6 +235,110 @@ def _fmt_fill(rate: Optional[float]) -> str:
     applicable" from "measured empty" (leçon #1531).
     """
     return "—" if rate is None else f"{rate:.1%}"
+
+
+def _is_filled(value: Any) -> bool:
+    """A state field counts as filled iff it carries something."""
+    return bool(value) and value not in ([], {}, "", None, 0)
+
+
+def _state_fill_rate(state: Any) -> Optional[float]:
+    """Fraction of state fields THIS RUN filled in, or None if no state.
+
+    ONE definition for the two BREACH paths (pipeline + hierarchical bridge),
+    where the fill is not a statistic but the verdict signal itself: it is what
+    ``_compute_decides`` reads to decide whether a cut run produced anything.
+    Two copies of this arithmetic is how the counters in this file drifted
+    before (#1560); the twin call-site kept the defect the first fix removed.
+
+    ⚠ The SUCCESS paths (``run_pipeline_mode`` / ``run_conversational_mode``,
+    at their non-breach return) still compute their fill inline, from a
+    snapshot dict rather than a state object, and WITHOUT the baseline
+    subtraction below — so their reported percentages run ~5-6 points high
+    (that is where the 51.2 % / 15.7 % / 7.8 % figures on #1528 come from).
+    That is a reporting inaccuracy, not a fabricated verdict: on a success path
+    ``_compute_decides`` is already carried by ``phases_completed > 0``, so no
+    verdict flips. Recalibrating them changes every headline number in the
+    comparison and belongs to its own measured round — filed rather than
+    silently drifted, and NOT quietly folded into this bound.
+
+    ⚠ The construction baseline is SUBTRACTED. A freshly built
+    ``UnifiedAnalysisState(text)`` is not empty: it already carries
+    ``raw_text``, ``deanonymized`` and ``stakes_and_stakeholders`` — 3 of 51
+    fields, i.e. **5.9 %**, before a single phase has run. Counting those made
+    a run that produced NOTHING score ``fill > 0``, which ``_compute_decides``
+    reads as a verdict artifact. That is where the ``pipeline_standard | ⏱
+    budget | 45.01s | Decides ✅ | 0/15 phases | 5.9 %`` row measured firsthand
+    at R723 came from: 5.9 % IS the empty baseline, echoed back. The verdict
+    was manufactured by the constructor. Same family as #1560/#1019 — a number
+    that looks like a measurement and is an artifact of the instrument.
+
+    So the numerator counts only fields a pristine state of the same class
+    does NOT already fill, and the denominator is the fillable remainder.
+
+    ``None`` (no state instrumented) and ``0.0`` (state instrumented, measured
+    empty) are DIFFERENT answers and must stay so — CG #1540 / leçon #1531.
+    """
+    if state is None:
+        return None
+    try:
+        snapshot = state.get_state_snapshot() or {}
+    except Exception:
+        return None
+    if not snapshot:
+        return 0.0
+
+    baseline: set = set()
+    try:
+        pristine = type(state)(getattr(state, "raw_text", "") or "")
+        baseline = {
+            k for k, v in (pristine.get_state_snapshot() or {}).items() if _is_filled(v)
+        }
+    except Exception:
+        # Baseline unknown → fall back to the raw count rather than guessing.
+        # Loud in the sense that matters: it can only OVER-report, and the
+        # honest-degrade tests pin the sterile case.
+        baseline = set()
+
+    fillable = [k for k in snapshot if k not in baseline]
+    if not fillable:
+        return 0.0
+    non_empty = sum(1 for k in fillable if _is_filled(snapshot[k]))
+    return round(non_empty / len(fillable), 3)
+
+
+def _delegation_task_counts(
+    operational_results: List[Dict[str, Any]],
+) -> Tuple[int, int, int]:
+    """(productive, failed, degraded) task counts for the M3 delegation mode.
+
+    ONE definition shared by the completion path and the wall-clock breach
+    path, so a task counts the same way whether the run finished or was cut.
+
+    Status values are ``completed`` / ``completed_with_issues`` / ``failed``
+    (rhetorical_tools_adapter.py:147 + delegation_orchestrator.py:213).
+    ``completed_with_issues`` produced output ⇒ counts (anti-#1019: honest,
+    not punitive). A task carrying ``degraded: True`` ran but produced
+    nothing — it keeps ``status: "completed"`` (the call did return) and is
+    subtracted (CC #1531 item 1): counting it is what fed a ✅ to a run that
+    analysed nothing. The discriminator is the self-declared non-analysis,
+    never the emptiness of the output — a clean corpus with zero fallacies is
+    a success that found zero.
+    """
+    completed = sum(
+        1
+        for r in operational_results
+        if isinstance(r, dict) and str(r.get("status", "")).startswith("completed")
+    )
+    failed = sum(
+        1
+        for r in operational_results
+        if isinstance(r, dict) and str(r.get("status", "")).startswith("failed")
+    )
+    degraded = sum(
+        1 for r in operational_results if isinstance(r, dict) and r.get("degraded")
+    )
+    return completed - degraded, failed, degraded
 
 
 def _fmt_count(count: Optional[int]) -> str:
@@ -599,15 +703,6 @@ async def run_pipeline_mode(
             f"— recovering partial state from the state reference "
             f"(completed levels only; torn level not counted)."
         )
-        snapshot: Dict[str, Any] = {}
-        try:
-            snapshot = state.get_state_snapshot() or {}
-        except Exception:
-            snapshot = {}
-        total_fields = len(snapshot) if snapshot else 1
-        non_empty = sum(
-            1 for v in snapshot.values() if v and v not in ([], {}, "", None, 0)
-        )
         # C3 #1500 (coord R710 wart): set the PLANNED phase total at breach so
         # the report's Phases column reads ``completed/planned`` (e.g. 8/15),
         # not the nonsensical ``N/0`` left by the pre-C3 breach path. The
@@ -621,7 +716,9 @@ async def run_pipeline_mode(
             terminates=True,
             terminated_by_budget=True,
             duration_seconds=round(duration, 2),
-            state_fill_rate=round(non_empty / max(total_fields, 1), 3),
+            # CB #1528 item 2: shared with the hierarchical bridge breach path
+            # (one definition, two call-sites).
+            state_fill_rate=_state_fill_rate(state),
             phases_completed=last_completed[0],
             phases_total=planned_total,
             # `decides` left None → _compute_decides in run_all. A partial
@@ -872,11 +969,19 @@ async def run_hierarchical_bridge_mode(
     analyze()`` (which predates the registry and never distinguishes
     bridge vs delegation).
 
-    CB #1528: ``run_hierarchical_analysis`` exposes NO incremental state, so a
-    wall-clock breach cannot recover a partial verdict — the honest degrade is
-    a sterile ``terminated_by_budget=True`` result (``decides`` → False → ``—``
-    via ``_compute_decides``). This is the structural asymmetry with the
-    pipeline (state-reference trick): documented here, not papered over.
+    CB #1528 item 2: when bounded, the runner passes an analysis state BY
+    REFERENCE plus a recording ``checkpoint_callback``, exactly as
+    ``run_pipeline_mode`` does. The bridge workflow is a strictly SEQUENTIAL
+    chain (``objectives_to_workflow`` makes every phase depend on the previous
+    one), so both fire once per completed phase — a breach therefore recovers
+    what the finished phases produced instead of losing everything with the
+    cancelled coroutine. The previous behaviour was documented here as "no
+    incremental state exposed → sterile partial"; that was true of the CALL,
+    not of the orchestrator, which already accepted the seam one layer down.
+
+    ``max_wall_seconds=None`` (default) = unbounded, unchanged: no state, no
+    callback, no writers (anti-pendule — the bound is opt-in and must not
+    alter the free-running path).
     """
     from argumentation_analysis.orchestration.hierarchical.orchestrator import (
         run_hierarchical_analysis,
@@ -891,10 +996,55 @@ async def run_hierarchical_bridge_mode(
     )
     start = time.time()
     registry = setup_registry(include_optional=True)
+
+    state = None
+    state_writers = None
+    checkpoint_callback = None
+    # ``planned`` stays None until a completed level reports it. Unlike the
+    # pipeline — whose planned total is a deterministic function of the
+    # workflow name (``_planned_workflow_phase_count``) — the bridge's phase
+    # count depends on the objectives the StrategicManager generates at
+    # runtime, so it can only be read off the built workflow, in the context.
+    # A breach BEFORE the first phase completes therefore leaves it unknown,
+    # and ``phases_total: int`` has no "unknown" value to render: the column
+    # shows 0/0. That is the field's pre-existing contract (leçon #1531 would
+    # want a "—" here; making that possible means turning phases_total
+    # Optional across all 8 runners + both report tables, which is a change to
+    # the report schema, not to this bound). Not silently papered over.
+    recorded: Dict[str, Any] = {"completed": 0, "planned": None}
+    if max_wall_seconds is not None:
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            CAPABILITY_STATE_WRITERS,
+        )
+
+        state = UnifiedAnalysisState(text)
+        state_writers = CAPABILITY_STATE_WRITERS
+
+        def _record_completed(results, ctx):
+            # Recording only — never raises (the executor swallows callback
+            # errors, so a throw here would be silenced, not surfaced).
+            try:
+                recorded["completed"] = sum(
+                    1
+                    for r in results.values()
+                    if getattr(getattr(r, "status", None), "name", "") == "COMPLETED"
+                )
+                planned = (ctx or {}).get("hierarchical_planned_phases")
+                if isinstance(planned, int) and not isinstance(planned, bool):
+                    recorded["planned"] = planned
+            except Exception:
+                pass
+
+        checkpoint_callback = _record_completed
+
     coro = run_hierarchical_analysis(
         text=text,
         capability_registry=registry,
         mode="bridge",
+        state=state,
+        state_writers=state_writers,
+        checkpoint_callback=checkpoint_callback,
     )
     try:
         if max_wall_seconds is not None:
@@ -903,10 +1053,14 @@ async def run_hierarchical_bridge_mode(
             result = await coro
     except asyncio.TimeoutError:
         duration = time.time() - start
+        fill = _state_fill_rate(state)
         logger.warning(
             f"hierarchical_bridge on {corpus_id} hit the "
-            f"{max_wall_seconds:g}s budget after {duration:.2f}s — honest "
-            f"degrade (no incremental state exposed → sterile partial)."
+            f"{max_wall_seconds:g}s budget after {duration:.2f}s — recovering "
+            f"the partial verdict from the state reference "
+            f"({recorded['completed']} completed phase(s), fill="
+            f"{'—' if fill is None else f'{fill:.1%}'}; the torn phase is not "
+            f"counted)."
         )
         return ModeResult(
             mode="hierarchical_bridge",
@@ -915,7 +1069,13 @@ async def run_hierarchical_bridge_mode(
             terminates=True,
             terminated_by_budget=True,
             duration_seconds=round(duration, 2),
+            state_fill_rate=fill,
+            phases_completed=recorded["completed"],
+            phases_total=recorded["planned"] or 0,
             error=f"Wall-clock budget (>={max_wall_seconds:g}s)",
+            # `decides` left None → _compute_decides in run_all: a completed
+            # phase or a non-empty state IS the partial verdict; nothing
+            # recovered stays honestly sterile (— , not a manufactured ✅).
             scope_of_work=scope,
         )
     except Exception as exc:
@@ -988,10 +1148,13 @@ async def run_hierarchical_delegation_mode(
     populated, per R648+R649+R651+R652). Wired via
     ``run_hierarchical_analysis(..., mode="delegation")``.
 
-    CB #1528: same honest-degrade contract as bridge —
-    ``run_hierarchical_analysis`` exposes no incremental state, so a
-    wall-clock breach yields a sterile ``terminated_by_budget=True`` result
-    (``decides`` → False → ``—``).
+    CB #1528 item 2: when bounded, the runner passes a recording
+    ``checkpoint_callback`` fired after each completed operational task. The
+    T→O loop is strictly sequential, so a breach recovers exactly the tasks
+    that finished — the same "accumulated work IS the partial verdict" contract
+    as the pipeline, in the shape this mode has (task results, not a shared
+    state: it has no ``UnifiedAnalysisState`` surface to fill, which is why
+    ``state_fill_rate`` legitimately stays ``—`` here).
     """
     from argumentation_analysis.orchestration.hierarchical.orchestrator import (
         run_hierarchical_analysis,
@@ -1006,10 +1169,29 @@ async def run_hierarchical_delegation_mode(
     )
     start = time.time()
     registry = setup_registry(include_optional=True)
+
+    checkpoint_callback = None
+    recorded: Dict[str, Any] = {"results": [], "planned": None}
+    if max_wall_seconds is not None:
+
+        def _record_tasks(results, ctx):
+            # Recording only — never raises (the orchestrator guards the call,
+            # so a throw here would be swallowed rather than surfaced).
+            try:
+                recorded["results"] = list(results or [])
+                planned = (ctx or {}).get("planned_tasks")
+                if isinstance(planned, int) and not isinstance(planned, bool):
+                    recorded["planned"] = planned
+            except Exception:
+                pass
+
+        checkpoint_callback = _record_tasks
+
     coro = run_hierarchical_analysis(
         text=text,
         capability_registry=registry,
         mode="delegation",
+        checkpoint_callback=checkpoint_callback,
     )
     try:
         if max_wall_seconds is not None:
@@ -1018,10 +1200,14 @@ async def run_hierarchical_delegation_mode(
             result = await coro
     except asyncio.TimeoutError:
         duration = time.time() - start
+        partial = recorded["results"]
+        completed, failed, degraded = _delegation_task_counts(partial)
         logger.warning(
             f"hierarchical_delegation on {corpus_id} hit the "
-            f"{max_wall_seconds:g}s budget after {duration:.2f}s — honest "
-            f"degrade (no incremental state exposed → sterile partial)."
+            f"{max_wall_seconds:g}s budget after {duration:.2f}s — recovering "
+            f"the partial verdict from the checkpointed task results "
+            f"({completed} productive / {len(partial)} finished; the task in "
+            f"flight is not counted)."
         )
         return ModeResult(
             mode="hierarchical_delegation",
@@ -1030,8 +1216,20 @@ async def run_hierarchical_delegation_mode(
             terminates=True,
             terminated_by_budget=True,
             duration_seconds=round(duration, 2),
+            phases_completed=completed,
+            phases_total=recorded["planned"] or 0,
             error=f"Wall-clock budget (>={max_wall_seconds:g}s)",
+            # `decides` left None → _compute_decides in run_all. No verdict
+            # artifact exists at breach (the strategic conclusion is produced
+            # AFTER the loop), so the row decides on completed tasks alone —
+            # nothing finished ⇒ honestly sterile.
             scope_of_work=scope,
+            extra_metrics={
+                "tasks_completed": completed,
+                "tasks_failed": failed,
+                "tasks_degraded": degraded,
+                "tasks_finished_before_breach": len(partial),
+            },
         )
     except Exception as exc:
         duration = time.time() - start
@@ -1065,33 +1263,14 @@ async def run_hierarchical_delegation_mode(
 
     # Phases column = the delegation depth axis DoD-3 asks for. Denominator =
     # tactical task count (``tasks_created``); numerator = tasks that reached a
-    # completed state. Status values are ``completed`` / ``completed_with_issues``
-    # / ``failed`` (operational/adapters/rhetorical_tools_adapter.py:147 +
-    # delegation_orchestrator.py:213). ``completed_with_issues`` still produced
-    # output → counts as completed (anti-#1019: honest, not punitive).
-    def _count_status(results: List[Dict[str, Any]], prefix: str) -> int:
-        return sum(
-            1
-            for r in results
-            if isinstance(r, dict) and str(r.get("status", "")).startswith(prefix)
-        )
-
+    # completed state. CB #1528 item 2: the counting rules live in
+    # ``_delegation_task_counts`` so this path and the wall-clock breach path
+    # cannot drift apart (the failure mode of #1560 was exactly a twin
+    # call-site left behind).
     phases_total = tasks_created
-    tasks_failed = _count_status(operational_results, "failed")
-    # CC #1531 item 1: a task whose provider declared itself degraded /
-    # unavailable ran, but produced nothing. It keeps ``status: "completed"``
-    # (the call did return) and carries ``degraded: True`` — set at the seam
-    # where the self-report is first visible (delegation_orchestrator.py).
-    # Counting it as a completed phase is what fed ``_compute_decides`` a ✅
-    # on a run that analysed nothing. NB the contrast with
-    # ``completed_with_issues`` above: that one produced output and still
-    # counts. The discriminator is the self-declared non-analysis, never the
-    # emptiness of the output — a clean corpus with zero fallacies is a
-    # success that found zero.
-    tasks_degraded = sum(
-        1 for r in operational_results if isinstance(r, dict) and r.get("degraded")
+    phases_completed, tasks_failed, tasks_degraded = _delegation_task_counts(
+        operational_results
     )
-    phases_completed = _count_status(operational_results, "completed") - tasks_degraded
 
     # Track CA #1529: ``decides`` is computed UNIFORMLY by run_all via
     # ``_compute_decides``. Post-fold-in it keys on ``phases_completed > 0``
@@ -1225,11 +1404,18 @@ def generate_report(
 
     Status legend:
       ✅ terminates=True, success=True (clean completion)
-      ✅⏱ bounded — success on a wall-clock-bounded PARTIAL verdict (C1 #1500):
-            the conversational mode exited cleanly at the bound and the partial
-            state IS the verdict (real, comparable — not a killed coroutine).
-      ⏱ terminates=True, terminated_by_budget=True (honest partial — safety-net
-            timeout fired, no verdict produced)
+      ✅⏱ bounded — a wall-clock-bounded PARTIAL verdict that is REAL (C1 #1500
+            + CB #1528 item 2): the run stopped at the bound and left behind
+            artifacts the partial state / completed phases carry. Two ways to
+            get here, both meaning the same thing for a reader of the table:
+            the mode exited cleanly at its own bound (conversational,
+            ``extra_metrics["wall_clock_bounded"]``), or it was cut at the
+            budget but the accumulated work was recovered (``decides=True``).
+      ⏱ terminates=True, terminated_by_budget=True AND nothing recovered — a
+            STERILE cut: the budget fired and no verdict artifact survived.
+            The discriminator against ``✅⏱`` is ``decides``, i.e. measured
+            output — never the mere fact of having been bounded (anti-théâtre:
+            relabelling a sterile cut as "bounded" would be the mirror lie).
       ❌ terminates=False (real failure / exception)
 
     Decides column (CB #1528 folds-in): ``✅`` produced ≥1 verdict artifact,
@@ -1259,7 +1445,14 @@ def generate_report(
 
     for r in sorted(results, key=lambda x: (x.mode, x.corpus_id)):
         if r.terminated_by_budget:
-            status = "⏱ budget"
+            # CB #1528 item 2 (coord R723 "écart de rapport"): a budget cut
+            # that recovered a real partial verdict reads ``✅⏱ bounded`` —
+            # the legend's own definition of that marker. Before, EVERY budget
+            # cut rendered ``⏱ budget``, whose legend says "no verdict
+            # produced", so a pipeline row with decides=✅ contradicted its own
+            # marker. `decides` is normalised by run_all via _compute_decides
+            # (untouched here); `is True` keeps an un-normalised None sterile.
+            status = "✅⏱ bounded" if r.decides is True else "⏱ budget"
         elif r.extra_metrics.get("wall_clock_bounded"):
             status = "✅⏱ bounded"
         elif r.terminates and r.success:
@@ -1399,11 +1592,14 @@ async def run_all(
 
     Args:
         max_wall_seconds: Wall-clock budget (CB #1528) threaded to EVERY
-            runner — pipeline (state-reference trick → real partial verdict),
-            conversational (internal bound, C1 #1500), hierarchical (honest
-            degrade — no incremental state exposed → sterile ``—``). Breach is
-            recorded as a HONEST PARTIAL verdict (``terminated_by_budget=True``)
-            — never faked into success (anti-#1019).
+            runner, and every runner now recovers a REAL partial verdict at
+            breach (item 2) — pipeline and hierarchical bridge via a state
+            reference + recording checkpoint, hierarchical delegation via
+            checkpointed task results, conversational via its internal bound
+            (C1 #1500). Breach is recorded as a HONEST PARTIAL verdict
+            (``terminated_by_budget=True``) — never faked into success
+            (anti-#1019), and a cut that recovered nothing still renders
+            sterile (``—``) rather than borrowing the bounded marker.
     """
     if modes is None:
         modes = list(MODE_RUNNERS.keys())

--- a/tests/scripts/test_compare_orchestration_modes_1480.py
+++ b/tests/scripts/test_compare_orchestration_modes_1480.py
@@ -992,9 +992,14 @@ class TestCBWallClockBudget1528:
         assert result.phases_completed == 15
 
     def test_hierarchical_bridge_budget_breach_honest_degrade(self) -> None:
-        """CB #1528: hierarchical exposes no incremental state → a budget
-        breach honestly degrades to a sterile ``terminated_by_budget=True``
-        result (decides False → ``—``), NOT a faked success."""
+        """CB #1528 item 2 anti-pendule: a breach that recovered NOTHING must
+        stay sterile.
+
+        The fake hangs before any checkpoint fires, so no phase completed and
+        the state is measured empty. Post-item-2 the runner instruments the
+        run — but instrumenting is not producing: ``decides`` must remain
+        False → ``—``. This is the guard against "relabel every budget cut as
+        bounded", which would destroy the column's discriminating power."""
         mod = self._harness()
 
         async def fake_hang(**kwargs):
@@ -1017,11 +1022,13 @@ class TestCBWallClockBudget1528:
         assert result.terminated_by_budget is True
         assert result.success is False
         assert result.terminates is True
-        # No partial state exposed → sterile → honestly decides False.
+        assert result.phases_completed == 0
+        # Nothing recovered → sterile → honestly decides False.
         assert mod._compute_decides(result) is False
 
     def test_hierarchical_delegation_budget_breach_honest_degrade(self) -> None:
-        """Same honest-degrade contract as bridge, for the delegation mode."""
+        """Same anti-pendule guard for the delegation mode: no task finished
+        before the cut ⇒ nothing to recover ⇒ still ``—``."""
         mod = self._harness()
 
         async def fake_hang(**kwargs):
@@ -1043,6 +1050,7 @@ class TestCBWallClockBudget1528:
         result = asyncio.run(_drive())
         assert result.terminated_by_budget is True
         assert result.success is False
+        assert result.phases_completed == 0
         assert mod._compute_decides(result) is False
 
     def test_count_pending_async_tasks_detects_leak(self) -> None:
@@ -1432,6 +1440,373 @@ class TestCC1531DegradedDelegationScoresDash:
         assert r.extra_metrics["verdict_artifact"] == "Analyse réussie."
         assert r.phases_completed == 4
         assert mod._compute_decides(r) is True
+
+
+class TestCB1528Item2HierarchicalPartialVerdict:
+    """CB #1528 item 2 — a wall-clock breach on a HIERARCHICAL mode must
+    produce a REAL partial verdict, not a sterile hole.
+
+    Measured gap that motivated this (coord R723/R724, firsthand): at N=45 s
+    the two hierarchical modes were cut at ~45 % of their ~100-160 s
+    trajectory and rendered ``decides —`` / ``0/0``, while the pipeline —
+    cut at ~10 % of its trajectory, four times earlier in proportion — still
+    rendered a verdict with 5.9 % fill. Coupé deux fois plus loin, on rendait
+    quatre fois moins: the work was done and then thrown away by the
+    ``asyncio.wait_for`` that killed the coroutine.
+
+    The fix reuses the pipeline's mechanism rather than reimplementing it
+    (issue périmètre point 2): a state reference + a recording checkpoint for
+    the bridge (its DAG is a strictly sequential chain, so both fire once per
+    completed phase), checkpointed task results for delegation (its T→O loop
+    is sequential too).
+
+    Anti-pendule guards live next to the recovery tests, not apart from them:
+    a cut that recovered nothing stays sterile, and the unbounded path keeps
+    passing no state / no callback at all.
+
+    LLM-free and deterministic: the inner entry-points are patched.
+    """
+
+    def _harness(self):
+        return _load_harness_module()
+
+    @staticmethod
+    def _phase(status_name: str) -> SimpleNamespace:
+        return SimpleNamespace(status=SimpleNamespace(name=status_name))
+
+    @staticmethod
+    def _drive_bridge(mod, fake, **kwargs):
+        async def _run():
+            with patch(
+                "argumentation_analysis.orchestration.hierarchical.orchestrator"
+                ".run_hierarchical_analysis",
+                side_effect=fake,
+            ), patch(
+                "argumentation_analysis.orchestration.registry_setup.setup_registry",
+                return_value=None,
+            ):
+                return await mod.run_hierarchical_bridge_mode(
+                    "text", "corpus_A", **kwargs
+                )
+
+        return asyncio.run(_run())
+
+    @staticmethod
+    def _drive_delegation(mod, fake, **kwargs):
+        async def _run():
+            with patch(
+                "argumentation_analysis.orchestration.hierarchical.orchestrator"
+                ".run_hierarchical_analysis",
+                side_effect=fake,
+            ), patch(
+                "argumentation_analysis.orchestration.registry_setup.setup_registry",
+                return_value=None,
+            ):
+                return await mod.run_hierarchical_delegation_mode(
+                    "text", "corpus_A", **kwargs
+                )
+
+        return asyncio.run(_run())
+
+    # ------------------------------------------------------------------
+    # Bridge
+    # ------------------------------------------------------------------
+
+    def test_bridge_breach_recovers_completed_phases_and_state(self) -> None:
+        """THE defect this item closes: work finished before the cut is
+        reported instead of dying with the cancelled coroutine."""
+        mod = self._harness()
+
+        async def fake(**kwargs):
+            state = kwargs.get("state")
+            if state is not None and hasattr(state, "add_argument"):
+                state.add_argument("argument_from_a_completed_phase")
+            cb = kwargs.get("checkpoint_callback")
+            if cb is not None:
+                cb(
+                    {"p1": self._phase("COMPLETED"), "p2": self._phase("COMPLETED")},
+                    {"hierarchical_planned_phases": 6},
+                )
+            await asyncio.sleep(5)  # next phase torn by the budget
+
+        result = self._drive_bridge(mod, fake, max_wall_seconds=0.5)
+
+        assert result.terminated_by_budget is True
+        assert result.success is False
+        assert result.phases_completed == 2
+        # Planned denominator read off the real WorkflowDefinition, so the
+        # Phases column reads 2/6 — not the nonsensical N/0 (coord R710 wart).
+        assert result.phases_total == 6
+        assert result.state_fill_rate is not None and result.state_fill_rate > 0
+        # The accumulated work IS the verdict (anti-#1019).
+        assert mod._compute_decides(result) is True
+
+    def test_bridge_breach_passes_the_recovery_seam(self) -> None:
+        """Mutation guard: if the runner ever stops passing state / writers /
+        checkpoint, recovery degrades SILENTLY back to the sterile result —
+        the row would just read ``—`` again with nothing to explain it."""
+        mod = self._harness()
+        seen = {}
+
+        async def fake(**kwargs):
+            seen.update(kwargs)
+            await asyncio.sleep(5)
+
+        self._drive_bridge(mod, fake, max_wall_seconds=0.5)
+
+        assert seen.get("state") is not None, "no state reference → nothing survives"
+        assert seen.get("checkpoint_callback") is not None
+        writers = seen.get("state_writers")
+        assert writers, "no writers → the state stays empty however far the run got"
+        from argumentation_analysis.orchestration.state_writers import (
+            CAPABILITY_STATE_WRITERS,
+        )
+
+        assert writers is CAPABILITY_STATE_WRITERS, (
+            "the harness must reuse the canonical writers, not a private copy "
+            "(a second mapping is how call-sites drift apart — #1560)."
+        )
+
+    def test_bridge_torn_phase_is_not_counted(self) -> None:
+        """A phase still running when the budget fires must not inflate the
+        count. Only COMPLETED statuses are summed."""
+        mod = self._harness()
+
+        async def fake(**kwargs):
+            cb = kwargs.get("checkpoint_callback")
+            if cb is not None:
+                cb(
+                    {"p1": self._phase("COMPLETED"), "p2": self._phase("RUNNING")},
+                    {"hierarchical_planned_phases": 4},
+                )
+            await asyncio.sleep(5)
+
+        result = self._drive_bridge(mod, fake, max_wall_seconds=0.5)
+        assert result.phases_completed == 1
+
+    def test_bridge_unbounded_path_passes_no_instrumentation(self) -> None:
+        """``max_wall_seconds=None`` = the original free-running path.
+        Bounding is opt-in; it must not change how an unbounded run executes."""
+        mod = self._harness()
+        seen = {}
+
+        async def fake(**kwargs):
+            seen.update(kwargs)
+            return {"summary": {"completed": 4, "total": 4}, "conclusion": "ok"}
+
+        result = self._drive_bridge(mod, fake)
+        assert result.success is True
+        assert seen.get("state") is None
+        assert seen.get("state_writers") is None
+        assert seen.get("checkpoint_callback") is None
+
+    # ------------------------------------------------------------------
+    # Delegation
+    # ------------------------------------------------------------------
+
+    def test_delegation_breach_recovers_finished_tasks(self) -> None:
+        mod = self._harness()
+
+        async def fake(**kwargs):
+            cb = kwargs.get("checkpoint_callback")
+            if cb is not None:
+                cb(
+                    [
+                        {"status": "completed", "capability": "c1"},
+                        {"status": "completed_with_issues", "capability": "c2"},
+                    ],
+                    {"planned_tasks": 5},
+                )
+            await asyncio.sleep(5)
+
+        result = self._drive_delegation(mod, fake, max_wall_seconds=0.5)
+
+        assert result.terminated_by_budget is True
+        # ``completed_with_issues`` produced output → counts (anti-punitive).
+        assert result.phases_completed == 2
+        assert result.phases_total == 5
+        assert result.extra_metrics["tasks_finished_before_breach"] == 2
+        assert mod._compute_decides(result) is True
+
+    def test_delegation_breach_uses_the_same_counting_rules(self) -> None:
+        """CC #1531 item 1 must hold at breach exactly as it holds on the
+        completion path: a task that ran but self-declared it produced
+        nothing is NOT a completed phase. One predicate, both paths — the
+        twin-call-site drift of #1560 is what this pins."""
+        mod = self._harness()
+
+        async def fake(**kwargs):
+            cb = kwargs.get("checkpoint_callback")
+            if cb is not None:
+                cb(
+                    [
+                        {"status": "completed", "capability": "c1"},
+                        {"status": "completed", "capability": "c2", "degraded": True},
+                        {"status": "failed", "capability": "c3"},
+                    ],
+                    {"planned_tasks": 5},
+                )
+            await asyncio.sleep(5)
+
+        result = self._drive_delegation(mod, fake, max_wall_seconds=0.5)
+
+        assert result.phases_completed == 1, "the degraded task must be subtracted"
+        assert result.extra_metrics["tasks_degraded"] == 1
+        assert result.extra_metrics["tasks_failed"] == 1
+
+    def test_delegation_breach_with_only_degraded_tasks_stays_sterile(self) -> None:
+        """The pendulum in the other direction: recovering *something* is not
+        the same as producing something. Three tasks that all self-declared
+        non-analysis leave no verdict."""
+        mod = self._harness()
+
+        async def fake(**kwargs):
+            cb = kwargs.get("checkpoint_callback")
+            if cb is not None:
+                cb(
+                    [{"status": "completed", "degraded": True} for _ in range(3)],
+                    {"planned_tasks": 5},
+                )
+            await asyncio.sleep(5)
+
+        result = self._drive_delegation(mod, fake, max_wall_seconds=0.5)
+        assert result.phases_completed == 0
+        assert mod._compute_decides(result) is False
+
+    def test_delegation_unbounded_path_passes_no_callback(self) -> None:
+        mod = self._harness()
+        seen = {}
+
+        async def fake(**kwargs):
+            seen.update(kwargs)
+            return {
+                "mode": "delegation",
+                "objectives": [{"id": "o1"}],
+                "tasks_created": 1,
+                "operational_results": [{"status": "completed"}],
+                "evaluation": {},
+                "conclusion": "ok",
+            }
+
+        result = self._drive_delegation(mod, fake)
+        assert result.success is True
+        assert seen.get("checkpoint_callback") is None
+
+    # ------------------------------------------------------------------
+    # Report marker (coord R723 "écart de rapport")
+    # ------------------------------------------------------------------
+
+    def test_recovered_budget_cut_renders_bounded(self) -> None:
+        """A budget cut that produced a verdict must not carry the marker
+        whose legend says "no verdict produced"."""
+        mod = self._harness()
+        r = mod.ModeResult(
+            mode="hierarchical_bridge",
+            corpus_id="corpus_A",
+            success=False,
+            terminates=True,
+            terminated_by_budget=True,
+            phases_completed=2,
+            phases_total=6,
+            decides=True,
+        )
+        row = [
+            ln
+            for ln in mod.generate_report([r]).splitlines()
+            if ln.startswith("| hierarchical_bridge |")
+        ]
+        assert row and "✅⏱ bounded" in row[0], row
+
+    def test_sterile_budget_cut_keeps_the_plain_marker(self) -> None:
+        """Anti-théâtre: the marker tracks measured output, not the mere fact
+        of having been bounded."""
+        mod = self._harness()
+        r = mod.ModeResult(
+            mode="hierarchical_bridge",
+            corpus_id="corpus_A",
+            success=False,
+            terminates=True,
+            terminated_by_budget=True,
+            decides=False,
+        )
+        row = [
+            ln
+            for ln in mod.generate_report([r]).splitlines()
+            if ln.startswith("| hierarchical_bridge |")
+        ]
+        assert row and "✅⏱ bounded" not in row[0] and "⏱ budget" in row[0], row
+
+
+class TestFillRateExcludesConstructionBaseline:
+    """The fill rate must measure what the RUN produced, not the constructor.
+
+    Discovered while implementing CB #1528 item 2. A freshly built
+    ``UnifiedAnalysisState(text)`` is not empty — it already carries
+    ``raw_text``, ``deanonymized`` and a ``stakes_and_stakeholders`` scaffold:
+    3 non-empty fields out of 51, i.e. **5.9 %**, before a single phase runs.
+
+    Counting those made an empty run score ``fill > 0``, which
+    ``_compute_decides`` reads as "produced something". That is exactly the
+    ``pipeline_standard | 45.01s | Decides ✅ | 0/15 phases | 5.9 %`` row
+    measured firsthand at R723: the 5.9 % WAS the empty baseline echoed back,
+    and the ✅ was manufactured by the constructor. Same family as
+    #1560/#1019 — a number that looks like a measurement and is an artifact
+    of the instrument.
+
+    These guards pin the corrected definition at BOTH ends: an untouched
+    state scores 0.0, and real content still scores > 0.
+    """
+
+    @staticmethod
+    def _harness():
+        return _load_harness_module()
+
+    @staticmethod
+    def _state(text: str = "some argument text about a claim"):
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+        return UnifiedAnalysisState(text)
+
+    def test_pristine_state_scores_zero_not_the_baseline(self) -> None:
+        """A state nobody wrote to has produced nothing → 0.0, not 5.9 %."""
+        mod = self._harness()
+        assert mod._state_fill_rate(self._state()) == 0.0
+
+    def test_pristine_state_alone_does_not_decide(self) -> None:
+        """The end-to-end consequence: constructing a state is not a verdict.
+
+        This is the defect as it was actually observed — the fill fed
+        ``_compute_decides``, so a run that completed 0 phases reported ✅.
+        """
+        mod = self._harness()
+        r = mod.ModeResult(
+            mode="hierarchical_bridge",
+            corpus_id="corpus_A",
+            success=False,
+            terminates=True,
+            terminated_by_budget=True,
+            phases_completed=0,
+            state_fill_rate=mod._state_fill_rate(self._state()),
+        )
+        assert mod._compute_decides(r) is False
+
+    def test_produced_content_still_scores_above_zero(self) -> None:
+        """Anti-pendule: subtracting the baseline must not zero out real work.
+
+        The failure mode of an over-corrected fix would be a state that DID
+        accumulate content still reporting 0.0 — trading a fabricated ✅ for a
+        fabricated ❌.
+        """
+        mod = self._harness()
+        state = self._state()
+        state.add_argument("corpus_A asserts a contested premise")
+        fill = mod._state_fill_rate(state)
+        assert fill is not None and fill > 0.0
+
+    def test_absent_state_still_reads_none_not_zero(self) -> None:
+        """CG #1540: "not instrumented" and "measured empty" stay distinct."""
+        mod = self._harness()
+        assert mod._state_fill_rate(None) is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes the **item 2** of CB #1528: *« le bound doit produire un verdict partiel réel au breach, comme C1 »*. Contributes to Epic #1500 (DoD-1 / DoD-4).

## Le défaut

Les deux runners hiérarchiques perdaient **tout** quand leur budget wall-clock tombait : `asyncio.wait_for` annulait la coroutine, le dict de retour partait avec elle, et le breach produisait un trou (`decides = —`, `0/0` phases) — pas un verdict. Les deux documentaient cela comme *« run_hierarchical_analysis exposes no incremental state »*.

C'était vrai de **l'appel**, pas de l'orchestrateur : `WorkflowExecutor.execute` acceptait déjà `state` / `state_writers` / `checkpoint_callback` un étage plus bas. Le seam existait, personne ne le transmettait. Ce PR **réutilise** le mécanisme du pipeline, il ne le réimplémente pas.

## Ce qui change

- **bridge** — transmet l'état *par référence* + les writers + le checkpoint à l'executor. `objectives_to_workflow` construit une chaîne **strictement séquentielle** (chaque phase `depends_on` la précédente), donc chaque niveau du DAG porte une phase et le checkpoint tire une fois par phase complétée. Une phase déchirée ne l'atteint jamais ⇒ un appelant borné ne peut pas sur-compter. Le nombre de phases **planifiées** voyage dans le contexte, lu sur le workflow construit.
- **delegation** — n'a aucune surface `UnifiedAnalysisState` ; il reçoit donc la forme qu'il a réellement : un checkpoint tiré après chaque tâche opérationnelle terminée. Y passer `state`/`state_writers` **lève** désormais au lieu d'être ignoré en silence.
- **Chemin non borné inchangé** : ni état, ni writers, ni callback. Le bound reste opt-in.

## Le verdict fabriqué découvert en mesurant

`_state_fill_rate` comptait la **ligne de base du constructeur**. Un `UnifiedAnalysisState(text)` neuf porte déjà `raw_text`, `deanonymized` et un échafaudage `stakes_and_stakeholders` — **3 champs sur 51 = 5,9 %** — avant qu'une seule phase ne tourne.

C'est exactement la ligne `0/15 phases | 5,9 % fill | Decides ✅` mesurée à R723 et citée **cinq fois** dans #1528 comme preuve que le pipeline avait déjà ce comportement. Les 5,9 % **étaient** la ligne de base vide renvoyée en écho, et le ✅ était fabriqué par le constructeur, pas par une analyse. Même famille que #1560/#1019 : un nombre qui ressemble à une mesure et qui est un artefact de l'instrument. Le numérateur ne compte plus que les champs qu'un état pristine de la même classe ne remplit pas déjà.

⚠️ Les deux chemins de **succès** calculent encore leur fill inline sans la soustraction (~5-6 points trop haut — d'où les 51,2 % / 15,7 % / 7,8 % de #1528). C'est une inexactitude de **rapport**, pas un verdict fabriqué : sur un chemin de succès `_compute_decides` est déjà porté par `phases_completed > 0`. Recalibrer déplace tous les chiffres de tête de la comparaison et mérite son propre tour mesuré — documenté dans la docstring, **pas** replié dans ce bound.

## Mesuré firsthand (corpus_A, `projet-is-roo-new`, LLM réel)

| run | avant | après |
|---|---|---|
| bridge @ 90 s | `—` / `0/0` | `✅⏱ bounded`, Decides ✅, **2/4 phases**, fill **10,4 %** |
| delegation @ 45 s | `—` / `0/0` | `✅⏱ bounded`, Decides ✅, **1/5 tâches** |
| bridge @ 45 s (1ʳᵉ phase ne tient pas) | ✅ depuis la base 5,9 % | `⏱ budget`, `—`, fill **0,0 %** |

La 3ᵉ ligne est le point : **rien de récupéré rapporte toujours rien**. Anti-#1019 des deux côtés — on ne fabrique ni le ✅ ni le ❌.

## Anti-pendule

- `_compute_decides` **non touché** (décision dashboard : hors périmètre CB/CC/CD).
- Le correctif #1560 n'est **pas** recopié ici : `—` = manque, `0` = fabrication, causes différentes.
- Soustraction de la base, pas ajout d'un contrepoids : on ne durcit pas le prédicat de verdict, on répare ce qu'il lit.
- `phases_total: int` n'a pas de valeur « inconnu » : un breach **avant** la 1ʳᵉ phase du bridge affiche `0/0`. Contrat pré-existant du champ, documenté en clair plutôt que maquillé (le rendre `Optional` toucherait les 8 runners et les 2 tables — schéma de rapport, pas ce bound).

## Tests

- `tests/scripts/test_compare_orchestration_modes_1480.py` : **64 passed** en 13,6 s — dont une classe de 10 tests pour item 2 (récupération, garde de mutation vérifiant que le runner passe bien le seam, phase déchirée non comptée, chemin non borné vierge, règles de comptage delegation partagées, marqueurs de rapport) et 4 gardes sur la ligne de base.
- Tests unitaires touchant les orchestrateurs hiérarchiques : **840 passed, 1 skipped**.
- ⚠️ `tests/scripts/` est **hors du gate CI** (`ci.yml:126` ne lance que `tests/unit/`, cf. #1563) ⇒ **run local cité**, la CI verte ne couvre pas ce fichier.
- Aucun test neutralisé, aucun `skip` ajouté. Zéro appel LLM dans les tests.

🤖 Coordinator ai-01
