### PR TITLE
test(tighten): prove non-failing mute-capability assertions bite (#1593)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_mute_capabilities_b02.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_mute_capabilities_b02.py
@@ -19,7 +19,6 @@ from argumentation_analysis.core.shared_state import (
     UnifiedAnalysisState,
 )
 
-
 # ---------------------------------------------------------------------------
 # Test: _invoke_sat (SAT solving)
 # ---------------------------------------------------------------------------
@@ -34,6 +33,7 @@ class TestInvokeSAT:
 
     def _get_invoke(self):
         from argumentation_analysis.orchestration.invoke_callables import _invoke_sat
+
         return _invoke_sat
 
     @patch(
@@ -42,7 +42,11 @@ class TestInvokeSAT:
     def test_basic_sat_solve(self, MockSATHandler):
         """SAT handler returns satisfiable result for simple formula."""
         mock_instance = MagicMock()
-        mock_instance.solve_formulas.return_value = (True, {"p": True}, {"backend": "Z3"})
+        mock_instance.solve_formulas.return_value = (
+            True,
+            {"p": True},
+            {"backend": "Z3"},
+        )
         MockSATHandler.return_value = mock_instance
 
         invoke = self._get_invoke()
@@ -65,7 +69,10 @@ class TestInvokeSAT:
         result = asyncio.get_event_loop().run_until_complete(
             invoke("", {"formulas": []})
         )
-        assert isinstance(result, dict)
+        # #1593: ``isinstance(result, dict)`` passed even with _invoke_sat stubbed
+        # to {}. The name promises "handles empty input gracefully" → the SAT
+        # verdict structure is present (mirrors sibling test_basic_sat_solve).
+        assert "satisfiable" in result, f"expected SAT verdict structure, got {result}"
 
     @patch(
         "argumentation_analysis.agents.core.logic.sat_handler.SATHandler",
@@ -89,14 +96,23 @@ class TestInvokeSAT:
     def test_custom_solver(self, MockSATHandler):
         """SAT handler respects solver choice from context."""
         mock_instance = MagicMock()
-        mock_instance.solve_formulas.return_value = (True, {"p": True}, {"backend": "cadical195"})
+        mock_instance.solve_formulas.return_value = (
+            True,
+            {"p": True},
+            {"backend": "cadical195"},
+        )
         MockSATHandler.return_value = mock_instance
 
         invoke = self._get_invoke()
         result = asyncio.get_event_loop().run_until_complete(
             invoke("p", {"formulas": ["p"], "solver": "cadical195"})
         )
-        assert isinstance(result, dict)
+        # #1593: ``isinstance(result, dict)`` passed even with _invoke_sat stubbed
+        # to {}. The name promises "respects solver choice" → the chosen solver
+        # propagates to the statistics backend.
+        assert (
+            result.get("statistics", {}).get("backend") == "cadical195"
+        ), f"solver choice not reflected in stats, got {result}"
 
 
 # ---------------------------------------------------------------------------
@@ -111,14 +127,13 @@ class TestInvokeStakesExtractor:
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_stakes_extractor,
         )
+
         return _invoke_stakes_extractor
 
     def test_no_state_returns_error(self):
         """When no state object in context, returns error dict."""
         invoke = self._get_invoke()
-        result = asyncio.get_event_loop().run_until_complete(
-            invoke("test text", {})
-        )
+        result = asyncio.get_event_loop().run_until_complete(invoke("test text", {}))
         assert "error" in result
 
     @patch(
@@ -216,14 +231,13 @@ class TestInvokeDeepSynthesis:
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_deep_synthesis,
         )
+
         return _invoke_deep_synthesis
 
     def test_no_state_returns_error(self):
         """When no state object in context, returns error dict."""
         invoke = self._get_invoke()
-        result = asyncio.get_event_loop().run_until_complete(
-            invoke("test text", {})
-        )
+        result = asyncio.get_event_loop().run_until_complete(invoke("test text", {}))
         assert "error" in result
 
     def test_deep_synthesis_on_populated_state(self):
@@ -251,7 +265,13 @@ class TestInvokeDeepSynthesis:
         result = asyncio.get_event_loop().run_until_complete(
             invoke("", {"_state_object": state, "source_metadata": {}})
         )
-        assert isinstance(result, dict)
+        # #1593: ``isinstance(result, dict)`` passed even with _invoke_deep_synthesis
+        # stubbed to {}. The name promises "handles empty state without crash" →
+        # the result carries deep-synthesis's structure (error + artifact fields),
+        # not just any dict.
+        assert (
+            "populated_artifact_fields" in result
+        ), f"expected deep-synthesis structure on empty state, got {result}"
 
 
 # ---------------------------------------------------------------------------
@@ -266,12 +286,14 @@ class TestInvokeCollaborativeAnalysis:
         from argumentation_analysis.orchestration.collaborative_debate import (
             _invoke_collaborative_analysis,
         )
+
         return _invoke_collaborative_analysis
 
     @patch.dict("os.environ", {}, clear=False)
     def test_no_api_key_uses_fallback(self):
         """When no API key, falls back to heuristic analysis."""
         import os
+
         # Ensure OPENAI_API_KEY is empty
         original = os.environ.get("OPENAI_API_KEY")
         os.environ["OPENAI_API_KEY"] = ""
@@ -282,7 +304,9 @@ class TestInvokeCollaborativeAnalysis:
             )
             assert isinstance(result, dict)
             # Fallback path returns structured analysis with agent_outputs, etc.
-            assert "agent_outputs" in result or "summary" in result or "fallback" in result
+            assert (
+                "agent_outputs" in result or "summary" in result or "fallback" in result
+            )
         finally:
             if original:
                 os.environ["OPENAI_API_KEY"] = original
@@ -305,7 +329,13 @@ class TestInvokeCollaborativeAnalysis:
         result = asyncio.get_event_loop().run_until_complete(
             invoke("test input", context)
         )
-        assert isinstance(result, dict)
+        # #1593: ``isinstance(result, dict)`` passed even with
+        # _invoke_collaborative_analysis stubbed to {}. The name promises
+        # "fallback path uses extract/quality context" → a structured analysis
+        # is produced (mirrors sibling test_no_api_key_uses_fallback).
+        assert (
+            "agent_outputs" in result
+        ), f"expected structured fallback analysis, got {result}"
 
 
 # ---------------------------------------------------------------------------
@@ -320,6 +350,7 @@ class TestSATStateWriter:
         from argumentation_analysis.orchestration.state_writers import (
             _write_sat_to_state,
         )
+
         return _write_sat_to_state
 
     def test_write_sat_result_to_state(self):
@@ -355,6 +386,7 @@ class TestCollaborativeStateWriter:
         from argumentation_analysis.orchestration.state_writers import (
             _write_collaborative_analysis_to_state,
         )
+
         return _write_collaborative_analysis_to_state
 
     def test_write_collaborative_result_to_state(self):


### PR DESCRIPTION
## Summary

Third lot of the #1593 non-failing-assertion triage: the concentrated 4-candidate bloc in `test_mute_capabilities_b02.py` (unfrozen now that #1582 is closed). Follows #1599 (18 blocs) and #1600 (8 singletons + 2 SAIN). Each candidate decided by degenerate substitution: stub the prod invoke callable to return `{}` (wrong-but-typed — passes `isinstance(result, dict)` but violates the named property); if the test still passes, the assertion is VIDE → tighten to a property-of-name check that fails on `{}`.

## Candidates (4 VIDE → tightened)

| Test | Named property | Old assertion | New assertion | Real return shape |
|------|---------------|---------------|---------------|-------------------|
| `test_empty_formulas` | "handles empty input gracefully" | `isinstance(result, dict)` | `"satisfiable" in result` | `{satisfiable, model, statistics}` |
| `test_custom_solver` | "respects solver choice" | `isinstance(result, dict)` | `result["statistics"]["backend"] == "cadical195"` | `{satisfiable, model, statistics}` |
| `test_deep_synthesis_empty_state` | "handles empty state without crash" | `isinstance(result, dict)` | `"populated_artifact_fields" in result` | `{error, fail_explicit, populated_artifact_fields}` |
| `test_fallback_with_context` | "fallback uses extract/quality context" | `isinstance(result, dict)` | `"agent_outputs" in result` | `{agent_outputs, agents_involved, ...}` |

## Control table (coord R747 isolation — each bite fails SOLO)

| State | Result |
|-------|--------|
| prod stubbed → `{}` | **4 failed** (only the tightened assertion catches the empty dict) |
| prod real | **4 passed** |

The degenerate `{}` is the right probe: the test bodies complete (no exception), the stub returns `{}`, and ONLY the new assertion fails — proving the bite is isolated, not masked by a pre-existing check.

## Validation

- File tally: **16 passed** (delta 0 — no regression, no test added/removed/marked).
- black clean, flake8 clean.
- Deconflicted from po-2023's PR #1598: that PR touches only `_invoke_counter_argument` (adds `degraded=True`), not the 3 invoke callables tested here (`_invoke_sat`, `_invoke_deep_synthesis`, `_invoke_collaborative_analysis`). Base is stable.

## Partial honest triage

0% false positives on this concentrated bloc (consistent with allocator 0/8, governance 0/7, conversation_orch 0/6, adapters 0/5). ~24 singletons remain; per coord R746 prediction, singletons carry a >0% false-positive rate (bite via `mock.assert_called_once` / exception-not-raised, invisible to AST).

Co-Authored-By: Claude-Code <noreply@anthropic.com>