### PR TITLE
feat(restitution): open the presence channel for structured-argumentation axes (#1667)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -796,53 +796,75 @@ def _bipolar_finding(state: Any) -> Optional[StructuredArgFinding]:
 
 
 def _aspic_finding(state: Any) -> Optional[StructuredArgFinding]:
-    """Project the surviving rule-derivations — what ASPIC+ alone says.
+    """Project what ASPIC+ alone establishes: derivations that exclude each other.
 
-    ASPIC+ arguments are derivations through strict/defeasible rules, so a
-    surviving extension names WHICH chains of reasoning withstand defeat, not
-    merely which atomic claims do.
+    An ASPIC+ argument is a derivation *through rules*, so what this axis brings
+    that no other does is naming WHICH chains of reasoning cannot be held
+    together. That — not "which claims survived" — is the finding.
 
-    Returns ``None`` when every extension is empty. That is the measured state
-    of the pipeline today: all 8 real artifacts carry ``extensions: [[]]`` with
-    ``axioms_count: 0``, because ``_invoke_aspic`` reads ``context["axioms"]``
-    and nothing in the orchestration ever writes that key — with no ordinary
-    premise, ASPIC+ builds no argument at all. Emitting anything here would
-    dress an argument-free theory as a result (#1019). This guard is the
-    regression sentinel for the day the producer is repaired.
+    Two conditions gate emission. Both are measured firsthand (JVM probes,
+    R766), not assumed:
+
+    1. **At least one non-empty extension.** All 8 real artifacts carry
+       ``extensions: [[]]``: ``_invoke_aspic`` reads ``context["axioms"]`` and
+       nothing in the orchestration writes it, and ``addOrdinaryPremise`` is
+       gated on ``if axioms:``. With no ordinary premise ASPIC+ builds no
+       argument at all — 0 arguments, empty framework, single empty extension.
+    2. **At least two distinct non-empty extensions.** Supplying premises is not
+       sufficient: the handler only ever builds ``Proposition(head)``, never a
+       ``Negation``, so no two rule heads can contradict — a head string of
+       ``"!x"`` yields a proposition *named* ``!x``, which conflicts with
+       nothing. Measured on the premises-supplied shape: 11 arguments, **0
+       attacks**, one extension holding all 11. A single all-inclusive extension
+       decided nothing; reporting it would hand the conclusion a
+       formally-authorised statement with no discriminating content (#1631).
+
+    So the finding is the *contested* set — what some extensions keep and others
+    drop — never a count, and never "everything survived".
     """
     entries = getattr(state, "aspic_results", None) or []
     if not isinstance(entries, list):
         return None
-    best: List[str] = []
+    contested: List[str] = []
     for entry in entries:
         if not isinstance(entry, dict):
             continue
         extensions = entry.get("extensions") or []
         if not isinstance(extensions, list):
             continue
+        distinct: List[frozenset] = []
         for ext in extensions:
             if not isinstance(ext, (list, tuple)):
                 continue
-            members = [
+            members = frozenset(
                 _truncate(str(m).strip(), _ASPIC_MEMBER_CAP)
                 for m in ext
                 if str(m).strip()
-            ]
-            if len(members) > len(best):
-                best = members
-    if not best:
+            )
+            if members and members not in distinct:
+                distinct.append(members)
+        # One extension (or one repeated) = nothing was arbitrated.
+        if len(distinct) < 2:
+            continue
+        union = frozenset().union(*distinct)
+        intersection = frozenset.intersection(*distinct)
+        entry_contested = sorted(union - intersection)
+        if len(entry_contested) > len(contested):
+            contested = entry_contested
+    if not contested:
         return None
-    shown = best[:_ASPIC_MEMBERS_SHOWN]
+    shown = contested[:_ASPIC_MEMBERS_SHOWN]
     tail = (
         ""
-        if len(best) <= _ASPIC_MEMBERS_SHOWN
-        else f" (et {len(best) - len(shown)} autre(s))"
+        if len(contested) <= _ASPIC_MEMBERS_SHOWN
+        else f" (et {len(contested) - len(shown)} autre(s))"
     )
     return StructuredArgFinding(
         capability="aspic_plus_reasoning",
         label=_axis_label("aspic_plus_reasoning"),
         statement=(
-            "les enchaînements de règles qui résistent à la défaite : "
+            "des enchaînements de raisonnement s'excluent mutuellement — "
+            "le corpus ne permet pas de les tenir tous ensemble : "
             + " | ".join(shown)
             + tail
         ),

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -88,6 +88,16 @@ _MAX_CLAIM_EXCERPTS = 5
 # a future longer wording cannot silently eat the prompt budget.
 _ABSENCE_REASON_CAP = 300
 
+# #1667 — the PRESENCE side of the same axes. Before this, a structured-argu-
+# mentation axis reached the conclusion ONLY through the absence ledger above:
+# the prose had a vocabulary for the axis that FAILED and none for the axis that
+# SUCCEEDED. Reanimating a module therefore REMOVED its single trace from the
+# narrative. These caps bound what a successful axis may spend of the prompt.
+_SUPPORT_NODE_CAP = 140
+_SUPPORT_PAIR_CAP = 3
+_ASPIC_MEMBER_CAP = 120
+_ASPIC_MEMBERS_SHOWN = 4
+
 # #1605 — reader-facing French names for the structured-argumentation axes. The
 # prose forbids raw snake_case identifiers (they are opaque to the non-technical
 # reader this narrative addresses), so a capability key never reaches the
@@ -303,6 +313,23 @@ class AbsentDimension:
 
 
 @dataclass(frozen=True)
+class StructuredArgFinding:
+    """What a structured-argumentation axis ESTABLISHED, when it succeeded (#1667).
+
+    The symmetric counterpart of :class:`AbsentDimension`. ``statement`` is not a
+    count and not a status word: it is what THIS formalism says and no other axis
+    says — the support relation for bipolar, the surviving rule-derivations for
+    ASPIC+. A count here would reproduce ``appendix.py``'s ``"disponible"`` one
+    hop further along: the witness moved, no decider created (anti-pendule
+    #1667).
+    """
+
+    capability: str
+    label: str
+    statement: str
+
+
+@dataclass(frozen=True)
 class BlockedClaim:
     """A sentence the gate removed because its axis produced nothing (#1605).
 
@@ -370,6 +397,12 @@ class Act3Evidence:
     # not a defect of the pipeline: it is the one thing the conclusion was
     # structurally unable to say before this field existed.
     absent_dimensions: List[AbsentDimension] = field(default_factory=list)
+    # #1667 — the symmetric PRESENCE channel. ``absent_dimensions`` above was the
+    # ONLY path from a structured-argumentation axis to this conclusion, and it
+    # opens on failure. An axis that worked was therefore mute here, and making a
+    # module work again removed its single trace from the prose. Empty when no
+    # axis established anything — never a status word, never a count.
+    structured_findings: List[StructuredArgFinding] = field(default_factory=list)
 
 
 @dataclass
@@ -710,6 +743,128 @@ def _collect_absent_dimensions(state: Any) -> List[AbsentDimension]:
     return sorted(out, key=lambda d: d.label)
 
 
+def _axis_label(capability: str) -> str:
+    """Reader-facing French name of a structured-argumentation axis.
+
+    Shares :data:`_ABSENT_DIMENSION_LABELS` with the absence ledger on purpose:
+    the French name of an axis does not depend on whether it succeeded. Only the
+    sentence built around it does.
+    """
+    return _ABSENT_DIMENSION_LABELS.get(capability, capability.replace("_", " "))
+
+
+def _bipolar_finding(state: Any) -> Optional[StructuredArgFinding]:
+    """Project the SUPPORT relation — what bipolar argumentation alone says.
+
+    Dung frameworks carry attacks only; ``supports`` is the relation no other
+    axis in the pipeline computes. Measured on 8 real state artifacts: 4 to 9
+    support pairs each, varying with the argument inventory — genuine payload,
+    not a constant.
+
+    Returns ``None`` when no well-formed pair exists (fail-loud #1019: an empty
+    support set is an honest absence, never a fabricated sentence).
+    """
+    entries = getattr(state, "bipolar_results", None) or []
+    if not isinstance(entries, list):
+        return None
+    pairs: List[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        supports = entry.get("supports") or []
+        if not isinstance(supports, list):
+            continue
+        for pair in supports:
+            if not isinstance(pair, (list, tuple)) or len(pair) != 2:
+                continue
+            source = _truncate(str(pair[0]).strip(), _SUPPORT_NODE_CAP)
+            target = _truncate(str(pair[1]).strip(), _SUPPORT_NODE_CAP)
+            if not source or not target:
+                continue
+            pairs.append(f"« {source} » appuie « {target} »")
+            if len(pairs) >= _SUPPORT_PAIR_CAP:
+                break
+        if len(pairs) >= _SUPPORT_PAIR_CAP:
+            break
+    if not pairs:
+        return None
+    return StructuredArgFinding(
+        capability="bipolar_argumentation",
+        label=_axis_label("bipolar_argumentation"),
+        statement="; ".join(pairs),
+    )
+
+
+def _aspic_finding(state: Any) -> Optional[StructuredArgFinding]:
+    """Project the surviving rule-derivations — what ASPIC+ alone says.
+
+    ASPIC+ arguments are derivations through strict/defeasible rules, so a
+    surviving extension names WHICH chains of reasoning withstand defeat, not
+    merely which atomic claims do.
+
+    Returns ``None`` when every extension is empty. That is the measured state
+    of the pipeline today: all 8 real artifacts carry ``extensions: [[]]`` with
+    ``axioms_count: 0``, because ``_invoke_aspic`` reads ``context["axioms"]``
+    and nothing in the orchestration ever writes that key — with no ordinary
+    premise, ASPIC+ builds no argument at all. Emitting anything here would
+    dress an argument-free theory as a result (#1019). This guard is the
+    regression sentinel for the day the producer is repaired.
+    """
+    entries = getattr(state, "aspic_results", None) or []
+    if not isinstance(entries, list):
+        return None
+    best: List[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        extensions = entry.get("extensions") or []
+        if not isinstance(extensions, list):
+            continue
+        for ext in extensions:
+            if not isinstance(ext, (list, tuple)):
+                continue
+            members = [
+                _truncate(str(m).strip(), _ASPIC_MEMBER_CAP)
+                for m in ext
+                if str(m).strip()
+            ]
+            if len(members) > len(best):
+                best = members
+    if not best:
+        return None
+    shown = best[:_ASPIC_MEMBERS_SHOWN]
+    tail = (
+        ""
+        if len(best) <= _ASPIC_MEMBERS_SHOWN
+        else f" (et {len(best) - len(shown)} autre(s))"
+    )
+    return StructuredArgFinding(
+        capability="aspic_plus_reasoning",
+        label=_axis_label("aspic_plus_reasoning"),
+        statement=(
+            "les enchaînements de règles qui résistent à la défaite : "
+            + " | ".join(shown)
+            + tail
+        ),
+    )
+
+
+def _collect_structured_arg_findings(state: Any) -> List[StructuredArgFinding]:
+    """Collect the structured-argumentation axes that produced something (#1667).
+
+    One channel, not one reader per axis (the eight-half-fixes lesson of #1633).
+    Each projector decides on its own whether its axis has a singular statement
+    to make; an axis with nothing to say produces nothing rather than a status
+    word.
+    """
+    out: List[StructuredArgFinding] = []
+    for projector in (_aspic_finding, _bipolar_finding):
+        finding = projector(state)
+        if finding is not None:
+            out.append(finding)
+    return sorted(out, key=lambda f: f.label)
+
+
 def _collect_debate(state: Any) -> List[DebateExchange]:
     """Collect adversarial-debate exchanges (SV #1182). Gap β G8: can be sparse.
 
@@ -943,6 +1098,7 @@ def build_act3_evidence(state: Any) -> Act3Evidence:
         deanonymized=bool(getattr(state, "deanonymized", True)),
         claim_excerpts=claim_excerpts,
         absent_dimensions=_collect_absent_dimensions(state),
+        structured_findings=_collect_structured_arg_findings(state),
     )
 
 
@@ -1196,6 +1352,20 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
             "abouti sur ce corpus)"
         )
 
+    # #1667 — the symmetric presence side. Rendered in both states, exactly like
+    # the absence block above: an empty section and a missing section read the
+    # same to the LLM, and this channel exists precisely because a silence was
+    # being read as a verdict.
+    if evidence.structured_findings:
+        presence_block = "\n".join(
+            f"  - {f.label} : {f.statement}" for f in evidence.structured_findings
+        )
+    else:
+        presence_block = (
+            "  (aucun cadre d'argumentation structurée n'a établi de relation "
+            "exploitable sur ce corpus — ne fabrique aucun résultat formel)"
+        )
+
     opaque_block = f"{_OPAQUE_ID_DIRECTIVE}\n\n" if not evidence.deanonymized else ""
 
     return (
@@ -1227,6 +1397,7 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         f"[CONTRE-POINTS — ce qui affaiblit les revendications]\n{counters_lines}\n\n"
         f"[POINTS DE PRUDENCE — ancrages structurels]\n{target_lines}\n\n"
         f"[DÉLIBÉRATION COLLECTIVE — governance + débat]\n{deliberation_block}\n\n"
+        f"[CE QUE LES CADRES STRUCTURÉS ÉTABLISSENT]\n{presence_block}\n\n"
         f"[DIMENSIONS NON ÉVALUÉES — à dire, jamais à taire]\n{absence_block}\n\n"
         f"{what_next_block}\n\n"
         "CONSIGNE DE RÉDACTION :\n"
@@ -1254,6 +1425,14 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         "  déanonymise aucune source.\n"
         "- La conclusion doit VARIER selon le contenu réel ci-dessus : pas de\n"
         "  prose générique recyclable.\n"
+        "- Si le bloc CE QUE LES CADRES STRUCTURÉS ÉTABLISSENT porte une relation,\n"
+        "  SERS-T'EN dans le deuxième battement : elle dit comment les propos du\n"
+        "  locuteur se tiennent ENTRE EUX (ce qui s'appuie sur quoi, quel\n"
+        "  enchaînement résiste), ce qu'aucune autre analyse du rapport ne dit.\n"
+        "  Rends-la en français courant, au service du jugement du lecteur, sans\n"
+        "  la nommer par son formalisme et sans en faire un titre. Si le bloc dit\n"
+        "  qu'aucun cadre n'a rien établi, n'invente aucun résultat formel : cette\n"
+        "  absence-là se tait, elle relève du bloc suivant.\n"
         "- Si le bloc DIMENSIONS NON ÉVALUÉES en liste, DIS-LE au lecteur dans le\n"
         "  troisième battement, en une phrase et en français courant : quel angle\n"
         "  d'analyse n'a pas abouti sur ce texte, et donc ce que ce verdict ne\n"

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -28,6 +28,8 @@ import pytest
 from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
     Act3Result,
     _COUNTER_LIST_CAP,
+    _SUPPORT_NODE_CAP,
+    _SUPPORT_PAIR_CAP,
     _fol_verified,
     _is_guest_formal_entry,
     _pl_verified,
@@ -1329,3 +1331,182 @@ class TestCounterTruncationIsAnnounced:
         assert (
             listed == _COUNTER_LIST_CAP
         ), f"enumerated {listed}, cap is {_COUNTER_LIST_CAP}"
+
+
+# --- #1667: the PRESENCE channel for structured-argumentation axes -----------
+#
+# Before this channel, `absent_dimensions` was the ONLY path from a structured
+# axis to the Acte III conclusion, and it opens on `degraded=True`. The prose
+# had a vocabulary for the axis that FAILED and none for the axis that
+# SUCCEEDED — so repairing a module REMOVED its single trace from the
+# narrative, and any "does the conclusion mention this axis?" metric read
+# exactly backwards. These tests pin the symmetric path.
+
+
+def _bipolar_state(supports: object, **extra: object) -> SimpleNamespace:
+    state = _rich_state()
+    state.bipolar_results = [
+        {
+            "id": "bipolar_1",
+            "framework_type": "necessity",
+            "arguments": ["A", "B"],
+            "supports": supports,
+        }
+    ]
+    for k, v in extra.items():
+        setattr(state, k, v)
+    return state
+
+
+def _aspic_state(extensions: object) -> SimpleNamespace:
+    state = _rich_state()
+    state.aspic_results = [
+        {
+            "id": "aspic_1",
+            "reasoner_type": "simple",
+            "extensions": extensions,
+            "statistics": {"extensions_count": 1},
+        }
+    ]
+    return state
+
+
+class TestStructuredArgPresenceChannel:
+    """A structured axis that SUCCEEDS must reach the conclusion (#1667)."""
+
+    def test_baseline_state_yields_no_finding(self) -> None:
+        """Non-vacuity floor: nothing in state ⇒ nothing fabricated."""
+        ev = build_act3_evidence(_rich_state())
+        assert ev.structured_findings == []
+
+    def test_empty_containers_leave_the_prompt_free_of_formal_claims(self) -> None:
+        state = _bipolar_state([])
+        state.aspic_results = []
+        prompt = build_act3_prompt(build_act3_evidence(state))
+        assert "aucun cadre d'argumentation structurée n'a établi" in prompt
+        # The support-sentence marker specifically — the bare word "appuie"
+        # already occurs in the static weaving rule ("le verdict formel appuie
+        # un battement narratif"), so asserting on it would pass vacuously.
+        assert "» appuie «" not in prompt
+
+    def test_bipolar_support_relation_becomes_a_finding(self) -> None:
+        state = _bipolar_state(
+            [["La croissance a repris", "La politique menée est bonne"]]
+        )
+        ev = build_act3_evidence(state)
+        (finding,) = ev.structured_findings
+        assert finding.capability == "bipolar_argumentation"
+        assert "La croissance a repris" in finding.statement
+        assert "La politique menée est bonne" in finding.statement
+
+    def test_finding_is_not_a_count(self) -> None:
+        """Anti-pendule of this issue: "1 résultat bipolaire" would reproduce
+        ``appendix.py``'s ``"disponible"`` one hop further along — the witness
+        moved, no decider created. The statement must carry the relation.
+        """
+        pair = ["Le chômage recule", "La réforme fonctionne"]
+        (finding,) = build_act3_evidence(_bipolar_state([pair])).structured_findings
+        assert all(node in finding.statement for node in pair)
+        assert finding.statement.strip() not in {"1", "1 relation", "disponible"}
+
+    def test_label_is_reader_facing_not_snake_case(self) -> None:
+        (finding,) = build_act3_evidence(
+            _bipolar_state([["x", "y"]])
+        ).structured_findings
+        assert "_" not in finding.label
+        assert finding.label != finding.capability
+
+    @pytest.mark.parametrize(
+        "supports",
+        [
+            [],
+            [["", ""]],
+            [["only-one-node"]],
+            [["a", "b", "c"]],
+            ["not-a-pair"],
+            "not-a-list",
+        ],
+        ids=["empty", "blank-nodes", "arity-1", "arity-3", "scalar-item", "scalar"],
+    )
+    def test_malformed_or_empty_supports_produce_nothing(self, supports) -> None:
+        """Fail-loud (#1019): a channel open onto emptiness is worse than a
+        closed one — the axis would count as "evaluated" while saying nothing.
+        """
+        assert build_act3_evidence(_bipolar_state(supports)).structured_findings == []
+
+    def test_support_pairs_are_capped(self) -> None:
+        pairs = [[f"source {i}", f"target {i}"] for i in range(_SUPPORT_PAIR_CAP + 5)]
+        (finding,) = build_act3_evidence(_bipolar_state(pairs)).structured_findings
+        assert finding.statement.count(" appuie ") == _SUPPORT_PAIR_CAP
+
+    def test_long_support_nodes_are_truncated(self) -> None:
+        long_node = "m" * (_SUPPORT_NODE_CAP + 200)
+        (finding,) = build_act3_evidence(
+            _bipolar_state([[long_node, "court"]])
+        ).structured_findings
+        assert long_node not in finding.statement
+        assert "[…]" in finding.statement
+
+    def test_aspic_empty_extension_produces_nothing(self) -> None:
+        """The measured production shape, unanimous on 8 real state artifacts:
+        ``extensions: [[]]`` with ``axioms_count: 0``. ``_invoke_aspic`` reads
+        ``context["axioms"]``, a key no producer in the orchestration writes, so
+        ASPIC+ builds no argument at all and its single extension is empty.
+        Emitting here would dress an argument-free theory as a result. This is
+        the regression sentinel for the day that producer is repaired.
+        """
+        assert build_act3_evidence(_aspic_state([[]])).structured_findings == []
+
+    def test_aspic_non_empty_extension_becomes_a_finding(self) -> None:
+        state = _aspic_state([[], ["def_arg_1: prémisse => conclusion_plausible"]])
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert finding.capability == "aspic_plus_reasoning"
+        assert "def_arg_1: prémisse => conclusion_plausible" in finding.statement
+
+    def test_both_axes_are_carried_by_one_channel(self) -> None:
+        """One channel, not one reader per axis (the eight-half-fixes lesson)."""
+        state = _bipolar_state([["s", "t"]])
+        state.aspic_results = [
+            {"extensions": [["derivation_1"]], "statistics": {}},
+        ]
+        ev = build_act3_evidence(state)
+        assert {f.capability for f in ev.structured_findings} == {
+            "aspic_plus_reasoning",
+            "bipolar_argumentation",
+        }
+
+    @pytest.mark.parametrize(
+        "state_factory, payload",
+        [
+            (
+                lambda: _bipolar_state([["la reprise est réelle", "le cap est bon"]]),
+                "la reprise est réelle",
+            ),
+            (lambda: _aspic_state([["chaine_defaisable_7"]]), "chaine_defaisable_7"),
+        ],
+        ids=["bipolar", "aspic"],
+    )
+    def test_a_present_non_trivial_axis_reaches_the_prompt(
+        self, state_factory, payload
+    ) -> None:
+        """The contract this issue exists to pin: it FAILS if a non-trivial axis
+        stops before the Acte III prompt — which is where all of them stopped.
+        """
+        prompt = build_act3_prompt(build_act3_evidence(state_factory()))
+        assert payload in prompt
+        assert "CE QUE LES CADRES STRUCTURÉS ÉTABLISSENT" in prompt
+
+    def test_presence_and_absence_are_additive_not_substitutive(self) -> None:
+        """Anti-pendule: the absence ledger stays correct and useful. An axis
+        that really degraded must keep being named; we ADD the presence lane.
+        """
+        state = _bipolar_state([["s", "t"]])
+        state.structured_arg_status = _ledger("setaf_reasoning")
+        ev = build_act3_evidence(state)
+        assert [d.capability for d in ev.absent_dimensions] == ["setaf_reasoning"]
+        assert [f.capability for f in ev.structured_findings] == [
+            "bipolar_argumentation"
+        ]
+        prompt = build_act3_prompt(ev)
+        assert "DIMENSIONS NON ÉVALUÉES" in prompt
+        assert "CE QUE LES CADRES STRUCTURÉS ÉTABLISSENT" in prompt

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -1457,17 +1457,59 @@ class TestStructuredArgPresenceChannel:
         """
         assert build_act3_evidence(_aspic_state([[]])).structured_findings == []
 
-    def test_aspic_non_empty_extension_becomes_a_finding(self) -> None:
-        state = _aspic_state([[], ["def_arg_1: prémisse => conclusion_plausible"]])
+    def test_aspic_single_all_inclusive_extension_produces_nothing(self) -> None:
+        """The state one hop after the premises are repaired — measured, not
+        hypothesised (JVM probe, R766): supplying ordinary premises yields 11
+        arguments, **0 attacks**, and ONE extension holding all 11.
+
+        Zero attacks because ``ASPICHandler`` only ever builds
+        ``Proposition(head)``, never a ``Negation``: a head string of ``"!x"``
+        becomes a proposition *named* ``!x``, conflicting with nothing. An
+        extension that excludes no argument arbitrated nothing, and emitting it
+        would hand the conclusion a formally-authorised statement with no
+        discriminating content (#1631). Fixing premises alone must NOT open this
+        channel.
+        """
+        state = _aspic_state([["def_arg_1: p => c", "def_arg_2: q => d"]])
+        assert build_act3_evidence(state).structured_findings == []
+
+    def test_aspic_competing_extensions_become_a_finding(self) -> None:
+        """Two extensions that disagree ⇒ a real arbitration happened. The
+        finding is the CONTESTED set (union − intersection), because what ASPIC+
+        brings that no other axis does is naming which derivations cannot be
+        held together — not which ones survived.
+        """
+        state = _aspic_state(
+            [
+                ["socle_partagé", "def_arg_1: prémisse => conclusion_plausible"],
+                ["socle_partagé", "rebuttal_1: sophisme => conclusion_contraire"],
+            ]
+        )
         (finding,) = build_act3_evidence(state).structured_findings
         assert finding.capability == "aspic_plus_reasoning"
         assert "def_arg_1: prémisse => conclusion_plausible" in finding.statement
+        assert "rebuttal_1: sophisme => conclusion_contraire" in finding.statement
+        # The uncontested member is not the finding — it is what both sides keep.
+        assert "socle_partagé" not in finding.statement
+
+    def test_aspic_duplicate_extensions_are_not_a_disagreement(self) -> None:
+        """Two entries carrying the SAME extension arbitrate nothing. Guards the
+        cheap reading of the rule above ("len(extensions) >= 2").
+        """
+        ext = ["def_arg_1: p => c"]
+        assert (
+            build_act3_evidence(_aspic_state([ext, list(ext)])).structured_findings
+            == []
+        )
 
     def test_both_axes_are_carried_by_one_channel(self) -> None:
         """One channel, not one reader per axis (the eight-half-fixes lesson)."""
         state = _bipolar_state([["s", "t"]])
         state.aspic_results = [
-            {"extensions": [["derivation_1"]], "statistics": {}},
+            {
+                "extensions": [["socle", "derivation_1"], ["socle", "derivation_2"]],
+                "statistics": {},
+            },
         ]
         ev = build_act3_evidence(state)
         assert {f.capability for f in ev.structured_findings} == {
@@ -1482,7 +1524,12 @@ class TestStructuredArgPresenceChannel:
                 lambda: _bipolar_state([["la reprise est réelle", "le cap est bon"]]),
                 "la reprise est réelle",
             ),
-            (lambda: _aspic_state([["chaine_defaisable_7"]]), "chaine_defaisable_7"),
+            (
+                lambda: _aspic_state(
+                    [["socle", "chaine_defaisable_7"], ["socle", "chaine_rivale_2"]]
+                ),
+                "chaine_defaisable_7",
+            ),
         ],
         ids=["bipolar", "aspic"],
     )

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
@@ -22,9 +22,10 @@ accord between them (same shape as the #1619 corrective).
 Falsifiability — two degenerate substitutions with disjoint kill-sets:
 
 * **Sub A** — remove ``"aspic_results"`` from ``state_adapter._STATE_KEYS``:
-  ``annexe - prose`` loses that key, so ``test_annexe_prose_relation_is_pinned``
-  fails (``ANNEXE_ONLY`` still contains it). ``test_ast_prose_matches_baseline``
-  survives (it does not read ``_STATE_KEYS``). Kill-set = {relation}.
+  the key sits in the intersection since #1667, so ``prose - annexe`` GAINS it
+  and ``test_annexe_prose_relation_is_pinned`` fails (``PROSE_ONLY`` does not
+  list it). ``test_ast_prose_matches_baseline`` survives (it does not read
+  ``_STATE_KEYS``). Kill-set = {relation}.
 * **Sub B** — delete the ``getattr(state, "deanonymized", ...)`` call in
   ``act1_framing_plugin.build_act1_evidence``: the AST extraction loses
   ``deanonymized``, so ``test_ast_prose_matches_baseline`` fails
@@ -92,9 +93,21 @@ def _prose_keys_read_from_state() -> set[str]:
 # Note: ``structured_arg_status`` IS read by the prose (act3 conclusion,
 # ``build_act3_evidence`` → the honest-absence ledger at l.685), so it is NOT
 # annexe-only despite living in ``_STATE_KEYS`` — it sits in the intersection.
+#
+# ``aspic_results`` and ``bipolar_results`` joined in #1667, and the move is the
+# measurable outcome of that issue rather than bookkeeping. Until then the ONLY
+# path from a structured-argumentation axis to the conclusion was
+# ``structured_arg_status``, whose collector opens on ``degraded=True``: the
+# prose had a vocabulary for the axis that FAILED and none for the axis that
+# SUCCEEDED. ``aspic_results`` therefore leaves ANNEXE_ONLY for the
+# intersection — the appendix attested "disponible" for an axis the conclusion
+# had no way to mobilise, which is precisely the divergence this module exists
+# to keep visible.
 PROSE_BASELINE = frozenset(
     {
         "argument_quality_scores",
+        "aspic_results",
+        "bipolar_results",
         "counter_arguments",
         "deanonymized",
         "debate_transcripts",
@@ -130,7 +143,6 @@ PROSE_BASELINE = frozenset(
 # still does not read it — annexe-only by construction, not by attrition.
 ANNEXE_ONLY = frozenset(
     {
-        "aspic_results",
         "final_conclusion",
         "formal_synthesis_reports",
         "narrative_synthesis",
@@ -140,8 +152,16 @@ ANNEXE_ONLY = frozenset(
 
 # Axes the PROSE reads that the ANNEXE never attests — mobilised by the
 # conclusion but invisible to the appendix provenance table.
+#
+# ``bipolar_results`` joined in #1667 from the prose side only: the presence
+# channel projects its support relation into the Acte III prompt, but the key is
+# absent from ``_STATE_KEYS``, so the appendix cannot attest the axis at all —
+# not even as "indisponible". That asymmetry is a finding for #1624 (the annexe
+# side), deliberately NOT patched here: adding the key to ``_STATE_KEYS`` is a
+# change to the other surface and belongs to the issue that owns it.
 PROSE_ONLY = frozenset(
     {
+        "bipolar_results",
         "deanonymized",
         "debate_transcripts",
         "governance_decisions",


### PR DESCRIPTION
Ferme #1667. Précondition mesurée de #1645 et #1649 (Epic #1644).

## Ce que ça corrige

Un axe d'argumentation structurée n'atteignait l'Acte III que par **un seul chemin** : `_collect_absent_dimensions`, dont le collecteur ouvre sur `if not info.get("degraded"): continue`.

> **La prose avait un vocabulaire pour l'axe qui échoue, et aucun pour l'axe qui réussit.**

Conséquence sur l'Epic : réanimer un module lui **retirait** sa seule trace dans la conclusion. Toute mesure de différenciation du type « la conclusion parle-t-elle de cet axe ? » lisait donc **à l'envers**, et l'étape de nudge du PM était sans objet — on aurait calé des prompts sur un canal fermé.

## Ce que la PR ajoute

Une voie symétrique, **un canal et non un lecteur par axe** (leçon des huit demi-fixes de #1633) :

| pièce | rôle |
|---|---|
| `StructuredArgFinding` | ce qu'un axe **établit** (capability, label lisible, énoncé) |
| `_collect_structured_arg_findings` | le canal ; délègue à un projecteur par axe |
| `Act3Evidence.structured_findings` | le champ symétrique de `absent_dimensions` |
| `[CE QUE LES CADRES STRUCTURÉS ÉTABLISSENT]` + consigne | l'arrivée dans le prompt de l'Acte III |

Le registre d'absence est **inchangé**. Un axe qui a réellement dégradé doit continuer d'être nommé : on **ajoute** la voie de présence, on ne substitue pas (anti-pendule explicite de l'issue, épinglé par `test_presence_and_absence_are_additive_not_substitutive`).

## Anti-pendule principal : jamais un décompte

Le mode d'échec le plus probable de cette issue était de livrer « 3 résultats ASPIC », ce qui reproduirait `axe_aspic = "disponible"` un cran plus loin — **le témoin déplacé, aucun décideur créé**. Chaque projecteur rend donc ce que son formalisme dit **et qu'aucun autre axe ne dit** :

- **bipolaire** → la relation de soutien. Mesurée sur 8 artefacts d'état réels : **4 à 9 paires** chacun, variant avec l'inventaire d'arguments. Charge utile réelle, projetable aujourd'hui.
- **ASPIC+** → les enchaînements de raisonnement qui **s'excluent mutuellement** — ce que certaines extensions gardent et que d'autres lâchent.

## Le prédicat ASPIC exige un arbitrage, pas seulement une extension non vide

Mesure JVM firsthand ajoutée après l'ouverture de la PR, et elle a changé le garde :

| variante | prémisses | arguments | **attaques** | extensions |
|---|---|---|---|---|
| production aujourd'hui | non | 0 | 0 | 1 × ∅ |
| prémisses fournies via l'API | oui | 11 | **0** | 1 × 11 (tout) |
| prémisses + tête de règle `"!x"` via l'API | oui | 6 | **0** | 1 × 6 (tout) |
| prémisses + `Negation` réelle, **hors** API handler | oui | 12 | **2** | 2 × 11 |

Le handler ne construit jamais que `Proposition(head)`, jamais une `Negation` : une tête `"!x"` produit une proposition *nommée* `!x`, qui ne contredit rien. **Aucune entrée acceptée par l'API actuelle ne peut produire une seule attaque** — c'est structurel, pas lié au corpus. Le contrôle positif (dernière ligne) montre que le raisonneur, lui, fonctionne.

Conséquence directe sur cette PR : réparer les prémisses **seules** aurait ouvert ce canal sur « ces 11 enchaînements sont conjointement acceptables » — autorité formelle, contenu discriminant nul. C'est le motif #1631 un cran plus loin, et le garde initial (une extension non vide suffit) ne l'aurait pas arrêté.

Le prédicat exige donc **deux extensions distinctes non vides**, et la trouvaille est l'ensemble **contesté** (union − intersection). Une extension qui n'exclut rien n'a rien arbitré : le canal reste fermé. Détail et conséquence sur l'ordre du chantier : #1649 (commentaire du R766).

## Le résultat ASPIC est mesuré, pas supposé

ASPIC **n'émet rien aujourd'hui**, et c'est un fait mesuré :

```
8/8 artefacts réels : extensions: [[]]  ·  axioms_count: 0
```

Cause : `_invoke_aspic` lit `context["axioms"]` (invoke_callables.py:3808) — **une clé qu'aucun producteur de l'orchestration n'écrit**. Contrôle positif exécuté dans le même grep sur `context["defeasible_rules"]`, qui a bien un writer ; l'asymétrie 1-occurrence / 2-occurrences est le témoin. Sans prémisse ordinaire, ASPIC+ ne construit **aucun argument** : la théorie de Dung dérivée est vide, et l'unique extension préférée est ∅.

Donc l'axe est attesté `"disponible"` dans l'annexe alors qu'il a évalué une **théorie sans arguments**. Émettre quoi que ce soit ici habillerait ce vide en résultat (#1019). Le garde est la **sentinelle de régression** pour le jour où ce producteur sera réparé — c'est l'item producteur de #1649, dont l'énoncé se trouve reformulé : le manque n'est pas « la portée d'attaque », il est **en amont**, il n'y a pas d'argument du tout.

Invariance parfaite entre corpus de tailles très différentes = le tell déjà consigné : une mesure qui rend rigoureusement la même chose sur tout son échantillon ne mesure pas l'échantillon.

## Les deux surfaces de lecture bougent — et c'est le livrable

`test_two_reading_surfaces_1624` a **échoué comme prévu** en cours de route (`Extra items in the left set: bipolar_results, aspic_results`) : le garde a fait exactement son travail. La mise à jour des baselines n'est pas de la comptabilité, c'est le résultat mesurable de la PR :

- **`aspic_results` quitte `ANNEXE_ONLY` pour l'intersection** — l'annexe attestait « disponible » pour un axe que la conclusion n'avait aucun moyen de mobiliser. C'est précisément la divergence que #1624 existe pour rendre visible.
- **`bipolar_results` entre dans `PROSE_ONLY`** — la clé est **absente de `_STATE_KEYS`**, donc l'annexe ne peut attester cet axe **ni comme disponible ni comme indisponible**. Asymétrie délibérément **non corrigée ici** : toucher `_STATE_KEYS` est un changement de l'autre surface et appartient à l'issue qui la porte (#1624). Consigné dans le commentaire de `PROSE_ONLY`.

La falsifiabilité **Sub A** du docstring de ce module a été réécrite en conséquence : la substitution tue toujours le seul test de relation, mais par l'autre différence de sets.

## Substitution chirurgicale — deux couches, kill-set / spare-set

| substitution | kill | spare |
|---|---|---|
| collecteur forcé à `return []` | **10** | 338 |
| section de prompt retirée | **3** | 345 |

Les deux couches sont épinglées **indépendamment** : les 4 tests de non-vacuité survivent à S1 **par construction** (ils affirment que rien n'est produit — c'est le contrôle qui prouve qu'ils ne portent pas le contrat), et les tests de collecteur survivent à S2. Aucune assertion n'est portée par l'autre couche.

## Non-vacuité

- état de base sans conteneur → `structured_findings == []`
- conteneurs vides → le prompt dit explicitement qu'aucun cadre n'a rien établi, et **ne contient aucun énoncé de soutien**
- `supports` malformés (arité 1, arité 3, nœuds vides, scalaires) → rien. Un canal **ouvert sur du vide** est pire qu'un canal fermé : l'axe compterait comme « évalué » tout en ne disant rien.

Le test du prompt vide ne s'appuie pas sur le mot « appuie » seul — il figure déjà dans la règle de tissage statique, l'assertion serait passée vacuously. Il porte sur le marqueur `» appuie «`.

## DoD #1667

- [x] Un lecteur de présence unique porte les axes de l'état jusqu'à `Act3Evidence` puis jusqu'au prompt
- [x] Projection **distinctive par axe**, jamais un décompte
- [x] Contrat épinglé par un test qui échoue si un axe présent et non-trivial n'atteint pas le prompt (`test_a_present_non_trivial_axis_reaches_the_prompt`, paramétré sur les 2 axes)
- [x] Substitution chirurgicale mesurée, kill-set et spare-set en nombres
- [x] Non-vacuité épinglée par ses propres tests
- [x] Aucun axe doublé : `deep_synthesis_agent.ARTIFACT_FIELDS` est une **autre** voie, non touchée ici

## Ce que je n'affirme pas

- **Pas** que le canal produise une prose différente sur corpus réel. Il n'y a aujourd'hui qu'un axe porteur (bipolaire) et la vérification demande un run vivant avec LLM. Ce que la PR établit est le **trajet**, épinglé déterministe.
- **Pas** que la projection bipolaire soit la bonne formulation finale. C'est la relation que le formalisme calcule ; sa mise en français relève du calage de #1645.
- **Pas** que `extensions: [[]]` soit propre à un corpus. C'est 8/8 sur les artefacts dont je dispose, tous produits par la même voie ; deux points ne font pas une corrélation et huit points d'une même voie non plus. La cause proposée (`axioms` sans producteur) est vérifiée dans le **code**, pas inférée de la mesure.

## Privacy

3 fichiers, 0 secret, 0 clé de dataset en clair, 0 chemin protégé. Les textes de test sont **inventés** (« La croissance a repris »…), aucun extrait de corpus. Les mesures d'artefacts sont citées en **forme** (nombre de paires, `[[]]`), jamais en contenu.

🤖 Coordinator ai-01 — R766


