### PR TITLE
fix(atms): rename phantom atms_hypothesis_testing to atms_reasoning (#1708)

### DIFF
--- a/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
+++ b/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
@@ -488,7 +488,19 @@ def build_sherlock_modern_workflow():
             .add_phase(
                 "narrative_synthesis",
                 capability="narrative_synthesis",
-                depends_on=["atms"],
+                # #1708 follow-up (coord R791): "jtms" is declared here because
+                # build_narrative reads state.jtms_beliefs and
+                # state.jtms_retraction_chain (narrative_synthesis_plugin.py:104,
+                # :120, :324).  Before this file dropped atms.depends_on=["jtms"],
+                # that ordering was supplied TRANSITIVELY through atms — removing
+                # the false edge on atms also removed a REAL edge for this phase,
+                # measured by execution: jtms and narrative_synthesis both landed
+                # on level 3, so narrative could read empty beliefs.  Same lesson
+                # as the atms fix one phase up, applied hop by hop: an edge that
+                # is false for a node can still be load-bearing for its
+                # descendants.  Full read set checked against the 7 phases —
+                # jtms was the only unordered producer.
+                depends_on=["atms", "jtms"],
                 optional=True,
             )
             .build()

--- a/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
+++ b/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
@@ -466,8 +466,23 @@ def build_sherlock_modern_workflow():
             )
             .add_phase(
                 "atms",
-                capability="atms_hypothesis_testing",
-                depends_on=["jtms"],
+                # #1708: was "atms_hypothesis_testing" — a phantom capability no
+                # producer supplies. The real producer (registry_setup.py registers
+                # atms_service, invoke=_invoke_atms) advertises "atms_reasoning",
+                # which this file's own _PHASE_TO_CAPABILITY table names (l.74) and
+                # the other two atms phase declarations use (workflows.py,
+                # formal_verification.py). Renamed, not registered — subtraction of
+                # a phantom name.
+                #
+                # depends_on was ["jtms"] — false (_invoke_atms never reads
+                # jtms_beliefs, #1650). Dropping it to zero left atms at DAG level 0
+                # (measured by execution), running BEFORE the extract/hierarchical_
+                # fallacy/quality context keys _invoke_atms actually consumes (R787)
+                # — the false jtms dep was carrying a real ordering side-effect.
+                # Declared here are the real inputs, so atms runs after them
+                # (level 2 measured) without re-introducing the false jtms link.
+                capability="atms_reasoning",
+                depends_on=["extract", "hierarchical_fallacy", "quality"],
                 optional=True,
             )
             .add_phase(

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
@@ -631,18 +631,41 @@ class TestSherlockModernWorkflowGolden:
         wf = build_sherlock_modern_workflow()
         assert wf.validate() == []
 
-    def test_execution_order_4_levels(self):
+    def test_execution_order_5_levels(self):
         # #1708: dropping the false depends_on=["jtms"] and declaring the real
         # inputs (extract/hierarchical_fallacy/quality — the context keys
-        # _invoke_atms consumes) collapses the chain from 6 levels to 4.
+        # _invoke_atms consumes) collapses the chain from 6 levels to 5.
         # Measured by execution (get_execution_order), not by reading the
         # declaration — the lesson of the #1650 golden: a false declaration can
         # carry a real ordering side-effect, so the new order must be attested.
+        #
+        # R791: the first pass of this fix read 4 levels, because dropping the
+        # false atms→jtms edge ALSO dropped the transitive ordering it supplied
+        # to narrative_synthesis (which reads state.jtms_beliefs).  jtms and
+        # narrative landed on the same level.  narrative_synthesis now declares
+        # jtms directly, so the count is 5 and the order below is the real one.
         wf = build_sherlock_modern_workflow()
         levels = wf.get_execution_order()
-        assert len(levels) == 4
+        assert len(levels) == 5
         assert levels[0] == ["extract"]
         assert set(levels[1]) == {"hierarchical_fallacy", "quality"}
+
+    def test_narrative_synthesis_runs_strictly_after_jtms(self):
+        """#1708 follow-up (R791) — the edge the atms fix nearly cost us.
+
+        ``build_narrative`` reads ``state.jtms_beliefs`` and
+        ``state.jtms_retraction_chain``.  Assert the ORDER by execution, not the
+        declaration: a same-level pair validates clean and reads empty beliefs.
+        """
+        wf = build_sherlock_modern_workflow()
+        levels = wf.get_execution_order()
+        pos = {name: i for i, lv in enumerate(levels) for name in lv}
+        assert pos["narrative_synthesis"] > pos["jtms"], (
+            "narrative_synthesis consumes jtms_beliefs; it must be on a strictly "
+            f"later level than jtms (got {pos}) "
+        )
+        # atms must NOT have regained the false jtms dependency to achieve this.
+        assert "jtms" not in wf.get_phase("atms").depends_on
 
     def test_dependency_chain(self):
         wf = build_sherlock_modern_workflow()

--- a/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_spectacular_regression_suite.py
@@ -119,13 +119,6 @@ MOCK_OUTPUTS = {
         "narrative": "Investigation complete with 2 hypotheses tested.",
         "paragraph_count": 3,
     },
-    "atms_hypothesis_testing": {
-        "atms_contexts": [
-            {"hypothesis_id": "h1", "coherent": True},
-            {"hypothesis_id": "h2", "coherent": False},
-        ],
-        "has_contradictions": True,
-    },
 }
 
 
@@ -262,9 +255,6 @@ def _make_mock_state_writers():
         if isinstance(output, dict) and "narrative" in output:
             state.narrative_synthesis = output["narrative"]
 
-    def _write_atms_hypothesis(output, state, ctx):
-        _write_atms(output, state, ctx)
-
     writers["argument_quality"] = _write_quality
     writers["counter_argument_generation"] = _write_counter
     writers["belief_maintenance"] = _write_jtms
@@ -282,7 +272,11 @@ def _make_mock_state_writers():
     writers["neural_fallacy_detection"] = _write_neural_fallacy
     writers["formal_synthesis"] = _write_formal_synthesis
     writers["narrative_synthesis"] = _write_narrative_synthesis
-    writers["atms_hypothesis_testing"] = _write_atms_hypothesis
+    # #1708: the "atms_hypothesis_testing" phantom-capability writer is removed —
+    # after the rename the phase asks for "atms_reasoning", whose writer is
+    # registered just above (l.271). The golden now attests a wiring that
+    # production actually supplies, instead of substituting a fixture for a
+    # capability nothing provides.
     return writers
 
 
@@ -637,10 +631,16 @@ class TestSherlockModernWorkflowGolden:
         wf = build_sherlock_modern_workflow()
         assert wf.validate() == []
 
-    def test_execution_order_6_levels(self):
+    def test_execution_order_4_levels(self):
+        # #1708: dropping the false depends_on=["jtms"] and declaring the real
+        # inputs (extract/hierarchical_fallacy/quality — the context keys
+        # _invoke_atms consumes) collapses the chain from 6 levels to 4.
+        # Measured by execution (get_execution_order), not by reading the
+        # declaration — the lesson of the #1650 golden: a false declaration can
+        # carry a real ordering side-effect, so the new order must be attested.
         wf = build_sherlock_modern_workflow()
         levels = wf.get_execution_order()
-        assert len(levels) == 6
+        assert len(levels) == 4
         assert levels[0] == ["extract"]
         assert set(levels[1]) == {"hierarchical_fallacy", "quality"}
 
@@ -651,7 +651,14 @@ class TestSherlockModernWorkflowGolden:
         assert "extract" in wf.get_phase("quality").depends_on
         assert "quality" in wf.get_phase("counter").depends_on
         assert "counter" in wf.get_phase("jtms").depends_on
-        assert "jtms" in wf.get_phase("atms").depends_on
+        # #1708: atms no longer depends on jtms (false — _invoke_atms never reads
+        # jtms_beliefs, #1650). It depends on the real inputs it consumes.
+        assert "jtms" not in wf.get_phase("atms").depends_on
+        assert {"extract", "hierarchical_fallacy", "quality"}.issubset(
+            set(wf.get_phase("atms").depends_on)
+        )
+        # narrative_synthesis still runs strictly after atms (measured: atms at
+        # level 2, narrative_synthesis at level 3).
         assert "atms" in wf.get_phase("narrative_synthesis").depends_on
 
     def test_capabilities_match_phases(self):


### PR DESCRIPTION
Dispatch R790 item 1. Implements the ruling posted on #1708 (option (a): rename, subtraction of a phantom name, nothing registered).

## The defect

`sherlock_modern_orchestrator.py:469` declared its atms phase on `capability="atms_hypothesis_testing"` — a capability **no producer supplies**. Its only other occurrences were a fake writer + mock output in the golden test (the fixture WAS the producer, form #1019). The real producer (`registry_setup.py` registers `atms_service`, `invoke=_invoke_atms`) advertises `atms_reasoning`, which this file's own `_PHASE_TO_CAPABILITY` table names (l.74) and the other two atms declarations use (`workflows.py`, `formal_verification.py`).

## The fix

**Rename** (subtraction, nothing registered):
- `atms_hypothesis_testing` → `atms_reasoning`

**`depends_on=["jtms"]` dropped — but NOT to zero.** This is the measured part. The dispatch anticipated it (« retirer depends_on change le DAG »). Measured by execution (`get_execution_order`):

- dropping to `[]` left **atms at DAG level 0** (parallel with extract) — running **before** the `extract`/`hierarchical_fallacy`/`quality` context keys `_invoke_atms` actually consumes (R787). The false jtms dep was carrying a real ordering side-effect — the exact lesson of the #1650 golden.
- Declared the **real inputs** instead → atms at level 2 (after them), `narrative_synthesis` (depends_on atms) at level 3 strictly after. Chain collapses 6 → 4 levels. DAG validates clean.

This is the analogue of the spectacular fix in R788 (PR #1705, `depends_on=['extract','hierarchical_fallacy','quality']`), applied to the sherlock mirror.

**Test fixture cleaned** (the « fixture IS the producer » form retires):
- `MOCK_OUTPUTS['atms_hypothesis_testing']` removed (phase now asks for `atms_reasoning`, whose mock output already exists)
- `writers['atms_hypothesis_testing']` fake writer removed (registry already carries `writers['atms_reasoning'] = _write_atms`, l.271)
- golden `test_dependency_chain` + `test_execution_order` recabled to the real wiring, **attested by execution** (4 levels, atms level 2 after its inputs, narrative level 3 after atms). The golden now attests a wiring production actually supplies.

## DoD

- [x] golden `test_dependency_chain` passes **without** the fake writer
- [x] DAG ordering verified by **execution** (not declaration-reading): 4 levels, atms after extract/hierarchical_fallacy/quality, narrative_synthesis strictly after atms
- [x] phase no longer SKIPPED: `test_all_7_phases_complete` (7 completed), `test_state_populated_after_execution` (`atms_contexts >= 1`)

## Consequence the ruling documents (not a regression to mask)

The phase ceases to be SKIPPED and now produces. What it produces is the ATMS with fabricated inputs that #1650 documents (`n_contexts` constant, justifications built by index). The rename does **not** create that surface — it stops hiding it. The `SherlockModernOrchestrator` class already executes ATMS in production today; a catalogue that silently skips what the primary entry point executes *underestimates* #1650's reach instead of protecting it.

On real data (R789, 3 corpora): the ATMS emits 3 contexts all `coherent: True`, so no visible count changes from this rename alone. The rename's value is correctness of declaration + a golden that attests real wiring, not a number.

## Out of scope

Item 2 of the dispatch (the two-state `coherent` motif across 7 sites) is a separate PR — same file at different sites but distinct concern, and it must land with the rewriter first.

REVIEW_REQUIRED — coord `--admin` merge.

Co-Authored-By: Claude-Code <noreply@anthropic.com>