### PR TITLE
test(gate): hermétise 19 family-(a) tests to 0 external req (#1591)

### DIFF
--- a/tests/unit/api/test_proposal_api.py
+++ b/tests/unit/api/test_proposal_api.py
@@ -198,16 +198,21 @@ class TestVoting:
 
 class TestDeliberation:
     def test_start_deliberation(self, client):
-        create_resp = client.post(
-            "/api/propose",
-            json={"text": "Start deliberation on this proposal", "author": "alice"},
-        )
-        pid = create_resp.json()["id"]
+        # Hermétisé #1591: ctor LLM lève. /api/deliberate met en queue (async,
+        # retour 202 queued avant toute analyse). Le verdict (mise en file) est
+        # posé par le handler quelle que soit la sortie du background task,
+        # modèle-indépendant.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")):
+            create_resp = client.post(
+                "/api/propose",
+                json={"text": "Start deliberation on this proposal", "author": "alice"},
+            )
+            pid = create_resp.json()["id"]
 
-        resp = client.post(
-            "/api/deliberate",
-            json={"proposal_id": pid, "workflow": "democratech"},
-        )
+            resp = client.post(
+                "/api/deliberate",
+                json={"proposal_id": pid, "workflow": "democratech"},
+            )
         assert resp.status_code == 202
         data = resp.json()
         assert data["status"] == "queued"

--- a/tests/unit/argumentation_analysis/orchestration/test_workflow_executor_invoke.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_workflow_executor_invoke.py
@@ -8,6 +8,7 @@ downstream context chaining, timeout support, and integration with real componen
 
 import asyncio
 import pytest
+from unittest.mock import patch
 
 from argumentation_analysis.core.capability_registry import (
     CapabilityRegistry,
@@ -477,9 +478,10 @@ class TestRealComponentIntegration:
             .build()
         )
         executor = WorkflowExecutor(registry)
-        results = await executor.execute(
-            workflow, "Les vaccins sont dangereux car un ami est tombé malade."
-        )
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")):
+            results = await executor.execute(
+                workflow, "Les vaccins sont dangereux car un ami est tombé malade."
+            )
 
         assert results["counter"].status == PhaseStatus.COMPLETED
         assert results["counter"].output is not None
@@ -497,10 +499,11 @@ class TestRealComponentIntegration:
         registry = setup_registry(include_optional=False)
         workflow = build_light_workflow()
         executor = WorkflowExecutor(registry)
-        results = await executor.execute(
-            workflow,
-            "La peine de mort devrait être abolie car elle ne dissuade pas le crime.",
-        )
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")):
+            results = await executor.execute(
+                workflow,
+                "La peine de mort devrait être abolie car elle ne dissuade pas le crime.",
+            )
 
         assert results["quality"].status == PhaseStatus.COMPLETED
         assert results["quality"].output is not None

--- a/tests/unit/argumentation_analysis/orchestration/test_workflow_state_integration.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_workflow_state_integration.py
@@ -9,6 +9,7 @@ error handling, run_unified_analysis with state, JSON serialization.
 import asyncio
 import json
 import pytest
+from unittest.mock import patch
 
 from argumentation_analysis.core.shared_state import UnifiedAnalysisState
 from argumentation_analysis.core.capability_registry import (
@@ -397,11 +398,15 @@ class TestRunUnifiedAnalysisWithState:
         )
 
         registry = setup_registry(include_optional=False)
-        result = await run_unified_analysis(
-            "Les vaccins sont efficaces.",
-            workflow_name="light",
-            registry=registry,
-        )
+        # Hermétisé #1591: ctor LLM lève. Le verdict porte sur la plomberie
+        # d'état (unified_state créé, snapshot dict) — structurel, posé par le
+        # runner quelle que soit la sortie des phases, modèle-indépendant.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")):
+            result = await run_unified_analysis(
+                "Les vaccins sont efficaces.",
+                workflow_name="light",
+                registry=registry,
+            )
 
         assert "unified_state" in result
         assert result["unified_state"] is not None
@@ -418,12 +423,15 @@ class TestRunUnifiedAnalysisWithState:
         )
 
         registry = setup_registry(include_optional=False)
-        result = await run_unified_analysis(
-            "Test text.",
-            workflow_name="light",
-            registry=registry,
-            create_state=False,
-        )
+        # Hermétisé #1591: create_state=False → pas d'état. Verdict = plomberie
+        # (absence d'unified_state), modèle-indépendant.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")):
+            result = await run_unified_analysis(
+                "Test text.",
+                workflow_name="light",
+                registry=registry,
+                create_state=False,
+            )
 
         assert "unified_state" not in result
 
@@ -436,11 +444,16 @@ class TestRunUnifiedAnalysisWithState:
         )
 
         registry = setup_registry(include_optional=False)
-        result = await run_unified_analysis(
-            "La peine de mort devrait être abolie car elle ne dissuade pas.",
-            workflow_name="light",
-            registry=registry,
-        )
+        # Hermétisé #1591: ctor LLM lève. Le verdict porte sur workflow_results
+        # peuplé + le garde `if status==COMPLETED` protège len(scores)>0. Sans
+        # LLM, quality peut tomber FAILED (garde saute l'assert scores) — le
+        # verdict structurel (`light_analysis in workflow_results`) reste tenu.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")):
+            result = await run_unified_analysis(
+                "La peine de mort devrait être abolie car elle ne dissuade pas.",
+                workflow_name="light",
+                registry=registry,
+            )
 
         state = result.get("unified_state")
         assert state is not None

--- a/tests/unit/argumentation_analysis/test_track_mm_formal_recall.py
+++ b/tests/unit/argumentation_analysis/test_track_mm_formal_recall.py
@@ -12,6 +12,7 @@ Tests cover:
 import asyncio
 import pytest
 import sys
+from unittest.mock import patch
 
 
 def _make_fake_invoke_pl(
@@ -118,9 +119,13 @@ class TestPLMetricsCountersPopulated:
         context = {
             "_state_object": None,
         }
-        result = asyncio.get_event_loop().run_until_complete(
-            fake_invoke("test text " * 20, context)
-        )
+        # Hermétisé #1591: ctor LLM lève → fallback template déterministe. Le
+        # verdict (clé "template" structurelle dans pl_metrics) est posé par le
+        # code quel que soit le chemin, modèle-indépendant.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")):
+            result = asyncio.get_event_loop().run_until_complete(
+                fake_invoke("test text " * 20, context)
+            )
         # Should fall through to template since no API key / no formulas
         assert "template" in result["pl_metrics"]
         assert result["pl_metrics"]["template"] >= 0
@@ -212,9 +217,13 @@ class TestFOLTemplateCounter:
         context = {
             "_state_object": None,
         }
-        result = asyncio.get_event_loop().run_until_complete(
-            fake_invoke("test text " * 20, context)
-        )
+        # Hermétisé #1591: ctor LLM lève → fol_metrics["template"] reste posé
+        # (clé structurelle, =0 sans template fallback depuis #1278). Verdict
+        # modèle-indépendant.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")):
+            result = asyncio.get_event_loop().run_until_complete(
+                fake_invoke("test text " * 20, context)
+            )
         assert "template" in result["fol_metrics"]
         assert result["fol_metrics"]["template"] >= 0
 

--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -568,6 +568,8 @@ class TestSetAFValueGate:
         )
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")
+        ), patch(
             "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
             side_effect=RuntimeError("No JVM for test"),
         ):
@@ -598,6 +600,8 @@ class TestWeightedValueGate:
         )
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")
+        ), patch(
             "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
             side_effect=RuntimeError("No JVM for test"),
         ):
@@ -669,6 +673,8 @@ class TestBipolarValueGate:
         )
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")
+        ), patch(
             "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
             side_effect=RuntimeError("No JVM for test"),
         ):
@@ -1319,6 +1325,8 @@ class TestFOLValueGate:
         }
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")
+        ), patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             side_effect=RuntimeError("No JVM for test"),
         ), patch(
@@ -1361,6 +1369,8 @@ class TestFOLValueGate:
         context = {}
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")
+        ), patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             side_effect=RuntimeError("No JVM for test"),
         ), patch(
@@ -1473,6 +1483,8 @@ class TestPLValueGate:
         context = {}
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")
+        ), patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             side_effect=RuntimeError("No JVM for test"),
         ), patch(
@@ -1503,6 +1515,8 @@ class TestPLValueGate:
         mock_bridge.check_consistency.return_value = (True, "Satisfiable")
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")
+        ), patch(
             "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge",
             return_value=mock_bridge,
         ), patch(
@@ -1657,6 +1671,8 @@ class TestABAValueGate:
         )
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")
+        ), patch(
             "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
             side_effect=RuntimeError("No JVM for test"),
         ):
@@ -1894,6 +1910,8 @@ class TestASPICValueGate:
         )
 
         with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")
+        ), patch(
             "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
             side_effect=RuntimeError("No JVM for test"),
         ):

--- a/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
+++ b/tests/unit/argumentation_analysis/workflows/test_formal_verification.py
@@ -324,8 +324,11 @@ class TestInvokeCallables:
             _invoke_propositional_logic,
         )
 
-        # Without JVM, should return error dict
-        result = await _invoke_propositional_logic("a && b", {})
+        # Without JVM, should return error dict. Hermétisé #1591: le ctor LLM lève
+        # → le code retourne l'error dict (logic_type posé avant l'appel modèle),
+        # verdict structurel préservé sans fuite réseau.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")):
+            result = await _invoke_propositional_logic("a && b", {})
         assert "logic_type" in result
         assert result["logic_type"] == "propositional"
 
@@ -335,7 +338,10 @@ class TestInvokeCallables:
             _invoke_fol_reasoning,
         )
 
-        result = await _invoke_fol_reasoning("forall x: P(x)", {})
+        # Hermétisé #1591: ctor LLM lève → code retourne error dict (logic_type
+        # structurel, posé avant l'appel modèle), verdict préservé sans fuite.
+        with patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")):
+            result = await _invoke_fol_reasoning("forall x: P(x)", {})
         assert result["logic_type"] == "first_order"
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

Suite of #1594 (the benchmark conversational→standard fallback). Hermétise the **19 remaining family-(a) tests** identified in the #1594 PR body — collateral LLM leaks whose verdict is model-independent. Each now reaches its existing verdict with **0 external LLM requests**.

## Root cause (#1583 M2)

All 19 leaked via a **dispersed `AsyncOpenAI()` constructor**: patching only `_get_openai_client` (or `_get_openai_client → (None, None)`) does not stop the leak, because an `AsyncOpenAI()` is constructed at a site that bypasses that helper. Fix = patch the constructor itself: `patch("openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591"))`.

## Per-test result (DoD)

| Test | Before (req / wall) | After (req / wall) | Verdict preserved (named) |
|---|---|---|---|
| `test_setaf_fallback_raises_fail_loud` | 1 / 4s | 0 / ~1.6s | `pytest.raises(RuntimeError, "SetAF…unavailable")` (via pre-existing `asyncio.to_thread` patch) |
| `test_weighted_fallback_raises_fail_loud` | 1 / 2s | 0 | `pytest.raises(... "Weighted AF…unavailable")` |
| `test_bipolar_fallback_raises_fail_loud` | 1 / 3s | 0 | `pytest.raises(... "Bipolar…unavailable")` |
| `test_aba_fallback_raises_fail_loud` | 1 / 2s | 0 | `pytest.raises(... "ABA reasoning unavailable")` |
| `test_aspic_fallback_raises_fail_loud` | 1 / 3s | 0 | `pytest.raises(... "ASPIC+…unavailable")` |
| `test_fol_degraded_message_is_honest` | 4 / 45s | 0 | `consistent is None` (degraded return holds even with ctor raising) |
| `test_pl_fallback_raises_fail_loud` | 4 / 26s | 0 | `pytest.raises(... "Propositional logic…unavailable")` |
| `test_fol_fallback_reports_honest_unavailable` | 2 / 27s | 0 | `consistent is None` + `fol_status.startswith("unavailable")` |
| `test_pl_satisfiable_is_bool_when_tweety_available` | 2 / 10s | 0 | `isinstance(satisfiable, bool)` + `len(formulas) > 0` (PL template fallback) |
| `test_invoke_propositional_logic_error_fallback` | 1 / 6s | 0 | `logic_type == "propositional"` (structural tag) |
| `test_invoke_fol_reasoning_error_fallback` | 1 / 4s | 0 | `logic_type == "first_order"` (structural tag) |
| `test_template_counter` (PL) | 2 / 8s | 0 | `"template" in pl_metrics` (structural key) |
| `test_template_counter_set` (FOL) | 3 / 19s | 0 | `"template" in fol_metrics` (structural key, =0 since #1278) |
| `test_counter_argument_real_invoke` | 1 / 11s | 0 | `status == COMPLETED` + `parsed_argument`/`suggested_strategy` keys |
| `test_light_workflow_quality_and_counter` | 4 / 72s | 0 | `quality`+`counter` `status == COMPLETED` + `quality_context` |
| `test_creates_state_by_default` | 4 / 45s | 0 | `unified_state is not None` + `state_snapshot` dict (state plumbing) |
| `test_no_state_when_disabled` | 3 / 17s | 0 | `unified_state not in result` (`create_state=False`) |
| `test_state_populated_after_quality_phase` | 4 / 80s | 0 | `light_analysis in workflow_results` (+ guarded `len(scores)>0`) |
| `test_start_deliberation` | 4 / 30s | 0 | `status_code == 202` + `status == "queued"` (queue plumbing) |
| **TOTAL** | **44 / ~414s** | **0 / ~12s** | |

## DoD checklist

- [x] Per touched test: 0 external req vs N before (measured httpx, plugin `_measure_1591b_plugin` — temporary, deleted before commit).
- [x] Verdict preserved — **named, not bypassed** (no `isinstance(result, dict)`-style hollow assert; each verdict is the original structural/raises assertion).
- [x] Non-vacuity: **no new assertion added** — the ctor patch only suppresses the network leak; the existing verdict still drives pass/fail. Control = 0 req + verdict holds, verified per test. (Contrast with #1594's benchmark, where a new `assert_awaited_once` bite was added and required an isolating probe; here nothing new was added, so the control is the preserved verdict itself.)
- [x] Delta tally = 0 — **188 collected before and after** (stash + `--collect-only` on `origin/main`); no test added/removed, no `slow`/`requires_api` marker, no exclusion.
- [x] Cumulative gain: **-44 req (-100%), ~414s → ~12s (-97%)** on the 19.

## Anti-pendule / scope

- **0 production file touched** (6 test files only).
- **0 test marked `requires_api`** — these are family-(a) (verdict model-independent), so hermetizing is correct; marking would be the silent exclusion of #1586 in disguise.
- **0 test added/removed** — delta tally = 0.
- The single family-(b) test in this set's files (`test_fol_consistent_is_bool_when_tweety_available`, marked `requires_api` in #1590) is **untouched** and still leaks 2 req legitimately — its verdict genuinely depends on the model.

## Deconfliction

- #1593 (po-2025): `test_allocator.py` — disjoint.
- #1595 (coordinator): `test_allocator.py` — disjoint.

Base: `origin/main` @ `23b4990d` (= #1594 merged).

Closes follow-up scope of #1591 (the 19 family-(a) remainder tabulated in #1594).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
