### PR TITLE
fix(bipolar): distinguish JVM-absent (honest-absent) from handler-failure (fail loud) (#1645)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3589,15 +3589,64 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str,
             handler.analyze_bipolar_framework, args, attacks, supports, fw_type
         )
     except Exception as e:
+        # #1645: three states, never two (coordinator review). Pre-fix this block
+        # had TWO defects of the #1634 family:
+        #   (1) diagnostic FABRICATED — every failure (ImportError, TypeError, a
+        #       real Tweety reasoning error, OR the JVM simply being absent) was
+        #       relabeled "JVM/Tweety required, install JVM". The cause was
+        #       rewritten toward the most reassuring reading ("environment"), so
+        #       three genuinely different situations (no JVM / handler broken /
+        #       analysis failed) were indistinguishable downstream.
+        #   (2) the message CONTRADICTED the flow — it announced "Reporting
+        #       unverified status" (i.e. "I continue and signal") and the very
+        #       next line raised. The message documented an intent it abandoned.
+        # Fix: distinguish JVM-absent (honest-absent, the phase continues
+        # degraded — mirrors _invoke_sat's solver-absence boundary at l.4045)
+        # from handler/analysis failure WITH the JVM up (fail loud with the REAL
+        # cause, preserved via `from e`, never relabeled as an environment gap).
+        # Anti-pendule: do NOT swap the raise for a silent `return {}` — that
+        # would trade this defect for its mirror (#1019).
+        import jpype
+
+        if not jpype.isJVMStarted():
+            logger.warning(
+                "Bipolar analysis unavailable: JVM not started (honest-absent, "
+                "the phase continues degraded). Underlying signal: %s",
+                e,
+            )
+            return {
+                "framework_type": fw_type,
+                "arguments": list(args),
+                "supports": [],
+                "attacks": list(attacks),
+                # tri-state None = not computed (JVM absent), never a fabricated
+                # empty extension set that would read as "consistent sur vide".
+                "extensions": None,
+                "statistics": {
+                    "handler": "BipolarHandler",
+                    "backend": "jvm-unavailable",
+                },
+                "degraded": True,
+                "absent_reason": "jvm_not_started",
+                "message": (
+                    "bipolar analysis unavailable: JVM not started (honest-absent)"
+                ),
+                "error": f"{type(e).__name__}: {e}",
+            }
+        # JVM is up — the failure is in OUR handler or analysis, not the
+        # environment. Fail loud with the real cause; do not relabel it
+        # "JVM/Tweety required" (that fabrication was the #1634 defect).
         logger.warning(
-            "Bipolar analysis unavailable: no JVM/Tweety handler could be loaded. "
-            "Reporting unverified status. (%s)",
+            "Bipolar analysis FAILED with JVM running (real cause, not an "
+            "environment gap): %s",
             e,
         )
         raise RuntimeError(
-            f"Bipolar analysis ({fw_type}) unavailable: JVM/Tweety required. "
-            "Install JVM and ensure Tweety JARs are on the classpath."
-        )
+            f"Bipolar analysis ({fw_type}) failed with JVM running: "
+            f"{type(e).__name__}: {e}. "
+            "This is a handler/analysis failure, not a missing-JVM gap — "
+            "see the original exception above."
+        ) from e
 
 
 async def _invoke_aba(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3579,6 +3579,15 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str,
                 context, "bipolar_argumentation", "translator_failed", type(e).__name__
             )
 
+    # #1645: resolve the JVM state ONCE, before the try. Resolving it inside the
+    # except (the earlier ``import jpype; jpype.isJVMStarted()``) would let an
+    # ImportError from a jpype-less environment mask the original cause — in the
+    # exact environment the honest-absent path targets. Reuses the helper already
+    # used at l.4490 instead of touching jpype directly. (coordinator point 3)
+    from argumentation_analysis.core.jvm_setup import is_jvm_started
+
+    jvm_up = is_jvm_started()
+
     try:
         from argumentation_analysis.agents.core.logic.bipolar_handler import (
             BipolarHandler,
@@ -3606,9 +3615,7 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str,
         # cause, preserved via `from e`, never relabeled as an environment gap).
         # Anti-pendule: do NOT swap the raise for a silent `return {}` — that
         # would trade this defect for its mirror (#1019).
-        import jpype
-
-        if not jpype.isJVMStarted():
+        if not jvm_up:
             logger.warning(
                 "Bipolar analysis unavailable: JVM not started (honest-absent, "
                 "the phase continues degraded). Underlying signal: %s",
@@ -3617,7 +3624,14 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str,
             return {
                 "framework_type": fw_type,
                 "arguments": list(args),
-                "supports": [],
+                # Echo the supports the translator established BEFORE this try
+                # (translation needs no JVM). supports is the ONLY non-empty
+                # payload of the two mode-3 axes on the 8 real artefacts; zeroing
+                # it would erase the relation the translator produced — which is
+                # exactly what _write_bipolar_to_state (l.823) and the #1667
+                # presence channel read from this dict. Mirrors the handler's own
+                # echo at bipolar_handler.py:105. extensions: None = not computed.
+                "supports": [[s, t] for s, t in supports],
                 "attacks": list(attacks),
                 # tri-state None = not computed (JVM absent), never a fabricated
                 # empty extension set that would read as "consistent sur vide".

--- a/tests/unit/argumentation_analysis/orchestration/test_bipolar_honest_degraded_1645.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_bipolar_honest_degraded_1645.py
@@ -31,7 +31,7 @@ other.
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -157,3 +157,80 @@ class TestJvmUpHandlerFailureFailsLoudRealCause:
         assert "Tweety rejected the support relation" in str(exc_info.value)
         # Crucially, it must NOT tell the user to install a JVM — the JVM is up.
         assert _INSTALL_HINT not in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Relation — translator's supports must survive the degraded branch to the writer
+# ---------------------------------------------------------------------------
+
+
+class TestTranslatorWorkSurvivesDegradedState:
+    """When the translator produced supports but the JVM is absent, the degraded
+    dict MUST echo those supports so ``_write_bipolar_to_state`` persists them.
+
+    Pre-fix the degraded branch returned ``"supports": []`` — the relation the
+    translator had just established (translation needs NO JVM) was erased at the
+    exact moment of writing. ``supports`` is the ONLY non-empty payload of the
+    two mode-3 axes on the 8 real artefacts, and it is exactly what
+    ``_write_bipolar_to_state`` (state_writers.py l.823) and the #1667 presence
+    channel read FROM the result dict. This test pins the relation
+    translator → handler-skip → writer so the echo cannot silently re-regress.
+    """
+
+    def test_writer_persists_translator_supports_not_empty(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_bipolar,
+        )
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_bipolar_to_state,
+        )
+
+        # The translator runs BEFORE the try (no JVM needed) and produces 2
+        # genuine support pairs.
+        translator_outcome = MagicMock()
+        translator_outcome.relations = [
+            ("corpus_A", "prop_1"),
+            ("corpus_B", "prop_2"),
+        ]
+        translator_outcome.cause = "ok"
+        translator_outcome.error = ""
+
+        # ctx WITHOUT supports ⇒ _invoke_bipolar calls the translator itself.
+        ctx = {"arguments": ["corpus_A", "corpus_B"]}
+
+        with patch(
+            "argumentation_analysis.orchestration.structured_arg_translator.translate_to_bipolar_supports",
+            new=AsyncMock(return_value=translator_outcome),
+        ), patch(
+            "argumentation_analysis.core.jvm_setup.is_jvm_started",
+            return_value=False,
+        ), patch(
+            _BRIDGE_BIPOLAR,
+            side_effect=RuntimeError("JVM absent: BipolarHandler ctor failed"),
+        ):
+            output = _run(_invoke_bipolar("opaque text", ctx))
+
+        # Degraded dict, supports echoed as 2 pairs — NOT zeroed to [].
+        assert output["degraded"] is True
+        assert output["extensions"] is None  # tri-state, Dung reasoning skipped
+        assert output["supports"] == [
+            ["corpus_A", "prop_1"],
+            ["corpus_B", "prop_2"],
+        ]
+
+        # The writer reads supports FROM the dict → it must persist the 2 pairs.
+        state = MagicMock()
+        with patch(
+            "argumentation_analysis.orchestration.state_writers._record_structured_arg_status"
+        ):
+            _write_bipolar_to_state(output, state, ctx)
+
+        state.add_bipolar_result.assert_called_once()
+        call_args = state.add_bipolar_result.call_args.args
+        # signature: add_bipolar_result(fw_type, arguments, supports)
+        persisted_supports = call_args[2]
+        assert persisted_supports == [
+            ["corpus_A", "prop_1"],
+            ["corpus_B", "prop_2"],
+        ], "writer must persist the translator's supports, not []"
+

--- a/tests/unit/argumentation_analysis/orchestration/test_bipolar_honest_degraded_1645.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_bipolar_honest_degraded_1645.py
@@ -1,0 +1,159 @@
+"""#1645 — bipolar invoke distinguishes JVM-absent (honest-absent) from
+handler-failure (fail loud with the real cause). Three states, never two.
+
+Pre-fix ``_invoke_bipolar`` (invoke_callables.py l.3591) had TWO defects of the
+#1634 family, both flagged in the coordinator's review of the #1645 checkpoint:
+
+  1. **Diagnostic fabricated.** The ``except Exception`` caught *everything* —
+     ``ImportError``, ``TypeError``, a real Tweety reasoning error, or the JVM
+     simply being absent — and relabeled all of it
+     ``"JVM/Tweety required, install JVM"``. Three genuinely different
+     situations (no JVM / handler broken / analysis failed) were made
+     indistinguishable downstream, always toward the most reassuring reading
+     ("it's the environment"). The cause was *rewritten*, not reported.
+  2. **The message contradicted the flow.** It announced
+     ``"Reporting unverified status"`` (i.e. "I continue and signal") and the
+     very next line ``raise``d — the message documented an intent it abandoned.
+
+The fix introduces THREE states:
+  - JVM absent (``jpype.isJVMStarted() is False``) ⇒ honest-absent: return a
+    degraded dict (``extensions: None``, tri-state), the phase continues. Mirrors
+    ``_invoke_sat``'s solver-absence boundary (l.4045).
+  - JVM up + the handler/analysis raises ⇒ fail loud with the REAL cause
+    (preserved via ``raise ... from e``), never relabeled "JVM required".
+
+Anti-pendule (coordinator DoD): do NOT swap the raise for a silent ``return {}``
+— that would trade this defect for its mirror (#1019: a crash turned into a mute
+session). Three states, never two; honest-absent on one side, fail-loud on the
+other.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_BRIDGE_BIPOLAR = (
+    "argumentation_analysis.agents.core.logic.bipolar_handler.BipolarHandler"
+)
+
+_FABRICATED = "JVM/Tweety required"  # the old relabeled diagnostic — must be GONE
+_INSTALL_HINT = "Install JVM"  # likewise
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _ctx() -> dict:
+    """Minimal context reaching the BipolarHandler construction."""
+    return {"arguments": ["arg_A", "arg_B"], "supports": [], "attacks": []}
+
+
+# ---------------------------------------------------------------------------
+# State 1 — JVM absent ⇒ honest-absent degraded dict (phase continues)
+# ---------------------------------------------------------------------------
+
+
+class TestJvmAbsentIsHonestAbsent:
+    """When the JVM is not started, bipolar returns a degraded dict instead of
+    raising — the phase continues, the axis is recorded absent, no verdict is
+    fabricated (#1019)."""
+
+    def test_returns_dict_not_raises(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_bipolar,
+        )
+
+        # BipolarHandler() construct + JClass would raise with no JVM; patch the
+        # handler to raise so the except path is exercised, AND force
+        # isJVMStarted False so the fix routes to honest-absent.
+        with patch(_BRIDGE_BIPOLAR, side_effect=RuntimeError("no JVM")), patch(
+            "jpype.isJVMStarted", return_value=False
+        ):
+            result = _run(_invoke_bipolar("text", _ctx()))
+
+        assert isinstance(result, dict)
+        assert result.get("degraded") is True
+        assert result.get("absent_reason") == "jvm_not_started"
+        # tri-state None = not computed, never a fabricated empty extension set
+        # (which would read as "consistent sur vide", #1019).
+        assert result.get("extensions") is None
+
+    def test_absent_dict_carries_no_fabricated_diagnostic(self):
+        """The honest-absent path must not relabel the cause as 'JVM required' —
+        it records the real underlying signal in ``error``."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_bipolar,
+        )
+
+        with patch(_BRIDGE_BIPOLAR, side_effect=RuntimeError("no JVM")), patch(
+            "jpype.isJVMStarted", return_value=False
+        ):
+            result = _run(_invoke_bipolar("text", _ctx()))
+
+        # The fabricated relabeling of the old code is gone from this path.
+        assert _FABRICATED not in result.get("message", "")
+        assert _INSTALL_HINT not in result.get("message", "")
+        # The REAL signal is preserved (not rewritten to "environment gap").
+        assert "no JVM" in result.get("error", "")
+
+
+# ---------------------------------------------------------------------------
+# State 2 — JVM up + handler/analysis failure ⇒ fail loud with the REAL cause
+# ---------------------------------------------------------------------------
+
+
+class TestJvmUpHandlerFailureFailsLoudRealCause:
+    """When the JVM is up but the handler/analysis raises, the failure is ours,
+    not the environment's. Fail loud with the real cause; do NOT relabel it
+    'JVM/Tweety required' (that fabrication was the #1634 defect)."""
+
+    def test_raises_with_real_cause_not_relabeled(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_bipolar,
+        )
+
+        # A TypeError inside the analysis with the JVM up — a genuine code bug,
+        # nothing to do with a missing JVM.
+        real_cause = TypeError("bad argument shape in analyze")
+        mock_handler = MagicMock()
+        mock_handler.analyze_bipolar_framework.side_effect = real_cause
+        with patch(_BRIDGE_BIPOLAR, return_value=mock_handler), patch(
+            "jpype.isJVMStarted", return_value=True
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                _run(_invoke_bipolar("text", _ctx()))
+
+        msg = str(exc_info.value)
+        # The REAL cause is named (type + message), preserved via `from e`.
+        assert "TypeError" in msg
+        assert "bad argument shape in analyze" in msg
+        # The fabricated environment-relabeled diagnostic is GONE.
+        assert _FABRICATED not in msg
+        assert _INSTALL_HINT not in msg
+        # The chained original exception is preserved (not swallowed).
+        assert exc_info.value.__cause__ is real_cause
+
+    def test_real_cause_not_reassuring_env_label(self):
+        """A Tweety reasoning error (JVM up) must surface as a reasoning error,
+        not as 'install a JVM'."""
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _invoke_bipolar,
+        )
+
+        mock_handler = MagicMock()
+        mock_handler.analyze_bipolar_framework.side_effect = ValueError(
+            "Tweety rejected the support relation"
+        )
+        with patch(_BRIDGE_BIPOLAR, return_value=mock_handler), patch(
+            "jpype.isJVMStarted", return_value=True
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                _run(_invoke_bipolar("text", _ctx()))
+
+        assert "Tweety rejected the support relation" in str(exc_info.value)
+        # Crucially, it must NOT tell the user to install a JVM — the JVM is up.
+        assert _INSTALL_HINT not in str(exc_info.value)

--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -697,34 +697,87 @@ class TestDeLPValueGate:
 
 
 class TestBipolarValueGate:
-    """Assert Bipolar fallback does not return fabricated args[:2] extensions.
+    """Assert Bipolar fallback discriminates TWO failure states, never conflates them.
 
-    The fallback used to return ``[args[:2]]`` as a fake extension — it could
-    not compute real bipolar argumentation semantics. After #964, it reports
-    honest unavailability (extensions=None, solver='unavailable').
+    Contract evolution (the anti-pendule trail — do not collapse it back to one
+    branch):
+      - #964: the fallback returned an honest-unavailable *dict*
+        (extensions=None, solver='unavailable').
+      - #1252/#1019: hardened to RAISE RuntimeError, so a solver failure could
+        never enter state — fabricated OR silently-degraded alike.
+      - #1645: the single ``except`` relabeled EVERY failure as
+        "JVM/Tweety required" (the #1634 fabrication), so "no JVM", "handler
+        broken", and "analysis failed" were indistinguishable downstream. The
+        fix restores the discrimination: JVM-absent ⇒ honest-absent dict (phase
+        continues, supports echoed), handler/analysis failure WITH the JVM up ⇒
+        fail loud with the REAL cause. Three states, never two.
+
+    #1645 is NOT a return to the #964 dict — it is the discrimination of the two
+    failure states the #1252 raise had merged. Do not "correct" it back toward
+    either single extreme.
     """
 
-    async def test_bipolar_fallback_raises_fail_loud(self):
-        """Bipolar AF must RAISE (fail-loud) when JVM unavailable — anti-theatre (#1252/#1019).
+    async def test_jvm_absent_returns_honest_absent_dict(self):
+        """State 1 — JVM not started ⇒ honest-absent dict (the phase continues).
 
-        Contract evolution: the earlier #964 guard asserted an honest-unavailable
-        *dict* (extensions=None, solver='unavailable'). Post-#1252/#1019 the
-        except block was hardened to RAISE RuntimeError, so a solver failure can
-        never enter state — fabricated OR silently-degraded extensions alike.
-        STRICTER than the old None-dict. Triage #1336.
+        The handler is patched to raise (it would, with no JVM) and is_jvm_started
+        is forced False. The phase MUST continue: a degraded dict with
+        extensions=None (tri-state, never a fabricated verdict), NOT a raise. The
+        supports the caller supplied are echoed — the relation was established
+        before the handler ran; only the Dung reasoning on top did not compute.
         """
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_bipolar,
         )
 
+        ctx = {"arguments": ["a", "b", "c"], "supports": [("a", "b"), ("b", "c")]}
         with patch(
-            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1591")
+            "argumentation_analysis.core.jvm_setup.is_jvm_started",
+            return_value=False,
         ), patch(
             "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
-            side_effect=RuntimeError("No JVM for test"),
+            side_effect=RuntimeError("handler exploded"),
         ):
-            with pytest.raises(RuntimeError, match="Bipolar analysis .* unavailable"):
+            result = await _invoke_bipolar("test", ctx)
+
+        assert isinstance(result, dict)
+        assert result.get("degraded") is True
+        assert result.get("absent_reason") == "jvm_not_started"
+        assert result.get("extensions") is None  # tri-state, not a verdict
+        # The caller's supports survive the degraded branch (not zeroed to []).
+        assert result.get("supports") == [["a", "b"], ["b", "c"]]
+
+    async def test_jvm_present_handler_failure_raises_real_cause(self):
+        """State 2 — JVM up + handler raises ⇒ fail loud with the REAL cause.
+
+        The JVM runs (is_jvm_started True), the handler raises. The failure is
+        ours, not the environment's: it MUST surface as a RuntimeError naming the
+        real cause and MUST NOT be relabeled "JVM/Tweety required" (that
+        fabrication was the #1634 defect the whole family shares). The regex is
+        NOT relaxed — the test asserts something specific (the real cause named,
+        the fabrication absent) and so keeps its power to discriminate.
+        """
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_bipolar,
+        )
+
+        real_cause = RuntimeError("handler exploded")
+        with patch(
+            "argumentation_analysis.core.jvm_setup.is_jvm_started",
+            return_value=True,
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=real_cause,
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
                 await _invoke_bipolar("test", {"arguments": ["a", "b", "c"]})
+
+        msg = str(exc_info.value)
+        assert "handler exploded" in msg
+        assert "RuntimeError" in msg
+        assert "JVM/Tweety required" not in msg
+        assert "Install JVM" not in msg
+        assert exc_info.value.__cause__ is real_cause
 
 
 # ============================================================


### PR DESCRIPTION
## #1645 — bipolar invoke: 3 states (JVM-absent honest-absent / handler-failure fail loud), commit separate from prompt calibration

Coordinator review of the #1645 checkpoint flagged `_invoke_bipolar` (`invoke_callables.py`) as carrying **two defects of the #1634 family**:

1. **Diagnostic FABRICATED.** The `except Exception` caught *everything* — `ImportError`, `TypeError`, a real Tweety reasoning error, or the JVM simply being absent — and relabeled all of it `"JVM/Tweety required, install JVM"`. Three genuinely different situations (no JVM / handler broken / analysis failed) were made indistinguishable downstream, always toward the most reassuring reading ("it's the environment"). The cause was *rewritten*, not reported.
2. **The message CONTRADICTED the flow.** It announced `"Reporting unverified status"` (i.e. "I continue and signal") and the very next line `raise`d — the message documented an intent it abandoned.

### The fix — three states, never two

- **JVM absent** (`is_jvm_started() is False`, resolved ONCE before the try) ⇒ **honest-absent**: return a degraded dict, the phase continues. Mirrors `_invoke_sat`'s solver-absence boundary (l.4045): *"honest-degraded, not a raw crash"*.
- **JVM up + handler/analysis raises** ⇒ **fail loud with the REAL cause** (preserved via `raise ... from e`), never relabeled `"JVM required"`.

**Anti-pendule (coordinator DoD)**: do NOT swap the raise for a silent `return {}` — that would trade this defect for its mirror (#1019: a crash turned into a mute session). Three states, never two; honest-absent on one side, fail-loud on the other.

### Coordinator review (R766) — 5 points addressed in this revision

The first review flagged 5 points (2 blocking, 3 not). All addressed:

1. **BLOQUANT — supports echoed, not zeroed.** The degraded dict used to return `"supports": []`, erasing the relation the translator had just established (translation runs BEFORE the try and needs NO JVM). `supports` is the ONLY non-empty payload of the two mode-3 axes on the 8 real artefacts, and it is exactly what `_write_bipolar_to_state` (l.823) and the #1667 presence channel read from this dict. Now `"supports": [[s, t] for s, t in supports]` — mirrors the handler's own echo at `bipolar_handler.py:105`. The relation is established; `extensions: None` carries "the Dung reasoning on top did not compute".
2. **BLOQUANT CI — `test_value_gates` remade in TWO explicit states** (not one). The old test patched `asyncio.to_thread` without controlling JVM state, so on CI (JVM up) my fix correctly raised the real cause and the `match="Bipolar analysis .* unavailable"` regex failed — because the defect it pinned was corrected. **The regex is NOT relaxed** (that would kill the discrimination). Instead: state 1 (JVM absent ⇒ honest-absent dict), state 2 (JVM up + handler raises ⇒ `pytest.raises` naming the real cause, `__cause__` preserved, NO `"JVM/Tweety required"`). Mock renamed `RuntimeError("handler exploded")` — the old `"No JVM for test"` named a state the test never established. Docstring records the anti-pendule trail (#964 dict → #1252/#1019 raise → #1645 discrimination), explicitly: NOT a return to the dict.
3. **`is_jvm_started()` resolved OUTSIDE the except.** Pre-fix did `import jpype; jpype.isJVMStarted()` inside the `except` — an ImportError from a jpype-less environment would mask the original cause, in the exact environment the honest-absent path targets. Now reuses the helper already used at l.4490, resolved before the try.
4. **Registry note** — see dedicated section below.
5. **Relation test** — see Falsifiability.

### Registry note — the `"evaluated"` label is deaf to `degraded` (#1671 / #1674)

The `degraded: True` flag in the honest-absent dict does **not** reach the structured-arg registry: `_record_structured_arg_status` decides the label from the **presence of an input** (`context["supports"]`), not from whether an evaluation actually ran. Because the translator populates `context["supports"]` before the handler fails, the axis would be tagged `"evaluated", degraded=False` on a JVM-less machine — a fake-green **revealed** by this migration (pre-fix the exception propagated and the writer never ran).

This is NOT caused by this PR's reasoning and is broader than the bipolar axis (it touches all 5). The coordinator has instructed the cause upstream:
- **#1671** opened the latent defect.
- **#1674** measures it as **alive on 6/8 real artefacts** (not latent): the handler does not *fail*, it *succeeds on an empty theory* → `extensions: [[]]` → `ext_count = 1` → `"evaluated"`. #1674 decides the label from the handler output and leaves `ext_count` untouched.

Linking #1671 here so whoever takes #1648 (the ~10 sibling handlers that emit `"JVM/Tweety required"`) lands on it before converting ten at once.

### Falsifiability — 5 dedicated tests + 2 gate states, disjoint kill-sets

`tests/unit/argumentation_analysis/orchestration/test_bipolar_honest_degraded_1645.py` — three classes:

| Class | State | Asserts |
|---|---|---|
| `TestJvmAbsentIsHonestAbsent` (2) | JVM absent + handler raise | degraded dict (`extensions: None`), NOT raises, NO fabricated `"JVM/Tweety required"`/`"Install JVM"`, real cause in `error` |
| `TestJvmUpHandlerFailureFailsLoudRealCause` (2) | JVM up + handler raises TypeError/ValueError | RuntimeError with REAL cause (type+msg), `__cause__` preserved, NO `"Install JVM"` hint |
| `TestTranslatorWorkSurvivesDegradedState` (1) | translator 2 pairs + JVM absent | writer persists the 2 pairs (not `[]`) — pins the translator→writer relation |

`tests/unit/argumentation_analysis/test_value_gates.py::TestBipolarValueGate` — the gate remade in 2 explicit states (see point 2).

**Degenerate subs, verified empirically** (pytest exit 1 under sub, green after restore):
- revert the fail-loud branch to the old relabeled raise → kills the 2 JVM-up tests, spares the honest-absent ones;
- revert `"supports"` to `[]` → kills the relation test AND the gate state-1, spares the others.

Disjoint kill-sets confirm each test asserts something the others do not.

### Validation

- `pytest test_bipolar_honest_degraded_1645.py` → **5 passed** (4 original + 1 relation);
- `pytest TestBipolarValueGate` → **2 passed** (the two states);
- `pytest test_fp6_fol_faillloud.py` → **4 passed** (#1630 regression: the `invoke_callables.py` edit does not touch the FOL isolation path);
- integration `TestInvokeBipolarFallback` → **3 passed** (JVM-up happy path unchanged);
- `mypy --strict invoke_callables.py` (8-file CI gate) → **0 issues**;
- `black` clean on the modified files (pre-existing unrelated drift in `test_value_gates.py` left untouched — not introduced here, not in scope).

### Scope — bipolar ONLY, separate commit

Per coordinator DoD: *"Commit séparé du calage de prompts."* This PR is the honest-degraded fix only. The prompt calibration (D/E/F) is unblocked now that **#1667 is merged** (`5a56d96a`, done by the coordinator), and follows separately.

The same relabel-then-raise motif exists on ~10 sibling handlers (`_invoke_aba`/`_invoke_adf`/`_invoke_aspic`/`_invoke_ranking`/... — all emit `"JVM/Tweety required"`); it is **NOT** addressed here — coordinator's **#1648** inventories the flattening motif family-wide. This PR fixes the outlier called out in the #1645 review.

Privacy: synthetic IDs only (`corpus_A`, `prop_1`), no corpus content.

🤖 Worker myia-po-2023 — #1645 (honest-degraded fix, separate commit)
