### PR TITLE
feat(bipolar): name support articulation points (sole supporter) — axis's 2nd distinctive insight (#1645 PR2)

### DIFF
--- a/argumentation_analysis/agents/core/logic/bipolar_insight.py
+++ b/argumentation_analysis/agents/core/logic/bipolar_insight.py
@@ -6,8 +6,9 @@ relation, which makes two properties computable that no attack-only framework
 
 1. support cycles — circular authority: A backs B which backs A, with no anchor
    outside the loop;
-2. articulation points (future work) — removing one argument collapses the
-   support of others.
+2. articulation points — an argument that is the SOLE support of at least one
+   other: removing it collapses that argument's support entirely (the "remark
+   presented as incidental that structurally carries the weight").
 
 These are pure graph properties of the ``supports`` edge list. They require NO
 JVM and NO Tweety reasoner — the framework object ``BipolarHandler`` builds is
@@ -140,3 +141,87 @@ def detect_support_cycles(supports: Sequence[SupportEdge]) -> List[List[str]]:
                 lowlink[parent] = min(lowlink[parent], lowlink[v])
     result.sort()
     return result
+
+
+def _build_supporters(supports: Sequence[SupportEdge]) -> Dict[str, List[str]]:
+    """Reverse adjacency (target -> its direct supporters) from [src, tgt] edges.
+
+    Every node mentioned gets a key. Malformed edges are dropped (mirrors
+    :func:`_build_adjacency`).
+    """
+    supporters: Dict[str, List[str]] = {}
+    for edge in supports:
+        if len(edge) != 2:
+            continue
+        src = str(edge[0]).strip()
+        tgt = str(edge[1]).strip()
+        if not src or not tgt:
+            continue
+        supporters.setdefault(tgt, []).append(src)
+        supporters.setdefault(src, [])
+    return supporters
+
+
+def detect_support_articulation_points(
+    supports: Sequence[SupportEdge],
+) -> List[Dict[str, object]]:
+    """Arguments that are the SOLE support of at least one other (#1645 B-insight-3).
+
+    A **support articulation point** is an argument whose removal would leave at
+    least one other argument with no support at all — it is that argument's only
+    backer. This is the digraph analogue of a graph articulation point and the
+    structural signature the issue names: *"retirer le seul argument A fait
+    tomber le support de plusieurs autres — alors que le texte le présente
+    comme une remarque incidente"*. Like the cycle insight it is invisible to
+    attack-only frameworks (the unbacked argument is still unattacked, so Dung
+    accepts it) and to LLM fallacy detection.
+
+    Pure graph theory over the ``supports`` edges — no JVM, no reasoner, no
+    recursion. Deterministic: each articulation node is reported once with its
+    sorted dependents, and the list is sorted by node.
+
+    Returns one dict ``{"node": str, "dependents": [str, ...]}`` per
+    articulation point, where ``dependents`` are the arguments that lose all
+    support if ``node`` is removed. An argument is only an articulation point
+    when it backs at least one target that it backs ALONE.
+
+    Examples:
+        >>> detect_support_articulation_points([["a", "b"]])
+        [{'node': 'a', 'dependents': ['b']}]
+        >>> detect_support_articulation_points([["a", "b"], ["c", "b"]])
+        []
+        >>> detect_support_articulation_points([["a", "b"], ["a", "c"]])
+        [{'node': 'a', 'dependents': ['b', 'c']}]
+        >>> detect_support_articulation_points([])
+        []
+    """
+    supporters = _build_supporters(supports)
+    result: List[Dict[str, object]] = []
+    for target, srcs in supporters.items():
+        # A target with exactly one direct supporter is solely backed by it.
+        # That supporter is an articulation point for this target.
+        if len(srcs) == 1:
+            sole_backer = srcs[0]
+            # Skip self-support: a self-loop is a cycle (detect_support_cycles),
+            # not an articulation point — removing it does not "drop" an
+            # independent argument.
+            if sole_backer == target:
+                continue
+            _merge_dependent(result, sole_backer, target)
+    result.sort(key=lambda d: str(d["node"]))
+    return result
+
+
+def _merge_dependent(
+    result: List[Dict[str, object]], node: str, dependent: str
+) -> None:
+    """Record that ``node`` is the sole backer of ``dependent`` (in place)."""
+    for entry in result:
+        if entry["node"] == node:
+            deps = entry["dependents"]
+            assert isinstance(deps, list)
+            if dependent not in deps:
+                deps.append(dependent)
+                deps.sort()
+            return
+    result.append({"node": node, "dependents": [dependent]})

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -1042,14 +1042,17 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         arguments: List[str],
         supports: List[List[str]],
         support_cycles: Optional[List[List[str]]] = None,
+        articulation_points: Optional[List[Dict[str, Any]]] = None,
     ) -> str:
         """Add a bipolar argumentation framework result.
 
         ``support_cycles`` (#1645) carries the axis's distinctive structural
         insight — groups of arguments locked in a mutual-support cycle (circular
-        authority). Computed JVM-free over the ``supports`` edges, so it is
-        populated even on the honest-degraded path. Defaults to an empty list so
-        callers that pre-date the insight store an honest "no cycle detected".
+        authority). ``articulation_points`` (#1645 PR2) carries the second
+        insight — arguments that are the sole support of at least one other.
+        Both are computed JVM-free over the ``supports`` edges, so they are
+        populated even on the honest-degraded path. Default to empty lists so
+        callers that pre-date the insight store an honest "none detected".
         """
         bp_id = self._generate_id("bipolar", self.bipolar_results)
         entry = {
@@ -1058,6 +1061,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "arguments": arguments,
             "supports": supports,
             "support_cycles": support_cycles or [],
+            "articulation_points": articulation_points or [],
         }
         self.bipolar_results.append(entry)
         state_logger.info(f"Bipolar result added: {bp_id} (type: {framework_type})")

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3599,12 +3599,15 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str,
     # (no cycles computable without the import) rather than the pipeline.
     try:
         from argumentation_analysis.agents.core.logic.bipolar_insight import (
+            detect_support_articulation_points,
             detect_support_cycles,
         )
 
         support_cycles = detect_support_cycles(supports)
+        articulation_points = detect_support_articulation_points(supports)
     except ImportError:
         support_cycles = []
+        articulation_points = []
 
     # #1645: resolve the JVM state ONCE, before the try. Resolving it inside the
     # except (the earlier ``import jpype; jpype.isJVMStarted()``) would let an
@@ -3638,6 +3641,7 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str,
             handler.analyze_bipolar_framework, args, attacks, supports, fw_type
         )
         result["support_cycles"] = support_cycles
+        result["articulation_points"] = articulation_points
         return result
     except Exception as e:
         # #1645: three states, never two (coordinator review). Pre-fix this block
@@ -3678,6 +3682,9 @@ async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str,
                 # above — survives the honest-degraded path so the reader can
                 # name "autorité circulaire" even when the handler never ran.
                 "support_cycles": [list(c) for c in support_cycles],
+                # #1645 PR2: articulation points (sole-supporter) — same JVM-free
+                # structural insight, survives the degraded path.
+                "articulation_points": [dict(ap) for ap in articulation_points],
                 "attacks": list(attacks),
                 # tri-state None = not computed (JVM absent), never a fabricated
                 # empty extension set that would read as "consistent sur vide".

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -916,7 +916,14 @@ def _write_bipolar_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> Non
     support_cycles = output.get("support_cycles", [])
     if not isinstance(support_cycles, list):
         support_cycles = []
-    state.add_bipolar_result(fw_type, arguments, supports, support_cycles)
+    # #1645 PR2: articulation points (sole-supporter) — same JVM-free structural
+    # insight, persisted alongside the cycles.
+    articulation_points = output.get("articulation_points", [])
+    if not isinstance(articulation_points, list):
+        articulation_points = []
+    state.add_bipolar_result(
+        fw_type, arguments, supports, support_cycles, articulation_points
+    )
 
 
 def _write_aba_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -99,6 +99,8 @@ _SUPPORT_PAIR_CAP = 3
 # most this many named groups in the prose. Smaller than _SUPPORT_PAIR_CAP: a
 # cycle is a stronger, more specific statement than a support pair.
 _SUPPORT_CYCLE_CAP = 2
+# #1645 PR2 — articulation points (sole-supporter) cap, same rationale.
+_ARTICULATION_CAP = 2
 _ASPIC_MEMBER_CAP = 120
 _ASPIC_MEMBERS_SHOWN = 4
 
@@ -782,21 +784,46 @@ def _cycle_phrase(nodes: List[str]) -> str:
     return f"{joined} forment un cycle de soutien sans ancrage externe (autorité circulaire)"
 
 
+def _articulation_phrase(node: str, dependents: List[str]) -> str:
+    """French prose naming a sole-supporter articulation point (#1645 PR2).
+
+    The figure: an argument that is the ONLY backer of one or more others, so
+    removing it would collapse their support — the "remark presented as
+    incidental that structurally carries the weight" (issue B-insight-3).
+    Naming the figure (``point d'articulation``) is the projection no other
+    axis produces; the dependent count conveys how much rests on it.
+    """
+    node_t = _truncate(node, _SUPPORT_NODE_CAP)
+    deps_t = [_truncate(d, _SUPPORT_NODE_CAP) for d in dependents if d]
+    if len(deps_t) == 1:
+        return (
+            f"« {node_t} » est le seul appui de « {deps_t[0]} » : le retirer "
+            f"lui ferait perdre tout soutien (point d'articulation)"
+        )
+    listed = ", ".join(f"« {d} »" for d in deps_t)
+    return (
+        f"« {node_t} » est le seul appui de {len(deps_t)} arguments ({listed}) : "
+        f"le retirer ferait s'effondrer leur soutien (point d'articulation)"
+    )
+
+
 def _bipolar_finding(state: Any) -> Optional[StructuredArgFinding]:
     """Project the SUPPORT relation — what bipolar argumentation alone says.
 
     Dung frameworks carry attacks only; ``supports`` is the relation no other
-    axis in the pipeline computes. Its most distinctive structural property is a
-    **support cycle** (circular authority: arguments that back each other with
-    no external anchor) — invisible to attack-only frameworks and to LLM fallacy
-    detection. When ``support_cycles`` is populated (#1645), that insight is
-    NAMED here (not recopied): the prose states the circular-authority structure
-    the text does not name itself. When no cycle is present, the support pairs
-    are projected descriptively as a fallback.
+    axis in the pipeline computes. Its two distinctive structural properties,
+    both NAMED here (not recopied) when populated (#1645):
+    1. **support cycles** (circular authority) — arguments backing each other
+       with no external anchor;
+    2. **articulation points** — an argument that is the SOLE support of one or
+       more others, so removing it collapses their support.
+    Both are invisible to attack-only frameworks and to LLM fallacy detection.
+    When neither is present, the support pairs are projected descriptively as a
+    fallback.
 
-    Returns ``None`` when no well-formed pair AND no cycle exists (fail-loud
-    #1019: an empty support set is an honest absence, never a fabricated
-    sentence).
+    Returns ``None`` when no well-formed pair AND no cycle/articulation exists
+    (fail-loud #1019: an empty support set is an honest absence, never a
+    fabricated sentence).
     """
     entries = getattr(state, "bipolar_results", None) or []
     if not isinstance(entries, list):
@@ -831,7 +858,35 @@ def _bipolar_finding(state: Any) -> Optional[StructuredArgFinding]:
             statement=" ; ".join(cycle_parts),
         )
 
-    # Fallback (no cycle): descriptive projection of the support pairs.
+    # Second insight (#1645 PR2, B-insight-3): articulation points = sole
+    # supporter. NAME the figure ("point d'articulation") — the gap between
+    # structural weight and displayed importance. Same anti-recopy rationale.
+    articulation_parts: List[str] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        for ap in entry.get("articulation_points") or []:
+            if not isinstance(ap, dict):
+                continue
+            node = str(ap.get("node", "")).strip()
+            if not node:
+                continue
+            deps_raw = ap.get("dependents") or []
+            deps = [str(d).strip() for d in deps_raw if str(d).strip()]
+            if deps:
+                articulation_parts.append(_articulation_phrase(node, deps))
+                if len(articulation_parts) >= _ARTICULATION_CAP:
+                    break
+        if len(articulation_parts) >= _ARTICULATION_CAP:
+            break
+    if articulation_parts:
+        return StructuredArgFinding(
+            capability="bipolar_argumentation",
+            label=_axis_label("bipolar_argumentation"),
+            statement=" ; ".join(articulation_parts),
+        )
+
+    # Fallback (no cycle, no articulation): descriptive projection of the pairs.
     pairs: List[str] = []
     for entry in entries:
         if not isinstance(entry, dict):

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_bipolar_insight_1645.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_bipolar_insight_1645.py
@@ -1,19 +1,25 @@
-"""#1645 — pure-graph support-cycle detection (the bipolar axis's distinctive insight).
+"""#1645 — pure-graph bipolar insights (no JVM, no reasoner).
 
 The bipolar axis's singular contribution (#1645 section A) is the support
-relation, whose most distinctive structural property is the support cycle
-(circular authority): arguments that back each other with no external anchor.
-This is pure graph theory over the ``supports`` edges — no JVM, no Tweety
-reasoner — so the insight survives the honest-degraded path where the handler
-never runs (#1670/#1677).
+relation, whose two distinctive structural properties are both pure graph
+theory over the ``supports`` edges — no JVM, no Tweety reasoner — so the
+insights survive the honest-degraded path where the handler never runs
+(#1670/#1677):
 
-These tests pin the algorithm directly (disjoint kill-set A: a broken Tarjan
-returns wrong/empty groups). The reader-side naming is pinned in
-``test_act3_conclusion_plugin.py::TestBipolarSupportCycleInsight`` (disjoint
-kill-set B: the reader). Opaque synthetic IDs only.
+1. **support cycles** (circular authority): arguments backing each other with no
+   external anchor (B-insight-2);
+2. **articulation points**: an argument that is the SOLE backer of one or more
+   others, so removing it collapses their support (B-insight-3).
+
+These tests pin the algorithms directly (disjoint kill-set A: a broken Tarjan or
+supporter-count returns wrong/empty results). The reader-side naming is pinned
+in ``test_act3_conclusion_plugin.py`` (``TestBipolarSupportCycleInsight`` and
+``TestBipolarArticulationPointInsight`` — disjoint kill-set B: the reader).
+Opaque synthetic IDs only.
 """
 
 from argumentation_analysis.agents.core.logic.bipolar_insight import (
+    detect_support_articulation_points,
     detect_support_cycles,
 )
 
@@ -78,3 +84,72 @@ class TestDetectSupportCycles:
         first = detect_support_cycles(supports)
         for _ in range(20):
             assert detect_support_cycles(supports) == first
+
+
+class TestDetectSupportArticulationPoints:
+    """#1645 PR2 — the sole-supporter articulation point (B-insight-3).
+
+    An argument that is the ONLY direct supporter of one or more others. Pure
+    supporter-count over the ``supports`` edges (reverse adjacency). Each entry
+    is ``{"node": <sole backer>, "dependents": [<targets it backs alone>]}``,
+    sorted by node; dependents sorted within an entry. Opaque IDs only.
+    """
+
+    def test_sole_backer_is_articulation_point(self) -> None:
+        """The canonical case: one backer, one target ⇒ that backer carries it."""
+        assert detect_support_articulation_points([["prop_a", "prop_b"]]) == [
+            {"node": "prop_a", "dependents": ["prop_b"]}
+        ]
+
+    def test_shared_backer_is_not_an_articulation_point(self) -> None:
+        """Two backers of the same target ⇒ removing either leaves the other, so
+        neither is an articulation point (anti-over-detection).
+        """
+        assert (
+            detect_support_articulation_points(
+                [["prop_a", "prop_b"], ["prop_c", "prop_b"]]
+            )
+            == []
+        )
+
+    def test_multi_dependent_grouped_under_one_entry(self) -> None:
+        """One sole backer of two targets ⇒ one entry with both dependents."""
+        assert detect_support_articulation_points(
+            [["prop_a", "prop_b"], ["prop_a", "prop_c"]]
+        ) == [{"node": "prop_a", "dependents": ["prop_b", "prop_c"]}]
+
+    def test_self_support_is_not_an_articulation_point(self) -> None:
+        """A self-loop is a cycle (B-insight-2), not an articulation: removing
+        it does not drop an independent argument. Must not be reported here.
+        """
+        assert detect_support_articulation_points([["prop_a", "prop_a"]]) == []
+
+    def test_two_articulation_points_returned_sorted(self) -> None:
+        """Two distinct sole backers ⇒ two entries, sorted by node."""
+        assert detect_support_articulation_points(
+            [["prop_b", "dep_one"], ["prop_a", "dep_two"]]
+        ) == [
+            {"node": "prop_a", "dependents": ["dep_two"]},
+            {"node": "prop_b", "dependents": ["dep_one"]},
+        ]
+
+    def test_malformed_edges_are_dropped(self) -> None:
+        """Wrong arity / blank nodes carry no structural meaning."""
+        assert detect_support_articulation_points(
+            [
+                ["prop_a", "prop_b"],
+                ["only_one"],
+                ["", "x"],
+                [1, 2, 3],
+            ]
+        ) == [{"node": "prop_a", "dependents": ["prop_b"]}]
+
+    def test_empty_input_returns_empty(self) -> None:
+        assert detect_support_articulation_points([]) == []
+
+    def test_result_is_deterministic(self) -> None:
+        """Same input ⇒ same output across calls (no dict-ordering leak)."""
+        supports = [["prop_b", "dep"], ["prop_a", "dep2"]]
+        first = detect_support_articulation_points(supports)
+        for _ in range(20):
+            assert detect_support_articulation_points(supports) == first

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -1344,7 +1344,10 @@ class TestCounterTruncationIsAnnounced:
 
 
 def _bipolar_state(
-    supports: object, support_cycles: object = None, **extra: object
+    supports: object,
+    support_cycles: object = None,
+    articulation_points: object = None,
+    **extra: object,
 ) -> SimpleNamespace:
     state = _rich_state()
     entry: dict = {
@@ -1355,6 +1358,8 @@ def _bipolar_state(
     }
     if support_cycles is not None:
         entry["support_cycles"] = support_cycles
+    if articulation_points is not None:
+        entry["articulation_points"] = articulation_points
     state.bipolar_results = [entry]
     for k, v in extra.items():
         setattr(state, k, v)
@@ -1645,3 +1650,123 @@ class TestBipolarSupportCycleInsight:
             )
         )
         assert "autorité circulaire" in prompt
+
+
+class TestBipolarArticulationPointInsight:
+    """#1645 PR2 — the second distinctive insight (B-insight-3): the support
+    articulation point. An argument that is the SOLE backer of one or more others
+    structurally carries a weight the text does not flag — removing it collapses
+    its dependents' support. The reader must NAME it ('point d'articulation'),
+    not recopy it as innocuous pairs. Invisible to attack-only frameworks and to
+    LLM fallacy detection, same as the cycle (section A).
+    """
+
+    def test_articulation_point_is_named_not_recopied(self) -> None:
+        """The singular figure: a sole supporter. Must be NAMED ('point
+        d'articulation'), never rendered as an 'appuie' pair.
+        """
+        (finding,) = build_act3_evidence(
+            _bipolar_state(
+                [["sole_backer", "dependent_a"]],
+                articulation_points=[
+                    {"node": "sole_backer", "dependents": ["dependent_a"]}
+                ],
+            )
+        ).structured_findings
+        assert "point d'articulation" in finding.statement
+        assert "sole_backer" in finding.statement
+        assert "dependent_a" in finding.statement
+        # Named, not recopied.
+        assert " appuie " not in finding.statement
+
+    def test_articulation_takes_priority_over_acyclic_recopy(self) -> None:
+        """An articulation sitting alongside ordinary supports IS the finding —
+        the descriptive recopy must not dilute the named figure.
+        """
+        supports = [
+            ["sole_backer", "dependent_a"],
+            ["prop_gamma", "prop_concl"],
+        ]
+        (finding,) = build_act3_evidence(
+            _bipolar_state(
+                supports,
+                articulation_points=[
+                    {"node": "sole_backer", "dependents": ["dependent_a"]}
+                ],
+            )
+        ).structured_findings
+        assert "point d'articulation" in finding.statement
+        # The ordinary acyclic pair is dropped when the articulation is named.
+        assert "prop_concl" not in finding.statement
+
+    def test_cycle_takes_priority_over_articulation(self) -> None:
+        """Priority order: cycle > articulation > recopy. When both a cycle and
+        an articulation are present, the cycle (the stronger, more specific
+        statement) wins and is the sole finding.
+        """
+        (finding,) = build_act3_evidence(
+            _bipolar_state(
+                [["prop_a", "prop_b"], ["prop_b", "prop_a"]],
+                support_cycles=[["prop_a", "prop_b"]],
+                articulation_points=[{"node": "prop_a", "dependents": ["prop_b"]}],
+            )
+        ).structured_findings
+        assert "autorité circulaire" in finding.statement
+        # The articulation wording does not co-occur with the cycle.
+        assert "point d'articulation" not in finding.statement
+
+    def test_no_articulation_falls_back_to_recopy(self) -> None:
+        """Backward-compat: without an articulation point the reader recopies
+        pairs. The articulation path is strictly additive.
+        """
+        (finding,) = build_act3_evidence(
+            _bipolar_state([["prop_alpha", "prop_beta"]])
+        ).structured_findings
+        assert " appuie " in finding.statement
+        assert "point d'articulation" not in finding.statement
+
+    def test_shared_backer_is_not_an_articulation_point(self) -> None:
+        """Anti-pendule / anti-over-detection: an argument backed by TWO
+        supporters is NOT solely backed — removing either leaves the other, so
+        neither is an articulation point. The reader recopies, never fabricates
+        a 'sole appui' figure that does not hold (fail-loud #1019).
+        """
+        supports = [["backer_one", "shared_target"], ["backer_two", "shared_target"]]
+        (finding,) = build_act3_evidence(
+            # No articulation point: the producer (detect_support_articulation_points)
+            # returns [] for a shared backer — modelled here by omission.
+            _bipolar_state(supports)
+        ).structured_findings
+        assert "point d'articulation" not in finding.statement
+        assert " appuie " in finding.statement
+
+    def test_multi_dependent_articulation_names_the_count(self) -> None:
+        """A sole backer of several arguments names the dependent count, so the
+        structural weight ('how much rests on it') reaches the reader.
+        """
+        (finding,) = build_act3_evidence(
+            _bipolar_state(
+                [["sole_backer", "dep_a"], ["sole_backer", "dep_b"]],
+                articulation_points=[
+                    {"node": "sole_backer", "dependents": ["dep_a", "dep_b"]}
+                ],
+            )
+        ).structured_findings
+        assert "point d'articulation" in finding.statement
+        assert "2 arguments" in finding.statement
+
+    def test_articulation_reaches_the_act3_prompt(self) -> None:
+        """DoD item 3: the insight must reach a reader that states it in the
+        prose — not only the appendix.
+        """
+        prompt = build_act3_prompt(
+            build_act3_evidence(
+                _bipolar_state(
+                    [["sole_backer", "dependent_a"]],
+                    articulation_points=[
+                        {"node": "sole_backer", "dependents": ["dependent_a"]}
+                    ],
+                )
+            )
+        )
+        assert "point d'articulation" in prompt


### PR DESCRIPTION
## What

#1645 PR2 — the bipolar axis's **second** distinctive insight: the **support articulation point** (section A, B-insight-3). An argument that is the **SOLE** direct backer of one or more others, so removing it would collapse their support — *"la remarque présentée comme incidente qui porte structuralement le poids"*. Like the support cycle (PR1 #1685), it is expressible by **neither** an attack-only (Dung) framework **nor** an LLM fallacy detector.

This is the direct follow-up PR1 announced: *"Articulation points (B-insight-3) → PR2."*

## Why (measured, not hypothesised)

E pass 1 (R774) measured firsthand that `BipolarHandler` builds the Tweety framework but calls **no reasoner**, and the reader recopied support pairs verbatim. A planted sole-backer edge was rendered **byte-for-byte identically** to a shared-backer pair — the structural figure present in the input, unnameable in the prose (anti-théâtre #1019, purest form: a structural fact rendered as its most reassuring reading).

The insight is **pure graph theory** over the `supports` edges (supporter count = reverse adjacency), so it lives **outside** the JVM-bound handler and survives the honest-degraded path where the handler never runs (#1670/#1677) — mirroring PR1's cycle detection.

## Changes (producer → writer → state → reader, keys aligned)

| File | Role |
|---|---|
| `agents/core/logic/bipolar_insight.py` | `detect_support_articulation_points` (+ `_build_supporters`, `_merge_dependent`). Iterative, no recursion, no JVM, deterministic. Self-support excluded (a cycle, not an articulation). |
| `orchestration/invoke_callables.py` | `_invoke_bipolar` computes articulation points alongside support cycles, under the same `try/except ImportError` guard; attached to **both** the JVM-up result and the honest-degraded dict. |
| `orchestration/state_writers.py` | `_write_bipolar_to_state` extracts + forwards articulation points. |
| `core/shared_state.py` | `add_bipolar_result` gains an optional `articulation_points` param (backward-compatible default `[]`). |
| `reporting/restitution/act3_conclusion_plugin.py` | Reader priority: **support cycles > articulation points > descriptive recopy**. The figure is **NAMED** (*« point d'articulation »*), not recopied; the dependent count conveys how much rests on the sole backer. |

## Anti-théâtre #1019 — the stage changes the verdict

A sole-backer edge that read as an innocuous `appuie` pair now reads as a **named structural figure**. The verdict changes on ≥1 synthetic case (DoD item 3 extended; item 2 measured for both bipolar insights now).

## Falsifiable — two disjoint kill-sets

- **Kill-set A (algorithm):** `tests/.../test_bipolar_insight_1645.py::TestDetectSupportArticulationPoints` — pure-fn tests. A broken supporter-count returns wrong/empty results.
- **Kill-set B (reader):** `tests/.../test_act3_conclusion_plugin.py::TestBipolarArticulationPointInsight` — naming tests. The reader must NAME the figure, with priority cycle > articulation > recopy, and must **not** over-detect (a shared backer is not an articulation point).

## Verification

- `python -m black --check` on all 7 files: clean (the `state_writers.py` SETAF list-comprehension deviation at l.1350 is **pre-existing on `origin/main`**, untouched — this PR's `state_writers` hunk is bipolar-only).
- CI mypy strict (the exact 8-file command): `Success: no issues found in 8 source files`.
- `mypy --strict` on `bipolar_insight.py`: clean.
- `pytest` on both test files: **133 passed**.

## DoD #1645

- Item 1 (flag/selectable): n/a here (PR2 is additive insight wiring; the axis is already selectable).
- Item 2 (differentiating verdict): **measured** for the articulation insight — invisible before (recopy), named after.
- Item 3 (verdict changed on synthetic case): **extended** to articulation; the synthetic sole-backer case changes the verdict.
- Item 4 (real-corpus + final verdict): **F + final verdict remain** — follow-up after this PR.

## Privacy

Opaque synthetic IDs only (`prop_a`, `sole_backer`, `dependent_a`). No corpus content, no source names.

Refs #1645

🤖 Worker myia-po-2023
