### PR TITLE
test(orchestration): stop collateral LLM leaks in gate family-(a) concentrateurs (#1583)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_conversational_orchestrator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversational_orchestrator.py
@@ -529,6 +529,8 @@ class TestRunConversationalAnalysis:
             return agent
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ), patch(
             "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
             return_value=mock_kernel,
         ), patch(
@@ -622,6 +624,8 @@ class TestRunConversationalAnalysis:
             return agent
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ), patch(
             "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
             return_value=mock_kernel,
         ), patch(
@@ -670,6 +674,8 @@ class TestRunConversationalAnalysis:
             return agent
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ), patch(
             "argumentation_analysis.orchestration.conversational_orchestrator.sk.Kernel",
             return_value=mock_kernel,
         ), patch(

--- a/tests/unit/argumentation_analysis/orchestration/test_router.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_router.py
@@ -514,7 +514,14 @@ class TestRouterIntegration:
 
         registry = setup_registry(include_optional=False)
 
+        # #1583: the standard fallback workflow drove real LLM calls (8 req,
+        # 47 s) that the verdict ("workflow_name == standard_analysis", a pure
+        # routing fallback) does not depend on. Patch the AsyncOpenAI ctor so
+        # the fallback phases run honest-degraded. Router mock kept: it is what
+        # triggers the fallback under test.
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ), patch(
             "argumentation_analysis.orchestration.router.TextAnalysisRouter"
         ) as MockRouter:
             instance = MagicMock()
@@ -543,14 +550,27 @@ class TestRouterIntegration:
 
         registry = setup_registry(include_optional=False)
 
-        for name in ("light", "standard", "full"):
-            result = await run_unified_analysis(
-                "Test text.",
-                workflow_name=name,
-                registry=registry,
-                create_state=False,
-            )
-            assert "phases" in result
+        # #1583 (family (a) of #1579): without this patch each workflow drove
+        # the real pipeline end-to-end and billed 20 real LLM calls (122 s),
+        # while the verdict ("phases" present, name mapped) does not depend on
+        # the model. The pipeline builds its LLM clients at several dispersed
+        # sites (router, nl_to_logic, french_fallacy_adapter, plugins, debate)
+        # -- not only via invoke_callables._get_openai_client -- so patching the
+        # single creation point is insufficient. Patch the AsyncOpenAI ctor to
+        # raise: every component that builds a client takes its honest-degraded
+        # path, "phases" is still produced, and the workflow_name mapping (the
+        # in-test bite) is preserved. Network hermeticity is re-verified by the
+        # #1579 instrumentation.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
+            for name in ("light", "standard", "full"):
+                result = await run_unified_analysis(
+                    "Test text.",
+                    workflow_name=name,
+                    registry=registry,
+                    create_state=False,
+                )
+                assert "phases" in result
+                assert result["workflow_name"] == f"{name}_analysis"
 
 
 # ============================================================

--- a/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_unified_pipeline.py
@@ -384,7 +384,16 @@ class TestWorkflowExecution:
 
     @pytest.mark.asyncio
     async def test_execute_light_workflow(self):
-        """Light workflow executes with registered components."""
+        """Light workflow executes with registered components.
+
+        #1583: this exercises the real light workflow end-to-end. The quality
+        and counter invoke_callables leak collateral LLM calls (4 req / 46s),
+        but ``COMPLETED`` does not depend on the model — phases reach
+        ``COMPLETED`` via the honest-degraded path too. Patch the AsyncOpenAI
+        ctor (family a, mechanism M2) so the verdict is decided without
+        network; the ``COMPLETED`` assertions still hold, proving (biting) the
+        phase status never depended on the leaked calls.
+        """
         from argumentation_analysis.orchestration.unified_pipeline import (
             setup_registry,
             build_light_workflow,
@@ -393,11 +402,13 @@ class TestWorkflowExecution:
         registry = setup_registry(include_optional=False)
         workflow = build_light_workflow()
         executor = WorkflowExecutor(registry)
-        results = await executor.execute(workflow, input_data="Test argument text")
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
+            results = await executor.execute(workflow, input_data="Test argument text")
         assert isinstance(results, dict)
         assert "quality" in results
         assert "counter" in results
-        # Quality and counter should complete (registered)
+        # Quality and counter complete (registered) even without any LLM —
+        # the status is honest-degraded, never model-gated.
         assert results["quality"].status == PhaseStatus.COMPLETED
         assert results["counter"].status == PhaseStatus.COMPLETED
 
@@ -735,16 +746,21 @@ class TestInvokeCallables:
         mock_plugin.suggest_strategy.return_value = (
             '{"strategy_name": "reductio", "confidence": 0.9}'
         )
+        # #1583: upstream extraction leaks a real LLM call. Patch the
+        # AsyncOpenAI ctor (family a, mechanism M2) so the verdict is decided
+        # by the mocked plugin, not a collateral network call.
         with patch(
             "argumentation_analysis.agents.core.counter_argument.counter_agent.CounterArgumentPlugin",
             return_value=mock_plugin,
-        ):
+        ), patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
             result = await _invoke_counter_argument(
                 "Test", {"phase_quality_output": {"score": 5}}
             )
         assert result["parsed_argument"]["premise"] == "X"
         assert result["suggested_strategy"]["strategy_name"] == "reductio"
         assert result["quality_context"] == {"score": 5}
+        # Bite: the verdict transits the mocked plugin.
+        mock_plugin.parse_argument.assert_called()
 
     async def test_invoke_counter_argument_no_quality_context(self):
         """_invoke_counter_argument handles missing quality context."""
@@ -758,9 +774,10 @@ class TestInvokeCallables:
         with patch(
             "argumentation_analysis.agents.core.counter_argument.counter_agent.CounterArgumentPlugin",
             return_value=mock_plugin,
-        ):
+        ), patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
             result = await _invoke_counter_argument("Test", {})
         assert result["quality_context"] is None
+        mock_plugin.parse_argument.assert_called()
 
     async def test_invoke_debate_analysis(self):
         """_invoke_debate_analysis calls DebatePlugin."""
@@ -908,15 +925,20 @@ class TestInvokeCallables:
         mock_plugin = MagicMock()
         mock_plugin.list_governance_methods.return_value = '["majority", "borda"]'
         mock_plugin.detect_conflicts_fn.return_value = "[]"
+        # #1583: upstream argument extraction leaks a real LLM call. Patch the
+        # AsyncOpenAI ctor (family a, mechanism M2) so the verdict comes from
+        # the mocked plugin, not a collateral network call.
         with patch(
             "argumentation_analysis.plugins.governance_plugin.GovernancePlugin",
             return_value=mock_plugin,
-        ):
+        ), patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
             result = await _invoke_governance("text", {})
         assert result["available_methods"] == ["majority", "borda"]
         assert "conflicts" in result
         assert "extraction_method" in result
         assert result["conflict_count"] == 0
+        # Bite: the verdict transits the mocked plugin.
+        mock_plugin.list_governance_methods.assert_called()
 
     async def test_invoke_governance_emits_degraded_canon_when_verdict_empty_bo2_1472(
         self,
@@ -939,6 +961,8 @@ class TestInvokeCallables:
             ic,
             "_derive_governance_profile",
             return_value=([], [], [], False, "no_preferences_synthetic"),
+        ), patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
         ):
             result = await ic._invoke_governance("text", {})
         # The verdict is honestly degraded.
@@ -975,6 +999,8 @@ class TestInvokeCallables:
             ic,
             "_aggregate_governance_votes",
             return_value=fake_verdict,
+        ), patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
         ):
             result = await ic._invoke_governance("text", {})
         assert result["degraded"] is False
@@ -1047,17 +1073,27 @@ class TestInvokeCallables:
         assert "audio_path" in result["note"]
 
     async def test_invoke_fact_extraction(self):
-        """_invoke_fact_extraction extracts claims from text (LLM or heuristic)."""
+        """_invoke_fact_extraction extracts claims from text (heuristic path)."""
+        # #1583 (family (a) of #1579): the assertion accepted ("llm","heuristic"),
+        # so in CI -- where pytest-dotenv leaks the real key into os.environ --
+        # the text routed to the LLM (2 billed calls) while the verdict did not
+        # depend on it. Same fix as the #1510 sibling
+        # (test_invoke_fact_extraction_empty): patch _get_openai_client so the
+        # heuristic path runs, and tighten the bite to =="heuristic" -- a revert
+        # to the LLM path flips this and fails the test.
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_fact_extraction,
         )
 
         text = "This is a very long claim sentence. Short. Another long enough claim for extraction."
-        result = await _invoke_fact_extraction(text, {})
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(None, ""),
+        ):
+            result = await _invoke_fact_extraction(text, {})
         assert result["claim_count"] >= 1
         assert result["source_length"] == len(text)
-        assert "extraction_method" in result
-        assert result["extraction_method"] in ("llm", "heuristic")
+        assert result["extraction_method"] == "heuristic"
         assert isinstance(result["claims"], list)
         assert isinstance(result.get("arguments", []), list)
         assert isinstance(result.get("fallacies", []), list)
@@ -1092,13 +1128,19 @@ class TestInvokeCallables:
 
         mock_bridge = MagicMock()
         mock_bridge.check_consistency.return_value = (True, "consistent")
+        # #1583: the NL→logic generator runs unconditionally and leaks a real
+        # LLM call for a short input. Patch the AsyncOpenAI ctor (family a,
+        # mechanism M2 — same as the router/conversational concentrateurs) so
+        # the verdict is decided by the mocked bridge alone.
         with patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             return_value=mock_bridge,
-        ):
+        ), patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
             result = await _invoke_propositional_logic("p => q", {})
         assert result["satisfiable"] is True
         assert result["logic_type"] == "propositional"
+        # Bite: the verdict transits the mocked bridge, no LLM path decides it.
+        mock_bridge.check_consistency.assert_called()
 
     async def test_invoke_propositional_logic_error(self):
         """_invoke_propositional_logic fails loud when Tweety unavailable (#1019, #1249).
@@ -1113,7 +1155,7 @@ class TestInvokeCallables:
         with patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             side_effect=RuntimeError("JVM not started"),
-        ):
+        ), patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
             with pytest.raises(RuntimeError, match="Propositional logic"):
                 await _invoke_propositional_logic("p", {})
 
@@ -1148,13 +1190,17 @@ class TestInvokeCallables:
 
         mock_bridge = MagicMock()
         mock_bridge.check_consistency.return_value = (True, "ok")
+        # #1583: patch the AsyncOpenAI ctor (family a, mechanism M2) — the
+        # NL→logic extraction leaks a real LLM call otherwise. The verdict is
+        # decided by the mocked bridge alone.
         with patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             return_value=mock_bridge,
-        ):
+        ), patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
             result = await _invoke_fol_reasoning("forall X: P(X)", {})
         assert result["consistent"] is True
         assert result["confidence"] == 0.8
+        mock_bridge.check_consistency.assert_called()
 
     async def test_invoke_fol_reasoning_inconsistent(self):
         """_invoke_fol_reasoning returns low confidence for inconsistency."""
@@ -1193,7 +1239,7 @@ class TestInvokeCallables:
         with patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             side_effect=Exception("no JVM"),
-        ):
+        ), patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
             result = await _invoke_fol_reasoning("text", {})
         # Now uses Python fallback instead of error dict
         assert result["logic_type"] == "first_order"


### PR DESCRIPTION
## What

Closes #1583 — fix the gate's family-(a) network leaks (collateral LLM calls the test never meant to make, where the verdict does not depend on the model). Follow-up to the measurement in #1579 (74 gate tests, 234 req, ~89% of the gate wall-clock).

## The coord's question answered — typology of the mechanisms

> "combien de mécanismes distincts font qu'un mock ne couvre pas, et un seul en explique-t-il beaucoup ?"

**Two mechanisms, and neither alone explains the cost:**

| Mechanism | What it is | Where it bites | Dominance |
|-----------|------------|----------------|-----------|
| **M1** | Uncovered LLM dependency — mock absent or patched at the wrong level. `pytest-dotenv` leaks the real key into `os.environ`; a permissive assertion accepts the LLM path while the verdict is heuristic. | single-invocable tests (`_invoke_fact_extraction` etc.) | **test count** |
| **M2** | Raw pipeline / invoke_callable runs the NL→logic generator unconditionally; `AsyncOpenAI` is built at dispersed sites (router, nl_to_logic, fallacy adapters, plugins, debate, invoke_callables). Patching one creation point is insufficient. | router, conversational orchestrator, `test_execute_light_workflow`, the logic InvokeCallables | **wall-clock cost** |

**Nuance:** M1 dominates in *number of tests*; M2 dominates in *seconds spent*. A single fix does not cover both. M1 gets `patch _get_openai_client` (the #1510 pattern already in-tree); M2 gets `patch openai.AsyncOpenAI` ctor → raise, which cuts every dispersed creation site at once (probe-confirmed: light/standard/full still map phases + workflow_name, no network).

## Both frontiers ruled

- `test_auto_falls_back_to_standard_on_failure` → **family (a)**. The `workflow_name == "standard_analysis"` verdict is pure routing fallback, not LLM-gated.
- `test_execute_light_workflow` → **family (a)**. Phase status `COMPLETED` is reached via the honest-degraded path; it never depended on the leaked calls (proven: with the ctor patched, the two phases still complete).

## Each fixed test bites

- M2 concentrateurs: `assert_called()` on the mocked plugin/bridge — the verdict transits the mock, never an LLM path.
- M1 (`test_invoke_fact_extraction`): tightened `extraction_method == "heuristic"` (was `in ("llm", "heuristic")`) — the permissive assertion that masked the leak.
- Router: `workflow_name == f"{name}_analysis"` — proves routing decided, not a model call.

Remove any patch and the leak resumes (measurable).

## Measured hermeticity (0 external requests — plugin reusing #1579)

| Test | Before | After |
|------|--------|-------|
| `test_existing_workflow_names_unchanged` | 20 req / 122 s | 0 / ~7 s |
| `test_auto_falls_back_to_standard_on_failure` | 8 req / 47 s | 0 |
| `TestRunConversationalAnalysis` (3 patched brothers of the school case) | leaks | 0 (2.5 s for the class) |
| `TestInvokeCallables` (9 patched) | ~10 req / 72 s | 0 (3.2 s for the class) |
| `test_execute_light_workflow` | 4 req / 47 s | 0 / 8 s |

~50 requests removed; the headline concentrateur drops from 122 s to ~14 s. Post-black smoke: 33 patched tests pass.

## Scope discipline (anti-pendule)

- No `requires_api`/`slow`/`skip`/`xfail` markers added — family (a) only. Family (b) (legitimately online tests that are mis-marked) stays **#1582's lane**.
- **No production change** — the real orchestration path (#1578 / C2 #1500) is untouched.
- No global network block added; no hard-to-mock test deleted; no real call replaced by a mock that asserts nothing.
- Temp measurement scaffolding deleted; nothing committed but the 3 test files.

## Files changed

- `tests/.../orchestration/test_router.py` — 2 tests
- `tests/.../orchestration/test_conversational_orchestrator.py` — 3 tests
- `tests/.../orchestration/test_unified_pipeline.py` — 10 tests (9 InvokeCallables + `test_execute_light_workflow`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
