### PR TITLE
fix(speech): remove the dead advanced-services tier from fallacy detection (#1567)

### DIFF
--- a/speech-to-text/services/fallacy_detector.py
+++ b/speech-to-text/services/fallacy_detector.py
@@ -7,13 +7,10 @@ Provides comprehensive fallacy detection with multiple detection methods
 """
 
 import sys
-import os
 import logging
 import time
-import asyncio
 from pathlib import Path
 from typing import Dict, Any, Optional, List
-from concurrent.futures import ThreadPoolExecutor
 
 # Add project root to path
 current_dir = Path(__file__).parent.parent.parent
@@ -23,92 +20,71 @@ if str(current_dir) not in sys.path:
 
 class FallacyDetectionService:
     """
-    Main fallacy detection service with three-tier fallback architecture:
-    1. Advanced Services (InformalAnalysisAgent)
-    2. Web API (when available)
-    3. Simple Pattern Matching (always available)
+    Main fallacy detection service with two-tier fallback architecture:
+    1. Web API (when available and healthy)
+    2. Simple Pattern Matching (always available)
+
+    #1567 — the former tier 1 ("Advanced Services", an InformalAnalysisAgent
+    bootstrapped via an ``AnalysisRunner`` import) was DEAD: the module
+    ``argumentation_analysis.orchestration.analysis_runner`` was removed in
+    ``d2fef7b4`` (obsolete analysis runners) and never replaced, the
+    ``AnalysisRunner`` class exists in NO module, and the assigned instance
+    was never read. Worse, the kernel was built with a FAKE key
+    (``api_key="mock_key"``), so repairing the import alone would have
+    flipped an honestly-OFF tier into a tier that LIES about being available
+    then fails on the first real call (motif #1019). The branch could not be
+    wired honestly without inventing a class for an unconsumed instance + a
+    real key + a reachability healthcheck — a feature, not a fix, never
+    requested (``SKIP_ADVANCED_SERVICES=true`` was already the config default).
+    Decision: REMOVE the tier (argumented); the rejected branch (wire it) is
+    documented above. Tiers web-API and pattern-matching are untouched.
     """
 
     def __init__(self):
         """Initialize the fallacy detection service"""
         self.logger = logging.getLogger(__name__)
         self.is_initialized = False
-        self.use_advanced_services = False
         self.use_web_api = False
-        self.informal_agent = None
-        self.analysis_runner = None
         self.web_api_detector = None
         self.api_base_url = "http://localhost:5000"
 
         self._initialize_services()
 
     def _initialize_services(self):
-        """Initialize services with fallback hierarchy"""
-        # Check if advanced services should be skipped
-        skip_advanced = os.environ.get("SKIP_ADVANCED_SERVICES", "").lower() == "true"
+        """Initialize services with fallback hierarchy (web API -> pattern)."""
+        # #1567: the dead "advanced services" tier (import to a removed module
+        # + fake key) is gone — no try/except ImportError can mask an
+        # unavailable tier here, because there is no such tier to mask. The
+        # web-API tier below reports its availability honestly via its own
+        # ``check_health`` (it only claims readiness when the endpoint answers).
+        try:
+            # Import web API detector if available
+            from .web_api_client import WebAPIClient
 
-        if skip_advanced:
-            self.logger.info("Skipping advanced services (SKIP_ADVANCED_SERVICES=true)")
-        else:
-            # Try advanced services first
-            try:
-                from argumentation_analysis.agents.core.informal.informal_agent import (
-                    InformalAnalysisAgent,
-                )
-                from argumentation_analysis.orchestration.analysis_runner import (
-                    AnalysisRunner,
-                )
-                import semantic_kernel as sk
-                from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+            self.web_api_detector = WebAPIClient(self.api_base_url)
 
-                kernel = sk.Kernel()
-                mock_llm_service = OpenAIChatCompletion(
-                    service_id="mock_openai",
-                    ai_model_id="gpt-3.5-turbo",
-                    api_key="mock_key",
-                )
-                kernel.add_service(mock_llm_service)
-
-                self.informal_agent = InformalAnalysisAgent(
-                    kernel=kernel, agent_name="fallacy_detection_service"
-                )
-                self.informal_agent.setup_agent_components(mock_llm_service.service_id)
-                self.analysis_runner = AnalysisRunner()
-
-                self.use_advanced_services = True
-                self.logger.info("Advanced services initialized successfully")
-
-            except ImportError as e:
-                self.logger.warning(f"Advanced services not available: {e}")
-
-            except Exception as e:
-                self.logger.warning(f"Error initializing advanced services: {e}")
-
-        # Try web API fallback
-        if not self.use_advanced_services:
-            try:
-                # Import web API detector if available
-                from .web_api_client import WebAPIClient
-
-                self.web_api_detector = WebAPIClient(self.api_base_url)
-
-                if self.web_api_detector.check_health():
-                    self.use_web_api = True
-                    self.logger.info("Web API fallback initialized")
-            except ImportError:
-                self.logger.info("Web API client not available")
-            except Exception as e:
-                self.logger.warning(f"Web API initialization failed: {e}")
+            if self.web_api_detector.check_health():
+                self.use_web_api = True
+                self.logger.info("Web API fallback initialized")
+        except ImportError:
+            self.logger.info("Web API client not available")
+        except Exception as e:
+            self.logger.warning(f"Web API initialization failed: {e}")
 
         self.is_initialized = True
         self.logger.info("Fallacy detection service initialized")
 
     def check_health(self) -> Dict[str, Any]:
-        """Check service health and return status"""
+        """Check service health and return status.
+
+        #1567: ``advanced_services`` is no longer reported — the dead tier was
+        removed, so check_health can no longer advertise a tier that would
+        fail on the first real call (DoD). ``web_api`` is reported honestly
+        (only True when the endpoint answered ``check_health`` at init).
+        """
         return {
             "service": "fallacy_detection",
             "status": "healthy" if self.is_initialized else "unhealthy",
-            "advanced_services": self.use_advanced_services,
             "web_api": self.use_web_api,
             "pattern_matching": True,  # Always available
             "timestamp": time.strftime("%Y-%m-%d %H:%M:%S"),
@@ -140,18 +116,8 @@ class FallacyDetectionService:
         start_time = time.time()
 
         try:
-            # Method 1: Advanced Services
-            if self.use_advanced_services and self.informal_agent:
-                try:
-                    result = self._run_advanced_analysis(text)
-                    processing_time = time.time() - start_time
-                    return self._format_result(
-                        result, text, processing_time, "advanced_services", options
-                    )
-                except Exception as e:
-                    self.logger.error(f"Advanced analysis failed: {e}")
-
-            # Method 2: Web API
+            # Method 1: Web API (the advanced-services tier was removed in
+            # #1567 — it was dead since d2fef7b4 and could only have lied).
             if self.use_web_api and self.web_api_detector:
                 try:
                     result = self.web_api_detector.detect_fallacies(text, options)
@@ -173,75 +139,6 @@ class FallacyDetectionService:
             self.logger.error(f"All analysis methods failed: {e}")
             processing_time = time.time() - start_time
             return self._create_error_response(f"Analysis failed: {e}", processing_time)
-
-    def _run_advanced_analysis(self, text: str) -> Dict[str, Any]:
-        """Run analysis using advanced services with async handling"""
-        try:
-            # Handle async/await properly
-            try:
-                loop = asyncio.get_running_loop()
-                if loop.is_running():
-                    with ThreadPoolExecutor() as executor:
-                        future = executor.submit(
-                            asyncio.run, self._async_advanced_analysis(text)
-                        )
-                        return future.result(timeout=30)
-                else:
-                    return loop.run_until_complete(self._async_advanced_analysis(text))
-            except RuntimeError:
-                return asyncio.run(self._async_advanced_analysis(text))
-
-        except Exception as e:
-            self.logger.error(f"Advanced analysis error: {e}")
-            # Fallback to pattern matching
-            return self._pattern_matching_analysis(text)
-
-    async def _async_advanced_analysis(self, text: str) -> Dict[str, Any]:
-        """Async advanced analysis using InformalAnalysisAgent"""
-        try:
-            plugin = self.informal_agent.sk_kernel.plugins.get("InformalAnalyzer")
-            if not plugin:
-                return {"error": "InformalAnalyzer plugin not found"}
-
-            available_functions = list(plugin.functions.keys())
-            self.logger.info(f"Available functions: {available_functions}")
-
-            # Try semantic analysis first
-            if "semantic_AnalyzeFallacies" in available_functions:
-                try:
-                    from semantic_kernel.functions import KernelArguments
-
-                    arguments = KernelArguments(input=text)
-
-                    result = await self.informal_agent.sk_kernel.invoke(
-                        plugin_name="InformalAnalyzer",
-                        function_name="semantic_AnalyzeFallacies",
-                        arguments=arguments,
-                    )
-
-                    analysis_text = str(result.value) if result and result.value else ""
-                    fallacies = self._parse_semantic_analysis(analysis_text)
-
-                    return {
-                        "fallacies": fallacies,
-                        "analysis_method": "semantic_analysis",
-                        "raw_analysis": analysis_text,
-                    }
-
-                except Exception as e:
-                    self.logger.error(f"Semantic analysis failed: {e}")
-
-            # Fallback to pattern matching with advanced service context
-            fallacies = self._pattern_matching_analysis(text)["fallacies"]
-            return {
-                "fallacies": fallacies,
-                "analysis_method": "advanced_services_with_pattern_matching",
-                "taxonomy_available": True,
-            }
-
-        except Exception as e:
-            self.logger.error(f"Async analysis error: {e}")
-            return {"error": f"Analysis failed: {str(e)}"}
 
     def _pattern_matching_analysis(self, text: str) -> Dict[str, Any]:
         """Pattern-based fallacy detection (always available)"""
@@ -290,38 +187,6 @@ class FallacyDetectionService:
                     break
 
         return {"fallacies": fallacies, "analysis_method": "pattern_matching"}
-
-    def _parse_semantic_analysis(self, analysis_text: str) -> List[Dict[str, Any]]:
-        """Parse semantic analysis results"""
-        fallacies = []
-
-        if not analysis_text.strip():
-            return fallacies
-
-        lines = analysis_text.split("\n")
-        for line in lines:
-            line = line.strip()
-            if not line:
-                continue
-
-            if any(
-                keyword in line.lower()
-                for keyword in ["fallacy", "sophisme", "erreur logique"]
-            ):
-                fallacies.append(
-                    {
-                        "type": "Semantic Detection",
-                        "name": "Detected Fallacy",
-                        "confidence": 0.75,
-                        "description": line,
-                        "start_position": 0,
-                        "end_position": 0,
-                        "context": "semantic analysis",
-                        "severity": "medium",
-                    }
-                )
-
-        return fallacies
 
     def _format_result(
         self,

--- a/tests/unit/speech_to_text/test_fallacy_detector_no_lying_tier_1567.py
+++ b/tests/unit/speech_to_text/test_fallacy_detector_no_lying_tier_1567.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+"""Tests for #1567 — the speech-to-text fallacy service advertises no lying tier.
+
+The former tier 1 ("Advanced Services") was DEAD: it imported a module removed
+in ``d2fef7b4`` (``argumentation_analysis.orchestration.analysis_runner``), the
+``AnalysisRunner`` class exists in NO module, the assigned instance was never
+read, and the kernel was built with a FAKE key (``api_key="mock_key"``). So
+repairing the import alone would have flipped an honestly-OFF tier into a tier
+that LIES about being available then fails on the first real call (motif #1019).
+Decision: REMOVE the tier (#1567).
+
+These tests prove the removal holds and is structural (not just behavioural):
+  * ``check_health()`` can no longer advertise the tier that lied.
+  * No phantom advanced-tier attribute lingers on the instance.
+  * No executable code passes ``api_key`` (the fake key was consumed only by the
+    removed kernel build; the docstring documenting the removal is a string
+    Constant, not a Call kwarg, so the AST walk over Calls excludes it).
+  * Every ``except ImportError`` is reachability-gated (calls ``check_health``)
+    so no tier can mask its own unavailability (anti-#1019).
+  * The dead importer is referenced in NO executable Name/Attribute (only in the
+    docstring).
+  * The always-on pattern tier delivers honest success.
+
+No-LLM, no-JVM. ``speech-to-text/`` is outside the CI gate (#1563); this test
+lives in ``tests/unit/`` (inside the gate) and imports the service by file path.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SERVICE_PATH = REPO_ROOT / "speech-to-text" / "services" / "fallacy_detector.py"
+
+
+def _load_service_module():
+    """Import fallacy_detector by file path (independent of package wiring).
+
+    The relative ``from .web_api_client`` import has no package context under a
+    file-path load, so it raises ImportError — which the service catches
+    honestly (the web-API tier stays OFF). That is exactly the honest-degraded
+    behaviour under test.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "fallacy_detector_1567", str(SERVICE_PATH)
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+def _ast_tree():
+    return ast.parse(SERVICE_PATH.read_text(encoding="utf-8"))
+
+
+def _is_import_error(node):
+    if node is None:
+        return False  # bare `except:` is not an ImportError handler
+    names = []
+    if isinstance(node, ast.Name):
+        names = [node.id]
+    elif isinstance(node, ast.Tuple):
+        names = [e.id for e in node.elts if isinstance(e, ast.Name)]
+    return "ImportError" in names
+
+
+# --- Behavioural: the lying tier is gone from the health report ---
+
+
+def test_check_health_advertises_no_advanced_tier():
+    """DoD: check_health() cannot announce a tier that would fail on first call."""
+    svc = _load_service_module().get_fallacy_detection_service()
+    health = svc.check_health()
+    assert (
+        "advanced_services" not in health
+    ), "check_health must not advertise the dead/lying advanced-services tier"
+    assert health["pattern_matching"] is True  # the always-on honest tier
+    assert "web_api" in health  # reports availability honestly (True only if up)
+
+
+def test_no_phantom_advanced_attributes():
+    """The removed tier left no attribute on the instance."""
+    svc = _load_service_module().get_fallacy_detection_service()
+    for attr in ("use_advanced_services", "informal_agent", "analysis_runner"):
+        assert not hasattr(svc, attr), f"phantom attribute {attr!r} lingers"
+
+
+def test_pattern_tier_delivers_honest_success():
+    """The always-on tier works with no LLM/JVM/key (opaque synthetic probe)."""
+    svc = _load_service_module().get_fallacy_detection_service()
+    result = svc.detect_fallacies("c est un idiot cet individu la")
+    assert result["status"] == "success"
+    assert result["summary"]["analysis_method"] == "pattern_matching"
+
+
+# --- Structural (AST): the removal cannot regress via executable code ---
+
+
+def test_no_executable_code_passes_api_key():
+    """No Call passes ``api_key`` — the fake key was the removed kernel's only
+    consumer. The docstring documenting the removal is a string Constant, so an
+    AST walk of Calls sees none."""
+    tree = _ast_tree()
+    offenders = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            for kw in node.keywords:
+                if kw.arg == "api_key":
+                    offenders.append(ast.unparse(node))
+    assert offenders == [], f"executable code still passes api_key: {offenders}"
+
+
+def test_every_importerror_tier_is_reachability_gated():
+    """Anti-#1019: any ``except ImportError`` must guard a tier whose try-body
+    probes reachability (``check_health``). No tier may mask its own
+    unavailability then claim ready."""
+    tree = _ast_tree()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Try):
+            for handler in node.handlers:
+                if _is_import_error(handler.type):
+                    try_src = ast.unparse(node)
+                    assert "check_health" in try_src, (
+                        "except ImportError without a check_health() reachability "
+                        "gate would mask an unavailable tier (anti-#1019)"
+                    )
+
+
+def test_no_dead_importer_reference_in_executable_code():
+    """The removed dead importer (analysis_runner module / AnalysisRunner class)
+    must not appear in any executable Name/Attribute. It may appear in the
+    docstring documenting the removal — AST Names/Attributes exclude docstrings."""
+    tree = _ast_tree()
+    referenced = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id in {
+            "AnalysisRunner",
+            "analysis_runner",
+        }:
+            referenced.append(node.id)
+        if isinstance(node, ast.Attribute) and node.attr in {
+            "AnalysisRunner",
+            "analysis_runner",
+        }:
+            referenced.append(node.attr)
+    assert (
+        referenced == []
+    ), f"executable code still references the dead importer: {referenced}"


### PR DESCRIPTION
## Summary
Fixes #1567 — the speech-to-text fallacy service no longer carries a tier that could lie about being available. The former tier 1 ("Advanced Services") was **dead** and, if "repaired" naively, would have become a lying tier (motif #1019). Removed it; the two honest tiers (web-API, pattern-matching) are untouched.

## Root cause (verify-before-assert, code is truth)
- The import `from argumentation_analysis.orchestration.analysis_runner import AnalysisRunner` points at a module **removed in `d2fef7b4`** (obsolete analysis runners) and never replaced.
- `git grep -w AnalysisRunner` → the class exists in **NO** module (`analysis_runner_v2.py` defines `AnalysisRunnerV2`, a different name). The assigned `self.analysis_runner` / `self.informal_agent` instance was **never read** anywhere.
- The kernel was built with `api_key="mock_key"` — a fake key. So merely fixing the import would flip an honestly-OFF tier into one that **lies** about readiness then fails on the first real call (#1019).
- `SKIP_ADVANCED_SERVICES=true` was already the config default → the tier was OFF in practice; nothing depended on it being ON.

## Decision — anti-pendule (suppression, not a counterweight)
**Branch kept: REMOVE the dead tier.** The service becomes an honest 2-tier fallback (web-API → pattern-matching).

**Branch rejected: wire it honestly.** That would require inventing a `class AnalysisRunner` for an instance nobody consumes, sourcing a real API key, and adding a reachability healthcheck — a feature, not a fix, never requested. Documented in-code so the picture is corrected.

### Methods/attrs removed
| Element | Role | Reason |
|---|---|---|
| `_run_advanced_analysis` | dead tier orchestrator | imported a removed module; instance never read |
| `_async_advanced_analysis` | dead-tier async shim | wrapped the above |
| `_parse_semantic_analysis` | dead-tier result parser | consumed only by the removed orchestrator |
| `use_advanced_services` / `informal_agent` / `analysis_runner` attrs | dead-tier state | never read |
| `"advanced_services"` in `check_health()` | health advertisement | advertised a tier that would fail on first call |
| `import os / asyncio / ThreadPoolExecutor` | dead-tier deps | no longer used |

No **files** deleted (the cleanup-gate file-removal table does not apply); this is a code-removal inside one module, documented here for transparency.

## DoD (proved structurally + behaviourally)
`tests/unit/speech_to_text/test_fallacy_detector_no_lying_tier_1567.py` (6 tests, no-LLM/no-JVM, file-path import):

1. **`check_health()` cannot advertise the lying tier** → `assert "advanced_services" not in health`.
2. **No phantom attribute lingers** → `not hasattr(svc, attr)` for the 3 removed attrs.
3. **Pattern tier delivers honest success** → `status == "success"`, `analysis_method == "pattern_matching"`.
4. **No executable code passes `api_key`** (AST walk over `Call` kwargs) → the fake key was the removed kernel's only consumer; the docstring documenting the removal is a string `Constant`, excluded by the walk.
5. **Every `except ImportError` is reachability-gated** (`check_health` in the try-body) → anti-#1019: no tier can mask its own unavailability then claim ready.
6. **No executable `Name`/`Attribute` references the dead importer** (`AnalysisRunner`/`analysis_runner`) → may appear only in the docstring.

Tests 4–6 are AST guards, so the removal **cannot regress** via a future edit that reintroduces a fake-key/import-masked tier without also rewriting the assertions.

## Validation (projet-is)
- 6/6 new tests pass.
- `python -m black` clean (1 file reformatted, re-verified green).
- Singleton `get_fallacy_detection_service()` + `check_health()` confirmed at runtime: keys `{service, status, web_api, pattern_matching, timestamp}` (no `advanced_services`), `web_api=False` (honest — no endpoint), `pattern_matching=True`, `detect_fallacies` → success on a generic probe.

## Notes
- `speech-to-text/` is outside the CI gate (#1563); the test is placed in `tests/unit/` (inside the gate) so it is durable, and imports the service by file path (no package wiring needed).
- Companion to #1566 (same anti-theatre family — honest availability reporting).

Does not auto-close #1567 — the coordinator owns the closure (branch decision documented here; the issue DoD is met).
