### PR TITLE
fix(qbf): sidecar formalism_specific carries quantifier prefix through state (#1648 Wave-2 site 8)

### DIFF
--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -1501,7 +1501,26 @@ def _write_delp_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
 
 
 def _write_qbf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
-    """Write QBF results to UnifiedAnalysisState (#90)."""
+    """Write QBF results to UnifiedAnalysisState (#90).
+
+    #1648 Wave-2 site 8: QBF's distinctive piece of data is the *alternating
+    quantifier prefix* (``output["quantifiers"]`` —
+    ``List[{"type": "forall"|"exists", "vars": [...]}]``) that the handler
+    returns at ``qbf_handler.py:167-174`` and ``_invoke_qbf`` passes through
+    unchanged (``invoke_callables.py:4536``). The writer used to keep only
+    ``f"QBF: {formula}"`` + the boolean ``valid`` and drop the quantifier
+    structure entirely — flattening a PSPACE-hard alternating-quantifier
+    problem to a single SAT boolean. The native propositional projection
+    (``formulas`` / ``satisfiable`` / ``model``) has no slot for the prefix,
+    so we attach a strictly-additive ``formalism_specific`` sidecar to the
+    entry dict without touching those projections.
+
+    Privacy: QBF quantifiers are formal logical symbols (a quantifier type
+    + variable names like ``x``/``y``), not source-derived prose, so the
+    sidecar is opaque even though ``propositional_analysis_results`` is not
+    a ``sanitize_state`` scrub target (the formula string already rides in
+    ``formulas`` regardless of this sidecar).
+    """
     if not output or not isinstance(output, dict):
         return
     state.add_propositional_analysis_result(
@@ -1509,6 +1528,30 @@ def _write_qbf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
         satisfiable=output.get("valid", False),
         model={},
     )
+    # #1648 Wave-2 sidecar: preserve the quantifier prefix the handler
+    # returns under ``output["quantifiers"]``. Absent/empty ⇒ sidecar stays
+    # absent (no ``formalism_specific`` key — empty handler output is
+    # indistinguishable from a handler that never ran, so we don't
+    # synthesize a key).
+    quantifiers = output.get("quantifiers")
+    if isinstance(quantifiers, list) and quantifiers:
+        # Defensive: each entry must be a dict with a str ``type`` and a
+        # list ``vars``; drop malformed entries rather than crash the
+        # writer boundary.
+        sanitised = [
+            {
+                "type": str(q["type"]),
+                "vars": [v for v in q["vars"] if isinstance(v, str)],
+            }
+            for q in quantifiers
+            if isinstance(q, dict)
+            and isinstance(q.get("type"), str)
+            and isinstance(q.get("vars"), list)
+        ]
+        if sanitised:
+            state.propositional_analysis_results[-1]["formalism_specific"] = {
+                "qbf_quantifiers": sanitised,
+            }
 
 
 def _write_collaborative_analysis_to_state(

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
@@ -708,13 +708,19 @@ class TestClFlattening1648:
 
 
 class TestQbfFlattening1648:
-    """QBF writer drops the alternating quantifier structure."""
+    """QBF writer carries the alternating quantifier prefix via the sidecar (Wave-2 site 8).
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Pinning #1648 Wave-1 known loss (QBF). Quantifier structure "
-        "dropped. Wave-2 fix.",
-    )
+    The handler returns ``output["quantifiers"]`` as
+    ``List[{"type": "forall"|"exists", "vars": [...]}]`` at
+    ``qbf_handler.py:167-174``, and ``_invoke_qbf`` passes it through
+    unchanged (``invoke_callables.py:4536``). The writer at
+    ``state_writers.py:_write_qbf_to_state`` keeps the formula + validity
+    boolean in the propositional projection (preserved) and attaches the
+    dropped quantifier prefix to the strictly additive ``formalism_specific``
+    sidecar. The xfail marker from #1672 R767 is removed (the strict-XPASS
+    is the signal the Wave-2 fix landed).
+    """
+
     def test_qbf_writer_preserves_quantifiers(self) -> None:
         state = _new_state()
         output = {
@@ -731,14 +737,49 @@ class TestQbfFlattening1648:
         pl = state.propositional_analysis_results
         assert pl, "QBF writer produced no entry"
         entry = pl[0]
-        extensions = entry.get("extensions", {})
-        formalism_specific = entry.get("formalism_specific", {})
-        has_quantifiers = (
-            "quantifiers" in extensions
-            or "quantifiers" in formalism_specific
-            or extensions.get("qbf_quantifiers") == output["quantifiers"]
-        )
-        assert has_quantifiers, (
-            f"QBF writer dropped quantifier structure: extensions={extensions!r}, "
-            f"formalism_specific={formalism_specific!r}"
-        )
+        # Native propositional projection untouched: formula rides in
+        # formulas, validity boolean in satisfiable.
+        assert entry["formulas"] == ["QBF: exists x. forall y. P(x,y)"], entry
+        assert entry["satisfiable"] is True, entry
+        # Sidecar carries the alternating quantifier prefix.
+        sidecar = entry.get("formalism_specific", {})
+        assert sidecar.get("qbf_quantifiers") == output["quantifiers"], sidecar
+
+    def test_qbf_writer_omits_sidecar_when_quantifiers_absent(self) -> None:
+        """No quantifiers ⇒ no ``formalism_specific`` key (no phantom sidecar)."""
+        state = _new_state()
+        output = {
+            "valid": False,
+            "formula": "P(x)",
+            "quantifiers": [],
+        }
+
+        _write_qbf_to_state(output, state, {})
+
+        entry = state.propositional_analysis_results[0]
+        assert "formalism_specific" not in entry, entry
+
+    def test_qbf_writer_drops_malformed_quantifier_entries(self) -> None:
+        """Defensive: malformed quantifier dicts are dropped, well-formed pass."""
+        state = _new_state()
+        output = {
+            "valid": True,
+            "formula": "P(x)",
+            "quantifiers": [
+                {"type": "exists", "vars": ["x", "y"]},  # OK
+                {"type": "forall"},  # missing vars
+                {"vars": ["z"]},  # missing type
+                {"type": 42, "vars": ["w"]},  # non-str type
+                {"type": "exists", "vars": "not-a-list"},  # vars not a list
+                "not-a-dict",  # not a dict at all
+            ],
+        }
+
+        _write_qbf_to_state(output, state, {})
+
+        entry = state.propositional_analysis_results[0]
+        sidecar = entry.get("formalism_specific", {})
+        # Only the first, well-formed entry survives.
+        assert sidecar.get("qbf_quantifiers") == [
+            {"type": "exists", "vars": ["x", "y"]},
+        ], sidecar


### PR DESCRIPTION
## What

Wave-2 site 8 of #1648. `_write_qbf_to_state` kept only `f"QBF: {formula}"` + the boolean `valid` and **dropped the alternating quantifier prefix** (`output["quantifiers"]`) that the handler returns at `qbf_handler.py:167-174` — flattening a PSPACE-hard alternating-quantifier problem to a single SAT boolean (#1648 Section 1.3 #13).

## Fix

Attach a strictly-additive `formalism_specific` sidecar (`qbf_quantifiers`) to the `propositional_analysis_results` entry — **same pattern as the 5 prior sites**: ABA (#1680), SetAF (#1683), Weighted (#1684), EAF (#1686), DeLP (#1690). This is the **first sidecar on a list-based state container** (`propositional_analysis_results`); the prior dung_frameworks sites used a dict.

## Anti-#1019 verification (the reason this site is deliverable now)

Read the **invoke layer** before fixing — confirmed `_invoke_qbf` (`invoke_callables.py:4536`) does `return await asyncio.to_thread(handler.analyze_qbf, ...)`, passing the handler output **through unchanged**. So the writer genuinely receives `quantifiers`. A dict-literal test fixture would have hidden a producer-side drop — the trap that catches **DL and CL**, which are held for separate ruling (see R781 proposal, not this PR).

## Privacy (verified)

`propositional_analysis_results` is **NOT** a `sanitize_state` scrub target (the sanitize_state docstring admits six containers are uncovered). BUT QBF quantifiers are **formal logical symbols** (quantifier type + variable names `x`/`y`), not source-derived prose — and the formula string already rides in `formulas` regardless of this sidecar. So the sidecar is opaque and does not worsen the export posture. (Contrast DL/CL, whose tbox/conditionals can carry source-derived entities — those need privacy review before carrying structure.)

## Tests

Convert the `xfail(strict=True)` inventory pin into **3 positive tests** mirroring EAF/DeLP:
- `test_qbf_writer_preserves_quantifiers` — full output → sidecar has `qbf_quantifiers`; native projection (formulas/satisfiable) untouched.
- `test_qbf_writer_omits_sidecar_when_quantifiers_absent` — empty → no `formalism_specific` key.
- `test_qbf_writer_drops_malformed_quantifier_entries` — defensive sanitization drops malformed dicts (missing type/vars, non-str type, non-list vars, non-dict).

## Verification

- `test_state_writers_1648.py`: **17 passed + 3 xfailed** (DeLP/DL/CL still pinned on this branch — DeLP fix rides PR #1690, DL/CL are producer-side losses held for ruling). No regression on ABA/SetAF/Weighted/EAF.
- `test_sanitize_state.py`: **63 passed** — scrub guard unaffected.
- flake8 clean. Black: my hunks clean (local black 26.3.1 version-skew flags pre-existing merged code, left untouched).

## Scope & reclassification (R781)

Investigation of sites 6-8 found that **DL(6) and CL(7) are producer-side losses** (`_invoke_dl`/`_invoke_cl` rebuild dicts with counts, dropping the structure before the writer boundary) — NOT fixable at the writer level, and a writer-only sidecar would be #1019 theater. **QBF(8) and DeLP(5)** are writer-side (invoke passes through). This PR delivers QBF(8); DL/CL await a coordinator ruling (invoke-layer + privacy review) — [R781 PROPOSAL] sent.

Wave-2 #1648 progress with this PR: writer-side sites exhausted (ABA/SetAF/Weighted/EAF/DeLP/QBF). Remaining DL/CL are a different category.

Refs #1648. No real corpus/speaker names (privacy HARD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)