### PR TITLE
test(gate): mark the single family-(b) FOL test requires_api (#1582)

### DIFF
--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -1377,6 +1377,7 @@ class TestFOLValueGate:
             f"FOL degraded message must state unavailability, got {message!r} (#1278)."
         )
 
+    @pytest.mark.requires_api
     async def test_fol_consistent_is_bool_when_tweety_available(self):
         """When Tweety path succeeds, 'consistent' must be a real bool.
 
@@ -1384,6 +1385,20 @@ class TestFOLValueGate:
         consistent as a proper boolean (not None, not missing), and
         formulas must be non-empty -- this is the regression guard
         against silently losing all verified formulas.
+
+        #1582 family-(b): the ``len(formulas) > 0`` verdict genuinely
+        depends on a real LLM response. FOL has NO template fallback (the
+        Asserted(argN) fabrication was removed in #1278), so the NL
+        translator is the ONLY source of formulas. Falsified by degenerate
+        substitution (#1589 method): under an empty model response this test
+        FAILS (formulas=[]), whereas all 9 sibling value_gates tests in the
+        #1582 perimeter PASS (their verdicts are structural / exception /
+        PL-template-fallback, model-independent → family (a), listed in the
+        PR). The test mocks ``_get_openai_client`` to ``(None, None)`` but a
+        dispersed direct ``AsyncOpenAI()`` construction bypasses it (#1583
+        M2) — that leaked call's output is what the assertion reads. Marking
+        ``requires_api`` removes this single family-(b) test from the gate;
+        it runs developer-local with a key (no CI lane runs requires_api).
         """
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_fol_reasoning,


### PR DESCRIPTION
# #1582 — Sortir du gate les tests dont le verdict dépend vraiment d'un LLM (famille b)

Closes #1582.

## Méthode

Discriminateur #1579/#1582 appliqué **test par test** aux 21 tests de la baseline qui touchent `api.openai.com`, **falsifié par substitution dégénérée** (méthode #1589) : un plugin intercepte les `httpx` sends vers `*.openai.com` et retourne une réponse chat-completion **valide mais vide**. Le test qui **passe quelle que soit la sortie** a un verdict modèle-indépendant → **(a)** ; celui qui **échoue** a un verdict qui dépend d'une vraie sortie LLM → **(b)**.

> Le probe « tuer le ctor » testait « a besoin d'UN modèle » ; le discriminateur exige « a besoin d'une BONNE sortie ». Le stub dégénéré au niveau httpx est la bonne falsification, et elle couvre tous les chemins (openai direct, SK, `_get_openai_client`) puisqu'ils passent tous par httpx.

## Résultat : 1 (b) sur 21

| # | Test | req | verdict | falsification | famille |
|---|------|----|---------|---------------|---------|
| 1 | `test_value_gates.py::…::test_fol_consistent_is_bool_when_tweety_available` | 2 | `len(formulas) > 0` | **FAIL** (FOL sans template depuis #1278, NL = seule source) | **(b) marqué** |
| 2 | `test_benchmark_conversational.py::…::test_conversational_fallback_on_error` | 93 | `workflow_name` contient "standard" | PASS (verdict = **routage** de fallback conversational→standard) | (a) |
| 3 | `test_value_gates.py::…::test_fol_degraded_message_is_honest` | 5 | `consistent is None` + msg "unavailable" | PASS (forcé par Tweety raise) | (a) |
| 4 | `test_value_gates.py::…::test_pl_fallback_raises_fail_loud` | 4 | `RuntimeError` | PASS (forcé par patch) | (a) |
| 5-10 | `*_fallback_raises_fail_loud` (setaf/weighted/bipolar/aba/aspic) | 1 each | `RuntimeError` | PASS (forcé par patch) | (a) |
| 11 | `test_value_gates.py::…::test_fol_fallback_reports_honest_unavailable` | 2 | `consistent is None` | PASS (forcé par Tweety raise) | (a) |
| 12 | `test_value_gates.py::…::test_pl_satisfiable_is_bool_when_tweety_available` | 2 | `formulas > 0` | PASS (**PL a un template fallback** `_pl_atom`) | (a) |
| 13-14 | `test_invoke_*_error_fallback` (formal_verification) | 2 each | tag `logic_type` | PASS (structurel) | (a) |
| 15-16 | `test_template_counter[_set]` (track_mm) | 2 each | clé `template` présente `>= 0` | PASS (structurel) | (a) |
| 17-19 | `TestRunUnifiedAnalysisWithState::*` | 3-4 each | état créé / scores qualité | PASS (structurel ; qualité heuristique) | (a) |
| 20-21 | `TestRealComponentIntegration::*` + `test_start_deliberation` | 1-4 each | status COMPLETED / 202 queued | PASS (structurel) | (a) |

**Leçon** : la prémisse #1579 (« la famille (b) porte l'essentiel du coût ») est renversée par la falsification. Le coût du gate est porté par les fuites **(a)** (le benchmark seul = 35 %), pas par les (b) légitimes. Marquer les (b) est nécessaire mais de faible amplitude ; le vrai levier de coût est la correction des (a) (lane #1583).

## DoD

- **P1 — Justification par test marqué** : `test_fol_consistent_is_bool_when_tweety_available` — son verdict `len(formulas) > 0` échoue sous sortie modèle vide (FOL n'a pas de template fallback depuis #1278 ; la traduction NL est sa seule source de formules). Documenté dans le docstring + ci-dessus.
- **P1 — Où atterrit la couverture déplacée** : **aucune lane CI n'exécute `requires_api`** (ci.yml:140 est le seul run pytest, filtre `-m "not slow and not requires_api"`). Le test marqué ne tourne plus en CI — il s'exécute seulement en local-développeur avec clé. **Perte de couverture CI assumée** (le test est un regression-guard du chemin NL→FOL réel ; sa couverture en CI était déjà fragilisée par la nondéterminisme du modèle). À traiter séparément si une lane `requires_api` cadencée est voulue.
- **P1 — Delta de tally réconcilié** : tests externes **21 → 20** (exactement le test marqué, `1 deselected`). Aucun test apparu. Le delta résiduel de req (141→137) est la fluctuation nondéterministe des fuites (a) restantes (benchmark 93→89, etc.) — un **signal** (DoD), pas le marquage.
- **P1 — Re-mesure après marquage** (même instrumentation #1579, 10 fichiers) :

| | avant | après | delta |
|---|------|------|------|
| tests externes | 21 | 20 | −1 = le marqué |
| requêtes | 141 | 137 | −4 (−2 marqué + −2 nondéterminisme (a)) |
| wall-clock gate (10 fichiers) | 432 s | 371 s | −61 s (surtout nondéterminisme benchmark) |

- **P2 — Wall-clock** : voir ci-dessus ; le marquage lui-même retire ~10 s, le reste est la variance du benchmark (a).
- **P2 — Tests (a) rencontrés, non traités ici** : les 20 tests du tableau ci-dessus (famille a). Le plus saillant est `test_conversational_fallback_on_error` (benchmark, 35 % du gate, #1578-family : le workflow standard de fallback tourne pour de vrai alors que le verdict ne lit que le nom du workflow). À alimenter dans la lane de correction #1583. Note : `test_dag_formal_logic_union_ll.py` était déjà sorti du périmètre (a, corrigé #1585).

## Cibles #1579 non fuyardes dans la re-mesure

`test_mute_capabilities_b02::test_fallback_with_context`, `test_pl_2pass_pipeline::test_fallback_when_no_api_key`, `test_nl_to_logic::test_translate_batch_heuristic` — listées par #1579 mais **non présentes** dans la re-mesure (déjà hermétiques ou chemin sans clé). Non marquées.

## Anti-pendule

- Aucun test (a) marqué. ✓
- Aucun test supprimé. ✓
- Aucun code de production touché. ✓
- ci.yml inchangé. ✓
- Aucun marqueur/skip/xfail ajouté par ailleurs. ✓

## Vérification

`pytest tests/unit/argumentation_analysis/test_value_gates.py -m "requires_api" --co -q` → 1/62 collecté (le marqué). Sous `-m "not requires_api"` → désélectionné.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
