### PR TITLE
fix(orchestration): make both fallacy-registration lanes resolve the same target (#1633)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -2463,6 +2463,9 @@ async def _run_parent_harness_fallback(
             _invoke_hierarchical_fallacy_per_argument,
             _invoke_hierarchical_fallacy,
         )
+        from argumentation_analysis.orchestration.state_writers import (
+            resolve_fallacy_target_arg_id,
+        )
 
         context = {"_state_object": state}
         # Merge selector context from API (#920)
@@ -2532,7 +2535,13 @@ async def _run_parent_harness_fallback(
                 or f.get("explanation")
                 or f"Detected by parent harness (confidence: {f.get('confidence', 'N/A')})"
             )
-            target_arg_id = f.get("source_arg_id") or f.get("target_argument_id")
+            # #1633 site 3: resolve through the same ladder the pipeline lane
+            # uses. This used to read ``source_arg_id or target_argument_id``,
+            # which inverted the precedence AND skipped the membership guard —
+            # so the sentinel ``"whole_text"`` stamped above was stored as a
+            # target that matches no argument, and the two lanes disagreed on
+            # the ASPIC survivor/defeated partition for identical input.
+            target_arg_id = resolve_fallacy_target_arg_id(state, f)
             try:
                 if hasattr(state, "add_fallacy"):
                     state.add_fallacy(

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -279,6 +279,19 @@ def _write_quality_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> Non
         )
 
 
+def _identified_arguments(state: Any) -> Dict[str, Any]:
+    """The state's identified arguments, or ``{}`` on states that carry none.
+
+    Shared by both fallacy-target resolvers (#1633 site 3). The conversational
+    lane also runs against states exposing only ``add_identified_fallacy``
+    (PhaseScopedState and friends), which have no ``identified_arguments`` at
+    all — reaching for it directly there raises, and the harness's outer
+    ``except`` turns that into a silent "no fallacies registered".
+    """
+    args = getattr(state, "identified_arguments", None)
+    return args if isinstance(args, dict) else {}
+
+
 def _resolve_target_arg_id(state: Any, target_text: str) -> Optional[str]:
     """Resolve target text to an arg_id from identified_arguments.
 
@@ -287,11 +300,12 @@ def _resolve_target_arg_id(state: Any, target_text: str) -> Optional[str]:
     """
     if not target_text:
         return None
+    arguments = _identified_arguments(state)
     # Direct ID match
-    if target_text in state.identified_arguments:
+    if target_text in arguments:
         return str(target_text)
     # Text-based matching (same heuristic as get_enrichment_summary)
-    for arg_id, desc in state.identified_arguments.items():
+    for arg_id, desc in arguments.items():
         if not desc:
             continue
         match_prefix = desc[:60]
@@ -303,6 +317,44 @@ def _resolve_target_arg_id(state: Any, target_text: str) -> Optional[str]:
         ):
             return str(arg_id)
     return None
+
+
+def resolve_fallacy_target_arg_id(state: Any, fallacy: Dict[str, Any]) -> Optional[str]:
+    """Resolve which identified argument a fallacy record attacks.
+
+    Single resolution used by **both** lanes that register fallacies into state
+    (#1633 site 3). It used to exist only here, in the pipeline writer; the
+    conversational lane carried a one-line ``source_arg_id or
+    target_argument_id`` that inverted the precedence and skipped the
+    membership guard, so the two lanes assigned *different* targets to the same
+    payload and produced different ASPIC survivor/defeated partitions.
+
+    Resolution order (D1a #1167 — surface what the per-argument descent already
+    grounded, do NOT invent a link):
+
+    1. ``target_argument_id`` — an explicit arg_id carried by the plugin. It
+       states which argument is *attacked*, so it outranks the id of whatever
+       argument happened to be under analysis.
+    2. ``source_arg_id`` — set by the per-argument harness to the arg_id the
+       descent analyzed this fallacy against, **only when it names a real
+       argument**. The wide-net whole-text pass stamps the sentinel
+       ``"whole_text"`` here; accepting it would store a dangling reference
+       that matches no argument and silently undermines nothing.
+    3. text-match fallbacks (``target_argument`` / ``problematic_quote`` /
+       ``explanation``) for wide-net fallacies with no grounded id.
+
+    Returns ``None`` when nothing resolves — the caller must not guess (#1019).
+    """
+    target_arg_id = fallacy.get("target_argument_id")
+    if not target_arg_id:
+        source_arg_id = str(fallacy.get("source_arg_id") or "")
+        if source_arg_id and source_arg_id in _identified_arguments(state):
+            target_arg_id = source_arg_id
+    for key in ("target_argument", "problematic_quote", "explanation"):
+        if target_arg_id:
+            break
+        target_arg_id = _resolve_target_arg_id(state, fallacy.get(key, ""))
+    return target_arg_id
 
 
 def _write_counter_argument_to_state(
@@ -622,30 +674,10 @@ def _write_hierarchical_fallacy_to_state(
             full_justification += f" [confidence:{confidence:.2f}]"
         if trace:
             full_justification += f" [trace:{'>'.join(trace)}]"
-        # Resolve target argument. Resolution order (D1a #1167 — surface what
-        # the per-argument descent already grounded, do NOT invent a link):
-        #   1. ``target_argument_id`` — an explicit arg_id carried by the plugin.
-        #   2. ``source_arg_id`` — set by the per-argument harness
-        #      (_invoke_hierarchical_fallacy_per_argument) to the arg_id the
-        #      descent analyzed this fallacy against. It IS a real arg_id from
-        #      state.identified_arguments (or "arg_N" from the extract phase),
-        #      so it is the most reliable grounded link — the wide-net fallacies
-        #      arrive with no quote/target and were orphaned without this.
-        #   3. text-match fallbacks (target_argument / problematic_quote /
-        #      explanation) for wide-net fallacies without a source_arg_id.
-        target_arg_id = f.get("target_argument_id")
-        if not target_arg_id:
-            _source_arg_id = str(f.get("source_arg_id") or "")
-            if _source_arg_id and _source_arg_id in state.identified_arguments:
-                target_arg_id = _source_arg_id
-        if not target_arg_id:
-            target_arg_id = _resolve_target_arg_id(state, f.get("target_argument", ""))
-        if not target_arg_id:
-            target_arg_id = _resolve_target_arg_id(
-                state, f.get("problematic_quote", "")
-            )
-        if not target_arg_id:
-            target_arg_id = _resolve_target_arg_id(state, f.get("explanation", ""))
+        # Resolve target argument through the resolution shared with the
+        # conversational lane (#1633 site 3) — see
+        # ``resolve_fallacy_target_arg_id`` for the order and its rationale.
+        target_arg_id = resolve_fallacy_target_arg_id(state, f)
         state.add_fallacy(
             fallacy_type=fallacy_type,
             justification=full_justification,

--- a/tests/unit/argumentation_analysis/orchestration/test_hierarchical_fallacy_writer.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_hierarchical_fallacy_writer.py
@@ -153,3 +153,167 @@ def test_no_target_link_when_nothing_matchable_d1a():
     entry = next(iter(state.identified_fallacies.values()))
     assert "target_argument_id" not in entry  # honest: no link
     assert entry["family"] == "Slippery Slope"
+
+
+# --------------------------------------------------------------------------
+# #1633 site 3 — the two lanes must agree on the same payload.
+#
+# These tests pin the RELATION between the pipeline lane and the conversational
+# lane, not the code they happen to share. They feed one identical payload to
+# both real writers and compare the outcome, so they survive a rewrite of
+# either lane: whoever changes one must keep it in step with the other, or
+# these fail. Asserting "both call resolve_fallacy_target_arg_id" would instead
+# die the moment either lane is refactored, while proving nothing about
+# agreement.
+#
+# Measured before the fix, on the payload below: the pipeline lane targeted
+# arg_3 and partitioned 1 surviving / 2 defeated; the conversational lane
+# targeted the sentinel "whole_text" and partitioned 2 surviving / 1 defeated.
+# --------------------------------------------------------------------------
+
+ARG_TEXTS = [
+    "Le rapport affirme que la mesure est efficace car un expert le dit.",
+    "Les données montrent une baisse régulière sur les cinq dernières années.",
+    "Si nous n'agissons pas, tout va s'effondrer très rapidement.",
+]
+
+# Shaped like the real producers: the per-argument descent stamps both
+# source_arg_id and target_argument (each an arg_N); the wide-net whole-text
+# pass is stamped source_arg_id="whole_text" by the conversational orchestrator
+# itself, and carries the plugin's explicit target_argument_id.
+_PER_ARG_FALLACY = {
+    "fallacy_type": "Appel à l'autorité",
+    "justification": "j1",
+    "source_arg_id": "arg_1",
+    "target_argument": "arg_1",
+}
+_WIDE_NET_FALLACY = {
+    "fallacy_type": "Appel à la peur",
+    "justification": "j2",
+    "source_arg_id": "whole_text",
+    "wide_net": True,
+    "target_argument_id": "arg_3",
+}
+
+
+def _real_state():
+    """A real UnifiedAnalysisState — _build_aspic_from_state needs add_aspic_result."""
+    from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+    state = UnifiedAnalysisState(initial_text="probe")
+    for text in ARG_TEXTS:
+        state.add_argument(text)
+    return state
+
+
+def _targets(state) -> list:
+    return [
+        entry.get("target_argument_id") for entry in state.identified_fallacies.values()
+    ]
+
+
+def _run_pipeline_lane(fallacies: list):
+    state = _real_state()
+    _write_hierarchical_fallacy_to_state(
+        {"fallacies": [dict(f) for f in fallacies]}, state, {}
+    )
+    assert state.identified_fallacies, "pipeline lane registered nothing"
+    return state
+
+
+async def _run_conversational_lane(fallacies: list):
+    """Drive the REAL conversational writer, stubbing only the two detectors."""
+    from unittest.mock import AsyncMock, patch
+
+    import argumentation_analysis.orchestration.invoke_callables as ic
+    from argumentation_analysis.orchestration.conversational_orchestrator import (
+        _run_parent_harness_fallback,
+    )
+
+    state = _real_state()
+    per_arg = [dict(f) for f in fallacies if f.get("source_arg_id") != "whole_text"]
+    whole = [dict(f) for f in fallacies if f.get("source_arg_id") == "whole_text"]
+    with patch.object(
+        ic,
+        "_invoke_hierarchical_fallacy_per_argument",
+        new=AsyncMock(return_value={"fallacies": per_arg}),
+    ), patch.object(
+        ic,
+        "_invoke_hierarchical_fallacy",
+        new=AsyncMock(return_value={"fallacies": whole}),
+    ):
+        # >500 chars so the wide-net whole-text pass fires.
+        await _run_parent_harness_fallback("x" * 600, state)
+    assert state.identified_fallacies, "conversational lane registered nothing"
+    return state
+
+
+async def test_both_lanes_assign_the_same_targets_for_one_payload():
+    """The relation: identical input must yield identical fallacy→argument links.
+
+    Before the fix the wide-net fallacy landed on arg_3 in one lane and on the
+    sentinel "whole_text" in the other.
+    """
+    payload = [_PER_ARG_FALLACY, _WIDE_NET_FALLACY]
+    pipeline = _run_pipeline_lane(payload)
+    conversational = await _run_conversational_lane(payload)
+    assert sorted(_targets(pipeline)) == sorted(_targets(conversational))
+    # Bite: the agreement must be on the grounded ids, not on both being empty.
+    assert sorted(_targets(pipeline)) == ["arg_1", "arg_3"]
+
+
+async def test_both_lanes_yield_the_same_aspic_partition():
+    """The consequence the divergence had: survivors/defeated differed (1/2 vs 2/1).
+
+    This is the measurement the issue asked for, pinned so it cannot drift back.
+    """
+    from argumentation_analysis.orchestration.conversational_orchestrator import (
+        _build_aspic_from_state,
+    )
+
+    payload = [_PER_ARG_FALLACY, _WIDE_NET_FALLACY]
+    from_pipeline = _build_aspic_from_state(_run_pipeline_lane(payload))
+    from_conversational = _build_aspic_from_state(
+        await _run_conversational_lane(payload)
+    )
+    assert from_pipeline is not None and from_conversational is not None
+    assert from_pipeline["surviving"] == from_conversational["surviving"]
+    assert from_pipeline["defeated"] == from_conversational["defeated"]
+    # Bite: a partition where nothing is defeated would satisfy equality alone.
+    assert from_pipeline["defeated"] == 2
+
+
+async def test_the_whole_text_sentinel_never_becomes_a_target():
+    """The membership guard, isolated.
+
+    A wide-net fallacy whose ONLY reference is the sentinel must resolve to no
+    target at all, rather than storing a dangling id that matches no argument.
+    """
+    orphan = {
+        "fallacy_type": "Appel à la peur",
+        "justification": "j",
+        "source_arg_id": "whole_text",
+    }
+    for state in (
+        _run_pipeline_lane([orphan]),
+        await _run_conversational_lane([orphan]),
+    ):
+        assert _targets(state) == [None]
+
+
+def test_an_explicit_target_outranks_the_analyzed_argument():
+    """The precedence, isolated.
+
+    ``source_arg_id`` names the argument the descent *analyzed*;
+    ``target_argument_id`` names the one the plugin says is *attacked*. When
+    both are present and real, the attacked one wins.
+    """
+    from argumentation_analysis.orchestration.state_writers import (
+        resolve_fallacy_target_arg_id,
+    )
+
+    state = _real_state()
+    resolved = resolve_fallacy_target_arg_id(
+        state, {"source_arg_id": "arg_1", "target_argument_id": "arg_2"}
+    )
+    assert resolved == "arg_2"

--- a/tests/unit/argumentation_analysis/orchestration/test_informal_taxonomy_injection_600.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_informal_taxonomy_injection_600.py
@@ -31,9 +31,9 @@ class TestInformalAgentInstructions:
             "Obstruction",
         ]
         for family in expected_families:
-            assert family in INFORMAL_AGENT_INSTRUCTIONS, (
-                f"Family '{family}' missing from INFORMAL_AGENT_INSTRUCTIONS"
-            )
+            assert (
+                family in INFORMAL_AGENT_INSTRUCTIONS
+            ), f"Family '{family}' missing from INFORMAL_AGENT_INSTRUCTIONS"
 
     def test_instructions_contain_english_family_names(self):
         """INFORMAL_AGENT_INSTRUCTIONS must include English family names."""
@@ -51,9 +51,9 @@ class TestInformalAgentInstructions:
             "Obstruction",
         ]
         for name in expected_en:
-            assert name in INFORMAL_AGENT_INSTRUCTIONS, (
-                f"English name '{name}' missing from INFORMAL_AGENT_INSTRUCTIONS"
-            )
+            assert (
+                name in INFORMAL_AGENT_INSTRUCTIONS
+            ), f"English name '{name}' missing from INFORMAL_AGENT_INSTRUCTIONS"
 
     def test_instructions_contain_systematic_traversal_section(self):
         """INFORMAL_AGENT_INSTRUCTIONS must have systematic traversal section."""
@@ -71,7 +71,10 @@ class TestInformalAgentInstructions:
             INFORMAL_AGENT_INSTRUCTIONS,
         )
 
-        assert "multilingue" in INFORMAL_AGENT_INSTRUCTIONS.lower() or "allemand" in INFORMAL_AGENT_INSTRUCTIONS.lower()
+        assert (
+            "multilingue" in INFORMAL_AGENT_INSTRUCTIONS.lower()
+            or "allemand" in INFORMAL_AGENT_INSTRUCTIONS.lower()
+        )
         assert "traduisez mentalement" in INFORMAL_AGENT_INSTRUCTIONS.lower()
 
     def test_instructions_still_has_gold_rule(self):
@@ -127,7 +130,9 @@ class TestGermanKeywordCoverage:
         roots_index = {
             "false dilemma": "PK_dilemma",
         }
-        result = plugin._map_fallacy_to_root_pk("Entweder-Oder Fehlschluss", roots_index)
+        result = plugin._map_fallacy_to_root_pk(
+            "Entweder-Oder Fehlschluss", roots_index
+        )
         assert result == "PK_dilemma"
 
     def test_german_circular_reasoning(self, plugin):
@@ -180,8 +185,12 @@ class TestGermanKeywordCoverage:
             "appel à l'émotion": "PK_emo",
             "faux dilemme": "PK_dilemma",
         }
-        assert plugin._map_fallacy_to_root_pk("Appel à l'émotion", roots_index) == "PK_emo"
-        assert plugin._map_fallacy_to_root_pk("Faux dilemme", roots_index) == "PK_dilemma"
+        assert (
+            plugin._map_fallacy_to_root_pk("Appel à l'émotion", roots_index) == "PK_emo"
+        )
+        assert (
+            plugin._map_fallacy_to_root_pk("Faux dilemme", roots_index) == "PK_dilemma"
+        )
 
     def test_english_keywords_still_work(self, plugin):
         """Existing English keywords must still work."""
@@ -190,9 +199,16 @@ class TestGermanKeywordCoverage:
             "ad hominem": "PK_adh",
             "slippery slope": "PK_slip",
         }
-        assert plugin._map_fallacy_to_root_pk("Appeal to authority", roots_index) == "PK_auth"
-        assert plugin._map_fallacy_to_root_pk("Ad hominem attack", roots_index) == "PK_adh"
-        assert plugin._map_fallacy_to_root_pk("Slippery slope", roots_index) == "PK_slip"
+        assert (
+            plugin._map_fallacy_to_root_pk("Appeal to authority", roots_index)
+            == "PK_auth"
+        )
+        assert (
+            plugin._map_fallacy_to_root_pk("Ad hominem attack", roots_index) == "PK_adh"
+        )
+        assert (
+            plugin._map_fallacy_to_root_pk("Slippery slope", roots_index) == "PK_slip"
+        )
 
 
 class TestParentHarnessFallback:
@@ -211,7 +227,10 @@ class TestParentHarnessFallback:
             "argumentation_analysis.orchestration.invoke_callables."
             "_invoke_hierarchical_fallacy_per_argument",
             new_callable=AsyncMock,
-            return_value={"fallacies": [], "exploration_method": "per_argument_parallel"},
+            return_value={
+                "fallacies": [],
+                "exploration_method": "per_argument_parallel",
+            },
         ):
             result = await _run_parent_harness_fallback("short text", mock_state)
             assert result is None
@@ -225,6 +244,13 @@ class TestParentHarnessFallback:
         ``add_identified_fallacy``) auto-exists — so it passed while the harness
         silently dropped every fallacy on the real state. Use the real state so
         the registration path is actually exercised end-to-end.
+
+        #1633 site 3: the fixture used to name ``arg-1``/``arg-2`` on a state
+        holding **zero** arguments, so the grounded link it asserted was a
+        dangling reference nothing could resolve — and the hyphenated ids are
+        not a format any producer mints (``add_argument`` mints ``arg_1``).
+        The arguments now exist and carry their real ids, so the assertion
+        below pins a link that is actually grounded.
         """
         from argumentation_analysis.orchestration.conversational_orchestrator import (
             _run_parent_harness_fallback,
@@ -236,18 +262,22 @@ class TestParentHarnessFallback:
         assert not hasattr(state, "add_identified_fallacy")
         assert hasattr(state, "add_fallacy")
 
+        arg_1 = state.add_argument("Le premier argument mis en cause.")
+        arg_2 = state.add_argument("Le second argument mis en cause.")
+        assert (arg_1, arg_2) == ("arg_1", "arg_2")  # the real minting format
+
         fake_fallacies = [
             {
                 "fallacy_type": "straw_man",
                 "justification": "Detected by parent harness",
                 "confidence": 0.85,
-                "source_arg_id": "arg-1",
+                "source_arg_id": arg_1,
             },
             {
                 "fallacy_type": "ad_hominem",
                 "justification": "Also detected",
                 "confidence": 0.72,
-                "source_arg_id": "arg-2",
+                "source_arg_id": arg_2,
             },
         ]
 
@@ -277,7 +307,7 @@ class TestParentHarnessFallback:
             targets = {
                 f.get("target_argument_id") for f in state.identified_fallacies.values()
             }
-            assert targets == {"arg-1", "arg-2"}
+            assert targets == {arg_1, arg_2}
 
     @pytest.mark.asyncio
     async def test_harness_singular_method_fallback(self):
@@ -415,8 +445,11 @@ class TestTaxonomyFamilyCoverage:
 
         df = pd.read_csv(csv_path)
         de_lang_cols = [
-            c for c in df.columns
-            if c.startswith(("text_de", "desc_de", "example_de", "link_de", "Family_de"))
+            c
+            for c in df.columns
+            if c.startswith(
+                ("text_de", "desc_de", "example_de", "link_de", "Family_de")
+            )
         ]
         # When DE enrichment is added, this test should be updated.
         assert len(de_lang_cols) == 0, f"Unexpected DE language columns: {de_lang_cols}"


### PR DESCRIPTION
Closes the third and last site of #1633: the two lanes that register hierarchical
fallacies into the shared state resolved the *target argument* by different rules,
so the same detector payload produced two different ASPIC partitions.

## The issue's diagnosis was wrong — and that matters

#1633 points at the **reader** (`conversational_orchestrator.py:3056` / `:3085`).
I read both: the reader is fine. It consumes `target_argument_id` off the state
entry and does nothing clever with it.

The divergence is upstream, in the two **writers**:

| | pipeline lane (`state_writers.py`) | conversational lane (`conversational_orchestrator.py:2535`) |
|---|---|---|
| resolution order | `target_argument_id` → `source_arg_id` → text-match on 3 fields | `source_arg_id` → `target_argument_id` |
| membership guard on `source_arg_id` | yes (must be a real key of `identified_arguments`) | **none** |
| text fallbacks | 3 | 0 |

Two consequences, both live. The precedence is **inverted**: `source_arg_id` names
the argument the descent *analyzed*, `target_argument_id` names the one the plugin
says is *attacked* — the conversational lane let the former win. And with no
membership guard, the sentinel `"whole_text"` (stamped by the orchestrator itself
on the wide-net pass, ~l.2506) was stored as if it were an argument id, so the
fallacy attached to nothing while *looking* attached.

## Measurement — one payload, both lanes

Fed to both real writers, no LLM (the two detectors are stubbed, everything
downstream is production code); state is a real `UnifiedAnalysisState` holding 3
arguments. Payload shaped like the real producers: one per-argument fallacy
(`source_arg_id`/`target_argument` = `arg_1`) and one wide-net fallacy
(`source_arg_id` = `"whole_text"`, `target_argument_id` = `arg_3`).

**Before**

| | lane P (pipeline) | lane C (conversational) |
|---|---|---|
| `fallacy_2` target | `arg_3` | `whole_text` |
| surviving / defeated | **1 / 2** | **2 / 1** |

`partitions identical: False`

**After**

Both **1 / 2**, `partitions identical: True`. Only lane C moved — the pipeline
lane's numbers are unchanged, which is the point: this is an alignment, not a
retuning of the semantics.

## Fix — by subtraction

The correct ladder already existed inside the pipeline writer as a 24-line inline
block. It is lifted verbatim into `resolve_fallacy_target_arg_id(state, fallacy)`
in `state_writers.py`; the pipeline writer now calls it (its 24 lines become 1),
and the conversational one-liner is **replaced** by the same call. Nothing was
layered on top of the old behaviour — the wrong resolution is removed, not
out-voted.

One defensive helper was necessary: `_identified_arguments(state)` returns `{}` on
states that expose only `add_identified_fallacy` (`PhaseScopedState` and friends,
which the conversational lane also runs against and which have no
`identified_arguments` at all).

## Blast radius caught two regressions

The full orchestration suite surfaced both; neither was visible from the diff.

1. **A real bug in my helper.** `test_harness_singular_method_fallback` broke:
   reaching for `identified_arguments` on a `MagicMock(spec=[...])` raised, and
   the harness's outer `except Exception` swallowed it into a silent
   `result is None` — no fallacies registered, no error. Fixed by
   `_identified_arguments`. (Worth noting separately: that outer `except` turning
   a crash into "nothing found" is the #1634 shape again — flagged, not fixed
   here.)

2. **A fixture, not the code.** `test_harness_registers_fallacies` asserted a
   grounded link to `arg-1`/`arg-2` on a state holding **zero** arguments, with
   hyphenated ids no producer mints (`add_argument` returns `arg_1`). It passed
   before only because the old lane never checked membership. Fixed by making the
   fixture realistic — three real `add_argument` calls, ids asserted against the
   real minting format — and **keeping** the assertion. Asserting `{None}` would
   have been the weaker option and would have pinned the bug.

## Tests — the relation, not the shared code

Four tests in `test_hierarchical_fallacy_writer.py`. They feed one identical
payload to both real writers and compare the outcome, so they survive a rewrite of
either lane. A test asserting "both lanes call `resolve_fallacy_target_arg_id`"
would instead die on any refactor while proving nothing about agreement.

- `test_both_lanes_assign_the_same_targets_for_one_payload` — bite:
  `== ["arg_1", "arg_3"]`, so agreement-on-nothing does not satisfy it
- `test_both_lanes_yield_the_same_aspic_partition` — bite: `defeated == 2`
- `test_the_whole_text_sentinel_never_becomes_a_target` — the guard, isolated
- `test_an_explicit_target_outranks_the_analyzed_argument` — the precedence, isolated

**Substitution matrix** (break one behaviour, record which tests die):

| | broken | tests killed |
|---|---|---|
| G | membership guard removed | 2 |
| H | precedence inverted | 1 |
| I | pre-fix one-liner restored | 3 |
| J | `_identified_arguments` guard removed | 1 |

G ∩ H = ∅ and H ∩ I = ∅ — the guard and the precedence are pinned *separately*,
and the pre-fix code cannot pass the new suite.

## Verification

- `test_hierarchical_fallacy_writer.py` + `test_informal_taxonomy_injection_600.py`: **31 passed**
- full `tests/unit/argumentation_analysis/orchestration/`: see below
- `black` clean, `flake8` rc=0
