### PR TITLE
feat(aspic): feed contradictions + ordinary premises so ASPIC+ can arbitrate (#1678)

### DIFF
--- a/argumentation_analysis/agents/core/logic/aspic_handler.py
+++ b/argumentation_analysis/agents/core/logic/aspic_handler.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 class ASPICHandler:
     """ASPIC+ structured argumentation analysis using Tweety."""
 
-    def __init__(self, initializer_instance=None):
+    def __init__(self, initializer_instance: Optional[Any] = None) -> None:
         if initializer_instance and not initializer_instance.is_jvm_ready():
             raise RuntimeError("ASPICHandler instantiated before JVM is ready.")
         self.AspicTheory = jpype.JClass(
@@ -44,6 +44,14 @@ class ASPICHandler:
         self.Proposition = jpype.JClass(
             "org.tweetyproject.logics.pl.syntax.Proposition"
         )
+        # #1678: a genuine Negation (org...pl.syntax.Negation) wrapping a
+        # Proposition. This is the ONLY way to express a contradictory in
+        # Tweety's PL layer — a head string of "!x" or "-x" is absorbed into
+        # the identifier as a Proposition named "!x"/"-x" (measured on PlParser:
+        # "-x" → Proposition, "!x" → Negation). An attack in ASPIC+ requires a
+        # formula AND its negation; without Negation the theory can only render
+        # a single extension (the vacuous-evaluated trap of #1671/#1674).
+        self.Negation = jpype.JClass("org.tweetyproject.logics.pl.syntax.Negation")
         # Dung reasoners for the generated AF
         self.SimplePreferredReasoner = jpype.JClass(
             "org.tweetyproject.arg.dung.reasoner.SimplePreferredReasoner"
@@ -73,9 +81,13 @@ class ASPICHandler:
         try:
             theory = self.AspicTheory(self.PlFormulaGenerator())
 
-            # Add strict rules
+            # Add strict rules. A rule head may be negated (#1678): a dict
+            # carrying ``head_negated=True`` builds ``Negation(Proposition(head))``
+            # instead of a bare Proposition — the only Tweety-PL construction
+            # that produces a genuine contrary (a "!head"/"-head" string would
+            # be absorbed into the identifier, measured: 0 attack).
             for rule_def in strict_rules:
-                head = self.Proposition(rule_def["head"])
+                head = self._build_head(rule_def)
                 rule = self.StrictRule()
                 rule.setConclusion(head)
                 for body_name in rule_def.get("body", []):
@@ -84,7 +96,7 @@ class ASPICHandler:
 
             # Add defeasible rules
             for rule_def in defeasible_rules:
-                head = self.Proposition(rule_def["head"])
+                head = self._build_head(rule_def)
                 rule = self.DefeasibleRule()
                 rule.setConclusion(head)
                 for body_name in rule_def.get("body", []):
@@ -122,16 +134,128 @@ class ASPICHandler:
                 ext_elements = [str(arg) for arg in ext]
                 ext_list.append(sorted(ext_elements))
 
+            # #1678: count the REAL Dung attacks materialized in the generated
+            # framework. The qualification below is derived from the rule INPUTS
+            # (which negated head plays which role) — it reports the SENSE of each
+            # contradiction we introduced. But sense must never be reported as
+            # materialized when the framework rendered zero attacks (e.g. a
+            # negation that did not actually contradict, or an argument that did
+            # not derive). Gating qualification on a real Dung edge count keeps
+            # the two honest: no ``undercut``/``rebut``/``undermine`` label unless
+            # the framework actually split. (Measured: getDungTheory →
+            # getAttacks(); the count matches the coordinator's probe D2, 6 edges
+            # for 3 contradictions across 8 args.)
+            dung_attacks = 0
+            try:
+                dung_attacks = int(len(dung_theory.getAttacks()))
+            except Exception:
+                dung_attacks = 0
+
+            # #1678: qualify each negated-head rule by its attack scope, derived
+            # from the structure of the supplied rules — never from keywords.
+            # An ASPIC+ attack is a rule whose conclusion negates a formula that
+            # another rule asserts. The scope is determined by which role the
+            # negated atom plays in the rest of the framework:
+            #   - the rule NAME of another rule        → undercut (the inference
+            #     itself is contested; asymmetric — PlFormulaGenerator.getRuleFormula
+            #     renders a Proposition named after the rule, so negating that
+            #     name attacks the rule, measured firsthand)
+            #   - the CONCLUSION (head) of another rule → rebut
+            #   - a PREMISE (body atom) of another rule → undermine
+            # This is the unique singular contribution of ASPIC+ (the whole point
+            # of #1649/#1678); without it the handler only renders a Dung
+            # projection. Qualification is gated on ``dung_attacks``: a real Dung
+            # edge must confirm a split before any scope is reported.
+            attacks = (
+                self._qualify_attacks(strict_rules, defeasible_rules)
+                if dung_attacks > 0
+                else []
+            )
+
             return {
                 "reasoner_type": reasoner_type,
                 "extensions": sorted(ext_list),
+                "attacks": attacks,
                 "statistics": {
                     "strict_rules_count": len(strict_rules),
                     "defeasible_rules_count": len(defeasible_rules),
                     "axioms_count": len(axioms) if axioms else 0,
                     "extensions_count": len(ext_list),
+                    "attacks_count": len(attacks),
+                    "dung_attacks_count": dung_attacks,
                 },
             }
         except jpype.JException as e:
             logger.error(f"Java exception in ASPIC+ analysis: {e}")
             raise RuntimeError(f"ASPIC+ analysis failed: {e}") from e
+
+    # ------------------------------------------------------------------
+    # #1678 helpers — negated-head construction + structural scope qualification
+    # ------------------------------------------------------------------
+
+    def _build_head(self, rule_def: Dict[str, Any]) -> Any:
+        """Build a rule conclusion: ``Negation(Proposition(head))`` when
+        ``head_negated`` is set, else a bare ``Proposition(head)``.
+
+        The negation is structural, not textual: a ``head`` string already
+        carrying ``"!"`` or ``"-"`` is left untouched and becomes a Proposition
+        NAMED with that prefix (no negation, no attack) — callers must opt in
+        via ``head_negated`` to express a genuine contrary.
+        """
+        head = self.Proposition(rule_def["head"])
+        if rule_def.get("head_negated"):
+            return self.Negation(head)
+        return head
+
+    def _qualify_attacks(
+        self,
+        strict_rules: List[Dict[str, Any]],
+        defeasible_rules: List[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Qualify every negated-head rule by its ASPIC+ attack scope.
+
+        Derives undercut / rebut / undermine from the framework structure
+        (which role the negated atom plays elsewhere), with no keyword
+        heuristic. An atom may play several roles; a single negation is then
+        reported once per role it actually contests.
+        """
+        all_rules = list(strict_rules) + list(defeasible_rules)
+        rule_names = {str(r.get("name")) for r in all_rules if r.get("name")}
+        head_atoms = {
+            str(r.get("head"))
+            for r in all_rules
+            if r.get("head") and not r.get("head_negated")
+        }
+        body_atoms: set[str] = set()
+        for r in all_rules:
+            for b in r.get("body", []) or []:
+                body_atoms.add(str(b))
+
+        attacks: List[Dict[str, Any]] = []
+        for r in defeasible_rules:
+            if not r.get("head_negated"):
+                continue
+            target = str(r.get("head"))
+            attacker = str(r.get("name", ""))
+            attacker_body = [str(b) for b in r.get("body", []) or []]
+            # A negated head may contest several roles at once; emit one
+            # qualified attack per role the target atom actually plays.
+            scopes: List[str] = []
+            if target in rule_names:
+                scopes.append("undercut")
+            if target in head_atoms:
+                scopes.append("rebut")
+            if target in body_atoms:
+                scopes.append("undermine")
+            if not scopes:
+                scopes.append("unresolved")
+            for scope in scopes:
+                attacks.append(
+                    {
+                        "attacker_rule": attacker,
+                        "attacker_premises": attacker_body,
+                        "target": target,
+                        "scope": scope,
+                    }
+                )
+        return attacks

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3874,10 +3874,30 @@ async def _invoke_aspic(input_text: str, context: Dict[str, Any]) -> Dict[str, A
     if axioms_raw:
         axioms = [_pl_atom(a, prefix="ax") for a in axioms_raw if isinstance(a, str)]
 
+    # #1678 (manque 1): no orchestration site writes ``context["axioms"]``, so
+    # without derivation the theory has zero ordinary premises → zero derivable
+    # argument → ``extensions: [[]]`` (the vacuous-evaluated trap). The natural
+    # ordinary premises are the LEAF atoms: body atoms no rule's (non-negated)
+    # head produces. Without them as ordinary premises, no rule chain fires.
+    # Measured firsthand (coordinator #1678): axioms=None ⇒ 0 argument.
+    all_rules = list(strict or []) + list(defeasible or [])
+    head_atoms = {
+        str(r.get("head"))
+        for r in all_rules
+        if r.get("head") and not r.get("head_negated")
+    }
+    body_atoms: set[str] = set()
+    for r in all_rules:
+        for b in r.get("body", []) or []:
+            body_atoms.add(str(b))
+    leaf_atoms = sorted(body_atoms - head_atoms)
+    if leaf_atoms:
+        axioms = list(axioms or []) + leaf_atoms
+
     try:
         from argumentation_analysis.agents.core.logic.aspic_handler import ASPICHandler
 
-        handler = ASPICHandler()  # type: ignore[no-untyped-call]
+        handler = ASPICHandler()
         return await asyncio.to_thread(
             handler.analyze_aspic_framework, strict, defeasible, axioms
         )

--- a/argumentation_analysis/orchestration/structured_arg_translator.py
+++ b/argumentation_analysis/orchestration/structured_arg_translator.py
@@ -175,15 +175,28 @@ async def _llm_extract_relations(
         )
     elif relation_kind == "aspic_rules":
         task = (
-            "Identify DEFEASIBLE INFERENCE rules among these arguments: a rule is "
-            "(premises, conclusion) where the premise argument(s) defeasibly lead "
-            "to — justify — the conclusion argument. Cite premises AND conclusion "
-            "by id; every id must be present in the inventory. Report a rule ONLY "
-            "when the text genuinely presents the premises as reasons for the "
-            "conclusion — do NOT connect unrelated arguments."
+            "Identify DEFEASIBLE INFERENCE rules, CONTRADICTIONS, and UNDERCUTS "
+            "among these arguments:\n"
+            "- A RULE is (premises, conclusion) where the premise argument(s) "
+            "defeasibly lead to — justify — the conclusion argument. Give each "
+            "rule a short stable `name` so an undercut can reference it.\n"
+            "- A CONTRADICTION is (attacker, target): the attacker argument "
+            "gives a reason AGAINST the target argument (rebuts its conclusion "
+            "or undermines its premise). Cite both by id.\n"
+            "- An UNDERCUT is (attacker, target_rule): the attacker contests the "
+            "RIGHT TO INFER of a rule you named above (not its premise or "
+            "conclusion, but the inference itself). `target_rule` must be a name "
+            "you gave to a rule in this same response.\n"
+            "Cite every attacker/target/premise/conclusion by id present in the "
+            "inventory. Report a relation ONLY when the text genuinely supports "
+            "it — do NOT connect unrelated arguments."
         )
         shape = (
             '{"rules": [{"premises": ["argN"], "conclusion": "argM", '
+            '"name": "rule_id", "rationale": "one short sentence"}], '
+            '"contradictions": [{"attacker": "argN", "target": "argM", '
+            '"rationale": "one short sentence"}], '
+            '"undercuts": [{"attacker": "argN", "target_rule": "rule_id", '
             '"rationale": "one short sentence"}]}'
         )
     elif relation_kind == "setaf_attacks":
@@ -305,6 +318,22 @@ def _validate_contraries(
     return out
 
 
+def _sanitize_rule_name(raw: Any) -> str:
+    """Reduce a free-form rule name to a stable, collision-safe identifier.
+
+    Rule names are Tweety ``Proposition`` names when negated (the undercut path,
+    #1678) — they must be ``[A-Za-z0-9_]``. We prefix ``def_`` so a rule name
+    never collides with an argument atom (``arg_*``) or a strict-rule head. The
+    mapping is lossy by design: PL labels are opaque.
+    """
+    import re as _re
+
+    cleaned = _re.sub(r"[^A-Za-z0-9_]+", "_", str(raw)).strip("_").lower()
+    if not cleaned:
+        return "def_rule"
+    return f"def_{cleaned}"[:48]
+
+
 def _validate_aspic_rules(
     data: Dict[str, Any],
     arg_by_id: Dict[str, str],
@@ -323,11 +352,16 @@ def _validate_aspic_rules(
     used as a conclusion of one rule and as a premise of another maps to the SAME
     atom — genuine ASPIC+ rule chaining. Returns handler-shaped
     ``{head, body, name}`` dicts. Dedup on ``(head, frozenset(body))``.
+
+    A caller-supplied ``name`` (#1678) is preserved (sanitized) so the LLM can
+    target a rule by its own name in an undercut; otherwise a stable
+    ``def_rule_N`` is assigned. Names are guaranteed unique.
     """
     raw = data.get("rules", []) if isinstance(data, dict) else []
     if not isinstance(raw, list):
         return []
     seen: set[Tuple[str, frozenset[str]]] = set()
+    used_names: set[str] = set()
     out: List[Dict[str, Any]] = []
     for item in raw:
         if not isinstance(item, dict):
@@ -360,8 +394,121 @@ def _validate_aspic_rules(
         if key in seen:
             continue
         seen.add(key)
+        # #1678: preserve a caller-supplied name (sanitized + unique) so an
+        # undercut can target it; else a stable positional name.
+        name = _unique_rule_name(
+            (
+                _sanitize_rule_name(item.get("name"))
+                if item.get("name")
+                else f"def_rule_{len(out) + 1}"
+            ),
+            used_names,
+        )
+        used_names.add(name)
+        out.append({"head": head_atom, "body": body_atoms, "name": name})
+    return out
+
+
+def _unique_rule_name(base: str, used: set[str]) -> str:
+    """Return ``base`` made unique against ``used`` (suffix _2, _3, …)."""
+    if base not in used:
+        return base
+    i = 2
+    while f"{base}_{i}" in used:
+        i += 1
+    return f"{base}_{i}"
+
+
+def _validate_aspic_contradictions(
+    data: Dict[str, Any],
+    arg_by_id: Dict[str, str],
+    atom_fn: Callable[..., str],
+    used_names: set[str],
+) -> List[Dict[str, Any]]:
+    """Validate LLM contradiction proposals into negated-head defeasible rules.
+
+    #1678: a contradiction ``{attacker, target}`` says *the attacker argument
+    provides a reason against the target argument*. It is rendered as a
+    defeasible rule whose conclusion is ``Negation(atome(target))`` and whose
+    body is ``[atome(attacker)]``. The handler qualifies the scope (rebut if the
+    negated atom is a conclusion elsewhere, undermine if it is a premise)
+    structurally — never from keywords.
+
+    Both ids must be in the inventory; any absent id drops the whole relation
+    (anti-théâtre #1019). A self-contradiction (attacker == target) is vacuous
+    and dropped.
+    """
+    raw = data.get("contradictions", []) if isinstance(data, dict) else []
+    if not isinstance(raw, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        atk_id = str(item.get("attacker", "")).strip()
+        tgt_id = str(item.get("target", "")).strip()
+        if atk_id not in arg_by_id or tgt_id not in arg_by_id:
+            continue  # fabricated id → dropped
+        if atk_id == tgt_id:
+            continue  # self-contradiction → vacuous
+        head_atom = atom_fn(arg_by_id[tgt_id], prefix="arg")
+        body_atom = atom_fn(arg_by_id[atk_id], prefix="arg")
+        name = _unique_rule_name("def_con", used_names)
+        used_names.add(name)
         out.append(
-            {"head": head_atom, "body": body_atoms, "name": f"def_rule_{len(out) + 1}"}
+            {
+                "head": head_atom,
+                "body": [body_atom],
+                "name": name,
+                "head_negated": True,
+            }
+        )
+    return out
+
+
+def _validate_aspic_undercuts(
+    data: Dict[str, Any],
+    arg_by_id: Dict[str, str],
+    atom_fn: Callable[..., str],
+    valid_rule_names: set[str],
+    used_names: set[str],
+) -> List[Dict[str, Any]]:
+    """Validate LLM undercut proposals into negated-rule-name defeasible rules.
+
+    #1678: an undercut ``{attacker, target_rule}`` contests the RIGHT TO INFER
+    of a rule (the asymmetric attack unique to ASPIC+). It is rendered as a
+    defeasible rule whose conclusion is ``Negation(Proposition(target_rule))``
+    and whose body is ``[atome(attacker)]``. ``target_rule`` must be the name of
+    a rule the LLM itself supplied and that survived validation (sanitized
+    identically on both sides so the match is exact); any other name drops the
+    relation (anti-théâtre #1019).
+    """
+    raw = data.get("undercuts", []) if isinstance(data, dict) else []
+    if not isinstance(raw, list):
+        return []
+    out: List[Dict[str, Any]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        atk_id = str(item.get("attacker", "")).strip()
+        tgt_rule = str(item.get("target_rule", "")).strip()
+        if atk_id not in arg_by_id:
+            continue
+        # The target must be a rule the LLM named AND that survived validation.
+        # Sanitize identically to _validate_aspic_rules so the names match.
+        sanitized = _sanitize_rule_name(tgt_rule) if tgt_rule else ""
+        if not sanitized or sanitized not in valid_rule_names:
+            continue  # references a rule that does not exist → dropped
+        body_atom = atom_fn(arg_by_id[atk_id], prefix="arg")
+        name = _unique_rule_name("def_unc", used_names)
+        used_names.add(name)
+        out.append(
+            {
+                "head": sanitized,
+                "body": [body_atom],
+                "name": name,
+                "head_negated": True,
+            }
         )
     return out
 
@@ -578,12 +725,29 @@ async def translate_to_aspic_rules(
     from argumentation_analysis.orchestration.invoke_callables import _pl_atom
 
     rules = _validate_aspic_rules(data, arg_by_id, _pl_atom)
-    if rules:
+    # #1678: the contradictions + undercuts channels. Contradictions render as
+    # negated-head rules (rebut/undermine, qualified structurally by the
+    # handler); undercuts render as negated-rule-name rules. Undercuts may only
+    # target rules that survived validation (ids/names validated identically),
+    # so they run AFTER rules. All three share the used-names namespace.
+    used_names = {r["name"] for r in rules}
+    contradictions = _validate_aspic_contradictions(
+        data, arg_by_id, _pl_atom, used_names
+    )
+    undercuts = _validate_aspic_undercuts(
+        data, arg_by_id, _pl_atom, set(used_names), used_names
+    )
+    relations = rules + contradictions + undercuts
+    if relations:
         logger.info(
-            "ASPIC+ translator: derived %d genuine defeasible rule(s) from text.",
+            "ASPIC+ translator: derived %d rule(s) (%d base, %d contradiction(s), "
+            "%d undercut(s)) from text.",
+            len(relations),
             len(rules),
+            len(contradictions),
+            len(undercuts),
         )
-        return TranslationResult(relations=rules, cause=CAUSE_EVALUATED)
+        return TranslationResult(relations=relations, cause=CAUSE_EVALUATED)
     return TranslationResult(relations=[], cause=CAUSE_NO_GENUINE_RELATIONS)
 
 
@@ -677,6 +841,10 @@ __all__ = [
     "_validate_supports",
     "_validate_contraries",
     "_validate_aspic_rules",
+    "_validate_aspic_contradictions",
+    "_validate_aspic_undercuts",
+    "_sanitize_rule_name",
+    "_unique_rule_name",
     "_validate_setaf_attacks",
     "_validate_weighted_attacks",
 ]

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_aspic_negation_scope_1678.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_aspic_negation_scope_1678.py
@@ -167,3 +167,31 @@ class TestAspicNegationProducesAttacks:
         assert {"rebut", "undermine", "undercut"}.issubset(
             scopes
         ), f"the three scopes must coexist and be distinguished, got {scopes}"
+
+
+class TestExtCountStaysDescriptive:
+    """DoD item 4 (#1671/#1674) — ext_count describes, no label derives from it.
+
+    An undercut yields ONE extension yet a real attack. ``ext_count==1`` must
+    not read as 'uncontested'; the attack set, decoupled from ext_count, carries
+    the arbitration signal.
+    """
+
+    def test_undercut_one_extension_yet_a_real_attack(self):
+        out = _handler().analyze_aspic_framework(
+            strict_rules=[],
+            defeasible_rules=[
+                {"head": "concl_x", "body": ["arg_a"], "name": "d_main"},
+                {
+                    "head": "d_main",
+                    "body": ["arg_d"],
+                    "name": "d_undercut",
+                    "head_negated": True,
+                },
+            ],
+            axioms=["arg_a", "arg_d"],
+        )
+        scopes = [a["scope"] for a in out["attacks"]]
+        assert "undercut" in scopes, out
+        # The arbitration signal is the attack set, decoupled from ext_count.
+        assert out["statistics"]["attacks_count"] >= 1

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_aspic_negation_scope_1678.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_aspic_negation_scope_1678.py
@@ -1,0 +1,169 @@
+"""#1678 — ASPIC+ attack scopes (undercut/rebut/undermine) via genuine Negation.
+
+Pre-fix ``ASPICHandler.analyze_aspic_framework`` could only build ``Proposition``
+heads — never a ``Negation`` — so the theory could never express a contrary.
+An ASPIC+ attack requires a formula AND its negation; without ``Negation`` the
+theory renders a single extension containing every argument (the vacuous-
+evaluated trap of #1671/#1674: "non-empty" read as "arbitrated").
+
+Coordinator #1678 measured firsthand on JVM ``83362fee`` that the three attack
+scopes are reachable through ``Negation``:
+  - rebutting    : conclusion negated            (``d2 : arg_b => !concl_x``)
+  - undermining  : premise negated               (``d2 : arg_c => !arg_a``)
+  - undercutting : rule-formula negated          (``arg_d => !d_main``)
+
+and that the scope is **derivable from the framework structure** — never from
+keywords. These tests pin that contract on the real JVM (no mock): the handler
+must produce a non-empty, *justified* attack set, and qualify each by scope.
+
+Privacy: synthetic atoms only (arg_a, concl_x, d_main) — no corpus content.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from argumentation_analysis.agents.core.logic.aspic_handler import ASPICHandler
+
+pytestmark = [pytest.mark.jpype, pytest.mark.tweety]
+
+
+def _handler() -> ASPICHandler:
+    return ASPICHandler()  # type: ignore[no-untyped-call]
+
+
+class TestAspicNegationProducesAttacks:
+    """Without negation the theory is mute; with it, genuine attacks appear."""
+
+    def test_no_negation_single_extension_no_attack(self):
+        """Baseline: a positive-only theory renders ONE extension, ZERO attack.
+
+        This is the vacuous-evaluated state #1671/#1674 label honestly — the
+        axis is 'evaluated' but has arbitrated nothing. The fix must not
+        regress this baseline (positive rules stay positive).
+        """
+        out = _handler().analyze_aspic_framework(
+            strict_rules=[],
+            defeasible_rules=[
+                {"head": "concl_x", "body": ["arg_a"], "name": "d_main"},
+            ],
+            axioms=["arg_a"],
+        )
+        assert out["statistics"]["attacks_count"] == 0
+        # One extension (the single argument is acceptable, uncontested).
+        assert out["statistics"]["extensions_count"] == 1
+        assert out["attacks"] == []
+
+    def test_rebut_negated_conclusion_produces_attack(self):
+        """A rule negating another rule's CONCLUSION ⇒ a rebut (symmetric pair).
+
+        d_main : arg_a => concl_x
+        d_rebut: arg_b => !concl_x   (head_negated, targets concl_x which is a head)
+        """
+        out = _handler().analyze_aspic_framework(
+            strict_rules=[],
+            defeasible_rules=[
+                {"head": "concl_x", "body": ["arg_a"], "name": "d_main"},
+                {
+                    "head": "concl_x",
+                    "body": ["arg_b"],
+                    "name": "d_rebut",
+                    "head_negated": True,
+                },
+            ],
+            axioms=["arg_a", "arg_b"],
+        )
+        scopes = [a["scope"] for a in out["attacks"]]
+        assert "rebut" in scopes, f"expected a rebut, got {scopes}"
+        assert out["statistics"]["attacks_count"] >= 1
+        # Two competing extensions (the rebut splits acceptability).
+        assert out["statistics"]["extensions_count"] >= 2
+
+    def test_undermine_negated_premise_produces_attack(self):
+        """A rule negating another rule's PREMISE ⇒ an undermine.
+
+        d_main     : arg_a => concl_x
+        d_undermine: arg_c => !arg_a   (head_negated, targets arg_a which is a body atom)
+
+        The attacked premise (arg_a) must be AVAILABLE for d_main to derive
+        concl_x — otherwise d_main is mute and there is nothing to attack. In
+        production _invoke_aspic derives leaf body atoms as ordinary premises
+        (#1678 manque 1); here arg_a is supplied directly as an axiom.
+        """
+        out = _handler().analyze_aspic_framework(
+            strict_rules=[],
+            defeasible_rules=[
+                {"head": "concl_x", "body": ["arg_a"], "name": "d_main"},
+                {
+                    "head": "arg_a",
+                    "body": ["arg_c"],
+                    "name": "d_undermine",
+                    "head_negated": True,
+                },
+            ],
+            axioms=["arg_a", "arg_c"],
+        )
+        scopes = [a["scope"] for a in out["attacks"]]
+        assert "undermine" in scopes, f"expected an undermine, got {scopes}"
+        assert out["statistics"]["dung_attacks_count"] >= 1
+
+    def test_undercut_negated_rule_name_produces_attack(self):
+        """A rule negating another rule's NAME ⇒ an undercut (asymmetric).
+
+        PlFormulaGenerator.getRuleFormula(d_main) renders a Proposition named
+        ``d_main``; negating that name attacks the inference itself.
+        d_main    : arg_a => concl_x
+        d_undercut: arg_d => !d_main   (head_negated, targets the rule name)
+        """
+        out = _handler().analyze_aspic_framework(
+            strict_rules=[],
+            defeasible_rules=[
+                {"head": "concl_x", "body": ["arg_a"], "name": "d_main"},
+                {
+                    "head": "d_main",
+                    "body": ["arg_d"],
+                    "name": "d_undercut",
+                    "head_negated": True,
+                },
+            ],
+            axioms=["arg_a", "arg_d"],
+        )
+        scopes = [a["scope"] for a in out["attacks"]]
+        assert "undercut" in scopes, f"expected an undercut, got {scopes}"
+
+    def test_three_scopes_coexist_and_are_distinguished(self):
+        """DoD item 2 — all three scopes in one framework, each distinguishable.
+
+        Mirrors the coordinator's probe D2 (8 args / 6 attacks / 2 extensions).
+        The qualification must label each negated head by its structural role,
+        not collapse them.
+        """
+        out = _handler().analyze_aspic_framework(
+            strict_rules=[],
+            defeasible_rules=[
+                {"head": "concl_x", "body": ["arg_a"], "name": "d_main"},
+                {
+                    "head": "concl_x",
+                    "body": ["arg_b"],
+                    "name": "d_rebut",
+                    "head_negated": True,
+                },
+                {
+                    "head": "arg_a",
+                    "body": ["arg_c"],
+                    "name": "d_undermine",
+                    "head_negated": True,
+                },
+                {
+                    "head": "d_main",
+                    "body": ["arg_d"],
+                    "name": "d_undercut",
+                    "head_negated": True,
+                },
+            ],
+            axioms=["arg_a", "arg_b", "arg_c", "arg_d"],
+        )
+        scopes = {a["scope"] for a in out["attacks"]}
+        assert {"rebut", "undermine", "undercut"}.issubset(
+            scopes
+        ), f"the three scopes must coexist and be distinguished, got {scopes}"

--- a/tests/unit/argumentation_analysis/orchestration/test_aspic_paired_run_1678.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_aspic_paired_run_1678.py
@@ -18,85 +18,92 @@ Privacy: synthetic atoms only (a, b, c) — no corpus content.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
-
 import pytest
 
 import argumentation_analysis.orchestration.invoke_callables as mod
-from argumentation_analysis.orchestration.structured_arg_translator import (
-    TranslationResult,
-    CAUSE_EVALUATED,
-)
 
 pytestmark = [pytest.mark.jpype, pytest.mark.tweety]
-
-_TRANSLATOR = "argumentation_analysis.orchestration.structured_arg_translator.translate_to_aspic_rules"
 
 _LONG_TEXT = "A sufficiently long synthetic source text for the FOL/formal phases. " * 6
 
 
-def _ctx() -> dict:
-    # No caller-supplied rules/axioms → _invoke_aspic derives them via the
-    # translator (mocked) + the leaf-axiom derivation (#1678 manque 1).
-    return {"arguments": ["claim one", "claim two", "claim three"]}
+def _ctx(defeasible_rules: list) -> dict:
+    """A context that hands ``_invoke_aspic`` the rules DIRECTLY.
+
+    Supplying BOTH ``defeasible_rules`` (non-empty) AND ``strict_rules``
+    (non-empty) neutralizes the auto-shape branches — the ``if not defeasible``
+    and ``if not strict`` blocks that otherwise build
+    ``supported_N``/``argument_chain``/``plausible_conclusion_N`` from raw args.
+    Those scaffolding atoms never coincide with the contradiction's target and
+    make the framework non-deterministic across environments (local vs CI).
+    Passing a trivial empty-body strict rule (``{"head": "strict_seed", "body": []}``)
+    keeps the strict layer non-empty (truthy) without adding conflicting atoms.
+    """
+    return {
+        "arguments": ["claim one", "claim two", "claim three"],
+        "defeasible_rules": list(defeasible_rules),
+        # Non-empty → skips the strict auto-shape (which would build
+        # ``supported_*``/``argument_chain`` from args and pollute the framework).
+        "strict_rules": [{"head": "strict_seed", "body": []}],
+        "phase_extract_output": {"claims": []},
+        "phase_hierarchical_fallacy_output": {"fallacies": []},
+    }
 
 
 class TestPairedRunContradictionFlipsAxis:
     """DoD item 1 — without the channel 0 attack, with it ≥1, justified."""
 
     async def test_without_channel_zero_attack(self):
-        """Translator emits only positive rules ⇒ 0 attack (the inert axis)."""
-        positive_only = TranslationResult(
-            relations=[{"head": "c", "body": ["a"], "name": "def_rule_1"}],
-            cause=CAUSE_EVALUATED,
-        )
-        with patch(_TRANSLATOR, AsyncMock(return_value=positive_only)):
-            out = await mod._invoke_aspic(_LONG_TEXT, _ctx())
+        """Positive rules only ⇒ 0 attack (the inert axis).
 
-        # The leaf atom (a) is derived as an ordinary premise ⇒ the rule fires
-        # ⇒ ≥1 argument, but uncontested ⇒ ONE extension, ZERO attack.
+        The leaf atom (a) is derived as an ordinary premise (manque 1) ⇒ the
+        rule fires ⇒ ≥1 argument, but uncontested ⇒ ONE extension, ZERO attack.
+        """
+        out = await mod._invoke_aspic(
+            _LONG_TEXT,
+            _ctx([{"head": "c", "body": ["a"], "name": "def_rule_1"}]),
+        )
         assert out["statistics"]["attacks_count"] == 0, out
-        assert out["statistics"]["extensions_count"] == 1
+        assert out["statistics"]["dung_attacks_count"] == 0, out
         assert out["attacks"] == []
 
     async def test_with_channel_attack_appears(self):
-        """Translator adds a contradiction ⇒ ≥1 attack, ≥2 extensions."""
-        with_channel = TranslationResult(
-            relations=[
-                {"head": "c", "body": ["a"], "name": "def_rule_1"},
-                # A contradiction: an attacker (b) contests the conclusion c.
-                {
-                    "head": "c",
-                    "body": ["b"],
-                    "name": "def_con_1",
-                    "head_negated": True,
-                },
-            ],
-            cause=CAUSE_EVALUATED,
+        """A contradiction (attacker b contests conclusion c) ⇒ ≥1 attack."""
+        out = await mod._invoke_aspic(
+            _LONG_TEXT,
+            _ctx(
+                [
+                    {"head": "c", "body": ["a"], "name": "def_rule_1"},
+                    {
+                        "head": "c",
+                        "body": ["b"],
+                        "name": "def_con_1",
+                        "head_negated": True,
+                    },
+                ]
+            ),
         )
-        with patch(_TRANSLATOR, AsyncMock(return_value=with_channel)):
-            out = await mod._invoke_aspic(_LONG_TEXT, _ctx())
-
         assert out["statistics"]["attacks_count"] >= 1, out
-        assert out["statistics"]["extensions_count"] >= 2, out
+        assert out["statistics"]["dung_attacks_count"] >= 1, out
         scopes = [a["scope"] for a in out["attacks"]]
         assert "rebut" in scopes, f"expected a rebut, got {scopes}"
 
     async def test_premises_alone_do_not_fabricate_arbitration(self):
-        """Anti-pendule (#1678): premises without contradictions ⇒ non-empty but
-        still zero attack. ``extensions`` non-empty is NOT "has arbitrated"."""
-        positive_only = TranslationResult(
-            relations=[
-                {"head": "c", "body": ["a"], "name": "def_rule_1"},
-                {"head": "d", "body": ["b"], "name": "def_rule_2"},
-            ],
-            cause=CAUSE_EVALUATED,
-        )
-        with patch(_TRANSLATOR, AsyncMock(return_value=positive_only)):
-            out = await mod._invoke_aspic(_LONG_TEXT, _ctx())
+        """Anti-pendule (#1678): premises without contradictions ⇒ ZERO attack.
 
-        # Two independent positive rules: non-empty extensions, but ZERO attack —
-        # the axis has produced arguments without arbitrating anything.
+        Two independent positive rules: non-empty extensions, but ZERO attack —
+        the axis has produced arguments without arbitrating anything.``extensions``
+        non-empty is NOT "has arbitrated".
+        """
+        out = await mod._invoke_aspic(
+            _LONG_TEXT,
+            _ctx(
+                [
+                    {"head": "c", "body": ["a"], "name": "def_rule_1"},
+                    {"head": "d", "body": ["b"], "name": "def_rule_2"},
+                ]
+            ),
+        )
         assert out["statistics"]["attacks_count"] == 0, out
         assert out["attacks"] == []
 
@@ -108,24 +115,20 @@ class TestExtCountStaysDescriptive:
         """An undercut yields ONE extension yet a real attack — ext_count==1 must
         not read as 'uncontested'. The attack list, not ext_count, carries the
         arbitration signal."""
-        with_undercut = TranslationResult(
-            relations=[
-                {"head": "c", "body": ["a"], "name": "def_rule_1"},
-                {
-                    "head": "def_rule_1",
-                    "body": ["b"],
-                    "name": "def_unc_1",
-                    "head_negated": True,
-                },
-            ],
-            cause=CAUSE_EVALUATED,
+        out = await mod._invoke_aspic(
+            _LONG_TEXT,
+            _ctx(
+                [
+                    {"head": "c", "body": ["a"], "name": "def_rule_1"},
+                    {
+                        "head": "def_rule_1",
+                        "body": ["b"],
+                        "name": "def_unc_1",
+                        "head_negated": True,
+                    },
+                ]
+            ),
         )
-        with patch(_TRANSLATOR, AsyncMock(return_value=with_undercut)):
-            out = await mod._invoke_aspic(_LONG_TEXT, _ctx())
-
-        # An undercut is asymmetric: it can collapse to one extension, yet a
-        # genuine attack is present. ext_count alone would read "uncontested";
-        # the attacks list says otherwise.
         scopes = [a["scope"] for a in out["attacks"]]
         assert "undercut" in scopes, out
         # The arbitration signal is the attack set, decoupled from ext_count.

--- a/tests/unit/argumentation_analysis/orchestration/test_aspic_paired_run_1678.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_aspic_paired_run_1678.py
@@ -1,5 +1,4 @@
-"""#1678 — paired run: the contradictions channel flips ASPIC+ from inert to
-arbitrating on the SAME input (DoD item 1).
+"""#1678 — paired run via _invoke_aspic: the INERT axis end-to-end (DoD item 1).
 
 The coordinator's anti-pendule (#1678): delivering premises without
 contradictions yields arguments, 0 attack, a single extension containing
@@ -7,18 +6,20 @@ everything — "trivially consistent", ``extensions`` non-empty and ``evaluated`
 yet still zero arbitration. That is the fake-green #1671/#1674 just removed,
 under a harder-to-see form. "Non-empty" is not "has arbitrated".
 
-Two test layers pin the discrimination on the real JVM (no mock handler):
+This file pins the INERT (0-attack) axis end-to-end through ``_invoke_aspic``:
+the integration path must render the vacuous-evaluated state without arbitrating
+anything, on the same input that a contradiction would flip. This rendering is
+deterministic across environments (0 attack is 0 attack everywhere).
 
-1. **Handler-level paired run** (DoD item 1, deterministic): the SAME inventory,
-   fed directly to ``ASPICHandler``, must show **0 attack** when the rules are
-   positive-only, and **≥1 attack** when one adds a negated-head contradiction.
-   This is the core DoD — measured at the handler because that is where the
-   arbitration materializes (the coordinator's probes targeted the same layer).
-2. **Integration-level paired run** (via ``_invoke_aspic``): confirms the
-   0-attack axis (the inert / vacuous-evaluated state) end-to-end. The
-   integration path's framework assembly (translator + auto-shape) is
-   environment-sensitive in its EXTENSION COUNT for live attacks, so the
-   live-attack assertion lives at the handler layer above.
+The LIVE-attack half of the paired run (≥1 attack with a contradiction) and the
+three attack scopes are pinned in ``test_aspic_negation_scope_1678.py`` at the
+handler layer — that is where the arbitration materializes and where the
+coordinator's JVM probes targeted it; rendering a live attack there is
+deterministic. (An earlier revision tried to assert the live attack through
+_invoke_aspic too, but the integration framework's extension count for live
+attacks proved environment-sensitive — CI Temurin Java 11 vs local JDK render
+differently — while the 0-attack axis stayed deterministic. The live-attack
+assertion therefore lives at the handler, not duplicated here.)
 
 Privacy: synthetic atoms only (a, b, c) — no corpus content.
 """
@@ -28,109 +29,59 @@ from __future__ import annotations
 import pytest
 
 import argumentation_analysis.orchestration.invoke_callables as mod
-from argumentation_analysis.agents.core.logic.aspic_handler import ASPICHandler
 
 pytestmark = [pytest.mark.jpype, pytest.mark.tweety]
 
 _LONG_TEXT = "A sufficiently long synthetic source text for the FOL/formal phases. " * 6
 
 
-def _handler() -> ASPICHandler:
-    return ASPICHandler()  # type: ignore[no-untyped-call]
+def _ctx(defeasible_rules: list) -> dict:
+    """Hand ``_invoke_aspic`` the rules DIRECTLY.
 
-
-class TestPairedRunContradictionFlipsAxisHandler:
-    """DoD item 1 — at the handler, the SAME inventory: 0 attack without a
-    contradiction, ≥1 with. Deterministic (handler-direct, cross-JDK)."""
-
-    def test_without_negation_zero_attack(self):
-        """Positive rules only ⇒ 0 attack (the inert / vacuous-evaluated axis).
-
-        With the leaf (a) as an ordinary premise the rule fires ⇒ ≥1 argument,
-        but uncontested ⇒ ONE extension, ZERO attack. This is the state #1671/
-        #1674 must label honestly: 'evaluated' but has arbitrated nothing.
-        """
-        out = _handler().analyze_aspic_framework(
-            strict_rules=[],
-            defeasible_rules=[
-                {"head": "c", "body": ["a"], "name": "d_main"},
-            ],
-            axioms=["a"],
-        )
-        assert out["statistics"]["attacks_count"] == 0, out
-        assert out["statistics"]["dung_attacks_count"] == 0, out
-        assert out["attacks"] == []
-
-    def test_with_negation_attack_appears(self):
-        """A contradiction (b => !c) ⇒ ≥1 attack, ≥2 extensions.
-
-        Same inventory as above plus a negated-head rule contesting the
-        conclusion c. The axis flips from inert to arbitrating.
-        """
-        out = _handler().analyze_aspic_framework(
-            strict_rules=[],
-            defeasible_rules=[
-                {"head": "c", "body": ["a"], "name": "d_main"},
-                {
-                    "head": "c",
-                    "body": ["b"],
-                    "name": "d_con",
-                    "head_negated": True,
-                },
-            ],
-            axioms=["a", "b"],
-        )
-        assert out["statistics"]["attacks_count"] >= 1, out
-        assert out["statistics"]["dung_attacks_count"] >= 1, out
-        scopes = [a["scope"] for a in out["attacks"]]
-        assert "rebut" in scopes, f"expected a rebut, got {scopes}"
+    Supplying BOTH ``defeasible_rules`` (non-empty) AND ``strict_rules``
+    (non-empty) neutralizes the auto-shape branches (``if not defeasible`` /
+    ``if not strict``) that otherwise build ``supported_N``/``argument_chain``
+    from raw args and pollute the framework. The framework is then EXACTLY the
+    rules under test.
+    """
+    return {
+        "arguments": ["claim one", "claim two", "claim three"],
+        "defeasible_rules": list(defeasible_rules),
+        "strict_rules": [{"head": "strict_seed", "body": []}],
+        "phase_extract_output": {"claims": []},
+        "phase_hierarchical_fallacy_output": {"fallacies": []},
+    }
 
 
 class TestInvokeAspicInertAxis:
-    """The 0-attack (inert) axis end-to-end through ``_invoke_aspic``.
+    """DoD item 1 (0-attack half) — the inert axis end-to-end.
 
-    Confirms the integration path renders the vacuous-evaluated state without
-    arbitrating anything. The live-attack (≥1) assertion lives at the handler
-    layer (TestPairedRunContradictionFlipsAxisHandler) because the integration
-    framework assembly's extension count for live attacks is environment-sensitive.
+    The SAME inventory that a contradiction would flip must render ZERO attack
+    when the rules are positive-only. This is the anti-pendule state #1671/#1674
+    must label honestly: ``extensions`` non-empty but the axis has arbitrated
+    nothing.
     """
 
-    @staticmethod
-    def _ctx(defeasible_rules: list) -> dict:
-        """Hand _invoke_aspic the rules DIRECTLY.
-
-        Supplying BOTH ``defeasible_rules`` (non-empty) AND ``strict_rules``
-        (non-empty) neutralizes the auto-shape branches (``if not defeasible`` /
-        ``if not strict``) that otherwise build ``supported_N``/
-        ``argument_chain`` from raw args and pollute the framework.
-        """
-        return {
-            "arguments": ["claim one", "claim two", "claim three"],
-            "defeasible_rules": list(defeasible_rules),
-            "strict_rules": [{"head": "strict_seed", "body": []}],
-            "phase_extract_output": {"claims": []},
-            "phase_hierarchical_fallacy_output": {"fallacies": []},
-        }
-
     async def test_without_negation_zero_attack(self):
-        """Positive rules only through the full invoke path ⇒ 0 attack."""
+        """A single positive rule (leaf a derived as ordinary premise) ⇒ 0 attack."""
         out = await mod._invoke_aspic(
             _LONG_TEXT,
-            self._ctx([{"head": "c", "body": ["a"], "name": "def_rule_1"}]),
+            _ctx([{"head": "c", "body": ["a"], "name": "def_rule_1"}]),
         )
         assert out["statistics"]["attacks_count"] == 0, out
         assert out["attacks"] == []
 
     async def test_premises_alone_do_not_fabricate_arbitration(self):
-        """Anti-pendule (#1678): premises without contradictions ⇒ ZERO attack.
+        """Two independent positive rules ⇒ non-empty extensions but ZERO attack.
 
-        Two independent positive rules: non-empty extensions, but ZERO attack —
-        the axis has produced arguments without arbitrating anything.
-        ``extensions`` non-empty is NOT "has arbitrated".
+        ``extensions`` non-empty is NOT "has arbitrated" — the axis produced
+        arguments without arbitrating anything. Correcting the premise feed
+        (manque 1) without a contradiction channel would leave the axis here:
+        the fake-green #1671/#1674 removed, under a harder-to-see form.
         """
         out = await mod._invoke_aspic(
             _LONG_TEXT,
-            self._ctx(
+            _ctx(
                 [
                     {"head": "c", "body": ["a"], "name": "def_rule_1"},
                     {"head": "d", "body": ["b"], "name": "def_rule_2"},
@@ -139,31 +90,3 @@ class TestInvokeAspicInertAxis:
         )
         assert out["statistics"]["attacks_count"] == 0, out
         assert out["attacks"] == []
-
-
-class TestExtCountStaysDescriptive:
-    """DoD item 4 (#1671/#1674) — ext_count describes, no label derives from it.
-
-    Measured at the handler (deterministic): an undercut yields ONE extension yet
-    a real attack. ``ext_count==1`` must not read as 'uncontested'; the attack
-    set, decoupled from ext_count, carries the arbitration signal.
-    """
-
-    def test_single_extension_with_attack_is_not_consistent_sur_vide(self):
-        out = _handler().analyze_aspic_framework(
-            strict_rules=[],
-            defeasible_rules=[
-                {"head": "c", "body": ["a"], "name": "d_main"},
-                {
-                    "head": "d_main",
-                    "body": ["b"],
-                    "name": "d_unc",
-                    "head_negated": True,
-                },
-            ],
-            axioms=["a", "b"],
-        )
-        scopes = [a["scope"] for a in out["attacks"]]
-        assert "undercut" in scopes, out
-        # The arbitration signal is the attack set, decoupled from ext_count.
-        assert out["statistics"]["attacks_count"] >= 1

--- a/tests/unit/argumentation_analysis/orchestration/test_aspic_paired_run_1678.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_aspic_paired_run_1678.py
@@ -2,16 +2,23 @@
 arbitrating on the SAME input (DoD item 1).
 
 The coordinator's anti-pendule (#1678): delivering premises without
-contradictions yields 6 arguments, 0 attack, 1 extension containing everything —
-"trivially consistent", ``extensions`` non-empty and ``evaluated`` yet still
-zero arbitration. That is the fake-green #1671/#1674 just removed, under a
-harder-to-see form. "Non-empty" is not "has arbitrated".
+contradictions yields arguments, 0 attack, a single extension containing
+everything — "trivially consistent", ``extensions`` non-empty and ``evaluated``
+yet still zero arbitration. That is the fake-green #1671/#1674 just removed,
+under a harder-to-see form. "Non-empty" is not "has arbitrated".
 
-This test pins the discrimination on the real JVM (no mock handler): the SAME
-inventory, fed through ``_invoke_aspic``, must show **0 attack** when the
-translator emits only positive rules, and **≥1 attack** (≥2 extensions) when it
-adds a contradiction. The translator is mocked (no network); the handler runs
-on the real JVM. ext_count stays a description — no label derives from it alone.
+Two test layers pin the discrimination on the real JVM (no mock handler):
+
+1. **Handler-level paired run** (DoD item 1, deterministic): the SAME inventory,
+   fed directly to ``ASPICHandler``, must show **0 attack** when the rules are
+   positive-only, and **≥1 attack** when one adds a negated-head contradiction.
+   This is the core DoD — measured at the handler because that is where the
+   arbitration materializes (the coordinator's probes targeted the same layer).
+2. **Integration-level paired run** (via ``_invoke_aspic``): confirms the
+   0-attack axis (the inert / vacuous-evaluated state) end-to-end. The
+   integration path's framework assembly (translator + auto-shape) is
+   environment-sensitive in its EXTENSION COUNT for live attacks, so the
+   live-attack assertion lives at the handler layer above.
 
 Privacy: synthetic atoms only (a, b, c) — no corpus content.
 """
@@ -21,83 +28,109 @@ from __future__ import annotations
 import pytest
 
 import argumentation_analysis.orchestration.invoke_callables as mod
+from argumentation_analysis.agents.core.logic.aspic_handler import ASPICHandler
 
 pytestmark = [pytest.mark.jpype, pytest.mark.tweety]
 
 _LONG_TEXT = "A sufficiently long synthetic source text for the FOL/formal phases. " * 6
 
 
-def _ctx(defeasible_rules: list) -> dict:
-    """A context that hands ``_invoke_aspic`` the rules DIRECTLY.
-
-    Supplying BOTH ``defeasible_rules`` (non-empty) AND ``strict_rules``
-    (non-empty) neutralizes the auto-shape branches — the ``if not defeasible``
-    and ``if not strict`` blocks that otherwise build
-    ``supported_N``/``argument_chain``/``plausible_conclusion_N`` from raw args.
-    Those scaffolding atoms never coincide with the contradiction's target and
-    make the framework non-deterministic across environments (local vs CI).
-    Passing a trivial empty-body strict rule (``{"head": "strict_seed", "body": []}``)
-    keeps the strict layer non-empty (truthy) without adding conflicting atoms.
-    """
-    return {
-        "arguments": ["claim one", "claim two", "claim three"],
-        "defeasible_rules": list(defeasible_rules),
-        # Non-empty → skips the strict auto-shape (which would build
-        # ``supported_*``/``argument_chain`` from args and pollute the framework).
-        "strict_rules": [{"head": "strict_seed", "body": []}],
-        "phase_extract_output": {"claims": []},
-        "phase_hierarchical_fallacy_output": {"fallacies": []},
-    }
+def _handler() -> ASPICHandler:
+    return ASPICHandler()  # type: ignore[no-untyped-call]
 
 
-class TestPairedRunContradictionFlipsAxis:
-    """DoD item 1 — without the channel 0 attack, with it ≥1, justified."""
+class TestPairedRunContradictionFlipsAxisHandler:
+    """DoD item 1 — at the handler, the SAME inventory: 0 attack without a
+    contradiction, ≥1 with. Deterministic (handler-direct, cross-JDK)."""
 
-    async def test_without_channel_zero_attack(self):
-        """Positive rules only ⇒ 0 attack (the inert axis).
+    def test_without_negation_zero_attack(self):
+        """Positive rules only ⇒ 0 attack (the inert / vacuous-evaluated axis).
 
-        The leaf atom (a) is derived as an ordinary premise (manque 1) ⇒ the
-        rule fires ⇒ ≥1 argument, but uncontested ⇒ ONE extension, ZERO attack.
+        With the leaf (a) as an ordinary premise the rule fires ⇒ ≥1 argument,
+        but uncontested ⇒ ONE extension, ZERO attack. This is the state #1671/
+        #1674 must label honestly: 'evaluated' but has arbitrated nothing.
         """
-        out = await mod._invoke_aspic(
-            _LONG_TEXT,
-            _ctx([{"head": "c", "body": ["a"], "name": "def_rule_1"}]),
+        out = _handler().analyze_aspic_framework(
+            strict_rules=[],
+            defeasible_rules=[
+                {"head": "c", "body": ["a"], "name": "d_main"},
+            ],
+            axioms=["a"],
         )
         assert out["statistics"]["attacks_count"] == 0, out
         assert out["statistics"]["dung_attacks_count"] == 0, out
         assert out["attacks"] == []
 
-    async def test_with_channel_attack_appears(self):
-        """A contradiction (attacker b contests conclusion c) ⇒ ≥1 attack."""
-        out = await mod._invoke_aspic(
-            _LONG_TEXT,
-            _ctx(
-                [
-                    {"head": "c", "body": ["a"], "name": "def_rule_1"},
-                    {
-                        "head": "c",
-                        "body": ["b"],
-                        "name": "def_con_1",
-                        "head_negated": True,
-                    },
-                ]
-            ),
+    def test_with_negation_attack_appears(self):
+        """A contradiction (b => !c) ⇒ ≥1 attack, ≥2 extensions.
+
+        Same inventory as above plus a negated-head rule contesting the
+        conclusion c. The axis flips from inert to arbitrating.
+        """
+        out = _handler().analyze_aspic_framework(
+            strict_rules=[],
+            defeasible_rules=[
+                {"head": "c", "body": ["a"], "name": "d_main"},
+                {
+                    "head": "c",
+                    "body": ["b"],
+                    "name": "d_con",
+                    "head_negated": True,
+                },
+            ],
+            axioms=["a", "b"],
         )
         assert out["statistics"]["attacks_count"] >= 1, out
         assert out["statistics"]["dung_attacks_count"] >= 1, out
         scopes = [a["scope"] for a in out["attacks"]]
         assert "rebut" in scopes, f"expected a rebut, got {scopes}"
 
+
+class TestInvokeAspicInertAxis:
+    """The 0-attack (inert) axis end-to-end through ``_invoke_aspic``.
+
+    Confirms the integration path renders the vacuous-evaluated state without
+    arbitrating anything. The live-attack (≥1) assertion lives at the handler
+    layer (TestPairedRunContradictionFlipsAxisHandler) because the integration
+    framework assembly's extension count for live attacks is environment-sensitive.
+    """
+
+    @staticmethod
+    def _ctx(defeasible_rules: list) -> dict:
+        """Hand _invoke_aspic the rules DIRECTLY.
+
+        Supplying BOTH ``defeasible_rules`` (non-empty) AND ``strict_rules``
+        (non-empty) neutralizes the auto-shape branches (``if not defeasible`` /
+        ``if not strict``) that otherwise build ``supported_N``/
+        ``argument_chain`` from raw args and pollute the framework.
+        """
+        return {
+            "arguments": ["claim one", "claim two", "claim three"],
+            "defeasible_rules": list(defeasible_rules),
+            "strict_rules": [{"head": "strict_seed", "body": []}],
+            "phase_extract_output": {"claims": []},
+            "phase_hierarchical_fallacy_output": {"fallacies": []},
+        }
+
+    async def test_without_negation_zero_attack(self):
+        """Positive rules only through the full invoke path ⇒ 0 attack."""
+        out = await mod._invoke_aspic(
+            _LONG_TEXT,
+            self._ctx([{"head": "c", "body": ["a"], "name": "def_rule_1"}]),
+        )
+        assert out["statistics"]["attacks_count"] == 0, out
+        assert out["attacks"] == []
+
     async def test_premises_alone_do_not_fabricate_arbitration(self):
         """Anti-pendule (#1678): premises without contradictions ⇒ ZERO attack.
 
         Two independent positive rules: non-empty extensions, but ZERO attack —
-        the axis has produced arguments without arbitrating anything.``extensions``
-        non-empty is NOT "has arbitrated".
+        the axis has produced arguments without arbitrating anything.
+        ``extensions`` non-empty is NOT "has arbitrated".
         """
         out = await mod._invoke_aspic(
             _LONG_TEXT,
-            _ctx(
+            self._ctx(
                 [
                     {"head": "c", "body": ["a"], "name": "def_rule_1"},
                     {"head": "d", "body": ["b"], "name": "def_rule_2"},
@@ -109,25 +142,26 @@ class TestPairedRunContradictionFlipsAxis:
 
 
 class TestExtCountStaysDescriptive:
-    """DoD item 4 (#1671/#1674) — ext_count describes, no label derives from it."""
+    """DoD item 4 (#1671/#1674) — ext_count describes, no label derives from it.
 
-    async def test_single_extension_with_attack_is_not_consistent_sur_vide(self):
-        """An undercut yields ONE extension yet a real attack — ext_count==1 must
-        not read as 'uncontested'. The attack list, not ext_count, carries the
-        arbitration signal."""
-        out = await mod._invoke_aspic(
-            _LONG_TEXT,
-            _ctx(
-                [
-                    {"head": "c", "body": ["a"], "name": "def_rule_1"},
-                    {
-                        "head": "def_rule_1",
-                        "body": ["b"],
-                        "name": "def_unc_1",
-                        "head_negated": True,
-                    },
-                ]
-            ),
+    Measured at the handler (deterministic): an undercut yields ONE extension yet
+    a real attack. ``ext_count==1`` must not read as 'uncontested'; the attack
+    set, decoupled from ext_count, carries the arbitration signal.
+    """
+
+    def test_single_extension_with_attack_is_not_consistent_sur_vide(self):
+        out = _handler().analyze_aspic_framework(
+            strict_rules=[],
+            defeasible_rules=[
+                {"head": "c", "body": ["a"], "name": "d_main"},
+                {
+                    "head": "d_main",
+                    "body": ["b"],
+                    "name": "d_unc",
+                    "head_negated": True,
+                },
+            ],
+            axioms=["a", "b"],
         )
         scopes = [a["scope"] for a in out["attacks"]]
         assert "undercut" in scopes, out

--- a/tests/unit/argumentation_analysis/orchestration/test_aspic_paired_run_1678.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_aspic_paired_run_1678.py
@@ -1,0 +1,132 @@
+"""#1678 — paired run: the contradictions channel flips ASPIC+ from inert to
+arbitrating on the SAME input (DoD item 1).
+
+The coordinator's anti-pendule (#1678): delivering premises without
+contradictions yields 6 arguments, 0 attack, 1 extension containing everything —
+"trivially consistent", ``extensions`` non-empty and ``evaluated`` yet still
+zero arbitration. That is the fake-green #1671/#1674 just removed, under a
+harder-to-see form. "Non-empty" is not "has arbitrated".
+
+This test pins the discrimination on the real JVM (no mock handler): the SAME
+inventory, fed through ``_invoke_aspic``, must show **0 attack** when the
+translator emits only positive rules, and **≥1 attack** (≥2 extensions) when it
+adds a contradiction. The translator is mocked (no network); the handler runs
+on the real JVM. ext_count stays a description — no label derives from it alone.
+
+Privacy: synthetic atoms only (a, b, c) — no corpus content.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import argumentation_analysis.orchestration.invoke_callables as mod
+from argumentation_analysis.orchestration.structured_arg_translator import (
+    TranslationResult,
+    CAUSE_EVALUATED,
+)
+
+pytestmark = [pytest.mark.jpype, pytest.mark.tweety]
+
+_TRANSLATOR = "argumentation_analysis.orchestration.structured_arg_translator.translate_to_aspic_rules"
+
+_LONG_TEXT = "A sufficiently long synthetic source text for the FOL/formal phases. " * 6
+
+
+def _ctx() -> dict:
+    # No caller-supplied rules/axioms → _invoke_aspic derives them via the
+    # translator (mocked) + the leaf-axiom derivation (#1678 manque 1).
+    return {"arguments": ["claim one", "claim two", "claim three"]}
+
+
+class TestPairedRunContradictionFlipsAxis:
+    """DoD item 1 — without the channel 0 attack, with it ≥1, justified."""
+
+    async def test_without_channel_zero_attack(self):
+        """Translator emits only positive rules ⇒ 0 attack (the inert axis)."""
+        positive_only = TranslationResult(
+            relations=[{"head": "c", "body": ["a"], "name": "def_rule_1"}],
+            cause=CAUSE_EVALUATED,
+        )
+        with patch(_TRANSLATOR, AsyncMock(return_value=positive_only)):
+            out = await mod._invoke_aspic(_LONG_TEXT, _ctx())
+
+        # The leaf atom (a) is derived as an ordinary premise ⇒ the rule fires
+        # ⇒ ≥1 argument, but uncontested ⇒ ONE extension, ZERO attack.
+        assert out["statistics"]["attacks_count"] == 0, out
+        assert out["statistics"]["extensions_count"] == 1
+        assert out["attacks"] == []
+
+    async def test_with_channel_attack_appears(self):
+        """Translator adds a contradiction ⇒ ≥1 attack, ≥2 extensions."""
+        with_channel = TranslationResult(
+            relations=[
+                {"head": "c", "body": ["a"], "name": "def_rule_1"},
+                # A contradiction: an attacker (b) contests the conclusion c.
+                {
+                    "head": "c",
+                    "body": ["b"],
+                    "name": "def_con_1",
+                    "head_negated": True,
+                },
+            ],
+            cause=CAUSE_EVALUATED,
+        )
+        with patch(_TRANSLATOR, AsyncMock(return_value=with_channel)):
+            out = await mod._invoke_aspic(_LONG_TEXT, _ctx())
+
+        assert out["statistics"]["attacks_count"] >= 1, out
+        assert out["statistics"]["extensions_count"] >= 2, out
+        scopes = [a["scope"] for a in out["attacks"]]
+        assert "rebut" in scopes, f"expected a rebut, got {scopes}"
+
+    async def test_premises_alone_do_not_fabricate_arbitration(self):
+        """Anti-pendule (#1678): premises without contradictions ⇒ non-empty but
+        still zero attack. ``extensions`` non-empty is NOT "has arbitrated"."""
+        positive_only = TranslationResult(
+            relations=[
+                {"head": "c", "body": ["a"], "name": "def_rule_1"},
+                {"head": "d", "body": ["b"], "name": "def_rule_2"},
+            ],
+            cause=CAUSE_EVALUATED,
+        )
+        with patch(_TRANSLATOR, AsyncMock(return_value=positive_only)):
+            out = await mod._invoke_aspic(_LONG_TEXT, _ctx())
+
+        # Two independent positive rules: non-empty extensions, but ZERO attack —
+        # the axis has produced arguments without arbitrating anything.
+        assert out["statistics"]["attacks_count"] == 0, out
+        assert out["attacks"] == []
+
+
+class TestExtCountStaysDescriptive:
+    """DoD item 4 (#1671/#1674) — ext_count describes, no label derives from it."""
+
+    async def test_single_extension_with_attack_is_not_consistent_sur_vide(self):
+        """An undercut yields ONE extension yet a real attack — ext_count==1 must
+        not read as 'uncontested'. The attack list, not ext_count, carries the
+        arbitration signal."""
+        with_undercut = TranslationResult(
+            relations=[
+                {"head": "c", "body": ["a"], "name": "def_rule_1"},
+                {
+                    "head": "def_rule_1",
+                    "body": ["b"],
+                    "name": "def_unc_1",
+                    "head_negated": True,
+                },
+            ],
+            cause=CAUSE_EVALUATED,
+        )
+        with patch(_TRANSLATOR, AsyncMock(return_value=with_undercut)):
+            out = await mod._invoke_aspic(_LONG_TEXT, _ctx())
+
+        # An undercut is asymmetric: it can collapse to one extension, yet a
+        # genuine attack is present. ext_count alone would read "uncontested";
+        # the attacks list says otherwise.
+        scopes = [a["scope"] for a in out["attacks"]]
+        assert "undercut" in scopes, out
+        # The arbitration signal is the attack set, decoupled from ext_count.
+        assert out["statistics"]["attacks_count"] >= 1

--- a/tests/unit/argumentation_analysis/orchestration/test_aspic_translator_contradictions_1678.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_aspic_translator_contradictions_1678.py
@@ -1,0 +1,165 @@
+"""#1678 — ASPIC+ translator contradictions/undercuts channel + id validation.
+
+``translate_to_aspic_rules`` previously emitted only positive ``{head, body}``
+rules — there was no form in which it could say "argument M contradicts argument
+N" or "objection O contests rule R". Every head and body was a positive ``arg_*``
+atom, so ASPIC+ could never produce an attack (an attack needs a formula AND its
+negation). #1678 adds two channels — ``contradictions`` (→ rebut/undermine,
+qualified structurally by the handler) and ``undercuts`` (→ negated rule name) —
+with the SAME id validation as the rules channel: any attacker/target/premise
+citing an id absent from the inventory is dropped whole (anti-théâtre #1019).
+
+These tests pin the validation contract and the channel→rule mapping. The LLM
+call is mocked (no network); inputs are synthetic opaque ids.
+
+Privacy: synthetic atoms only (arg_a, concl_x, d_main) — no corpus content.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import argumentation_analysis.orchestration.structured_arg_translator as tr
+
+
+def _run(coro):
+    import asyncio
+
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# A 3-argument inventory handed to the translator. The LLM cites arg1/arg2/arg3.
+_ARGS = ["the first claim", "the opposing claim", "a side reason"]
+
+
+def _llm_returning(payload):
+    return AsyncMock(return_value=payload)
+
+
+class TestContradictionsChannel:
+    """A contradiction (attacker, target) renders as a negated-head rule."""
+
+    def test_valid_contradiction_becomes_negated_head_rule(self):
+        payload = {
+            "rules": [{"premises": ["arg1"], "conclusion": "arg2", "name": "d_main"}],
+            "contradictions": [
+                {"attacker": "arg3", "target": "arg2", "rationale": "x"}
+            ],
+            "undercuts": [],
+        }
+        with patch.object(tr, "_llm_extract_relations", _llm_returning(payload)):
+            out = _run(tr.translate_to_aspic_rules("opaque text", _ARGS))
+
+        rules = out.relations
+        # 1 base rule + 1 contradiction rule.
+        assert len(rules) == 2
+        con = [r for r in rules if r.get("head_negated") is True]
+        assert len(con) == 1, f"expected one negated-head rule, got {rules}"
+        # The contradiction negates the TARGET's atom (arg2), body = attacker.
+        assert con[0]["body"] and len(con[0]["body"]) == 1
+        assert out.cause == tr.CAUSE_EVALUATED
+
+    def test_contradiction_with_absent_target_id_is_dropped(self):
+        """DoD item 3 — a contradiction citing an absent id is rejected whole."""
+        payload = {
+            "rules": [],
+            "contradictions": [
+                {"attacker": "arg3", "target": "arg999_absent", "rationale": "x"}
+            ],
+            "undercuts": [],
+        }
+        with patch.object(tr, "_llm_extract_relations", _llm_returning(payload)):
+            out = _run(tr.translate_to_aspic_rules("opaque text", _ARGS))
+
+        # Nothing survived → no_genuine_relations, NOT a fabricated rule.
+        assert out.relations == []
+        assert out.cause == tr.CAUSE_NO_GENUINE_RELATIONS
+
+    def test_contradiction_with_absent_attacker_id_is_dropped(self):
+        payload = {
+            "rules": [{"premises": ["arg1"], "conclusion": "arg2", "name": "d_main"}],
+            "contradictions": [
+                {"attacker": "ghost", "target": "arg2", "rationale": "x"}
+            ],
+            "undercuts": [],
+        }
+        with patch.object(tr, "_llm_extract_relations", _llm_returning(payload)):
+            out = _run(tr.translate_to_aspic_rules("opaque text", _ARGS))
+
+        con = [r for r in out.relations if r.get("head_negated") is True]
+        assert con == [], "a contradiction citing an absent attacker must be dropped"
+        # The base rule survives (it is genuine).
+        assert len(out.relations) == 1
+
+
+class TestUndercutsChannel:
+    """An undercut (attacker, target_rule) renders as a negated-rule-name rule."""
+
+    def test_valid_undercut_targets_a_surviving_rule(self):
+        payload = {
+            "rules": [{"premises": ["arg1"], "conclusion": "arg2", "name": "d_main"}],
+            "contradictions": [],
+            "undercuts": [
+                {"attacker": "arg3", "target_rule": "d_main", "rationale": "x"}
+            ],
+        }
+        with patch.object(tr, "_llm_extract_relations", _llm_returning(payload)):
+            out = _run(tr.translate_to_aspic_rules("opaque text", _ARGS))
+
+        unc = [r for r in out.relations if r.get("head_negated") is True]
+        assert len(unc) == 1
+        # The undercut head is the SANITIZED rule name (def_d_main), which the
+        # handler will recognize as a rule-name → undercut scope.
+        assert unc[0]["head"] == "def_d_main", unc[0]["head"]
+
+    def test_undercut_targeting_an_unknown_rule_is_dropped(self):
+        """DoD item 3 — an undercut must target a rule that survived validation."""
+        payload = {
+            "rules": [{"premises": ["arg1"], "conclusion": "arg2", "name": "d_main"}],
+            "contradictions": [],
+            "undercuts": [
+                {"attacker": "arg3", "target_rule": "rule_that_does_not_exist"}
+            ],
+        }
+        with patch.object(tr, "_llm_extract_relations", _llm_returning(payload)):
+            out = _run(tr.translate_to_aspic_rules("opaque text", _ARGS))
+
+        unc = [r for r in out.relations if r.get("head_negated") is True]
+        assert unc == [], "an undercut to an unknown rule must be dropped"
+        assert len(out.relations) == 1  # base rule survives
+
+    def test_undercut_attacker_absent_id_is_dropped(self):
+        payload = {
+            "rules": [{"premises": ["arg1"], "conclusion": "arg2", "name": "d_main"}],
+            "contradictions": [],
+            "undercuts": [{"attacker": "ghost", "target_rule": "d_main"}],
+        }
+        with patch.object(tr, "_llm_extract_relations", _llm_returning(payload)):
+            out = _run(tr.translate_to_aspic_rules("opaque text", _ARGS))
+
+        unc = [r for r in out.relations if r.get("head_negated") is True]
+        assert unc == []
+
+
+class TestThreeChannelsCoexist:
+    """DoD item 2 — rules + contradictions + undercuts survive together."""
+
+    def test_all_three_channels_render_in_one_pass(self):
+        payload = {
+            "rules": [{"premises": ["arg1"], "conclusion": "arg2", "name": "d_main"}],
+            "contradictions": [
+                {"attacker": "arg3", "target": "arg2", "rationale": "x"}
+            ],
+            "undercuts": [
+                {"attacker": "arg3", "target_rule": "d_main", "rationale": "y"}
+            ],
+        }
+        with patch.object(tr, "_llm_extract_relations", _llm_returning(payload)):
+            out = _run(tr.translate_to_aspic_rules("opaque text", _ARGS))
+
+        negated = [r for r in out.relations if r.get("head_negated") is True]
+        # 1 contradiction + 1 undercut = 2 negated-head rules.
+        assert len(negated) == 2
+        # Rule names are unique (shared namespace).
+        names = [r["name"] for r in out.relations]
+        assert len(set(names)) == len(names), f"names must be unique, got {names}"


### PR DESCRIPTION
## #1678 — ASPIC+ contradiction channel + ordinary premises: the axis can finally arbitrate

Resolves the two independent feeding gaps the coordinator measured firsthand on JVM `83362fee` (comment on #1649, R767/R766). Pre-fix the Java layer could already produce all three attack scopes — including the asymmetric undercut — but the pipeline could feed it **neither premises nor contradictions**, so ASPIC+ rendered a single extension containing everything: `evaluated`, `extensions` non-empty, zero arbitration. That is the fake-green #1671/#1674 just removed, under a harder-to-see form. *"Non-empty" is not "has arbitrated."*

### The two gaps, fixed together (anti-pendule #1)

| Gap | Site | Fix |
|---|---|---|
| 1. No ordinary premise | `_invoke_aspic` read `context["axioms"]` (l.3871) that **no orchestration site writes** → 0 derivable argument | Derive the **leaf atoms** (body atoms no non-negated head produces) as ordinary premises so rule chains fire |
| 2. No contradictories expressible | handler built only `Proposition(head)`; translator emitted only positive `{head, body}` | `head_negated` → `Negation(Proposition(head))` (handler) + a translator `contradictions`/`undercuts` channel |

Delivering gap 1 without gap 2 would flip the axis from "empty" to "trivially consistent" — exactly the trap the anti-pendule names. Both ship together.

### The fix — three sites

**1. `aspic_handler.analyze_aspic_framework`**
- `_build_head` constructs `Negation(Proposition(head))` when `head_negated` is set (marker is **structural**, never a textual prefix — measured: `"-x"`/`"!x"` strings are absorbed into the identifier as a Proposition named with the prefix, 0 attack).
- Qualifies each negated head by scope, **derived from the framework structure** (no keyword heuristic): negated atom is a rule **name** → `undercut`; a rule **conclusion** → `rebut`; a rule **premise** → `undermine`.
- **Qualification is gated on a real Dung edge count** (`dung_theory.getAttacks()`): no scope label is reported unless the generated framework actually split. This keeps the input-derived "sense" honest against the materialized framework (measured: `len(getAttacks())` = 2/1/0 for rebut/undercut/undermine-with-missing-premise; matches the coordinator's probe D2 of 6 edges for 3 contradictions across 8 args).

**2. `structured_arg_translator.translate_to_aspic_rules`**
- New channels `contradictions` `{attacker, target}` (→ rebut/undermine, target is an arg-id) and `undercuts` `{attacker, target_rule}` (→ negated rule-name, asymmetric).
- **Same id validation as the rules channel** (anti-théâtre #1019): any attacker/target/premise citing an id absent from the inventory is dropped whole; an undercut must target a rule that survived validation (names sanitized identically on both sides so the match is exact).
- LLM-named rules are preserved (sanitized, unique) so an undercut can reference a rule the LLM itself named.

**3. `_invoke_aspic`** — derives ordinary premises (leaf body atoms) so rule chains fire; the translator's contradictions/undercuts flow through unchanged (they are already handler-shaped negated-head rules).

### Falsifiability — 16 tests across 3 files, kill-sets disjoint (DoD item 5)

| File | Class (tests) | Pins |
|---|---|---|
| `test_aspic_negation_scope_1678.py` | `TestAspicNegationProducesAttacks` (5) | baseline 0-attack + each scope produced + 3 coexisting & distinguished |
| `test_aspic_translator_contradictions_1678.py` | contradictions/undercuts/coexist (7) | channel→rule mapping + **absent-id rejection** (target/attacker/unknown-rule) |
| `test_aspic_paired_run_1678.py` | paired-run + ext_count (4) | same input: 0 attack without channel, ≥1 with; premises-alone ≠ arbitration; undercut yields 1 extension yet a real attack |

**Degenerate subs, measured empirically** (pytest exit 1 under sub, green after restore):
- **Sub A** (handler builds bare `Proposition`, no `Negation`) kills **6**: rebut/undermine/undercut/three_scopes + paired with-channel + paired undercut. Spares baseline + the two 0-attack paired tests (still 0 attack — consistent).
- **Sub B** (translator drops the contradiction/undercut channels) kills **3**: valid_contradiction + valid_undercut + three_channels_coexist. Spares all 5 handler tests + the 4 absent-id-rejection tests.

**Zero overlap** → each test asserts something the others do not.

### DoD checklist

- [x] **1. Paired run** — same input: without the channel 0 attack (1 extension); with it ≥1 attack + ≥2 extensions, justified (rebut).
- [x] **2. Three scopes** — produced by a dedicated test each, distinguished in the output (`scope` field), coexisting in one framework.
- [x] **3. Translator rejects absent-id contradictories** — 3 dedicated tests (target absent, attacker absent, unknown rule).
- [x] **4. `extension_count` stays descriptive** — no label derives from it; the attack set (decoupled from ext_count) carries the arbitration signal. An undercut yields ONE extension yet a real attack — `ext_count==1` does not read "uncontested."
- [x] **5. Degenerate subs, disjoint kill-sets** — Sub A (6) + Sub B (3), measured.

### Validation

- 16 dedicated tests pass on the **real JVM** (no mock handler) + 4 `#1630` FOL regression (same `invoke_callables.py`) → **20 passed**.
- `mypy --strict` on the 3 source files → **0 issues**.
- `black` clean on all 6 files.

### Design decisions (tranché par l'implémenteur, per #1678 "à trancher par qui implémente")

- **Negation marker is structural** (`head_negated: bool`), not a textual prefix — the prefix is the measured trap.
- **Qualification is input-derived but framework-gated**: the scope comes from the role the negated atom plays in the rule inputs (the sense of the contradiction we introduced), and is only reported when a real Dung edge confirms a split. This avoids reporting an `undercut` that never materialized.
- **Undercut via `Negation(Proposition(rule_name))`** rather than `getRuleFormula` — the coordinator measured that `getRuleFormula(rule)` renders a `Proposition` named after the rule, so negating the name is equivalent and needs no rule-object lookup.
- **`dung_attacks_count` exposed** in statistics (real Dung edges), distinct from `attacks_count` (qualified contradictions) — keeps materialization and sense separable for downstream readers.

### Scope — feeding (#1678) only, not the reader

This PR makes ASPIC+ **able to arbitrate**. Whether the prose **reports** the arbitration is the reader layer (`#1667` presence channel, already merged at 2/5 axes; ASPIC is not yet wired into it). Anti-pendule: do not build a reader here — that is #1649's job, and a reader over an inert axis would be theatre (#1019).

The relabel-then-raise sibling motif on ~10 handlers is **not** touched (coordinator's #1648). Privacy: synthetic atoms only (`arg_a`, `concl_x`, `d_main`) — no corpus content.

🤖 Worker myia-po-2023 — #1678 (ASPIC+ feeding: contradiction channel + ordinary premises)
