### PR TITLE
test(hermetic): the two collaborative-fallback tests never pinned the fallback (#1591)

### DIFF
--- a/tests/unit/argumentation_analysis/orchestration/test_mute_capabilities_b02.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_mute_capabilities_b02.py
@@ -289,29 +289,38 @@ class TestInvokeCollaborativeAnalysis:
 
         return _invoke_collaborative_analysis
 
-    @patch.dict("os.environ", {}, clear=False)
     def test_no_api_key_uses_fallback(self):
         """When no API key, falls back to heuristic analysis."""
-        import os
-
-        # Ensure OPENAI_API_KEY is empty
-        original = os.environ.get("OPENAI_API_KEY")
-        os.environ["OPENAI_API_KEY"] = ""
-        try:
-            invoke = self._get_invoke()
+        # #1591 (re-qualification): blanking ``OPENAI_API_KEY`` closes nothing.
+        # ``_invoke_collaborative_analysis`` resolves its endpoint through
+        # ``core.llm_service.resolve_chat_endpoint``, which consults
+        # ``OPENROUTER_*`` FIRST (llm_service.py:60-62) — and ``pytest-dotenv``
+        # re-loads .env over the process env. So this test, named for the
+        # fallback, took the LIVE path on any machine with OpenRouter
+        # configured, and the fallback path only in the gate (no OPENROUTER_*
+        # secret). Same test, two different code paths depending on the host.
+        # Close the door at the canonical resolver — the precedent is
+        # test_collaborative_debate.py:305 (#1336, option B): the resolver is
+        # imported lazily *inside* the callee, so patching it at its source
+        # binds a name the callee really re-reads on every call.
+        invoke = self._get_invoke()
+        with patch(
+            "argumentation_analysis.core.llm_service.resolve_chat_endpoint",
+            return_value=("", "", ""),
+        ):
             result = asyncio.get_event_loop().run_until_complete(
                 invoke("This is a test argument about policy reform.", {})
             )
-            assert isinstance(result, dict)
-            # Fallback path returns structured analysis with agent_outputs, etc.
-            assert (
-                "agent_outputs" in result or "summary" in result or "fallback" in result
-            )
-        finally:
-            if original:
-                os.environ["OPENAI_API_KEY"] = original
+        assert isinstance(result, dict)
+        # The bite: the previous three-branch ``or`` was satisfied by every
+        # possible return of this function, fallback or not. ``interaction_type``
+        # is the only key that DISTINGUISHES the two paths — the live path
+        # returns "sequential_collaborative" (collaborative_debate.py:221),
+        # the fallback "fallback_heuristic" (l.286).
+        assert (
+            result.get("interaction_type") == "fallback_heuristic"
+        ), f"expected the heuristic fallback path, got {result.get('interaction_type')!r}"
 
-    @patch.dict("os.environ", {"OPENAI_API_KEY": ""}, clear=False)
     def test_fallback_with_context(self):
         """Fallback path uses extract/quality context when available."""
         invoke = self._get_invoke()
@@ -326,16 +335,30 @@ class TestInvokeCollaborativeAnalysis:
                 "per_argument_scores": {"arg_1": {"note_finale": 7.5}},
             },
         }
-        result = asyncio.get_event_loop().run_until_complete(
-            invoke("test input", context)
-        )
-        # #1593: ``isinstance(result, dict)`` passed even with
-        # _invoke_collaborative_analysis stubbed to {}. The name promises
-        # "fallback path uses extract/quality context" → a structured analysis
-        # is produced (mirrors sibling test_no_api_key_uses_fallback).
+        # #1591: same open door as the sibling above — see its comment.
+        with patch(
+            "argumentation_analysis.core.llm_service.resolve_chat_endpoint",
+            return_value=("", "", ""),
+        ):
+            result = asyncio.get_event_loop().run_until_complete(
+                invoke("test input", context)
+            )
+        # #1593 tightened ``isinstance(result, dict)`` to this, which does kill
+        # the stubbed-``{}`` case. But BOTH paths return ``agent_outputs``
+        # (l.215 live, l.280 fallback), so it cannot fail for the reason the
+        # name promises. Pin the path, then pin that the context was USED:
+        # the fallback maps ``arguments[:6]`` into ``surviving_arguments``.
+        assert (
+            result.get("interaction_type") == "fallback_heuristic"
+        ), f"expected the heuristic fallback path, got {result.get('interaction_type')!r}"
         assert (
             "agent_outputs" in result
         ), f"expected structured fallback analysis, got {result}"
+        surviving = result.get("surviving_arguments", [])
+        assert [s["argument"] for s in surviving] == [
+            "The economy needs stimulus.",
+            "Tax cuts help growth.",
+        ], f"extract context was not carried into the fallback, got {surviving}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

Re-qualification of the #1591 residual. The residual classified ~20 entries as family **(b)** — "the verdict legitimately reads a model output, so the test stays online" — using the discriminator *"patching the constructor makes the test fail ⇒ it needs a real model"*.

That discriminator has a blind spot: **three** distinct situations produce its signature, and only one is a real (b). The other two are tests whose *own* hermeticity control is broken, so they fail under a constructor patch for the opposite reason. #1742 already found two of them (`test_auto_evaluate_governance`, `test_nl_to_logic`) the hard way — via a red gate on an unrelated PR. This PR closes the third and last one the sweep found.

## The measurement (firsthand, not reasoned)

Swept every test that blanks `OPENAI_API_KEY`, scoring whether it also closes OpenRouter or the constructor:

| file | closes OpenRouter | patches ctor | verdict |
|---|---|---|---|
| `test_nl_to_logic.py` | ✅ | ✅ | fixed by #1742 |
| `test_fol_2pass_pipeline.py` | ✅ | ✅ | clean |
| `test_pl_2pass_pipeline.py` | — | ✅ | clean (ctor closes it) |
| `test_conversational_orchestrator.py` | — | ✅ | clean (ctor closes it) |
| `test_extract_belief_trajectories_1489.py` | ✅ `delenv` ×3 | — | clean |
| **`test_mute_capabilities_b02.py`** | ❌ | ❌ | **fully open** |

One file left open, two tests in it.

## The door

`_invoke_collaborative_analysis` resolves its endpoint through `core.llm_service.resolve_chat_endpoint`, which consults `OPENROUTER_*` **first** (`llm_service.py:60-62`). Blanking `OPENAI_API_KEY` closes nothing — and `pytest-dotenv` re-loads `.env` over the process env on top.

Consequence: on any host with OpenRouter configured, these two tests took the **live** path; in the gate (no `OPENROUTER_*` secret) they took the fallback. **The same test measured two different code paths depending on the machine** — which is worse than red, because nothing ever goes red.

## The assertions could not fail either

Measured by degenerate substitution (resolver forced to a key + stubbed client, so the live branch completes without opening a socket):

| assertion | live path | fallback path | discriminates? |
|---|---|---|---|
| old 3-branch `or` | True | True | **no** |
| #1593's `agent_outputs` | True | True | **no** |
| `interaction_type` (this PR) | `sequential_collaborative` | `fallback_heuristic` | **yes** |
| context carried (this PR) | `[]` | both arguments | **yes** |

#1593 *did* kill the stubbed-`{}` case — that tightening was real. But it landed on a key **both** paths return (`collaborative_debate.py:215` live, `:280` fallback), so the tightened assertion still could not fail for the reason the test's name promises.

## The fix

Close the door at the **canonical resolver**, following the in-repo precedent `test_collaborative_debate.py:305` (#1336, "option B"): the resolver is imported *lazily inside* the callee, so patching it at its source binds a name the callee genuinely re-reads on every call. Then pin the path with `interaction_type`, and — for `test_fallback_with_context`, whose name promises the context is *used* — pin that the extract context actually reached the output (`surviving_arguments` carries both arguments; the live path returns `[]`).

**Anti-pendule**: not fixed by enumerating provider env vars. That list grows forever and the next provider re-opens the door silently. Not fixed by marking the tests `requires_api` either — that hides the leak instead of closing it, and #1583 forbids it for this family.

## Verification

- 16/16 tests in the file pass, 3.16s, **no network**.
- Falsifiability control run explicitly (table above) rather than asserted — the repaired assertion goes red on the live branch.
- `black` clean, `flake8` clean.
- Test-only change; 0 production files touched.

## Note for the #1591 residual

The residual's (b) column cannot be trusted where the entry carries its own mock or env-blanking. The cheap tell before applying any discriminator: *does the artifact already carry a mock, a `patch.dict` of the environment, or a name promising an offline path?* If yes, its intent was hermeticity — a failure under constructor patching proves **its control is broken**, not that it needs the model. Three states, never two: hermetic / leaking-with-broken-control / deliberately online.

🤖 Coordinator ai-01 — R807
