### PR TITLE
fix(privacy): close the export guard on the six list-shaped state containers (#1664)

### DIFF
--- a/argumentation_analysis/evaluation/sanitize_state.py
+++ b/argumentation_analysis/evaluation/sanitize_state.py
@@ -12,6 +12,30 @@ git, a dashboard, a PR, or an API: it is where nominative content is scrubbed
 at the boundary. Anti-penduple: this is the *only* scrubber — the scattered
 ones (``generate_spectacular_bundle._scrub_state_for_export``,
 ``appendix._strip_leak_keys``) are consolidation targets, not siblings.
+
+Coverage is ALLOWLIST-DRIVEN, and that is a deliberate design: a catch-all
+"scrub every long string" pass would erase the structural aggregates
+(identifiers, methods, framework types, extension topologies) this function
+promises to preserve. The consequence is equally deliberate to state: a
+container absent from every table below traverses this function **intact**.
+Adding a state container is therefore not neutral — it must be classified
+here, and "it carries no natural language" is a claim to be verified against
+its producer, not assumed from its name. #1664 measured the cost of leaving
+that implicit: ``dung_frameworks`` was covered (#1265, #1271) while six
+sibling containers carrying the *same* claim text under the *same* sub-key
+were not, for the simple reason that they are declared ``List[Dict]`` and the
+passes written for Dung gate on ``isinstance(..., dict)``.
+
+Known and deliberately NOT covered, each for a stated reason:
+  * ``workflow_results`` — a free-form dict with no imposed schema; scrubbing
+    it needs a policy, not a table entry.
+  * ``formal_synthesis_reports[*].phase_results.*.formulas`` — symbolic, but
+    Track 2 makes symbols readable (which is why ``variables`` IS opacified);
+    the producer has to be read before deciding.
+  * ``extracts[*].name``, ``semantic_index_refs[*].document_id`` — declared as
+    names, yet structural in every artefact measured so far, and used as join
+    keys downstream. Opacifying them on suspicion would trade a hypothetical
+    leak for a certain breakage.
 """
 
 from __future__ import annotations
@@ -110,6 +134,65 @@ _TEXT_STRIP_LISTS = {
     "nl_to_logic_translations": {"original_text"},
     "semantic_index_refs": {"query", "snippet"},
     "formal_synthesis_reports": {"summary"},
+}
+
+# LIST-of-dicts fields whose sub-keys carry the same nominative claim text that
+# 4b/4c opacify for ``dung_frameworks`` (#1664): top-level field -> {sub_key}.
+# Each sub-key is passed through ``_opacify_list_values``, which handles a bare
+# string, a flat list and a nested list alike — so arity and topology survive
+# and only the content is opacified, exactly as in 4b.
+#
+# Why these fields, measured rather than assumed: ``_extract_arguments_from_
+# context`` (invoke_callables.py:3036) is the helper the 4b comment already
+# cites as the one that "puts the real claim text into ``arguments``". It feeds
+# 17 callables, not just Dung — ranking, probabilistic, bipolar, ASPIC+, belief
+# revision and dialogue among them. Their writers store that list verbatim
+# (shared_state.py:941-1032), so these carry claim text *by construction*:
+#   bipolar_results[*].supports      = [[text_a, text_b], ...]  (cf. Dung attacks)
+#   aspic_results[*].extensions      = [[text, ...], ...]       (cf. Dung extensions)
+#   belief_revision_results[*].original/.revised = [text, ...]
+#   dialogue_results[*].topic        = a claim text (the writer logs topic[:50])
+#
+# Anti-pendulum, also measured: the sibling label fields are NOT here.
+# ``ranking_results.method``, ``aspic_results.reasoner_type``,
+# ``bipolar_results.framework_type``, ``belief_revision_results.method`` are
+# closed vocabularies at every producer, and the contract promises to preserve
+# structural aggregates. Same verdict for ``dung_frameworks.name``: all ten
+# call sites build it from a fixed vocabulary (``aba_preferred``,
+# ``setaf_grounded``, ``social_af``, ``dung_arbitration``…), which confirms the
+# #1271 firsthand reading — it stays untouched.
+_OPAQUE_LIST_OF_DICTS_SUBKEYS = {
+    "ranking_results": {"arguments"},
+    "probabilistic_results": {"arguments"},
+    "bipolar_results": {"arguments", "supports"},
+    "aspic_results": {"extensions"},
+    "belief_revision_results": {"original", "revised"},
+    "dialogue_results": {"topic"},
+}
+
+# List-of-dicts fields with a dict sub-key whose *KEYS* are claim texts
+# (#1664): top-level field -> {sub_key}. ``_invoke_probabilistic`` builds
+# ``probs = {a: 0.5 for a in args}`` (invoke_callables.py:3896), so the
+# acceptance map is indexed by the argument text itself. The keys are
+# opacified and the numeric values kept, so the distribution survives intact.
+_OPAQUE_LIST_OF_DICTS_MAPPING_KEYS = {
+    "probabilistic_results": {"acceptance_probabilities"},
+}
+
+# List-of-dicts fields whose sub-key is ITSELF a list of dicts carrying
+# nominative leaves (#1664): top-level field -> {sub_key -> {leaf_subkeys}}.
+# One level deeper than pass 5.
+#   dialogue_results[*].trace[*]      = {round, speaker, action, argument, target}
+#       ``argument``/``target`` are claim texts (dialogue_handler.py:100-130);
+#       ``speaker``/``action`` are closed vocabularies and survive.
+#   debate_transcripts[*].exchanges[*] = {proponent_move, opponent_move, ...}
+#       ``_TEXT_STRIP_LISTS`` already declares those two sub-keys, but the real
+#       writer nests them one level down inside ``exchanges``
+#       (shared_state.py:860-872), so the declaration never had a target. This
+#       completes an intent already recorded rather than adding a new one.
+_OPAQUE_NESTED_ITEM_SUBKEYS = {
+    "dialogue_results": {"trace": {"argument", "target"}},
+    "debate_transcripts": {"exchanges": {"proponent_move", "opponent_move"}},
 }
 
 # List-of-dicts fields carrying a symbol-mapping sub-key: a ``Dict[str, str]``
@@ -305,6 +388,56 @@ def sanitize_state(state: dict[str, Any] | Any) -> dict[str, Any]:
     for field, text_keys in _TEXT_STRIP_LISTS.items():
         if field in data and isinstance(data[field], list) and text_keys:
             data[field] = _strip_text_from_list(data[field], text_keys)
+
+    # 5b. Opacify the nominative sub-keys of LIST-of-dicts fields — the same
+    #     claim text 4b opacifies for the dict-shaped ``dung_frameworks``
+    #     (#1664). Four of the five formal-argumentation containers are
+    #     declared ``List[Dict]`` and filled by ``append()``, so 4b's
+    #     ``isinstance(data[field], dict)`` gate could never reach them.
+    for field, subkeys in _OPAQUE_LIST_OF_DICTS_SUBKEYS.items():
+        if field in data and isinstance(data[field], list):
+            for item in data[field]:
+                if not isinstance(item, dict):
+                    continue
+                for sk in subkeys:
+                    if sk in item:
+                        item[sk] = _opacify_list_values(item[sk])
+
+    # 5c. Opacify the *keys* of mapping sub-keys inside list-of-dicts fields
+    #     (probabilistic_results[*].acceptance_probabilities is indexed by the
+    #     argument text). Values are numeric and survive, so the distribution
+    #     is unaffected.
+    for field, subkeys in _OPAQUE_LIST_OF_DICTS_MAPPING_KEYS.items():
+        if field in data and isinstance(data[field], list):
+            for item in data[field]:
+                if not isinstance(item, dict):
+                    continue
+                for sk in subkeys:
+                    mapping = item.get(sk)
+                    if isinstance(mapping, dict):
+                        item[sk] = {
+                            (opaque_id(k) if isinstance(k, str) and k else k): v
+                            for k, v in mapping.items()
+                        }
+
+    # 5d. Opacify nominative leaves one level deeper: a list-of-dicts field
+    #     whose sub-key is itself a list of dicts (dialogue traces, debate
+    #     exchanges). Entry count and turn structure survive.
+    for field, nested_spec in _OPAQUE_NESTED_ITEM_SUBKEYS.items():
+        if field in data and isinstance(data[field], list):
+            for item in data[field]:
+                if not isinstance(item, dict):
+                    continue
+                for subtree_key, leaf_subkeys in nested_spec.items():
+                    subtree = item.get(subtree_key)
+                    if not isinstance(subtree, list):
+                        continue
+                    for leaf_item in subtree:
+                        if not isinstance(leaf_item, dict):
+                            continue
+                        for leaf in leaf_subkeys:
+                            if leaf in leaf_item:
+                                leaf_item[leaf] = _opacify_list_values(leaf_item[leaf])
 
     # 6. Opacify symbol-mapping sub-keys inside list-of-dicts fields
     #    (nl_to_logic_translations[*].variables).

--- a/tests/unit/argumentation_analysis/evaluation/test_sanitize_state.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_sanitize_state.py
@@ -698,3 +698,156 @@ class TestSanitizeDungExtensions:
         state = {"dung_frameworks": {"df_1": {"name": "fw", "arguments": ["a"]}}}
         result = sanitize_state(state)
         assert "extensions" not in result["dung_frameworks"]["df_1"]
+
+
+class TestListShapedContainers1664:
+    """#1664 — the six list-shaped containers carrying the same claim text.
+
+    Every state here is built by the REAL writers and serialized by the REAL
+    ``get_state_snapshot()``. A literal fixture cannot prove anything about
+    this defect: the passes written for ``dung_frameworks`` gate on
+    ``isinstance(..., dict)``, so a fixture that builds these containers as
+    dicts hands the guard the one shape no writer emits, and the test agrees
+    with itself while the mechanism is dead.
+
+    The planted string carries NO name from the fixed entity allowlist, so the
+    protection under measurement is the SHAPE-based one, not the name-based
+    final pass.
+    """
+
+    NL = "The speaker asserts that the proposed reform is the only viable path forward"
+    OTHER_NL = "A second claim contending that the timetable was never realistic"
+
+    def _snapshot(self):
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+        state = UnifiedAnalysisState("initial")
+        state.add_ranking_result("burden", [self.NL], [{"rank": 1}])
+        state.add_probabilistic_result([self.NL], {self.NL: 0.75})
+        state.add_bipolar_result("necessity", [self.NL], [[self.NL, self.OTHER_NL]])
+        state.add_aspic_result(
+            "simple", [[self.NL], [self.NL, self.OTHER_NL]], {"n": 2}
+        )
+        state.add_belief_revision_result("dalal", [self.NL], [self.OTHER_NL])
+        state.add_dialogue_result(
+            self.NL,
+            "accepted",
+            [
+                {
+                    "round": 1,
+                    "speaker": "opponent",
+                    "action": "attack",
+                    "argument": self.OTHER_NL,
+                    "target": self.NL,
+                }
+            ],
+        )
+        state.add_debate_transcript(
+            self.NL,
+            [{"proponent_move": self.NL, "opponent_move": self.OTHER_NL}],
+            "proponent",
+        )
+        return state.get_state_snapshot()
+
+    # --- premise guard: must SURVIVE the fix ---------------------------------
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "ranking_results",
+            "probabilistic_results",
+            "bipolar_results",
+            "aspic_results",
+            "belief_revision_results",
+            "dialogue_results",
+            "debate_transcripts",
+        ],
+    )
+    def test_writers_emit_list_shaped_containers(self, field):
+        # Pins the premise of the whole defect: these are lists, so any pass
+        # gated on isinstance(container, dict) is unreachable for them. If a
+        # future refactor unifies the shapes, this fails FIRST and says why,
+        # instead of letting a dict-gated pass silently re-cover half of them.
+        snap = self._snapshot()
+        assert isinstance(snap[field], list), f"{field} is no longer list-shaped"
+        assert isinstance(snap["dung_frameworks"], dict)
+
+    # --- the defect: must DIE when the fix is reverted ------------------------
+
+    @pytest.mark.parametrize(
+        "field,subkey",
+        [
+            ("ranking_results", "arguments"),
+            ("probabilistic_results", "arguments"),
+            ("bipolar_results", "arguments"),
+            ("bipolar_results", "supports"),
+            ("aspic_results", "extensions"),
+            ("belief_revision_results", "original"),
+            ("belief_revision_results", "revised"),
+        ],
+    )
+    def test_claim_text_subkeys_are_opacified(self, field, subkey):
+        result = sanitize_state(self._snapshot())
+        assert self.NL not in json.dumps(
+            result[field]
+        ), f"{field}[*].{subkey}: claim text survived sanitize_state"
+        assert self.OTHER_NL not in json.dumps(result[field])
+
+    def test_probabilistic_acceptance_map_keys_opacified_values_kept(self):
+        # The map is built as {arg_text: prob} by the producer, so the KEYS
+        # carry the payload. The distribution itself must survive intact.
+        result = sanitize_state(self._snapshot())
+        probs = result["probabilistic_results"][0]["acceptance_probabilities"]
+        assert self.NL not in probs
+        assert len(probs) == 1
+        assert list(probs.values()) == [0.75]
+
+    def test_dialogue_trace_leaves_opacified_vocabulary_kept(self):
+        result = sanitize_state(self._snapshot())
+        move = result["dialogue_results"][0]["trace"][0]
+        assert self.NL not in json.dumps(move)
+        assert self.OTHER_NL not in json.dumps(move)
+        # Closed vocabularies and turn structure survive.
+        assert move["speaker"] == "opponent"
+        assert move["action"] == "attack"
+        assert move["round"] == 1
+
+    def test_debate_exchanges_moves_opacified(self):
+        # _TEXT_STRIP_LISTS already declared proponent_move/opponent_move, but
+        # the real writer nests them inside `exchanges` — the declaration had
+        # no target until this pass.
+        result = sanitize_state(self._snapshot())
+        exchange = result["debate_transcripts"][0]["exchanges"][0]
+        assert self.NL not in json.dumps(exchange)
+        assert self.OTHER_NL not in json.dumps(exchange)
+
+    def test_bipolar_support_topology_preserved(self):
+        # Arity and the identity relation must survive: the support pair still
+        # links the SAME two opaque ids that appear in `arguments`.
+        result = sanitize_state(self._snapshot())
+        entry = result["bipolar_results"][0]
+        assert len(entry["supports"]) == 1
+        assert len(entry["supports"][0]) == 2
+        # Non-vacuity: on unscrubbed input both sides are the raw claim text,
+        # so the identity below would hold trivially. Pin that the values are
+        # opacified FIRST, then that the relation between them survived.
+        assert entry["arguments"][0] != self.NL
+        assert entry["supports"][0][0] == entry["arguments"][0]
+
+    def test_no_planted_claim_text_survives_anywhere(self):
+        blob = json.dumps(sanitize_state(self._snapshot()))
+        assert self.NL not in blob
+        assert self.OTHER_NL not in blob
+
+    # --- anti-pendulum: structural aggregates must SURVIVE the fix -----------
+
+    def test_structural_labels_not_over_scrubbed(self):
+        # Measured at every producer: these are closed vocabularies, and the
+        # contract promises to preserve structural aggregates. Scrubbing them
+        # would be the pendulum swing.
+        result = sanitize_state(self._snapshot())
+        assert result["ranking_results"][0]["method"] == "burden"
+        assert result["bipolar_results"][0]["framework_type"] == "necessity"
+        assert result["aspic_results"][0]["reasoner_type"] == "simple"
+        assert result["belief_revision_results"][0]["method"] == "dalal"
+        assert result["dialogue_results"][0]["outcome"] == "accepted"


### PR DESCRIPTION
## #1664 — le garde canonique couvrait un conteneur sur sept

`sanitize_state` se déclare « **the UNIQUE export guard** […] the single chokepoint through which a state snapshot must pass before reaching **git, a dashboard, a PR, or an API** ». Il opacifiait `dung_frameworks.arguments` en `f74d51a7` et laissait **mot pour mot** la même chaîne dans six conteneurs frères.

Cause : `dung_frameworks` est `Dict[str, Dict]`, ses frères sont `List[Dict]` remplis par `.append()`. Les passes 4b/4c écrites pour Dung sont gardées `isinstance(data[field], dict)` — inatteignables pour eux, sans trace.

## Ce qui est corrigé, et pourquoi ces champs-là

Le fil conducteur est `_extract_arguments_from_context` — l'helper que le commentaire de la passe 4b cite **lui-même** comme celui qui « puts the real claim text into `arguments` » pour justifier son existence. Il alimente **17 callables**, pas seulement Dung. Les writers stockent la liste verbatim, donc ces sous-clés portent du texte de revendication **par construction**, pas par hypothèse :

| Conteneur | Sous-clés | Jumeau Dung déjà couvert |
|---|---|---|
| `ranking_results` | `arguments` | `dung_frameworks.arguments` |
| `probabilistic_results` | `arguments`, **les clés de** `acceptance_probabilities` | le producteur écrit `{a: 0.5 for a in args}` — la map est **indexée par le texte** |
| `bipolar_results` | `arguments`, `supports` | `supports` a la forme exacte de `attacks` |
| `aspic_results` | `extensions` | forme exacte de `dung_frameworks[*].extensions` |
| `belief_revision_results` | `original`, `revised` | — |
| `dialogue_results` | `topic`, `trace[*].{argument,target}` | le writer journalise `topic[:50]`, donc le suppose long |
| `debate_transcripts` | `exchanges[*].{proponent_move,opponent_move}` | voir ci-dessous |

Le cas `debate_transcripts` est d'une autre nature : `_TEXT_STRIP_LISTS` **déclarait déjà** `proponent_move` et `opponent_move`, mais le vrai writer les niche un niveau plus bas dans `exchanges`. Deux des trois sous-clés déclarées n'ont jamais eu de cible. Ce commit complète une intention déjà enregistrée — il n'en ajoute pas une nouvelle.

## Anti-pendule — ce qui est délibérément laissé intact

Le contrat promet de **préserver** les agrégats structurels, et l'erreur symétrique serait de tout scrubber.

- **Étiquettes à vocabulaire fermé** : `ranking_results.method`, `aspic_results.reasoner_type`, `bipolar_results.framework_type`, `belief_revision_results.method`, `dialogue_results.outcome`, `trace[*].{speaker,action}`. Un test de non-régression les épingle.
- **`dung_frameworks.name`** : l'issue demandait de trancher. Les **dix** sites d'appel le construisent depuis un vocabulaire fixe (`aba_preferred`, `setaf_grounded`, `social_af`, `dung_arbitration`, `verification_<sem>`, `delp_analysis`…). Le verdict firsthand de #1271 tient ⇒ **laissé intact**. C'est le scrubber du bundle, qui le remplace au-delà de 20 caractères, qui sur-scrubbe — pas celui-ci.
- **Pas de passe attrape-tout récursive.** Effacer « toute chaîne longue » détruirait les identifiants, méthodes et topologies d'extension que le contrat garantit ; le premier à en avoir besoin la désactiverait.

## Le balayage systématique (item 4 de la DoD) — le vrai livrable

Un marqueur **unique** planté dans chaque argument de type chaîne de **chaque** writer, état sérialisé par le vrai `get_state_snapshot()`, sortie parcourue pour retrouver chaque survivant **avec son chemin** :

```
avant : planted=60  reached_snapshot=57  survived_sanitize=33
après : planted=60  reached_snapshot=57  survived_sanitize=20
```

Les 13 tués sont exactement les sous-clés du tableau ci-dessus. Les 20 restants sont classés : étiquettes structurelles (à garder), et trois cas explicitement **non tranchés**, désormais écrits dans la docstring avec leur raison — `workflow_results` (dict libre, demande une politique et non une entrée de table), `formal_synthesis_reports[*].phase_results.*.formulas` (symbolique, mais Track 2 rend les symboles lisibles — c'est pourquoi `variables` EST opacifié : il faut lire le producteur), `extracts[*].name` et `semantic_index_refs[*].document_id` (déclarés comme des noms, mais structurels dans tous les artefacts mesurés et utilisés comme clés de jointure — les opacifier échangerait une fuite hypothétique contre une casse certaine).

La docstring énonce maintenant la limite du modèle en liste d'autorisation : **un conteneur absent de toutes les tables traverse intact**, donc ajouter un conteneur d'état n'est pas neutre. C'est ce non-dit qui a produit le trou.

## Falsifiabilité — substitution vérifiée, pas supposée

19 tests, état construit par les **vrais writers** et sérialisé par le **vrai** `get_state_snapshot()`. Une fixture littérale ne peut rien prouver ici : elle fournirait au garde la forme `dict` qu'aucun writer n'émet, et le test s'accorderait avec lui-même — c'est exactement ce qui a laissé le défaut dormir. La chaîne plantée ne contient aucun nom de la liste d'entités figée, pour que la mesure porte sur la protection **par forme**.

Revert chirurgical du seul fichier de production, tests inchangés : **12 KILL / 8 SPARE**, kill-sets disjoints par construction.

| Rôle | Tests | Revert |
|---|---|---|
| Le défaut | 7 paramétrés (claim text) + map d'acceptation + trace de dialogue + échanges de débat + topologie bipolaire + rien-ne-survit | **KILL** ×12 |
| Prémisse (7 conteneurs en forme de liste, Dung en dict) | `test_writers_emit_list_shaped_containers` | SPARE |
| Anti-pendule (étiquettes structurelles) | `test_structural_labels_not_over_scrubbed` | SPARE |

Le garde de prémisse est là pour un motif précis : si un refactor futur unifie les formes, il échoue **le premier** et le dit, au lieu de laisser une passe gardée par le type re-couvrir silencieusement une partie des conteneurs.

⚠️ `test_bipolar_support_topology_preserved` a d'abord **survécu** au revert : sur entrée non scrubbée, `supports[0][0]` et `arguments[0]` sont tous deux le texte brut, donc l'identité tenait trivialement. Corrigé en épinglant d'abord la non-vacuité (`arguments[0] != NL`), puis la relation.

## Portée — mesurée, et non gonflée

Sur les artefacts réels dont je dispose, ces sept conteneurs sont **vides**. **Aucune fuite constatée.** Ce qui est établi : un garde qui se déclare unique couvrait une fraction de ce qu'il annonce.

Ce n'est pas une raison de différer — c'est la raison de fermer maintenant. Ces conteneurs sont précisément ceux que l'Epic des modules inertes travaille à remplir : le vide qui rend le défaut inoffensif est **la même cause** que celle qui l'a rendu invisible. Le jour où ces modules produisent enfin quelque chose, l'attention sera sur « le module marche », pas sur « son garde d'export est-il juste ? ».

Blast radius : `evaluation/` + `reporting/` + `tests/unit/scripts/` → **1317 passed**.

Closes #1664

🤖 Coordinator ai-01
