### PR TITLE
test(gate): make two gate assertions falsifiable (#1588)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_external_solvers.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_external_solvers.py
@@ -139,8 +139,19 @@ class TestInvokeFOLWithExternalSolvers:
             result = asyncio.get_event_loop().run_until_complete(
                 invoke("test argument", {"fol_solver": "prover9"})
             )
-        # Should produce a result either way
-        assert isinstance(result, dict)
+        # #1588: the previous sole assertion was ``isinstance(result, dict)``,
+        # which no state of the code could falsify — every return path of
+        # ``_invoke_fol_reasoning`` returns a dict. Assert instead the property
+        # the name promises: the prover9 choice is routed away (fallback) and
+        # still terminates on a rendered FOL outcome rather than an arbitrary
+        # mapping. All four return paths carry ``fol_status``/``logic_type``,
+        # so this holds whichever backend the runner ends up using.
+        assert result["logic_type"] == "first_order"
+        assert result["fol_status"], "no FOL status rendered — routing did not complete"
+        assert "prover9" not in str(result.get("message", "")).lower(), (
+            "Prover9 reported as the engine that ran — the test is named for the "
+            "fallback; if Prover9 is now wired, rename it and assert the verdict."
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/argumentation_analysis/orchestration/test_pipeline_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_pipeline_wiring.py
@@ -542,12 +542,47 @@ class TestDebateCrossKB:
             },
         }
 
-        # #1583: family-(a) — verdict is local; patch ctor (mechanism M2).
+        # #1588: this test is named for the cross-KB read (#289), which lives
+        # inside ``if client:`` in ``_invoke_debate_analysis``. Killing the
+        # constructor (#1583) made the client falsy, so the run fell to the
+        # heuristic branch and the cross-KB code never executed — measured:
+        # dropping ``phase_quality_output`` or ``phase_jtms_output`` entirely
+        # left the output byte-identical. The old assertion could not catch it
+        # (neither ``argument_scores`` nor ``scores`` is ever a key of the
+        # result, so the trailing ``isinstance(result, dict)`` carried it and
+        # no state of the code could falsify it).
+        #
+        # Stay hermetic — no network — but with a *live* fake client, so the
+        # named path runs and the prompt it builds can be inspected.
+        captured = {}
+
+        async def _fake_create(**kwargs):
+            captured["user"] = kwargs["messages"][1]["content"]
+            response = MagicMock()
+            choice = MagicMock()
+            choice.message.content = '{"debate_quality": 3, "winner": "draw"}'
+            response.choices = [choice]
+            return response
+
+        fake_client = MagicMock()
+        fake_client.chat.completions.create = AsyncMock(side_effect=_fake_create)
+
+        import argumentation_analysis.orchestration.invoke_callables as _mod
+
         with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")):
-            result = await _invoke_debate_analysis("test", context)
-        # Basic structure check — LLM enrichment won't fire without API key
-        assert (
-            "argument_scores" in result
-            or "scores" in result
-            or isinstance(result, dict)
-        )
+            with patch.object(
+                _mod, "_get_openai_client", return_value=(fake_client, "fake-model")
+            ):
+                result = await _invoke_debate_analysis("test", context)
+
+        prompt = captured.get("user", "")
+        assert prompt, "the debate never reached the LLM path — cross-KB read skipped"
+        # Quality scores were read: note_finale and the fallacy penalty marker.
+        assert "QUALITY SCORES:" in prompt
+        assert "9.0/10" in prompt
+        assert "[PENALIZED by fallacy]" in prompt
+        # JTMS was read: the invalid belief is surfaced as retracted, and the
+        # formal_consistency=False flag raises the inconsistency warning.
+        assert "RETRACTED BELIEFS (JTMS): Argument with low quality" in prompt
+        assert "Formal inconsistency detected" in prompt
+        assert isinstance(result, dict)


### PR DESCRIPTION
Closes #1588.

Two gate assertions could not be falsified by any state of the code. Both are now tightened onto the property their name promises. **No test added or removed — expected tally delta 0.**

## Le contrôle, pas la lecture

Le motif syntaxique ne tranche pas ; la **substitution dégénérée** tranche. Avec le callable de production stubbé pour renvoyer `{}` :

| État | Production renvoie `{}` | Production réelle |
|---|---|---|
| Avant (`adc6ed0e`) | **2 passed** — aucune assertion ne mord | 2 passed |
| Après (cette PR) | **2 failed** — les deux mordent | **2 passed** |

La colonne du milieu est la seule qui prouve quoi que ce soit. Les deux tests passaient avec un corps de fonction vidé.

## `test_debate_reads_quality_and_jtms`

Le read cross-KB dont le test porte le nom vit **dans `if client:`** (`_invoke_debate_analysis`, `invoke_callables.py:1495-1501`). Le patch du constructeur `AsyncOpenAI` rend le client falsy ⇒ la branche heuristique est prise et **le code nommé ne s'exécute jamais**.

Mesuré : retirer entièrement `phase_quality_output` **ou** `phase_jtms_output` laisse la sortie **strictement identique** —

```
FULL   : {"logical_coherence":0.5, ..., "debate_quality":3.05, "debate_quality_source":"heuristic"}
NO_QUAL: idem, delta = {}
NO_JTMS: idem, delta = {}
```

L'invariance parfaite d'une sortie entre présence et absence de l'entrée qu'elle est censée lire = elle ne la lit pas. L'ancienne assertion ne pouvait pas le voir : ni `argument_scores` ni `scores` n'est **jamais** une clé du résultat (clés réelles : `logical_coherence`, `evidence_quality`, `relevance_score`, `persuasiveness`, `emotional_appeal`, `fact_check_score`, `novelty_score`, `readability_score`, `debate_quality`, `debate_quality_source`), donc les deux premiers disjoints étaient **toujours faux** et le `isinstance(result, dict)` terminal portait le test à lui seul.

Le fix garde l'hermétisation (aucun réseau) mais avec un **faux client vivant** au lieu d'un constructeur mort, pour que le chemin nommé s'exécute, puis assert que les scores de qualité et les croyances JTMS **atteignent effectivement le prompt** (`QUALITY SCORES:`, `9.0/10`, `[PENALIZED by fallacy]`, `RETRACTED BELIEFS (JTMS): …`, `Formal inconsistency detected`).

⚠️ **C'est une couverture déplacée par l'hermétisation, pas une assertion simplement faible.** #1585 a hermétisé correctement au regard de son propre objectif ; l'effet de bord est que ce test a changé de chemin sans que rien ne rougisse — parce que l'assertion était tautologique. Hermétiser un test à assertion tautologique le rend *plus* creux : avant, la lenteur prouvait au moins qu'un chemin réel tournait.

## `test_prover9_solver_choice_fallback`

Seule assertion : `isinstance(result, dict)`. Les **quatre** chemins de retour de `_invoke_fol_reasoning` renvoient un dict ⇒ inréfutable.

Mesuré avec `fol_solver="prover9"` : `fol_status='decided'`, `message='FOL consistency check (EProver): consistent'`, `consistent=True`. Le repli a bien lieu — mais l'assertion ne pouvait pas le distinguer du cas où Prover9 aurait tourné. Les quatre chemins portent `fol_status` et `logic_type`, donc les nouvelles assertions tiennent quel que soit le backend du runner.

## Constats adjacents — signalés, non corrigés

Périmètre tenu volontairement à l'assertion ; ces trois points sont du code de production ou d'autres périmètres :

1. **Le choix de solveur ne laisse pas de trace dans la sortie FOL.** `fol_metadata_shared["fol_solver"] = fol_solver_choice` est bien posé en amont, mais `fol_metadata` observé ne contient que `sorts`/`predicates`/`constants`/`variables`/`signature_lines`. Le sélecteur paramétrique `--fol-solver` n'est donc pas observable en aval — à traiter séparément si on veut pouvoir l'asserter.
2. **`libs/prover9/bin/prover9.exe` est vendoré et tracké.** La prémisse « Prover9 unavailable » du nom du test est peut-être périmée ; la nouvelle assertion la rend explicite (message d'échec dédié) au lieu de la laisser invérifiable.
3. **Recensement : 66 candidats** (`assert isinstance(x, <type large>)` seul, ou `or isinstance(...)` terminal, sans autre contrôle) sur `tests/unit/`. **Borne supérieure, pas un compte de défauts** — sur 8 lus en échantillon, 4 portaient un contrôle réel que le scan AST ne compte pas (`mock.assert_called_once()`, `assert_valid_result(...)` sont des *appels*, pas des nœuds `ast.Assert`), 1 mord via l'absence d'exception. Le scan est un générateur de candidats ; seule la substitution tranche. Liste complète en commentaire sur #1588. Cinq candidats tombent dans le périmètre de #1582 (`test_mute_capabilities_b02.py`, `test_workflow_state_integration.py`) — **non touchés ici** pour ne pas collisionner.

## Validation

- `test_pipeline_wiring.py` + `test_external_solvers.py` : **43 passed** en 7 s
- `black --check` : 2 files unchanged · `flake8` : clean
- Aucun test ajouté ni retiré ⇒ **delta de tally attendu : 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
