### PR TITLE
fix(orches): carry #1698 honest attack accounting on curated surface + per-nature split

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3382,6 +3382,28 @@ def _retained_attacks(arguments: List[str], submitted_attacks: List[Any]) -> Lis
     return retained
 
 
+def _attack_source_nature(attacker: Any) -> str:
+    """Classify a synthetic attack source by nature (#1698 R791 item 2).
+
+    The producer mints two disjoint families (``_generate_attacks_from_args``):
+    ``fallacy_{i}_{label}`` from fallacy detections, ``CA: {text[:50]}`` from
+    counter-argument text matches. Anything else (malformed, unknown, or a
+    real inventory member when upstream provided ``context["attacks"]``) lands
+    in ``other`` — a defensive bucket that keeps
+    ``sum(natures) == attacks_submitted`` verifiable.
+
+    Returns the KEY only, never the source string: ``CA:`` sources embed
+    counter-argument text (= corpus), so callers must never print them
+    (#1698 privacy HARD — the frontier is GitHub indexation).
+    """
+    s = str(attacker)
+    if s.startswith("fallacy_"):
+        return "fallacy"
+    if s.startswith("CA: "):
+        return "ca"
+    return "other"
+
+
 def _annotate_attack_retention(
     output: Dict[str, Any],
     arguments: List[str],
@@ -3411,6 +3433,35 @@ def _annotate_attack_retention(
     output["attacks_submitted"] = n_sub
     output["attacks_retained"] = n_ret
     output["attacks_dropped"] = n_sub - n_ret
+    # #1698 (R791 item 2): per-nature split of the accounting. The dropped
+    # edges are not persisted as a list anywhere, so the split is declared
+    # HERE, at the point where the candidates are in hand — reproducible by
+    # construction, never reconstructed post-hoc from a snapshot. Keys are
+    # counts only; the ``CA:`` sources embed counter-argument text (= corpus)
+    # and must never be printed or persisted verbatim (#1698 privacy HARD).
+    # ``_retained_attacks`` appends the same candidate objects, so id()
+    # membership is a faithful retained test across shapes.
+    if isinstance(submitted_attacks, list):
+        retained_ids = {id(a) for a in retained}
+        by_nature: Dict[str, List[int]] = {
+            "fallacy": [0, 0],
+            "ca": [0, 0],
+            "other": [0, 0],
+        }  # [submitted, dropped]
+        for atk in submitted_attacks:
+            attacker: Any = None
+            if isinstance(atk, dict) and atk.get("attackers"):
+                attackers = atk["attackers"]
+                attacker = attackers[0] if isinstance(attackers, (list, tuple)) else None
+            elif isinstance(atk, (list, tuple)) and atk:
+                attacker = atk[0]
+            nature = _attack_source_nature(attacker)
+            by_nature[nature][0] += 1
+            if id(atk) not in retained_ids:
+                by_nature[nature][1] += 1
+        for nature, (sub, dropped) in by_nature.items():
+            output[f"attacks_submitted_{nature}"] = sub
+            output[f"attacks_dropped_{nature}"] = dropped
     stats = output.get("statistics")
     if isinstance(stats, dict):
         # statistics.attacks_count now counts what was EVALUATED (retained),

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -8,7 +8,7 @@ Split from unified_pipeline.py (#310).
 """
 
 import logging
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, List, Optional, Tuple
 
 logger = logging.getLogger("UnifiedPipeline")
 
@@ -1159,6 +1159,110 @@ def _write_nl_to_logic_to_state(output: Any, state: Any, ctx: dict[str, Any]) ->
             )
 
 
+def _carry_attack_retention(state: Any, df_id: str, output: Any) -> None:
+    """#1698 (R791 item 1): carry the #1704 submitted/retained/dropped
+    accounting onto the CURATED ``dung_frameworks`` entry.
+
+    The honest report lives on the invoke output (persisted in bulk under
+    ``formal_synthesis_reports[*].phase_results.<axe>``); the curated writer
+    projects a frozen subset ``{name, arguments, attacks, extensions}`` and was
+    dropping the declaration, so a reader of the surface the conclusion reads
+    (``dung_frameworks``) could not distinguish "the text carried no conflict"
+    from "15 edges submitted, all rejected". Same three keys, same names,
+    top-level peers of ``attacks`` — zero reader migration. Absent keys ⇒
+    nothing carried (the writer boundary never synthesises an accounting the
+    producer did not make).
+    """
+    if not isinstance(output, dict) or state is None:
+        return
+    base_keys = ("attacks_submitted", "attacks_retained", "attacks_dropped")
+    if not all(k in output for k in base_keys):
+        return
+    # R791 item 2: the per-nature split rides along (counts only — the CA:
+    # sources themselves are corpus text and never leave the producer).
+    all_keys = base_keys + (
+        "attacks_submitted_fallacy",
+        "attacks_dropped_fallacy",
+        "attacks_submitted_ca",
+        "attacks_dropped_ca",
+        "attacks_submitted_other",
+        "attacks_dropped_other",
+    )
+    entry = getattr(state, "dung_frameworks", {}).get(df_id)
+    if not isinstance(entry, dict):
+        return
+    for k in all_keys:
+        if isinstance(output.get(k), int):
+            entry[k] = output[k]
+
+
+def _acceptance_member_lists(extensions: Any) -> List[List[str]]:
+    """Flatten the acceptance-extension shapes the annotated writers produce
+    into plain member lists: dung ``{sem: [members]}`` and setaf/weighted
+    ``[ [members], ... ]``. Social ranking/scores, empty and malformed shapes
+    return ``[]`` — the contradiction guard needs comparable member sets."""
+    out: List[List[str]] = []
+    if isinstance(extensions, dict):
+        for v in extensions.values():
+            if isinstance(v, list):
+                if v and all(isinstance(x, str) for x in v):
+                    out.append(v)
+                else:
+                    out.extend(m for m in v if isinstance(m, list) and m)
+    elif isinstance(extensions, list):
+        out.extend(m for m in extensions if isinstance(m, list) and m)
+    return out
+
+
+def _guard_attack_contradiction(
+    state: Any, df_id: str, output: Any, arguments: Any
+) -> None:
+    """#1698 DoD item 4 — internal-contradiction guard.
+
+    A framework that RETAINED edges (``attacks_retained > 0``) yet whose
+    acceptance extensions all return the full argument inventory is internally
+    contradictory: with a live edge, no Dung-family semantics accepts every
+    member (the edge's target is attacked, hence excluded or at least never
+    conflict-free with the full set). Detect it rather than publish it as a
+    normal verdict: flag the curated entry and trace.
+
+    Anti-pendule: ``attacks_submitted > 0`` with ``attacks_retained == 0`` is
+    NOT a contradiction — that is #1704's honest empty report doing its job
+    (the edges never reached the evaluated graph). The guard fires only when
+    an edge is actually IN the frame while every acceptance semantics still
+    accepts everything.
+    """
+    if not isinstance(output, dict) or state is None:
+        return
+    retained = output.get("attacks_retained", 0)
+    if not isinstance(retained, int) or retained <= 0:
+        return
+    entry = getattr(state, "dung_frameworks", {}).get(df_id)
+    if not isinstance(entry, dict):
+        return
+    member_lists = _acceptance_member_lists(output.get("extensions"))
+    if not member_lists:
+        return
+    arg_set = {str(a) for a in (arguments or []) if isinstance(a, str)}
+    if not arg_set:
+        return
+    if all({str(m) for m in members} == arg_set for members in member_lists):
+        entry["internal_contradiction"] = True
+        add_trace = getattr(state, "add_trace_entry", None)
+        if callable(add_trace):
+            add_trace(
+                phase="dung",
+                agent="AttackContradictionGuard",
+                reacts_to=["extract", "counter"],
+                summary=(
+                    f"Cadre {entry.get('name', df_id)}: {retained} arête(s) dans "
+                    f"le cadre mais toutes les sémantiques d'acceptation rendent "
+                    f"l'inventaire complet — contradiction interne détectée, "
+                    f"non publiée comme résultat sain (#1698)."
+                ),
+            )
+
+
 def _write_dung_extensions_to_state(
     output: Any, state: Any, ctx: dict[str, Any]
 ) -> None:
@@ -1171,22 +1275,32 @@ def _write_dung_extensions_to_state(
     arguments = output.get("arguments", [])
     attacks = output.get("attacks", [])
     # Store primary framework with actual arguments and attacks
-    state.add_dung_framework(
-        name=f"verification_{semantics}",
-        arguments=arguments if isinstance(arguments, list) else [],
-        attacks=attacks if isinstance(attacks, list) else [],
-        extensions=extensions if isinstance(extensions, dict) else {},
-    )
+    df_ids = [
+        state.add_dung_framework(
+            name=f"verification_{semantics}",
+            arguments=arguments if isinstance(arguments, list) else [],
+            attacks=attacks if isinstance(attacks, list) else [],
+            extensions=extensions if isinstance(extensions, dict) else {},
+        )
+    ]
     # Store additional semantics if computed
     if isinstance(all_extensions, dict):
         for sem, ext in all_extensions.items():
             if sem != semantics and isinstance(ext, dict) and ext:
-                state.add_dung_framework(
-                    name=f"verification_{sem}",
-                    arguments=arguments if isinstance(arguments, list) else [],
-                    attacks=attacks if isinstance(attacks, list) else [],
-                    extensions=ext,
+                df_ids.append(
+                    state.add_dung_framework(
+                        name=f"verification_{sem}",
+                        arguments=arguments if isinstance(arguments, list) else [],
+                        attacks=attacks if isinstance(attacks, list) else [],
+                        extensions=ext,
+                    )
                 )
+    # #1698 (R791 item 1): the honest submitted/retained/dropped accounting
+    # reaches the curated surface the conclusion reads, not only the invoke
+    # output — and the internal-contradiction guard runs on each entry.
+    for df_id in df_ids:
+        _carry_attack_retention(state, df_id, output)
+        _guard_attack_contradiction(state, df_id, output, arguments)
 
 
 def _write_dung_arbitration_to_state(
@@ -1368,6 +1482,9 @@ def _write_setaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
             state.dung_frameworks[df_id]["formalism_specific"] = {
                 "set_attacks": sanitised,
             }
+    # #1698 (R791 item 1): carry the honest accounting onto the curated entry.
+    _carry_attack_retention(state, df_id, output)
+    _guard_attack_contradiction(state, df_id, output, output.get("arguments", []))
 
 
 def _write_weighted_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
@@ -1434,6 +1551,9 @@ def _write_weighted_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> No
             sidecar["weight_statistics"] = stats_clean
     if sidecar:
         state.dung_frameworks[df_id]["formalism_specific"] = sidecar
+    # #1698 (R791 item 1): carry the honest accounting onto the curated entry.
+    _carry_attack_retention(state, df_id, output)
+    _guard_attack_contradiction(state, df_id, output, output.get("arguments", []))
 
 
 def _write_social_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
@@ -1442,12 +1562,16 @@ def _write_social_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None
         return
     ranking = output.get("ranking", [])
     scores = output.get("scores", {})
-    state.add_dung_framework(
+    df_id = state.add_dung_framework(
         name="social_af",
         arguments=output.get("arguments", []),
         attacks=output.get("attacks", []),
         extensions={"social_ranking": ranking, "social_scores": scores},
     )
+    # #1698 (R791 item 1): carry the honest accounting onto the curated entry
+    # (no contradiction guard: social has ranking/scores, not acceptance
+    # extensions — _acceptance_member_lists yields nothing to compare).
+    _carry_attack_retention(state, df_id, output)
 
 
 def _write_eaf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/scripts/probe_attack_source_nature_split.py
+++ b/scripts/probe_attack_source_nature_split.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python
+"""#1698 (R791 item 2) — reproducible probe: dropped-edge split by source nature.
+
+The #1704 honest report (``attacks_submitted/retained/dropped``) counted how
+many attack candidates never reached the evaluated Dung-family graphs. Item 2
+splits that count by the *nature* of the synthetic source the producer minted:
+
+  * ``fallacy_*``   — fallacy detections with a resolvable target
+  * ``CA: ...``     — counter-argument text matches (``ca`` family)
+  * ``other``       — defensive bucket (unknown / malformed / upstream pairs)
+
+The split is declared at the annotation point (``_annotate_attack_retention``,
+where the candidates are in hand) as ``attacks_submitted_<nature>`` /
+``attacks_dropped_<nature>`` — reproducible by construction, never
+reconstructed post-hoc. This probe only READS those numeric keys off a state
+snapshot and aggregates them.
+
+Privacy HARD: this probe never reads, prints, or stores source strings — the
+``CA:`` sources embed counter-argument text (= corpus). It touches the numeric
+accounting keys only. If a snapshot predates the instrumentation, the probe
+reports the totals and an honest "per-nature split unavailable" note rather
+than fabricating a split (#1019).
+
+Usage:
+    python scripts/probe_attack_source_nature_split.py STATE.json [STATE2.json ...]
+    python scripts/probe_attack_source_nature_split.py --json STATE.json ...
+    python scripts/probe_attack_source_nature_split.py --snapshots iter42_snapshots.jsonl
+
+Input formats accepted:
+  * a plain ``UnifiedAnalysisState`` export (``to_json()`` output) — the
+    ``iter*_snapshots.jsonl`` ``state_snapshot`` payload;
+  * ``--snapshots``: an LLM-Judge ``iter*_snapshots.jsonl`` where each line is
+    ``{"document_name": ..., "state_snapshot": {...}}``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List, Optional
+
+# The accounting keys the probe reads. Counts only — never source text.
+_TOTAL_KEYS = ("attacks_submitted", "attacks_retained", "attacks_dropped")
+_NATURE_KEYS = (
+    ("attacks_submitted_fallacy", "attacks_dropped_fallacy"),
+    ("attacks_submitted_ca", "attacks_dropped_ca"),
+    ("attacks_submitted_other", "attacks_dropped_other"),
+)
+_NATURES = ("fallacy", "ca", "other")
+
+
+def _as_int(value: Any) -> Optional[int]:
+    """Accept ints only — a non-numeric accounting key is not a count we
+    aggregate (the probe must never guess)."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    return None
+
+
+def _collect_accounting(state: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Collect every dung-family accounting block in a state snapshot.
+
+    Sources, in preference order:
+      1. curated ``dung_frameworks[*]`` (the surface the conclusion reads,
+         carries the accounting since R791 item 1);
+      2. bulk ``formal_synthesis_reports[*].phase_results.*`` (invoke outputs).
+
+    Returns a list of dicts, each carrying totals + per-nature counts when
+    present (all ``None`` fields mean "keys absent — pre-instrumentation").
+    """
+    blocks: List[Dict[str, Any]] = []
+
+    def _add(surface: str, prefix: str, block: Dict[str, Any]) -> None:
+        submitted = _as_int(block.get("attacks_submitted"))
+        retained = _as_int(block.get("attacks_retained"))
+        dropped = _as_int(block.get("attacks_dropped"))
+        if submitted is None and retained is None and dropped is None:
+            return  # not an accounting block
+        by_nature: Dict[str, Dict[str, Optional[int]]] = {}
+        for nature, (sub_k, dropped_k) in zip(_NATURES, _NATURE_KEYS):
+            by_nature[nature] = {
+                "submitted": _as_int(block.get(sub_k)),
+                "dropped": _as_int(block.get(dropped_k)),
+            }
+        blocks.append(
+            {
+                "surface": surface,
+                "source": prefix,
+                "attacks_submitted": submitted,
+                "attacks_retained": retained,
+                "attacks_dropped": dropped,
+                "by_nature": by_nature,
+            }
+        )
+
+    # Since R791 item 1 the SAME declaration is projected on the curated
+    # ``dung_frameworks`` entry AND sits in the bulk ``phase_results`` — the
+    # probe aggregates PER SURFACE (no cross-surface dedup): counting both
+    # would double it, and the two surfaces agreeing is itself the check.
+    frameworks = state.get("dung_frameworks")
+    if isinstance(frameworks, dict):
+        for df_id, entry in frameworks.items():
+            if isinstance(entry, dict):
+                _add("curated", f"dung_frameworks[{df_id}]", entry)
+
+    reports = state.get("formal_synthesis_reports")
+    if isinstance(reports, list):
+        for rep in reports:
+            if not isinstance(rep, dict):
+                continue
+            phase_results = rep.get("phase_results")
+            if not isinstance(phase_results, dict):
+                continue
+            for axe, block in phase_results.items():
+                if isinstance(block, dict):
+                    _add("bulk", f"phase_results.{axe}", block)
+    return blocks
+
+
+def _aggregate(blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Sum totals + per-nature counts across blocks (None-aware)."""
+    out: Dict[str, Any] = {
+        "blocks": len(blocks),
+        "surfaces": {},
+        "nature_keys_present": False,
+    }
+    for surface in ("curated", "bulk"):
+        surface_blocks = [b for b in blocks if b.get("surface") == surface]
+        agg: Dict[str, Any] = {
+            "blocks": len(surface_blocks),
+            "attacks_submitted": 0,
+            "attacks_retained": 0,
+            "attacks_dropped": 0,
+            "by_nature": {n: {"submitted": 0, "dropped": 0} for n in _NATURES},
+        }
+        for b in surface_blocks:
+            for k in ("attacks_submitted", "attacks_retained", "attacks_dropped"):
+                v = b[k]
+                if v is not None:
+                    agg[k] += v
+            for nature in _NATURES:
+                for side in ("submitted", "dropped"):
+                    v = b["by_nature"][nature][side]
+                    if v is not None:
+                        agg["by_nature"][nature][side] += v
+                        out["nature_keys_present"] = True
+        out["surfaces"][surface] = agg
+    return out
+
+
+def _report_doc(name: str, blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
+    agg = _aggregate(blocks)
+    agg["document"] = name
+    return agg
+
+
+def _render_surface(title: str, agg: Dict[str, Any]) -> List[str]:
+    lines = [f"  {title} ({agg['blocks']} block(s)):"]
+    lines.append(
+        f"    totals: submitted={agg['attacks_submitted']} "
+        f"retained={agg['attacks_retained']} "
+        f"dropped={agg['attacks_dropped']}"
+    )
+    sub_f, drop_f = (
+        agg["by_nature"]["fallacy"]["submitted"],
+        agg["by_nature"]["fallacy"]["dropped"],
+    )
+    sub_c, drop_c = (
+        agg["by_nature"]["ca"]["submitted"],
+        agg["by_nature"]["ca"]["dropped"],
+    )
+    sub_o, drop_o = (
+        agg["by_nature"]["other"]["submitted"],
+        agg["by_nature"]["other"]["dropped"],
+    )
+    lines.append(
+        "    split by source nature (submitted / dropped):\n"
+        f"      fallacy: {sub_f} / {drop_f}\n"
+        f"      ca:      {sub_c} / {drop_c}\n"
+        f"      other:   {sub_o} / {drop_o}"
+    )
+    # Invariant: sum(natures) == submitted total (verifiable honesty).
+    sum_sub = sub_f + sub_c + sub_o
+    match = "OK" if sum_sub == agg["attacks_submitted"] else "MISMATCH"
+    lines.append(f"    invariant sum(natures) == submitted: {match}")
+    return lines
+
+
+def _render(agg: Dict[str, Any], as_json: bool) -> str:
+    if as_json:
+        return json.dumps(agg, ensure_ascii=False, indent=2)
+    lines = [f"document: {agg.get('document', '?')}"]
+    surfaces = agg.get("surfaces", {})
+    curated = surfaces.get("curated", {})
+    bulk = surfaces.get("bulk", {})
+    if curated:
+        lines.extend(_render_surface("curated surface", curated))
+    if bulk:
+        lines.extend(_render_surface("bulk phase_results", bulk))
+    if not lines[1:]:
+        lines.append("  no accounting blocks found")
+    if not agg["nature_keys_present"] and (curated or bulk):
+        lines.append(
+            "  per-nature split: UNAVAILABLE on this snapshot — the accounting "
+            "carries totals only (pre-#1698 R791 instrumentation). Re-run the "
+            "corpus with the instrumented producer to obtain the split; no "
+            "split is fabricated (#1019)."
+        )
+    return "\n".join(lines)
+
+
+def _load_snapshot(line: str) -> Dict[str, Any]:
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid JSON line: {exc}") from exc
+
+
+def _looks_like_state_payload(obj: Any) -> bool:
+    """A state export (``to_json()``) carries collection keys the probe reads
+    (``dung_frameworks`` / ``formal_synthesis_reports`` / ``counter_arguments``).
+    The LLM-Judge wrapper carries a ``state_snapshot`` field instead."""
+    if not isinstance(obj, dict):
+        return False
+    if "state_snapshot" in obj and isinstance(obj["state_snapshot"], dict):
+        return True
+    return any(
+        k in obj
+        for k in ("dung_frameworks", "formal_synthesis_reports", "counter_arguments")
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("paths", nargs="+", help="state JSON files")
+    parser.add_argument(
+        "--snapshots",
+        action="store_true",
+        help="paths are LLM-Judge iter*_snapshots.jsonl (one JSON object per line)",
+    )
+    parser.add_argument(
+        "--jsonl",
+        action="store_true",
+        help="paths are JSONL where each line is a state export (to_json output)",
+    )
+    parser.add_argument("--json", action="store_true", help="machine-readable output")
+    args = parser.parse_args(argv)
+
+    results: List[Dict[str, Any]] = []
+
+    for path in args.paths:
+        with open(path, encoding="utf-8") as f:
+            if args.snapshots:
+                for line in f:
+                    if not line.strip():
+                        continue
+                    raw = _load_snapshot(line)
+                    if not _looks_like_state_payload(raw):
+                        continue
+                    snapshot = raw.get("state_snapshot", raw)
+                    doc = str(raw.get("document_name", raw.get("document_index", "?")))
+                    blocks = _collect_accounting(snapshot)
+                    results.append(_report_doc(doc, blocks))
+            elif args.jsonl:
+                for line in f:
+                    if not line.strip():
+                        continue
+                    raw = _load_snapshot(line)
+                    if not _looks_like_state_payload(raw):
+                        continue
+                    snapshot = raw.get("state_snapshot", raw)
+                    doc = str(raw.get("document_name", raw.get("document_index", "?")))
+                    blocks = _collect_accounting(snapshot)
+                    results.append(_report_doc(doc, blocks))
+            else:
+                # Auto-detect: peek at the first non-blank line, dispatch.
+                first_obj = None
+                try:
+                    first_obj = json.load(f)
+                except json.JSONDecodeError:
+                    # Try JSONL fallback.
+                    f.seek(0)
+                    for line in f:
+                        if not line.strip():
+                            continue
+                        first_obj = _load_snapshot(line)
+                        break
+                if not _looks_like_state_payload(first_obj):
+                    print(f"{path}: not a state export (no state keys found)", file=sys.stderr)
+                    return 2
+                snapshot = first_obj.get("state_snapshot", first_obj)
+                doc = str(first_obj.get("document_name", path))
+                blocks = _collect_accounting(snapshot)
+                results.append(_report_doc(doc, blocks))
+
+    if not results:
+        print("no state snapshots found in the given paths", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(results, ensure_ascii=False, indent=2))
+        return 0
+    for agg in results:
+        print(_render(agg, as_json=False))
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py
@@ -459,3 +459,423 @@ class TestSoustractionNoGenuineRelations1629:
 
         assert sink["weighted"] == []
         assert output["attacks_submitted"] == 0
+
+
+# ============================================================
+# R791 item 1 — the honest report reaches the CURATED surface
+# (dung_frameworks[*], the one the conclusion reads)
+# ============================================================
+
+
+class TestCarryAttackRetentionWriters:
+    """#1698 (R791 item 1): the #1704 submitted/retained/dropped accounting
+    must reach ``dung_frameworks[*]`` — the surface the conclusion reads —
+    not only the invoke output persisted under ``formal_synthesis_reports``.
+    Built through the real ``UnifiedAnalysisState.add_dung_framework`` entry
+    point (anti-#1019: no dict-literal state)."""
+
+    def test_dung_writer_carries_accounting_onto_curated_entry(self) -> None:
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_dung_extensions_to_state,
+        )
+
+        state = UnifiedAnalysisState(initial_text="x")
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "attacks": [],
+            "extensions": {"grounded": ["a", "b"]},
+            # The #1704 accounting, as the producer now declares it.
+            "attacks_submitted": 2,
+            "attacks_retained": 0,
+            "attacks_dropped": 2,
+        }
+        _write_dung_extensions_to_state(output, state, {})
+        entry = next(iter(state.dung_frameworks.values()))
+        assert entry["attacks_submitted"] == 2
+        assert entry["attacks_retained"] == 0
+        assert entry["attacks_dropped"] == 2
+
+    def test_all_four_annotated_writers_carry_the_accounting(self) -> None:
+        """Dung, social, setaf, weighted all project the frozen subset — the
+        accounting must ride on each curated entry, not be writer-specific."""
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_dung_extensions_to_state,
+            _write_setaf_to_state,
+            _write_social_to_state,
+            _write_weighted_to_state,
+        )
+
+        cases = [
+            (
+                _write_dung_extensions_to_state,
+                {
+                    "semantics": "grounded",
+                    "arguments": ["a", "b"],
+                    "attacks": [],
+                    "extensions": {"grounded": ["a", "b"]},
+                },
+            ),
+            (
+                _write_social_to_state,
+                {"arguments": ["a", "b"], "attacks": [], "ranking": [], "scores": {}},
+            ),
+            (
+                _write_setaf_to_state,
+                {"semantics": "grounded", "arguments": ["a", "b"], "attacks": []},
+            ),
+            (
+                _write_weighted_to_state,
+                {"semantics": "grounded", "arguments": ["a", "b"], "attacks": []},
+            ),
+        ]
+        for writer, base in cases:
+            state = UnifiedAnalysisState(initial_text="x")
+            output = dict(base)
+            output.update(
+                {
+                    "attacks_submitted": 3,
+                    "attacks_retained": 1,
+                    "attacks_dropped": 2,
+                }
+            )
+            writer(output, state, {})
+            assert state.dung_frameworks, f"{writer.__name__} wrote nothing"
+            for entry in state.dung_frameworks.values():
+                assert entry["attacks_submitted"] == 3, writer.__name__
+                assert entry["attacks_retained"] == 1, writer.__name__
+                assert entry["attacks_dropped"] == 2, writer.__name__
+
+    def test_writer_does_not_synthesise_accounting_when_keys_absent(self) -> None:
+        """Absent keys ⇒ nothing carried: a legacy producer (or a writer path
+        without annotation) must not gain a fabricated accounting (#1019)."""
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_dung_extensions_to_state,
+        )
+
+        state = UnifiedAnalysisState(initial_text="x")
+        _write_dung_extensions_to_state(
+            {"semantics": "grounded", "arguments": ["a"], "attacks": []}, state, {}
+        )
+        entry = next(iter(state.dung_frameworks.values()))
+        assert "attacks_submitted" not in entry
+        assert "attacks_retained" not in entry
+        assert "attacks_dropped" not in entry
+
+
+# ============================================================
+# R791 item 3 — internal-contradiction guard (DoD item 4)
+# ============================================================
+
+
+class TestInternalContradictionGuard:
+    """#1698 DoD item 4: a framework that RETAINED edges yet whose acceptance
+    semantics all return the full inventory is internally contradictory — it
+    must be detected, not published as a normal verdict.
+
+    Armed by a framework that declares edges and accepts everything.
+    Substitution control: reverting the guard condition (e.g. dropping the
+    ``attacks_retained > 0`` gate or the ``all(members == inventory)`` check)
+    makes ``test_guard_detects_retained_edges_with_full_acceptance`` red.
+    """
+
+    def test_guard_detects_retained_edges_with_full_acceptance(self) -> None:
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_dung_extensions_to_state,
+        )
+
+        state = UnifiedAnalysisState(initial_text="x")
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "attacks": [["a", "b"]],  # a live edge IS in the frame
+            "extensions": {"grounded": ["a", "b"], "preferred": ["a", "b"]},
+            "attacks_submitted": 1,
+            "attacks_retained": 1,
+            "attacks_dropped": 0,
+        }
+        _write_dung_extensions_to_state(output, state, {})
+        entry = next(iter(state.dung_frameworks.values()))
+        assert entry["internal_contradiction"] is True
+        # The contradiction is declared in the trace, not silent (#1019).
+        assert any(
+            "contradiction interne" in str(t.get("summary", ""))
+            for t in state.analysis_trace
+        )
+
+    def test_guard_silent_when_zero_retained(self) -> None:
+        """submitted > 0 with retained == 0 is NOT a contradiction — it is the
+        honest empty report of #1704 doing its job (the edges never reached
+        the evaluated graph). This is the exact 3-corpus real shape."""
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_dung_extensions_to_state,
+        )
+
+        state = UnifiedAnalysisState(initial_text="x")
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "attacks": [],
+            "extensions": {"grounded": ["a", "b"]},
+            "attacks_submitted": 15,
+            "attacks_retained": 0,
+            "attacks_dropped": 15,
+        }
+        _write_dung_extensions_to_state(output, state, {})
+        entry = next(iter(state.dung_frameworks.values()))
+        assert "internal_contradiction" not in entry
+
+    def test_guard_silent_when_some_semantics_exclude(self) -> None:
+        """A framework whose semantics discriminate (at least one excludes
+        something) is healthy — no contradiction."""
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_dung_extensions_to_state,
+        )
+
+        state = UnifiedAnalysisState(initial_text="x")
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "attacks": [["a", "b"]],
+            "extensions": {"grounded": ["a"], "preferred": ["a"]},
+            "attacks_submitted": 1,
+            "attacks_retained": 1,
+            "attacks_dropped": 0,
+        }
+        _write_dung_extensions_to_state(output, state, {})
+        entry = next(iter(state.dung_frameworks.values()))
+        assert "internal_contradiction" not in entry
+
+    def test_guard_silent_without_accounting_keys(self) -> None:
+        """No accounting keys ⇒ guard has nothing to judge (never flags on a
+        producer that did not run the annotation)."""
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_dung_extensions_to_state,
+        )
+
+        state = UnifiedAnalysisState(initial_text="x")
+        _write_dung_extensions_to_state(
+            {
+                "semantics": "grounded",
+                "arguments": ["a", "b"],
+                "attacks": [["a", "b"]],
+                "extensions": {"grounded": ["a", "b"]},
+            },
+            state,
+            {},
+        )
+        entry = next(iter(state.dung_frameworks.values()))
+        assert "internal_contradiction" not in entry
+
+
+# ============================================================
+# R791 item 2 — dropped-edge split by source nature
+# (fallacy_* vs CA: vs other) — producer side + probe side
+# ============================================================
+
+
+class TestAttackSourceNatureSplit:
+    """#1698 (R791 item 2): the accounting is split by the NATURE of the
+    synthetic source the producer minted (``fallacy_*`` / ``CA: ...`` /
+    ``other``). The split is declared at the annotation point where the
+    candidates are in hand — reproducible by construction, never
+    reconstructed post-hoc. Keys are counts only: the ``CA:`` sources embed
+    counter-argument text (= corpus) and must never be printed."""
+
+    def test_source_nature_classification(self) -> None:
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _attack_source_nature,
+        )
+
+        assert _attack_source_nature("fallacy_0_ad_hominem") == "fallacy"
+        assert _attack_source_nature("CA: contredit cette affirmation") == "ca"
+        # A real inventory member (upstream-provided context["attacks"]) or a
+        # malformed source lands in the defensive ``other`` bucket.
+        assert _attack_source_nature("arg_1") == "other"
+        assert _attack_source_nature(None) == "other"
+        assert _attack_source_nature("") == "other"
+
+    def test_annotation_splits_by_nature_all_dropped(self) -> None:
+        """Mixed candidates with synthetic sources: every edge is dropped (the
+        sources are never inventory members) — the split reflects each
+        family's submitted count."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _annotate_attack_retention,
+        )
+
+        candidates = [
+            ["fallacy_0_ad_hominem", "a"],
+            ["fallacy_1_faux_dilemme", "b"],
+            ["CA: contredit cette affirmation", "a"],
+            ["c", "a"],  # real member source → other, retained
+        ]
+        output = _annotate_attack_retention(
+            {}, ["a", "b", "c"], candidates, framework_name="test"
+        )
+        assert output["attacks_submitted"] == 4
+        assert output["attacks_retained"] == 1
+        assert output["attacks_dropped"] == 3
+        assert output["attacks_submitted_fallacy"] == 2
+        assert output["attacks_dropped_fallacy"] == 2
+        assert output["attacks_submitted_ca"] == 1
+        assert output["attacks_dropped_ca"] == 1
+        assert output["attacks_submitted_other"] == 1
+        assert output["attacks_dropped_other"] == 0
+        # Invariant: the split recomposes the totals (verifiable honesty).
+        assert (
+            output["attacks_submitted_fallacy"]
+            + output["attacks_submitted_ca"]
+            + output["attacks_submitted_other"]
+            == output["attacks_submitted"]
+        )
+        assert (
+            output["attacks_dropped_fallacy"]
+            + output["attacks_dropped_ca"]
+            + output["attacks_dropped_other"]
+            == output["attacks_dropped"]
+        )
+
+    def test_annotation_splits_setaf_shapes(self) -> None:
+        """SetAF specs carry the source under ``attackers`` — the split must
+        classify the same way as pairs."""
+        from argumentation_analysis.orchestration.invoke_callables import (
+            _annotate_attack_retention,
+        )
+
+        candidates = [
+            {"attackers": ["CA: contredit ce point"], "target": "a"},
+            {"attackers": ["fallacy_0_generalisation"], "target": "b"},
+        ]
+        output = _annotate_attack_retention(
+            {}, ["a", "b"], candidates, framework_name="test"
+        )
+        assert output["attacks_submitted_fallacy"] == 1
+        assert output["attacks_dropped_fallacy"] == 1
+        assert output["attacks_submitted_ca"] == 1
+        assert output["attacks_dropped_ca"] == 1
+
+
+class TestAttackSourceNatureProbe:
+    """The probe is a READ-ONLY reader of the numeric accounting keys — it
+    aggregates counts by surface (curated vs bulk) and never touches source
+    strings (#1698 privacy HARD: ``CA:`` embeds corpus text)."""
+
+    def _probe(self) -> Any:
+        from scripts.probe_attack_source_nature_split import (
+            _aggregate,
+            _collect_accounting,
+        )
+
+        return _collect_accounting, _aggregate
+
+    def test_probe_reads_split_off_a_real_state(self) -> None:
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_dung_extensions_to_state,
+        )
+
+        collect, aggregate = self._probe()
+        state = UnifiedAnalysisState(initial_text="x")
+        output = {
+            "semantics": "grounded",
+            "arguments": ["a", "b"],
+            "attacks": [],
+            "extensions": {"grounded": ["a", "b"]},
+            "attacks_submitted": 3,
+            "attacks_retained": 0,
+            "attacks_dropped": 3,
+            "attacks_submitted_fallacy": 2,
+            "attacks_dropped_fallacy": 2,
+            "attacks_submitted_ca": 1,
+            "attacks_dropped_ca": 1,
+            "attacks_submitted_other": 0,
+            "attacks_dropped_other": 0,
+        }
+        _write_dung_extensions_to_state(output, state, {})
+        # Same declaration also lands in the bulk phase_results — the probe
+        # reports each surface separately, never double-counting.
+        state.add_formal_synthesis_report("synthesis", {"dung_grounded": output}, 0.0)
+
+        blocks = collect(state.get_state_snapshot())
+        agg = aggregate(blocks)
+        curated = agg["surfaces"]["curated"]
+        bulk = agg["surfaces"]["bulk"]
+        assert curated["attacks_submitted"] == 3
+        assert curated["by_nature"]["fallacy"] == {"submitted": 2, "dropped": 2}
+        assert curated["by_nature"]["ca"] == {"submitted": 1, "dropped": 1}
+        assert bulk["attacks_submitted"] == 3
+        assert bulk["by_nature"]["fallacy"] == {"submitted": 2, "dropped": 2}
+        assert agg["nature_keys_present"] is True
+
+    def test_probe_honest_when_split_absent(self) -> None:
+        """Pre-instrumentation snapshots carry totals only — the probe says so
+        instead of fabricating a split (#1019)."""
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_dung_extensions_to_state,
+        )
+        from scripts.probe_attack_source_nature_split import _render
+
+        collect, aggregate = self._probe()
+        state = UnifiedAnalysisState(initial_text="x")
+        _write_dung_extensions_to_state(
+            {
+                "semantics": "grounded",
+                "arguments": ["a", "b"],
+                "attacks": [],
+                "extensions": {"grounded": ["a", "b"]},
+                "attacks_submitted": 15,
+                "attacks_retained": 0,
+                "attacks_dropped": 15,
+            },
+            state,
+            {},
+        )
+        blocks = collect(state.get_state_snapshot())
+        agg = aggregate(blocks)
+        assert agg["nature_keys_present"] is False
+        assert "UNAVAILABLE" in _render({"document": "doc", **agg}, as_json=False)
+
+    def test_probe_never_leaks_ca_source_text(self) -> None:
+        """The probe output must never contain the ``CA:`` source string —
+        it embeds counter-argument text (= corpus)."""
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_dung_extensions_to_state,
+        )
+        from scripts.probe_attack_source_nature_split import _render
+
+        collect, aggregate = self._probe()
+        state = UnifiedAnalysisState(initial_text="x")
+        secret = "CA: contenu contre-argumentaire sensible non publiable"
+        _write_dung_extensions_to_state(
+            {
+                "semantics": "grounded",
+                "arguments": ["a", "b"],
+                "attacks": [[secret, "a"]],  # the CA source IS in the state
+                "extensions": {"grounded": ["a", "b"]},
+                "attacks_submitted": 1,
+                "attacks_retained": 0,
+                "attacks_dropped": 1,
+                "attacks_submitted_ca": 1,
+                "attacks_dropped_ca": 1,
+                "attacks_submitted_fallacy": 0,
+                "attacks_dropped_fallacy": 0,
+                "attacks_submitted_other": 0,
+                "attacks_dropped_other": 0,
+            },
+            state,
+            {},
+        )
+        blocks = collect(state.get_state_snapshot())
+        agg = aggregate(blocks)
+        rendered = _render({"document": "doc", **agg}, as_json=False)
+        assert "contenu contre-argumentaire" not in rendered
+        assert "ca:      1 / 1" in rendered  # nature KEY yes, source text no


### PR DESCRIPTION
## Scope

R791 dispatch #1698, three items delivered in one commit.

| Item | Scope | Status |
|------|-------|--------|
| 1 | The #1704 honest accounting reaches `dung_frameworks[*]` (the surface the conclusion reads), not only the bulk invoke output | DONE |
| 2 | Dropped-edge split by source nature (`fallacy_*` / `CA: ...` / `other`), reproducible by construction | DONE |
| 3 | Internal-contradiction guard (DoD item 4) — a framework that retains edges yet accepts the full inventory is detected, not published | DONE |

## DoD checklist

- [x] (a) `dung_frameworks[*]` carries the declaration — verified on real `UnifiedAnalysisState` via `add_dung_framework` (anti-#1019: no dict-literal fixture)
- [x] (b) Dropped-edge split by source nature, declared at the annotation point (`_annotate_attack_retention`) — invariant `sum(natures) == submitted` verified by test
- [x] (c) Contradiction guard + its test armed by a framework that declares edges and accepts everything (`test_guard_detects_retained_edges_with_full_acceptance`)
- [x] (d) Substitution control: reverting the guard condition to `if False:` makes the armed test red; restoring it makes it green again

## Files

- `argumentation_analysis/orchestration/invoke_callables.py` — new `_attack_source_nature` classifier + per-nature split in `_annotate_attack_retention` (51 lines)
- `argumentation_analysis/orchestration/state_writers.py` — new `_carry_attack_retention`, `_acceptance_member_lists`, `_guard_attack_contradiction` helpers + 4 writer call sites (137 lines)
- `scripts/probe_attack_source_nature_split.py` — reproducible probe (313 lines), reads numeric accounting keys only, auto-detects bare `to_json()` vs LLM-Judge `iter*_snapshots.jsonl`
- `tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py` — 13 new tests, 34/34 green in the file

## MUST NOT (verified)

- No promotion of `fallacy_*` to argument nodes (R757 circular authority)
- No `CA:` source string ever leaves the producer — verified by `test_probe_never_leaks_ca_source_text` (probe output never contains the source text, only the count under the `ca:` key)
- No fabricated accounting: the carry is no-op when keys absent (legacy producer path stays untouched)
- No number-is-spurious on weighted/corpus_C (n=1) — the probe reports only what the accounting declares

## Reproducibility

The probe is reproducible by design — it does not depend on JVM/Tweety/LLM. It reads the numeric accounting keys off a state snapshot and aggregates them. Re-running on the live corpus (the next iteration) closes the only remaining item 2 step (coord executes on ai-01's real state, since 3-corpus snapshots live on ai-01 scratchpad only).

```bash
# Bare state JSON
python scripts/probe_attack_source_nature_split.py state.json
# LLM-Judge iter*_snapshots.jsonl
python scripts/probe_attack_source_nature_split.py --snapshots iter42_snapshots.jsonl
```

## Tests / mypy

- `pytest tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py`: 34 passed
- `mypy --strict argumentation_analysis/orchestration/state_writers.py argumentation_analysis/orchestration/invoke_callables.py`: Success, no issues

## Privacy HARD (verified)

- `CA:` source strings never appear in curated entries, accounting payloads, or probe output
- Test `test_probe_never_leaks_ca_source_text` asserts the source text ("contenu contre-argumentaire sensible non publiable") never appears in the rendered probe output, even when it IS in the state
- Probe output uses the nature KEY only — the source string is corpus text

## Dispatch

Closes R791 dispatch #1698 item 1, item 2 (probe side), item 3. Item 2 measurement on the 3 live corpora remains a coordination step (the corpora live on ai-01 scratchpad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
