### PR TITLE
fix(compare): a count whose producer never ran renders n/a, not 0 (#1740)

### DIFF
--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -412,6 +412,62 @@ def _fmt_count(count: Optional[int]) -> str:
     return "—" if count is None else str(count)
 
 
+# #1740: which capability PRODUCES each count. A count only means something if
+# its producer actually ran — see ``_fmt_count_in_perimeter``.
+#
+# Pinned against ``CAPABILITY_STATE_WRITERS`` by the #1740 tests so these sets
+# cannot drift silently when a workflow gains a capability. ⚠ Stated limit: the
+# pin keys on the ``*fallacy*`` naming convention, so a fallacy capability
+# introduced under an unconventional name would escape it. That hole is far
+# narrower than the one being closed (a fabricated 0 on every single run), and
+# it is written down rather than hidden.
+_FALLACY_PRODUCING_CAPABILITIES: FrozenSet[str] = frozenset(
+    {"neural_fallacy_detection", "hierarchical_fallacy_detection"}
+)
+_ARGUMENT_PRODUCING_CAPABILITIES: FrozenSet[str] = frozenset({"fact_extraction"})
+
+
+def _fmt_count_in_perimeter(
+    count: Optional[int],
+    producers: FrozenSet[str],
+    capabilities_used: List[str],
+) -> str:
+    """Render a count as ``n/a`` when its PRODUCER never ran (#1740).
+
+    Three states, never two:
+
+    * ``n/a``   — the producing capability is demonstrably outside the executed
+      perimeter: never evaluated;
+    * ``—``     — inside the perimeter (or perimeter unknown) but not written;
+    * ``<int>`` — written.
+
+    **Why this cannot be decided one hop earlier.** ``get_state_snapshot``
+    derives every count as ``len()`` over a PRE-DECLARED container
+    (``shared_state.py``: ``"fallacy_count": len(self.identified_fallacies)``),
+    so the key is *never* absent and the "absent → None → —" convention of
+    Track CG #1540 is structurally inert on this field. Three correct fixes at
+    the reader hop (#1528 item 3, #1540, #1560) left the symptom untouched for
+    exactly that reason — repeated fixes at one hop mean the defect is at
+    another. The discriminator therefore has to come from the executed
+    perimeter, not from key presence.
+
+    ``capabilities_used`` is built from ``PhaseStatus.COMPLETED`` with degraded
+    capabilities removed (``unified_pipeline.py``) — it is the EXECUTED set,
+    not the declared one. So a phase cut off by the wall-clock budget reads
+    ``n/a`` rather than ``0``, which matters: the #1735 baseline truncated 20
+    of 24 runs.
+
+    ⚠ An EMPTY ``capabilities_used`` means the mode reports **no perimeter at
+    all** (``conversation_deterministic``), NOT an empty perimeter. Absence
+    cannot be demonstrated there, so the count renders as-is — emitting ``n/a``
+    would erase a genuine observation, which is the mirror-image of the defect
+    being fixed.
+    """
+    if capabilities_used and not (set(capabilities_used) & producers):
+        return "n/a"
+    return _fmt_count(count)
+
+
 def _compute_decides(result: ModeResult) -> bool:
     """The ONE uniform definition of whether a mode *decided* (Track CA #1529).
 
@@ -1036,7 +1092,11 @@ async def run_conversation_deterministic_mode(
         terminates=True,
         duration_seconds=round(duration, 3),
         state_fill_rate=None,
-        fallacy_count=conv_state.get("state", {}).get("fallacies_detected", 0),
+        # #1740: absent key → None → "—", never a fabricated 0. This site kept
+        # a literal ``0`` default long after the same defect was fixed for the
+        # two other runners (#1528 item 3 / #1560) — currently populated, so it
+        # was invisible; it would have manufactured a 0 the day the key moved.
+        fallacy_count=conv_state.get("state", {}).get("fallacies_detected"),
         phases_completed=3,  # informal + fol + synthesis
         phases_total=3,
         # Track CA #1529: `decides` computed uniformly (phases_completed=3 → True).
@@ -1458,6 +1518,20 @@ MODE_RUNNERS: Dict[str, Callable[..., Awaitable[ModeResult]]] = {
     "hierarchical": run_hierarchical_mode,
 }
 
+# #1740: aliases stay DISPATCHABLE (``--modes hierarchical`` keeps working for
+# whoever scripted it) but are excluded from the DEFAULT sweep. Running them by
+# default emitted rows the runner self-labels ``hierarchical_bridge`` — strictly
+# indistinguishable from the real bridge rows, so the #1735 baseline carried the
+# bridge SIX times for three corpora, announced "Modes tested: 7", and anyone
+# aggregating that table counted the bridge twice.
+_DEPRECATED_MODE_ALIASES: FrozenSet[str] = frozenset({"hierarchical"})
+
+
+def default_modes() -> List[str]:
+    """The default sweep: every runner except deprecated aliases (#1740)."""
+    return [m for m in MODE_RUNNERS if m not in _DEPRECATED_MODE_ALIASES]
+
+
 # Mode -> human-readable scope-of-work description, for the report table.
 # Modes NOT in this map use the value already stored in ``ModeResult.scope_of_work``.
 MODE_SCOPE_DESCRIPTIONS = {
@@ -1595,6 +1669,12 @@ def generate_report(
     lines.append("## Detailed Summary (legacy format)")
     lines.append("")
     lines.append(
+        "Counts (#1740): `n/a` = the producing capability was **not in the "
+        "executed perimeter** (never evaluated — not a zero); `—` = in the "
+        "perimeter but not written; a number = written."
+    )
+    lines.append("")
+    lines.append(
         "| Mode | Corpus | Success | Duration | State Fill | Fallacies | Args | Phases |"
     )
     lines.append(
@@ -1607,7 +1687,8 @@ def generate_report(
         lines.append(
             f"| {r.mode} | {r.corpus_id} | {status}{err} | "
             f"{r.duration_seconds:.2f}s | {_fmt_fill(r.state_fill_rate)} | "
-            f"{_fmt_count(r.fallacy_count)} | {_fmt_count(r.argument_count)} | "
+            f"{_fmt_count_in_perimeter(r.fallacy_count, _FALLACY_PRODUCING_CAPABILITIES, r.capabilities_used)} | "
+            f"{_fmt_count_in_perimeter(r.argument_count, _ARGUMENT_PRODUCING_CAPABILITIES, r.capabilities_used)} | "
             f"{r.phases_completed}/{r.phases_total} |"
         )
 
@@ -1696,7 +1777,7 @@ async def run_all(
             sterile (``—``) rather than borrowing the bounded marker.
     """
     if modes is None:
-        modes = list(MODE_RUNNERS.keys())
+        modes = default_modes()
     if corpora is None:
         corpora = list(BENCHMARK_TEXTS.keys())
 

--- a/tests/unit/argumentation_analysis/orchestration/test_perimeter_aware_counts_1740.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_perimeter_aware_counts_1740.py
@@ -1,0 +1,186 @@
+# tests/unit/argumentation_analysis/orchestration/test_perimeter_aware_counts_1740.py
+"""#1740 — a count whose PRODUCER never ran must not render as ``0``.
+
+The comparison harness printed ``Fallacies: 0`` for ``pipeline_light``, whose
+workflow carries **no fallacy capability at all**. That ``0`` meant "never
+evaluated" and was numerically identical to "evaluated, found none" — the
+#1019 family, inside the instrument that exists to detect it elsewhere.
+
+The defect was NOT at the reader hop, where it had already been fixed three
+times (#1528 item 3, #1540, #1560). Those fixes are correct: ``_fmt_count``
+renders ``—`` for an absent key. They are also inert, because
+``get_state_snapshot`` derives every count as ``len()`` over a *pre-declared*
+container — so the key is never absent and the "absent → —" convention can
+never fire on this field. The discriminator has to come from the **executed
+perimeter** instead.
+
+These tests are JVM/LLM-free: they build ``ModeResult`` objects directly and
+introspect the real workflow builders.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[4]
+_SCRIPTS_DIR = str(_PROJECT_ROOT / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+import compare_orchestration_modes as harness  # noqa: E402
+from argumentation_analysis.orchestration.state_writers import (  # noqa: E402
+    CAPABILITY_STATE_WRITERS,
+)
+from argumentation_analysis.orchestration.workflows import (  # noqa: E402
+    build_light_workflow,
+    build_standard_workflow,
+)
+
+
+def _result(mode: str, **kw) -> harness.ModeResult:
+    """A minimal ModeResult; only the count/perimeter fields matter here."""
+    base = dict(
+        mode=mode,
+        corpus_id="corpus_A",
+        success=True,
+        duration_seconds=1.0,
+        phases_completed=1,
+        phases_total=1,
+    )
+    base.update(kw)
+    return harness.ModeResult(**base)
+
+
+class TestTheDefectItself:
+    """The exact row that started #1740."""
+
+    def test_light_workflow_really_has_no_fallacy_capability(self) -> None:
+        # Verify-before-assert: the premise is re-measured, never trusted.
+        light_caps = {p.capability for p in build_light_workflow().phases}
+        assert not (light_caps & harness._FALLACY_PRODUCING_CAPABILITIES)
+        # ...and the contrast case does carry one, so the distinction is real.
+        standard_caps = {p.capability for p in build_standard_workflow().phases}
+        assert standard_caps & harness._FALLACY_PRODUCING_CAPABILITIES
+
+    def test_pipeline_light_row_renders_na_not_zero(self) -> None:
+        # The regression: a run that completed 3/3 phases, none of which can
+        # produce a fallacy, must not report "0 fallacies found".
+        row = _result(
+            "pipeline_light",
+            fallacy_count=0,
+            argument_count=5,
+            capabilities_used=[
+                "fact_extraction",
+                "argument_quality",
+                "counter_argument_generation",
+            ],
+        )
+        section = harness.generate_report([row])
+        assert "| n/a |" in section, "fallacy count outside the perimeter must be n/a"
+        assert "| 0 |" not in section, "a never-evaluated capability must not read 0"
+        # The argument count IS in perimeter (fact_extraction ran) → real value.
+        assert "| 5 |" in section
+
+
+class TestThreeStatesNeverTwo:
+    """``n/a`` / ``—`` / ``<int>`` must be mutually distinguishable."""
+
+    def test_producer_ran_and_wrote_zero_still_reads_zero(self) -> None:
+        # The state that MUST survive: a genuine, observed zero. If this
+        # rendered n/a, the fix would have swung into the mirror-image defect.
+        row = _result(
+            "pipeline_standard",
+            fallacy_count=0,
+            capabilities_used=["fact_extraction", "neural_fallacy_detection"],
+        )
+        assert (
+            harness._fmt_count_in_perimeter(
+                row.fallacy_count,
+                harness._FALLACY_PRODUCING_CAPABILITIES,
+                row.capabilities_used,
+            )
+            == "0"
+        )
+
+    def test_producer_ran_but_nothing_written_reads_dash(self) -> None:
+        assert (
+            harness._fmt_count_in_perimeter(
+                None,
+                harness._FALLACY_PRODUCING_CAPABILITIES,
+                ["neural_fallacy_detection"],
+            )
+            == "—"
+        )
+
+    def test_producer_absent_reads_na(self) -> None:
+        assert (
+            harness._fmt_count_in_perimeter(
+                0, harness._FALLACY_PRODUCING_CAPABILITIES, ["fact_extraction"]
+            )
+            == "n/a"
+        )
+
+    def test_the_three_renderings_are_pairwise_distinct(self) -> None:
+        caps = harness._FALLACY_PRODUCING_CAPABILITIES
+        out_of_perimeter = harness._fmt_count_in_perimeter(0, caps, ["fact_extraction"])
+        in_perimeter_unwritten = harness._fmt_count_in_perimeter(
+            None, caps, ["neural_fallacy_detection"]
+        )
+        observed_zero = harness._fmt_count_in_perimeter(
+            0, caps, ["neural_fallacy_detection"]
+        )
+        assert len({out_of_perimeter, in_perimeter_unwritten, observed_zero}) == 3
+
+
+class TestUnknownPerimeterIsNotAnEmptyPerimeter:
+    """The trap that would have made this fix a lie in the other direction."""
+
+    def test_empty_capabilities_preserves_a_genuine_count(self) -> None:
+        # conversation_deterministic reports NO perimeter and a real count of 2.
+        # Treating "no perimeter reported" as "empty perimeter" would erase it.
+        assert (
+            harness._fmt_count_in_perimeter(
+                2, harness._FALLACY_PRODUCING_CAPABILITIES, []
+            )
+            == "2"
+        )
+
+    def test_deterministic_row_keeps_its_count(self) -> None:
+        row = _result("conversation_deterministic", fallacy_count=2, phases_completed=3)
+        section = harness.generate_report([row])
+        assert "| 2 |" in section
+        # Cell form, not bare substring: the column legend also says "n/a".
+        assert "| n/a |" not in section
+
+
+class TestProducersPinnedAgainstTheRegistry:
+    """The declared producer sets must not drift from the real capabilities."""
+
+    def test_fallacy_producers_match_the_registry(self) -> None:
+        # Derived, not hand-copied: whatever the registry calls a fallacy
+        # capability is what the harness must treat as a fallacy producer.
+        from_registry = {k for k in CAPABILITY_STATE_WRITERS if "fallacy" in k}
+        assert from_registry == harness._FALLACY_PRODUCING_CAPABILITIES
+
+    def test_argument_producer_is_a_real_registered_capability(self) -> None:
+        assert harness._ARGUMENT_PRODUCING_CAPABILITIES <= set(CAPABILITY_STATE_WRITERS)
+
+
+class TestDeprecatedAliasExcludedFromDefaultSweep:
+    """The alias emitted rows indistinguishable from the real bridge."""
+
+    def test_default_sweep_excludes_the_alias(self) -> None:
+        assert "hierarchical" not in harness.default_modes()
+
+    def test_alias_stays_dispatchable_on_demand(self) -> None:
+        # Excluded from the default sweep, NOT removed — anyone who scripted
+        # ``--modes hierarchical`` keeps working.
+        assert "hierarchical" in harness.MODE_RUNNERS
+
+    def test_default_sweep_has_no_duplicate_labels(self) -> None:
+        # The baseline ran 24 instead of 21 because two keys produced rows
+        # bearing the same label. Every default mode must be distinct.
+        modes = harness.default_modes()
+        assert len(modes) == len(set(modes))
+        assert len(modes) == len(harness.MODE_RUNNERS) - 1


### PR DESCRIPTION
Ferme **#1740**. Trouvé en rendant la baseline T4 de #1735 : le rapport affiche `Fallacies: 0` pour `pipeline_light`, dont le workflow ne contient **aucune** capacité de détection de sophismes. Un `0` « jamais évalué », indiscernable d'un `0` « évalué, rien trouvé » — famille #1019, dans l'instrument qui existe pour la détecter ailleurs. Aggravant : les fixtures sont saturées de sophismes explicitement nommés, donc la lecture naturelle de la ligne est « ce mode échoue à les détecter ».

## Le défaut n'était pas où trois correctifs l'ont cherché

Remonté saut par saut, firsthand :

- **Lecteur du harnais — correct.** `_summarized_count` rend `None` → `—` si la clé manque. Rien à corriger.
- **Producteur d'état — c'est là.** `shared_state.py` dérive `"fallacy_count": len(self.identified_fallacies)` sur un conteneur **pré-déclaré**. La clé n'est donc **jamais** absente : le mécanisme `—` de #1540 ne peut structurellement pas se déclencher sur ce champ.
- **Workflow.** `build_light_workflow` = `fact_extraction`, `argument_quality`, `counter_argument_generation`. Aucune capacité sophisme. `build_standard_workflow` en porte une.

Ce champ précis a été corrigé **trois fois au même saut** (#1528 item 3, #1540, #1560). Les trois correctifs sont justes ; les trois sont inertes. **Des correctifs répétés au même endroit signalent le mauvais saut** — c'est la leçon que je retiens de ce lot autant que le code.

## Le correctif

Le discriminant vient du **périmètre exécuté**, pas de la présence de clé. `capabilities_used` est bâti sur `PhaseStatus.COMPLETED` avec les capacités dégradées retirées — c'est l'ensemble **exécuté**, pas déclaré. Ça traite correctement la troncature au passage : une phase coupée par le budget rend `n/a`, pas `0`. Ça compte, la baseline ayant tronqué 20 runs sur 24.

Trois états, jamais deux : `n/a` (producteur hors périmètre) / `—` (dans le périmètre, non écrit) / `<n>` (écrit).

## L'anti-pendule, qui a failli être le vrai défaut

`conversation_deterministic` ne rapporte **aucun** périmètre (`capabilities_used` vide) **et** un `fallacy_count` réel de 2. Traiter « aucun périmètre rapporté » comme « périmètre vide » aurait rendu `n/a` et **effacé une observation authentique** — l'image miroir du défaut corrigé, et plus difficile à voir parce qu'elle ressemble à de la rigueur. Un périmètre vide veut dire « je ne peux pas démontrer l'absence » ⇒ le compte est rendu tel quel. Test dédié : `TestUnknownPerimeterIsNotAnEmptyPerimeter`.

## Deux défauts voisins du même lot

- **Alias déprécié** : `hierarchical` sort du **balayage par défaut** (il reste dispatchable par `--modes hierarchical`). Les deux clés s'auto-étiquettent `hierarchical_bridge` ⇒ la baseline portait le bridge **6 fois pour 3 corpora**, annonçait « Modes tested: 7 » pour 8 clés, et 24 runs au lieu de 21. Quiconque agrégeait comptait le bridge deux fois.
- **`.get(..., 0)` latent** sur le runner déterministe → None-safe, cohérent avec les deux autres runners. Actuellement peuplé donc invisible ; il aurait fabriqué un 0 le jour où la clé bouge.

## Limite assumée

Les producteurs sont épinglés contre `CAPABILITY_STATE_WRITERS` par un test, mais l'épinglage porte sur la convention de nommage `*fallacy*` : une capacité sophisme introduite sous un nom non conventionnel y échapperait. Trou plus étroit que celui qu'on ferme (un 0 fabriqué à **chaque** run), et écrit dans le code plutôt que tu.

## Contrôles par substitution dégénérée (kill-sets disjoints)

| Substitution | Rouges | Verts |
|---|---|---|
| **Sub A** — contrôle de périmètre neutralisé (comportement d'avant) | **3** (rendu `n/a`) | tests d'alias |
| **Sub B** — alias remis dans le balayage par défaut | **2** (alias) | tests de périmètre |

Chaque test mesure bien sa propre chose ; aucun ne survit à la substitution qui le vise.

## Validation

13 nouveaux tests, **25 verts** avec la suite depth-parity #1500 (0 régression), `black` + `flake8` propres. JVM/LLM-free.

Refs #1740, #1735, #1019

🤖 Coordinator ai-01 — R807 ter
