### PR TITLE
fix(restitution): drop the unread synthesis flag, un-bias the appendix signal (#1620)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -33,9 +33,13 @@ Verdict band — honest adaptation of #1008 §2 to the restitution context:
 
 Privacy HARD: opaque IDs only (``arg_N``, fallacy families are taxonomy
 constants). The prompt carries the OPAQUE_ID_DIRECTIVE (FB-34). Corpus-derived
-fields (fallacy justifications, counter-content, synthesis snippets) are
-**truncated** before entering the prompt; the LLM is told to paraphrase, never
-echo verbatim — the final R6 scrub (spec §6) is the downstream guard.
+fields (fallacy justifications, counter-content) are **truncated** before
+entering the prompt; the LLM is told to paraphrase, never echo verbatim — the
+final R6 scrub (spec §6) is the downstream guard. (#1620: "synthesis snippets"
+used to be listed here and never were one — no synthesis text has ever entered
+this prompt; the ``_SYNTHESIS_CAP`` that would have capped it was declared in
+the same commit as the claim and never used. Both removed rather than
+implemented, since nothing in the prose needs them.)
 
 Testability: ``build_act3_evidence`` is deterministic (no LLM/JVM/API); the LLM
 is an injectable async callable ``Callable[[str], Awaitable[str]]`` (FB-29/38
@@ -64,7 +68,6 @@ LlmCallable = Callable[[str], Awaitable[str]]
 # prompt-budget discipline). The LLM is told to paraphrase, not echo.
 _JUSTIFICATION_CAP = 200
 _COUNTER_CAP = 200
-_SYNTHESIS_CAP = 400
 # SV (#1182): caps for governance/debate evidence (privacy + prompt budget).
 _DEBATE_CAP = 200
 _DEBATE_MAX_EXCHANGES = 4
@@ -336,7 +339,6 @@ class Act3Evidence:
     weak_points: List[StructuringWeakPoint] = field(default_factory=list)
     counter_strategies: List[CounterStrategy] = field(default_factory=list)
     verdict: Optional[VerdictBand] = None
-    narrative_synthesis_available: bool = False
     gates: Dict[str, bool] = field(default_factory=dict)
     # SV (#1182): governance verdict + debate exchanges, surfaced so the
     # conclusion can cite collective deliberation. None/empty when the phases
@@ -877,12 +879,18 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
 
     quality_strengths = _collect_quality_strengths(quality)
 
-    narrative_synthesis = getattr(state, "narrative_synthesis", None)
-    narrative_synthesis_available = bool(
-        narrative_synthesis
-        and isinstance(narrative_synthesis, str)
-        and narrative_synthesis.strip()
-    )
+    # #1620 — ``narrative_synthesis_available`` was read here and dropped. It is
+    # gone by subtraction, not relocated: measured on three real artifacts, the
+    # Acte III prose asserts *nothing* about a narrative synthesis (0 mentions
+    # in 3447 / 3742 / 3560 chars of conclusion) even where the state carries a
+    # 5053-char one, so the flag guarded no claim. The availability signal the
+    # reader does get comes from ``appendix.py`` (``synthese_narrative``), which
+    # computes it from the state directly — a working reader, not this one.
+    #
+    # Anti-pendule: do NOT reintroduce it as "evidence the prompt might use one
+    # day". A flag that changes no verdict is not a reader (#1019). If Acte III
+    # should ever *use the synthesis content*, that is a different gesture —
+    # passing the text, not a boolean — and it needs its own issue.
 
     # SV (#1182): surface governance verdict + debate exchanges (debranched
     # capabilities — same fix shape as G6 for counter-arg validity).
@@ -921,7 +929,6 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
         weak_points=weak_points,
         counter_strategies=counter_strategies,
         verdict=verdict,
-        narrative_synthesis_available=narrative_synthesis_available,
         gates=gates,
         virtuous_mode=virtuous_mode,
         governance_verdict=governance_verdict,

--- a/argumentation_analysis/reporting/restitution/appendix.py
+++ b/argumentation_analysis/reporting/restitution/appendix.py
@@ -251,6 +251,13 @@ def _provenance_counts(state: Mapping[str, Any]) -> Dict[str, Any]:
     # Anti-pendule: this resolves at the *reader*, deliberately. The two state
     # fields keep their own histories and are NOT merged — a state migration
     # would be a much larger gesture for the same observable fix.
+    #
+    # This resolver is only live because ``state_adapter._STATE_KEYS`` carries
+    # ``final_conclusion``. ``state`` here is the *projection*, not the state:
+    # resolving a key the projection drops is inert in production while passing
+    # any unit test built on a raw dict — which is exactly how the first cut of
+    # this fix shipped green and dead. Both hops are pinned separately in
+    # ``test_synthesis_two_lane_1620.py``.
     counts["synthese_narrative"] = (
         "présente"
         if (_g("narrative_synthesis") or _g("final_conclusion"))

--- a/argumentation_analysis/reporting/restitution/appendix.py
+++ b/argumentation_analysis/reporting/restitution/appendix.py
@@ -239,8 +239,22 @@ def _provenance_counts(state: Mapping[str, Any]) -> Dict[str, Any]:
     else:
         counts["arg_structuree"] = "indisponible"
 
+    # #1620 — two-lane resolver. The two voies file the *same* thing under two
+    # keys: the pipeline writers put the narrative synthesis in
+    # ``narrative_synthesis``, while on the conversational voie the PM is told
+    # (``pm/prompts.py`` l.95) to call ``set_final_conclusion`` with its
+    # synthèse, which lands in ``final_conclusion``. Reading only the first key
+    # reported "absente" for every conversational run that *did* synthesise —
+    # and a report that looks quieter reads as a healthier report, which biases
+    # any pipeline-vs-conversational comparison in favour of the louder voie.
+    #
+    # Anti-pendule: this resolves at the *reader*, deliberately. The two state
+    # fields keep their own histories and are NOT merged — a state migration
+    # would be a much larger gesture for the same observable fix.
     counts["synthese_narrative"] = (
-        "présente" if _g("narrative_synthesis") else "absente"
+        "présente"
+        if (_g("narrative_synthesis") or _g("final_conclusion"))
+        else "absente"
     )
     counts["synthese_formelle"] = (
         "présente" if _g("formal_synthesis_reports") else "absente"

--- a/argumentation_analysis/reporting/restitution/state_adapter.py
+++ b/argumentation_analysis/reporting/restitution/state_adapter.py
@@ -30,6 +30,17 @@ _STATE_KEYS = (
     "aspic_results",
     "structured_arg_status",
     "narrative_synthesis",
+    # #1620 — not a spec §2 axis of its own. The *synthesis* axis has two
+    # writers: the pipeline files it under ``narrative_synthesis``, while on the
+    # conversational voie the PM is instructed (``pm/prompts.py`` l.95) to copy
+    # its synthèse into ``set_final_conclusion``. This projection is what the
+    # appendix reader receives, so a key absent here is invisible downstream no
+    # matter what the reader tries to resolve — the two-lane resolver in
+    # ``appendix._provenance_counts`` was inert until this key was carried.
+    # Kept under its own name rather than aliased onto ``narrative_synthesis``:
+    # the opt-in full-state dump renders mapped content verbatim, and filing one
+    # field's text under the other's name would misattribute it.
+    "final_conclusion",
     "formal_synthesis_reports",
     "stakes_and_stakeholders",
     "source_metadata",

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_synthesis_two_lane_1620.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_synthesis_two_lane_1620.py
@@ -1,0 +1,114 @@
+"""#1620 — the appendix's "synthèse narrative" signal must not favour one voie.
+
+The two orchestration voies file the *same* semantic object under two different
+state keys:
+
+* **pipeline** — ``state_writers`` (l.1266 / l.1305) write the narrative
+  synthesis into ``state.narrative_synthesis``.
+* **conversational** — the PM prompt (``pm/prompts.py`` l.95) instructs the
+  agent to call ``StateManager.set_final_conclusion(conclusion="[Copie de votre
+  synthèse ici]")``, which lands in ``state.final_conclusion``
+  (``shared_state.py`` l.224).
+
+``_provenance_counts`` read only the first key, so a conversational run that
+*did* synthesise was reported ``synthese_narrative = "absente"``. That is the
+one-lane-writer bias: the quieter report reads as the healthier one, which
+skews any pipeline-vs-conversational comparison in favour of the louder voie.
+
+Falsifiability — ``test_both_voies_agree_when_each_wrote_its_own_key`` asserts
+the two voies produce the **same** value from the same content. On the pre-fix
+code the conversational side yields "absente" while the pipeline side yields
+"présente", so the equality fails. Degenerate substitution: delete the
+``or _g("final_conclusion")`` term → the conversational case reverts to
+"absente" → the test fails.
+
+Scope: this is a *reader-side* resolver. The two state fields keep their own
+histories and are deliberately NOT merged (a state migration would be a far
+larger gesture for the same observable fix).
+"""
+
+from __future__ import annotations
+
+from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+    Act3Evidence,
+)
+from argumentation_analysis.reporting.restitution.appendix import _provenance_counts
+
+# The synthesis text is identical on both voies — the voie is the only variable.
+_SYNTHESIS = "Le discours articule trois mouvements argumentatifs distincts."
+
+
+def _state(**overrides):
+    """Minimal state; only the synthesis-carrying keys vary between cases."""
+    base = {
+        "identified_arguments": {"arg_1": "thèse A"},
+        "identified_fallacies": {},
+        "counter_arguments": [],
+        "argument_quality_scores": {},
+        "narrative_synthesis": "",
+        "final_conclusion": None,
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSynthesisPresenceAgreesAcrossVoies:
+    """Same content in ⇒ same signal out, whichever voie wrote it."""
+
+    def test_both_voies_agree_when_each_wrote_its_own_key(self) -> None:
+        """The load-bearing assertion: agreement, not a particular wording.
+
+        Pre-fix, the conversational state yields "absente" and the pipeline one
+        "présente" — the inequality *is* the defect.
+        """
+        pipeline = _provenance_counts(_state(narrative_synthesis=_SYNTHESIS))
+        conversational = _provenance_counts(_state(final_conclusion=_SYNTHESIS))
+
+        assert (
+            pipeline["synthese_narrative"] == conversational["synthese_narrative"]
+        ), "the two voies must report the same synthesis presence for the same content"
+        assert pipeline["synthese_narrative"] == "présente"
+
+    def test_conversational_synthesis_is_not_reported_absent(self) -> None:
+        """The concrete regression: a conversational synthesis exists and counts."""
+        counts = _provenance_counts(_state(final_conclusion=_SYNTHESIS))
+        assert counts["synthese_narrative"] == "présente"
+
+    def test_neither_voie_wrote_anything_stays_absent(self) -> None:
+        """Anti-pendule: the resolver must not fabricate presence from nothing."""
+        counts = _provenance_counts(_state())
+        assert counts["synthese_narrative"] == "absente"
+
+    def test_empty_conversational_conclusion_stays_absent(self) -> None:
+        """An empty/whitespace conclusion is not a synthesis (falsy, like the twin)."""
+        assert (
+            _provenance_counts(_state(final_conclusion=""))["synthese_narrative"]
+            == "absente"
+        )
+
+
+class TestAct3DroppedTheUnreadFlag:
+    """#1620 defect 1 — the flag is gone by subtraction, not relocated.
+
+    ``Act3Evidence.narrative_synthesis_available`` was computed from
+    ``state.narrative_synthesis`` and passed into the bundle, and no code ever
+    read it (3 sites, all declaration/computation/construction). Measured on
+    three real artifacts, the Acte III prose asserts nothing about a narrative
+    synthesis even where the state carries a 5053-char one — so the flag
+    guarded no claim.
+
+    This test pins the *rule*, not the instance: a boolean on the evidence
+    bundle exists to gate prose, so re-adding this one silently would restore
+    the defect. Re-adding it **with a reader** is a different change and would
+    come with its own test.
+    """
+
+    def test_flag_is_absent_from_the_evidence_bundle(self) -> None:
+        assert not hasattr(Act3Evidence(), "narrative_synthesis_available")
+
+    def test_evidence_builder_does_not_reintroduce_it(self) -> None:
+        """Constructing the bundle must not accept the removed keyword."""
+        import pytest
+
+        with pytest.raises(TypeError):
+            Act3Evidence(narrative_synthesis_available=True)

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_synthesis_two_lane_1620.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_synthesis_two_lane_1620.py
@@ -15,24 +15,54 @@ state keys:
 one-lane-writer bias: the quieter report reads as the healthier one, which
 skews any pipeline-vs-conversational comparison in favour of the louder voie.
 
-Falsifiability — ``test_both_voies_agree_when_each_wrote_its_own_key`` asserts
-the two voies produce the **same** value from the same content. On the pre-fix
-code the conversational side yields "absente" while the pipeline side yields
-"présente", so the equality fails. Degenerate substitution: delete the
-``or _g("final_conclusion")`` term → the conversational case reverts to
-"absente" → the test fails.
+**Two hops, two ways to be inert.** The reader does not receive the state — it
+receives ``state_adapter.state_to_appendix_mapping(state)``, a projection onto
+``_STATE_KEYS``. A resolver that reads a key the projection drops is green in a
+unit test built on a raw dict and dead in production. That happened here: the
+first cut of this fix touched only the reader, and a probe on the real
+``render_spectacular_restitution`` path still printed
+``| synthese_narrative | absente |`` for a state carrying a synthesis (found in
+review by po-2023). The tests below therefore pin *each hop separately* plus the
+composed path, so no single edit can make the chain silently inert again:
 
-Scope: this is a *reader-side* resolver. The two state fields keep their own
-histories and are deliberately NOT merged (a state migration would be a far
-larger gesture for the same observable fix).
+===========================  ======================================  ==========
+test class                   what it would catch                     hop
+===========================  ======================================  ==========
+``TestReaderResolvesBoth``   reader stops resolving the second key   reader
+``TestProjectionCarries``    projection stops carrying the key       projection
+``TestProdPathAgrees``       either hop breaks                       composed
+``TestRenderedReport``       either hop breaks, at the surface        end-to-end
+===========================  ======================================  ==========
+
+Degenerate substitutions (all run, none reasoned):
+
+* delete ``or _g("final_conclusion")`` in ``_provenance_counts`` → the reader,
+  prod-path and rendered tests fail; the projection test **survives**.
+* delete ``"final_conclusion"`` from ``_STATE_KEYS`` → the projection, prod-path
+  and rendered tests fail; the reader test **survives**.
+
+Neither substitution kills everything, so neither hop's guard is redundant.
+
+Scope: this is a *reader-side* resolver fed by a widened projection. The two
+state fields keep their own names and histories and are deliberately NOT merged
+— aliasing one onto the other would misattribute its text in the opt-in
+full-state dump, which renders mapped content verbatim.
 """
 
 from __future__ import annotations
+
+import pytest
 
 from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
     Act3Evidence,
 )
 from argumentation_analysis.reporting.restitution.appendix import _provenance_counts
+from argumentation_analysis.reporting.restitution.pipeline_adapter import (
+    render_spectacular_restitution,
+)
+from argumentation_analysis.reporting.restitution.state_adapter import (
+    state_to_appendix_mapping,
+)
 
 # The synthesis text is identical on both voies — the voie is the only variable.
 _SYNTHESIS = "Le discours articule trois mouvements argumentatifs distincts."
@@ -52,17 +82,53 @@ def _state(**overrides):
     return base
 
 
-class TestSynthesisPresenceAgreesAcrossVoies:
-    """Same content in ⇒ same signal out, whichever voie wrote it."""
+def _prod_counts(**overrides):
+    """Counts as production computes them: through the projection, not around it."""
+    return _provenance_counts(state_to_appendix_mapping(_state(**overrides)))
+
+
+class TestReaderResolvesBoth:
+    """Hop 1 — the reader itself, handed both keys directly."""
+
+    def test_reader_accepts_either_key(self) -> None:
+        assert (
+            _provenance_counts({"narrative_synthesis": _SYNTHESIS})[
+                "synthese_narrative"
+            ]
+            == "présente"
+        )
+        assert (
+            _provenance_counts({"final_conclusion": _SYNTHESIS})["synthese_narrative"]
+            == "présente"
+        )
+
+
+class TestProjectionCarries:
+    """Hop 2 — the projection must not drop what the reader resolves.
+
+    This is the guard whose absence made the first cut of the fix inert: the
+    reader was correct and never saw the key.
+    """
+
+    def test_projection_carries_both_synthesis_keys(self) -> None:
+        mapping = state_to_appendix_mapping(_state(final_conclusion=_SYNTHESIS))
+        assert "final_conclusion" in mapping, (
+            "the appendix reader receives this projection, not the state — "
+            "a key dropped here is invisible downstream whatever the reader does"
+        )
+
+    def test_projection_omits_absent_keys(self) -> None:
+        """Anti-pendule: widening the projection must not fabricate entries."""
+        assert "final_conclusion" not in state_to_appendix_mapping(_state())
+
+
+class TestProdPathAgrees:
+    """Composed — same content in ⇒ same signal out, whichever voie wrote it."""
 
     def test_both_voies_agree_when_each_wrote_its_own_key(self) -> None:
-        """The load-bearing assertion: agreement, not a particular wording.
-
-        Pre-fix, the conversational state yields "absente" and the pipeline one
-        "présente" — the inequality *is* the defect.
-        """
-        pipeline = _provenance_counts(_state(narrative_synthesis=_SYNTHESIS))
-        conversational = _provenance_counts(_state(final_conclusion=_SYNTHESIS))
+        """The load-bearing assertion: agreement, not a particular wording."""
+        pipeline = _prod_counts(narrative_synthesis=_SYNTHESIS)
+        conversational = _prod_counts(final_conclusion=_SYNTHESIS)
 
         assert (
             pipeline["synthese_narrative"] == conversational["synthese_narrative"]
@@ -70,20 +136,39 @@ class TestSynthesisPresenceAgreesAcrossVoies:
         assert pipeline["synthese_narrative"] == "présente"
 
     def test_conversational_synthesis_is_not_reported_absent(self) -> None:
-        """The concrete regression: a conversational synthesis exists and counts."""
-        counts = _provenance_counts(_state(final_conclusion=_SYNTHESIS))
-        assert counts["synthese_narrative"] == "présente"
+        """The concrete regression, measured where production measures it."""
+        assert _prod_counts(final_conclusion=_SYNTHESIS)["synthese_narrative"] == (
+            "présente"
+        )
 
     def test_neither_voie_wrote_anything_stays_absent(self) -> None:
         """Anti-pendule: the resolver must not fabricate presence from nothing."""
-        counts = _provenance_counts(_state())
-        assert counts["synthese_narrative"] == "absente"
+        assert _prod_counts()["synthese_narrative"] == "absente"
 
     def test_empty_conversational_conclusion_stays_absent(self) -> None:
         """An empty/whitespace conclusion is not a synthesis (falsy, like the twin)."""
-        assert (
-            _provenance_counts(_state(final_conclusion=""))["synthese_narrative"]
-            == "absente"
+        assert _prod_counts(final_conclusion="")["synthese_narrative"] == "absente"
+
+
+class TestRenderedReport:
+    """End-to-end — the row a reader actually sees in the rendered appendix."""
+
+    class _ConvState:
+        """A conversational run: the PM copied its synthèse into final_conclusion."""
+
+        act1_framing = "Cadrage."
+        act2_investigation = "Investigation."
+        act3_conclusion = "Conclusion."
+        final_conclusion = _SYNTHESIS
+        identified_arguments = {"arg_1": "thèse A"}
+
+    def test_conversational_run_renders_synthesis_as_present(self) -> None:
+        markdown = render_spectacular_restitution(
+            self._ConvState(), source_id="doc_A"
+        ).markdown
+        assert "| synthese_narrative | présente |" in markdown, (
+            "a conversational run that synthesised must not be rendered 'absente' — "
+            "this is the surface the one-lane bias reached"
         )
 
 
@@ -108,7 +193,5 @@ class TestAct3DroppedTheUnreadFlag:
 
     def test_evidence_builder_does_not_reintroduce_it(self) -> None:
         """Constructing the bundle must not accept the removed keyword."""
-        import pytest
-
         with pytest.raises(TypeError):
             Act3Evidence(narrative_synthesis_available=True)

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
@@ -123,9 +123,15 @@ PROSE_BASELINE = frozenset(
 # no claim and was removed. The appendix still attests it, which is why the key
 # lands here rather than disappearing: it is genuinely "attested but not
 # mobilised" — the exact divergence this module exists to keep visible.
+#
+# ``final_conclusion`` joined in the same change, from the other direction: it
+# was never projected at all, so the appendix could not see the synthesis the
+# conversational voie writes. It is carried now (``_STATE_KEYS``) and the prose
+# still does not read it — annexe-only by construction, not by attrition.
 ANNEXE_ONLY = frozenset(
     {
         "aspic_results",
+        "final_conclusion",
         "formal_synthesis_reports",
         "narrative_synthesis",
         "workflow_results",

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
@@ -104,7 +104,6 @@ PROSE_BASELINE = frozenset(
         "identified_arguments",
         "identified_fallacies",
         "modal_analysis_results",
-        "narrative_synthesis",
         "propositional_analysis_results",
         "source_metadata",
         "stakes_and_stakeholders",
@@ -115,10 +114,20 @@ PROSE_BASELINE = frozenset(
 # Axes the ANNEXE attests (``state_adapter._STATE_KEYS``) that the PROSE never
 # reads — declared "disponible" in the appendix table but absent from the
 # conclusion's conducted prompt.
+#
+# ``narrative_synthesis`` joined this set in #1620. It used to sit in the
+# intersection: ``build_act3_evidence`` read it — and reduced it to a boolean
+# (``narrative_synthesis_available``) that no code ever consumed. Measured on
+# three real artifacts, the Acte III prose asserts nothing about a narrative
+# synthesis even where the state carries a 5053-char one, so the read guarded
+# no claim and was removed. The appendix still attests it, which is why the key
+# lands here rather than disappearing: it is genuinely "attested but not
+# mobilised" — the exact divergence this module exists to keep visible.
 ANNEXE_ONLY = frozenset(
     {
         "aspic_results",
         "formal_synthesis_reports",
+        "narrative_synthesis",
         "workflow_results",
     }
 )


### PR DESCRIPTION
Closes #1620.

Two stacked defects on the narrative-synthesis signal. The issue framed them as a choice between "remove the flag" and "wire it a reader"; the measurement says **both, in two different places** — because defect 2 does not disappear when the flag does. It just moves to the module that actually has a reader.

## The discriminating question, answered by measurement

The DoD asked for it on a real artifact, not a fixture: *what does the Acte III prose assert today about the synthesis?*

| corpus | `act3_conclusion` | `narrative_synthesis` | flag would read | act III mentions a synthesis? |
|---|---|---|---|---|
| corpus_A | 3447 chars | 0 | `False` | **none** |
| corpus_B | 3742 chars | 3307 | `True` | **none** |
| corpus_C | 3560 chars | 5053 | `True` | **none** |

Measured on the raw state, not the audit rendering (the audit's act3 section is 11-13 lines of long paragraphs, which could have masked a truncation — it did not; both agree).

The flag genuinely discriminates on real data, and the prose is **identical in this respect** across all three. Acte III writes its own ~3.5k-char conclusion from scratch and says nothing about the synthesis, including where the state carries a 5053-char one. **The flag guarded no claim** → option 1, subtraction.

## Defect 1 — subtraction

`Act3Evidence.narrative_synthesis_available`: 3 sites (declaration / computation / construction), **zero consumers repo-wide including tests**. Removed with it:

- `_SYNTHESIS_CAP = 400` — declared in the same commit as the flag (`9de8feff`) and **never used since**, on any line.
- The module docstring's claim that "synthesis snippets" are truncated *before entering the prompt*. No synthesis text has ever entered that prompt. The cap and the claim were the design of a data flow that was never built.

## Defect 2 — not moot, and it has a real reader

The one-lane writer afflicts `appendix._provenance_counts`, which **does** reach the reader:

- pipeline → `state_writers` file the synthesis in `narrative_synthesis`
- conversational → the PM is instructed (`pm/prompts.py` l.95) to call `set_final_conclusion(conclusion="[Copie de votre synthèse ici]")`, landing it in `final_conclusion` — a key **no restitution module reads**

So every conversational run that *did* synthesise was reported `synthese_narrative = "absente"`. A quieter report reads as a healthier one, which biases any pipeline-vs-conversational comparison toward the louder voie. Fixed with a resolver **at the reader**; the two state fields keep their own histories and are deliberately not merged (anti-pendule from the issue).

## The #1624 baseline moves rather than shrinks

`test_ast_prose_matches_baseline` fired on the subtraction — correctly: it pins the set of state keys the prose surface reads, and the prose no longer reads `narrative_synthesis`. So the key leaves `PROSE_BASELINE` and joins `ANNEXE_ONLY` — *"attested by the appendix, not mobilised by the conclusion"*, which is precisely what it now is. The guard did its job; the update is deliberate and documented in place, not a silent green.

Note this refines the DoD's prediction ("option 1: no test should die"). None died *for the flag* — the flag had no test reader. What died was a guard on the **state read** that fed it. Read and claim are two different things, which is the issue's own distinction.

## Falsifiability — three substitutions, disjoint kill-sets

| substitution | kills | survives |
|---|---|---|
| drop `or _g("final_conclusion")` | the 2 agreement tests | subtraction + baseline |
| re-add the flag to `Act3Evidence` | the 2 subtraction tests | agreement + baseline |
| re-add `getattr(state, "narrative_synthesis")` | `test_ast_prose_matches_baseline` | agreement + subtraction |

Disjoint ⇒ no assertion is vacuous. All three run and measured, not reasoned.

## Not claimed

- **Not** that Acte III should never use the synthesis. It should probably use the *content* — 74 s and nine sections reduced to a boolean is the real waste — but that is a different gesture (passing text, not a flag) and needs its own issue. Re-adding a boolean would be branching for branching.
- **Not** that the appendix wording is ideal; only that it now answers the same for the same content on both voies.

## Tests

`tests/unit/argumentation_analysis/reporting/restitution/` — **314 passed** (+6). flake8 clean. Black: `appendix.py` has a pre-existing violation on `main` at an unrelated helper (`_pl_verdict_of`); my edit introduces **no new** violation (diff of complaints against `main` is empty), and I did not reformat unrelated code.

⚠️ CI has not run: GitHub Actions is in a major outage (incident `qcvjkzcs7j74`). The numbers above are local.

🤖 Coordinator ai-01
