### PR TITLE
test(1646): paired-run on producer-built states — minimal-retraction differentiation (incr 4)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_belief_revision_paired_run_1646_inc4.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_belief_revision_paired_run_1646_inc4.py
@@ -1,0 +1,336 @@
+"""#1646 incr 4 — paired-run: minimal-retraction end-to-end on producer-built states.
+
+Incr 1+2+3 (PRs #1689, #1691, #1701) computed the minimal-retraction as a pure
+function, wired it through the producer / state / bridge / reader pipeline, and
+proved it on unit fixtures. What remains unmeasured is the **end-to-end
+differential**: given a real producer invocation, does the insight say something
+that the upstream evidence (the planted fallacies) does not already say?
+
+The R791 framing refinement is the heart of this test: on real corpora, the
+upstream argument inventory is empty (0/21 propositions, #1710) — so any
+contradiction measured today comes from a *planted* fallacy. The question is
+therefore **not** "did the retraction find something?" (the plant guarantees
+yes) but **"what does the insight name that the plant did not put there?"**
+
+The test is **paired**: a control run with no fallacies (the D-forensic baseline
+where the base is consistent and the insight is empty) and a planted run where
+the base is genuinely inconsistent (one or two fallacies on distinct beliefs).
+The differential is the concrete answer to R791:
+
+| Planted | Insight (planted) | Insight (control) | What the insight says the plant did not |
+|---|---|---|---|
+| 1 fallacy on 1 belief | cardinality 1, options touch the clashing pair | empty (no fallacy path) | **the base is inconsistent** + **the cardinality is 1**, not "there is a fallacy" — the fallacy is the upstream input, the inconsistency is the property the insight derives |
+| 2 fallacies on 2 beliefs | cardinality 2, options isolated to the 2 clash pairs | empty | **the two clashes are independent** (both must be given up, no single removal restores consistency) — the plant says "two fallacies", the insight says "two independent inconsistencies" |
+| 1 fallacy on 1 belief + 5 inert beliefs | cardinality 1, options never touch the 5 inert beliefs | empty | **the contradiction is inert** w.r.t. the unrevised beliefs — the discrimination is "what survives?", not "what clashes?" |
+
+This is the B-3 inert-contradiction output the reader cannot produce from any
+of PL/UNSAT, the LLM "find contradictions" prompt, or the Tweety Levi handler.
+The paired-run is the first place those properties are measured *as a
+differential against a real run*, not as a property of an isolated pure function.
+
+The harness deliberately bypasses the corpus runner (#1697 / no live JVM on this
+worker) and calls the producer directly on a state built by the real
+``add_jtms_belief`` / ``add_fallacy`` public APIs. The fixtures are producer-
+faithful (the producer is the one wired by #1701): every shape is the shape it
+runs on, the only difference between the two runs is the planted fallacy.
+
+Privacy HARD: no fixture carries NL source text. The belief names are synthetic
+opaque labels (the producer treats them as opaque; the reader renders them
+verbatim into the Acte III finding, which is the entire point of B-1 — the
+insight names the rupture point in the corpus' own vocabulary, not in a
+privatised form). The artefact paths are gitignored.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.orchestration.conversational_orchestrator import (
+    _run_belief_revision_from_state,
+)
+
+# Synthetic opaque belief labels — never NL source text. The producer treats
+# these as opaque strings; the reader uses them as the rupture-point name in
+# the Acte III finding (insight B-1). The fact that they are *not* real NL is
+# what makes the privacy claim honest in this test.
+BELIEF_LABELS = [
+    "claim_alpha",
+    "claim_beta",
+    "claim_gamma",
+    "claim_delta",
+    "claim_epsilon",
+]
+
+
+def _build_state(fallacy_targets: List[str]) -> UnifiedAnalysisState:
+    """Build a producer-fed state with the given planted fallacy targets.
+
+    ``fallacy_targets`` is a list of **belief names** the fallacy undermines.
+    Empty list = control run (no fallacies ⇒ producer returns None, the
+    ``belief_revision_results`` stays empty — the D-forensic baseline where the
+    base is trivially consistent and the minimal-retraction insight is ∅).
+
+    Each belief is a valid JTMS belief in the upstream inventory; the producer
+    consumes ``state.jtms_beliefs`` to build the original-belief list that
+    ``build_belief_base`` operates on. The ``target_argument_id`` argument of
+    ``add_fallacy`` is the belief name as the producer matches it (l.3202:
+    ``bname == target_arg or target_arg in bname``), so setting it to the
+    belief name is the honest way to plant the contradiction.
+    """
+    state = UnifiedAnalysisState("initial text")
+    for name in BELIEF_LABELS:
+        state.add_jtms_belief(name, valid=True, justifications=[f"src:{name}"])
+    for i, target in enumerate(fallacy_targets):
+        state.add_fallacy(
+            fallacy_type="ad_hominem",
+            justification=f"planted fallacious attack targeting {target}",
+            target_arg_id=target,
+            family="relevance",
+            taxonomy_path="relevance.ad_hominem",
+        )
+    return state
+
+
+def _drain_state(state: UnifiedAnalysisState) -> List[Dict[str, Any]]:
+    """Return belief_revision_results as a list of plain dicts (test-friendly)."""
+    return [dict(entry) for entry in state.belief_revision_results]
+
+
+class TestPairedRunNoFallacyIsTheBaseline:
+    """Control: no fallacy ⇒ empty belief_revision_results, no insight.
+
+    The D-forensic measured that without fallacies the base is trivially
+    consistent and the producer returns ``None`` (the first guard, l.3160).
+    This pins the runner contract: the planted-run differential is measured
+    against a *non-empty* baseline, not a fabricated one.
+    """
+
+    def test_control_returns_nothing(self) -> None:
+        state = _build_state(fallacy_targets=[])
+        result = _run_belief_revision_from_state(state)
+        assert result is None, (
+            "the first producer guard is `if not fallacies: return None`; the "
+            "control run must not produce a result entry, else the differential "
+            "below is noise on a non-empty baseline."
+        )
+        assert _drain_state(state) == [], (
+            "control run must leave belief_revision_results empty; a non-empty "
+            "baseline would mean every other 'delta' is a fabrication."
+        )
+
+
+class TestPairedRunCardinalityOne:
+    """Planted: 1 fallacy on 1 belief ⇒ cardinality 1, options isolate the clash.
+
+    The plant puts ONE fallacy on ONE belief. The differential = the base is
+    inconsistent (the insight) + the cardinality is 1 (the insight) + the
+    rupture point is *the clashing pair* (the belief OR its negation — the
+    retraction choices are structural, not planted).
+    """
+
+    def test_planted_run_is_non_empty(self) -> None:
+        state = _build_state(fallacy_targets=[BELIEF_LABELS[0]])
+        result = _run_belief_revision_from_state(state)
+        # The producer must populate the entry (the planted contradiction is real).
+        assert (
+            result is not None
+        ), "planted run with a real fallacy produced None — the wiring is dead."
+        entries = _drain_state(state)
+        assert len(entries) == 1
+        # The original-beleifs list is the full JTMS inventory (5 names).
+        assert len(entries[0]["original"]) == len(BELIEF_LABELS)
+
+    def test_minimal_retraction_is_non_empty(self) -> None:
+        # R791 DoD item 1: the retraction is non-empty on the planted run.
+        state = _build_state(fallacy_targets=[BELIEF_LABELS[0]])
+        _run_belief_revision_from_state(state)
+        entry = _drain_state(state)[0]
+        mr = entry["minimal_retraction"]
+        assert mr is not None, (
+            "minimal_retraction is missing from the planted-run entry — the "
+            "wiring did not carry the insight through. #1701 said it would."
+        )
+
+    def test_insight_is_not_just_a_plant_echo(self) -> None:
+        """R791 DoD item 3: the insight says something the plant did not put there.
+
+        The plant put ONE fallacy on ONE belief. The insight reports a
+        **cardinality** (1) and **options** (which beliefs to give up). Both are
+        aspects of the *structure* of the base, not aspects of the upstream
+        evidence: the plant says "fallacy on alpha", the insight says
+        "the base is inconsistent at cardinality 1, with these rupture options".
+        That difference IS the minimal-retraction contribution.
+        """
+        state = _build_state(fallacy_targets=[BELIEF_LABELS[0]])
+        _run_belief_revision_from_state(state)
+        mr = _drain_state(state)[0]["minimal_retraction"]
+
+        # The plant specifies a fallacy on alpha; the insight isolates the
+        # clash. The clash has TWO relief points (alpha OR ¬alpha) — the
+        # plant says "alpha is undermined", the insight says "to restore
+        # consistency you must choose: drop alpha OR drop the negation that
+        # fallacy added (call it ¬alpha)". The multiplicity is structural.
+        assert mr["cardinality"] == 1, (
+            f"cardinality {mr['cardinality']} != 1 — one fallacy on one belief "
+            "yields exactly one remaining clause to retract."
+        )
+        # Every option is a single belief (the cardinality-1 guarantee).
+        assert all(len(opt) == 1 for opt in mr["options"]), (
+            f"options {mr['options']} are not all singletons — the "
+            "cardinality-1 guarantee is violated."
+        )
+        # The optional readings are limited to the clashing pair (alpha or its
+        # negation). NO inert belief (beta, gamma, delta, epsilon) ever
+        # appears in any option — this is B-3 inert-contradiction in practice.
+        clashing = {BELIEF_LABELS[0], f"¬{BELIEF_LABELS[0]}"}
+        for opt in mr["options"]:
+            for belief in opt:
+                assert belief in clashing, (
+                    f"belief {belief!r} is NOT in the clashing pair {clashing} — "
+                    "the insight is going wider than the plant, which means the "
+                    "minimal-retraction has reached beyond the contradiction "
+                    "(the base has more than one clash, contradicting the "
+                    "test premise)."
+                )
+
+    def test_structural_property_base_size_and_touched_count(self) -> None:
+        """R791 DoD item 4: every number carries its n.
+
+        The insight carries three integers: cardinality, base_size, touched_count.
+        Their meanings are:
+        - cardinality = 1 (the answer)
+        - base_size = 6 (5 original + 1 negation from the plant)
+        - touched_count = 2 (the two singletons-alpha + ¬alpha — both are
+          "touched" by the answer, even though only one is dropped)
+
+        The plant put ONE fallacy. The insight says the answer is "1 of these 6,
+        but EVERY option touches either alpha or ¬alpha". The 2 of the 6 is
+        derivable from the plant (the negation clause was added by the plant),
+        but the *answer set* (alpha OR ¬alpha, never both, never anything else)
+        is not in the plant.
+        """
+        state = _build_state(fallacy_targets=[BELIEF_LABELS[0]])
+        _run_belief_revision_from_state(state)
+        mr = _drain_state(state)[0]["minimal_retraction"]
+        assert mr["base_size"] == len(BELIEF_LABELS) + 1, (
+            f"base_size {mr['base_size']} != {len(BELIEF_LABELS) + 1} — "
+            "5 original beliefs + 1 negation from the plant."
+        )
+        assert (
+            mr["touched_count"] == 2
+        ), f"touched_count {mr['touched_count']} != 2 — should be alpha + ¬alpha."
+        assert mr["degraded"] is False
+
+
+class TestPairedRunCardinalityTwo:
+    """Planted: 2 fallacies on 2 beliefs ⇒ cardinality 2, options isolate the 2.
+
+    The plant puts TWO fallacies on TWO distinct beliefs. The differential:
+    the two clashes are **independent** (no single removal restores
+    consistency; both must be given up). The plant says "two fallacies", the
+    insight says "these are two independent inconsistencies" — independence is
+    not in the plant.
+    """
+
+    def test_two_independent_clashes_need_cardinality_two(self) -> None:
+        state = _build_state(fallacy_targets=[BELIEF_LABELS[0], BELIEF_LABELS[1]])
+        _run_belief_revision_from_state(state)
+        mr = _drain_state(state)[0]["minimal_retraction"]
+        assert mr["cardinality"] == 2, (
+            f"cardinality {mr['cardinality']} != 2 — two independent clashes "
+            "require two removals; the insight is reporting one. This is the "
+            "minimality guarantee: the search did not stop at a non-restoring "
+            "cardinal-1 guess."
+        )
+        # Every option is a pair.
+        assert all(len(opt) == 2 for opt in mr["options"])
+        # The clashing pairs are mirror-symmetric: (alpha OR ¬alpha) AT LEAST
+        # one is in every option, AND (beta OR ¬beta) AT LEAST one is in every
+        # option. The plant does not say "one from each clash", only "fallacy on
+        # alpha and fallacy on beta" — the *distribution* across clashes is
+        # structural: each option must touch both.
+        clashing_a = {BELIEF_LABELS[0], f"¬{BELIEF_LABELS[0]}"}
+        clashing_b = {BELIEF_LABELS[1], f"¬{BELIEF_LABELS[1]}"}
+        for opt in mr["options"]:
+            touches_a = any(b in clashing_a for b in opt)
+            touches_b = any(b in clashing_b for b in opt)
+            assert touches_a and touches_b, (
+                f"option {opt} does not touch BOTH clashes — insight is "
+                "missing one of the two independent inconsistencies."
+            )
+        # base_size = 5 original + 2 negations = 7; touched_count = 4.
+        assert mr["base_size"] == len(BELIEF_LABELS) + 2
+        assert mr["touched_count"] == 4
+
+
+class TestPairedRunInertBeliefsSurvive:
+    """Differential on inert beliefs: the retraction never touches them.
+
+    The reader's B-3 inert-contradiction insight — "the contradiction is real
+    but its retraction leaves the unrevised beliefs untouched" — is exactly
+    the asymmetry the plant does not state. Five beliefs, one fallacy (on
+    alpha). The plant says "alpha is undermined". The insight says "alpha
+    clashes; beta, gamma, delta, epsilon are inert under this retraction".
+    """
+
+    @pytest.mark.parametrize("target", BELIEF_LABELS)
+    def test_inert_beliefs_never_appear_in_any_option(self, target: str) -> None:
+        """Parametrised over the planted target — the inert set is invariant.
+
+        Whatever belief is targeted, the options never reach the others. This
+        is the B-3 inert-contradiction: the rupture is local to the targeted
+        pair, the rest of the base is untouched. The plant says "this belief";
+        the insight says "ONLY this belief (and its negation)". The "only" is
+        the structural contribution.
+        """
+        state = _build_state(fallacy_targets=[target])
+        _run_belief_revision_from_state(state)
+        mr = _drain_state(state)[0]["minimal_retraction"]
+        inert = set(BELIEF_LABELS) - {target}
+        for opt in mr["options"]:
+            for belief in opt:
+                assert belief not in inert, (
+                    f"option {opt} contains inert belief {belief!r} — the "
+                    "minimal-retraction is reaching beyond the clashing pair."
+                )
+
+
+class TestPairedRunNonVacuous:
+    """The producer wiring is exercised; the test is not vacuous.
+
+    If the producer's wiring of ``minimal_retraction`` is dead (e.g. a
+    refactor that drops the call to ``build_belief_base`` /
+    ``minimal_retractions``), the planted run still returns a result entry
+    (the AGM contraction path runs), but without the insight. The previous
+    tests pin the entry's *shape*; this one pins the *insight-bearing slot*
+    — if it is missing, the wiring is broken even if the AGM path is alive.
+    """
+
+    def test_contraction_result_carries_minimal_retraction_slot(self) -> None:
+        state = _build_state(fallacy_targets=[BELIEF_LABELS[0]])
+        _run_belief_revision_from_state(state)
+        entries = _drain_state(state)
+        assert len(entries) == 1
+        assert "minimal_retraction" in entries[0], (
+            "the producer ran the contraction but did not carry the "
+            "minimal_retraction slot — the #1701 wiring is broken on the "
+            "conversational path (R787 insight measured surviving both producers)."
+        )
+
+    def test_degraded_flag_is_false_on_healthy_run(self) -> None:
+        """A degraded dossier (cardinality -1, no options) would mean the
+        pysat import failed (#1697 cascade) — the reader would have nothing to
+        name. On this worker the import is healthy; the test is the control
+        that catches an environment regression.
+        """
+        state = _build_state(fallacy_targets=[BELIEF_LABELS[0]])
+        _run_belief_revision_from_state(state)
+        mr = _drain_state(state)[0]["minimal_retraction"]
+        assert mr["degraded"] is False, (
+            "minimal_retraction.degraded=True on a healthy python-sat env "
+            "— the import guard fired unexpectedly. The reader would be "
+            "mute on this run; investigate the #1697 cascade at the entry."
+        )

--- a/tests/unit/argumentation_analysis/orchestration/test_belief_revision_planted_text_1646.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_belief_revision_planted_text_1646.py
@@ -1,0 +1,325 @@
+"""#1646 incr 4 — planted-text paired-run differentiation (the empirical DoD).
+
+Incr 1/2/3 (merged) pin the belief-revision insight as:
+
+* a pure JVM-free function — ``minimal_retractions`` / ``build_belief_base``
+  (kill-set A, ``test_belief_revision_insight_1646``);
+* the producer → bridge → reader → privacy wiring with **hand-injected state**
+  (kill-set B, ``test_belief_revision_wiring_1646``).
+
+What those tests do NOT prove, and what this file does, is the DoD's empirical
+claim (issue #1646):
+
+* « Texte planté écrit, différenciation mesurée sur run apparié » — on a
+  **planted text** whose inconsistency is real but non-trivial (it emerges from
+  a fallacy undermining a headlined proposition, NOT from "A and ¬A" two
+  sentences apart), the insight FIRES through the same JVM-free chain the wired
+  pipeline runs, and the differentiation against the pre-#1646 baseline is
+  MEASURED, not asserted a priori.
+* « Le cas "contradiction inerte" (insight 3) est testé explicitement » — the
+  B-3 inert signal is DISCRIMINATING (it distinguishes two planted texts that a
+  pure UNSAT oracle reads identically), not just always-on.
+
+The chain under test (the insight-specific path, JVM-free by construction — the
+#1645 lesson, restated in ``belief_revision_insight.py``)::
+
+    planted args + fallacy-negated index
+        → build_belief_base          # the producer's base construction (incr 2)
+        → minimal_retractions        # the MCS computation (incr 1)
+        → producer-shaped mr dict    # named options + touched_count (incr 3)
+        → _belief_revision_finding   # the Act III reader NAMES it (incr 3)
+
+The **baseline** is what the chain had before #1646: ``build_belief_base(args,
+[])`` produced an all-positive base (``_pl_atom`` laundered the fallacy back to
+a positive atom — the D-forensic Lock 1), which is trivially SAT, so
+``minimal_retractions`` returned cardinal 0 and the reader was silent. A PL/UNSAT
+oracle, available pre-#1646, returned a bare boolean. The paired run contrasts
+the two arms on the SAME planted text.
+
+Opaque synthetic claims only (privacy HARD): no corpus text, no source-derived
+atoms — the labels are structural placeholders. No JVM, no API key.
+
+Out of scope for incr 4 (planted-text), stated honestly:
+* DoD item F « Corpus réel » — real-corpus runs are data-gated on ai-01 (same
+  path as #1668). The R781 D/E forensic showed real-run bases are all-positive
+  until a fallacy targets a headlined proposition; the planted text simulates
+  exactly that trigger without needing the corpus.
+* B-1 *unique* retraction (reader lead « une seule proposition suffit… » with a
+  single option) — ``build_belief_base`` represents a fallacy as {[i], [-i]},
+  which always yields ≥ 2 cardinal-1 retractions (drop the belief OR its
+  negation), so the honest planted-text figure is B-2 (non-unique) + B-3 (inert).
+  Forcing a degenerate single-option base to trip B-1 would be the #1019
+  anti-pattern; B-1-unique stays covered by the injected-state wiring test.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List, Sequence, Tuple
+
+from argumentation_analysis.agents.core.logic.belief_revision_insight import (
+    build_belief_base,
+    minimal_retractions,
+)
+from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+    _belief_revision_finding,
+)
+
+# ---------------------------------------------------------------------------
+# Chain harness — mirrors the producer shaping (invoke_callables l.4204-4217)
+# so the test exercises the REAL dict the wired pipeline stores, not a hand
+# -built surrogate.
+# ---------------------------------------------------------------------------
+
+
+def _sat_oracle(base: List[List[int]]) -> bool:
+    """The pre-#1646 PL signal: a bare satisfiability boolean (Glucose3, the
+    same oracle ``minimal_retractions`` uses). This is ALL a UNSAT check gives
+    you — no named belief, no cardinality, no survivor count."""
+    from pysat.solvers import Glucose3
+
+    if not base:
+        return True
+    with Glucose3(bootstrap_with=base) as solver:
+        return bool(solver.solve())
+
+
+def _insight_chain(
+    args: Sequence[str], negated_indices: Sequence[int]
+) -> Tuple[List[List[int]], List[str], Dict[str, Any]]:
+    """Run the full JVM-free insight chain on a planted argument set.
+
+    Returns ``(base, names, mr_dict)`` where ``mr_dict`` is shaped exactly as the
+    producer shapes it (``invoke_callables._invoke_belief_revision`` l.4204-4217):
+    cardinality, NAMED options (so the reader can name the rupture), base_size,
+    and touched_count (which drives the B-3 inert signal).
+    """
+    base, names = build_belief_base(args, negated_indices)
+    card, options = minimal_retractions(base)
+    named_options = [[names[i] for i in opt] for opt in options]
+    touched = len({i for opt in options for i in opt})
+    mr = {
+        "cardinality": card,
+        "options": named_options,
+        "base_size": len(base),
+        "touched_count": touched,
+        "degraded": False,
+    }
+    return base, names, mr
+
+
+def _reader_finding(mr: Dict[str, Any]) -> Any:
+    """Wrap the insight dict as the reader sees it (one state entry) and run the
+    Act III reader — proving the insight reaches the conclusion prose."""
+    state = SimpleNamespace(belief_revision_results=[{"minimal_retraction": mr}])
+    return _belief_revision_finding(state)
+
+
+# A planted multi-commitment discourse. claim_T is the headlined founding
+# proposition; claim_a/b/c are supporting engagements, each plausible in
+# isolation. Opaque synthetic labels (privacy HARD — no corpus text).
+_PLANTED_ARGS = ["claim_T", "claim_a", "claim_b", "claim_c"]
+_THESIS_IDX = 0  # the fallacy undermines the headlined thesis
+
+
+# ---------------------------------------------------------------------------
+# DoD: « Texte planté écrit, différenciation mesurée sur run apparié »
+# ---------------------------------------------------------------------------
+
+
+class TestPlantedTextPairedRun:
+    """The paired run: SAME planted text, the only difference between arms is
+    whether the fallacy-negation is wired (incr 2's ``build_belief_base``). The
+    differentiation is measured against the pre-#1646 baseline (all-positive
+    base, trivially SAT, reader silent) and against the UNSAT boolean (which
+    carries no named belief / cardinality / survivors)."""
+
+    def test_planted_text_is_non_trivially_inconsistent(self) -> None:
+        """DoD C: the inconsistency is NOT "A and ¬A" two phrases apart. The
+        text's commitments, taken at face value, are CONSISTENT — no adjacent
+        pair contradicts. The inconsistency is brought SOLELY by the fallacy
+        negating the thesis (the speaker asserts claim_T; the fallacy establishes
+        claim_T is not tenable). That is the non-trivial emergence the DoD asks
+        for, and it is measurable: the no-fallacy base is SAT, the fallacy base
+        is UNSAT, on the same commitments."""
+        # Face-value commitments (pre-#1646): consistent.
+        base_face_value, _, _ = _insight_chain(_PLANTED_ARGS, [])
+        assert _sat_oracle(base_face_value) is True  # no surface contradiction
+
+        # Fallacy undermines the thesis: the conjunction becomes inconsistent.
+        base_with_fallacy, _, _ = _insight_chain(_PLANTED_ARGS, [_THESIS_IDX])
+        assert _sat_oracle(base_with_fallacy) is False  # real clash, non-trivial
+
+    def test_paired_run_differentiation_pre_vs_post(self) -> None:
+        """The paired measurement. Arm A (pre-#1646, no fallacy-negation): the
+        base is all-positive → cardinal 0 → reader SILENT (the insight is missed
+        by construction — D-forensic Lock 1). Arm B (post-#1646, fallacy negates
+        the thesis): cardinal 1 → reader NAMES the rupture. The differentiation
+        is the #1646 contribution, measured on the same planted text."""
+        # Arm A — pre-#1646 baseline.
+        _, _, mr_pre = _insight_chain(_PLANTED_ARGS, [])
+        finding_pre = _reader_finding(mr_pre)
+        assert mr_pre["cardinality"] == 0  # trivially consistent base
+        assert finding_pre is None  # the reader had nothing to say
+
+        # Arm B — post-#1646 insight.
+        _, names_post, mr_post = _insight_chain(_PLANTED_ARGS, [_THESIS_IDX])
+        finding_post = _reader_finding(mr_post)
+        assert mr_post["cardinality"] == 1  # one belief restores consistency
+        assert finding_post is not None  # the insight now reaches the prose
+
+        # The differentiation is strict: silent vs naming the rupture.
+        assert finding_pre is None and finding_post is not None
+
+    def test_insight_adds_info_the_unsat_boolean_cannot(self) -> None:
+        """The pre-#1646 chain ALSO had a PL/UNSAT oracle: on the fallacy base
+        it returns False ("inconsistent"). That boolean was available all along.
+        The differentiation is NOT "the insight detects inconsistency" — it is
+        that the insight adds WHAT to give up (a NAMED belief), HOW LITTLE
+        suffices (a cardinality), and WHAT SURVIVES (a count) — none of which
+        the boolean carries. Measured on the fallacy base."""
+        base, _, mr = _insight_chain(_PLANTED_ARGS, [_THESIS_IDX])
+        finding = _reader_finding(mr)
+
+        # The UNSAT boolean the pre-#1646 chain already had.
+        unsat_signal = _sat_oracle(base)
+        assert unsat_signal is False  # "inconsistent" — that is all it says
+
+        # The insight adds three things the boolean cannot express.
+        assert finding is not None
+        assert "claim_T" in finding.statement  # NAMED rupture belief
+        assert "cardinal 1" in finding.statement  # HOW LITTLE suffices
+        # WHAT SURVIVES (B-3 inert clause — see TestInertContradiction below).
+        assert "survivent" in finding.statement
+
+    def test_reader_names_headlined_proposition_as_rupture(self) -> None:
+        """DoD B-1/B-2: the rupture the reader names is the HEADLINED thesis
+        (``claim_T``), the proposition the speaker puts forward as founding —
+        not a peripheral detail. ``build_belief_base`` represents the fallacy as
+        {[T], [-T]}, so the reader emits the B-2 non-unique lead (drop T or drop
+        ¬T, two incompatible consistent worlds) and names T as the rupture
+        point."""
+        _, _, mr = _insight_chain(_PLANTED_ARGS, [_THESIS_IDX])
+        finding = _reader_finding(mr)
+        assert finding is not None
+        # B-2: the non-unicity is the headline (a fallacy always yields ≥ 2
+        # cardinal-1 retractions — see module docstring for why B-1-unique is
+        # out of scope for the planted text).
+        assert "pas de rétractation minimale unique" in finding.statement
+        # The headlined proposition is named as the rupture point.
+        assert "claim_T" in finding.statement
+        assert finding.capability == "belief_revision"
+
+
+# ---------------------------------------------------------------------------
+# DoD: « Le cas "contradiction inerte" (insight 3) est testé explicitement »
+# ---------------------------------------------------------------------------
+
+
+class TestInertContradictionIsDiscriminating:
+    """B-3 (the most discriminating insight): a real contradiction whose minimal
+    retraction leaves conclusions intact — inert. The discriminating proof is
+    that the insight DISTINGUISHES two planted texts that a pure UNSAT oracle
+    reads identically (both False). If B-3 fired on both (or neither), it would
+    not be a discriminator — just noise. With ``build_belief_base``, a single
+    fallacy touches exactly 2 clauses, so survivor count = (n_args + 1) − 2 =
+    n_args − 1: a multi-commitment discourse has survivors (inert), a
+    single-commitment discourse has none (non-inert). Both UNSAT; the insight
+    tells them apart."""
+
+    def test_multi_commitment_discourse_contradiction_is_inert(self) -> None:
+        """Inert case: a 4-commitment discourse where the fallacy undermines one
+        belief. The clash is real (UNSAT) but localized — 3 engagements survive
+        every retraction, so the reader emits the B-3 inert clause. A pure UNSAT
+        oracle returns the same boolean it returns for a thesis-fatal clash."""
+        args = ["claim_T", "claim_a", "claim_b", "claim_c"]  # 4 commitments
+        base, _, mr = _insight_chain(args, [_THESIS_IDX])
+        finding = _reader_finding(mr)
+
+        assert _sat_oracle(base) is False  # real contradiction
+        assert mr["cardinality"] == 1
+        # The B-3 discriminator fires: survivors > 0 → "confinée / inerte".
+        assert mr["base_size"] - mr["touched_count"] == 3  # 3 survivors
+        assert finding is not None
+        assert "inerte" in finding.statement or "confinée" in finding.statement
+        assert "3 engagement" in finding.statement  # the survivor count is named
+
+    def test_single_commitment_discourse_contradiction_is_not_inert(self) -> None:
+        """Non-inert control: a single-commitment discourse where the one belief
+        IS the clash (fallacy undermines the only claim). Nothing survives — the
+        contradiction bears on the whole base. The reader does NOT emit the B-3
+        inert clause. A pure UNSAT oracle reads this IDENTICALLY to the inert
+        case above (both False) — that is precisely what it cannot distinguish."""
+        args = ["claim_solo"]  # 1 commitment
+        base, _, mr = _insight_chain(args, [0])
+        finding = _reader_finding(mr)
+
+        assert _sat_oracle(base) is False  # real contradiction, same boolean
+        assert mr["cardinality"] == 1
+        assert mr["base_size"] - mr["touched_count"] == 0  # no survivors
+        assert finding is not None
+        # B-3 does NOT fire — the inert clause is absent.
+        assert "inerte" not in finding.statement
+        assert "confinée" not in finding.statement
+
+    def test_b3_signal_tracks_survivors_not_cardinality(self) -> None:
+        """The B-3 discrimination is driven by SURVIVORS (untouched beliefs),
+        not by cardinality. Both cases above are cardinal 1; the inert clause
+        fires in one and not the other. This pins the reader's B-3 logic to the
+        ``base_size − touched_count > 0`` property (act3_conclusion_plugin
+        l.1139), so a future change that ties inert-ness to cardinality alone
+        would break here — guarding the discriminating figure."""
+        multi_base, _, mr_multi = _insight_chain(
+            ["claim_T", "claim_a", "claim_b", "claim_c"], [_THESIS_IDX]
+        )
+        solo_base, _, mr_solo = _insight_chain(["claim_solo"], [0])
+
+        # Same boolean baseline, same cardinality — the insight differs.
+        assert _sat_oracle(multi_base) is _sat_oracle(solo_base) is False
+        assert mr_multi["cardinality"] == mr_solo["cardinality"] == 1
+
+        f_multi = _reader_finding(mr_multi)
+        f_solo = _reader_finding(mr_solo)
+        multi_inert = "inerte" in f_multi.statement or "confinée" in f_multi.statement
+        solo_inert = "inerte" in f_solo.statement or "confinée" in f_solo.statement
+        # The discriminator: inert in the multi case, NOT in the solo case.
+        assert multi_inert is True
+        assert solo_inert is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end on a planted text: the insight dict the producer shapes reaches
+# the reader unchanged (no loss between producer shaping and reader prose).
+# ---------------------------------------------------------------------------
+
+
+class TestPlantedTextProducerReaderRoundtrip:
+    """The producer shapes the ``minimal_retraction`` dict (incr 3); the reader
+    projects it to prose. On a planted text, the shaping → reader path must not
+    drop the structural signal: the cardinality, the named rupture belief, and
+    the survivor count all survive into the rendered conclusion. This is the
+    « Le résultat atteint la prose de conclusion, pas seulement l'annexe » DoD
+    item, measured through the real chain (not injected state)."""
+
+    def test_planted_insight_reaches_conclusion_prose(self) -> None:
+        _, names, mr = _insight_chain(_PLANTED_ARGS, [_THESIS_IDX])
+        finding = _reader_finding(mr)
+
+        # The reader consumed the producer-shaped dict and rendered a finding.
+        assert finding is not None
+        assert finding.capability == "belief_revision"
+        # Cardinality survived into prose.
+        assert "cardinal 1" in finding.statement
+        # The NAMED rupture belief survived (not an opaque index).
+        assert any(names[i] in finding.statement for i in range(len(names)))
+        # The fallacy-negation clause label survived too (the ¬T side of the clash).
+        assert "¬claim_T" in finding.statement
+
+    def test_no_finding_when_planted_text_has_no_fallacy(self) -> None:
+        """Honest absence (#1019): a planted text with no fallacy produces an
+        all-positive base → cardinal 0 → the reader emits NOTHING (no fabricated
+        retraction). This is the Arm-A baseline restated as a negative guarantee:
+        the insight does not invent a rupture where the text is consistent."""
+        _, _, mr = _insight_chain(_PLANTED_ARGS, [])
+        assert mr["cardinality"] == 0
+        assert _reader_finding(mr) is None


### PR DESCRIPTION
## What

Measures the **end-to-end differential** of the minimal-retraction insight wired in #1701 (incr 3). The R791 framing is the heart of this PR: on real corpora the upstream argument inventory is empty (0/21 propositions, #1710) — so any contradiction measured today comes from a planted fallacy. The question is therefore **not** "did the retraction find something?" (the plant guarantees yes) but **"what does the insight name that the plant did not put there?"**

`Refs #1646` (fraction closed, not whole — see "Closing #1646" below).

## Two complementary paired-run tests, both privacy-HARD

### Principal — `test_belief_revision_planted_text_1646.py`

Exercises the full **insight → reader** chain on a planted multi-commitment discourse. Validates:

- **The paired-run differentiation against the pre-#1646 baseline** (all-positive base, cardinal 0, reader silent) — the D-forensic Lock 1 made measurable.
- **The insight adds three things the pre-#1646 UNSAT oracle cannot**: a NAMED rupture belief, a CARDINALITY, a SURVIVOR count. The pre-#1646 chain had a UNSAT boolean; it said "inconsistent" and nothing else. The insight says *what* to give up, *how little* suffices, and *what survives*.
- **B-3 inert-contradiction is DISCRIMINATING** — it distinguishes two planted texts that a pure UNSAT oracle reads identically (both False). The discriminator: a multi-commitment discourse has survivors (inert), a single-commitment thesis-fatal has none.

Out-of-scope honestly: B-1-unique is structurally unattainable for `build_belief_base` (a fallacy adds the same `{-T, T}` shape, so the cardinal-1 options are always ≥ 2 — drop T or drop ¬T). Forcing a degenerate single-option base to trip B-1 would be the #1019 anti-pattern; B-1-unique stays covered by the `test_belief_revision_wiring_1646` (injected-state) test from incr 3.

### Complementary — `test_belief_revision_paired_run_1646_inc4.py`

Exercises the **producer wiring** of #1701 end-to-end via the public `add_jtms_belief` / `add_fallacy` APIs and the conversational producer `_run_belief_revision_from_state`. Pins the differential on:

- Cardinality 1 (1 fallacy on 1 belief) — base inconsistent, options isolated to the clashing pair, inert beliefs (β, γ, δ, ε) untouched.
- Cardinality 2 (2 fallacies on 2 distinct beliefs) — every option touches BOTH clashes (independence is structural, not in the plant).
- Parametrised over all 5 beliefs — the rupture is local to the targeted pair.
- Anti-vacuous controls: the `minimal_retraction` slot is present in the state entry after the producer ran; the `degraded` flag is `False` on a healthy python-sat env.

## Why both

The two files test different angles of the same DoD:

- `planted_text_1646.py` — does the **insight** chain (incr 1+2 functions → reader) produce a discriminating signal on a planted text? Uses the real `_belief_revision_finding` reader from #1701.
- `paired_run_1646_inc4.py` — does the **producer** wiring (incr 3) carry the insight from the public state APIs to the state entry? Uses the real `_run_belief_revision_from_state` producer from #1701.

Together they cover the full chain in two complementary directions; neither subsumes the other.

## Anti-pendule

- These tests do **not** enlarge the plant to make the insight bite. The plant is the minimal honest one (one fallacy on a headlined proposition); the size of the option set and the inert set emerge from the structure, not from a calibration of the input.
- These tests do **not** assert on a numeric count that would silently drift. The pin is structural (`options ⊆ clashing`, `inert set never appears in any option`, `B-3 fires on multi-commitment but not single-commitment`).
- These tests do **not** rely on a live JVM or corpus runner. The harness bypasses the corpus runner (#1697 / no live JVM on this worker) and calls the producer and the pure functions directly on producer-faithful states.

## Privacy HARD

No fixture carries NL source text. All belief labels are synthetic opaque strings (`claim_alpha`, `claim_T`, `claim_solo`, …). The producer treats them as opaque; the reader renders them verbatim into the Acte III finding — that is the entire point of insight B-1 (the insight names the rupture point in the corpus' own vocabulary, not in a privatised form). The fact that they are *not* real NL is what makes the privacy claim honest: nothing in this PR depends on real corpus content.

## Verification

```
test_belief_revision_planted_text_1646.py ....  9 passed
test_belief_revision_paired_run_1646_inc4.py . 13 passed (combined 22)
mypy --ignore-missing-imports ........... Success: no issues
black --check ........................... clean
non-regression (incr 1+2 + wiring + guard) ... 42 passed
```

## Closing #1646 — what this PR does and does not do

This PR satisfies **DoD items A (résultat atteint la prose), B (contradiction inerte testée), and now C (paired-run)**. What it does NOT close:

- The full #1646 DoD includes running the wired insight on real corpora once the upstream argument inventory is non-empty. The R791 measurement found 0/21 propositions on three corpora — the upstream stage never feeds structured arguments to belief-revision today. Until that gap is closed (separate lane, see #1710), the paired-run validates the *wiring* on synthetic inventories; the *real* paired-run needs the inventory fix.
- The conversational mode is exercised (the producer called in `paired_run_1646_inc4.py` is `_run_belief_revision_from_state`). The pipeline mode (`_invoke_belief_revision`, registered at `registry_setup.py:801`) is not — its caller signature requires a `context` dict constructed by the upstream orchestration. A parallel harness exercising it would be possible but would add a different shape to assert against, not new insight. I leave it for a follow-up if coord sees value.

`Refs #1646` — I do not propose `Closes` because the DoD is fractionally closed, not whole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
