### PR TITLE
fix(restitution): give the conversational lane its missing degraded writer (#1618)

### DIFF
--- a/argumentation_analysis/reporting/restitution/conversational_adapter.py
+++ b/argumentation_analysis/reporting/restitution/conversational_adapter.py
@@ -36,7 +36,7 @@ boundary stays at the caller via ``output_path``).
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 from .act1_framing_plugin import LlmCallable, build_act1_framing
 from .act2_narrative_plugin import build_act2_narrative
@@ -117,7 +117,13 @@ async def generate_and_render_for_conversational_state(
     # plugin derives framing evidence from the state.
     try:
         act1 = await build_act1_framing(state, llm_callable=llm)
-        _persist_act(state, "act1_framing", act1.narrative, act1.status)
+        _persist_act(
+            state,
+            "act1_framing",
+            act1.narrative,
+            act1.status,
+            getattr(act1, "degraded", None),
+        )
     except Exception:  # noqa: BLE001 — one act failing must not abort the others
         logger.warning("Acte I framing failed (fail-loud, continuing): ", exc_info=True)
 
@@ -126,27 +132,63 @@ async def generate_and_render_for_conversational_state(
     # narrative can weave as "how the experts debated" material.
     try:
         act2 = await build_act2_narrative(state, llm_callable=llm)
-        _persist_act(state, "act2_narrative", act2.narrative, act2.status)
+        _persist_act(
+            state,
+            "act2_narrative",
+            act2.narrative,
+            act2.status,
+            getattr(act2, "degraded", None),
+        )
     except Exception:  # noqa: BLE001
-        logger.warning("Acte II narrative failed (fail-loud, continuing): ", exc_info=True)
+        logger.warning(
+            "Acte II narrative failed (fail-loud, continuing): ", exc_info=True
+        )
 
     # Acte III — actionable conclusion (gated verdict + balanced appréciations).
     try:
         act3 = await build_act3_conclusion(state, llm_callable=llm)
-        _persist_act(state, "act3_conclusion", act3.narrative, act3.status)
+        _persist_act(
+            state,
+            "act3_conclusion",
+            act3.narrative,
+            act3.status,
+            getattr(act3, "degraded", None),
+        )
     except Exception:  # noqa: BLE001
-        logger.warning("Acte III conclusion failed (fail-loud, continuing): ", exc_info=True)
+        logger.warning(
+            "Acte III conclusion failed (fail-loud, continuing): ", exc_info=True
+        )
 
     return render_spectacular_restitution(state, output_path=output_path)
 
 
-def _persist_act(state: Any, key: str, narrative: str, status: str) -> None:
-    """Write an act narrative onto the state if the state accepts the attribute.
+def _persist_act(
+    state: Any,
+    key: str,
+    narrative: str,
+    status: str,
+    degraded: Optional[Dict[str, str]] = None,
+) -> None:
+    """Write an act narrative — and its degradation motifs — onto the state.
 
     Skips silently when the state does not expose the attribute (defensive — the
     conversational state is a ``UnifiedAnalysisState`` which does, but the act
     generators are kept decoupled from the state class). Logs the act status so
     a fail-loud "unavailable" is traceable in the run log.
+
+    #1618 — the motifs used to be dropped here. This module is a deliberately
+    file-disjoint lane mirroring ``pipeline_adapter.py``, and that disjunction is
+    exactly how the twin drifted: the pipeline lane received the motif transport
+    (#1608) then its reader (#1614) while this one received neither, so
+    ``RestitutionActs.degraded`` was structurally always empty on a
+    conversational run — a reader with no writer. A report that cannot say it is
+    degraded reads as a healthier report, which biases any comparison between
+    the two orchestration modes.
+
+    **Twin**: ``state_writers._persist_act_degraded_reasons``. The semantics MUST
+    stay identical (same target field, same "only when non-empty" rule); the
+    agreement is pinned by ``test_both_lanes_agree_on_degraded`` rather than by
+    shared code, so it survives a refactor of either lane.
     """
     if not hasattr(state, key):
         logger.warning(
@@ -159,4 +201,22 @@ def _persist_act(state: Any, key: str, narrative: str, status: str) -> None:
         state[key] = narrative
     else:
         setattr(state, key, narrative)
-    logger.info("Restitution %s persisted (%d chars, status=%s)", key, len(narrative), status)
+    logger.info(
+        "Restitution %s persisted (%d chars, status=%s)", key, len(narrative), status
+    )
+
+    # Anti-pendule: an act that recorded no motif is never marked degraded by
+    # default — absence from the mapping is the honest state, not a gap to fill.
+    if not degraded:
+        return
+    rstd = getattr(state, "restitution_acts_degraded", None)
+    if not isinstance(rstd, dict):
+        logger.warning(
+            "State has no usable 'restitution_acts_degraded' mapping — %d "
+            "degradation motif(s) for '%s' dropped (fail-loud, #1618)",
+            len(degraded),
+            key,
+        )
+        return
+    rstd[key] = dict(degraded)
+    logger.info("Restitution %s degradation motifs persisted (%d)", key, len(degraded))

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_conversational_adapter.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_conversational_adapter.py
@@ -20,12 +20,15 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from argumentation_analysis.reporting.restitution.act1_framing_plugin import Act1Result
-from argumentation_analysis.reporting.restitution.act2_narrative_plugin import Act2Result
-from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import Act3Result
+from argumentation_analysis.reporting.restitution.act2_narrative_plugin import (
+    Act2Result,
+)
+from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+    Act3Result,
+)
 from argumentation_analysis.reporting.restitution.conversational_adapter import (
     generate_and_render_for_conversational_state,
 )
-
 
 # --- state stub (mirrors test_pipeline_adapter) ------------------------------
 
@@ -113,7 +116,9 @@ class TestGenerateAndRender:
         llm = AsyncMock(return_value="conducted narrative")
         p1, p2, p3 = _patched_act_builders()
         with p1 as m1, p2 as m2, p3 as m3:
-            await generate_and_render_for_conversational_state(state, "t", llm_callable=llm)
+            await generate_and_render_for_conversational_state(
+                state, "t", llm_callable=llm
+            )
             # each builder received the SAME injected llm_callable
             assert m1.call_args.kwargs.get("llm_callable") is llm
             assert m2.call_args.kwargs.get("llm_callable") is llm
@@ -237,3 +242,193 @@ class TestConversationalWiringContract:
         doc = run_conversational_analysis.__doc__ or ""
         assert "render_restitution" in doc
         assert "restitution_report" in doc
+
+
+# ============================================================================
+# #1618 — degradation motifs on the conversational lane
+#
+# #1608 gave the motifs a transport (state.restitution_acts_degraded) and #1614
+# gave them a reader (_read_act_degraded → RestitutionActs.degraded). Both hops
+# landed on the *pipeline* lane only. This module is a deliberately file-disjoint
+# lane, and that disjunction is exactly how the twin drifted: the conversational
+# adapter dropped ``ActNResult.degraded`` on the floor, so its report was
+# structurally incapable of saying it was degraded — a reader with no writer, on
+# one lane of two. A quieter report reads as a healthier report, which biases any
+# comparison of the two orchestration modes.
+#
+# The pinning below is therefore NOT "the writer exists" but "the two lanes agree"
+# — a property that survives a refactor of either lane, which shared code would
+# not. The degenerate substitutions that kill these tests are in the PR body.
+# ============================================================================
+
+
+_MOTIF1 = {
+    "act1_framing": "Enjeux non extraits (stakes vide) — cadrage limité, fail-loud."
+}
+_MOTIF2 = {"act2_narrative": "Axe qualité non concluable ici — vertus tues, fail-loud."}
+_MOTIF3 = {
+    "act3_conclusion_gates": "Gates G1–G4 : G2 non passé — wording de repli honnête.",
+    "act3_conclusion": "Axe qualité non concluable ici — appréciations limitées.",
+    "act3_conclusion_thin": "Aucun point faible localisé — pas de claim vertueux non dérivé.",
+}
+
+
+def _stub_state_with_degraded_map(**fields: object) -> SimpleNamespace:
+    """A stub state carrying the #1608 motif mapping (UnifiedAnalysisState has it)."""
+    state = _stub_state(**fields)
+    state.restitution_acts_degraded = {}
+    return state
+
+
+def _degraded_act_builders():
+    """Patch the 3 builders so each returns a narrative AND degradation motifs."""
+    return (
+        patch(
+            "argumentation_analysis.reporting.restitution.conversational_adapter."
+            "build_act1_framing",
+            new=AsyncMock(
+                return_value=Act1Result(
+                    narrative=_ACT1, status="woven", degraded=dict(_MOTIF1)
+                )
+            ),
+        ),
+        patch(
+            "argumentation_analysis.reporting.restitution.conversational_adapter."
+            "build_act2_narrative",
+            new=AsyncMock(
+                return_value=Act2Result(
+                    narrative=_ACT2, status="woven", degraded=dict(_MOTIF2)
+                )
+            ),
+        ),
+        patch(
+            "argumentation_analysis.reporting.restitution.conversational_adapter."
+            "build_act3_conclusion",
+            new=AsyncMock(
+                return_value=Act3Result(
+                    narrative=_ACT3, status="woven", degraded=dict(_MOTIF3)
+                )
+            ),
+        ),
+    )
+
+
+def _drive_pipeline_lane(state: SimpleNamespace) -> None:
+    """Feed the SAME motifs through the pipeline lane's state writers.
+
+    Mirrors what ``_invoke_actN_*`` hand to ``_write_actN_*_to_state``: the
+    narrative under the capability key, plus ``degraded_reasons``.
+    """
+    from argumentation_analysis.orchestration.state_writers import (
+        _write_act1_framing_to_state,
+        _write_act2_narrative_to_state,
+        _write_act3_conclusion_to_state,
+    )
+
+    for key, narrative, motifs, writer in (
+        ("act1_framing", _ACT1, _MOTIF1, _write_act1_framing_to_state),
+        ("act2_narrative", _ACT2, _MOTIF2, _write_act2_narrative_to_state),
+        ("act3_conclusion", _ACT3, _MOTIF3, _write_act3_conclusion_to_state),
+    ):
+        writer(
+            {key: narrative, "status": "woven", "degraded_reasons": dict(motifs)},
+            state,
+            {},
+        )
+
+
+class TestConversationalLaneDegradedMotifs:
+    async def test_persists_motifs_for_the_three_acts(self):
+        """The direct regression: the motifs must reach the state, not the floor."""
+        state = _stub_state_with_degraded_map()
+        p1, p2, p3 = _degraded_act_builders()
+        with p1, p2, p3:
+            await generate_and_render_for_conversational_state(
+                state, "t", llm_callable=AsyncMock()
+            )
+        assert state.restitution_acts_degraded == {
+            "act1_framing": _MOTIF1,
+            "act2_narrative": _MOTIF2,
+            "act3_conclusion": _MOTIF3,
+        }
+
+    async def test_report_names_the_degradation(self):
+        """End-to-end: a motif recorded upstream is visible to the reader."""
+        state = _stub_state_with_degraded_map()
+        p1, p2, p3 = _degraded_act_builders()
+        with p1, p2, p3:
+            report = await generate_and_render_for_conversational_state(
+                state, "t", llm_callable=AsyncMock()
+            )
+        assert "Acte dégradé" in report.markdown
+        # the motif TEXT reaches the page, not just the marker
+        assert "vertus tues" in report.markdown
+
+    async def test_act_without_motifs_stays_absent_from_the_map(self):
+        """Anti-pendule: a successful act is never marked degraded by default.
+
+        Absence from the mapping is the honest state, not a gap to fill. This is
+        the guard that must SURVIVE the fix — a writer that files an empty dict
+        per act would make every report look degraded.
+        """
+        state = _stub_state_with_degraded_map()
+        p1, p2, p3 = _patched_act_builders()  # builders return degraded={} by default
+        with p1, p2, p3:
+            report = await generate_and_render_for_conversational_state(
+                state, "t", llm_callable=AsyncMock()
+            )
+        assert state.restitution_acts_degraded == {}
+        assert "Acte dégradé" not in report.markdown
+
+    async def test_state_without_the_mapping_does_not_crash(self):
+        """Defensive: a state predating #1608 loses the motifs, never the run.
+
+        The narratives must still land — reporting never fails the analysis
+        (#1019/#369).
+        """
+        state = _stub_state()  # no restitution_acts_degraded attribute
+        p1, p2, p3 = _degraded_act_builders()
+        with p1, p2, p3:
+            report = await generate_and_render_for_conversational_state(
+                state, "t", llm_callable=AsyncMock()
+            )
+        assert state.act1_framing == _ACT1
+        assert state.act3_conclusion == _ACT3
+        assert "Acte I" in report.markdown
+
+    async def test_both_lanes_agree_on_degraded(self):
+        """THE item of #1618: same motifs in ⇒ same ``RestitutionActs.degraded`` out.
+
+        Pins the *property* rather than the implementation. The two lanes are
+        deliberately file-disjoint (one LLM resolution for three acts vs. three
+        kernels); merging them to share six lines of guard would be a pendulum.
+        What must not diverge is the observable: the target field, the per-act
+        key, and the join the renderer consumes. This test fails if either lane
+        drops the motifs, files them under a different key, or joins them
+        differently — including if only ONE lane is refactored.
+        """
+        from argumentation_analysis.reporting.restitution.pipeline_adapter import (
+            build_restitution_acts,
+        )
+
+        conv = _stub_state_with_degraded_map()
+        p1, p2, p3 = _degraded_act_builders()
+        with p1, p2, p3:
+            await generate_and_render_for_conversational_state(
+                conv, "t", llm_callable=AsyncMock()
+            )
+
+        pipe = _stub_state_with_degraded_map()
+        _drive_pipeline_lane(pipe)
+
+        # agreement at the transport…
+        assert conv.restitution_acts_degraded == pipe.restitution_acts_degraded
+        # …and at the shape the renderer actually consumes (key, sort, join)
+        assert (
+            build_restitution_acts(conv).degraded
+            == build_restitution_acts(pipe).degraded
+        )
+        # guard against a vacuous pass: both lanes agreeing on EMPTY proves nothing
+        assert build_restitution_acts(
+            conv
+        ).degraded, "sonde vide — les motifs n'ont pas circulé"


### PR DESCRIPTION
Ferme #1618.

`RestitutionActs.degraded` était structurellement toujours vide sur un run conversationnel : **un lecteur sans écrivain, sur une voie sur deux**. #1608 a donné aux motifs un transport (`state.restitution_acts_degraded`), #1614 leur a donné un lecteur — les deux sauts ont atterri sur la voie pipeline seulement. `conversational_adapter._persist_act` prenait `(state, key, narrative, status)` et jetait `ActNResult.degraded` sur place.

## Pourquoi ça compte au-delà du bug

Un des objectifs durables du dépôt est la **comparaison des modes d'orchestration**. Une voie qui ne *peut pas* rapporter sa dégradation pendant que l'autre le peut biaise toute comparaison : la conversationnelle paraît plus propre parce que sa dégradation est irrapportable, pas parce qu'elle est moindre. **Un rapport plus silencieux se lit comme un rapport plus sain.**

Et les motifs perdus ne sont pas décoratifs — ce sont exactement ceux que construisent les trois retours fail-loud de l'Acte III, plus le motif d'axe qualité indisponible et celui de run *thin* (#1615).

## Le correctif n'est pas seulement « ajouter le writer »

Le module se déclare explicitement « file-disjoint lane mirroring `pipeline_adapter.py` ». C'est une décision assumée (une résolution LLM pour trois actes vs. trois kernels) — et c'est le mécanisme exact par lequel le jumeau a dérivé : la voie pipeline a reçu #1608 puis #1614, la conversationnelle n'a rien reçu, et rien dans les tests ne l'a signalé.

Donc le correctif pose aussi **le dispositif qui attrape la prochaine dérive** : un test d'accord entre voies. Épingler la **propriété** est plus robuste que partager du code — ça survit à une refonte de l'une ou l'autre voie. Le docstring du writer **nomme son jumeau** (`state_writers._persist_act_degraded_reasons`) et nomme le test qui tient l'accord.

## Mesuré — la voie conversationnelle rejoint la pipeline au bit près

Sonde locale, mêmes motifs en entrée sur les deux voies, état réel (`UnifiedAnalysisState`), trois actes :

| | avant | après |
|---|---|---|
| `state.restitution_acts_degraded` (conv.) | `{}` | 3 actes, 5 motifs |
| `RestitutionActs.degraded` (conv.) | `{}` | 3 entrées |
| « Acte dégradé » dans le rendu conv. | ❌ | ✅ |
| **Accord conv. ⇄ pipeline** | **False** | **True** |

L'accord tient au **transport** (`restitution_acts_degraded` identique) *et* à la **forme que le renderer consomme** (clé par acte, tri, jointure).

⚠️ Le premier verdict `False` post-correctif était un **artefact de la sonde**, pas un défaut : son témoin pipeline ne pilotait qu'`_write_act3_conclusion_to_state` alors que la voie conversationnelle écrit trois actes. Comparaison remise à périmètre égal avant de conclure.

## Substitutions dégénérées — la règle encadrée des deux côtés

| substitution | tests morts |
|---|---|
| **1.** writer neutralisé (comportement d'avant #1618) | `persists_motifs_for_the_three_acts`, `report_names_the_degradation`, `both_lanes_agree_on_degraded` — **3** |
| **2.** garde anti-pendule retirée (`if not degraded: return`) | `act_without_motifs_stays_absent_from_the_map` — **1**, sous-ensemble **disjoint** |
| **3.** dépôt sous une autre clé (motifs présents, mal rangés) | les **mêmes 3** que (1) |

- (1) et (2) sont **disjoints** : ni l'un ni l'autre n'est un sous-ensemble. La règle est tenue des deux côtés — le writer doit écrire, *et* il ne doit pas écrire quand il n'y a rien.
- Sous (1), les deux gardes anti-pendule **survivent**, et c'est ce qu'on veut : elles assertent une **absence**, elles doivent rester vertes quand le writer disparaît. Un test qui mourrait là serait un test qui exige la dégradation.
- (3) est le discriminant du test d'accord : il prouve qu'il attrape une **dérive de forme**, pas seulement une **perte**. Motifs présents mais mal rangés meurt exactement comme motifs jetés.
- Le test d'accord porte enfin sa propre garde anti-vacuité : `assert build_restitution_acts(conv).degraded` — deux voies d'accord sur du **vide** ne prouveraient rien.

## Anti-pendule

- **Voies non fusionnées.** Leur disjonction est une décision documentée ; la casser pour partager six lignes de garde serait le pendule.
- **Duplication non silencieuse.** Le docstring nomme le jumeau et le test qui tient l'accord.
- **Aucun motif fabriqué** là où le générateur n'en a pas produit — un acte réussi n'est jamais marqué dégradé par défaut.
- **Reporting ne fait jamais échouer l'analyse** : un état antérieur à #1608 (sans le mapping) perd les motifs avec un log fail-loud, jamais le run. Épinglé.

## DoD

- [x] La voie conversationnelle persiste les motifs des trois actes dans `restitution_acts_degraded`
- [x] **Test d'accord entre voies** : mêmes motifs en entrée ⇒ même `RestitutionActs.degraded` en sortie
- [x] Le test échoue si on retire le nouveau writer (subst. 1) **et** si les deux voies divergent sur la forme (subst. 3)
- [x] Anti-pendule préservé sur les deux voies (subst. 2 le prouve mordant)
- [x] Aucun contenu de corpus — IDs opaques, fixtures synthétiques, aucun appel réseau

## Validation

- `tests/unit/argumentation_analysis/reporting/restitution/` : **269 passed** (5 nouveaux)
- `black --check` + `flake8` : propres sur les deux fichiers. ⚠️ `conversational_adapter.py` était **déjà** black-sale sur `main` dans les hunks touchés (vérifié par `git stash`) — le reformat inclut une ligne pré-existante entre deux de mes sites d'appel.

Trouvé en vérifiant que le lecteur de #1614 recevait bien quelque chose sur un chemin réel — le réflexe « vérifier les jumeaux » de #1615.

🤖 Coordinator ai-01
