### PR TITLE
fix(sanitize): scrub aspic_results.attacks source-derived atoms (#1649 privacy follow-up)

### DIFF
--- a/argumentation_analysis/evaluation/sanitize_state.py
+++ b/argumentation_analysis/evaluation/sanitize_state.py
@@ -193,6 +193,17 @@ _OPAQUE_LIST_OF_DICTS_MAPPING_KEYS = {
 _OPAQUE_NESTED_ITEM_SUBKEYS = {
     "dialogue_results": {"trace": {"argument", "target"}},
     "debate_transcripts": {"exchanges": {"proponent_move", "opponent_move"}},
+    # #1649 privacy follow-up: aspic_results[*].attacks = the qualified attacks
+    # surfaced top-level by the #1681 writer (and now read by the #1699 reader).
+    # Each attack dict = {target, attacker_premises, scope, attacker_rule}.
+    # ``target``/``attacker_premises`` are source-derived PL atoms — ``_pl_atom``
+    # (invoke_callables.py) keeps up to 24 leading chars of the argument text,
+    # so they ARE nominative → opacify. ``scope`` (undercut/rebut/undermine/
+    # unresolved) and ``attacker_rule`` (def_con_N / def_unc_N) are structural
+    # closed vocabularies at every producer (measured: handler _qualify_attacks,
+    # translator _validate_aspic_*) → preserved, exactly as dung_frameworks.name
+    # is. Uses the same opacify_list_values path as dialogue_results.trace.
+    "aspic_results": {"attacks": {"target", "attacker_premises"}},
 }
 
 # List-of-dicts fields carrying a symbol-mapping sub-key: a ``Dict[str, str]``

--- a/tests/unit/argumentation_analysis/evaluation/test_sanitize_state.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_sanitize_state.py
@@ -834,6 +834,43 @@ class TestListShapedContainers1664:
         assert entry["arguments"][0] != self.NL
         assert entry["supports"][0][0] == entry["arguments"][0]
 
+    def test_aspic_attacks_atoms_opacified_scope_vocabulary_kept(self):
+        """#1649 privacy follow-up: aspic_results[*].attacks (qualified attacks
+        surfaced top-level by #1681, read by the #1699 reader) carry source-
+        derived atoms in target/attacker_premises → opacified. scope (undercut/
+        rebut/undermine/unresolved) and attacker_rule (def_con_N) are closed
+        vocabularies at every producer → preserved, exactly as
+        dung_frameworks.name is. Built by the real add_aspic_result +
+        get_state_snapshot, not a literal fixture.
+        """
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+        state = UnifiedAnalysisState("initial")
+        state.add_aspic_result(
+            "simple",
+            [["a"]],
+            {"n": 1},
+            attacks=[
+                {
+                    "target": self.NL,
+                    "attacker_premises": [self.OTHER_NL],
+                    "scope": "undercut",
+                    "attacker_rule": "def_con_1",
+                }
+            ],
+        )
+        result = sanitize_state(state.get_state_snapshot())
+        atk = result["aspic_results"][0]["attacks"][0]
+        # Source-derived atoms opacified (not the raw NL text).
+        assert atk["target"] != self.NL
+        assert atk["attacker_premises"][0] != self.OTHER_NL
+        assert self.NL not in json.dumps(result["aspic_results"])
+        assert self.OTHER_NL not in json.dumps(result["aspic_results"])
+        # Closed vocabularies survive — the #1699 reader names the scope to
+        # qualify the attack; opacifying it would erase the axis's contribution.
+        assert atk["scope"] == "undercut"
+        assert atk["attacker_rule"] == "def_con_1"
+
     def test_no_planted_claim_text_survives_anywhere(self):
         blob = json.dumps(sanitize_state(self._snapshot()))
         assert self.NL not in blob


### PR DESCRIPTION
## Privacy follow-up to #1681 (writer) + #1699 (reader) — closes the FLAG I raised in R783

`sanitize_state` scrubbed `aspic_results.extensions` but **not** `aspic_results.attacks` — #1681 added the field (top-level qualified attacks list) without updating the scrub config. The #1699 reader now consumes these attacks, so they are freshly load-bearing in the bundle export. Each attack dict = `{target, attacker_premises, scope, attacker_rule}`:
- **target / attacker_premises** = source-derived PL atoms (`_pl_atom` keeps up to 24 leading chars of argument text) → **nominative, must scrub**.
- **scope** (undercut/rebut/undermine/unresolved) + **attacker_rule** (def_con_N) = structural closed vocabularies at every producer → **must preserve** (the reader names scope to qualify the attack).

### Fix — minimal, reuses an existing pattern
ONE entry added to `_OPAQUE_NESTED_ITEM_SUBKEYS` — the **pass-5d** pattern that already scrubs `dialogue_results.trace[*]` and `debate_transcripts.exchanges[*]` (list-of-dicts nested as a sub-key of a list-of-dicts field). No new scrub pattern, no consumer change: the existing loop (`sanitize_state.py:426-440`) already iterates `field[*][subtree][*]` and opacifies the leaf subkeys. Anti-pendule: reuse rather than add a parallel mechanism.

### Test (anti-#1019)
Built via real `add_aspic_result(attacks=...)` + `get_state_snapshot()` — not a literal fixture (a literal can't prove the scrub fires on the real serialized shape). Asserts target/attacker_premises opacified + scope/attacker_rule survive. 64 sanitize tests pass; black clean. mypy nit at line 475 is pre-existing (outside this change, outside the CI strict gate).

### Privacy judgment for coordinator review
I made the call: target/attacker_premises → opacify (source-derived); scope/attacker_rule → preserve (closed vocab). Flagging explicitly for your review since this is the judgment you asked to keep privacy-reviewed (R783 flag).

Co-Authored-By: Claude-Code <noreply@anthropic.com>
