### PR TITLE
fix(ci): the gate ran tests/unit only — tests/scripts never executed (#1563)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,27 @@ jobs:
 
       - name: Run automated tests
         if: env.API_KEYS_CONFIGURED == 'true'
-        # Gate scope (#1336/#1341): tests/unit only, LLM- and slow-marked tests
-        # excluded. The full suite cannot be a per-push gate: integration tests
-        # spawn a JVM subprocess or make real LLM calls (~1 test/min — the
-        # 2026-07-01 full run reached 2% of 14k tests in 6h before GitHub's job
-        # limit killed it), and tests/bench runs 15+ min LLM benchmarks by
-        # design. Integration/e2e/bench/LLM lanes need a scheduled or on-demand
-        # workflow, not this gate.
+        # Gate scope (#1336/#1341): tests/unit + tests/scripts, LLM- and
+        # slow-marked tests excluded. The full suite cannot be a per-push gate:
+        # integration tests spawn a JVM subprocess or make real LLM calls
+        # (~1 test/min — the 2026-07-01 full run reached 2% of 14k tests in 6h
+        # before GitHub's job limit killed it), and tests/bench runs 15+ min LLM
+        # benchmarks by design. Integration/e2e/bench/LLM lanes need a scheduled
+        # or on-demand workflow, not this gate.
+        #
+        # #1563: the gate ran tests/unit ONLY, so tests/scripts — which holds
+        # the orchestration-comparison harness suite, i.e. the tests guarding
+        # every number Epic #1500 reports — never executed in CI. A PR touching
+        # only the harness went green having run none of its own tests; the
+        # compensating control was a hand-cited local run, which is not a gate.
+        # Widened ONE directory at a time under a MEASURED budget, never to
+        # tests/ wholesale (#1341 was slowness, and re-including it in bulk is
+        # the pendulum). Measured on projet-is, same marker filter:
+        #   tests/scripts       → 129 passed, 2 deselected, 22.7s   → ADMITTED
+        #   tests/orchestration → still running at 10 min, killed   → EXCLUDED
+        # The next candidate directory needs its own measurement, not this
+        # precedent. The tally in the summary below is the proof the widening
+        # took effect: it must rise by ~129 on the first run after this change.
         # Backstop below the 6h GitHub job default; --timeout converts a hung
         # test into a failure with a stack dump of every thread (thread method
         # is the only one available on Windows; it aborts the run on fire, so
@@ -123,7 +137,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TEXT_CONFIG_PASSPHRASE: ${{ secrets.TEXT_CONFIG_PASSPHRASE }}
         run: |
-          conda run -n projet-is --no-capture-output pytest tests/unit/ -m "not slow and not requires_api" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
+          conda run -n projet-is --no-capture-output pytest tests/unit/ tests/scripts/ -m "not slow and not requires_api" --junitxml=pytest_report.xml -v --timeout=900 --timeout-method=thread
 
       - name: Generate test summary
         if: always()


### PR DESCRIPTION
Ferme #1563.

Le gate CI lançait `pytest tests/unit/`. Tout ce qui vit ailleurs sous `tests/` n'a **jamais** tourné en intégration — dont `tests/scripts/`, qui porte la suite du harnais de comparaison d'orchestration, c'est-à-dire les tests qui gardent **chacun des chiffres publiés par l'Epic #1500**.

## Ce que ça produisait

Une PR ne touchant que le harnais partait verte **sans avoir exécuté un seul de ses propres tests**. Le contrôle compensatoire était un run local cité à la main dans le corps de la PR — utile, mais ce n'est pas un gate : rien ne le vérifie, et il disparaît au premier auteur qui ne le cite pas.

## Le correctif — un répertoire, sous budget mesuré

Mesuré sur `projet-is`, avec le filtre de marqueurs du gate lui-même :

| Répertoire | Mesure | Décision |
|---|---|---|
| `tests/scripts` | **129 passed, 2 deselected, 22,7 s** | **admis** |
| `tests/orchestration` | toujours en cours à **10 min**, tué | **exclu** |

22,7 s s'ajoutent à une suite qui tourne en 1500–2100 s. `tests/orchestration` reste dehors et devra faire l'objet de sa propre mesure — c'est vraisemblablement la même famille de lenteur que #1341.

## Anti-pendule

**Pas** élargi à `tests/` en bloc. #1341 était un problème de **lenteur** (`integration/` lance des JVM et des appels LLM réels, ~1 test/min ; le run complet du 2026-07-01 a atteint 2 % de 14k tests en 6 h avant d'être tué par la limite GitHub). Réadmettre la suite entière serait exactement le retour de balancier dans le défaut qu'on avait corrigé. Un répertoire, mesuré, admis ; le suivant devra être mesuré à son tour et ne pourra pas s'appuyer sur ce précédent.

## Vérification

Collecte combinée, sans conflit de conftest :

```
pytest tests/unit/ tests/scripts/  -> 13594 collected (300 deselected) en 57,6 s
pytest tests/unit/                 -> 13465 collected (298 deselected) en 45,0 s
                                      delta = +129
```

**+129, exactement le répertoire admis.** Ce delta est le contrôle : si le tally du résumé CI ne bouge pas d'environ 129 au premier run après ce merge, c'est que rien de neuf n'a tourné. C'est le même contrôle qui a servi à valider #1560 (`13185 -> 13190` pour 5 tests attendus).

## Note

Ce diff touche `.github/workflows/ci.yml`, zone protégée par ma propre discipline de merge. Arbitrage utilisateur obtenu avant ouverture.

🤖 Coordinator ai-01 — R731
