### PR TITLE
fix(harness): the budget flag reads its measurement, n/a requires an exhaustive ledger (#1752, #1753)

### DIFF
--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -192,8 +192,18 @@ class ModeResult:
                             nothing" is not "indeterminate"). A budget breach
                             that still produced partial artifacts honestly
                             decides ``True`` (the partial state IS the verdict).
-        terminated_by_budget — bool: True iff the run hit the wall-clock
-                            budget and was killed by asyncio.wait_for.
+        terminated_by_budget — bool: True iff the run hit its wall-clock
+                            budget, whether it was KILLED by the safety-net
+                            ``asyncio.wait_for`` or stopped ITSELF gracefully
+                            at an internal deadline. #1752: the narrower
+                            "killed by asyncio.wait_for" wording is what let
+                            the conversational runner hard-code ``False`` —
+                            its budget stop is by design a graceful one
+                            ("verdict partiel honnête", C1 #1500), so it
+                            matched the field's prose while contradicting its
+                            purpose. The field marks a row as NOT comparable
+                            against a run that finished on its own terms; how
+                            the run was stopped is irrelevant to that.
                             Treated as a HONEST PARTIAL verdict (anti-pendule
                             #1019 — never faked into success=True).
         scope_of_work      — short human-readable description of what the
@@ -237,6 +247,12 @@ class ModeResult:
     decides: Optional[bool] = None
     terminated_by_budget: bool = False
     scope_of_work: str = ""
+    # #1753: does ``capabilities_used`` list EVERY capability this run
+    # exercised? Only then may a missing producer be read as "never evaluated"
+    # (``n/a``). Set at the source by each runner, never inferred at the reader
+    # hop. Default False = "cannot demonstrate an absence" — the safe side,
+    # which shows the observed count instead of overclaiming.
+    perimeter_is_exhaustive: bool = False
 
     def to_dict(self) -> Dict[str, Any]:
         return asdict(self)
@@ -434,6 +450,7 @@ def _fmt_count_in_perimeter(
     count: Optional[int],
     producers: FrozenSet[str],
     capabilities_used: List[str],
+    perimeter_is_exhaustive: bool = False,
 ) -> str:
     """Render a count as ``n/a`` when its PRODUCER never ran (#1740).
 
@@ -465,8 +482,25 @@ def _fmt_count_in_perimeter(
     cannot be demonstrated there, so the count renders as-is — emitting ``n/a``
     would erase a genuine observation, which is the mirror-image of the defect
     being fixed.
+
+    ⚠⚠ #1753: that guard was calibrated on **empty ↔ populated**, and production
+    delivers a third shape — **populated but partial**. The conversational mode
+    reports two self-declared plugin capabilities and nothing for the agents
+    that actually ran, so ``fact_extraction`` is missing from a ledger whose
+    run genuinely wrote 4 arguments: a real observation rendered "never
+    evaluated". A ``n/a`` claims MORE than a number does — it is an epistemic
+    verdict ("do not compare this cell") — so it may only be emitted by a mode
+    whose ledger is *exhaustive*. ``perimeter_is_exhaustive`` is set at the
+    SOURCE by each runner (never inferred here): the pipeline runners set it
+    (their ledger comes from the WorkflowExecutor and is complete); the
+    conversational and hierarchical runners do not. Default ``False`` = "I
+    cannot demonstrate an absence", which degrades to showing the count.
     """
-    if capabilities_used and not (set(capabilities_used) & producers):
+    if (
+        perimeter_is_exhaustive
+        and capabilities_used
+        and not (set(capabilities_used) & producers)
+    ):
         return "n/a"
     return _fmt_count(count)
 
@@ -911,6 +945,11 @@ async def run_pipeline_mode(
         phases_total=summary.get("total", 0),
         capabilities_used=result.get("capabilities_used", []),
         capabilities_missing=result.get("capabilities_missing", []),
+        # #1753: the pipeline ledger comes from the WorkflowExecutor, which
+        # sees every phase — so an absent producer here really does mean "not
+        # in the executed perimeter", and ``n/a`` is earned. This is the ONE
+        # runner that may claim it; the others cannot.
+        perimeter_is_exhaustive=True,
         scope_of_work=scope,
     )
 
@@ -1041,7 +1080,14 @@ async def run_conversational_mode(
         capabilities_used=result.get("capabilities_used", []),
         # Track CA #1529: `decides` is no longer hand-set here — run_all
         # computes it uniformly from phases_completed + total_messages below.
-        terminated_by_budget=False,
+        # #1752: read the measurement taken 40 lines above instead of writing a
+        # constant. This runner MEASURED `wall_clock_bounded` and filed it in
+        # `extra_metrics`, then nailed the decision-bearing field to False —
+        # so a run that burned 900.02s of a 900s budget and completed 2/3
+        # phases advertised itself as a completed run. Two witnesses agreed
+        # (`wall_clock_bounded`, `conversational_status`) and the decider
+        # disagreed with both.
+        terminated_by_budget=wall_clock_bounded,
         scope_of_work=scope,
         extra_metrics={
             "total_messages": total_messages,
@@ -1642,8 +1688,14 @@ def generate_report(
             # marker. `decides` is normalised by run_all via _compute_decides
             # (untouched here); `is True` keeps an un-normalised None sterile.
             status = "✅⏱ bounded" if r.decides is True else "⏱ budget"
-        elif r.extra_metrics.get("wall_clock_bounded"):
-            status = "✅⏱ bounded"
+        # #1752: an ``elif r.extra_metrics.get("wall_clock_bounded")`` used to
+        # sit here, rescuing the marker for the one runner that hard-coded
+        # ``terminated_by_budget=False``. It is removed WITH that constant, not
+        # kept alongside it: a reader-hop patch that compensates for a wrong
+        # source is exactly what made the defect survive — the Trade-off table
+        # looked right while the JSON and the metric table stayed wrong, so
+        # nobody had a reason to look at the source. Keeping it now would also
+        # mask any future regression of the source it once papered over.
         elif r.terminates and r.success:
             status = "✅"
         else:
@@ -1703,13 +1755,20 @@ def generate_report(
     )
 
     for r in sorted(results, key=lambda x: (x.mode, x.corpus_id)):
+        # #1752: this is the table that carries the COMPARISON metrics (State
+        # Fill / Fallacies / Args), so it is the table where a budget-truncated
+        # row misleads most — and it was the only one without the marker. A
+        # reader comparing 22.0% against 48.7% was comparing a policy to a
+        # budget.
         status = "✅" if r.success else "❌"
+        if r.success and r.terminated_by_budget:
+            status = "✅⏱"
         err = f" ({r.error})" if r.error and len(r.error) < 50 else ""
         lines.append(
             f"| {r.mode} | {r.corpus_id} | {status}{err} | "
             f"{r.duration_seconds:.2f}s | {_fmt_fill(r.state_fill_rate)} | "
-            f"{_fmt_count_in_perimeter(r.fallacy_count, _FALLACY_PRODUCING_CAPABILITIES, r.capabilities_used)} | "
-            f"{_fmt_count_in_perimeter(r.argument_count, _ARGUMENT_PRODUCING_CAPABILITIES, r.capabilities_used)} | "
+            f"{_fmt_count_in_perimeter(r.fallacy_count, _FALLACY_PRODUCING_CAPABILITIES, r.capabilities_used, r.perimeter_is_exhaustive)} | "
+            f"{_fmt_count_in_perimeter(r.argument_count, _ARGUMENT_PRODUCING_CAPABILITIES, r.capabilities_used, r.perimeter_is_exhaustive)} | "
             f"{r.phases_completed}/{r.phases_total} |"
         )
 

--- a/scripts/compare_orchestration_modes.py
+++ b/scripts/compare_orchestration_modes.py
@@ -192,18 +192,25 @@ class ModeResult:
                             nothing" is not "indeterminate"). A budget breach
                             that still produced partial artifacts honestly
                             decides ``True`` (the partial state IS the verdict).
-        terminated_by_budget — bool: True iff the run hit its wall-clock
-                            budget, whether it was KILLED by the safety-net
-                            ``asyncio.wait_for`` or stopped ITSELF gracefully
-                            at an internal deadline. #1752: the narrower
-                            "killed by asyncio.wait_for" wording is what let
-                            the conversational runner hard-code ``False`` —
-                            its budget stop is by design a graceful one
-                            ("verdict partiel honnête", C1 #1500), so it
-                            matched the field's prose while contradicting its
-                            purpose. The field marks a row as NOT comparable
-                            against a run that finished on its own terms; how
-                            the run was stopped is irrelevant to that.
+        terminated_by_budget — bool: True iff the run was KILLED by the
+                            safety-net ``asyncio.wait_for``. This is the
+                            MECHANISM, and it is deliberately narrow: a run
+                            that stopped ITSELF at its own internal deadline
+                            is ``False`` here and carries
+                            ``extra_metrics["wall_clock_bounded"]`` instead —
+                            two DIFFERENT states, not two witnesses of one
+                            (C1 #1500: the graceful stop yields a real partial
+                            verdict, the kill does not, and the report renders
+                            them ``⏱ budget`` vs ``✅⏱ bounded``).
+                            #1752: I read the pair as one state and made this
+                            field read ``wall_clock_bounded``, which collapsed
+                            the distinction; ``test_internal_bound_maps_to_
+                            real_partial_verdict`` (#1480) caught it. What was
+                            genuinely missing is the COMPARABILITY predicate —
+                            "did this row hit its wall clock at all, so its
+                            metrics may not be compared against a run that
+                            finished on its own terms" — which is neither
+                            field alone: use ``_hit_its_wall_clock(result)``.
                             Treated as a HONEST PARTIAL verdict (anti-pendule
                             #1019 — never faked into success=True).
         scope_of_work      — short human-readable description of what the
@@ -444,6 +451,34 @@ _FALLACY_PRODUCING_CAPABILITIES: FrozenSet[str] = frozenset(
     {"neural_fallacy_detection", "hierarchical_fallacy_detection"}
 )
 _ARGUMENT_PRODUCING_CAPABILITIES: FrozenSet[str] = frozenset({"fact_extraction"})
+
+
+def _hit_its_wall_clock(result: "ModeResult") -> bool:
+    """Did this row hit its wall-clock budget, by EITHER route? (#1752)
+
+    Two distinct states share this consequence and neither field spans both:
+
+    * ``terminated_by_budget`` — the safety net fired and KILLED the run. No
+      verdict of its own; the report marks it ``⏱ budget``.
+    * ``extra_metrics["wall_clock_bounded"]`` — the run stopped ITSELF at its
+      internal deadline and recovered a real partial verdict (C1 #1500); the
+      report marks it ``✅⏱ bounded``.
+
+    Those two must stay separate wherever the *mechanism* matters — that is
+    what #1480 pins, and collapsing them is the mistake this helper exists to
+    make unnecessary. But wherever the question is **comparability** ("may I
+    put this row's State Fill next to a run that finished on its own terms?"),
+    the answer is the same for both and the caller should not have to know
+    which route was taken. Callers asking the comparability question use this;
+    callers rendering the mechanism read the two fields directly.
+
+    Deliberately NOT a ``ModeResult`` field: a third stored boolean derivable
+    from two others is a third thing to keep in sync, and drift between stored
+    duplicates is the defect family this instrument exists to detect.
+    """
+    return bool(result.terminated_by_budget) or bool(
+        result.extra_metrics.get("wall_clock_bounded")
+    )
 
 
 def _fmt_count_in_perimeter(
@@ -1080,14 +1115,16 @@ async def run_conversational_mode(
         capabilities_used=result.get("capabilities_used", []),
         # Track CA #1529: `decides` is no longer hand-set here — run_all
         # computes it uniformly from phases_completed + total_messages below.
-        # #1752: read the measurement taken 40 lines above instead of writing a
-        # constant. This runner MEASURED `wall_clock_bounded` and filed it in
-        # `extra_metrics`, then nailed the decision-bearing field to False —
-        # so a run that burned 900.02s of a 900s budget and completed 2/3
-        # phases advertised itself as a completed run. Two witnesses agreed
-        # (`wall_clock_bounded`, `conversational_status`) and the decider
-        # disagreed with both.
-        terminated_by_budget=wall_clock_bounded,
+        # #1752 (CORRECTED): this ``False`` is CORRECT and deliberate, not the
+        # constant I first took it for. This runner enforces its bound
+        # INTERNALLY and recovers a real partial verdict; the safety net did
+        # not fire, so the KILL flag is False while
+        # ``extra_metrics["wall_clock_bounded"]`` (set below) records the
+        # graceful bound. The tell I misread: every other runner sets this
+        # field only on an EXCEPTION path — which is the field's definition,
+        # not an anomaly. Readers wanting "hit its wall clock at all" must use
+        # ``_hit_its_wall_clock``, not this field.
+        terminated_by_budget=False,
         scope_of_work=scope,
         extra_metrics={
             "total_messages": total_messages,
@@ -1688,14 +1725,14 @@ def generate_report(
             # marker. `decides` is normalised by run_all via _compute_decides
             # (untouched here); `is True` keeps an un-normalised None sterile.
             status = "✅⏱ bounded" if r.decides is True else "⏱ budget"
-        # #1752: an ``elif r.extra_metrics.get("wall_clock_bounded")`` used to
-        # sit here, rescuing the marker for the one runner that hard-coded
-        # ``terminated_by_budget=False``. It is removed WITH that constant, not
-        # kept alongside it: a reader-hop patch that compensates for a wrong
-        # source is exactly what made the defect survive — the Trade-off table
-        # looked right while the JSON and the metric table stayed wrong, so
-        # nobody had a reason to look at the source. Keeping it now would also
-        # mask any future regression of the source it once papered over.
+        elif _hit_its_wall_clock(r):
+            # #1752 (CORRECTED): this branch is NOT a reader-hop rescue for the
+            # constant above — it renders a DIFFERENT state. A run that stopped
+            # itself at its own internal bound produced a real partial verdict
+            # (C1 #1500); a run killed by the safety net did not. I first read
+            # the two as duplicate witnesses of one state and deleted this
+            # branch; ``test_report_marks_bounded_verdict_distinctly`` caught it.
+            status = "✅⏱ bounded"
         elif r.terminates and r.success:
             status = "✅"
         else:
@@ -1759,9 +1796,11 @@ def generate_report(
         # Fill / Fallacies / Args), so it is the table where a budget-truncated
         # row misleads most — and it was the only one without the marker. A
         # reader comparing 22.0% against 48.7% was comparing a policy to a
-        # budget.
+        # budget. This is the one defect of the original #1752 report that
+        # survived its own correction: here the question is comparability, not
+        # mechanism, so both budget routes get the same mark.
         status = "✅" if r.success else "❌"
-        if r.success and r.terminated_by_budget:
+        if r.success and _hit_its_wall_clock(r):
             status = "✅⏱"
         err = f" ({r.error})" if r.error and len(r.error) < 50 else ""
         lines.append(

--- a/tests/unit/argumentation_analysis/orchestration/test_perimeter_aware_counts_1740.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_perimeter_aware_counts_1740.py
@@ -75,6 +75,11 @@ class TestTheDefectItself:
                 "argument_quality",
                 "counter_argument_generation",
             ],
+            # #1753: the pipeline runner sets this at the source — its ledger
+            # comes from the WorkflowExecutor and lists everything that ran, so
+            # an absent producer really is demonstrable absence. Without it the
+            # row can only show its count, never claim "never evaluated".
+            perimeter_is_exhaustive=True,
         )
         section = harness.generate_report([row])
         assert "| n/a |" in section, "fallacy count outside the perimeter must be n/a"
@@ -116,14 +121,19 @@ class TestThreeStatesNeverTwo:
     def test_producer_absent_reads_na(self) -> None:
         assert (
             harness._fmt_count_in_perimeter(
-                0, harness._FALLACY_PRODUCING_CAPABILITIES, ["fact_extraction"]
+                0,
+                harness._FALLACY_PRODUCING_CAPABILITIES,
+                ["fact_extraction"],
+                True,  # #1753: exhaustive ledger — absence is demonstrable
             )
             == "n/a"
         )
 
     def test_the_three_renderings_are_pairwise_distinct(self) -> None:
         caps = harness._FALLACY_PRODUCING_CAPABILITIES
-        out_of_perimeter = harness._fmt_count_in_perimeter(0, caps, ["fact_extraction"])
+        out_of_perimeter = harness._fmt_count_in_perimeter(
+            0, caps, ["fact_extraction"], True
+        )
         in_perimeter_unwritten = harness._fmt_count_in_perimeter(
             None, caps, ["neural_fallacy_detection"]
         )
@@ -197,3 +207,93 @@ class TestDeprecatedAliasExcludedFromDefaultSweep:
         assert (
             set(modes) == set(harness.MODE_RUNNERS) - harness._DEPRECATED_MODE_ALIASES
         )
+
+
+class TestPartialPerimeterIsNotAnAbsence:
+    """#1753 — the mirror defect, arriving through the *partial* door.
+
+    ``TestUnknownPerimeterIsNotAnEmptyPerimeter`` above guards the EMPTY
+    ledger. The guard it protects was calibrated on ``empty ↔ populated``, and
+    production delivers a third shape: **populated but partial**. On a real run
+    the conversational mode reported two self-declared plugin capabilities and
+    nothing for the agents that actually ran, so ``fact_extraction`` was absent
+    from a ledger whose run genuinely wrote 4 arguments — and the report
+    rendered ``n/a`` ("never evaluated") over a real observation.
+    """
+
+    def test_partial_ledger_may_not_claim_an_absence(self) -> None:
+        # The exact production row: 4 arguments written, no argument producer
+        # in a ledger that never listed the agents that ran.
+        assert (
+            harness._fmt_count_in_perimeter(
+                4,
+                harness._ARGUMENT_PRODUCING_CAPABILITIES,
+                ["hierarchical_fallacy_detection", "neural_fallacy_detection"],
+                False,  # conversational: ledger is NOT exhaustive
+            )
+            == "4"
+        )
+
+    def test_conversational_row_shows_its_arguments(self) -> None:
+        row = _result(
+            "conversational",
+            argument_count=4,
+            fallacy_count=14,
+            capabilities_used=[
+                "hierarchical_fallacy_detection",
+                "neural_fallacy_detection",
+            ],
+        )
+        section = harness.generate_report([row])
+        assert "| 4 |" in section, "a real, written count must not read n/a"
+        assert "| n/a |" not in section
+
+    def test_exhaustive_ledger_still_claims_the_absence(self) -> None:
+        # Non-regression on #1740: the guard must keep firing where it is
+        # earned, otherwise this fix is the pendulum swing back to a
+        # never-evaluated count rendering as an observation.
+        assert (
+            harness._fmt_count_in_perimeter(
+                0,
+                harness._FALLACY_PRODUCING_CAPABILITIES,
+                ["fact_extraction", "argument_quality"],
+                True,
+            )
+            == "n/a"
+        )
+
+    def test_only_the_pipeline_runner_claims_exhaustiveness(self) -> None:
+        # The claim is made at the SOURCE, and exactly one runner may make it.
+        # A default-constructed result must never claim it.
+        assert (
+            harness.ModeResult(
+                mode="x", corpus_id="corpus_A", success=True
+            ).perimeter_is_exhaustive
+            is False
+        )
+
+
+class TestBudgetFlagReadsItsOwnMeasurement:
+    """#1752 — ``terminated_by_budget`` was a hard-coded ``False``."""
+
+    def test_detailed_table_marks_a_budget_truncated_row(self) -> None:
+        # The Trade-off table already marked it (via a reader-hop rescue that
+        # this fix removes). The Detailed table — the one carrying State Fill /
+        # Fallacies / Args — did not, which is where a truncated run misleads.
+        row = _result(
+            "conversational",
+            duration_seconds=900.02,
+            phases_completed=2,
+            phases_total=3,
+            state_fill_rate=0.22,
+            terminated_by_budget=True,
+        )
+        section = harness.generate_report([row])
+        detailed = section.split("## Detailed Summary")[1]
+        assert "✅⏱" in detailed, "a budget-truncated row must be marked here too"
+
+    def test_a_completed_row_carries_no_budget_marker(self) -> None:
+        # Counterpart control: the marker must discriminate, not decorate.
+        row = _result("pipeline_standard", phases_completed=15, phases_total=15)
+        detailed = harness.generate_report([row]).split("## Detailed Summary")[1]
+        assert "⏱" not in detailed

--- a/tests/unit/argumentation_analysis/orchestration/test_perimeter_aware_counts_1740.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_perimeter_aware_counts_1740.py
@@ -273,24 +273,76 @@ class TestPartialPerimeterIsNotAnAbsence:
         )
 
 
-class TestBudgetFlagReadsItsOwnMeasurement:
-    """#1752 — ``terminated_by_budget`` was a hard-coded ``False``."""
+class TestBothBudgetRoutesMarkTheMetricTable:
+    """#1752, as CORRECTED by its own red tests.
 
-    def test_detailed_table_marks_a_budget_truncated_row(self) -> None:
-        # The Trade-off table already marked it (via a reader-hop rescue that
-        # this fix removes). The Detailed table — the one carrying State Fill /
-        # Fallacies / Args — did not, which is where a truncated run misleads.
+    The original claim was that ``terminated_by_budget`` hard-coded ``False``
+    on the conversational runner while ``wall_clock_bounded`` said ``True`` —
+    "three surfaces of one state, two agreeing, and the decider a constant".
+    **That premise was wrong.** They are two DIFFERENT states:
+    ``terminated_by_budget`` = the safety net KILLED the run (no verdict of its
+    own, rendered ``⏱ budget``); ``wall_clock_bounded`` = the run stopped
+    ITSELF at its internal deadline and recovered a real partial verdict (C1
+    #1500, rendered ``✅⏱ bounded``). Making one read the other collapsed the
+    distinction, and #1480's own tests caught it.
+
+    The tell I had in hand and misread: every other runner sets
+    ``terminated_by_budget`` only on an EXCEPTION path. I filed that as an
+    anomaly; it is the field's definition.
+
+    What survives is narrower and real: wherever the question is
+    **comparability** rather than mechanism, the two routes have the same
+    consequence — and the Detailed Summary, the table carrying State Fill /
+    Fallacies / Args, marked neither.
+    """
+
+    def test_metric_table_marks_a_killed_row(self) -> None:
+        row = _result(
+            "pipeline_standard",
+            duration_seconds=900.02,
+            phases_completed=2,
+            phases_total=15,
+            state_fill_rate=0.22,
+            terminated_by_budget=True,
+        )
+        detailed = harness.generate_report([row]).split("## Detailed Summary")[1]
+        assert "✅⏱" in detailed, "a safety-net kill must be marked in the metric table"
+
+    def test_metric_table_marks_a_gracefully_bounded_row(self) -> None:
+        # The production row: stopped itself at 900s of a 900s budget, 2/3
+        # phases. ``terminated_by_budget`` is legitimately False here — reading
+        # the marker from it alone is exactly the collapse this class documents.
         row = _result(
             "conversational",
             duration_seconds=900.02,
             phases_completed=2,
             phases_total=3,
             state_fill_rate=0.22,
+            extra_metrics={"wall_clock_bounded": True},
+        )
+        detailed = harness.generate_report([row]).split("## Detailed Summary")[1]
+        assert "✅⏱" in detailed, "a graceful bound must be marked in the metric table"
+
+    def test_the_two_routes_stay_distinct_where_mechanism_matters(self) -> None:
+        # Non-regression on #1480: the Trade-off table must keep rendering the
+        # mechanism, so the comparability helper must NOT have flattened it.
+        killed = _result(
+            "pipeline_standard",
+            terminates=True,
+            decides=False,
             terminated_by_budget=True,
         )
-        section = harness.generate_report([row])
-        detailed = section.split("## Detailed Summary")[1]
-        assert "✅⏱" in detailed, "a budget-truncated row must be marked here too"
+        graceful = _result(
+            "conversational",
+            terminates=True,
+            decides=True,
+            extra_metrics={"wall_clock_bounded": True},
+        )
+        tradeoff = harness.generate_report([killed, graceful]).split("## Depth-Parity")[
+            0
+        ]
+        assert "⏱ budget" in tradeoff
+        assert "✅⏱ bounded" in tradeoff
 
     def test_a_completed_row_carries_no_budget_marker(self) -> None:
         # Counterpart control: the marker must discriminate, not decorate.


### PR DESCRIPTION
Deux défauts de l'instrument de comparaison. Le second (#1753) tient tel quel ; **le premier (#1752) a été partiellement réfuté par sa propre CI**, et ce que la PR livre n'est pas ce que l'issue annonçait. Le détail de la rétractation est [sur #1752](https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/issues/1752#issuecomment-5295974864) ; l'essentiel est ci-dessous.

## #1752 — deux états, pas deux témoins d'un état

**Ce que j'affirmais** : `terminated_by_budget=False` codé en dur à 5 lignes d'un `wall_clock_bounded=True` mesuré — « trois surfaces d'un même état, deux d'accord, et celle qui décide est une constante ». **Faux.**

| champ | signifie | rendu |
|---|---|---|
| `terminated_by_budget` | le filet `asyncio.wait_for` a **tué** le run — pas de verdict propre | `⏱ budget` |
| `extra_metrics["wall_clock_bounded"]` | le run s'est arrêté **lui-même** à sa borne interne, verdict partiel **réel** (C1 #1500) | `✅⏱ bounded` |

`test_internal_bound_maps_to_real_partial_verdict` (#1480) asserte que l'arrêt gracieux conversationnel vaut `terminated_by_budget is False` — **et il a raison**, le filet n'a pas tiré. Le `elif` de `:1624` que j'avais retiré comme « rattrapage au hop lecteur » **rend l'autre état** : le supprimer transformait `✅⏱ bounded` en `✅` nu, effaçant la distinction que je prétendais restaurer.

Le tell que j'avais en main : j'avais noté dans l'issue que *« les autres runners ne posent ce champ que sur des chemins d'exception »*, en le qualifiant d'**ironie de construction**. C'est la **définition du champ**.

### Ce qui survit, et qui est réel

Là où la question est la **comparabilité** et non le **mécanisme**, les deux routes ont la même conséquence — et la table **Detailed Summary**, celle qui porte State Fill / Fallacies / Args, ne marquait **ni l'une ni l'autre**. Un lecteur comparant `22,0 %` à `48,7 %` comparait une course tronquée à une course terminée.

- `terminated_by_budget` **rétabli à `False`**, avec la raison écrite sur place pour que le prochain lecteur ne re-dépose pas l'issue.
- `elif :1624` **rétabli**, avec le commentaire disant qu'il rend un état distinct.
- Docstring **aiguisée** (pas élargie — mon élargissement collapsait la distinction) : elle nomme les deux états et renvoie vers le helper.
- **`_hit_its_wall_clock(result)`** — répond « cette ligne a-t-elle touché son mur, par l'une ou l'autre route ? ». **Helper, pas troisième champ stocké** : un booléen dérivable de deux autres est une troisième chose à tenir synchronisée, et la dérive entre doublons stockés est la famille de défauts que cet instrument existe pour détecter.
- Table Detailed : `✅⏱` sur les deux routes.

## #1753 — `n/a` sur quatre arguments réellement écrits (inchangé)

Le garde de #1740 rend `n/a` quand aucun producteur n'apparaît dans le registre des capacités exercées. Il a été calibré sur **vide ↔ peuplé** ; la production livre une troisième forme : **peuplé-mais-partiel**. Le registre conversationnel contient deux capacités auto-déclarées par des plugins et rien pour les agents qui ont réellement tourné, donc `fact_extraction` manque d'un registre dont le run a écrit **4 arguments** — et le rapport a rendu « jamais évalué » par-dessus une observation réelle.

Un `n/a` revendique **plus** qu'un nombre : c'est un verdict épistémique (« ne comparez pas cette cellule »). Il ne peut donc être émis que par un mode dont le registre est *exhaustif*. `perimeter_is_exhaustive` est posé **à la source** par chaque runner, jamais inféré au hop lecteur — un seul runner peut le revendiquer aujourd'hui (le pipeline, dont le registre vient du `WorkflowExecutor` qui voit toutes les phases). Défaut `False` = « je ne peux pas démontrer une absence », qui dégrade vers l'affichage du compte observé.

## Contrôles rouge-avant-fix (sur `74af82d7`)

| famille | rouge attendu | vert attendu |
|---|---|---|
| #1752 | les **2** tests de marqueur (`_marks_a_killed_row`, `_marks_a_gracefully_bounded_row`) | les **2** de non-régression : le mécanisme reste distinct dans le Trade-off, une ligne terminée ne porte aucun marqueur |
| #1753 | `test_conversational_row_shows_its_arguments` — rouge **comportementalement** (rend `n/a` sur un 4 réel), pas par signature | `test_exhaustive_ledger_still_claims_the_absence` (non-régression #1740) |

Sans la moitié verte, « corriger » aurait voulu dire **aplatir**.

## Anti-pendule (transcrits en tests, pas en prose)

- **Ne pas dériver le drapeau budget de `duration >= budget`** : une coïncidence de durée n'est pas un état d'arrêt.
- **Ne pas fusionner les deux routes budgétaires là où le mécanisme compte** — `test_the_two_routes_stay_distinct_where_mechanism_matters` épingle le Trade-off.
- **Ne pas neutraliser le garde #1740** — `test_exhaustive_ledger_still_claims_the_absence` : là où l'exhaustivité est acquise, `n/a` continue de tirer.
- Les trois rendus (`n/a` / `—` / `<int>`) restent deux à deux distincts.

## Tests

**251 passed** sur les **trois** suites du harnais : `tests/unit/scripts/`, `tests/scripts/test_compare_orchestration_modes_1480.py`, `tests/unit/argumentation_analysis/orchestration/test_perimeter_aware_counts_1740.py`. `black` et `flake8` propres.

⚠ Note de méthode : le premier passage de CI est rouge dans l'historique de cette PR parce que j'avais lancé `tests/unit/scripts/` en local et déclaré la suite verte — le harnais a **deux** répertoires de tests, et les deux rouges étaient dans celui que je n'avais pas lancé. Un « suite verte » qui ne nomme pas son périmètre ne vaut rien.

## Conséquence sur les résultats publiés

Inchangée : la ligne `conversational` de `sweep_1735_R808_A` est **budget-confinée** (900,02 s pour 900 s de budget, 2/3 phases, phase 3 jamais entrée) et ne doit pas être comparée telle quelle. Seul le **chemin** de son arrêt était mal décrit — pas le fait. Cf. #1735 et #1751.

Instrument, pas politique. Famille #1019 · voisin de #1749.

Closes #1752
Closes #1753

🤖 Generated with [Claude Code](https://claude.com/claude-code)
