### PR TITLE
fix(weighted): sidecar formalism_specific carries attack weights + statistics through state (#1648 Wave-2 site 3)

### DIFF
--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -1301,16 +1301,52 @@ def _write_sat_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
 
 
 def _write_setaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
-    """Write SetAF results to UnifiedAnalysisState (#87)."""
+    """Write SetAF results to UnifiedAnalysisState (#87).
+
+    #1648 Wave-2 site 2: SetAF's distinctive piece of data is the
+    *joint* attack list (``List[{attackers: List[str], target: str}]``) that
+    the handler computes and the writer used to drop on the floor
+    (handler at ``setaf_handler.py:120-131`` returns it; writer at
+    ``state_writers.py:1303-1313`` discarded it with the comment "set
+    attacks don't map to binary attacks"). The native Dung projection
+    cannot store joint attacks in its binary ``attacks`` field, so we
+    attach a strictly-additive ``formalism_specific`` sidecar to the
+    entry dict without touching the ``attacks`` / ``extensions`` /
+    ``arguments`` projections. The 12 readers of ``dung_frameworks``
+    (pattern_mining, deep_synthesis_agent, act2/3 restitution,
+    visualization, …) are not migrated: a downstream reader that wants
+    the joint attacks reads
+    ``entry["formalism_specific"]["set_attacks"]``.
+    """
     _record_structured_arg_status(state, "setaf_reasoning", output, ctx)
     if not output or not isinstance(output, dict):
         return
-    state.add_dung_framework(
+    df_id = state.add_dung_framework(
         name=f"setaf_{output.get('semantics', 'grounded')}",
         arguments=output.get("arguments", []),
         attacks=[],  # set attacks don't map to binary attacks
         extensions={"setaf_extensions": output.get("extensions", [])},
     )
+    # #1648 Wave-2 sidecar: preserve the joint attacks the handler
+    # returns under ``output["attacks"]``. Empty list ⇒ sidecar stays
+    # absent (no ``formalism_specific`` key — empty handler output is
+    # indistinguishable from a handler that never ran, so we don't
+    # synthesize a key).
+    set_attacks = output.get("attacks")
+    if isinstance(set_attacks, list) and set_attacks:
+        # Defensive: each entry must be a dict with ``attackers`` and
+        # ``target`` keys; drop malformed entries rather than crash the
+        # writer boundary.
+        sanitised = [
+            dict(a) for a in set_attacks
+            if isinstance(a, dict)
+            and isinstance(a.get("attackers"), list)
+            and isinstance(a.get("target"), str)
+        ]
+        if sanitised:
+            state.dung_frameworks[df_id]["formalism_specific"] = {
+                "set_attacks": sanitised,
+            }
 
 
 def _write_weighted_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -1350,11 +1350,26 @@ def _write_setaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
 
 
 def _write_weighted_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
-    """Write Weighted AF results to UnifiedAnalysisState (#87)."""
+    """Write Weighted AF results to UnifiedAnalysisState (#87).
+
+    #1648 Wave-2 site 3: Weighted AF's distinctive piece of data is the
+    *numeric weight* on each attack (``List[{source, target, weight}]``,
+    plus ``weight_statistics: {min, max, avg}``) that the handler computes
+    at ``weighted_handler.py:139-144`` and the writer used to drop on the
+    floor by projecting to ``[src, tgt]`` pairs only. The native Dung
+    projection carries the binary attack but has no slot for the weight,
+    so we attach a strictly-additive ``formalism_specific`` sidecar to
+    the entry dict without touching the ``attacks`` / ``extensions`` /
+    ``arguments`` projections. The 12 readers of ``dung_frameworks``
+    (pattern_mining, deep_synthesis_agent, act2/3 restitution,
+    visualization, …) are not migrated: a downstream reader that wants
+    the weights reads ``entry["formalism_specific"]["attack_weights"]``
+    (and optionally ``entry["formalism_specific"]["weight_statistics"]``).
+    """
     _record_structured_arg_status(state, "weighted_argumentation", output, ctx)
     if not output or not isinstance(output, dict):
         return
-    state.add_dung_framework(
+    df_id = state.add_dung_framework(
         name=f"weighted_{output.get('semantics', 'grounded')}",
         arguments=output.get("arguments", []),
         attacks=[
@@ -1364,6 +1379,40 @@ def _write_weighted_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> No
         ],
         extensions={"weighted_extensions": output.get("extensions", [])},
     )
+    # #1648 Wave-2 sidecar: preserve the per-attack weight the handler
+    # returns under ``output["attacks"]`` (and the aggregate statistics
+    # of those weights). Empty list ⇒ sidecar stays absent (no
+    # ``formalism_specific`` key — empty handler output is
+    # indistinguishable from a handler that never ran, so we don't
+    # synthesize a key).
+    weighted_attacks = output.get("attacks")
+    sidecar: dict[str, Any] = {}
+    if isinstance(weighted_attacks, list) and weighted_attacks:
+        # Defensive: each entry must be a dict with ``source`` (str)
+        # and ``target`` (str) and a numeric ``weight``; drop malformed
+        # entries rather than crash the writer boundary.
+        sanitised = [
+            {"source": a["source"], "target": a["target"], "weight": float(a["weight"])}
+            for a in weighted_attacks
+            if isinstance(a, dict)
+            and isinstance(a.get("source"), str)
+            and isinstance(a.get("target"), str)
+            and isinstance(a.get("weight"), (int, float))
+        ]
+        if sanitised:
+            sidecar["attack_weights"] = sanitised
+    weight_stats = output.get("weight_statistics")
+    if isinstance(weight_stats, dict) and weight_stats:
+        # Sanitise: keep only numeric min/max/avg if present.
+        stats_clean: dict[str, float] = {}
+        for key in ("min_weight", "max_weight", "avg_weight"):
+            val = weight_stats.get(key)
+            if isinstance(val, (int, float)):
+                stats_clean[key] = float(val)
+        if stats_clean:
+            sidecar["weight_statistics"] = stats_clean
+    if sidecar:
+        state.dung_frameworks[df_id]["formalism_specific"] = sidecar
 
 
 def _write_social_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
@@ -212,14 +212,28 @@ class TestSetafFlattening1648:
 
     Section 2.3: ``handler.analyze_setaf`` returns ``attacks`` at
     ``setaf_handler.py:123`` as ``List[{attackers: List[str], target: str}]``.
-    Writer at ``state_writers.py:1199-1209`` ignores them with the comment
-    "set attacks don't map to binary attacks".
+    Writer at ``state_writers.py:1303-1341`` attaches them to a strictly
+    additive ``formalism_specific`` sidecar (joint attacks don't fit the
+    binary ``attacks`` projection).
 
-    Today's expected failure: ``state.dung_frameworks[<id>]["attacks"]`` is
-    ``[]`` and the joint-attack list is not in ``extensions`` either.
+    #1648 Wave-2 site 2 (this PR): the writer now mirrors the joint
+    attacks into ``entry["formalism_specific"]["set_attacks"]``. The 12
+    readers of ``dung_frameworks`` see the same ``attacks=[]`` and
+    ``extensions={"setaf_extensions": [...]}`` as before — only readers
+    that look for ``formalism_specific["set_attacks"]`` pick up the
+    joint attacks. SetAF still cannot refute anything via the binary Dung
+    projection, but it can be refuted via its own joint attacks in the
+    sidecar.
+
+    Pin: today's expected behaviour on the test stub is that the joint
+    attacks that the *real* handler returns now reach the state via the
+    sidecar. The xfail marker from #1672 R767 is removed (the
+    strict=True contract would flip the test to a strict failure as
+    soon as it passed).
     """
 
     def _stub_handler_output(self) -> Dict[str, Any]:
+        """Mimic the post-#1679 handler output (returns ``attacks`` already)."""
         return {
             "semantics": "grounded",
             "arguments": ["a", "b", "c"],
@@ -232,29 +246,84 @@ class TestSetafFlattening1648:
             "statistics": {"arguments_count": 3, "attacks_count": 2},
         }
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Pinning #1648 Wave-1 known loss (SetAF). Handler returns joint "
-        "attacks, writer drops them at state_writers.py:1199-1209. Wave-2 fix.",
-    )
-    def test_setaf_writer_preserves_set_attacks(self) -> None:
+    def test_setaf_writer_attaches_set_attacks_sidecar(self) -> None:
+        """Joint attacks survive in ``formalism_specific``.
+
+        Pre-fix the writer dropped ``output["attacks"]`` on the floor:
+        ``entry["attacks"]`` was ``[]`` (binary field — joint attacks
+        don't fit) and the joint list was lost. Post-fix the writer
+        attaches ``entry["formalism_specific"]["set_attacks"]`` mirroring
+        the handler's output verbatim.
+        """
         state = _new_state()
         output = self._stub_handler_output()
 
         _write_setaf_to_state(output, state, {})
 
         entry = next(iter(state.dung_frameworks.values()))
-        extensions = entry.get("extensions", {})
-        formalism_specific = entry.get("formalism_specific", {})
-        # The joint-attack list must survive somewhere.
-        has_set_attacks = (
-            extensions.get("set_attacks") == output["attacks"]
-            or "set_attacks" in extensions
-            or formalism_specific.get("set_attacks") == output["attacks"]
+        # Binary projection stays untouched — the Dung projection has
+        # no slot for joint attacks, and the readers expect it empty.
+        assert entry["attacks"] == [], (
+            "SetAF writer must keep ``attacks=[]`` for the binary Dung "
+            f"projection — the sidecar carries the joint attacks. "
+            f"Got non-empty: {entry['attacks']!r}"
         )
-        assert has_set_attacks, (
-            "SetAF writer dropped joint attacks (handler returned them): "
-            f"extensions={extensions!r}, formalism_specific={formalism_specific!r}"
+        # The sidecar is present and carries the joint attacks verbatim.
+        formalism_specific = entry.get("formalism_specific", {})
+        assert formalism_specific.get("set_attacks") == output["attacks"], (
+            "SetAF writer did not mirror the handler's joint attacks into "
+            f"``formalism_specific.set_attacks``: got {formalism_specific!r}, "
+            f"expected set_attacks={output['attacks']!r}"
+        )
+
+    def test_setaf_writer_omits_sidecar_when_handler_returns_empty_attacks(
+        self,
+    ) -> None:
+        """An empty ``attacks`` list ⇒ no ``formalism_specific`` key.
+
+        We don't synthesize a sidecar for empty input: an empty handler
+        output is indistinguishable from a handler that never ran, and
+        downstream readers should not see a phantom key.
+        """
+        state = _new_state()
+        output = self._stub_handler_output()
+        output["attacks"] = []
+        output["statistics"]["attacks_count"] = 0
+
+        _write_setaf_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        assert "formalism_specific" not in entry, (
+            "SetAF writer must NOT attach ``formalism_specific`` when the "
+            "handler returned no joint attacks — synthesising a sidecar "
+            f"for empty input would mislead downstream readers. Got: {entry!r}"
+        )
+
+    def test_setaf_writer_drops_malformed_set_attack_entries(self) -> None:
+        """Defensive: a malformed joint-attack entry (no ``attackers`` key
+        or non-list ``attackers``) is dropped rather than crashing the
+        writer boundary. Valid entries still pass through."""
+        state = _new_state()
+        output = self._stub_handler_output()
+        output["attacks"] = [
+            {"attackers": ["a", "b"], "target": "c"},     # valid
+            {"target": "b"},                              # missing attackers
+            {"attackers": "not-a-list", "target": "d"},   # wrong shape
+            {"attackers": [], "target": "e"},             # empty set (valid)
+        ]
+
+        _write_setaf_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        formalism_specific = entry.get("formalism_specific", {})
+        sanitised = formalism_specific.get("set_attacks", [])
+        # Only the well-formed entries survive (the valid + the empty set).
+        assert sanitised == [
+            {"attackers": ["a", "b"], "target": "c"},
+            {"attackers": [], "target": "e"},
+        ], (
+            "SetAF writer must drop malformed joint-attack entries "
+            f"instead of crashing — got {sanitised!r}"
         )
 
 

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
@@ -372,18 +372,15 @@ class TestAdfFlattening1648:
 
 
 class TestWeightedFlattening1648:
-    """Weighted writer extracts only ``[src, tgt]`` from each attack dict.
+    """Weighted writer carries attack weights via the sidecar (Wave-2 site 3).
 
     The handler returns ``output["attacks"]`` as ``List[{source, target, weight}]``
-    but the writer at ``state_writers.py:1212-1226`` projects to ``[src, tgt]``
-    pairs only. The weight is invisible to readers.
+    plus ``weight_statistics: {min, max, avg}``. The writer at
+    ``state_writers.py:1352-1428`` projects the binary attacks to ``[src, tgt]``
+    pairs (preserved) and attaches the dropped weight list to the strictly
+    additive ``formalism_specific`` sidecar.
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Pinning #1648 Wave-1 known loss (Weighted). Handler returns "
-        "weights, writer projects to [src, tgt] only. Wave-2 fix.",
-    )
     def test_weighted_writer_preserves_attack_weights(self) -> None:
         state = _new_state()
         output = {
@@ -394,23 +391,69 @@ class TestWeightedFlattening1648:
                 {"source": "b", "target": "c", "weight": 0.5},
             ],
             "extensions": [["a", "c"]],
+            "weight_statistics": {
+                "min_weight": 0.5,
+                "max_weight": 0.9,
+                "avg_weight": 0.7,
+            },
         }
 
         _write_weighted_to_state(output, state, {})
 
         entry = next(iter(state.dung_frameworks.values()))
-        extensions = entry.get("extensions", {})
-        formalism_specific = entry.get("formalism_specific", {})
-        has_weights = (
-            extensions.get("weights") is not None
-            or "weights" in extensions
-            or "weights" in formalism_specific
-            or any(len(pair) > 2 for pair in entry["attacks"])  # weight in pair
-        )
-        assert has_weights, (
-            f"Weighted writer dropped attack weights: attacks={entry['attacks']!r}, "
-            f"extensions={extensions!r}, formalism_specific={formalism_specific!r}"
-        )
+        # Binary Dung projection untouched: attacks carry [src, tgt] pairs.
+        assert entry["attacks"] == [["a", "b"], ["b", "c"]], entry["attacks"]
+        # Sidecar carries the weights.
+        sidecar = entry.get("formalism_specific", {})
+        assert sidecar.get("attack_weights") == [
+            {"source": "a", "target": "b", "weight": 0.9},
+            {"source": "b", "target": "c", "weight": 0.5},
+        ], sidecar
+        assert sidecar.get("weight_statistics") == {
+            "min_weight": 0.5,
+            "max_weight": 0.9,
+            "avg_weight": 0.7,
+        }, sidecar
+
+    def test_weighted_writer_omits_sidecar_when_attacks_empty(self) -> None:
+        """Empty attacks ⇒ no ``formalism_specific`` key (no phantom sidecar)."""
+        state = _new_state()
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "attacks": [],
+            "extensions": [["a", "b"]],
+        }
+
+        _write_weighted_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        assert "formalism_specific" not in entry, entry
+
+    def test_weighted_writer_drops_malformed_attack_entries(self) -> None:
+        """Defensive: malformed entries are dropped, well-formed ones pass."""
+        state = _new_state()
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b", "c"],
+            "attacks": [
+                {"source": "a", "target": "b", "weight": 0.9},  # OK
+                {"source": "b"},  # missing target + weight
+                {"source": "c", "target": "d", "weight": "bad"},  # weight not numeric
+                {"source": "x", "target": "y", "weight": 0.3},  # OK
+            ],
+            "extensions": [],
+        }
+
+        _write_weighted_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        sidecar = entry.get("formalism_specific", {})
+        assert sidecar.get("attack_weights") == [
+            {"source": "a", "target": "b", "weight": 0.9},
+            {"source": "x", "target": "y", "weight": 0.3},
+        ], sidecar
+        # weight_statistics absent because none was provided.
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Contexte

Wave-2 site 3 of 11 du motif d'aplatissement #1648. Pattern sidecar additif (ABA #1680, SetAF #1683) répliqué sur Weighted AF.

L'inventaire (#1672, `c7321ad7`) a classé Weighted en **REAL LOSS** : le handler à `weighted_handler.py:139-144` retourne une liste de dicts `{source, target, weight}` + un agrégat `weight_statistics`, mais le writer à `state_writers.py:1352-1366` projetait sur des paires `[src, tgt]` et **dropait** à la fois le poids et les statistiques.

## Fix — un seul edit coordonné (writer only)

**`orchestration/state_writers.py:_write_weighted_to_state`** — capture le `df_id` retourné par `add_dung_framework`, sanitise `output['attacks']` (defensive : drop les entries sans `source`/`target` ou avec `weight` non-numérique), sanitise `weight_statistics` (garder uniquement `min_weight`/`max_weight`/`avg_weight` numériques), attache `state.dung_frameworks[df_id]['formalism_specific'] = {'attack_weights': [...], 'weight_statistics': {...}}` strictement additivement. Les projections `attacks`/`extensions`/`arguments` sont **intouchées** — les 12 readers de `dung_frameworks` (pattern_mining, deep_synthesis_agent, restitution act2/3, visualization) ne sont pas migrés.

## Anti-pendule

- **Scope honnête** : Weighted ne peut pas exprimer des attaques pondérées via la projection binaire Dung (schéma trop pauvre) ; ce que cette PR restaure est la **visibilité** des poids pour tout reader aval qui opte-in via le sidecar.
- **Empty handler output ⇒ no sidecar key** (input vide = handler jamais tourné, ne pas synthétiser une clé fantôme).
- **Defensive normalization** : entrée malformée droppée silencieusement plutôt que crash writer boundary (posture ASPIC+ #1681).
- **Pas de migration reader** : `pattern_mining`, `deep_synthesis_agent`, restitution act2/3 inchangés. Un reader qui veut les poids lit `entry['formalism_specific']['attack_weights']`.

## Anti-#1019 (R761/R764/R765/R767)

- **Vrai writer + stub handler** : `test_state_writers_1648.py::TestWeightedFlattening1648` drive `_write_weighted_to_state` directement (no mocked writer) et stub le handler output pour mirrorer `weighted_handler.py:139-144`. Un mocked writer s'accorderait avec lui-même.
- **Différentiel prouvé** : stash writer edit → 2 tests FAIL (le bug mord) ; pop stash → 3 tests PASS. Le test "empty no-key" sert de regression guard futur contre une synthèse fantôme.
- **Strict-xfail marker removed** : `TestWeightedFlattening1648` perd son marker `xfail(strict=True)` posé en #1672 (R767) — le strict contract flip le test en loud failure dès qu'il passe, donc le marker doit partir avec le fix. Remplacé par 3 nouveaux tests pinnant le contrat sidecar (weights présents / empty no-key / malformed drop).

## Validation

- **mypy strict** sur `state_writers.py` : **0 issues**.
- **`test_state_writers_1648.py`** (bloc Weighted) : **3 passed** (post-fix).
- **`test_state_writers_1648.py` + `test_state_writers_1649.py`** (régression) : **13 passed, 5 xfailed** (5 = EAF, DeLP, DL, CL, QBF ; Weighted sauté après fix).
- **Blast radius** (`test_state_writers_1648` + `test_state_writers_1649` + `test_unified_pipeline`) : **183 passed, 5 xfailed, exit 0**.

## Privacy

Atomes synthétiques uniquement (`a`, `b`, `c`). **Known gap** (out of scope, follow-up) : `sanitize_state.py` n'opacifie pas encore `dung_frameworks[*].formalism_specific.attack_weights[*].source`/`target` — ceux-ci peuvent porter des tokens corpus en production (LLM-derived attack specs). Le sanitizer update est sa propre tâche ; l'anti-pendule du coord l'interdit ici.

## Anti-pendule (fichiers hors scope)

- **Pre-existing black non-compliance** dans `state_writers.py` (bloc SetAF l.1336-1344) **non fixé** ici : CI black est `continue-on-error: true`, anti-pendule du coord interdit d'étendre le scope.
- **Pre-existing missing trailing newline** dans `test_state_writers_1648.py` (dernier test QBF) **non touché** : même raison.

## Scope — writer-side only

Clôt la ligne writer-side de #1648 Weighted (Wave-2 site 3). Sites restants : **EAF, DeLP, DL, CL, QBF** (5 pertes réelles). ADF et Social déjà PASS le contrat inventaire (pas de perte) ; SAT hors périmètre (PySAT, pas JVM). Le pattern sidecar additif est maintenant éprouvé sur 3 sites (ABA + SetAF + Weighted).

🤖 Worker myia-po-2025 — R771 (Weighted writer-side, Wave-2 site 3)