### PR TITLE
feat(restitution): Act III carries the lost dimensions AND refuses claims without support (#1605)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -1368,22 +1368,54 @@ def _gate_unsupported_claims(
     return _drop_empty_headings("\n".join(out_lines)), blocked
 
 
+def _heading_depth(line: str) -> int:
+    """Markdown depth of a heading line, or 0 when the line is not a heading."""
+    stripped = line.lstrip()
+    if not stripped.startswith("#"):
+        return 0
+    return len(stripped) - len(stripped.lstrip("#"))
+
+
 def _drop_empty_headings(text: str) -> str:
-    """Remove headings left with no content beneath them, and collapse gaps."""
+    """Remove headings whose whole subtree is empty, and collapse the gaps.
+
+    Emptiness is a property of the SUBTREE, not of the lines immediately
+    below. A heading that carries its content in subsections has nothing
+    directly under it, and a rule that only looked ahead to the next heading
+    would delete it while keeping its children — mangling the hierarchy of a
+    document the gate never touched. The narrative here is free-form markdown
+    conducted by the LLM (``weave_act3_conclusion``), so nested headings are
+    ordinary input, not a corner case.
+
+    Walks backwards so children are decided before their parents: a heading
+    survives if it has own content OR if any of its descendants survived.
+    """
     lines = text.split("\n")
-    kept: List[str] = []
-    for i, line in enumerate(lines):
-        if line.lstrip().startswith("#"):
-            has_content = False
-            for nxt in lines[i + 1 :]:
-                if nxt.lstrip().startswith("#"):
-                    break
-                if nxt.strip():
-                    has_content = True
-                    break
-            if not has_content:
-                continue
-        kept.append(line)
+    dropped: set[int] = set()
+    # Depths of surviving headings already decided BELOW the current line and
+    # not yet absorbed by a shallower heading — i.e. the current candidate's
+    # descendants once we reach it.
+    surviving_below: List[int] = []
+    for i in range(len(lines) - 1, -1, -1):
+        depth = _heading_depth(lines[i])
+        if depth == 0:
+            continue
+        has_own_content = False
+        for nxt in lines[i + 1 :]:
+            if _heading_depth(nxt):
+                break
+            if nxt.strip():
+                has_own_content = True
+                break
+        has_surviving_descendant = any(d > depth for d in surviving_below)
+        # Everything deeper than this heading belongs to its subtree; it is
+        # now accounted for and must not count for anything further up.
+        surviving_below = [d for d in surviving_below if d <= depth]
+        if has_own_content or has_surviving_descendant:
+            surviving_below.append(depth)
+        else:
+            dropped.add(i)
+    kept = [line for i, line in enumerate(lines) if i not in dropped]
     return re.sub(r"\n{3,}", "\n\n", "\n".join(kept)).strip()
 
 

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -1362,9 +1362,29 @@ def _gate_unsupported_claims(
 
     if not blocked:
         return narrative, []
-    # Removing sentences can leave runs of blank lines where a paragraph was.
-    gated = re.sub(r"\n{3,}", "\n\n", "\n".join(out_lines)).strip()
-    return gated, blocked
+    # Removing sentences can leave runs of blank lines where a paragraph was,
+    # and can empty a section outright — a bare heading with nothing under it
+    # is an artefact of the gate, not something the reader should receive.
+    return _drop_empty_headings("\n".join(out_lines)), blocked
+
+
+def _drop_empty_headings(text: str) -> str:
+    """Remove headings left with no content beneath them, and collapse gaps."""
+    lines = text.split("\n")
+    kept: List[str] = []
+    for i, line in enumerate(lines):
+        if line.lstrip().startswith("#"):
+            has_content = False
+            for nxt in lines[i + 1 :]:
+                if nxt.lstrip().startswith("#"):
+                    break
+                if nxt.strip():
+                    has_content = True
+                    break
+            if not has_content:
+                continue
+        kept.append(line)
+    return re.sub(r"\n{3,}", "\n\n", "\n".join(kept)).strip()
 
 
 def _blocked_claim_note(blocked: List[BlockedClaim]) -> str:
@@ -1514,7 +1534,10 @@ async def build_act3_conclusion(
             narrative, evidence.verdict.nontrivial_axes
         )
         if blocked:
-            narrative = narrative.rstrip() + "\n\n" + _blocked_claim_note(blocked)
+            survivor = narrative.rstrip()
+            narrative = (survivor + "\n\n" if survivor else "") + _blocked_claim_note(
+                blocked
+            )
             degraded["act3_claim_blocked"] = (
                 f"{len(blocked)} affirmation(s) retirée(s), sans support dans "
                 "l'état : "
@@ -1522,6 +1545,16 @@ async def build_act3_conclusion(
                     f"{b.label} — « {_truncate(b.sentence, 90)} »" for b in blocked
                 )
             )
+            if not survivor:
+                # Every sentence rested on an axis the analysis never produced.
+                # Emitting only the removal note is the honest outcome, but a
+                # consumer reading `status == "woven"` would otherwise have no
+                # way to tell an empty conclusion from a written one.
+                degraded["act3_claim_blocked_all"] = (
+                    "Aucune phrase de la conclusion n'a survécu au gate : toutes "
+                    "reposaient sur des dimensions sans résultat dans l'état. "
+                    "Le livrable ne porte que l'avis de retrait."
+                )
 
     # §4 self-check (honest, never grades on a curve).
     gate = ReadabilityGate()

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -1387,8 +1387,17 @@ def _drop_empty_headings(text: str) -> str:
     return re.sub(r"\n{3,}", "\n\n", "\n".join(kept)).strip()
 
 
-def _blocked_claim_note(blocked: List[BlockedClaim]) -> str:
-    """The paragraph that replaces what was removed — the removal must be said."""
+def _blocked_claim_note(
+    blocked: List[BlockedClaim], *, nothing_survived: bool = False
+) -> str:
+    """The paragraph that replaces what was removed — the removal must be said.
+
+    ``nothing_survived`` is not cosmetic. The structured ``degraded`` dict does
+    NOT survive the state round-trip (``_write_act3_conclusion_to_state`` stores
+    only the narrative; see the provenance note in ``pipeline_adapter``), so the
+    narrative is the ONLY surface that reaches the reader. If every sentence was
+    removed, the emptiness has to be stated *here* or it is not stated at all.
+    """
     labels = sorted({b.label for b in blocked})
     if len(labels) == 1:
         listing = labels[0]
@@ -1396,6 +1405,15 @@ def _blocked_claim_note(blocked: List[BlockedClaim]) -> str:
     else:
         listing = ", ".join(labels[:-1]) + f" et {labels[-1]}"
         subject = "des dimensions que cette analyse n'a pas pu établir"
+    if nothing_survived:
+        return (
+            "### Aucune conclusion soutenable\n\n"
+            "**Il ne reste aucune conclusion.** L'intégralité de la conclusion "
+            f"conduite reposait sur {subject} : {listing}. Tout a été retiré : "
+            "il ne s'agit pas d'une conclusion écourtée mais d'une conclusion "
+            "dont aucune affirmation n'avait de support dans l'état de "
+            "l'analyse. Le lecteur ne doit rien en inférer."
+        )
     return (
         "### Affirmation retirée\n\n"
         f"La conclusion conduite s'appuyait sur {subject} : {listing}. "
@@ -1535,8 +1553,11 @@ async def build_act3_conclusion(
         )
         if blocked:
             survivor = narrative.rstrip()
+            # When nothing survives, the note IS the whole deliverable and must
+            # say so in the prose: the structured `degraded` dict below is
+            # dropped by the state round-trip, so it cannot carry that fact.
             narrative = (survivor + "\n\n" if survivor else "") + _blocked_claim_note(
-                blocked
+                blocked, nothing_survived=not survivor
             )
             degraded["act3_claim_blocked"] = (
                 f"{len(blocked)} affirmation(s) retirée(s), sans support dans "
@@ -1546,10 +1567,6 @@ async def build_act3_conclusion(
                 )
             )
             if not survivor:
-                # Every sentence rested on an axis the analysis never produced.
-                # Emitting only the removal note is the honest outcome, but a
-                # consumer reading `status == "woven"` would otherwise have no
-                # way to tell an empty conclusion from a written one.
                 degraded["act3_claim_blocked_all"] = (
                     "Aucune phrase de la conclusion n'a survécu au gate : toutes "
                     "reposaient sur des dimensions sans résultat dans l'état. "

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -48,6 +48,7 @@ files, append-only.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
@@ -112,6 +113,97 @@ _AXIS_DUNG = "dung"
 _EXCEEDED_MIN_AXES = 5
 _MATCH_MIN_AXES = 4
 _PARTIAL_MIN_AXES = 2
+
+# Single definition of the axis set, shared by the band computation and the
+# claim gate below. Two lists would drift, and the gate's whole job is to be
+# exactly as wide as the band's notion of coverage.
+_ALL_AXES: Tuple[str, ...] = (
+    _AXIS_FALLACIES,
+    _AXIS_QUALITY,
+    _AXIS_COUNTERS,
+    _AXIS_FORMAL_PL,
+    _AXIS_FORMAL_FOL,
+    _AXIS_DUNG,
+)
+
+# Formula prefixes written by a formalism into ANOTHER formalism's container
+# (#1605). See _is_guest_formal_entry for why the host axis must not credit them.
+_GUEST_FORMULA_MARKERS: Tuple[str, ...] = ("dl:", "cl(", "qbf:")
+
+# --- #1605: the blocking half of the conclusion gate -------------------------
+#
+# _band_claim_ceiling tells the LLM how strongly it may characterise the
+# discourse. That is a *prompt* instruction, and nothing verified afterwards
+# that the produced prose respected it. This gate is the deterministic half:
+# after the conclusion is woven, an assertion resting on an axis that produced
+# nothing is removed and the removal is said out loud.
+#
+# Per-axis, deliberately, and NOT band-based: the band counts axes against fixed
+# thresholds, so a run can lose an entire formalism and keep the same band
+# (measured — losing formal_fol takes 6 axes to 5, still EXCEEDED). A count
+# cannot express "this particular claim has no support".
+
+_AXIS_LABELS_FR: Dict[str, str] = {
+    _AXIS_FALLACIES: "les sophismes",
+    _AXIS_QUALITY: "la qualité argumentative",
+    _AXIS_COUNTERS: "les contre-arguments",
+    _AXIS_FORMAL_PL: "la logique propositionnelle",
+    _AXIS_FORMAL_FOL: "la logique du premier ordre",
+    _AXIS_DUNG: "l'argumentation abstraite (Dung)",
+}
+
+# Phrases by which a French conclusion asserts an axis. Kept narrow: a marker
+# that also occurs in ordinary prose would block honest sentences.
+_AXIS_CLAIM_MARKERS: Dict[str, Tuple[str, ...]] = {
+    _AXIS_FALLACIES: ("sophisme", "fallacieu", "paralogisme"),
+    _AXIS_QUALITY: ("qualité argumentative", "score de qualité", "vertu argumentative"),
+    _AXIS_COUNTERS: ("contre-argument", "contre-argumentation"),
+    _AXIS_FORMAL_PL: (
+        "logique propositionnelle",
+        "satisfiabilité",
+        "solveur sat",
+    ),
+    _AXIS_FORMAL_FOL: (
+        "logique du premier ordre",
+        "premier ordre",
+        "eprover",
+        "prover9",
+        "quantificateur",
+    ),
+    _AXIS_DUNG: (
+        "sémantique de dung",
+        "argumentation abstraite",
+        "extension fondée",
+        "extension admissible",
+        "extension préférée",
+    ),
+}
+
+# A sentence carrying one of these is *stating the absence*, not claiming the
+# axis — exactly what #1609 asks the conclusion to do. Blocking it would punish
+# the honest wording. The gate is biased toward NOT blocking.
+_ABSENCE_MARKERS: Tuple[str, ...] = (
+    "aucun",
+    "aucune",
+    "n'a pas",
+    "n'ont pas",
+    "ne permet",
+    "ne peut",
+    "n'est pas",
+    "ne sont pas",
+    "faute de",
+    "absence",
+    "non évalu",
+    "pas de ",
+    "sans ",
+    "indisponible",
+    "n'a produit",
+    "hors de portée",
+)
+
+# Sentence splitter that preserves each chunk's leading whitespace, so removing
+# a sentence leaves the rest of the line spaced as the LLM wrote it.
+_SENTENCE_RE = re.compile(r"\s*[^.!?\n]+[.!?]*")
 
 
 # --- evidence dataclasses ----------------------------------------------------
@@ -198,6 +290,20 @@ class AbsentDimension:
     label: str
     status: str
     reason: str
+
+
+@dataclass(frozen=True)
+class BlockedClaim:
+    """A sentence the gate removed because its axis produced nothing (#1605).
+
+    Carries the offending sentence so a reviewer can audit what was withheld —
+    a gate whose decisions are not inspectable is indistinguishable from prose
+    that simply never made the claim.
+    """
+
+    axis: str
+    label: str
+    sentence: str
 
 
 @dataclass
@@ -303,6 +409,32 @@ def _pl_verdict(result: Dict[str, Any]) -> Optional[bool]:
     return sat if isinstance(sat, bool) else None
 
 
+def _is_guest_formal_entry(result: Dict[str, Any]) -> bool:
+    """True when a record in a formal container was written by ANOTHER formalism.
+
+    #1605: the formal containers are shared. ``fol_analysis_results`` also
+    receives Description Logic verdicts (``state_writers._write_dl_to_state``
+    renders them as ``formulas=["DL: <message>"]``), and
+    ``propositional_analysis_results`` receives Conditional-Logic (``CL(...)``)
+    and QBF ones. Sharing a container is a storage decision and is fine; letting
+    a GUEST verdict credit the HOST axis is not — measured on 2 of 3 real
+    corpora, the ``formal_fol`` axis was carried solely by a DL prose entry on
+    runs where the real FOL theory failed to parse, so the conclusion was
+    granted first-order support that no first-order solver ever produced.
+
+    Conservative on purpose: only an entry whose formulas are *all* guest
+    markers is treated as a guest, so a real theory that happens to mention a
+    marker keeps its credit.
+    """
+    formulas = result.get("formulas")
+    if not isinstance(formulas, list) or not formulas:
+        return False
+    return all(
+        isinstance(f, str) and f.strip().lower().startswith(_GUEST_FORMULA_MARKERS)
+        for f in formulas
+    )
+
+
 def _pl_inconsistent(state: Any) -> int:
     """Count PL inferences the Tweety solver found inconsistent (real-in-state).
 
@@ -312,7 +444,13 @@ def _pl_inconsistent(state: Any) -> int:
     pl = getattr(state, "propositional_analysis_results", None)
     if not isinstance(pl, list):
         return 0
-    return sum(1 for r in pl if isinstance(r, dict) and _pl_verdict(r) is False)
+    return sum(
+        1
+        for r in pl
+        if isinstance(r, dict)
+        and not _is_guest_formal_entry(r)
+        and _pl_verdict(r) is False
+    )
 
 
 def _pl_verified(state: Any) -> int:
@@ -329,7 +467,13 @@ def _pl_verified(state: Any) -> int:
     pl = getattr(state, "propositional_analysis_results", None)
     if not isinstance(pl, list):
         return 0
-    return sum(1 for r in pl if isinstance(r, dict) and _pl_verdict(r) is not None)
+    return sum(
+        1
+        for r in pl
+        if isinstance(r, dict)
+        and not _is_guest_formal_entry(r)
+        and _pl_verdict(r) is not None
+    )
 
 
 def _fol_inconsistent(state: Any) -> int:
@@ -337,7 +481,13 @@ def _fol_inconsistent(state: Any) -> int:
     fol = getattr(state, "fol_analysis_results", None)
     if not isinstance(fol, list):
         return 0
-    return sum(1 for r in fol if isinstance(r, dict) and r.get("consistent") is False)
+    return sum(
+        1
+        for r in fol
+        if isinstance(r, dict)
+        and not _is_guest_formal_entry(r)
+        and r.get("consistent") is False
+    )
 
 
 def _fol_verified(state: Any) -> int:
@@ -354,6 +504,7 @@ def _fol_verified(state: Any) -> int:
         1
         for r in fol
         if isinstance(r, dict)
+        and not _is_guest_formal_entry(r)
         and (r.get("consistent") is True or r.get("consistent") is False)
     )
 
@@ -613,16 +764,8 @@ def _compute_verdict_band(
     characterised discourse) on top of broad coverage — the "depth surpassing"
     spirit of #1008 §2.1, read as analytical depth rather than comparison.
     """
-    all_axes = [
-        _AXIS_FALLACIES,
-        _AXIS_QUALITY,
-        _AXIS_COUNTERS,
-        _AXIS_FORMAL_PL,
-        _AXIS_FORMAL_FOL,
-        _AXIS_DUNG,
-    ]
     present = set(axes_nontrivial)
-    missing = [a for a in all_axes if a not in present]
+    missing = [a for a in _ALL_AXES if a not in present]
     n = len(axes_nontrivial)
     has_formal_depth = _AXIS_FORMAL_PL in present or _AXIS_FORMAL_FOL in present
     has_quality = _AXIS_QUALITY in present
@@ -1163,6 +1306,85 @@ def _scope_note(absent: List[AbsentDimension]) -> str:
     )
 
 
+def _states_absence(lowered_sentence: str) -> bool:
+    """True when the sentence names the axis in order to say it produced nothing."""
+    return any(m in lowered_sentence for m in _ABSENCE_MARKERS)
+
+
+def _gate_unsupported_claims(
+    narrative: str, nontrivial_axes: List[str]
+) -> Tuple[str, List[BlockedClaim]]:
+    """Remove assertions resting on an axis that produced nothing.
+
+    The blocking half of the #1605 conclusion gate. ``_band_claim_ceiling``
+    *instructs* the LLM; this *enforces*, after the fact, on the produced prose.
+    A sentence is blocked when it names an absent axis without stating that the
+    axis is absent — the honest wording (#1609) must survive untouched, so the
+    absence markers act as an exemption rather than the claim markers acting as
+    a trigger on their own.
+
+    Fail loud, not fail hard: the offending sentence is dropped and the drop is
+    reported through ``degraded``; the rest of the conclusion is preserved. A
+    reader must never receive an unsupported claim, and must never silently lose
+    a whole conclusion either.
+    """
+    absent = [a for a in _ALL_AXES if a not in set(nontrivial_axes)]
+    if not absent or not narrative:
+        return narrative, []
+
+    blocked: List[BlockedClaim] = []
+    out_lines: List[str] = []
+    for line in narrative.splitlines():
+        chunks = _SENTENCE_RE.findall(line)
+        if not chunks:
+            out_lines.append(line)
+            continue
+        kept: List[str] = []
+        for chunk in chunks:
+            lowered = chunk.lower()
+            hit = next(
+                (
+                    axis
+                    for axis in absent
+                    if any(m in lowered for m in _AXIS_CLAIM_MARKERS[axis])
+                ),
+                None,
+            )
+            if hit is not None and not _states_absence(lowered):
+                blocked.append(
+                    BlockedClaim(
+                        axis=hit, label=_AXIS_LABELS_FR[hit], sentence=chunk.strip()
+                    )
+                )
+                continue
+            kept.append(chunk)
+        out_lines.append("".join(kept).rstrip())
+
+    if not blocked:
+        return narrative, []
+    # Removing sentences can leave runs of blank lines where a paragraph was.
+    gated = re.sub(r"\n{3,}", "\n\n", "\n".join(out_lines)).strip()
+    return gated, blocked
+
+
+def _blocked_claim_note(blocked: List[BlockedClaim]) -> str:
+    """The paragraph that replaces what was removed — the removal must be said."""
+    labels = sorted({b.label for b in blocked})
+    if len(labels) == 1:
+        listing = labels[0]
+        subject = "une dimension que cette analyse n'a pas pu établir"
+    else:
+        listing = ", ".join(labels[:-1]) + f" et {labels[-1]}"
+        subject = "des dimensions que cette analyse n'a pas pu établir"
+    return (
+        "### Affirmation retirée\n\n"
+        f"La conclusion conduite s'appuyait sur {subject} : {listing}. "
+        f"{'Cette phrase a été retirée' if len(blocked) == 1 else 'Ces phrases ont été retirées'} "
+        "plutôt que nuancée : sans résultat dans l'état, l'affirmation n'avait "
+        "aucun support à nuancer."
+    )
+
+
 # --- LLM-conducted weaving (fail-loud) ---------------------------------------
 
 
@@ -1282,6 +1504,23 @@ async def build_act3_conclusion(
             degraded["act3_scope_note_appended"] = (
                 "La prose conduite ne rattachait aucune limitation aux axes "
                 "perdus — paragraphe de portée ajouté de façon déterministe."
+            )
+
+    # #1605 — the blocking half. Runs BEFORE the §4 self-check so the gate reads
+    # the text the reader will actually receive. The band's claim ceiling is a
+    # prompt instruction; this is the enforcement.
+    if evidence.verdict is not None:
+        narrative, blocked = _gate_unsupported_claims(
+            narrative, evidence.verdict.nontrivial_axes
+        )
+        if blocked:
+            narrative = narrative.rstrip() + "\n\n" + _blocked_claim_note(blocked)
+            degraded["act3_claim_blocked"] = (
+                f"{len(blocked)} affirmation(s) retirée(s), sans support dans "
+                "l'état : "
+                + "; ".join(
+                    f"{b.label} — « {_truncate(b.sentence, 90)} »" for b in blocked
+                )
             )
 
     # §4 self-check (honest, never grades on a curve).

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -49,7 +49,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Awaitable, Callable, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 from .readability_gate import GateVerdict, ReadabilityGate
 from .virtuous_identification import VirtuousModeAssessment, detect_virtuous_mode
@@ -72,6 +72,24 @@ _DEBATE_MAX_EXCHANGES = 4
 # not all; each is truncated (privacy HARD + prompt budget).
 _CLAIM_EXCERPT_CAP = 240
 _MAX_CLAIM_EXCERPTS = 5
+# #1605 — the honest-absence ledger entering the prompt. The reason strings are
+# code-authored (no corpus content), but they are capped like everything else so
+# a future longer wording cannot silently eat the prompt budget.
+_ABSENCE_REASON_CAP = 300
+
+# #1605 — reader-facing French names for the structured-argumentation axes. The
+# prose forbids raw snake_case identifiers (they are opaque to the non-technical
+# reader this narrative addresses), so a capability key never reaches the
+# narrative as-is. A capability absent from this map degrades to its
+# underscore-stripped key rather than being dropped: an unnamed absence must
+# still be said.
+_ABSENT_DIMENSION_LABELS: Dict[str, str] = {
+    "aspic_plus_reasoning": "l'argumentation défaisable (règles strictes et révisables)",
+    "aba_reasoning": "l'argumentation par hypothèses et contraires",
+    "setaf_reasoning": "les attaques collectives (plusieurs arguments attaquant ensemble)",
+    "weighted_argumentation": "la force pondérée des attaques",
+    "bipolar_argumentation": "les relations de soutien entre arguments",
+}
 
 # Verdict bands (adapted from #1008 §2.1 to the restitution coverage model).
 _BAND_EXCEEDED = "EXCEEDED"
@@ -164,6 +182,25 @@ class QualityStrength:
 
 
 @dataclass
+class AbsentDimension:
+    """An analytical dimension the run did NOT genuinely evaluate (#1605).
+
+    Built from ``state.structured_arg_status`` — the honest-absence ledger that
+    #1236 populates and that, until now, no restitution module read. A run may
+    complete all its phases and still have lost an axis (the translator raised,
+    or found nothing genuine); the conclusion must be able to say so.
+
+    ``label`` is the reader-facing French name: the prose forbids raw snake_case
+    identifiers, so the capability key never reaches the narrative as-is.
+    """
+
+    capability: str
+    label: str
+    status: str
+    reason: str
+
+
+@dataclass
 class VerdictBand:
     """The computed verdict band + the honest coverage that earned it.
 
@@ -213,6 +250,11 @@ class Act3Evidence:
     # Reader-oriented conclusion needs the real claim excerpts to let a reader
     # re-link the verdict to the discourse. Privacy: truncated via _truncate.
     claim_excerpts: List[str] = field(default_factory=list)
+    # #1605 — dimensions the run did NOT genuinely evaluate, read from
+    # ``state.structured_arg_status``. Empty on a healthy run. Non-empty here is
+    # not a defect of the pipeline: it is the one thing the conclusion was
+    # structurally unable to say before this field existed.
+    absent_dimensions: List[AbsentDimension] = field(default_factory=list)
 
 
 @dataclass
@@ -287,9 +329,7 @@ def _pl_verified(state: Any) -> int:
     pl = getattr(state, "propositional_analysis_results", None)
     if not isinstance(pl, list):
         return 0
-    return sum(
-        1 for r in pl if isinstance(r, dict) and _pl_verdict(r) is not None
-    )
+    return sum(1 for r in pl if isinstance(r, dict) and _pl_verdict(r) is not None)
 
 
 def _fol_inconsistent(state: Any) -> int:
@@ -297,11 +337,7 @@ def _fol_inconsistent(state: Any) -> int:
     fol = getattr(state, "fol_analysis_results", None)
     if not isinstance(fol, list):
         return 0
-    return sum(
-        1
-        for r in fol
-        if isinstance(r, dict) and r.get("consistent") is False
-    )
+    return sum(1 for r in fol if isinstance(r, dict) and r.get("consistent") is False)
 
 
 def _fol_verified(state: Any) -> int:
@@ -482,6 +518,38 @@ def _collect_governance(state: Any) -> Optional[GovernanceVerdict]:
     return chosen
 
 
+def _collect_absent_dimensions(state: Any) -> List[AbsentDimension]:
+    """Collect the dimensions the run did not genuinely evaluate (#1605).
+
+    Reads ``state.structured_arg_status``, the honest-absence ledger written by
+    ``state_writers._record_structured_arg_status``. Measured on three real
+    corpora: A lost 4 axes of 5, B lost none, C lost 2 — and the conclusion read
+    identically in all three, because nothing here reached the restitution.
+
+    Only genuinely-degraded entries are surfaced. An ``evaluated`` capability is
+    not an absence, and an axis that simply found nothing to report is NOT a
+    degradation (anti-pendule: an honest absence correctly labelled is a success
+    of the matrix, not a failure of the pipeline).
+    """
+    ledger = getattr(state, "structured_arg_status", None) or {}
+    if not isinstance(ledger, dict):
+        return []
+    out: List[AbsentDimension] = []
+    for capability, info in ledger.items():
+        if not isinstance(info, dict) or not info.get("degraded"):
+            continue
+        cap = str(capability)
+        out.append(
+            AbsentDimension(
+                capability=cap,
+                label=_ABSENT_DIMENSION_LABELS.get(cap, cap.replace("_", " ")),
+                status=str(info.get("status", "")).strip(),
+                reason=_truncate(info.get("reason", ""), _ABSENCE_REASON_CAP),
+            )
+        )
+    return sorted(out, key=lambda d: d.label)
+
+
 def _collect_debate(state: Any) -> List[DebateExchange]:
     """Collect adversarial-debate exchanges (SV #1182). Gap β G8: can be sparse.
 
@@ -507,7 +575,11 @@ def _collect_debate(state: Any) -> List[DebateExchange]:
                 continue
             # G8 (#1184): carry scheme grounding (None when no match — honest).
             scheme_raw = ex.get("scheme")
-            scheme = str(scheme_raw).strip() if isinstance(scheme_raw, str) and scheme_raw.strip() else None
+            scheme = (
+                str(scheme_raw).strip()
+                if isinstance(scheme_raw, str) and scheme_raw.strip()
+                else None
+            )
             cq_raw = ex.get("critical_question")
             critical_question = (
                 str(cq_raw).strip()
@@ -595,9 +667,17 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
         counters = []
 
     args_total = len(args)
-    fallacies_total = sum(1 for _f, d in fallacies.items() if isinstance(d, dict) and (d.get("target_argument_id") or ""))
+    fallacies_total = sum(
+        1
+        for _f, d in fallacies.items()
+        if isinstance(d, dict) and (d.get("target_argument_id") or "")
+    )
     quality_axis_available = bool(quality)
-    counters_total = sum(1 for c in counters if isinstance(c, dict) and (c.get("target_arg_id") or c.get("counter_content")))
+    counters_total = sum(
+        1
+        for c in counters
+        if isinstance(c, dict) and (c.get("target_arg_id") or c.get("counter_content"))
+    )
     pl_inc = _pl_inconsistent(state)
     fol_inc = _fol_inconsistent(state)
     # D1c (#1167): a verified-consistent theory is a real formal result too —
@@ -656,7 +736,9 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
 
     narrative_synthesis = getattr(state, "narrative_synthesis", None)
     narrative_synthesis_available = bool(
-        narrative_synthesis and isinstance(narrative_synthesis, str) and narrative_synthesis.strip()
+        narrative_synthesis
+        and isinstance(narrative_synthesis, str)
+        and narrative_synthesis.strip()
     )
 
     # SV (#1182): surface governance verdict + debate exchanges (debranched
@@ -703,6 +785,7 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
         debate_exchanges=debate_exchanges,
         deanonymized=bool(getattr(state, "deanonymized", True)),
         claim_excerpts=claim_excerpts,
+        absent_dimensions=_collect_absent_dimensions(state),
     )
 
 
@@ -866,7 +949,8 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
     target_lines = (
         "\n".join(
             f"  - {wp.label} sur {wp.target_arg_id} (ancre : {wp.source})"
-            for wp in evidence.weak_points if wp.source in ("fallacy", "pl", "fol", "dung")
+            for wp in evidence.weak_points
+            if wp.source in ("fallacy", "pl", "fol", "dung")
         )
         or "  (aucun point faible structurel localisé)"
     )
@@ -921,6 +1005,22 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         else "  (aucune délibération governance/débat non-triviale — ne la fabrique pas)"
     )
 
+    # #1605 — what the run did NOT genuinely evaluate. Measured on three real
+    # corpora: the conclusion read the same whether 0, 2 or 4 axes of 5 had been
+    # lost, because this ledger reached no restitution module. The block is
+    # rendered in both states (present / empty) so the LLM sees an explicit
+    # "nothing was lost" rather than the ambiguity of a missing section.
+    if evidence.absent_dimensions:
+        absence_block = "\n".join(
+            f"  - {d.label} : NON ÉVALUÉE ({d.status}). {d.reason}"
+            for d in evidence.absent_dimensions
+        )
+    else:
+        absence_block = (
+            "  (aucune dimension perdue — toutes les analyses structurées ont "
+            "abouti sur ce corpus)"
+        )
+
     opaque_block = f"{_OPAQUE_ID_DIRECTIVE}\n\n" if not evidence.deanonymized else ""
 
     return (
@@ -952,6 +1052,7 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         f"[CONTRE-POINTS — ce qui affaiblit les revendications]\n{counters_lines}\n\n"
         f"[POINTS DE PRUDENCE — ancrages structurels]\n{target_lines}\n\n"
         f"[DÉLIBÉRATION COLLECTIVE — governance + débat]\n{deliberation_block}\n\n"
+        f"[DIMENSIONS NON ÉVALUÉES — à dire, jamais à taire]\n{absence_block}\n\n"
         f"{what_next_block}\n\n"
         "CONSIGNE DE RÉDACTION :\n"
         f"{consigne_virtue}"
@@ -978,7 +1079,87 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         "  déanonymise aucune source.\n"
         "- La conclusion doit VARIER selon le contenu réel ci-dessus : pas de\n"
         "  prose générique recyclable.\n"
+        "- Si le bloc DIMENSIONS NON ÉVALUÉES en liste, DIS-LE au lecteur dans le\n"
+        "  troisième battement, en une phrase et en français courant : quel angle\n"
+        "  d'analyse n'a pas abouti sur ce texte, et donc ce que ce verdict ne\n"
+        "  couvre pas. Le lecteur doit pouvoir situer la portée de ce qu'il lit.\n"
+        "  N'en fais ni un titre ni un paragraphe : une absence dite est une\n"
+        "  précision honnête, pas un aveu de faiblesse — et l'analyse conduite\n"
+        "  garde toute sa valeur. Si le bloc dit qu'aucune dimension n'a été\n"
+        "  perdue, n'invente aucune réserve.\n"
         "- Rédige en français, markdown léger. 300-600 mots selon la richesse.\n"
+    )
+
+
+# --- #1605: the scope limitation the narrative must carry --------------------
+
+# Distinctive French words tying a prose sentence to a specific lost axis. A
+# generic hedge ("certaines analyses n'ont pas abouti") must NOT count as having
+# named the absence — the reader has to know WHICH angle is missing.
+_ABSENCE_KEYWORDS: Dict[str, Tuple[str, ...]] = {
+    "aspic_plus_reasoning": ("défaisable", "revisable", "révisable", "règles strictes"),
+    "aba_reasoning": ("hypothès", "contraire"),
+    "setaf_reasoning": ("collectiv", "conjoint", "ensemble"),
+    "weighted_argumentation": ("pondér", "poids", "force des attaques"),
+    "bipolar_argumentation": ("soutien", "appui mutuel"),
+}
+
+# Phrases that mark a scope limitation being stated. Presence is necessary but
+# NOT sufficient: it must co-occur with a keyword of an actually-lost axis.
+_SCOPE_LIMIT_MARKERS: Tuple[str, ...] = (
+    "n'a pas abouti",
+    "n'a pas pu",
+    "n'a pas permis",
+    "non évalué",
+    "pas été évalué",
+    "pas été conduite",
+    "pas été menée",
+    "ne couvre pas",
+    "hors de portée",
+    "faute de",
+)
+
+
+def _narrative_states_scope_limit(
+    narrative: str, absent: List[AbsentDimension]
+) -> bool:
+    """True only when the narrative visibly ties a limitation to a lost axis.
+
+    Deliberately strict, and biased toward returning ``False``: a false negative
+    costs a redundant sentence, a false positive costs exactly the defect this
+    guards against — a conclusion that reads identically whether the run lost 0
+    or 4 analytical axes (measured on three real corpora, #1605).
+    """
+    low = narrative.lower()
+    if not any(m in low for m in _SCOPE_LIMIT_MARKERS):
+        return False
+    for dim in absent:
+        if any(w in low for w in _ABSENCE_KEYWORDS.get(dim.capability, ())):
+            return True
+    return False
+
+
+def _scope_note(absent: List[AbsentDimension]) -> str:
+    """The deterministic scope paragraph appended when the LLM stayed silent.
+
+    Not a fallback template for the conclusion (#1108 forbids that): the
+    conclusion itself is LLM-conducted or absent. This is the one factual
+    sentence the run *knows* and the reader cannot infer — appended, never
+    substituted.
+    """
+    labels = [d.label for d in absent]
+    if len(labels) == 1:
+        listing = labels[0]
+        opening = "Un angle d'analyse n'a pas abouti sur ce texte"
+        coverage = "cette dimension"
+    else:
+        listing = ", ".join(labels[:-1]) + f" et {labels[-1]}"
+        opening = "Plusieurs angles d'analyse n'ont pas abouti sur ce texte"
+        coverage = "ces dimensions"
+    return (
+        "### Portée de cette analyse\n\n"
+        f"{opening} : {listing}. Ce verdict ne couvre donc pas {coverage} — ce "
+        "qui précède garde sa valeur sur les angles effectivement conduits."
     )
 
 
@@ -1082,10 +1263,30 @@ async def build_act3_conclusion(
             },
         )
 
+    # #1605 — the conclusion must carry what the run failed to evaluate. The
+    # ledger is recorded unconditionally (it is a fact about the run), and the
+    # scope paragraph is appended when the woven prose did not tie a limitation
+    # to a lost axis. Deterministic on purpose: the guarantee cannot depend on
+    # the LLM having complied with the prompt directive.
+    degraded: Dict[str, str] = {}
+    if evidence.absent_dimensions:
+        labels = ", ".join(d.label for d in evidence.absent_dimensions)
+        degraded["act3_absent_dimensions"] = (
+            f"{len(evidence.absent_dimensions)} dimension(s) non évaluée(s) sur "
+            f"ce corpus : {labels}."
+        )
+        if not _narrative_states_scope_limit(narrative, evidence.absent_dimensions):
+            narrative = (
+                narrative.rstrip() + "\n\n" + _scope_note(evidence.absent_dimensions)
+            )
+            degraded["act3_scope_note_appended"] = (
+                "La prose conduite ne rattachait aucune limitation aux axes "
+                "perdus — paragraphe de portée ajouté de façon déterministe."
+            )
+
     # §4 self-check (honest, never grades on a curve).
     gate = ReadabilityGate()
     verdict = gate.check_body(narrative)
-    degraded: Dict[str, str] = {}
     if verdict.band != "PASS":
         degraded["act3_conclusion_gate"] = (
             f"Self-check §4 = {verdict.band}: " + "; ".join(verdict.reasons[:3])

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -36,7 +36,6 @@ from argumentation_analysis.reporting.restitution.readability_gate import (
     ReadabilityGate,
 )
 
-
 # --- state stubs -------------------------------------------------------------
 
 
@@ -283,7 +282,9 @@ class TestBuildEvidence:
     def test_governance_trivial_winner_is_none_sv(self):
         """SV fail-loud: a placeholder 'N/A' winner carries no verdict (#1019)."""
         state = _state(
-            governance_decisions=[{"method": "majority", "winner": "N/A", "scores": {}}],
+            governance_decisions=[
+                {"method": "majority", "winner": "N/A", "scores": {}}
+            ],
             debate_transcripts=[{"exchanges": [{"point": "", "rebuttal": ""}]}],
         )
         ev = build_act3_evidence(state)
@@ -393,10 +394,18 @@ class TestBuildEvidence:
             },
             argument_quality_scores={"arg_1": {"scores_par_vertu": {"clarte": 5.0}}},
             counter_arguments=[
-                {"target_arg_id": "arg_1", "strategy": "contre-exemple", "counter_content": "réponse"}
+                {
+                    "target_arg_id": "arg_1",
+                    "strategy": "contre-exemple",
+                    "counter_content": "réponse",
+                }
             ],
             dung_frameworks={
-                "fw_1": {"arguments": ["arg_1"], "extensions": {}, "semantics": "grounded"}
+                "fw_1": {
+                    "arguments": ["arg_1"],
+                    "extensions": {},
+                    "semantics": "grounded",
+                }
             },
         )
         ev = build_act3_evidence(state)
@@ -443,9 +452,7 @@ class TestBuildEvidence:
             _pl_verified,
         )
 
-        state = _state(
-            propositional_analysis_results=[{"satisfiable": True}]
-        )
+        state = _state(propositional_analysis_results=[{"satisfiable": True}])
         assert _pl_verified(state) == 1
         ev = build_act3_evidence(state)
         assert "formal_pl" in ev.verdict.nontrivial_axes
@@ -468,9 +475,7 @@ class TestBuildEvidence:
             _pl_verified,
         )
 
-        state = _state(
-            propositional_analysis_results=[{"satisfiable": None}]
-        )
+        state = _state(propositional_analysis_results=[{"satisfiable": None}])
         assert _pl_verified(state) == 0
 
 
@@ -493,7 +498,9 @@ class TestPrivacy:
         assert long_just not in prompt
         assert "[…]" in prompt
 
-    @pytest.mark.parametrize("deanonymized,expect_opaque", [(True, False), (False, True)])
+    @pytest.mark.parametrize(
+        "deanonymized,expect_opaque", [(True, False), (False, True)]
+    )
     def test_opaque_directive_gated_by_deanonymized(self, deanonymized, expect_opaque):
         # Epic #1258 / Track 1 #1259 — opaque-ID directive present only when
         # NOT deanonymized; weaving rule + fail-loud always present.
@@ -662,7 +669,10 @@ class TestConsumedByRenderer:
         # The woven act3 conclusion is rendered into the body verbatim.
         assert _WOVEN_CONCLUSION.splitlines()[0] in report.markdown
         # act1/act2 are reported as missing (fail-loud), not silently dropped.
-        assert "indisponible" in report.markdown.lower() or "acte" in report.markdown.lower()
+        assert (
+            "indisponible" in report.markdown.lower()
+            or "acte" in report.markdown.lower()
+        )
 
 
 # ============================================================================
@@ -745,3 +755,179 @@ class TestVirtuousMode:
         prompt = build_act3_prompt(ev)
         assert "fabrique" in prompt.lower() or "ne fabrique" in prompt.lower()
         assert ev.weak_points == []
+
+
+# --- #1605: the conclusion must carry what the run failed to evaluate --------
+
+
+def _ledger(*capabilities: str) -> dict:
+    """A ``structured_arg_status`` ledger marking ``capabilities`` degraded.
+
+    Mirrors the shape written by ``state_writers._record_structured_arg_status``.
+    """
+    return {
+        cap: {
+            "capability": cap,
+            "status": "absent_no_translator",
+            "degraded": True,
+            "reason": f"{cap} not genuinely evaluated: no translator wired.",
+            "extension_count": 1,
+        }
+        for cap in capabilities
+    }
+
+
+_SILENT_CONCLUSION = (
+    "### Ce que le discours dit vraiment\n\n"
+    "Le locuteur défend sa position en disqualifiant son contradicteur.\n\n"
+    "### Ce qui tient et ce qui ne tient pas\n\n"
+    "L'analyse formelle confirme la cohérence d'une partie du raisonnement.\n\n"
+    "### Comment se faire son avis\n\n"
+    "Recevoir avec prudence l'attaque personnelle, retenir l'argument causal."
+)
+
+
+class TestAbsentDimensionsCollected:
+    """``structured_arg_status`` reaches the evidence (it reached nothing before)."""
+
+    def test_no_ledger_yields_no_absence(self):
+        ev = build_act3_evidence(_rich_state())
+        assert ev.absent_dimensions == []
+
+    def test_evaluated_capability_is_not_an_absence(self):
+        state = _rich_state()
+        state.structured_arg_status = {
+            "setaf_reasoning": {
+                "capability": "setaf_reasoning",
+                "status": "evaluated",
+                "degraded": False,
+                "reason": "Genuine structured input supplied via context.",
+                "extension_count": 3,
+            }
+        }
+        ev = build_act3_evidence(state)
+        assert ev.absent_dimensions == []
+
+    def test_degraded_capabilities_are_collected(self):
+        state = _rich_state()
+        state.structured_arg_status = _ledger("aspic_plus_reasoning", "setaf_reasoning")
+        ev = build_act3_evidence(state)
+        assert {d.capability for d in ev.absent_dimensions} == {
+            "aspic_plus_reasoning",
+            "setaf_reasoning",
+        }
+
+    def test_label_is_reader_facing_not_snake_case(self):
+        # The prose forbids raw identifiers; a capability key must never reach
+        # the narrative as-is.
+        state = _rich_state()
+        state.structured_arg_status = _ledger("weighted_argumentation")
+        ev = build_act3_evidence(state)
+        (dim,) = ev.absent_dimensions
+        assert "_" not in dim.label
+        assert dim.label != dim.capability
+
+    def test_unknown_capability_is_still_surfaced(self):
+        # An absence we have no French label for must still be said, not dropped.
+        state = _rich_state()
+        state.structured_arg_status = _ledger("some_future_formalism")
+        ev = build_act3_evidence(state)
+        assert len(ev.absent_dimensions) == 1
+        assert "_" not in ev.absent_dimensions[0].label
+
+
+class TestAbsencePromptBlock:
+    """The prompt states the absence in BOTH directions (present / none)."""
+
+    def test_block_lists_the_lost_axes(self):
+        state = _rich_state()
+        state.structured_arg_status = _ledger("aba_reasoning")
+        prompt = build_act3_prompt(build_act3_evidence(state))
+        assert "[DIMENSIONS NON ÉVALUÉES" in prompt
+        assert "hypothèses et contraires" in prompt
+
+    def test_block_says_explicitly_when_nothing_was_lost(self):
+        # An absent section would be ambiguous; the healthy run says so.
+        prompt = build_act3_prompt(build_act3_evidence(_rich_state()))
+        assert "aucune dimension perdue" in prompt
+
+
+class TestConclusionCarriesTheAbsence:
+    """The guarantee is deterministic — it does not depend on the LLM complying."""
+
+    def _run(self, state, completion):
+        return asyncio.get_event_loop().run_until_complete(
+            build_act3_conclusion(state, llm_callable=_stub_llm(completion))  # type: ignore[arg-type]
+        )
+
+    def test_silent_prose_gets_the_scope_note_appended(self):
+        state = _rich_state()
+        state.structured_arg_status = _ledger("aspic_plus_reasoning")
+        result = self._run(state, _SILENT_CONCLUSION)
+        assert "Portée de cette analyse" in result.narrative
+        assert "act3_scope_note_appended" in result.degraded
+
+    def test_compliant_prose_is_not_duplicated(self):
+        # The detector must be able to return True — otherwise the append is
+        # unconditional and the check measures nothing.
+        state = _rich_state()
+        state.structured_arg_status = _ledger("aspic_plus_reasoning")
+        compliant = _SILENT_CONCLUSION + (
+            "\n\nL'examen du raisonnement défaisable n'a pas abouti sur ce texte."
+        )
+        result = self._run(state, compliant)
+        assert "Portée de cette analyse" not in result.narrative
+        assert "act3_scope_note_appended" not in result.degraded
+        assert "act3_absent_dimensions" in result.degraded
+
+    def test_generic_hedge_does_not_count_as_naming_the_absence(self):
+        # "certaines analyses n'ont pas abouti" leaves the reader unable to know
+        # WHICH angle is missing — the note must still be appended.
+        state = _rich_state()
+        state.structured_arg_status = _ledger("setaf_reasoning")
+        hedged = _SILENT_CONCLUSION + (
+            "\n\nCertaines analyses n'ont pas abouti sur ce texte."
+        )
+        result = self._run(state, hedged)
+        assert "Portée de cette analyse" in result.narrative
+
+    def test_healthy_run_gets_no_scope_note(self):
+        result = self._run(_rich_state(), _SILENT_CONCLUSION)
+        assert "Portée de cette analyse" not in result.narrative
+        assert result.degraded.get("act3_absent_dimensions") is None
+
+    def test_conclusion_discriminates_three_run_states(self):
+        """The falsifiable control: 0 / 2 / 4 lost axes → three distinct outputs.
+
+        Measured on three real corpora (#1605): before this wiring, the three
+        conclusions were 3447 / 3742 / 3560 chars and none mentioned anything —
+        a reader could not tell the amputated run from the healthy one.
+        """
+        healthy = _rich_state()
+        two_lost = _rich_state()
+        two_lost.structured_arg_status = _ledger(
+            "setaf_reasoning", "weighted_argumentation"
+        )
+        four_lost = _rich_state()
+        four_lost.structured_arg_status = _ledger(
+            "setaf_reasoning",
+            "weighted_argumentation",
+            "aba_reasoning",
+            "aspic_plus_reasoning",
+        )
+
+        counts = [
+            len(build_act3_evidence(s).absent_dimensions)
+            for s in (healthy, two_lost, four_lost)
+        ]
+        assert counts == [0, 2, 4]
+
+        narratives = [
+            self._run(s, _SILENT_CONCLUSION).narrative
+            for s in (healthy, two_lost, four_lost)
+        ]
+        # Three genuinely different run states must yield three different texts.
+        assert len(set(narratives)) == 3
+        assert "Portée de cette analyse" not in narratives[0]
+        assert "attaques collectives" in narratives[1]
+        assert "hypothèses et contraires" in narratives[2]

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -1133,12 +1133,25 @@ class TestUnsupportedClaimBlocked:
         assert "Le solveur SAT établit" in result.narrative
         assert "La logique du premier ordre confirme" not in result.narrative
 
-    def test_wholly_unsupported_conclusion_says_so_rather_than_going_silent(
+    def test_wholly_unsupported_conclusion_declares_it_in_the_narrative(
         self,
     ) -> None:
-        """If nothing survives, the emptiness must be declared, not implied."""
+        """If nothing survives, the NARRATIVE must say so — not just `degraded`.
+
+        The structured `degraded` dict does not survive the state round-trip
+        (``_write_act3_conclusion_to_state`` stores only the narrative), so a
+        fact carried solely there never reaches the reader.
+        """
         conclusion = "La logique du premier ordre confirme la cohérence du discours."
         result = self._run(_rich_state(), conclusion)
+        assert "Aucune conclusion soutenable" in result.narrative
+        assert "Il ne reste aucune conclusion" in result.narrative
         assert "act3_claim_blocked_all" in result.degraded
-        assert "Affirmation retirée" in result.narrative
         assert not result.narrative.startswith("\n")
+
+    def test_partial_removal_does_not_claim_the_conclusion_is_empty(self) -> None:
+        """The bite proof: surviving prose must NOT get the emptiness wording."""
+        result = self._run(_rich_state(), _CLAIM_ON_ABSENT_AXIS)
+        assert "Aucune conclusion soutenable" not in result.narrative
+        assert "act3_claim_blocked_all" not in result.degraded
+        assert "Affirmation retirée" in result.narrative

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -1105,3 +1105,40 @@ class TestUnsupportedClaimBlocked:
         assert "Le locuteur disqualifie l'adversaire" in result.narrative
         assert "Le raisonnement causal tient" in result.narrative
         assert result.status == "woven"
+
+    def test_emptied_section_does_not_leave_a_bare_heading(self) -> None:
+        """Removing the only sentence of a section must remove its heading too."""
+        conclusion = (
+            "### Ce que le discours dit\n\n"
+            "Le locuteur avance sa thèse avec des exemples concrets.\n\n"
+            "### Appui formel\n\n"
+            "La logique du premier ordre confirme la structure du discours.\n\n"
+            "### Ce qui tient\n\n"
+            "Le raisonnement causal tient."
+        )
+        result = self._run(_rich_state(), conclusion)
+        assert "### Appui formel" not in result.narrative
+        assert "### Ce que le discours dit" in result.narrative
+        assert "### Ce qui tient" in result.narrative
+
+    def test_heading_is_kept_when_its_section_still_has_content(self) -> None:
+        """The bite proof for heading removal: a surviving sibling keeps it."""
+        conclusion = (
+            "### Appui formel\n\n"
+            "La logique du premier ordre confirme la structure du discours.\n"
+            "Le solveur SAT établit la satisfiabilité de la thèse.\n"
+        )
+        result = self._run(_rich_state(), conclusion)
+        assert "### Appui formel" in result.narrative
+        assert "Le solveur SAT établit" in result.narrative
+        assert "La logique du premier ordre confirme" not in result.narrative
+
+    def test_wholly_unsupported_conclusion_says_so_rather_than_going_silent(
+        self,
+    ) -> None:
+        """If nothing survives, the emptiness must be declared, not implied."""
+        conclusion = "La logique du premier ordre confirme la cohérence du discours."
+        result = self._run(_rich_state(), conclusion)
+        assert "act3_claim_blocked_all" in result.degraded
+        assert "Affirmation retirée" in result.narrative
+        assert not result.narrative.startswith("\n")

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -27,6 +27,9 @@ import pytest
 
 from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
     Act3Result,
+    _fol_verified,
+    _is_guest_formal_entry,
+    _pl_verified,
     build_act3_conclusion,
     build_act3_evidence,
     build_act3_prompt,
@@ -931,3 +934,174 @@ class TestConclusionCarriesTheAbsence:
         assert "Portée de cette analyse" not in narratives[0]
         assert "attaques collectives" in narratives[1]
         assert "hypothèses et contraires" in narratives[2]
+
+
+# --- #1605: guest formalisms must not credit the host axis -------------------
+
+
+def _dl_entry() -> dict:
+    """The shape ``state_writers._write_dl_to_state`` really writes (measured)."""
+    return {
+        "id": "fol_1",
+        "formulas": ["DL: Knowledge base is consistent."],
+        "consistent": True,
+        "inferences": [],
+        "confidence": 1.0,
+    }
+
+
+def _real_fol_entry(consistent: bool = False) -> dict:
+    """A genuine first-order theory decided by a first-order prover."""
+    return {
+        "id": "fol_2",
+        "formulas": ["forall X: (humain(X) => mortel(X))", "humain(socrate)"],
+        "consistent": consistent,
+        "inferences": [],
+        "confidence": 1.0,
+    }
+
+
+class TestGuestFormalEntriesDoNotCreditHostAxis:
+    """A formalism writing into another's container must not earn its axis.
+
+    Measured on the real runs: ``fol_analysis_results`` also receives
+    Description Logic verdicts, and on 2 of 3 corpora the ``formal_fol`` axis was
+    carried *solely* by such an entry — on runs where the real FOL theory failed
+    to parse. The conclusion was granted first-order support that no first-order
+    prover ever produced.
+    """
+
+    def test_dl_entry_is_recognised_as_guest(self) -> None:
+        assert _is_guest_formal_entry(_dl_entry()) is True
+
+    def test_real_fol_entry_is_not_guest(self) -> None:
+        assert _is_guest_formal_entry(_real_fol_entry()) is False
+
+    def test_entry_mixing_real_and_marker_formulas_keeps_credit(self) -> None:
+        """Conservative by design: only an ALL-marker entry is a guest."""
+        mixed = {
+            "formulas": ["DL: Knowledge base is consistent.", "humain(socrate)"],
+            "consistent": True,
+        }
+        assert _is_guest_formal_entry(mixed) is False
+
+    def test_entry_without_formulas_is_not_guest(self) -> None:
+        """``all([])`` is True — the empty case must not be swept in silently."""
+        assert _is_guest_formal_entry({"consistent": True}) is False
+        assert _is_guest_formal_entry({"formulas": [], "consistent": True}) is False
+
+    def test_dl_only_state_loses_the_fol_axis(self) -> None:
+        state = _state(fol_analysis_results=[_dl_entry()])
+        assert _fol_verified(state) == 0
+        axes = build_act3_evidence(state).verdict.nontrivial_axes
+        assert "formal_fol" not in axes
+
+    def test_real_fol_verdict_keeps_the_fol_axis(self) -> None:
+        """The bite-proving negative: the filter removes guests, not the axis."""
+        state = _state(fol_analysis_results=[_dl_entry(), _real_fol_entry()])
+        assert _fol_verified(state) == 1
+        axes = build_act3_evidence(state).verdict.nontrivial_axes
+        assert "formal_fol" in axes
+
+    def test_guest_cl_and_qbf_do_not_credit_the_pl_axis(self) -> None:
+        """CL and QBF write into the propositional container the same way."""
+        guests_only = _state(
+            propositional_analysis_results=[
+                {
+                    "formulas": ["CL(0 conditionals): No query specified."],
+                    "satisfiable": True,
+                },
+                {"formulas": ["QBF: <texte brut du document>"], "satisfiable": True},
+            ]
+        )
+        assert _pl_verified(guests_only) == 0
+        assert (
+            "formal_pl" not in build_act3_evidence(guests_only).verdict.nontrivial_axes
+        )
+
+        with_host = _state(
+            propositional_analysis_results=[
+                {
+                    "formulas": ["CL(0 conditionals): No query specified."],
+                    "satisfiable": True,
+                },
+                {"formulas": ["p && q"], "satisfiable": True},
+            ]
+        )
+        assert _pl_verified(with_host) == 1
+        assert "formal_pl" in build_act3_evidence(with_host).verdict.nontrivial_axes
+
+
+# --- #1605: the blocking half of the conclusion gate -------------------------
+
+
+# A conclusion asserting first-order support. ``_rich_state`` has no formal_fol
+# axis, so this claim rests on nothing.
+_CLAIM_ON_ABSENT_AXIS = (
+    "### Ce que le discours dit\n\n"
+    "Le locuteur disqualifie l'adversaire avant de défendre sa thèse sur le "
+    "fond. La logique du premier ordre confirme que la structure profonde du "
+    "discours est cohérente. Le lecteur peut donc suivre le second mouvement "
+    "sans réserve.\n\n"
+    "### Ce qui tient\n\n"
+    "Le raisonnement causal tient et reste lisible pour qui suit le débat."
+)
+
+
+class TestUnsupportedClaimBlocked:
+    """The DoD's blocking half: an affirmation refused for lack of a dimension.
+
+    ``_band_claim_ceiling`` *instructs* the LLM about how strongly it may
+    characterise the discourse. Nothing verified the produced prose afterwards.
+    This gate is that verification, per axis — the band cannot do it, because
+    losing an entire formalism moves 6 axes to 5 and keeps the same band.
+    """
+
+    def _run(self, state: object, conclusion: str) -> Act3Result:
+        return asyncio.run(build_act3_conclusion(state, _stub_llm(conclusion)))
+
+    def test_claim_on_absent_axis_is_removed_from_the_narrative(self) -> None:
+        result = self._run(_rich_state(), _CLAIM_ON_ABSENT_AXIS)
+        assert "La logique du premier ordre confirme" not in result.narrative
+
+    def test_removal_is_reported_in_degraded(self) -> None:
+        result = self._run(_rich_state(), _CLAIM_ON_ABSENT_AXIS)
+        assert "act3_claim_blocked" in result.degraded
+        assert "premier ordre" in result.degraded["act3_claim_blocked"]
+
+    def test_removal_note_names_the_axis_for_the_reader(self) -> None:
+        result = self._run(_rich_state(), _CLAIM_ON_ABSENT_AXIS)
+        assert "Affirmation retirée" in result.narrative
+        assert "la logique du premier ordre" in result.narrative
+
+    def test_same_claim_survives_when_the_axis_is_present(self) -> None:
+        """The bite proof: identical prose, one axis added, no removal."""
+        supported = _rich_state()
+        supported.fol_analysis_results = [_real_fol_entry(consistent=True)]
+        result = self._run(supported, _CLAIM_ON_ABSENT_AXIS)
+        assert "La logique du premier ordre confirme" in result.narrative
+        assert "act3_claim_blocked" not in result.degraded
+        assert "Affirmation retirée" not in result.narrative
+
+    def test_honest_absence_statement_is_not_blocked(self) -> None:
+        """Naming an absent axis to SAY it is absent is what #1609 asks for."""
+        honest = _CLAIM_ON_ABSENT_AXIS.replace(
+            "La logique du premier ordre confirme que la structure profonde du "
+            "discours est cohérente.",
+            "La logique du premier ordre n'a pas abouti sur ce texte.",
+        )
+        result = self._run(_rich_state(), honest)
+        assert "n'a pas abouti sur ce texte" in result.narrative
+        assert "act3_claim_blocked" not in result.degraded
+
+    def test_conclusion_making_no_unsupported_claim_is_untouched(self) -> None:
+        result = self._run(_rich_state(), _WOVEN_CONCLUSION)
+        assert "act3_claim_blocked" not in result.degraded
+        assert "Affirmation retirée" not in result.narrative
+
+    def test_gate_preserves_the_rest_of_the_conclusion(self) -> None:
+        """Fail loud, not fail hard: one sentence goes, the conclusion stays."""
+        result = self._run(_rich_state(), _CLAIM_ON_ABSENT_AXIS)
+        assert "Le locuteur disqualifie l'adversaire" in result.narrative
+        assert "Le raisonnement causal tient" in result.narrative
+        assert result.status == "woven"

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -1155,3 +1155,47 @@ class TestUnsupportedClaimBlocked:
         assert "Aucune conclusion soutenable" not in result.narrative
         assert "act3_claim_blocked_all" not in result.degraded
         assert "Affirmation retirée" in result.narrative
+
+    def test_parent_heading_survives_when_its_subsections_carry_the_content(
+        self,
+    ) -> None:
+        """A heading is empty only if its whole SUBTREE is.
+
+        The narrative is free-form markdown conducted by the LLM, so a section
+        that holds its content in subsections is ordinary input. Judging
+        emptiness on the lines immediately below would delete the parent while
+        keeping its children — mangling a hierarchy the gate never touched.
+        """
+        conclusion = (
+            "## Ce que l'analyse établit\n\n"
+            "### Appui formel\n\n"
+            "La logique du premier ordre confirme la structure du discours.\n\n"
+            "### Ce qui tient\n\n"
+            "Le raisonnement causal tient et les prémisses sont explicites.\n"
+        )
+        result = self._run(_rich_state(), conclusion)
+        # The blocked claim took `### Appui formel` with it...
+        assert "### Appui formel" not in result.narrative
+        # ...but the parent keeps its surviving subsection, and both remain.
+        assert "## Ce que l'analyse établit" in result.narrative
+        assert "### Ce qui tient" in result.narrative
+        assert "Le raisonnement causal tient" in result.narrative
+
+    def test_parent_heading_falls_when_its_whole_subtree_is_emptied(self) -> None:
+        """The bite proof for the subtree rule: an emptied subtree takes the parent.
+
+        Without this, "keep a parent whose descendants survived" could degrade
+        into "always keep parents", which is the symmetrical error.
+        """
+        conclusion = (
+            "## Ce que l'analyse établit\n\n"
+            "### Appui formel\n\n"
+            "La logique du premier ordre confirme la structure du discours.\n\n"
+            "## Ce qui tient\n\n"
+            "Le raisonnement causal tient et les prémisses sont explicites.\n"
+        )
+        result = self._run(_rich_state(), conclusion)
+        assert "### Appui formel" not in result.narrative
+        assert "## Ce que l'analyse établit" not in result.narrative
+        assert "## Ce qui tient" in result.narrative
+        assert "Le raisonnement causal tient" in result.narrative


### PR DESCRIPTION
Volet **gate de conclusion** de #1605 (coordinateur). Le volet **registre** est chez po-2023 sur #1608 — fichiers disjoints, aucune sérialisation nécessaire.

Mandat utilisateur (2026-08-06) : *« que tous les outils se consolident harmonieusement dans la gestion incrémentale de l'état interne hétérogène, aboutissant à une conclusion réellement complète et parfaitement éclairée. »*

## Le défaut, mesuré avant d'écrire une ligne

Trois runs `spectacular_analysis` sur base main `c806a770` :

| | phases | registre structuré | conclusion | l'avoue ? |
|---|---|---|---|---|
| corpus_A | 38 ok / 2 ko | **4/5 dégradées** | 3447 car. | **non** |
| corpus_B | 40 ok / 0 ko | 0/5 dégradées | 3742 car. | non *(correct)* |
| corpus_C | 40 ok / 0 ko | **2/5 dégradées** | 3560 car. | **non** |

Zéro occurrence de `dégradé` / `absent` / `partiel` / `timeout` dans les trois. Le lecteur ne peut pas distinguer le run amputé du run sain — et la conclusion de corpus_A invoque « validation formelle » comme autorité sur des axes qui n'ont jamais été évalués.

Le registre d'absence `structured_arg_status` est écrit avec soin, et lu par personne : c'est `feedback_zero_recipients_working_bus` au niveau du livrable.

## Ce que cette PR fait

**Côté prompt** — `_collect_absent_dimensions` lit `state.structured_arg_status`, ne garde que les entrées `degraded`, et mappe chaque capacité vers un libellé lisible. Une capacité non mappée dégrade vers sa clé sans underscores **plutôt que d'être écartée** : une absence qu'on ne sait pas nommer doit quand même être dite.

Le bloc est injecté dans **les deux états** — les axes perdus quand il y en a, et une ligne explicite *« aucune dimension perdue »* quand il n'y en a pas. Une section absente serait ambiguë là où une section présente ne l'est pas.

**Côté déterministe** — la garantie ne peut pas dépendre de l'obéissance du modèle. `build_act3_conclusion` ajoute un paragraphe `### Portée de cette analyse` quand la prose tissée ne rattache pas déjà un marqueur de limite à un axe **effectivement** perdu, et enregistre `act3_absent_dimensions` + `act3_scope_note_appended`.

## Pourquoi le détecteur est biaisé vers `False`

`_narrative_states_scope_limit` exige un marqueur de limite **ET** un mot-clé d'un axe réellement perdu. Un hedge générique — *« certaines analyses n'ont pas abouti »* — laisse le lecteur incapable de savoir **lequel** manque : il ne compte pas, le paragraphe est quand même ajouté.

Le détecteur a été sondé sur 5 cas avant d'être utilisé, et rend bien les **deux** valeurs (prose muette → `False` · hedge générique → `False` · axe nommé sans marqueur → `False` · marqueur + axe → `True` · marqueur + autre axe → `True`). Sans cette preuve, l'append serait inconditionnel et le contrôle vacant — `feedback_assertion_that_cannot_fail` appliqué à mon propre code.

## Vérification — le contrôle qu'aucun changement de code ne peut truquer

Rejeu du gate sur les **trois artefacts réels** :

```
corpus_A -> 4 absences, paragraphe ajouté, degraded=['act3_absent_dimensions','act3_scope_note_appended']
corpus_B -> 0 absence,  aucun paragraphe,  degraded=[]
corpus_C -> 2 absences, paragraphe ajouté, mêmes deux clés
```

Trois états réellement différents rendent désormais trois livrables différents. `test_conclusion_discriminates_three_run_states` porte ce contrôle dans la suite.

## Périmètre

- `argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py`
- `tests/unit/.../test_act3_conclusion_plugin.py` : **44 → 56**. J'avais annoncé **+11**, le run rend **+12** (une classe de cas ajoutée en cours d'écriture — le hedge générique). L'écart est dit, pas réécrit.
- `black` + `flake8` propres · 659 tests verts sous `tests/unit/argumentation_analysis/reporting/`

## Ce que cette PR ne fait PAS — et ne doit pas faire

- **Elle ne corrige pas la cause de l'absence.** Sur corpus_A les traducteurs n'ont pas manqué, ils ont **expiré**, et le motif enregistré affirme le contraire. C'est #1608 (po-2023). Le gate dit fidèlement ce que le registre lui donne — y compris un motif faux. La chaîne devient honnête quand les deux moitiés atterrissent.
- **Elle ne fabrique pas de réserve** quand rien n'a été perdu : corpus_B ne change pas d'un caractère. Un aveu inventé serait le symétrique de l'omission.
- **Elle ne transforme pas l'absence en score.** Pas de « 62 % substantive » : un composite masque exactement ce qu'on cherche à exposer.

## Privacy

IDs opaques partout (`corpus_A/B/C`). Aucun contenu de corpus dans le diff ni dans cette description — les artefacts vivent sous `evaluation/results/` (gitignoré). Scan `raw_text|full_text|api.?key|token|secret` sur le diff : **0**.

Refs #1605


---

# Second commit — la moitié bloquante (`70e29c8a`)

Ferme la **moitié bloquante** du gate de conclusion (#1605) : une affirmation qui repose sur une dimension n'ayant rien produit est **retirée** de la conclusion, et le retrait est dit au lecteur.

## Pourquoi ce commit existe

Le fichier portait déjà `_band_claim_ceiling` : un plafond d'affirmation par bande de verdict. Mais c'est une **instruction de prompt** — elle dit au modèle jusqu'où il peut caractériser le discours, et **rien ne vérifiait ensuite** que la prose produite l'avait respectée. Ce commit est la vérification déterministe, côté sortie.

## La mesure qui a rendu ce gate écrivable — et falsifiable

Avant ce commit, sur les trois runs réels : `missing_axes` était **vide partout**, bande `EXCEEDED` partout. Un gate branché sur cette partition n'aurait **jamais pu mordre** — le vert aurait été vert de toute façon. En cherchant pourquoi, j'ai trouvé la cause :

**Les conteneurs formels sont partagés entre formalismes.** `_write_dl_to_state` ([state_writers.py:1039](../blob/main/argumentation_analysis/orchestration/state_writers.py#L1039)) écrit la Description Logic dans `fol_analysis_results`, sous la forme `formulas=["DL: <message>"]` — un message en prose rendu comme formule, avec `consistent` et `confidence=1.0`. La Conditional Logic (`CL(...)`) et QBF font de même dans `propositional_analysis_results`.

Conséquence mesurée sur les artefacts : **sur 2 corpus sur 3, l'axe `formal_fol` était porté uniquement par cette entrée DL — sur des runs où le vrai théorème du premier ordre avait échoué à parser.** La conclusion recevait un appui « premier ordre » qu'aucun prouveur du premier ordre n'avait produit.

Le writer FOL avait pourtant été durci exactement contre ça (#1278, l.858-866 : surfacer `unavailable:` « instead of silence or a fabricated "consistent" finding »). L'invité rouvrait le trou par une autre porte.

## Ce que change ce commit

**1. Un verdict invité ne crédite plus l'axe hôte.** `_is_guest_formal_entry` — volontairement conservateur : seule une entrée dont **toutes** les formules sont des marqueurs invités est écartée, pour qu'un vrai théorème mentionnant un marqueur garde son crédit.

**2. Le gate par axe.** `_gate_unsupported_claims` retire les phrases qui nomment un axe absent. Biaisé vers **ne pas** bloquer : une phrase qui nomme l'axe *pour dire qu'il est absent* — précisément ce que la première moitié de cette PR demande à la conclusion de faire — est exemptée par les marqueurs d'absence.

**3. Fail loud, pas fail hard.** La phrase saute, le reste de la conclusion reste, un paragraphe « Affirmation retirée » l'annonce au lecteur, et `degraded["act3_claim_blocked"]` porte la phrase retirée pour qu'un relecteur puisse auditer ce qui a été retenu.

**Par axe, pas par bande — et c'est mesuré.** Perdre `formal_fol` fait passer un corpus de 6 axes à 5 : la bande reste `EXCEEDED` (seuil ≥ 5). Un compte d'axes ne peut structurellement pas exprimer « *cette* affirmation-là n'a pas de support ».

## Effet vérifié sur les trois artefacts réels

| | avant | après |
|---|---|---|
| corpus_A | 6 axes, `missing=[]` | 6 axes, `missing=[]` — le vrai FOL décide, l'axe reste |
| corpus_B | 6 axes, `missing=[]` | **5 axes, `missing=['formal_fol']`** |
| corpus_C | 6 axes, `missing=[]` | **5 axes, `missing=['formal_fol']`** |

Prédiction annoncée avant de lancer, confirmée à l'identique. `formal_pl` survit partout : il est porté par une entrée hôte authentique, pas par les invités CL/QBF.

## Falsifiabilité — trois substitutions dégénérées

| substitution | tests tués |
|---|---|
| gate neutralisé (ne bloque jamais) | **3** — les trois qui affirment un retrait |
| `_is_guest_formal_entry ≡ False` (comportement d'avant) | **4** |
| `_is_guest_formal_entry ≡ True` (filtre trop large) | **6**, dont `test_same_claim_survives_when_the_axis_is_present` |

Les négatifs (`test_same_claim_survives…`, `test_gate_preserves_the_rest…`) **survivent** au gate neutralisé — c'est ce qui montre qu'ils testent l'autre moitié et non le même fait deux fois. Le filtre est borné des deux côtés.

## Ce que ce gate ne fait PAS — mesuré, à ne pas surinterpréter

Rejoué contre la prose réellement produite par le LLM sur les trois corpus : **0 phrase bloquée**. C'est un vrai négatif, pas un raté — et la distinction se vérifie :

La prose réelle écrit « validation formelle », « vérification formelle », « analyse formelle ». Elle ne nomme **jamais** un formalisme. Et l'appui formel générique **est** réellement porté sur les trois corpus par l'axe propositionnel (une entrée hôte, verdict SAT authentique). Le gate a donc raison de ne pas bloquer.

**Mais cela découvre un trou distinct** : une conclusion qui dit « l'analyse formelle l'appuie » sans nommer lequel des formalismes est **infalsifiable par un gate par axe** — et c'est exactement la formulation vague qui masque qu'un formalisme a échoué. Je ne l'ai pas colmaté ici : élargir les marqueurs à « formel » bloquerait des phrases légitimement portées par PL. Ce serait le pendule. C'est noté sur #1605 comme constat séparé.

## Tests

`tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py` : **56 → 74** (+18 au total ; chaque lot annoncé avant écriture, chaque delta exact : +14, +3, +1).

- `TestGuestFormalEntriesDoNotCreditHostAxis` (7) — dont le négatif prouvant la morsure : un vrai verdict FOL **garde** l'axe.
- `TestUnsupportedClaimBlocked` (7) — dont l'affirmation identique qui **survit** quand l'axe est présent, et l'énoncé d'absence honnête qui n'est **pas** bloqué.

Suite `reporting/restitution/` complète : 268 → 286, aucune régression. `black` + `flake8` propres.

## Anti-pendule

- **Ne pas supprimer l'écriture DL dans `fol_analysis_results`.** Le verdict DL est réel et le stockage partagé est une décision assumée. Ce qui était faux, c'est qu'il **crédite l'axe d'un autre**. On corrige la lecture, pas l'écriture.
- **Ne pas élargir les marqueurs de revendication.** Un marqueur qui attrape la prose ordinaire bloquerait des phrases honnêtes ; le gate doit rester biaisé vers ne pas bloquer.
- **Ne pas faire porter ce gate par la bande.** Le seuil est un compte ; il ne peut pas dire « cette affirmation-là ».

Privacy : IDs opaques, aucun contenu de corpus. Les artefacts vivent sous `evaluation/results/` (gitignoré).

---

## Deux commits de finition — et une correction que je me fais

### `8ddae3fb` — le gate ne doit pas laisser d'artefacts de lui-même

Sonde sur les cas limites du retrait de phrase. Deux défauts visibles **dans le livrable lu** :

1. Retirer l'unique phrase d'une section laissait un `### titre` nu, sans rien dessous. `_drop_empty_headings` supprime un titre dont la section n'a plus de contenu.
2. Quand *toutes* les phrases reposaient sur un axe absent, le gate vidait le narratif entier et l'avis de retrait était collé à rien.

### `34382092` — la correction

Dans `8ddae3fb`, j'avais justifié la clé `degraded["act3_claim_blocked_all"]` par : *« un consommateur lisant `status == "woven"` n'aurait sinon aucun moyen de distinguer une conclusion vide d'une conclusion écrite »*. J'ai ensuite vérifié que ce consommateur existe. **Il n'existe pas.**

| mesure | résultat |
|---|---|
| `pipeline_adapter.py:92` — seule construction prod de `RestitutionActs` | **ne passe aucun `degraded=`** ; lit uniquement les 3 chaînes de narratif |
| `renderer.py:119` — la branche « Acte dégradé » | ne tire donc jamais dans le chemin pipeline |
| `workflow_dsl.py:521` | lit un **autre** `degraded` (le booléen `PhaseResult` de DT-1 #1499) |
| `invoke_callables.py:8395` | renvoie bien le dict, mais `_write_act3_conclusion_to_state` ne persiste que `state.act3_conclusion` |

La note de provenance en tête de `pipeline_adapter.py:29-36` le dit d'ailleurs explicitement : le `degraded` structuré n'est pas porté sur le state, *« the act narratives themselves already carry the honest degradation wording inline »*.

J'avais nommé un lecteur sans le chercher — la fabrication exacte que cette campagne traque chez les autres depuis dix tours. **Le geste n'est pas de retirer la clé** (elle est cohérente avec ses sœurs act1/act2, et l'invoke-callable la rend à un intégrateur direct) : c'est de porter la garantie sur la surface qui la transporte réellement. Quand rien ne survit, la **prose** s'ouvre désormais sur « Aucune conclusion soutenable / **Il ne reste aucune conclusion** ».

Le constat que ça ouvre — un **troisième** registre de dégradation jamais alimenté, route morte en prod épinglée par `test_renderer.py:100` — est posé sur #1608 comme constat **adjacent, hors DoD** : c'est à po-2023 de décider s'il le replie dans son item « réconcilier les registres ».

### Falsifiabilité de ces deux lots

| substitution | tests tués |
|---|---|
| `_drop_empty_headings` réduit à un collapse de lignes vides | **1** — le négatif (titre conservé quand la section survit) tient |
| branche narratif-vide rendue inatteignable | **1** |
| `nothing_survived=False` toujours | **1** (le positif) |
| `nothing_survived=True` toujours | **2**, dont le négatif du cas partiel |

Note de méthode : la première tentative de substitution fut un **no-op silencieux** — un remplacement scripté dont l'aiguille n'a jamais matché, rendu « 73 passed », lu un instant comme « le test ne mord pas ». Même famille que tout le reste : *un vert qui serait vert de toute façon*. C'est d'avoir vérifié que la substitution s'était appliquée qui a séparé les deux.
