### PR TITLE
test(hermetic): trois tests du gate n'étaient verts que si un appel LLM réel réussissait (#1742)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_auto_evaluate_governance.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_auto_evaluate_governance.py
@@ -127,11 +127,18 @@ class TestCounterArgumentAutoEvaluation:
         mock_client = AsyncMock()
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
+        # #1742: patch the namespace the callee RESOLVES from, not the facade.
+        # ``_invoke_counter_argument`` is defined in ``invoke_callables``;
+        # ``unified_pipeline`` only star-imports it, so its ``__globals__`` is
+        # ``invoke_callables.__dict__``. Patching the facade name bound a symbol
+        # nobody reads: measured ``mock_client.…create.await_count == 0`` while a
+        # REAL client ran, and the test was green only while the live key had
+        # quota. It went red on a 429 with a diff that touched neither path.
         with patch(
             "argumentation_analysis.agents.core.counter_argument.counter_agent.CounterArgumentPlugin",
             return_value=mock_plugin,
         ), patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(mock_client, "gpt-5-mini"),
         ):
             context = {
@@ -139,6 +146,9 @@ class TestCounterArgumentAutoEvaluation:
             }
             result = await _invoke_counter_argument("Test", context)
 
+        # The mock must MORD (#1583 geste): if the real path is ever taken again,
+        # this fails here instead of producing a confusing downstream KeyError.
+        mock_client.chat.completions.create.assert_awaited()
         assert "llm_counter_arguments" in result
         ca = result["llm_counter_arguments"][0]
         assert "evaluation" in ca
@@ -168,7 +178,7 @@ class TestGovernanceAutoVote:
             "argumentation_analysis.plugins.governance_plugin.GovernancePlugin",
             return_value=mock_plugin,
         ), patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(None, None),
         ), patch(
             "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")
@@ -233,7 +243,7 @@ class TestGovernanceAutoVote:
             "argumentation_analysis.plugins.governance_plugin.GovernancePlugin",
             return_value=mock_plugin,
         ), patch(
-            "argumentation_analysis.orchestration.unified_pipeline._get_openai_client",
+            "argumentation_analysis.orchestration.invoke_callables._get_openai_client",
             return_value=(None, None),
         ), patch(
             "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1583")

--- a/tests/unit/argumentation_analysis/test_nl_to_logic.py
+++ b/tests/unit/argumentation_analysis/test_nl_to_logic.py
@@ -245,7 +245,22 @@ class TestNLToLogicTranslator:
     async def test_translate_batch_heuristic(self):
         """Batch translation works with heuristic fallback."""
         translator = self._make_translator()
-        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+        # #1742: blanking OPENAI_API_KEY does NOT close the LLM gate on its own.
+        # Locally ``pytest-dotenv`` re-loads .env over the process env (measured:
+        # the var is 164 chars long INSIDE the session after `env OPENAI_API_KEY=`),
+        # and ``_translate_with_llm`` prefers OpenRouter when OPENROUTER_* are set.
+        # In the gate the door opened too and the live call 429'd, so this test —
+        # named "heuristic" — was in fact asserting on LLM output. Close the door
+        # structurally at the constructor (#1583 no-network geste): whichever
+        # branch is taken, no socket is opened, and ``translate()`` falls back to
+        # the heuristic it is named for.
+        with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1742")
+        ), patch.dict(
+            "os.environ",
+            {"OPENAI_API_KEY": "", "OPENROUTER_API_KEY": "", "OPENROUTER_BASE_URL": ""},
+            clear=False,
+        ):
             batch = await translator.translate_batch(
                 [
                     "Rain causes wet ground and slippery conditions.",
@@ -255,17 +270,31 @@ class TestNLToLogicTranslator:
             )
         assert len(batch.translations) == 2
         assert all(t.is_valid for t in batch.translations)
+        # The bite: ``method`` is "llm" as soon as any translation carries
+        # attempts > 0. A heuristic-named test that silently ran the LLM is the
+        # defect this pins.
+        assert batch.method == "heuristic"
 
     @pytest.mark.asyncio
     async def test_translate_batch_skips_short(self):
         """Batch skips arguments shorter than 10 chars."""
         translator = self._make_translator()
-        with patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False):
+        # #1742 (neighbour sweep): same open door as the sibling above. This one
+        # only asserts a count, so the live call was pure cost + nondeterminism
+        # rather than a red — which is exactly why it went unnoticed.
+        with patch(
+            "openai.AsyncOpenAI", side_effect=RuntimeError("no-network-1742")
+        ), patch.dict(
+            "os.environ",
+            {"OPENAI_API_KEY": "", "OPENROUTER_API_KEY": "", "OPENROUTER_BASE_URL": ""},
+            clear=False,
+        ):
             batch = await translator.translate_batch(
                 ["short", "This is a sufficiently long argument about something."],
                 logic_type="propositional",
             )
         assert len(batch.translations) == 1
+        assert batch.method == "heuristic"
 
     # ── #1457: NL→modal silent collapse guard ────────────────────────
 


### PR DESCRIPTION
Ferme #1742.

## Le contrôle qui tranche

Le gate est passé rouge sur deux tests avec un diff qui ne touche **aucun** des deux chemins. La lecture « c'est la branche » se fabrique toute seule avec n=2 (main vert / branche rouge). Le troisième point, pris du côté qui réfute : **re-run de `main` au commit identique `485824c2`, 50 min après son run vert → les deux mêmes tests échouent**, mêmes assertions, mêmes `429 insufficient_quota`. Cause externe ; les tests n'étaient simplement jamais hermétiques.

## Mécanismes mesurés

**1. Le mock de `test_invoke_counter_includes_evaluation` n'a jamais rien piloté.** `_invoke_counter_argument` est défini dans `invoke_callables.py:1170` ; `unified_pipeline.py:38` ne fait que `import *`. Ses `__globals__` sont donc ceux du module d'origine (vérifié par identité), et patcher le nom de la façade pose un symbole que personne ne lit. Sonde instrumentée sous pytest :

```
PROBE_MOCK_AWAIT_COUNT 0
PROBE_REAL_GETTER_CALLS [True]     # un VRAI client a été construit
```

Contrôle négatif avec clé morte : le dict rendu est exactement celui de l'échec CI (`['parsed_argument', 'quality_context', 'suggested_strategy']`).

**2. Blanchir `OPENAI_API_KEY` ne ferme pas la porte.** `_translate_with_llm` préfère OpenRouter dès que `OPENROUTER_*` sont posés, et `pytest-dotenv` recharge `.env` par-dessus l'environnement du process. Mesuré **à l'intérieur** de la session, après blanchiment en ligne de commande :

```
PROBE_ENV {'OPENAI_API_KEY': 164, 'OPENROUTER_API_KEY': 73, 'OPENROUTER_BASE_URL': 28}
```

⇒ tout run local « sans clé » censé prouver l'herméticité tourne en fait **avec les vraies clés**. C'est la sonde qui était cassée, pas seulement le test.

## Le geste (celui de #1583)

Router le test vers la branche qu'il mocke, puis faire **mordre** le mock :

- `invoke_callables._get_openai_client` comme cible de patch (3 sites du fichier, pas seulement celui qui rougissait) + `assert_awaited()`. **Contrôle par substitution dégénérée** : remettre la cible sur la façade rend le test rouge sur `AssertionError: Expected create to have been awaited` — au lieu de passer sur un appel réel.
- Fermeture du réseau au constructeur pour les deux tests `*_batch_*` nommés « heuristic », et assertion de `batch.method == "heuristic"` : la propriété que leur nom revendique, et que le chemin LLM violait en silence.

## Herméticité mesurée — `.env` CHARGÉ

Le run de contrôle garde `.env` (DoD de #1583 : c'est ce qui prouve que le mock pilote, et non l'absence de clé).

| test | avant | après |
|---|---|---|
| `test_translate_batch_heuristic` | 20,27 s | 5,35 s |
| `test_invoke_counter_includes_evaluation` | 11,90 s | 0,15 s |
| `test_translate_batch_skips_short` | 6,29 s | 0,01 s |
| **trio** | **39,66 s** | **6,87 s** |

Les 5,35 s résiduels sont la vérification de consistance Tweety/JVM (Java local), pas une socket.

Suites complètes des deux fichiers : **38 passed**. Delta de tally **0** (aucun test ajouté ni retiré). `black` + `flake8` propres.

## Ce que cette PR ne fait pas

- Elle **ne marque pas** `requires_api`/`skip` : l'appel réseau n'était pas voulu (anti-pendule de #1583).
- Elle **n'ajoute pas** de blocage réseau global.
- Elle **ne referme pas** la question P1 restante de #1742 : *pourquoi* la porte s'ouvre dans le runner, où `OPENROUTER_*` sont absents et où il n'y a pas de `.env`. La fermeture au constructeur rend le test déterministe quelle que soit la réponse, mais la mesure de la variable d'env au moment de l'appel, dans le gate, reste à prendre. L'issue le dit explicitement — à mesurer, pas à raisonner.

## Privacy

`nodeid`, durées, longueurs de variables d'environnement. Aucune clé, aucun prompt, aucun contenu de corpus.

🤖 Coordinator ai-01
