### PR TITLE
fix(sanitize): opacify the formalism_specific sidecar leaves (#1702)

### DIFF
--- a/argumentation_analysis/evaluation/sanitize_state.py
+++ b/argumentation_analysis/evaluation/sanitize_state.py
@@ -122,6 +122,52 @@ _OPAQUE_NESTED_LIST_SUBKEYS = {
     "dung_frameworks": {"extensions": {"extensions", "all_members"}},
 }
 
+# Wave-2 ``formalism_specific`` sidecars on ``dung_frameworks`` entries (#1702).
+# The six #1648 writers (ABA/SetAF/Weighted/EAF/DeLP, plus ADF which attaches no
+# sidecar) attach a strictly-additive ``entry["formalism_specific"] = {...}`` dict
+# to carry data the native Dung projection has no slot for. Each leaf was measured
+# at its producer (the anti-pendule of #1702: "mesurer le producteur"), and the
+# verdict split is nominative-source-atom vs closed-vocabulary/numeric-aggregate:
+#
+#   contraries        Dict[assumption_atom, contrary_atom]   — ABA l.968, BOTH
+#                                                               keys+values source
+#   set_attacks       List[{attackers:[atom], target:atom}]  — SetAF l.1482
+#   attack_weights    List[{source, target, weight:float}]   — Weighted l.1541,
+#                                                               weight KEPT (numeric)
+#   epistemic_beliefs Dict[agent, List[arg_atom]]            — EAF l.1611
+#   delp_arguments    str | List[str] (defeasible rule source over source
+#                     predicates)                            — DeLP l.1658
+#
+# Deliberately NOT listed (survive untouched — closed vocab / pure numeric, the
+# #1702 anti-pendule symmetrical to the scrubber's own l.156-163):
+#   weight_statistics {min/max/avg_weight: float}            — Weighted l.1551
+#   program_size      int                                     — DeLP l.1660
+#   criterion         str (e.g. "generalized_specificity")   — DeLP l.1662, closed
+#
+# Parent 2 (``propositional_analysis_results[*].formalism_specific.qbf_quantifiers``)
+# is ALSO not listed here and needs no scrub: the QBF writer docstring
+# (state_writers.py:1683) measures its leaves as formal logical symbols
+# (quantifier type + variable names like ``x``/``y``), not source-derived prose.
+# "Covering both parents" (#1702 DoD) is therefore statuated by measurement on
+# parent 2 (opaque by construction), not by a table entry.
+#
+# ``aspic_results.attacks`` (the other #1702 surface) is already covered by pass
+# 5d via ``_OPAQUE_NESTED_ITEM_SUBKEYS`` (commit a9bcf516, #1649 follow-up).
+#
+# Leaf -> opacification mode:
+#   "mapping"                 Dict keyed by a source atom -> opacify keys AND
+#                             values (values may be a list of atoms).
+#   ("dict_list", (fields,))  List[Dict] -> opacify the named string-leaves,
+#                             keep the rest (e.g. the numeric ``weight``).
+#   "atom_list"               A source-atom string OR list of them -> opacify.
+_OPAQUE_FORMALISM_SPECIFIC = {
+    "contraries": "mapping",
+    "epistemic_beliefs": "mapping",
+    "set_attacks": ("dict_list", ("attackers", "target")),
+    "attack_weights": ("dict_list", ("source", "target")),
+    "delp_arguments": "atom_list",
+}
+
 # List-of-dicts fields: top-level field -> sub-keys whose values are
 # nominative text to drop (the rest of each item is preserved).
 _TEXT_STRIP_LISTS = {
@@ -285,6 +331,60 @@ def _opacify_list_values(value: Any) -> Any:
     return value
 
 
+def _scrub_formalism_specific(sidecar: Any) -> Any:
+    """Opacify the nominative leaves of a ``formalism_specific`` sidecar (#1702).
+
+    The Wave-2 sidecar is a heterogeneous dict whose leaves mix source-derived
+    PL atoms (the nominative payload — ``_pl_atom`` keeps up to 24 leading chars
+    of argument text) with closed vocabularies and numeric aggregates the export
+    contract promises to preserve. ``_OPAQUE_FORMALISM_SPECIFIC`` names the
+    nominative leaves and their opacification mode; every key NOT in that table
+    (``weight_statistics``, ``program_size``, ``criterion``) survives untouched.
+
+    Topology is preserved everywhere: a list stays a list of the same arity, a
+    mapping keeps its key count, and the numeric ``weight`` on each
+    ``attack_weights`` entry survives — so downstream quantitative aggregates
+    (joint-attack arity, weight distribution) are unaffected, exactly as passes
+    4b/4c preserve Dung extension sizes.
+    """
+    if not isinstance(sidecar, dict):
+        return sidecar
+    out = dict(sidecar)  # shallow copy; untouched keys (criterion/stats) ride through
+    for leaf, mode in _OPAQUE_FORMALISM_SPECIFIC.items():
+        if leaf not in out:
+            continue
+        val = out[leaf]
+        if mode == "mapping":
+            # Dict keyed by a source atom; opacify keys AND values (values may be
+            # a list of atoms — _opacify_list_values handles both str and list).
+            if isinstance(val, dict):
+                out[leaf] = {
+                    (
+                        opaque_id(k) if isinstance(k, str) and k else k
+                    ): _opacify_list_values(v)
+                    for k, v in val.items()
+                }
+        elif isinstance(mode, tuple) and mode[0] == "dict_list":
+            fields = mode[1]
+            if isinstance(val, list):
+                scrubbed: list[Any] = []
+                for entry in val:
+                    if isinstance(entry, dict):
+                        new_entry = dict(entry)
+                        for f in fields:
+                            if f in new_entry:
+                                new_entry[f] = _opacify_list_values(new_entry[f])
+                        scrubbed.append(new_entry)
+                    else:
+                        scrubbed.append(entry)
+                out[leaf] = scrubbed
+        elif mode == "atom_list":
+            # A source-atom string OR a list of them (DeLP ``program`` can be
+            # either); _opacify_list_values handles both shapes uniformly.
+            out[leaf] = _opacify_list_values(val)
+    return out
+
+
 def _scrub_struct(value: Any, list_keys: tuple[str, ...]) -> dict[str, Any]:
     """Reduce a stakes/stakeholders struct to a counts-only summary."""
     if not isinstance(value, dict):
@@ -408,6 +508,22 @@ def sanitize_state(state: dict[str, Any] | Any) -> dict[str, Any]:
                 else:
                     nested_entries[key] = val
             data[field] = nested_entries
+
+    # 4d. Opacify the Wave-2 ``formalism_specific`` sidecar on ``dung_frameworks``
+    #     entries (#1702). The six #1648 writers attach this strictly-additive dict
+    #     to carry formalism-specific data the native Dung projection has no slot
+    #     for (ABA contraries, SetAF joint attacks, Weighted weights, EAF
+    #     epistemic beliefs, DeLP program/criterion). Its nominative leaves are
+    #     the same source-derived atoms passes 4b/4c opacify one level up, under a
+    #     sibling key the dict-of-dicts sub-key passes never inspect. The closed-
+    #     vocabulary / numeric-aggregate leaves (criterion, weight_statistics,
+    #     program_size) survive by being absent from the spec table.
+    if isinstance(data.get("dung_frameworks"), dict):
+        for entry in data["dung_frameworks"].values():
+            if isinstance(entry, dict) and "formalism_specific" in entry:
+                entry["formalism_specific"] = _scrub_formalism_specific(
+                    entry["formalism_specific"]
+                )
 
     # 5. Strip nominative sub-keys from list-of-dicts fields.
     for field, text_keys in _TEXT_STRIP_LISTS.items():

--- a/tests/unit/argumentation_analysis/evaluation/test_sanitize_coverage_guard_1702.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_sanitize_coverage_guard_1702.py
@@ -371,21 +371,14 @@ def _surviving_paths(sanitized: dict[str, Any]) -> dict[str, set[str]]:
 # elsewhere) is a privacy decision pending triage on #1702 — see the module
 # docstring for why this PR does not patch the scrubber.
 EXPECTED_UNCOVERED: dict[str, frozenset[str]] = {
-    # Wave-2 ``formalism_specific`` sidecars — attached by ``_write_setaf /
-    # _write_weighted / _write_eaf / _write_delp`` via direct assignment, never
-    # declared in any scrubber table. Same claim text the 4b/4c passes opacify
-    # one level up, under a sibling container the passes do not inspect.
-    "dung_frameworks": frozenset(
-        {
-            "dung_frameworks[*].formalism_specific.set_attacks[*].attackers[*]",
-            "dung_frameworks[*].formalism_specific.set_attacks[*].target",
-            "dung_frameworks[*].formalism_specific.attack_weights[*].source",
-            "dung_frameworks[*].formalism_specific.attack_weights[*].target",
-            "dung_frameworks[*].formalism_specific.epistemic_beliefs[*][*]",
-            "dung_frameworks[*].formalism_specific.contraries[*]",
-            "dung_frameworks[*].formalism_specific.delp_arguments[*]",
-        }
-    ),
+    # The Wave-2 ``formalism_specific`` sidecar on ``dung_frameworks`` was a
+    # frozen gap at #1711; #1702 covered it via pass 4d
+    # (``_scrub_formalism_specific`` — see sanitize_state.py). Its seven
+    # nominative paths are now opacified, so ``dung_frameworks`` no longer
+    # appears in the uncovered set. The canary plan still plants them (so a
+    # regression in 4d re-leaks here immediately), and ``test_scrubber_is_alive``
+    # keeps watching the sibling 4b ``.arguments`` path.
+    #
     # The dominant survivor on real corpora (coord R785: 1024–2304 occurrences).
     # ``add_formal_synthesis_report`` stores ``phase_results`` verbatim, and it
     # republishes the formal phases' output — including the Dung extensions,
@@ -546,44 +539,84 @@ class TestSubstitutionControl:
     """
 
     @pytest.mark.parametrize(
-        "table_attr,field,expected_path_fragment",
+        "table_attr,remove_field,survivor_field,expected_path_fragment",
         [
             # Pass 4b: dung_frameworks.arguments/attacks.
-            ("_OPAQUE_LIST_SUBKEYS", "dung_frameworks", ".arguments"),
+            (
+                "_OPAQUE_LIST_SUBKEYS",
+                "dung_frameworks",
+                "dung_frameworks",
+                ".arguments",
+            ),
             # Pass 5b: aspic_results.extensions.
-            ("_OPAQUE_LIST_OF_DICTS_SUBKEYS", "aspic_results", ".extensions"),
+            (
+                "_OPAQUE_LIST_OF_DICTS_SUBKEYS",
+                "aspic_results",
+                "aspic_results",
+                ".extensions",
+            ),
             # Pass 5b: belief_revision_results.original/revised.
             (
                 "_OPAQUE_LIST_OF_DICTS_SUBKEYS",
                 "belief_revision_results",
+                "belief_revision_results",
                 ".original",
             ),
             # Pass 5d: aspic_results.attacks target/attacker_premises.
-            ("_OPAQUE_NESTED_ITEM_SUBKEYS", "aspic_results", ".attacks"),
+            (
+                "_OPAQUE_NESTED_ITEM_SUBKEYS",
+                "aspic_results",
+                "aspic_results",
+                ".attacks",
+            ),
+            # Pass 4d (#1702): formalism_specific leaves. Removing a leaf from
+            # the spec re-leaks its canary under the dung_frameworks top-level
+            # field — the new pass is not vacuous. The table key (``set_attacks``)
+            # differs from the survivor field (``dung_frameworks``) because the
+            # sidecar is nested inside a dung_frameworks entry, not a top-level.
+            (
+                "_OPAQUE_FORMALISM_SPECIFIC",
+                "set_attacks",
+                "dung_frameworks",
+                ".formalism_specific.set_attacks",
+            ),
+            (
+                "_OPAQUE_FORMALISM_SPECIFIC",
+                "contraries",
+                "dung_frameworks",
+                ".formalism_specific.contraries",
+            ),
+            (
+                "_OPAQUE_FORMALISM_SPECIFIC",
+                "attack_weights",
+                "dung_frameworks",
+                ".formalism_specific.attack_weights",
+            ),
         ],
     )
     def test_removing_a_rule_lets_the_canary_through(
         self,
         monkeypatch: pytest.MonkeyPatch,
         table_attr: str,
-        field: str,
+        remove_field: str,
+        survivor_field: str,
         expected_path_fragment: str,
     ) -> None:
         original_table = getattr(_sanitize_mod, table_attr)
         # Surgical copy minus the one field — the rest of the table stays armed.
-        reduced = {k: v for k, v in original_table.items() if k != field}
+        reduced = {k: v for k, v in original_table.items() if k != remove_field}
         monkeypatch.setattr(_sanitize_mod, table_attr, reduced)
 
         survivors = _surviving_paths(
             sanitize_state(_canaried_state().get_state_snapshot())
         )
-        field_paths = survivors.get(field, set())
+        field_paths = survivors.get(survivor_field, set())
         # The canary that the removed rule was killing must now survive, and at
         # least one surviving path must carry the expected sub-path fragment.
         assert field_paths, (
-            f"removing {table_attr}[{field!r}] did NOT let the canary through — "
-            "the substitution control is vacuous (some other pass also covers "
-            "it, or the canary never reached it)."
+            f"removing {table_attr}[{remove_field!r}] did NOT let the canary "
+            "through — the substitution control is vacuous (some other pass "
+            "also covers it, or the canary never reached it)."
         )
         assert any(
             expected_path_fragment in p for p in field_paths

--- a/tests/unit/argumentation_analysis/evaluation/test_sanitize_formalism_specific_1702.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_sanitize_formalism_specific_1702.py
@@ -1,0 +1,187 @@
+"""#1702 — direct contract test for the ``formalism_specific`` sidecar scrub.
+
+The coverage guard (``test_sanitize_coverage_guard_1702``) pins the RELATION
+between what producers write and what the scrubber covers (canary planted in
+every NL slot, survivors must match a frozen baseline). This file pins the
+CONTRACT of pass 4d directly: every nominative leaf of the Wave-2
+``formalism_specific`` sidecar is opacified, the closed-vocabulary / numeric
+leaves survive untouched, and the topology (list arity, mapping key count) is
+preserved — so the downstream quantitative aggregates (joint-attack arity,
+weight distribution, extension sizes) are unaffected.
+
+The leaf shapes mirror the real ``_write_*_to_state`` sites exactly (measured at
+each producer — the anti-pendule of #1702): ABA ``contraries`` (Dict[atom,atom]),
+SetAF ``set_attacks`` (List[{attackers,target}]), Weighted ``attack_weights``
+(List[{source,target,weight}]) + ``weight_statistics``, EAF ``epistemic_beliefs``
+(Dict[agent,List[atom]]), DeLP ``delp_arguments`` + ``program_size`` +
+``criterion``. Opaque synthetic atoms only (privacy HARD — no corpus text).
+"""
+
+from __future__ import annotations
+
+from argumentation_analysis.evaluation.sanitize_state import sanitize_state
+
+
+def _entry(sidecar: dict) -> dict:
+    """Wrap a formalism_specific sidecar in a single dung_frameworks entry."""
+    return {
+        "dung_frameworks": {
+            "dung_1": {"name": "setaf_grounded", "formalism_specific": sidecar}
+        }
+    }
+
+
+class TestFormalismSpecificNominativeLeavesOpacified:
+    """Each source-derived leaf is opacified; its content no longer survives."""
+
+    def test_contraries_keys_and_values_opacified(self) -> None:
+        # ABA: Dict[assumption_atom, contrary_atom] — BOTH nominative.
+        out = sanitize_state(
+            _entry(
+                {
+                    "contraries": {
+                        "claim_alpha": "claim_beta",
+                        "claim_gamma": "claim_delta",
+                    }
+                }
+            )
+        )
+        contra = out["dung_frameworks"]["dung_1"]["formalism_specific"]["contraries"]
+        assert len(contra) == 2  # topology preserved (key count)
+        # Neither the original atoms nor their keys survive verbatim.
+        flat = set(contra.keys()) | set(str(v) for v in contra.values())
+        assert all("claim_" not in s for s in flat)
+
+    def test_set_attacks_attackers_and_target_opacified(self) -> None:
+        # SetAF: List[{attackers: [atom], target: atom}].
+        out = sanitize_state(
+            _entry(
+                {
+                    "set_attacks": [
+                        {
+                            "attackers": ["claim_alpha", "claim_beta"],
+                            "target": "claim_gamma",
+                        }
+                    ]
+                }
+            )
+        )
+        sa = out["dung_frameworks"]["dung_1"]["formalism_specific"]["set_attacks"]
+        assert len(sa) == 1  # attack count preserved
+        assert len(sa[0]["attackers"]) == 2  # joint-attack arity preserved
+        assert all("claim_" not in a for a in sa[0]["attackers"])
+        assert "claim_" not in sa[0]["target"]
+
+    def test_attack_weights_source_target_opacified_weight_kept(self) -> None:
+        # Weighted: List[{source, target, weight}] — source/target opacified,
+        # weight (numeric) KEPT.
+        out = sanitize_state(
+            _entry(
+                {
+                    "attack_weights": [
+                        {
+                            "source": "claim_alpha",
+                            "target": "claim_beta",
+                            "weight": 0.75,
+                        }
+                    ]
+                }
+            )
+        )
+        aw = out["dung_frameworks"]["dung_1"]["formalism_specific"]["attack_weights"]
+        assert len(aw) == 1
+        assert aw[0]["weight"] == 0.75  # numeric survives
+        assert "claim_" not in aw[0]["source"]
+        assert "claim_" not in aw[0]["target"]
+
+    def test_epistemic_beliefs_keys_and_values_opacified(self) -> None:
+        # EAF: Dict[agent, List[atom]] — agent names + belief atoms both nominative.
+        out = sanitize_state(
+            _entry({"epistemic_beliefs": {"agent_one": ["claim_alpha", "claim_beta"]}})
+        )
+        eb = out["dung_frameworks"]["dung_1"]["formalism_specific"]["epistemic_beliefs"]
+        assert len(eb) == 1  # agent count preserved
+        only_args = next(iter(eb.values()))
+        assert len(only_args) == 2  # belief arity preserved
+        assert all("claim_" not in a for a in only_args)
+        assert all("agent_" not in k for k in eb.keys())
+
+    def test_delp_arguments_opacified_as_atom_list(self) -> None:
+        # DeLP: the defeasible program — a source-derived string OR list of them.
+        out = sanitize_state(_entry({"delp_arguments": ["claim_alpha <- claim_beta"]}))
+        da = out["dung_frameworks"]["dung_1"]["formalism_specific"]["delp_arguments"]
+        assert isinstance(da, list) and len(da) == 1  # topology preserved
+        assert "claim_" not in da[0]
+
+    def test_delp_arguments_opacified_as_bare_string(self) -> None:
+        # The DeLP handler may emit the program as a single rule string.
+        out = sanitize_state(_entry({"delp_arguments": "claim_alpha <- claim_beta"}))
+        da = out["dung_frameworks"]["dung_1"]["formalism_specific"]["delp_arguments"]
+        assert isinstance(da, str)
+        assert "claim_" not in da
+
+
+class TestFormalismSpecificClosedVocabAndNumericSurvive:
+    """The anti-pendule: leaves the #1702 contract promises to preserve are
+    NOT opacified (the symmetrical guarantee to the nominative-leaf tests)."""
+
+    def test_weight_statistics_survive(self) -> None:
+        out = sanitize_state(
+            _entry(
+                {
+                    "attack_weights": [{"source": "a", "target": "b", "weight": 0.5}],
+                    "weight_statistics": {
+                        "min_weight": 0.1,
+                        "max_weight": 0.9,
+                        "avg_weight": 0.5,
+                    },
+                }
+            )
+        )
+        stats = out["dung_frameworks"]["dung_1"]["formalism_specific"][
+            "weight_statistics"
+        ]
+        assert stats == {"min_weight": 0.1, "max_weight": 0.9, "avg_weight": 0.5}
+
+    def test_program_size_and_criterion_survive(self) -> None:
+        out = sanitize_state(
+            _entry(
+                {
+                    "delp_arguments": ["x <- y"],
+                    "program_size": 7,
+                    "criterion": "generalized_specificity",
+                }
+            )
+        )
+        side = out["dung_frameworks"]["dung_1"]["formalism_specific"]
+        assert side["program_size"] == 7  # int untouched
+        assert side["criterion"] == "generalized_specificity"  # closed vocab untouched
+
+
+class TestFormalismSpecificAbsentOrNonDictIsSafe:
+    """Defensive: an entry without the sidecar, or a non-dict sidecar, is left
+    alone (no crash, no synthesis). Honest-absent stays honest-absent (#1019)."""
+
+    def test_entry_without_sidecar_unchanged(self) -> None:
+        out = sanitize_state(
+            {
+                "dung_frameworks": {
+                    "dung_1": {"name": "dung_arbitration", "arguments": []}
+                }
+            }
+        )
+        assert "formalism_specific" not in out["dung_frameworks"]["dung_1"]
+
+    def test_non_dict_sidecar_passes_through(self) -> None:
+        # A malformed sidecar (producer bug) must not crash the export boundary.
+        out = sanitize_state(
+            {"dung_frameworks": {"dung_1": {"formalism_specific": "not-a-dict"}}}
+        )
+        # _scrub_formalism_specific returns non-dict input unchanged.
+        assert out["dung_frameworks"]["dung_1"]["formalism_specific"] == "not-a-dict"
+
+    def test_empty_sidecar_dict_survives(self) -> None:
+        out = sanitize_state(
+            {"dung_frameworks": {"dung_1": {"formalism_specific": {}}}}
+        )
+        assert out["dung_frameworks"]["dung_1"]["formalism_specific"] == {}


### PR DESCRIPTION
# #1702 — opacify the `formalism_specific` sidecar leaves

Epic #1644. Closes the seven nominative `formalism_specific` paths frozen in the #1711 coverage guard.

## The gap

The Wave-2 `formalism_specific` sidecar (attached to `dung_frameworks` entries by the six #1648 writers — ABA/SetAF/Weighted/EAF/DeLP) carried the same source-derived PL atoms passes 4b/4c opacify one level up, under a sibling key the dict-of-dicts sub-key passes never inspected. #1702 measured the gap firsthand and #1711 froze it; this PR closes it via a new pass 4d (`_scrub_formalism_specific`).

## The triage (DoD item 1 — the deliverable is the list)

Every leaf was measured at its producer (the #1702 anti-pendule *« mesurer le producteur »*), statuating opacify vs preserve:

### Parent 1 — `dung_frameworks[df_id].formalism_specific` (scrub target)

| subkey | writer (line) | shape | verdict | reason (measured) |
|---|---|---|---|---|
| `contraries` | ABA l.968 | `Dict[atom,atom]` | **opacify keys + values** | assumptions = source atoms |
| `set_attacks` | SetAF l.1482 | `List[{attackers:[atom], target:atom}]` | **opacify attackers + target** | source atoms |
| `attack_weights` | Weighted l.1541 | `List[{source, target, weight:float}]` | **opacify source + target, KEEP weight** | weight = numeric |
| `epistemic_beliefs` | EAF l.1611 | `Dict[agent, List[atom]]` | **opacify keys + values** | agent + args source |
| `delp_arguments` | DeLP l.1658 | `str \| List[str]` (rule source) | **opacify** | rules over source predicates |
| `weight_statistics` | Weighted l.1551 | `{min/max/avg_weight: float}` | **KEEP** | pure numeric aggregate |
| `program_size` | DeLP l.1660 | `int` | **KEEP** | numeric |
| `criterion` | DeLP l.1662 | `str` (e.g. `generalized_specificity`) | **KEEP** | closed vocabulary |

### Parent 2 — `propositional_analysis_results[*].formalism_specific`

| subkey | writer (line) | shape | verdict | reason (measured) |
|---|---|---|---|---|
| `qbf_quantifiers` | QBF l.1717 | `List[{type, vars}]` | **KEEP (no scrub)** | writer docstring l.1683: *« formal logical symbols (quantifier type + variable names like x/y), not source-derived prose »*. Covering both parents (DoD) is statuated by **measurement**, not a table entry. |

### `aspic_results.attacks` — already covered

| subkey | shape | verdict | reason |
|---|---|---|---|
| `attacks[*].target` / `.attacker_premises` | source atoms | **DONE (a9bcf516)** | pass 5d `_OPAQUE_NESTED_ITEM_SUBKEYS` l.206 (#1649 follow-up); `scope`/`attacker_rule` kept |

## Implementation

- **`_OPAQUE_FORMALISM_SPECIFIC`** spec table (leaf → mode: `mapping` / `dict_list` / `atom_list`).
- **`_scrub_formalism_specific(sidecar)`** — opacifies named leaves, leaves the rest (`criterion`/`weight_statistics`/`program_size`) untouched. Topology preserved everywhere (list arity, mapping key count, numeric `weight`) so downstream quantitative aggregates are unaffected — same contract as 4b/4c.
- **Pass 4d** iterates `dung_frameworks` entries, scrubs `formalism_specific` if present.

## Tests

- **`test_sanitize_formalism_specific_1702.py`** (new, 11 tests): direct contract — each nominative leaf opacified, closed-vocab/numeric survive, topology preserved, defensive on absent/non-dict/empty sidecar.
- **`test_sanitize_coverage_guard_1702.py`** (updated): the seven `formalism_specific` paths **removed from `EXPECTED_UNCOVERED`** (the bidirectional guard goes red when a frozen gap gets covered without updating the baseline — intended workflow). **Three new substitution controls** prove pass 4d is alive per-leaf (removing `set_attacks`/`contraries`/`attack_weights` re-leaks the canary). The substitution parametrize is decoupled to a 4-tuple `(table_attr, remove_field, survivor_field, expected_fragment)` because the formalism_specific table key (`set_attacks`) nests under a different top-level field (`dung_frameworks`).
- **522 tests green** (evaluation/ 483 + Wave-2 writers + belief-revision wiring 39), **0 regression**. `black` clean.

## Honest scope

- **DoD item 5 (« vérifier sur un état réel »)**: the canary guard exercises the exact producer assignment shapes (verified at each `_write_*` site), and the bidirectional baseline proves zero canary survivors in `formalism_specific` post-scrub. True real-state snapshots live on ai-01 (data-gated, same path as #1668/#1698) — a real-snapshot spot-check is an ai-01 lane, not blocked by this PR.
- **Pre-existing mypy strict** error on `sanitize_state.py` (`return data` Any-inference from the Pydantic `model_dump()` branch) — unchanged by this PR (same error on main, shifted line), not fixed to keep the diff scoped (#1702 scrubber only).

Refs #1702
