### PR TITLE
feat(restitution): guard the third hop — projection vs rendered rows (#1676)

### DIFF
--- a/argumentation_analysis/reporting/restitution/appendix.py
+++ b/argumentation_analysis/reporting/restitution/appendix.py
@@ -73,6 +73,12 @@ _MOBILISATION: Dict[str, tuple] = {
     "axe_revision": (("belief_revision_results",), "prose", "acte III"),
     "deliberation": (("debate_transcripts",), "prose", "actes II–III"),
     "gouvernance": (("governance_decisions",), "prose", "actes II–III"),
+    # #1676 — stakes & stakeholders reach the Acte I framing (the genre/arena
+    # derivation in ``act1_framing_plugin`` reads both containers) and have a
+    # live writer (``invoke_callables._invoke_stakes_extractor``, measured
+    # populated on real runs, #1604 R751). The annexe attests the axis by
+    # cardinality; the names themselves stay in the state (privacy).
+    "enjeux": (("stakes_and_stakeholders",), "prose", "acte I"),
     "arg_structuree": (("structured_arg_status",), "failure_only", "acte III"),
     "synthese_narrative": (("narrative_synthesis", "final_conclusion"), "none", ""),
     "synthese_formelle": (("formal_synthesis_reports",), "none", ""),
@@ -122,6 +128,27 @@ def _safe_len(value: Any) -> int:
         return len(value)
     except TypeError:
         return 0
+
+
+def _stakes_summary(stakes: Any) -> str:
+    """#1676 — cardinality of the stakes & stakeholders axis, never its content.
+
+    ``stakes_and_stakeholders`` carries ``{stakes: [...], stakeholders: [...],
+    rhetorical_register, discursive_arena}`` (the schema ``stakes_extractor``
+    writes). The annexe attests the axis by how many enjeux and parties
+    prenantes were identified — the names are nominative and stay in the state.
+    """
+    if not isinstance(stakes, Mapping) or not stakes:
+        return "indisponible"
+    n_stakes = _safe_len(stakes.get("stakes"))
+    n_holders = _safe_len(stakes.get("stakeholders"))
+    enjeux = f"{n_stakes} enjeu" if n_stakes == 1 else f"{n_stakes} enjeux"
+    parties = (
+        f"{n_holders} partie prenante"
+        if n_holders == 1
+        else f"{n_holders} parties prenantes"
+    )
+    return f"{enjeux}, {parties}"
 
 
 def _fol_axis_status(fol: Any) -> Any:
@@ -305,6 +332,13 @@ def _provenance_counts(state: Mapping[str, Any]) -> Dict[str, Any]:
     # the conclusion leans on hardest.
     counts["deliberation"] = _safe_len(_g("debate_transcripts", []))
     counts["gouvernance"] = _safe_len(_g("governance_decisions", []))
+
+    # #1676 — the stakes & stakeholders axis is mobilised by the Acte I framing
+    # (``act1_framing_plugin`` derives the genre/arena from both containers) and
+    # has a live writer, so the coverage table attests it — by cardinality only.
+    # Privacy HARD: the stakes/stakeholders names are nominative (real labels
+    # when the working state is deanonymized) — never rendered here.
+    counts["enjeux"] = _stakes_summary(_g("stakes_and_stakeholders"))
 
     # Structured-argumentation honesty (FP-17 #1236). ASPIC+/ABA/SETAF/weighted/
     # bipolar have no text→structured translator wired (translation-gap FP-4

--- a/argumentation_analysis/reporting/restitution/state_adapter.py
+++ b/argumentation_analysis/reporting/restitution/state_adapter.py
@@ -64,8 +64,24 @@ _STATE_KEYS = (
     # field's text under the other's name would misattribute it.
     "final_conclusion",
     "formal_synthesis_reports",
+    # #1676 — decision at this site. The three keys below are carried here so
+    # the opt-in full-state dump stays their traceability; only one gets an
+    # annexe row. ``stakes_and_stakeholders`` is attested (the ``enjeux`` row,
+    # by cardinality) because the Acte I framing mobilises it and a live writer
+    # fills it (``invoke_callables._invoke_stakes_extractor``, measured
+    # populated on real runs, #1604 R751).
     "stakes_and_stakeholders",
+    # #1676 privacy decision (HARD): NO annexe row. The values are nominative
+    # (``{genre, speaker_role, channel, title, ...}`` — a title is a source name
+    # per CLAUDE.md privacy), and a count of metadata fields informs nobody.
+    # The prose reads it for the Acte I framing; its values are opacified on the
+    # export boundary (``sanitize_state._OPAQUE_DICT_VALUES``), and carrying the
+    # key here keeps the opt-in dump traceable without surfacing content.
     "source_metadata",
+    # #1676 decision: NO annexe row. Distinct case — neither the prose nor any
+    # annexe line reads it: a generic bag of phase/workflow results (and
+    # value-gate ledgers) with no informative count. Other surfaces read it
+    # (html_report durations, multi_format_exporter), the restitution does not.
     "workflow_results",
 )
 

--- a/tests/unit/argumentation_analysis/reporting/restitution/test_third_hop_projection_guard_1676.py
+++ b/tests/unit/argumentation_analysis/reporting/restitution/test_third_hop_projection_guard_1676.py
@@ -1,0 +1,291 @@
+"""#1676 — pin the third hop: what the projection carries vs what the render names.
+
+#1624 pinned the relation between the two reading surfaces (prose / annexe).
+This module pins the hop one step DOWNSTREAM: between what the *projection*
+carries (``state_adapter._STATE_KEYS`` → ``state_to_appendix_mapping``) and
+what the *render* names (the keys named by a rendered row of
+``appendix._provenance_counts``).
+
+Three keys were measured on ``main`` (``ca40f6d2``, unchanged by #1675) to
+traverse the projection without any rendered line naming them::
+
+    _STATE_KEYS  \\  {keys named by a rendered row}
+      = source_metadata, stakes_and_stakeholders, workflow_results
+
+Before this guard, a future addition to ``_STATE_KEYS`` without a
+corresponding rendered row would pass silently — the projection would carry
+it to the opt-in full-state dump, and the default render would stay mute.
+The point of this module is that such an addition *fails* instead of drifting.
+
+The guard does NOT prescribe equality. An explicit, key-by-key justified
+``_UNRENDERED`` frozenset carries the legitimate exceptions — the whole
+content of the issue is that the three cases are distinct and none is an
+oversight.
+
+Anti-pendule (from the issue body):
+
+* Do NOT add three rows "to close the gap" — a row counting metadata fields
+  informs nobody (``source_metadata``) and ``workflow_results`` is a generic
+  bag. Only ``stakes_and_stakeholders`` earns a row (the Acte I framing
+  mobilises it, a live writer fills it — #1604 R751).
+* Do NOT remove the three keys from ``_STATE_KEYS`` to make the guard
+  trivially green: the opt-in dump is their only traceability today.
+* Do NOT mutualise a constant between ``state_adapter`` and ``appendix``: the
+  file-disjoint wiring is deliberate (``state_adapter.py`` header l.6-8); the
+  accord is carried by THIS test (same shape as #1624).
+
+Falsifiability — two substitutions with disjoint kill-sets:
+
+* **Sub A** — add a bogus key ``"future_axis"`` to ``state_adapter._STATE_KEYS``
+  without a row: ``test_projection_render_relation_is_pinned`` fails (the new
+  key is neither in the rendered set nor in ``_UNRENDERED``).
+  ``test_every_unrendered_key_is_justified`` survives (it only checks the
+  current ``_UNRENDERED`` explains itself). Kill-set = {relation}.
+* **Sub B** — remove the ``enjeux`` row from ``_provenance_counts`` (revert the
+  ``stakes_and_stakeholders`` attestation): ``stakes_and_stakeholders`` rejoins
+  the unrendered set but is NOT in ``_UNRENDERED``, so
+  ``test_projection_render_relation_is_pinned`` fails.
+  ``test_stakes_axis_is_attested_by_cardinality`` also fails. Kill-set =
+  {relation, stakes-canary}.
+
+The two substitutions kill different tests, so neither assertion is vacuous.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from argumentation_analysis.reporting.restitution.appendix import (
+    _provenance_counts,
+    _stakes_summary,
+    render_appendix,
+)
+from argumentation_analysis.reporting.restitution.state_adapter import (
+    _STATE_KEYS,
+    state_to_appendix_mapping,
+)
+
+
+def _full_state() -> Dict[str, Any]:
+    """A projection where every key in ``_STATE_KEYS`` carries something.
+
+    Synthetic atoms only (privacy HARD — no corpus tokens). Shapes match the
+    writers' output so the cardinality helpers exercise their real branches.
+    """
+    return {
+        "identified_arguments": {"a1": {}},
+        "identified_fallacies": {"f1": {}},
+        "counter_arguments": [{"strategy": "distinction"}],
+        "argument_quality_scores": {"a1": 0.7},
+        "fol_analysis_results": [{"consistent": True, "message": "ok"}],
+        "propositional_analysis_results": [{"consistent": True}],
+        "modal_analysis_results": [{"consistent": True}],
+        "dung_frameworks": {"dung_1": {"name": "dung_arbitration"}},
+        "aspic_results": [{"id": "aspic_1", "extensions": [["a"]]}],
+        "belief_revision_results": [{"method": "dalal"}],
+        "bipolar_results": [{"supports": [["a", "b"]]}],
+        "debate_transcripts": [{"turns": []}],
+        "governance_decisions": [{"method": "borda"}],
+        "structured_arg_status": {
+            "aspic_plus_reasoning": {
+                "capability": "aspic_plus_reasoning",
+                "status": "evaluated",
+                "degraded": False,
+                "reason": "",
+                "extension_count": 1,
+            }
+        },
+        "narrative_synthesis": "synthèse",
+        "final_conclusion": "conclusion",
+        "formal_synthesis_reports": [{"axis": "fol"}],
+        # #1676 — the three keys the third-hop guard reasons about.
+        "stakes_and_stakeholders": {
+            "stakes": ["enjeu_A", "enjeu_B"],
+            "stakeholders": ["partie_A"],
+            "rhetorical_register": "",
+            "discursive_arena": "",
+        },
+        "source_metadata": {"genre": "politique", "speaker_role": "orateur"},
+        "workflow_results": {"total_duration_ms": 1000},
+    }
+
+
+# Keys carried by the projection (``_STATE_KEYS``) that NO rendered row of
+# ``_provenance_counts`` names. Each is a deliberate decision documented at its
+# site in ``state_adapter.py`` (#1676). The guard below asserts this set is
+# EXACTLY the projection-minus-render difference, so a future addition to
+# ``_STATE_KEYS`` without a row must either land here (with its justification)
+# or fail the relation test.
+#
+# ``stakes_and_stakeholders`` is NOT here: it earns the ``enjeux`` row (Acte I
+# framing mobilises it, live writer fills it — #1604 R751).
+#
+# ``source_metadata`` — privacy HARD. The values are nominative (a ``title`` is
+# a source name per CLAUDE.md privacy); a count of metadata fields informs
+# nobody. The prose reads it for the Acte I framing; values are opacified on
+# the export boundary (``sanitize_state._OPAQUE_DICT_VALUES``).
+#
+# ``workflow_results`` — distinct case. Neither the prose nor any annexe line
+# reads it: a generic bag of phase/workflow results with no informative count.
+# Other surfaces read it (html_report durations, multi_format_exporter); the
+# restitution does not.
+_UNRENDERED = frozenset({"source_metadata", "workflow_results"})
+
+
+def _rendered_keys() -> set[str]:
+    """State keys named by a rendered row, in projection terms.
+
+    ``_provenance_counts`` keys are dimension labels, not state keys. Each
+    rendered dimension declares its state key(s) in ``_MOBILISATION``; the
+    ``enjeux`` row added by #1676 names ``stakes_and_stakeholders``. Inverting
+    that mapping gives the set of state keys the render attests.
+    """
+    # Inline rather than importing _MOBILISATION: the projection→render
+    # relation is the claim under test, and reading the render's own declaration
+    # keeps the guard honest if _MOBILISATION drifts from _provenance_counts.
+    from argumentation_analysis.reporting.restitution.appendix import _MOBILISATION
+
+    keys: set[str] = set()
+    for _dim, (state_keys, _kind, _site) in _MOBILISATION.items():
+        keys.update(state_keys)
+    return keys
+
+
+# ---------------------------------------------------------------------------
+# DoD item 1 — the relation between projection and render is pinned
+# ---------------------------------------------------------------------------
+
+
+def test_projection_render_relation_is_pinned() -> None:
+    """Every key in ``_STATE_KEYS`` is either rendered or explicitly justified.
+
+    The difference ``_STATE_KEYS - rendered`` must equal ``_UNRENDERED``
+    exactly. A future key added to the projection without a row lands in the
+    difference; unless it is added to ``_UNRENDERED`` with its justification,
+    this assertion fails — the drift becomes a deliberate decision instead of
+    passing silently.
+    """
+    projected = set(_STATE_KEYS)
+    rendered = _rendered_keys()
+    unrendered = projected - rendered
+    assert unrendered == _UNRENDERED, (
+        "The projection carries keys the render never names, beyond the "
+        f"explicitly justified set: {unrendered - _UNRENDERED} (unexpected) "
+        f"and missing from the justified set: {_UNRENDERED - unrendered} "
+        "(a key dropped from _STATE_KEYS or newly rendered)."
+    )
+
+
+def test_every_unrendered_key_is_justified() -> None:
+    """Each key in ``_UNRENDERED`` is actually carried by the projection.
+
+    A stale entry (a key removed from ``_STATE_KEYS`` or newly rendered) would
+    make ``_UNRENDERED`` lie about the live decision. This is the mirror of the
+    relation test: it pins the justified set against reality, not just against
+    the difference.
+    """
+    projected = set(_STATE_KEYS)
+    stale = _UNRENDERED - projected
+    assert not stale, (
+        f"_UNRENDERED lists keys the projection no longer carries: {stale}. "
+        "Remove them or re-add them to _STATE_KEYS."
+    )
+
+
+# ---------------------------------------------------------------------------
+# DoD item 2 — stakes_and_stakeholders earns the row (cardinality, not content)
+# ---------------------------------------------------------------------------
+
+
+class TestStakesAxisIsAttested:
+    """``stakes_and_stakeholders`` is mobilised by the Acte I framing and has a
+    live writer, so the annexe attests it — by cardinality only (privacy)."""
+
+    def test_stakes_axis_is_attested_by_cardinality(self) -> None:
+        counts = _provenance_counts(_full_state())
+        assert "enjeux" in counts
+        # Cardinality surfaced, names never.
+        assert "2 enjeux" in counts["enjeux"]
+        assert "1 partie prenante" in counts["enjeux"]
+
+    def test_empty_stakes_is_indisponible(self) -> None:
+        # An empty stakes container reads as "indisponible", not as a fabricated
+        # count — the honest absence (#1019).
+        assert _stakes_summary(None) == "indisponible"
+        assert _stakes_summary({}) == "indisponible"
+        assert _provenance_counts({})["enjeux"] == "indisponible"
+
+    def test_singular_plural_forms(self) -> None:
+        # The cardinality helper distinguishes 1 vs many — "1 enjeu" not "1 enjeux".
+        # French pluralisation: 0 takes the plural ("0 parties prenantes").
+        assert _stakes_summary({"stakes": ["x"], "stakeholders": []}) == (
+            "1 enjeu, 0 parties prenantes"
+        )
+        assert (
+            _stakes_summary({"stakes": ["x", "y"], "stakeholders": ["a", "b"]})
+            == "2 enjeux, 2 parties prenantes"
+        )
+
+    def test_stakes_names_never_leak(self) -> None:
+        # Privacy HARD: the names are nominative and must stay in the state.
+        # A pure-NL sentinel (no entity structure) so the leak keys strip cannot
+        # mask a miss — a leak here is attributable to _stakes_summary alone.
+        state = _full_state()
+        state["stakes_and_stakeholders"] = {
+            "stakes": ["CANARY_TOKEN_STAKE"],
+            "stakeholders": ["CANARY_TOKEN_HOLDER"],
+            "rhetorical_register": "",
+            "discursive_arena": "",
+        }
+        out = render_appendix(state)
+        assert "CANARY_TOKEN_STAKE" not in out
+        assert "CANARY_TOKEN_HOLDER" not in out
+        assert "| enjeux |" in out
+
+    def test_stakes_axis_survives_the_projection(self) -> None:
+        # The #1620 trap (projection drops the key → the reader is inert in
+        # production while passing unit tests on a raw dict). The stakes key
+        # must be carried by _STATE_KEYS so the annexe reader can see it.
+        assert "stakes_and_stakeholders" in set(_STATE_KEYS)
+
+
+# ---------------------------------------------------------------------------
+# DoD item 3 — source_metadata is NOT attested (privacy HARD decision)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceMetadataPrivacyDecision:
+    """``source_metadata`` is carried by the projection (opt-in dump
+    traceability) but deliberately NOT rendered — its values are nominative
+    (a ``title`` is a source name per CLAUDE.md privacy), and a count of
+    metadata fields informs nobody."""
+
+    def test_source_metadata_not_in_rendered_rows(self) -> None:
+        counts = _provenance_counts(_full_state())
+        # No dimension label surfaces the metadata content.
+        assert "source_metadata" not in counts
+        # No dimension's VALUE echoes a nominative metadata value.
+        for value in counts.values():
+            assert (
+                "politique" not in str(value).lower()
+                or "orateur" not in str(value).lower()
+            )
+
+    def test_source_metadata_carried_by_projection(self) -> None:
+        # The key stays in _STATE_KEYS so the opt-in full-state dump keeps it
+        # traceable (anti-pendule: do not remove to make the guard trivially green).
+        assert "source_metadata" in set(_STATE_KEYS)
+        mapping = state_to_appendix_mapping(_full_state())
+        assert "source_metadata" in mapping
+
+    def test_source_metadata_values_never_leak_in_default_render(self) -> None:
+        # The default render (include_full_state_json=False) must not surface
+        # nominative metadata even when the projection carries it.
+        state = _full_state()
+        state["source_metadata"] = {
+            "title": "CANARY_TITLE_TOKEN",
+            "speaker": "CANARY_SPEAKER_TOKEN",
+        }
+        out = render_appendix(state, include_full_state_json=False)
+        assert "CANARY_TITLE_TOKEN" not in out
+        assert "CANARY_SPEAKER_TOKEN" not in out


### PR DESCRIPTION
## Object

Closes #1676. Three keys (`source_metadata`, `stakes_and_stakeholders`, `workflow_results`) were carried by `_STATE_KEYS` through the projection without any rendered row of `_provenance_counts` naming them — a third hop, downstream of the two-surface guard of #1624, that no guard watched. This PR puts a guard on that hop and takes the per-key decisions the issue asks for.

## What changed

**Production (2 files, +50 lines total, additive only):**

- `appendix.py`:
  - new `enjeux` dimension in `_MOBILISATION` mapping `stakes_and_stakeholders` (prose, acte I);
  - `_stakes_summary()` helper — renders the axis by **cardinality only** ("2 enjeux, 1 partie prenante"), never the names (privacy HARD: nominative values when the working state is deanonymized). Empty/absent container reads "indisponible" (honest absence, #1019), not a fabricated count;
  - `counts["enjeux"] = _stakes_summary(...)` row in `_provenance_counts`.
- `state_adapter.py`: per-key decision comments written **at the site** of each of the three keys (the issue asks that the decision be "écrite à son site") — no code change beyond the comments; the keys stay in `_STATE_KEYS`.

**Test (new file):** `test_third_hop_projection_guard_1676.py` — 10 tests:

| DoD item | Test | What it pins |
|---|---|---|
| 1 | `test_projection_render_relation_is_pinned` | `_STATE_KEYS − rendered == _UNRENDERED` exactly — a future key added to the projection without a row **fails** unless it lands in `_UNRENDERED` with a justification |
| 1 (mirror) | `test_every_unrendered_key_is_justified` | no stale entry in `_UNRENDERED` (a key dropped from the projection or newly rendered must leave the set) |
| 2 | `TestStakesAxisIsAttested` (5 tests) | the `enjeux` row attests the axis by cardinality; singular/plural forms; empty → "indisponible"; **names never leak** (pure-NL canary, no entity structure so the leak-keys strip cannot mask a miss); the key survives the projection (#1620 trap) |
| 3 | `TestSourceMetadataPrivacyDecision` (3 tests) | `source_metadata` is **carried** (opt-in dump traceability) but **never rendered** — canary title/speaker tokens absent from the default render |

The rendered-keys set is derived from `_MOBILISATION` read **at test time** (imported inside the helper), not from a mutualized constant — the file-disjoint wiring is deliberate (#1624 shape), and reading the render's own declaration keeps the guard honest if `_MOBILISATION` drifts.

## The three decisions (per the issue's DoD)

1. **`stakes_and_stakeholders` → annexe row** (cardinality). The axis is mobilised by the Acte I framing (`act1_framing_plugin` derives genre/arena from both containers) and has a **live writer** — `invoke_callables._invoke_stakes_extractor`, measured populated on real runs (#1604 R751). The cross-check with #1604 asked by the issue: the writer exists and fires, so a row attests a container that can be non-empty — it is not attesting an always-empty one.
2. **`source_metadata` → NO row** (privacy HARD). Values are nominative (`title` is a source name per the dataset-privacy discipline); a count of metadata fields informs nobody. The decision is written at its site in `state_adapter.py`, referencing the export-boundary opacification (`sanitize_state._OPAQUE_DICT_VALUES`). Carrying the key keeps the opt-in full-state dump traceable.
3. **`workflow_results` → NO row** (distinct case). Neither the prose nor any annexe line reads it: a generic bag of phase/workflow results with no informative count. Other surfaces read it (html_report durations, multi_format_exporter); the restitution does not. Decision written at its site.

## Anti-pendule compliance (from the issue body)

- ❌ Not "three rows to close the gap" — only `enjeux` earns one.
- ❌ Not removing the three keys from `_STATE_KEYS` to make the guard trivially green — the opt-in dump is their only traceability.
- ❌ Not mutualizing a constant between `state_adapter` and `appendix` — the accord is carried by the test.

## Falsifiability — substitution controls (executed, disjoint kill-sets)

- **Sub A** — add bogus `"future_axis"` to `_STATE_KEYS`, no row: `test_projection_render_relation_is_pinned` **fails** (1 failed, 9 passed). Kill-set = {relation}.
- **Sub B** — remove the `enjeux` attestation (both the `_MOBILISATION` entry and the `counts["enjeux"]` line): relation test **and** the stakes canaries **fail** (4 failed, 6 passed). Kill-set ⊇ {relation, stakes-canary}.

Different substitutions kill different tests → neither assertion is vacuous.

## Regression evidence

- New test file: **10 passed**.
- Restitution suite (`tests/unit/argumentation_analysis/reporting/restitution/`): **414 passed**, 0 failed.
- Out-of-suite `_provenance_counts` consumer (`tests/unit/argumentation_analysis/orchestration/test_structured_arg_honest_absent.py`): **22 passed**.
- `black --check`: 3 files clean.
- `mypy --no-incremental` (both production files): **0 new** — the single `appendix.py:61` `type-arg` error is baseline, verified identical on clean `main` (`git stash` comparison).

## Honesty note

The `enjeux` row renders `"indisponible"` on every state where `stakes_and_stakeholders` is absent — the annexe attests the axis by its cardinality, including cardinality zero; it does not claim the axis ran. The three keys' content is never rendered in the default output.

🤖 Claude Code @ myia-po-2023:2025-Epita-Intelligence-Symbolique
