### PR TITLE
feat(dl-cl): carry input provenance via invoke layer + scrub on export (#1693)

### DIFF
--- a/argumentation_analysis/evaluation/sanitize_state.py
+++ b/argumentation_analysis/evaluation/sanitize_state.py
@@ -166,6 +166,14 @@ _OPAQUE_FORMALISM_SPECIFIC = {
     "set_attacks": ("dict_list", ("attackers", "target")),
     "attack_weights": ("dict_list", ("source", "target")),
     "delp_arguments": "atom_list",
+    # #1693: DL/CL provenance sidecars on fol_analysis_results (DL) and
+    # propositional_analysis_results (CL). Each leaf is a list of source-derived
+    # logical axioms/conditionals (NL→DL/CL translation of claim text) — same
+    # nominative class as DeLP ``program``, so the ``atom_list`` mode applies.
+    "tbox": "atom_list",
+    "abox_concepts": "atom_list",
+    "abox_roles": "atom_list",
+    "conditionals": "atom_list",
 }
 
 # List-of-dicts fields: top-level field -> sub-keys whose values are
@@ -596,6 +604,25 @@ def sanitize_state(state: dict[str, Any] | Any) -> dict[str, Any]:
                     for leaf in leaf_subkeys:
                         if leaf in sub:
                             sub[leaf] = _opacify_list_values(sub[leaf])
+
+    # 5f. Opacify the ``formalism_specific`` provenance sidecar on the FOL/PL
+    #     list-of-dicts containers (#1693). DL attaches the sidecar to
+    #     ``fol_analysis_results[*]`` (carrying the input TBox/ABox), CL to
+    #     ``propositional_analysis_results[*]`` (carrying the input
+    #     conditionals). These containers are not 4d scrub targets (4d covers
+    #     ``dung_frameworks``), and the sidecar leaves are NL→DL/CL
+    #     translations of source claim text — nominative, same class as the
+    #     Wave-2 leaves 4d opacifies. Same ``_scrub_formalism_specific`` and
+    #     the same ``_OPAQUE_FORMALISM_SPECIFIC`` table (extended with the
+    #     DL/CL leaves); topology (list arity) survives, only the axiom text
+    #     is opacified, so downstream counts (tbox_size etc.) are unaffected.
+    for field in ("fol_analysis_results", "propositional_analysis_results"):
+        if isinstance(data.get(field), list):
+            for item in data[field]:
+                if isinstance(item, dict) and "formalism_specific" in item:
+                    item["formalism_specific"] = _scrub_formalism_specific(
+                        item["formalism_specific"]
+                    )
 
     # 6. Opacify symbol-mapping sub-keys inside list-of-dicts fields
     #    (nl_to_logic_translations[*].variables).

--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -4412,6 +4412,18 @@ async def _invoke_dl(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]
             "message": msg,
             "tbox_size": len(tbox),
             "abox_size": len(abox_concepts) + len(abox_roles),
+            # #1693: carry the INPUT ontology the reasoner worked over, named
+            # as provenance (these are context entries, not reasoner output —
+            # _write_dl_to_state attaches them as a formalism_specific sidecar
+            # so a reader can distinguish "the reasoner produced this" from
+            # "this was handed to the reasoner", anti-#1019). The lists are
+            # source-derived (NL→DL translation of claim text) and scrubbed on
+            # export via sanitize_state pass 5f.
+            "input_ontology": {
+                "tbox": list(tbox),
+                "abox_concepts": list(abox_concepts),
+                "abox_roles": list(abox_roles),
+            },
             "statistics": {"handler": "DLHandler", "reasoner": "NaiveDlReasoner"},
         }
     except Exception as e:
@@ -4446,6 +4458,11 @@ async def _invoke_cl(input_text: str, context: Dict[str, Any]) -> Dict[str, Any]
             "entailed": entailed,
             "message": msg,
             "num_conditionals": len(conditionals),
+            # #1693: carry the INPUT conditionals the reasoner worked over,
+            # named as provenance (context entry, not reasoner output — see
+            # the DL sibling above). Source-derived (NL→CL translation) and
+            # scrubbed on export via sanitize_state pass 5f.
+            "input_conditionals": list(conditionals),
             "statistics": {"handler": "CLHandler", "reasoner": "SimpleCReasoner"},
         }
     except Exception as e:

--- a/argumentation_analysis/orchestration/state_writers.py
+++ b/argumentation_analysis/orchestration/state_writers.py
@@ -1389,7 +1389,20 @@ def _write_formal_synthesis_to_state(
 
 
 def _write_dl_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
-    """Write Description Logic results to UnifiedAnalysisState (#86)."""
+    """Write Description Logic results to UnifiedAnalysisState (#86).
+
+    #1693: the TBox/ABox the reasoner worked over used to be dropped at the
+    invoke boundary (only ``tbox_size``/``abox_size`` survived). The invoke now
+    carries them as ``input_ontology`` (named for what they are — provenance,
+    not reasoner output, anti-#1019), and this writer attaches them as a
+    strictly-additive ``formalism_specific`` sidecar on the FOL entry. The
+    native projection (formulas/consistent/confidence) is untouched; the
+    sidecar is absent when the invoke produced no ontology (empty lists ⇒ no
+    key, so an entry from a pre-#1693 or empty-context run is indistinguishable
+    from one where the reasoner saw no axioms). The sidecar is scrubbed on
+    export (sanitize_state pass 5f) because the axioms are NL→DL translations
+    of source claim text.
+    """
     if not output or not isinstance(output, dict):
         return
     consistent = output.get("consistent")  # None = unverified (#1019)
@@ -1405,6 +1418,19 @@ def _write_dl_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
         inferences=[],
         confidence=confidence,
     )
+    ontology = output.get("input_ontology")
+    if isinstance(ontology, dict):
+        sidecar = {
+            k: list(v)
+            for k, v in (
+                ("tbox", ontology.get("tbox")),
+                ("abox_concepts", ontology.get("abox_concepts")),
+                ("abox_roles", ontology.get("abox_roles")),
+            )
+            if isinstance(v, list)
+        }
+        if sidecar and state.fol_analysis_results:
+            state.fol_analysis_results[-1]["formalism_specific"] = sidecar
 
 
 def _write_cl_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
@@ -1424,6 +1450,19 @@ def _write_cl_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:
         satisfiable=entailed,
         model={},
     )
+    # #1693: carry the INPUT conditionals the reasoner worked over as a
+    # strictly-additive ``formalism_specific`` sidecar (named provenance — see
+    # _write_dl_to_state). Absent when the invoke produced no list (empty ⇒ no
+    # key, same theatre-guard as QBF/DL). Scrubbed on export (pass 5f).
+    conditionals = output.get("input_conditionals")
+    if (
+        isinstance(conditionals, list)
+        and conditionals
+        and state.propositional_analysis_results
+    ):
+        state.propositional_analysis_results[-1]["formalism_specific"] = {
+            "conditionals": list(conditionals),
+        }
 
 
 def _write_sat_to_state(output: Any, state: Any, ctx: dict[str, Any]) -> None:

--- a/tests/unit/argumentation_analysis/evaluation/test_sanitize_dl_cl_provenance_1693.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_sanitize_dl_cl_provenance_1693.py
@@ -1,0 +1,201 @@
+"""#1693 — DL/CL input provenance carried through, then scrubbed on export.
+
+Two layers, both tested here:
+
+1. **Producer** (``_invoke_dl``/``_invoke_cl``): the input ontology /
+   conditionals the reasoner worked over are returned in the output dict
+   (named ``input_ontology``/``input_conditionals`` — provenance, not result).
+2. **Export** (``sanitize_state`` pass 5f): the ``formalism_specific`` sidecar
+   on ``fol_analysis_results`` (DL) and ``propositional_analysis_results`` (CL)
+   is opacified — the axiom text is source-derived (NL→DL/CL translation of
+   claim text), so it must not survive an export. Topology (list arity)
+   survives, so downstream counts are unaffected.
+
+Privacy: opaque synthetic atoms only (no corpus text).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from argumentation_analysis.evaluation.sanitize_state import sanitize_state
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Producer — the invoke now carries the input ontology / conditionals.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestInvokeDlCarriesOntology1693:
+    """_invoke_dl returns the input ontology (provenance), not just counts."""
+
+    async def test_invoke_dl_carries_input_ontology(self) -> None:
+        from argumentation_analysis.orchestration import invoke_callables
+
+        with (
+            patch(
+                "argumentation_analysis.agents.core.logic.dl_handler.DLHandler"
+            ) as DLH,
+            patch(
+                "argumentation_analysis.agents.core.logic.tweety_initializer."
+                "TweetyInitializer"
+            ),
+        ):
+            handler = DLH.return_value
+            handler.create_knowledge_base.return_value = object()
+            # is_consistent is called via asyncio.to_thread (sync); return the
+            # (verdict, message) tuple directly.
+            handler.is_consistent.return_value = (True, "consistent")
+
+            result = await invoke_callables._invoke_dl(
+                "unused",
+                {
+                    "tbox": ["synthetic_axiom_1"],
+                    "abox_concepts": ["synthetic_concept_a"],
+                    "abox_roles": ["synthetic_role_r"],
+                },
+            )
+
+        assert result["consistent"] is True
+        ontology = result["input_ontology"]
+        assert ontology["tbox"] == ["synthetic_axiom_1"], ontology
+        assert ontology["abox_concepts"] == ["synthetic_concept_a"], ontology
+        assert ontology["abox_roles"] == ["synthetic_role_r"], ontology
+        # The counts the writer still carries ride alongside (unchanged).
+        assert result["tbox_size"] == 1 and result["abox_size"] == 2
+
+
+class TestInvokeClCarriesConditionals1693:
+    """_invoke_cl returns the input conditionals (provenance), not just a count."""
+
+    async def test_invoke_cl_carries_input_conditionals(self) -> None:
+        from argumentation_analysis.orchestration import invoke_callables
+
+        with (
+            patch(
+                "argumentation_analysis.agents.core.logic.cl_handler.CLHandler"
+            ) as CLH,
+            patch(
+                "argumentation_analysis.agents.core.logic.tweety_initializer."
+                "TweetyInitializer"
+            ),
+        ):
+            handler = CLH.return_value
+            handler.create_knowledge_base.return_value = object()
+            handler.query.return_value = (False, "not entailed")
+
+            result = await invoke_callables._invoke_cl(
+                "unused",
+                {
+                    "conditionals": ["synthetic_cond_1 => synthetic_cond_2"],
+                    "query_conclusion": "synthetic_conclusion",
+                    "query_premise": None,
+                },
+            )
+
+        assert result["entailed"] is False
+        assert result["input_conditionals"] == [
+            "synthetic_cond_1 => synthetic_cond_2"
+        ], result
+        assert result["num_conditionals"] == 1
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Export — pass 5f opacifies the DL/CL provenance sidecar on FOL/PL containers.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSanitizeDlClProvenanceSidecar1693:
+    """The fol/pl ``formalism_specific`` sidecar leaves are opacified (pass 5f)."""
+
+    def test_dl_tbox_abox_opacified_topology_preserved(self) -> None:
+        out = sanitize_state(
+            {
+                "fol_analysis_results": [
+                    {
+                        "id": "fol_1",
+                        "formulas": ["DL: msg"],
+                        "consistent": True,
+                        "formalism_specific": {
+                            "tbox": ["synthetic_axiom_alpha", "synthetic_axiom_beta"],
+                            "abox_concepts": ["synthetic_concept_gamma"],
+                            "abox_roles": ["synthetic_role_delta"],
+                        },
+                    }
+                ]
+            }
+        )
+        side = out["fol_analysis_results"][0]["formalism_specific"]
+        # Topology preserved: list arity survives.
+        assert len(side["tbox"]) == 2, side
+        assert len(side["abox_concepts"]) == 1, side
+        assert len(side["abox_roles"]) == 1, side
+        # Content opacified: no synthetic- atom survives verbatim.
+        flat = side["tbox"] + side["abox_concepts"] + side["abox_roles"]
+        assert all("synthetic_" not in str(a) for a in flat), flat
+
+    def test_cl_conditionals_opacified_topology_preserved(self) -> None:
+        out = sanitize_state(
+            {
+                "propositional_analysis_results": [
+                    {
+                        "id": "pl_1",
+                        "formulas": ["CL(2 conditionals): ok"],
+                        "satisfiable": True,
+                        "formalism_specific": {
+                            "conditionals": [
+                                "synthetic_cond_1 => synthetic_cond_2",
+                                "synthetic_cond_3",
+                            ]
+                        },
+                    }
+                ]
+            }
+        )
+        side = out["propositional_analysis_results"][0]["formalism_specific"]
+        assert len(side["conditionals"]) == 2, side  # arity preserved
+        assert all("synthetic_" not in str(c) for c in side["conditionals"]), side[
+            "conditionals"
+        ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Substitution control on the real input — empty vs non-empty TBox.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDlClProvenanceDistinguishableDownstream1693:
+    """DoD item 4: an empty and a non-empty TBox produce two distinguishable
+    states downstream. If the figure does not move, say so in the PR."""
+
+    def test_empty_vs_nonempty_ontology_produce_distinguishable_sidecars(self) -> None:
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+        from argumentation_analysis.orchestration.state_writers import (
+            _write_dl_to_state,
+        )
+
+        def _build(ontology_present: bool) -> dict:
+            state = UnifiedAnalysisState("dl-1693 probe")
+            output = {
+                "consistent": True,
+                "message": "m",
+                "tbox_size": 1 if ontology_present else 0,
+                "abox_size": 0,
+            }
+            if ontology_present:
+                output["input_ontology"] = {
+                    "tbox": ["synthetic_axiom"],
+                    "abox_concepts": [],
+                    "abox_roles": [],
+                }
+            _write_dl_to_state(output, state, {})
+            entry = state.fol_analysis_results[-1]
+            return entry.get("formalism_specific", {})
+
+        empty_sidecar = _build(ontology_present=False)
+        full_sidecar = _build(ontology_present=True)
+
+        # The two states ARE distinguishable downstream: the empty-TBox run has
+        # no sidecar, the non-empty one carries the axiom. (Reverting the writer
+        # to always-attach would collapse the two — the theatre guard #1019.)
+        assert empty_sidecar == {}, empty_sidecar
+        assert full_sidecar.get("tbox") == ["synthetic_axiom"], full_sidecar

--- a/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_state_writers_1648.py
@@ -306,10 +306,10 @@ class TestSetafFlattening1648:
         state = _new_state()
         output = self._stub_handler_output()
         output["attacks"] = [
-            {"attackers": ["a", "b"], "target": "c"},     # valid
-            {"target": "b"},                              # missing attackers
-            {"attackers": "not-a-list", "target": "d"},   # wrong shape
-            {"attackers": [], "target": "e"},             # empty set (valid)
+            {"attackers": ["a", "b"], "target": "c"},  # valid
+            {"target": "b"},  # missing attackers
+            {"attackers": "not-a-list", "target": "d"},  # wrong shape
+            {"attackers": [], "target": "e"},  # empty set (valid)
         ]
 
         _write_setaf_to_state(output, state, {})
@@ -343,7 +343,9 @@ class TestAdfFlattening1648:
     future refactor that tries to "fix" ADF attacks breaks it visibly.
     """
 
-    def test_adf_attacks_stay_empty_and_acceptance_conditions_acknowledged(self) -> None:
+    def test_adf_attacks_stay_empty_and_acceptance_conditions_acknowledged(
+        self,
+    ) -> None:
         state = _new_state()
         output = {
             "semantics": "grounded",
@@ -356,14 +358,14 @@ class TestAdfFlattening1648:
 
         entry = next(iter(state.dung_frameworks.values()))
         # Writer-side contract: attacks stay empty (ADF has none).
-        assert entry["attacks"] == [], (
-            f"ADF writer unexpectedly produced attacks={entry['attacks']!r}"
-        )
+        assert (
+            entry["attacks"] == []
+        ), f"ADF writer unexpectedly produced attacks={entry['attacks']!r}"
         # Distinct ADF data (interpretations) IS preserved via extensions.
         # If a future refactor drops them, this assertion fires.
-        assert "adf_models" in entry["extensions"], (
-            f"ADF writer dropped interpretations: extensions={entry['extensions']!r}"
-        )
+        assert (
+            "adf_models" in entry["extensions"]
+        ), f"ADF writer dropped interpretations: extensions={entry['extensions']!r}"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -482,9 +484,9 @@ class TestSocialFlattening1648:
         extensions = entry.get("extensions", {})
         # Today's behaviour: scores live in extensions under "social_scores".
         # If a future writer refactor drops them, this assertion fires.
-        assert extensions.get("social_scores") == output["scores"], (
-            f"Social writer dropped scores: extensions={extensions!r}"
-        )
+        assert (
+            extensions.get("social_scores") == output["scores"]
+        ), f"Social writer dropped scores: extensions={extensions!r}"
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -654,121 +656,122 @@ class TestDelpFlattening1648:
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# DL — ontology structure is a PRODUCER-side loss (out of #1648 writer-scope).
-# See #1693 for the invoke-layer fix. The writer's contract on the real
-# (count-only) producer output is pinned here.
+# DL — ontology provenance now carried via the invoke layer (#1693, was
+# producer-side loss out of #1648 writer-scope). The writer attaches the
+# input ontology as a strictly-additive ``formalism_specific`` sidecar.
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 class TestDlFlattening1648:
-    """DL ontology loss is producer-side (invoke-layer), not writer-side.
+    """DL ontology provenance: the invoke now carries it, the writer sidecars it.
 
-    ``dl_handler.py`` builds a Tweety KB from the TBox/ABox, but
-    ``_invoke_dl`` (``invoke_callables.py:4125-4131``) **rebuilds the output
-    dict with counts only** (``tbox_size``, ``abox_size``) — the TBox/ABox
-    lists are consumed by ``create_knowledge_base`` and dropped *before* the
-    writer boundary. So the writer never receives the ontology; no writer-side
-    sidecar could recover it (that would be #1019 theater — a dict-literal
-    fixture pretending the writer gets the lists). The genuine fix is
-    invoke-layer (carry the lists through) + a privacy review (the int
-    reduction may be a deliberate export guard, since
-    ``fol_analysis_results`` is not a ``sanitize_state`` scrub target) —
-    tracked in #1693, deferred by coord ruling R780 option (ii).
-
-    What the writer DOES receive and must carry honestly: the tri-state
-    consistency verdict (None=unverified / True / False, #1019 fail-loud) and
-    the message. The xfail-strict pin (which assumed a writer-side fix) is
-    retired; this test now pins the real writer contract on the real producer
-    output, and asserts the ontology is NOT fabricated from counts.
+    Pre-#1693 ``_invoke_dl`` rebuilt its output with counts only and dropped
+    the TBox/ABox lists before the writer boundary — so no writer-side change
+    could recover them. #1693 makes ``_invoke_dl`` carry the lists as
+    ``input_ontology`` (named provenance — context entries, not reasoner
+    output), and ``_write_dl_to_state`` attaches them as a
+    ``formalism_specific`` sidecar on the FOL entry. Native projection
+    (formulas/consistent/confidence) untouched; the sidecar is absent when
+    the invoke produced no ontology, so it never fabricates an empty TBox
+    (the anti-#1019 guard the retired version of this test pinned).
     """
 
-    def test_dl_writer_carries_verdict_ontology_is_producer_loss_1693(self) -> None:
-        """Writer carries the consistency verdict on ``_invoke_dl``'s real
-        output (counts, not lists) and does not synthesise an ontology it was
-        never given (anti-#1019). The ontology loss is documented producer-side
-        (refs #1693), not a writer defect."""
+    def test_dl_writer_carries_ontology_sidecar_when_invoke_provides_it_1693(
+        self,
+    ) -> None:
+        """Writer attaches ``formalism_specific.tbox/abox_*`` when the invoke
+        carried the input ontology (#1693)."""
         state = _new_state()
-        # The dict _invoke_dl actually builds (invoke_callables.py:4125-4131):
-        # counts only — the TBox/ABox lists are gone at this boundary.
         output = {
             "consistent": True,
             "message": "Knowledge base is consistent.",
-            "tbox_size": 1,
+            "tbox_size": 2,
             "abox_size": 2,
+            "input_ontology": {
+                "tbox": ["synthetic_axiom_1", "synthetic_axiom_2"],
+                "abox_concepts": ["synthetic_concept_a"],
+                "abox_roles": ["synthetic_role_r"],
+            },
             "statistics": {"handler": "DLHandler", "reasoner": "NaiveDlReasoner"},
         }
 
         _write_dl_to_state(output, state, {})
 
-        fol = state.fol_analysis_results
-        assert fol, "DL writer produced no entry"
-        entry = fol[0]
-        # The tri-state verdict is carried (the writer's real job, #1019
-        # fail-loud: True here, not a fabricated default).
+        entry = state.fol_analysis_results[0]
         assert entry["consistent"] is True, entry
-        # The ontology structure is NOT here — and must NOT be synthesised
-        # from the counts. A future naïve ``entry["tbox"] = output.get("tbox",
-        # [])`` (inventing a list from a missing key) would fabricate an empty
-        # tbox and disguise the producer loss; this assertion guards against
-        # that theater. Refs #1693 for the genuine invoke-layer fix.
-        assert "tbox" not in entry, entry
-        assert "abox_concepts" not in entry, entry
-        assert "abox_roles" not in entry, entry
+        sidecar = entry["formalism_specific"]
+        assert sidecar["tbox"] == ["synthetic_axiom_1", "synthetic_axiom_2"], sidecar
+        assert sidecar["abox_concepts"] == ["synthetic_concept_a"], sidecar
+        assert sidecar["abox_roles"] == ["synthetic_role_r"], sidecar
+
+    def test_dl_writer_omits_sidecar_when_invoke_produced_no_ontology(self) -> None:
+        """Pre-#1693 invoke output (no ``input_ontology``) ⇒ no sidecar, and
+        the native projection still carries the verdict. No fabrication."""
+        state = _new_state()
+        output = {
+            "consistent": False,
+            "message": "inconsistent",
+            "tbox_size": 0,
+            "abox_size": 0,
+        }
+
+        _write_dl_to_state(output, state, {})
+
+        entry = state.fol_analysis_results[0]
+        assert entry["consistent"] is False, entry
+        assert "formalism_specific" not in entry, entry
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# CL — conditionals are a PRODUCER-side loss (out of #1648 writer-scope).
-# See #1693 for the invoke-layer fix. The writer's contract on the real
-# (count-only) producer output is pinned here.
+# CL — conditionals provenance now carried via the invoke layer (#1693).
 # ─────────────────────────────────────────────────────────────────────────────
 
 
 class TestClFlattening1648:
-    """CL conditional loss is producer-side (invoke-layer), not writer-side.
+    """CL conditionals provenance: the invoke now carries them, the writer sidecars them.
 
-    ``_invoke_cl`` (``invoke_callables.py:4160-4164``) **rebuilds the output
-    dict with a count only** (``num_conditionals``) — the ``conditionals``
-    list is consumed by ``create_knowledge_base`` and dropped *before* the
-    writer boundary. Same producer-loss category as DL (see above). A
-    writer-side sidecar would be #1019 theater; the genuine fix is
-    invoke-layer + privacy review (``propositional_analysis_results`` is not
-    a ``sanitize_state`` scrub target) — tracked in #1693, deferred by coord
-    ruling R780 option (ii).
-
-    The xfail-strict pin is retired; this test pins the real writer contract
-    on the real producer output, and asserts conditionals are NOT fabricated
-    from the count.
+    Same #1693 pattern as DL: ``_invoke_cl`` carries the input conditionals as
+    ``input_conditionals``, and ``_write_cl_to_state`` attaches them as a
+    ``formalism_specific`` sidecar on the PL entry. Absent ⇒ no sidecar (no
+    fabrication from the count).
     """
 
-    def test_cl_writer_carries_verdict_conditionals_are_producer_loss_1693(
+    def test_cl_writer_carries_conditionals_sidecar_when_invoke_provides_it_1693(
         self,
     ) -> None:
-        """Writer carries the entailment verdict on ``_invoke_cl``'s real
-        output (count, not list) and does not synthesise conditionals it was
-        never given (anti-#1019). The loss is documented producer-side
-        (refs #1693), not a writer defect."""
+        """Writer attaches ``formalism_specific.conditionals`` when the invoke
+        carried the input conditionals (#1693)."""
         state = _new_state()
-        # The dict _invoke_cl actually builds (invoke_callables.py:4160-4164):
-        # count only — the conditionals list is gone at this boundary.
         output = {
             "entailed": True,
             "message": "ok",
             "num_conditionals": 2,
+            "input_conditionals": ["synthetic_cond_1 => synthetic_cond_2"],
             "statistics": {"handler": "CLHandler", "reasoner": "SimpleCReasoner"},
         }
 
         _write_cl_to_state(output, state, {})
 
-        pl = state.propositional_analysis_results
-        assert pl, "CL writer produced no entry"
-        entry = pl[0]
-        # The entailment verdict is carried (the writer's real job).
+        entry = state.propositional_analysis_results[0]
         assert entry["satisfiable"] is True, entry
-        # The count rides in the formula label (the writer's real job).
-        assert "2 conditionals" in entry["formulas"][0], entry
-        # The conditional list is NOT here — and must NOT be synthesised from
-        # the count. Anti-#1019 guard (same rationale as DL above). Refs #1693.
-        assert "conditionals" not in entry, entry
+        sidecar = entry["formalism_specific"]
+        assert sidecar["conditionals"] == [
+            "synthetic_cond_1 => synthetic_cond_2"
+        ], sidecar
+
+    def test_cl_writer_omits_sidecar_when_invoke_produced_no_conditionals(self) -> None:
+        """Pre-#1693 invoke output (no ``input_conditionals``) ⇒ no sidecar."""
+        state = _new_state()
+        output = {
+            "entailed": True,
+            "message": "ok",
+            "num_conditionals": 2,
+        }
+
+        _write_cl_to_state(output, state, {})
+
+        entry = state.propositional_analysis_results[0]
+        assert "formalism_specific" not in entry, entry
 
 
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes **#1693** — the DL/CL formalism loss was one layer above the #1648 writer-side flattening: the input ontology the reasoner worked over was dropped at the **invoke boundary** (`_invoke_dl`/`_invoke_cl` rebuilt their output with counts only). The writer never received the lists, so no writer-side sidecar could recover them (#1019 theater).

This PR carries the input ontology (DL: `tbox`/`abox_concepts`/`abox_roles`) and conditionals (CL) through the invoke layer, attaches them as a strictly-additive `formalism_specific` sidecar at the writer, and scrubs them on export.

## DoD item 1 — Decision: WHERE to widen (written, not just coded)

**Decision: provenance sidecar, NOT handler-signature widening.**

The body of #1693 proposed *« mirror `_invoke_delp`/`_invoke_qbf`: pass `output` through »*. That direction is **not executable**: `DLHandler.is_consistent` and `CLHandler.query` return a **2-tuple** `Tuple[Optional[bool], str]`, not a dict — there is no richer `output` to let through (confirmed at `dl_handler.py:161`, `cl_handler.py:178`). The loss is in the handler's return *signature*, one layer above what the body describes.

Widening the handler signatures to return a dict would make the TBox/ABox/conditionals look like **reasoner output** — but they are **inputs**, read from `context` (`_invoke_dl:4394-4396`, `_invoke_cl:4426`). Presenting an input as a result is the #1019 family: a reader could no longer distinguish *"the reasoner produced this"* from *"someone put this in the context"*.

So the lists are carried as **provenance**, named for what they are:
- `_invoke_dl` returns `input_ontology: {tbox, abox_concepts, abox_roles}` — *"the ontology the reasoner worked over"*.
- `_invoke_cl` returns `input_conditionals: [...]` — *"the conditionals the reasoner worked over"*.
- The writer attaches them under `entry["formalism_specific"]` (the Wave-2 additive pattern, same as QBF/SetAF/ABA), absent when the invoke produced no list (no fabrication from counts — the anti-#1019 guard the retired version of this contract pinned).

The native projection (`formulas`/`consistent`/`satisfiable`/counts) is untouched; only the sidecar is additive.

## DoD item 2 — Privacy review (rendered)

**Is the opaque-int reduction a deliberate privacy guard? No.** `git log --all -S 'tbox_size'` → the reduction is a mechanical consequence of the handler's 2-tuple return (`b0ab2941` wiring + `f78fa383` refactor split). No privacy commit on these lines, no message mentioning it.

**Are the carried lists source-derived? Yes** — the TBox/ABox/conditionals are NL→DL/CL translations of source claim text (they enter `context` from upstream extraction). They are therefore nominative and **must** be scrubbed on export.

`fol_analysis_results` (DL) and `propositional_analysis_results` (CL) are **not** `sanitize_state` scrub targets under pass 4d (which covers `dung_frameworks` only). This PR adds **pass 5f**: it applies the existing `_scrub_formalism_specific` opacifier to the `formalism_specific` sidecar of both FOL/PL containers, using the same `_OPAQUE_FORMALISM_SPECIFIC` table (extended with `tbox`/`abox_concepts`/`abox_roles`/`conditionals` as `atom_list` leaves — same nominative class as DeLP `program`).

**Topology survives** (list arity preserved), so downstream counts (`tbox_size`, `num_conditionals`) are unaffected — only the axiom text is opacified. Read #1673 first (pass 8 tests the container type): this scrub tests the **artefact content**, not the container type — `test_sanitize_dl_cl_provenance_1693.py` asserts no synthetic- atom survives verbatim while arity is preserved.

## DoD item 3 — Pins converted to positive tests

The `xfail(strict=True)` DL/CL pins were **already retired by #1695** (`4ddc7910`) — there were no pins left to convert. The retirement replaced them with assertions that the ontology keys are **absent** (a deliberate guard against a naive `entry["tbox"] = output.get("tbox", [])` fabrication).

This PR **inverts those assertions in the same change that carries the lists** (never relaxed ahead of it, per #1695's instruction): `TestDlFlattening1648` / `TestClFlattening1648` now assert the sidecar **is present** with the right shape when the invoke provides the lists, and **absent** when it doesn't (no fabrication). Verified the assertions are reached (not a pre-assertion crash): substitution control disabling the writer sidecar makes `test_dl_writer_carries_ontology_sidecar_when_invoke_provides_it_1693` go red on the reached assertion.

## DoD item 4 — Substitution control on the real input

**An empty TBox and a non-empty TBox produce two distinguishable states downstream** (`test_empty_vs_nonempty_ontology_produce_distinguishable_sidecars`): the empty run has no sidecar; the non-empty one carries the axiom. Reverting the writer to always-attach would collapse the two — the theatre guard.

**On real corpora**: DL/CL are wired in `workflows.py` (`dl_reasoning`/`cl_reasoning`) but the `tbox`/`conditionals` context keys are **not populated by any producer today** (grep shows no caller fills them — only test fixtures do). So on the real corpora the sidecar will be **absent**: the invoke runs with empty context lists, and the writer omits the sidecar (no fabrication). The figure does not move on real corpora today; it moves the day a producer wires the NL→DL/CL extraction upstream. Stating this is the deliverable (anti-pendule: never claim a real-corpus fix when the producer isn't connected).

## Files

- `invoke_callables.py` — `_invoke_dl`/`_invoke_cl` carry `input_ontology`/`input_conditionals`.
- `state_writers.py` — `_write_dl_to_state`/`_write_cl_to_state` attach the `formalism_specific` sidecar (additive, absent when no list).
- `sanitize_state.py` — `_OPAQUE_FORMALISM_SPECIFIC` extended (4 leaves) + pass 5f scrubs the FOL/PL sidecar.
- `test_state_writers_1648.py` — DL/CL tests inverted (absent → present-when-provided + absent-when-not, no fabrication).
- `test_sanitize_dl_cl_provenance_1693.py` (new, 5 tests) — invoke carries lists + scrub opacifies with topology preserved + empty/non-empty distinguishable.

## Not in scope

- Wiring a real NL→DL/CL extraction producer to populate `context["tbox"]`/`context["conditionals"]` — that is the day-2 work the sidecar prepares for; this track carries the lists **if** they are provided.
- The pre-existing `black` violations in `state_writers.py` / `invoke_callables.py` (verified on `origin/main`) and the pre-existing mypy `return data` on `sanitize_state.py` (l.622 on main → l.649 here, shifted by this diff; identical error) — left untouched (scoped diff).

Refs #1693.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
