### PR TITLE
feat(hierarchical): motivated tactical designation — who AND why per allocation (#1735 T3)

### DIFF
--- a/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
+++ b/argumentation_analysis/orchestration/hierarchical/delegation_orchestrator.py
@@ -445,6 +445,39 @@ class DelegationOrchestrator:
             "M3 tactical tier decomposed into %d task(s).", len(pending_tasks)
         )
 
+        # --- #1735 T3: la désignation motivée remonte à la trace ------------
+        # ``TaskCoordinator.assign_task_to_operational`` a écrit, pour chaque
+        # tâche, qui (``task_assignments``) et pourquoi
+        # (``task_assignments_motivation``) dans l'état tactique. On expose la
+        # paire ici pour que la trace du run la porte. Le scrub réutilise le
+        # mécanisme de ``strategic_bridge`` (dispatch #1735 : « réutilise-la,
+        # ne recâble pas ») — la motivation est du texte libre et PEUT contenir
+        # un nom de source : elle passe par le même strip par clé nominative
+        # que les objectifs stratégiques déjà syncés.
+        from argumentation_analysis.core.strategic_bridge import _scrub_dict
+
+        task_assignments = []
+        for task in pending_tasks:
+            # L'id est garanti : la décomposition tactique le construit toujours
+            # (``base_task_id + n``, coordinator._decompose_objective_to_tasks).
+            task_id = task["id"]
+            task_assignments.append(
+                _scrub_dict(
+                    {
+                        "task_id": task_id,
+                        "description": task.get("description", ""),
+                        "agent_id": self.tactical_coordinator.state.task_assignments.get(
+                            task_id
+                        ),
+                        "motivation": (
+                            self.tactical_coordinator.state.task_assignments_motivation.get(
+                                task_id, ""
+                            )
+                        ),
+                    }
+                )
+            )
+
         # --- T→O: translate + execute each task ----------------------------
         operational_results: List[Dict[str, Any]] = []
         for task in pending_tasks:
@@ -532,6 +565,11 @@ class DelegationOrchestrator:
             "mode": "delegation",
             "objectives": objectives,
             "tasks_created": decomposition.get("tasks_created", len(pending_tasks)),
+            # #1735 T3: la désignation motivée (qui + pourquoi), scrubée.
+            # Lue par la trace CLI (run_orchestration.py) et par les
+            # consommateurs du résultat — pas par le harnais de comparaison
+            # (il reste sur terminates/wall-time/decides/scope, #1735 T4).
+            "task_assignments": task_assignments,
             "operational_results": operational_results,
             "evaluation": final.get("evaluation"),
             "conclusion": conclusion,

--- a/argumentation_analysis/orchestration/hierarchical/tactical/coordinator.py
+++ b/argumentation_analysis/orchestration/hierarchical/tactical/coordinator.py
@@ -145,7 +145,11 @@ class TaskCoordinator:
         Assigne une tâche à l'agent opérationnel le plus compétent.
 
         Utilise le registre `agent_capabilities` pour trouver le meilleur agent.
-        Envoie ensuite une directive d'assignation via le middleware.
+        Envoie ensuite une directive d'assignation via le middleware. Depuis
+        #1735 T3, chaque allocation est aussi enregistrée dans l'état tactique
+        — qui (``task_assignments``) **et pourquoi**
+        (``task_assignments_motivation``) — pour que le forensic de trace du
+        mode conversationnel s'applique au palier tactique hiérarchique.
 
         Args:
             task: La tâche à assigner.
@@ -153,9 +157,11 @@ class TaskCoordinator:
         required_capabilities = task.get("required_capabilities", [])
         recipient_id = self._determine_appropriate_agent(required_capabilities)
         message_priority = self._map_priority_to_enum(task.get("priority", "medium"))
+        motivation = self._motivate_allocation(task, recipient_id)
 
         self.logger.info(
-            f"Assignation de la tâche {task.get('id')} à l'agent {recipient_id}."
+            f"Assignation de la tâche {task.get('id')} à l'agent {recipient_id} "
+            f"— {motivation[:80]}"
         )
         self.adapter.assign_task(
             task_type="operational_task",
@@ -163,6 +169,36 @@ class TaskCoordinator:
             recipient_id=recipient_id,
             priority=message_priority,
             requires_ack=True,
+        )
+        # #1735 T3: la désignation (qui + pourquoi) est écrite dans l'état
+        # tactique. ``assign_task`` réanime le champ existant — le palier
+        # enregistre désormais l'allocation réelle, pas seulement la directive
+        # middleware. La motivation n'est tracée que si la tâche a bien été
+        # assignée (cohérence : pas de motivation orpheline).
+        if self.state.assign_task(task["id"], recipient_id):
+            self.state.record_allocation_motivation(task["id"], motivation)
+
+    def _motivate_allocation(self, task: Dict[str, Any], recipient_id: str) -> str:
+        """Construit le *pourquoi* de l'allocation de ``task`` à ``recipient_id``.
+
+        #1735 T3. Le palier tactique est déterministe : sa « motivation » est
+        la règle de décision elle-même — la couverture de capacités qui a fait
+        gagner cet agent au scoring — pas une narration. Anti-pendule #1732 :
+        on refuse le template vide « tâche X → agent Y » (zéro information) ;
+        le texte documente le score réellement appliqué.
+        """
+        required = task.get("required_capabilities", [])
+        agent_caps = self.agent_capabilities.get(recipient_id, [])
+        covered = [cap for cap in required if cap in agent_caps]
+        if not required:
+            return (
+                f"Aucune capacité requise (tâche générique) — "
+                f"{recipient_id} retenu par le fallback de décomposition"
+            )
+        return (
+            f"{recipient_id} couvre {len(covered)}/{len(required)} "
+            f"capacité(s) requise(s) de « {task.get('description', '')} » : "
+            f"{', '.join(covered) if covered else 'aucune'}"
         )
 
     def handle_task_result(self, result: Dict[str, Any]) -> Dict[str, Any]:
@@ -278,9 +314,8 @@ class TaskCoordinator:
             handle_directive
         )
 
-    def _determine_appropriate_agent(
-        self, required_capabilities: List[str]
-    ) -> Optional[str]:
+    def _determine_appropriate_agent(self, required_capabilities: List[str]) -> str:
+        # Toujours une chaîne : le fallback couvre cap inconnue ET vide.
         agent_scores = {}
         for cap in required_capabilities:
             for agent, agent_caps in self.agent_capabilities.items():

--- a/argumentation_analysis/orchestration/hierarchical/tactical/state.py
+++ b/argumentation_analysis/orchestration/hierarchical/tactical/state.py
@@ -41,15 +41,22 @@ class TacticalState:
         # Assignations des tâches
         self.task_assignments: Dict[str, str] = {}  # task_id -> agent_id
 
+        # #1735 T3: le *pourquoi* de chaque assignation, miroir du CONV-C
+        # ``record_designation`` (shared_state.py). Une allocation sans motivation
+        # est le défaut exact que ce champ existe pour interdire : toujours écrit
+        # par paires avec ``task_assignments`` (voir
+        # ``TaskCoordinator.assign_task_to_operational``).
+        self.task_assignments_motivation: Dict[str, str] = {}  # task_id -> motivation
+
         # Dépendances entre tâches
-        self.task_dependencies: Dict[str, List[str]] = (
-            {}
-        )  # task_id -> [dependent_task_ids]
+        self.task_dependencies: Dict[
+            str, List[str]
+        ] = {}  # task_id -> [dependent_task_ids]
 
         # Progression des tâches
-        self.task_progress: Dict[str, float] = (
-            {}
-        )  # task_id -> completion_rate (0.0 to 1.0)
+        self.task_progress: Dict[
+            str, float
+        ] = {}  # task_id -> completion_rate (0.0 to 1.0)
 
         # Résultats intermédiaires
         self.intermediate_results: Dict[str, Any] = {}
@@ -168,6 +175,38 @@ class TacticalState:
             return False
 
         self.task_assignments[task_id] = agent_id
+        return True
+
+    def record_allocation_motivation(self, task_id: str, motivation: str) -> bool:
+        """
+        Enregistre le *pourquoi* d'une assignation de tâche (#1735 T3).
+
+        Miroir du ``record_designation`` conversationnel (CONV-C #1334) : le
+        palier tactique hiérarchique enregistre désormais, pour chaque
+        allocation, la raison de la décision — pas seulement l'agent choisi.
+        Le contenu est du texte libre (la motivation d'un palier déterministe
+        documente la règle de décision appliquée) ; une motivation vide est
+        refusée : c'est précisément le défaut (allocation sans pourquoi) que
+        ce point d'écriture existe pour interdire.
+
+        Args:
+            task_id: Identifiant de la tâche assignée.
+            motivation: La motivation de l'allocation (non vide, stripée).
+
+        Returns:
+            True si l'enregistrement a réussi.
+
+        Raises:
+            ValueError: si ``motivation`` est vide (ou blanche) après strip.
+        """
+        motivation = motivation.strip()
+        if not motivation:
+            raise ValueError(
+                f"L'allocation de la tâche {task_id} exige une motivation non "
+                f"vide (#1735 T3) — une assignation sans pourquoi est le défaut "
+                f"que record_allocation_motivation existe pour interdire."
+            )
+        self.task_assignments_motivation[task_id] = motivation
         return True
 
     def add_task_dependency(self, task_id: str, dependent_task_id: str) -> bool:
@@ -489,6 +528,7 @@ class TacticalState:
             "assigned_objectives": self.assigned_objectives,
             "tasks": self.tasks,
             "task_assignments": self.task_assignments,
+            "task_assignments_motivation": self.task_assignments_motivation,
             "task_dependencies": self.task_dependencies,
             "task_progress": self.task_progress,
             "intermediate_results": {
@@ -531,6 +571,11 @@ class TacticalState:
 
         if "task_assignments" in state_dict:
             state.task_assignments = state_dict["task_assignments"]
+
+        if "task_assignments_motivation" in state_dict:
+            state.task_assignments_motivation = state_dict[
+                "task_assignments_motivation"
+            ]
 
         if "task_dependencies" in state_dict:
             state.task_dependencies = state_dict["task_dependencies"]

--- a/argumentation_analysis/run_orchestration.py
+++ b/argumentation_analysis/run_orchestration.py
@@ -767,6 +767,17 @@ Exemples:
                 )
             print(f"  Tâches créées      : {results.get('tasks_created', 0)}")
             print(f"  Tâches complétées  : {completed}/{len(op_results)}")
+            # #1735 T3: la désignation motivée du palier tactique (qui +
+            # pourquoi), portée par le résultat du run. La motivation est du
+            # texte libre construit par le coordinator (règle de décision).
+            assignments = results.get("task_assignments", [])
+            if assignments:
+                print(f"  Assignations ({len(assignments)}):")
+                for a in assignments:
+                    print(
+                        f"    - {a.get('task_id')} → {a.get('agent_id')} — "
+                        f"{a.get('motivation', '')}"
+                    )
         else:
             summary = results.get("summary", {})
             print(f" Mode hiérarchique (M2 bridge) — {summary.get('total', 0)} phases")

--- a/tests/unit/argumentation_analysis/orchestration/hierarchical/test_delegation_motivated_designation_1735.py
+++ b/tests/unit/argumentation_analysis/orchestration/hierarchical/test_delegation_motivated_designation_1735.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+"""
+#1735 T3 — désignation motivée au palier tactique hiérarchique.
+
+Le palier tactique (``TaskCoordinator``) enregistre désormais POURQUOI il
+alloue chaque tâche — miroir du ``record_designation`` conversationnel
+(CONV-C #1334) — et la trace du run (``DelegationOrchestrator.analyze``)
+l'expose, scrubée par le mécanisme de ``strategic_bridge``.
+
+DoD couvert :
+- chaque allocation porte une motivation non vide, vérifiable en trace ;
+- un test échoue si une allocation est enregistrée SANS motivation
+  (``record_allocation_motivation`` refuse le blanc ; l'invariant de run
+  vérifie l'alignement assignation↔motivation) ;
+- le scrub privacy de ``strategic_bridge`` s'applique au nouveau contenu ;
+- la trace CLI (run_orchestration.py) lit ``result["task_assignments"]``.
+
+Contrôles de substitution (kill-sets disjoints, exécutés en session) :
+- Sub A (retirer l'enregistrement dans ``assign_task_to_operational``) →
+  invariant de run rouge seul.
+- Sub B (vider ``record_allocation_motivation`` de son ValueError) → le
+  test de refus de blanc rouge seul.
+"""
+
+import json
+
+import pytest
+
+from argumentation_analysis.orchestration.hierarchical.delegation_orchestrator import (
+    DelegationOrchestrator,
+)
+from argumentation_analysis.orchestration.hierarchical.tactical.state import (
+    TacticalState,
+)
+
+
+class _FakeStrategicManager:
+    """Strategic tier fake — deterministic objectives, no LLM."""
+
+    def __init__(self, objectives):
+        self._objectives = objectives
+
+    def initialize_analysis(self, text):
+        return {"objectives": list(self._objectives), "strategic_plan": {}}
+
+    def evaluate_final_results(self, eval_input):
+        return {
+            "conclusion": "Conclusion de test.",
+            "evaluation": {"objectives_evaluation": eval_input},
+        }
+
+
+async def _completed_executor(command):
+    """Operational executor fake — every task completes."""
+    caps = command.get("required_capabilities") or ["generic"]
+    return {
+        "task_id": command.get("tactical_task_id"),
+        "objective_id": command.get("objective_id"),
+        "status": "completed",
+        "capability": caps[0],
+        "outputs": {"echo": "ok"},
+    }
+
+
+def _objectives():
+    """Two objectives hitting the two keyword decomposition branches:
+    "identifier"+arguments → 2 tasks, "détecter"+sophisme → 1 task."""
+    return [
+        {
+            "id": "obj-identify",
+            "description": "Identifier les arguments dans le texte",
+            "priority": "high",
+        },
+        {
+            "id": "obj-fallacy",
+            "description": "Détecter les sophismes dans le texte",
+            "priority": "medium",
+        },
+    ]
+
+
+async def _run(objectives=None, executor=None):
+    orch = DelegationOrchestrator(
+        strategic_manager=_FakeStrategicManager(objectives or _objectives()),
+        operational_executor=executor or _completed_executor,
+    )
+    result = await orch.analyze("Texte de test court, sans source nominative.")
+    return orch, result
+
+
+async def test_every_allocation_carries_non_empty_motivation():
+    """DoD 1 : chaque allocation porte une motivation non vide, en trace."""
+    orch, result = await _run()
+    assignments = result.get("task_assignments", [])
+    assert len(assignments) == 3, (
+        f"expected 3 decomposed tasks (2 identifier-branch + 1 fallacy-branch), "
+        f"got {len(assignments)}"
+    )
+    for a in assignments:
+        assert a["task_id"], f"assignment missing task_id: {a}"
+        assert a["agent_id"], f"assignment {a['task_id']} missing agent_id"
+        motivation = a.get("motivation", "")
+        assert motivation.strip(), (
+            f"allocation {a['task_id']} recorded WITHOUT a motivation (#1735 T3): "
+            f"an allocation without a why is the defect the motivated designation "
+            f"exists to forbid"
+        )
+
+
+async def test_state_assignments_and_motivations_are_aligned():
+    """Invariant : tout task_id assigné a une motivation, et réciproquement."""
+    orch, _ = await _run()
+    state = orch.tactical_coordinator.state
+    assert set(state.task_assignments) == set(state.task_assignments_motivation), (
+        f"assignations {sorted(state.task_assignments)} != motivations "
+        f"{sorted(state.task_assignments_motivation)} — désalignement "
+        f"qui/ pourquoi"
+    )
+    assert len(state.task_assignments) == 3
+    for task_id, motivation in state.task_assignments_motivation.items():
+        assert (
+            motivation.strip()
+        ), f"task {task_id} assigned with a blank motivation in the state"
+
+
+def test_blank_motivation_is_refused():
+    """DoD 2 : une allocation enregistrée SANS motivation est refusée.
+
+    Version directe du canari : ``record_allocation_motivation`` lève
+    ValueError sur blanc — le point d'écriture rend le défaut impossible,
+    pas seulement détectable.
+    """
+    state = TacticalState()
+    with pytest.raises(ValueError, match="non vide"):
+        state.record_allocation_motivation("task-1", "   ")
+    # Une motivation réelle passe.
+    assert state.record_allocation_motivation("task-1", "  raison réelle  ") is True
+    assert state.task_assignments_motivation["task-1"] == "raison réelle"
+
+
+async def test_motivation_documents_the_score_not_the_forbidden_template():
+    """Anti-pendule #1732 : la motivation n'est PAS « tâche X → agent Y ».
+
+    Elle documente la règle de décision réellement appliquée : la couverture
+    de capacités qui a fait gagner l'agent au scoring.
+    """
+    _, result = await _run()
+    assignments = result["task_assignments"]
+    premise_task = next(
+        a
+        for a in assignments
+        if a["description"] == "Identifier prémisses et conclusions"
+    )
+    assert premise_task["agent_id"] == "informal_analyzer"
+    motivation = premise_task["motivation"]
+    forbidden_template = (
+        f"allocation de la tâche {premise_task['task_id']} à l'agent "
+        f"{premise_task['agent_id']}"
+    )
+    assert motivation != forbidden_template
+    assert "informal_analyzer" in motivation
+    assert "1/1" in motivation, f"motivation lacks the score: {motivation!r}"
+    assert (
+        "argument_identification" in motivation
+    ), f"motivation lacks the covered capability: {motivation!r}"
+
+
+async def test_motivation_for_generic_task_documents_fallback():
+    """Une tâche sans capacité requise est quand même motivée — par le fallback."""
+    generic = [
+        {
+            "id": "obj-g",
+            "description": "Analyser la structure logique",
+            "priority": "low",
+        }
+    ]
+    _, result = await _run(objectives=generic)
+    assignments = result["task_assignments"]
+    assert len(assignments) == 1
+    a = assignments[0]
+    assert a["agent_id"] == "default_operational_agent"
+    assert a["motivation"].strip()
+    assert (
+        "fallback" in a["motivation"]
+    ), f"fallback not documented: {a['motivation']!r}"
+
+
+async def test_privacy_scrub_applies_to_motivated_assignments():
+    """DoD 3 : le scrub de strategic_bridge s'applique au nouveau contenu.
+
+    Un objectif portant des champs nominatifs (``author``/``source_name``)
+    ne laisse aucune clé nominative ni aucune valeur canary dans les
+    assignations motivées — la motivation est construite des libellés
+    génériques + scoring, jamais des champs nominatifs de l'objectif, et le
+    dict passe par ``strategic_bridge._scrub_dict`` avant de sortir.
+    """
+    objectives = [
+        {
+            "id": "obj-p",
+            "description": "Identifier les arguments dans le texte",
+            "priority": "high",
+            "author": "Nom_Reel_Source_1735",
+            "source_name": "Titre_Reel_Source_1735",
+        }
+    ]
+    _, result = await _run(objectives=objectives)
+    serialized = json.dumps(result["task_assignments"], ensure_ascii=False)
+    assert "Nom_Reel_Source_1735" not in serialized
+    assert "Titre_Reel_Source_1735" not in serialized
+    assert '"author"' not in serialized
+    assert '"source_name"' not in serialized
+
+
+async def test_trace_exposes_motivated_assignments():
+    """DoD 4 (tracé) : la trace du run porte les assignations motivées.
+
+    C'est la clé lue par la trace CLI delegation
+    (``run_orchestration.py`` — "Assignations (N):").
+    """
+    _, result = await _run()
+    assert "task_assignments" in result
+    assignments = result["task_assignments"]
+    assert isinstance(assignments, list) and assignments
+    for a in assignments:
+        assert {"task_id", "description", "agent_id", "motivation"} <= set(a)


### PR DESCRIPTION
## Summary

**#1735 T3 — Désignation motivée au palier tactique hiérarchique.** Le palier tactique enregistre désormais POURQUOI il alloue chaque tâche, miroir du `record_designation` conversationnel (CONV-C #1334), et la trace du run (`DelegationOrchestrator.analyze`) l'expose, scrubée par le mécanisme de `strategic_bridge`.

- **`TacticalState`** : réanime le champ mort `task_assignments` (qui) et ajoute `task_assignments_motivation` (pourquoi), écrits par paires dans `TaskCoordinator.assign_task_to_operational`. `record_allocation_motivation` refuse une motivation vide **au point d'écriture** — une allocation sans pourquoi est le défaut exact que ce champ existe pour interdire.
- **Motivation** : le palier tactique est déterministe, donc sa motivation est **la règle de décision réellement appliquée** — la couverture de capacités qui a fait gagner l'agent au scoring (`informal_analyzer couvre 1/1 capacité(s) requise(s) de « … » : argument_identification`). Pas de narration LLM (le palier n'en produit pas) et **pas** le template interdit « tâche X → agent Y » (anti-pendule #1732 : zéro information).
- **Scrub privacy** : `DelegationOrchestrator.analyze` réutilise `strategic_bridge._scrub_dict` (dispatch : « réutilise-la, ne recâble pas ») — la motivation est du texte libre et **peut** contenir un nom de source ; elle passe par le même strip par clé nominative (`author`/`source_name`/`raw_text`/`full_text`) que les objectifs déjà syncés.
- **Trace** : `result["task_assignments"]` porté par le résultat du run, lu par la trace CLI delegation de `run_orchestration.py` (« Assignations (N): »).
- **Nettoyage de type** : `_determine_appropriate_agent` `Optional[str]` → `str` — elle ne retourne jamais None (le fallback couvre cap inconnue **et** vide) ; l'`Optional` était un mensonge de type.

## Test plan

7 tests dans `tests/unit/argumentation_analysis/orchestration/hierarchical/test_delegation_motivated_designation_1735.py` (fakes, pas de LLM) :

- invariant de run : chaque allocation porte une motivation non vide, en trace ;
- alignement d'état : `task_assignments` ↔ `task_assignments_motivation` (mêmes clés) ;
- refus de blanc : `record_allocation_motivation("t", "  ")` → `ValueError` ;
- score pas template : la motivation documente le score/capacité, jamais « tâche X → agent Y » ;
- fallback documenté : tâche sans capacité requise → motivation non vide (fallback) ;
- scrub privacy : objectif avec `author`/`source_name` canary → aucune clé ni valeur canary dans `task_assignments` sérialisé ;
- trace : `result["task_assignments"]` présent, 4 clés minimum par entrée.

**Contrôles de substitution** (kill-sets disjoints, exécutés en session) :
- Sub A — retirer l'enregistrement dans `assign_task_to_operational` → 4 tests rouges (invariant + alignement + score + fallback), 3 verts (structure/refus) ;
- Sub B — retirer le `ValueError` de `record_allocation_motivation` → `test_blank_motivation_is_refused` rouge **seul**.

**Validation** :
- suite hiérarchique complète (unit + integration) : **291 passed** (284 baseline + 7 nouveaux), 0 régression ;
- `python -m black` : 5 fichiers, propre ;
- `mypy` (config projet) : 0 erreur nouvelle (7 pré-existantes sur des lignes non touchées — `state.py:21/674`, `coordinator.py:76/242/321/330/382`).

## Honnêteté (limites documentées)

1. Le palier tactique est déterministe : sa « motivation » est la règle de décision, pas une narration. C'est le contenu honnête que ce palier peut produire.
2. `_scrub_dict` strip les clés nominatives, pas les noms enfouis dans du texte libre (ex. une description d'objectif portant un nom propre passerait dans la description de tâche de la branche fallback). C'est le niveau de garantie pré-existant de `strategic_bridge`, pas étendu par #1735.
3. `record_allocation_motivation` est écrit par paires avec `assign_task` : pas de motivation orpheline (cohérence).

Refs #1735 T3, #1732, #1334. Lane T4 = PR #1738 (harnais), indépendante.

🤖 Claude Code @ myia-po-2023:2025-Epita-Intelligence-Symbolique
