### PR TITLE
feat(runner): --mode pipeline|conversational for run_real_analysis.py (#1668 item 5-bis Temps 1)

### DIFF
--- a/scripts/run_real_analysis.py
+++ b/scripts/run_real_analysis.py
@@ -13,6 +13,17 @@ everything that reaches git; this artifact stays on disk.
 
 Usage:
     conda run -n projet-is-roo-new --no-capture-output python scripts/run_real_analysis.py --corpus A
+    conda run -n projet-is-roo-new --no-capture-output python scripts/run_real_analysis.py --corpus A --mode conversational
+
+``--mode`` selects the orchestration path (#1668 item 5-bis):
+  * ``pipeline`` (default) — sequential DAG via ``run_unified_analysis`` workflow
+    ``spectacular``. The historic, unchanged behaviour.
+  * ``conversational`` — SK AgentGroupChat multi-agent dialogue via
+    ``run_conversational_analysis`` (``workflow_name="conversational"``). The
+    runner surfaces ``execution_path`` (agent_group_chat / round_robin_fallback)
+    and detects a silent fallback to pipeline (the conversational path raises
+    inside ``run_unified_analysis`` and is swallowed back to ``standard``) by
+    the absence of the conversational result keys — fail-loud, anti-#1019.
 """
 
 import argparse
@@ -43,6 +54,38 @@ from argumentation_analysis.core.io_manager import load_extract_definitions
 CORPUS_SRC_IDX = {"A": 11, "B": 3, "C": 2}
 RESULTS_DIR = Path("argumentation_analysis/evaluation/results/real_analysis")
 DATASET_PATH = Path("argumentation_analysis/data/extract_sources.json.gz.enc")
+
+# Mode → run_unified_analysis workflow_name. The pipeline mode is the historic
+# ``spectacular`` workflow; the conversational mode routes through
+# ``run_conversational_analysis`` inside ``run_unified_analysis``. Kept as a
+# standalone mapping so the routing is unit-testable without an API run.
+MODE_TO_WORKFLOW: Dict[str, str] = {
+    "pipeline": "spectacular",
+    "conversational": "conversational",
+}
+
+# Result keys that distinguish a genuine conversational run from a pipeline
+# fallback (run_unified_analysis swallows a conversational exception back to
+# ``standard``). Used to detect the silent fallback — anti-#1019.
+_CONV_RESULT_KEYS = ("conversation_log", "execution_path")
+
+
+def is_conversational_fallback(mode: str, result: Any) -> bool:
+    """Did a ``--mode conversational`` run silently fall back to the pipeline?
+
+    ``run_unified_analysis`` swallows a conversational exception back to the
+    ``standard`` workflow and returns a pipeline result. A mode-conversational
+    run that returns a result without any conversational key
+    (``conversation_log`` / ``execution_path``) is NOT a conversational verdict
+    — the two call opposite paths, and reading the fallback as the mode asked
+    for would measure the wrong voie (#1668 item 5-bis anti-#1019). Pure
+    function (no I/O) so the detection is unit-testable without an API run.
+    """
+    if mode != "conversational":
+        return False
+    if not isinstance(result, dict):
+        return True
+    return not any(k in result for k in _CONV_RESULT_KEYS)
 
 
 def load_corpus(label: str, max_chars: int = 60000) -> Dict[str, Any]:
@@ -93,12 +136,21 @@ def render_markdown(
     label: str,
     elapsed: float,
     summary: Dict[str, Any] | None = None,
+    mode: str = "pipeline",
+    execution_path: str | None = None,
+    conversational_fallback: bool = False,
 ) -> str:
     md = [f"# Analyse réelle (non-anonymisée) — corpus {label}", ""]
     md.append(f"> Généré localement, chemin GITIGNORED. Ne pas committer / publier.")
-    md.append(
-        f"> Pipeline: `spectacular` + `fallacy_tier:full` — {elapsed:.1f}s — corpus {corpus['raw_len']} chars (tronqué à {len(corpus['text'])})."
-    )
+    mode_line = f"> Mode: `{mode}` — {elapsed:.1f}s — corpus {corpus['raw_len']} chars (tronqué à {len(corpus['text'])})."
+    if mode == "conversational":
+        path_str = execution_path or "—"
+        mode_line += f" — execution_path: `{path_str}`"
+        if conversational_fallback:
+            mode_line += " — ⚠ FALLBACK pipeline (voie conversationnelle non atteinte)"
+    else:
+        mode_line += " — workflow: `spectacular` + `fallacy_tier:full`"
+    md.append(mode_line)
     md.append("")
     md.append("## Identité réelle du corpus (métadonnées source)")
     md.append("")
@@ -234,10 +286,14 @@ def render_markdown(
     return "\n".join(md)
 
 
-async def main_async(label: str) -> None:
+async def main_async(label: str, mode: str = "pipeline") -> None:
     from argumentation_analysis.orchestration.unified_pipeline import (
         run_unified_analysis,
     )
+
+    if mode not in MODE_TO_WORKFLOW:
+        raise ValueError(f"unknown mode '{mode}'; choose from {list(MODE_TO_WORKFLOW)}")
+    workflow_name = MODE_TO_WORKFLOW[mode]
 
     RESULTS_DIR.mkdir(parents=True, exist_ok=True)
     corpus = load_corpus(label)
@@ -245,6 +301,7 @@ async def main_async(label: str) -> None:
         f"[REAL] corpus {label}: {corpus['raw_len']} chars (using {len(corpus['text'])})"
     )
     print(f"[REAL] meta: {corpus['meta']}")
+    print(f"[REAL] mode: {mode} (workflow_name={workflow_name})")
 
     # NO shield_config: (a) the owner wants the REAL non-anonymized view, the shield
     # injects an opaque-ID directive; (b) shield_config switches the workflow name to
@@ -254,34 +311,73 @@ async def main_async(label: str) -> None:
     context = {"fallacy_tier": "full"}
     t0 = time.time()
     result = await run_unified_analysis(
-        text=corpus["text"], workflow_name="spectacular", context=context
+        text=corpus["text"], workflow_name=workflow_name, context=context
     )
     elapsed = time.time() - t0
     print(f"[REAL] pipeline done in {elapsed:.1f}s")
 
+    # Fail-loud on the silent conversational→pipeline fallback (#1668 item 5-bis
+    # anti-#1019): run_unified_analysis swallows a conversational exception back
+    # to ``standard``. A mode-conversational run that returns a pipeline result
+    # (no conversation_log / execution_path) is NOT a conversational verdict —
+    # the two call opposite paths, and reading the fallback as the mode asked
+    # for would measure the wrong voie. The proof of presence is these keys.
+    if is_conversational_fallback(mode, result):
+        print(
+            "[REAL] WARNING: --mode conversational requested but the result "
+            "carries no conversational keys (conversation_log/execution_path) — "
+            "run_unified_analysis fell back to the pipeline. The state below is "
+            "a PIPELINE verdict, NOT a conversational one. Re-run after fixing "
+            "the conversational path before measuring #1668 item 5-bis."
+        )
+
     state = result.get("unified_state")
     snap = state.get_state_snapshot(summarize=False) if state is not None else {}
 
-    # Full ground-truth JSON (unscrubbed — gitignored)
-    json_path = RESULTS_DIR / f"real_{label}_state.json"
+    # Full ground-truth JSON (unscrubbed — gitignored). Keep the mode in the
+    # filename so the two voies do not overwrite each other when both are run.
+    json_path = RESULTS_DIR / f"real_{label}_{mode}_state.json"
     with open(json_path, "w", encoding="utf-8") as f:
         json.dump(snap, f, indent=2, ensure_ascii=False, default=str)
     print(f"[REAL] full snapshot -> {json_path}")
 
     # Readable digest
-    md = render_markdown(snap, corpus, label, elapsed, summary=result.get("summary"))
-    md_path = RESULTS_DIR / f"real_{label}_report.md"
+    conv_fallback = is_conversational_fallback(mode, result)
+    md = render_markdown(
+        snap,
+        corpus,
+        label,
+        elapsed,
+        summary=result.get("summary"),
+        mode=mode,
+        execution_path=(
+            result.get("execution_path") if isinstance(result, dict) else None
+        ),
+        conversational_fallback=conv_fallback,
+    )
+    md_path = RESULTS_DIR / f"real_{label}_{mode}_report.md"
     with open(md_path, "w", encoding="utf-8") as f:
         f.write(md)
     print(f"[REAL] readable report -> {md_path}")
     print(f"[REAL] top-level snapshot keys: {sorted(snap.keys())}")
 
 
-def main():
-    parser = argparse.ArgumentParser()
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
     parser.add_argument("--corpus", choices=["A", "B", "C"], default="A")
+    parser.add_argument(
+        "--mode",
+        choices=list(MODE_TO_WORKFLOW),
+        default="pipeline",
+        help="orchestration path: pipeline (default, sequential DAG) or "
+        "conversational (SK AgentGroupChat dialogue). The conversational mode "
+        "is the voie the #1668 item 5-bis gate lives on.",
+    )
     args = parser.parse_args()
-    asyncio.run(main_async(args.corpus))
+    asyncio.run(main_async(args.corpus, args.mode))
 
 
 if __name__ == "__main__":

--- a/tests/unit/argumentation_analysis/orchestration/test_runner_mode_1668.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_runner_mode_1668.py
@@ -1,0 +1,202 @@
+"""Tests for the ``--mode`` wiring of ``scripts/run_real_analysis.py`` (#1668).
+
+The runner gained ``--mode pipeline|conversational`` (#1668 item 5-bis Temps 1)
+so the cluster can drive the conversational voie — the one the
+``("UNDERCUT","REBUT","REBUTTAL")`` gate lives on — without confining corpus
+measurement to one machine.
+
+These tests cover the WIRING only (mode → workflow_name routing + silent-fallback
+detection), not the conversational verdict itself (that needs a live corpus run,
+~450-720 s + API credits — #1668 item 5-bis Temps 2). The routing is exercised
+by mocking ``run_unified_analysis``; no API call is made. Anti-#1019: a mock is
+legitimate here because the unit under test is *our routing code*, not the
+orchestrator behaviour — the live run (Temps 2) validates the voie executes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from scripts.run_real_analysis import (
+    MODE_TO_WORKFLOW,
+    is_conversational_fallback,
+)
+
+
+class TestModeToWorkflowMapping:
+    """The mode→workflow_name mapping is the routing contract."""
+
+    def test_pipeline_is_the_default_and_unchanged(self) -> None:
+        # Historic behaviour: pipeline → spectacular. Must not change without a
+        # deliberate decision (the spectacular workflow is what FB-37 ran).
+        assert MODE_TO_WORKFLOW["pipeline"] == "spectacular"
+
+    def test_conversational_routes_through_run_conversational_analysis(self) -> None:
+        # conversational → workflow_name="conversational", which run_unified_analysis
+        # routes to run_conversational_analysis (unified_pipeline.py:207-217).
+        assert MODE_TO_WORKFLOW["conversational"] == "conversational"
+
+    def test_choices_match_the_mapping_keys(self) -> None:
+        # The argparse choices=list(MODE_TO_WORKFLOW) — kept in sync by construction.
+        assert set(MODE_TO_WORKFLOW) == {"pipeline", "conversational"}
+
+
+class TestIsConversationalFallback:
+    """The silent fallback detector — pure function, no I/O.
+
+    run_unified_analysis swallows a conversational exception back to ``standard``.
+    A mode-conversational run whose result carries NO conversational key is a
+    pipeline verdict mislabelled — the exact #1019 defect this gate prevents
+    (reading a fallback as the asked-for mode would measure the wrong voie).
+    """
+
+    def test_pipeline_mode_never_reports_fallback(self) -> None:
+        # Pipeline is the fallback target — it cannot "fall back to itself".
+        assert is_conversational_fallback("pipeline", {}) is False
+        assert is_conversational_fallback("pipeline", {"conversation_log": []}) is False
+
+    def test_conversational_with_conv_keys_is_genuine(self) -> None:
+        # A genuine conversational result carries execution_path and/or
+        # conversation_log — not a fallback.
+        assert (
+            is_conversational_fallback(
+                "conversational", {"execution_path": "agent_group_chat"}
+            )
+            is False
+        )
+        assert (
+            is_conversational_fallback("conversational", {"conversation_log": []})
+            is False
+        )
+
+    def test_conversational_without_conv_keys_is_fallback(self) -> None:
+        # The conversational path raised inside run_unified_analysis and was
+        # swallowed back to standard — the result is a pipeline verdict.
+        assert is_conversational_fallback("conversational", {"summary": {}}) is True
+
+    def test_conversational_with_non_dict_result_is_fallback(self) -> None:
+        assert is_conversational_fallback("conversational", None) is True
+
+
+class TestMainAsyncRouting:
+    """main_async passes the right workflow_name and warns on the silent fallback.
+
+    ``run_unified_analysis`` and ``load_corpus`` are mocked — no API call, no
+    dataset decrypt. The assertion is on the workflow_name our routing passes
+    (captured by the mock), not on the orchestrator's behaviour.
+    """
+
+    @staticmethod
+    def _fake_corpus() -> Dict[str, Any]:
+        return {"text": "x", "raw_len": 1, "meta": {"src": "opaque"}}
+
+    @pytest.mark.asyncio
+    async def test_pipeline_mode_passes_spectacular_workflow(self) -> None:
+        from scripts.run_real_analysis import main_async
+
+        captured: Dict[str, Any] = {}
+
+        async def fake_run(
+            text: str, workflow_name: str, context: Any
+        ) -> Dict[str, Any]:
+            captured["workflow_name"] = workflow_name
+            return {"unified_state": None, "summary": {}}
+
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            new=AsyncMock(side_effect=fake_run),
+        ), patch(
+            "scripts.run_real_analysis.load_corpus",
+            return_value=self._fake_corpus(),
+        ), patch(
+            "scripts.run_real_analysis.RESULTS_DIR"
+        ), patch(
+            "builtins.open", new=mock_open_noop()
+        ):
+            await main_async("A", mode="pipeline")
+
+        assert captured["workflow_name"] == "spectacular"
+
+    @pytest.mark.asyncio
+    async def test_conversational_mode_passes_conversational_workflow(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        from scripts.run_real_analysis import main_async
+
+        captured: Dict[str, Any] = {}
+
+        async def fake_run(
+            text: str, workflow_name: str, context: Any
+        ) -> Dict[str, Any]:
+            captured["workflow_name"] = workflow_name
+            # A genuine conversational result carries execution_path.
+            return {"unified_state": None, "execution_path": "agent_group_chat"}
+
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            new=AsyncMock(side_effect=fake_run),
+        ), patch(
+            "scripts.run_real_analysis.load_corpus",
+            return_value=self._fake_corpus(),
+        ), patch(
+            "scripts.run_real_analysis.RESULTS_DIR"
+        ), patch(
+            "builtins.open", new=mock_open_noop()
+        ):
+            await main_async("A", mode="conversational")
+
+        assert captured["workflow_name"] == "conversational"
+        out = capsys.readouterr().out
+        # Genuine conversational ⇒ no fallback WARNING printed.
+        assert "WARNING" not in out
+
+    @pytest.mark.asyncio
+    async def test_conversational_fallback_prints_warning(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The silent fallback is detected and printed — fail-loud, anti-#1019.
+
+        run_unified_analysis swallowed the conversational exception and returned
+        a pipeline result (no conversation_log / execution_path). The runner
+        must say so, not hand back a pipeline verdict labelled conversational.
+        """
+        from scripts.run_real_analysis import main_async
+
+        async def fake_run(
+            text: str, workflow_name: str, context: Any
+        ) -> Dict[str, Any]:
+            # Note: workflow_name IS "conversational" (we routed correctly), but
+            # the RESULT is a pipeline fallback (no conv keys) — the swallow.
+            return {"unified_state": None, "summary": {"completed_phases": ["extract"]}}
+
+        with patch(
+            "argumentation_analysis.orchestration.unified_pipeline.run_unified_analysis",
+            new=AsyncMock(side_effect=fake_run),
+        ), patch(
+            "scripts.run_real_analysis.load_corpus",
+            return_value=self._fake_corpus(),
+        ), patch(
+            "scripts.run_real_analysis.RESULTS_DIR"
+        ), patch(
+            "builtins.open", new=mock_open_noop()
+        ):
+            await main_async("A", mode="conversational")
+
+        out = capsys.readouterr().out
+        assert "WARNING" in out
+        assert "fell back to the pipeline" in out
+
+
+def mock_open_noop() -> Any:
+    """A context-manager mock for ``open`` that discards writes (the runner
+    dumps JSON + Markdown to a gitignored path; the test does not assert on
+    file content, only on routing + the printed fallback warning)."""
+    from unittest.mock import MagicMock
+
+    m = MagicMock()
+    m.return_value.__enter__.return_value = MagicMock()
+    m.return_value.__exit__.return_value = False
+    return m


### PR DESCRIPTION
## What

R795 dispatch (ai-01 → po-2025, item 5-bis Temps 1): add `--mode pipeline|conversational` to the corpus measurement runner so the cluster can drive the conversational voie — the one the `("UNDERCUT","REBUT","REBUTTAL")` gate lives on — without confining corpus measurement to one machine.

> *« Ajoute `--mode pipeline|conversational` (défaut `pipeline`, comportement actuel inchangé). C'est du câblage, ta lane. Livre-le en PR séparée de la mesure : l'outil a une valeur propre pour le cluster, il ne doit pas attendre le verdict. »*

## Changes

`scripts/run_real_analysis.py`:
- `--mode` (choices `pipeline`/`conversational`, default `pipeline`) maps to `run_unified_analysis` `workflow_name` via `MODE_TO_WORKFLOW` (`pipeline`→`spectacular` unchanged; `conversational`→`conversational`, routes to `run_conversational_analysis`).
- `is_conversational_fallback(mode, result)` — pure function detecting the **silent fallback** (anti-#1019): `run_unified_analysis` swallows a conversational exception back to `standard`; a mode-conversational result with no `conversation_log`/`execution_path` is a pipeline verdict mislabelled. Prints a `WARNING` — reading the fallback as the asked-for mode would measure the wrong voie.
- Report header surfaces `mode` + `execution_path` (`agent_group_chat`/`round_robin_fallback`) + a `⚠ FALLBACK` marker.
- Output filenames carry the mode (`real_{label}_{mode}_state.json`) so the two voies don't overwrite each other.

## Why the fallback detector is the point

Temps 2 (the live measure) asks: *does the gate fire on the conversational voie?* A 0 "never reached" and a 0 "evaluated and rejected" are numerically identical and call for **opposite** fixes — the exact #1019 trap that bit this issue once already (the 0/66 that wasn't a rejection). The detector surfaces the prior question — *did the voie even run?* — so the live measure starts from a known voie, not an assumed one. The proof of presence is a conversational key in the result, not a reasoning over the call graph.

## Tests — `test_runner_mode_1668.py` (10)

- `TestModeToWorkflowMapping` (3): the routing contract (pipeline=spectacular historic; conversational=conversational; choices match keys).
- `TestIsConversationalFallback` (4): pure-function detector (pipeline never reports; conv-with-keys genuine; conv-without-keys fallback; non-dict result fallback).
- `TestMainAsyncRouting` (3): `main_async` passes the right `workflow_name` (captured by mock) + WARNING on fallback / no WARNING on genuine. `run_unified_analysis` + `load_corpus` mocked — no API call, no dataset decrypt. **The unit under test is the routing code, not the orchestrator behaviour** (the live run, Temps 2, validates the voie executes).

**Substitution control EXECUTED** (leçon R794: *« un raisonnement juste n'est pas une exécution ; un contrôle par substitution coûte 90 secondes »*): disabling `is_conversational_fallback` (`or True` ⇒ always False) makes `test_conversational_without_conv_keys_is_fallback` red on the reached assertion (`assert ... is True`) and `test_conversational_fallback_prints_warning` red (`assert "WARNING" in out`). Restored, 10/10 green.

**black** clean. **mypy** clean on the diff (1 pre-existing error in unchanged `load_corpus` — `derive_encryption_key` returns `bytes|None` vs `str|None` — structural, `scripts/` is outside CI mypy scope anyway).

## Scope / lane

Worker PR (po-2025) — lane merge coord `--admin`. Temps 2 (live conversational corpus run + gate-reach verdict, 3-state per #1605) follows in a separate change; it needs the ~450-720 s + credits run on one corpus.

Privacy: no corpus content in this PR; the runner output stays under the gitignored `evaluation/results/real_analysis/`.

🤖 Worker po-2025 — R795