### PR TITLE
fix(annexe): attest what the conclusion actually read, not just what existed (#1624)

### DIFF
--- a/argumentation_analysis/reporting/restitution/appendix.py
+++ b/argumentation_analysis/reporting/restitution/appendix.py
@@ -34,6 +34,77 @@ _LEAK_KEYS = (
 )
 
 
+# #1624 — the appendix attests *availability*; the conducted prose is built from
+# a DIFFERENT reading list (``build_act{1,2,3}_evidence``). A row saying only
+# "disponible" therefore reads as "this backed the conclusion", which is the
+# inverse of the truth for the rows the prose never opens: the report looks
+# better informed than it is. Each rendered dimension declares here whether the
+# prose reads its state key, and by which act.
+#
+# Three kinds, giving the three states of #1624 once composed with the value
+# column (absent / present-and-mobilised / present-not-mobilised):
+#
+# * ``prose`` — the conclusion reads this key when it carries something.
+# * ``failure_only`` — the key reaches the prose through ONE branch, the one that
+#   reports the axis as lost. A run where the axis works is mute in the
+#   conclusion; a run where it degrades gains a sentence. Attesting that as plain
+#   "mobilisée" would read exactly backwards.
+# * ``none`` — attested by the appendix, never read by the prose.
+#
+# Anti-pendule: this literal is NOT imported from the act plugins, and they do
+# not import it. The file-disjoint wiring is deliberate (``state_adapter.py``
+# l.6-8) and mutualising a constant would recreate the coupling the adapter
+# exists to avoid. The accord between this declaration and what the prose
+# actually reads is carried by ``test_two_reading_surfaces_1624.py``, which
+# checks it against an AST sweep of the three act modules — same shape as the
+# #1619 corrective.
+_MOBILISATION: Dict[str, tuple] = {
+    # dimension              state key(s)                        kind         site
+    "arguments_extraits": (("identified_arguments",), "prose", "actes I–III"),
+    "sophismes_localises": (("identified_fallacies",), "prose", "actes II–III"),
+    "contre_arguments": (("counter_arguments",), "prose", "actes II–III"),
+    "scores_qualite": (("argument_quality_scores",), "prose", "actes II–III"),
+    "axe_fol": (("fol_analysis_results",), "prose", "actes II–III"),
+    "axe_pl": (("propositional_analysis_results",), "prose", "actes II–III"),
+    "axe_modale": (("modal_analysis_results",), "prose", "acte II"),
+    "axe_dung": (("dung_frameworks",), "prose", "actes II–III"),
+    "axe_aspic": (("aspic_results",), "prose", "acte III"),
+    "axe_bipolaire": (("bipolar_results",), "prose", "acte III"),
+    "deliberation": (("debate_transcripts",), "prose", "actes II–III"),
+    "gouvernance": (("governance_decisions",), "prose", "actes II–III"),
+    "arg_structuree": (("structured_arg_status",), "failure_only", "acte III"),
+    "synthese_narrative": (("narrative_synthesis", "final_conclusion"), "none", ""),
+    "synthese_formelle": (("formal_synthesis_reports",), "none", ""),
+}
+
+_MOBILISATION_LABEL = {
+    "prose": "mobilisée ({site})",
+    "failure_only": "mobilisée par l'{site} seulement si l'axe échoue",
+    "none": "**non mobilisée** — attestée ici, jamais lue par la conclusion",
+}
+
+
+def _mobilisation_notes(state: Mapping[str, Any]) -> Dict[str, str]:
+    """Per-dimension mobilisation cell for the appendix table (#1624).
+
+    Returns one entry per key of :data:`_MOBILISATION`. A dimension carrying
+    nothing gets ``"—"``: mobilisation of an absent axis is not a fact about the
+    report, and asserting either way there would be the same over-claim this
+    column exists to remove.
+
+    Kept out of :func:`_provenance_counts` on purpose — that function's return
+    shape is consumed by callers and tests that want the value alone.
+    """
+    notes: Dict[str, str] = {}
+    for dimension, (keys, kind, site) in _MOBILISATION.items():
+        present = any(state.get(key) for key in keys)
+        if not present:
+            notes[dimension] = "—"
+            continue
+        notes[dimension] = _MOBILISATION_LABEL[kind].format(site=site)
+    return notes
+
+
 def _strip_leak_keys(state: Mapping[str, Any]) -> Dict[str, Any]:
     """Return a copy of ``state`` with leak-capable top-level keys removed."""
     out: Dict[str, Any] = {}
@@ -136,9 +207,7 @@ def _modal_axis_status(modal: Any) -> Any:
         decided = [
             r for r in modal if isinstance(r, dict) and r.get("valid") in (True, False)
         ]
-        degraded = [
-            r for r in modal if isinstance(r, dict) and r.get("valid") is None
-        ]
+        degraded = [r for r in modal if isinstance(r, dict) and r.get("valid") is None]
         if decided:
             status: Dict[str, Any] = {
                 "verdict": "décidé",
@@ -182,9 +251,7 @@ def _pl_axis_status(pl: Any) -> Any:
         return "disponible" if pl else "indisponible"
     if isinstance(pl, list) and pl:
         decided = [r for r in pl if _pl_verdict_of(r) in (True, False)]
-        degraded = [
-            r for r in pl if isinstance(r, dict) and _pl_verdict_of(r) is None
-        ]
+        degraded = [r for r in pl if isinstance(r, dict) and _pl_verdict_of(r) is None]
         if decided:
             status: Dict[str, Any] = {
                 "verdict": "décidé",
@@ -223,6 +290,14 @@ def _provenance_counts(state: Mapping[str, Any]) -> Dict[str, Any]:
     counts["axe_modale"] = _modal_axis_status(_g("modal_analysis_results"))
     counts["axe_dung"] = "disponible" if _g("dung_frameworks") else "indisponible"
     counts["axe_aspic"] = "disponible" if _g("aspic_results") else "indisponible"
+    counts["axe_bipolaire"] = "disponible" if _g("bipolar_results") else "indisponible"
+
+    # #1624 item 3 — two axes the Actes II and III genuinely mobilise and that
+    # this table did not name at all. A coverage table that omits the
+    # deliberation and the governance vote understates precisely the material
+    # the conclusion leans on hardest.
+    counts["deliberation"] = _safe_len(_g("debate_transcripts", []))
+    counts["gouvernance"] = _safe_len(_g("governance_decisions", []))
 
     # Structured-argumentation honesty (FP-17 #1236). ASPIC+/ABA/SETAF/weighted/
     # bipolar have no text→structured translator wired (translation-gap FP-4
@@ -304,17 +379,30 @@ def render_appendix(
         )
 
     counts = _provenance_counts(state)
+    mobilisation = _mobilisation_notes(state)
     lines = [
         "\n<details>",
         "<summary>Annexe — provenance dimensionnelle ( repliée par défaut)</summary>",
         "",
         "Agrégats de traçabilité uniquement — pas de contenu de corpus.",
         "",
-        "| Dimension | Valeur |",
-        "|---|---|",
+        "La colonne *Mobilisation* dit si la conclusion a lu la dimension. Une "
+        "dimension disponible n'est pas nécessairement une dimension qui a nourri "
+        "le raisonnement : les deux surfaces de lecture de l'état sont distinctes "
+        "(#1624).",
+        "",
+        "| Dimension | Valeur | Mobilisation |",
+        "|---|---|---|",
     ]
     for label, value in counts.items():
-        lines.append(f"| {label} | {value} |")
+        # A dimension with no declaration is rendered "non déclarée" rather than
+        # blank: a silent empty cell reads as "nothing to say", which is the
+        # over-claim this column exists to remove. The test module pins the
+        # declaration table against the rendered rows, so the case is a guard,
+        # not an expected state.
+        lines.append(
+            f"| {label} | {value} | {mobilisation.get(label, 'non déclarée')} |"
+        )
     lines.append("")
 
     if include_full_state_json:

--- a/argumentation_analysis/reporting/restitution/state_adapter.py
+++ b/argumentation_analysis/reporting/restitution/state_adapter.py
@@ -28,6 +28,22 @@ _STATE_KEYS = (
     "modal_analysis_results",
     "dung_frameworks",
     "aspic_results",
+    # #1624 — three axes the PROSE mobilises that the appendix could not attest
+    # at all, not even as "indisponible": a report whose conclusion rests on the
+    # deliberation, on the governance vote and on the bipolar support relation
+    # carried no trace of any of them in its own coverage table. Carried here so
+    # the table can name them; the omission was the asymmetry, not a choice.
+    # ``bipolar_results`` reached the prose in #1667 (act3 presence channel) and
+    # was flagged there as owed to this issue.
+    "bipolar_results",
+    "debate_transcripts",
+    "governance_decisions",
+    # Deliberately NOT carried: ``deanonymized``. The prose reads it in all three
+    # acts, so it is on the prose surface — but it is a rendering *flag* (are
+    # entity names shown in clear?), not an analytical dimension. The appendix
+    # table attests what backs the narrative; a boolean about how names are
+    # printed has no "disponible / mobilisée" reading. Its absence from this
+    # tuple is the justification required by #1624 item 3, recorded at the site.
     "structured_arg_status",
     "narrative_synthesis",
     # #1620 — not a spec §2 axis of its own. The *synthesis* axis has two

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
@@ -25,7 +25,11 @@ Falsifiability — two degenerate substitutions with disjoint kill-sets:
   the key sits in the intersection since #1667, so ``prose - annexe`` GAINS it
   and ``test_annexe_prose_relation_is_pinned`` fails (``PROSE_ONLY`` does not
   list it). ``test_ast_prose_matches_baseline`` survives (it does not read
-  ``_STATE_KEYS``). Kill-set = {relation}.
+  ``_STATE_KEYS``). Kill-set = {relation, projection} — re-measured after
+  #1624 added ``test_every_declared_key_survives_the_projection``, which the
+  same substitution also trips. The claim was {relation} alone when written;
+  a falsifiability note that is never re-run decays exactly like the guard it
+  describes.
 * **Sub B** — delete the ``getattr(state, "deanonymized", ...)`` call in
   ``act1_framing_plugin.build_act1_evidence``: the AST extraction loses
   ``deanonymized``, so ``test_ast_prose_matches_baseline`` fails
@@ -33,15 +37,81 @@ Falsifiability — two degenerate substitutions with disjoint kill-sets:
   survives (it compares against the literal, not the AST). Kill-set = {baseline}.
 
 The two substitutions kill different tests, so neither assertion is vacuous.
+
+#1624 closes the annexe side: the appendix now attests the three axes the prose
+mobilises and it was silent about, and each rendered dimension declares whether
+the conclusion reads it (``appendix._MOBILISATION``). That declaration is a
+second claim about the same state, so it gets the same treatment — five more
+substitutions, each killing a different set:
+
+* **Sub C** — drop ``"debate_transcripts"`` from ``_STATE_KEYS``: kills the
+  relation, the projection guard, and the adapter test (3).
+* **Sub D** — declare ``arg_structuree`` a plain ``"prose"`` dimension instead
+  of ``"failure_only"``: kills exactly one test, the fourth-case guard. Nothing
+  else can see that mislabel, which is why it has its own assertion.
+* **Sub E** — declare ``synthese_formelle`` mobilised: kills the
+  declaration/AST agreement and the "present but unread" state (2).
+* **Sub F** — make ``_mobilisation_notes`` return ``"mobilisée"``
+  unconditionally: kills 6, i.e. every assertion about the column's content.
+  A constant column is the degenerate case the whole class exists to exclude.
+* **Sub G** — remove the ``gouvernance`` row from ``_provenance_counts``: kills
+  the declaration/row coverage and the two count assertions (3).
 """
 
 from __future__ import annotations
 
 import ast
 import pathlib
+from typing import Any, Dict
 
 from argumentation_analysis.reporting.restitution import state_adapter as _sa
-from argumentation_analysis.reporting.restitution.state_adapter import _STATE_KEYS
+from argumentation_analysis.reporting.restitution.appendix import (
+    _MOBILISATION,
+    _mobilisation_notes,
+    _provenance_counts,
+    render_appendix,
+)
+from argumentation_analysis.reporting.restitution.state_adapter import (
+    _STATE_KEYS,
+    state_to_appendix_mapping,
+)
+
+
+def _full_state() -> Dict[str, Any]:
+    """A projection where every declared dimension carries something.
+
+    Synthetic atoms only (privacy HARD — no corpus tokens). Shapes match what the
+    writers produce, not what is convenient: ``fol_analysis_results`` is the list
+    of per-theory dicts the #1290 reader expects, ``structured_arg_status`` the
+    per-capability ledger.
+    """
+    return {
+        "identified_arguments": {"a1": {}},
+        "identified_fallacies": {"f1": {}},
+        "counter_arguments": [{"strategy": "distinction"}],
+        "argument_quality_scores": {"a1": 0.7},
+        "fol_analysis_results": [{"consistent": True, "message": "ok"}],
+        "propositional_analysis_results": [{"consistent": True}],
+        "modal_analysis_results": [{"consistent": True}],
+        "dung_frameworks": {"dung_1": {"name": "dung_arbitration"}},
+        "aspic_results": [{"id": "aspic_1", "extensions": [["a"]]}],
+        "bipolar_results": [{"supports": [["a", "b"]]}],
+        "debate_transcripts": [{"turns": []}, {"turns": []}],
+        "governance_decisions": [{"method": "borda"}],
+        "structured_arg_status": {
+            "aspic_plus_reasoning": {
+                "capability": "aspic_plus_reasoning",
+                "status": "evaluated",
+                "degraded": False,
+                "reason": "",
+                "extension_count": 1,
+            }
+        },
+        "narrative_synthesis": "synthèse",
+        "final_conclusion": "conclusion",
+        "formal_synthesis_reports": [{"axis": "fol"}],
+    }
+
 
 # The prose modules live alongside state_adapter in the same package — locate
 # them via the package path rather than counting parents from this test file.
@@ -153,20 +223,17 @@ ANNEXE_ONLY = frozenset(
 # Axes the PROSE reads that the ANNEXE never attests — mobilised by the
 # conclusion but invisible to the appendix provenance table.
 #
-# ``bipolar_results`` joined in #1667 from the prose side only: the presence
-# channel projects its support relation into the Acte III prompt, but the key is
-# absent from ``_STATE_KEYS``, so the appendix cannot attest the axis at all —
-# not even as "indisponible". That asymmetry is a finding for #1624 (the annexe
-# side), deliberately NOT patched here: adding the key to ``_STATE_KEYS`` is a
-# change to the other surface and belongs to the issue that owns it.
-PROSE_ONLY = frozenset(
-    {
-        "bipolar_results",
-        "deanonymized",
-        "debate_transcripts",
-        "governance_decisions",
-    }
-)
+# This set held four keys until #1624 closed the annexe side. ``bipolar_results``
+# (which had joined the prose in #1667), ``debate_transcripts`` and
+# ``governance_decisions`` are now carried by ``_STATE_KEYS`` and rendered by
+# the appendix: a report whose conclusion leans on the deliberation and on the
+# governance vote no longer omits both from its own coverage table.
+#
+# ``deanonymized`` stays, and stays deliberately. It is on the prose surface
+# (all three acts read it) but it is a rendering flag — are entity names printed
+# in clear? — not an analytical dimension, so "disponible / mobilisée" has no
+# meaning for it. The justification lives at its site in ``state_adapter.py``.
+PROSE_ONLY = frozenset({"deanonymized"})
 
 
 def test_ast_prose_matches_baseline() -> None:
@@ -190,3 +257,155 @@ def test_annexe_prose_relation_is_pinned() -> None:
     prose = set(PROSE_BASELINE)
     assert annexe - prose == ANNEXE_ONLY
     assert prose - annexe == PROSE_ONLY
+
+
+class TestMobilisationDeclarationMatchesTheProse:
+    """#1624 item 2 — the appendix declares mobilisation; the prose decides it.
+
+    ``appendix._MOBILISATION`` is a literal written at the appendix's own site
+    (the two surfaces stay file-disjoint on purpose). These tests are what makes
+    that literal answerable to reality instead of being a second, independent
+    claim about the same state.
+    """
+
+    def test_dimensions_declared_mobilised_are_read_by_the_prose(self) -> None:
+        prose = _prose_keys_read_from_state()
+        offenders = {
+            dim: [k for k in keys if k not in prose]
+            for dim, (keys, kind, _site) in _MOBILISATION.items()
+            if kind in ("prose", "failure_only")
+        }
+        offenders = {dim: missing for dim, missing in offenders.items() if missing}
+        assert offenders == {}, (
+            "these dimensions claim the conclusion reads them, but no act module "
+            f"reads the key: {offenders}"
+        )
+
+    def test_dimensions_declared_unmobilised_are_absent_from_the_prose(self) -> None:
+        # The other direction, and the one that decays silently: an axis wired
+        # into the prose later would keep its "non mobilisée" cell and the
+        # appendix would under-claim — the mirror of the over-claim #1624 opened
+        # on. Understating is less harmful, not harmless.
+        prose = _prose_keys_read_from_state()
+        wrongly_silent = {
+            dim: [k for k in keys if k in prose]
+            for dim, (keys, kind, _site) in _MOBILISATION.items()
+            if kind == "none"
+        }
+        wrongly_silent = {d: k for d, k in wrongly_silent.items() if k}
+        assert wrongly_silent == {}
+
+    def test_every_declared_key_survives_the_projection(self) -> None:
+        # The #1620 trap, documented in ``appendix.py``: the appendix receives a
+        # PROJECTION of the state, not the state. A dimension whose key is not in
+        # ``_STATE_KEYS`` reads ``None`` in production however correct its
+        # declaration is — inert, while passing any unit test built on a raw
+        # dict. That is exactly how the first cut of the #1620 fix shipped green
+        # and dead.
+        carried = set(_STATE_KEYS)
+        dropped = {
+            dim: [k for k in keys if k not in carried]
+            for dim, (keys, _kind, _site) in _MOBILISATION.items()
+        }
+        dropped = {d: k for d, k in dropped.items() if k}
+        assert dropped == {}
+
+    def test_declaration_covers_exactly_the_rendered_rows(self) -> None:
+        # No row without a declaration (it would render "non déclarée"), and no
+        # declaration without a row (a dead entry drifts out of sight).
+        rendered = set(_provenance_counts(_full_state()))
+        assert rendered == set(_MOBILISATION)
+
+
+class TestTheThreeStatesAreDistinguishable:
+    """#1624 item 2 — absent / present-and-mobilised / present-not-mobilised."""
+
+    def test_absent_dimension_claims_nothing_about_mobilisation(self) -> None:
+        notes = _mobilisation_notes({})
+        assert set(notes.values()) == {"—"}
+
+    def test_present_and_mobilised_names_the_act(self) -> None:
+        notes = _mobilisation_notes(_full_state())
+        assert notes["axe_dung"].startswith("mobilisée")
+        assert "acte" in notes["axe_dung"].lower()
+
+    def test_present_but_not_mobilised_says_so(self) -> None:
+        notes = _mobilisation_notes(_full_state())
+        assert "non mobilisée" in notes["synthese_formelle"]
+        assert "non mobilisée" in notes["synthese_narrative"]
+
+    def test_failure_only_is_not_rendered_as_plain_mobilisation(self) -> None:
+        # The fourth case: ``structured_arg_status`` reaches the conclusion
+        # through the absence collector alone, which opens on ``degraded``. A run
+        # where the axis WORKS is mute; a run where it degrades gains a sentence.
+        # Rendering that as plain "mobilisée" would read backwards.
+        notes = _mobilisation_notes(_full_state())
+        assert "seulement si l'axe échoue" in notes["arg_structuree"]
+        assert notes["arg_structuree"] != notes["axe_dung"]
+
+    def test_the_three_states_coexist_in_one_render(self) -> None:
+        # Not three separate reads of three separate states: one state, three
+        # cells. A table whose column is constant would satisfy every assertion
+        # above taken alone.
+        state = _full_state()
+        del state["formal_synthesis_reports"]  # → absent
+        notes = _mobilisation_notes(state)
+        assert notes["synthese_formelle"] == "—"  # absent
+        assert "non mobilisée" in notes["synthese_narrative"]  # present, unread
+        assert notes["axe_dung"].startswith("mobilisée")  # present, read
+        assert (
+            len(
+                {
+                    notes["synthese_formelle"],
+                    notes["synthese_narrative"],
+                    notes["axe_dung"],
+                }
+            )
+            == 3
+        )
+
+
+class TestTheNewlyAttestedAxesReachTheTable:
+    """#1624 item 3 — the axes the prose mobilises are named by the annexe."""
+
+    def test_deliberation_and_governance_are_counted(self) -> None:
+        counts = _provenance_counts(_full_state())
+        assert counts["deliberation"] == 2
+        assert counts["gouvernance"] == 1
+
+    def test_bipolar_axis_is_attested(self) -> None:
+        counts = _provenance_counts(_full_state())
+        assert counts["axe_bipolaire"] == "disponible"
+        assert _provenance_counts({})["axe_bipolaire"] == "indisponible"
+
+    def test_the_adapter_carries_them_off_a_real_state_object(self) -> None:
+        # The projection hop, on an object rather than a dict — ``_STATE_KEYS``
+        # is read via ``getattr`` in production.
+        class _S:
+            debate_transcripts = [{"turns": []}]
+            governance_decisions = [{"method": "borda"}]
+            bipolar_results = [{"supports": [["a", "b"]]}]
+
+        mapping = state_to_appendix_mapping(_S())
+        assert set(mapping) == {
+            "debate_transcripts",
+            "governance_decisions",
+            "bipolar_results",
+        }
+
+    def test_rendered_table_carries_the_third_column(self) -> None:
+        out = render_appendix(_full_state())
+        assert "| Dimension | Valeur | Mobilisation |" in out
+        assert "| deliberation | 2 |" in out
+        assert "| gouvernance | 1 |" in out
+        assert "non mobilisée" in out
+
+    def test_added_rows_carry_counts_not_content(self) -> None:
+        # Privacy HARD: the deliberation and governance containers hold turns and
+        # ballots; the table must expose their cardinality and nothing else.
+        state = _full_state()
+        state["debate_transcripts"] = [{"turns": ["CANARY_TOKEN"]}]
+        state["governance_decisions"] = [{"rationale": "CANARY_TOKEN"}]
+        out = render_appendix(state)
+        assert "CANARY_TOKEN" not in out
+        assert "| deliberation | 1 |" in out


### PR DESCRIPTION
Closes #1624.

## Ce que la mesure dit aujourd'hui — et ce qu'elle ne dit plus

Le corps de l'issue relevait 4 clés « annexe sans prose » et 4 « prose sans annexe ». Relevé refait sur `main` `ca40f6d2`, par balayage AST des trois modules d'actes :

| | clés |
|---|---|
| **annexe sans prose** | `final_conclusion`, `formal_synthesis_reports`, `narrative_synthesis`, `workflow_results` |
| **prose sans annexe** | `bipolar_results`, `deanonymized`, `debate_transcripts`, `governance_decisions` |

Deux des quatre clés du premier groupe listées à l'ouverture — `aspic_results` et `structured_arg_status` — **ont bougé** : elles sont maintenant lues par l'Acte III. C'est le résultat mesurable de #1667, pas de la comptabilité. Le premier item du DoD (épingler la relation) était déjà livré par `test_two_reading_surfaces_1624.py` ; cette PR ferme les deux autres, **côté annexe**.

## Item 3 — trois axes que la prose mobilise et que l'annexe ne pouvait pas nommer

`debate_transcripts`, `governance_decisions` et `bipolar_results` étaient absents de `_STATE_KEYS`. L'annexe ne pouvait donc pas les attester **du tout** — pas même comme « indisponible ». Un rapport dont la conclusion s'appuie sur la délibération et sur le vote de gouvernance n'en portait aucune trace dans sa propre table de couverture. Ils sont portés et rendus.

`deanonymized` reste dehors, **délibérément** : il est bien sur la surface de prose (les trois actes le lisent), mais c'est un drapeau de rendu — les noms d'entités sont-ils affichés en clair ? — pas une dimension d'analyse. « disponible / mobilisée » n'a pas de sens pour lui. La justification est écrite **à son site**, dans `state_adapter.py`, comme le demande le DoD.

Le test qui portait la relation enregistre le mouvement : `PROSE_ONLY` passe de 4 clés à `{"deanonymized"}`. C'est exactement ce que ce garde existe pour produire — une mise à jour délibérée, pas une dérive silencieuse.

## Item 2 — trois états, et un quatrième nommé plutôt qu'aplati

Une ligne qui dit « disponible » se lit comme « ceci a nourri la conclusion ». Pour les lignes que la prose n'ouvre jamais, c'est l'inverse du vrai — et le biais penche du côté habituel : **le rapport paraît mieux informé qu'il ne l'est.**

La table gagne une colonne *Mobilisation*. Composée avec la colonne de valeur, elle donne les trois états demandés :

| Valeur | Mobilisation | lecture |
|---|---|---|
| `indisponible` / `0` | `—` | **absent** — mobiliser un axe absent n'est pas un fait sur le rapport |
| `disponible` / `12` | `mobilisée (actes II–III)` | **présent et mobilisé** |
| `présente` | `**non mobilisée** — attestée ici, jamais lue par la conclusion` | **présent, non mobilisé** |

Un **quatrième** cas est nommé au lieu d'être rangé dans le deuxième : `arg_structuree` n'atteint la prose que par le collecteur d'absence, qui ouvre sur `degraded`. Un run où l'axe **fonctionne** est muet dans la conclusion ; un run où il **dégrade** y gagne une phrase. Le rendre en « mobilisée » se lirait exactement à l'envers, donc il porte son propre libellé : `mobilisée par l'acte III seulement si l'axe échoue`.

Cette asymétrie a une conséquence directe sur l'Epic en cours, déjà notée en commentaire : **faire cesser la dégradation d'un module lui retire sa seule trace actuelle dans la conclusion.** Toute mesure de différenciation qui compterait « la conclusion parle-t-elle de cet axe ? » lirait à l'envers. La colonne rend cette lecture inversée visible dans le rapport lui-même.

## Anti-pendules

- **Les deux listes ne sont pas mutualisées.** La déclaration `_MOBILISATION` vit au site de l'annexe ; elle n'importe pas les modules d'actes et ils ne l'importent pas. La disjonction de fichiers est voulue (`state_adapter.py` l.6-8) et partager une constante recréerait exactement le couplage que l'adaptateur existe pour éviter. **C'est le test qui porte l'accord** — même forme que le correctif #1619.
- **Aucun des 4 axes n'entre dans la prose « pour aligner ».** Le contrat de restitution n'est pas décidé depuis une symétrie de tableau.
- **Aucune ligne gênante n'est retirée.** Une annexe honnête est plus informative que pas d'annexe, une fois qu'elle dit ce qu'elle mesure.
- **La déclaration n'est pas une seconde affirmation libre.** Elle est vérifiée contre la réalité dans les deux sens : les dimensions déclarées mobilisées doivent être lues par un module d'acte, et celles déclarées non mobilisées ne doivent l'être par aucun. Le second sens est celui qui se dégrade en silence — un axe câblé plus tard garderait sa cellule « non mobilisée » et l'annexe **sous**-affirmerait. Sous-affirmer est moins nocif, pas inoffensif.
- **Le piège #1620 est épinglé.** L'annexe reçoit une **projection** de l'état, pas l'état. Une dimension dont la clé n'est pas dans `_STATE_KEYS` lit `None` en production, si correcte que soit sa déclaration — inerte, tout en passant n'importe quel test unitaire bâti sur un dict brut. C'est exactement ainsi que la première version du correctif #1620 avait été livrée verte et morte. Un test le vérifie clé par clé.

## Vérification

Module de garde : **2 tests → 16**.

Falsifiabilité mesurée par **cinq** substitutions dégénérées, chacune avec un kill-set distinct (le détail est dans le docstring du module) :

| Substitution | tests tués |
|---|---|
| retirer `debate_transcripts` de `_STATE_KEYS` | 3 |
| déclarer `arg_structuree` en `prose` au lieu de `failure_only` | **1** — le garde du quatrième cas, que rien d'autre ne voit |
| déclarer `synthese_formelle` mobilisée | 2 |
| `_mobilisation_notes` rend `"mobilisée"` inconditionnellement | 6 |
| retirer la ligne `gouvernance` de `_provenance_counts` | 3 |

La substitution `Sub A` **préexistante** a été **re-mesurée** : son kill-set annoncé était `{relation}`, il est désormais `{relation, projection}`. Une note de falsifiabilité qu'on ne rejoue jamais se périme exactement comme le garde qu'elle décrit ; la correction est écrite dans le docstring plutôt que passée sous silence.

Régression : **364 passed** sur le paquet `restitution`, **386** avec les tests du writer honest-absent, **1212** sur `reporting` + `evaluation`. Aucun appelant de `render_appendix` / `_provenance_counts` hors du paquet et de ses tests.

## Reste ouvert, mesuré ici, non traité

`_STATE_KEYS` porte trois clés que `_provenance_counts` ne rend dans **aucune** ligne : `stakes_and_stakeholders`, `source_metadata`, `workflow_results`. « L'annexe atteste X » est donc faux pour elles — troisième couche de divergence, **à l'intérieur** de la surface annexe. Hors périmètre du DoD (qui porte sur « les axes qu'elle liste »), signalé pour ne pas être re-découvert.

## Privacy

Les deux lignes ajoutées exposent des **cardinalités** (`_safe_len`), jamais du contenu : les transcripts portent des tours de parole et les décisions de gouvernance des bulletins. Un test injecte un jeton canari dans les deux conteneurs et vérifie qu'il n'atteint pas le rendu. Fixtures en atomes synthétiques uniquement.

🤖 Coordinator ai-01
