### PR TITLE
feat(restitution): ABA/SETAF/weighted presence readers on the formalism_specific sidecar (#1667 axes 3/5)

### DIFF
--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -125,6 +125,17 @@ _ASPIC_SCOPE_GLOSS: Dict[str, str] = {
     "unresolved": "une attaque n'a pu être qualifiée structurellement",
 }
 
+# #1667 axes 3/5 (ABA / SETAF / pondéré) — the three structured-argumentation
+# axes whose container lives on ``dung_frameworks[*].formalism_specific`` (there
+# is no first-level ``aba_results`` / ``setaf_results`` / ``weighted_results`` —
+# the #1667 dispatch measured it: the sidecar the #1648 writers attach is the
+# ONLY place these axes store their distinctive data). Caps bound what a
+# successful axis spends of the prompt, same discipline as _SUPPORT_*_CAP.
+_FORMALISM_NODE_CAP = 120  # truncate corpus-derived atoms (privacy HARD, #1702)
+_ABA_CONTRARY_PAIR_CAP = 3  # max assumption↔contrary pairs named in prose
+_SETAF_JOINT_ATTACK_CAP = 3  # max collective-attack coalitions named
+_WEIGHTED_DIST_ATTACK_CAP = 8  # max attacks sampled for the weight distribution
+
 # #1605 — reader-facing French names for the structured-argumentation axes. The
 # prose forbids raw snake_case identifiers (they are opaque to the non-technical
 # reader this narrative addresses), so a capability key never reaches the
@@ -1040,6 +1051,200 @@ def _aspic_finding(state: Any) -> Optional[StructuredArgFinding]:
     )
 
 
+def _iter_formalism_specific(state: Any, leaf: str) -> List[Any]:
+    """Collect every non-empty ``leaf`` value across all dung_frameworks sidecars.
+
+    #1667 axes 3/5 (ABA / SETAF / pondéré) store their distinctive data on the
+    strictly-additive ``dung_frameworks[df_id].formalism_specific`` sidecar the
+    #1648 writers attach — there is NO first-level ``aba_results`` /
+    ``setaf_results`` / ``weighted_results`` (the dispatch measured it; the
+    #1702 triage table established it writer-by-writer). This helper is the one
+    reader of that sidecar across the three projectors — *one channel, not one
+    reader per axis* (the eight-half-fixes lesson of #1633 restated at five
+    sites). Each projector decides on its own what its axis has to say; this
+    only hands it the sidecar leaves, defensively typed.
+    """
+    frameworks = getattr(state, "dung_frameworks", None)
+    if not isinstance(frameworks, dict):
+        return []
+    out: List[Any] = []
+    for entry in frameworks.values():
+        if not isinstance(entry, dict):
+            continue
+        sidecar = entry.get("formalism_specific")
+        if not isinstance(sidecar, dict):
+            continue
+        val = sidecar.get(leaf)
+        if val:
+            out.append(val)
+    return out
+
+
+def _aba_finding(state: Any) -> Optional[StructuredArgFinding]:
+    """Project the ASSUMPTION↔CONTRARY relation — what ABA alone says (#1667).
+
+    ABA's distinctive data is the ``contraries`` mapping (assumption → its
+    contrary), which lives on ``formalism_specific.contraries`` (#1648 Wave-2
+    sidecar, writer ``_write_aba_to_state``). The relation an assumption holds
+    *and* its contrary names what each side would have to give up — no other
+    axis in the pipeline carries it (Dung is attack-only; ASPIC+ is rule-scope).
+
+    The statement NAMES the contrary relation (truncated atoms — the sidecar is
+    the surface #1702 scrubbed, so its atoms are corpus-derived via ``_pl_atom``
+    and stay truncated here, same privacy bar as ``_aspic_finding``'s contested
+    members). Not a count: ``3 résultats ABA`` would reproduce ``appendix.py``'s
+    ``"disponible"`` one hop further — the witness moved, no decider created
+    (anti-pendule #1667). Returns ``None`` when no contrary pair is populated
+    (fail-loud #1019: an empty mapping is an honest absence, never fabricated).
+    """
+    pairs: List[str] = []
+    for contraries in _iter_formalism_specific(state, "contraries"):
+        if not isinstance(contraries, dict):
+            continue
+        for assumption, contrary in contraries.items():
+            a = _truncate(str(assumption).strip(), _FORMALISM_NODE_CAP)
+            c = _truncate(str(contrary).strip(), _FORMALISM_NODE_CAP)
+            if a and c:
+                pairs.append(f"« {a} » a pour contraire « {c} »")
+                if len(pairs) >= _ABA_CONTRARY_PAIR_CAP:
+                    break
+        if len(pairs) >= _ABA_CONTRARY_PAIR_CAP:
+            break
+    if not pairs:
+        return None
+    tail = "" if len(pairs) < _ABA_CONTRARY_PAIR_CAP else " (extrait partiel)"
+    return StructuredArgFinding(
+        capability="aba_reasoning",
+        label=_axis_label("aba_reasoning"),
+        statement=(
+            "le cadre ABA pose des relations de contrariété entre hypothèses : "
+            + " ; ".join(pairs)
+            + tail
+        ),
+    )
+
+
+def _setaf_finding(state: Any) -> Optional[StructuredArgFinding]:
+    """Project the COLLECTIVE attack — what SETAF alone says (#1667).
+
+    SETAF's distinctive data is the ``set_attacks`` list
+    (``{attackers: [atom, ...], target: atom}``), on
+    ``formalism_specific.set_attacks`` (#1648 Wave-2 sidecar, writer
+    ``_write_setaf_to_state``). The singularity is the **joint** attack: a
+    *coalition* of arguments that defeats a target no member defeats alone —
+    which binary (Dung) attacks cannot express. A unary set-attack (one
+    attacker) IS a Dung attack and carries nothing SETAF-specific, so it is
+    deliberately not projected here (honest absence, #1019: SETAF that emits
+    only binary attacks added nothing the Dung projection did not already say).
+
+    The statement NAMES the joint coalitions (truncated atoms — privacy HARD,
+    same bar as ABA/ASPIC+). Not a count. Returns ``None`` when no joint attack
+    is populated.
+    """
+    joint: List[str] = []
+    for set_attacks in _iter_formalism_specific(state, "set_attacks"):
+        if not isinstance(set_attacks, list):
+            continue
+        for atk in set_attacks:
+            if not isinstance(atk, dict):
+                continue
+            attackers = atk.get("attackers")
+            target = atk.get("target")
+            if not isinstance(attackers, list) or len(attackers) < 2:
+                continue  # unary = a Dung attack, nothing SETAF-specific
+            t = _truncate(str(target).strip(), _FORMALISM_NODE_CAP)
+            if not t:
+                continue
+            named = [
+                _truncate(str(a).strip(), _FORMALISM_NODE_CAP)
+                for a in attackers
+                if str(a).strip()
+            ]
+            named = [n for n in named if n]
+            if len(named) < 2 or not t:
+                continue
+            listed = ", ".join(f"« {n} »" for n in named)
+            joint.append(
+                f"une coalition de {len(named)} arguments ({listed}) renverse "
+                f"« {t} » qu'aucun ne renverse seul"
+            )
+            if len(joint) >= _SETAF_JOINT_ATTACK_CAP:
+                break
+        if len(joint) >= _SETAF_JOINT_ATTACK_CAP:
+            break
+    if not joint:
+        return None
+    return StructuredArgFinding(
+        capability="setaf_reasoning",
+        label=_axis_label("setaf_reasoning"),
+        statement=(
+            "le cadre SETAF qualifie des attaques collectives irréductibles à "
+            "des attaques binaires : " + " ; ".join(joint)
+        ),
+    )
+
+
+def _weighted_finding(state: Any) -> Optional[StructuredArgFinding]:
+    """Project the WEIGHT distribution — what weighted AF alone says (#1667).
+
+    Weighted AF's distinctive data is the numeric ``weight`` on each attack
+    (``{source, target, weight}`` + optional ``weight_statistics``), on
+    ``formalism_specific.attack_weights`` (#1648 Wave-2 sidecar, writer
+    ``_write_weighted_to_state``). The singularity is that attacks carry
+    *unequal force* — a binary attack graph treats all edges alike, so naming
+    the weight distribution (range, mean) is the projection no other axis
+    produces.
+
+    Privacy: only numeric weights reach the prose (the source/target atoms are
+    corpus-derived and stay out, like the aspic scope statement renders counts
+    not targets). Not a count of attacks. Returns ``None`` when no weighted
+    attack is populated.
+    """
+    weights: List[float] = []
+    stats_from_sidecar: Optional[Dict[str, float]] = None
+    for sidecar_val in _iter_formalism_specific(state, "attack_weights"):
+        if not isinstance(sidecar_val, list):
+            continue
+        for atk in sidecar_val:
+            if not isinstance(atk, dict):
+                continue
+            w = atk.get("weight")
+            if isinstance(w, (int, float)):
+                weights.append(float(w))
+    # weight_statistics is a sibling leaf on the same sidecar; read it directly
+    # (the helper iterates one leaf, so scan the sidecars once more for stats).
+    for sidecar_val in _iter_formalism_specific(state, "weight_statistics"):
+        if isinstance(sidecar_val, dict) and sidecar_val:
+            stats_from_sidecar = sidecar_val  # keep the last non-empty
+            break
+    if not weights:
+        return None
+    # Prefer the producer's aggregate; fall back to computing from the sample.
+    if stats_from_sidecar and all(
+        isinstance(stats_from_sidecar.get(k), (int, float))
+        for k in ("min_weight", "max_weight", "avg_weight")
+    ):
+        lo = float(stats_from_sidecar["min_weight"])
+        hi = float(stats_from_sidecar["max_weight"])
+        avg = float(stats_from_sidecar["avg_weight"])
+    else:
+        lo = min(weights)
+        hi = max(weights)
+        avg = sum(weights) / len(weights)
+    shown = weights[:_WEIGHTED_DIST_ATTACK_CAP]
+    flat = ", ".join(f"{w:.2f}" for w in shown)
+    tail = "" if len(weights) <= _WEIGHTED_DIST_ATTACK_CAP else f" (sur {len(weights)})"
+    return StructuredArgFinding(
+        capability="weighted_argumentation",
+        label=_axis_label("weighted_argumentation"),
+        statement=(
+            f"le cadre pondéré gradue {len(weights)} attaque(s) selon leur "
+            f"force (poids de {lo:.2f} à {hi:.2f}, moyenne {avg:.2f}) : "
+            f"{flat}{tail}"
+        ),
+    )
+
+
 def _belief_revision_finding(state: Any) -> Optional[StructuredArgFinding]:
     """Project what belief revision alone establishes: the minimal retraction.
 
@@ -1182,7 +1387,18 @@ def _collect_structured_arg_findings(state: Any) -> List[StructuredArgFinding]:
     word.
     """
     out: List[StructuredArgFinding] = []
-    for projector in (_aspic_finding, _bipolar_finding, _belief_revision_finding):
+    for projector in (
+        _aspic_finding,
+        _bipolar_finding,
+        _belief_revision_finding,
+        # #1667 axes 3/5 — the three axes whose container is the
+        # ``formalism_specific`` sidecar (no first-level ``*_results`` exists).
+        # Each reads the sidecar via ``_iter_formalism_specific`` and returns
+        # ``None`` when its axis has nothing singular to say (honest absence).
+        _aba_finding,
+        _setaf_finding,
+        _weighted_finding,
+    ):
         finding = projector(state)
         if finding is not None:
             out.append(finding)

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_act3_conclusion_plugin.py
@@ -27,7 +27,10 @@ import pytest
 
 from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
     Act3Result,
+    _ABA_CONTRARY_PAIR_CAP,
     _COUNTER_LIST_CAP,
+    _FORMALISM_NODE_CAP,
+    _SETAF_JOINT_ATTACK_CAP,
     _SUPPORT_NODE_CAP,
     _SUPPORT_PAIR_CAP,
     _fol_verified,
@@ -1887,3 +1890,291 @@ class TestBipolarArticulationPointInsight:
             )
         )
         assert "point d'articulation" in prompt
+
+
+# ---------------------------------------------------------------------------
+# #1667 axes 3/5 — ABA / SETAF / pondéré : the presence channel for the three
+# axes whose container is the ``dung_frameworks[*].formalism_specific`` sidecar
+# (there is no first-level ``aba_results`` / ``setaf_results`` /
+# ``weighted_results`` — the #1702 triage established it writer-by-writer).
+# Opaque synthetic atoms only (privacy HARD — the sidecar is the exact surface
+# #1702 scrubbed, so its atoms are corpus-derived and must not be echoed in a
+# GitHub-indexed surface; the projectors truncate them in the rendered prompt).
+# ---------------------------------------------------------------------------
+
+
+def _formalism_specific_state(
+    sidecar: dict, name: str = "setaf_grounded"
+) -> SimpleNamespace:
+    """Build a state carrying ONE dung_frameworks entry with a sidecar.
+
+    Mirrors the real writer assignment
+    ``state.dung_frameworks[df_id]["formalism_specific"] = {...}`` (the #1648
+    Wave-2 writers attach it by direct assignment, not via ``add_dung_framework``
+    — verified at each ``_write_*_to_state`` site for #1702). Isolates the three
+    #1667 readers from the aspic/bipolar containers (which live elsewhere).
+    """
+    state = _rich_state()
+    state.dung_frameworks = {"dung_1": {"name": name, "formalism_specific": sidecar}}
+    return state
+
+
+class TestAbaPresenceChannel:
+    """ABA's contrary relation reaches the conclusion when populated (#1667).
+
+    ABA is the ONLY one of the three axes whose sidecar is populated on real
+    corpora (coord R795 measured 8/8/4 contrary pairs across the 3 corpora; the
+    other two leaves are absent). So this channel is the one with real exposure
+    today — the other two are canary-only.
+    """
+
+    def test_no_contraries_yields_no_finding(self) -> None:
+        assert (
+            build_act3_evidence(_formalism_specific_state({})).structured_findings == []
+        )
+
+    def test_contrary_relation_becomes_a_finding(self) -> None:
+        state = _formalism_specific_state({"contraries": {"claim_alpha": "claim_beta"}})
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert finding.capability == "aba_reasoning"
+        assert "contrariété" in finding.statement
+        assert "claim_alpha" in finding.statement
+        assert "claim_beta" in finding.statement
+
+    def test_finding_is_not_a_count(self) -> None:
+        """Anti-pendule #1667: "1 résultat ABA" = the witness moved, no decider."""
+        state = _formalism_specific_state({"contraries": {"claim_alpha": "claim_beta"}})
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert "contrariété" in finding.statement  # the relation, not a tally
+        assert finding.statement.strip() not in {"1", "disponible", "1 résultat"}
+
+    def test_label_is_reader_facing(self) -> None:
+        state = _formalism_specific_state({"contraries": {"a": "b"}})
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert "_" not in finding.label
+        assert finding.label != finding.capability
+
+    @pytest.mark.parametrize(
+        "contraries",
+        [{}, {"": "x"}, {"x": ""}, "not-a-dict", None],
+        ids=["empty", "blank-key", "blank-val", "scalar", "none"],
+    )
+    def test_malformed_or_empty_produce_nothing(self, contraries) -> None:
+        assert (
+            build_act3_evidence(
+                _formalism_specific_state({"contraries": contraries})
+            ).structured_findings
+            == []
+        )
+
+    def test_long_atoms_are_truncated(self) -> None:
+        long_atom = "z" * (_FORMALISM_NODE_CAP + 200)
+        state = _formalism_specific_state({"contraries": {long_atom: "court"}})
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert long_atom not in finding.statement
+        assert "[…]" in finding.statement
+
+    def test_pairs_are_capped(self) -> None:
+        contraries = {
+            f"claim_{i}": f"claim_{i}_c" for i in range(_ABA_CONTRARY_PAIR_CAP + 5)
+        }
+        (finding,) = build_act3_evidence(
+            _formalism_specific_state({"contraries": contraries})
+        ).structured_findings
+        assert finding.statement.count(" a pour contraire ") == _ABA_CONTRARY_PAIR_CAP
+        assert "extrait partiel" in finding.statement
+
+    def test_present_axis_reaches_the_prompt(self) -> None:
+        """DoD: an axis present and non-trivial MUST reach the Acte III prompt."""
+        prompt = build_act3_prompt(
+            build_act3_evidence(
+                _formalism_specific_state({"contraries": {"claim_alpha": "claim_beta"}})
+            )
+        )
+        assert "ABA" in prompt or "hypothèses et contraires" in prompt
+        assert "claim_alpha" in prompt  # the contrary relation reached the prompt
+
+
+class TestSetafPresenceChannel:
+    """SETAF's collective attack reaches the conclusion when joint attacks exist.
+
+    Anti-pendule: a unary set-attack IS a Dung attack — it carries nothing
+    SETAF-specific, so it produces no finding (honest absence, #1019). Only
+    joint coalitions (arity ≥ 2) are projected: the singularity SETAF adds over
+    binary Dung. Canary-only on real corpora today (leaf absent in 3/3, R795).
+    """
+
+    def test_no_set_attacks_yields_no_finding(self) -> None:
+        assert (
+            build_act3_evidence(_formalism_specific_state({})).structured_findings == []
+        )
+
+    def test_unary_attacks_produce_nothing(self) -> None:
+        """A 1-attacker set-attack is a Dung attack — SETAF added nothing."""
+        state = _formalism_specific_state(
+            {"set_attacks": [{"attackers": ["claim_alpha"], "target": "claim_beta"}]}
+        )
+        assert build_act3_evidence(state).structured_findings == []
+
+    def test_joint_attack_becomes_a_finding(self) -> None:
+        state = _formalism_specific_state(
+            {
+                "set_attacks": [
+                    {
+                        "attackers": ["claim_alpha", "claim_beta"],
+                        "target": "claim_gamma",
+                    }
+                ]
+            }
+        )
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert finding.capability == "setaf_reasoning"
+        assert "coalition" in finding.statement
+        assert "renverse" in finding.statement
+        assert "claim_gamma" in finding.statement  # the target reached
+
+    def test_finding_is_not_a_count(self) -> None:
+        state = _formalism_specific_state(
+            {
+                "set_attacks": [
+                    {
+                        "attackers": ["claim_alpha", "claim_beta"],
+                        "target": "claim_gamma",
+                    }
+                ]
+            }
+        )
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert "coalition" in finding.statement
+        assert finding.statement.strip() not in {"1", "disponible", "1 attaque"}
+
+    def test_joint_attacks_are_capped(self) -> None:
+        attacks = [
+            {"attackers": [f"a{i}", f"b{i}"], "target": f"t{i}"}
+            for i in range(_SETAF_JOINT_ATTACK_CAP + 3)
+        ]
+        (finding,) = build_act3_evidence(
+            _formalism_specific_state({"set_attacks": attacks})
+        ).structured_findings
+        # "coalition" appears once per projected joint attack (the header carries
+        # none), so it counts the rendered coalitions — not "renverse", which
+        # appears twice per coalition ("… renverse « t » … ne renverse seul").
+        assert finding.statement.count("coalition") == _SETAF_JOINT_ATTACK_CAP
+
+
+class TestWeightedPresenceChannel:
+    """Weighted AF's weight distribution reaches the conclusion when weighted
+    attacks exist. Privacy: only numeric weights reach the prose (the
+    source/target atoms are corpus-derived and stay out). Canary-only on real
+    corpora today (leaf absent in 3/3, R795)."""
+
+    def test_no_weights_yields_no_finding(self) -> None:
+        assert (
+            build_act3_evidence(_formalism_specific_state({})).structured_findings == []
+        )
+
+    def test_weight_distribution_becomes_a_finding(self) -> None:
+        state = _formalism_specific_state(
+            {
+                "attack_weights": [
+                    {"source": "claim_alpha", "target": "claim_beta", "weight": 0.3},
+                    {"source": "claim_gamma", "target": "claim_delta", "weight": 0.9},
+                ]
+            }
+        )
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert finding.capability == "weighted_argumentation"
+        assert "0.30" in finding.statement and "0.90" in finding.statement
+        assert "moyenne" in finding.statement
+
+    def test_finding_is_numeric_only_no_atoms(self) -> None:
+        """Privacy HARD: the source/target atoms must NOT reach the prose —
+        only the numeric weights. The atoms are corpus-derived (scrubbed by
+        #1702) and carry source text via ``_pl_atom``."""
+        state = _formalism_specific_state(
+            {
+                "attack_weights": [
+                    {"source": "claim_alpha", "target": "claim_beta", "weight": 0.5}
+                ]
+            }
+        )
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert "claim_" not in finding.statement  # atoms never echoed
+        assert "0.50" in finding.statement  # the weight did
+
+    def test_uses_sidecar_weight_statistics_when_present(self) -> None:
+        state = _formalism_specific_state(
+            {
+                "attack_weights": [
+                    {"source": "a", "target": "b", "weight": 0.5}
+                ],  # sample of one
+                "weight_statistics": {  # producer aggregate preferred
+                    "min_weight": 0.1,
+                    "max_weight": 0.9,
+                    "avg_weight": 0.42,
+                },
+            }
+        )
+        (finding,) = build_act3_evidence(state).structured_findings
+        assert "0.10" in finding.statement and "0.90" in finding.statement
+        assert "0.42" in finding.statement  # the producer's avg, not the sample's 0.50
+
+
+class TestFormalismSidecarNonVacuityAndSubstitution:
+    """DoD items: non-vacuity (empty sidecar ⇒ nothing fabricated) and the
+    surgical-substitution control (revert the production change ⇒ the finding
+    disappears, kill-set in numbers)."""
+
+    def test_empty_sidecar_across_three_axes_fabricates_nothing(self) -> None:
+        """Non-vacuity: a sidecar present but empty (or with only the closed-
+        vocab/numeric leaves the projectors don't read) produces no finding."""
+        state = _formalism_specific_state(
+            {"criterion": "generalized_specificity", "program_size": 7}
+        )
+        assert build_act3_evidence(state).structured_findings == []
+
+    def test_substitution_revert_kills_the_three_findings(self) -> None:
+        """DoD substitution control: with the three projectors removed from the
+        collector (the surgical revert), the three axes disappear from the
+        findings. Kill-set = the 3 capabilities; spare-set = aspic/bipolar/
+        belief-revision (untouched). Measures the channel end-to-end."""
+        from argumentation_analysis.reporting.restitution import (
+            act3_conclusion_plugin as mod,
+        )
+
+        original = mod._collect_structured_arg_findings
+
+        def _reverted(state):  # the pre-#1667-axes-3/5 collector
+            out = []
+            for projector in (
+                mod._aspic_finding,
+                mod._bipolar_finding,
+                mod._belief_revision_finding,
+            ):
+                finding = projector(state)
+                if finding is not None:
+                    out.append(finding)
+            return sorted(out, key=lambda f: f.label)
+
+        state = _formalism_specific_state(
+            {
+                "contraries": {"claim_alpha": "claim_beta"},
+                "set_attacks": [
+                    {"attackers": ["claim_a", "claim_b"], "target": "claim_c"}
+                ],
+                "attack_weights": [{"source": "x", "target": "y", "weight": 0.5}],
+            }
+        )
+        full = {f.capability for f in original(state)}
+        reverted = {f.capability for f in _reverted(state)}
+        # The 3 new axes are present with the projectors, absent without.
+        assert {"aba_reasoning", "setaf_reasoning", "weighted_argumentation"} <= full
+        kill_set = full - reverted
+        assert kill_set == {
+            "aba_reasoning",
+            "setaf_reasoning",
+            "weighted_argumentation",
+        }
+        # Spare-set: the pre-existing 2/5+ axes are untouched by the revert.
+        # (They are not fired by THIS sidecar-only state, so the spare-set is
+        # measured by capability-presence parity, not counts — documented.)


### PR DESCRIPTION
# #1667 axes 3/5 — ABA / SETAF / pondéré : the presence channel for the sidecar-only axes

Epic #1644. Dispatch R795: « #1667 axes 3/5, branchés sur `dung_frameworks[*].formalism_specific` ».

## The gap

Three structured-argumentation axes had **no presence reader** in Act III: a present, non-trivial axis on ABA / SETAF / weighted AF never reached the conclusion. The #1667 discovery (confirmed writer-by-writer during the #1702 triage) is that these axes have **no first-level `aba_results` / `setaf_results` / `weighted_results` container** — the strictly-additive `formalism_specific` sidecar the six #1648 Wave-2 writers attach is the *only* place they store their distinctive data. So the existing presence channel (`structured_findings`) never saw them.

## The three projectors — one channel, one reader per axis

Added to `_collect_structured_arg_findings` (one channel, not one reader per axis — the eight-half-fixes lesson of #1633):

| projector | axis | the singular relation it names | honest-absence condition (`None`) |
|---|---|---|---|
| `_aba_finding` | ABA | assumption ↔ contrary (`« a » a pour contraire « c »`) | no contrary pair populated |
| `_setaf_finding` | SETAF | the **joint** collective attack (coalition of ≥ 2 attackers, arity ≥ 2) | only unary set-attacks present — a unary set-attack **IS** a Dung attack, SETAF added nothing (#1019) |
| `_weighted_finding` | weighted AF | the weight distribution (min/max/avg), numeric only | no weighted attack populated |

Each statement **names the relation, not a count** — `3 résultats ABA` would reproduce the witness-moved-no-decider failure (#1667 anti-pendule: the structured finding is the *decider*, a tally is only a *witness*). Atoms are truncated via `_FORMALISM_NODE_CAP` — the sidecar is the exact surface #1702 scrubbed, so its atoms are corpus-derived (`_pl_atom`) and stay truncated in the prose (privacy HARD, same bar as `_aspic_finding`'s contested members).

`_weighted_finding` prefers the producer's `weight_statistics` aggregate and falls back to computing from the sample; **only numeric weights reach the prose** (the source/target atoms are corpus-derived and never echoed).

## Anti-pendule — measured at the producer

Per the dispatch's explicit instruction, each axis was measured at its producer (`_write_aba_to_state` / `_write_setaf_to_state` / `_write_weighted_to_state`) to statuate *what the axis alone says* vs what an adjacent axis already says:

- **ABA**: the contrary relation — Dung is attack-only, ASPIC+ is rule-scope, neither carries it.
- **SETAF**: the *joint* attack — binary Dung cannot express a coalition that defeats a target no member defeats alone. A unary set-attack is deliberately NOT projected (it would duplicate the Dung projection).
- **weighted**: unequal force — a binary attack graph treats all edges alike; naming the distribution is the projection no other axis produces.

## Tests (23 new)

`TestAbaPresenceChannel`, `TestSetafPresenceChannel`, `TestWeightedPresenceChannel`, `TestFormalismSidecarNonVacuityAndSubstitution`:

- capability key correct, non-vacuity (empty / malformed sidecar ⇒ nothing fabricated, fail-loud #1019),
- **not-a-count** (the relation named, not a tally),
- caps respected (pairs / coalitions / weight sample), long-atom truncation,
- reader-facing label (no snake_case in prose),
- privacy (weighted = numeric only, no `claim_*` atoms echoed),
- **DoD: present non-trivial axis reaches the prompt** (`"claim_alpha" in build_act3_prompt(...)`),
- **surgical-substitution control**: reverting the 3 projectors ⇒ the 3 capabilities disappear from the findings (kill-set = `{aba, setaf, weighted}`; spare-set = aspic/bipolar/belief-revision untouched, measured by capability parity).

142 tests green (0 regression). `black` clean.

## Honest scope — 3 écrits, 1 vérifié sur réel, 2 canary-seulement

Per the coordinator's anti-pendule instruction, reported honestly:

- **ABA**: the ONLY axis whose sidecar leaf is populated on real corpora — `contraries` measured **8 / 8 / 4 pairs** across the 3 real corpora (R795). This channel has real exposure today.
- **SETAF** (`set_attacks`) and **weighted** (`attack_weights`): the leaves are **absent in 3 / 3 real corpora** → these two readers are **canary-only** today (the tests prove the channel is alive on the producer assignment shapes; a real-state spot-check is an ai-01 lane, data-gated, same path as #1668 / #1698).

## Pre-existing mypy strict error (not this PR)

`act3_conclusion_plugin.py:992` (`distinct: List[frozenset] = []`, in the bipolar region) — `Missing type arguments for generic type frozenset [type-arg]`. Verified on clean main via stash (present at l.992, shifted to l.1003 by my added lines above). Not introduced by this PR, not fixed (scoped diff — same discipline as the documented sanitize_state l.622 pre-existing error in #1702).

Refs #1667
