### PR TITLE
fix(harness): subtract the construction baseline on the success fill paths (#1566)

### DIFF
--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -46,8 +46,9 @@ import sys
 import time
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+from typing import Any, Awaitable, Callable, Dict, FrozenSet, List, Optional, Tuple
 
 # Add project root to path
 PROJECT_ROOT = Path(__file__).parent.parent
@@ -242,43 +243,97 @@ def _is_filled(value: Any) -> bool:
     return bool(value) and value not in ([], {}, "", None, 0)
 
 
-def _state_fill_rate(state: Any) -> Optional[float]:
+@lru_cache(maxsize=2)
+def _construction_baseline_keys(summarize: bool) -> FrozenSet[str]:
+    """Keys a pristine ``UnifiedAnalysisState(text)`` fills at CONSTRUCTION.
+
+    #1566: the success paths (``run_pipeline_mode`` / ``run_conversational_mode``)
+    hold only a snapshot **dict**, never the state object — so they cannot reuse
+    the object-form baseline (``type(state)(raw_text)``). This helper rebuilds
+    that baseline from the class, snapshotted in the SAME form as the
+    measurement: ``summarize=True`` → the 41-key summarized shape
+    (``raw_text`` + ``raw_text_snippet``); ``summarize=False`` → the 51-key raw
+    shape (``raw_text`` + ``deanonymized`` + ``stakes_and_stakeholders``).
+
+    A raw baseline subtracted from a summarized snapshot (or the reverse) would
+    re-manufacture the drift this helper exists to remove — the ``summarize``
+    arg is load-bearing, not decorative. Cached: the set depends only on the
+    form, not on any run's text, so it is computed once per form per process.
+
+    Opaque synthetic probe (privacy HARD — never a corpus string here).
+    """
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+    pristine = UnifiedAnalysisState("baseline_probe_opaque_synthetic")
+    snap = pristine.get_state_snapshot(summarize=summarize) or {}
+    return frozenset(k for k, v in snap.items() if _is_filled(v))
+
+
+def _state_fill_rate(
+    snapshot_or_state: Any,
+    summarize: Optional[bool] = None,
+) -> Optional[float]:
     """Fraction of state fields THIS RUN filled in, or None if no state.
 
-    ONE definition for the two BREACH paths (pipeline + hierarchical bridge),
-    where the fill is not a statistic but the verdict signal itself: it is what
-    ``_compute_decides`` reads to decide whether a cut run produced anything.
-    Two copies of this arithmetic is how the counters in this file drifted
-    before (#1560); the twin call-site kept the defect the first fix removed.
+    ONE definition, TWO call shapes — a second helper here is how the counters
+    in this file drifted before (#1560):
 
-    ⚠ The SUCCESS paths (``run_pipeline_mode`` / ``run_conversational_mode``,
-    at their non-breach return) still compute their fill inline, from a
-    snapshot dict rather than a state object, and WITHOUT the baseline
-    subtraction below — so their reported percentages run ~5-6 points high
-    (that is where the 51.2 % / 15.7 % / 7.8 % figures on #1528 come from).
-    That is a reporting inaccuracy, not a fabricated verdict: on a success path
-    ``_compute_decides`` is already carried by ``phases_completed > 0``, so no
-    verdict flips. Recalibrating them changes every headline number in the
-    comparison and belongs to its own measured round — filed rather than
-    silently drifted, and NOT quietly folded into this bound.
+    * **State-object form** (breach paths): ``_state_fill_rate(state)``. The
+      fill is not a statistic but the verdict signal itself — it is what
+      ``_compute_decides`` reads to decide whether a cut run produced anything.
+      The baseline is built from the class via ``type(state)(raw_text)``, so it
+      tracks whatever subclass the runner instrumented.
 
-    ⚠ The construction baseline is SUBTRACTED. A freshly built
+    * **Snapshot-dict form** (#1566 success paths): ``_state_fill_rate(snap,
+      summarize=...)``. The success returns hold only the snapshot dict the
+      runner emitted (``result["state_snapshot"]``), never the object, so the
+      object-form baseline is unreachable. ``summarize`` MUST match the shape
+      the runner snapshotted in (pipeline → ``True`` per
+      ``unified_pipeline.py``; conversational → ``False``, raw attribute names)
+      so the baseline is subtracted in the SAME form as the measurement.
+
+    The construction baseline is SUBTRACTED either way. A freshly built
     ``UnifiedAnalysisState(text)`` is not empty: it already carries
-    ``raw_text``, ``deanonymized`` and ``stakes_and_stakeholders`` — 3 of 51
-    fields, i.e. **5.9 %**, before a single phase has run. Counting those made
-    a run that produced NOTHING score ``fill > 0``, which ``_compute_decides``
-    reads as a verdict artifact. That is where the ``pipeline_standard | ⏱
-    budget | 45.01s | Decides ✅ | 0/15 phases | 5.9 %`` row measured firsthand
-    at R723 came from: 5.9 % IS the empty baseline, echoed back. The verdict
-    was manufactured by the constructor. Same family as #1560/#1019 — a number
-    that looks like a measurement and is an artifact of the instrument.
+    ``raw_text`` (and ``deanonymized`` / ``stakes_and_stakeholders`` raw, or
+    ``raw_text_snippet`` summarized) — ~5-6 % of fields before a phase runs.
+    Counting those made an empty run score ``fill > 0``, which on a breach path
+    ``_compute_decides`` read as a verdict artifact (the
+    ``pipeline_standard | 0/15 phases | 5.9 % | Decides ✅`` row measured at
+    R723 — 5.9 % WAS the empty baseline echoed back). On a success path no
+    verdict flips (``_compute_decides`` is already carried by
+    ``phases_completed > 0``), but the headline percentage was ~5-6 pts high
+    and the success/breach columns were not on the same footing. #1566 puts
+    them on the same footing. Same family as #1560/#1019 — a number that looks
+    like a measurement and is an artifact of the instrument.
 
-    So the numerator counts only fields a pristine state of the same class
-    does NOT already fill, and the denominator is the fillable remainder.
+    So the numerator counts only fields a pristine state of the same form does
+    NOT already fill, and the denominator is the fillable remainder.
 
     ``None`` (no state instrumented) and ``0.0`` (state instrumented, measured
     empty) are DIFFERENT answers and must stay so — CG #1540 / leçon #1531.
     """
+    # Dict form (#1566): snapshot already computed by the runner; ``summarize``
+    # selects the baseline form. A dict passed without ``summarize`` is a
+    # programming error (the form is ambiguous) → refuse rather than guess.
+    if isinstance(snapshot_or_state, dict):
+        snapshot = snapshot_or_state
+        if summarize is None:
+            raise ValueError(
+                "_state_fill_rate(dict, summarize=None): the snapshot form is "
+                "ambiguous — pass summarize=True (summarized) or False (raw) "
+                "so the baseline is subtracted in the same form."
+            )
+        if not snapshot:
+            return 0.0
+        baseline = _construction_baseline_keys(bool(summarize))
+        fillable = [k for k in snapshot if k not in baseline]
+        if not fillable:
+            return 0.0
+        non_empty = sum(1 for k in fillable if _is_filled(snapshot[k]))
+        return round(non_empty / len(fillable), 3)
+
+    # State-object form (breach paths): unchanged since #1565.
+    state = snapshot_or_state
     if state is None:
         return None
     try:
@@ -731,11 +786,11 @@ async def run_pipeline_mode(
     summary = result.get("summary", {})
     snap = result.get("state_snapshot", {})
 
-    total_fields = len(snap) if snap else 1
-    non_empty = sum(
-        1 for v in (snap or {}).values() if v and v not in ([], {}, "", None, 0)
-    )
-
+    # #1566: the fill is the SAME definition as the breach path (baseline
+    # subtracted), via the snapshot-dict form. ``unified_pipeline`` returns
+    # ``get_state_snapshot(summarize=True)`` (shared_state.py:358-359), so the
+    # baseline must be subtracted in the summarized form — the 41-key shape,
+    # not the 51-key raw one.
     # #1560: the counts are MEASURED from the snapshot the pipeline returns.
     # ``result["extra_metrics"]`` has NO producer anywhere in the package, so
     # ``.get("extra_metrics", {}).get("fallacy_count", 0)`` returned its literal
@@ -762,7 +817,7 @@ async def run_pipeline_mode(
         corpus_id=corpus_id,
         success=True,
         duration_seconds=round(duration, 2),
-        state_fill_rate=round(non_empty / max(total_fields, 1), 3),
+        state_fill_rate=_state_fill_rate(snap, summarize=True),
         fallacy_count=_summarized_count("fallacy_count"),
         argument_count=_summarized_count("argument_count"),
         phases_completed=summary.get("completed", 0),
@@ -849,10 +904,11 @@ async def run_conversational_mode(
     wall_clock_bounded = bool(budget.get("wall_clock_bounded", False))
 
     state = result.get("state_snapshot", {})
-    total_fields = len(state) if state else 1
-    non_empty = sum(
-        1 for v in (state or {}).values() if v and v not in ([], {}, "", None, 0)
-    )
+    snapshot = state if isinstance(state, dict) else {}
+    # #1566: same fill definition as the breach path (baseline subtracted),
+    # via the snapshot-dict form. The conversational snapshot is the raw
+    # (non-summarized) one — 51-key shape, raw attribute names — so the
+    # baseline is subtracted in the raw form (summarize=False).
 
     planned_phases = result.get("phases", []) if isinstance(result, dict) else []
     conv_log = result.get("conversation_log", []) if isinstance(result, dict) else []
@@ -875,8 +931,6 @@ async def run_conversational_mode(
     # names, ``identified_arguments`` / ``identified_fallacies``), NOT the
     # summarized ``*_count`` shape. Absent key → None ("not written", Track CG
     # #1540), never a fabricated 0.
-    snapshot = state if isinstance(state, dict) else {}
-
     def _snapshot_count(key: str) -> Optional[int]:
         value = snapshot.get(key)
         if value is None:
@@ -892,7 +946,7 @@ async def run_conversational_mode(
         success=True,
         terminates=True,
         duration_seconds=round(duration, 2),
-        state_fill_rate=round(non_empty / max(total_fields, 1), 3),
+        state_fill_rate=_state_fill_rate(snapshot, summarize=False),
         fallacy_count=_snapshot_count("identified_fallacies"),
         argument_count=_snapshot_count("identified_arguments"),
         phases_completed=len(phases_ran),
@@ -935,6 +989,17 @@ async def run_conversation_deterministic_mode(
     duration = time.time() - start
 
     conv_state = orch.get_conversation_state()
+    # #1566 tranche (coord R730 left this 5th site open): the deterministic
+    # orchestrator exposes NO UnifiedAnalysisState — it publishes a weighted
+    # QUALITY grade (conversation_orchestrator.py:
+    # sophistication*0.4 + logical*0.3 + unified*0.3) in ``state.score``.
+    # Publishing that grade in the State Fill column put a different QUANTITY
+    # under the same name (the metric-named-beyond-its-calculation family).
+    # Branch A (kept): state_fill_rate=None (renders "—", CG #1540
+    # not-applicable, NOT measured-empty) and the grade moves to
+    # extra_metrics["quality_score"]. Branch B (invent a field-fraction for an
+    # orchestrator that exposes no UnifiedAnalysisState) = fabrication, rejected.
+    quality_score = conv_state.get("state", {}).get("score", 0)
 
     return ModeResult(
         mode="conversation_deterministic",
@@ -942,7 +1007,7 @@ async def run_conversation_deterministic_mode(
         success=True,
         terminates=True,
         duration_seconds=round(duration, 3),
-        state_fill_rate=round(conv_state.get("state", {}).get("score", 0), 3),
+        state_fill_rate=None,
         fallacy_count=conv_state.get("state", {}).get("fallacies_detected", 0),
         phases_completed=3,  # informal + fol + synthesis
         phases_total=3,
@@ -952,6 +1017,7 @@ async def run_conversation_deterministic_mode(
             "messages_count": conv_state.get("messages_count", 0),
             "tools_count": conv_state.get("tools_count", 0),
             "processing_time": conv_state.get("processing_time", 0),
+            "quality_score": quality_score,
         },
     )
 

--- a/tests/scripts/test_compare_orchestration_modes_1480.py
+++ b/tests/scripts/test_compare_orchestration_modes_1480.py
@@ -1808,6 +1808,113 @@ class TestFillRateExcludesConstructionBaseline:
         mod = self._harness()
         assert mod._state_fill_rate(None) is None
 
+    # --- #1566: the snapshot-dict form (success paths) ---------------------
+    # The success returns (``run_pipeline_mode`` / ``run_conversational_mode``)
+    # hold only a snapshot DICT, never the state object, so they call the dict
+    # form. Its baseline must be subtracted in the SAME shape the runner
+    # snapshotted in — a raw baseline on a summarized snapshot (or the reverse)
+    # would re-manufacture the very drift this class pins out.
+
+    @staticmethod
+    def _snap(
+        text: str = "some argument text about a claim", summarize: bool = False
+    ) -> dict:
+        """A snapshot dict in the requested form (what the runners hold)."""
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+        return UnifiedAnalysisState(text).get_state_snapshot(summarize=summarize) or {}
+
+    def test_dict_form_pristine_scores_zero_both_shapes(self) -> None:
+        """A snapshot nobody wrote to → 0.0 in BOTH forms (raw + summarized)."""
+        mod = self._harness()
+        assert mod._state_fill_rate(self._snap(summarize=False), summarize=False) == 0.0
+        assert mod._state_fill_rate(self._snap(summarize=True), summarize=True) == 0.0
+
+    def test_dict_form_produced_content_scores_above_zero(self) -> None:
+        """Anti-pendule: baseline subtraction must not zero out real work."""
+        mod = self._harness()
+        state = self._state()
+        state.add_argument("corpus_A asserts a contested premise")
+        raw = state.get_state_snapshot(summarize=False) or {}
+        fill = mod._state_fill_rate(raw, summarize=False)
+        assert fill is not None and fill > 0.0
+
+    def test_dict_form_requires_explicit_summarize(self) -> None:
+        """A dict passed without ``summarize`` is ambiguous → refuse, do not guess.
+
+        Silent-defaulting to raw or summarized would be exactly the drift this
+        helper exists to remove; the form MUST be stated.
+        """
+        import pytest
+
+        mod = self._harness()
+        with pytest.raises(ValueError):
+            mod._state_fill_rate(self._snap(summarize=False))
+
+    def test_dict_form_baselines_differ_between_shapes(self) -> None:
+        """The raw baseline (51-key: raw_text + deanonymized + stakes) and the
+        summarized baseline (41-key: raw_text + raw_text_snippet) are DIFFERENT
+        sets — subtracting the wrong one re-manufactures the drift."""
+        mod = self._harness()
+        raw_base = mod._construction_baseline_keys(False)
+        sum_base = mod._construction_baseline_keys(True)
+        assert raw_base != sum_base
+        # Measured firsthand (R729 / coord R730): 3 raw, 2 summarized.
+        assert len(raw_base) == 3
+        assert len(sum_base) == 2
+
+    def test_dict_form_agrees_with_object_form(self) -> None:
+        """Object form and dict form give the SAME fill for the same state —
+        they are one definition, two call shapes, not two definitions."""
+        mod = self._harness()
+        state = self._state()
+        state.add_argument("corpus_A asserts a contested premise")
+        state.add_argument("corpus_A further develops the claim with evidence")
+        via_object = mod._state_fill_rate(state)
+        via_dict = mod._state_fill_rate(
+            state.get_state_snapshot(summarize=False) or {}, summarize=False
+        )
+        assert via_object is not None and via_dict is not None
+        assert via_object == via_dict
+
+
+class TestDeterministicFillTranche:
+    """#1566 tranche — the deterministic mode's 5th site (coord R730 left open).
+
+    ``run_conversation_deterministic_mode`` exposes NO ``UnifiedAnalysisState``;
+    it published a weighted QUALITY grade in the State Fill column. Branch A
+    (kept): ``state_fill_rate=None`` (renders "—", CG #1540 not-applicable) and
+    the grade moves to ``extra_metrics["quality_score"]``.
+    """
+
+    @staticmethod
+    def _harness():
+        return _load_harness_module()
+
+    def test_deterministic_publishes_none_fill_and_quality_score(self) -> None:
+        """The quality grade is NOT a fill rate — it lives in extra_metrics."""
+        mod = self._harness()
+        r = mod.ModeResult(
+            mode="conversation_deterministic",
+            corpus_id="corpus_A",
+            success=True,
+            terminates=True,
+            phases_completed=3,
+            state_fill_rate=None,  # branch A: not-applicable, not measured-empty
+            extra_metrics={
+                "messages_count": 6,
+                "tools_count": 3,
+                "processing_time": 1.2,
+                "quality_score": 0.74,
+            },
+        )
+        assert r.state_fill_rate is None
+        assert r.extra_metrics["quality_score"] == 0.74
+        # _fmt_fill renders None as "—" (CG #1540), never "0.0%".
+        assert mod._fmt_fill(r.state_fill_rate) == "—"
+        # `decides` still carries on phases_completed, unaffected by the tranche.
+        assert mod._compute_decides(r) is True
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
Fixes #1566 -- every **success-path** `state_fill_rate` ran ~5-6 pts high because the two success returns (`run_pipeline_mode`, `run_conversational_mode`) computed their fill **inline from a snapshot dict, without subtracting the construction baseline** that the breach paths already subtract (#1565). The success and breach columns of a comparison table were not on the same footing.

This is the rework the coordinator reaffected to po-2023 (R735, option b of my ASK). The earlier #1568 was closed (DIRTY base off `2eaf08f6`, duplicated #1565 helper/tests, carried a redundant #1555 commit). This PR is off a fresh `origin/main` (`e6f9d246`), reuses nothing of #1568 commits, and extends -- does not duplicate -- `TestFillRateExcludesConstructionBaseline`.

## Why a dict form is necessary (verified firsthand, coord R735)
The success returns hold only `result["state_snapshot"]` -- a **dict** -- never the `UnifiedAnalysisState` object. Main breach-path helper builds its baseline via `type(state)(raw_text)`, which is **impossible** without the object. So calling the existing helper is not an option at the success sites; the `summarize` parameter is load-bearing, not decorative.

## Fix -- one helper, two call shapes (anti-pendule)
`_state_fill_rate` becomes polymorphic (no second helper -- arithmetic duplication is what drifted before, #1560):

| Shape | Caller | Baseline source |
|---|---|---|
| `_state_fill_rate(state)` -- **unchanged** | breach paths (pipeline + hierarchical bridge) | `type(state)(raw_text)` |
| `_state_fill_rate(snap, summarize=...)` -- **new** | success paths | `_construction_baseline_keys(summarize)` -- rebuilt from the class, cached per form |

The dict-form baseline is snapshotted **in the SAME form** as the measurement (raw 51 / summarized 41). A dict passed without `summarize` is **ambiguous -> refused (ValueError)**, never silently defaulted (silent-default would be exactly the drift this removes).

### Sites
| Site | form | before | after |
|---|---|---|---|
| `run_pipeline_mode` success | summarized (41) | inline, baseline incl. | `_state_fill_rate(snap, summarize=True)` |
| `run_conversational_mode` success | raw (51) | inline, baseline incl. | `_state_fill_rate(snapshot, summarize=False)` |
| `run_conversation_deterministic_mode` (5th site) | -- | weighted quality grade in fill column | `state_fill_rate=None` + `extra_metrics["quality_score"]` (branch A) |

`_compute_decides` untouched. Denominators untouched (41 vs 51) -- the ticket is about the baseline, not the scale.

## 5th site -- tranche (coord R730 left open)
`run_conversation_deterministic_mode` published a weighted quality grade (`sophistication*0.4 + logical*0.3 + unified*0.3`) in the State Fill column -- a different quantity under the same name.
- **Branch A (kept)**: `state_fill_rate=None` -> renders "--" (CG #1540: not-applicable, not measured-empty); grade -> `extra_metrics["quality_score"]`.
- **Branch B (rejected)**: invent a field-fraction for an orchestrator that exposes no `UnifiedAnalysisState` -> fabrication.

## Measured firsthand
| | total | baseline | baseline keys | rate |
|---|---|---|---|---|
| raw (summarize=False) | 51 | 3 | `raw_text`, `deanonymized`, `stakes_and_stakeholders` | **5.9%** |
| summarized (summarize=True) | 41 | 2 | `raw_text`, `raw_text_snippet` | **4.9%** |

Object and dict forms agree on produced content (verified). The two baselines **differ** (anti-regression guard).

## Tests -- extend, do not recreate
`TestFillRateExcludesConstructionBaseline` (exists on main via #1565) is **extended** with the dict form: pristine dict -> 0.0 in both shapes; produced content -> >0; dict without `summarize` -> ValueError; raw vs summarized baselines differ (3 vs 2 keys); object/dict agree on the same state. Plus a new `TestDeterministicFillTranche`.

## Validation
`tests/scripts/` is now in the CI gate (#1563/#1570), so this runs in CI -- local run cited too:
- 10/10 extended tests pass.
- **137 passed** non-regression (`tests/scripts/`).
- `black` clean (both files).
- JVM/LLM-free; privacy HARD (opaque synthetic probe `baseline_probe_opaque_synthetic`, 0 corpus, 0 raw_text).

Companion to #1565 (same baseline, breach paths) and #1567 (same anti-theatre family). Does not auto-close #1566 -- the coordinator owns the closure.
