### PR TITLE
fix(communication): stop routing to unimplemented channel types (#1571)

### DIFF
--- a/argumentation_analysis/core/communication/middleware.py
+++ b/argumentation_analysis/core/communication/middleware.py
@@ -195,15 +195,25 @@ class MessageMiddleware:
         elif message.type == MessageType.RESPONSE:
             # Les réponses suivent généralement le même canal que la requête
             return ChannelType.HIERARCHICAL
-        elif message.type == MessageType.EVENT:
-            return ChannelType.FEEDBACK
-        elif message.type == MessageType.CONTROL:
-            return ChannelType.SYSTEM
         elif message.type == MessageType.PUBLICATION:
             return ChannelType.DATA
-        elif message.type == MessageType.SUBSCRIPTION:
-            return ChannelType.SYSTEM
 
+        # #1571: EVENT / CONTROL / SUBSCRIPTION no longer route to FEEDBACK /
+        # SYSTEM. Three of seven ``ChannelType`` members (NEGOTIATION, FEEDBACK,
+        # SYSTEM) have NO ``Channel`` implementation, so routing there was
+        # indeliverable by construction: ``send_message`` logged
+        # ``Channel not found: feedback|system`` and returned False, swallowed
+        # by callers — a routing table promising transports that do not exist
+        # (anti-#1019). Verified firsthand: zero production producers for these
+        # three message types (``SUBSCRIPTION`` emission removed from
+        # ``pub_sub.subscribe``; no ``CONTROL`` producer; ``EventMessage`` used
+        # only in its own unit test). The dead routes are subtracted rather
+        # than wired to empty channel classes (fabricating transport for
+        # messages with no consumer would be the #1019 theater). These types
+        # now fall through to the default bus below. A future
+        # FeedbackChannel / SystemChannel should be registered via
+        # ``create_default_middleware()`` and re-add the route here.
+        #
         # Canal par défaut
         return ChannelType.HIERARCHICAL
 

--- a/argumentation_analysis/core/communication/pub_sub.py
+++ b/argumentation_analysis/core/communication/pub_sub.py
@@ -425,21 +425,19 @@ class PublishSubscribeProtocol:
         # Ajouter l'abonné au topic
         subscription_id = topic.add_subscriber(subscriber_id, callback, filter_criteria)
 
-        # Créer un message d'abonnement
-        message = Message(
-            message_type=MessageType.SUBSCRIPTION,
-            sender=subscriber_id,
-            sender_level=AgentLevel.SYSTEM,  # À remplacer par le niveau réel de l'agent
-            content={"topic": topic_id, "filter": filter_criteria},
-            recipient=None,  # Pas de destinataire spécifique
-            channel=None,  # Le canal sera déterminé par le middleware
-            priority=MessagePriority.NORMAL,
-            metadata={"subscription_id": subscription_id},
-        )
-
-        # Envoyer le message d'abonnement via le middleware
-        self.middleware.send_message(message)
-
+        # #1571: subscribe NO LONGER emits a SUBSCRIPTION message. The
+        # subscription itself is done (``topic.add_subscriber`` above) — that is
+        # the work that delivers future publications to this subscriber. The
+        # message we used to build here routed to ``ChannelType.SYSTEM``
+        # (``determine_channel`` for SUBSCRIPTION), a channel with NO
+        # implementation, so ``send_message`` logged ``Channel not found: system``
+        # and returned False, swallowed. There was (and is) NO consumer of a
+        # SUBSCRIPTION message anywhere in the package (``grep -rn
+        # MessageType.SUBSCRIPTION`` → 1 producer, 1 router, 0 consumers), so the
+        # emission was theater: indeliverable, its failure hidden. Mirror of the
+        # C2 #1500 publish fix (publish fans out via ``_handle_message``; this
+        # removes the dead notify entirely). The CLI delegation run no longer
+        # emits the spurious ``Channel not found``.
         return subscription_id
 
     def unsubscribe(self, topic_id: str, subscription_id: str) -> bool:

--- a/tests/orchestration/hierarchical/test_channel_registration_1471_R652.py
+++ b/tests/orchestration/hierarchical/test_channel_registration_1471_R652.py
@@ -70,6 +70,7 @@ def _run_cli(*extra_args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+@pytest.mark.slow
 class TestChannelRegistration:
     """The R652 fix wires HIERARCHICAL + DATA channels into the
     ``MessageMiddleware`` used by the hierarchical orchestrator, so
@@ -98,10 +99,15 @@ class TestChannelRegistration:
 
         occurrences = combined.count(CHANNEL_NOT_FOUND_MARKER)
         assert occurrences == 0, (
-            "R652 regression: 'Channel not found' still appears "
+            "'Channel not found' still appears "
             f"{occurrences} time(s) on the CLI delegation path. "
-            "The HIERARCHICAL+DATA channels are not registered on the "
-            "per-tier MessageMiddleware instances.\n"
+            "The HIERARCHICAL+DATA channels ARE registered (witnessed by the "
+            "sibling test), so this is NOT an R652 registration regression. "
+            "#1571: the likely cause is a message routed to a ChannelType with "
+            "no implementation (SYSTEM/FEEDBACK/NEGOTIATION) — e.g. a producer "
+            "of SUBSCRIPTION/EVENT/CONTROL, or an explicit message.channel to "
+            "an unregistered type. Inspect the 'Channel not found: <type>' line "
+            "below for the culprit channel.\n"
             f"--- STDOUT (tail) ---\n{result.stdout[-2000:]}\n"
             f"--- STDERR (tail) ---\n{result.stderr[-2000:]}"
         )

--- a/tests/orchestration/hierarchical/test_cli_registry_wiring_1471_R651.py
+++ b/tests/orchestration/hierarchical/test_cli_registry_wiring_1471_R651.py
@@ -62,6 +62,7 @@ def _run_cli(*extra_args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+@pytest.mark.slow
 class TestCLIRegistryWiring:
     """The real CLI must wire a CapabilityRegistry into the hierarchical
     orchestrator so delegation mode completes E2E. This is the R651 fix

--- a/tests/orchestration/hierarchical/test_mode_decides_firsthand_1471.py
+++ b/tests/orchestration/hierarchical/test_mode_decides_firsthand_1471.py
@@ -34,6 +34,7 @@ SYNTHETIC_FALLACY_TEXT = (
 )
 
 
+@pytest.mark.slow
 class TestHierarchicalBridgeModeFirsthandDecision:
     """Bridge mode (M2 default) runs end-to-end with REAL agents and reaches
     a strategic decision. This is the DoD baseline for BO-1 #1471.
@@ -76,6 +77,7 @@ class TestHierarchicalBridgeModeFirsthandDecision:
         assert result.get("duration_seconds", 0) > 0
 
 
+@pytest.mark.slow
 class TestHierarchicalDelegationModeFailsLoud:
     """Delegation mode (M3 true 3-tier) FAILS LOUD on missing tier
     instead of fabricating a degraded result (anti-théâtre #1019).

--- a/tests/unit/argumentation_analysis/core/communication/test_middleware.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_middleware.py
@@ -162,21 +162,30 @@ class TestDetermineChannel:
         msg = _make_msg(msg_type=MessageType.RESPONSE)
         assert middleware.determine_channel(msg) == ChannelType.HIERARCHICAL
 
-    def test_event_routes_to_feedback(self, middleware):
+    def test_event_falls_to_default_no_feedback_channel(self, middleware):
+        # #1571: EVENT used to route to FEEDBACK — a ChannelType member with NO
+        # Channel implementation, so the route was indeliverable. It now falls
+        # to the default HIERARCHICAL bus. Anti-regression guard: re-adding
+        # EVENT → FEEDBACK requires a FeedbackChannel registered first.
         msg = _make_msg(msg_type=MessageType.EVENT)
-        assert middleware.determine_channel(msg) == ChannelType.FEEDBACK
+        assert middleware.determine_channel(msg) == ChannelType.HIERARCHICAL
 
-    def test_control_routes_to_system(self, middleware):
+    def test_control_falls_to_default_no_system_channel(self, middleware):
+        # #1571: CONTROL used to route to SYSTEM (no implementation). Falls to
+        # the default HIERARCHICAL bus.
         msg = _make_msg(msg_type=MessageType.CONTROL)
-        assert middleware.determine_channel(msg) == ChannelType.SYSTEM
+        assert middleware.determine_channel(msg) == ChannelType.HIERARCHICAL
 
     def test_publication_routes_to_data(self, middleware):
         msg = _make_msg(msg_type=MessageType.PUBLICATION)
         assert middleware.determine_channel(msg) == ChannelType.DATA
 
-    def test_subscription_routes_to_system(self, middleware):
+    def test_subscription_falls_to_default_no_system_channel(self, middleware):
+        # #1571: SUBSCRIPTION used to route to SYSTEM (no implementation) — the
+        # dead ``pub_sub.subscribe`` emission hit exactly this and logged
+        # ``Channel not found: system``. Falls to the default HIERARCHICAL bus.
         msg = _make_msg(msg_type=MessageType.SUBSCRIPTION)
-        assert middleware.determine_channel(msg) == ChannelType.SYSTEM
+        assert middleware.determine_channel(msg) == ChannelType.HIERARCHICAL
 
 
 # ── send_message ──

--- a/tests/unit/argumentation_analysis/core/communication/test_pub_sub.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_pub_sub.py
@@ -374,13 +374,33 @@ class TestProtocolPublish:
         assert "agent_1" in recipients
         proto.shutdown()
 
+    def test_publish_delivers_to_subscriber_firsthand(self):
+        # DoD #1571 P1 — a test that asserts DELIVERY (the message reaches a
+        # subscriber's callback firsthand), not the routing decision. The unit
+        # suite used to assert only ``determine_channel`` return values, so a
+        # route to an unimplemented channel stayed green. Anti-#1019: genuine
+        # firsthand reception, not a cosmetic recipients-list flag.
+        mw = MagicMock()
+        proto = PublishSubscribeProtocol(mw)
+        received = []
+        proto.subscribe("t1", "agent_1", callback=lambda m: received.append(m))
+        proto.publish("t1", "sender", AgentLevel.OPERATIONAL, {"data": "opaque"})
+        assert len(received) == 1
+        assert received[0].content == {"data": "opaque"}
+        proto.shutdown()
+
     def test_subscribe_to_topic(self):
         mw = MagicMock()
         proto = PublishSubscribeProtocol(mw)
         sub_id = proto.subscribe("t1", "agent_1")
         assert sub_id.startswith("sub-")
-        # subscribe also sends a subscription message
-        mw.send_message.assert_called_once()
+        # #1571 (mirror of C2 #1500 publish fix): subscribe NO LONGER emits a
+        # SUBSCRIPTION message. The old emission routed to ChannelType.SYSTEM
+        # (no implementation), so ``send_message`` logged
+        # ``Channel not found: system`` and returned False, swallowed — theater.
+        # The subscription itself succeeds via ``topic.add_subscriber`` (the
+        # work that delivers future publications), so the dead notify is gone.
+        mw.send_message.assert_not_called()
         proto.shutdown()
 
     def test_unsubscribe(self):


### PR DESCRIPTION
## TL;DR

The middleware routing table mapped 3 message types to `ChannelType` members with **no `Channel` implementation** (`EVENT`→`FEEDBACK`, `CONTROL`→`SYSTEM`, `SUBSCRIPTION`→`SYSTEM`). `send_message` logged `Channel not found: <type>` and returned `False`, swallowed. The one live producer was `pub_sub.subscribe` — its `SUBSCRIPTION` emission routed to `SYSTEM` and surfaced as the spurious `Channel not found: system` on the CLI delegation path (the #1571 symptom). Fix is **soustraction** (anti-#1019): remove the dead emission + the 3 dead routes. No empty channel classes fabricated for messages with no consumer.

## DoD

- [x] **P1 — Consumers of `SUBSCRIPTION`/`EVENT`/`CONTROL` searched, result written.** `grep -rn "MessageType\.\(EVENT\|CONTROL\|SUBSCRIPTION\)"` over `argumentation_analysis/` returns: the 3 router branches in `determine_channel`, the (now-removed) `pub_sub.subscribe` emission, the `EventMessage` factory class, and enum-value test assertions. **0 consumers. 0 producers** once the subscribe emission is removed (`SUBSCRIPTION`: removed here; `CONTROL`: never produced; `EVENT`: `EventMessage` instantiated only in `tests/.../test_message.py`).
- [x] **P1 — Decision applied (soustraction) + justified; unimplemented members treated together.** See "Decision" below. The 3 unimplemented `ChannelType` members (`NEGOTIATION`/`FEEDBACK`/`SYSTEM`) are treated together. ⚠️ The DoD says "4 membres … sans implémentation" — `ChannelType` has **7 members** (`channel_interface.py:19-28`), **4 implemented** (`HierarchicalChannel`/`CollaborationChannel`/`DataChannel`/`LocalChannel`), **3 not** (`NEGOTIATION`/`FEEDBACK`/`SYSTEM`). The "4" is a typo; this PR treats the real 3 together.
- [x] **P1 — Routing to an unimplemented channel can no longer be silent: *le cas disparaît*.** The 3 dead routes are removed from `determine_channel`; no `MessageType` routes to an unimplemented channel. (`send_message`'s log-and-return-False on an explicitly-set `message.channel` to an unregistered type is left intact — see "Out of scope".)
- [x] **P1 — A test asserts DELIVERY, not `determine_channel`.** New `test_publish_delivers_to_subscriber_firsthand`: subscribes a callback, publishes, asserts the callback received the message firsthand with the right content.
- [x] **P1 — `test_cli_delegation_mode_has_no_channel_not_found` passes + message corrected.** The assertion message no longer accuses HIERARCHICAL+DATA (they ARE registered — sibling test witnesses it); it now points at the real cause (a message routed to an unimplemented channel type). The test's `count == 0` now holds: the only producer of the spurious `Channel not found: system` (the subscribe emission) is gone.
- [x] **P2 — The 3 CLI-real tests bear `@pytest.mark.slow`** (`test_channel_registration_1471_R652.py`, `test_mode_decides_firsthand_1471.py`, `test_cli_registry_wiring_1471_R651.py`; 150–466 s each, LLM-real). Gate admission of the rest of `tests/orchestration/` is a follow-up (one directory at a time, anti-pendule #1341).

## Decision — soustraction (Option A), not fail-loud (Option B)

The DoD allowed either "le cas disparaît" (remove the routes) **or** "il échoue bruyamment" (make `send_message` raise). Chose **remove the routes**:

- **Anti-pendule / coord's lean** ("L'évidence penche vers la soustraction"): pure subtraction, no new behaviour added.
- **No contract change**: `send_message` still returns `bool`. Option B (raise `ChannelException`) would have broken `test_middleware::test_send_no_channel` and the C2 #1500 defect-reproduction test (both assert `send_message → False` on an unregistered channel), and would change a contract used by every adapter / `request_response` / `jtms_communication_hub`.
- **No crash risk on the naked-middleware fallback** (`pipelines/orchestration/core/communication.py:65-71`, the issue's secondary observation): Option A leaves `send_message`'s swallow intact, so that (unreachable-in-the-observed-run) branch is unaffected.
- **0 producers** → the semantic mismatch (EVENT/CONTROL/SUBSCRIPTION now falling to the default HIERARCHICAL bus) is academic; no behaviour change in practice. A future `FeedbackChannel`/`SystemChannel` registers via `create_default_middleware()` and re-adds the route — documented in the `determine_channel` comment.

## Changes

| File | Change |
|---|---|
| `pub_sub.py` | `subscribe()` no longer builds/sends the dead `SUBSCRIPTION` message (mirror of C2 #1500 `publish` fix). Subscription succeeds via `topic.add_subscriber`. |
| `middleware.py` | `determine_channel` drops `EVENT`→`FEEDBACK`, `CONTROL`→`SYSTEM`, `SUBSCRIPTION`→`SYSTEM`. They fall to the default `HIERARCHICAL` bus. Comment explains the subtraction + the extension path. |
| `test_middleware.py` | The 3 "routes to FEEDBACK/SYSTEM" assertions → default-bus fallthrough assertions (anti-regression guards). |
| `test_pub_sub.py` | `test_subscribe_to_topic` → `send_message.assert_not_called`; new `test_publish_delivers_to_subscriber_firsthand` (DoD delivery test). |
| `test_channel_registration_1471_R652.py` | Corrected assertion message (was: "HIERARCHICAL+DATA not registered" — wrong; now: points at unimplemented-channel routing). `@pytest.mark.slow`. |
| `test_mode_decides_firsthand_1471.py`, `test_cli_registry_wiring_1471_R651.py` | `@pytest.mark.slow` on the CLI-real classes. |

## Out of scope

- `send_message`'s log-and-return-False on a message whose **explicit** `message.channel` is an unregistered type (e.g. `Message(channel="feedback")`) is left intact. This is a deliberate caller choice, not the routing table's promise that #1571 targets. Making it fail-loud is a contract change with broader ripple — separate concern.
- The naked-middleware fallback at `pipelines/orchestration/core/communication.py:65-71` (issue's secondary observation): untouched (branch not taken in the observed run; `send_message` swallow unchanged under Option A). Documenting/fixing it is a follow-up if the branch proves reachable.

## Validation

- `tests/unit/argumentation_analysis/core/communication/` — **436 passed** (incl. C2 #1500 broadcast-bus non-regression, #1555 strategic broadcast junction, the 3 updated routing tests, the new delivery test, the subscribe `assert_not_called`). JVM/LLM-free, 12 s.
- The 3 CLI-real tests: `--collect-only` clean (9 collected); `@pytest.mark.slow` recognized (no `PytestUnknownMarkWarning`).
- `black --check` clean on all 7 files.
- The primary DoD CLI test (`test_cli_delegation_mode_has_no_channel_not_found`) — **PASSED firsthand** (LLM-real, 65 s): the delegation run now emits 0 `Channel not found`.

Base: `main` `e6f9d246`.
