### PR TITLE
fix(delp): sidecar formalism_specific carries program + criterion through state (#1648 Wave-2 site 5)

### DIFF
--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -1488,16 +1488,50 @@ def _write_eaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
 
 
 def _write_delp_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
-    """Write DeLP results to UnifiedAnalysisState (#89)."""
+    """Write DeLP results to UnifiedAnalysisState (#89).
+
+    #1648 Wave-2 site 5: DeLP's distinctive pieces of data are the
+    *defeasible program* (``output["program"]`` — the rule source the
+    handler parsed at ``delp_handler.py:134``), its size
+    (``output["program_size"]``), and the *comparison criterion* used for
+    dialectical reasoning (``output["criterion"]`` — e.g.
+    ``generalized_specificity``, ``delp_handler.py:121``). The writer used
+    to keep only ``query_results`` (the YES/NO/UNDECIDED verdicts) and drop
+    the program + criterion entirely — the deepest flattening in the
+    inventory (Section 2.4): the whole formalism reduced to query verdicts,
+    with no trace of what was reasoned over or how. The native Dung
+    projection has no slot for a defeasible program or a comparison
+    criterion, so we attach a strictly-additive ``formalism_specific``
+    sidecar to the entry dict without touching the ``attacks`` /
+    ``extensions`` / ``arguments`` projections.
+    """
     if not output or not isinstance(output, dict):
         return
     query_results = output.get("query_results", [])
-    state.add_dung_framework(
+    df_id = state.add_dung_framework(
         name="delp_analysis",
         arguments=[],
         attacks=[],
         extensions={"delp_query_results": query_results},
     )
+    # #1648 Wave-2 sidecar: preserve the defeasible program + comparison
+    # criterion the handler returns. Absent program AND criterion ⇒ sidecar
+    # stays absent (no ``formalism_specific`` key — empty handler output is
+    # indistinguishable from a handler that never ran, so we don't
+    # synthesize a key). Each field is carried independently so partial
+    # output never produces phantom-None keys (anti-#1019).
+    program = output.get("program")
+    criterion = output.get("criterion")
+    sidecar: dict[str, Any] = {}
+    if program:
+        sidecar["delp_arguments"] = program
+        size = output.get("program_size")
+        if isinstance(size, int):
+            sidecar["program_size"] = size
+    if criterion:
+        sidecar["criterion"] = criterion
+    if sidecar:
+        state.dung_frameworks[df_id]["formalism_specific"] = sidecar
 
 
 def _write_qbf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
@@ -571,47 +571,86 @@ class TestEafFlattening1648:
 
 
 class TestDelpFlattening1648:
-    """DeLP writer produces empty arguments/attacks; only query_results survive.
+    """DeLP writer carries the defeasible program + criterion via the sidecar (Wave-2 site 5).
 
-    The dialectical tree, defeat relations, and comparison criterion are all
-    gone. This is the deepest flattening in the inventory.
+    The handler returns ``output["program"]`` (the rule source),
+    ``output["program_size"]`` and ``output["criterion"]`` (e.g.
+    ``generalized_specificity``) at ``delp_handler.py:149-157``. The writer
+    at ``state_writers.py:_write_delp_to_state`` keeps the query verdicts in
+    ``extensions`` (preserved) and attaches the dropped program + criterion
+    to the strictly additive ``formalism_specific`` sidecar. This was the
+    deepest flattening in the inventory (Section 2.4): the whole formalism
+    reduced to YES/NO/UNDECIDED verdicts. The xfail marker from #1672 R767
+    is removed (the strict-XPASS is the signal the Wave-2 fix landed).
     """
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Pinning #1648 Wave-1 known loss (DeLP). Program + defeat "
-        "relations flattened away. Wave-2 fix.",
-    )
-    def test_delp_writer_preserves_argument_graph_or_defeat_relations(self) -> None:
+    def test_delp_writer_preserves_program_and_criterion(self) -> None:
         state = _new_state()
         output = {
-            "program": [{"head": "a", "body": []}],
-            "program_size": 1,
-            "criterion": "specificity",
+            "program": "birds <- penguin\nflies <- birds",
+            "program_size": 2,
+            "criterion": "generalized_specificity",
             "query_results": [
-                {"query": "a", "answer": "warranted", "message": "ok"}
+                {"query": "flies", "answer": "UNDECIDED", "message": "ok"}
             ],
         }
 
         _write_delp_to_state(output, state, {})
 
         entry = next(iter(state.dung_frameworks.values()))
-        extensions = entry.get("extensions", {})
-        formalism_specific = entry.get("formalism_specific", {})
-        # Either the dialectical tree reaches the state, or at least the
-        # defeat relations are preserved. Today: NEITHER — assertion fails.
-        has_structure = (
-            extensions.get("delp_arguments") == output["program"]
-            or extensions.get("defeat_relations") is not None
-            or "delp_arguments" in extensions
-            or "delp_arguments" in formalism_specific
-            or "defeat_relations" in formalism_specific
-        )
-        assert has_structure, (
-            f"DeLP writer flattened away the argument graph and defeat "
-            f"relations: extensions={extensions!r}, "
-            f"formalism_specific={formalism_specific!r}"
-        )
+        # Native Dung projection stays empty (DeLP has no binary attack
+        # graph at this layer) — query verdicts ride in extensions.
+        assert entry["arguments"] == [], entry["arguments"]
+        assert entry["attacks"] == [], entry["attacks"]
+        assert entry["extensions"] == {
+            "delp_query_results": output["query_results"]
+        }, entry["extensions"]
+        # Sidecar carries the program + criterion the writer used to drop.
+        sidecar = entry.get("formalism_specific", {})
+        assert sidecar.get("delp_arguments") == output["program"], sidecar
+        assert sidecar.get("program_size") == 2, sidecar
+        assert sidecar.get("criterion") == "generalized_specificity", sidecar
+
+    def test_delp_writer_omits_sidecar_when_program_and_criterion_absent(
+        self,
+    ) -> None:
+        """No program AND no criterion ⇒ no ``formalism_specific`` key."""
+        state = _new_state()
+        output = {
+            "program": "",
+            "query_results": [],
+        }
+
+        _write_delp_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        assert "formalism_specific" not in entry, entry
+
+    def test_delp_writer_carries_partial_output_without_phantom_keys(
+        self,
+    ) -> None:
+        """Program present but criterion absent ⇒ no phantom ``criterion`` key.
+
+        Anti-#1019: each sidecar field is carried independently so partial
+        handler output never synthesises a ``None``/empty placeholder that a
+        reader would mistake for a real (empty) value.
+        """
+        state = _new_state()
+        output = {
+            "program": "a <- b",
+            "program_size": 1,
+            # criterion intentionally absent
+            "query_results": [],
+        }
+
+        _write_delp_to_state(output, state, {})
+
+        entry = next(iter(state.dung_frameworks.values()))
+        sidecar = entry.get("formalism_specific", {})
+        assert sidecar.get("delp_arguments") == "a <- b", sidecar
+        assert sidecar.get("program_size") == 1, sidecar
+        # No phantom criterion key synthesised from absence.
+        assert "criterion" not in sidecar, sidecar
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

Wave-2 site 5 of #1648. `_write_delp_to_state` kept only the DeLP query verdicts (YES/NO/UNDECIDED) in `extensions` and dropped the **defeasible program** (`output["program"]`), its **size** (`output["program_size"]`), and the **comparison criterion** (`output["criterion"]`, e.g. `generalized_specificity`) that the handler returns at `delp_handler.py:149-157`. This was the **deepest flattening in the inventory** (Section 2.4): the whole formalism reduced to query verdicts, with no trace of what was reasoned over or how.

## Fix

Attach a strictly-additive `formalism_specific` sidecar to the `dung_frameworks` entry — **same pattern as the 4 prior sites**: ABA (#1680 `contraries`), SetAF (#1683 `set_attacks`), Weighted (#1684 `attack_weights`), EAF (#1686 `epistemic_beliefs`). The sidecar carries `delp_arguments` + `program_size` + `criterion`, without touching the `attacks` / `extensions` / `arguments` Dung projections. Each field is carried independently so partial handler output never synthesises phantom-`None` keys (anti-#1019).

## Tests

Convert the `xfail(strict=True)` inventory pin (#1672 R767 convention: the strict-XPASS is the signal the Wave-2 fix landed) into **3 positive tests** mirroring EAF:
- `test_delp_writer_preserves_program_and_criterion` — full output → sidecar has all 3 keys; native projection stays empty; query verdicts ride in extensions.
- `test_delp_writer_omits_sidecar_when_program_and_criterion_absent` — empty → no `formalism_specific` key (no phantom sidecar).
- `test_delp_writer_carries_partial_output_without_phantom_keys` — program present, criterion absent → no phantom `criterion` key.

## Verification

- `test_state_writers_1648.py`: **17 passed + 3 xfailed** (DL/CL/QBF still pinned — sites 6-8). No regression on ABA/SetAF/Weighted/EAF.
- `test_sanitize_state.py`: **63 passed** — privacy scrub guard compatible with the sidecar.
- flake8 clean. Black: my hunks clean (local black 26.3.1 also flags *pre-existing* merged code from #1683/#1684 due to version skew — left untouched to keep this PR focused).

## Scope

Wave-2 #1648 progress: **5/11 sites delivered** (ABA / SetAF / Weighted / EAF / **DeLP**). Remaining standing-authority sites: DL (6), CL (7), QBF (8). Non-colliding with po-2023 (Front B / #1677).

Refs #1648. No real corpus/speaker names (privacy HARD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)