### PR TITLE
fix(setaf): sidecar formalism_specific carries joint attacks through state (#1648 Wave-2 site 2)

### DIFF
--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -1301,16 +1301,52 @@ def _write_sat_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
 
 
 def _write_setaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
-    """Write SetAF results to UnifiedAnalysisState (#87)."""
+    """Write SetAF results to UnifiedAnalysisState (#87).
+
+    #1648 Wave-2 site 2: SetAF's distinctive piece of data is the
+    *joint* attack list (``List[{attackers: List[str], target: str}]``) that
+    the handler computes and the writer used to drop on the floor
+    (handler at ``setaf_handler.py:120-131`` returns it; writer at
+    ``state_writers.py:1303-1313`` discarded it with the comment "set
+    attacks don't map to binary attacks"). The native Dung projection
+    cannot store joint attacks in its binary ``attacks`` field, so we
+    attach a strictly-additive ``formalism_specific`` sidecar to the
+    entry dict without touching the ``attacks`` / ``extensions`` /
+    ``arguments`` projections. The 12 readers of ``dung_frameworks``
+    (pattern_mining, deep_synthesis_agent, act2/3 restitution,
+    visualization, …) are not migrated: a downstream reader that wants
+    the joint attacks reads
+    ``entry["formalism_specific"]["set_attacks"]``.
+    """
     _record_structured_arg_status(state, "setaf_reasoning", output, ctx)
     if not output or not isinstance(output, dict):
         return
-    state.add_dung_framework(
+    df_id = state.add_dung_framework(
         name=f"setaf_{output.get('semantics', 'grounded')}",
         arguments=output.get("arguments", []),
         attacks=[],  # set attacks don't map to binary attacks
         extensions={"setaf_extensions": output.get("extensions", [])},
     )
+    # #1648 Wave-2 sidecar: preserve the joint attacks the handler
+    # returns under ``output["attacks"]``. Empty list ⇒ sidecar stays
+    # absent (no ``formalism_specific`` key — empty handler output is
+    # indistinguishable from a handler that never ran, so we don't
+    # synthesize a key).
+    set_attacks = output.get("attacks")
+    if isinstance(set_attacks, list) and set_attacks:
+        # Defensive: each entry must be a dict with ``attackers`` and
+        # ``target`` keys; drop malformed entries rather than crash the
+        # writer boundary.
+        sanitised = [
+            dict(a) for a in set_attacks
+            if isinstance(a, dict)
+            and isinstance(a.get("attackers"), list)
+            and isinstance(a.get("target"), str)
+        ]
+        if sanitised:
+            state.dung_frameworks[df_id]["formalism_specific"] = {
+                "set_attacks": sanitised,
+            }
 
 
 def _write_weighted_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
@@ -212,14 +212,28 @@ class TestSetafFlattening1648:
 
     Section 2.3: ``handler.analyze_setaf`` returns ``attacks`` at
     ``setaf_handler.py:123`` as ``List[{attackers: List[str], target: str}]``.
-    Writer at ``state_writers.py:1199-1209`` ignores them with the comment
-    "set attacks don't map to binary attacks".
+    Writer at ``state_writers.py:1303-1341`` attaches them to a strictly
+    additive ``formalism_specific`` sidecar (joint attacks don't fit the
+    binary ``attacks`` projection).
 
-    Today's expected failure: ``state.dung_frameworks[<id>]["attacks"]`` is
-    ``[]`` and the joint-attack list is not in ``extensions`` either.
+    #1648 Wave-2 site 2 (this PR): the writer now mirrors the joint
+    attacks into ``entry["formalism_specific"]["set_attacks"]``. The 12
+    readers of ``dung_frameworks`` see the same ``attacks=[]`` and
+    ``extensions={"setaf_extensions": [...]}`` as before — only readers
+    that look for ``formalism_specific["set_attacks"]`` pick up the
+    joint attacks. SetAF still cannot refute anything via the binary Dung
+    projection, but it can be refuted via its own joint attacks in the
+    sidecar.
+
+    Pin: today's expected behaviour on the test stub is that the joint
+    attacks that the *real* handler returns now reach the state via the
+    sidecar. The xfail marker from #1672 R767 is removed (the
+    strict=True contract would flip the test to a strict failure as
+    soon as it passed).
     """
 
     def _stub_handler_output(self) -> Dict[str, Any]:
+        """Mimic the post-#1679 handler output (returns ``attacks`` already)."""
         return {
             "semantics": "grounded",
             "arguments": ["a", "b", "c"],
@@ -232,29 +246,84 @@ class TestSetafFlattening1648:
             "statistics": {"arguments_count": 3, "attacks_count": 2},
         }
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Pinning #1648 Wave-1 known loss (SetAF). Handler returns joint "
-        "attacks, writer drops them at state_writers.py:1199-1209. Wave-2 fix.",
-    )
-    def test_setaf_writer_preserves_set_attacks(self) -> None:
+    def test_setaf_writer_attaches_set_attacks_sidecar(self) -> None:
+        """Joint attacks survive in ``formalism_specific``.
+
+        Pre-fix the writer dropped ``output["attacks"]`` on the floor:
+        ``entry["attacks"]`` was ``[]`` (binary field — joint attacks
+        don't fit) and the joint list was lost. Post-fix the writer
+        attaches ``entry["formalism_specific"]["set_attacks"]`` mirroring
+        the handler's output verbatim.
+        """
         state = _new_state()
         output = self._stub_handler_output()
 
         _write_setaf_to_state(output, state, {})
 
         entry = next(iter(state.dung_frameworks.values()))
-        extensions = entry.get("extensions", {})
-        formalism_specific = entry.get("formalism_specific", {})
-        # The joint-attack list must survive somewhere.
-        has_set_attacks = (
-            extensions.get("set_attacks") == output["attacks"]
-            or "set_attacks" in extensions
-            or formalism_specific.get("set_attacks") == output["attacks"]
+        # Binary projection stays untouched — the Dung projection has
+        # no slot for joint attacks, and the readers expect it empty.
+        assert entry["attacks"] == [], (
+            "SetAF writer must keep ``attacks=[]`` for the binary Dung "
+            f"projection — the sidecar carries the joint attacks. "
+            f"Got non-empty: {entry['attacks']!r}"
         )
-        assert has_set_attacks, (
-            "SetAF writer dropped joint attacks (handler returned them): "
-            f"extensions={extensions!r}, formalism_specific={formalism_specific!r}"
+        # The sidecar is present and carries the joint attacks verbatim.
+        formalism_specific = entry.get("formalism_specific", {})
+        assert formalism_specific.get("set_attacks") == output["attacks"], (
+            "SetAF writer did not mirror the handler's joint attacks into "
+            f"``formalism_specific.set_attacks``: got {formalism_specific!r}, "
+            f"expected set_attacks={output['attacks']!r}"
+        )
+
+    def test_setaf_writer_omits_sidecar_when_handler_returns_empty_attacks(
+        self,
+    ) -> None:
+        """An empty ``attacks`` list ⇒ no ``formalism_specific`` key.
+
+        We don't synthesize a sidecar for empty input: an empty handler
+        output is indistinguishable from a handler that never ran, and
+        downstream readers should not see a phantom key.
+        """
+        state = _new_state()
+        output = self._stub_handler_output()
+        output["attacks"] = []
+        output["statistics"]["attacks_count"] = 0
+
+        _write_setaf_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        assert "formalism_specific" not in entry, (
+            "SetAF writer must NOT attach ``formalism_specific`` when the "
+            "handler returned no joint attacks — synthesising a sidecar "
+            f"for empty input would mislead downstream readers. Got: {entry!r}"
+        )
+
+    def test_setaf_writer_drops_malformed_set_attack_entries(self) -> None:
+        """Defensive: a malformed joint-attack entry (no ``attackers`` key
+        or non-list ``attackers``) is dropped rather than crashing the
+        writer boundary. Valid entries still pass through."""
+        state = _new_state()
+        output = self._stub_handler_output()
+        output["attacks"] = [
+            {"attackers": ["a", "b"], "target": "c"},     # valid
+            {"target": "b"},                              # missing attackers
+            {"attackers": "not-a-list", "target": "d"},   # wrong shape
+            {"attackers": [], "target": "e"},             # empty set (valid)
+        ]
+
+        _write_setaf_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        formalism_specific = entry.get("formalism_specific", {})
+        sanitised = formalism_specific.get("set_attacks", [])
+        # Only the well-formed entries survive (the valid + the empty set).
+        assert sanitised == [
+            {"attackers": ["a", "b"], "target": "c"},
+            {"attackers": [], "target": "e"},
+        ], (
+            "SetAF writer must drop malformed joint-attack entries "
+            f"instead of crashing — got {sanitised!r}"
         )
 
 


### PR DESCRIPTION
## #1648 — SetAF writer must surface the joint attacks list (Wave-2 site 2)

Replicates the additive sidecar pattern from PR #1680 (ABA, Wave-2 site 1) onto SetAF. The inventory at `c7321ad7` (R762) flagged SetAF as a **writer-side loss**: the handler at `setaf_handler.py:120-131` already returns the joint attack list (`List[{attackers, target}]`), but the writer at `state_writers.py:1303-1313` hard-codes `attacks=[]` with the comment "set attacks don't map to binary attacks" — and the joint list never reaches the state.

### The fix — one coordinated edit

**`core/orchestration/state_writers.py:_write_setaf_to_state`** — capture the `df_id` returned by `add_dung_framework`, normalise `output["attacks"]` (defensive: must be a list of dicts with `attackers` (list) and `target` (str)), and attach `state.dung_frameworks[df_id]["formalism_specific"] = {"set_attacks": sanitised}` strictly additively. The binary `attacks=[]` / `extensions={"setaf_extensions": [...]}` / `arguments` projections are untouched.

### Anti-pendule

- **Strict sidecar pattern, same shape as #1680.** ABA → `formalism_specific.contraries`; SetAF → `formalism_specific.set_attacks`. Same writer pattern, same field name, same additive scope. The 9 remaining sites (ADF, Weighted, Social, EAF, DeLP, DL, CL, SAT, QBF) will follow the same template per the inventory.
- **No handler change.** Unlike ABA (whose handler had to be modified to echo `contraries`), SetAF's handler ALREADY returns the joint attacks at line 123 — the loss is purely writer-side. This PR is a writer edit only.
- **Empty handler output ⇒ no `formalism_specific` key.** Empty input is indistinguishable from "handler never ran", so we don't synthesise a phantom key.
- **Defensive normalisation.** A malformed entry (missing `attackers`, non-list `attackers`, non-string `target`) is dropped silently rather than crashing the writer boundary — the same posture as the ASPIC+ writer (PR #1681).
- **No reader migration.** The 12 readers of `dung_frameworks` (pattern_mining, deep_synthesis_agent, act2/3 restitution, visualization, …) are NOT touched. A reader that wants the joint attacks reads `entry["formalism_specific"]["set_attacks"]`.

### Privacy

Synthetic atoms only in tests (`a`, `b`, `c`). **Known gap** (out of scope, follow-up): `sanitize_state.py` does not yet opacify `dung_frameworks[*].formalism_specific.set_attacks[*].attackers` — these may carry corpus tokens in production (LLM-derived set-attack specs). The sanitiser update is its own task; coord's anti-pendule rule forbids bundling it here.

### Anti-#1019 discipline (R761/R764/R765/R767)

- **Real writer, handler stub.** `test_state_writers_1648.py::TestSetafFlattening1648` drives `_write_setaf_to_state` directly (no mocked writer) and stubs the handler output to mirror `setaf_handler.py:120-131`. A mocked writer would just agree with itself.
- **Differential proven.** Stash the writer edit → 2 tests FAIL (the bug bites); pop the stash → 3 tests PASS. The PASS under stash (`test_setaf_writer_omits_sidecar_when_handler_returns_empty_attacks`) is a vacuous positive — the unfixed writer also omits the sidecar — but it serves as a **future regression guard**: a future "fix" that synthesises an empty sidecar for empty input would fail it.
- **Strict-xfail marker removed.** The R767 convention requires the marker to leave with the fix — `strict=True` would flip the test to a loud failure the moment it passes. The marker was removed in the same commit that flips the assertion to PASS.

### DoD checklist (the writer-side line items of #1648 SetAF)

- [x] The entry `state.dung_frameworks[<id>]["formalism_specific"]["set_attacks"]` mirrors the handler's joint attacks list.
- [x] The binary `attacks` field stays `[]` (untouched — the Dung projection has no slot for joint attacks).
- [x] Empty `output["attacks"]` ⇒ no `formalism_specific` key (no phantom empty sidecar).
- [x] Malformed entries (missing `attackers`, wrong shape) are dropped, well-formed entries pass through.
- [x] **No reader migration** — `pattern_mining`, `deep_synthesis_agent`, `act2_narrative_plugin`, `act3_conclusion_plugin`, etc. unchanged.
- [x] **No handler change** — unlike ABA, SetAF's handler already returns the data; the writer is the sole loss point.

### Validation

- **mypy strict** on the modified source file (`state_writers.py`): **0 issues**.
- **`test_state_writers_1648.py`** (SetAF bloc): **3 passed** (post-fix).
- **`test_state_writers_1648.py` + `test_state_writers_1649.py`** (regression): **13 passed, 6 xfailed** (6 xfail = the remaining Wave-2 sites: ADF, Weighted, Social, EAF, DeLP, DL/CL/SAT/QBF).
- **`test_unified_pipeline.py`** (regression): **167 passed**.
- **Differential** (stash writer edit → run new tests): 2 FAIL; pop stash → 3 PASS.

### Scope — writer-side only

This PR closes the writer-side line of #1648 SetAF (Wave-2 site 2). The remaining 9 sites (ADF, Weighted, Social, EAF, DeLP, DL, CL, SAT, QBF) will follow the same site-by-site additive pattern in subsequent PRs — the template is proven, the discipline is locked.

🤖 Worker myia-po-2025 — R770 (SetAF writer-side, Wave-2 site 2)
