### PR TITLE
feat(belief-revision): pure-Python minimal-retraction fn (MCS) — #1646 lane (a)

### DIFF
--- a/argumentation_analysis/agents/core/logic/belief_revision_insight.py
+++ b/argumentation_analysis/agents/core/logic/belief_revision_insight.py
@@ -1,0 +1,138 @@
+"""JVM-free minimal-retraction computation over a propositional belief base.
+
+The singular contribution of belief revision (#1646 section A) is the **minimal
+retraction**: the *smallest* set of beliefs whose removal restores the
+consistency of the base. This is a global cardinality property — "the minimal
+retraction is of cardinal 1, and it is Z" — that no other component of the chain
+produces:
+
+- an LLM asked to "find contradictions" gives local observations
+  ("the speaker contradicts themselves between X and Y"), never a global
+  minimal-retraction cardinality;
+- the PL solver says UNSAT (the base is inconsistent), but not *what to give up*
+  nor *how little suffices*;
+- the Tweety-bound ``BeliefRevisionHandler`` runs the **Levi pattern**
+  (contraction of ``¬new`` + expansion of ``new``), which is an *expansion* when
+  the base does not contain ``¬new`` — it never computes a distance-based
+  minimal retraction (Tweety 1.28 exposes no ``DalalRevision`` operator; the
+  handler docstring says so).
+
+So the insight lives HERE, as a pure function, not in the JVM-bound handler —
+the same architectural lesson as ``bipolar_insight.py`` (#1645): a structural
+insight that lives inside a JVM-bound handler dies on the honest-degraded path
+where the handler never runs (#1670/#1677).
+
+The computation is a **minimum correction subset** (MCS): enumerate removal
+subsets of the clause base by increasing size and return the smallest whose
+removal makes the conjunction satisfiable. For the small bases the pipeline
+produces (8-12 clauses on real runs, measured #1646 D) this is trivially cheap.
+A pure-Python SAT oracle (``python-sat``, a pinned dep) is used — **no JVM, no
+Tweety reasoner**.
+
+Each entry of ``belief_base`` is one belief expressed as a CNF clause (a list of
+signed integer literals). A belief ``p1 -> p2`` is the clause ``[-1, 2]``; a
+positive belief ``p1`` is ``[1]``; a negation ``¬p2`` is ``[-2]``. Retraction is
+at the **belief** granularity (one clause = one belief), so the reader can name
+which belief is the point of rupture (insight B-1) and how many alternatives of
+the same cardinality exist (insight B-2). The discriminating case (insight B-3,
+"inert contradiction") reads directly off the result: a real inconsistency whose
+minimal retraction touches only a clashing belief while the conclusion beliefs
+never appear in any retraction option.
+"""
+
+from __future__ import annotations
+
+from typing import List, Tuple
+
+# A belief, here, is one CNF clause: a list of signed integer literals.
+#   [1]       = positive belief in atom 1
+#   [-2]      = belief ¬(atom 2)
+#   [-1, 2]   = belief (atom 1 -> atom 2)
+Clause = List[int]
+BeliefBase = List[Clause]
+
+#: upper bound on the retraction cardinality we search for. The pipeline bases
+#: are small (<= ~12 clauses on real runs); a retraction beyond this would mean
+#: the base is deeply inconsistent and the insight degrades honestly (no
+#: fabricated minimal set).
+_MAX_SEARCH = 4
+
+
+def _is_satisfiable(clauses: BeliefBase) -> bool:
+    """True iff the conjunction of ``clauses`` is SAT (Glucose3 oracle)."""
+    # Local import: python-sat is a hard pinned dep (1.9.dev8). Keeping it
+    # inside the function means a missing dep degrades THIS insight honestly
+    # (the function raises) rather than poisoning the module import for callers
+    # that only want, e.g., a future non-SAT helper in this module.
+    from pysat.solvers import Glucose3
+
+    if not clauses:
+        return True
+    with Glucose3(bootstrap_with=clauses) as solver:
+        return bool(solver.solve())
+
+
+def minimal_retractions(belief_base: BeliefBase) -> Tuple[int, List[Tuple[int, ...]]]:
+    """Minimum correction subsets of a proposional belief base (#1646).
+
+    Returns ``(cardinality, options)`` where ``options`` is the list of minimal
+    retraction sets (as index-tuples into ``belief_base``). ``cardinality == 0``
+    with ``options == [()]`` means the base is already consistent (no retraction
+    needed). ``cardinality == -1`` means no retraction within ``_MAX_SEARCH``
+    restores consistency (deeply inconsistent base; the insight degrades
+    honestly rather than fabricate).
+
+    The minimal retraction is the smallest set of beliefs to give up so the rest
+    holds together — the singular contribution of belief revision. Enumerating
+    by increasing size guarantees the *minimal* cardinality (a greedy or
+    single-shot removal would not). For the small pipeline bases this is cheap;
+    the search bound keeps it bounded on pathological inputs.
+
+    Examples (opaque synthetic atoms):
+
+        A single belief restores consistency (insight B-1, "cardinal 1")::
+
+            >>> base = [[1], [-1, 2], [-2]]  # p1, p1->p2, ¬p2  => UNSAT
+            >>> card, opts = minimal_retractions(base)
+            >>> card
+            1
+            >>> len(opts)  # three cardinal-1 options (p1, p1->p2, ¬p2)
+            3
+
+        No unique minimal retraction (insight B-2) — same base, >1 option::
+
+            >>> card, opts = minimal_retractions([[1], [-1, 2], [-2]])
+            >>> len(opts) >= 2
+            True
+
+        An inert contradiction (insight B-3): the clash is real but its minimal
+        retraction never touches the conclusion beliefs (atoms 5, 6)::
+
+            >>> base = [[1], [-1], [5], [6]]  # p1/¬p1 clash, r & s independent
+            >>> card, opts = minimal_retractions(base)
+            >>> card
+            1
+            >>> all(5 not in base[i] and 6 not in base[i]
+            ...     for opt in opts for i in opt)
+            True
+
+        A consistent base needs no retraction::
+
+            >>> minimal_retractions([[1], [2], [3]])
+            (0, [()])
+    """
+    if _is_satisfiable(belief_base):
+        return (0, [()])
+
+    n = len(belief_base)
+    from itertools import combinations
+
+    for k in range(1, min(_MAX_SEARCH, n) + 1):
+        winners: List[Tuple[int, ...]] = []
+        for drop in combinations(range(n), k):
+            kept = [belief_base[i] for i in range(n) if i not in drop]
+            if _is_satisfiable(kept):
+                winners.append(drop)
+        if winners:
+            return (k, winners)
+    return (-1, [])

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_belief_revision_insight_1646.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_belief_revision_insight_1646.py
@@ -1,0 +1,119 @@
+"""#1646 — pure-Python minimal-retraction computation (the belief-revision insight).
+
+The singular contribution of belief revision (#1646 section A) is the **minimal
+retraction** — the smallest set of beliefs whose removal restores consistency
+(a minimum correction subset). This is a global cardinality property no other
+component computes (PL says UNSAT but not what to give up; the Tweety handler
+runs Levi expansion, not a distance-based retraction; an LLM gives local
+observations, never a minimal cardinality). The function is a pure SAT
+enumeration over the clause base — no JVM, no Tweety reasoner — so it survives
+the honest-degraded path where the handler never runs (#1670/#1677), mirroring
+``bipolar_insight.py`` (#1645).
+
+These tests pin the algorithm directly (kill-set A: a broken enumeration /
+oracle returns wrong cardinality or misses options). The reader-side naming is
+pinned in a separate test file (kill-set B) once the insight is wired to the
+Acte III reader. Opaque synthetic atoms only.
+"""
+
+from argumentation_analysis.agents.core.logic.belief_revision_insight import (
+    minimal_retractions,
+)
+
+
+class TestMinimalRetractions:
+    def test_consistent_base_needs_no_retraction(self) -> None:
+        """A satisfiable base has cardinality 0 — no insight fabricated."""
+        assert minimal_retractions([[1], [2], [3]]) == (0, [()])
+
+    def test_single_clause_retraction_cardinality_one(self) -> None:
+        """B-1: the canonical case — ONE belief restores consistency (cardinal 1).
+
+        base p1, p1->p2, ¬p2 is UNSAT (p1 ∧ (p1->p2) |= p2 contradicts ¬p2).
+        """
+        card, opts = minimal_retractions([[1], [-1, 2], [-2]])
+        assert card == 1
+        # Three cardinal-1 options exist: drop p1, drop p1->p2, drop ¬p2.
+        assert len(opts) == 3
+        assert all(len(o) == 1 for o in opts)
+
+    def test_no_unique_retraction_insight_b2(self) -> None:
+        """B-2: when several cardinal-1 retractions exist, none is privileged.
+
+        This is the figure "there is no unique minimal retraction" — the options
+        are all returned, same cardinality, leading to incompatible consistent
+        bases.
+        """
+        card, opts = minimal_retractions([[1], [-1, 2], [-2]])
+        assert card == 1
+        assert len(opts) >= 2
+        # Each option is a distinct singleton retraction.
+        flat = {o[0] for o in opts}
+        assert len(flat) == len(opts)
+
+    def test_inert_contradiction_insight_b3(self) -> None:
+        """B-3 (the most discriminating): a real clash whose minimal retraction
+        never touches the conclusion beliefs.
+
+        base p1, ¬p1, r, s — the p1/¬p1 clash is real, but r and s are
+        independent conclusions. The minimal retraction isolates the clash and
+        leaves r, s intact. No contradiction-detector (PL/UNSAT) can establish
+        this, because it never asks what survives.
+        """
+        base = [[1], [-1], [5], [6]]
+        card, opts = minimal_retractions(base)
+        assert card == 1
+        # Every retraction option touches only the clashing beliefs (idx 0,1),
+        # never the conclusions (idx 2,3).
+        for opt in opts:
+            assert all(i in (0, 1) for i in opt)
+
+    def test_bare_contradiction_two_clauses(self) -> None:
+        """p and ¬p: cardinal 1, two options (drop either)."""
+        card, opts = minimal_retractions([[1], [-1]])
+        assert card == 1
+        assert (0,) in opts and (1,) in opts
+
+    def test_two_independent_clashes_need_cardinal_two(self) -> None:
+        """Minimality over TWO independent clashes: cardinal 2, not 1.
+
+        base p1, p2, ¬p1, ¬p2 has two disjoint clashes. Removing any single
+        clause leaves the other clash intact (still UNSAT), so the minimal
+        cardinality is 2 — one retraction per clash. This is the minimality
+        guarantee: the search does not stop at a non-restoring cardinal-1 guess.
+        """
+        card, opts = minimal_retractions([[1], [2], [-1], [-2]])
+        assert card == 2
+        assert all(len(o) == 2 for o in opts)
+
+    def test_beyond_search_bound_degrades_honestly(self) -> None:
+        """A base whose minimal retraction exceeds the search bound returns -1
+        (no fabricated minimal set) — fail-loud #1019.
+
+        Five independent clashes need cardinal 5, but the search bound caps at 4,
+        so no restoring subset is found within budget.
+        """
+        five_clashes = [[1], [-1], [2], [-2], [3], [-3], [4], [-4], [5], [-5]]
+        card, opts = minimal_retractions(five_clashes)
+        assert card == -1
+        assert opts == []
+
+    def test_empty_base_is_consistent(self) -> None:
+        """An empty belief base is trivially satisfiable (no retraction)."""
+        assert minimal_retractions([]) == (0, [()])
+
+    def test_result_is_deterministic(self) -> None:
+        """Same input ⇒ same output across calls (no set-ordering leak)."""
+        base = [[1], [-1, 2], [-2]]
+        first = minimal_retractions(base)
+        for _ in range(20):
+            assert minimal_retractions(base) == first
+
+    def test_implication_chain_forces_contradiction(self) -> None:
+        """p1 -> p2 -> p3, plus ¬p3, plus p1: the chain derives p3, contradicting
+        ¬p3. Cardinal 1 — break any link.
+        """
+        # p1, p1->p2, p2->p3, ¬p3
+        card, opts = minimal_retractions([[1], [-1, 2], [-2, 3], [-3]])
+        assert card == 1
+        assert len(opts) == 4  # p1, p1->p2, p2->p3, ¬p3 each break the chain


### PR DESCRIPTION
## What

First increment of **#1646** (lane po-2023, dispatch R775 Front B): the pure-Python **minimal-retraction** computation — the singular contribution of belief revision (section A) — as a JVM-free function, mirroring `bipolar_insight.py` (#1645).

The **minimal retraction** is the *smallest* set of beliefs whose removal restores the consistency of the base (a minimum correction subset, MCS). It is a global cardinality property **no other component produces**:

- PL solver says UNSAT, but not *what to give up* nor *how little suffices*;
- the Tweety-bound `BeliefRevisionHandler.revise` runs the **Levi pattern** (`contraction(¬new)` + `expansion(new)`) — an *expansion* when the base lacks `¬new`, never a distance-based retraction (Tweety 1.28 exposes no `DalalRevision` operator; the handler docstring says so);
- an LLM gives local observations, never a global minimal-cardinality.

## Why JVM-free

A structural insight that lives inside a JVM-bound handler **dies on the honest-degraded path** where the handler never runs (#1670/#1677). The same architectural lesson as #1645: the insight lives HERE, as a pure function. The pinned `python-sat` (`Glucose3`) is the oracle — no JVM, no Tweety reasoner.

## What this PR delivers

`minimal_retractions(belief_base) -> (cardinality, options)` in [belief_revision_insight.py](argumentation_analysis/agents/core/logic/belief_revision_insight.py):
- enumerates removal subsets by increasing size, returns the smallest whose removal restores SAT (minimum correction subset);
- `cardinality == 0` + `[()]` ⇒ already consistent; `cardinality == -1` + `[]` ⇒ beyond `_MAX_SEARCH=4` (honest degradation, fail-loud #1019 — no fabricated minimal set);
- retraction at **belief** granularity (one clause = one belief), so the reader can later *name* which belief is the point of rupture.

**Kill-set A (algorithm)** — 10 tests in [test_belief_revision_insight_1646.py](tests/unit/argumentation_analysis/agents/core/logic/test_belief_revision_insight_1646.py):
- B-1: a single belief restores consistency (cardinal 1);
- B-2: multiple cardinal-1 retractions ⇒ "no unique minimal retraction";
- **B-3 (most discriminating)**: an *inert contradiction* — a real clash (`p1, ¬p1`) whose minimal retraction never touches the independent conclusion beliefs (`r, s`). No contradiction-detector (PL/UNSAT) can establish this, because it never asks *what survives*;
- two independent clashes ⇒ cardinal 2 (minimality guarantee: the search does not stop at a non-restoring cardinal-1 guess);
- five independent clashes ⇒ `-1` beyond the bound (honest degradation);
- empty base ⇒ cardinal 0; determinism (no set-ordering leak); implication chain.

Opaque synthetic atoms only (`p1`, `r`, `s`). No corpus content.

## DoD mapping (#1646)

| item | status |
|---|---|
| (A) the insight is the minimal retraction, not the contradiction | ✅ this PR — the fn + its tests |
| (B) craft B-1/B-2/B-3 | ✅ this PR — pinned as tests |
| (2) belief base is non-empty on real runs | ✅ measured beforehand (D forensic) |
| (C) planted inconsistent base + paired-run | ⏳ after coord ruling |
| (D/E) forensic | ✅ delivered (3 locks: `_pl_atom` positive-only ⇒ trivially consistent base; handler = Levi expansion; reader = per-belief, never cardinality) |
| reader NAMES the cardinality (Acte III) | ⏳ kill-set B — after wiring |

## Ruling-agnostic

This PR is **non-presumptuous**: the computation fn is independent of the two rulings I asked the coordinator for (probe at `Refs #1646`):
1. **(a1) PySAT vs (a2) Tweety** — probe proved (a1) viable (reproduces B-3) and (a2) non-viable (no Dalal in Tweety 1.28). This PR is the (a1) fn. **Awaiting GO (a1).**
2. **Base construction** — today `_pl_atom` sanitizes every belief to a *positive* atom, so the pipeline base is trivially consistent on any input (a planted text renders identically to a consistent one ⇒ retraction ∅). Recommended (i): derive `¬arg` from detected fallacies (mirrors the conversational `fallacy_contraction` path). **Awaiting ruling.**

Producer/reader wiring + C planted text land in a follow-up PR once both rulings land.

## Validation

- `pytest test_belief_revision_insight_1646.py` ⇒ **10 passed**;
- `pytest --doctest-modules belief_revision_insight.py` ⇒ 1 passed;
- `mypy --strict` ⇒ Success, no issues;
- `black --check` ⇒ unchanged.

Refs #1646
