### PR TITLE
fix(privacy): pass 8 iterates extract entries regardless of container shape (#1673)

### DIFF
--- a/scripts/analysis/generate_spectacular_bundle.py
+++ b/scripts/analysis/generate_spectacular_bundle.py
@@ -197,21 +197,19 @@ def _scrub_state_for_export(state_data: Dict[str, Any]) -> Dict[str, Any]:
                 scrubbed_bs[bs_id] = bs_val
         cleaned["belief_sets"] = scrubbed_bs
 
-    # Eighth pass: scrub extracts (List[Dict[str, Any]] in prod via add_extract)
-    extracts = cleaned.get("extracts", [])
-    if isinstance(extracts, list):
-        scrubbed_extracts = []
-        for entry in extracts:
-            if isinstance(entry, dict):
-                scrubbed_extracts.append({
-                    k: ("<scrubbed>" if isinstance(v, str) and len(v) > 20 else v)
-                    for k, v in entry.items()
-                })
-            elif isinstance(entry, str) and len(entry) > 20:
-                scrubbed_extracts.append("<scrubbed>")
-            else:
-                scrubbed_extracts.append(entry)
-        cleaned["extracts"] = scrubbed_extracts
+    # Eighth pass: scrub extracts entries regardless of container shape (#1673).
+    # Prod is List[Dict] via add_extract (shared_state.py:94) but the scrub must
+    # not gate on the container type — _iter_dimension_entries yields the dict
+    # entries whether the container is a list or a mapping (#1662, same family).
+    # Divergence note: sanitize_state.py preserves extracts[*].name as a join
+    # key for its downstream consumer (l.35-38); this pass scrubs any value
+    # above threshold, name included. The two agree on all measured state
+    # (0/97 names reach threshold) and this script has no join-key consumer —
+    # aligning them without a consumer to arbitrate would be a blind call.
+    for entry in _iter_dimension_entries(cleaned.get("extracts")):
+        for k, v in list(entry.items()):
+            if isinstance(v, str) and len(v) > 20:
+                entry[k] = "<scrubbed>"
 
     # Ninth pass: scrub analysis_tasks (may contain NL instructions)
     tasks = cleaned.get("analysis_tasks", {})

--- a/tests/unit/scripts/analysis/test_generate_spectacular_bundle_privacy.py
+++ b/tests/unit/scripts/analysis/test_generate_spectacular_bundle_privacy.py
@@ -832,3 +832,139 @@ class TestVector6Pass12CoversAllContainers:
         for entry in state["bipolar_results"]:
             for arg in entry["arguments"]:
                 assert arg == "<scrubbed>" or len(arg) <= 10
+
+
+# ---------------------------------------------------------------------------
+# Vector 7 (#1673) — Pass 8 must scrub extracts entries whatever the container
+# ---------------------------------------------------------------------------
+
+class TestVector7Pass8ExtractsContainerShape:
+    """Pass 8 (extracts) must scrub entries regardless of container shape.
+
+    Third occurrence of the #1662 family (#1662, #1664, #1665, now #1673): a
+    privacy guard written against the container shape *observed at write time*.
+    Pass 8 gated on ``isinstance(extracts, list)`` — before #1665 it gated on
+    ``isinstance(extracts, dict)``; each version swapped the orphan form rather
+    than removing the constraint. The orphan form has no producer today, so the
+    defect is in place but lets nothing through — which is exactly why the
+    previous version survived so long.
+
+    Prod shape is ``List[Dict]`` (``shared_state.add_extract`` l.279 appends a
+    dict; ``self.extracts: List[Dict[str, Any]]`` l.94). The orphan form is a
+    ``Dict[str, Dict]`` mapping (id -> entry), analogous to ``dung_frameworks``.
+    The armed canary drives that orphan shape with pure descriptive NL — no
+    entity from Pass 14's allowlist — so a leak is attributable to Pass 8 alone.
+
+    Per #1673: use ``_iter_dimension_entries`` (landed #1662, already used by
+    Pass 12) and mutate entries in place; do NOT re-introduce a ``dict`` branch
+    parallel to the ``list`` one (two branches guarded = the same defect twice).
+    """
+
+    # Pure descriptive NL — no Pass-14 entity name can mask a Pass 8 miss.
+    _LONG_CONTENT = (
+        "The speaker develops an extended argument about institutional reform"
+    )
+    _SENTINEL = "reform"  # generic word, absent from Pass 14's entity regex
+
+    def _entry(self) -> Dict[str, Any]:
+        return {"id": "ext_1", "name": "short", "content": self._LONG_CONTENT}
+
+    # -- Premise guard: prod really is List[Dict] via the real writer ----------
+
+    def test_prod_extracts_is_list_of_dicts_via_real_writer(self):
+        """Guard on the premise: add_extract appends a dict to a list.
+
+        If a future refactor stores extracts as a mapping, this fails first
+        and says so, instead of the scrub silently covering only one shape.
+        """
+        from argumentation_analysis.core.shared_state import UnifiedAnalysisState
+
+        state = UnifiedAnalysisState(initial_text="premise-fixture")
+        state.add_extract(name="short", content=self._LONG_CONTENT)
+        snapshot = state.get_state_snapshot()
+        assert isinstance(
+            snapshot["extracts"], list
+        ), "extracts is no longer a list — the premise of Pass 8 has moved"
+        assert snapshot["extracts"], "add_extract did not populate the list"
+        assert isinstance(snapshot["extracts"][0], dict)
+
+    # -- No-regression: prod list shape still scrubbed ------------------------
+
+    def test_pass8_scrubs_extracts_list_shape_prod(self):
+        """List[Dict] (prod shape) entries are scrubbed — holds pre- and post-fix."""
+        state = {"extracts": [self._entry()]}
+        result = _scrub_state_for_export(state)
+        assert isinstance(result["extracts"], list)
+        assert result["extracts"][0]["content"] == "<scrubbed>"
+
+    # -- Armed canary: the orphan dict shape (RED on main, GREEN after fix) ---
+
+    def test_pass8_scrubs_extracts_dict_shape_orphan(self):
+        """Dict[str, Dict] container (orphan form) entries must be scrubbed too.
+
+        This is the armed test for #1673: on main, Pass 8 gates on
+        ``isinstance(extracts, list)`` and skips the dict container entirely,
+        so ``content`` traverses the export untouched. After the fix (iterate
+        via ``_iter_dimension_entries``), the dict entries are reached.
+        """
+        state = {"extracts": {"ext_1": self._entry()}}
+        result = _scrub_state_for_export(state)
+        # The dict container survives (shape preserved); its entry is scrubbed.
+        assert isinstance(result["extracts"], dict)
+        assert "ext_1" in result["extracts"]
+        assert result["extracts"]["ext_1"]["content"] == "<scrubbed>", (
+            "Pass 8 skipped the dict-shaped extracts container — the orphan "
+            "form let raw NL through (#1673, same family as #1662)."
+        )
+
+    def test_pass8_dict_shape_preserves_short_values(self):
+        """The threshold logic is unchanged on the dict shape: short strings kept."""
+        state = {
+            "extracts": {"ext_1": {"id": "ext_1", "name": "ok", "content": "tiny"}}
+        }
+        result = _scrub_state_for_export(state)
+        assert result["extracts"]["ext_1"]["content"] == "tiny"
+        assert result["extracts"]["ext_1"]["name"] == "ok"
+
+    # -- Pure-NL no-leak: Pass 14 cannot mask a Pass 8 miss -------------------
+
+    def test_pass8_dict_shape_no_pure_nl_sentinel_leak(self):
+        """End-to-end: the planted pure-NL sentinel must not survive.
+
+        Free of entity names, so Pass 14 (the ~30-name allowlist) cannot scrub
+        it — only Pass 8 can. A leak means Pass 8 missed the dict container.
+        """
+        state = {"extracts": {"ext_1": self._entry()}}
+        result = _scrub_state_for_export(state)
+        assert self._SENTINEL not in json.dumps(result).lower(), (
+            "Pure-NL sentinel leaked through the dict-shaped extracts container "
+            "— Pass 8 missed it and Pass 14 cannot mask it (no entity name)."
+        )
+
+    # -- Divergence from sanitize_state on extracts[*].name -------------------
+
+    def test_pass8_scrubs_long_name_diverging_from_sanitize_state(self):
+        """Documents the known divergence: Pass 8 scrubs a long ``name``;
+        ``sanitize_state`` preserves ``extracts[*].name`` as a join key (l.35-38).
+
+        Not a behavior change — the two scrubbers agree on all measured state
+        (0/97 real names reach the threshold), and this script has no join-key
+        consumer. The comment in Pass 8 records the divergence; this test pins
+        the actual policy so a future reader sees it.
+        """
+        entry = {"id": "ext_1", "name": self._LONG_CONTENT, "content": "x"}
+        state = {"extracts": [entry]}
+        result = _scrub_state_for_export(state)
+        assert result["extracts"][0]["name"] == "<scrubbed>"
+
+    # -- Container-type guard removed: both shapes via the same code path -----
+
+    def test_pass8_reaches_both_shapes_through_one_path(self):
+        """The fix removes the type test, not the list support: both shapes
+        are scrubbed through ``_iter_dimension_entries``. Differential on the
+        same entry payload — list and dict containers both scrub content."""
+        entry = self._entry()
+        list_result = _scrub_state_for_export({"extracts": [dict(entry)]})
+        dict_result = _scrub_state_for_export({"extracts": {"ext_1": dict(entry)}})
+        assert list_result["extracts"][0]["content"] == "<scrubbed>"
+        assert dict_result["extracts"]["ext_1"]["content"] == "<scrubbed>"


### PR DESCRIPTION
## Summary

Closes **#1673** — the third occurrence of the container-type guard family (#1662, #1664, #1665). Pass 8 of `generate_spectacular_bundle.py`'s export scrub gated on `isinstance(extracts, list)`; before #1665 it gated on `isinstance(extracts, dict)`. Each version swapped the orphan form instead of removing the constraint. Prod is `List[Dict]` via `add_extract` (`shared_state.py:94`), so the orphan `dict` form has no producer today and nothing leaks — which is exactly why the previous version survived so long.

The fix iterates extract entries via `_iter_dimension_entries` (landed `b248cfeb` for #1662, already used by pass 12 just below) and mutates them in place. No container-type test, no parallel `dict` branch (two branches guarded is the same defect written twice). The orphan `dict` shape is now covered.

## DoD item 1 — Both container forms accepted without testing the container type

Pass 8 now reads:
```python
for entry in _iter_dimension_entries(cleaned.get("extracts")):
    for k, v in list(entry.items()):
        if isinstance(v, str) and len(v) > 20:
            entry[k] = "<scrubbed>"
```
`_iter_dimension_entries` yields the dict entries whether the container is a `list` or a `dict` mapping; the scrub no longer gates on the container's type. Per the issue's only design point ("la passe 8 reconstruit une liste au lieu de muter en place"), the rebuild was what forced the type test — the helper returns entries by reference, so in-place mutation works for both shapes and the rebuild is gone.

## DoD item 2 — A test that fails on the current pass 8

`TestVector7Pass8ExtractsContainerShape` (7 tests) drives the orphan `dict` shape with pure descriptive NL — no entity from pass 14's ~30-name allowlist, so a leak is attributable to pass 8 alone (pass 14 cannot mask it). On main, the three dict-shape canaries are **red** (content traverses the export untouched); after the fix they are green.

- `test_pass8_scrubs_extracts_dict_shape_orphan` — the armed canary, red on main.
- `test_pass8_dict_shape_no_pure_nl_sentinel_leak` — end-to-end, the pure-NL sentinel must not survive (pass 14 can't mask it).
- `test_pass8_reaches_both_shapes_through_one_path` — differential: same entry payload, list and dict containers both scrub content.
- `test_prod_extracts_is_list_of_dicts_via_real_writer` — premise guard via the real `add_extract` writer (anti-#1019 fixture: the premise is grounded on the producer, not asserted by hand). Fails first if a future refactor changes the prod shape.
- `test_pass8_scrubs_extracts_list_shape_prod` — no-regression on the prod list shape.
- `test_pass8_dict_shape_preserves_short_values` — threshold logic unchanged on the dict shape.
- `test_pass8_scrubs_long_name_diverging_from_sanitize_state` — pins the actual `name` policy (see item 3).

## DoD item 3 — Divergence on `extracts[*].name` documented in-comment

A comment block in pass 8 records the divergence: `sanitize_state.py` (l.35-38) preserves `extracts[*].name` as a join key for its downstream consumer; this pass scrubs any value above its threshold, `name` included. The two agree on all measured state (0/97 real names reach the threshold) and this script has no join-key consumer — aligning them without a consumer to arbitrate would be a blind call. Not a behavior change.

## DoD item 4 — No regression on the 97 real entries

The list-shape per-entry logic is unchanged (same threshold, same `<scrubbed>` replacement, same entries reached — only the iteration is now shape-agnostic). So `content` stays scrubbed on the prod shape by construction.

Honesty note: the populated 97-entry artifacts live on ai-01 (data-gated, same as #1668 item 1). On this worker the available state artifacts (`outputs/scda_audit/*`, `docs/reports/spectacular/*`) carry **empty** `extracts` (len=0 on 4/4 scda snapshots + 4/4 spectacular bundles), so the 97 count is the coordinator's measurement, not re-run here. What is verified locally: the container shape is `list` on every available artifact (confirming the prod-shape premise), and the list-shape scrubbing is observationally identical pre- and post-fix (covered by the existing `test_extracts_long_values_scrubbed` plus the new `test_pass8_scrubs_extracts_list_shape_prod`).

Aside: one spectacular bundle (`corpus_D`) already stores `extracts` as a `dict` (empty) — so the orphan shape is not purely hypothetical, it is present without a live producer filling it.

## Substitution control (falsifiability)

Reverting only the script change (test kept): the three dict-shape canaries go red; the four no-regression / premise tests stay green. Restoring the fix: 7/7 green. The armed tests are reached (not a pre-assertion crash) — they assert on the scrubbed value.

## Scope and anti-pendule

- Only pass 8 touched; no other pass of the script. The pre-existing `black` debt on this file (the `frozenset` declarations) and the 8 pre-existing `mypy` errors are on main and left untouched (scoped diff). The added test code is `black`-clean.
- No parallel `dict` branch introduced — the container-type test is removed, not duplicated.
- No behavior change to `name` handling — only a comment recording the existing policy.

## Files

- `scripts/analysis/generate_spectacular_bundle.py` — pass 8 iterates via `_iter_dimension_entries` (in-place); divergence comment added.
- `tests/unit/scripts/analysis/test_generate_spectacular_bundle_privacy.py` — `TestVector7Pass8ExtractsContainerShape` (7 tests).

## Validation

- 65 privacy tests green (7 new + 58 existing, 0 regression).
- Vector 7 canaries: red on main, green after fix; substitution control executed.
- mypy: 8 errors, all pre-existing on main (none in the changed region); 0 new.
- black: added test code clean; pre-existing debt on the file untouched (out of scope).

Refs #1673.

Generated with Claude Code
