### PR TITLE
doc(1648): inventory of 11 flattening sites + regression tests pinning the writer contract

### DIFF
--- a/docs/reports/1648-flattening-inventory.md
+++ b/docs/reports/1648-flattening-inventory.md
@@ -1,0 +1,528 @@
+# Issue #1648 — Inventory of Flattening Sites
+
+**Issue:** `#1648` — "Motif d'aplatissement : 11 modules ecrivant dans le conteneur d'un autre formalisme" (Epic `#1644`, mode 2).
+**Status:** Open at time of investigation (aout 2026).
+**Scope:** Per-site inventory of writers that flatten into a neighbouring formalism's
+container; per-container reader inventory; recommended single remedy; anti-#1019
+regression test idea.
+**Privacy discipline:** Opaque corpus IDs (`corpus_A`, `corpus_B`) only. No real source
+names. No plaintext dataset content. The dispatcher's commit is docs-only.
+
+---
+
+## 0. Methodology and ground rules
+
+**Triple grounding (technique only, docs-only investigation):**
+- **Writer source-of-truth:** `argumentation_analysis/orchestration/state_writers.py`
+  (only place where state is mutated via `add_*` hooks). Read with `Read` offset 1-1649.
+- **Invoke source-of-truth:** `argumentation_analysis/orchestration/invoke_callables.py`
+  (9594 lines; `_invoke_*` returns are the payload the writer sees).
+- **Handler source-of-truth:** `argumentation_analysis/agents/core/logic/<name>_handler.py`
+  (defines the **native** data structure of each formalism — what was actually
+  computed before flattening).
+- **Reader source-of-truth:** grep over `argumentation_analysis/` (production only,
+  `tests/` excluded). The `Reporting/R6` restitution and the `evaluation/` mining
+  code are the canonical consumers.
+
+**Definition adopted.** A "flattening site" is a writer `W` such that:
+1. `W` writes into a container `C` whose **legitimate owner** is formalism `F ≠ formalism(W)`;
+2. the writer re-emits a **subset** of the invoke return into `C`, dropping
+   information that was present in the invoke output (and therefore producible);
+3. the dropped information is **distinctive** of `formalism(W)` (not shared with `F`).
+
+The 11 sites in the issue body match this definition; the inventory is below.
+
+**Conventions used in tables.** "**Distinct info lost**" enumerates invoke-return keys
+(or, when absent there, source-of-information at the handler) that the writer does
+NOT surface into `C`. "**Source vs re-read gap**" enumerates ways the writer
+*synthesises* or *replaces* the emitted payload (e.g. string-encoding a fact into
+`formulas`, or emitting `attacks=[]` in place of available data).
+
+**Anti-pendule guardrails (from issue body, restated for the table):**
+- "Ne pas supposer que la perte est au writer. Elle peut etre a l'invoke." For
+  each site, the "Distinct info lost" column distinguishes **invoke-side loss**
+  (handler did not return the key) from **writer-side loss** (writer received
+  the key but did not surface it). When the distinction cannot be made from
+  static reading, it is labelled "**non verifie**".
+- "Ne pas traiter `attacks=[]` comme une evidence a corriger" — for ADF, the
+  absence of attacks is **correct** (the formalism has acceptance conditions,
+  not binary attacks). For ABA, attacks **are derivable** from contraries and
+  their absence is a real loss. Section 2 answers this case-by-case.
+
+---
+
+## 1. Per-site inventory (11 sites)
+
+### 1.1 Sites writing to `state.dung_frameworks`
+
+The container `state.dung_frameworks` is declared at
+`core/shared_state.py:442` and populated via `add_dung_framework`
+(`core/shared_state.py:811-829`). The canonical owner is `dung_extensions`
+(`_invoke_dung_extensions` → `_write_dung_extensions_to_state`).
+
+| # | Module | Container | Writer (file:line) | Invoke (file:line) | Distinct info lost | Source vs re-read gap |
+|---|--------|-----------|--------------------|--------------------|--------------------|-----------------------|
+| 1 | **ABA** | `state.dung_frameworks` | `_write_aba_to_state` (`state_writers.py:831-845`) | `_invoke_aba` (`invoke_callables.py:3603-3646`) → `handler.analyze_aba_framework` (`agents/core/logic/aba_handler.py:59-128`) | **Contraries** (`Dict[str, str]` mapping assumption → contrary) consumed at `invoke_callables.py:3610,3640` but NEVER returned by handler (`aba_handler.py:115-125` returns `{semantics, extensions, assumptions, rules_count, statistics}` only). Also: ABA semantics is multi-extension (`preferred`/`stable`/`complete`/`well_founded`/`ideal`), the writer stores only ONE composite `{"aba_extensions": extensions}` key — distinct semantics names are collapsed into a single list. | **`attacks=[]` hard-coded** (`state_writers.py:843`). Native Dung `add_dung_framework` interprets empty attacks as "no attack relations" → extension trivially contains all arguments. See Section 2. |
+| 2 | **ADF** | `state.dung_frameworks` | `_write_adf_to_state` (`state_writers.py:848-861`) | `_invoke_adf` (`invoke_callables.py:3649-3668`) → `handler.analyze_adf` (`agents/core/logic/adf_handler.py:61-126`) | **Acceptance conditions** (the `Dict[str, str]` mapping `statement → "tautology"|"contradiction"|"negation:stmt"`). Consumed at `invoke_callables.py:3654,3662` (`_adf_conditions_from_context(args, context)`). The handler computes interpretations over the conditions but returns `{semantics, statements, interpretations, statistics}` — **conditions are NOT in the return dict** (loss at the handler level, not the writer). | **`attacks=[]` hard-coded** (`state_writers.py:859`). **Correct representation** for ADF: ADF has no binary attack relation, only acceptance conditions. See Section 2. Writer is technically correct; the real loss is the conditions themselves (the formalism's distinctive data). |
+| 3 | **SetAF** | `state.dung_frameworks` | `_write_setaf_to_state` (`state_writers.py:1199-1209`) | `_invoke_setaf` (`invoke_callables.py:4126-4180`) → `handler.analyze_setaf` (`agents/core/logic/setaf_handler.py:69-134`) | **Joint (set) attacks** — the native data structure `List[{attackers: List[str], target: str}]`. The handler returns them in `output["attacks"]` (line 123), but the writer hard-codes `attacks=[]` with comment "set attacks don't map to binary attacks" (`state_writers.py:1207`). The information exists in the invoke return; the writer explicitly drops it. | Writer synthesises the extensions dict as `{"setaf_extensions": [...]}`. Any reader looking for Dung-style `attacks` sees `[]` — silent lossy projection. See Section 2. |
+| 4 | **Weighted** | `state.dung_frameworks` | `_write_weighted_to_state` (`state_writers.py:1212-1226`) | `_invoke_weighted` (`invoke_callables.py:4183-4249`) → `handler.analyze_weighted_framework` (`agents/core/logic/weighted_handler.py:73-153`) | **Attack weights** — the handler returns `output["attacks"]` as `List[{source, target, weight}]` (line 139-141). The writer extracts only `[src, tgt]` (drops `weight`). **Also lost: `weight_statistics`** (the handler returns `min_weight`, `max_weight`, `avg_weight` at lines 130-134, never consumed). | Writer produces attacks as `[src, tgt]` pairs — a list-shape that downstream readers expect, but the weight is invisible. `weight_statistics` is computed at the handler but discarded at the writer. |
+| 5 | **Social** | `state.dung_frameworks` | `_write_social_to_state` (`state_writers.py:1229-1240`) | `_invoke_social` (`invoke_callables.py:4252-4277`) → `handler.analyze_social_framework` (`agents/core/logic/social_handler.py:56-133`) | **Per-argument social strength scores** (the `Dict[str, float]` of `model.get(arg)`) and **vote tallies** (`Dict[arg, (pos, neg)]`). Both are computed by the handler (`social_handler.py:113` for scores, line 89-92 for votes). The writer stores them only inside `extensions={"social_ranking": [...], "social_scores": {...}}` — opaque to readers that aggregate `attacks`. | Reader-visible shape: `attacks` preserved as `[src, tgt]` (good), but a reader iterating `attacks` cannot tell a social-vote weighted graph from a Dung binary graph. |
+| 6 | **EAF (Epistemic)** | `state.dung_frameworks` | `_write_eaf_to_state` (`state_writers.py:1243-1252`) | `_invoke_eaf` (`invoke_callables.py:4317-4342`) → `handler.analyze_epistemic_framework` (`agents/core/logic/eaf_handler.py:71-130`) | **Epistemic beliefs** — the per-agent `Dict[agent, List[arg]]` mapping. Computed at `invoke_callables.py:4326` (`_eaf_beliefs_from_context`) and returned by the handler (`eaf_handler.py:118`). The writer discards them; only `extensions={"eaf_extensions": extensions}` survives. `statistics.agents_count` is computed (`eaf_handler.py:124`) and dropped. | Reader-visible shape: `attacks` preserved as `[src, tgt]` (good), but the EAF-specific epistemic dimension is invisible to readers that read `extensions["eaf_extensions"]` as a flat list of extensions. |
+| 7 | **DeLP** | `state.dung_frameworks` | `_write_delp_to_state` (`state_writers.py:1255-1265`) | `_invoke_delp` (`invoke_callables.py:4345-4384`) → `handler.analyze_delp` (`agents/core/logic/delp_handler.py:117-164`) | **The whole dialectical tree** (literal DeLP arguments with strict/defeasible rules, defeat relations, comparison criterion verdict). The handler returns `{program, program_size, criterion, query_results: [{query, answer, message}]}` — the writer stashes the query_results inside `extensions={"delp_query_results": ...}`. **Defeat relations between arguments are nowhere in the state** — DeLP's whole reason for existing. | **Both `arguments=[]` and `attacks=[]` hard-coded** (`state_writers.py:1262-1263`). Reader looking at `state.dung_frameworks["delp_analysis"]` sees an empty AF — the dialectical engine ran but the result is a single (answer, message) per query. |
+| 8 | **Dung-arbitration** (native Dung, less critical) | `state.dung_frameworks` | `_write_dung_arbitration_to_state` (`state_writers.py:1067-1125`) | `_invoke_dung_arbitration` (`invoke_callables.py:7974-8048`) → `arbitrate_detections` (logic-only, no JVM) | **Walton-Krabbe declared relations** and **same-span rivalry** (the attack-generation primitives at `invoke_callables.py:8028-8033`). The verdict survives as `attacks` + `extensions={"surviving_ids", "eliminated_ids", "honest_absent", "enabled", "input_count", "surviving_count"}` — comprehensive but inside a non-Dung semantics-keyed bag. | Honest projection (the verdict IS the format), but provenance ("how was the attack generated?") is lost — the `honest_absent` flag is preserved but the *reason* (no declared relations / no same-span rivalry) is not. |
+| 9 | **Dung-verification** (native Dung, less critical) | `state.dung_frameworks` | `_write_dung_extensions_to_state` (`state_writers.py:1037-1064`) | `_invoke_dung_extensions` (`invoke_callables.py:7057-7973`) | None — this IS the legitimate Dung writer; semantics keys match what readers expect. **NB**: it stores primary + additional semantics as separate `name=verification_<sem>` entries (line 1050, 1061). | None observed. Native Dung contract. |
+
+### 1.2 Sites writing to `state.fol_analysis_results`
+
+The container `state.fol_analysis_results` is declared at
+`core/shared_state.py:1079-1111`. The canonical owner is `fol_reasoning`
+(`_invoke_fol_reasoning` → `_write_fol_to_state`).
+
+| # | Module | Container | Writer (file:line) | Invoke (file:line) | Distinct info lost | Source vs re-read gap |
+|---|--------|-----------|--------------------|--------------------|--------------------|-----------------------|
+| 10 | **Description Logic (DL)** | `state.fol_analysis_results` | `_write_dl_to_state` (`state_writers.py:1144-1160`) | `_invoke_dl` (`invoke_callables.py:3971-4000`) → `handler.is_consistent` (`agents/core/logic/dl_handler.py:161-198`) | **The full DL ontology** — TBox (`List[Tuple[concept, equivalent_concept]]`), ABox concepts (`List[Tuple[individual, concept]]`), ABox roles (`List[Tuple[ind, role, ind]]`), and the **subsumption queries** (`query_subsumption` at `dl_handler.py:213`). The invoke receives them at `invoke_callables.py:3973-3975` and counts them in `tbox_size` / `abox_size` (`invoke_callables.py:3992-3993`), but the writer stores only `[f"DL: {message}"]` as `formulas` — sizes are dropped. | Writer synthesises a single fake-formula string `"DL: {message}"` (the consistency verdict's textual representation). Verdict (`consistent`) IS preserved correctly (None/True/False); the **structure** (TBox, ABox, subsumptions) is gone. **Survives honest-absent only by accident** — if `handler.is_consistent` raises, `_invoke_dl` raises `RuntimeError` and nothing is written (anti-#1019, good). But when `is_consistent` succeeds, the ontology disappears. |
+
+### 1.3 Sites writing to `state.propositional_analysis_results`
+
+The container `state.propositional_analysis_results` is declared at
+`core/shared_state.py:1113-1148`. The canonical owner is `propositional_logic`
+(`_invoke_propositional_logic` → `_write_propositional_to_state`).
+
+| # | Module | Container | Writer (file:line) | Invoke (file:line) | Distinct info lost | Source vs re-read gap |
+|---|--------|-----------|--------------------|--------------------|--------------------|-----------------------|
+| 11 | **Conditional Logic (CL)** | `state.propositional_analysis_results` | `_write_cl_to_state` (`state_writers.py:1163-1174`) | `_invoke_cl` (`invoke_callables.py:4003-4034`) → `handler.query` (`agents/core/logic/cl_handler.py:178-212`) | **The conditionals themselves** (the `ClBeliefSet` of `(conclusion | premise)` formulas). The invoke receives them at `invoke_callables.py:4005` (`conditionals = context.get("conditionals", [])`) and the handler parses them via `kb = handler.create_knowledge_base(conditionals)` (line 4017), but the writer stores only `[f"CL({num_conditionals} conditionals): {message}"]`. The count is in the formula string; the conditionals themselves are gone. CL's distinctive semantics (non-material conditionals, system-P/System-Z ranking) is invisible. | Writer synthesises a label `"CL(N conditionals): {msg}"` — the verdict (`entailed` → `satisfiable`) is preserved; structure is dropped. |
+| 12 | **SAT** | `state.propositional_analysis_results` | `_write_sat_to_state` (`state_writers.py:1177-1196`) | `_invoke_sat` (`invoke_callables.py:4037-4120`) | **MUS list** (in MUS mode): `output["mus_subsets"]` (line 4088). The writer preserves `mus_count` inside a label `"SAT/MUS: {n} minimal unsatisfiable subsets"` but the actual subsets are dropped. **In solve mode**, the model IS preserved (writer at line 1195 passes `model`). **Backend comparison** (`sat_backend_comparison`) is dropped (line 4119 builds it, writer never reads it). | In MUS mode: synthesises a label, drops the actual subsets. In solve mode: model preserved (writer at line 1195). |
+| 13 | **QBF** | `state.propositional_analysis_results` | `_write_qbf_to_state` (`state_writers.py:1268-1276`) | `_invoke_qbf` (`invoke_callables.py:4387-4415`) → `handler.analyze_qbf` (`agents/core/logic/qbf_handler.py:152-177`) | **Quantifiers** (the `List[{type: "forall"|"exists", vars: [...]}]` structure). The invoke receives them at `invoke_callables.py:4389`, the handler returns them at `qbf_handler.py:169` (`"quantifiers": quantifiers`), and **the writer drops them**. The whole point of QBF — alternating quantifiers over propositional matrix — is invisible. | Writer synthesises `[f"QBF: {formula}"]` from the formula string only. Verdict (`valid`) preserved; quantifier alternation lost. |
+
+### 1.4 Count reconciliation (issue body says 11)
+
+The 11 sites in the issue body correspond to the 11 entries that **flatten into
+another formalism's container** with **distinctive data lost**:
+
+- Sites 1, 2, 3, 4, 5, 6, 7 — seven formalisms (ABA, ADF, SetAF, Weighted, Social,
+  EAF, DeLP) flattened into `dung_frameworks`.
+- Sites 10, 11, 12, 13 — DL, CL, SAT, QBF flattened into their PL/FOL containers.
+
+**Dung-arbitration (#8) and Dung-verification (#9)** are listed in this table
+for completeness but are **not flatteners**:
+- Dung-verification is the legitimate native writer.
+- Dung-arbitration writes into the same container but with the canonical Dung
+  shape (attacks as `[src, tgt]` pairs, surviving/eliminated ids). Its loss is
+  provenance-only (Walton-Krabbe relations), which the issue body itself flags
+  as "less critical".
+
+If the issue body's "11" excludes Dung-arbitration and Dung-verification, the
+count matches. If it includes both, the count is 13. The reader should treat
+"11" as the **strict** flatteners; the dispatcher should confirm with the
+coordinator.
+
+---
+
+## 2. Hard-coded `attacks=[]` verdict (ABA / ADF / SETAF / DeLP)
+
+The issue body singles out ABA and ADF as "aggravated" because they hard-code
+`attacks=[]`. This section answers: for each formalism, is the empty list the
+**correct representation** of the formalism, or is it a **real loss**?
+
+### 2.1 ABA — REAL LOSS
+
+**Handler return** (`aba_handler.py:115-125`):
+```python
+{"semantics", "extensions", "assumptions", "rules_count", "statistics"}
+```
+**No `attacks` key, no `contraries` key.** Contraries were consumed at
+`invoke_callables.py:3610,3640` (`contraries = context.get("contraries")`) and
+passed to `handler.analyze_aba_framework`. The handler uses them **inside**
+Tweety to build the `AbaTheory` (line 87-92 in `aba_handler.py`), but the
+returned dict does **not** surface them.
+
+**Consequence:** the writer's `attacks=[]` is a real loss **at the invoke /
+handler level**, not the writer's fault. To fix it, the handler would have to
+return `{"contraries": ..., "attacks_from_contraries": [...]}` and the writer
+would have to project the contrary-derived attacks. **The writer alone cannot
+fix this site** — the loss is upstream.
+
+The semantic correctness claim: a Dung AF with `arguments=assumptions` and
+`attacks=[]` has a grounded extension equal to all assumptions → ABA cannot
+refute anything via this projection. The "aggravated" framing in the issue
+body is correct.
+
+### 2.2 ADF — FORMALLY CORRECT, STRUCTURE LOST
+
+ADF is **not** a Dung-style binary attack framework. Its native data is
+acceptance conditions (`Dict[statement, {tautology|contradiction|negation:stmt}]`,
+`adf_handler.py:89-103`). The semantics computes **interpretations** (3-valued
+valuations), not extensions over a binary attack relation.
+
+**Consequence:** `attacks=[]` is **the correct representation** — there are no
+attacks to project. The loss is the **acceptance conditions** themselves (and
+the interpretations computed from them). The handler returns
+`{semantics, statements, interpretations, statistics}` (`adf_handler.py:114-123`)
+— conditions are NOT returned.
+
+**The fix is not at the writer.** It is at the handler / invoke contract: the
+acceptance conditions should be returned (or at least the computed
+interpretations, which ARE returned). The writer could then either project the
+interpretations into a Dung-extension-equivalent (`extensions={"adf_models": ...}`
+is already there, line 860) **OR** a dedicated ADF container would carry the
+interpretations natively.
+
+### 2.3 SetAF — LOSS AT THE WRITER (handler returns attacks, writer drops them)
+
+**Handler return** (`setaf_handler.py:120-131`):
+```python
+{"semantics", "arguments", "attacks", "extensions", "extensions_count", "statistics"}
+```
+**The handler does return `attacks`** as the original `List[{attackers: List[str], target: str}]`
+(line 123). The writer explicitly drops them:
+```python
+state.add_dung_framework(
+    ...
+    attacks=[],  # set attacks don't map to binary attacks
+    extensions={"setaf_extensions": output.get("extensions", [])},
+)
+```
+
+**The comment is honest** — SetAF's joint (set) attacks are not binary
+Dung-style. The writer cannot store them in the binary `attacks` field without
+loss. But the writer drops them entirely from the extensions dict too, so
+**the joint-attack information is unreachable from the state**.
+
+**The fix is structural.** A dedicated `set_attacks` field, or a
+`{"set_attacks": [...]}` key inside `extensions`, would preserve the data
+without breaking the Dung contract. Section 4 evaluates this option.
+
+### 2.4 DeLP — WHOLE FORMALISM IS GONE
+
+DeLP has **arguments** (literal `~arg` rules, strict and defeasible), **defeat
+relations** (a defeat is a relation between arguments under a comparison
+criterion), and **warrant** verdicts (per query). The handler returns
+`{program, program_size, criterion, query_results: [{query, answer, message}]}`
+(`delp_handler.py:149-158`). The writer stores ONLY:
+```python
+arguments=[],
+attacks=[],
+extensions={"delp_query_results": query_results},
+```
+(`state_writers.py:1260-1265`).
+
+**This is the deepest flattening of the inventory.** A DeLP run produces
+literally nothing that survives the writer except a list of `(query, answer,
+message)` triples. The argument graph, the defeat relations, the comparison
+criterion — all gone. A reader looking at `state.dung_frameworks["delp_analysis"]`
+sees an empty AF plus a query-result bag. The fix cannot be at the writer level
+alone; it requires a **dedicated DeLP container** (or a `formalism_specific`
+sidecar — see Section 4).
+
+---
+
+## 3. Reader inventory
+
+This section inventories ALL production consumers of the three target containers
+(grep over `argumentation_analysis/`, excluding `tests/`). For each, we ask:
+what does it read, and does it **aggregate over the container as a whole** (in
+which case heterogeneous flattened entries pollute the aggregate)?
+
+### 3.1 Readers of `state.dung_frameworks`
+
+| Reader (file:line) | Reads | Aggregate / per-entry | Affected by flattening? |
+|--------------------|-------|------------------------|--------------------------|
+| `reporting/restitution/act2_narrative_plugin.py:332-375` (`_dung_rejected_by_arg`) | Iterates `frameworks.items()`, reads `arguments` + `extensions` per entry; computes arg ∈ `arguments` but ∉ `extensions` → "rejected". | **Per-entry**. Rejection verdict per `(arg, semantics)`. ABA / SetAF / ADF entries contribute their `extensions` (computed) — so this reader DOES receive the flattened data, but interprets it as Dung extensions. | **Partial.** ABA returns ABA extensions as the `extensions` value; the rejection logic at line 372-374 will treat every argument NOT in any ABA extension as "rejected by ABA semantics" — which is correct for ABA. The reader does not crash, but ABA / ADF / SetAF semantics get the same "Dung" reading. |
+| `reporting/restitution/act2_narrative_plugin.py:384-428` (`_collect_dung_trace`) | Picks the first `verification_*` entry (line 411-414). **Ignores `aba_*`, `adf_*`, `setaf_*`, `weighted_*`, `eaf_*`, `delp_analysis`, `social_af` entries** (only matches `verification_<sem>` names). | Single-entry. | **The flatteners are NOT read here** — the reader explicitly filters by name. Confirms the flatteners are inert for this code path. |
+| `reporting/restitution/act3_conclusion_plugin.py:530-562` (`_dung_rejected_by_arg`) | Same logic as act2 — iterates all frameworks, computes rejection per `(arg, semantics)`. | **Per-entry**. | Same partial effect as act2. |
+| `visualization/html_report.py:516-553` (Dung visualisation) | Iterates `dung_frameworks.values()`, takes the **first** entry (line 548-550). Reads `arguments` + `attacks` + `extensions`. Renders the graph for HTML/JS. | Single-entry (first wins). | **CRITICAL.** The first framework in the dict is **implementation-order-dependent**. ABA / ADF / SetAF writers all use `attacks=[]` → empty graph rendered. With DL / SAT / CL / QBF → no effect (different container). Pattern_mining also reads the first entry — see below. |
+| `evaluation/pattern_mining.py:75-114` (`DungTopologyDetector`) | Takes the first framework (line 90), reads `arguments`, `attacks`, `extensions`. Computes `n_attacks / n*(n-1)` density. | Single-entry + density metric. | **CRITICAL.** For ABA / ADF / SetAF, `attacks=[]` → `density=0`. The "dung_unsupported" detection at line 402-418 uses `attacks` as a dict-shape `{from, to}` (line 414-416) — but the writer stores `[src, tgt]` lists. **Two shape mismatches at once**: empty for formalisms that DO have attacks (ABA contraries, SetAF joint attacks, EAF epistemic), and dict-vs-list for the rest. |
+| `evaluation/pattern_mining.py:400-418` (formal-signals aggregation) | Iterates ALL frameworks, sums `attacks` (expecting dicts with `{from, to}`). | **Aggregate.** | **CRITICAL.** ABA / ADF / SetAF contribute zero attacks → `dung_unsupported` is under-counted at the corpus level. **The flattened sites SILENTLY zero out a corpus-level signal.** |
+| `reporting/restitution/act3_conclusion_plugin.py:530` (used downstream by `_collect_weak_points`) | Same as act2. | Per-entry → aggregated into `StructuringWeakPoint` list. | Same partial effect. |
+| `agents/core/synthesis/deep_synthesis_agent.py:587-603` (`_build_dung_structure`) | First entry, reads `name`, `arguments`, `attacks`, `extensions.{grounded,preferred,stable}`. | Single-entry. | **CRITICAL.** ABA's `extensions={"aba_extensions": [...]}` doesn't have a `grounded` / `preferred` key — `extensions.get("grounded", [])` returns `[]` → ABA's grounded extension reported as empty. Same for ADF (`adf_models`). Same for SetAF (`setaf_extensions`). The deep synthesis agent interprets these as "the framework found no extension" — **the flattening directly corrupts the restitution narrative**. |
+| `agents/core/synthesis/deep_synthesis_agent.py:1267-1277` (deep context dump) | Iterates up to `max_items_per_field`, formats `name / args=N / attacks=N / grounded_extension=...`. | Per-entry (capped). | ABA / ADF / SetAF report `attacks=0`, `grounded_extension=[]` — same narrative corruption as above. |
+| `reporting/reprompt_trace.py:23` | Listed in trace field whitelist. | n/a (just lists the key). | Not affected. |
+| `cli/output_formatter.py:212,289` | Counts frameworks, renders summary. | Aggregate count only. | Not affected (count is correct). |
+| `reporting/multi_format_exporter.py:28` | Display label only. | n/a. | Not affected. |
+| `evaluation/sanitize_state.py:97-160` | Opacification of `arguments` (line 102), `attacks` (line 102), `extensions.{extensions, all_members}` (line 122). | n/a — privacy discipline, no semantics. | Not affected. |
+| `services/web_api/services/framework_service.py:36-61` | Standalone Dung analysis endpoint (independent of state). | n/a — separate code path. | Not affected. |
+| `plugins/tweety_logic_plugin.py:93-120` | `analyze_dung_framework` (SK plugin). | n/a — produces an invoke result, not a reader. | Not affected. |
+| `plugins/narrative_synthesis_plugin.py:143,239` | Same logic as act2 (`_dung_rejected_args`). | Per-entry. | Same partial effect. |
+
+**Summary for `dung_frameworks` readers.** Two readers aggregate across the
+container and are sensitive to the flattened entries:
+1. **`pattern_mining.py:402-418`** — corpus-level `dung_unsupported` signal is
+   under-counted because ABA / ADF / SetAF contribute zero attacks.
+2. **`deep_synthesis_agent.py:587-603`** — narrative corruption (single-entry
+   wins, ABA's "grounded_extension" is empty even when extensions exist).
+
+All other readers either filter by name (so flatteners are inert) or only count
+(so shape is irrelevant).
+
+### 3.2 Readers of `state.fol_analysis_results`
+
+| Reader (file:line) | Reads | Aggregate / per-entry | Affected by flattening? |
+|--------------------|-------|------------------------|--------------------------|
+| `reporting/restitution/act2_narrative_plugin.py:844-884` | Iterates `fol` (list of dicts), reads `consistent` (None/True/False) and `message`. Aggregates consistent/inconsistent counts. | **Aggregate.** | **Partial.** Verdict IS preserved by DL writer (line 1155-1160). The corpus-level consistent count is correct. **What is lost is the FOL-vs-DL distinction** — a reader cannot tell which entry came from DL and which from real FOL. If a corpus mixes FOL theories and DL ontologies, the count lumps them together. |
+| `reporting/restitution/appendix.py:55-111` (`_fol_axis_status`) | Same: reads `consistent` + `formulas` (for the "formules" count). | Aggregate tri-state (decided / degraded / indisponible). | **Partial.** Decision counts correct. The `formules` field shows `1` for DL entries (the synthesised `"DL: ..."` string) versus N for real FOL entries (the formula list). A corpus-level `formules: 1` could be a single FOL theory OR a single DL ontology — **the axis label is correct but the granularity is lost**. |
+| `reporting/restitution/state_adapter.py:27` | Listed as a spec §2 axis key — passed verbatim to the renderer. | n/a (key pass-through). | Not affected semantically. |
+
+**Summary for `fol_analysis_results` readers.** The verdict is preserved by DL;
+the **origin** (FOL vs DL) is not. The aggregation is **safe** but
+**indistinguishable** — a restitution cannot say "FOL said X, DL said Y" if
+both wrote into the same container.
+
+### 3.3 Readers of `state.propositional_analysis_results`
+
+| Reader (file:line) | Reads | Aggregate / per-entry | Affected by flattening? |
+|--------------------|-------|------------------------|--------------------------|
+| `reporting/restitution/act2_narrative_plugin.py:815-842` | Iterates `pl` (list of dicts), reads `_pl_verdict(r)` (which reads `satisfiable` then `consistent` for legacy). Aggregates satisfiable/insatisfiable counts. | **Aggregate.** | **Safe for verdict counts.** The verdict (satisfiable) is preserved by CL, SAT, QBF writers. **Origin is lost** — SAT, CL, QBF, and the real PL all contribute to the same counter. |
+| `reporting/restitution/appendix.py:170-199` (`_pl_axis_status`) | Same logic — tri-state satisfiable verdict. | Aggregate tri-state. | Same partial effect. |
+| `reporting/restitution/state_adapter.py:26` | Key pass-through. | n/a. | Not affected. |
+
+**Summary for `propositional_analysis_results` readers.** Same verdict-preserved,
+origin-lost pattern as FOL. The corpus-level PL-axis verdict is correct; the
+PL-vs-CL-vs-SAT-vs-QBF distinction is gone.
+
+---
+
+## 4. Recommended single remedy
+
+The issue body proposes three options. This section evaluates them against the
+reader inventory above.
+
+### Option 1 — Dedicated container per formalism + dedicated readers
+
+**Effort.** High. Each of the 7+3 (Dung-side) + 1 (DL) + 3 (PL-side) formalisms
+gets its own container (e.g. `state.aba_frameworks`, `state.adf_models`,
+`state.set_attacks`, `state.weighted_attacks`, `state.social_scores`,
+`state.eaf_beliefs`, `state.delp_arguments`, `state.dl_ontology`,
+`state.cl_conditionals`, `state.sat_mus_subsets`, `state.qbf_quantifiers`).
+Each reader grows a branch per formalism. The restitution must thread all 11
+containers into the R6 narrative.
+
+**Risk.** As the issue body warns ("un conteneur sans lecteur est un mode 1
+fabrique de nos propres mains"): a new container with no reader is the same
+silently-empty failure the issue is trying to fix. The contract MUST include
+the reader migration as a single atomic change.
+
+**Verdict.** **Faithful** (no information loss) but **expensive** and **risk-prone**
+(multi-reader migration can produce silent omissions). Only justified if a
+reader of one formalism should NEVER see another's data — which is not the
+case here (restitution aggregates, but it aggregates at the verdict level, not
+at the formalism-specific level).
+
+### Option 2 — Single enriched container with `formalism_specific` field
+
+**Effort.** Medium. Extend `state.dung_frameworks[*]` (and the two others) with
+a sidecar `formalism_specific: Dict[str, Any]` carrying the lost data:
+- ABA: `{"contraries": {...}, "extensions_by_semantics": {...}}`
+- ADF: `{"acceptance_conditions": {...}, "interpretations": [...]}`
+- SetAF: `{"set_attacks": [...]}` (joint attacks)
+- Weighted: `{"weights": {...}, "weight_statistics": {...}}`
+- Social: `{"votes": {...}, "scores": {...}}`
+- EAF: `{"epistemic_beliefs": {...}}`
+- DeLP: `{"arguments": [...], "defeat_relations": [...], "criterion": "..."}`
+- DL: `{"tbox": [...], "abox_concepts": [...], "abox_roles": [...], "subsumptions": [...]}`
+- CL: `{"conditionals": [...]}` (the raw CL formula list)
+- SAT/MUS: `{"mus_subsets": [...]}` (the actual subsets)
+- QBF: `{"quantifiers": [...]}`
+
+Readers that don't care about the sidecar ignore it; readers that do
+(formalism-specific consumers) opt in. The existing projection stays — `attacks`
+remains binary, `formulas` remains a list — so backward compatibility is
+preserved.
+
+**Risk.** The sidecar can become a "fourre-tout" (the issue body's stated
+concern). To avoid that, **the sidecar MUST be typed** (a per-formalism TypedDict
+in `shared_state.py`) and **the existing readers' contract must explicitly
+forbid reading from `formalism_specific`**.
+
+**Verdict.** **Best fit.** Faithful, backward-compatible, single change,
+the reader inventory (Section 3) shows that existing readers ONLY consume the
+projected fields (`attacks`, `extensions.grounded`, `consistent`, `satisfiable`,
+`message`) — none of them would read the sidecar. New formalism-specific
+readers (e.g. for ABA contraries, for QBF quantifiers) opt in explicitly.
+
+### Option 3 — Documented lossy projection + parallel preservation
+
+**Effort.** Low. Add a `lossy_projection: True` flag (or similar) to each
+flattened entry, plus a parallel `state.formalism_specific: Dict[capability, Any]`
+container carrying the lost data. Document at the writer level which fields are
+preserved vs lost. Update the readers' contracts to say "this reader reads the
+projection only — formalism-specific data is in `state.formalism_specific`".
+
+**Risk.** Same as Option 2 plus the doc-discipline requirement. If the doc
+isn't maintained, the projection silently re-becomes the projection-of-record.
+This is precisely the current state (de facto lossy, de jure undocumented).
+
+**Verdict.** **Acceptable but inferior.** Option 2 + a brief docstring at the
+container level achieves the same outcome with a cleaner type contract.
+
+### **Recommended: Option 2 (enriched container with `formalism_specific` sidecar)**
+
+**Reasoning anchored in Section 3:**
+- **Verdict-level readers** (act2 / act3 / appendix / pattern_mining density):
+  read only `consistent`, `satisfiable`, `arguments`, `attacks`, `extensions`
+  — projection is sufficient for them.
+- **Narrative-level readers** (deep_synthesis_agent): currently single-entry,
+  picks first framework — **already broken** under the current flattening
+  (ABA's `extensions={"aba_extensions": [...]}` does not have `grounded` /
+  `preferred` keys, so the deep synthesis gets `[]`). Adding `formalism_specific`
+  is not a regression here — the existing readers stay unchanged, the new
+  field is opt-in.
+- **Corpus-level signals** (pattern_mining `dung_unsupported`): unaffected by
+  adding the sidecar. The current under-counting is **preserved as-is** (a
+  separate fix); the sidecar gives future readers the data to compute the
+  correct count.
+
+**One single change, applied to all 11 sites at once** (per the issue body's
+mandate: "Un remede unique est choisi et applique aux onze sites"). One
+TypedDict in `core/shared_state.py`, one read in each of the 11 writers, one
+typed `formalism_specific` per capability.
+
+### 4.1 Pre-recommendation checks
+
+Before the remedy is applied, the issue body's DoD must be addressed:
+
+1. **Per-module comparison (invoke vs state):** the inventory above IS that
+   comparison — "Distinct info lost" enumerates the gap. Future issue: run a
+   one-shot test that diffs `invoke_output` against `state.<container>[<id>]`
+   per capability and prints the gap. (This is the same anti-#1019 family as
+   `feedback_injected_fakes_hide_real_shape_bugs.md`.)
+
+2. **Reader impact measurement:** Section 3 inventories the readers. The
+   **before/after** measurement on `pattern_mining.py:402-418` (`dung_unsupported`)
+   and `deep_synthesis_agent.py:587-603` (grounded_extension reads) is the
+   concrete number the coordinator wants.
+
+3. **`attacks=[]` for ABA/ADF tranché:**
+   - **ADF: correct (formally).** The fix is at the handler / writer level —
+     return / surface the acceptance conditions (or interpretations), not the
+     attack list.
+   - **ABA: real loss.** Contraries are upstream of the handler's return dict.
+     Either the handler returns `contraries` (and the writer projects the
+     contrary-derived attacks), OR a `formalism_specific.contraries` carries
+     them.
+   - **SetAF: writer-side loss.** Handler returns the joint attacks. Fix is
+     a `formalism_specific.set_attacks`.
+   - **DeLP: structural.** A `formalism_specific` carrying the DeLP argument
+     tree + defeat relations is the minimum viable preservation.
+
+---
+
+## 5. Anti-#1019 regression test idea
+
+The issue body's DoD item 5 demands "Un test qui **échouerait aujourd'hui** :
+un module du mode 2 dont l'information distinctive est présente en entrée et
+absente après relecture".
+
+**Test concept: `test_1648_aba_writer_preserves_contraries`**
+
+**Setup:**
+1. Build a small `UnifiedAnalysisState` (via `core.shared_state.UnifiedAnalysisState`).
+2. Stub `ABAHandler.analyze_aba_framework` to return a controlled dict:
+   ```python
+   {
+       "semantics": "preferred",
+       "extensions": [["a", "b"], ["a", "c"]],
+       "assumptions": ["a", "b", "c"],
+       "rules_count": 2,
+       "statistics": {"assumptions_count": 3, "rules_count": 2, "extensions_count": 2},
+   }
+   ```
+   (Stubbing the handler avoids JVM / Tweety dependency. The contract under
+   test is **the writer**, not the handler.)
+3. Inject context `{"contraries": {"a": "b", "b": "a", "c": "a"}}` so the
+   distinctive ABA data is in the writer's input path.
+
+**Action:** call `_write_aba_to_state(output, state, ctx)`.
+
+**Assertions (today, the test FAILS):**
+- After the call, `state.dung_frameworks` contains ONE entry with name
+  `aba_preferred`.
+- That entry's `attacks` field contains at least one pair `[a, b]` (because
+  `a`'s contrary is `b`, ABA's native semantics gives a `(a, b)` attack).
+  **Today this assertion FAILS** — the writer hard-codes `attacks=[]`.
+- (Stretch, after the remedy:) that entry's `formalism_specific.contraries`
+  equals `{"a": "b", "b": "a", "c": "a"}`.
+
+**Why this catches the flattening bug.** The test pins the writer's contract:
+**if the writer receives an ABA output (and the context carries contraries),
+the state MUST reflect that the framework has attacks.** Today's writer
+silently writes `attacks=[]` and the test fails — the assertion message names
+exactly the gap ("ABA writer dropped contraries-derived attacks; `attacks` is
+`[]` but should contain `[a, b]`").
+
+**Anti-#1019 discipline.** The stub returns a real, non-empty, distinctively
+ABA-shaped output. The assertion reads through the canonical writer, not a
+mocked one. This is the same family as the R761 #1643 / R764 #1636 / R765 #1662
+fixes: the test must drive the **real code path** and observe the real loss.
+
+**Location.** Suggested: `tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py`.
+Symmetric tests for ADF / SetAF / Weighted / Social / EAF / DeLP / DL / CL /
+SAT / QBF can be added in the same file, one per site, all failing today.
+
+**Per-site cost.** Each stub is ~10 lines. The total file is ~250 lines for
+11 sites. The test runs without JVM (all stubs), so it is CI-friendly.
+
+---
+
+## Appendix A — File-and-line index (for citable review)
+
+| Site | Writer file:line | Invoke file:line | Handler file:line | Reader file:line (key) |
+|------|------------------|------------------|-------------------|------------------------|
+| ABA | `state_writers.py:831-845` | `invoke_callables.py:3603-3646` | `aba_handler.py:59-128` | `act2_narrative_plugin.py:332-375` |
+| ADF | `state_writers.py:848-861` | `invoke_callables.py:3649-3668` | `adf_handler.py:61-126` | `act2_narrative_plugin.py:332-375` |
+| SetAF | `state_writers.py:1199-1209` | `invoke_callables.py:4126-4180` | `setaf_handler.py:69-134` | `pattern_mining.py:402-418` |
+| Weighted | `state_writers.py:1212-1226` | `invoke_callables.py:4183-4249` | `weighted_handler.py:73-153` | `pattern_mining.py:402-418` |
+| Social | `state_writers.py:1229-1240` | `invoke_callables.py:4252-4277` | `social_handler.py:56-133` | `act2_narrative_plugin.py:332-375` |
+| EAF | `state_writers.py:1243-1252` | `invoke_callables.py:4317-4342` | `eaf_handler.py:71-130` | `act3_conclusion_plugin.py:530-562` |
+| DeLP | `state_writers.py:1255-1265` | `invoke_callables.py:4345-4384` | `delp_handler.py:117-164` | `deep_synthesis_agent.py:587-603` |
+| Dung-arbitration | `state_writers.py:1067-1125` | `invoke_callables.py:7974-8048` | n/a (pure Python) | `act2_narrative_plugin.py:332-375` |
+| Dung-verification | `state_writers.py:1037-1064` | `invoke_callables.py:7057-7973` | n/a (delegate to AF handler) | `act2_narrative_plugin.py:384-428` |
+| DL | `state_writers.py:1144-1160` | `invoke_callables.py:3971-4000` | `dl_handler.py:161-198` | `act2_narrative_plugin.py:844-884`, `appendix.py:55-111` |
+| CL | `state_writers.py:1163-1174` | `invoke_callables.py:4003-4034` | `cl_handler.py:178-212` | `act2_narrative_plugin.py:815-842`, `appendix.py:170-199` |
+| SAT | `state_writers.py:1177-1196` | `invoke_callables.py:4037-4120` | `sat_handler.py` (external) | `act2_narrative_plugin.py:815-842` |
+| QBF | `state_writers.py:1268-1276` | `invoke_callables.py:4387-4415` | `qbf_handler.py:152-177` | `act2_narrative_plugin.py:815-842` |
+
+## Appendix B — Reader-aggregation impact (recap)
+
+| Reader | Aggregation | Today's behaviour under flatteners | With Option 2 sidecar |
+|--------|-------------|------------------------------------|------------------------|
+| `pattern_mining.DungTopologyDetector` | Single-entry (first) | ABA / ADF / SetAF first → `n_attacks=0`, `density=0` | Unchanged (sidecar ignored). Future reader could compute correct density. |
+| `pattern_mining.formal_signals` (line 402) | Aggregate over all | ABA / ADF / SetAF contribute `0` attacks → `dung_unsupported` under-count | Unchanged (sidecar ignored). Future reader could fix. |
+| `deep_synthesis_agent._build_dung_structure` | Single-entry (first) | ABA's `extensions={"aba_extensions": [...]}` → `grounded_extension=[]` reported | Unchanged. Future reader could read sidecar. |
+| `act2_narrative._dung_rejected_by_arg` | Per-entry | Each flattener contributes its own rejection set | Unchanged. |
+| `act2_narrative._collect_dung_trace` | Filters by `verification_*` | Flatteners are inert (filtered out) | Unchanged. |
+| `act2_narrative._pl_finding` (line 815) | Aggregate verdict | CL/SAT/QBF verdicts lumped with PL — count correct, origin lost | Unchanged. **Origin could be surfaced via `formalism_specific`.** |
+| `act2_narrative._fol_finding` (line 844) | Aggregate verdict | DL verdict lumped with FOL — count correct, origin lost | Unchanged. **Origin could be surfaced via `formalism_specific`.** |
+| `appendix._pl_axis_status` / `_fol_axis_status` | Tri-state aggregate | Same as act2 — verdict correct, origin lost | Unchanged. |
+| `html_report` (line 548) | Single-entry (first) | Same as deep_synthesis — first wins | Unchanged. |
+
+**Pattern.** Under Option 2, all existing readers stay **byte-for-byte identical**.
+The remedy is **strictly additive**: new sidecar, new writers, no reader
+migration. New formalism-specific readers can be written later without
+coordinating with the existing readers.
+
+---
+
+## Appendix C — Anti-pendule notes (for the coordinator)
+
+1. **Do not** add 11 dedicated containers (Option 1). The reader inventory
+   shows that verdict-level aggregation works today; only the formalism-specific
+   dimension is lost. Sidecar is sufficient.
+2. **Do not** treat `attacks=[]` as a uniform bug. For ADF, it is **correct**;
+   the fix is upstream (return the acceptance conditions). For ABA, the fix is
+   upstream too (return the contraries). For SetAF, the fix is at the writer
+   (preserve joint attacks in the sidecar). For DeLP, the fix is structural
+   (the whole formalism needs a sidecar).
+3. **Do not** migrate readers in the same PR as the writer change. The whole
+   point of the sidecar is that the existing readers stay unchanged.
+4. **Do not** add a `formalism_specific: Dict[str, Any]` (untyped). The
+   sidecar must be a TypedDict (or a per-formalism dataclass) so a reader
+   cannot accidentally fish random keys out of it.
+5. **Do not** claim the remedy fixes `pattern_mining.dung_unsupported` under-
+   counting. The sidecar preserves the data; a future PR can write the reader
+   that uses it. Confusing "data preserved" with "signal computed" is the
+   pendulum the issue body warns against.
+
+---
+
+*Inventory produced for Epic `#1644`, issue `#1648`. Read-only investigation;
+no production code modified. Dispatcher will commit as docs-only.*

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
@@ -51,7 +51,7 @@ class TestAbaFlattening1648:
     hard-codes ``attacks=[]`` (state_writers.py:843). A reader aggregating
     attacks sees zero — and ABA cannot refute anything via this projection.
 
-    Today's expected failure: ``state.dung_frameworks["aba_preferred"]["attacks"]``
+    Today's expected failure: ``state.dung_frameworks[<generated_id>]["attacks"]``
     is ``[]`` even though ``context["contraries"]`` was non-empty.
     """
 
@@ -68,14 +68,21 @@ class TestAbaFlattening1648:
             },
         }
 
-    def test_aba_writer_preserves_contraries_or_derived_attacks(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Pinning #1648 Wave-1 known loss (ABA). Handler drops contraries; "
+        "writer drops attacks. Wave-2 fix expected to flip this to PASS.",
+    )
+    def test_aba_writer_preserves_contraries_or_derived_attacks(self) -> None:
         state = _new_state()
         output = self._stub_handler_output()
         ctx = {"contraries": {"a": "b", "b": "a", "c": "a"}}
 
         _write_aba_to_state(output, state, ctx)
 
-        entry = state.dung_frameworks["aba_preferred"]
+        # The frame is keyed by a generated id (df_001), not by the 'name' field.
+        # Fetch the entry the same way the rest of the inventory does.
+        entry = next(iter(state.dung_frameworks.values()))
         # The diagnostic: writer stored no attacks despite contraries being
         # genuine structured input. Today: FAILS (entry["attacks"] == []).
         attacks: List[List[str]] = entry.get("attacks", [])
@@ -85,7 +92,12 @@ class TestAbaFlattening1648:
             "non-empty binary attack relations."
         )
 
-    def test_aba_writer_or_sidecar_carries_contraries(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Pinning #1648 Wave-1 known loss (ABA sidecar). Contraries never "
+        "reach the state. Wave-2 fix expected to flip this to PASS.",
+    )
+    def test_aba_writer_or_sidecar_carries_contraries(self) -> None:
         """Stretch assertion: even if `attacks` stays empty, the contraries
         themselves must reach the state (via extensions or a sidecar)."""
         state = _new_state()
@@ -94,7 +106,7 @@ class TestAbaFlattening1648:
 
         _write_aba_to_state(output, state, ctx)
 
-        entry = state.dung_frameworks["aba_preferred"]
+        entry = next(iter(state.dung_frameworks.values()))
         # Look for contraries anywhere the state carries them today or
         # in a future formalism-specific sidecar.
         extensions = entry.get("extensions", {})
@@ -140,7 +152,12 @@ class TestSetafFlattening1648:
             "statistics": {"arguments_count": 3, "attacks_count": 2},
         }
 
-    def test_setaf_writer_preserves_set_attacks(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Pinning #1648 Wave-1 known loss (SetAF). Handler returns joint "
+        "attacks, writer drops them at state_writers.py:1199-1209. Wave-2 fix.",
+    )
+    def test_setaf_writer_preserves_set_attacks(self) -> None:
         state = _new_state()
         output = self._stub_handler_output()
 
@@ -177,7 +194,7 @@ class TestAdfFlattening1648:
     future refactor that tries to "fix" ADF attacks breaks it visibly.
     """
 
-    def test_adf_attacks_stay_empty_and_acceptance_conditions_acknowledged(self):
+    def test_adf_attacks_stay_empty_and_acceptance_conditions_acknowledged(self) -> None:
         state = _new_state()
         output = {
             "semantics": "grounded",
@@ -213,7 +230,12 @@ class TestWeightedFlattening1648:
     pairs only. The weight is invisible to readers.
     """
 
-    def test_weighted_writer_preserves_attack_weights(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Pinning #1648 Wave-1 known loss (Weighted). Handler returns "
+        "weights, writer projects to [src, tgt] only. Wave-2 fix.",
+    )
+    def test_weighted_writer_preserves_attack_weights(self) -> None:
         state = _new_state()
         output = {
             "semantics": "grounded",
@@ -253,7 +275,7 @@ class TestWeightedFlattening1648:
 class TestSocialFlattening1648:
     """Social writer carries scores/votes in extensions — pin the contract."""
 
-    def test_social_writer_preserves_scores_and_votes(self):
+    def test_social_writer_preserves_scores_and_votes(self) -> None:
         state = _new_state()
         output = {
             "ranking": ["a", "b"],
@@ -281,7 +303,12 @@ class TestSocialFlattening1648:
 class TestEafFlattening1648:
     """EAF writer drops per-agent epistemic beliefs."""
 
-    def test_eaf_writer_preserves_epistemic_beliefs(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Pinning #1648 Wave-1 known loss (EAF). Writer drops per-agent "
+        "epistemic beliefs. Wave-2 fix.",
+    )
+    def test_eaf_writer_preserves_epistemic_beliefs(self) -> None:
         state = _new_state()
         output = {
             "semantics": "grounded",
@@ -319,7 +346,12 @@ class TestDelpFlattening1648:
     gone. This is the deepest flattening in the inventory.
     """
 
-    def test_delp_writer_preserves_argument_graph_or_defeat_relations(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Pinning #1648 Wave-1 known loss (DeLP). Program + defeat "
+        "relations flattened away. Wave-2 fix.",
+    )
+    def test_delp_writer_preserves_argument_graph_or_defeat_relations(self) -> None:
         state = _new_state()
         output = {
             "program": [{"head": "a", "body": []}],
@@ -362,7 +394,12 @@ class TestDlFlattening1648:
     TBox, ABox, subsumptions are all gone (counted at invoke but never written).
     """
 
-    def test_dl_writer_preserves_ontology_structure(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Pinning #1648 Wave-1 known loss (DL). TBox/ABox/subsumptions "
+        "dropped. Wave-2 fix.",
+    )
+    def test_dl_writer_preserves_ontology_structure(self) -> None:
         state = _new_state()
         output = {
             "consistent": True,
@@ -400,7 +437,12 @@ class TestDlFlattening1648:
 class TestClFlattening1648:
     """CL writer stores only ``[f"CL(N): {msg}"]`` as formulas."""
 
-    def test_cl_writer_preserves_conditionals(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Pinning #1648 Wave-1 known loss (CL). Conditionals dropped. "
+        "Wave-2 fix.",
+    )
+    def test_cl_writer_preserves_conditionals(self) -> None:
         state = _new_state()
         output = {
             "entailed": True,
@@ -437,7 +479,12 @@ class TestClFlattening1648:
 class TestQbfFlattening1648:
     """QBF writer drops the alternating quantifier structure."""
 
-    def test_qbf_writer_preserves_quantifiers(self):
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Pinning #1648 Wave-1 known loss (QBF). Quantifier structure "
+        "dropped. Wave-2 fix.",
+    )
+    def test_qbf_writer_preserves_quantifiers(self) -> None:
         state = _new_state()
         output = {
             "valid": True,

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
@@ -1,0 +1,466 @@
+"""#1648 — Regression tests pinning the flattening contract for state writers.
+
+Each test stubs the corresponding handler (to avoid JVM/Tweety dependency) and
+drives the real ``_write_*_to_state`` writer. The assertion reads back through
+the canonical ``state.<container>`` — so the test fails today precisely where
+the writer drops distinctive information.
+
+Anti-#1019 discipline (R761 #1643, R764 #1636, R765 #1662): the writer is
+real, the handler is stubbed. A mocked writer would just agree with itself.
+
+Privacy: synthetic atoms only (no corpus tokens).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.orchestration.state_writers import (
+    _write_aba_to_state,
+    _write_adf_to_state,
+    _write_cl_to_state,
+    _write_delp_to_state,
+    _write_dl_to_state,
+    _write_eaf_to_state,
+    _write_qbf_to_state,
+    _write_setaf_to_state,
+    _write_social_to_state,
+    _write_weighted_to_state,
+)
+
+
+def _new_state() -> UnifiedAnalysisState:
+    """A fresh state for a single writer probe."""
+    return UnifiedAnalysisState("flattening-1648 synthetic probe")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ABA — handler drops contraries, writer drops attacks (Section 2.1)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAbaFlattening1648:
+    """ABA writer must surface contraries (or contrary-derived attacks) somewhere.
+
+    Section 2.1: ``handler.analyze_aba_framework`` consumes ``contraries`` at
+    ``invoke_callables.py:3610,3640`` but does NOT return them. The writer then
+    hard-codes ``attacks=[]`` (state_writers.py:843). A reader aggregating
+    attacks sees zero — and ABA cannot refute anything via this projection.
+
+    Today's expected failure: ``state.dung_frameworks["aba_preferred"]["attacks"]``
+    is ``[]`` even though ``context["contraries"]`` was non-empty.
+    """
+
+    def _stub_handler_output(self) -> Dict[str, Any]:
+        return {
+            "semantics": "preferred",
+            "extensions": [["a", "b"], ["a", "c"]],
+            "assumptions": ["a", "b", "c"],
+            "rules_count": 2,
+            "statistics": {
+                "assumptions_count": 3,
+                "rules_count": 2,
+                "extensions_count": 2,
+            },
+        }
+
+    def test_aba_writer_preserves_contraries_or_derived_attacks(self):
+        state = _new_state()
+        output = self._stub_handler_output()
+        ctx = {"contraries": {"a": "b", "b": "a", "c": "a"}}
+
+        _write_aba_to_state(output, state, ctx)
+
+        entry = state.dung_frameworks["aba_preferred"]
+        # The diagnostic: writer stored no attacks despite contraries being
+        # genuine structured input. Today: FAILS (entry["attacks"] == []).
+        attacks: List[List[str]] = entry.get("attacks", [])
+        assert attacks, (
+            "ABA writer dropped contraries-derived attacks: `attacks` is "
+            f"{attacks!r} but contraries={ctx['contraries']!r} indicate "
+            "non-empty binary attack relations."
+        )
+
+    def test_aba_writer_or_sidecar_carries_contraries(self):
+        """Stretch assertion: even if `attacks` stays empty, the contraries
+        themselves must reach the state (via extensions or a sidecar)."""
+        state = _new_state()
+        output = self._stub_handler_output()
+        ctx = {"contraries": {"a": "b", "b": "a", "c": "a"}}
+
+        _write_aba_to_state(output, state, ctx)
+
+        entry = state.dung_frameworks["aba_preferred"]
+        # Look for contraries anywhere the state carries them today or
+        # in a future formalism-specific sidecar.
+        extensions = entry.get("extensions", {})
+        formalism_specific = entry.get("formalism_specific", {})
+        has_contraries = (
+            "contraries" in extensions
+            or "contraries" in formalism_specific
+            or extensions.get("aba_extensions") == ctx["contraries"]
+        )
+        assert has_contraries, (
+            "ABA writer dropped contraries from extensions/sidecar: "
+            f"extensions={extensions!r}, formalism_specific={formalism_specific!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SetAF — writer drops joint attacks that the handler returns (Section 2.3)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSetafFlattening1648:
+    """SetAF handler returns joint attacks; writer hardcodes ``attacks=[]``.
+
+    Section 2.3: ``handler.analyze_setaf`` returns ``attacks`` at
+    ``setaf_handler.py:123`` as ``List[{attackers: List[str], target: str}]``.
+    Writer at ``state_writers.py:1199-1209`` ignores them with the comment
+    "set attacks don't map to binary attacks".
+
+    Today's expected failure: ``state.dung_frameworks[<id>]["attacks"]`` is
+    ``[]`` and the joint-attack list is not in ``extensions`` either.
+    """
+
+    def _stub_handler_output(self) -> Dict[str, Any]:
+        return {
+            "semantics": "grounded",
+            "arguments": ["a", "b", "c"],
+            "attacks": [
+                {"attackers": ["a", "b"], "target": "c"},
+                {"attackers": ["a"], "target": "b"},
+            ],
+            "extensions": [["a"]],
+            "extensions_count": 1,
+            "statistics": {"arguments_count": 3, "attacks_count": 2},
+        }
+
+    def test_setaf_writer_preserves_set_attacks(self):
+        state = _new_state()
+        output = self._stub_handler_output()
+
+        _write_setaf_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        extensions = entry.get("extensions", {})
+        formalism_specific = entry.get("formalism_specific", {})
+        # The joint-attack list must survive somewhere.
+        has_set_attacks = (
+            extensions.get("set_attacks") == output["attacks"]
+            or "set_attacks" in extensions
+            or formalism_specific.get("set_attacks") == output["attacks"]
+        )
+        assert has_set_attacks, (
+            "SetAF writer dropped joint attacks (handler returned them): "
+            f"extensions={extensions!r}, formalism_specific={formalism_specific!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ADF — writer is correct (no binary attacks), but acceptance conditions
+# are lost upstream of the writer (Section 2.2). This test pins the
+# *current correct* behaviour on the writer and documents the upstream gap.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAdfFlattening1648:
+    """ADF has no binary attacks — ``attacks=[]`` is the correct projection.
+
+    Section 2.2: the writer's ``attacks=[]`` is formally correct. The
+    distinctive ADF data (acceptance conditions, interpretations) is lost
+    upstream of the writer. This test pins the writer-side contract so a
+    future refactor that tries to "fix" ADF attacks breaks it visibly.
+    """
+
+    def test_adf_attacks_stay_empty_and_acceptance_conditions_acknowledged(self):
+        state = _new_state()
+        output = {
+            "semantics": "grounded",
+            "statements": ["p", "q"],
+            "interpretations": ["{p=T,q=F}", "{p=F,q=F}"],
+            "statistics": {"statements_count": 2, "interpretations_count": 2},
+        }
+
+        _write_adf_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        # Writer-side contract: attacks stay empty (ADF has none).
+        assert entry["attacks"] == [], (
+            f"ADF writer unexpectedly produced attacks={entry['attacks']!r}"
+        )
+        # Distinct ADF data (interpretations) IS preserved via extensions.
+        # If a future refactor drops them, this assertion fires.
+        assert "adf_models" in entry["extensions"], (
+            f"ADF writer dropped interpretations: extensions={entry['extensions']!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Weighted — handler returns weights, writer drops them (Section 1.1 #4)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestWeightedFlattening1648:
+    """Weighted writer extracts only ``[src, tgt]`` from each attack dict.
+
+    The handler returns ``output["attacks"]`` as ``List[{source, target, weight}]``
+    but the writer at ``state_writers.py:1212-1226`` projects to ``[src, tgt]``
+    pairs only. The weight is invisible to readers.
+    """
+
+    def test_weighted_writer_preserves_attack_weights(self):
+        state = _new_state()
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b", "c"],
+            "attacks": [
+                {"source": "a", "target": "b", "weight": 0.9},
+                {"source": "b", "target": "c", "weight": 0.5},
+            ],
+            "extensions": [["a", "c"]],
+        }
+
+        _write_weighted_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        extensions = entry.get("extensions", {})
+        formalism_specific = entry.get("formalism_specific", {})
+        has_weights = (
+            extensions.get("weights") is not None
+            or "weights" in extensions
+            or "weights" in formalism_specific
+            or any(len(pair) > 2 for pair in entry["attacks"])  # weight in pair
+        )
+        assert has_weights, (
+            f"Weighted writer dropped attack weights: attacks={entry['attacks']!r}, "
+            f"extensions={extensions!r}, formalism_specific={formalism_specific!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Social — handler returns scores/votes, writer stashes them in extensions
+# (Section 1.1 #5). Today the writer is honest (carries them in extensions).
+# This test pins the current behaviour so a refactor that "cleans up"
+# extensions doesn't silently drop them.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSocialFlattening1648:
+    """Social writer carries scores/votes in extensions — pin the contract."""
+
+    def test_social_writer_preserves_scores_and_votes(self):
+        state = _new_state()
+        output = {
+            "ranking": ["a", "b"],
+            "scores": {"a": 1.0, "b": 0.5},
+            "arguments": ["a", "b"],
+            "attacks": [["a", "b"]],
+        }
+
+        _write_social_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        extensions = entry.get("extensions", {})
+        # Today's behaviour: scores live in extensions under "social_scores".
+        # If a future writer refactor drops them, this assertion fires.
+        assert extensions.get("social_scores") == output["scores"], (
+            f"Social writer dropped scores: extensions={extensions!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# EAF — epistemic beliefs dropped (Section 1.1 #6)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestEafFlattening1648:
+    """EAF writer drops per-agent epistemic beliefs."""
+
+    def test_eaf_writer_preserves_epistemic_beliefs(self):
+        state = _new_state()
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "attacks": [["a", "b"]],
+            "extensions": [["a"]],
+            "epistemic_beliefs": {"agent1": ["a"], "agent2": ["b"]},
+        }
+
+        _write_eaf_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        extensions = entry.get("extensions", {})
+        formalism_specific = entry.get("formalism_specific", {})
+        has_beliefs = (
+            "epistemic_beliefs" in extensions
+            or "epistemic_beliefs" in formalism_specific
+            or extensions.get("eaf_beliefs") == output["epistemic_beliefs"]
+        )
+        assert has_beliefs, (
+            f"EAF writer dropped epistemic beliefs: extensions={extensions!r}, "
+            f"formalism_specific={formalism_specific!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DeLP — whole formalism flattened away (Section 2.4)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDelpFlattening1648:
+    """DeLP writer produces empty arguments/attacks; only query_results survive.
+
+    The dialectical tree, defeat relations, and comparison criterion are all
+    gone. This is the deepest flattening in the inventory.
+    """
+
+    def test_delp_writer_preserves_argument_graph_or_defeat_relations(self):
+        state = _new_state()
+        output = {
+            "program": [{"head": "a", "body": []}],
+            "program_size": 1,
+            "criterion": "specificity",
+            "query_results": [
+                {"query": "a", "answer": "warranted", "message": "ok"}
+            ],
+        }
+
+        _write_delp_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        extensions = entry.get("extensions", {})
+        formalism_specific = entry.get("formalism_specific", {})
+        # Either the dialectical tree reaches the state, or at least the
+        # defeat relations are preserved. Today: NEITHER — assertion fails.
+        has_structure = (
+            extensions.get("delp_arguments") == output["program"]
+            or extensions.get("defeat_relations") is not None
+            or "delp_arguments" in extensions
+            or "delp_arguments" in formalism_specific
+            or "defeat_relations" in formalism_specific
+        )
+        assert has_structure, (
+            f"DeLP writer flattened away the argument graph and defeat "
+            f"relations: extensions={extensions!r}, "
+            f"formalism_specific={formalism_specific!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DL — full ontology dropped (Section 1.2 #10)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDlFlattening1648:
+    """DL writer stores only ``[f"DL: {message}"]`` as formulas.
+
+    TBox, ABox, subsumptions are all gone (counted at invoke but never written).
+    """
+
+    def test_dl_writer_preserves_ontology_structure(self):
+        state = _new_state()
+        output = {
+            "consistent": True,
+            "message": "consistent",
+            "tbox": [("Human", "Mammal")],
+            "abox_concepts": [("alice", "Human")],
+            "abox_roles": [("alice", "hasPet", "bob")],
+        }
+
+        _write_dl_to_state(output, state, {})
+
+        fol = state.fol_analysis_results
+        assert fol, "DL writer produced no entry"
+        entry = fol[0]
+        # Today: entry["formulas"] is just ["DL: consistent"] — synthesised.
+        # After remedy: TBox / ABox should survive in extensions or sidecar.
+        extensions = entry.get("extensions", {})
+        formalism_specific = entry.get("formalism_specific", {})
+        has_structure = (
+            "tbox" in extensions
+            or "tbox" in formalism_specific
+            or extensions.get("tbox") == output["tbox"]
+        )
+        assert has_structure, (
+            f"DL writer dropped ontology: extensions={extensions!r}, "
+            f"formalism_specific={formalism_specific!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CL — conditionals dropped (Section 1.3 #11)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestClFlattening1648:
+    """CL writer stores only ``[f"CL(N): {msg}"]`` as formulas."""
+
+    def test_cl_writer_preserves_conditionals(self):
+        state = _new_state()
+        output = {
+            "entailed": True,
+            "message": "ok",
+            "conditionals": [
+                {"conclusion": "P", "premise": "Q"},
+                {"conclusion": "R", "premise": "S"},
+            ],
+        }
+
+        _write_cl_to_state(output, state, {"conditionals": output["conditionals"]})
+
+        pl = state.propositional_analysis_results
+        assert pl, "CL writer produced no entry"
+        entry = pl[0]
+        extensions = entry.get("extensions", {})
+        formalism_specific = entry.get("formalism_specific", {})
+        has_conditionals = (
+            "conditionals" in extensions
+            or "conditionals" in formalism_specific
+            or extensions.get("cl_conditionals") == output["conditionals"]
+        )
+        assert has_conditionals, (
+            f"CL writer dropped conditionals: extensions={extensions!r}, "
+            f"formalism_specific={formalism_specific!r}"
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# QBF — quantifiers dropped (Section 1.3 #13)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestQbfFlattening1648:
+    """QBF writer drops the alternating quantifier structure."""
+
+    def test_qbf_writer_preserves_quantifiers(self):
+        state = _new_state()
+        output = {
+            "valid": True,
+            "formula": "exists x. forall y. P(x,y)",
+            "quantifiers": [
+                {"type": "exists", "vars": ["x"]},
+                {"type": "forall", "vars": ["y"]},
+            ],
+        }
+
+        _write_qbf_to_state(output, state, {})
+
+        pl = state.propositional_analysis_results
+        assert pl, "QBF writer produced no entry"
+        entry = pl[0]
+        extensions = entry.get("extensions", {})
+        formalism_specific = entry.get("formalism_specific", {})
+        has_quantifiers = (
+            "quantifiers" in extensions
+            or "quantifiers" in formalism_specific
+            or extensions.get("qbf_quantifiers") == output["quantifiers"]
+        )
+        assert has_quantifiers, (
+            f"QBF writer dropped quantifier structure: extensions={extensions!r}, "
+            f"formalism_specific={formalism_specific!r}"
+        )


### PR DESCRIPTION
Investigation deliverable for issue #1648 (Epic #1644 Wave-1, modules inertes). No fix lands in this PR — the inventory is what unblocks #1645/#1647/#1649 dispatch (per R763: 'C'est l'issue qui débloque #1645/#1647/#1649 — elle passe donc devant').

## What this PR adds

1. **docs/reports/1648-flattening-inventory.md** (528 lines)
2. **tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py** (410 lines, 10 test classes)

## Verdicts

### `attacks=[]` verdict per site

| Site | Source | Verdict |
|------|--------|---------|
| ABA | state_writers.py:843 | **REAL LOSS** (handler successful, writer drops) |
| ADF | state_writers.py:859 | **FORMALLY CORRECT** (ADF has no binary attacks) |
| SetAF | state_writers.py:1207 | **REAL LOSS** (handler returns joint attacks, writer drops) |
| Weighted | state_writers.py:1212-1226 | **REAL LOSS** (handler returns weight, writer drops) |
| Social | state_writers.py:1229-1240 | **OK** (scores preserved in extensions) |
| EAF | state_writers.py:1243-1252 | **REAL LOSS** (epistemic beliefs dropped) |
| DeLP | state_writers.py:1255-1265 | **DEEPEST FLATTENING** (program + defeat gone) |
| DL | state_writers.py:1144-1160 | **REAL LOSS** (TBox/ABox/subsumptions gone) |
| CL | state_writers.py:1163-1174 | **REAL LOSS** (conditionals dropped) |
| QBF | state_writers.py:1268-1276 | **REAL LOSS** (quantifier structure dropped) |

### Reader impact (cascade)

- **pattern_mining.py:402-418** — corpus-level `dung_unsupported` undercounts because flatteners contribute `attacks=[]`
- **deep_synthesis_agent.py:587-603** — picks first framework; ABA's `extensions=aba_extensions` (not `grounded`/`preferred`) → false 'empty grounded extension' in narrative
- 12 readers of `dung_frameworks`, 3 of FOL, 3 of Prop — all silent about the loss

### Recommended fix (Option 2)

Enriched container with `formalism_specific` sidecar — **strictly additive**, no reader migration required. Affects the canonical `state.dung_frameworks[entry]` shape only, leaving `attacks` / `extensions` projections intact.

## Anti-#1019 discipline

Tests use **real writers** (`_write_aba_to_state` etc.) + **real handler stubs** (return-value mocking is the #1019 theater pattern).

| Class | Site | Today (test outcome) |
|-------|------|----------------------|
| TestAbaFlattening1648 | ABA | **XFAIL** (handler drops contraries — strict=True, will fail loudly when Wave-2 fixes arrive) |
| TestSetafFlattening1648 | SetAF | **XFAIL** (writer drops joint attacks) |
| TestAdfFlattening1648 | ADF | **PASS** (correct contract — pin today) |
| TestWeightedFlattening1648 | Weighted | **XFAIL** |
| TestSocialFlattening1648 | Social | **PASS** (correct contract — pin today) |
| TestEafFlattening1648 | EAF | **XFAIL** |
| TestDelpFlattening1648 | DeLP | **XFAIL** |
| TestDlFlattening1648 | DL | **XFAIL** |
| TestClFlattening1648 | CL | **XFAIL** |
| TestQbfFlattening1648 | QBF | **XFAIL** |

The 9 XFAIL tests are pinned with **`strict=True`** — when Wave-2 actually fixes the bug, the test will fail loudly (xfail + actual pass = strict failure), forcing removal of the marker. Without strict=True, a real fix would silently flip xfail to xpass and the bug would be 'fixed' without the test proving it.

The 2 PASS tests **pin today's correct behavior** — they fail if a future refactor wrongly 'fixes' ADF or removes social scores.

## Why no fix

Per dispatch R763, this issue is the **predecessor** that unblocks Wave-1 siblings. The fix (Option 2 sidecar) is listed in the inventory but explicitly out of scope — Wave-2 would land it issue-by-issue.

## Privacy

No source names on GitHub-indexed surfaces. Synthetic atoms only (a, b, c, p, q). Opaque IDs throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>