### PR TITLE
fix(dung): attack echo declares submitted/retained/dropped (#1698 item 3 — honest report)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3644,6 +3644,23 @@ def _propagate_structured_arg_cause(
     context[_translation_error_key(capability)] = error
 
 
+def _structured_arg_cause(context: Dict[str, Any], capability: str) -> Optional[str]:
+    """Read the discriminated translation cause a translator wrote into context.
+
+    Inverse of ``_propagate_structured_arg_cause`` (which writes it). Used by
+    the Dung-family invokes to decide whether an arbiter already answered
+    (#1629 soustraction): ``no_genuine_relations`` means the translator RAN and
+    found nothing — an analytical result, distinct from ``translator_failed`` /
+    ``translator_unconfigured`` where no answer was obtained.
+    """
+    from argumentation_analysis.orchestration.state_writers import (
+        _translation_cause_key,
+    )
+
+    cause = context.get(_translation_cause_key(capability))
+    return cause if isinstance(cause, str) else None
+
+
 async def _invoke_bipolar(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]:
     """Invoke bipolar argumentation handler with JVM fallback."""
     args = context.get("arguments") or _extract_arguments_from_context(
@@ -4509,6 +4526,17 @@ async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict[str, A
         and isinstance(raw_attacks[0], dict)
     ):
         attacks = raw_attacks
+    elif _structured_arg_cause(context, "setaf_reasoning") == "no_genuine_relations":
+        # #1629 soustraction: the translator arbitrated and found NO genuine
+        # joint attacks in the source — an analytical result, not a failure
+        # (it is correct on 2/3 corpus). Do NOT fall back to synthetic
+        # _generate_attacks_from_args pairs: that fabricated edges whose
+        # endpoints were never inventory members, so the handler dropped 100%
+        # of them while the producer echoed the input as a result (#1698).
+        # Fabricating nothing is the honest input to a "nothing to attack"
+        # graph. (Dung/social have no translator covering naked attacks and
+        # stay out of this scope.)
+        attacks = []
     else:
         pairs = context.get("attacks") or _generate_attacks_from_args(args, context)
         attacks = _setaf_attacks_from_pairs(pairs)
@@ -4584,6 +4612,16 @@ async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict[str
             for t in raw_attacks
             if isinstance(t, (list, tuple)) and len(t) >= 3
         ]
+    elif (
+        _structured_arg_cause(context, "weighted_argumentation")
+        == "no_genuine_relations"
+    ):
+        # #1629 soustraction: the translator arbitrated and found NO genuine
+        # weighted attacks — an analytical result, not a failure. Do NOT fall
+        # back to synthetic _generate_attacks_from_args pairs with a fabricated
+        # neutral weight: those edges were dropped by the handler (out-of-
+        # inventory sources) and echoed as a result (#1698). See setaf twin.
+        attacks = []
     else:
         pairs = context.get("attacks") or _generate_attacks_from_args(args, context)
         attacks = _weighted_attacks_from_pairs(pairs)

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3335,6 +3335,104 @@ def _aba_rules_from_context(
     return assumptions, derived
 
 
+# --- #1698: honest attack-retention accounting for the Dung family ----------
+#
+# Every Dung-family handler (af, weighted, social, setaf) builds its framework
+# by guarding each attack against the inventory ``arg_map`` and SILENTLY
+# dropping any edge with an endpoint outside it (af_handler.py:101,
+# weighted_handler.py:107, social_handler.py:97, setaf_handler.py:102/106/108).
+# ``_generate_attacks_from_args`` mints synthetic sources (``fallacy_*``,
+# ``CA:*``) that are never inventory members, so on the real corpus 100% of
+# edges are dropped — yet the producers paste the INPUT attacks back into the
+# output as if they were the evaluated graph, and up to thirteen state entries
+# (11 ``verification_*`` + ``social_af`` + ``weighted_grounded``) echo them.
+#
+# The retain/drop decision is a pure membership test in all four handlers, so
+# it is faithfully reproducible from the inputs they received — no second Java
+# build, no handler change. These helpers make the echo honest: the output
+# carries the edges actually in the frame plus an explicit
+# submitted/retained/dropped accounting, so a graph evaluated with no edge
+# declares itself (#1698 item 3 — the honest report, NOT the attacker-identity
+# design decision, which is gated on #1629).
+
+
+def _retained_attacks(arguments: List[str], submitted_attacks: List[Any]) -> List[Any]:
+    """Attacks whose endpoints are all members of ``arguments``.
+
+    Shapes (the four handlers' input contracts):
+      - Dung/Social pair ``[src, tgt]``            -> src and tgt in inventory
+      - Weighted triple ``(src, tgt, w)``          -> src and tgt in inventory
+      - SetAF spec ``{"attackers": [...], "target"}`` -> target in inventory AND
+        at least one attacker in inventory (the handler keeps the partial set).
+
+    Anything else (malformed / unknown shape) is dropped — the caller must not
+    assert an attack it cannot ground (#1019).
+    """
+    arg_set = {str(a) for a in arguments}
+    retained: List[Any] = []
+    for atk in submitted_attacks:
+        if isinstance(atk, dict) and "attackers" in atk and "target" in atk:
+            target = str(atk.get("target", ""))
+            attackers = atk.get("attackers") or []
+            if target in arg_set and any(str(a) in arg_set for a in attackers):
+                retained.append(atk)
+        elif isinstance(atk, (list, tuple)) and len(atk) >= 2:
+            if str(atk[0]) in arg_set and str(atk[1]) in arg_set:
+                retained.append(atk)
+    return retained
+
+
+def _annotate_attack_retention(
+    output: Dict[str, Any],
+    arguments: List[str],
+    submitted_attacks: List[Any],
+    *,
+    framework_name: str,
+    state: Any = None,
+) -> Dict[str, Any]:
+    """Make a Dung-family producer's attack echo honest about retention.
+
+    Replaces the input-echo ``output["attacks"]`` with the edges that actually
+    reached the framework, and records how many were submitted, retained, and
+    dropped. ``statistics.attacks_count`` is aligned to the retained count (it
+    previously echoed the input size and fed verdicts about a graph that had
+    no edges). When edges were dropped, a single trace entry declares it —
+    replacing today's pattern where ``af_handler`` logs the drop once while the
+    state entries echo the input as a result.
+
+    Anti-pendule (#1698): this reports the CURRENT behaviour honestly. It does
+    NOT make synthetic sources inventory members — that is the attacker-identity
+    design decision, gated on #1629 and on a measured rejection.
+    """
+    retained = _retained_attacks(arguments, submitted_attacks)
+    n_sub = len(submitted_attacks) if isinstance(submitted_attacks, list) else 0
+    n_ret = len(retained)
+    output["attacks"] = retained
+    output["attacks_submitted"] = n_sub
+    output["attacks_retained"] = n_ret
+    output["attacks_dropped"] = n_sub - n_ret
+    stats = output.get("statistics")
+    if isinstance(stats, dict):
+        # statistics.attacks_count now counts what was EVALUATED (retained),
+        # not what was submitted — the old value echoed the input (#1698).
+        stats["attacks_count"] = n_ret
+        stats["attacks_submitted"] = n_sub
+    if n_sub - n_ret > 0 and state is not None:
+        add_trace = getattr(state, "add_trace_entry", None)
+        if callable(add_trace):
+            add_trace(
+                phase="dung",
+                agent="AttackRetentionAccounting",
+                reacts_to=["extract", "counter"],
+                summary=(
+                    f"Cadre {framework_name}: {n_sub} arête(s) soumise(s), "
+                    f"{n_ret} retenue(s) — {n_sub - n_ret} hors inventaire "
+                    f"droppée(s) (#1698)."
+                ),
+            )
+    return output
+
+
 def _adf_conditions_from_context(
     arguments: List[str],
     context: Dict[str, Any],
@@ -4424,7 +4522,17 @@ async def _invoke_setaf(input_text: str, context: Dict[str, Any]) -> Dict[str, A
 
         initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = SetAFHandler(initializer)
-        return await asyncio.to_thread(handler.analyze_setaf, args, attacks, semantics)
+        output = await asyncio.to_thread(
+            handler.analyze_setaf, args, attacks, semantics
+        )
+        # #1698: the handler echoes the INPUT attacks; make the echo honest.
+        return _annotate_attack_retention(
+            output,
+            args,
+            attacks,
+            framework_name=f"setaf_{semantics}",
+            state=context.get("_state_object"),
+        )
     except Exception as e:
         raise RuntimeError(
             f"SetAF analysis unavailable: JVM/Tweety required ({e}). "
@@ -4491,8 +4599,16 @@ async def _invoke_weighted(input_text: str, context: Dict[str, Any]) -> Dict[str
 
         initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = WeightedHandler(initializer)
-        return await asyncio.to_thread(
+        output = await asyncio.to_thread(
             handler.analyze_weighted_framework, args, attacks, semantics
+        )
+        # #1698: the handler echoes the INPUT attacks; make the echo honest.
+        return _annotate_attack_retention(
+            output,
+            args,
+            attacks,
+            framework_name=f"weighted_{semantics}",
+            state=context.get("_state_object"),
         )
     except Exception as e:
         raise RuntimeError(
@@ -4521,8 +4637,16 @@ async def _invoke_social(input_text: str, context: Dict[str, Any]) -> Dict[str, 
 
         initializer = TweetyInitializer()  # type: ignore[no-untyped-call]
         handler = SocialHandler(initializer)
-        return await asyncio.to_thread(
+        output = await asyncio.to_thread(
             handler.analyze_social_framework, args, attacks, votes
+        )
+        # #1698: the handler echoes the INPUT attacks; make the echo honest.
+        return _annotate_attack_retention(
+            output,
+            args,
+            attacks,
+            framework_name="social_af",
+            state=context.get("_state_object"),
         )
     except Exception as e:
         logger.info(f"Social handler unavailable ({e}), using Python fallback")
@@ -7483,10 +7607,10 @@ async def _invoke_dung_extensions(
             "extensions": primary,
             "all_extensions": enriched_extensions,
             "arguments": arguments,
-            "attacks": attacks,
+            # ``attacks`` is set by _annotate_attack_retention below (#1698):
+            # the edges actually in the frame, not the submitted input.
             "statistics": {
                 "arguments_count": len(arguments),
-                "attacks_count": len(attacks),
                 "semantics_computed": len(
                     [v for v in enriched_extensions.values() if "count" in v]
                 ),
@@ -7494,12 +7618,26 @@ async def _invoke_dung_extensions(
         }
         # Trace entry for Dung extensions specialist
         _state = context.get("_state_object")
+        # #1698: make the attack echo honest (retained edges + submitted/
+        # retained/dropped accounting) before the result trace reads it.
+        _annotate_attack_retention(
+            _dung_result,
+            arguments,
+            attacks,
+            framework_name="verification",
+            state=_state,
+        )
         _dung_args = _dung_result.get("arguments")
         if _state is not None and _dung_args:
             _n_args = len(_dung_args)
             _stats = _dung_result.get("statistics")
-            _n_attacks = (
+            _n_retained = (
                 _stats.get("attacks_count", 0) if isinstance(_stats, dict) else 0
+            )
+            _n_submitted = (
+                _stats.get("attacks_submitted", _n_retained)
+                if isinstance(_stats, dict)
+                else _n_retained
             )
             _ext_block = _dung_result.get("extensions")
             _grounded = (
@@ -7510,7 +7648,11 @@ async def _invoke_dung_extensions(
                 phase="dung",
                 agent="DungAnalyzer",
                 reacts_to=["extract", "counter"],
-                summary=f"Cadre Dung: {_n_args} arguments, {_n_attacks} attaques — extension fondée: {_g_size} arguments acceptés. 11 sémantiques calculées.",
+                summary=(
+                    f"Cadre Dung: {_n_args} arguments, {_n_retained}/"
+                    f"{_n_submitted} arêtes retenues — extension fondée: "
+                    f"{_g_size} arguments acceptés. 11 sémantiques calculées."
+                ),
             )
         return _dung_result
     except Exception as e:

--- a/tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py
@@ -1,0 +1,270 @@
+"""Tests for the honest attack-retention accounting (#1698 item 3).
+
+The Dung-family producers (``_invoke_dung_extensions`` / ``_invoke_setaf`` /
+``_invoke_weighted`` / ``_invoke_social``) used to paste the INPUT attacks back
+into their output as if they were the evaluated graph, while every handler
+silently drops any edge with an endpoint outside the inventory
+(``_generate_attacks_from_args`` mints synthetic sources ``fallacy_*`` / ``CA:*``
+that are never members). On the real corpus this means 100% of edges are
+dropped yet the artefact presents K attacks as a result.
+
+``_annotate_attack_retention`` replaces the echo with the edges actually in the
+frame plus a submitted/retained/dropped accounting, so a graph evaluated with
+no edge declares itself. These tests exercise the real accounting functions
+(not literal fixtures — anti-#1019), built around the two states the DoD names:
+sources outside the inventory (⇒ 0 retained) vs sources that are members (⇒ N
+retained). Two states that differ must produce two outputs that differ.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from argumentation_analysis.orchestration.invoke_callables import (
+    _annotate_attack_retention,
+    _retained_attacks,
+)
+
+# ============================================================
+# _retained_attacks — membership logic per handler shape
+# ============================================================
+
+
+class TestRetainedAttacksPairShape:
+    """Dung/Social pair-list shape ``[source, target]``."""
+
+    def test_synthetic_sources_dropped(self) -> None:
+        # The exact shape _generate_attacks_from_args emits (invoke:3204/3221):
+        # sources are synthetic fallacy / counter-arg labels, never members.
+        arguments = ["claim_one", "claim_two"]
+        submitted = [
+            ["fallacy_0_ad_hominem", "claim_one"],
+            ["CA: counter text snippet", "claim_two"],
+        ]
+        assert _retained_attacks(arguments, submitted) == []
+
+    def test_member_sources_kept(self) -> None:
+        arguments = ["a", "b", "c"]
+        submitted = [["c", "a"], ["a", "b"]]
+        assert _retained_attacks(arguments, submitted) == [["c", "a"], ["a", "b"]]
+
+    def test_partial_membership_drops_the_edge(self) -> None:
+        # An attack with one endpoint in, one out, is not in the frame.
+        arguments = ["a", "b"]
+        submitted = [["a", "x_not_in_inventory"]]
+        assert _retained_attacks(arguments, submitted) == []
+
+
+class TestRetainedAttacksWeightedShape:
+    """Weighted triple shape ``(source, target, weight)``."""
+
+    def test_synthetic_source_triple_dropped(self) -> None:
+        arguments = ["arg_a", "arg_b"]
+        submitted = [("fallacy_1_strawman", "arg_a", 0.7), ("CA: x", "arg_b", 0.3)]
+        assert _retained_attacks(arguments, submitted) == []
+
+    def test_member_source_triple_kept_with_weight(self) -> None:
+        arguments = ["a", "b"]
+        submitted = [("b", "a", 0.9)]
+        assert _retained_attacks(arguments, submitted) == [("b", "a", 0.9)]
+
+
+class TestRetainedAttacksSetafShape:
+    """SetAF joint-attack spec ``{"attackers": [...], "target"}``.
+
+    The handler keeps an attack whose target is a member AND at least one
+    attacker is a member (it stores the partial attacker set). This is why
+    SetAF discriminated once on the real corpus (7/8) when its translator
+    path produced genuine member attacks — it must NOT be absorbed into a
+    global "nothing is ever excluded" claim.
+    """
+
+    def test_target_member_one_attacker_member_kept(self) -> None:
+        arguments = ["a", "b", "c"]
+        submitted = [{"attackers": ["b", "fallacy_0_x"], "target": "a"}]
+        # target "a" is a member, attacker "b" is a member (fallacy_0_x is not)
+        assert _retained_attacks(arguments, submitted) == submitted
+
+    def test_all_attackers_synthetic_dropped(self) -> None:
+        arguments = ["a", "b"]
+        submitted = [{"attackers": ["fallacy_0_x", "fallacy_1_y"], "target": "a"}]
+        assert _retained_attacks(arguments, submitted) == []
+
+    def test_target_not_member_dropped(self) -> None:
+        arguments = ["a", "b"]
+        submitted = [{"attackers": ["a"], "target": "x_not_in"}]
+        assert _retained_attacks(arguments, submitted) == []
+
+    def test_setaf_discriminates_when_member_attacker_present(self) -> None:
+        # Reproduces the corpus_B 7/8 signature: a genuine member attacker
+        # excludes the target. Retention is non-empty here.
+        arguments = ["arg1", "arg2", "arg3"]
+        submitted = [{"attackers": ["arg2"], "target": "arg1"}]
+        assert len(_retained_attacks(arguments, submitted)) == 1
+
+
+class TestRetainedAttacksMalformed:
+    def test_unknown_shape_dropped(self) -> None:
+        arguments = ["a"]
+        assert (
+            _retained_attacks(arguments, [{"weird": "shape"}, "bare_string", []]) == []
+        )
+
+
+# ============================================================
+# _annotate_attack_retention — the honest report (DoD)
+# ============================================================
+
+
+class _FakeState:
+    """Captures trace entries so we can assert the drop is declared."""
+
+    def __init__(self) -> None:
+        self.traces: List[Dict[str, Any]] = []
+
+    def add_trace_entry(self, **kwargs: Any) -> None:
+        self.traces.append(kwargs)
+
+
+class TestAnnotateHonestReport:
+    def _pair_output(self, attacks: List[Any]) -> Dict[str, Any]:
+        # The shape a Dung/Social handler returns (echo of the input attacks).
+        return {
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "attacks": attacks,
+            "extensions": [["a", "b"]],
+            "statistics": {"arguments_count": 2, "attacks_count": len(attacks)},
+        }
+
+    def test_synthetic_sources_declare_zero_retained(self) -> None:
+        """DoD: input with sources outside inventory ⇒ output declares 0 retained."""
+        state = _FakeState()
+        output = self._pair_output([["fallacy_0_x", "a"], ["CA: snippet", "b"]])
+        result = _annotate_attack_retention(
+            output,
+            ["a", "b"],
+            output["attacks"],
+            framework_name="verification",
+            state=state,
+        )
+        assert result["attacks"] == []
+        assert result["attacks_submitted"] == 2
+        assert result["attacks_retained"] == 0
+        assert result["attacks_dropped"] == 2
+        # statistics.attacks_count now counts what was EVALUATED (#1698).
+        assert result["statistics"]["attacks_count"] == 0
+        assert result["statistics"]["attacks_submitted"] == 2
+        # The drop is declared in the trace (not silent).
+        assert len(state.traces) == 1
+        assert "2 retenue" not in state.traces[0]["summary"]
+        assert "droppée" in state.traces[0]["summary"]
+
+    def test_member_sources_declare_n_retained(self) -> None:
+        """DoD: input with member sources ⇒ output declares N retained."""
+        state = _FakeState()
+        output = self._pair_output([["b", "a"], ["a", "b"]])
+        result = _annotate_attack_retention(
+            output,
+            ["a", "b"],
+            output["attacks"],
+            framework_name="verification",
+            state=state,
+        )
+        assert result["attacks"] == [["b", "a"], ["a", "b"]]
+        assert result["attacks_retained"] == 2
+        assert result["attacks_dropped"] == 0
+        # No drop ⇒ no drop-declaration trace.
+        assert state.traces == []
+
+    def test_two_states_produce_two_outputs_that_differ(self) -> None:
+        """DoD (anti-#1019): two inputs that differ ⇒ two outputs that differ.
+
+        A "the output is non-empty" assertion would see nothing — both states
+        carry attacks. The discriminating signal is the retained count and the
+        retained edge list.
+        """
+        args_inventory = ["a", "b"]
+        synthetic = _annotate_attack_retention(
+            self._pair_output([["fallacy_0_x", "a"]]),
+            args_inventory,
+            [["fallacy_0_x", "a"]],
+            framework_name="verification",
+        )
+        genuine = _annotate_attack_retention(
+            self._pair_output([["b", "a"]]),
+            args_inventory,
+            [["b", "a"]],
+            framework_name="verification",
+        )
+        assert synthetic["attacks_retained"] != genuine["attacks_retained"]
+        assert synthetic["attacks"] != genuine["attacks"]
+        assert synthetic["attacks_dropped"] == 1
+        assert genuine["attacks_dropped"] == 0
+
+    def test_setaf_partial_attacker_set_is_honest(self) -> None:
+        """SetAF retains an attack with one member attacker even if others are
+        synthetic — the report must preserve this discrimination."""
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "attacks": [{"attackers": ["b", "fallacy_x"], "target": "a"}],
+            "extensions": [["a", "b"]],
+            "statistics": {"arguments_count": 2, "attacks_count": 1},
+        }
+        result = _annotate_attack_retention(
+            output,
+            ["a", "b"],
+            output["attacks"],
+            framework_name="setaf_grounded",
+        )
+        assert result["attacks_retained"] == 1
+        assert result["attacks_dropped"] == 0
+
+    def test_no_state_no_trace_no_crash(self) -> None:
+        output = self._pair_output([["fallacy_0_x", "a"]])
+        # state=None must not crash even when edges are dropped.
+        result = _annotate_attack_retention(
+            output,
+            ["a", "b"],
+            [["fallacy_0_x", "a"]],
+            framework_name="verification",
+            state=None,
+        )
+        assert result["attacks_dropped"] == 1
+
+    def test_empty_submitted_is_honest_zero(self) -> None:
+        output = self._pair_output([])
+        result = _annotate_attack_retention(
+            output,
+            ["a", "b"],
+            [],
+            framework_name="verification",
+        )
+        assert result["attacks"] == []
+        assert result["attacks_submitted"] == 0
+        assert result["attacks_retained"] == 0
+        assert result["attacks_dropped"] == 0
+
+    def test_existing_statistics_preserved_beyond_attacks_count(self) -> None:
+        # annotate must align attacks_count but not clobber sibling stats.
+        output = {
+            "attacks": [["fallacy_0_x", "a"]],
+            "statistics": {
+                "arguments_count": 2,
+                "attacks_count": 1,
+                "semantics_computed": 4,
+                "handler": "AFHandler",
+            },
+        }
+        result = _annotate_attack_retention(
+            output,
+            ["a", "b"],
+            [["fallacy_0_x", "a"]],
+            framework_name="verification",
+        )
+        assert result["statistics"]["semantics_computed"] == 4
+        assert result["statistics"]["handler"] == "AFHandler"
+        assert result["statistics"]["attacks_count"] == 0  # aligned to retained

--- a/tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 import pytest
+from unittest.mock import AsyncMock, patch
 
 from argumentation_analysis.orchestration.invoke_callables import (
     _annotate_attack_retention,
@@ -268,3 +269,193 @@ class TestAnnotateHonestReport:
         assert result["statistics"]["semantics_computed"] == 4
         assert result["statistics"]["handler"] == "AFHandler"
         assert result["statistics"]["attacks_count"] == 0  # aligned to retained
+
+
+# ============================================================
+# #1629 soustraction — translator answered "nothing" ⇒ no fabrication
+# ============================================================
+#
+# Coord ruling (R786, posted on #1629): when a translator arbitrated and
+# returned ``no_genuine_relations``, the synthetic ``_generate_attacks_from_args``
+# fallback must NOT fire. Tested through the real ``_invoke_setaf`` /
+# ``_invoke_weighted`` with the translator outcome + handler stubbed
+# (anti-#1019: real producer path, not a literal). Dung/social have no
+# translator covering naked attacks and stay out of this scope.
+
+
+class TestSoustractionNoGenuineRelations1629:
+    """#1629: ``no_genuine_relations`` (arbiter answered nothing) ⇒ fabricate
+    nothing. ``evaluated`` ⇒ use the genuine relations. ``translator_failed`` /
+    absent ⇒ arbiter did not answer ⇒ synthetic fallback stands (regression)."""
+
+    @staticmethod
+    def _stub_handler_module(attacks_sink: Dict[str, Any]) -> Any:
+        """Build a stub SetAFHandler/WeightedHandler capturing the attacks it
+        received, so we can assert what the invoke layer fed it."""
+
+        class _Stub:
+            def __init__(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+            def analyze_setaf(
+                self, args: Any, attacks: Any, semantics: Any
+            ) -> Dict[str, Any]:
+                attacks_sink["setaf"] = attacks
+                return {
+                    "semantics": semantics,
+                    "arguments": list(args),
+                    "attacks": attacks,
+                    "extensions": [],
+                    "statistics": {
+                        "arguments_count": len(args),
+                        "attacks_count": len(attacks),
+                    },
+                }
+
+            def analyze_weighted_framework(
+                self, args: Any, attacks: Any, semantics: Any
+            ) -> Dict[str, Any]:
+                attacks_sink["weighted"] = attacks
+                return {
+                    "semantics": semantics,
+                    "arguments": list(args),
+                    "attacks": [
+                        {"source": s, "target": t, "weight": w} for s, t, w in attacks
+                    ],
+                    "extensions": [],
+                    "statistics": {
+                        "arguments_count": len(args),
+                        "attacks_count": len(attacks),
+                    },
+                }
+
+        return _Stub
+
+    async def test_setaf_subtracts_when_translator_found_nothing(self) -> None:
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_setaf
+        from argumentation_analysis.orchestration.structured_arg_translator import (
+            CAUSE_NO_GENUINE_RELATIONS,
+            TranslationResult,
+        )
+
+        sink: Dict[str, Any] = {}
+        outcome = TranslationResult(
+            relations=[], cause=CAUSE_NO_GENUINE_RELATIONS, error=""
+        )
+        with patch(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_setaf_attacks",
+            new=AsyncMock(return_value=outcome),
+        ), patch(
+            "argumentation_analysis.agents.core.logic.setaf_handler.SetAFHandler",
+            self._stub_handler_module(sink),
+        ), patch(
+            "argumentation_analysis.agents.core.logic.tweety_initializer."
+            "TweetyInitializer",
+            return_value=None,
+        ):
+            output = await _invoke_setaf("text", {"arguments": ["a", "b"]})
+
+        # Soustraction: the handler received NO fabricated attacks.
+        assert sink["setaf"] == []
+        assert output["attacks"] == []
+        assert output["attacks_submitted"] == 0
+        assert output["attacks_dropped"] == 0  # nothing dropped: nothing fabricated
+
+    async def test_setaf_uses_genuine_when_translator_evaluated(self) -> None:
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_setaf
+        from argumentation_analysis.orchestration.structured_arg_translator import (
+            CAUSE_EVALUATED,
+            TranslationResult,
+        )
+
+        sink: Dict[str, Any] = {}
+        # corpus_B signature: 3 genuine member joint-attacks.
+        genuine = [
+            {"attackers": ["b"], "target": "a"},
+            {"attackers": ["c"], "target": "a"},
+            {"attackers": ["c"], "target": "b"},
+        ]
+        outcome = TranslationResult(relations=genuine, cause=CAUSE_EVALUATED)
+        with patch(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_setaf_attacks",
+            new=AsyncMock(return_value=outcome),
+        ), patch(
+            "argumentation_analysis.agents.core.logic.setaf_handler.SetAFHandler",
+            self._stub_handler_module(sink),
+        ), patch(
+            "argumentation_analysis.agents.core.logic.tweety_initializer."
+            "TweetyInitializer",
+            return_value=None,
+        ):
+            output = await _invoke_setaf("text", {"arguments": ["a", "b", "c"]})
+
+        assert sink["setaf"] == genuine  # genuine relations used as-is
+        assert output["attacks_retained"] == 3  # all members ⇒ all retained
+
+    async def test_setaf_falls_back_when_translator_failed(self) -> None:
+        """Regression: translator_failed = arbiter did NOT answer ⇒ synthetic
+        fallback stands (soustraction does NOT fire on failure)."""
+        from argumentation_analysis.orchestration.invoke_callables import _invoke_setaf
+        from argumentation_analysis.orchestration.structured_arg_translator import (
+            CAUSE_TRANSLATOR_FAILED,
+            TranslationResult,
+        )
+
+        sink: Dict[str, Any] = {}
+        outcome = TranslationResult(
+            relations=[], cause=CAUSE_TRANSLATOR_FAILED, error="RuntimeError"
+        )
+        with patch(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_setaf_attacks",
+            new=AsyncMock(return_value=outcome),
+        ), patch(
+            "argumentation_analysis.orchestration.invoke_callables."
+            "_generate_attacks_from_args",
+            return_value=[["arg1", "arg2"]],  # synthetic, member sources
+        ), patch(
+            "argumentation_analysis.agents.core.logic.setaf_handler.SetAFHandler",
+            self._stub_handler_module(sink),
+        ), patch(
+            "argumentation_analysis.agents.core.logic.tweety_initializer."
+            "TweetyInitializer",
+            return_value=None,
+        ):
+            output = await _invoke_setaf("text", {"arguments": ["arg1", "arg2"]})
+
+        # Fallback fired (NOT subtracted): handler received the synthetic pair.
+        assert len(sink["setaf"]) == 1
+        assert output["attacks_submitted"] == 1
+
+    async def test_weighted_subtracts_when_translator_found_nothing(self) -> None:
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _invoke_weighted,
+        )
+        from argumentation_analysis.orchestration.structured_arg_translator import (
+            CAUSE_NO_GENUINE_RELATIONS,
+            TranslationResult,
+        )
+
+        sink: Dict[str, Any] = {}
+        outcome = TranslationResult(
+            relations=[], cause=CAUSE_NO_GENUINE_RELATIONS, error=""
+        )
+        with patch(
+            "argumentation_analysis.orchestration.structured_arg_translator."
+            "translate_to_weighted_attacks",
+            new=AsyncMock(return_value=outcome),
+        ), patch(
+            "argumentation_analysis.agents.core.logic.weighted_handler."
+            "WeightedHandler",
+            self._stub_handler_module(sink),
+        ), patch(
+            "argumentation_analysis.agents.core.logic.tweety_initializer."
+            "TweetyInitializer",
+            return_value=None,
+        ):
+            output = await _invoke_weighted("text", {"arguments": ["a", "b"]})
+
+        assert sink["weighted"] == []
+        assert output["attacks_submitted"] == 0


### PR DESCRIPTION
## #1698 item 3 — the honest report + #1629 soustraction (NOT the attacker-identity design decision)

This PR carries **two composed gestures** in the same `_invoke_setaf` / `_invoke_weighted` / `_invoke_dung_extensions` / `_invoke_social` blocks (coord R786: one lane, not two concurrent edits of the same block):

1. **#1698 item 3 — honest attack-retention report** (all 4 Dung-family producers).
2. **#1629 ruling (R786) — soustraction**: when a translator arbitrated and returned `no_genuine_relations`, the synthetic fallback must NOT fire (setaf/weighted only; Dung/social out of scope).

The attacker-identity decision (make synthetic sources inventory members) is **gated on a measured rejection** — it is explicitly NOT this PR.

### The defect (VERIFIED R784c + coord's corpus run = 29/11/11 = 100% dropped)

The four Dung-family producers paste the **input** `attacks` back into their output as if they were the evaluated graph. Every handler silently drops any edge with an out-of-inventory endpoint (`_generate_attacks_from_args` mints synthetic sources `fallacy_*` / `CA:*` that are never members). On the real corpus: 100% of edges dropped, yet up to **13 state entries** echo K attacks as a result, while `af_handler` logs the drop only **once**.

### Reader inventory (delivered BEFORE the patch — DoD verdict item)

The echo is at two layers (Dung invoke-layer `invoke_callables.py:7370`; SetAF/Weighted/Social handler-layer `setaf:123`/`weighted:139`/`social:120`). `attacks_count` = `len(input)` at all four.

Three downstream readers consume `dung_frameworks[*]["attacks"]` — all three are fooled by the echo today, and all three **semantically want the evaluated edges**:

| reader | usage | wants |
|---|---|---|
| `pattern_mining:92,95` | `n_attacks = len(attacks)` feature | evaluated |
| `deep_synthesis_agent:1081-1086` | LLM prompt "N attacks, these survive" | evaluated |
| `html_report:552` | graph viz edges | evaluated |

→ **option (a)**: `output["attacks"]` = retained edges makes all three honest **automatically**, zero reader migration. The five state-writers already project `output["attacks"]` (retained has the same shape, just fewer entries — no writer broken). Act III (`act3:982`) reads `aspic_results.attacks`, not dung — out of scope.

### Fix — the common point, not four patches

The retain/drop decision is a **pure membership test** in all four handlers (verified: Dung/Weighted/Social = src∈ ∧ tgt∈; SetAF = tgt∈ ∧ ≥1 attacker∈), so it is faithfully reproducible from the inputs — no second Java build, no handler change. One shared invoke-layer helper, called at the four `_invoke_*` sites:

- **`_retained_attacks(arguments, submitted)`** — shape-aware membership (pair / weighted triple / SetAF `{attackers,target}`).
- **`_annotate_attack_retention(output, ...)`**:
  - `output["attacks"]` ← retained edges (what the reasoner saw)
  - `attacks_submitted` / `attacks_retained` / `attacks_dropped` declared
  - `statistics.attacks_count` aligned to retained (it echoed the input and fed verdicts about an edge-free graph)
  - a single trace entry declares the drop when edges were lost

No handler change. No state-writer change (the 11 `verification_*` entries fan out from one annotated output → all honest). The counts reach consumers: `retained` → the 3 readers; `dropped` → the trace (anti-"counter nobody reads").

### Anti-pendules (all held)

### SetAF insight (explains coord's corpus_B 7/8 anomaly)

`_invoke_setaf` / `_invoke_weighted` try the **structured translator first** → genuine member attacks → discrimination possible (the 7/8). `_invoke_dung` / `_invoke_social` always use `_generate_attacks_from_args` (synthetic) → always 0 retained. So "100% dropped" is specific to the synthetic path. The accounting is shape- and source-agnostic — it reports whatever retention is. The SetAF partial-attacker-set discrimination is **preserved** (test `test_setaf_partial_attacker_set_is_honest`).

### #1629 soustraction — coord ruling R786 (composed with item 3)

Coord measured the translator outcome on the real corpus: SetAF corpus_B = translator **succeeded** (3 genuine member joint-attacks ⇒ 7/8, the one place the attack graph works); corpus_A/C = `no_genuine_relations` (translator ran and found nothing — an **analytical result**, correct on 2/3 corpus) ⇒ today 11 fabricated synthetic edges, all dropped by the handler, echoed as a result.

**Ruling (posted on #1629): soustraction.** When a translator arbitrated and returned `no_genuine_relations`, the synthetic `_generate_attacks_from_args` fallback must NOT fire. The two gestures compose:

- **soustraction** = "an arbiter answered *nothing*" ⇒ fabricate nothing
- **retention annotation** = "edges exist, some fall" ⇒ count honestly

Implementation: 2 sites only (`_invoke_setaf`, `_invoke_weighted`). When `_structured_arg_cause(context, capability) == "no_genuine_relations"`, `attacks = []`. `translator_failed` / `translator_unconfigured` / absent cause = arbiter did **not** answer ⇒ synthetic fallback stands (regression preserved). **Dung/social out of scope** — no translator covers naked Dung attacks; applying soustraction there would declare the axis empty on every corpus, a separate decision.

Tests through the real `_invoke_setaf` / `_invoke_weighted` (translator outcome + handler stubbed, anti-#1019): `no_genuine_relations` ⇒ handler receives `[]` ; `evaluated` ⇒ genuine relations used ; `translator_failed` ⇒ synthetic fallback stands. 4 tests (total file now 21).

### Anti-pendules (all held)

- **No guard moved.** Making synthetic sources inventory members is the attacker-identity design decision, gated on #1629 + a measured rejection. This PR reports current behaviour honestly (item 3) and subtracts fabrication when an arbiter already answered (#1629).
- **No counter nobody reads.** Retained reaches the 3 readers (auto-honest); dropped reaches the trace.
- **No echo removed without the reader inventory.** Done above — the 3 readers all want evaluated edges.
- **No "wire the translator everywhere".** It succeeds 1/6 (existence, not reliability). Soustraction is at the arbitrated site, not a generalization.
- **`no_genuine_relations` is a result, not a bug.** Preserved as a status, not "repaired" (same trap as #1649 where `raw=0` was the model).

### ABA / student-provider — out of stated scope (noted, not fixed)

ABA uses a rules-based model (not attack pairs) — separate cause. The `abs_arg_dung_student` delegation path returns early without annotation — same echo pattern; noted for a follow-up, not expanded here (4-handler scope).

### Test (anti-#1019)

Built from the real accounting functions (not literals). The two DoD states — sources outside the inventory (⇒ 0 retained) vs member sources (⇒ N retained) — produce two outputs that differ, across all three attack shapes. Plus 4 soustraction tests through the real `_invoke_*` path. 21 tests total; mypy strict + black clean; 226 structured-arg/consumer tests pass (no regression).

### DoD

Capacity (closable by test):
- [x] A frame where 100% of edges are dropped produces output that says so, across the 4 handlers, via the common point
- [x] Test by real producers: out-of-inventory sources ⇒ 0 retained; member sources ⇒ N; two states differ ⇒ two outputs differ
- [x] ABA out of scope
- [x] #1629 soustraction: `no_genuine_relations` ⇒ no synthetic fallback (setaf/weighted); `evaluated` ⇒ genuine used; `translator_failed` ⇒ fallback stands

Verdict (closable only by real measurement):
- [x] Reader inventory of `attacks` delivered before the patch (above)
- [ ] Real corpus: retained edges per frame — coord's paired run will now read honest counts (was K everywhere; should be 0 on Dung/Social paths, N where translators succeed)

Privacy HARD: the trace counts edges; it prints no source/target content. Opaque IDs on this PR.

Co-Authored-By: Claude-Code <noreply@anthropic.com>
