### PR TITLE
chore(gitignore): scope package-lock.json ignore to root only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,7 @@ tmp/
 
 # === Node.js ===
 node_modules/
-package-lock.json
+/package-lock.json
 
 # === Playwright ===
 playwright-report/


### PR DESCRIPTION
## What

Scope the `package-lock.json` ignore (line 107) to **root-only** (`/package-lock.json`).

## Why

The broad `package-lock.json` pattern ignores lockfiles at **all** directory levels. The 3 existing nested lockfiles are tracked only because they were added *before* the rule — any new nested subproject would have its lockfile **silently ignored**, causing dependency drift.

| path | before | after |
|------|--------|-------|
| `package-lock.json` (root) | ignored | ignored (no root package.json/lockfile anyway) |
| `3.1.5_Interface_Mobile/package-lock.json` | tracked (grandfathered) | tracked (and no longer matched by rule) |
| new `<sub>/package-lock.json` | silently ignored | tracked |

Verified with `git check-ignore -v`: root still ignored, nested + deep-nested no longer matched.

## Provenance

- Finding: po-2023 c.140 (whitelist nested lockfile)
- Campaign: roo-extensions [#3042](https://github.com/jsboige/roo-extensions/issues/3042) (myia-po-2025 lane, item 3)

1-file, 1-line diff. No code or test impact.

🤖 myia-po-2025 · executor · #3042 item 3