### PR TITLE
chore(scripts): track the real-analysis runner so corpus measurement is not ai-01-only

### DIFF
--- a/.claude/commands/coordinate.md
+++ b/.claude/commands/coordinate.md
@@ -246,6 +246,18 @@ Ne pas relier sur `GH_TOKEN` env var seul — il n'override pas le keyring. Pref
 export GH_TOKEN=$(grep "^GH_TOKEN=" .env | cut -d= -f2)
 ```
 
+## CoursIA — 3 missions d'accompagnement (standing, cross-workspace)
+
+En plus du rôle coordinateur 2025-Epita, ai-01 porte **3 prérogatives d'accompagnement** dans le dépôt **`D:\CoursIA`** (cluster distinct, dashboard workspace `CoursIA`). Définies par l'user 2026-07-21 (R687) pour 1-2, 2026-08-10 (R786) pour 3. **Source de vérité détaillée** : `memory/project_coursia_accompaniment_missions.md` (relire avant d'agir).
+
+⚠ **Identité** : la lane `myia-ai-01:CoursIA` poste sur le même dashboard — même machine, workspace différent, **ce n'est pas moi**. Toujours signer `myia-ai-01:2025-Epita-Intelligence-Symbolique` et ne jamais prendre un dispatch adressé à l'autre.
+
+1. **Distiller** notre travail dans la série `D:\CoursIA\MyIA.AI.Notebooks\SymbolicAI\Argument_Analysis\` (existe déjà, miroir de notre archi + sous-module `Argumentum`). Notre dépôt 2025 = **fabrique** (distillation incrémentale au fil de la consolidation), **jamais un sous-module** de CoursIA. Tweety s'enrichit dans les 2 sens.
+2. **Valider la strate-6 de la série ICT** (couche S6, se construit sans attendre la fin de la distillation) sous validation conjointe **2025-Epita + Argumentum**. Inclut le **port du système d'extracts** (jina/tika + chiffrement + compression) pour un accès public partiel du dataset (contenus polémiques retirés).
+3. **Accompagner l'EPIC CoursIA #10355** — finetuning + posttraining Qwen3.5 de détection de sophismes sur la taxonomie Argumentum, gated SAE, 5 phases séquentielles (Phase 1 = #10356). Je fournis **2 actifs** : le corpus FR + schéma d'étiquettes de `2.3.2-detection-sophismes/` (2680 ex., 13 classes — c'est Logic/LogicClimate traduit ; **aucun poids n'a jamais existé**, tier déprécié #297) et **l'entonnoir** `plugins/fallacy_workflow_plugin.py` (master/slave, trace de navigation ⇒ générateur de supervision pour leur Phase 4). Greffe posée R786 sur #10356 + #10355 + dashboard CoursIA. ⚠ **Anti-pendule** : s'entraîner sur nos traces = distiller notre LLM ; l'accord élève↔maître ne mesure pas la justesse. ⚠ **Splits FR fuyants** (train∩test 42) ⇒ leur gate F1 Phase 3 ne peut pas échouer pour la bonne raison.
+
+**Discipline** : CoursIA = **proposal-only, jamais push unilatéral** (PR + validation partenaires). Barème privacy CoursIA **plus strict** que notre corpus mdp (public/traduit). Gouvernance CoursIA-side : « Directive Argumentation : insight systématique workspaces partenaires requis, zéro self-dispatch CoursIA ». Relire les dashboards CoursIA + Argumentum avant d'agir (`roosync_dashboard read type:workspace workspace:CoursIA`). Ne pas doubler-dispatcher (le cluster CoursIA a sa propre coordination).
+
 ## Démarrage
 
 Charge ce contexte, lis dashboard + inbox + GitHub, puis enchaîne Phase 2 → Phase 8.

--- a/scripts/run_real_analysis.py
+++ b/scripts/run_real_analysis.py
@@ -1,0 +1,288 @@
+"""Real (NON-anonymized) spectacular analysis — for the data owner's local inspection.
+
+Runs the full `spectacular` + `fallacy_tier:"full"` pipeline on ONE real corpus and
+renders BOTH:
+  - a full unscrubbed state snapshot (JSON, ground truth)
+  - a readable Markdown digest with REAL names (arguments, located fallacies + taxonomy
+    path, formal formulas + Tweety verdicts, quality virtues + exhibits, LLM synthesis)
+
+Output lands under argumentation_analysis/evaluation/results/real_analysis/ which is
+GITIGNORED (.gitignore line 70). This is the owner's local view — NEVER commit it,
+NEVER post its content to dashboard / PR / chat. Opaque-ID discipline still governs
+everything that reaches git; this artifact stays on disk.
+
+Usage:
+    conda run -n projet-is-roo-new --no-capture-output python scripts/run_real_analysis.py --corpus A
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+os.chdir(Path(__file__).parent.parent)
+
+# Load .env
+_env_path = Path(__file__).parent.parent / ".env"
+if _env_path.exists():
+    with open(_env_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, _, val = line.partition("=")
+                os.environ.setdefault(key.strip(), val.strip())
+
+from argumentation_analysis.core.utils.crypto_utils import derive_encryption_key
+from argumentation_analysis.core.io_manager import load_extract_definitions
+
+CORPUS_SRC_IDX = {"A": 11, "B": 3, "C": 2}
+RESULTS_DIR = Path("argumentation_analysis/evaluation/results/real_analysis")
+DATASET_PATH = Path("argumentation_analysis/data/extract_sources.json.gz.enc")
+
+
+def load_corpus(label: str, max_chars: int = 60000) -> Dict[str, Any]:
+    key = derive_encryption_key(os.environ["TEXT_CONFIG_PASSPHRASE"])
+    defs = load_extract_definitions(DATASET_PATH, key)
+    entry = defs[CORPUS_SRC_IDX[label]]
+    text = entry.get("full_text", "") or ""
+    meta = {
+        k: v
+        for k, v in entry.items()
+        if k != "full_text" and not isinstance(v, (list, dict))
+    }
+    return {"text": text[:max_chars], "raw_len": len(text), "meta": meta}
+
+
+def _md_section(title: str, body: str) -> str:
+    return f"\n## {title}\n\n{body}\n"
+
+
+def _fmt(v: Any, indent: int = 0) -> str:
+    """Compact readable rendering of an arbitrary snapshot value."""
+    pad = "  " * indent
+    if isinstance(v, str):
+        return v
+    if isinstance(v, (int, float, bool)) or v is None:
+        return str(v)
+    if isinstance(v, list):
+        if not v:
+            return "(vide)"
+        return "\n".join(f"{pad}- {_fmt(x, indent + 1)}" for x in v[:50])
+    if isinstance(v, dict):
+        if not v:
+            return "(vide)"
+        lines = []
+        for k, val in list(v.items())[:50]:
+            rendered = _fmt(val, indent + 1)
+            if "\n" in rendered:
+                lines.append(f"{pad}**{k}**:\n{rendered}")
+            else:
+                lines.append(f"{pad}**{k}**: {rendered}")
+        return "\n".join(lines)
+    return str(v)
+
+
+def render_markdown(
+    snap: Dict[str, Any],
+    corpus: Dict[str, Any],
+    label: str,
+    elapsed: float,
+    summary: Dict[str, Any] | None = None,
+) -> str:
+    md = [f"# Analyse réelle (non-anonymisée) — corpus {label}", ""]
+    md.append(f"> Généré localement, chemin GITIGNORED. Ne pas committer / publier.")
+    md.append(
+        f"> Pipeline: `spectacular` + `fallacy_tier:full` — {elapsed:.1f}s — corpus {corpus['raw_len']} chars (tronqué à {len(corpus['text'])})."
+    )
+    md.append("")
+    md.append("## Identité réelle du corpus (métadonnées source)")
+    md.append("")
+    md.append(_fmt(corpus["meta"]))
+
+    # 0. Phase status — honest view of what actually ran
+    if summary:
+        done = summary.get("completed_phases", [])
+        failed = summary.get("failed_phases", [])
+        skipped = summary.get("skipped_phases", [])
+        body = [
+            f"- **Complétées ({len(done)})**: {', '.join(done) if done else '(aucune)'}",
+            f"- **Échouées ({len(failed)})**: {', '.join(failed) if failed else '(aucune)'}",
+            f"- **Sautées ({len(skipped)})**: {', '.join(skipped) if skipped else '(aucune)'}",
+        ]
+        md.append(
+            _md_section("0. Statut des phases (transparence run)", "\n".join(body))
+        )
+
+    # 1. Arguments
+    args = snap.get("identified_arguments", {})
+    if isinstance(args, dict) and args:
+        body = []
+        for aid, a in list(args.items())[:60]:
+            if isinstance(a, dict):
+                desc = a.get("description") or a.get("text") or a.get("thesis") or ""
+                body.append(f"- **{aid}** — {desc}")
+            else:
+                body.append(f"- **{aid}** — {a}")
+        md.append(_md_section(f"1. Arguments extraits ({len(args)})", "\n".join(body)))
+
+    # 2. Fallacies (located, real text + taxonomy)
+    fals = snap.get("identified_fallacies", {})
+    if isinstance(fals, dict) and fals:
+        body = []
+        for fid, f in list(fals.items())[:80]:
+            if not isinstance(f, dict):
+                body.append(f"- **{fid}** — {f}")
+                continue
+            ftype = f.get("fallacy_type", f.get("type", "?"))
+            fam = f.get("family", "")
+            path = f.get("taxonomy_path", "")
+            just = f.get("justification", "")
+            tgt = f.get("target_arg_id", "")
+            head = f"- **{ftype}**"
+            if fam:
+                head += f" _(famille: {fam})_"
+            if path:
+                head += f" — taxo: `{path}`"
+            if tgt:
+                head += f" → {tgt}"
+            body.append(head + (f"\n    {just}" if just else ""))
+        md.append(
+            _md_section(
+                f"2. Sophismes localisés ({len(fals)}) — descente taxonomie",
+                "\n".join(body),
+            )
+        )
+    else:
+        md.append(
+            _md_section(
+                "2. Sophismes localisés (0) — descente taxonomie",
+                "_(aucun sophisme — vérifier le statut de la phase `hierarchical_fallacy` "
+                "en section 0 ; 0 alors qu'elle est complétée = anomalie d'extraction amont)_",
+            )
+        )
+
+    # 3. Formal reasoning
+    for key, title in [
+        (
+            "propositional_analysis_results",
+            "3a. Logique propositionnelle (PL) — vérifiée Tweety",
+        ),
+        ("fol_analysis_results", "3b. Logique du 1er ordre (FOL) — vérifiée Tweety"),
+        ("modal_analysis_results", "3c. Logique modale — vérifiée Tweety"),
+    ]:
+        r = snap.get(key)
+        if r:
+            md.append(_md_section(title, _fmt(r)))
+
+    # 4. Dung
+    dung = snap.get("dung_frameworks", snap.get("dung_extensions"))
+    if dung:
+        md.append(
+            _md_section("4. Argumentation abstraite (Dung) — extensions", _fmt(dung))
+        )
+
+    # 5. Quality virtues + exhibits
+    q = snap.get("argument_quality_scores", snap.get("quality_evaluation"))
+    if q:
+        md.append(_md_section("5. Qualité — 9 vertus (+ exhibits agentiques)", _fmt(q)))
+
+    # 6. Counter-arguments
+    ca = snap.get("counter_arguments")
+    if ca:
+        md.append(_md_section("6. Contre-arguments (5 stratégies)", _fmt(ca)))
+
+    # 7. Synthesis (the LLM prose — REAL). Keys vary by phase; render whatever exists,
+    # honestly note the empties (the owner wants to see exactly what the run produced).
+    synth_keys = [
+        ("narrative_synthesis", "7a. Synthèse narrative (LLM)"),
+        ("analysis_synthesis", "7b. Synthèse d'analyse (phase `synthesis`)"),
+        ("deep_synthesis", "7c. Synthèse profonde (phase `deep_synthesis`)"),
+        ("formal_synthesis_reports", "7d. Synthèse formelle (Tweety)"),
+        ("final_conclusion", "7e. Conclusion finale"),
+    ]
+    seen = {k for k, _ in synth_keys}
+    # catch any other synthesis-ish top-level key we didn't name explicitly
+    for k in sorted(snap.keys()):
+        if k not in seen and ("synth" in k.lower() or "conclus" in k.lower()):
+            synth_keys.append((k, f"7z. {k}"))
+    sec = []
+    for key, title in synth_keys:
+        v = snap.get(key)
+        if v:
+            sec.append(f"### {title}\n\n{_fmt(v)}")
+        else:
+            sec.append(
+                f"### {title}\n\n_(vide — phase non exécutée ou sans sortie LLM ce run)_"
+            )
+    md.append(_md_section("7. Synthèses (prose LLM réelle)", "\n\n".join(sec)))
+
+    # 8. JTMS / governance / debate
+    for key, title in [
+        ("jtms_beliefs", "8a. JTMS — croyances / justifications"),
+        ("governance_decisions", "8b. Gouvernance — votes / consensus"),
+        ("debate_transcripts", "8c. Débat adversarial"),
+    ]:
+        v = snap.get(key)
+        if v:
+            md.append(_md_section(title, _fmt(v)))
+
+    return "\n".join(md)
+
+
+async def main_async(label: str) -> None:
+    from argumentation_analysis.orchestration.unified_pipeline import (
+        run_unified_analysis,
+    )
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    corpus = load_corpus(label)
+    print(
+        f"[REAL] corpus {label}: {corpus['raw_len']} chars (using {len(corpus['text'])})"
+    )
+    print(f"[REAL] meta: {corpus['meta']}")
+
+    # NO shield_config: (a) the owner wants the REAL non-anonymized view, the shield
+    # injects an opaque-ID directive; (b) shield_config switches the workflow name to
+    # 'shielded_spectacular_analysis', which makes the `workflow_name == "spectacular"`
+    # JPype-warmup guard FALSE -> JVM never warms -> the Tweety phases all fail. Plain
+    # `spectacular` is what FB-37 ran (38 fallacies / 138 args). Subtraction, not counterweight.
+    context = {"fallacy_tier": "full"}
+    t0 = time.time()
+    result = await run_unified_analysis(
+        text=corpus["text"], workflow_name="spectacular", context=context
+    )
+    elapsed = time.time() - t0
+    print(f"[REAL] pipeline done in {elapsed:.1f}s")
+
+    state = result.get("unified_state")
+    snap = state.get_state_snapshot(summarize=False) if state is not None else {}
+
+    # Full ground-truth JSON (unscrubbed — gitignored)
+    json_path = RESULTS_DIR / f"real_{label}_state.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(snap, f, indent=2, ensure_ascii=False, default=str)
+    print(f"[REAL] full snapshot -> {json_path}")
+
+    # Readable digest
+    md = render_markdown(snap, corpus, label, elapsed, summary=result.get("summary"))
+    md_path = RESULTS_DIR / f"real_{label}_report.md"
+    with open(md_path, "w", encoding="utf-8") as f:
+        f.write(md)
+    print(f"[REAL] readable report -> {md_path}")
+    print(f"[REAL] top-level snapshot keys: {sorted(snap.keys())}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--corpus", choices=["A", "B", "C"], default="A")
+    args = parser.parse_args()
+    asyncio.run(main_async(args.corpus))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why

`scripts/run_real_analysis.py` has **never been tracked** (`git log --all -- <path>` is empty; it is not gitignored either). It is the canonical runner for the three real corpora (`spectacular` + `fallacy_tier:full`), and it existed only in the ai-01 working tree.

That is the root of a blocker both workers have now hit twice:

- **#1698 item 2** (R791/R792) — po-2025 shipped the probe but left the measurement in the coord lane: *"les snapshots sont sur ai-01 scratchpad, po-2025 n'y accède pas"*.
- **#1668 item 1** (R793) — same shape: *"il est data-gated : les 66 valeurs de `strategy` vivent dans les états de run corpus, qui sont sur ai-01"*, and po-2025 explicitly flagged that running locally was blocked because *"le runner canonique"* was a phantom path.

The measurement was not coord-lane by design — it was coord-lane because only one machine had the tool.

## Safety of tracking it

| Check | Result |
|---|---|
| Secrets (`api_key`/`token`/`sk-`/private keys) | none |
| Corpus text hardcoded | none — loads via `load_extract_definitions` on the encrypted dataset, **in-memory** (privacy rule 5) |
| Corpus addressing | opaque index only (`{"A": 11, "B": 3, "C": 2}`) |
| Output location | `argumentation_analysis/evaluation/results/real_analysis/` — **gitignored** (.gitignore line 70) |
| Convention | ~50 sibling `run_*.py` are already tracked in `scripts/` |

The docstring says the **output** must never be committed. That was never a reason to keep the **script** untracked.

## Changes

1. `scripts/run_real_analysis.py` — tracked, and **formatted with black** (it had never been through the CI formatter, so tracking it unformatted would have turned `lint-and-format` red). `flake8` clean, compiles.
2. `.claude/commands/coordinate.md` — commits the CoursIA standing-missions section written R786 and in effect since, left uncommitted in the working tree.

## What this does not claim

Tracking the runner does not mean the workers' measurements become free: a real run is ~450-720s per corpus and costs API credits, and it needs `TEXT_CONFIG_PASSPHRASE` in the worker's `.env`. It removes the *capability* blocker, not the *cost* one — the choice of who runs which corpus stays a dispatch decision.

🤖 Coordinator ai-01 — R794