### PR TITLE
fix(atms): three-state coherent counts in narrative prose (#1650 item 1)

### DIFF
--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -129,10 +129,23 @@ def build_narrative(state: Any) -> str:
     # ── ATMS multi-context ─────────────────────────────────────────
     atms_contexts = getattr(state, "atms_contexts", [])
     if atms_contexts:
-        coherent = sum(
-            1 for c in atms_contexts if isinstance(c, dict) and c.get("coherent")
-        )
-        incoherent = len(atms_contexts) - coherent
+        # #1650 (item 1): three states on the ``coherent`` field, mirroring
+        # pattern_mining — never ``len - coherent`` (that two-state arithmetic
+        # folds absent keys onto ``False``, diluting unclassifiable contexts
+        # into the incoherent count). True => coherent, False => incoherent,
+        # absent (or non-bool) => unclassifiable.
+        coherent = 0
+        incoherent = 0
+        unclassified = 0
+        for c in atms_contexts:
+            if not isinstance(c, dict):
+                continue
+            if c.get("coherent") is True:
+                coherent += 1
+            elif c.get("coherent") is False:
+                incoherent += 1
+            else:
+                unclassified += 1
         parts.append(
             # #1650: the hypothesis count is the size of a predefined probe
             # battery (a fixed menu of reading-hypotheses, capped in code), NOT
@@ -140,8 +153,15 @@ def build_narrative(state: Any) -> str:
             # than implying the count characterizes the corpus.
             f"L'analyse ATMS a teste une batterie de {len(atms_contexts)} "
             f"hypothese(s) de lecture predefinie(s): {coherent} coherente(s), "
-            f"{incoherent} incoherente(s). Ce compte reflete la taille de la "
-            f"batterie de sondes, non un denombrement des lectures du texte."
+            f"{incoherent} incoherente(s)."
+            + (
+                f" {unclassified} non classifiable(s) "
+                f"(cle 'coherent' absente)."
+                if unclassified
+                else ""
+            )
+            + " Ce compte reflete la taille de la batterie de sondes, non un"
+            f" denombrement des lectures du texte."
         )
 
     # ── Dung frameworks ────────────────────────────────────────────

--- a/tests/unit/argumentation_analysis/test_narrative_synthesis.py
+++ b/tests/unit/argumentation_analysis/test_narrative_synthesis.py
@@ -114,6 +114,30 @@ class TestBuildNarrative:
         # The old misleading phrase is gone.
         assert "sensibilite des conclusions" not in lowered
 
+    def test_atms_counts_absent_key_separately_three_states(self):
+        """#1650 item 1: the ATMS counts must be three-state on ``coherent``,
+        never the two-state ``len - coherent`` arithmetic (which folds an
+        absent key onto ``False`` and dilutes unclassifiable contexts into the
+        incoherent count). With a mixed population [True, False, absent]:
+          - three-state -> 1 coherent, 1 incoherent, 1 non-classifiable
+          - ``len - coherent`` -> 1 coherent, 2 incoherent, no mention
+        This test arms the distinction: it goes red if the arithmetic ever
+        reverts to two states (substitution control per DoD)."""
+        state = UnifiedAnalysisState("discourse")
+        state.atms_contexts = [
+            {"hypothesis_id": "h_a", "coherent": True},
+            {"hypothesis_id": "h_b", "coherent": False},
+            {"hypothesis_id": "h_c"},  # absent key — the arming input
+        ]
+        result = build_narrative(state)
+        # Three-state counts.
+        assert "1 coherente" in result
+        assert "1 incoherente" in result
+        # The absent key is surfaced as non-classifiable, NOT folded into
+        # incoherent (which would read "2 incoherente").
+        assert "2 incoherente" not in result
+        assert "non classifiable" in result
+
     def test_references_counter_arguments(self):
         state = _rich_state()
         result = build_narrative(state)


### PR DESCRIPTION
Dispatch R788 item 1. PR #1705 merged the three honesty gestures but the squash (`d66dc603`) took the branch at `e50ea350` — just before this item was pushed. This PR rebases item 1 onto `d66dc603`. No work lost; the cherry-pick applied cleanly (the base gesture-3 phrase is unchanged, only the arithmetic underneath moves).

## The defect

`narrative_synthesis_plugin.py` kept the two-state arithmetic:

```python
coherent = sum(1 for c in atms_contexts if isinstance(c, dict) and c.get("coherent"))
incoherent = len(atms_contexts) - coherent
```

This is the **exact two-state the gesture-2 fix corrected in `pattern_mining`**, on the same `coherent` field, one file over. Gesture 3 rewrote the prose *built on this count* without touching the arithmetic underneath — so the phrase was honest about where the count comes from while the count itself stayed wrong: an absent `coherent` key folded onto `False`, diluting unclassifiable contexts into the incoherent tally.

## The fix

Three states, mirroring `pattern_mining`:
- `coherent is True` → coherent
- `coherent is False` → incoherent
- `coherent` absent (or non-bool) → unclassifiable

When unclassifiable contexts exist, the phrase says so rather than diluting them. The phrase formulation is untouched (settled in R787) — **only the arithmetic moves** (anti-pendule per dispatch).

## DoD (per dispatch)

- [x] Three states; never `len - coherent`
- [x] Test with a mixed population including at least one context lacking the key — the arming input
- [x] Substitution control: reverting to `len - coherent` turns the new test red (verified — yields `2 incoherente(s)` instead of `1 incoherente(s)` + no non-classifiable mention)

## Tests

`test_atms_counts_absent_key_separately_three_states` — population `[True, False, absent]`: asserts `1 coherente`, `1 incoherente`, `non classifiable` present, `2 incoherente` absent. 17 narrative tests pass; 114 consumer tests pass (narrative + atms_multi_context + convergent + golden + DAG).

Out of scope: the phrase wording (settled). Item 2 (#1708 measurement) is separate.

REVIEW_REQUIRED — coord `--admin` merge.

Co-Authored-By: Claude-Code <noreply@anthropic.com>