### PR TITLE
test(orchestration): extend family-(a) gate-leak sweep to the P2 files (#1583)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_auto_evaluate_governance.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_auto_evaluate_governance.py
@@ -170,6 +170,8 @@ class TestGovernanceAutoVote:
         ), patch(
             "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
             return_value=(None, None),
+        ), patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
         ):
             context = {
                 "phase_extract_output": {
@@ -181,9 +183,27 @@ class TestGovernanceAutoVote:
                 },
                 "phase_quality_output": {
                     "per_argument_scores": {
-                        "arg_1": {"scores_par_vertu": {"clarte": 9.0, "pertinence": 4.0, "structure": 3.0}},
-                        "arg_2": {"scores_par_vertu": {"clarte": 5.0, "pertinence": 8.0, "structure": 7.0}},
-                        "arg_3": {"scores_par_vertu": {"clarte": 2.0, "pertinence": 6.0, "structure": 5.0}},
+                        "arg_1": {
+                            "scores_par_vertu": {
+                                "clarte": 9.0,
+                                "pertinence": 4.0,
+                                "structure": 3.0,
+                            }
+                        },
+                        "arg_2": {
+                            "scores_par_vertu": {
+                                "clarte": 5.0,
+                                "pertinence": 8.0,
+                                "structure": 7.0,
+                            }
+                        },
+                        "arg_3": {
+                            "scores_par_vertu": {
+                                "clarte": 2.0,
+                                "pertinence": 6.0,
+                                "structure": 5.0,
+                            }
+                        },
                     }
                 },
             }
@@ -215,6 +235,8 @@ class TestGovernanceAutoVote:
         ), patch(
             "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
             return_value=(None, None),
+        ), patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
         ):
             context = {
                 "phase_extract_output": {"arguments": [{"text": "Single arg"}]},

--- a/tests/unit/argumentation_analysis/orchestration/test_conversational_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversational_spectacular.py
@@ -28,6 +28,14 @@ def mock_conversational_deps():
         ".create_conversational_agents"
     ) as mock_create, patch.dict(
         "os.environ", {"OPENAI_API_KEY": "test-key", "OPENAI_CHAT_MODEL_ID": "test"}
+    ), patch(
+        # #1583: family-(a) — the orchestrator builds an AsyncOpenAI client at
+        # a dispersed site (not via the mocked sk kernel); patch the ctor
+        # (mechanism M2) so a collateral LLM call cannot leak. The verdict
+        # (workflow_name / unified_state type / capabilities) is decided by
+        # the mocked _run_phase, not the model.
+        "openai.AsyncOpenAI",
+        side_effect=RuntimeError("no-network-1583"),
     ):
         mock_kernel = MagicMock()
         mock_sk.Kernel.return_value = mock_kernel

--- a/tests/unit/argumentation_analysis/orchestration/test_dag_formal_logic_union_ll.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dag_formal_logic_union_ll.py
@@ -48,9 +48,9 @@ class TestDagPlUnionsAndDoesNotShortCircuit:
             calls["client"] += 1
             return (None, None)  # client unavailable → 2-pass body is a no-op
 
-        with patch.object(
-            mod, "_get_openai_client", side_effect=_fake_client
-        ), patch(_BRIDGE, side_effect=RuntimeError("no JVM")):
+        with patch.object(mod, "_get_openai_client", side_effect=_fake_client), patch(
+            _BRIDGE, side_effect=RuntimeError("no JVM")
+        ):
             with pytest.raises(RuntimeError, match="Tweety solvers failed"):
                 await mod._invoke_propositional_logic(
                     _LONG_TEXT, {"formulas": ["a", "b"]}
@@ -84,9 +84,9 @@ class TestDagPlUnionsAndDoesNotShortCircuit:
             },
             "phase_extract_output": {"arguments": [{"text": "arg one"}]},
         }
-        with patch.object(
-            mod, "_get_openai_client", side_effect=_fake_client
-        ), patch(_BRIDGE, side_effect=RuntimeError("no JVM")):
+        with patch.object(mod, "_get_openai_client", side_effect=_fake_client), patch(
+            _BRIDGE, side_effect=RuntimeError("no JVM")
+        ):
             with pytest.raises(RuntimeError, match="Tweety solvers failed"):
                 await mod._invoke_propositional_logic(_LONG_TEXT, context)
 
@@ -109,9 +109,9 @@ class TestDagFolUnionsAndDoesNotShortCircuit:
             calls["client"] += 1
             return (None, None)
 
-        with patch.object(
-            mod, "_get_openai_client", side_effect=_fake_client
-        ), patch(_BRIDGE, side_effect=RuntimeError("no JVM")):
+        with patch.object(mod, "_get_openai_client", side_effect=_fake_client), patch(
+            _BRIDGE, side_effect=RuntimeError("no JVM")
+        ):
             out = await mod._invoke_fol_reasoning(
                 _LONG_TEXT, {"formulas": ["P(a)", "Q(b)"]}
             )
@@ -139,9 +139,9 @@ class TestConversationalPathUnchanged:
             calls["client"] += 1
             return (None, None)
 
-        with patch.object(
-            mod, "_get_openai_client", side_effect=_fake_client
-        ), patch(_BRIDGE, side_effect=RuntimeError("no JVM")):
+        with patch.object(mod, "_get_openai_client", side_effect=_fake_client), patch(
+            _BRIDGE, side_effect=RuntimeError("no JVM")
+        ), patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
             with pytest.raises(RuntimeError, match="Tweety solvers failed"):
                 await mod._invoke_propositional_logic(_LONG_TEXT, {})
 

--- a/tests/unit/argumentation_analysis/orchestration/test_external_solvers.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_external_solvers.py
@@ -13,7 +13,6 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch, AsyncMock
 
-
 # ---------------------------------------------------------------------------
 # Test: _invoke_asp_reasoning (Clingo/ASP)
 # ---------------------------------------------------------------------------
@@ -24,14 +23,13 @@ class TestInvokeASPReasoning:
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_asp_reasoning,
         )
+
         return _invoke_asp_reasoning
 
     def test_fallback_when_no_jvm(self):
         """When no JVM is available, uses Python clingo or heuristic fallback."""
         invoke = self._get_invoke()
-        result = asyncio.get_event_loop().run_until_complete(
-            invoke("a :- b. b.", {})
-        )
+        result = asyncio.get_event_loop().run_until_complete(invoke("a :- b. b.", {}))
         # Either clingo_python (if clingo package available) or heuristic
         assert result["solver"] in ("clingo_python", "clingo_jvm", "heuristic")
 
@@ -46,9 +44,7 @@ class TestInvokeASPReasoning:
     def test_empty_program(self):
         """Handles empty program gracefully."""
         invoke = self._get_invoke()
-        result = asyncio.get_event_loop().run_until_complete(
-            invoke("", {})
-        )
+        result = asyncio.get_event_loop().run_until_complete(invoke("", {}))
         assert "solver" in result
 
     def test_comment_only_program(self):
@@ -64,9 +60,7 @@ class TestInvokeASPReasoning:
     def test_jvm_not_ready_falls_through(self, mock_jvm):
         """When JVM not ready, tries Python clingo then heuristic."""
         invoke = self._get_invoke()
-        result = asyncio.get_event_loop().run_until_complete(
-            invoke("a.", {})
-        )
+        result = asyncio.get_event_loop().run_until_complete(invoke("a.", {}))
         # Either clingo_python or heuristic
         assert result["solver"] in ("clingo_python", "clingo_jvm", "heuristic")
 
@@ -81,14 +75,18 @@ class TestInvokeFOLWithExternalSolvers:
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_fol_reasoning,
         )
+
         return _invoke_fol_reasoning
 
     def test_default_tweety_routing(self):
         """Without fol_solver context, uses TweetyBridge or Python fallback."""
         invoke = self._get_invoke()
-        result = asyncio.get_event_loop().run_until_complete(
-            invoke("test argument", {})
-        )
+        # #1583: family-(a) — short input leaks a real NL→logic LLM call; the
+        # verdict (formulas/logic_type) is solver routing, not model-gated.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
+            result = asyncio.get_event_loop().run_until_complete(
+                invoke("test argument", {})
+            )
         assert "formulas" in result
         assert "logic_type" in result
         assert result["logic_type"] == "first_order"
@@ -101,16 +99,22 @@ class TestInvokeFOLWithExternalSolvers:
         """When fol_solver=eprover, routes to EProver."""
         # Mock the FOLHandler and its method
         mock_instance = MagicMock()
-        mock_instance._fol_check_consistency_with_eprover.return_value = (True, "Consistent")
+        mock_instance._fol_check_consistency_with_eprover.return_value = (
+            True,
+            "Consistent",
+        )
         mock_handler_cls.return_value = mock_instance
 
         # Patch the import within the function
         invoke = self._get_invoke()
-        with patch.dict("sys.modules", {
-            "argumentation_analysis.agents.core.logic.fol_handler": MagicMock(
-                FOLHandler=mock_handler_cls
-            ),
-        }):
+        with patch.dict(
+            "sys.modules",
+            {
+                "argumentation_analysis.agents.core.logic.fol_handler": MagicMock(
+                    FOLHandler=mock_handler_cls
+                ),
+            },
+        ):
             result = asyncio.get_event_loop().run_until_complete(
                 invoke("test", {"fol_solver": "eprover", "formulas": ["P(X)"]})
             )
@@ -119,18 +123,22 @@ class TestInvokeFOLWithExternalSolvers:
     def test_eprover_fallback_on_import_error(self):
         """When EProver handler can't be imported, falls back to Tweety."""
         invoke = self._get_invoke()
-        result = asyncio.get_event_loop().run_until_complete(
-            invoke("test argument", {"fol_solver": "eprover"})
-        )
+        # #1583: family-(a) — verdict (fallback result) is local; patch ctor.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
+            result = asyncio.get_event_loop().run_until_complete(
+                invoke("test argument", {"fol_solver": "eprover"})
+            )
         # Should still produce a result (fallback to Tweety or Python)
         assert "formulas" in result or "error" in result
 
     def test_prover9_solver_choice_fallback(self):
         """When fol_solver=prover9 but Prover9 unavailable, falls back."""
         invoke = self._get_invoke()
-        result = asyncio.get_event_loop().run_until_complete(
-            invoke("test argument", {"fol_solver": "prover9"})
-        )
+        # #1583: family-(a) — verdict (fallback result) is local; patch ctor.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
+            result = asyncio.get_event_loop().run_until_complete(
+                invoke("test argument", {"fol_solver": "prover9"})
+            )
         # Should produce a result either way
         assert isinstance(result, dict)
 
@@ -145,6 +153,7 @@ class TestInvokeModalWithSPASS:
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_modal_logic,
         )
+
         return _invoke_modal_logic
 
     # #1279 (2ccb1de3): a modal KB is supplied through ``context['formulas']``
@@ -209,6 +218,7 @@ class TestInvokeModalWithSPASS:
 class TestInvokeSAT:
     def _get_invoke(self):
         from argumentation_analysis.orchestration.invoke_callables import _invoke_sat
+
         return _invoke_sat
 
     def test_sat_solve(self):

--- a/tests/unit/argumentation_analysis/orchestration/test_nl_to_logic_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_nl_to_logic_wiring.py
@@ -104,8 +104,13 @@ class TestPropositionalLogicNLWiring:
             },
         )
 
-        # Mock TweetyBridge since fallback path calls check_consistency
-        with patch(TWEETY_BRIDGE_PATH) as MockBridge:
+        # Mock TweetyBridge since fallback path calls check_consistency.
+        # #1583: family-(a) — the 2-pass NL→logic generator leaks a real LLM
+        # call; the verdict (logic_type/formulas) is template/bridge logic,
+        # not model-gated. Patch the AsyncOpenAI ctor (mechanism M2).
+        with patch(TWEETY_BRIDGE_PATH) as MockBridge, patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ):
             MockBridge.return_value.check_consistency.return_value = (
                 True,
                 "consistent",

--- a/tests/unit/argumentation_analysis/orchestration/test_pipeline_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_pipeline_wiring.py
@@ -157,6 +157,8 @@ class TestQualityFallacyCrossReference:
             "argumentation_analysis.orchestration.unified_pipeline._llm_enrich_quality",
             new_callable=AsyncMock,
             return_value=None,
+        ), patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
         ):
             result = await _invoke_quality_evaluator("test", context)
 
@@ -191,6 +193,8 @@ class TestQualityFallacyCrossReference:
             "argumentation_analysis.orchestration.unified_pipeline._llm_enrich_quality",
             new_callable=AsyncMock,
             return_value=None,
+        ), patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
         ):
             result = await _invoke_quality_evaluator("test", context)
 
@@ -222,6 +226,8 @@ class TestQualityFallacyCrossReference:
             "argumentation_analysis.orchestration.unified_pipeline._llm_enrich_quality",
             new_callable=AsyncMock,
             return_value=None,
+        ), patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
         ):
             result = await _invoke_quality_evaluator("test", context)
 
@@ -388,8 +394,12 @@ class TestCounterArgumentCrossKB:
             },
         }
 
-        # Without LLM, result still contains quality_context
-        result = await _invoke_counter_argument("test", context)
+        # #1583: family-(a) — the verdict (quality_context read from the
+        # upstream phase) is local to the context, not model-gated. Patch the
+        # AsyncOpenAI ctor (mechanism M2) so a collateral extraction/enrichment
+        # call cannot leak; the assertions below still hold.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
+            result = await _invoke_counter_argument("test", context)
         assert "quality_context" in result
         assert result["quality_context"] is not None
 
@@ -409,7 +419,9 @@ class TestCounterArgumentCrossKB:
             "phase_quality_output": {},
         }
 
-        result = await _invoke_counter_argument("test", context)
+        # #1583: family-(a) — verdict is local; patch ctor (mechanism M2).
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
+            result = await _invoke_counter_argument("test", context)
         assert "parsed_argument" in result
 
 
@@ -445,7 +457,9 @@ class TestGovernanceCrossKB:
             "phase_jtms_output": {},
         }
 
-        result = await _invoke_governance("test", context)
+        # #1583: family-(a) — verdict is local; patch ctor (mechanism M2).
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
+            result = await _invoke_governance("test", context)
         assert "available_methods" in result
 
     async def test_governance_reads_quality_and_fallacies(self):
@@ -478,7 +492,9 @@ class TestGovernanceCrossKB:
             },
         }
 
-        result = await _invoke_governance("test", context)
+        # #1583: family-(a) — verdict is local; patch ctor (mechanism M2).
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
+            result = await _invoke_governance("test", context)
         assert "available_methods" in result
 
 
@@ -526,7 +542,9 @@ class TestDebateCrossKB:
             },
         }
 
-        result = await _invoke_debate_analysis("test", context)
+        # #1583: family-(a) — verdict is local; patch ctor (mechanism M2).
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
+            result = await _invoke_debate_analysis("test", context)
         # Basic structure check — LLM enrichment won't fire without API key
         assert (
             "argument_scores" in result

--- a/tests/unit/argumentation_analysis/test_counter_strategy_selector.py
+++ b/tests/unit/argumentation_analysis/test_counter_strategy_selector.py
@@ -12,7 +12,6 @@ import pytest
 import json
 from unittest.mock import patch, MagicMock
 
-
 # ---------------------------------------------------------------------------
 # CLI argument parsing
 # ---------------------------------------------------------------------------
@@ -126,6 +125,12 @@ class TestCounterStrategyConsumer:
         with patch(
             "argumentation_analysis.agents.core.counter_argument.counter_agent.CounterArgumentPlugin",
             return_value=mock_plugin,
+        ), patch(
+            # #1583: family-(a) — collateral LLM enrichment leaks; the verdict
+            # (suggested_strategy override from context) is local, not model-
+            # gated. Patch the AsyncOpenAI ctor (mechanism M2).
+            "openai.AsyncOpenAI",
+            side_effect=RuntimeError("no-network-1583"),
         ):
             result = await _invoke_counter_argument("Test argument", {})
 
@@ -151,6 +156,12 @@ class TestCounterStrategyConsumer:
         with patch(
             "argumentation_analysis.agents.core.counter_argument.counter_agent.CounterArgumentPlugin",
             return_value=mock_plugin,
+        ), patch(
+            # #1583: family-(a) — collateral LLM enrichment leaks; the verdict
+            # (suggested_strategy override from context) is local, not model-
+            # gated. Patch the AsyncOpenAI ctor (mechanism M2).
+            "openai.AsyncOpenAI",
+            side_effect=RuntimeError("no-network-1583"),
         ):
             result = await _invoke_counter_argument("Test argument", context)
 
@@ -176,6 +187,12 @@ class TestCounterStrategyConsumer:
         with patch(
             "argumentation_analysis.agents.core.counter_argument.counter_agent.CounterArgumentPlugin",
             return_value=mock_plugin,
+        ), patch(
+            # #1583: family-(a) — collateral LLM enrichment leaks; the verdict
+            # (suggested_strategy override from context) is local, not model-
+            # gated. Patch the AsyncOpenAI ctor (mechanism M2).
+            "openai.AsyncOpenAI",
+            side_effect=RuntimeError("no-network-1583"),
         ):
             result = await _invoke_counter_argument("Test argument", context)
 
@@ -200,6 +217,12 @@ class TestCounterStrategyConsumer:
         with patch(
             "argumentation_analysis.agents.core.counter_argument.counter_agent.CounterArgumentPlugin",
             return_value=mock_plugin,
+        ), patch(
+            # #1583: family-(a) — collateral LLM enrichment leaks; the verdict
+            # (suggested_strategy override from context) is local, not model-
+            # gated. Patch the AsyncOpenAI ctor (mechanism M2).
+            "openai.AsyncOpenAI",
+            side_effect=RuntimeError("no-network-1583"),
         ):
             result = await _invoke_counter_argument("Test argument", context)
 

--- a/tests/unit/argumentation_analysis/test_ra8_anti_theater.py
+++ b/tests/unit/argumentation_analysis/test_ra8_anti_theater.py
@@ -110,7 +110,12 @@ class TestBipolarFailLoud:
         # Force the handler import to fail (JVM-unavailable scenario) — on a
         # JVM-available machine (CI/agent) the real handler would run and never
         # fail-loud, so we mock it to fail exactly as the file docstring says.
-        with patch.dict(
+        # #1583: family-(a) — a collateral LLM call leaks before the import
+        # fails; the verdict (RuntimeError) depends on the import, not the
+        # model. Patch the AsyncOpenAI ctor (mechanism M2).
+        with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ), patch.dict(
             sys.modules,
             {"argumentation_analysis.agents.core.logic.bipolar_handler": None},
         ):
@@ -120,7 +125,11 @@ class TestBipolarFailLoud:
 
 class TestABAFailLoud:
     def test_raises_runtime_error(self):
-        with patch.dict(
+        # #1583: family-(a) — collateral LLM leak before the import fails; the
+        # verdict (RuntimeError) depends on the import, not the model.
+        with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ), patch.dict(
             sys.modules,
             {"argumentation_analysis.agents.core.logic.aba_handler": None},
         ):
@@ -140,7 +149,11 @@ class TestADFFailLoud:
 
 class TestASPICFailLoud:
     def test_raises_runtime_error(self):
-        with patch.dict(
+        # #1583: family-(a) — collateral LLM leak before the import fails; the
+        # verdict (RuntimeError) depends on the import, not the model.
+        with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ), patch.dict(
             sys.modules,
             {"argumentation_analysis.agents.core.logic.aspic_handler": None},
         ):
@@ -327,8 +340,13 @@ class TestStateWriterGuard:
         )
 
         mock_state = MagicMock()
-        # Invoke raises RuntimeError (as it does now when JVM unavailable)
-        with patch.dict(
+        # Invoke raises RuntimeError (as it does now when JVM unavailable).
+        # #1583: family-(a) — a collateral LLM call leaks before the import
+        # fails; the verdict (RuntimeError) depends on the import, not the
+        # model. Patch the AsyncOpenAI ctor (mechanism M2).
+        with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ), patch.dict(
             sys.modules,
             {
                 "argumentation_analysis.agents.core.logic.aba_handler": None,


### PR DESCRIPTION
## What

Follow-up to PR #1584 (the three cost concentrateurs of #1583). Sweeps the **remaining family-(a) files** identified in the #1579 measurement. Same mechanism **M2** (dispersed `AsyncOpenAI` creation sites), same unifying fix: patch the `openai.AsyncOpenAI` ctor to raise.

Refines #1583 (does not close it — the parent issue tracks the full picture across #1584 + this).

## 27 tests hermetized (0 external requests, plugin reusing #1579)

| File | Tests | Nature of the verdict (local, not model-gated) |
|------|-------|------------------------------------------------|
| `test_pipeline_wiring.py` | 8 | quality/counter/governance/debate cross-KB logic on the upstream context |
| `test_external_solvers.py` | 3 | FOL solver routing (`formulas`/`logic_type`) |
| `test_nl_to_logic_wiring.py` | 1 | PL template/bridge logic |
| `test_dag_formal_logic_union_ll.py` | 1 | the 2-pass regression guard — **already patched `_get_openai_client` but still leaked 4 req** (direct proof of M2: sites outside `_get_openai_client`). `calls["client"] >= 1` still bites. |
| `test_auto_evaluate_governance.py` | 2 | governance formal vote aggregation |
| `test_conversational_spectacular.py` | 4 | fixture now patches the ctor — verdict (`workflow_name`/state type) decided by mocked `_run_phase` |
| `test_counter_strategy_selector.py` | 4 | strategy override from context — local |
| `test_ra8_anti_theater.py` | 4 | FailLoud — a collateral LLM call leaked before the handler import failed; `RuntimeError` depends on the import, not the model |

~32 requests removed; the P2 group drops from ~215 s to ~10 s.

## One frontier ruled family (b) — NOT fixed here

`test_auto_evaluate_governance.py::test_invoke_counter_includes_evaluation`. Its verdict (`evaluation.overall_score`) depends on a **second LLM enrichment path** (`invoke_callables` L1224) that builds its own client outside the mocked `_get_openai_client`. Patching the ctor makes the test **fail** (`"LLM counter-argument enrichment failed"`) — proving the verdict genuinely depends on the model. That is family (b) (legitimately online, mis-marked) → **lane #1582**.

This is exactly the (a)/(b) discrimination the coord's dispatch called for: *"le verdict dépend-il de ce que le modèle a répondu ?"*

## Scope discipline (anti-pendule)

- No `requires_api`/`slow`/`skip`/`xfail` markers added — family (a) only. Family (b) stays #1582's lane.
- **No production change.**
- Each fixed test bites on the mocked plugin/bridge/context (`assert_called` / `calls["client"] >= 1` / `pytest.raises` / local verdict assertions).
- Temp measurement scaffolding deleted; nothing committed but the 8 test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
