### PR TITLE
test(tighten): prove non-failing singleton assertions bite (#1593, lot-4)

### DIFF
--- a/tests/unit/argumentation_analysis/plugins/analysis_tools/logic/test_enhanced_contextual_fallacy_analyzer.py
+++ b/tests/unit/argumentation_analysis/plugins/analysis_tools/logic/test_enhanced_contextual_fallacy_analyzer.py
@@ -539,7 +539,14 @@ class TestIdentifyContextualFallacies:
         # In political context, Ad hominem gets +0.3 -> 0.4 still below 0.5?
         # Actually: 0.1 + 0.3 = 0.4, filtered out (< 0.5)
         # But result depends on exact boosting
-        assert isinstance(result, list)
+        # #1593: ``isinstance(result, list)`` passed even when a fake-full list
+        # (fallacy NOT filtered) was returned — it cannot distinguish "filtered"
+        # from "passed through". The name promises low-confidence is filtered OUT
+        # → the result is empty (mirrors sibling test_high_confidence_passed_through
+        # which asserts len==1 for the kept fallacy). Real prod returns [] here.
+        assert (
+            result == []
+        ), f"expected low-confidence fallacy filtered out, got {result}"
 
     def test_high_confidence_passed_through(self, analyzer, mock_detector):
         mock_detector.detect_fallacies.return_value = [

--- a/tests/unit/argumentation_analysis/plugins/test_quality_scoring_plugin.py
+++ b/tests/unit/argumentation_analysis/plugins/test_quality_scoring_plugin.py
@@ -56,7 +56,10 @@ class TestEvaluateArgumentQuality:
 
     def test_empty_text(self, plugin):
         result = json.loads(plugin.evaluate_argument_quality(""))
-        assert isinstance(result, dict)
+        # #1593: ``isinstance(result, dict)`` passed even with evaluate_argument_quality
+        # stubbed to "{}". The name promises empty text is scored (not crashed) →
+        # the result carries the quality structure (mirrors test_has_note_finale).
+        assert "note_finale" in result, f"expected quality structure, got {result}"
 
     def test_long_text(self, plugin):
         text = "Cet argument est bien construit. " * 20


### PR DESCRIPTION
## Summary

Fourth lot of the #1593 non-failing-assertion triage (singletons). Follows #1599 (18 blocs), #1600 (8 singletons + 2 SAIN), #1601 (4 mute bloc). This lot **confirms coord R746 prediction**: singletons carry a >0% false-positive rate. The `isinstance(list/str)` singletons bite on the standard `{}` probe (SAIN), unlike the concentrated `isinstance(dict)` blocs which were 0% FP across allocator/governance/conversation_orch/adapters/mute.

## 8 candidates decided

**2 VIDE → tightened** (bite proven, control table below):

| Test | Named property | Old | New | Real prod |
|------|---------------|-----|-----|-----------|
| `quality::test_empty_text` | empty text scored | `isinstance(result, dict)` | `"note_finale" in result` | `{note_finale, note_moyenne, rapport_detaille, scores_par_vertu}` |
| `enhanced CFA::test_filters_by_confidence` | low-conf filtered OUT | `isinstance(result, list)` | `result == []` | `[]` (0.1+0.3=0.4 < 0.5) |

The second is the nuanced case: `isinstance(list)` is SAIN-by-type under `{}` (bites a dict return), but **VIDE-by-name** under a semantic degenerate `[FakeFallacy]` (a fallacy that passed through unfiltered is still a list). The name promises filtering, so the tightening mirrors sibling `test_high_confidence_passed_through` (`len==1` for the kept fallacy).

**5 SAIN — reported, not tightened** (bite confirmed on degenerate):
- `test_contexts_are_strings` (isinstance str bites non-string)
- `test_detect_empty_text` (isinstance list bites non-list; real=[])
- `test_all_values_are_lists` (isinstance list bites non-list)
- `test_metadata_non_serializable_converted` (isinstance str bites unconverted obj)
- `test_generate_simple_summary` (isinstance str bites non-str)

**1 structural VIDE — reported, degenerate method inapplicable** (anti-pendule: left untouched):
- `test_valid_presets` — asserts `isinstance(preset, str)` over the string literals `"all"/"core"/"none"`, which is always true by construction; there is no prod callable to stub. Redesigning it to check validity against the parser's choice set is a behavior change, out of scope for this triage.

## Control table (coord R747 isolation — each bite fails SOLO)

| State | `quality::test_empty_text` | `enhanced CFA::test_filters_by_confidence` |
|-------|---------------------------|-------------------------------------------|
| prod stubbed → degenerate | **failed** (`"{}"` → no `note_finale`) | **failed** (`[FakeFallacy]` → not `[]`) |
| prod real | passed | passed |

## Validation

- File tallies: quality **13 passed**, enhanced CFA **55 passed** (delta 0 — no regression).
- black + flake8 clean.

## Partial honest triage

2 tightened + 5 SAIN + 1 structural in this lot of 8. Singleton FP rate (SAIN + structural / total) = 6/8 = 75%, confirming the predicted >0% rate vs the 0% on concentrated blocs. ~16 singletons remain.

Co-Authored-By: Claude-Code <noreply@anthropic.com>