### PR TITLE
fix(state-writers): tri-state formal verdicts — None never folds onto False (#1650)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -1061,9 +1061,12 @@ async def _run_formal_logic_from_state(
             pl_out = await _invoke_propositional_logic(input_text, context)
             formulas = pl_out.get("formulas", []) if isinstance(pl_out, dict) else []
             if formulas:
+                # Three states (#1650): same motif as _write_propositional_to_state
+                # — an absent ``satisfiable`` must stay None, never fold onto
+                # False (the readers classify `is True`/`is False`/None).
                 state.add_propositional_analysis_result(
                     formulas,
-                    bool(pl_out.get("satisfiable", False)),
+                    pl_out.get("satisfiable"),
                     pl_out.get("model", {}) or {},
                 )
                 result["pl_added"] = len(formulas)
@@ -4874,7 +4877,11 @@ async def _invoke_qbf(input_text: str, context: Dict[str, Any]) -> Dict[str, Any
             return {
                 "quantifiers": quantifiers,
                 "formula": formula[:100],
-                "valid": False,
+                # Three states (#1650): the QBF analysis FAILED — the validity
+                # verdict is undetermined, not False. Folding onto False would
+                # make "no solver ran" indistinguishable from "the formula is
+                # invalid" for every downstream reader of `valid`.
+                "valid": None,
                 "message": f"QBF unavailable: {e2}",
                 "fallback": "error",
             }

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -1048,7 +1048,10 @@ def _write_propositional_to_state(output: Any, state: Any, ctx: dict[str, Any]) 
     if not output or not isinstance(output, dict):
         return
     formulas = output.get("formulas", [])
-    satisfiable = output.get("satisfiable", False)
+    # Three states, never two (#1650): an absent ``satisfiable`` (or an explicit
+    # None) means the reasoner did not decide — folding it onto False would make
+    # "the prover said nothing" indistinguishable from "the prover said no".
+    satisfiable = output.get("satisfiable")
     model = output.get("model", {})
     if not isinstance(formulas, list):
         formulas = []
@@ -1061,9 +1064,7 @@ def _write_propositional_to_state(output: Any, state: Any, ctx: dict[str, Any]) 
         kwargs["query_count"] = output["query_count"]
     if output.get("message"):
         kwargs["message"] = output["message"]
-    state.add_propositional_analysis_result(
-        formulas, bool(satisfiable), model, **kwargs
-    )
+    state.add_propositional_analysis_result(formulas, satisfiable, model, **kwargs)
 
 
 def _write_fol_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
@@ -1115,7 +1116,11 @@ def _write_modal_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     if not output or not isinstance(output, dict):
         return
     formulas = output.get("formulas", [])
-    valid = output.get("valid", False)
+    # Three states, never two (#1650): ``valid`` is None when the solver could
+    # not decide (no-translation / no-solver), True/False when it did. An absent
+    # key must not fold onto False — the modal reader (Acte II) already
+    # classifies ``valid is None`` as degraded.
+    valid = output.get("valid")
     modalities = output.get("modalities", [])
     if not isinstance(formulas, list):
         formulas = []
@@ -1134,7 +1139,7 @@ def _write_modal_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
         status_message = None
     state.add_modal_analysis_result(
         formulas,
-        valid if valid is not None else None,
+        valid,
         modalities,
         message=status_message,
     )
@@ -1153,7 +1158,10 @@ def _write_nl_to_logic_to_state(output: Any, state: Any, ctx: dict[str, Any]) ->
                 original_text=t.get("original_text", ""),
                 formula=t.get("formula", ""),
                 logic_type=t.get("logic_type", "propositional"),
-                is_valid=bool(t.get("is_valid", False)),
+                # Three states (#1650): is_valid is the translation-validation
+                # verdict; absent/None means the validation never ran, not that
+                # the translation failed validation.
+                is_valid=t.get("is_valid"),
                 variables=t.get("variables", {}),
                 confidence=float(t.get("confidence", 0.0)),
             )
@@ -1403,12 +1411,17 @@ def _write_cl_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write Conditional Logic results to UnifiedAnalysisState (#86)."""
     if not output or not isinstance(output, dict):
         return
-    entailed = output.get("entailed", False)
+    # Three states (#1650): ``entailed`` is the Conditional-Logic verdict (the
+    # query follows from the conditionals); absent/None means the reasoner did
+    # not decide. The CL entry is a guest in the PL container
+    # (_is_guest_formal_entry excludes it from host-PL counts) — the field must
+    # still carry None rather than a fabricated False.
+    entailed = output.get("entailed")
     message = str(output.get("message", ""))
     num = output.get("num_conditionals", 0)
     state.add_propositional_analysis_result(
         formulas=[f"CL({num} conditionals): {message}"],
-        satisfiable=bool(entailed),
+        satisfiable=entailed,
         model={},
     )
 
@@ -1417,7 +1430,13 @@ def _write_sat_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """Write SAT solver results to UnifiedAnalysisState (#86)."""
     if not output or not isinstance(output, dict):
         return
-    is_sat = output.get("satisfiable", False)
+    # Three states (#1650): ``satisfiable`` is None when the SAT backend is
+    # unavailable (the producer emits ``satisfiable: None`` on PySAT absence) —
+    # folding it onto False would make "no solver ran" indistinguishable from
+    # "the formula set is UNSAT", and the old formula string claimed exactly
+    # that. The mus branch is a decided verdict (MUS found unsat subsets), so it
+    # keeps its explicit False.
+    is_sat = output.get("satisfiable")
     model = output.get("model") or {}
     mode = output.get("mode", "solve")
     if mode == "mus":
@@ -1428,9 +1447,12 @@ def _write_sat_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
             model={},
         )
     else:
+        sat_label = (
+            "SAT" if is_sat is True else ("UNSAT" if is_sat is False else "indéterminé")
+        )
         state.add_propositional_analysis_result(
-            formulas=[f"SAT: {'SAT' if is_sat else 'UNSAT'}"],
-            satisfiable=bool(is_sat),
+            formulas=[f"SAT: {sat_label}"],
+            satisfiable=is_sat,
             model=model if isinstance(model, dict) else {},
         )
 
@@ -1688,9 +1710,14 @@ def _write_qbf_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
     """
     if not output or not isinstance(output, dict):
         return
+    # Three states (#1650): ``valid`` is the QBF validity verdict; the producer
+    # emits ``valid: None`` when the QBF analysis failed (native fallback
+    # error), so an absent key must not fold onto False. The QBF entry is a
+    # guest in the PL container (_is_guest_formal_entry) — the field still
+    # carries the honest tri-state value.
     state.add_propositional_analysis_result(
         formulas=[f"QBF: {output.get('formula', '')}"],
-        satisfiable=output.get("valid", False),
+        satisfiable=output.get("valid"),
         model={},
     )
     # #1648 Wave-2 sidecar: preserve the quantifier prefix the handler

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_1650.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_1650.py
@@ -1,0 +1,351 @@
+"""#1650 — Three-state formal verdicts: an absent verdict never folds onto False.
+
+Each writer test drives the real ``_write_*_to_state`` writer with an output
+dict that LACKS the verdict key (or carries an explicit ``None``), and asserts
+the state entry preserves it — ``None`` (undetermined) is never collapsed onto
+``False`` ("the prover said nothing" != "the prover said no", #1019).
+
+Anti-#1019 discipline (R761 #1643, R764 #1636): the writer is real, the handler
+output is stubbed. A mocked writer would just agree with itself. The
+substitution control is executed per site in the PR: reverting a writer to the
+two-state form (``.get(key, False)`` / ``bool(...)``) makes the armed test go
+red.
+
+Privacy: synthetic atoms only (no corpus tokens).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+from unittest.mock import AsyncMock, patch
+
+from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+from argumentation_analysis.orchestration.state_writers import (
+    _write_cl_to_state,
+    _write_modal_to_state,
+    _write_nl_to_logic_to_state,
+    _write_propositional_to_state,
+    _write_qbf_to_state,
+    _write_sat_to_state,
+)
+
+
+def _new_state() -> UnifiedAnalysisState:
+    """A fresh state for a single writer probe."""
+    return UnifiedAnalysisState("three-state-1650 synthetic probe")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PL — _write_propositional_to_state (state_writers.py, satisfiable)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPlSatisfiableThreeState1650:
+    def test_absent_key_is_none_not_false(self) -> None:
+        state = _new_state()
+        _write_propositional_to_state(
+            {"formulas": ["p & q"], "model": {"p": True}}, state, {}
+        )
+        assert state.propositional_analysis_results[0]["satisfiable"] is None
+
+    def test_explicit_none_preserved(self) -> None:
+        state = _new_state()
+        _write_propositional_to_state(
+            {"formulas": ["p"], "satisfiable": None, "model": {}}, state, {}
+        )
+        assert state.propositional_analysis_results[0]["satisfiable"] is None
+
+    def test_decided_false_preserved(self) -> None:
+        state = _new_state()
+        _write_propositional_to_state(
+            {"formulas": ["p & !p"], "satisfiable": False, "model": {}}, state, {}
+        )
+        assert state.propositional_analysis_results[0]["satisfiable"] is False
+
+    def test_decided_true_preserved(self) -> None:
+        state = _new_state()
+        _write_propositional_to_state(
+            {"formulas": ["p"], "satisfiable": True, "model": {"p": True}}, state, {}
+        )
+        assert state.propositional_analysis_results[0]["satisfiable"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Modal — _write_modal_to_state (state_writers.py, valid)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestModalValidThreeState1650:
+    def test_absent_key_is_none_not_false(self) -> None:
+        state = _new_state()
+        _write_modal_to_state(
+            {"formulas": ["K(agent, p)"], "modalities": ["epistemic"]}, state, {}
+        )
+        assert state.modal_analysis_results[0]["valid"] is None
+
+    def test_explicit_none_preserved(self) -> None:
+        # no-solver / no-translation → the producer emits valid=None
+        state = _new_state()
+        _write_modal_to_state(
+            {"formulas": ["<>p"], "valid": None, "modalities": ["alethic"]}, state, {}
+        )
+        assert state.modal_analysis_results[0]["valid"] is None
+
+    def test_decided_false_preserved(self) -> None:
+        state = _new_state()
+        _write_modal_to_state(
+            {"formulas": ["[]p"], "valid": False, "modalities": ["necessity"]},
+            state,
+            {},
+        )
+        assert state.modal_analysis_results[0]["valid"] is False
+
+    def test_decided_true_preserved(self) -> None:
+        state = _new_state()
+        _write_modal_to_state(
+            {"formulas": ["<>p"], "valid": True, "modalities": ["possibility"]},
+            state,
+            {},
+        )
+        assert state.modal_analysis_results[0]["valid"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# NL→logic — _write_nl_to_logic_to_state (state_writers.py, is_valid)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestNlToLogicIsValidThreeState1650:
+    def test_absent_key_is_none_not_false(self) -> None:
+        state = _new_state()
+        _write_nl_to_logic_to_state(
+            {"translations": [{"formula": "p -> q", "original_text": "s1"}]},
+            state,
+            {},
+        )
+        assert state.nl_to_logic_translations[0]["is_valid"] is None
+
+    def test_decided_false_preserved(self) -> None:
+        state = _new_state()
+        _write_nl_to_logic_to_state(
+            {
+                "translations": [
+                    {"formula": "p -> q", "original_text": "s1", "is_valid": False}
+                ]
+            },
+            state,
+            {},
+        )
+        assert state.nl_to_logic_translations[0]["is_valid"] is False
+
+    def test_decided_true_preserved(self) -> None:
+        state = _new_state()
+        _write_nl_to_logic_to_state(
+            {
+                "translations": [
+                    {"formula": "p -> q", "original_text": "s1", "is_valid": True}
+                ]
+            },
+            state,
+            {},
+        )
+        assert state.nl_to_logic_translations[0]["is_valid"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Conditional Logic — _write_cl_to_state (state_writers.py, entailed)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestClEntailedThreeState1650:
+    def test_absent_key_is_none_not_false(self) -> None:
+        state = _new_state()
+        _write_cl_to_state({"message": "synthetic", "num_conditionals": 2}, state, {})
+        entry = state.propositional_analysis_results[0]
+        assert entry["satisfiable"] is None
+        assert entry["formulas"][0].startswith("CL(")
+
+    def test_decided_false_preserved(self) -> None:
+        state = _new_state()
+        _write_cl_to_state(
+            {"entailed": False, "message": "m", "num_conditionals": 1}, state, {}
+        )
+        assert state.propositional_analysis_results[0]["satisfiable"] is False
+
+    def test_decided_true_preserved(self) -> None:
+        state = _new_state()
+        _write_cl_to_state(
+            {"entailed": True, "message": "m", "num_conditionals": 0}, state, {}
+        )
+        assert state.propositional_analysis_results[0]["satisfiable"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SAT — _write_sat_to_state (state_writers.py, satisfiable)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSatSatisfiableThreeState1650:
+    def test_absent_key_is_none_not_false(self) -> None:
+        state = _new_state()
+        _write_sat_to_state({"mode": "solve", "model": {}}, state, {})
+        entry = state.propositional_analysis_results[0]
+        assert entry["satisfiable"] is None
+        assert entry["formulas"] == ["SAT: indéterminé"]
+
+    def test_explicit_none_preserved(self) -> None:
+        # PySAT unavailable → the producer emits satisfiable=None
+        state = _new_state()
+        _write_sat_to_state(
+            {"mode": "solve", "satisfiable": None, "model": None}, state, {}
+        )
+        entry = state.propositional_analysis_results[0]
+        assert entry["satisfiable"] is None
+        assert entry["formulas"] == ["SAT: indéterminé"]
+
+    def test_sat_true_preserved(self) -> None:
+        state = _new_state()
+        _write_sat_to_state(
+            {"mode": "solve", "satisfiable": True, "model": {"p": True}}, state, {}
+        )
+        entry = state.propositional_analysis_results[0]
+        assert entry["satisfiable"] is True
+        assert entry["formulas"] == ["SAT: SAT"]
+
+    def test_unsat_false_preserved(self) -> None:
+        state = _new_state()
+        _write_sat_to_state(
+            {"mode": "solve", "satisfiable": False, "model": {}}, state, {}
+        )
+        entry = state.propositional_analysis_results[0]
+        assert entry["satisfiable"] is False
+        assert entry["formulas"] == ["SAT: UNSAT"]
+
+    def test_mus_branch_keeps_explicit_false(self) -> None:
+        # MUS found unsat subsets = a decided verdict; the explicit False stays
+        state = _new_state()
+        _write_sat_to_state({"mode": "mus", "mus_count": 2}, state, {})
+        entry = state.propositional_analysis_results[0]
+        assert entry["satisfiable"] is False
+        assert entry["formulas"][0].startswith("SAT/MUS:")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# QBF — _write_qbf_to_state (state_writers.py, valid → satisfiable)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestQbfValidThreeState1650:
+    def test_absent_key_is_none_not_false(self) -> None:
+        state = _new_state()
+        _write_qbf_to_state({"formula": "exists x. P(x)"}, state, {})
+        assert state.propositional_analysis_results[0]["satisfiable"] is None
+
+    def test_explicit_none_preserved(self) -> None:
+        # QBF analysis failed → the producer emits valid=None
+        state = _new_state()
+        _write_qbf_to_state(
+            {"formula": "P(x)", "valid": None, "fallback": "error"}, state, {}
+        )
+        assert state.propositional_analysis_results[0]["satisfiable"] is None
+
+    def test_decided_false_preserved(self) -> None:
+        state = _new_state()
+        _write_qbf_to_state({"formula": "P(x)", "valid": False}, state, {})
+        assert state.propositional_analysis_results[0]["satisfiable"] is False
+
+    def test_decided_true_preserved(self) -> None:
+        state = _new_state()
+        _write_qbf_to_state({"formula": "P(x)", "valid": True}, state, {})
+        assert state.propositional_analysis_results[0]["satisfiable"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Producer regrep finds — invoke_callables.py
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestInvokeQbfErrorBranchThreeState1650:
+    """A failed QBF analysis is undetermined (None), never 'invalid' (False).
+
+    Regrep finding (#1650 DoD): the error fallback of ``_invoke_qbf`` wrote
+    ``valid: False`` when both backends failed — folding "no solver ran" onto
+    "the formula is invalid" for every downstream reader of ``valid``.
+    """
+
+    async def test_error_fallback_valid_is_none(self) -> None:
+        from argumentation_analysis.orchestration import invoke_callables
+
+        with (
+            patch(
+                "argumentation_analysis.agents.core.logic.qbf_handler.QBFHandler",
+                side_effect=RuntimeError("forced JVM QBF failure"),
+            ),
+            patch(
+                "argumentation_analysis.agents.core.logic.qbf_native.analyze_qbf",
+                side_effect=RuntimeError("forced native QBF failure"),
+            ),
+        ):
+            result = await invoke_callables._invoke_qbf(
+                "P(x)", {"quantifiers": [], "formula": "P(x)"}
+            )
+
+        assert result["fallback"] == "error"
+        assert result["valid"] is None
+
+
+class TestRunFormalLogicFromStatePlThreeState1650:
+    """The conversational PL post-processor preserves an absent verdict.
+
+    Regrep finding (#1650 DoD): the direct ``add_propositional_analysis_result``
+    call in ``_run_formal_logic_from_state`` folded
+    ``bool(pl_out.get("satisfiable", False))`` — the same two-state motif as the
+    sequential writer, on the conversational path.
+    """
+
+    async def test_absent_satisfiable_preserved_as_none(self) -> None:
+        from argumentation_analysis.orchestration import invoke_callables
+
+        state = _new_state()
+        state.identified_arguments = {"a1": "synthetic argument text"}
+        with (
+            patch(
+                "argumentation_analysis.orchestration.invoke_callables."
+                "_invoke_propositional_logic",
+                new=AsyncMock(return_value={"formulas": ["p"], "model": {"p": True}}),
+            ),
+            patch(
+                "argumentation_analysis.orchestration.invoke_callables."
+                "_invoke_fol_reasoning",
+                new=AsyncMock(return_value={}),
+            ),
+        ):
+            result = await invoke_callables._run_formal_logic_from_state(
+                state, "synthetic"
+            )
+
+        assert result["pl_added"] == 1
+        assert state.propositional_analysis_results[0]["satisfiable"] is None
+
+    async def test_decided_false_preserved(self) -> None:
+        from argumentation_analysis.orchestration import invoke_callables
+
+        state = _new_state()
+        state.identified_arguments = {"a1": "synthetic argument text"}
+        with (
+            patch(
+                "argumentation_analysis.orchestration.invoke_callables."
+                "_invoke_propositional_logic",
+                new=AsyncMock(
+                    return_value={"formulas": ["p"], "satisfiable": False, "model": {}}
+                ),
+            ),
+            patch(
+                "argumentation_analysis.orchestration.invoke_callables."
+                "_invoke_fol_reasoning",
+                new=AsyncMock(return_value={}),
+            ),
+        ):
+            await invoke_callables._run_formal_logic_from_state(state, "synthetic")
+
+        assert state.propositional_analysis_results[0]["satisfiable"] is False

--- a/tests/unit/argumentation_analysis/test_value_gates.py
+++ b/tests/unit/argumentation_analysis/test_value_gates.py
@@ -1721,10 +1721,16 @@ class TestEAFValueGate:
 
 
 class TestQBFValueGate:
-    """QBF solver — error fallback returns valid=False honestly (#1005)."""
+    """QBF solver — error fallback reports the verdict as undetermined (#1650).
+
+    Previously (#1005) the error fallback reported ``valid=False`` — folding
+    "the QBF reasoner failed" onto "the formula is invalid". #1650 makes formal
+    verdicts tri-state: a failed reasoner is ``None`` (undetermined), never
+    ``False`` (decided-no), so downstream readers can distinguish the two.
+    """
 
     async def test_qbf_error_fallback_reports_unavailable(self):
-        """When both JVM and native fail, QBF must report unavailability."""
+        """When both JVM and native fail, QBF must report undetermined (None)."""
         from argumentation_analysis.orchestration.invoke_callables import (
             _invoke_qbf,
         )
@@ -1742,8 +1748,9 @@ class TestQBFValueGate:
         assert result.get("fallback") == "error", (
             f"QBF error fallback should set fallback='error', got {result.get('fallback')} (#1005)."
         )
-        assert result.get("valid") is False, (
-            f"QBF unavailable must report valid=False, got {result.get('valid')} (#1005)."
+        assert result.get("valid") is None, (
+            f"QBF unavailable must report valid=None (undetermined, not False), "
+            f"got {result.get('valid')} (#1650)."
         )
 
 


### PR DESCRIPTION
## Summary

Closes the writer side of **#1650** — the "formal verdict absent ⇒ négatif" two-state motif. An absent (or `None`) formal verdict was folded onto `False` at 8 sites, making *"the prover said nothing"* indistinguishable from *"the prover said no"* (#1019). The 6 sites the coordinator named in `state_writers.py`, plus 2 same-motif sites found by re-running the grep across `orchestration/` (DoD anti-pendule: a named list can be wrong both ways).

The model applied is the **internal** one (`state_writers._write_external_fol_solver_to_state:2002`), not `_write_dl_to_state` cited in the first dispatch: *verdict* keys keep no default (`None` survives); *flag* keys keep their `False` default. The same file already distinguished verdict-from-flag — the 8 sites now follow it.

## Sites changed (8)

### `state_writers.py` — 6 sites (coordinator's corrected list)
| site | formalism | key | before | after |
|---|---|---|---|---|
| `_write_propositional_to_state` | PL | `satisfiable` | `.get(k, False)` + `bool()` | `.get(k)` |
| `_write_modal_to_state` | modal | `valid` | `.get(k, False)` | `.get(k)` |
| `_write_nl_to_logic_to_state` | NL→logic | `is_valid` | `bool(.get(k, False))` | `.get(k)` |
| `_write_cl_to_state` | Cond. Logic | `entailed` | `.get(k, False)` + `bool()` | `.get(k)` |
| `_write_sat_to_state` | SAT | `satisfiable` | `.get(k, False)` + `bool()` | `.get(k)` + honest formula label (`indéterminé`) |
| `_write_qbf_to_state` | QBF | `valid` | `.get(k, False)` | `.get(k)` |

### `invoke_callables.py` — 2 sites (regrep finds)
| site | what | before | after |
|---|---|---|---|
| `_run_formal_logic_from_state` (conversational PL enrichment) | direct `add_propositional_analysis_result` call | `bool(pl_out.get("satisfiable", False))` | `pl_out.get("satisfiable")` |
| `_invoke_qbf` error fallback | QBF reasoner FAILED → verdict | `"valid": False` | `"valid": None` |

## DoD

- [x] 8 sites render three states (`None` = reasoner did not decide); never two. `None` is never collapsed onto the negative.
- [x] **Substitution control executed per site** — reverted each site to its two-state form, ran the armed (absent-key) test, confirmed red, restored. **Kill-set 8/8** (6 writers + QBF-error + conversational-PL).
- [x] **Downstream readers followed** — every state-side reader of the 6 fields was already 3-state-hardened in prior rounds and classifies `None` distinctly: `_pl_verdict`/`_pl_verdict_of` (`isinstance(sat, bool) else None`), `_pl_axis_status`/`_modal_axis_status` (`in (True, False)` / `is None`), Acte II `_collect_formal_findings` (`is True`/`is False`), `_formal_holds` (`is True`), `formal_synthesis_report` scoring (`key in val` + `is True`/`is False`). No reader migration needed — the writers were the last two-state link.
- [x] **Regrep re-run across `orchestration/` + `reporting/`** — form sought: `.get(key, False)` default + `bool(.get(key, False))` cast + dataclass `bool` attributes carrying a reasoner verdict. Found the 2 `invoke_callables.py` sites above (fixed). **Triaged out** (authentically binary flags, not reasoner verdicts): `is_assumption` (structural nature), `honest_absent`/`enabled`/`degraded` (producer-set flags), `consistency_check`/`urgent`/`resolved`/`available` (lifecycle/availability flags), `has_contradictions` (ATMS summary flag, #1713 already covered `coherent` in the same file), `jtms_beliefs[].valid` (different container — #1646 belief-revision lane). The only dataclass-attribute reasoner verdict was `open_domain_investigation.coherent` — already fixed by #1713 (`b7890116`).
- [x] **Honesty on real states** (see below).

## Honesty: does the producer emit always-bool today?

Measured on the real run states available on disk (`evaluation/results/fp5/fp5_doc{A,B,C}`, `judge_A_state`) + the producer code:

| site | key_absent today | verdict |
|---|---|---|
| PL `satisfiable` | 0/3 (always bool) | arms a property |
| modal `valid` | 0/1 (bool; `None` when degraded — already preserved when key present) | arms a property (absent-key was the only gap) |
| NL→logic `is_valid` | 0/6 (always bool) | arms a property |
| CL `entailed` | 0 (always bool; `True` when no query) | arms a property |
| **SAT `satisfiable`** | producer emits `None` when **PySAT unavailable** (the CI env lacks `python-sat` per `invoke_callables.py:4464`) | **corrects a number** — the old writer wrote `satisfiable=False` + formula `"SAT: UNSAT"`, fabricating an inconsistency verdict |
| **QBF error branch** | producer wrote `valid: False` when both QBF backends failed | **corrects a fold** — "reasoner failed" was "the formula is invalid" |

So 5 sites arm a property (`key_absent = 0` today), and **2 sites (SAT, QBF-error) correct an active fold** in degraded environments. Stating the fraction is the deliverable (anti-pendule: never claim "3/3 fixed" — most sites arm, two correct).

## Anti-pendules honored

- **No count sold as a verdict.** The writers preserve `None`/`True`/`False`; the formula strings follow (`SAT: indéterminé` when undetermined).
- **Authentically-binary flags untouched.** `degraded`/`honest_absent`/`enabled`/`is_assumption` keep their `False` default — they are flags, not reasoner verdicts.
- **MUS branch keeps its explicit `False`.** MUS found unsat subsets = a decided verdict, not an undetermined one.
- **No reader left folding.** Verified each downstream reader crosses the three states; none does `if not verdict:`.

## Not in scope

- `atms_core` enumeration, real JTMS→ATMS justifications (orthogonal, R787 ruling stands).
- The pre-existing `black` violations at `state_writers.py:1476` (`dict(a) for a in set_attacks`) and `invoke_callables.py:3455` (`attacker = attackers[0] if …`) — **verified on `origin/main`**, not introduced by this PR; left untouched (scoped diff).

## Tests

New file `tests/unit/argumentation_analysis/orchestration/test_state_writers_1650.py` — 26 tests (3-state per site + QBF-error producer + conversational-PL). Real writers, real `UnifiedAnalysisState`, stubbed handler outputs (anti-#1019: the writer is real). black-clean, mypy-clean.

Refs #1650.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
