### PR TITLE
test(tighten): prove non-failing singleton assertions bite (#1593)

### DIFF
--- a/tests/unit/argumentation_analysis/agents/tools/analysis/new/test_contextual_fallacy_detector.py
+++ b/tests/unit/argumentation_analysis/agents/tools/analysis/new/test_contextual_fallacy_detector.py
@@ -265,16 +265,22 @@ class TestDetectContextualFallacies:
             "Selon l'expert, ce produit est sûr.", "commercial"
         )
         fallacies = result["detected_fallacies"]
-        # Should detect something with "expert" and "selon" markers
-        assert isinstance(fallacies, list)
+        # #1593: ``isinstance(fallacies, list)`` passed even with detection stubbed
+        # to return []. The name promises authority markers ARE detected here
+        # ("expert"/"selon") — measured: 1 fallacy on this input.
+        assert (
+            len(fallacies) >= 1
+        ), f"expected authority markers detected, got {fallacies}"
 
     def test_no_fallacies_in_clean_text(self, detector):
         result = detector.detect_contextual_fallacies(
             "La terre tourne autour du soleil.", "scientifique"
         )
-        # Simple factual statement — unlikely to trigger markers
-        # (depends on exact rules, just check structure)
-        assert isinstance(result["detected_fallacies"], list)
+        fallacies = result["detected_fallacies"]
+        # #1593: ``isinstance(fallacies, list)`` passed even with detection stubbed
+        # to report a FAKE fallacy. The name promises NO fallacies on a clean
+        # factual statement — measured: 0.
+        assert fallacies == [], f"expected no fallacies on clean text, got {fallacies}"
 
     def test_contextual_factors_inferred(self, detector):
         result = detector.detect_contextual_fallacies(

--- a/tests/unit/argumentation_analysis/agents/tools/test_fallacy_analyzers.py
+++ b/tests/unit/argumentation_analysis/agents/tools/test_fallacy_analyzers.py
@@ -442,7 +442,12 @@ class TestContextualFallacyAnalyzer:
             fallacies = analyzer.identify_contextual_fallacies(
                 "Le chat dort.", "général"
             )
-            assert isinstance(fallacies, list)
+            # #1593: ``isinstance(fallacies, list)`` passed even with the method
+            # stubbed to return a FAKE non-empty list. The name promises empty
+            # text yields no fallacies — measured: [].
+            assert (
+                fallacies == []
+            ), f"expected no fallacies on empty text, got {fallacies}"
 
     # --- get_contextual_fallacy_examples ---
 
@@ -732,7 +737,10 @@ class TestComplexFallacyAnalyzer:
     def test_fallacy_patterns_empty_text(self, analyzer, mock_contextual):
         mock_contextual.identify_contextual_fallacies.return_value = []
         result = analyzer.identify_fallacy_patterns("")
-        assert isinstance(result, list)
+        # #1593: ``isinstance(result, list)`` passed even with identify_fallacy_patterns
+        # stubbed to return a FAKE non-empty list. The name promises empty text
+        # yields no patterns — measured: [].
+        assert result == [], f"expected no patterns on empty text, got {result}"
 
     def test_fallacy_patterns_delegates_to_contextual(self, analyzer, mock_contextual):
         mock_contextual.identify_contextual_fallacies.return_value = []

--- a/tests/unit/argumentation_analysis/plugins/test_narrate_convergence.py
+++ b/tests/unit/argumentation_analysis/plugins/test_narrate_convergence.py
@@ -186,7 +186,10 @@ class TestNarrateConvergenceFallback:
         """Malformed JSON → parsed as empty state → template narrative."""
         plugin = NarrativeSynthesisPlugin(kernel=None)
         result = await plugin.narrate_convergence(state_json="not-json{{{")
-        assert isinstance(result, str)
+        # #1593: ``isinstance(result, str)`` passed even with narrate_convergence
+        # stubbed to "". The name promises a (non-empty) fallback narrative is
+        # produced despite the bad JSON — measured: ~284 chars.
+        assert result, "no fallback narrative produced on bad JSON"
 
 
 # ---------------------------------------------------------------------------
@@ -257,7 +260,10 @@ class TestNarrativeSynthesisPluginInit:
     def test_synthesize_still_works(self):
         plugin = NarrativeSynthesisPlugin()
         result = plugin.synthesize(state_json="{}")
-        assert isinstance(result, str)
+        # #1593: ``isinstance(result, str)`` passed even with synthesize stubbed
+        # to "". The name promises synthesize still produces a (non-empty)
+        # narrative — measured: ~134 chars.
+        assert result, "synthesize produced an empty result"
 
     def test_convergent_synthesize_still_works(self):
         plugin = NarrativeSynthesisPlugin()

--- a/tests/unit/argumentation_analysis/utils/test_tweety_error_analyzer.py
+++ b/tests/unit/argumentation_analysis/utils/test_tweety_error_analyzer.py
@@ -244,7 +244,10 @@ class TestGenerateExampleFix:
         fix = analyzer._generate_example_fix(
             "syntax_error", "missing something before '.'", "rule(X) :- body"
         )
-        assert isinstance(fix, str)
+        # #1593: ``isinstance(fix, str)`` passed even with _generate_example_fix
+        # stubbed to "". The name promises a (non-empty) fix suggestion is
+        # produced even with a partial context — measured: ~53 chars.
+        assert fix, "no fix produced for syntax error with context"
 
     def test_no_entity_in_error(self, analyzer):
         fix = analyzer._generate_example_fix("atom_error", "atom not defined", None)
@@ -384,7 +387,10 @@ class TestAnalyzeTweetyError:
 
     def test_with_context(self):
         result = analyze_tweety_error("syntax error", context="rule(X).")
-        assert isinstance(result, str)
+        # #1593: ``isinstance(result, str)`` passed even with analyze_tweety_error
+        # stubbed to "". The name promises a (non-empty) feedback that uses the
+        # provided context — measured: ~725 chars.
+        assert result, "no feedback produced for error with context"
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

Second lot of the #1593 non-failing-assertion triage (singletons). Follows #1599 (18 concentrated-bloc candidates, awaiting admin-merge). Each candidate is decided by the **degenerate-substitution method**: inject a WRONG-but-typed stub into the prod callable; if the test still passes, the assertion does not bite (VIDE) → concentrate to a property-of-name check that fails on the degenerate value. A candidate whose probe cannot be invalidated is SAIN and is left untouched (anti-pendule: a healthy candidate is a deliverable).

## Candidates decided in this lot (10)

**8 VIDE → tightened** (bite proven under degenerate stub or by construction):

| File | Test | Old assertion | New assertion | Measured |
|------|------|---------------|---------------|----------|
| `test_contextual_fallacy_detector.py` | `test_detects_authority_markers` | `isinstance(fallacies, list)` | `len(fallacies) >= 1` | 1 fallacy |
| `test_contextual_fallacy_detector.py` | `test_no_fallacies_in_clean_text` | `isinstance(fallacies, list)` | `fallacies == []` | 0 |
| `test_fallacy_analyzers.py` | `test_identify_contextual_fallacies_empty_text` | `isinstance(fallacies, list)` | `fallacies == []` | `[]` |
| `test_fallacy_analyzers.py` | `test_fallacy_patterns_empty_text` | `isinstance(result, list)` | `result == []` | `[]` |
| `test_narrate_convergence.py` | `test_fallback_on_bad_json` | `isinstance(result, str)` | `assert result` | len=284 |
| `test_narrate_convergence.py` | `test_synthesize_still_works` | `isinstance(result, str)` | `assert result` | len=134 |
| `test_tweety_error_analyzer.py` | `test_syntax_error_with_missing_context` | `isinstance(fix, str)` | `assert fix` | len=53 |
| `test_tweety_error_analyzer.py` | `test_with_context` | `isinstance(result, str)` | `assert result` | len=725 |

**2 SAIN — not tightened** (anti-pendule, reported honestly):
- `test_default_chat_model`, `test_deployment_name_optional` (`test_settings.py`) — pydantic v2 instance-field defaults shadow the class-level monkeypatch, so the probe was invalid; the latter's `is None or isinstance(str)` is exactly the optional property.

## Validation

- Degenerate stub bite: 7/8 confirmed under runtime semantic stub; `test_with_context` bite confirmed by Python `bool("")` construction (top-level import binding resists source-module patch — documented honestly).
- Real-prod tally on all 4 files: **220 passed**, delta 0 (no regressions, no added tests).
- black clean, flake8 clean, mypy N/A (test files not in CI gate scope).

## Partial honest triage

~28 singletons remain untriaged after this lot. Per #1593: "Un tri partiel honnête vaut mieux qu'un balayage non mesuré."

Co-Authored-By: Claude-Code <noreply@anthropic.com>