### PR TITLE
fix(probe): print N/A not spurious MISMATCH when a surface has no nature keys

### DIFF
--- a/scripts/probe_attack_source_nature_split.py
+++ b/scripts/probe_attack_source_nature_split.py
@@ -228,6 +228,13 @@ def _aggregate(blocks: List[Dict[str, Any]]) -> Dict[str, Any]:
             "distinct_fingerprints": len(multiplicity),
             "max_multiplicity": max_mult,
             "replicated": max_mult > 1,
+            # Per-surface nature-availability flag. The invariant
+            # (sum(natures) == submitted) is only meaningful when this surface
+            # actually carried per-nature keys; otherwise it would compare
+            # 0 (None summed) against the real submitted total and print a
+            # spurious MISMATCH — a verdict on a magnitude it never received
+            # (#1019 one level up from the aggregation defect).
+            "nature_keys_present": nature_present,
             # Deduped totals = authoritative candidate counts.
             "attacks_submitted": dedup_sums["attacks_submitted"],
             "attacks_retained": dedup_sums["attacks_retained"],
@@ -304,12 +311,21 @@ def _render_surface(title: str, agg: Dict[str, Any]) -> List[str]:
         f"      ca:      {bn['ca']['submitted']} / {bn['ca']['dropped']}\n"
         f"      other:   {bn['other']['submitted']} / {bn['other']['dropped']}"
     )
-    # Invariant: sum(natures) == submitted total (verifiable honesty).
-    sum_sub = (
-        bn["fallacy"]["submitted"] + bn["ca"]["submitted"] + bn["other"]["submitted"]
-    )
-    match = "OK" if sum_sub == agg["attacks_submitted"] else "MISMATCH"
-    lines.append(f"    invariant sum(natures) == submitted: {match}")
+    # Invariant: sum(natures) == submitted total (verifiable honesty). Printed
+    # only when this surface carried per-nature keys — on a pre-instrumentation
+    # surface the per-nature values are absent (summed to 0) and the invariant
+    # would print a spurious MISMATCH, a verdict on a magnitude the surface
+    # never declared (#1019 one level up from the aggregation defect).
+    if agg.get("nature_keys_present"):
+        sum_sub = (
+            bn["fallacy"]["submitted"]
+            + bn["ca"]["submitted"]
+            + bn["other"]["submitted"]
+        )
+        match = "OK" if sum_sub == agg["attacks_submitted"] else "MISMATCH"
+        lines.append(f"    invariant sum(natures) == submitted: {match}")
+    else:
+        lines.append("    invariant sum(natures) == submitted: N/A (split unavailable)")
     return lines
 
 

--- a/tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_attack_retention_accounting_1698.py
@@ -841,7 +841,18 @@ class TestAttackSourceNatureProbe:
         blocks = collect(state.get_state_snapshot())
         agg = aggregate(blocks)
         assert agg["nature_keys_present"] is False
-        assert "UNAVAILABLE" in _render({"document": "doc", **agg}, as_json=False)
+        rendered = _render({"document": "doc", **agg}, as_json=False)
+        assert "UNAVAILABLE" in rendered
+        # R794 follow-up: on a pre-instrumentation surface the per-nature
+        # values are absent, so the invariant must NOT print a spurious
+        # MISMATCH (a verdict on a magnitude the surface never declared —
+        # #1019 one level up). It prints N/A instead. Substitution control:
+        # reverting _render_surface to an unconditional invariant makes the
+        # MISMATCH assertion red.
+        assert "MISMATCH" not in rendered
+        assert "N/A (split unavailable)" in rendered
+        # The per-surface flag is set, not only the document-global one.
+        assert agg["surfaces"]["curated"]["nature_keys_present"] is False
 
     def test_probe_never_leaks_ca_source_text(self) -> None:
         """The probe output must never contain the ``CA:`` source string —


### PR DESCRIPTION
## What

R794 dispatch (ai-01 → po-2025, item 3 — \"un défaut de ta sonde, trouvé en la relançant\"):

> *« Sur des états pré-instrumentation (\`by_nature\` à \`None\`), la sonde imprime \`invariant sum(natures) == submitted: MISMATCH\` alors que l'énoncé honnête est « pas de split à contrôler »… \`nature_keys_present\` existe mais il est global au document, pas par surface. Même forme #1019 que celle que tu viens de corriger, un cran plus haut. »*

On a pre-instrumentation snapshot the per-nature keys are absent (producer predates the #1698 R791 split). The probe summed them to 0 and compared against the real submitted total → spurious `MISMATCH`. A verdict on a magnitude the surface never declared — #1019 one level up from the aggregation defect fixed in #1715.

## Fix

- `_aggregate` stores `nature_keys_present` **per surface** (it was computed but only rolled up to a document-global flag).
- `_render_surface` prints `N/A (split unavailable)` instead of the invariant when that surface's flag is False. The document-level `UNAVAILABLE` note is retained for readability.

## Tests

`test_probe_honest_when_split_absent` extended: asserts `MISMATCH` is **absent** and `N/A (split unavailable)` **present** on a totals-only surface, plus the per-surface flag is set. **Substitution control**: reverting `_render_surface` to an unconditional invariant makes the `MISMATCH` assertion red (verified by reasoning: pre-instrumentation sums to 0 vs submitted=15 → MISMATCH).

**36/36** green. **black** clean.

## Scope

Worker PR (po-2025) — lane merge coord `--admin` (REVIEW_REQUIRED artefactuel). Only `scripts/probe_*.py` + its test touched; no handler/writer change. Small follow-up to #1715 on the same file.

🤖 Worker po-2025