### PR TITLE
fix(harness): exclude construction baseline from state fill rate (#1566)

### DIFF
--- a/argumentation_analysis/core/communication/tactical_adapter.py
+++ b/argumentation_analysis/core/communication/tactical_adapter.py
@@ -658,6 +658,50 @@ class TacticalAdapter:
         )
         return subscription_id
 
+    def subscribe_to_directives(
+        self,
+        callback: Callable[[Message], None],
+        topic_id: str = "objectives.strategic_decision",
+        filter_criteria: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """S'abonne aux directives stratégiques diffusées par le manager.
+
+        #1555 (Track C2, Epic #1500) — la jonction publieur/abonné se fait sur
+        le **chemin topic** du middleware, pas sur le canal HIERARCHICAL. Le
+        manager stratégique émet via ``StrategicAdapter.broadcast_objective``
+        → ``middleware.publish(topic_id="objectives.<type>", ...)`` (topic
+        path). ``subscribe_to_operational_updates`` (le miroir obvious)
+        utilise ``get_channel(HIERARCHICAL).subscribe`` (channel path) — or
+        ``publish`` ne livre qu'aux topic subscribers + ``global_handlers``
+        (pub_sub.py:386/399, middleware.py:419-434), JAMAIS aux subscribers
+        d'un canal. Un miroir aveugle du canal laisserait le broadcast
+        atteindre 0 agent. On s'abonne donc au topic que le publieur utilise
+        vraiment (Option A du DoD item 4 de #1555).
+
+        Args:
+            callback: Fonction **synchrone** appelée à la réception —
+                ``Topic.publish_message`` invoque le callback sans ``await``
+                (pub_sub.py:121), un ``async def`` créerait une coroutine
+                jamais attendue et ne s'exécuterait jamais.
+            topic_id: Topic auquel s'abonner (``objectives.strategic_decision``
+                par défaut — le type émis par
+                ``StrategicManager.evaluate_final_results``).
+            filter_criteria: Critères de filtrage optionnels (``None`` =
+                accepte tous les messages du topic ; le nom du topic filtre
+                déjà par type d'objectif).
+
+        Returns:
+            Un identifiant d'abonnement.
+        """
+        subscription_id = self.middleware.subscribe(
+            topic_id=topic_id,
+            subscriber_id=self.agent_id,
+            callback=callback,
+            filter_criteria=filter_criteria,
+        )
+        self.logger.info(f"Subscribed to strategic directives on topic {topic_id!r}")
+        return subscription_id
+
     def send_status_update(
         self,
         update_type: str,

--- a/argumentation_analysis/orchestration/hierarchical/tactical/coordinator.py
+++ b/argumentation_analysis/orchestration/hierarchical/tactical/coordinator.py
@@ -10,7 +10,7 @@ import uuid
 from argumentation_analysis.orchestration.hierarchical.tactical.state import (
     TacticalState,
 )
-from argumentation_analysis.paths import RESULTS_DIR
+from argumentation_analysis.paths import RESULTS_DIR, DATA_DIR
 from argumentation_analysis.core.communication.middleware import (
     MessageMiddleware,
     create_default_middleware,
@@ -248,20 +248,35 @@ class TaskCoordinator:
         self.logger.info(f"Action Tactique: {action_type} - {description}")
 
     def _subscribe_to_strategic_directives(self) -> None:
-        async def handle_directive(message: Message) -> None:
-            directive_type = message.content.get("directive_type")
-            self.logger.info(f"Directive stratégique reçue : {directive_type}")
-            if directive_type == "new_strategic_plan":
-                objectives = message.content.get("objectives", [])
-                self.process_strategic_objectives(objectives)
-            elif directive_type == "strategic_adjustment":
-                self._apply_strategic_adjustments(message.content)
+        # #1555 (Track C2, Epic #1500) — le handler est désormais enregistré
+        # pour de vrai (plus de commentaire + log menteur). La signature est
+        # synchrone : ``Topic.publish_message`` appelle le callback sans
+        # ``await`` (pub_sub.py:121), un ``async def`` n'aurait jamais tourné.
+        def handle_directive(message: Message) -> None:
+            # Le publieur (``StrategicAdapter.broadcast_objective``) écrit la
+            # clé ``objective_type`` (pas ``directive_type`` — celle-là vient
+            # du point-à-point ``issue_directive``, un autre chemin).
+            objective_type = message.content.get("objective_type")
+            self.logger.info(f"Directive stratégique reçue : {objective_type}")
+            if objective_type == "strategic_decision":
+                # Le payload (decision_type/conclusion/evaluation) est niché
+                # sous la clé ``DATA_DIR`` (un Path) — lu de la même façon
+                # qu'écrit par le publieur (strategic_adapter.py:122). Le type
+                # ignore reflète ce couplage : ``content`` est typé
+                # ``Dict[str, Any]`` mais le publieur utilise le Path comme
+                # clé (défaut latent pré-existant, hors périmètre #1555).
+                payload = message.content.get(DATA_DIR, {}) or {}  # type: ignore[call-overload]
+                self._log_action(
+                    "strategic_decision_received",
+                    (
+                        f"decision_type={payload.get('decision_type', 'unknown')}; "
+                        f"conclusion={payload.get('conclusion', '')}"
+                    ),
+                )
 
-        # self.adapter.subscribe_to_directives(handle_directive)
-        self.logger.warning(
-            "Subscription to directives is currently disabled due to API changes."
+        self._directive_subscription_id = self.adapter.subscribe_to_directives(
+            handle_directive
         )
-        self.logger.info("Abonné aux directives stratégiques.")
 
     def _determine_appropriate_agent(
         self, required_capabilities: List[str]

--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -46,8 +46,9 @@ import sys
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, FrozenSet, List, Optional
 
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -240,6 +241,60 @@ def _fmt_fill(rate: Optional[float]) -> str:
 def _fmt_count(count: Optional[int]) -> str:
     """CG #1540: render a count (fallacies/args) as "—" when not written."""
     return "—" if count is None else str(count)
+
+
+# Sentinels that mean "this state field is empty" (mirrors the inline check the
+# 3 success-path sites used before #1566 — 0 counts as empty, matching the
+# existing behavior, so a numeric field legitimately at 0 is not a "fill").
+_STATE_EMPTY_SENTINELS = ([], {}, "", None, 0)
+
+
+def _is_state_value_filled(value: Any) -> bool:
+    """True if a snapshot field counts as populated."""
+    return bool(value) and value not in _STATE_EMPTY_SENTINELS
+
+
+@lru_cache(maxsize=2)
+def _construction_baseline_keys(summarize: bool) -> FrozenSet[str]:
+    """#1566 — keys a pristine ``UnifiedAnalysisState(text)`` fills at
+    construction, BEFORE any analysis phase runs.
+
+    Measured firsthand: ``raw_text`` + ``deanonymized`` + ``stakes_and_
+    stakeholders`` in the raw form (3/51 ≈ 5.9 %) and ``raw_text`` +
+    ``raw_text_snippet`` in the summarized form (2/41 ≈ 4.9 %). Counting these
+    in the fill rate inflated every success-path fill by ~5-6 pts and broke
+    comparability between two columns whose comparability is the harness's
+    reason for being.
+
+    The baseline is snapshotted in the SAME form (``summarize``) as the
+    measurement: a raw baseline subtracted from a summarized snapshot (or
+    vice-versa) would re-manufacture the very drift this helper removes. The
+    set of filled *keys* is independent of the probe text, so the result is
+    cached per form. Opaque synthetic probe text (privacy HARD).
+    """
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+    pristine = UnifiedAnalysisState("baseline_probe_opaque_synthetic")
+    snap = pristine.get_state_snapshot(summarize=summarize)
+    return frozenset(k for k, v in snap.items() if _is_state_value_filled(v))
+
+
+def _state_fill_rate(snapshot: Dict[str, Any], summarize: bool = False) -> float:
+    """#1566 — the single definition of state fill for every path that reports
+    a real field-fraction (pipeline breach/success, conversational success).
+
+    Fraction of NON-baseline state fields populated (0.0..1.0). The
+    construction baseline (``_construction_baseline_keys``) is excluded so a
+    run that produced nothing scores 0.0, not ~5 %, and the success paths
+    compare to the breach path on the same footing. Hierarchical modes leave
+    ``state_fill_rate=None`` (they decide by conclusion, not shared state —
+    CG #1540); this helper is never called for them.
+    """
+    baseline = _construction_baseline_keys(summarize)
+    measured = [(k, v) for k, v in snapshot.items() if k not in baseline]
+    total = len(measured)
+    non_empty = sum(1 for _, v in measured if _is_state_value_filled(v))
+    return round(non_empty / max(total, 1), 3)
 
 
 def _compute_decides(result: ModeResult) -> bool:
@@ -604,10 +659,6 @@ async def run_pipeline_mode(
             snapshot = state.get_state_snapshot() or {}
         except Exception:
             snapshot = {}
-        total_fields = len(snapshot) if snapshot else 1
-        non_empty = sum(
-            1 for v in snapshot.values() if v and v not in ([], {}, "", None, 0)
-        )
         # C3 #1500 (coord R710 wart): set the PLANNED phase total at breach so
         # the report's Phases column reads ``completed/planned`` (e.g. 8/15),
         # not the nonsensical ``N/0`` left by the pre-C3 breach path. The
@@ -621,7 +672,9 @@ async def run_pipeline_mode(
             terminates=True,
             terminated_by_budget=True,
             duration_seconds=round(duration, 2),
-            state_fill_rate=round(non_empty / max(total_fields, 1), 3),
+            # #1566: breach fill excludes the construction baseline (raw form)
+            # so a breach that produced nothing scores 0.0, not ~6 %.
+            state_fill_rate=_state_fill_rate(snapshot, summarize=False),
             phases_completed=last_completed[0],
             phases_total=planned_total,
             # `decides` left None → _compute_decides in run_all. A partial
@@ -634,17 +687,15 @@ async def run_pipeline_mode(
     summary = result.get("summary", {})
     snap = result.get("state_snapshot", {})
 
-    total_fields = len(snap) if snap else 1
-    non_empty = sum(
-        1 for v in (snap or {}).values() if v and v not in ([], {}, "", None, 0)
-    )
-
     return ModeResult(
         mode=f"pipeline_{workflow_name}",
         corpus_id=corpus_id,
         success=True,
         duration_seconds=round(duration, 2),
-        state_fill_rate=round(non_empty / max(total_fields, 1), 3),
+        # #1566: success-path fill excludes the construction baseline in the
+        # SAME summarized form the pipeline emits (unified_pipeline.py:344), so
+        # it is comparable to the breach fill on the same footing.
+        state_fill_rate=_state_fill_rate(snap, summarize=True),
         fallacy_count=result.get("extra_metrics", {}).get("fallacy_count", 0),
         argument_count=result.get("extra_metrics", {}).get("argument_count", 0),
         phases_completed=summary.get("completed", 0),
@@ -731,10 +782,6 @@ async def run_conversational_mode(
     wall_clock_bounded = bool(budget.get("wall_clock_bounded", False))
 
     state = result.get("state_snapshot", {})
-    total_fields = len(state) if state else 1
-    non_empty = sum(
-        1 for v in (state or {}).values() if v and v not in ([], {}, "", None, 0)
-    )
 
     planned_phases = result.get("phases", []) if isinstance(result, dict) else []
     conv_log = result.get("conversation_log", []) if isinstance(result, dict) else []
@@ -774,7 +821,9 @@ async def run_conversational_mode(
         success=True,
         terminates=True,
         duration_seconds=round(duration, 2),
-        state_fill_rate=round(non_empty / max(total_fields, 1), 3),
+        # #1566: conversational success fill excludes the construction baseline
+        # (raw form — the snapshot is non-summarized, cf. comment above).
+        state_fill_rate=_state_fill_rate(snapshot, summarize=False),
         fallacy_count=_snapshot_count("identified_fallacies"),
         argument_count=_snapshot_count("identified_arguments"),
         phases_completed=len(phases_ran),
@@ -824,7 +873,17 @@ async def run_conversation_deterministic_mode(
         success=True,
         terminates=True,
         duration_seconds=round(duration, 3),
-        state_fill_rate=round(conv_state.get("state", {}).get("score", 0), 3),
+        # #1566: this mode runs a ConversationOrchestrator, not an
+        # UnifiedAnalysisState, so a field-fraction does not apply. The ``score``
+        # it used to publish here is a weighted quality grade
+        # (conversation_orchestrator.py: sophistication*0.4 + logical*0.3 +
+        # unified*0.3) — a DIFFERENT quantity that masqueraded as a fill rate
+        # under the same column name. Tranche (coord R730, branch A kept, B
+        # rejected): publish None (renders "—", CG #1540 — "not applicable", not
+        # "measured empty") and surface the quality grade in its own
+        # extra_metrics key. Branch B (invent a field-fraction for an
+        # orchestrator that exposes none) = fabrication, rejected.
+        state_fill_rate=None,
         fallacy_count=conv_state.get("state", {}).get("fallacies_detected", 0),
         phases_completed=3,  # informal + fol + synthesis
         phases_total=3,
@@ -834,6 +893,9 @@ async def run_conversation_deterministic_mode(
             "messages_count": conv_state.get("messages_count", 0),
             "tools_count": conv_state.get("tools_count", 0),
             "processing_time": conv_state.get("processing_time", 0),
+            # #1566: the quality grade keeps its own channel (not the State Fill
+            # column) so the table stays comparable across modes.
+            "quality_score": conv_state.get("state", {}).get("score", 0),
         },
     )
 

--- a/tests/orchestration/tactical/test_tactical_coordinator_advanced.py
+++ b/tests/orchestration/tactical/test_tactical_coordinator_advanced.py
@@ -182,6 +182,18 @@ class AuthenticMiddleware:
             self.channels[channel_type] = AuthenticChannel(channel_type)
         return self.channels[channel_type]
 
+    def subscribe(self, topic_id, subscriber_id, callback=None, filter_criteria=None):
+        """S'abonne à un topic — interface du middleware réel (#1555).
+
+        Le double authentique se contente de renvoyer un id d'abonnement ; il
+        ne reproduit pas la livraison topic (les tests de réception firsthand
+        passent par le vrai ``create_default_middleware``). Présent pour que la
+        construction d'un ``TacticalCoordinator`` (qui appelle désormais
+        ``subscribe_to_directives``) ne lève pas.
+        """
+        logger.info(f"Abonnement authentique de {subscriber_id} au topic {topic_id}")
+        return f"sub-{subscriber_id}-{topic_id}"
+
     def publish(
         self, topic_id, sender, sender_level, content, priority=None, metadata=None
     ):

--- a/tests/orchestration/tactical/test_tactical_coordinator_coverage.py
+++ b/tests/orchestration/tactical/test_tactical_coordinator_coverage.py
@@ -297,6 +297,18 @@ class AuthenticMiddlewareExtended:
             logger.info(f"Canal authentique créé automatiquement: {channel_type}")
         return self.channels[channel_type]
 
+    def subscribe(self, topic_id, subscriber_id, callback=None, filter_criteria=None):
+        """S'abonne à un topic — interface du middleware réel (#1555).
+
+        Le double authentique renvoie un id d'abonnement sans reproduire la
+        livraison topic (les tests de réception firsthand utilisent le vrai
+        ``create_default_middleware``). Présent pour que la construction d'un
+        ``TacticalCoordinator`` (qui appelle désormais
+        ``subscribe_to_directives``) ne lève pas.
+        """
+        logger.info(f"Abonnement authentique de {subscriber_id} au topic {topic_id}")
+        return f"sub-{subscriber_id}-{topic_id}"
+
     def publish(
         self, topic_id, sender, sender_level, content, priority=None, metadata=None
     ):

--- a/tests/scripts/test_fill_rate_baseline_1566.py
+++ b/tests/scripts/test_fill_rate_baseline_1566.py
@@ -1,0 +1,144 @@
+# -*- coding: utf-8 -*-
+"""Tests for #1566 — state fill rate excludes the construction baseline.
+
+The harness ``_state_fill_rate`` (scripts/compare_orchestration_modes.py)
+excludes the keys a pristine ``UnifiedAnalysisState(text)`` fills at
+construction (``raw_text`` / ``raw_text_snippet`` summarized; ``raw_text`` /
+``deanonymized`` / ``stakes_and_stakeholders`` raw) so a run that produced
+nothing scores 0.0, not ~5-6 %, and the success paths compare to the breach
+path on the same footing. The deterministic mode now publishes ``None`` (it
+has no UnifiedAnalysisState) and surfaces its quality grade in
+``extra_metrics["quality_score"]``.
+
+These tests are no-key / no-LLM. ``tests/scripts/`` is outside the CI gate
+(#1563), so run locally and cite in the PR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS_PATH = REPO_ROOT / "scripts" / "compare_orchestration_modes.py"
+
+
+def _load_harness_module():
+    """Import the harness by file path (independent of scripts namespace)."""
+    spec = importlib.util.spec_from_file_location(
+        "compare_orchestration_modes", str(HARNESS_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _pristine_snapshot(summarize: bool):
+    """Snapshot of a pristine state (no phase has run) — the construction
+    baseline. Opaque synthetic probe text (privacy HARD)."""
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+    pristine = UnifiedAnalysisState("baseline_probe_opaque_synthetic")
+    return pristine.get_state_snapshot(summarize=summarize)
+
+
+# ---------------------------------------------------------------------------
+# DoD #4 — a pristine state scores 0.0 on BOTH success-path forms
+# ---------------------------------------------------------------------------
+
+
+class TestFillRateExcludesConstructionBaseline:
+    """A pristine state (nothing produced) scores 0.0, not ~5-6 %."""
+
+    def test_pristine_summarized_scores_zero(self):
+        h = _load_harness_module()
+        snap = _pristine_snapshot(summarize=True)
+        # BEFORE #1566 this was 2/41 ≈ 4.9 % (raw_text + raw_text_snippet
+        # counted as "filled"). It must now be 0.0.
+        assert h._state_fill_rate(snap, summarize=True) == 0.0
+
+    def test_pristine_brut_scores_zero(self):
+        h = _load_harness_module()
+        snap = _pristine_snapshot(summarize=False)
+        # BEFORE #1566 this was 3/51 ≈ 5.9 % (raw_text + deanonymized +
+        # stakes_and_stakeholders). It must now be 0.0.
+        assert h._state_fill_rate(snap, summarize=False) == 0.0
+
+    def test_produced_content_summarized_is_positive(self):
+        """A summarized snapshot with real analysis output scores > 0."""
+        h = _load_harness_module()
+        snap = _pristine_snapshot(summarize=True)
+        # Simulate a phase that filled 3 analysis counts.
+        snap["argument_count"] = 3
+        snap["fallacy_count"] = 2
+        snap["belief_set_count"] = 1
+        rate = h._state_fill_rate(snap, summarize=True)
+        assert rate > 0.0
+        # 3 produced fields out of (41 total - 2 baseline) = 3/39 ≈ 0.077.
+        assert rate == round(3 / 39, 3)
+
+    def test_produced_content_brut_is_positive(self):
+        """A raw snapshot with real analysis output scores > 0."""
+        h = _load_harness_module()
+        snap = _pristine_snapshot(summarize=False)
+        snap["identified_arguments"] = ["opaque_arg_0", "opaque_arg_1"]
+        snap["identified_fallacies"] = ["opaque_fallacy_0"]
+        rate = h._state_fill_rate(snap, summarize=False)
+        assert rate > 0.0
+        # 2 produced fields out of (51 total - 3 baseline) = 2/48 ≈ 0.042.
+        assert rate == round(2 / 48, 3)
+
+    def test_baseline_keys_differ_between_forms(self):
+        """The baseline MUST be snapshotted in the same form as the
+        measurement — a raw baseline subtracted from a summarized snapshot
+        would re-manufacture drift. Prove the two baselines are genuinely
+        different sets (so mixing them would be wrong)."""
+        h = _load_harness_module()
+        b_sum = h._construction_baseline_keys(True)
+        b_raw = h._construction_baseline_keys(False)
+        assert b_sum != b_raw
+        # raw_text is filled in BOTH forms; the divergence proves the forms
+        # carry different keys (raw_text_snippet only summarized,
+        # deanonymized/stakes_and_stakeholders only raw).
+        assert "raw_text" in b_sum and "raw_text" in b_raw
+        assert "raw_text_snippet" in b_sum and "raw_text_snippet" not in b_raw
+        assert "deanonymized" in b_raw and "deanonymized" not in b_sum
+
+    def test_zero_sentinels_do_not_count_as_fill(self):
+        """A field set to an empty sentinel (0, [], {}, "", None) does NOT
+        inflate the fill — mirrors the pre-#1566 inline check."""
+        h = _load_harness_module()
+        snap = {"raw_text": "x", "raw_text_snippet": "x", "a": 0, "b": [], "c": {}}
+        # 5 fields, 2 baseline, 3 measured all empty → 0.0 (not 3/3).
+        assert h._state_fill_rate(snap, summarize=True) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# DoD "tranche" — deterministic mode no longer masquerades a quality grade
+# as a fill rate
+# ---------------------------------------------------------------------------
+
+
+class TestDeterministicFillTranche:
+    """run_conversation_deterministic_mode publishes state_fill_rate=None
+    (no UnifiedAnalysisState) and the quality grade in extra_metrics."""
+
+    def test_deterministic_emits_none_fill_and_quality_score(self):
+        h = _load_harness_module()
+        result = asyncio.run(
+            h.run_conversation_deterministic_mode(
+                "opaque_synthetic_deliberation_probe corpus_A.", "corpus_A"
+            )
+        )
+        # The State Fill column renders "—" (CG #1540: not applicable, not
+        # measured-empty). The previous behavior published the quality grade
+        # here — a different quantity under the same column name.
+        assert result.state_fill_rate is None
+        # The quality grade is preserved in its own channel, not dropped.
+        assert "quality_score" in result.extra_metrics
+        assert isinstance(result.extra_metrics["quality_score"], (int, float))
+        # decides is unaffected (phases_completed=3 → True); fill is not the
+        # verdict signal for this mode.
+        assert result.phases_completed == 3

--- a/tests/unit/argumentation_analysis/core/communication/test_strategic_broadcast_junction_1555.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_strategic_broadcast_junction_1555.py
@@ -1,0 +1,180 @@
+# tests/unit/argumentation_analysis/core/communication/test_strategic_broadcast_junction_1555.py
+"""Track C2 of #1500 — #1555: the strategic→tactical broadcast junction.
+
+``test_broadcast_bus_fix_1500.py`` established the *plumbing* (Fix B: ``publish``
+fans out to ``global_handlers`` so a registered listener receives the broadcast
+firsthand) and CC #1531 made the *hole* visible (the ``NO subscriber`` warning).
+Neither **closed** the hole for production: the tactical coordinator — the one
+tier meant to consume strategic decisions — never subscribed. Its
+``_subscribe_to_strategic_directives`` had the handler commented out, logged
+``"Abonné aux directives stratégiques."`` (affirming the subscription it just
+disabled), and called ``subscribe_to_directives`` — a method that did not exist.
+
+The mechanism (issue #1555, established firsthand on ``main``): three pieces.
+(1) The handler was commented (coordinator.py); (2) ``subscribe_to_directives``
+did not exist — the only subscription primitive is ``subscribe_to_operational_updates``
+(``tactical_adapter.py:623``), which uses the **channel** path
+(``get_channel(HIERARCHICAL).subscribe``); (3) the publisher emits on the
+**topic** path (``middleware.publish(topic_id="objectives.<type>")``), and these
+two paths do not meet. ``publish`` delivers to topic subscribers + ``global_handlers``
+(pub_sub.py:386/399, middleware.py:419-434) — NEVER to a channel's subscribers.
+
+So the fix is the junction of DoD item 4, **Option A**: the tactical tier
+subscribes to the topic ``objectives.strategic_decision`` via
+``middleware.subscribe`` (the topic path the publisher actually uses). The shape
+mirrors ``subscribe_to_operational_updates`` (adapter method, filter_criteria,
+returns a subscription id); the transport is the topic path, because a channel
+mirror would leave the broadcast reaching 0 agents. Option B (make the strategic
+tier emit on the channel) is rejected — it is exactly the delivery-semantics
+change forbidden by ``strategic_adapter.py:177-179``.
+
+These tests prove the production junction firsthand, LLM-free and JVM-free: a
+real ``TacticalCoordinator`` subscribes in its ``__init__``, a real
+``StrategicAdapter`` broadcasts on the same shared middleware, and the decision
+lands in tactical state (a genuine effect, anti-#1019 / anti-pendule: not a
+debug listener invented to bump a counter). The no-subscriber guard stays armed
+on topics nobody listens to (DoD bullet 3).
+
+Content uses opaque IDs only (corpus_A) — privacy discipline.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from argumentation_analysis.core.communication.message import MessagePriority
+from argumentation_analysis.core.communication.middleware import (
+    create_default_middleware,
+)
+from argumentation_analysis.core.communication.strategic_adapter import (
+    StrategicAdapter,
+)
+from argumentation_analysis.orchestration.hierarchical.tactical.coordinator import (
+    TacticalCoordinator,
+)
+from argumentation_analysis.orchestration.hierarchical.tactical.state import (
+    TacticalState,
+)
+
+# ── DoD bullet 1+2 — production reception, firsthand, same run ──────────────
+
+
+class TestStrategicDecisionReachesTacticalFirsthand:
+    """A real ``TacticalCoordinator`` receives a strategic broadcast and acts
+    on it (records the decision in tactical state). This is the closed hole:
+    not a debug listener, a production component that does something.
+    """
+
+    def test_tactical_coordinator_records_strategic_decision(self) -> None:
+        mw = create_default_middleware()
+        tactical_state = TacticalState()
+        # Construction subscribes the coordinator to the strategic_decision
+        # topic (via _subscribe_to_strategic_directives → subscribe_to_directives).
+        TacticalCoordinator(tactical_state=tactical_state, middleware=mw)
+        strategic = StrategicAdapter("strategic_manager", mw)
+
+        # Same shared middleware, same run: emission then reception.
+        strategic.broadcast_objective(
+            "strategic_decision",
+            {
+                "decision_type": "final_conclusion",
+                "conclusion": "corpus_A_coherent",
+                "evaluation": {"score": 0.8},
+            },
+            priority=MessagePriority.HIGH,
+        )
+
+        # Firsthand reception — a REAL effect on production state, not a flag.
+        received = [
+            a
+            for a in tactical_state.tactical_actions_log
+            if a.get("type") == "strategic_decision_received"
+        ]
+        assert len(received) == 1, (
+            f"expected the tactical coordinator to record the strategic "
+            f"decision firsthand; actions log = {tactical_state.tactical_actions_log!r}"
+        )
+        assert "corpus_A_coherent" in received[0]["description"]
+        assert "final_conclusion" in received[0]["description"]
+
+
+# ── DoD bullet 3 — the no-subscriber guard stays armed ──────────────────────
+
+
+class TestNoSubscriberGuardArmedAndScoped:
+    """The CC #1531 ``NO subscriber`` warning must NOT fire on the now-wired
+    ``strategic_decision`` path, and MUST still fire on a topic with nobody
+    listening. It must not be neutralized (DoD bullet 3).
+    """
+
+    def test_no_warning_when_tactical_subscribed(self, caplog: logging.Logger) -> None:
+        mw = create_default_middleware()
+        TacticalCoordinator(middleware=mw)
+        strategic = StrategicAdapter("strategic_manager", mw)
+        with caplog.at_level(
+            logging.WARNING, logger="StrategicAdapter.strategic_manager"
+        ):
+            strategic.broadcast_objective(
+                "strategic_decision", {"decision_type": "final_conclusion"}
+            )
+        assert "NO subscriber" not in caplog.text
+
+    def test_warning_still_fires_when_nobody_listens(
+        self, caplog: logging.Logger
+    ) -> None:
+        # A topic with NO production subscriber → the guard fires. Do not
+        # neutralize it.
+        mw = create_default_middleware()
+        with caplog.at_level(
+            logging.WARNING, logger="StrategicAdapter.strategic_manager"
+        ):
+            StrategicAdapter("strategic_manager", mw).broadcast_objective(
+                "global_strategy", {"goal": "opaque"}
+            )
+        assert "NO subscriber" in caplog.text
+
+
+# ── Anti-pendule — topic-scoped subscription, not a fabricated catch-all ─────
+
+
+class TestSubscriptionIsTopicScoped:
+    """The junction is a **topic** subscription (Option A), not a
+    ``register_global_handler`` invented to bump the reception counter. A
+    topic-scoped subscriber receives ``strategic_decision`` and ignores an
+    unrelated objective type — proving the scope is real, not a wildcard.
+    """
+
+    def test_tactical_ignores_unrelated_objective_type(self) -> None:
+        mw = create_default_middleware()
+        tactical_state = TacticalState()
+        TacticalCoordinator(tactical_state=tactical_state, middleware=mw)
+        strategic = StrategicAdapter("strategic_manager", mw)
+
+        # An objective type the coordinator did NOT subscribe to.
+        strategic.broadcast_objective("global_strategy", {"goal": "opaque"})
+
+        decisions = [
+            a
+            for a in tactical_state.tactical_actions_log
+            if a.get("type") == "strategic_decision_received"
+        ]
+        assert decisions == [], (
+            "a topic-scoped subscriber must not catch unrelated objective "
+            "types — that would be a global catch-all (the fabricated-counter "
+            "anti-pattern), not a topic junction"
+        )
+
+    def test_subscribe_to_directives_uses_topic_path(self) -> None:
+        """Mutation guard: the subscription lands on the topic the publisher
+        uses (``objectives.strategic_decision``), reachable via ``publish`` —
+        not stranded on a channel that ``publish`` never delivers to.
+        """
+        mw = create_default_middleware()
+        TacticalCoordinator(middleware=mw)
+        # The topic must exist and carry the tactical subscriber.
+        topic = mw.publish_subscribe.topics.get("objectives.strategic_decision")
+        assert topic is not None, (
+            "subscribe_to_directives must subscribe on the topic path — the "
+            "topic objectives.strategic_decision was not created"
+        )
+        assert topic.get_subscriber_count() >= 1


### PR DESCRIPTION
## Summary
Fixes #1566 — every **success-path** `state_fill_rate` ran ~5-6 pts high because it counted the keys a pristine `UnifiedAnalysisState(text)` fills at construction (`raw_text`, `deanonymized`, `stakes_and_stakeholders` raw; `raw_text` + `raw_text_snippet` summarized) as if the run had produced them. Two non-comparable State Fill columns in a table whose reason for being is comparability.

## ⚠️ verify-before-assert finding (unwritten-vs-measured, CG #1540)
The coordinator comment R730 on #1566 described `_state_fill_rate(state)` and `TestFillRateExcludesConstructionBaseline` as **already covering the breach path** (introduced by #1565). **Neither exists in the code** — `git log -S "_state_fill_rate"` is empty, and #1565 (CB #1528 item 2) treated the breach **verdict** (`decides`/partial state), not the fill rate. So the construction baseline was included at **all** sites (3 inline computations), not "2 breach fixed + 2 success to fix". This PR builds the real helper and unifies every site. Flagging so the picture of the codebase is corrected.

## Root cause (measured firsthand)
| snapshot form | total | baseline-filled | baseline keys | rate |
|---|---|---|---|---|
| raw (summarize=False) | 51 | 3 | `raw_text`, `deanonymized`, `stakes_and_stakeholders` | **5.9%** |
| summarized (summarize=True) | 41 | 2 | `raw_text`, `raw_text_snippet` | **4.9%** |

Observed effect on a produced-content snapshot: `15.7%` (inline, baseline incluse) → `10.4%` (helper, baseline excluded) = **5.3 pts** of inflation. (The `15.7%` matches the figure cited in #1528.)

## Fix (anti-pendule — soustraction, not a counterweight)
One helper, `_state_fill_rate(snapshot, summarize)`, that excludes the construction baseline snapshotted **in the SAME form** as the measurement (a raw baseline subtracted from a summarized snapshot would re-manufacture the drift — the DoD's explicit warning). Cached per form (`lru_cache`). Applied to the 3 inline sites:

| Site | form | before | after |
|---|---|---|---|
| `run_pipeline_mode` breach | raw | inline, baseline incl. | `_state_fill_rate(snapshot, summarize=False)` |
| `run_pipeline_mode` success | summarized | inline, baseline incl. | `_state_fill_rate(snap, summarize=True)` |
| `run_conversational_mode` success | raw | inline, baseline incl. | `_state_fill_rate(snapshot, summarize=False)` |

Hierarchical modes already leave `state_fill_rate=None` (decide by conclusion, CG #1540) — untouched.

## Tranche — the 5th site (coord R730 left it open)
`run_conversation_deterministic_mode` published a **weighted quality grade** (`sophistication*0.4 + logical*0.3 + unified*0.3`) in the State Fill column — a different quantity under the same name.
- **Branch A (kept)**: `state_fill_rate=None` → renders "—" (CG #1540: not-applicable, not measured-empty); the grade moves to `extra_metrics["quality_score"]`.
- **Branch B (rejected)**: invent a field-fraction for an orchestrator that exposes no `UnifiedAnalysisState` → fabrication.

`_compute_decides` untouched (DoD). The deterministic mode still decides via `phases_completed=3`.

## DoD
- [x] One definition of fill for the sites (helper takes snapshot + baseline; the baseline is computed from a pristine state by the helper, not passed in).
- [x] Baseline snapshotted in the same form as the measurement (`summarize` param).
- [x] Re-measured chiffres cited (5.9% / 4.9% baseline; 5.3-pt observed effect). The deterministic column changes from a `%` to `—`.
- [x] Tests: `TestFillRateExcludesConstructionBaseline` (the class the DoD referenced — it did not exist, now created) — pristine → 0.0 on both forms, produced content → >0, baseline differs between forms, zero-sentinels don't count. Plus a deterministic tranche test.
- [x] `_compute_decides` untouched.

## Validation (projet-is — `tests/scripts/` is outside the CI gate, #1563, so run locally and cited)
- 7 new tests pass (`TestFillRateExcludesConstructionBaseline` + `TestDeterministicFillTranche`).
- **118 passed** non-regression (`tests/scripts/`).
- 7 passed (`test_cg1540_unwritten_vs_measured.py`).
- `black` clean (both files).
- JVM/LLM-free; privacy HARD (opaque synthetic probes `baseline_probe_opaque_synthetic`, 0 corpus, 0 raw_text).

Does not auto-close #1566 — the coordinator owns the closure (the tranche decision is documented here; the issue body's DoD is met).
