### PR TITLE
fix(atms): stop the module from lying about what it does (#1650)

### DIFF
--- a/argumentation_analysis/evaluation/pattern_mining.py
+++ b/argumentation_analysis/evaluation/pattern_mining.py
@@ -131,7 +131,32 @@ class AtmsBranchingDetector:
 
         n = len(contexts)
         assumption_counts = [len(c.get("assumptions", [])) for c in contexts]
-        contradictions = sum(1 for c in contexts if c.get("status") == "contradictory")
+        # #1650: the producer emits ``coherent`` (bool) per context, NOT a
+        # ``status == "contradictory"`` string. The previous reader probed a
+        # phantom key (gotcha #1636/#765) → ``contradictions`` was always 0
+        # → ``contradiction_rate`` read 0.0 on every corpus, masking whether
+        # the ATMS actually found any incoherent hypothesis. Three states,
+        # never the boolean negation ``not c.get("coherent")`` (that would
+        # fabricate a contradiction for every context lacking the key):
+        #   - coherent present and False  → contradiction (incoherent env)
+        #   - coherent present and True   → coherent
+        #   - coherent absent             → unclassifiable (logged, not counted)
+        contradictions = 0
+        unclassified = 0
+        for c in contexts:
+            if "coherent" in c:
+                if c["coherent"] is False:
+                    contradictions += 1
+            else:
+                unclassified += 1
+        if unclassified:
+            _logger.warning(
+                "atms_branching: %d/%d context(s) lack the 'coherent' key — "
+                "contradiction_rate is a lower bound (unclassifiable contexts "
+                "excluded from the count, not assumed contradictory).",
+                unclassified,
+                n,
+            )
 
         return {
             "max_assumption_count": float(max(assumption_counts, default=0)),

--- a/argumentation_analysis/orchestration/workflows.py
+++ b/argumentation_analysis/orchestration/workflows.py
@@ -701,7 +701,7 @@ def build_spectacular_workflow() -> WorkflowDefinition:
         L5  counter                               (from quality)
         L6  jtms | debate                         (from counter)
         L6b belief_revision                       (from jtms + dung)
-        L7  atms                                  (from jtms)
+        L7  atms                                  (from extract + fallacy + quality)
         L8  governance | formal_synthesis         (aggregation)
         L9  synthesis                               (terminal aggregation)
     """
@@ -937,11 +937,17 @@ def build_spectacular_workflow() -> WorkflowDefinition:
             depends_on=["counter"],
             optional=True,
         )
-        # L7 — ATMS multi-context (from JTMS beliefs)
+        # L7 — ATMS multi-context. #1650: the producer (_invoke_atms) reads
+        # extract (arguments/claims), hierarchical_fallacy (detected fallacies)
+        # and quality (per-argument scores) — NOT jtms_beliefs. The previous
+        # depends_on=["jtms"] + "(from JTMS beliefs)" comment declared a data
+        # link the producer never realized. Declared here are the phases the
+        # producer actually consumes context from (anti-pendule: declare the
+        # real inputs rather than zero, so the DAG stays ordered).
         .add_phase(
             "atms",
             capability="atms_reasoning",
-            depends_on=["jtms"],
+            depends_on=["extract", "hierarchical_fallacy", "quality"],
             optional=True,
         )
         # L8 — governance + formal synthesis (terminal aggregation)

--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -134,9 +134,14 @@ def build_narrative(state: Any) -> str:
         )
         incoherent = len(atms_contexts) - coherent
         parts.append(
-            f"L'analyse ATMS multi-contextes a teste {len(atms_contexts)} hypothese(s): "
-            f"{coherent} coherente(s), {incoherent} incoherente(s), "
-            f"illustrant la sensibilite des conclusions aux hypotheses retenues."
+            # #1650: the hypothesis count is the size of a predefined probe
+            # battery (a fixed menu of reading-hypotheses, capped in code), NOT
+            # a measurement of how many readings the text admits. Say so, rather
+            # than implying the count characterizes the corpus.
+            f"L'analyse ATMS a teste une batterie de {len(atms_contexts)} "
+            f"hypothese(s) de lecture predefinie(s): {coherent} coherente(s), "
+            f"{incoherent} incoherente(s). Ce compte reflete la taille de la "
+            f"batterie de sondes, non un denombrement des lectures du texte."
         )
 
     # ── Dung frameworks ────────────────────────────────────────────

--- a/tests/unit/argumentation_analysis/evaluation/test_pattern_mining.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_pattern_mining.py
@@ -282,11 +282,15 @@ class TestAtmsBranchingDetector:
         assert result["contradiction_rate"] == 0.0
 
     def test_with_contexts(self):
+        # #1650: the producer (_invoke_atms) emits ``coherent`` (bool) per
+        # context, not a ``status`` string. The fixture mirrors the real
+        # contract: coherent=True → consistent env, coherent=False →
+        # incoherent (contradictory) env.
         sig = {
             "state": {
                 "atms_contexts": [
-                    {"assumptions": ["a1", "a2"], "status": "consistent"},
-                    {"assumptions": ["a3"], "status": "contradictory"},
+                    {"assumptions": ["a1", "a2"], "coherent": True},
+                    {"assumptions": ["a3"], "coherent": False},
                 ]
             }
         }
@@ -294,6 +298,62 @@ class TestAtmsBranchingDetector:
         assert result["max_assumption_count"] == 2.0
         assert result["avg_assumptions"] == 1.5
         assert result["contradiction_rate"] == 0.5
+
+    def test_all_coherent_true_yields_zero_rate(self):
+        sig = {
+            "state": {
+                "atms_contexts": [
+                    {"assumptions": ["a1"], "coherent": True},
+                    {"assumptions": ["a2"], "coherent": True},
+                ]
+            }
+        }
+        result = AtmsBranchingDetector().detect(sig)
+        assert result["contradiction_rate"] == 0.0
+
+    def test_absent_coherent_key_not_fabricated_as_contradiction(self, caplog):
+        """#1650: a context lacking the ``coherent`` key is unclassifiable —
+        it must NOT be counted as a contradiction via boolean negation
+        (``not c.get('coherent')`` would fabricate a false-positive for
+        every absent-key context). The rate stays a lower bound and the
+        data-shape drift is logged."""
+        import logging
+
+        sig = {
+            "state": {
+                "atms_contexts": [
+                    {"assumptions": ["a1"]},  # no 'coherent' key
+                    {"assumptions": ["a2"]},  # no 'coherent' key
+                ]
+            }
+        }
+        with caplog.at_level(logging.WARNING, logger="argumentation_analysis.evaluation.pattern_mining"):
+            result = AtmsBranchingDetector().detect(sig)
+        # Neither counted as contradiction → rate 0.0, NOT 1.0.
+        assert result["contradiction_rate"] == 0.0
+        # The drift is surfaced, not silent.
+        assert any(
+            "lack the 'coherent' key" in rec.message for rec in caplog.records
+        )
+
+    def test_mixed_present_and_absent_keys(self, caplog):
+        """A present coherent=False counts; an absent key does not inflate
+        the count (anti-fabrication on a mixed population)."""
+        import logging
+
+        sig = {
+            "state": {
+                "atms_contexts": [
+                    {"assumptions": ["a1"], "coherent": False},
+                    {"assumptions": ["a2"]},  # absent → unclassifiable
+                    {"assumptions": ["a3"], "coherent": True},
+                ]
+            }
+        }
+        with caplog.at_level(logging.WARNING, logger="argumentation_analysis.evaluation.pattern_mining"):
+            result = AtmsBranchingDetector().detect(sig)
+        # 1 real contradiction out of 3 → 0.3333, the absent one not counted.
+        assert result["contradiction_rate"] == round(1 / 3, 4)
 
 
 class TestJtmsRetractionRateDetector:

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
@@ -415,10 +415,26 @@ class TestSpectacularWorkflowGolden:
         counter = wf.get_phase("counter")
         assert "quality" in counter.depends_on
 
-    def test_atms_depends_on_jtms(self):
+    def test_atms_declares_the_inputs_its_producer_reads(self):
+        # #1650: this golden used to assert ``"jtms" in atms.depends_on``. The
+        # producer ``_invoke_atms`` never reads ``jtms_beliefs`` — it builds the
+        # ATMS from extract (arguments/claims), hierarchical_fallacy (detected
+        # fallacies) and quality (per-argument scores). The golden pinned a
+        # declaration nothing realized, so it defended the lie rather than the
+        # behaviour. It now asserts the real inputs AND the absence of the
+        # phantom link, so re-introducing the false dependency goes red.
         wf = build_spectacular_workflow()
         atms = wf.get_phase("atms")
-        assert "jtms" in atms.depends_on
+        assert "jtms" not in atms.depends_on
+        assert {"extract", "hierarchical_fallacy", "quality"}.issubset(
+            set(atms.depends_on)
+        )
+        # The DAG must still order atms strictly after every input it declares.
+        levels = wf.get_execution_order()
+        atms_level = next(i for i, lv in enumerate(levels) if "atms" in lv)
+        for dep in ("extract", "hierarchical_fallacy", "quality"):
+            dep_level = next(i for i, lv in enumerate(levels) if dep in lv)
+            assert dep_level < atms_level
 
     def test_formal_synthesis_aggregates_three_logic_families(self):
         # #1115: formal_synthesis is no longer terminal (deep_synthesis is the

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_workflow_dag.py
@@ -137,10 +137,36 @@ class TestSpectacularWorkflowDAG:
         assert "hierarchical_fallacy" in phase.depends_on
         assert "pl" in phase.depends_on
 
-    def test_atms_depends_on_jtms(self):
+    def test_atms_depends_on_real_inputs_not_jtms(self):
+        """#1650: the ATMS producer (_invoke_atms) reads extract (arguments/
+        claims), hierarchical_fallacy (detected fallacies) and quality
+        (per-argument scores). It does NOT read jtms_beliefs. The previous
+        depends_on=['jtms'] + '(from JTMS beliefs)' comment declared a data
+        link the producer never realized. This is the DAG-side honesty fix:
+        declare the phases the producer actually consumes, drop the false jtms
+        link. The maximal-enumeration contribution is out of scope here
+        (does not ship); this only stops the phase declaration from lying."""
         wf = build_spectacular_workflow()
         phase = wf.get_phase("atms")
-        assert "jtms" in phase.depends_on
+        # The false link is gone.
+        assert "jtms" not in phase.depends_on
+        # The real inputs (the context keys _invoke_atms reads) are declared.
+        assert "extract" in phase.depends_on
+        assert "hierarchical_fallacy" in phase.depends_on
+        assert "quality" in phase.depends_on
+        # And the producer runs strictly after all its real inputs.
+        levels = wf.get_execution_order()
+        atms_level = next(
+            i for i, lvl in enumerate(levels) if "atms" in lvl
+        )
+        for upstream in ("extract", "hierarchical_fallacy", "quality"):
+            up_level = next(
+                i for i, lvl in enumerate(levels) if upstream in lvl
+            )
+            assert up_level < atms_level, (
+                f"atms (level {atms_level}) must run after '{upstream}' "
+                f"(level {up_level})"
+            )
 
     def test_formal_synthesis_aggregates(self):
         wf = build_spectacular_workflow()

--- a/tests/unit/argumentation_analysis/test_narrative_synthesis.py
+++ b/tests/unit/argumentation_analysis/test_narrative_synthesis.py
@@ -99,6 +99,21 @@ class TestBuildNarrative:
         result = build_narrative(state)
         assert "atms" in result.lower() or "hypothese" in result.lower()
 
+    def test_atms_phrase_declares_predefined_battery_not_text_measurement(self):
+        """#1650: the ATMS hypothesis count is the size of a predefined probe
+        battery (a fixed menu in code), not a measurement of how many readings
+        the text admits. The prose must say so, and must NOT carry the old
+        implication that the count characterizes the corpus."""
+        state = _rich_state()
+        result = build_narrative(state)
+        lowered = result.lower()
+        # Declares a predefined battery.
+        assert "batterie" in lowered
+        # Explicitly disclaims counting the text's readings.
+        assert "denombrement" in lowered or "non un denombrement" in lowered
+        # The old misleading phrase is gone.
+        assert "sensibilite des conclusions" not in lowered
+
     def test_references_counter_arguments(self):
         state = _rich_state()
         result = build_narrative(state)


### PR DESCRIPTION
## Context

Dispatch #1650 (coord msg-q4xs5l). Follows the R787 forensic (8 defects, read-only). This PR implements the **3 honesty gestures** the coordinator scoped: zero new algorithm — the module ceases to claim what it does not do, without yet pretending to do more.

> « Que le module cesse de mentir sur ce qu'il fait, sans prétendre encore le faire. »

Order per dispatch: justifications réelles → énumération → lecteurs. **L'énumération does NOT ship** (out of scope here). This PR is gestures on the declaration, the reader, and the prose only.

## Gesture 1 — workflow declaration stops claiming a JTMS link

`workflows.py` L7 atms phase declared `depends_on=['jtms']` + comment `# L7 — ATMS multi-context (from JTMS beliefs)` + docstring `L7 atms (from jtms)`.

The producer `_invoke_atms` never reads `jtms_beliefs`. It builds the ATMS from scratch from `extract` (arguments/claims), `hierarchical_fallacy` (detected fallacies) and `quality` (per-argument scores). The declared data link was never realized — the workflow declaration is not proof of wiring (lesson [feedback-attack-source-node-membership] family).

**Fix:** declare the phases the producer actually consumes (`extract`, `hierarchical_fallacy`, `quality`); drop the false jtms link. Anti-pendule (per dispatch): declare the real inputs rather than zero so the DAG stays ordered.

## Gesture 2 — pattern_mining reader stops reading a phantom key

`AtmsBranchingDetector` (pattern_mining.py:134) probed `c.get('status') == 'contradictory'`. The producer emits `c['coherent']` (bool), not `c['status']`. Phantom key → `contradictions = 0` always → `contradiction_rate = 0.0` on every corpus (gotcha #1636/#765 — a `.get` on a missing key fabricates a zero).

**Fix:** three states on the real key, never the boolean negation `not c.get('coherent')` (that would fabricate a contradiction for every absent-key context):
- `coherent` present and `False` → contradiction (incoherent env)
- `coherent` present and `True` → coherent
- `coherent` **absent** → unclassifiable → logged as a lower bound, NOT counted

## Gesture 3 — narrative prose stops implying the count measures the text

The ATMS phrase (narrative_synthesis_plugin.py:137-139) said: *« L'analyse ATMS … a testé N hypothèse(s) … illustrant la sensibilité des conclusions aux hypothèses retenues. »* — implying N is a property of the text. N is the size of a predefined probe battery (a fixed menu in code, `_generate_hypotheses`, 6-block capped `[:4]`), not a measurement of how many readings the text admits.

**Fix:** the phrase now declares a predefined battery and disclaims counting the text's readings. Subtraction of the implicit claim, not addition of prose.

## Out of scope (does NOT ship)

The singular contribution — native enumeration of maximal coherent readings (the ATMS engine has `get_environments`/`is_consistent`/`invalidate_environment` but no maximal-enumeration method; the producer substitutes a 6-block menu). Per dispatch anti-pendule: do not « improve » the hypotheses in passing (no 7th block, no cap varying with corpus size). That is a separate decision.

## Verdict item — deferred to coord lane

`contradiction_rate` on a real corpus stays a coord-lane verdict (needs API key; capacity ≠ result). Prediction: with the reader now reading the real key, the rate is finally *readable* — on the empty object it will read what the producer actually emits (likely 0 because the menu hypotheses are constructed to be mostly coherent, but that is a measurement now, not a phantom).

## Tests

- `test_atms_depends_on_real_inputs_not_jtms` — DAG: jtms link gone; real inputs declared; atms runs strictly after extract/hierarchical_fallacy/quality.
- `test_atms_branching` 3-state — absent `coherent` key not fabricated as contradiction (rate stays 0.0, not 1.0); drift logged; mixed population counted correctly.
- `test_atms_phrase_declares_predefined_battery_not_text_measurement` — prose contains `batterie` + `dénombrement` disclaimer; old `sensibilité des conclusions` phrase gone.

mypy strict clean on `workflows.py` (CI-scope file). 16+30+16 tests pass. 4 pre-existing failures in `test_track_xx_extraction_variance.py::TestGetDeterminismParams` (`_get_determinism_params`, gpt-4o/LLM_SEED) are orthogonal — `invoke_callables.py` is untouched by this PR.

REVIEW_REQUIRED — coord `--admin` merge (shared write account, no self-approve).

Co-Authored-By: Claude-Code <noreply@anthropic.com>