### PR TITLE
fix(formal): un echec de parsing Tweety n'est plus serialise comme un verdict decide (#1634)

### DIFF
--- a/argumentation_analysis/agents/core/logic/tweety_bridge.py
+++ b/argumentation_analysis/agents/core/logic/tweety_bridge.py
@@ -263,7 +263,7 @@ class TweetyBridge:
 
     def execute_modal_query(
         self, belief_set: str, query: str, logic_type: str = "K"
-    ) -> Tuple[bool, str]:
+    ) -> Tuple[Optional[bool], str]:
         """Backward compatibility wrapper for execute_modal_query.
 
         #1192: the underlying ``ModalHandler.execute_modal_query`` takes only
@@ -272,6 +272,19 @@ class TweetyBridge:
         ``logic_type`` as a third positional arg → ``TypeError`` on every
         modal query. Drop it here rather than adding an unused parameter to
         the handler (anti-pendule: subtract the mismatch).
+
+        #1634: the verdict is TRI-state. ``FUNC_ERROR`` (the parser refused the
+        belief set, the reasoner crashed) is *not* a negative answer, and this
+        wrapper used to return ``False`` for it — making "Tweety could not read
+        this" indistinguishable from "the query does not follow", always toward
+        the negative. Measured: a REJECTED query and an unparsable belief set
+        both came back ``False``.
+
+        Nothing downstream needed to be added to consume the third state — it
+        was already written and simply never fed. ``_invoke_modal_logic``
+        computes ``modal_status = "decided" if accepted in (True, False) else
+        "unverified"``, so its ``"unverified"`` branch was unreachable on this
+        lane; the state writer already passes ``valid`` through unflattened.
         """
         _ = logic_type  # accepted for API compatibility; handler is reasoner-global
         result_str = self.modal_handler.execute_modal_query(belief_set, query)
@@ -281,18 +294,28 @@ class TweetyBridge:
                 return True, result_str
             if "REJECTED" in result_str:
                 return False, result_str
-            return False, result_str  # FUNC_ERROR or unexpected
+            # FUNC_ERROR or unexpected → no verdict (#1634). Not ``False``:
+            # the answer to "did it fail?" is not the other boolean.
+            return None, result_str
+        if result_str is None:
+            return None, "FUNC_ERROR: modal handler returned no result"
         return bool(result_str), str(result_str)
 
     def check_consistency(
         self, belief_set: str, logic_type: str = "propositional"
-    ) -> Tuple[bool, str]:
+    ) -> Tuple[Optional[bool], str]:
         """Backward compatibility wrapper for check_consistency.
 
         #1192: ``ModalHandler`` exposes ``is_modal_kb_consistent`` (not
         ``check_consistency``); the previous dispatch raised
         ``AttributeError`` for K/T/S4/S5. Route modal consistency to the
         existing method.
+
+        #1634: the return type is tri-state — ``FOLHandler.check_consistency``
+        already answers ``(None, "Degraded: …")`` when the reasoner is absent or
+        the belief set will not parse. The annotation said ``bool`` and lied
+        about it, which is how callers ended up wrapping the result in
+        ``bool()``.
         """
         if logic_type == "propositional":
             return self.pl_handler.check_consistency(belief_set)
@@ -301,7 +324,11 @@ class TweetyBridge:
         elif logic_type in ["K", "T", "S4", "S5"]:
             return self.modal_handler.is_modal_kb_consistent(belief_set)
         else:
-            return False, f"Unknown logic type: {logic_type}"
+            # #1634: an unroutable logic type means nothing was checked. Three
+            # call sites in logic_agent_plugin already call the old ``False``
+            # here "a fabricated (False, 'Unknown logic type: …')" and guard
+            # against reaching it; stop fabricating at the source.
+            return None, f"Unknown logic type: {logic_type}"
 
     def check_consistency_detailed(
         self, belief_set: str, logic_type: str = "propositional"

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -8953,8 +8953,16 @@ async def _invoke_external_fol_solver(
     EFOLReasoner first, then Prover9 subprocess. Falls back to TweetyBridge
     (the default FOL path) when neither external solver is available.
 
-    #1019: No degraded flag. TweetyBridge is a genuine FOL reasoner.
-    External solvers are optional performance enhancers, not prerequisites.
+    #1019: falling back to TweetyBridge is NOT degradation. TweetyBridge is a
+    genuine FOL reasoner; external solvers are optional performance enhancers,
+    not prerequisites. So ``degraded`` never means "we used the fallback".
+
+    #1634: it means "no verdict was reached" — the belief set would not parse,
+    or no reasoner was reachable. It used to be hardcoded ``False`` on every
+    branch (an inert field), while ``consistent`` was flattened through
+    ``bool()``, so a parse failure was published as a decided *inconsistent*.
+    Both now track the tri-state: ``consistent`` is ``True``/``False``/``None``
+    and ``degraded`` is exactly ``consistent is None``.
     """
     _preflight_solver_check()
 
@@ -8999,9 +9007,12 @@ async def _invoke_external_fol_solver(
             )
             return {
                 "formulas": formulas,
-                "consistent": bool(is_consistent),
+                # #1634: pass the handler's tri-state through. It answers
+                # ``(None, "Degraded: …")`` when the belief set will not parse;
+                # ``bool(None)`` turned that into a decided "inconsistent".
+                "consistent": is_consistent,
                 "solver": "eprover",
-                "degraded": False,
+                "degraded": is_consistent is None,
                 "message": msg,
                 "logic_type": "first_order",
             }
@@ -9029,12 +9040,29 @@ async def _invoke_external_fol_solver(
                 )
                 prover9_input = f"formulas(sos).\n{belief_set_str}\nend_of_list.\n"
                 result = await asyncio.to_thread(run_prover9, prover9_input)
-                proved = "THEOREM PROVED" in result or "Proof found" in result
+                # #1634: report what Prover9 actually said, and only that.
+                #
+                # The input above is a bare SOS list with NO goal, so a proof
+                # here IS the derivation of the empty clause: "THEOREM PROVED"
+                # means the KB is INCONSISTENT and "SEARCH FAILED" means it is
+                # consistent (the runner's own docstring says so — exit 2 =
+                # SEARCH FAILED on a consistent KB). The previous expression
+                # stored ``consistent = proved``, i.e. exactly backwards.
+                # Measured against the bundled binary: ``P(a). -P(a).`` →
+                # THEOREM PROVED (was stored as consistent=True), and
+                # ``P(a). Q(b).`` → SEARCH FAILED (was stored as False).
+                #
+                # And when NEITHER marker is present, Prover9 decided nothing —
+                # that is the #1634 motif proper, so it yields None rather than
+                # a boolean picked by default.
+                refuted = "THEOREM PROVED" in result or "Proof found" in result
+                exhausted = "SEARCH FAILED" in result
+                consistent = False if refuted else (True if exhausted else None)
                 return {
                     "formulas": formulas,
-                    "consistent": proved,
+                    "consistent": consistent,
                     "solver": "prover9",
-                    "degraded": False,
+                    "degraded": consistent is None,
                     "raw_output": result[:500],
                     "logic_type": "first_order",
                 }
@@ -9063,8 +9091,13 @@ async def _invoke_external_fol_solver(
         )
         return {
             "formulas": formulas,
-            "consistent": bool(is_consistent),
+            # #1634: same tri-state pass-through as the EProver branch above.
+            # This is the branch actually taken when ``eprover`` is not on PATH,
+            # so it is where real corpora had their parse failures rendered as
+            # a decided ``consistent: False``.
+            "consistent": is_consistent,
             "solver": "tweety",
+            "degraded": is_consistent is None,
             "message": msg,
             "logic_type": "first_order",
         }
@@ -9087,8 +9120,13 @@ async def _invoke_external_modal_solver(
     SPASSMlReasoner first. Falls back to TweetyBridge when SPASS is
     not available.
 
-    #1019: No degraded flag. TweetyBridge is a genuine modal reasoner.
-    External solvers are optional performance enhancers, not prerequisites.
+    #1019: falling back to TweetyBridge is NOT degradation. TweetyBridge is a
+    genuine modal reasoner; external solvers are optional performance
+    enhancers, not prerequisites.
+
+    #1634: ``degraded`` means "no verdict was reached" — the belief set would
+    not parse (``FUNC_ERROR``), or no reasoner was reachable. It tracks
+    ``valid is None``, which the wrapper can now actually produce.
     """
     _preflight_solver_check()
     modal_output = context.get("phase_modal_output", {})
@@ -9124,10 +9162,15 @@ async def _invoke_external_modal_solver(
             )
             return {
                 "formulas": formulas,
-                "valid": bool(is_consistent),
+                # #1634: ``is_modal_kb_consistent`` is tri-state — the sibling
+                # phase (``_invoke_modal_logic``) already passes it through
+                # unflattened. This branch wrapped it in ``bool()``, so the
+                # external-solver lane reported a decided verdict where the
+                # reasoning lane reported none, for the very same KB.
+                "valid": is_consistent,
                 "modalities": modalities,
                 "solver": "spass",
-                "degraded": False,
+                "degraded": is_consistent is None,
                 "message": msg,
                 "logic_type": "modal",
             }
@@ -9155,9 +9198,13 @@ async def _invoke_external_modal_solver(
         )
         return {
             "formulas": formulas,
+            # #1634: ``accepted`` is now tri-state (the wrapper stopped turning
+            # FUNC_ERROR into False), so a refused belief set reaches the state
+            # writer as "no verdict" instead of "invalid".
             "valid": accepted,
             "modalities": modalities,
             "solver": "tweety",
+            "degraded": accepted is None,
             "message": msg,
             "logic_type": "modal",
         }

--- a/argumentation_analysis/reporting/restitution/appendix.py
+++ b/argumentation_analysis/reporting/restitution/appendix.py
@@ -66,8 +66,14 @@ def _fol_axis_status(fol: Any) -> Any:
     collapse to ``False`` (#1019/#1278).
     """
     if isinstance(fol, Mapping):
+        # #1634: this is the branch the docstring above says does NOT use
+        # ``bool(consistent)`` — and it did. The list branch below is tri-state
+        # honest; this legacy Mapping branch rendered a degraded ``None`` as a
+        # decided ``False``, i.e. the annex asserted "inconsistent" about a
+        # theory the reasoner never read.
+        raw = fol.get("consistent")
         return {
-            "consistent": bool(fol.get("consistent")),
+            "consistent": raw if raw in (True, False) else None,
             "formules": _safe_len(fol.get("formulas")),
         }
     if isinstance(fol, list) and fol:

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_fol_handler.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_fol_handler.py
@@ -384,6 +384,79 @@ class TestTweetyBridgeModalDispatch:
         mock_modal.is_modal_kb_consistent.assert_called_once_with("kb")
         assert result == (True, "ok")
 
+    def _modal_verdict(self, handler_reply):
+        """Drive the real wrapper over one handler reply, return its verdict."""
+        from argumentation_analysis.agents.core.logic.tweety_bridge import (
+            TweetyBridge,
+        )
+
+        mock_modal = MagicMock()
+        mock_modal.execute_modal_query.return_value = handler_reply
+        with patch.object(
+            TweetyBridge,
+            "modal_handler",
+            new_callable=lambda: property(lambda self: mock_modal),
+        ):
+            bridge = TweetyBridge.__new__(TweetyBridge)
+            verdict, _msg = bridge.execute_modal_query("kb", "p", logic_type="K")
+        return verdict
+
+    def test_modal_crash_is_not_the_same_answer_as_a_rejection(self):
+        """#1634: a refused belief set must not read as a decided negative.
+
+        Measured before the fix, on a real JVM: querying ``!Wet`` against a
+        well-formed KB (a genuine REJECTED) and querying anything against
+        ``!!! illegal sort ::: @@@`` (the parser refuses, FUNC_ERROR) both
+        returned ``False``. Two opposite situations, one value, and always the
+        negative one — so every downstream reader counted a crash as evidence.
+
+        The assertion is on the DISTINCTION, not on the sentinel: asserting
+        ``crash is None`` alone would still pass if REJECTED also became None.
+        """
+        rejected = self._modal_verdict(
+            "Tweety Result (SimpleMlReasoner): Modal Query 'p' is REJECTED (False)."
+        )
+        crashed = self._modal_verdict(
+            "FUNC_ERROR: Error executing modal query: "
+            "org.tweetyproject.commons.ParserException: Predicate 'x' has not "
+            "been declared."
+        )
+        assert rejected is False, "a REJECTED query is a real, decided negative"
+        assert crashed is None, "a parser refusal decided nothing"
+        assert rejected is not crashed, (
+            "a crash and a rejection are indistinguishable again — the whole "
+            "point of #1634 is that these two must not share a value"
+        )
+
+    def test_modal_accepted_still_decides(self):
+        """The fix must not cost the decided cases (anti-pendule #1634)."""
+        assert (
+            self._modal_verdict(
+                "Tweety Result (SimpleMlReasoner): Modal Query 'p' is ACCEPTED (True)."
+            )
+            is True
+        )
+
+    def test_modal_handler_returning_nothing_decides_nothing(self):
+        """A non-string handler reply is not a verdict either (#1634)."""
+        assert self._modal_verdict(None) is None
+
+    def test_unroutable_logic_type_decides_nothing(self):
+        """#1634: ``check_consistency`` on an unknown logic ran no reasoner.
+
+        Three call sites in ``logic_agent_plugin`` already describe the old
+        return as "a fabricated (False, 'Unknown logic type: fol')" and guard
+        against reaching it. Stop fabricating at the source.
+        """
+        from argumentation_analysis.agents.core.logic.tweety_bridge import (
+            TweetyBridge,
+        )
+
+        bridge = TweetyBridge.__new__(TweetyBridge)
+        verdict, msg = bridge.check_consistency("kb", "hyperintensional")
+        assert verdict is None
+        assert "Unknown logic type" in msg
+
 
 # ──── #1204 anti-théâtre: EProver delivery-contract sentinel guard ────
 

--- a/tests/unit/argumentation_analysis/orchestration/test_external_solvers.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_external_solvers.py
@@ -330,3 +330,168 @@ class TestSafeFloatEnv:
         # the test asserts the MISSING key still falls back to default.
         with self._patch_mod_env_get({"_TEST_FLOAT": "irrelevant"}):
             assert mod._safe_float_env("_TEST_FLOAT_MISSING", 99.0) == 99.0
+
+
+# ---------------------------------------------------------------------------
+# #1634: a Tweety parse failure must not be serialized as a decided verdict
+# ---------------------------------------------------------------------------
+
+
+class TestParseFailureIsNotAVerdict:
+    """A refused belief set decided nothing, and must say so.
+
+    Measured on a real JVM before the fix, driving the production callable with
+    an unparsable FOL belief set: ``consistent=False`` — the *same* value a
+    genuinely inconsistent theory produces — while the accompanying message
+    read ``"Degraded: FOL consistency check error (Erreur de parsing Tweety
+    …)"``. The message was honest; the field a reader actually consumes was
+    not, and it always erred toward the negative.
+
+    Each test below asserts the CONTRAST (undecided vs decided), not just the
+    sentinel: asserting ``is None`` alone would survive a change that made
+    every outcome None.
+    """
+
+    @staticmethod
+    def _run(coro):
+        return asyncio.get_event_loop().run_until_complete(coro)
+
+    def _fol_with_handler_reply(self, reply, solver="eprover", eprover=True):
+        """Drive the real external-FOL callable over one bridge reply."""
+        import argumentation_analysis.orchestration.invoke_callables as mod
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_external_fol_solver,
+        )
+
+        bridge = MagicMock()
+        bridge.check_consistency.return_value = reply
+        fake_mod = MagicMock()
+        fake_mod.TweetyBridge.return_value = bridge
+        with patch.dict(
+            "sys.modules",
+            {"argumentation_analysis.agents.core.logic.tweety_bridge": fake_mod},
+        ), patch.object(
+            mod.shutil, "which", side_effect=lambda b: "/x" if eprover else None
+        ):
+            return self._run(
+                _invoke_external_fol_solver(
+                    "probe",
+                    {
+                        "fol_solver": solver,
+                        "phase_fol_output": {"formulas": ["P(a)"]},
+                    },
+                )
+            )
+
+    @pytest.mark.parametrize("eprover", [True, False], ids=["eprover", "tweety"])
+    def test_fol_parse_failure_is_undecided_on_both_branches(self, eprover):
+        """Both FOL return paths flattened the handler's ``None`` (#1634).
+
+        The EProver branch and the TweetyBridge fallback carried the same
+        ``bool(is_consistent)``; the fallback is the one real corpora take,
+        since ``eprover`` is usually not on PATH.
+        """
+        degraded = self._fol_with_handler_reply(
+            (None, "Degraded: FOL consistency check error (parse)"), eprover=eprover
+        )
+        decided = self._fol_with_handler_reply(
+            (False, "FOL consistency check (EProver): inconsistent"), eprover=eprover
+        )
+        assert decided["consistent"] is False, "a real inconsistency still decides"
+        assert degraded["consistent"] is None, "a parse failure decided nothing"
+        assert degraded["consistent"] is not decided["consistent"], (
+            "a parse failure is indistinguishable from a decided inconsistency "
+            "again — that conflation is #1634"
+        )
+
+    def test_fol_degraded_flag_tracks_the_verdict_rather_than_the_solver(self):
+        """``degraded`` was hardcoded False on every branch — an inert field.
+
+        It never meant "we fell back to Tweety" (#1019 settled that Tweety is a
+        genuine reasoner); it now means "no verdict was reached", which is the
+        one thing it can usefully tell the state writer.
+        """
+        degraded = self._fol_with_handler_reply((None, "Degraded: parse"))
+        decided = self._fol_with_handler_reply((True, "consistent"))
+        assert degraded["degraded"] is True
+        assert decided["degraded"] is False
+
+    def test_modal_parse_failure_is_undecided(self):
+        """The modal external phase inherited the wrapper's flattening (#1634)."""
+        import argumentation_analysis.orchestration.invoke_callables as mod
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_external_modal_solver,
+        )
+
+        def run(verdict):
+            bridge = MagicMock()
+            bridge.execute_modal_query.return_value = (verdict, "msg")
+            fake_mod = MagicMock()
+            fake_mod.TweetyBridge.return_value = bridge
+            with patch.dict(
+                "sys.modules",
+                {"argumentation_analysis.agents.core.logic.tweety_bridge": fake_mod},
+            ), patch.object(mod.shutil, "which", return_value=None):
+                return self._run(
+                    _invoke_external_modal_solver(
+                        "probe",
+                        {
+                            "phase_modal_output": {
+                                "formulas": ["[](p)"],
+                                "modalities": ["necessity"],
+                            }
+                        },
+                    )
+                )
+
+        assert run(False)["valid"] is False, "a decided negative stays decided"
+        assert run(None)["valid"] is None, "a refused belief set decided nothing"
+
+    def test_prover9_reports_what_the_binary_actually_said(self):
+        """#1634 + a polarity inversion found at the same line.
+
+        The Prover9 input is a bare SOS list with **no goal**, so a proof is the
+        derivation of the empty clause: ``THEOREM PROVED`` ⇒ the KB is
+        INCONSISTENT, ``SEARCH FAILED`` ⇒ consistent. The old expression stored
+        ``consistent = proved``, exactly backwards — measured against the
+        bundled binary, ``P(a). -P(a).`` yielded THEOREM PROVED and was stored
+        ``consistent=True``.
+
+        And with neither marker present, nothing was decided at all.
+        """
+        import argumentation_analysis.orchestration.invoke_callables as mod
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_external_fol_solver,
+        )
+
+        def run(prover9_stdout):
+            fake_runner = MagicMock()
+            fake_runner.run_prover9.return_value = prover9_stdout
+            with patch.dict(
+                "sys.modules",
+                {"argumentation_analysis.core.prover9_runner": fake_runner},
+            ), patch.object(mod.shutil, "which", return_value=None), patch(
+                "pathlib.Path.is_file", return_value=True
+            ):
+                return self._run(
+                    _invoke_external_fol_solver(
+                        "probe",
+                        {
+                            "fol_solver": "prover9",
+                            "phase_fol_output": {"formulas": ["P(a)"]},
+                        },
+                    )
+                )
+
+        refuted = run("... THEOREM PROVED ...")
+        exhausted = run("... SEARCH FAILED ...")
+        silent = run("... nothing conclusive here ...")
+
+        assert refuted["solver"] == "prover9", "the prover9 branch was not taken"
+        assert refuted["consistent"] is False, (
+            "Prover9 derived the empty clause from the SOS list — that is an "
+            "INCONSISTENT KB, not a consistent one"
+        )
+        assert exhausted["consistent"] is True
+        assert silent["consistent"] is None
+        assert silent["degraded"] is True

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_appendix.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_appendix.py
@@ -147,6 +147,23 @@ class TestFolAxisStatusListShape:
         status = _fol_axis_status({"consistent": True, "formulas": ["a", "b"]})
         assert status == {"consistent": True, "formules": 2}
 
+    def test_legacy_mapping_shape_does_not_decide_for_a_degraded_axis(self):
+        """#1634: the Mapping branch used ``bool(consistent)`` — the exact call
+        this function's own docstring says it does not make.
+
+        The list branch three lines below is tri-state honest; this one turned
+        a degraded ``None`` into a decided ``False``, so the annex asserted
+        "inconsistent" about a theory no reasoner had read. The decided cases
+        must be untouched, which is why they are asserted alongside.
+        """
+        degraded = _fol_axis_status({"consistent": None, "formulas": ["a"]})
+        inconsistent = _fol_axis_status({"consistent": False, "formulas": ["a"]})
+        assert degraded == {"consistent": None, "formules": 1}
+        assert inconsistent == {"consistent": False, "formules": 1}
+        assert degraded["consistent"] is not inconsistent["consistent"], (
+            "a degraded axis reads as a decided inconsistency again (#1634)"
+        )
+
 
 class TestModalAxisStatus:
     """#1276 (po-2023 R487): the modal axis was reduced to a binary presence flag


### PR DESCRIPTION
## Le défaut, mesuré

Un échec de parsing Tweety ressortait comme un verdict formel **décidé**, sur les deux axes. Mesuré avec du code de production, une vraie JVM, et des belief sets délibérément construits pour être refusés par le parseur :

| axe | entrée | avant | après |
|---|---|---|---|
| FOL | belief set illisible | `consistent=False` | `consistent=None` |
| FOL | belief set valide | `consistent=True` | `consistent=True` |
| modal | requête réellement REJECTED | `False` | `False` |
| modal | belief set illisible (FUNC_ERROR) | `False` | `None` |

Le contrôle est le **contraste**, pas la sentinelle : avant, une théorie que le raisonneur n'a jamais lue et une théorie réellement inconsistante rendaient la même valeur — et toujours la négative. Le message, lui, était honnête (`"Degraded: FOL consistency check error (Erreur de parsing Tweety: …)"`) ; c'est le champ que les lecteurs consomment qui mentait. Après, les cas décidés ne bougent pas : seuls les cas indécidés se séparent.

## Rejeu sur les 3 artefacts réels (DoD 5)

Aucun LLM n'a été nécessaire : les formules sur lesquelles les phases plantaient sont **enregistrées** dans les artefacts, elles repassent donc telles quelles dans les callables de production. Cellules de verdict seulement (artefacts gitignorés, rien d'autre n'est lu ni publié) :

| corpus | FOL avant | FOL après | msg FOL | modal avant | modal après | msg modal |
|---|---|---|---|---|---|---|
| corpus_A | `False` | **`False`** | décidé : inconsistant | `False` | **`None`** | crash (FUNC_ERROR) |
| corpus_B | `False` | **`None`** | crash (parse) | `False` | **`None`** | crash (FUNC_ERROR) |
| corpus_C | `False` | **`None`** | crash (parse) | `False` | **`None`** | crash (FUNC_ERROR) |

C'est exactement la table du corps de l'issue, et exactement la distinction qu'elle demandait. L'issue disait : « Pas que corpus_A soit faux : son message est cohérent avec une décision réelle. Je dis qu'on ne peut pas le savoir depuis la valeur seule. » On peut maintenant le savoir depuis la valeur seule — corpus_A reste `False` parce que le prouveur a réellement décidé, corpus_B/C passent à `None` parce que le parseur a refusé. **La colonne qui voulait dire deux choses n'en veut plus dire qu'une.**

## Deux axes, deux gestes — comme l'issue le demande

**Modal — dans le wrapper** (`tweety_bridge.py`). `execute_modal_query` traduisait `FUNC_ERROR` en `False`. Il rend `None`.

**FOL — aux sites d'appel** (`invoke_callables.py`). `fol_handler.check_consistency` répond déjà `(None, "Degraded: …")` : la convention amont est correcte, c'est le `bool()` du consommateur qui l'écrasait. Il est retiré. Aucune levée d'exception n'a été réintroduite dans le handler (#1192 les avait retirées délibérément).

## Ce que la correction ne fait pas

Rien n'a été **ajouté** en aval pour consommer le troisième état : il était déjà écrit et n'était simplement jamais alimenté.

- `_invoke_modal_logic` calcule `modal_status = "decided" if accepted in (True, False) else "unverified"`. Comme le wrapper ne rendait jamais `None`, la branche `"unverified"` était **inatteignable** sur cette voie. Elle l'est maintenant.
- Les deux state writers passent déjà `consistent` / `valid` sans les aplatir.
- `degraded` existait sur chaque branche, **codé en dur à `False`** — un champ inerte. Il vaut maintenant exactement `consistent is None`, ce qui est la seule chose utile qu'il puisse dire au writer. La docstring qui affirmait « No degraded flag » est corrigée : elle voulait dire « se rabattre sur Tweety n'est pas une dégradation » (#1019), ce qui reste vrai et n'est pas la même question.

## Sites corrigés — dont trois que l'issue ne nomme pas

L'issue donne `invoke_callables.py:8946` / `:8882` ; ces numéros ont dérivé (le fichier a grossi avec #1653 et #1654). En grepant **le motif** plutôt que les sites nommés :

| # | site | avant | nommé par l'issue |
|---|---|---|---|
| 1 | `invoke_callables` branche EProver | `bool(is_consistent)` | oui (comme 8946) |
| 2 | `invoke_callables` repli TweetyBridge | `bool(is_consistent)` | oui (comme 8882) |
| 3 | `tweety_bridge.execute_modal_query` | `return False` sur FUNC_ERROR | oui |
| 4 | `invoke_callables` branche SPASS modale | `bool(is_consistent)` | **non** |
| 5 | `tweety_bridge.check_consistency` type inconnu | `return False, "Unknown logic type"` | **non** |
| 6 | `appendix._fol_axis_status` branche Mapping | `bool(fol.get("consistent"))` | **non** |

Le site 2 est celui que les vrais corpus empruntent (`eprover` n'est en général pas sur le PATH). Le site 4 est le même motif sur l'axe modal : la voie « raisonnement » passait déjà le tri-état, la voie « solveur externe » l'aplatissait — donc le **même KB** rendait un verdict décidé d'un côté et rien de l'autre. Le site 6 est dans la fonction dont la docstring dit, trois lignes plus haut, que `bool(consistent)` n'y est **pas** utilisé — la branche liste est honnête, la branche Mapping ne l'était pas.

## Une inversion de polarité, trouvée à côté — et mesurée → #1657

⚠️ **Ce n'est pas le motif #1634, c'est un défaut distinct trouvé sur la même ligne**, ouvert séparément en #1657 pour qu'il ait sa trace propre. La branche Prover9 construisait `consistent = "THEOREM PROVED" in result`. L'entrée est une liste SOS **sans but** : une preuve y est donc la dérivation de la clause vide, c'est-à-dire une KB **inconsistante**. Mesuré contre le binaire embarqué (`libs/prover9/bin/prover9.bat`, présent) :

| KB | marqueur Prover9 | stocké avant | stocké après |
|---|---|---|---|
| `P(a).` + `-P(a).` (inconsistante) | `THEOREM PROVED` | `consistent=True` | `consistent=False` |
| `P(a).` + `Q(b).` (consistante) | `SEARCH FAILED` | `consistent=False` | `consistent=True` |

Exactement à l'envers. La ligne portait **deux** défauts — l'inversion, et « aucun marqueur ⇒ booléen par défaut » (celui-là est bien #1634). On ne peut pas corriger le second sans écrire la table des marqueurs, et l'écrire sciemment inversée n'aurait pas de sens : les deux partent ensemble. Signalé séparément pour que personne ne lise ce PR comme « le tri-état a retourné un verdict ».

## Matrice de substitution

| | défaut réintroduit | tests tués |
|---|---|---|
| K | modal `FUNC_ERROR → False` | 1 |
| L | `bool()` FOL, branche EProver seule | 1 |
| L2 | `bool()` FOL, les deux branches | 2 |
| M | polarité Prover9 inversée | 1 |
| N | `bool()` appendix | 1 |
| O | `degraded` re-codé en dur à `False` | 1 |
| P | type de logique inconnu → `False` | 1 |

L et L2 séparent les deux branches FOL : chacune est épinglée pour elle-même. Aucune assertion ne se contente de `is None` — chacune affirme le **contraste** avec le cas décidé correspondant, faute de quoi un changement rendant *tout* indécidé passerait.

## DoD de #1634

- [x] `fol_solver` : `consistent` vaut `None` quand le handler retourne `None` — le `bool()` est retiré aux deux branches
- [x] `modal_solver` : un `FUNC_ERROR` ne produit plus `valid: False` ; il produit `None`, et le statut explicite (`modal_status: "unverified"`, `degraded: True`) devient atteignable
- [x] `tweety_bridge.execute_modal_query` distingue `REJECTED` de `FUNC_ERROR` **dans sa valeur de retour**
- [x] Test par substitution : 7 substitutions, chacune tue au moins un test ; les deux branches FOL sont épinglées séparément
- [x] Rejeu sur les 3 artefacts réels : plus aucune cellule issue d'un crash ne se présente comme décidée

Closes #1634. Closes #1657.

🤖 Coordinator ai-01 — R764
