### PR TITLE
test(gate): remove the stale collect_ignore hiding 142 tests from the gate (#1586)

### DIFF
--- a/tests/unit/argumentation_analysis/pipelines/conftest.py
+++ b/tests/unit/argumentation_analysis/pipelines/conftest.py
@@ -1,8 +1,0 @@
-# conftest.py for tests/unit/argumentation_analysis/pipelines/
-# Exclude test_unified_pipelines.py from collection — JPype DLL crash on Windows
-# + broken import get_fallacy_detector cascading to all orchestration subpackages.
-# The module targets the legacy router argumentation_analysis.pipelines.unified_pipeline
-# (NOT the active orchestration/unified_pipeline.py).
-# B-03 audit #814 — 88 tests archived (0 collected due to collection error).
-
-collect_ignore = ["test_unified_pipelines.py"]


### PR DESCRIPTION
## What

Closes #1586. Removes `tests/unit/argumentation_analysis/pipelines/conftest.py`, whose only active line was `collect_ignore = ["test_unified_pipelines.py"]`.

That single line kept **142 tests out of the gate** — not skipped, *absent*. `collect_ignore` drops the module before collection, so it produces no skip line, no warning, and no junit entry. Nothing in any CI report signalled the loss.

## Measured

| Control | Result |
|---|---|
| `pytest tests/unit --collect-only` + `grep -c "test_unified_pipelines.py::"` — before | **0** |
| Same, after this change | **142** |
| Total collected over `tests/unit` — before / after | **13733 → 13875, exactly +142** |
| The module run on its own (Windows, `projet-is-roo-new`) | **142 passed in 8.04 s** |

The delta is the falsifiable control: any number other than +142 would mean something else moved.

## The three reasons in the conftest header no longer hold

Header written at `706ee3d3` (2026-06-01, B-03 audit #814):

1. *"JPype DLL crash on Windows"* — no crash; the module runs in 8 s on Windows.
2. *"broken import get_fallacy_detector cascading to all orchestration subpackages"* — the module now carries its own `_ensure_uta_importable()` shim addressing exactly that.
3. *"88 tests archived (0 collected due to collection error)"* — 142 collected, 142 green, no error.

The exclusion was likely correct two months ago. It stopped describing the file it excludes.

## Why it matters beyond the count

Two PRs merged this week edit this module believing they repair gate tests: `4c42277d` (#1574 → #1577) and `217de13e` (#1578 → #1581). Their green CI could not have caught a defect in the changed lines, because those tests do not run in CI.

It also re-explains #1578's original symptom. "Red on the worker's machine, green in CI" was attributed to the test's verdict being rendered by a model. That finding stands on its own — the test really did bill 5 LLM calls and really did contradict its twin. But the CI/worker divergence had a structural cause we had not found: green in CI because the module never runs there. The worker saw red because they named the file explicitly, which pytest honours over `collect_ignore`.

And it retires point 3 of #1579: there is no import pollution to bisect. Under a full-tree run the module is never imported at all.

Same family as the JVM guard before #1557, which read `0 / 0` and reported nothing to see: **an absence that looks like a success**, invisible to the tally because the tally counts what was collected.

## Files removed and why

| File | Role | Reason |
|---|---|---|
| `tests/unit/argumentation_analysis/pipelines/conftest.py` | test config | Contained only a stale `collect_ignore` plus its explanatory header; all three stated reasons are contradicted by measurement above. No fixtures, no hooks, nothing else depended on it. |

## Anti-pendule

If CI turns red on any of the 142, the answer is **not** to restore the blanket exclusion — read what actually fails and fix it. Excluding a whole module is what produced this issue. Equally, marking the module `slow` or `requires_api` would be the same move under a nicer name: it runs in 8 s and, since #1581, makes no network call.

## Note on scope

`pytest.ini:5` carries a second silent exclusion (`--ignore=tests/unit/api/test_analysis_service_mock.py`, 1 test). Same mechanism, much smaller stake; flagged in #1586, not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
