### PR TITLE
fix(eaf): sidecar formalism_specific carries per-agent epistemic beliefs through state (#1648 Wave-2 site 4)

### DIFF
--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -1437,15 +1437,47 @@ def _write_social_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None
 
 
 def _write_eaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
-    """Write EAF results to UnifiedAnalysisState (#88)."""
+    """Write EAF results to UnifiedAnalysisState (#88).
+
+    #1648 Wave-2 site 4: EAF's distinctive piece of data is the
+    *per-agent epistemic beliefs* dict (``Dict[agent_name, List[arg_name]]``)
+    that the handler computes at ``eaf_handler.py:118`` and the writer
+    used to drop on the floor. The native Dung projection carries the
+    binary attack graph but has no slot for the multi-agent belief map,
+    so we attach a strictly-additive ``formalism_specific`` sidecar to
+    the entry dict without touching the ``attacks`` / ``extensions`` /
+    ``arguments`` projections. The 12 readers of ``dung_frameworks``
+    (pattern_mining, deep_synthesis_agent, act2/3 restitution,
+    visualization, …) are not migrated: a downstream reader that wants
+    the per-agent beliefs reads
+    ``entry["formalism_specific"]["epistemic_beliefs"]``.
+    """
     if not output or not isinstance(output, dict):
         return
-    state.add_dung_framework(
+    df_id = state.add_dung_framework(
         name=f"eaf_{output.get('semantics', 'grounded')}",
         arguments=output.get("arguments", []),
         attacks=[a for a in output.get("attacks", []) if isinstance(a, list)],
         extensions={"eaf_extensions": output.get("extensions", [])},
     )
+    # #1648 Wave-2 sidecar: preserve the per-agent epistemic beliefs the
+    # handler returns under ``output["epistemic_beliefs"]``. Empty dict
+    # ⇒ sidecar stays absent (no ``formalism_specific`` key — empty
+    # handler output is indistinguishable from a handler that never ran,
+    # so we don't synthesize a key).
+    beliefs = output.get("epistemic_beliefs")
+    if isinstance(beliefs, dict) and beliefs:
+        # Defensive: each value must be a list of strings; drop
+        # malformed entries rather than crash the writer boundary.
+        sanitised: dict[str, list[str]] = {
+            str(agent): [arg for arg in args if isinstance(arg, str)]
+            for agent, args in beliefs.items()
+            if isinstance(args, list)
+        }
+        if sanitised:
+            state.dung_frameworks[df_id]["formalism_specific"] = {
+                "epistemic_beliefs": sanitised,
+            }
 
 
 def _write_delp_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
@@ -493,13 +493,15 @@ class TestSocialFlattening1648:
 
 
 class TestEafFlattening1648:
-    """EAF writer drops per-agent epistemic beliefs."""
+    """EAF writer carries per-agent epistemic beliefs via the sidecar (Wave-2 site 4).
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Pinning #1648 Wave-1 known loss (EAF). Writer drops per-agent "
-        "epistemic beliefs. Wave-2 fix.",
-    )
+    The handler returns ``output["epistemic_beliefs"]`` as
+    ``Dict[agent_name, List[arg_name]]`` at ``eaf_handler.py:118``. The writer
+    at ``state_writers.py:1432-1480`` projects the binary attack graph
+    (preserved) and attaches the dropped belief map to the strictly additive
+    ``formalism_specific`` sidecar.
+    """
+
     def test_eaf_writer_preserves_epistemic_beliefs(self) -> None:
         state = _new_state()
         output = {
@@ -513,17 +515,54 @@ class TestEafFlattening1648:
         _write_eaf_to_state(output, state, {})
 
         entry = next(iter(state.dung_frameworks.values()))
-        extensions = entry.get("extensions", {})
-        formalism_specific = entry.get("formalism_specific", {})
-        has_beliefs = (
-            "epistemic_beliefs" in extensions
-            or "epistemic_beliefs" in formalism_specific
-            or extensions.get("eaf_beliefs") == output["epistemic_beliefs"]
-        )
-        assert has_beliefs, (
-            f"EAF writer dropped epistemic beliefs: extensions={extensions!r}, "
-            f"formalism_specific={formalism_specific!r}"
-        )
+        # Binary Dung projection untouched: attacks carry [src, tgt] pairs.
+        assert entry["attacks"] == [["a", "b"]], entry["attacks"]
+        # Sidecar carries the per-agent beliefs.
+        sidecar = entry.get("formalism_specific", {})
+        assert sidecar.get("epistemic_beliefs") == {
+            "agent1": ["a"],
+            "agent2": ["b"],
+        }, sidecar
+
+    def test_eaf_writer_omits_sidecar_when_beliefs_empty(self) -> None:
+        """Empty beliefs ⇒ no ``formalism_specific`` key (no phantom sidecar)."""
+        state = _new_state()
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "attacks": [["a", "b"]],
+            "extensions": [["a"]],
+            "epistemic_beliefs": {},
+        }
+
+        _write_eaf_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        assert "formalism_specific" not in entry, entry
+
+    def test_eaf_writer_drops_malformed_belief_entries(self) -> None:
+        """Defensive: malformed entries are dropped, well-formed ones pass."""
+        state = _new_state()
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b", "c"],
+            "attacks": [["a", "b"]],
+            "extensions": [],
+            "epistemic_beliefs": {
+                "agent1": ["a", "b"],  # OK
+                "agent2": "not a list",  # malformed: value not a list
+                "agent3": ["c", 42, None],  # mixed: keep strings, drop non-strings
+            },
+        }
+
+        _write_eaf_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        sidecar = entry.get("formalism_specific", {})
+        assert sidecar.get("epistemic_beliefs") == {
+            "agent1": ["a", "b"],
+            "agent3": ["c"],
+        }, sidecar
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Contexte

Wave-2 site 4 of 11 du motif d'aplatissement #1648. Pattern sidecar additif (ABA #1680, SetAF #1683, Weighted #1684) répliqué sur **EAF** (Epistemic Argumentation Frameworks).

L'inventaire (#1672, `c7321ad7`) a classé EAF en **REAL LOSS** : le handler à `eaf_handler.py:118` retourne un dict `epistemic_beliefs: Dict[agent_name, List[arg_name]]` représentant la couche multi-agents qui distingue EAF du Dung plain, mais le writer à `state_writers.py:1432-1441` **dropait entièrement** ce champ.

## Fix — un seul edit coordonné (writer only)

**`orchestration/state_writers.py:_write_eaf_to_state`** — capture le `df_id` retourné par `add_dung_framework`, sanitise `output['epistemic_beliefs']` (defensive : drop les valeurs non-list, drop les args non-string), attache `state.dung_frameworks[df_id]['formalism_specific'] = {'epistemic_beliefs': sanitised}` strictement additivement. Les projections `attacks`/`extensions`/`arguments` sont **intouchées** — les 12 readers de `dung_frameworks` ne sont pas migrés.

## Anti-pendule

- **Scope honnête** : EAF surface son attack graph binaire via le champ `attacks` standard ; le sidecar ajoute la couche croyances multi-agents qui était précédemment invisible à tout reader.
- **Empty handler output ⇒ no sidecar key** (input vide = handler jamais tourné, ne pas synthétiser une clé fantôme).
- **Defensive normalization** : valeur non-list dropped (l'agent n'est pas conservé), arg non-string dropped (l'arg dans la liste est droppé). L'agent lui-même est préservé même si sa liste est entièrement droppée (cohérent avec le filtre clé).
- **Pas de migration reader** : `pattern_mining`, `deep_synthesis_agent`, restitution act2/3 inchangés. Un reader qui veut les beliefs lit `entry['formalism_specific']['epistemic_beliefs']`.

## Anti-#1019 (R761/R764/R765/R767)

- **Vrai writer + stub handler** : `test_state_writers_1648.py::TestEafFlattening1648` drive `_write_eaf_to_state` directement (no mocked writer) et stub le handler output pour mirrorer `eaf_handler.py:114-127`.
- **Différentiel prouvé** : stash writer edit → 2 tests FAIL (le bug mord), pop stash → 3 tests PASS. Le test "empty no-key" sert de regression guard futur contre une synthèse fantôme.
- **Strict-xfail marker removed** : `TestEafFlattening1648` perd son marker `xfail(strict=True)` posé en #1672 (R767). Remplacé par 3 nouveaux tests pinnant le contrat sidecar (beliefs présents / empty no-key / malformed drop).

## Validation

- **mypy strict** sur `state_writers.py` : **0 issues**.
- **`test_state_writers_1648.py`** (bloc EAF) : **3 passed** (post-fix).
- **Blast radius** (`test_state_writers_1648` + `test_state_writers_1649` + `test_unified_pipeline`) : **186 passed, 4 xfailed, exit 0** en 8min. Sites xfailed restants = DeLP, DL, CL, QBF (4 pertes réelles restantes).

## Privacy

Atomes synthétiques uniquement (`a`, `b`, `c`, `agent1`, `agent2`, `agent3`). **Known gap** (out of scope, follow-up) : `sanitize_state.py` n'opacifie pas encore `dung_frameworks[*].formalism_specific.epistemic_beliefs[*]` — les noms d'agents peuvent porter des tokens corpus en production. Le sanitizer update est sa propre tâche.

## Anti-pendule (fichiers hors scope)

- **Pre-existing black/EOF** dans `state_writers.py` et `test_state_writers_1648.py` **non touchés** ici (mêmes fichiers que Wave-2 sites précédents, déjà signalés PR #1684).

## Scope — writer-side only

Clôt la ligne writer-side de #1648 EAF (Wave-2 site 4). Sites restants : **DeLP** (DEEPEST FLATTENING — program + defeat + arg_graph), **DL** (TBox/ABox/subsumptions), **CL** (conditionnels), **QBF** (quantifier structure). 4 sites → 4 PRs candidates, à arbitrer cadence (j'attends dispatch explicite pour DeLP car fix non-trivial). ADF et Social déjà PASS le contrat inventaire ; SAT hors périmètre (PySAT).

🤖 Worker myia-po-2025 — R772 (EAF writer-side, Wave-2 site 4)