### PR TITLE
fix(conftest): propagate initialize_jvm's bool return into jvm_started (#1641)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -423,12 +423,46 @@ def pytest_sessionstart(session):
         session.config.cache.set("jvm_started", False)
         return
 
+    # #1641 (B): pytest captures logs per-test and only releases them on a test
+    # FAILURE. pytest_sessionstart runs before any test, so on a green or skip-
+    # heavy run its logs (and jvm_setup's logger.critical failure causes) are
+    # swallowed — the diagnostic is lost EXACTLY when the CI guard #1385 trips
+    # on a mass-skip storm. Route the JVM-init diagnostics to stdout for the
+    # duration of the init attempt, bypassing pytest's capture, so the next
+    # storm arrives with its cause in the CI log. Scoped to the call (handler
+    # removed in finally); attached to the ROOT logger so jvm_setup's critical
+    # lines (different logger) propagate through.
+    _diag_handler = logging.StreamHandler(sys.stdout)
+    _diag_handler.setLevel(logging.INFO)
+    _diag_handler.set_name("jvm_sessionstart_diag_1641")
+    logging.getLogger().addHandler(_diag_handler)
     try:
         from argumentation_analysis.core.jvm_setup import initialize_jvm
 
-        initialize_jvm(session_fixture_owns_jvm=True)
-        session.config.cache.set("jvm_started", True)
-        logger.info("JVM initialisée avec succès depuis pytest_sessionstart.")
+        # #1641: honor the bool return. initialize_jvm signals a DECIDED failure
+        # (no Java / no JARs / post-shutdown re-init) by RETURNING False, not by
+        # raising — 5 reachable return-False paths (jvm_setup.py l.773/781/791/…).
+        # Discarding the return and forcing jvm_started=True recorded that decided
+        # failure as "started": the l.513 guard then never fired, the skip fell
+        # through to the l.522 jpype double-check, whose message ("JVM pas
+        # réellement démarrée") reads as a transient native crash — so the CI
+        # guard #1385 says "re-run" where the real fix is a config correction. A
+        # decided failure rendered as an alea (#1019 family, same shape as #1634).
+        # Propagating the return makes the l.513 guard fire and the skip carry the
+        # honest "l'initialisation a échoué" message. The except below still covers
+        # a genuine raise; the l.522 double-check still covers a real post-start
+        # crash — three distinct causes, three distinct messages, all kept.
+        _jvm_ok = initialize_jvm(session_fixture_owns_jvm=True)
+        session.config.cache.set("jvm_started", bool(_jvm_ok))
+        if _jvm_ok:
+            logger.info("JVM initialisée avec succès depuis pytest_sessionstart.")
+        else:
+            logger.error(
+                "initialize_jvm() a retourné False — échec d'initialisation DÉCIDÉ "
+                "(voir les logger.critical ci-dessus : pas de Java / JARs manquants / "
+                "ré-init après arrêt). Le garde jvm_session sautera les tests JVM avec "
+                "le message d'échec d'init, pas le message de crash transitoire (#1641)."
+            )
     except Exception as e:
         logger.error(
             f"ÉCHEC CRITIQUE de l'initialisation de la JVM dans pytest_sessionstart: {e}"
@@ -436,6 +470,8 @@ def pytest_sessionstart(session):
         session.config.cache.set("jvm_started", False)
         # On ne lance pas pytest.exit ici pour laisser les tests non-JVM s'exécuter
         # Mais on pourrait le faire si la JVM est absolument critique pour toute la suite.
+    finally:
+        logging.getLogger().removeHandler(_diag_handler)
 
 
 def pytest_sessionfinish(session):

--- a/tests/unit/test_conftest_jvm_return_1641.py
+++ b/tests/unit/test_conftest_jvm_return_1641.py
@@ -1,0 +1,112 @@
+"""#1641 — conftest must propagate ``initialize_jvm``'s bool return into
+``jvm_started``, instead of recording a DECIDED init failure as "started".
+
+Pre-fix ``pytest_sessionstart`` (tests/conftest.py) discarded the return of
+``initialize_jvm(...)`` and set ``cache["jvm_started"] = True`` unconditionally.
+But ``initialize_jvm`` signals a decided failure (no Java / no Tweety JARs /
+re-init after shutdown) by RETURNING ``False`` — 5 reachable return-False paths
+(``jvm_setup.py`` l.773/781/791/...) — not by raising. So a decided failure was
+recorded as "started": the ``jvm_session`` guard ``if not jvm_started`` never
+fired, the skip fell through to the ``jpype.isJVMStarted()`` double-check, whose
+message ("la JVM n'est pas réellement démarrée") reads as a transient native
+crash — which is why the CI guard #1385 says "re-run" where the real cure is a
+config correction. A decided failure rendered as an alea (#1019 family, same
+shape as #1634: two opposite causes made indistinguishable downstream, always
+toward the more reassuring reading).
+
+The fix propagates the return: ``initialize_jvm`` → ``False`` ⇒
+``jvm_started = False`` ⇒ the guard fires ⇒ the skip carries the honest
+"l'initialisation de la JVM a échoué" message. The ``except`` (genuine raise)
+and the ``jpype`` double-check (real post-start crash) are KEPT — three distinct
+causes, three distinct messages (anti-pendule: do not collapse them).
+
+Falsifiability — the degenerate substitution of DoD item 1 (force
+``initialize_jvm`` to return ``False``) is pinned by
+``test_initialize_jvm_false_sets_jvm_started_false``: on the pre-fix code the
+return was discarded → ``cache.set("jvm_started", True)`` regardless → the
+``assert_any_call("jvm_started", False)`` FAILS. Verified empirically (revert
+the propagation, this test goes red; restore, green). The companion
+``test_initialize_jvm_true_sets_jvm_started_true`` pins the no-regression path
+(passes both pre- and post-fix). A single decided-failure canary is honest here:
+unlike #1630 there is ONE defect (the discarded return), not two independent
+ones, so a single canary + empirical sub-verification matches the issue's DoD.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_CONFTEST_PATH = Path(__file__).resolve().parents[1] / "conftest.py"
+_JVM_SETUP = "argumentation_analysis.core.jvm_setup.initialize_jvm"
+
+
+@pytest.fixture(scope="module")
+def _sessionstart():
+    """Load the real tests/conftest.py and expose its pytest_sessionstart hook.
+
+    Loaded under a distinct module name so the live conftest registered with
+    pytest is untouched; we only need the function object to call it with a mock
+    session.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "_conftest_under_test_1641", _CONFTEST_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.pytest_sessionstart
+
+
+def _mock_session() -> MagicMock:
+    """A session past the three early-return guards (collectonly / --disable-jvm-
+    session / is_e2e_session all False) so execution reaches the initialize_jvm
+    call."""
+    session = MagicMock()
+    # l.404 guard: collectonly must be False.
+    session.config.option.collectonly = False
+    # l.411 guard: --disable-jvm-session must be False.
+    session.config.getoption.return_value = False
+    # l.417: is_e2e_session cache lookup must return False.
+    session.config.cache.get.return_value = False
+    return session
+
+
+class TestJvmReturnPropagatedToStartedFlag:
+    """DoD #1641 item 2: initialize_jvm's bool return ⇒ jvm_started matches it."""
+
+    def test_initialize_jvm_false_sets_jvm_started_false(self, _sessionstart):
+        """A DECIDED init failure (return False, no raise) must NOT be recorded
+        as 'started'. Pre-fix this assertion fails: the return was discarded and
+        jvm_started forced True."""
+        session = _mock_session()
+        with patch(_JVM_SETUP, return_value=False):
+            _sessionstart(session)
+
+        session.config.cache.set.assert_any_call("jvm_started", False)
+        # And it must NOT have been told the JVM started.
+        set_calls = {
+            tuple(c.args) for c in session.config.cache.set.call_args_list if c.args
+        }
+        assert ("jvm_started", True) not in set_calls
+
+    def test_initialize_jvm_true_sets_jvm_started_true(self, _sessionstart):
+        """No-regression: a genuine success still records started=True."""
+        session = _mock_session()
+        with patch(_JVM_SETUP, return_value=True):
+            _sessionstart(session)
+
+        session.config.cache.set.assert_any_call("jvm_started", True)
+
+    def test_initialize_jvm_raise_still_records_false(self, _sessionstart):
+        """The except branch (genuine raise) is preserved by the fix — a raised
+        failure still records False (anti-pendule: the fix only adds propagation
+        of the return, it does not weaken exception handling)."""
+        session = _mock_session()
+        with patch(_JVM_SETUP, side_effect=RuntimeError("native crash")):
+            _sessionstart(session)
+
+        session.config.cache.set.assert_any_call("jvm_started", False)


### PR DESCRIPTION
## #1641 — conftest must propagate `initialize_jvm`'s bool return into `jvm_started`

`pytest_sessionstart` discarded the return of `initialize_jvm(...)` and set `cache["jvm_started"] = True` **unconditionally**. But `initialize_jvm` signals a **decided** failure (no Java / no Tweety JARs / re-init after shutdown) by **RETURNING** `False` — 5 reachable return-False paths (`jvm_setup.py` l.773/781/791/...) — not by raising.

So a decided failure was recorded as "started": the `jvm_session` guard `if not jvm_started` never fired, the skip fell through to the `jpype.isJVMStarted()` double-check, whose message (*« la JVM n'est pas réellement démarrée »*) reads as a **transient native crash** — which is why the CI guard #1385 says "re-run" where the real cure is a config correction. A decided failure rendered as an alea (#1019 family, same shape as #1634: two opposite causes made indistinguishable downstream, always toward the more reassuring reading).

### The fix (A) — honor the return

```python
_jvm_ok = initialize_jvm(session_fixture_owns_jvm=True)
session.config.cache.set("jvm_started", bool(_jvm_ok))
```

`initialize_jvm → False ⇒ jvm_started = False ⇒ the l.513 guard fires ⇒ the skip carries the honest « l'initialisation de la JVM a échoué » message` instead of the crash message.

**Anti-pendules (issue DoD) — all honored:**
- The `except` (genuine raise) and the l.522 `jpype` double-check (real post-start crash) are **KEPT** — three distinct causes, three distinct messages. Do not collapse them.
- **No `pytest.exit()`** — the l.437-438 deliberate choice (let non-JVM tests run) is preserved. The subject is the *status*, not the severity.

### The fix (B) — DoD item 3, CI diagnosability

pytest captures logs per-test and only releases them on a test **FAILURE**. `pytest_sessionstart` runs before any test, so on a green or skip-heavy run its logs (and `jvm_setup`'s `logger.critical` failure causes) are swallowed — the diagnostic is lost **exactly** when guard #1385 trips on a mass-skip storm. A `StreamHandler` is attached to the **root** logger for the duration of the init attempt (removed in `finally`), routing `jvm_setup`'s critical lines to stdout bypassing pytest's capture, so the next storm arrives with its cause in the CI log.

**The CI guard #1385 is NOT touched** (it works: it converts silent mass-skips into a red build). This fix addresses what happens **upstream** of it.

### Falsifiability — `tests/unit/test_conftest_jvm_return_1641.py` (3 tests)

The degenerate substitution of DoD item 1 (force `initialize_jvm` to return `False`) is pinned by `test_initialize_jvm_false_sets_jvm_started_false`: on the pre-fix code the return was discarded → `cache.set("jvm_started", True)` regardless → the `assert_any_call("jvm_started", False)` **FAILS**. **Verified empirically** (revert the propagation → this test red; restore → green). The companion `true→started=True` and `raise→started=False` pin the no-regression paths.

| Test | Sub (unconditional True) |
|---|---|
| `false→started=False` (canary) | **KILL** |
| `true→started=True` | SPARE |
| `raise→started=False` | SPARE |

A single decided-failure canary is honest here: unlike #1630 there is **one** defect (the discarded return), not two independent ones, so a single canary + empirical sub-verification matches the issue's DoD.

The test loads the **real** `tests/conftest.py` via `importlib` (under a distinct module name so the live conftest is untouched) and calls `pytest_sessionstart` with a mock session past the three early-return guards, patching `initialize_jvm` to the desired return — testing the contract, not a replica.

### Validation

- `pytest test_conftest_jvm_return_1641.py` → **3 passed**;
- conftest loads end-to-end with the modified sessionstart (handler wrapping + real init) — **7 passed** incl. #1630 regression check;
- `conftest.py` is **not** in the 8-file mypy CI gate;
- `black` clean.

### Scope

`tests/conftest.py` (fix A + B) + the new test. Privacy: no corpus content.

🤖 Worker myia-po-2023 — #1641
