### PR TITLE
fix(dung): remove dead counter-argument strategy gate (#1668)

### DIFF
--- a/argumentation_analysis/orchestration/conversational_orchestrator.py
+++ b/argumentation_analysis/orchestration/conversational_orchestrator.py
@@ -2834,11 +2834,24 @@ def _retract_fallacious_beliefs(
 
 
 def _build_dung_framework_from_state(state: Any) -> Optional[Dict[str, Any]]:
-    """Build a Dung AF from identified_arguments + counter_arguments (#564).
+    """Build a Dung AF from identified_arguments + fallacy targets (#564, rev #1668).
 
-    Constructs attack relations from counter-argument strategies (UNDERCUT,
-    REBUT) and computes grounded extension via pure-Python DungFramework.
+    Constructs attack relations from fallacies that target an argument and
+    computes the grounded extension via the pure-Python DungFramework.
     Writes the result to state.dung_frameworks if non-trivial.
+
+    #1668 — the counter-argument strategy branch was removed. The original
+    #564 implementation filtered counter-arguments through a
+    ``strategy in ("UNDERCUT", "REBUT", "REBUTTAL")`` gate on the assumption
+    that the producer would emit that vocabulary. It never did: the counter-
+    argument producer (``collaborative_debate``) emits free-text strategy
+    names, disjoint from this triplet. Two independent real runs measured
+    0/66 (pipeline voie) and 0/16 (conversational voie) matches — a structural
+    property, not a draw. The branch produced zero attacks on every real run;
+    the framework was in fact populated solely by the fallacy branch below.
+    Removing the dead branch is behaviourally neutral (see
+    ``test_dung_conversational`` post-removal coverage) and deletes no live
+    capacity.
     """
     if not hasattr(state, "identified_arguments") or not state.identified_arguments:
         return None
@@ -2851,36 +2864,12 @@ def _build_dung_framework_from_state(state: Any) -> Optional[Dict[str, Any]]:
     if len(arg_ids) < 2:
         return None
 
-    # Build attack relations from counter-arguments
+    # Build attack relations from fallacies targeting arguments.
+    # #1668: the counter-argument strategy branch (the
+    # ``strategy in ("UNDERCUT", "REBUT", "REBUTTAL")`` gate) previously lived
+    # here — removed, see the function docstring for why.
     attacks = []
-    counter_args = getattr(state, "counter_arguments", [])
-    for ca in counter_args:
-        strategy = ca.get("strategy", "").upper()
-        if strategy in ("UNDERCUT", "REBUT", "REBUTTAL"):
-            original = ca.get("original_argument", "")
-            counter_text = ca.get("counter_argument", "")
-            if not original:
-                continue
-            # Match counter-arg to argument IDs
-            source_id = None
-            target_id = None
-            for aid, desc in state.identified_arguments.items():
-                if desc and (original[:60] in desc or desc[:60] in original):
-                    target_id = aid
-                    break
-            # Source: find which argument the counter supports
-            for aid, desc in state.identified_arguments.items():
-                if (
-                    desc
-                    and counter_text
-                    and (counter_text[:40] in desc or desc[:40] in counter_text)
-                ):
-                    source_id = aid
-                    break
-            if source_id and target_id and source_id != target_id:
-                attacks.append([source_id, target_id])
 
-    # Also build attacks from fallacies targeting arguments
     fallacies = getattr(state, "identified_fallacies", {})
     if isinstance(fallacies, dict):
         fallacies = list(fallacies.values())

--- a/tests/unit/argumentation_analysis/test_dung_conversational.py
+++ b/tests/unit/argumentation_analysis/test_dung_conversational.py
@@ -1,11 +1,18 @@
-"""Tests for Dung framework construction in conversational mode (#564).
+"""Tests for Dung framework construction in conversational mode (#564, rev #1668).
 
 Validates that:
-- _build_dung_framework_from_state builds Dung AF from arguments + counter-args
-- Attack relations are derived from counter-argument strategies (UNDERCUT/REBUT)
+- _build_dung_framework_from_state builds a Dung AF from arguments + fallacy targets
 - Fallacy-targeted arguments become attack relations
 - Grounded extension is computed via pure-Python DungFramework
 - Result is persisted to state.dung_frameworks
+
+#1668 — the counter-argument strategy branch (the ``("UNDERCUT","REBUT","REBUTTAL")``
+gate) was removed. The producer never emitted that vocabulary (0/66 pipeline +
+0/16 conversational matches on real runs), so the branch populated zero attacks.
+``test_counter_argument_no_longer_populates_framework`` is the armed proof of the
+removal (a gated strategy that used to populate the framework no longer does);
+the fallacy-driven tests prove behavioural neutrality (the framework is still
+populated by the fallacy branch, unchanged).
 """
 
 import pytest
@@ -56,8 +63,18 @@ class TestBuildDungFramework:
         result = _build_dung_framework_from_state(state)
         assert result is None
 
-    def test_builds_from_counter_argument(self):
-        """Counter-argument with UNDERCUT strategy creates attack relation."""
+    def test_counter_argument_no_longer_populates_framework(self):
+        """#1668 armed proof: a gated counter-argument strategy does NOT populate
+        the framework after the CA branch was removed.
+
+        Before #1668, a counter-argument whose ``strategy`` was in
+        ``("UNDERCUT","REBUT","REBUTTAL")`` created an attack relation here.
+        The branch was removed because the producer never emitted that
+        vocabulary (0/66 + 0/16 real-run matches). This test pins the removal:
+        with no fallacies, a gated-strategy counter-argument yields no attack,
+        so the builder returns ``None``. If this assertion ever flips back to
+        "populated", someone reintroduced a live CA branch — investigate.
+        """
         from argumentation_analysis.orchestration.conversational_orchestrator import (
             _build_dung_framework_from_state,
         )
@@ -68,19 +85,20 @@ class TestBuildDungFramework:
         for desc in args:
             arg_ids.append(state.add_argument(desc))
 
-        state.counter_arguments.append({
-            "strategy": "UNDERCUT",
-            "original_argument": args[1],
-            "counter_argument": args[0],
-        })
+        # A counter-argument whose strategy is in the (removed) gate vocabulary.
+        # No fallacy is added, so the fallacy branch cannot mask the removal.
+        state.counter_arguments.append(
+            {
+                "strategy": "UNDERCUT",
+                "original_argument": args[1],
+                "counter_argument": args[0],
+            }
+        )
 
         result = _build_dung_framework_from_state(state)
-        assert result is not None
-        assert result["attacks"] >= 1
-        assert result["arguments"] >= 2
-
-        # Verify persisted to state
-        assert len(state.dung_frameworks) >= 1
+        # No attacks (CA branch gone, no fallacies) → builder short-circuits.
+        assert result is None
+        assert len(state.dung_frameworks) == 0
 
     def test_builds_from_fallacy_target(self):
         """Fallacy targeting an argument creates a pseudo-attacker node."""
@@ -99,7 +117,13 @@ class TestBuildDungFramework:
         assert result["attacks"] >= 1
 
     def test_computes_grounded_extension(self):
-        """Grounded extension is computed for valid Dung AF."""
+        """Grounded extension is computed for a valid Dung AF.
+
+        #1668: previously this test drove the attack via a counter-argument
+        (``REBUT`` strategy); it now drives it via a fallacy target, which is
+        the only attack source after the CA branch removal. The grounded
+        extension semantics under test are unchanged.
+        """
         from argumentation_analysis.orchestration.conversational_orchestrator import (
             _build_dung_framework_from_state,
         )
@@ -108,16 +132,12 @@ class TestBuildDungFramework:
         arg_a = state.add_argument("Strong argument A")
         arg_b = state.add_argument("Weak argument B")
 
-        # A attacks B via counter-argument
-        state.counter_arguments.append({
-            "strategy": "REBUT",
-            "original_argument": "Weak argument B",
-            "counter_argument": "Strong argument A",
-        })
+        # A fallacy targeting arg_b makes a pseudo-attacker attack arg_b.
+        state.add_fallacy("ad_hominem", "Attacks the speaker", target_arg_id=arg_b)
 
         result = _build_dung_framework_from_state(state)
         assert result is not None
-        # Grounded extension should include the unattacked argument
+        # Grounded extension should include the unattacked argument (arg_a).
         grounded = result.get("grounded_extension", [])
         assert arg_a in grounded
 
@@ -153,8 +173,83 @@ class TestBuildDungFramework:
         assert len(df_data["arguments"]) >= 2
         assert len(df_data["attacks"]) >= 1
 
-    def test_multiple_attacks_from_mixed_sources(self):
-        """Both counter-args and fallacies contribute attacks."""
+    def test_multiple_attacks_from_distinct_fallacy_targets(self):
+        """Fallacies targeting distinct arguments each contribute one attack.
+
+        #1668: previously asserted ``attacks >= 2`` from one counter-argument
+        (``UNDERCUT``) + one fallacy. With the CA branch removed only the
+        fallacy attack remains per source; this test now uses two distinct
+        fallacy targets to preserve multi-attack coverage on the live branch.
+        """
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _build_dung_framework_from_state,
+        )
+
+        state = UnifiedAnalysisState("Test")
+        state.add_argument("Argument A about policy")
+        arg_b = state.add_argument("Argument B about evidence")
+        arg_c = state.add_argument("Argument C about logic")
+
+        # The CA below would have contributed an attack pre-#1668; it is now
+        # inert. It is kept here to prove the removal is neutral even when a
+        # gated counter-argument is present alongside live fallacy sources.
+        state.counter_arguments.append(
+            {
+                "strategy": "UNDERCUT",
+                "original_argument": "Argument B about evidence",
+                "counter_argument": "Argument A about policy",
+            }
+        )
+
+        # Two distinct fallacy targets → two attacks via the live branch.
+        state.add_fallacy("straw_man", "Misrepresents", target_arg_id=arg_b)
+        state.add_fallacy("ad_hominem", "Attacks speaker", target_arg_id=arg_c)
+
+        result = _build_dung_framework_from_state(state)
+        assert result is not None
+        assert result["attacks"] >= 2
+
+    def test_no_duplicate_attacks(self):
+        """Two fallacies targeting the same argument don't duplicate the node.
+
+        #1668: the counter-argument previously present here (``REBUT``) is now
+        inert; the test still passes because the fallacy branch alone populates
+        at least one attack.
+        """
+        from argumentation_analysis.orchestration.conversational_orchestrator import (
+            _build_dung_framework_from_state,
+        )
+
+        state = UnifiedAnalysisState("Test")
+        state.add_argument("Argument A")
+        arg_b = state.add_argument("Argument B")
+
+        # Inert post-#1668; kept to show neutrality in the presence of a
+        # gated counter-argument.
+        state.counter_arguments.append(
+            {
+                "strategy": "REBUT",
+                "original_argument": "Argument B",
+                "counter_argument": "Argument A",
+            }
+        )
+        state.add_fallacy("hasty_generalization", "Too broad", target_arg_id=arg_b)
+
+        result = _build_dung_framework_from_state(state)
+        assert result is not None
+        assert result["attacks"] >= 1
+
+    def test_fallacy_population_unaffected_by_gate_removal(self):
+        """#1668 neutrality proof: a realistic state (fallacies + gated CAs) is
+        still populated, entirely by the fallacy branch.
+
+        This is the behavioural-neutrality leg of the removal: the gate never
+        matched on real runs, so the framework's population came only from
+        fallacies. With gated counter-arguments present (as on a real run) the
+        framework still builds and carries the fallacy-driven attacks. If the
+        attack count here ever drops to 0, the fallacy branch was damaged —
+        that would be a real regression, unlike the dead CA branch removal.
+        """
         from argumentation_analysis.orchestration.conversational_orchestrator import (
             _build_dung_framework_from_state,
         )
@@ -162,40 +257,22 @@ class TestBuildDungFramework:
         state = UnifiedAnalysisState("Test")
         arg_a = state.add_argument("Argument A about policy")
         arg_b = state.add_argument("Argument B about evidence")
-        arg_c = state.add_argument("Argument C about logic")
 
-        # Counter-arg attack
-        state.counter_arguments.append({
-            "strategy": "UNDERCUT",
-            "original_argument": "Argument B about evidence",
-            "counter_argument": "Argument A about policy",
-        })
-
-        # Fallacy attack
-        state.add_fallacy("straw_man", "Misrepresents", target_arg_id=arg_c)
-
-        result = _build_dung_framework_from_state(state)
-        assert result is not None
-        assert result["attacks"] >= 2
-
-    def test_no_duplicate_attacks(self):
-        """Same attack from multiple sources doesn't duplicate."""
-        from argumentation_analysis.orchestration.conversational_orchestrator import (
-            _build_dung_framework_from_state,
+        # Gated-strategy counter-arguments, as a real producer emits (free-text
+        # strategies that don't match the gate). Inert post-#1668.
+        state.counter_arguments.append(
+            {
+                "strategy": "reductio ad absurdum",
+                "original_argument": "Argument B about evidence",
+                "counter_argument": "Argument A about policy",
+            }
         )
 
-        state = UnifiedAnalysisState("Test")
-        arg_a = state.add_argument("Argument A")
-        arg_b = state.add_argument("Argument B")
-
-        # Both counter-arg and fallacy target B from A
-        state.counter_arguments.append({
-            "strategy": "REBUT",
-            "original_argument": "Argument B",
-            "counter_argument": "Argument A",
-        })
-        state.add_fallacy("hasty_generalization", "Too broad", target_arg_id=arg_b)
+        # Fallacies targeting each argument — the live population source.
+        state.add_fallacy("ad_hominem", "Attacks the speaker", target_arg_id=arg_a)
+        state.add_fallacy("straw_man", "Misrepresents", target_arg_id=arg_b)
 
         result = _build_dung_framework_from_state(state)
         assert result is not None
-        assert result["attacks"] >= 1
+        # Two distinct fallacy targets → at least two attacks, none from CAs.
+        assert result["attacks"] >= 2


### PR DESCRIPTION
## What & why

Removes the `strategy in ("UNDERCUT", "REBUT", "REBUTTAL")` gate and its enclosing counter-argument branch from `_build_dung_framework_from_state` in `conversational_orchestrator.py`.

Dispatched by coord R798 (decision: **retire the gate, don't rename, don't constrain the producer**). The gate never matched on any real run:

| Voie | Run | Counter-args | Gate matches | Source |
|------|-----|--------------|--------------|--------|
| pipeline | R796 | 66 | **0/66** | #1725 measure + issue #1668 |
| conversational | Temps 2 (#1725) | 16 | **0/16** | merged measure `measure_1668_convo_gate.py` |

The producer (`collaborative_debate`) emits free-text strategy names (reductio / counter-example / distinction / reformulation / concession), disjoint from the triplet the gate filtered on. **Structural property, not a draw.** The gated branch produced zero attacks on every real run; the Dung framework was in fact populated solely by the independent **fallacy branch**.

## DoD 1 — Grep by form (not by named site)

Form searched: `UNDERCUT|REBUT|REBUTTAL` across the whole repo. Hits classified by perimeter:

**The gate (target of removal):**
- `conversational_orchestrator.py` — `if strategy in ("UNDERCUT", "REBUT", "REBUTTAL")` (+ function docstring) → **removed**

**Consumers of the matched-set (tests armed on the branch):**
- `test_dung_conversational.py` — 5 sites testing CA UNDERCUT/REBUT → attacks → **rewritten** (see Tests)
- `test_kb_completeness.py` — 1 CA REBUT in a fixture carrying 2 fallacies → **unchanged** (passes via fallacies)

**Out of scope (different vocabularies, untouched):** `abs_arg_dung/aif_adapter.py` (lowercase AIF kinds), `1_2_7_argumentation_dialogique/` + `agents/core/debate/` (`REBUTTAL` ArgumentType/DebatePhase), `structured_arg_translator.py` (ASPIC prompt mentioning undercuts), student-subject docs, AIF demos, `measure_1668_convo_gate.py` (standalone classifier, historical artifact).

**Structural conclusion:** no downstream reader consumes the matched-set specifically — attacks from both branches were fused into one `attacks` list before reaching DungFramework. Nothing distinguishes a CA-derived attack from a fallacy-derived one downstream.

## DoD 2 — Archaeology (`git log -S`)

```
git log -S 'REBUTTAL' -- conversational_orchestrator.py  →  d06b986c  feat(dung): #564
git log -S 'UNDERCUT' -- conversational_orchestrator.py  →  d06b986c  feat(dung): #564
```

Single origin commit: `d06b986c #564` (2026-05-16). That commit introduces the gate **and the function together**; it contains **no producer** of `strategy` (only the function + tests + a post-phase hook). Its message states the gate was built on the assumption counter-arguments "available in state" would carry that vocabulary.

**Verdict: dead on arrival.** No producer ever emitted the triplet; the branch is an unmaterialized hypothesis from #564, not a withdrawn capacity. The removal is a post-mortem cleanup, not the suppression of a live mechanism.

## DoD 3 — Substitution control (executed, R794/R795 lesson)

Removed the **entire branch**, not just the guard: de-guarding alone would let every counter-argument through and **change** the population (non-neutral). The fallacy branch is unchanged.

**Armed test** `test_counter_argument_no_longer_populates_framework`: a single CA with a gated strategy (no fallacies) → asserts `result is None` post-removal. **Executed substitution**:
1. Re-injected the CA branch temporarily → test went **RED** (CA populated → `result is None` assertion broke) ✅
2. Removed the branch again → test **GREEN** ✅

This proves the test observes the removal, not a coincidental pass.

**Neutrality test** `test_fallacy_population_unaffected_by_gate_removal`: a realistic state (free-text-strategy CAs + 2 fallacies) → framework still populated with ≥2 attacks, entirely from the fallacy branch. `test_kb_completeness` passes unchanged — its fixture's fallacies were carrying the assertions all along.

## DoD 4 — Statement of the removal

- **Why removed:** 0 matches on both voies (0/66 + 0/16), two independent runs, producer vocabulary disjoint from the gate triplet — structural.
- **What replaces it:** nothing. The framework is populated by the independent fallacy branch, which is the documented real behaviour.
- **What the removal does NOT change:** the fallacy-driven Dung population, the grounded-extension computation, the persistence to `state.dung_frameworks`, the build-trigger conditions (≥2 args + ≥1 attack). On real corpora the attack count is unchanged because the CA branch contributed zero.

## Tests

17/17 green (`test_dung_conversational` 10 + `test_kb_completeness` 7). black clean on both files. mypy: 0 new errors on the edited zone (pre-existing errors elsewhere in the file are out of CI scope).

- `test_builds_from_counter_argument` → rewritten as `test_counter_argument_no_longer_populates_framework` (armed proof)
- `test_computes_grounded_extension` → re-driven via a fallacy target (CA REBUT → fallacy)
- `test_multiple_attacks_from_mixed_sources` → `test_multiple_attacks_from_distinct_fallacy_targets` (2 fallacies → ≥2; CA kept inert to prove neutrality)
- `test_no_duplicate_attacks` → documented (still passes; CA kept inert)
- **added** `test_fallacy_population_unaffected_by_gate_removal` (neutrality)

## Anti-pendule check

- ✅ Removed dead code (subtraction), not added a counterweight.
- ✅ Did not touch the fallacy population branch (real behaviour, stays).
- ✅ Did not rename the gate (renaming a mechanism that matches nothing = keeping it decorative).
- ✅ Did not constrain the producer (constraining free-text generation to a 3-value vocab would break what works).

Awaiting coord `--admin` merge. Refs #1668.