### PR TITLE
test(gate): hermétise the benchmark conversational→standard fallback (#1591)

### DIFF
--- a/tests/unit/argumentation_analysis/evaluation/test_benchmark_conversational.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_benchmark_conversational.py
@@ -102,7 +102,30 @@ class TestRunUnifiedAnalysisConversational:
         assert result["workflow_name"] == "conversational"
 
     async def test_conversational_fallback_on_error(self):
-        """Conversational mode falls back to standard on import/runtime error."""
+        """Conversational mode falls back to standard on import/runtime error.
+
+        #1591 family-(a): the verdict is the conversational→standard ROUTING.
+        ``workflow_name`` in the result comes from ``workflow.name``
+        (unified_pipeline.py:324), i.e. from the workflow object the fallback
+        selects (``catalog["standard"]`` at line 175) — NOT from executing it.
+        The real standard pipeline running end-to-end billed ~94 LLM requests
+        (~35-40 % of the gate, measured #1579) while establishing nothing the
+        assertion reads: the routing property holds in a single string.
+
+        Hermétisé calqué sur #1578/#1581 (correct the path, add a structural
+        bite): the standard workflow's *execution* is short-circuited by
+        mocking ``WorkflowExecutor.execute``. The routing verdict is preserved
+        (``workflow.name`` is still "standard") AND a structural bite proves
+        the fallback drove it: ``execute`` is reached *only* on the fallback
+        path — a successful conversational branch returns early
+        (unified_pipeline.py:169) and never calls the executor. So if the
+        fallback stops triggering, ``mock_exec.assert_awaited_once()`` fails.
+
+        Non-vacuity (leçon #1588, contrôle DoD #1591): the test fails if the
+        routing does not happen — remove the ``side_effect=ImportError`` and
+        ``run_conversational_analysis`` succeeds, the early-return fires, the
+        executor is never awaited → bite fires. Measured: 94 req → 0 req.
+        """
         from argumentation_analysis.orchestration.unified_pipeline import (
             run_unified_analysis,
         )
@@ -111,15 +134,34 @@ class TestRunUnifiedAnalysisConversational:
             "argumentation_analysis.orchestration.conversational_orchestrator.run_conversational_analysis",
             new_callable=AsyncMock,
             side_effect=ImportError("Module not available"),
-        ):
+        ), patch(
+            "argumentation_analysis.orchestration.unified_pipeline.WorkflowExecutor.execute",
+            new_callable=AsyncMock,
+            return_value={},
+        ) as mock_exec:
             # Should fall back to standard workflow without raising
             result = await run_unified_analysis(
                 "test text", workflow_name="conversational"
             )
 
         assert result is not None
-        # Fell back to standard pipeline, workflow name from catalog
+        # Verdict preserved: the fallback routed to the standard workflow
+        # (workflow_name comes from workflow.name, not from execution).
         assert "standard" in result.get("workflow_name", "").lower()
+        # Structural bite (#1578/#1591): the executor is reached ONLY on the
+        # fallback path. A successful conversational branch returns early and
+        # never calls execute — so this proves the fallback fired. It also
+        # proves the standard workflow (not another) was what the fallback
+        # selected: execute's first positional arg is the workflow object.
+        mock_exec.assert_awaited_once()
+        # execute's first positional arg is the workflow object (self is not
+        # recorded: the AsyncMock patch replaces the class attribute without a
+        # binding descriptor). This pins WHICH workflow the fallback selected.
+        # NB: the catalogued "standard" workflow's .name is "standard_analysis"
+        # — same substring verdict as the result assertion above ("light" or
+        # "full" would not contain "standard", so the bite still discriminates).
+        selected_workflow = mock_exec.call_args.args[0]
+        assert "standard" in selected_workflow.name.lower()
 
     async def test_conversational_preserves_original_fields(self):
         """Normalization adds summary but preserves conversation_log etc."""


### PR DESCRIPTION
# #1591 — Hermétiser le benchmark conversational→standard (le levier ~35-40 % du gate)

Addresses #1591 (primary lever). Suite directe de mon #1590/#1582.

## Le constat

`test_conversational_fallback_on_error` pilote le **vrai pipeline standard** de bout en bout pour prouver une propriété d'une chaîne : que l'échec conversational route vers le workflow standard. Or `workflow_name` dans le résultat vient de `workflow.name` ([unified_pipeline.py:324](argumentation_analysis/orchestration/unified_pipeline.py#L324) — l'**objet** workflow que le fallback sélectionne à la ligne 175), **pas de son exécution**. Les ~94 requêtes LLM (~35-40 % du gate, mesuré #1579) n'établissaient rien que l'assertion lise : le verdict de routage tient en une chaîne de caractères. Famille **(a)** pure (#1578-family).

## Le fix — calqué sur #1578/#1581

« Corriger le mode plutôt que patcher le symbole » + morsure structurelle :

1. **Mock `WorkflowExecutor.execute`** → le pipeline standard ne tourne plus. Le verdict de routage (lu sur `workflow.name`) est intact.
2. **Morsure structurelle** : `mock_exec.assert_awaited_once()` — l'executor n'est atteint **que** sur le path de fallback ; une branche conversational réussie fait `return conv_result` ([ligne 169](argumentation_analysis/orchestration/unified_pipeline.py#L169)) et n'appelle jamais execute. + `selected_workflow.name` contient "standard" (le workflow catalogué "standard" s'appelle `standard_analysis` — même verdict substring que l'assertion de résultat, qui distingue bien standard de light/full).

## DoD #1591

- **Herméticité 0 req, mesurée** (instrumentation httpx #1579) :

| | avant | après |
|---|------|------|
| requêtes (test seul) | 94 | **0** |
| wall-clock (test seul) | 155 s | **1.88 s** |
| fichier entier | 1 test fuyait / 6 | **0 / 6**, 6 passed |

- **Verdict préservé, pas contourné** : le test prouve toujours le routage conversational→standard (lu sur `workflow.name`), pas un `isinstance(result, dict)` (leçon #1588).
- **Contrôle non-vacuité (obligatoire, #1588)** — prouvé empiriquement : un probe copiant le test sans `side_effect=ImportError` (conversational réussit) fait **déclencher la morsure** :
  ```
  AssertionError: Expected execute to have been awaited once. Awaited 0 times.
  ```
  Le test échoue quand le routage n'a pas lieu → il n'est pas tautologique.
- **Delta tally = 0** : 6 passed avant et après (ni test ajouté ni retiré).

## Scope

Cette PR livre le **levier principal** (~35-40 % du gate, le seul test qui porte ~35 % des requêtes selon #1579/#1590). Les **19 tests (a) restants** (1-5 req chacun, ~50 req cumulées) sont tabulés dans l'issue et laissés à une PR suivante — chacun exige sa propre analyse + son propre probe de non-vacuité, pas une hermétisation en masse (leçon #1588 : hermétiser un test à assertion faible le rend plus creux).

Typologie des 19 restants (pour la suite) :
- **9 `*_fallback_raises_fail_loud` / honest-unavailable** (value_gates) — pattern M2 (constructeur `AsyncOpenAI` dispersé), fix connu (#1585).
- **2 `test_invoke_*_error_fallback`** (formal_verification) — verdict = tag `logic_type` structurel.
- **2 `test_template_counter[_set]`** (track_mm) — verdict = clé de métrique présente.
- **3 `TestRunUnifiedAnalysisWithState::*`** — exécutent `run_unified_analysis` réel (même famille que ce benchmark).
- **2 `TestRealComponentIntegration::*`** + **1 `test_start_deliberation`** (proposal_api) — verdicts structurels (status COMPLETED / 202 queued).

## Anti-pendule

- 0 test supprimé, 0 code de production touché, ci.yml inchangé, delta tally = 0. ✓

## Vérification

`pytest tests/unit/argumentation_analysis/evaluation/test_benchmark_conversational.py -p _measure_1591_plugin --allow-dotenv` → 6 passed, `[measure-1591] 0 test(s) hit EXTERNAL (0 req)`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
