### PR TITLE
fix(compare): derive depth-parity counts from rows, not prose literals

### DIFF
--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -12,6 +12,17 @@ R652+#1471-era entry-points are wired here:
 - ``conversational``        -> ``run_conversational_analysis`` (wall-time-bounded)
 - ``conversation_deterministic`` -> ``ConversationOrchestrator(mode="demo")`` (no LLM)
 
+Three counts appear in this module and they denominate different things —
+do not "reconcile" them into one (R807):
+
+- **5 engines** — the list above: the distinct orchestration implementations.
+- **8 ``MODE_RUNNERS`` keys** — the ``--modes`` dispatch surface: the 5 engines
+  plus 2 pipeline workflow presets (``pipeline_light`` / ``pipeline_full``,
+  same engine, different DAG) plus 1 deprecated alias (``hierarchical``).
+- **N ``compute_depth_parity()`` rows** — the modes that have a *measurable*
+  structural depth, one row per pipeline preset. The trade-off verdict derives
+  its counts from these rows rather than restating a literal.
+
 Usage:
     # Compare all available modes on benchmark texts
     python scripts/compare_orchestration_modes.py
@@ -606,19 +617,36 @@ def compute_depth_parity() -> List[DepthParityRow]:
     return rows
 
 
-_DEPTH_PARITY_TRADEOFF_VERDICT = (
-    "The 4 modes are comparable in interface (all produce a verdict on the "
-    "same synthetic input) but NOT in work-perimeter. They occupy three "
-    "different depth dimensions: pipeline = breadth (a wide capability "
-    "catalogue, shallow per-capability), hierarchical = delegation (few "
-    "objectives, multi-tier decomposition), conversational = dialogue-depth "
-    "(few macro-phases, deep multi-turn). This asymmetry is a DELIBERATE "
-    "design trade-off, not a defect: aligning the catalogue would mean "
-    "gutting pipeline's breadth or artificially inflating hierarchical/"
-    "conversational — both pendulum swings the project rejects (anti-#1019). "
-    "Making the trade-off explicit and firsthand-chiffred (this section) is "
-    "the honest C3 deliverable."
-)
+def _depth_parity_tradeoff_verdict(rows: List[DepthParityRow]) -> str:
+    """Render the trade-off verdict with counts DERIVED from ``rows``.
+
+    R807: the counts used to be hardcoded prose ("The 4 modes ... three
+    different depth dimensions") while ``compute_depth_parity`` had grown to
+    emit more rows — a count that stopped reading the structure it describes
+    (the #1019 family in miniature). Deriving them keeps the sentence honest
+    when a mode is added or removed; bumping the literal would rot identically.
+
+    The *dimension family* is the nature up to its first parenthesis, so
+    ``"delegation"`` / ``"delegation (3-tier depth)"`` count once, as do
+    ``"dialogue-depth"`` / ``"dialogue-depth (no LLM)"``.
+    """
+    n_modes = len(rows)
+    families = {r.nature.split(" (")[0].strip() for r in rows}
+    n_families = len(families)
+    return (
+        f"The {n_modes} modes are comparable in interface (all produce a "
+        "verdict on the same synthetic input) but NOT in work-perimeter. "
+        f"They occupy {n_families} "
+        "different depth dimensions: pipeline = breadth (a wide capability "
+        "catalogue, shallow per-capability), hierarchical = delegation (few "
+        "objectives, multi-tier decomposition), conversational = dialogue-depth "
+        "(few macro-phases, deep multi-turn). This asymmetry is a DELIBERATE "
+        "design trade-off, not a defect: aligning the catalogue would mean "
+        "gutting pipeline's breadth or artificially inflating hierarchical/"
+        "conversational — both pendulum swings the project rejects (anti-#1019). "
+        "Making the trade-off explicit and firsthand-chiffred (this section) is "
+        "the honest C3 deliverable."
+    )
 
 
 def render_depth_parity_section() -> str:
@@ -643,7 +671,7 @@ def render_depth_parity_section() -> str:
             count = "variable (LLM-derived)"
         lines.append(f"| {r.mode} | {r.depth_dimension} | {count} | {r.nature} |")
     lines.append("")
-    lines.append(_DEPTH_PARITY_TRADEOFF_VERDICT)
+    lines.append(_depth_parity_tradeoff_verdict(rows))
     lines.append("")
     return "\n".join(lines)
 

--- a/tests/unit/argumentation_analysis/orchestration/test_depth_parity_1500.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_depth_parity_1500.py
@@ -1,7 +1,7 @@
 # tests/unit/argumentation_analysis/orchestration/test_depth_parity_1500.py
 """Track C3 of #1500 — depth-parity trade-off (documented, firsthand-chiffred).
 
-The 4 orchestration modes are comparable in interface (all produce a
+The orchestration modes are comparable in interface (all produce a
 verdict on the same synthetic input) but NOT in work-perimeter. R653
 surfaced the asymmetry firsthand: pipeline = breadth (workflow DAG phase
 count), hierarchical = delegation (4 default objectives / 3-tier),
@@ -109,6 +109,68 @@ class TestRenderDepthParitySection:
         section = harness.render_depth_parity_section()
         assert "DELIBERATE design trade-off" in section
         assert "anti-#1019" in section
+
+    def test_verdict_counts_are_derived_not_hardcoded(self) -> None:
+        """R807: the verdict's counts must READ ``rows``, not restate a literal.
+
+        The prose used to say "The 4 modes ... three different depth
+        dimensions" while ``compute_depth_parity`` emitted more rows — a count
+        that stopped reading the structure it describes. Feeding synthetic rows
+        is the degenerate substitution: any re-hardcoded literal fails here.
+        """
+        rows = [
+            harness.DepthParityRow(
+                mode="fake_a",
+                depth_dimension="d",
+                depth_count=1,
+                nature="breadth",
+                verdict_dimension="v",
+            ),
+            harness.DepthParityRow(
+                mode="fake_b",
+                depth_dimension="d",
+                depth_count=1,
+                nature="dialogue-depth (no LLM)",
+                verdict_dimension="v",
+            ),
+        ]
+        verdict = harness._depth_parity_tradeoff_verdict(rows)
+        assert "The 2 modes" in verdict
+        assert "occupy 2 " in verdict
+
+    def test_verdict_dimension_families_collapse_parenthetical_variants(
+        self,
+    ) -> None:
+        """``delegation`` and ``delegation (3-tier depth)`` are ONE family.
+
+        Counting raw ``nature`` strings would inflate the dimension count and
+        re-introduce the drift from the other end.
+        """
+        rows = [
+            harness.DepthParityRow(
+                mode="fake_a",
+                depth_dimension="d",
+                depth_count=1,
+                nature="delegation",
+                verdict_dimension="v",
+            ),
+            harness.DepthParityRow(
+                mode="fake_b",
+                depth_dimension="d",
+                depth_count=1,
+                nature="delegation (3-tier depth)",
+                verdict_dimension="v",
+            ),
+        ]
+        verdict = harness._depth_parity_tradeoff_verdict(rows)
+        assert "The 2 modes" in verdict
+        assert "occupy 1 " in verdict
+
+    def test_rendered_section_count_matches_row_count(self) -> None:
+        """End-to-end: the rendered prose agrees with the emitted table."""
+        n_rows = len(harness.compute_depth_parity())
+        section = harness.render_depth_parity_section()
+        assert f"The {n_rows} modes are comparable" in section
 
     def test_section_contains_firsthand_chiffres(self) -> None:
         section = harness.render_depth_parity_section()


### PR DESCRIPTION
## Contexte

Relevé pendant la baseline T4 de #1735. Le harnais de comparaison expose **8** clés `MODE_RUNNERS`, son docstring annonce **5** modes, et sa table depth-parity en annonçait **4**. J'avais noté ça comme un « écart d'inventaire à réconcilier ».

Après lecture : **il n'y a pas d'écart à réconcilier — ce sont trois dénominateurs différents, dont deux sont corrects.**

| Compte | Où | Ce qu'il dénombre | État |
|---|---|---|---|
| 5 | docstring du module | moteurs d'orchestration distincts | ✅ correct |
| 8 | clés `MODE_RUNNERS` | surface de dispatch `--modes` : 5 moteurs + 2 presets pipeline (`light`/`full`) + 1 alias déprécié | ✅ correct |
| 4 | `_DEPTH_PARITY_TRADEOFF_VERDICT` | prose figée | ❌ **périmé** — `compute_depth_parity()` émet plus de lignes |

## Le défaut

Un compte en prose qui a cessé de lire la structure qu'il décrit — la famille #1019 en miniature. La clause à laquelle il est accolé (« trois dimensions de profondeur différentes ») reste vraie ; seul le nombre de modes avait pourri.

**Anti-pendule** : remonter le littéral de 4 à 7 pourrit exactement pareil dans trois mois. Les deux comptes sont donc **dérivés** :
- nombre de modes = `len(rows)` ;
- nombre de dimensions = familles de `nature`, coupées à la première parenthèse, pour que `delegation` et `delegation (3-tier depth)` comptent **une** fois (compter les chaînes brutes réintroduirait la dérive par l'autre bout).

## Tests

3 tests ajoutés, chacun nourri de **lignes synthétiques** — un littéral re-codé en dur échoue immédiatement :

- `test_verdict_counts_are_derived_not_hardcoded` — 2 lignes ⇒ « The 2 modes »
- `test_verdict_dimension_families_collapse_parenthetical_variants` — `delegation` + `delegation (3-tier depth)` ⇒ 1 famille
- `test_rendered_section_count_matches_row_count` — bout en bout : la prose s'accorde à la table

**Contrôle (substitution dégénérée)** : en re-figeant le littéral `"The 4 modes ... 3"`, **les 3 tests rougissent** — vérifié. Le troisième rougit aussi, ce qui confirme au passage que le compte réel n'a jamais été 4.

`82 passed` sur `test_depth_parity_1500.py` + `test_compare_orchestration_modes_1480.py`. `black` et `flake8` propres.

## Aussi

Le docstring du module documente désormais **pourquoi** trois comptes coexistent légitimement, pour que le prochain lecteur ne les « réconcilie » pas en un seul nombre faux.

Aucun changement de comportement de mesure : la section depth-parity reste déterministe, sans LLM ni JVM.

Réf #1735 (T4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)