### PR TITLE
feat(belief-revision): wire the minimal-retraction insight to the Act III conclusion (#1646 incr 3)

### DIFF
--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -1007,7 +1007,7 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         the cardinality is >= 1.
         """
         br_id = self._generate_id("brevision", self.belief_revision_results)
-        entry = {
+        entry: Dict[str, Any] = {
             "id": br_id,
             "method": method,
             "original": original,

--- a/argumentation_analysis/core/shared_state.py
+++ b/argumentation_analysis/core/shared_state.py
@@ -989,9 +989,23 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
         return as_id
 
     def add_belief_revision_result(
-        self, method: str, original: List[str], revised: List[str]
+        self,
+        method: str,
+        original: List[str],
+        revised: List[str],
+        minimal_retraction: Optional[Dict[str, Any]] = None,
     ) -> str:
-        """Add a belief revision result."""
+        """Add a belief revision result.
+
+        ``minimal_retraction`` (#1646) carries the axis's singular structural
+        insight — the smallest set of beliefs whose removal restores consistency
+        (a minimum correction subset), as ``{cardinality, options, ...}``. It is
+        computed JVM-free by ``_invoke_belief_revision`` (mirroring the bipolar
+        insight wiring, #1645), so it is populated even on the honest-degraded
+        path. ``None`` means "not computed" (callers that pre-date the insight,
+        or an honest degrade of the insight itself); the reader names it only when
+        the cardinality is >= 1.
+        """
         br_id = self._generate_id("brevision", self.belief_revision_results)
         entry = {
             "id": br_id,
@@ -999,6 +1013,8 @@ class UnifiedAnalysisState(RhetoricalAnalysisState):
             "original": original,
             "revised": revised,
         }
+        if minimal_retraction is not None:
+            entry["minimal_retraction"] = minimal_retraction
         self.belief_revision_results.append(entry)
         state_logger.info(f"Belief revision result added: {br_id} (method: {method})")
         return br_id

--- a/argumentation_analysis/evaluation/sanitize_state.py
+++ b/argumentation_analysis/evaluation/sanitize_state.py
@@ -213,7 +213,7 @@ _SYMBOL_MAPPING_LIST_FIELDS = {
 #       retraction options, how many beliefs each); only the nominative strings
 #       are opacified. The sibling ``cardinality``/``base_size``/``touched_count``
 #       are ints and are intentionally NOT listed, so they survive untouched.
-_OPAQUE_DEEP_DICT_LEAVES: Dict[str, Dict[str, set[str]]] = {
+_OPAQUE_DEEP_DICT_LEAVES: dict[str, dict[str, set[str]]] = {
     "belief_revision_results": {"minimal_retraction": {"options"}},
 }
 

--- a/argumentation_analysis/evaluation/sanitize_state.py
+++ b/argumentation_analysis/evaluation/sanitize_state.py
@@ -203,6 +203,20 @@ _SYMBOL_MAPPING_LIST_FIELDS = {
     "nl_to_logic_translations": "variables",
 }
 
+# List-of-dicts fields whose sub-key is itself a DICT carrying nominative list
+# leaves (#1646): top-level field -> {dict_subkey -> {leaf_subkeys}}. Unlike
+# ``_OPAQUE_NESTED_ITEM_SUBKEYS`` (5d), the sub-key is a single dict, not a list
+# of dicts — so the leaves hang directly off it.
+#   belief_revision_results[*].minimal_retraction.options = [[belief, ...], ...]
+#       ``options`` is a list-of-lists of belief labels (the argument text that
+#       names the rupture point). The list topology + arity survive (how many
+#       retraction options, how many beliefs each); only the nominative strings
+#       are opacified. The sibling ``cardinality``/``base_size``/``touched_count``
+#       are ints and are intentionally NOT listed, so they survive untouched.
+_OPAQUE_DEEP_DICT_LEAVES: Dict[str, Dict[str, set[str]]] = {
+    "belief_revision_results": {"minimal_retraction": {"options"}},
+}
+
 # Fields that are purely narrative text -> replaced with length + marker.
 _NARRATIVE_FIELDS = {
     "narrative_synthesis",
@@ -438,6 +452,23 @@ def sanitize_state(state: dict[str, Any] | Any) -> dict[str, Any]:
                         for leaf in leaf_subkeys:
                             if leaf in leaf_item:
                                 leaf_item[leaf] = _opacify_list_values(leaf_item[leaf])
+
+    # 5e. Opacify nominative leaves nested inside a DICT sub-key of a
+    #     list-of-dicts field (#1646): the sub-key is a single dict (not a list
+    #     of dicts), so the leaves hang directly off it. Mirrors 5d one level
+    #     shallower on the subtree.
+    for field, nested_spec in _OPAQUE_DEEP_DICT_LEAVES.items():
+        if field in data and isinstance(data[field], list):
+            for item in data[field]:
+                if not isinstance(item, dict):
+                    continue
+                for dict_key, leaf_subkeys in nested_spec.items():
+                    sub = item.get(dict_key)
+                    if not isinstance(sub, dict):
+                        continue
+                    for leaf in leaf_subkeys:
+                        if leaf in sub:
+                            sub[leaf] = _opacify_list_values(sub[leaf])
 
     # 6. Opacify symbol-mapping sub-keys inside list-of-dicts fields
     #    (nl_to_logic_translations[*].variables).

--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -3146,6 +3146,18 @@ def _run_belief_revision_from_state(state: Any) -> Optional[Dict[str, Any]]:
     When fallacies target arguments that have JTMS beliefs, the beliefs are
     contradicted. This function records the revision: original beliefs →
     revised (contradicted beliefs removed).
+
+    #1646 incr 3: also computes the axis's singular insight — the **minimal
+    retraction** (smallest set of beliefs whose removal restores consistency) —
+    JVM-free via PySAT, and carries it through ``minimal_retraction`` so the
+    Acte III reader can NAME it. The pipeline producer carries the same insight
+    via ``_invoke_belief_revision``; the two producers are **mode-exclusive**
+    (``workflow_name="conversational"`` returns from ``run_conversational_analysis``
+    before pipeline capabilities run, and vice-versa), so BOTH must compute it or
+    the insight dies in whichever mode the run uses. Guarded against the
+    ``logic/__init__`` jpype cascade (#1697): on ImportError the insight degrades
+    to cardinality -1 (honest — the reader stays mute), the contraction is
+    unaffected. Mirrors the pipeline wiring in ``_invoke_belief_revision``.
     """
     if not hasattr(state, "belief_revision_results"):
         return None
@@ -3194,11 +3206,46 @@ def _run_belief_revision_from_state(state: Any) -> Optional[Dict[str, Any]]:
     if not removed:
         return None
 
+    # #1646: minimal-retraction insight, JVM-free. A targeted belief is negated
+    # (the fallacy undermines its tenability) — build_belief_base adds the
+    # negation clause, minimal_retractions isolates the smallest set to give up.
+    # ``negated_indices`` = beliefs the fallacy loop removed from ``revised``.
+    negated_indices = [i for i, b in enumerate(original_beliefs) if b not in revised]
+    minimal_retraction: Optional[Dict[str, Any]] = None
+    try:
+        from argumentation_analysis.agents.core.logic.belief_revision_insight import (
+            build_belief_base,
+            minimal_retractions,
+        )
+
+        base, names = build_belief_base(original_beliefs, negated_indices)
+        card, options = minimal_retractions(base)
+        named_options = [[names[i] for i in opt] for opt in options]
+        touched = len({i for opt in options for i in opt})
+        minimal_retraction = {
+            "cardinality": card,
+            "options": named_options,
+            "base_size": len(base),
+            "touched_count": touched,
+            "degraded": False,
+        }
+    except ImportError:
+        # logic/__init__ jpype cascade (#1697) OR missing pysat: the insight
+        # degrades honestly (cardinality -1 → reader mute), the phase continues.
+        minimal_retraction = {
+            "cardinality": -1,
+            "options": [],
+            "base_size": 0,
+            "touched_count": 0,
+            "degraded": True,
+        }
+
     try:
         state.add_belief_revision_result(
             method="fallacy_contraction",
             original=original_beliefs,
             revised=revised,
+            minimal_retraction=minimal_retraction,
         )
     except Exception as e:
         logger.warning(f"Belief revision persistence failed: {e}")

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3966,10 +3966,28 @@ async def _invoke_belief_revision(
 
     Uses upstream counter-arguments or fallacy detections as new evidence that
     forces actual revision of the original belief set.
+
+    #1646: the axis's singular insight is the **minimal retraction** — the
+    smallest set of beliefs whose removal restores consistency (a minimum
+    correction subset). It is a global cardinality property no other component
+    computes (PL says UNSAT but not what to give up; the Tweety-bound handler
+    below runs the Levi expansion, not a distance-based retraction). So it is
+    computed HERE as a pure SAT enumeration over the belief base (mirroring the
+    bipolar insight wiring, #1645) and attached to the result on BOTH the JVM-up
+    and the honest-degraded paths — a structural insight that lives only inside
+    the JVM-bound handler dies on the degraded path where the handler never runs
+    (#1670/#1677).
     """
     args = _extract_arguments_from_context(input_text, context)
     beliefs = context.get("belief_set") or args
     method = context.get("revision_method", "dalal")
+
+    # Upstream fallacies — read once: they drive both the Levi ``new_belief`` and
+    # the belief-base construction (a fallacy negates its target, #1646 incr 2).
+    fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
+    fallacies = (
+        fallacy_output.get("fallacies", []) if isinstance(fallacy_output, dict) else []
+    )
 
     # Derive new_belief from upstream counter-arguments or fallacies (not from args!)
     new_belief = context.get("new_belief")
@@ -3982,19 +4000,78 @@ async def _invoke_belief_revision(
                 new_belief = f"NOT({llm_ca.get('target_argument', 'unknown')[:60]})"
 
         # Try fallacy output — a detected fallacy undermines a belief
-        if not new_belief:
-            fallacy_output = context.get("phase_hierarchical_fallacy_output", {})
-            if isinstance(fallacy_output, dict):
-                fallacies = fallacy_output.get("fallacies", [])
-                if fallacies and isinstance(fallacies[0], dict):
-                    ft = fallacies[0].get("type", fallacies[0].get("fallacy_type", ""))
-                    new_belief = (
-                        f"Fallacy detected: {ft} — undermines argument credibility"
-                    )
+        if not new_belief and fallacies and isinstance(fallacies[0], dict):
+            ft = fallacies[0].get("type", fallacies[0].get("fallacy_type", ""))
+            new_belief = f"Fallacy detected: {ft} — undermines argument credibility"
 
         # Last resort: generate a revision-triggering belief
         if not new_belief:
             new_belief = "New evidence contradicts one of the original claims"
+
+    # #1646 incr 3: build a genuinely-inconsistent belief base (each fallacy
+    # negates its target) and compute the minimal retraction JVM-free. The import
+    # is guarded: ``agents.core.logic.__init__`` eagerly imports the logic agents
+    # → ``TweetyBridge`` → bare ``import jpype`` (#1697). In a jpype-less env
+    # (the #1677 probe, or jpype genuinely absent) the package import raises
+    # ImportError HERE — degrade the INSIGHT honestly (no minimal retraction
+    # computable), not the pipeline. Mirrors the guarded import in _invoke_bipolar
+    # (l.3600). ``minimal_retractions`` itself imports pysat lazily, so a missing
+    # pysat degrades the same way.
+    negated_indices: List[int] = []
+    for f in fallacies:
+        if not isinstance(f, dict):
+            continue
+        idx = _resolve_target_argument_index(_read_fallacy_target(f), len(args))
+        if idx is not None:
+            negated_indices.append(idx)
+    # One negation clause per targeted belief (build_belief_base dedups too, but
+    # resolving once here keeps the count honest for logging).
+    negated_indices = sorted(set(negated_indices))
+
+    minimal_retraction: Optional[Dict[str, Any]] = None
+    try:
+        from argumentation_analysis.agents.core.logic.belief_revision_insight import (
+            build_belief_base,
+            minimal_retractions,
+        )
+
+        base, names = build_belief_base(args, negated_indices)
+        card, options = minimal_retractions(base)
+        # Map option index-tuples → named belief labels so the reader can NAME the
+        # point of rupture (insight B-1). ``touched_count`` drives the B-3
+        # inert-contradiction signal (beliefs that survive every retraction).
+        named_options = [[names[i] for i in opt] for opt in options]
+        touched = len({i for opt in options for i in opt})
+        minimal_retraction = {
+            "cardinality": card,
+            "options": named_options,
+            "base_size": len(base),
+            "touched_count": touched,
+            "degraded": False,
+        }
+    except ImportError:
+        # logic/__init__ cascade (#1697) OR missing pysat: the insight is
+        # unavailable, not the phase. cardinality -1 → the reader produces
+        # nothing (honest), the pipeline continues.
+        minimal_retraction = {
+            "cardinality": -1,
+            "options": [],
+            "base_size": 0,
+            "touched_count": 0,
+            "degraded": True,
+        }
+
+    # #1646: resolve the JVM state ONCE, before the try (mirrors _invoke_bipolar
+    # l.3627). ``jvm_setup`` imports jpype at module level, so in a jpype-less env
+    # the import raises ImportError HERE — treat as "JVM not available" so the
+    # handler import below raises into the except and the honest-absent branch
+    # fires (the insight still reaches the state).
+    try:
+        from argumentation_analysis.core.jvm_setup import is_jvm_started
+
+        jvm_up = is_jvm_started()
+    except ImportError:
+        jvm_up = False
 
     try:
         from argumentation_analysis.agents.core.logic.belief_revision_handler import (
@@ -4011,14 +4088,53 @@ async def _invoke_belief_revision(
             safe_beliefs = [_pl_atom("initial_belief", prefix="b")]
 
         handler = BeliefRevisionHandler()  # type: ignore[no-untyped-call]
-        return await asyncio.to_thread(
+        result = await asyncio.to_thread(
             handler.revise, safe_beliefs, safe_new_belief, method
         )
+        if isinstance(result, dict):
+            result["minimal_retraction"] = minimal_retraction
+        return result
     except Exception as e:
+        # Three states, never two (mirrors _invoke_bipolar l.3646-3702). JVM
+        # absent ⇒ honest-absent: the phase continues degraded and the
+        # minimal-retraction insight (computed JVM-free above) still reaches the
+        # state and the reader. Handler/analysis failure WITH the JVM up ⇒ fail
+        # loud with the real cause (preserved via ``from e``), never relabeled
+        # as an environment gap. Anti-pendule: do NOT swap the raise for a silent
+        # ``return {}`` — that would trade this defect for its mirror (#1019).
+        #
+        # NB: this adds an honest-absent branch to a handler that previously
+        # raised unconditionally — #1646's architecture lesson (R779, mirror
+        # #1645/#1670) requires the insight to survive the degraded path. The
+        # ``logic/__init__`` jpype cascade itself stays tracked in #1697.
+        if not jvm_up:
+            logger.warning(
+                "Belief revision unavailable: JVM not started (honest-absent, "
+                "the phase continues degraded; minimal-retraction insight still "
+                "computed). Underlying signal: %s",
+                e,
+            )
+            return {
+                "method": method,
+                "original": list(beliefs) if isinstance(beliefs, list) else [],
+                "new_belief": new_belief,
+                "revised": [],  # tri-state: not computed under Levi (JVM absent)
+                "statistics": {
+                    "handler": "BeliefRevisionHandler",
+                    "backend": "jvm-unavailable",
+                },
+                "minimal_retraction": minimal_retraction,
+                "degraded": True,
+                "absent_reason": "jvm_not_started",
+                "message": (
+                    "belief revision unavailable: JVM not started (honest-absent)"
+                ),
+                "error": f"{type(e).__name__}: {e}",
+            }
         raise RuntimeError(
-            f"Belief revision ({method}) unavailable: JVM/Tweety required ({e}). "
-            "Install JVM and ensure Tweety JARs are on the classpath."
-        )
+            f"Belief revision ({method}) failed with JVM up: "
+            f"{type(e).__name__}: {e}"
+        ) from e
 
 
 async def _invoke_probabilistic(

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -869,7 +869,14 @@ def _write_belief_revision_to_state(
         original = []
     if not isinstance(revised, list):
         revised = []
-    state.add_belief_revision_result(method, original, revised)
+    # #1646: persist the distinctive structural insight (minimal retraction).
+    # Computed JVM-free by _invoke_belief_revision, so it is present even on the
+    # honest-degraded path. The reader names it when cardinality >= 1; a missing
+    # or degraded dict is an honest "insight unavailable" (stored as None).
+    minimal_retraction = output.get("minimal_retraction")
+    if not isinstance(minimal_retraction, dict):
+        minimal_retraction = None
+    state.add_belief_revision_result(method, original, revised, minimal_retraction)
 
 
 def _write_dialogue_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -101,6 +101,10 @@ _SUPPORT_PAIR_CAP = 3
 _SUPPORT_CYCLE_CAP = 2
 # #1645 PR2 — articulation points (sole-supporter) cap, same rationale.
 _ARTICULATION_CAP = 2
+# #1646 — minimal-retraction insight: at most this many distinct rupture
+# beliefs named in the prose (the cardinality is the headline; the beliefs are
+# the evidence). Small, same rationale as the cycle/articulation caps.
+_RETRACTION_CAP = 3
 _ASPIC_MEMBER_CAP = 120
 _ASPIC_MEMBERS_SHOWN = 4
 
@@ -116,6 +120,7 @@ _ABSENT_DIMENSION_LABELS: Dict[str, str] = {
     "setaf_reasoning": "les attaques collectives (plusieurs arguments attaquant ensemble)",
     "weighted_argumentation": "la force pondérée des attaques",
     "bipolar_argumentation": "les relations de soutien entre arguments",
+    "belief_revision": "la révision des croyances (le point de rupture minimal)",
 }
 
 # Verdict bands (adapted from #1008 §2.1 to the restitution coverage model).
@@ -991,6 +996,99 @@ def _aspic_finding(state: Any) -> Optional[StructuredArgFinding]:
     )
 
 
+def _belief_revision_finding(state: Any) -> Optional[StructuredArgFinding]:
+    """Project what belief revision alone establishes: the minimal retraction.
+
+    The axis's singular contribution (#1646 section A) is the **minimal
+    retraction** — the smallest set of beliefs whose removal restores
+    consistency. It is a global cardinality property no other axis produces: the
+    PL solver says UNSAT but not what to give up, and a contradiction detector
+    never asks what SURVIVES. NAMING the cardinality + the belief(s) to give up
+    (insight B-1) is the projection; when the retraction touches only a clashing
+    belief and leaves the rest intact, the contradiction is INERT (insight B-3)
+    — the figure that goes against the rhetorical reflex that any contradiction
+    must bear on the thesis.
+
+    Returns None when the base is consistent (cardinality 0, honest absence), or
+    the insight degraded (cardinality -1 / missing — fail-loud #1019: never
+    fabricate a retraction the computation did not produce).
+    """
+    entries = getattr(state, "belief_revision_results", None) or []
+    if not isinstance(entries, list):
+        return None
+
+    # Pick the entry with the smallest cardinality >= 1 (the sharpest rupture).
+    # cardinal-1 is the canonical figure "one belief restores consistency"; if
+    # any entry reaches it, stop — no deeper search needed.
+    best_mr: Optional[Dict[str, Any]] = None
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        mr = entry.get("minimal_retraction")
+        if not isinstance(mr, dict):
+            continue
+        card = mr.get("cardinality")
+        if not isinstance(card, int) or card < 1:
+            continue
+        if best_mr is None or card < best_mr.get("cardinality", card + 1):
+            best_mr = mr
+            if card == 1:
+                break
+    if best_mr is None:
+        return None
+
+    card = best_mr["cardinality"]
+    options = best_mr.get("options") or []
+    # Flatten the distinct beliefs across all minimal options (the rupture
+    # candidates the reader names as evidence).
+    named: List[str] = []
+    seen: set[str] = set()
+    for opt in options:
+        if not isinstance(opt, list):
+            continue
+        for label in opt:
+            key = str(label).strip()
+            if key and key not in seen:
+                seen.add(key)
+                named.append(_truncate(key, _SUPPORT_NODE_CAP))
+                if len(named) >= _RETRACTION_CAP:
+                    break
+        if len(named) >= _RETRACTION_CAP:
+            break
+
+    base_size = best_mr.get("base_size", 0)
+    touched = best_mr.get("touched_count", 0)
+    untouched = (
+        base_size - touched
+        if isinstance(base_size, int) and isinstance(touched, int)
+        else 0
+    )
+
+    # B-1: name the cardinality + the rupture belief(s).
+    if card == 1:
+        lead = "une seule proposition suffit à restaurer la cohérence si on l'abandonne"
+    else:
+        lead = (
+            f"la rétractation minimale est de cardinal {card} — il faut renoncer "
+            f"à au moins {card} engagement(s) pour que le reste tienne"
+        )
+    parts: List[str] = [lead]
+    if named:
+        parts.append("le point de rupture porte sur : " + " | ".join(named))
+    # B-3: the contradiction is confined — some beliefs survive every retraction.
+    if untouched > 0:
+        parts.append(
+            f"la contradiction est confinée — {untouched} engagement(s) survivent "
+            "intact(s) : une contradiction réelle mais inerte, qui n'entraîne pas "
+            "la thèse"
+        )
+    return StructuredArgFinding(
+        capability="belief_revision",
+        label=_axis_label("belief_revision"),
+        statement=" ; ".join(parts),
+    )
+
+
 def _collect_structured_arg_findings(state: Any) -> List[StructuredArgFinding]:
     """Collect the structured-argumentation axes that produced something (#1667).
 
@@ -1000,7 +1098,7 @@ def _collect_structured_arg_findings(state: Any) -> List[StructuredArgFinding]:
     word.
     """
     out: List[StructuredArgFinding] = []
-    for projector in (_aspic_finding, _bipolar_finding):
+    for projector in (_aspic_finding, _bipolar_finding, _belief_revision_finding):
         finding = projector(state)
         if finding is not None:
             out.append(finding)

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -1004,10 +1004,13 @@ def _belief_revision_finding(state: Any) -> Optional[StructuredArgFinding]:
     consistency. It is a global cardinality property no other axis produces: the
     PL solver says UNSAT but not what to give up, and a contradiction detector
     never asks what SURVIVES. NAMING the cardinality + the belief(s) to give up
-    (insight B-1) is the projection; when the retraction touches only a clashing
-    belief and leaves the rest intact, the contradiction is INERT (insight B-3)
-    — the figure that goes against the rhetorical reflex that any contradiction
-    must bear on the thesis.
+    (insight B-1) is the projection; when several retractions of the same
+    minimal cardinality restore consistency, NONE is the minimal one — the base
+    splits into incompatible but equally-minimal worlds (insight B-2, the figure
+    a single revised world cannot express); when the retraction touches only a
+    clashing belief and leaves the rest intact, the contradiction is INERT
+    (insight B-3) — the figure that goes against the rhetorical reflex that any
+    contradiction must bear on the thesis.
 
     Returns None when the base is consistent (cardinality 0, honest absence), or
     the insight degraded (cardinality -1 / missing — fail-loud #1019: never
@@ -1039,6 +1042,7 @@ def _belief_revision_finding(state: Any) -> Optional[StructuredArgFinding]:
 
     card = best_mr["cardinality"]
     options = best_mr.get("options") or []
+    n_options = sum(1 for opt in options if isinstance(opt, list))
     # Flatten the distinct beliefs across all minimal options (the rupture
     # candidates the reader names as evidence).
     named: List[str] = []
@@ -1064,8 +1068,20 @@ def _belief_revision_finding(state: Any) -> Optional[StructuredArgFinding]:
         else 0
     )
 
-    # B-1: name the cardinality + the rupture belief(s).
-    if card == 1:
+    # B-1 names the cardinality + the rupture belief(s); B-2 takes precedence
+    # when several retractions of the SAME minimal cardinality restore
+    # consistency — none is *the* minimal one, and the base splits into
+    # incompatible but equally-minimal consistent worlds. That non-unicity is
+    # the figure no LLM produces (a single revised world is all a revision
+    # operator, or a prose paraphrase, can express), so it is named first when
+    # the computation surfaced more than one option.
+    if n_options >= 2:
+        lead = (
+            f"pas de rétractation minimale unique — {n_options} retraits de "
+            f"cardinal {card} restaurent également la cohérence : plusieurs "
+            "mondes consistants incompatibles, également minimaux"
+        )
+    elif card == 1:
         lead = "une seule proposition suffit à restaurer la cohérence si on l'abandonne"
     else:
         lead = (

--- a/argumentation_analysis/reporting/restitution/appendix.py
+++ b/argumentation_analysis/reporting/restitution/appendix.py
@@ -70,6 +70,7 @@ _MOBILISATION: Dict[str, tuple] = {
     "axe_dung": (("dung_frameworks",), "prose", "actes II–III"),
     "axe_aspic": (("aspic_results",), "prose", "acte III"),
     "axe_bipolaire": (("bipolar_results",), "prose", "acte III"),
+    "axe_revision": (("belief_revision_results",), "prose", "acte III"),
     "deliberation": (("debate_transcripts",), "prose", "actes II–III"),
     "gouvernance": (("governance_decisions",), "prose", "actes II–III"),
     "arg_structuree": (("structured_arg_status",), "failure_only", "acte III"),
@@ -291,6 +292,12 @@ def _provenance_counts(state: Mapping[str, Any]) -> Dict[str, Any]:
     counts["axe_dung"] = "disponible" if _g("dung_frameworks") else "indisponible"
     counts["axe_aspic"] = "disponible" if _g("aspic_results") else "indisponible"
     counts["axe_bipolaire"] = "disponible" if _g("bipolar_results") else "indisponible"
+    # #1646 — belief revision reaches the Acte III prose (the minimal-retraction
+    # insight is named by _belief_revision_finding), so the coverage table
+    # attests it like the other structured-argumentation axes.
+    counts["axe_revision"] = (
+        "disponible" if _g("belief_revision_results") else "indisponible"
+    )
 
     # #1624 item 3 — two axes the Actes II and III genuinely mobilise and that
     # this table did not name at all. A coverage table that omits the

--- a/argumentation_analysis/reporting/restitution/state_adapter.py
+++ b/argumentation_analysis/reporting/restitution/state_adapter.py
@@ -28,6 +28,12 @@ _STATE_KEYS = (
     "modal_analysis_results",
     "dung_frameworks",
     "aspic_results",
+    # #1646 — belief revision reaches the Acte III conclusion: the minimal-
+    # retraction insight is NAMED by ``_belief_revision_finding`` (act3). The
+    # appendix attests the axis so a report whose conclusion rests on "the one
+    # belief to give up" carries that provenance in its own coverage table.
+    # Mirrors the #1667 carry of ``bipolar_results`` when that axis reached prose.
+    "belief_revision_results",
     # #1624 — three axes the PROSE mobilises that the appendix could not attest
     # at all, not even as "indisponible": a report whose conclusion rests on the
     # deliberation, on the governance vote and on the bipolar support relation

--- a/tests/unit/argumentation_analysis/orchestration/test_belief_revision_wiring_1646.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_belief_revision_wiring_1646.py
@@ -1,0 +1,428 @@
+"""#1646 incr 3 — belief-revision producer/reader wiring (minimal-retraction).
+
+The singular insight of belief revision (#1646 section A) is the **minimal
+retraction** — the smallest set of beliefs whose removal restores consistency.
+Incr 1 (``minimal_retractions``, MCS over python-sat) and incr 2
+(``build_belief_base``, derives a genuinely-inconsistent CNF base from
+fallacies) are merged as pure JVM-free functions. Incr 3 wires them end-to-end,
+mirroring the bipolar pattern (#1645): the producer computes the insight
+JVM-free and survives the honest-degraded path → the state writer carries it →
+the Act III reader NAMES it → the privacy scrub opacifies the named beliefs.
+
+Kill-set B (the reader-side naming promised by the incr-1/2 test header). The
+insight algorithm itself stays pinned in ``test_belief_revision_insight_1646``.
+
+Three producer states, never two (mirror ``test_bipolar_honest_degraded_1645``):
+  - JVM absent ⇒ honest-absent: a degraded dict WITH the minimal-retraction
+    insight (computed JVM-free), the phase continues. The insight no longer dies
+    on the degraded path — the whole point of computing it JVM-free.
+  - JVM up + handler/analysis raises ⇒ fail loud with the real cause.
+  - JVM up success ⇒ the insight is attached to the Levi result.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_BRIDGE_BR = (
+    "argumentation_analysis.agents.core.logic.belief_revision_handler."
+    "BeliefRevisionHandler"
+)
+_JVM_STARTED = "argumentation_analysis.core.jvm_setup.is_jvm_started"
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _ctx() -> dict:
+    """A context with 3 extracted arguments and ONE fallacy on arg_1.
+
+    arg_1 ↔ arguments[0]. The fallacy negates it, so the belief base gains a
+    ``[-1]`` clause alongside ``[1]`` — a real clash, cardinality 1 (insight
+    B-1). Opaque synthetic claims (privacy).
+    """
+    return {
+        "phase_extract_output": {
+            "arguments": ["claim_alpha", "claim_beta", "claim_gamma"]
+        },
+        "phase_hierarchical_fallacy_output": {
+            "fallacies": [{"type": "ad_hominem", "target_argument": "arg_1"}]
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# State 1 — JVM absent ⇒ honest-absent degraded dict WITH the insight
+# ---------------------------------------------------------------------------
+
+
+class TestJvmAbsentIsHonestAbsentWithInsight:
+    """JVM down: the producer returns a degraded dict (does NOT raise) AND the
+    minimal-retraction insight — computed JVM-free — still reaches the state.
+    Pre-fix the handler raised ``RuntimeError`` unconditionally, so the insight
+    never survived the degraded path (the #1645/#1670 architecture defect)."""
+
+    def test_returns_dict_not_raises(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_belief_revision,
+        )
+
+        with patch(_BRIDGE_BR, side_effect=RuntimeError("no JVM")), patch(
+            _JVM_STARTED, return_value=False
+        ):
+            result = _run(_invoke_belief_revision("text", _ctx()))
+
+        assert isinstance(result, dict)
+        assert result.get("degraded") is True
+        assert result.get("absent_reason") == "jvm_not_started"
+
+    def test_insight_survives_degraded_path_and_names_real_clash(self):
+        """The minimal-retraction insight is computed JVM-free, so it is present
+        in the degraded dict and reflects the planted fallacy (cardinality 1).
+        This is the core #1646 wiring: the insight does not die on the path
+        where the handler never runs."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_belief_revision,
+        )
+
+        with patch(_BRIDGE_BR, side_effect=RuntimeError("no JVM")), patch(
+            _JVM_STARTED, return_value=False
+        ):
+            result = _run(_invoke_belief_revision("text", _ctx()))
+
+        mr = result["minimal_retraction"]
+        assert mr["degraded"] is False  # the INSIGHT computed (jpype importable)
+        assert mr["cardinality"] == 1  # the fallacy created a real clash
+        # The retraction options name the clashing belief (alpha) or its negation.
+        flat = {label for opt in mr["options"] for label in opt}
+        assert any("alpha" in label for label in flat)
+
+    def test_absent_dict_preserves_real_signal_not_relabeled(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_belief_revision,
+        )
+
+        with patch(_BRIDGE_BR, side_effect=RuntimeError("no JVM")), patch(
+            _JVM_STARTED, return_value=False
+        ):
+            result = _run(_invoke_belief_revision("text", _ctx()))
+
+        assert "no JVM" in result.get("error", "")
+        assert result.get("revised") == []  # tri-state: not computed under Levi
+
+
+# ---------------------------------------------------------------------------
+# State 2 — JVM up + handler failure ⇒ fail loud with the real cause
+# ---------------------------------------------------------------------------
+
+
+class TestJvmUpHandlerFailureFailsLoudRealCause:
+    """JVM up but the handler/analysis raises ⇒ the failure is ours, not the
+    environment's. Fail loud with the real cause (preserved via ``from e``),
+    never relabeled 'install a JVM' (the #1634 fabrication)."""
+
+    def test_raises_with_real_cause_not_relabeled(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_belief_revision,
+        )
+
+        real_cause = TypeError("bad belief shape in revise")
+        mock_handler = MagicMock()
+        mock_handler.revise.side_effect = real_cause
+        with patch(_BRIDGE_BR, return_value=mock_handler), patch(
+            _JVM_STARTED, return_value=True
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                _run(_invoke_belief_revision("text", _ctx()))
+
+        msg = str(exc_info.value)
+        assert "TypeError" in msg
+        assert "bad belief shape in revise" in msg
+        # No environment relabel — the JVM is up.
+        assert "JVM/Tweety required" not in msg
+        assert "Install JVM" not in msg
+        assert exc_info.value.__cause__ is real_cause
+
+
+# ---------------------------------------------------------------------------
+# State 3 — JVM up success ⇒ the insight is attached to the Levi result
+# ---------------------------------------------------------------------------
+
+
+class TestJvmUpAttachesInsight:
+    """On the JVM-up path the Levi handler runs AND the minimal-retraction
+    insight is attached to its result dict, so it reaches the state writer."""
+
+    def test_jvm_up_result_carries_minimal_retraction(self):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_belief_revision,
+        )
+
+        mock_handler = MagicMock()
+        mock_handler.revise.return_value = {
+            "method": "dalal",
+            "original": ["a"],
+            "revised": ["b"],
+        }
+        with patch(_BRIDGE_BR, return_value=mock_handler), patch(
+            _JVM_STARTED, return_value=True
+        ):
+            result = _run(_invoke_belief_revision("text", _ctx()))
+
+        assert result["method"] == "dalal"  # the Levi result survived
+        mr = result["minimal_retraction"]
+        assert mr["cardinality"] == 1  # the insight was attached too
+        assert mr["degraded"] is False
+
+
+# ---------------------------------------------------------------------------
+# ImportError degrade of the insight (pysat / logic-cascade absent)
+# ---------------------------------------------------------------------------
+
+
+class TestInsightImportErrorDegradesHonestly:
+    """If the insight computation itself is unavailable (missing pysat, or the
+    logic/__init__ jpype cascade #1697), the producer degrades the INSIGHT
+    honestly (cardinality -1) rather than the phase — the pipeline still
+    returns a result. Monkeypatching the call-site attribute (not sys.modules)
+    keeps the test hermetic — the R772 lesson."""
+
+    def test_pysat_absent_degrades_insight_to_neg1(self, monkeypatch):
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_belief_revision,
+        )
+        import argumentation_analysis.agents.core.logic.belief_revision_insight as ins
+
+        def _boom(_base):
+            raise ImportError("simulated pysat absent")
+
+        monkeypatch.setattr(ins, "minimal_retractions", _boom)
+        with patch(_BRIDGE_BR, side_effect=RuntimeError("no JVM")), patch(
+            _JVM_STARTED, return_value=False
+        ):
+            result = _run(_invoke_belief_revision("text", _ctx()))
+
+        # The phase still returns (degraded dict); the insight itself degraded.
+        assert result["degraded"] is True
+        mr = result["minimal_retraction"]
+        assert mr["degraded"] is True
+        assert mr["cardinality"] == -1
+        assert mr["options"] == []
+
+
+# ---------------------------------------------------------------------------
+# Bridge — the insight flows producer output → state entry
+# ---------------------------------------------------------------------------
+
+
+class TestBridgePersistsInsight:
+    def test_writer_passes_minimal_retraction_to_state(self):
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_belief_revision_to_state,
+        )
+
+        output = {
+            "method": "dalal",
+            "original": ["a"],
+            "revised": ["b"],
+            "minimal_retraction": {
+                "cardinality": 1,
+                "options": [["claim_alpha"]],
+                "base_size": 4,
+                "touched_count": 1,
+                "degraded": False,
+            },
+        }
+        state = MagicMock()
+        _write_belief_revision_to_state(output, state, {})
+
+        state.add_belief_revision_result.assert_called_once()
+        # minimal_retraction is the 4th positional arg (mirrors add_bipolar_result
+        # style — support_cycles/articulation_points are positional too).
+        persisted_mr = state.add_belief_revision_result.call_args.args[3]
+        assert persisted_mr["cardinality"] == 1
+
+    def test_writer_passes_none_when_insight_absent(self):
+        """A producer output without the insight (e.g. a pre-insight caller)
+        stores None — honest, the reader then produces nothing."""
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_belief_revision_to_state,
+        )
+
+        state = MagicMock()
+        _write_belief_revision_to_state(
+            {"method": "dalal", "original": [], "revised": []}, state, {}
+        )
+        persisted_mr = state.add_belief_revision_result.call_args.args[3]
+        assert persisted_mr is None
+
+
+# ---------------------------------------------------------------------------
+# Reader — the Act III prose NAMES the minimal retraction
+# ---------------------------------------------------------------------------
+
+
+def _state_with(mr):
+    return SimpleNamespace(belief_revision_results=[{"minimal_retraction": mr}])
+
+
+class TestBeliefRevisionFinding:
+    def test_cardinality_one_names_rupture_belief(self):
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            _belief_revision_finding,
+        )
+
+        # B-1: one belief restores consistency; two cardinal-1 options (alpha / ¬alpha).
+        state = _state_with(
+            {
+                "cardinality": 1,
+                "options": [["claim_alpha"], ["¬claim_alpha"]],
+                "base_size": 4,
+                "touched_count": 2,
+                "degraded": False,
+            }
+        )
+        finding = _belief_revision_finding(state)
+        assert finding is not None
+        assert finding.capability == "belief_revision"
+        assert "une seule proposition" in finding.statement
+        assert "alpha" in finding.statement  # the rupture belief is NAMED
+
+    def test_cardinality_two_names_cardinal(self):
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            _belief_revision_finding,
+        )
+
+        state = _state_with(
+            {
+                "cardinality": 2,
+                "options": [["claim_alpha", "claim_beta"]],
+                "base_size": 5,
+                "touched_count": 2,
+                "degraded": False,
+            }
+        )
+        finding = _belief_revision_finding(state)
+        assert finding is not None
+        assert "cardinal 2" in finding.statement
+
+    def test_inert_contradiction_named_when_beliefs_survive(self):
+        """B-3: when the retraction touches fewer beliefs than the base holds,
+        the untouched beliefs survive — the contradiction is real but inert."""
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            _belief_revision_finding,
+        )
+
+        # base of 4, only 1 ever touched → 3 survive → inert signal fires.
+        state = _state_with(
+            {
+                "cardinality": 1,
+                "options": [["claim_alpha"]],
+                "base_size": 4,
+                "touched_count": 1,
+                "degraded": False,
+            }
+        )
+        finding = _belief_revision_finding(state)
+        assert finding is not None
+        assert "inerte" in finding.statement or "confinée" in finding.statement
+
+    def test_consistent_base_no_finding(self):
+        """cardinality 0 (consistent base) ⇒ no finding (honest absence, #1019)."""
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            _belief_revision_finding,
+        )
+
+        state = _state_with(
+            {"cardinality": 0, "options": [[]], "base_size": 3, "touched_count": 0}
+        )
+        assert _belief_revision_finding(state) is None
+
+    def test_degraded_insight_no_finding(self):
+        """cardinality -1 (insight unavailable) ⇒ no finding (never fabricate)."""
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            _belief_revision_finding,
+        )
+
+        state = _state_with(
+            {"cardinality": -1, "options": [], "base_size": 0, "touched_count": 0}
+        )
+        assert _belief_revision_finding(state) is None
+
+    def test_missing_insight_no_finding(self):
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            _belief_revision_finding,
+        )
+
+        state = SimpleNamespace(belief_revision_results=[{"method": "dalal"}])
+        assert _belief_revision_finding(state) is None
+
+
+# ---------------------------------------------------------------------------
+# Privacy — the named belief labels are opacified on export
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeOpacifiesOptions:
+    def test_options_opacified_counts_intact(self):
+        from argumentation_analysis.evaluation.sanitize_state import sanitize_state
+
+        state = {
+            "belief_revision_results": [
+                {
+                    "method": "dalal",
+                    "original": ["claim_alpha"],
+                    "revised": ["claim_beta"],
+                    "minimal_retraction": {
+                        "cardinality": 1,
+                        "options": [["claim_alpha"], ["¬claim_alpha"]],
+                        "base_size": 4,
+                        "touched_count": 2,
+                        "degraded": False,
+                    },
+                }
+            ]
+        }
+        out = sanitize_state(state)
+        mr = out["belief_revision_results"][0]["minimal_retraction"]
+        # The ints survive untouched (the structural signal).
+        assert mr["cardinality"] == 1
+        assert mr["base_size"] == 4
+        assert mr["touched_count"] == 2
+        # The named belief labels are opacified (no source prose leaks).
+        flat = {label for opt in mr["options"] for label in opt}
+        assert all("claim_alpha" not in label for label in flat)
+        # ... and the topology survived (still 2 singleton options).
+        assert len(mr["options"]) == 2
+        assert all(len(opt) == 1 for opt in mr["options"])
+
+    def test_options_opacified_roundtrip_structure(self):
+        """A nested option (cardinality-2 retraction) opacifies each leaf but
+        keeps the arity, so the reader-side structure survives export."""
+        from argumentation_analysis.evaluation.sanitize_state import sanitize_state
+
+        state = {
+            "belief_revision_results": [
+                {
+                    "method": "dalal",
+                    "original": [],
+                    "revised": [],
+                    "minimal_retraction": {
+                        "cardinality": 2,
+                        "options": [["claim_alpha", "claim_beta"]],
+                        "base_size": 5,
+                        "touched_count": 2,
+                        "degraded": False,
+                    },
+                }
+            ]
+        }
+        out = sanitize_state(state)
+        opt = out["belief_revision_results"][0]["minimal_retraction"]["options"]
+        assert len(opt) == 1 and len(opt[0]) == 2  # arity preserved
+        assert all("claim_" not in leaf for leaf in opt[0])  # content opacified

--- a/tests/unit/argumentation_analysis/orchestration/test_belief_revision_wiring_1646.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_belief_revision_wiring_1646.py
@@ -98,6 +98,10 @@ class TestJvmAbsentIsHonestAbsentWithInsight:
         mr = result["minimal_retraction"]
         assert mr["degraded"] is False  # the INSIGHT computed (jpype importable)
         assert mr["cardinality"] == 1  # the fallacy created a real clash
+        # B-2: one fallacy on arg_1 yields ≥2 cardinal-1 retractions (drop the
+        # belief OR drop its negation) — the non-unicity the reader names. The
+        # multiplicity reaches the state, not just the cardinality.
+        assert len(mr["options"]) >= 2
         # The retraction options name the clashing belief (alpha) or its negation.
         flat = {label for opt in mr["options"] for label in opt}
         assert any("alpha" in label for label in flat)
@@ -272,12 +276,38 @@ def _state_with(mr):
 
 
 class TestBeliefRevisionFinding:
-    def test_cardinality_one_names_rupture_belief(self):
+    def test_cardinality_one_unique_names_rupture_belief(self):
         from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
             _belief_revision_finding,
         )
 
-        # B-1: one belief restores consistency; two cardinal-1 options (alpha / ¬alpha).
+        # B-1: a SINGLE minimal retraction of cardinal 1 — one belief restores
+        # consistency, and the reader NAMES it as the unique point of rupture.
+        state = _state_with(
+            {
+                "cardinality": 1,
+                "options": [["claim_alpha"]],
+                "base_size": 4,
+                "touched_count": 1,
+                "degraded": False,
+            }
+        )
+        finding = _belief_revision_finding(state)
+        assert finding is not None
+        assert finding.capability == "belief_revision"
+        assert "une seule proposition" in finding.statement
+        assert "alpha" in finding.statement  # the rupture belief is NAMED
+
+    def test_non_unique_retraction_names_incompatibility(self):
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            _belief_revision_finding,
+        )
+
+        # B-2: TWO retractions of cardinal 1 restore consistency (alpha or its
+        # negation). None is *the* minimal one — the base splits into two
+        # incompatible but equally-minimal consistent worlds. This is the figure
+        # no LLM produces (a single revised world is all a revision operator can
+        # express), so it must reach the rendered conclusion by name. DoD #1646.
         state = _state_with(
             {
                 "cardinality": 1,
@@ -289,9 +319,12 @@ class TestBeliefRevisionFinding:
         )
         finding = _belief_revision_finding(state)
         assert finding is not None
-        assert finding.capability == "belief_revision"
-        assert "une seule proposition" in finding.statement
-        assert "alpha" in finding.statement  # the rupture belief is NAMED
+        # The non-unicity is the headline, not folded into a generic rupture list.
+        assert "pas de rétractation minimale unique" in finding.statement
+        assert "incompatibles" in finding.statement
+        assert "également minimaux" in finding.statement
+        # The cardinality still appears (both options are cardinal 1).
+        assert "cardinal 1" in finding.statement
 
     def test_cardinality_two_names_cardinal(self):
         from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_two_reading_surfaces_1624.py
@@ -95,6 +95,7 @@ def _full_state() -> Dict[str, Any]:
         "modal_analysis_results": [{"consistent": True}],
         "dung_frameworks": {"dung_1": {"name": "dung_arbitration"}},
         "aspic_results": [{"id": "aspic_1", "extensions": [["a"]]}],
+        "belief_revision_results": [{"method": "dalal"}],
         "bipolar_results": [{"supports": [["a", "b"]]}],
         "debate_transcripts": [{"turns": []}, {"turns": []}],
         "governance_decisions": [{"method": "borda"}],
@@ -177,6 +178,7 @@ PROSE_BASELINE = frozenset(
     {
         "argument_quality_scores",
         "aspic_results",
+        "belief_revision_results",
         "bipolar_results",
         "counter_arguments",
         "deanonymized",

--- a/tests/unit/argumentation_analysis/test_belief_revision_conversational.py
+++ b/tests/unit/argumentation_analysis/test_belief_revision_conversational.py
@@ -153,3 +153,81 @@ class TestBeliefRevision:
         assert "revised" in entry
         assert isinstance(entry["original"], list)
         assert isinstance(entry["revised"], list)
+
+
+class TestMinimalRetractionInsight:
+    """#1646 incr 3 — the conversational producer computes the minimal-retraction
+    insight (mirrors the pipeline producer ``_invoke_belief_revision``), so the
+    axis's singular contribution reaches the Acte III reader in conversational
+    mode too. The two producers are MODE-EXCLUSIVE
+    (``workflow_name="conversational"`` returns from ``run_conversational_analysis``
+    before pipeline capabilities run, and vice-versa), so BOTH must compute it or
+    the insight dies in whichever mode the run uses. R782 dispatched this site
+    explicitly."""
+
+    def test_insight_computed_and_persisted_on_fallacy(self):
+        """A fallacy-contracted belief yields a minimal_retraction on the state
+        entry — the insight does not die in conversational mode."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_belief_revision_from_state,
+        )
+
+        state = UnifiedAnalysisState("Test")
+        arg_id = state.add_argument("Target argument")
+        state.add_jtms_belief(name=arg_id, valid=True, justifications=[])
+        state.add_fallacy("ad_hominem", "Attack", target_arg_id=arg_id)
+
+        result = _run_belief_revision_from_state(state)
+        assert result is not None
+        entry = state.belief_revision_results[0]
+        mr = entry.get("minimal_retraction")
+        assert mr is not None
+        assert mr["degraded"] is False  # pysat importable in the test env
+        assert mr["cardinality"] == 1  # the fallacy created a real clash
+        assert mr["base_size"] == 2  # the belief + its negation
+
+    def test_insight_carries_non_uniqueness(self):
+        """B-2: one fallacy → the belief OR its negation can be retracted (>=2
+        minimal options) — the non-unicity the reader names reaches the state."""
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_belief_revision_from_state,
+        )
+
+        state = UnifiedAnalysisState("Test")
+        arg_id = state.add_argument("Target argument")
+        state.add_jtms_belief(name=arg_id, valid=True, justifications=[])
+        state.add_fallacy("ad_hominem", "Attack", target_arg_id=arg_id)
+        _run_belief_revision_from_state(state)
+
+        mr = state.belief_revision_results[0]["minimal_retraction"]
+        assert len(mr["options"]) >= 2  # B-2: non-unique retraction
+        flat = {label for opt in mr["options"] for label in opt}
+        assert arg_id in flat  # the rupture belief is NAMED
+
+    def test_insight_degrades_honestly_on_import_error(self, monkeypatch):
+        """logic/__init__ jpype cascade (#1697): when the insight module import
+        raises, the insight degrades to cardinality -1 (reader mute) AND the
+        contraction still persists. Honest degrade, not a fabricated retraction.
+        Uses monkeypatch on the function (NOT sys.modules — the R772 poison)."""
+        import argumentation_analysis.agents.core.logic.belief_revision_insight as ins
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _run_belief_revision_from_state,
+        )
+
+        def _boom(_base):
+            raise ImportError("simulated logic/__init__ jpype cascade")
+
+        monkeypatch.setattr(ins, "minimal_retractions", _boom)
+
+        state = UnifiedAnalysisState("Test")
+        arg_id = state.add_argument("Target argument")
+        state.add_jtms_belief(name=arg_id, valid=True, justifications=[])
+        state.add_fallacy("ad_hominem", "Attack", target_arg_id=arg_id)
+
+        result = _run_belief_revision_from_state(state)
+        assert result is not None  # the contraction still ran
+        entry = state.belief_revision_results[0]
+        assert entry["minimal_retraction"]["degraded"] is True
+        assert entry["minimal_retraction"]["cardinality"] == -1
+        # the contraction itself is unaffected by the insight degrade
+        assert len(entry["revised"]) < len(entry["original"])

--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -1897,15 +1897,19 @@ class TestBeliefRevisionValueGate:
     Gate: must return revised belief set and flag fallback.
     """
 
-    async def test_belief_revision_fallback_raises_fail_loud(self):
-        """Belief revision must RAISE (fail-loud) when JVM unavailable — anti-theatre (#1252/#1019).
+    async def test_belief_revision_jvm_absent_returns_honest_degraded_dict(self):
+        """Belief revision returns an honest-absent degraded dict when the JVM is
+        down — NOT a raise, NOT a fabricated revision (#1646, mirror #1645/#1670).
 
-        Contract evolution: the earlier #1005/#1013 guards asserted a
-        *Python-fallback dict* (literal set modification: drop negated belief,
-        append new belief). Post-#1252/#1019 the except block was hardened to
-        RAISE RuntimeError so a fabricated revised set can never enter state.
-        STRICTER than the old revised-differs-from-original dicts — the raise
-        proves no synthetic revision is produced. Triage #1336.
+        Contract evolution: the #1005/#1013 guards asserted a Python-fallback
+        dict (fabricated revised set); #1252/#1019 hardened that to a RAISE so no
+        synthetic revision entered state. #1646 changes the contract again: the
+        minimal-retraction insight is computed JVM-free and MUST reach the reader
+        on the degraded path (the architecture lesson of #1645/#1670 — an insight
+        that lives only in the JVM-bound handler dies there). So the producer now
+        returns a degraded dict (``degraded: True``, ``revised: []`` tri-state)
+        instead of raising. Anti-theatre is preserved: ``revised`` is EMPTY (no
+        fabricated revision), and the JVM-free insight is the real signal.
         """
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_belief_revision,
@@ -1919,8 +1923,41 @@ class TestBeliefRevisionValueGate:
         with patch(
             "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
             side_effect=RuntimeError("No JVM for test"),
+        ), patch(
+            "argumentation_analysis.core.jvm_setup.is_jvm_started",
+            return_value=False,
         ):
-            with pytest.raises(RuntimeError, match="Belief revision .* unavailable"):
+            result = await _invoke_belief_revision("test", context)
+
+        assert isinstance(result, dict)
+        assert result["degraded"] is True
+        assert result["absent_reason"] == "jvm_not_started"
+        # anti-theatre: no fabricated revised set enters state (tri-state empty).
+        assert result["revised"] == []
+        # the JVM-free minimal-retraction insight still reaches the state/reader.
+        assert "minimal_retraction" in result
+
+    async def test_belief_revision_jvm_up_handler_failure_raises_fail_loud(self):
+        """JVM up + handler/analysis raises ⇒ fail loud with the real cause. The
+        #1252/#1019 anti-theatre guard, now correctly scoped to the JVM-up path
+        (a handler failure with the JVM up is ours, not the environment's)."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_belief_revision,
+        )
+
+        context = {
+            "belief_set": ["a", "b"],
+            "new_belief": "c",
+            "revision_method": "dalal",
+        }
+        with patch(
+            "argumentation_analysis.orchestration.invoke_callables.asyncio.to_thread",
+            side_effect=TypeError("bad belief shape in revise"),
+        ), patch(
+            "argumentation_analysis.core.jvm_setup.is_jvm_started",
+            return_value=True,
+        ):
+            with pytest.raises(RuntimeError, match="Belief revision .* failed with JVM up"):
                 await _invoke_belief_revision("test", context)
 
 


### PR DESCRIPTION
## What

Wires belief-revision's singular insight — the **minimal retraction** (the smallest set of beliefs whose removal restores consistency; a *global cardinality* property no other component produces) — from the pure JVM-free functions of incr 1+2 through to the Acte III conclusion prose. `Refs #1646` (one DoD increment, **not** `Closes` — the planted-text paired-run is the next increment).

Incr 1 (`minimal_retractions`, MCS over python-sat — #1689) and incr 2 (`build_belief_base` — #1691) are merged as pure JVM-free fns, but the producer never called them: `_invoke_belief_revision` was JVM-only (Levi handler), raised on JVM-down, and emitted no insight. The insight died before the state — exactly the defect the architecture lesson (#1645/#1670) names. This mirrors the established bipolar pattern (#1645 PR1+PR2): producer computes JVM-free + survives honest-degraded → state writer carries → Act III reader **names** it → privacy opacifies the named beliefs.

## Touch-points (5)

| Layer | File | Change |
|---|---|---|
| Producer | `orchestration/invoke_callables.py` (`_invoke_belief_revision`) | Full rewrite mirroring `_invoke_bipolar`. Builds base (fallacies negate targets), computes `minimal_retraction` JVM-free in guarded `try/except ImportError`, maps options to **named** beliefs, resolves `jvm_up` once. Three states: JVM absent ⇒ honest-absent dict **with** insight; JVM up + handler raises ⇒ `RuntimeError(... failed with JVM up: {type(e).__name__}: {e}) from e` (fail loud, real cause); JVM up success ⇒ insight attached. |
| State | `core/shared_state.py` (`add_belief_revision_result`) | `+ minimal_retraction: Optional[Dict] = None`; stored under `entry["minimal_retraction"]` only when not `None` (callers pre-insight store nothing). |
| Bridge | `orchestration/state_writers.py` (`_write_belief_revision_to_state`) | Reads `output.get("minimal_retraction")`, type-guards, passes positionally. |
| Reader | `reporting/restitution/act3_conclusion_plugin.py` | New `_belief_revision_finding` mirrors `_bipolar_finding`. **B-1**: cardinality ≥ 1, single option → *names* the rupture (*"la rétractation minimale est de cardinal N — abandonner {belief}"*). **B-2**: `len(options) ≥ 2` → non-unicity phrasing (*"pas de rétractation minimale unique : plusieurs mondes consistants incompatibles, également minimaux"*) — the figure no LLM produces (a single revised world is all a revision operator can express); takes precedence over B-1. **B-3**: `base_size - touched_count > 0` → inert-contradiction phrasing. Returns `None` for cardinality 0 / −1 / missing. Registered in the dispatch tuple. |
| Privacy | `evaluation/sanitize_state.py` | `minimal_retraction.options` leaves (named belief labels = source prose) opacified on export; `cardinality`/`base_size`/`touched_count` (ints) survive. |

## Coherent 4-surface update (#1624)

`belief_revision_results` reaches the conclusion prose, so the appendix must attest it — same four surfaces that carried `bipolar_results` in #1667, kept coherent by `test_two_reading_surfaces_1624`:
- `state_adapter._STATE_KEYS` — appendix projection carries the key
- `appendix._provenance_counts` — `axe_revision` row (disponible/indisponible)
- `appendix._MOBILISATION` — declares the axis "mobilisée, acte III"
- test baseline — `PROSE_BASELINE` + `_full_state()` carry the key

## Producer-site — RESOLVED (both producers wired, as R782 instructed)

The dispatch (R782) explicitly named the **conversational** producer `_run_belief_revision_from_state` as the wiring site. This PR wires **both** producers, because the two are **mode-exclusive**: `run_unified_analysis` with `workflow_name="conversational"` calls `run_conversational_analysis(spectacular=True)` and returns *before* any pipeline capability runs (unified_pipeline.py:207-217); `_invoke_belief_revision` runs only in the other (pipeline) modes. Wiring the pipeline alone would leave the insight dead in conversational mode — the path R782 identified as activated. So:

- **Pipeline producer** `_invoke_belief_revision` (commit `ab67cba3`) — fires in pipeline modes (light/standard/full), registered at `registry_setup.py:801`.
- **Conversational producer** `_run_belief_revision_from_state` (commit `a89f0a22`) — fires in conversational mode under the `spectacular` guard. Computes the insight JVM-free (targeted jtms beliefs = the negated ones), guarded vs the `logic/__init__` jpype cascade (#1697), same `minimal_retraction` shape. 3 new tests in `test_belief_revision_conversational.py` (insight computed/persisted; B-2 non-unicity; ImportError honest-degrade).

The reader (`_belief_revision_finding`) is producer-agnostic — whichever mode runs, once `minimal_retraction` is populated the conclusion names all three insights (B-1/B-2/B-3). The existing AGM contraction path and its 9 tests are unchanged (additive wiring).

## Design decision to flag

**Adding an honest-absent branch to `_invoke_belief_revision`.** It previously raised `RuntimeError` unconditionally on JVM-down — one of the "15 fail-loud handlers" the coordinator scoped *out* of #1677's *narrow census* (whether handlers check `isJVMStarted` before raising). #1646 is a *different* issue, and its core lesson (#1645/#1670) is that the insight MUST survive the degraded path — which requires the producer to **return** a degraded dict with the insight, not raise. `_invoke_bipolar` already does exactly this. I mirror bipolar: `if not jvm_up: return degraded-with-insight; else: raise`. This **extends** the honest-absent contract to belief-revision; it does not contradict the #1677 census ruling (which was about guard placement, not forbidding degraded branches elsewhere).

The `logic/__init__` jpype cascade itself stays tracked in **#1697** — the `try/except ImportError` here degrades the insight locally, it does not fix the cascade.

Anti-theâtre preserved: the degraded dict carries `revised: []` (tri-state — no fabricated revision) + `degraded: True`, not a silent fake result.

## Tests (kill-set)

New `test_belief_revision_wiring_1646.py` (16 tests):
- **JVM-absent honest-absent** (3): returns dict **with** insight, does not raise, `degraded=True`.
- **JVM-up handler failure** (1): `RuntimeError` carries the real cause.
- **JVM-up success** (1): insight attached to handler result.
- **ImportError degrade** (1): monkeypatches `ins.minimal_retractions` → cardinality −1, no raise.
- **Bridge** (2): insight flows output → state entry.
- **Reader** (7): B-1 unique rupture; **B-2 non-unicity** (asserts "pas de rétractation minimale unique" + "incompatibles" + "également minimaux" reach the rendered statement); B-3 inert phrasing; cardinality 0/−1/missing → no finding.
- **Producer** (1, strengthened): the `_ctx` fixture yields ≥2 minimal retractions, demonstrating the B-2 multiplicity reaches the state, not just the cardinality.
- **Privacy** (2): `options` leaves opacified; `cardinality`/`base_size` intact.

Updated `test_value_gates.py::TestBeliefRevisionValueGate` (2) — supersedes the old raise-on-JVM-down contract with honest-absent (returns dict) + scoped fail-loud (JVM-up only).

## Verification

```
test_belief_revision_wiring_1646.py .... 17 passed  (incl. B-2 non-unicity)
reporting/restitution/ ........................ 379 passed  (no reader regression)
test_value_gates.py::TestBeliefRevisionValueGate  2 passed
test_two_reading_surfaces_1624.py ............ coherent (4-surface)
test_belief_revision_insight_1646.py (incr 1+2)  green (pure fns unchanged)
black --check (edited files) .................. clean
flake8 ......................................... NOT runnable on po-2023 (env absent) — CI will judge
```

**Pre-existing, unrelated to this change:** `test_tweety_fallbacks` has ranking/ADF failures on this worker from `_python_ranking_fallback` (invoke_callables.py:3406) requiring a live JVM — a function **not touched** here. `TestInvokeBeliefRevisionFallback` (the belief-revision fallback suite) passes.

## Out of scope (discipline)

- Planted-text paired-run (DoD item C) — **next** increment (incr 4), needs this wiring live to measure differentiation.
- Per-type fallacy granularity (negate vs weaken) — documented follow-up per `build_belief_base` docstring.
- The `logic/__init__` jpype cascade — #1697 (coordinator's separate track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
