### PR TITLE
fix(restitution): tell the Acte III prompt its counter-argument list is partial (#1622)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -68,6 +68,13 @@ LlmCallable = Callable[[str], Awaitable[str]]
 # prompt-budget discipline). The LLM is told to paraphrase, not echo.
 _JUSTIFICATION_CAP = 200
 _COUNTER_CAP = 200
+# #1622 — how many counter-strategies the prompt ENUMERATES. Distinct from
+# ``_COUNTER_CAP`` above (that one truncates each snippet's *text*). Named so the
+# truncation notice below is computed from the same constant that produces the
+# truncation: a literal ``[:8]`` and a hard-coded "8" in the notice can drift
+# apart silently. Do NOT raise it — 16 would have the identical defect at 17;
+# the fix is to *say* the list is partial, not to show more of it.
+_COUNTER_LIST_CAP = 8
 # SV (#1182): caps for governance/debate evidence (privacy + prompt budget).
 _DEBATE_CAP = 200
 _DEBATE_MAX_EXCHANGES = 4
@@ -1088,13 +1095,31 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         )
 
     # --- Que faire (actionnable) ---
-    if evidence.counter_strategies:
+    shown_counters = evidence.counter_strategies[:_COUNTER_LIST_CAP]
+    if shown_counters:
         counters_lines = "\n".join(
             f"  - Pour contrer {cs.target_arg_id} ({cs.strategy}) : {cs.snippet}"
-            for cs in evidence.counter_strategies[:8]
+            for cs in shown_counters
         )
     else:
         counters_lines = "  (aucun contre-argument généré — recommandations de contre limitées aux exceptions de scheme)"
+    # #1622 — the enumeration above is capped, and it is the ONLY place the
+    # prompt lists counter-arguments. Measured on 8 real artifacts, 8/8 carried
+    # more than the cap (11 to 56), so the conclusion routinely wrote its
+    # actionable section from as little as 14 % of the material while nothing
+    # told it a remainder existed. ``counters_total`` already reached the
+    # evidence bundle; only its *magnitude* had no reader (the boolean did, at
+    # the axis test). The notice fires from the gap between what is shown and
+    # what exists — not from the cap alone — so it stays honest if the two ever
+    # diverge, and stays silent (no false alarm) on a run below the cap.
+    _omitted_counters = evidence.counters_total - len(shown_counters)
+    if _omitted_counters > 0:
+        counters_lines += (
+            f"\n  (liste tronquée : {len(shown_counters)} contre-arguments "
+            f"listés sur {evidence.counters_total} au total, "
+            f"{_omitted_counters} non énumérés ici. N'écris pas, et ne laisse "
+            f"pas entendre, que cette liste est exhaustive.)"
+        )
 
     target_lines = (
         "\n".join(

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -27,6 +27,7 @@ import pytest
 
 from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
     Act3Result,
+    _COUNTER_LIST_CAP,
     _fol_verified,
     _is_guest_formal_entry,
     _pl_verified,
@@ -1241,3 +1242,90 @@ class TestUnsupportedClaimBlocked:
         assert "## Ce que l'analyse établit" not in result.narrative
         assert "## Ce qui tient" in result.narrative
         assert "Le raisonnement causal tient" in result.narrative
+
+
+# --- #1622 : la magnitude des contre-arguments circule ------------------------
+
+
+def _counters(n: int) -> List[dict]:
+    """``n`` distinct, well-formed counter-arguments (each passes the filter)."""
+    return [
+        {
+            "target_arg_id": f"arg_{i + 1}",
+            "strategy": "contre-exemple",
+            "counter_content": (
+                f"Contre-argument {i + 1} : la revendication ne tient pas si "
+                "l'on considère un cas où la relation causale s'inverse."
+            ),
+        }
+        for i in range(n)
+    ]
+
+
+def _prompt_with_counters(n: int) -> str:
+    """Prompt built from a state carrying exactly ``n`` counter-arguments."""
+    state = _state(
+        identified_arguments={f"arg_{i + 1}": f"Thèse {i + 1}." for i in range(n or 1)},
+        counter_arguments=_counters(n),
+    )
+    evidence = build_act3_evidence(state)
+    # Guard the fixture itself: the prompt assertions below are only meaningful
+    # if the state really produced ``n`` counter-arguments in the bundle.
+    assert evidence.counters_total == n
+    return build_act3_prompt(evidence)
+
+
+class TestCounterTruncationIsAnnounced:
+    """#1622 — the Acte III prompt enumerates at most ``_COUNTER_LIST_CAP``
+    counter-arguments, and that enumeration is the ONLY place it lists them.
+
+    Measured on 8 real artifacts, 8/8 carried more than the cap (11 to 56), so
+    writing the actionable section from a fraction of the material is the
+    nominal regime, not an edge case. ``counters_total`` reached the evidence
+    bundle but only its *truthiness* had a reader (the axis test); the magnitude
+    had none, so nothing could tell the conclusion a remainder existed.
+    """
+
+    def test_above_the_cap_the_prompt_states_the_true_total(self) -> None:
+        n = _COUNTER_LIST_CAP + 7
+        prompt = _prompt_with_counters(n)
+        # The true total and the omitted count both reach the prompt — not just
+        # "this list is partial", which would leave the magnitude unknown.
+        assert str(n) in prompt
+        assert str(n - _COUNTER_LIST_CAP) in prompt
+        assert "tronquée" in prompt
+
+    def test_at_or_below_the_cap_no_truncation_is_claimed(self) -> None:
+        """Anti-pendule: a systematic notice would be a false alarm.
+
+        A run that fits under the cap loses nothing; saying otherwise would tell
+        the LLM to hedge a complete list.
+        """
+        for n in (0, 1, _COUNTER_LIST_CAP - 1, _COUNTER_LIST_CAP):
+            prompt = _prompt_with_counters(n)
+            assert "tronquée" not in prompt, f"false truncation notice at n={n}"
+            assert "non énumérés" not in prompt, f"false omission notice at n={n}"
+
+    def test_two_states_differing_only_in_count_yield_different_prompts(self) -> None:
+        """The bite proof, and the one the previous test suite could not give.
+
+        ``test_evidence_counts_counter_arguments`` asserts the *field* is
+        computed; it passes identically whether or not anything reads the field.
+        This pins the observable consequence: crossing the cap must change the
+        prompt. Below vs. above, everything else about the two states is equal.
+        """
+        below = _prompt_with_counters(_COUNTER_LIST_CAP)
+        above = _prompt_with_counters(_COUNTER_LIST_CAP + 1)
+        assert below != above
+
+    def test_the_enumeration_itself_stays_capped(self) -> None:
+        """Anti-pendule: the remedy is to *say* the list is partial, not to show
+        more of it. Removing the cap would blow the prompt budget on a corpus
+        with 56 counter-arguments — replacing one line by its opposite.
+        """
+        n = _COUNTER_LIST_CAP + 20
+        prompt = _prompt_with_counters(n)
+        listed = prompt.count("  - Pour contrer ")
+        assert (
+            listed == _COUNTER_LIST_CAP
+        ), f"enumerated {listed}, cap is {_COUNTER_LIST_CAP}"


### PR DESCRIPTION
Ferme #1622.

## Le constat, en une phrase

Le prompt de l'Acte III énumère les contre-stratégies **cappées à 8**, et c'est la **seule** énumération des contre-arguments du prompt. `counters_total` atteignait bien le bundle d'évidence, mais **seule sa véracité booléenne avait un lecteur** (le test d'axe, `if counters_total: axes_nontrivial.append(...)`) : la **magnitude** n'en avait aucun. La conclusion apprenait donc qu'il existe des contre-arguments, en énumérait 8, et n'avait aucun moyen de savoir qu'il y en avait 56.

Sur les 8 artefacts réels mesurés (relevé dans le corps de l'issue), **8/8 sont au-dessus du cap** — de 11 à 56 contre-arguments. Ce n'est pas un cas limite atteignable en théorie : c'est le régime nominal. Sur le plus riche, la section actionnable était écrite depuis 14 % du matériel disponible.

## Le geste

```python
shown_counters = evidence.counter_strategies[:_COUNTER_LIST_CAP]
...
_omitted_counters = evidence.counters_total - len(shown_counters)
if _omitted_counters > 0:
    counters_lines += (
        f"\n  (liste tronquée : {len(shown_counters)} contre-arguments "
        f"listés sur {evidence.counters_total} au total, "
        f"{_omitted_counters} non énumérés ici. N'écris pas, et ne laisse "
        f"pas entendre, que cette liste est exhaustive.)"
    )
```

Deux choix qui méritent d'être dits :

1. **La condition porte sur l'écart entre ce qui est montré et ce qui existe**, pas sur le cap seul (`counters_total > 8`). Les deux coïncident aujourd'hui — `counters_total` et le filtre de construction appliquent le même prédicat — mais la formulation par l'écart reste juste si les deux divergent un jour, et reste silencieuse (pas de fausse alerte) sur un run sous le cap.
2. **`[:8]` devient `_COUNTER_LIST_CAP`.** Un littéral `8` dans la tranche et un `8` en dur dans le message de troncature peuvent dériver l'un de l'autre sans que rien ne le signale. La constante nommée rend l'avis calculé depuis exactement ce qui produit la troncature.

## Anti-pendules respectés

- **Le cap n'est pas retiré.** Il existe pour la taille du prompt ; le supprimer ferait exploser le contexte sur un corpus à 56 contre-arguments. On ne change pas *ce que le prompt montre*, on change *ce qu'il dit de ce qu'il montre*.
- **Le cap n'est pas élargi.** 16 aurait la faille identique à 17.
- **`fallacies_total` n'est pas traité** — honnêtement redondant, `target_lines` énumère sans cap.
- **`weak_points` / `quality_strengths` non plus** : la mesure postée en commentaire de l'issue les écarte (jumeau complet pour l'un, tri par score décroissant pour l'autre). Périmètre : **un seul champ câblé**.

## Tests — 4 ajoutés, chacun gagne sa place

| Substitution dégénérée | Tests qui meurent |
|---|---|
| A — l'avis ne se déclenche **jamais** | `test_above_the_cap_the_prompt_states_the_true_total`, `test_two_states_differing_only_in_count_yield_different_prompts` |
| B — l'avis se déclenche **toujours** | `test_at_or_below_the_cap_no_truncation_is_claimed` |
| C — le cap est **retiré** | `test_above_the_cap_...`, `test_the_enumeration_itself_stays_capped` |

**A ∩ B = ∅** — les deux comportements (dire quand c'est tronqué / se taire quand ça ne l'est pas) sont épinglés séparément, ce que demandait le DoD. Aucun des 4 tests ne survit aux trois substitutions : aucun n'est vacuous.

Le test qui manquait vraiment est `test_two_states_differing_only_in_count_yield_different_prompts`. Le test préexistant (`assert ev.counters_total == 1`) n'assert que le **calcul du champ** — il passe à l'identique que le champ soit lu ou non, donc il ne pouvait structurellement pas attraper l'absence de lecteur. Celui-ci épingle la **conséquence observable** : franchir le cap doit changer le prompt.

La fixture porte aussi sa propre garde (`assert evidence.counters_total == n`) : les assertions sur le prompt ne veulent rien dire si l'état n'a pas réellement produit `n` contre-arguments dans le bundle.

## Mesure

- `tests/unit/argumentation_analysis/reporting/restitution/` : **322 passed**
- `black --check` + `flake8` : clean
- Diff : +115 / −2, 2 fichiers

## Files removed and why

Aucun fichier supprimé.

🤖 Coordinator ai-01
