### PR TITLE
fix(counter): surface degraded=True when LLM enrichment silently failed (#1597)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -1167,6 +1167,16 @@ async def _invoke_counter_argument(
 
     # Enrich with LLM-generated counter-arguments for fallacious/weak arguments
     llm_counters = []
+    # #1597 — honest degradation flag. Set True only when the LLM enrichment
+    # was *attempted* but raised (network/key/parse). Mirrors the governance
+    # top-level ``degraded`` canon (BO-2 #1472): the phase still COMPLETED —
+    # parsed_argument/suggested_strategy come from the deterministic plugin —
+    # but the LLM enrichment was lost, and that loss must not be silent (a
+    # consumer reading ``llm_counter_arguments`` cannot otherwise tell "none
+    # needed" from "the LLM never ran" — the inverse of the #1019 phantom
+    # key). Surfaced via the pipeline rollup
+    # (unified_pipeline.run_unified_analysis → capabilities_degraded).
+    llm_enrichment_failed = False
     try:
         client, model_id = _get_openai_client()
         if client:
@@ -1222,6 +1232,7 @@ async def _invoke_counter_argument(
             )
     except Exception as e:
         logger.warning(f"LLM counter-argument enrichment failed: {e}")
+        llm_enrichment_failed = True
 
     # (#294) Auto-evaluate each LLM counter-argument
     if llm_counters:
@@ -1236,6 +1247,8 @@ async def _invoke_counter_argument(
         # Keep first as llm_counter_argument for backward compat
         result["llm_counter_argument"] = llm_counters[0] if llm_counters else None
         result["llm_counter_arguments"] = llm_counters
+    if llm_enrichment_failed:
+        result["degraded"] = True
     # Trace entry for counter-argument specialist (Track UU #724)
     _state = context.get("_state_object")
     if _state is not None and llm_counters:

--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -538,6 +538,51 @@ class TestCounterArgValueGate:
                 f"Strategy {strat.name} returned empty output after #960 fix"
             )
 
+    async def test_counter_argument_marks_degraded_when_llm_enrichment_fails(self):
+        """#1597 — a phase that completed without its LLM must say so.
+
+        ``_invoke_counter_argument`` enriches the deterministic plugin output
+        (parsed_argument/suggested_strategy) with LLM-generated counter-arguments.
+        When that enrichment is attempted but raises, the result MUST carry
+        ``degraded=True`` (the codebase canon, BO-2 #1472), so the pipeline
+        rollup surfaces this phase in ``capabilities_degraded`` instead of
+        ``capabilities_used``. Without it, a consumer reading
+        ``llm_counter_arguments`` (absent rather than empty on failure) cannot
+        tell "none needed" from "the LLM never ran" — the inverse of the #1019
+        phantom key. The phase still COMPLETED (deterministic keys present):
+        fail-loud, not fail-hard.
+
+        Anti-vacuity: the verdict is the NEW ``degraded`` key. If the fix is
+        removed, ``result.get("degraded")`` is None → assertion fails. Nothing
+        else in the result asserts this (the deterministic keys are present
+        either way).
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_counter_argument,
+        )
+
+        ctx = {"phase_extract_output": {"arguments": [{"text": "claim needing rebuttal"}]}}
+        # Force the LLM path (client present) then make generation raise — the
+        # exact production failure mode (network/key/parse). CI-stable: no .env
+        # dependency (we mock the client provider, not the ctor).
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
+            return_value=(MagicMock(), "model-id"),
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables._generate_counters_for_targets",
+            side_effect=RuntimeError("LLM enrichment failed"),
+        ):
+            result = await _invoke_counter_argument("claim needing rebuttal", ctx)
+
+        assert result.get("degraded") is True, (
+            "Counter-argument phase must surface degraded=True when its LLM "
+            "enrichment failed, so the rollup reports capabilities_degraded "
+            "(#1597, BO-2 #1472, anti-theatre #1019)."
+        )
+        # Deterministic plugin output still present (fail-loud, not fail-hard).
+        assert "parsed_argument" in result
+        assert "suggested_strategy" in result
+
 
 # =====================================================================
 # 7. Satellite handlers — honest unavailable, not fabricated data (#964)


### PR DESCRIPTION
## What

Closes #1597 (partial — see scope). Fixes the one **rollup-visible** silent-LLM-fallback defect among the 10 candidates, and reports the measured verdict on all 10 with the false-positive rate.

Found by ai-01 while auditing #1596 (good PR, merged): `_invoke_counter_argument` enriched its deterministic output with an LLM call wrapped in `except Exception -> logger.warning`. When the LLM was attempted but raised, the result carried **no marker** — `llm_counters` stayed `[]`, so the keys `llm_counter_argument*` were *absent* (not empty), and every consumer reading `.get("llm_counter_arguments", [])` got `[]`, indistinguishable from "no counter-argument needed". A phase that completed without its LLM was silent — the inverse of the #1019 phantom key.

## The fix

A top-level `degraded=True` on the phase output when the LLM enrichment was *attempted* but raised — the codebase canon already used by governance (BO-2 #1472). A new boolean `llm_enrichment_failed` is set only in the `except` (so a legitimate "no targets / no client" path stays `degraded`-free).

```python
llm_enrichment_failed = False
try:
    client, model_id = _get_openai_client()
    ...
except Exception as e:
    logger.warning(f"LLM counter-argument enrichment failed: {e}")
    llm_enrichment_failed = True
...
if llm_enrichment_failed:
    result["degraded"] = True
```

**Consumer verified (anti-theatre #1019):** `unified_pipeline.run_unified_analysis` already reads `pr.output.get("degraded") is True` (l.310-318) and moves the capability from `capabilities_used` to `capabilities_degraded`. Measured end-to-end (light workflow, ctor broken): `counter_argument_generation` now appears in `capabilities_degraded` (was in `capabilities_used`); the phase stays `COMPLETED` with `parsed_argument`/`suggested_strategy`/`quality_context` present.

**Anti-pendule (fail-loud, not fail-hard):** the `except` is NOT converted to a `raise`. The enrichment is optional by design; a run without an API key must still succeed (the gate requires it). What was in fault was the *silence*, not the fallback.

## Measured verdict on all 10 candidates (#1597 grep)

Method (ai-01's R747, applied to each): spy the `AsyncOpenAI` ctor attempt count (did the path *try* the LLM?), then break it (ctor raises) and read whether the output lets a consumer see the miss.

| Line | Site | ctor_try | signal on failure | verdict |
|------|------|:---:|------|---------|
| **1224** | **counter-arg enrichment** | **1** | **was MUTE → `degraded=True`** | **FIXED** |
| 1635 | debate assessment | 1 | `debate_quality_source` (GE-5 #1467) | **SAIN** (already signals, just not via the canon) |
| 2073 | governance assessment | 1 | `degraded` (BO-2 #1472) | **SAIN** (the canon itself) |
| 8551 | TextToKB | 0 | `error` dict | **SAIN** (no LLM tried on this path — plugin heuristic) |
| 8608 | KBToTweety | 0 | `error` dict | **SAIN** (no LLM tried on this path) |
| 8695 | TweetyInterpretation | 0 | `error` dict | **SAIN** (no LLM tried on this path) |
| 979 | GG-bis coverage retry | 1 | count `added` | **SAIN** (best-effort retry inside a conversational post-processor; consumed only on success) |
| 1040 | conversational PL enrich | 0 | count `pl_added` | **SAIN** (no LLM tried on this path) |
| 1063 | conversational FOL enrich | 0 | count `fol_added` | **SAIN** (no LLM tried on this path) |
| 1111 | conversational quality sweep | 1 | count `added` | **partial** — conversational post-processor, separate subsystem (not the rollup); best-effort by design |

**Grep false-positive rate: 9/10.** Only `1224` was a rollup-visible defect. The generator proposes, only the measure decides (#1593 lesson). A candidate declared SAIN is a deliverable on the same footing as one corrected.

The three KB phases (8551/8608/8695) return `{"error": str(e), ...}` rather than `degraded`, but `ctor_try=0` shows the `AsyncOpenAI` path was never taken on this input (the plugins have a heuristic path), so there is no silent-LLM-fallback to fix there. `1111` does try the LLM and is silent (count), but it lives in the conversational subsystem whose consumer (`conversational_orchestrator`) reports only on success — a separate reporting model, intentionally best-effort, out of this PR's scope.

## DoD checklist (#1597)

- [x] Each of the 10 measured (spy ctor attempt + break) — verdict table above.
- [x] False-positive rate chiffré: 9/10.
- [x] The real silent site (1224) now carries `degraded=True` (governance convention, no new mechanic).
- [x] `except` NOT converted to `raise`; enrichment stays optional (fail-loud, not fail-hard).
- [x] Consumer reads the flag: `unified_pipeline.py:310-318` → `capabilities_degraded` (measured end-to-end).
- [x] mypy strict on `invoke_callables.py`: no issues.
- [x] Tally delta: **+1** (anti-regression test `test_counter_argument_marks_degraded_when_llm_enrichment_fails`). Production fix adds/removes 0 tests. The new test's verdict IS the new `degraded` key (non-vacuous: remove the fix → `result.get("degraded")` is None → test fails).

## Deconfliction / base

Base: `origin/main` @ `c806a770` (post #1595). Touches `invoke_callables.py` (1 hunk group in `_invoke_counter_argument`) + `test_value_gates.py` (1 new test). 0 production file beyond the single fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
