### PR TITLE
feat(translator): rendre lisible l'absence de relations structurees sur les 5 axes (#1706)

### DIFF
--- a/argumentation_analysis/orchestration/structured_arg_translator.py
+++ b/argumentation_analysis/orchestration/structured_arg_translator.py
@@ -92,6 +92,55 @@ class TranslationResult:
 _MAX_INVENTORY = 20
 
 
+def _raw_count(data: object, key: str) -> int:
+    """Count the items the LLM proposed under ``key``, tolerating any payload.
+
+    Must be at least as tolerant as the ``_validate_*`` helpers (which return
+    ``[]``/``{}`` on any non-list payload): a malformed LLM response (int/dict
+    where a list is expected) must never raise here — ``len(non-sized)`` would
+    crash the whole translation for the sake of a diagnostic.
+    """
+    if not isinstance(data, dict):
+        return 0
+    raw = data.get(key)
+    return len(raw) if isinstance(raw, list) else 0
+
+
+def _log_translation_yield(
+    axis: str, data: object, raw_keys: Tuple[str, ...], kept: int
+) -> None:
+    """Record raw / kept / dropped for one translator call — UNCONDITIONALLY.
+
+    ``CAUSE_NO_GENUINE_RELATIONS`` conflates two disjoint facts about a run:
+    the model proposed **nothing**, or it proposed items that were **all
+    dropped** at validation (unknown/fabricated ids → bare ``continue``). The
+    cause is documented as a statement about the *source* (``state_writers``
+    l.190) and fires identically in both cases, so downstream nobody can tell
+    a silent model from a silent validator.
+
+    #1649 answered exactly that question on the ASPIC axis, and only because an
+    **unconditional** line carried the counts: an absence proves nothing when
+    the only instrument is conditional on presence. This generalises that
+    instrument to every axis. Emitting on every call (including the ``raw=0,
+    kept=0`` case) is the whole point — a line that only prints when there is
+    something to report cannot distinguish "nothing happened" from "the
+    instrument was not reached".
+
+    Diagnostic only: never changes what the translator returns.
+    """
+    raw = sum(_raw_count(data, k) for k in raw_keys)
+    logger.info(
+        "%s translator yield (#1706): raw=%d kept=%d dropped=%d [keys: %s]. "
+        "raw=0 ⇒ the model proposed none; raw>0 & kept=0 ⇒ every proposal was "
+        "dropped at validation. Both report no_genuine_relations.",
+        axis,
+        raw,
+        kept,
+        raw - kept,
+        "/".join(raw_keys),
+    )
+
+
 def _build_inventory(
     arguments: List[str],
 ) -> Tuple[Dict[str, str], List[Dict[str, str]]]:
@@ -644,6 +693,7 @@ async def translate_to_bipolar_supports(
             relations=[], cause=CAUSE_TRANSLATOR_FAILED, error=type(e).__name__
         )
     supports = _validate_supports(data, arg_by_id)
+    _log_translation_yield("Bipolar", data, ("supports",), len(supports))
     if supports:
         logger.info(
             "Bipolar translator: derived %d genuine support relation(s) from text.",
@@ -679,6 +729,7 @@ async def translate_to_aba_contraries(
             relations={}, cause=CAUSE_TRANSLATOR_FAILED, error=type(e).__name__
         )
     contraries = _validate_contraries(data, arg_by_id)
+    _log_translation_yield("ABA", data, ("contraries",), len(contraries))
     if contraries:
         logger.info(
             "ABA translator: derived %d genuine contrary pair(s) from text.",
@@ -751,17 +802,8 @@ async def translate_to_aspic_rules(
     #     plumbing).
     # Surfaced as a warning so it is visible even when base rules make
     # ``relations`` non-empty and the info log below hides the drop. The count
-    # must be at least as tolerant as ``_validate_aspic_*`` (which returns ``[]``
-    # on any non-list payload): a malformed LLM payload (int/dict where a list
-    # is expected) must not raise here — ``len(non-sized)`` would crash the
-    # whole translation. Guard on ``isinstance(raw, list)`` exactly as the
-    # validators do.
-    def _raw_count(_data: object, _key: str) -> int:
-        if not isinstance(_data, dict):
-            return 0
-        _raw = _data.get(_key)
-        return len(_raw) if isinstance(_raw, list) else 0
-
+    # tolerates any payload shape — see :func:`_raw_count` (hoisted to module
+    # level in #1706 so every axis gets the same instrument).
     _raw_contradictions = _raw_count(data, "contradictions")
     _raw_undercuts = _raw_count(data, "undercuts")
     if _raw_contradictions or _raw_undercuts:
@@ -779,6 +821,13 @@ async def translate_to_aspic_rules(
             _raw_undercuts - len(undercuts),
         )
     relations = rules + contradictions + undercuts
+    # The ASPIC info log below is conditional on ``relations`` being non-empty:
+    # its coverage on the #1649 runs was accidental (base rules happened to be
+    # non-empty). The unconditional line is the one that makes an absence
+    # readable.
+    _log_translation_yield(
+        "ASPIC+", data, ("rules", "contradictions", "undercuts"), len(relations)
+    )
     if relations:
         logger.info(
             "ASPIC+ translator: derived %d rule(s) (%d base, %d contradiction(s), "
@@ -820,6 +869,7 @@ async def translate_to_setaf_attacks(
             relations=[], cause=CAUSE_TRANSLATOR_FAILED, error=type(e).__name__
         )
     attacks = _validate_setaf_attacks(data, arg_by_id)
+    _log_translation_yield("SetAF", data, ("attacks",), len(attacks))
     if attacks:
         logger.info(
             "SetAF translator: derived %d genuine joint attack(s) from text.",
@@ -857,6 +907,7 @@ async def translate_to_weighted_attacks(
             relations=[], cause=CAUSE_TRANSLATOR_FAILED, error=type(e).__name__
         )
     attacks = _validate_weighted_attacks(data, arg_by_id)
+    _log_translation_yield("Weighted", data, ("attacks",), len(attacks))
     if attacks:
         logger.info(
             "Weighted translator: derived %d genuine weighted attack(s) from text.",

--- a/tests/unit/argumentation_analysis/orchestration/test_translator_yield_diagnostics_1706.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_translator_yield_diagnostics_1706.py
@@ -1,0 +1,223 @@
+"""#1706 — every structured-arg translator must report raw / kept / dropped.
+
+``CAUSE_NO_GENUINE_RELATIONS`` is documented as a statement about the *source*
+("the text has no structured relations", ``state_writers`` l.190). It is
+returned identically in two disjoint situations:
+
+  1. the model proposed **nothing** (``raw = 0``);
+  2. the model proposed items and **every one was dropped** at validation
+     (unknown / fabricated ids → bare ``continue`` in ``_validate_*``).
+
+The two have opposite consequences — (1) is a prompt/model question, (2) is a
+plumbing question — and until #1706 only the ASPIC axis could tell them apart
+(#1649's counter). On the other four axes an absence carried no information,
+which is how a coordinator read "the arbiter almost never speaks" out of a
+silence nothing was measuring.
+
+These tests pin the instrument, not the wording: for each axis the two
+situations must yield the **same cause** (that ambiguity is real and stays) and
+**different diagnostics** (that ambiguity must be resolvable from a run's log).
+
+No JVM, no real LLM. Synthetic atoms only (privacy HARD — no corpus tokens).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from argumentation_analysis.orchestration.structured_arg_translator import (
+    CAUSE_NO_GENUINE_RELATIONS,
+    _raw_count,
+    translate_to_aba_contraries,
+    translate_to_aspic_rules,
+    translate_to_bipolar_supports,
+    translate_to_setaf_attacks,
+    translate_to_weighted_attacks,
+)
+
+_INVENTORY = ["alpha claim", "beta claim"]  # → ids arg1, arg2
+_UNKNOWN = "arg99"  # never in the inventory → every item is dropped
+
+# axis label, translate fn, payload key, one fabricated item, one genuine item
+_AXES: List[Tuple[str, Any, str, Dict[str, Any], Dict[str, Any]]] = [
+    (
+        "Bipolar",
+        translate_to_bipolar_supports,
+        "supports",
+        {"source": _UNKNOWN, "target": "arg1"},
+        {"source": "arg1", "target": "arg2"},
+    ),
+    (
+        "ABA",
+        translate_to_aba_contraries,
+        "contraries",
+        {"assumption": _UNKNOWN, "contrary": "not alpha"},
+        {"assumption": "arg1", "contrary": "not alpha"},
+    ),
+    (
+        "ASPIC+",
+        translate_to_aspic_rules,
+        "rules",
+        {"premises": [_UNKNOWN], "conclusion": _UNKNOWN},
+        {"premises": ["arg1"], "conclusion": "arg2"},
+    ),
+    (
+        "SetAF",
+        translate_to_setaf_attacks,
+        "attacks",
+        {"attackers": [_UNKNOWN], "target": "arg1"},
+        {"attackers": ["arg1"], "target": "arg2"},
+    ),
+    (
+        "Weighted",
+        translate_to_weighted_attacks,
+        "attacks",
+        {"source": _UNKNOWN, "target": "arg1", "weight": 0.8},
+        {"source": "arg1", "target": "arg2", "weight": 0.8},
+    ),
+]
+
+
+class _Collector(logging.Handler):
+    """Collect formatted records straight off the module logger.
+
+    Deliberately not ``caplog``: the project's logging setup reconfigures the
+    root handlers, and a diagnostic that only shows up under a particular
+    global config is not the instrument we want to certify.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.lines: List[str] = []
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.lines.append(record.getMessage())
+
+
+@pytest.fixture
+def yield_lines():
+    """Capture the ``yield (#1706)`` lines emitted during the test."""
+    log = logging.getLogger("UnifiedPipeline")
+    handler = _Collector()
+    previous = log.level
+    log.addHandler(handler)
+    log.setLevel(logging.INFO)
+    try:
+        yield handler.lines
+    finally:
+        log.removeHandler(handler)
+        log.setLevel(previous)
+
+
+def _patch_llm(monkeypatch, payload: Dict[str, Any]) -> None:
+    async def _fake(input_text: str, arguments: List[str], relation_kind: str):
+        return payload
+
+    monkeypatch.setattr(
+        "argumentation_analysis.orchestration.structured_arg_translator."
+        "_llm_extract_relations",
+        _fake,
+    )
+
+
+def _yield_counts(lines: List[str]) -> Tuple[int, int, int]:
+    """Extract ``(raw, kept, dropped)`` from the single yield line emitted."""
+    hits = [ln for ln in lines if "yield (#1706)" in ln]
+    assert len(hits) == 1, f"expected exactly one yield line, got {len(hits)}: {hits}"
+    m = re.search(r"raw=(\d+) kept=(\d+) dropped=(-?\d+)", hits[0])
+    assert m, f"yield line does not carry parsable counts: {hits[0]!r}"
+    return int(m.group(1)), int(m.group(2)), int(m.group(3))
+
+
+@pytest.mark.parametrize(
+    "axis,fn,key,fabricated,genuine",
+    _AXES,
+    ids=[a[0] for a in _AXES],
+)
+class TestYieldIsReportedOnEveryAxis:
+    async def test_model_silent_reports_raw_zero(
+        self, axis, fn, key, fabricated, genuine, monkeypatch, yield_lines
+    ):
+        """Situation 1: the model proposed nothing."""
+        _patch_llm(monkeypatch, {key: []})
+        result = await fn("text", _INVENTORY)
+        assert result.cause == CAUSE_NO_GENUINE_RELATIONS
+        assert _yield_counts(yield_lines) == (0, 0, 0)
+
+    async def test_all_dropped_reports_raw_nonzero(
+        self, axis, fn, key, fabricated, genuine, monkeypatch, yield_lines
+    ):
+        """Situation 2: the model proposed items, validation dropped them all.
+
+        This is the case an un-instrumented axis could not distinguish from
+        situation 1 — the arming input, not a restatement of the guard.
+        """
+        _patch_llm(monkeypatch, {key: [fabricated, fabricated]})
+        result = await fn("text", _INVENTORY)
+        assert result.cause == CAUSE_NO_GENUINE_RELATIONS  # same cause as above
+        assert _yield_counts(yield_lines) == (2, 0, 2)
+
+    async def test_kept_items_are_counted(
+        self, axis, fn, key, fabricated, genuine, monkeypatch, yield_lines
+    ):
+        """A surviving item is reported as kept, not dropped — no free pass."""
+        _patch_llm(monkeypatch, {key: [genuine, fabricated]})
+        result = await fn("text", _INVENTORY)
+        assert result.relations, f"{axis}: genuine item should have survived"
+        assert _yield_counts(yield_lines) == (2, 1, 1)
+
+    async def test_malformed_payload_does_not_raise(
+        self, axis, fn, key, fabricated, genuine, monkeypatch, yield_lines
+    ):
+        """A diagnostic must never be the thing that kills a run.
+
+        ``len()`` on a non-list payload would crash the translation for the
+        sake of a counter.
+        """
+        _patch_llm(monkeypatch, {key: {"not": "a list"}})
+        result = await fn("text", _INVENTORY)
+        assert result.cause == CAUSE_NO_GENUINE_RELATIONS
+        assert _yield_counts(yield_lines) == (0, 0, 0)
+
+
+class TestYieldResolvesTheAmbiguity:
+    """The point of the instrument, stated as one assertion per half."""
+
+    @pytest.mark.parametrize(
+        "axis,fn,key,fabricated,genuine", _AXES, ids=[a[0] for a in _AXES]
+    )
+    async def test_same_cause_different_diagnostic(
+        self, axis, fn, key, fabricated, genuine, monkeypatch, yield_lines
+    ):
+        _patch_llm(monkeypatch, {key: []})
+        silent = await fn("text", _INVENTORY)
+        silent_line = [ln for ln in yield_lines if "yield (#1706)" in ln][0]
+
+        yield_lines.clear()
+        _patch_llm(monkeypatch, {key: [fabricated]})
+        dropped = await fn("text", _INVENTORY)
+        dropped_line = [ln for ln in yield_lines if "yield (#1706)" in ln][0]
+
+        # The ambiguity is real: the API cannot tell these apart …
+        assert silent.cause == dropped.cause == CAUSE_NO_GENUINE_RELATIONS
+        assert not silent.relations and not dropped.relations
+        # … and the log now can.
+        assert silent_line != dropped_line
+
+
+class TestRawCountTolerance:
+    """``_raw_count`` must be at least as tolerant as the validators it mirrors."""
+
+    @pytest.mark.parametrize(
+        "payload",
+        [None, [], "string", 42, {"k": None}, {"k": 7}, {"k": {"nested": 1}}],
+    )
+    def test_never_raises_on_any_payload(self, payload):
+        assert _raw_count(payload, "k") == 0
+
+    def test_counts_a_list(self):
+        assert _raw_count({"k": [1, 2, 3]}, "k") == 3


### PR DESCRIPTION
Closes la moitie **capacite** de #1706. La moitie **verdict** reste ouverte (mesure sur corpus reel, lane coordinateur).

## Le defaut

`no_genuine_relations` est documentee (`state_writers.py:190`) comme une affirmation **sur la source** — « le texte ne porte pas de relation structuree ». Elle est rendue a l'identique dans deux situations disjointes :

1. le modele n'a **rien propose** (`raw = 0`) — question de prompt/modele ;
2. le modele a propose et **tout a ete droppe** a la validation (ids inconnus → `continue` nu) — question de plomberie.

Seul l'axe ASPIC les departage, depuis #1700. Les quatre autres (bipolar, ABA, SetAF, pondere) rejettent en silence, ne journalisent rien, ne comptent jamais `raw`.

Un instrument conditionne a la presence ne peut pas rendre une absence lisible. Le verdict #1649 le disait deja : « le second n'est lisible **que** parce que le premier est inconditionnel ». Et la couverture inconditionnelle d'ASPIC etait accidentelle — sa ligne `derived N rule(s)` est elle aussi dans `if relations:`.

## Le diff

- `_raw_count` hisse au niveau module (il etait niche dans `translate_to_aspic_rules`), tolerant a toute forme de payload — un diagnostic ne doit jamais tuer un run.
- `_log_translation_yield(axis, data, raw_keys, kept)` : une ligne **inconditionnelle** par appel, sur les 5 axes.
- **Aucun changement de comportement** : valeur retournee, cause et validation inchangees. L'avertissement fin d'ASPIC (contradictions vs undercuts) est conserve.

## Controle

**Substitution** — instrument neutralise par un `return` en tete de fonction : **25 rouges / 8 verts**. Les 8 survivants sont les tests de tolerance de `_raw_count`, qui ne dependent pas de la ligne. Les tests ne peuvent pas passer sans l'instrument.

Le test pique la **relation** : par axe, les deux situations doivent rendre **la meme cause** (l'ambiguite est reelle et reste) et **un diagnostic different** (elle doit etre resoluble depuis un log). Le cas armant `raw>0, kept=0` est construit explicitement.

```
108 passed  (nouveau fichier + suite translator preexistante)
black --check  OK  ·  flake8  OK
```

## Privacy

Atomes synthetiques uniquement dans les tests. La ligne de log ne porte que des **comptes** et le nom de l'axe — jamais un identifiant ni un fragment de source.

## Anti-pendules

- Ne **pas** relacher les validateurs pour faire monter `kept` : si la mesure donne `raw>0, kept=0`, il faut comprendre pourquoi les ids sont hors inventaire, pas accepter des ids fabriques (#1019).
- Ne **pas** ecrire `raw/kept/dropped` dans l'etat : ce reste un diagnostic de log, pas un champ de plus a lire, scrubber et faire mentir.

🤖 Coordinator ai-01 — R788