### PR TITLE
fix(runner): render section-0 phase status for the conversational summary shape

### DIFF
--- a/scripts/run_real_analysis.py
+++ b/scripts/run_real_analysis.py
@@ -33,7 +33,7 @@ import os
 import sys
 import time
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 os.chdir(Path(__file__).parent.parent)
@@ -130,6 +130,57 @@ def _fmt(v: Any, indent: int = 0) -> str:
     return str(v)
 
 
+def _phase_status_lines(summary: Any) -> List[str]:
+    """Build the section-0 phase-status body, honest to the summary's shape.
+
+    The two orchestration paths emit different summaries — and that difference
+    is honest, not a bug to paper over:
+
+    * **pipeline** (``WorkflowExecutor`` via ``run_unified_analysis``): named
+      phase lists — ``completed_phases`` / ``failed_phases`` / ``skipped_phases``
+      (a DAG fails / skips individual named phases).
+    * **conversational** (``run_conversational_analysis``): aggregate counters —
+      ``completed`` / ``failed`` / ``skipped`` / ``total`` / ``total_messages``
+      (an AgentGroupChat dialogue does not fail individual named phases, so no
+      names exist).
+
+    Display what each shape actually carries; never fabricate phase names on the
+    conversational path (#1019 — ``completed_phases`` was always absent there, so
+    section 0 read ``(aucune)`` on every conversational run, hiding real progress).
+    Pure function (no I/O) so the shape handling is unit-testable without a run.
+    """
+    if not summary or not isinstance(summary, dict):
+        return ["_(résumé indisponible pour ce run)_"]
+    # Pipeline shape: named phase lists.
+    if any(
+        k in summary for k in ("completed_phases", "failed_phases", "skipped_phases")
+    ):
+        done = summary.get("completed_phases") or []
+        failed = summary.get("failed_phases") or []
+        skipped = summary.get("skipped_phases") or []
+        return [
+            f"- **Complétées ({len(done)})**: {', '.join(done) if done else '(aucune)'}",
+            f"- **Échouées ({len(failed)})**: {', '.join(failed) if failed else '(aucune)'}",
+            f"- **Sautées ({len(skipped)})**: {', '.join(skipped) if skipped else '(aucune)'}",
+        ]
+    # Conversational shape: aggregate counters (no per-phase names).
+    completed = summary.get("completed")
+    failed = summary.get("failed")
+    skipped = summary.get("skipped")
+    total = summary.get("total")
+    done_str = "?" if completed is None else str(completed)
+    failed_str = "0" if failed is None else str(failed)
+    skipped_str = "0" if skipped is None else str(skipped)
+    total_str = done_str if total is None else str(total)
+    lines = [
+        f"- **Phases**: {done_str}/{total_str} complétées · "
+        f"{failed_str} échouées · {skipped_str} sautées"
+    ]
+    if "total_messages" in summary and summary["total_messages"] is not None:
+        lines.append(f"- **Messages (conversation)**: {summary['total_messages']}")
+    return lines
+
+
 def render_markdown(
     snap: Dict[str, Any],
     corpus: Dict[str, Any],
@@ -156,18 +207,15 @@ def render_markdown(
     md.append("")
     md.append(_fmt(corpus["meta"]))
 
-    # 0. Phase status — honest view of what actually ran
+    # 0. Phase status — honest view of what actually ran. The two paths emit
+    # different summary shapes (named lists vs aggregate counters); the helper
+    # displays whichever exists rather than fabricating phase names (#1019).
     if summary:
-        done = summary.get("completed_phases", [])
-        failed = summary.get("failed_phases", [])
-        skipped = summary.get("skipped_phases", [])
-        body = [
-            f"- **Complétées ({len(done)})**: {', '.join(done) if done else '(aucune)'}",
-            f"- **Échouées ({len(failed)})**: {', '.join(failed) if failed else '(aucune)'}",
-            f"- **Sautées ({len(skipped)})**: {', '.join(skipped) if skipped else '(aucune)'}",
-        ]
         md.append(
-            _md_section("0. Statut des phases (transparence run)", "\n".join(body))
+            _md_section(
+                "0. Statut des phases (transparence run)",
+                "\n".join(_phase_status_lines(summary)),
+            )
         )
 
     # 1. Arguments

--- a/tests/unit/argumentation_analysis/orchestration/test_runner_mode_1668.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_runner_mode_1668.py
@@ -200,3 +200,65 @@ def mock_open_noop() -> Any:
     m.return_value.__enter__.return_value = MagicMock()
     m.return_value.__exit__.return_value = False
     return m
+
+
+class TestPhaseStatusLines:
+    """Section 0 must show what the summary actually carries, per path (#1668).
+
+    The pipeline path emits named phase lists (``*_phases``); the conversational
+    path emits aggregate counters (``completed``/``failed``/``skipped``/``total``).
+    Before the fix, section 0 always read ``completed_phases`` — absent on every
+    conversational run — so it showed ``(aucune)`` and hid real progress (#1019).
+    """
+
+    def test_pipeline_shape_renders_named_lists(self) -> None:
+        from scripts.run_real_analysis import _phase_status_lines
+
+        lines = _phase_status_lines(
+            {
+                "completed_phases": ["extract", "quality"],
+                "failed_phases": ["fol"],
+                "skipped_phases": [],
+            }
+        )
+        joined = "\n".join(lines)
+        assert "extract" in joined and "quality" in joined
+        assert "fol" in joined
+        assert "Complétées (2)" in joined
+        assert "Échouées (1)" in joined
+
+    def test_conversational_shape_renders_counters_not_empty(self) -> None:
+        from scripts.run_real_analysis import _phase_status_lines
+
+        lines = _phase_status_lines(
+            {
+                "completed": 9,
+                "failed": 0,
+                "skipped": 0,
+                "total": 9,
+                "total_messages": 46,
+            }
+        )
+        joined = "\n".join(lines)
+        # Counters are shown, not "(aucune)"
+        assert "9/9 complétées" in joined
+        assert "(aucune)" not in joined
+        assert "Messages (conversation)" in joined and "46" in joined
+
+    def test_conversational_shape_never_fabricates_phase_names(self) -> None:
+        """The conversational summary has no per-phase names; section 0 must
+        not invent them (anti-#1019). It shows counters only."""
+        from scripts.run_real_analysis import _phase_status_lines
+
+        lines = _phase_status_lines(
+            {"completed": 9, "failed": 0, "skipped": 0, "total": 9}
+        )
+        joined = "\n".join(lines)
+        assert "Complétées (9)" not in joined  # the pipeline format is not used
+        assert "complétées" in joined  # the counter format is
+
+    def test_empty_or_none_summary_is_honest(self) -> None:
+        from scripts.run_real_analysis import _phase_status_lines
+
+        assert _phase_status_lines(None) == ["_(résumé indisponible pour ce run)_"]
+        assert _phase_status_lines({}) == ["_(résumé indisponible pour ce run)_"]


### PR DESCRIPTION
## Context

Observed firsthand on the Temps 2 conversational run (#1668 item 5-bis): the runner's section 0 ("Statut des phases") showed `(aucune)` on every conversational run, hiding real progress. The runner always read `completed_phases` / `failed_phases` / `skipped_phases` (named lists) — the pipeline shape. The conversational path emits a **different** summary.

## The two summary shapes

| path | summary keys | type |
|---|---|---|
| pipeline (`WorkflowExecutor`, `unified_pipeline.py:352-354`) | `completed_phases` / `failed_phases` / `skipped_phases` | **named lists** (a DAG fails/skips individual phases) |
| conversational (`conversational_orchestrator.py:1558-1564`) | `completed` / `failed` / `skipped` / `total` / `total_messages` | **aggregate counters** (an AgentGroupChat does not fail individual named phases) |

So `completed_phases` was always absent on the conversational path → section 0 read `[]` → `(aucune)`. Classic #1019 form: a key absent on one path reads as empty, indistinguishable from "nothing ran".

## Fix

Extracts `_phase_status_lines(summary) -> list[str]` — branches on the summary **shape** (which keys are present), not on the mode, so it stays correct if either contract moves:

- pipeline shape (`*_phases` present) → named lists (unchanged)
- conversational shape (`completed` present) → counters, **never fabricates phase names that do not exist**

Anti-pendule: does NOT invent a list of failed-phase names on the conversational path — the orchestrator honestly tracks only counters there, and we display what exists.

## DoD

- [x] Section 0 shows real progress on the conversational path (counters, not `(aucune)`)
- [x] Pipeline behaviour unchanged (named lists still rendered)
- [x] Honest on empty / None summary
- [x] **Substitution control executed** (not reasoned): disarming the helper back to pipeline-only behaviour ⇒ the 3 conversational tests go red (they observe behaviour, not a declaration); the pipeline test stays green. Restored ⇒ 4/4 green.

## Validation

- `pytest tests/unit/argumentation_analysis/orchestration/test_runner_mode_1668.py` → 14 passed (10 existing + 4 new)
- `black --check` clean on both files

## Out of scope

The conversational summary hardcodes `failed: 0, skipped: 0` (the AgentGroupChat path does not currently fail/skip named phases). Surfacing those counters honestly is the fix; enriching the conversational summary to track real failures is a separate, larger change.

Refs #1668 (the runner this PR fixes is the Temps 1 runner). Surfaced in the Temps 2 conversational run report.

🤖 Worker po-2025