### PR TITLE
test(restitution): pin the two state-reading surfaces (#1624, DoD 1)

### DIFF
--- a/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
@@ -1,0 +1,157 @@
+"""#1624 — pin the relation between the two state-reading surfaces in restitution.
+
+The restitution reads the shared state through TWO divergent surfaces:
+
+1. PROSE — ``build_act{1,2,3}_evidence(state)`` in the ``act*_plugin`` modules
+   reads its axes via ``getattr(state, "<key>")`` / ``state["<key>"]`` and feeds
+   the three-act narrative (the conducted prompt).
+2. ANNEXE — ``state_adapter._STATE_KEYS`` enumerates the axes the appendix
+   attests as "disponible", and ``appendix._provenance_counts`` renders them.
+
+Same state, two reading lists, different keys. Before this guard, a future
+divergence (an axis added to one surface but not the other) would pass
+silently — the report could attest "disponible" for an axis the conclusion
+never mobilised, or omit one it did. This module pins the relation explicitly
+so any divergence fails instead of drifting.
+
+The file-disjoint wiring is deliberate (``state_adapter.py`` header, lines 6-8):
+the adapter does not import the prose plugins, and the plugins do not import
+``_STATE_KEYS``. The two lists are not mutualised — THIS TEST carries the
+accord between them (same shape as the #1619 corrective).
+
+Falsifiability — two degenerate substitutions with disjoint kill-sets:
+
+* **Sub A** — remove ``"aspic_results"`` from ``state_adapter._STATE_KEYS``:
+  ``annexe - prose`` loses that key, so ``test_annexe_prose_relation_is_pinned``
+  fails (``ANNEXE_ONLY`` still contains it). ``test_ast_prose_matches_baseline``
+  survives (it does not read ``_STATE_KEYS``). Kill-set = {relation}.
+* **Sub B** — delete the ``getattr(state, "deanonymized", ...)`` call in
+  ``act1_framing_plugin.build_act1_evidence``: the AST extraction loses
+  ``deanonymized``, so ``test_ast_prose_matches_baseline`` fails
+  (``PROSE_BASELINE`` still contains it). ``test_annexe_prose_relation_is_pinned``
+  survives (it compares against the literal, not the AST). Kill-set = {baseline}.
+
+The two substitutions kill different tests, so neither assertion is vacuous.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+from argumentation_analysis.reporting.restitution import state_adapter as _sa
+from argumentation_analysis.reporting.restitution.state_adapter import _STATE_KEYS
+
+# The prose modules live alongside state_adapter in the same package — locate
+# them via the package path rather than counting parents from this test file.
+_BASE = pathlib.Path(_sa.__file__).resolve().parent
+_PROSE_MODULES = (
+    "act1_framing_plugin.py",
+    "act2_narrative_plugin.py",
+    "act3_conclusion_plugin.py",
+)
+
+
+def _prose_keys_read_from_state() -> set[str]:
+    """Conservative superset of state keys read by the three prose modules.
+
+    Walks every ``getattr(state, "<key>")`` and ``state["<key>"]`` across the
+    act-plugin modules. These modules contain only prose code, so every state
+    access in them is on the prose reading surface — including accesses inside
+    the helpers that ``build_act{1,2,3}_evidence`` delegates to (e.g.
+    ``_derive_genre``, ``detect_virtuous_mode``).
+    """
+    keys: set[str] = set()
+    for mod in _PROSE_MODULES:
+        tree = ast.parse((_BASE / mod).read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "getattr"
+                and len(node.args) >= 2
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id == "state"
+                and isinstance(node.args[1], ast.Constant)
+            ):
+                keys.add(node.args[1].value)
+            if (
+                isinstance(node, ast.Subscript)
+                and isinstance(node.value, ast.Name)
+                and node.value.id == "state"
+                and isinstance(node.slice, ast.Constant)
+            ):
+                keys.add(node.slice.value)
+    return keys
+
+
+# The state keys the three act modules read off ``state`` to build their
+# evidence (the PROSE surface). AST-derived conservative superset of the
+# transitive accesses made by ``build_act{1,2,3}_evidence`` and its delegates.
+#
+# Note: ``structured_arg_status`` IS read by the prose (act3 conclusion,
+# ``build_act3_evidence`` → the honest-absence ledger at l.685), so it is NOT
+# annexe-only despite living in ``_STATE_KEYS`` — it sits in the intersection.
+PROSE_BASELINE = frozenset(
+    {
+        "argument_quality_scores",
+        "counter_arguments",
+        "deanonymized",
+        "debate_transcripts",
+        "dung_frameworks",
+        "fol_analysis_results",
+        "governance_decisions",
+        "identified_arguments",
+        "identified_fallacies",
+        "modal_analysis_results",
+        "narrative_synthesis",
+        "propositional_analysis_results",
+        "source_metadata",
+        "stakes_and_stakeholders",
+        "structured_arg_status",
+    }
+)
+
+# Axes the ANNEXE attests (``state_adapter._STATE_KEYS``) that the PROSE never
+# reads — declared "disponible" in the appendix table but absent from the
+# conclusion's conducted prompt.
+ANNEXE_ONLY = frozenset(
+    {
+        "aspic_results",
+        "formal_synthesis_reports",
+        "workflow_results",
+    }
+)
+
+# Axes the PROSE reads that the ANNEXE never attests — mobilised by the
+# conclusion but invisible to the appendix provenance table.
+PROSE_ONLY = frozenset(
+    {
+        "deanonymized",
+        "debate_transcripts",
+        "governance_decisions",
+    }
+)
+
+
+def test_ast_prose_matches_baseline() -> None:
+    """The AST extraction of prose state reads equals the declared baseline.
+
+    Catches both directions: a new ``getattr(state, X)`` in a prose module
+    without a baseline update, or a stale baseline entry the prose no longer
+    reads.
+    """
+    assert _prose_keys_read_from_state() == PROSE_BASELINE
+
+
+def test_annexe_prose_relation_is_pinned() -> None:
+    """The annexe/prose divergence is exactly ANNEXE_ONLY / PROSE_ONLY.
+
+    If a future change adds an axis to one surface without the other, the
+    set difference shifts and this assertion fails — the divergence becomes a
+    deliberate update to these two frozensets, not a silent drift.
+    """
+    annexe = set(_STATE_KEYS)
+    prose = set(PROSE_BASELINE)
+    assert annexe - prose == ANNEXE_ONLY
+    assert prose - annexe == PROSE_ONLY


### PR DESCRIPTION
## #1624 — pin the two state-reading surfaces (DoD item 1, the core)

The restitution reads the shared state through **two divergent surfaces**:

| Surface | What reads | Keys | Feeds |
|---|---|---|---|
| **PROSE** | `build_act{1,2,3}_evidence(state)` via `getattr(state, "<key>")` / `state["<key>"]` | 15 (AST-derived) | the three-act conducted prompt |
| **ANNEXE** | `state_adapter._STATE_KEYS` + `appendix._provenance_counts` via `state.get` | 15 (declared) | the appendix provenance table |

Same state, two key lists, different members. Before this guard, a future divergence (an axis added to one surface but not the other) passed silently — the report could attest **"disponible" for an axis the conclusion never mobilised**, or omit one it did.

This PR adds a guard that **pins the relation** so any divergence fails instead of drifting.

### The guard

`tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py`:

- **`test_ast_prose_matches_baseline`** — the AST extraction of every `getattr(state, …)` / `state[…]` across the three `act*_plugin` modules equals the declared `PROSE_BASELINE`. Catches both directions: a new prose read without a baseline update, or a stale entry no longer read.
- **`test_annexe_prose_relation_is_pinned`** — `set(_STATE_KEYS) − PROSE_BASELINE == ANNEXE_ONLY` and the reverse == `PROSE_ONLY`. A divergence shifts the difference and fails.

### Anti-pendule: no constant mutualisation

The file-disjoint wiring is **deliberate** (`state_adapter.py:6-8`): the adapter does not import the prose plugins, and the plugins do not import `_STATE_KEYS`. The two lists are **not** mutualised — the **test** carries the accord between them (same shape as the #1619 corrective). I did not extract a shared constant to "align" the two files.

### The pinned relation (today)

| Diff | Members |
|---|---|
| `ANNEXE_ONLY` (attested "disponible", never mobilised by the conclusion) | `aspic_results`, `formal_synthesis_reports`, `workflow_results` |
| `PROSE_ONLY` (mobilised by the conclusion, invisible to the appendix) | `deanonymized`, `debate_transcripts`, `governance_decisions` |

> **The guard caught a latent misclassification on arrival.** A static read of `_STATE_KEYS` suggested `structured_arg_status` was annexe-only. The AST extraction revealed the prose *does* read it (act3 conclusion, the honest-absence ledger at `act3_conclusion_plugin.py:685`) — so it sits in the **intersection**, not annexe-only. This is exactly the silent drift the guard exists to catch; it is now correctly pinned in `PROSE_BASELINE`.

### Falsifiability — two degenerate substitutions, disjoint kill-sets

Verified on the pure sets (probe, not committed):

| Substitution | `test_ast_prose_matches_baseline` | `test_annexe_prose_relation_is_pinned` |
|---|---|---|
| (none — GREEN) | ✅ pass | ✅ pass |
| **Sub A** — drop `aspic_results` from `_STATE_KEYS` | ✅ survives | ❌ **kills** (diff loses the key) |
| **Sub B** — drop `getattr(state, "deanonymized", …)` from `act1` | ❌ **kills** (AST loses the key) | ✅ survives |

Disjoint kill-sets → neither assertion is vacuous.

### Scope

- **Files**: `state_adapter.py` (read), `appendix.py` (read), the three `act*_plugin.py` (read-only for the list). **No production code changed** — item 1 is a pure guard.
- **Out of scope here (follow-up PRs)**: DoD items 2 and 3.
  - **Item 2** (3-state wording: absent / présent+mobilisé / présent non-mobilisé) rewords the existing `axe_*` assertions across the 23-test appendix suite (`axe_pl == "disponible"`, etc.) and warrants a focused PR rather than being mixed into the guard.
  - **Item 3** (add the prose-only axes `debate_transcripts` / `governance_decisions` to the annexe, justify `deanonymized` omission) is the natural companion to item 2.

### Validation

- `pytest tests/unit/argumentation_analysis/reporting/restitution/` → **308 passed** (was 306; +2 here, 0 regressions).
- `black --check` clean.
- mypy: the test file is not in the 8-file CI gate; no prod files touched.

Privacy: opaque IDs only, no corpus content.

🤖 Worker myia-po-2023 — #1624 DoD item 1
