### PR TITLE
fix(restitution): a missing act cedes the floor to its precise motif (#1617)

### DIFF
--- a/argumentation_analysis/reporting/restitution/pipeline_adapter.py
+++ b/argumentation_analysis/reporting/restitution/pipeline_adapter.py
@@ -129,7 +129,9 @@ def _read_act_degraded(state: Any) -> Dict[str, str]:
     return flattened
 
 
-def build_restitution_acts(state: Any, source_id: Optional[str] = None) -> RestitutionActs:
+def build_restitution_acts(
+    state: Any, source_id: Optional[str] = None
+) -> RestitutionActs:
     """Build a ``RestitutionActs`` from a completed spectacular shared-state.
 
     Reads the three act strings (populated by the ``act1_framing`` /
@@ -139,12 +141,12 @@ def build_restitution_acts(state: Any, source_id: Optional[str] = None) -> Resti
     honestly ("acte indisponible"), never fabricated (anti-pendule #1019/#369).
 
     Degradation motifs persisted by the act state writers (#1608) are read here
-    too — see ``_read_act_degraded``. Known boundary: the renderer only prints a
-    degradation note for an act that HAS text (its degraded branch sits below the
-    missing-act ``continue``), so a motif explaining a *missing* act does not
-    reach the reader. Recorded rather than fixed here — widening the renderer is
-    a separate change with its own test.
+    too — see ``_read_act_degraded``. The renderer prints a degradation note for
+    a missing act too: when the motif is present it *cedes the floor* to it, so
+    the precise reason an act is missing reaches the reader instead of a
+    hard-coded (and, for Acte III, false) cause (#1617).
     """
+
     def _read(key: str) -> str:
         if isinstance(state, dict):
             val = state.get(key, "")

--- a/argumentation_analysis/reporting/restitution/renderer.py
+++ b/argumentation_analysis/reporting/restitution/renderer.py
@@ -39,19 +39,31 @@ from .readability_gate import GateVerdict, ReadabilityGate
 # this comfortably.
 _MIN_ACT_CHARS = 120
 
+# Generic fallback for a missing act. Honest by construction: it names the
+# missing act and what the reader loses, but it does NOT name a cause — the
+# cause is only known from the precise motif filed in ``acts.degraded`` (when
+# the generator ran far enough to record one). ``_MISSING_ACT_LEAD`` is the
+# short form used when a motif *is* available and this wording cedes the floor
+# to it (#1617).
+_MISSING_ACT_LEAD = {
+    1: "Acte I indisponible",
+    2: "Acte II indisponible",
+    3: "Acte III indisponible",
+}
+
 _MISSING_ACT_WORDING = {
     1: (
         "Acte I indisponible — le générateur de mise en situation n'a pas "
-        "produit de cadre (non câblé ou en échec). Le rapport entre directement "
-        "dans l'analyse sans filet de cadrage."
+        "produit de cadre. Le rapport entre directement dans l'analyse sans "
+        "filet de cadrage."
     ),
     2: (
-        "Acte II indisponible — le récit dialectique n'a pas pu être généré "
-        "(cœur narratif absent). Le rapport n'a pas de substance narrative."
+        "Acte II indisponible — le récit dialectique n'a pas pu être généré. "
+        "Le rapport n'a pas de substance narrative."
     ),
     3: (
-        "Acte III indisponible — la conclusion actionnable n'a pas été générée "
-        "(portes G1–G4 non évaluées). Le rapport s'arrête sans synthèse."
+        "Acte III indisponible — la conclusion actionnable n'a pas été générée. "
+        "Le rapport s'arrête sans synthèse."
     ),
 }
 
@@ -106,9 +118,25 @@ class RestitutionReportRenderer:
             body_parts.append("")
 
             if acts.is_missing(n):
-                # fail-loud: name the missing act, never omit
-                body_parts.append(f"_{_MISSING_ACT_WORDING[n]}_")
-                body_parts.append("")
+                # fail-loud: name the missing act, never omit. But a missing
+                # act may carry the *precise* reason it is missing in
+                # ``acts.degraded`` (e.g. no LLM injected, LLM produced nothing,
+                # no substrate). When such a motif exists, the generic wording
+                # cedes the floor to it — the wording stays only when no motif
+                # was recorded (#1617). The ``continue`` is deliberate: a
+                # missing act must NOT also fall through to the degraded branch
+                # *or* the "thin act" check (``min_act_chars``) below, which
+                # would count 0 chars and add misleading noise.
+                key = RestitutionActs.act_key(n)
+                motif = acts.degraded.get(key)
+                if motif:
+                    body_parts.append(f"_{_MISSING_ACT_LEAD[n]}._")
+                    body_parts.append("")
+                    body_parts.append(f"> ⚠️ **Acte dégradé** — {motif}")
+                    body_parts.append("")
+                else:
+                    body_parts.append(f"_{_MISSING_ACT_WORDING[n]}_")
+                    body_parts.append("")
                 continue
 
             body_parts.append(text)

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_missing_act_motif_1617.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_missing_act_motif_1617.py
@@ -1,0 +1,177 @@
+"""#1617 — a missing act must not have its precise degradation motif thrown away.
+
+When an act is missing (empty narrative), the renderer used to print a
+hard-coded wording and ``continue`` past the degraded branch — so the *precise*
+reason the act is missing (filed in ``acts.degraded``) never reached the reader.
+
+For Acte III the hard-coded wording named a cause — *« portes G1–G4 non
+évaluées »* — that is **false on all three real paths** that produce a missing
+act (verified firsthand in ``act3_conclusion_plugin.build_act3_conclusion``):
+
+* ``empty_state`` (l.1509) — G1 WAS evaluated (and failed); the real cause is
+  *« Aucun argument extrait »*.
+* no LLM injected (l.1521) — the gates passed; the real cause is
+  *« aucun LLM injecté »*.
+* LLM produced nothing (l.1547) — gates passed, LLM called; the real cause is
+  *« le LLM n'a rien produit »*.
+
+The fix: the hard-coded wording *cedes the floor* to the precise motif when one
+exists, and is itself made honest-generic (no false cause named). The
+``continue`` stays in place — a missing act must not also pass through the
+"thin act" check (``min_act_chars``), which would count 0 chars and add
+misleading noise.
+
+The same mechanism covers Acte I and Acte II — verified firsthand: both have
+missing-with-degraded return paths in their generators
+(``act1_framing_plugin`` l.570/583, ``act2_narrative_plugin`` l.1294/1306/1318),
+so the defect is NOT specific to Acte III (contrary to the issue body's guess
+that act1/act2 were "sains"). The fix is generic in the renderer's per-act
+loop. This contradicts the parallel drawn with #1615: #1615 was about motif
+flattening at ``_read_act_degraded``; #1617 is about the renderer's ``continue``
+short-circuit — a different mechanism that hits all three acts.
+
+Falsifiability — ``test_three_missing_paths_produce_distinct_renders`` asserts
+the three renders DIFFER. On the pre-fix code they are identical (the motif is
+dropped, the same hard-coded wording is printed for all three), so the
+inequalities fail. Degenerate substitution: delete the
+``acts.degraded.get(key)`` lookup in the renderer's missing-act branch → all
+three renders collapse to the generic wording again → the test fails.
+
+Anti-pendule: ``_MISSING_ACT_WORDING`` is NOT removed — it stays as the generic
+fallback when no motif was recorded (an act never invoked produces none).
+"""
+
+from __future__ import annotations
+
+from argumentation_analysis.reporting.restitution.acts import RestitutionActs
+from argumentation_analysis.reporting.restitution.renderer import (
+    RestitutionReportRenderer,
+)
+
+# The exact motifs ``build_act3_conclusion`` records on the three missing-act
+# paths (act3_conclusion_plugin.py:1509/1521/1547). Using the real strings, not
+# paraphrases — the test must break if the plugin rewording drifts.
+_ACT3_MISSING_MOTIFS = {
+    "empty_state": (
+        "Aucun argument extrait — l'Acte III n'a pas de substrat à conclure "
+        "(G1 échoué : identified_arguments vide)."
+    ),
+    "llm_absent": (
+        "Conclusion non conduite — aucun LLM injecté pour l'Acte III "
+        "(fail-loud, #1108)."
+    ),
+    "llm_mute": (
+        "Conclusion indisponible — le LLM n'a rien produit (fail-loud, #1108)."
+    ),
+}
+
+# The hard-coded cause the renderer used to print unconditionally for a missing
+# Acte III — false on all three paths above (G1 is evaluated, not "non évaluée").
+_FALSE_ACT3_CAUSE = "portes G1–G4 non évaluées"
+
+
+def _acts_with_missing_act3(motif: str) -> RestitutionActs:
+    """Three-act bundle with Acte III missing and a precise motif recorded."""
+    return RestitutionActs(
+        act1_framing="Cadre woven suffisamment long pour éviter le seuil min_act_chars.",
+        act2_narrative="Récit dialectique woven suffisamment long pour le seuil.",
+        act3_conclusion="",
+        source_id="doc_A",
+        degraded={"act3_conclusion": motif},
+    )
+
+
+class TestMissingActMotifCeded:
+    """A missing act with a recorded motif prints the motif, not a false cause."""
+
+    def test_three_missing_paths_produce_distinct_renders(self) -> None:
+        """The three real missing-act paths render to DISTINCT markdown.
+
+        The assertion is on the DIFFERENCE between renders, not on the presence
+        of any particular word. On the pre-fix code the three renders are
+        identical (the motif is dropped, the same hard-coded wording is printed),
+        so these inequalities fail — that is the defect.
+        """
+        renders = {
+            path: RestitutionReportRenderer()
+            .render(_acts_with_missing_act3(motif))
+            .markdown
+            for path, motif in _ACT3_MISSING_MOTIFS.items()
+        }
+        assert renders["empty_state"] != renders["llm_absent"]
+        assert renders["empty_state"] != renders["llm_mute"]
+        assert renders["llm_absent"] != renders["llm_mute"]
+
+    def test_missing_act_with_motif_prints_the_motif(self) -> None:
+        """The precise motif reaches the reader (here: the empty_state path)."""
+        acts = _acts_with_missing_act3(_ACT3_MISSING_MOTIFS["empty_state"])
+        md = RestitutionReportRenderer().render(acts).markdown
+        assert "Aucun argument extrait" in md
+
+    def test_missing_act_with_motif_does_not_name_false_cause(self) -> None:
+        """The hard-coded false cause is gone when a real motif exists."""
+        acts = _acts_with_missing_act3(_ACT3_MISSING_MOTIFS["empty_state"])
+        md = RestitutionReportRenderer().render(acts).markdown
+        assert _FALSE_ACT3_CAUSE not in md
+
+    def test_missing_act_without_motif_uses_generic_fallback(self) -> None:
+        """No motif recorded → generic honest wording (an act never invoked).
+
+        ``_MISSING_ACT_WORDING`` stays — but honest: it names the missing act
+        without naming a cause it did not observe.
+        """
+        acts = RestitutionActs(
+            act1_framing="Cadre woven suffisamment long pour le seuil.",
+            act2_narrative="Récit dialectique woven suffisamment long pour le seuil.",
+            act3_conclusion="",
+            source_id="doc_A",
+            degraded={},
+        )
+        md = RestitutionReportRenderer().render(acts).markdown
+        assert "Acte III indisponible" in md
+        assert _FALSE_ACT3_CAUSE not in md
+
+
+class TestMissingActTwinsAct1Act2:
+    """The same mechanism covers Acte I and Acte II (verified firsthand).
+
+    Both have missing-with-degraded return paths in their generators, so the
+    renderer's ``continue`` short-circuit dropped their motifs too. The fix is
+    generic in the per-act loop, so it covers them without per-act code.
+    """
+
+    def test_missing_act1_cedes_to_its_motif(self) -> None:
+        acts = RestitutionActs(
+            act1_framing="",
+            act2_narrative="Récit dialectique woven suffisamment long pour le seuil.",
+            act3_conclusion="Conclusion woven suffisamment long pour le seuil.",
+            source_id="doc_A",
+            degraded={
+                "act1_framing": (
+                    "Cadrage non conduit — aucun LLM injecté pour l'Acte I "
+                    "(fail-loud, #1108)."
+                )
+            },
+        )
+        md = RestitutionReportRenderer().render(acts).markdown
+        assert "Cadrage non conduit" in md
+        # the disjunctive hard-coded wording ("non câblé ou en échec") cedes
+        assert "non câblé ou en échec" not in md
+
+    def test_missing_act2_cedes_to_its_motif(self) -> None:
+        acts = RestitutionActs(
+            act1_framing="Cadre woven suffisamment long pour le seuil.",
+            act2_narrative="",
+            act3_conclusion="Conclusion woven suffisamment long pour le seuil.",
+            source_id="doc_A",
+            degraded={
+                "act2_narrative": (
+                    "Aucun argument extrait — l'Acte II n'a pas de substrat "
+                    "argumentatif à narrer (identified_arguments vide)."
+                )
+            },
+        )
+        md = RestitutionReportRenderer().render(acts).markdown
+        assert "Aucun argument extrait" in md
+        # the hard-coded wording ("cœur narratif absent") cedes
+        assert "cœur narratif absent" not in md


### PR DESCRIPTION
## #1617 — a missing act cedes the floor to its precise motif

When an act was **missing** (empty narrative), the renderer printed a hard-coded wording and `continue` past the degraded branch — so the *precise* reason the act was missing (filed in `acts.degraded`) never reached the reader.

For **Acte III** the hard-coded wording named a cause — *« portes G1–G4 non évaluées »* — that is **false on all three real paths** that produce a missing act (verified firsthand in `build_act3_conclusion`, `act3_conclusion_plugin.py`):

| path | line | real cause recorded in `degraded` | « portes G1–G4 non évaluées » ? |
|---|---|---|---|
| `empty_state` | 1509 | *« Aucun argument extrait — G1 échoué : identified_arguments vide »* | **faux** — G1 was evaluated, and failed |
| no LLM | 1521 | *« Conclusion non conduite — aucun LLM injecté »* | **faux** — gates passed, LLM missing |
| LLM mute | 1547 | *« Conclusion indisponible — le LLM n'a rien produit »* | **faux** — gates passed, LLM called, empty output |

The reader could not distinguish three radically different situations (a corpus with no extractable arguments vs. an infrastructure with no LLM vs. a mute LLM), and received instead a fourth cause that occurred in none of them.

### The fix (`renderer.py`)

In the missing-act branch, when `acts.degraded[key]` carries a motif, it **cedes the floor** to it: a short lead (`_MISSING_ACT_LEAD`) + the degradation note (`> ⚠️ **Acte dégradé** — {motif}`). The generic `_MISSING_ACT_WORDING` stays only when **no motif** was recorded (an act never invoked produces none).

The three paths now render to **distinct** markdown — each carries its real cause.

`_MISSING_ACT_WORDING` is **not removed** (anti-pendule) but is made honest-generic: it names the missing act and what the reader loses, without naming a cause it did not observe. (Removed: *« (portes G1–G4 non évaluées) »*, *« (non câblé ou en échec) »*, *« (cœur narratif absent) »*.)

The `continue` is **deliberate** and stays: a missing act must NOT fall through to the degraded branch *or* the "thin act" check (`min_act_chars`), which would count 0 chars and add misleading noise.

### Twins verified firsthand — the defect is NOT specific to Acte III

The issue body guessed act1/act2 were "sains" (cf. #1615). **They are not.** `build_act1_framing` (l.570/583) and `build_act2_narrative` (l.1294/1306/1318) have the same missing-with-degraded return paths. Their wording was a *disjunction* (« non câblé ou en échec », « cœur narratif absent ») — less false than act3's named cause, but the precise motif was just as thrown away. The fix is generic in the per-act loop, so it covers all three acts without per-act code.

This is a **different mechanism** from #1615: #1615 was about motif flattening at `_read_act_degraded`; #1617 is about the renderer's `continue` short-circuit — one layer up, hitting all three acts.

### DoD

- [x] A missing act **with a motif** prints it; the degraded branch is no longer short-circuited by `continue` (the motif is emitted *before* the `continue`)
- [x] The fallback wording no longer names a cause it did not observe — generic when no motif, cedes when one exists
- [x] Test: the **three** paths produce **three distinct renders**; the assertion is on the **difference**, not on the presence of a word
- [x] Twins Acte I / Acte II measured before generalizing — they have the defect (contrary to the issue body); the fix covers them generically
- [x] No corpus content outside gitignored artefacts; opaque IDs only

### Falsifiability — `test_missing_act_motif_1617.py` (6 tests, all red pre-fix)

`test_three_missing_paths_produce_distinct_renders` asserts the three renders DIFFER. On the pre-fix code they are identical (motif dropped, same wording printed) → the inequalities fail. Degenerate substitutions with disjoint kill-sets:

| Sub | Kills | Spares |
|---|---|---|
| **Sub A** — force `motif = None` in the missing branch | distinct-renders, prints-the-motif, act1-cedes, act2-cedes | does-not-name-false-cause, generic-fallback |
| **Sub B** — reintroduce *« portes G1–G4 non évaluées »* in `_MISSING_ACT_WORDING[3]` | does-not-name-false-cause, generic-fallback | distinct-renders, prints-the-motif, act1-cedes, act2-cedes |

Sub A verified empirically (pytest exit 1 under patch; passes after revert). Neither assertion is vacuous.

### Validation

- `pytest tests/unit/argumentation_analysis/reporting/restitution/` → **314 passed** (was 308; +6 here, 0 regressions; `test_missing_act_named_not_omitted`, `test_degraded_act_note_surfaced`, `test_thin_act_warns` all still green).
- `black` clean.
- Dep #1614 (`_read_act_degraded`) merged → `RestitutionActs.degraded` is populated on a real run.
- mypy: `renderer.py`/`pipeline_adapter.py` not in the 8-file CI gate.

### Scope

`renderer.py` (the fix) + `pipeline_adapter.py` (comment: the boundary it documented is now lifted) + the test. Read-only verification: `act{1,2,3}_plugin.py`, `acts.py`. **No change to any act generator** — this is purely the renderer's missing-act branch.

Privacy: opaque IDs (`doc_A`), no corpus content.

🤖 Worker myia-po-2023 — #1617
