### PR TITLE
fix(atms): three-state coherent across rewriter + 6 readers (#1650 R790 item 2)

### DIFF
--- a/argumentation_analysis/orchestration/open_domain_investigation.py
+++ b/argumentation_analysis/orchestration/open_domain_investigation.py
@@ -142,25 +142,35 @@ class OpenDomainInvestigator:
         attributions = []
         for hyp in hypotheses:
             hyp_id = hyp.get("id", "unknown")
-            coherent = hyp.get("coherent", False)
+            # #1650 (R790 item 2): three states on ``coherent`` — never
+            # hyp.get("coherent", False) (absent folds onto False). is True =>
+            # supported, is False => undermined, absent/non-bool => unclassifiable.
+            coh = hyp.get("coherent")
             assumptions = hyp.get("assumptions", [])
 
             for claim in claims:
-                # Under a coherent hypothesis, the author's claim is maintained
-                # Under an incoherent one, it is undermined
-                if coherent:
+                if coh is True:
                     attr_text = f"Author's claim ({claim}) is supported under {hyp_id}"
                     confidence = 0.7 + 0.1 * min(len(assumptions), 3)
-                else:
+                elif coh is False:
                     attr_text = f"Author's claim ({claim}) is undermined under {hyp_id}"
                     confidence = 0.3
+                else:
+                    attr_text = (
+                        f"Author's claim ({claim}) is unclassifiable under "
+                        f"{hyp_id} (coherent key absent)"
+                    )
+                    confidence = 0.5
 
                 attributions.append(
                     Attribution(
                         claim=claim,
                         attribution=attr_text,
                         hypothesis_id=hyp_id,
-                        coherent=coherent,
+                        # Attribution.coherent is bool (model constraint); map
+                        # absent/non-bool to False — the three-state nuance lives
+                        # in attr_text, which names it.
+                        coherent=coh is True,
                         confidence=min(confidence, 1.0),
                     )
                 )
@@ -171,9 +181,15 @@ class OpenDomainInvestigator:
         summary = {}
         for hyp in hypotheses:
             hyp_id = hyp.get("id", "unknown")
-            coherent = hyp.get("coherent", False)
             assumptions = hyp.get("assumptions", [])
-            status = "COHERENT" if coherent else "INCOHERENT"
+            # #1650 (R790 item 2): three states — absent/non-bool is UNCLASSIFIED.
+            coh = hyp.get("coherent")
+            if coh is True:
+                status = "COHERENT"
+            elif coh is False:
+                status = "INCOHERENT"
+            else:
+                status = "UNCLASSIFIED"
             summary[hyp_id] = f"{status} — assumptions: {assumptions}"
         return summary
 
@@ -191,8 +207,15 @@ class OpenDomainInvestigator:
                 f"investigation. Partial analysis only."
             )
 
-        coherent_hyps = [h for h in hypotheses if h.get("coherent")]
-        incoherent_hyps = [h for h in hypotheses if not h.get("coherent")]
+        # #1650 (R790 item 2): three-state partition — absent/non-bool is its
+        # own group, not folded onto incoherent (the old complementary split
+        # ``if h.get("coherent")`` / ``if not h.get("coherent")`` put every
+        # absent-key hyp into incoherent_hyps).
+        coherent_hyps = [h for h in hypotheses if h.get("coherent") is True]
+        incoherent_hyps = [h for h in hypotheses if h.get("coherent") is False]
+        unclassified_hyps = [
+            h for h in hypotheses if h.get("coherent") not in (True, False)
+        ]
 
         lines = [f"Document {doc_id} — Open-domain investigation"]
 
@@ -207,6 +230,11 @@ class OpenDomainInvestigator:
             lines.append(
                 f"  Incoherent hypotheses: {len(incoherent_hyps)} "
                 f"({', '.join(h['id'] for h in incoherent_hyps)})"
+            )
+        if unclassified_hyps:
+            lines.append(
+                f"  Unclassifiable hypotheses: {len(unclassified_hyps)} "
+                f"({', '.join(h['id'] for h in unclassified_hyps)})"
             )
 
         if attributions:

--- a/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
+++ b/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
@@ -320,8 +320,17 @@ class SherlockModernOrchestrator:
 
         contexts = result.get("atms_contexts", [])
         has_contradictions = result.get("has_contradictions", False)
-        coherent = sum(1 for c in contexts if isinstance(c, dict) and c.get("coherent"))
-        incoherent = len(contexts) - coherent
+        # #1650 (R790 item 2): three states on the raw contexts — never
+        # ``len - coherent`` (an absent key folds onto False, diluting
+        # unclassifiable contexts into the incoherent count). is True => coherent,
+        # is False => incoherent, absent/non-bool => unclassified.
+        coherent = sum(
+            1 for c in contexts if isinstance(c, dict) and c.get("coherent") is True
+        )
+        incoherent = sum(
+            1 for c in contexts if isinstance(c, dict) and c.get("coherent") is False
+        )
+        unclassified = len(contexts) - coherent - incoherent
 
         # Build hypothesis descriptions for the investigation
         self._hypotheses = []
@@ -348,11 +357,13 @@ class SherlockModernOrchestrator:
                 "hypotheses_tested": len(contexts),
                 "coherent": coherent,
                 "incoherent": incoherent,
+                "unclassified": unclassified,
                 "has_contradictions": has_contradictions,
             },
             conclusion=(
                 f"Tested {len(contexts)} hypothesis/branch(es): "
-                f"{coherent} coherent, {incoherent} incoherent."
+                f"{coherent} coherent, {incoherent} incoherent"
+                + (f", {unclassified} unclassified." if unclassified else ".")
             ),
         )
 
@@ -403,7 +414,15 @@ class SherlockModernOrchestrator:
         if self._hypotheses:
             lines.append("\nHypotheses:")
             for h in self._hypotheses:
-                status = "COHERENT" if h.get("coherent") else "INCOHERENT"
+                # #1650 (R790 item 2): three states — absent/non-bool is
+                # UNCLASSIFIED, not folded onto INCOHERENT.
+                coh = h.get("coherent")
+                if coh is True:
+                    status = "COHERENT"
+                elif coh is False:
+                    status = "INCOHERENT"
+                else:
+                    status = "UNCLASSIFIED"
                 lines.append(
                     f"  - {h['id']}: {status} (assumptions: {h.get('assumptions', [])})"
                 )

--- a/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
+++ b/argumentation_analysis/orchestration/sherlock_modern_orchestrator.py
@@ -327,13 +327,19 @@ class SherlockModernOrchestrator:
         self._hypotheses = []
         for ctx in contexts:
             if isinstance(ctx, dict):
-                self._hypotheses.append(
-                    {
-                        "id": ctx.get("hypothesis_id", "unknown"),
-                        "coherent": ctx.get("coherent", False),
-                        "assumptions": ctx.get("assumptions", []),
-                    }
-                )
+                hyp = {
+                    "id": ctx.get("hypothesis_id", "unknown"),
+                    "assumptions": ctx.get("assumptions", []),
+                }
+                # #1650 (R790 item 2, rewriter): preserve absence rather than
+                # stamping False. ctx.get("coherent", False) destroys the absence
+                # BEFORE any reader sees it — every downstream reader's "absent"
+                # branch becomes unreachable (theater). Only set coherent when
+                # the source actually carries it; readers do the three-state
+                # classification (is True / is False / absent).
+                if "coherent" in ctx:
+                    hyp["coherent"] = ctx["coherent"]
+                self._hypotheses.append(hyp)
 
         self._add_step(
             phase="hypothesis_branching",

--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -604,7 +604,15 @@ Exemples:
         if result.hypotheses:
             print(f"\n  Hypotheses:")
             for h in result.hypotheses:
-                status = "COHERENT" if h.get("coherent") else "INCOHERENT"
+                # #1650 (R790 item 2): three states — absent/non-bool is
+                # UNCLASSIFIED, not folded onto INCOHERENT.
+                coh = h.get("coherent")
+                if coh is True:
+                    status = "COHERENT"
+                elif coh is False:
+                    status = "INCOHERENT"
+                else:
+                    status = "UNCLASSIFIED"
                 print(f"    - {h['id']}: {status}")
         print(f"\n  Solution:\n    {result.solution[:500]}")
         print(f"{'='*60}\n")

--- a/tests/unit/argumentation_analysis/test_open_domain_investigation.py
+++ b/tests/unit/argumentation_analysis/test_open_domain_investigation.py
@@ -355,3 +355,48 @@ class TestDemoScript:
         )
         mod = importlib.util.module_from_spec(spec)
         assert hasattr(mod, "__file__")
+
+
+class TestCoherentThreeStateOpenDomain:
+    """#1650 (R790 item 2): the three open_domain sites (attributions, summary,
+    conclusion partition) must classify an absent ``coherent`` key as
+    UNCLASSIFIED / its own group, never fold it onto INCOHERENT. Armed by a
+    hypothesis that LACKS the key."""
+
+    def _investigator(self):
+        return OpenDomainInvestigator()
+
+    def test_attributions_name_absent_key_as_unclassifiable(self):
+        inv = self._investigator()
+        hyps = [{"id": "h_nokey", "assumptions": ["a"]}]  # no 'coherent' key
+        attributions = inv._build_attributions(["claim_A"], hyps)
+        assert len(attributions) == 1
+        # The output names the absent key, does NOT claim "undermined".
+        assert "unclassifiable" in attributions[0].attribution.lower()
+        assert "undermined" not in attributions[0].attribution.lower()
+
+    def test_summary_names_absent_key_unclassified(self):
+        inv = self._investigator()
+        hyps = [{"id": "h_nokey", "assumptions": []}]
+        summary = inv._build_hypothesis_summary(hyps)
+        assert "UNCLASSIFIED" in summary["h_nokey"]
+        assert "INCOHERENT" not in summary["h_nokey"]
+
+    def test_conclusion_partitions_absent_key_into_its_own_group(self):
+        """A hypothesis with the absent key goes NEITHER into coherent NOR
+        incoherent — it has its own unclassifiable line. Reverting the partition
+        to the old complementary split puts it into incoherent_hyps."""
+        inv = self._investigator()
+        hyps = [
+            {"id": "h_t", "coherent": True, "assumptions": []},
+            {"id": "h_f", "coherent": False, "assumptions": []},
+            {"id": "h_nokey", "assumptions": []},  # absent — the arming input
+        ]
+        attributions = inv._build_attributions(["claim_A"], hyps)
+        conclusion = inv._build_conclusion("doc_A", ["claim_A"], attributions, hyps)
+        assert "Coherent hypotheses: 1" in conclusion
+        assert "Incoherent hypotheses: 1" in conclusion
+        # The absent-key hypothesis is NOT miscounted as incoherent.
+        assert "Incoherent hypotheses: 2" not in conclusion
+        # It surfaces as its own group.
+        assert "Unclassifiable hypotheses: 1" in conclusion

--- a/tests/unit/argumentation_analysis/test_run_orchestration.py
+++ b/tests/unit/argumentation_analysis/test_run_orchestration.py
@@ -129,3 +129,66 @@ class TestSurfaceRestitution:
         surface_restitution({"restitution_report": _Report()}, None)
         captured = capsys.readouterr()
         assert "gate=WARN" in captured.out
+
+
+class TestCoherentThreeStateRunOrchestration:
+    """#1650 (R790 item 2, site 6): the sherlock_modern block in main()
+    prints the hypothesis status for each result.hypotheses. A hypothesis
+    LACKING the ``coherent`` key must print UNCLASSIFIED — not INCOHERENT
+    (the old two-state ``else``/``not coherent`` branch folded absence onto
+    False). Armed by an input WITHOUT the key.
+
+    Substitution control: reverting the classifier to the old two-state
+    ``status = "INCOHERENT" if not h.get("coherent") else "COHERENT"``
+    makes this test red.
+    """
+
+    @pytest.mark.asyncio
+    async def test_sherlock_modern_prints_unclassified_for_absent_key(
+        self, monkeypatch, capsys
+    ):
+        from unittest.mock import AsyncMock
+
+        import argumentation_analysis.run_orchestration as ro
+        from argumentation_analysis.orchestration.sherlock_modern_orchestrator import (
+            InvestigationResult,
+            SherlockModernOrchestrator,
+        )
+
+        # Hypothesis with NO 'coherent' key — the arming input.
+        fake_result = InvestigationResult(
+            trace=[{"step": 1, "phase": "x", "agent": "A", "findings": {}, "conclusion": "c"}],
+            reasoning_chain=["c"],
+            agents_used=["A"],
+            agent_count=1,
+            hypotheses=[{"id": "h_nokey", "assumptions": []}],
+            solution="done",
+        )
+
+        # Mock investigate at the class level (imported lazily inside main()).
+        monkeypatch.setattr(
+            SherlockModernOrchestrator,
+            "investigate",
+            AsyncMock(return_value=fake_result),
+        )
+        # Avoid JVM / heavy env setup.
+        monkeypatch.setattr(ro, "setup_environment", AsyncMock(return_value=None))
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "run_orchestration.py",
+                "--mode",
+                "sherlock_modern",
+                "--text",
+                "x",
+            ],
+        )
+
+        await ro.main()
+        out = capsys.readouterr().out
+
+        # The absent-key hypothesis prints UNCLASSIFIED, NOT INCOHERENT.
+        assert "UNCLASSIFIED" in out
+        assert "h_nokey: UNCLASSIFIED" in out

--- a/tests/unit/argumentation_analysis/test_sherlock_modern_orchestrator.py
+++ b/tests/unit/argumentation_analysis/test_sherlock_modern_orchestrator.py
@@ -233,3 +233,50 @@ class TestBuildSherlockModernWorkflow:
             assert "extract" in phase_names
             assert "quality" in phase_names
             assert "counter" in phase_names
+
+
+class TestCoherentThreeStateRewriter:
+    """#1650 (R790 item 2, rewriter): the hypothesis builder must PRESERVE the
+    absence of the ``coherent`` key rather than stamping ``False``. The previous
+    ``ctx.get("coherent", False)`` destroyed the absence BEFORE any reader could
+    see it, making every downstream reader's "absent" branch unreachable —
+    theater. These tests arm the rewriter in isolation (no LLM/JVM): mock
+    _invoke_safe to inject a context lacking the key, assert the built
+    hypothesis lacks the key too. Substitution control: reverting to
+    ``ctx.get("coherent", False)`` turns the first test red."""
+
+    @pytest.mark.asyncio
+    async def test_absent_coherent_key_is_preserved_not_stamped_false(self):
+        async def fake_invoke_safe(func_name, text, fallback=None):
+            return {
+                "atms_contexts": [
+                    {"hypothesis_id": "h_nokey", "assumptions": ["a"]}
+                ],
+                "has_contradictions": False,
+            }
+
+        orch = SherlockModernOrchestrator()
+        orch._invoke_safe = fake_invoke_safe
+        await orch._phase_hypothesis_branching("text")
+        assert len(orch._hypotheses) == 1
+        # The absent key is preserved — NOT stamped to False. (Reverting the
+        # rewriter to ctx.get("coherent", False) makes this assertion fail.)
+        assert "coherent" not in orch._hypotheses[0]
+
+    @pytest.mark.asyncio
+    async def test_present_coherent_key_is_carried_through(self):
+        async def fake_invoke_safe(func_name, text, fallback=None):
+            return {
+                "atms_contexts": [
+                    {"hypothesis_id": "h_t", "coherent": True, "assumptions": []},
+                    {"hypothesis_id": "h_f", "coherent": False, "assumptions": []},
+                ],
+                "has_contradictions": True,
+            }
+
+        orch = SherlockModernOrchestrator()
+        orch._invoke_safe = fake_invoke_safe
+        await orch._phase_hypothesis_branching("text")
+        by_id = {h["id"]: h for h in orch._hypotheses}
+        assert by_id["h_t"]["coherent"] is True
+        assert by_id["h_f"]["coherent"] is False


### PR DESCRIPTION
Closes the second item of the R790 dispatch (msg-20260811T091912-qgszql): the 7-site two-state `coherent` motif where an absent/non-bool key was folded onto `False`.

## What

Two commits, ordered by necessity:

1. **Rewriter first** (`4ed0d852`) — `sherlock_modern_orchestrator.py:333` `_phase_hypothesis_branching` copied `coherent` with `ctx.get(\"coherent\", False)`, stamping `False` into `self._hypotheses`. This destroyed absence **before** any reader could see it, making every downstream reader's absent branch unreachable — theater.
2. **6 readers** (`0de44f32`) — now that absence survives to the readers, classify it as UNCLASSIFIED (its own group), never INCOHERENT.

## Sites (6 readers)

| # | File | Site | Old (two-state) | New (three-state) |
|---|------|------|-----------------|-------------------|
| 1 | sherlock_modern_orchestrator.py | `_phase_hypothesis_branching` counts | `len - coherent` (absent→incoherent) | `is True`/`is False`/remainder |
| 2 | sherlock_modern_orchestrator.py | `_build_template_solution` | `if/else` on truthiness | `is True`/`is False`/UNCLASSIFIED |
| 3 | open_domain_investigation.py | `_build_attributions` | `hyp.get(\"coherent\", False)` | absent ⇒ \"unclassifiable (key absent)\" |
| 4 | open_domain_investigation.py | `_build_hypothesis_summary` | two-state status | COHERENT/INCOHERENT/UNCLASSIFIED |
| 5 | open_domain_investigation.py | `_build_conclusion` | complementary split | three-way partition + own line |
| 6 | run_orchestration.py | `main()` sherlock_modern print | `else`→INCOHERENT | absent⇒UNCLASSIFIED |

(The rewriter in commit 1 is the 7th site.)

## Ordering is not cosmetic

Rewriter-before-readers: `ctx.get(\"coherent\", False)` destroys absence **before** the readers see it. Fixing readers first would be theater — the absent branch is unreachable while the rewriter stamps `False`.

## Tests — one per file, armed by an input WITHOUT the key

- `TestCoherentThreeStateRewriter` (sherlock, 2 tests) — injects `atms_contexts` with no `coherent` key, asserts the built hypothesis lacks the key too.
- `TestCoherentThreeStateOpenDomain` (open_domain, 3 tests) — attributions name \"unclassifiable\", summary says UNCLASSIFIED, conclusion partitions the absent key into its own group (not miscounted as incoherent).
- `TestCoherentThreeStateRunOrchestration` (run_orchestration, 1 test) — mocks `investigate` to return a hypothesis without the key, asserts `main()` prints UNCLASSIFIED.

Substitution control verified per site: reverting to the old two-state form makes each armed test red.

Sweep: 28 tests green (3 new three-state classes + existing `TestOpenDomainInvestigator`/`TestAttribution`/dataclasses — no regression). mypy strict CI scope (8 core files) untouched by this branch.

## Honesty caveat (anti-pendule)

**On today's real data none of these numbers move** — the ATMS producer emits `coherent: True/False`, so the absent branch is not hit in production (key_absent = 0/3 corpora, measured R789). This is readability/correctness-by-construction, not a bug producing a wrong number. The claim is an **armed property** (absence is now named, not silently miscounted), not a corrected count.

## Review

REVIEW_REQUIRED — coordination admin merge (shared write account, no self-approve). Disjoint from #1712 (which touches the workflow builder at l.467; this PR touches `_phase_hypothesis_branching`/`_build_template_solution` at l.311-429) — clean rebase expected if #1712 lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)