### PR TITLE
fix(fol): make the per-formula isolation net reachable and effective (#1630)

### DIFF
--- a/argumentation_analysis/agents/core/logic/fol_logic_agent.py
+++ b/argumentation_analysis/agents/core/logic/fol_logic_agent.py
@@ -535,7 +535,6 @@ RÉPONDS EN FORMAT JSON :
 
         predicates: Dict[str, int] = {}  # name -> arity
         constants: Set[str] = set()
-        variables: Set[str] = set()
 
         # Extended regex: handle accented chars, digits, and underscores in names.
         # Matches both predicate (CamelCase) and function (lowercase) applications.
@@ -554,11 +553,13 @@ RÉPONDS EN FORMAT JSON :
                 if pred_name not in predicates or predicates[pred_name] < arity:
                     predicates[pred_name] = arity
                 for arg in args:
-                    # Variable: starts with uppercase letter (X, Y, Z)
-                    # Constant: starts with lowercase or digit (socrates, c1, 42)
-                    if arg[0].isupper():
-                        variables.add(arg)
-                    else:
+                    # Constant: starts with lowercase or digit (socrates, c1, 42).
+                    # Uppercase-starting identifiers (X, Y, Z) are FOL variables;
+                    # they are NOT declared in the Tweety signature (implicitly of
+                    # sort `thing`). #1630 retired the collected-but-prod-unread
+                    # `variables` set (#1019: a produced-but-never-read field is
+                    # decided, not kept).
+                    if not arg[0].isupper():
                         constants.add(arg)
 
         # Also scan for standalone lowercase identifiers not inside predicates
@@ -637,7 +638,6 @@ RÉPONDS EN FORMAT JSON :
             "sorts": sorts,
             "predicates": sanitized_predicates,
             "constants": sanitized_constants,
-            "variables": variables,
             "signature_lines": signature_lines,
             "constant_map": constant_map,
             "predicate_map": predicate_map,

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -6102,7 +6102,10 @@ async def _invoke_fol_reasoning(
     state_obj = context.get("_state_object")
 
     # Track FOL formula pipeline metrics (#655 Track MM)
-    fol_metrics: Dict[str, int] = {
+    # #1630: widened from Dict[str, int] to carry the rejected-formula NAMES
+    # (isolation_rejected_count stays int; rejected_formulas is List[str]) so a
+    # parse-poison is diagnosable from the artefact without a re-run (DoD item 4).
+    fol_metrics: Dict[str, Any] = {
         "upstream_nl": 0,
         "pass1_sorts": 0,
         "pass1_predicates": 0,
@@ -6392,6 +6395,127 @@ async def _invoke_fol_reasoning(
     # Bind bridge outside the try so the except isolation loop can reference it
     # even if TweetyBridge import/construction itself raises (#697 Track HH).
     bridge = None
+
+    # #1630: per-formula isolation net. Two defects made it dead code:
+    #   (1) the handler (fol_handler.check_consistency, FP-3 #1192) signals a
+    #       parse/reasoner failure by RETURNING (None, "Degraded ..."), not by
+    #       raising. So the combined check completes without exception and the
+    #       except below never armed — the net was unreachable on the very
+    #       failure mode it was built for.
+    #   (2) the per-formula loop triaged on absence-of-exception, which accepted
+    #       every formula under the None-return mode (handler returns, doesn't
+    #       raise) → valid_formulas == formulas → the net was empty even when it
+    #       ran.
+    # The fix: trigger the net on the combined-check None-verdict too (wired
+    # after the combined check), and triage on the RETURNED verdict — None ⇒ the
+    # formula did not parse / could not be reasoned about in isolation ⇒ the
+    # poison, rejected; True/False ⇒ it parses (decidable on its own) ⇒ kept.
+    # FP-6 #1197 still holds for the survivors combined check: parse ≠ decide,
+    # the tri-state passes through; never fabricate True from parse-success.
+    async def _attempt_isolation(trigger: str) -> Optional[Dict[str, Any]]:
+        """Return the survivor-result dict, or None when no formula survives.
+
+        Never raises: per-formula and combined failures are caught internally so
+        the caller can fall through to its own honest degraded return.
+        """
+        # formulas is non-None at every call site (assigned in the try before
+        # either branch calls this), but the closure captures the declared
+        # Optional type — guard once to narrow it for the whole body.
+        if formulas is None:
+            return None
+        valid_formulas: List[str] = []
+        rejected_formulas: List[str] = []
+        if bridge is not None:
+            for formula in formulas:
+                try:
+                    single_meta = FOLLogicAgent.extract_fol_metadata([formula])
+                    single_sig = single_meta.get("signature_lines", [])
+                    single_bs = "\n".join(str(f) for f in single_sig + [""] + [formula])
+                    f_verdict, _f_msg = await asyncio.to_thread(
+                        bridge.check_consistency, single_bs, "first_order"
+                    )
+                except Exception as single_err:
+                    logger.debug(
+                        "FOL formula rejected by Tweety (exception): %s — %s",
+                        formula,
+                        single_err,
+                    )
+                    rejected_formulas.append(formula)
+                    continue
+                # None ⇒ did not parse / could not reason about the formula in
+                # isolation ⇒ the poison. True/False ⇒ it parses (decidable on
+                # its own) ⇒ keep. (#1630 triage on verdict, not on absence of
+                # exception; FP-3 #1192 tri-state.)
+                if f_verdict is None:
+                    logger.debug(
+                        "FOL formula rejected by Tweety (None verdict): %s",
+                        formula,
+                    )
+                    rejected_formulas.append(formula)
+                else:
+                    valid_formulas.append(formula)
+        fol_metrics["isolation_survivors"] = len(valid_formulas)
+        # DoD item 4: the rejected formulas are NAMED in the metrics artefact,
+        # not only logged at debug — diagnosable without a re-run.
+        fol_metrics["isolation_rejected_count"] = len(rejected_formulas)
+        fol_metrics["rejected_formulas"] = rejected_formulas
+        if not valid_formulas:
+            logger.info(
+                "FOL per-formula isolation (%s): 0/%d survived.",
+                trigger,
+                len(formulas),
+            )
+            return None
+        logger.info(
+            "FOL per-formula isolation (%s): %d/%d formulas accepted by Tweety.",
+            trigger,
+            len(valid_formulas),
+            len(formulas),
+        )
+        surv_meta = FOLLogicAgent.extract_fol_metadata(valid_formulas)
+        surv_signature = surv_meta.get("signature_lines", [])
+        iso_consistent: Optional[bool] = None
+        iso_msg = "combined consistency unverified"
+        if bridge is not None:
+            try:
+                combined_bs = "\n".join(
+                    str(f) for f in surv_signature + [""] + valid_formulas
+                )
+                iso_consistent, iso_msg = await asyncio.to_thread(
+                    bridge.check_consistency, combined_bs, "first_order"
+                )
+            except Exception as iso_err:
+                logger.warning(
+                    "FOL isolation: combined consistency check failed (%s) — "
+                    "reporting unverified (None), not fabricated True.",
+                    iso_err,
+                )
+                iso_consistent = None
+        return {
+            "formulas": valid_formulas,
+            "fol_signature": surv_signature,
+            "fol_metadata": surv_meta,
+            "consistent": iso_consistent,
+            "inferences": inferences,
+            "confidence": (
+                0.6
+                if iso_consistent is True
+                else (0.0 if iso_consistent is None else 0.4)
+            ),
+            "message": iso_msg,
+            # Track B #1278: real formulas survived per-formula isolation;
+            # "decided" only on a definite prover verdict (#1019).
+            "fol_status": (
+                "decided" if iso_consistent in (True, False) else "unverified"
+            ),
+            "logic_type": "first_order",
+            "argument_count": len(args),
+            "isolation_retry": True,
+            "rejected_count": len(rejected_formulas),
+            "fol_metrics": fol_metrics,
+            **({"strategic_objective_ids": _strat_ids_fol} if _strat_ids_fol else {}),
+        }
+
     try:
         from argumentation_analysis.agents.core.logic.tweety_bridge import TweetyBridge
         from argumentation_analysis.agents.core.logic.fol_logic_agent import (
@@ -6435,6 +6559,18 @@ async def _invoke_fol_reasoning(
             bridge.check_consistency, belief_set_str, "first_order"
         )
         fol_metrics["post_tweety"] = len(formulas)
+        # #1630: the handler returns (None, "Degraded ...") on parse failure since
+        # FP-3 #1192 — the combined check completes WITHOUT raising, so the except
+        # below never arms on this failure mode. Trigger the per-formula net here
+        # on the None-verdict so isolation is reachable (DoD item 1). If isolation
+        # yields no survivors, fall through to the honest None-return below (the
+        # combined check's own None stays unverified — never fabricated, #1019).
+        if is_consistent is None:
+            _iso = await _attempt_isolation(
+                "degraded: combined KB returned None verdict (#1192)"
+            )
+            if _iso is not None:
+                return _iso
         # FP-19 #1243: opt-in multi-prover cross-validation. ADDITIVE — only runs
         # when the caller passes context["compare_backends"], leaving the default
         # path (single configured solver) untouched. Surfaces every available FOL
@@ -6495,85 +6631,17 @@ async def _invoke_fol_reasoning(
             f"FOL Tweety parse failed ({tweety_err}). "
             f"Attempting per-formula isolation with {len(formulas)} formulas."
         )
-        # Retry: isolate valid formulas by parsing each individually.
-        # This handles the case where one bad formula causes the entire
-        # batch to fail in Tweety's parser.
-        valid_formulas = []
-        if bridge is not None:
-            for formula in formulas:
-                try:
-                    single_meta = FOLLogicAgent.extract_fol_metadata([formula])
-                    single_sig = single_meta.get("signature_lines", [])
-                    single_bs = "\n".join(str(f) for f in single_sig + [""] + [formula])
-                    await asyncio.to_thread(
-                        bridge.check_consistency, single_bs, "first_order"
-                    )
-                    valid_formulas.append(formula)
-                except Exception:
-                    logger.debug(f"FOL formula rejected by Tweety: {formula}")
-
-        if valid_formulas:
-            meta = FOLLogicAgent.extract_fol_metadata(valid_formulas)
-            fol_signature = meta.get("signature_lines", [])
-            fol_metrics["isolation_survivors"] = len(valid_formulas)
-            logger.info(
-                f"FOL per-formula isolation: {len(valid_formulas)}/{len(formulas)} "
-                f"formulas accepted by Tweety"
-            )
-            # FP-6 #1197: the per-formula loop only proved each formula PARSES — it
-            # discarded the consistency verdicts. Hardcoding `consistent: True` here
-            # fabricated a consistency verdict out of parse-success (théâtre, R405 /
-            # #1019). Run a real combined consistency check on the survivors and pass
-            # the tri-state through; if the combined check itself fails/OOMs, that is
-            # `None` (unverified), never a fabricated True.
-            iso_consistent: Optional[bool] = None
-            iso_msg = "combined consistency unverified"
-            # bridge is non-None whenever valid_formulas is non-empty (the loop
-            # above is guarded by `if bridge is not None`), but narrow explicitly
-            # for the type checker; None ⇒ stay unverified (never fabricate True).
-            if bridge is not None:
-                try:
-                    combined_bs = "\n".join(
-                        str(f) for f in fol_signature + [""] + valid_formulas
-                    )
-                    iso_consistent, iso_msg = await asyncio.to_thread(
-                        bridge.check_consistency, combined_bs, "first_order"
-                    )
-                except Exception as iso_err:  # combined check failed → unverified
-                    logger.warning(
-                        "FOL isolation: combined consistency check failed (%s) — "
-                        "reporting unverified (None), not fabricated True.",
-                        iso_err,
-                    )
-                    iso_consistent = None
-            return {
-                "formulas": valid_formulas,
-                "fol_signature": fol_signature,
-                "fol_metadata": meta,
-                "consistent": iso_consistent,
-                "inferences": inferences,
-                "confidence": (
-                    0.6
-                    if iso_consistent is True
-                    else (0.0 if iso_consistent is None else 0.4)
-                ),
-                "message": iso_msg,
-                # Track B #1278: real formulas survived per-formula isolation;
-                # "decided" only on a definite prover verdict (#1019).
-                "fol_status": (
-                    "decided" if iso_consistent in (True, False) else "unverified"
-                ),
-                "logic_type": "first_order",
-                "argument_count": len(args),
-                "isolation_retry": True,
-                "rejected_count": len(formulas) - len(valid_formulas),
-                "fol_metrics": fol_metrics,
-                **(
-                    {"strategic_objective_ids": _strat_ids_fol}
-                    if _strat_ids_fol
-                    else {}
-                ),
-            }
+        # #1630: this branch reaches isolation on a genuine RAISE (Track HH
+        # import/construction failure, or a true Tweety exception). The same
+        # _attempt_isolation helper is ALSO reached on the None-verdict path
+        # above — both modes coexist, the except is NOT removed (DoD item 2).
+        # The helper triages on the RETURNED verdict (None ⇒ rejected), not on
+        # absence-of-exception, so the net is non-empty under the #1192
+        # None-return mode (DoD item 1). If no formula survives, fall through to
+        # the honest all-failed return below.
+        _iso = await _attempt_isolation(f"exception: {tweety_err}")
+        if _iso is not None:
+            return _iso
 
         # All formulas failed — no heuristic fallback (#1019)
         # Tweety is the solver; if it cannot parse the formulas, report

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_fol_signature_predeclaration.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_fol_signature_predeclaration.py
@@ -29,7 +29,6 @@ class TestExtractFolMetadata:
         meta = FOLLogicAgent.extract_fol_metadata(formulas)
         assert "Homme" in meta["predicates"]
         assert "Mortel" in meta["predicates"]
-        assert "X" in meta["variables"]
         assert meta["predicates"]["Homme"] == 1
         assert meta["predicates"]["Mortel"] == 1
 

--- a/tests/unit/argumentation_analysis/agents/test_fol_signature_extraction.py
+++ b/tests/unit/argumentation_analysis/agents/test_fol_signature_extraction.py
@@ -53,15 +53,6 @@ class TestExtractFolMetadataExtended:
 
         assert meta["predicates"]["P"] == 3
 
-    def test_variables_detected(self):
-        """Uppercase identifiers in args should be classified as variables."""
-        formulas = ["forall X: (Human(X) => Mortal(X))"]
-        meta = FOLLogicAgent.extract_fol_metadata(formulas)
-
-        assert "X" in meta["variables"]
-        assert "Human" in meta["predicates"]
-        assert "Mortal" in meta["predicates"]
-
     def test_signature_lines_format(self):
         """Signature lines should follow Tweety BNF format."""
         formulas = ["P(a)", "Q(a, b)"]
@@ -80,7 +71,6 @@ class TestExtractFolMetadataExtended:
 
         assert meta["predicates"] == {}
         assert meta["constants"] == set()
-        assert meta["variables"] == set()
         assert meta["signature_lines"] == ["thing = {}"]
 
     def test_quantified_formula_with_implication(self):
@@ -90,7 +80,6 @@ class TestExtractFolMetadataExtended:
 
         assert "Fallacious" in meta["predicates"]
         assert "FullySupported" in meta["predicates"]
-        assert "X" in meta["variables"]
         assert len(meta["constants"]) == 0  # No lowercase args
 
     def test_mixed_formulas_batch(self):
@@ -106,7 +95,6 @@ class TestExtractFolMetadataExtended:
         assert len(meta["predicates"]) >= 4
         assert "arg1" in meta["constants"]
         assert "fallacy1" in meta["constants"]
-        assert "X" in meta["variables"]
 
     def test_predicate_with_underscore(self):
         """Predicates and constants with underscores should be captured."""

--- a/tests/unit/argumentation_analysis/orchestration/test_fol_isolation_net_1630.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_fol_isolation_net_1630.py
@@ -1,0 +1,243 @@
+"""#1630 — FOL per-formula isolation net: reachable AND effective.
+
+Two independent defects had made the net dead code in
+``_invoke_fol_reasoning`` (invoke_callables.py):
+
+  1. **Unreachable on the real failure mode.** The handler
+     (``fol_handler.check_consistency``, FP-3 #1192) signals a parse / reasoner
+     failure by RETURNING ``(None, "Degraded ...")`` — not by raising. The
+     combined check therefore completes without exception, so the ``except``
+     isolation branch never armed. The net only triggered on genuine Tweety
+     *exceptions*, never on the None-verdict that is the actual degraded signal.
+  2. **Empty when it ran.** The per-formula loop triaged on absence-of-exception
+     (``try ... valid_formulas.append``), which accepted every formula under the
+     None-return mode (the handler returns, it doesn't raise) →
+     ``valid_formulas == formulas`` → the net caught nothing.
+
+The fix:
+  - trigger the net on the combined-check None-verdict too (not only on a raise);
+  - triage on the RETURNED verdict — None ⇒ the poison, True/False ⇒ kept;
+  - name the rejected formulas in ``fol_metrics`` (DoD item 4), not only at
+    ``logger.debug``.
+
+Anti-pendules (coordinator dispatch #1630):
+  - the handler is NOT made to raise — the #1192 tri-state contract is correct;
+    it is the downstream guard that must read the returned value;
+  - the survivors' combined check passes the tri-state through (FP-6 #1197):
+    parsing ≠ deciding, never fabricate True from parse-success;
+  - the existing ``except`` branch stays (DoD item 2): both modes coexist.
+
+Falsifiability — two degenerate substitutions with disjoint kill-sets:
+  - Sub A (defect 2): the per-formula triage reverts to absence-of-exception
+    (accept on any non-raising return). Kills the naming/survivors/exception
+    tests; SPARES the pure reachability test (the loop still runs).
+  - Sub B (defect 1): the None-trigger is removed. Kills the reachability +
+    naming/survivors tests (isolation never runs on the None mode); SPARES the
+    exception-path test (the ``except`` branch is untouched).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+TWEETY_BRIDGE_PATH = (
+    "argumentation_analysis.agents.core.logic.tweety_bridge.TweetyBridge"
+)
+
+# Opaque, deterministic atoms. The poison is a distinctive predicate the mock can
+# match inside the belief-set string; it models a formula the reasoner cannot
+# parse (returns None per #1192) while the genuine formulas parse fine.
+_GOOD_FORMULAS = [
+    "forall X: (Human(X) => Mortal(X))",
+    "forall X: (Cat(X) => Animal(X))",
+]
+_POISON_FORMULA = "BadPoison(X)"
+_POISON_TOKEN = "BadPoison"
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _ctx(formulas: list) -> dict:
+    """Context carrying pre-formed FOL formulas via context['formulas'] (unioned
+    into the belief set, bypassing NL translation)."""
+    return {
+        "phase_extract_output": {"arguments": [{"text": "an argument"}]},
+        "formulas": formulas,
+        "_state_object": None,
+    }
+
+
+def _verdict_reject_poison(belief_set_str: str, _logic_type: str):
+    """Models the #1192 degraded signal: the poison (single or in a batch)
+    returns a None verdict — the reasoner could not compute; the genuine
+    formulas return a definite True verdict."""
+    if _POISON_TOKEN in belief_set_str:
+        return (None, f"Degraded: parse error on {_POISON_TOKEN} (#1192)")
+    return (True, "FOL consistency check: consistent.")
+
+
+def _combined_raises_poison_none(belief_set_str: str, _logic_type: str):
+    """Models a genuine Tweety EXCEPTION on the combined batch (it cannot reason
+    about the full set with the poison), while the poison ALONE returns the #1192
+    None-verdict and the genuine formulas return True. This exercises the except
+    branch with a poison whose individual failure mode is the None-return, so the
+    per-formula triage (defect 2) — not only the per-formula except — decides its
+    fate."""
+    if _POISON_TOKEN in belief_set_str:
+        # Combined batch (genuine formulas + poison) → genuine raise → except.
+        if "Human" in belief_set_str or "Cat" in belief_set_str:
+            raise RuntimeError(
+                f"Tweety parse error on combined batch with {_POISON_TOKEN}"
+            )
+        # Single poison → None verdict (#1192 degraded, not a raise).
+        return (None, f"Degraded: {_POISON_TOKEN} (#1192)")
+    return (True, "FOL consistency check: consistent.")
+
+
+# ---------------------------------------------------------------------------
+# DoD item 1 — reachability: the None-verdict reaches the net
+# ---------------------------------------------------------------------------
+
+
+class TestNoneVerdictReachesIsolation:
+    """Pre-fix the combined None-verdict fell through to the silent 'unverified'
+    main return without ever running isolation (the handler returns None, it
+    doesn't raise → the except never armed). Post-fix the None-verdict REACHES
+    the net."""
+
+    def test_isolation_reached_on_combined_none(self):
+        """Every formula returns None individually (total reasoner failure).
+        The reachability signal: ``isolation_rejected_count`` is present in the
+        metrics — isolation ran. (Sub B, which removes the None-trigger, makes
+        this key absent → this test fails; Sub A spares it, the loop still
+        runs.)"""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fol_reasoning,
+        )
+
+        context = _ctx(list(_GOOD_FORMULAS))
+        mock_bridge = MagicMock()
+        mock_bridge.check_consistency.return_value = (
+            None,
+            "Degraded: reasoner could not compute (#1192)",
+        )
+        with patch(TWEETY_BRIDGE_PATH, return_value=mock_bridge):
+            result = _run(_invoke_fol_reasoning("text", context))
+
+        metrics = result["fol_metrics"]
+        # Reachability: isolation ran and recorded a rejection count. Pre-fix
+        # (no None-trigger) this key is absent.
+        assert "isolation_rejected_count" in metrics
+        # No fabricated verdict: combined None ⇒ unverified, never True (#1019).
+        assert result["consistent"] is None
+        assert result["fol_status"] == "unverified"
+
+
+# ---------------------------------------------------------------------------
+# DoD item 4 — rejected formulas named in the metrics artefact
+# ---------------------------------------------------------------------------
+
+
+class TestRejectedFormulasNamedInMetrics:
+    """The rejected formulas must be NAMED in fol_metrics (not only at
+    logger.debug), so a parse-poison is diagnosable without a re-run."""
+
+    def test_all_rejected_formulas_listed_by_name(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fol_reasoning,
+        )
+
+        context = _ctx(list(_GOOD_FORMULAS))
+        mock_bridge = MagicMock()
+        mock_bridge.check_consistency.return_value = (
+            None,
+            "Degraded: reasoner could not compute (#1192)",
+        )
+        with patch(TWEETY_BRIDGE_PATH, return_value=mock_bridge):
+            result = _run(_invoke_fol_reasoning("text", context))
+
+        metrics = result["fol_metrics"]
+        # Every injected formula was rejected (None verdict) and named.
+        assert metrics["isolation_rejected_count"] == len(_GOOD_FORMULAS)
+        rejected = metrics["rejected_formulas"]
+        assert isinstance(rejected, list)
+        assert len(rejected) == len(_GOOD_FORMULAS)
+        # The names survive sanitization recognizably (Human / Cat predicates).
+        rejected_text = " ".join(rejected)
+        assert "Human" in rejected_text
+        assert "Cat" in rejected_text
+
+
+# ---------------------------------------------------------------------------
+# DoD item 3 — N-1 survive + combined verdict (synthetic, no corpus)
+# ---------------------------------------------------------------------------
+
+
+class TestPoisonIsolatedSurvivorsCarryVerdict:
+    """A KB of N formulas whose combined belief set returns None (the batch
+    cannot be reasoned about) but where only ONE formula is the poison: the
+    N-1 genuine formulas survive and carry a real combined verdict."""
+
+    def test_poison_rejected_and_survivors_decided(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fol_reasoning,
+        )
+
+        # N = 2 genuine + 1 poison = 3; expect N-1 = 2 survivors.
+        context = _ctx(list(_GOOD_FORMULAS) + [_POISON_FORMULA])
+        mock_bridge = MagicMock()
+        mock_bridge.check_consistency.side_effect = _verdict_reject_poison
+        with patch(TWEETY_BRIDGE_PATH, return_value=mock_bridge):
+            result = _run(_invoke_fol_reasoning("text", context))
+
+        # DoD item 3: N-1 survive, the poison is rejected.
+        assert result["isolation_retry"] is True
+        assert len(result["formulas"]) == len(_GOOD_FORMULAS)
+        assert not any(_POISON_TOKEN in f for f in result["formulas"])
+        # A real combined verdict on the survivors (FP-6 #1197: decided, not
+        # fabricated from parse-success).
+        assert result["fol_status"] == "decided"
+        assert result["consistent"] is True
+        # DoD item 4: the poison is named in the metrics.
+        rejected = result["fol_metrics"]["rejected_formulas"]
+        assert any(_POISON_TOKEN in f for f in rejected)
+        assert result["fol_metrics"]["isolation_survivors"] == len(_GOOD_FORMULAS)
+
+
+# ---------------------------------------------------------------------------
+# DoD item 2 — the except branch stays reachable AND effective
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionPathStillIsolates:
+    """The existing except branch (genuine Tweety exception on the combined
+    check) still isolates the survivors after the refactor — both failure modes
+    coexist, the except is NOT removed."""
+
+    def test_combined_exception_isolates_survivors(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_fol_reasoning,
+        )
+
+        # The combined check raises (genuine Tweety exception on the full batch);
+        # the poison alone returns the #1192 None-verdict; the genuine formulas
+        # parse and are consistent. So the poison's fate in the except branch is
+        # decided by the per-formula VERDICT triage (defect 2), not by a raise.
+        context = _ctx(list(_GOOD_FORMULAS) + [_POISON_FORMULA])
+        mock_bridge = MagicMock()
+        mock_bridge.check_consistency.side_effect = _combined_raises_poison_none
+        with patch(TWEETY_BRIDGE_PATH, return_value=mock_bridge):
+            result = _run(_invoke_fol_reasoning("text", context))
+
+        # The except branch isolated the survivors — same contract as the
+        # None-trigger path, reached via a genuine exception instead.
+        assert result["isolation_retry"] is True
+        assert len(result["formulas"]) == len(_GOOD_FORMULAS)
+        assert not any(_POISON_TOKEN in f for f in result["formulas"])
+        assert result["fol_status"] == "decided"
+        assert result["consistent"] is True

--- a/tests/unit/argumentation_analysis/orchestration/test_fp6_fol_faillloud.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_fp6_fol_faillloud.py
@@ -92,8 +92,16 @@ class TestFolFailLoudTriState:
         combined consistency check — not hardcode ``consistent: True`` from parse-success.
 
         Here the first batch ``check_consistency`` raises (forcing the isolation
-        branch); per-formula parse checks succeed; the combined re-check returns the
-        degraded ``None``. Output must be ``consistent=None``, never the old ``True``.
+        branch); each per-formula check returns a definite ``True`` verdict (the
+        formula parses and is individually consistent, so it SURVIVES isolation);
+        the combined re-check on the survivors then returns the degraded ``None``.
+        Output must be ``consistent=None``, never the old ``True``.
+
+        (#1630 contract: the per-formula triage now keys on the RETURNED verdict —
+        a ``None`` would REJECT the formula as the poison. The per-formula checks
+        here therefore return ``True``, keeping this test focused on the FP-6 point
+        — the survivors' combined re-check must not fabricate ``True`` from the fact
+        that each formula parsed.)
         """
         bridge = MagicMock()
         calls = {"n": 0}
@@ -103,9 +111,13 @@ class TestFolFailLoudTriState:
             if calls["n"] == 1:
                 # First (batch) call raises → drives the except-isolation branch.
                 raise RuntimeError("batch parse failed")
-            # Per-formula parse checks + final combined re-check.
-            # Return the degraded tri-state for the combined re-check.
-            return (None, "combined degraded")
+            # Combined re-check on the survivors (both formulas in the belief set)
+            # → degraded None: the reasoner could not compute on the combined KB.
+            if "Human" in belief_set and "Mortal" in belief_set:
+                return (None, "combined degraded")
+            # Per-formula check → the formula parses and is individually consistent
+            # (True verdict) ⇒ it SURVIVES isolation. (#1630: a None would reject.)
+            return (True, "parses individually")
 
         bridge.check_consistency.side_effect = _check
 


### PR DESCRIPTION
## #1630 — FOL per-formula isolation net: reachable AND effective

Two independent defects had made `_invoke_fol_reasoning`'s per-formula isolation net **dead code** on the very failure mode it was built for.

### Defect 1 — unreachable on the real failure mode

The handler (`fol_handler.check_consistency`, FP-3 #1192) signals a parse/reasoner failure by **RETURNING** `(None, "Degraded...")`, not by raising. The combined check therefore completed without exception, so the `except tweety_err` isolation branch **never armed**. The net only triggered on genuine Tweety *exceptions*, never on the `None`-verdict that is the actual degraded signal.

### Defect 2 — empty when it ran

The per-formula loop triaged on **absence-of-exception** (`try ... valid_formulas.append`), which accepted every formula under the None-return mode (the handler returns, it doesn't raise) → `valid_formulas == formulas` → the net caught nothing.

### The fix (`invoke_callables.py`)

- **Trigger the net on the combined-check `None`-verdict too** — a new `_attempt_isolation(trigger)` helper is called right after the combined check returns `None`. The existing `except tweety_err` branch still calls the same helper on a genuine exception → **both modes coexist, the `except` is NOT removed** (DoD item 2).
- **Triage on the RETURNED verdict**: `None` ⇒ the poison (rejected), `True/False` ⇒ it parses (kept). FP-6 #1197 still holds for the survivors' combined check: parse ≠ decide, the tri-state passes through, never fabricate `True`.
- **Name the rejected formulas in `fol_metrics`** (`rejected_formulas` + `isolation_rejected_count`) — DoD item 4: a parse-poison is diagnosable from the artefact without a re-run, not only at `logger.debug`.

### Anti-pendules (coordinator dispatch #1630) — all honored

- The handler is **NOT** made to raise — the #1192 tri-state contract is correct; it is the downstream guard that must read the returned value.
- No verdict is fabricated from survivors (FP-6 #1197).
- `fol_metrics` widened `Dict[str,int]` → `Dict[str,Any]` to carry the rejected **names** (the count stays int alongside the list).

### DoD item 5 — `meta["variables"]` retired

`extract_fol_metadata` collected quantified variables (`fol_logic_agent.py:538-560`) but never emitted them in `signature_lines` (only `thing = {constants}` and `type(pred(thing))`) — a produced-but-prod-unread field. Per #1019 it is **decided, not kept**: the collection and the `"variables"` return key are removed (constant classification preserved); the 5 test assertions that validated the dead field are removed. Emitting variable-sort declarations into the signature was the alternative, but Tweety's sorted FOL infers variable sorts from predicate arguments, so the formulas already parse without it.

### Falsifiability — `test_fol_isolation_net_1630.py` (4 tests, all red pre-fix)

Degenerate substitutions with **disjoint kill-sets** (verified empirically):

| Sub | Kills | Spares |
|---|---|---|
| **A** — per-formula triage reverts to absence-of-exception | naming, survivors, exception | **reachability** (loop still runs) → pins defect 2 |
| **B** — None-trigger removed | reachability, naming, survivors | **exception** (except branch untouched) → pins defect 1 |

Reachability is killed by **B alone**; the exception-path test by **A alone** — each defect is pinned by a sub the other spares. No test is vacuous.

### `test_fp6_fol_faillloud.py` updated

`test_isolation_retry_does_not_fabricate_true` updated for the new contract: under #1630 a `None`-verdict formula is **rejected** (not accepted), so the per-formula checks now return a definite `True` (the formula genuinely parses) and only the combined re-check returns the degraded `None` — keeping the FP-6 focus on "survivors' combined re-check must not fabricate `True`".

### Validation

- `pytest` (isolation + fp6 + track_b_fail_loud + signature + fol_logic_agent + track_vv_formula_survival) → **76 passed**, 0 regressions.
- `mypy --strict` on the CI-gated `invoke_callables.py` → clean.
- `black` clean.

### Scope

`invoke_callables.py` (the fix), `fol_logic_agent.py` (item 5 retirement), 4 test files. Region ~l.6395-6610; does **not** touch po-2025's l.164 / l.8494 region. Privacy: opaque atoms (`BadPoison`, `Human`/`Mortal`), no corpus content.

🤖 Worker myia-po-2023 — #1630
