### PR TITLE
chore(aspic): instrument contradiction/undercut validation drops (#1649 diagnostics)

### DIFF
--- a/argumentation_analysis/orchestration/structured_arg_translator.py
+++ b/argumentation_analysis/orchestration/structured_arg_translator.py
@@ -737,6 +737,7 @@ async def translate_to_aspic_rules(
     undercuts = _validate_aspic_undercuts(
         data, arg_by_id, _pl_atom, set(used_names), used_names
     )
+
     # #1649 diagnostics (coord R783): on real corpus the handler emits 0 attack
     # even though this translator ran (status "evaluated", axioms_count>0 ⇒
     # #1679 leaf-atom derivation fired). The axis is alive end-to-end but
@@ -749,13 +750,20 @@ async def translate_to_aspic_rules(
     #   - raw=0          ⇒ the LLM emitted NONE (a prompt/LLM question, not
     #     plumbing).
     # Surfaced as a warning so it is visible even when base rules make
-    # ``relations`` non-empty and the info log below hides the drop.
-    _raw_contradictions = (
-        len(data.get("contradictions", []) or []) if isinstance(data, dict) else 0
-    )
-    _raw_undercuts = (
-        len(data.get("undercuts", []) or []) if isinstance(data, dict) else 0
-    )
+    # ``relations`` non-empty and the info log below hides the drop. The count
+    # must be at least as tolerant as ``_validate_aspic_*`` (which returns ``[]``
+    # on any non-list payload): a malformed LLM payload (int/dict where a list
+    # is expected) must not raise here — ``len(non-sized)`` would crash the
+    # whole translation. Guard on ``isinstance(raw, list)`` exactly as the
+    # validators do.
+    def _raw_count(_data: object, _key: str) -> int:
+        if not isinstance(_data, dict):
+            return 0
+        _raw = _data.get(_key)
+        return len(_raw) if isinstance(_raw, list) else 0
+
+    _raw_contradictions = _raw_count(data, "contradictions")
+    _raw_undercuts = _raw_count(data, "undercuts")
     if _raw_contradictions or _raw_undercuts:
         logger.warning(
             "ASPIC+ #1649 diagnostics: LLM proposed %d contradiction(s) "

--- a/argumentation_analysis/orchestration/structured_arg_translator.py
+++ b/argumentation_analysis/orchestration/structured_arg_translator.py
@@ -737,6 +737,39 @@ async def translate_to_aspic_rules(
     undercuts = _validate_aspic_undercuts(
         data, arg_by_id, _pl_atom, set(used_names), used_names
     )
+    # #1649 diagnostics (coord R783): on real corpus the handler emits 0 attack
+    # even though this translator ran (status "evaluated", axioms_count>0 ⇒
+    # #1679 leaf-atom derivation fired). The axis is alive end-to-end but
+    # produces no attack because no ``head_negated`` rule reaches the handler.
+    # This counter distinguishes the two remaining hypotheses WITHOUT further
+    # code — a corpus run's log answers it:
+    #   - raw>0, kept=0  ⇒ the LLM DID emit contradictions/undercuts, all
+    #     SILENTLY DROPPED at validation (fabricated id / self / non-existent
+    #     rule → bare ``continue`` in _validate_aspic_*).
+    #   - raw=0          ⇒ the LLM emitted NONE (a prompt/LLM question, not
+    #     plumbing).
+    # Surfaced as a warning so it is visible even when base rules make
+    # ``relations`` non-empty and the info log below hides the drop.
+    _raw_contradictions = (
+        len(data.get("contradictions", []) or []) if isinstance(data, dict) else 0
+    )
+    _raw_undercuts = (
+        len(data.get("undercuts", []) or []) if isinstance(data, dict) else 0
+    )
+    if _raw_contradictions or _raw_undercuts:
+        logger.warning(
+            "ASPIC+ #1649 diagnostics: LLM proposed %d contradiction(s) "
+            "(kept %d, dropped %d) and %d undercut(s) (kept %d, dropped %d). "
+            "Drops = fabricated/self ids or non-existent rule names "
+            "(anti-#1019 validation). If kept==0, no head_negated rule reaches "
+            "the handler ⇒ 0 attack.",
+            _raw_contradictions,
+            len(contradictions),
+            _raw_contradictions - len(contradictions),
+            _raw_undercuts,
+            len(undercuts),
+            _raw_undercuts - len(undercuts),
+        )
     relations = rules + contradictions + undercuts
     if relations:
         logger.info(

--- a/tests/unit/argumentation_analysis/orchestration/test_aspic_translator_contradictions_1678.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_aspic_translator_contradictions_1678.py
@@ -163,3 +163,58 @@ class TestThreeChannelsCoexist:
         # Rule names are unique (shared namespace).
         names = [r["name"] for r in out.relations]
         assert len(set(names)) == len(names), f"names must be unique, got {names}"
+
+
+class Test1649DropDiagnostics:
+    """#1649 (coord R783): on real corpus the handler emits 0 attack though the
+    translator ran. The diagnostic counter distinguishes — without further code
+    — whether the LLM emitted contradictions/undercuts that were SILENTLY
+    DROPPED at validation (raw>0, kept=0), or emitted NONE (raw=0). A corpus
+    run's log answers it; these tests pin the diagnostic contract.
+    """
+
+    def test_drop_diagnostic_fires_when_all_contradictions_dropped(self, caplog):
+        """raw>0, kept=0 ⇒ a warning logs the drop (the 'emitted-then-dropped'
+        hypothesis). This is the case that would explain 0 attack on a live axis.
+        """
+        payload = {
+            "rules": [{"premises": ["arg1"], "conclusion": "arg2", "name": "d_main"}],
+            "contradictions": [
+                {"attacker": "arg3", "target": "arg999_absent", "rationale": "x"},
+                {"attacker": "ghost", "target": "arg2", "rationale": "y"},
+            ],
+            "undercuts": [],
+        }
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger=tr.logger.name):
+            with patch.object(tr, "_llm_extract_relations", _llm_returning(payload)):
+                out = _run(tr.translate_to_aspic_rules("opaque text", _ARGS))
+
+        # Both contradictions dropped (absent ids) ⇒ no negated-head rule.
+        assert [r for r in out.relations if r.get("head_negated") is True] == []
+        diag = [r.message for r in caplog.records if "#1649 diagnostics" in r.message]
+        assert len(diag) == 1, f"expected one #1649 diagnostics warning, got {diag}"
+        msg = diag[0]
+        assert "2 contradiction(s)" in msg
+        assert "kept 0" in msg
+        assert "dropped 2" in msg
+
+    def test_no_diagnostic_when_llm_emitted_no_contradiction_or_undercut(self, caplog):
+        """raw=0 ⇒ NO #1649 diagnostics warning (the 'LLM emitted none'
+        hypothesis — silent, distinct from 'dropped'). Pin the negative so a
+        corpus log showing no warning reads unambiguously as 'emitted none'.
+        """
+        payload = {
+            "rules": [{"premises": ["arg1"], "conclusion": "arg2", "name": "d_main"}],
+            "contradictions": [],
+            "undercuts": [],
+        }
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger=tr.logger.name):
+            with patch.object(tr, "_llm_extract_relations", _llm_returning(payload)):
+                _run(tr.translate_to_aspic_rules("opaque text", _ARGS))
+
+        diag = [r.message for r in caplog.records if "#1649 diagnostics" in r.message]
+        assert diag == [], f"no diagnostic expected when raw=0, got {diag}"


### PR DESCRIPTION
## #1649 diagnostics — why does the live ASPIC+ axis emit 0 attack?

Optional companion to PR #1699 (the reader). Coord R783 framing: on real corpus the handler emits **0 attack** though the translator ran (status `evaluated`, `axioms_count` 7/6/9 ⇒ #1679 leaf-atom derivation fired). The axis is alive end-to-end but produces no attack because no `head_negated` rule reaches the handler. Coord refuted "translator not taken" — so the open question is upstream/LLM, and this instrumentation settles it in one corpus run.

### What it does
`translate_to_aspic_rules` now logs (WARNING) **raw vs kept** for contradictions and undercuts when the LLM proposed any:
- `raw>0, kept=0` ⇒ the LLM **did** emit contradictions/undercuts, all SILENTLY DROPPED at validation (fabricated id / self / non-existent rule → bare `continue` in `_validate_aspic_contradictions` / `_validate_aspic_undercuts`).
- `raw=0` ⇒ the LLM emitted **none** (a prompt/LLM question, not plumbing).

Additive, non-invasive; the validation contract is unchanged. Surfaced as WARNING so it is visible even when base rules make `relations` non-empty and the existing info log hides the drop.

### Why separate from #1699
Coord: "ne le laisse pas retarder le lecteur." The reader (consumer-side) is independent and mergeable on its own; this diagnostics (producer-side) is an optional tool whose payoff is coords corpus run.

### Tests
2 new tests pin the contract (`raw>0/kept=0` ⇒ one `#1649 diagnostics` warning with the counts; `raw=0` ⇒ no warning — the negative reads unambiguously as "emitted none"). 9 translator tests pass; black + mypy clean.

Co-Authored-By: Claude-Code <noreply@anthropic.com>