### PR TITLE
feat(restitution): give the persisted degradation motifs a reader (#1605)

### DIFF
--- a/argumentation_analysis/reporting/restitution/pipeline_adapter.py
+++ b/argumentation_analysis/reporting/restitution/pipeline_adapter.py
@@ -26,14 +26,16 @@ Design (anti-pendule, file-disjoint lane per dispatch R433):
     this on a non-spectacular state (act strings empty) yields an honest
     "acte indisponible" report rather than a crash or silent omission.
 
-Provenance note: the act invoke-callables return a ``degraded`` dict per act,
-but the state-writers store only the narrative string (the structured
-``degraded`` is not carried on state). This is acceptable — the act narratives
-themselves already carry the honest degradation wording inline (the plugins
-append caveats / §4 self-check notes into the text), so the report stays honest
-without a state-schema change. Surfacing structured per-act ``degraded`` would
-require touching ``state_writers.py`` / ``shared_state.py`` (out of this lane's
-scope; the narrative carries the honesty).
+Provenance note (superseded — #1608): this module used to record that the act
+invoke-callables returned a per-act ``degraded`` dict which the state-writers
+dropped, and that carrying it would require touching ``state_writers.py`` /
+``shared_state.py`` "out of this lane's scope". That work has since been done:
+``shared_state`` carries ``restitution_acts_degraded`` and the act state-writers
+persist the motifs into it. The note is kept, corrected, because the reasoning it
+recorded was the actual defect — the structured motifs were declared in seven
+places and read in none, and the narrative-carries-the-honesty argument is what
+made that look acceptable. ``_read_act_degraded`` below is the hop that finally
+gives those motifs a reader.
 
 Privacy HARD: ``source_id`` must be opaque (``doc_A``, never a speaker name /
 title / date). The appendix layer strips ``raw_text`` defensively regardless.
@@ -43,7 +45,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from .acts import RestitutionActs
 from .renderer import RenderedReport, render_restitution_report
@@ -73,6 +75,60 @@ def _derive_source_id(state: Any, source_id: Optional[str]) -> str:
     return _SOURCE_ID_FALLBACK
 
 
+def _read_act_degraded(state: Any) -> Dict[str, str]:
+    """Flatten ``state.restitution_acts_degraded`` into ``RestitutionActs.degraded``.
+
+    This is the last hop of the #1608 chain. The two ends already agreed on the
+    *key* — the state writers file motifs under ``act1_framing`` /
+    ``act2_narrative`` / ``act3_conclusion``, which is exactly what
+    ``RestitutionActs.act_key`` returns — but not on the *value*: the state holds
+    ``{motif_key -> text}`` (every motif preserved; #1608 deliberately refused to
+    throw them away behind a ``bool()``), while the renderer prints a single line
+    per act. The join happens here, at the boundary, so neither end has to
+    compromise its own shape.
+
+    Motifs are joined sorted by motif key: a rendered report must not depend on
+    the order in which a plugin happened to insert them.
+
+    Anti-pendule: an act with no motif stays absent from the mapping — nothing is
+    degraded by default. An unexpected shape is *reported*, not silently dropped:
+    losing a degradation motif in silence is the exact failure this chain exists
+    to remove.
+    """
+    if isinstance(state, dict):
+        raw = state.get("restitution_acts_degraded")
+    else:
+        raw = getattr(state, "restitution_acts_degraded", None)
+    if not isinstance(raw, dict):
+        return {}
+
+    valid_keys = {RestitutionActs.act_key(n) for n in (1, 2, 3)}
+    flattened: Dict[str, str] = {}
+    for key, motifs in raw.items():
+        if key not in valid_keys:
+            logger.warning(
+                "Ignoring degradation motifs filed under unknown act key %r "
+                "(fail-loud): expected one of %s",
+                key,
+                sorted(valid_keys),
+            )
+            continue
+        if not isinstance(motifs, dict):
+            logger.warning(
+                "Degradation motifs for %r have an unexpected shape %s "
+                "(fail-loud): expected a {motif_key: text} mapping",
+                key,
+                type(motifs).__name__,
+            )
+            continue
+        text = "; ".join(
+            str(motifs[k]).strip() for k in sorted(motifs) if str(motifs[k]).strip()
+        )
+        if text:
+            flattened[key] = text
+    return flattened
+
+
 def build_restitution_acts(state: Any, source_id: Optional[str] = None) -> RestitutionActs:
     """Build a ``RestitutionActs`` from a completed spectacular shared-state.
 
@@ -81,6 +137,13 @@ def build_restitution_acts(state: Any, source_id: Optional[str] = None) -> Resti
     defaults — works on a dataclass, a dict, or any object exposing the named
     attributes. Missing/empty acts are left empty so the renderer reports them
     honestly ("acte indisponible"), never fabricated (anti-pendule #1019/#369).
+
+    Degradation motifs persisted by the act state writers (#1608) are read here
+    too — see ``_read_act_degraded``. Known boundary: the renderer only prints a
+    degradation note for an act that HAS text (its degraded branch sits below the
+    missing-act ``continue``), so a motif explaining a *missing* act does not
+    reach the reader. Recorded rather than fixed here — widening the renderer is
+    a separate change with its own test.
     """
     def _read(key: str) -> str:
         if isinstance(state, dict):
@@ -94,6 +157,7 @@ def build_restitution_acts(state: Any, source_id: Optional[str] = None) -> Resti
         act2_narrative=_read("act2_narrative"),
         act3_conclusion=_read("act3_conclusion"),
         source_id=_derive_source_id(state, source_id),
+        degraded=_read_act_degraded(state),
     )
 
 

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_pipeline_adapter.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_pipeline_adapter.py
@@ -107,6 +107,115 @@ class TestBuildRestitutionActs:
 
 
 # ============================================================================
+# #1608 last hop — degradation motifs must reach the READER
+# ============================================================================
+
+
+class TestActDegradationReachesTheReader:
+    """The motifs persisted by the act state writers must change the report.
+
+    The load-bearing property is stated end-to-end and as a *difference*:
+    mutating ``state.restitution_acts_degraded`` MUST change the rendered
+    markdown. Asserting only that ``build_restitution_acts`` returns the right
+    mapping would pass even with a renderer that never printed it — which is
+    exactly the situation this hop closes (the motifs reached the state, the
+    renderer had the branch, and nothing joined the two).
+    """
+
+    @staticmethod
+    def _rendered(**degraded: object) -> str:
+        state = _stub_state(
+            act1_framing=_ACT1,
+            act2_narrative=_ACT2,
+            act3_conclusion=_ACT3,
+            restitution_acts_degraded=dict(degraded),
+        )
+        return render_spectacular_restitution(state).markdown
+
+    def test_mutating_the_state_changes_the_rendered_report(self):
+        clean = self._rendered()
+        degraded = self._rendered(
+            act3_conclusion={"act3_conclusion_gate": "G2 partiellement satisfaite"}
+        )
+        # The difference IS the property under test — not the presence alone.
+        assert clean != degraded
+        assert "G2 partiellement satisfaite" not in clean
+        assert "G2 partiellement satisfaite" in degraded
+        assert "Acte dégradé" in degraded
+
+    def test_motifs_joined_sorted_by_motif_key(self):
+        # Sorted, so the report never depends on a plugin's insertion order.
+        acts = build_restitution_acts(
+            _stub_state(
+                act3_conclusion=_ACT3,
+                restitution_acts_degraded={
+                    "act3_conclusion": {"z_motif": "dernier", "a_motif": "premier"}
+                },
+            )
+        )
+        assert acts.degraded["act3_conclusion"] == "premier; dernier"
+
+    def test_clean_act_is_absent_from_the_mapping(self):
+        # Anti-pendule: nothing is degraded by default.
+        acts = build_restitution_acts(
+            _stub_state(act1_framing=_ACT1, restitution_acts_degraded={})
+        )
+        assert acts.degraded == {}
+
+    def test_state_without_the_field_yields_no_degradation(self):
+        # Backward compatibility with states predating #1608.
+        assert build_restitution_acts(_stub_state(act1_framing=_ACT1)).degraded == {}
+
+    def test_empty_motif_texts_do_not_fabricate_a_note(self):
+        acts = build_restitution_acts(
+            _stub_state(
+                act1_framing=_ACT1,
+                restitution_acts_degraded={"act1_framing": {"motif": "   "}},
+            )
+        )
+        assert acts.degraded == {}
+
+    def test_unknown_act_key_is_dropped_and_reported(self, monkeypatch):
+        # Losing a motif in silence is the failure this chain exists to remove,
+        # so the drop must be audible. The module logger is doubled rather than
+        # relying on caplog, whose records this repo's logging setup can wipe.
+        warnings: List[str] = []
+        monkeypatch.setattr(
+            "argumentation_analysis.reporting.restitution.pipeline_adapter.logger",
+            SimpleNamespace(
+                warning=lambda msg, *a: warnings.append(msg % a if a else msg),
+                info=lambda *a, **k: None,
+            ),
+        )
+        acts = build_restitution_acts(
+            _stub_state(
+                act1_framing=_ACT1,
+                restitution_acts_degraded={"act9_imaginaire": {"m": "texte"}},
+            )
+        )
+        assert acts.degraded == {}
+        assert warnings and "act9_imaginaire" in warnings[0]
+
+    def test_non_mapping_motifs_are_dropped_and_reported(self, monkeypatch):
+        warnings: List[str] = []
+        monkeypatch.setattr(
+            "argumentation_analysis.reporting.restitution.pipeline_adapter.logger",
+            SimpleNamespace(
+                warning=lambda msg, *a: warnings.append(msg % a if a else msg),
+                info=lambda *a, **k: None,
+            ),
+        )
+        acts = build_restitution_acts(
+            _stub_state(
+                act1_framing=_ACT1,
+                restitution_acts_degraded={"act1_framing": "une chaîne, pas un dict"},
+            )
+        )
+        assert acts.degraded == {}
+        assert warnings and "act1_framing" in warnings[0]
+
+
+# ============================================================================
 # source_id derivation (opaque, privacy HARD)
 # ============================================================================
 


### PR DESCRIPTION
Ferme le **dernier saut** de la chaîne #1608 : les motifs de dégradation persistés dans l'état atteignent enfin le lecteur du rapport.

## Ce qui était cassé

Les trois maillons existaient déjà, et aucun ne se parlait :

| Maillon | État avant |
|---|---|
| `state.restitution_acts_degraded` | **écrit** par les state writers d'acte (#1610) |
| `RestitutionActs.degraded` | **déclaré** (`acts.py`), jamais renseigné |
| `> ⚠️ **Acte dégradé** — …` | **branche présente** dans le renderer, jamais atteinte |

`build_restitution_acts` construisait `RestitutionActs(...)` **sans** `degraded=`. Un motif qui arrivait jusqu'à l'état y mourait, et la branche du renderer était inatteignable. C'est le motif « écrit-jamais-lu » (#1019) sous sa forme la plus littérale.

## Ce que fait le correctif

`_read_act_degraded` aplatit `{act_key -> {motif_key -> texte}}` vers le `{act_key -> raison}` que consomme le renderer.

Les deux bouts s'accordaient **déjà sur la clé** — les state writers classent sous `act1_framing` / `act2_narrative` / `act3_conclusion`, qui est exactement ce que retourne `RestitutionActs.act_key`. Seule la **valeur** différait. La jointure est donc faite à la frontière, sans qu'aucun des deux côtés n'ait à renoncer à sa forme : l'état garde tous ses motifs (#1608 avait délibérément refusé de les jeter derrière un `bool()`), le renderer garde sa ligne unique.

Motifs joints **triés par clé de motif** — un rapport rendu ne doit pas dépendre de l'ordre d'insertion d'un plugin.

## Falsifiabilité — deux substitutions qui tuent des sous-ensembles différents

| Substitution | Morts | Survivants |
|---|---|---|
| **A** — raccord coupé (`degraded=_read_act_degraded(state)` → `degraded={}`) | **4** | 19 |
| **B** — tri retiré (`sorted(motifs)` → `motifs`) | **1** (le test de tri) | 22 |

A tue les quatre assertions positives ; les trois survivants de A sont précisément les gardes anti-pendule qui affirment `degraded == {}` — ils **doivent** survivre. B ne tue que le test de tri, donc la garantie d'ordre est épinglée **indépendamment**, pas couverte par accident.

La propriété centrale est énoncée **end-to-end et comme une différence** :

```python
clean    = self._rendered()
degraded = self._rendered(act3_conclusion={"act3_conclusion_gate": "…"})
assert clean != degraded          # la différence EST la propriété
```

Un test sur le dict intermédiaire seul serait passé contre un renderer qui ne l'imprime jamais — c'était exactement le défaut.

## Forme inattendue : signalée, pas avalée

Clé d'acte inconnue ou motifs non-mapping → `logger.warning(… (fail-loud) …)`, suivant la convention **déjà présente dans le module** (l. 150). Perdre un motif de dégradation en silence est précisément la panne que cette chaîne existe pour supprimer. Le logger du module est doublé par `monkeypatch` plutôt que via `caplog`, dont les enregistrements peuvent être effacés par le setup logging de ce dépôt.

## Note de provenance corrigée, pas supprimée

Le docstring du module affirmait encore que le `degraded` structuré n'est pas porté par l'état et que le porter « sortirait du périmètre de cette lane ». #1610 l'a fait. La note est **corrigée sur place plutôt qu'effacée** : le raisonnement qu'elle consignait — « les narratifs portent déjà l'honnêteté inline » — est ce qui a fait paraître acceptable un champ déclaré à sept endroits et lu à zéro.

## Limite mesurée, consignée et NON corrigée ici

La branche dégradée du renderer est **sous** le `continue` de l'acte manquant. Donc un motif qui explique un acte **absent** n'atteint pas le lecteur — or c'est souvent le motif le plus utile. Élargir le renderer est un changement distinct avec son propre test ; je l'écris plutôt que de le glisser ici.

## Dépendance

Empilée sur #1612, et pas seulement par commodité de diff : **sans** #1612, un acte *vertueux* persiste `{"act1_framing": {"act1_virtuous_mode": …}}`, et ce raccord **imprimerait « Acte dégradé » sur le meilleur acte**. Ce saut rend visible dans le rapport ce que #1611 rendait silencieux.

## Vérifications

- `tests/…/restitution/` : **263 passés** (256 + 7 nouveaux — delta prédit avant le run)
- `flake8` : propre sur les deux fichiers
- `black` : les deux fichiers étaient **déjà** non conformes à la base (2 avant, 2 après) ; le `--diff` ne porte que sur des lignes **préexistantes** (signature de `build_restitution_acts`, appels `_stub_state` de tests antérieurs), aucune des lignes ajoutées. Pas de reformatage sans rapport mélangé à une PR sémantique.
- Privacy : aucun texte de corpus, IDs opaques (`doc_A`, `corpus_anonyme`) uniquement.

Refs #1605, #1608.
