### PR TITLE
fix(restitution): a virtue is not a degradation (#1611)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act1_framing_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act1_framing_plugin.py
@@ -609,12 +609,14 @@ async def build_act1_framing(
             "l'Acte II sans filet d'attente."
         )
     vm = evidence.virtuous_mode
+    # The virtuous shift (spec §5) is a POSITIVE outcome and is reported by
+    # ``is_virtuous`` below — it is deliberately NOT filed under ``degraded``.
+    # ``degraded`` used to double as a notes bag, which was harmless while
+    # nobody read it; #1608 promoted it to a verdict (the invoker publishes
+    # ``bool(degraded)`` and the collector strips the capability out of
+    # ``capabilities_used``). A virtue left in here made the BEST-case act
+    # report as degraded.
     is_virtuous = vm is not None and vm.is_virtuous
-    if vm is not None and vm.is_virtuous:
-        degraded["act1_virtuous_mode"] = (
-            "Mode vertueux (spec §5) — spectre lu comme anticipation qui ne "
-            "dérape pas. " + vm.reasoning
-        )
 
     return Act1Result(
         narrative=narrative,

--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -1315,12 +1315,11 @@ async def build_act2_narrative(
             "indisponible) — vertus tues, fail-loud."
         )
     vm = evidence.virtuous_mode
+    # Positive outcome — reported by ``is_virtuous``, never filed under
+    # ``degraded`` (see the note in ``act1_framing_plugin``): #1608 turned
+    # ``degraded`` into a verdict, so a virtue left here marked the act as
+    # degraded and stripped it from ``capabilities_used``.
     is_virtuous = vm is not None and vm.is_virtuous
-    if vm is not None and vm.is_virtuous:
-        degraded["act2_virtuous_mode"] = (
-            "Mode vertueux (spec §5) — récit mené par pourquoi ça tient. "
-            + vm.reasoning
-        )
 
     return Act2Result(
         narrative=narrative,

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -1098,12 +1098,13 @@ async def build_act3_conclusion(
             "indisponible) — appréciations limitées aux faiblesses, fail-loud."
         )
     vm = evidence.virtuous_mode
+    # Positive outcome — reported by ``is_virtuous``, never filed under
+    # ``degraded`` (see the note in ``act1_framing_plugin``): #1608 turned
+    # ``degraded`` into a verdict, so a virtue left here marked the act as
+    # degraded and stripped it from ``capabilities_used``. The branch below
+    # stays gated on NOT-virtuous, which is what the ``elif`` expressed.
     is_virtuous = vm is not None and vm.is_virtuous
-    if vm is not None and vm.is_virtuous:
-        degraded["act3_virtuous_mode"] = (
-            "Mode vertueux (spec §5) — titre sur les vertus. " + vm.reasoning
-        )
-    elif not evidence.weak_points:
+    if not is_virtuous and not evidence.weak_points:
         # Defensive: no weak points AND not flagged virtuous (an empty-ish run
         # that still passed G1). Honest note — not a positive virtuous claim,
         # since no non-trivial axis qualified the text as virtuous.

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act1_framing_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act1_framing_plugin.py
@@ -414,6 +414,15 @@ class TestVirtuousMode:
         assert "MODE VIRTUEUX" not in build_act1_prompt(ev2)
 
     def test_virtuous_result_carries_positive_marker(self):
+        """The virtue is reported as a virtue — and NOT as a degradation.
+
+        This assertion was ``"act1_virtuous_mode" in result.degraded`` while
+        ``degraded`` doubled as a notes bag that nobody read. #1608 promoted it
+        to a verdict: the invoker publishes ``bool(degraded)`` and the collector
+        strips the capability out of ``capabilities_used``. Filing a virtue
+        there made the best-case act report as degraded, so the marker moves to
+        its own field — which this test already asserted.
+        """
         result = asyncio.get_event_loop().run_until_complete(
             build_act1_framing(
                 _virtuous_state(), llm_callable=_stub_llm(_WOVEN_FRAMING)  # type: ignore[arg-type]
@@ -421,4 +430,7 @@ class TestVirtuousMode:
         )
         assert result.is_virtuous is True
         assert result.status == "woven"
-        assert "act1_virtuous_mode" in result.degraded
+        assert "act1_virtuous_mode" not in result.degraded
+        # The predicate the consumer actually evaluates (#1608): a virtuous act
+        # must not raise it. Asserting the published bool, not just the key.
+        assert bool(result.degraded) is False

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
@@ -787,7 +787,11 @@ class TestVirtuousMode:
         )
         assert result.is_virtuous is True
         assert result.status == "woven"
-        assert "act2_virtuous_mode" in result.degraded
+        # The virtue is reported as a virtue, not as a degradation: #1608 made
+        # ``degraded`` a verdict (the invoker publishes ``bool(degraded)``), so
+        # a virtue filed there marked the best-case act as degraded.
+        assert "act2_virtuous_mode" not in result.degraded
+        assert bool(result.degraded) is False
 
 
 class TestTweetyInconsistanceGapRegression:

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -728,16 +728,27 @@ class TestVirtuousMode:
         )
         assert result.is_virtuous is True
         assert result.status == "woven"
-        assert "act3_virtuous_mode" in result.degraded
+        # The virtue is reported as a virtue, not as a degradation: #1608 made
+        # ``degraded`` a verdict (the invoker publishes ``bool(degraded)``), so
+        # a virtue filed there marked the best-case act as degraded.
+        assert "act3_virtuous_mode" not in result.degraded
+        assert bool(result.degraded) is False
 
     def test_non_virtuous_result_no_virtuous_marker(self):
+        """A non-virtuous state must not claim the virtuous shift.
+
+        The former companion assertion (``"act3_virtuous_mode" not in
+        result.degraded``) is dropped rather than kept: the key no longer
+        exists in any branch, so it could not fail under any implementation —
+        a passing assertion that measures nothing. ``is_virtuous`` is the flag
+        that still discriminates, and it is the one asserted.
+        """
         result = asyncio.get_event_loop().run_until_complete(
             build_act3_conclusion(
                 _rich_state(), llm_callable=_stub_llm(_WOVEN_CONCLUSION)  # type: ignore[arg-type]
             )
         )
         assert result.is_virtuous is False
-        assert "act3_virtuous_mode" not in result.degraded
 
     def test_no_fabricated_fallacy_in_virtuous_prompt(self):
         # the virtuous prompt must NOT invent a weak point to fill a beat


### PR DESCRIPTION
Closes #1611.

## Ce que ça corrige

Un acte de restitution réussi **en mode vertueux** est aujourd'hui compté comme dégradé sur `main`, et retiré de `capabilities_used`. Mesuré de bout en bout, pas déduit :

```
status      : woven
is_virtuous : True
degraded    : ['act1_virtuous_mode']
bool(degraded) -> True     <- ce que l'invoker publie
```

Après le correctif : `degraded : []`, `bool(...) -> False`.

## Pourquoi ce n'est la faute de personne

Les trois actes se servaient de `degraded` comme d'un sac à notes — délibérément : le test qui l'épinglait s'appelait `test_virtuous_result_carries_positive_marker`. Sans conséquence tant que rien ne le lisait.

#1608 a corrigé un vrai défaut (le prédicat `is True` sur un dict n'était jamais vrai — 7 sites de déclaration, 0 lecteur) en publiant `bool(result.degraded)`. Ce faisant il a promu le sac à notes en **verdict**, et la vertu a suivi. La collision naît de la composition.

## Le geste : soustraire

`is_virtuous` existe déjà sur les trois `ActNResult`, est déjà asserté par les mêmes tests, et façonne déjà la prose via la section `MODE VIRTUEUX` du prompt. L'entrée `degraded` était un doublon. Filtrer sur les noms de clés côté invoker aurait gardé la collision en la cachant.

## Falsifiabilité

| substitution | morts attendus | constatés |
|---|---|---|
| remettre les 3 clés `*_virtuous_mode` | les 3 tests de vertu | **3** (1 par acte, rien d'autre) |

Les assertions passent de `in` à `not in` **et** gagnent le prédicat que le consommateur évalue vraiment (`bool(result.degraded) is False`). C'est une affirmation plus forte sur le sens, pas un test affaibli — la substitution ci-dessus le prouve.

Une assertion compagne est **retirée** plutôt que gardée : la clé n'existant plus dans aucune branche, `"act3_virtuous_mode" not in result.degraded` ne pouvait plus échouer sous aucune implémentation.

## Tests

- `reporting/restitution/` : **256 passed** (inchangé — aucun test ajouté, assertions renforcées)
- `orchestration/` (spectacular + `test_structured_arg_degradation_1608`) : **94 passed**

## Ce que je ne prétends pas

`is_virtuous` n'a **aucun lecteur hors des plugins**. La vertu atteint le prompt et le narratif, mais aucun canal structuré ne la porte jusqu'au rapport. Constat mesuré, délibérément non câblé ici : brancher un champ que personne ne lit serait le réflexe inverse du même défaut.

Note lint : `black` signale les **mêmes 6 fichiers avant et après** ce changement — la non-conformité préexiste et le step CI est `continue-on-error`. Non élargi ici.

🤖 Coordinator ai-01 — R753
