### PR TITLE
feat(cache): commit cassette + replay round-trip probe (#1603, item 1/3)

### DIFF
--- a/scripts/cassettes/__init__.py
+++ b/scripts/cassettes/__init__.py
@@ -1,0 +1,32 @@
+"""Cassettes LLM : record→export→commit→import→replay (#1603).
+
+The runtime LLM cache (`argumentation_analysis.services.llm_cache`) uses
+`diskcache.Cache` (SQLite-backed) under `LLM_CACHE_DIR`. Runtime caches are
+gitignored; fixtures committed to `tests/fixtures/llm_cassettes/` need a
+diff-friendly representation.
+
+Workflow:
+
+1.  **Record** — set ``LLM_CACHE_MODE=record`` and ``LLM_CACHE_DIR`` to the
+    runtime location. Run the test suite (or selected tests). The runtime DB
+    grows.
+2.  **Export** — ``python scripts/cassettes/export.py <runtime_db_dir>
+    <fixtures_dir>``. Reads each ``cache.db`` entry, audits the value for
+    forbidden plaintext fields (`raw_text`, `full_text`, etc.) and writes
+    one ``<sha256>.json`` per entry under ``fixtures_dir``. Each file holds
+    the serialized response only — the prompt is recomputed from the
+    request.
+3.  **Commit** — the fixtures directory. Git diffs line-oriented JSON.
+4.  **Replay** — ``python scripts/cassettes/import.py <fixtures_dir> <db_dir>``
+    populates a DB from the fixtures, then ``LLM_CACHE_MODE=replay`` replays.
+    A miss in replay raises ``LLMCacheMiss`` (fail-loud).
+
+This module stays read-only on the cache layer: it never modifies
+`llm_cache.py`. The exported format is the literal output of
+`_serialize_response` (list[dict]) and `_serialize_chat_completion` (dict)
+in llm_cache.py — round-tripped through ``_deserialize_*`` and
+``ChatCompletion.model_validate``.
+
+Privacy: see ``scripts/cassettes/privacy_audit.py`` for the forbidden-fields
+list and the probe that runs before export.
+"""

--- a/scripts/cassettes/export.py
+++ b/scripts/cassettes/export.py
@@ -1,0 +1,119 @@
+"""Export LLM cache entries from a runtime diskcache DB to JSON fixtures.
+
+Usage::
+
+    python scripts/cassettes/export.py <source_db_dir> <fixtures_dir>
+
+Source DB layout (produced by `llm_cache.CachedChatCompletion` at runtime):
+
+    <source_db_dir>/cache.db        # SQLite, opened as diskcache.Cache
+
+Each entry has:
+- key: hex sha256 string (32 chars)
+- value: JSON list-of-dicts (SK-path: `_serialize_response`)
+       OR JSON dict (raw-path: `_serialize_chat_completion`)
+
+The fixtures layout is:
+
+    <fixtures_dir>/<sha256>.json    # {"key": "...", "value": [...] or {...}}
+
+If `value` fails the privacy audit (see ``privacy.audit_value``), the
+script refuses to write that cassette and exits with code 2. A summary is
+printed at the end (cassettes exported, refused, total).
+
+Why one-file-per-cassette: PR diffs become readable; partial fixes can be
+targeted; git blame stays useful. The DB format (SQLite) is opaque to the
+auditor — JSON files make the privacy check possible without parsing
+SQLite.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Allow `python scripts/cassettes/export.py` invocation from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+import diskcache  # type: ignore[import-not-found]
+
+from scripts.cassettes.privacy import assert_safe, audit_value
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument(
+        "source_dir",
+        type=Path,
+        help="Runtime diskcache directory (e.g. .cache/llm_responses)",
+    )
+    p.add_argument(
+        "fixtures_dir",
+        type=Path,
+        help="Destination directory for JSON cassette fixtures",
+    )
+    p.add_argument(
+        "--allow-unsafe",
+        action="store_true",
+        help="Skip privacy audit (DO NOT USE without explicit review, #1603)",
+    )
+    return p.parse_args(argv)
+
+
+def export_one(db: diskcache.Cache, key: str, value, fixtures_dir: Path, *, allow_unsafe: bool) -> str:
+    """Write one cassette. Returns 'ok' | 'unsafe' | 'already'."""
+    out = fixtures_dir / f"{key}.json"
+    if out.exists():
+        return "already"
+    if not allow_unsafe:
+        violations = audit_value(value, source=f"cassette {key[:16]}")
+        if violations:
+            return "unsafe"
+    out.write_text(
+        json.dumps({"key": key, "value": value}, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return "ok"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.source_dir.exists():
+        print(f"Source DB dir does not exist: {args.source_dir}", file=sys.stderr)
+        return 1
+    args.fixtures_dir.mkdir(parents=True, exist_ok=True)
+
+    db = diskcache.Cache(str(args.source_dir))
+    try:
+        total = len(db)
+        if total == 0:
+            print(f"No entries in {args.source_dir}; nothing to export.", file=sys.stderr)
+            return 0
+
+        counts: dict[str, int] = {"ok": 0, "already": 0, "unsafe": 0}
+        unsafe_keys: list[str] = []
+        for key in db.iterkeys():
+            value = db[key]
+            status = export_one(db, key, value, args.fixtures_dir, allow_unsafe=args.allow_unsafe)
+            counts[status] = counts.get(status, 0) + 1
+            if status == "unsafe":
+                unsafe_keys.append(key[:16])
+    finally:
+        db.close()
+
+    print(f"Source: {args.source_dir}")
+    print(f"Fixtures: {args.fixtures_dir}")
+    print(f"Total entries: {total}")
+    print(f"Exported: {counts['ok']}")
+    print(f"Already present: {counts['already']}")
+    print(f"Refused (privacy): {counts['unsafe']}")
+    if unsafe_keys:
+        print(f"Refused cassettes (first 16 chars of key): {unsafe_keys}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cassettes/import.py
+++ b/scripts/cassettes/import.py
@@ -1,0 +1,96 @@
+"""Import LLM cassettes from JSON fixtures into a runtime diskcache DB.
+
+Usage::
+
+    python scripts/cassettes/import.py <fixtures_dir> <target_db_dir>
+
+Target DB layout (consumed by `llm_cache.CachedChatCompletion` at replay):
+
+    <target_db_dir>/cache.db        # SQLite, opened as diskcache.Cache
+
+Each fixture file `<sha256>.json` holds ``{"key": sha256, "value": ...}``
+— the ``value`` is the literal output of `_serialize_response` /
+`_serialize_chat_completion`. Round-tripped through the matching
+`_deserialize_*` at replay.
+
+This is the inverse of ``export.py``. No privacy audit is run on import
+because the audit ran at export time and any new cassette written to the
+fixtures dir would have failed it. Re-running the export after an import
+should be idempotent.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+# Allow `python scripts/cassettes/import.py` invocation from the repo root.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent))
+
+import diskcache  # type: ignore[import-not-found]
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument(
+        "fixtures_dir",
+        type=Path,
+        help="Directory containing <sha256>.json cassette files",
+    )
+    p.add_argument(
+        "target_dir",
+        type=Path,
+        help="Runtime diskcache directory to populate (e.g. .cache/llm_responses)",
+    )
+    p.add_argument(
+        "--purge",
+        action="store_true",
+        help="Purge the target DB before import (otherwise merge)",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    if not args.fixtures_dir.exists():
+        print(f"Fixtures dir does not exist: {args.fixtures_dir}", file=sys.stderr)
+        return 1
+    args.target_dir.mkdir(parents=True, exist_ok=True)
+
+    db = diskcache.Cache(str(args.target_dir))
+    try:
+        if args.purge:
+            db.clear()
+        existing = set(db.iterkeys())
+
+        written = 0
+        skipped = 0
+        bad = 0
+        for path in sorted(args.fixtures_dir.glob("*.json")):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            key = data.get("key")
+            value = data.get("value")
+            if not isinstance(key, str) or value is None:
+                print(f"Malformed cassette: {path.name}", file=sys.stderr)
+                bad += 1
+                continue
+            if key in existing:
+                skipped += 1
+                continue
+            db.set(key, value)
+            written += 1
+    finally:
+        db.close()
+
+    print(f"Fixtures: {args.fixtures_dir}")
+    print(f"Target: {args.target_dir}")
+    print(f"Written: {written}")
+    print(f"Skipped (already present): {skipped}")
+    print(f"Malformed: {bad}")
+    return 0 if bad == 0 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cassettes/privacy.py
+++ b/scripts/cassettes/privacy.py
@@ -1,0 +1,109 @@
+"""Privacy audit for recorded LLM cassettes (#1603).
+
+A cassette contains the LLM response, optionally with metadata. Per project
+policy, no plaintext dataset content may appear in committed fixtures:
+
+- raw_text / full_text / full_text_segment / raw_text_snippet (forbidden keys)
+- Source names (heuristic — year ranges + author hints; PROVEN absent in the
+  recorded subset used for the probe)
+- Encrypted ciphertext is allowed (cannot be decrypted without the passphrase;
+  useless alone)
+
+The audit is a *blocking* gate at export time: a cassette with any forbidden
+field listed raises and refuses to write.
+
+Why blocking rather than warning: a silent privacy leak onto a tracked
+surface (GitHub search index) is a release-blocker, not a lint warning.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Iterable
+
+# Forbidden plaintext keys — checked recursively in any dict / list element.
+# Names mirror `argumentation_analysis.core.io_manager` extraction schema.
+FORBIDDEN_KEYS = frozenset((
+    "raw_text",
+    "full_text",
+    "full_text_segment",
+    "raw_text_snippet",
+    "passphrase",  # never commit derived secrets
+))
+
+# Heuristic: politically sensitive corpus sources the dataset can contain.
+# If any name appears in a cassette, the audit fails.
+# Source: project CLAUDE.md "Dataset Privacy Discipline" + the canonical
+# dataset is political speeches (historical dictators, current heads of state).
+# This list is intentionally narrow — broader NER catches false positives.
+# Last update: 2026-08-06 (#1603 R758).
+SOURCE_NAME_HINTS = (
+    "Trump", "Biden", "Macron", "Le Pen", "Mélenchon", "Melenchon",
+    "Poutine", "Zelensky", "Zelenskyy", "Mussolini", "Hitler",
+    "Pétain", "Petain", "Staline", "Stalin",
+    "Bachelet", "Milei", "Bolsonaro", "Orbán", "Orban",
+)
+
+# Historical political date range — corpus contains (year: 1933-2026).
+DATE_RE = re.compile(r"\b(19[3-9]\d|20[0-2]\d)\b")
+
+
+def audit_value(value: Any, *, source: str = "<unknown>") -> list[str]:
+    """Return a list of privacy violation descriptions (empty == safe).
+
+    Walks ``value`` recursively and checks for any forbidden key, source
+    name, or historical political date. Strict-mode is intentional: a
+    cassette that fails this audit cannot be committed.
+    """
+    violations: list[str] = []
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for k, v in node.items():
+                if k in FORBIDDEN_KEYS:
+                    violations.append(
+                        f"{source}: forbidden key {k!r} at {path}.{k}"
+                    )
+                walk(v, f"{path}.{k}" if path else k)
+        elif isinstance(node, list):
+            for i, item in enumerate(node):
+                walk(item, f"{path}[{i}]")
+        elif isinstance(node, str):
+            # Source name / date hints — only on text-sized strings, not on
+            # the role field etc. (which is short anyway).
+            if len(node) < 20:
+                return
+            for name in SOURCE_NAME_HINTS:
+                if name in node:
+                    violations.append(
+                        f"{source}: source-name hint {name!r} found at {path}"
+                    )
+                    break  # one report per node is enough
+            for year in DATE_RE.findall(node):
+                # 1933..2026 are the politically sensitive corpus years.
+                # Earlier (1920s debates etc.) would slip by design — broader
+                # range adds false positives on test fixtures.
+                violations.append(
+                    f"{source}: historical-year hint {year} found at {path}"
+                )
+
+    walk(value, "")
+    return violations
+
+
+def assert_safe(value: Any, *, source: str) -> None:
+    """Raise ``PrivacyViolation`` if ``value`` fails the audit."""
+    v = audit_value(value, source=source)
+    if v:
+        raise PrivacyViolation(v)
+
+
+class PrivacyViolation(RuntimeError):
+    """Raised when an LLM cassette response contains forbidden content."""
+
+    def __init__(self, violations: list[str]) -> None:
+        super().__init__(
+            "Cassette refused — privacy violations:\n  - " + "\n  - ".join(violations)
+        )
+        self.violations = violations

--- a/tests/fixtures/llm_cassettes/3bc939106c8f81270bd0d4ea58a057f48b2659747e3745898a7966d0e9c34e6b.json
+++ b/tests/fixtures/llm_cassettes/3bc939106c8f81270bd0d4ea58a057f48b2659747e3745898a7966d0e9c34e6b.json
@@ -1,0 +1,16 @@
+{
+  "key": "3bc939106c8f81270bd0d4ea58a057f48b2659747e3745898a7966d0e9c34e6b",
+  "value": [
+    {
+      "role": "assistant",
+      "content": "arg_1 — L’analyse converge: cet argument est identifié comme un sophisme (sophisme: straw_man), reçoit une évaluation quantitative très basse (qualite faible: 2.5/10) et n’est assorti que d’un seul élément de réfutation (contre-argument: 1). Le label sophisme: straw_man signale une distorsion formelle de la position adverse (détournement ou caricature de la thèse attaquée), tandis que qualite faible: 2.5/10 fournit une mesure indépendante de la faiblesse globale (manque de rigueur, de preuve ou de cohérence). Le faible nombre de répliques effectives (contre-argument: 1) indique en outre une pauvreté des ressources argumentatives disponibles pour soutenir ou défendre la formulation proposée.  \n\nConclusion substantielle — La convergence de ces trois méthodes rend la faiblesse d’arg_1 surdéterminée : le sophisme structurel (sophisme: straw_man) montre que la faiblesse ne tient pas seulement à un détail factuel mais au mode même d’argumenter (déformation), la notation faible (qualite faible: 2.5/10) corrobore objectivement l’absence de fondement et de solidité, et l’unique contre-argument (contre-argument: 1) révèle l’insuffisance de redressement ou de défense possible. Ensemble, ces éléments montrent que la fragilité de l’argument est systémique — elle combine une erreur logique, un déficit qualitatif et un manque de réponses — et ne peut donc être attribuée à une simple omission circonstancielle.",
+      "metadata": {
+        "logprobs": null,
+        "id": "gen-1786030328-qPxQ3MKX5ggGuIJ3ogSQ",
+        "created": 1786030328,
+        "system_fingerprint": null,
+        "usage": "prompt_tokens=280 prompt_tokens_details=PromptTokensDetails(audio_tokens=0, cached_tokens=0, cache_write_tokens=0, video_tokens=0) completion_tokens=1519 completion_tokens_details=CompletionTokensDetails(accepted_prediction_tokens=None, audio_tokens=0, reasoning_tokens=1152, rejected_prediction_tokens=None, image_tokens=0)"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/llm_cassettes/README.md
+++ b/tests/fixtures/llm_cassettes/README.md
@@ -1,0 +1,75 @@
+# LLM Cassettes — tracktes fixtures for offline replay (#1603)
+
+This directory holds a **deterministic, audited subset** of LLM responses
+used by `tests/unit/.../test_cassette_round_trip.py` to prove the
+record/export/import/replay loop end-to-end.
+
+## Why
+
+- `argumentation_analysis.services.llm_cache` supports `off` / `record` /
+  `replay` modes. `record` writes to a runtime diskcache DB under
+  `LLM_CACHE_DIR` (default `.cache/llm_responses`, gitignored). `replay`
+  reads from this DB and raises `LLMCacheMiss` on a miss — never falls back
+  silently to a live call.
+- The runtime DB is opaque (SQLite, binary). This directory holds a
+  diff-friendly export: one `<sha256>.json` per cassette, each containing
+  `{"key": sha256, "value": <serialized LLM response>}`.
+- Each cassette was recorded against a **synthetic test fixture** (no
+  plaintext dataset content). Privacy audit at export time is blocking —
+  see `scripts/cassettes/privacy.py` for the forbidden-key list.
+
+## Layout
+
+Each file: `<sha256>.json`. The sha256 is the cache key computed by
+`llm_cache.compute_cache_key` over (model_id, messages, temperature, tools)
+— deterministic across runs.
+
+## Usage
+
+Recording a new cassette (manual workflow, NOT part of the default tests):
+
+```bash
+# 1. Run the test with `record` mode into a clean DB:
+LLM_CACHE_MODE=record LLM_CACHE_DIR=.cache/llm_record \
+  conda run -n projet-is-roo-new pytest \
+    tests/unit/argumentation_analysis/plugins/test_narrate_convergence.py::TestNarrateConvergenceIntegration
+
+# 2. Export the DB to JSON, audits privacy:
+python scripts/cassettes/export.py .cache/llm_record tests/fixtures/llm_cassettes
+
+# 3. Commit the new <sha256>.json files (a PR diff shows them).
+```
+
+Replaying (the default — CI lane and reproducibility):
+
+```bash
+# 1. Import JSON fixtures into a fresh DB:
+python scripts/cassettes/import.py tests/fixtures/llm_cassettes .cache/llm_replay --purge
+
+# 2. Run the test in `replay` mode. A miss raises `LLMCacheMiss`:
+LLM_CACHE_MODE=replay LLM_CACHE_DIR=.cache/llm_replay \
+  conda run -n projet-is-roo-new pytest \
+    tests/unit/argumentation_analysis/plugins/test_narrate_convergence.py::TestNarrateConvergenceIntegration
+```
+
+The pytest test `tests/unit/.../test_cassette_round_trip.py` runs the
+full record → export → import → replay loop and asserts `live == 0` in
+replay (the anti-#1019 metric).
+
+## Privacy contract
+
+Cassettes committed here MUST be:
+
+- Synthetic (test fixture inputs only — no real corpus).
+- Free of the forbidden keys listed in `scripts/cassettes/privacy.py`
+  (`raw_text`, `full_text`, `full_text_segment`, `raw_text_snippet`,
+  `passphrase`).
+- Free of source-name hints (politically sensitive authors / historical
+  figures) and politically sensitive date stamps (1933–2026).
+- Audited by `scripts/cassettes/privacy.py` at export. The audit is
+  blocking — a violation raises `PrivacyViolation` and the cassette is
+  refused.
+
+If a legitimate-cassette use case conflicts with the privacy contract,
+do NOT bypass with `--allow-unsafe` — open an issue and discuss
+documented-bounded leakage first.

--- a/tests/unit/argumentation_analysis/plugins/test_cassette_round_trip.py
+++ b/tests/unit/argumentation_analysis/plugins/test_cassette_round_trip.py
@@ -153,10 +153,17 @@ class TestCassetteReplayHitsCache:
         monkeypatch.setenv("LLM_CACHE_MODE", "replay")
         monkeypatch.setenv("LLM_CACHE_DIR", str(replay_db))
 
-        # Reload llm_cache + llm_service so the env vars take effect.
-        import importlib
+        # CACHE_DIR is computed at llm_cache import time (line 29: `CACHE_DIR =
+        # Path(os.getenv("LLM_CACHE_DIR", ".cache/llm_responses"))`) and used as
+        # the fallback by CachedChatCompletion.__init__ — it does NOT re-read
+        # the env var. When llm_cache is imported for the FIRST time during a
+        # prior test (no env var set), CACHE_DIR is frozen to the default and
+        # later monkeypatch.setenv has no effect on the wrap's cache_dir.
+        # Patch the module attribute too so the CachedChatCompletion wrap opens
+        # the populated replay_db, not an empty default.
         import argumentation_analysis.services.llm_cache as llm_cache_mod
-        importlib.reload(llm_cache_mod)
+        monkeypatch.setattr(llm_cache_mod, "CACHE_DIR", replay_db)
+        llm_cache_mod.reset_raw_cache()
 
         assert llm_cache_mod.get_cache_mode() == "replay"
         llm_cache_mod.reset_cache_stats()

--- a/tests/unit/argumentation_analysis/plugins/test_cassette_round_trip.py
+++ b/tests/unit/argumentation_analysis/plugins/test_cassette_round_trip.py
@@ -1,0 +1,229 @@
+"""Round-trip probe for LLM cassettes (#1603).
+
+Proves that an LLM response, once recorded into a `diskcache` runtime DB,
+can be exported to JSON, then imported into a fresh DB, and replayed
+without making any outbound API call. The anti-#1019 metric is `live == 0`
+in replay: a non-zero value means a cache miss silently fell through to
+the API.
+
+The test is hermetic — it does NOT call the real LLM. It uses the cassette
+committed to `tests/fixtures/llm_cassettes/` and proves it round-trips.
+
+If new cassettes are committed, extend ``CASSETTE_FIXTURE`` to the most
+recent key (sorted by mtime) so the test exercises the latest fixture.
+The intent is to *verify* the export/import scripts, not to re-record the
+fixture — re-recording is a manual workflow described in
+``tests/fixtures/llm_cassettes/README.md``.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO = Path(__file__).resolve().parents[4]  # tests/unit/.../test_*.py -> repo root
+SCRIPTS = REPO / "scripts" / "cassettes"
+FIXTURES_DIR = REPO / "tests" / "fixtures" / "llm_cassettes"
+
+
+def _list_cassette_keys() -> list[str]:
+    """Return cassette file stems (sha256 keys) sorted by mtime, newest first."""
+    return sorted(
+        (p.stem for p in FIXTURES_DIR.glob("*.json")),
+        key=lambda stem: (FIXTURES_DIR / f"{stem}.json").stat().st_mtime,
+        reverse=True,
+    )
+
+
+class TestCassetteRoundTrip:
+    """Recorded cassettes must replay without any outbound API call."""
+
+    def test_at_least_one_cassette_is_committed(self):
+        """The fixture directory has at least one cassette.
+
+        If this fails, either the cassettes were never recorded or they
+        were committed to a different path. See
+        ``tests/fixtures/llm_cassettes/README.md``.
+        """
+        cassettes = list(FIXTURES_DIR.glob("*.json"))
+        assert cassettes, f"No cassettes found in {FIXTURES_DIR}"
+
+    def test_cassette_value_is_well_formed(self):
+        """Each cassette is ``{"key": sha256, "value": list | dict}``."""
+        for path in FIXTURES_DIR.glob("*.json"):
+            data = json.loads(path.read_text(encoding="utf-8"))
+            assert isinstance(data, dict), path
+            assert "key" in data and "value" in data, path
+            assert isinstance(data["key"], str) and len(data["key"]) == 64, path
+            assert isinstance(data["value"], (list, dict)), path
+
+    def test_export_then_import_round_trip_preserves_value(self, tmp_path: Path):
+        """A cassette reaches a fresh DB identical to the source.
+
+        Probes the two scripts as plain subprocesses (matches the workflow
+        committed by po-2025 in #1603). Probes the *first* committed
+        cassette — the value is bytes-identical after the round trip.
+        """
+        keys = _list_cassette_keys()
+        assert keys, "no cassette fixture present"
+        first_key = keys[0]
+
+        src_db = tmp_path / "src_db"
+        dst_db = tmp_path / "dst_db"
+        src_db.mkdir()
+        dst_db.mkdir()
+
+        # 1. Re-create source DB from the cassette fixture (one entry).
+        import diskcache  # type: ignore[import-not-found]
+
+        src = diskcache.Cache(str(src_db))
+        try:
+            cassette = json.loads(
+                (FIXTURES_DIR / f"{first_key}.json").read_text(encoding="utf-8")
+            )
+            src.set(cassette["key"], cassette["value"])
+        finally:
+            src.close()
+
+        # 2. Export (DB → JSON onto a fresh dir).
+        exported_dir = tmp_path / "exported"
+        exported_dir.mkdir()
+        ret = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS / "export.py"),
+                str(src_db),
+                str(exported_dir),
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert ret.returncode == 0, f"export failed: {ret.stderr}"
+        assert (exported_dir / f"{first_key}.json").exists()
+
+        # 3. Import (JSON → DB).
+        ret = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPTS / "import.py"),
+                str(exported_dir),
+                str(dst_db),
+                "--purge",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert ret.returncode == 0, f"import failed: {ret.stderr}"
+
+        # 4. Read back from the destination DB. The value must equal the source.
+        dst = diskcache.Cache(str(dst_db))
+        try:
+            assert first_key in set(dst.iterkeys())
+            round_tripped = dst[first_key]
+        finally:
+            dst.close()
+        assert round_tripped == cassette["value"], (
+            "round-trip changed the value — export/import scripts are not "
+            "lossless; check for pydantic / JSON normalization drift."
+        )
+
+
+class TestCassetteReplayHitsCache:
+    """End-to-end: the cached LLM response replays without `live`."""
+
+    def test_replay_path_uses_cache(self, monkeypatch, tmp_path: Path):
+        """Given a populated cache, replay yields `hit=1, live=0`."""
+        keys = _list_cassette_keys()
+        if not keys:
+            pytest.skip("no cassette committed")
+        first_key = keys[0]
+
+        # Configure llm_cache to use a fresh DB populated from the cassette.
+        replay_db = tmp_path / "replay_db"
+        replay_db.mkdir()
+        _populate_db_from_first_cassette(replay_db, first_key)
+
+        monkeypatch.setenv("LLM_CACHE_MODE", "replay")
+        monkeypatch.setenv("LLM_CACHE_DIR", str(replay_db))
+
+        # Reload llm_cache + llm_service so the env vars take effect.
+        import importlib
+        import argumentation_analysis.services.llm_cache as llm_cache_mod
+        importlib.reload(llm_cache_mod)
+
+        assert llm_cache_mod.get_cache_mode() == "replay"
+        llm_cache_mod.reset_cache_stats()
+
+        # Spy on httpx so any outbound call would raise.
+        import httpx
+        real_send = httpx.AsyncClient.send
+
+        async def anti_theatre(self, request, *a, **kw):
+            if "openrouter" in str(request.url) or "openai.com" in str(request.url):
+                raise RuntimeError(
+                    f"OUTBOUND CALL DETECTED in replay mode to {request.url}"
+                )
+            return await real_send(self, request, *a, **kw)
+
+        httpx.AsyncClient.send = anti_theatre
+        try:
+            from semantic_kernel import Kernel
+            from argumentation_analysis.core.llm_service import create_llm_service
+            from argumentation_analysis.plugins.narrative_synthesis_plugin import (
+                NarrativeSynthesisPlugin,
+            )
+            from tests.unit.argumentation_analysis.plugins.test_narrate_convergence import (
+                _convergent_state_json,
+            )
+
+            kernel = Kernel()
+            # force_authentic=True: bypass the test-env mock so we exercise
+            # the real CachedChatCompletion wrap (the cassette is the layer
+            # under test, not the LLM provider).
+            svc = create_llm_service(
+                "narration_test_replay_unit", force_authentic=True
+            )
+            assert getattr(svc, "mode", None) == "replay", (
+                "service was not wrapped in replay mode — cache wiring failed"
+            )
+            kernel.add_service(svc)
+            plugin = NarrativeSynthesisPlugin(kernel=kernel)
+
+            result = asyncio.run(
+                plugin.narrate_convergence(state_json=_convergent_state_json())
+            )
+        finally:
+            httpx.AsyncClient.send = real_send
+
+        # Stats — anti-#1019: `live` must be 0 in replay.
+        stats = llm_cache_mod.get_cache_stats()
+        assert stats["live"] == 0, (
+            f"replay triggered a live API call (live={stats['live']}); "
+            "either the cache miss wasn't a hit or the cache.get returned None"
+        )
+        assert stats["hit"] >= 1, (
+            f"replay did not hit the cache (hit={stats['hit']}); "
+            f"miss_record={stats['miss_record']} miss_replay={stats['miss_replay']}"
+        )
+        assert result, "replay returned an empty string — cache value is broken"
+
+
+def _populate_db_from_first_cassette(db_dir: Path, key: str) -> None:
+    """Materialize the first cassette into a fresh diskcache DB."""
+    import diskcache  # type: ignore[import-not-found]
+
+    cassette = json.loads(
+        (FIXTURES_DIR / f"{key}.json").read_text(encoding="utf-8")
+    )
+    cache = diskcache.Cache(str(db_dir))
+    try:
+        cache.set(cassette["key"], cassette["value"])
+    finally:
+        cache.close()


### PR DESCRIPTION
# feat(cache): commit cassette + replay round-trip probe (#1603, item 1/3)

## Résumé

Première sous-étape de #1603 (anti-#1019 théâtre, anti-coût, anti-pendule) : un sous-ensemble minimal de cassettes LLM est committée et un test pytest prouve le round-trip record → export → import → replay. Cette PR couvre **uniquement** l'étape 1 (cassettes) du triplet ordonné imposé par l'arbitrage user #1592 : cassettes → replay → déclencheur.

**PRs séparées à venir (anti-pendule, le mélange produit une facture silencieuse)** :
- PR #2 — câblage CI lane replay (mode `replay` + `LLM_CACHE_DIR=tests/fixtures/llm_cassettes` sur `unit-api` ou nouveau lane)
- PR #3 — déclencheur `workflow_dispatch` seul (coût passif zéro, choix déjà documenté)

## Ce qui est livré

- `scripts/cassettes/{__init__,privacy,export,import}.py` — wrapper externe autour de `llm_cache.py` (intouché). `export.py` lit la DB `diskcache` runtime et écrit un fichier JSON par cassette, audit privacy bloquant. `import.py` fait l'inverse.
- `tests/fixtures/llm_cassettes/3bc939106c8f81270bd0d4ea58a057f48b2659747e3745898a7966d0e9c34e6b.json` — 1 cassette pour `narrate_convergence::test_real_llm_returns_non_empty_prose`. Synthetic fixture (arg_1 stub), audit privacy OK.
- `tests/fixtures/llm_cassettes/README.md` — workflow manuel record → commit + replay + contrat privacy HARD.
- `tests/unit/.../plugins/test_cassette_round_trip.py` — 4 tests prouvant round-trip lossless + replay avec `live=0` (anti-#1019, fail-loud en cas de miss). `force_authentic=True` sur le test replay pour court-circuiter le mock LLM de la conftest et exercer le vrai wrapping `CachedChatCompletion`.

## Ce qui est prouvé firsthand

| Étape | Mesure |
|---|---|
| Record | `LLM_CACHE_MODE=record` → `miss_record=1, live=1` → cassette créée (1417 chars) |
| Export | `python scripts/cassettes/export.py ...` → 1 fichier JSON, audit privacy OK |
| Import | `python scripts/cassettes/import.py ... --purge` → 1 cassette écrite dans DB fraîche |
| Replay | `LLM_CACHE_MODE=replay` + DB importée → `hit=1, miss_record=0, miss_replay=0, live=0` |
| Round-trip | `replay_result == record_result` (byte-perfect sur 1417 chars) |
| Anti-outbound | Spy `httpx.AsyncClient.send` raise sur `openrouter.ai` / `openai.com` → **jamais déclenché** en replay |

## Anti-pendule inscrit

- **`llm_cache.py` intouché** : wrapper au-dessus, pas d'extension. Le `cache_dir` runtime reste `.cache/llm_responses/` (gitignored) ; le format fixtures est JSON commitable.
- **Tests existants intacts** : `pytest tests/unit/argumentation_analysis/plugins/` → **530 passed, 0 failed**.
- **Aucun mock LLM ajouté qui masquerait un vrai bug** : au contraire, `force_authentic=True` sur le test replay court-circuite le mock conftest pour exercer le **vrai** `CachedChatCompletion`.
- **Mode CI lane et déclencheur `workflow_dispatch` reportés à des PRs séparées** (les PRs #2 et #3 ne sont pas dans cette PR).

## Privacy contract

Les cassettes committées DOIVENT être :

- Synthétiques (test fixture inputs — pas de corpus réel)
- Sans les clés interdites listées dans `scripts/cassettes/privacy.py` (`raw_text`, `full_text`, `full_text_segment`, `raw_text_snippet`, `passphrase`)
- Sans indices de noms de sources (heuristique : auteurs politiquement sensibles) ni dates historiques 1933–2026
- Auditées par `scripts/cassettes/privacy.py` à l'export (bloquant — `PrivacyViolation` levée)

La cassette committée ici a passé l'audit : `content` porte uniquement sur `arg_1` synthétique, `metadata` contient usage + identifiant LLM upstream (acceptable).

## Tests

```
$ conda run -n projet-is-roo-new pytest tests/unit/argumentation_analysis/plugins/test_cassette_round_trip.py -v --allow-dotenv
TestCassetteRoundTrip::test_at_least_one_cassette_is_committed           PASSED
TestCassetteRoundTrip::test_cassette_value_is_well_formed                PASSED
TestCassetteRoundTrip::test_export_then_import_round_trip_preserves_value PASSED
TestCassetteReplayHitsCache::test_replay_path_uses_cache                 PASSED
4 passed in 2.35s
```

## Suite du triplet (#1603)

- **PR #2 — câblage CI lane replay** : modifier `.github/workflows/extended-tests.yml` pour que la lane `unit-api` (ou nouveau lane) exporte `LLM_CACHE_MODE=replay` + `LLM_CACHE_DIR=tests/fixtures/llm_cassettes`. Aucun appel LLM facturé. Test de `live == 0` à l'exécution.
- **PR #3 — déclencheur `workflow_dispatch`** : ajouter le workflow_dispatch (déjà seul sur extended-tests ; confirmer la même posture pour le nouveau lane si introduit). Coût zéro tant que pas de trigger manuel.

## Liens

- Issue #1603 — https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/issues/1603
- DoD coord R752/R753 — `main 04749540` est la base de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
