### PR TITLE
feat(restitution): ASPIC+ attack scope reaches the rendered conclusion (#1649 reader)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -103,6 +103,23 @@ _SUPPORT_CYCLE_CAP = 2
 _ARTICULATION_CAP = 2
 _ASPIC_MEMBER_CAP = 120
 _ASPIC_MEMBERS_SHOWN = 4
+# #1649 — ASPIC+'s singular contribution is attack SCOPE (undercut has no
+# equivalent anywhere in the stack). The prose names the scope DISTRIBUTION
+# only (undercut/rebut/undermine counts = vocabulary markers), never the raw
+# ``attacks[*].target`` atoms: ``_pl_atom`` keeps up to 24 leading chars of
+# source text, so those atoms are source-derived and must stay out of the
+# prose (privacy HARD, coord R781 — "marqueurs de vocabulaire, texte caviardé").
+# Ordered so the most singular scope (undercut) leads the sentence.
+_ASPIC_ATTACK_SCOPES = ("undercut", "rebut", "undermine", "unresolved")
+_ASPIC_SCOPE_GLOSS: Dict[str, str] = {
+    "undercut": (
+        "l'inférence elle-même est contestée à la racice (règle attaquée "
+        "nommément) — l'apport singulier d'ASPIC+, sans équivalent dans la stack"
+    ),
+    "rebut": "la conclusion d'un autre enchaînement est contredite",
+    "undermine": "la prémisse d'un autre enchaînement est attaquée",
+    "unresolved": "une attaque n'a pu être qualifiée structurellement",
+}
 
 # #1605 — reader-facing French names for the structured-argumentation axes. The
 # prose forbids raw snake_case identifiers (they are opaque to the non-technical
@@ -916,39 +933,54 @@ def _bipolar_finding(state: Any) -> Optional[StructuredArgFinding]:
 
 
 def _aspic_finding(state: Any) -> Optional[StructuredArgFinding]:
-    """Project what ASPIC+ alone establishes: derivations that exclude each other.
+    """Project what ASPIC+ alone establishes, in priority order (#1649).
 
     An ASPIC+ argument is a derivation *through rules*, so what this axis brings
-    that no other does is naming WHICH chains of reasoning cannot be held
-    together. That — not "which claims survived" — is the finding.
+    that no other does is naming HOW derivations conflict — the attack SCOPE
+    (undercut = the inference link itself contested; rebut = a conclusion
+    contradicted; undermine = a premise attacked). Undercut has no equivalent
+    anywhere in the stack; that is the singular contribution (#1649).
 
-    Two conditions gate emission. Both are measured firsthand (JVM probes,
-    R766), not assumed:
+    Emission is gated, in priority order, each gate measured firsthand:
 
-    1. **At least one non-empty extension.** All 8 real artifacts carry
-       ``extensions: [[]]``: ``_invoke_aspic`` reads ``context["axioms"]`` and
-       nothing in the orchestration writes it, and ``addOrdinaryPremise`` is
-       gated on ``if axioms:``. With no ordinary premise ASPIC+ builds no
-       argument at all — 0 arguments, empty framework, single empty extension.
-    2. **At least two distinct non-empty extensions.** Supplying premises is not
-       sufficient: the handler only ever builds ``Proposition(head)``, never a
-       ``Negation``, so no two rule heads can contradict — a head string of
-       ``"!x"`` yields a proposition *named* ``!x``, which conflicts with
-       nothing. Measured on the premises-supplied shape: 11 arguments, **0
-       attacks**, one extension holding all 11. A single all-inclusive extension
-       decided nothing; reporting it would hand the conclusion a
-       formally-authorised statement with no discriminating content (#1631).
+    1. **Qualified attacks** (``aspic_results[*].attacks``, #1649). The producer
+       (#1678 handler ``_qualify_attacks`` + #1679 translator emitting
+       ``head_negated`` rules) fires real attacks only when genuine contraries
+       are supplied — a ``Negation(Proposition(head))``, not a head string
+       carrying ``"!"`` (the latter is absorbed into the identifier, measured 0
+       attack), and only when the generated Dung framework actually materialised
+       an edge (``dung_attacks > 0`` gate). An empty ``attacks`` list is the
+       honest "ran, no attack", never a dropped field (#1681 writer carries it).
+       The statement names the scope DISTRIBUTION only — never the raw target
+       atoms (source-derived via ``_pl_atom``, privacy HARD).
+    2. **Contested sets** (fallback, pre-#1649 finding). At least two distinct
+       non-empty extensions: what some extensions keep and others drop. A single
+       all-inclusive extension arbitrated nothing; reporting it would hand the
+       conclusion a formally-authorised statement with no discriminating content
+       (#1631).
 
-    So the finding is the *contested* set — what some extensions keep and others
-    drop — never a count, and never "everything survived".
+    Nothing to say on either → ``None`` (honest absence, never a status word).
     """
     entries = getattr(state, "aspic_results", None) or []
     if not isinstance(entries, list):
         return None
     contested: List[str] = []
+    # #1649: aggregate qualified attack scopes across entries. The producer
+    # (#1678 handler + #1679 translator) emits ``attacks[*].scope`` in
+    # {undercut, rebut, undermine, unresolved}, gated on ``dung_attacks > 0``
+    # so an empty list is the honest "ran, no attack" (never a dropped field).
+    # Undercut is the singular contribution — no other axis names it.
+    scope_counts: Dict[str, int] = {s: 0 for s in _ASPIC_ATTACK_SCOPES}
     for entry in entries:
         if not isinstance(entry, dict):
             continue
+        for atk in entry.get("attacks") or []:
+            if not isinstance(atk, dict):
+                continue
+            scope = str(atk.get("scope", "unresolved"))
+            if scope not in scope_counts:
+                scope = "unresolved"
+            scope_counts[scope] += 1
         extensions = entry.get("extensions") or []
         if not isinstance(extensions, list):
             continue
@@ -971,6 +1003,18 @@ def _aspic_finding(state: Any) -> Optional[StructuredArgFinding]:
         entry_contested = sorted(union - intersection)
         if len(entry_contested) > len(contested):
             contested = entry_contested
+    # #1649: attack scope is ASPIC+'s singular contribution and strictly more
+    # specific than contested sets (which Dung preferred-semantics also yields),
+    # so it leads the finding when the producer fired real attacks. Falls back
+    # to contested sets, then to None — preserving the existing honest-absence
+    # gate. Anti-#1019 (coord R782): the rendered statement CHANGES when
+    # ``attacks`` changes; an empty/absent list yields no scope statement.
+    if sum(scope_counts.values()) > 0:
+        return StructuredArgFinding(
+            capability="aspic_plus_reasoning",
+            label=_axis_label("aspic_plus_reasoning"),
+            statement=_aspic_attack_statement(scope_counts),
+        )
     if not contested:
         return None
     shown = contested[:_ASPIC_MEMBERS_SHOWN]
@@ -988,6 +1032,30 @@ def _aspic_finding(state: Any) -> Optional[StructuredArgFinding]:
             + " | ".join(shown)
             + tail
         ),
+    )
+
+
+def _aspic_attack_statement(scope_counts: Dict[str, int]) -> str:
+    """Render the ASPIC+ attack-scope finding (#1649).
+
+    Names the scope DISTRIBUTION only (counts + vocabulary gloss), never the
+    raw ``attacks[*].target`` atoms — those are source-derived via ``_pl_atom``
+    (24 leading chars of text) and stay out of the prose (privacy HARD). The
+    most singular scope (undercut) leads the sentence; absent scopes are
+    omitted so the statement reflects exactly what the producer qualified.
+    """
+    parts: List[str] = []
+    for scope in _ASPIC_ATTACK_SCOPES:
+        count = scope_counts.get(scope, 0)
+        if count <= 0:
+            continue
+        parts.append(f"{count} « {scope} » ({_ASPIC_SCOPE_GLOSS[scope]})")
+    if not parts:
+        # Defensive: callers gate on sum>0, but never trust the gate alone.
+        return ""
+    return (
+        "le cadre ASPIC+ qualifie des attaques qui fragmentent le raisonnement "
+        "selon leur portée : " + " ; ".join(parts) + "."
     )
 
 

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -1379,6 +1379,30 @@ def _aspic_state(extensions: object) -> SimpleNamespace:
     return state
 
 
+def _aspic_state_with_attacks(
+    attacks: list, extensions: object = None
+) -> SimpleNamespace:
+    """#1649: an ASPIC state carrying the qualified ``attacks`` list (the
+    #1681 writer's top-level field). ``attacks`` uses the real handler shape
+    (``{attacker_rule, attacker_premises, target, scope}``), verified firsthand
+    in the producer tests — this helper feeds the READER, the #1649 deliverable.
+    """
+    state = _rich_state()
+    state.aspic_results = [
+        {
+            "id": "aspic_1",
+            "reasoner_type": "simple",
+            "extensions": [[]] if extensions is None else extensions,
+            "statistics": {
+                "extensions_count": 1,
+                "attacks_count": len(attacks),
+            },
+            "attacks": attacks,
+        }
+    ]
+    return state
+
+
 class TestStructuredArgPresenceChannel:
     """A structured axis that SUCCEEDS must reach the conclusion (#1667)."""
 
@@ -1524,6 +1548,99 @@ class TestStructuredArgPresenceChannel:
             "aspic_plus_reasoning",
             "bipolar_argumentation",
         }
+
+    # ------------------------------------------------------------------
+    # #1649 — ASPIC+ attack SCOPE (undercut/rebut/undermine) is the axis's
+    # singular contribution: no other axis names HOW a derivation is attacked.
+    # The producer (#1678 handler ``_qualify_attacks`` + #1679 translator
+    # emitting ``head_negated`` rules) populates ``attacks[*].scope`` ONLY on a
+    # real LLM-translator run (CI / no-API-key ⇒ honest empty). These tests use
+    # the real handler output shape (verified firsthand: producer tests
+    # ``test_aspic_negation_scope_1678`` + ``test_aspic_translator_contradictions_1678``,
+    # 13 passed) — they exercise the READER (the #1649 deliverable), not the
+    # producer. Coord R782 anti-#1019: the deliverable is that the RENDERED
+    # output changes when ``attacks`` changes, verified consumer-side below.
+    # ------------------------------------------------------------------
+
+    def test_aspic_qualified_attacks_reach_the_conclusion_1649(self) -> None:
+        """Qualified attacks ⇒ the finding names the SCOPE, undercut leading."""
+        state = _aspic_state_with_attacks(
+            [
+                {
+                    "attacker_rule": "d_undercut",
+                    "attacker_premises": ["arg_d"],
+                    "target": "d_main",
+                    "scope": "undercut",
+                },
+                {
+                    "attacker_rule": "d_rebut",
+                    "attacker_premises": ["arg_b"],
+                    "target": "concl_x",
+                    "scope": "rebut",
+                },
+            ]
+        )
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert finding.capability == "aspic_plus_reasoning"
+        stmt = finding.statement
+        assert "undercut" in stmt
+        assert "rebut" in stmt
+        # The singular scope (undercut) leads the sentence.
+        assert stmt.index("undercut") < stmt.index("rebut")
+        # Privacy HARD: raw source-derived atoms never reach the prose.
+        assert "d_main" not in stmt
+        assert "concl_x" not in stmt
+
+    def test_aspic_rendered_statement_changes_when_attacks_change_1649(self) -> None:
+        """Anti-#1019 (coord R782): same state with vs without ``attacks``
+        yields DIFFERENT rendered conclusions — the field genuinely drives the
+        prose, not just the writer/bundle (the witness-is-not-the-decider trap).
+        """
+        attacks = [
+            {
+                "attacker_rule": "d_u",
+                "attacker_premises": ["a"],
+                "target": "rule_x",
+                "scope": "undercut",
+            }
+        ]
+        with_stmt = (
+            build_act3_evidence(_aspic_state_with_attacks(attacks))
+            .structured_findings[0]
+            .statement
+        )
+        # Same state minus the attacks field (producer honest-empty, vacuous ext).
+        without = build_act3_evidence(_aspic_state([[]])).structured_findings
+        assert "undercut" in with_stmt
+        assert without == []
+        assert with_stmt != ""
+
+    def test_aspic_empty_attacks_do_not_open_the_scope_channel_1649(self) -> None:
+        """The producer's honest-empty ``attacks=[]`` (ran, no attack) must NOT
+        fabricate a scope statement — mirrors the contested-sets honest-absence
+        gate. Tri-state safe: an empty list must read as "no attack".
+        """
+        state = _aspic_state_with_attacks([], extensions=[[]])
+        assert build_act3_evidence(state).structured_findings == []
+
+    def test_aspic_attacks_take_priority_over_contested_sets_1649(self) -> None:
+        """When BOTH attacks and contested extensions are present, the singular
+        contribution (scope) leads; contested sets (Dung-equivalent) defer.
+        """
+        state = _aspic_state_with_attacks(
+            [
+                {
+                    "attacker_rule": "d_u",
+                    "attacker_premises": ["a"],
+                    "target": "r",
+                    "scope": "undercut",
+                }
+            ],
+            extensions=[["socle", "d1"], ["socle", "d2"]],
+        )
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert "undercut" in finding.statement
+        assert "s'excluent mutuellement" not in finding.statement
 
     @pytest.mark.parametrize(
         "state_factory, payload",


### PR DESCRIPTION
## #1649 reader — ASPIC+ attack SCOPE (undercut/rebut/undermine) reaches the rendered conclusion

Epic #1644 (réanimer modules inertes). Dispatch coord R781/R783.

### Forensic verdict (before code)
The trajet `aspic_results → prose rendue` was **HALF-real**:
- **Producer → state: MERGED & sound.** `_invoke_aspic` is a passthrough (`return await asyncio.to_thread(handler.analyze_aspic_framework, …)`), NOT the DL/CL producer-loss trap (#1693). Handler `_qualify_attacks` derives undercut/rebut/undermine structurally, gated honestly on `dung_attacks > 0`. Wired via the translator (`head_negated` rules). Verified firsthand: 13 producer tests pass.
- **Writer (#1681): MERGED.** `add_aspic_result(attacks=…)` carries `attacks` top-level.
- **Reader → prose: the gap.** `_aspic_finding` read `aspic_results` only for contested **extensions**, never `attacks`. No restitution consumer read `aspic_results[*].attacks` → ASPIC+ projected as a Dung copy even when attacks fired. `appendix "disponible if aspic_results"` was a false witness (presence, not conclusion content).

### This PR — the reader
`_aspic_finding` aggregates `attacks[*].scope`; when the producer fired real attacks it emits a scope-distribution statement **foregrounding undercut** (the singular contribution — no stack equivalent), falling back to the existing contested-sets finding, then `None` (honest absence preserved). Docstring updated (it described the pre-#1678 reality; now corrected).

### Anti-#1019 (coord R782 framing)
Deliverable = *the rendered output changes when the field changes*. New tests feed the reader the **real handler output shape** and assert:
- qualified attacks ⇒ finding names the scope, undercut leading;
- same state minus `attacks` ⇒ **different** conclusion (the field genuinely drives the prose, not the bundle — witness-is-not-the-decider);
- empty/absent `attacks` ⇒ no scope statement (tri-state safe);
- attacks take priority over contested sets when both present.

### Privacy HARD
Prose names the scope **distribution only** (counts + vocabulary gloss) — never raw `attacks[*].target` atoms, which are source-derived via `_pl_atom` (24 leading chars of text). Producer populates `attacks` only on a real LLM-translator run (CI/no-API-key ⇒ honest empty); corpus-level population = Front A paired-run (coord-owned).

### ⚠️ Privacy follow-up FLAGGED (not fixed here)
`sanitize_state` scrubs `aspic_results.extensions` but **not** `aspic_results.attacks` (#1681 added the field without updating the scrub config). The export bundle may thus carry source-derived atoms in `attacks[*].target`/`attacker_premises`. Selective list-of-dicts scrubbing (keep `scope`, opaque the atoms) deserves its own privacy-reviewed PR — flagged for coord arbitration.

### Tests
119 act3 tests pass (4 new #1649 + existing aspic/bipolar, no regressions); 63 sanitize + 5 writer green; black clean. (Pre-existing bare-`frozenset` mypy-strict nit at the contested-sets line is untouched — not in the CI strict gate.)

Co-Authored-By: Claude-Code <noreply@anthropic.com>