### PR TITLE
fix(state): compute "evaluated" from the handler output, not the input (#1671)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -1059,6 +1059,19 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         - ``"absent_no_translator"`` — legacy/#1236 honest-absent label for the
           rare path where no cause was recorded (nothing wired). The capability
           ran on auto-shaped synthetic input. ``degraded`` is ``True``.
+        - ``"evaluated_empty"`` (#1671) — genuine structured input WAS supplied
+          and the framework ran, but it came back with no non-empty result set
+          (or reported itself degraded). ``degraded`` is ``True``: the axis
+          accepted, excluded and arbitrated nothing, so it contributed no
+          analysis and must not be counted among the capabilities used.
+          Distinct from ``no_genuine_relations``, which is a statement about the
+          *source* (the translator found nothing to translate); this one is a
+          statement about the *reasoning step* on input that did exist.
+
+        ``extension_count`` is how many result sets came back, not how much they
+        contain: ``[[]]`` is one extension and is reported as ``1``. It is a
+        description, never a verdict — the ``evaluated`` / ``evaluated_empty``
+        split is decided by the members' contents, not by this number.
 
         This only *labels* what happened; it never fabricates extensions
         (#1019). Keyed by ``capability`` (last write wins — one status per

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -135,6 +135,30 @@ def _resolve_absent_status(
     )
 
 
+def _structured_arg_substantive_members(output: Any) -> int:
+    """Count the NON-EMPTY result sets a structured-arg handler returned (#1671).
+
+    ``extension_count`` answers "how many result sets came back", and ``[[]]``
+    genuinely *is* one extension — so that field is correct as it stands. What it
+    cannot do is decide anything: a framework returning a single EMPTY extension
+    has accepted nothing, excluded nothing and arbitrated nothing. Measured on
+    real state artefacts, four of the five axes come back as ``[[]]`` — one
+    result set, empty — which ``len()`` reports as ``1``.
+
+    This counts what the members *contain* rather than how many there are, and
+    is used only to decide the status label, never recorded as a metric of its
+    own (counting is not deciding).
+    """
+    if not isinstance(output, dict):
+        return 0
+    members = output.get("extensions")
+    if members is None:
+        members = output.get("supports")
+    if not isinstance(members, list):
+        return 0
+    return sum(1 for member in members if member)
+
+
 def _record_structured_arg_status(
     state: Any, capability: str, output: Any, ctx: dict[str, Any]
 ) -> None:
@@ -148,6 +172,26 @@ def _record_structured_arg_status(
     #1236-era ``absent_no_translator`` catch-all that asserted a cause it had
     not observed. Only labels what happened; never fabricates extensions (#1019).
     No-op on states that predate ``add_structured_arg_status`` (defensive).
+
+    #1671 — the ``has_genuine_input`` branch used to be the mirror image of the
+    defect #1608 fixed on the other branch: it asserted *"framework evaluated on
+    real structured artifacts"* while observing only that an INPUT key was
+    present. Nothing in it looked at what came back. Measured on real state
+    artefacts, four of the five axes reached that branch with
+    ``extensions == [[]]`` — the handler had not failed, it had *succeeded on an
+    empty theory* — and were filed ``evaluated / degraded=False``. Such an axis
+    is then invisible in both directions: the absence ledger skips it (it is not
+    degraded) and the presence channel finds nothing to project. The branch now
+    reads the output and splits into ``evaluated`` (a non-empty result set came
+    back) and ``evaluated_empty`` (the handler ran and returned nothing
+    substantive, or reported itself degraded).
+
+    Anti-pendulum: ``evaluated_empty`` is deliberately NOT the same thing as
+    ``no_genuine_relations``. The latter is a statement about the *source* — the
+    translator looked and found no such relations, an analytical result, hence
+    ``degraded=False``. This one is a statement about the *reasoning step*: the
+    translator did supply relations and the framework still produced nothing, so
+    the axis contributed no analysis and must not be counted as used.
     """
     recorder = getattr(state, "add_structured_arg_status", None)
     if not callable(recorder):
@@ -163,14 +207,33 @@ def _record_structured_arg_status(
         if isinstance(exts, list):
             ext_count = len(exts)
     if has_genuine_input:
-        recorder(
-            capability,
-            "evaluated",
-            False,
-            "Genuine structured input supplied via context; framework "
-            "evaluated on real structured artifacts.",
-            ext_count,
-        )
+        handler_degraded = bool(isinstance(output, dict) and output.get("degraded"))
+        substantive = _structured_arg_substantive_members(output)
+        if not handler_degraded and substantive:
+            recorder(
+                capability,
+                "evaluated",
+                False,
+                "Genuine structured input supplied via context; the framework "
+                f"returned {substantive} non-empty result set(s).",
+                ext_count,
+            )
+            return
+        formalism = _STRUCTURED_ARG_FORMALISM_NAME.get(capability, capability)
+        if handler_degraded:
+            reason = (
+                f"Genuine structured input was supplied, but the {formalism} "
+                "handler reported a degraded result — no reasoning was performed "
+                "on that input."
+            )
+        else:
+            reason = (
+                f"Genuine structured input was supplied, but the {formalism} "
+                f"framework returned no non-empty result set ({ext_count} "
+                "returned, all empty) — nothing was accepted, excluded or "
+                "arbitrated."
+            )
+        recorder(capability, "evaluated_empty", True, reason, ext_count)
         return
     # No genuine input — discriminate the cause (#1608). The invoke callable
     # that ran the translator wrote the cause into ctx. Falls back to

--- a/tests/unit/argumentation_analysis/orchestration/test_structured_arg_evaluated_from_observation_1671.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_structured_arg_evaluated_from_observation_1671.py
@@ -1,0 +1,227 @@
+"""#1671 — ``evaluated`` must be computed from an observation, not from an input.
+
+The ``has_genuine_input`` branch of ``_record_structured_arg_status`` used to
+write *"framework evaluated on real structured artifacts"* while observing only
+that an INPUT key was present in the context. Nothing in it looked at what the
+handler returned.
+
+That is not a latent defect. Measured on the real state artefacts, four of the
+five axes reach that branch with ``extensions == [[]]`` — the handler did not
+raise, it *succeeded on an empty theory* — and were filed
+``evaluated / degraded=False``. Such an axis is invisible in both directions: the
+absence ledger skips it (not degraded) and the presence channel finds nothing to
+project.
+
+The condition these tests establish and that no pre-existing fixture posed: a
+genuine input present **and** an output carrying nothing. That pair is why the
+branch was never armed.
+
+No JVM, no LLM. Synthetic atoms only (privacy HARD — no corpus tokens).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.orchestration.state_writers import (
+    _record_structured_arg_status,
+)
+from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+    _collect_absent_dimensions,
+)
+
+# One genuine-structured-input context per capability, keyed exactly as
+# ``_STRUCTURED_ARG_INPUT_KEYS`` expects. Every one of these makes
+# ``has_genuine_input`` true, which is the branch under test.
+_GENUINE_CTX: Dict[str, Dict[str, Any]] = {
+    "aspic_plus_reasoning": {"defeasible_rules": [{"head": "h", "body": ["b"]}]},
+    "aba_reasoning": {"contraries": {"a": "not_a"}},
+    "setaf_reasoning": {"set_attacks": [{"attackers": ["a", "b"], "target": "c"}]},
+    "weighted_argumentation": {"weighted_attacks": [("a", "b", 0.9)]},
+    "bipolar_argumentation": {"supports": [["a", "b"]]},
+}
+
+_CAPABILITIES = sorted(_GENUINE_CTX)
+
+
+def _new_state() -> UnifiedAnalysisState:
+    return UnifiedAnalysisState("synthetic structured-arg probe")
+
+
+class TestEmptyResultIsNotAnEvaluation:
+    """The pair no fixture posed: genuine input present, output carrying nothing."""
+
+    @pytest.mark.parametrize("capability", _CAPABILITIES)
+    def test_single_empty_extension_is_not_evaluated(self, capability):
+        # The exact shape measured on real artefacts: one result set, empty.
+        state = _new_state()
+        _record_structured_arg_status(
+            state, capability, {"extensions": [[]]}, _GENUINE_CTX[capability]
+        )
+        entry = state.structured_arg_status[capability]
+        assert entry["status"] == "evaluated_empty"
+        assert entry["degraded"] is True
+
+    @pytest.mark.parametrize("capability", _CAPABILITIES)
+    def test_no_result_set_at_all_is_not_evaluated(self, capability):
+        state = _new_state()
+        _record_structured_arg_status(
+            state, capability, {"extensions": []}, _GENUINE_CTX[capability]
+        )
+        assert state.structured_arg_status[capability]["status"] == "evaluated_empty"
+
+    @pytest.mark.parametrize("capability", _CAPABILITIES)
+    def test_handler_reporting_degraded_is_not_evaluated(self, capability):
+        # The second route to the same false label: the honest-degraded migration
+        # turns handler ``raise`` into a degraded return. Input is still genuine.
+        state = _new_state()
+        _record_structured_arg_status(
+            state,
+            capability,
+            {"degraded": True, "extensions": [["a", "b"]]},
+            _GENUINE_CTX[capability],
+        )
+        entry = state.structured_arg_status[capability]
+        assert entry["status"] == "evaluated_empty"
+        assert entry["degraded"] is True
+
+    @pytest.mark.parametrize("capability", _CAPABILITIES)
+    def test_reason_asserts_only_what_was_observed(self, capability):
+        state = _new_state()
+        _record_structured_arg_status(
+            state, capability, {"extensions": [[]]}, _GENUINE_CTX[capability]
+        )
+        reason = state.structured_arg_status[capability]["reason"]
+        # The pre-#1671 sentence claimed an evaluation nothing had observed.
+        assert "evaluated on real structured artifacts" not in reason
+        assert "no non-empty result set" in reason
+
+
+class TestSubstantiveResultStaysEvaluated:
+    """Anti-pendulum: repairing the false positive must not paint everything red."""
+
+    @pytest.mark.parametrize("capability", _CAPABILITIES)
+    def test_non_empty_extension_is_evaluated(self, capability):
+        state = _new_state()
+        _record_structured_arg_status(
+            state,
+            capability,
+            {"extensions": [["a", "b"], ["c"]]},
+            _GENUINE_CTX[capability],
+        )
+        entry = state.structured_arg_status[capability]
+        assert entry["status"] == "evaluated"
+        assert entry["degraded"] is False
+
+    def test_supports_carry_the_result_when_extensions_absent(self):
+        # Bipolar reports under "supports", not "extensions" — the only axis that
+        # comes back substantive on every real artefact measured.
+        state = _new_state()
+        _record_structured_arg_status(
+            state,
+            "bipolar_argumentation",
+            {"supports": [["a", "b"], ["b", "c"]]},
+            _GENUINE_CTX["bipolar_argumentation"],
+        )
+        entry = state.structured_arg_status["bipolar_argumentation"]
+        assert entry["status"] == "evaluated"
+        assert entry["degraded"] is False
+
+    @pytest.mark.parametrize("capability", _CAPABILITIES)
+    def test_absent_input_path_is_untouched(self, capability):
+        # #1608 owns the other branch; #1671 must not reach into it.
+        state = _new_state()
+        _record_structured_arg_status(state, capability, {"extensions": [[]]}, {})
+        assert state.structured_arg_status[capability]["status"] != "evaluated_empty"
+
+
+class TestExtensionCountKeepsItsMeaning:
+    """``extension_count`` describes; it does not decide."""
+
+    def test_one_empty_extension_still_counts_as_one(self):
+        state = _new_state()
+        _record_structured_arg_status(
+            state,
+            "aspic_plus_reasoning",
+            {"extensions": [[]]},
+            _GENUINE_CTX["aspic_plus_reasoning"],
+        )
+        entry = state.structured_arg_status["aspic_plus_reasoning"]
+        # len([[]]) == 1 is the right answer to "how many result sets came back".
+        assert entry["extension_count"] == 1
+        # ...and it is precisely why the count cannot carry the verdict.
+        assert entry["status"] == "evaluated_empty"
+
+    @pytest.mark.parametrize(
+        "output,expected",
+        [
+            ({"extensions": [[]]}, 0),
+            ({"extensions": []}, 0),
+            ({"extensions": [["a"], []]}, 1),
+            ({"extensions": [["a"], ["b", "c"]]}, 2),
+            ({"supports": [["a", "b"]]}, 1),
+            ({"supports": []}, 0),
+            ({}, 0),
+            (None, 0),
+            ({"extensions": "not-a-list"}, 0),
+        ],
+    )
+    def test_substantive_member_count(self, output, expected):
+        # Imported here, not at module scope: a module-level import of a helper
+        # that #1671 introduces would turn every test in this file into a
+        # collection error on the pre-fix code, and a collection error proves
+        # nothing about the assertions. The rest of the file must be able to run
+        # — and fail on its assertions — against the code it accuses.
+        from argumentation_analysis.orchestration.state_writers import (
+            _structured_arg_substantive_members,
+        )
+
+        assert _structured_arg_substantive_members(output) == expected
+
+
+class TestTheAxisBecomesVisibleDownstream:
+    """The consequence, not the label: pin the relation to the absence ledger."""
+
+    def test_vacuous_axis_reaches_the_absence_collector(self):
+        state = _new_state()
+        _record_structured_arg_status(
+            state,
+            "aspic_plus_reasoning",
+            {"extensions": [[]]},
+            _GENUINE_CTX["aspic_plus_reasoning"],
+        )
+        absent = _collect_absent_dimensions(state)
+        assert [d.capability for d in absent] == ["aspic_plus_reasoning"]
+        assert absent[0].status == "evaluated_empty"
+
+    def test_substantive_axis_stays_out_of_the_absence_collector(self):
+        state = _new_state()
+        _record_structured_arg_status(
+            state,
+            "aspic_plus_reasoning",
+            {"extensions": [["a"], ["b"]]},
+            _GENUINE_CTX["aspic_plus_reasoning"],
+        )
+        assert _collect_absent_dimensions(state) == []
+
+    def test_vacuous_axis_is_not_counted_among_capabilities_used(self):
+        from argumentation_analysis.orchestration.unified_pipeline import (
+            _collect_degraded_capabilities,
+        )
+
+        state = _new_state()
+        _record_structured_arg_status(
+            state,
+            "aspic_plus_reasoning",
+            {"extensions": [[]]},
+            _GENUINE_CTX["aspic_plus_reasoning"],
+        )
+        degraded, used = _collect_degraded_capabilities(
+            {}, state, ["aspic_plus_reasoning", "informal_analysis"]
+        )
+        assert "aspic_plus_reasoning" in degraded
+        assert "aspic_plus_reasoning" not in used
+        assert "informal_analysis" in used

--- a/tests/unit/argumentation_analysis/orchestration/test_structured_arg_honest_absent.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_structured_arg_honest_absent.py
@@ -43,7 +43,10 @@ _WRITERS = [
 ]
 
 # A genuine-structured-input context per capability (a future translator would
-# populate these keys). Presence of any flips the status to "evaluated".
+# populate these keys). Presence of any takes the writer down the
+# ``has_genuine_input`` branch; since #1671 the label on that branch is decided
+# by what the handler returned, so these fixtures pair the context with a
+# non-empty result set to land on "evaluated".
 _GENUINE_CTX: Dict[str, Dict[str, Any]] = {
     "aspic_plus_reasoning": {"strict_rules": [{"head": "h", "body": ["b"]}]},
     "aba_reasoning": {"contraries": {"a": "not_a"}},


### PR DESCRIPTION
Closes #1671.

## Le défaut n'est pas latent — il est vivant sur 4 axes sur 5

L'issue décrit la branche `has_genuine_input` de `_record_structured_arg_status` comme armable par la migration honest-degraded. La mesure sur les **8 artefacts d'état réels** dit plus : la branche est déjà prise, et par une route inattendue. Le handler ne *échoue* pas — il *réussit sur une théorie vide*.

Distribution relevée dans `structured_arg_status` **avant** ce correctif (8 artefacts) :

| capability | `evaluated`, `ext_count=1` | `absent_no_translator` | `evaluated`, comptes substantiels |
|---|---|---|---|
| `aspic_plus_reasoning` | 6 | 2 | 0 |
| `aba_reasoning` | 6 | 2 | 0 |
| `setaf_reasoning` | 2 | 6 | 0 |
| `weighted_argumentation` | 2 | 6 | 0 |
| `bipolar_argumentation` | 0 | 0 | 8 (4, 5, 8, 9) |

La chaîne causale, lisible sur la sortie ASPIC persistée (statistiques seules, aucun contenu) :

```
strict_rules_count: 5, defeasible_rules_count: 3, axioms_count: 0
  → 0 prémisse → 0 argument dérivable
  → extensions: [[]]
  → len([[]]) == 1 → ext_count = 1
  → "evaluated", degraded=False
```

Un axe dans cet état est **invisible dans les deux sens** : le registre d'absence le saute (il est gardé sur `degraded`) et le canal de présence n'a rien à projeter. Il ne reste que l'étiquette, qui affirme une évaluation que personne n'a observée.

## Les trois demandes de l'issue

1. **`"evaluated"` se calcule depuis une observation.** La branche lit maintenant la sortie : `degraded` rapporté par le handler, et le nombre d'ensembles-résultats **non vides** (`extensions`, à défaut `supports`). Le libellé en découle.
2. **Le motif n'affirme que ce qui est calculé.** La phrase *« framework evaluated on real structured artifacts »* disparaît. À la place, soit `« the framework returned N non-empty result set(s) »`, soit `« returned no non-empty result set (1 returned, all empty) — nothing was accepted, excluded or arbitrated »`, soit, si le handler s'est déclaré dégradé, `« the handler reported a degraded result — no reasoning was performed on that input »`.
3. **Un test qui pose les deux conditions ensemble.** `TestEmptyResultIsNotAnEvaluation` paramètre sur les 5 capacités : intrant générique présent **et** sortie sans contenu (une extension vide / aucun ensemble / handler dégradé). C'est le couple qu'aucune fixture existante ne posait, et la raison pour laquelle la branche n'était jamais armée.

## Anti-pendules respectés

- **Pas de retour au `raise`.** Le nouvel état s'écrit dans le registre, comme les autres ; aucun appelant ne voit d'exception.
- **Pas un compteur de plus.** `ext_count` est laissé **strictement inchangé** — `len([[]]) == 1` est la bonne réponse à *« combien d'ensembles-résultats sont revenus »*. Le nom du champ n'était pas faux ; c'est une **étiquette** qui traitait ce compte comme une preuve. Compter n'est pas décider. `TestExtensionCountKeepsItsMeaning` épingle les deux faits ensemble : `ext_count == 1` **et** `status == "evaluated_empty"` sur la même entrée.
- **Pas de troisième état bricolé par axe.** Les 5 capacités passent par la même fonction ; le correctif y reste, et les 4 consommateurs du registre commutent sur `degraded`, pas sur la chaîne de statut — la nouvelle valeur se propage donc sans changement chez eux.

Un anti-pendule s'ajoute, écrit dans le docstring : `evaluated_empty` **n'est pas** `no_genuine_relations`. Le second parle de la **source** (le traducteur n'a rien trouvé à traduire — `degraded=False`, c'est un résultat d'analyse). Le premier parle de l'**étape de raisonnement**, sur un intrant qui, lui, existait.

## Vérification

| Contrôle | Résultat |
|---|---|
| Nouveaux tests (44) | 44 passed |
| **Contrôle d'attribution** — production revertée, tests conservés | 32 failed / 12 passed, dont **23 `AssertionError`** + 9 `ImportError` |
| Rejeu des 8 formes de sortie réelles à travers le writer réparé | **8/8** `evaluated_empty`, `degraded=True`, `ext_count=1` |
| Régression consommateurs (`honest_absent`, `degradation_1608`, `translator`, `unified_pipeline`, tout `reporting/restitution/`) | 681 passed |
| `grep` de l'ancienne phrase dans l'arbre | plus qu'une occurrence, dans le test qui interdit son retour |

L'`ImportError` du contrôle d'attribution concerne les 9 cas paramétrés du helper introduit ici ; son import est **délibérément local à ce seul test** pour que les 35 autres puissent tourner — et échouer **sur leurs assertions** — contre le code qu'ils accusent. Une erreur de collecte ne prouverait rien.

## Non-changement délibéré

`act3_conclusion_plugin` rend l'absence par `f"  - {label} : NON ÉVALUÉE ({status}). {reason}"`. Il affichera donc `NON ÉVALUÉE (evaluated_empty)` sans modification. Ce rendu est resté générique **exprès** : tous les statuts y passent en snake_case brut, et particulariser celui-ci encoderait la sémantique des statuts à un deuxième endroit.

## Privacy

Aucun contenu de corpus dans le diff, le message de commit ou ce corps : les artefacts réels ne sont cités que par leurs compteurs. Les tests n'utilisent que des atomes synthétiques (`a`, `b`, `c`, `h`).

🤖 Coordinator ai-01
