### PR TITLE
fix(synthesis): map real producer keys in formal findings (#1636)

### DIFF
--- a/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
+++ b/argumentation_analysis/agents/core/synthesis/deep_synthesis_agent.py
@@ -477,42 +477,92 @@ class DeepSynthesisAgent(BaseAgent):
         return entries
 
     @staticmethod
+    def _verdict_label_pl(r: Dict[str, Any]) -> str:
+        """#1636: tri-state verdict label for PL entries.
+
+        ``satisfiable`` is None (unverified) vs True vs False; conflating
+        them with a falsy default would smuggle "no answer" into "UNSAT"
+        (#1019, same family as #1278/#1279).
+        """
+        sat = r.get("satisfiable")
+        if sat is True:
+            return "SAT"
+        if sat is False:
+            return "UNSAT"
+        return ""
+
+    @staticmethod
+    def _verdict_label_fol(r: Dict[str, Any]) -> str:
+        """#1636: tri-state verdict label for FOL entries. See #1278."""
+        c = r.get("consistent")
+        if c is True:
+            return "consistent"
+        if c is False:
+            return "inconsistent"
+        return ""
+
+    @staticmethod
+    def _verdict_label_modal(r: Dict[str, Any]) -> str:
+        """#1636: tri-state verdict label for Modal entries. See #1279."""
+        v = r.get("valid")
+        if v is True:
+            return "valid"
+        if v is False:
+            return "invalid"
+        return ""
+
+    @staticmethod
     def _build_formal_findings(state: Any) -> List[FormalFinding]:
         findings = []
-        # PL results
+        # PL results — #1636: only the keys that the real PL writer actually
+        # stores (``formulas``, ``satisfiable``, ``model``, ``axiom_count``,
+        # ``query_count``, ``message``) are read. The former keys
+        # (``axioms``/``queries``/``results``/``inconsistency_measures``/
+        # ``linked_args``) had no producer, so each finding shipped as
+        # ``axioms=0 results=`` and the formal channel went silent (#1019).
+        # ``formulas`` is the actual asserted formula text — the legitimate
+        # content of "axioms" here. ``satisfiable`` is the tri-state verdict.
         for r in getattr(state, "propositional_analysis_results", []):
+            verdict = DeepSynthesisAgent._verdict_label_pl(r)
             findings.append(
                 FormalFinding(
                     logic_type="PL",
-                    axioms=r.get("axioms", []),
-                    queries=r.get("queries", []),
-                    results=r.get("results", []),
-                    inconsistency_measures=r.get("inconsistency_measures", {}),
-                    linked_args=r.get("linked_args", []),
+                    axioms=list(r.get("formulas", []) or []),
+                    queries=[],
+                    results=[verdict] if verdict else [],
+                    inconsistency_measures={},
+                    linked_args=[],
                 )
             )
-        # FOL results
+        # FOL results — #1636: the real FOL writer stores ``formulas``,
+        # ``consistent`` (None|True|False), ``inferences``, ``confidence``,
+        # ``message``. We map ``formulas`` → axioms and ``consistent`` → a
+        # tri-state verdict label preserving None vs True vs False.
         for r in getattr(state, "fol_analysis_results", []):
+            verdict = DeepSynthesisAgent._verdict_label_fol(r)
             findings.append(
                 FormalFinding(
                     logic_type="FOL",
-                    axioms=r.get("axioms", []),
-                    queries=r.get("queries", []),
-                    results=r.get("results", []),
-                    inconsistency_measures=r.get("inconsistency_measures", {}),
-                    linked_args=r.get("linked_args", []),
+                    axioms=list(r.get("formulas", []) or []),
+                    queries=[],
+                    results=[verdict] if verdict else [],
+                    inconsistency_measures={},
+                    linked_args=[],
                 )
             )
-        # Modal results
+        # Modal results — #1636: the real Modal writer stores ``formulas``,
+        # ``valid`` (None|True|False), ``modalities``, ``message``. Same
+        # mapping discipline as PL/FOL.
         for r in getattr(state, "modal_analysis_results", []):
+            verdict = DeepSynthesisAgent._verdict_label_modal(r)
             findings.append(
                 FormalFinding(
                     logic_type="Modal",
-                    axioms=r.get("axioms", []),
-                    queries=r.get("queries", []),
-                    results=r.get("results", []),
-                    inconsistency_measures=r.get("inconsistency_measures", {}),
-                    linked_args=r.get("linked_args", []),
+                    axioms=list(r.get("formulas", []) or []),
+                    queries=[],
+                    results=[verdict] if verdict else [],
+                    inconsistency_measures={},
+                    linked_args=[],
                 )
             )
         # Belief sets + query log
@@ -1178,31 +1228,40 @@ class DeepSynthesisAgent(BaseAgent):
                 :max_items_per_field
             ]
         ):
+            # #1636: read the keys the real PL writer actually stores.
+            # ``formulas`` (the asserted theory) replaces the phantom
+            # ``axioms`` key; ``satisfiable`` tri-state replaces the
+            # phantom ``results`` list. A blank verdict token means the
+            # entry exists but the solver returned no decision — distinguish
+            # that from a decided verdict.
+            verdict = DeepSynthesisAgent._verdict_label_pl(r)
+            formulas = r.get("formulas") or []
             _add(
                 "propositional_analysis_results",
                 i,
-                f"axioms={len(r.get('axioms', []))} "
-                f"queries={len(r.get('queries', []))} "
-                f"results={'; '.join(map(str, r.get('results', [])[:3]))}",
+                f"formulas={len(formulas)} verdict={verdict or 'absent'}",
             )
 
         for i, r in enumerate(
             (getattr(state, "fol_analysis_results", []) or [])[:max_items_per_field]
         ):
+            verdict = DeepSynthesisAgent._verdict_label_fol(r)
+            formulas = r.get("formulas") or []
             _add(
                 "fol_analysis_results",
                 i,
-                f"axioms={len(r.get('axioms', []))} "
-                f"results={'; '.join(map(str, r.get('results', [])[:3]))}",
+                f"formulas={len(formulas)} verdict={verdict or 'absent'}",
             )
 
         for i, r in enumerate(
             (getattr(state, "modal_analysis_results", []) or [])[:max_items_per_field]
         ):
+            verdict = DeepSynthesisAgent._verdict_label_modal(r)
+            formulas = r.get("formulas") or []
             _add(
                 "modal_analysis_results",
                 i,
-                f"results={'; '.join(map(str, r.get('results', [])[:3]))}",
+                f"formulas={len(formulas)} verdict={verdict or 'absent'}",
             )
 
         dung = getattr(state, "dung_frameworks", {}) or {}

--- a/tests/unit/argumentation_analysis/test_deep_synthesis_agent.py
+++ b/tests/unit/argumentation_analysis/test_deep_synthesis_agent.py
@@ -68,15 +68,16 @@ def _make_fixture_state() -> UnifiedAnalysisState:
         }
     )
 
-    # Propositional analysis (Section 4)
-    state.propositional_analysis_results.append(
-        {
-            "axioms": ["p => q", "p"],
-            "queries": ["q"],
-            "results": ["q is entailed"],
-            "inconsistency_measures": {"drastic": 0},
-            "linked_args": ["arg_1"],
-        }
+    # Propositional analysis (Section 4) — #1636: build via the real writer
+    # so the test exercises the same key shape the production code reads.
+    # ``axioms``/``queries``/``results`` were phantom keys (no producer) and
+    # the dict literal masked the bug. The real writer stores ``formulas``
+    # + ``satisfiable``; downstream _build_formal_findings maps those into
+    # the FormalFinding fields.
+    state.add_propositional_analysis_result(
+        formulas=["p => q", "p"],
+        satisfiable=True,
+        model={"p": True, "q": True},
     )
 
     # Dung framework (Section 5)
@@ -330,6 +331,154 @@ class TestSectionBuilders:
         d = report.to_dict()
         assert "final_synthesis_status" in d
         assert d["final_synthesis_status"] == "unavailable"
+
+
+# =========================================================================
+# Test: #1636 — _build_formal_findings maps real producer keys
+# =========================================================================
+
+
+class TestFormalFindingsMapping1636:
+    """#1636: deep_synthesis used to read phantom keys (``axioms``,
+    ``queries``, ``results``, ``inconsistency_measures``, ``linked_args``)
+    that no writer produced for PL/FOL/Modal — every FormalFinding shipped
+    as ``axioms=0 results=``. These tests build state via the real
+    ``add_*_analysis_result`` writers and assert the formal channel now
+    reflects the real verdict and formula count."""
+
+    def test_pl_satisfiable_true_propagates_as_SAT_verdict(self):
+        state = UnifiedAnalysisState("test text")
+        state.add_propositional_analysis_result(
+            formulas=["p => q", "p"],
+            satisfiable=True,
+            model={"p": True, "q": True},
+        )
+        findings = DeepSynthesisAgent._build_formal_findings(state)
+        pl = [f for f in findings if f.logic_type == "PL"]
+        assert len(pl) == 1
+        assert pl[0].axioms == ["p => q", "p"]
+        assert pl[0].results == ["SAT"]
+
+    def test_pl_satisfiable_false_propagates_as_UNSAT_verdict(self):
+        state = UnifiedAnalysisState("test text")
+        state.add_propositional_analysis_result(
+            formulas=["p AND NOT p"],
+            satisfiable=False,
+        )
+        findings = DeepSynthesisAgent._build_formal_findings(state)
+        pl = [f for f in findings if f.logic_type == "PL"]
+        assert pl[0].results == ["UNSAT"]
+
+    def test_pl_unverified_does_not_fabricate_verdict(self):
+        """Anti-#1019: satisfiable=None must NOT collapse to a verdict. The
+        pre-fix code didn't have this code path; the dict-literal test fixture
+        masked the bug by always providing a verdict."""
+        state = UnifiedAnalysisState("test text")
+        state.add_propositional_analysis_result(
+            formulas=["p"],
+            satisfiable=None,
+        )
+        findings = DeepSynthesisAgent._build_formal_findings(state)
+        pl = [f for f in findings if f.logic_type == "PL"]
+        # No verdict → results stays empty (the honest "I don't know" signal).
+        assert pl[0].results == []
+        assert pl[0].axioms == ["p"]
+
+    def test_fol_consistent_true_propagates(self):
+        state = UnifiedAnalysisState("test text")
+        state.add_fol_analysis_result(
+            formulas=["forall x. P(x) => P(x)"],
+            consistent=True,
+            inferences=[],
+            confidence=1.0,
+        )
+        findings = DeepSynthesisAgent._build_formal_findings(state)
+        fol = [f for f in findings if f.logic_type == "FOL"]
+        assert len(fol) == 1
+        assert fol[0].axioms == ["forall x. P(x) => P(x)"]
+        assert fol[0].results == ["consistent"]
+
+    def test_fol_unverified_does_not_fabricate(self):
+        state = UnifiedAnalysisState("test text")
+        state.add_fol_analysis_result(
+            formulas=["P(a)"],
+            consistent=None,
+            inferences=[],
+        )
+        findings = DeepSynthesisAgent._build_formal_findings(state)
+        fol = [f for f in findings if f.logic_type == "FOL"]
+        assert fol[0].results == []
+
+    def test_modal_valid_true_propagates(self):
+        state = UnifiedAnalysisState("test text")
+        state.add_modal_analysis_result(
+            formulas=["[]p"],
+            valid=True,
+            modalities=[],
+        )
+        findings = DeepSynthesisAgent._build_formal_findings(state)
+        modal = [f for f in findings if f.logic_type == "Modal"]
+        assert modal[0].results == ["valid"]
+
+    def test_modal_unverified_does_not_fabricate(self):
+        state = UnifiedAnalysisState("test text")
+        state.add_modal_analysis_result(
+            formulas=["<>p"],
+            valid=None,
+            modalities=[],
+        )
+        findings = DeepSynthesisAgent._build_formal_findings(state)
+        modal = [f for f in findings if f.logic_type == "Modal"]
+        assert modal[0].results == []
+
+    def test_phantom_fields_default_to_empty(self):
+        """#1636 anti-pendule: queries / inconsistency_measures / linked_args
+        have no producer for solver-produced PL/FOL/Modal entries. They are
+        set to empty defaults, NOT mapped from ``axiom_count`` or fabricated.
+        The belief_sets branch (separate producer) is the only legitimate
+        source for those fields; this test scopes to the solver branch."""
+        state = UnifiedAnalysisState("test text")
+        state.add_propositional_analysis_result(
+            formulas=["p"],
+            satisfiable=True,
+            axiom_count=3,
+            query_count=2,
+        )
+        findings = DeepSynthesisAgent._build_formal_findings(state)
+        pl = [f for f in findings if f.logic_type == "PL"]
+        assert pl[0].queries == []
+        assert pl[0].inconsistency_measures == {}
+        assert pl[0].linked_args == []
+        # axiom_count / query_count are provenance for the writer, NOT for
+        # the FormalFinding (they're counts, not formula/result content).
+        assert pl[0].axioms == ["p"]
+
+    def test_artifact_fields_distinguishes_decided_from_absent(self):
+        """#1636: ARTIFACT_FIELDS line for PL must NOT emit ``axioms=0
+        results=`` (the old silent-failure signature) when the entry
+        actually carries a verdict. A "decided" entry must say so."""
+        state = UnifiedAnalysisState("test text")
+        state.add_propositional_analysis_result(
+            formulas=["p => q", "p"],
+            satisfiable=True,
+        )
+        rendered = DeepSynthesisAgent.build_artifact_briefing(state)
+        assert "formulas=2" in rendered, rendered
+        assert "verdict=SAT" in rendered, rendered
+        # Anti-#1019: never the broken "axioms=0 results=" signature.
+        assert "axioms=0" not in rendered
+        assert "results=" not in rendered
+
+    def test_artifact_fields_marks_absent_verdict_honestly(self):
+        """#1636: an entry with satisfiable=None must be visibly distinct
+        from a decided entry — the old silent ``0`` would have masked this."""
+        state = UnifiedAnalysisState("test text")
+        state.add_propositional_analysis_result(
+            formulas=["p"],
+            satisfiable=None,
+        )
+        rendered = DeepSynthesisAgent.build_artifact_briefing(state)
+        assert "verdict=absent" in rendered, rendered
 
 
 # =========================================================================


### PR DESCRIPTION
## Contexte

#1636 — `deep_synthesis` lit cinq clés qu'aucun writer ne produit pour les conteneurs PL/FOL/Modal : `axioms`, `queries`, `results`, `inconsistency_measures`, `linked_args`. Chaque `FormalFinding` était donc vide par construction, et la ligne envoyée vers la synthèse narrative valait littéralement `axioms=0 results=`. Canal formel **muet par construction** (#1019).

## Cause localisée

**Production** (R763-style, 3 étages) :
- **Writer** (`_write_fol_to_state:912`, `_write_modal_to_state:956`, writers PL l.1138/1154/1160/1240) : stocke `formulas`, `consistent`/`valid`/`satisfiable`, `model`, `inferences`, `modalities`, `axiom_count`, `query_count`, `message`. **Aucune des 5 clés lues.**
- **Reader** (`_build_formal_findings:480-517` + `build_artifact_briefing:1226-1256`) : lit 5 clés sans producteur. Zéro bien formé, indiscernable d'un zéro mesuré.

## Fix

### Reader-side — ne lire que les clés qu'un writer produit réellement

| Champ `FormalFinding` | Avant (clés fantômes) | Après (clés réelles) |
|---|---|---|
| `axioms` | `r.get("axioms", [])` → 0 | `r.get("formulas", [])` (la théorie assertée EST les axiomes) |
| `results` | `r.get("results", [])` → 0 | verdict tri-état depuis `satisfiable`/`consistent`/`valid` |
| `queries` | `r.get("queries", [])` → 0 | `[]` (pas de producteur pour solver) — honest-empty |
| `inconsistency_measures` | `r.get(...) {} ` → {} | `{}` — honest-empty |
| `linked_args` | `r.get("linked_args", [])` → 0 | `[]` — honest-empty |

**Tri-état verdict** (famille #1278/#1279/#1019) :
- `True` → "SAT" / "consistent" / "valid"
- `False` → "UNSAT" / "inconsistent" / "invalid"
- `None` → **vide** (≠ "UNSAT" : distinguer absence de décision)

**Branche `belief_sets` (l.518-534) inchangée** : c'est le seul producteur légitime pour `queries`/`inconsistency_measures`/`linked_args`.

### ARTIFACT_FIELDS — distinguer decided vs absent

```
Avant:  axioms=0 results=                  ← muet, identique à absent
Après:  formulas=2 verdict=SAT              ← décidé, verdict explicite
        formulas=1 verdict=absent           ← présent mais verdict manquant
```

### Test fixture — ne plus masquer le bug

L.71-80 du test original utilisait un **dict littéral** pour fabriquer les clés fantômes que le reader attendait — ce qui **invalidait le test comme garde-fou**. Remplacé par `state.add_propositional_analysis_result(formulas=[...], satisfiable=True, model={...})` (le vrai writer).

### Anti-pendule explicite

- ❌ **Pas** inventé de producteur pour les 5 clés fantômes (le sujet n'est pas ce que le reader demande, c'est ce que l'état **a**)
- ❌ **Pas** mappé `axiom_count` → `axioms` par `[None] * n` (un compteur n'est pas une liste ; la longueur redeviendrait juste, le contenu resterait faux)
- ❌ **Pas** confondu `satisfiable=None` avec `False` (famille #1019)
- ✅ Tri-état préservé, honest-empty pour les champs sans producteur

## Validation

- `tests/unit/argumentation_analysis/test_deep_synthesis_agent.py`: **61/61 PASSED** (10 nouveaux `TestFormalFindingsMapping1636` + 51 existants dont `test_s4_formal_findings` qui passe maintenant avec le writer réel)
- `tests/unit/argumentation_analysis/test_deep_synthesis_wiring.py`: **11/11 PASSED**
- `tests/unit/argumentation_analysis/test_fb18_grounded_synthesis.py`: PASSED
- `tests/unit/argumentation_analysis/orchestration/test_track_b_fol_fail_loud_1278.py + test_track_c_modal_spass_1279.py`: PASSED
- `tests/unit/argumentation_analysis/reporting/restitution/test_act2_narrative_plugin.py`: **64/64 PASSED**
- `mypy --strict` sur `deep_synthesis_agent.py`: 9 errors (**delta 0**, tous préexistants — vérifié par stash+run sur main propre)

🤖 Generated with [Claude Code](https://claude.com/claude-code)