### PR TITLE
test(gate): make the 8 allocator assertions falsifiable (#1593)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/hierarchical/strategic/test_allocator.py
+++ b/tests/unit/argumentation_analysis/orchestration/hierarchical/strategic/test_allocator.py
@@ -129,8 +129,21 @@ class TestAllocateInitialResources:
         assert abs(total - 1.0) < 0.01
 
     def test_empty_phases(self, allocator):
+        # #1593: ``isinstance(result, dict)`` alone could not fail — every
+        # return path of allocate_initial_resources returns a dict, so the
+        # test passed even with the method stubbed to ``{}``. The property the
+        # name promises is that an empty plan still produces a COMPLETE
+        # allocation over the known agents, not an empty one.
         result = allocator.allocate_initial_resources({"phases": [], "priorities": {}})
-        assert isinstance(result, dict)
+        assert set(result) == {
+            "agent_assignments",
+            "priority_levels",
+            "computational_budget",
+        }
+        assert result["computational_budget"], "no agent received any budget"
+        assert abs(sum(result["computational_budget"].values()) - 1.0) < 0.01
+        # No phase to assign ⇒ every agent's assignment list is empty.
+        assert all(v == [] for v in result["agent_assignments"].values())
 
     def test_updates_state(self, allocator, sample_plan):
         allocator.allocate_initial_resources(sample_plan)
@@ -393,21 +406,38 @@ class TestAdjustAllocation:
             "idle_resources": [{"agent_id": target_agent, "idle_level": "high"}],
         }
         result = alloc.adjust_allocation(feedback)
-        # Budget should be reduced (but may be normalized)
-        # At least the raw adjustment is applied
-        assert isinstance(result, dict)
+        # #1593: the comment said "budget should be reduced" but the assertion
+        # was ``isinstance(result, dict)`` — the named property was never
+        # checked. Measured: an idle agent goes 0.2 → 0.1.
+        assert result["computational_budget"][target_agent] < original_budget, (
+            "idle_resources did not reduce the agent's budget "
+            f"({original_budget} → {result['computational_budget'][target_agent]})"
+        )
 
     def test_empty_feedback(self, allocated_allocator):
+        # #1593: the property is that empty feedback is a NO-OP, not merely
+        # that something dict-shaped comes back.
+        before = dict(
+            allocated_allocator.state.resource_allocation["computational_budget"]
+        )
         result = allocated_allocator.adjust_allocation({})
-        assert isinstance(result, dict)
+        assert result["computational_budget"] == before
 
     def test_unknown_agent_in_feedback_ignored(self, allocated_allocator):
         feedback = {
             "bottlenecks": [{"agent_id": "nonexistent_agent", "severity": "high"}],
             "idle_resources": [],
         }
+        before = dict(
+            allocated_allocator.state.resource_allocation["computational_budget"]
+        )
         result = allocated_allocator.adjust_allocation(feedback)
-        assert isinstance(result, dict)
+        # #1593: "ignored" means two things, and neither was asserted — known
+        # agents keep their budget, and no phantom entry is fabricated for the
+        # unknown one (cf. the phantom-key pattern of #1019).
+        assert result["computational_budget"] == before
+        assert "nonexistent_agent" not in result["computational_budget"]
+        assert "nonexistent_agent" not in result["priority_levels"]
 
     def test_medium_severity_bottleneck(self, allocated_allocator):
         alloc = allocated_allocator
@@ -442,12 +472,21 @@ class TestOptimizeResourceUtilization:
             },
             "task_completion_rates": {},
         }
+        before = alloc.state.resource_allocation["computational_budget"][agents[0]]
         result = alloc.optimize_resource_utilization(metrics)
-        assert isinstance(result, dict)
+        # #1593: the name promises the budget is ADJUSTED from the efficiency
+        # metrics. Measured: a highly efficient agent goes 0.2 → ~0.6.
+        assert (
+            result["computational_budget"][agents[0]] != before
+        ), "efficiency metrics left the budget untouched — nothing was optimized"
 
     def test_empty_metrics(self, allocated_allocator):
+        # #1593: empty metrics must be a NO-OP, not merely dict-shaped.
+        before = dict(
+            allocated_allocator.state.resource_allocation["computational_budget"]
+        )
         result = allocated_allocator.optimize_resource_utilization({})
-        assert isinstance(result, dict)
+        assert result["computational_budget"] == before
 
     def test_unknown_agent_in_metrics_ignored(self, allocated_allocator):
         metrics = {
@@ -459,8 +498,14 @@ class TestOptimizeResourceUtilization:
                 },
             },
         }
+        before = dict(
+            allocated_allocator.state.resource_allocation["computational_budget"]
+        )
         result = allocated_allocator.optimize_resource_utilization(metrics)
-        assert isinstance(result, dict)
+        # #1593: same two-part "ignored" property as the feedback case — known
+        # agents untouched, and no phantom entry for the unknown agent.
+        assert result["computational_budget"] == before
+        assert "unknown_agent_xyz" not in result["computational_budget"]
 
     def test_high_efficiency_gets_more_budget(self, allocated_allocator):
         alloc = allocated_allocator
@@ -489,9 +534,19 @@ class TestOptimizeResourceUtilization:
             agents[1], 0
         )
         result = alloc.optimize_resource_utilization(metrics)
-        # After optimization, the more efficient agent should move toward more budget
-        # (progressive 50% movement toward ideal)
-        assert isinstance(result, dict)
+        # #1593: the comment already described the property — the more
+        # efficient agent moves toward MORE budget — but the assertion was
+        # ``isinstance(result, dict)``, which no state of the code could
+        # falsify. Measured on equal starting budgets (0.2 each): the
+        # efficient agent ends at ~0.56, the inefficient one at ~0.14.
+        after_0 = result["computational_budget"][agents[0]]
+        after_1 = result["computational_budget"][agents[1]]
+        assert after_0 > after_1, (
+            "the more efficient agent did not end up with more budget "
+            f"({agents[0]}: {before_0}→{after_0}, {agents[1]}: {before_1}→{after_1})"
+        )
+        assert after_0 > before_0, "the efficient agent gained nothing"
+        assert after_1 < before_1, "the inefficient agent lost nothing"
 
 
 # ============================================================


### PR DESCRIPTION
Addresses #1593 — le plus gros bloc du recensement (8 des 64 candidats, un seul fichier).

**8 candidats, 8 confirmés vides, 8 resserrés. Aucun test ajouté ni retiré ⇒ delta de tally 0.**

## Le contrôle

Substitution dégénérée ciblée : stubber les méthodes de production dont le résultat est asserté, et regarder si le test passe quand même. `allocate_initial_resources` est laissée intacte dans le mode `adjust` — la fixture `allocated_allocator` s'en sert pour construire l'état, et la stubber ferait échouer le **setup**, pas l'assertion, ce qui ne prouverait rien.

| | prod stubbée → `{}` | prod réelle |
|---|---|---|
| **Avant** | **8 passed** — aucune assertion ne mord | 8 passed |
| **Après** | **8 failed** (7 `adjust`/`optimize` + 1 `initial`) | **8 passed** |

Fichier entier : **46 passed** avant et après.

## Ce que les tests prétendaient couvrir, et ce qu'ils vérifient maintenant

Le cas le plus net est `test_idle_resource_reduces_budget` : son commentaire disait déjà *« Budget should be reduced »*, et son assertion était `isinstance(result, dict)`. La propriété était **écrite dans le fichier** et jamais vérifiée. Idem pour `test_high_efficiency_gets_more_budget` (*« the more efficient agent should move toward more budget »*).

Toutes les assertions ci-dessous décrivent le comportement **mesuré** du code, pas un comportement supposé :

| Test | Propriété désormais assertée | Mesuré |
|---|---|---|
| `test_empty_phases` | un plan vide rend quand même une allocation **complète** (3 clés, budget sommant à 1.0, assignations vides) | 5 agents à 0.2 |
| `test_idle_resource_reduces_budget` | le budget de l'agent oisif **diminue** strictement | 0.2 → 0.1 |
| `test_empty_feedback` | no-op : budget inchangé | inchangé |
| `test_unknown_agent_in_feedback_ignored` | budget inchangé **et** aucune clé fantôme fabriquée pour l'agent inconnu | ni dans `computational_budget` ni dans `priority_levels` |
| `test_adjusts_budget_based_on_efficiency` | le budget **change** sous l'effet des métriques | 0.2 → ~0.6 |
| `test_empty_metrics` | no-op : budget inchangé | inchangé |
| `test_unknown_agent_in_metrics_ignored` | inchangé + aucune clé fantôme | idem |
| `test_high_efficiency_gets_more_budget` | l'agent efficace finit **au-dessus** de l'inefficace, gagne, et l'autre perd | 0.2/0.2 → ~0.56 / ~0.14 |

Les deux assertions « clé fantôme » ne sont pas décoratives : « ignoré » a deux sens (ne pas altérer les connus, ne pas fabriquer d'entrée pour l'inconnu) et le second est exactement le motif de clé fantôme de #1019.

## Une correction sur le recensement de #1593

L'issue annonce la liste comme une **borne supérieure** avec un taux de faux positifs estimé à environ la moitié, tiré d'un échantillon de 8 candidats lus **à travers plusieurs fichiers**. Sur ce bloc-ci, le taux est **0/8** : les 8 sont réellement vides.

Ce n'est pas une contradiction, c'est une non-uniformité qu'il vaut mieux énoncer avant que quelqu'un ne se serve du chiffre global comme d'une prédiction locale : **un bloc concentré (8 candidats sur un même fichier) est bien plus susceptible d'être réel qu'un candidat isolé**, parce qu'une cause partagée produit un raccourci partagé — ici, une même famille de méthodes qui rendent toutes un dict bien formé, donc un même `isinstance` qui passe partout. Les singletons, eux, sont plus souvent des tests qui mordent par un `mock.assert_called_once()` ou une exception non levée, invisibles au scan AST.

Reste donc 56 candidats, dont les deux blocs suivants (`test_governance_plugin.py` 7, `test_conversation_orchestrator.py` 6) sont les plus prometteurs par le même raisonnement.

## Anti-pendule

0 test supprimé, 0 code de production touché, 0 marqueur `slow`/`requires_api` ajouté, `ci.yml` intact. Les assertions restent au niveau de la propriété nommée — pas de `result == {...}` exhaustif qui casserait au premier refactor de l'allocateur.

## Validation

- `test_allocator.py` : **46 passed** en 10,3 s
- `black --check` : unchanged · `flake8` : clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
