### PR TITLE
fix(quality): resolve the fallacy target by identifier so the #289 penalty fires (#1633)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -509,22 +509,48 @@ async def _invoke_quality_evaluator(
     detected_fallacies = (
         fallacy_output.get("fallacies", []) if isinstance(fallacy_output, dict) else []
     )
-    # Build a map: arg_index → list of fallacy types targeting that argument
+    # Build a map: arg_index → list of fallacy types targeting that argument.
+    #
+    # #1633 site 2: this read ``target_argument`` into a variable named
+    # ``target_text`` and fed it to a substring match. The field carries an
+    # *identifier* — ``_enrich_fallacies`` writes ``f["target_argument"] =
+    # arg_id`` and no producer of this phase writes prose there — so
+    # ``"arg_1" in <prose>`` and ``<prose>[:40] in "arg_1"`` were both false and
+    # ``fallacy_targets`` stayed empty: the #289 penalty never applied.
+    # Measured on the real producer shape, 0 of 3 arguments were penalized where
+    # 3 of 3 should have been (the pre-existing test passed only because its
+    # fixture supplied full argument text, a value no producer emits).
+    # The defect was invisible because "no argument penalized" looks exactly
+    # like "no fallacy targeted an argument".
+    #
+    # Resolution is now by identifier, shared with ``_generate_attacks_from_args``
+    # (#1629/#1632) — same field, same meaning, one mechanism. ``arg_N`` indexes
+    # the extract phase's argument list 1-based, which is the very list
+    # ``raw_args`` holds, so the inverse is arithmetic. Unresolvable references
+    # (absent, or the ``paragraph_N`` ids the heuristic fallback mints) are
+    # counted and logged, never guessed (#1019).
     fallacy_targets: Dict[int, list[str]] = {}
+    unresolved_fallacy_targets = 0
     for f in detected_fallacies:
         if not isinstance(f, dict):
             continue
-        target_text = f.get("target_argument", "")
         fallacy_type = f.get("type", f.get("fallacy_type", "unknown"))
-        if target_text and raw_args:
-            target_lower = target_text.lower()[:80]
-            for idx, a in enumerate(raw_args[:8]):
-                a_text = (
-                    a.get("text", str(a)) if isinstance(a, dict) else str(a)
-                ).lower()
-                if target_lower in a_text or a_text[:40] in target_lower:
-                    fallacy_targets.setdefault(idx, []).append(str(fallacy_type))
-                    break
+        idx = _resolve_target_argument_index(
+            _read_fallacy_target(f), min(len(raw_args), 8)
+        )
+        if idx is None:
+            unresolved_fallacy_targets += 1
+            continue
+        fallacy_targets.setdefault(idx, []).append(str(fallacy_type))
+    if detected_fallacies:
+        logger.info(
+            "(#289) fallacy→argument targeting: %d resolved onto %d argument(s), "
+            "%d unresolved (of %d detections)",
+            len(detected_fallacies) - unresolved_fallacy_targets,
+            len(fallacy_targets),
+            unresolved_fallacy_targets,
+            len(detected_fallacies),
+        )
 
     if raw_args:
         results = {}
@@ -809,6 +835,12 @@ async def _generate_counters_for_targets(
             f"Total = {k} × (number of items). Each CA must target the same "
             f"item but via a different rhetorical move."
         )
+    # #1633 — TRAP: the ``target_argument`` this prompt asks for is FREE TEXT
+    # (the LLM echoes the argument it rebuts). The identically-named field in
+    # ``phase_hierarchical_fallacy_output`` is an ``arg_N`` IDENTIFIER. Same
+    # name, two meanings — a consumer must know which payload it is reading.
+    # Text-matching is correct HERE and wrong there; identifier resolution is
+    # correct there and wrong here. Do not unify the two branches.
     system_prompt = (
         "You are an expert in argumentation and counter-argument generation. "
         + prompt_count_clause
@@ -3063,6 +3095,44 @@ def _extract_arguments_from_context(
 _ARG_ID_RE = re.compile(r"^\s*arg_(\d+)\s*$")
 
 
+# #1633 — the three key conventions a fallacy record may name its target by.
+# Ordered most-specific first. An explicit loop rather than a chained ``get``
+# default: producers emit the key with a ``None`` value when a detection has no
+# target, and ``get(k, default)`` returns that ``None`` instead of the default.
+_FALLACY_TARGET_KEYS = ("target_argument", "target_argument_id", "target_arg_id")
+
+
+def _read_fallacy_target(fallacy: Dict[str, Any]) -> Any:
+    """First non-empty target reference a fallacy record carries, or ``None``."""
+    for key in _FALLACY_TARGET_KEYS:
+        value = fallacy.get(key)
+        if value:
+            return value
+    return None
+
+
+def _resolve_target_argument_index(raw_target: Any, count: int) -> Optional[int]:
+    """Resolve an upstream ``arg_N`` reference to a 0-based index below ``count``.
+
+    ``arg_1``, ``arg_2``, … are minted by ``shared_state._generate_id`` as
+    ``f"{prefix}_{index + 1}"`` over an insertion-ordered dict, and by
+    ``_extract_arguments_for_parallel`` as ``f"arg_{i+1}"`` over the extract
+    phase's argument list — the same 1-based enumeration in both cases, so the
+    inverse is arithmetic, not matching.
+
+    Returns ``None`` when the reference is absent, malformed (e.g. the
+    ``paragraph_N`` ids the heuristic fallback mints), or out of range. The
+    caller must NOT guess in that case (#1019).
+    """
+    if not raw_target:
+        return None
+    match = _ARG_ID_RE.match(str(raw_target))
+    if not match:
+        return None
+    index = int(match.group(1)) - 1  # IDs are 1-based
+    return index if 0 <= index < count else None
+
+
 def _resolve_target_argument_id(raw_target: Any, arguments: List[str]) -> Optional[str]:
     """Resolve an upstream ``arg_N`` reference to its entry in ``arguments``.
 
@@ -3075,15 +3145,8 @@ def _resolve_target_argument_id(raw_target: Any, arguments: List[str]) -> Option
     The caller must NOT invent a target in that case (#1019): an attack we
     cannot ground is an attack we do not assert.
     """
-    if not raw_target:
-        return None
-    match = _ARG_ID_RE.match(str(raw_target))
-    if not match:
-        return None
-    index = int(match.group(1)) - 1  # IDs are 1-based
-    if 0 <= index < len(arguments):
-        return arguments[index]
-    return None
+    index = _resolve_target_argument_index(raw_target, len(arguments))
+    return None if index is None else arguments[index]
 
 
 def _generate_attacks_from_args(
@@ -3129,16 +3192,9 @@ def _generate_attacks_from_args(
             if not isinstance(f, dict):
                 continue
             fallacy_label = f.get("type", f.get("fallacy_type", f"fallacy_{i}"))
-            # Explicit loop rather than chained ``get`` defaults: producers emit
-            # the key with a ``None`` value when a detection has no target, and
-            # ``get(k, default)`` returns that ``None`` instead of the default.
-            raw_target = None
-            for key in ("target_argument", "target_argument_id", "target_arg_id"):
-                value = f.get(key)
-                if value:
-                    raw_target = value
-                    break
-            target_arg = _resolve_target_argument_id(raw_target, arguments)
+            # #1633: key reading and id resolution are shared with the #289
+            # quality penalty, which read the same field with a text match.
+            target_arg = _resolve_target_argument_id(_read_fallacy_target(f), arguments)
             if target_arg is None:
                 # Non-taxonomic detections carry no target at all. Pairing them
                 # by position is what this fix removes; skip and count instead.
@@ -5081,6 +5137,18 @@ async def _invoke_hierarchical_fallacy_per_argument(
                 are gitignored) — the writer's text-match fallback anchor.
             This surfaces what the descent already grounded (which argument
             it analyzed) — it does NOT fabricate family/target (anti-pendule).
+
+            #1633 — TRAP, read before adding a consumer of this field: the
+            ``target_argument`` written here is an IDENTIFIER, while the
+            ``target_argument`` of ``phase_counter_output`` is FREE TEXT (see
+            the counter-argument system prompt: ``"target_argument": "which
+            argument"``). Same name, two meanings, two payloads. A consumer that
+            feeds this value to a substring match silently matches nothing —
+            that is exactly how the #289 quality penalty went unapplied from its
+            introduction until #1633, and how the Dung attack graph was built by
+            positional pairing until #1629. Resolve it with
+            ``_resolve_target_argument_index`` / ``_resolve_target_argument_id``;
+            do not text-match it.
             """
 
             def _enrich_fallacies(res: Dict[str, Any]) -> None:

--- a/tests/unit/argumentation_analysis/orchestration/test_pipeline_wiring.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_pipeline_wiring.py
@@ -127,7 +127,17 @@ class TestQualityFallacyCrossReference:
         return mock
 
     async def test_quality_penalizes_fallacy_target(self, mock_evaluator):
-        """Quality score is reduced when argument is targeted by a fallacy."""
+        """Quality score is reduced when argument is targeted by a fallacy.
+
+        #1633 site 2 — this fixture used to supply the full argument TEXT as
+        ``target_argument``, a value no producer of this phase ever writes:
+        ``_enrich_fallacies`` writes ``f["target_argument"] = arg_id`` and the
+        fallacy plugin emits the key not at all. The test therefore passed while
+        the penalty was structurally unable to fire in production (measured: 0
+        of 3 arguments penalized on the producer shape, 3 of 3 on this fixture's
+        shape — an exact inversion). The fixture now carries what the producer
+        carries.
+        """
         from argumentation_analysis.orchestration.unified_pipeline import (
             _invoke_quality_evaluator,
         )
@@ -143,7 +153,7 @@ class TestQualityFallacyCrossReference:
                 "fallacies": [
                     {
                         "fallacy_type": "appeal_to_authority",
-                        "target_argument": "Elon Musk says AI is dangerous",
+                        "target_argument": "arg_1",
                         "confidence": 0.9,
                     },
                 ],
@@ -233,6 +243,89 @@ class TestQualityFallacyCrossReference:
 
         assert "fallacy_cross_reference" in result
         assert result["fallacy_cross_reference"]["fallacies_found"] == 1
+
+    async def _penalized(self, mock_evaluator, fallacies):
+        """Ids of the arguments the #289 penalty actually reduced."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_quality_evaluator,
+        )
+
+        context = {
+            "phase_extract_output": {
+                "arguments": [
+                    {"text": "Elon Musk says AI is dangerous"},
+                    {"text": "Studies show AI risks are real"},
+                ],
+            },
+            "phase_hierarchical_fallacy_output": {"fallacies": fallacies},
+        }
+        with patch(
+            "argumentation_analysis.agents.core.quality.quality_evaluator."
+            "ArgumentQualityEvaluator",
+            return_value=mock_evaluator,
+        ), patch(
+            "argumentation_analysis.orchestration.unified_pipeline._llm_enrich_quality",
+            new_callable=AsyncMock,
+            return_value=None,
+        ), patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
+        ):
+            result = await _invoke_quality_evaluator("test", context)
+        scores = result["per_argument_scores"]
+        # Guard the fixture: an empty score set would make every assertion below
+        # vacuously true.
+        assert scores, "no argument was evaluated"
+        return {
+            aid
+            for aid, s in scores.items()
+            if s.get("fallacy_penalty", {}).get("applied")
+        }
+
+    async def test_penalty_resolves_the_target_by_identifier(self, mock_evaluator):
+        """#1633 site 2 — ``arg_2`` must penalize the SECOND argument.
+
+        The bite proof the previous suite could not give: it only ever asserted
+        that arg_1 (the first) was penalized, which an off-by-one or a
+        position-based pairing would satisfy just as well.
+        """
+        hit = await self._penalized(
+            mock_evaluator, [{"fallacy_type": "straw_man", "target_argument": "arg_2"}]
+        )
+        assert hit == {"arg_2"}
+
+    async def test_penalty_accepts_the_state_key_convention(self, mock_evaluator):
+        """The same field is named ``target_argument_id`` on state-sourced
+        records (``shared_state.add_fallacy``) and ``target_arg_id`` on
+        counter-argument records. One resolver reads all three (#1633)."""
+        for key in ("target_argument", "target_argument_id", "target_arg_id"):
+            hit = await self._penalized(
+                mock_evaluator, [{"fallacy_type": "straw_man", key: "arg_1"}]
+            )
+            assert hit == {"arg_1"}, f"convention {key!r} did not resolve"
+
+    async def test_penalty_does_not_fire_on_an_ungroundable_target(
+        self, mock_evaluator
+    ):
+        """Anti-pendule: do NOT restore a text match to "catch more".
+
+        A target we cannot ground is a penalty we do not apply (#1019). Prose,
+        an out-of-range id, and the ``paragraph_N`` ids the heuristic fallback
+        mints must all resolve to nothing rather than to a plausible guess —
+        this is the failure mode #1629 documented, where feeding an identifier
+        to a substring match silently paired the wrong arguments.
+        """
+        for bogus in (
+            "Elon Musk says AI is dangerous",  # prose: the old fixture's shape
+            "arg_9",  # in-convention but out of range
+            "paragraph_1",  # heuristic-fallback id, not an argument id
+            "",
+            None,
+        ):
+            hit = await self._penalized(
+                mock_evaluator,
+                [{"fallacy_type": "straw_man", "target_argument": bogus}],
+            )
+            assert hit == set(), f"{bogus!r} was grounded onto {hit}"
 
 
 # ============================================================


### PR DESCRIPTION
Ferme le **site 2** de #1633. Le site 1 est traité par #1632 ; le site 3 reste ouvert (livrable distinct).

## La mesure — la pénalité #289 n'a jamais tiré

Le DoD demandait, mot pour mot : « mesure avant/après du nombre d'arguments pénalisés sur un artefact réel — **si la pénalité n'a jamais tiré, le dire explicitement** ». Elle n'a jamais tiré. Voici sur quoi je fonde ça.

`evaluation/results/` est vide sur cette machine (gitignoré), donc pas d'artefact réel sous la main. J'ai fait la mesure un cran plus haut mais toujours sur du **code de production** : appeler le vrai `_invoke_quality_evaluator` deux fois, mêmes arguments, en ne changeant **que la forme de `target_argument`** —

- **(A)** ce que fournit la fixture du test existant : le **texte complet** de l'argument
- **(B)** ce qu'écrit le vrai producteur (`invoke_callables.py:5173`, `f["target_argument"] = arg_id`) : `"arg_1"`

| entrée | arguments évalués | pénalisés **avant** | pénalisés **après** |
|---|---|---|---|
| (A) `target_argument` = texte complet *(fixture)* | 3 | **3** | 0 |
| (B) `target_argument` = `"arg_N"` *(producteur réel)* | 3 | **0** | **3** |

Inversion exacte. La seule forme sur laquelle la pénalité s'appliquait est celle qu'**aucun** producteur n'émet ; la seule forme réellement émise n'en déclenchait aucune.

Vérifié côté producteur avant de conclure : `FallacyWorkflowPlugin` n'émet jamais la clé — `_enrich_fallacies` la pose donc systématiquement, et toujours à `arg_id`.

## Pourquoi le test était vert

```python
"target_argument": "Elon Musk says AI is dangerous",   # le texte complet de arg_1
```

La fixture était **le seul producteur** de la valeur qui faisait tirer le mécanisme. Le test passait depuis #289, le mécanisme était mort depuis #289, et les deux faits sont compatibles parce que rien ne reliait la fixture à ce qu'écrivent les producteurs.

Le défaut était invisible pour une raison précise : « aucun argument pénalisé » ressemble exactement à « aucun sophisme ne visait d'argument ». Un mécanisme mort et un corpus sans sophisme ciblé rendent la même sortie.

## Ce que ça change

La pénalité s'applique désormais, donc **`note_finale` change sur tous les corpus** : c'est la première fois que le poids `0.3 × nb_sophismes` (plafonné à `0.6`) y entre réellement. Tout ce qui lit `note_finale` en hérite — agrégat qualité, axe qualité de l'Acte III, `_collect_quality_strengths`. Changement de livrable assumé, comme le corps de l'issue l'annonçait ; ce n'est pas un nettoyage.

## Le geste

Résolution **par identifiant**, via la couche partagée avec `_generate_attacks_from_args` (#1629/#1632) — même champ, même sens, **un seul mécanisme** :

```python
idx = _resolve_target_argument_index(_read_fallacy_target(f), min(len(raw_args), 8))
if idx is None:
    unresolved_fallacy_targets += 1
    continue
fallacy_targets.setdefault(idx, []).append(str(fallacy_type))
```

- `_read_fallacy_target` lit les trois conventions (`target_argument` / `target_argument_id` / `target_arg_id`) par une boucle explicite — un `get` chaîné rendrait le `None` d'un producteur au lieu de passer au suivant.
- `_resolve_target_argument_index` est l'inverse arithmétique de la frappe d'identifiant : `arg_N` → index `N-1`, borné.
- Les références non résolvables sont **comptées et loguées**, jamais devinées (#1019, fail loud).

Le match lexical part par **soustraction**, comme au site 1. Anti-pendule : je n'ai pas ajouté les trois noms de clé à une chaîne de `get` en gardant le match textuel par-dessus — c'est l'erreur exacte que #1629 documente.

### Le piège documenté chez les producteurs (item 5 du DoD)

Aux **deux** sites qui produisent les payloads, pas seulement chez les consommateurs :

- `_enrich_fallacies` : ce `target_argument` est un IDENTIFIANT ; celui de `phase_counter_output` est du TEXTE LIBRE ; ne pas le text-matcher.
- prompt système des contre-arguments : ce `target_argument` est du TEXTE LIBRE ; l'homonyme du payload sophisme est un `arg_N` ; ne pas unifier les deux branches.

## Tests — 3 ajoutés, 1 fixture corrigée

| Substitution dégénérée | Tests qui meurent |
|---|---|
| **D** — le résolveur ancre tout sur l'index 0 *(pairage positionnel)* | `test_penalty_resolves_the_target_by_identifier`, `test_penalty_does_not_fire_on_an_ungroundable_target` |
| **E** — une seule convention de clé lue | `test_penalty_accepts_the_state_key_convention` |
| **F** — comportement **pré-fix** restauré | les **4** |

**D ∩ E = ∅**, et aucun test ne survit à toutes les substitutions. F est celle qui compte : **le code d'avant ne peut pas passer la nouvelle suite**, ce qui n'était pas vrai de l'ancienne.

Le test qui manquait vraiment est `test_penalty_resolves_the_target_by_identifier`. L'ancien n'assertait que « `arg_1` est pénalisé » — ce qu'un pairage positionnel ou un off-by-one satisfait aussi bien. Le nouveau vise `arg_2` et exige que ce soit le **deuxième** argument qui prenne la pénalité.

`test_penalty_does_not_fire_on_an_ungroundable_target` porte l'anti-pendule : prose, `arg_9` hors borne, `paragraph_1` (l'identifiant que frappe le repli heuristique), `""` et `None` ne doivent rien ancrer. Une cible qu'on ne sait pas fonder est une pénalité qu'on n'applique pas.

Le helper `_penalized` porte un garde de non-vacuité (`assert scores, "no argument was evaluated"`) : sans lui, un pipeline qui n'évaluerait rien ferait passer les trois tests de non-pénalisation.

## Vérification

- `test_pipeline_wiring.py` : **24 passed**
- suite `orchestration/` complète : **2696 passed, 2 failed**
- `black --check` : 2 files unchanged · `flake8` : rc=0

Les 2 échecs sont **antérieurs et non liés** — mesuré en stashant ce diff et en relançant : ils échouent à l'identique sur `main` vierge. Cause nommée dans les logs : OpenRouter renvoie `403 Key limit exceeded (total limit)`, donc l'extraction ne produit aucun argument (`Expected ≥3 arguments, got 0`) et la génération de contre-arguments ne tourne pas (`'llm_counter_arguments' not in {...}`). Crédits épuisés sur la clé, pas une régression.

## Ce que je n'affirme pas

- **Pas de mesure sur un artefact réel** : l'ampleur du décalage de scores sur un vrai corpus reste inconnue. L'affirmation est plus étroite et plus solide — sur la forme que le producteur écrit, le compte passe de 0 à 3 sur 3.
- **Site 3 non traité** ici : il change une partition ASPIC, pas des scores, et mérite son propre diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
