### PR TITLE
docs(orchestration): hierarchical mode is ACTIVE, not DORMANT (#1735)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,8 +228,10 @@ The system supports 4 orchestration modes. See `docs/architecture/ORCHESTRATION_
 |------|--------|-------------|-------------|
 | Sequential (Pipeline) | ACTIVE | `--mode pipeline` (default) | Phases run in DAG order via WorkflowExecutor |
 | Conversational | ACTIVE | `--mode conversational` | Multi-agent dialogue via SK AgentGroupChat |
-| Hierarchical | DORMANT | — | Strategic → Tactical → Operational delegation |
+| Hierarchical | ACTIVE | `--mode hierarchical --hierarchical-mode bridge\|delegation` | `bridge` (M2, RA-10 #1069): StrategicManager → Lego WorkflowExecutor. `delegation` (M3): Strategic → Tactical → Operational, dispatching through `CapabilityRegistry` via `RegistryBackedOperationalRegistry` (BO-1 #1471, fail-loud `DelegationError` without a registry). ~10.3k LOC, `strategic_bridge.py` (RA-4 #1049) syncs NL objectives/decisions into `UnifiedAnalysisState` with privacy scrubbing. |
 | Cluedo | ACTIVE | Dedicated scripts | Sherlock-Watson investigation game |
+
+**Cross-mode comparison**: `scripts/compare_orchestration_modes.py` runs `pipeline`, `hierarchical_bridge`, `hierarchical_delegation`, `conversational` and `conversation_deterministic` on the same corpus and emits markdown + JSON with trade-off metrics (terminates / wall-time / decides / scope). This is the instrument for improving each mode against the others — see #1735.
 
 ## CI/CD
 


### PR DESCRIPTION
Corrects the orchestration modes table in `CLAUDE.md`.

The table declared `Hierarchical | DORMANT | —`. Measured firsthand, false on every column: ~10.3k LOC live, first-class CLI mode `--mode hierarchical --hierarchical-mode bridge|delegation` (RA-10 #1069), registry-backed operational dispatch with fail-loud `DelegationError` (BO-1 #1471), four real consumers, and already covered by `scripts/compare_orchestration_modes.py`.

Also documents that harness (5 modes, trade-off metrics) — it was absent from `CLAUDE.md` despite being the measuring instrument for #1735.

**Why this matters beyond documentation**: the `DORMANT` label removed the hierarchical mode from consideration for several rounds, while that mode already implemented the fix for a starvation diagnosed independently in #1732 (registry-derived roster vs hand-written capability map). A doc that declares a live module dead is more harmful than a missing doc.

Docs-only, no code touched.

Refs #1735, #1732.

🤖 Generated with [Claude Code](https://claude.com/claude-code)