### PR TITLE
fix(orchestration): resolve fallacy attack targets by identifier (#1629)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3057,17 +3057,66 @@ def _extract_arguments_from_context(
     return [input_text[:200] if len(input_text) > 10 else "argument_placeholder"]
 
 
+# #1629: fallacy records name their target by *identifier* — ``arg_1``,
+# ``arg_2``, … — minted by ``shared_state._generate_id`` as
+# ``f"{prefix}_{index + 1}"`` over an insertion-ordered dict. Resolution is that
+# generation's inverse.
+_ARG_ID_RE = re.compile(r"^\s*arg_(\d+)\s*$")
+
+
+def _resolve_target_argument_id(raw_target: Any, arguments: List[str]) -> Optional[str]:
+    """Resolve an upstream ``arg_N`` reference to its entry in ``arguments``.
+
+    Indexing back into the caller's own list (rather than returning the
+    producer's stored description) guarantees every attack endpoint is a member
+    of the argument set the graph is built over; a resolved text absent from
+    that set would corrupt the graph just as surely as a wrong target.
+
+    Returns ``None`` when the reference is absent, malformed, or out of range.
+    The caller must NOT invent a target in that case (#1019): an attack we
+    cannot ground is an attack we do not assert.
+    """
+    if not raw_target:
+        return None
+    match = _ARG_ID_RE.match(str(raw_target))
+    if not match:
+        return None
+    index = int(match.group(1)) - 1  # IDs are 1-based
+    if 0 <= index < len(arguments):
+        return arguments[index]
+    return None
+
+
 def _generate_attacks_from_args(
     arguments: List[str], context: Optional[Dict[str, Any]] = None
 ) -> List[List[str]]:
-    """Generate attack relations between arguments based on detected fallacies.
+    """Generate attack relations between arguments from upstream detections.
 
-    Uses upstream fallacy detections to create meaningful attacks:
-    - A fallacy undermines the argument it targets
-    - Counter-arguments attack the arguments they rebut
-    Falls back to sparse heuristic if no upstream data available.
+    - A fallacy attacks the argument it targets, resolved by identifier.
+    - Counter-arguments attack the arguments they rebut, matched by text.
+
+    #1629: the fallacy branch used to read ``target_text`` / ``argument`` /
+    ``text``. No producer writes any of those. The hierarchical fallacy phase
+    writes ``target_argument`` (an ``arg_N`` identifier) and ``shared_state``
+    entries write ``target_argument_id``. Every lookup therefore missed and
+    fell through to an enumeration-index pairing — ``fallacy_0`` -> ``arg_1``,
+    ``fallacy_1`` -> ``arg_2``, … — which spreads one attack per argument
+    regardless of what was detected. Real targeting *concentrates* (measured on
+    a real corpus: six fallacies on the first argument, six on the second),
+    so the two graphs differ in topology, not in detail. Since extensions are a
+    function of topology, every downstream reasoner (Dung, ranking, SETAF,
+    bipolar, weighted, ABA, DeLP) computed correct answers about a graph that
+    was never the corpus'. Reading the right key alone would not have fixed it:
+    the old strategy fed its value to a word-overlap match, and ``"arg_1"``
+    shares no words with argument prose, so it would have missed too.
+
+    NOTE: ``target_argument`` carries an *identifier* in the fallacy payload
+    and *free text* in ``phase_counter_output``. Same name, two meanings — do
+    not unify the two branches.
     """
-    attacks = []
+    attacks: List[List[str]] = []
+    resolved_targets = 0
+    unresolved_targets = 0
 
     if context:
         # Use fallacies to generate attacks: fallacious arg attacks its target
@@ -3081,32 +3130,27 @@ def _generate_attacks_from_args(
             if not isinstance(f, dict):
                 continue
             fallacy_label = f.get("type", f.get("fallacy_type", f"fallacy_{i}"))
-            # Try to match fallacy to argument by text content
-            target_text = str(
-                f.get("target_text", f.get("argument", f.get("text", "")))
-            ).lower()[:60]
-            target_arg = None
-            # Strategy 1: exact text overlap between fallacy target and argument
-            if target_text:
-                best_overlap = 0
-                for arg in arguments:
-                    overlap = len(set(target_text.split()) & set(arg.lower().split()))
-                    if overlap > best_overlap:
-                        best_overlap = overlap
-                        target_arg = arg
-                # Require at least 2 words overlap for a meaningful match
-                if best_overlap < 2:
-                    target_arg = None
-            # Strategy 2: index-based fallback
-            if target_arg is None and arguments:
-                target_idx = min(i, len(arguments) - 1)
-                target_arg = arguments[target_idx]
+            # Explicit loop rather than chained ``get`` defaults: producers emit
+            # the key with a ``None`` value when a detection has no target, and
+            # ``get(k, default)`` returns that ``None`` instead of the default.
+            raw_target = None
+            for key in ("target_argument", "target_argument_id", "target_arg_id"):
+                value = f.get(key)
+                if value:
+                    raw_target = value
+                    break
+            target_arg = _resolve_target_argument_id(raw_target, arguments)
+            if target_arg is None:
+                # Non-taxonomic detections carry no target at all. Pairing them
+                # by position is what this fix removes; skip and count instead.
+                unresolved_targets += 1
+                continue
+            # The fallacious argument attacks the argument it undermines
+            attacks.append([f"fallacy_{i}_{fallacy_label}", target_arg])
+            resolved_targets += 1
 
-            if target_arg:
-                # The fallacious argument attacks the argument it undermines
-                attacks.append([f"fallacy_{i}_{fallacy_label}", target_arg])
-
-        # Use counter-arguments to generate attacks
+        # Use counter-arguments to generate attacks. Here ``target_argument`` is
+        # free text, so a text match is the right kind of resolution (#1629).
         ca_output = context.get("phase_counter_output", {})
         if isinstance(ca_output, dict):
             cas = ca_output.get("llm_counter_arguments", [])
@@ -3123,12 +3167,21 @@ def _generate_attacks_from_args(
                             )
                             break
 
-    # Fallback: sparse heuristic if no meaningful attacks generated
-    if not attacks:
-        for i in range(len(arguments)):
-            for j in range(i + 1, len(arguments)):
-                if (i + j) % 3 == 0:
-                    attacks.append([arguments[i], arguments[j]])
+    # #1629: the ``(i + j) % 3 == 0`` fallback that stood here is REMOVED by
+    # subtraction (anti-pendulum), not replaced. It built a modulo graph over
+    # the arguments whenever nothing else fired — a shape with no relation to
+    # the corpus, handed to solvers that then reported extensions over it. An
+    # attack graph we cannot derive is empty, and an empty graph is a truthful
+    # input: every argument stands, because none was shown to be attacked.
+    if unresolved_targets:
+        logger.info(
+            "Attack graph: %d edge(s) total, %d from resolved fallacy targets; "
+            "%d detection(s) carried no resolvable target and were skipped "
+            "(no positional pairing, #1629).",
+            len(attacks),
+            resolved_targets,
+            unresolved_targets,
+        )
 
     return attacks
 

--- a/tests/integration/test_tweety_fallbacks.py
+++ b/tests/integration/test_tweety_fallbacks.py
@@ -96,19 +96,96 @@ class TestExtractArgumentsFromContext:
 
 
 class TestGenerateAttacksFromArgs:
+    """#1629: targets are resolved by identifier, never by enumeration index.
+
+    ``TARGETED_ARGS`` deliberately does NOT reuse ``arg_N`` as argument *text*:
+    with ``SAMPLE_ARGS`` the resolution ``arg_1 -> arguments[0]`` is the
+    identity, which would make a wrong resolution indistinguishable from a
+    right one.
+    """
+
+    TARGETED_ARGS = ["first claim", "second claim", "third claim"]
+
+    @staticmethod
+    def _ctx(targets, key="target_argument"):
+        """Build a hierarchical-fallacy context from a list of target IDs."""
+        return {
+            "phase_hierarchical_fallacy_output": {
+                "fallacies": [
+                    {"fallacy_type": f"type_{n}", key: t} for n, t in enumerate(targets)
+                ]
+            }
+        }
+
     def test_returns_list(self):
         result = _generate_attacks_from_args(SAMPLE_ARGS)
         assert isinstance(result, list)
 
     def test_attacks_reference_valid_args(self):
-        result = _generate_attacks_from_args(SAMPLE_ARGS)
+        ctx = self._ctx(["arg_1", "arg_2", "arg_3"])
+        result = _generate_attacks_from_args(self.TARGETED_ARGS, ctx)
+        assert len(result) == 3
         for src, tgt in result:
-            assert src in SAMPLE_ARGS
-            assert tgt in SAMPLE_ARGS
+            assert tgt in self.TARGETED_ARGS
+            assert src.startswith("fallacy_")
 
     def test_empty_args_returns_empty(self):
         result = _generate_attacks_from_args([])
         assert result == []
+
+    def test_no_upstream_data_yields_no_fabricated_graph(self):
+        """The ``(i + j) % 3`` modulo graph is removed, not replaced (#1629).
+
+        A graph we cannot derive is empty; it is not a shape invented over the
+        argument list and handed to solvers as if it came from the corpus.
+        """
+        assert _generate_attacks_from_args(SAMPLE_ARGS) == []
+        assert _generate_attacks_from_args(SAMPLE_ARGS, {}) == []
+
+    def test_two_targetings_produce_two_graphs(self):
+        """The discriminating control: the output must depend on the targets.
+
+        Under the pre-#1629 index pairing both contexts yielded the very same
+        edges (fallacy 0 -> args[0], fallacy 1 -> args[1], ...), so no
+        assertion over one of them alone could detect the defect.
+        """
+        spread = _generate_attacks_from_args(
+            self.TARGETED_ARGS, self._ctx(["arg_1", "arg_2", "arg_3"])
+        )
+        concentrated = _generate_attacks_from_args(
+            self.TARGETED_ARGS, self._ctx(["arg_1", "arg_1", "arg_1"])
+        )
+        assert [t for _, t in spread] == self.TARGETED_ARGS
+        assert [t for _, t in concentrated] == [self.TARGETED_ARGS[0]] * 3
+        assert spread != concentrated
+
+    def test_target_is_not_the_enumeration_index(self):
+        """Reversed targeting must reverse the graph, not reproduce 0,1,2."""
+        result = _generate_attacks_from_args(
+            self.TARGETED_ARGS, self._ctx(["arg_3", "arg_2", "arg_1"])
+        )
+        assert [t for _, t in result] == list(reversed(self.TARGETED_ARGS))
+
+    def test_detection_without_target_is_skipped(self):
+        """Non-taxonomic detections carry no target — and get no attack.
+
+        The producer emits the key with a ``None`` value, which is why the
+        resolution cannot rely on ``dict.get(key, default)``.
+        """
+        ctx = self._ctx(["arg_2", None, "arg_3"])
+        result = _generate_attacks_from_args(self.TARGETED_ARGS, ctx)
+        assert [t for _, t in result] == ["second claim", "third claim"]
+
+    def test_out_of_range_or_malformed_target_is_skipped(self):
+        ctx = self._ctx(["arg_99", "not_an_id", "arg_0", "arg_2"])
+        result = _generate_attacks_from_args(self.TARGETED_ARGS, ctx)
+        assert [t for _, t in result] == ["second claim"]
+
+    def test_shared_state_key_convention_also_resolves(self):
+        """``shared_state`` entries name the target ``target_argument_id``."""
+        ctx = self._ctx(["arg_2"], key="target_argument_id")
+        result = _generate_attacks_from_args(self.TARGETED_ARGS, ctx)
+        assert [t for _, t in result] == ["second claim"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_dung_aspic_wiring.py
@@ -77,8 +77,13 @@ class TestInvokeDungExtensions:
             "phase_hierarchical_fallacy_output": {
                 "fallacies": [
                     {
+                        # #1629: the phase emits an ``arg_N`` identifier under
+                        # ``target_argument``. The former ``target_text`` here
+                        # was a fixture-only key no producer ever wrote, so this
+                        # test passed through the index fallback rather than
+                        # through the targeting it claims to exercise.
                         "type": "Appel a l'autorite",
-                        "target_text": "Ce regime est le meilleur car le professeur le dit",
+                        "target_argument": "arg_1",
                     }
                 ]
             },
@@ -498,10 +503,17 @@ class TestDungStateWriter:
 
 
 class TestCrossKBFallacyAttacks:
-    """Test _generate_attacks_from_args with text-based fallacy matching."""
+    """Test _generate_attacks_from_args target resolution (#1629).
 
-    def test_matches_by_text_overlap(self):
-        """Fallacies matched to arguments by text content, not just index."""
+    These tests used to exercise a word-overlap match keyed on ``target_text``.
+    No producer writes that key: the fixtures supplied it themselves, so the
+    tests were green while the mechanism was inert on every real payload, and
+    the code silently paired fallacies to arguments by enumeration index. The
+    lexical strategy is removed by subtraction; resolution is by identifier.
+    """
+
+    def test_matches_by_target_identifier(self):
+        """Fallacies target the argument their identifier names, not their rank."""
         from argumentation_analysis.orchestration.unified_pipeline import (
             _generate_attacks_from_args,
         )
@@ -513,21 +525,18 @@ class TestCrossKBFallacyAttacks:
         context = {
             "phase_hierarchical_fallacy_output": {
                 "fallacies": [
-                    {
-                        "type": "Appel a l'autorite",
-                        "target_text": "Le professeur Dupont affirme que ce regime",
-                    }
+                    {"type": "Appel a l'autorite", "target_argument": "arg_2"}
                 ]
             }
         }
 
         attacks = _generate_attacks_from_args(arguments, context)
 
-        assert len(attacks) > 0
-        # The fallacy should target the first argument (text overlap)
-        assert any(
-            "professeur" in a[1].lower() or "dupont" in a[1].lower() for a in attacks
-        )
+        # arg_2 -> the SECOND argument. Under the index pairing this lone
+        # fallacy (enumeration index 0) attacked the first one, so the choice
+        # of arg_2 is what makes the assertion able to fail.
+        assert len(attacks) == 1
+        assert attacks[0][1] == arguments[1]
 
     def test_fallacy_label_in_attack(self):
         """Attack labels include fallacy type."""
@@ -539,7 +548,7 @@ class TestCrossKBFallacyAttacks:
         context = {
             "phase_hierarchical_fallacy_output": {
                 "fallacies": [
-                    {"type": "Appel a l'autorite", "target_text": "appel a l'autorite"}
+                    {"type": "Appel a l'autorite", "target_argument": "arg_1"}
                 ]
             }
         }
@@ -573,15 +582,21 @@ class TestCrossKBFallacyAttacks:
         assert len(attacks) > 0
         assert any("CA" in a[0] for a in attacks)
 
-    def test_fallback_heuristic(self):
-        """Sparse heuristic used when no upstream data."""
+    def test_no_upstream_data_fabricates_no_graph(self):
+        """#1629: the sparse ``(i + j) % 3`` heuristic is removed, not replaced.
+
+        It invented an attack graph over the argument list whenever nothing
+        else fired, and the Dung family then reported extensions over that
+        shape as if it came from the corpus. With no derivable relation the
+        graph is empty — every argument stands, because none was shown to be
+        attacked. This assertion is the inverse of the one it replaces.
+        """
         from argumentation_analysis.orchestration.unified_pipeline import (
             _generate_attacks_from_args,
         )
 
         arguments = ["arg1", "arg2", "arg3"]
-        attacks = _generate_attacks_from_args(arguments, None)
-        assert len(attacks) > 0  # Should generate some attacks
+        assert _generate_attacks_from_args(arguments, None) == []
 
 
 # ============================================================


### PR DESCRIPTION
Ferme #1629.

## Le défaut

`_generate_attacks_from_args` cherchait l'argument attaqué par un sophisme sous `target_text` / `argument` / `text`. **Aucun producteur n'écrit ces clés.** La phase de détection hiérarchique écrit `target_argument` (un identifiant `arg_N`), les entrées `shared_state` écrivent `target_argument_id`. Chaque lecture manquait, et le code tombait sans bruit dans un appariement par **index d'énumération** : sophisme 0 → arg_1, sophisme 1 → arg_2, etc.

Ce graphe est l'entrée de Dung, du ranking, de SETAF, du bipolaire, du pondéré, d'ABA et de DeLP. Les solveurs sont justes ; leur entrée n'était pas celle du corpus. Et les extensions revenaient sous forme d'« arguments rejetés », cités en conclusion comme **confirmation formelle indépendante** des sophismes qui avaient produit le graphe. Boucle fermée, que rien ne signalait — parce qu'à chaque étage le calcul était exact.

## Mesure sur deux artefacts réels (agrégats seuls)

| | détections / arguments | avant | après | arêtes inchangées |
|---|---|---|---|---|
| `corpus_A` | 34 / 138 | 34 arêtes, **34** cibles distinctes, `[1×34]` | 33 arêtes, **8** cibles, `[9,8,7,4,2,1,1,1]` | **2 / 34** |
| `corpus_C` | 24 / 10 | 24 arêtes, `[15,1,1,1,1,1,1,1,1,1]` | 23 arêtes, `[6,6,3,2,2,1,1,1,1]` | **2 / 24** |

Le ciblage réel **concentre**, l'appariement par index **étale**. Sur `corpus_C`, `min(i, n-1)` sature : les 15 dernières détections attaquaient toutes le même dernier argument. Les deux graphes ne diffèrent pas dans le détail, ils diffèrent de topologie — et les extensions sont fonction de la topologie.

## Pourquoi changer la clé ne suffisait pas

L'ancienne stratégie passait la valeur lue à un recouvrement lexical d'au moins deux mots. `"arg_1"` ne partage aucun mot avec de la prose argumentative : même en lisant la bonne clé, elle aurait manqué et serait retombée sur l'index. C'est le **mécanisme de résolution** qui devait changer.

Résolution retenue : `arg_N` → `arguments[N-1]`, l'inverse exact de `shared_state._generate_id` (`f"{prefix}_{index+1}"` sur un dict à ordre d'insertion), borné — un identifiant résolu vers un texte absent de la liste `arguments` corromprait le graphe autrement.

## Retiré par soustraction (anti-pendule)

- Le recouvrement lexical : un appariement approximatif en concurrence avec un identifiant exact, et inerte sur tout payload réel.
- Le repli `(i + j) % 3 == 0` : un graphe modulo inventé sur la liste d'arguments dès que rien d'autre ne tirait. Un graphe indérivable est désormais **vide** — chaque argument tient, faute d'attaque démontrée.
- L'appariement par index pour les détections sans cible : les détections non taxonomiques n'en portent pas ; elles sont ignorées et **comptées**, plus appariées par rang.

## Non modifié, délibérément

La branche contre-arguments. `target_argument` y porte du **texte libre**, pas un identifiant — vérifié sur artefact. Sa correspondance textuelle est donc du bon genre. Même nom de clé, deux sens : noté dans la docstring pour que les deux branches ne soient pas « unifiées » par un futur passage.

## Tests

Quatre tests existants épinglaient le comportement retiré, tous bâtis sur des clés que **seule la fixture fournissait** — c'est pourquoi ils étaient verts pendant que le mécanisme était mort sur données réelles (`feedback_falsifiable_on_synthetic_inert_on_real`).

| test | traitement |
|---|---|
| `test_matches_by_text_overlap` | → `test_matches_by_target_identifier` : cible `arg_2` avec **une seule** détection, donc l'appariement par index (qui prendrait le premier argument) le fait échouer |
| `test_fallback_heuristic` | → `test_no_upstream_data_fabricates_no_graph` : l'assertion inverse |
| `test_fallacy_label_in_attack` | propriété conservée (le label porte le type), clé de fixture corrigée |
| `test_generates_attacks_from_fallacies` | idem |

Six cas ajoutés : deux ciblages ⇒ deux graphes, ciblage inversé, saut sans cible, saut hors borne / malformé, convention de clé `shared_state`.

**Contrôle par substitution** — un résolveur dégénéré (renvoie toujours le premier argument) tue **5** tests ; réintroduire le comportement pré-#1629 (index + modulo) en tue **3**. Et la substitution sur l'**entrée réelle** confirme que le correctif mord là où il sert (tableau ci-dessus), ce que la seule substitution de code ne prouve pas.

## État

`black` + `flake8` propres. `tests/unit/argumentation_analysis/orchestration/` : **2416 passed**, 0 échec. Les 11 échecs de `tests/integration/test_tweety_fallbacks.py` (replis ranking / ADF) sont **identiques sur `main` vierge** — préexistants, hors périmètre, déjà documentés dans la docstring du fichier.

## Motif à suivre séparément

Le grep du motif donne **trois** sites lisant la cible d'un sophisme, chacun avec un traitement partiel différent — celui-ci (corrigé), la pénalité qualité `#289` (`invoke_callables.py:518`, lit l'identifiant comme du texte ⇒ la pénalité ne s'applique jamais), et la voie conversationnelle (`conversational_orchestrator.py:3056` / `3085`, comparaison d'identifiant **correcte** mais câblée sur une seule des deux conventions de clé). Je ne les corrige pas ici : ce sont des changements de comportement sur d'autres axes, qui méritent leur propre mesure. Issue de motif à ouvrir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
