### PR TITLE
fix(test): route the two real-mode orch tests through their mocked orchestrator (#1578)

### DIFF
--- a/tests/unit/argumentation_analysis/pipelines/test_unified_pipelines.py
+++ b/tests/unit/argumentation_analysis/pipelines/test_unified_pipelines.py
@@ -1091,7 +1091,12 @@ class TestUnifiedTextAnalysisPipeline:
         assert (await p._perform_orchestration_analysis("t"))["status"] == "Skipped"
 
     async def test_orch_comprehensive(self):
-        p = self._make(orchestration_mode="real")
+        # #1578: orchestration_mode="real" bypasses self.orchestrator and calls
+        # the module-level run_unified_analysis (real pipeline -> real LLM). Use
+        # "pipeline" so the analyze_text_comprehensive branch below -- the one
+        # this test mocks -- is the path actually driven. Real mode is a
+        # deliberate production path (C2 #1500), not something to bend.
+        p = self._make(orchestration_mode="pipeline")
         mo = AsyncMock()
         mo.analyze_text_comprehensive = AsyncMock(
             return_value={
@@ -1102,6 +1107,9 @@ class TestUnifiedTextAnalysisPipeline:
         )
         p.orchestrator = mo
         assert (await p._perform_orchestration_analysis("t"))["status"] == "success"
+        # Structural bite (#1578): prove the orchestrator branch drove this, not
+        # the real pipeline. Reverting to mode="real" would skip this call.
+        mo.analyze_text_comprehensive.assert_awaited_once()
 
     async def test_orch_conversation(self):
         p = self._make(orchestration_mode="conversation")
@@ -1116,11 +1124,18 @@ class TestUnifiedTextAnalysisPipeline:
         assert (await p._perform_orchestration_analysis("t"))["status"] == "Failed"
 
     async def test_orch_error(self):
-        p = self._make(orchestration_mode="real")
+        # #1578: "real" mode ignores self.orchestrator (real pipeline path);
+        # use "pipeline" so the mocked analyze_text_comprehensive raising
+        # RuntimeError is what drives the status="Error" verdict (caught by the
+        # except clause in _perform_orchestration_analysis).
+        p = self._make(orchestration_mode="pipeline")
         mo = AsyncMock()
         mo.analyze_text_comprehensive = AsyncMock(side_effect=RuntimeError("E"))
         p.orchestrator = mo
         assert (await p._perform_orchestration_analysis("t"))["status"] == "Error"
+        # Structural bite (#1578): the raise must come from the mocked
+        # orchestrator, not the real pipeline.
+        mo.analyze_text_comprehensive.assert_awaited_once()
 
     async def test_analyze_unified_runs(self):
         p = self._make(analysis_modes=["informal"])


### PR DESCRIPTION
## TL;DR

`test_orch_comprehensive` and `test_orch_error` both built the pipeline with `orchestration_mode="real"` and set `p.orchestrator` to an `AsyncMock` exposing `analyze_text_comprehensive`. But the `"real"` branch of `_perform_orchestration_analysis` calls the **module-level** `run_unified_analysis` and **never reads `self.orchestrator`** — by design (C2 #1500). So the mock was bypassed, the real pipeline ran, and both tests drove the **same unmocked path** with input `"t"` while asserting **opposite** verdicts (`"success"` vs `"Error"`). Since the gate exports `OPENAI_API_KEY`, each run billed real LLM calls (>120 s). #1579 measured this pair as a canonical family-(a) network leaker (76 requests for `comprehensive` alone).

**Fix = correct the mode, do not patch the symbol.** Route the tests through `orchestration_mode="pipeline"` (the default) so the `analyze_text_comprehensive` branch — the one they mock — is the path actually driven. Add `mo.analyze_text_comprehensive.assert_awaited_once()` so each test structurally bites.

Production `unified_text_analysis.py` is **untouched** (read-only); the `"real"` path stays as designed.

## The bug (firsthand, no environment needed)

`argumentation_analysis/pipelines/unified_text_analysis.py`:

```python
if not self.orchestrator and self.config.orchestration_mode != "real":   # guard bypassed when mode=="real"
    return {... "status": "Skipped"}
try:
    if self.config.orchestration_mode == "real":                         # THIS branch fires
        orch_result = await run_unified_analysis(text, ...)              # module-level; ignores self.orchestrator
    elif hasattr(self.orchestrator, "analyze_text_comprehensive"):       # the branch the tests intend
        ...
```

With `mode="real"`, `self.orchestrator = mo` is dead: the real branch never consults it. `grep -nE "run_unified_analysis|autouse"` on the test file → **0 occurrence**: nothing is patched. The contradiction is structural — one twin passes by luck (real pipeline succeeds), the other fails (real pipeline doesn't error).

## Decision (written, per DoD)

**Option 2 — correct orchestration mode.** The tests set `mo.analyze_text_comprehensive`; their intent is the orchestrator branch + the exception handler. `mode="pipeline"` routes there (guard passes, real branch skipped, `hasattr(mo, "analyze_text_comprehensive")` → True).

**Option 1 — patch `run_unified_analysis` at the consumption point — rejected.** It would keep `mode="real"`, test the wrong branch (the module-level call, not the orchestrator), and leave `p.orchestrator = mo` as dead setup — a test that *accompanies* rather than *bites*, the exact anti-pattern retired in #1571/#1576. Option 2 makes the test's own mock load-bearing.

## DoD

- [x] **Both tests drive the path they announce**, by the correct orchestration mode (decision above + inline `# #1578` comments).
- [x] **Hermeticity proven by a measure** (`--durations`):

      | test | before | after (call) |
      |---|---|---|
      | `test_orch_comprehensive` | >120 s, 76 LLM req (#1579) | **0.00 s** |
      | `test_orch_error` | >120 s, ~70 LLM req | **0.00 s** |

      `.env` was loaded (key present) during the run — yet zero LLM call: the mock drove, not the model.
- [x] **P1 readable failure**: deliberately breaking the success property (mock raises instead of returns) yields, in <5 ms:

      ```
      assert (await p._perform_orchestration_analysis("t"))["status"] == "success"
      E   AssertionError: assert 'Error' == 'success'
      ```
      (+ log `Erreur orchestration: DELIBERATE_BREAK_1578`). The test detects the violated contract with no network.
- [x] **P2 sweep** of other `orchestration_mode="real"` in the file: **4 occurrences**. Only these 2 (L1099, L1131) drive a pipeline. The other 2 (`test_real` L1191 = enum-value assert; L1256 = config-enum mapping) are pure config/enum unit tests — no pipeline, no LLM — **left intact**.
- [x] **Tally delta: 0.** Two existing tests modified in place; 0 added, 0 removed.

## Anti-pendule (respected)

- No `skip`/`xfail`/`requires_api` to extinguish the symptom.
- No production `elif` added so `"real"` consults `self.orchestrator` (the `"real"` path is deliberate, C2 #1500).
- No dry deletion of `test_orch_error` (the raise → `status=Error` property deserves a test; only its piloting was wrong).
- Production `unified_text_analysis.py` **untouched**.

## Changes

| File | Change |
|---|---|
| `tests/unit/argumentation_analysis/pipelines/test_unified_pipelines.py` | 2 tests: `orchestration_mode="real"` → `"pipeline"` + inline rationale + `mo.analyze_text_comprehensive.assert_awaited_once()` structural bite. |

## Validation

- 2 fixed tests: **PASSED**, 0.00 s call each.
- Non-regression orch cluster (comprehensive + conversation + unknown_method + error): **4 passed in 4.18 s**.
- Deliberate-break demo: FAILED with the readable assertion above (then restored).
- `black --check`: clean.
- JVM/LLM-free (static test reroute + mock bite; production untouched).

Base: `main` `c9a82753` (fresh; `origin/main` is ancestor of HEAD).

## Privacy

Opaque IDs only. No `raw_text`. Test input is the literal `"t"` (already in-tree).

\#1579 (the measure, delivered separately as a comment) identified this pair as family-(a); this PR is the fix.
