### PR TITLE
fix(orchestration): retire L9 analysis_synthesis phase (#1625, R759)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -161,7 +161,6 @@ __all__ = [
     "_invoke_text_to_kb",
     "_invoke_kb_to_tweety",
     "_invoke_tweety_interpretation",
-    "_invoke_analysis_synthesis",
     "_invoke_external_fol_solver",
     "_invoke_external_modal_solver",
     "_invoke_deep_synthesis",
@@ -8537,106 +8536,6 @@ def _count_referenced_fields(state: Any) -> int:
         if val and (isinstance(val, (list, dict)) and len(val) > 0):
             count += 1
     return count
-
-
-# ---------------------------------------------------------------------------
-# Analysis synthesis invoke callable (#508)
-# ---------------------------------------------------------------------------
-
-
-async def _invoke_analysis_synthesis(
-    input_text: str, context: Dict[str, Any]
-) -> Dict[str, Any]:
-    """Aggregate all analysis phase outputs into a structured synthesis (#508).
-
-    Collects results from quality, fallacy, counter-argument, debate,
-    governance, and formal phases (from context), and produces a
-    structured summary with scores and key findings.
-    """
-    state = context.get("_state_object")
-    phase_results = {}
-
-    # Collect phase outputs from context
-    for key, val in context.items():
-        if (
-            key.startswith("phase_")
-            and key.endswith("_output")
-            and isinstance(val, dict)
-        ):
-            phase_name = key[len("phase_") : -len("_output")]
-            phase_results[phase_name] = val
-
-    # Build structured synthesis from state if available
-    sections = {}
-
-    # Quality summary
-    quality_scores = getattr(state, "argument_quality_scores", None) if state else None
-    if quality_scores and isinstance(quality_scores, (list, dict)):
-        sections["quality"] = {
-            "evaluated": (
-                len(quality_scores)
-                if isinstance(quality_scores, list)
-                else len(quality_scores)
-            ),
-            "summary": f"{len(quality_scores)} arguments evaluated",
-        }
-
-    # Fallacy summary
-    fallacies = getattr(state, "identified_fallacies", None) if state else None
-    if fallacies and isinstance(fallacies, list):
-        sections["fallacies"] = {
-            "count": len(fallacies),
-            "types": list(
-                set(f.get("type", "unknown") for f in fallacies if isinstance(f, dict))
-            ),
-        }
-
-    # Counter-argument summary
-    counter_args = getattr(state, "counter_arguments", None) if state else None
-    if counter_args and isinstance(counter_args, list):
-        sections["counter_arguments"] = {
-            "generated": len(counter_args),
-        }
-
-    # JTMS beliefs
-    jtms_beliefs = getattr(state, "jtms_beliefs", None) if state else None
-    if jtms_beliefs and isinstance(jtms_beliefs, (list, dict)):
-        sections["beliefs"] = {
-            "tracked": (
-                len(jtms_beliefs)
-                if isinstance(jtms_beliefs, list)
-                else len(jtms_beliefs)
-            ),
-        }
-
-    # Formal results
-    for field_name in [
-        "dung_frameworks",
-        "fol_analysis_results",
-        "propositional_analysis_results",
-        "modal_analysis_results",
-    ]:
-        formal = getattr(state, field_name, None) if state else None
-        if formal and isinstance(formal, (list, dict)):
-            sections[field_name] = {"present": True, "size": len(formal)}
-
-    # Overall assessment
-    total_phases = len(phase_results)
-    sections_count = len(sections)
-    overall_completeness = (
-        sections_count / max(total_phases, 1) if total_phases > 0 else 0.0
-    )
-
-    return {
-        "synthesis": sections,
-        "phase_count": total_phases,
-        "sections_count": sections_count,
-        "overall_completeness": round(overall_completeness, 2),
-        "phase_results_summary": {
-            name: "completed" if "error" not in res else f"error: {res['error'][:50]}"
-            for name, res in phase_results.items()
-        },
-    }
 
 
 # --- State writers: map capability → (output, state, ctx) → None ---

--- a/argumentation_analysis/orchestration/registry_setup.py
+++ b/argumentation_analysis/orchestration/registry_setup.py
@@ -57,7 +57,6 @@ from argumentation_analysis.orchestration.invoke_callables import (
     _invoke_text_to_kb,
     _invoke_kb_to_tweety,
     _invoke_tweety_interpretation,
-    _invoke_analysis_synthesis,
     _invoke_narrative_synthesis,
     _invoke_act2_narrative,
     _invoke_act1_framing,
@@ -670,24 +669,6 @@ def setup_registry(
             registered.append(name)
         except Exception as e:
             skipped.append((name, str(e)))
-
-    # --- Analysis synthesis service (#508) ---
-    try:
-        registry.register_service(
-            name="analysis_synthesis_service",
-            service_class=type("analysis_synthesis_service", (), {}),
-            capabilities=["analysis_synthesis"],
-            metadata={
-                "description": (
-                    "Terminal aggregation of all analysis phase outputs "
-                    "into a structured synthesis report"
-                )
-            },
-            invoke=_invoke_analysis_synthesis,
-        )
-        registered.append("analysis_synthesis_service")
-    except Exception as e:
-        skipped.append(("analysis_synthesis_service", str(e)))
 
     # --- Collaborative multi-agent debate (#175) ---
     try:

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -1468,22 +1468,6 @@ def _write_tweety_interpretation_to_state(
             state.formal_interpretation = interpretation
 
 
-def _write_analysis_synthesis_to_state(
-    output: Any, state: Any, ctx: dict[str, Any]
-) -> None:
-    """Write analysis synthesis results to UnifiedAnalysisState (#508)."""
-    if not output or not isinstance(output, dict):
-        return
-    synthesis = output.get("synthesis", {})
-    if isinstance(synthesis, dict) and synthesis:
-        if hasattr(state, "analysis_synthesis"):
-            state.analysis_synthesis = {
-                "synthesis": synthesis,
-                "phase_count": output.get("phase_count", 0),
-                "overall_completeness": output.get("overall_completeness", 0.0),
-            }
-
-
 def _write_external_fol_solver_to_state(
     output: Any, state: Any, ctx: dict[str, Any]
 ) -> None:
@@ -1577,7 +1561,6 @@ CAPABILITY_STATE_WRITERS: Dict[str, Any] = {
     "nl_extraction": _write_text_to_kb_to_state,
     "kb_to_tweety": _write_kb_to_tweety_to_state,
     "formal_result_interpretation": _write_tweety_interpretation_to_state,
-    "analysis_synthesis": _write_analysis_synthesis_to_state,
     "external_fol_solving": _write_external_fol_solver_to_state,
     "external_modal_solving": _write_external_modal_solver_to_state,
 }

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -996,25 +996,16 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             optional=True,
             timeout_seconds=180,
         )
-        # L9 — terminal synthesis aggregation (#508)
-        .add_phase(
-            "synthesis",
-            capability="analysis_synthesis",
-            depends_on=[
-                "quality",
-                "counter",
-                "debate",
-                "governance",
-                "formal_synthesis",
-            ],
-            optional=True,
-        )
-        # L10 — Deep synthesis: grounded 9-section markdown report (#534)
+        # L10 — Deep synthesis: grounded 9-section markdown report (#534).
+        # Depends on belief_revision + stakes (the meaningful predecessors).
+        # The previous L9 "analysis_synthesis" aggregation phase (#508) was
+        # removed in #1625 (R759): zero prod reader, zero LLM call, the cost
+        # was the orchestration step itself. Anti-pendule — depend_on must
+        # not reference a phase that no longer exists.
         .add_phase(
             "deep_synthesis",
             capability="deep_synthesis",
             depends_on=[
-                "synthesis",
                 "belief_revision",
                 "stakes",
             ],

--- a/tests/unit/argumentation_analysis/orchestration/test_belief_revision_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_belief_revision_spectacular.py
@@ -24,11 +24,12 @@ class TestBeliefRevisionSpectacularPhase:
 
         wf = build_spectacular_workflow()
         # Canary: bump this when build_spectacular_workflow gains/loses a phase
-        # (catches an accidental dropped/duplicated phase). 40 = 31 (E1b base)
-        # + 5 W1 reasoners (setaf/aba/delp/dl/dialogue, #1169) incl. the
+        # (catches an accidental dropped/duplicated phase). 39 = 31 (E1b base
+        # minus the #1625-retired L9 `synthesis` aggregation phase) + 5 W1
+        # reasoners (setaf/aba/delp/dl/dialogue, #1169) incl. the
         # belief_revision phase wired here, + 4 #1178 reasoners
         # (weighted/social/qbf/cl).
-        assert len(wf.phases) == 40
+        assert len(wf.phases) == 39
 
     def test_belief_revision_state_writer_exists(self):
         from argumentation_analysis.orchestration.state_writers import (

--- a/tests/unit/argumentation_analysis/orchestration/test_external_solver_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_external_solver_spectacular.py
@@ -41,11 +41,12 @@ class TestExternalSolverSpectacular:
 
         wf = build_spectacular_workflow()
         # Canary: bump this when build_spectacular_workflow gains/loses a phase
-        # (catches an accidental dropped/duplicated phase). 40 = 31 (E1b base)
-        # + 5 W1 reasoners (setaf/aba/delp/dl/dialogue, #1169) incl. the L5
+        # (catches an accidental dropped/duplicated phase). 39 = 31 (E1b base
+        # minus the #1625-retired L9 `synthesis` aggregation phase) + 5 W1
+        # reasoners (setaf/aba/delp/dl/dialogue, #1169) incl. the L5
         # external fol_solver + modal_solver phases + narrative_synthesis,
         # + 4 #1178 reasoners (weighted/social/qbf/cl).
-        assert len(wf.phases) == 40
+        assert len(wf.phases) == 39
 
     def test_external_fol_solver_service_registered(self):
         from argumentation_analysis.orchestration.registry_setup import setup_registry

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
@@ -334,7 +334,6 @@ class TestSpectacularWorkflowGolden:
         "kb_to_tweety",
         "tweety_interpretation",
         "belief_revision",
-        "synthesis",
         "deep_synthesis",
         # Restitution acts (Epic #1134): R2 framing + R3 narrative + R4 conclusion.
         "act1_framing",
@@ -352,8 +351,10 @@ class TestSpectacularWorkflowGolden:
         # (determinization residue #1109 §5); count reflects real phase set PLUS
         # the three restitution acts (R2 act1_framing #1136, R3 act2_narrative
         # #1137, R4 act3_conclusion #1138) wired onto the spectacular DAG.
+        # #1625 (R759): the L9 `analysis_synthesis` (#508 terminal aggregation)
+        # was retired (zero prod reader). Phase count drops from 40 to 39.
         wf = build_spectacular_workflow()
-        assert len(wf.phases) == 40
+        assert len(wf.phases) == 39
 
     def test_all_expected_phases_present(self):
         wf = build_spectacular_workflow()
@@ -374,10 +375,14 @@ class TestSpectacularWorkflowGolden:
         # belief_revision, synthesis, deep_synthesis) PLUS the three restitution
         # acts: act1_framing (R2, depends on extract+stakes), act2_narrative
         # (R3, depends on deep_synthesis) and act3_conclusion (R4, depends on
-        # act2_narrative — the terminal level). Execution order is now 10 levels.
+        # act2_narrative — the terminal level).
+        # #1625 (R759): L9 `synthesis` aggregation phase was retired. L10
+        # `deep_synthesis` now depends on belief_revision + stakes only, which
+        # were already satisfied at L4/L2 before L9 existed. The DAG drops
+        # from 10 levels to 8.
         wf = build_spectacular_workflow()
         levels = wf.get_execution_order()
-        assert len(levels) == 10
+        assert len(levels) == 8
 
     def test_extract_is_sole_entry_point(self):
         wf = build_spectacular_workflow()
@@ -439,15 +444,17 @@ class TestSpectacularWorkflowGolden:
         wf = build_spectacular_workflow()
         results, state = await _execute_workflow(wf)
         failed = [r for r in results.values() if r.status == PhaseStatus.FAILED]
-        assert failed == [], f"Phases failed: {[r for r in results if results[r].status == PhaseStatus.FAILED]}"
+        assert (
+            failed == []
+        ), f"Phases failed: {[r for r in results if results[r].status == PhaseStatus.FAILED]}"
         for name, phase in [(p.name, p) for p in wf.phases]:
             result = results.get(name)
             if result is None:
                 continue
             if not getattr(phase, "optional", True):
-                assert result.status == PhaseStatus.COMPLETED, (
-                    f"Non-optional phase {name} did not complete: {result.status}"
-                )
+                assert (
+                    result.status == PhaseStatus.COMPLETED
+                ), f"Non-optional phase {name} did not complete: {result.status}"
 
     @pytest.mark.asyncio
     async def test_no_failed_phases(self):
@@ -679,9 +686,11 @@ class TestWorkflowCatalogGolden:
         catalog = get_workflow_catalog()
         assert "spectacular" in catalog
         assert catalog["spectacular"].name == "spectacular_analysis"
-        # #1115: spectacular has 31 phases (narrative_synthesis template removed;
-        # DAG grew via #504/#506/#507/#508/#534 + 3 restitution acts R2/R3/R4).
-        assert len(catalog["spectacular"].phases) == 40
+        # #1115: spectacular grew to 31 phases (narrative_synthesis template
+        # removed; DAG grew via #504/#506/#507/#508/#534 + 3 restitution
+        # acts R2/R3/R4). #1625 (R759) retired L9 `analysis_synthesis`,
+        # dropping the count from 40 to 39.
+        assert len(catalog["spectacular"].phases) == 39
 
     def test_catalog_includes_sherlock_modern(self):
         catalog = get_workflow_catalog()

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
@@ -31,14 +31,17 @@ class TestSpectacularWorkflowDAG:
         # #1115: the template `narrative_synthesis` phase was REMOVED from the
         # spectacular workflow (determinization residue per #1109 §5). The count
         # reflects the real phase set (#504 solvers, #506 KB/tweety, #507
-        # belief_revision, #508 synthesis, #534 deep_synthesis, ...) PLUS the
-        # three restitution acts wired onto the spectacular DAG: act1_framing
+        # belief_revision, #534 deep_synthesis, ...) PLUS the three
+        # restitution acts wired onto the spectacular DAG: act1_framing
         # (R2 #1136), act2_narrative (R3 #1137) and act3_conclusion (R4 #1138)
         # — the 3-act narrative.
+        # #1625 (R759): the L9 `analysis_synthesis` (#508 terminal aggregation)
+        # was retired (zero prod reader). Phase count drops from 40 to 39.
         wf = build_spectacular_workflow()
-        # 40 = 31 (E1b base) + 5 W1 reasoners (#1169: setaf/aba/delp/dl/dialogue)
-        # + 4 #1178 reasoners (weighted/social/qbf/cl).
-        assert len(wf.phases) == 40
+        # 39 = 31 (E1b base, was 30 post-#1625) + 5 W1 reasoners (#1169:
+        # setaf/aba/delp/dl/dialogue) + 4 #1178 reasoners (weighted/social/
+        # qbf/cl). -1 vs pre-#1625 because the L9 `synthesis` phase is gone.
+        assert len(wf.phases) == 39
 
     def test_all_expected_phases_present(self):
         wf = build_spectacular_workflow()
@@ -75,7 +78,6 @@ class TestSpectacularWorkflowDAG:
             "kb_to_tweety",
             "tweety_interpretation",
             "belief_revision",
-            "synthesis",
             "deep_synthesis",
             # Restitution acts (Epic #1134): R2 framing + R3 narrative + R4 conclusion.
             "act1_framing",

--- a/tests/unit/argumentation_analysis/orchestration/test_synthesis_spectacular.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_synthesis_spectacular.py
@@ -1,27 +1,44 @@
-"""Tests for synthesis phase wiring in spectacular (#508)."""
+"""Tests for synthesis phase wiring in spectacular (#508).
+
+R759 / #1625: the L9 `analysis_synthesis` aggregation phase was retired —
+zero prod reader, zero LLM call. This file now covers the surviving
+synthesis path (L10 `deep_synthesis`) and the post-retrait invariant:
+the spectacular workflow MUST NOT contain a phase named `synthesis`.
+"""
 
 from unittest.mock import MagicMock
 
 
 class TestSynthesisSpectacularPhase:
-    """Verify synthesis phase exists in spectacular with correct DAG deps."""
+    """Verify the synthesis chain (deep_synthesis) is wired and that the
+    retired L9 `analysis_synthesis` aggregation phase stays absent."""
 
-    def test_spectacular_has_synthesis_phase(self):
+    def test_spectacular_no_synthesis_phase_after_retrait(self):
+        """#1625: L9 `analysis_synthesis` was removed. The phase name MUST
+        not reappear in the spectacular workflow — depend_on, registration,
+        and state writer were all cleaned up; a re-introduction would be a
+        regression against the anti-pendule decision."""
+        from argumentation_analysis.orchestration.workflows import (
+            build_spectacular_workflow,
+        )
+
+        wf = build_spectacular_workflow()
+        phase_names = {p.name for p in wf.phases}
+        assert "synthesis" not in phase_names
+
+    def test_spectacular_deep_synthesis_depends_on_belief_revision_and_stakes(self):
+        """#1625: L10 `deep_synthesis` lost its dependency on the removed L9
+        `synthesis`. It must now depend on `belief_revision` + `stakes` only.
+        Anti-pendule: depend_on must not name a phase that no longer exists."""
         from argumentation_analysis.orchestration.workflows import (
             build_spectacular_workflow,
         )
 
         wf = build_spectacular_workflow()
         phase = {p.name: p for p in wf.phases}
-        assert "synthesis" in phase
-        assert phase["synthesis"].capability == "analysis_synthesis"
-        deps = phase["synthesis"].depends_on
-        assert "quality" in deps
-        assert "counter" in deps
-        assert "debate" in deps
-        assert "governance" in deps
-        assert "formal_synthesis" in deps
-        assert phase["synthesis"].optional is True
+        assert "deep_synthesis" in phase
+        deps = set(phase["deep_synthesis"].depends_on)
+        assert deps == {"belief_revision", "stakes"}
 
     def test_spectacular_phase_count_with_synthesis(self):
         from argumentation_analysis.orchestration.workflows import (
@@ -31,13 +48,15 @@ class TestSynthesisSpectacularPhase:
         wf = build_spectacular_workflow()
         # The workflow grew from 21 to 31 phases over #504/#506/#507/#508/#534/
         # Epic #1134 (3 acts + deep_synthesis + stakes + kb pipeline + solvers).
-        # A fixed exact count is fragile test-debt; assert load-bearing invariants
-        # instead: the synthesis chain is present and the mandatory acts exist.
+        # #1625 (R759) removed the L9 `synthesis` phase, lowering the floor by
+        # one. A fixed exact count is fragile test-debt; assert load-bearing
+        # invariants instead: the surviving synthesis chain is present and the
+        # mandatory acts exist.
         phase_names = {p.name for p in wf.phases}
-        assert "synthesis" in phase_names
+        assert "synthesis" not in phase_names  # #1625 retrait
         assert "deep_synthesis" in phase_names
         assert {"act1_framing", "act2_narrative", "act3_conclusion"} <= phase_names
-        assert len(wf.phases) >= 21  # never regresses below the original floor
+        assert len(wf.phases) >= 20  # never regresses below the post-retrait floor
 
     def test_deep_synthesis_state_writer_registered(self):
         """D1b (#1167): the deep_synthesis phase must have a state writer, else
@@ -50,8 +69,7 @@ class TestSynthesisSpectacularPhase:
 
         assert "deep_synthesis" in CAPABILITY_STATE_WRITERS
         assert (
-            CAPABILITY_STATE_WRITERS["deep_synthesis"]
-            is _write_deep_synthesis_to_state
+            CAPABILITY_STATE_WRITERS["deep_synthesis"] is _write_deep_synthesis_to_state
         )
 
     def test_write_deep_synthesis_populates_narrative(self):
@@ -70,10 +88,7 @@ class TestSynthesisSpectacularPhase:
             state,
             {},
         )
-        assert (
-            state.narrative_synthesis
-            == "Synthèse ancrée avec [artifact:arg_1]."
-        )
+        assert state.narrative_synthesis == "Synthèse ancrée avec [artifact:arg_1]."
 
     def test_write_deep_synthesis_drops_empty_fail_loud(self):
         """D1b (#1167): empty/unavailable grounded_synthesis is left as the empty
@@ -89,37 +104,21 @@ class TestSynthesisSpectacularPhase:
         _write_deep_synthesis_to_state({}, state, {})
         assert state.narrative_synthesis == ""
 
-    def test_analysis_synthesis_state_writer_registered(self):
+    def test_analysis_synthesis_state_writer_absent_after_retrait(self):
+        """#1625: CAPABILITY_STATE_WRITERS must not carry the removed
+        `analysis_synthesis` entry — otherwise the registry would crash on
+        phase resolution at runtime."""
         from argumentation_analysis.orchestration.state_writers import (
             CAPABILITY_STATE_WRITERS,
         )
 
-        assert "analysis_synthesis" in CAPABILITY_STATE_WRITERS
+        assert "analysis_synthesis" not in CAPABILITY_STATE_WRITERS
 
-    def test_analysis_synthesis_service_in_registry(self):
+    def test_analysis_synthesis_capability_not_registered(self):
+        """#1625: the analysis_synthesis capability must not resolve to any
+        provider in the registry."""
         from argumentation_analysis.orchestration.registry_setup import setup_registry
 
         registry = setup_registry()
         providers = registry.find_for_capability("analysis_synthesis")
-        names = [p.name for p in providers]
-        assert "analysis_synthesis_service" in names
-        provider = next(p for p in providers if p.name == "analysis_synthesis_service")
-        assert provider.invoke is not None
-
-    def test_write_analysis_synthesis_to_state(self):
-        from argumentation_analysis.orchestration.state_writers import (
-            _write_analysis_synthesis_to_state,
-        )
-
-        state = MagicMock()
-        output = {
-            "synthesis": {
-                "quality": {"evaluated": 3},
-                "fallacies": {"count": 2},
-            },
-            "phase_count": 5,
-            "overall_completeness": 0.8,
-        }
-        _write_analysis_synthesis_to_state(output, state, {})
-        assert state.analysis_synthesis["phase_count"] == 5
-        assert state.analysis_synthesis["overall_completeness"] == 0.8
+        assert providers == []

--- a/tests/unit/argumentation_analysis/orchestration/test_text_kb_spectacular_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_text_kb_spectacular_wiring.py
@@ -68,7 +68,9 @@ class TestSpectacularWorkflowPhases:
         # the original 20) to 40. Sibling tests (test_spectacular_regression_suite,
         # test_belief_revision_spectacular, test_external_solver_spectacular,
         # test_spectacular_workflow_dag) already assert 40; this one was missed.
-        assert len(wf.phases) == 40
+        # #1625 (R759): L9 `analysis_synthesis` was retired (zero prod reader,
+        # no LLM call). Phase count drops from 40 to 39.
+        assert len(wf.phases) == 39
 
 
 class TestInvokeCallables:

--- a/tests/unit/argumentation_analysis/test_deep_synthesis_wiring.py
+++ b/tests/unit/argumentation_analysis/test_deep_synthesis_wiring.py
@@ -80,7 +80,7 @@ class TestDAGOrdering:
         ), f"deep_synthesis not in spectacular phases: {phase_names}"
 
     def test_deep_synthesis_depends_on_correct_phases(self):
-        """deep_synthesis should depend on synthesis, narrative_synthesis, belief_revision."""
+        """deep_synthesis should depend on belief_revision and stakes."""
         from argumentation_analysis.orchestration.workflows import (
             build_spectacular_workflow,
         )
@@ -89,26 +89,41 @@ class TestDAGOrdering:
         ds_phase = next(p for p in wf.phases if p.name == "deep_synthesis")
         # The spectacular workflow has no ``narrative_synthesis`` phase — its
         # narrative output is produced via the ``act1_framing`` /
-        # ``act2_narrative`` / ``act3_conclusion`` phases. deep_synthesis
-        # depends on synthesis + belief_revision + stakes (the validated DAG
-        # edges; all three exist as spectacular phases).
+        # ``act2_narrative`` / ``act3_conclusion`` phases. The L9
+        # ``synthesis`` aggregation phase was retired in #1625 (R759): zero
+        # prod reader, zero LLM call. deep_synthesis now depends on
+        # belief_revision + stakes (the validated DAG edges; both exist as
+        # spectacular phases).
         assert set(ds_phase.depends_on) == {
-            "synthesis",
             "belief_revision",
             "stakes",
         }
 
-    def test_deep_synthesis_is_after_synthesis(self):
-        """deep_synthesis must come after synthesis in the phase list."""
+    def test_deep_synthesis_is_after_all_its_predecessors(self):
+        """deep_synthesis must come after every phase it declares a dep on.
+
+        Stated against ``depends_on`` rather than against a hardcoded phase
+        name: the previous form pinned ``synthesis``, and went stale the day
+        that phase was retired (#1625) without the DAG property itself
+        changing. This form survives the next edge change and still fails if
+        a predecessor is ever declared downstream of its consumer.
+        """
         from argumentation_analysis.orchestration.workflows import (
             build_spectacular_workflow,
         )
 
         wf = build_spectacular_workflow()
         phase_names = [p.name for p in wf.phases]
-        synthesis_idx = phase_names.index("synthesis")
+        ds_phase = next(p for p in wf.phases if p.name == "deep_synthesis")
+        # Guard against a vacuous pass: an empty depends_on would satisfy the
+        # loop below without asserting anything.
+        assert ds_phase.depends_on, "deep_synthesis declares no predecessor"
         ds_idx = phase_names.index("deep_synthesis")
-        assert ds_idx > synthesis_idx
+        for dep in ds_phase.depends_on:
+            assert dep in phase_names, f"declared dep {dep!r} is not a phase"
+            assert (
+                phase_names.index(dep) < ds_idx
+            ), f"{dep!r} is declared after deep_synthesis"
 
     def test_deep_synthesis_not_optional_in_spectacular(self):
         """deep_synthesis should be non-optional in the spectacular workflow."""


### PR DESCRIPTION
# fix(orchestration): retire L9 `analysis_synthesis` phase (#1625, R759)

## Résumé

Le constat coord #1625 (R756 dispatch) : `state.analysis_synthesis` n'a **aucun lecteur en production du dépôt**. Grep exhaustif sur tous styles d'accès (`getattr`, `state.X`, `state.get`, `state[…]`) — ni les builders de restitution (act1/2/3), ni `deep_synthesis_agent.ARTIFACT_FIELDS`, ni aucune autre surface de prod du dépôt. La phase dont le métier est d'agréger 5 phases amont écrit dans un état que personne ne relit côté code source.

**Cette PR traite l'item (1) du triage #1625** — le retrait total du L9 `analysis_synthesis` (cleanup `tweety_formulas_from_kb` item (2) est hors scope, à arbitrer séparément par coord).

**Anti-pendule inscrit** : Fix = suppression du problème, pas ajout d'un contrepoids. La phase coûte un step d'orchestration (no LLM call mais getattr/dict aggregation), un writer, une entrée de registry, une dépendance dans la chaîne de tests golden. Aucune de ces 4 surfaces ne lit rien. On retire les 4.

## Lecteur hors-dépôt (note coord R760)

Coord signale un lecteur hors-dépôt : `scripts/run_real_analysis.py:175` (sur la machine ai-01, **untracked** — n'existe pas dans ce clone, le grep ne pouvait pas l'atteindre). Il consomme `analysis_synthesis` et l'affiche sous « 7b. Synthèse d'analyse (phase `synthesis`) » dans les dumps d'artefacts réels.

**Ça ne change pas la décision** : un script d'audit local n'est pas un consommateur de production du système — c'est précisément la définition #1019 (calculé, écrit, jamais mobilisé par le système). Mais la section 7b des dumps va disparaître après ce merge, et c'est un retrait **délibéré**, pas une capacité perdue. Toute future « comptabilité de complétude » se construira avec son lecteur, pas en recyclant `overall_completeness` calculé-mais-non-lu.

**Anti-pendule explicite** : ne pas ré-introduire plus tard un agrégat « completeness » sans lecteur au motif que « ça pourrait servir ». Ce serait re-créer #1625 sous un autre nom.

## Ce qui est livré

- **`argumentation_analysis/orchestration/workflows.py`** : suppression du bloc `add_phase("synthesis", capability="analysis_synthesis", ...)` (L9). Nettoyement concomitant du `depends_on` de L10 `deep_synthesis` qui référençait `"synthesis"` (`workflows.py:1014-1021`).
  - **Important** : `WorkflowBuilder.build()` lève `ValueError` sur une dépendance pendante (`workflow_dsl.py:321-326`, message « dependency 'X' is not a defined phase »). Sans ce nettoyage de L10, le retrait ne **peut pas** livrer — le build casse net (fail-loud). C'est la partie de la PR qui mérite l'attention, pas les 4 autres fichiers (la queue narrative `act2_narrative` → `act3_conclusion` pend à L10).
- **`argumentation_analysis/orchestration/invoke_callables.py`** : suppression de `_invoke_analysis_synthesis` (L9 invoke callable, pure dict aggregation, no LLM call) + de l'export `__all__`.
- **`argumentation_analysis/orchestration/state_writers.py`** : suppression de `_write_analysis_synthesis_to_state` + de l'entrée `"analysis_synthesis"` dans `CAPABILITY_STATE_WRITERS`.
- **`argumentation_analysis/orchestration/registry_setup.py`** : suppression de l'import `_invoke_analysis_synthesis` + du bloc `register_service(name="analysis_synthesis_service", ...)`.
- **`tests/unit/argumentation_analysis/orchestration/test_synthesis_spectacular.py`** : refonte des 4 tests L9 → invariants de retrait (`"synthesis" not in phase names`, `not in CAPABILITY_STATE_WRITERS`, capability not registered, `depends_on == {belief_revision, stakes}`).
- **`tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py`** + **`test_spectacular_regression_suite.py`** + **`test_belief_revision_spectacular.py`** + **`test_external_solver_spectacular.py`** + **`test_text_kb_spectacular_wiring.py`** : mise à jour des compteurs hardcodés (40 → 39 phases, 10 → 8 levels) avec commentaires référençant #1625.

## Ce qui est prouvé firsthand

| Mesure | Avant | Après |
|---|---|---|
| Phase count spectacular | 40 | 39 |
| DAG levels | 10 | 8 |
| `build_spectacular_workflow()` passe `validate()` | n/a | ✅ (test `test_dag_validates_clean` couvre) |
| Test count (orchestration × 9 fichiers blast radius) | 0/9 verts | **152/152 verts** |
| mypy strict (8 fichiers CI core, dont 4 touchés) | 0 issues | **0 issues, delta 0** |
| black | n/a | clean après auto-fix de 2 tests |
| Lignes nettes | n/a | **−132 (91 + / 223 −)** |

**Isolation R747** : phase topologique confirmée par probe direct (`get_execution_order()` → 8 paliers, deep_synthesis en L5 conjoint avec `dialogue_reasoning`/`formal_synthesis`/`tweety_interpretation`).

**Anti-#1019 / anti-théâtre** : les invariants sont des tests d'**absence** (`not in` / `== 0`), pas des tests d'écriture. Une ré-introduction de la phase casserait immédiatement les 4 tests `test_*_absent_after_retrait` — c'est le test par soustraction, pas par présence. Le test `test_dag_validates_clean` (`test_spectacular_regression_suite.py:368-370`) meurt immédiatement si `depends_on` L10 référence une phase inexistante — c'est le garde fail-loud contre une dépendance pendante.

## Delta de métrique publié (note coord R760)

Le retrait fait **baisser d'une unité** le compte de phases du workflow spectacular :
- `phases_total` dans `evaluation/*` → 40 → 39
- `phases_completed` → 39 → 38 (à l'exécution end-to-end)
- `completion_ratio` → légèrement plus élevé (dénominateur plus petit)

Toute comparaison de baseline post-merge doit lire ce delta comme un retrait de phase (intentionnel), pas comme une régression de complétion.

## Cleanup Gate — Rule B justificatif (commits d'origine)

La règle Rule B de CLAUDE.md (« origin check ») demande justification explicite pour les commits `feat(` supprimés, qui sont des artefacts de feature et non des brouillons. Les deux commits qui ont introduit L9 sont :

- `a70395e4 feat(orchestration): add synthesis phase to spectacular workflow (#508) (#516)` — création L9
- `7b532bc6 feat(synthesis): wire DeepSynthesisAgent as terminal phase + CLI runner (#534) (#535)` — câblage L9 → L10 (`synthesis` dans `depends_on`)

**Justification** : depuis `a70395e4` (2026-07-xx) jusqu'à `12ebc98c` (ce commit), la phase L9 a tourné 0 fois dans une exécution réelle avec un consommateur en aval. Aucune trace d'utilisation dans `evaluation/`, dans la prose de restitution, ni dans `deep_synthesis_agent.ARTIFACT_FIELDS`. Le seul « lecteur » est `scripts/run_real_analysis.py` sur ai-01 (untracked), pas un consommateur de prod du système. C'est précisément le pattern #1019 (calculé-écrit-non-lu) que coord signale dans le constat — la suppression est donc un retrait délibéré, pas une perte de fonctionnalité.

**Cleanup Gate Rule A (justification par fichier) et Rule C (table si >5 suppressions)** : cette PR supprime **0 fichier** (5 blocs édités dans 4 fichiers existants). Donc **ni table, ni justification par fichier** requises. Le périmètre est intra-fichier uniquement.

## Anti-pendule inscrit

- **Zéro nouveau code** ajouté : c'est une PR de suppression pure. Aucun wrapper, aucune compat shim, aucun `try/except` pour "préserver l'API" (l'API n'avait pas de consommateurs de prod).
- **Zéro impact sur les autres workflows** : seul `build_spectacular_workflow()` portait L9. `build_sherlock_modern_workflow` (7 phases, pas de L9) et `build_standard_workflow` intouchés.
- **Zéro impact runtime po-2023** : aucune modif de `llm_cache.py`, `core/llm_service.py`, ou autre module partagé inter-agents.
- **Anti-réintroduction** : les tests `*_absent_after_retrait` détectent toute tentative de ré-introduire L9 — c'est le garde-fou structurel du retrait.

## Suite du triage #1625 (séparé)

- **Item (2) `tweety_formulas_from_kb`** : à arbitrer par coord — le constat note "partiellement récupérable" (un seul des 2 champs lus ?). Hors scope de cette PR — ne pas mélanger dans le même merge (anti-pendule, le mélange cache le verdict).
- **Pas de #1603 mêlé** : cassette PR #1628 est déjà mergée (`d6415011`). PR distincte = distincte.

## Liens

- Issue #1625 — https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/issues/1625
- DoD coord R756/R760 — anti-pendule « pas de troisième option » respecté : on tranche (retrait), on ne câble pas.
- PR admin-merge : compte partagé → coord `--admin` (R658 firsthand).

🤖 Generated with [Claude Code](https://claude.com/claude-code)