### PR TITLE
fix(orchestration): discriminate structured-arg absence cause + reconcile degraded (#1608)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -599,9 +599,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "argument_count": len(self.identified_arguments),
             "fallacy_count": len(self.identified_fallacies),
             "belief_set_count": len(self.belief_sets),
-            "counter_argument_count": len(
-                getattr(self, "counter_arguments", [])
-            ),
+            "counter_argument_count": len(getattr(self, "counter_arguments", [])),
             "jtms_belief_count": len(getattr(self, "jtms_beliefs", {})),
             "conclusion_present": self.final_conclusion is not None,
         }
@@ -654,9 +652,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             if delta:
                 sign = "+" if delta > 0 else ""
                 parts.append(f"{key.removesuffix('_count')}{sign}{delta}")
-        if after.get("conclusion_present") and not before.get(
-            "conclusion_present"
-        ):
+        if after.get("conclusion_present") and not before.get("conclusion_present"):
             parts.append("conclusion_set")
         return ", ".join(parts) if parts else "no_growth"
 
@@ -1036,13 +1032,22 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
 
         ``status`` is one of:
 
-        - ``"absent_no_translator"`` — the capability ran on auto-shaped
-          synthetic input because no text→structured translator is wired
-          (translation-gap FP-4 #1201). Its empty/degenerate extension list is
-          **not** a genuine evaluation of the source. ``degraded`` is ``True``.
         - ``"evaluated"`` — genuine structured input (defeasible rules,
           assumptions+contraries, collective attacks, weights, supports) was
           supplied via context, so the framework reflects real structure.
+          ``degraded`` is ``False``.
+        - ``"translator_failed"`` (#1608) — the text→structured translator
+          raised; the framework fell back to auto-shaped synthetic input.
+          ``degraded`` is ``True`` (the axis could not be obtained genuinely).
+        - ``"no_genuine_relations"`` (#1608) — the translator ran and found no
+          genuine structured relations in the source. This is an analytical
+          RESULT, not a failure: the source genuinely lacks such relations.
+          ``degraded`` is ``False`` (anti-pendule: not red).
+        - ``"translator_unconfigured"`` (#1608) — the translator could not run:
+          no LLM API key configured. ``degraded`` is ``True``.
+        - ``"absent_no_translator"`` — legacy/#1236 honest-absent label for the
+          rare path where no cause was recorded (nothing wired). The capability
+          ran on auto-shaped synthetic input. ``degraded`` is ``True``.
 
         This only *labels* what happened; it never fabricates extensions
         (#1019). Keyed by ``capability`` (last write wins — one status per

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -501,6 +501,17 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         # Empty until the act3_conclusion phase runs; the renderer reports the gap
         # honestly.
         self.act3_conclusion: str = ""
+        # #1608 — per-act degradation motifs (the *why* an act ran degraded:
+        # readability-gate band, virtuous-mode shift, etc.). The acts return
+        # ``degraded`` as a dict of motifs (``ActNResult.degraded``); the act
+        # invokers surface it as ``output["degraded_reasons"]`` and the act
+        # state writers persist it here, keyed by capability. Surfacing the
+        # motifs in the state (rather than letting them die in the return
+        # value) lets the renderer attribute a degraded act to its true cause
+        # — fail-loud, not fail-hard (#1019). Anti-pendule: only populated
+        # when an act genuinely recorded motifs; an act that succeeded stays
+        # empty (never marked degraded by default).
+        self.restitution_acts_degraded: Dict[str, Dict[str, str]] = {}
         # PP #715: source-level metadata for qualitative synthesis
         self.source_metadata: Dict[str, str] = {}
         # Epic #1258 / Track 1 #1259 — déanonymisation du pipeline de travail.

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3419,6 +3419,25 @@ async def _invoke_ranking(input_text: str, context: Dict[str, Any]) -> Dict[str,
         return _enrich_ranking_with_justification(result, args, attacks, context)
 
 
+def _propagate_structured_arg_cause(
+    context: Dict[str, Any], capability: str, cause: str, error: str = ""
+) -> None:
+    """Write the discriminated translation cause into the pipeline context (#1608).
+
+    The recorder ``state_writers._record_structured_arg_status`` reads these
+    keys (namespaced per capability) to label the axis with its true status
+    (``translator_failed`` / ``no_genuine_relations`` / ``translator_unconfigured``)
+    instead of the #1236-era ``absent_no_translator`` catch-all.
+    """
+    from argumentation_analysis.orchestration.state_writers import (
+        _translation_cause_key,
+        _translation_error_key,
+    )
+
+    context[_translation_cause_key(capability)] = cause
+    context[_translation_error_key(capability)] = error
+
+
 async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke bipolar argumentation handler with JVM fallback."""
     args = context.get("arguments") or _extract_arguments_from_context(
@@ -3439,11 +3458,18 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str,
                 translate_to_bipolar_supports,
             )
 
-            supports = await translate_to_bipolar_supports(input_text, args)
+            outcome = await translate_to_bipolar_supports(input_text, args)
+            supports = outcome.relations
             if supports:
                 context["supports"] = supports
+            _propagate_structured_arg_cause(
+                context, "bipolar_argumentation", outcome.cause, outcome.error
+            )
         except Exception as e:
-            logger.info("Bipolar translator unavailable (%s); absent_no_translator.", e)
+            logger.warning("Bipolar translator unavailable (%s); translator_failed.", e)
+            _propagate_structured_arg_cause(
+                context, "bipolar_argumentation", "translator_failed", type(e).__name__
+            )
 
     try:
         from argumentation_analysis.agents.core.logic.bipolar_handler import (
@@ -3485,11 +3511,18 @@ async def _invoke_aba(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
                 translate_to_aba_contraries,
             )
 
-            contraries = await translate_to_aba_contraries(input_text, args)
+            outcome = await translate_to_aba_contraries(input_text, args)
+            contraries = outcome.relations
             if contraries:
                 context["contraries"] = contraries
+            _propagate_structured_arg_cause(
+                context, "aba_reasoning", outcome.cause, outcome.error
+            )
         except Exception as e:
-            logger.info("ABA translator unavailable (%s); absent_no_translator.", e)
+            logger.warning("ABA translator unavailable (%s); translator_failed.", e)
+            _propagate_structured_arg_cause(
+                context, "aba_reasoning", "translator_failed", type(e).__name__
+            )
 
     try:
         from argumentation_analysis.agents.core.logic.aba_handler import ABAHandler
@@ -3596,11 +3629,18 @@ async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict[str, A
                 translate_to_aspic_rules,
             )
 
-            derived_rules = await translate_to_aspic_rules(input_text, args)
+            outcome = await translate_to_aspic_rules(input_text, args)
+            derived_rules = outcome.relations
             if derived_rules:
                 context["defeasible_rules"] = derived_rules
+            _propagate_structured_arg_cause(
+                context, "aspic_plus_reasoning", outcome.cause, outcome.error
+            )
         except Exception as e:
-            logger.info("ASPIC+ translator unavailable (%s); absent_no_translator.", e)
+            logger.warning("ASPIC+ translator unavailable (%s); translator_failed.", e)
+            _propagate_structured_arg_cause(
+                context, "aspic_plus_reasoning", "translator_failed", type(e).__name__
+            )
 
     # Build meaningful rules from upstream data
     fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
@@ -3990,11 +4030,18 @@ async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict[str, A
                 translate_to_setaf_attacks,
             )
 
-            derived_attacks = await translate_to_setaf_attacks(input_text, args)
+            outcome = await translate_to_setaf_attacks(input_text, args)
+            derived_attacks = outcome.relations
             if derived_attacks:
                 context["set_attacks"] = derived_attacks
+            _propagate_structured_arg_cause(
+                context, "setaf_reasoning", outcome.cause, outcome.error
+            )
         except Exception as e:
-            logger.info("SetAF translator unavailable (%s); absent_no_translator.", e)
+            logger.warning("SetAF translator unavailable (%s); translator_failed.", e)
+            _propagate_structured_arg_cause(
+                context, "setaf_reasoning", "translator_failed", type(e).__name__
+            )
     # SetAF attacks come as {attackers, target} dicts. Upstream may provide
     # them directly, else shape from the canonical pairwise attack graph.
     raw_attacks = context.get("set_attacks")
@@ -4040,12 +4087,19 @@ async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict[str
                 translate_to_weighted_attacks,
             )
 
-            derived_attacks = await translate_to_weighted_attacks(input_text, args)
+            outcome = await translate_to_weighted_attacks(input_text, args)
+            derived_attacks = outcome.relations
             if derived_attacks:
                 context["weighted_attacks"] = derived_attacks
+            _propagate_structured_arg_cause(
+                context, "weighted_argumentation", outcome.cause, outcome.error
+            )
         except Exception as e:
-            logger.info(
-                "Weighted translator unavailable (%s); absent_no_translator.", e
+            logger.warning(
+                "Weighted translator unavailable (%s); translator_failed.", e
+            )
+            _propagate_structured_arg_cause(
+                context, "weighted_argumentation", "translator_failed", type(e).__name__
             )
     # Weighted attacks come as (source, target, weight) triples. Upstream may
     # provide them directly, else shape from the canonical pairwise graph with

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -8247,7 +8247,8 @@ async def _invoke_act2_narrative(
         "act2_narrative": result.narrative,
         "status": result.status,
         "gate_band": gate_band,
-        "degraded": result.degraded,
+        "degraded": bool(result.degraded),
+        "degraded_reasons": dict(result.degraded),
     }
 
 
@@ -8346,7 +8347,8 @@ async def _invoke_act1_framing(
         "act1_framing": result.narrative,
         "status": result.status,
         "gate_band": gate_band,
-        "degraded": result.degraded,
+        "degraded": bool(result.degraded),
+        "degraded_reasons": dict(result.degraded),
     }
 
 
@@ -8446,7 +8448,8 @@ async def _invoke_act3_conclusion(
         "act3_conclusion": result.narrative,
         "status": result.status,
         "gate_band": gate_band,
-        "degraded": result.degraded,
+        "degraded": bool(result.degraded),
+        "degraded_reasons": dict(result.degraded),
     }
 
 

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -1335,6 +1335,27 @@ def _write_act2_narrative_to_state(
     narrative = output.get("act2_narrative", "")
     if isinstance(narrative, str) and narrative:
         state.act2_narrative = narrative
+    # #1608 — persist the degradation motifs so they reach the state instead
+    # of dying in the return value (the acts return ``degraded`` as a dict;
+    # the invoker surfaces it as ``degraded_reasons``).
+    _persist_act_degraded_reasons(state, "act2_narrative", output)
+
+
+def _persist_act_degraded_reasons(state: Any, capability: str, output: Any) -> None:
+    """Persist an act's degradation motifs into ``restitution_acts_degraded``.
+
+    Anti-pendule (#1608): only populated when the act genuinely recorded
+    motifs (non-empty dict) — an act that succeeded is never marked degraded
+    by default. No-op on states that predate the field (defensive).
+    """
+    if not isinstance(output, dict):
+        return
+    reasons = output.get("degraded_reasons")
+    if not isinstance(reasons, dict) or not reasons:
+        return
+    rstd = getattr(state, "restitution_acts_degraded", None)
+    if isinstance(rstd, dict):
+        rstd[capability] = dict(reasons)
 
 
 def _write_act1_framing_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
@@ -1350,6 +1371,7 @@ def _write_act1_framing_to_state(output: Any, state: Any, ctx: dict[str, Any]) -
     narrative = output.get("act1_framing", "")
     if isinstance(narrative, str) and narrative:
         state.act1_framing = narrative
+    _persist_act_degraded_reasons(state, "act1_framing", output)  # #1608 motifs
 
 
 def _write_act3_conclusion_to_state(
@@ -1367,6 +1389,7 @@ def _write_act3_conclusion_to_state(
     narrative = output.get("act3_conclusion", "")
     if isinstance(narrative, str) and narrative:
         state.act3_conclusion = narrative
+    _persist_act_degraded_reasons(state, "act3_conclusion", output)  # #1608 motifs
 
 
 def _write_text_to_kb_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -30,47 +30,123 @@ _STRUCTURED_ARG_INPUT_KEYS: Dict[str, Tuple[str, ...]] = {
     "bipolar_argumentation": ("supports",),
 }
 
-# Per-formalism reason string explaining what extraction is missing. Kept in the
-# state so a reader sees *why* the axis is absent, not just that it is.
+# Per-formalism display name (used to build the discriminated reason strings).
+_STRUCTURED_ARG_FORMALISM_NAME: Dict[str, str] = {
+    "aspic_plus_reasoning": "ASPIC+",
+    "aba_reasoning": "ABA",
+    "setaf_reasoning": "SetAF",
+    "weighted_argumentation": "Weighted AF",
+    "bipolar_argumentation": "Bipolar AF",
+}
+
+# Per-formalism reason string for the ``absent_no_translator`` fallback (#1608).
+# Reformulated to describe what was *observed* (ran on auto-shaped synthetic
+# input) rather than the #1236-era claim "no translator extracts …" — which was
+# falsified once ``structured_arg_translator`` existed and a translator could
+# raise, run empty, or skip for want of a key. The discriminated statuses
+# (``translator_failed`` / ``no_genuine_relations`` / ``translator_unconfigured``)
+# now carry the precise cause; this string only backs the rare legacy path where
+# no cause was recorded (nothing wired).
 _STRUCTURED_ARG_ABSENT_REASON: Dict[str, str] = {
     "aspic_plus_reasoning": (
-        "ASPIC+ not genuinely evaluated: no translator extracts defeasible/"
-        "strict rules + preferences from the source. Ran on auto-shaped "
-        "synthetic rules — not fabricated, but not a genuine ASPIC+ analysis "
-        "of the text."
+        "ASPIC+ ran on auto-shaped synthetic rules: no genuine defeasible/"
+        "strict rules + preferences were supplied from the source. Not "
+        "fabricated, but not a genuine ASPIC+ analysis of the text."
     ),
     "aba_reasoning": (
-        "ABA not genuinely evaluated: no translator extracts assumptions + "
-        "their contraries from the source. Ran on auto-shaped synthetic rules "
-        "without genuine contraries."
+        "ABA ran on auto-shaped synthetic rules: no genuine assumptions + "
+        "their contraries were supplied from the source."
     ),
     "setaf_reasoning": (
-        "SetAF not genuinely evaluated: no translator extracts collective "
-        "(joint) attacks from the source. Ran on auto-shaped synthetic "
-        "pairwise attacks lifted to singletons."
+        "SetAF ran on auto-shaped synthetic pairwise attacks lifted to "
+        "singletons: no genuine collective (joint) attacks were supplied "
+        "from the source."
     ),
     "weighted_argumentation": (
-        "Weighted AF not genuinely evaluated: no translator extracts attack "
-        "weights from the source. Ran on auto-shaped synthetic attacks with "
-        "neutral placeholder weights."
+        "Weighted AF ran on auto-shaped synthetic attacks with neutral "
+        "placeholder weights: no genuine attack weights were supplied from "
+        "the source."
     ),
     "bipolar_argumentation": (
-        "Bipolar AF not genuinely evaluated: no translator extracts support "
-        "relations from the source. Ran on auto-shaped synthetic attacks with "
-        "no genuine supports."
+        "Bipolar AF ran on auto-shaped synthetic attacks with no genuine "
+        "supports: no genuine support relations were supplied from the source."
     ),
 }
+
+
+def _translation_cause_key(capability: str) -> str:
+    """Context key carrying the discriminated translation cause (#1608).
+
+    The invoke callable that ran the translator writes the cause here; the
+    recorder reads it. Namespaced by capability so the five translators do not
+    overwrite each other in the shared pipeline context.
+    """
+    return f"_structured_arg_cause:{capability}"
+
+
+def _translation_error_key(capability: str) -> str:
+    """Context key carrying the exception type for a ``translator_failed`` cause."""
+    return f"_structured_arg_error:{capability}"
+
+
+def _resolve_absent_status(
+    capability: str, cause: Optional[str], error: str
+) -> tuple[str, bool, str]:
+    """Map a translation cause to ``(status, degraded, reason)`` (#1608).
+
+    Used when no genuine structured input was supplied. Anti-pendule: cause 3
+    (``no_genuine_relations`` — the translator ran and found nothing) is an
+    analytical RESULT, not a failure; it must NOT be marked ``degraded``.
+    Making it red would be the symmetrical error of the current bug.
+    """
+    formalism = _STRUCTURED_ARG_FORMALISM_NAME.get(capability, capability)
+    synthetic = "The framework ran on auto-shaped synthetic input."
+    if cause == "translator_failed":
+        return (
+            "translator_failed",
+            True,
+            f"{formalism} translator raised {error or 'an exception'} — genuine "
+            f"structured input could not be obtained. {synthetic}",
+        )
+    if cause == "no_genuine_relations":
+        return (
+            "no_genuine_relations",
+            False,
+            f"{formalism} translator ran and found no genuine structured "
+            f"relations in the source — an analytical result, not a failure. "
+            f"{synthetic}",
+        )
+    if cause == "translator_unconfigured":
+        return (
+            "translator_unconfigured",
+            True,
+            f"{formalism} translator could not run: no LLM API key configured. "
+            f"{synthetic}",
+        )
+    # No cause recorded (nothing wired / legacy path) — honest-absent #1236.
+    return (
+        "absent_no_translator",
+        True,
+        _STRUCTURED_ARG_ABSENT_REASON.get(
+            capability,
+            "No text→structured translator wired; ran on auto-shaped synthetic "
+            "input (translation-gap FP-4 #1201).",
+        ),
+    )
 
 
 def _record_structured_arg_status(
     state: Any, capability: str, output: Any, ctx: dict[str, Any]
 ) -> None:
-    """Surface the honest-absent status of a structured-arg capability (FP-17 #1236).
+    """Surface the honest status of a structured-arg capability (#1236 / #1608).
 
-    Records ``status="absent_no_translator"`` (+ ``degraded=True``) when the
-    context carried no genuine formalism-specific structured input — the
-    translation-gap reality (FP-4 #1201) — or ``status="evaluated"`` when it
-    did. Only labels what happened; never fabricates extensions (#1019).
+    Records ``status="evaluated"`` when the context carried genuine
+    formalism-specific structured input. Otherwise discriminates the cause via
+    :func:`_resolve_absent_status` — reading the cause the invoke callable wrote
+    into ``ctx`` — so the axis is labelled ``translator_failed`` /
+    ``no_genuine_relations`` / ``translator_unconfigured`` rather than the
+    #1236-era ``absent_no_translator`` catch-all that asserted a cause it had
+    not observed. Only labels what happened; never fabricates extensions (#1019).
     No-op on states that predate ``add_structured_arg_status`` (defensive).
     """
     recorder = getattr(state, "add_structured_arg_status", None)
@@ -95,18 +171,15 @@ def _record_structured_arg_status(
             "evaluated on real structured artifacts.",
             ext_count,
         )
-    else:
-        recorder(
-            capability,
-            "absent_no_translator",
-            True,
-            _STRUCTURED_ARG_ABSENT_REASON.get(
-                capability,
-                "No text→structured translator wired; ran on auto-shaped "
-                "synthetic input (translation-gap FP-4 #1201).",
-            ),
-            ext_count,
-        )
+        return
+    # No genuine input — discriminate the cause (#1608). The invoke callable
+    # that ran the translator wrote the cause into ctx. Falls back to
+    # absent_no_translator only when no cause was recorded (nothing wired /
+    # legacy paths), preserving the #1236 honest-absent label.
+    cause = ctx.get(_translation_cause_key(capability))
+    error = ctx.get(_translation_error_key(capability), "") or ""
+    status, degraded, reason = _resolve_absent_status(capability, cause, error)
+    recorder(capability, status, degraded, reason, ext_count)
 
 
 __all__ = [

--- a/argumentation_analysis/orchestration/structured_arg_translator.py
+++ b/argumentation_analysis/orchestration/structured_arg_translator.py
@@ -20,11 +20,16 @@ Relations returned by the LLM are **validated against the real argument
 inventory**. The arguments are handed to the LLM as an enumerated list
 (``arg1``..``argN``) and it must cite relations *by id*. Any relation that
 references an id not in the inventory, or is otherwise malformed, is dropped.
-If after validation nothing remains, the formalism stays
-``absent_no_translator`` — an honest absence, never a fabricated evaluation
-("soustraire le gap, pas contourner le garde"). The honest-absent gate in
-``_record_structured_arg_status`` is never modified: this module only feeds it
-genuine input.
+If after validation nothing remains, the translator returns a
+``TranslationResult`` whose ``cause`` discriminates *why* (the LLM ran and
+found no genuine relations · no API key configured · the call raised) — never a
+fabricated evaluation ("soustraire le gap, pas contourner le garde"). The
+caller propagates ``cause`` into the context so
+``_record_structured_arg_status`` labels the axis with its true status
+(``no_genuine_relations`` / ``translator_unconfigured`` / ``translator_failed``)
+instead of the #1236-era ``absent_no_translator`` catch-all (#1608). The
+honest-absent gate itself is never modified: this module only feeds it genuine
+input + a discriminated cause.
 
 Privacy HARD
 ------------
@@ -36,9 +41,49 @@ gitignored state artifacts.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Tuple
 
 logger = logging.getLogger("UnifiedPipeline")
+
+
+class TranslatorUnconfigured(RuntimeError):
+    """No LLM API key configured (#1608).
+
+    Distinct from a runtime failure: the translator could not even attempt
+    the work. Raised inside ``_llm_extract_relations`` and caught by each
+    translator, which labels the axis ``translator_unconfigured`` rather than
+    collapsing onto ``absent_no_translator``.
+    """
+
+
+# Discriminated causes for a structured-arg translation (#1608). The four
+# values map 1:1 to the four statuses the recorder emits — a translator must
+# never silently return an empty result without one of them.
+CAUSE_EVALUATED = "evaluated"
+CAUSE_TRANSLATOR_FAILED = "translator_failed"
+CAUSE_NO_GENUINE_RELATIONS = "no_genuine_relations"
+CAUSE_TRANSLATOR_UNCONFIGURED = "translator_unconfigured"
+
+
+@dataclass
+class TranslationResult:
+    """Outcome of a structured-arg translation, carrying the discriminated cause.
+
+    Replaces the bare ``[]`` / ``{}`` return that collapsed four distinct
+    causes (translator raised · translator ran and found nothing · no API key
+    · empty inventory) onto a single ``absent_no_translator`` label. The
+    caller propagates ``cause`` into the pipeline context so
+    :func:`state_writers._record_structured_arg_status` can label the axis
+    honestly — *fail loud, not fail hard* (#1597): the run still completes,
+    but the reason it ran degraded is now visible and attributed to its true
+    cause, not the #1236-era "no translator" story.
+    """
+
+    relations: Any  # list | dict — the validated relations (empty when none)
+    cause: str  # one of the CAUSE_* constants above
+    error: str = ""  # exception type name, only when cause == translator_failed
+
 
 # Cap the argument inventory handed to the LLM so prompt + response stay bounded
 # (mirrors the [:40] cap in _extract_arguments_from_context, #708). Bipolar/ABA
@@ -47,7 +92,9 @@ logger = logging.getLogger("UnifiedPipeline")
 _MAX_INVENTORY = 20
 
 
-def _build_inventory(arguments: List[str]) -> Tuple[Dict[str, str], List[Dict[str, str]]]:
+def _build_inventory(
+    arguments: List[str],
+) -> Tuple[Dict[str, str], List[Dict[str, str]]]:
     """Enumerate the real arguments as ``{id: text}`` + the LLM-facing list.
 
     Skips empty/whitespace entries. Returns ``(arg_by_id, listed)`` where
@@ -94,10 +141,10 @@ async def _llm_extract_relations(
     client, model_id = _get_openai_client()
     if client is None:
         logger.info(
-            "%s translator: no LLM API key configured — staying absent_no_translator.",
+            "%s translator: no LLM API key configured — cannot translate.",
             relation_kind,
         )
-        return {}
+        raise TranslatorUnconfigured("no LLM API key configured")
 
     inventory_json = ", ".join(
         f'{{"id":"{a["id"]}","text":"{a["text"][:140]}"}}' for a in listed
@@ -177,8 +224,7 @@ async def _llm_extract_relations(
         + task
         + " If no genuine relations of this kind exist in the text, return an empty "
         "list — do NOT invent relations. "
-        "Respond with ONLY a JSON object of this shape:\n"
-        + shape
+        "Respond with ONLY a JSON object of this shape:\n" + shape
     )
     user_content = (
         f"Source text (excerpt):\n{input_text[:3000]}\n\n"
@@ -423,72 +469,87 @@ def _validate_weighted_attacks(
 
 async def translate_to_bipolar_supports(
     input_text: str, arguments: List[str]
-) -> List[List[str]]:
+) -> TranslationResult:
     """Derive genuine bipolar support relations from the text + arguments.
 
-    Returns a list of ``[source, target]`` pairs (canonical argument texts),
-    validated against the real inventory. Empty list when the LLM finds no
-    genuine supports OR no API key is configured — the caller then stays
-    ``absent_no_translator`` (honest absence, anti-théâtre #1019).
+    Returns a ``TranslationResult`` whose ``relations`` is a list of
+    ``[source, target]`` pairs (canonical argument texts), validated against
+    the real inventory. The ``cause`` discriminates why the axis is absent
+    when ``relations`` is empty: ``no_genuine_relations`` (ran, found none —
+    an analytical result), ``translator_unconfigured`` (no API key), or
+    ``translator_failed`` (the call raised — ``error`` carries the type).
+    Anti-théâtre #1019 / #1608: the caller labels the axis from ``cause``,
+    never fabricating supports.
     """
     arg_by_id, _ = _build_inventory(arguments)
     if not arg_by_id:
-        return []
+        return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
     try:
         data = await _llm_extract_relations(input_text, arguments, "supports")
+    except TranslatorUnconfigured:
+        return TranslationResult(relations=[], cause=CAUSE_TRANSLATOR_UNCONFIGURED)
     except Exception as e:  # network / parse / budget — never fatal to the run
-        logger.info(
-            "Bipolar supports translator failed (%s) — staying absent_no_translator.",
-            e,
+        logger.warning(
+            "Bipolar supports translator failed (%s) — staying absent.",
+            type(e).__name__,
         )
-        return []
+        return TranslationResult(
+            relations=[], cause=CAUSE_TRANSLATOR_FAILED, error=type(e).__name__
+        )
     supports = _validate_supports(data, arg_by_id)
     if supports:
         logger.info(
             "Bipolar translator: derived %d genuine support relation(s) from text.",
             len(supports),
         )
-    return supports
+        return TranslationResult(relations=supports, cause=CAUSE_EVALUATED)
+    return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
 
 
 async def translate_to_aba_contraries(
     input_text: str, arguments: List[str]
-) -> Dict[str, str]:
+) -> TranslationResult:
     """Derive genuine ABA assumption↔contrary pairs from the text + arguments.
 
-    Returns ``{assumption_text: contrary_sentence}`` validated against the real
-    inventory. Empty dict when the LLM finds no genuine contraries OR no API key
-    is configured — the caller then stays ``absent_no_translator``.
+    Returns a ``TranslationResult`` whose ``relations`` is an
+    ``{assumption_text: contrary_sentence}`` dict validated against the real
+    inventory. See :func:`translate_to_bipolar_supports` for the ``cause``
+    contract (#1608).
     """
     arg_by_id, _ = _build_inventory(arguments)
     if not arg_by_id:
-        return {}
+        return TranslationResult(relations={}, cause=CAUSE_NO_GENUINE_RELATIONS)
     try:
         data = await _llm_extract_relations(input_text, arguments, "contraries")
+    except TranslatorUnconfigured:
+        return TranslationResult(relations={}, cause=CAUSE_TRANSLATOR_UNCONFIGURED)
     except Exception as e:  # network / parse / budget — never fatal to the run
-        logger.info(
-            "ABA contraries translator failed (%s) — staying absent_no_translator.",
-            e,
+        logger.warning(
+            "ABA contraries translator failed (%s) — staying absent.",
+            type(e).__name__,
         )
-        return {}
+        return TranslationResult(
+            relations={}, cause=CAUSE_TRANSLATOR_FAILED, error=type(e).__name__
+        )
     contraries = _validate_contraries(data, arg_by_id)
     if contraries:
         logger.info(
             "ABA translator: derived %d genuine contrary pair(s) from text.",
             len(contraries),
         )
-    return contraries
+        return TranslationResult(relations=contraries, cause=CAUSE_EVALUATED)
+    return TranslationResult(relations={}, cause=CAUSE_NO_GENUINE_RELATIONS)
 
 
 async def translate_to_aspic_rules(
     input_text: str, arguments: List[str]
-) -> List[Dict[str, Any]]:
+) -> TranslationResult:
     """Derive genuine ASPIC+ defeasible inference rules from the text + arguments.
 
-    Returns a list of handler-shaped ``{head, body, name}`` rule dicts with
-    PL-atom heads/bodies, validated against the real inventory. Empty list when
-    the LLM finds no genuine rules OR no API key is configured — the caller then
-    stays ``absent_no_translator`` (honest absence, anti-théâtre #1019).
+    Returns a ``TranslationResult`` whose ``relations`` is a list of
+    handler-shaped ``{head, body, name}`` rule dicts with PL-atom
+    heads/bodies, validated against the real inventory. See
+    :func:`translate_to_bipolar_supports` for the ``cause`` contract (#1608).
 
     Only **defeasible** rules are derived: natural-language argumentation is
     defeasible, and strict rules / preference orderings are not reliably
@@ -500,15 +561,19 @@ async def translate_to_aspic_rules(
     """
     arg_by_id, _ = _build_inventory(arguments)
     if not arg_by_id:
-        return []
+        return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
     try:
         data = await _llm_extract_relations(input_text, arguments, "aspic_rules")
+    except TranslatorUnconfigured:
+        return TranslationResult(relations=[], cause=CAUSE_TRANSLATOR_UNCONFIGURED)
     except Exception as e:  # network / parse / budget — never fatal to the run
-        logger.info(
-            "ASPIC+ rules translator failed (%s) — staying absent_no_translator.",
-            e,
+        logger.warning(
+            "ASPIC+ rules translator failed (%s) — staying absent.",
+            type(e).__name__,
         )
-        return []
+        return TranslationResult(
+            relations=[], cause=CAUSE_TRANSLATOR_FAILED, error=type(e).__name__
+        )
     # _pl_atom lives in invoke_callables (lazy import — no module-load cycle).
     from argumentation_analysis.orchestration.invoke_callables import _pl_atom
 
@@ -518,72 +583,82 @@ async def translate_to_aspic_rules(
             "ASPIC+ translator: derived %d genuine defeasible rule(s) from text.",
             len(rules),
         )
-    return rules
+        return TranslationResult(relations=rules, cause=CAUSE_EVALUATED)
+    return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
 
 
 async def translate_to_setaf_attacks(
     input_text: str, arguments: List[str]
-) -> List[Dict[str, Any]]:
+) -> TranslationResult:
     """Derive genuine SetAF joint attacks from the text + arguments.
 
-    Returns a list of handler-shaped ``{attackers, target}`` joint-attack dicts
-    (canonical argument texts), validated against the real inventory. Empty list
-    when the LLM finds no genuine joint attacks OR no API key is configured — the
-    caller then stays ``absent_no_translator`` (honest absence, anti-théâtre
-    #1019). The gate ``_STRUCTURED_ARG_INPUT_KEYS['setaf_reasoning']`` accepts
+    Returns a ``TranslationResult`` whose ``relations`` is a list of
+    handler-shaped ``{attackers, target}`` joint-attack dicts (canonical
+    argument texts), validated against the real inventory. See
+    :func:`translate_to_bipolar_supports` for the ``cause`` contract (#1608).
+    The gate ``_STRUCTURED_ARG_INPUT_KEYS['setaf_reasoning']`` accepts
     ``set_attacks``; the gate itself is never modified.
     """
     arg_by_id, _ = _build_inventory(arguments)
     if not arg_by_id:
-        return []
+        return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
     try:
         data = await _llm_extract_relations(input_text, arguments, "setaf_attacks")
+    except TranslatorUnconfigured:
+        return TranslationResult(relations=[], cause=CAUSE_TRANSLATOR_UNCONFIGURED)
     except Exception as e:  # network / parse / budget — never fatal to the run
-        logger.info(
-            "SetAF attacks translator failed (%s) — staying absent_no_translator.",
-            e,
+        logger.warning(
+            "SetAF attacks translator failed (%s) — staying absent.",
+            type(e).__name__,
         )
-        return []
+        return TranslationResult(
+            relations=[], cause=CAUSE_TRANSLATOR_FAILED, error=type(e).__name__
+        )
     attacks = _validate_setaf_attacks(data, arg_by_id)
     if attacks:
         logger.info(
             "SetAF translator: derived %d genuine joint attack(s) from text.",
             len(attacks),
         )
-    return attacks
+        return TranslationResult(relations=attacks, cause=CAUSE_EVALUATED)
+    return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
 
 
 async def translate_to_weighted_attacks(
     input_text: str, arguments: List[str]
-) -> List[Tuple[str, str, float]]:
+) -> TranslationResult:
     """Derive genuine weighted attacks from the text + arguments.
 
-    Returns a list of ``(source, target, weight)`` triples (canonical argument
-    texts, weight clamped to ``[0, 1]``), validated against the real inventory.
-    Empty list when the LLM finds no genuine weighted attacks OR no API key is
-    configured — the caller then stays ``absent_no_translator`` (honest absence,
-    anti-théâtre #1019). The gate ``_STRUCTURED_ARG_INPUT_KEYS[
-    'weighted_argumentation']`` accepts ``weighted_attacks``; the gate itself is
-    never modified.
+    Returns a ``TranslationResult`` whose ``relations`` is a list of
+    ``(source, target, weight)`` triples (canonical argument texts, weight
+    clamped to ``[0, 1]``), validated against the real inventory. See
+    :func:`translate_to_bipolar_supports` for the ``cause`` contract (#1608).
+    The gate ``_STRUCTURED_ARG_INPUT_KEYS['weighted_argumentation']`` accepts
+    ``weighted_attacks``; the gate itself is never modified.
     """
     arg_by_id, _ = _build_inventory(arguments)
     if not arg_by_id:
-        return []
+        return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
     try:
         data = await _llm_extract_relations(input_text, arguments, "weighted_attacks")
+    except TranslatorUnconfigured:
+        return TranslationResult(relations=[], cause=CAUSE_TRANSLATOR_UNCONFIGURED)
     except Exception as e:  # network / parse / budget — never fatal to the run
-        logger.info(
-            "Weighted attacks translator failed (%s) — staying absent_no_translator.",
-            e,
+        logger.warning(
+            "Weighted attacks translator failed (%s) — staying absent.",
+            type(e).__name__,
         )
-        return []
+        return TranslationResult(
+            relations=[], cause=CAUSE_TRANSLATOR_FAILED, error=type(e).__name__
+        )
     attacks = _validate_weighted_attacks(data, arg_by_id)
     if attacks:
         logger.info(
             "Weighted translator: derived %d genuine weighted attack(s) from text.",
             len(attacks),
         )
-    return attacks
+        return TranslationResult(relations=attacks, cause=CAUSE_EVALUATED)
+    return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
 
 
 __all__ = [
@@ -592,6 +667,12 @@ __all__ = [
     "translate_to_aspic_rules",
     "translate_to_setaf_attacks",
     "translate_to_weighted_attacks",
+    "TranslationResult",
+    "TranslatorUnconfigured",
+    "CAUSE_EVALUATED",
+    "CAUSE_TRANSLATOR_FAILED",
+    "CAUSE_NO_GENUINE_RELATIONS",
+    "CAUSE_TRANSLATOR_UNCONFIGURED",
     "_build_inventory",
     "_validate_supports",
     "_validate_contraries",

--- a/argumentation_analysis/orchestration/unified_pipeline.py
+++ b/argumentation_analysis/orchestration/unified_pipeline.py
@@ -17,7 +17,7 @@ backward compatibility.
 """
 
 import logging
-from typing import Dict, Any, Optional
+from typing import Dict, Any, List, Optional, Tuple
 
 from argumentation_analysis.core.capability_registry import (
     CapabilityRegistry,
@@ -50,6 +50,54 @@ from argumentation_analysis.orchestration.registry_setup import (  # noqa: F401
 from argumentation_analysis.orchestration.workflows import *  # noqa: F401,F403
 
 logger = logging.getLogger("UnifiedPipeline")
+
+
+def _collect_degraded_capabilities(
+    phase_results: Dict[str, Any],
+    state: Any,
+    capabilities_used: List[str],
+) -> Tuple[List[str], List[str]]:
+    """Collect capabilities that ran degraded (#1355 / #1608).
+
+    Two independent sources, reconciled into ``capabilities_degraded``:
+
+    * the honest ``structured_arg_status`` registry — formal/logic axes
+      (ASPIC+/SetAF/weighted/Dung) whose translator raised, was unconfigured,
+      or stayed honestly absent (populated by ``_record_structured_arg_status``
+      with ``degraded=True``);
+    * the phase-output ``degraded`` canon — non-formal phases (governance,
+      external solvers, and the three restitution acts) that mark
+      ``output["degraded"] = True`` (BO-2 #1472 / GE-4 #1462).
+
+    #1608 — the restitution acts return ``degraded`` as a *dict of motifs*
+    (``ActNResult.degraded``), so the act invokers now surface it as a BOOL
+    ``output["degraded"]`` (feeds this ``is True`` predicate) AND a
+    ``degraded_reasons`` dict (persisted to state by the act writers). A dict
+    is never ``is True`` — before the raccord the acts structurally could not
+    feed this list (7 declaration sites, 0 readers).
+
+    Returns ``(capabilities_degraded, capabilities_used)`` with degraded caps
+    removed from ``capabilities_used`` so a degraded capability surfaces as
+    degraded, NOT as ``used`` (anti-theater #1019). Additive: phases/axes
+    without a degraded marker are unaffected.
+    """
+    degraded_caps: set[str] = set()
+    if state is not None:
+        structured = getattr(state, "structured_arg_status", None) or {}
+        degraded_caps = {
+            cap
+            for cap, info in structured.items()
+            if isinstance(info, dict) and info.get("degraded")
+        }
+    for pr in phase_results.values():
+        if pr.status != PhaseStatus.COMPLETED:
+            continue
+        out = getattr(pr, "output", None)
+        if isinstance(out, dict) and out.get("degraded") is True:
+            degraded_caps.add(pr.capability)
+    capabilities_degraded = sorted(degraded_caps)
+    capabilities_used = [c for c in capabilities_used if c not in degraded_caps]
+    return capabilities_degraded, capabilities_used
 
 
 async def run_unified_analysis(
@@ -185,7 +233,9 @@ async def run_unified_analysis(
     # #905: Apply formal extension filter before execution
     formal_filter = context.get("formal_extension_filter", "all") if context else "all"
     if formal_filter != "all":
-        from argumentation_analysis.orchestration.workflows import filter_formal_extensions
+        from argumentation_analysis.orchestration.workflows import (
+            filter_formal_extensions,
+        )
 
         workflow = filter_formal_extensions(workflow, formal_filter)
 
@@ -287,38 +337,9 @@ async def run_unified_analysis(
     # degraded capability surfaces via capabilities_degraded, NOT as ``used``.
     # Mirrors the conversational_orchestrator fix (#1446). Additive key: zero
     # blast radius on consumers (all read capabilities_used via .get(..., [])).
-    capabilities_degraded: list[str] = []
-    degraded_caps: set[str] = set()
-    if state is not None:
-        structured = getattr(state, "structured_arg_status", None) or {}
-        degraded_caps = {
-            cap
-            for cap, info in structured.items()
-            if isinstance(info, dict) and info.get("degraded")
-        }
-
-    # BO-2 #1472 — ``structured_arg_status`` only covers the formal/logic
-    # axes (ASPIC+/SetAF/weighted/Dung). Non-formal workflows (e.g.
-    # ``democratech``) carry their honest-degraded verdict in the phase
-    # output itself, via the codebase's standard ``output["degraded"] = True``
-    # canon (state_writers._write_external_*_solver, fallacy_detection,
-    # governance per GE-4 #1462). Without this cross-check, a 9-phase
-    # deliberation whose governance verdict is empty (no derivable
-    # preferences — no LLM key, sparse upstream) reports as 9/9 success —
-    # exactly the theatre #1019 forbids. Surface phase-level degraded
-    # markers here too. Additive: phases without the marker are unaffected.
-    for pr in phase_results.values():
-        if pr.status != PhaseStatus.COMPLETED:
-            continue
-        out = getattr(pr, "output", None)
-        if isinstance(out, dict) and out.get("degraded") is True:
-            degraded_caps.add(pr.capability)
-
-    if degraded_caps:
-        capabilities_degraded = sorted(degraded_caps)
-        capabilities_used = [
-            c for c in capabilities_used if c not in degraded_caps
-        ]
+    capabilities_degraded, capabilities_used = _collect_degraded_capabilities(
+        phase_results, state, capabilities_used
+    )
 
     result = {
         "workflow_name": workflow.name,

--- a/argumentation_analysis/orchestration/workflow_dsl.py
+++ b/argumentation_analysis/orchestration/workflow_dsl.py
@@ -517,19 +517,24 @@ class WorkflowExecutor:
         # exhausted retry and stayed FAILED on an optional slot. The
         # consumer (CLI summary, API summary, dashboard) MUST surface
         # this — anti-theater #1019.
-        degraded_phases = sorted(
-            name for name, r in results.items() if r.degraded
+        degraded, degraded_phases, structured_degraded_caps = (
+            self._compute_workflow_degraded(results, state)
         )
-        degraded = len(degraded_phases) > 0
         slog.info(
             f"Workflow '{workflow.name}' finished: "
             f"{completed} completed, {failed} failed, {skipped} skipped, "
-            f"{len(degraded_phases)} degraded",
+            f"{len(degraded_phases)} degraded"
+            + (
+                f", {len(structured_degraded_caps)} structured-arg degraded"
+                if structured_degraded_caps
+                else ""
+            ),
             extra={
                 "workflow": workflow.name,
                 "phases_completed": completed,
                 "phases_total": len(results),
                 "phases_degraded": degraded_phases,
+                "structured_arg_degraded": structured_degraded_caps,
             },
         )
 
@@ -543,6 +548,7 @@ class WorkflowExecutor:
                         "skipped": skipped,
                         "degraded": degraded,
                         "degraded_phases": degraded_phases,
+                        "structured_arg_degraded": structured_degraded_caps,
                         "phases": {name: r.status.value for name, r in results.items()},
                     },
                 )
@@ -741,12 +747,19 @@ class WorkflowExecutor:
             # non-retryable errors (no retry attempted), retry_cfg.max_attempts
             # for retry-exhausted transient failures.
             retry_cfg = phase.retry_config
-            if retry_cfg is None or not isinstance(
-                e, retry_cfg.retryable_exceptions
-            ):
+            if retry_cfg is None or not isinstance(e, retry_cfg.retryable_exceptions):
                 attempts_used = 1
             else:
                 attempts_used = retry_cfg.max_attempts
+            # #1608 — an error must not be empty. ``str(asyncio.TimeoutError())``
+            # is ``""`` (and other bare exceptions can be too), which left the
+            # error registry with ``{"message": "", "timestamp": null}`` — an
+            # error that records nothing. ``_build_phase_error_message`` surfaces
+            # the exception type, the phase, and (for timeouts) the budget that
+            # was exceeded, so the failure is attributable rather than silent.
+            error_msg = self._build_phase_error_message(
+                e, phase_name, phase.timeout_seconds
+            )
             return (
                 phase_name,
                 PhaseResult(
@@ -754,13 +767,76 @@ class WorkflowExecutor:
                     status=PhaseStatus.FAILED,
                     capability=phase.capability,
                     component_used=provider.name,
-                    error=str(e),
+                    error=error_msg,
                     duration_seconds=duration,
                     degraded=phase.optional,
                     attempts=attempts_used,
                 ),
                 None,
             )
+
+    def _compute_workflow_degraded(
+        self,
+        results: Dict[str, PhaseResult],
+        state: Any,
+    ) -> Tuple[bool, List[str], List[str]]:
+        """Compute the workflow-level ``degraded`` flag (#1608).
+
+        Reconciles two independent degradation sources so the flag stops being
+        invariant across distinct analysis states (it stayed ``False`` on
+        corpus A/B/C in the #1608 measure):
+
+        * phase-level — optional slots that exhausted retry and stayed FAILED
+          (``PhaseResult.degraded``, set in :meth:`_execute_phase`);
+        * structured-arg — translators that raised mid-phase while the phase
+          still COMPLETED (the handler ran on auto-shaped input), recorded in
+          ``state.structured_arg_status`` with ``degraded=True``.
+
+        Anti-pendule: ``no_genuine_relations`` is an analytical RESULT and
+        carries ``degraded=False``, so a corpus genuinely lacking joint attacks
+        is NOT marked degraded here — only ``translator_failed`` /
+        ``translator_unconfigured`` / the legacy ``absent_no_translator`` flip
+        the flag. This is an honest OR over the registries, never a composite
+        that averages them.
+
+        Returns ``(degraded, degraded_phases, structured_degraded_caps)``.
+        """
+        degraded_phases = sorted(name for name, r in results.items() if r.degraded)
+        degraded = len(degraded_phases) > 0
+        structured_degraded_caps: List[str] = []
+        if state is not None:
+            sas = getattr(state, "structured_arg_status", None) or {}
+            for cap, info in sas.items():
+                if isinstance(info, dict) and info.get("degraded") is True:
+                    structured_degraded_caps.append(cap)
+            structured_degraded_caps.sort()
+            if structured_degraded_caps:
+                degraded = True
+        return degraded, degraded_phases, structured_degraded_caps
+
+    @staticmethod
+    def _build_phase_error_message(
+        exc: BaseException,
+        phase_name: str,
+        timeout_seconds: Optional[float],
+    ) -> str:
+        """Build a non-empty, descriptive phase-error message (#1608).
+
+        ``str(asyncio.TimeoutError())`` is ``""`` (and other bare exceptions can
+        be too), which left the error registry with ``{"message": "", ...}`` —
+        an error that records nothing. Surface the exception type, the phase,
+        and (for timeouts) the budget that was exceeded, so the failure is
+        attributable rather than silent.
+        """
+        msg = str(exc)
+        if msg:
+            return msg
+        if isinstance(exc, asyncio.TimeoutError) and timeout_seconds:
+            return (
+                f"{type(exc).__name__}: phase '{phase_name}' exceeded its "
+                f"{timeout_seconds}s budget"
+            )
+        return type(exc).__name__ or "UnknownError"
 
     def _store_phase_result(
         self,

--- a/tests/unit/argumentation_analysis/orchestration/test_structured_arg_degradation_1608.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_structured_arg_degradation_1608.py
@@ -48,6 +48,9 @@ class _FakeState:
 
     def __init__(self) -> None:
         self.structured_arg_status: Dict[str, Dict[str, Any]] = {}
+        # #1608 act-raccord: per-act degradation motifs (mirrors the real
+        # UnifiedAnalysisState field populated by the act state writers).
+        self.restitution_acts_degraded: Dict[str, Dict[str, Any]] = {}
 
     def add_structured_arg_status(
         self,
@@ -283,3 +286,129 @@ class TestPhaseErrorIsNeverEmpty:
         msg = self._msg(asyncio.TimeoutError(), "p", None)
         assert msg == "TimeoutError"
         assert msg != ""
+
+
+# =============================================================================
+# Défaut 2 (act raccord, R752) — the restitution acts' degraded dict must feed
+# capabilities_degraded, and its motifs must reach the state
+# =============================================================================
+
+
+class TestActDegradedFeedsCapabilities:
+    """#1608 R752 — the three restitution acts return ``degraded`` as a DICT of
+    motifs, but the only consumer tested ``out.get("degraded") is True`` (a dict
+    is never ``is True``), so the acts structurally could not feed
+    ``capabilities_degraded`` (7 declaration sites, 0 readers). The invokers now
+    surface ``degraded`` as a BOOL + ``degraded_reasons`` dict; this proves the
+    raccord via the extracted consumer ``_collect_degraded_capabilities``."""
+
+    @staticmethod
+    def _collect(phase_results, state, used):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _collect_degraded_capabilities,
+        )
+
+        return _collect_degraded_capabilities(phase_results, state, used)
+
+    def test_act_with_bool_degraded_feeds_capabilities_degraded(self):
+        # Post-raccord: the invoker surfaces ``degraded`` as a BOOL, so the
+        # ``is True`` predicate matches and the act feeds capabilities_degraded.
+        pr = {
+            "act3": PhaseResult(
+                "act3",
+                PhaseStatus.COMPLETED,
+                "act3_conclusion",
+                output={
+                    "act3_conclusion": "x",
+                    "degraded": True,
+                    "degraded_reasons": {"act3_conclusion_gate": "G2"},
+                },
+            )
+        }
+        degraded, used = self._collect(pr, None, ["act3_conclusion"])
+        assert "act3_conclusion" in degraded
+        assert "act3_conclusion" not in used
+
+    def test_act_with_dict_degraded_does_not_feed(self):
+        # THE FALSIFIABILITY TEST. Pre-raccord the invoker returned the dict
+        # as-is; ``out.get("degraded") is True`` is False on a dict → the act
+        # never fed capabilities_degraded (it stayed "used"). Revert the
+        # invoker to return the raw dict and this assertion flips.
+        pr = {
+            "act3": PhaseResult(
+                "act3",
+                PhaseStatus.COMPLETED,
+                "act3_conclusion",
+                output={
+                    "act3_conclusion": "x",
+                    "degraded": {"act3_conclusion_gate": "G2"},  # dict, not bool
+                },
+            )
+        }
+        degraded, used = self._collect(pr, None, ["act3_conclusion"])
+        assert "act3_conclusion" not in degraded
+        assert "act3_conclusion" in used  # stayed "used" — the bug
+
+    def test_structured_registry_axis_also_feeds(self):
+        state = _FakeState()
+        state.add_structured_arg_status(
+            "setaf_reasoning", "translator_failed", True, "raised", 0
+        )
+        degraded, _ = self._collect({}, state, [])
+        assert "setaf_reasoning" in degraded
+
+    def test_clean_act_unaffected(self):
+        pr = {
+            "act3": PhaseResult(
+                "act3",
+                PhaseStatus.COMPLETED,
+                "act3_conclusion",
+                output={"act3_conclusion": "x"},
+            )
+        }
+        degraded, used = self._collect(pr, None, ["act3_conclusion"])
+        assert degraded == []
+        assert "act3_conclusion" in used
+
+
+class TestActDegradedMotifsReachState:
+    """#1608 'Faire atteindre l'état aux motifs' — the act state writers persist
+    ``degraded_reasons`` into ``state.restitution_acts_degraded`` so the motifs
+    no longer die in the return value. Anti-pendule: an act that succeeded
+    (empty / absent motifs) is NOT marked degraded."""
+
+    @staticmethod
+    def _write_act3(output, state):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_act3_conclusion_to_state,
+        )
+
+        _write_act3_conclusion_to_state(output, state, {})
+
+    def test_motifs_persisted_for_degraded_act(self):
+        state = _FakeState()
+        state.act3_conclusion = ""
+        self._write_act3(
+            {
+                "act3_conclusion": "concl",
+                "degraded_reasons": {"act3_conclusion_gate": "G2 partielle"},
+            },
+            state,
+        )
+        assert state.restitution_acts_degraded == {
+            "act3_conclusion": {"act3_conclusion_gate": "G2 partielle"}
+        }
+
+    def test_clean_act_not_marked_degraded(self):
+        # No degraded_reasons → the field stays empty (anti-pendule: an act
+        # that succeeded is never degraded by default).
+        state = _FakeState()
+        state.act3_conclusion = ""
+        self._write_act3({"act3_conclusion": "concl"}, state)
+        assert state.restitution_acts_degraded == {}
+
+    def test_empty_motifs_not_persisted(self):
+        state = _FakeState()
+        state.act3_conclusion = ""
+        self._write_act3({"act3_conclusion": "concl", "degraded_reasons": {}}, state)
+        assert state.restitution_acts_degraded == {}

--- a/tests/unit/argumentation_analysis/orchestration/test_structured_arg_degradation_1608.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_structured_arg_degradation_1608.py
@@ -1,0 +1,285 @@
+"""#1608 — anti-théâtre pivot tests for the structured-arg degradation contract.
+
+Three defects closed in #1608, each with a FALSIFIABLE pivot test (a test that
+passes on the fixed code AND fails on the pre-#1608 code — "un test qui passe
+avec les deux versions du code ne prouve rien"):
+
+* **Défaut 1** — the four distinct causes (translator raised · translator ran
+  and found nothing · no API key · nothing wired) used to collapse onto one
+  label ``absent_no_translator`` with ``degraded`` invariant across corpus
+  A/B/C. The discriminated cause now propagates to four distinct statuses, and
+  ``degraded`` stops being invariant.
+* **Défaut 2** — ``workflow_results.degraded`` never consulted
+  ``structured_arg_status``; a workflow whose translators raised (phase
+  COMPLETED, axis degraded) was reported not-degraded. Muter le registre →
+  ``degraded`` bascule.
+* **Défaut 3** — ``str(asyncio.TimeoutError()) == ""`` left the error registry
+  with an empty message. The enriched message names the exception type, the
+  phase, and the budget exceeded.
+
+No JVM, no real LLM. Synthetic atoms only (privacy HARD — no corpus tokens).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from argumentation_analysis.orchestration.state_writers import (
+    _record_structured_arg_status,
+    _resolve_absent_status,
+    _translation_cause_key,
+    _translation_error_key,
+)
+from argumentation_analysis.orchestration.workflow_dsl import (
+    PhaseResult,
+    PhaseStatus,
+    WorkflowExecutor,
+)
+
+
+class _FakeState:
+    """Minimal state double exposing the two surfaces the recorder + the
+    workflow degraded-reconciliation read: ``add_structured_arg_status`` and
+    ``structured_arg_status``. Stores exactly what the real state stores
+    (a dict with a ``degraded`` key per capability)."""
+
+    def __init__(self) -> None:
+        self.structured_arg_status: Dict[str, Dict[str, Any]] = {}
+
+    def add_structured_arg_status(
+        self,
+        capability: str,
+        status: str,
+        degraded: bool,
+        reason: str,
+        extension_count: int = 0,
+    ) -> None:
+        self.structured_arg_status[capability] = {
+            "capability": capability,
+            "status": status,
+            "degraded": degraded,
+            "reason": reason,
+            "extension_count": extension_count,
+        }
+
+
+# =============================================================================
+# Défaut 1 — four causes → four statuses; degraded no longer invariant
+# =============================================================================
+
+
+class TestStructuredArgStatusDiscrimination:
+    """#1608 Défaut 1 — the cause discriminated by the translator must reach the
+    recorder as a distinct ``(status, degraded)`` pair. Before #1608 four causes
+    collapsed onto ``absent_no_translator``; this suite proves the
+    discrimination AND that ``degraded`` is no longer invariant across the
+    corpus-shaped causes A/B/C."""
+
+    @staticmethod
+    def _record(
+        capability: str, cause: Optional[str], error: str = ""
+    ) -> Dict[str, Any]:
+        state = _FakeState()
+        ctx: Dict[str, Any] = {}
+        if cause is not None:
+            ctx[_translation_cause_key(capability)] = cause
+            if error:
+                ctx[_translation_error_key(capability)] = error
+        # output={} → no genuine structured input → absent/discrimination path.
+        _record_structured_arg_status(state, capability, output={}, ctx=ctx)
+        return state.structured_arg_status[capability]
+
+    def test_translator_failed_is_degraded_true(self):
+        # Corpus A — the translator raised (e.g. a timeout). Genuine structured
+        # input could not be obtained → degraded.
+        rec = self._record("setaf_reasoning", "translator_failed", "TimeoutError")
+        assert rec["status"] == "translator_failed"
+        assert rec["degraded"] is True
+        assert "TimeoutError" in rec["reason"]
+
+    def test_no_genuine_relations_is_degraded_false(self):
+        # Corpus B — the translator RAN and found nothing. ANTI-PENDULE crux:
+        # this is an analytical result (the text has no joint attack), not a
+        # degraded pipeline. It must NOT be red.
+        rec = self._record("setaf_reasoning", "no_genuine_relations")
+        assert rec["status"] == "no_genuine_relations"
+        assert rec["degraded"] is False
+        assert "analytical result" in rec["reason"]
+
+    def test_translator_unconfigured_is_degraded_true(self):
+        # Corpus C — no LLM API key configured; the translator could not run.
+        rec = self._record("setaf_reasoning", "translator_unconfigured")
+        assert rec["status"] == "translator_unconfigured"
+        assert rec["degraded"] is True
+
+    def test_no_cause_recorded_keeps_legacy_absent_label(self):
+        # The legacy path (nothing wired / no cause propagated) preserves the
+        # #1236 honest-absent label rather than inventing a cause it did not
+        # observe. ``absent_no_translator`` is NOT deleted (#1608 constraint).
+        rec = self._record("setaf_reasoning", None)
+        assert rec["status"] == "absent_no_translator"
+        assert rec["degraded"] is True
+
+    def test_degraded_is_no_longer_invariant_across_corpus_states(self):
+        # THE PIVOT. The #1608 measure found ``degraded`` invariant (always
+        # False) across corpus A/B/C. After the fix the three corpus-shaped
+        # causes yield three DISTINCT ``(status, degraded)`` outcome triples —
+        # the correctif now measures something. Before #1608 all three recorded
+        # ``absent_no_translator`` → the set would have one element.
+        outcomes = {
+            (
+                self._record("setaf_reasoning", c, "TimeoutError")["status"],
+                self._record("setaf_reasoning", c, "TimeoutError")["degraded"],
+            )
+            for c in (
+                "translator_failed",
+                "no_genuine_relations",
+                "translator_unconfigured",
+            )
+        }
+        assert len(outcomes) == 3
+        # And specifically corpus B is the one NOT degraded (anti-pendule).
+        assert ("no_genuine_relations", False) in outcomes
+
+    def test_resolve_absent_status_unknown_cause_falls_back(self):
+        # Defensive: a cause string the recorder does not recognise falls back
+        # to the honest-absent label rather than crash.
+        status, degraded, _ = _resolve_absent_status("setaf_reasoning", "???", "")
+        assert status == "absent_no_translator"
+        assert degraded is True
+
+
+# =============================================================================
+# Défaut 2 — workflow_results.degraded reconciles the structured-arg registry
+# =============================================================================
+
+
+class TestWorkflowDegradedReconcilesStructuredRegistry:
+    """#1608 Défaut 2 — ``_compute_workflow_degraded`` must read
+    ``structured_arg_status`` so a workflow whose translators raised (phase
+    COMPLETED, axis degraded) is reported degraded. Muter le registre → le
+    drapeau ``degraded`` bascule (falsifiable: revert the structured read and
+    the flip test fails)."""
+
+    @staticmethod
+    def _executor() -> WorkflowExecutor:
+        # _compute_workflow_degraded is pure (never touches the registry), so a
+        # trivial registry is enough to instantiate the executor.
+        return WorkflowExecutor(registry=object())  # type: ignore[arg-type]
+
+    @staticmethod
+    def _completed_results() -> Dict[str, PhaseResult]:
+        return {"p": PhaseResult("p", PhaseStatus.COMPLETED, "cap")}
+
+    def test_clean_registry_is_not_degraded(self):
+        state = _FakeState()  # empty structured_arg_status
+        degraded, _, caps = self._executor()._compute_workflow_degraded(
+            self._completed_results(), state
+        )
+        assert degraded is False
+        assert caps == []
+
+    def test_degraded_structured_axis_flips_workflow_degraded(self):
+        # THE FALSIFIABILITY TEST. A structured axis marked degraded=True flips
+        # the workflow-level flag EVEN THOUGH every phase COMPLETED with no
+        # degraded phase. Revert the structured-arg read in
+        # _compute_workflow_degraded → this assertion fails (degraded stays False).
+        state = _FakeState()
+        state.add_structured_arg_status(
+            "setaf_reasoning", "translator_failed", True, "raised", 0
+        )
+        degraded, _, caps = self._executor()._compute_workflow_degraded(
+            self._completed_results(), state
+        )
+        assert degraded is True
+        assert caps == ["setaf_reasoning"]
+
+    def test_no_genuine_relations_does_not_flip_degraded(self):
+        # ANTI-PENDULE. Cause 3 carries degraded=False → it must NOT flip the
+        # workflow flag. A corpus lacking joint attacks is not a degraded run.
+        state = _FakeState()
+        state.add_structured_arg_status(
+            "setaf_reasoning", "no_genuine_relations", False, "ran empty", 0
+        )
+        degraded, _, caps = self._executor()._compute_workflow_degraded(
+            self._completed_results(), state
+        )
+        assert degraded is False
+        assert caps == []
+
+    def test_phase_level_degraded_still_counted(self):
+        # The structured read is ADDITIVE (honest OR), not a replacement: a
+        # degraded optional phase still flags the workflow even with a clean
+        # structured registry.
+        results = {"p": PhaseResult("p", PhaseStatus.FAILED, "cap", degraded=True)}
+        degraded, degraded_phases, _ = self._executor()._compute_workflow_degraded(
+            results, _FakeState()
+        )
+        assert degraded is True
+        assert degraded_phases == ["p"]
+
+    def test_state_none_is_safe(self):
+        degraded, _, _ = self._executor()._compute_workflow_degraded(
+            self._completed_results(), None
+        )
+        assert degraded is False
+
+    def test_multiple_degraded_axes_are_sorted(self):
+        state = _FakeState()
+        state.add_structured_arg_status(
+            "weighted_argumentation", "translator_failed", True, "x", 0
+        )
+        state.add_structured_arg_status(
+            "aspic_plus_reasoning", "translator_failed", True, "y", 0
+        )
+        _, _, caps = self._executor()._compute_workflow_degraded(
+            self._completed_results(), state
+        )
+        assert caps == ["aspic_plus_reasoning", "weighted_argumentation"]
+
+
+# =============================================================================
+# Défaut 3 — a phase error is never empty; a timeout names phase + budget
+# =============================================================================
+
+
+class TestPhaseErrorIsNeverEmpty:
+    """#1608 Défaut 3 — ``str(asyncio.TimeoutError()) == ""`` left the error
+    registry with ``{"message": "", "timestamp": null}``. The enriched message
+    names the exception type, the phase, and (for timeouts) the budget
+    exceeded, so the failure is attributable rather than silent."""
+
+    @staticmethod
+    def _msg(exc: BaseException, phase: str, timeout: Optional[float]) -> str:
+        return WorkflowExecutor._build_phase_error_message(exc, phase, timeout)
+
+    def test_timeout_names_phase_and_budget(self):
+        msg = self._msg(asyncio.TimeoutError(), "setaf_reasoning", 30)
+        assert msg != ""
+        assert "TimeoutError" in msg
+        assert "setaf_reasoning" in msg
+        assert "30s" in msg
+
+    def test_exception_with_message_is_preserved(self):
+        # A descriptive exception is passed through unchanged.
+        msg = self._msg(ValueError("bad input"), "p", None)
+        assert msg == "bad input"
+
+    def test_bare_exception_falls_back_to_type_name(self):
+        # A bare exception (empty str()) surfaces its type name rather than "".
+        class _Bare(Exception):
+            pass
+
+        msg = self._msg(_Bare(), "p", None)
+        assert msg == "_Bare"
+        assert msg != ""
+
+    def test_timeout_without_budget_names_type_only(self):
+        # A timeout on a phase that had no budget configured still names the
+        # type — never empty.
+        msg = self._msg(asyncio.TimeoutError(), "p", None)
+        assert msg == "TimeoutError"
+        assert msg != ""

--- a/tests/unit/argumentation_analysis/orchestration/test_structured_arg_translator.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_structured_arg_translator.py
@@ -1,10 +1,12 @@
 """TR-1 #1419 / FP-17 #1236 — text→structured translator (bipolar/ABA) unit tests.
 
-Validates the anti-théâtre contract (#1019):
+Validates the anti-théâtre contract (#1019 / #1608):
 - Relations returned by the LLM are validated against the REAL argument
   inventory; fabricated pairs referencing unknown ids are DROPPED.
-- An empty / failed LLM extraction yields an empty result, so the formalism
-  stays ``absent_no_translator`` (honest absence) — never a fabricated evaluation.
+- An empty / failed LLM extraction yields a ``TranslationResult`` whose ``cause``
+  discriminates *why* the axis is absent — ``no_genuine_relations`` (ran, found
+  none — an analytical result) or ``translator_failed`` (the call raised) — so the
+  formalism is labelled honestly, never by a fabricated evaluation.
 - The handler wiring persists genuine relations into ``context``, which lets
   ``_record_structured_arg_status`` label the axis ``evaluated``.
 
@@ -20,6 +22,9 @@ from typing import Any, Dict, List, Tuple
 import pytest
 
 from argumentation_analysis.orchestration.structured_arg_translator import (
+    CAUSE_EVALUATED,
+    CAUSE_NO_GENUINE_RELATIONS,
+    TranslationResult,
     _build_inventory,
     _validate_aspic_rules,
     _validate_contraries,
@@ -69,20 +74,24 @@ class TestBuildInventory:
 class TestValidateSupports:
     def test_keeps_valid_pairs_mapped_to_canonical_text(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta", "arg3": "Gamma"}
-        data = {"supports": [
-            {"source": "arg1", "target": "arg2", "rationale": "r"},
-            {"source": "arg3", "target": "arg1", "rationale": "r"},
-        ]}
+        data = {
+            "supports": [
+                {"source": "arg1", "target": "arg2", "rationale": "r"},
+                {"source": "arg3", "target": "arg1", "rationale": "r"},
+            ]
+        }
         out = _validate_supports(data, arg_by_id)
         assert out == [["Alpha", "Beta"], ["Gamma", "Alpha"]]
 
     def test_drops_pairs_referencing_unknown_ids(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"supports": [
-            {"source": "arg1", "target": "arg9"},   # unknown target → dropped
-            {"source": "argX", "target": "arg2"},   # unknown source → dropped
-            {"source": "arg1", "target": "arg2"},   # valid → kept
-        ]}
+        data = {
+            "supports": [
+                {"source": "arg1", "target": "arg9"},  # unknown target → dropped
+                {"source": "argX", "target": "arg2"},  # unknown source → dropped
+                {"source": "arg1", "target": "arg2"},  # valid → kept
+            ]
+        }
         out = _validate_supports(data, arg_by_id)
         assert out == [["Alpha", "Beta"]]
 
@@ -95,10 +104,12 @@ class TestValidateSupports:
 
     def test_dedups_identical_pairs(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"supports": [
-            {"source": "arg1", "target": "arg2"},
-            {"source": "arg1", "target": "arg2"},
-        ]}
+        data = {
+            "supports": [
+                {"source": "arg1", "target": "arg2"},
+                {"source": "arg1", "target": "arg2"},
+            ]
+        }
         out = _validate_supports(data, arg_by_id)
         assert out == [["Alpha", "Beta"]]
 
@@ -107,26 +118,33 @@ class TestValidateSupports:
         assert _validate_supports({}, arg_by_id) == []
         assert _validate_supports({"supports": []}, arg_by_id) == []
         assert _validate_supports({"supports": "not-a-list"}, arg_by_id) == []
-        assert _validate_supports(
-            {"supports": [{"source": 1}]}, arg_by_id  # type: ignore[list-item]
-        ) == []
+        assert (
+            _validate_supports(
+                {"supports": [{"source": 1}]}, arg_by_id  # type: ignore[list-item]
+            )
+            == []
+        )
 
 
 class TestValidateContraries:
     def test_keeps_valid_pairs_mapped_to_canonical_text(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"contraries": [
-            {"assumption": "arg1", "contrary": "not Alpha", "rationale": "r"},
-        ]}
+        data = {
+            "contraries": [
+                {"assumption": "arg1", "contrary": "not Alpha", "rationale": "r"},
+            ]
+        }
         out = _validate_contraries(data, arg_by_id)
         assert out == {"Alpha": "not Alpha"}
 
     def test_drops_unknown_assumption_ids(self):
         arg_by_id = {"arg1": "Alpha"}
-        data = {"contraries": [
-            {"assumption": "arg9", "contrary": "x"},   # unknown → dropped
-            {"assumption": "arg1", "contrary": "y"},   # valid → kept
-        ]}
+        data = {
+            "contraries": [
+                {"assumption": "arg9", "contrary": "x"},  # unknown → dropped
+                {"assumption": "arg1", "contrary": "y"},  # valid → kept
+            ]
+        }
         out = _validate_contraries(data, arg_by_id)
         assert out == {"Alpha": "y"}
 
@@ -139,10 +157,12 @@ class TestValidateContraries:
 
     def test_last_write_wins_on_duplicate_assumption(self):
         arg_by_id = {"arg1": "Alpha"}
-        data = {"contraries": [
-            {"assumption": "arg1", "contrary": "first"},
-            {"assumption": "arg1", "contrary": "second"},
-        ]}
+        data = {
+            "contraries": [
+                {"assumption": "arg1", "contrary": "first"},
+                {"assumption": "arg1", "contrary": "second"},
+            ]
+        }
         assert _validate_contraries(data, arg_by_id) == {"Alpha": "second"}
 
 
@@ -163,60 +183,87 @@ def _patch_llm(monkeypatch, payload: Dict[str, Any]) -> None:
 
 
 class TestTranslatorEmptyStaysHonest:
-    """Empty / failed LLM extraction → empty result → formalism stays
-    absent_no_translator (anti-théâtre #1019)."""
+    """Empty / failed LLM extraction → empty relations with cause
+    ``no_genuine_relations`` (anti-théâtre #1019 / #1608). The cause is the
+    discriminated signal the recorder needs; an empty list alone is not enough."""
 
     async def test_bipolar_empty_llm_output_returns_empty(self, monkeypatch):
         _patch_llm(monkeypatch, {"supports": []})
         out = await translate_to_bipolar_supports("some text", ["a", "b"])
-        assert out == []
+        assert isinstance(out, TranslationResult)
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_bipolar_no_inventory_returns_empty(self, monkeypatch):
         _patch_llm(monkeypatch, {"supports": [{"source": "arg1", "target": "arg2"}]})
         out = await translate_to_bipolar_supports("text", [])
-        assert out == []
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_aba_empty_llm_output_returns_empty(self, monkeypatch):
         _patch_llm(monkeypatch, {"contraries": []})
         out = await translate_to_aba_contraries("some text", ["a", "b"])
-        assert out == {}
+        assert out.relations == {}
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_bipolar_only_fabricated_relations_dropped(self, monkeypatch):
         # Every pair references ids absent from the inventory → all dropped.
-        _patch_llm(monkeypatch, {"supports": [
-            {"source": "arg9", "target": "arg8"},
-            {"source": "phantom", "target": "ghost"},
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "supports": [
+                    {"source": "arg9", "target": "arg8"},
+                    {"source": "phantom", "target": "ghost"},
+                ]
+            },
+        )
         out = await translate_to_bipolar_supports("text", ["a", "b"])
-        assert out == []
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_aba_only_fabricated_assumptions_dropped(self, monkeypatch):
-        _patch_llm(monkeypatch, {"contraries": [
-            {"assumption": "arg9", "contrary": "x"},
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "contraries": [
+                    {"assumption": "arg9", "contrary": "x"},
+                ]
+            },
+        )
         out = await translate_to_aba_contraries("text", ["a", "b"])
-        assert out == {}
+        assert out.relations == {}
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
 
 class TestTranslatorReturnsValidatedRelations:
     async def test_bipolar_returns_validated_supports(self, monkeypatch):
-        _patch_llm(monkeypatch, {"supports": [
-            {"source": "arg1", "target": "arg2", "rationale": "r"},
-            {"source": "arg2", "target": "arg3", "rationale": "r"},
-            {"source": "arg1", "target": "arg9"},  # dropped (unknown)
-        ]})
-        out = await translate_to_bipolar_supports(
-            "text", ["Alpha", "Beta", "Gamma"]
+        _patch_llm(
+            monkeypatch,
+            {
+                "supports": [
+                    {"source": "arg1", "target": "arg2", "rationale": "r"},
+                    {"source": "arg2", "target": "arg3", "rationale": "r"},
+                    {"source": "arg1", "target": "arg9"},  # dropped (unknown)
+                ]
+            },
         )
-        assert out == [["Alpha", "Beta"], ["Beta", "Gamma"]]
+        out = await translate_to_bipolar_supports("text", ["Alpha", "Beta", "Gamma"])
+        assert out.relations == [["Alpha", "Beta"], ["Beta", "Gamma"]]
+        assert out.cause == CAUSE_EVALUATED
 
     async def test_aba_returns_validated_contraries(self, monkeypatch):
-        _patch_llm(monkeypatch, {"contraries": [
-            {"assumption": "arg1", "contrary": "not Alpha"},
-            {"assumption": "argX", "contrary": "dropped"},  # dropped
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "contraries": [
+                    {"assumption": "arg1", "contrary": "not Alpha"},
+                    {"assumption": "argX", "contrary": "dropped"},  # dropped
+                ]
+            },
+        )
         out = await translate_to_aba_contraries("text", ["Alpha", "Beta"])
-        assert out == {"Alpha": "not Alpha"}
+        assert out.relations == {"Alpha": "not Alpha"}
+        assert out.cause == CAUSE_EVALUATED
 
 
 # -- handler wiring: context persists (no JVM) -------------------------------
@@ -225,7 +272,9 @@ class TestTranslatorReturnsValidatedRelations:
 def _inject_fake_logic_modules(monkeypatch, bipolar_payload, aba_payload):
     """Inject fake BipolarHandler / ABAHandler modules so the handlers run
     without a JVM, returning canned reasoner output."""
-    fake_bipolar = types.ModuleType("argumentation_analysis.agents.core.logic.bipolar_handler")
+    fake_bipolar = types.ModuleType(
+        "argumentation_analysis.agents.core.logic.bipolar_handler"
+    )
 
     class _FakeBipolarHandler:
         def analyze_bipolar_framework(self, args, attacks, supports, fw_type):
@@ -263,7 +312,9 @@ class TestHandlerWiringPersistsToContext:
         )
 
         async def _fake_supports(text, args):
-            return [["Alpha", "Beta"]]
+            return TranslationResult(
+                relations=[["Alpha", "Beta"]], cause=CAUSE_EVALUATED
+            )
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -278,14 +329,18 @@ class TestHandlerWiringPersistsToContext:
         await _invoke_bipolar("source text", ctx)
         assert ctx.get("supports") == [["Alpha", "Beta"]]
 
-    async def test_bipolar_does_not_override_caller_supplied_supports(self, monkeypatch):
+    async def test_bipolar_does_not_override_caller_supplied_supports(
+        self, monkeypatch
+    ):
         # If the caller already supplied genuine supports, the translator must
         # NOT run / NOT override them.
         called = {"n": 0}
 
         async def _fake_supports(text, args):
             called["n"] += 1
-            return [["should", "not", "be", "used"]]
+            return TranslationResult(
+                relations=[["should", "not", "be", "used"]], cause=CAUSE_EVALUATED
+            )
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -313,7 +368,9 @@ class TestHandlerWiringPersistsToContext:
         )
 
         async def _fake_contraries(text, args):
-            return {"Alpha": "not Alpha"}
+            return TranslationResult(
+                relations={"Alpha": "not Alpha"}, cause=CAUSE_EVALUATED
+            )
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -328,9 +385,11 @@ class TestHandlerWiringPersistsToContext:
         await _invoke_aba("source text", ctx)
         assert ctx.get("contraries") == {"Alpha": "not Alpha"}
 
-    async def test_bipolar_honest_absent_when_translator_returns_empty(self, monkeypatch):
-        # Translator yields nothing → context["supports"] is NOT set → the gate
-        # keeps absent_no_translator.
+    async def test_bipolar_honest_absent_when_translator_returns_empty(
+        self, monkeypatch
+    ):
+        # Translator yields nothing (cause no_genuine_relations) → context["supports"]
+        # is NOT set → the axis stays honestly absent with its true cause propagated.
         _inject_fake_logic_modules(
             monkeypatch,
             bipolar_payload={"framework_type": "necessity", "supports": []},
@@ -338,7 +397,7 @@ class TestHandlerWiringPersistsToContext:
         )
 
         async def _fake_supports(text, args):
-            return []
+            return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -360,9 +419,11 @@ class TestHandlerWiringPersistsToContext:
 class TestValidateAspicRules:
     def test_keeps_valid_rule_mapped_to_atoms(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta", "arg3": "Gamma"}
-        data = {"rules": [
-            {"premises": ["arg1", "arg2"], "conclusion": "arg3", "rationale": "r"},
-        ]}
+        data = {
+            "rules": [
+                {"premises": ["arg1", "arg2"], "conclusion": "arg3", "rationale": "r"},
+            ]
+        }
         out = _validate_aspic_rules(data, arg_by_id, _atom)
         assert out == [
             {
@@ -374,16 +435,20 @@ class TestValidateAspicRules:
 
     def test_drops_rule_with_unknown_premise(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"rules": [
-            {"premises": ["arg1", "arg9"], "conclusion": "arg2"},  # arg9 unknown
-        ]}
+        data = {
+            "rules": [
+                {"premises": ["arg1", "arg9"], "conclusion": "arg2"},  # arg9 unknown
+            ]
+        }
         assert _validate_aspic_rules(data, arg_by_id, _atom) == []
 
     def test_drops_rule_with_unknown_conclusion(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"rules": [
-            {"premises": ["arg1"], "conclusion": "arg9"},  # unknown conclusion
-        ]}
+        data = {
+            "rules": [
+                {"premises": ["arg1"], "conclusion": "arg9"},  # unknown conclusion
+            ]
+        }
         assert _validate_aspic_rules(data, arg_by_id, _atom) == []
 
     def test_drops_rule_with_no_premises(self):
@@ -393,9 +458,11 @@ class TestValidateAspicRules:
 
     def test_removes_conclusion_from_premises_keeps_rest(self):
         arg_by_id = {"arg1": "Alpha", "arg3": "Gamma"}
-        data = {"rules": [
-            {"premises": ["arg1", "arg3"], "conclusion": "arg3"},  # arg3 dropped
-        ]}
+        data = {
+            "rules": [
+                {"premises": ["arg1", "arg3"], "conclusion": "arg3"},  # arg3 dropped
+            ]
+        }
         out = _validate_aspic_rules(data, arg_by_id, _atom)
         assert out == [
             {"head": "arg:Gamma", "body": ["arg:Alpha"], "name": "def_rule_1"}
@@ -408,10 +475,12 @@ class TestValidateAspicRules:
 
     def test_dedups_identical_rules(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"rules": [
-            {"premises": ["arg1"], "conclusion": "arg2"},
-            {"premises": ["arg1"], "conclusion": "arg2"},
-        ]}
+        data = {
+            "rules": [
+                {"premises": ["arg1"], "conclusion": "arg2"},
+                {"premises": ["arg1"], "conclusion": "arg2"},
+            ]
+        }
         out = _validate_aspic_rules(data, arg_by_id, _atom)
         assert out == [
             {"head": "arg:Beta", "body": ["arg:Alpha"], "name": "def_rule_1"}
@@ -419,9 +488,11 @@ class TestValidateAspicRules:
 
     def test_dedups_repeated_body_atoms(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"rules": [
-            {"premises": ["arg1", "arg1"], "conclusion": "arg2"},
-        ]}
+        data = {
+            "rules": [
+                {"premises": ["arg1", "arg1"], "conclusion": "arg2"},
+            ]
+        }
         out = _validate_aspic_rules(data, arg_by_id, _atom)
         assert out[0]["body"] == ["arg:Alpha"]
 
@@ -438,51 +509,73 @@ class TestValidateAspicRules:
         assert _validate_aspic_rules({}, arg_by_id, _atom) == []
         assert _validate_aspic_rules({"rules": []}, arg_by_id, _atom) == []
         assert _validate_aspic_rules({"rules": "nope"}, arg_by_id, _atom) == []
-        assert _validate_aspic_rules(
-            {"rules": [{"premises": 1, "conclusion": "arg1"}]},  # type: ignore[dict-item]
-            arg_by_id,
-            _atom,
-        ) == []
+        assert (
+            _validate_aspic_rules(
+                {"rules": [{"premises": 1, "conclusion": "arg1"}]},  # type: ignore[dict-item]
+                arg_by_id,
+                _atom,
+            )
+            == []
+        )
 
 
 class TestAspicTranslator:
     async def test_empty_llm_output_returns_empty(self, monkeypatch):
         _patch_llm(monkeypatch, {"rules": []})
         out = await translate_to_aspic_rules("some text", ["a", "b"])
-        assert out == []
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_no_inventory_returns_empty(self, monkeypatch):
-        _patch_llm(monkeypatch, {"rules": [
-            {"premises": ["arg1"], "conclusion": "arg2"},
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "rules": [
+                    {"premises": ["arg1"], "conclusion": "arg2"},
+                ]
+            },
+        )
         out = await translate_to_aspic_rules("text", [])
-        assert out == []
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_only_fabricated_rules_dropped(self, monkeypatch):
-        _patch_llm(monkeypatch, {"rules": [
-            {"premises": ["arg8"], "conclusion": "arg9"},   # unknown ids
-            {"premises": ["phantom"], "conclusion": "ghost"},
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "rules": [
+                    {"premises": ["arg8"], "conclusion": "arg9"},  # unknown ids
+                    {"premises": ["phantom"], "conclusion": "ghost"},
+                ]
+            },
+        )
         out = await translate_to_aspic_rules("text", ["a", "b"])
-        assert out == []
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_returns_validated_rules_with_real_atoms(self, monkeypatch):
         # Uses the real _pl_atom; assert head/body are the deterministic atoms
         # for the cited canonical argument texts.
         from argumentation_analysis.orchestration.invoke_callables import _pl_atom
 
-        _patch_llm(monkeypatch, {"rules": [
-            {"premises": ["arg1", "arg2"], "conclusion": "arg3"},
-            {"premises": ["arg1"], "conclusion": "arg9"},  # dropped (unknown)
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "rules": [
+                    {"premises": ["arg1", "arg2"], "conclusion": "arg3"},
+                    {"premises": ["arg1"], "conclusion": "arg9"},  # dropped (unknown)
+                ]
+            },
+        )
         out = await translate_to_aspic_rules("text", ["Alpha", "Beta", "Gamma"])
-        assert len(out) == 1
-        assert out[0]["head"] == _pl_atom("Gamma", prefix="arg")
-        assert out[0]["body"] == [
+        assert out.cause == CAUSE_EVALUATED
+        assert len(out.relations) == 1
+        assert out.relations[0]["head"] == _pl_atom("Gamma", prefix="arg")
+        assert out.relations[0]["body"] == [
             _pl_atom("Alpha", prefix="arg"),
             _pl_atom("Beta", prefix="arg"),
         ]
-        assert out[0]["name"] == "def_rule_1"
+        assert out.relations[0]["name"] == "def_rule_1"
 
 
 def _inject_fake_aspic_module(monkeypatch, payload):
@@ -511,7 +604,7 @@ class TestAspicHandlerWiring:
         genuine = [{"head": "arg:h", "body": ["arg:b"], "name": "def_rule_1"}]
 
         async def _fake_rules(text, args):
-            return genuine
+            return TranslationResult(relations=genuine, cause=CAUSE_EVALUATED)
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -520,9 +613,7 @@ class TestAspicHandlerWiring:
         )
         from argumentation_analysis.orchestration.invoke_callables import _invoke_aspic
 
-        ctx: Dict[str, Any] = {
-            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
-        }
+        ctx: Dict[str, Any] = {"phase_extract_output": {"arguments": ["Alpha", "Beta"]}}
         await _invoke_aspic("source text", ctx)
         assert ctx.get("defeasible_rules") == genuine
 
@@ -531,7 +622,12 @@ class TestAspicHandlerWiring:
 
         async def _fake_rules(text, args):
             called["n"] += 1
-            return [{"head": "arg:x", "body": ["arg:y"], "name": "should_not_be_used"}]
+            return TranslationResult(
+                relations=[
+                    {"head": "arg:x", "body": ["arg:y"], "name": "should_not_be_used"}
+                ],
+                cause=CAUSE_EVALUATED,
+            )
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -554,7 +650,7 @@ class TestAspicHandlerWiring:
         _inject_fake_aspic_module(monkeypatch, {"extensions": []})
 
         async def _fake_rules(text, args):
-            return []
+            return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -563,9 +659,7 @@ class TestAspicHandlerWiring:
         )
         from argumentation_analysis.orchestration.invoke_callables import _invoke_aspic
 
-        ctx: Dict[str, Any] = {
-            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
-        }
+        ctx: Dict[str, Any] = {"phase_extract_output": {"arguments": ["Alpha", "Beta"]}}
         await _invoke_aspic("text", ctx)
         # Nothing genuine → context key stays unset → gate keeps absent_no_translator.
         assert "defeasible_rules" not in ctx
@@ -577,24 +671,30 @@ class TestAspicHandlerWiring:
 class TestValidateSetafAttacks:
     def test_keeps_valid_joint_attack_mapped_to_text(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta", "arg3": "Gamma"}
-        data = {"attacks": [
-            {"attackers": ["arg1", "arg2"], "target": "arg3", "rationale": "r"},
-        ]}
+        data = {
+            "attacks": [
+                {"attackers": ["arg1", "arg2"], "target": "arg3", "rationale": "r"},
+            ]
+        }
         out = _validate_setaf_attacks(data, arg_by_id)
         assert out == [{"attackers": ["Alpha", "Beta"], "target": "Gamma"}]
 
     def test_drops_attack_with_unknown_attacker(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"attacks": [
-            {"attackers": ["arg1", "arg9"], "target": "arg2"},  # arg9 unknown
-        ]}
+        data = {
+            "attacks": [
+                {"attackers": ["arg1", "arg9"], "target": "arg2"},  # arg9 unknown
+            ]
+        }
         assert _validate_setaf_attacks(data, arg_by_id) == []
 
     def test_drops_attack_with_unknown_target(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"attacks": [
-            {"attackers": ["arg1"], "target": "arg9"},  # unknown target
-        ]}
+        data = {
+            "attacks": [
+                {"attackers": ["arg1"], "target": "arg9"},  # unknown target
+            ]
+        }
         assert _validate_setaf_attacks(data, arg_by_id) == []
 
     def test_drops_attack_with_no_attackers(self):
@@ -604,9 +704,11 @@ class TestValidateSetafAttacks:
 
     def test_removes_target_from_attackers_keeps_rest(self):
         arg_by_id = {"arg1": "Alpha", "arg3": "Gamma"}
-        data = {"attacks": [
-            {"attackers": ["arg1", "arg3"], "target": "arg3"},  # arg3 removed
-        ]}
+        data = {
+            "attacks": [
+                {"attackers": ["arg1", "arg3"], "target": "arg3"},  # arg3 removed
+            ]
+        }
         out = _validate_setaf_attacks(data, arg_by_id)
         assert out == [{"attackers": ["Alpha"], "target": "Gamma"}]
 
@@ -617,28 +719,34 @@ class TestValidateSetafAttacks:
 
     def test_dedups_identical_attacks(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"attacks": [
-            {"attackers": ["arg1"], "target": "arg2"},
-            {"attackers": ["arg1"], "target": "arg2"},
-        ]}
+        data = {
+            "attacks": [
+                {"attackers": ["arg1"], "target": "arg2"},
+                {"attackers": ["arg1"], "target": "arg2"},
+            ]
+        }
         out = _validate_setaf_attacks(data, arg_by_id)
         assert out == [{"attackers": ["Alpha"], "target": "Beta"}]
 
     def test_dedups_repeated_attackers(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"attacks": [
-            {"attackers": ["arg1", "arg1"], "target": "arg2"},
-        ]}
+        data = {
+            "attacks": [
+                {"attackers": ["arg1", "arg1"], "target": "arg2"},
+            ]
+        }
         out = _validate_setaf_attacks(data, arg_by_id)
         assert out[0]["attackers"] == ["Alpha"]
 
     def test_dedups_attacker_order_independence(self):
         # SetAF attacker set is a SET: {arg1,arg2} == {arg2,arg1} → one attack.
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta", "arg3": "Gamma"}
-        data = {"attacks": [
-            {"attackers": ["arg1", "arg2"], "target": "arg3"},
-            {"attackers": ["arg2", "arg1"], "target": "arg3"},
-        ]}
+        data = {
+            "attacks": [
+                {"attackers": ["arg1", "arg2"], "target": "arg3"},
+                {"attackers": ["arg2", "arg1"], "target": "arg3"},
+            ]
+        }
         out = _validate_setaf_attacks(data, arg_by_id)
         assert len(out) == 1
 
@@ -653,41 +761,63 @@ class TestValidateSetafAttacks:
         assert _validate_setaf_attacks({}, arg_by_id) == []
         assert _validate_setaf_attacks({"attacks": []}, arg_by_id) == []
         assert _validate_setaf_attacks({"attacks": "nope"}, arg_by_id) == []
-        assert _validate_setaf_attacks(
-            {"attacks": [{"attackers": 1, "target": "arg1"}]},  # type: ignore[dict-item]
-            arg_by_id,
-        ) == []
+        assert (
+            _validate_setaf_attacks(
+                {"attacks": [{"attackers": 1, "target": "arg1"}]},  # type: ignore[dict-item]
+                arg_by_id,
+            )
+            == []
+        )
 
 
 class TestSetafTranslator:
     async def test_empty_llm_output_returns_empty(self, monkeypatch):
         _patch_llm(monkeypatch, {"attacks": []})
         out = await translate_to_setaf_attacks("some text", ["a", "b"])
-        assert out == []
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_no_inventory_returns_empty(self, monkeypatch):
-        _patch_llm(monkeypatch, {"attacks": [
-            {"attackers": ["arg1"], "target": "arg2"},
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "attacks": [
+                    {"attackers": ["arg1"], "target": "arg2"},
+                ]
+            },
+        )
         out = await translate_to_setaf_attacks("text", [])
-        assert out == []
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_only_fabricated_attacks_dropped(self, monkeypatch):
-        _patch_llm(monkeypatch, {"attacks": [
-            {"attackers": ["arg8"], "target": "arg9"},   # unknown ids
-            {"attackers": ["phantom"], "target": "ghost"},
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "attacks": [
+                    {"attackers": ["arg8"], "target": "arg9"},  # unknown ids
+                    {"attackers": ["phantom"], "target": "ghost"},
+                ]
+            },
+        )
         out = await translate_to_setaf_attacks("text", ["a", "b"])
-        assert out == []
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_returns_validated_attacks_with_real_texts(self, monkeypatch):
         # SetAF attacks use canonical argument TEXTS (no PL-atom mapping).
-        _patch_llm(monkeypatch, {"attacks": [
-            {"attackers": ["arg1", "arg2"], "target": "arg3"},
-            {"attackers": ["arg1"], "target": "arg9"},  # dropped (unknown)
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "attacks": [
+                    {"attackers": ["arg1", "arg2"], "target": "arg3"},
+                    {"attackers": ["arg1"], "target": "arg9"},  # dropped (unknown)
+                ]
+            },
+        )
         out = await translate_to_setaf_attacks("text", ["Alpha", "Beta", "Gamma"])
-        assert out == [{"attackers": ["Alpha", "Beta"], "target": "Gamma"}]
+        assert out.relations == [{"attackers": ["Alpha", "Beta"], "target": "Gamma"}]
+        assert out.cause == CAUSE_EVALUATED
 
 
 def _inject_fake_setaf_module(monkeypatch, payload):
@@ -735,7 +865,7 @@ class TestSetafHandlerWiring:
         genuine = [{"attackers": ["Alpha"], "target": "Beta"}]
 
         async def _fake_attacks(text, args):
-            return genuine
+            return TranslationResult(relations=genuine, cause=CAUSE_EVALUATED)
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -744,9 +874,7 @@ class TestSetafHandlerWiring:
         )
         from argumentation_analysis.orchestration.invoke_callables import _invoke_setaf
 
-        ctx: Dict[str, Any] = {
-            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
-        }
+        ctx: Dict[str, Any] = {"phase_extract_output": {"arguments": ["Alpha", "Beta"]}}
         await _invoke_setaf("source text", ctx)
         assert ctx.get("set_attacks") == genuine
 
@@ -755,7 +883,10 @@ class TestSetafHandlerWiring:
 
         async def _fake_attacks(text, args):
             called["n"] += 1
-            return [{"attackers": ["x"], "target": "should_not_be_used"}]
+            return TranslationResult(
+                relations=[{"attackers": ["x"], "target": "should_not_be_used"}],
+                cause=CAUSE_EVALUATED,
+            )
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -778,7 +909,7 @@ class TestSetafHandlerWiring:
         _inject_fake_setaf_module(monkeypatch, {"extensions": []})
 
         async def _fake_attacks(text, args):
-            return []
+            return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -787,11 +918,9 @@ class TestSetafHandlerWiring:
         )
         from argumentation_analysis.orchestration.invoke_callables import _invoke_setaf
 
-        ctx: Dict[str, Any] = {
-            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
-        }
+        ctx: Dict[str, Any] = {"phase_extract_output": {"arguments": ["Alpha", "Beta"]}}
         await _invoke_setaf("text", ctx)
-        # Nothing genuine → context key stays unset → gate keeps absent_no_translator.
+        # Nothing genuine → context key stays unset → axis stays honestly absent.
         assert "set_attacks" not in ctx
 
 
@@ -801,9 +930,11 @@ class TestSetafHandlerWiring:
 class TestValidateWeightedAttacks:
     def test_keeps_valid_attack_with_weight(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"attacks": [
-            {"source": "arg1", "target": "arg2", "weight": 0.8, "rationale": "r"},
-        ]}
+        data = {
+            "attacks": [
+                {"source": "arg1", "target": "arg2", "weight": 0.8, "rationale": "r"},
+            ]
+        }
         out = _validate_weighted_attacks(data, arg_by_id)
         assert out == [("Alpha", "Beta", 0.8)]
 
@@ -836,17 +967,21 @@ class TestValidateWeightedAttacks:
 
     def test_drops_non_numeric_weight(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"attacks": [
-            {"source": "arg1", "target": "arg2", "weight": "high"},  # non-numeric
-        ]}
+        data = {
+            "attacks": [
+                {"source": "arg1", "target": "arg2", "weight": "high"},  # non-numeric
+            ]
+        }
         assert _validate_weighted_attacks(data, arg_by_id) == []
 
     def test_dedups_identical_attacks_keeps_first_weight(self):
         arg_by_id = {"arg1": "Alpha", "arg2": "Beta"}
-        data = {"attacks": [
-            {"source": "arg1", "target": "arg2", "weight": 0.9},
-            {"source": "arg1", "target": "arg2", "weight": 0.1},  # dup → dropped
-        ]}
+        data = {
+            "attacks": [
+                {"source": "arg1", "target": "arg2", "weight": 0.9},
+                {"source": "arg1", "target": "arg2", "weight": 0.1},  # dup → dropped
+            ]
+        }
         out = _validate_weighted_attacks(data, arg_by_id)
         assert out == [("Alpha", "Beta", 0.9)]
 
@@ -855,40 +990,70 @@ class TestValidateWeightedAttacks:
         assert _validate_weighted_attacks({}, arg_by_id) == []
         assert _validate_weighted_attacks({"attacks": []}, arg_by_id) == []
         assert _validate_weighted_attacks({"attacks": "nope"}, arg_by_id) == []
-        assert _validate_weighted_attacks(
-            {"attacks": [{"source": 1, "target": "arg1", "weight": 0.5}]},  # type: ignore[dict-item]
-            arg_by_id,
-        ) == []
+        assert (
+            _validate_weighted_attacks(
+                {"attacks": [{"source": 1, "target": "arg1", "weight": 0.5}]},  # type: ignore[dict-item]
+                arg_by_id,
+            )
+            == []
+        )
 
 
 class TestWeightedTranslator:
     async def test_empty_llm_output_returns_empty(self, monkeypatch):
         _patch_llm(monkeypatch, {"attacks": []})
         out = await translate_to_weighted_attacks("some text", ["a", "b"])
-        assert out == []
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_no_inventory_returns_empty(self, monkeypatch):
-        _patch_llm(monkeypatch, {"attacks": [
-            {"source": "arg1", "target": "arg2", "weight": 0.5},
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "attacks": [
+                    {"source": "arg1", "target": "arg2", "weight": 0.5},
+                ]
+            },
+        )
         out = await translate_to_weighted_attacks("text", [])
-        assert out == []
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_only_fabricated_attacks_dropped(self, monkeypatch):
-        _patch_llm(monkeypatch, {"attacks": [
-            {"source": "arg8", "target": "arg9", "weight": 0.5},  # unknown ids
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "attacks": [
+                    {"source": "arg8", "target": "arg9", "weight": 0.5},  # unknown ids
+                ]
+            },
+        )
         out = await translate_to_weighted_attacks("text", ["a", "b"])
-        assert out == []
+        assert out.relations == []
+        assert out.cause == CAUSE_NO_GENUINE_RELATIONS
 
     async def test_returns_validated_triples_with_real_weights(self, monkeypatch):
-        _patch_llm(monkeypatch, {"attacks": [
-            {"source": "arg1", "target": "arg2", "weight": 0.7},
-            {"source": "arg1", "target": "arg9", "weight": 0.5},  # dropped (unknown)
-            {"source": "arg2", "target": "arg1", "weight": 2.0},  # clamped to 1.0
-        ]})
+        _patch_llm(
+            monkeypatch,
+            {
+                "attacks": [
+                    {"source": "arg1", "target": "arg2", "weight": 0.7},
+                    {
+                        "source": "arg1",
+                        "target": "arg9",
+                        "weight": 0.5,
+                    },  # dropped (unknown)
+                    {
+                        "source": "arg2",
+                        "target": "arg1",
+                        "weight": 2.0,
+                    },  # clamped to 1.0
+                ]
+            },
+        )
         out = await translate_to_weighted_attacks("text", ["Alpha", "Beta"])
-        assert out == [("Alpha", "Beta", 0.7), ("Beta", "Alpha", 1.0)]
+        assert out.relations == [("Alpha", "Beta", 0.7), ("Beta", "Alpha", 1.0)]
+        assert out.cause == CAUSE_EVALUATED
 
 
 def _inject_fake_weighted_module(monkeypatch, payload):
@@ -936,7 +1101,7 @@ class TestWeightedHandlerWiring:
         genuine: List[Tuple[str, str, float]] = [("Alpha", "Beta", 0.8)]
 
         async def _fake_attacks(text, args):
-            return genuine
+            return TranslationResult(relations=genuine, cause=CAUSE_EVALUATED)
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -947,9 +1112,7 @@ class TestWeightedHandlerWiring:
             _invoke_weighted,
         )
 
-        ctx: Dict[str, Any] = {
-            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
-        }
+        ctx: Dict[str, Any] = {"phase_extract_output": {"arguments": ["Alpha", "Beta"]}}
         await _invoke_weighted("source text", ctx)
         assert ctx.get("weighted_attacks") == genuine
 
@@ -958,7 +1121,7 @@ class TestWeightedHandlerWiring:
 
         async def _fake_attacks(text, args):
             called["n"] += 1
-            return [("x", "y", 0.5)]
+            return TranslationResult(relations=[("x", "y", 0.5)], cause=CAUSE_EVALUATED)
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -983,7 +1146,7 @@ class TestWeightedHandlerWiring:
         _inject_fake_weighted_module(monkeypatch, {"extensions": []})
 
         async def _fake_attacks(text, args):
-            return []
+            return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
 
         monkeypatch.setattr(
             "argumentation_analysis.orchestration.structured_arg_translator."
@@ -994,9 +1157,7 @@ class TestWeightedHandlerWiring:
             _invoke_weighted,
         )
 
-        ctx: Dict[str, Any] = {
-            "phase_extract_output": {"arguments": ["Alpha", "Beta"]}
-        }
+        ctx: Dict[str, Any] = {"phase_extract_output": {"arguments": ["Alpha", "Beta"]}}
         await _invoke_weighted("text", ctx)
         # Nothing genuine → context key stays unset → gate keeps absent_no_translator.
         assert "weighted_attacks" not in ctx


### PR DESCRIPTION
## #1608 — Discriminate structured-arg absence cause + reconcile `degraded`

Closes #1608. Three defects in the structured-argumentation honest-absent contract, each fixed with a **falsifiable pivot test** (passes on the fixed code, fails on the pre-#1608 code — *"un test qui passe avec les deux versions du code ne prouve rien"*).

### Defect 1 — four causes collapsed onto one label; `degraded` was invariant

The structured-arg axis had four genuinely distinct reasons to be absent, all collapsed onto `absent_no_translator`, and `degraded` stayed `False` across corpus A/B/C in the #1608 measure.

| Cause | Before | After |
|-------|--------|-------|
| translator raised (e.g. timeout) | `absent_no_translator`, degraded=False | `translator_failed`, **degraded=True** |
| translator ran, found nothing genuine | `absent_no_translator`, degraded=False | `no_genuine_relations`, **degraded=False** *(analytical result)* |
| no API key configured | `absent_no_translator`, degraded=False | `translator_unconfigured`, **degraded=True** |
| nothing wired / no cause recorded | `absent_no_translator`, degraded=True | `absent_no_translator`, degraded=True *(unchanged)* |

**Fix.** The five translators (`translate_to_bipolar_supports` / `_aba_contraries` / `_aspic_rules` / `_setaf_attacks` / `_weighted_attacks`) now return a `TranslationResult(relations, cause, error)` discriminated union instead of a bare `[]`/`{}`. The invoke callables (`_invoke_bipolar`/`_aba`/`_aspic`/`_setaf`/`_weighted`) propagate the cause into the shared pipeline context via namespaced keys `_structured_arg_cause:{cap}` / `_structured_arg_error:{cap}`. The recorder `_record_structured_arg_status` reads the cause and resolves it to a distinct `(status, degraded, reason)` via the new `_resolve_absent_status`.

**Anti-pendule (hard constraint).** `no_genuine_relations` carries `degraded=False`. A corpus that genuinely has no joint attack is an **analytical result**, not a degraded pipeline — making it red would be the symmetrical error. `absent_no_translator` is **preserved** (not deleted) for the rare legacy path where no cause was recorded.

### Defect 2 — `workflow_results.degraded` ignored `structured_arg_status` (+ the restitution-act raccord)

`workflow_results.degraded` was computed only from phase-level optional-slot exhaustion. A workflow whose translators raised (phase still COMPLETED, handler ran on auto-shaped input, axis degraded) was reported **not-degraded**. Extracted `_compute_workflow_degraded` reconciles both registries via an honest **OR** (not a composite average — `no_genuine_relations` with `degraded=False` does not flip it). Reverting the structured-arg read → the flip test fails.

**The restitution-act raccord (R752).** The same `is True` predicate at the workflow level (`_collect_degraded_capabilities`) is the *only* reader of the phase-output `degraded` canon — but the three restitution acts (`_invoke_act{1,2,3}`) returned `degraded` as a **dict of motifs** (`ActNResult.degraded`), and a dict is never `is True`. So the acts had **7 declaration sites and 0 readers** — they structurally could not feed `capabilities_degraded`. The raccord (coordinator's chosen second option):
- the act invokers now surface `degraded` as a **BOOL** (feeds the `is True` predicate) **AND** `degraded_reasons` as a **dict** — the motifs are preserved rather than collapsed (anti-pendule #1019: `bool(result.degraded)` alone would pass the test and discard exactly the information that was demanded visible);
- the act state writers persist `degraded_reasons` into `state.restitution_acts_degraded` so the motifs reach the state instead of dying in the return value;
- `_collect_degraded_capabilities` is extracted from `run_unified_analysis` (pure, mirrors `_compute_workflow_degraded`).

**Anti-pendule.** An act that succeeded (empty/absent motifs) is NOT marked degraded — only non-empty `degraded_reasons` are persisted.

### Defect 3 — a phase error could be empty

`str(asyncio.TimeoutError()) == ""`, which left the error registry with `{"message": "", "timestamp": null}`. Extracted `_build_phase_error_message` surfaces the exception type, the phase, and (for timeouts) the budget exceeded, so the failure is attributable rather than silent.

### Tests

- **New pivot suite** `test_structured_arg_degradation_1608.py` (23 tests):
  - Défaut 1 — the four causes yield four distinct statuses; `degraded` is no longer invariant across corpus A/B/C (3 distinct `(status, degraded)` outcome triples; `no_genuine_relations` is the one NOT degraded).
  - Défaut 2 — a degraded structured axis flips `workflow_results.degraded` even with all phases COMPLETED; `no_genuine_relations` does NOT flip it; phase-level degradation still counted (additive OR); state-None safe; multiple axes sorted. **+ act raccord**: a bool-degraded act feeds `capabilities_degraded`; a dict-degraded act does NOT (falsifiable: revert the invoker and it flips); the structured axis feeds too; motifs reach `state.restitution_acts_degraded`; a clean act is never marked; empty motifs not persisted.
  - Défaut 3 — timeout names phase + budget; bare exception falls back to type name; descriptive exception preserved; timeout without budget names type only.
- **Updated** `test_structured_arg_translator.py` (75 tests) — follows the new `TranslationResult` return type (the 13 handler-wiring mocks + 19 direct-translator assertions); `_validate_*` contract unchanged.
- `test_structured_arg_honest_absent.py` (22 tests) — unchanged, still green (no-cause → `absent_no_translator` fallback preserved).

### Files

**Prod (6):**
- `orchestration/structured_arg_translator.py` — `TranslationResult`, `TranslatorUnconfigured`, `CAUSE_*`, 5 translators return discriminated result.
- `orchestration/state_writers.py` — `_resolve_absent_status`, `_translation_cause_key/_error_key`, reformulated `_STRUCTURED_ARG_ABSENT_REASON`, `_STRUCTURED_ARG_FORMALISM_NAME`, recorder reads cause; `_persist_act_degraded_reasons` (act raccord).
- `orchestration/invoke_callables.py` — `_propagate_structured_arg_cause` helper + 5 translator invoke sites propagate cause; 3 act invokers surface `degraded` as bool + `degraded_reasons` dict (act raccord).
- `orchestration/workflow_dsl.py` — `_compute_workflow_degraded` (Défaut 2) + `_build_phase_error_message` (Défaut 3), both extracted as pure helpers.
- `orchestration/unified_pipeline.py` — `_collect_degraded_capabilities` extracted from `run_unified_analysis` (Défaut 2 / act raccord).
- `core/shared_state.py` — `add_structured_arg_status` docstring documents the 5 statuses; `restitution_acts_degraded` field (act raccord).

**Tests (2):** new pivot suite (23) + updated translator suite (75).

### Delta tally (announced before the run)

- **+23 tests** (new pivot file: 16 defect suites + 7 act-raccord). **0 removed. 0 new skips.** Translator suite function count unchanged (contract updated, not added/removed). All tests JVM/LLM-free (no API key needed).

### Verification

- CI mypy gate clean (`mypy --config-file pyproject.toml` on the 8 gated files: *Success: no issues found in 8 source files*).
- `black` clean on all touched files.
- Targeted: **120 passed** (`translator` 75 + `honest_absent` 22 + `degradation_1608` 23).

### Privacy

Opaque atoms only (`corpus A/B/C`, `Alpha/Beta/Gamma` synthetic argument texts) on every GitHub-indexed surface. No corpus content. No JVM, no real LLM in the test suite.
