### PR TITLE
fix(privacy): make the bundle scrub pass reach its list-shaped containers (#1662)

### DIFF
--- a/scripts/analysis/generate_spectacular_bundle.py
+++ b/scripts/analysis/generate_spectacular_bundle.py
@@ -17,7 +17,7 @@ import logging
 import re
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Iterator, Optional
 
 # ── Project root ──────────────────────────────────────────────────────
 ROOT = Path(__file__).resolve().parent.parent.parent
@@ -88,6 +88,30 @@ def _strip_privacy(data: Any, depth: int = 0) -> Any:
         # Top-level string values in dicts (e.g. arg values that are raw strings)
         return "<scrubbed>"
     return data
+
+
+def _iter_dimension_entries(dim: Any) -> Iterator[Dict[str, Any]]:
+    """Yield the mutable entry dicts of an analysis dimension, whatever its shape.
+
+    #1662: analysis dimensions are stored under two different shapes in
+    ``UnifiedAnalysisState`` — a mapping of generated id -> entry
+    (``dung_frameworks``) or a plain list of entries (``ranking_results``,
+    ``probabilistic_results``, ``bipolar_results``). A scrub keyed on the
+    *container's* type only ever reaches one of them. The entries themselves are
+    dicts in both cases, so iterate those and let the caller work on the shape
+    that is actually stable.
+
+    Entries are yielded by reference: mutating them mutates the exported state.
+    """
+    if isinstance(dim, dict):
+        values: Iterable[Any] = dim.values()
+    elif isinstance(dim, list):
+        values = dim
+    else:
+        return
+    for item_val in values:
+        if isinstance(item_val, dict):
+            yield item_val
 
 
 def _scrub_state_for_export(state_data: Dict[str, Any]) -> Dict[str, Any]:
@@ -234,13 +258,16 @@ def _scrub_state_for_export(state_data: Dict[str, Any]) -> Dict[str, Any]:
     # (dung_frameworks, ranking_results, probabilistic_results, bipolar_results)
     # These store List[str] under key "arguments" with raw NL descriptions
     # that bypass the identified_arguments scrub (Pass 2).
+    #
+    # #1662: the four containers do NOT share a shape. `dung_frameworks` is a
+    # Dict[str, Dict] (shared_state.py:442, filled by `[df_id] = {...}`), while
+    # `ranking_results` / `probabilistic_results` / `bipolar_results` are
+    # List[Dict] (l.454/458/459, filled by `.append(entry)`). Gating this pass on
+    # `isinstance(dim, dict)` therefore ran it on ONE of its four declared
+    # targets and silently skipped the other three. Iterate the entries whatever
+    # the container shape instead of testing the container's type.
     for dim_key in ("dung_frameworks", "ranking_results", "probabilistic_results", "bipolar_results"):
-        dim = cleaned.get(dim_key)
-        if not isinstance(dim, dict):
-            continue
-        for item_id, item_val in dim.items():
-            if not isinstance(item_val, dict):
-                continue
+        for item_val in _iter_dimension_entries(cleaned.get(dim_key)):
             args_list = item_val.get("arguments")
             if isinstance(args_list, list):
                 item_val["arguments"] = [

--- a/tests/unit/scripts/analysis/test_generate_spectacular_bundle_privacy.py
+++ b/tests/unit/scripts/analysis/test_generate_spectacular_bundle_privacy.py
@@ -510,3 +510,95 @@ class TestVector5DAGArgumentsDescription:
         """Pass 2 (identified_arguments) should still work alongside Pass 12."""
         result = _scrub_state_for_export(self._make_dag_state())
         assert result["identified_arguments"]["arg_1"]["confidence"] == 0.8
+
+
+# ---------------------------------------------------------------------------
+# Vector 6 (#1662) — the DAG pass must reach the shape the WRITERS produce
+# ---------------------------------------------------------------------------
+
+class TestVector6RealWriterShapes:
+    """Pass 12 must scrub every container it declares, not just the dict-shaped one.
+
+    ``TestVector5DAGArgumentsDescription`` above builds its four containers as
+    dict-of-id -> entry. Only ONE of them is stored that way: ``dung_frameworks``
+    is a ``Dict[str, Dict]`` (shared_state.py:442, filled by ``[df_id] = {...}``),
+    while ``ranking_results`` / ``probabilistic_results`` / ``bipolar_results``
+    are ``List[Dict]`` (l.454/458/459, filled by ``.append(entry)``). Pass 12 was
+    gated on ``isinstance(dim, dict)``, so it ran on the one and silently skipped
+    the three — and the Vector-5 tests stayed green, because their fixture built
+    the shape the guard expected instead of the shape a writer emits.
+
+    That is why these tests drive the REAL writers and serialize through the REAL
+    ``get_state_snapshot()`` rather than hand-rolling a dict: a fixture that
+    invents its own producer can only prove the test agrees with itself.
+
+    Entity names are deliberately absent from the NL below so the final
+    ``_global_entity_scrub`` (a fixed ~30-name allowlist) cannot mask a Pass 12
+    failure — these assertions must be armed by the shape-based scrub alone.
+    """
+
+    _LONG_NL = (
+        "The speaker asserts that the proposed reform is the only viable path forward"
+    )
+
+    def _snapshot_from_real_writers(self):
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+        state = UnifiedAnalysisState("initial text for the analysis")
+        state.add_dung_framework(
+            name="A framework carrying a long descriptive name in natural language",
+            arguments=[self._LONG_NL, "short"],
+            attacks=[["arg_1", "arg_2"]],
+        )
+        state.add_ranking_result(
+            method="burden", arguments=[self._LONG_NL], comparisons=[]
+        )
+        state.add_probabilistic_result(
+            arguments=[self._LONG_NL], acceptance_probs={"arg_1": 0.7}
+        )
+        state.add_bipolar_result(
+            framework_type="bipolar", arguments=[self._LONG_NL], supports=[]
+        )
+        return state.get_state_snapshot()
+
+    def test_writers_emit_list_shaped_containers(self):
+        """Guard on the premise itself: three of the four are lists, one is a dict.
+
+        If a future refactor unifies the shapes, this test fails first and says so,
+        instead of the scrub silently going back to covering only part of them.
+        """
+        snapshot = self._snapshot_from_real_writers()
+        assert isinstance(snapshot["dung_frameworks"], dict)
+        for key in ("ranking_results", "probabilistic_results", "bipolar_results"):
+            assert isinstance(snapshot[key], list), f"{key} is no longer a list"
+            assert snapshot[key], f"{key} was not populated by its writer"
+
+    @pytest.mark.parametrize(
+        "dim_key", ["ranking_results", "probabilistic_results", "bipolar_results"]
+    )
+    def test_list_shaped_dimension_arguments_scrubbed(self, dim_key):
+        """The canary: pre-fix these three were skipped by the isinstance(dict) gate."""
+        result = _scrub_state_for_export(self._snapshot_from_real_writers())
+        entries = result[dim_key]
+        assert entries, f"{dim_key} empty — the assertion would be vacuous"
+        for entry in entries:
+            assert entry["arguments"] == ["<scrubbed>"], (
+                f"{dim_key} carried raw NL through the export scrub"
+            )
+
+    def test_dict_shaped_dimension_still_scrubbed(self):
+        """No-regression: dung_frameworks was the one container the gate reached."""
+        result = _scrub_state_for_export(self._snapshot_from_real_writers())
+        for entry in result["dung_frameworks"].values():
+            assert entry["arguments"][0] == "<scrubbed>"
+            assert entry["arguments"][1] == "short"  # short strings preserved
+            assert entry["name"] == "<scrubbed>"
+
+    def test_no_long_nl_survives_anywhere_in_snapshot(self):
+        """End-to-end: the planted sentence must not appear in the exported JSON.
+
+        Deliberately free of allowlisted entity names, so a pass is attributable
+        to Pass 12 and not to the final entity regex.
+        """
+        result = _scrub_state_for_export(self._snapshot_from_real_writers())
+        assert self._LONG_NL not in json.dumps(result)


### PR DESCRIPTION
## #1662 — la douzième passe déclare quatre conteneurs et n'en atteignait qu'un

`_scrub_state_for_export` (l.232-250) déclare nettoyer `dung_frameworks`, `ranking_results`, `probabilistic_results`, `bipolar_results`, et le fait sous garde `isinstance(dim, dict)`. Un seul des quatre est rangé ainsi :

| Conteneur | Déclaration (`shared_state.py`) | Remplissage | Garde |
|---|---|---|---|
| `dung_frameworks` | `Dict[str, Dict]` (l.442) | `[df_id] = {...}` (l.820) | **vraie** |
| `ranking_results` | `List[Dict]` (l.454) | `.append()` (l.952) | **jamais** |
| `probabilistic_results` | `List[Dict]` (l.458) | `.append()` (l.1013) | **jamais** |
| `bipolar_results` | `List[Dict]` (l.459) | `.append()` (l.1030) | **jamais** |

La passe s'exécutait donc sur **1 de ses 4 cibles**, et les trois autres traversaient l'export avec leurs descriptions NL brutes — précisément la charge que le commentaire de la passe annonce retirer.

## Pourquoi les tests existants étaient verts

`TestVector5DAGArgumentsDescription` couvre les quatre conteneurs et passe depuis des mois. Sa fixture les construit tous les quatre en `dict` d'identifiant → entrée : **la forme que la garde attend, celle qu'aucun writer ne produit**. Une fixture qui invente son propre producteur ne peut prouver que l'accord du test avec lui-même. Le test « étalon » `test_dag_entity_grep_zero_hits` ne discriminait pas non plus : il passait par la passe finale, pas par la douzième.

## Le correctif

Itérer les entrées quelle que soit la forme du conteneur (`_iter_dimension_entries`) au lieu de tester le type du conteneur. Les entrées, elles, sont des `dict` dans les deux cas — c'est la partie stable du contrat.

## Portée — mesurée, et volontairement non gonflée

**Aucune exposition.** Les bundles sont écrits sous `outputs/`, ignoré par `.gitignore:173`, et `git ls-files outputs/` rend **0 fichier suivi**. C'est un contrôle de défense en profondeur qui était inerte, pas une fuite constatée.

En revanche l'argument « la passe finale rattrape » ne tient pas, et c'est mesuré : `_global_entity_scrub` est une **liste nominative figée d'une trentaine d'entités**. La chaîne plantée dans le test de bout en bout ne contient délibérément aucun nom de cette liste, et elle **survit** sur le code pré-correctif. La protection agnostique du corpus, c'est la passe par forme — celle qui était morte.

## Falsifiabilité — substitution vérifiée, pas supposée

6 tests ajoutés, pilotant les **vrais writers** (`add_ranking_result`, `add_probabilistic_result`, `add_bipolar_result`, `add_dung_framework`) et la **vraie sérialisation** (`get_state_snapshot()`).

Revert chirurgical du seul fichier de production, tests inchangés :

| Test | Substitution (garde `isinstance(dict)` rétablie) |
|---|---|
| `test_list_shaped_dimension_arguments_scrubbed[ranking_results]` | **KILL** |
| `test_list_shaped_dimension_arguments_scrubbed[probabilistic_results]` | **KILL** |
| `test_list_shaped_dimension_arguments_scrubbed[bipolar_results]` | **KILL** |
| `test_no_long_nl_survives_anywhere_in_snapshot` | **KILL** |
| `test_writers_emit_list_shaped_containers` (garde de prémisse) | SPARE |
| `test_dict_shaped_dimension_still_scrubbed` (non-régression) | SPARE |

`4 failed, 2 passed` avant, `52 passed` après (46 en base + 6). Les kill-sets sont disjoints comme voulu : la garde de prémisse épingle la *forme des writers* et doit survivre au correctif ; si un refactor futur unifie les formes, elle échoue la première et le dit, au lieu de laisser la passe re-couvrir silencieusement une partie des conteneurs.

Blast radius : `tests/unit/scripts/` **140 passed** ; `tests/unit/argumentation_analysis/{evaluation,reporting}/` **1157 passed**.

## Motif

Troisième site de la garde `isinstance(..., dict)` posée sur un attribut déclaré `List[Dict]` (cf. #1635, où c'était un writer et son lecteur écrits en paire). Premier site dans du code de privacy. L'origine se lit dans l'historique : la passe a été construite et vérifiée contre `dung_frameworks` (#1265, #1271), et ses trois voisins ont été ajoutés au tuple **par leur nom**. Un nom de conteneur ne dit pas sa forme ; l'autorité sur la forme est la classe d'état.

## Note de périmètre

`sanitize_state.py` se déclare « the UNIQUE export guard » et désigne nommément ce scrubber comme **cible de consolidation, pas comme frère**. Corriger un contrôle en sursis n'est pas l'entériner : tant que la consolidation n'a pas eu lieu, c'est du code vivant. Un défaut voisin y a été mesuré au passage et est déposé séparément.

Closes #1662

🤖 Coordinator ai-01
