### PR TITLE
test(gate): tighten 18 vacuous assertions proven by degenerate substitution (#1593)

### DIFF
--- a/tests/unit/argumentation_analysis/core/communication/test_adapters.py
+++ b/tests/unit/argumentation_analysis/core/communication/test_adapters.py
@@ -144,7 +144,9 @@ class TestIssueDirective:
     def test_send_failure_still_returns_id(self, strategic, mock_middleware):
         mock_middleware.send_message.return_value = False
         msg_id = strategic.issue_directive("a", {})
-        assert isinstance(msg_id, str)
+        # #1593: vacuous ``isinstance(msg_id, str)`` passed with issue_directive
+        # stubbed to "". The name promises an ID is STILL returned on send failure.
+        assert msg_id, "no id returned despite send failure"
 
 
 class TestBroadcastObjective:
@@ -152,7 +154,9 @@ class TestBroadcastObjective:
 
     def test_returns_message_id(self, strategic):
         msg_id = strategic.broadcast_objective("global_strategy", {"plan": "full"})
-        assert isinstance(msg_id, str)
+        # #1593: vacuous ``isinstance(msg_id, str)`` passed with broadcast_objective
+        # stubbed to "". broadcast_objective must return a (non-empty) message id.
+        assert msg_id, "broadcast_objective returned no id"
 
     def test_publishes_via_middleware(self, strategic, mock_middleware):
         strategic.broadcast_objective("perf_target", {"target": 95})
@@ -382,7 +386,9 @@ class TestAssignTask:
         msg_id = tactical.assign_task(
             "detect_fallacies", {"text": "sample"}, "operational_01"
         )
-        assert isinstance(msg_id, str)
+        # #1593: vacuous ``isinstance(msg_id, str)`` passed with assign_task
+        # stubbed to "". assign_task must return a (non-empty) message id.
+        assert msg_id, "assign_task returned no id"
 
     def test_sends_via_middleware(self, tactical, mock_middleware):
         tactical.assign_task("analyze", {"t": "x"}, "op_01")
@@ -404,7 +410,9 @@ class TestAssignTask:
     def test_send_failure(self, tactical, mock_middleware):
         mock_middleware.send_message.return_value = False
         msg_id = tactical.assign_task("t", {}, "op_01")
-        assert isinstance(msg_id, str)  # Still returns ID
+        # #1593: vacuous ``isinstance(msg_id, str)`` passed with assign_task
+        # stubbed to "". The name promises an ID is STILL returned on send failure.
+        assert msg_id, "no id returned despite send failure"
 
 
 class TestSendReport:
@@ -412,7 +420,9 @@ class TestSendReport:
 
     def test_returns_message_id(self, tactical):
         msg_id = tactical.send_report("status_update", {"done": True}, "strategic_01")
-        assert isinstance(msg_id, str)
+        # #1593: vacuous ``isinstance(msg_id, str)`` passed with send_report
+        # stubbed to "". send_report must return a (non-empty) message id.
+        assert msg_id, "send_report returned no id"
 
     def test_report_content(self, tactical, mock_middleware):
         tactical.send_report("analysis_complete", {"score": 0.9}, "s01")

--- a/tests/unit/argumentation_analysis/orchestration/test_conversation_orchestrator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_conversation_orchestrator.py
@@ -237,9 +237,15 @@ class TestConversationOrchestrator:
         assert len(orch.conv_logger.tool_calls) <= 6
 
     def test_run_orchestration_trace_no_print(self):
-        orch = ConversationOrchestrator(mode="trace")
-        report = orch.run_orchestration(SAMPLE_TEXT)
-        assert isinstance(report, str)
+        # #1593: the name promises trace mode does NOT print, but the old
+        # ``isinstance(report, str)`` never checked print at all and passed
+        # with run_orchestration stubbed to "". Measured: trace produces a
+        # non-empty report (print is exercised via the conv_logger, not stdout).
+        with patch("builtins.print") as mock_print:
+            orch = ConversationOrchestrator(mode="trace")
+            report = orch.run_orchestration(SAMPLE_TEXT)
+        assert report, "trace mode produced an empty report"
+        mock_print.assert_not_called()
 
     @patch("builtins.print")
     def test_generate_report_content(self, mock_print):
@@ -284,7 +290,10 @@ class TestConversationOrchestrator:
         orch.agents[0] = FailingAgent()
         # Should not raise — errors are caught
         report = orch.run_orchestration(SAMPLE_TEXT)
-        assert isinstance(report, str)
+        # #1593: vacuous ``isinstance(report, str)`` passed with run_orchestration
+        # stubbed to "". The named property is graceful handling: a non-empty
+        # report is still produced (measured: ~3.8k chars) despite the agent error.
+        assert report, "no report produced despite handled error"
 
     @patch("builtins.print")
     def test_report_contains_text_excerpt(self, mock_print):
@@ -305,18 +314,20 @@ class TestFactoryAndModes:
     @patch("builtins.print")
     def test_run_mode_micro(self, mock_print):
         report = run_mode_micro(SAMPLE_TEXT)
-        assert isinstance(report, str)
+        # #1593: vacuous ``isinstance(report, str)`` passed with run_mode_micro
+        # stubbed to "". The mode must produce a (non-empty) report.
+        assert report, "micro mode produced an empty report"
 
     @patch("builtins.print")
     def test_run_mode_demo(self, mock_print):
         report = run_mode_demo(SAMPLE_TEXT)
-        assert isinstance(report, str)
+        assert report, "demo mode produced an empty report"
 
     def test_run_mode_trace(self):
         report = run_mode_trace(SAMPLE_TEXT)
-        assert isinstance(report, str)
+        assert report, "trace mode produced an empty report"
 
     @patch("builtins.print")
     def test_run_mode_enhanced(self, mock_print):
         report = run_mode_enhanced(SAMPLE_TEXT)
-        assert isinstance(report, str)
+        assert report, "enhanced mode produced an empty report"

--- a/tests/unit/argumentation_analysis/plugins/test_governance_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_governance_plugin.py
@@ -25,7 +25,10 @@ class TestDetectConflicts:
     def test_no_conflicts(self, plugin):
         positions = {"agent_a": "agree", "agent_b": "agree"}
         result = json.loads(plugin.detect_conflicts_fn(json.dumps(positions)))
-        assert isinstance(result, list)
+        # #1593: ``isinstance(result, list)`` passed even with detect_conflicts_fn
+        # stubbed to report a fake conflict — it never checked emptiness. The name
+        # promises NO conflicts, i.e. an empty list.
+        assert result == [], f"expected no conflicts, got {result}"
 
     def test_opposing_positions(self, plugin):
         positions = {"agent_a": "pour", "agent_b": "contre"}
@@ -41,12 +44,20 @@ class TestDetectConflicts:
     def test_single_agent(self, plugin):
         positions = {"agent_a": "pour"}
         result = json.loads(plugin.detect_conflicts_fn(json.dumps(positions)))
-        assert isinstance(result, list)
+        # #1593: a single agent cannot conflict with itself; the name promises
+        # an empty list, not just a list. Stubbed to a fake conflict, the old
+        # ``isinstance`` assertion still passed.
+        assert result == [], f"expected no conflict for a single agent, got {result}"
 
     def test_three_agents_mixed(self, plugin):
         positions = {"a": "pour", "b": "contre", "c": "pour"}
         result = json.loads(plugin.detect_conflicts_fn(json.dumps(positions)))
-        assert isinstance(result, list)
+        # #1593: ``isinstance(result, list)`` passed even with detect_conflicts_fn
+        # stubbed to ``[]`` (no detection). The name "mixed" promises conflicts
+        # ARE detected — mirrors test_opposing_positions.
+        assert (
+            len(result) >= 1
+        ), f"expected conflicts among mixed positions, got {result}"
 
 
 # ============================================================
@@ -64,7 +75,10 @@ class TestResolveConflict:
         result = json.loads(
             plugin.resolve_conflict_fn(json.dumps(conflict), strategy="collaborative")
         )
-        assert isinstance(result, dict)
+        # #1593: ``isinstance(result, dict)`` passed with resolve_conflict_fn
+        # stubbed to a dict with no resolution fields. The name promises the
+        # collaborative STRATEGY is honored — measured: resolution_type == collaborative.
+        assert result.get("resolution_type") == "collaborative", result
 
     def test_competitive(self, plugin):
         conflict = {
@@ -75,7 +89,9 @@ class TestResolveConflict:
         result = json.loads(
             plugin.resolve_conflict_fn(json.dumps(conflict), strategy="competitive")
         )
-        assert isinstance(result, dict)
+        # #1593: vacuous ``isinstance(result, dict)``. Name promises the
+        # competitive strategy — measured: resolution_type == competitive.
+        assert result.get("resolution_type") == "competitive", result
 
     def test_arbitration(self, plugin):
         conflict = {
@@ -86,7 +102,12 @@ class TestResolveConflict:
         result = json.loads(
             plugin.resolve_conflict_fn(json.dumps(conflict), strategy="arbitration")
         )
-        assert isinstance(result, dict)
+        # #1593: vacuous ``isinstance(result, dict)``. NOTE: arbitration currently
+        # maps to the collaborative resolution in production (resolution_type ==
+        # "collaborative"), so we assert the real invariant the name still implies
+        # — the conflict's agents are carried through — rather than a strategy
+        # value the code does not produce. Flagged in PR #1593; prod untouched.
+        assert result.get("agents") == ["a", "b"], result
 
     def test_default_strategy(self, plugin):
         conflict = {
@@ -95,7 +116,10 @@ class TestResolveConflict:
             "conflict_level": "low",
         }
         result = json.loads(plugin.resolve_conflict_fn(json.dumps(conflict)))
-        assert isinstance(result, dict)
+        # #1593: vacuous ``isinstance(result, dict)``. The default strategy still
+        # resolves the conflict — the real invariant is the conflict's agents
+        # are preserved in the resolution (stubbed to a keyless dict, this fails).
+        assert result.get("agents") == ["a", "b"], result
 
 
 # ============================================================


### PR DESCRIPTION
Partial honest triage of #1593 — the 56 candidates left after the coordinator's #1595 (`test_allocator.py`, 8). Three concentrated blocs, triaged **by measurement not reading**: `governance_plugin` (7), `conversation_orchestrator` (6), `communication adapters` (5).

**18 candidats, 18 confirmés vides, 18 resserrés. 0 SAIN / 18 — taux de faux positifs 0% sur les blocs concentrés.** Delta de tally = 0 (107 passed avant/après sur les 3 fichiers).

## Le contrôle — substitution dégénérée

Pour chaque candidat: stubber le callable de production à une valeur **WRONG-but-typed** (un faux conflit pour `detect_conflicts`, `""` pour les reports, un dict sans invariants pour `resolve_conflict`). Si le test passe quand même, l'assertion ne mord pas.

| Bloc | prod stubbée (wrong-but-typed) | Avant | Après resserrement |
|---|---|---|---|
| governance `detect_conflicts` (3) | faux conflit `[{"agents":["FAKE"]}]` / empty `[]` | 3 passed | 3 failed |
| governance `resolve_conflict` (4) | `{"unrelated_key":"x"}` (no invariants) | 4 passed | 4 failed |
| `conversation_orchestrator` (6) | `run_*` stubbed to `""` | 6 passed | 6 failed |
| communication adapters (5) | adapter methods stubbed to `""` | 5 passed | 5 failed |

Substitution nuance: un stub égal à la vraie réponse ne prouve rien. Pour `test_three_agents_mixed` (« doit détecter »), c'est le stub **vide** `[]` qui prouve la vacuité (l'ancien `isinstance` passait); pour `test_no_conflicts` (« doit être vide »), c'est le stub **faux-conflit**. Chaque resserrement est vérifié mordre sous le dégénéré approprié ET passer en prod réelle.

## Propriétés désormais assertées (mesurées)

| Test | Propriété du nom désormais vérifiée | Mesuré |
|---|---|---|
| `test_no_conflicts` / `test_single_agent` | NO conflicts ⇒ liste vide | `[]` |
| `test_three_agents_mixed` | conflits DETECTED ⇒ len ≥ 1 | 2 conflits |
| `test_collaborative` / `test_competitive` | stratégie honorée ⇒ `resolution_type` | collaborative / competitive |
| `test_arbitration` / `test_default_strategy` | agents du conflit préservés | `["a","b"]` |
| `test_run_orchestration_trace_no_print` | trace ne imprime PAS + report non vide | `print` call_count = 0 |
| `test_agent_error_handled` | report non vide malgré agent défaillant | ~3.8k chars |
| `test_run_mode_micro/demo/trace/enhanced` | report non vide | 3.1k–5.1k chars |
| adapters `test_*_message_id` / `send_failure` | id non vide retourné (même si send échoue) | uuid |

## Note — arbitrage est un possible écart prod (signalé, non corrigé)

`resolve_conflict_fn(strategy="arbitration")` retourne `resolution_type == "collaborative"` (identique au défaut) — la prod ne différencie pas l'arbitrage. **Aucun code de production touché** (anti-pendule); le test asserte l'invariant réel mesuré (agents préservés) et l'écart est signalé ici pour décision séparée.

## Reste — singletons (~38 candidats)

Laissés pour un suivi. Prédiction du coordinateur (R746): les singletons mordent souvent par un `mock.assert_called_once()` ou une exception non levée — invisibles au scan AST — donc leur taux de faux positifs devrait être plus élevé que les 0% mesurés sur les blocs concentrés. Ce sera l'information utile du prochain lot.

## Anti-pendule

0 test supprimé, 0 code de production touché, 0 marqueur `slow`/`requires_api` ajouté, `ci.yml` intact. Assertions au niveau de la propriété nommée — pas de `result == {...}` exhaustif.

## Validation (locale; les 3 fichiers sont dans le gate CI `tests/unit/`)

- 3 fichiers: **107 passed**, delta tally 0.
- `black --check`: clean · `flake8`: clean.

Awaits coordinator `--admin` merge (shared write-account blocks worker self-approve).

Addresses #1593 (partial: 18/56).