### PR TITLE
test(sanitize): fix #1702 atms_contexts phantom canary

### DIFF
--- a/tests/unit/argumentation_analysis/evaluation/test_sanitize_coverage_guard_1702.py
+++ b/tests/unit/argumentation_analysis/evaluation/test_sanitize_coverage_guard_1702.py
@@ -229,8 +229,31 @@ def _canaried_state() -> UnifiedAnalysisState:
     # --- jtms_beliefs: belief name can be argument text; justifications free-form
     s.add_jtms_belief(NL, True, [NL2])
 
-    # atms_contexts: stored verbatim by ``_write_atms_to_state``; plant one entry.
-    s.atms_contexts = [{"context": "ctx_1", "hypotheses": [NL]}]
+    # atms_contexts: stored verbatim by ``_write_atms_to_state`` (which does
+    # ``state.atms_contexts = output.get("atms_contexts", [])``). The producer
+    # (``_invoke_atms``, invoke_callables.py:2660) builds each context as
+    # ``{hypothesis_id, label, assumptions, coherent, derivable_beliefs,
+    #    contradicting_beliefs, derivation_count, contradiction_count}`` — there
+    # is NO ``hypotheses`` key. ``assumptions``/``derivable_beliefs``/
+    # ``contradicting_beliefs`` are arg atoms (source-derived via
+    # ``_generate_hypotheses(arg_names, ...)``); ``label`` is the hypothesis
+    # label. Plant the canary in those four nominative leaves, mirroring the real
+    # producer shape exactly (a synthetic ``{"hypotheses": [...]}`` shape would
+    # be the #1664 anti-pattern this module exists to catch — and was, until this
+    # fix, what the phantom ``atms_contexts[*].hypotheses[*]`` baseline path
+    # frozen below measured).
+    s.atms_contexts = [
+        {
+            "hypothesis_id": "ctx_1",
+            "label": NL,
+            "assumptions": [NL, NL2],
+            "coherent": True,
+            "derivable_beliefs": [NL],
+            "contradicting_beliefs": [NL2],
+            "derivation_count": 1,
+            "contradiction_count": 1,
+        }
+    ]
 
     # governance_decisions: structural (method/winner/scores). Exercised so the
     # field is in the written-set, but no NL canary — producer values are short
@@ -403,8 +426,23 @@ EXPECTED_UNCOVERED: dict[str, frozenset[str]] = {
     "jtms_beliefs": frozenset(
         {"jtms_beliefs[*].name", "jtms_beliefs[*].justifications[*]"}
     ),
-    # Stored verbatim by ``_write_atms_to_state``; not in any scrubber table.
-    "atms_contexts": frozenset({"atms_contexts[*].hypotheses[*]"}),
+    # Stored verbatim by ``_write_atms_to_state``
+    # (``state.atms_contexts = output.get("atms_contexts", [])``); not in any
+    # scrubber table. The surviving NL leaves are the ATMS producer's arg-atom
+    # fields: ``label`` (the hypothesis label) and ``assumptions``/
+    # ``derivable_beliefs``/``contradicting_beliefs`` (sorted atom lists sourced
+    # from ``arg_names`` via ``_generate_hypotheses``). ``coherent``/``*_count``
+    # are bool/int and ``hypothesis_id`` is an opaque id, so none surface here.
+    # The narrative reader consumes only ``len()`` + ``coherent``, so these
+    # atoms never reach prose — but they survive export verbatim.
+    "atms_contexts": frozenset(
+        {
+            "atms_contexts[*].label",
+            "atms_contexts[*].assumptions[*]",
+            "atms_contexts[*].derivable_beliefs[*]",
+            "atms_contexts[*].contradicting_beliefs[*]",
+        }
+    ),
 }
 
 


### PR DESCRIPTION
## Summary

The `atms_contexts` canary in the #1702 coverage guard measured a surface that no producer emits — the #1664 anti-pattern this module exists to catch, inside the guard itself.

- **Phantom**: the canary planted `{"context": "ctx_1", "hypotheses": [NL]}`, but the ATMS producer ([invoke_callables.py:2660](argumentation_analysis/orchestration/invoke_callables.py#L2660)) builds each context with 8 keys (`hypothesis_id`/`label`/`assumptions`/`coherent`/`derivable_beliefs`/`contradicting_beliefs`/`derivation_count`/`contradiction_count`) — there is **no** `hypotheses` key.
- **Consequence**: the frozen baseline path `atms_contexts[*].hypotheses[*]` froze a non-existent surface, so the four real nominative leaves (`label`, `assumptions`, `derivable_beliefs`, `contradicting_beliefs`) went unmeasured.

## Changes

- Replant the canary in the producer-faithful shape, NL token in the four arg-atom leaves.
- Update `EXPECTED_UNCOVERED` to freeze the four real surviving paths (verified by the guard's RED→GREEN transition — the diff named exactly these four as `new leaks` and the phantom as `newly covered`).

## Scope — guard correctness, no scrubber patch

These four atoms survive `sanitize_state` verbatim (stored by `_write_atms_to_state` → `state.atms_contexts = output.get(...)`, not in any scrubber table) but **never reach narrative prose** — the ATMS reader ([narrative_synthesis_plugin.py](argumentation_analysis/plugins/narrative_synthesis_plugin.py)) consumes only `len(atms_contexts)` + `coherent`. The privacy triage on whether to opacify these atoms is a separate lane (anti-pendule: not added here). This PR only makes the instrument measure the real producer surface instead of a phantom.

## Test plan

- [x] `test_uncovered_paths_match_frozen_baseline` RED before the `EXPECTED_UNCOVERED` edit (named the 4 real leaves as leaks, phantom as covered — bidirectional proof the guard reads the real surface)
- [x] Full file GREEN after: 11/11 passed
- [x] `black --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)