### PR TITLE
fix(conclusion): strategy is free text, the conclusion stops categorising (#1668)

### DIFF
--- a/argumentation_analysis/plugins/narrative_synthesis_plugin.py
+++ b/argumentation_analysis/plugins/narrative_synthesis_plugin.py
@@ -88,15 +88,18 @@ def build_narrative(state: Any) -> str:
         parts.append(fallacy_text)
 
     # ── Counter-arguments ──────────────────────────────────────────
+    # #1668 conclusion-side: ``strategy`` is free text emitted by the
+    # collaborative_debate producer (91 CAs measured, 100% distinct values, 0
+    # from any closed vocabulary). Enumerating the values via set()/join() (the
+    # former "via {labels}" prose) presented rich rhetorical moves as a list of
+    # named strategies, and the ``"general"`` default fabricated a label for an
+    # absent key (#1019). The conclusion reports the honest count of
+    # contestation points; the observed moves live with the counter-arguments
+    # themselves, not categorised in the narrative.
     counters = getattr(state, "counter_arguments", [])
     if counters:
-        strategies = set()
-        for ca in counters:
-            if isinstance(ca, dict):
-                strategies.add(ca.get("strategy", "general"))
-        strat_text = ", ".join(strategies) if strategies else "plusieurs approches"
         parts.append(
-            f"Des contre-arguments ont ete generes via {strat_text}, "
+            f"Des contre-arguments ont ete generes, "
             f"identifiant {len(counters)} point(s) de contestation."
         )
 

--- a/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act2_narrative_plugin.py
@@ -1088,7 +1088,11 @@ def build_act2_prompt(evidence: Act2Evidence) -> str:
                     f"Justification : {fl.justification}"
                 )
             for ca in a.counter_args:
-                lines.append(f"      Contre-argument ({ca.strategy}) : {ca.snippet}")
+                # #1668: strategy is free text; surface in parens only when
+                # present — an empty strategy renders as an absence, not ().
+                _strat = (ca.strategy or "").strip()
+                _slot = f" ({_strat})" if _strat else ""
+                lines.append(f"      Contre-argument{_slot} : {ca.snippet}")
             if a.dung_rejected:
                 # Track D #1280 — frame honestly: the Dung graph is built from
                 # the extracted arguments, so the verdict is a reorganisation of

--- a/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
+++ b/argumentation_analysis/reporting/restitution/act3_conclusion_plugin.py
@@ -1717,6 +1717,17 @@ def _band_claim_ceiling(band: str) -> str:
     )
 
 
+def _strategy_suffix(strategy: str) -> str:
+    """Render a counter-argument's observed strategy as a parenthetical suffix.
+
+    #1668 conclusion-side: ``strategy`` is free text. Surface it in parentheses
+    only when non-empty — an empty strategy renders as nothing, not as dangling
+    empty parens (which read as a labelled-but-empty slot, the #1019 shape).
+    """
+    s = (strategy or "").strip()
+    return f" ({s})" if s else ""
+
+
 def build_act3_prompt(evidence: Act3Evidence) -> str:
     """Build the §4-compliant LLM-conducted prompt for the Acte III conclusion.
 
@@ -1791,10 +1802,14 @@ def build_act3_prompt(evidence: Act3Evidence) -> str:
         )
 
     # --- Que faire (actionnable) ---
+    # #1668 conclusion-side: ``strategy`` is free text (an observed rhetorical
+    # move), surfaced in parentheses only when present — an empty strategy
+    # renders as an absence, not as dangling empty parens (which read as a
+    # labelled-but-empty slot).
     shown_counters = evidence.counter_strategies[:_COUNTER_LIST_CAP]
     if shown_counters:
         counters_lines = "\n".join(
-            f"  - Pour contrer {cs.target_arg_id} ({cs.strategy}) : {cs.snippet}"
+            f"  - Pour contrer {cs.target_arg_id}{_strategy_suffix(cs.strategy)} : {cs.snippet}"
             for cs in shown_counters
         )
     else:

--- a/tests/unit/argumentation_analysis/test_conclusion_strategy_free_text_1668.py
+++ b/tests/unit/argumentation_analysis/test_conclusion_strategy_free_text_1668.py
@@ -1,0 +1,157 @@
+"""#1668 conclusion-side — `strategy` is free text, the conclusion stops categorising.
+
+Coordinator decision (R800 dispatch): ``strategy`` is free text emitted by the
+``collaborative_debate`` producer. 91 counter-arguments measured, 100% distinct
+values, 0 from the closed vocabulary ``("UNDERCUT","REBUT","REBUTTAL")``. The
+conclusion-side consumers must present the field honestly as an observed
+rhetorical move, never as a closed category; an absence must render as an
+absence, not as a named label.
+
+Armed canaries (RED on main, GREEN after fix) + no-regression on the honest
+counter-argument count. Anti-#1019: the writer always stores the key
+(``shared_state.add_counter_argument`` l.760), so the canaries drive the
+absent-key shape and the free-text-verbatim shape directly through the reader.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from argumentation_analysis.plugins.narrative_synthesis_plugin import build_narrative
+
+
+# ---------------------------------------------------------------------------
+# narrative_synthesis — the "general" default + the categorical set()/join()
+# ---------------------------------------------------------------------------
+
+_FREE_TEXT_STRATEGY = (
+    "The speaker conflates correlation with causation to inflate the claim"
+)
+
+
+def _state_with_counters(counters):
+    """Minimal state carrying a counter_arguments list (reader-level fixture)."""
+    return SimpleNamespace(counter_arguments=counters)
+
+
+class TestNarrativeStopsCategorisingStrategy:
+    """Pass: narrative_synthesis must not enumerate free-text strategies as labels
+    nor fabricate the ``"general"`` label for an absent key.
+
+    Pre-fix l.93-101 collected ``ca.get("strategy", "general")`` into a ``set()``
+    and joined them into ``"via {strat_text}"`` — presenting free-text moves as a
+    list of named strategies, and fabricating ``"general"`` when the key was
+    absent (#1019: an absence rendered as a named label).
+    """
+
+    def test_free_text_strategy_not_enumerated_verbatim_in_prose(self):
+        """The rich free-text strategy must not surface verbatim in the narrative
+        joined as a pseudo-label. Pre-fix: ``set()`` + ``join()`` rendered it."""
+        state = _state_with_counters(
+            [{"id": "ca_1", "counter_content": "a counter point", "strategy": _FREE_TEXT_STRATEGY}]
+        )
+        result = build_narrative(state)
+        assert _FREE_TEXT_STRATEGY not in result, (
+            "Free-text strategy rendered verbatim in the narrative — the set()/join() "
+            "presented a rich rhetorical move as a named label (#1668)."
+        )
+        assert "via " not in result, (
+            "The categorical 'via {labels}' enumeration survived — strategies are free "
+            "text, not a closed vocabulary to enumerate."
+        )
+
+    def test_absent_strategy_key_not_fabricated_as_general(self):
+        """A counter-argument with no ``strategy`` key must not surface as the
+        fabricated label ``"general"``. #1019: absence rendered as a named label."""
+        state = _state_with_counters(
+            [{"id": "ca_1", "counter_content": "a counter point"}]  # no strategy key
+        )
+        result = build_narrative(state)
+        assert "general" not in result.lower(), (
+            "An absent strategy key was fabricated into the named label 'general' "
+            "(#1019 — an absence must render as an absence)."
+        )
+
+    def test_empty_strategy_string_not_a_label(self):
+        """A counter-argument whose ``strategy`` is the empty string must not
+        surface as a fabricated label either."""
+        state = _state_with_counters(
+            [{"id": "ca_1", "counter_content": "a counter point", "strategy": ""}]
+        )
+        result = build_narrative(state)
+        # No 'via ,' dangling enumeration, no fabricated label
+        assert "via " not in result
+        assert "general" not in result.lower()
+
+    def test_counter_argument_count_still_reported(self):
+        """No-regression: the honest count of contestation points survives the
+        removal of the categorical enumeration."""
+        state = _state_with_counters(
+            [
+                {"id": "ca_1", "counter_content": "point one", "strategy": _FREE_TEXT_STRATEGY},
+                {"id": "ca_2", "counter_content": "point two", "strategy": "another move"},
+            ]
+        )
+        result = build_narrative(state)
+        assert "2" in result
+        assert "contestat" in result.lower() or "contre-argument" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# act3 conclusion — empty strategy must not render as empty parens
+# ---------------------------------------------------------------------------
+
+class TestAct3EmptyStrategyNoEmptyParens:
+    """Pass: when a CounterStrategy carries an empty ``strategy`` (absence), the
+    conclusion line must not render dangling empty parentheses ``()`` — an
+    absence renders as an absence, not as a labelled-but-empty slot.
+
+    Drives the prompt renderer (``build_act3_prompt``) with a minimal
+    ``Act3Evidence`` whose counter carries an empty strategy. The reader-level
+    fixture is legitimate here: this is a presentation test, not a writer test.
+    """
+
+    def test_no_empty_parens_in_counter_line(self):
+        """The rendered counter-argument line must not carry ``()`` for an empty
+        strategy. Pre-fix: ``f'({cs.strategy})'`` rendered the empty string as
+        dangling parentheses."""
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            Act3Evidence,
+            CounterStrategy,
+            build_act3_prompt,
+        )
+
+        evidence = Act3Evidence(
+            counters_total=1,
+            counter_strategies=[
+                CounterStrategy(
+                    strategy="",  # absent / empty — honest absence, not a category
+                    target_arg_id="arg_1",
+                    snippet="The data does not support the inference drawn",
+                )
+            ],
+        )
+        prompt = build_act3_prompt(evidence)
+        assert "()" not in prompt, (
+            "Empty strategy rendered as dangling empty parentheses '()' — an absent "
+            "strategy must not produce an empty labelled slot (#1668 conclusion-side)."
+        )
+
+    def test_nonempty_strategy_kept_as_observed_move(self):
+        """No-regression: a non-empty free-text strategy stays in the line (as an
+        observed rhetorical move), only the empty-parens slot disappears."""
+        from argumentation_analysis.reporting.restitution.act3_conclusion_plugin import (
+            Act3Evidence,
+            CounterStrategy,
+            build_act3_prompt,
+        )
+
+        move = "The speaker conflates correlation with causation"
+        evidence = Act3Evidence(
+            counters_total=1,
+            counter_strategies=[
+                CounterStrategy(strategy=move, target_arg_id="arg_1", snippet="a counter")
+            ],
+        )
+        prompt = build_act3_prompt(evidence)
+        assert move in prompt  # the observed move is still surfaced, honestly


### PR DESCRIPTION
## Summary

Coordinator decision (R800): `strategy` is **free text** emitted by the `collaborative_debate` producer — 91 counter-arguments measured, 100% distinct values, 0 from any closed vocabulary. The conclusion-side consumers must present it honestly as an observed rhetorical move, never as a closed category; an **absence must render as an absence, not as a named label** (#1019).

The gate-side consumer was removed in #1728. This PR fixes the **conclusion-side** consumers — the readers that surface `strategy` to the human reader in the narrative and the Act II/Act III restitution.

Each change is a **subtraction** (anti-pendule): no new mapping, no new category, no producer constraint.

## Changes

### `narrative_synthesis_plugin.py` — the #1019 defect site
The `ca.get("strategy", "general")` default **fabricated a named label for an absent key**, and `set()` + `", ".join()` enumerated the free-text moves as pseudo-labels in `"via {labels}"` prose. Both removed — the narrative now reports the honest count of contestation points, and the observed moves stay with the counter-arguments themselves.

### `act3_conclusion_plugin.py` — empty-parens slot
`f"({cs.strategy})"` rendered an empty strategy as dangling empty parens `()` — a labelled-but-empty slot (the #1019 shape). New `_strategy_suffix(strategy)` helper surfaces the move in parentheses **only when non-empty**; an empty strategy renders as nothing.

### `act2_narrative_plugin.py` — same empty-parens shape
`f"({ca.strategy})"` had the same defect. Same conditional treatment.

## Sweep — 5 conclusion-side readers found, 3 fixed, 2 documented

| # | File:line | Shape | Action | Why |
|---|-----------|-------|--------|-----|
| 1 | `narrative_synthesis_plugin.py:93` | `"general"` default + `set()`/`join()` enumeration | **FIXED** | Fabricated label for absent key + categorised free text (#1019) |
| 2 | `act3_conclusion_plugin.py:1797` | `({cs.strategy})` empty-parens | **FIXED** | Empty strategy → `()` labelled-but-empty slot |
| 3 | `act2_narrative_plugin.py:1090` | `({ca.strategy})` empty-parens | **FIXED** | Same shape as #2 |
| 4 | `html_report.py` (template) | `<strong>{{ ca.strategy }}</strong>` | DOCUMENTED | Renders free text verbatim, no default, no mapping — already honest |
| 5 | `deep_synthesis_agent.py` | "Strategy" column, free-text cell | DOCUMENTED | Free text in a cell, no default, no mapping — already honest |

### Out of scope (verified, not conclusion-side)
- `collaborative_debate.py` (producer — emits the field), `run_orchestration.py` / `invoke_callables.py` (`--counter-strategy` parametric override selector) — producer-side.
- Unrelated `strategy` concepts: `metrics_collector` (Cluedo reveal), `engine/strategy.py` + `main_orchestrator` (`OrchestrationStrategy` enum = pipeline/conversational mode), `counter_argument/strategies.py` (internal 5-strategy producer selector), `governance_agent`, `registry_setup` (Dung reasoner ranking), `sherlock_modern_orchestrator` (fallback dict).

## DoD — Definition of Done

- [x] **Sweep published** (table above): 5 conclusion-side readers found, classified, 3 fixed, 2 documented as already-honest.
- [x] **Anti-#1019 per consumer**: each fix is a subtraction — removed the `"general"` default, removed the `set()`/`join()` enumeration, removed the unconditional parens. No new label, no new mapping.
- [x] **Anti-pendule**: no counterweight added. No "free text" meta-label, no parallel dict branch.
- [x] **Armed canaries (falsifiable)**: 4 tests RED on main (fabricated "general", verbatim free-text enumeration, "via " survival, empty-parens `()`), GREEN after fix.
- [x] **Substitution control**: `git stash` → 4 canaries RED → `git stash pop` → GREEN, per consumer.
- [x] **No regression**: narrative suite 23 green, act3 counter/strategy 7 green, act2 66 green.

## Honesty on real corpora

The producer emits **100% non-empty distinct** strategies (91 CAs measured on ai-01). So **no CA carries `strategy=""` today** — the act3/act2 fixes change **no produced output** (contract hardening against a future empty value, not a current behaviour change). `narrative_synthesis` IS wired (`invoke_callables.py:8800`), so its prose drops `"via {labels}"` and keeps the count — that is a real, honest output change (less categorisation).

## Validation

- `test_conclusion_strategy_free_text_1668.py`: 6/6 GREEN (4 RED on main, 2 no-regression).
- narrative regression: 23 green. act3 counter/strategy: 7 green. act2: 66 green.
- mypy: 9 errors = baseline 9 (0 new; all pre-existing on these files, out of scope).
- black: clean on the changed regions (pre-existing debt untouched).

## Test plan
- [ ] CI green on `automated-tests` (Windows + Conda + Java 11).
- [ ] Reviewer confirms the sweep is exhaustive (no conclusion-side reader missed).
- [ ] Reviewer confirms each fix is a subtraction (no pendulum).

Refs #1668.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
