### PR TITLE
fix(mcp): migrate mcp_server to mcp 2.x API (#1559)

### DIFF
--- a/argumentation_analysis/services/mcp_server/main.py
+++ b/argumentation_analysis/services/mcp_server/main.py
@@ -9,7 +9,7 @@ import sys
 print("Importation des modules...")
 
 from fastapi import Response
-from mcp.server.fastmcp import FastMCP
+from mcp.server import MCPServer
 from pydantic import ValidationError
 
 # Import des services Web API
@@ -95,7 +95,8 @@ class MCPService:
         """
         Initialise le service MCP avec les mêmes services que l'API Web.
         """
-        self.mcp = FastMCP(service_name, host="0.0.0.0", port=8000)
+        # mcp 2.x (#1559): host/port moved out of the constructor into run().
+        self.mcp = MCPServer(service_name)
         self.logger = logging.getLogger(__name__)
         self._initialized = False
         self.services = None
@@ -684,9 +685,20 @@ class MCPService:
         except Exception as e:
             self.logger.warning(f"V2 tools not registered: {e}")
 
-    def run(self, transport: str = "streamable-http"):
-        """Lance le serveur MCP."""
-        self.mcp.run(transport=transport)
+    def run(
+        self,
+        transport: str = "streamable-http",
+        host: str = "0.0.0.0",
+        port: int = 8000,
+    ):
+        """Lance le serveur MCP.
+
+        mcp 2.x (#1559): transport-specific params (host/port) are passed here,
+        not to the MCPServer constructor.
+        """
+        # transport is a runtime str; MCPServer.run's overloads are per-Literal,
+        # so mypy cannot narrow — stdio ignores host/port server-side (see #1559).
+        self.mcp.run(transport=transport, host=host, port=port)  # type: ignore[call-overload]
 
 
 # Point d'entrée principal

--- a/environment.yml
+++ b/environment.yml
@@ -82,7 +82,7 @@ dependencies:
     - tenacity
     - pybreaker
     - pytest-dotenv
-    - mcp>=1.26,<2  # PIN: mcp 2.0.0 (sorti le 2026-07-28) supprime `mcp.server.fastmcp`, importé par argumentation_analysis/services/mcp_server/main.py → 3 erreurs de COLLECTION dans tests/unit/services/test_mcp_server_v2/, qui avortent toute la suite. Non épinglé, la CI a résolu 2.0.0 le jour de sa sortie et a bloqué toutes les PRs. Migration vers l'API 2.x = ticket séparé.
+    - mcp>=2.0  # #1559 : migré vers l'API mcp 2.x (FastMCP renommé MCPServer, host/port déplacés du ctor vers run()). Le pin <2 de #1558 était un sursis le temps de la migration.
     - blis
     - JPype1>=1.5.0
     - pytest-benchmark

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,6 +15,6 @@ psutil
 unidecode
 pytest-playwright
 matplotlib
-mcp>=1.26,<2  # voir environment.yml : mcp 2.0.0 supprime `mcp.server.fastmcp`
+mcp>=2.0  # #1559 : migré vers l'API mcp 2.x (voir environment.yml)
 hypothesis
 pytest-timeout

--- a/tests/unit/argumentation_analysis/services/test_mcp_server.py
+++ b/tests/unit/argumentation_analysis/services/test_mcp_server.py
@@ -348,7 +348,7 @@ class TestAppServices:
 def _make_mcp_service():
     """Create an MCPService with all heavy dependencies mocked."""
     with patch(
-        "argumentation_analysis.services.mcp_server.main.FastMCP"
+        "argumentation_analysis.services.mcp_server.main.MCPServer"
     ) as mock_fmcp, patch(
         "argumentation_analysis.services.mcp_server.main.initialize_project_environment"
     ), patch(
@@ -383,7 +383,7 @@ class TestMCPServiceInit:
 
     def test_init_failure_raises_runtime_error(self):
         with patch(
-            "argumentation_analysis.services.mcp_server.main.FastMCP"
+            "argumentation_analysis.services.mcp_server.main.MCPServer"
         ) as mock_fmcp, patch(
             "argumentation_analysis.services.mcp_server.main.initialize_project_environment",
             side_effect=Exception("init failed"),
@@ -397,7 +397,7 @@ class TestMCPServiceInit:
     def test_v2_tools_failure_is_silent(self):
         """V2 tool registration failure should not crash init."""
         with patch(
-            "argumentation_analysis.services.mcp_server.main.FastMCP"
+            "argumentation_analysis.services.mcp_server.main.MCPServer"
         ) as mock_fmcp, patch(
             "argumentation_analysis.services.mcp_server.main.initialize_project_environment"
         ), patch(
@@ -717,7 +717,12 @@ class TestMCPServiceRun:
     def test_run_delegates_to_mcp(self):
         svc = _make_mcp_service()
         svc.run("stdio")
-        svc.mcp.run.assert_called_once_with(transport="stdio")
+        # mcp 2.x (#1559): host/port now flow through run() (moved out of the
+        # ctor). stdio ignores them server-side, but the delegation contract
+        # forwards them regardless of transport.
+        svc.mcp.run.assert_called_once_with(
+            transport="stdio", host="0.0.0.0", port=8000
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_mcp_server_v2/test_main_v2.py
+++ b/tests/unit/services/test_mcp_server_v2/test_main_v2.py
@@ -31,7 +31,7 @@ class TestBackwardCompatibility:
     def test_v1_tools_registered(self):
         """Original 10 tools are registered even when v2 fails."""
         with patch(
-            "argumentation_analysis.services.mcp_server.main.FastMCP"
+            "argumentation_analysis.services.mcp_server.main.MCPServer"
         ) as mock_fast_mcp, patch(
             "argumentation_analysis.services.mcp_server.main.initialize_project_environment"
         ), patch(
@@ -52,7 +52,7 @@ class TestListAvailableTools:
     async def test_list_includes_v2_tools(self):
         """list_available_tools includes both v1 and v2 tools."""
         with patch(
-            "argumentation_analysis.services.mcp_server.main.FastMCP"
+            "argumentation_analysis.services.mcp_server.main.MCPServer"
         ) as mock_fast_mcp, patch(
             "argumentation_analysis.services.mcp_server.main.initialize_project_environment"
         ), patch(


### PR DESCRIPTION
## What

Migrates the MCP server to the mcp 2.x API, closing the provisional `<2` pin from #1558 (which was a stay of execution pending this migration). mcp 2.x renamed `FastMCP` → `MCPServer` and moved `host`/`port` out of the constructor into `run()`.

## Changes

| File | Change |
|------|--------|
| `argumentation_analysis/services/mcp_server/main.py` | `FastMCP` → `MCPServer`; `host`/`port` relocated from the ctor to `MCPService.run()`; targeted `type:ignore[call-overload]` on the `run()` dispatch (the runtime `str` transport does not narrow to `MCPServer.run`'s per-`Literal` overloads — stdio ignores `host`/`port` server-side, sse/streamable-http use them). |
| `tests/unit/argumentation_analysis/services/test_mcp_server.py` | 3 mock targets `FastMCP` → `MCPServer`; `test_run_delegates_to_mcp` assertion updated to the new `mcp.run(transport=, host=, port=)` contract. |
| `tests/unit/services/test_mcp_server_v2/test_main_v2.py` | 2 mock targets `FastMCP` → `MCPServer`. |
| `environment.yml` | `mcp>=1.26,<2` → `mcp>=2.0`. |
| `requirements-test.txt` | `mcp>=1.26,<2` → `mcp>=2.0`. |

## On the contract-update test (not a neutralized test)

`test_run_delegates_to_mcp` previously asserted `mcp.run.assert_called_once_with(transport="stdio")`. Under mcp 2.x, `run()` is *always* called with `host`/`port` from `MCPService.run()`'s defaults. The assertion was updated to `transport="stdio", host="0.0.0.0", port=8000` — this preserves the test's intent (verify delegation to `mcp.run`), it does **not** weaken it. Verified server-side: stdio silently ignores `host`/`port` (only sse/streamable-http read `**kwargs`), so "always pass" is safe.

## Verification (firsthand, local)

- `pytest tests/unit/argumentation_analysis/services/test_mcp_server.py tests/unit/services/test_mcp_server_v2/` → **119 passed, 0 failed**.
- `pydantic 2.13.4` installed in `projet-is-roo-new`: 201 SK-exercising tests pass → the `semantic-kernel<2.12` upper bound on pydantic is resolver-level only, **not** a runtime blocker (SK imports and runs fine under 2.13.4).
- `mypy main.py`: **44 pre-existing errors, zero delta** from this change (main.py is outside the 8-file CI mypy gate; the single new overload-narrowing error is silenced by a targeted `type:ignore`).

## Notes for review

- The `# type: ignore[call-overload]` is deliberate and documented inline — `transport` is a runtime `str` (CLI/config-driven), so it cannot satisfy `MCPServer.run`'s `Literal` overloads at type-check time. Alternative (`cast`) would hide the call; the inline ignore is honest.
- No CI gate concern: the affected tests live under `tests/unit/`, which IS in the CI test gate. Local runs cited above.
- Awaits coordinator `--admin` merge (shared write-account blocks worker self-approve).

Closes #1559.