### PR TITLE
fix(orchestration): decouple the formal axes from the fallacy axis (#1631, #1637)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -5802,14 +5802,20 @@ async def _invoke_propositional_logic(
             formulas = list(prop_vars)
             pl_metrics["template"] = len(prop_vars)
             argument_mapping = {prop_vars[i]: a[:60] for i, a in enumerate(args)}
-            fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
-            fallacies = (
-                fallacy_output.get("fallacies", [])
-                if isinstance(fallacy_output, dict)
-                else []
-            )
-            if fallacies and len(prop_vars) >= 2:
-                formulas.append(f"!{prop_vars[-1]}")
+            # #1637: the belief set is built from the source arguments ONLY.
+            # This fallback used to append `!{prop_vars[-1]}` whenever the
+            # upstream fallacy axis had detected anything — planting a
+            # contradiction on the LAST atom (unrelated to whatever argument the
+            # fallacy actually targeted) and turning `satisfiable` into False.
+            # That made the SAT verdict a function of the fallacy axis rather
+            # than of the propositional structure, and it fired exactly on the
+            # path where NL→PL translation had produced nothing, i.e. where the
+            # axis has nothing to say. Same family as the FOL template
+            # fabrication removed in #1278 (see the note in
+            # _invoke_fol_reasoning); this PL one was one line, so the sweep
+            # missed it. A fallacy is a rhetorical defect, not a propositional
+            # contradiction: re-aiming the negation at the targeted argument
+            # would be a better-aimed fabrication, not a fix (#1019 fail-loud).
 
     if not isinstance(formulas, list):
         formulas = [str(formulas)]
@@ -6211,17 +6217,22 @@ async def _invoke_fol_reasoning(
     if not isinstance(formulas, list):
         formulas = [str(formulas)]
 
-    inferences = []
-    # Derive inferences from the structure
-    fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
-    fallacies = (
-        fallacy_output.get("fallacies", []) if isinstance(fallacy_output, dict) else []
-    )
-    for f in fallacies:
-        if isinstance(f, dict):
-            inferences.append(
-                f"Argument undermined by {f.get('type', f.get('fallacy_type', 'unknown'))} fallacy"
-            )
+    # #1631: `inferences` carries what the FOL reasoning produced — nothing
+    # else. It used to be filled, BEFORE any formula reached Tweety, with one
+    # "Argument undermined by <type> fallacy" line per fallacy detected by the
+    # upstream hierarchical axis, and returned on every exit path including the
+    # ones where the prover decided nothing. Three things were wrong with it:
+    # none of those lines is an inference (no derivation from the KB, a purely
+    # lexical restatement); none names the argument concerned, so it was a
+    # LOSSY copy of the fallacy axis (the source record carries a target id);
+    # and it survived prover failure, so an artefact could carry
+    # `consistent: None` + "Degraded: no verdict" alongside a list of claims
+    # rendered under a heading announcing a Tweety verification.
+    # Reader census before removal (DoD item 1, #1631): zero readers, by name
+    # or by whole-dict serialization — the removal cannot change the deliverable.
+    # Tweety can do deduction; wiring it is a separate question. Until then the
+    # honest value is the empty list, and the field marks the place.
+    inferences: List[str] = []
 
     # Track B #1278: gate fol_handler.py:830 from the caller. When NO real FOL
     # formula was translated from the source arguments, do NOT hand an empty

--- a/tests/unit/argumentation_analysis/orchestration/test_formal_axes_decoupled_from_fallacies.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_formal_axes_decoupled_from_fallacies.py
@@ -1,0 +1,235 @@
+"""The formal axes must not be a function of the fallacy axis (#1631, #1637).
+
+Two distinct couplings existed between the upstream hierarchical fallacy phase
+and the formal-logic phases, and neither was visible from a test:
+
+* **#1637 — the propositional belief set.** On the template-fallback path (one
+  readable atom per argument, reached only when NL->PL translation produced
+  nothing), the presence of *any* upstream fallacy appended ``!{last_atom}`` to
+  the belief set. The SAT solver then returned UNSAT, so ``satisfiable`` became
+  a function of the fallacy axis rather than of the propositional structure —
+  and the contradiction landed on the last argument, unrelated to whatever the
+  fallacy actually targeted.
+
+* **#1631 — the FOL ``inferences`` field.** It was filled, before any formula
+  reached Tweety, with one ``"Argument undermined by <type> fallacy"`` line per
+  detected fallacy, and returned on every exit path including those where the
+  prover decided nothing.
+
+Why the existing suite could not see either one: ``test_nl_to_logic_wiring.py``
+already exercises the PL template-fallback path and already asserts
+``len(formulas) == len(args)`` and ``all(_is_pl_atom(f))`` — both of which the
+injection would break. They pass because its helper never puts
+``phase_hierarchical_fallacy_output`` in the context. The path was covered; the
+defect was dormant in the single configuration every fixture instantiated.
+
+That is why :func:`_context` below takes ``fallacies`` as a **required keyword**
+argument (#1637 DoD item 3): a future fixture cannot re-create the blind spot by
+forgetting it.
+"""
+
+import re
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+TWEETY_BRIDGE_PATH = (
+    "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge"
+)
+
+_ARGS = ["Arg one", "Arg two", "Arg three"]
+
+_FALLACIES = [
+    {"type": "ad_hominem", "target_argument": "arg_1"},
+    {"type": "straw_man", "target_argument": "arg_2"},
+]
+
+
+def _context(args, *, fallacies, translations=None):
+    """Build a phase context.
+
+    ``fallacies`` is intentionally required and keyword-only: the couplings this
+    module pins were invisible precisely because every other fixture omitted the
+    fallacy phase output. Pass ``[]`` for the control run and a non-empty list
+    for the treatment run — never omit the decision.
+    """
+    ctx = {"phase_extract_output": {"arguments": [{"text": t} for t in args]}}
+    ctx["phase_hierarchical_fallacy_output"] = {"fallacies": list(fallacies)}
+    if translations is not None:
+        ctx["phase_nl_to_logic_output"] = {"translations": translations}
+    return ctx
+
+
+class TestPropositionalBeliefSetIgnoresFallacies:
+    """#1637 — the PL belief set is built from the source arguments only."""
+
+    async def test_template_fallback_is_identical_with_and_without_fallacies(self):
+        """Same arguments + same solver, fallacies as the only variable.
+
+        Before the fix this produced ``satisfiable=True`` / 3 formulas without
+        fallacies and ``satisfiable=False`` / 4 formulas with them. Comparing
+        both runs (rather than asserting one expected shape) is what makes the
+        test die if the injection is reintroduced anywhere on this path.
+        """
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_propositional_logic,
+        )
+
+        without = await _invoke_propositional_logic(
+            "text", _context(_ARGS, fallacies=[])
+        )
+        with_ = await _invoke_propositional_logic(
+            "text", _context(_ARGS, fallacies=_FALLACIES)
+        )
+
+        assert with_["formulas"] == without["formulas"], (
+            "the belief set changed when only the upstream fallacy axis changed "
+            f"(#1637): {without['formulas']} -> {with_['formulas']}"
+        )
+        assert with_["satisfiable"] == without["satisfiable"], (
+            "the SAT verdict changed when only the upstream fallacy axis "
+            f"changed (#1637): {without['satisfiable']} -> {with_['satisfiable']}"
+        )
+
+    async def test_no_negation_is_planted_in_the_belief_set(self):
+        """The fabricated formula was a negated atom; none may appear.
+
+        Complements the equality test above: that one dies if the two runs
+        diverge, this one dies if a negation is planted unconditionally (which
+        equality alone would not catch).
+        """
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_propositional_logic,
+        )
+
+        result = await _invoke_propositional_logic(
+            "text", _context(_ARGS, fallacies=_FALLACIES)
+        )
+
+        negated = [
+            f
+            for f in result["formulas"]
+            if isinstance(f, str) and f.lstrip().startswith("!")
+        ]
+        assert not negated, f"negation planted in the PL belief set (#1637): {negated}"
+
+    async def test_one_atom_per_argument_even_when_fallacies_were_detected(self):
+        """``test_pl_falls_back_to_templates`` asserts this without fallacies.
+
+        The injection was guarded by ``if fallacies and len(prop_vars) >= 2``,
+        so the existing assertion held in the only configuration it was ever run
+        in. Re-asserting it *with* fallacies present is the missing half.
+        """
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_propositional_logic,
+        )
+
+        result = await _invoke_propositional_logic(
+            "text", _context(_ARGS, fallacies=_FALLACIES)
+        )
+
+        assert len(result["formulas"]) == len(_ARGS), result["formulas"]
+        assert all(
+            re.match(r"^[a-z][a-z0-9_]*$", f) for f in result["formulas"]
+        ), result["formulas"]
+
+
+class TestFolInferencesCarryOnlyFormalOutput:
+    """#1631 — ``inferences`` holds what the prover produced, or nothing."""
+
+    async def test_no_translation_path_is_identical_with_and_without_fallacies(self):
+        """The ``unavailable:no-translation`` early return.
+
+        This is the exit path where the coupling was most damaging: the axis has
+        formalized nothing, yet used to return one line per upstream fallacy
+        under a heading announcing a Tweety verification.
+        """
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fol_reasoning,
+        )
+
+        without = await _invoke_fol_reasoning("text", _context(_ARGS, fallacies=[]))
+        with_ = await _invoke_fol_reasoning(
+            "text", _context(_ARGS, fallacies=_FALLACIES)
+        )
+
+        assert without["fol_status"] == "unavailable:no-translation"
+        assert with_ == without, (
+            "FOL output changed when only the upstream fallacy axis changed "
+            f"(#1631): {without} -> {with_}"
+        )
+        assert with_["inferences"] == []
+
+    async def test_decided_path_carries_no_fallacy_derived_inferences(self):
+        """The nominal path, where the prover actually returns a verdict.
+
+        The removed block ran before any formula reached Tweety, so it polluted
+        the decided path too — an artefact could carry a real verdict alongside
+        claims the prover never produced.
+        """
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fol_reasoning,
+        )
+
+        translations = [
+            {
+                "logic_type": "first_order",
+                "formula": "forall X: (Human(X) => Mortal(X))",
+                "is_valid": True,
+                "original_text": "Arg one",
+            },
+            {
+                "logic_type": "first_order",
+                "formula": "Human(socrates)",
+                "is_valid": True,
+                "original_text": "Arg two",
+            },
+        ]
+
+        mock_bridge = MagicMock()
+        mock_bridge.check_consistency.return_value = (True, "Consistent")
+
+        with patch(TWEETY_BRIDGE_PATH, return_value=mock_bridge):
+            without = await _invoke_fol_reasoning(
+                "text", _context(_ARGS, fallacies=[], translations=translations)
+            )
+            with_ = await _invoke_fol_reasoning(
+                "text",
+                _context(_ARGS, fallacies=_FALLACIES, translations=translations),
+            )
+
+        assert with_["inferences"] == [], (
+            "fallacy-derived content reappeared in FOL inferences on the decided "
+            f"path (#1631): {with_['inferences']}"
+        )
+        assert with_["inferences"] == without["inferences"]
+        assert with_["formulas"] == without["formulas"]
+
+
+@pytest.mark.parametrize(
+    "axis",
+    ["_invoke_propositional_logic", "_invoke_fol_reasoning", "_invoke_modal_logic"],
+)
+def test_formal_axes_do_not_read_the_fallacy_phase(axis):
+    """Structural guard: no formal axis reads ``phase_hierarchical_fallacy_output``.
+
+    The behavioural tests above pin the two couplings that existed. This one
+    pins the *rule*, so a third coupling — in modal, or on an exit path the
+    behavioural tests do not reach — fails here rather than shipping silently.
+    Modal is included although it was already clean: the point is to keep it so.
+    """
+    import inspect
+
+    from argumentation_analysis.orchestration import invoke_callables
+
+    source = inspect.getsource(getattr(invoke_callables, axis))
+    offending = [
+        line.strip()
+        for line in source.splitlines()
+        if "phase_hierarchical_fallacy_output" in line
+        and not line.lstrip().startswith("#")
+    ]
+    assert not offending, (
+        f"{axis} reads the fallacy phase output (#1631/#1637); the formal axes "
+        f"must depend on the source arguments only: {offending}"
+    )


### PR DESCRIPTION
Closes #1631, closes #1637.

Deux couplages laissaient l'axe sophismes décider de ce que les axes formels rapportaient. Le correctif est une soustraction des deux côtés.

## #1637 — l'ensemble de croyances propositionnel

Sur le chemin de repli par atomes (un atome lisible par argument, atteint uniquement quand la traduction NL→PL n'a rien produit), la présence d'un sophisme en amont ajoutait `!{dernier_atome}` à l'ensemble de croyances. Le solveur SAT retournait alors UNSAT.

Mesuré par substitution **sur l'entrée**, sur le vrai chemin de code — trois arguments identiques, même solveur, le sophisme en amont comme seule variable :

| contexte amont | `satisfiable` | ensemble de croyances |
|---|---|---|
| aucun sophisme | `True` | `[p_arg_one_…, p_arg_two_…, p_arg_three_…]` |
| un sophisme visant `arg_1` | **`False`** | `[…, '! p_arg_three_…']` |

Deux choses en sortent. D'abord `satisfiable` était une fonction de l'axe sophismes, pas de la structure propositionnelle. Ensuite la contradiction était plantée sur `arg_3` alors que le sophisme visait `arg_1` : même en accordant la prémisse, la cible était fausse.

Le régime de déclenchement est le pire possible : le repli n'est atteint **que** lorsque la traduction NL→PL a échoué, c'est-à-dire quand l'axe formel n'a rien à dire. Il transformait ce silence en verdict décidé et négatif. Et contrairement au champ ci-dessous, `satisfiable` est lu partout dans la restitution — annexe, synthèse narrative, conclusion.

## #1631 — le champ `inferences` de l'axe FOL

Rempli **avant** que la moindre formule atteigne Tweety, avec une ligne `"Argument undermined by <type> fallacy"` par sophisme détecté, et retourné sur les quatre chemins de sortie — y compris ceux où le prouveur n'a rien décidé.

Aucune de ces lignes n'est une inférence : rien n'est dérivé du KB, la transformation est lexicale. Aucune ne nomme l'argument concerné, alors que l'enregistrement source, lui, porte un identifiant de cible — c'était donc une copie *appauvrie* de l'axe sophismes. Et elle survivait à l'échec du prouveur : un artefact pouvait porter `consistent: None` + `Degraded: no verdict` à côté de 24 affirmations rendues sous un intitulé annonçant une vérification Tweety.

Le recensement des lecteurs (DoD item 1) a trouvé **zéro lecteur**, ni par nom ni par sérialisation du dict entier — le retrait ne peut pas changer le livrable. C'est ce qui rend le geste franc plutôt qu'arbitral.

## Le motif, et pourquoi il a survécu

Les deux appartiennent à la famille de la fabrication de gabarit retirée de l'axe FOL en #1278 (`Undermines(fallacyN, argM)`, `Fallacious(argM)`, …), dont le commentaire disait déjà l'essentiel : ces prédicats « are fabricated to make the FOL axis *look alive* ». La version PL tenait en une ligne — trop petite pour le balayage de l'époque. Modal était déjà propre ; il l'est resté et le test le vérifie.

**Ce qui mérite d'être noté, c'est que le test qui l'attrape existait déjà.** `test_nl_to_logic_wiring.py:124-147` exerce exactement le chemin de repli PL et assert `len(formulas) == len(args)` puis `all(_is_pl_atom(f))`, avec `_PL_ATOM_RE = ^[a-z][a-z0-9_]*$`. L'injection produit 4 formules pour 3 arguments dont une commençant par `!` : **les deux assertions tombent**. Elles ne tombaient pas parce que le helper `_make_context_with_args` ne pose jamais `phase_hierarchical_fallacy_output`.

Le chemin était couvert, la couverture était réelle, et le défaut était dormant dans la seule configuration que toutes les fixtures instancient. C'est une variante de « la fixture est le seul producteur », par omission : ce n'est pas qu'aucun test n'exerce le chemin, c'est que tous l'exercent dans la configuration où le défaut se tait. D'où le choix, dans le nouveau helper, de rendre `fallacies` **obligatoire et keyword-only** — on ne peut plus recréer l'angle mort en oubliant le paramètre.

## Tests

`tests/unit/argumentation_analysis/orchestration/test_formal_axes_decoupled_from_fallacies.py`, 8 tests. Chaque axe est comparé **à lui-même**, sophismes en amont comme seule variable : c'est cette comparaison, plutôt qu'une forme attendue figée, qui fait mourir le test si l'injection revient n'importe où sur le chemin. Plus un garde structurel paramétré sur les trois axes formels, qui épingle la règle et non les deux instances — un troisième couplage, en modal ou sur un chemin que les tests comportementaux n'atteignent pas, échouera là plutôt que de passer en silence.

Substitution **sur le code**, avec kill-sets disjoints :

| substitution | tests tués |
|---|---|
| injection PL réintroduite | 4 — les 3 comportementaux PL + le garde paramétré sur PL |
| dérivation FOL réintroduite | 3 — les 2 comportementaux FOL + le garde paramétré sur FOL |

Aucun recouvrement : aucun test n'est redondant, chacun vise son propre défaut. La paramétrisation modale survit aux deux — elle mesure une propriété déjà vraie, et le garde sert à ce qu'elle le reste.

## Ce que je n'affirme pas

- **Pas** que #1637 soit visible sur les artefacts réels courants. Sur les trois, la traduction NL→PL a réussi (33 / 12 / 32 formules) et le repli n'a pas été atteint : aucune formule à `!` en tête. Le défaut est atteignable par construction et prouvé par substitution, **pas observé sur ces runs-là**. Il mord dans le régime dégradé.
- **Pas** que l'axe FOL soit maintenant sain. Le contenu qu'il transmet bel et bien porte encore le défaut de #1634 — un `consistent: False` fabriqué depuis un crash de parsing. Indépendant de cette PR.
- **Pas** que `inferences` doive rester vide pour toujours. Tweety sait déduire ; le câbler est une autre question. En attendant, la valeur honnête est la liste vide, et le champ marque l'endroit.

## Vérifications

- `black --check` et `flake8` : propres sur les deux fichiers
- 93 tests verts sur les fichiers directement concernés (`test_nl_to_logic_wiring.py`, `test_structured_arg_translator.py`, le nouveau fichier)
- Grep de contrôle (DoD #1637 item 4) : **0** lecture de `phase_hierarchical_fallacy_output` dans `_invoke_propositional_logic`, `_invoke_fol_reasoning`, `_invoke_modal_logic`

🤖 Coordinator ai-01 — R757
