### PR TITLE
fix(restitution): surface the fallacies no movement can carry (#1621)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -1100,6 +1100,31 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
                 )
         blocks.append("\n".join(lines))
 
+    # --- #1621: detections the movement enumeration structurally cannot carry ---
+    # Note (a) (#1153) added ``unattributed_fallacies`` so these would be
+    # "surfaced honestly rather than silently dropped (#1019)" — and then nothing
+    # read it. The promise lived only in the comment that made it.
+    #
+    # Why the enumeration above cannot stand in for this line: in
+    # ``build_act2_evidence`` the ``continue`` fires BEFORE the insertion into
+    # ``fallacy_by_arg``, so a fallacy with no resolvable target joins no
+    # movement; and ``fallacies_total`` increments AFTER it, so it is absent from
+    # the count too. Neither enumerated nor counted nor flagged — the exact
+    # definition of the silent drop the field was created to prevent. Contrast
+    # ``fallacies_total``, which IS recoverable here (the movement enumeration is
+    # uncapped) and is therefore deliberately left unwired: transport where the
+    # information already flows is #1019 read backwards.
+    unattributed_block = ""
+    if evidence.unattributed_fallacies:
+        unattributed_block = (
+            f"DÉTECTIONS NON RATTACHÉES : {evidence.unattributed_fallacies} "
+            f"sophisme(s) détecté(s) sans argument cible résolvable. Ils ne "
+            f"figurent dans AUCUN mouvement ci-dessus et ne sont pas comptés "
+            f"dans les dérapages localisés. Si tu les évoques, dis-le "
+            f"honnêtement — « non rattaché(s) à un argument identifié » — et "
+            f"ne leur invente NI cible NI mouvement d'accueil.\n\n"
+        )
+
     # --- formal anchors (verified-in-state) ---
     formal_block = "AUCUN verdict formel vérifié dans le state."
     if evidence.formal_findings:
@@ -1185,6 +1210,7 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
         f"{virtuous_section}"
         "DONNÉES VERIFIÉES DANS LE STATE (ne citer que celles-ci) :\n\n"
         f"{chr(10).join(blocks)}\n\n"
+        f"{unattributed_block}"
         f"TENUE FORMELLE (ancres vérifiées, à tisser comme PREUVE d'un battement) :\n"
         f"{formal_block}\n\n"
         f"DÉLIBÉRATION COLLECTIVE (governance + débat, à tisser dans le récit — "

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py
@@ -1031,3 +1031,106 @@ class TestAtt3RestitutionPolish1421:
         # The honest framing is preserved.
         assert "oracle externe" in dung.detail.lower()
 
+
+def _state_with_unattributed(n_unattributed: int) -> SimpleNamespace:
+    """One attributed fallacy, plus ``n_unattributed`` with no resolvable target.
+
+    The attributed one is held constant so the ONLY difference between two
+    states built here is the number of unattributed detections.
+    """
+    fallacies = {
+        "fl_att": {
+            "target_argument_id": "arg_1",
+            "family": "ad hominem",
+            "type": "ad hominem",
+            "justification": "attaque la personne",
+        }
+    }
+    for i in range(n_unattributed):
+        fallacies[f"fl_orphan_{i}"] = {
+            "target_argument_id": "",
+            "family": "fuite",
+            "type": "fuite en avant",
+            "justification": "sans cible résolvable",
+        }
+    return _state(
+        identified_arguments={"arg_1": "Claim."},
+        identified_fallacies=fallacies,
+    )
+
+
+class TestUnattributedFallaciesReachTheReader:
+    """#1621 — the field added to fix #1019 was itself an instance of it.
+
+    ``unattributed_fallacies`` was computed, stored, and never read. Its comment
+    promised the report would surface these detections as "non rattaché(s) à un
+    argument identifié"; that string existed only in the comment that promised
+    it.
+
+    These tests pin the *difference* rather than the computation. The pre-#1621
+    test (``test_note_a_unattributed_fallacies_traced``) asserts
+    ``ev.unattributed_fallacies == 1`` — true both before and after the defect
+    was introduced, which is exactly why it survived. An assertion on the
+    evidence object cannot see whether anything downstream consumes it.
+    """
+
+    def test_the_count_reaches_the_prompt(self):
+        ev = build_act2_evidence(_state_with_unattributed(2))
+        prompt = build_act2_prompt(ev)
+        assert "NON RATTACHÉES" in prompt
+        assert "2 sophisme(s)" in prompt
+        # The honest wording the comment promised, now actually emitted.
+        assert "non rattaché(s) à un argument identifié" in prompt
+
+    def test_silent_when_every_fallacy_is_attributed(self):
+        """Anti-pendule: absence of unattributed detections is not a gap to fill.
+
+        A systematic mention would be a false alarm on every clean run — the
+        pendulum swing (replacing a missing line with an always-present one).
+        """
+        ev = build_act2_evidence(_state_with_unattributed(0))
+        assert ev.unattributed_fallacies == 0
+        prompt = build_act2_prompt(ev)
+        assert "NON RATTACHÉES" not in prompt
+        assert "non rattaché" not in prompt
+
+    def test_prompts_differ_on_one_unattributed_detection(self):
+        """THE item of #1621: the same state ± one orphan fallacy ⇒ two prompts.
+
+        This is the property the wiring exists for. It fails if the count is
+        computed but not consumed — no matter how correct the computation is.
+        """
+        p0 = build_act2_prompt(build_act2_evidence(_state_with_unattributed(0)))
+        p1 = build_act2_prompt(build_act2_evidence(_state_with_unattributed(1)))
+        assert p0 != p1
+        # Guard against a vacuous pass: the difference must be the orphan line,
+        # not incidental noise elsewhere in the prompt.
+        assert "NON RATTACHÉES" in p1 and "NON RATTACHÉES" not in p0
+
+    def test_the_movement_enumeration_cannot_carry_them(self):
+        """Why the line is not redundant with the movements block.
+
+        The orphan is excluded from every movement by construction (the
+        ``continue`` fires before the insertion into ``fallacy_by_arg``) AND
+        excluded from ``fallacies_total`` (incremented after it). If a later
+        change ever attached orphans to an argument by heuristic — which G4 and
+        #1019 forbid, since no anchor exists — this test fails and says so.
+        """
+        ev = build_act2_evidence(_state_with_unattributed(3))
+        assert ev.unattributed_fallacies == 3
+        assert ev.fallacies_total == 1  # the attributed one only
+        enumerated = [
+            fl.type for mvt in ev.movements for a in mvt.arguments for fl in a.fallacies
+        ]
+        assert "fuite en avant" not in enumerated
+        assert enumerated == ["ad hominem"]
+
+    def test_count_is_not_folded_into_fallacies_total(self):
+        """``fallacies_total`` means "attributed" and is read as such elsewhere.
+
+        Folding the orphans in would put two meanings behind one key — the
+        defect #1615/#1616 just cost us on the act III side.
+        """
+        ev = build_act2_evidence(_state_with_unattributed(5))
+        assert ev.fallacies_total == 1
+        assert ev.unattributed_fallacies == 5


### PR DESCRIPTION
Ferme #1621. `Act2Evidence.unattributed_fallacies` était **écrit, jamais lu** — et le champ avait été ajouté par la Note (a) (#1153) précisément pour empêcher un `#1019`.

## Le défaut

Le commentaire de la déclaration (act2:279-283) promet :

> These cannot join a movement beat, but they **ARE counted (here) rather than silently dropped (#1019)** — the LLM/rapport **surfaces them honestly as "non rattaché(s) à un argument identifié"**.

`grep -rn "non rattaché\|unattributed"` en production ne retournait que la déclaration, le commentaire, l'incrément et le passage au constructeur. **Zéro lecteur.** La chaîne promise n'existait que dans le commentaire qui la promet.

## Pourquoi la perte est totale et non partielle

Dans `build_act2_evidence`, le `continue` est **avant** l'insertion dans `fallacy_by_arg` — l'orphelin ne rejoint aucun mouvement ; et `fallacies_total` s'incrémente **après** — il est aussi absent du total. Ni énuméré, ni compté, ni signalé. C'est la définition exacte du « silently dropped » que le champ existait pour empêcher.

C'est ce qui distingue ce champ des autres non-lus du même bundle : l'énumération du prompt **ne peut pas** le suppléer, parce que ces détections en sont exclues par construction.

## Mesure sur artefacts réels

Sonde sur les 8 états sérialisés disponibles (`evaluation/results/`, gitignoré) : **4 détections orphelines réparties sur 4 artefacts sur 8**, contre 245 attribuées. Volume faible, perte totale. `dangling = 0` — le problème est bien l'absence de cible, pas une référence cassée, donc il n'y a pas de second mode de perte à traiter en même temps.

## Le correctif

`build_act2_prompt` émet une ligne d'absence honnête **quand et seulement quand** le compte est non nul, alignée sur la convention déjà présente dans le fichier (l.1081 « axe non concluable », l.1102 « AUCUN verdict formel vérifié », l.1166 « ne la fabrique pas, note l'absence honnêtement »).

## Falsifiabilité — 3 substitutions dégénérées, 3 ensembles distincts

| substitution | morts | lesquels |
|---|---|---|
| raccord coupé (le bloc n'atteint plus le prompt) | **2** | `count_reaches_the_prompt` + `prompts_differ` |
| garde anti-pendule retirée (émis même à 0) | **2** | `silent_when_every_fallacy_is_attributed` + `prompts_differ` |
| **le faux-fix interdit** : rattacher l'orphelin par heuristique | **3** | `movement_enumeration_cannot_carry_them`, `count_is_not_folded_into_fallacies_total`, + le test Note (a) préexistant |

Les deux premiers ensembles sont **partiellement disjoints** : chaque direction est épinglée indépendamment, et `prompts_differ` tombe dans les deux — c'est sa fonction, c'est le test de la propriété.

Le test préexistant (`test_note_a_unresolved_fallacy_traced_not_dropped`, l.553-555) assertait `ev.unattributed_fallacies == 1` : vrai avant comme après l'introduction du défaut. **Une assertion sur l'objet d'évidence ne peut pas voir si quelqu'un le consomme en aval** — c'est exactement pourquoi le défaut a survécu, et pourquoi les nouveaux tests portent sur la **différence** entre deux prompts.

## Anti-pendule — ce qui n'a délibérément PAS été fait

- **Pas de rattachement heuristique.** Ces sophismes n'ont pas d'ancre ; en fabriquer une est ce que G4 et #1019 interdisent. On dit qu'ils existent **sans les localiser**.
- **Pas de fusion dans `fallacies_total`.** Ce total signifie « attribués » et est lu comme tel. Deux sens derrière une clé, c'est #1615/#1616, qu'on vient de payer sur l'Acte III.
- **`Act2Evidence.fallacies_total` reste non câblé.** Il est également sans lecteur, mais **honnêtement redondant** : l'énumération des mouvements est non cappée (`for mvt` / `for a` / `for fl`, aucun slice), donc le lecteur peut compter. Ajouter du transport là où l'information circule déjà, c'est #1019 pris à l'envers.

## Tests

274 verts sur `tests/unit/argumentation_analysis/reporting/restitution/` (269 avant + 5). flake8 propre sur les deux fichiers.

⚠️ **Note sur black** : les deux fichiers étaient **déjà** black-dirty à `HEAD` avant ce changement (vérifié par `git stash`), et `ci.yml:37` marque l'étape black `continue-on-error: true — codebase not yet fully black-formatted`. Je n'ai donc **pas** reformaté les 6 hunks préexistants (ils ne sont pas à moi et ajouteraient du bruit) — seulement mes propres lignes, qui ne produisent plus aucun hunk black.

## Contexte

Trouvé par balayage exhaustif des 39 champs des trois bundles d'évidence, côté lecteur : 5 champs à zéro lecteur, scindés par « l'énumération peut-elle porter l'info ? ». Celui-ci est le premier des deux irrécupérables ; l'autre est #1622 (Acte III, sérialisée derrière #1609). Famille #1019, après #1618 et #1620.

🤖 Coordinator ai-01
