### PR TITLE
fix(aspic): writer must carry the qualified attacks list (#1649 post-#1679)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -954,15 +954,35 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         return rk_id
 
     def add_aspic_result(
-        self, reasoner_type: str, extensions: List[Any], statistics: Dict[str, Any]
+        self,
+        reasoner_type: str,
+        extensions: List[Any],
+        statistics: Dict[str, Any],
+        attacks: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
-        """Add an ASPIC+ analysis result."""
+        """Add an ASPIC+ analysis result.
+
+        #1649 (#1678 #1679): ``attacks`` carries the qualified attack list
+        produced by ``ASPICHandler.analyze_aspic_framework`` — a list of dicts
+        shaped ``{attacker_rule, attacker_premises, target, scope}`` with
+        ``scope`` in ``{undercut, rebut, undermine, unresolved}``. The field
+        is the singular contribution of ASPIC+ (#1649): without it the
+        projection is a Dung copy and the axis loses its only reason to
+        exist. ``attacks`` defaults to ``None`` so all 3-arg callers
+        (SK plugin wrappers, tests, fixtures) stay backward compatible;
+        ``None`` is serialized as the empty list so readers never see the
+        distinction. The Semantic Kernel plugin wrappers
+        (``state_manager_plugin.py``, ``phase_scoped_state.py``) keep the
+        3-arg signature by design — the LLM does not write attacks, the
+        writer does, post-handler.
+        """
         as_id = self._generate_id("aspic", self.aspic_results)
         entry = {
             "id": as_id,
             "reasoner_type": reasoner_type,
             "extensions": extensions,
             "statistics": statistics,
+            "attacks": list(attacks) if attacks is not None else [],
         }
         self.aspic_results.append(entry)
         state_logger.info(f"ASPIC+ result added: {as_id} (reasoner: {reasoner_type})")

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -821,18 +821,39 @@ def _write_ranking_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> Non
 
 
 def _write_aspic_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
-    """Write ASPIC+ analysis results to UnifiedAnalysisState."""
+    """Write ASPIC+ analysis results to UnifiedAnalysisState.
+
+    #1649 (#1678 #1679): the handler now produces a qualified ``attacks``
+    list (undercut / rebut / undermine / unresolved, scoped structurally on
+    the rule inputs). Pre-fix the writer dropped it on the floor — ASPIC+
+    rendered as a Dung copy and the axis lost its singular contribution.
+    We surface ``attacks`` as a top-level entry field (peer of ``extensions``
+    and ``statistics``), NOT via a ``formalism_specific`` sidecar: the
+    ABA writer (site 1 of #1648 Wave-2) uses the sidecar pattern because
+    ``dung_frameworks`` has a constrained projection, but ``aspic_results``
+    is a flat list with explicit peer fields and ``attacks`` is a peer —
+    the top-level shape is the natural one. The 11 readers of
+    ``aspic_results`` (sanitize_state, restitution, deep_synthesis, …) are
+    not migrated: a reader that wants the field reads
+    ``entry["attacks"]``. Anti-pendule: additif, single site, no reader
+    migration. Privacy: synthetic atoms only in tests; the LLM-named rules
+    that survive validation in production may carry corpus tokens — see the
+    sanitize_state update tracked separately.
+    """
     _record_structured_arg_status(state, "aspic_plus_reasoning", output, ctx)
     if not output or not isinstance(output, dict):
         return
     reasoner_type = str(output.get("reasoner_type", "simple"))
     extensions = output.get("extensions", [])
     statistics = output.get("statistics", {})
+    attacks = output.get("attacks")
     if not isinstance(extensions, list):
         extensions = []
     if not isinstance(statistics, dict):
         statistics = {}
-    state.add_aspic_result(reasoner_type, extensions, statistics)
+    if not isinstance(attacks, list):
+        attacks = None
+    state.add_aspic_result(reasoner_type, extensions, statistics, attacks=attacks)
 
 
 def _write_belief_revision_to_state(

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_1649.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_1649.py
@@ -1,0 +1,171 @@
+"""#1649 — Regression tests pinning the ASPIC+ writer must carry ``attacks``.
+
+ASPIC+ is the unique singular contribution of the structured-argumentation
+axes (#1649): its attacks carry a **scope** (undercut / rebut / undermine /
+unresolved) that Dung has no equivalent for. Pre-fix the handler at
+``aspic_handler.analyze_aspic_framework`` (post-#1679) emits the qualified
+list — but the writer ``_write_aspic_to_state`` threw it away, so the state
+saw ``aspic_results[0]["attacks"] = []`` and the axis projected as a Dung
+copy. A reader aggregating attacks saw zero ASPIC+ arbitration even when the
+handler had qualified several.
+
+Anti-#1019 discipline (R761 #1643, R764 #1636, R765 #1662, R767 #1648): the
+writer is real, the handler is stubbed. A mocked writer would just agree
+with itself.
+
+Privacy: synthetic atoms only (no corpus tokens).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+import pytest
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.orchestration.state_writers import (
+    _write_aspic_to_state,
+)
+
+
+def _new_state() -> UnifiedAnalysisState:
+    """A fresh state for a single writer probe."""
+    return UnifiedAnalysisState("aspic-writer-1649 synthetic probe")
+
+
+def _stub_post1679_output() -> Dict[str, Any]:
+    """Mirror of ``ASPICHandler.analyze_aspic_framework`` after #1679/#1649.
+
+    Carries the qualified attacks list — three scopes coexisting in one
+    framework, plus the matching statistics. Synthetic atoms only.
+    """
+    return {
+        "reasoner_type": "simple",
+        "extensions": [["a"], ["b"]],
+        "attacks": [
+            {
+                "attacker_rule": "r_neg_main",
+                "attacker_premises": ["p", "q"],
+                "target": "r_main",
+                "scope": "undercut",
+            },
+            {
+                "attacker_rule": "r_neg_main",
+                "attacker_premises": ["p", "q"],
+                "target": "concl_x",
+                "scope": "rebut",
+            },
+            {
+                "attacker_rule": "r_neg_main",
+                "attacker_premises": ["p", "q"],
+                "target": "p",
+                "scope": "undermine",
+            },
+        ],
+        "statistics": {
+            "strict_rules_count": 1,
+            "defeasible_rules_count": 1,
+            "axioms_count": 2,
+            "extensions_count": 2,
+            "attacks_count": 3,
+            "dung_attacks_count": 3,
+        },
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestAspicWriterCarriesAttacks1649 — the writer must surface attacks
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAspicWriterCarriesAttacks1649:
+    """ASPIC+ writer must surface the qualified attacks list post-#1679."""
+
+    def test_writer_surfaces_attacks_top_level(self) -> None:
+        """The qualified attacks list survives ``_write_aspic_to_state``.
+
+        Pre-fix the writer dropped ``output["attacks"]`` on the floor; the
+        entry was persisted with no ``attacks`` field at all. Post-fix
+        ``entry["attacks"]`` mirrors the handler's qualified list, top-level.
+        """
+        state = _new_state()
+        output = _stub_post1679_output()
+        _write_aspic_to_state(output, state, {})
+
+        assert len(state.aspic_results) == 1
+        entry = state.aspic_results[0]
+        assert "attacks" in entry, (
+            "writer dropped the qualified attacks list — #1649 loss: "
+            "ASPIC+ projected as a Dung copy with no arbitration signal"
+        )
+        assert isinstance(entry["attacks"], list)
+        assert len(entry["attacks"]) == 3, (
+            f"expected 3 qualified attacks (undercut/rebut/undermine), "
+            f"got {len(entry['attacks'])}: {entry['attacks']!r}"
+        )
+
+    def test_writer_preserves_attack_shape_and_scope(self) -> None:
+        """Each attack keeps ``scope`` (the singular contribution of ASPIC+)."""
+        state = _new_state()
+        _write_aspic_to_state(_stub_post1679_output(), state, {})
+
+        attacks = state.aspic_results[0]["attacks"]
+        scopes = sorted(a["scope"] for a in attacks)
+        assert scopes == ["rebut", "undercut", "undermine"], (
+            f"expected undercut+rebut+undermine, got {scopes}"
+        )
+        for attack in attacks:
+            assert set(attack.keys()) >= {
+                "attacker_rule",
+                "attacker_premises",
+                "target",
+                "scope",
+            }, f"attack missing required key: {attack!r}"
+            assert isinstance(attack["attacker_premises"], list)
+
+    def test_writer_attacks_empty_when_handler_returns_no_attacks(self) -> None:
+        """When the handler produced no Dung edges, ``attacks`` is ``[]``,
+        not ``None`` (so downstream readers never see the distinction)."""
+        state = _new_state()
+        output = _stub_post1679_output()
+        output["attacks"] = []
+        output["statistics"]["attacks_count"] = 0
+        output["statistics"]["dung_attacks_count"] = 0
+        _write_aspic_to_state(output, state, {})
+
+        entry = state.aspic_results[0]
+        assert entry["attacks"] == []
+        assert "attacks" in entry, (
+            "writer must serialize an empty attacks list as a present key"
+        )
+
+    def test_writer_ignores_non_list_attacks(self) -> None:
+        """Defensive: a malformed ``attacks`` (e.g. a string) is normalized
+        to ``None`` so the entry serializes ``[]`` rather than crashing."""
+        state = _new_state()
+        output = _stub_post1679_output()
+        output["attacks"] = "not-a-list"
+        _write_aspic_to_state(output, state, {})
+
+        assert state.aspic_results[0]["attacks"] == []
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TestAspicWriterBackwardsCompat1649 — the 3-arg signature stays alive
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAspicWriterBackwardsCompat1649:
+    """``add_aspic_result(reasoner, ext, stats)`` must keep working."""
+
+    def test_add_aspic_result_3arg_unchanged(self) -> None:
+        """The 3-arg form (no ``attacks``) keeps the legacy contract."""
+        state = _new_state()
+        aid = state.add_aspic_result("grounded", ["ext1"], {"time_ms": 42})
+        assert aid.startswith("aspic_")
+        entry = state.aspic_results[0]
+        assert entry["reasoner_type"] == "grounded"
+        assert entry["statistics"]["time_ms"] == 42
+        # The new field defaults to ``[]`` (serialized None), not missing:
+        assert entry["attacks"] == []
+        assert "attacks" in entry


### PR DESCRIPTION
## #1649 — ASPIC+ writer must surface the qualified attacks list

Resolves the writer-side loss exposed by #1679 (the ASPIC+ feeding PR). The handler now produces a qualified attacks list with structural scope (`undercut` / `rebut` / `undermine` / `unresolved`), but the writer dropped it on the floor: `state.aspic_results[0]` had no `attacks` field, the axis projected as a Dung copy, and the unique singular contribution of ASPIC+ (#1649) was invisible to any reader of the state.

### The fix — two coordinated edits

**1. `core/shared_state.py:add_aspic_result`** — extend the signature with `attacks: Optional[List[Dict[str, Any]]] = None` (default keeps all 3-arg callers backward compatible: SK plugin wrappers, tests, fixtures). The new field is serialized as `[]` when `None` so downstream readers never see the distinction between "handler ran, no attacks" and "writer dropped the field".

**2. `orchestration/state_writers.py:_write_aspic_to_state`** — read `output.get("attacks")`, normalize non-list shapes to `None` (defensive — a malformed value should not crash the writer), pass to `add_aspic_result(reasoner_type, extensions, statistics, attacks=attacks)`.

### Anti-pendule

- **Top-level entry field, not a `formalism_specific` sidecar.** The ABA writer (site 1 of #1648 Wave-2, PR #1680) uses the sidecar pattern because `dung_frameworks` has a constrained `arguments/attacks/extensions` projection. `aspic_results` is a flat list with explicit peer fields (`extensions`, `statistics`) — `attacks` is a peer, the top-level shape is the natural one. Recording the design choice in the docstring so the next site-by-site fix picks the right shape.
- **SK plugin signatures untouched.** `state_manager_plugin.py` and `phase_scoped_state.py` keep their 3-arg `add_aspic_result` wrappers — the LLM does not write attacks, the writer does, post-handler. The LLM-facing surface is preserved.
- **11 readers of `aspic_results` not migrated** — sanitize_state, restitution, deep_synthesis, appendix, multi_format_exporter, reprompt_trace, tweety_result_interpretation_plugin, conversational_orchestrator, conversational_benchmark, … A reader that wants the field reads `entry["attacks"]`. Anti-pendule: additif, single site, no reader migration.

### Privacy

Synthetic atoms only in tests (`r_main`, `r_neg_main`, `concl_x`, `p`, `q`, `a`, `b`). **Known gap** (out of scope, follow-up): `sanitize_state.py` does not yet opacify `aspic_results[*].attacks.attacker_premises` or `.attacker_rule` — these may carry corpus tokens in production (LLM-named rules that survive id validation in #1679's translator). The sanitiser update is its own task; the coord's anti-pendule rule forbids addressing here.

### Anti-#1019 discipline (R761/R764/R765/R767)

- **Real writer, handler stub.** `test_state_writers_1649.py` drives `_write_aspic_to_state` directly (no mocked writer) and stubs the handler output to mirror the post-#1679 shape. A mocked writer would just agree with itself.
- **Differential proven.** With the writer edits reverted (5 tests FAIL — `writer dropped the qualified attacks list`, `writer dropped attacks shape`, etc.); with the edits in place (5 tests PASS — `attacks` flows to state with all 3 scopes preserved).

### DoD checklist (the writer-side line items of #1649)

- [x] The entry `state.aspic_results[-1]` carries a `attacks` list paralleling `extensions` and `statistics`.
- [x] Each attack preserves `{attacker_rule, attacker_premises, target, scope}`.
- [x] All 4 ASPIC+ scopes (`undercut` / `rebut` / `undermine` / `unresolved`) survive the writer boundary (the 3 non-`unresolved` scopes pinned by separate assertions).
- [x] Empty handler `attacks` serializes to `[]` (not `None`, not missing).
- [x] Malformed `attacks` (non-list) normalizes to `None` → `[]`.
- [x] `add_aspic_result(reasoner_type, extensions, statistics)` — the legacy 3-arg form — still works and now defaults `attacks` to `[]`.
- [x] **No reader migration** — sanitize_state, restitution, appendix, etc. unchanged.
- [x] **SK plugin signatures unchanged** — LLM-facing surface preserved.

### Validation

- **mypy strict** on the 2 modified source files: **0 issues**.
- **`test_state_writers_1649.py`** (new): **5 passed**.
- **`test_state_writers_1648.py` + `test_unified_pipeline.py`** (regression): **169 passed, 9 xfailed** (unrelated sites).
- **Differential** (stash writer → run new tests): 5 FAIL; pop stash → 5 PASS.

### Scope — writer-side only

This PR closes the writer-side line of #1649. The reader-side (prose channel for ASPIC+ arbitration, `#1667` presence channel at 2/5 axes) is a separate task — a reader over an inert axis is theatre #1019, and the writer-side prerequisite is exactly what this PR delivers.

🤖 Worker myia-po-2025 — R769 (ASPIC+ writer-side, post-#1679)
