### PR TITLE
feat(extraction): carry cited/adversary positions as discrete inventory items (#1745)

### DIFF
--- a/argumentation_analysis/orchestration/invoke_callables.py
+++ b/argumentation_analysis/orchestration/invoke_callables.py
@@ -3455,7 +3455,9 @@ def _annotate_attack_retention(
             attacker: Any = None
             if isinstance(atk, dict) and atk.get("attackers"):
                 attackers = atk["attackers"]
-                attacker = attackers[0] if isinstance(attackers, (list, tuple)) else None
+                attacker = (
+                    attackers[0] if isinstance(attackers, (list, tuple)) else None
+                )
             elif isinstance(atk, (list, tuple)) and atk:
                 attacker = atk[0]
             nature = _attack_source_nature(attacker)
@@ -5890,6 +5892,22 @@ def _normalize_fallacies_with_quotes(items: list[Any]) -> list[Dict[str, Any]]:
     return result
 
 
+# #1745 — pole-coverage instruction, appended VERBATIM to the extraction
+# system prompt. Measured against hand-annotated real-prose ground truth
+# (issue #1745): without it the model folds cited/adversarial positions
+# into single evaluative items, so every downstream attack axis faces a
+# one-pole inventory (famine_proposal at extraction).
+_OPPOSING_POSITIONS_INSTRUCTION = (
+    " An argumentative text also CONTAINS the positions it argues against - "
+    "quoted, paraphrased, or reformulated. Extract each of those cited or "
+    "opposing positions as a standalone item of the same rank as the "
+    "positions the text defends: one item per position, stated NEUTRALLY "
+    "(the assertion as its holder would state it, not as the author "
+    "disqualifies it). Do NOT fold an opposing position inside the "
+    "description of another item."
+)
+
+
 async def _invoke_fact_extraction(
     input_text: str, context: Dict[str, Any]
 ) -> Dict[str, Any]:
@@ -5945,6 +5963,7 @@ async def _invoke_fact_extraction(
             "Focus on: (1) identifying distinct argumentative positions, "
             "(2) extracting factual claims that can be verified, "
             "(3) noting rhetorical strategies used (without labeling them as fallacies). "
+            + _OPPOSING_POSITIONS_INSTRUCTION
             + lang_clause
             + " Respond with ONLY a JSON object:\n"
             '{"arguments": [{"text": "arg description", "source_quote": "exact quote..."}], '

--- a/scripts/measure_1745_pole_coverage.py
+++ b/scripts/measure_1745_pole_coverage.py
@@ -1,0 +1,376 @@
+"""#1745 — does the single-pole inventory explain the attack famine, and does
+ONE prompt instruction (extract cited/adversarial positions as discrete,
+neutral items) lift it?
+
+Issue #1745 protocol (pre-registered at
+https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/issues/1745#issuecomment-5295035932
+BEFORE any run):
+
+  * Arm CONTROL = the production ``_invoke_fact_extraction`` prompt VERBATIM
+    (single variable design: nothing else moves — no schema, no window, no
+    max_tokens).
+  * Arm TREATED = the same body + ONE instruction (the "geste"): an
+    argumentative text contains the positions it argues against; extract each
+    as a STANDALONE item stated NEUTRALLY, never folded inside another item.
+  * k >= 5 runs per arm (extraction is a draw). Report RATES, never a single
+    value. "Effective coverage" = pair covered in >= 2/5 runs.
+  * Pole coverage = for an annotated pair (A attacks B), the PRODUCTION
+    inventory contains BOTH poles as DISTINCT items (each pole matching a
+    different item at score >= 0.6, same exact/containment/Jaccard scale as
+    the R808 harness). The membership input is ALWAYS the production output —
+    never the annotations (anti-pendule).
+  * Step 0 gate: if the CONTROL arm already covers >= 1 pair effectively
+    (>= 2/5 runs), the hypothesis is REFUTED at extraction — report and stop.
+  * Step 3 (reader): attack axes run over the PRODUCTION inventory of both
+    arms; raw proposals captured before validation. If coverage rises but raw
+    stays 0, the defect is at the NEXT hop — named, not counted as success.
+  * Neutrality inspection: matched target-pole items are kept in the
+    gitignored artifact; a heuristic flags disqualifying markers ("wrongly",
+    "erroneous", ...) so a loaded item cannot silently pass as neutral.
+
+Reuses the R808 harness (measure_1710_ground_truth) for extraction call
+shape, raw capture, axis runs and similarity — identical measurement chain.
+
+Privacy HARD: corpus content in-memory only; outputs under
+evaluation/results/real_analysis/ (GITIGNORED); opaque IDs everywhere.
+
+Usage:
+    conda run -n projet-is-roo-new --no-capture-output python scripts/measure_1745_pole_coverage.py --passage C --arm control
+    conda run -n projet-is-roo-new --no-capture-output python scripts/measure_1745_pole_coverage.py --passage C --arm treated
+    conda run -n projet-is-roo-new --no-capture-output python scripts/measure_1745_pole_coverage.py --passage A --arm all
+"""
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent))
+os.chdir(Path(__file__).parent.parent)
+
+import measure_1710_ground_truth as gt  # noqa: E402  (R808 harness, merged)
+
+RESULTS_DIR = Path("argumentation_analysis/evaluation/results/real_analysis")
+K_DEFAULT = 5
+EFFECTIVE_MIN_RUNS = 2  # pre-registered: pair "effectively covered" iff >= 2/K runs
+
+# ---------------------------------------------------------------------------
+# The geste — ONE instruction appended to the production body. Two exigences
+# from the issue: DISCRETE (standalone item, never folded) and NEUTRAL (as its
+# holder would state it, not as the author disqualifies it).
+# ---------------------------------------------------------------------------
+_GESTE = (
+    " An argumentative text also CONTAINS the positions it argues against - "
+    "quoted, paraphrased, or reformulated. Extract each of those cited or "
+    "opposing positions as a standalone item of the same rank as the "
+    "positions the text defends: one item per position, stated NEUTRALLY "
+    "(the assertion as its holder would state it, not as the author "
+    "disqualifies it). Do NOT fold an opposing position inside the "
+    "description of another item."
+)
+
+ARMS: Dict[str, str] = {
+    "control": gt._BASELINE_BODY,
+    "treated": gt._BASELINE_BODY + _GESTE,
+}
+
+# Heuristic disqualifying markers — a "target-pole" item carrying one of these
+# is possibly loaded (stated as the author disqualifies it, not neutrally).
+_LOADED_MARKERS = (
+    "wrongly",
+    "erroneous",
+    "so-called",
+    "false claim",
+    "alleged",
+    "myth",
+    "supposedly",
+    "falsely",
+)
+
+
+def pole_coverage(arg_texts: List[str], pair: Dict[str, Any]) -> Dict[str, Any]:
+    """Both poles of the pair present as DISTINCT inventory items?
+
+    A pole is "present" iff its best-matching item scores >= _SIM_THRESHOLD
+    (same scale as R808). The pair is covered iff both poles are present AND
+    their best items are different items.
+    """
+    atk_claim = pair["attacker"]["claim"]
+    tgt_claim = pair["target"]["claim"]
+
+    def best(claim: str) -> Tuple[Optional[int], float, Optional[str]]:
+        best_i, best_s = None, 0.0
+        for i, t in enumerate(arg_texts):
+            s = gt._sim(claim, t)
+            if s > best_s:
+                best_i, best_s = i, s
+        if best_i is None:
+            return None, 0.0, None
+        return best_i, best_s, arg_texts[best_i]
+
+    a_i, a_s, a_t = best(atk_claim)
+    t_i, t_s, t_t = best(tgt_claim)
+    covered = (
+        a_s >= gt._SIM_THRESHOLD
+        and t_s >= gt._SIM_THRESHOLD
+        and a_i is not None
+        and t_i is not None
+        and a_i != t_i
+    )
+    return {
+        "pair_id": pair["id"],
+        "covered": covered,
+        "attacker": {
+            "score": round(a_s, 3),
+            "item_idx": a_i,
+            "item_text": a_t,  # artifact-only (gitignored)
+        },
+        "target": {
+            "score": round(t_s, 3),
+            "item_idx": t_i,
+            "item_text": t_t,
+            "possibly_loaded": bool(
+                t_t and any(m in t_t.lower() for m in _LOADED_MARKERS)
+            ),
+        },
+    }
+
+
+async def run_arm(
+    arm_name: str,
+    body: str,
+    text: str,
+    lang_clause: str,
+    ann: Dict[str, Any],
+    k: int,
+    model_id: str,
+) -> Dict[str, Any]:
+    arm: Dict[str, Any] = {"body_len": len(body), "runs": []}
+    for i in range(1, k + 1):
+        t0 = time.time()
+        args, summary = await gt.extract_inventory(text, body, lang_clause)
+        arg_texts = [a["text"] for a in args if isinstance(a, dict) and a.get("text")]
+        coverage = [pole_coverage(arg_texts, p) for p in ann["pairs"]]
+        axes = await gt.run_path(text, arg_texts, model_id, arm_name, i)
+        n_cov = sum(1 for c in coverage if c["covered"])
+        print(
+            f"   [{arm_name}] run {i}/{k}: {len(arg_texts)} items, "
+            f"pairs covered this run: {n_cov}/{len(coverage)} "
+            f"({round(time.time() - t0)}s)"
+        )
+        arm["runs"].append(
+            {
+                "run": i,
+                "n_args": len(arg_texts),
+                "elapsed_s": round(time.time() - t0, 1),
+                "status": summary[:80],
+                "arg_texts_full": arg_texts,
+                "coverage": coverage,
+                "axes": axes,
+            }
+        )
+    # Aggregate: coverage rate per pair + effective coverage (>= EFFECTIVE_MIN_RUNS).
+    agg_cov = []
+    for p in ann["pairs"]:
+        hits = sum(
+            1
+            for r in arm["runs"]
+            for c in r["coverage"]
+            if c["pair_id"] == p["id"] and c["covered"]
+        )
+        loaded = any(
+            c["target"]["possibly_loaded"]
+            for r in arm["runs"]
+            for c in r["coverage"]
+            if c["pair_id"] == p["id"] and c["covered"]
+        )
+        agg_cov.append(
+            {
+                "pair_id": p["id"],
+                "covered_runs": hits,
+                "rate": round(hits / k, 2),
+                "effectively_covered": hits >= EFFECTIVE_MIN_RUNS,
+                "any_matched_target_possibly_loaded": loaded,
+            }
+        )
+    arm["coverage_aggregate"] = agg_cov
+    arm["effective_pairs"] = sum(1 for c in agg_cov if c["effectively_covered"])
+    # Raw attack counts per axis per run.
+    arm["raw_attacks"] = {
+        axis: [r["axes"][axis]["raw"] for r in arm["runs"]]
+        for axis in ("setaf", "weighted", "aspic")
+    }
+    return arm
+
+
+def render(result: Dict[str, Any]) -> str:
+    p = result["passage"]
+    lines = [
+        f"\n=== #1745 pole-coverage — {p['corpus']} offset {p['offset']} ===",
+        f"model={result['model']}  k={result['k']}  "
+        f"effective = pair covered in >= {EFFECTIVE_MIN_RUNS}/{result['k']} runs",
+        "",
+    ]
+    for arm_name, arm in result["arms"].items():
+        lines.append(f"--- arm: {arm_name} ---")
+        lines.append(
+            f"{'pair':<8} {'covered':<10} {'rate':<6} {'target possibly loaded'}"
+        )
+        for c in arm["coverage_aggregate"]:
+            eff = "YES" if c["effectively_covered"] else "no"
+            loaded = "FLAG" if c["any_matched_target_possibly_loaded"] else "clean"
+            lines.append(
+                f"{c['pair_id']:<8} {eff:<10} {c['covered_runs']}/{result['k']}"
+                f"     {loaded}"
+            )
+        lines.append(
+            f"effective pairs: {arm['effective_pairs']}  |  raw attacks "
+            f"(per run): {arm['raw_attacks']}"
+        )
+        lines.append("")
+    gate = result.get("gate")
+    if gate:
+        lines.append(f"GATE (step 0): {gate}")
+    return "\n".join(lines)
+
+
+# passage_1 = the R808 annotated passage (corpus C); passage_2 = the #1745
+# portée passage (corpus A, annotated to the same barème BEFORE any run on it).
+PASSAGES: Dict[str, Dict[str, Any]] = {
+    "C": {
+        "corpus": "C",
+        "offset": 10400,
+        "width": 3000,
+        "annot": "annotations_1710_gt_C.json",
+    },
+    "A": {
+        "corpus": "A",
+        "offset": 14000,
+        "width": 3000,
+        "annot": "annotations_1745_gt_A.json",
+    },
+}
+
+
+async def main_async(arms: List[str], k: int, passage_key: str) -> None:
+    passage = PASSAGES[passage_key]
+    text = gt.load_corpus_text(passage["corpus"], passage["offset"], passage["width"])
+    annot_path = RESULTS_DIR / passage["annot"]
+    with open(annot_path, encoding="utf-8") as f:
+        ann = json.load(f)
+    lang_clause = gt._lang_clause(text)
+    _client, model_id = gt._get_openai_client()
+    if not model_id:
+        model_id = "(unresolved)"
+    print(
+        f"[1745] passage_{passage_key} corpus {passage['corpus']} offset "
+        f"{passage['offset']}: {len(text)} chars, "
+        f"{len(ann['pairs'])} frozen annotated pairs, model={model_id}, "
+        f"k={k}, arms={arms}"
+    )
+    print(
+        "[1745] pre-registered verdict: "
+        "https://github.com/jsboigeEpita/2025-Epita-Intelligence-Symbolique/"
+        "issues/1745#issuecomment-5295035932"
+    )
+
+    result: Dict[str, Any] = {
+        "issue": 1745,
+        "passage": dict(passage),
+        "model": model_id,
+        "k": k,
+        "effective_min_runs": EFFECTIVE_MIN_RUNS,
+        "geste": _GESTE,
+        "annotation_artifact": str(annot_path),
+        "arms": {},
+    }
+
+    for arm_name in arms:
+        result["arms"][arm_name] = await run_arm(
+            arm_name, ARMS[arm_name], text, lang_clause, ann, k, model_id
+        )
+        # Step 0 gate fires right after the control arm.
+        if arm_name == "control" and "treated" not in arms:
+            eff = result["arms"]["control"]["effective_pairs"]
+            result["gate"] = f"control arm effective pairs = {eff} -> " + (
+                "HYPOTHESIS REFUTED AT EXTRACTION (>=1 pair already "
+                "covered): report and STOP, dispatch retargets."
+                if eff >= 1
+                else "gate passes (0 effective pairs) -> proceed to " "treated arm."
+            )
+
+    # Pair-level raw-proposal overlap on the production inventories (both arms).
+    for arm_name, arm in result["arms"].items():
+        overlap_rows = []
+        for pair in ann["pairs"]:
+            hit_any, best, correct = False, 0.0, False
+            for r in arm["runs"]:
+                for axis_key in ("setaf", "weighted", "aspic"):
+                    entry = r["axes"].get(axis_key, {})
+                    hit, score, cd = gt._pair_overlap(entry.get("proposed", []), pair)
+                    hit_any = hit_any or hit
+                    best = max(best, score)
+                    correct = correct or cd
+            overlap_rows.append(
+                {
+                    "pair_id": pair["id"],
+                    "proposed_in_any_run": hit_any,
+                    "best_score": round(best, 3),
+                    "correct_direction": correct,
+                }
+            )
+        arm["overlap"] = overlap_rows
+
+    result["date_utc"] = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    out_path = RESULTS_DIR / f"measure_1745_pole_coverage_{passage_key}.json"
+    existing = {}
+    if out_path.exists():
+        try:
+            with open(out_path, encoding="utf-8") as f:
+                existing = json.load(f)
+        except Exception:
+            existing = {}
+    # Merge by arm so control/treated can be run in separate invocations.
+    # (Explicit key merge — a blanket dict.update would REPLACE the arms
+    # dict wholesale and wipe arms from earlier invocations.)
+    for key in (
+        "issue",
+        "passage",
+        "model",
+        "k",
+        "effective_min_runs",
+        "geste",
+        "annotation_artifact",
+    ):
+        existing[key] = result[key]
+    existing.setdefault("arms", {}).update(result["arms"])
+    existing["date_utc"] = result["date_utc"]
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(existing, f, indent=2, ensure_ascii=False, default=str)
+    print(render(result))
+    print(f"\n[1745] artifact (gitignored) -> {out_path}")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--arm", choices=["control", "treated", "all"], default="all")
+    p.add_argument("--k", type=int, default=K_DEFAULT, help="runs per arm")
+    p.add_argument(
+        "--passage",
+        choices=list(PASSAGES),
+        default="C",
+        help="C = passage_1 (R808 annotations); A = passage_2 (portée)",
+    )
+    a = p.parse_args()
+    arms = ["control", "treated"] if a.arm == "all" else [a.arm]
+    asyncio.run(main_async(arms, a.k, a.passage))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/argumentation_analysis/orchestration/test_fact_extraction_opposing_poles_1745.py
+++ b/tests/unit/argumentation_analysis/orchestration/test_fact_extraction_opposing_poles_1745.py
@@ -1,0 +1,239 @@
+"""#1745 — the extraction inventory must carry BOTH poles of an opposition.
+
+Measured against hand-annotated real-prose ground truth (issue #1745): the
+baseline extraction prompt folds the cited/adversary position inside the
+speaker's evaluative items, leaving every downstream attack axis a ONE-pole
+inventory — the famine_proposal state of #1710. The production prompt now
+appends ``_OPPOSING_POSITIONS_INSTRUCTION``.
+
+Two contracts, explicitly separated:
+
+1. ``test_instruction_reaches_the_wire`` (hermetic, no API key) — the
+   instruction deployed in production is EXACTLY the variable measured in
+   the #1745 two-arm runs (verbatim fidelity pin). A silent rewording or
+   removal of the instruction would keep the behaviour test green on easy
+   draws while voiding the 2-passage two-arm measurement evidence.
+   Substitution control EXECUTED: emptying
+   ``_OPPOSING_POSITIONS_INSTRUCTION`` turns this test red
+   deterministically (3/3 draws).
+
+2. ``test_inventory_carries_both_poles_of_explicit_opposition``
+   (``requires_api``, real LLM) — BEHAVIOUR: on a dense synthetic text
+   whose target position appears only as the object of disqualifying
+   predicates, the inventory must carry the position as its own
+   non-disqualified item, so downstream attack axes have a node to attack.
+   Substitution matrix EXECUTED (2026-08-14, final test code): emptied
+   arm — fold-red 2/3 draws, mint-pass 1/3 (gpt-5-mini stochastically
+   mints an existential meta-claim "the claim exists that X" on synthetic
+   prose); restored arm — green 3/3. The fold is NOT deterministically
+   reproducible off the real corpus (control-arm fold rate on real prose:
+   10/10), so this test is the carriage REGRESSION GUARD, not the causal
+   evidence for the instruction; the causal evidence is the #1745
+   measurement artifact (real prose, 2 passages x 2 arms x k=5).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from argumentation_analysis.orchestration.invoke_callables import (
+    _invoke_fact_extraction,
+)
+
+INVOKE_PATH = "argumentation_analysis.orchestration.invoke_callables"
+
+# Synthetic op-ed (invented city, no dataset content), production window
+# density (~2400 chars). The pro-subsidy position is NEVER asserted
+# standalone — it exists only inside "whatever its architects still claim"
+# and "the subsidy coalition's insistence that ... is the same thinking
+# that gave us the failed stadium bond".
+_TEXT = (
+    "Downtown's revival did not come from the riverfront subsidy program, "
+    "whatever its architects still claim. The program burned through forty "
+    "million dollars in six years and delivered a convention center that "
+    "sits empty most winters. The real drivers were the community college's "
+    "night classes, which doubled enrollment in four years; the ferry "
+    "contract, which put eleven hundred commuters on the water every "
+    "morning; and the police walking beats again after the 2019 staffing "
+    "deal. Each of those moved the vacancy numbers before a single subsidy "
+    "check cleared. The subsidy coalition's insistence that the program "
+    "deserves the credit is the same thinking that gave us the failed "
+    "stadium bond and the abandoned tech campus: pick a flagship, pour "
+    "money, announce success. The bond cost taxpayers thirty-one million "
+    "and the stadium hosted four concerts. The tech campus drew no anchor "
+    "tenant and was converted to storage. What actually revives a downtown "
+    "is boring: permit times cut from nine months to eleven weeks, parking "
+    "that costs less than the bus, landlords who can evict non-paying "
+    "tenants inside a season, and a sanitation contract that gets the trash "
+    "picked up before noon. Every one of those was proposed in the 2017 "
+    "commission report the council shelved. The council keeps voting to "
+    "renew the subsidy because canceling it would mean admitting the "
+    "original vote was wrong, and the architects of that vote still chair "
+    "the committees that would have to say so. The county next door cut "
+    "its subsidy in 2021 and its vacancy rate fell below ours within two "
+    "years. Ours rose. The program's own consultant counted the jobs it "
+    "'created' by including transfers from existing hotels. When the state "
+    "auditor asked for payroll records, the program office provided "
+    "rounding-error summaries instead. Forty million, and the best its "
+    "defenders can point to is a plaza where the fountains work on "
+    "weekends."
+)
+
+# Disqualification markers — the author's evaluation. An item carrying one
+# of these states the position AS THE AUTHOR DISQUALIFIES IT, not as its
+# holder would state it; it cannot count as the neutral pole. Marker
+# family mirrors the #1745 measurement script's _LOADED_MARKERS plus the
+# fold frames observed on this text's baseline inventories.
+_LOADED = (
+    "fantasy",
+    "fail",
+    "myth",
+    "wrong",
+    "absurd",
+    "fals",
+    "so-called",
+    "merely",
+    "destroy",
+    "harm",
+    "decay",
+    "deferred",
+    "blocked",
+    "waiting list",
+    "not solve",
+    "cannot solve",
+    "whatever",
+    "insistence",
+    "challeng",
+    "not result",
+    "did not",
+    "denial",
+    "denies",
+    "dismiss",
+    "burned",
+    "abandoned",
+    "inflat",
+    "resist",
+    "accuse",
+    "minimal",
+    "shelved",
+    "pour money",
+    "announce success",
+    "underused",
+)
+
+
+def _resp(content: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content))]
+    )
+
+
+def _item_texts(result: dict) -> list[str]:
+    """Item TEXTS only — the verbatim source_quote legitimately contains
+    the disqualifying phrasing of the cited mention, so scanning quotes
+    would false-red a correct neutral item (observed on treated draws)."""
+    texts: list[str] = []
+    for key in ("arguments", "claims"):
+        for item in result.get(key, []):
+            if isinstance(item, dict):
+                combined = str(item.get("text", ""))
+            elif item:
+                combined = str(item)
+            else:
+                continue
+            if combined.strip():
+                texts.append(combined.lower())
+    return texts
+
+
+def _target_content(t: str) -> bool:
+    """Cited position: the subsidy program deserves the revival credit."""
+    return ("subsidy" in t or "riverfront" in t) and (
+        "credit" in t or "deserves" in t or "deserve" in t
+    )
+
+
+def _attacker_content(t: str) -> bool:
+    """Speaker position: the program failed; the revival came from elsewhere."""
+    return (
+        "vacancy" in t
+        or "ferry" in t
+        or "permit" in t
+        or "forty million" in t
+        or "fountain" in t
+        or "stadium" in t
+        or "auditor" in t
+        or "night classes" in t
+    )
+
+
+class TestInstructionReachesTheWire:
+    """Contract 1 — the deployed system prompt carries the measured
+    instruction VERBATIM (fidelity pin to the #1745 two-arm evidence)."""
+
+    def test_instruction_reaches_the_wire(self):
+        import argumentation_analysis.orchestration.invoke_callables as mod
+
+        assert mod._OPPOSING_POSITIONS_INSTRUCTION.strip(), (
+            "_OPPOSING_POSITIONS_INSTRUCTION is empty — the #1745 geste is "
+            "not deployed"
+        )
+        valid_json = (
+            '{"arguments": [{"text": "x", "source_quote": "x"}], '
+            '"claims": [], "summary": "ok"}'
+        )
+        with (
+            patch(
+                f"{INVOKE_PATH}._get_openai_client",
+                return_value=(MagicMock(), "m"),
+            ),
+            patch(
+                f"{INVOKE_PATH}._guarded_chat_completion",
+                new=AsyncMock(return_value=_resp(valid_json)),
+            ) as mock_call,
+            patch(f"{INVOKE_PATH}._get_determinism_params", return_value={}),
+        ):
+            asyncio.new_event_loop().run_until_complete(
+                _invoke_fact_extraction("some text", {"_state_object": None})
+            )
+        system_message = mock_call.call_args.kwargs["messages"][0]["content"]
+        assert mod._OPPOSING_POSITIONS_INSTRUCTION in system_message, (
+            "the #1745 instruction is not threaded into the extraction " "system prompt"
+        )
+
+
+class TestInventoryCarriesBothPoles:
+    """Contract 2 — BEHAVIOUR on a real LLM draw: the cited position must
+    exist as its own non-disqualified item (a node the attack axes can
+    attack). See module docstring for the honest substitution result."""
+
+    @pytest.mark.requires_api
+    async def test_inventory_carries_both_poles_of_explicit_opposition(self):
+        result = await _invoke_fact_extraction(_TEXT, {"_state_object": None})
+        assert (
+            result.get("extraction_status") == "ok"
+        ), f"extraction failed: {result.get('extraction_status')}"
+        texts = _item_texts(result)
+        assert texts, "empty inventory"
+
+        # Attacker pole (the speaker's own assertion) — sanity anchor.
+        assert any(
+            _attacker_content(t) for t in texts
+        ), "attacker pole (speaker position) absent from the inventory"
+        # Target pole: a standalone restatement WITHOUT the author's
+        # disqualification. A fused item carries a loaded marker by
+        # construction and cannot satisfy this.
+        neutral_target = [
+            t for t in texts if _target_content(t) and not any(m in t for m in _LOADED)
+        ]
+        assert neutral_target, (
+            "target pole FOLDED: the cited position (the subsidy program "
+            "deserves the revival credit) appears only inside the "
+            "speaker's evaluative items, never as its own neutral item — "
+            "_OPPOSING_POSITIONS_INSTRUCTION not in effect (#1745). "
+            f"Inventory: {texts}"
+        )


### PR DESCRIPTION
## What

Closes #1745 (worker myia-po-2025). Deploys the ONE-instruction "geste" measured in the #1745 two-arm runs, plus the measurement script and the P2 tests.

## Measurement summary (real prose, pre-registered protocol)

Protocol pre-registered at issue #1745 (comment 5295035932) BEFORE any run. k=5 draws per arm per passage, model `openai/gpt-5-mini` via OpenRouter, production extraction chain (`_invoke_fact_extraction` prompt verbatim as CONTROL arm; + geste as TREATED arm). Artifacts under `argumentation_analysis/evaluation/results/real_analysis/` (gitignored).

- **Step 0 gate**: CONTROL arm covers **0/5** annotated pairs on passage_1 (corpus C), replicated twice. Gate passed — hypothesis not refuted at extraction.
- **Step 2 (passage_1, corpus C)**: strict token-Jaccard@0.6 = 0 everywhere (the metric is paraphrase-blind — treated best ~0.46 on semantically-equivalent items; reported as a methodological finding, not silently switched). Symmetric human semantic adjudication (both arms, all 10 runs): TREATED covers C-GT1 **5/5** (covered AND attacked in the correct direction on every run) and C-GT2 **2/5**; CONTROL **0/5** (the GT1 target appears 1/5 in loaded form "wrongly claim", never as its own item). Pre-registered confirmation criterion (≥2 effective pairs treated, 0 control) met on the semantic reading.
- **Portée (passage_2, corpus A, annotated to the same barème BEFORE any run on it)**: A-GT1 **5/5** treated vs 0/5 control; A-GT2 **4/5** vs 0/5. **A-GT3 is non-discriminating**: both its poles are speaker-narrated facts (the offer + the response), extracted by BOTH arms without the geste (control attacked it 4/5) — annotation caveat reported: a pair only tests the mechanism if its TARGET is an adversary position. Not counted as geste gain.
- **Raw attack channel (pre-validation proposals, production inventories)**: treated never zeroes (setaf/weighted) on either passage vs control zeroing on 2-3/5 runs. kept=raw observed — no next-hop (reader) defect on the measured runs.
- **Neutrality: partial** — some treated items retain attribution scaffolding ("Opposing position (cited neutrally): ..."); the position content is stated neutrally, the label is scaffolding. Flagged, non-blocking.
- 3 corpus-C pairs remain folded (bundled criticism, concessive embedding, never-extracted attacker): the geste is not universal — net = 4/7 discriminating pairs covered treated vs 0/7 control.

## Diff (production)

`_invoke_fact_extraction` system prompt: the geste is appended verbatim (the exact string measured as `ARMS["treated"]` in the harness) as module constant `_OPPOSING_POSITIONS_INSTRUCTION`, inserted between focus point (3) and the language clause. Single variable — nothing else moves.

## Tests (P2)

1. `TestInstructionReachesTheWire` (hermetic): captures the system message actually sent and asserts the instruction is threaded verbatim — fidelity pin to the k=20 measurement evidence. **Substitution control EXECUTED**: emptying the constant turns it red deterministically.
2. `TestInventoryCarriesBothPoles` (`requires_api`, real LLM): on a dense (~2400 chars) synthetic op-ed whose cited position appears only as the object of disqualifying predicates, the inventory must carry that position as its own non-disqualified item (a node the attack axes can attack). **Substitution control EXECUTED and reported honestly**: on synthetic input the emptied arm folds 2/3 draws and mints an existential meta-claim 1/3 — gpt-5-mini's fold is stochastic off the real corpus (real-prose control fold rate: 10/10). This test is the carriage regression guard; the causal evidence is the measurement artifact, not this test. Item scanning is on item TEXT only (the verbatim `source_quote` legitimately carries the disqualifying phrasing — false-reds observed before that correction).

## Files

- `argumentation_analysis/orchestration/invoke_callables.py` — +17 lines (constant + interpolation)
- `scripts/measure_1745_pole_coverage.py` — the two-arm measurement harness (both passages, gate, pole-coverage scoring, loaded-marker heuristic, artifact writer). Reuses `measure_1710_ground_truth` (R808) for the identical measurement chain.
- `tests/unit/argumentation_analysis/orchestration/test_fact_extraction_opposing_poles_1745.py` — the two P2 contracts above.

Annotations and run artifacts stay gitignored (`evaluation/results/real_analysis/`). Opaque IDs only on GitHub surfaces.

## Verification

- Substitution matrix (executed today): emptied → wiring RED (deterministic), behavior fold-red observed; restored → wiring+behavior green on treated draws (n recorded in test docstring).
- `black` + `flake8 --select=E9,F63,F7,F82` clean on all three files.
- `pytest tests/unit/argumentation_analysis/orchestration/test_fact_extraction_opposing_poles_1745.py` — behavior test requires API keys (`requires_api`, excluded from per-push gate).
