### PR TITLE
fix(restitution): stop the generic motif from erasing the precise one (#1615)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -1108,7 +1108,14 @@ async def build_act3_conclusion(
         # Defensive: no weak points AND not flagged virtuous (an empty-ish run
         # that still passed G1). Honest note — not a positive virtuous claim,
         # since no non-trivial axis qualified the text as virtuous.
-        degraded["act3_conclusion"] = (
+        #
+        # Key is ``act3_conclusion_thin``, NOT ``act3_conclusion`` (#1615): the
+        # latter is already written above when the quality axis is unavailable,
+        # and both conditions hold together on a thin run — measured through the
+        # real builder, the generic motif here silently replaced the precise
+        # "axe qualité non concluable" one, so the reader was told the wrong
+        # reason for the degradation. Distinct keys, both motifs survive.
+        degraded["act3_conclusion_thin"] = (
             "Aucun point faible localisé et aucun axe vertueux non-trivial — "
             "la conclusion titre sur les forces disponibles sans claim vertueux "
             "non dérivé (fail-loud)."

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -607,6 +607,37 @@ class TestBuildConclusion:
             for v in result.degraded.values()
         )
 
+    def test_thin_run_keeps_both_motifs_instead_of_overwriting(self):
+        """#1615 — the precise motif must survive the generic one.
+
+        On a thin run the quality axis is unavailable AND there are no weak
+        points, so both degradation branches fire. They used to write the same
+        ``act3_conclusion`` key, and the generic "aucun point faible" motif
+        silently replaced the precise "axe qualité non concluable" one — the
+        reader was told the wrong reason for the degradation.
+
+        Measured through the real builder before the fix: ``degraded`` held
+        ``act3_conclusion`` carrying the GENERIC text, the precise one gone.
+        Restoring the single key kills this test (and only this one).
+        """
+        state = _state(
+            identified_arguments={
+                "arg_1": "Une revendication défendue par un raisonnement causal étayé.",
+                "arg_2": "Une seconde revendication appuyée sur un précédent documenté.",
+            },
+            argument_quality_scores={},  # axe qualité indisponible
+        )
+        result = asyncio.get_event_loop().run_until_complete(
+            build_act3_conclusion(
+                state, llm_callable=_stub_llm(_WOVEN_CONCLUSION)  # type: ignore[arg-type]
+            )
+        )
+        # Both motifs present, each under its own key.
+        assert "act3_conclusion" in result.degraded
+        assert "qualit" in result.degraded["act3_conclusion"].lower()
+        assert "act3_conclusion_thin" in result.degraded
+        assert "point faible" in result.degraded["act3_conclusion_thin"].lower()
+
     def test_g2_failure_flags_gate_note(self):
         """G2 fails when no axis is non-trivial but args exist (vacuous)."""
         state = _state(identified_arguments={"arg_1": "un argument sans analyse"})


### PR DESCRIPTION
Closes #1615. Signalé par `myia-po-2023` en review de #1612 comme un borderline de jugement ; la mesure a montré qu'il y avait un défaut sous le borderline.

## Le défaut

`act3_conclusion_plugin.py` écrivait `degraded["act3_conclusion"]` **deux fois** :

| ligne | condition | motif |
|---|---|---|
| 1096 | `not evidence.quality_axis_available` | « Axe qualité non concluable (`argument_quality_scores` indisponible) » — **la cause précise** |
| 1111 | `not is_virtuous and not evidence.weak_points` | « Aucun point faible localisé et aucun axe vertueux non-trivial » — **générique** |

Sur un run *thin* les deux conditions tiennent, et la seconde écrasait la première. Mesuré **par le vrai builder**, pas simulé :

```
status: woven | band: PASS | is_virtuous: False
degraded: ['act3_conclusion_gates', 'act3_conclusion']
  act3_conclusion = "Aucun point faible localisé…"      <- le générique
(le motif « axe qualité non concluable » a disparu)
```

Le lecteur recevait **la mauvaise raison** de la dégradation. C'est la famille du défaut 1 de #1608 — une absence dont la cause est remplacée par une autre — une couche plus bas.

## Le geste

La branche générique écrit désormais `act3_conclusion_thin`. Les deux motifs coexistent.

**Jumeaux vérifiés avant de généraliser** : `act1_framing` (3 clés) et `act2_narrative` (2 clés) écrivent des clés toutes distinctes. La collision est **isolée à act3** — ce n'est pas un motif répandu, et je ne corrige donc pas ailleurs.

**Aucun lecteur des clés de motif** en dehors du `_read_act_degraded` de #1614, qui les parcourt sans en nommer aucune. Renommer est sûr — vérifié par grep avant, pas supposé.

## Périmètre réduit par la mesure

Le DoD que j'avais écrit dans #1615 comptait deux points de plus : discriminer « l'analyse a tourné » de « rien n'a tourné », et garantir qu'un texte propre ne soit jamais marqué dégradé. **Une sonde les a rendus sans objet** :

```
CAS A — analyse tournée, axe qualité disponible, zéro faiblesse
status: woven | band: PASS | is_virtuous: True
degraded: []   bool(degraded) -> False
```

Un texte propre et réellement analysé sort par le chemin **vertueux**, donc la branche `not is_virtuous and …` ne peut pas se déclencher pour lui. Ces deux points étaient écrits depuis un raisonnement ; ils sont **retirés plutôt qu'implémentés**. Le correctif ne fait que ce qui est mesuré.

## Falsifiabilité

| substitution | morts | constatés |
|---|---|---|
| rétablir la clé unique (`act3_conclusion_thin` → `act3_conclusion`) | le test nommé, et lui seul | **1** |

`test_thin_run_keeps_both_motifs_instead_of_overwriting` reproduit le cas B par le vrai builder et affirme que **les deux** motifs sont présents, chacun sous sa clé.

## Pourquoi maintenant

Avant #1614 ces motifs mouraient sur l'état — `build_restitution_acts` ne lisait pas `restitution_acts_degraded`, la branche `⚠️ Acte dégradé` du renderer était inatteignable. #1614 leur donne un lecteur : **l'écrasement passe d'inoffensif à imprimé dans le rapport**. Et depuis #1608 `degraded` est un verdict (`bool(degraded)` retire la capacité de `capabilities_used`), donc le motif faux pèse aussi sur le décompte.

## Vérifications

- `tests/…/restitution/` : **257 passés** (256 + 1, delta prédit avant le run)
- `flake8` : propre sur les deux fichiers
- `black` : **0 ligne ajoutée** visée ; les 73 lignes que black veut toucher sont toutes préexistantes
- Privacy : aucun texte de corpus

Refs #1608, #1611, #1614.
