### PR TITLE
feat(belief-revision): build a genuinely-inconsistent belief base from fallacies — #1646 base construction (i)

### DIFF
--- a/argumentation_analysis/agents/core/logic/belief_revision_insight.py
+++ b/argumentation_analysis/agents/core/logic/belief_revision_insight.py
@@ -42,7 +42,7 @@ never appear in any retraction option.
 
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import List, Sequence, Tuple
 
 # A belief, here, is one CNF clause: a list of signed integer literals.
 #   [1]       = positive belief in atom 1
@@ -136,3 +136,84 @@ def minimal_retractions(belief_base: BeliefBase) -> Tuple[int, List[Tuple[int, .
         if winners:
             return (k, winners)
     return (-1, [])
+
+
+def build_belief_base(
+    arguments: Sequence[str],
+    negated_indices: Sequence[int],
+) -> Tuple[BeliefBase, List[str]]:
+    """Build a CNF belief base where fallacies introduce real contradictions.
+
+    This is the **base construction** for ``minimal_retractions`` (#1646, coord
+    ruling R779 ruling 2 — "derive ¬arg from fallacies"). It turns the pipeline's
+    extracted arguments + the fallacies that undermine them into a belief base
+    that is *genuinely inconsistent*, which is the precondition for the
+    minimal-retraction insight to bite (without it, ``_pl_atom`` sanitizes every
+    belief to a positive atom and the base is trivially consistent — the D-forensic
+    verdict, 3 locks).
+
+    **Derivation convention** (documented per the coord's guard): a detected
+    fallacy targeting argument X establishes that belief X is **not tenable**.
+    Argument X is the positive unit clause ``[x]`` (the belief as the speaker
+    advanced it); the fallacy adds the negation ``[-x]``. The base
+    ``{[x], [-x]}`` is a real clash, and ``minimal_retractions`` isolates it —
+    naming which belief must be given up. This mirrors the conversational path's
+    ``fallacy_contraction`` (which *removes* the targeted belief; here we *negate*
+    it, creating the clash the retraction computation resolves) and the pipeline's
+    own ``new_belief = NOT(target)`` counter-argument intent (l.3982), which
+    ``_pl_atom`` was silently laundering back to a positive atom.
+
+    The fallacy must undermine the *tenability* of the belief it targets for the
+    negation to be honest. All targeted fallacies in this repo's taxonomy
+    (ad hominem, petitio principii, false cause, …) attack tenability — that is
+    precisely the ``fallacy_contraction`` contract. A per-type granularity (which
+    fallacy *negates* vs merely *weakens*) is a documented follow-up, not a
+    precondition; the convention here matches the existing contraction path
+    rather than inventing a new taxonomy call.
+
+    Atom ``i+1`` ↔ ``arguments[i]`` (the 1-based signed-int convention of this
+    module). Indices out of range are **ignored** (#1019: an ungrounded target is
+    not asserted — we do not invent a clash where the upstream did not ground one).
+
+    Args:
+        arguments: the belief labels, in order. Each becomes a positive unit
+            clause; the label names the point of rupture for the reader.
+        negated_indices: 0-based indices into ``arguments`` of the beliefs a
+            fallacy negates (already resolved from ``arg_N`` identifiers by the
+            producer — see ``_resolve_target_argument_index``).
+
+    Returns:
+        ``(base, names)`` where ``base[i]`` is clause ``i`` and ``names[i]`` is
+        its label (the argument, or ``"¬arg"`` for a fallacy-negation clause).
+
+    Examples (opaque synthetic atoms):
+
+        No fallacy ⇒ consistent base (cardinal 0, the D-forensic baseline)::
+
+            >>> base, names = build_belief_base(["x", "y", "z"], [])
+            >>> base
+            [[1], [2], [3]]
+            >>> minimal_retractions(base)[0]
+            0
+
+        One fallacy on the first argument ⇒ a real clash (cardinal 1)::
+
+            >>> base, names = build_belief_base(["x", "y"], [0])
+            >>> base
+            [[1], [2], [-1]]
+            >>> card, opts = minimal_retractions(base)
+            >>> card
+            1
+            >>> all(names[i] in ("x", "¬x") for opt in opts for i in opt)
+            True
+    """
+    n = len(arguments)
+    base: BeliefBase = [[i + 1] for i in range(n)]
+    names: List[str] = list(arguments)
+    seen: set[int] = set()
+    for idx in negated_indices:
+        if isinstance(idx, int) and 0 <= idx < n and idx not in seen:
+            seen.add(idx)
+            base.append([-(idx + 1)])
+            names.append(f"¬{arguments[idx]}")
+    return base, names

--- a/tests/unit/argumentation_analysis/agents/core/logic/test_belief_revision_insight_1646.py
+++ b/tests/unit/argumentation_analysis/agents/core/logic/test_belief_revision_insight_1646.py
@@ -17,6 +17,7 @@ Acte III reader. Opaque synthetic atoms only.
 """
 
 from argumentation_analysis.agents.core.logic.belief_revision_insight import (
+    build_belief_base,
     minimal_retractions,
 )
 
@@ -117,3 +118,102 @@ class TestMinimalRetractions:
         card, opts = minimal_retractions([[1], [-1, 2], [-2, 3], [-3]])
         assert card == 1
         assert len(opts) == 4  # p1, p1->p2, p2->p3, ¬p3 each break the chain
+
+
+class TestBuildBeliefBase:
+    """#1646 base construction (coord ruling R779 ruling 2): derive ¬arg from
+    fallacies so the belief base is *genuinely* inconsistent — the precondition
+    for minimal_retractions to bite (the D-forensic verdict: _pl_atom sanitizes
+    every belief positive → trivially consistent → retraction ∅).
+
+    Convention: a fallacy on argument X adds [-x] alongside [x]. Mirrors
+    fallacy_contraction (conversational), which removes the targeted belief.
+    Opaque synthetic atoms only.
+    """
+
+    def test_no_fallacy_yields_consistent_base(self) -> None:
+        """Arguments alone, no fallacy negation → trivially consistent (card 0).
+
+        This is the baseline the D-forensic measured: a base with no negations
+        has a minimal retraction of ∅ — no insight. The base construction must
+        not fabricate a clash where the upstream detected none.
+        """
+        base, names = build_belief_base(["x", "y", "z"], [])
+        assert base == [[1], [2], [3]]
+        assert names == ["x", "y", "z"]
+        assert minimal_retractions(base)[0] == 0
+
+    def test_one_fallacy_creates_real_clash(self) -> None:
+        """A fallacy on the first argument adds ¬x → base {[x],[y],[-x]} UNSAT.
+
+        The clash is real; minimal_retractions returns cardinal 1. The negation
+        clause is labeled ¬x (the reader names the point of rupture).
+        """
+        base, names = build_belief_base(["x", "y"], [0])
+        assert base == [[1], [2], [-1]]
+        assert names == ["x", "y", "¬x"]
+        card, opts = minimal_retractions(base)
+        assert card == 1
+        # Each retraction touches only the clash (index 0 = x, or 2 = ¬x), never y.
+        for opt in opts:
+            assert all(i in (0, 2) for i in opt)
+            assert all(names[i] in ("x", "¬x") for i in opt)
+
+    def test_inert_contradiction_leaves_conclusions_intact(self) -> None:
+        """B-3 via base construction: a fallacy on x clashes, but y, z survive.
+
+        base {[x],[y],[z],[-x]}: the x/¬x clash is real, cardinal 1, and the
+        conclusion beliefs y, z never appear in any retraction option — the
+        discriminating figure no contradiction-detector (PL/UNSAT) produces.
+        """
+        base, names = build_belief_base(["x", "y", "z"], [0])
+        card, opts = minimal_retractions(base)
+        assert card == 1
+        for opt in opts:
+            # Only the clash beliefs (x at 0, ¬x at 3) are ever retracted.
+            assert all(i in (0, 3) for i in opt)
+            assert all(names[i] not in ("y", "z") for i in opt)
+
+    def test_two_fallacies_on_distinct_args_need_cardinal_two(self) -> None:
+        """Two fallacies on two distinct arguments → two independent clashes.
+
+        base {[x],[y],[-x],[-y]}: removing one clause leaves the other clash,
+        so the minimal cardinality is 2 — one retraction per clash (the
+        minimality guarantee).
+        """
+        base, names = build_belief_base(["x", "y"], [0, 1])
+        assert base == [[1], [2], [-1], [-2]]
+        card, opts = minimal_retractions(base)
+        assert card == 2
+        assert all(len(o) == 2 for o in opts)
+
+    def test_out_of_range_index_ignored(self) -> None:
+        """An ungrounded target (index out of range) is ignored, not asserted.
+
+        #1019: an attack we cannot ground is an attack we do not assert. A
+        fallacy whose target resolves outside the argument list adds no clause.
+        """
+        base, names = build_belief_base(["x"], [0, 1, 5, -1])
+        # Only index 0 is in range → one negation; the rest are dropped.
+        assert base == [[1], [-1]]
+        assert names == ["x", "¬x"]
+
+    def test_repeated_fallacy_same_arg_adds_one_negation(self) -> None:
+        """Several fallacies on the same argument yield one clash, not many.
+
+        A negated belief is one clause ``[-x]`` regardless of how many fallacies
+        target x — the belief-not-tenable is a single belief, not one-per-fallacy
+        (deduplication; otherwise the reader would name phantom alternatives).
+        """
+        base, _names = build_belief_base(["x"], [0, 0, 0])
+        assert base == [[1], [-1]]
+        card, opts = minimal_retractions(base)
+        assert card == 1
+        # Two singletons: drop x (index 0) or drop ¬x (index 1).
+        assert sorted(opts) == [(0,), (1,)]
+
+    def test_construction_is_deterministic(self) -> None:
+        """Same arguments + same indices ⇒ same (base, names) every call."""
+        first = build_belief_base(["a", "b", "c"], [1])
+        for _ in range(20):
+            assert build_belief_base(["a", "b", "c"], [1]) == first


### PR DESCRIPTION
## What

Second increment of **#1646** (Front B, coord ruling R779 ruling 2 — GO base construction (i)): `build_belief_base()` — the base construction that turns the pipeline's extracted arguments + the fallacies that undermine them into a belief base that is **genuinely inconsistent**, the precondition for the `minimal_retractions` insight (PR #1689) to bite.

## Why

The D-forensic verdict (#1646 DoD item 2, delivered) was **negative**: the pipeline belief base is *trivially consistent* because `_pl_atom` sanitizes every belief to a **positive** atom (`p_<cleaned>_<digest>`), so there is never a `¬arg`. The computation fn (#1689) is correct but starved — it computes `∅` on any input. The base must become genuinely contradictory for the insight to fire. This PR implements the coord's ruling: **derive `¬arg` from fallacies**.

## Derivation convention (documented per the coord's guard)

A detected fallacy targeting argument X establishes that belief X is **not tenable**. Argument X is the positive unit clause `[x]` (the belief as the speaker advanced it); the fallacy adds the negation `[-x]`. The base `{[x], [-x]}` is a real clash, and `minimal_retractions` isolates it — naming which belief must be given up.

This **mirrors the conversational path's `fallacy_contraction`** (which *removes* the targeted belief; here we *negate* it, creating the clash the retraction computation resolves) and the pipeline's own `new_belief = NOT(target)` counter-argument intent (`invoke_callables.py:3982`), which `_pl_atom` was silently laundering back to a positive atom.

Per-type granularity (which fallacy *negates* vs merely *weakens*) is a **documented follow-up**, not a precondition — the convention matches the existing contraction contract rather than inventing a new taxonomy call. All targeted fallacies in this repo's taxonomy attack tenability (the `fallacy_contraction` contract).

## What this PR delivers

`build_belief_base(arguments, negated_indices) -> (base, names)` in [belief_revision_insight.py](argumentation_analysis/agents/core/logic/belief_revision_insight.py):
- atom `i+1` ↔ `arguments[i]`; each argument is `[x]`; a negation adds `[-x]`;
- **deduplicated** — one `[-x]` per negated argument regardless of how many fallacies target it (a negated belief is a single belief, not one-per-fallacy);
- out-of-range indices **ignored** (#1019: an ungrounded target is not asserted — we do not invent a clash where the upstream did not ground one);
- JVM-free, pure: takes already-resolved 0-based indices — the `arg_N` → index resolution stays in the producer (`_resolve_target_argument_index`).

**Kill-set (7 tests)** in [test_belief_revision_insight_1646.py](tests/unit/argumentation_analysis/agents/core/logic/test_belief_revision_insight_1646.py):
- no-fallacy ⇒ consistent base (card 0) — the D-forensic baseline, no fabricated clash;
- one fallacy ⇒ real clash (card 1), retraction touches only the clash beliefs;
- **B-3 inert contradiction** (via base construction): a fallacy on `x` clashes, but conclusions `y`, `z` survive untouched — never in any retraction option;
- two distinct fallacies ⇒ cardinal 2 (two independent clashes, minimality guarantee);
- out-of-range index ignored (#1019);
- repeated fallacy on the same arg ⇒ one clash (dedup), not many;
- determinism.

Opaque synthetic atoms only (`x`, `y`, `z`). No corpus content.

## DoD mapping (#1646)

| item | status |
|---|---|
| (A) the insight is the minimal retraction | ✅ #1689 |
| (B) craft B-1/B-2/B-3 | ✅ #1689 + this PR (B-3 via base construction) |
| (2) belief base is non-empty + D-forensic | ✅ delivered (negative verdict → orients the fix) |
| base construction (i) | ✅ this PR |
| producer/reader wiring | ⏳ follow-up PR |
| (C) planted inconsistent base + paired-run | ⏳ follow-up PR |
| reader NAMES the cardinality (Acte III) | ⏳ follow-up PR |

## Validation

- `pytest test_belief_revision_insight_1646.py --doctest-modules belief_revision_insight.py` ⇒ **19 passed** (10 + 7 + 2 doctests);
- `mypy --strict` ⇒ Success;
- `black --check` ⇒ unchanged.

Refs #1646
